### PR TITLE
Remove AA comparison from std.xml

### DIFF
--- a/std/xml.d
+++ b/std/xml.d
@@ -1117,9 +1117,11 @@ class Tag
         override int opCmp(Object o)
         {
             const tag = toType!(const Tag)(o);
+            // Note that attr is an AA, so the comparison is nonsensical (bug 10381)
+            // The ordering may change if attr is rehashed, for example.
             return
                 ((name != tag.name) ? ( name < tag.name ? -1 : 1 ) :
-                ((attr != tag.attr) ? ( attr < tag.attr ? -1 : 1 ) :
+                ((attr != tag.attr) ? ( cast(void *)attr < cast(void*)tag.attr ? -1 : 1 ) :
                 ((type != tag.type) ? ( type < tag.type ? -1 : 1 ) :
             0 )));
         }


### PR DESCRIPTION
Necessary for bugfix for 10381
The compiler has historically been doing a cast(void *) for AA compares,
which doesn't make much sense. Make it explicit to preserve existing behaviour, until this module is replaced.

Note that std.xml has a fundamentally broken design. It creates an AA for every tag in the XML file (!) And that's part of the interface, so it isn't fixable.
