### PR TITLE
Fixes in Cycle

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4455,6 +4455,7 @@ struct Cycle(R)
     private static struct DollarToken {}
 
     enum opDollar = DollarToken.init;
+
     auto opSlice(size_t i, size_t j) nothrow
     in
     {


### PR DESCRIPTION
Fixes and improves a couple of points in cycle:
1. Overflow protection: After being iterated on for more than size_t.max, the index overflow+modulo broke the correct flow of the cicular buffer.
2. improved a couple of safe/nothrow signatures
3. Added support for unicode with static arrays
4. Added a special case for 1 element array circular buffer. This is actually important, as things like recurrence tends to use them...

The changes mostly shuffles and/or changes the indentation of the code, Github's diff is very bad with this. It may be worth looking into each diff individually to see what changed, and what was just moved for each edit.
