### PR TITLE
Scoped the imports in std.ascii

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -25,12 +25,12 @@
   +/
 module std.ascii;
 
-import std.traits;
-
-version(unittest)
+version (unittest)
 {
-    import std.range;
-    import std.typetuple;
+    // FIXME: When dmd bug #314 is fixed, make these selective.
+    import std.range; // : chain;
+    import std.traits; // : functionAttributes, FunctionAttribute, isSafe;
+    import std.typetuple; // : TypeTuple;
 }
 
 
@@ -40,9 +40,8 @@ immutable fullHexDigits  = "0123456789ABCDEFabcdef";     /// 0..9A..Fa..f
 immutable digits         = "0123456789";                 /// 0..9
 immutable octalDigits    = "01234567";                   /// 0..7
 immutable lowercase      = "abcdefghijklmnopqrstuvwxyz"; /// a..z
-immutable letters        = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ~
-                           "abcdefghijklmnopqrstuvwxyz"; /// A..Za..z
 immutable uppercase      = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; /// A..Z
+immutable letters        = uppercase ~ lowercase;        /// A..Za..z
 immutable whitespace     = " \t\v\r\n\f";                /// ASCII whitespace
 
 /**
@@ -318,18 +317,21 @@ unittest
     letter is returned. Otherwise, $(D c) is returned.
 
     $(D C) can be any type which implicitly converts to $(D dchar). In the case
-    where it's a built-in type, or enum of a built-in type,
+    where it's a built-in type, or an enum of a built-in type,
     $(D Unqual!(OriginalType!C)) is returned, whereas if it's a user-defined
     type, $(D dchar) is returned.
   +/
 auto toLower(C)(C c)
     if(is(C : dchar))
 {
+    import std.traits : isAggregateType, OriginalType, Unqual;
+
     alias OC = OriginalType!C;
     static if (isAggregateType!OC)
         alias R = dchar;
     else
         alias R = Unqual!OC;
+    
     return isUpper(c) ? cast(R)(cast(R)c + 'a' - 'A') : cast(R)c;
 }
 
@@ -364,18 +366,21 @@ auto toLower(C)(C c)
     letter is returned. Otherwise, $(D c) is returned.
 
     $(D C) can be any type which implicitly converts to $(D dchar). In the case
-    where it's a built-in type, or enum of a built-in type,
+    where it's a built-in type, or an enum of a built-in type,
     $(D Unqual!(OriginalType!C)) is returned, whereas if it's a user-defined
     type, $(D dchar) is returned.
   +/
 auto toUpper(C)(C c)
     if(is(C : dchar))
 {
+    import std.traits : isAggregateType, OriginalType, Unqual;
+
     alias OC = OriginalType!C;
     static if (isAggregateType!OC)
         alias R = dchar;
     else
         alias R = Unqual!OC;
+    
     return isLower(c) ? cast(R)(cast(R)c - ('a' - 'A')) : cast(R)c;
 }
 
@@ -466,34 +471,34 @@ private:
 
 enum
 {
-    _SPC =      8,
-    _CTL =      0x20,
-    _BLK =      0x40,
-    _HEX =      0x80,
-    _UC  =      1,
-    _LC  =      2,
-    _PNC =      0x10,
-    _DIG =      4,
-    _ALP =      _UC|_LC,
+    _UC  = 0x01,
+    _LC  = 0x02,
+    _DIG = 0x04,
+    _SPC = 0x08,
+    _PNC = 0x10,
+    _CTL = 0x20,
+    _BLK = 0x40,
+    _HEX = 0x80,
+    _ALP = _UC | _LC,
 }
 
 immutable ubyte[128] _ctype =
 [
-        _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
-        _CTL,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL,_CTL,
-        _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
-        _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
-        _SPC|_BLK,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
-        _PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
-        _DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,
-        _DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,
-        _PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
-        _PNC,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC,
-        _UC,_UC,_UC,_UC,_UC,_UC,_UC,_UC,
-        _UC,_UC,_UC,_UC,_UC,_UC,_UC,_UC,
-        _UC,_UC,_UC,_PNC,_PNC,_PNC,_PNC,_PNC,
-        _PNC,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC,
-        _LC,_LC,_LC,_LC,_LC,_LC,_LC,_LC,
-        _LC,_LC,_LC,_LC,_LC,_LC,_LC,_LC,
-        _LC,_LC,_LC,_PNC,_PNC,_PNC,_PNC,_CTL
+    _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
+    _CTL,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL|_SPC,_CTL,_CTL,
+    _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
+    _CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,_CTL,
+    _SPC|_BLK,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
+    _PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
+    _DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,
+    _DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,_DIG|_HEX,
+    _PNC,_PNC,_PNC,_PNC,_PNC,_PNC,
+    _PNC,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC|_HEX,_UC,
+    _UC,_UC,_UC,_UC,_UC,_UC,_UC,_UC,
+    _UC,_UC,_UC,_UC,_UC,_UC,_UC,_UC,
+    _UC,_UC,_UC,_PNC,_PNC,_PNC,_PNC,_PNC,
+    _PNC,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC|_HEX,_LC,
+    _LC,_LC,_LC,_LC,_LC,_LC,_LC,_LC,
+    _LC,_LC,_LC,_LC,_LC,_LC,_LC,_LC,
+    _LC,_LC,_LC,_PNC,_PNC,_PNC,_PNC,_CTL
 ];


### PR DESCRIPTION
This basically scopes the imports in `std.ascii`, as well as modifies those imports to be selective in what they import. There are also a couple of style changes, namely the ordering of values in an anonymous enum, and the use of only 1 indent level within an array declaration. The final change is to mark `toLower` and `toUpper` explicitly as `@safe pure nothrow`, as these are checked in unittests, but a unittest wouldn't tell you what was causing one of the attributes to not be valid for them. ~~As well as making a set of globals that were immutable into enums, which means they should now be fully accessible for CTFE. By making `_ctype` into an enum, all methods in `std.ascii` should now be CTFE'able.~~

This was previously [Pull Request 1557](https://github.com/D-Programming-Language/phobos/pull/1557), but due to limitations of the Github web interface, I have to create a new pull request to compact the changes into one commit.
