### PR TITLE
ptrEnd for arrays

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -635,9 +635,8 @@ assert(b.ptr == b.ptrEnd);
 ----
 ), $(ARGS), $(ARGS), $(ARGS import std.array;))
 
-    $(RED The returned pointer should be used ONLY for pointer arithmatic,
-    as it will not be considered a refernce to the array by the Garbage
-    Collector.)
+    $(RED Warning: The pointer returned by this function will not be
+    considered a live reference to the array by the garbage collector.)
 */
 @property @trusted pure nothrow
 auto ptrEnd(T)(T arr)


### PR DESCRIPTION
Just a tiny something I've found to be missing: Getting the (one-past-the-) end pointer of an array (dynamic or static).

This is a tiny convenience/helper function, but is (IMO) quite useful.

No more writing `arr.ptr + arr.length`. Now, it's just `arr.ptrEnd`

Discussion here: http://forum.dlang.org/thread/kcfqyxbnlhxdkqibfpiu@forum.dlang.org
