### PR TITLE
remove ctfe check in popFront!NarrowString

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -393,16 +393,8 @@ if (isNarrowString!S && isMutable!S && !isStaticArray!S)
         immutable c = str[0];
         if(c < 0x80)
         {
-            if(__ctfe)
-            {
-                //The ptr trick doesn't work in CTFE.
-                str = str[1 .. $];
-            }
-            else
-            {
-                //ptr is used to avoid unnnecessary bounds checking.
-                str = str.ptr[1 .. str.length];
-            }
+            //ptr is used to avoid unnnecessary bounds checking.
+            str = str.ptr[1 .. str.length];
         }
         else
         {


### PR DESCRIPTION
This check was not actually needed. Considering that __ctfe is actually evaluated during runtime, this should help boost popFront's performance with narrow strings.

No unit tests added, because there was already one checking ctfe:

``` D
version(unittest) C[] _eatString(C)(C[] str)
{
    while(!str.empty)
        str.popFront();

    return str;
}

unittest
{
    [...]

    static assert(!is(typeof(popFront!(immutable string))));
    static assert(!is(typeof(popFront!(char[4]))));

    enum checkCTFE = _eatString("ウェブサイト@La_Verité.com");
    static assert(checkCTFE.empty);
    enum checkCTFEW = _eatString("ウェブサイト@La_Verité.com"w);
    static assert(checkCTFEW.empty);
}
```
