### PR TITLE
[Refactor] Add internal `_ArrayElementType` trait.

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -296,7 +296,7 @@ private template nDimensions(T)
 {
     static if(isArray!T)
     {
-        enum nDimensions = 1 + nDimensions!(typeof(T.init[0]));
+        enum nDimensions = 1 + nDimensions!(_ArrayElementType!T);
     }
     else
     {
@@ -368,7 +368,7 @@ if(allSatisfy!(isIntegral, I))
         to!string(sizes.length) ~ " dimensions specified for a " ~
         to!string(nDimensions!T) ~ " dimensional array.");
 
-    alias typeof(T.init[0]) E;
+    alias _ArrayElementType!T E;
 
     auto ptr = (__ctfe) ?
         {
@@ -524,7 +524,7 @@ if (isNarrowString!(C[]))
         assert(str.empty);
 
         static assert(!is(typeof({          immutable S a; popFront(a); })));
-        static assert(!is(typeof({ typeof(S.init[0])[4] a; popFront(a); })));
+        static assert(!is(typeof({ _ArrayElementType!S[4] a; popFront(a); })));
     }
 
     C[] _eatString(C)(C[] str)
@@ -600,7 +600,7 @@ if (isNarrowString!(T[]))
         assert(str.empty);
 
         static assert(!is(typeof({          immutable S a; popBack(a); })));
-        static assert(!is(typeof({ typeof(S.init[0])[4] a; popBack(a); })));
+        static assert(!is(typeof({ _ArrayElementType!S[4] a; popBack(a); })));
     }
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -1497,7 +1497,7 @@ T toImpl(T, S)(S value)
         !isSomeString!S && isDynamicArray!S &&
         !isExactSomeString!T && isArray!T)
 {
-    alias E = typeof(T.init[0]);
+    alias E = _ArrayElementType!T;
 
     auto w = appender!(E[])();
     w.reserve(value.length);
@@ -3099,7 +3099,7 @@ Target parse(Target, Source)(ref Source s, dchar lbracket = '[', dchar rbracket 
         isStaticArray!Target && !is(Target == enum))
 {
     static if (hasIndirections!Target)
-        Target result = Target.init[0].init;
+        Target result = _ArrayElementType!Target.init.init;
     else
         Target result = void;
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -34017,7 +34017,7 @@ template _isPrintable(T...)
     else static if(T.length == 1)
     {
         enum _isPrintable = (!isArray!(T[0]) && __traits(compiles, to!string(T[0].init))) ||
-                           (isArray!(T[0]) && __traits(compiles, to!string(T[0].init[0])));
+                           __traits(compiles, to!string(_ArrayElementType!(T[0]).init));
     }
     else
     {

--- a/std/format.d
+++ b/std/format.d
@@ -4386,7 +4386,7 @@ body
             debug (unformatRange) printf("\t) spec = %c, front = %c ", fmt.spec, input.front);
             static if (isStaticArray!T)
             {
-                result[i++] = unformatElement!(typeof(T.init[0]))(input, fmt);
+                result[i++] = unformatElement!(_ArrayElementType!T)(input, fmt);
             }
             else static if (isDynamicArray!T)
             {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3834,7 +3834,7 @@ private struct RoundRobinBuffer(C1, C2)
     // No need for constraints because they're already checked for in asyncBuf.
 
     alias ParameterTypeTuple!(C1.init)[0] Array;
-    alias typeof(Array.init[0]) T;
+    alias _ArrayElementType!Array T;
 
     T[][] bufs;
     size_t index;

--- a/std/range.d
+++ b/std/range.d
@@ -1093,7 +1093,7 @@ $(D ElementType).
 template ElementEncodingType(R)
 {
     static if (isNarrowString!R)
-        alias typeof(*lvalueOf!R.ptr) ElementEncodingType;
+        alias _ArrayElementType!R ElementEncodingType;
     else
         alias ElementType!R ElementEncodingType;
 }
@@ -4000,7 +4000,7 @@ template Cycle(R)
 struct Cycle(R)
     if (isStaticArray!R)
 {
-    private alias typeof(R.init[0]) ElementType;
+    private alias _ArrayElementType!R ElementType;
     private ElementType* _ptr;
     private size_t _index;
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -1665,7 +1665,7 @@ unittest
     {
         debug
         {
-            arr[] = cast(typeof(T.init[0]))(0xdead_beef);
+            arr[] = cast(_ArrayElementType!T)(0xdead_beef);
         }
         arr = null;
     }

--- a/std/variant.d
+++ b/std/variant.d
@@ -418,7 +418,7 @@ private:
                 enforce(0, "Not implemented");
             }
             // Can't handle void arrays as there isn't any result to return.
-            static if (isDynamicArray!(A) && !is(Unqual!(typeof(A.init[0])) == void) && allowed!(typeof(A.init[0])))
+            static if (isDynamicArray!(A) && !is(Unqual!(_ArrayElementType!A) == void) && allowed!(_ArrayElementType!A))
             {
                 // array type; input and output are the same VariantN
                 auto result = cast(VariantN*) parm;


### PR DESCRIPTION
Replace `<type>.init[0]` with new trait to increase code self documentation and avoid incorrect indexing in the case of zero-length static array.

Also replace one `typeof(*lvalueOf!T.ptr)`.
## 

Before:

``` D
Target.init[0].init; // some code, unsure what it does
```

After:

``` D
_ArrayElementType!Target.init.init; // harmless duplication is clear now
```
