### PR TITLE
Fix Issue 11336 - ElementType does not support types with disabled postb...

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -1044,6 +1044,14 @@ unittest
     static assert(is(ElementType!(inout(int)[]) : inout(int)));
 }
 
+unittest
+{
+    static assert(is(ElementType!(int[5]) == int));
+    static assert(is(ElementType!(int[0]) == int));
+    static assert(is(ElementType!(char[5]) == dchar));
+    static assert(is(ElementType!(char[0]) == dchar));
+}
+
 unittest //11336
 {
     static struct S
@@ -1063,7 +1071,7 @@ $(D ElementType).
 template ElementEncodingType(R)
 {
     static if (isNarrowString!R)
-        alias typeof(lvalueOf!R[0]) ElementEncodingType;
+        alias typeof(*lvalueOf!R.ptr) ElementEncodingType;
     else
         alias ElementType!R ElementEncodingType;
 }
@@ -1084,6 +1092,14 @@ unittest
     static assert(is(ElementType!(typeof(buf)) : void));
 
     static assert(is(ElementEncodingType!(inout char[]) : inout(char)));
+}
+
+unittest
+{
+    static assert(is(ElementEncodingType!(int[5]) == int));
+    static assert(is(ElementEncodingType!(int[0]) == int));
+    static assert(is(ElementEncodingType!(char[5]) == char));
+    static assert(is(ElementEncodingType!(char[0]) == char));
 }
 
 /**


### PR DESCRIPTION
...lits

The root issue was an old hack which tested via a function a return by value. No postblit => no return by value.

I was able to work around the entire hack by simply using @denis-sh 's `lvalueOf`. A really neat thing about `lvalueOf` is that it has the whole `inout` hack "integrated" into it, so the hack can be entirely removed from the calling code. No hack => no function => no problem :)

The makes the final code trivial and straight forward. I'll really loving this `lvalueOf` trait.

@denis-sh : You introduced the hack (AFAIK), and implemented `lvalueOf`: Do you see anything here I might have missed?

If this is correct, I think it's time to do a pass on all of `range`/`traits` and deploy `lvalueOf`...

http://d.puremagic.com/issues/show_bug.cgi?id=11336
