### PR TITLE
std.format.formatValue: Names instead of integer values for enum members.

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -381,11 +381,9 @@ T toImpl(T, S)(S s) if (is(S == enum) && isSomeString!(T)
             return __traits(allMembers, S)[i];
     }
 
-    // Embed the actual value encountered into the error message.
+    // val is not a member of T, output cast(T)rawValue instead.
     static assert(!is(OriginalType!S == S));
-    OriginalType!S v = s;
-    throw new ConvException(
-        "value '" ~ to!string(v) ~ "' is not enumerated in " ~ S.stringof);
+    return to!T("cast(" ~ S.stringof ~ ")") ~ to!T(cast(OriginalType!S)s);
 }
 
 unittest
@@ -401,14 +399,11 @@ unittest
     assert(to!wstring(F.y) == "y"w);
     assert(to!dstring(F.z) == "z"d);
 
-    try
-    {
-        to!string(cast(E) (E.max + 1));
-        assert(0);
-    }
-    catch (ConvException e)
-    {
-    }
+    // Test an value not corresponding to an enum member.
+    auto o = cast(E)5;
+    assert(to! string(o) == "cast(E)5"c);
+    assert(to!wstring(o) == "cast(E)5"w);
+    assert(to!dstring(o) == "cast(E)5"d);
 }
 
 /**

--- a/std/format.d
+++ b/std/format.d
@@ -903,11 +903,10 @@ if (is(T == enum))
         }
     }
 
-    // Embed the actual value encountered into the error message.
+    // val is not a member of T, output cast(T)rawValue instead.
+    put(w, "cast(" ~ T.stringof ~ ")");
     static assert(!is(OriginalType!T == T));
-    OriginalType!T rawVal = val;
-    throw new FormatError("value '" ~ to!string(rawVal) ~
-        "' is not enumerated in " ~ T.stringof);
+    formatValue(w, cast(OriginalType!T)val, f);
 }
 
 /**
@@ -2049,6 +2048,8 @@ here:
     }
     stream.clear; formattedWrite(stream, "%s", TestEnum.Value2);
     assert(stream.data == "Value2", stream.data);
+    stream.clear; formattedWrite(stream, "%s", cast(TestEnum)5);
+    assert(stream.data == "cast(TestEnum)5", stream.data);
 
     //immutable(char[5])[int] aa = ([3:"hello", 4:"betty"]);
     //stream.clear; formattedWrite(stream, "%s", aa.values);


### PR DESCRIPTION
std.format.formatValue: Names instead of integer values for enum members.

to!string(someEnum) is already implemented like that, which led to writeln(to!string(someEnum)) and writeln(someEnum) giving different results.
