### PR TITLE
fix issue 8729 do not skip leading ws in parse (again)

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2608,8 +2608,9 @@ unittest
 unittest
 {
     //extra stress testing
-    auto ssOK    = ["1.", "1.1.1", "1.e5", "2e1e", "2a", "2e1_1", "inf2e", "-inf2e", "+inf2"];
-    auto ssKO    = ["", " ", "2e", "2e+", "2e-", "2ee", "2e++1", "2e--1", "2e_1"];
+    auto ssOK    = ["1.", "1.1.1", "1.e5", "2e1e", "2a", "2e1_1",
+                    "inf", "-inf", "infa", "-infa", "inf2e2", "-inf2e2"];
+    auto ssKO    = ["", " ", "2e", "2e+", "2e-", "2ee", "2e++1", "2e--1", "2e_1", "+inf"];
     foreach(s; ssOK)
         parse!double(s);
     foreach(s; ssKO)


### PR DESCRIPTION
Fixes issue 8729: parse!double was skipping leading ws.

Now it doesn't.

Unit tests added. No other change to existing behavior. This is _just_ a bug fix to the existing behavior, not a change of behavior
