### PR TITLE
Add Issue 9578 workaround to `std.algorithm.all`

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -9838,13 +9838,18 @@ assert(!all!"a & 1"([1, 2, 3, 5, 7, 9]));
 bool all(alias pred, R)(R range)
 if (isInputRange!R && is(typeof(unaryFun!pred(range.front))))
 {
-    return find!(not!(unaryFun!pred))(range).empty;
+    // dmd @@@BUG9578@@@ workaround
+    // return find!(not!(unaryFun!pred))(range).empty;
+    bool notPred(ElementType!R a) { return !unaryFun!pred(a); }
+    return find!notPred(range).empty;
 }
 
 unittest
 {
     assert(all!"a & 1"([1, 3, 5, 7, 9]));
     assert(!all!"a & 1"([1, 2, 3, 5, 7, 9]));
+    int x = 1;
+    assert(all!(a => a > x)([2, 3]));
 }
 
 // Deprecated. It will be removed in January 2013.  Use std.range.SortedRange.canFind.


### PR DESCRIPTION
As a result `all` can now be used with nested predicates.

Issue URL: http://d.puremagic.com/issues/show_bug.cgi?id=9578
