### PR TITLE
skipWhite in conv.parse

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2916,7 +2916,7 @@ unittest
  * Example:
  * string ss = "123 12.5";
  * int i = parse!int(ss);
- * skipWhite(s);
+ * skipWhite(ss);
  * double d = parse!double(ss);
  *
  * Example:


### PR DESCRIPTION
Spliced from pull 817
https://github.com/D-Programming-Language/phobos/pull/817

This is the developement discussed in 817: It adds a "skipWhite" function in std.conv that works on anything Range!Character, and operates by reference.

This "fixes" the leading ws "problem" in parse.
