### PR TITLE
Add sin(), cos() and sqrt() to std.complex

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -706,7 +706,7 @@ double tanh(double x) @safe pure nothrow { return tanh(cast(real)x); }
 /// ditto
 float tanh(float x) @safe pure nothrow { return tanh(cast(real)x); }
 
-private:
+package:
 /* Returns cosh(x) + I * sinh(x)
  * Only one call to exp() is performed.
  */


### PR DESCRIPTION
These functions are already defined for the `creal` type in `std.math`. To prepare for the transition to library complex numbers, I have adapted their implementation to `Complex!T` and added them to `std.complex`.

Under the hood they still use `std.math.coshisinh` and `std.math.expi`. Note that `coshisinh` was marked as `private`; I changed that to `package`.
