### PR TITLE
Add `destruct` function

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3642,6 +3642,22 @@ unittest
     assert(i is k);
 }
 
+
+/** Destructs a given object $(D t).
+
+It puts destructed object in its $(D init) state if $(D resetInitialState)
+is $(D true), otherwise object state will be undefined (i.e. possibly invalid).
+
+Note, that it destructs a given object, but not something it references.
+So to destruct a class instance, use $(D object.finalizeClassInstance).
+*/
+void destruct(T)(ref T t, bool resetInitialState = true)
+{
+    callDestructors(t);
+    if(resetInitialState)
+        setInitialState(t);
+}
+
 // Undocumented for the time being
 void toTextRange(T, W)(T value, W writer)
     if (isIntegral!T && isOutputRange!(W, char))


### PR DESCRIPTION
**[EDITED]**

We definitely need a function for object destruction which do exactly the same a compiler do in a case an object goes out of scope. First of all, it is needed for template programming:

``` D
struct S { T t; }

T* allocT() { ... }
...
T* p = allocT();
...
destruct(*t);

// These two calls must do the same as the first one do:
destruct(*cast(T[1]*) t);
destruct(*cast(S*) t);
```

An example of usage is an analog of a struct with manual memory management. Let us want to destruct such struct-analog:

``` D
void destructIt()
{
    ...
    foreach(i, T; Types)
        destruct(* cast(T*) getMemory(i)); // must destruct the object, not the reference
    ...
}
```

Also note, that _druntime_ isn't a place for template code at all so proposed `destruct` function should definitely be in _phobos_.

Not sure about module where to place `destruct`.

Requires pull #928, assumes pull D-Programming-Language/druntime#344.
