### PR TITLE
Win64 linking fix for std.c.windows.com

### DIFF
--- a/std/c/windows/com.d
+++ b/std/c/windows/com.d
@@ -2,8 +2,9 @@ module std.c.windows.com;
 
 pragma(lib,"uuid");
 
-private import std.c.windows.windows;
-private import std.string;
+import core.atomic;
+import std.c.windows.windows;
+import std.string;
 
 alias WCHAR OLECHAR;
 alias OLECHAR *LPOLESTR;
@@ -232,12 +233,12 @@ extern (System):
 
     ULONG AddRef()
     {
-        return InterlockedIncrement(&count);
+        return atomicOp!"+="(*cast(shared)&count, 1);
     }
 
     ULONG Release()
     {
-        LONG lRef = InterlockedDecrement(&count);
+        LONG lRef = atomicOp!"-="(*cast(shared)&count, 1);
         if (lRef == 0)
         {
             // free object


### PR DESCRIPTION
Linking with LINK.EXE from VisualStudio 2012 Express Desktop results in the following linker errors:

```
phobos64.lib(com_151d_376.obj) : error LNK2019: unresolved external symbol __imp
_InterlockedDecrement referenced in function _D3std1c7windows3com9ComObject7Rele
aseMWZk
phobos64.lib(com_151d_376.obj) : error LNK2019: unresolved external symbol __imp
_InterlockedIncrement referenced in function _D3std1c7windows3com9ComObject6AddR
efMWZk
C:\Users\sludwig\AppData\Local\Temp\.rdmd\source\150067089-krtek.exe : fatal err
or LNK1120: 2 unresolved externals
--- errorlevel 1120
```

Using atomicOp instead of InterlockedIncrement here to avoid those.
