### PR TITLE
Modified moduleName trait to only include the package name if it is valid

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -150,7 +150,10 @@ template moduleName(alias T)
         static assert(T.stringof[0..8] != "package ", "cannot get the module name for a package");
 
     static if (T.stringof.length >= 8 && T.stringof[0..7] == "module ")
-        enum moduleName = packageName!(T) ~ '.' ~ T.stringof[7..$];
+        static if (__traits(compiles, packageName!(T)))
+            enum moduleName = packageName!(T) ~ '.' ~ T.stringof[7..$];
+        else
+            enum moduleName = T.stringof[7..$];
     else
         alias moduleName!(__traits(parent, T)) moduleName;
 }


### PR DESCRIPTION
Calling std.traits.moduleName fails for any symbol that is not in a package.

```
module test;
import std.traits;
int foo;
unittest {
    assert(moduleName!(foo) == "test");
}
```

Error: static assert  "module test has no parent"

This change simply ignores the package if it is not set.
