### PR TITLE
Enhancement of FreeBSD(amd64) support for D1

### DIFF
--- a/std/c/freebsd/freebsd.d
+++ b/std/c/freebsd/freebsd.d
@@ -180,10 +180,10 @@ extern (C)
     int dup2(int, int);
     int pipe(int[2]);
     pid_t wait(int*);
-    int waitpid(pid_t, int*, int);
+    pid_t waitpid(pid_t, int*, int);
 
     uint alarm(uint);
-    char* basename(char*);
+    char* basename(in char*);
     //wint_t btowc(int);
     int chown(in char*, uid_t, gid_t);
     int chroot(in char*);
@@ -191,7 +191,7 @@ extern (C)
     int creat(in char*, mode_t);
     char* ctermid(char*);
     int dirfd(DIR*);
-    char* dirname(char*);
+    char* dirname(in char*);
     int fattach(int, char*);
     int fchmod(int, mode_t);
     int fdatasync(int);


### PR DESCRIPTION
I compiled phobos1 on a FreeBSD 8.2R(amd64) box, I encountered an compilation error.
 In this pull request, the fix contains. Furthermore I fixed some declarations of some C functions
 for FreeBSD(amd64). I have checked the compilation passes on FreeBSD(i386) and FreeBSD(amd64).

---

The following changes since commit 1e18776:

speed up (2011-08-05 16:48:11 -0700)

are available in the git repository at:
https://sohgo@github.com/sohgo/phobos.git freebsd-runtime1

Sohgo Takeuchi (4):
 make it compilable on FreeBSD 8.2R (amd64)
 time_t and __time_t definition for 64 bit on FreeBSD
 return value and arguments of some functions for a FreeBSD 64bit system
 fixed declarations of some C functions for FreeBSD

std/c/freebsd/freebsd.d | 35 +++++++++++++++++++++--------------
 1 files changed, 21 insertions(+), 14 deletions(-)
