### PR TITLE
Fix issue 10881: support writefln("%f") of complex numbers

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -122,7 +122,7 @@ struct Complex(T)  if (isFloatingPoint!T)
 	See the $(LINK2 std_format.html, std.format documentation) for more
 	information.
     */
-    string toString() const
+    string toString() const /* TODO: pure @safe nothrow */
     {
         import std.exception : assumeUnique;
         char[] buf;


### PR DESCRIPTION
It appears that the original toString implementation already supported format specs like %f, but it appears to be out-of-sync with the latest std.format so that writefln("%f", complex(...)) doesn't work.

So, rewrite toString to use the up-to-date std.format API for supporting custom format specifiers. Added a bunch of unittests and code examples.

I left the original toString intact, but just redirected the actual formatting logic to the new toString, just in case some external code actually relied on it, since it was actually documented in detail. It can probably be removed if no user code depends on it, since it appears to be an attempt to integrate with an older version of std.format, but the current std.format no longer picks up on its function signature so it's quite useless now. But just to be safe and prevent breaking existing D code, I left it intact.

http://d.puremagic.com/issues/show_bug.cgi?id=10881
