### PR TITLE
Implement assumeWontThrow.

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -830,8 +830,13 @@ version(none) unittest
  * This wrapper function documents commitment on the part of the caller that
  * the appropriate steps have been taken to avoid whatever conditions may
  * trigger an exception during the evaluation of $(D expr).  If it turns out
- * that the expression $(I does) throw at runtime, the wrapper will terminate
- * the program with an $(D AssertError).
+ * that the expression $(I does) throw at runtime, the wrapper will throw an
+ * $(D AssertError).
+ *
+ * (Note that $(D Throwable) objects such as $(D AssertError) that do not
+ * subclass $(D Exception) may be thrown even from $(D nothrow) functions,
+ * since they are considered to be serious runtime problems that cannot be
+ * recovered from.)
  */
 T assumeWontThrow(T)(lazy T expr,
                      string msg = null,


### PR DESCRIPTION
As discussed on the forum, one often needs to use `std.format.format` to format nice error messages inside an `assert`. However, since `format` cannot be made `nothrow`, this prevents the code from being made `nothrow`, even though under normal circumstances it indeed will never throw.

This pull implements an `assumeWontThrow` wrapper which wraps an expression inside a try block with a catch block that asserts false should the expression actually throw. This allows the wrapper to be made `nothrow`, and thus usable without undue encumbrence from `nothrow` functions. Thus, the original motivating case can now be implemented thus:

```
void func(int x) nothrow
{
    assert(someCondition(x), assumeWontThrow(
        format("Error: x=%d fails to satisfy some condition", x)
    ));
}
```

http://d.puremagic.com/issues/show_bug.cgi?id=11348
