### PR TITLE
Improve XnaryFun argument passing

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -42,8 +42,8 @@ template unaryFun(alias fun, string parmName = "a")
     {
         auto unaryFun(ElementType)(auto ref ElementType __a)
         {
-            mixin("alias __a "~parmName~";");
-            mixin("return (" ~ fun ~ ");");
+            mixin("alias " ~ parmName ~ " = __a ;");
+            return mixin(fun);
         }
     }
     else
@@ -97,9 +97,9 @@ template binaryFun(alias fun, string parm1Name = "a",
         auto binaryFun(ElementType1, ElementType2)
             (auto ref ElementType1 __a, auto ref ElementType2 __b)
         {
-            mixin("alias __a "~parm1Name~";");
-            mixin("alias __b "~parm2Name~";");
-            mixin("return (" ~ fun ~ ");");
+            mixin("alias "~parm1Name~" = __a ;");
+            mixin("alias "~parm2Name~" = __b ;");
+            return mixin(fun);
         }
     }
     else


### PR DESCRIPTION
From the conversation here:
http://forum.dlang.org/thread/qhlsrpqajuwstvlspimf@forum.dlang.org

Basically, using binaryFun!"a < b" made extra and un-necassary copies to just call binaryFun, before it actually calls the internal `return(fun)`. This is problematic if the object passed by value has a postblit (as even if the postblit is cheap, calling it is _completly_ unnecessary). This is especially apparent given how _massively_ XnaryFun is used, I think it is very important to make it run as fast as possible, with no compromises.

The designed was improved to provide both pass by ref, and pass by value*.

The changes where thoroughly benched: Small built-in types (eg int) take absolutely no penalty from the new pass by ref. As for objects with a postblit (even trivially simple: increment a global counter) take a great performance boost: algorithm.sort ran about 50% faster for the type `struct S{int i; this(this){++k;}}`.

== The pulls ==

The first pull is just a fix for CTFE: in CTFE, it is illegal to pass by mutable ref a non-mutable. Having *naryFun take by ref revealed the bug.

The second pull is a quick and easy change to take by auto ref. Benches showed results that are maybe faster, never slower. win-win. Since the argument "byRef" is now useless, is deprecated the signature that uses "byRef"

== Debatable pull ==

EDIT: Removed.
