### PR TITLE
remove access to private function

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -1628,7 +1628,7 @@ struct Array(T) if (!is(T : const(bool)))
             emplace(p + i, e);
             assert(p[i] == e);
         }
-        _data.RefCounted.initialize(p[0 .. values.length]);
+        _data = Data(p[0 .. values.length]);
     }
 
 /**
@@ -1814,7 +1814,7 @@ Complexity: $(BIGOH 1)
             {
                 GC.addRange(p, sz);
             }
-            _data.RefCounted.initialize(cast(T[]) p[0 .. 0]);
+            _data = Data(cast(T[]) p[0 .. 0]);
             _data._capacity = elements;
         }
         else

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1998,7 +1998,6 @@ struct HTTP
 
     private void initialize()
     {
-        p.RefCounted.initialize();
         p.curl.initialize();
         maxRedirects = HTTP.defaultMaxRedirects;
         p.charset = "ISO-8859-1"; // Default charset defined in HTTP RFC
@@ -2666,7 +2665,6 @@ struct FTP
 
     private void initialize()
     {
-        p.RefCounted.initialize();
         p.curl.initialize();
         p.encoding = "ISO-8859-1";
         dataTimeout = _defaultDataTimeout;
@@ -2943,7 +2941,6 @@ struct SMTP
     */
     this(string url)
     {
-        p.RefCounted.initialize();
         p.curl.initialize();
         auto lowered = url.toLower();
 


### PR DESCRIPTION
- std.net.curl uses RefCountedAutoInitialize.yes
