### PR TITLE
Adds Bidirectionality to Repeat

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3721,9 +3721,13 @@ struct Repeat(T)
 {
     private T _value;
     /// Range primitive implementations.
+    @property T back() { return _value; }
+    /// Ditto
     @property T front() { return _value; }
     /// Ditto
     enum bool empty = false;
+    /// Ditto
+    void popBack() {}
     /// Ditto
     void popFront() {}
     /// Ditto
@@ -3754,10 +3758,13 @@ unittest
 {
     auto  r = repeat(5);
     alias R = typeof(r);
+    static assert(isBidirectionalRange!R);
     static assert(isForwardRange!R);
     static assert(isInfinite!R);
     static assert(hasSlicing!R);
 
+    assert(r.back == 5);
+    assert(r.front == 5);
     assert(r.take(4).equal([ 5, 5, 5, 5 ]));
     assert(r[0 .. 4].equal([ 5, 5, 5, 5 ]));
 


### PR DESCRIPTION
There is no reason (that I can see) that Repeat should not be implemented as a Bidirectional range, therefore this pull request adds that functionality.

See attached an arbitrary test that ensures this functionality is correct.
