### PR TITLE
std.algorithm.joiner() should only require an input range

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2289,6 +2289,13 @@ unittest
                     "Mary...has...a...little...lamb"));
 }
 
+unittest
+{
+    // joiner() should work for non-forward ranges too.
+    InputRange!string r = inputRangeObject(["abc", "def"]);
+    assert (equal(joiner(r, "xyz"), "abcxyzdef"));
+}
+
 auto joiner(RoR)(RoR r)
 if (isInputRange!RoR && isInputRange!(ElementType!RoR))
 {


### PR DESCRIPTION
The template constraint for std.algorithm.joiner(r, sep) requires a forward range, when an input range would suffice.  (The one-argument version of joiner() does not have this problem.)

Only tested on Linux.
