### PR TITLE
Missing op's in std.algorithm.map

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -439,11 +439,19 @@ template map(fun...) if (fun.length >= 1)
                     return _input.length;
                 }
 
-                alias length opDollar;
+                auto opDollar(size_t dim)()
+                {
+                    return _input.length;
+                }
             }
 
             static if (hasSlicing!R)
             {
+                auto opSlice()
+                {
+                    return typeof(this)(_input[]);
+                }
+
                 auto opSlice(size_t lowerBound, size_t upperBound)
                 {
                     return typeof(this)(_input[lowerBound..upperBound]);


### PR DESCRIPTION
There was opSlice(/_no argument_/) missing from the list of operators, making this code not compile:

void main()
{
  auto vals = [1, 2, 3, 4, 5];
  auto squares = map!("a \* a")(vals[]);  
  writeln(squares[]); //Here: squares []
}

Also, added support for multidimensional opDollar, for writing things such as:
writeln(squares[$-2 .. $])
Which did not work.
