### PR TITLE
Issue6634

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -2262,7 +2262,7 @@ unittest
     assert(!globMatch("foo.bar", "[gh]???bar"));
     assert(!globMatch("foo.bar"w, "[!fg]*bar"w));
     assert(!globMatch("foo.bar"d, "[fg]???baz"d));
-    assert(!globMatch("foo.di", "*.d")); // test BUG 6634: triggered bad assertion
+    assert(!globMatch("foo.di", "*.d")); // test issue 6634: triggered bad assertion
 
     assert(globMatch("foo.bar", "{foo,bif}.bar"));
     assert(globMatch("bif.bar"w, "{foo,bif}.bar"w));
@@ -3996,7 +3996,7 @@ version (OldStdPathUnittest) unittest
     assert(!fnmatch("foo.bar", "[gh]???bar"));
     assert(!fnmatch("foo.bar", "[!fg]*bar"));
     assert(!fnmatch("foo.bar", "[fg]???baz"));
-    assert(!fnmatch("foo.di", "*.d")); // test BUG 6634: triggered bad assertion
+    assert(!fnmatch("foo.di", "*.d")); // test issue 6634: triggered bad assertion
 
     assert(fnmatch("foo.bar", "{foo,bif}.bar"));
     assert(fnmatch("bif.bar", "{foo,bif}.bar"));


### PR DESCRIPTION
fixes Issue 6634 - std.path.globMatch throws wrong assertion

http://d.puremagic.com/issues/show_bug.cgi?id=6634

Also adds a problematic test case to the unittests.
