### PR TITLE
Some updates to std.datetime

### DIFF
--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -195,7 +195,7 @@ int opCmp(Tdummy = void)(BigUint y)
 {
     if (data.length != y.data.length)
         return (data.length > y.data.length) ?  1 : -1;
-    uint k = highestDifferentDigit(data, y.data);
+    size_t k = highestDifferentDigit(data, y.data);
     if (data[k] == y.data[k])
         return 0;
     return data[k] > y.data[k] ? 1 : -1;

--- a/win32.mak
+++ b/win32.mak
@@ -907,7 +907,7 @@ $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 zip : win32.mak posix.mak $(STDDOC) $(SRC) \
 	$(SRC_STD) $(SRC_STD_C) $(SRC_STD_WIN) \
 	$(SRC_STD_C_WIN) $(SRC_STD_C_LINUX) $(SRC_STD_C_OSX) $(SRC_STD_C_FREEBSD) \
-	$(SRC_ETC) $(SRC_ETC_C) $(SRC_ZLIB)
+	$(SRC_ETC) $(SRC_ETC_C) $(SRC_ZLIB) $(SRC_STD_NET)
 	del phobos.zip
 	zip32 -u phobos win32.mak posix.mak $(STDDOC)
 	zip32 -u phobos $(SRC)
@@ -921,6 +921,7 @@ zip : win32.mak posix.mak $(STDDOC) $(SRC) \
 	zip32 -u phobos $(SRC_STD_INTERNAL_MATH)
 	zip32 -u phobos $(SRC_ETC) $(SRC_ETC_C)
 	zip32 -u phobos $(SRC_ZLIB)
+	zip32 -u phobos $(SRC_STD_NET)
 
 clean:
 	cd etc\c\zlib


### PR DESCRIPTION
I was going to wait until I was farther in reworking the unit tests before creating a pull request, but it appears that we're likely to be doing a release fairly soon, so I should probably get the changes that I have in, since it includes several bug fixes. In particular, these changes include fixes for bugs 5761, 5781, and 5794. In addition to that, I've started on reworking the unit tests per the requests on the Phobos list, and a good chunk of the tests for `SysTime` have been reworked as well as a few of the others, but there's still plenty of work left to do there. Also, all of the new/updated code follows the 80/120 rule for line length, with most of them being within 80 characters.
