### PR TITLE
Make std.conv unittests independent of floating point rounding

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2510,9 +2510,9 @@ unittest
         assert(to!Float("123e+2") == Literal!Float(123e+2));
         assert(to!Float("123e-2") == Literal!Float(123e-2));
         assert(to!Float("123.") == Literal!Float(123.0));
-        assert(to!Float(".456") == Literal!Float(.456));
+        assert(to!Float(".375") == Literal!Float(.375));
 
-        assert(to!Float("1.23456E+2") == Literal!Float(1.23456E+2));
+        assert(to!Float("1.23375E+2") == Literal!Float(1.23375E+2));
 
         assert(to!Float("0") is 0.0);
         assert(to!Float("-0") is -0.0);
@@ -2612,7 +2612,7 @@ unittest
 // Unittest for bug 6160
 unittest
 {
-    assert(1000_000_000e50L == to!real("1000_000_000_e50"));        // 1e59
+    assert(6_5.536e3L == to!real("6_5.536e3"));                     // 2^16
     assert(0x1000_000_000_p10 == to!real("0x1000_000_000_p10"));    // 7.03687e+13
 }
 


### PR DESCRIPTION
These unittest fail on gdc for a subtle reason: gdc has to parse the literal values at compile time, then store them into reals. The strings are parsed by the `to` function at runtime. But these values do not fit completely into a 80bit real which means that there is rounding. And this means these tests actually test that the `string->real` function in phobos is 1:1 identical to the function used in the compiler. (And we have a 1-bit difference in gdc because of rounding)

So I changed these values to something that fits into 80 bit.

It would be nice if people writing unittests could try not to use binary equality with floating point values which do not fit into the used float type. I guess we'll see many more of these problems on non-x86 hardware.
