### PR TITLE
std.process: Fix spawnProcess in Windows GUI programs (issue #11180)

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -485,18 +485,21 @@ private Pid spawnProcessImpl(in char[] commandLine,
             version (DMC_RUNTIME) handle = _fdToHandle(fileDescriptor);
             else    /* MSVCRT */  handle = _get_osfhandle(fileDescriptor);
         }
+
         DWORD dwFlags;
-        GetHandleInformation(handle, &dwFlags);
-        if (!(dwFlags & HANDLE_FLAG_INHERIT))
+        if (GetHandleInformation(handle, &dwFlags))
         {
-            if (!SetHandleInformation(handle,
-                                      HANDLE_FLAG_INHERIT,
-                                      HANDLE_FLAG_INHERIT))
+            if (!(dwFlags & HANDLE_FLAG_INHERIT))
             {
-                throw new StdioException(
-                    "Failed to make "~which~" stream inheritable by child process ("
-                    ~sysErrorString(GetLastError()) ~ ')',
-                    0);
+                if (!SetHandleInformation(handle,
+                                          HANDLE_FLAG_INHERIT,
+                                          HANDLE_FLAG_INHERIT))
+                {
+                    throw new StdioException(
+                        "Failed to make "~which~" stream inheritable by child process ("
+                        ~sysErrorString(GetLastError()) ~ ')',
+                        0);
+                }
             }
         }
     }


### PR DESCRIPTION
The old code also didn't check if `GetHandleInformation` succeeded, so this kills two birds with one stone (although we still don't throw on `GetHandleInformation` failure).

Note that although the documentation of `GetStdHandle` implies that the function will return `NULL` for GUI processes, this doesn't appear to be the case - GUI processes launched from console processes will have standard handles (`GetStdHandle(STD_INPUT_HANDLE)` will return 3), however those handles will be invalid (`GetHandleInformation` will fail for them). So this fix covers both cases, even though it ignores other reasons for `GetHandleInformation` to fail.
