### PR TITLE
Fix std.conv.to for alias this type interactions

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -9,6 +9,7 @@ $(VERSION 060, ddd mm, 2012, =================================================,
         $(LI $(BUGZILLA 6157): to!string should work for various pointer types)
         $(LI $(BUGZILLA 7348): to!string(null) matches more than one template declaration)
         $(LI $(BUGZILLA 7909): to!enum(string) and to!string(enum) break when enum is integral)
+        $(LI $(BUGZILLA 8080): 'alias this' causes toString to be shadowed by aliased object)
      )
  )
 $(VERSION 059, ddd mm, 2012, =================================================,

--- a/std/conv.d
+++ b/std/conv.d
@@ -1020,6 +1020,16 @@ unittest
     }
     S2 s2;
     assert(to!string(s2) == "S2(42, 43.5)");
+
+    // Test for issue 8080
+    struct S8080
+    {
+        short[4] data;
+        alias data this;
+        string toString() { return "<S>"; }
+    }
+    S8080 s8080;
+    assert(to!string(s8080) == "<S>");
 }
 
 unittest


### PR DESCRIPTION
(This is based on #537. Please merge it first.)

Now `std.format.formatValue` considers 'alias this' types. But `std.conv.to` doesn't yet.
This pull fixes following bugs and increases maintainability.

<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6175">Issue 6175</a> - String corruption when passing static char arrays to std.conv
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7348">Issue 7348</a> - to!string(null) matches more than one template declaration
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=8080">Issue 8080</a> - 'alias this' causes toString to be shadowed by aliased object
