### PR TITLE
Added version of receiveTimeout which takes a Duration.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -501,6 +501,11 @@ bool receiveTimeout(T...)( long ms, T ops )
     return mbox.get( ms * TICKS_PER_MILLI, ops );
 }
 
+/++ ditto +/
+bool receiveTimeout(T...)( Duration duration, T ops )
+{
+    return receiveTimeout(duration.total!"msecs"(), ops);
+}
 
 unittest
 {
@@ -519,6 +524,11 @@ unittest
                        {
                            receiveTimeout( 0, (int x) {}, (int x) {} );
                        } ) );
+
+    assert( __traits( compiles,
+                      {
+                          receiveTimeout( dur!"msecs"(10), (int x) {}, (Variant x) {} );
+                      } ) );
 }
 
 


### PR DESCRIPTION
Now that we have core.time.Duration, we should probably make it so that all of our functions which take a duration of time at least have a version which take a Duration rather than just a bare number. I'm not sure if we want to push that to the point that we eventually deprecate the versions that take bare numbers, but we certainly should add versions that take a Duration. So, here's one for std.concurrency.receiveTimeout.
