### PR TITLE
Fix issue 10601.

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -836,19 +836,10 @@ unittest
 
     static assert (setExtension("file"w.dup, "ext"w) == "file.ext");
     static assert (setExtension("file.old"d.dup, "new"d) == "file.new");
-}
 
-// Issue 10601
-unittest
-{
+    // Issue 10601
     assert (setExtension("file", "") == "file");
     assert (setExtension("file.ext", "") == "file");
-    assert (setExtension("file".dup, "") == "file");
-    assert (setExtension("file.ext".dup, "") == "file");
-    assert (setExtension("file"w, ""w) == "file");
-    assert (setExtension("file.ext"w, ""w) == "file");
-    assert (setExtension("file"d, ""d) == "file");
-    assert (setExtension("file.ext"d, ""d) == "file");
 }
 
 


### PR DESCRIPTION
If extension is empty, std.path.setExtension should be equivalent to
std.path.stripExtension. This special case is useful in generic code
that needs to alternate between, e.g., .exe on Windows and no executable
extension on Posix.
