### PR TITLE
Improved parallel foreach amap

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -467,7 +467,6 @@ struct Task(alias fun, Args...) {
             foreach(i, Type; typeof(this.tupleof)) {
                 this.tupleof[i] = rhs.tupleof[i];
             }
-
             return this;
         }
     } else {


### PR DESCRIPTION
Massive improvements to the implementation of parallel foreach and amap.  When working on std.parallel_algorithm, I discovered a way of doing these that was so much simpler, more elegant, more efficient and less bug-prone that I wanted to completely rip up the old implementation.  Also, a few minor cleanups:
1.  amap now can use any random access assignable range for output, not just an array.
2.  map now statically disallows the buffer recycling overload of asyncBuf as input, since this never worked correctly.
3.  Improved memory management for reduce to avoid the GC.
