### PR TITLE
Added new StaticTuple template and deprecated use of TypeTuple with non-...

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2027,10 +2027,10 @@ template forward(args...)
             alias fwd = arg;
         else
             @property fwd()(){ return move(arg); }
-        alias forward = TypeTuple!(fwd, forward!(args[1..$]));
+        alias forward = StaticTuple!(fwd, forward!(args[1..$]));
     }
     else
-        alias forward = TypeTuple!();
+        alias forward = StaticTuple!();
 }
 
 unittest

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3138,7 +3138,7 @@ unittest
 {
     import std.string;
 
-    foreach(endianness; TypeTuple!(Endian.bigEndian, Endian.littleEndian))
+    foreach(endianness; StaticTuple!(Endian.bigEndian, Endian.littleEndian))
     {
         auto toWrite = appender!(ubyte[])();
         alias TypeTuple!(uint, int, long, ulong, short, ubyte, ushort, byte, uint) Types;

--- a/std/conv.d
+++ b/std/conv.d
@@ -702,8 +702,8 @@ unittest
     class C : B, I, J {}
     class D : I {}
 
-    foreach (m1; TypeTuple!(0,1,2,3,4)) // enumerate modifiers
-    foreach (m2; TypeTuple!(0,1,2,3,4)) // ditto
+    foreach (m1; StaticTuple!(0,1,2,3,4)) // enumerate modifiers
+    foreach (m2; StaticTuple!(0,1,2,3,4)) // ditto
     {
         alias AddModifier!m1 srcmod;
         alias AddModifier!m2 tgtmod;

--- a/std/exception.d
+++ b/std/exception.d
@@ -428,11 +428,11 @@ unittest
 {
     import std.typetuple;
 
-    foreach (EncloseSafe; TypeTuple!(false, true))
-    foreach (EnclosePure; TypeTuple!(false, true))
+    foreach (EncloseSafe; StaticTuple!(false, true))
+    foreach (EnclosePure; StaticTuple!(false, true))
     {
-        foreach (BodySafe; TypeTuple!(false, true))
-        foreach (BodyPure; TypeTuple!(false, true))
+        foreach (BodySafe; StaticTuple!(false, true))
+        foreach (BodyPure; StaticTuple!(false, true))
         {
             enum code =
                 "delegate void() " ~

--- a/std/file.d
+++ b/std/file.d
@@ -184,7 +184,7 @@ void[] read(in char[] name, size_t upTo = size_t.max)
 {
     version(Windows)
     {
-        alias TypeTuple!(GENERIC_READ,
+        alias StaticTuple!(GENERIC_READ,
                 FILE_SHARE_READ, (SECURITY_ATTRIBUTES*).init, OPEN_EXISTING,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                 HANDLE.init)
@@ -319,7 +319,7 @@ void write(in char[] name, const void[] buffer)
 {
     version(Windows)
     {
-        alias TypeTuple!(GENERIC_WRITE, 0, null, CREATE_ALWAYS,
+        alias StaticTuple!(GENERIC_WRITE, 0, null, CREATE_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                 HANDLE.init)
             defaults;
@@ -358,7 +358,7 @@ void append(in char[] name, in void[] buffer)
 {
     version(Windows)
     {
-        alias TypeTuple!(GENERIC_WRITE,0,null,OPEN_ALWAYS,
+        alias StaticTuple!(GENERIC_WRITE,0,null,OPEN_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,HANDLE.init)
             defaults;
 
@@ -690,7 +690,7 @@ void setTimes(in char[] name,
     {
         const ta = SysTimeToFILETIME(accessTime);
         const tm = SysTimeToFILETIME(modificationTime);
-        alias TypeTuple!(GENERIC_WRITE,
+        alias StaticTuple!(GENERIC_WRITE,
                          0,
                          null,
                          OPEN_EXISTING,

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3455,7 +3455,7 @@ struct Curl
         copy.stopped = false;
 
         with (CurlOption) {
-            auto tt = TypeTuple!(file, writefunction, writeheader,
+            auto tt = StaticTuple!(file, writefunction, writeheader,
                                  headerfunction, infile,
                                  readfunction, ioctldata, ioctlfunction,
                                  seekdata, seekfunction, sockoptdata,

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -121,7 +121,7 @@ private template CustomFloatParams(uint bits)
 
 private template CustomFloatParams(uint precision, uint exponentWidth, CustomFloatFlags flags)
 {
-    alias TypeTuple!(
+    alias StaticTuple!(
         precision,
         exponentWidth,
         flags,

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2499,7 +2499,7 @@ public:
                 // since we're assuming functions are associative anyhow.
 
                 // This is so that loops can be unrolled automatically.
-                enum ilpTuple = TypeTuple!(0, 1, 2, 3, 4, 5);
+                enum ilpTuple = StaticTuple!(0, 1, 2, 3, 4, 5);
                 enum nILP = ilpTuple.length;
                 immutable subSize = (upperBound - lowerBound) / nILP;
 

--- a/std/range.d
+++ b/std/range.d
@@ -3230,7 +3230,7 @@ unittest
         int[] _arr;
     }
 
-    foreach(range; TypeTuple!(`[1, 2, 3, 4, 5]`,
+    foreach(range; StaticTuple!(`[1, 2, 3, 4, 5]`,
                               `"hello world"`,
                               `"hello world"w`,
                               `"hello world"d`,
@@ -3246,7 +3246,7 @@ unittest
                      range, range, range));
     }
 
-    foreach(range; TypeTuple!(`NormalStruct([1, 2, 3])`,
+    foreach(range; StaticTuple!(`NormalStruct([1, 2, 3])`,
                               `InitStruct([1, 2, 3])`))
     {
         mixin(format("enum a = takeNone(%s).empty;", range));
@@ -5442,7 +5442,7 @@ unittest
 
 unittest
 {
-    foreach(range; TypeTuple!(iota(2, 27, 4),
+    foreach(range; StaticTuple!(iota(2, 27, 4),
                               iota(3, 9),
                               iota(2.7, 12.3, .1),
                               iota(3.2, 9.7)))

--- a/std/regex.d
+++ b/std/regex.d
@@ -649,7 +649,7 @@ enum RegexOption: uint {
     multiline = 0x10,
     singleline = 0x20
 };
-alias TypeTuple!('g', 'i', 'x', 'U', 'm', 's') RegexOptionNames;//do not reorder this list
+alias StaticTuple!('g', 'i', 'x', 'U', 'm', 's') RegexOptionNames;//do not reorder this list
 static assert( RegexOption.max < 0x80);
 enum RegexInfo : uint { oneShot = 0x80 };
 
@@ -4052,10 +4052,10 @@ template BacktrackingMatcher(bool CTregex)
     return format;
 }
 
-//generate code for TypeTuple(S, S+1, S+2, ... E)
+//generate code for StaticTuple(S, S+1, S+2, ... E)
 @system string ctGenSeq(int S, int E)
 {
-    string s = "alias TypeTuple!(";
+    string s = "alias StaticTuple!(";
     if(S < E)
         s ~= to!string(S);
     for(int i = S+1; i < E;i++)
@@ -4066,7 +4066,7 @@ template BacktrackingMatcher(bool CTregex)
     return s ~") Sequence;";
 }
 
-//alias to TypeTuple(S, S+1, S+2, ... E)
+//alias to StaticTuple(S, S+1, S+2, ... E)
 template Sequence(int S, int E)
 {
     mixin(ctGenSeq(S,E));
@@ -7076,7 +7076,7 @@ unittest
     }
     static string generate(uint n,uint[] black_list...)
     {
-        string s = "TypeTuple!(";
+        string s = "StaticTuple!(";
         for(uint i = 0; i < n; i++)
         {
             uint j;

--- a/std/traits.d
+++ b/std/traits.d
@@ -136,7 +136,7 @@ version(unittest)
     template WildOf(T)        { alias        inout(T)  WildOf;        }
     template SharedWildOf(T)  { alias shared(inout(T)) SharedWildOf;  }
 
-    alias TypeTuple!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf) TypeQualifierList;
+    alias StaticTuple!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf) TypeQualifierList;
 
     struct SubTypeOf(T)
     {
@@ -333,8 +333,8 @@ private template fullyQualifiedNameImplForTypes(T,
         _inout = 3
     }
 
-    alias TypeTuple!(is(T == const), is(T == immutable), is(T == shared), is(T == inout)) qualifiers;
-    alias TypeTuple!(false, false, false, false) noQualifiers;
+    alias StaticTuple!(is(T == const), is(T == immutable), is(T == shared), is(T == inout)) qualifiers;
+    alias StaticTuple!(false, false, false, false) noQualifiers;
 
     string storageClassesString(uint psc)() @property
     {
@@ -761,14 +761,14 @@ template ParameterStorageClassTuple(func...)
             enum skip = mangledName!(Params[i]).length; // for bypassing Type
             enum rest = demang.rest;
 
-            alias TypeTuple!(
+            alias StaticTuple!(
                     demang.value + 0, // workaround: "not evaluatable at ..."
                     demangleNextParameter!(rest[skip .. $], i + 1)
                 ) demangleNextParameter;
         }
         else // went thru all the parameters
         {
-            alias TypeTuple!() demangleNextParameter;
+            alias StaticTuple!() demangleNextParameter;
         }
     }
 
@@ -855,9 +855,9 @@ template ParameterIdentifierTuple(func...)
     template Impl(size_t i = 0)
     {
         static if (i == PT.length)
-            alias TypeTuple!() Impl;
+            alias StaticTuple!() Impl;
         else
-            alias TypeTuple!(Get!i, Impl!(i+1)) Impl;
+            alias StaticTuple!(Get!i, Impl!(i+1)) Impl;
     }
 
     alias Impl!() ParameterIdentifierTuple;
@@ -943,9 +943,9 @@ template ParameterDefaultValueTuple(func...)
     template Impl(size_t i = 0)
     {
         static if (i == PT.length)
-            alias TypeTuple!() Impl;
+            alias StaticTuple!() Impl;
         else
-            alias TypeTuple!(Get!i, Impl!(i+1)) Impl;
+            alias StaticTuple!(Get!i, Impl!(i+1)) Impl;
     }
 
     alias Impl!() ParameterDefaultValueTuple;
@@ -967,14 +967,14 @@ unittest
     static assert(PDVT!bar.length == 2);
     static assert(PDVT!bar[0] == 1);
     static assert(PDVT!bar[1] == "hello");
-    static assert(is(typeof(PDVT!bar) == typeof(TypeTuple!(1, "hello"))));
+    static assert(is(typeof(PDVT!bar) == typeof(StaticTuple!(1, "hello"))));
 
     void baz(int x, int n = 1, string s = "hello"){}
     static assert(PDVT!baz.length == 3);
     static assert(is(PDVT!baz[0] == void));
     static assert(   PDVT!baz[1] == 1);
     static assert(   PDVT!baz[2] == "hello");
-    static assert(is(typeof(PDVT!baz) == typeof(TypeTuple!(void, 1, "hello"))));
+    static assert(is(typeof(PDVT!baz) == typeof(StaticTuple!(void, 1, "hello"))));
 
     struct Colour
     {
@@ -1507,7 +1507,7 @@ unittest
         int  test();
         int  test() @property;
     }
-    alias TypeTuple!(__traits(getVirtualFunctions, Overloads, "test")) ov;
+    alias StaticTuple!(__traits(getVirtualFunctions, Overloads, "test")) ov;
     alias FunctionTypeOf!(ov[0]) F_ov0;
     alias FunctionTypeOf!(ov[1]) F_ov1;
     alias FunctionTypeOf!(ov[2]) F_ov2;
@@ -1646,7 +1646,7 @@ unittest
             // Check that all linkage types work (D-style variadics require D linkage).
             static if (variadicFunctionStyle!T != Variadic.d)
             {
-                foreach (newLinkage; TypeTuple!("D", "C", "Windows", "Pascal", "C++"))
+                foreach (newLinkage; StaticTuple!("D", "C", "Windows", "Pascal", "C++"))
                 {
                     alias SetFunctionAttributes!(T, newLinkage, attrs) New;
                     static assert(functionLinkage!New == newLinkage,
@@ -1816,7 +1816,7 @@ unittest
 //         else
 //         {
 //             private enum size_t mySize = T[0].sizeof;
-//             alias TypeTuple!myOffset Head;
+//             alias StaticTuple!myOffset Head;
 //             static if (is(T == union))
 //             {
 //                 alias FieldOffsetsTupleImpl!(myOffset, T[1 .. $]).Result
@@ -1828,7 +1828,7 @@ unittest
 //                                              T[1 .. $]).Result
 //                     Tail;
 //             }
-//             alias TypeTuple!(Head, Tail) Result;
+//             alias StaticTuple!(Head, Tail) Result;
 //         }
 //     }
 // }
@@ -3102,7 +3102,7 @@ template EnumMembers(E)
     {
         static if (names.length > 0)
         {
-            alias TypeTuple!(
+            alias StaticTuple!(
                     WithIdentifier!(names[0])
                         .Symbolize!(__traits(getMember, E, names[0])),
                     EnumSpecificMembers!(names[1 .. $])
@@ -3110,7 +3110,7 @@ template EnumMembers(E)
         }
         else
         {
-            alias TypeTuple!() EnumSpecificMembers;
+            alias StaticTuple!() EnumSpecificMembers;
         }
     }
 
@@ -3438,28 +3438,28 @@ template MemberFunctionsTuple(C, string name)
             static if (__traits(hasMember, Node, name) && __traits(compiles, __traits(getMember, Node, name)))
             {
                 // Get all overloads in sight (not hidden).
-                alias TypeTuple!(__traits(getVirtualFunctions, Node, name)) inSight;
+                alias StaticTuple!(__traits(getVirtualFunctions, Node, name)) inSight;
 
                 // And collect all overloads in ancestor classes to reveal hidden
                 // methods.  The result may contain duplicates.
                 template walkThru(Parents...)
                 {
                     static if (Parents.length > 0)
-                        alias TypeTuple!(
+                        alias StaticTuple!(
                                     CollectOverloads!(Parents[0]),
                                     walkThru!(Parents[1 .. $])
                                 ) walkThru;
                     else
-                        alias TypeTuple!() walkThru;
+                        alias StaticTuple!() walkThru;
                 }
 
                 static if (is(Node Parents == super))
-                    alias TypeTuple!(inSight, walkThru!Parents) CollectOverloads;
+                    alias StaticTuple!(inSight, walkThru!Parents) CollectOverloads;
                 else
-                    alias TypeTuple!inSight CollectOverloads;
+                    alias StaticTuple!inSight CollectOverloads;
             }
             else
-                alias TypeTuple!() CollectOverloads; // no overloads in this hierarchy
+                alias StaticTuple!() CollectOverloads; // no overloads in this hierarchy
         }
 
         // duplicates in this tuple will be removed by shrink()
@@ -3485,13 +3485,13 @@ template MemberFunctionsTuple(C, string name)
                     alias shrinkOne!(rest[0], rest[1 .. $]) shrinkOne;
                 else
                     // target and rest[0] are distinct.
-                    alias TypeTuple!(
+                    alias StaticTuple!(
                                 shrinkOne!(target, rest[1 .. $]),
                                 rest[0] // keep
                             ) shrinkOne;
             }
             else
-                alias TypeTuple!target shrinkOne; // done
+                alias StaticTuple!target shrinkOne; // done
         }
 
         /*
@@ -3502,17 +3502,17 @@ template MemberFunctionsTuple(C, string name)
             static if (overloads.length > 0)
             {
                 alias shrinkOne!overloads temp;
-                alias TypeTuple!(temp[0], shrink!(temp[1 .. $])) shrink;
+                alias StaticTuple!(temp[0], shrink!(temp[1 .. $])) shrink;
             }
             else
-                alias TypeTuple!() shrink; // done
+                alias StaticTuple!() shrink; // done
         }
 
         // done.
         alias shrink!overloads MemberFunctionsTuple;
     }
     else
-        alias TypeTuple!() MemberFunctionsTuple;
+        alias StaticTuple!() MemberFunctionsTuple;
 }
 
 unittest
@@ -4322,8 +4322,8 @@ template StaticArrayTypeOf(T)
 
 unittest
 {
-    foreach (T; TypeTuple!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-    foreach (Q; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (T; StaticTuple!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+    foreach (Q; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
     {
         static assert(is( Q!(   T[1] ) == StaticArrayTypeOf!( Q!(              T[1]  ) ) ));
 
@@ -4332,8 +4332,8 @@ unittest
         static assert(is( Q!(P!(T[1])) == StaticArrayTypeOf!( Q!(SubTypeOf!(P!(T[1]))) ) ));
       }
     }
-    foreach (T; TypeTuple!void)
-    foreach (Q; TypeTuple!TypeQualifierList)
+    foreach (T; StaticTuple!void)
+    foreach (Q; StaticTuple!TypeQualifierList)
     {
         static assert(is( StaticArrayTypeOf!( Q!(void[1]) ) == Q!(void[1]) ));
     }
@@ -4368,13 +4368,13 @@ template DynamicArrayTypeOf(T)
 
 unittest
 {
-    foreach (T; TypeTuple!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-    foreach (Q; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (T; StaticTuple!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+    foreach (Q; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
     {
         static assert(is( Q!T[]  == DynamicArrayTypeOf!( Q!T[] ) ));
         static assert(is( Q!(T[])  == DynamicArrayTypeOf!( Q!(T[]) ) ));
 
-      foreach (P; TypeTuple!(MutableOf, ConstOf, ImmutableOf))
+      foreach (P; StaticTuple!(MutableOf, ConstOf, ImmutableOf))
       {
         static assert(is( Q!(P!T[]) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!T[])) ) ));
         static assert(is( Q!(P!(T[])) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!(T[]))) ) ));
@@ -4424,7 +4424,7 @@ template StringTypeOf(T)
 unittest
 {
     foreach (T; CharTypeList)
-    foreach (Q; TypeTuple!(MutableOf, ConstOf, ImmutableOf, WildOf))
+    foreach (Q; StaticTuple!(MutableOf, ConstOf, ImmutableOf, WildOf))
     {
         static assert(is(Q!T[] == StringTypeOf!( Q!T[] )));
 
@@ -4438,7 +4438,7 @@ unittest
         }
     }
     foreach (T; CharTypeList)
-    foreach (Q; TypeTuple!(SharedOf, SharedConstOf, SharedWildOf))
+    foreach (Q; StaticTuple!(SharedOf, SharedConstOf, SharedWildOf))
     {
         static assert(!is(StringTypeOf!( Q!T[] )));
     }
@@ -4488,17 +4488,17 @@ template AssocArrayTypeOf(T)
 unittest
 {
     foreach (T; TypeTuple!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-    foreach (P; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
-    foreach (Q; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
-    foreach (R; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (P; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (Q; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (R; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
     {
         static assert(is( P!(Q!T[R!T]) == AssocArrayTypeOf!(            P!(Q!T[R!T])  ) ));
     }
     foreach (T; TypeTuple!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-    foreach (O; TypeTuple!(TypeQualifierList, WildOf, SharedWildOf))
-    foreach (P; TypeTuple!TypeQualifierList)
-    foreach (Q; TypeTuple!TypeQualifierList)
-    foreach (R; TypeTuple!TypeQualifierList)
+    foreach (O; StaticTuple!(TypeQualifierList, WildOf, SharedWildOf))
+    foreach (P; StaticTuple!TypeQualifierList)
+    foreach (Q; StaticTuple!TypeQualifierList)
+    foreach (R; StaticTuple!TypeQualifierList)
     {
         static assert(is( O!(P!(Q!T[R!T])) == AssocArrayTypeOf!( O!(SubTypeOf!(P!(Q!T[R!T]))) ) ));
     }
@@ -4755,7 +4755,7 @@ unittest
 {
     foreach (T; TypeTuple!(char[], string, wstring, char[4]))
     {
-        foreach (Q; TypeTuple!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
+        foreach (Q; StaticTuple!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
         {
             static assert( isNarrowString!(            Q!T  ));
             static assert(!isNarrowString!( SubTypeOf!(Q!T) ));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -278,18 +278,18 @@ private:
     {
         static if (Specs.length == 0)
         {
-            alias TypeTuple!() parseSpecs;
+            alias StaticTuple!() parseSpecs;
         }
         else static if (is(Specs[0]))
         {
             static if (is(typeof(Specs[1]) : string))
             {
-                alias TypeTuple!(FieldSpec!(Specs[0 .. 2]),
+                alias StaticTuple!(FieldSpec!(Specs[0 .. 2]),
                                  parseSpecs!(Specs[2 .. $])) parseSpecs;
             }
             else
             {
-                alias TypeTuple!(FieldSpec!(Specs[0]),
+                alias StaticTuple!(FieldSpec!(Specs[0]),
                                  parseSpecs!(Specs[1 .. $])) parseSpecs;
             }
         }
@@ -344,11 +344,11 @@ private:
     {
         static if (spec.name.length == 0)
         {
-            alias TypeTuple!(spec.Type) expandSpec;
+            alias StaticTuple!(spec.Type) expandSpec;
         }
         else
         {
-            alias TypeTuple!(spec.Type, spec.name) expandSpec;
+            alias StaticTuple!(spec.Type, spec.name) expandSpec;
         }
     }
 
@@ -1996,12 +1996,12 @@ private static:
             alias staticFilter!(pred, lst[1 .. $]) tail;
             //
             static if (pred!(lst[0]))
-                alias TypeTuple!(lst[0], tail) staticFilter;
+                alias StaticTuple!(lst[0], tail) staticFilter;
             else
                 alias tail staticFilter;
         }
         else
-            alias TypeTuple!() staticFilter;
+            alias StaticTuple!() staticFilter;
     }
 
     // Returns function overload sets in the class C, filtered with pred.
@@ -2015,12 +2015,12 @@ private static:
                 alias Impl!(names[1 .. $]) next;
 
                 static if (methods.length > 0)
-                    alias TypeTuple!(OverloadSet!(names[0], methods), next) Impl;
+                    alias StaticTuple!(OverloadSet!(names[0], methods), next) Impl;
                 else
                     alias next Impl;
             }
             else
-                alias TypeTuple!() Impl;
+                alias StaticTuple!() Impl;
         }
 
         alias Impl!(__traits(allMembers, C)) enumerateOverloads;
@@ -2341,9 +2341,9 @@ private static:
     template CountUp(size_t n)
     {
         static if (n > 0)
-            alias TypeTuple!(CountUp!(n - 1), n - 1) CountUp;
+            alias StaticTuple!(CountUp!(n - 1), n - 1) CountUp;
         else
-            alias TypeTuple!() CountUp;
+            alias StaticTuple!() CountUp;
     }
 
 
@@ -2475,7 +2475,7 @@ private static:
             /* Declare keywords: args, self and parent. */
             string preamble;
 
-            preamble ~= "alias TypeTuple!(" ~ enumerateParameters!(nparams) ~ ") args;\n";
+            preamble ~= "alias StaticTuple!(" ~ enumerateParameters!(nparams) ~ ") args;\n";
             if (!isCtor)
             {
                 preamble ~= "alias " ~ name ~ " self;\n";
@@ -3459,7 +3459,7 @@ unittest // Issue 6580 testcase
             byte[size] arr;
             alignmentTest();
         }
-        foreach(i; TypeTuple!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        foreach(i; StaticTuple!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
             test!i();
     }
 }

--- a/std/utf.d
+++ b/std/utf.d
@@ -296,7 +296,7 @@ uint strideBack(S)(auto ref S str, size_t index)
 
     if (index >= 4) //single verification for most common case
     {
-        foreach(i; TypeTuple!(2, 3, 4))
+        foreach(i; StaticTuple!(2, 3, 4))
         {
             if ((str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;
@@ -304,7 +304,7 @@ uint strideBack(S)(auto ref S str, size_t index)
     }
     else
     {
-        foreach(i; TypeTuple!(2, 3))
+        foreach(i; StaticTuple!(2, 3))
         {
             if (index >= i && (str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;
@@ -326,7 +326,7 @@ uint strideBack(S)(auto ref S str)
 {
     assert(!str.empty, "Past the end of the UTF-8 sequence");
     auto temp = str.save;
-    foreach(i; TypeTuple!(1, 2, 3, 4))
+    foreach(i; StaticTuple!(1, 2, 3, 4))
     {
         if ((temp.back & 0b1100_0000) != 0b1000_0000) return i;
         temp.popBack();
@@ -1144,7 +1144,7 @@ private dchar decodeImpl(bool canIndex, S)(auto ref S str, ref size_t index)
     dchar d = fst; // upper control bits are masked out later
     fst <<= 1;
 
-    foreach(i; TypeTuple!(1, 2, 3))
+    foreach(i; StaticTuple!(1, 2, 3))
     {
 
         static if (canIndex)
@@ -1372,7 +1372,7 @@ version(unittest) private void testBadDecode(R)(R range, size_t index, size_t li
 
 unittest
 {
-    foreach (S; TypeTuple!(to!string, InputCU!char, RandomCU!char,
+    foreach (S; StaticTuple!(to!string, InputCU!char, RandomCU!char,
                            (string s) => new RefBidirCU!char(s),
                            (string s) => new RefRandomCU!char(s)))
     {
@@ -1430,7 +1430,7 @@ unittest
 
 unittest
 {
-    foreach (S; TypeTuple!(to!wstring, InputCU!wchar, RandomCU!wchar,
+    foreach (S; StaticTuple!(to!wstring, InputCU!wchar, RandomCU!wchar,
                            (wstring s) => new RefBidirCU!wchar(s),
                            (wstring s) => new RefRandomCU!wchar(s)))
     {
@@ -1454,7 +1454,7 @@ unittest
         }
     }
 
-    foreach (S; TypeTuple!(to!wstring, RandomCU!wchar, (wstring s) => new RefRandomCU!wchar(s)))
+    foreach (S; StaticTuple!(to!wstring, RandomCU!wchar, (wstring s) => new RefRandomCU!wchar(s)))
     {
         auto str = S([cast(wchar)0xD800, cast(wchar)0xDC00,
                       cast(wchar)0x1400,
@@ -1467,7 +1467,7 @@ unittest
 
 unittest
 {
-    foreach(S; TypeTuple!(to!dstring, RandomCU!dchar, InputCU!dchar,
+    foreach(S; StaticTuple!(to!dstring, RandomCU!dchar, InputCU!dchar,
                           (dstring s) => new RefBidirCU!dchar(s),
                           (dstring s) => new RefRandomCU!dchar(s)))
     {
@@ -1492,7 +1492,7 @@ unittest
         }
     }
 
-    foreach (S; TypeTuple!(to!dstring, RandomCU!dchar, (dstring s) => new RefRandomCU!dchar(s)))
+    foreach (S; StaticTuple!(to!dstring, RandomCU!dchar, (dstring s) => new RefRandomCU!dchar(s)))
     {
         auto str = S([cast(dchar)0x10000, cast(dchar)0x1400, cast(dchar)0xB9DDE]);
         testDecode(str, 0, 0x10000, 1);


### PR DESCRIPTION
...type parameters

http://forum.dlang.org/thread/hwlrptkobszameyvkgam@forum.dlang.org

TypeTuple!(int, "Hello") will now cause a deprecation warning
TypeTuple!(int, float) will work exactly as before

StaticTuple!(int, "Hello") is used for non-type tuples

StaticTuple!(int, float) == TypeTuple!(int, float)

Library code has been updated to use StaticTuple in the case that it depends on the undocumented feature of TypeTuple to store non-types.

For what it's worth, the only major uses of the non-type version of TypeTuple were in std.traits and std.typetuple itself, and of the rest (~30) the majority were used in unit test code.
