### PR TITLE
Make std.conv.to @safe for pointer to string conversion

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -815,7 +815,7 @@ T toImpl(T, S)(S value)
     }
     else static if (isPointer!S && is(S : const(char)*))
     {
-        return value ? cast(T) value[0 .. strlen(value)].dup : cast(string)null;
+        return value ? ()@trusted{ return value[0 .. strlen(value)].dup; }() : null;
     }
     else
     {
@@ -878,7 +878,7 @@ T toImpl(T, S)(S value)
     assert(c == "abcx");
 }
 
-/*@safe pure */unittest
+@safe pure unittest
 {
     // char* to string conversion
     debug(conv) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");


### PR DESCRIPTION
The trusted lambda block contains the following unsafe instructions:
- use of core.stdc.string.strlen
- use of pointer slicing

Currently, this pull request does not work because of the bug in dmd (http://d.puremagic.com/issues/show_bug.cgi?id=10728).
