### PR TITLE
Correction of setIntersection's description in the cheat sheet.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -250,8 +250,8 @@ of sets implemented as a range of sorted ranges.)
 $(TR $(TDNW $(LREF setDifference)) $(TD Lazily computes the set
 difference of two or more sorted ranges.)
 )
-$(TR $(TDNW $(LREF setIntersection)) $(TD Lazily computes the
-set difference of two or more sorted ranges.)
+$(TR $(TDNW $(LREF setIntersection)) $(TD Lazily computes the 
+intesection of two or more sorted ranges.)
 )
 $(TR $(TDNW $(LREF setSymmetricDifference)) $(TD Lazily
 computes the symmetric set difference of two or more sorted ranges.)


### PR DESCRIPTION
setIntersection's description was the same as setDifference's, which 
seemed like an error, I think I fixed it.
