### PR TITLE
fix Issue 11112 - Unable to execute shell commands in different threads

### DIFF
--- a/std/internal/processinit.d
+++ b/std/internal/processinit.d
@@ -13,10 +13,10 @@ module std.internal.processinit;
 
 version(OSX)
 {
-    extern(C) void std_process_static_this();
+    extern(C) void std_process_shared_static_this();
 
     shared static this()
     {
-        std_process_static_this();
+        std_process_shared_static_this();
     }
 }

--- a/std/process.d
+++ b/std/process.d
@@ -153,14 +153,19 @@ version (Posix)
     version (OSX)
     {
         extern(C) char*** _NSGetEnviron() nothrow;
-        private const(char**)* environPtr;
-        extern(C) void std_process_static_this() { environPtr = _NSGetEnviron(); }
+        private __gshared const(char**)* environPtr;
+        extern(C) void std_process_shared_static_this() { environPtr = _NSGetEnviron(); }
         const(char**) environ() @property @trusted nothrow { return *environPtr; }
     }
     else
     {
         // Made available by the C runtime:
         extern(C) extern __gshared const char** environ;
+    }
+
+    unittest
+    {
+        new Thread({assert(environ !is null);}).start();
     }
 }
 


### PR DESCRIPTION
- the environPtr initializer was only called for the main thread

[Issue 11112](https://d.puremagic.com/issues/show_bug.cgi?id=11112)
