### PR TITLE
Fix issue 11580 - A unittest of std.stdio.rawRead cannot run and some unittests in std.stdio must run on Win64.

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -532,7 +532,7 @@ $(D rawRead) always reads in binary mode on Windows.
     T[] rawRead(T)(T[] buffer)
     {
         enforce(buffer.length, "rawRead must take a non-empty buffer");
-        version(Win32)
+        version(Windows)
         {
             immutable fd = ._fileno(_p.handle);
             immutable mode = ._setmode(fd, _O_BINARY);
@@ -602,7 +602,6 @@ Throws: $(D ErrnoException) if the file is not opened or if the call to $D(fread
                         _name, "'"));
     }
 
-    version(Win64) {} else
     unittest
     {
         auto deleteme = testFilename();
@@ -636,7 +635,6 @@ Throws: $(D Exception) if the file is not opened.
         }
     }
 
-    version(Win64) {} else
     unittest
     {
         auto deleteme = testFilename();


### PR DESCRIPTION
Issue URL: http://d.puremagic.com/issues/show_bug.cgi?id=11580
