### PR TITLE
fixup for pull #1301 and #1309

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2417,8 +2417,10 @@ template hasElaborateAssign(S)
     }
     else
     {
+        @property auto ref lvalueOf() { static S s = void; return s; }
+
         enum hasElaborateAssign = is(typeof(S.init.opAssign(S.init))) ||
-                                  is(typeof(S.init.opAssign({ S s = void; return s; }()))) ||
+                                  is(typeof(S.init.opAssign(lvalueOf))) ||
             anySatisfy!(.hasElaborateAssign, typeof(S.tupleof));
     }
 }


### PR DESCRIPTION
By fixing bug 9069 and 9035, T.init always returns rvalue and ref cannot receive it.
