### PR TITLE
socket.d: Add required cast for 64 bit compilation on Windows

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -942,7 +942,7 @@ private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addr
                 cast(AddressFamily) ai.ai_family,
                 cast(SocketType   ) ai.ai_socktype,
                 cast(ProtocolType ) ai.ai_protocol,
-                new UnknownAddressReference(ai.ai_addr, ai.ai_addrlen),
+                new UnknownAddressReference(ai.ai_addr, cast(socklen_t) ai.ai_addrlen),
                 ai.ai_canonname ? to!string(ai.ai_canonname) : null);
 
         assert(result.length > 0);


### PR DESCRIPTION
If you compile phobos targeting Win64 (using LDC2), an error occurs because `ai_addrlen` is of type `size_t` (64 bit), but `UnknownAddressReference.len` is of type `socklen_t` (32 bit).
I checked both types in the Windows C Runtime. The types in D and C are equal. Therefore this cast is missing or `UnknownAddressReference.len` needs to be changed.
