### PR TITLE
Apply ddoc-ed unittest feature in std.typetuple, and fix issue 9976

### DIFF
--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -461,10 +461,17 @@ unittest
  */
 template Reverse(TList...)
 {
-    static if (TList.length == 0)
-    alias TList Reverse;
+    static if (TList.length <= 1)
+    {
+        alias Reverse = TList;
+    }
     else
-    alias TypeTuple!(Reverse!(TList[1 .. $]), TList[0]) Reverse;
+    {
+        alias Reverse =
+            TypeTuple!(
+                Reverse!(TList[$/2 ..  $ ]),
+                Reverse!(TList[ 0  .. $/2]));
+    }
 }
 
 ///


### PR DESCRIPTION
Make examples testable.

---

Issue 9976 - Needlessly large instantiation depth in std.typetuple algorithms
http://d.puremagic.com/issues/show_bug.cgi?id=9976

Improved `Reverse` template instantiation depth.
