### PR TITLE
Implement variadic cartesianProduct

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -11272,26 +11272,17 @@ auto B = [ 'a', 'b', 'c' ];
 auto C = [ "x", "y", "z" ];
 auto ABC = cartesianProduct(A, B, C);
 
-auto expected = [
-    tuple(1, 'a', "x"), tuple(1, 'a', "y"), tuple(1, 'a', "z"),
-    tuple(1, 'b', "x"), tuple(1, 'b', "y"), tuple(1, 'b', "z"),
-    tuple(1, 'c', "x"), tuple(1, 'c', "y"), tuple(1, 'c', "z"),
-    tuple(2, 'a', "x"), tuple(2, 'a', "y"), tuple(2, 'a', "z"),
-    tuple(2, 'b', "x"), tuple(2, 'b', "y"), tuple(2, 'b', "z"),
-    tuple(2, 'c', "x"), tuple(2, 'c', "y"), tuple(2, 'c', "z"),
-    tuple(3, 'a', "x"), tuple(3, 'a', "y"), tuple(3, 'a', "z"),
-    tuple(3, 'b', "x"), tuple(3, 'b', "y"), tuple(3, 'b', "z"),
-    tuple(3, 'c', "x"), tuple(3, 'c', "y"), tuple(3, 'c', "z")
-];
-
-foreach (e; expected)
-{
-    assert(canFind(ABC, e));
-}
-foreach (abc; ABC)
-{
-    assert(canFind(expected, abc));
-}
+assert(ABC.equal([
+    tuple(1, 'a', "x"), tuple(2, 'a', "x"), tuple(3, 'a', "x"),
+    tuple(1, 'b', "x"), tuple(2, 'b', "x"), tuple(3, 'b', "x"),
+    tuple(1, 'c', "x"), tuple(2, 'c', "x"), tuple(3, 'c', "x"),
+    tuple(1, 'a', "y"), tuple(2, 'a', "y"), tuple(3, 'a', "y"),
+    tuple(1, 'b', "y"), tuple(2, 'b', "y"), tuple(3, 'b', "y"),
+    tuple(1, 'c', "y"), tuple(2, 'c', "y"), tuple(3, 'c', "y"),
+    tuple(1, 'a', "z"), tuple(2, 'a', "z"), tuple(3, 'a', "z"),
+    tuple(1, 'b', "z"), tuple(2, 'b', "z"), tuple(3, 'b', "z"),
+    tuple(1, 'c', "z"), tuple(2, 'c', "z"), tuple(3, 'c', "z")
+]));
 ---
 */
 auto cartesianProduct(R1, R2)(R1 range1, R2 range2)
@@ -11548,24 +11539,15 @@ unittest
     auto C = [ "x", "y", "z" ];
     auto ABC = cartesianProduct(A, B, C);
 
-    auto expected = [
-        tuple(1, 'a', "x"), tuple(1, 'a', "y"), tuple(1, 'a', "z"),
-        tuple(1, 'b', "x"), tuple(1, 'b', "y"), tuple(1, 'b', "z"),
-        tuple(1, 'c', "x"), tuple(1, 'c', "y"), tuple(1, 'c', "z"),
-        tuple(2, 'a', "x"), tuple(2, 'a', "y"), tuple(2, 'a', "z"),
-        tuple(2, 'b', "x"), tuple(2, 'b', "y"), tuple(2, 'b', "z"),
-        tuple(2, 'c', "x"), tuple(2, 'c', "y"), tuple(2, 'c', "z"),
-        tuple(3, 'a', "x"), tuple(3, 'a', "y"), tuple(3, 'a', "z"),
-        tuple(3, 'b', "x"), tuple(3, 'b', "y"), tuple(3, 'b', "z"),
-        tuple(3, 'c', "x"), tuple(3, 'c', "y"), tuple(3, 'c', "z")
-    ];
-
-    foreach (e; expected)
-    {
-        assert(canFind(ABC, e));
-    }
-    foreach (abc; ABC)
-    {
-        assert(canFind(expected, abc));
-    }
+    assert(ABC.equal([
+        tuple(1, 'a', "x"), tuple(2, 'a', "x"), tuple(3, 'a', "x"),
+        tuple(1, 'b', "x"), tuple(2, 'b', "x"), tuple(3, 'b', "x"),
+        tuple(1, 'c', "x"), tuple(2, 'c', "x"), tuple(3, 'c', "x"),
+        tuple(1, 'a', "y"), tuple(2, 'a', "y"), tuple(3, 'a', "y"),
+        tuple(1, 'b', "y"), tuple(2, 'b', "y"), tuple(3, 'b', "y"),
+        tuple(1, 'c', "y"), tuple(2, 'c', "y"), tuple(3, 'c', "y"),
+        tuple(1, 'a', "z"), tuple(2, 'a', "z"), tuple(3, 'a', "z"),
+        tuple(1, 'b', "z"), tuple(2, 'b', "z"), tuple(3, 'b', "z"),
+        tuple(1, 'c', "z"), tuple(2, 'c', "z"), tuple(3, 'c', "z"),
+    ]));
 }


### PR DESCRIPTION
This pull request extends cartesianProduct to 3 or more arguments.

I'm running into a bit of a snag with the unittests, though. Currently I've commented out the last unittest because it runs out of memory on my machine. Can somebody help me find out what's eating up so much memory? Does the cartesianProduct implementation need some tweaking to reduce its memory footprint?
