### PR TITLE
Expanded test for issue# 8792.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2755,6 +2755,14 @@ unittest
     auto jb = joiner(b);
     auto js = jb.save;
     assert(equal(jb, js));
+
+    auto js2 = jb.save;
+    jb.popFront();
+    assert(!equal(jb, js));
+    assert(equal(js2, js));
+    js.popFront();
+    assert(equal(jb, js));
+    assert(!equal(js2, js));
 }
 
 // uniq


### PR DESCRIPTION
This tests that the saved range from `joiner` is appropriately separate from the original.
