### PR TITLE
Fix transient and forward range bugs in joiner with separator

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2665,6 +2665,14 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
         private ElementType!RoR _current;
         private Separator _sep, _currentSep;
 
+        // This is a mixin instead of a function for the following reason (as
+        // explained by Kenji Hara): "This is necessary from 2.061.  If a
+        // struct has a nested struct member, it must be directly initialized
+        // in its constructor to avoid leaving undefined state.  If you change
+        // setItem to a function, the initialization of _current field is
+        // wrapped into private member function, then compiler could not detect
+        // that is correctly initialized while constructing.  To avoid the
+        // compiler error check, string mixin is used."
         private enum setItem =
         q{
             if (!_items.empty)


### PR DESCRIPTION
This pull request concerns the variant of joiner that takes a separator (the other pull request is for the one without separator).

The joiner is revamped to work correctly with transient ranges (not assume that .front remains valid after calling .popFront).

It is also fixed to always iterate on a .save'd copy of subranges, when forward ranges are involved, because the outer range's .save is not guaranteed to preserve the states of the inner ranges.

**Note:** please review the full code for joiner, not just the diff, because GitHub's context diff may be missing important parts of the functions. The logic has been extensively revamped, but the new code is similar enough to the old code that some important context may be left out in GitHub's diff output.
