### PR TITLE
Supplemental fix for issue 10334

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1844,7 +1844,7 @@ unittest
       static if (flags & 4)
         string toString() const { return "S"; }
     }
-    formatTest(S!0b000([0, 1, 2]), "S!(0)([0, 1, 2])");
+    formatTest(S!0b000([0, 1, 2]), "S!0([0, 1, 2])");
     formatTest(S!0b001([0, 1, 2]), "[0, 1, 2]");        // Test for bug 7628
     formatTest(S!0b010([0, 1, 2]), "[0, 2, 4]");
     formatTest(S!0b011([0, 1, 2]), "[0, 2, 4]");


### PR DESCRIPTION
[Issue 10334](http://d.puremagic.com/issues/show_bug.cgi?id=10334) - ddoc should prefer simple syntax for template instantiations with one parameter

https://github.com/D-Programming-Language/dmd/pull/2173

You need to merge this and compiler fix at the same time.
