### PR TITLE
Fix Issue 11960 - Phobos Mersenne Random Engine not supporting unsigned longs

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -782,6 +782,17 @@ unittest
     }
 }
 
+unittest //11690
+{
+    alias MT(UIntType, uint w) = MersenneTwisterEngine!(UIntType, w, 624, 397, 31,
+                                                        0x9908b0df, 11, 7,
+                                                        0x9d2c5680, 15,
+                                                        0xefc60000, 18);
+
+    foreach (R; TypeTuple!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
+        auto a = R();
+}
+
 
 /**
  * Xorshift generator using 32bit algorithm.


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11960

The "root" issue was the way `max` was being calculated. It's a 1 line change. That's it. There where 2 ways to fix. I chose the one without a conditional statement.

The rest is just trivial and stylistic changes. If there is any individual pull you don't like, just tell me, and I'll remove it. I wouldn't want them to block the fix in any way.
