### PR TITLE
Fix Issue 8849

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1395,13 +1395,12 @@ private:
         task.taskStatus = TaskStatus.inProgress;
         this.head = task;
         singleTaskThread = new Thread(&doSingleTask);
+        singleTaskThread.start();
 
         if(priority != int.max)
         {
             singleTaskThread.priority = priority;
         }
-
-        singleTaskThread.start();
     }
 
 public:
@@ -3973,7 +3972,7 @@ unittest
 
     // Test executeInNewThread().
     auto ct = scopedTask!refFun(x);
-    ct.executeInNewThread();
+    ct.executeInNewThread(Thread.PRIORITY_MAX);
     ct.yieldForce();
     assert(ct.args[0] == 1);
 


### PR DESCRIPTION
Fixes Issue 8849:  std.parallelism.executeInNewThread with thread priority segfaults.  This was caused by trying to set the priority of a thread that isn't started yet.  Apparently this can't be done and noone, myself included, ever noticed until now.  The solution is to set the priority after starting the thread.  This is not ideal because the thread can theoretically run a long time before having its priority switched, but it's probably the best we can do.
