### PR TITLE
Add -w switch for building unittest in Windows

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -41,7 +41,7 @@ DFLAGS=-O -release -nofloat -w -d
 
 ## Flags for compiling unittests
 
-UDFLAGS=-O -nofloat -d
+UDFLAGS=-O -nofloat -w -d
 
 ## C compiler
 


### PR DESCRIPTION
In windows, unittest.exe is builded without -w switch, it is different from in posix.
