### PR TITLE
Change toString signature taking sink

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -406,13 +406,13 @@ public:
      * $(TR $(TD null) $(TD Default formatting (same as "d") ))
      * )
      */
-    void toString(void delegate(const (char)[]) sink, string formatString) const
+    void toString(scope void delegate(const (char)[]) sink, string formatString) const
     {
         auto f = FormatSpec!char(formatString);
         f.writeUpToNextSpec(sink);
         toString(sink, f);
     }
-    void toString(void delegate(const(char)[]) sink, ref FormatSpec!char f) const
+    void toString(scope void delegate(const(char)[]) sink, ref FormatSpec!char f) const
     {
         auto hex = (f.spec == 'x' || f.spec == 'X');
         if (!(f.spec == 's' || f.spec == 'd' || hex))

--- a/std/complex.d
+++ b/std/complex.d
@@ -415,7 +415,7 @@ struct Complex(T)  if (isFloatingPoint!T)
         more information.
     */
     string toString
-        (void delegate(const(char)[]) sink = null, string formatSpec = "%s")
+        (scope void delegate(const(char)[]) sink = null, string formatSpec = "%s")
         const
     {
         if (sink == null)

--- a/std/format.d
+++ b/std/format.d
@@ -1735,36 +1735,21 @@ unittest
    Structs are formatted using by calling toString member function
    of the struct. toString must have one of the following signatures:
    ---
-   void toString(void delegate(const(char)[]) sink, FormatSpec fmt);
-   void toString(void delegate(const(char)[]) sink, string fmt);
+   void toString(scope void delegate(const(char)[]) sink, FormatSpec fmt);
+   void toString(scope void delegate(const(char)[]) sink, string fmt);
    ---
 
  */
 void formatValue(Writer, T, Char)(Writer w, T val, ref FormatSpec!Char f)
 if (is(T == struct) && !isInputRange!T)
 {
-    // @@@ BUG @@@
-    // Workaround for a closure scoped destruction problem.
-    static struct WriterSink
-    {
-        Writer* w;
-        void sink(const(char)[] s) { put(*w, s); }
-    }
-
     static if (is(typeof(val.toString((const(char)[] s){}, f))))
     {   // Support toString( delegate(const(char)[]) sink, FormatSpec)
-        WriterSink sinker;
-        sinker.w = &w;
-        string outbuff = "";
-        void sink(const(char)[] s) { outbuff ~= s; }
-        val.toString(&sink, f);
-        put(w, outbuff);
+        val.toString((const(char)[] s) { put(w, s); }, f);
     }
     else static if (is(typeof(val.toString((const(char)[] s){}, "%s"))))
     {   // Support toString( delegate(const(char)[]) sink, string fmt)
-        WriterSink sinker;
-        sinker.w = &w;
-        val.toString(&sinker.sink, f.getCurFmtStr());
+        val.toString((const(char)[] s) { put(w, s); }, f.getCurFmtStr());
     }
     else static if (is(typeof(val.toString()) S) && isSomeString!S)
     {


### PR DESCRIPTION
The sink delegate should be scoped. After fixing it, we can remove the workaround for a closure scoped destruction problem.
