### PR TITLE
Make std.string.chomp @safe

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1321,7 +1321,7 @@ unittest
     the end of $(D str). If $(D str) does not end with any of those characters,
     then it is returned unchanged.
   +/
-C[] chomp(C)(C[] str) @safe
+C[] chomp(C)(C[] str) @safe pure
     if (isSomeChar!C)
 {
     if (str.empty)
@@ -1363,7 +1363,7 @@ C[] chomp(C)(C[] str) @safe
 }
 
 /// Ditto
-C1[] chomp(C1, C2)(C1[] str, const(C2)[] delimiter) @safe
+C1[] chomp(C1, C2)(C1[] str, const(C2)[] delimiter) @safe pure
     if (isSomeChar!C1 && isSomeChar!C2)
 {
     if (delimiter.empty)
@@ -1389,7 +1389,7 @@ C1[] chomp(C1, C2)(C1[] str, const(C2)[] delimiter) @safe
 }
 
 ///
-@safe unittest
+@safe pure unittest
 {
     assert(chomp(" hello world  \n\r") == " hello world  \n");
     assert(chomp(" hello world  \r\n") == " hello world  ");


### PR DESCRIPTION
`chomp` only accepts arrays of built-in string types as arguments and uses safe functions for them.
Additionally it does not use any other unsafe instructions.
So we can mark it as safe.

I do not mark one of unittests for that because it uses `std.conv.to` which is currently unsafe.
