### PR TITLE
SortedRange.length should support inner ranges with ulong as length

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -7386,7 +7386,7 @@ if (isRandomAccessRange!Range && hasLength!Range)
         }
 
     /// Ditto
-    @property size_t length()          //const
+    @property auto length()          //const
     {
         return _input.length;
     }


### PR DESCRIPTION
`assumeSorted(iota(cast(ulong)2))` does not compile in 32 bit.
