### PR TITLE
Fix for issue 6113.

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -9,5 +9,6 @@ $(VERSION 054, ddd mm, 2011, =================================================,
         $(LI $(BUGZILLA 3479): writef/writefln: positional precision not working)
         $(LI $(BUGZILLA 3564): Rdmd failing to link external C libraries)
         $(LI $(BUGZILLA 3752): File.byLine fetches lines in a confusing manner)
+        $(LI $(BUGZILLA 6113): singletons in std.datetime are not created early enough)
     )
 )

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -28359,7 +28359,7 @@ private:
     static immutable LocalTime _localTime;
 
 
-    static this()
+    shared static this()
     {
         tzset();
 
@@ -28483,7 +28483,7 @@ private:
     static immutable UTC _utc;
 
 
-    static this()
+    shared static this()
     {
         _utc = new immutable(UTC)();
     }


### PR DESCRIPTION
This is actually simple enough that I'm halfway tempted to just commit the changes. UTC._utc and LocalTime._localTime are immutable class variables which are the singletons for their respective classes.  However, the static constructor which initialize them are not currently shared like they should be. Since immutable static variables and immutable global variables are implicitly shared, it's not a good idea to initialize them in non-shared static constructors and in fact should probably be an error  (e.g. http://d.puremagic.com/issues/show_bug.cgi?id=4923 and http://d.puremagic.com/issues/show_bug.cgi?id=6114 ).
