### PR TITLE
fix for calling .array() on ranges in CTFE

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -318,7 +318,9 @@ if(allSatisfy!(isIntegral, I))
 
     alias typeof(T.init[0]) E;
 
-    auto ptr = cast(E*) GC.malloc(sizes[0] * E.sizeof, blockAttribute!(E));
+    auto ptr = (__ctfe) ?
+        (new E[](sizes[0])).ptr :
+        cast(E*) GC.malloc(sizes[0] * E.sizeof, blockAttribute!(E));
     auto ret = ptr[0..sizes[0]];
 
     static if(sizes.length > 1)


### PR DESCRIPTION
Previously .array() could not be called on ranges in CTFE mode as it relied on calling malloc(), so code such as this would not work:

``` d
void main() {
  const a = [1, 2, 3];
  const b = a.map!("a + 1").array();
  pragma(msg, b);
}
```

This provides a fix so memory will be allocated with new() instead of malloc() if the compiler is in CTFE mode. 
