### PR TITLE
Put 64-bit phobos in lib64 in the release zip

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -815,8 +815,8 @@ cleanhtml:
 	del $(DOCS)
 
 install: phobos.zip
-	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib
-	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib
+	$(CP) phobos.lib $(DIR)\windows\lib
+	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DIR)\windows\lib
 	+rd/s/q $(DIR)\html\d\phobos
 	+md $(DIR)\html\d\phobos
 	$(CP) $(DOCS) $(DIR)\html\d\phobos

--- a/win64.mak
+++ b/win64.mak
@@ -790,7 +790,7 @@ cleanhtml:
 	del $(DOCS)
 
 install: phobos.zip
-	$(CP) phobos.lib phobos64.lib $(DIR)\windows\lib
-	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib
+	$(CP) phobos64.lib $(DIR)\windows\lib64
+	$(CP) $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib64
 	+rd/s/q $(DIR)\src\phobos
 	unzip -o phobos.zip -d $(DIR)\src\phobos


### PR DESCRIPTION
This is for [dmd pull 2684](https://github.com/D-Programming-Language/dmd/pull/2684).

@WalterBright I'm not entirely sure if this was the correct approach to get the 64-bit phobos/gcstub in lib64.  Some guidance if this is wrong would be appreciated.

Also, it seemed odd to me that win32.mak and win64.mak referenced the 64 bit and 32 bit libraries, respectively.  Is that intentional?
