### PR TITLE
Tweak in /pop(Front|Back)N/

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3194,6 +3194,8 @@ Example:
 int[] a = [ 1, 2, 3, 4, 5 ];
 a.popFrontN(2);
 assert(a == [ 3, 4, 5 ]);
+a.popFrontN(7);
+assert(a == [ ]);
 ----
 */
 size_t popFrontN(Range)(ref Range r, size_t n) if (isInputRange!(Range))
@@ -3230,6 +3232,15 @@ unittest
     int[] a = [ 1, 2, 3, 4, 5 ];
     a.popFrontN(2);
     assert(a == [ 3, 4, 5 ]);
+    a.popFrontN(7);
+    assert(a == [ ]);
+}
+unittest
+{
+    auto LL = iota(1L, 7L);
+    auto r = popFrontN(LL, 2);
+    assert(equal(LL, [3L, 4L, 5L, 6L]));
+    assert(r == 2);
 }
 
 /**
@@ -3248,22 +3259,35 @@ unittest
    int[] a = [ 1, 2, 3, 4, 5 ];
    a.popBackN(2);
    assert(a == [ 1, 2, 3 ]);
+   a.popBackN(7);
+   assert(a == [ ]);
    ----
 */
 size_t popBackN(Range)(ref Range r, size_t n) if (isInputRange!(Range))
 {
     static if (hasSlicing!(Range) && hasLength!(Range))
     {
-        n = cast(size_t) min(n, r.length);
+        n = min(n, r.length);
         auto newLen = r.length - n;
         r = r[0 .. newLen];
     }
     else
     {
-        foreach (i; 0 .. n)
+        static if (hasLength!Range)
         {
-            if (r.empty) return i;
-            r.popBack();
+            n = min(n, r.length);
+            foreach (i; 0 .. n)
+            {
+                r.popBack();
+            }
+        }
+        else
+        {
+            foreach (i; 0 .. n)
+            {
+                if (r.empty) return i;
+                r.popBack();
+            }
         }
     }
     return n;
@@ -3274,6 +3298,8 @@ unittest
     int[] a = [ 1, 2, 3, 4, 5 ];
     a.popBackN(2);
     assert(a == [ 1, 2, 3 ]);
+    a.popBackN(7);
+    assert(a == [ ]);
 }
 unittest
 {


### PR DESCRIPTION
Just some teeny tiny fixes:
1. Added a cast(size_t) in popFrontN for the odd ranges that return something bigger than a size_t. Note that popBackN already had this "fix"
2. Gave popBackN the same optimization for nonSliceable ranges that have length (avoids checking empty every time). This applies for ranges such as "take".
3. Enriched documentation (and corresponding unittest), to stress /pop(Front|Back)N/'s safety regarding over-emptying a range.
