### PR TITLE
Fix issue 9583

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -408,7 +408,7 @@ private void getoptImpl(T...)(ref string[] args,
             if (endOfOptions.length && a == endOfOptions)
             {
                 // Consume the "--"
-                args = args[0 .. i + 1] ~ args[i + 2 .. $];
+                args = args.remove(i + 1);
                 break;
             }
             if (!cfg.passThrough)


### PR DESCRIPTION
std.getopt.getopt should consume options terminator "--" as claimed by docs
