### PR TITLE
[TRIVIAL] Fixup docs in std.regex

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -27,7 +27,7 @@
   ...
 
   // Create a static regex at compile-time, which contains fast native code.
-  enum ctr = ctRegex!(`^.*/([^/]+)/?$`);
+  auto ctr = ctRegex!(`^.*/([^/]+)/?$`);
 
   // It works just like a normal regex:
   auto m2 = match("foo/bar", ctr);   // First match found here, if any
@@ -2084,8 +2084,6 @@ public struct Regex(Char)
         }
         return NamedGroupRange(dict, 0, dict.length);
     }
-
-    ///
 
 private:
     NamedGroup[] dict;  //maps name -> user group number


### PR DESCRIPTION
And I was wondering where the questionable `enum` anti-pattern came from... Silly me.
Also a workaround for issue 11479. It would be tremendously helpful to regenerate 2.064 DDoc though after that.
