### PR TITLE
Add _d_run_main to give applications more control at start

### DIFF
--- a/internal/dmain2.d
+++ b/internal/dmain2.d
@@ -45,20 +45,33 @@ version (Solaris)
  * The D main() function supplied by the user's program
  */
 int main(char[][] args);
+alias int function(char[][] args) MainFunc;
 
 /***********************************
  * Substitutes for the C main() function.
- * It's purpose is to wrap the call to the D main()
+ * Just calls into d_run_main with the default main function.
+ * Applications are free to implement their own
+ * main function and call the _d_run_main function
+ * themselves with any main function.
+ */
+extern (C) int main(size_t argc, char **argv)
+{
+    return _d_run_main(argc, argv, cast(void*)&main);
+}
+
+/***********************************
+ * Run the given main function.
+ * It's purpose is to wrap the D main()
  * function and catch any unhandled exceptions.
  */
-
-extern (C) int main(size_t argc, char **argv)
+extern (C) int _d_run_main(size_t argc, char **argv, void *p)
 {
     char[] *am;
     char[][] args;
     int result;
     int myesp;
     int myebx;
+    MainFunc main = cast(MainFunc)p;
 
     version (OSX)
     {   /* OSX does not provide a way to get at the top of the


### PR DESCRIPTION
This allows a application to supply its own main function that
gets run before any D code is run, allowing it to setup external
dependancies that might be tricky to do from static contructors.
GDC has been shipping with something similar sing a long time
so its not especially new or original, the code is compatible.

This is especially usefull for Mac OSX where in order to use Obj-C
code you need to setup various bits of things like a memory pool.

Cheers Jakob!

Signed-off-by: Jakob Bornecrantz wallbraker@gmail.com
