### PR TITLE
Fix imports in isemail.d.

### DIFF
--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -24,7 +24,8 @@
  */
 module std.net.isemail;
 
-import std.algorithm : ElementType, equal, uniq, filter, contains = canFind;
+import std.algorithm : equal, uniq, filter, contains = canFind;
+import std.range : ElementType;
 import std.array;
 import std.ascii;
 import std.conv;


### PR DESCRIPTION
ElementType is defined in std.range. The import works currently, but would break if https://github.com/D-Programming-Language/dmd/pull/190 were applied to dmd.
