### PR TITLE
Adjust floating point formatting tests for MinGW

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3121,6 +3121,11 @@ unittest
         assert(stream.data == "1.67 -0X1.47AE147AE147BP+0 nan",
                 stream.data);
     }
+    else version (MinGW)
+    {
+        assert(stream.data == "1.67 -0XA.3D70A3D70A3D8P-3 nan",
+                stream.data);
+    }
     else
     {
         assert(stream.data == "1.67 -0X1.47AE147AE147BP+0 nan",
@@ -3662,7 +3667,10 @@ unittest
     {
         auto f = 3.14;
         formatReflectTest(f, "%s",  `3.14`);
-        formatReflectTest(f, "%e",  `3.140000e+00`);
+        version (MinGW)
+            formatReflectTest(f, "%e",  `3.140000e+000`);
+        else
+            formatReflectTest(f, "%e",  `3.140000e+00`);
         formatReflectTest(f, "%f",  `3.140000`);
         formatReflectTest(f, "%g",  `3.14`);
     }
@@ -5591,6 +5599,9 @@ unittest
     //else version (OSX)
     //    assert(s == "1.67 -0XA.3D70A3D70A3D8P-3 nan", s);
     //else
+    version (MinGW)
+        assert(s == "1.67 -0XA.3D70A3D70A3D8P-3 nan", s);
+    else
         assert(s == "1.67 -0X1.47AE147AE147BP+0 nan", s);
 
     s = std.string.format("%x %X", 0x1234AF, 0xAFAFAFAF);

--- a/std/json.d
+++ b/std/json.d
@@ -512,7 +512,6 @@ unittest
         `0.23`,
         `-0.23`,
         `""`,
-        `1.223e+24`,
         `"hello\nworld"`,
         `"\"\\\/\b\f\n\r\t"`,
         `[]`,
@@ -522,6 +521,11 @@ unittest
         // Currently broken
         // `{"hello":{"json":"is great","array":[12,null,{}]},"goodbye":[true,"or",false,["test",42,{"nested":{"a":23.54,"b":0.0012}}]]}`
     ];
+
+    version (MinGW)
+        jsons ~= `1.223e+024`;
+    else
+        jsons ~= `1.223e+24`;
 
     JSONValue val;
     string result;


### PR DESCRIPTION
As far as I am aware, the C standard doesn't make any
guarantees about what the leading digit in the hex formats
is, nor about the number of exponent digits displayed by
default.

We should look into replacing the functions with our own
implementations to provide consistent behavior independent
of the host C runtime library, and potentially also allowing
the functionality to be used from CTFE.
