### PR TITLE
Update in chunks

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -6529,8 +6529,8 @@ struct Chunks(Source)
         }
         else
         {
-            //Dollar token caries a static type, with no extra information.
-            //It can lazilly transform into _source.length on algorithmic
+            //Dollar token carries a static type, with no extra information.
+            //It can lazily transform into _source.length on algorithmic
             //operations such as : chunks[$/2, $-1];
             private static struct DollarToken
             {


### PR DESCRIPTION
Basically the old `if(isInputRange!Source && hasSlicing!Source && hasLength!Source)` was pretty much the same as "finite RA".

This implementation only requires `ForwardRange`. This means `chunks` can now be used with "simple" ranges, such as `byLine` (to read blocks of lines at once), or `filter`, or infinite ranges, both non-ra (Fib by blocks), or with RA and slicing (Sequence).

AFAIK, chunks requires _at least_ forward: I don't think it could work on a input only.

Implementation wise, there is not much: slicing was basically just changed for `take`, and everything works just as well. I re-organized a bit so as to document what functions require what traits from `Source`. Finally, I improved on the implementations of `Back`/`popBack`/`Length`, simply by using more accurate arithmetics.

This pull currently works, but would require #854 to fully unlock the slicing functionality of infinite ranges, and requires #991 so as to test said functionality.
