### PR TITLE
Issue 9046 - typeof(T.init) should have the type T

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -33037,14 +33037,16 @@ unittest
   +/
 template hasOverloadedOpAssignWithDuration(T)
 {
-    enum hasOverloadedOpAssignWithDuration = __traits(compiles, T.init += dur!"days"(5)) &&
-                                             is(typeof(T.init += dur!"days"(5)) == Unqual!T) &&
-                                             __traits(compiles, T.init -= dur!"days"(5)) &&
-                                             is(typeof(T.init -= dur!"days"(5)) == Unqual!T) &&
-                                             __traits(compiles, T.init += TickDuration.from!"hnsecs"(5)) &&
-                                             is(typeof(T.init += TickDuration.from!"hnsecs"(5)) == Unqual!T) &&
-                                             __traits(compiles, T.init -= TickDuration.from!"hnsecs"(5)) &&
-                                             is(typeof(T.init -= TickDuration.from!"hnsecs"(5)) == Unqual!T);
+    enum hasOverloadedOpAssignWithDuration = is(typeof(
+    {
+        auto  d = dur!"days"(5);
+        auto td = TickDuration.from!"hnsecs"(5);
+        alias U = Unqual!T;
+        static assert(is(typeof(U.init +=  d) == U));
+        static assert(is(typeof(U.init -=  d) == U));
+        static assert(is(typeof(U.init += td) == U));
+        static assert(is(typeof(U.init -= td) == U));
+    }));
 }
 
 unittest


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9046

This is a supplemental change of compiler fix.

`hasOverloadedOpAssignWithDuration!T` returns `true` even if `T` is not a mutable type (e.g. for `const Date`). But, until now, the type of `T.init` had been accidentally unqualified by bug 9046.

@jmdavis, could you please review this?
