### PR TITLE
Bug 5547: assertPred (workaround bug 4737)

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1945,6 +1945,11 @@ Target parse(Target, Source)(ref Source s)
         ~ to!string(s) ~ "'");
 }
 
+//@@@BUG4737@@@: typeid doesn't work for scoped enum with initializer
+version(unittest)
+{
+    private enum F : real { x = 1.414, y = 1.732, z = 2.236 }
+}
 unittest
 {
     debug(conv) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
@@ -1953,7 +1958,7 @@ unittest
     assert(to!E("b"w) == E.b);
     assert(to!E("c"d) == E.c);
 
-    enum F : real { x = 1.414, y = 1.732, z = 2.236 }
+    
     assert(to!F("x"c) == F.x);
     assert(to!F("y"w) == F.y);
     assert(to!F("z"d) == F.z);


### PR DESCRIPTION
If [bug 5547 is merged](https://github.com/D-Programming-Language/dmd/pull/263), the Phobos unittest can no longer pass because of [bug 4737](http://d.puremagic.com/issues/show_bug.cgi?id=4737). This pull request is to workaround the problem.
