### PR TITLE
fix issue 8737 Unqual for AA

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4359,22 +4359,32 @@ static assert(is(Unqual!(shared(const int)) == int));
  */
 template Unqual(T)
 {
-    version (none) // Error: recursive alias declaration @@@BUG1308@@@
+    static if (!isAssociativeArray!T)
     {
-             static if (is(T U ==     const U)) alias Unqual!U Unqual;
-        else static if (is(T U == immutable U)) alias Unqual!U Unqual;
-        else static if (is(T U ==     inout U)) alias Unqual!U Unqual;
-        else static if (is(T U ==    shared U)) alias Unqual!U Unqual;
-        else                                    alias        T Unqual;
+        version (none) // Error: recursive alias declaration @@@BUG1308@@@
+        {
+                 static if (is(T U ==     const U)) alias Unqual!U Unqual;
+            else static if (is(T U == immutable U)) alias Unqual!U Unqual;
+            else static if (is(T U ==     inout U)) alias Unqual!U Unqual;
+            else static if (is(T U ==    shared U)) alias Unqual!U Unqual;
+            else                                    alias        T Unqual;
+        }
+        else // workaround
+        {
+                 static if (is(T U == shared(const U))) alias U Unqual;
+            else static if (is(T U ==        const U )) alias U Unqual;
+            else static if (is(T U ==    immutable U )) alias U Unqual;
+            else static if (is(T U ==        inout U )) alias U Unqual;
+            else static if (is(T U ==       shared U )) alias U Unqual;
+            else                                        alias T Unqual;
+        }
     }
-    else // workaround
+    else
     {
-             static if (is(T U == shared(const U))) alias U Unqual;
-        else static if (is(T U ==        const U )) alias U Unqual;
-        else static if (is(T U ==    immutable U )) alias U Unqual;
-        else static if (is(T U ==        inout U )) alias U Unqual;
-        else static if (is(T U ==       shared U )) alias U Unqual;
-        else                                        alias T Unqual;
+        //An AA's mutability is defined by its key's mutability.
+        alias KeyType!T K;
+        alias Unqual!(ValueType!T) V;
+        alias V[K] Unqual;
     }
 }
 
@@ -4388,6 +4398,18 @@ unittest
     static assert(is(Unqual!(shared(const int)) == int));
     alias immutable(int[]) ImmIntArr;
     static assert(is(Unqual!(ImmIntArr) == immutable(int)[]));
+}
+unittest //8737 AA
+{
+    alias const(int[int]) AA;
+    alias const(int)[int] BB;
+    alias const(int)[const(int)] CC;
+    static assert(is(Unqual!AA == int[int]));
+    static assert(is(Unqual!BB == int[int]));
+    static assert(is(Unqual!CC == int[const(int)]));
+    alias int[int[int]] DD;
+    static assert(is(KeyType!DD == const(int)[int]));
+    static assert(is(Unqual!(KeyType!DD) == int[int]));
 }
 
 // [For internal use]


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8737

Unqual did not work with AAs.

This is mostly because an AA with a const KeyType is considered non-mutable, even if the AA's general type is not const. This fixes this by Unqualing the Key Type directly.

Examples in the unittests. Non of these unit tests worked without the fix.

Pre-required for 8709 http://d.puremagic.com/issues/show_bug.cgi?id=8709, in pull request...

823 fix issue 8709, from documentation
https://github.com/D-Programming-Language/phobos/pull/823
