### PR TITLE
coerce string to other types workaround

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -735,6 +735,13 @@ public:
         }
     }
 
+    // testing the string coerce
+    unittest
+    {
+        Variant a = "10";
+	assert(a.coerce!int == 10);
+    }
+
     /**
      * Formats the stored value as a string.
      */


### PR DESCRIPTION
This is just a quick workaround for an annoying bug. It looks like this is supposed to work.

void main() {
   Variant a = "10";
   int a = a.coerce!int; // currently throws, but this little fix takes care of it
}
object.Exception@variant.d(708): Type immutable(char)[] does not convert to int

I hate that error message too (no **FILE** and **LINE**), but one thing at a time...
