### PR TITLE
Fix floor/ceil for real==double targets.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3063,7 +3063,7 @@ real floor(real x) @trusted pure nothrow
         // Find the exponent (power of 2)
         static if (real.mant_dig == 53)
         {
-            int exp = (vu[F.EXPPOS_SHORT] & 0x7ff) - 0x3ff;
+            int exp = ((vu[F.EXPPOS_SHORT] >> 4) & 0x7ff) - 0x3ff;
 
             version (LittleEndian)
                 int pos = 0;


### PR DESCRIPTION
Fix for a bug found testing on ARM targets this morning.  Would have been included in the puremath pull, but it got merged before this was discovered. :)
