### PR TITLE
Mark std.string.isNumeric as @safe and pure

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -3142,7 +3142,7 @@ unittest
  * function, or any of the conversion functions.
  */
 
-bool isNumeric(const(char)[] s, in bool bAllowSep = false)
+bool isNumeric(const(char)[] s, in bool bAllowSep = false) @safe pure
 {
     ptrdiff_t iLen = s.length;
     bool   bDecimalPoint = false;


### PR DESCRIPTION
It doesn't contain unsafe and impure operations.
It cannot be marked as `nothrow` because it uses `std.string.toLower` which may throw exceptions.
