### PR TITLE
Make conv unittest private simbols private

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -577,22 +577,23 @@ unittest
     assert(c2.x == 3);
 }
 
-version (unittest)
-{
-    class A
-    {
-        this(B b) {}
-    }
-    class B : A
-    {
-        this() { super(this); }
-    }
-}
 unittest
 {
-    B b = new B();
-    A a = to!A(b);      // == cast(A)b
-                        // (do not run construction conversion like new A(b))
+    struct S
+    {
+        class A
+        {
+            this(B b) {}
+        }
+        class B : A
+        {
+            this() { super(this); }
+        }
+    }
+
+    S.B b = new S.B();
+    S.A a = to!(S.A)(b);      // == cast(S.A)b
+                              // (do not run construction conversion like new S.A(b))
     assert(b is a);
 
     static class C : Object


### PR DESCRIPTION
There were some symbols in a "version(unittest)" block that were not declared private.

This can create some conflicts during unittest releases. I started out just declaring them private, but that created some ambiguities in other modules that used "A" in their names, eg:

``` D
struct Appender(A : T[], T)
```

`std\array.d(2129): Error: module std.array std.conv.A is private`.

So I just mangled the names. As a workaround. I'll file a bug report later.
