### PR TITLE
Make std.string.indexOf @safe

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -260,7 +260,7 @@ ptrdiff_t indexOf(Char)(in Char[] s,
         {
             if (std.ascii.isASCII(c) && !__ctfe)
             {                                               // Plain old ASCII
-                auto trustedmemchr() @trusted { return memchr(s.ptr, c, s.length); }
+                auto trustedmemchr() @trusted { return cast(Char*)memchr(s.ptr, c, s.length); }
                 auto p = trustedmemchr();
                 if (p)
                     return p - s.ptr;


### PR DESCRIPTION
`indexOf` only accepts built-in string types.
It uses unsafe function `core.stdc.string.memchr` but it does not touch the memory over the length of the string.

I do not mark the third and fourth definition of `indexOf` as safe because currently `std.algorithm.find` is not safe for these cases.

I do not mark the unittests for it as safe because it uses `core.stdc.stdio.printf` which is an unsafe function.
