### PR TITLE
Fix issue 8792

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2749,6 +2749,12 @@ unittest
 
     // bugzilla 8240
     assert(equal(joiner([inputRangeObject("")]), ""));
+
+    // issue 8792
+    auto b = [[1], [2], [3]];
+    auto jb = joiner(b);
+    auto js = jb.save;
+    assert(equal(jb, js));
 }
 
 // uniq


### PR DESCRIPTION
std.algorithm.joiner(ror).Result.save fails to copy the value of _valid_current, resulting in .save returning a defective copy of the range that doesn't work.
