### PR TITLE
Fix dataTimeout in std.net.curl

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -5,11 +5,14 @@ $(VERSION 061, ddd mm, 2012, =================================================,
         $(LI std.digest.sha: Added SHA1 digest implementation.)
         $(LI std.uuid: Support SHA1 UUIDs.)
         $(LI std.uuid: md5UUID and sha1UUID can now be used in pure code.)
+        $(LI std.net.curl: Added operationTimeout.)
         $(LI std.md5 has been scheduled for deprecation (Use std.digest.md instead).)
         $(LI crc32 has been scheduled for deprecation (Use std.digest.crc instead).)
     )
 
     $(LIBBUGSFIXED
+        $(LI Unlisted Bug: std.net.curl dataTimeout fixed. (Used to set operation timeout
+             instead of inactivity timeout))
     )
 )
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1544,6 +1544,15 @@ private mixin template Protocol()
     /// Set timeout for activity on connection.
     @property void dataTimeout(Duration d)
     {
+        p.curl.set(CurlOption.low_speed_limit, 1);
+        p.curl.set(CurlOption.low_speed_time, d.total!"seconds"());
+    }
+
+    /** Set maximum time an operation is allowed to take.
+        This includes dns resolution, connecting, data transfer, etc.
+     */
+    @property void operationTimeout(Duration d)
+    {
         p.curl.set(CurlOption.timeout_ms, d.total!"msecs"());
     }
 
@@ -2089,6 +2098,11 @@ struct HTTP
 
         /// Set timeout for activity on connection.
         @property void dataTimeout(Duration d);
+
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
 
         /// Set timeout for connecting.
         @property void connectTimeout(Duration d);
@@ -2729,6 +2743,11 @@ struct FTP
         /// Set timeout for activity on connection.
         @property void dataTimeout(Duration d);
 
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
+
         /// Set timeout for connecting.
         @property void connectTimeout(Duration d);
 
@@ -3012,6 +3031,11 @@ struct SMTP
 
         /// Set timeout for activity on connection.
         @property void dataTimeout(Duration d);
+
+        /** Set maximum time an operation is allowed to take.
+            This includes dns resolution, connecting, data transfer, etc.
+          */
+        @property void operationTimeout(Duration d);
 
         /// Set timeout for connecting.
         @property void connectTimeout(Duration d);


### PR DESCRIPTION
- std.net.curl: Added operationTimeout.
- std.net.curl: dataTimeout fixed. (Used to set operation timeout instead of inactivity timeout)
