### PR TITLE
Fix issue 11360 - Function pointers / delegates returning void fail to compile with Variant.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -518,7 +518,7 @@ private:
                 static if(is(ReturnType!A == void))
                 {
                     (*zis)(t.expand);
-                    *p = VariantN.init; // Uninitialized Variant.Uninitialized
+                    *p = VariantN.init; // void returns uninitialized Variant.
                 }
                 else
                 {


### PR DESCRIPTION
This causes invoking a Variant assigned to a function pointer / delegate returning void to return an uninitialized Variant.
