### PR TITLE
fix moduleName else block

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -212,8 +212,10 @@ template moduleName(alias T)
 
         enum moduleName = packagePrefix ~ T.stringof[7..$];
     }
-    else
+    else static if (!is(typeof(__traits(parent, T)) == bool))
         alias moduleName!(__traits(parent, T)) moduleName;
+    else
+        enum moduleName = ""; 
 }
 
 unittest


### PR DESCRIPTION
Old version of this code use a compiler issue (parent trait can't evaluate parent object for manifest constants.)
this patch need for correct D-Programming-Language/dmd#1960 tests passing
