### PR TITLE
fix Issue 10125 Unicode non-BMP decoding to dchar in stdio readln

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -873,9 +873,7 @@ int main()
         foreach (uint i,C; Tuple!(char, wchar, dchar).Types)
         {
             immutable(C)[] witness = "cześć \U0002000D";
-            auto f = File(deleteme);
-            immutable(C)[] buf;
-            buf = f.readln!(typeof(buf))();
+            auto buf = File(deleteme).readln!(immutable(C)[])();
             assert(buf.length==lengths[i]);
             assert(buf==witness);
         }


### PR DESCRIPTION
readln!dchar decodes Unicode code point >U+FFFF to 2 surrogates instead of 1
dchar containing the code point.

e.g. U+10001 becomes [0xd800,0xdc01] instead of [0x10001]

strings were first decoded to wchars, each wchar was then separately
decoded to dchar, resulting in 2 dchars in the surrogate block instead
of 1 correct dchar.

added unit test to verify readln decoding of non-ASCII characters
