### PR TITLE
Insert missing "HTTP." prefix in std.curl

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -953,6 +953,11 @@ unittest
     auto line = res.front();
     assert(line == "Hello world",
            "byLine!HTTP() returns unexpected content: " ~ line);
+
+    auto res2 = byLine(testUrl1, KeepTerminator.no, '\n', HTTP());
+    line = res2.front();
+    assert(line == "Hello world",
+           "byLine!HTTP() returns unexpected content: " ~ line);
 }
 
 /** HTTP/FTP fetch content as a range of chunks.
@@ -1013,6 +1018,21 @@ auto byChunk(Conn = AutoProtocol)
 
     auto result = _getForRange!ubyte(url, conn);
     return SyncChunkInputRange(result, chunkSize);
+}
+
+unittest
+{
+    if (!netAllowed()) return;
+
+    auto res = byChunk(testUrl1);
+    auto line = res.front();
+    assert(line == cast(ubyte[])"Hello world\n",
+           "byLineAsync!HTTP() returns unexpected content " ~ to!string(line));
+
+    auto res2 = byChunk(testUrl1, 1024, HTTP());
+    line = res2.front();
+    assert(line == cast(ubyte[])"Hello world\n",
+           "byLineAsync!HTTP() returns unexpected content: " ~ to!string(line));
 }
 
 private T[] _getForRange(T,Conn)(const(char)[] url, Conn conn)


### PR DESCRIPTION
`HTTP.Method` has to be fully qualified in the external method `_getForRange`.
