### PR TITLE
Fixed Issue 6194 - [GSoC] Destructor gets called on object before it is copied when calling writeln()

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -309,7 +309,7 @@ void formattedWrite(Writer, Char, A...)(Writer w, in Char[] fmt, A args)
         funs[i] = &formatGeneric!(Writer, typeof(arg), Char);
         // We can safely cast away shared because all data is either
         // immutable or completely owned by this function.
-        argsAddresses[i] = cast(const(void*)) &arg;
+        argsAddresses[i] = cast(const(void*)) &args[ i ];
     }
     // Are we already done with formats? Then just dump each parameter in turn
     uint currentArg = 0;


### PR DESCRIPTION
Destructors would get called on struct instances passed to formattedWrite before they were actually used. This was because in the loop that takes the addresses of its arguments the code was actually taking the addresses of copies of the arguments created by foreach().
