### PR TITLE
std.regex fix .* optimization issues (issue 6072)

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -23,7 +23,7 @@ $(VERSION 053, ddd mm, 2011, =================================================,
         $(LI $(BUGZILLA 5451): Three ideas for RedBlackTree)
         $(LI $(BUGZILLA 5474): unaryFun byRef is borked for custom parameter name)
         $(LI $(BUGZILLA 5485): TLS sections handled incorrectly in FreeBSD)
-        $(LI $(BUGZILLA 5511): std.regex optional capture with no-match cause error
+        $(LI $(BUGZILLA 5511): std.regex optional capture with no-match cause error)
         $(LI $(BUGZILLA 5616): std.datetime: not cross-platform)
         $(LI $(BUGZILLA 5654): BigInt returns ZERO with strings of single digit number with leading zeros)
         $(LI $(BUGZILLA 5661): std.algorithm.move does not work on elaborate struct)
@@ -33,7 +33,7 @@ $(VERSION 053, ddd mm, 2011, =================================================,
         $(LI $(BUGZILLA 5781): std.datetime: On Windows, times off by one hour in some years due to DST rule changes)
         $(LI $(BUGZILLA 5794): std.datetime StopWatch (and perhaps benchmark) examples need a small fix)
         $(LI $(BUGZILLA 5857): std.regex (...){n,m} is bogus when (...) contains repetitions)
-	$(LI $(BUGZILLA 6076): std.regex: "c.*|d" matches "mm")
+        $(LI $(BUGZILLA 6076): std.regex: "c.*|d" matches "mm")
      )
 
 )

--- a/std/regex.d
+++ b/std/regex.d
@@ -348,10 +348,6 @@ Returns the number of parenthesized captures
     //adjust jumps, after removing instructions at 'place'
     void fixup(ubyte[] prog, size_t place, uint change)
     {
-        size_t len;
-        ushort* pu;
-        uint* dest;
-
         for (size_t pc=0;pc<prog.length;)
         {
             switch (prog[pc])
@@ -362,7 +358,7 @@ Returns the number of parenthesized captures
             case REcounter: //jump forward
                 if(pc < place)
                 {
-                    dest = cast(uint *)&prog[pc + 1 + uint.sizeof];
+                    auto dest = cast(uint *)&prog[pc + 1 + uint.sizeof];
                     if (pc + *dest > place)
                         *dest -= change; 
                 }
@@ -372,7 +368,7 @@ Returns the number of parenthesized captures
             case REloop, REloopg: //jump back
                 if (pc > place)
                 {
-                    dest = cast(uint *)&prog[pc + 1 + 2*uint.sizeof];
+                    auto dest = cast(uint *)&prog[pc + 1 + 2*uint.sizeof];
                     if (pc + *dest > place)
                         *dest += change;
                 }
@@ -385,7 +381,7 @@ Returns the number of parenthesized captures
             case REgoto:
                 if (pc < place)
                 {
-                    dest = cast(uint *)&prog[pc+1];
+                    auto dest = cast(uint *)&prog[pc+1];
                     if (pc + *dest > place)
                         *dest -= change;
                 }
@@ -422,7 +418,7 @@ Returns the number of parenthesized captures
 
             case REstring:
             case REistring:
-                len = *cast(size_t *)&prog[pc + 1];
+                auto len = *cast(size_t *)&prog[pc + 1];
                 assert(len % E.sizeof == 0);
                 pc += 1 + size_t.sizeof + len;
                 break;
@@ -430,14 +426,14 @@ Returns the number of parenthesized captures
             case REtestbit:
             case REbit:
             case REnotbit:
-                pu = cast(ushort *)&prog[pc + 1];
-                len = pu[1];
+                auto pu = cast(ushort *)&prog[pc + 1];
+                auto len = pu[1];
                 pc += 1 + 2 * ushort.sizeof + len;
                 break;
 
             case RErange:
             case REnotrange:
-                len = *cast(uint *)&prog[pc + 1];
+                auto len = *cast(uint *)&prog[pc + 1];
                 pc += 1 + uint.sizeof + len;
                 break;
 


### PR DESCRIPTION
Also adds fixed isuess to changelog and reduces alloca burden to 32 Kb (if available).
Now there is one problem with it I can't figure, on all of 32 bits it passes all tests.
On 64 bit when I run make MODEL=64 -fposix.mak unittest
I get the following from linker:
generated/linux/debug/64/unittest/std/regex.o: In function `_D3std5regex20__T10RegexMatchTAyuZ10RegexMatch8trymatchMFkAhZb':
/home/dmitry/dmd2/src/phobos/std/regex.d:2352: undefined reference to`_D3std3utf10strideBackFNaNfxAumZk'
generated/linux/debug/64/unittest/std/regex.o: In function `_D3std5regex20__T10RegexMatchTAyaZ10RegexMatch8trymatchMFkAhZb':
/home/dmitry/dmd2/src/phobos/std/regex.d:2352: undefined reference to`_D3std3utf10strideBackFNaNfxAamZk'
generated/linux/debug/64/unittest/std/regex.o: In function `_D3std5regex20__T10RegexMatchTAywZ10RegexMatch8trymatchMFkAhZb':
/home/dmitry/dmd2/src/phobos/std/regex.d:2352: undefined reference to`_D3std3utf10strideBackFNaNbNfxAwmZk'
generated/linux/debug/64/unittest/std/regex.o: In function `_D3std5regex19__T10RegexMatchTAaZ10RegexMatch8trymatchMFkAhZb':
/home/dmitry/dmd2/src/phobos/std/regex.d:2352: undefined reference to`_D3std3utf10strideBackFNaNfxAamZk'
Any ideas?
