### PR TITLE
tweaks in doc and impl for std.utf

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -166,7 +166,7 @@ uint stride(S)(auto ref S str, size_t index)
     if (is(S : const char[]) ||
         (isRandomAccessRange!S && is(Unqual!(ElementType!S) == char)))
 {
-    static if (hasLength!S)
+    static if (is(typeof(str.length) : ulong))
         assert(index < str.length, "Past the end of the UTF-8 sequence");
     immutable c = str[index];
 
@@ -397,7 +397,7 @@ uint stride(S)(auto ref S str, size_t index)
     if (is(S : const wchar[]) ||
         (isRandomAccessRange!S && is(Unqual!(ElementType!S) == wchar)))
 {
-    static if (hasLength!S)
+    static if (is(typeof(str.length) : ulong))
         assert(index < str.length, "Past the end of the UTF-16 sequence");
     immutable uint u = str[index];
     return 1 + (u >= 0xD800 && u <= 0xDBFF);
@@ -580,7 +580,7 @@ uint stride(S)(auto ref S str, size_t index = 0)
     if (is(S : const dchar[]) ||
         (isInputRange!S && is(Unqual!(ElementEncodingType!S) == dchar)))
 {
-    static if (hasLength!S)
+    static if (is(typeof(str.length) : ulong))
         assert(index < str.length, "Past the end of the UTF-32 sequence");
     else
         assert(!str.empty, "UTF-32 sequence is empty.");
@@ -653,7 +653,7 @@ unittest
 uint strideBack(S)(auto ref S str, size_t index)
     if (isRandomAccessRange!S && is(Unqual!(ElementEncodingType!S) == dchar))
 {
-    static if (hasLength!S)
+    static if (is(typeof(str.length) : ulong))
         assert(index <= str.length, "Past the end of the UTF-32 sequence");
     assert (index > 0, "Not the end of the UTF-32 sequence");
     return 1;


### PR DESCRIPTION
This was primarily a documentation tweak for std.utf: Certains functions, such as `stride` did not actually fully validate their input. As such, they were marked as:

"May throw a $(D UTFException)". Afterwards, in the "notes" the garantees (if any) are specified.

`decode` was specifically marked as "fully guarantees a valid sequence".

More asserts, and comments on the asserts: A commented assert is always better than an array out of range error... Also, strideBack now asserts that `index > 0`.

---

I also did a few tweaks in the implementations, in 
- `strideBack(char)`:
  The "ifs" were re-organized to first check if the index is higher than 4, in which case this will be the only check done. If the index is _not_ higher than 4, this will not require extra ifs either, so win-win.
- `strideBack(wchar)`:
  UTF-16 is "self synchronizing", so only looking at the last object is enough to know the length of the strideBack. This is faster than the current implementation. Validation is even weaker, but this does not seem to be a problem for the other forms of stride...
- `strideBack(char) For bidirectionalRange`:
  Removed the calls to save: saving a range to avoid modifying it is inconsistent with the rest of phobos: It is the caller's job to pass a saved range if re-use is intended.
  Furthermore, all flavors of `stride` accept only `input` range: If stride doesn't save, why should `strideBack`?
