### PR TITLE
Add unittest for issue 6381 (std.math.floor/ceil should be pure)

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5816,3 +5816,10 @@ unittest
     real r = tan(-2.0L);
     assert(fabs(r - 2.18504f) < .00001);
 }
+
+pure @safe nothrow unittest
+{
+    // issue 6381: floor/ceil should be usable in pure function.
+    auto x = floor(1.2);
+    auto y = ceil(1.2);
+}


### PR DESCRIPTION
To prevent regressions (issue is already fixed thanks to Iain's work on std.math).
