### PR TITLE
[fix for previous commit]

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -495,16 +495,16 @@ alias Environment environment;
 
 abstract final class Environment
 {
-static:
     // initiaizes the value of environ for OSX
     version(OSX)
     {
-        private char** environ;
-        this()
+        static private char** environ;
+        static this()
         {
             environ = * _NSGetEnviron();
         }
     }
+static:
 
 private:
     // Return the length of an environment variable (in number of


### PR DESCRIPTION
Fixed the OSX bug fix. Explicitly qualify "static this()" instead of putting it under "static:"
