### PR TITLE
Issue 10269 - RandomSample should use popFrontExactly, not popFrontN ...

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1660,10 +1660,15 @@ struct RandomSample(R, Random = void)
     {
         _available = total;
         _toSelect = howMany;
-        enforce(_toSelect <= _available, text("RandomSample: cannot sample ", _toSelect, " items when only ", _available, " are available"));
+        enforce(_toSelect <= _available,
+                text("RandomSample: cannot sample ", _toSelect,
+                     " items when only ", _available, " are available"));
         static if (hasLength!R)
         {
-            enforce(_available <= _input.length, text("RandomSample: specified ", _available, " items as available when input contains only ", _input.length));
+            enforce(_available <= _input.length,
+                    text("RandomSample: specified ", _available,
+                         " items as available when input contains only ",
+                         _input.length));
         }
         _first = true;
     }


### PR DESCRIPTION
... when skipping across input range.  This results in a small speedup of RandomSample.popFront(), larger in the case of input where popFrontN() and popFrontExactly() will be of O(n) rather than O(1).

This small tweak has been accompanied by a couple of extra checks to ensure that users do not request more sample points than are available in the input, which could otherwise be the source of exceptions.

There exists one remaining case where RandomSample may fail: if it is given an InputRange without the .length property, and the user indicates that the total number of items available is greater than what the InputRange actually contains.  In this case an exception is thrown from std.array.popFront() line 450, "Attempting to popFront() past the end of an array", or from std.array.front() line 624, "Attempting to fetch the front of an empty array."
