### PR TITLE
Fix a set of typo's in std.encoding

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1797,6 +1797,13 @@ size_t encode(E, R)(dchar c, R range)
         static assert(0);
     }
 }
+unittest
+{
+    Appender!(char[]) r;
+    assert(encode!(char)('T', r) == 1);
+    assert(encode!(wchar)('T', r) == 1);
+    assert(encode!(dchar)('T', r) == 1);
+}
 
 /**
  Encodes a single code point to a delegate.


### PR DESCRIPTION
This is just an issue I noticed while poking around the the source for the encoding module, and after asking the IRC in general, they agreed that `r` was indeed meant to refer to `range`, and that it was simply a bug that hadn't been noticed yet.
