### PR TITLE
Issue 6160 - std.conv.to: Ignore _ to match the rest of D

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2249,6 +2249,13 @@ Target parse(Target, Source)(ref Source p)
                 if (p.empty)
                     break;
                 i = p.front;
+                if (i == '_')
+                {
+                    p.popFront();
+                    if (p.empty)
+                        break;
+                    i = p.front;
+                }
             }
             if (i == '.' && !dot)
             {       p.popFront();
@@ -2358,6 +2365,13 @@ Target parse(Target, Source)(ref Source p)
                 if (p.empty)
                     break;
                 i = p.front;
+                if (i == '_')
+                {
+                    p.popFront();
+                    if (p.empty)
+                        break;
+                    i = p.front;
+                }
             }
             if (i == '.' && !dot)
             {
@@ -2570,6 +2584,13 @@ unittest
 {
     assert(to!float("inf") == float.infinity);
     assert(to!float("-inf") == -float.infinity);
+}
+
+// Unittest for bug 6160
+unittest
+{
+    assert(1000_000_000e50L == to!real("1000_000_000_e50"));        // 1e59
+    assert(0x1000_000_000_p10 == to!real("0x1000_000_000_p10"));    // 7.03687e+13
 }
 
 /**


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6160
