### PR TITLE
Adding "secs" to possible time units in std.datetime

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -69,16 +69,18 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
     Various functions take a string (or strings) to represent a unit of time
     (e.g. $(D convert!("days", "hours")(numDays))). The valid strings to use
     with such functions are $(D "years"), $(D "months"), $(D "weeks"),
-    $(D "days"), $(D "hours"), $(D "minutes"), $(D "seconds"),
-    $(D "msecs") (milliseconds), $(D "usecs") (microseconds),
-    $(D "hnsecs") (hecto-nanoseconds - i.e. 100 ns), or some subset thereof.
-    There are a few functions in core.time which take $(D "nsecs"), but because
-    nothing in std.datetime has precision greater than hnsecs, and very little
-    in core.time does, no functions in std.datetime accept $(D "nsecs").
-    To remember which units are abbreviated and which aren't,
-    all units seconds and greater use their full names, and all
-    sub-second units are abbreviated (since they'd be rather long if they
-    weren't).
+    $(D "days"), $(D "hours"), $(D "minutes"), $(D "seconds"), $(D "secs")
+    (equivalent to $(D "seconds")), $(D "msecs") (milliseconds), $(D "usecs")
+    (microseconds), $(D "hnsecs") (hecto-nanoseconds - i.e. 100 ns), or some
+    subset thereof.  There are a few functions in core.time which take
+    $(D "nsecs"), but because nothing in std.datetime has precision greater
+    than hnsecs, and very little in core.time does, no functions in
+    std.datetime accept $(D "nsecs").  To remember which units are abbreviated
+    and which aren't, all units greater than seconds use their full names, and
+    all sub-second units are abbreviated (since they'd be rather long if they
+    weren't).  The one exception is seconds, which can be either seconds, or
+    abbreviated secs, since all other names with "seconds" in them are
+    abbreviated.
 
     Note:
         $(D DateTimeException) is an alias for core.time's $(D TimeException),
@@ -304,12 +306,12 @@ enum AutoStart
 
 /++
     Array of the strings representing time units, starting with the smallest
-    unit and going to the largest. It does not include $(D "nsecs").
+    unit and going to the largest. It does not include $(D "nsecs") or $(D "secs").
 
    Includes $(D "hnsecs") (hecto-nanoseconds (100 ns)),
    $(D "usecs") (microseconds), $(D "msecs") (milliseconds), $(D "seconds"),
-   $(D "minutes"), $(D "hours"), $(D "days"), $(D "weeks"), $(D "months"), and
-   $(D "years")
+   $(D "minutes"), $(D "hours"), $(D "days"), $(D "weeks"), $(D "months"),
+   and $(D "years")
   +/
 immutable string[] timeStrings = ["hnsecs", "usecs", "msecs", "seconds", "minutes",
                                   "hours", "days", "weeks", "months", "years"];
@@ -4500,8 +4502,8 @@ assert(st6 == SysTime(DateTime(2001, 2, 28, 12, 30, 33)));
         year's worth of days gets the exact same $(D SysTime).
 
         Accepted units are $(D "days"), $(D "minutes"), $(D "hours"),
-        $(D "minutes"), $(D "seconds"), $(D "msecs"), $(D "usecs"), and
-        $(D "hnsecs").
+        $(D "minutes"), $(D "seconds"), $(D "secs"), $(D "msecs"),
+        $(D "usecs"), and $(D "hnsecs").
 
         Note that when rolling msecs, usecs or hnsecs, they all add up to a
         second. So, for example, rolling 1000 msecs is exactly the same as
@@ -13824,7 +13826,8 @@ public:
         one hours's worth of minutes gets the exact same
         $(D TimeOfDay).
 
-        Accepted units are $(D "hours"), $(D "minutes"), and $(D "seconds").
+        Accepted units are $(D "hours"), $(D "minutes"), and $(D "seconds")
+        (or $(D "secs")).
 
         Params:
             units = The units to add.
@@ -13854,7 +13857,7 @@ tod5.roll!"seconds"(1);
 assert(tod5 == TimeOfDay(23, 59, 0));
 
 auto tod6 = TimeOfDay(0, 0, 0);
-tod6.roll!"seconds"(-1);
+tod6.roll!"secs"(-1);
 assert(tod6 == TimeOfDay(0, 0, 59));
 --------------------
       +/
@@ -13890,7 +13893,7 @@ assert(tod6 == TimeOfDay(0, 0, 59));
             assert(tod5 == TimeOfDay(23, 59, 0));
 
             auto tod6 = TimeOfDay(0, 0, 0);
-            tod6.roll!"seconds"(-1);
+            tod6.roll!"secs"(-1);
             assert(tod6 == TimeOfDay(0, 0, 59));
         }
     }
@@ -16083,7 +16086,7 @@ assert(dt6 == DateTime(2001, 2, 28, 12, 30, 33));
         year's worth of days gets the exact same $(D DateTime).
 
         Accepted units are $(D "days"), $(D "minutes"), $(D "hours"),
-        $(D "minutes"), and $(D "seconds").
+        $(D "minutes"), and $(D "seconds") (or $(D "secs")).
 
         Params:
             units = The units to add.


### PR DESCRIPTION
See pull request https://github.com/D-Programming-Language/druntime/pull/173

This depends on that pull request, and brings phobos in line with druntime's core.time.  If that pull request is rejected, this should also be.
