### PR TITLE
std.variant: Adjust test for ARM

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1438,9 +1438,9 @@ unittest
     assert( v.get!(string) == "Hello, World!" );
 
     // Literal arrays are dynamically-typed
-    v = cast(int[5]) [1,2,3,4,5];
-    assert( v.peek!(int[5]) );
-    assert( v.get!(int[5]) == [1,2,3,4,5] );
+    v = cast(int[4]) [1,2,3,4];
+    assert( v.peek!(int[4]) );
+    assert( v.get!(int[4]) == [1,2,3,4] );
 
     {
         // @@@BUG@@@: array literals should have type T[], not T[5] (I guess)


### PR DESCRIPTION
The array used in the test is bigger than the maximal size which can be stored in a Variant on ARM.
See http://d.puremagic.com/issues/show_bug.cgi?id=10879 for details.

Note: This is part of a set of changes which are required to get test suite & unit tests passing on ARM GDC. All necessary changes for GDC are here for reference:
https://github.com/jpf91/GDC/commits/arm-old

Once these pull requests are merged upstream I'll merge them into GDC as well.
