### PR TITLE
MmFile Linux constructor patch

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -128,6 +128,8 @@ class MmFile
             assert(0);
         }
 
+        fd = fildes;
+
         // Adjust size
         struct_stat64 statbuf = void;
         errnoEnforce(fstat64(fd, &statbuf) == 0);


### PR DESCRIPTION
The fd field was not set.
