### PR TITLE
Split(string) unicode support

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1164,8 +1164,18 @@ unittest
 unittest
 {
     //Testing @@@7689
+    //Note: Split does not guarantee an actual exception,
+    //So this unittest is just a "stability" test.
     char[] s = cast(char[])[131, 64, 32, 251, 22];
     assertThrown(std.string.split(s).length == 2);
+}
+
+unittest
+{
+    enum rw = split("\u3000日\u3000本\u3000語\u3000");
+    static assert(rw[0] == "日");
+    static assert(rw[1] == "本");
+    static assert(rw[2] == "語");
 }
 
 /**


### PR DESCRIPTION
Added unicde support, plus unittest, for split.

The implementation was completely changed, so not much point looking at it in "diff" mode.

I'm not 100% sure about `appender`'s usage, but the documentation says to use `appender` instead of `~=` when making several appends in a row, so I did.

Addresses #7689 issues 7689.
http://d.puremagic.com/issues/show_bug.cgi?id=7689
(what syntax am I supposed to use for automatic tagging?)

``` D
S[] split(S)(S s)
    if (isSomeString!S)
{
    alias ElementEncodingType!S C;

    S[] result;
    auto app = appender!(S[])();

    s = s.strip(); //Means there is no trailing ws: Usefull so we only check empty once.
    if(!s.empty)
    {
        restart:
        foreach (size_t i, dchar c; s)
        {
            if(std.uni.isWhite(c))
            {
                app.put(s[0 .. i]);
                //Slice s at i+1 to manually remove the item we already know is white
                s = s[i + c.codeLength!C() .. $];
                //Then remove the rest of the whites
                s = s.stripLeft();
                goto restart; //And look for the next one
            }
        }
        //When we reach here, we know that s has no whites, but is not empty, so it HAS
        //to contain a word.
        app.put(s);
    }

    return app.data;
}
```
