### PR TITLE
Reformat `std.range` book table

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -531,27 +531,26 @@ are attempted in order, and the first to compile "wins" and gets
 evaluated.
 
 $(BOOKTABLE ,
-
-$(TR $(TH Code Snippet) $(TH Scenario))
-
+$(TR $(TH Code Snippet) $(TH Scenario
+))
 $(TR $(TD $(D r.put(e);)) $(TD $(D R) specifically defines a method
-$(D put) accepting an $(D E).))
-
+    $(D put) accepting an $(D E).
+))
 $(TR $(TD $(D r.put([ e ]);)) $(TD $(D R) specifically defines a
-method $(D put) accepting an $(D E[]).))
-
+    method $(D put) accepting an $(D E[]).
+))
 $(TR $(TD $(D r.front = e; r.popFront();)) $(TD $(D R) is an input
-range and $(D e) is assignable to $(D r.front).))
-
+    range and $(D e) is assignable to $(D r.front).
+))
 $(TR $(TD $(D for (; !e.empty; e.popFront()) put(r, e.front);)) $(TD
-Copying range $(D E) to range $(D R).))
-
+    Copying range $(D E) to range $(D R).
+))
 $(TR $(TD $(D r(e);)) $(TD $(D R) is e.g. a delegate accepting an $(D
-E).))
-
+    E).
+))
 $(TR $(TD $(D r([ e ]);)) $(TD $(D R) is e.g. a $(D delegate)
-accepting an $(D E[]).))
-
+    accepting an $(D E[]).
+))
 )
  */
 void put(R, E)(ref R r, E e)


### PR DESCRIPTION
Empty lines aren't allowed in `BOOKTABLE` macro as it results in inserting a "break" into a table.

Currently because of empty lines in `std.range` resulting HTML code in _phobos_ documentation on `dlang.org` is incorrect because `p` is not allowed within `table` but modern browsers fixes it by moving `<p></p>` before `table`.

_bootDoc_-generated _phobos_ documentation inserts `br` instead of `p` so result of fixing this by browsers looks poor: http://jakobovrum.github.com/bootdoc-phobos/std.range.html

This pull diff without WS-changes:
https://github.com/D-Programming-Language/phobos/pull/940/files?w=1
