### PR TITLE
Issue 8574 - [std.format] The flag ' ' works for floating numbers, not only for integers

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -186,7 +186,7 @@ $(I FormatChar):
     values $(D nan) and $(D infinity)).  Ignore if there's a $(I
     Precision).))
 
-    $(TR $(TD $(B ' ')) $(TD integral ($(B 'd'))) $(TD Prefix positive
+    $(TR $(TD $(B ' ')) $(TD numeric)) $(TD Prefix positive
     numbers in a signed conversion with a space.)))
 
     <dt>$(I Width)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8574
