### PR TITLE
Fix for issue 8694, (Un)Compress may cause an InvalidMemoryOperationError

### DIFF
--- a/std/zlib.d
+++ b/std/zlib.d
@@ -298,9 +298,7 @@ class Compress
         if (inited)
         {
             inited = 0;
-            err = deflateEnd(&zs);
-            if (err)
-                error(err);
+            deflateEnd(&zs);
         }
     }
 
@@ -458,9 +456,7 @@ class UnCompress
         if (inited)
         {
             inited = 0;
-            err = inflateEnd(&zs);
-            if (err)
-                error(err);
+            inflateEnd(&zs);
         }
         done = 1;
     }


### PR DESCRIPTION
The calls to error() are removed from the finalizers to avoid memory allocations there. The result does not matter at this point anyway since nothing can be done about it.
