### PR TITLE
Do not specify paths to DMD and DMC under Wine

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -80,8 +80,8 @@ endif
 
 # Set CC and DMD
 ifeq ($(OS),win32wine)
-	CC = wine $(HOME)/dmc/bin/dmc.exe
-	DMD = wine $(HOME)/dmd2/windows/bin/dmd.exe
+	CC = wine dmc.exe
+	DMD = wine dmd.exe
 	RUN = wine
 else
 	ifeq ($(OS),win32remote)


### PR DESCRIPTION
Everyone can't be expected to have the same directory structure, but everyone _can_ be expected to have the compilers in their path.
