### PR TITLE
Result of __traits(parent) may not have a type

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -312,7 +312,7 @@ version(unittest)
  */
 template packageName(alias T)
 {
-    static if (is(typeof(__traits(parent, T))))
+    static if (__traits(compiles, __traits(parent, T)))
         enum parent = packageName!(__traits(parent, T));
     else
         enum string parent = null;


### PR DESCRIPTION
Found by fixing https://d.puremagic.com/issues/show_bug.cgi?id=9081

See https://github.com/D-Programming-Language/dmd/pull/2866
