### PR TITLE
Fix Issue 9456 -  decodeFront is inconsistent in whether it pops elements off of the range or not 

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -990,15 +990,7 @@ out (result)
 }
 body
 {
-    //@@@BUG@@@ 8521 forces canIndex to be done outside of decodeImpl, which
-    //is undesirable, since not all overloads of decodeImpl need it. So, it
-    //should be moved back into decodeImpl once bug# 8521 has been fixed.
-    enum canIndex = isRandomAccessRange!S && hasSlicing!S && hasLength!S && isSomeChar!(ElementType!S);
-    //static if (isRandomAccessRange!S && hasSlicing!S && hasLength!S && isSomeChar!(ElementType!S))
-    static if (canIndex)
-        immutable fst = str[0];
-    else
-        immutable fst = str.front;
+    immutable fst = str.front;
 
     if (fst < codeUnitLimit!S)
     {
@@ -1007,6 +999,10 @@ body
         return fst;
     }
 
+    //@@@BUG@@@ 8521 forces canIndex to be done outside of decodeImpl, which
+    //is undesirable, since not all overloads of decodeImpl need it. So, it
+    //should be moved back into decodeImpl once bug# 8521 has been fixed.
+    enum canIndex = isRandomAccessRange!S && hasSlicing!S && hasLength!S;
     immutable retval = decodeImpl!canIndex(str, numCodeUnits);
 
     // The other range types were already popped by decodeImpl.


### PR DESCRIPTION
`decodeFront` was popping off elements from reference type ranges and input ranges but not other types. Ideally, it would act like `decode` and not pop any elements off of any range, but that doesn't work with input ranges. So, in order to keep it consistent, `decodeFront` now takes its range by `ref` and always pops off the code units that it decodes.

Also, the tests have been improved for `decode`, `decodeFront`, `stride`, and `strideBack` so that they test more range types (including reference types ranges).
