### PR TITLE
Fix missed cases of <>= operator

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -32244,7 +32244,7 @@ version(testStdDateTime) @safe unittest
 {
     @safe static void func(TickDuration td)
     {
-        assert(td.to!("seconds", real)() <>= 0);
+        assert(!td.to!("seconds", real)().isNaN);
     }
 
     auto mt = measureTime!(func)();
@@ -32262,7 +32262,7 @@ version(testStdDateTime) unittest
 {
     static void func(TickDuration td)
     {
-        assert(td.to!("seconds", real)() <>= 0);
+        assert(!td.to!("seconds", real)().isNaN);
     }
 
     auto mt = measureTime!(func)();

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -753,7 +753,7 @@ T findRoot(T, R)(scope R delegate(T) f, T a, T b)
 Tuple!(T, T, R, R) findRoot(T,R)(scope R delegate(T) f, T ax, T bx, R fax, R fbx,
     scope bool delegate(T lo, T hi) tolerance)
 in {
-    assert(ax<>=0 && bx<>=0, "Limits must not be NaN");
+    assert(!ax.isNaN && !bx.isNaN, "Limits must not be NaN");
     assert(signbit(fax) != signbit(fbx), "Parameters must bracket the root.");
 }
 body {
@@ -999,7 +999,7 @@ unittest
     void testFindRoot(real delegate(real) f, real x1, real x2) {
         numCalls=0;
         ++numProblems;
-        assert(x1<>=0 && x2<>=0);
+        assert(!x1.isNaN && !x2.isNaN);
         assert(signbit(x1) != signbit(x2));
         auto result = findRoot(f, x1, x2, f(x1), f(x2),
           (real lo, real hi) { return false; });


### PR DESCRIPTION
Because I forgot not all nceg operators match `![<>]`
