### PR TITLE
Fix bug 8900 - Zip with infinite char range fails.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1932,7 +1932,7 @@ if (isInputRange!T)
                     // right align
                     auto len = val.length;
                 }
-                else static if (isForwardRange!T)
+                else static if (isForwardRange!T && !isInfinite!T)
                 {
                     auto len = walkLength(val.save);
                 }

--- a/std/range.d
+++ b/std/range.d
@@ -4150,6 +4150,10 @@ unittest
         assert(zLongest.empty);
     }
 
+    // BUG 8900
+    static assert(__traits(compiles, zip([1, 2], repeat('a'))));
+    static assert(__traits(compiles, zip(repeat('a'), [1, 2])));
+
     // Doesn't work yet.  Issues w/ emplace.
     // static assert(is(Zip!(immutable int[], immutable float[])));
 


### PR DESCRIPTION
`std.range.Zip` contains a `Tuple`, whose `toString()` function calls `formatElement` which eventually calls this function when the range element type `isSomeChar`, leading to a static call to `walkLength` on infinite ranges. Since pull request 880, `walkLength` doesn't work with infinite ranges, so it fails to compile.

This change ensures that `walkLength` is called with only valid range types.

Bug: http://d.puremagic.com/issues/show_bug.cgi?id=8900
