### PR TITLE
import std.typecons outside unittests since it is needed

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -645,7 +645,7 @@ import std.traits, std.range, std.algorithm, std.conv,
 import std.array; //@@BUG UFCS doesn't work with 'local' imports
 import core.bitop;
 
-version(unittest) import std.typecons;
+import std.typecons;
 
 // debug = std_uni;
 


### PR DESCRIPTION
see the code I wrote here:
http://forum.dlang.org/thread/xmusisihhbmefeigvxvd@forum.dlang.org#post-sxbwtjnchkjzfqgocoxf:40forum.dlang.org

/home/me/d/dmd2/linux/bin32/../../src/phobos/std/uni.d(6301): Error: undefined identifier tuple
[snip]
test50.d(8): Error: template instance std.uni.normalize!(cast(NormalizationForm)0, dchar) error instantiating

std.typecons is needed outside of unittests too!
