### PR TITLE
Change DDoc examples in std.algorithm to documented unittests

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -401,10 +401,15 @@ function.
 */
 unittest
 {
-    auto arr1 = [ 1, 2, 3, 4 ];
-    foreach (e; map!("a + a", "a * a")(arr1))
+    auto sums = [2, 4, 6, 8];
+    auto products = [1, 4, 9, 16];
+
+    size_t i = 0;
+    foreach (result; [ 1, 2, 3, 4 ].map!("a + a", "a * a"))
     {
-        writeln(e[0], " ", e[1]);
+        assert(result[0] == sums[i]);
+        assert(result[1] == products[i]);
+        ++i;
     }
 }
 


### PR DESCRIPTION
And fix all the tests that proved broken, which turned out to be quite a few. Some of them contained rather nonsensical code, presumably relics of copy-paste (e.g. see the `intersection3` example). I think the amount of broken examples discovered by this really proves the usefulness of this new feature.

Examples that reside in between general explanations were left untouched for now.
