### PR TITLE
Fixes format ddoc BOOKTABLE section

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -186,6 +186,7 @@ private alias enforceFmt = enforceEx!FormatException;
 
         $(TR $(TD $(B ' ')) $(TD numeric) $(TD Prefix positive
         numbers in a signed conversion with a space.))
+    )
 
     <dt>$(I Width)
     <dd>


### PR DESCRIPTION
Search for the work "BOOKTABLE" here: http://dlang.org/phobos/std_format.html

First 3 commits are the _ONLY_ indents that help organise the DDOC.

Commit 4 is the fix.
