### PR TITLE
Make a unittest for toImpl for char* to string conversion system

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -880,7 +880,7 @@ T toImpl(T, S)(S value)
     assert(c == "abcx");
 }
 
-/*@safe pure */unittest
+@system pure unittest
 {
     // char* to string conversion
     debug(conv) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");


### PR DESCRIPTION
`std.conv.toImpl` for char\* to string conversion is a system function.
It is good for readability to mark a unittest for this case as `system`.
