### PR TITLE
Fix completely trivial typo in std.process.execute documentation

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1883,7 +1883,7 @@ auto dmd = execute(["dmd", "myapp.d"]);
 if (dmd.status != 0) writeln("Compilation failed:\n", dmd.output);
 
 auto ls = executeShell("ls -l");
-if (ls.status == 0) writeln("Failed to retrieve file listing");
+if (ls.status != 0) writeln("Failed to retrieve file listing");
 else writeln(ls.output);
 ---
 


### PR DESCRIPTION
Fix a (trivial) typo in the std.process.execute documentation --- the code compiled but had the opposite effect than what was suggested.
