### PR TITLE
Issue 7460 - std.windows.registry reports a false exception message

### DIFF
--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -400,7 +400,7 @@ body
             useWfuncs ? RegDeleteKeyW(hkey, toUTF16z(subKey))
                       : RegDeleteKeyA(hkey, toMBSz(subKey));
     }
-    enforceSucc(res, "Value cannot be deleted: \"" ~ subKey ~ "\"");
+    enforceSucc(res, "Key cannot be deleted: \"" ~ subKey ~ "\"");
 }
 
 private void regDeleteValue(in HKEY hkey, in string valueName)


### PR DESCRIPTION
The cause is that constructors drop the argument values and member variables are unintialized. I suppose it is just a mistake.

[CAUTION] D1 has a different code, therefore unittest must be fixed in D1.

The second commit( 6a768c3c ) is just a message modification.
