### PR TITLE
Disable SIGPIPE on send()ing to a Socket on OS X.

### DIFF
--- a/std/c/osx/socket.d
+++ b/std/c/osx/socket.d
@@ -54,11 +54,6 @@ enum: int
 
 enum: int
 {
-    MSG_NOSIGNAL =   0x4000,
-}
-
-enum: int
-{
     IP_MULTICAST_LOOP =  11,
     IP_ADD_MEMBERSHIP =  12,
     IP_DROP_MEMBERSHIP = 13,

--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -382,8 +382,7 @@ enum: int
 {
         MSG_OOB =        0x1,
         MSG_PEEK =       0x2,
-        MSG_DONTROUTE =  0x4,
-        MSG_NOSIGNAL =   0x0, /// not supported on win32, would be 0x4000 if it was
+        MSG_DONTROUTE =  0x4
 }
 
 


### PR DESCRIPTION
Previously, `std.socket` code assumed that `MSG_NOSIGNAL` existed on all platforms, which is not the case – `std.c.osx.socket` actually has a comment saying »Not defined in OS X, but we'll use them anyway«. This led to `Socket.send()` raising `SIGPIPE` on OS X if the peer had already closed the connection.

With this commit, `std.socket` sets the `SO_NOSIGPIPE` socket option on systems that support it for the same effect as `MSG_NOSIGNAL` on Linux.

Strictly speaking, removing the `NOSIGNAL` `SocketFlag` is a breaking API change, but I do not think there is any code actually using it, as it has always been set implicitly anyway.
