### PR TITLE
Supplemental changes of dmd/pull/41

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -336,7 +336,7 @@ public:
     }
 
     ///
-    bool opEquals(Tdummy=void)(ref const BigInt y) const
+    bool opEquals()(auto ref const BigInt y) const
     {
        return sign == y.sign && y.data == data;
     }

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -496,7 +496,8 @@ private void _send(T...)( Tid tid, T vals )
  */
 private void _send(T...)( MsgType type, Tid tid, T vals )
 {
-    tid.mbox.put( Message( type, vals ) );
+    auto msg = Message( type, vals );
+    tid.mbox.put( msg );
 }
 
 
@@ -1042,7 +1043,8 @@ private
                     if( *depends && tid != owner )
                     {
                         auto e = new LinkTerminated( tid );
-                        if( onStandardMsg( Message( MsgType.standard, e ) ) )
+                        auto msg = Message( MsgType.standard, e );
+                        if( onStandardMsg( msg ) )
                             return true;
                         throw e;
                     }
@@ -1051,7 +1053,8 @@ private
                 {
                     owner = Tid.init;
                     auto e = new OwnerTerminated( tid );
-                    if( onStandardMsg( Message( MsgType.standard, e ) ) )
+                    auto msg = Message( MsgType.standard, e );
+                    if( onStandardMsg( msg ) )
                         return true;
                     throw e;
                 }

--- a/std/container.d
+++ b/std/container.d
@@ -922,6 +922,12 @@ Comparison for equality.
 Complexity: $(BIGOH min(n, n1)) where $(D n1) is the number of
 elements in $(D rhs).
      */
+    bool opEquals(const SList rhs) const
+    {
+        return opEquals(rhs);
+    }
+
+    /// ditto
     bool opEquals(ref const SList rhs) const
     {
         const(Node) * n1 = _root, n2 = rhs._root;
@@ -1634,6 +1640,12 @@ struct Array(T) if (!is(T : const(bool)))
 /**
 Comparison for equality.
      */
+    bool opEquals(const Array rhs) const
+    {
+        return opEquals(rhs);
+    }
+
+    /// ditto
     bool opEquals(ref const Array rhs) const
     {
         if (empty) return rhs.empty;

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -799,6 +799,12 @@ public:
         Note that the time zone is ignored. Only the internal
         std times (which are in UTC) are compared.
      +/
+    bool opEquals(const SysTime rhs) const pure nothrow
+    {
+        return opEquals(rhs);
+    }
+
+    /// ditto
     bool opEquals(const ref SysTime rhs) const pure nothrow
     {
         return _stdTime == rhs._stdTime;
@@ -30816,6 +30822,12 @@ public:
 
 
     ///
+    bool opEquals(const StopWatch rhs) const pure nothrow
+    {
+        return opEquals(rhs);
+    }
+
+    /// ditto
     bool opEquals(const ref StopWatch rhs) const pure nothrow
     {
         return _timeStart == rhs._timeStart &&


### PR DESCRIPTION
https://github.com/D-Programming-Language/dmd/pull/41 makes struct literal and struct constructor call as rvalue, and passing them to ref parameter make invalid.
This pull request adds function overloads for ref and non-ref.

CAUTION: It is necessary to apply changes to phobos and dmd _at the same time_.
