### PR TITLE
[trivial] Placement of WIKI ddoc macro in std.conv was corrupting docs

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -14,6 +14,10 @@ Authors:   $(WEB digitalmars.com, Walter Bright),
            Kenji Hara
 
 Source:    $(PHOBOSSRC std/_conv.d)
+
+Macros:
+WIKI = Phobos/StdConv
+
 */
 module std.conv;
 
@@ -257,7 +261,6 @@ $(D_PARAM to!(double[])) applies to an $(D_PARAM int[]). The
 conversion might throw an exception because $(D_PARAM to!short)
 might fail the range check.
 
-Macros: WIKI=Phobos/StdConv
  */
 
 /**


### PR DESCRIPTION
Not sure of the root cause of this but moving it fixes this.  It was in a weird place in the source file before, does anyone know if there was a reason for that?

Here's what the "corruption" looks like:
![image](https://f.cloud.github.com/assets/74619/503371/051c3d90-bcca-11e2-9ba8-2bd6bf3a89fd.png)
