### PR TITLE
Fix for std.parallelism

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3553,3 +3553,4 @@ version(parallelismStressTest) {
         }
     }
 }
+


### PR DESCRIPTION
Fix subtle race condition in std.parallelism by using heap instead of stack to hold key shared state in parallel foreach and amap implementations.  To explain in more detail, parallel foreach and amap use tasks that resubmit themselves to achieve O(1) auxillary memory usage.  Previously these tasks were stored on the stack.  The task that resubmits itself is called submitNextBatch.  I realized that the stack frame that holds submitNextBatch can be destroyed while other threads still have references to it.  This never seemed to occur in practice because it rapidly becomes unlikely with increasingly large work units.  

The fix is to allocate this and a bunch of other state used for parallel foreach and amap on the heap.  The cost of this is one heap allocation per call to amap or parallel foreach.  (One for each time a parallel foreach loop is entered, not one for each iteration.)
