### PR TITLE
Templatized toUTF16z on string type.

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -1290,10 +1290,30 @@ const(wchar)* toUTF16z(C)(const(C)[] str)
 
 unittest
 {
+    import std.metastrings;
     import std.typetuple;
 
+    size_t zeroLen(C)(const(C)* ptr)
+    {
+        size_t len = 0;
+
+        while(*ptr != '\0')
+        {
+            ++ptr;
+            ++len;
+        }
+
+        return len;
+    }
+
     foreach(S; TypeTuple!(string, wstring, dstring))
-        auto s = toUTF16z(to!S("hello world"));
+    {
+        auto s = to!S("hello\U00010143\u0100world\U00010143");
+        auto p = toUTF16z(s);
+
+        immutable len = zeroLen(p);
+        assert(cmp(s, p[0 .. len]) == 0, Format!("Unit test failed: %s", S.stringof));
+    }
 }
 
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6130

I'm not sure if we want to change `toUTF16z` to return `immutable` like `toStringz` does or not, so I just left it as-is. I considered getting rid of `toUTF16z` altogether in favor of `toUTFz`, but given that you have to give the return type to `toUTFz`, `toUTF16z` is more usable in the general case (like `toStringz`). So, I figured that we might as well just leave it but templatize it on string type as previously requested. It does now call `toUTFz` for its implementation though.
