### PR TITLE
Fix flaky TaskPool.finish() unittest.

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4057,9 +4057,9 @@ unittest
         pool1.put(tSlow);
         pool1.finish();
         assert(!tSlow.done);
-        tSlow.yieldForce();
-        slowFun(); // allow work loop time to notice there are no more tasks
-        assert(pool1.status == TaskPool.PoolState.stopNow);
+        // TODO: come up with a deterministic way for testing terminal state
+        // of TaskPool in this non-blocking case.
+        //assert(pool1.status == TaskPool.PoolState.stopNow);
 
         auto pool2 = new TaskPool();
         auto tSlow2 = task!slowFun();


### PR DESCRIPTION
Fix intermittent failure on std.parallelism related to recent change for Issue 8214.

I haven't been able to reproduce the problem, but from reading code there was obvious race condition.  After last task completes there is a minute time before work loop attempts to pop next task, sees there are no more, and sets TaskPool state to stopped.
