### PR TITLE
Fix Issue 11681 - std.datetime.IntervalRange.opAssign with non-ref parameter is required

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26393,10 +26393,7 @@ public:
     }
 
 
-    /++
-        Params:
-            rhs = The $(D IntervalRange) to assign to this one.
-      +/
+    /++ Ditto +/
     /+ref+/ IntervalRange opAssign(IntervalRange rhs) pure nothrow
     {
         return this = rhs;
@@ -26920,10 +26917,7 @@ public:
     }
 
 
-    /++
-        Params:
-            rhs = The $(D PosInfIntervalRange) to assign to this one.
-      +/
+    /++ Ditto +/
     /+ref+/ PosInfIntervalRange opAssign(PosInfIntervalRange rhs) pure nothrow
     {
         return this = rhs;
@@ -27229,10 +27223,7 @@ public:
     }
 
 
-    /++
-        Params:
-            rhs = The $(D NegInfIntervalRange) to assign to this one.
-      +/
+    /++ Ditto +/
     /+ref+/ NegInfIntervalRange opAssign(NegInfIntervalRange rhs) pure nothrow
     {
         return this = rhs;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11681

This change enables an rvalue to assigned to IntervalRange/PosInfIntervalRange/NegInfIntervalRange.

``` d
auto interval1 = NegInfInterval!Date(Date(2013, 1, 1));
auto interval2 = NegInfInterval!Date(Date(2014, 2, 1));

auto range1 = interval1.bwdRange(a => a - 1.days);
auto range2 = interval2.bwdRange(a => a - 1.days);

//  range1 = range2; // already possible
range1 = range2.save; // ok
range1 = interval2.bwdRange(a => a - 2.days); // ok
```
