### PR TITLE
Mark std.string.chompPrefix and its unittests as @safe and pure

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1454,7 +1454,7 @@ unittest
     $(D delimiter) is returned. If it $(D str) does $(I not) start with
     $(D delimiter), then it is returned unchanged.
  +/
-C1[] chompPrefix(C1, C2)(C1[] str, C2[] delimiter)
+C1[] chompPrefix(C1, C2)(C1[] str, C2[] delimiter) @safe pure
     if (isSomeChar!C1 && isSomeChar!C2)
 {
     static if (is(Unqual!C1 == Unqual!C2))
@@ -1479,7 +1479,7 @@ C1[] chompPrefix(C1, C2)(C1[] str, C2[] delimiter)
 }
 
 ///
-unittest
+@safe pure unittest
 {
     assert(chompPrefix("hello world", "he") == "llo world");
     assert(chompPrefix("hello world", "hello w") == "orld");
@@ -1487,7 +1487,7 @@ unittest
     assert(chompPrefix("", "hello") == "");
 }
 
-unittest
+/* @safe */ pure unittest
 {
     assertCTFEable!(
     {


### PR DESCRIPTION
Currently I cannot mark one of the unittest as safe because `std.conv.to` for string to string conversion cannot be safe (See Issue #1491).
If #1491 is merged, I will send another request to mark it as safe.
