### PR TITLE
Fix endian-dependent unit test.

### DIFF
--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -657,7 +657,10 @@ unittest
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
     string d = toHexString(sha1Of(a, b, c));
-    assert(d == "CDBB611D00AC2387B642D3D7BDF4C3B342237110", d);
+    version(LittleEndian)
+        assert(d == "CDBB611D00AC2387B642D3D7BDF4C3B342237110", d);
+    else
+        assert(d == "A0F1196C7A379C09390476D9CA4AA11B71FD11C8", d);
 }
 
 /**

--- a/std/md5.d
+++ b/std/md5.d
@@ -164,7 +164,10 @@ unittest
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
     string d = getDigestString(a, b, c);
-    assert(d == "F36625A66B2A8D9F47270C00C8BEFD2F", d);
+    version(LittleEndian)
+        assert(d == "F36625A66B2A8D9F47270C00C8BEFD2F", d);
+    else
+        assert(d == "2656D2008FF10DAE4B0783E6E0171655", d);
 }
 
 /**


### PR DESCRIPTION
The input to the digest tests is not endian-neutral. This is now considered.
The big endian values were derived by writing the data into a file (on Linux/PPC64) and running md5sum and sha1sum with the file as input.
