### PR TITLE
improve std.string.strip documentation

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1184,7 +1184,12 @@ unittest
 
 
 /++
-    Strips leading whitespace.
+    Strips leading whitespace (as defined by $(XREF uni, isWhite)).
+
+    Returns: $(D str) stripped of leading whitespace.
+
+    Postconditions: $(D str) and the returned value
+    will share the same tail (see $(XREF array, sameTail)).
   +/
 C[] stripLeft(C)(C[] str) @safe pure
     if (isSomeChar!C)
@@ -1215,7 +1220,12 @@ C[] stripLeft(C)(C[] str) @safe pure
 
 
 /++
-    Strips trailing whitespace.
+    Strips trailing whitespace (as defined by $(XREF uni, isWhite)).
+
+    Returns: $(D str) stripped of trailing whitespace.
+
+    Postconditions: $(D str) and the returned value
+    will share the same head (see $(XREF array, sameHead)).
   +/
 C[] stripRight(C)(C[] str) @safe pure
     if (isSomeChar!C)
@@ -1246,7 +1256,10 @@ C[] stripRight(C)(C[] str) @safe pure
 
 
 /++
-    Strips both leading and trailing whitespace.
+    Strips both leading and trailing whitespace (as defined by
+    $(XREF uni, isWhite)).
+
+    Returns: $(D str) stripped of trailing whitespace.
   +/
 C[] strip(C)(C[] str) @safe pure
     if (isSomeChar!C)


### PR DESCRIPTION
From the thread:
Java moves to copying for substrings
over at:
http://forum.dlang.org/thread/rnogwmgunahampftnzvs@forum.dlang.org
Specifically the comment:
"avoid memory leakage caused by retained substrings holding the entire character array."

Technically, most string/array/range based functions are subject to this "issue", but I figure strip is more vulnerable to it, and is the ideal place to document  and raise awareness of the the "a slice holds on to the entire array" issue.
