### PR TITLE
Less problems with dirEntries.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2541,7 +2541,7 @@ private struct DirIteratorImpl
         bool mayStepIn()
         {
             return (_followSymlink ? _cur.isDir : attrIsDir(_cur.linkAttributes))
-                && access(_cur.name.toStringz(), X_OK) == 0;
+                && access(_cur.name.toStringz(), X_OK | R_OK) == 0;
         }
     }
 
@@ -2718,9 +2718,17 @@ unittest
         {
             auto somedir = toStringz(buildPath(testdir, "somedir"));
             assert(access(somedir, X_OK) == 0);
+            assert(access(somedir, R_OK) == 0);
             scope(exit) chmod(somedir, octal!755);
+            assert(chmod(somedir, octal!100) == 0);
+            assert(access(somedir, X_OK) == 0);
+            assert(access(somedir, R_OK) != 0);
+            assert(equalEntries(testdir, SpanMode.shallow) == 2);
+            assert(equalEntries(testdir, SpanMode.depth) == 2);
+            assert(equalEntries(testdir, SpanMode.breadth) == 2);
             assert(chmod(somedir, octal!000) == 0);
             assert(access(somedir, X_OK) != 0);
+            assert(access(somedir, R_OK) != 0);
             assert(equalEntries(testdir, SpanMode.shallow) == 2);
             assert(equalEntries(testdir, SpanMode.depth) == 2);
             assert(equalEntries(testdir, SpanMode.breadth) == 2);


### PR DESCRIPTION
0ee90d8 solves a problem with code such as `dirEntries("somedir", SpanMode.whatever).filter!(de => de.isFile)()`, when broken symlinks are encountered. A broken symlink is simply neither a file nor a directory (but it is still a symlink), and no exception is thrown.

0ac4055 solves an issue with recursive iteration - when a directory was encountered to which the current user had insufficient rights to list its contents, an exception was thrown. Now such a directory is simply omitted from the iteration.

Both changes are Posix-only. They don't break any contracts ensured by previously existing unit tests, although the semantics of `bool exists(in char[])` and possibly some other functions may need to be revised and defined more strictly for symlinks in the near future.
`bool isDir(in char[])` and `bool isFile(in char[])` still assume that the symlinked object exists, and throw if it doesn't.
