### PR TITLE
Fix issue 313 & 314 - Add necessary imports and fix FQN accesses

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -5747,7 +5747,7 @@ unittest
     assert(count("abcadfabf", "ab") == 2);
     assert(count("ababab", "abab") == 1);
     assert(count("ababab", "abx") == 0);
-    assert(count!"std.uni.toLower(a) == std.uni.toLower(b)"("AbcAdFaBf", "ab") == 2);
+    assert(count!((a, b) => std.uni.toLower(a) == std.uni.toLower(b))("AbcAdFaBf", "ab") == 2);
 }
 
 /// Ditto
@@ -6640,7 +6640,7 @@ unittest
     assert(levenshteinDistance("cat", "rat") == 1);
     assert(levenshteinDistance("parks", "spark") == 2);
     assert(levenshteinDistance("kitten", "sitting") == 3);
-    assert(levenshteinDistance!("std.uni.toUpper(a) == std.uni.toUpper(b)")
+    assert(levenshteinDistance!((a, b) => std.uni.toUpper(a) == std.uni.toUpper(b))
         ("parks", "SPARK") == 2);
 }
 
@@ -9774,8 +9774,8 @@ unittest
     // random data
     auto b = rndstuff!(string)();
     auto index = new string*[b.length];
-    partialIndex!("std.uni.toUpper(a) < std.uni.toUpper(b)")(b, index);
-    assert(isSorted!("std.uni.toUpper(*a) < std.uni.toUpper(*b)")(index));
+    partialIndex!((a, b) => std.uni.toUpper(a) < std.uni.toUpper(b))(b, index);
+    assert(isSorted!((a, b) => std.uni.toUpper(*a) < std.uni.toUpper(*b))(index));
 
     // random data with indexes
     auto index1 = new size_t[b.length];

--- a/std/c/stdio.d
+++ b/std/c/stdio.d
@@ -18,13 +18,4 @@ extern (C):
 version (Windows)
 {
     extern shared ubyte[_NFILE] __fhnd_info;
-
-    enum
-    {
-        FHND_APPEND     = 0x04,
-        FHND_DEVICE     = 0x08,
-        FHND_TEXT       = 0x10,
-        FHND_BYTE       = 0x20,
-        FHND_WCHAR      = 0x40,
-    }
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -2164,6 +2164,8 @@ Target parse(Target, Source)(ref Source p)
     if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
         isFloatingPoint!Target && !is(Target == enum))
 {
+    static import core.stdc.math/* : HUGE_VAL*/;
+
     static immutable real negtab[14] =
         [ 1e-4096L,1e-2048L,1e-1024L,1e-512L,1e-256L,1e-128L,1e-64L,1e-32L,
                 1e-16L,1e-8L,1e-4L,1e-2L,1e-1L,1.0L ];

--- a/std/cstream.d
+++ b/std/cstream.d
@@ -102,7 +102,7 @@ class CFile : Stream {
    * Ditto
    */
   override char ungetc(char c) {
-    return cast(char).std.c.stdio.ungetc(c,cfile);
+    return cast(char)std.c.stdio.ungetc(c,cfile);
   }
 
   /**

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -936,6 +936,8 @@ enum Order : bool
  */
 char[num*2] toHexString(Order order = Order.increasing, size_t num)(in ubyte[num] digest)
 {
+    import std.ascii : hexDigits;
+
     char[num*2] result;
     size_t i;
 
@@ -963,6 +965,8 @@ char[num*2] toHexString(Order order = Order.increasing, size_t num)(in ubyte[num
 ///ditto
 string toHexString(Order order = Order.increasing)(in ubyte[] digest)
 {
+    import std.ascii : hexDigits;
+
     auto result = new char[digest.length*2];
     size_t i;
 

--- a/std/file.d
+++ b/std/file.d
@@ -1821,7 +1821,7 @@ else version(Windows)
 
         void _init(in char[] path, in WIN32_FIND_DATA* fd)
         {
-            auto clength = to!int(std.c.string.strlen(fd.cFileName.ptr));
+            auto clength = to!int(core.stdc.string.strlen(fd.cFileName.ptr));
 
             // Convert cFileName[] to unicode
             const wlength = MultiByteToWideChar(0, 0, fd.cFileName.ptr, clength, null, 0);
@@ -1955,7 +1955,7 @@ else version(Posix)
 
         void _init(in char[] path, core.sys.posix.dirent.dirent* fd)
         {
-            immutable len = std.c.string.strlen(fd.d_name.ptr);
+            immutable len = core.stdc.string.strlen(fd.d_name.ptr);
             _name = buildPath(path, fd.d_name[0 .. len]);
 
             _didLStat = false;
@@ -2581,8 +2581,8 @@ unittest
         auto len = enforce(walkLength(dirEntries(absolutePath(relpath), mode)));
         assert(walkLength(dirEntries(relpath, mode)) == len);
         assert(equal(
-                   map!(q{std.path.absolutePath(a.name)})(dirEntries(relpath, mode)),
-                   map!(q{a.name})(dirEntries(absolutePath(relpath), mode))));
+                   map!(a => std.path.absolutePath(a.name))(dirEntries(relpath, mode)),
+                   map!(a => a.name)(dirEntries(absolutePath(relpath), mode))));
         return len;
     }
 

--- a/std/format.d
+++ b/std/format.d
@@ -2163,6 +2163,8 @@ if (isInputRange!T)
 // character formatting with ecaping
 private void formatChar(Writer)(Writer w, in dchar c, in char quote)
 {
+    import std.uni : isGraphical;
+
     if (std.uni.isGraphical(c))
     {
         if (c == quote || c == '\\')

--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -214,6 +214,8 @@ version(USE_SSSE3)
      */
     private nothrow pure string[] weave(string[] seq1, string[] seq2, uint dist = 1)
     {
+        import std.algorithm : min;
+
         string[] res = [];
         auto i1 = 0, i2 = 0;
         while (i1 < seq1.length || i2 < seq2.length)

--- a/std/json.d
+++ b/std/json.d
@@ -20,7 +20,6 @@ module std.json;
 import std.ascii;
 import std.conv;
 import std.range;
-import std.uni : isControl;
 import std.utf;
 
 private
@@ -518,6 +517,8 @@ string toJSON(in JSONValue* root, in bool pretty = false)
 private void appendJSONChar(Appender!string* dst, dchar c,
                             scope void delegate(string) error)
 {
+    import std.uni : isControl;
+
     if(isControl(c))
         error("Illegal control character.");
     dst.put(c);

--- a/std/md5.d
+++ b/std/md5.d
@@ -177,6 +177,8 @@ unittest
  */
 struct MD5_CTX
 {
+    private import core.stdc.string : memcpy, memset;
+
     uint state[4] =                                   /* state (ABCD) */
     /* magic initialization constants */
     [0x67452301,0xefcdab89,0x98badcfe,0x10325476];
@@ -269,7 +271,7 @@ struct MD5_CTX
       /* Transform as many times as possible. */
       if (inputLen >= partLen)
       {
-            std.c.string.memcpy(&buffer[index], input.ptr, partLen);
+            core.stdc.string.memcpy(&buffer[index], input.ptr, partLen);
             transform (buffer.ptr);
 
             for (i = partLen; i + 63 < inputLen; i += 64)
@@ -282,7 +284,7 @@ struct MD5_CTX
 
       /* Buffer remaining input */
       if (inputLen - i)
-            std.c.string.memcpy(&buffer[index], &input[i], inputLen-i);
+            core.stdc.string.memcpy(&buffer[index], &input[i], inputLen-i);
     }
 
     /** MD5 finalization. Ends an MD5 message-digest operation, writing the
@@ -311,7 +313,7 @@ struct MD5_CTX
       digest[12 .. 16] = nativeToLittleEndian(state[3])[];
 
       /* Zeroize sensitive information. */
-      std.c.string.memset (&this, 0, MD5_CTX.sizeof);
+      core.stdc.string.memset (&this, 0, MD5_CTX.sizeof);
     }
 
     /* MD5 basic transformation. Transforms state based on block.

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3507,6 +3507,8 @@ struct Curl
 
     private string errorString(CurlCode code)
     {
+        import core.stdc.string : strlen;
+
         auto msgZ = curl_easy_strerror(code);
         // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
         return format("%s on handle %s", msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -734,7 +734,7 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = CheckDns.no
             returnStatus ~= EmailStatusCode.rfc5321TopLevelDomainNumeric;
     }
 
-    returnStatus = array(std.algorithm.uniq(returnStatus));
+    returnStatus = array(uniq(returnStatus));
     auto finalStatus = returnStatus.max();
 
     if (returnStatus.length != 1)
@@ -1740,6 +1740,8 @@ enum AsciiToken
  */
 T max (T) (T[] arr)
 {
+    import std.algorithm/* : max*/;
+
     auto max = arr.front;
 
     foreach (i ; 0 .. arr.length - 1)

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3364,6 +3364,7 @@ private void submitAndExecute(
 
     alias typeof(scopedTask(doIt)) PTask;
     import core.stdc.stdlib;
+    import core.stdc.string : memcpy;
 
     // The logical thing to do would be to just use alloca() here, but that
     // causes problems on Windows for reasons that I don't understand

--- a/std/process.d
+++ b/std/process.d
@@ -375,6 +375,8 @@ private Pid spawnProcessImpl(in char[][] args,
                              Config config)
     @trusted // TODO: Should be @safe
 {
+    import core.exception: RangeError;
+
     if (args.empty) throw new RangeError("Command line is empty");
     const(char)[] name = args[0];
     if (any!isDirSeparator(name))
@@ -479,6 +481,8 @@ private Pid spawnProcessImpl(in char[] commandLine,
                              Config config)
     @trusted
 {
+    import core.exception: RangeError;
+
     if (commandLine.empty) throw new RangeError("Command line is empty");
     auto commandz = toUTFz!(wchar*)(commandLine);
 

--- a/std/regex.d
+++ b/std/regex.d
@@ -228,7 +228,7 @@ import std.array, std.algorithm, std.range,
        std.uni, std.utf, std.format, std.typecons, std.bitmanip,
        std.functional, std.exception;
 import core.bitop, core.stdc.string, core.stdc.stdlib;
-import ascii = std.ascii;
+static import ascii = std.ascii;
 import std.string : representation;
 
 debug import std.stdio;
@@ -6560,7 +6560,7 @@ L_Replace_Loop:
             }
             else if(format[0] == '{')
             {
-                auto x = find!"!std.ascii.isAlpha(a)"(format[1..$]);
+                auto x = find!(a => !ascii.isAlpha(a))(format[1..$]);
                 enforce(!x.empty && x[0] == '}', "no matching '}' in replacement format");
                 auto name = format[1 .. $ - x.length];
                 format = x[1..$];
@@ -7348,6 +7348,8 @@ else
     {
         void test(alias matchFn)()
         {
+            import std.string : toUpper;
+
             foreach(i, v; TypeTuple!(string, wstring, dstring))
             {
                 auto baz(Cap)(Cap m)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2461,7 +2461,7 @@ Initialize with a message and an error code. */
         }
         else
         {
-            auto s = std.c.string.strerror(errno);
+            auto s = core.stdc.string.strerror(errno);
         }
         auto sysmsg = to!string(s);
         // If e is 0, we don't use the system error message.  (The message

--- a/std/uri.d
+++ b/std/uri.d
@@ -387,6 +387,7 @@ size_t uriLength(string s)
      *  https://
      *  www.
      */
+    import std.string : icmp;
 
     size_t i;
 

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -520,6 +520,8 @@ in
 }
 body
 {
+    import core.bitop : bswap;
+
     REG_VALUE_TYPE type;
 
     // See bugzilla 961 on this
@@ -631,6 +633,8 @@ in
 }
 body
 {
+    import core.bitop : bswap;
+
     REG_VALUE_TYPE type;
 
     DWORD cbData = value.sizeof;

--- a/std/xml.d
+++ b/std/xml.d
@@ -441,6 +441,8 @@ enum DecodeMode
  */
 string decode(string s, DecodeMode mode=DecodeMode.LOOSE)
 {
+    import std.utf : encode;
+
     if (mode == DecodeMode.NONE) return s;
 
     char[] buffer;


### PR DESCRIPTION
Supplemental fix for these compiler bugs.
[Issue 313](http://d.puremagic.com/issues/show_bug.cgi?id=313) - [module] Fully qualified names bypass private imports
[Issue 314](http://d.puremagic.com/issues/show_bug.cgi?id=314) - [module] Static, renamed, and selective imports are always public
