### PR TITLE
Mark std.string.chomp as nothrow

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1322,7 +1322,7 @@ unittest
     the end of $(D str). If $(D str) does not end with any of those characters,
     then it is returned unchanged.
   +/
-C[] chomp(C)(C[] str) @safe pure
+C[] chomp(C)(C[] str) @safe pure nothrow
     if (isSomeChar!C)
 {
     if (str.empty)


### PR DESCRIPTION
This pull request marks one of the definitions of `chomp` as nothorw.

Another definition cannot be nothrow because `foreach_reverse` for `const(C2)[]` may throw.
