### PR TITLE
Minor tweaks in std.string

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -29,7 +29,7 @@ import core.exception : RangeError, onRangeError;
 import core.vararg, core.stdc.stdlib, core.stdc.string,
     std.algorithm, std.ascii, std.conv, std.exception, std.format, std.functional,
     std.metastrings, std.range, std.regex, std.traits,
-    std.typetuple, std.uni, std.utf;
+    std.typecons, std.typetuple, std.uni, std.utf;
 
 //Remove when repeat is finally removed. They're only here as part of the
 //deprecation of these functions in std.string.


### PR DESCRIPTION
Very minor changes in std.string:
- `FormatError => FormatException`

Basically just because `FormatError` is deprecated. While it was used in "deprecated unittest", it also appeared in some "non-deprecated unittest". This means that `rdmd --main -unittest std/string.d` did not compile. Given that none of those tests where testing the _actual_ `FormatError` (which is just an alias anyways), it had no reason to stay.
- Extra example in representation

Just 'cause "why not?". Technically, you don't need to call representation to do this, but I think it expresses much more visually and directly what we the intent is.
- Extra Unittest block in representation

Because we should _always_ validate out examples.
- Refactored unittest of representation

Added a `foreach(Type; TypeTuple!(Tuple!(char , ubyte ), ... )` in there. Not a huge difference, but I think it is important for our code base to be as clean as possible. People read and learn from it, and judge us by the quality of the code in it.
