### PR TITLE
fixup for Issue 8902

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -683,7 +683,6 @@ struct FormatSpec(Char)
     {
         union
         {
-            ubyte allFlags;
             mixin(bitfields!(
                         bool, "flDash", 1,
                         bool, "flZero", 1,
@@ -691,6 +690,7 @@ struct FormatSpec(Char)
                         bool, "flPlus", 1,
                         bool, "flHash", 1,
                         ubyte, "", 3));
+            ubyte allFlags;
         }
     }
 


### PR DESCRIPTION
After default initialization, only the first one in overlapped fields is readable in CTFE.

Required: https://github.com/D-Programming-Language/dmd/pull/1369
