### PR TITLE
Fix for issue# 8362.

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -16,6 +16,9 @@ $(VERSION 060, ddd mm, 2012, =================================================,
              pass a range by reference.)
         $(LI std.traits: Added KeyType, ValueType, isScalarType, isBasicType, and
              SetFunctionAttributes templates.)
+        $(LI std.traits: isSafe now checks for @safe only rather than @safe and @trusted.
+             Use isSafelyCallable to check for both. Due to bug# 8362, isSafe was badly
+             broken prior to 2.060 anyway, so any code using isSafe should probably be examined.)
         $(LI std.utf: Added overload of codeLength which operates on a string.)
         $(LI Capitalized std.traits.pointerTarget to PointerTarget. Old one is
              scheduled for deprecation.)
@@ -153,6 +156,7 @@ $(VERSION 060, ddd mm, 2012, =================================================,
         $(LI $(BUGZILLA 8264): [std.conv.to] constructing conversion doesn't work with alias this)
         $(LI $(BUGZILLA 8310): writeln of Range of fixed size array)
         $(LI $(BUGZILLA 8323): std.string.chompPrefix does not handle differing string types properly)
+        $(LI $(BUGZILLA 8362): std.traits.isSafe doesn't work with unsafe lamdba functions)
         $(LI $(BUGZILLA 8386): writeln stopped working with wstring)
         $(LI $(BUGZILLA 8398): enforceEx cannot be used with OutOfMemoryError)
     )


### PR DESCRIPTION
"std.traits.isSafe doesn't work with unsafe lamdba functions"

`std.traits.isSafe` seems to have been fairly broken. It's first branch was done completely incorrectly and showed a lack of understanding of how `FunctionAttribute` works, and the second half didn't take into account that the function wouldn't compile if the argument was `@system`. Templatizing the function that it used to test would have fixed it, but I just fixed the first part so that it should work for everything.

The original problem was that something like

```
import std.traits;

struct S{ auto fun() { return 1; } }

void main()
{
  auto s1 = S();
  static assert(!isSafe!({auto r = s1.fun();}));
}
```

didn't compile, since the latter half of `isSafe` didn't work with `@system` at all.
