### PR TITLE
std.traits: Add SetFunctionAttributes.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -920,9 +920,8 @@ unittest
  * }
  * ---
  */
-template SetFunctionAttributes(T, string linkage = "D",
-    uint attrs = FunctionAttribute.none)
-if (isFunctionPointer!T || isDelegate!T)
+template SetFunctionAttributes(T, string linkage, uint attrs)
+    if (isFunctionPointer!T || isDelegate!T)
 {
     mixin({
         static assert(!(attrs & FunctionAttribute.trusted) ||
@@ -980,9 +979,8 @@ if (isFunctionPointer!T || isDelegate!T)
 }
 
 /// Ditto
-template SetFunctionAttributes(T, string linkage = "D",
-    uint attrs = FunctionAttribute.none)
-if (is(T == function))
+template SetFunctionAttributes(T, string linkage, uint attrs)
+    if (is(T == function))
 {
     // To avoid a lot of syntactic headaches, we just use the above version to
     // operate on the corresponding function pointer type and then remove the


### PR DESCRIPTION
Currently, function/delegate types are quite hard to handle in D. For example, there is no easy way to add or remove attributes from functions in generic code (in situations like shown in the examples). Additionally, attributes can currently only specified in some declarations, but e.g. `cast(extern(C) void function())` does not compile.

The added template provides an easy solution for the former problem. I have been using it in various projects to implement things like `assumeNothrow(someDg)`, `ExternC`, etc. While something like `assumePure` (or adding attributes in general) should be included in Phobos as well (like `assumeUnique`), I think this is a solid start in any case.
