### PR TITLE
Undo workaround for bug 7898

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -5658,8 +5658,6 @@ if (isInputRange!Range1 && isOutputRange!(Range2, ElementType!Range1))
 
         return target;
     }
-    if (__ctfe)
-        return genericImpl(source, target);
 
     static if (isArray!Range1 && isArray!Range2 &&
                is(Unqual!(typeof(source[0])) == Unqual!(typeof(target[0]))))


### PR DESCRIPTION
Undo commit 12a866f03, which was a fix for 7898 "[CTFE] std.algorithm:copy fails when used with two arrays."

The workaround is unnecessary now that 8216 "CTFE should allow 'pointer is inside range' comparisons" has been implemented in the compiler.
