### PR TITLE
More fix for Issue 8705 - std.conv.to bug, from documentation

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1432,6 +1432,7 @@ unittest // Bugzilla 8705, from doc
     a = [null:["hello":int.max]];
     assertThrown!ConvOverflowException(to!(short[wstring][string[double[]]])(a));
 }
+version(none) // masked by unexpected linker error in posix platforms
 unittest // Extra cases for AA with qualifiers conversion
 {
     int[][int[]] a;// = [[], []];


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8705

Mutable care is just necessary for value type, and doesn't need for key types.

---

@monarchdodra, how about this change?
