### PR TITLE
Improve the documentation for std.concurrency.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -38,7 +38,7 @@
  *     send(tid, 42);
  *    
  *     // Receive the result code.  
- *     auto wasSuccessful = receiveOnly!(int);
+ *     auto wasSuccessful = receiveOnly!(bool);
  *     assert(wasSuccessful);
  *     writeln("Successfully printed number.");
  * }


### PR DESCRIPTION
Add some examples, a synopsis, better explanations of when the various flavors of exception are thrown, and a little explanation of the concept that messages and arguments to spawn can't have unshared aliasing.

This commit doesn't affect any code, only documentation.
