### PR TITLE
Re-enable std.typecons.Nullable and NullableRef

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1111,7 +1111,7 @@ unittest
 
 /**
 Defines a value paired with a distinctive "null" state that denotes
-the absence of a valud value. If default constructed, a $(D
+the absence of a value. If default constructed, a $(D
 Nullable!T) object starts in the null state. Assigning it renders it
 non-null. Calling $(D nullify) can nullify it again.
 


### PR DESCRIPTION
Re-enable these types which were disabled in commit d218c12e 2 years ago. 

These changes were made:
1. `Nullable!T.nullify` calls `object.clear` instead of the destructor directly. 
2. Added `@property` and `const` annotations to `isNull` and `get`.
3. Added a lot of unit tests to ensure 100% coverage.
