### PR TITLE
Use `FieldTypeTuple!S` instead of `typeof(S.tupleof)`.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2786,7 +2786,7 @@ template hasElaborateCopyConstructor(S)
     else static if(is(S == struct))
     {
         enum hasElaborateCopyConstructor = hasMember!(S, "__postblit")
-            || anySatisfy!(.hasElaborateCopyConstructor, typeof(S.tupleof));
+            || anySatisfy!(.hasElaborateCopyConstructor, FieldTypeTuple!S);
     }
     else
     {
@@ -2839,7 +2839,7 @@ template hasElaborateAssign(S)
 
         enum hasElaborateAssign = is(typeof(S.init.opAssign(S.init))) ||
                                   is(typeof(S.init.opAssign(lvalueOf))) ||
-            anySatisfy!(.hasElaborateAssign, typeof(S.tupleof));
+            anySatisfy!(.hasElaborateAssign, FieldTypeTuple!S);
     }
 }
 
@@ -2902,7 +2902,7 @@ template hasElaborateDestructor(S)
     else static if(is(S == struct))
     {
         enum hasElaborateDestructor = hasMember!(S, "__dtor")
-            || anySatisfy!(.hasElaborateDestructor, typeof(S.tupleof));
+            || anySatisfy!(.hasElaborateDestructor, FieldTypeTuple!S);
     }
     else
     {


### PR DESCRIPTION
`FieldTypeTuple` is what have to be used when searching through fields as it ignores hidden fields which we don't need here.

Replace in `std.traits.hasElaborate{CopyConstructor,Assign,Destructor}`.
