### PR TITLE
std.stdio: improve standardization of C I/O functions across runtimes

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -160,13 +160,16 @@ extern (C)
     }
     else version( GENERIC_IO )
     {
+        int    getc_unlocked(_iobuf*);
+        int    putc_unlocked(int, _iobuf*);
         void   flockfile(FILE*);
         void   funlockfile(FILE*);
 
-        int    fgetc_unlocked (_iobuf* fp)            { return fgetc(cast(shared) fp);     }
         wint_t fgetwc_unlocked(_iobuf* fp)            { return fgetwc(cast(shared) fp);    }
-        int    fputc_unlocked (int     c, _iobuf* fp) { return fputc(c, cast(shared) fp);  }
         wint_t fputwc_unlocked(wchar_t c, _iobuf* fp) { return fputwc(c, cast(shared) fp); }
+
+        alias  getc_unlocked fgetc_unlocked;
+        alias  putc_unlocked fputc_unlocked;
     }
     else
     {


### PR DESCRIPTION
Standardize the primary C I/O functions into a common (GCC) interface:
- fgetc_unlocked, fgetwc_unlocked
- fputc_unlocked, fputwc_unlocked
- flockfile, funlockfile

On OSX/FreeBSD, use provided fgetc_unlocked/fputc_unlocked functions instead of using the locked versions internally (may increase performance for narrow streams).
