### PR TITLE
Add ProxyOf and TypeDef

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2736,14 +2736,14 @@ unittest
 }
 
 /**
-Make proxy of $(D a).
+Make proxy for $(D a).
 
 Example:
 ----
 struct MyInt
 {
     private int value;
-    mixin ProxyOf!value;
+    mixin Proxy!value;
 
     this(int n){ value = n; }
 }
@@ -2762,7 +2762,7 @@ void func(int n) { }
 //func(n);
 ----
  */
-mixin template ProxyOf(alias a)
+mixin template Proxy(alias a)
 {
     auto ref opEquals(this X, B)(auto ref B b) { return a == b; }
 
@@ -2831,7 +2831,7 @@ unittest
     static struct MyInt
     {
         private int value;
-        mixin ProxyOf!value;
+        mixin Proxy!value;
         this(int n){ value = n; }
     }
 
@@ -2863,7 +2863,7 @@ unittest
     static struct MyArray
     {
         private int[] value;
-        mixin ProxyOf!value;
+        mixin Proxy!value;
         this(int[] arr){ value = arr; }
     }
 
@@ -2907,7 +2907,7 @@ unittest
     class Hoge
     {
         Foo foo;
-        mixin ProxyOf!foo;
+        mixin Proxy!foo;
         this(Foo f) { foo = f; }
     }
 
@@ -2954,38 +2954,38 @@ unittest
 /**
 Library typedef.
  */
-template TypeDef(T)
+template Typedef(T)
 {
-    alias .TypeDef!(T, T.init) TypeDef;
+    alias .Typedef!(T, T.init) Typedef;
 }
 
 /// ditto
-struct TypeDef(T, T init, string cookie=null)
+struct Typedef(T, T init, string cookie=null)
 {
-    private T TypeDef_payload = init;
+    private T Typedef_payload = init;
 
     this(T init)
     {
-        TypeDef_payload = init;
+        Typedef_payload = init;
     }
 
-    mixin ProxyOf!TypeDef_payload;
+    mixin Proxy!Typedef_payload;
 }
 
 unittest
 {
-    TypeDef!int x = 10;
+    Typedef!int x = 10;
     static assert(!__traits(compiles, { int y = x; }));
     static assert(!__traits(compiles, { long z = x; }));
 
-    TypeDef!int y = 10;
+    Typedef!int y = 10;
     assert(x == y);
 
-    TypeDef!(float, 1.0) z; // specifies the init
+    Typedef!(float, 1.0) z; // specifies the init
     assert(z == 1.0);
 
-    alias TypeDef!(int, 0, "dollar") Dollar;
-    alias TypeDef!(int, 0, "yen") Yen;
+    alias Typedef!(int, 0, "dollar") Dollar;
+    alias Typedef!(int, 0, "yen") Yen;
     static assert(!is(Dollar == Yen));
 }
 


### PR DESCRIPTION
ProxyOf requires following dmd patch:
<del> https://github.com/D-Programming-Language/dmd/pull/280 </del> Merged.

`ProxyOf` works like `alias this`, except implicit conversion to original type.
I think this is also useful for `scoped!T`, because scoped!T object should reject implicit conversion to T.

`TypeDef` is a simple use case of `ProxyOf`.
