### PR TITLE
Supplemental change required by regression bug 6681

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -680,7 +680,19 @@ struct FormatSpec(Char)
     private void fillUp()
     {
         // Reset content
-        allFlags = 0;
+        if (__ctfe)
+        {
+            flDash = false;
+            flZero = false;
+            flSpace = false;
+            flPlus = false;
+            flHash = false;
+        }
+        else
+        {
+            allFlags = 0;
+        }
+
         width = 0;
         precision = UNSPECIFIED;
         nested = null;
@@ -864,7 +876,18 @@ struct FormatSpec(Char)
     private bool readUpToNextSpec(R)(ref R r)
     {
         // Reset content
-        allFlags = 0;
+        if (__ctfe)
+        {
+            flDash = false;
+            flZero = false;
+            flSpace = false;
+            flPlus = false;
+            flHash = false;
+        }
+        else
+        {
+            allFlags = 0;
+        }
         width = 0;
         precision = UNSPECIFIED;
         nested = null;


### PR DESCRIPTION
A unittest in std.format has been relying on a CTFE bug.

Setting one field of a union, and then reading from another, is not currently supported in CTFE.
