### PR TITLE
Hopefully final decision on escapes in character sets

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -1521,7 +1521,7 @@ struct Parser(R, bool CTFE=false)
                     last = parseControlCode();
                     state = State.Char;
                     break;
-                case '[',']','\\','^','$','.','|','?'
+                case '[',']','\\','^','$','.','|','?',','
                 ,'*','+','(',')','{','}':
                     last = current;
                     state = State.Char;
@@ -1624,7 +1624,7 @@ struct Parser(R, bool CTFE=false)
                 case 'v':
                     end = '\v';
                     break;
-                case '[',']','\\','^','$','.','|','?'
+                case '[',']','\\','^','$','.','|','?',','
                 ,'*','+','(',')','{','}':
                     end = current;
                     break;


### PR DESCRIPTION
As per last known good idea:
- allow escaping of _all_ regex related punctuation [^$.|?*+(){} inside of character class
- disallowing anything else that is not a known escape sequence 
