### PR TITLE
Fixup for cycle RangeError invocation

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3832,8 +3832,7 @@ struct Cycle(Range)
 
         auto opSlice(size_t i, size_t j)
         {
-            version (assert)
-                if (i > j) throw new RangeError(text(i, " > ", j));
+            version (assert) if (i > j) throw new RangeError();
             auto retval = this.save;
             retval._index += i;
             return takeExactly(retval, j - i);
@@ -3934,8 +3933,7 @@ struct Cycle(R)
 
     auto opSlice(size_t i, size_t j)
     {
-        version (assert)
-            if (i > j) throw new RangeError(text(i, " > ", j));
+        version (assert) if (i > j) throw new RangeError();
         auto retval = this.save;
         retval._index += i;
         return takeExactly(retval, j - i);


### PR DESCRIPTION
From: #1183 :
Issue 9612: Cycle opSlice should throw when finish > start

Because a RangeError is not actually customizable, and the first argument is actually the file name. The error was producing:

```
core.exception.RangeError@2 > 1(3836): Range violation
```

Now it produces:

```
core.exception.RangeError@std\range.d(3835): Range violation
```
