### PR TITLE
Issue 8367 - Insufficient constraints for chain

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -2016,7 +2016,9 @@ assert(equal(s, [1, 2, 3, 4, 5, 6, 7][]));
 ----
  */
 auto chain(Ranges...)(Ranges rs)
-if (Ranges.length > 0 && allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)))
+if (Ranges.length > 0 &&
+    allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)) &&
+    !is(CommonType!(staticMap!(ElementType, staticMap!(Unqual, Ranges))) == void))
 {
     static if (Ranges.length == 1)
     {


### PR DESCRIPTION
The error message from compiling the bug's sample code after this change is:

```
bug.d(11): Error: template std.range.chain does not match any function template declaration. Candidates are:
std/range.d(2018):        std.range.chain(Ranges...)(Ranges rs) if (Ranges.length > 0 && allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)) && !is(CommonType!(staticMap!(ElementType, staticMap!(Unqual, Ranges))) == void))
bug.d(11): Error: template std.range.chain(Ranges...)(Ranges rs) if (Ranges.length > 0 && allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)) && !is(CommonType!(staticMap!(ElementType, staticMap!(Unqual, Ranges))) == void)) cannot deduce template function from argument types !()(MapResult!(__lambda2, Foo[]),string)
```

Fixes Issue 8367
http://d.puremagic.com/issues/show_bug.cgi?id=8367
