### PR TITLE
Changes required for Win64 support by MinGW64

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -3,6 +3,8 @@
 
 module etc.c.zlib;
 
+public import core.stdc.config; // c_ulong
+
 /* zlib.h -- interface of the 'zlib' general purpose compression library
    version 1.2.3, July 18th, 2005
 
@@ -77,13 +79,13 @@ alias void  function (void* opaque, void* address) free_func;
 
 struct z_stream
 {
-    ubyte    *next_in;  /* next input byte */
-    uint     avail_in;  /* number of bytes available at next_in */
-    size_t   total_in;  /* total nb of input bytes read so far */
+    ubyte      *next_in;  /* next input byte */
+    uint       avail_in;  /* number of bytes available at next_in */
+    c_ulong    total_in;  /* total nb of input bytes read so far */
 
-    ubyte    *next_out; /* next output byte should be put there */
-    uint     avail_out; /* remaining free space at next_out */
-    size_t   total_out; /* total nb of bytes output so far */
+    ubyte      *next_out; /* next output byte should be put there */
+    uint       avail_out; /* remaining free space at next_out */
+    c_ulong    total_out; /* total nb of bytes output so far */
 
     char     *msg;      /* last error message, NULL if no error */
     void*    state;     /* not visible by applications */
@@ -92,9 +94,9 @@ struct z_stream
     free_func  zfree;   /* used to free the internal state */
     void*      opaque;  /* private data object passed to zalloc and zfree */
 
-    int    data_type;  /* best guess about the data type: binary or text */
-    size_t adler;      /* adler32 value of the uncompressed data */
-    size_t reserved;   /* reserved for future use */
+    int      data_type;  /* best guess about the data type: binary or text */
+    c_ulong  adler;      /* adler32 value of the uncompressed data */
+    c_ulong  reserved;   /* reserved for future use */
 }
 
 alias z_stream* z_streamp;
@@ -104,20 +106,20 @@ alias z_stream* z_streamp;
   for more details on the meanings of these fields.
 */
 struct gz_header {
-    int     text;       /* true if compressed data believed to be text */
-    ulong   time;       /* modification time */
-    int     xflags;     /* extra flags (not used when writing a gzip file) */
-    int     os;         /* operating system */
-    byte    *extra;     /* pointer to extra field or Z_NULL if none */
-    uint    extra_len;  /* extra field length (valid if extra != Z_NULL) */
-    uint    extra_max;  /* space at extra (only when reading header) */
-    byte    *name;      /* pointer to zero-terminated file name or Z_NULL */
-    uint    name_max;   /* space at name (only when reading header) */
-    byte    *comment;   /* pointer to zero-terminated comment or Z_NULL */
-    uint    comm_max;   /* space at comment (only when reading header) */
-    int     hcrc;       /* true if there was or will be a header crc */
-    int     done;       /* true when done reading gzip header (not used
-                           when writing a gzip file) */
+    int       text;       /* true if compressed data believed to be text */
+    c_ulong   time;       /* modification time */
+    int       xflags;     /* extra flags (not used when writing a gzip file) */
+    int       os;         /* operating system */
+    byte      *extra;     /* pointer to extra field or Z_NULL if none */
+    uint      extra_len;  /* extra field length (valid if extra != Z_NULL) */
+    uint      extra_max;  /* space at extra (only when reading header) */
+    byte      *name;      /* pointer to zero-terminated file name or Z_NULL */
+    uint      name_max;   /* space at name (only when reading header) */
+    byte      *comment;   /* pointer to zero-terminated comment or Z_NULL */
+    uint      comm_max;   /* space at comment (only when reading header) */
+    int       hcrc;       /* true if there was or will be a header crc */
+    int       done;       /* true when done reading gzip header (not used
+                             when writing a gzip file) */
 }
 
 alias gz_header* gz_headerp;
@@ -707,7 +709,7 @@ int deflateTune(z_streamp strm, int good_length, int max_lazy, int nice_length,
    returns Z_OK on success, or Z_STREAM_ERROR for an invalid deflate stream.
  */
 
-int deflateBound(z_streamp strm, size_t sourceLen);
+c_ulong deflateBound(z_streamp strm, c_ulong sourceLen);
 /*
      deflateBound() returns an upper bound on the compressed size after
    deflation of sourceLen bytes.  It must be called after deflateInit()
@@ -962,7 +964,7 @@ int inflateBackEnd(z_stream* strm);
    state was inconsistent.
 */
 
-uint zlibCompileFlags();
+c_ulong zlibCompileFlags();
 /* Return flags indicating compile-time options.
 
     Type sizes, two bits each, 00 = 16 bits, 01 = 32, 10 = 64, 11 = other:
@@ -1014,9 +1016,9 @@ uint zlibCompileFlags();
 */
 
 int compress(ubyte* dest,
-             size_t* destLen,
+             c_ulong* destLen,
              ubyte* source,
-             size_t sourceLen);
+             c_ulong sourceLen);
 /*
      Compresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer. Upon entry, destLen is the total
@@ -1031,9 +1033,9 @@ int compress(ubyte* dest,
 */
 
 int compress2(ubyte* dest,
-              size_t* destLen,
+              c_ulong* destLen,
               ubyte* source,
-              size_t sourceLen,
+              c_ulong  sourceLen,
               int level);
 /*
      Compresses the source buffer into the destination buffer. The level
@@ -1048,7 +1050,7 @@ int compress2(ubyte* dest,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
 
-size_t compressBound(size_t sourceLen);
+c_ulong compressBound(c_ulong sourceLen);
 /*
      compressBound() returns an upper bound on the compressed size after
    compress() or compress2() on sourceLen bytes.  It would be used before
@@ -1056,9 +1058,9 @@ size_t compressBound(size_t sourceLen);
 */
 
 int uncompress(ubyte* dest,
-               size_t* destLen,
+               c_ulong* destLen,
                ubyte* source,
-               size_t sourceLen);
+               c_ulong  sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer. Upon entry, destLen is the total
@@ -1269,7 +1271,7 @@ void gzclearerr (gzFile file);
    compression library.
 */
 
- uint adler32  (uint adler, ubyte *buf, uint len);
+ c_ulong adler32  (c_ulong adler, ubyte *buf, uint len);
 
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
@@ -1294,7 +1296,7 @@ uint adler32_combine(uint adler1, uint adler2, z_off_t len2);
    seq1 and seq2 concatenated, requiring only adler1, adler2, and len2.
 */
 
-uint crc32(uint crc, ubyte *buf, uint len);
+c_ulong crc32(c_ulong crc, ubyte *buf, uint len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32. If buf is NULL, this function returns the required initial

--- a/std/socket.d
+++ b/std/socket.d
@@ -942,7 +942,7 @@ private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addr
                 cast(AddressFamily) ai.ai_family,
                 cast(SocketType   ) ai.ai_socktype,
                 cast(ProtocolType ) ai.ai_protocol,
-                new UnknownAddressReference(ai.ai_addr, ai.ai_addrlen),
+                new UnknownAddressReference(ai.ai_addr, to!uint(ai.ai_addrlen)),
                 ai.ai_canonname ? to!string(ai.ai_canonname) : null);
 
         assert(result.length > 0);

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -657,7 +657,7 @@ body
 
         auto keyname = toSTRz!Char(name);
         Char[] data = new Char[256];
-        DWORD cbData = data.length / Char.sizeof;
+        DWORD cbData = to!DWORD(data.length / Char.sizeof);
         LONG res = RegQueryValueEx!Char(hkey, keyname, null, cast(LPDWORD) &type, data.ptr, &cbData);
         if (res == ERROR_MORE_DATA)
         {
@@ -769,7 +769,7 @@ body
     REG_VALUE_TYPE type;
 
     byte[] data = new byte[100];
-    DWORD cbData = data.length;
+    DWORD cbData = to!DWORD(data.length);
     LONG res;
     if (useWfuncs)
     {
@@ -1180,7 +1180,7 @@ public:
         {
             auto psz = toUTF16z(value);
             data = psz;
-            len = lstrlenW(psz) * wchar.sizeof;
+            len = to!DWORD(lstrlenW(psz) * wchar.sizeof);
         }
         else
         {
@@ -1218,21 +1218,21 @@ public:
 
         if (useWfuncs)
         {
-            regSetValue(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, ws.ptr, ws.length * wchar.sizeof);
+            regSetValue(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, ws.ptr, to!uint(ws.length * wchar.sizeof));
         }
         else
         {
             char[] cs;
             int readLen;
-            cs.length = WideCharToMultiByte(/*CP_ACP*/ 0, 0, ws.ptr, ws.length, null, 0, null, null);
+            cs.length = WideCharToMultiByte(/*CP_ACP*/ 0, 0, ws.ptr, to!uint(ws.length), null, 0, null, null);
             if (cs.length)
             {
-                readLen = WideCharToMultiByte(/*CP_ACP*/ 0, 0, ws.ptr, ws.length, cs.ptr, cs.length, null, null);
+                readLen = WideCharToMultiByte(/*CP_ACP*/ 0, 0, ws.ptr, to!uint(ws.length), cs.ptr, to!int(cs.length), null, null);
             }
             enforce(readLen && readLen == cs.length,
                 new Win32Exception("Couldn't convert string: " ~ sysErrorString(GetLastError())));
 
-            regSetValue(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, cs.ptr, cs.length);
+            regSetValue(m_hkey, name, REG_VALUE_TYPE.REG_MULTI_SZ, cs.ptr, to!uint(cs.length));
         }
     }
 

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -120,9 +120,9 @@ in
 }
 body
 {
-    auto destlen = srcbuf.length + ((srcbuf.length + 1023) / 1024) + 12;
+    auto destlen = to!c_ulong(srcbuf.length + ((srcbuf.length + 1023) / 1024) + 12);
     auto destbuf = new ubyte[destlen];
-    auto err = etc.c.zlib.compress2(destbuf.ptr, &destlen, cast(ubyte *)srcbuf.ptr, srcbuf.length, level);
+    auto err = etc.c.zlib.compress2(destbuf.ptr, &destlen, cast(ubyte *)srcbuf.ptr, to!c_ulong(srcbuf.length), level);
     if (err)
     {   delete destbuf;
         throw new ZlibException(err);


### PR DESCRIPTION
The type uLong is declared by zlib.h to be unsigned long.  Windows follows the LLP64 convention which defines unsigned long as be 32-bit.

Win64 being LLP64 is responsible for most of these changes.
