### PR TITLE
FIx issue 7992

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -3391,7 +3391,8 @@ unittest
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
 
-    struct CustomString {
+    struct CustomString
+    {
         string _impl;
 
         // This is what triggers issue 7992.


### PR DESCRIPTION
The problem is caused by haystackTooShort() always returning false when both the haystack and the needle have a length property defined. This causes the searching loop to call popFront() on an empty haystack.
