### PR TITLE
Mark std.array.split and splitter as @safe, pure and nothrow

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1298,7 +1298,7 @@ unittest
 Split the string $(D s) into an array of words, using whitespace as
 delimiter. Runs of whitespace are merged together (no empty words are produced).
  */
-S[] split(S)(S s) if (isSomeString!S)
+S[] split(S)(S s) @safe pure if (isSomeString!S)
 {
     size_t istart;
     bool inword = false;
@@ -1347,20 +1347,21 @@ unittest
 
 /**
 Splits a string by whitespace.
-
-Example:
-----
-auto a = " a     bcd   ef gh ";
-assert(equal(splitter(a), ["", "a", "bcd", "ef", "gh"][]));
-----
  */
-auto splitter(C)(C[] s)
+auto splitter(C)(C[] s) @safe pure
     if(isSomeString!(C[]))
 {
     return std.algorithm.splitter!(std.uni.isWhite)(s);
 }
 
-unittest
+///
+@safe pure unittest
+{
+    auto a = " a     bcd   ef gh ";
+    assert(equal(splitter(a), ["", "a", "bcd", "ef", "gh"][]));
+}
+
+/*@safe*/ pure unittest
 {
     foreach(S; TypeTuple!(string, wstring, dstring))
     {
@@ -1369,9 +1370,6 @@ unittest
         a = "";
         assert(splitter(a).empty);
     }
-
-    immutable string s = " a     bcd   ef gh ";
-    assert(equal(splitter(s), ["", "a", "bcd", "ef", "gh"][]));
 }
 
 /**************************************


### PR DESCRIPTION
This pull request contains the following changes:
- mark `split` for string types as safe, pure and nothrow  
  It doesn't contain encode/decode operations for string types. So we can mark it as nothrow.
- mark `splitter` as safe and pure  
  It cannot be nothrow because it may contain encode/decode operations for string types.
- mark the unittests for them as safe, pure and nothrow  
  Some of them cannot be marked when it contains `core.stdc.stdio.printf` and `std.conv.to`.
- Use a documented unittest instead of the example in the comment
