### PR TITLE
Fix Take's "back"

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3347,6 +3347,16 @@ unittest
     t3 = take(t2, 1);
 }
 
+unittest
+{
+    alias R1 = typeof(repeat(1));
+    alias R2 = typeof(cycle([1]));
+    alias TR1 = Take!R1;
+    alias TR2 = Take!R2;
+    static assert(isBidirectionalRange!TR1);
+    static assert(isBidirectionalRange!TR2);
+}
+
 /**
 Similar to $(LREF take), but assumes that $(D range) has at least $(D
 n) elements. Consequently, the result of $(D takeExactly(range, n))


### PR DESCRIPTION
Trivial fix. Reproducing it required a non-sliceable (or infinite) RA range. `Take` _should_ be bidirectinal, but because the "write" version of `back` was not marked as `@property`, calling it produced a `Error: cannot overload both property and non-property functions`. This meant the resulting range was not bidirectional.

This fixes that. Also added a unittest.
