### PR TITLE
exp, expm1, exp2 return 'inf' for targets that don't use iasm.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -939,7 +939,7 @@ real exp(real x) @trusted pure nothrow
         // and exp2 are so similar).
         return exp2(LOG2E*x);
     } else {
-        return core.stdc.math.exp(x);
+        return core.stdc.math.expl(x);
     }
 }
 /// ditto
@@ -1105,7 +1105,7 @@ L_largenegative:
             ret;
         }
     } else {
-        return core.stdc.math.expm1(x);
+        return core.stdc.math.expm1l(x);
     }
 }
 
@@ -1287,7 +1287,7 @@ L_was_nan:
             ret;
         }
     } else {
-        return core.stdc.math.exp2(x);
+        return core.stdc.math.exp2l(x);
     }
 }
 


### PR DESCRIPTION
Relevant bug report.
http://d.puremagic.com/issues/show_bug.cgi?id=5757
