### PR TITLE
Issue 8368 - Insufficient constraints for sort

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -7825,6 +7825,11 @@ sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
         isRandomAccessRange!Range &&
         hasSlicing!Range &&
         hasLength!Range)
+    /+ Unstable sorting uses the quicksort algorithm, which uses swapAt,
+       which either uses swap(...), requiring swappable elements, or just
+       swaps using assignment.
+       Stable sorting uses TimSort, which needs to copy elements into a buffer,
+       requiring assignable elements. +/
 {
     alias binaryFun!(less) lessFun;
     alias typeof(lessFun(r.front, r.front)) LessRet;    // instantiate lessFun


### PR DESCRIPTION
Error from bug code after this change:

```
Error: template std.algorithm.sort does not match any function template declaration. Candidates are:
std/algorithm.d(7820):        std.algorithm.sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable, Range)(Range r) if ((ss == SwapStrategy.unstable && (hasSwappableElements!(Range) || hasAssignableElements!(Range)) || ss != SwapStrategy.unstable && hasAssignableElements!(Range)) && isRandomAccessRange!(Range) && hasSlicing!(Range) && hasLength!(Range))
bug.d(6): Error: template std.algorithm.sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable, Range)(Range r) if ((ss == SwapStrategy.unstable && (hasSwappableElements!(Range) || hasAssignableElements!(Range)) || ss != SwapStrategy.unstable && hasAssignableElements!(Range)) && isRandomAccessRange!(Range) && hasSlicing!(Range) && hasLength!(Range)) cannot deduce template function from argument types !()(MapResult!(__lambda2, string[]))
```

Fixes Issue 8368
http://d.puremagic.com/issues/show_bug.cgi?id=8368
