### PR TITLE
Fix issue 11600: to!BigInt(string) should validate input.

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -878,3 +878,18 @@ unittest // 11148
     BigInt n = 2;
     n *= 2;
 }
+
+unittest // 11600
+{
+    import std.conv;
+    import std.exception : assertThrown;
+
+    // Original bug report
+    assertThrown!ConvException(to!BigInt("avadakedavra"));
+
+    // Digit string lookalikes that are actually invalid
+    assertThrown!ConvException(to!BigInt("0123hellothere"));
+    assertThrown!ConvException(to!BigInt("-hihomarylowe"));
+    assertThrown!ConvException(to!BigInt("__reallynow__"));
+    assertThrown!ConvException(to!BigInt("-123four"));
+}

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1467,6 +1467,8 @@ in
 }
 body
 {
+    import std.conv : ConvException;
+
     // Convert to base 1e19 = 10_000_000_000_000_000_000.
     // (this is the largest power of 10 that will fit into a long).
     // The length will be less than 1 + s.length/log2(10) = 1 + s.length/3.3219.
@@ -1488,6 +1490,8 @@ body
     {
         if (s[i] == '_')
             continue;
+        if (s[i] < '0' || s[i] > '9')
+            throw new ConvException("invalid digit");
         x *= 10;
         x += s[i] - '0';
         ++lo;


### PR DESCRIPTION
It's pretty hilarious to print the result of `to!BigInt("abracadabra")`, which is currently accepted by the `BigInt` code.

About the fix: I know the ddocs of `fromDecimalString` claims to return `false` upon invalid input, but this is not implemented, and I don't really like to change `biguintFromDecimal`'s function signature just so I can implement what the ddocs claim. So I'm opting to just throw when an invalid digit is found rather than go back to the bad ole C way of returning an error status that has to be checked by every function up the call stack. We have an exception system for a reason, after all.
