### PR TITLE
Add -f to ln

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -271,10 +271,10 @@ $(LIB) : $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 dll : $(ROOT)/libphobos2.so
 
 $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
-	ln -s $(notdir $(LIBSO)) $@ 
+	ln -sf $(notdir $(LIBSO)) $@ 
 
 $(ROOT)/$(SONAME): $(LIBSO)
-	ln -s $(notdir $(LIBSO)) $@
+	ln -sf $(notdir $(LIBSO)) $@
 
 $(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(D_FILES) $(OBJS)


### PR DESCRIPTION
On some systems, ln will fail if the target link already exists. This causes rebuilding Phobos to fail if the target file already exists. This pull fixes this by adding -f to the ln command line to force it to overwrite the old link.
