### PR TITLE
Use "autoEmplace" for performance

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -794,7 +794,7 @@ template reduce(fun...) if (fun.length >= 1)
                         result = void;
                     foreach (i, T; result.Types)
                     {
-                        emplace(&result[i], seed);
+                        autoEmplace(result[i], seed);
                     }
                     r.popFront();
                     return reduce(result, r);
@@ -856,7 +856,7 @@ template reduce(fun...) if (fun.length >= 1)
 
                     foreach (i, T; result.Types)
                     {
-                        emplace(&result[i], elem);
+                        autoEmplace(result[i], elem);
                     }
                 }
             }
@@ -1186,7 +1186,7 @@ void uninitializedFill(Range, Value)(Range range, Value filler)
     {
         // Must construct stuff by the book
         for (; !range.empty; range.popFront())
-            emplace(addressOf(range.front), filler);
+            autoEmplace(range.front, filler);
     }
     else
         // Doesn't matter whether fill is initialized or not

--- a/std/functional.d
+++ b/std/functional.d
@@ -368,7 +368,7 @@ template adjoin(F...) if (F.length)
             Tuple!(Head, typeof(.adjoin!(F[1..$])(a)).Types) result = void;
             foreach (i, Unused; result.Types)
             {
-                emplace(&result[i], F[i](a));
+                autoEmplace(result[i], F[i](a));
             }
             return result;
         }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3522,7 +3522,7 @@ if (!is(T == class))
             _store = cast(Impl*) enforce(malloc(Impl.sizeof));
             static if (hasIndirections!T)
                 GC.addRange(&_store._payload, T.sizeof);
-            emplace(&_store._payload, args);
+            autoEmplace(_store._payload, args);
             _store._count = 1;
         }
 


### PR DESCRIPTION
The idea is that we are trying to reduce the amount of "conditional calls to emplace" in phobos (see #1655).

The problem though, is that when making a "trivial emplace" (eg for `int` int), the dereferencing that is used to _call_ said emplace clashes DMD's inliner, severely hurting performance.

To workaround both issues, I'm introducing `autoEmplace`, which is nothing more than a "centralized conditonal emplace caller". Doing this helps keep the code clean, safe, and fast.

Using `autoEmplace` over "raw" `emplace`, I was able to see speed benefits of upwards to 40&times; for `std.array` (!), and 10&times; for `Appender`, fixing https://d.puremagic.com/issues/show_bug.cgi?id=10864 at the same time.

Other places that could benefit from this is `std.container.Array`, but I wanted to keep the changes minimal for now. I also didn't change `Appender`, as I want to do that in another dedicated pull.
