### PR TITLE
fullyQualifiedNameImplForSymbols: .stringof -> __traits(identifier)

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -302,7 +302,7 @@ private template fullyQualifiedNameImplForSymbols(alias T)
         if(s.skipOver("package ") || s.skipOver("module "))
             return s;
         return s.findSplit("(")[0];
-    }(T.stringof);
+    }(__traits(identifier, T));
 }
 
 unittest
@@ -315,6 +315,7 @@ unittest
     alias fqn = fullyQualifiedName;
     static assert(fqn!fqn == "std.traits.fullyQualifiedName");
     static assert(fqn!(QualifiedNameTests.Inner) == "std.traits.QualifiedNameTests.Inner");
+    static assert(fqn!(QualifiedNameTests.func) == "std.traits.QualifiedNameTests.func");
     import core.sync.barrier;
     static assert(fullyQualifiedName!Barrier == "core.sync.barrier.Barrier");
 }


### PR DESCRIPTION
Thanks D.learn for hinting me that Symbol.stringof fails for function with parameters symbols because of an optional parens call attempt. Changed fullyQualifiedName accordingly and added test case for function symbol.
