### PR TITLE
Remove stray NUL character at the end of std/perf.d

### DIFF
--- a/std/perf.d
+++ b/std/perf.d
@@ -898,4 +898,3 @@ else
 
     static assert(platform_not_supported);
 }
- 


### PR DESCRIPTION
`grep` was complaining about a binary file.
