### PR TITLE
std.math: Fix modf() documentation, add fmod()

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -1739,14 +1739,27 @@ real logb(real x) @trusted nothrow    { return core.stdc.math.logbl(x); }
  * be completely subtracted from x. The result has the same sign as x.
  *
  * $(TABLE_SV
- *  $(TR $(TH x)              $(TH y)             $(TH modf(x, y))   $(TH invalid?))
+ *  $(TR $(TH x)              $(TH y)             $(TH fmod(x, y))   $(TH invalid?))
  *  $(TR $(TD $(PLUSMN)0.0)   $(TD not 0.0)       $(TD $(PLUSMN)0.0) $(TD no))
  *  $(TR $(TD $(PLUSMNINF))   $(TD anything)      $(TD $(NAN))       $(TD yes))
  *  $(TR $(TD anything)       $(TD $(PLUSMN)0.0)  $(TD $(NAN))       $(TD yes))
  *  $(TR $(TD !=$(PLUSMNINF)) $(TD $(PLUSMNINF))  $(TD x)            $(TD no))
  * )
  */
-real modf(real x, ref real y) @trusted nothrow { return core.stdc.math.modfl(x,&y); }
+real fmod(real x, real y) @trusted nothrow { return core.stdc.math.fmodl(x, y); }
+
+/************************************
+ * Breaks x into an integral part and a fractional part, each of which has
+ * the same sign as x. The integral part is stored in i.
+ * Returns:
+ * The fractional part of x.
+ *
+ * $(TABLE_SV
+ *  $(TR $(TH x)              $(TH i (on input))  $(TH modf(x, i))   $(TH i (on return)))
+ *  $(TR $(TD $(PLUSMNINF))   $(TD anything)      $(TD $(PLUSMN)0.0) $(TD $(PLUSMNINF)))
+ * )
+ */
+real modf(real x, ref real i) @trusted nothrow { return core.stdc.math.modfl(x,&i); }
 
 /*************************************
  * Efficiently calculates x * 2$(SUP n).


### PR DESCRIPTION
The documentation for std.math.modf() actually describes the [fmod()](http://www.cplusplus.com/reference/clibrary/cmath/fmod/) function of C's math.h, which doesn't have a counterpart in std.math. This commit adds fmod() and fixes the documentation for modf().

This fixes [issue 4765](http://d.puremagic.com/issues/show_bug.cgi?id=4765).
