### PR TITLE
Improve std.typecons.Tuple implementation

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -501,11 +501,19 @@ template Tuple(Specs...)
          * Assignment from another tuple. Each element of the source must be
          * implicitly assignable to the respective element of the target.
          */
-        void opAssign(R)(R rhs)
+        void opAssign(R)(auto ref R rhs)
         if (areCompatibleTuples!(typeof(this), R, "="))
         {
-            // Do not swap; opAssign should be called on the fields.
-            field[] = rhs.field[];
+            static if (is(R : Tuple!Types) && !__traits(isRef, rhs))
+            {
+                // Use swap-and-destroy to optimize rvalue assignment
+                swap!(Tuple!Types)(this, rhs);
+            }
+            else
+            {
+                // Do not swap; opAssign should be called on the fields.
+                field[] = rhs.field[];
+            }
         }
 
         /**


### PR DESCRIPTION
This improvement has two purpose.
- Refactoring
  Remove unnecessary workadounds that was for legacy compiler bugs.
- Add relation between named-field tuple and unnamed-field one.
  Named-field tuple should be a subtype of unnamed-field tuple.

---

Required compiler fixes by this:
<del>https://github.com/D-Programming-Language/dmd/pull/2084</del> (merged)
<del>https://github.com/D-Programming-Language/dmd/pull/2085</del> (merged)
