### PR TITLE
[MINOR] Change default doc dir to dlang.org

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -61,7 +61,7 @@ ZIPFILE = phobos.zip
 ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 # Documentation-related stuff
-DOCSRC = ../d-programming-language.org
+DOCSRC = ../dlang.org
 WEBSITE_DIR = ../web
 DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp


### PR DESCRIPTION
This will require developers to rename the website dir (if they use it) from d-programming-language.org to dlang.org.
