### PR TITLE
fix Issue 10644 - Win64: wrong code when passing arguments through ...

### DIFF
--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -310,10 +310,7 @@ class OutBuffer
     {
         version (Win64)
         {
-            va_list ap;
-            ap = cast(va_list)&format;
-            ap += format.sizeof;
-            vprintf(format, ap);
+            vprintf(format, _argptr);
         }
         else version (X86_64)
         {

--- a/std/stream.d
+++ b/std/stream.d
@@ -1164,10 +1164,7 @@ class Stream : InputStream, OutputStream {
   // returns number of bytes written
   version (Win64)
   size_t printf(const(char)[] format, ...) {
-    va_list ap;
-    ap = cast(va_list) &format;
-    ap += format.sizeof;
-    return vprintf(format, ap);
+    return vprintf(format, _argptr);
   }
   else version (X86_64)
   size_t printf(const(char)[] format, ...) {


### PR DESCRIPTION
fix http://d.puremagic.com/issues/show_bug.cgi?id=10644

The test cases are the unittests.
