### PR TITLE
std.process: Remove incorrect usage of file RangeError ctor parameter

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -357,7 +357,7 @@ private Pid spawnProcessImpl(in char[][] args,
 {
     import core.exception: RangeError;
 
-    if (args.empty) throw new RangeError("Command line is empty");
+    if (args.empty) throw new RangeError();
     const(char)[] name = args[0];
     if (any!isDirSeparator(name))
     {


### PR DESCRIPTION
The code attempted to construct a RangeError object with a "Command line is empty" string as the first parameter. However, the first parameter specifies the source file (and defaults to `__FILE__`), not the reason (which is always "Range violation").
