### PR TITLE
Some tweaks to unsigned.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4263,26 +4263,63 @@ auto unsigned(T)(T x) if (isIntegral!T)
     else
     {
         static assert(T.min == 0, "Bug in either unsigned or isIntegral");
-        return x;
+        return cast(Unqual!T) x;
     }
 }
 
 unittest
 {
-    static assert(is(typeof(unsigned(1 + 1)) == uint));
+    foreach(T; TypeTuple!(byte, ubyte))
+    {
+        static assert(is(typeof(unsigned(cast(T)1)) == ubyte));
+        static assert(is(typeof(unsigned(cast(const T)1)) == ubyte));
+        static assert(is(typeof(unsigned(cast(immutable T)1)) == ubyte));
+    }
+
+    foreach(T; TypeTuple!(short, ushort))
+    {
+        static assert(is(typeof(unsigned(cast(T)1)) == ushort));
+        static assert(is(typeof(unsigned(cast(const T)1)) == ushort));
+        static assert(is(typeof(unsigned(cast(immutable T)1)) == ushort));
+    }
+
+    foreach(T; TypeTuple!(int, uint))
+    {
+        static assert(is(typeof(unsigned(cast(T)1)) == uint));
+        static assert(is(typeof(unsigned(cast(const T)1)) == uint));
+        static assert(is(typeof(unsigned(cast(immutable T)1)) == uint));
+    }
+
+    foreach(T; TypeTuple!(long, ulong))
+    {
+        static assert(is(typeof(unsigned(cast(T)1)) == ulong));
+        static assert(is(typeof(unsigned(cast(const T)1)) == ulong));
+        static assert(is(typeof(unsigned(cast(immutable T)1)) == ulong));
+    }
 }
 
 auto unsigned(T)(T x) if (isSomeChar!T)
 {
     // All characters are unsigned
     static assert(T.min == 0);
-    return x;
+    return cast(Unqual!T) x;
+}
+
+unittest
+{
+    foreach(T; TypeTuple!(char, wchar, dchar))
+    {
+        static assert(is(typeof(unsigned(cast(T)'A')) == T));
+        static assert(is(typeof(unsigned(cast(const T)'A')) == T));
+        static assert(is(typeof(unsigned(cast(immutable T)'A')) == T));
+    }
 }
 
 /**
 Returns the most negative value of the numeric type T.
 */
 template mostNegative(T)
+    if(isNumeric!T || isSomeChar!T)
 {
     static if (is(typeof(T.min_normal)))
         enum mostNegative = -T.max;
@@ -4294,9 +4331,15 @@ template mostNegative(T)
 
 unittest
 {
-    static assert(mostNegative!(float) == -float.max);
-    static assert(mostNegative!(uint) == 0);
-    static assert(mostNegative!(long) == long.min);
+    static assert(mostNegative!float == -float.max);
+    static assert(mostNegative!double == -double.max);
+    static assert(mostNegative!real == -real.max);
+
+    foreach(T; TypeTuple!(byte, short, int, long))
+        static assert(mostNegative!T == T.min);
+
+    foreach(T; TypeTuple!(ubyte, ushort, uint, ulong, char, wchar, dchar))
+        static assert(mostNegative!T == 0);
 }
 
 


### PR DESCRIPTION
unsigned was severely lacking in unit tests. This remedies that. It also
makes its return types more consistent. Previously, in the case of
signed values, the return type was their Unqualed, unsigned counterpart,
whereas in the case of unsigned values, the return type was exactly the
same as the type passed in. Now, it's the Unqualed, unsigned type in all
cases.

My one concern here is whether `unsigned` should always return the Unqualed version or always return a type with exactly the same attributes but unsigned instead of signed. Since, it's dealing with value types which implicitly convert to their const, immutable, and/or shared counterparts, I believe that it's fine to return the Unqualed version, but someone might else might be able to come up with a reason why that isn't so. Regardless, this _will_ affect code which calls `unsigned` with an unsigned type and uses auto. There's no avoiding that.

Oh, and I also added a template constraint to `mostNegative`, since as far as I can tell, it's only supposed to work with numeric and character types.
