### PR TITLE
Mark unittests for blockAttribute and nDimensions as @safe, pure, nothrow

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -275,7 +275,7 @@ private template blockAttribute(T)
         enum blockAttribute = GC.BlkAttr.NO_SCAN;
     }
 }
-unittest
+version(unittest)
 {
     static assert(!(blockAttribute!void & GC.BlkAttr.NO_SCAN));
 }
@@ -293,7 +293,7 @@ private template nDimensions(T)
     }
 }
 
-unittest
+version(unittest)
 {
     static assert(nDimensions!(uint[]) == 1);
     static assert(nDimensions!(float[][]) == 2);


### PR DESCRIPTION
It is obviously safe, pure, and nothrow because these unittests check for the template constant.
## 

I will move examples in the comments in std.array into documented unittests from top to bottom.
