### PR TITLE
Let enforce rely on deduced purity & safety

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -7592,6 +7592,11 @@ else
             for(int i=0; i<20; i++)
                 foreach (matchNew; uniCapturesNew) {}
     }
+    unittest
+    {// bugzilla 8637 purity of enforce
+        auto m = match("hello world", regex("world"));
+        enforce(m);
+    }
 }
 
 }//version(unittest)


### PR DESCRIPTION
Compiler can and should deduce purity of templates in this case enforce.

Putting pure on it manually just kills some important use cases without benefit.

This fixes issue 8637.
