### PR TITLE
Issue 3789 - Structs members that require non-bitwise comparison not correctly compared

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2442,7 +2442,7 @@ unittest
 
     // void static array hides actual type of bits, so "may have indirections".
     static assert( hasIndirections!(void[1]));
-    interface I;
+    interface I {}
     struct S1 {}
     struct S2 { int a; }
     struct S3 { int a; int b; }

--- a/std/variant.d
+++ b/std/variant.d
@@ -1097,7 +1097,7 @@ unittest
         int a;
         long b;
         string c;
-        real d;
+        real d = 0.0;
         bool e;
     }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3789
