### PR TITLE
changed return type of NWayUnion.front to auto ref

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -9350,7 +9350,7 @@ struct NWayUnion(alias less, RangeOfRanges)
 
     @property bool empty() { return _ror.empty; }
 
-    @property ref ElementType front()
+    @property auto ref front()
     {
         return _heap.front.front;
     }


### PR DESCRIPTION
NWayUnion seems to be the only bad guy in `std.algorithm` who uses `ref ElementType` to return `front`. This bugged me when I tried to use it with `std.algorithm.map`.
