### PR TITLE
Fixes & docs for DList

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -2196,20 +2196,33 @@ Complexity: $(BIGOH 1)
 
     /// ditto
     Range linearRemove(R)(R r)
-    if (isInputRange!R && is(typeof(r.source)))
+        if (is(R == Range))
+    {
+         return remove(r);
+    }
+
+/**
+$(D linearRemove) functions as $(D remove), but also accepts ranges that are
+result the of a $(D take) operation. This is a convenient way to remove a
+fixed amount of elements from the range.
+
+Complexity: $(BIGOH r.walkLength)
+     */
+    Range linearRemove(R)(R r)
+        if (is(R == Take!Range))
     {
         if (r.empty)
-        {
             return Range(null,null);
-        }
-        enforce(r.source._first);
+        assert(r.source._first);
+
         Node* first = r.source._first;
-        Node* last;
-        while(!r.empty)
+        Node* last = void;
+        do
         {
             last = r.source._first;
             r.popFront();
-        }
+        } while ( !r.empty );
+
         return remove(Range(first, last));
     }
 


### PR DESCRIPTION
Addresses all issues in:
http://forum.dlang.org/thread/gjhclwsuqyhrimdeoaec@forum.dlang.org
and
http://d.puremagic.com/issues/show_bug.cgi?id=8905
1. Adds extra documentation on what to expect from range operations.
2. Fixes a lot of corner cases, when trying to push after poping, inparticular, the two bugs in 8905.
3. Renamed `opOpassign` into `opOpAssign`
4. Fixed the "~" operators, which were not behaving according to docuementation (and tested them in unit tests)
5. Major re-implemention of `remove` and `insertBeforeNode`, which were more or less responsible for all the bugs in DList.

Also, tons of unittests.

Finally: And this is kind of major, I scheduled for deprecation "stableRemove(R)" and "stableLinearRemove(R)", since neither could actually guarantee stability. For example:

``` D
auto a = DList([1, 2, 3]);
auto r1 = a[];
auto r2 = a[];
r1.popBack(); //[1, 2]
r2.popFront(); //[2, 3]
a.stableRemove(r1);/// DERP!
//r2 is now invalid.
```
