### PR TITLE
Enable osx > 10.4 developers to use environment vars

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -52,8 +52,17 @@ version (Posix)
 // The following is needed for reading/writing environment variables.
 version(Posix)
 {
-    // Made available by the C runtime:
-    private extern(C) extern __gshared const char** environ;
+    version(OSX)
+    {
+        // https://www.gnu.org/software/gnulib/manual/html_node/environ.html
+        private extern(C) extern __gshared char*** _NSGetEnviron();
+        // need to declare environ = *_NSGetEnviron() in static this()
+    }
+    else
+    {
+        // Made available by the C runtime:
+        private extern(C) extern __gshared const char** environ;
+    }
 }
 version(Windows)
 {
@@ -487,6 +496,15 @@ alias Environment environment;
 abstract final class Environment
 {
 static:
+    // initiaizes the value of environ for OSX
+    version(OSX)
+    {
+        private char** environ;
+        this()
+        {
+            environ = * _NSGetEnviron();
+        }
+    }
 
 private:
     // Return the length of an environment variable (in number of


### PR DESCRIPTION
 (otherwise linking fails because of missing symbol)

Explanation of change:
https://www.gnu.org/software/gnulib/manual/html_node/environ.html
