### PR TITLE
Fix std.math.frexp for real == double targets

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -1964,7 +1964,7 @@ real frexp(real value, out int exp) @trusted pure nothrow
 {
     ushort* vu = cast(ushort*)&value;
     long* vl = cast(long*)&value;
-    uint ex;
+    int ex;
     alias floatTraits!(real) F;
 
     ex = vu[F.EXPPOS_SHORT] & F.EXPMASK;


### PR DESCRIPTION
I found this problem when testing std.math on ARM where real is the same type as double. The unit test in line 2109 fails on ARM. It also fails on x86 if `real` is replaced by `double` in frexp. See http://dpaste.dzfl.pl/72725240 for a test case reduced from that unit test.

The problem is in line 2087:

``` d
 exp = ((ex - F.EXPBIAS)>> 4) - real.mant_dig + 1;
```

If ex is unsigned, then `ex-F.EXPBIAS` underflows and gives wrong results. Changed ex from `uint` to `int` to fix this.

ping @donc : is this the correct fix?
