### PR TITLE
Fix unlisted bug in std.typecons.Scoped.  writeln() has no place in prod...

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2687,8 +2687,7 @@ private struct Scoped(T)
 
     @disable this(this)
     {
-        writeln("Illegal call to Scoped this(this)");
-        assert(false);
+        assert(false, "Illegal call to Scoped this(this)");
     }
 
     ~this()


### PR DESCRIPTION
...uction code in these cases and wasn't properly imported either.
