### PR TITLE
Issue 5825 - write is calling a deprecated function

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1623,7 +1623,7 @@ unittest
 /*
    Formatting a $(D typedef) is deprecated but still kept around for a while.
  */
-deprecated void formatValue(Writer, T, Char)
+void formatValue(Writer, T, Char)
 (Writer w, T val, ref FormatSpec!Char f)
 if (is(T == typedef))
 {


### PR DESCRIPTION
Un-deprecate formatValue taking a typedef.  This is not valid while typedef is not a deprecated declaration inside dmd.

http://d.puremagic.com/issues/show_bug.cgi?id=5825
