### PR TITLE
Add public import for KeepTerminator

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -15,7 +15,7 @@ Authors:   $(WEB digitalmars.com, Walter Bright),
  */
 module std.stdio;
 
-public import core.stdc.stdio;
+public import core.stdc.stdio, std.string : KeepTerminator;
 static import std.c.stdio;
 import std.stdiobase;
 import core.stdc.errno, core.stdc.stddef, core.stdc.stdlib, core.memory,
@@ -942,7 +942,6 @@ Returns the file number corresponding to this object.
 
 /**
 Range that reads one line at a time. */
-    alias std.string.KeepTerminator KeepTerminator;
     /// ditto
     struct ByLine(Char, Terminator)
     {


### PR DESCRIPTION
This commit creates a public import for std.string.KeepTerminator. This
way if you use e.g. byLine() you do not have to import it yourself.
