### PR TITLE
Issue 6572 - Deprecate typedef

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -1076,7 +1076,7 @@ int uncompress(ubyte* dest,
 */
 
 
-typedef void* gzFile;
+alias void* gzFile;
 alias int z_off_t;              // file offset
 
 gzFile gzopen(char* path, char* mode);

--- a/std/conv.d
+++ b/std/conv.d
@@ -929,7 +929,7 @@ T toImpl(T, S)(S s, in T left = S.stringof~"(", in T right = ")")
     }
 }
 
-unittest
+version(none) unittest
 {
     debug(conv) scope(success) writeln("unittest @",
             __FILE__, ":", __LINE__, " succeeded.");
@@ -2700,7 +2700,7 @@ Target parse(Target, Source)(ref Source s, dchar lbracket = '[', dchar rbracket 
     return result;
 }
 
-unittest
+version(none) unittest
 {
     debug(conv) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
     typedef uint Testing;

--- a/std/date.d
+++ b/std/date.d
@@ -1091,7 +1091,7 @@ version (Posix)
 /***
  * Type representing the DOS file date/time format.
  */
-typedef uint DosFileTime;
+alias uint DosFileTime;
 
 /************************************
  * Convert from DOS file date/time to d_time.

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -31542,7 +31542,7 @@ else version(Windows)
 /++
     Type representing the DOS file date/time format.
   +/
-typedef uint DosFileTime;
+alias uint DosFileTime;
 
 /++
     Converts from DOS file date/time to $(D SysTime).

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -656,7 +656,7 @@ template EncoderInstance(E)
 //=============================================================================
 
 /** Defines various character sets. */
-typedef ubyte AsciiChar;
+enum AsciiChar : ubyte { init };
 /// Ditto
 alias immutable(AsciiChar)[] AsciiString;
 
@@ -736,7 +736,7 @@ template EncoderInstance(CharType : AsciiChar)
 //=============================================================================
 
 /** Defines an Latin1-encoded character. */
-typedef ubyte Latin1Char;
+enum Latin1Char : ubyte { init };
 /**
 Defines an Latin1-encoded string (as an array of $(D
 immutable(Latin1Char))).
@@ -812,7 +812,7 @@ template EncoderInstance(CharType : Latin1Char)
 //=============================================================================
 
 /** Defines a Windows1252-encoded character. */
-typedef ubyte Windows1252Char;
+enum Windows1252Char : ubyte { init };
 /**
 Defines an Windows1252-encoded string (as an array of $(D
 immutable(Windows1252Char))).

--- a/std/format.d
+++ b/std/format.d
@@ -3849,10 +3849,10 @@ unittest
     r = std.string.format("%.*d", -3, 7);
     assert(r == "7");
 
-    typedef int myint;
-    myint m = -7;
-    r = std.string.format(m);
-    assert(r == "-7");
+    //typedef int myint;
+    //myint m = -7;
+    //r = std.string.format(m);
+    //assert(r == "-7");
 
     r = std.string.format("abc"c);
     assert(r == "abc");

--- a/std/loader.d
+++ b/std/loader.d
@@ -95,7 +95,7 @@ else
  * can result in the same module being loaded, which cannot be detected in
  * some operating systems
  */
-typedef void    *HXModule;
+alias void    *HXModule;
 
 /* /////////////////////////////////////////////////////////////////////////////
  * ExeModule functions

--- a/std/socket.d
+++ b/std/socket.d
@@ -63,7 +63,7 @@ version(Win32)
     private import std.c.windows.windows, std.c.windows.winsock;
     private alias std.c.windows.winsock.timeval _ctimeval;
 
-    typedef SOCKET socket_t = INVALID_SOCKET;
+    enum socket_t : SOCKET { INVALID_SOCKET };
     private const int _SOCKET_ERROR = SOCKET_ERROR;
 
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -1106,8 +1106,8 @@ unittest
     static assert(!hasRawAliasing!(S6));
     union S7 { int a; int * b; }
     static assert(hasRawAliasing!(S7));
-    typedef int* S8;
-    static assert(hasRawAliasing!(S8));
+    //typedef int* S8;
+    //static assert(hasRawAliasing!(S8));
     enum S9 { a };
     static assert(!hasRawAliasing!(S9));
     // indirect members
@@ -1190,10 +1190,10 @@ unittest
     static assert(hasRawUnsharedAliasing!(S9));
     union S10 { int a; shared int * b; }
     static assert(!hasRawUnsharedAliasing!(S10));
-    typedef int* S11;
-    static assert(hasRawUnsharedAliasing!(S11));
-    typedef shared int* S12;
-    static assert(hasRawUnsharedAliasing!(S12));
+    //typedef int* S11;
+    //static assert(hasRawUnsharedAliasing!(S11));
+    //typedef shared int* S12;
+    //static assert(hasRawUnsharedAliasing!(S12));
     enum S13 { a };
     static assert(!hasRawUnsharedAliasing!(S13));
     // indirect members
@@ -3319,18 +3319,18 @@ private template OriginalTypeImpl(T)
 
 unittest
 {
-    typedef real T;
-    typedef T    U;
-    enum V : U { a }
-    static assert(is(OriginalType!T == real));
-    static assert(is(OriginalType!U == real));
-    static assert(is(OriginalType!V == real));
+    //typedef real T;
+    //typedef T    U;
+    //enum V : U { a }
+    //static assert(is(OriginalType!T == real));
+    //static assert(is(OriginalType!U == real));
+    //static assert(is(OriginalType!V == real));
     enum E : real { a }
     enum F : E    { a = E.a }
-    typedef const F G;
+    //typedef const F G;
     static assert(is(OriginalType!E == real));
     static assert(is(OriginalType!F == real));
-    static assert(is(OriginalType!G == const real));
+    //static assert(is(OriginalType!G == const real));
 }
 
 
@@ -3551,8 +3551,8 @@ private string removeDummyEnvelope(string s)
 
 unittest
 {
-    typedef int MyInt;
-    MyInt test() { return 0; }
+    //typedef int MyInt;
+    //MyInt test() { return 0; }
     class C { int value() @property { return 0; } }
     static assert(mangledName!(int) == int.mangleof);
     static assert(mangledName!(C) == C.mangleof);

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -114,7 +114,7 @@ public enum Endian
 /+ + These are borrowed from synsoft.win32.types for the moment, but will not be
  + needed once I've convinced Walter to use strong typedefs for things like HKEY +
  +/
-private typedef uint Reserved;
+private alias uint Reserved;
 
 //import synsoft.text.token;
 /+ ++++++ This is borrowed from synsoft.text.token, until such time as something


### PR DESCRIPTION
Remove use of deprecated typedef from phobos.  This mostly consists of changing typedef to alias, and disabling unittests that require typedef.  One change to std.registry is needed to work around a bug in typedef (6571).

http://d.puremagic.com/issues/show_bug.cgi?id=6572
