### PR TITLE
Scoped the imports in std.ascii

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -25,6 +25,13 @@
   +/
 module std.ascii;
 
+version (unittest)
+{
+    // FIXME: When dmd bug #314 is fixed, make these selective.
+    import std.range; // : chain;
+    import std.traits; // : functionAttributes, FunctionAttribute, isSafe;
+    import std.typetuple; // : TypeTuple;
+}
 
 immutable hexDigits      = "0123456789ABCDEF";           /// 0..9A..F
 immutable lowerHexDigits = "0123456789abcdef";           /// 0..9a..f
@@ -69,8 +76,6 @@ bool isAlphaNum(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; chain(digits, octalDigits, fullHexDigits, letters, lowercase, uppercase))
         assert(isAlphaNum(c));
 
@@ -89,8 +94,6 @@ bool isAlpha(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; chain(letters, lowercase, uppercase))
         assert(isAlpha(c));
 
@@ -109,8 +112,6 @@ bool isLower(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; lowercase)
         assert(isLower(c));
 
@@ -129,8 +130,6 @@ bool isUpper(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; uppercase)
         assert(isUpper(c));
 
@@ -149,8 +148,6 @@ bool isDigit(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; digits)
         assert(isDigit(c));
 
@@ -169,8 +166,6 @@ bool isOctalDigit(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; octalDigits)
         assert(isOctalDigit(c));
 
@@ -189,8 +184,6 @@ bool isHexDigit(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; fullHexDigits)
         assert(isHexDigit(c));
 
@@ -210,8 +203,6 @@ bool isWhite(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(c; whitespace)
         assert(isWhite(c));
 
@@ -230,8 +221,6 @@ bool isControl(dchar c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    
     foreach(dchar c; 0 .. 32)
         assert(isControl(c));
     assert(isControl(127));
@@ -342,10 +331,6 @@ auto toLower(C)(C c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    import std.traits : functionAttributes, FunctionAttribute, isSafe;
-    import std.typetuple : TypeTuple;
-    
     foreach(C; TypeTuple!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach(i, c; uppercase)
@@ -395,10 +380,6 @@ auto toUpper(C)(C c) @safe pure nothrow
 
 unittest
 {
-    import std.range : chain;
-    import std.traits : functionAttributes, FunctionAttribute, isSafe;
-    import std.typetuple : TypeTuple;
-    
     foreach(C; TypeTuple!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach(i, c; lowercase)


### PR DESCRIPTION
This basically scopes the imports in `std.ascii`, as well as modifies those imports to be selective in what they import. There are also a couple of style changes, namely the ordering of values in an anonymous enum, and the use of only 1 indent level within an array declaration. The final change is to mark `toLower` and `toUpper` explicitly as `@safe pure nothrow`, as these are checked in unittests, but a unittest wouldn't tell you what was causing one of the attributes to not be valid for them. ~~As well as making a set of globals that were immutable into enums, which means they should now be fully accessible for CTFE. By making `_ctype` into an enum, all methods in `std.ascii` should now be CTFE'able.~~
