### PR TITLE
64bit Windows always supports the W functions, so no need to check for them

### DIFF
--- a/std/__fileinit.d
+++ b/std/__fileinit.d
@@ -22,7 +22,7 @@ version (Windows)
     version (Win32)
     {
         private import std.c.windows.windows;
-        shared bool useWfuncs = true;
+        immutable bool useWfuncs;
 
         shared static this()
         {


### PR DESCRIPTION
64bit versions of Windows always support the W versions of functions, so no need to check for them at runtime.
