### PR TITLE
Adds fromStringz

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -137,9 +137,11 @@ unittest
 }
 
 /++
-    Returns a $(D string) slice of a C-style null-terminated string.
+    Returns a D-style array of $(D char) given a zero-terminated C-style string.
+    The returned array will retain the same type qualifiers as the input.
 
-    $(RED Important Note:) The returned $(D string) is a slice of the original buffer.
+    $(RED Important Note:) The returned array is a slice of the original buffer.
+    The original data is not changed and not copied.
 +/
 
 inout(char)[] fromStringz(inout(char)* cString) @system pure {


### PR DESCRIPTION
In this pull request, instead of the currently present special casing in `std.conv.to!string` for `char*`, `std.string.fromStringz` is provided as an alternative solution.

This more readily compliments the existing `std.string.toStringz` function, and allows `to!string` to be consistent with semantics similar to `formattedWrite`/`writeln` etc.

While `std.conv.to!string(const(char*) s)` has not been deprecated, it is open to discussion as to what path would be the best to take if this request is accepted.
