### PR TITLE
Improved design for RandomCover and RandomSample

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1590,7 +1590,7 @@ foreach (e; randomCover(a, Random(unpredictableSeed)))  // correct!
     writeln(e);
 }
 
-foreach (e; randomCover(a, rndGen))  // WRONG!! rndGen gets copied by value
+foreach (e; randomCover(a, rndGen))  // DANGEROUS!! rndGen gets copied by value
 {
     writeln(e);
 }
@@ -1808,8 +1808,8 @@ foreach (e; randomSample(a, 5, Random(unpredictableSeed)))  // correct!
     writeln(e);
 }
 
-foreach (e; randomSample(a, 5, rndGen))  // WRONG!! rndGen gets copied
-{                                        // by value
+foreach (e; randomSample(a, 5, rndGen))  // DANGEROUS!! rndGen gets
+{                                        // copied by value
     writeln(e);
 }
 


### PR DESCRIPTION
This set of patches presents a partial fix of Issue 7067 -- a full fix is not possible without breaking changes, namely, converting all RNGs to reference types.  See discussion thread of that issue for details:
http://d.puremagic.com/issues/show_bug.cgi?id=7067#c14

RandomCover has been updated to be able to work with the thread-global RNG rndGen, in line with the design of RandomSample. This should enable statistically safe uses of RandomCover.

The code layout of both RandomCover and RandomSample has been tweaked to emphasize the similarity of their design, and template parameters and variable names have been updated in line with Issue 10434.

The .save methods of both have been corrected to ensure that .save is only available when (i) the input to be covered/sampled is a forward range; (ii) the thread-global RNG is not in use; (iii) the RNG in use is a forward range.  (The second constraint might be possible to avoid with a more complex solution, but will be simple to avoid with the more general but breaking fix of converting RNGs to reference types.)

Finally, the unittests have been updated to ensure that RandomCover and RandomSample are tested with all available RNG types.
