### PR TITLE
Add workaround to fix issue 10567

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -787,6 +787,12 @@ public:
                      cast(void*) &temp);
     }
 
+    // workaround for bug 10567 fix
+    int opCmp(ref const VariantN rhs) const
+    {
+        return (cast()this).opCmp!(VariantN)(cast()rhs);
+    }
+
     /**
      * Ordering comparison used by the "<", "<=", ">", and ">="
      * operators. In case comparison is not sensible between the held


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10567

Currently VariantN does not support const objects comparison. So just add specialized opCmp member and use cast().

Corresponding compiler change: https://github.com/D-Programming-Language/dmd/pull/2321
