### PR TITLE
Remove conditional emplace call

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -32,7 +32,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
     {
         if(r.length == 0) return null;
 
-        static auto trustedAllocateArray(size_t n) @trusted nothrow pure
+        static auto trustedAllocateArray(size_t n) @trusted nothrow
         {
             return uninitializedArray!(Unqual!E[])(n);
         }


### PR DESCRIPTION
This removes a conditional call to `emplace` in `array`. The condition is gratuitous, and is present mostly for historical reasons.

This pull is a quick "test" if there is any need of discussion about this.

If there is not, I will deploy it to `appender`:
https://github.com/D-Programming-Language/phobos/pull/1529
