### PR TITLE
Fix previous bug in countUntil

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -4263,7 +4263,7 @@ ptrdiff_t countUntil(alias pred = "a == b", R1, R2)(R1 haystack, R2 needle)
     }
     else
     {
-        if (r2.empty)
+        if (needle.empty)
             return 0;
 
         //Default case, slower route doing startsWith iteration


### PR DESCRIPTION
As pointed out by denish-sh in:
https://github.com/D-Programming-Language/phobos/pull/1024
Also, more unittests.

To note: This actually fixes another (pre-existing) bug, where comparing two empty no-length ranges would actually return -1, whereas it should return 0:

``` D
assert(countUntil("", "") == 0); //before-after
assert(countUntil("".filter!"true"(), "") == -1); //before
assert(countUntil("".filter!"true"(), "") ==  0); //after
```

---

I'm actually at relatives', and can't deploy a full testing environment, so I'm coding blind on github-web. My apologies if this doesn't pass the testers the first time. Please don't merge until the D2 tester is finished.
