### PR TITLE
c[a, b] should be c[a .. b]

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -47,7 +47,7 @@ type associated with the _container.))
 $(TR $(TD $(D c[])) $(TDNW $(D log n$(SUB c))) $(TD Returns a range
 iterating over the entire _container, in a _container-defined order.))
 
-$(TR $(TDNW $(D c[a, b])) $(TDNW $(D log n$(SUB c))) $(TD Fetches a
+$(TR $(TDNW $(D c[a .. b])) $(TDNW $(D log n$(SUB c))) $(TD Fetches a
 portion of the _container from key $(D a) to key $(D b).))
 
 $(LEADINGROW Capacity)


### PR DESCRIPTION
in std.container, Container has member opSlice(a, b), but the table lists Container as supporting c[a, b], which translates to a call to opIndex, which Container does not support.
