### PR TITLE
Improve std.conv

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1204,7 +1204,6 @@ unittest
         debug(conv) printf("string.to!string(%.*s, uint).unittest\n", Int.stringof.length, Int.stringof.ptr);
 
         assert(to!string(to!Int(-10), 10u) == "-10");
-        //assert(to!string(to!Int(-15), 2u) == (repeat("1", Int.sizeof)~"1111")[$-Int.sizeof .. $]);
     }
 }
 


### PR DESCRIPTION
Cleanup code:
-  639b099f - Remove dead code.
  They have been no longer used -  parseIntegral, parseFloating, toIfloat, toIdouble, toIreal, toCfloat, toCdouble, toCreal, getComplexStrings
-  f176fdec - Remove duplicate unittests
  Some unittests are redundant, so remove them.

Bug fixes:
- d74bb146 - Fix octal and enable part of its unittest.
- 3b7dd27b and 03a76d8 - Support parse!dchar(dstring) behave like chomp
- 277c7a72 - Fix const(bool) parsing.
