### PR TITLE
Fix issue 11839

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -1086,10 +1086,11 @@ struct Parser(R)
                         if(current != '<')
                             error("Expected '<' in named group");
                         string name;
-                        if(!next() || !isAlpha(current))
+                        if(!next() || !(isAlpha(current) || current == '_'))
                             error("Expected alpha starting a named group");
                         name ~= current;
-                        while(next() && (isAlpha(current) || ascii.isDigit(current)))
+                        while(next() && (isAlpha(current) || 
+                            current == '_' || ascii.isDigit(current)))
                         {
                             name ~= current;
                         }
@@ -7472,6 +7473,9 @@ unittest
 {
     assert(regex(`(?P<var1>\w+)`).namedCaptures.equal(["var1"]));
     assert(collectException(regex(`(?P<1>\w+)`)));
+    assert(regex(`(?P<v1>\w+)`).namedCaptures.equal(["v1"]));
+    assert(regex(`(?P<__>\w+)`).namedCaptures.equal(["__"]));
+    assert(regex(`(?P<я>\w+)`).namedCaptures.equal(["я"]));
 }
 
 }//version(unittest)


### PR DESCRIPTION
Allow digits in std.regex named capture identifier. As usual it may not _start_ with digit.

http://d.puremagic.com/issues/show_bug.cgi?id=11839
