### PR TITLE
Avoid calling a qualified constructor in Cycle.

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4463,9 +4463,9 @@ nothrow:
         return this[i .. $].takeExactly(j - i);
     }
 
-    auto opSlice(size_t i, DollarToken) inout
+    typeof(this) opSlice(size_t i, DollarToken) inout
     {
-        return typeof(this)(*cast(R*)_ptr, _index + i);
+        return Cycle(*cast(R*)_ptr, _index + i);
     }
 }
 


### PR DESCRIPTION
This is actually invalid code, as typeof(this) == inout(this),
but Cycle has no inout constructor. This wasn't previously
detected, as the constructor was mistakenly flagged as creating
an unique object where qualifiers can be disregarded. (The
reference parameter is leaked into the Cycle instance, so
this is obviously not the case.)
