### PR TITLE
Fix std.conv unittest for *nix OS

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2647,7 +2647,8 @@ unittest
     assertThrown!ConvException(parse!bool(m));
     assert (m == "maybe");  // m shouldn't change on failure
 
-    auto b = parse!(const(bool))("true");
+    auto s = "true";
+    auto b = parse!(const(bool))(s);
     assert(b == true);
 }
 


### PR DESCRIPTION
I bumped the bug 4539. In *nix OS this generates segfault.
