### PR TITLE
Tuple improvements (specifically: opCmp)

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -836,6 +836,48 @@ unittest
         Tuple!(long, uint) t2 = ints;
         assert(t2[0] == 1 && t2[1] == 2);
     }
+    // opCmp runtime
+    {
+        struct S
+        {
+            int i;
+            int opCmp(const S rhs) const pure @safe
+            {
+                if (i != rhs.i)
+                    return (i < rhs.i) ? -1 : 1;
+                return 0;
+            }
+            int opCmp(const int rhs) const pure @safe
+            {
+                if (i != rhs)
+                    return (i < rhs) ? -1 : 1;
+                return 0;
+            }
+            bool opEquals(T)(T rhs) const {assert(0);}
+        }
+        //Uniform initialization
+        auto s(int k){return S(k);}
+        auto i(int k){return k;}
+        foreach (f1; TypeTuple!(i, s))
+        {
+            foreach (f2; TypeTuple!(i, s))
+            {
+                auto a = tuple(f1(1), f2(2));
+                auto b = tuple(f2(1), f1(2));
+                auto c = tuple(f1(2), f2(0));
+                const d = tuple(f2(2), f1(0));
+                const e = tuple(f1(1), f2(0));
+                const f = tuple(f2(1), f1(0));
+                assert(a <= b && a >= b);
+                assert(c <= d && c >= d);
+                assert(e <= f && e >= f);
+
+                assert(a < c && a < d && b < c && b < d);
+                assert(a > e && a > f && b > e && b > f);
+                assert(c > e && c > f && d > e && d > f);
+            }
+        }
+    }
 }
 @safe unittest
 {


### PR DESCRIPTION
3 parts:
1. Made the interfaces auto ref. We really shouldn't be making copies when we can pass by ref.
2. Improved the implementation of opCmp:

Fixes: It is not actually legal to call a user defined type's `opEqual` (`!=`) when testing user-defined inequality. The "legal" code should be:

``` D
if (lhs < rhs)
    return -1;
if (lhs > rhs) //NOT "if (rhs < lhs)": This could call a different function
    return 1;
return 0;
```

However, implementing `opCmp` in terms of `<` is _very_ ineficient, especially when lhs and rhs have opCmp already... So I improved the runtime by calling opCmp directly when possible.
1. Improved opCmp unittests.

This verifies that: 1) Tuples of different types can be compared (eg Tuple!int vs Tuple!short) and 2) Makes sure you get the correct run-time result.
