### PR TITLE
Bugfix in std.conv.parseEscape

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2899,7 +2899,7 @@ unittest
 
 unittest
 {
-    //Checks parsing of strings with escapped characters
+    //Checks parsing of strings with escaped characters
     string s1 = `[
         "Contains a\0null!",
         "tab\there",


### PR DESCRIPTION
This is a really easy and minor 1 liner fix:
std.conv.parseEscape basically forgot to check for backslash in the
list of possibly escaped characters. This made it imposible to parse
strings that container an actual backslash:

``` D
import std.conv;

void main()
{
    string s = `["C:\\FolderA", "D:\\FolderB"]`;
    parse!(string[])(s); //Can't parse string: Unknown escape character \
}
```

This fixes that.
