### PR TITLE
dirEntries issues 7264 & 7138

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -31169,7 +31169,7 @@ version(testStdDateTime) unittest
 
     Returns a $(D d_time) for the given $(D SysTime).
  +/
-deprecated long sysTimeToDTime(in SysTime sysTime) pure nothrow
+deprecated long sysTimeToDTime(in SysTime sysTime)
 {
     return convert!("hnsecs", "msecs")(sysTime.stdTime - 621355968000000000L);
 }

--- a/std/file.d
+++ b/std/file.d
@@ -2136,7 +2136,7 @@ else version(Windows)
             return _size;
         }
 
-        deprecated @property d_time creationTime() const pure nothrow
+        deprecated @property d_time creationTime() const
         {
             return sysTimeToDTime(_timeCreated);
         }
@@ -2146,7 +2146,7 @@ else version(Windows)
             return cast(SysTime)_timeCreated;
         }
 
-        deprecated @property d_time lastAccessTime() const pure nothrow
+        deprecated @property d_time lastAccessTime() const
         {
             return sysTimeToDTime(_timeLastAccessed);
         }
@@ -2156,7 +2156,7 @@ else version(Windows)
             return cast(SysTime)_timeLastAccessed;
         }
 
-        deprecated @property d_time lastWriteTime() const pure nothrow
+        deprecated @property d_time lastWriteTime() const
         {
             return sysTimeToDTime(_timeLastModified);
         }


### PR DESCRIPTION
Use alias this, as it now appears to work properly.
Dual overload of opDispatch is removed together with its problems.

Fixes:
Issue 7264 - Can't iterate result from 4-arg dirEntries as string
Issue 7138 - Can't call array() on dirEntries
