### PR TITLE
Removed static constructors from std.datetime.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -28546,13 +28546,13 @@ private:
         //to use memory fences properly.
         if(!_initialized)
         {
-            _initialized = true;
-
             synchronized
             {
                 if(!_localTime)
                     _localTime = cast(shared LocalTime)new immutable(LocalTime)();
             }
+
+            _initialized = true;
         }
 
         return cast(immutable LocalTime)_localTime;
@@ -28696,13 +28696,13 @@ private:
         //to use memory fences properly.
         if(!_initialized)
         {
-            _initialized = true;
-
             synchronized
             {
                 if(!_utc)
                     _utc = cast(shared UTC)new immutable(UTC)();
             }
+
+            _initialized = true;
         }
 
         return cast(immutable UTC)_utc;


### PR DESCRIPTION
This turned out to be far easier than I thought that it would, though I don't know why I couldn't get the cast to work without the alias. Purity and immutability are maintained, albeit by cheating. I even removed the static constructor used for unit tests, since it's easy enough to get the same behavior without an actual static constructor, and it will help avoid any possible circular dependencies in the future.
