### PR TITLE
Issue 7397 - [Regression] std.path.buildPath can't be used with string[]

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -958,7 +958,14 @@ unittest
 {
     // Test for issue 7397
     string[] ary = ["a", "b"];
-    buildPath(ary);
+    version (Posix)
+    {
+        assert (buildPath(ary) == "a/b");
+    }
+    else version (Windows)
+    {
+        assert (buildPath(ary) == `a\b`);
+    }
 }
 
 
@@ -1376,7 +1383,14 @@ unittest
 {
     // 7397
     string[] ary = ["a", "b"];
-    buildNormalizedPath(ary);
+    version (Posix)
+    {
+        assert (buildNormalizedPath(ary) == "a/b");
+    }
+    else version (Windows)
+    {
+        assert (buildNormalizedPath(ary) == `a\b`);
+    }
 }
 
 
@@ -3791,7 +3805,14 @@ unittest
 {
     // 7397
     string[] ary = ["a", "b"];
-    join("x", "y", ary);
+    version (Posix)
+    {
+        assert (join("x", "y", ary) == "x/y/a/b");
+    }
+    else version (Windows)
+    {
+        assert (join("x", "y", ary) == `x\y\a\b`);
+    }
 }
 
 /**********************************


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7397
