### PR TITLE
Supplemental fix for Issue 9199 - Module level qualified functions should be rejected

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -809,7 +809,7 @@ unittest
     static assert(dglit_pstc[0] == STC.ref_);
 
     // Bugzilla 9317
-    static inout int func(inout int param) { return param; }
+    static inout(int) func(inout int param) { return param; }
     static assert(ParameterStorageClassTuple!(typeof(func))[0] == STC.none);
 }
 


### PR DESCRIPTION
`inout` had qualified the function itself, rather than its return type.

When I fixed issue 9317 (by #1073), I had accidentally stepped on the bug 9199.
By this, a compiler fix https://github.com/D-Programming-Language/dmd/pull/1400 now fails in auto-tester.
