### PR TITLE
InputRange doc fixes

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -6188,7 +6188,7 @@ unittest
  * around input ranges with element type E.  This is useful where a well-defined
  * binary interface is required, such as when a DLL function or virtual function
  * needs to accept a generic range as a parameter.  Note that
- * $(D isInputRange) and friends check for conformance to structural
+ * $(LREF isInputRange) and friends check for conformance to structural
  * interfaces, not for implementation of these $(D interface) types.
  *
  * Examples:
@@ -6215,6 +6215,8 @@ unittest
  *
  * Length is not propagated in the case of non-random access ranges.
  *
+ * See_Also:
+ * $(LREF inputRangeObject)
  */
 interface InputRange(E) {
     ///
@@ -6523,7 +6525,9 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
     }
 }
 
-/**Convenience function for creating a $(D InputRangeObject) of the proper type.*/
+/**Convenience function for creating an $(D InputRangeObject) of the proper type.
+ * See $(LREF InputRange) for an example.
+ */
 InputRangeObject!R inputRangeObject(R)(R range) if (isInputRange!R) {
     static if (is(R : InputRange!(ElementType!R))) {
         return range;
@@ -6532,7 +6536,7 @@ InputRangeObject!R inputRangeObject(R)(R range) if (isInputRange!R) {
     }
 }
 
-/**Convenience function for creating a $(D OutputRangeObject) with a base range
+/**Convenience function for creating an $(D OutputRangeObject) with a base range
  * of type $(D R) that accepts types $(D E).
 
  Examples:


### PR DESCRIPTION
This simplifies the inputRangeObject example and fixes a documentation bug where InputRange was used as a type without instantiating it. It also adds some helpful links to ease navigation.
