### PR TITLE
Fix splitter!pred and splitter(string)

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2900,7 +2900,7 @@ unittest
 //@@@6730@@@ This exists already in std.array, so this declaration, at best, will only create ambiguity.
 //unfortunatly, an alias will conflict with the existing splitter in std.algorithm.
 //It needs to be removed.
-deprecated("std.algorithm.splitter(string) is deprecated in favor of std.algortihm.splitter(string)")
+deprecated("Please use std.array.splitter for string specific splitting")
 auto splitter(Range)(Range input)
 if (isSomeString!Range)
 {

--- a/std/array.d
+++ b/std/array.d
@@ -1388,10 +1388,11 @@ unittest //safety, purity, ctfe ...
 
 /++
 Lazily splits the string $(D s) into words, using whitespace as
-delimiter.
+the delimiter.
 
 This function is string specific and, contrary to $(D
-splitter!(std.uni.isWhite)), runs of white spaces will be merged together.
+splitter!(std.uni.isWhite)), runs of whitespace will be merged together
+(no empty tokens will be produced).
  +/
 auto splitter(C)(C[] s)
 if(isSomeChar!C)
@@ -1463,7 +1464,7 @@ if(isSomeChar!C)
 }
 
 /++
-Eagerly Splits $(D s) into an array, using $(D delim) as the delimiter.
+Eagerly splits $(D s) into an array, using $(D delim) as the delimiter.
 
 See also: $(XREF algorithm, splitter) for the lazy version of this operator.
  +/


### PR DESCRIPTION
This fixes:
- Issue 6730 - std.algorithm.splitter conflicts with std.array.splitter
- Issue 6791 - std.algorithm.splitter random indexes utf strings
- Issue 8013 - splitter() and split() give different results

(links:)
- http://d.puremagic.com/issues/show_bug.cgi?id=6730
- http://d.puremagic.com/issues/show_bug.cgi?id=6791
- http://d.puremagic.com/issues/show_bug.cgi?id=8013

as well as "unlocks" `splitter!pred` for forward ranges. Also fixes the splitting behavior of `splitter!pred`, which was just wrong, which, in turn, also fixes `std.array.splitter`.

---

FWI, this is a toned down failed pull I had oppened 9 months ago: #934.

This fix can be review in 3 parts
1: A complet `splitter!pred` rewrite

I did this because `splitter!pred` was _completely_ inconsistent with the rest of the splitter functions:
- leading delimiters where kept, but (edited) ~~leading~~ trailing delimiters where omitted
- empty tokens where kept, but _multiple_ runs of empty tokens where merged into a single token.

The new implementation has the exact same behavior as the other splitters. Also, the new implementation works on forward ranges. The new implementation is arguably simpler, even though it handles more types.

2: This leads to a `std.array.splitter(string)` rewrite:

`std.array.split` has a string specific overload that takes no teminator: This special case takes a string, and splits it on unicode white, and returns _no_ empty tokens. Unfortunatly, `std.array.splitter(string)` was simply `return std.algorithm.splitter!(std.uni.isWhite)`. This means that `split` and `splitter` did not have the same output. Un-acceptable. Now it does.

3: Deprecate `std.algorithm.splitter(string)`

This _string_ function specific function has no reason to be in algorithm. The only thing it is doing, is creating ambiguity for users who have both algorithm and string included.

(4: Also included: `std.array.split!pred`, which was missing for some stringe reason)
