### PR TITLE
Fix and test for JSONValue(true), JSONValue(false)

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -172,6 +172,10 @@ struct JSONValue
             type_tag = JSON_TYPE.STRING;
             store.str = arg;
         }
+        else static if(is(Unqual!T == bool))
+        {
+            type_tag = arg ? JSON_TYPE.TRUE : JSON_TYPE.FALSE;
+        }
         else static if(is(T : ulong) && isUnsigned!T)
         {
             type_tag = JSON_TYPE.UINTEGER;
@@ -216,10 +220,6 @@ struct JSONValue
                     new_arg[i] = JSONValue(e);
                 store.array = new_arg;
             }
-        }
-        else static if(is(T : bool))
-        {
-            type_tag = arg ? JSON_TYPE.TRUE : JSON_TYPE.FALSE;
         }
         else static if(is(T : JSONValue))
         {
@@ -888,6 +888,12 @@ unittest
     jv.array = [JSONValue(1), JSONValue(2), JSONValue(3)];
     assert(jv.type == JSON_TYPE.ARRAY);
     assert(jv.array == [JSONValue(1), JSONValue(2), JSONValue(3)]);
+
+    jv = true;
+    assert(jv.type == JSON_TYPE.TRUE);
+
+    jv = false;
+    assert(jv.type == JSON_TYPE.FALSE);
 }
 
 unittest


### PR DESCRIPTION
In current implementation, handling for boolean value was incomplete and was not able to assign true/false to JSONValue. This pull request allows to assign a boolean value and completes unittest.
