### PR TITLE
Datetime typo1: tzname[1]

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -28622,7 +28622,7 @@ public:
             try
                 return to!string(tzname[1]);
             catch(Exception e)
-                assert(0, "to!string(tzname[0]) failed.");
+                assert(0, "to!string(tzname[1]) failed.");
         }
         else version(Windows)
         {


### PR DESCRIPTION
I've found a typo in std.datetime.
Thank you.
