### PR TITLE
fix Issue 10710 - phobos depends on versioned libcurl

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -31,7 +31,7 @@
 
 module etc.c.curl;
 
-pragma(lib, "curl");
+version (Windows) pragma(lib, "curl");
 
 import core.stdc.time;
 import core.stdc.config;

--- a/posix.mak
+++ b/posix.mak
@@ -168,6 +168,9 @@ else
 	LIB:=$(ROOT)/phobos.lib
 endif
 
+LIBCURL_STUB:=$(if $(findstring $(OS),linux),$(ROOT)/libcurl_stub.so,)
+LINKCURL:=$(if $(LIBCURL_STUB),-L$(LIBCURL_STUB),-L-lcurl)
+
 ################################################################################
 MAIN = $(ROOT)/emptymain.d
 
@@ -282,8 +285,13 @@ $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
 $(ROOT)/$(SONAME): $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
-$(LIBSO): $(OBJS) $(ALL_D_FILES) druntime_libs
-	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
+$(LIBSO): $(OBJS) $(ALL_D_FILES) druntime_libs $(LIBCURL_STUB)
+	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(LINKCURL) $(D_FILES) $(OBJS)
+
+# stub library with soname of the real libcurl.so (Bugzilla 10710)
+$(LIBCURL_STUB):
+	@echo "void curl_global_init() {}" > $(ROOT)/libcurl_stub.c
+	$(CC) -shared $(CFLAGS) $(ROOT)/libcurl_stub.c -o $@ -Wl,-soname=libcurl.so.4
 
 ifeq (osx,$(OS))
 # Build fat library that combines the 32 bit and the 64 bit libraries
@@ -311,15 +319,15 @@ $(UT_D_OBJS): $(ROOT)/unittest/%.o: %.d
 ifneq (linux,$(OS))
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) druntime_libs
-	$(DMD) $(DFLAGS) -unittest -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) -defaultlib= -debuglib= -L-lcurl
+	$(DMD) $(DFLAGS) -unittest -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKCURL) -defaultlib= -debuglib=
 
 else
 
 UT_LIBSO:=$(ROOT)/unittest/libphobos2-ut.so
 
 $(UT_LIBSO): override PIC:=-fPIC
-$(UT_LIBSO): $(UT_D_OBJS) $(OBJS) druntime_libs
-	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib= -L-lcurl
+$(UT_LIBSO): $(UT_D_OBJS) $(OBJS) druntime_libs $(LIBCURL_STUB)
+	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) $(LINKCURL) -defaultlib= -debuglib=
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_LIBSO)
 	$(DMD) $(DFLAGS) -of$@ $< -L$(UT_LIBSO) -defaultlib= -debuglib=

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -188,7 +188,7 @@ version(unittest)
 }
 version(StdDdoc) import std.stdio;
 
-pragma(lib, "curl");
+version (Windows) pragma(lib, "curl");
 extern (C) void exit(int);
 
 // Default data timeout for Protcools


### PR DESCRIPTION
- create a libcurl_stub.so for linking
- set it's soname to libcurl.so.4 so that phobos
  gets a DT_NEEDED libcurl.so.4 entry
- the runtime linker will load libcurl.so and resolve
  all undefined references
- disable pragma(lib, "curl") because it doesn't work
  for archives anyways and additionally links against
  the real libcurl

Fixes [Issue 10710 – shared phobos library doesn't work on all linux distributions](https://d.puremagic.com/issues/show_bug.cgi?id=10710).
Simplifies building phobos (see [here](https://github.com/D-Programming-Language/installer/pull/24#issuecomment-30482436)).
