### PR TITLE
Restore ByLine ddoc comment

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1046,7 +1046,7 @@ Returns the file number corresponding to this object.
         return .fileno(cast(FILE*) _p.handle);
     }
 
-/*
+/**
 Range that reads one line at a time.  Returned by $(LREF byLine).
 
 Allows to directly use range operations on lines of a file.


### PR DESCRIPTION
1a2eaf8d094f32da4e934116085a1519b64afe34 changed it to a regular comment.

I don't believe that was intended. @ntrel confirm?
