### PR TITLE
Remove the undocumented sqrt(2) hack

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -872,31 +872,6 @@ float sqrt(float x) @safe pure nothrow;    /* intrinsic */
 double sqrt(double x) @safe pure nothrow;  /* intrinsic */ /// ditto
 real sqrt(real x) @safe pure nothrow;      /* intrinsic */ /// ditto
 
-@trusted pure nothrow {  // Should be @safe.  See bugs 4628, 4630.
-    // Create explicit overloads for integer sqrts.  No ddoc for these because
-    // hopefully a more elegant solution will eventually be found, so we don't
-    // want people relying too heavily on the minutiae of this, for example,
-    // by taking the address of sqrt(int) or something.
-    real sqrt(byte x) { return sqrt(cast(real) x); }
-    real sqrt(ubyte x) { return sqrt(cast(real) x); }
-    real sqrt(short x) { return sqrt(cast(real) x); }
-    real sqrt(ushort x) { return sqrt(cast(real) x); }
-    real sqrt(int x) { return sqrt(cast(real) x); }
-    real sqrt(uint x) { return sqrt(cast(real) x); }
-    real sqrt(long x) { return sqrt(cast(real) x); }
-    real sqrt(ulong x) { return sqrt(cast(real) x); }
-}
-
-unittest {
-    alias TypeTuple!(byte, ubyte, short, ushort,
-                     int, uint, long, ulong, float, double, real) Numerics;
-    foreach(T; Numerics) {
-        immutable T two = 2;
-        assert(approxEqual(sqrt(two), SQRT2),
-            "sqrt unittest failed on type " ~ T.stringof);
-    }
-}
-
 creal sqrt(creal z) @safe pure nothrow
 {
     creal c;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1312,7 +1312,7 @@ public:
     argument must be a random access range.
 
     ---
-    auto numbers = iota(100_000_000);
+    auto numbers = iota(100_000_000.0);
 
     // Find the square roots of numbers.
     //
@@ -3593,7 +3593,7 @@ unittest {
 
     // Test Map/AsyncBuf chaining.
 
-    auto abuf = poolInstance.asyncBuf(iota(-1, 3_000_000), 100);
+    auto abuf = poolInstance.asyncBuf(iota(-1.0, 3_000_000), 100);
     auto temp = poolInstance.map!sqrt(
             abuf, 100, 5
         );
@@ -3609,7 +3609,7 @@ unittest {
     }
 
     // Test buffer trick in parallel foreach.
-    abuf = poolInstance.asyncBuf(iota(-1, 1_000_000), 100);
+    abuf = poolInstance.asyncBuf(iota(-1.0, 1_000_000), 100);
     abuf.popFront();
     auto bufTrickTest = new size_t[abuf.length];
     foreach(i, elem; parallel(abuf)) {


### PR DESCRIPTION
As discussed in the newsgroup:
http://www.digitalmars.com/d/archives/digitalmars/D/sqrt_2_must_go_146998.html

It was used in one place in std.parallelism. Note that this is removed, not deprecated, because it was never documented as working (it was always intended as a short-term hack), it's only behaved this way for a couple of releases, and it gives a nice enough error message.

After this change, sqrt(2) gives the same errors as, say, exp(2).
