### PR TITLE
std.c.windows.winsock: Win64 and type fixes

### DIFF
--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -312,8 +312,17 @@ struct servent
 {
     char* s_name;
     char** s_aliases;
-    SHORT s_port;
-    char* s_proto;
+
+    version (Win64)
+    {
+        char* s_proto;
+        SHORT s_port;
+    }
+    else
+    {
+        SHORT s_port;
+        char* s_proto;
+    }
 }
 
 


### PR DESCRIPTION
The SOCKET type was wrong and caused 64-bit programs using WinSock functions that passed SOCKETs indirectly (like `select`) to not work.

I noticed the signedness of `socklen_t` was also different from the C headers, so I fixed that as well.

As far as I can tell, this was the only problem preventing std.socket from working on Win64.

The servent fix also fixes std.socket unit tests.
