### PR TITLE
Capitalize `pointerTarget`'s first letter

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -574,8 +574,8 @@ accepting an $(D E[]).))
 void put(R, E)(ref R r, E e)
 {
     static if (hasMember!(R, "put") ||
-    (isPointer!R && is(pointerTarget!R == struct) &&
-     hasMember!(pointerTarget!R, "put")))
+    (isPointer!R && is(PointerTarget!R == struct) &&
+     hasMember!(PointerTarget!R, "put")))
     {
         // commit to using the "put" method
         static if (!isArray!R && is(typeof(r.put(e))))

--- a/std/traits.d
+++ b/std/traits.d
@@ -3443,17 +3443,20 @@ unittest
 /**
 Returns the target type of a pointer.
 */
-template pointerTarget(T : T*)
+template PointerTarget(T : T*)
 {
-    alias T pointerTarget;
+    alias T PointerTarget;
 }
+
+/// $(RED Scheduled for deprecation. Please use $(LREF PointerTarget) instead.)
+alias PointerTarget pointerTarget;
 
 unittest
 {
-    static assert( is(pointerTarget!(int*) == int));
-    static assert( is(pointerTarget!(long*) == long));
+    static assert( is(PointerTarget!(int*) == int));
+    static assert( is(PointerTarget!(long*) == long));
 
-    static assert(!is(pointerTarget!int));
+    static assert(!is(PointerTarget!int));
 }
 
 /**


### PR DESCRIPTION
Ones a caught myself at trying to compile `PointerTarget!T` and getting an error...

Let's follow naming conventions!
