### PR TITLE
Fixing put.

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1724,8 +1724,8 @@ if (isDynamicArray!(E[]) && isForwardRange!R1 && isForwardRange!R2
         return subject;
 
     auto app = appender!(E[])();
-    app.put(subject[0 .. subject.length - balance.length]);
-    app.put(to.save);
+    put(app, subject[0 .. subject.length - balance.length]);
+    put(app, to.save);
     replaceInto(app, balance[from.length .. $], from, to);
 
     return app.data;
@@ -1742,7 +1742,7 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
 {
     if (from.empty)
     {
-        sink.put(subject);
+        put(sink, subject);
         return;
     }
     for (;;)
@@ -1750,11 +1750,11 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
         auto balance = std.algorithm.find(subject, from.save);
         if (balance.empty)
         {
-            sink.put(subject);
+            put(sink, subject);
             break;
         }
-        sink.put(subject[0 .. subject.length - balance.length]);
-        sink.put(to.save);
+        put(sink, subject[0 .. subject.length - balance.length]);
+        put(sink, to.save);
         subject = balance[from.length .. $];
     }
 }
@@ -1793,6 +1793,7 @@ unittest
         C[] desired;
         this(C[] arr){ desired = arr; }
         void put(C[] part){ assert(skipOver(desired, part)); }
+        void put(C   part){ assert(skipOver(desired, part)); }
     }
     foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
     {


### PR DESCRIPTION
Second attempt. This makes it so that put can transcode char and strings of any width, to chars and strings to of any width.

Not only is this convenient, but it also fixes a lot of bugs in `std.format`, which actually relied on put doing it. Up until now, we did not notice, because we tested with `Appender`, which was natively able to do this, but `formatedWrite` actually failed with a simple sink, on the most trivial cases. So this also fixes that (amongst other things):

[x] http://d.puremagic.com/issues/show_bug.cgi?id=9823
[x] http://d.puremagic.com/issues/show_bug.cgi?id=10571

Now, it is also possible to use format on sinks that accepts any string widths (so it is possible to format the output stright as wstring, without allocating). Yay!

---

More importantly though, I realized there was a _huge_ bug in the way `put` works, and the only way to fix it is to change its semantics. This is discussed in more detail in the message boards: http://forum.dlang.org/thread/norljobuehkokoqsdlmt@forum.dlang.org
