### PR TITLE
Fix save in filter.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1356,7 +1356,7 @@ private struct FilterResult(alias pred, Range)
     {
         @property auto save()
         {
-            return typeof(this)(_input);
+            return typeof(this)(_input.save);
         }
     }
 }


### PR DESCRIPTION
`filter.save` was missing the call for `_input.save`.

filterBidir was actually correct.

That's it.
