### PR TITLE
Fix empty range creation when using stride.

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -1684,6 +1684,8 @@ if (isInputRange!(Unqual!Range))
                         (upper * _n - (_n - 1));
                     immutable translatedLower = min(lower * _n, translatedUpper);
                     
+                    assert(translatedLower <= translatedUpper);
+                    
                     return typeof(this)(source[translatedLower..translatedUpper], _n);
                 }
 
@@ -1724,7 +1726,8 @@ unittest
     assert(s1[1..5].length == 4);
     assert(s1[0..0].empty);
     assert(s1[3..3].empty);
-    assert(s1[$ .. $].empty);
+    // assert(s1[$ .. $].empty);
+    assert(s1[s1.opDollar() .. s1.opDollar()].empty);
 
     auto s2 = stride(arr, 2);
     assert(equal(s2[0..2], [1,3]));
@@ -1733,7 +1736,8 @@ unittest
     assert(s2[1..5].length == 4);
     assert(s2[0..0].empty);
     assert(s2[3..3].empty);
-    assert(s2[$ .. $].empty);
+    // assert(s2[$ .. $].empty);
+    assert(s2[s2.opDollar() .. s2.opDollar()].empty);
 
     // Test fix for Bug 5035
     auto m = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]; // 3 rows, 4 columns


### PR DESCRIPTION
When using stride, you previously got an out of bound exception when creating an empty slice. This patch fix this problem.
