### PR TITLE
[minor] Change "runtime library" to "standard library" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![D Logo](http://dlang.org/images/dlogo.png) Phobos Runtime Library
+![D Logo](http://dlang.org/images/dlogo.png) Phobos Standard Library
 ===================================================================
 
-Phobos is the standard runtime library that comes with the
+Phobos is the standard library that comes with the
 [D Programming Language](http://dlang.org) Compiler.
 
 


### PR DESCRIPTION
So phobos doesn't get confused with druntime.
