### PR TITLE
Allow to enforceEx making partial instantiated alias

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -349,7 +349,7 @@ unittest
 --------------------
 auto f = enforce(fopen("data.txt"));
 auto line = readln(f);
-enforce(line.length, "Expected a non-empty line."));
+enforce(line.length, "Expected a non-empty line.");
 --------------------
  +/
 T enforce(T, string file = __FILE__, size_t line = __LINE__)


### PR DESCRIPTION
I've got an idea from https://github.com/D-Programming-Language/phobos/pull/298#issuecomment-3602761 .

`enforceEx!SomeException` is a little long than the frequency of its use.
This change allows to make `alias enforceEx!SomeException enf;` and to use `enf(condition, "message");`.
