### PR TITLE
Workaround Issue 11497 - lambda in "static if"/"assert" prevent inlining of functio

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3865,7 +3865,8 @@ T* emplace(T, Args...)(T* chunk, auto ref Args args)
     static assert (is(T* : void*),
         format("Cannot emplace a %s because it is qualified.", T.stringof));
 
-    static assert(is(typeof({T t = args[0];})),
+    //static assert(is(typeof({T t = args[0];})),
+    static assert(is(typeof({T t = lvalueOf!(Args[0]);})), // @@@11497@@@
         format("%s cannot be emplaced from a %s.", T.stringof, Arg.stringof));
 
     static if (isStaticArray!T)
@@ -3989,7 +3990,8 @@ T* emplace(T, Args...)(T* chunk, auto ref Args args)
         format("Cannot emplace a %s because it is qualified.", T.stringof));
 
     static if (Args.length == 1 && is(Args[0] : T) &&
-        is (typeof({T t = args[0];})) //Check for legal postblit
+        //is (typeof({T t = args[0];})) //Check for legal postblit
+        is (typeof({T t = lvalueOf!(Args[0]);})) // @@@11497@@@
         )
     {
         static if (is(T == Unqual!(Args[0])))


### PR DESCRIPTION
This little "trivial" change is all that is required for `emplace` to be always inlined at call site (regardless of `-inline` switch) with DMD.

This gives _drastic_ performance improvements for the likes of `array`, `Appender`, `Array`.

I had to use `lvalueOf!Arg` instead of `Arg.init`, because the point of the test is to check for postblit, and `Arg.init` specifically bypasses it. I left in the old code, so we can revert if/when 11497 is fixed.
