### PR TITLE
Make std.file.deleteme @safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -42,14 +42,14 @@ version (unittest)
 {
     import core.thread;
 
-    private @property string deleteme()
+    private @property string deleteme() @safe
     {
         static _deleteme = "deleteme.dmd.unittest.pid";
         static _first = true;
 
         if(_first)
         {
-            _deleteme = buildPath(tempDir(), _deleteme) ~ to!string(getpid());
+            _deleteme = buildPath(tempDir(), _deleteme) ~ to!string(thisProcessID);
             _first = false;
         }
 


### PR DESCRIPTION
This pull request makes a private function `std.file.deleteme` safe.

`deleteme` is used in several unittests in `std.file`, so this request helps to make them safe.

In this request, I use `std.process.thisProcessID` instead of `core.thread.getpid()`
because they have the same effect and `thisProcessID` is a trusted function.

Note: We cannot remove `import core.thread;` in line 43 because it is used in the unittests for `getTimes`, `getTimesWin` and `dirEntry`.
