### PR TITLE
Remove deprecated uninitializedFill

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1190,14 +1190,6 @@ void uninitializedFill(Range, Value)(Range range, Value filler)
         return fill(range, filler);
 }
 
-deprecated("Cannot reliably call uninitializedFill on range that does not expose references. Use fill instead.")
-void uninitializedFill(Range, Value)(Range range, Value filler)
-    if (isInputRange!Range && !hasLvalueElements!Range && is(typeof(range.front = filler)))
-{
-    static assert(hasElaborateAssign!T, "Cannot execute uninitializedFill a range that does not expose references, and whose objects have an elaborate assign.");
-    return fill(range, filler);
-}
-
 /**
 Initializes all elements of a range with their $(D .init)
 value. Assumes that the range does not currently contain meaningful


### PR DESCRIPTION
This removes a function branch that I deprecated for 2.062. Not that long yes, but:
1. The call was just plain _wrong_ to begin with.
2. My static assert was actually upside down. This means that: Either your code was "semi correct" but didn't compile, or was "totally wrong".

Either way, I think we should just do away with it now, instead of "fixing" it.
