### PR TITLE
Partial fix Issue 7648

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2758,6 +2758,12 @@ version(linux) {
 version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__)
 {
     import std.path;
-    // filename intentionally contains non-ASCII (Russian) characters
-    return text("deleteme-детка.", baseName(file), ".", line);
+
+    // Non-ASCII characters can't be used because of snn.lib @@@BUG8643@@@
+    version(DIGITAL_MARS_STDIO)
+        return text("deleteme-.", baseName(file), ".", line);
+    else
+
+        // filename intentionally contains non-ASCII (Russian) characters
+        return text("deleteme-детка.", baseName(file), ".", line);
 }


### PR DESCRIPTION
This fixes Phobos related part of [Issue 7648 - std.stdio expects file names to be encoded in CP_ACP on Windows instead of UTF-8](http://d.puremagic.com/issues/show_bug.cgi?id=7648), but as far as we use DigitalMars C runtime the issue is blocked by [Issue 8643 - [snn] _wfopen and other non-standard wide-character functions fail with non-ASCII symbols](http://d.puremagic.com/issues/show_bug.cgi?id=8643).
