### PR TITLE
std.net.curl: Allow user to specify Content-Type in POST requests

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2635,6 +2635,20 @@ struct HTTP
     /**
      * Specify data to post when not using the onSend callback, with
      * user-specified Content-Type.
+     * Params:
+     *	data = Data to post.
+     *	contentType = MIME type of the data, for example, "text/plain" or
+     *	    "application/octet-stream". See also:
+     *      $(LINK2 http://en.wikipedia.org/wiki/Internet_media_type,
+     *      Internet media type) on Wikipedia.
+     *-----
+     * import std.net.curl;
+     * auto http = HTTP("http://onlineform.example.com");
+     * auto data = "app=login&username=bob&password=s00perS3kret";
+     * http.setPostData(data, "application/x-www-form-urlencoded");
+     * http.onReceive = (ubyte[] data) { return data.length; };
+     * http.perform();
+     *-----
      */
     void setPostData(const(void)[] data, string contentType)
     {


### PR DESCRIPTION
Fixes http://d.puremagic.com/issues/show_bug.cgi?id=10911

I'm not sure setPostData fits into the overall API of std.net.curl.HTTP, but since postData is a @property, it's not possible to just add a default parameter to it. If anyone has better suggestions, please let me know. In any case, the inability to specify Content-Type in POST requests makes std.net.curl.HTTP pretty much useless for me.
