### PR TITLE
Usefull generic stuff: getMemberType and FieldNameTuple

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2246,7 +2246,7 @@ version(none) unittest
 
 /// getMemberType
 /**
-*   Retrieves member type with $(D name) of class $(D Class). If member is agregate 
+*   Retrieves member type with $(D name) of aggregate type $(D Class). If member is agregate 
 *   type declaration or simply doesn't exist, retrieves no type. You can check it with
 *   $(D is) operator.
 *


### PR DESCRIPTION
Added two new templates to std.traits.d: getMemberType and FieldNameTuple.
getMemberType retrieves member type of aggregate type. If member is agregate 
type declaration or simply doesn't exist, retrieves no type.
FieldNameTuple retrieves names of all aggregate type fields excluding technical ones like this, Monitor.
