### PR TITLE
enable now-passing std.container tests on freebsd64

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -241,11 +241,6 @@ $(ROOT)/%$(DOTOBJ) : %.c
 $(LIB) : $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
 
-ifeq ($(OS)$(MODEL),freebsd64)
-DISABLED_TESTS += std/container
-# fails freebsd64 debug test
-endif
-
 ifeq ($(MODEL),64)
 DISABLED_TESTS += std/conv
 # not reduced yet. I hate reducing this file


### PR DESCRIPTION
Closes bug 6009.  The actual bug was fixed at some point before now.
