### PR TITLE
[ARM] Fix phobos unit tests

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -591,12 +591,13 @@ uint formattedRead(R, Char, S...)(ref R r, const(Char)[] fmt, S args)
 
 unittest
 {
+    import std.math;
     string s = " 1.2 3.4 ";
     double x, y, z;
     assert(formattedRead(s, " %s %s %s ", &x, &y, &z) == 2);
     assert(s.empty);
-    assert(x == 1.2);
-    assert(y == 3.4);
+    assert(approxEqual(x, 1.2));
+    assert(approxEqual(y, 3.4));
     assert(isnan(z));
 }
 

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -660,6 +660,7 @@ private void setConfig(ref configuration cfg, config option)
 
 unittest
 {
+    import std.math;
     uint paranoid = 2;
     string[] args = (["program.name",
                       "--paranoid", "--paranoid", "--paranoid"]).dup;
@@ -706,8 +707,8 @@ unittest
     getopt(args, "tune", &tuningParms);
     assert(args.length == 1);
     assert(tuningParms.length == 2);
-    assert(tuningParms["alpha"] == 0.5);
-    assert(tuningParms["beta"] == 0.6);
+    assert(approxEqual(tuningParms["alpha"], 0.5));
+    assert(approxEqual(tuningParms["beta"], 0.6));
 
     uint verbosityLevel = 1;
     void myHandler(string option)

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -215,15 +215,15 @@ unittest {
 
     assert(feqrel(erfc(0.250L), erfc0_250 )>=real.mant_dig-1);
     assert(feqrel(erfc(0.375L), erfc0_375 )>=real.mant_dig-0);
-    assert(feqrel(erfc(0.500L), erfc0_500 )>=real.mant_dig-1);
+    assert(feqrel(erfc(0.500L), erfc0_500 )>=real.mant_dig-2);
     assert(feqrel(erfc(0.625L), erfc0_625 )>=real.mant_dig-1);
     assert(feqrel(erfc(0.750L), erfc0_750 )>=real.mant_dig-1);
     assert(feqrel(erfc(0.875L), erfc0_875 )>=real.mant_dig-4);
-    assert(feqrel(erfc(1.000L), erfc1_000 )>=real.mant_dig-0);
+    assert(feqrel(erfc(1.000L), erfc1_000 )>=real.mant_dig-2);
     assert(feqrel(erfc(1.125L), erfc1_125 )>=real.mant_dig-2);
     assert(feqrel(erf(0.875L), erf0_875 )>=real.mant_dig-1);
     // The DMC implementation of erfc() fails this next test (just)
-    assert(feqrel(erfc(4.1L),0.67000276540848983727e-8L)>=real.mant_dig-4);
+    assert(feqrel(erfc(4.1L),0.67000276540848983727e-8L)>=real.mant_dig-5);
 
     assert(isIdentical(erf(0.0),0.0));
     assert(isIdentical(erf(-0.0),-0.0));

--- a/std/traits.d
+++ b/std/traits.d
@@ -5793,7 +5793,7 @@ template Largest(T...) if(T.length >= 1)
 
 unittest
 {
-    static assert(is(Largest!(uint, ubyte, ulong, real) == real));
+    static assert(is(Largest!(uint, ubyte, ushort, real) == real));
     static assert(is(Largest!(ulong, double) == ulong));
     static assert(is(Largest!(double, ulong) == double));
     static assert(is(Largest!(uint, byte, double, short) == double));


### PR DESCRIPTION
Changes to make the unit tests pass on ARM. Mostly reducing required precision for math tests,
adding replacements for tests which required 80 bit reals and so on.

Note: This is part of a set of changes which are required to get test suite & unit tests passing on ARM GDC. All necessary changes for GDC are here for reference:
https://github.com/jpf91/GDC/commits/arm-old

Once these pull requests are merged upstream I'll merge them into GDC as well.
