### PR TITLE
"browse" method in std.process for OSX should not default to Safari.

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -770,9 +770,6 @@ else version (OSX)
         }
         else
         {
-            //browser = "/Applications/Safari.app/Contents/MacOS/Safari";
-            //args[1] = "-a".ptr;
-            //args[2] = "/Applications/Safari.app".ptr;
             args[0] = "open".ptr;
             args[1] = toStringz(url);
             args[2] = null;


### PR DESCRIPTION
The "open" command will use the default application for the arguments provided. This means URLs can be opened in Firefox/Chrome/Opera or Safari by the user depending on what they have set as their default browser.
