### PR TITLE
WOW64 deleteKey support and issue 5888 fix

### DIFF
--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -344,6 +344,11 @@ shared static this()
     advapi32Mutex = new shared(Object)();
 }
 
+shared static ~this()
+{
+    freeAdvapi32();
+}
+
 private {
     immutable bool isWow64;
     shared Object advapi32Mutex;


### PR DESCRIPTION
Issue 5888 fix - createKey and getKey in registry.d always use KEY_ALL_ACCESS
