### PR TITLE
Document std.algorithm eponymous template members

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1161,8 +1161,8 @@ template filter(alias pred) if (is(typeof(unaryFun!pred)))
 {
     /**
     Implements the homonym function present in various programming
-    languages of functional flavor. The call $(D filter!(fun)(range))
-    returns a new range only containing elements $(D x) in $(D r) for
+    languages of functional flavor. The call $(D filter!(predicate)(range))
+    returns a new range only containing elements $(D x) in $(D range) for
     which $(D predicate(x)) is $(D true).
 
     Example:


### PR DESCRIPTION
Function signatures are currently not shown in the std.algorithm docs for eponymous template members:
http://dlang.org/phobos/std_algorithm.html#filter

This is confusing, especially as some readers won't be familiar with the eponymous template feature.

This PR moves the doc-comment for each eponymous template to the eponymous template member and adds a short 'Eponymous template' doc-comment for the template block itself. Using 'Eponymous template' explicitly provides a phrase that programmers unaware of the feature can search for.

Note: the github combined diff looks very noisy because of the indentation changes on doc-comments, so I committed the indentation changes separately from the other commits. (`git show --ignore-all-space 895626` reports no changes).

This is a win for documentation readers, but it does make reading the source code a bit more awkward (unless you use an editor that supports comment folding) as each template line is now quite far from the template body.
