### PR TITLE
Fix issue 7111 - New regex engine cannot match beginning of empty string

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -1,3 +1,15 @@
+$(VERSION 059, ddd mm, 2012, =================================================,
+
+    $(LIBBUGSFIXED
+        $(LI $(BUGZILLA 4604) - A stack overflow with writeln)
+        $(LI $(BUGZILLA 5674) - AssertError in std.regex)
+        $(LI $(BUGZILLA 5652) - Add \p and \P unicode properties to std.regex)
+        $(LI $(BUGZILLA 6403) - Upgrade std.regex to Unicode UTS #18 Level 1 support)
+        $(LI $(BUGZILLA 7111) - New regex engine cannot match beginning of empty string)
+        $(LI $(BUGZILLA 7374) - stdin.byLine() throws AssertError on empty input)
+     )
+ )
+
 $(VERSION 058, ddd mm, 2012, =================================================,
 
     $(WHATSNEW


### PR DESCRIPTION
Fixes a bug in a matchOneShot that's used for any regex with '^' at start and for lookaround. 

Also updated changelog, including old std.regex reports.
