### PR TITLE
Fix test compilation error in std.algorithm on 64-bit.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2160,7 +2160,7 @@ unittest
        foreach (word; splitter(strip(line))) {
             if (word in dictionary) continue; // Nothing to do
             auto newID = dictionary.length;
-            dictionary[to!string(word)] = newID;
+            dictionary[to!string(word)] = cast(uint)newID;
         }
     }
     assert(dictionary.length == 5);


### PR DESCRIPTION
I don't know if this is the exact fix that you want Andrei (since it seems like either the cast needs to be there or the type of the associative array needs to change to `size_t[string]`, and I don't know which you want). Obviously, the TDPL errata page will need to be fixed with whichever of the two possible fixes you think is appropriate.
