### PR TITLE
DDoc: elaborated on 'scalar type' and 'basic type'

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4799,7 +4799,7 @@ unittest
 }
 
 /**
-Detect whether $(D T) is a scalar type.
+Detect whether $(D T) is a scalar type (a built-in numeric, character or boolean type).
  */
 template isScalarType(T)
 {
@@ -4816,7 +4816,7 @@ unittest
 }
 
 /**
-Detect whether $(D T) is a basic type.
+Detect whether $(D T) is a basic type (scalar type or void).
  */
 template isBasicType(T)
 {


### PR DESCRIPTION
Previously it wasn't completely obvious what a scalar or basic type is in std.traits; now it's described explicitly.
