### PR TITLE
Fix typo leading to incorrect empty result

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -4401,10 +4401,10 @@ auto commonPrefix(alias pred = "a == b", R1, R2)(R1 r1, R2 r2)
 if (isForwardRange!R1 && isForwardRange!R2)
 {
     static if (isSomeString!R1 && isSomeString!R2
-            && (ElementEncodingType!R1).sizeof == (ElementEncodingType!R2).sizeof
+            && ElementEncodingType!R1.sizeof == ElementEncodingType!R2.sizeof
             || isRandomAccessRange!R1 && hasLength!R2)
     {
-        auto limit = min(r1.length, r2.length);
+        immutable limit = min(r1.length, r2.length);
         foreach (i; 0 .. limit)
         {
             if (!binaryFun!pred(r1[i], r2[i]))
@@ -4412,7 +4412,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
                 return r1[0 .. i];
             }
         }
-        return r1[0 .. 0];
+        return r1[0 .. limit];
     }
     else
     {
@@ -4429,6 +4429,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
 unittest
 {
     assert(commonPrefix("hello, world", "hello, there") == "hello, ");
+    assert(commonPrefix("hello, ", "hello, world") == "hello, ");
     assert(equal(commonPrefix("hello, world", "hello, there"w), "hello, "));
     assert(equal(commonPrefix("hello, world"w, "hello, there"), "hello, "));
     assert(equal(commonPrefix("hello, world", "hello, there"d), "hello, "));


### PR DESCRIPTION
- also improve style a bit

Now `commonPrefix` is usable with `reduce`
