### PR TITLE
Fix the comment of std.datetime.TimeOfDay.toISOExtString

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -14433,7 +14433,7 @@ assert(TimeOfDay(12, 30, 33).toISOString() == "123033");
     }
 
     ///
-    version(testStdDateTime) unittest
+    unittest
     {
         assert(TimeOfDay(0, 0, 0).toISOExtString() == "00:00:00");
         assert(TimeOfDay(12, 30, 33).toISOExtString() == "12:30:33");


### PR DESCRIPTION
In the description of `toISOExtString` it returns a string with the format "HH:MM:SS" but the examples in the comment shows that it returns a string with the format "HHMMSS".
In this case, the examples in the comment is wrong.
