### PR TITLE
Retry to pull #238 Improve error message

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2764,10 +2764,13 @@ Target parse(Target, Source)(ref Source s, dchar lbracket = '[', dchar rbracket 
     skipWS(s);
     if (s.front == rbracket)
     {
-        if (result.length != 0)
+        static if (result.length != 0)
             goto Lmanyerr;
-        s.popFront();
-        return result;
+        else
+        {
+            s.popFront();
+            return result;
+        }
     }
     for (size_t i = 0; ; s.popFront(), skipWS(s))
     {


### PR DESCRIPTION
#238 was reverted. The reason is https://github.com/D-Programming-Language/phobos/pull/238#issuecomment-1997064

```
if (s.front == rbracket)
{
    if (result.length != 0)
        goto Lmanyerr;
    s.popFront();  // std\conv.d(2769): Warning: statement is not reachable
    return result; // std\conv.d(2770): Warning: statement is not reachable
}
```

When `typeof(result)` is >= 0 length satic array, L2769 & L2770 is never reachable, then warning is raised.
