### PR TITLE
Fix Bug 8582

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1110,6 +1110,8 @@ private:
             threadIndex = nextThreadIndex;
             nextThreadIndex++;
         }
+        
+        executeWorkLoop();
     }
 
     // This is the main work loop that worker threads spend their time in


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8582

The fix works by using the thread that calls finish() as a worker thread until the TaskPool queue is empty, if finish() is called with block=true.
