### PR TITLE
Changes required for issue# 6277.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -777,7 +777,7 @@ unittest
     assert(r1 == 107);
 
     // two funs
-    auto r2 = reduce!("a + b", "a - b")(tuple(0., 0.), a);
+    auto r2 = reduce!("a + b", "a - b")(tuple(0.0, 0.0), a);
     assert(r2[0] == 7 && r2[1] == -7);
     auto r3 = reduce!("a + b", "a - b")(a);
     assert(r3[0] == 7 && r3[1] == -1);
@@ -4891,7 +4891,7 @@ assert(!equal(a, a[1..$]));
 assert(equal(a, a));
 
 // different types
-double[] b = [ 1., 2, 4, 3];
+double[] b = [ 1.0, 2, 4, 3];
 assert(!equal(a, b[1..$]));
 assert(equal(a, b));
 
@@ -4920,7 +4920,7 @@ unittest
     assert(!equal(a, a[1..$]));
     assert(equal(a, a));
     // test with different types
-    double[] b = [ 1., 2, 4, 3];
+    double[] b = [ 1.0, 2, 4, 3];
     assert(!equal(a, b[1..$]));
     assert(equal(a, b));
 
@@ -5339,7 +5339,7 @@ sgi.com/tech/stl/_mismatch.html, STL's _mismatch).
 Example:
 ----
 int[]    x = [ 1,  5, 2, 7,   4, 3 ];
-double[] y = [ 1., 5, 2, 7.3, 4, 8 ];
+double[] y = [ 1.0, 5, 2, 7.3, 4, 8 ];
 auto m = mismatch(x, y);
 assert(m[0] == x[3 .. $]);
 assert(m[1] == y[3 .. $]);
@@ -5363,7 +5363,7 @@ unittest
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
     // doc example
     int[]    x = [ 1,  5, 2, 7,   4, 3 ];
-    double[] y = [ 1., 5, 2, 7.3, 4, 8 ];
+    double[] y = [ 1.0, 5, 2, 7.3, 4, 8 ];
     auto m = mismatch(x, y);
     assert(m[0] == [ 7, 4, 3 ]);
     assert(m[1] == [ 7.3, 4, 8 ]);
@@ -8738,7 +8738,7 @@ version(unittest)
         double[] result;
         foreach (i; rndstuff!(int)())
         {
-            result ~= i / 50.;
+            result ~= i / 50.0;
         }
         return result;
     }
@@ -8974,7 +8974,7 @@ unittest
     largestPartialIntersection(a, b, SortOutput.yes);
     //sort(b);
     //writeln(b);
-    assert(b == [ tuple(7., 4u), tuple(1., 3u) ][], text(b));
+    assert(b == [ tuple(7.0, 4u), tuple(1.0, 3u) ][], text(b));
     assert(a[0].empty);
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -128,7 +128,7 @@ unittest
     auto c = array([new C(1), new C(2)][]);
     //writeln(c);
 
-    auto d = array([1., 2.2, 3][]);
+    auto d = array([1.0, 2.2, 3][]);
     assert(is(typeof(d) == double[]));
     //writeln(d);
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -2467,7 +2467,7 @@ unittest
         assert(to!Float("123e2") == Literal!Float(123e2));
         assert(to!Float("123e+2") == Literal!Float(123e+2));
         assert(to!Float("123e-2") == Literal!Float(123e-2));
-        assert(to!Float("123.") == Literal!Float(123.));
+        assert(to!Float("123.") == Literal!Float(123.0));
         assert(to!Float(".456") == Literal!Float(.456));
 
         assert(to!Float("1.23456E+2") == Literal!Float(1.23456E+2));

--- a/std/format.d
+++ b/std/format.d
@@ -3002,7 +3002,7 @@ unittest
     assert(stream.data == "  12.68:");
     stream.clear();
 
-    formattedWrite(stream, "%04f|%05d|%#05x|%#5x",-4.,-10,1,1);
+    formattedWrite(stream, "%04f|%05d|%#05x|%#5x",-4.0,-10,1,1);
     assert(stream.data == "-4.000000|-0010|0x001|  0x1",
             stream.data);
     stream.clear();
@@ -5405,7 +5405,7 @@ unittest
     s = std.string.format("%7.4g:", 12.678L);
     assert(s == "  12.68:");
 
-    s = std.string.format("%04f|%05d|%#05x|%#5x",-4.,-10,1,1);
+    s = std.string.format("%04f|%05d|%#05x|%#5x",-4.0,-10,1,1);
     assert(s == "-4.000000|-0010|0x001|  0x1");
 
     i = -10;

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1206,8 +1206,8 @@ euclideanDistance(Range1, Range2, F)(Range1 a, Range2 b, F limit)
 
 unittest
 {
-    double[] a = [ 1., 2., ];
-    double[] b = [ 4., 6., ];
+    double[] a = [ 1.0, 2.0, ];
+    double[] b = [ 4.0, 6.0, ];
     assert(euclideanDistance(a, b) == 5);
     assert(euclideanDistance(a, b, 5) == 5);
     assert(euclideanDistance(a, b, 4) == 5);
@@ -1291,8 +1291,8 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
 
 unittest
 {
-    double[] a = [ 1., 2., ];
-    double[] b = [ 4., 6., ];
+    double[] a = [ 1.0, 2.0, ];
+    double[] b = [ 4.0, 6.0, ];
     assert(dotProduct(a, b) == 16);
     assert(dotProduct([1, 3, -5], [4, -2, -1]) == 3);
 
@@ -1335,8 +1335,8 @@ cosineSimilarity(Range1, Range2)(Range1 a, Range2 b)
 
 unittest
 {
-    double[] a = [ 1., 2., ];
-    double[] b = [ 4., 3., ];
+    double[] a = [ 1.0, 2.0, ];
+    double[] b = [ 4.0, 3.0, ];
     // writeln(cosineSimilarity(a, b));
     // writeln(10.0 / sqrt(5.0 * 25));
     assert(approxEqual(
@@ -1396,10 +1396,10 @@ unittest
 {
     double[] a = [];
     assert(!normalize(a));
-    a = [ 1., 3. ];
+    a = [ 1.0, 3.0 ];
     assert(normalize(a));
     assert(a == [ 0.25, 0.75 ]);
-    a = [ 0., 0. ];
+    a = [ 0.0, 0.0 ];
     assert(!normalize(a));
     assert(a == [ 0.5, 0.5 ]);
 }
@@ -1800,7 +1800,7 @@ unittest
     assert(gapWeightedSimilarity(t, t, 1) == 7);
     assert(gapWeightedSimilarity(s, t, 1) == 7);
     assert(approxEqual(gapWeightedSimilarityNormalized(s, t, 1),
-                    7. / sqrt(15. * 7), 0.01));
+                    7.0 / sqrt(15.0 * 7), 0.01));
 }
 
 /**
@@ -2055,14 +2055,14 @@ unittest
             ["nyuk", "I", "have", "no", "chocolate", "giba"],
             ["wyda", "I", "have", "I", "have", "have", "I", "have", "hehe"],
             0.5);
-    double witness[] = [ 7., 4.03125, 0, 0 ];
+    double witness[] = [ 7.0, 4.03125, 0, 0 ];
     foreach (e; sim)
     {
         //writeln(e);
         assert(e == witness.front);
         witness.popFront();
     }
-    witness = [ 3., 1.3125, 0.25 ];
+    witness = [ 3.0, 1.3125, 0.25 ];
     sim = GapWeightedSimilarityIncremental!(string[])(
         ["I", "have", "no", "chocolate"],
         ["I", "have", "some", "chocolate"],

--- a/std/random.d
+++ b/std/random.d
@@ -1111,7 +1111,7 @@ unittest
     MinstdRand0 gen;
     foreach (i; 0 .. 20)
     {
-        auto x = uniform(0., 15., gen);
+        auto x = uniform(0.0, 15.0, gen);
         assert(0 <= x && x < 15);
     }
     foreach (i; 0 .. 20)

--- a/std/range.d
+++ b/std/range.d
@@ -4241,7 +4241,7 @@ unittest
     auto fact = recurrence!("n * a[n-1]")(1);
     assert( equal(take(fact, 10), [1, 1, 2, 2*3, 2*3*4, 2*3*4*5, 2*3*4*5*6,
                             2*3*4*5*6*7, 2*3*4*5*6*7*8, 2*3*4*5*6*7*8*9][]) );
-    auto piapprox = recurrence!("a[n] + (n & 1 ? 4. : -4.) / (2 * n + 3)")(4.);
+    auto piapprox = recurrence!("a[n] + (n & 1 ? 4.0 : -4.0) / (2 * n + 3)")(4.0);
     foreach (e; take(piapprox, 20)) {}
     // Thanks to yebblies for this test and the associated fix
     auto r = recurrence!"a[n-2]"(1, 2);


### PR DESCRIPTION
This fixes it so that Phobos doesn't use any floating point literals which end with a decimal point, which is required if [dmd pull request 1061](https://github.com/D-Programming-Language/dmd/pull/1061) gets merged in. But these changes do not require that the dmd pull request be accepted. They're just adding 0's after the trailing decimal points.
