### PR TITLE
Getopt fixes

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -168,7 +168,9 @@ getopt(args, "output", &outputFiles);
 
   Invoking the program with "--output=myfile.txt --output=yourfile.txt"
   or "--output myfile.txt --output yourfile.txt" will set $(D
-  outputFiles) to [ "myfile.txt", "yourfile.txt" ].
+  outputFiles) to [ "myfile.txt", "yourfile.txt" ]. The same result can be
+  achieved by "--output myfile.txt,yourfile.txt" specifying multiple elements
+  separated by $(LREF arraySep).
   )
 
   $(LI $(I Hash options.) If an option is bound to an associative
@@ -181,8 +183,11 @@ getopt(args, "tune", &tuningParms);
 ---------
 
   Invoking the program with e.g. "--tune=alpha=0.5 --tune beta=0.6" will
-  set $(D tuningParms) to [ "alpha" : 0.5, "beta" : 0.6 ]. In general,
-  keys and values can be of any parsable types.
+  set $(D tuningParms) to [ "alpha" : 0.5, "beta" : 0.6 ]. Specifying multiple
+  elements separated by $(LREF arraySep) is also possible, e.g.
+  "--tune=alpha=0.5,beta=0.6".
+
+  Keys and values can be of any parsable types.
   )
 
   $(LI $(I Delegate options.) An option can be bound to a delegate with
@@ -605,14 +610,17 @@ void handleOption(R)(string option, R receiver, ref string[] args,
                 else static if (isArray!(ReceiverType))
                 {
                     // array receiver
-                    *receiver ~= [ to!(typeof(*receiver[0]))(val) ];
+                    foreach (elem; split(val, arraySep))
+                    {
+                        *receiver ~= [ to!(typeof(*receiver[0]))(elem) ];
+                    }
                 }
                 else static if (isAssociativeArray!(ReceiverType))
                 {
                     // hash receiver
                     alias typeof(receiver.keys[0]) K;
                     alias typeof(receiver.values[0]) V;
-                    foreach (elem; split(val, assocSep))
+                    foreach (elem; split(val, arraySep))
                     {
                         auto j = std.string.indexOf(elem, assignChar);
                         enforce(j > 0,
@@ -667,11 +675,10 @@ string endOfOptions = "--";
 dchar assignChar = '=';
 
 /**
-   The string used to separate multiple elements of associative array
-   parameters. Defaults to "," but can be assigned to prior to calling
-   $(D getopt).
+   The string used to separate multiple elements of array parameters. Defaults
+   to "," but can be assigned to prior to calling $(D getopt).
  */
-string assocSep = ",";
+string arraySep = ",";
 
 enum autoIncrementChar = '+';
 
@@ -1043,6 +1050,74 @@ unittest {
         assertThrown!Exception(getopt(args, "t|timeout", &timeout));
         assert(isEqual(timeout, timeout.init), to!string(timeout));
     }
+}
+
+// specifying associative arrays with arraySep
+unittest
+{
+    int[string] parameters;
+    auto args = ["program.name",
+                 "-tfoo=0,bar=1,baz=2"];
+    getopt(args, "tune|t", &parameters);
+    assert(parameters == ["foo":0, "bar":1, "baz":2], to!string(parameters));
+
+    parameters = parameters.init;
+    args = ["program.name",
+            "-t=foo=0,bar=1,baz=2"].dup;
+    getopt(args, "tune|t", &parameters);
+    assert(parameters == ["foo":0, "bar":1, "baz":2], to!string(parameters));
+
+    parameters = parameters.init;
+    args = ["program.name",
+            "-t", "foo=0,bar=1,baz=2"].dup;
+    getopt(args, "tune|t", &parameters);
+    assert(parameters == ["foo":0, "bar":1, "baz":2], to!string(parameters));
+
+    parameters = parameters.init;
+    args = ["program.name",
+            "--tune", "foo=0,bar=1,baz=2"].dup;
+    getopt(args, "tune|t", &parameters);
+    assert(parameters == ["foo":0, "bar":1, "baz":2], to!string(parameters));
+
+    parameters = parameters.init;
+    args = ["program.name",
+            "--tune=foo=0,bar=1,baz=2"].dup;
+    getopt(args, "tune|t", &parameters);
+    assert(parameters == ["foo":0, "bar":1, "baz":2], to!string(parameters));
+}
+
+// specifying arrays with arraySep
+unittest
+{
+    string[] names;
+    auto args = ["program.name",
+                 "-nfoo,bar,baz"];
+    getopt(args, "name|n", &names);
+    assert(names == ["foo", "bar", "baz"], to!string(names));
+
+    names = names.init;
+    args = ["program.name",
+            "-n=foo,bar,baz"].dup;
+    getopt(args, "name|n", &names);
+    assert(names == ["foo", "bar", "baz"], to!string(names));
+
+    names = names.init;
+    args = ["program.name",
+            "-n" "foo,bar,baz"].dup;
+    getopt(args, "name|n", &names);
+    assert(names == ["foo", "bar", "baz"], to!string(names));
+
+    names = names.init;
+    args = ["program.name",
+            "--name", "foo,bar,baz"].dup;
+    getopt(args, "name|n", &names);
+    assert(names == ["foo", "bar", "baz"], to!string(names));
+
+    names = names.init;
+    args = ["program.name",
+            "--name=foo,bar,baz"].dup;
+    getopt(args, "name|n", &names);
+    assert(names == ["foo", "bar", "baz"], to!string(names));
 }
 
 // with no space only for short numeric options, i.e. config.noSpaceOnlyForShortNumericOptions


### PR DESCRIPTION
I'm sorry that this pull requests has so many commits. It's okay with me if we do a formal review if this is better.

This pull requests fixes:
- 5316 (with support for arrays in addition to associative arrays)
- 5228 (provides specific exceptions for getopt)
- 5762

Issue #6335 should be closed as well. Since I cannot reproduce it.

Besides these fixes this request clarifies short vs. long options and strives to provide a consistent behavior to the user.
The updated documentation can be found at http://jkm.github.com/phobos/phobos-prerelease/std_getopt.html.

In particular I'd like to get feedback regarding documentation because I'm not a native English speaker.
