### PR TITLE
Update COM header with CoInitializeEx

### DIFF
--- a/std/c/windows/com.d
+++ b/std/c/windows/com.d
@@ -1,4 +1,3 @@
-
 module std.c.windows.com;
 
 pragma(lib,"uuid");
@@ -56,6 +55,16 @@ enum
         CLSCTX_ALL = (CLSCTX_INPROC_SERVER| CLSCTX_INPROC_HANDLER| CLSCTX_LOCAL_SERVER),
         CLSCTX_SERVER = (CLSCTX_INPROC_SERVER|CLSCTX_LOCAL_SERVER),
 }
+
+enum
+{ 
+       COINIT_APARTMENTTHREADED   = 0x2,
+       COINIT_MULTITHREADED       = 0x0,
+       COINIT_DISABLE_OLE1DDE     = 0x4,
+       COINIT_SPEED_OVER_MEMORY   = 0x8 
+}
+alias DWORD COINIT;
+enum RPC_E_CHANGED_MODE = 0x80010106;
 
 alias const(GUID) IID;
 alias const(GUID) CLSID;
@@ -177,6 +186,7 @@ int StringFromGUID2(GUID *rguid, LPOLESTR lpsz, int cbMax);
 /* init/uninit */
 
 HRESULT CoInitialize(LPVOID pvReserved);
+HRESULT CoInitializeEx(LPVOID pvReserved, DWORD dwCoInit);
 void    CoUninitialize();
 DWORD   CoGetCurrentProcess();
 


### PR DESCRIPTION
`CoInitializeEx` is essential to setting the threading model to multi-threaded.
Multi-threaded COM is ideal in D where threading is safer and synchronization easier.
