### PR TITLE
move Alias to package (std.typetuple)

### DIFF
--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -670,6 +670,8 @@ unittest
     static assert(is(Filter!isPointer == TypeTuple!()));
 }
 
+// : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
+package:
 
 /*
  * With the builtin alias declaration, you cannot declare


### PR DESCRIPTION
see no reason for it to be public, so should be package until someone thinks of a reason.
