### PR TITLE
better support of foreach for array

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -2491,10 +2491,13 @@ Complexity: $(BIGOH n)
      */
     int opApply(int delegate(ref T) dg)
     {
-        foreach(ref v; _data._payload)
+        if(_data.RefCounted.isInitialized())
         {
-            int result = dg(v);
-            if(result) return result;
+            foreach(ref v; _data._payload)
+            {
+                int result = dg(v);
+                if(result) return result;
+            }
         }
         return 0;
     }
@@ -2507,12 +2510,15 @@ Complexity: $(BIGOH n)
      */
     int opApplyReverse(int delegate(ref T) dg)
     {
-      foreach_reverse(ref v; _data._payload)
-      {
-        int result = dg(v);
-        if(result) return result;
-      }
-      return 0;
+        if(_data.RefCounted.isInitialized())
+        {
+            foreach_reverse(ref v; _data._payload)
+            {
+                int result = dg(v);
+                if(result) return result;
+            }
+        }
+        return 0;
     }
 
 /**


### PR DESCRIPTION
See discussion "foreach ref very broken: fails to call front(val)" here:
http://forum.dlang.org/thread/uoptrrkgfczyozxtkkvi@forum.dlang.org

This fix allows writting things like:
Array!int arr;
foreach(ref a; arr)
  ++a;

In the sense that:
1) arr actually gets modified as intended by ref.
2) "++a" compiles correctly, even though "++front" doesn't allow it.

I think the pull request is complete:
I implemented both opApply and opApplyReverse.
I implemented it both for Array.Range and Array (see: http://forum.dlang.org/thread/rxpbtrawpjzvdfuuwmwp@forum.dlang.org)
I implemented correct behavior for "break" cases.
I documented the public opApply.
I wrote a complete unit test.
I tested && unittested it.

This is my first time doing this, so please forgive me if I did something wrong :(
