### PR TITLE
Remove more uses of NCEG operators in phobos

### DIFF
--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1504,7 +1504,7 @@ unittest {
     assert(digamma(1)== -EULERGAMMA);
     assert(feqrel(digamma(0.25), -PI/2 - 3* LN2 - EULERGAMMA) >= real.mant_dig-7);
     assert(feqrel(digamma(1.0L/6), -PI/2 *sqrt(3.0L) - 2* LN2 -1.5*log(3.0L) - EULERGAMMA) >= real.mant_dig-7);
-    assert(digamma(-5)!<>0);
+    assert(digamma(-5).isNaN);
     assert(feqrel(digamma(2.5), -EULERGAMMA - 2*LN2 + 2.0 + 2.0L/3) >= real.mant_dig-9);
     assert(isIdentical(digamma(NaN(0xABC)), NaN(0xABC)));
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -714,7 +714,7 @@ T findRoot(T, R)(scope R delegate(T) f, T a, T b)
 {
     auto r = findRoot(f, a, b, f(a), f(b), (T lo, T hi){ return false; });
     // Return the first value if it is smaller or NaN
-    return fabs(r[2]) !> fabs(r[3]) ? r[0] : r[1];
+    return !(fabs(r[2]) > fabs(r[3])) ? r[0] : r[1];
 }
 
 /** Find root of a real function f(x) by bracketing, allowing the
@@ -777,7 +777,7 @@ body {
     void bracket(T c)
     {
         T fc = f(c);
-        if (fc !<> 0) { // Exact solution, or NaN
+        if (fc == 0 || fc.isNaN) { // Exact solution, or NaN
             a = c;
             fa = fc;
             d = c;
@@ -847,11 +847,11 @@ body {
     }
 
     // On the first iteration we take a secant step:
-    if (fa !<> 0) {
+    if (fa == 0 || fa.isNaN) {
         done = true;
         b = a;
         fb = fa;
-    } else if (fb !<> 0) {
+    } else if (fb == 0 || fb.isNaN) {
         done = true;
         a = b;
         fa = fb;
@@ -891,7 +891,7 @@ whileloop:
                 real d32 = (d31 - q21) * fd / (fd - fa);
                 real q33 = (d32 - q22) * fa / (fe - fa);
                 c = a + (q31 + q32 + q33);
-                if (c!<>=0 || (c <= a) || (c >= b)) {
+                if (c.isNaN || (c <= a) || (c >= b)) {
                     // DAC: If the interpolation predicts a or b, it's
                     // probable that it's the actual root. Only allow this if
                     // we're already close to the root.
@@ -909,7 +909,7 @@ whileloop:
                 // DAC: Alefeld doesn't explain why the number of newton steps
                 // should vary.
                 c = newtonQuadratic(distinct ? 3 : 2);
-                if(c!<>=0 || (c <= a) || (c >= b)) {
+                if(c.isNaN || (c <= a) || (c >= b)) {
                     // Failure, try a secant step:
                     c = secant_interpolate(a, b, fa, fb);
                 }
@@ -936,7 +936,7 @@ whileloop:
         c = u - 2 * (fu / (fb - fa)) * (b - a);
         // DAC: If the secant predicts a value equal to an endpoint, it's
         // probably false.
-        if(c==a || c==b || c!<>=0 || fabs(c - u) > (b - a) / 2) {
+        if(c==a || c==b || c.isNaN || fabs(c - u) > (b - a) / 2) {
             if ((a-b) == a || (b-a) == b) {
                 if ( (a>0 && b<0) || (a<0 && b>0) ) c = 0;
                 else {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -45,7 +45,7 @@ Authors:   $(WEB erdani.org, Andrei Alexandrescu),
 module std.typecons;
 import core.memory, core.stdc.stdlib;
 import std.algorithm, std.array, std.conv, std.exception, std.format,
-    std.string, std.traits, std.typetuple, std.range;
+    std.math, std.string, std.traits, std.typetuple, std.range;
 
 debug(Unique) import std.stdio;
 
@@ -1842,7 +1842,7 @@ unittest
     {
         interface I_1 { real test(); }
         auto o = new BlackHole!I_1;
-        assert(o.test() !<>= 0); // NaN
+        assert(o.test().isNaN); // NaN
     }
     // doc example
     {
@@ -1859,7 +1859,7 @@ unittest
         auto c = new BlackHole!C(42);
         assert(c.value == 42);
 
-        assert(c.realValue !<>= 0); // NaN
+        assert(c.realValue.isNaN); // NaN
         c.doSomething();
     }
 }


### PR DESCRIPTION
The one in gammafunction appears to be a mistake - digamma(-5) returns NaN.
