### PR TITLE
Added .DS_Store to .gitignore for OSX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 generated
 GNUmakefile
+.DS_Store


### PR DESCRIPTION
.DS_Store is a file created by OSX for Finder meta-data. Added to the ignore list.
