### PR TITLE
Fixes for emplace struct

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3434,7 +3434,7 @@ $(D T) is $(D @safe).
 Returns: A pointer to the newly constructed object (which is the same
 as $(D chunk)).
  */
-T* emplace(T, Args...)(T* chunk, Args args)
+T* emplace(T, Args...)(T* chunk, auto ref Args args)
     if (!is(T == struct) && Args.length == 1)
 {
     *chunk = args[0];


### PR DESCRIPTION
Contains a fix for emplace!struct that I happened upon:
- Given a struct with an opAssign, emplace was calling opAssign without first copying over T.init: This creates undefined behavior if the opAssign actually did anything on this, such as deleting a payload, or copying to a payload.

I re-implemented "most" of emplace!Struct to outright bypass opAssign when possible by doing a move directly "onto" the un-initialized chunk. There is only one case where opAssign is called: If there is absolutely no way to construct a T without it.

The way emplace!struct reimplemented is pretty straight forward, trying cases, and finally giving up with a verbose message. "Don't know how to emplace..."

Also added a message in "initalize" regarding the need to access "T.init". Note that I did not change the existing behavior, merely asserted it with a message.

There _is_ some limited support for `@disable this` if emplace can do without T.init

Pretty chunky unit tests added too, for coverage.

``` D
T* emplace(T, Args...)(T* chunk, Args args)
    if (is(T == struct))
{
    auto result = cast(typeof(return)) chunk;

    //Copies T.init over destination
    void initialize(T* dest, size_t size = T.sizeof)
    {
        static assert(is(typeof({T i;})), text(T.stringof, " is not emplaceable because it has @disable this()."));
        static T i;
        memcpy(dest, &i, size);
    }

    //From std.algorithm.move, but without destroying destination (since it is uninitialized).
    void moveOver(ref T source)
    {
        memcpy(result, &source, T.sizeof);
        // If the source defines a destructor or a postblit hook, we must obliterate the
        // object in order to avoid double freeing and undue aliasing
        static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
        {
            static if (T.tupleof[$-1].stringof.endsWith("this"))
            {
                // Keep original context pointer
                initialize(&source, T.sizeof - (void*).sizeof);
            }
            else
            {
                initialize(&source);
            }
        }
    }

    static if (is(typeof(result.__ctor(args))))
    {
        // T defines a genuine constructor accepting args
        // Go the classic route: write .init first, then call ctor
        initialize(result);
        result.__ctor(args);
    }
    else static if (is(typeof(T(args))))
    {
        // Struct without constructor that has one matching field for
        // each argument: This is an agglomerate construction.
        T t = T(args);
        moveOver(t);
        //Note: This creates a temporary t. We *could* improve this
        //by initializing to T.init, and then emplacing each arg individually:
        //
        //initialize(result);
        //foreach(i, ref v; args)
        //    emplace(&result.tupleof[i], v);
        //
        //However, to *really* be efficient, we'd need a helper emplace that takes
        //by reference, and doesn't copy over T.init again. This would make emplace
        //More complicated, so we stick to this for now.
    }
    else static if (Args.length == 1 && is(Args[0] == T))
    {
        //Exact type match, with no CC. Just memcpy it construct.
        memcpy(chunk, &args[0], T.sizeof);
    }
    else
    {
        //Give up
        static assert(0, text("Don't know how to emplace a ", T.stringof, " with ", Args[].stringof));
    }

    return result;
}
```
