### PR TITLE
Stop using `auto ref` to distinguish lvalue and rvalue.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1822,9 +1822,8 @@ unittest
 
     struct S4
     {
-        void opAssign(U)(auto ref U u)
-            if (!__traits(isRef, u))
-        {}
+        void opAssign(U)(U u) {}
+        @disable void opAssign(U)(ref U u);
     }
     static assert( hasElaborateAssign!S4);
 }


### PR DESCRIPTION
This is a supplemental change of <a href="https://github.com/D-Programming-Language/dmd/pull/1019">dmd/pull/1019</a>, but this commit doesn't need the compiler change.
