### PR TITLE
Fixed bug in std.file.readLink with regards to cenforce.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1898,6 +1898,8 @@ version(Posix) unittest
             assert(readLink(symfile) == file, format("Failed file: %s", file));
         }
     }
+
+    assertThrown!FileException(readLink("/doesnotexist"));
 }
 
 


### PR DESCRIPTION
readLink should be checking that the result of readlink is not -1,
not that it's not 0, so the cenforce calls were wrong and were
resulting in incorrect behavior when readlink failed.
