### PR TITLE
Fix the range primitives for array in std.array

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -405,13 +405,6 @@ Implements the range interface primitive $(D empty) for built-in
 arrays. Due to the fact that nonmember functions can be called with
 the first argument using the dot notation, $(D array.empty) is
 equivalent to $(D empty(array)).
-
-Example:
-----
-auto a = [ 1, 2, 3 ];
-assert(!a.empty);
-assert(a[3 .. $].empty);
-----
  */
 
 @property bool empty(T)(in T[] a) @safe pure nothrow
@@ -419,7 +412,8 @@ assert(a[3 .. $].empty);
     return !a.length;
 }
 
-unittest
+///
+@safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     assert(!a.empty);
@@ -432,13 +426,6 @@ arrays. Due to the fact that nonmember functions can be called with
 the first argument using the dot notation, $(D array.save) is
 equivalent to $(D save(array)). The function does not duplicate the
 content of the array, it simply returns its argument.
-
-Example:
-----
-auto a = [ 1, 2, 3 ];
-auto b = a.save;
-assert(b is a);
-----
  */
 
 @property T[] save(T)(T[] a) @safe pure nothrow
@@ -446,6 +433,13 @@ assert(b is a);
     return a;
 }
 
+///
+@safe pure nothrow unittest
+{
+    auto a = [ 1, 2, 3 ];
+    auto b = a.save;
+    assert(b is a);
+}
 /**
 Implements the range interface primitive $(D popFront) for built-in
 arrays. Due to the fact that nonmember functions can be called with
@@ -453,28 +447,25 @@ the first argument using the dot notation, $(D array.popFront) is
 equivalent to $(D popFront(array)). For $(GLOSSARY narrow strings),
 $(D popFront) automaticaly advances to the next $(GLOSSARY code
 point).
-
-Example:
-----
-int[] a = [ 1, 2, 3 ];
-a.popFront();
-assert(a == [ 2, 3 ]);
-----
 */
 
-void popFront(T)(ref T[] a)
+void popFront(T)(ref T[] a) @safe pure nothrow
 if (!isNarrowString!(T[]) && !is(T[] == void[]))
 {
     assert(a.length, "Attempting to popFront() past the end of an array of " ~ T.stringof);
     a = a[1 .. $];
 }
 
-unittest
+///
+@safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     a.popFront();
     assert(a == [ 2, 3 ]);
+}
 
+version(unittest)
+{
     static assert(!is(typeof({          int[4] a; popFront(a); })));
     static assert(!is(typeof({ immutable int[] a; popFront(a); })));
     static assert(!is(typeof({          void[] a; popFront(a); })));
@@ -514,7 +505,7 @@ if (isNarrowString!(C[]))
     else static assert(0, "Bad template constraint.");
 }
 
-unittest
+@safe pure unittest
 {
     foreach(S; TypeTuple!(string, wstring, dstring))
     {
@@ -553,43 +544,39 @@ arrays. Due to the fact that nonmember functions can be called with
 the first argument using the dot notation, $(D array.popBack) is
 equivalent to $(D popBack(array)). For $(GLOSSARY narrow strings), $(D
 popFront) automaticaly eliminates the last $(GLOSSARY code point).
-
-
-Example:
-----
-int[] a = [ 1, 2, 3 ];
-a.popBack();
-assert(a == [ 1, 2 ]);
-----
 */
 
-void popBack(T)(ref T[] a)
+void popBack(T)(ref T[] a) @safe pure nothrow
 if (!isNarrowString!(T[]) && !is(T[] == void[]))
 {
     assert(a.length);
     a = a[0 .. $ - 1];
 }
 
-unittest
+///
+@safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     a.popBack();
     assert(a == [ 1, 2 ]);
+}
 
+version(unittest)
+{
     static assert(!is(typeof({ immutable int[] a; popBack(a); })));
     static assert(!is(typeof({          int[4] a; popBack(a); })));
     static assert(!is(typeof({          void[] a; popBack(a); })));
 }
 
 // Specialization for arrays of char
-@trusted void popBack(T)(ref T[] a)
+void popBack(T)(ref T[] a) @safe pure
 if (isNarrowString!(T[]))
 {
     assert(a.length, "Attempting to popBack() past the front of an array of " ~ T.stringof);
     a = a[0 .. $ - std.utf.strideBack(a, $)];
 }
 
-unittest
+@safe pure unittest
 {
     foreach(S; TypeTuple!(string, wstring, dstring))
     {
@@ -622,22 +609,22 @@ the first argument using the dot notation, $(D array.front) is
 equivalent to $(D front(array)). For $(GLOSSARY narrow strings), $(D
 front) automaticaly returns the first $(GLOSSARY code point) as a $(D
 dchar).
-
-
-Example:
-----
-int[] a = [ 1, 2, 3 ];
-assert(a.front == 1);
-----
 */
-@property ref T front(T)(T[] a)
+@property ref T front(T)(T[] a) @safe pure nothrow
 if (!isNarrowString!(T[]) && !is(T[] == void[]))
 {
     assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
     return a[0];
 }
 
-unittest
+///
+@safe pure nothrow unittest
+{
+    int[] a = [ 1, 2, 3 ];
+    assert(a.front == 1);
+}
+
+@safe pure nothrow unittest
 {
     auto a = [ 1, 2 ];
     a.front = 4;
@@ -651,7 +638,7 @@ unittest
     assert(c.front == 1);
 }
 
-@property dchar front(T)(T[] a) if (isNarrowString!(T[]))
+@property dchar front(T)(T[] a) @safe pure if (isNarrowString!(T[]))
 {
     assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
     size_t i = 0;
@@ -665,26 +652,24 @@ the first argument using the dot notation, $(D array.back) is
 equivalent to $(D back(array)). For $(GLOSSARY narrow strings), $(D
 back) automaticaly returns the last $(GLOSSARY code point) as a $(D
 dchar).
-
-Example:
-----
-int[] a = [ 1, 2, 3 ];
-assert(a.back == 3);
-----
 */
-@property ref T back(T)(T[] a) if (!isNarrowString!(T[]))
+@property ref T back(T)(T[] a) @safe pure nothrow if (!isNarrowString!(T[]))
 {
     assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
     return a[$ - 1];
 }
 
-unittest
+///
+@safe pure nothrow unittest
 {
     int[] a = [ 1, 2, 3 ];
     assert(a.back == 3);
     a.back += 4;
     assert(a.back == 7);
+}
 
+@safe pure nothrow unittest
+{
     immutable b = [ 1, 2, 3 ];
     assert(b.back == 3);
 
@@ -693,7 +678,7 @@ unittest
 }
 
 // Specialization for strings
-@property dchar back(T)(T[] a) if (isNarrowString!(T[]))
+@property dchar back(T)(T[] a) @safe pure if (isNarrowString!(T[]))
 {
     assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
     size_t i = a.length - std.utf.strideBack(a, a.length);


### PR DESCRIPTION
This pull request includes the following changes for the range primitives for built-in arrays (`empty`, `save`, `front`, `back`, `popFront` and `popBack`).
- mark them as safe, pure and nothrow
  Some primitives for built-in string types cannot be nothrow because the functions in `std.utf` may throw.
- mark the unittest for them as safe, pure and nothrow
- Use documented unittests instead of the examples in the comments and normal unittests
  In the documented unittest for `back`, I use the following unittest which has two additional lines from the original example in the comment.
  It is because I reuse one of the original unittests for the documented unittest.

``` d
    int[] a = [ 1, 2, 3 ];
    assert(a.back == 3);
    a.back += 4;
    assert(a.back == 7);
```
