### PR TITLE
temporarily disable std/container on freebsd64

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -236,6 +236,11 @@ $(ROOT)/%$(DOTOBJ) : %.c
 $(LIB) : $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
 
+ifeq ($(OS)$(MODEL),freebsd64)
+DISABLED_TESTS += std/container
+# fails freebsd64 debug test
+endif
+
 ifeq ($(MODEL),64)
 DISABLED_TESTS += std/conv
 # not reduced yet. I hate reducing this file


### PR DESCRIPTION
Disable the only test that fails on freebsd/64, std/container.
