### PR TITLE
std.md5: Lower buffer size in mdFile example

### DIFF
--- a/std/md5.d
+++ b/std/md5.d
@@ -49,7 +49,7 @@ void mdFile(string filename)
 
     MD5_CTX context;
     context.start();
-    foreach (buffer; File(filename).byChunk(4096 * 1024))
+    foreach (buffer; File(filename).byChunk(64 * 1024))
         context.update(buffer);
     context.finish(digest);
     writefln("MD5 (%s) = %s", filename, digestToString(digest));


### PR DESCRIPTION
When trying to use the function from the example as-is on a large directory tree, the D program will quickly run out of memory due to false pointers on 32-bit machines (File.byChunk will allocate a new buffer for every file).
