### PR TITLE
Fixes in std algorithm

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -441,7 +441,7 @@ private struct MapResult(alias fun, Range)
         }
     }
 
-    static if (hasLength!R)
+    static if (hasLength!R || isSomeString!R)
     {
         @property auto length()
         {


### PR DESCRIPTION
_Merged & Squashed_

This is the same pull request as before, from a newer cleaner parallel branch, with a single commit.

*Tuning of map for "opIndex", "opSlice"
*map "length" does not check isSomeString, since "hasLength" is enough => maps of dstrings are indexable
*Fill is more efficient, accepts infinite inpute length
*adjacentFind: Correctly saves
*minCount: Using value types (and not reference types). Throws on empty range
*minPos: Correcttly saves
*equal: More efficient implementation

*New reference type ranges, for more thorough unit tests.
*Unit tests for all the above
