### PR TITLE
Fixup for 9975: swap and pointsTo

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1859,21 +1859,12 @@ private struct FilterBidiResult(alias pred, Range)
 // move
 /**
 Moves $(D source) into $(D target) via a destructive
-copy. Specifically: $(UL $(LI If $(D hasAliasing!T) is true (see
-$(XREF traits, hasAliasing)), then the representation of $(D source)
-is bitwise copied into $(D target) and then $(D source = T.init) is
-evaluated.)  $(LI Otherwise, $(D target = source) is evaluated.)) See
-also $(XREF exception, pointsTo).
-
-Preconditions:
-$(D &source == &target || !pointsTo(source, source))
+copy.
 */
 void move(T)(ref T source, ref T target)
 {
     import core.stdc.string : memcpy;
-    import std.exception : pointsTo;
 
-    assert(!pointsTo(source, source));
     static if (is(T == struct))
     {
         if (&source == &target) return;


### PR DESCRIPTION
Fixing 9975 (http://d.puremagic.com/issues/show_bug.cgi?id=9975) revealed that checking `pointsTo` was creating problems in swap for legitimate use cases.

This is because:
1. pointsTo can sometimes create "false positives"
2. Internal pointing is not outright forbidden, it is just that the runtime is allowed to make the assumption they don't exist.

While swapping aliasing objects is a sign of stink, it should still "just work".
