### PR TITLE
Function for opening default browser with a given URL

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -724,3 +724,97 @@ unittest
         assert (v == environment[n]);
     }
 }
+
+
+version (Windows)
+{
+    import core.sys.windows.windows;
+
+    extern (Windows)
+    HINSTANCE ShellExecuteA(HWND hwnd, LPCSTR lpOperation, LPCSTR lpFile, LPCSTR lpParameters, LPCSTR lpDirectory, INT nShowCmd);
+
+
+    pragma(lib,"shell32.lib");
+
+    /****************************************
+     * Start up the browser and set it to viewing the page at url.
+     */
+    void browse(string url)
+    {
+        ShellExecuteA(null, "open", toStringz(url), null, null, SW_SHOWNORMAL);
+    }
+}
+else version (OSX)
+{
+    import core.stdc.stdio;
+    import core.stdc.string;
+    import core.sys.posix.unistd;
+
+    void browse(string url)
+    {
+        const(char)*[5] args;
+
+        const(char)* browser = core.stdc.stdlib.getenv("BROWSER");
+        if (browser)
+        {   browser = strdup(browser);
+            args[0] = browser;
+            args[1] = toStringz(url);
+            args[2] = null;
+        }
+        else
+        {
+            //browser = "/Applications/Safari.app/Contents/MacOS/Safari";
+            args[0] = "open".ptr;
+            args[1] = "-a".ptr;
+            args[2] = "/Applications/Safari.app".ptr;
+            args[3] = toStringz(url);
+            args[4] = null;
+        }
+
+        auto childpid = fork();
+        if (childpid == 0)
+        {
+            core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);
+            perror(args[0]);                // failed to execute
+            return;
+        }
+        if (browser)
+            free(cast(void*)browser);
+    }
+}
+else version (Posix)
+{
+    import core.stdc.stdio;
+    import core.stdc.string;
+    import core.sys.posix.unistd;
+
+    void browse(string url)
+    {
+        const(char)*[3] args;
+
+        const(char)* browser = core.stdc.stdlib.getenv("BROWSER");
+        if (browser)
+        {   browser = strdup(browser);
+            args[0] = browser;
+        }
+        else
+            args[0] = "x-www-browser".ptr;
+
+        args[1] = toStringz(url);
+        args[2] = null;
+
+        auto childpid = fork();
+        if (childpid == 0)
+        {
+            core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);
+            perror(args[0]);                // failed to execute
+            return;
+        }
+        if (browser)
+            free(cast(void*)browser);
+    }
+}
+else
+    static assert(0, "os not supported");
+
+


### PR DESCRIPTION
Okay. This pull request is on Walter's behalf. I reverted the original commits and created this pull request as discussed. It was suggested that it was better to put the function in std.process instead of its own module, so that's what I did. The only changes that I made were to remove some imports that std.process was already importing and fully give the full module path for `getenv` and and `execvp`, since Walter used the C versions rather than those in std.process. Personally, I think that the code should be changed to use the std.process ones instead, but I didn't make any such functional changes prior to creating the pull request, since it's not my code, and it should probably be reviewed as Walter created it (which may very well in it getting changed as I suggested).
