### PR TITLE
Supplemental change for dmd/pull/1087 (fix Issue 8339)

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -2270,19 +2270,19 @@ template hasToString(T, Char)
         // X* does not have toString, even if X is aggregate type has toString.
         enum hasToString = 0;
     }
-    else static if (is(typeof({ T val; FormatSpec!Char f; val.toString((const(char)[] s){}, f); })))
+    else static if (is(typeof({ T val = void; FormatSpec!Char f; val.toString((const(char)[] s){}, f); })))
     {
         enum hasToString = 4;
     }
-    else static if (is(typeof({ T val; val.toString((const(char)[] s){}, "%s"); })))
+    else static if (is(typeof({ T val = void; val.toString((const(char)[] s){}, "%s"); })))
     {
         enum hasToString = 3;
     }
-    else static if (is(typeof({ T val; val.toString((const(char)[] s){}); })))
+    else static if (is(typeof({ T val = void; val.toString((const(char)[] s){}); })))
     {
         enum hasToString = 2;
     }
-    else static if (is(typeof({ T val; return val.toString(); }()) S) && isSomeString!S)
+    else static if (is(typeof({ T val = void; return val.toString(); }()) S) && isSomeString!S)
     {
         enum hasToString = 1;
     }

--- a/std/traits.d
+++ b/std/traits.d
@@ -2067,7 +2067,7 @@ template hasElaborateCopyConstructor(S)
     else
     {
         enum hasElaborateCopyConstructor = is(typeof({
-            S s;
+            S s = void;
             return &s.__postblit;
         })) || anySatisfy!(.hasElaborateCopyConstructor, typeof(S.tupleof));
     }
@@ -2084,6 +2084,9 @@ unittest
     struct S3 { uint num; S1 s; }
     static assert(!hasElaborateCopyConstructor!S2);
     static assert( hasElaborateCopyConstructor!S3);
+
+    struct S4 { @disable this(); this(int n){} this(this){} }
+    static assert( hasElaborateCopyConstructor!S4);
 }
 
 /**
@@ -2101,7 +2104,7 @@ template hasElaborateAssign(S)
     else
     {
         enum hasElaborateAssign = is(typeof(S.init.opAssign(S.init))) ||
-                                  is(typeof(S.init.opAssign({ return S.init; }()))) ||
+                                  is(typeof(S.init.opAssign({ S s = void; return s; }()))) ||
             anySatisfy!(.hasElaborateAssign, typeof(S.tupleof));
     }
 }
@@ -2126,6 +2129,9 @@ unittest
         @disable void opAssign(U)(ref U u);
     }
     static assert( hasElaborateAssign!S4);
+
+    struct S5 { @disable this(); this(int n){} S s; }
+    static assert( hasElaborateAssign!S5);
 }
 
 /**
@@ -2950,8 +2956,8 @@ static assert(!isAssignable!(string, char[]));
 template isAssignable(Lhs, Rhs)
 {
     enum bool isAssignable = is(typeof({
-        Lhs l;
-        Rhs r;
+        Lhs l = void;
+        Rhs r = void;
         l = r;
         return l;
     }));
@@ -2964,6 +2970,9 @@ unittest
 
     static assert(!isAssignable!(int, long));
     static assert(!isAssignable!(string, char[]));
+
+    struct S { @disable this(); this(int n){} }
+    static assert( isAssignable!(S, S));
 }
 
 


### PR DESCRIPTION
This is supplemental change for <a href="https://github.com/D-Programming-Language/dmd/pull/1087">dmd/pull/1087</a>.

Avoid frame access check and disabled default construction in predicate templates.
