### PR TITLE
 Fix Issue 10517 - readln(Char)(Char[] buf) accepts non-mutable buffers 

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -917,7 +917,7 @@ by $(D buf), whereas $(D buf = stdin.readln()) makes a new memory allocation
 with every line. 
 */
     size_t readln(C)(ref C[] buf, dchar terminator = '\n')
-    if ((is(C == char) || is(C == wchar) || is(C == dchar)) && !is(C == enum))
+    if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum))
     {
         static if (is(C == char))
         {
@@ -940,7 +940,7 @@ with every line.
 
 /** ditto */
     size_t readln(C, R)(ref C[] buf, R terminator)
-    if ((is(C == char) || is(C == wchar) || is(C == dchar)) && !is(C == enum) &&
+    if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum) &&
         isBidirectionalRange!R && is(typeof(terminator.front == dchar.init)))
     {
         auto last = terminator.back;
@@ -2002,14 +2002,14 @@ if (isSomeString!S)
 }
 /** ditto */
 size_t readln(C)(ref C[] buf, dchar terminator = '\n')
-if ((is(C == char) || is(C == wchar) || is(C == dchar)) && !is(C == enum))
+if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum))
 {
     return stdin.readln(buf, terminator);
 }
 
 /** ditto */
 size_t readln(C, R)(ref C[] buf, R terminator)
-if ((is(C == char) || is(C == wchar) || is(C == dchar)) && !is(C == enum) &&
+if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum) &&
     isBidirectionalRange!R && is(typeof(terminator.front == dchar.init)))
 {
     return stdin.readln(buf, terminator);


### PR DESCRIPTION
Bug: http://d.puremagic.com/issues/show_bug.cgi?id=10517
Boards: http://forum.dlang.org/thread/odkkhkgnahhpklvumghv@forum.dlang.org

Note that the old code is considered "accepts-invalid", and is now simply illegal (no deprecation) (per Steven Schveighoffer's recommendation on Boards).

Also templatizes global readln.

Fixes a wchar issue

On topic: Is there a cleaner way to say `isMutableChar!C` or `isMutableString!S`?

Semi on topic: We have no "range terminator" signature that returns a string, eg:

``` D
string s = stream.readln("<br />");
```

I wanted to add it, but we can't due to ambiguity with buffered readln, which is a shame...
