### PR TITLE
10% faster compile for std.algorithm

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -323,12 +323,11 @@ private:
         string decl = "";
         foreach (i, name; staticMap!(extractName, fieldSpecs))
         {
-            enum    field = Format!("Identity!(field[%s])",i);
-            enum numbered = Format!("_%s", i);
-            decl ~= Format!("alias %s %s;", field, numbered);
+            enum numbered = toStringNow!(i);
+            decl ~= "alias Identity!(field[" ~ numbered ~ "]) _" ~ numbered ~ ";";
             if (name.length != 0)
             {
-                decl ~= Format!("alias %s %s;", numbered, name);
+                decl ~= "alias _" ~ numbered ~ " " ~ name ~ ";";
             }
         }
         return decl;


### PR DESCRIPTION
by fixing the incredibly slow Tuple code.

This reduces the number of templates instantiated by the unit tests in std.algorithm, by several thousand. Should improve compile time and memory usage of other parts of Phobos, as well.
