### PR TITLE
Consolidating forward range requirements

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -743,7 +743,7 @@ The following code should compile for any forward range.
 ----
 static assert(isInputRange!R);
 R r1;
-R r2 = r1.save; // can save the current position into another range
+static assert (is(typeof(r1.save) == R));
 ----
 
 Saving a range is not duplicating it; in the example above, $(D r1)
@@ -761,7 +761,7 @@ template isForwardRange(R)
     (inout int = 0)
     {
         R r1 = void;
-        R r2 = r1.save; // can call "save" against a range object
+        static assert (is(typeof(r1.save) == R));
     }));
 }
 


### PR DESCRIPTION
Spliced from another pull I messed up beyond repair.

Basically, `save` doesn't require an actual type match, but merely implicit cast back to the original type.

This can be problematic if the save is stored in an `auto`, or forwarded straight to a template. In particular, it may instantiate the wrong template, or even fail compile if the result of save is some sort of weird non-range proxy. Things get especially funky if you pass the save to a take or similar.

Keeping this behavior means that you pretty much have to throw `auto bck = r.save;` out the window in favor of `R bck = r.save;` or `typeof(r) bck = r.save;`. More importantly, the one-liners `foo(r.save)` becomes non-valid, for the cases where foo is a template.

This pull identified a invalid forward range (ByCodePoint), which is fixed in #1006 EDIT: Done

Unfortunately, like the hasSlicing pull, this pull is still subject to 8847 http://d.puremagic.com/issues/show_bug.cgi?id=8847 ...

So I'm mostly posting this pull request to "get the ball rolling" regarding discussion, and to increase importance of 8847.
