### PR TITLE
fix issue 11528: crashes or undefined behaviour of appender's first allocation

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2454,6 +2454,8 @@ struct Appender(A : T[], T)
 //ret sugLen: A suggested growth.
 private size_t appenderNewCapacity(size_t TSizeOf)(size_t curLen, size_t reqLen) @safe pure nothrow
 {
+    if(curLen == 0)
+        return max(reqLen,8);
     ulong mult = 100 + (1000UL) / (bsr(curLen * TSizeOf) + 1);
     // limit to doubling the length, we don't want to grow too much
     if(mult > 200)


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11528

bsr is undefined for argument 0 (i.e. leaves destination register untouched).
