### PR TITLE
Add `asFlatStaticArray`

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -672,6 +672,80 @@ unittest
     assert(overlap(c, d.idup).empty);
 }
 
+
+/**
+Represents value as a flat (single-dimention) static array.
+Considers $(D T) to be an $(D n)-dimensional static array type.
+
+Example:
+---
+int i;
+static assert(is(typeof(asFlatStaticArray(i)) == int[1]));
+asFlatStaticArray(i) = 5;
+assert(i == 5);
+
+int[1][2][3] mdimSArr;
+static assert(is(typeof(asFlatStaticArray(mdimSArr)) == int[6]));
+asFlatStaticArray(mdimSArr) = [1, 2, 3, 4, 5, 6];
+assert(mdimSArr == [[[1], [2]], [[3], [4]], [[5], [6]]]);
+
+static assert(is(typeof(asFlatStaticArray!2(mdimSArr)) == int[1][6]));
+assert(asFlatStaticArray!2(mdimSArr) == [[1], [2], [3], [4], [5], [6]]);
+---
+*/
+package ref asFlatStaticArray(T, size_t n = staticArrayDimensions!T)(ref T t)
+{
+    return *(cast(MultidimStaticArrayElementType!(T, n)
+        [multidimStaticArrayElementCount!(T, n)]*) &t);
+}
+
+/// ditto
+package ref asFlatStaticArray(size_t n, T)(ref T t)
+{
+    return asFlatStaticArray!(T, n)(t);
+}
+
+unittest
+{
+    int i;
+    static assert(is(typeof(asFlatStaticArray(i)) == int[1]));
+    asFlatStaticArray(i) = 5;
+    assert(i == 5);
+
+    int[1][2][3] mdimSArr;
+    static assert(is(typeof(asFlatStaticArray(mdimSArr)) == int[6]));
+    asFlatStaticArray(mdimSArr) = [1, 2, 3, 4, 5, 6];
+    assert(mdimSArr == [[[1], [2]], [[3], [4]], [[5], [6]]]);
+
+    static assert(is(typeof(asFlatStaticArray!2(mdimSArr)) == int[1][6]));
+    assert(asFlatStaticArray!2(mdimSArr) == [[1], [2], [3], [4], [5], [6]]);
+}
+
+unittest
+{
+    static void test(T, U, El, V, W)(U valInit, El[] sarrFrom, V arrAssign, W valNew)
+    {
+        T t = valInit;
+        auto p = &asFlatStaticArray(t);
+        assert(cast(void*) p == &t);
+        static assert((*p).sizeof == T.sizeof);
+        assert(*p == sarrFrom);
+        *p = arrAssign;
+        assert(t == valNew);
+    }
+
+    test!int(3, [3],  4 , 4);
+    test!int(3, [3], [4], 4);
+
+    test!(int[0])(null, [], null, []);
+    test!(int[0])( 3, [], null, []);
+    test!(int[0])( 3, [],  4, []);
+
+    test!(int[2])([3, 4], [3, 4], [5, 6], [5, 6]);
+    test!(int[2])(3, [3, 3], 1, [1, 1]);
+}
+
+
 /+
 Commented out until the insert which has been deprecated has been removed.
 I'd love to just remove it in favor of insertInPlace, but then code would then


### PR DESCRIPTION
`asFlatStaticArray` adds an ability to view any abject as a single-dimensional static array which is very useful for template code as it eliminates error-prone need to create branches and recursion for static-arrays support.

`asFlatStaticArray` isn't a `to*` function as it doesn't create a copy. It creates a view of object. And it is important that it doesn't require to provide any types explicitly.

Example:

``` D
int i;
static assert(is(typeof(asFlatStaticArray(i)) == int[1]));
asFlatStaticArray(i) = 5;
assert(i == 5);

int[1][2][3] mdimSArr;
static assert(is(typeof(asFlatStaticArray(mdimSArr)) == int[6]));
asFlatStaticArray(mdimSArr) = [1, 2, 3, 4, 5, 6];
assert(mdimSArr == [[[1], [2]], [[3], [4]], [[5], [6]]]);
```

Requires pull #924.
