### PR TITLE
Supplemental fix for issue 10811 - Remove conflict template function

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -2256,15 +2256,6 @@ template toUTFz(P)
     }
 }
 
-/++ Ditto +/
-template toUTFz(P, S)
-{
-    P toUTFz(S str) @system
-    {
-        return toUTFzImpl!(P, S)(str);
-    }
-}
-
 ///
 unittest
 {


### PR DESCRIPTION
Required by the compiler fix: https://github.com/D-Programming-Language/dmd/pull/2472

By fixing bug 10811, both toUTFz template functions will conflict on the call `toUTFz!(T)(str)`. Remove one to resolve ambiguity.
