### PR TITLE
Fix for fill(value) (again)

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -880,6 +880,8 @@ assert(a == [ 5, 5, 5, 5 ]);
 void fill(Range, Value)(Range range, Value filler)
     if (isInputRange!Range && is(typeof(range.front = filler)))
 {
+    alias ElementType!Range T;
+
     static if (is(typeof(range[] = filler)))
     {
         range[] = filler;


### PR DESCRIPTION
As pointed out by @denis-sh

https://github.com/D-Programming-Language/phobos/pull/838#issuecomment-9206817

The alias T was being used in a conditional if.

``` D
void fill(Range, Value)(Range range, Value filler)
    if (isInputRange!Range && is(typeof(range.front = filler)))
{
    alias ElementType!Range T; //***RE-INSERTED THIS***

    static if (is(typeof(range[] = filler)))
    {
        range[] = filler;
    }
    else static if (is(typeof(range[] = T(filler)))) //***TO FIX THIS***
    {
        range[] = T(filler); //***SO THIS WOULD WORK***
    }
    else
    {
        for ( ; !range.empty; range.popFront() )
        {
            range.front = filler;
        }
    }
}
```
