### PR TITLE
Merge dirEntries unittests and modify to run within the same testdir.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2711,21 +2711,18 @@ unittest
         //writeln(name);
         assert(e.isFile || e.isDir, e.name);
     }
-}
 
-unittest
-{
     //issue 7264
-    foreach (string name; dirEntries(".", "*.d", SpanMode.breadth))
+    foreach (string name; dirEntries(testdir, "*.d", SpanMode.breadth))
     {
 
     }
-    foreach (entry; dirEntries(".", SpanMode.breadth))
+    foreach (entry; dirEntries(testdir, SpanMode.breadth))
     {
         static assert(is(typeof(entry) == DirEntry));
     }
     //issue 7138
-    auto a = array(dirEntries(".", SpanMode.shallow));
+    auto a = array(dirEntries(testdir, SpanMode.shallow));
 }
 
 /++


### PR DESCRIPTION
This should prevent transient failures such as: http://d.puremagic.com/test-results/pull.ghtml?projectid=1&runid=768194
