### PR TITLE
Make Tuple.toString conditional

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -547,6 +547,7 @@ template Tuple(Specs...)
         /**
          * Converts to string.
          */
+        static if (allSatisfy!(isPrintable, Types))
         string toString()
         {
             enum header = typeof(this).stringof ~ "(",
@@ -574,6 +575,14 @@ template Tuple(Specs...)
             return w.data;
         }
     }
+}
+
+private template isPrintable(T)
+{
+    enum isPrintable = is(typeof({
+        Appender!string w;
+        formattedWrite(w, "%s", T.init);
+    }));
 }
 
 private template Identity(alias T)
@@ -843,6 +852,11 @@ unittest
         auto t = tuple(1);
         t = tuple(2);   // assignment
     });
+}
+unittest
+{
+    class Foo{}
+    Tuple!(immutable(Foo)[]) a;
 }
 
 /**


### PR DESCRIPTION
Certain types are not actually printable (may be a bug). Because `toString` was not conditionally compiled, it was not even possible to _declare_ a tuple of such a type. With this fix, the Tuple will be declarable and useable, it'll just not be printable.

I'll file an issue for this later.
