### PR TITLE
Revert "Merge dirEntries unittests and modify to run within the same tes...

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2711,18 +2711,21 @@ unittest
         //writeln(name);
         assert(e.isFile || e.isDir, e.name);
     }
+}
 
+unittest
+{
     //issue 7264
-    foreach (string name; dirEntries(testdir, "*.d", SpanMode.breadth))
+    foreach (string name; dirEntries(".", "*.d", SpanMode.breadth))
     {
 
     }
-    foreach (entry; dirEntries(testdir, SpanMode.breadth))
+    foreach (entry; dirEntries(".", SpanMode.breadth))
     {
         static assert(is(typeof(entry) == DirEntry));
     }
     //issue 7138
-    auto a = array(dirEntries(testdir, SpanMode.shallow));
+    auto a = array(dirEntries(".", SpanMode.shallow));
 }
 
 /++


### PR DESCRIPTION
...tdir."

This reverts commit 249c6328ff8e8c339851f5d597181d0b803fbc12.

https://github.com/D-Programming-Language/phobos/pull/1657

This is a _test_ to see if it triggers a bug in osx64 release.
