### PR TITLE
fix issue 7022

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -382,8 +382,8 @@ and throws if that fails.
     void detach()
     {
         if (!p) return;
-        // @@@BUG
-        //if (p.refs == 1) close();
+        if (p.refs == 1) close();
+        else if(p.refs != 0) p.refs--;
         p = null;
     }
 


### PR DESCRIPTION
fix issue 7831

detach sets p=null, which makes it kind of hard for the destructor
to actually close the file or decrement the reference count.
