### PR TITLE
Fix Windows make files broken by Pull 803

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -359,7 +359,7 @@ $(LIB) : $(SRC_TO_COMPILE) \
 		$(ZLIB) $(DRUNTIMELIB)
 
 UNITTEST_OBJS= unittest1.obj unittest2.obj unittest2a.obj \
-		unittest3.obj unittest4.obj \
+		unittest3.obj unittest3a.obj unittest4.obj \
 		unittest5.obj unittest6.obj unittest7.obj
 
 unittest : $(LIB)

--- a/win64.mak
+++ b/win64.mak
@@ -360,7 +360,7 @@ $(LIB) : $(SRC_TO_COMPILE) \
 		$(ZLIB) $(DRUNTIMELIB)
 
 UNITTEST_OBJS= unittest1.obj unittest2.obj unittest2a.obj \
-		unittest3.obj unittest4.obj \
+		unittest3.obj unittest3a.obj unittest4.obj \
 		unittest5.obj unittest6.obj unittest7.obj
 
 unittest : $(LIB)


### PR DESCRIPTION
Breaking commit: 2dfb76d08dee2c2be58ae95bf3d15a39097c96a3

I have no idea how `unittest.exe` managed to compile without `unittest3a.obj`...
