### PR TITLE
Get rid of transitional lfs API

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -122,8 +122,8 @@ class MmFile
         fd = fildes;
 
         // Adjust size
-        struct_stat64 statbuf = void;
-        errnoEnforce(fstat64(fd, &statbuf) == 0);
+        stat_t statbuf = void;
+        errnoEnforce(fstat(fd, &statbuf) == 0);
         if (prot & PROT_WRITE && size > statbuf.st_size)
         {
             // Need to make the file size bytes big
@@ -316,8 +316,8 @@ class MmFile
                 fd = .open(namez, oflag, fmode);
                 errnoEnforce(fd != -1, "Could not open file "~filename);
 
-                struct_stat64 statbuf;
-                if (fstat64(fd, &statbuf))
+                stat_t statbuf;
+                if (fstat(fd, &statbuf))
                 {
                     //printf("\tfstat error, errno = %d\n", errno);
                     .close(fd);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -43,19 +43,16 @@ version (linux)
 {
     // Specific to the way Gnu C does stdio
     version = GCC_IO;
-    extern(C) FILE* fopen64(const char*, const char*);
 }
 
 version (OSX)
 {
     version = GENERIC_IO;
-    alias core.stdc.stdio.fopen fopen64;
 }
 
 version (FreeBSD)
 {
     version = GENERIC_IO;
-    alias core.stdc.stdio.fopen fopen64;
 }
 
 version(Windows)
@@ -63,14 +60,9 @@ version(Windows)
     // core.stdc.stdio.fopen expects file names to be
     // encoded in CP_ACP on Windows instead of UTF-8.
     /+ Waiting for druntime pull 299
-    alias core.sys.windows.c.stdio._wfopen fopen64; 
-    +/ extern (C) nothrow FILE* _wfopen(in wchar* filename, in wchar* mode);
-    alias _wfopen fopen64;
-
-    alias std.utf.toUTF16z toOSStringz;
+    +/
+    extern (C) nothrow FILE* _wfopen(in wchar* filename, in wchar* mode);
 }
-else
-    alias std.string.toStringz toOSStringz;
 
 version (DIGITAL_MARS_STDIO)
 {
@@ -122,13 +114,6 @@ else version (GCC_IO)
 
         private size_t fwrite_unlocked(const(void)* ptr,
                 size_t size, size_t n, _iobuf *stream);
-    }
-
-    version (linux)
-    {
-        // declare fopen64 if not already
-        static if (!is(typeof(fopen64)))
-            extern (C) FILE* fopen64(in char*, in char*);
     }
 
     alias fputc_unlocked FPUTC;
@@ -1877,26 +1862,41 @@ size_t readln(ref char[] buf, dchar terminator = '\n')
 }
 
 /*
- * Convenience function that forwards to $(D std.c.stdio.fopen)
- * (to $(D std.c.stdio._wfopen) on Windows)
+ * Convenience function that forwards to $(D core.stdc.stdio.fopen)
+ * (to $(D _wfopen) on Windows)
  * with appropriately-constructed C-style strings.
  */
 private FILE* fopen(in char[] name, in char[] mode = "r")
 {
-    return fopen64(toOSStringz(name), toOSStringz(mode));
+    version(Windows)
+        return _wfopen(toUTF16z(name), toUTF16z(mode));
+    else version(Posix)
+    {
+        /* 
+         * The new opengroup large file support API is transparently
+         * included in the normal C bindings. http://opengroup.org/platform/lfs.html#1.0
+         * if _FILE_OFFSET_BITS in druntime is 64, off_t is 64 bit and  
+         * the normal functions work fine. If not, then large file support
+         * probably isn't available. Do not use the old transitional API
+         * (the native extern(C) fopen64, http://www.unix.org/version2/whatsnew/lfs20mar.html#3.0)
+         */
+        return core.sys.posix.stdio.fopen(toStringz(name), toStringz(mode));
+    }
+    else
+    {
+        return core.stdc.stdio.fopen(toStringz(name), toStringz(mode));
+    }
 }
 
 version (Posix)
 {
-    extern(C) FILE* popen(const char*, const char*);
-
-/***********************************
- * Convenience function that forwards to $(D std.c.stdio.popen)
- * with appropriately-constructed C-style strings.
- */
+    /***********************************
+     * Convenience function that forwards to $(D std.c.stdio.popen)
+     * with appropriately-constructed C-style strings.
+     */
     FILE* popen(in char[] name, in char[] mode = "r")
     {
-        return popen(toOSStringz(name), toOSStringz(mode));
+        return core.sys.posix.stdio.popen(toStringz(name), toStringz(mode));
     }
 }
 


### PR DESCRIPTION
Those kind of functions should be placed in druntime, but the *64 (transitional) functions as a public interface are actually deprecated and shouldn't be used anymore.

Druntime takes care that the normal stat, fopen,... calls support large files, if __USE_FILE_OFFSET64 is defined (which is what the new C API does as well)

Note: It's actually important to use the functions from core.sys.posix.stdio as the functions in core.stdc.stdio are not large file aware. This is probably a bug in druntime.

Note 2: I hope that the new stdio/File will work better if no lfs support is available. The current implementation probably won't even compile if off_t is 32bit.

BTW: Is there a place where I could write down some documentation on implementation details?
Large file support is a mess and it would probably be a good idea to document our implementation somewhere.
