### PR TITLE
bugfixes for compile-time regex

### DIFF
--- a/std/internal/uni.d
+++ b/std/internal/uni.d
@@ -21,6 +21,13 @@ public:
         insertInPlace(arr, idx, items);
 }
 
+//ditto + nothing better in std.algo for overlapping arrays anyway
+@trusted void copyForwardAlt(T)(T[] src, T[] dest)
+{
+    for(size_t i = 0; i < src.length; i++)
+        dest[i] = src[i];
+}
+
 //ditto
 @trusted void replaceInPlaceAlt(T)(ref T[] arr, size_t from, size_t to, T[] items...)
 in


### PR DESCRIPTION
I don't expect fixes for std.algorithm.move to land in phobos any day soon.

Let's go the faster route of just fixing the problem without it. 

The fix is trivial so don't hesitatate to just give it a nod and merge.
