### PR TITLE
use module scope for imports...

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -96,7 +96,7 @@ class CFile : Stream {
    * Ditto
    */
   override char ungetc(char c) {
-    return cast(char)std.c.stdio.ungetc(c,cfile);
+    return cast(char).std.c.stdio.ungetc(c,cfile);
   }
 
   /**
@@ -168,14 +168,14 @@ class CFile : Stream {
     auto exp = "Testing stream.d:";
     assert(line[0] == 'T');
     assert(line.length == exp.length);
-    assert(!std.string.cmp(line, "Testing stream.d:"));
+    assert(!.std.string.cmp(line, "Testing stream.d:"));
     // jump over "Hello, "
     file.seek(7, SeekPos.Current);
     version (Windows)
       assert(file.position() == 19 + 7);
     version (Posix)
       assert(file.position() == 18 + 7);
-    assert(!std.string.cmp(file.readString(6), "world!"));
+    assert(!.std.string.cmp(file.readString(6), "world!"));
     i = 0; file.read(i);
     assert(i == 666);
     // string#1 + string#2 + int should give exacly that


### PR DESCRIPTION
...because the std imports in the Base class are private (see [7491](http://d.puremagic.com/issues/show_bug.cgi?id=7491)).
