### PR TITLE
Issue 6040: Implement std.cpuid in terms of core.cpuid

### DIFF
--- a/std/cpuid.d
+++ b/std/cpuid.d
@@ -1,6 +1,8 @@
 // Written in the D programming language.
 
 /**
+ * $(RED Scheduled for deprecation. Please use core.cpuid instead.)
+ *
  * Identify the characteristics of the host CPU.
  *
  * Implemented according to:


### PR DESCRIPTION
std.cpuid (from Phobos) duplicates functionality from core.cpuid (from druntime). Worse, some methods return different values. E.g. hyperThreading() and threadsPerCPU(). 

This pull request removes the implementation from std.cpuid and uses alias to reuse core.cpuid while preserving API compatibility.

As Don has suggested in the issue thread, std.cpuid should be removed in the long term. Maybe a deprecated message should be added? 
