### PR TITLE
Issue 11512 - Can't build Phobos docs with win32 makefile

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -60,7 +60,7 @@ DMD=dmd
 
 ## Location of where to write the html documentation files
 
-DOCSRC = .
+DOCSRC = ../dlang.org
 STDDOC = $(DOCSRC)/std.ddoc
 
 DOC=..\..\html\d\phobos

--- a/win64.mak
+++ b/win64.mak
@@ -60,7 +60,7 @@ DMD=dmd
 
 ## Location of where to write the html documentation files
 
-DOCSRC = .
+DOCSRC = ../dlang.org
 STDDOC = $(DOCSRC)/std.ddoc
 
 DOC=..\..\html\d\phobos


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11512

Change default value of `DOCSRC` to `../dlang.org` (It is same as the value in `posix.mak`)
