### PR TITLE
Separate phobos unittest compilation in Windows platform

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -342,14 +342,15 @@ $(LIB) : $(SRC_TO_COMPILE) \
 	$(DMD) -lib -of$(LIB) -Xfphobos.json $(DFLAGS) $(SRC_TO_COMPILE) \
 		etc\c\zlib\zlib.lib $(DRUNTIMELIB)
 
-UNITTEST_OBJS= unittest1.obj unittest2.obj unittest3.obj unittest4.obj
+UNITTEST_OBJS= unittest1.obj unittest2.obj unittest3.obj unittest4.obj unittest5.obj
 
 unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest1.obj $(SRC_STD_1_HEAVY)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest2.obj $(SRC_STD_2_HEAVY)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3.obj $(SRC_STD_3)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest4.obj $(SRC_STD_4)
-	$(DMD) $(UDFLAGS) -L/co -unittest unittest.d $(SRC_STD_REST) $(SRC_TO_COMPILE_NOT_STD) $(UNITTEST_OBJS) \
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest5.obj $(SRC_STD_REST)
+	$(DMD) $(UDFLAGS) -L/co -unittest unittest.d $(SRC_TO_COMPILE_NOT_STD) $(UNITTEST_OBJS) \
 		etc\c\zlib\zlib.lib $(DRUNTIMELIB)
 	unittest
 


### PR DESCRIPTION
In the following pull requests, Phobos unittest compilations in Windows fail with "out of memory" error.
To fix the problem, I think this is necessary.

http://d.puremagic.com/test-results/pull.ghtml?runid=222632
http://d.puremagic.com/test-results/pull.ghtml?runid=222228
http://d.puremagic.com/test-results/pull.ghtml?runid=222557
