### PR TITLE
Throw exception upon division by zero. (issue 8021)

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -493,9 +493,8 @@ private:
     // Generate a runtime error if division by zero occurs
     void checkDivByZero() pure const
     {
-        assert(!isZero(), "BigInt division by zero");
         if (isZero())
-           auto x = 1/toInt(); // generate a div by zero error
+            throw new Error("BigInt division by zero");
     }
 }
 


### PR DESCRIPTION
Instead of trying to trigger an integer divide by zero, which seems to
get "optimized" out by the compiler, causing control to return to the caller, ending in an infinite loop.

Also, forcing an integer divide by zero on Linux triggers a "floating point exception", which is rather unhelpful compared to an exception that says "BigInt divide by zero".
