### PR TITLE
Supplement fix fox issue 6178

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -3949,7 +3949,7 @@ unittest // codepointTrie example
     // create a temporary associative array (AA)
     LuckFactor[dchar] map;
     foreach(ch; set.byCodepoint)
-        map[ch] = luckFactor(ch);
+        map[ch] = LuckFactor(luckFactor(ch));
 
     // bits per stage are chosen randomly, fell free to optimize
     auto trie = codepointTrie!(LuckFactor, 8, 5, 8)(map);


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6178

AA value setting through alias this should not be allowed, because it could access invalid object state.
