### PR TITLE
Add formatting option to `std.json.toJSON`.

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -378,8 +378,12 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T)
 
 /**
 Takes a tree of JSON values and returns the serialized string.
+
+If $(D pretty) is false no whitespaces are generated.
+If $(D pretty) is true serialized string is formatted to be human-readable.
+No exact formatting layout is guaranteed in the latter case.
 */
-string toJSON(in JSONValue* root)
+string toJSON(in JSONValue* root, in bool pretty = false)
 {
     auto json = appender!string();
 
@@ -408,34 +412,73 @@ string toJSON(in JSONValue* root)
         json.put('"');
     }
 
-    void toValue(in JSONValue* value)
+    void toValue(in JSONValue* value, ulong indentLevel)
     {
+        void putTabs(ulong additionalIndent = 0)
+        {
+            if(pretty)
+                foreach(i; 0 .. indentLevel + additionalIndent)
+                    json.put("    ");
+        }
+        void putEOL()
+        {
+            if(pretty)
+                json.put('\n');
+        }
+        void putCharAndEOL(char ch)
+        {
+            json.put(ch);
+            putEOL();
+        }
+
         final switch(value.type)
         {
             case JSON_TYPE.OBJECT:
-                json.put('{');
-                bool first = true;
-                foreach(name, member; value.object)
+                if(!value.object.length)
                 {
-                    if(!first)
-                        json.put(',');
-                    first = false;
-                    toString(name);
-                    json.put(':');
-                    toValue(&member);
+                    json.put("{}");
                 }
-                json.put('}');
+                else
+                {
+                    putCharAndEOL('{');
+                    bool first = true;
+                    foreach(name, member; value.object)
+                    {
+                        if(!first)
+                            putCharAndEOL(',');
+                        first = false;
+                        putTabs(1);
+                        toString(name);
+                        json.put(':');
+                        if(pretty)
+                            json.put(' ');
+                        toValue(&member, indentLevel + 1);
+                    }
+                    putEOL();
+                    putTabs();
+                    json.put('}');
+                }
                 break;
 
             case JSON_TYPE.ARRAY:
-                json.put('[');
-                foreach (i, ref el; value.array)
+                if(value.array.empty)
                 {
-                    if(i)
-                        json.put(',');
-                    toValue(&el);
+                    json.put("[]");
                 }
-                json.put(']');
+                else
+                {
+                    putCharAndEOL('[');
+                    foreach (i, ref el; value.array)
+                    {
+                        if(i)
+                            putCharAndEOL(',');
+                        putTabs(1);
+                        toValue(&el, indentLevel + 1);
+                    }
+                    putEOL();
+                    putTabs();
+                    json.put(']');
+                }
                 break;
 
             case JSON_TYPE.STRING:
@@ -468,7 +511,7 @@ string toJSON(in JSONValue* root)
         }
     }
 
-    toValue(root);
+    toValue(root, 0);
     return json.data;
 }
 
@@ -554,4 +597,17 @@ unittest
         assert(str == "" && str !is null);
     with(parseJSON(`[]`))
         assert(!array.length && array !is null);
+
+    // Formatting
+    val = parseJSON(`{"a":[null,{"x":1},{},[]]}`);
+    assert(toJSON(&val, true) == `{
+    "a": [
+        null,
+        {
+            "x": 1
+        },
+        {},
+        []
+    ]
+}`);
 }


### PR DESCRIPTION
This allows _JSON_ to be used as a temporary serialization format when debugging an application as it becomes human- and diff-readable.
