### PR TITLE
Make an unit test of std.math IEEE 754-2008 compliant.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -1881,13 +1881,13 @@ unittest
     resetIeeeFlags();
     x = exp(real.nan);
     f = ieeeFlags;
-    assert(isIdentical(x,real.nan));
+    assert(isIdentical(abs(x), real.nan));
     assert(f.flags == 0);
 
     resetIeeeFlags();
     x = exp(-real.nan);
     f = ieeeFlags;
-    assert(isIdentical(x, -real.nan));
+    assert(isIdentical(abs(x), real.nan));
     assert(f.flags == 0);
 
     x = exp(NaN(0x123));


### PR DESCRIPTION
IEEE 754-2008 does not specify the sign bit of a NaN. The exceptions to this rule are the operations copy, negate, abs and copySign. In all other cases, the standard does not specify the sign bit (chapter 6.3 on page 35).

The unit test I like to change with this pull request assumes that the sign bit of a NaN is propagated through the exp() computation. This assumption violates IEEE 754-2008.

My fix is the use of abs() on the result, because this operation changes the sign bit of a NaN in a compliant way.

There might be other places which must be fixed but this one really hurts me.
