### PR TITLE
Allow iteration through named subgroups of Capture object

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -2038,40 +2038,6 @@ public struct Regex(Char)
     }
 
     ///
-    unittest
-    {
-        auto re = regex(`(?P<name>\w+) = (?P<var>\d+)`);
-        auto nc = re.namedCaptures;
-        static assert(isRandomAccessRange!(typeof(nc)));
-        assert(!nc.empty);
-        assert(nc.length == 2);
-        assert(nc.equal(["name", "var"]));
-        assert(nc[0] == "name");
-        assert(nc[1..$].equal(["var"]));
-    }
-
-    unittest
-    {
-        auto re = regex(`(\w+) (?P<named>\w+) (\w+)`);
-        auto nc = re.namedCaptures;
-        assert(nc.length == 1);
-        assert(nc[0] == "named");
-        assert(nc.front == "named");
-        assert(nc.back == "named");
-
-        re = regex(`(\w+) (\w+)`);
-        nc = re.namedCaptures;
-        assert(nc.empty);
-
-        re = regex(`(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/`);
-        nc = re.namedCaptures;
-        auto cp = nc.save;
-        assert(nc.equal(cp));
-        nc.popFront();
-        assert(nc.equal(cp[1..$]));
-        nc.popBack();
-        assert(nc.equal(cp[1..$-1]));
-    }
 
 private:
     NamedGroup[] dict;  //maps name -> user group number
@@ -2238,6 +2204,38 @@ private:
         }
         debug validate();
     }
+}
+
+unittest
+{
+    auto re = regex(`(?P<name>\w+) = (?P<var>\d+)`);
+    auto nc = re.namedCaptures;
+    static assert(isRandomAccessRange!(typeof(nc)));
+    assert(!nc.empty);
+    assert(nc.length == 2);
+    assert(nc.equal(["name", "var"]));
+    assert(nc[0] == "name");
+    assert(nc[1..$].equal(["var"]));
+
+    re = regex(`(\w+) (?P<named>\w+) (\w+)`);
+    nc = re.namedCaptures;
+    assert(nc.length == 1);
+    assert(nc[0] == "named");
+    assert(nc.front == "named");
+    assert(nc.back == "named");
+
+    re = regex(`(\w+) (\w+)`);
+    nc = re.namedCaptures;
+    assert(nc.empty);
+
+    re = regex(`(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/`);
+    nc = re.namedCaptures;
+    auto cp = nc.save;
+    assert(nc.equal(cp));
+    nc.popFront();
+    assert(nc.equal(cp[1..$]));
+    nc.popBack();
+    assert(nc.equal(cp[1..$-1]));
 }
 
 //


### PR DESCRIPTION
Currently there is no way to get the names of the named subgroups from a captures/match object (afaict). This patch allows the user to iterate through the captures object and get all named group names and values.

I've no idea if this is the best API, but even if this patch isn't accepted, it'd be really useful to have some way of getting the names of the named subgroups in a Capture object.
