### PR TITLE
Make std.array.array @safe if possible

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -49,7 +49,7 @@ if (isIterable!Range && !isNarrowString!Range)
         {
             // hacky
             static if (is(typeof(result[i].opAssign(e))) ||
-                       !is(typeof(result[i] == e)))
+                       !is(typeof(result[i] = e)))
             {
                 // this should be in-place construction
                 emplace(result.ptr + i, e);


### PR DESCRIPTION
This pull request makes `std.array.array` safe for some cases like:
- `array` for `int[]`
- `array` for `T[]` if `T` has `opAssign` with safe attribute
