### PR TITLE
DDoc (minor): array.d: Appender.shrinkTo throws Exception

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2373,8 +2373,9 @@ possibility that $(D Appender) might overwrite immutable data.
         }
 
 /**
-Shrinks the managed array to the given length.  Passing in a length that's
-greater than the current array length throws an enforce exception.
+Shrinks the managed array to the given length.
+
+Throws: $(D Exception) if newlength is greater than the current array length.
 */
         void shrinkTo(size_t newlength)
         {


### PR DESCRIPTION
Specified that Exception gets thrown (the previous ddoc didn't make sense).
