### PR TITLE
File.detach should decrement the ref count - Issue 7022

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -387,6 +387,19 @@ and throws if that fails.
         p = null;
     }
 
+    unittest
+    {
+        auto deleteme = testFilename();
+        scope(exit) std.file.remove(deleteme);
+        auto f = File(deleteme, "w");
+        {
+            auto f2 = f;
+            f2.detach();
+        }
+        assert(f.p.refs == 1);
+        f.close();
+    }
+
 /**
 If the file was unopened, succeeds vacuously. Otherwise closes the
 file (by calling $(WEB


### PR DESCRIPTION
Because detach invalidates a copy of the File struct it should also decrement the ref count.
The File destructor doesn't take care of this because by then p is already null.
