### PR TITLE
Doc fix: an O(1) op was documented as O(log(n))

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -1100,7 +1100,7 @@ iterating over the container are never invalidated.
 
 Returns: The number of elements inserted
 
-Complexity: $(BIGOH log(n))
+Complexity: $(BIGOH m), where $(D m) is the length of $(D stuff)
      */
     size_t insertFront(Stuff)(Stuff stuff)
     if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))


### PR DESCRIPTION
I thought it was odd that inserting an element at the front of a singly-linked-list would be an O(log(n)) operation.  Too expensive!  So I looked at the code and it does seem to be O(1).  I'm hoping this is just needing a documentation edit ;)
