### PR TITLE
fix issue 11194 - std.container.Array.reserve calls opAssign on uninitia...

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -2583,7 +2583,7 @@ struct Array(T) if (!is(T : const(bool)))
                 auto newPayload =
                     enforce((cast(T*) malloc(sz))[0 .. oldLength]);
                 // copy old data over to new array
-                newPayload[] = _payload[];
+                memcpy(newPayload.ptr, _payload.ptr, T.sizeof * oldLength);
                 // Zero out unused capacity to prevent gc from seeing
                 // false pointers
                 memset(newPayload.ptr + oldLength,
@@ -3677,6 +3677,20 @@ unittest
     assert(r.equal([6, 35, 40]));
     r[0 .. 2] = 0;
     assert(r.equal([0, 0, 40]));
+}
+
+// Test issue 11194
+unittest {
+    static struct S {
+        int i = 1337;
+        void* p;
+        this(this) { assert(i == 1337); }
+        ~this() { assert(i == 1337); }
+    }
+    Array!S arr;
+    S s;
+    arr ~= s;
+    arr ~= s;
 }
 
 // BinaryHeap


### PR DESCRIPTION
...lized data

This fix performs a postblit instead of a full assignment in case of a struct with elaborate assignment.
