### PR TITLE
Fix std.parallelism test

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4116,8 +4116,7 @@ unittest
         auto tSlow = task!slowFun();
         pool1.put(tSlow);
         pool1.finish();
-        assert(!tSlow.done);
-        tSlow.yieldForce;
+        tSlow.yieldForce();
         // Can't assert that pool1.status == PoolState.stopNow because status 
         // doesn't change until after the "done" flag is set and the waiting
         // thread is woken up.


### PR DESCRIPTION
Fix incorrect test. Calling finish(false) doesn't guarantee that the task won't be complete immediately after finish() returns.
