### PR TITLE
Scoped fixes

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2763,7 +2763,7 @@ unittest
 @system Scoped!T scoped(T, Args...)(Args args) if (is(T == class))
 {
     Scoped!T result;
-    emplace!T(cast(void[]) result.Scoped_store, args);
+    emplace!(Unqual!T)(cast(void[])result.Scoped_store, args);
     return result;
 }
 
@@ -2914,9 +2914,25 @@ unittest
     assert(a1.foo == 1);
     static assert(is(typeof(a1.foo) == int));
 
+    auto a2 = scoped!(const(A))();
+    assert(a2.foo == 1);
+    static assert(is(typeof(a2.foo) == const(int)));
+
+    auto a3 = scoped!(immutable(A))();
+    assert(a3.foo == 1);
+    static assert(is(typeof(a3.foo) == immutable(int)));
+
     const c1 = scoped!A();
     assert(c1.foo == 1);
     static assert(is(typeof(c1.foo) == const(int)));
+
+    const c2 = scoped!(const(A))();
+    assert(c2.foo == 1);
+    static assert(is(typeof(c2.foo) == const(int)));
+
+    const c3 = scoped!(immutable(A))();
+    assert(c3.foo == 1);
+    static assert(is(typeof(c3.foo) == immutable(int)));
 }
 
 /**


### PR DESCRIPTION
- scoped!T allowed to default construct any class
- made payload inout
- additionally allow to use qualified classes
