### PR TITLE
Make std.compiler able to detect LDC and GDC.

### DIFF
--- a/std/compiler.d
+++ b/std/compiler.d
@@ -18,7 +18,7 @@
  */
 module std.compiler;
 
-const
+immutable
 {
     /// Vendor specific string naming the compiler, for example: "Digital Mars D".
     string name = __VENDOR__;


### PR DESCRIPTION
std.compiler can now detect DMD, GDC, and LDC. Other compiles will just be flagged as unknown vendor.
