### PR TITLE
Use scope(exit) for LocalFree in std.windows.syserror.sysErrorString

### DIFF
--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -47,8 +47,9 @@ string sysErrorString(uint errcode) @trusted
     result[0 .. r] = buffer[0 .. r];
     result[r] = 0;
 
+    LocalFree(cast(HLOCAL)buffer);
+
     auto res = std.windows.charset.fromMBSz(cast(immutable)result.ptr);
 
-    LocalFree(cast(HLOCAL)buffer);
     return res;
 }


### PR DESCRIPTION
It is for exception safety.
