### PR TITLE
Fix Issue 5813, Fix Issue 7215, Fix Issue 6641, Fix Issue 4287 - Appender rewrite

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -1463,36 +1463,36 @@ unittest
     }
 
     { // with OutputRange
-        auto a = Appender!(char[])([]);
-        auto b = Appender!(ubyte[])([]);
+        auto a = appender!(char[])();
+        auto b = appender!(ubyte[])();
 
         assert(Base64.encode(tv[""], a) == 0);
-        assert(Base64.decode(a.data, b) == 0);
-        assert(tv[""] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup, b) == 0);
+        assert(tv[""] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["f"], a) == 4);
-        assert(Base64.decode(a.data,  b) == 1);
-        assert(tv["f"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup,  b) == 1);
+        assert(tv["f"] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["fo"], a) == 4);
-        assert(Base64.decode(a.data,   b) == 2);
-        assert(tv["fo"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup,   b) == 2);
+        assert(tv["fo"] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["foo"], a) == 4);
-        assert(Base64.decode(a.data,    b) == 3);
-        assert(tv["foo"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup,    b) == 3);
+        assert(tv["foo"] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["foob"], a) == 8);
-        assert(Base64.decode(a.data,     b) == 4);
-        assert(tv["foob"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup,     b) == 4);
+        assert(tv["foob"] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["fooba"], a) == 8);
-        assert(Base64.decode(a.data, b)      == 5);
-        assert(tv["fooba"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup, b)      == 5);
+        assert(tv["fooba"] == b.dup); a.clear(); b.clear();
 
         assert(Base64.encode(tv["foobar"], a) == 8);
-        assert(Base64.decode(a.data, b)       == 6);
-        assert(tv["foobar"] == b.data); a.clear(); b.clear();
+        assert(Base64.decode(a.dup, b)       == 6);
+        assert(tv["foobar"] == b.dup); a.clear(); b.clear();
     }
 
     { // with InputRange
@@ -1502,12 +1502,12 @@ unittest
         assert(Base64.decode(map!q{a}(encoded)) == [0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e]);
 
         // InputRange to OutputRange
-        auto a = Appender!(char[])([]);
-        auto b = Appender!(ubyte[])([]);
+        auto a = appender!(char[])();
+        auto b = appender!(ubyte[])();
         assert(Base64.encode(map!(to!(ubyte))(["20", "251", "156", "3", "217", "126"]), a) == 8);
-        assert(a.data == "FPucA9l+");
-        assert(Base64.decode(map!q{a}(a.data), b) == 6);
-        assert(b.data == [0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e]);
+        assert(a.dup == "FPucA9l+");
+        assert(Base64.decode(map!q{a}(a.dup), b) == 6);
+        assert(b.dup == [0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e]);
     }
 
     { // Encoder and Decoder

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -600,15 +600,15 @@ unittest
 
         formattedWrite(w1, fmt, BigInt(10));
         formattedWrite(w2, fmt, 10);
-        assert(w1.data == w2.data);
-        assert(w1.data == entry[1]);
+        assert(w1.dup == w2.dup);
+        assert(w1.dup == entry[1]);
         w1.clear();
         w2.clear();
 
         formattedWrite(w1, fmt, BigInt(-10));
         formattedWrite(w2, fmt, -10);
-        assert(w1.data == w2.data);
-        assert(w1.data == entry[2]);
+        assert(w1.dup == w2.dup);
+        assert(w1.dup == entry[2]);
         w1.clear();
         w2.clear();
     }
@@ -651,15 +651,15 @@ unittest
 
         formattedWrite(w1, fmt, BigInt(10));
         formattedWrite(w2, fmt, 10);
-        assert(w1.data == w2.data);     // Equal only positive BigInt
-        assert(w1.data == entry[1]);
+        assert(w1.dup == w2.dup);     // Equal only positive BigInt
+        assert(w1.dup == entry[1]);
         w1.clear();
         w2.clear();
 
         formattedWrite(w1, fmt, BigInt(-10));
         //formattedWrite(w2, fmt, -10);
-        //assert(w1.data == w2.data);
-        assert(w1.data == entry[2]);
+        //assert(w1.dup == w2.dup);
+        assert(w1.dup == entry[2]);
         w1.clear();
         //w2.clear();
     }
@@ -678,5 +678,5 @@ unittest
     formattedWrite(w1, "%010d", x);
     BigInt bx = x;
     formattedWrite(w2, "%010d", bx);
-    assert(w1.data == w2.data);
+    assert(w1.dup == w2.dup);
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -99,7 +99,7 @@ private
         auto w = appender!T();
         FormatSpec!(typeof(T.init[0])) f;
         formatValue(w, src, f);
-        return w.data;
+        return w.dup;
     }
 }
 
@@ -827,7 +827,7 @@ T toImpl(T, S)(S s, in T leftBracket, in T separator = ", ", in T rightBracket =
     {
         alias Unqual!(typeof(T.init[0])) Char;
         // array-to-string conversion
-        auto result = appender!(Char[])();
+        auto result = Appender!(Char[])();
         result.put(leftBracket);
         bool first = true;
         for (; !s.empty; s.popFront())
@@ -843,7 +843,7 @@ T toImpl(T, S)(S s, in T leftBracket, in T separator = ", ", in T rightBracket =
             result.put(to!T(s.front));
         }
         result.put(rightBracket);
-        return cast(T) result.data;
+        return cast(T) result.dup;
     }
 }
 
@@ -911,7 +911,7 @@ T toImpl(T, S)(S s, in T leftBracket, in T keyval = ":", in T separator = ", ", 
                                                  "std.format.formattedWrite"));
 
     alias Unqual!(typeof(T.init[0])) Char;
-    auto result = appender!(Char[])();
+    auto result = Appender!(Char[])();
 // hash-to-string conversion
     result.put(leftBracket);
     bool first = true;
@@ -925,7 +925,7 @@ T toImpl(T, S)(S s, in T leftBracket, in T keyval = ":", in T separator = ", ", 
         result.put(to!T(v));
     }
     result.put(rightBracket);
-    return cast(T) result.data;
+    return cast(T) result.dup;
 }
 
 /// ditto
@@ -1000,7 +1000,7 @@ T toImpl(T, S)(S s, in T left, in T separator = ", ", in T right = ")")
         // ok, attempt to forge the tuple
         t = cast(typeof(t)) &s;
         alias Unqual!(typeof(T.init[0])) Char;
-        auto app = appender!(Char[])();
+        auto app = Appender!(Char[])();
         app.put(left);
         foreach (i, e; t.field)
         {
@@ -1009,7 +1009,7 @@ T toImpl(T, S)(S s, in T left, in T separator = ", ", in T right = ")")
             app.put(to!T(e));
         }
         app.put(right);
-        return cast(T) app.data;
+        return cast(T) app.dup;
     }
     else
     {
@@ -1980,7 +1980,7 @@ body
 
     Target v = 0;
     size_t i = 0;
-    
+
     for (; !s.empty; s.popFront(), ++i)
     {
         uint c = s.front;
@@ -2949,7 +2949,7 @@ Target parseElement(Target, Source)(ref Source s)
     if (s.front == '\"')
     {
         s.popFront();
-        return result.data;
+        return result.dup;
     }
     while (true)
     {
@@ -2959,7 +2959,7 @@ Target parseElement(Target, Source)(ref Source s)
         {
             case '\"':
                 s.popFront();
-                return result.data;
+                return result.dup;
             case '\\':
                 result.put(parseEscape(s));
                 break;

--- a/std/csv.d
+++ b/std/csv.d
@@ -1075,7 +1075,7 @@ private:
     Separator _separator;
     Separator _quote;
     Contents curContentsoken;
-    typeof(appender!(dchar[])()) _front;
+    Appender!(dchar[]) _front;
     bool _empty;
     size_t[] _popCount;
 public:
@@ -1194,7 +1194,7 @@ public:
         if(_input.range.front == _separator)
             _input.range.popFront();
 
-        _front.shrinkTo(0);
+        _front.clear;
 
         prime();
     }
@@ -1207,7 +1207,7 @@ public:
         foreach(i; 0..skipNum)
         {
             _input.col++;
-            _front.shrinkTo(0);
+            _front.clear;
             if(_input.range.front == _separator)
                 _input.range.popFront();
 
@@ -1218,7 +1218,7 @@ public:
             {
                 ice.row = _input.row;
                 ice.col = _input.col;
-                ice.partialData = _front.data.idup;
+                ice.partialData = _front.idup;
                 throw ice;
             }
             catch(ConvException e)
@@ -1240,7 +1240,7 @@ public:
         {
             ice.row = _input.row;
             ice.col = _input.col;
-            ice.partialData = _front.data.idup;
+            ice.partialData = _front.idup;
             throw ice;
         }
 
@@ -1258,7 +1258,7 @@ public:
         if(skipNum)
             prime(skipNum);
 
-        try curContentsoken = to!Contents(_front.data);
+        try curContentsoken = to!Contents(_front.dup);
         catch(ConvException e)
         {
             throw new CSVException(e.msg, _input.row, _input.col, e);
@@ -1279,19 +1279,19 @@ public:
  * auto a = appender!(char[])();
  *
  * csvNextToken(str,a,',','"');
- * assert(a.data == "65");
+ * assert(a.dup == "65");
  * assert(str == ",63\n123,3673");
  *
  * str.popFront();
- * a.shrinkTo(0);
+ * a.clear;
  * csvNextToken(str,a,',','"');
- * assert(a.data == "63");
+ * assert(a.dup == "63");
  * assert(str == "\n123,3673");
  *
  * str.popFront();
- * a.shrinkTo(0);
+ * a.clear;
  * csvNextToken(str,a,',','"');
- * assert(a.data == "123");
+ * assert(a.dup == "123");
  * assert(str == ",3673");
  * -------
  *
@@ -1417,37 +1417,37 @@ unittest
 
     auto a = appender!(dchar[])();
     csvNextToken!string(str,a,',','"');
-    assert(a.data == "\U00010143Hello");
+    assert(a.dup == "\U00010143Hello");
     assert(str == ",65,63.63\nWorld,123,3673.562");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "65");
+    assert(a.dup == "65");
     assert(str == ",63.63\nWorld,123,3673.562");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "63.63");
+    assert(a.dup == "63.63");
     assert(str == "\nWorld,123,3673.562");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "World");
+    assert(a.dup == "World");
     assert(str == ",123,3673.562");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "123");
+    assert(a.dup == "123");
     assert(str == ",3673.562");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "3673.562");
+    assert(a.dup == "3673.562");
     assert(str == "");
 }
 
@@ -1458,37 +1458,37 @@ unittest
 
     auto a = appender!(dchar[])();
     csvNextToken!string(str,a,',','"');
-    assert(a.data == "one");
+    assert(a.dup == "one");
     assert(str == `,two,"three ""quoted""","",` ~ "\"five\nnew line\"\nsix");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "two");
+    assert(a.dup == "two");
     assert(str == `,"three ""quoted""","",` ~ "\"five\nnew line\"\nsix");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "three \"quoted\"");
+    assert(a.dup == "three \"quoted\"");
     assert(str == `,"",` ~ "\"five\nnew line\"\nsix");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "");
+    assert(a.dup == "");
     assert(str == ",\"five\nnew line\"\nsix");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "five\nnew line");
+    assert(a.dup == "five\nnew line");
     assert(str == "\nsix");
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "six");
+    assert(a.dup == "six");
     assert(str == "");
 }
 
@@ -1498,12 +1498,12 @@ unittest
     string str = "one,";
     auto a = appender!(dchar[])();
     csvNextToken(str,a,',','"');
-    assert(a.data == "one");
+    assert(a.dup == "one");
     assert(str == ",");
 
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a,',','"');
-    assert(a.data == "");
+    assert(a.dup == "");
 }
 
 // Test exceptions
@@ -1511,7 +1511,7 @@ unittest
 {
     string str = "\"one\nnew line";
 
-    typeof(appender!(dchar[])()) a;
+    Appender!(dchar[]) a;
     try
     {
         a = appender!(dchar[])();
@@ -1520,7 +1520,7 @@ unittest
     }
     catch (IncompleteCellException ice)
     {
-        assert(a.data == "one\nnew line");
+        assert(a.dup == "one\nnew line");
         assert(str == "");
     }
 
@@ -1534,7 +1534,7 @@ unittest
     }
     catch (IncompleteCellException ice)
     {
-        assert(a.data == "Hello world");
+        assert(a.dup == "Hello world");
         assert(str == "\"");
     }
 
@@ -1542,11 +1542,11 @@ unittest
 
     a = appender!(dchar[])();
     csvNextToken!(string,Malformed.ignore)(str,a,',','"');
-    assert(a.data == "one");
+    assert(a.dup == "one");
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken!(string,Malformed.ignore)(str,a,',','"');
-    assert(a.data == " two \"quoted\" end");
+    assert(a.dup == " two \"quoted\" end");
 }
 
 
@@ -1557,23 +1557,23 @@ unittest
 
     auto a = appender!(dchar[])();
     csvNextToken(str,a, '|','/');
-    assert(a.data == "one"d);
+    assert(a.dup == "one"d);
     assert(str == `|two|/three "quoted"/|//`);
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a, '|','/');
-    assert(a.data == "two"d);
+    assert(a.dup == "two"d);
     assert(str == `|/three "quoted"/|//`);
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a, '|','/');
-    assert(a.data == `three "quoted"`);
+    assert(a.dup == `three "quoted"`);
     assert(str == `|//`);
 
     str.popFront();
-    a.shrinkTo(0);
+    a.clear;
     csvNextToken(str,a, '|','/');
-    assert(a.data == ""d);
+    assert(a.dup == ""d);
 }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27934,19 +27934,21 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
         else version(Windows)
         {
             auto windowsNames = WindowsTimeZone.getInstalledTZNames();
-            auto retval = appender!(string[])();
+            auto app = Appender!(string[])();
 
             foreach(winName; windowsNames)
             {
                 auto tzName = windowsTZNameToTZDatabaseName(winName);
 
                 if(tzName.startsWith(subName))
-                    retval.put(tzName);
+                    app.put(tzName);
             }
 
-            sort(retval.data);
+            auto retval = app.dup;
 
-            return retval.data;
+            sort(retval);
+
+            return retval;
         }
     }
 
@@ -29597,7 +29599,7 @@ assert(tz.dstName == "PDT");
         enforce(tzDatabaseDir.exists, new DateTimeException(format("Directory %s does not exist.", tzDatabaseDir)));
         enforce(tzDatabaseDir.isDir, new DateTimeException(format("%s is not a directory.", tzDatabaseDir)));
 
-        auto timezones = appender!(string[])();
+        auto timezones = Appender!(string[])();
 
         foreach(DirEntry dentry; dirEntries(tzDatabaseDir, SpanMode.depth))
         {
@@ -29616,9 +29618,10 @@ assert(tz.dstName == "PDT");
             }
         }
 
-        sort(timezones.data);
 
-        return timezones.data;
+        auto result = timezones.dup;
+        sort(result);
+        return result;
     }
 
     unittest
@@ -30099,7 +30102,7 @@ else version(Windows)
 
         static string[] getInstalledTZNames()
         {
-            auto timezones = appender!(string[])();
+            auto timezones = Appender!(string[])();
 
             scope baseKey = Registry.localMachine.getKey(`Software\Microsoft\Windows NT\CurrentVersion\Time Zones`);
 
@@ -30107,9 +30110,12 @@ else version(Windows)
             {
                 timezones.put(tzKeyName);
             }
-            sort(timezones.data);
 
-            return timezones.data;
+            auto result = timezones.dup;
+
+            sort(result);
+
+            return result;
         }
 
         unittest

--- a/std/internal/uni.d
+++ b/std/internal/uni.d
@@ -96,7 +96,7 @@ struct Interval
     {
         auto s = appender!string();
         formattedWrite(s,"%s..%s", begin, end);
-        return s.data;
+        return s.dup;
     }
 
 }

--- a/std/json.d
+++ b/std/json.d
@@ -139,7 +139,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T) {
         }
 
         string parseString() {
-                auto str = appender!string();
+                auto str = Appender!string();
 
         Next:
                 switch(peekChar()) {
@@ -181,7 +181,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T) {
                         goto Next;
                 }
 
-                return str.data;
+                return str.dup;
         }
 
         void parseValue(JSONValue* value) {
@@ -232,7 +232,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T) {
 
                 case '0': .. case '9':
                 case '-':
-                        auto number = appender!string();
+                        auto number = Appender!string();
                         bool isFloat;
 
                         void readInteger() {
@@ -268,7 +268,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T) {
                                 readInteger();
                         }
 
-                        string data = number.data;
+                        string data = number.dup;
                         if(isFloat) {
                                 value.type = JSON_TYPE.FLOAT;
                                 value.floating = parse!real(data);
@@ -319,7 +319,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T) {
  Takes a tree of JSON values and returns the serialized string.
 */
 string toJSON(in JSONValue* root) {
-        auto json = appender!string();
+        auto json = Appender!string();
 
         void toString(string str) {
                 json.put('"');
@@ -395,7 +395,7 @@ string toJSON(in JSONValue* root) {
         }
 
         toValue(root);
-        return json.data;
+        return json.dup;
 }
 
 private void appendJSONChar(Appender!string* dst, dchar c,

--- a/std/range.d
+++ b/std/range.d
@@ -245,95 +245,90 @@ unittest
     static assert(!isInputRange!(char[4]));
 }
 
-/**
-Outputs $(D e) to $(D r). The exact effect is dependent upon the two
-types. Several cases are accepted, as described below. The code snippets
-are attempted in order, and the first to compile "wins" and gets
-evaluated.
+/** Outputs $(D e) to $(D r). The exact effect is dependent upon the two types.
+    Several cases are accepted, as described below. The code snippets are
+    attempted in order, and the first to compile "wins" and gets evaluated.
+    Setting $(D asArray) to true will skip code snippets using user defined
+    $(D put) and $(D opCall) methods, allowing templated user defined $(D put)
+    methods to reuse some of $(D put)'s code snippets. Furthermore, $(D ER)
+    allows the caller to set a preferred conversion type, enabling put to
+    perform the correct UTF conversions for character and string inputs.
 
 $(BOOKTABLE ,
-
 $(TR $(TH Code Snippet) $(TH Scenario))
-
-$(TR $(TD $(D r.put(e);)) $(TD $(D R) specifically defines a method
-$(D put) accepting an $(D E).))
-
-$(TR $(TD $(D r.put([ e ]);)) $(TD $(D R) specifically defines a
-method $(D put) accepting an $(D E[]).))
-
-$(TR $(TD $(D r.front = e; r.popFront();)) $(TD $(D R) is an input
-range and $(D e) is assignable to $(D r.front).))
-
-$(TR $(TD $(D for (; !e.empty; e.popFront()) put(r, e.front);)) $(TD
-Copying range $(D E) to range $(D R).))
-
-$(TR $(TD $(D r(e);)) $(TD $(D R) is e.g. a delegate accepting an $(D
-E).))
-
-$(TR $(TD $(D r([ e ]);)) $(TD $(D R) is e.g. a $(D delegate)
-accepting an $(D E[]).))
-
+$(TR $(TD $(D r.put(e);))
+     $(TD $(D R) defines a method $(D put) accepting an $(D E).))
+$(TR $(TD $(D r.put([ e ]);))
+     $(TD $(D R) defines a method $(D put) accepting an $(D E[]).))
+$(TR $(TD $(D r.front = e; r.popFront();))
+     $(TD $(D R) is an input range and $(D e) is assignable to $(D r.front).))
+$(TR $(TD $(D r[0] = e; r = r[1..$];))
+     $(TD $(D R) supports slicing and $(D e) is index assignable to $(D r).))
+$(TR $(TD $(D r[0..e.length] = e[0..$]; r = r[e.length..$];))
+     $(TD $(D R) supports slicing and $(D e) is slice assignable to $(D r).))
+$(TR $(TD $(D foreach(ER v; e) put(r,v)))
+     $(TD String safe copying of a range $(D E) to range $(D R).))
+$(TR $(TD $(D foreach(v; e) put(r,v)))
+     $(TD General copying of a range $(D E) to range $(D R).))
+$(TR $(TD $(D foreach(i;0..e.length) put(r,e[i])))
+     $(TD Copying range $(D E) to range $(D R).))
+$(TR $(TD $(D r ~= e;))
+     $(TD $(D R) supports concatenation with $(D e).))
+$(TR $(TD $(D r(e);))
+     $(TD $(D R) is e.g. a delegate accepting an $(D E).))
+$(TR $(TD $(D r([ e ]);))
+     $(TD $(D R) is e.g. a $(D delegate) accepting an $(D E[]).))
 )
  */
-void put(R, E)(ref R r, E e)
-{
-    static if (hasMember!(R, "put") ||
-    (isPointer!R && is(pointerTarget!R == struct) &&
-     hasMember!(pointerTarget!R, "put")))
-    {
-        // commit to using the "put" method
-        static if (!isArray!R && is(typeof(r.put(e))))
-        {
-            r.put(e);
-        }
-        else static if (!isArray!R && is(typeof(r.put((&e)[0..1]))))
-        {
-            r.put((&e)[0..1]);
-        }
-        else
-        {
-            static assert(false,
-                    "Cannot put a "~E.stringof~" into a "~R.stringof);
-        }
+void put(R, E, bool asArray=isArray!R, ER=ElementEncodingType!R, string file = __FILE__, int line = __LINE__)(auto ref R r, auto ref E e){
+    static if(isSomeChar!ER && isSomeChar!E && ER.sizeof < E.sizeof ) {
+        // Transcoding is required to support r.put(dchar)
+        Unqual!ER[ER.sizeof == 1 ? 4 : 2] encoded;
+        auto len = std.utf.encode(encoded, e);
+        put(r,encoded[0 .. len]);
+    } else static if( !asArray && __traits(compiles,  r.put(  e          ))  ){
+                                                      r.put(  e          );
+    } else static if( !asArray && __traits(compiles,  r.put((&e)[0..1]   ))  ){
+                                                      r.put((&e)[0..1]   );
+    } else static if (isInputRange!R && is(typeof(r.front = e) )) {
+        r.front = e;
+        r.popFront();
+    } else static if(__traits(compiles, {r[0] = e; r = r[1..r.length];}     )){
+        r[0] = e;
+        r    = r[1..r.length];
+    } else static if(__traits(compiles, {r[0..e.length] = e[0..e.length];
+                                                      r = r[1..r.length];  })){
+        r[0..e.length] = e[0..e.length];
+        r              = r[e.length..r.length];
+    } else static if( ( (isArray!R || !asArray) && __traits(compiles,r~=e)  )&&
+                      ( is(ER == void) || !(isSomeChar!ER ^ isSomeChar!E)   )){
+        r ~= e;
+    } else static if( _putCall!(R,E,asArray) && is(typeof( r( e          )) )){
+                                                           r( e          );
+    } else static if( _putCall!(R,E,asArray) && is(typeof( r( (&e)[0..1] )) )){
+                                                           r( (&e)[0..1] );
+    } else static if(__traits(compiles,{foreach(ER v; e  )     put(r,  v );})){
+                                        foreach(ER v; e  )     put(r,  v );
+    } else static if(__traits(compiles,{foreach(   v; e  )     put(r,  v );})){
+                                        foreach(   v; e  )     put(r,  v );
+    } else static if(__traits(compiles,{foreach(ER v; e[])     put(r,  v );})){
+                                        foreach(ER v; e[])     put(r,  v );
+    } else static if(__traits(compiles,{foreach(   v; e[])     put(r,  v );})){
+                                        foreach(   v; e[])     put(r,  v );
+    } else static if(__traits(compiles,{foreach(i;0..e.length) put(r,e[i]);})){
+                                        foreach(i;0..e.length) put(r,e[i]);
+    } else {
+        static assert(false, "Can't put a "~E.stringof~" into a "~R.stringof);
     }
-    else
-    {
-        static if (isInputRange!R)
-        {
-            // Commit to using assignment to front
-            static if (is(typeof(r.front = e, r.popFront())))
-            {
-                r.front = e;
-                r.popFront();
-            }
-            else static if (isInputRange!E && is(typeof(put(r, e.front))))
-            {
-                for (; !e.empty; e.popFront()) put(r, e.front);
-            }
-            else
-            {
-                static assert(false,
-                        "Cannot put a "~E.stringof~" into a "~R.stringof);
-            }
-        }
-        else
-        {
-            // Commit to using opCall
-            static if (is(typeof(r(e))))
-            {
-                r(e);
-            }
-            else static if (is(typeof(r((&e)[0..1]))))
-            {
-                r((&e)[0..1]);
-            }
-            else
-            {
-                static assert(false,
-                        "Cannot put a "~E.stringof~" into a "~R.stringof);
-            }
-        }
-    }
+}
+// Helper template for put(): filters out opCall from ctors
+private template _putCall(R, E, bool asArray = false) {
+    static if(asArray)    enum _putCall = false;
+    else static if( is(R==class) || is(R==struct) || is(R==union) )
+         enum _putCall = is(typeof( (R r, E e){r.opCall(   e        );}))||
+                         is(typeof( (R r, E e){r.opCall( (&e)[0..1] );}));
+    else enum _putCall = is(typeof( (R r, E e){r(          e        );}))||
+                         is(typeof( (R r, E e){r(        (&e)[0..1] );}));
 }
 
 unittest
@@ -391,9 +386,9 @@ unittest
     char[] a = new char[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
     static assert(!__traits(compiles, put(a, 1)));
-    // char[] is NOT output range.
-    static assert(!__traits(compiles, put(a, 'a')));
-    static assert(!__traits(compiles, put(a, "ABC")));
+    // char[] is an output range.
+    static assert( __traits(compiles, put(a, 'a')));
+    static assert( __traits(compiles, put(a, "ABC")));
 }
 
 /**
@@ -401,14 +396,14 @@ Returns $(D true) if $(D R) is an output range for elements of type
 $(D E). An output range is defined functionally as a range that
 supports the operation $(D put(r, e)) as defined above.
  */
-template isOutputRange(R, E)
+template isOutputRange(R, E, string file = __FILE__, int line = __LINE__)
 {
-    enum bool isOutputRange = is(typeof(
+    enum bool isOutputRange = __traits(compiles,
     {
         R r = void;
         E e;
         put(r, e);
-    }));
+    });
 }
 
 unittest
@@ -421,8 +416,8 @@ unittest
     static assert( isOutputRange!(Appender!string, string));
     static assert( isOutputRange!(Appender!string*, string));
     static assert(!isOutputRange!(Appender!string, int));
-    static assert(!isOutputRange!(char[], char));
-    static assert(!isOutputRange!(wchar[], wchar));
+    static assert( isOutputRange!(char[], char));
+    static assert( isOutputRange!(wchar[], wchar));
     static assert( isOutputRange!(dchar[], char));
     static assert( isOutputRange!(dchar[], wchar));
     static assert( isOutputRange!(dchar[], dchar));
@@ -809,7 +804,7 @@ unittest
 {
     static assert(hasLvalueElements!(int[]));
     static assert(!hasLvalueElements!(typeof(iota(3))));
-    
+
     auto c = chain([1, 2, 3], [4, 5, 6]);
     static assert(hasLvalueElements!(typeof(c)));
 }
@@ -3508,7 +3503,7 @@ private string lockstepApply(Ranges...)(bool withIndex) if (Ranges.length > 0)
         {
             ret ~= "ref ";
         }
-        
+
         ret ~= "ElementType!(Ranges[" ~ to!string(ti) ~ "]), ";
     }
 
@@ -3527,7 +3522,7 @@ private string lockstepApply(Ranges...)(bool withIndex) if (Ranges.length > 0)
 
     // Check for emptiness.
     ret ~= "\twhile(";                 //someEmpty) {\n";
-    foreach(ti, Unused; Ranges) 
+    foreach(ti, Unused; Ranges)
     {
         ret ~= "!ranges[" ~ to!string(ti) ~ "].empty && ";
     }
@@ -3682,7 +3677,7 @@ unittest {
     auto l = lockstep(foo, bar);
 
     // Should work twice.  These are forward ranges with implicit save.
-    foreach(i; 0..2) 
+    foreach(i; 0..2)
     {
         uint[] res1;
         float[] res2;
@@ -5872,8 +5867,8 @@ unittest {
 
     appWrapped.put(1);
     appWrapped.put([2, 3]);
-    assert(app.data.length == 3);
-    assert(equal(app.data, [1,2,3]));
+    assert(app.walkLength == 3);
+    assert(equal(app.dup, [1,2,3]));
 }
 
 /**

--- a/std/string.d
+++ b/std/string.d
@@ -1290,7 +1290,7 @@ unittest
 deprecated S capwords(S)(S s) if (isSomeString!S)
 {
     alias typeof(s[0]) C;
-    auto retval = appender!(C[])();
+    auto retval = Appender!(C[])();
     bool inWord = false;
     size_t wordStart = 0;
 
@@ -1306,7 +1306,7 @@ deprecated S capwords(S)(S s) if (isSomeString!S)
         }
         else if(!inWord)
         {
-            if(!retval.data.empty)
+            if(!retval.empty)
                 retval.put(' ');
 
             wordStart = i;
@@ -1317,7 +1317,7 @@ deprecated S capwords(S)(S s) if (isSomeString!S)
     if(inWord)
         retval.put(capitalize(s[wordStart .. $]));
 
-    return cast(S)retval.data;
+    return cast(S)retval.dup;
 }
 
 unittest
@@ -1380,7 +1380,7 @@ S[] splitLines(S)(S s, KeepTerminator keepTerm = KeepTerminator.no)
 {
     size_t iStart = 0;
     size_t nextI = 0;
-    auto retval = appender!(S[])();
+    auto retval = Appender!(S[])();
 
     for(size_t i; i < s.length; i = nextI)
     {
@@ -1410,7 +1410,7 @@ S[] splitLines(S)(S s, KeepTerminator keepTerm = KeepTerminator.no)
     if(iStart != nextI)
         retval.put(s[iStart .. $]);
 
-    return retval.data;
+    return retval.dup;
 }
 
 unittest
@@ -2266,7 +2266,7 @@ private auto translateImpl(C1, T, C2)(C1[] str,
                                       T transTable,
                                       const(C2)[] toRemove) @trusted
 {
-    auto retval = appender!(C1[])();
+    auto retval = Appender!(C1[])();
 
     bool[dchar] removeTable;
 
@@ -2286,7 +2286,7 @@ private auto translateImpl(C1, T, C2)(C1[] str,
             retval.put(c);
     }
 
-    return retval.data;
+    return retval.dup;
 }
 
 
@@ -2954,7 +2954,7 @@ C1[] tr(C1, C2, C3, C4 = immutable char)
     if (to.empty && !mod_d)
         to = std.conv.to!(typeof(to))(from);
 
-    auto result = appender!(C1[])();
+    auto result = Appender!(C1[])();
     bool modified;
     dchar lastc;
 
@@ -3040,7 +3040,7 @@ C1[] tr(C1, C2, C3, C4 = immutable char)
         modified = false;
     }
 
-    return result.data;
+    return result.dup;
 }
 
 unittest

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -516,7 +516,7 @@ assert(s[0] == "abc" && s[1] == 4.5);
             }
         }
         app.put(footer);
-        return app.data;
+        return app.dup;
     }
 }
 
@@ -2521,15 +2521,14 @@ to deallocate the corresponding resource.
         debug(RefCounted) if (RefCounted.debugging) writeln("done!");
     }
 
-/**
-Assignment operators
- */
-    void opAssign(typeof(this) rhs)
-    {
-        swap(RefCounted._store, rhs.RefCounted._store);
-    }
+//    void opAssign(typeof(this) rhs)
+//    {
+//        swap(RefCounted._store, rhs.RefCounted._store);
+//    }
 
-/// Ditto
+/**
+Assignment operator
+ */
     void opAssign(T rhs)
     {
         RefCounted._store._payload = move(rhs);

--- a/std/utf.d
+++ b/std/utf.d
@@ -1575,13 +1575,13 @@ P toUTFz(P, S)(S str)
        !is(Unqual!(typeof(*P.init)) == Unqual!(ElementEncodingType!S)))
 //C1[], const(C1)[], or immutable(C1)[] -> C2*, const(C2)*, or immutable(C2)*
 {
-    auto retval = appender!(typeof(*P.init)[])();
+    auto retval = Appender!(typeof(*P.init)[])();
 
     foreach(dchar c; str)
         retval.put(c);
     retval.put('\0');
 
-    return cast(P)retval.data.ptr;
+    return cast(P)retval.dup.ptr;
 }
 
 //Verify Examples.

--- a/std/xml.d
+++ b/std/xml.d
@@ -352,7 +352,7 @@ S encode(S)(S s)
 {
     string r;
     size_t lastI;
-    auto result = appender!S();
+    auto result = Appender!S();
 
     foreach (i, c; s)
     {
@@ -371,9 +371,9 @@ S encode(S)(S s)
         lastI = i + 1;
     }
 
-    if (!result.data) return s;
+    if (result.empty) return s; // no escapes found
     result.put(s[lastI .. $]);
-    return result.data;
+    return result.dup;
 }
 
 unittest


### PR DESCRIPTION
This pull request addresses:

[patch] std.array.Appender has severe performance and memory leak problems
http://d.puremagic.com/issues/show_bug.cgi?id=5813

Issue 7215 - array.Appender.put should work on its own type
http://d.puremagic.com/issues/show_bug.cgi?id=7215

Issue 6641 - RefAppender!(T[]) should be OutputRange.
http://d.puremagic.com/issues/show_bug.cgi?id=6641

Issue 4287 - opOpAssign!("~=") for std.array.Appender
http://d.puremagic.com/issues/show_bug.cgi?id=4287

Appender has been rewritten to improve memory usage and performance, both at small and large scales. Algorithmically, Appender is implemented using a sealed rope, a linked-list of arrays, with the first node being cached in a thread local free list. It provides strict computational and memory performance bounds: for most users data will be copied exactly twice, there will be less than 4k of wasted space and a maximum memory usage of o(2N). For small arrays, this results in a 40% performance increase. For large arrays, the lack of memory/GC churn and false pointers eliminates a source of memory leaks that prevented very large arrays.

The implementation change is reflected in the API; .data has been soft-deprecated and the conventions of std.container have been employed were applicable. Phobos has been reviewed for usages of .data. The vast majority of uses involve de novo array creation and have been migrated to using .dup. Two uses involved using appender as a stack (std.file and std.regex). std.file was migrated to the appropriate container APIs. std.regex required an un-sealed container. A simple, array based stack was written to fulfill this need. std.stdio used appender to wrap a buffer as part of readlnImpl. A zero-overhead method of wrapping a buffer (wrappedBuffer) was added to efficiently support this use case and is available to @system methods. As discussed in issue  6641, RefAppender has been removed; wrappedBuffer provides similar functionality with no extra overhead. Unittestsand documentation were added for all new functionality.

Unittests have been verified on DMD 2.058, 32-bit windows.
