### PR TITLE
put rewrite

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -837,6 +837,15 @@ unittest
     assert(r == "ABC");
 }
 
+unittest
+{
+    // issue 10571
+    import std.format;
+    string buf;
+    formattedWrite((in char[] s) { buf ~= s; }, "%s", "hello");
+    assert(buf == "hello");
+}
+
 /**
 Returns $(D true) if $(D R) is an output range for elements of type
 $(D E). An output range is defined functionally as a range that


### PR DESCRIPTION
A rewrite/re-organization of put: This helps keep it simpler and easier to maintain.

Originally forked from @9rnsr 's pull: https://github.com/D-Programming-Language/phobos/pull/1000

The code was further improved/simplified.

Improvements mainly include:
- Cross string compatibility: Eg: you can place a `dchar` in a `char` output range, or a `string` in a `wstring` output range. The sky is the limit here actually.
- More support cases for input ranges: For example, input ranges did not support ouput of `E` element, if they were `E[]` output range. Actually, now, there is no special case taking them into account, so everything should be alright.

Apparently, this also fixes issue http://d.puremagic.com/issues/show_bug.cgi?id=9823.

Things that were not done: put is _only_ "Range Aware", and will NOT consider `char[]` as an output range. This could be improved. Just... not now. Maybe in the future.

The diff is a bit complicated, so I'm copy pasting the new code here for independent reading.
