### PR TITLE
extern(C) not needed for vararg any longer

### DIFF
--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -302,7 +302,7 @@ class OutBuffer
      */
 
     version (X86_64)
-    extern (C) void printf(string format, ...)
+    void printf(string format, ...)
     {
         va_list ap;
         va_start(ap, __va_argsave);


### PR DESCRIPTION
- misleading to have extern(C) member functions
  http://d.puremagic.com/issues/show_bug.cgi?id=6132
