### PR TITLE
add an alias "var" for Variant.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1117,6 +1117,9 @@ storing larger types, or for saving memory.
 
 alias VariantN!(maxSize!(creal, char[], void delegate())) Variant;
 
+/// $(D_PARAM var) is an alternate version of $(D_PARAM Variant).
+alias Variant var;
+
 /**
  * Returns an array of variants constructed from $(D_PARAM args).
  * Example:


### PR DESCRIPTION
The use of "var" for a variant is similar to the syntax of languages like Javascript. `var x = 4;` is more concise than `Variant x = 4;`.
