### PR TITLE
reenable unittest for mangle/demangle

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5834,7 +5834,6 @@ unittest
     static assert(mangledName!((int a) { return a+x; }) == "DFNbNfiZi");    // nothrow safe
 }
 
-version(none) // disabled until druntime pull #611 is merged
 unittest
 {
     // Test for bug 5718


### PR DESCRIPTION
This test has been disabled to verify https://github.com/D-Programming-Language/druntime/pull/611
