### PR TITLE
Support degenerate bitfields with fields of length 32 and 64

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -283,6 +283,40 @@ unittest
 
 unittest
 {
+    // Bug #6686
+    union  S {
+        ulong bits = ulong.max;
+        mixin (bitfields!(
+            ulong, "back",  31,
+            ulong, "front", 33)
+        );
+    }
+    S num;
+
+    num.bits = ulong.max;
+    num.back = 1;
+    assert(num.bits == 0xFFFF_FFFF_8000_0001uL);
+}
+
+unittest
+{
+    // Bug #5942
+    struct S
+    {
+        mixin(bitfields!(
+            int, "a" , 32,
+            int, "b" , 32
+        ));
+    }
+
+    S data;
+    data.b = 42;
+    data.a = 1;
+    assert(data.b == 42);
+}
+
+unittest
+{
     struct Test
     {
         mixin(bitfields!(bool, "a", 1,


### PR DESCRIPTION
Fixes http://d.puremagic.com/issues/show_bug.cgi?id=11160 / http://d.puremagic.com/issues/show_bug.cgi?id=8474

Adds tests for:
http://d.puremagic.com/issues/show_bug.cgi?id=6686
http://d.puremagic.com/issues/show_bug.cgi?id=5942
Which seem to have been fixed over time.
