### PR TITLE
The index cannot be ref in a foreach over an array.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1459,7 +1459,7 @@ if (isAssociativeArray!T && !is(T == enum))
 {
     bool firstTime = true;
     auto vf = f;
-    foreach (ref k, v; val)
+    foreach (k, ref v; val)
     {
         if (firstTime) firstTime = false;
         else put(w, ' ');


### PR DESCRIPTION
The index cannot be ref in a foreach over an array.  The check for this is currently broken but this code is wrong anyway.

http://d.puremagic.com/issues/show_bug.cgi?id=4460
