### PR TITLE
Small fixes in RefCounted

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2479,12 +2479,26 @@ Assignment operators
     void opAssign(typeof(this) rhs)
     {
         swap(RefCounted._store, rhs.RefCounted._store);
+
+        //Take this opportunity to check this is initialized for autoInit == yes
+        static if (autoInit == RefCountedAutoInitialize.yes)
+        {
+            RefCounted.ensureInitialized();
+        }
     }
 
 /// Ditto
     void opAssign(T rhs)
     {
-        RefCounted._store._payload = move(rhs);
+        static if (autoInit == RefCountedAutoInitialize.yes)
+        {
+            RefCounted.ensureInitialized();
+        }
+        else
+        {
+            assert(RefCounted.isInitialized);
+        }
+        move(rhs, RefCounted._store._payload);
     }
 
 /**


### PR DESCRIPTION
I was originally trying to fix a bug in Array when copying it.

Allows Fix allws this to work correctly:
RefCounted!(int, RefCountedAutoInitialize.yes) a;
a = 5;

(this used to create an access violation)
In the case of a non-autoInit, it will create an assert (as opposed to an access violation)

Better move optimization for opAssign(T)
Enforce initialization in opAssign(RefCounted) when autoInit == yes
