### PR TITLE
detect other uname -m outputs

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -53,16 +53,16 @@ ifeq (,$(OS))
 endif
 
 ifeq (,$(MODEL))
-    uname_M:=$(shell uname -m)
-    ifeq (x86_64,$(uname_M))
-        MODEL=64
-    else
-        ifeq (i686,$(uname_M))
-            MODEL=32
-        else
-            $(error Cannot figure 32/64 model from uname -m: $(uname_M))
-        endif
-    endif
+  uname_M:=$(shell uname -m)
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+    MODEL:=64
+  endif
+  ifneq (,$(findstring $(uname_M),i386 i586 i686))
+    MODEL:=32
+  endif
+  ifeq (,$(MODEL))
+    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+  endif
 endif
 
 # Default to a release built, override with BUILD=debug


### PR DESCRIPTION
- x86_64, amd64 => MODEL:=64
- i386, i586, i686 => MODEL:32
