### PR TITLE
fix Issue 11853 - Tuples fail "isAssignable"

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1997,7 +1997,7 @@ See_Also:
 void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow
 if (allMutableFields!T && !is(typeof(T.init.proxySwap(T.init))))
 {
-    static if (!isAssignable!T || hasElaborateAssign!T)
+    static if (hasElaborateAssign!T || !isAssignable!T)
     {
         import std.exception : pointsTo;
 
@@ -2166,6 +2166,13 @@ unittest
     }
     S s;
     static assert(!__traits(compiles, swap(s, s)));
+}
+
+unittest
+{
+    //11853
+    alias T = Tuple!(int, double);
+    static assert(isAssignable!T);
 }
 
 void swapFront(R1, R2)(R1 r1, R2 r2)


### PR DESCRIPTION
Very ugly fix for https://d.puremagic.com/issues/show_bug.cgi?id=11853

Basically, Tuple's opAssign calls swap, but swap needs to know tuples are assignable => circular dependency and dmd confusion.

This hackish solution short-circuits the problem by simply checking first the mere presence of an elaborate assign.

There is still some smell, you can read more about it in the bug report, but in the mean time, this is a very low cost fix (and more optimal in general, testing existence is cheaper than testing if something compiles).
