### PR TITLE
This should make CurlException error string messages more informative

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3341,7 +3341,7 @@ struct Curl
     {
         auto msgZ = curl_easy_strerror(code);
         // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
-        return format("%s on handle %s", cast(string) msgZ[0 .. core.stdc.strlen(msgZ)], handle);
+        return format("%s on handle %s", cast(string) msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
     }
 
     private void throwOnStopped(string message = null)


### PR DESCRIPTION
Instead of something like

"59D3810 on handle 99B1F70"

you will now get something like

"Login denied on handle 99B1F70"
