### PR TITLE
Fix joiner output for infinite range of ranges

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2690,7 +2690,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
             _items = r;
             prepare();
         }
-        static if (isInfinite!(ElementType!RoR))
+        static if (isInfinite!RoR)
         {
             enum bool empty = false;
         }


### PR DESCRIPTION
Joining an infinite range of finite ranges will also produce an infinite range, not just when joining a range of infinite ranges.
