### PR TITLE
Fixes in std algorithm:

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -8955,7 +8955,7 @@ version(unittest)
     private class ReferenceForwardRange(T) : ReferenceInputRange!T
     {
         this(Range)(Range r) if (isInputRange!Range) {super(r);}
-        final ReferenceForwardRange save()
+        final @property ReferenceForwardRange save()
         {return new ReferenceForwardRange!T(_payload);}
     }
 
@@ -8973,7 +8973,7 @@ version(unittest)
     private class ReferenceInfiniteForwardRange(T) : ReferenceInfiniteInputRange!T
     {
         this(T first = T.init) {super(first);}
-        final ReferenceInfiniteForwardRange save()
+        final @property ReferenceInfiniteForwardRange save()
         {return new ReferenceInfiniteForwardRange!T(_val);}
     }
 }


### PR DESCRIPTION
This is the same pull request as before, from a newer cleaner parallel branch, with a single commit.

*Tuning of map for "opIndex", "opSlice"
*map "length" does not check isSomeString, since "hasLength" is enough => maps of dstrings are ibdexable
*Fill is more efficient, accepts infinite inpute length
*adjacentFind: Correctly saves
*minCount: Using value types (and not reference types). Throws on empty range
*minPos: Correcttly saves
*equal: More efficient implementation

*New reference type ranges, for more thorough unit tests.
*Unit tests for all the above
