### PR TITLE
Add alwaysAssert.

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -504,7 +504,7 @@ unittest
     try 
     {
         alwaysAssert(0);
-        assert(0);
+        enforce(0);
     } catch(AssertError) {}
     
     alwaysAssert(1);
@@ -512,7 +512,7 @@ unittest
     try 
     {
         alwaysAssert(0, "msg");
-        assert(0);
+        enforce(0);
     } 
     catch(AssertError e) 
     {


### PR DESCRIPTION
This function differes from enforce in two ways:
1.  alwaysAssert documents that, if the predicate fails, it is a bug in the program.  enforce documents that, if the predicate fails,  it is due to an external factor and may be recoverable.
2.  alwaysAssert throws an AssertError, which is derived from Error and not meant to be caught under normal circumstances.  enforce throws an Exception which is meant to be caught and handled if possible.
