### PR TITLE
Add `std.traits.isNestedFunction`.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5293,6 +5293,22 @@ unittest
 }
 
 /**
+Determines whether function $(D f) requires a context pointer.
+*/
+template isNestedFunction(alias f)
+{
+    enum isNestedFunction = __traits(isNested, f);
+}
+
+unittest
+{
+    static void f() { }
+    void g() { }
+    static assert(!isNestedFunction!f);
+    static assert( isNestedFunction!g);
+}
+
+/**
  * Detect whether $(D T) is a an abstract class.
  */
 template isAbstractClass(T...)


### PR DESCRIPTION
As I see no cases where nestidness check for both types and functions is required a new `isNestedFunction` template is created instead if adding an overload to `isNested`.
