### PR TITLE
Fix: Incorrect indentation using std.xml.pretty.

### DIFF
--- a/std/xml.d
+++ b/std/xml.d
@@ -123,6 +123,7 @@ Distributed under the Boost Software License, Version 1.0.
 */
 module std.xml;
 
+import std.algorithm : count;
 import std.array;
 import std.ascii;
 import std.string;
@@ -921,7 +922,7 @@ class Element : Item
                 string[] b = item.pretty(indent);
                 foreach(s;b)
                 {
-                    a ~= rightJustify(s,s.length + indent);
+                    a ~= rightJustify(s,count(s) + indent);
                 }
             }
             a ~= tag.toEndString();


### PR DESCRIPTION
When an attribute contains a multibyte string std.xml.pretty
incorrectly indent the tag.
