### PR TITLE
Build missing std.net.curl and documentation on Windows

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -140,6 +140,8 @@ SRCS_3 = std\variant.d \
     std\internal\math\gammafunction.d std\internal\math\errorfunction.d \
 	std\internal\windows\advapi32.d \
 	crc32.d \
+	std\net\curl.d \
+	std\net\isemail.d \
 	std\c\process.d \
 	std\c\stdarg.d \
 	std\c\stddef.d \
@@ -255,6 +257,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_c_string.html \
 	$(DOC)\std_c_time.html \
 	$(DOC)\std_c_wcharh.html \
+	$(DOC)\std_net_curl.html \
 	$(DOC)\std_net_isemail.html \
 	$(DOC)\etc_c_curl.html \
 	$(DOC)\etc_c_sqlite3.html \
@@ -591,6 +594,9 @@ errorfunction.obj : std\internal\math\errorfunction.d
 
 isemail.obj : std\net\isemail.d
 	$(DMD) -c $(DFLAGS) std\net\isemail.d
+
+curl.obj : std\net\curl.d
+	$(DMD) -c $(DFLAGS) std\net\curl.d
 
 ### std\windows
 
@@ -929,6 +935,9 @@ $(DOC)\std_c_wcharh.html : $(STDDOC) std\c\wcharh.d
 
 $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_isemail.html $(STDDOC) std\net\isemail.d
+
+$(DOC)\std_net_curl.html : $(STDDOC) std\net\curl.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_curl.html $(STDDOC) std\net\curl.d
 
 $(DOC)\etc_c_curl.html : $(STDDOC) etc\c\curl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\etc_c_curl.html $(STDDOC) etc\c\curl.d


### PR DESCRIPTION
2.058 was released without std.net.curl built in.  This adds it to the windows makefile. This is forked from the 2.058 tag as I think it'd be nice to roll a minor release update to 2.058 so Windows users can use std.net.curl.  It'd be a shame if they had to wait until the next release to use this useful addition.

I would like to add curl.lib also so it is included with the release so users don't have to find/create it themselves but I'm not sure where that would go and which version of curl to use (SSL or not).  I can update this pull request if someone can point me in the right direction.

Also a missing std.net.isemail line.
