### PR TITLE
Fix issue 11583.

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -893,3 +893,9 @@ unittest // 11600
     assertThrown!ConvException(to!BigInt("__reallynow__"));
     assertThrown!ConvException(to!BigInt("-123four"));
 }
+
+unittest // 11583
+{
+    BigInt x = 0;
+    assert((x > 0) == false);
+}

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -96,7 +96,7 @@ struct BigUint
 private:
     pure invariant() 
     {
-        assert( data.length == 1 || data[$-1] != 0 );
+        assert( data.length >= 1 && (data.length == 1 || data[$-1] != 0 ));
     }    
     immutable(BigDigit) [] data = ZERO;
     this(immutable(BigDigit) [] x) pure
@@ -214,7 +214,11 @@ public:
             BigDigit tmp = cast(BigDigit)(y>>(i*BigDigitBits));
             if (tmp == 0)
                 if (data.length >= i+1)
-                    return 1;
+                {
+                    // Since ZERO is [0], so we cannot simply return 1 here, as
+                    // data[i] would be 0 for i==0 in that case.
+                    return (data[i] > 0) ? 1 : 0;
+                }
                 else
                     continue;
             else


### PR DESCRIPTION
The problem is that the assumption that the first word of a `BigUint` is always non-zero is false when `BigUint` == `biguintcore.ZERO`, which is defined to be `[0]`. So we need to check for that case in `BigUint.opCmp(ulong)`.

Also, crash-proof `BigUint`'s invariant, since it would cause an out-of-bounds array access if a bug causes `data.length==0`.
