### PR TITLE
Fix spelling mistake in doc comment

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -6889,7 +6889,7 @@ unittest
 This range iterates over fixed-sized chunks of size $(D chunkSize) of a
 $(D source) range. $(D Source) must be a forward range.
 
-If $(D !isInfinitite!Source) and $(D source.walkLength) is not evenly
+If $(D !isInfinite!Source) and $(D source.walkLength) is not evenly
 divisible by $(D chunkSize), the back element of this range will contain
 fewer than $(D chunkSize) elements.
 


### PR DESCRIPTION
About as trivial as it gets.
