### PR TITLE
Fix bug 6761 where RedBlackTree's vtable layout differs when in -unittest mode

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -4254,7 +4254,8 @@ class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     {
         private enum doUnittest = isIntegral!T;
 
-        bool arrayEqual(T[] arr)
+        // note, this must be final so it does not affect the vtable layout
+        final bool arrayEqual(T[] arr)
         {
             if(walkLength(this[]) == arr.length)
             {


### PR DESCRIPTION
Fixed issue where RedBlackTree's vtable was different when compiled with -unittest.

http://d.puremagic.com/issues/show_bug.cgi?id=6761
