### PR TITLE
Enable hasSlicing test which had been blocked by bug 9947

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -1294,10 +1294,7 @@ template hasSlicing(R)
             typeof(take(r, 1)) s = r[1 .. 2];
         else
         {
-            //@@@BUG@@@ 8847 makes it so that the three commented out lines
-            //cause Phobos to fail to compile - hence why they're commented
-            //out. They should be uncommented once that bug has been fixed.
-            //static assert(is(typeof(r[1 .. 2]) == R));
+            static assert(is(typeof(r[1 .. 2]) == R));
             R s = r[1 .. 2];
         }
 


### PR DESCRIPTION
See https://github.com/D-Programming-Language/phobos/pull/854#issuecomment-10914291
