### PR TITLE
Turned Examples section in std.digest.* into documented unittest

### DIFF
--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -46,39 +46,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of))
  *
  * CTFE:
  * Digests do not work in CTFE
- *
- * Examples:
- * ---------
- * //Template API
- * import std.digest.crc;
- *
- * ubyte[4] hash = crc32Of("The quick brown fox jumps over the lazy dog");
- * assert(crcHexString(hash) == "414FA339");
- *
- * //Feeding data
- * ubyte[1024] data;
- * CRC32 crc;
- * crc.put(data[]);
- * crc.start(); //Start again
- * crc.put(data[]);
- * hash = crc.finish();
- * ---------
- *
- * ---------
- * //OOP API
- * import std.digest.crc;
- *
- * auto crc = new CRC32Digest();
- * ubyte[] hash = crc.digest("The quick brown fox jumps over the lazy dog");
- * assert(crcHexString(hash) == "414FA339");
- *
- * //Feeding data
- * ubyte[1024] data;
- * crc.put(data[]);
- * crc.reset(); //Start again
- * crc.put(data[]);
- * hash = crc.finish();
- * ---------
  */
 /*
  * Copyright (c) 2001 - 2002
@@ -98,7 +65,7 @@ version(unittest)
 
 import std.bitmanip;
 
-//verify example
+///
 unittest
 {
     //Template API
@@ -116,7 +83,7 @@ unittest
     hash = crc.finish();
 }
 
-//verify example
+///
 unittest
 {
     //OOP API
@@ -178,36 +145,6 @@ private immutable uint[256] crc32_table =
 /**
  * Template API CRC32 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using crc32Of helper function
- * ubyte[4] hash = crc32Of("abc");
- * //Let's get a hash string
- * assert(crcHexString(hash) == "352441C2");
- * --------
- *
- * --------
- * //Using the basic API
- * CRC32 hash;
- * ubyte[1024] data;
- * //Initialize data here...
- * hash.put(data);
- * ubyte[4] result = hash.finish();
- * --------
- *
- * --------
- * //Let's use the template features:
- * //Note: When passing a CRC32 to a function, it must be passed by reference!
- * void doSomething(T)(ref T hash) if(isDigest!T)
- * {
- *     hash.put(cast(ubyte)0);
- * }
- * CRC32 crc;
- * crc.start();
- * doSomething(crc);
- * assert(crcHexString(crc.finish()) == "D202EF8D");
- * --------
  */
 struct CRC32
 {
@@ -220,20 +157,20 @@ struct CRC32
          * Use this to feed the digest with data.
          * Also implements the $(XREF range, OutputRange) interface for $(D ubyte) and
          * $(D const(ubyte)[]).
-         *
-         * Examples:
-         * ----
-         * CRC32 dig;
-         * dig.put(cast(ubyte)0); //single ubyte
-         * dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
-         * ubyte[10] buf;
-         * dig.put(buf); //buffer
-         * ----
          */
         @trusted pure nothrow void put(scope const(ubyte)[] data...)
         {
             foreach (val; data)
                 _state = (_state >> 8) ^ crc32_table[cast(ubyte)_state ^ val];
+        }
+        ///
+        unittest
+        {
+            CRC32 dig;
+            dig.put(cast(ubyte)0); //single ubyte
+            dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+            ubyte[10] buf;
+            dig.put(buf); //buffer
         }
 
         /**
@@ -244,36 +181,36 @@ struct CRC32
          * is not necessary. Calling start is only necessary to reset the Digest.
          *
          * Generic code which deals with different Digest types should always call start though.
-         *
-         * Examples:
-         * --------
-         * CRC32 digest;
-         * //digest.start(); //Not necessary
-         * digest.put(0);
-         * --------
          */
         @trusted pure nothrow void start()
         {
             this = CRC32.init;
         }
+        ///
+        unittest
+        {
+            CRC32 digest;
+            //digest.start(); //Not necessary
+            digest.put(0);
+        }
 
         /**
          * Returns the finished CRC32 hash. This also calls $(LREF start) to
          * reset the internal state.
-         *
-         * Examples:
-         * --------
-         * //Simple example
-         * CRC32 hash;
-         * hash.put(cast(ubyte)0);
-         * ubyte[4] result = hash.finish();
-         * --------
          */
         @trusted pure nothrow ubyte[4] finish()
         {
             auto tmp = peek();
             start();
             return tmp;
+        }
+        ///
+        unittest
+        {
+            //Simple example
+            CRC32 hash;
+            hash.put(cast(ubyte)0);
+            ubyte[4] result = hash.finish();
         }
 
         /**
@@ -287,7 +224,7 @@ struct CRC32
         }
 }
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using crc32Of helper function
@@ -296,7 +233,7 @@ unittest
     assert(crcHexString(hash) == "352441C2");
 }
 
-//verify example
+///
 unittest
 {
     //Using the basic API
@@ -307,11 +244,11 @@ unittest
     ubyte[4] result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     //Let's use the template features:
-    //Note: When passing a CRC32 to a function, it must be passed by referece!
+    //Note: When passing a CRC32 to a function, it must be passed by reference!
     void doSomething(T)(ref T hash) if(isDigest!T)
     {
       hash.put(cast(ubyte)0);
@@ -369,12 +306,6 @@ unittest
 /**
  * This is a convenience alias for $(XREF digest.digest, digest) using the
  * CRC32 implementation.
- *
- * Examples:
- * ---------
- * ubyte[4] hash = crc32Of("abc");
- * assert(hash == digest!CRC32("abc")); //This is the same as above
- * ---------
  */
 //simple alias doesn't work here, hope this gets inlined...
 auto crc32Of(T...)(T data)
@@ -390,7 +321,7 @@ public alias toHexString!(Order.decreasing) crcHexString;
 ///ditto
 public alias toHexString!(Order.decreasing, 16) crcHexString;
 
-//verify example
+///
 unittest
 {
     ubyte[4] hash = crc32Of("abc");
@@ -403,34 +334,10 @@ unittest
  *
  * This is an alias for $(XREF digest.digest, WrapperDigest)!CRC32, see
  * $(XREF digest.digest, WrapperDigest) for more information.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using Digest.digest helper function
- * auto crc = new CRC32Digest();
- * ubyte[] hash = crc.digest("abc");
- * //Let's get a hash string
- * assert(crcHexString(hash) == "352441C2");
- * --------
- *
- * --------
- * //Let's use the OOP features:
- * void test(Digest dig)
- * {
- *     dig.put(cast(ubyte)0);
- * }
- * auto crc = new CRC32Digest();
- * test(crc);
- *
- * //Let's use a custom buffer:
- * ubyte[4] buf;
- * ubyte[] result = crc.finish(buf[]);
- * assert(crcHexString(result) == "D202EF8D");
- * --------
  */
 alias WrapperDigest!CRC32 CRC32Digest;
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
@@ -440,7 +347,7 @@ unittest
     assert(crcHexString(hash) == "352441C2");
 }
 
-//verify example
+///
 unittest
 {
      //Let's use the OOP features:
@@ -457,7 +364,7 @@ unittest
     assert(crcHexString(result) == "D202EF8D");
 }
 
-//verify example
+///
 unittest
 {
     //Simple example
@@ -466,7 +373,7 @@ unittest
     ubyte[] result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     //using a supplied buffer

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -53,117 +53,6 @@ $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDi
  * CTFE:
  * Digests do not work in CTFE
  *
- * Examples:
- * ---------
- * import std.digest.crc;
- *
- * //Simple example
- * char[8] hexHash = hexDigest!CRC32("The quick brown fox jumps over the lazy dog");
- * assert(hexHash == "39A34F41");
- *
- * //Simple example, using the API manually
- * CRC32 context = makeDigest!CRC32();
- * context.put(cast(ubyte[])"The quick brown fox jumps over the lazy dog");
- * ubyte[4] hash = context.finish();
- * assert(toHexString(hash) == "39A34F41");
- * ---------
- *
- * ---------
- * //Generating the hashes of a file, idiomatic D way
- * import std.digest.crc, std.digest.sha, std.digest.md;
- * import std.stdio;
- *
- * // Digests a file and prints the result.
- * void digestFile(Hash)(string filename) if(isDigest!Hash)
- * {
- *     auto file = File(filename);
- *     auto result = digest!Hash(file.byChunk(4096 * 1024));
- *     writefln("%s (%s) = %s", Hash.stringof, filename, toHexString(result));
- * }
- *
- * void main(string[] args)
- * {
- *     foreach (name; args[1 .. $])
- *     {
- *         digestFile!MD5(name);
- *         digestFile!SHA1(name);
- *         digestFile!CRC32(name);
- *     }
- * }
- * ---------
- *
- * ---------
- * //Generating the hashes of a file using the template API, old school way
- * import std.digest.crc, std.digest.sha, std.digest.md;
- * import std.stdio;
- *
- * void main(string[] args)
- * {
- *     MD5 md5;
- *     SHA1 sha1;
- *     CRC32 crc32;
- *
- *     md5.start();
- *     sha1.start();
- *     crc32.start();
- *
- *     foreach (arg; args[1 .. $])
- *     {
- *         digestFile(md5, arg);
- *         digestFile(sha1, arg);
- *         digestFile(crc32, arg);
- *     }
- * }
- *
- * // Digests a file and prints the result.
- * void digestFile(Hash)(ref Hash hash, string filename) if(isDigest!Hash)
- * {
- *     File file = File(filename);
- *
- *     //As digests implement OutputRange, we could use std.algorithm.copy
- *     //Let's do it manually for now
- *     foreach (buffer; file.byChunk(4096 * 1024))
- *         hash.put(buffer);
- *
- *     auto result = hash.finish();
- *     writefln("%s (%s) = %s", hash.stringof, filename, toHexString(result));
- * }
- * ---------
- *
- * ---------
- * //The same using the OOP API
- * import std.digest.crc, std.digest.sha, std.digest.md;
- * import std.stdio;
- *
- * void main(string[] args)
- * {
- *     auto md5 = new MD5Digest();
- *     auto sha1 = new SHA1Digest();
- *     auto crc32 = new CRC32Digest();
- *
- *     foreach (arg; args[1 .. $])
- *     {
- *         digestFile(md5, arg);
- *         digestFile(sha1, arg);
- *         digestFile(crc32, arg);
- *     }
- * }
- *
- * // Digests a file and prints the result.
- * void digestFile(Digest hash, string filename)
- * {
- *     File file = File(filename);
- *
- *     //As digests implement OutputRange, we could use std.algorithm.copy
- *     //Let's do it manually for now
- *     foreach (buffer; file.byChunk(4096 * 1024))
- *         hash.put(buffer);
- *
- *     ubyte[] result = hash.finish();
- *     writefln("%s (%s) = %s", typeid(hash).toString(), filename, toHexString(result));
- * }
- * ---------
- *
  * TODO:
  * Digesting single bits (as opposed to bytes) is not implemented. This will be done as another
  * template constraint helper (hasBitDigesting!T) and an additional interface (BitDigest)
@@ -180,7 +69,7 @@ import std.algorithm : copy;
 import std.typetuple : allSatisfy;
 import std.ascii : LetterCase;
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -196,7 +85,7 @@ unittest
     assert(toHexString(hash) == "39A34F41");
 }
 
-//verify example
+///
 unittest
 {
     //Generating the hashes of a file, idiomatic D way
@@ -221,7 +110,7 @@ unittest
         }
     }
 }
-//verify example
+///
 unittest
 {
     //Generating the hashes of a file using the template API
@@ -260,7 +149,7 @@ unittest
     }
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc, std.digest.sha, std.digest.md;
@@ -310,19 +199,6 @@ version(ExampleDigest)
      * $(LI A digest must be a struct (value type) to pass the $(LREF isDigest) test.)
      * $(LI A digest passing the $(LREF isDigest) test is always an $(D OutputRange))
      * )
-     *
-     * Examples:
-     * ----
-     * //Using the OutputRange feature
-     * import std.algorithm : copy;
-     * import std.range : repeat;
-     * import std.digest.md;
-     *
-     * auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
-     * auto ctx = makeDigest!MD5();
-     * copy(oneMillionRange, &ctx); //Note: You must pass a pointer to copy!
-     * assert(ctx.finish().toHexString() == "7707D6AE4E027C70EEA2A935C2296F21");
-     * ----
      */
     struct ExampleDigest
     {
@@ -376,7 +252,7 @@ version(ExampleDigest)
     }
 }
 
-//verify example
+///
 unittest
 {
     //Using the OutputRange feature
@@ -397,21 +273,6 @@ unittest
  * Note:
  * This is very useful as a template constraint (see examples)
  *
- * Examples:
- * ---------
- * import std.digest.crc;
- * static assert(isDigest!CRC32);
- * ---------
- *
- * ---------
- * void myFunction(T)() if(isDigest!T)
- * {
- *     T dig;
- *     dig.start();
- *     auto result = dig.finish();
- * }
- * ---------
- *
  * BUGS:
  * $(UL
  * $(LI Does not yet verify that put takes scope parameters.)
@@ -431,13 +292,13 @@ template isDigest(T)
         }));
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
     static assert(isDigest!CRC32);
 }
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -452,19 +313,6 @@ unittest
 
 /**
  * Use this template to get the type which is returned by a digest's $(LREF finish) method.
- *
- * Examples:
- * --------
- * import std.digest.crc;
- * assert(is(DigestType!(CRC32) == ubyte[4]));
- * --------
- *
- * --------
- * import std.digest.crc;
- * CRC32 dig;
- * dig.start();
- * DigestType!CRC32 result = dig.finish();
- * --------
  */
 template DigestType(T)
 {
@@ -480,13 +328,13 @@ template DigestType(T)
         static assert(false, T.stringof ~ " is not a digest! (fails isDigest!T)");
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
     assert(is(DigestType!(CRC32) == ubyte[4]));
 }
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -505,22 +353,6 @@ unittest
  * $(LI This is very useful as a template constraint (see examples))
  * $(LI This also checks if T passes $(LREF isDigest))
  * )
- *
- * Examples:
- * ---------
- * import std.digest.crc, std.digest.md;
- * assert(!hasPeek!(MD5));
- * assert(hasPeek!CRC32);
- * ---------
- *
- * ---------
- * void myFunction(T)() if(hasPeek!T)
- * {
- *     T dig;
- *     dig.start();
- *     auto result = dig.peek();
- * }
- * ---------
  */
 template hasPeek(T)
 {
@@ -532,14 +364,14 @@ template hasPeek(T)
         }));
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc, std.digest.md;
     assert(!hasPeek!(MD5));
     assert(hasPeek!CRC32);
 }
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -569,14 +401,6 @@ private template isDigestibleRange(Range)
  *
  * Params:
  *  range= an $(D InputRange) with $(D ElementType) $(D ubyte), $(D ubyte[]) or $(D ubyte[num])
- *
- *
- * Examples:
- * ---------
- * import std.digest.md;
- * auto testRange = repeat!ubyte(cast(ubyte)'a', 100);
- * auto md5 = digest!MD5(testRange);
- * ---------
  */
 DigestType!Hash digest(Hash, Range)(auto ref Range range) if(!isArray!Range
     && isDigestibleRange!Range)
@@ -587,7 +411,7 @@ DigestType!Hash digest(Hash, Range)(auto ref Range range) if(!isArray!Range
     return hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md;
@@ -600,22 +424,6 @@ unittest
  *
  * Params:
  *  data= one or more arrays of any type
- *
- * Examples:
- * ---------
- * import std.digest.md, std.digest.sha, std.digest.crc;
- * auto md5   = digest!MD5(  "The quick brown fox jumps over the lazy dog");
- * auto sha1  = digest!SHA1( "The quick brown fox jumps over the lazy dog");
- * auto crc32 = digest!CRC32("The quick brown fox jumps over the lazy dog");
- * assert(toHexString(crc32) == "39A34F41");
- * ---------
- *
- * ---------
- * //It's also possible to pass multiple values to this function:
- * import std.digest.crc;
- * auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString(crc32) == "39A34F41");
- * ---------
  */
 DigestType!Hash digest(Hash, T...)(scope const T data) if(allSatisfy!(isArray, typeof(data)))
 {
@@ -626,7 +434,7 @@ DigestType!Hash digest(Hash, T...)(scope const T data) if(allSatisfy!(isArray, t
     return hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md, std.digest.sha, std.digest.crc;
@@ -636,7 +444,7 @@ unittest
     assert(toHexString(crc32) == "39A34F41");
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -652,14 +460,6 @@ unittest
  * Params:
  *  order= the order in which the bytes are processed (see $(LREF toHexString))
  *  range= an $(D InputRange) with $(D ElementType) $(D ubyte), $(D ubyte[]) or $(D ubyte[num])
- *
- *
- * Examples:
- * ---------
- * import std.digest.md;
- * auto testRange = repeat!ubyte(cast(ubyte)'a', 100);
- * assert(hexDigest!MD5(testRange) == "36A92CC94A9E0FA21F625F8BFB007ADF");
- * ---------
  */
 char[digestLength!(Hash)*2] hexDigest(Hash, Order order = Order.increasing, Range)(ref Range range)
     if(!isArray!Range && isDigestibleRange!Range)
@@ -667,7 +467,7 @@ char[digestLength!(Hash)*2] hexDigest(Hash, Order order = Order.increasing, Rang
     return toHexString!order(digest!Hash(range));
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md;
@@ -681,18 +481,6 @@ unittest
  * Params:
  *  order= the order in which the bytes are processed (see $(LREF toHexString))
  *  data= one or more arrays of any type
- *
- * Examples:
- * ---------
- * import std.digest.crc;
- * assert(hexDigest!(CRC32, Order.decreasing)("The quick brown fox jumps over the lazy dog") == "414FA339");
- * ---------
- *
- * ---------
- * //It's also possible to pass multiple values to this function:
- * import std.digest.crc;
- * assert(hexDigest!(CRC32, Order.decreasing)("The quick ", "brown ", "fox jumps over the lazy dog") == "414FA339");
- * ---------
  */
 char[digestLength!(Hash)*2] hexDigest(Hash, Order order = Order.increasing, T...)(scope const T data)
     if(allSatisfy!(isArray, typeof(data)))
@@ -700,13 +488,13 @@ char[digestLength!(Hash)*2] hexDigest(Hash, Order order = Order.increasing, T...
     return toHexString!order(digest!Hash(data));
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
     assert(hexDigest!(CRC32, Order.decreasing)("The quick brown fox jumps over the lazy dog") == "414FA339");
 }
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -716,14 +504,6 @@ unittest
 /**
  * This is a convenience function which returns an initialized digest, so it's not necessary to call
  * start manually.
- *
- * Examples:
- * ---------
- * import std.digest.md;
- * auto md5 = makeDigest!MD5();
- * md5.put("Hello");
- * assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
- * ---------
  */
 Hash makeDigest(Hash)()
 {
@@ -732,7 +512,7 @@ Hash makeDigest(Hash)()
     return hash;
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md;
@@ -751,19 +531,6 @@ unittest
  *
  * Note:
  * A Digest implementation is always an $(D OutputRange)
- *
- * Examples:
- * ----
- * //Using the OutputRange feature
- * import std.algorithm : copy;
- * import std.range : repeat;
- * import std.digest.md;
- *
- * auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
- * auto ctx = new MD5Digest();
- * copy(oneMillionRange, ctx);
- * assert(ctx.finish().toHexString() == "7707D6AE4E027C70EEA2A935C2296F21");
- * ----
  */
 interface Digest
 {
@@ -815,22 +582,6 @@ interface Digest
 
         /**
          * This is a convenience function to calculate the hash of a value using the OOP API.
-         *
-         * Examples:
-         * ---------
-         * import std.digest.md, std.digest.sha, std.digest.crc;
-         * ubyte[] md5   = (new MD5Digest()).digest("The quick brown fox jumps over the lazy dog");
-         * ubyte[] sha1  = (new SHA1Digest()).digest("The quick brown fox jumps over the lazy dog");
-         * ubyte[] crc32 = (new CRC32Digest()).digest("The quick brown fox jumps over the lazy dog");
-         * assert(crcHexString(crc32) == "414FA339");
-         * ---------
-         *
-         * ---------
-         * //It's also possible to pass multiple values to this function:
-         * import std.digest.crc;
-         * ubyte[] crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
-         * assert(crcHexString(crc32) == "414FA339");
-         * ---------
          */
         final @trusted nothrow ubyte[] digest(scope const(void[])[] data...)
         {
@@ -841,7 +592,7 @@ interface Digest
         }
 }
 
-//verify example
+///
 unittest
 {
     //Using the OutputRange feature
@@ -855,7 +606,7 @@ unittest
     assert(ctx.finish().toHexString() == "7707D6AE4E027C70EEA2A935C2296F21");
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md, std.digest.sha, std.digest.crc;
@@ -865,7 +616,7 @@ unittest
     assert(crcHexString(crc32) == "414FA339");
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
@@ -879,7 +630,7 @@ unittest
     assert(isOutputRange!(Digest, ubyte));
 }
 
-//verify example
+///
 unittest
 {
     void test(Digest dig)
@@ -914,37 +665,6 @@ enum Order : bool
  * The additional letterCase parameter can be used to specify the case of the output data.
  * By default the output is in upper case. To change it to the lower case
  * pass LetterCase.lower as a parameter.
- *
- * Examples:
- * --------
- * //With template API:
- * auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString(crc32) == "39A34F41");
- * --------
- * 
- * --------
- * //Lower case variant:
- * auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString!(LetterCase.lower)(crc32) == "39a34f41");
- * --------
- * 
- * --------
- * //Usually CRCs are printed in this order, though:
- * auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString!(Order.decreasing)(crc32) == "414FA339");
- * --------
- *
- * --------
- * //With OOP API:
- * auto crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString(crc32) == "39A34F41");
- * --------
- *
- * --------
- * //Usually CRCs are printed in this order, though:
- * auto crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
- * assert(toHexString!(Order.decreasing)(crc32) == "414FA339");
- * --------
  */
 char[num*2] toHexString(Order order = Order.increasing, size_t num, LetterCase letterCase = LetterCase.upper)
 (in ubyte[num] digest)
@@ -1032,23 +752,26 @@ auto toHexString(LetterCase letterCase, Order order = Order.increasing)(in ubyte
 
 //For more example unittests, see Digest.digest, digest
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
-    //Usually CRCs are printed in this order, though:
+    //Test with template API:
     auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
+    //Lower case variant:
+    assert(toHexString!(LetterCase.lower)(crc32) == "39a34f41");
+    //Usually CRCs are printed in this order, though:
     assert(toHexString!(Order.decreasing)(crc32) == "414FA339");
     assert(toHexString!(LetterCase.lower, Order.decreasing)(crc32) == "414fa339");
-    assert(toHexString!(LetterCase.lower)(crc32) == "39a34f41");
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.crc;
-    //Usually CRCs are printed in this order, though:
+    // With OOP API
     auto crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
+    //Usually CRCs are printed in this order, though:
     assert(toHexString!(Order.decreasing)(crc32) == "414FA339");
 }
 
@@ -1110,17 +833,6 @@ class WrapperDigest(T) if(isDigest!T) : Digest
          * Use this to feed the digest with data.
          * Also implements the $(XREF range, OutputRange) interface for $(D ubyte) and
          * $(D const(ubyte)[]).
-         *
-         * Examples:
-         * ----
-         * void test(Digest dig)
-         * {
-         *     dig.put(cast(ubyte)0); //single ubyte
-         *     dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
-         *     ubyte[10] buf;
-         *     dig.put(buf); //buffer
-         * }
-         * ----
          */
         @trusted nothrow void put(scope const(ubyte)[] data...)
         {
@@ -1153,15 +865,7 @@ class WrapperDigest(T) if(isDigest!T) : Digest
          *
          * Examples:
          * --------
-         * //Simple example
-         * import std.digest.md;
-         * auto hash = new WrapperDigest!MD5();
-         * hash.put(cast(ubyte)0);
-         * auto result = hash.finish();
-         * --------
-         *
-         * --------
-         * //using a supplied buffer
+         * 
          * import std.digest.md;
          * ubyte[16] buf;
          * auto hash = new WrapperDigest!MD5();
@@ -1231,7 +935,7 @@ class WrapperDigest(T) if(isDigest!T) : Digest
         }
 }
 
-//verify example
+///
 unittest
 {
     import std.digest.md;
@@ -1241,9 +945,10 @@ unittest
     auto result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
+    //using a supplied buffer
     import std.digest.md;
     ubyte[16] buf;
     auto hash = new WrapperDigest!MD5();

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -39,40 +39,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
  * Macros:
  * WIKI = Phobos/StdMd5
  * MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#$1">$1</a>&nbsp;</font>
- *
- * Examples:
- * ---------
- * //Template API
- * import std.digest.md;
- *
- * ubyte[16] hash = md5Of("abc");
- * assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
- *
- * //Feeding data
- * ubyte[1024] data;
- * MD5 md5;
- * md5.start();
- * md5.put(data[]);
- * md5.start(); //Start again
- * md5.put(data[]);
- * hash = md5.finish();
- * ---------
- *
- * ---------
- * //OOP API
- * import std.digest.md;
- *
- * auto md5 = new MD5Digest();
- * ubyte[] hash = md5.digest("abc");
- * assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
- *
- * //Feeding data
- * ubyte[1024] data;
- * md5.put(data[]);
- * md5.reset(); //Start again
- * md5.put(data[]);
- * hash = md5.finish();
- * ---------
  */
 
 /* md5.d - RSA Data Security, Inc., MD5 message-digest algorithm
@@ -84,14 +50,11 @@ import std.bitmanip, std.exception, std.string;
 
 public import std.digest.digest;
 
-//verify example
+///
 unittest
 {
     //Template API
     import std.digest.md;
-
-    ubyte[16] hash = md5Of("abc");
-    assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
 
     //Feeding data
     ubyte[1024] data;
@@ -100,10 +63,10 @@ unittest
     md5.put(data[]);
     md5.start(); //Start again
     md5.put(data[]);
-    hash = md5.finish();
+    auto hash = md5.finish();
 }
 
-//verify example
+///
 unittest
 {
     //OOP API
@@ -132,37 +95,6 @@ private nothrow pure uint rotateLeft(uint x, uint n)
 /**
  * Template API MD5 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using md5Of helper function
- * ubyte[16] hash = md5Of("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
- * --------
- *
- * --------
- * //Using the basic API
- * MD5 hash;
- * hash.start();
- * ubyte[1024] data;
- * //Initialize data here...
- * hash.put(data);
- * ubyte[16] result = hash.finish();
- * --------
- *
- * --------
- * //Let's use the template features:
- * //Note: When passing a MD5 to a function, it must be passed by referece!
- * void doSomething(T)(ref T hash) if(isDigest!T)
- * {
- *     hash.put(cast(ubyte)0);
- * }
- * MD5 md5;
- * md5.start();
- * doSomething(md5);
- * assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
- * --------
  */
 struct MD5
 {
@@ -423,16 +355,7 @@ struct MD5
         /**
          * Returns the finished MD5 hash. This also calls $(LREF start) to
          * reset the internal state.
-         *
-         * Examples:
-         * --------
-         * //Simple example
-         * MD5 hash;
-         * hash.start();
-         * hash.put(cast(ubyte)0);
-         * ubyte[16] result = hash.finish();
-         * --------
-         */
+          */
         @trusted nothrow pure ubyte[16] finish()
         {
             ubyte[16] data = void;
@@ -460,9 +383,18 @@ struct MD5
             start();
             return data;
         }
+        ///
+        unittest
+        {
+            //Simple example
+            MD5 hash;
+            hash.start();
+            hash.put(cast(ubyte)0);
+            ubyte[16] result = hash.finish();
+        }
 }
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using md5Of helper function
@@ -471,7 +403,7 @@ unittest
     assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
 }
 
-//verify example
+///
 unittest
 {
     //Using the basic API
@@ -483,7 +415,7 @@ unittest
     ubyte[16] result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     //Let's use the template features:
@@ -495,16 +427,6 @@ unittest
     md5.start();
     doSomething(md5);
     assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
-}
-
-//verify example
-unittest
-{
-    //Simple example
-    MD5 hash;
-    hash.start();
-    hash.put(cast(ubyte)0);
-    ubyte[16] result = hash.finish();
 }
 
 unittest
@@ -565,12 +487,6 @@ unittest
 /**
  * This is a convenience alias for $(XREF digest.digest, digest) using the
  * MD5 implementation.
- *
- * Examples:
- * ---------
- * ubyte[16] hash = md5Of("abc");
- * assert(hash == digest!MD5("abc")); //This is the same as above
- * ---------
  */
 //simple alias doesn't work here, hope this gets inlined...
 auto md5Of(T...)(T data)
@@ -578,7 +494,7 @@ auto md5Of(T...)(T data)
     return digest!(MD5, T)(data);
 }
 
-//verify example
+///
 unittest
 {
     ubyte[16] hash = md5Of("abc");
@@ -591,34 +507,10 @@ unittest
  *
  * This is an alias for $(XREF digest.digest, WrapperDigest)!MD5, see
  * $(XREF digest.digest, WrapperDigest) for more information.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using Digest.digest helper function
- * auto md5 = new MD5Digest();
- * ubyte[] hash = md5.digest("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
- * --------
- *
- * --------
- * //Let's use the OOP features:
- * void test(Digest dig)
- * {
- *     dig.put(cast(ubyte)0);
- * }
- * auto md5 = new MD5Digest();
- * test(md5);
- *
- * //Let's use a custom buffer:
- * ubyte[16] buf;
- * ubyte[] result = md5.finish(buf[]);
- * assert(toHexString(result) == "93B885ADFE0DA089CDF634904FD59F71");
- * --------
  */
 alias WrapperDigest!MD5 MD5Digest;
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
@@ -628,7 +520,7 @@ unittest
     assert(toHexString(hash) == "900150983CD24FB0D6963F7D28E17F72");
 }
 
-//verify example
+///
 unittest
 {
      //Let's use the OOP features:

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -43,40 +43,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
  * Macros:
  * WIKI = Phobos/StdRipemd
  * MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#$1">$1</a>&nbsp;</font>
- *
- * Examples:
- * ---------
- * //Template API
- * import std.digest.ripemd;
- *
- * ubyte[20] hash = ripemd160Of("abc");
- * assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
- *
- * //Feeding data
- * ubyte[1024] data;
- * RIPEMD160 md;
- * md.start();
- * md.put(data[]);
- * md.start(); //Start again
- * md.put(data[]);
- * hash = md.finish();
- * ---------
- *
- * ---------
- * //OOP API
- * import std.digest.ripemd;
- *
- * auto md = new RIPEMD160Digest();
- * ubyte[] hash = md.digest("abc");
- * assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
- *
- * //Feeding data
- * ubyte[1024] data;
- * md.put(data[]);
- * md.reset(); //Start again
- * md.put(data[]);
- * hash = md.finish();
- * ---------
  */
 
 module std.digest.ripemd;
@@ -85,7 +51,7 @@ import std.bitmanip, std.exception, std.string;
 
 public import std.digest.digest;
 
-//verify example
+///
 unittest
 {
     //Template API
@@ -104,7 +70,7 @@ unittest
     hash = md.finish();
 }
 
-//verify example
+///
 unittest
 {
     //OOP API
@@ -133,37 +99,6 @@ private nothrow pure uint rotateLeft(uint x, uint n)
 /**
  * Template API RIPEMD160 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using ripemd160Of helper function
- * ubyte[20] hash = ripemd160Of("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
- * --------
- *
- * --------
- * //Using the basic API
- * RIPEMD160 hash;
- * hash.start();
- * ubyte[1024] data;
- * //Initialize data here...
- * hash.put(data);
- * ubyte[20] result = hash.finish();
- * --------
- *
- * --------
- * //Let's use the template features:
- * //Note: When passing a RIPEMD160 to a function, it must be passed by referece!
- * void doSomething(T)(ref T hash) if(isDigest!T)
- * {
- *     hash.put(cast(ubyte)0);
- * }
- * RIPEMD160 md;
- * md.start();
- * doSomething(md);
- * assert(toHexString(md.finish()) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
- * --------
  */
 struct RIPEMD160
 {
@@ -610,7 +545,7 @@ struct RIPEMD160
         }
 }
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using ripemd160Of helper function
@@ -619,7 +554,7 @@ unittest
     assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
 }
 
-//verify example
+///
 unittest
 {
     //Using the basic API
@@ -631,7 +566,7 @@ unittest
     ubyte[20] result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     //Let's use the template features:
@@ -645,7 +580,7 @@ unittest
     assert(toHexString(md.finish()) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
 
-//verify example
+///
 unittest
 {
     //Simple example
@@ -714,12 +649,6 @@ unittest
 /**
  * This is a convenience alias for $(XREF digest.digest, digest) using the
  * RIPEMD160 implementation.
- *
- * Examples:
- * ---------
- * ubyte[20] hash = ripemd160Of("abc");
- * assert(hash == digest!RIPEMD160("abc")); //This is the same as above
- * ---------
  */
 //simple alias doesn't work here, hope this gets inlined...
 auto ripemd160Of(T...)(T data)
@@ -727,7 +656,7 @@ auto ripemd160Of(T...)(T data)
     return digest!(RIPEMD160, T)(data);
 }
 
-//verify example
+///
 unittest
 {
     ubyte[20] hash = ripemd160Of("abc");
@@ -740,34 +669,10 @@ unittest
  *
  * This is an alias for $(XREF digest.digest, WrapperDigest)!RIPEMD160, see
  * $(XREF digest.digest, WrapperDigest) for more information.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using Digest.digest helper function
- * auto md = new RIPEMD160Digest();
- * ubyte[] hash = md.digest("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
- * --------
- *
- * --------
- * //Let's use the OOP features:
- * void test(Digest dig)
- * {
- *     dig.put(cast(ubyte)0);
- * }
- * auto md = new RIPEMD160Digest();
- * test(md);
- *
- * //Let's use a custom buffer:
- * ubyte[20] buf;
- * ubyte[] result = md.finish(buf[]);
- * assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
- * --------
  */
 alias WrapperDigest!RIPEMD160 RIPEMD160Digest;
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
@@ -777,10 +682,10 @@ unittest
     assert(toHexString(hash) == "8EB208F7E05D987A9B044A8E98C6B087F15A0BFC");
 }
 
-//verify example
+///
 unittest
 {
-     //Let's use the OOP features:
+    //Let's use the OOP features:
     void test(Digest dig)
     {
       dig.put(cast(ubyte)0);

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -45,40 +45,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  * Macros:
  *      WIKI = Phobos/StdSha1
  *      MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#$1">$1</a>&nbsp;</font>
- *
- * Examples:
- * ---------
- * //Template API
- * import std.digest.sha;
- *
- * ubyte[20] hash = sha1Of("abc");
- * assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
- *
- * //Feeding data
- * ubyte[1024] data;
- * SHA1 sha;
- * sha.start();
- * sha.put(data[]);
- * sha.start(); //Start again
- * sha.put(data[]);
- * hash = sha.finish();
- * ---------
- *
- * ---------
- * //OOP API
- * import std.digest.sha;
- *
- * auto sha = new SHA1Digest();
- * ubyte[] hash = sha.digest("abc");
- * assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
- *
- * //Feeding data
- * ubyte[1024] data;
- * sha.put(data[]);
- * sha.reset(); //Start again
- * sha.put(data[]);
- * hash = sha.finish();
- * ---------
  */
 
 /*          Copyright Kai Nacke 2012.
@@ -88,7 +54,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  */
 module std.digest.sha;
 
-//verify example
+///
 unittest
 {
     //Template API
@@ -107,7 +73,7 @@ unittest
     hash = sha.finish();
 }
 
-//verify example
+///
 unittest
 {
     //OOP API
@@ -194,37 +160,6 @@ private nothrow pure uint rotateLeft(uint x, uint n)
 /**
  * Template API SHA1 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using sha1Of helper function
- * ubyte[20] hash = sha1Of("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
- * --------
- *
- * --------
- * //Using the basic API
- * SHA1 hash;
- * hash.start();
- * ubyte[1024] data;
- * //Initialize data here...
- * hash.put(data);
- * ubyte[20] result = hash.finish();
- * --------
- *
- * --------
- * //Let's use the template features:
- * //Note: When passing a SHA1 to a function, it must be passed by referece!
- * void doSomething(T)(ref T hash) if(isDigest!T)
- * {
- *     hash.put(cast(ubyte)0);
- * }
- * SHA1 sha;
- * sha.start();
- * doSomething(sha);
- * assert(toHexString(sha.finish()) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
- * --------
  */
 struct SHA1
 {
@@ -437,15 +372,6 @@ struct SHA1
          * Use this to feed the digest with data.
          * Also implements the $(XREF range, OutputRange) interface for $(D ubyte) and
          * $(D const(ubyte)[]).
-         *
-         * Examples:
-         * ----
-         * SHA1 dig;
-         * dig.put(cast(ubyte)0); //single ubyte
-         * dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
-         * ubyte[10] buf;
-         * dig.put(buf); //buffer
-         * ----
          */
         @trusted nothrow pure void put(scope const(ubyte)[] input...)
         {
@@ -478,19 +404,20 @@ struct SHA1
             if (inputLen - i)
                 (&buffer[index])[0 .. inputLen-i] = (&input[i])[0 .. inputLen-i];
         }
+        ///
+        unittest
+        {
+            SHA1 dig;
+            dig.put(cast(ubyte)0); //single ubyte
+            dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+            ubyte[10] buf;
+            dig.put(buf); //buffer
+        }
+
 
         /**
          * Returns the finished SHA1 hash. This also calls $(LREF start) to
          * reset the internal state.
-         *
-         * Examples:
-         * --------
-         * //Simple example
-         * SHA1 hash;
-         * hash.start();
-         * hash.put(cast(ubyte)0);
-         * ubyte[20] result = hash.finish();
-         * --------
          */
         @trusted nothrow pure ubyte[20] finish()
         {
@@ -516,9 +443,18 @@ struct SHA1
             start();
             return data;
         }
+        ///
+        unittest
+        {
+            //Simple example
+            SHA1 hash;
+            hash.start();
+            hash.put(cast(ubyte)0);
+            ubyte[20] result = hash.finish();
+        }
 }
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using sha1Of helper function
@@ -527,7 +463,7 @@ unittest
     assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
 }
 
-//verify example
+///
 unittest
 {
     //Using the basic API
@@ -539,7 +475,7 @@ unittest
     ubyte[20] result = hash.finish();
 }
 
-//verify example
+///
 unittest
 {
     //Let's use the template features:
@@ -552,26 +488,6 @@ unittest
     sha.start();
     doSomething(sha);
     assert(toHexString(sha.finish()) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
-}
-
-//verify example
-unittest
-{
-    SHA1 dig;
-    dig.put(cast(ubyte)0); //single ubyte
-    dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
-    ubyte[10] buf;
-    dig.put(buf); //buffer
-}
-
-//verify example
-unittest
-{
-    //Simple example
-    SHA1 hash;
-    hash.start();
-    hash.put(cast(ubyte)0);
-    ubyte[20] result = hash.finish();
 }
 
 unittest
@@ -632,12 +548,6 @@ unittest
 /**
  * This is a convenience alias for $(XREF digest.digest, digest) using the
  * SHA1 implementation.
- *
- * Examples:
- * ---------
- * ubyte[20] hash = sha1Of("abc");
- * assert(hash == digest!SHA1("abc")); //This is the same as above
- * ---------
  */
 //simple alias doesn't work here, hope this gets inlined...
 auto sha1Of(T...)(T data)
@@ -645,7 +555,7 @@ auto sha1Of(T...)(T data)
     return digest!(SHA1, T)(data);
 }
 
-//verify example
+///
 unittest
 {
     ubyte[20] hash = sha1Of("abc");
@@ -669,34 +579,10 @@ unittest
  *
  * This is an alias for $(XREF digest.digest, WrapperDigest)!SHA1, see
  * $(XREF digest.digest, WrapperDigest) for more information.
- *
- * Examples:
- * --------
- * //Simple example, hashing a string using Digest.digest helper function
- * auto sha = new SHA1Digest();
- * ubyte[] hash = sha.digest("abc");
- * //Let's get a hash string
- * assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
- * --------
- *
- * --------
- * //Let's use the OOP features:
- * void test(Digest dig)
- * {
- *     dig.put(cast(ubyte)0);
- * }
- * auto sha = new SHA1Digest();
- * test(sha);
- *
- * //Let's use a custom buffer:
- * ubyte[20] buf;
- * ubyte[] result = sha.finish(buf[]);
- * assert(toHexString(result) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
- * --------
  */
 alias WrapperDigest!SHA1 SHA1Digest;
 
-//verify example
+///
 unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
@@ -706,7 +592,7 @@ unittest
     assert(toHexString(hash) == "A9993E364706816ABA3E25717850C26C9CD0D89D");
 }
 
-//verify example
+///
 unittest
 {
     //Let's use the OOP features:


### PR DESCRIPTION
This commit turns almost all the examples in std.digest into documented unittest.
As most of them were just copy-pasting, I would flag it as trivial if it wasn't for the number of lines impacted.
