### PR TITLE
std.process: Fix documentation for exec*() functions.

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -228,12 +228,12 @@ private
 /* ========================================================== */
 
 /**
- * Replace the current process by executing a command, pathname, with
- * the arguments in argv. Typically, the first element of argv is the
- * command being executed, i.e. argv[0] == pathname. The 'p' versions
- * of exec search the PATH environment variable for pathname. The 'e'
- * versions additionally take the new process' environment variables
- * as an array of strings of the form key=value.
+ * Replace the current process by executing a command, $(D pathname), with
+ * the arguments in $(D argv). Typically, the first element of $(D argv) is
+ * the command being executed, i.e. $(D argv[0] == pathname). The 'p'
+ * versions of $(D exec) search the PATH environment variable for $(D
+ * pathname). The 'e' versions additionally take the new process'
+ * environment variables as an array of strings of the form key=value.
  *
  * Does not return on success (the current process will have been
  * replaced). Returns -1 on failure with no indication of the


### PR DESCRIPTION
They really are just like POSIX exec*(), i.e. they do not return an
exit status. In fact, they don't return at all on success.
Unfortunately, it looks like all you get on failure is a return value
of -1, no indication of whether the failure was "No such file or
directory", "Permission denied", etc.
