### PR TITLE
Issue 9350 - findAdjacent unreachable code warning with infinite ranges

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -5485,6 +5485,8 @@ unittest
     ReferenceForwardRange!int rfr = new ReferenceForwardRange!int([1, 2, 3, 2, 2, 3]);
     assert(equal(findAdjacent(rfr), [2, 2, 3]));
 
+    // Issue 9350
+    assert(!repeat(1).findAdjacent().empty);
 }
 
 // findAmong


### PR DESCRIPTION
Fixes Issue 9350

http://d.puremagic.com/issues/show_bug.cgi?id=9350
