### PR TITLE
Make constructors of std.file.FileException @safe and @trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -122,7 +122,7 @@ class FileException : Exception
     version(Windows) this(in char[] name,
                           uint errno = .GetLastError(),
                           string file = __FILE__,
-                          size_t line = __LINE__) @trusted
+                          size_t line = __LINE__) @safe
     {
         this(name, sysErrorString(errno), file, line);
         this.errno = errno;


### PR DESCRIPTION
This pull request makes one constructor of `FileException` safe and
makes another constructor trusted in Posix systems.

I leave the case for Windows because I don't have a Windows machine for development.
