### PR TITLE
Fix 672 broken links (complements work in d-programming-language.org)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -165,10 +165,12 @@ STD_MODULES = $(addprefix std/, algorithm array base64 bigint bitmanip	\
 STD_NET_MODULES = $(addprefix std/net/, isemail)
 
 # Other D modules that aren't under std/
-EXTRA_DOCUMENTABLES = $(addprefix etc/c/,curl zlib)
-EXTRA_MODULES := $(addprefix std/c/, stdarg stdio) \
-	$(EXTRA_DOCUMENTABLES) $(addprefix std/internal/math/, \
-	biguintcore biguintnoasm biguintx86 gammafunction errorfunction)
+EXTRA_DOCUMENTABLES := $(addprefix etc/c/,curl zlib) $(addprefix		\
+std/c/, fenv locale math process stdarg stddef stdio stdlib string	\
+time wcharh)
+EXTRA_MODULES := $(EXTRA_DOCUMENTABLES) $(addprefix			\
+	std/internal/math/, biguintcore biguintnoasm biguintx86	\
+	gammafunction errorfunction)
 
 # OS-specific D modules
 EXTRA_MODULES_LINUX := $(addprefix std/c/linux/, linux socket)
@@ -177,9 +179,9 @@ EXTRA_MODULES_FREEBSD := $(addprefix std/c/freebsd/, socket)
 EXTRA_MODULES_WIN32 := $(addprefix std/c/windows/, com stat windows		\
 		winsock) $(addprefix std/windows/, charset iunknown syserror)
 ifeq (,$(findstring win,$(OS)))
-	EXTRA_MODULES+=$(EXTRA_MODULES_LINUX)
+	EXTRA_DOCUMENTABLES+=$(EXTRA_MODULES_LINUX)
 else
-	EXTRA_MODULES+=$(EXTRA_MODULES_WIN32)
+	EXTRA_DOCUMENTABLES+=$(EXTRA_MODULES_WIN32)
 endif
 
 # Aggregate all D modules relevant to this build
@@ -303,6 +305,9 @@ $(DOC_OUTPUT_DIR)/std_c_%.html : std/c/%.d $(STDDOC)
 	$(DDOC) $(DDOCFLAGS) -Df$@ $<
 
 $(DOC_OUTPUT_DIR)/std_c_linux_%.html : std/c/linux/%.d $(STDDOC)
+	$(DDOC) $(DDOCFLAGS) -Df$@ $<
+
+$(DOC_OUTPUT_DIR)/std_c_windows_%.html : std/c/windows/%.d $(STDDOC)
 	$(DDOC) $(DDOCFLAGS) -Df$@ $<
 
 $(DOC_OUTPUT_DIR)/etc_c_%.html : etc/c/%.d $(STDDOC)

--- a/std/process.d
+++ b/std/process.d
@@ -91,8 +91,7 @@ version(Windows)
 
    Note: On Unix systems, the homonym C function (which is accessible
    to D programs as $(LINK2 std_c_process.html, std.c._system))
-   returns a code in the same format as
-   $(WEB www.scit.wlv.ac.uk/cgi-bin/mansec?2+waitpid, waitpid),
+   returns a code in the same format as $(LUCKY waitpid, waitpid),
    meaning that C programs must use the $(D WEXITSTATUS) macro to
    extract the actual exit code from the $(D system) call. D's $(D
    system) automatically extracts the exit status.

--- a/std/random.d
+++ b/std/random.d
@@ -11,12 +11,12 @@ immune of threading issues. The generators feature a number of
 well-known and well-documented methods of generating random
 numbers. An overall fast and reliable means to generate random numbers
 is the $(D_PARAM Mt19937) generator, which derives its name from
-"$(WEB math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html, Mersenne
-Twister) with a period of 2 to the power of 19937". In
-memory-constrained situations, $(LUCKY linear congruential) generators
-such as $(D MinstdRand0) and $(D MinstdRand) might be useful. The
-standard library provides an alias $(D_PARAM Random) for whichever
-generator it considers the most fit for the target environment.
+"$(LUCKY Mersenne Twister) with a period of 2 to the power of
+19937". In memory-constrained situations, $(LUCKY linear congruential)
+generators such as $(D MinstdRand0) and $(D MinstdRand) might be
+useful. The standard library provides an alias $(D_PARAM Random) for
+whichever generator it considers the most fit for the target
+environment.
 
 Example:
 
@@ -372,8 +372,7 @@ unittest
 }
 
 /**
-The $(WEB math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html, Mersenne
-Twister) generator.
+The $(LUCKY Mersenne Twister) generator.
  */
 struct MersenneTwisterEngine(
     UIntType, size_t w, size_t n, size_t m, size_t r,

--- a/std/range.d
+++ b/std/range.d
@@ -2294,11 +2294,10 @@ unittest
 }
 
 /**
-Similar to $(XREF range,take), but assumes that $(D range) has at
-least $(D n) elements. Consequently, the result of $(D
-takeExactly(range, n)) always defines the $(D length) property (and
-initializes it to $(D n)) even when $(D range) itself does not define
-$(D length).
+Similar to $(LREF take), but assumes that $(D range) has at least $(D
+n) elements. Consequently, the result of $(D takeExactly(range, n))
+always defines the $(D length) property (and initializes it to $(D n))
+even when $(D range) itself does not define $(D length).
 
 If $(D R) is a random-access range, the result of $(D takeExactly) is
 $(D R) as well because $(D takeExactly) simply returns a slice of $(D
@@ -2865,8 +2864,8 @@ if(Ranges.length && allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)))
 
 /**
    Builds an object. Usually this is invoked indirectly by using the
-   $(XREF range,zip) function.
-*/
+   $(LREF zip) function.
+ */
     this(R rs, StoppingPolicy s = StoppingPolicy.shortest)
     {
         stoppingPolicy = s;
@@ -5319,9 +5318,8 @@ unittest {
 
 /**
    Policy used with the searching primitives $(D lowerBound), $(D
-   upperBound), and $(D equalRange) of $(XREF range,SortedRange)
-   below.
-*/
+   upperBound), and $(D equalRange) of $(LREF SortedRange) below.
+ */
 enum SearchPolicy
 {
     /**
@@ -5372,11 +5370,11 @@ enum SearchPolicy
 /**
    Represents a sorted random-access range. In addition to the regular
    range primitives, supports fast operations using binary search. To
-   obtain a $(D SortedRange) from an unsorted range $(D r), use $(XREF
-   algorithm, sort) which sorts $(D r) in place and returns the
-   corresponding $(D SortedRange). To construct a $(D SortedRange) from a
-   range $(D r) that is known to be already sorted, use $(XREF
-   range,assumeSorted) described below.
+   obtain a $(D SortedRange) from an unsorted range $(D r), use
+   $(XREF algorithm, sort) which sorts $(D r) in place and returns the
+   corresponding $(D SortedRange). To construct a $(D SortedRange)
+   from a range $(D r) that is known to be already sorted, use
+   $(LREF assumeSorted) described below.
 
    Example:
 
@@ -5602,8 +5600,8 @@ if (isRandomAccessRange!Range)
    largest left subrange on which $(D pred(x, value)) is $(D true) for
    all $(D x) (e.g., if $(D pred) is "less than", returns the portion of
    the range with elements strictly smaller than $(D value)). The search
-   schedule and its complexity are documented in $(XREF
-   range,SearchPolicy).  See also STL's $(WEB
+   schedule and its complexity are documented in
+   $(LREF SearchPolicy).  See also STL's $(WEB
    sgi.com/tech/stl/lower_bound.html, lower_bound).
 
    Example:
@@ -5623,11 +5621,11 @@ if (isRandomAccessRange!Range)
 // upperBound
 /**
    This function uses binary search with policy $(D sp) to find the
-   largest right subrange on which $(D pred(value, x)) is $(D true) for
-   all $(D x) (e.g., if $(D pred) is "less than", returns the portion of
-   the range with elements strictly greater than $(D value)). The search
-   schedule and its complexity are documented in $(XREF
-   range,SearchPolicy).  See also STL's $(WEB
+   largest right subrange on which $(D pred(value, x)) is $(D true)
+   for all $(D x) (e.g., if $(D pred) is "less than", returns the
+   portion of the range with elements strictly greater than $(D
+   value)). The search schedule and its complexity are documented in
+   $(LREF SearchPolicy).  See also STL's $(WEB
    sgi.com/tech/stl/lower_bound.html,upper_bound).
 
    Example:
@@ -5899,7 +5897,7 @@ effect on the complexity of subsequent operations specific to sorted
 ranges (such as binary search). The probability of an arbitrary
 unsorted range failing the test is very high (however, an
 almost-sorted range is likely to pass it). To check for sortedness at
-cost $(BIGOH n), use $(XREF algorithm, isSorted).
+cost $(BIGOH n), use $(XREF algorithm,isSorted).
  */
 auto assumeSorted(alias pred = "a < b", R)(R r)
 if (isRandomAccessRange!(Unqual!R))

--- a/std/signals.d
+++ b/std/signals.d
@@ -11,7 +11,7 @@
  * longer necessary to instrument the slots.
  *
  * References:
- *      $(LINK2 http://scottcollins.net/articles/a-deeper-look-at-_signals-and-slots.html, A Deeper Look at Signals and Slots)$(BR)
+ *      $(LUCKY A Deeper Look at Signals and Slots)$(BR)
  *      $(LINK2 http://en.wikipedia.org/wiki/Observer_pattern, Observer pattern)$(BR)
  *      $(LINK2 http://en.wikipedia.org/wiki/Signals_and_slots, Wikipedia)$(BR)
  *      $(LINK2 http://boost.org/doc/html/$(SIGNALS).html, Boost Signals)$(BR)

--- a/std/string.d
+++ b/std/string.d
@@ -18,7 +18,7 @@ Authors: $(WEB digitalmars.com, Walter Bright), $(WEB erdani.org,
 Andrei Alexandrescu)
 
 Source:    $(PHOBOSSRC std/_string.d)
-     
+
 $(B $(RED IMPORTANT NOTE:)) Beginning with version 2.052, the
 following symbols have been generalized beyond strings and moved to
 different modules. This action was prompted by the fact that
@@ -53,7 +53,7 @@ $(TR $(TD $(D replaceSlice)) $(TD Use $(XREF array, replace) instead.))
 
 $(TR $(TD $(D split)) $(TD Use $(XREF array, split) instead.))
 )
-   
+
 */
 module std.string;
 
@@ -1040,11 +1040,11 @@ unittest
         s2 = capitalize(s1);
         assert(cmp(s2, "Fol") == 0);
         assert(s2 !is s1);
-        
+
         s2 = capitalize(s1[0 .. 2]);
         assert(cmp(s2, "Fo") == 0);
         assert(s2.ptr == s1.ptr);
-        
+
         s1 = to!S("fOl");
         s2 = capitalize(s1);
         assert(cmp(s2, "Fol") == 0);
@@ -1082,7 +1082,7 @@ S capwords(S)(S s) if (isSomeString!S)
                 inword = false;
             }
             break;
-            
+
         default:
             if (!inword)
             {
@@ -1098,7 +1098,7 @@ S capwords(S)(S s) if (isSomeString!S)
     {
         r ~= capitalize(s[istart .. i]);
     }
-    
+
     return cast(S) r;
 }
 
@@ -2535,7 +2535,7 @@ S succ(S)(S s) if (isSomeString!S)
         {
             dchar c = s[i];
             dchar carry;
-            
+
             switch (c)
             {
             case '9':
@@ -2650,7 +2650,7 @@ string tr(const(char)[] str, const(char)[] from, const(char)[] to, const(char)[]
         dchar lastt;
         dchar newc;
         int n = 0;
-        
+
         for (size_t i = 0; i < from.length; )
         {
             dchar f = std.utf.decode(from, i);
@@ -3128,7 +3128,7 @@ unittest
  *
  * See_Also:
  *  $(LINK2 http://en.wikipedia.org/wiki/Soundex, Wikipedia),
- *  $(LINK2 http://www.archives.gov/publications/general-info-leaflets/55.html, The Soundex Indexing System)
+ *  $(LUCKY The Soundex Indexing System)
  *
  * Bugs:
  *  Only works well with English names.


### PR DESCRIPTION
I used the online tool http://www.brokenlinkcheck.com/ to get rid of broken links in Phobos.
