### PR TITLE
std.array.replaceFirst() bug and doc fixes

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1776,13 +1776,16 @@ unittest
         auto from = to!T("foo");
         auto into = to!T("silly");
 
-        S r1 = replace(s, from, into);
-        assert(cmp(r1, "This is a silly silly list") == 0);
+        S r1 = replaceFirst(s, from, into);
+        assert(cmp(r1, "This is a silly foo list") == 0);
 
-        S r2 = replace(s, to!T(""), into);
-        assert(cmp(r2, "This is a foo foo list") == 0);
+        S r2 = replaceFirst(r1, from, into);
+        assert(cmp(r2, "This is a silly silly list") == 0);
 
-        assert(replace(r2, to!T("won't find this"), to!T("whatever")) is r2);
+        S r3 = replaceFirst(s, to!T(""), into);
+        assert(cmp(r3, "This is a foo foo list") == 0);
+
+        assert(replaceFirst(r3, to!T("won't find"), to!T("whatever")) is r3);
     }
 }
 


### PR DESCRIPTION
This fixes a bug in `replaceFirst` which was recently mentioned on the NG, and went undetected because the `unittest` block didn't actually test the right function.

Additionally, it clarifies the documentation for `replace` and `replaceFirst` with regard to array copying.
