### PR TITLE
Fix Issue 9607 - std.random.randomShuffle() and partialShuffle() don't work with Xorshift.

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -112,13 +112,6 @@ version(unittest) import std.typetuple;
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 */
 
-version(unittest)
-{
-    alias TypeTuple!(MinstdRand0, MinstdRand, Mt19937, Xorshift32, Xorshift64, Xorshift96,
-                     Xorshift128, Xorshift160, Xorshift192) PseudoRngTypes;
-}
-
-
 /**
  * Test if Rng is a random-number generator. The overload
  * taking a ElementType also makes sure that the Rng generates
@@ -1011,6 +1004,37 @@ unittest
             assert(rnd.front == e);
             rnd.popFront();
         }
+    }
+}
+
+
+/* A complete list of all pseudo-random number generators implemented in
+ * std.random.  This can be used to confirm that a given function or
+ * object is compatible with all the pseudo-random number generators
+ * available.  It is enabled only in unittest mode.
+ *
+ * Example:
+ *
+ * ----
+ * foreach(Rng; PseudoRngTypes)
+ * {
+ *     static assert(isUniformRng!Rng);
+ *     auto rng = Rng(unpredictableSeed);
+ *     foo(rng);
+ * }
+ * ----
+ */
+version(unittest)
+{
+    package alias PseudoRngTypes = TypeTuple!(MinstdRand0, MinstdRand, Mt19937, Xorshift32, Xorshift64,
+                                              Xorshift96, Xorshift128, Xorshift160, Xorshift192);
+}
+
+unittest
+{
+    foreach(Rng; PseudoRngTypes)
+    {
+        static assert(isUniformRNG!Rng);
     }
 }
 


### PR DESCRIPTION
This is an instance of Issue 2803, a clash between a template parameter and a default argument.  With no general solution on the horizon for that bug, I've used the workaround proposed in that issue thread:
http://d.puremagic.com/issues/show_bug.cgi?id=2803#c1

Tests have been included to ensure that these functions work with all possible RNG types.  If this style of testing is considered useful I propose extending it to all functions that make use of RNGs.
