### PR TITLE
Fix some minor doc typos

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -754,7 +754,7 @@ unittest
 }
 
 /**
-Stringnize conversion from all types is supported.
+Stringize conversion from all types is supported.
 $(UL
   $(LI String _to string conversion works for any two string types having
        ($(D char), $(D wchar), $(D dchar)) character widths and any

--- a/std/range.d
+++ b/std/range.d
@@ -1646,9 +1646,9 @@ unittest
 
 /**
 Iterates range $(D r) with stride $(D n). If the range is a
-random-access range, moves by indexing into the range; otehrwise,
+random-access range, moves by indexing into the range; otherwise,
 moves by successive calls to $(D popFront). Applying stride twice to
-the same range results in a stride that with a step that is the
+the same range results in a stride with a step that is the
 product of the two applications.
 
 Throws: $(D Exception) if $(D n == 0).
@@ -3475,7 +3475,7 @@ unittest
 
     Returns:
     How much $(D r) was actually advanced, which may be less than $(D n) if
-    $(D r) did not have at least $(D n) element.
+    $(D r) did not have at least $(D n) elements.
 
     $(D popBackN) will behave the same but instead removes elements from
     the back of the (bidirectional) range instead of the front.

--- a/std/traits.d
+++ b/std/traits.d
@@ -1214,7 +1214,7 @@ unittest
  * Constructs a new function or delegate type with the same basic signature
  * as the given one, but different attributes (including linkage).
  *
- * This is especially useful for adding/removing attributes from/to types in
+ * This is especially useful for adding/removing attributes to/from types in
  * generic code, where the actual type name cannot be spelt out.
  *
  * Params:

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3053,7 +3053,7 @@ it is the responsibility of the user to not escape a reference to the
 object outside the scope.
 
 Note: it's illegal to move a class reference even if you are sure there
-is no pointers to it.
+are no pointers to it.
 
 Example:
 ----


### PR DESCRIPTION
Simple fixes for some minor typos in the docs.
