### PR TITLE
Fix for Bug #6472. Make RedBlackTree's removeKey work with strings.

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -4825,19 +4825,7 @@ assert(std.algorithm.equal(rbt[], [5]));
         foreach(i, e; elems)
             toRemove[i] = e;
 
-        immutable lenBefore = length;
-
-        foreach(e; toRemove)
-        {
-            auto beg = _firstGreaterEqual(e);
-            if(beg is _end || _less(e, beg.value))
-                // no values are equal
-                continue;
-            beg.remove(_end);
-            --_length;
-        }
-
-        return lenBefore - length;
+        return removeKey(toRemove[]);
     }
 
     /++ Ditto +/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6472

I also made `RedBlackTree` final, which it should have been in the first place. That _might_ break code (if anyone decided to derive their own class from `RedBlackTree` - unlikely IMHO), but it was already decide previously that std.container's containers should be final classes so that they would be reference types and still be able to have their functions be non-virtual and inlinable.
