### PR TITLE
Revert "Workaround Issue 11497 - lambda in "static if"/"assert" prevent ...

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3866,8 +3866,7 @@ T* emplace(T, Args...)(T* chunk, auto ref Args args)
     static assert (is(T* : void*),
         format("Cannot emplace a %s because it is qualified.", T.stringof));
 
-    //static assert(is(typeof({T t = args[0];})),
-    static assert(is(typeof({T t = lvalueOf!(Args[0]);})), // @@@11497@@@
+    static assert(is(typeof({T t = args[0];})),
         format("%s cannot be emplaced from a %s.", T.stringof, Arg.stringof));
 
     static if (isStaticArray!T)
@@ -3991,8 +3990,7 @@ T* emplace(T, Args...)(T* chunk, auto ref Args args)
         format("Cannot emplace a %s because it is qualified.", T.stringof));
 
     static if (Args.length == 1 && is(Args[0] : T) &&
-        //is (typeof({T t = args[0];})) //Check for legal postblit
-        is (typeof({T t = lvalueOf!(Args[0]);})) // @@@11497@@@
+        is (typeof({T t = args[0];})) //Check for legal postblit
         )
     {
         static if (is(T == Unqual!(Args[0])))


### PR DESCRIPTION
...inlining of function"

This reverts commit 8f10b877ead5e82e5c9a05fc2ed361ab6b08a398.

Itroduced by pull #1688. Because 11497 is now fixed.

Assigning to @AndrejMitrovic .
