### PR TITLE
Re-enable unittest that is now working.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -11399,8 +11399,6 @@ unittest
     // And therefore, by set comprehension, XY == Expected
 }
 
-// FIXME: this unittest has been disabled because of issue 8542.
-version(none)
 unittest
 {
     auto N = sequence!"n"(0);


### PR DESCRIPTION
Now that issue 8542 has been fixed, reenable the failing unittest.
