### PR TITLE
isIntegerLike template needed for David Simcha's std.rational

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4726,7 +4726,7 @@ unittest
  * while for a non-mutable type, the above must compile for its unqualified,
  * mutable variant.
  *
- * All built-in D integers and character types and $(D std.bigint.BigInt) are
+ * All built-in D integers and character types and $(XREF bigint, BigInt) are
  * integer-like by this definition.
  */
 template isIntegerLike(T)


### PR DESCRIPTION
Unlike std.traits.isIntegral this template checks for "integer-like" properties, i.e. that the type offers all the operations that an integer type should.  It can therefore be used to support arbitrary integer implementations, including all built-in integer (and char) types, std.bigint.BigInt, and in principle any user- or library-defined integer type.

Besides the soon-to-be-proposed-for-review std.rational, for which this is a dependency, it ought to be useful for e.g. std.math and std.numeric where one would wish for functions to be designed to work with any integer implementation.

The background discussion on std.rational, including the rationale for this template, can be found here:
http://forum.dlang.org/thread/mailman.1899.1380723964.1719.digitalmars-d@puremagic.com
