### PR TITLE
Stack overflow test **DO NOT PULL**

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2940,17 +2940,18 @@ unittest
 }
 
 // Temporarily disable this unittest due to issue 9131 on OSX/64.
-version = Issue9131;
+//version = Issue9131;
 version(Issue9131) {} else
 unittest
 {
     struct TransientRange
     {
-        dchar[128] _buf;
+        dchar[] _buf;
         dstring[] _values;
         this(dstring[] values)
         {
             _values = values;
+	    _buf.length = 128;
         }
         @property bool empty()
         {
@@ -2979,8 +2980,8 @@ unittest
         result ~= c;
     }
 
-    assert(equal(result, "abc12def34"d),
-    	"Unexpected result: '%s'"d.format(result));
+    assert(equal(result, "abc12def34"),
+    	"Unexpected result: '%s'".format(result));
 }
 
 // uniq


### PR DESCRIPTION
Reenable failing unittest and change to use heap instead of stack for
transient buffer. The OSX/64 problem _may_ be related to stack overflow.

**Do not pull this request; I just wanted to use the autotester to verify whether or not issue 9131 is related to stack overflow on OSX/64.**
