### PR TITLE
fix SO version names

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -147,11 +147,12 @@ VERSION=../dmd/VERSION
 # Set LIB, the ultimate target
 ifeq (,$(findstring win,$(OS)))
 	LIB:=$(ROOT)/libphobos2.a
-	# 2.064.2 => libphobos2.so.64.2.0
-	# 2.065 => libphobos2.so.65.0.0
-	MAJOR:=$(shell awk -F. '{ print int($$2) }' $(VERSION))
-	MINOR:=$(shell awk -F. '{ print int($$3) }' $(VERSION))
-	PATCH:=0
+	# 2.064.2 => libphobos2.so.0.64.2
+	# 2.065 => libphobos2.so.0.65.0
+	# MAJOR version is 0 for now, which means the ABI is still unstable
+	MAJOR:=0
+	MINOR:=$(shell awk -F. '{ print int($$2) }' $(VERSION))
+	PATCH:=$(shell awk -F. '{ print int($$3) }' $(VERSION))
 	# SONAME doesn't use patch level (ABI compatible)
 	SONAME:=libphobos2.so.$(MAJOR).$(MINOR)
 	LIBSO:=$(ROOT)/$(SONAME).$(PATCH)


### PR DESCRIPTION
- MAJOR is always 0 for now, as we still have an unstable ABI
- MINOR version is 64 part of 2.064.2
- PATCH is .2 part of 2.064.2
