### PR TITLE
Fix Issue 10227: Add missing file I/O functions for Win64 DMD and Windows LDC

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -115,6 +115,8 @@ else version (MICROSOFT_STDIO)
         int _fgetwc_nolock(_iobuf*);
         void _lock_file(FILE*);
         void _unlock_file(FILE*);
+        int _setmode(int, int);
+        int _fileno(FILE*);
     }
     alias _fputc_nolock FPUTC;
     alias _fputwc_nolock FPUTWC;
@@ -123,6 +125,9 @@ else version (MICROSOFT_STDIO)
 
     alias _lock_file FLOCK;
     alias _unlock_file FUNLOCK;
+
+    enum _O_BINARY = 0x8000;
+
 }
 else version (GCC_IO)
 {


### PR DESCRIPTION
Closes [10227](http://d.puremagic.com/issues/show_bug.cgi?id=10227)
