### PR TITLE
Adding arity traits

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -379,7 +379,7 @@ static assert(arity!bar==1);
 template arity(alias func) 
     if ( isCallable!func && variadicFunctionStyle!func == Variadic.no ) 
 {
-	enum uint arity = (ParameterTypeTuple!func).length;
+	enum size_t arity = (ParameterTypeTuple!func).length;
 }
 
 unittest {


### PR DESCRIPTION
First minimal addition to _std.traits_.
Adding an _arity_ template returning the number of argument of a function.

Maybe it should go to std.functional instead ?
