### PR TITLE
Convert C-style array declarations to D-style.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -4012,7 +4012,7 @@ unittest
 struct BoyerMooreFinder(alias pred, Range)
 {
 private:
-    size_t skip[];
+    size_t[] skip;
     ptrdiff_t[ElementType!(Range)] occ;
     Range needle;
 

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -368,7 +368,7 @@ enum
     _ALP =      _UC|_LC,
 }
 
-immutable ubyte _ctype[128] =
+immutable ubyte[128] _ctype =
 [
         _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
         _CTL,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL,_CTL,

--- a/std/c/linux/tipc.d
+++ b/std/c/linux/tipc.d
@@ -36,7 +36,7 @@ struct tipc_subscr
         tipc_name_seq seq;
         uint timeout;
         uint filter;
-        ubyte usr_handle[8];
+        ubyte[8] usr_handle;
 }
 
 struct tipc_event

--- a/std/c/windows/com.d
+++ b/std/c/windows/com.d
@@ -38,7 +38,7 @@ struct GUID {          // size is 16
         DWORD Data1;
         WORD  Data2;
         WORD  Data3;
-        BYTE  Data4[8];
+        BYTE[8]  Data4;
 }
 
 enum
@@ -58,11 +58,11 @@ enum
 }
 
 enum
-{ 
+{
        COINIT_APARTMENTTHREADED   = 0x2,
        COINIT_MULTITHREADED       = 0x0,
        COINIT_DISABLE_OLE1DDE     = 0x4,
-       COINIT_SPEED_OVER_MEMORY   = 0x8 
+       COINIT_SPEED_OVER_MEMORY   = 0x8
 }
 alias DWORD COINIT;
 enum RPC_E_CHANGED_MODE = 0x80010106;

--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -25,8 +25,8 @@ struct WSADATA
 {
     WORD wVersion;
     WORD wHighVersion;
-    char szDescription[WSADESCRIPTION_LEN + 1];
-    char szSystemStatus[WSASYS_STATUS_LEN + 1];
+    char[WSADESCRIPTION_LEN + 1] szDescription;
+    char[WSASYS_STATUS_LEN + 1] szSystemStatus;
     USHORT iMaxSockets;
     USHORT iMaxUdpDg;
     char* lpVendorInfo;

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -168,7 +168,7 @@ struct MD5
 {
     private:
         // magic initialization constants
-        uint _state[4] = [0x67452301,0xefcdab89,0x98badcfe,0x10325476]; // state (ABCD)
+        uint[4] _state = [0x67452301,0xefcdab89,0x98badcfe,0x10325476]; // state (ABCD)
         ulong _count; //number of bits, modulo 2^64
         ubyte[64] _buffer; // input buffer
 

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -169,7 +169,7 @@ struct RIPEMD160
 {
     private:
         // magic initialization constants
-        uint _state[5] = [0x67452301,0xefcdab89,0x98badcfe,0x10325476,0xc3d2e1f0]; // state (ABCDE)
+        uint[5] _state = [0x67452301,0xefcdab89,0x98badcfe,0x10325476,0xc3d2e1f0]; // state (ABCDE)
         ulong _count; //number of bits, modulo 2^64
         ubyte[64] _buffer; // input buffer
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -243,7 +243,7 @@ struct SHA1
     }
 
     private:
-        uint state[5] =                                   /* state (ABCDE) */
+        uint[5] state =                                   /* state (ABCDE) */
         /* magic initialization constants */
         [0x67452301,0xefcdab89,0x98badcfe,0x10325476,0xc3d2e1f0];
 

--- a/std/md5.d
+++ b/std/md5.d
@@ -179,12 +179,12 @@ struct MD5_CTX
 {
     private import core.stdc.string : memcpy, memset;
 
-    uint state[4] =                                   /* state (ABCD) */
+    uint[4] state =                                   /* state (ABCD) */
     /* magic initialization constants */
     [0x67452301,0xefcdab89,0x98badcfe,0x10325476];
 
     ulong count;        /* number of bits, modulo 2^64 */
-    ubyte buffer[64];   /* input buffer */
+    ubyte[64] buffer;   /* input buffer */
 
     static ubyte[64] PADDING =
     [

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -37,7 +37,7 @@ private
 
 class OutBuffer
 {
-    ubyte data[];
+    ubyte[] data;
     size_t offset;
 
     invariant()

--- a/std/random.d
+++ b/std/random.d
@@ -700,7 +700,7 @@ Always $(D false).
  */
     enum bool empty = false;
 
-    private UIntType mt[n];
+    private UIntType[n] mt;
     private size_t mti = size_t.max; /* means mt is not initialized */
     UIntType _y = UIntType.max;
 }


### PR DESCRIPTION
C-style array declarations are problematic (see http://d.puremagic.com/issues/show_bug.cgi?id=953). This pull request converts all of the C-style array declarations in Phobos to use the (better) D-style.
