### PR TITLE
Fix issue 11762 - DDoc macro S_LINK

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -6134,7 +6134,7 @@ private R replaceAllWith(alias output,
     input = string to search
     re = compiled regular expression to use
     format = format string to generate replacements from, 
-    see $(S_LINK Replace format string).
+    see $(S_LINK Replace format string, the format string).
 
     Returns:
     A string of the same type with the first match (if any) replaced. 
@@ -6246,7 +6246,7 @@ public @trusted void replaceFirstInto(alias fun, Sink, R, RegEx)
     input = string to search
     re = compiled regular expression to use
     format = format string to generate replacements from, 
-    see $(S_LINK Replace format string).
+    see $(S_LINK Replace format string, the format string).
 
     Returns:
     A string of the same type as $(D input) with the all 


### PR DESCRIPTION
I've taken similar usage from std.uni as example.

Strangely I can't seem to generate DDocs correctly - I get a page that stops short, something like all API docs short of full documentation. Not before this patch nor after - is that something on my end?
