### PR TITLE
fixed wrong headers for decompression

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -36,6 +36,7 @@ import std.zlib;
 import std.datetime;
 import core.bitop;
 import std.conv;
+import std.algorithm;
 
 //debug=print;
 
@@ -426,8 +427,8 @@ class ZipArchive
         de.compressionMethod = getUshort(de.offset + 8);
         de.time = cast(DosFileTime)getUint(de.offset + 10);
         de.crc32 = getUint(de.offset + 14);
-        de.compressedSize = getUint(de.offset + 18);
-        de.expandedSize = getUint(de.offset + 22);
+        de.compressedSize = max(getUint(de.offset + 18), de.compressedSize);
+        de.expandedSize = max(getUint(de.offset + 22), de.expandedSize);
         namelen = getUshort(de.offset + 26);
         extralen = getUshort(de.offset + 28);
 


### PR DESCRIPTION
In some archives the headers for each indivdual `ArchivMember` are incomplete.
And these incomplete headers would overwrite the actual headers with `0` which
results in a `ZlibException` (since `compressedSize` and `expandedSize` are `0`).
