### PR TITLE
std.algorithm.map does not cache front. Update ddoc.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -332,9 +332,7 @@ Implements the homonym function (also known as $(D transform)) present
 in many languages of functional flavor. The call $(D map!(fun)(range))
 returns a range of which elements are obtained by applying $(D fun(x))
 left to right for all $(D x) in $(D range). The original ranges are
-not changed. Evaluation is done lazily. The range returned by $(D map)
-caches the last value such that evaluating $(D front) multiple times
-does not result in multiple calls to $(D fun).
+not changed. Evaluation is done lazily.
 
 Example:
 ----


### PR DESCRIPTION
std.algorithm.map's ddoc says that it caches each element, but it doesn't. It appears to have be removed at some point.

See: https://github.com/D-Programming-Language/phobos/blob/master/std/algorithm.d#L428

Resolves bug 8803:  http://d.puremagic.com/issues/show_bug.cgi?id=8803
