### PR TITLE
Fixed x86_64 issues in Socket timeout code.

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -40,6 +40,7 @@ module std.socket;
 import core.stdc.stdint, std.string, std.c.string, std.c.stdlib, std.conv,
     std.traits;
 
+import core.stdc.config;
 import core.time : dur, Duration;
 import std.algorithm : max;
 import std.exception : assumeUnique, enforce;
@@ -947,8 +948,8 @@ enum SocketFlags: int
 extern(C) struct timeval
 {
         // D interface
-        int seconds;            /// Number of seconds.
-        int microseconds;       /// Number of additional microseconds.
+        c_long seconds;            /// Number of seconds.
+        c_long microseconds;       /// Number of additional microseconds.
 
         // C interface
         deprecated


### PR DESCRIPTION
Sorry, I forgot to test on x86_64 before committing the updated version of pull request 99. The cast is safe, as `NI_MAXHOST` is only as low as 1025 anyway.

The second commit fixes a bug in the original std.socket code. As noted in the commit message, the `std.socket.timeval` struct should probably be removed altogether (I was just accidentally using it instead of the druntime Posix one), but maybe some code out there uses it, so I suggest to wait until the (inevitable, imho) `std.socket` rewrite…
