### PR TITLE
Remove useless Tuple from chain

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -2491,7 +2491,7 @@ if (Ranges.length > 0 &&
             }
 
 // This is the entire state
-            Tuple!R source;
+            R source;
 // TODO: use a vtable (or more) instead of linear iteration
 
         public:
@@ -2849,6 +2849,14 @@ unittest
             }
         }
     }
+}
+
+unittest
+{
+    class Foo{}
+    immutable(Foo)[] a;
+    immutable(Foo)[] b;
+    auto c = chain(a, b);
 }
 
 /**


### PR DESCRIPTION
http://forum.dlang.org/thread/jnnkjftmfizokokssixn@forum.dlang.org

Chain was using a Tuple to hold its internal state, which is actually 100% useless. Using it is a bad idea, since Tuples tend to always be the first to get hit by bugs, and introduce non-trivial operations (assign, cc, compare), all of which would be trivial otherwise.

So simply removing it seems like the right more to me.
