### PR TITLE
Build std.net.curl and documentation on Windows (second attempt)

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -139,6 +139,8 @@ SRCS_3 = std\variant.d \
     std\internal\math\gammafunction.d std\internal\math\errorfunction.d \
 	std\internal\windows\advapi32.d \
 	crc32.d \
+	std\net\curl.d \
+	std\net\isemail.d \
 	std\c\process.d \
 	std\c\stdarg.d \
 	std\c\stddef.d \
@@ -254,6 +256,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_c_string.html \
 	$(DOC)\std_c_time.html \
 	$(DOC)\std_c_wcharh.html \
+	$(DOC)\std_net_curl.html \
 	$(DOC)\std_net_isemail.html \
 	$(DOC)\etc_c_curl.html \
 	$(DOC)\etc_c_sqlite3.html \
@@ -587,6 +590,9 @@ errorfunction.obj : std\internal\math\errorfunction.d
 
 isemail.obj : std\net\isemail.d
 	$(DMD) -c $(DFLAGS) std\net\isemail.d
+
+curl.obj : std\net\curl.d
+	$(DMD) -c $(DFLAGS) std\net\curl.d
 
 ### std\windows
 
@@ -925,6 +931,9 @@ $(DOC)\std_c_wcharh.html : $(STDDOC) std\c\wcharh.d
 
 $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_isemail.html $(STDDOC) std\net\isemail.d
+
+$(DOC)\std_net_curl.html : $(STDDOC) std\net\curl.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_curl.html $(STDDOC) std\net\curl.d
 
 $(DOC)\etc_c_curl.html : $(STDDOC) etc\c\curl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\etc_c_curl.html $(STDDOC) etc\c\curl.d


### PR DESCRIPTION
Another attempt at enable std.net.curl on Windows.  This is actually identical to the last one but comes after some discussion.

[Under Walter's advice](http://forum.dlang.org/post/jijhcs$e04$1@digitalmars.com) I've prepared a separate download containing cURL for Windows users. Phobos unit tests will break for anyone who does not have cURL on their machine unfortunately (and this includes the auto-tester).

You can find my packaging of it here: [curl-7.24.0-dmd-win32.zip](http://gnuk.net/d/curl-7.24.0-dmd-win32.zip).  It is dynamically linked which affords users easier use of the LGPL libraries this particular build of cURL uses.  Alternatively you can use the version of cURL that was offered during the std.net.curl review which has fewer libraries it depends on (just SSL): [libcurl_7.21.7.zip](http://gool.googlecode.com/files/libcurl_7.21.7.zip)

@braddr Can we get cURL installed on the autotester machine?  This pull request shouldn't be merged until this happens.

I have two more pull requests related to this which eases finding/downloading this cURL packaging for Windows users (one for the [website](https://github.com/D-Programming-Language/d-programming-language.org/pull/92) and one for the [installer](https://github.com/D-Programming-Language/installer/pull/7)).
