### PR TITLE
Bugfix: locking text writer dies on .init

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1517,15 +1517,20 @@ $(D Range) that locks the file and allows fast writing to it.
 
         ~this()
         {
-            FUNLOCK(fps);
-            fps = null;
-            handle = null;
+            if(fps)
+            {
+                FUNLOCK(fps);
+                fps = null;
+                handle = null;
+            }
         }
 
         this(this)
         {
-            enforce(fps);
-            FLOCK(fps);
+            if(fps)
+            {
+                FLOCK(fps);
+            }
         }
 
         /// Range primitive implementations.
@@ -1989,6 +1994,19 @@ unittest
         assert(cast(char[]) std.file.read(deleteme) ==
                 "A\nB\nA\nB\nA\nB\nA\nB\n");
 }
+
+unittest
+{
+    static auto useInit(T)(T ltw)
+    {
+        T val;
+        val = ltw;
+        val = T.init;
+        return val;
+    }
+    useInit(stdout.lockingTextWriter());
+}
+
 
 /***********************************
  * If the first argument $(D args[0]) is a $(D FILE*), use


### PR DESCRIPTION
Fixes issue 10898
