### PR TITLE
The new std.path

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -35,7 +35,7 @@
         Thomas Kühne,
         $(WEB erdani.org, Andrei Alexandrescu)
     Copyright:
-        Copyright (c) 2000, the authors. All rights reserved.
+        Copyright (c) 2000–2011, the authors. All rights reserved.
     License:
         $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:


### PR DESCRIPTION
This pull request _only_ affects `std/path.d`. All the old std.path functions are still in there for backwards compatibility, so no other modules need to be changed to make things compile. However, you _will_ get a lot of "scheduled for deprecation" messages when compiling Phobos (especially in std.file, as that uses std.path extensively). I will update the other modules with the new std.path functions in a later pull request, once this one has been accepted.

I have verified that the Phobos unittests pass on Linux 32/64, as well as Wine. It would be great if someone could run the tests on "real Windows" and OS X.
