### PR TITLE
Some simple std.regex optimization

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -431,13 +431,16 @@ struct Bytecode
     }
 
     //bit twiddling helpers
-    @property uint data() const { return raw & 0x003f_ffff; }
+    //0-arg template due to @@@BUG@@@ 10985
+    @property uint data()() const { return raw & 0x003f_ffff; }
 
     //ditto
-    @property uint sequence() const { return 2 + (raw >> 22 & 0x3); }
+    //0-arg template due to @@@BUG@@@ 10985
+    @property uint sequence()() const { return 2 + (raw >> 22 & 0x3); }
 
     //ditto
-    @property IR code() const { return cast(IR)(raw>>24); }
+    //0-arg template due to @@@BUG@@@ 10985
+    @property IR code()() const { return cast(IR)(raw>>24); }
 
     //ditto
     @property bool hotspot() const { return hasMerge(code); }
@@ -2280,14 +2283,16 @@ unittest
 }
 
 //whether ch is one of unicode newline sequences
-bool endOfLine(dchar front, bool seenCr)
+//0-arg template due to @@@BUG@@@ 10985
+bool endOfLine()(dchar front, bool seenCr)
 {
     return ((front == '\n') ^ seenCr) || front == '\r'
     || front == NEL || front == LS || front == PS;
 }
 
 //
-bool startOfLine(dchar back, bool seenNl)
+//0-arg template due to @@@BUG@@@ 10985
+bool startOfLine()(dchar back, bool seenNl)
 {
     return ((back == '\r') ^ seenNl) || back == '\n'
     || back == NEL || back == LS || back == PS;


### PR DESCRIPTION
This picks a couple of low-hanging fruits to optimize R-T & (a bit) C-T regex.

First is inlining. DMD basically _never inlines stuff that is in the library and is not a template_. It doesn't matter if it has the source for it (obviously DMD has all of Phobos source). 
Currently the only way out is marking everything as empty-arg template and this gets us the rough analog of 'explicitly inlined'  in C++.

Anyhow - around 30% of speed gain is obtained by adding a couple of empty brackets here and there alone. Or rather I got them back (in the days of FReD it was always inlined).

UPDATE:
The latter was addressed in a separate pull.

<del>
Second is removal of indirect call in the outer loop search loop. Basically it had to pick if it can do fast (kicked) search or if it should just use char by char crawling. Being outer loop I thought it wouldn't cost much to use an indirect call. Yet test runs on line by line matching indicate a noticeble speed up of around ~2% in the new version.
</del>


P.S. See e.g. this sample (one of examples that are currently difficult for std.regex) https://gist.github.com/blackwhale/6470498
