### PR TITLE
[REG 2.064] Fix issue 11283 - Remove sysErrorString unittest

### DIFF
--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -79,16 +79,3 @@ string sysErrorString(
 
     return cast(immutable)message[0 .. writtenLength];
 }
-
-/*
- * If the test fails, the text representation for the tested
- * error codes may have changed in a future Windows version,
- * but at the time of writing it was deemed unlikely to happen.
- */
-@safe unittest
-{
-    assert(sysErrorString(ERROR_SUCCESS, LANG_ENGLISH, SUBLANG_ENGLISH_US)
-        == "The operation completed successfully.");
-    assert(sysErrorString(ERROR_FILE_NOT_FOUND, LANG_ENGLISH, SUBLANG_ENGLISH_US)
-        == "The system cannot find the file specified.");
-}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11283

As noted in the bug report, it may be Windows 8 specific, but it's hard to tell what exactly causes it, or why US English error messages can be missing from Windows systems. In light of this, I can't think of a meaningful test that works on all Windows systems, so this PR removes the unittest entirely. The old `sysErrorString` did not have a unittest either, so it's not a net loss. At least the current incarnation of `sysErrorString` has been manually tested on systems of various language configurations.
