### PR TITLE
std.stream.EndianStream.readStringW returned invalid wchar[]

### DIFF
--- a/std/stream.d
+++ b/std/stream.d
@@ -2375,8 +2375,8 @@ class EndianStream : FilterStream {
 
   override wchar[] readStringW(size_t length) {
     wchar[] result = new wchar[length];
-    readExact(result.ptr, result.length * wchar.sizeof);
-    fixBlockBO(&result,2,length);
+    readExact(result.ptr, length * wchar.sizeof);
+    fixBlockBO(result.ptr, wchar.sizeof, length);
     return result;
   }
 


### PR DESCRIPTION
This is just a pretty little change but with a fairly huge impact, I ran into this issue while using a BigEndian stream with the string "-" [0x00, 0x2D] arriving.
