### PR TITLE
Remove comments from range traits claiming that they don't require ranges

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -567,8 +567,6 @@ $(TR $(TD $(D r([ e ]);)) $(TD $(D R) is e.g. a $(D delegate)
     accepting an $(D E[]).
 ))
 )
-
-Note that $(D R) does not have to be a range.
  */
 void put(R, E)(ref R r, E e)
 {
@@ -951,8 +949,6 @@ as well as $(D moveBack) and $(D moveAt) if it's a bidirectional or
 random access range.  These may be explicitly implemented, or may work
 via the default behavior of the module level functions $(D moveFront)
 and friends.
-
-Note that $(D R) does not have to be a range.
  */
 template hasMobileElements(R)
 {
@@ -997,8 +993,6 @@ object $(D r) of type $(D R). For example, $(D ElementType!(T[])) is
 $(D T) if $(D T[]) isn't a narrow string; if it is, the element type is
 $(D dchar). If $(D R) doesn't have $(D front), $(D ElementType!R) is
 $(D void).
-
-Note that $(D R) does not have to be a range.
  */
 template ElementType(R)
 {
@@ -1028,8 +1022,6 @@ $(D wchar[]) and their qualified variants including $(D string) and
 $(D wstring)), $(D ElementEncodingType) is the character type of the
 string. For all other types, $(D ElementEncodingType) is the same as
 $(D ElementType).
-
-Note that $(D R) does not have to be a range.
  */
 template ElementEncodingType(R)
 {
@@ -1122,8 +1114,6 @@ unittest
 /**
 Tests whether $(D R) has lvalue elements.  These are defined as elements that
 can be passed by reference and have their address taken.
-
-Note that $(D R) does not have to be a range.
 */
 template hasLvalueElements(R)
 {
@@ -1166,8 +1156,6 @@ hasLength) yields $(D false) for them. This is because a narrow
 string's length does not reflect the number of characters, but instead
 the number of encoding units, and as such is not useful with
 range-oriented algorithms.
-
-Note that $(D R) does not have to be a range.
  */
 template hasLength(R)
 {
@@ -1232,8 +1220,6 @@ R r;
 auto s = r[1 .. 2];
 static assert(isInputRange!(typeof(s)));
 ----
-
-Note that $(D R) does not have to be a range.
  */
 template hasSlicing(R)
 {
@@ -2805,9 +2791,6 @@ Otherwise if $(D R) is an input range, the type of the result
 is an input range with length. Finally, if $(D R) is a forward range
 (including bidirectional), the type of the result is a forward range
 with length.
-
-Note that $(D R) does not have to be a range in case it has slicing and
-its slice has length.
  */
 auto takeExactly(R)(R range, size_t n)
 if (isInputRange!R && !hasSlicing!R)
@@ -3596,7 +3579,7 @@ infinite (fact that would make $(D Cycle) the identity application),
 $(D Cycle) detects that and aliases itself to the range type
 itself. If the original range has random access, $(D Cycle) offers
 random access and also offers a constructor taking an initial position
-$(D index). $(D Cycle) is specialized for statically-sized arrays,
+$(D index). $(D Cycle) works with static arrays in addition to ranges,
 mostly for performance reasons.
 
 Example:
@@ -3605,9 +3588,6 @@ assert(equal(take(cycle([1, 2][]), 5), [ 1, 2, 1, 2, 1 ][]));
 ----
 
 Tip: This is a great way to implement simple circular buffers.
-
-Note that $(D Range) does not have to be a range as $(D Cycle) also
-accepts static arrays which aren't ranges (see $(LREF isInputRange)).
 */
 struct Cycle(Range)
     if (isForwardRange!(Unqual!Range) && !isInfinite!(Unqual!Range))
@@ -6362,8 +6342,6 @@ unittest
    Moves the front of $(D r) out and returns it. Leaves $(D r.front) in a
    destroyable state that does not allocate any resources (usually equal
    to its $(D .init) value).
-
-   Note that $(D R) does not have to be a range.
 */
 ElementType!R moveFront(R)(R r)
 {
@@ -6394,8 +6372,6 @@ unittest
    Moves the back of $(D r) out and returns it. Leaves $(D r.back) in a
    destroyable state that does not allocate any resources (usually equal
    to its $(D .init) value).
-
-   Note that $(D R) does not have to be a range.
 */
 ElementType!R moveBack(R)(R r)
 {
@@ -6432,8 +6408,6 @@ unittest
    Moves element at index $(D i) of $(D r) out and returns it. Leaves $(D
    r.front) in a destroyable state that does not allocate any resources
    (usually equal to its $(D .init) value).
-
-   Note that $(D R) does not have to be a range.
 */
 ElementType!R moveAt(R, I)(R r, I i) if (isIntegral!I)
 {


### PR DESCRIPTION
I don't know why these were added or how they got past the reviewers,
but it makes no sense for traits which check ranges for various
attributes to say that they don't require a range - especially when they
specifically check stuff like front! The only two where such a comment
makes sense (hasLength and ElementType) already had such comments,
making the comments added to them redundant, whereas the others were
just plain wrong. This commit removes all of those incorrect comments.
