### PR TITLE
Issue 11403 - functions in std.algo can't be used as pred

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -10655,7 +10655,7 @@ unittest
 
 unittest
 {
-    equal!(canFind!"a < b")([[1, 2, 3], [7, 8, 9]], [2, 3]);
+    assert(equal!(canFind!"a < b")([[1, 2, 3], [7, 8, 9]], [2, 8]));
 }
 
 /++


### PR DESCRIPTION
Partial fix for 11403:
http://d.puremagic.com/issues/show_bug.cgi?id=11403

This pull allows declaring `any`, `all` and `canFind` with their predicates, but without args. This allows either aliasing them to a new name, or using them as a pred to yet a third function. For example:

``` D
alias fun = canFind!"a < b";
if (fun([1, 2, 3], 4))
{...}
```

or

``` D
import std.ascii : isWhite;
assert( all!(any!isWhite)(["a a", "b b"]));
assert(!any!(all!isWhite)(["a a", "b b"]));
```
