### PR TITLE
std.file: Fix race condition when mkdirRecurse runs concurrently 

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1396,15 +1396,8 @@ private bool ensureDirExists(in char[] pathname)
 void mkdirRecurse(in char[] pathname)
 {
     const left = dirName(pathname);
-    if (!exists(left))
+    if (left.length != pathname.length && !exists(left))
     {
-        version (Windows)
-        {   /* Prevent infinite recursion if left is "d:\" and
-             * drive d does not exist.
-             */
-            if (left.length >= 3 && left[$ - 2] == ':')
-                throw new FileException(left.idup);
-        }
         mkdirRecurse(left);
     }
     if (!baseName(pathname).empty)
@@ -1431,6 +1424,11 @@ unittest
         path = buildPath(basepath, "d");
         mkdirRecurse(path);
         mkdirRecurse(path); // should not throw
+    }
+
+    version(Windows)
+    {
+        assertThrown!FileException(mkdirRecurse(`1:\foobar`));
     }
 
     // bug3570


### PR DESCRIPTION
`mkdirRecurse` would throw if a directory was created between its `exists()` and `mkdir()` calls. This could occur if `mkdirRecurse` was called at the same time from mutiple threads or processes.

Instead of relying on the `exists()` check to indicate whether the next `mkdir()` should succeed, we explicitly ignore "already exists" errors from the OS. Note that this changes the behavior of `mkdirRecurse` when the leaf directory already existed: previously it would throw, whereas now it will silently succeed. The new behavior is conformant with some other implementations of "recursive mkdir": the `-p` flag of the GNU tool, Ruby's `mkpath`, Java's `mkdirs`, and Perl's `make_path`. (On the other hand, the old behavior was equivalent to the behavior of Python's `makedirs`).
