### PR TITLE
[REG2.064a] Issue 11165 - std.typecons._d_toObject conflicts with std.signals._d_toObject

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2701,7 +2701,8 @@ template generateAssertTrap(C, func.../+[BUG 4217]+/)
 
 private
 {
-    extern(C) pure nothrow Object _d_toObject(void* p);
+    pragma(mangle, "_d_toObject")
+    extern(C) pure nothrow Object typecons_d_toObject(void* p);
 }
 
 /*
@@ -2724,7 +2725,7 @@ if (is(T == class) || is(T == interface))
         }
         else
         {
-            return cast(T)_d_toObject(*cast(void**)(&source));
+            return cast(T)typecons_d_toObject(*cast(void**)(&source));
         }
     }
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11165

Workaround for the not-well-defined language semantics - the combination of cross-module overload set resolution and protection attribute.
