### PR TITLE
Unicode 6.2.0

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -28,11 +28,11 @@ static import std.ascii;
 
 //Note: Importing std.typecons prevents std.format from properly building.
 import std.typecons : Tuple;
-//static struct PoorTuple(Types...)
-//{
-//    Types field;
-//    alias field this;
-//}
+static struct PoorTuple(Types...)
+{
+    Types field;
+    alias field this;
+}
 
 enum dchar lineSep = '\u2028'; /// UTF line separator
 enum dchar paraSep = '\u2029'; /// UTF paragraph separator
@@ -107,8 +107,10 @@ deprecated("Please use std.uni.toLower instead.")  dchar toUniLower(dchar c) @sa
 
 dchar toLower(dchar c) @safe pure nothrow
 {
-    alias DDI = Tuple!(dchar, dchar, int);
-    //alias DDI = PoorTuple!(dchar, dchar, int);
+    alias DD = Tuple!dchar;               //HERE
+    static immutable DD ddt = DD(0x0041); //HERE   
+
+    alias DDI = PoorTuple!(dchar, dchar, int);
 
     static immutable DDI[] tableToLowerOdd =
     [
@@ -325,8 +327,7 @@ deprecated("Please use std.uni.toUpper instead.")   dchar toUniUpper(dchar c) @s
   +/
 dchar toUpper(dchar c) @safe pure nothrow
 {
-    alias DDI = Tuple!(dchar, dchar, int);
-    //alias DDI = PoorTuple!(dchar, dchar, int);
+    alias DDI = PoorTuple!(dchar, dchar, int);
 
     static immutable DDI[] tableToUpperOdd =
     [


### PR DESCRIPTION
Unicode 6.2.0 as described in the standard, specifically, the text UCD:

http://www.unicode.org/Public/6.2.0/ucd/UnicodeData.txt

**_ALL**_ data was processed/parsed, and **_NOTHING**_ was patched manually. There was no room for "typo"/"copypaste" or "what-not" errors.

Not much else to say in regards to 6.2.0. specifically.

---

`toLower` and `toUpper` were completely redesigned: 6.2.0 pretty much multiplied by 5 (!) the amount of "upper-able" and "lowerable" chars. Worst, yet,  there was no real convenient grouping, making the current (manual) approach untenable. I basically implemented a binary look-up table that gives by how much the char needs to be mutated.

I realized a lot of "upper" chars were "odd-consecutive" or "even-consecutive", fragmenting standard binary tables. I had a fancy idea, which was to have 2 different tables, for odd and even chars. There is some slight lookup duplication, but the final result is a clean and efficient implementation.

To do this, I had to change how "binarySeach" works. While the change might look "dirty", it will become very useful for other changes I plan to implement, will which need to customize what is returned. For instance: `numericValue` or `generalCategory`, or, as a rule of thumb, anything that needs anything that is different from bool.

---

One last thing: I had problems using a Tuple inside uni:

```
dmd -O -w -d -property -L/co -c -unittest -ofunittest1.obj std\stdio.d std\stdiobase.d  std\string.d std\format.d  std\file.d
std\conv.d(2674): Error: variable s cannot be read at compile time
Assertion failure: 'values.dim >= stackpointer' on line 195 in file 'interpret.c'
```

I have no idea what is wrong. I had to resort to using a `PoorTuple`. I can remove it if somebody wants to help analyze the issue, but I don't know how else to workaround it.

---

One more question: Should I commit, under the form of "dead code" the code that was used to generate all these tables?

This could help for when the next standard comes out, if I'm not around to do this again, so that no work is lost.

Or I suppose seeing the code I used could help validate this pull?

I'm just not 100% sure about adding dead code, so an opinion on whether or not to commit it.

---

Also, I suppose I should modify the change log (if) when this gets pulled, right?
