### PR TITLE
Conv missing doc

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -134,7 +134,7 @@ class ConvOverflowException : ConvException
     }
 }
 
-/* **************************************************************
+/**
 
 The $(D_PARAM to) family of functions converts a value from type
 $(D_PARAM Source) to type $(D_PARAM Target). The source type is


### PR DESCRIPTION
There is a huge bloc of documentation regarding "to", that doesn't show up in http://dlang.org/phobos/std_conv.html

This pull request makes it appear.
