### PR TITLE
[trivial] Property and non-property function cannot overload each other.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2163,7 +2163,6 @@ unittest
             void test(string);
             real test(real);
             int  test();
-            int  test() @property; // ?
         }
         auto o = new BlackHole!I_5;
     }


### PR DESCRIPTION
Today, compiler does not check it if they are just defined. It is another compiler bug, but this code is essentially illegal.
