### PR TITLE
fix issue 9926 - Add the let function

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -761,6 +761,37 @@ auto toDelegate(F)(auto ref F fp) if (isCallable!(F))
     }
 }
 
+/**
+ * Calls the delegate with the value as argument. Used for temporarily binding
+ * a value as an argument.
+ *
+ * Example:
+ * ----
+ * assert(
+ *         (1 + 2 * 3).bindTo!(x => x * x * x + 2 * x * x + 3 * x)()
+ *         ==
+ *         (1 + 2 * 3) * ( 1 + 2 * 3) * ( 1 + 2 * 3)
+ *         + 2 * ( 1 + 2 * 3) * (1 + 2 * 3)
+ *         + 3 * ( 1 + 2 * 3)
+ *       );
+ * ----
+ */
+auto bindTo(alias dlg, T)(T value) if(__traits(compiles, dlg(value)))
+{
+    return dlg(value);
+}
+
+unittest//verify example
+{
+    assert(
+            (1 + 2 * 3).bindTo!(x => x * x * x + 2 * x * x + 3 * x)()
+            ==
+            (1 + 2 * 3) * ( 1 + 2 * 3) * ( 1 + 2 * 3)
+            + 2 * ( 1 + 2 * 3) * (1 + 2 * 3)
+            + 3 * ( 1 + 2 * 3)
+          );
+}
+
 unittest {
     static int inc(ref uint num) {
         num++;


### PR DESCRIPTION
`bindTo`(formerly `let`) is a very fundamental building block in functional
programming. It's similar to variable declaration+assignment in imperative
programming, but the name-binding is done mid-expression, and the scope of the
binding is limited to the part of the expression where it is used.

These properties make it beneficial for imperative languages as well, since it
exempts the programmer from having to split a calculation, allowing them to put
a complex calculation with mid-results inside an expression, and to limit the
scope of the mid-results to that calculation.

Example:

``` D
    functionWithManyArguments(
            //Many arguments
            (1 + 2 * 3).bindTo!(x => x * x * x + 2 * x * x + 3 * x)(),
            //More arguments
            );
```

Instead of:

``` D
    int x = 1 + 2 * 3;
    functionWithManyArguments(
            //Many arguments
            x * x * x + 2 * x * x + 3 * x,
            //More arguments
            );
```

Without the `bindTo` function, not only are we forced to split the calculation and
put some of it before the call to `functionWithManyArguments`, but we are also
exposing the mid-result `x` that can be used in later parts of the program -
even though it is only needed for this calculation.

See http://d.puremagic.com/issues/show_bug.cgi?id=9926
