### PR TITLE
Change Nullable ctor to inout

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1169,7 +1169,7 @@ struct Nullable(T)
 /**
 Constructor initializing $(D this) with $(D value).
  */
-    this()(T value)
+    this()(T value) inout
     {
         _value = value;
         _isNull = false;


### PR DESCRIPTION
Nullable object does not concern about stored object qualifier. So in this case, inout constructor is the best.
