### PR TITLE
std.variant: Fix "ditto ditto" documentation bug

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -899,7 +899,7 @@ public:
     // Commenteed all _r versions for now because of ambiguities
     // arising when two Variants are used
 
-    /////ditto
+    // ///ditto
     // VariantN opSub_r(T)(T lhs)
     // {
     //     return VariantN(lhs).opArithmetic!(VariantN, "-")(this);


### PR DESCRIPTION
As seen on http://dlang.org/phobos/std_variant.html , methods opMul through opCatAssign had the documentation "ditto ditto" because of an improperly-commented DDoc line.
