### PR TITLE
Trivial doc fix: InternetHost.getHostByAddr expects address in host byte order.

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -586,7 +586,7 @@ class InternetHost
      * Resolve IPv4 address number. Returns false if unable to resolve.
      *
      * Params:
-     *   addr = The IPv4 address to resolve, in network byte order.
+     *   addr = The IPv4 address to resolve, in host byte order.
      */
     bool getHostByAddr(uint addr)
     {


### PR DESCRIPTION
Thanks to Vladimir Panteleev for reporting this. It is also used wrongly from `InternetAddress.toHostNameString`, but since the latter accidentally went undocumented, and the code path that suffers from the bug is only triggered on ancient Windows boxes, I'd rather fix that after the release.
