### PR TITLE
Fixed enforcement in emplace

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3371,7 +3371,8 @@ T emplace(T, Args...)(void[] chunk, Args args) if (is(T == class))
     enforce(chunk.length >= __traits(classInstanceSize, T),
            new ConvException("emplace: chunk size too small"));
     auto a = cast(size_t) chunk.ptr;
-    enforce(a % T.alignof == 0, text(a, " vs. ", T.alignof));
+    enforce(a % 16 == 0, 
+           new ConvException("emplace: chunk not 16-byte aligned"));
     auto result = cast(typeof(return)) chunk.ptr;
 
     // Initialize the object in its pre-ctor state


### PR DESCRIPTION
std.conv.emplace checked for sizeof(size_t)-byte alignment of emplace'd class instances, but, as far as I know, 16-byte alignment is required. Apparently it was incorrectly assumed that T.alignof would be the alignment of the class instance. Actually it is the alignment of the class reference which is equal to sizeof(size_t).
