### PR TITLE
Supplemental fix for Issue 3449 - Stop fwdref by the immutable field

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -669,7 +669,7 @@ unittest
     {
         ubyte a,r,g,b;
 
-        immutable Colour white = Colour(255,255,255,255);
+        static immutable Colour white = Colour(255,255,255,255);
     }
     void bug8106(Colour c = Colour.white){}
     //pragma(msg, PDVT!bug8106);


### PR DESCRIPTION
This pull request is a supplemental change of [dmd/pull/93](https://github.com/D-Programming-Language/dmd/pull/93).

After fixing bug 3449, non-manifest constant immutable field will have runtime spaces in the object.
Therefore, this trivial fix is necessary to avoid forward reference error.
