### PR TITLE
std.stdio: Need to check ret != -1, not ret == 0 

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -416,7 +416,7 @@ referring to the same handle will see a closed file henceforth.
             if (p.isPipe)
             {
                 // Ignore the result of the command
-                errnoEnforce(.pclose(p.handle) == 0,
+                errnoEnforce(.pclose(p.handle) != -1,
                         "Could not close pipe `"~p.name~"'");
                 return;
             }


### PR DESCRIPTION
Using std.process.shell produces this error:

```
std/stdio.d(419): Could not close pipe `./a.out' (Success)
```

The return value check has to check for != -1, not == 0, see http://linux.die.net/man/3/pclose
