### PR TITLE
Typo in std.math doc: "Source" link appears twice

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -18,7 +18,6 @@
  * Status:
  * The semantics and names of feqrel and approxEqual will be revised.
  *
- * Source: $(PHOBOSSRC std/_math.d)
  * Macros:
  *      WIKI = Phobos/StdMath
  *


### PR DESCRIPTION
http://dlang.org/phobos/std_math.html

Just a typo-type fix

There are two links to source. I removed the top one line 21.

The other one appears under the "macros" section, after License and Authors, line 51.

BTW, what is that "macro" section ???
