### PR TITLE
Make std.math compile on non-x86 by stubbing/asserting things out.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2076,6 +2076,8 @@ private:
             DIVBYZERO_MASK = 0x020,
             INVALID_MASK   = 0xF80 // PowerPC has five types of invalid exceptions.
         }
+    } else version (ARM) {
+        // TODO: Fill this in for VFP.
     } else version(SPARC) { // SPARC FSR is a 32bit register
              //(64 bits for Sparc 7 & 8, but high 32 bits are uninteresting).
         enum : int {
@@ -2113,6 +2115,8 @@ private:
                return retval;
             */
            assert(0, "Not yet supported");
+        } else version (ARM) {
+            assert(false, "Not yet supported.");
         } else
             assert(0, "Not yet supported");
     }
@@ -2133,6 +2137,7 @@ private:
         }
     }
 public:
+     version (X86_Any) { // TODO: Lift this version condition when we support !x86.
      /// The result cannot be represented exactly, so rounding occured.
      /// (example: x = sin(0.1); )
      @property bool inexact() { return (flags & INEXACT_MASK) != 0; }
@@ -2144,6 +2149,7 @@ public:
      @property bool divByZero() { return (flags & DIVBYZERO_MASK) != 0; }
      /// A machine NaN was generated. (example: x = real.infinity * 0.0; )
      @property bool invalid() { return (flags & INVALID_MASK) != 0; }
+     }
 }
 
 


### PR DESCRIPTION
This is just a temporary measure until we fill this stuff out for non-x86 architectures.
