### PR TITLE
A few std.socket additions

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -190,6 +190,17 @@ SocketException getLastSocketException(string msg = null)
     return new SocketException(msg, _lasterr());
 }
 
+/// Return $(D true) if the last socket operation failed because the socket was in non-blocking mode and the operation would have blocked.
+bool wouldBlock()
+{
+    version(Win32)
+        return _lasterr() == WSAEWOULDBLOCK;
+    else version(BsdSockets)
+        return _lasterr() == EAGAIN;
+    else
+        static assert(0);
+}
+
 
 private __gshared typeof(&getnameinfo) getnameinfoPointer;
 


### PR DESCRIPTION
Changes are up for criticism. My D1 network library currently relies on these two small additions (by having a local copy of Phobos1's std.socket), so I'd like to merge these changes into D2's Phobos to avoid having to do the same hack for my eventual D2 port. The additions rely on std.socket internals (`_lasterr` and `SocketException`'s ctor), which is why I can't move them to my library without making said symbols public or reimplementing it.

I certainly hope no one minds the uncrustify. The indentation looked like the aftermath of a misconfigured automatic tabs-to-spaces conversion process (and also some parts of the code used braces on the same line).
