### PR TITLE
Fix issue 7767 - worst case of quick sort

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -9363,7 +9363,7 @@ private template HeapSortImpl(alias less, Range)
         if(r.length < 2) return;
 
         // Build Heap
-        size_t i = (r.length - 2) / 2 + 1;
+        size_t i = r.length / 2;
         while(i > 0) sift(r, --i, r.length);
 
         // Sort


### PR DESCRIPTION
The unstable sort in std.algorithm is currently implemented as quick sort. There are many cases which cause it to run in quadratic time. This has security implications and can result in a DoS attack.

This pull request resolves the problem by implementing heap sort as a fall-back algorithm, effectively changing it into an intro-sort. This will guarantee that the unstable sort runs in O(n log n) time in the worst-case.

Relevant discussion: http://forum.dlang.org/thread/prkthuzsmbppjltvohdh@forum.dlang.org
Bug report: http://d.puremagic.com/issues/show_bug.cgi?id=7767

EDIT: The auto-tester is occasionally failing on Darwin_32 and Darwin_64_64, but only the instance running on the Amazon server. It fails when testing std.parallelism with the error, "Unable to set thread priority." Other pull requests are experiencing the same failure.
