### PR TITLE
Raise a SIGTRAP on an uncaught exception when no_catch_exceptions was set

### DIFF
--- a/internal/deh2.d
+++ b/internal/deh2.d
@@ -20,6 +20,7 @@
 //debug=1;
 
 import std.c.linux.linuxextern;
+import std.c.linux.linux;
 
 extern (C) int _d_isbaseof(ClassInfo oc, ClassInfo c);
 
@@ -363,4 +364,8 @@ extern (C) void _d_throwc(Object *h)
             }
         }
     }
+
+    // If we're here, it probably means that no_catch_exceptions was
+    // set with a debugger, so raise a signal
+    raise(SIGTRAP);
 }

--- a/std/c/linux/linux.d
+++ b/std/c/linux/linux.d
@@ -231,6 +231,7 @@ extern (C)
     int pipe(int[2]);
     pid_t wait(int*);
     int waitpid(pid_t, int*, int);
+    int raise(int);
 
     uint alarm(uint);
     char* basename(char*);


### PR DESCRIPTION
Without this change, setting `no_catch_exceptions` would just cause execution to merrily continue after the `throw` statement, usually leading to undefined behavior.

I'm unsure if importing `std.c.linux.linux` was a good idea with respect to other Posix platforms.

I'm not sure if this applies to D2, I don't have a Linux machine with DMD2 to test.
