### PR TITLE
Fix Issue 6408 - Phobos fixes

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -2172,7 +2172,7 @@ if (is(StringTypeOf!T) && !is(T == enum))
         try
         {
             // ignore other specifications and quote
-            auto app = appender!(typeof(T[0])[])();
+            auto app = appender!(typeof(val[0])[])();
             put(app, '\"');
             for (size_t i = 0; i < str.length; )
             {

--- a/std/range.d
+++ b/std/range.d
@@ -3899,7 +3899,7 @@ template Cycle(R)
 struct Cycle(R)
     if (isStaticArray!R)
 {
-    private alias typeof(R[0]) ElementType;
+    private alias typeof(R.init[0]) ElementType;
     private ElementType* _ptr;
     private size_t _index;
 

--- a/std/string.d
+++ b/std/string.d
@@ -1769,7 +1769,7 @@ deprecated("Please use std.string.leftJustify instead.") S ljustify(S)(S s, size
 S leftJustify(S)(S s, size_t width, dchar fillChar = ' ') @trusted
     if(isSomeString!S)
 {
-    alias typeof(S[0]) C;
+    alias typeof(s[0]) C;
 
     if(cast(dchar)(cast(C)fillChar) == fillChar)
     {
@@ -1810,7 +1810,7 @@ deprecated("Please use std.string.rightJustify instead.") S rjustify(S)(S s, siz
 S rightJustify(S)(S s, size_t width, dchar fillChar = ' ') @trusted
     if(isSomeString!S)
 {
-    alias typeof(S[0]) C;
+    alias typeof(s[0]) C;
 
     if(cast(dchar)(cast(C)fillChar) == fillChar)
     {
@@ -1845,7 +1845,7 @@ S rightJustify(S)(S s, size_t width, dchar fillChar = ' ') @trusted
 S center(S)(S s, size_t width, dchar fillChar = ' ') @trusted
     if(isSomeString!S)
 {
-    alias typeof(S[0]) C;
+    alias typeof(s[0]) C;
 
     if(cast(dchar)(cast(C)fillChar) == fillChar)
     {

--- a/std/traits.d
+++ b/std/traits.d
@@ -2676,7 +2676,7 @@ template hasElaborateCopyConstructor(S)
 {
     static if(isStaticArray!S && S.length)
     {
-        enum bool hasElaborateCopyConstructor = hasElaborateCopyConstructor!(typeof(S[0]));
+        enum bool hasElaborateCopyConstructor = hasElaborateCopyConstructor!(typeof(S.init[0]));
     }
     else static if(is(S == struct))
     {
@@ -2771,7 +2771,7 @@ template hasElaborateDestructor(S)
 {
     static if(isStaticArray!S && S.length)
     {
-        enum bool hasElaborateDestructor = hasElaborateDestructor!(typeof(S[0]));
+        enum bool hasElaborateDestructor = hasElaborateDestructor!(typeof(S.init[0]));
     }
     else static if(is(S == struct))
     {


### PR DESCRIPTION
Do not use typeof(Type[0]) to get the element type of an array, use typeof(Type.init[0])

Required for [this pull](https://github.com/D-Programming-Language/dmd/pull/1495) for [this bug](http://d.puremagic.com/issues/show_bug.cgi?id=6408)
