### PR TITLE
Fix Issue 5378 - Make File.byLine accept a string terminator

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1140,7 +1140,7 @@ Allows to directly use range operations on lines of a file.
                 else static if (isArray!Terminator)
                 {
                     static assert(
-                        is(Unqual!(typeof(terminator[0])) == Char));
+                        is(Unqual!(ElementEncodingType!Terminator) == Char));
                     const tlen = terminator.length;
                 }
                 else
@@ -1207,7 +1207,7 @@ void main()
 /// ditto
     auto byLine(Terminator, Char = char)
     (KeepTerminator keepTerminator, Terminator terminator)
-    if (is(Unqual!(typeof(terminator[0])) == Char))
+    if (is(Unqual!(ElementEncodingType!Terminator) == Char))
     {
         return ByLine!(Char, Terminator)(this, keepTerminator, terminator);
     }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5378

Add an overload of `byLine` without a default argument for `terminator`.
Before, `byLine!string` tried to instantiate `string terminator = '\n'`, which is invalid.

This is important to allow passing `"\r\n"` as line terminator for Windows text files.

Before:

``` d
    auto byLine(Terminator = char, Char = char)
        (KeepTerminator keepTerminator = KeepTerminator.no, Terminator terminator = '\n');
```

Proposed:

``` d
    auto byLine(Terminator = char, Char = char)
        (KeepTerminator keepTerminator = KeepTerminator.no);
    auto byLine(Terminator, Char = char)
        (KeepTerminator keepTerminator, Terminator terminator);
```

This is backward compatible.
