### PR TITLE
Patch to prevent requiring memchr at compile time

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -322,12 +322,21 @@ ptrdiff_t indexOf(Char)(in Char[] s,
         {
             if (std.ascii.isASCII(c))
             {                                               // Plain old ASCII
-                auto c1 = cast(char) c;
-
-                foreach (ptrdiff_t i, c2; s)
-                {
-                    if (c1 == c2)
-                        return i;
+                if (__ctfe) {
+                    auto c1 = cast(char) c;
+    
+                    foreach (ptrdiff_t i, c2; s)
+                    {
+                        if (c1 == c2)
+                            return i;
+                    }
+                }
+                else {
+                    auto p = cast(char*)memchr(s.ptr, c, s.length);
+                    if (p)
+                        return p - cast(char *)s;
+                    else
+                        return -1;
                 }
             }
         }


### PR DESCRIPTION
See http://d.puremagic.com/issues/show_bug.cgi?id=10078 for full description.

If the std.string.indexOf(Char[], dchar, CaseSensitive) method is called at compile time with an ASCII dchar, it will fail:

```
/usr/share/dmd/src/phobos/std/string.d(345): 
    Error: memchr cannot be interpreted at compile time, 
    because it has no available source code
```
