### PR TITLE
Remove useless dependency on std.regex in std.string

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -29,7 +29,7 @@ debug(string) import core.stdc.stdio;
 import core.exception : RangeError, onRangeError;
 import core.vararg, core.stdc.stdlib, core.stdc.string,
     std.algorithm, std.ascii, std.conv, std.exception, std.format, std.functional,
-    std.range, std.regex, std.traits,
+    std.range, std.traits,
     std.typecons, std.typetuple, std.uni, std.utf;
 
 //Remove when repeat is finally removed. They're only here as part of the


### PR DESCRIPTION
Speechless. We need better dependency management.
This brings hello world back from ~420Kb to ~290Kb
