### PR TITLE
Remove -property from Makefiles.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -117,7 +117,7 @@ ifneq (,$(filter cc% gcc% clang% icc% egcc%, $(CC)))
 endif
 
 # Set DFLAGS
-DFLAGS := -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -d -property -m$(MODEL) $(PIC)
+DFLAGS := -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -d -m$(MODEL) $(PIC)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
 else

--- a/win32.mak
+++ b/win32.mak
@@ -38,13 +38,13 @@ CFLAGS=-mn -6 -r
 
 ## Flags for dmd D compiler
 
-DFLAGS=-O -release -w -d -property
+DFLAGS=-O -release -w -d
 #DFLAGS=-unittest -g -d
 #DFLAGS=-unittest -cov -g -d
 
 ## Flags for compiling unittests
 
-UDFLAGS=-O -w -d -property
+UDFLAGS=-O -w -d
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -37,13 +37,13 @@ CFLAGS=/O2 /nologo /I"$(VCDIR)\INCLUDE" /I"$(SDKDIR)\Include"
 
 ## Flags for dmd D compiler
 
-DFLAGS=-m$(MODEL) -O -release -w -d -property
+DFLAGS=-m$(MODEL) -O -release -w -d
 #DFLAGS=-m$(MODEL) -unittest -g -d
 #DFLAGS=-m$(MODEL) -unittest -cov -g -d
 
 ## Flags for compiling unittests
 
-UDFLAGS=-g -m$(MODEL) -O -w -d -property
+UDFLAGS=-g -m$(MODEL) -O -w -d
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
I believe that it was clear from the last major property discussion that we're not going to have strict property enforcement (which is what `-property` attempts to do) and that the `-property` flag should be removed. As such, there's no point in leaving it in the builds for druntime or Phobos.
