### PR TITLE
Issue 6194 - [GSoC] Destructor gets called on object before it is copied when calling writeln()

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -309,7 +309,7 @@ void formattedWrite(Writer, Char, A...)(Writer w, in Char[] fmt, A args)
         funs[i] = &formatGeneric!(Writer, typeof(arg), Char);
         // We can safely cast away shared because all data is either
         // immutable or completely owned by this function.
-        argsAddresses[i] = cast(const(void*)) &arg;
+        argsAddresses[i] = cast(const(void*)) &args[ i ];
     }
     // Are we already done with formats? Then just dump each parameter in turn
     uint currentArg = 0;


### PR DESCRIPTION
The problem was that, when taking the addresses of its arguments, formattedWrite would instead take the addresses of copies created by the foreach() loop. The copies would go out of scope when the loop was exited and thus the destructors got called. I fixed the line that takes the address to index the argument tuple rather than use the copy.
