### PR TITLE
Mark std.string.translate, makeTrans and unittests as @safe and pure

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -2095,7 +2095,7 @@ void translate(C1, C2 = immutable char, Buffer)(C1[] str,
 }
 
 ///
-unittest
+@safe pure unittest
 {
     dchar[dchar] transTable1 = ['e' : '5', 'o' : '7', '5': 'q'];
     auto buffer = appender!(dchar[])();
@@ -2303,7 +2303,7 @@ body
 }
 
 ///
-unittest
+@safe pure unittest
 {
     auto buffer = appender!(char[])();
     auto transTable1 = makeTrans("eo5", "57q");


### PR DESCRIPTION
This pull request marks `std.string.translate` as pure and marks unittests for them as safe and pure.
I marked a unittest for `translate` for ASCII-only overload as safe, pure, and nothrow because `translate` for ASCII is marked as safe, pure, and nothrow.

Some unittests are not marked as safe or nothrow because in these cases `std.conv.to` is (currently) not safe and it is not nothrow.
