### PR TITLE
[ARM] Implement remaining std.math stuff

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3593,7 +3593,7 @@ private:
         }
     }
 public:
-    version (X86_Any) { // TODO: Lift this version condition when we support !x86.
+    version (IeeeFlagsSupport) {
 
      /// The result cannot be represented exactly, so rounding occured.
      /// (example: x = sin(0.1); )
@@ -3613,7 +3613,14 @@ public:
 
      }
 }
-
+version(X86_Any)
+{
+    version = IeeeFlagsSupport;
+}
+else version(ARM)
+{
+    version = IeeeFlagsSupport;
+}
 
 /// Set all of the floating-point status flags to false.
 void resetIeeeFlags() { IeeeFlags.resetIeeeFlags(); }
@@ -3680,49 +3687,103 @@ struct FloatingPointControl
     /** IEEE rounding modes.
      * The default mode is roundToNearest.
      */
-    enum : RoundingMode
+    version(ARM)
     {
-        roundToNearest = 0x0000,
-        roundDown      = 0x0400,
-        roundUp        = 0x0800,
-        roundToZero    = 0x0C00
+        enum : RoundingMode
+        {
+            roundToNearest = 0x000000,
+            roundDown      = 0x400000,
+            roundUp        = 0x800000,
+            roundToZero    = 0xC00000
+        }
+    }
+    else
+    {
+        enum : RoundingMode
+        {
+            roundToNearest = 0x0000,
+            roundDown      = 0x0400,
+            roundUp        = 0x0800,
+            roundToZero    = 0x0C00
+        }
     }
 
     /** IEEE hardware exceptions.
      *  By default, all exceptions are masked (disabled).
      */
-    enum : uint
+    version(ARM)
     {
-        inexactException      = 0x20,
-        underflowException    = 0x10,
-        overflowException     = 0x08,
-        divByZeroException    = 0x04,
-        subnormalException    = 0x02,
-        invalidException      = 0x01,
-        /// Severe = The overflow, division by zero, and invalid exceptions.
-        severeExceptions   = overflowException | divByZeroException
-                             | invalidException,
-        allExceptions      = severeExceptions | underflowException
-                             | inexactException | subnormalException,
+        enum : uint
+        {
+            subnormalException    = 0x8000,
+            inexactException      = 0x1000,
+            underflowException    = 0x0800,
+            overflowException     = 0x0400,
+            divByZeroException    = 0x0200,
+            invalidException      = 0x0100,
+            /// Severe = The overflow, division by zero, and invalid exceptions.
+            severeExceptions   = overflowException | divByZeroException
+                                 | invalidException,
+            allExceptions      = severeExceptions | underflowException
+                                 | inexactException | subnormalException,
+        }
+    }
+    else
+    {
+        enum : uint
+        {
+            inexactException      = 0x20,
+            underflowException    = 0x10,
+            overflowException     = 0x08,
+            divByZeroException    = 0x04,
+            subnormalException    = 0x02,
+            invalidException      = 0x01,
+            /// Severe = The overflow, division by zero, and invalid exceptions.
+            severeExceptions   = overflowException | divByZeroException
+                                 | invalidException,
+            allExceptions      = severeExceptions | underflowException
+                                 | inexactException | subnormalException,
+        }
     }
 
 private:
-    enum ushort EXCEPTION_MASK = 0x3F;
-    enum ushort ROUNDING_MASK = 0xC00;
+    version(ARM)
+    {
+        enum uint EXCEPTION_MASK = 0x9F00;
+        enum uint ROUNDING_MASK = 0xC00000;
+    }
+    else version(X86)
+    {
+        enum ushort EXCEPTION_MASK = 0x3F;
+        enum ushort ROUNDING_MASK = 0xC00;
+    }
+    else version(X86_64)
+    {
+        enum ushort EXCEPTION_MASK = 0x3F;
+        enum ushort ROUNDING_MASK = 0xC00;
+    }
+    else
+        static assert(false, "Architecture not supported");
 
 public:
     /// Enable (unmask) specific hardware exceptions. Multiple exceptions may be ORed together.
     void enableExceptions(uint exceptions)
     {
         initialize();
-        setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+        version(ARM)
+            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+        else
+            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
     }
 
     /// Disable (mask) specific hardware exceptions. Multiple exceptions may be ORed together.
     void disableExceptions(uint exceptions)
     {
         initialize();
-        setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+        version(ARM)
+            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+        else
+            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
     }
 
     //// Change the floating-point hardware rounding mode
@@ -3735,7 +3796,10 @@ public:
     /// Return the exceptions which are currently enabled (unmasked)
     @property static uint enabledExceptions()
     {
-        return (getControlState() & EXCEPTION_MASK) ^ EXCEPTION_MASK;
+        version(ARM)
+            return (getControlState() & EXCEPTION_MASK);
+        else
+            return (getControlState() & EXCEPTION_MASK) ^ EXCEPTION_MASK;
     }
 
     /// Return the currently active rounding mode
@@ -3753,9 +3817,18 @@ public:
     }
 
 private:
-    ushort savedState;
+    ControlState savedState;
 
     bool initialized = false;
+
+    version(ARM)
+    {
+        alias ControlState = uint;
+    }
+    else
+    {
+        alias ControlState = ushort;
+    }
 
     void initialize()
     {


### PR DESCRIPTION
Implement ARM support in std.math. This pull request only contains the compiler-independent parts. Some inline-asm is necessary to make std.math work 100% but we won't upstream this code. The gdc implementation is here, for reference:
https://github.com/jpf91/GDC/commit/017d7aa5d0745188f3d74ae068ce6c046adb4494

Note: This is part of a set of changes which are required to get test suite & unit tests passing on ARM GDC. All necessary changes for GDC are here for reference:
https://github.com/jpf91/GDC/commits/arm-old

Once these pull requests are merged upstream I'll merge them into GDC as well.
