### PR TITLE
fix Issue 7944 - std.range.iota.popFront() cycles when the range is empty

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4361,6 +4361,8 @@ if ((isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         @property auto save() { return this; }
         Value opIndex(ulong n)
         {
+            assert(n < this.length);
+
             // Just cast to Value here because doing so gives overflow behavior
             // consistent with calling popFront() n times.
             return cast(Value) (current + step * n);
@@ -4427,6 +4429,8 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         @property auto save() { return this; }
         Value opIndex(ulong n)
         {
+            assert(n < this.length);
+
             // Just cast to Value here because doing so gives overflow behavior
             // consistent with calling popFront() n times.
             return cast(Value) (current + n);


### PR DESCRIPTION
Added !empty assertions to front, popFront, back, and popBack to the integer iota like some other ranges do to catch popping an empty range. Also added the !empty assert to floating point iota front() which was the only one of those four that was missing.

http://d.puremagic.com/issues/show_bug.cgi?id=7944
