### PR TITLE
Revert "Build std.net.curl and documentation on Windows 2"

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -139,8 +139,6 @@ SRCS_3 = std\variant.d \
     std\internal\math\gammafunction.d std\internal\math\errorfunction.d \
 	std\internal\windows\advapi32.d \
 	crc32.d \
-	std\net\curl.d \
-	std\net\isemail.d \
 	std\c\process.d \
 	std\c\stdarg.d \
 	std\c\stddef.d \
@@ -256,7 +254,6 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_c_string.html \
 	$(DOC)\std_c_time.html \
 	$(DOC)\std_c_wcharh.html \
-	$(DOC)\std_net_curl.html \
 	$(DOC)\std_net_isemail.html \
 	$(DOC)\etc_c_curl.html \
 	$(DOC)\etc_c_sqlite3.html \
@@ -590,9 +587,6 @@ errorfunction.obj : std\internal\math\errorfunction.d
 
 isemail.obj : std\net\isemail.d
 	$(DMD) -c $(DFLAGS) std\net\isemail.d
-
-curl.obj : std\net\curl.d
-	$(DMD) -c $(DFLAGS) std\net\curl.d
 
 ### std\windows
 
@@ -931,9 +925,6 @@ $(DOC)\std_c_wcharh.html : $(STDDOC) std\c\wcharh.d
 
 $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_isemail.html $(STDDOC) std\net\isemail.d
-
-$(DOC)\std_net_curl.html : $(STDDOC) std\net\curl.d
-	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_curl.html $(STDDOC) std\net\curl.d
 
 $(DOC)\etc_c_curl.html : $(STDDOC) etc\c\curl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\etc_c_curl.html $(STDDOC) etc\c\curl.d


### PR DESCRIPTION
This reverts commit 9c2f390be07927ef08a9d681924afcb90892b3cb which broke the autotester.  A new pull request will come but shouldn't be merged until the autotester works with it.
