### PR TITLE
Fix for Issue 5036 -  Remove caching from ranges

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -330,9 +330,7 @@ Implements the homonym function (also known as $(D transform)) present
 in many languages of functional flavor. The call $(D map!(fun)(range))
 returns a range of which elements are obtained by applying $(D fun(x))
 left to right for all $(D x) in $(D range). The original ranges are
-not changed. Evaluation is done lazily. The range returned by $(D map)
-caches the last value such that evaluating $(D front) multiple times
-does not result in multiple calls to $(D fun).
+not changed. Evaluation is done lazily.
 
 Example:
 ----

--- a/std/range.d
+++ b/std/range.d
@@ -4271,37 +4271,26 @@ private:
     alias typeof(compute(State.init, cast(size_t) 1)) ElementType;
     State _state;
     size_t _n;
-    ElementType _cache;
 
 public:
     this(State initial, size_t n = 0)
     {
         this._state = initial;
         this._n = n;
-        this._cache = compute(this._state, this._n);
     }
 
     @property ElementType front()
     {
-        //return ElementType.init;
-        return this._cache;
-    }
-
-    ElementType moveFront()
-    {
-        return move(this._cache);
+        return compute(this._state, this._n);
     }
 
     void popFront()
     {
-        this._cache = compute(this._state, ++this._n);
+        ++this._n;
     }
-
-
 
     ElementType opIndex(size_t n)
     {
-        //return ElementType.init;
         return compute(this._state, n + this._n);
     }
 


### PR DESCRIPTION
- std.algorithm.map's documentation states that map does caching, which is false. The misleading sentence in the documentation was removed.
- std.range.Sequence's caching operations have been removed.
