### PR TITLE
Update OS detection logic in posix.mak to handle OpenBSD and Solaris.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -33,7 +33,19 @@ ifeq (,$(OS))
             ifeq (FreeBSD,$(OS))
                 OS:=freebsd
             else
-                $(error Unrecognized or unsupported OS for uname: $(OS))
+                ifeq (OpenBSD,$(OS))
+                    TARGET=OPENBSD
+                else
+                    ifeq (Solaris,$(OS))
+                        TARGET=SOLARIS
+                    else
+                        ifeq (SunOS,$(OS))
+                            TARGET=SOLARIS
+                        else
+                            $(error Unrecognized or unsupported OS for uname: $(OS))
+                        endif
+                    endif
+                endif
             endif
         endif
     endif


### PR DESCRIPTION
Just some initial plumbing for the Solaris port primarily.
