### PR TITLE
Fix v2.054 tag

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -22,7 +22,7 @@
 
 ## Copy command
 
-CP=copy
+CP=cp
 
 ## Directory where dmd has been installed
 


### PR DESCRIPTION
The v2.054 tag is on a branch that never got merged into master. I believe @WalterBright forgot to merge his commit db88b8b6 into master and then merged origin/master into his master. Anyway, this means that db88b8b6 (changing the `CP` macro in `win32.mak` to cp) never actually made it into master. This merge fixes this (and ensures the v2.054 tag is a descendant of master).
