### PR TITLE
Add array specialization for copy.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -5359,11 +5359,29 @@ assert(b[0 .. $ - c.length] == [ 1, 5, 9, 1 ]);
 Range2 copy(Range1, Range2)(Range1 source, Range2 target)
 if (isInputRange!Range1 && isOutputRange!(Range2, ElementType!Range1))
 {
-    for (; !source.empty; source.popFront())
+    static if(isArray!Range1 && isArray!Range2 && 
+    is(Unqual!(typeof(source[0])) == Unqual!(typeof(target[0]))))
     {
-        put(target, source.front);
+        // Array specialization.  This uses optimized memory copying routines
+        // under the hood and is about 10-20x faster than the generic 
+        // implementation.
+        enforce(target.length >= source.length, 
+            "Cannot copy a source array into a smaller target array.");
+        target[0..source.length] = source;
+        
+        return target[source.length..$];
     }
-    return target;
+    else
+    {   
+        // Generic implementation.    
+        for (; !source.empty; source.popFront())
+        {
+            put(target, source.front);
+        }
+        
+        return target;
+    }
+    
 }
 
 unittest


### PR DESCRIPTION
This pull request adds a specialization to std.algorithm.copy that uses D's array-wise operations.  These are 10-80x faster than the generic version, depending on the type being copied.  In the past, I've manually specialized this in various code and I figured it's such a simple optimization that it should be encapsulated once and for all in Phobos.

Benchmark:

```
import std.datetime, std.algorithm, std.stdio;

void main() {
    auto arr1 = new int[1_000];
    auto arr2 = new int[1_000];

    auto sw = StopWatch(AutoStart.yes);
    foreach(i; 0..10_000) {
        copy(arr1, arr2);
    }

    // About 3 milliseconds with patch, 77 without.
    writeln(sw.peek.msecs);
}
```

IMHO arrays are such an important special case of ranges that range algorithms need to be as efficient as possible with them, even if that means some special-casing.  Otherwise, the annoying special-casing will be repeated zillions of times in user code, where it's even worse.
