### PR TITLE
Runnable examples - std.bitmanip, std.complex, std.concurrency, std.cont...

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -6,6 +6,7 @@ Bit-level manipulation facilities.
 Macros:
 
 WIKI = StdBitarray
+BITMANIP_RUN = $(D_RUN_CODE $0, $(ARGS), $(ARGS), $(ARGS import std.bitmanip;))
 
 Copyright: Copyright Digital Mars 2007 - 2011.
 License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
@@ -167,6 +168,7 @@ class)es.
 
 Example:
 
+$(BITMANIP_RUN
 ----
 struct A
 {
@@ -181,6 +183,7 @@ A obj;
 obj.x = 2;
 obj.z = obj.x;
 ----
+)
 
 The example above creates a bitfield pack of eight bits, which fit in
 one $(D_PARAM ubyte). The bitfields are allocated starting from the
@@ -193,6 +196,7 @@ one bitfield with an empty name.
 
 Example:
 
+$(BITMANIP_RUN
 ----
 struct A
 {
@@ -202,6 +206,7 @@ struct A
         uint, "",         6));
 }
 ----
+)
 
 The type of a bit field can be any integral type or enumerated
 type. The most efficient type to store in bitfields is $(D_PARAM
@@ -293,6 +298,7 @@ unittest
    Allows manipulating the fraction, exponent, and sign parts of a
    $(D_PARAM float) separately. The definition is:
 
+$(BITMANIP_RUN
 ----
 struct FloatRep
 {
@@ -307,6 +313,7 @@ struct FloatRep
     enum uint bias = 127, fractionBits = 23, exponentBits = 8, signBits = 1;
 }
 ----
+)
 */
 
 struct FloatRep
@@ -326,6 +333,7 @@ struct FloatRep
    Allows manipulating the fraction, exponent, and sign parts of a
    $(D_PARAM double) separately. The definition is:
 
+$(BITMANIP_RUN
 ----
 struct DoubleRep
 {
@@ -340,6 +348,7 @@ struct DoubleRep
     enum uint bias = 1023, signBits = 1, fractionBits = 52, exponentBits = 11;
 }
 ----
+)
 */
 
 struct DoubleRep
@@ -1517,6 +1526,7 @@ private union EndianSwapper(T)
     unusable if you tried to transfer it to another machine).
 
         Examples:
+$(BITMANIP_RUN
 --------------------
 int i = 12345;
 ubyte[4] swappedI = nativeToBigEndian(i);
@@ -1526,6 +1536,7 @@ double d = 123.45;
 ubyte[8] swappedD = nativeToBigEndian(d);
 assert(d == bigEndianToNative!double(swappedD));
 --------------------
+)
   +/
 auto nativeToBigEndian(T)(T val) @safe pure nothrow
     if(isIntegral!T ||
@@ -1653,6 +1664,7 @@ unittest
     can't actually have swapped floating point values as floating point values).
 
         Examples:
+$(BITMANIP_RUN
 --------------------
 ushort i = 12345;
 ubyte[2] swappedI = nativeToBigEndian(i);
@@ -1662,6 +1674,7 @@ dchar c = 'D';
 ubyte[4] swappedC = nativeToBigEndian(c);
 assert(c == bigEndianToNative!dchar(swappedC));
 --------------------
+)
   +/
 T bigEndianToNative(T, size_t n)(ubyte[n] val) @safe pure nothrow
     if((isIntegral!T ||
@@ -1722,6 +1735,7 @@ private T bigEndianToNativeImpl(T, size_t n)(ubyte[n] val) @safe pure nothrow
     can't actually have swapped floating point values as floating point values).
 
         Examples:
+$(BITMANIP_RUN      
 --------------------
 int i = 12345;
 ubyte[4] swappedI = nativeToLittleEndian(i);
@@ -1731,6 +1745,7 @@ double d = 123.45;
 ubyte[8] swappedD = nativeToLittleEndian(d);
 assert(d == littleEndianToNative!double(swappedD));
 --------------------
+)
   +/
 auto nativeToLittleEndian(T)(T val) @safe pure nothrow
     if(isIntegral!T ||
@@ -1831,6 +1846,7 @@ unittest
     unusable if you tried to transfer it to another machine).
 
         Examples:
+$(BITMANIP_RUN
 --------------------
 ushort i = 12345;
 ubyte[2] swappedI = nativeToLittleEndian(i);
@@ -1840,6 +1856,7 @@ dchar c = 'D';
 ubyte[4] swappedC = nativeToLittleEndian(c);
 assert(c == littleEndianToNative!dchar(swappedC));
 --------------------
+)
   +/
 T littleEndianToNative(T, size_t n)(ubyte[n] val) @safe pure nothrow
     if((isIntegral!T ||
@@ -1931,6 +1948,7 @@ private auto floatEndianImpl(size_t n, bool swap)(ubyte[n] val) @safe pure nothr
                 available if $(D hasSlicing!R) is $(D true).
 
         Examples:
+$(BITMANIP_RUN
 --------------------
 ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
 assert(buffer.peek!uint() == 17110537);
@@ -1951,6 +1969,7 @@ assert(index == 6);
 assert(buffer.peek!ubyte(&index) == 8);
 assert(index == 7);
 --------------------
+)
   +/
 T peek(T, Endian endianness = Endian.bigEndian, R)(R range)
     if(isIntegral!T && isForwardRange!R && is(ElementType!R : const ubyte))
@@ -2052,6 +2071,8 @@ unittest
         range = The range to read from.
 
         Examples:
+$(D_RUN_CODE
+$(ARGS
 --------------------
 ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
 assert(buffer.length == 7);
@@ -2065,6 +2086,7 @@ assert(buffer.length == 1);
 assert(buffer.read!ubyte() == 8);
 assert(buffer.empty);
 --------------------
+), $(ARGS), $(ARGS), $(ARGS import std.bitmanip, std.array;))
   +/
 T read(T, Endian endianness = Endian.bigEndian, R)(ref R range)
     if(isIntegral!T && isInputRange!R && is(ElementType!R : const ubyte))
@@ -2138,6 +2160,7 @@ unittest
                 is updated to the index after the bytes read.
 
         Examples:
+$(BITMANIP_RUN
 --------------------
 //Bug# 8129 forces the casts. They shouldn't be necessary.
 {
@@ -2180,6 +2203,7 @@ unittest
     assert(index == 7);
 }
 --------------------
+)
   +/
 void write(T, Endian endianness = Endian.bigEndian, R)(R range, T value, size_t index)
     if(isIntegral!T &&
@@ -2268,6 +2292,8 @@ unittest
         range = The range to append to.
 
         Examples:
+$(D_RUN_CODE
+$(ARGS
 --------------------
 //Bug# 8129 forces the casts. They shouldn't be necessary.
 auto buffer = appender!(const ubyte[])();
@@ -2280,6 +2306,7 @@ assert(buffer.data == [1, 5, 22, 9, 44, 255]);
 buffer.append!ubyte(cast(ubyte)8);
 assert(buffer.data == [1, 5, 22, 9, 44, 255, 8]);
 --------------------
+), $(ARGS), $(ARGS), $(ARGS import std.bitmanip, std.array;))
   +/
 void append(T, Endian endianness = Endian.bigEndian, R)(R range, T value)
     if(isIntegral!T && isOutputRange!(R, ubyte))

--- a/std/complex.d
+++ b/std/complex.d
@@ -7,6 +7,9 @@
     the built-in types $(D cfloat), $(D cdouble), $(D creal), $(D ifloat),
     $(D idouble), and $(D ireal).
 
+    Macros:
+        COMPLEX_RUN = $(D_RUN_CODE $0, $(ARGS), $(ARGS), $(ARGS import std.complex;))
+
     Authors:    Lars Tandle Kyllingstad, Don Clugston
     Copyright:  Copyright (c) 2010, Lars T. Kyllingstad.
     License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
@@ -28,22 +31,24 @@ import std.traits;
     function returns a $(D Complex!double).  Otherwise, the return type
     is deduced using $(D std.traits.CommonType!(R, I)).
 
-    Examples:
-    ---
-    auto c = complex(2.0);
-    static assert (is(typeof(c) == Complex!double));
-    assert (c.re == 2.0);
-    assert (c.im == 0.0);
+Examples:
+$(COMPLEX_RUN
+---
+auto c = complex(2.0);
+static assert (is(typeof(c) == Complex!double));
+assert (c.re == 2.0);
+assert (c.im == 0.0);
 
-    auto w = complex(2);
-    static assert (is(typeof(w) == Complex!double));
-    assert (w == c);
+auto w = complex(2);
+static assert (is(typeof(w) == Complex!double));
+assert (w == c);
 
-    auto z = complex(1, 3.14L);
-    static assert (is(typeof(z) == Complex!real));
-    assert (z.re == 1.0L);
-    assert (z.im == 3.14L);
-    ---
+auto z = complex(1, 3.14L);
+static assert (is(typeof(z) == Complex!real));
+assert (z.re == 1.0L);
+assert (z.im == 3.14L);
+---
+)
 */
 auto complex(T)(T re)  @safe pure nothrow  if (is(T : double))
 {

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -393,7 +393,7 @@ private:
  *     auto tid1 = spawn(&f1, str);
  *
  *     // Fails:  char[] has mutable aliasing.
- *     auto tid2 = spawn(&f2, str.dup);
+ *     //auto tid2 = spawn(&f2, str.dup);
  * }
  * ---
  *), $(ARGS), $(ARGS), $(ARGS))

--- a/std/container.d
+++ b/std/container.d
@@ -7,6 +7,7 @@ Source: $(PHOBOSSRC std/_container.d)
 Macros:
 WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
+CONTAINER_RUN = $(D_RUN_CODE $0, $(ARGS), $(ARGS), $(ARGS import std.container;))
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
@@ -1214,6 +1215,7 @@ Complexity: $(BIGOH k + m), where $(D k) is the number of elements in
 $(D r) and $(D m) is the length of $(D stuff).
 
 Examples:
+$(CONTAINER_RUN
 --------------------
 auto sl = SList!string(["a", "b", "d"]);
 sl.insertAfter(sl[], "e"); // insert at the end (slowest)
@@ -1221,6 +1223,7 @@ assert(std.algorithm.equal(sl[], ["a", "b", "d", "e"]));
 sl.insertAfter(std.range.take(sl[], 2), "c"); // insert after "b"
 assert(std.algorithm.equal(sl[], ["a", "b", "c", "d", "e"]));
 --------------------
+)
      */
 
     size_t insertAfter(Stuff)(Range r, Stuff stuff)
@@ -3078,6 +3081,7 @@ insertBack), the $(D BinaryHeap) may grow by adding elements to the
 container.
 
 Example:
+$(CONTAINER_RUN
 ----
 // Example from "Introduction to Algorithms" Cormen et al, p 146
 int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
@@ -3085,8 +3089,9 @@ auto h = heapify(a);
 // largest element
 assert(h.front == 16);
 // a has the heap property
-assert(equal(a, [ 16, 14, 10, 9, 8, 7, 4, 3, 2, 1 ]));
+assert(std.algorithm.equal(a, [16, 14, 10, 8, 7, 9, 3, 2, 4, 1]));
 ----
+)
      */
 struct BinaryHeap(Store, alias less = "a < b")
 if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
@@ -5465,6 +5470,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
        Complexity: $(BIGOH m log(n)) (where m is the number of elements to remove)
 
         Examples:
+$(CONTAINER_RUN
 --------------------
 auto rbt = redBlackTree!true(0, 1, 1, 1, 4, 5, 7);
 rbt.removeKey(1, 4, 7);
@@ -5472,6 +5478,7 @@ assert(std.algorithm.equal(rbt[], [0, 1, 1, 5]));
 rbt.removeKey(1, 1, 0);
 assert(std.algorithm.equal(rbt[], [5]));
 --------------------
+)
       +/
     size_t removeKey(U...)(U elems)
         if(allSatisfy!(isImplicitlyConvertibleToElem, U))
@@ -5869,6 +5876,7 @@ unittest
     values.
 
         Examples:
+$(CONTAINER_RUN
 --------------------
 auto rbt1 = redBlackTree(0, 1, 5, 7);
 auto rbt2 = redBlackTree!string("hello", "world");
@@ -5876,6 +5884,7 @@ auto rbt3 = redBlackTree!true(0, 1, 5, 7, 5);
 auto rbt4 = redBlackTree!"a > b"(0, 1, 5, 7);
 auto rbt5 = redBlackTree!("a > b", true)(0.1, 1.3, 5.9, 7.2, 5.9);
 --------------------
+)
   +/
 auto redBlackTree(E)(E[] elems...)
 {

--- a/std/conv.d
+++ b/std/conv.d
@@ -14,6 +14,9 @@ Authors:   $(WEB digitalmars.com, Walter Bright),
            Kenji Hara
 
 Source:    $(PHOBOSSRC std/_conv.d)
+
+Macros:
+CONV_RUN = $(D_RUN_CODE $0, $(ARGS), $(ARGS), $(ARGS import std.conv;))
 */
 module std.conv;
 
@@ -150,11 +153,13 @@ Converting a value to its own type (useful mostly for generic code)
 simply returns its argument.
 
 Example:
+$(CONV_RUN
 -------------------------
 int a = 42;
 auto b = to!int(a); // b is int with value 42
 auto c = to!double(3.14); // c is double with value 3.14
 -------------------------
+)
 
 Converting among numeric types is a safe way to cast them around.
 
@@ -165,6 +170,7 @@ truncate. (To round a floating point value when casting to an
 integral, use $(D_PARAM roundTo).)
 
 Examples:
+$(CONV_RUN
 -------------------------
 int a = 420;
 auto b = to!long(a); // same as long b = a;
@@ -181,7 +187,7 @@ h = to!uint(a); // h = 3
 e = -3.99;
 f = to!int(a); // f = -3
 -------------------------
-
+)
 Conversions from integral types to floating-point types always
 succeed, but might lose accuracy. The largest integers with a
 predecessor representable in floating-point format are 2^24-1 for
@@ -189,6 +195,7 @@ float, 2^53-1 for double, and 2^64-1 for $(D_PARAM real) (when
 $(D_PARAM real) is 80-bit, e.g. on Intel machines).
 
 Example:
+$(CONV_RUN
 -------------------------
 int a = 16_777_215; // 2^24 - 1, largest proper integer representable as float
 assert(to!int(to!float(a)) == a);
@@ -196,6 +203,7 @@ assert(to!int(to!float(-a)) == -a);
 a += 2;
 assert(to!int(to!float(a)) == a); // fails!
 -------------------------
+)
 
 Conversions from string to numeric types differ from the C equivalents
 $(D_PARAM atoi()) and $(D_PARAM atol()) by checking for overflow and
@@ -222,6 +230,7 @@ element in turn. Associative arrays can be converted to associative
 arrays as long as keys and values can in turn be converted.
 
 Example:
+$(CONV_RUN
 -------------------------
 int[] a = ([1, 2, 3]).dup;
 auto b = to!(float[])(a);
@@ -235,16 +244,17 @@ c["b"] = 2;
 auto d = to!(double[wstring])(c);
 assert(d["a"w] == 1 && d["b"w] == 2);
 -------------------------
+)
 
 Conversions operate transitively, meaning that they work on arrays and
 associative arrays of any complexity:
-
+$(CONV_RUN
 -------------------------
 int[string][double[int[]]] a;
-...
+//...
 auto b = to!(short[wstring][string[double[]]])(a);
 -------------------------
-
+)
 This conversion works because $(D_PARAM to!short) applies to an
 $(D_PARAM int), $(D_PARAM to!wstring) applies to a $(D_PARAM
 string), $(D_PARAM to!string) applies to a $(D_PARAM double), and
@@ -431,7 +441,7 @@ class Date
     {
         return timestamp;
     }
-    ...
+    //...
 }
 
 unittest
@@ -1626,6 +1636,7 @@ unittest
  Rounded conversion from floating point to integral.
 
 Example:
+$(CONV_RUN
 ---------------
 assert(roundTo!int(3.14) == 3);
 assert(roundTo!int(3.49) == 3);
@@ -1636,6 +1647,7 @@ assert(roundTo!int(-3.49) == -3);
 assert(roundTo!int(-3.5) == -4);
 assert(roundTo!int(-3.999) == -4);
 ---------------
+)
 Rounded conversions do not work with non-integral target types.
  */
 
@@ -1682,17 +1694,19 @@ unittest
  * was meaningfully converted.
  *
  * Example:
+ $(CONV_RUN
 --------------
 string test = "123 \t  76.14";
 auto a = parse!uint(test);
 assert(a == 123);
 assert(test == " \t  76.14"); // parse bumps string
-munch(test, " \t\n\r"); // skip ws
+std.string.munch(test, " \t\n\r"); // skip ws
 assert(test == "76.14");
 auto b = parse!double(test);
 assert(b == 76.14);
 assert(test == "");
 --------------
+)
  */
 
 Target parse(Target, Source)(ref Source s)
@@ -3031,11 +3045,13 @@ Target parseElement(Target, Source)(ref Source s)
    arguments into _text (the three character widths).
 
    Example:
+$(CONV_RUN   
 ----
 assert(text(42, ' ', 1.5, ": xyz") == "42 1.5: xyz");
 assert(wtext(42, ' ', 1.5, ": xyz") == "42 1.5: xyz"w);
 assert(dtext(42, ' ', 1.5, ": xyz") == "42 1.5: xyz"d);
 ----
+)
 */
 string text(T...)(T args)
 {
@@ -3086,6 +3102,7 @@ U) or $(D u) suffix. _Octals created from integers preserve the type
 of the passed-in integral.
 
 Example:
+$(CONV_RUN
 ----
 // same as 0177
 auto x = octal!177;
@@ -3094,6 +3111,7 @@ enum y = octal!160;
 // Create an unsigned octal
 auto z = octal!"1_000_000u";
 ----
+)
  */
 @property int octal(string num)()
     if((octalFitsInInt!(num) && !literalIsLong!(num)) && !literalIsUnsigned!(num))

--- a/std/csv.d
+++ b/std/csv.d
@@ -1,6 +1,9 @@
 //Written in the D programming language
 
 /**
+ * Macros:
+ *       CSV_RUN = $(D_RUN_CODE $0, $(ARGS), $(ARGS), $(ARGS import std.csv;))
+ *
  * Implements functionality to read Comma Separated Values and its variants
  * from a input range of $(D dchar).
  *
@@ -23,40 +26,54 @@
  *
  * Example:
  *
+ *$(D_RUN_CODE
+ *$(ARGS
  * -------
- * import std.algorithm;
- * import std.array;
- * import std.csv;
- * import std.stdio;
- * import std.typecons;
+ *import std.algorithm;
+ *import std.array;
+ *import std.csv;
+ *import std.stdio;
+ *import std.typecons;
  *
- * void main()
- * {
- *     auto text = "Joe,Carpenter,300000\nFred,Blacksmith,400000\r\n";
+ *void main()
+ *{
+ *    auto text = "Joe,Carpenter,300000\nFred,Blacksmith,400000\r\n";
  *
- *     foreach(record; csvReader!(Tuple!(string,string,int))(text))
- *     {
- *         writefln("%s works as a %s and earns $%d per year",
- *                  record[0], record[1], record[2]);
- *     }
+ *    foreach(record; csvReader!(Tuple!(string,string,int))(text))
+ *    {
+ *        writefln("%s works as a %s and earns $%d per year",
+ *                 record[0], record[1], record[2]);
+ *    }
  * }
  * -------
- *
+ *),$(ARGS),$(ARGS),$(ARGS))
  * When an input contains a header the $(D Contents) can be specified as an
  * associative array. Passing null to signify that a header is present.
  *
+ *$(D_RUN_CODE
+ *$(ARGS
  * -------
- * auto text = "Name,Occupation,Salary\r"
- *     "Joe,Carpenter,300000\nFred,Blacksmith,400000\r\n";
+ *import std.algorithm;
+ *import std.array;
+ *import std.csv;
+ *import std.stdio;
+ *import std.typecons;
  *
- * foreach(record; csvReader!(string[string])
- *         (text, null))
- * {
- *     writefln("%s works as a %s and earns $%s per year.",
- *              record["Name"], record["Occupation"],
- *              record["Salary"]);
- * }
+ *void main()
+ *{
+ *      auto text = "Name,Occupation,Salary\r"
+ *          "Joe,Carpenter,300000\nFred,Blacksmith,400000\r\n";
+ *
+ *      foreach(record; csvReader!(string[string])
+ *              (text, null))
+ *      {
+ *          writefln("%s works as a %s and earns $%s per year.",
+ *                  record["Name"], record["Occupation"],
+ *                  record["Salary"]);
+ *      }
+ *}
  * -------
+ *),$(ARGS),$(ARGS),$(ARGS))
  *
  * This module allows content to be iterated by record stored in a struct,
  * class, associative array, or as a range of fields. Upon detection of an
@@ -219,6 +236,7 @@ enum Malformed
  * The $(D Contents) of the input can be provided if all the records are the
  * same type such as all integer data:
  *
+ *$(CSV_RUN
  * -------
  * string str = `76,26,22`;
  * int[] ans = [76,26,22];
@@ -226,12 +244,14 @@ enum Malformed
  *
  * foreach(record; records)
  * {
- *     assert(equal(record, ans));
+ *     assert(std.algorithm.equal(record, ans));
  * }
  * -------
+ *)
  *
  * Example using a struct with modified delimiter:
  *
+ *$(CSV_RUN
  * -------
  * string str = "Hello;65;63.63\nWorld;123;3673.562";
  * struct Layout
@@ -245,16 +265,18 @@ enum Malformed
  *
  * foreach(record; records)
  * {
- *     writeln(record.name);
- *     writeln(record.value);
- *     writeln(record.other);
+ *     std.stdio.writeln(record.name);
+ *     std.stdio.writeln(record.value);
+ *     std.stdio.writeln(record.other);
  * }
  * -------
+ *)
  *
  * Specifying $(D ErrorLevel) as Malformed.ignore will lift restrictions
  * on the format. This example shows that an exception is not thrown when
  * finding a quote in a field not quoted.
  *
+ *$(CSV_RUN
  * -------
  * string str = "A \" is now part of the data";
  * auto records = csvReader!(string,Malformed.ignore)(str);
@@ -262,6 +284,7 @@ enum Malformed
  *
  * assert(record.front == str);
  * -------
+ *)
  *
  * Returns:
  *        An input range R as defined by $(XREF range, isInputRange). When $(D
@@ -300,6 +323,8 @@ auto csvReader(Contents = string,Malformed ErrorLevel = Malformed.throwException
  *
  * Read only column "b":
  *
+ *$(D_RUN_CODE
+ *$(ARGS
  * -------
  * string str = "a,b,c\nHello,65,63.63\nWorld,123,3673.562";
  * auto records = csvReader!int(str, ["b"]);
@@ -311,9 +336,11 @@ auto csvReader(Contents = string,Malformed ErrorLevel = Malformed.throwException
  *     ans.popFront();
  * }
  * -------
+ *), $(ARGS), $(ARGS), $(ARGS import std.csv, std.array, std.algorithm;))
  *
  * Read from header of different order:
  *
+ *$(CSV_RUN
  * -------
  * string str = "a,b,c\nHello,65,63.63\nWorld,123,3673.562";
  * struct Layout
@@ -325,17 +352,20 @@ auto csvReader(Contents = string,Malformed ErrorLevel = Malformed.throwException
  *
  * auto records = csvReader!Layout(str, ["b","c","a"]);
  * -------
+ *)
  *
  * The header can also be left empty if the input contains a header but
  * all columns should be iterated. The header from the input can always
  * be accessed from the header field.
  *
+ *$(CSV_RUN
  * -------
  * string str = "a,b,c\nHello,65,63.63\nWorld,123,3673.562";
  * auto records = csvReader(str, null);
  *
  * assert(records.header == ["a","b","c"]);
  * -------
+ *)
  *
  * Returns:
  *        An input range R as defined by $(XREF range, isInputRange). When $(D
@@ -346,12 +376,14 @@ auto csvReader(Contents = string,Malformed ErrorLevel = Malformed.throwException
  *        The returned range provides a header field for accessing the header
  *        from the input in array form.
  *
+ *$(CSV_RUN
  * -------
  * string str = "a,b,c\nHello,65,63.63";
  * auto records = csvReader(str, ["a"]);
  *
  * assert(records.header == ["a","b","c"]);
  * -------
+ *)
  *
  * Throws:
  *       $(LREF CSVException) When a quote is found in an unquoted field,
@@ -732,6 +764,7 @@ private struct Input(Range, Malformed ErrorLevel)
  *
  * Example for integer data:
  *
+ *$(CSV_RUN
  * -------
  * string str = `76;^26^;22`;
  * int[] ans = [76,26,22];
@@ -742,6 +775,7 @@ private struct Input(Range, Malformed ErrorLevel)
  *    assert(equal(record, ans));
  * }
  * -------
+ *)
  *
  */
 private struct CsvReader(Contents, Malformed ErrorLevel, Range, Separator, Header)
@@ -770,13 +804,14 @@ private:
 public:
     /**
      * Header from the input in array form.
-     *
+     *$(CSV_RUN
      * -------
      * string str = "a,b,c\nHello,65,63.63";
      * auto records = csvReader(str, ["a"]);
      *
      * assert(records.header == ["a","b","c"]);
      * -------
+     *)
      */
     string[] header;
 
@@ -784,6 +819,7 @@ public:
      * Constructor to initialize the input, delimiter and quote for input
      * without a header.
      *
+     *$(CSV_RUN
      * -------
      * string str = `76;^26^;22`;
      * int[] ans = [76,26,22];
@@ -794,6 +830,8 @@ public:
      *    assert(equal(record, ans));
      * }
      * -------
+     *)
+     *
      */
     this(Range input, Separator delimiter, Separator quote)
     {
@@ -809,6 +847,7 @@ public:
      * Constructor to initialize the input, delimiter and quote for input
      * with a header.
      *
+     *$(CSV_RUN
      * -------
      * string str = `high;mean;low\n76;^26^;22`;
      * auto records = CsvReader!(int,Malformed.ignore,string,char,string[])
@@ -819,6 +858,7 @@ public:
      *    assert(equal(record, ans));
      * }
      * -------
+     *)
      *
      * Throws:
      *       $(LREF HeaderMismatchException)  when a header is provided but a
@@ -1273,6 +1313,8 @@ public:
  * start with either a delimiter or record break (\n, \r\n, \r) which
  * must be removed for subsequent calls.
  *
+ *$(D_RUN_CODE
+ *$(ARGS
  * -------
  * string str = "65,63\n123,3673";
  *
@@ -1294,6 +1336,7 @@ public:
  * assert(a.data == "123");
  * assert(str == ",3673");
  * -------
+ *), $(ARGS), $(ARGS), $(ARGS import std.csv, std.array;))
  *
  * params:
  *       input = Any CSV input


### PR DESCRIPTION
...ainer, std.conv, std.csv

Continuation.

Demo: http://dlang.dzfl.pl/phobos/
Important: some examples like http://dlang.dzfl.pl/phobos/std_bitmanip.html#peek fail now, that's because dlang examples run on release branch of compiler, so at the moment it's 2.059, while this example is from phobos 2.060.

All examples were tested on my local machine against 2.060 so they will work correctly when dmd2.060 is out and we will switch to 2.060 compiler and publish phobos docs.
