### PR TITLE
Make std.typetuple.template{And, Or, Not} public as intended.

### DIFF
--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -670,174 +670,9 @@ unittest
     static assert(is(Filter!isPointer == TypeTuple!()));
 }
 
-// : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
-package:
-
-/*
- * With the builtin alias declaration, you cannot declare
- * aliases of, for example, literal values. You can alias anything
- * including literal values via this template.
- */
-// symbols and literal values
-template Alias(alias a)
-{
-    static if (__traits(compiles, { alias a x; }))
-        alias a Alias;
-    else static if (__traits(compiles, { enum x = a; }))
-        enum Alias = a;
-    else
-        static assert(0, "Cannot alias " ~ a.stringof);
-}
-// types and tuples
-template Alias(a...)
-{
-    alias a Alias;
-}
-
-unittest
-{
-    enum abc = 1;
-    static assert(__traits(compiles, { alias Alias!(123) a; }));
-    static assert(__traits(compiles, { alias Alias!(abc) a; }));
-    static assert(__traits(compiles, { alias Alias!(int) a; }));
-    static assert(__traits(compiles, { alias Alias!(1,abc,int) a; }));
-}
-
-
-// : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
-private:
-
-/*
- * [internal] Returns true if a and b are the same thing, or false if
- * not. Both a and b can be types, literals, or symbols.
- *
- * How:                     When:
- *      is(a == b)        - both are types
- *        a == b          - both are literals (true literals, enums)
- * __traits(isSame, a, b) - other cases (variables, functions,
- *                          templates, etc.)
- */
-private template isSame(ab...)
-    if (ab.length == 2)
-{
-    static if (__traits(compiles, expectType!(ab[0]),
-                                  expectType!(ab[1])))
-    {
-        enum isSame = is(ab[0] == ab[1]);
-    }
-    else static if (!__traits(compiles, expectType!(ab[0])) &&
-                    !__traits(compiles, expectType!(ab[1])) &&
-                     __traits(compiles, expectBool!(ab[0] == ab[1])))
-    {
-        static if (!__traits(compiles, &ab[0]) ||
-                   !__traits(compiles, &ab[1]))
-            enum isSame = (ab[0] == ab[1]);
-        else
-            enum isSame = __traits(isSame, ab[0], ab[1]);
-    }
-    else
-    {
-        enum isSame = __traits(isSame, ab[0], ab[1]);
-    }
-}
-private template expectType(T) {}
-private template expectBool(bool b) {}
-
-unittest
-{
-    static assert( isSame!(int, int));
-    static assert(!isSame!(int, short));
-
-    enum a = 1, b = 1, c = 2, s = "a", t = "a";
-    static assert( isSame!(1, 1));
-    static assert( isSame!(a, 1));
-    static assert( isSame!(a, b));
-    static assert(!isSame!(b, c));
-    static assert( isSame!("a", "a"));
-    static assert( isSame!(s, "a"));
-    static assert( isSame!(s, t));
-    static assert(!isSame!(1, "1"));
-    static assert(!isSame!(a, "a"));
-    static assert( isSame!(isSame, isSame));
-    static assert(!isSame!(isSame, a));
-
-    static assert(!isSame!(byte, a));
-    static assert(!isSame!(short, isSame));
-    static assert(!isSame!(a, int));
-    static assert(!isSame!(long, isSame));
-
-    static immutable X = 1, Y = 1, Z = 2;
-    static assert( isSame!(X, X));
-    static assert(!isSame!(X, Y));
-    static assert(!isSame!(Y, Z));
-
-    int  foo();
-    int  bar();
-    real baz(int);
-    static assert( isSame!(foo, foo));
-    static assert(!isSame!(foo, bar));
-    static assert(!isSame!(bar, baz));
-    static assert( isSame!(baz, baz));
-    static assert(!isSame!(foo, 0));
-
-    int  x, y;
-    real z;
-    static assert( isSame!(x, x));
-    static assert(!isSame!(x, y));
-    static assert(!isSame!(y, z));
-    static assert( isSame!(z, z));
-    static assert(!isSame!(x, 0));
-}
-
-/*
- * [internal] Confines a tuple within a template.
- */
-private template Pack(T...)
-{
-    alias T tuple;
-
-    // For convenience
-    template equals(U...)
-    {
-        static if (T.length == U.length)
-        {
-            static if (T.length == 0)
-                enum equals = true;
-            else
-                enum equals = isSame!(T[0], U[0]) &&
-                    Pack!(T[1 .. $]).equals!(U[1 .. $]);
-        }
-        else
-        {
-            enum equals = false;
-        }
-    }
-}
-
-unittest
-{
-    static assert( Pack!(1, int, "abc").equals!(1, int, "abc"));
-    static assert(!Pack!(1, int, "abc").equals!(1, int, "cba"));
-}
-
-
-/*
- * Instantiates the given template with the given list of parameters.
- *
- * Used to work around syntactic limitations of D with regard to instantiating
- * a template from a type tuple (e.g. T[0]!(...) is not valid) or a template
- * returning another template (e.g. Foo!(Bar)!(Baz) is not allowed).
- */
-// TODO: Consider publicly exposing this, maybe even if only for better
-// understandability of error messages.
-template Instantiate(alias Template, Params...)
-{
-    alias Template!Params Instantiate;
-}
-
 
 // Used in template predicate unit tests below.
-version (unittest)
+private version (unittest)
 {
     template testAlways(T...)
     {
@@ -1029,4 +864,169 @@ unittest
         // instantiations in the module.
         // static assert(!is(typeof(Instantiate!(templateOr!(testNever, testError), T))));
     }
+}
+
+
+// : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
+package:
+
+/*
+ * With the builtin alias declaration, you cannot declare
+ * aliases of, for example, literal values. You can alias anything
+ * including literal values via this template.
+ */
+// symbols and literal values
+template Alias(alias a)
+{
+    static if (__traits(compiles, { alias a x; }))
+        alias a Alias;
+    else static if (__traits(compiles, { enum x = a; }))
+        enum Alias = a;
+    else
+        static assert(0, "Cannot alias " ~ a.stringof);
+}
+// types and tuples
+template Alias(a...)
+{
+    alias a Alias;
+}
+
+unittest
+{
+    enum abc = 1;
+    static assert(__traits(compiles, { alias Alias!(123) a; }));
+    static assert(__traits(compiles, { alias Alias!(abc) a; }));
+    static assert(__traits(compiles, { alias Alias!(int) a; }));
+    static assert(__traits(compiles, { alias Alias!(1,abc,int) a; }));
+}
+
+
+// : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
+private:
+
+/*
+ * [internal] Returns true if a and b are the same thing, or false if
+ * not. Both a and b can be types, literals, or symbols.
+ *
+ * How:                     When:
+ *      is(a == b)        - both are types
+ *        a == b          - both are literals (true literals, enums)
+ * __traits(isSame, a, b) - other cases (variables, functions,
+ *                          templates, etc.)
+ */
+private template isSame(ab...)
+    if (ab.length == 2)
+{
+    static if (__traits(compiles, expectType!(ab[0]),
+                                  expectType!(ab[1])))
+    {
+        enum isSame = is(ab[0] == ab[1]);
+    }
+    else static if (!__traits(compiles, expectType!(ab[0])) &&
+                    !__traits(compiles, expectType!(ab[1])) &&
+                     __traits(compiles, expectBool!(ab[0] == ab[1])))
+    {
+        static if (!__traits(compiles, &ab[0]) ||
+                   !__traits(compiles, &ab[1]))
+            enum isSame = (ab[0] == ab[1]);
+        else
+            enum isSame = __traits(isSame, ab[0], ab[1]);
+    }
+    else
+    {
+        enum isSame = __traits(isSame, ab[0], ab[1]);
+    }
+}
+private template expectType(T) {}
+private template expectBool(bool b) {}
+
+unittest
+{
+    static assert( isSame!(int, int));
+    static assert(!isSame!(int, short));
+
+    enum a = 1, b = 1, c = 2, s = "a", t = "a";
+    static assert( isSame!(1, 1));
+    static assert( isSame!(a, 1));
+    static assert( isSame!(a, b));
+    static assert(!isSame!(b, c));
+    static assert( isSame!("a", "a"));
+    static assert( isSame!(s, "a"));
+    static assert( isSame!(s, t));
+    static assert(!isSame!(1, "1"));
+    static assert(!isSame!(a, "a"));
+    static assert( isSame!(isSame, isSame));
+    static assert(!isSame!(isSame, a));
+
+    static assert(!isSame!(byte, a));
+    static assert(!isSame!(short, isSame));
+    static assert(!isSame!(a, int));
+    static assert(!isSame!(long, isSame));
+
+    static immutable X = 1, Y = 1, Z = 2;
+    static assert( isSame!(X, X));
+    static assert(!isSame!(X, Y));
+    static assert(!isSame!(Y, Z));
+
+    int  foo();
+    int  bar();
+    real baz(int);
+    static assert( isSame!(foo, foo));
+    static assert(!isSame!(foo, bar));
+    static assert(!isSame!(bar, baz));
+    static assert( isSame!(baz, baz));
+    static assert(!isSame!(foo, 0));
+
+    int  x, y;
+    real z;
+    static assert( isSame!(x, x));
+    static assert(!isSame!(x, y));
+    static assert(!isSame!(y, z));
+    static assert( isSame!(z, z));
+    static assert(!isSame!(x, 0));
+}
+
+/*
+ * [internal] Confines a tuple within a template.
+ */
+private template Pack(T...)
+{
+    alias T tuple;
+
+    // For convenience
+    template equals(U...)
+    {
+        static if (T.length == U.length)
+        {
+            static if (T.length == 0)
+                enum equals = true;
+            else
+                enum equals = isSame!(T[0], U[0]) &&
+                    Pack!(T[1 .. $]).equals!(U[1 .. $]);
+        }
+        else
+        {
+            enum equals = false;
+        }
+    }
+}
+
+unittest
+{
+    static assert( Pack!(1, int, "abc").equals!(1, int, "abc"));
+    static assert(!Pack!(1, int, "abc").equals!(1, int, "cba"));
+}
+
+/*
+ * Instantiates the given template with the given list of parameters.
+ *
+ * Used to work around syntactic limitations of D with regard to instantiating
+ * a template from a type tuple (e.g. T[0]!(...) is not valid) or a template
+ * returning another template (e.g. Foo!(Bar)!(Baz) is not allowed).
+ */
+// TODO: Consider publicly exposing this, maybe even if only for better
+// understandability of error messages.
+template Instantiate(alias Template, Params...)
+{
+    alias Template!Params Instantiate;
 }


### PR DESCRIPTION
They accidentally ended up below a "private:" label. Now that
DMD actually checks template visibility, this rendered them
effectively unusable.
