### PR TITLE
Allow use of UnixAddress in std.socket on Unix-like platforms

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -1785,7 +1785,7 @@ version(StdDdoc)
     }
 }
 else
-static if (is(typeof(sockaddr_un)))
+static if (is(sockaddr_un))
 {
     class UnixAddress: Address
     {


### PR DESCRIPTION
In current state static if check fails even if platform is
Linux, FreeBSD etc. As we noticed with CyberShadow the check for
struct existance should have form of is(StructName).
