### PR TITLE
Fix Issue 8866 - Splitter(R1, R2) CANNOT be bidirectional.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2773,7 +2773,6 @@ unittest
 
             auto s2 = splitter(d, [4, 5]);
             assert(equal(s2.front, [1,2,3]));
-            assert(equal(s2.back, [6,7,8,9,10]));
         }
     }
 }
@@ -2914,12 +2913,16 @@ if (is(typeof(Range.init.front == Separator.init.front) : bool)
         // Bidirectional functionality as suggested by Brad Roberts.
         static if (isBidirectionalRange!Range && isBidirectionalRange!Separator)
         {
+            //Deprecated. It will be removed in December 2015
+            deprecated("splitter!(Range, Range) cannot be iterated backwards (due to separator overlap).")
             @property Range back()
             {
                 ensureBackLength();
                 return _input[_input.length - _backLength .. _input.length];
             }
 
+            //Deprecated. It will be removed in December 2015
+            deprecated("splitter!(Range, Range) cannot be iterated backwards (due to separator overlap).")
             void popBack()
             {
                 ensureBackLength();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8866

The problem is that when the separator is a range, two separators may overlap, in which case the range's result depends on the direction it is being iterated (which is not acceptable).

Correctly fixing this would be horrendously complicated. I think it is better to simply not provide bidirectional functionality for splitter!(Range Range).

Besides, arguably, since bidirectional iteration is not free (even when un-used), it should be opt-in, via `splitterBidirectional`, so we'll have to deprecate sooner or later.

Not that it matters much, as I don't think anybody iterates both ends at once, so anybody wanting to split from the right can just call splitter(myRange.retro(), mySpe.retro) instead.
