### PR TITLE
[RFC] Fix `move`

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1504,7 +1504,13 @@ void move(T)(ref T source, ref T target)
 in { assert(&source == &target || !pointsTo(source, source)); }
 body
 {
-    if (&source == &target) return;
+    // Performance optimization:
+    // Do not compare addresses if we don't have side effects,
+    // will not need addresses in `memcpy`, and T fits in register.
+    static if (hasElaborateCopyConstructor!T || hasElaborateAssign!T ||
+               hasElaborateDestructor!T || !isAssignable!T ||
+               T.sizeof > size_t.sizeof)
+        if (&source == &target) return;
 
     static if (hasElaborateDestructor!T)
         destruct(target, false);


### PR DESCRIPTION
It's better to analyze by commit and see commits comments for description.

And yes, I also dislike moving `const`/`immutabe` objects. But have no idea how to avoid it and not make `move` unusable.

**[EDITED] 3 times**
My `move`:

``` D
void move(T)(ref T source, ref T target)
in { assert(&source == &target || !pointsTo(source, source)); }
body
{
    // Performance optimization:
    // Do not compare addresses if we don't have side effects,
    // will not need addresses in `memcpy`, and T fits in register.
    static if (hasElaborateCopyConstructor!T || hasElaborateAssign!T ||
               hasElaborateDestructor!T || !isAssignable!T ||
               T.sizeof > size_t.sizeof)
        if (&source == &target) return;

    static if (hasElaborateDestructor!T)
        destruct(target, false);

    // If there is no elaborate assign and no elaborate copy constructor,
    // `target = source` has no side effects.
    static if (hasElaborateAssign!T || hasElaborateCopyConstructor!T || !isAssignable!T)
        memcpy(cast(void*) &target, cast(const void*) &source, T.sizeof);
    else
        target = source;

    static if (hasElaborateCopyConstructor!T || hasElaborateDestructor!T)
        setInitialState(source);
}

T move(T)(ref T source)
{
    // Can avoid to check aliasing here.

    static if (hasElaborateCopyConstructor!T || hasElaborateDestructor!T)
    {
        T result = void;
        memcpy(cast(void*) &result, cast(const void*) &source, T.sizeof);
        setInitialState(source); // from pull 928
        return result;
    }
    else
    {
        return source;
    }
}
```

I also dislike that `move` doesn't always set `source` to it's `init`. As it is documented now, it's not such a big problem as it was but it still looks inconsistent.

So can I just tell `move` to write `init` to `source` obligatory?

And don't ask me to fill all fixed `move` bug in bugzilla as it will take a full day at least and I will probably still miss something.

Requires `setInitialState` from pull #928 and `destruct` from #929.
