### PR TITLE
Changed min()/max() to use T.init instead of 0

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4045,7 +4045,7 @@ auto unsigned(T)(T x) if (isIntegral!T)
     else static if (is(Unqual!T == long )) return cast(ulong ) x;
     else
     {
-        static assert(T.min == 0, "Bug in either unsigned or isIntegral");
+        static assert(T.min == T.init, "Bug in either unsigned or isIntegral");
         return x;
     }
 }
@@ -4058,7 +4058,7 @@ unittest
 auto unsigned(T)(T x) if (isSomeChar!T)
 {
     // All characters are unsigned
-    static assert(T.min == 0);
+    static assert(T.min == T.init);
     return x;
 }
 
@@ -4069,8 +4069,8 @@ template mostNegative(T)
 {
     static if (is(typeof(T.min_normal)))
         enum mostNegative = -T.max;
-    else static if (T.min == 0)
-        enum byte mostNegative = 0;
+    else static if (T.min == T.init)
+        enum byte mostNegative = T.init;
     else
         enum mostNegative = T.min;
 }
@@ -4078,7 +4078,7 @@ template mostNegative(T)
 unittest
 {
     static assert(mostNegative!(float) == -float.max);
-    static assert(mostNegative!(uint) == 0);
+    static assert(mostNegative!(uint) == uint.init);
     static assert(mostNegative!(long) == long.min);
 }
 


### PR DESCRIPTION
This allows us to use them with user-defined structs as well.
