### PR TITLE
Changing ByCodepoint's "save" signature 

### DIFF
--- a/std/internal/uni.d
+++ b/std/internal/uni.d
@@ -439,7 +439,7 @@ struct CodepointSet
                     j = ivals[0];
             }
         }
-        @property auto ref save() const { return this; }
+        @property ByCodepoint save() const { return this; }
     }
     static assert(isForwardRange!ByCodepoint);
 


### PR DESCRIPTION
Spliced from a pull in a branch I accidently deleted.

`std.internal.uni.ByCodepoint.save`:

1) Because if it returns a ref, then it isn't actually saving anything...
2) Changed the auto return type (which resolves to `const ByCodepoint`) to an explicit `ByCodepoint`. This means the static return type is not const, and can be stored directly in an auto.

The change is mostly moot, since it would appear ByCodepoint's save or forwardness is never used anyways. But that doesn't mean it shouldn't be correct.
