### PR TITLE
Disable SSL cert validation in curl client

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2071,6 +2071,7 @@ struct HTTP
         p.curl.initialize();
         maxRedirects = HTTP.defaultMaxRedirects;
         p.charset = "ISO-8859-1"; // Default charset defined in HTTP RFC
+        p.curl.set(CurlOption.ssl_verifypeer, false);
         p.method = Method.undefined;
         dataTimeout = _defaultDataTimeout;
         onReceiveHeader = null;
@@ -3048,7 +3049,7 @@ struct SMTP
     /**
         Sets to the URL of the SMTP server.
     */
-    this(string url)
+    this(const(char)[] url)
     {
         p.curl.initialize();
         auto lowered = url.toLower();


### PR DESCRIPTION
Since std.net.curl.HTTP doesn't provide a means to select whether the SSL cert for a secure host should be validated, validation should be disabled by default.  This is consistent with the way the SMTP client already works.  I also changed a ctor param for the SMTP client to match the same param in the HTTP client.
