### PR TITLE
GDC Win64 patch for Phobos2

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -29967,7 +29967,7 @@ else version(Windows)
             scope(exit) RegCloseKey(baseKey);
 
             char[1024] keyName;
-            auto nameLen = keyName.length;
+            auto nameLen = to!DWORD(keyName.length);
             int result;
             for(DWORD index = 0;
                 (result = RegEnumKeyExA(baseKey, index, keyName.ptr, &nameLen, null, null, null, null)) != ERROR_NO_MORE_ITEMS;
@@ -29980,7 +29980,7 @@ else version(Windows)
                     {
                         scope(exit) RegCloseKey(tzKey);
                         char[1024] strVal;
-                        auto strValLen = strVal.length;
+                        auto strValLen = to!DWORD(strVal.length);
 
                         bool queryStringValue(string name, size_t lineNum = __LINE__)
                         {
@@ -30021,7 +30021,7 @@ else version(Windows)
 
                                     enum tzi = "TZI\0";
                                     REG_TZI_FORMAT binVal;
-                                    auto binValLen = REG_TZI_FORMAT.sizeof;
+                                    auto binValLen = to!DWORD(REG_TZI_FORMAT.sizeof);
 
                                     if(RegQueryValueExA(tzKey, tzi.ptr, null, null, cast(ubyte*)&binVal, &binValLen) == ERROR_SUCCESS)
                                     {
@@ -30067,7 +30067,7 @@ else version(Windows)
             scope(exit) RegCloseKey(baseKey);
 
             char[1024] keyName;
-            auto nameLen = keyName.length;
+            auto nameLen = to!DWORD(keyName.length);
             int result;
             for(DWORD index = 0;
                 (result = RegEnumKeyExA(baseKey, index, keyName.ptr, &nameLen, null, null, null, null)) != ERROR_NO_MORE_ITEMS;

--- a/std/file.d
+++ b/std/file.d
@@ -446,7 +446,7 @@ void write(in char[] name, const void[] buffer)
         cenforce(h != INVALID_HANDLE_VALUE, name);
         scope(exit) cenforce(CloseHandle(h), name);
         DWORD numwritten;
-        cenforce(WriteFile(h, buffer.ptr, buffer.length, &numwritten, null) == 1
+        cenforce(WriteFile(h, buffer.ptr, to!DWORD(buffer.length), &numwritten, null) == 1
                 && buffer.length == numwritten,
                 name);
     }
@@ -488,7 +488,7 @@ void append(in char[] name, in void[] buffer)
         scope(exit) cenforce(CloseHandle(h), name);
         DWORD numwritten;
         cenforce(SetFilePointer(h, 0, null, FILE_END) != INVALID_SET_FILE_POINTER
-                && WriteFile(h,buffer.ptr,buffer.length,&numwritten,null) == 1
+                && WriteFile(h,buffer.ptr,to!DWORD(buffer.length),&numwritten,null) == 1
                 && buffer.length == numwritten,
                 name);
     }
@@ -1859,7 +1859,7 @@ version(Windows) string getcwd()
     if (useWfuncs)
     {
         auto buffW = cast(wchar[]) staticBuff;
-        immutable n = cenforce(GetCurrentDirectoryW(buffW.length, buffW.ptr),
+        immutable n = cenforce(GetCurrentDirectoryW(to!DWORD(buffW.length), buffW.ptr),
                 "getcwd");
         // we can do it because toUTFX always produces a fresh string
         if(n < buffW.length)
@@ -1878,7 +1878,7 @@ version(Windows) string getcwd()
     else
     {
         auto buffA = cast(char[]) staticBuff;
-        immutable n = cenforce(GetCurrentDirectoryA(buffA.length, buffA.ptr),
+        immutable n = cenforce(GetCurrentDirectoryA(to!DWORD(buffA.length), buffA.ptr),
                 "getcwd");
         // fromMBSz doesn't always produce a fresh string
         if(n < buffA.length)
@@ -2246,7 +2246,7 @@ else version(Windows)
 
         void _init(in char[] path, in WIN32_FIND_DATA* fd)
         {
-            auto clength = std.c.string.strlen(fd.cFileName.ptr);
+            auto clength = to!int(std.c.string.strlen(fd.cFileName.ptr));
 
             // Convert cFileName[] to unicode
             const wlength = MultiByteToWideChar(0, 0, fd.cFileName.ptr, clength, null, 0);

--- a/std/process.d
+++ b/std/process.d
@@ -542,7 +542,7 @@ private:
             if (len == 1) return true;
 
             auto buf = new WCHAR[len];
-            GetEnvironmentVariableW(namez, buf.ptr, buf.length);
+            GetEnvironmentVariableW(namez, buf.ptr, to!DWORD(buf.length));
             value = toUTF8(buf[0 .. $-1]);
             return true;
         }

--- a/std/socket.d
+++ b/std/socket.d
@@ -1497,7 +1497,10 @@ class Socket
                 {
                         flags = cast(SocketFlags)(flags | MSG_NOSIGNAL);
                 }
-                auto sent = .send(sock, buf.ptr, buf.length, cast(int)flags);
+                version( Windows )
+                        auto sent = .send(sock, buf.ptr, to!int(buf.length), cast(int)flags);
+                else
+                        auto sent = .send(sock, buf.ptr, buf.length, cast(int)flags);
                 return sent;
         }
 
@@ -1517,7 +1520,10 @@ class Socket
                 {
                         flags = cast(SocketFlags)(flags | MSG_NOSIGNAL);
                 }
-                return .sendto(sock, buf.ptr, buf.length, cast(int)flags, to.name(), to.nameLen());
+                version( Windows )
+                        return .sendto(sock, buf.ptr, to!int(buf.length), cast(int)flags, to.name(), to.nameLen());
+                else
+                        return .sendto(sock, buf.ptr, buf.length, cast(int)flags, to.name(), to.nameLen());
         }
 
         /// ditto
@@ -1535,7 +1541,10 @@ class Socket
                 {
                         flags = cast(SocketFlags)(flags | MSG_NOSIGNAL);
                 }
-                return .sendto(sock, buf.ptr, buf.length, cast(int)flags, null, 0);
+                version(Windows)
+                        return .sendto(sock, buf.ptr, to!int(buf.length), cast(int)flags, null, 0);
+                else
+                        return .sendto(sock, buf.ptr, buf.length, cast(int)flags, null, 0);
         }
 
 
@@ -1556,9 +1565,16 @@ class Socket
         //returns number of bytes actually received, 0 on connection closure, or -1 on error
     ptrdiff_t receive(void[] buf, SocketFlags flags)
         {
-        return buf.length
-            ? .recv(sock, buf.ptr, buf.length, cast(int)flags)
-            : 0;
+                version(Win32) // Does not use size_t
+                {
+                        return buf.length
+                            ? .recv(sock, buf.ptr, to!int(buf.length), cast(int)flags)
+                            : 0;
+                } else {
+                        return buf.length
+                            ? .recv(sock, buf.ptr, buf.length, cast(int)flags)
+                            : 0;	
+                }
         }
 
         /// ditto
@@ -1581,10 +1597,18 @@ class Socket
                         return 0;
                 from = newFamilyObject();
                 socklen_t nameLen = cast(socklen_t) from.nameLen();
-                auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, from.name(), &nameLen);
-                assert(from.addressFamily() == _family);
-                // if(!read) //connection closed
-                return read;
+                version(Win32)
+                {
+                        auto read = .recvfrom(sock, buf.ptr, to!int(buf.length), cast(int)flags, from.name(), &nameLen);
+                        assert(from.addressFamily() == _family);
+                        // if(!read) //connection closed
+                        return read;
+                } else {
+                        auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, from.name(), &nameLen);
+                        assert(from.addressFamily() == _family);
+                        // if(!read) //connection closed
+                        return read;
+                }
         }
 
 
@@ -1602,9 +1626,16 @@ class Socket
         {
                 if(!buf.length) //return 0 and don't think the connection closed
                         return 0;
-                auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, null, null);
-                // if(!read) //connection closed
-                return read;
+                version(Win32)
+                {
+                        auto read = .recvfrom(sock, buf.ptr, to!int(buf.length), cast(int)flags, null, null);
+                        // if(!read) //connection closed
+                        return read;
+                } else {
+                        auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, null, null);
+                        // if(!read) //connection closed
+                        return read;
+                }
         }
 
 

--- a/std/stream.d
+++ b/std/stream.d
@@ -1954,7 +1954,9 @@ class File: Stream {
   override size_t readBlock(void* buffer, size_t size) {
     assertReadable();
     version (Win32) {
-      ReadFile(hFile, buffer, size, &size, null);
+	  auto dwSize = to!DWORD(size);
+      ReadFile(hFile, buffer, dwSize, &dwSize, null);
+	  size = dwSize;
     } else version (Posix) {
       size = core.sys.posix.unistd.read(hFile, buffer, size);
       if (size == -1)
@@ -1967,7 +1969,9 @@ class File: Stream {
   override size_t writeBlock(const void* buffer, size_t size) {
     assertWriteable();
     version (Win32) {
-      WriteFile(hFile, buffer, size, &size, null);
+	  auto dwSize = to!DWORD(size);
+      WriteFile(hFile, buffer, dwSize, &dwSize, null);
+	  size = dwSize;
     } else version (Posix) {
       size = core.sys.posix.unistd.write(hFile, buffer, size);
       if (size == -1)

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -17,6 +17,7 @@
  */
 module std.windows.charset;
 
+private import std.conv;
 private import std.c.windows.windows;
 private import std.windows.syserror;
 private import std.utf;
@@ -53,7 +54,7 @@ const(char)* toMBSz(in char[] s, uint codePage = 0)
             if (result.length)
             {
                 readLen = WideCharToMultiByte(codePage, 0, ws, -1, result.ptr,
-                        result.length, null, null);
+                        to!int(result.length), null, null);
             }
 
             if (!readLen || readLen != result.length)
@@ -98,7 +99,7 @@ string fromMBSz(immutable(char)* s, int codePage = 0)
             if (result.length)
             {
                 readLen = MultiByteToWideChar(codePage, 0, s, -1, result.ptr,
-                        result.length);
+                        to!int(result.length));
             }
 
             if (!readLen || readLen != result.length)

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -597,7 +597,7 @@ body
     // more if it does.
     for(;;)
     {
-        cchName = name.length;
+        cchName = to!DWORD(name.length);
 
         res = RegEnumKeyExA(hkey, index, name.ptr, cchName, RESERVED, null, null, null);
 
@@ -1306,7 +1306,7 @@ public:
         Reg_SetValueExA_(m_hkey, name, asEXPAND_SZ
                                             ? REG_VALUE_TYPE.REG_EXPAND_SZ
                                             : REG_VALUE_TYPE.REG_SZ, value.ptr
-                        , value.length);
+                        , to!DWORD(value.length));
     }
 
     /// Sets the named value with the given multiple-strings value
@@ -1328,13 +1328,13 @@ public:
         // Allocate
 
         char[]  cs      =   new char[total];
-        int     base    =   0;
+        size_t  base    =   0;
 
         // Slice the individual strings into the new array
 
         foreach(string s; value)
         {
-            int top = base + s.length;
+            size_t top = base + s.length;
 
             cs[base .. top] = s;
             cs[top] = 0;
@@ -1342,7 +1342,7 @@ public:
             base = 1 + top;
         }
 
-        Reg_SetValueExA_(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, cs.ptr, cs.length);
+        Reg_SetValueExA_(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, cs.ptr, to!DWORD(cs.length));
     }
 
     /// Sets the named value with the given binary value
@@ -1352,7 +1352,7 @@ public:
     /// \note If a value corresponding to the requested name is not found, a RegistryException is thrown
     void setValue(string name, byte[] value)
     {
-        Reg_SetValueExA_(m_hkey, name, REG_VALUE_TYPE.REG_BINARY, value.ptr, value.length);
+        Reg_SetValueExA_(m_hkey, name, REG_VALUE_TYPE.REG_BINARY, value.ptr, to!DWORD(value.length));
     }
 
     /// Deletes the named value
@@ -1475,7 +1475,7 @@ public:
         DWORD   cchRequired =   ExpandEnvironmentStringsA(lpSrc, null, 0);
         char[]  newValue    =   new char[cchRequired];
 
-        if(!ExpandEnvironmentStringsA(lpSrc, newValue.ptr, newValue.length))
+        if(!ExpandEnvironmentStringsA(lpSrc, newValue.ptr, to!DWORD(newValue.length)))
         {
             throw new Win32Exception("Failed to expand environment variables");
         }


### PR DESCRIPTION
Patch to allow GDC to compile 64-bit Phobos2.  

This patch is the minimum required to allow GDC to compile Phobos2.  It has not been well tested.
