### PR TITLE
AsyncBuf Overload For Buffer Recycling

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3267,8 +3267,6 @@ if(!randLen!Range) {
 
     static if(is(typeof(range.buf1)) && is(typeof(range.bufPos)) &&
     is(typeof(range.doBufSwap()))) {
-        enum bool bufferTrick = true;
-    } else {
         // Make sure we don't have the buffer recycling overload of
         // asyncBuf.
         static if(is(typeof(range.range)) &&
@@ -3277,6 +3275,8 @@ if(!randLen!Range) {
                 "the buffer recycling overload of asyncBuf.");
         }
 
+        enum bool bufferTrick = true;
+    } else {
         enum bool bufferTrick = false;
     }
 


### PR DESCRIPTION
Add an asyncBuf overload for the case where data is being read into a buffer, and the buffer is to be recycled instead of reallocated.  An example of this is by-line or by-chunk file I/O.  Also fix two related edge-case bugs in TaskPool.map and the other overload of TaskPool.asyncBuf.
