### PR TITLE
Cleanup of std.windows.registry

### DIFF
--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -233,10 +233,10 @@ private REG_VALUE_TYPE _RVT_from_Endian(Endian endian)
 {
     final switch(endian)
     {
-        case    Endian.BigEndian:
+        case    Endian.bigEndian:
             return REG_VALUE_TYPE.REG_DWORD_BIG_ENDIAN;
 
-        case    Endian.LittleEndian:
+        case    Endian.littleEndian:
             return REG_VALUE_TYPE.REG_DWORD_LITTLE_ENDIAN;
     }
 }


### PR DESCRIPTION
This pull request changes the following:
- The swap() method is replaced by core.bitops.bswap
- std.system.Endian is used instead of own enumeration
- UTF-8 strings are now correctly converted to zero terminated ANSI strings suitable for Windows API
- Windows API functions declarations are removed, using the ones from core.sys.windows.windows
- Removed the Reserved type and the RESERVED constant. This construct assumed uint.sizeof == LPDWORD.sizeof, which isn't true on 64bit Windows
- Replaced tokenise() method with std.array.split()
- Added a unit test using Unicode characters
