### PR TITLE
Restored error code reading to cenforce().

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -255,7 +255,14 @@ private T cenforce(T)(T condition, lazy const(char)[] name, string file = __FILE
 {
     if (!condition)
     {
-        throw new FileException(name, "", file, line);
+      version (Windows)
+      {
+        throw new FileException(name, .GetLastError(), file, line);
+      }
+      else version (Posix)
+      {
+        throw new FileException(name, .getErrno(), file, line);
+      }
     }
     return condition;
 }
@@ -540,7 +547,7 @@ void remove(in char[] name)
                 name);
     }
     else version(Posix)
-        cenforce(std.c.stdio.remove(toStringz(name)) == 0, 
+        cenforce(std.c.stdio.remove(toStringz(name)) == 0,
             "Failed to remove file " ~ name);
 }
 


### PR DESCRIPTION
The `getErrno` call was removed completely in commit cf02c92 by Shin, without any further comment instead of just calling `GetLastError` on Windows.

With this commit, the example from [issue 4188](http://d.puremagic.com/issues/show_bug.cgi?id=4188) cited in  cf02c92 still results in a sensible error message: »IDontExist.txt: The system cannot find the file specified.«
