### PR TITLE
Mark std.string.splitLines as @safe pure

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1097,7 +1097,7 @@ unittest
   +/
 enum KeepTerminator : bool { no, yes }
 /// ditto
-S[] splitLines(S)(S s, KeepTerminator keepTerm = KeepTerminator.no)
+S[] splitLines(S)(S s, KeepTerminator keepTerm = KeepTerminator.no) @safe pure
     if (isSomeString!S)
 {
     size_t iStart = 0;


### PR DESCRIPTION
`splitLines` only accepts built-in string types and it doesn't contain unsafe/impure instructions.
