### PR TITLE
Added tempFile to std.file.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -3092,9 +3092,18 @@ string tempDir()
         }
         else static assert (false, "Unsupported platform");
 
-        if (cache is null) cache = ".";
+        if (cache is null)
+            cache = ".";
+        else if (cache.endsWith(dirSeparator))
+            cache.popBackN(walkLength(dirSeparator));
     }
     return cache;
+}
+
+unittest
+{
+    assert(tempDir() !is null);
+    assert(!tempDir().endsWith(dirSeparator));
 }
 
 


### PR DESCRIPTION
It generates a random file name in the directory that you tell it to,
defaulting to the result of tempDir.

I'm planning on adding a `tempFile` function to `std.stdio.File` as well which uses this (and replaces `tempdir`, which does _not_ give its `File` a filename and also deletes the file when the `File` is closed - both of which are potentially problems), but I ran into Windows header problems, since in order to implement it correctly (without race conditions), you have to use `open` and `fdopen`, which we don't currently have declarations for on Windows, and I don't want to deal with that right now, so I'm tabling it for the moment.

But this function is still useful, so I'm creating this pull request.
