### PR TITLE
Fix regression 6314

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -765,7 +765,7 @@ private auto makeRangeTuple(E, U...)(E[] place, U stuff)
 {
     enum toPack = staticFrontConvertible!(E, U);
     foreach(i, v; stuff[0..toPack])
-        static if(is(E == class))
+        static if(!is(E == struct))
             place[i] = v;
         else
             emplace!E(&place[i], v);


### PR DESCRIPTION
Fix for  regression in insertInPlace that I introduced between 2.053-2.054, basically emplace is not the way to go for array of class instances.
Also now it bypasses emplace for builtins, should help performance a bit (esp. w/o -inline).
