### PR TITLE
Applied deprecations for November 2011.

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -575,7 +575,7 @@ unittest
 }
 
 /+
-Commented out until the insert which is scheduled for deprecation is removed.
+Commented out until the insert which has been deprecated has been removed.
 I'd love to just remove it in favor of insertInPlace, but then code would then
 use this version of insert and silently break. So, it's here so that it can
 be used once insert has not only been deprecated but removed, but until then,
@@ -923,12 +923,12 @@ unittest
 }
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Deprecated. It will be removed in May 2012.
           Please use $(LREF insertInPlace) instead.)
 
     Same as $(XREF array, insertInPlace).
   +/
-void insert(T, Range)(ref T[] array, size_t pos, Range stuff)
+deprecated void insert(T, Range)(ref T[] array, size_t pos, Range stuff)
 if (isInputRange!Range && is(ElementEncodingType!Range : T))
 {
     insertInPlace(array, pos, stuff);
@@ -1503,7 +1503,7 @@ unittest
 }
 
 /+
-Commented out until the replace which is scheduled for deprecation is removed.
+Commented out until the replace which has been deprecated has been removed.
 I'd love to just remove it in favor of replaceInPlace, but then code would then
 use this version of replaceInPlace and silently break. So, it's here so that it
 can be used once replace has not only been deprecated but removed, but
@@ -1742,12 +1742,12 @@ unittest
 }
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Deprecated. It will be removed in May 2012.
           Please use $(LREF replaceInPlace) instead.)
 
     Same as $(XREF array, replaceInPlace).
   +/
-void replace(T, Range)(ref T[] array, size_t from, size_t to, Range stuff)
+deprecated void replace(T, Range)(ref T[] array, size_t from, size_t to, Range stuff)
 if (isDynamicArray!Range && is(ElementType!Range : T))
 {
     replaceInPlace(array, from, to, stuff);

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -7898,10 +7898,13 @@ assert(SysTime(DateTime(-4, 1, 5, 0, 0, 2),
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use toISOExtString instead.)
       +/
-    alias toISOExtString toISOExtendedString;
+    deprecated string toISOExtendedString() const nothrow
+    {
+        return toISOExtString();
+    }
 
     unittest
     {
@@ -8453,10 +8456,10 @@ assert(SysTime.fromISOExtString("2010-07-04T07:06:12+8:00") ==
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use fromISOExtString instead.)
       +/
-    static SysTime fromISOExtendedString(S)(in S isoExtString, immutable TimeZone tz = null)
+    deprecated static SysTime fromISOExtendedString(S)(in S isoExtString, immutable TimeZone tz = null)
         if(isSomeString!(S))
     {
         return fromISOExtString!string(isoExtString, tz);
@@ -12791,10 +12794,13 @@ assert(Date(-4, 1, 5).toISOExtString() == "-0004-01-05");
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use toISOExtString instead.)
       +/
-    alias toISOExtString toISOExtendedString;
+    deprecated string toISOExtendedString() const nothrow
+    {
+        return toISOExtString();
+    }
 
     unittest
     {
@@ -13108,10 +13114,10 @@ assert(Date.fromISOExtString(" 2010-07-04 ") == Date(2010, 7, 4));
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use fromISOExtString instead.)
       +/
-    static Date fromISOExtendedString(S)(in S isoExtString)
+    deprecated static Date fromISOExtendedString(S)(in S isoExtString)
         if(isSomeString!(S))
     {
         return fromISOExtString!string(isoExtString);
@@ -14511,10 +14517,13 @@ assert(TimeOfDay(12, 30, 33).toISOExtString() == "123033");
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use toISOExtString instead.)
       +/
-    alias toISOExtString toISOExtendedString;
+    deprecated string toISOExtendedString() const nothrow
+    {
+        return toISOExtString();
+    }
 
     unittest
     {
@@ -14725,10 +14734,10 @@ assert(TimeOfDay.fromISOExtString(" 12:30:33 ") == TimeOfDay(12, 30, 33));
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use fromISOExtString instead.)
       +/
-    static TimeOfDay fromISOExtendedString(S)(in S isoExtString)
+    deprecated static TimeOfDay fromISOExtendedString(S)(in S isoExtString)
         if(isSomeString!(S))
     {
         return fromISOExtString!string(isoExtString);
@@ -17692,10 +17701,13 @@ assert(DateTime(Date(-4, 1, 5), TimeOfDay(0, 0, 2)).toISOExtString() ==
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use toISOExtString instead.)
       +/
-    alias toISOExtString toISOExtendedString;
+    deprecated string toISOExtendedString() const nothrow
+    {
+        return toISOExtString();
+    }
 
     unittest
     {
@@ -17964,10 +17976,10 @@ assert(DateTime.fromISOExtString(" 2010-07-04T07:06:12 ") ==
     }
 
     /++
-        $(RED Scheduled for deprecation in November 2011.
+        $(RED Deprecated. It will be removed in May 2012.
               Please use fromISOExtString instead.)
       +/
-    static DateTime fromISOExtendedString(S)(in S isoExtString)
+    deprecated static DateTime fromISOExtendedString(S)(in S isoExtString)
         if(isSomeString!(S))
     {
         return fromISOExtString!string(isoExtString);

--- a/std/file.d
+++ b/std/file.d
@@ -899,8 +899,8 @@ version(Windows) unittest
 }
 
 /++
-    $(RED Scheduled for deprecation in November 2011. Please use the
-          $(D getTimes) with two arguments instead.)
+    $(RED Deprecated. It will be removed in May 2012.
+          Please use the $(D getTimes) with two arguments instead.)
 
     $(BLUE This function is Posix-Only.)
 
@@ -929,14 +929,14 @@ version(Windows) unittest
     Throws:
         $(D FileException) on error.
  +/
-version(StdDdoc) void getTimesPosix(in char[] name,
-                                    out SysTime fileStatusChangeTime,
-                                    out SysTime fileAccessTime,
-                                    out SysTime fileModificationTime);
-else version(Posix) void getTimesPosix(C)(in C[] name,
-                                          out SysTime fileStatusChangeTime,
-                                          out SysTime fileAccessTime,
-                                          out SysTime fileModificationTime)
+version(StdDdoc) deprecated void getTimesPosix(in char[] name,
+                                               out SysTime fileStatusChangeTime,
+                                               out SysTime fileAccessTime,
+                                               out SysTime fileModificationTime);
+else version(Posix) deprecated void getTimesPosix(C)(in C[] name,
+                                                     out SysTime fileStatusChangeTime,
+                                                     out SysTime fileAccessTime,
+                                                     out SysTime fileModificationTime)
     if(is(Unqual!C == char))
 {
     struct_stat64 statbuf = void;
@@ -1266,11 +1266,14 @@ unittest
  $(RED Deprecated. It will be removed in February 2012. Please use
        $(D isDir) instead.)
  +/
-deprecated alias isDir isdir;
+deprecated @property bool isdir(in char[] name)
+{
+    return name.isDir;
+}
 
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Deprecated. It will be removed in May 2012.
           Please use $(D attrIsDir) instead.)
 
     Returns whether the given file attributes are for a directory.
@@ -1278,7 +1281,7 @@ deprecated alias isDir isdir;
     Params:
         attributes = The file attributes.
   +/
-@property bool isDir(uint attributes) nothrow
+deprecated @property bool isDir(uint attributes) nothrow
 {
     version(Windows)
     {
@@ -1407,11 +1410,14 @@ unittest
  $(RED Deprecated. It will be removed in February 2012. Please use
        $(D isDir) instead.)
  +/
-deprecated alias isFile isfile;
+deprecated @property bool isfile(in char[] name)
+{
+    return name.isFile;
+}
 
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Deprecated. It will be removed in May 2012.
           Please use $(D attrIsFile) instead.)
 
     Returns whether the given file attributes are for a file.
@@ -1429,7 +1435,7 @@ deprecated alias isFile isfile;
     Params:
         attributes = The file attributes.
   +/
-@property bool isFile(uint attributes) nothrow
+deprecated @property bool isFile(uint attributes) nothrow
 {
     version(Windows)
     {
@@ -1603,7 +1609,7 @@ unittest
 
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Deprecated. It will be removed in May 2012.
           Please use $(D attrIsSymlink) instead.)
 
     Returns whether the given file attributes are for a symbolic link.
@@ -1614,7 +1620,7 @@ unittest
     Params:
         attributes = The file attributes.
   +/
-@property bool isSymLink(uint attributes) nothrow
+deprecated @property bool isSymLink(uint attributes) nothrow
 {
     version(Windows)
         return (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
@@ -2084,7 +2090,7 @@ assert(!de2.isFile);
 
 
         /++
-            $(RED Scheduled for deprecation in November 2011. It will not be
+            $(RED Deprecated. It will be removed in May 2012. It will not be
                   replaced. You can use $(D attributes) to get at this
                   information if you need it.)
 
@@ -2093,7 +2099,7 @@ assert(!de2.isFile);
             Returns the last time that the status of file represented by this
             $(D DirEntry) was changed (i.e. owner, group, link count, mode, etc.).
           +/
-        @property SysTime timeStatusChanged();
+        deprecated @property SysTime timeStatusChanged();
 
         /++
             $(RED Deprecated. It will be removed in February 2012. Please use
@@ -2596,7 +2602,7 @@ unittest
 
 
 /******************************************************
- * $(RED Scheduled for deprecation in November 2011.
+ * $(RED Scheduled for deprecation.
  *       Please use $(D dirEntries) instead.)
  *
  * For each file and directory $(D DirEntry) in $(D pathname[])
@@ -3598,7 +3604,7 @@ unittest
 
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Scheduled for deprecation.
           Please use $(D dirEntries) instead.)
 
     Returns the contents of the given directory.
@@ -3646,7 +3652,7 @@ unittest
 
 
 /++
-    $(RED Scheduled for deprecation in November 2011.
+    $(RED Scheduled for deprecation.
           Please use $(D dirEntries) instead.)
 
     Returns all the files in the directory and its sub-directories
@@ -3730,7 +3736,7 @@ string[] listDir(C, U)(in C[] pathname, U filter, bool followSymlink = true)
 }
 
 /******************************************************
- * $(RED Scheduled for deprecation in November 2011.
+ * $(RED Scheduled for deprecation.
  *       Please use $(D dirEntries) instead.)
  *
  * For each file and directory name in pathname[],


### PR DESCRIPTION
I deprecated most everything which was scheduled for deprecation in November 2011. The sole exception is `listDir` in std.file, because we still don't have all of the overloads of `dirEntries` that we need to completely replace it (IIRC it's one which does glob matching that's missing, but I don't remember the details at the moment). I changed that one to simply say "scheduled for deprecation" without a date, since we don't know when `dirEntries` will be ready to completely replace `listDir`. The other stuff scheduled for deprecation in November 2011 has all been deprecated however (not that there was a lot of it).
