### PR TITLE
Make std.file.tempDir @trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2954,7 +2954,7 @@ meantime.
 The POSIX $(D tempDir) algorithm is inspired by Python's
 $(LINK2 http://docs.python.org/library/tempfile.html#tempfile.tempdir, $(D tempfile.tempdir)).
 */
-string tempDir()
+string tempDir() @trusted
 {
     static string cache;
     if (cache is null)


### PR DESCRIPTION
This pull request makes `std.file.tempDir` trusted.

Note:
It can be a safe function in POSIX systems but it cannot in Windows because of `GetTempPathW`.
