### PR TITLE
Reduce Scoped size

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4214,8 +4214,8 @@ template scoped(T)
         Scoped result = void;
         void* alignedStore = cast(void*) aligned(cast(size_t) result.Scoped_store.ptr);
         immutable size_t d = alignedStore - result.Scoped_store.ptr;
-        *cast(size_t*) &result.Scoped_store[$ - size_t.sizeof] = d;
-        emplace!(Unqual!T)(result.Scoped_store[d .. $ - size_t.sizeof], args);
+        *cast(ubyte*) &result.Scoped_store[$ - ubyte.sizeof] = cast(ubyte)d;
+        emplace!(Unqual!T)(result.Scoped_store[d .. $ - ubyte.sizeof], args);
         return result;
     }
 }


### PR DESCRIPTION
Two simple enough tweaks that reduces Scoped's size by 8 to 16 bytes (on 64 bit systems). The total "overhead" is now exactly +8 bytes compared to the class instance's size (used to be about 16-24).

First, we store the offset in a `ubyte`, as opposed to a `size_t`. This is combined with the fact that we only need `alignment - 1` padding (We never use the very last byte) means we can place the `offset` ubyte inside the very last byte of `alignement`.

An entire size_t saved!

Second, I removed the `aligned` in the calculation of the Scoped buffer. This is not necessary, and serves no purpose other than giving Scoped an "aligned size".
