### PR TITLE
Update std.datetime and std.file for new std.path

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -29423,7 +29423,7 @@ assert(tz.dstName == "PDT");
             {
                 auto tzName = dentry.name[tzDatabaseDir.length .. $];
 
-                if(!tzName.getExt().empty() ||
+                if(!tzName.extension().empty() ||
                    !tzName.startsWith(subName) ||
                    tzName == "+VERSION")
                 {


### PR DESCRIPTION
This gets rid of the "scheduled for deprecation" messages related to the old `std.path` functions.
