### PR TITLE
Fixup commit a8177b8cc3300fd64eef0acb7397be15fb0e0b4c

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4434,7 +4434,7 @@ nothrow:
 
     enum bool empty = false;
 
-    void popFront() nothrow
+    void popFront()
     {
         ++_index;
     }


### PR DESCRIPTION
Per https://github.com/D-Programming-Language/phobos/commit/a8177b8cc3300fd64eef0acb7397be15fb0e0b4c#commitcomment-4991972 :
"nothrow" was superfluous
