### PR TITLE
Improve std.file.dirEntries ddoc

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2661,6 +2661,9 @@ unittest
                          should be treated as directories and their contents
                          iterated over.
 
+    Throws:
+        $(D FileException) if the directory does not exist.
+
 Examples:
 --------------------
 // Iterate over all D source files in current directory and all its


### PR DESCRIPTION
Add missing documentation on thrown exceptions in second variant of dirEntries.

Also trivial fix to remove two ugly stray //'s from the html output.
