### PR TITLE
fix issue 11232 - rewritten std.windows.syserror.sysErrorString

### DIFF
--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -3,12 +3,12 @@
 /**
  * Convert Win32 error code to string.
  *
- * Copyright: Copyright Digital Mars 2006 - 2009.
+ * Copyright: Copyright Digital Mars 2006 - 2013.
  * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
  * Authors:   $(WEB digitalmars.com, Walter Bright)
  * Credits:   Based on code written by Regan Heath
  *
- *          Copyright Digital Mars 2006 - 2009.
+ *          Copyright Digital Mars 2006 - 2013.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
@@ -16,40 +16,79 @@
 module std.windows.syserror;
 version (Windows):
 
-private import std.windows.charset;
-private import std.c.windows.windows;
+import std.windows.charset;
+import core.sys.windows.windows;
 
-string sysErrorString(uint errcode) @trusted
+// MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT) is the user's default language
+string sysErrorString(
+    uint errCode,
+    int langId = LANG_NEUTRAL,
+    int subLangId = SUBLANG_DEFAULT) @trusted
 {
-    char[] result;
-    char* buffer;
-    DWORD r;
+    wchar* pWideMessage;
 
-    r = FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER |
-            FORMAT_MESSAGE_FROM_SYSTEM |
-            FORMAT_MESSAGE_IGNORE_INSERTS,
-            null,
-            errcode,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-            cast(LPTSTR)&buffer,
-            0,
-            null);
+    DWORD length = FormatMessageW(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        null,
+        errCode,
+        MAKELANGID(langId, subLangId),
+        cast(LPWSTR)&pWideMessage,
+        0,
+        null);
+
+    if(length == 0)
+    {
+        throw new Exception(
+            "failed getting error string for WinAPI error code: " ~
+            sysErrorString(GetLastError()));
+    }
+
+    scope(exit) LocalFree(cast(HLOCAL)pWideMessage);
 
     /* Remove \r\n from error string */
-    if (r >= 2)
-        r -= 2;
+    if (length >= 2)
+        length -= 2;
 
-    /* Create 0 terminated copy on GC heap because fromMBSz()
-     * may return it.
-     */
-    result = new char[r + 1];
-    result[0 .. r] = buffer[0 .. r];
-    result[r] = 0;
+    static int wideToNarrow(wchar[] wide, char[] narrow) nothrow
+    {
+        return WideCharToMultiByte(
+            CP_UTF8,
+            0, // No WC_COMPOSITECHECK, as system error messages are precomposed
+            wide.ptr,
+            cast(int)wide.length,
+            narrow.ptr,
+            cast(int)narrow.length,
+            null,
+            null);
+    }
 
-    LocalFree(cast(HLOCAL)buffer);
+    auto wideMessage = pWideMessage[0 .. length];
 
-    auto res = std.windows.charset.fromMBSz(cast(immutable)result.ptr);
+    int requiredCodeUnits = wideToNarrow(wideMessage, null);
 
-    return res;
+    // If FormatMessage with FORMAT_MESSAGE_FROM_SYSTEM succeeds,
+    // there's no reason for the returned UTF-16 to be invalid.
+    assert(requiredCodeUnits > 0);
+
+    auto message = new char[requiredCodeUnits];
+    auto writtenLength = wideToNarrow(wideMessage, message);
+
+    assert(writtenLength > 0); // Ditto
+
+    return cast(immutable)message[0 .. writtenLength];
+}
+
+/*
+ * If the test fails, the text representation for the tested
+ * error codes may have changed in a future Windows version,
+ * but at the time of writing it was deemed unlikely to happen.
+ */
+@safe unittest
+{
+    assert(sysErrorString(ERROR_SUCCESS, LANG_ENGLISH, SUBLANG_ENGLISH_US)
+        == "The operation completed successfully.");
+    assert(sysErrorString(ERROR_FILE_NOT_FOUND, LANG_ENGLISH, SUBLANG_ENGLISH_US)
+        == "The system cannot find the file specified.");
 }


### PR DESCRIPTION
Depends on ~~[druntime pull request #637](https://github.com/D-Programming-Language/druntime/pull/637)~~ so that Phobos doesn't have multiple declarations of `CP_UTF8`.

Fixed for Unicode-correctness; now works on non-English Windows systems.
Added unit test.
Throws an `Exception` if the given error code or language combination was invalid.

As it is a rewrite, it's probably easier to review by looking at the [new source](https://github.com/JakobOvrum/phobos/blob/syserrorstring/std/windows/syserror.d).
