### PR TITLE
Fixup `std.file.thisExePath`.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1646,8 +1646,6 @@ else version (FreeBSD)
                 return to!(string)(buffer[0 .. len]);
             buffer.length *= 2;
         }
-
-        assert(0, "should not happen");
     }
     else version (FreeBSD)
     {


### PR DESCRIPTION
It's dangerous to add `assert(0)` at unreachable location because is will force the compiler to not show error if the location accidentally became reachable.
