### PR TITLE
Supplemental changes of dmd/pull/498 - Issue 6902 - Different "pure nothrow int()" types 

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -390,7 +390,7 @@ unittest
     static assert(functionAttributes!(Test2.pure_const) == FA.pure_);
     static assert(functionAttributes!(Test2.pure_sharedconst) == FA.pure_);
 
-    static assert(functionAttributes!((int a) {}) == FA.none);
+    static assert(functionAttributes!((int a) {}) == (FA.safe | FA.pure_ | FA.nothrow_));
 }
 
 
@@ -3493,7 +3493,7 @@ unittest
     static assert(mangledName!(removeDummyEnvelope) ==
             "_D3std6traits19removeDummyEnvelopeFAyaZAya");
     int x;
-    static assert(mangledName!((int a) { return a+x; })[$ - 5 .. $] == "MFiZi");
+    static assert(mangledName!((int a) { return a+x; })[$ - 9 .. $] == "MFNbNfiZi");    // nothrow safe
 }
 
 


### PR DESCRIPTION
This pull request is part of dmd/pull/498.
We should apply this after dmd changing.

This pull has same change with #322, that was merged into master in an accident.
