### PR TITLE
Issue 6130: utf.toUTF16z needs to be callable with any string type

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -1128,6 +1128,19 @@ wstring toUTF16(in wchar[] s)
 }
 
 /// ditto
+const(wchar)* toUTF16z(in wchar[] s)
+{
+    wchar[] r;
+    size_t slen = s.length;
+
+    validate(s);
+    r.length = slen+1;
+    r[0 .. slen] = s[0 .. $];
+    r[slen] = '\000';
+    return r.ptr;
+}
+
+/// ditto
 pure wstring toUTF16(in dchar[] s)
 {
     wchar[] r;
@@ -1141,6 +1154,24 @@ pure wstring toUTF16(in dchar[] s)
     }
 
     return r.assumeUnique();  // ok because r is unique
+}
+
+
+/// ditto
+const(wchar)* toUTF16z(in dchar[] s)
+{
+    wchar[] r;
+    size_t slen = s.length;
+
+    r.length = slen+1;
+    r.length = 0;
+    for (size_t i = 0; i < slen; i++)
+    {
+        encode(r, s[i]);
+    }
+    r ~= "\000";
+
+    return r.ptr;
 }
 
 
@@ -1209,6 +1240,7 @@ unittest
     string c;
     wstring w;
     dstring d;
+    const(wchar)* wp;
 
     c = "hello";
     w = toUTF16(c);
@@ -1224,6 +1256,13 @@ unittest
     assert(c == "hello");
     w = toUTF16(d);
     assert(w == "hello");
+    
+    wp = toUTF16z(c);
+    assert(wp[0 .. 6] == "hello\000");
+    wp = toUTF16z(w);
+    assert(wp[0 .. 6] == "hello\000");
+    wp = toUTF16z(d);
+    assert(wp[0 .. 6] == "hello\000");
 
 
     c = "hel\u1234o";
@@ -1241,6 +1280,13 @@ unittest
     assert(c == "hel\u1234o");
     w = toUTF16(d);
     assert(w == "hel\u1234o");
+
+    wp = toUTF16z(c);
+    assert(wp[0 .. 6] == "hel\u1234o\000");
+    wp = toUTF16z(w);
+    assert(wp[0 .. 6] == "hel\u1234o\000");
+    wp = toUTF16z(d);
+    assert(wp[0 .. 6] == "hel\u1234o\000");
 
 
     c = "he\U0010AAAAllo";
@@ -1260,6 +1306,13 @@ unittest
     assert(c == "he\U0010AAAAllo");
     w = toUTF16(d);
     assert(w == "he\U0010AAAAllo");
+
+    wp = toUTF16z(c);
+    assert(wp[0 .. 8] == "he\U0010AAAAllo\000");
+    wp = toUTF16z(w);
+    assert(wp[0 .. 8] == "he\U0010AAAAllo\000");
+    wp = toUTF16z(d);
+    assert(wp[0 .. 8] == "he\U0010AAAAllo\000");
 }
 
 


### PR DESCRIPTION
I added toUTF16z(wchar[]) and toUTF16z(dchar[]) to solve the issue. I also extended the unit test.
