### PR TITLE
Windows's altsep support in getExt, getName and join (bugfix, I think)

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -53,11 +53,11 @@ version(Windows)
     
     static assert(sep.length == 1 && altsep.length == 1);
     private bool isSep(dchar ch) {
-        return (ch == sep[0]) | (ch == altsep[0]);
+        return ch == sep[0] || ch == altsep[0];
     }
     
     private bool isSepOrDriveSep(dchar ch) {
-        return isSep(ch) | (ch == ':');
+        return isSep(ch) || ch == ':';
     }
 }
 version(Posix)


### PR DESCRIPTION
Added Windows's altsep support to getExt, getName and join (bugfix, I think).
Some cosmetic changes.
