### PR TITLE
fixup #5705

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1479,7 +1479,7 @@ if (isMutable!T && !is(typeof(T.init.proxySwap(T.init))))
 {
     static if (hasElaborateAssign!T)
     {
-      if (lhs !is rhs) {
+      if (&lhs != &rhs) {
         // For structs with non-trivial assignment, move memory directly
         // First check for undue aliasing
         assert(!pointsTo(lhs, rhs) && !pointsTo(rhs, lhs)


### PR DESCRIPTION
- don't do bitwise compare of structs but compare their memory locations

The already pulled fix for Bug5705 needs a change. To my surprise I just learned, that the identity
expression does a bitwise comparison for structs.
