### PR TITLE
snprintf already defined in core.stdc.stdio.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -44,12 +44,6 @@ version (DigitalMarsC)
                 in real* pdval,
                 char* buf, size_t* psl, int width) __pfloatfmt;
     }
-    alias core.stdc.stdio._snprintf snprintf;
-}
-else
-{
-    // Use C99 snprintf
-    extern (C) int snprintf(char* s, size_t n, in char* format, ...);
 }
 
 /**********************************************************************


### PR DESCRIPTION
The snprintf function is already defined in core.stdc.stdio. This version has the advantage that it also works with the MS C Runtine on Windows.
