### PR TITLE
Improve std.format.formatValue

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -12,7 +12,7 @@
    License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
    Authors: $(WEB digitalmars.com, Walter Bright), $(WEB erdani.com,
-   Andrei Alexandrescu) and Kenji Hara
+   Andrei Alexandrescu), and Kenji Hara
 
    Source: $(PHOBOSSRC std/_format.d)
  */

--- a/std/uni.d
+++ b/std/uni.d
@@ -19,7 +19,7 @@
 
     Copyright: Copyright 2000 -
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-    Authors:   $(WEB digitalmars.com, Walter Bright), Jonathan M Davis and Kenji Hara
+    Authors:   $(WEB digitalmars.com, Walter Bright), Jonathan M Davis, and Kenji Hara
     Source:    $(PHOBOSSRC std/_uni.d)
   +/
 module std.uni;


### PR DESCRIPTION
- Issue 3813 - Bad writeln of arrays
  <br/>When string value is the element of an container, format it double-quoted like "...".
- Issue 3890 - Bad writeln of a nested struct
- Issue 5042 - format("%s") of struct without toString
  <br/>Add formatting like to!T().
- Issue 5043 - writeln with empty arrays should write something useful
  <br/>Now empty range is formatted as "[]", including arrays and associative-arrays.
- Issue 5237 - writefln doesn't respect Complex.toString
  <br/>Add conversion from FormatSpec!char("%.16f") to "%.16f".
- Issue 5346 - instantiation of std.conv.toImpl and std.format.formatValue fails for unions
  <br/>When union object has toString, use it. Otherwise causes compile error.
- (Unlisted) Support nested range formatting like "%({%(%02x %)} %)".
- (Unlisted) Rewriting formatValue parameter 'ref FormatSpec!Char f' is breaks formatting.
- (Unlisted) void[] was raw formatted, not like ubyte[].
