### PR TITLE
Add Identifiers tuple to std.typecons.Tuple

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -374,16 +374,16 @@ template Tuple(Specs...)
         alias staticMap!(extractType, fieldSpecs) Types;
         
         /**
-         * The indentifiers of the tuple's components, as a TypeTuple of strings.
+         * The identifiers of the tuple's components, as a TypeTuple of strings.
          * The identifier of a component without a name is $(D "").
          * 
          * Examples:
          * ----
          * auto t = Tuple!(int, "num", string, "name", bool)();
-         * static assert(t.Identifiers == TypeTuple!("num", "name", ""));
+         * static assert(t.identifiers == TypeTuple!("num", "name", ""));
          * ----
          */
-        alias staticMap!(extractName, fieldSpecs) Identifiers;
+        alias staticMap!(extractName, fieldSpecs) identifiers;
 
         /**
          * Use $(D t.expand) for a tuple $(D t) to expand it into its
@@ -598,7 +598,7 @@ unittest
     {
         Tuple!(int, "a", int, "b") nosh;
         static assert(nosh.length == 2);
-        static assert(nosh.Identifiers == TypeTuple!("a", "b"));
+        static assert(nosh.identifiers == TypeTuple!("a", "b"));
         nosh.a = 5;
         nosh.b = 6;
         assert(nosh.a == 5);
@@ -607,7 +607,7 @@ unittest
     {
         Tuple!(short, double) b;
         static assert(b.length == 2);
-        static assert(b.Identifiers == TypeTuple!("",""));
+        static assert(b.identifiers == TypeTuple!("",""));
         b[1] = 5;
         auto a = Tuple!(int, real)(b);
         assert(a[0] == 0 && a[1] == 5);
@@ -656,7 +656,7 @@ unittest
     // slicing
     {
         Tuple!(int, "x", real, "y", double, "z", string) t;
-        static assert(t.Identifiers == TypeTuple!("x","y","z",""));
+        static assert(t.identifiers == TypeTuple!("x","y","z",""));
         t[0] = 10;
         t[1] = 11;
         t[2] = 12;


### PR DESCRIPTION
Useful to have, trivial to implement, awkward to do from outside.
