### PR TITLE
Issue 10874 - conv.to ulong to int enum conversion

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1713,7 +1713,8 @@ a ConvException is thrown.
 Enums with floating-point or string base types are not supported.
 */
 T toImpl(T, S)(S value)
-    if (is(T == enum) && !is(S == enum) && is(S : OriginalType!T)
+    if (is(T == enum) && !is(S == enum)
+        && is(typeof(value == OriginalType!T.init))
         && !isFloatingPoint!(OriginalType!T) && !isSomeString!(OriginalType!T))
 {
     foreach (Member; EnumMembers!T)
@@ -4088,4 +4089,12 @@ unittest
         static assert(is(typeof(signed(cast(const T)1)) == long));
         static assert(is(typeof(signed(cast(immutable T)1)) == long));
     }
+}
+
+unittest
+{
+    // issue 10874
+    enum Test { a = 0 }
+    ulong l = 0;
+    auto t = l.to!Test;
 }


### PR DESCRIPTION
Don't assume that is(A : B) means a==b is valid, or that !is(A : B)
implies that a==b is invalid. Instead, test for a==b explicitly.

More specifically, int and ulong are ==-comparable, even though ulong is
not implicitly convertible to int. Thus, one should be able to convert
ulong to an int-based enum, but is(A : B) in the signature constraint
prohibits this. Testing for a==b explicitly, OTOH, makes this work.

http://d.puremagic.com/issues/show_bug.cgi?id=10874
