### PR TITLE
Issue 8617 - std.typecons.Proxy.opEquals compiles error: undefined identifier 'startsWith'

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2655,7 +2655,8 @@ mixin template Proxy(alias a)
 {
     auto ref opEquals(this X)(auto ref typeof(this) b)
     {
-        static assert(a.stringof.startsWith("this."));
+        import std.algorithm;
+        static assert(startsWith(a.stringof, "this."));
         return a == mixin("b."~a.stringof[5..$]);   // remove "this."
     }
     auto ref opEquals(this X, B)(auto ref B b) if (!is(B == typeof(this)))


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8617
