### PR TITLE
Make swap work on non-assignable structs

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1927,7 +1927,14 @@ unittest
 
 // swap
 /**
-Swaps $(D lhs) and $(D rhs). 
+Swaps $(D lhs) and $(D rhs). The instances $(D lhs) and $(D rhs) are moved in
+memory, without ever calling $(D opAssign), nor any other function. $(D T)
+need not be assignable at all to be swapped.
+
+If $(D lhs) and $(D rhs) reference the same instance, then nothing is done.
+
+$(D lhs) and $(D rhs) must be mutable. If $(D T) is a struct or union, then
+its fields must also all be (recursivelly) mutable.
 
 Preconditions:
 


### PR DESCRIPTION
Simply put, swap forgot to check for actually assign-ability, before looking at it's elaborateness.

This will make swap take the memswap road, if the object is not assignable.

http://d.puremagic.com/issues/show_bug.cgi?id=11324
