### PR TITLE
Issue 9612: Cycle opSlice should throw when finish > start

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3832,6 +3832,8 @@ struct Cycle(Range)
 
         auto opSlice(size_t i, size_t j)
         {
+            version (assert)
+                if (i > j) throw new RangeError(text(i, " > ", j));
             auto retval = this.save;
             retval._index += i;
             return takeExactly(retval, j - i);
@@ -3932,6 +3934,8 @@ struct Cycle(R)
 
     auto opSlice(size_t i, size_t j)
     {
+        version (assert)
+            if (i > j) throw new RangeError(text(i, " > ", j));
         auto retval = this.save;
         retval._index += i;
         return takeExactly(retval, j - i);
@@ -4021,6 +4025,8 @@ unittest
                     }
 
                     assert(cRange[10] == 1);
+
+                    assertThrown!RangeError(cy[2..1]);
                 }
             }
 


### PR DESCRIPTION
Wasn't in a position to run tests locally so waiting for the autotester is essential.
