### PR TITLE
Remove unsafe and unnecessary casting

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3341,7 +3341,7 @@ struct Curl
     {
         auto msgZ = curl_easy_strerror(code);
         // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
-        return format("%s on handle %s", cast(string) msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
+        return format("%s on handle %s", msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
     }
 
     private void throwOnStopped(string message = null)


### PR DESCRIPTION
`cast(string)` is neither necessary nor safe
*`curl_easy_strerror` isn't documented as returning immutable string
