### PR TITLE
Issue 2486 - taking address of slice rvalue is valid

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2844,10 +2844,13 @@ unittest
 unittest
 {
     //Check proper failure
-    auto ss = "[ 1 , 2 , 3 ]";
-    foreach(i ; 0..ss.length-1)
-        assertThrown!ConvException(parse!(int[])(ss[0 .. i]));
-    int[] arr = parse!(int[])(ss);
+    auto s = "[ 1 , 2 , 3 ]";
+    foreach(i ; 0..s.length-1)
+    {
+        auto ss = s[0 .. i];
+        assertThrown!ConvException(parse!(int[])(ss));
+    }
+    int[] arr = parse!(int[])(s);
 }
 
 /// ditto
@@ -2971,10 +2974,13 @@ unittest
 unittest
 {
     //Check proper failure
-    auto ss = "[1:10, 2:20, 3:30]";
-    foreach(i ; 0..ss.length-1)
-        assertThrown!ConvException(parse!(int[int])(ss[0 .. i]));
-    int[int] aa = parse!(int[int])(ss);
+    auto s = "[1:10, 2:20, 3:30]";
+    foreach(i ; 0..s.length-1)
+    {
+        auto ss = s[0 .. i];
+        assertThrown!ConvException(parse!(int[int])(ss));
+    }
+    int[int] aa = parse!(int[int])(s);
 }
 
 private dchar parseEscape(Source)(ref Source s)

--- a/std/exception.d
+++ b/std/exception.d
@@ -817,7 +817,11 @@ enum emptyExceptionMsg = "<Empty Exception Message>";
  * assumeUnique) is simple and rare enough to be tolerable.
  *
  */
-
+immutable(T)[] assumeUnique(T)(T[] array) pure nothrow
+{
+    return .assumeUnique(array);    // call ref version
+}
+/// ditto
 immutable(T)[] assumeUnique(T)(ref T[] array) pure nothrow
 {
     auto result = cast(immutable(T)[]) array;
@@ -857,7 +861,9 @@ internal pointers. This should only be done as an assertive test,
 as the language is free to assume objects don't have internal pointers
 (TDPL 7.1.3.5).
 */
-bool pointsTo(S, T, Tdummy=void)(ref const S source, ref const T target) @trusted pure nothrow
+bool pointsTo(S, T, Tdummy=void)(auto ref const S source, auto ref const T target) @trusted pure nothrow
+    if ((__traits(isRef, source) || isDynamicArray!S) &&    // lvalue or slice rvalue
+        (__traits(isRef, target) || isDynamicArray!T))      // lvalue or slice rvalue
 {
     static if (is(S P : U*, U))
     {
@@ -889,8 +895,7 @@ bool pointsTo(S, T, Tdummy=void)(ref const S source, ref const T target) @truste
 // for shared objects
 bool pointsTo(S, T)(ref const shared S source, ref const shared T target) @trusted pure nothrow
 {
-    alias pointsTo!(shared(S), shared(T), void) ptsTo;  // do instantiate explicitly
-    return ptsTo(source, target);
+    return pointsTo!(shared S, shared T, void)(source, target);
 }
 unittest
 {

--- a/std/regex.d
+++ b/std/regex.d
@@ -3765,6 +3765,10 @@ template BacktrackingMatcher(bool CTregex)
             debug(fred_matching) writeln("pop element SP= ", lastState);
         }
 
+        void stackPop(T)(T[] val)
+        {
+            stackPop(val);  // call ref version
+        }
         void stackPop(T)(ref T[] val)
         {
             lastState -= val.length*(T.sizeof/size_t.sizeof);
@@ -4388,6 +4392,10 @@ struct CtContext
 
     // generate fixup code for instruction in ir,
     // fixup means it has an alternative way for control flow
+    string ctGenFixupCode(Bytecode[] ir, int addr, int fixup)
+    {
+        return ctGenFixupCode(ir, addr, fixup); // call ref Bytecode[] version
+    }
     string ctGenFixupCode(ref Bytecode[] ir, int addr, int fixup)
     {
         string r;

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -367,7 +367,8 @@ public struct UUID
                     {
                         try
                         {
-                            data2[element++] = parse!ubyte(uuid[pairStart .. pos+1], 16);
+                            auto part = uuid[pairStart .. pos+1];
+                            data2[element++] = parse!ubyte(part, 16);
                             pairStart = -1;
                         }
                         catch(Exception e)
@@ -1275,7 +1276,8 @@ UUID parseUUID(Range)(ref Range uuidRange) if(isInputRange!Range
                         parserError(consumed, UUIDParsingException.Reason.tooLittle,
                             "Insufficient Input");
                     }
-                    result.data[element++] = parse!ubyte(uuidRange[0 .. 2], 16);
+                    auto part = uuidRange[0 .. 2];
+                    result.data[element++] = parse!ubyte(part, 16);
                     uuidRange.popFront();
                 }
                 else
@@ -1289,7 +1291,8 @@ UUID parseUUID(Range)(ref Range uuidRange) if(isInputRange!Range
                             "Insufficient Input");
                     }
                     copyBuf[1] = uuidRange.front;
-                    result.data[element++] = parse!ubyte(copyBuf[], 16);
+                    auto part = copyBuf[];
+                    result.data[element++] = parse!ubyte(part, 16);
                 }
 
                 if(element == 16)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=2486
1. Add overload function to receive rvalue slices.
2. `std.conv.parse` should only receive just lvalues, so give a made variable to bind the slice result in caller side explicitly.

Rrequires: https://github.com/D-Programming-Language/dmd/pull/1343
