### PR TITLE
Fix Windows makefiles' install target

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -758,7 +758,7 @@ cleanhtml:
 	del $(DOCS)
 
 install: phobos.zip
-	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib\
-	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib\
-	+rd/s/q $(DIR)\src\phobos\
-	unzip -o phobos.zip -d $(DIR)\src\phobos\
+	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib\ 
+	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib\ 
+	+rd/s/q $(DIR)\src\phobos\ 
+	unzip -o phobos.zip -d $(DIR)\src\phobos\ 

--- a/win64.mak
+++ b/win64.mak
@@ -811,7 +811,7 @@ cleanhtml:
 	del $(DOCS)
 
 install: phobos.zip
-	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib\
-	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib\
-	+rd/s/q $(DIR)\src\phobos\
-	unzip -o phobos.zip -d $(DIR)\src\phobos\
+	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib\ 
+	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib\ 
+	+rd/s/q $(DIR)\src\phobos\ 
+	unzip -o phobos.zip -d $(DIR)\src\phobos\ 


### PR DESCRIPTION
I'm confused how this problem (no whitespace after trailing backslash) keeps appearing again and again. I've already figured out that Walter and I must be the the only users of the win##.mak install target. However, apparently Walter isn't even using the version of make.exe from the DMD zip files? (That, or I'm the only one who uses the install target.)
