### PR TITLE
improvements to uninitializedFill && initializeAll

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1142,6 +1142,7 @@ void initializeAll(Range)(Range range)
     else
         fill(range, T.init);
 }
+
 // ditto
 void initializeAll(Range)(Range range)
     if (is(Range == char[]) || is(Range == wchar[]))
@@ -1163,7 +1164,7 @@ unittest
     assert(a[] == [char.init, char.init, char.init]);
     string s;
     assert(!__traits(compiles, s.initializeAll()));
-    
+
     //Note: Cannot call uninitializedFill on narrow strings
 
     enum e {e1, e2}


### PR DESCRIPTION
I've had this planned for _months_ now, but kept getting sidetracked, in particular, by things like emplace/move and whatnot.

Because they didn't really handle all of the cases correctly. In particular `uninitializedFill`.

I removed support for calling `uninitializedFill` and `initializeAll` for ranges that don't expose references to its members. Trying to support that is (IMO) stupid, and error prone.

In particular, I think it is especially bad design in that it will accept to work if there is no elaborate opAssign. The problem is that if you _do_ add a `opAssign` to your type, then your code will stop compiling, as opposed to just taking another branch. This kind of behavior is (again, IMO) bad design.
## initializeAll

The good news is that `initializeAll` was so broken that it didn't compile for ranges that didn't expose references (it used an undefined `filler`). This means it wasn't physically possible to even call it. Ergo, I removed support for this entirely.

I also added an overload to `initializeAll` so that it could operate on narrow (mutable) strings (which was not the case before).
## uninitializedFill

Less change in `uninitializedFill`. I just simplified the branching a little, by adding a deprecated overload for non-hasLvalue ranges.

---

Added unit tests that at least cover all branches.
