### PR TITLE
CTFE Dot Product

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1278,7 +1278,11 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
 
     /* Do trailing portion in naive loop. */
     while (avec != all_endp)
-        sum0 += (*avec++) * (*bvec++);
+    {
+        sum0 += *avec * *bvec;
+        ++avec;
+        ++bvec;
+    }
 
     return sum0;
 }
@@ -1289,6 +1293,17 @@ unittest
     double[] b = [ 4., 6., ];
     assert(dotProduct(a, b) == 16);
     assert(dotProduct([1, 3, -5], [4, -2, -1]) == 3);
+    
+    // Make sure the unrolled loop codepath gets tested.
+    static const x = 
+        [1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
+    static const y = 
+        [2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+    assert(dotProduct(x, y) == 2280);
+    
+    // Test in CTFE
+    enum ctfeDot = dotProduct(x, y);
+    static assert(ctfeDot == 2280);
 }
 
 /**


### PR DESCRIPTION
Issue 6514:  CTFE dot product.  This is a trivial change to the syntax to work around issue 6517, which was the only thing keeping the old dotProduct function from working at compile time.

I'd recommend accepting this pull request even if Bug 6517 (http://d.puremagic.com/issues/show_bug.cgi?id=6517) might get fixed soon, since it also improves the unit tests for dotProduct, including testing for CTFE.  Also, the workaround for 6517 is a trivial syntactic change that doesn't add any maintenance burden or code complexity.
