### PR TITLE
Small fix for opAssign(T)

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2484,7 +2484,15 @@ Assignment operators
 /// Ditto
     void opAssign(T rhs)
     {
-        RefCounted._store._payload = move(rhs);
+        static if (autoInit == RefCountedAutoInitialize.yes)
+        {
+            RefCounted.ensureInitialized();
+        }
+        else
+        {
+            assert(RefCounted.isInitialized);
+        }
+        move(rhs, RefCounted._store._payload);
     }
 
 /**
@@ -2591,6 +2599,17 @@ unittest
     }
 
     alias RefCounted!S SRC;
+}
+
+unittest
+{
+    RefCounted!int a;
+    a = 5; //This should not assert
+    assert(a == 5);
+
+    RefCounted!int b;
+    b = a; //This should not assert either
+    assert(b == 5);
 }
 
 /**


### PR DESCRIPTION
Just a quick patch for opAssign(T)

This either:
*Asserts not initialized and autoInit==No (instead of doing an straight up access violation)
*calls "ensuresInitialized" if autoInit==Yes (making it work, instead of doing an access violation)

Uses "move(a, b)" instead of "b = move(a)" for slightly increased performance

Contains a stupid and small unittest, but covers as-of-yet uncovered basic usage
