### PR TITLE
Fix std.file unittest in Windows

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1471,7 +1471,7 @@ bool attrIsFile(uint attributes) nothrow
 {
     version(Windows)
     {
-        return (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+        return (attributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
     }
     else version(Posix)
     {


### PR DESCRIPTION
Now Phobos unittest is broken in Windows by merging #273.
See D auto tester result (http://d.puremagic.com/test-results/test_data.ghtml?dataid=101422)

I don't know this is _right_ fix, but test passes in my computer (64-bit Windows 7).

@CyberShadow, Please check this patch.
