### PR TITLE
workaround Bug 9378

### DIFF
--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -125,9 +125,9 @@ unittest
     hash = sha.finish();
 }
 
-version(OSX)
+version(D_PIC)
 {
-    // Do not use.
+    // Do not use (Bug9378).
 }
 else version(D_InlineAsm_X86)
 {

--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -17,9 +17,9 @@ module std.internal.digest.sha_SSSE3;
 
 import std.conv;
 
-version(OSX)
+version(D_PIC)
 {
-    // Do not use.
+    // Do not use (Bug9378).
 }
 else version(D_InlineAsm_X86)
 {


### PR DESCRIPTION
- SHA1 asm is broken for PIC

The [comment](807#issuecomment-9424736) in #807 hints that this is the actual problem on OSX.
