### PR TITLE
Fix for issue# 9214.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -31062,7 +31062,7 @@ void f0() {}
 void f1() {auto b = a;}
 void f2() {auto b = to!(string)(a);}
 auto r = benchmark!(f0, f1, f2)(10_000);
-writefln("Milliseconds to call fun[0] n times: %s", r[0].to!("msecs", int));
+writefln("Milliseconds to call fun[0] n times: %s", r[0].msecs);
 --------------------
   +/
 TickDuration[lengthof!(fun)()] benchmark(fun...)(uint n)
@@ -31092,7 +31092,7 @@ version(testStdDateTime) unittest
     void f1() {auto b = a;}
     void f2() {auto b = to!(string)(a);}
     auto r = benchmark!(f0, f1, f2)(10_000);
-    writefln("Milliseconds to call fun[0] n times: %s", r[0].to!("msecs", int)());
+    writefln("Milliseconds to call fun[0] n times: %s", r[0].msecs);
 }
 
 version(testStdDateTime) @safe unittest


### PR DESCRIPTION
I don't think that it makes any sense for core.time.TickDuration.to to
be a property, since it's a conversion function, not an abstraction for
a variable. However, it _does_ make sense for the example to use one of
TickDuration's property functions instead (it makes the code cleaner
too). So, I've done that. And if the property debate results in
non-property functions being allowed to be called without parens (as
currently seems likely), then anyone wanting to use the to function
without the extra parens can do so then.
