### PR TITLE
rework setIntersection

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -11161,7 +11161,7 @@ ranges). The ranges are assumed to be sorted by $(D less). The element
 types of the ranges must have a common type.
  */
 struct SetIntersection(alias less = "a < b", Rs...)
-    if (allSatisfy!(isInputRange, Rs) &&
+    if (Rs.length >= 2 && allSatisfy!(isInputRange, Rs) &&
         !is(CommonType!(staticMap!(ElementType, Rs)) == void))
 {
 private:
@@ -11172,25 +11172,25 @@ private:
     // Positions to the first elements that are all equal
     void adjustPosition()
     {
-        outer:
-        while (!empty)
+        if (empty) return;
+
+        size_t done = Rs.length;
+        static if (Rs.length > 1) while (true)
         {
-            foreach (i, ref r; _input[0 .. $ - 1])
+            foreach (i, ref r; _input)
             {
-                alias next = _input[i + 1];
-                if (comp(r.front, next.front))
-                {
-                    r.popFront();
-                    continue outer;
-                }
+                alias next = _input[(i + 1) % Rs.length];
+
                 if (comp(next.front, r.front))
                 {
-                    next.popFront();
-                    continue outer;
+                    do {
+                        next.popFront();
+                        if (next.empty) return;
+                    } while(comp(next.front, r.front));
+                    done = Rs.length;
                 }
+                if (--done == 0) return;
             }
-
-            return;
         }
     }
 
@@ -11214,10 +11214,10 @@ public:
     void popFront()
     {
         assert(!empty);
-        foreach (i, ref r; _input[0 .. $ - 1])
+        static if (Rs.length > 1) foreach (i, ref r; _input)
         {
-            alias next = _input[i + 1];
-            assert(!comp(r.front, next.front) && !comp(next.front, r.front));
+            alias next = _input[(i + 1) % Rs.length];
+            assert(!comp(r.front, next.front));
         }
 
         foreach (ref r; _input)
@@ -11238,9 +11238,9 @@ public:
         @property SetIntersection save()
         {
             auto ret = this;
-            foreach (ti, elem; _input)
+            foreach (i, ref r; _input)
             {
-                ret._input[ti] = elem.save;
+                ret._input[i] = r.save;
             }
             return ret;
         }
@@ -11248,9 +11248,8 @@ public:
 }
 
 /// Ditto
-SetIntersection!(less, Rs) setIntersection(alias less = "a < b", Rs...)
-(Rs ranges)
-    if (allSatisfy!(isInputRange, Rs) &&
+SetIntersection!(less, Rs) setIntersection(alias less = "a < b", Rs...)(Rs ranges)
+    if (Rs.length >= 2 && allSatisfy!(isInputRange, Rs) &&
         !is(CommonType!(staticMap!(ElementType, Rs)) == void))
 {
     return typeof(return)(ranges);


### PR DESCRIPTION
Forked from #1798 : I was able to rework the algorithm into something both very simple, and efficient. The "trick", is instead of iterating on all pairs in 0 ..  $ - 1, to go all the way to $, and have "$ - 1" match up with "0".

I'd describe this as a "continuous circular bubble". The fact that it is circular means we can also run the checks in only 1 direction: If all elements in a circular buffer are smaller than their predecessor, then they have to all be equivalent.

Benches:

```
wideTest
bubble: 27284ms, shaker: 2400ms, composed: 4734ms, circular: 2264ms
bubble: 1, shaker: 11.3658, composed: 5.76286, linear: 12.0471

quadTest
bubble: 218ms, shaker: 290ms, composed: 208ms, circular: 190ms
bubble: 1, shaker: 0.751943, composed: 1.04846, linear: 1.14866

tripleTest
bubble: 217ms, shaker: 304ms, composed: 204ms, circular: 187ms
bubble: 1, shaker: 0.713614, composed: 1.06307, linear: 1.16154

trivialTest
bubble: 169ms, shaker: 166ms, composed: 171ms, circular: 157ms
bubble: 1, shaker: 1.02392, composed: 0.990549, linear: 1.07631
```

Look at that: It's better than _every_ other algorithm, regardless of input size! And the algo is really very small:

``` D
    void adjustPosition()
    {
        if (empty) return;

        size_t done = Rs.length;
        static if (Rs.length > 1) while (true)
        {     
            foreach (I, R; Rs)
            {     
                alias r    = _input[I];
                alias next = _input[(I + 1) % Rs.length];

                if (comp(next.front, r.front))
                {     
                    next.popFront();
                    if (next.empty) return;
                    done = Rs.length;
                }
                else
                    if (--done == 0) return;
            }     
        }     
    }
```
