### PR TITLE
Fix mismatched parens in DDoc.

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3468,7 +3468,7 @@ unittest
 
 /**
     Eagerly advances $(D r) itself (not a copy) up to $(D n) times (by
-    calling $(D r.popFront()). $(D popFrontN) takes $(D r) by $(D ref),
+    calling $(D r.popFront)). $(D popFrontN) takes $(D r) by $(D ref),
     so it mutates the original range. Completes in $(BIGOH 1) steps for ranges
     that support slicing and have length.
     Completes in $(BIGOH n) time for all other ranges.
@@ -3596,7 +3596,7 @@ unittest
 
 /**
     Eagerly advances $(D r) itself (not a copy) exactly $(D n) times (by
-    calling $(D r.popFront). $(D popFrontExactly) takes $(D r) by $(D ref),
+    calling $(D r.popFront)). $(D popFrontExactly) takes $(D r) by $(D ref),
     so it mutates the original range. Completes in $(BIGOH 1) steps for ranges
     that support slicing, and have either length or are infinite.
     Completes in $(BIGOH n) time for all other ranges.

--- a/std/socket.d
+++ b/std/socket.d
@@ -2994,7 +2994,7 @@ public:
 
     /**
      * Wait for a socket to change status. A wait timeout of $(Duration) or
-     * $(D TimeVal, may be specified; if a timeout is not specified or the
+     * $(D TimeVal), may be specified; if a timeout is not specified or the
      * $(D TimeVal) is $(D null), the maximum timeout is used. The $(D TimeVal)
      * timeout has an unspecified value when $(D select) returns.
      * Returns: The number of sockets with status changes, $(D 0) on timeout,


### PR DESCRIPTION
Third pull request in the series. I think we should consider making DDoc warnings cause the autotester to fail...
