### PR TITLE
improve set intersection algorithm

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -10928,13 +10928,13 @@ private:
             //Iterate left to right, lopping off the RHS when smaller than LHS
             //This propagates the highest value to the right.
             --done;
-            foreach (i, ref l; _input[0 .. $ - 1])
+            foreach (i, ref lhs; _input[0 .. $ - 1])
             {
-                alias r = _input[i + 1];
-                if (comp(r.front, l.front)) //(l > r)?
+                alias rhs = _input[i + 1];
+                if (comp(rhs.front, lhs.front)) //(lhs > rhs)?
                 {
-                    r.popFront();
-                    if (r.empty) return;
+                    rhs.popFront();
+                    if (rhs.empty) return;
                     done = 2;
                 }
             }
@@ -10942,13 +10942,13 @@ private:
 
             //Then iterate right to left, propagting the high value back to the left
             --done;
-            foreach_reverse(i, ref l; _input[0 .. $ - 1])
+            foreach_reverse(i, ref lhs; _input[0 .. $ - 1])
             {
-                alias r = _input[i + 1];
-                if (comp(l.front, r.front)) //(l < r)?
+                alias rhs = _input[i + 1];
+                if (comp(lhs.front, rhs.front)) //(lhs < rhs)?
                 {
-                    l.popFront();
-                    if (l.empty) return;
+                    lhs.popFront();
+                    if (lhs.empty) return;
                     done = 2;
                 }
             }


### PR DESCRIPTION
https://github.com/D-Programming-Language/phobos/pull/1796

pinging @JakobOvrum : After merging your commit, I couldn't get the code out of my head. I just kept teling myself "it works, but isn't that inefficient?" Give it a review?

The first commit is trivial: It makes a "preemptive" call to `empty` in `adjustPosition`, and then check each range individually after every pop. `empty` is kind of expensive in the contex of `setIntersection`, especially if there are a lot of ranges being intersected, so it should be a net gain right there.

The second commit is more complicated. The existing algorithm had 2 flaws, which combined, lead to a performance (if I'm not mistaken), of O(N²), where N is the ammount of ranges involved.
- First, the algorithm "restarts" after each operation. So if "range 5" needs to be popped 5 elements, we need to re-check ranges 1-4 first, 5 times :/
- Second, the algorithm has a "bubble sort" kind of problem with it: It is easy to propagate the min from "left to right", due to the iteration scheme, but "right to left" is much harder, as the "swaps" go left to right.

So the second commit solves both these issues with a "shaker sort" style algorithm: Instead of checking both directions when dealing with "i, i+1", it iterates left to right while propagating the low value to the right, and _then_ does the other check, while iterating the other way. Instead of doing a "continue", we simply mark "done" as false, which means we can pop with a "while". AFAIK, the algo should be O(N) in terms of ranges involved.

Can the algorithm be further improved? Maybe, but I think this one is "good enough" for a fair amount of code (IMO).

For every day cases, I don't think it makes much difference, but if you want to intersect a fair bit of ranges, and with a "low concentration" of intersection, it makes quite a difference.
