### PR TITLE
Fix for issue# 8334:  find cannot handle close match at end of haystack in needle isn't bi-directional

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -3102,8 +3102,7 @@ unittest
 // non-bidirectional forward range
 R1 find(alias pred = "a == b", R1, R2)(R1 haystack, R2 needle)
 if (isRandomAccessRange!R1 && isForwardRange!R2 && !isBidirectionalRange!R2 &&
-    is(typeof(binaryFun!pred(haystack.front, needle.front)) : bool) &&
-    (isInfinite!R1 || (hasLength!R1 && is(typeof(emptyRange(haystack))))))
+    is(typeof(binaryFun!pred(haystack.front, needle.front)) : bool))
 {
     static if (!is(ElementType!R1 == ElementType!R2))
     {
@@ -3117,7 +3116,7 @@ if (isRandomAccessRange!R1 && isForwardRange!R2 && !isBidirectionalRange!R2 &&
 
         haystack = .find!pred(haystack, needle.front);
 
-        static if (hasLength!R1 && hasLength!R2)
+        static if (hasLength!R1 && hasLength!R2 && is(typeof(emptyRange(haystack))))
         {
             if (needle.length > haystack.length)
                 return emptyRange(haystack);


### PR DESCRIPTION
This was failing with a RangeError:

```
auto haystack = [1, 2, 3, 4, 1, 9, 12, 42];
auto needle = filter!"true"([12, 42, 27]);
assert(find(haystack, needle).empty);
```

This pull request fixes that. It also adds `std.range.emptyRange` as part of it to avoid code duplication in the case where it was necessary to get an empty range from a range which wasn't sliceable.
