### PR TITLE
std.math.exp() should be @trusted because it can fall back to core.stdc.math.exp().

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -923,7 +923,7 @@ creal sqrt(creal z) @safe pure nothrow
  *    $(TR $(TD $(NAN))        $(TD $(NAN))    )
  *  )
  */
-real exp(real x) @safe pure nothrow
+real exp(real x) @trusted pure nothrow
 {
     version(D_InlineAsm_X86)
     {


### PR DESCRIPTION
This is a minor ABI break, but I very much doubt it matters.
