### PR TITLE
std.datetime: Remove redundant SYSTEMTIME step when converting FILETIME

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -432,18 +432,10 @@ public:
     {
         version(Windows)
         {
-            //FILETIME represents hnsecs from midnight, January 1st, 1601.
-            enum hnsecsFrom1601 = 504_911_232_000_000_000L;
-
             FILETIME fileTime;
-
             GetSystemTimeAsFileTime(&fileTime);
 
-            ulong tempHNSecs = fileTime.dwHighDateTime;
-            tempHNSecs <<= 32;
-            tempHNSecs |= fileTime.dwLowDateTime;
-
-            return cast(long)tempHNSecs + hnsecsFrom1601;
+            return FILETIMEToStdTime(&fileTime);
         }
         else version(Posix)
         {
@@ -31366,6 +31358,22 @@ version(StdDdoc)
     /++
         $(BLUE This function is Windows-Only.)
 
+        Converts a $(D FILETIME) struct to the number of hnsecs since midnight,
+        January 1st, 1 A.D.
+
+        Params:
+            ft = The $(D FILETIME) struct to convert.
+
+        Throws:
+            $(D DateTimeException) if the given $(D FILETIME) cannot be
+            represented as the return value.
+      +/
+    long FILETIMEToStdTime(const FILETIME* ft);
+
+
+    /++
+        $(BLUE This function is Windows-Only.)
+
         Converts a $(D FILETIME) struct to a $(D SysTime).
 
         Params:
@@ -31375,10 +31383,25 @@ version(StdDdoc)
 
         Throws:
             $(D DateTimeException) if the given $(D FILETIME) will not fit in a
-            $(D SysTime) or if the $(D FILETIME) cannot be converted to a
-            $(D SYSTEMTIME).
+            $(D SysTime).
       +/
     SysTime FILETIMEToSysTime(const FILETIME* ft, immutable TimeZone tz = LocalTime());
+
+
+    /++
+        $(BLUE This function is Windows-Only.)
+
+        Converts a number of hnsecs since midnight, January 1st, 1 A.D. to a
+        $(D FILETIME) struct.
+
+        Params:
+            sysTime = The $(D SysTime) to convert.
+
+        Throws:
+            $(D DateTimeException) if the given value will not fit in a
+            $(D FILETIME).
+      +/
+    FILETIME stdTimeToFILETIME(long stdTime);
 
 
     /++
@@ -31504,15 +31527,24 @@ else version(Windows)
         }
     }
 
+    private enum hnsecsFrom1601 = 504_911_232_000_000_000L;
+
+    long FILETIMEToStdTime(const FILETIME* ft)
+    {
+        ULARGE_INTEGER ul;
+        ul.HighPart = ft.dwHighDateTime;
+        ul.LowPart = ft.dwLowDateTime;
+        ulong tempHNSecs = ul.QuadPart;
+
+        if(tempHNSecs > long.max - hnsecsFrom1601)
+            throw new DateTimeException("The given FILETIME cannot be represented as a stdTime value.");
+
+        return cast(long)tempHNSecs + hnsecsFrom1601;
+    }
 
     SysTime FILETIMEToSysTime(const FILETIME* ft, immutable TimeZone tz = LocalTime())
     {
-        SYSTEMTIME st = void;
-
-        if(!FileTimeToSystemTime(ft, &st))
-            throw new DateTimeException("FileTimeToSystemTime() failed.");
-
-        auto sysTime = SYSTEMTIMEToSysTime(&st, UTC());
+        auto sysTime = SysTime(FILETIMEToStdTime(ft), UTC());
         sysTime.timezone = tz;
 
         return sysTime;
@@ -31537,14 +31569,24 @@ else version(Windows)
     }
 
 
-    FILETIME SysTimeToFILETIME(SysTime sysTime)
+    FILETIME stdTimeToFILETIME(long stdTime)
     {
-        SYSTEMTIME st = SysTimeToSYSTEMTIME(sysTime.toUTC());
+        if(stdTime < hnsecsFrom1601)
+            throw new DateTimeException("The given stdTime value cannot be represented as a FILETIME.");
 
-        FILETIME ft = void;
-        SystemTimeToFileTime(&st, &ft);
+        ULARGE_INTEGER ul;
+        ul.QuadPart = cast(ulong)stdTime - hnsecsFrom1601;
+
+        FILETIME ft;
+        ft.dwHighDateTime = ul.HighPart;
+        ft.dwLowDateTime = ul.LowPart;
 
         return ft;
+    }
+
+    FILETIME SysTimeToFILETIME(SysTime sysTime)
+    {
+        return stdTimeToFILETIME(sysTime.stdTime);
     }
 
     unittest


### PR DESCRIPTION
Both FILETIME and SysTime store time as the number of elapsed hnsecs since a certain (different) epoch. Therefore, the optimal way to convert between the two would be simply adding/subtracting the epoch difference. This is not what std.datetime used to do - instead, FILETIME values were converted to SYSTEMTIME (a structure with year/month/day/etc. fields), and then created the SysTime result from that (and vice-versa), which was very inefficient.

The "add epoch difference" method was already used in SysTime.currStdTime. It has been refactored out and used in FILETIME conversion functions.
