### PR TITLE
Make std.string.removechars @safe and pure

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -2604,8 +2604,10 @@ S removechars(S)(S s, in S pattern) @safe pure if (isSomeString!S)
             std.utf.encode(r, c);
         }
     }
-    auto trustedAssumeUnique(typeof(r) a)@trusted{ return assumeUnique(a); }
-    return (changed ? trustedAssumeUnique(r) : s);
+    if (changed)
+        return r;
+    else
+        return s;
 }
 
 unittest


### PR DESCRIPTION
In `removechars`, `r` is newly allocated array. So it can be safe to cast it to the string type.
I use a trusted nested function instead of trusted lambda call because of the performance issue.
