### PR TITLE
Import posix module only if version Posix is defined.

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -38,7 +38,7 @@ import core.stdc.config;
 import std.socket;
 
 // linux
-import core.sys.posix.sys.socket;
+version(Posix) import core.sys.posix.sys.socket;
 
 //
 // LICENSE FROM CURL HEADERS


### PR DESCRIPTION
The `curl` module always includes `core.sys.posix.sys.socket`. This is not required on non-Posix systems.  
