### PR TITLE
Fix issue 8061.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2814,7 +2814,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
             // We cannot export .save method unless we ensure subranges are not
             // consumed when a .save'd copy of ourselves is iterated over. So
             // we need to .save each subrange we traverse.
-            static if (isForwardRange!(ElementType!RoR))
+            static if (isForwardRange!RoR && isForwardRange!(ElementType!RoR))
                 _current = _items.front.save;
             else
                 _current = _items.front;


### PR DESCRIPTION
We cannot assume that RoR.save will also .save the state of its
subranges; so the only way we can correctly export a .save method in the
joined range is if we also .save its subranges as we traverse over them.
