### PR TITLE
Fix Issue 10662 - byLine!(Char, immutable Char) won't compile

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1241,9 +1241,9 @@ void main()
         }
         // test line persistence
         std.file.write(deleteme, "mary\njohn\narnold");
-        assert(File(deleteme).byLine.array.sort !=
+        assert(File(deleteme).byLine().array().sort !=
             ["arnold", "john", "mary"]);
-        assert(File(deleteme).byLine!(char, immutable char).array.sort ==
+        assert(File(deleteme).byLine!(char, immutable char)().array().sort ==
             ["arnold", "john", "mary"]);
     }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10662

This wouldn't compile because `readln(buf)` now requires a mutable `buf`.
Also make `ByLine.line`, `ByLine.first_call` private.
