### PR TITLE
Attempt to fix circular dependency on OS X.

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -46,11 +46,6 @@ module std.exception;
 
 import std.array, std.c.string, std.conv, std.range, std.string, std.traits;
 import core.exception, core.stdc.errno;
-version(unittest)
-{
-    import std.datetime;
-    import std.stdio;
-}
 
 /++
     Asserts that the given expression does $(I not) throw the given type
@@ -68,12 +63,14 @@ version(unittest)
 
     Examples:
 --------------------
-assertNotThrown!TimeException(std.datetime.TimeOfDay(0, 0, 0));
-assertNotThrown(std.datetime.TimeOfDay(23, 59, 59));  //Exception is default.
+assertNotThrown!StringException(enforceEx!StringException(true, "Error!"));
 
-assert(collectExceptionMsg!AssertError(assertNotThrown!TimeException(
-                            std.datetime.TimeOfDay(12, 0, 60))) ==
-       `assertNotThrown failed: TimeException was thrown.`);
+//Exception is the default.
+assertNotThrown(enforceEx!StringException(true, "Error!"));
+
+assert(collectExceptionMsg!AssertError(assertNotThrown!StringException(
+           enforceEx!StringException(false, "Error!"))) ==
+       `assertNotThrown failed: StringException was thrown.`);
 --------------------
   +/
 void assertNotThrown(T : Throwable = Exception, E)
@@ -100,12 +97,14 @@ void assertNotThrown(T : Throwable = Exception, E)
 //Verify Examples
 unittest
 {
-    assertNotThrown!TimeException(std.datetime.TimeOfDay(0, 0, 0));
-    assertNotThrown(std.datetime.TimeOfDay(23, 59, 59));  //Exception is default.
+    assertNotThrown!StringException(enforceEx!StringException(true, "Error!"));
 
-    assert(collectExceptionMsg!AssertError(assertNotThrown!TimeException(
-                                std.datetime.TimeOfDay(12, 0, 60))) ==
-           `assertNotThrown failed: TimeException was thrown.`);
+    //Exception is the default.
+    assertNotThrown(enforceEx!StringException(true, "Error!"));
+
+    assert(collectExceptionMsg!AssertError(assertNotThrown!StringException(
+               enforceEx!StringException(false, "Error!"))) ==
+           `assertNotThrown failed: StringException was thrown.`);
 }
 
 unittest
@@ -207,12 +206,14 @@ unittest
 
     Examples:
 --------------------
-assertThrown!TimeException(std.datetime.TimeOfDay(-1, 15, 30));
-assertThrown(std.datetime.TimeOfDay(12, 15, 60));  //Exception is default.
+assertThrown!StringException(enforceEx!StringException(false, "Error!"));
 
-assert(collectExceptionMsg!AssertError(assertThrown!AssertError(
-                            std.datetime.TimeOfDay(12, 0, 0))) ==
-       `assertThrown failed: No AssertError was thrown.`);
+//Exception is the default.
+assertThrown(enforceEx!StringException(false, "Error!"));
+
+assert(collectExceptionMsg!AssertError(assertThrown!StringException(
+           enforceEx!StringException(true, "Error!"))) ==
+       `assertThrown failed: No StringException was thrown.`);
 --------------------
   +/
 void assertThrown(T : Throwable = Exception, E)
@@ -243,12 +244,14 @@ void assertThrown(T : Throwable = Exception, E)
 //Verify Examples
 unittest
 {
-    assertThrown!TimeException(std.datetime.TimeOfDay(-1, 15, 30));
-    assertThrown(std.datetime.TimeOfDay(12, 15, 60));  //Exception is default.
+    assertThrown!StringException(enforceEx!StringException(false, "Error!"));
 
-    assert(collectExceptionMsg!AssertError(assertThrown!AssertError(
-                                std.datetime.TimeOfDay(12, 0, 0))) ==
-           `assertThrown failed: No AssertError was thrown.`);
+    //Exception is the default.
+    assertThrown(enforceEx!StringException(false, "Error!"));
+
+    assert(collectExceptionMsg!AssertError(assertThrown!StringException(
+               enforceEx!StringException(true, "Error!"))) ==
+           `assertThrown failed: No StringException was thrown.`);
 }
 
 unittest


### PR DESCRIPTION
As shown [here](http://d.puremagic.com/test-results/test_data.ghtml?dataid=104543), there's currently a circular dependency on Mac OS X due to the fact that std.exception uses std.datetime in its unit tests. This should fix the problem, but I've been unable to actually verify that it does, since I don't have a Mac.
