### PR TITLE
Various DDoc syntax fixes

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1182,7 +1182,7 @@ uint getAttributes(in char[] name)
         name = The file to get the symbolic link attributes of.
 
     Throws:
-        FileException on error.
+        $(D FileException) on error.
  +/
 uint getLinkAttributes(in char[] name)
 {
@@ -1206,7 +1206,7 @@ uint getLinkAttributes(in char[] name)
         name = The path to the file.
 
     Throws:
-        FileException if the given file does not exist.
+        $(D FileException) if the given file does not exist.
 
 Examples:
 --------------------
@@ -1504,7 +1504,7 @@ unittest
         name = The path to the file.
 
     Throws:
-        FileException if the given file does not exist.
+        $(D FileException) if the given file does not exist.
   +/
 @property bool isSymlink(C)(const(C)[] name)
 {
@@ -2646,7 +2646,7 @@ void copy(in char[] from, in char[] to)
         Set access/modified times of file $(D name).
 
         Throws:
-            $(D_PARAM FileException) on error.
+            $(D FileException) on error.
      +/
 version(StdDdoc) void setTimes(in char[] name, d_time fta, d_time ftm);
 else void setTimes(C)(in C[] name, d_time fta, d_time ftm)
@@ -2760,7 +2760,7 @@ unittest
     recursively.
 
     Throws:
-        FileException if there is an error (including if the given
+        $(D FileException) if there is an error (including if the given
         file is not a directory).
  +/
 void rmdirRecurse(in char[] pathname)
@@ -2776,7 +2776,7 @@ void rmdirRecurse(in char[] pathname)
     recursively.
 
     Throws:
-        FileException if there is an error (including if the given
+        $(D FileException) if there is an error (including if the given
         file is not a directory).
  +/
 void rmdirRecurse(ref DirEntry de)
@@ -3255,7 +3255,7 @@ unittest
         name = The file (or directory) to get a DirEntry for.
 
     Throws:
-        FileException) if the file does not exist.
+        $(D FileException) if the file does not exist.
  +/
 DirEntry dirEntry(in char[] name)
 {
@@ -3511,7 +3511,7 @@ unittest
     The names in the contents do not include the pathname.
 
     Throws:
-        FileException on error.
+        $(D FileException) on error.
 
 Examples:
     This program lists all the files and subdirectories in its

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -92,7 +92,7 @@ void main(string[] args)
   getopt(args, "verbose", &verbose, "debug", &debugging);
 ---------
 
- $(LI $(I Numeric options.) If an option is bound to a numeric type, a
+ )$(LI $(I Numeric options.) If an option is bound to a numeric type, a
  number is expected as the next option, or right within the option
  separated with an "=" sign:
 
@@ -118,7 +118,7 @@ To set $(D timeout) to $(D 5), invoke the program with either $(D
  expects a parameter, e.g. in the command line "--paranoid 42
  --paranoid", the "42" does not set $(D paranoid) to 42;
  instead, $(D paranoid) is set to 2 and "42" is not considered
- as part of the normal program arguments.))
+ as part of the normal program arguments.)))
 
  $(LI $(I Enum options.) If an option is bound to an enum, an enum symbol as a
  string is expected as the next option, or right within the option separated
@@ -131,7 +131,7 @@ To set $(D timeout) to $(D 5), invoke the program with either $(D
 ---------
 
 To set $(D color) to $(D Color.yes), invoke the program with either $(D
---color=yes) or $(D --color yes).
+--color=yes) or $(D --color yes).)
 
  $(LI $(I String options.) If an option is bound to a string, a string
  is expected as the next option, or right within the option separated
@@ -143,9 +143,9 @@ getopt(args, "output", &outputFile);
 ---------
 
  Invoking the program with "--output=myfile.txt" or "--output
- myfile.txt" will set $(D outputFile) to "myfile.txt".) If you want to
+ myfile.txt" will set $(D outputFile) to "myfile.txt". If you want to
  pass a string containing spaces, you need to use the quoting that is
- appropriate to your shell, e.g. --output='my file.txt'.
+ appropriate to your shell, e.g. --output='my file.txt'.)
 
  $(LI $(I Array options.) If an option is bound to an array, a new
  element is appended to the array each time the option occurs:
@@ -169,7 +169,7 @@ getopt(args, "tune", &tuningParms);
 ---------
 
 Invoking the program with e.g. "--tune=alpha=0.5 --tune beta=0.6" will
-set $(D tuningParms) to [ "alpha" : 0.5, "beta" : 0.6 ].)  In general,
+set $(D tuningParms) to [ "alpha" : 0.5, "beta" : 0.6 ]. In general,
 keys and values can be of any parsable types.)
 
 $(LI $(I Delegate options.) An option can be bound to a delegate with
@@ -180,7 +180,7 @@ $(UL $(LI In the $(D void delegate()) case, the delegate is invoked
 whenever the option is seen.) $(LI In the $(D void delegate(string
 option)) case, the option string (without the leading dash(es)) is
 passed to the delegate. After that, the option string is considered
-handled and removed from the options array.)
+handled and removed from the options array.
 
 ---------
 void main(string[] args)
@@ -202,11 +202,11 @@ void main(string[] args)
 }
 ---------
 
-$(LI In the $(D void delegate(string option, string value)) case, the
+)$(LI In the $(D void delegate(string option, string value)) case, the
 option string is handled as an option with one argument, and parsed
 accordingly. The option and its value are passed to the
 delegate. After that, whatever was passed to the delegate is
-considered handled and removed from the list.)
+considered handled and removed from the list.
 
 ---------
 void main(string[] args)

--- a/std/string.d
+++ b/std/string.d
@@ -875,7 +875,7 @@ unittest
 
 /************************************
  * $(RED Scheduled for deprecation in January 2012.
- *       Please use $(D toLower instead.)
+ *       Please use $(D toLower) instead.)
  *
  * Convert string s[] to lower case.
  */
@@ -934,7 +934,7 @@ unittest
 
 /**
    $(RED Scheduled for deprecation in January 2012.
-         Please use toLowerInPlace instead.)
+         Please use $(D toLowerInPlace) instead.)
 
    Converts $(D s) to lowercase in place.
  */
@@ -1050,7 +1050,7 @@ unittest
 
 /************************************
  * $(RED Scheduled for deprecation in January 2012.
- *       Please use toUpper instead.)
+ *       Please use $(D toUpper) instead.)
  *
  * Convert string s[] to upper case.
  */
@@ -1360,7 +1360,7 @@ unittest
 
 /********************************************
  *  $(RED Scheduled for deprecation in August 2011.
- *        Please use $(XREF array, replicate) instead.
+ *        Please use $(XREF array, replicate) instead.)
  *
  * Repeat $(D s) for $(D n) times.
  */
@@ -1447,7 +1447,7 @@ unittest
 
 /*****************************************
  *  $(RED Scheduled for deprecation in January 2012.
- *        Please use $(D stripLeft) instead.
+ *        Please use $(D stripLeft) instead.)
  *
  * Strips leading whitespace.
  */
@@ -1483,7 +1483,7 @@ S stripLeft(S)(S s) @safe pure
 
 /*****************************************
  *  $(RED Scheduled for deprecation in January 2012.
- *        Please use $(D stripRight) instead.
+ *        Please use $(D stripRight) instead.)
  *
  * Strips trailing whitespace.
  */
@@ -1871,7 +1871,7 @@ body
 
 /************************************************
  * $(RED Scheduled for deprecation in January 2012.
- *       Please use $(D detab) instead.
+ *       Please use $(D detab) instead.)
  *
  * Replace tabs with the appropriate number of spaces.
  * tabsize is the distance between tab stops.


### PR DESCRIPTION
Close some parens, fix some inconsistencies, make my text editor highlighter happy.

This also fixes the visible (OL on http://www.d-programming-language.org/phobos/std_getopt.html#getopt .
