### PR TITLE
Make $(DMD) properly configurable.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -61,7 +61,7 @@ DDOCFLAGS=-m$(MODEL) -d -c -o- -version=StdDdoc -I$(DRUNTIME_PATH)/import $(DMDE
 
 # Variable defined in an OS-dependent manner (see below)
 CC =
-DMD =
+DMD ?=
 DDOC =
 CFLAGS =
 DFLAGS =
@@ -83,14 +83,14 @@ endif
 # Set CC and DMD
 ifeq ($(OS),win32wine)
 	CC = wine dmc.exe
-	DMD = wine dmd.exe
+	DMD ?= wine dmd.exe
 	RUN = wine
 else
 	ifeq ($(OS),win32remote)
-		DMD = ssh 206.125.170.138 "cd code/dmd/phobos && dmd"
+		DMD ?= ssh 206.125.170.138 "cd code/dmd/phobos && dmd"
 		CC = ssh 206.125.170.138 "cd code/dmd/phobos && dmc"
 	else
-		DMD = dmd
+		DMD ?= dmd
 		ifeq ($(OS),win32)
 			CC = dmc
 		else


### PR DESCRIPTION
This makes $(DMD) properly configurable in the makefiles in a standard Make fashion, e.g.: DMD=/foo/bar/baz/dmd make -f posix.mak
