### PR TITLE
std.conv integral radix conversion, to work when destination T is not string or char[]

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1066,6 +1066,7 @@ unittest
     assert(to!dstring(o) == "cast(EU)5"d);
 }
 
+
 /// ditto
 T toImpl(T, S)(S value, uint radix)
     if (isIntegral!S &&
@@ -1089,11 +1090,16 @@ body
         uint i = buffer.length;
 
         if (value < radix && value < hexDigits.length)
-        static if (isAssignable!(T,string))
-            return hexDigits[cast(size_t)value .. cast(size_t)value + 1];
-        else 
-            return to!T(hexDigits[cast(size_t)value .. cast(size_t)value+1]);
-
+	{
+		static if (isAssignable!(T, string))
+		{
+			return hexDigits[cast(size_t)value .. cast(size_t)value + 1];
+		}
+		else
+		{
+			return to!T(hexDigits[cast(size_t)value .. cast(size_t)value + 1]);
+		}
+	}
         do
         {
             ubyte c;
@@ -1102,12 +1108,17 @@ body
             i--;
             buffer[i] = cast(char)((c < 10) ? c + '0' : c + 'A' - 10);
         } while (value);
-        static if (isAssignable!(T,char[]))
-            return to!T(buffer[i .. $].dup);
-        else
-            return to!T(buffer[i .. $]);
+	static if (isAssignable!(T,char[]))
+	{
+		return to!T(buffer[i .. $].dup);
+	}
+	else
+	{
+		return to!T(buffer[i .. $]);
+	}
     }
 }
+
 
 unittest
 {


### PR DESCRIPTION
Encountered issue that
T toImpl(T, S)(S value, uint radix) did not work for T == immutable(wchar)[].
Using isAssignable!(R,L) to figure out if .dup is required on local buffer.
