### PR TITLE
Implement issue# 9103.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -3597,7 +3597,7 @@ few times as possible.
  */
 Tuple!(Range, size_t) find(alias pred = "a == b", Range, Ranges...)
 (Range haystack, Ranges needles)
-if (Ranges.length > 1 && allSatisfy!(isForwardRange, Ranges))
+if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 {
     for (;; haystack.popFront())
     {
@@ -3616,6 +3616,8 @@ unittest
     auto s1 = "Mary has a little lamb";
     //writeln(find(s1, "has a", "has an"));
     assert(find(s1, "has a", "has an") == tuple("has a little lamb", 1));
+    assert(find(s1, 't', "has a", "has an") == tuple("has a little lamb", 2));
+    assert(find(s1, 't', "has a", 'y', "has an") == tuple("y has a little lamb", 3));
     assert(find("abc", "bc").length == 2);
 }
 


### PR DESCRIPTION
find should work with multiple needles which are a combination of
elements and ranges rather than just all ranges - just like startsWith
and endsWith do - and since that overload of find calls startsWith, it's
trivial to make it take the same types of arguments as startsWith.
