### PR TITLE
Better pointer format specifier mismatch message.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -2160,7 +2160,8 @@ if (isPointer!T)
             }
             else
             {
-                enforce(f.spec == 'X' || f.spec == 'x');
+                enforceEx!FormatException(f.spec == 'X' || f.spec == 'x',
+                   "Expected one of %s, %x or %X for pointer type.");
                 formatValue(w, cast(ulong) p, f);
             }
         }


### PR DESCRIPTION
Fixes [issue 7480](http://d.puremagic.com/issues/show_bug.cgi?id=7480).
