### PR TITLE
std.regex: First step to lookbehind in ctRegex

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -618,17 +618,17 @@ struct Group(DataIndex)
     {
         for(uint pc = start; pc < end; )
         {
-        uint len = code[pc].length;
+            uint len = code[pc].length;
             if(code[pc].code == IR.GotoEndOr)
                 break; //pick next alternation branch
-        if(code[pc].isAtom)
-        {
-            rev[revPc - len .. revPc] = code[pc .. pc + len];
-            revPc -= len;
-                pc += len;
-        }
-        else if(code[pc].isStart || code[pc].isEnd)
-        {
+            if(code[pc].isAtom)
+            {
+                rev[revPc - len .. revPc] = code[pc .. pc + len];
+                revPc -= len;
+                    pc += len;
+            }
+            else if(code[pc].isStart || code[pc].isEnd)
+            {
                 //skip over other embedded lookbehinds they are reversed 
                 if(code[pc].code == IR.LookbehindStart
                     || code[pc].code == IR.NeglookbehindStart)
@@ -640,10 +640,10 @@ struct Group(DataIndex)
                     revPc -= blockLen;
                     continue;
                 }
-            uint second = code[pc].indexOfPair(pc);
-            uint secLen = code[second].length;
-            rev[revPc - secLen .. revPc] = code[second .. second + secLen];
-            revPc -= secLen;
+                uint second = code[pc].indexOfPair(pc);
+                uint secLen = code[second].length;
+                rev[revPc - secLen .. revPc] = code[second .. second + secLen];
+                revPc -= secLen;
                 if(code[pc].code == IR.OrStart)
                 {
                     //we pass len bytes forward, but secLen in reverse
@@ -656,7 +656,7 @@ struct Group(DataIndex)
                         {
                             assert(code[i - 1].code == IR.GotoEndOr);
                             rev[r - 1] = code[i - 1];
-        }
+                        }
                         rev[r] = code[i];
                         auto newStart = i + IRL!(IR.Option);
                         auto newEnd = newStart + code[i].data;
@@ -664,7 +664,7 @@ struct Group(DataIndex)
                         if(code[newEnd].code != IR.OrEnd)
                         {
                             newRpc--;
-                        }                        
+                        }
                         stack.push(tuple(newStart, newEnd, newRpc));
                         r += code[i].data + IRL!(IR.Option);                        
                         i += code[i].data + IRL!(IR.Option);
@@ -674,8 +674,8 @@ struct Group(DataIndex)
                     assert(code[pc].code == IR.OrEnd);
                 }
                 else
-        pc += len;
-    }
+                    pc += len;
+            }
         }
         if(stack.empty())
             break;
@@ -3489,7 +3489,7 @@ template BacktrackingMatcher(bool CTregex)
                         //no matching inside \r\n
                         if(atEnd || ((re.flags & RegexOption.multiline)
                             && endOfLine(front, s.loopBack(index).nextChar(back,bi)
-								&& back == '\r')))
+                            && back == '\r')))
                         {
                             pc += IRL!(IR.Eol);
                         }


### PR DESCRIPTION
Removes one of the most questionable design decisions in std.regex - execution of bytecode backwards 
(a-la UTF-8). While a cute idea at first it is:
- slow as each word has to be checked/skipped till the head of instruction is found
- duplicates literally each matcher's code (x2 with B-T, Thompson, and would be x3 with C-T)
- the above also applies to binary code bloat, as 'back' version code is generated even if not used
- adds extra assumption on bytecode format (that could be avoided to simplify/speed things up)

Instead just reverse required pieces of bytecode during compilation in a centralized manner.  
-900 lines of code speak for themselves but more importantly this sets the stage for lookbehind in ctRegex.

P.S. The bidirectional _ability_ of bytecode is left as is at the moment so I can try real hard to imagine the potential use cases we might have had in mind back then... 
