### PR TITLE
replace use of deprecated canFind overload

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -12907,18 +12907,18 @@ assert(Date.fromISOString(" 20100704 ") == Date(2010, 7, 4));
         auto month = dstr[$-4 .. $-2];
         auto year = dstr[0 .. $-4];
 
-        enforce(!canFind!(not!isDigit)(day), new DateTimeException(format("Invalid ISO String: %s", isoString)));
-        enforce(!canFind!(not!isDigit)(month), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce(all!isDigit(day), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce(all!isDigit(month), new DateTimeException(format("Invalid ISO String: %s", isoString)));
 
         if(year.length > 4)
         {
             enforce(year.startsWith("-") || year.startsWith("+"),
                     new DateTimeException(format("Invalid ISO String: %s", isoString)));
-            enforce(!canFind!(not!isDigit)(year[1..$]),
+            enforce(all!isDigit(year[1..$]),
                     new DateTimeException(format("Invalid ISO String: %s", isoString)));
         }
         else
-            enforce(!canFind!(not!isDigit)(year), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+            enforce(all!isDigit(year), new DateTimeException(format("Invalid ISO String: %s", isoString)));
 
         return Date(to!short(year), to!ubyte(month), to!ubyte(day));
     }
@@ -13034,20 +13034,20 @@ assert(Date.fromISOExtString(" 2010-07-04 ") == Date(2010, 7, 4));
 
         enforce(dstr[$-3] == '-', new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
         enforce(dstr[$-6] == '-', new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        enforce(!canFind!(not!isDigit)(day),
+        enforce(all!isDigit(day),
                 new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        enforce(!canFind!(not!isDigit)(month),
+        enforce(all!isDigit(month),
                 new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
 
         if(year.length > 4)
         {
             enforce(year.startsWith("-") || year.startsWith("+"),
                     new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-            enforce(!canFind!(not!isDigit)(year[1..$]),
+            enforce(all!isDigit(year[1..$]),
                     new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
         }
         else
-            enforce(!canFind!(not!isDigit)(year),
+            enforce(all!isDigit(year),
                     new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
 
         return Date(to!short(year), to!ubyte(month), to!ubyte(day));
@@ -13164,17 +13164,17 @@ assert(Date.fromSimpleString(" 2010-Jul-04 ") == Date(2010, 7, 4));
 
         enforce(dstr[$-3] == '-', new DateTimeException(format("Invalid string format: %s", simpleString)));
         enforce(dstr[$-7] == '-', new DateTimeException(format("Invalid string format: %s", simpleString)));
-        enforce(!canFind!(not!isDigit)(day), new DateTimeException(format("Invalid string format: %s", simpleString)));
+        enforce(all!isDigit(day), new DateTimeException(format("Invalid string format: %s", simpleString)));
 
         if(year.length > 4)
         {
             enforce(year.startsWith("-") || year.startsWith("+"),
                     new DateTimeException(format("Invalid string format: %s", simpleString)));
-            enforce(!canFind!(not!isDigit)(year[1..$]),
+            enforce(all!isDigit(year[1..$]),
                     new DateTimeException(format("Invalid string format: %s", simpleString)));
         }
         else
-            enforce(!canFind!(not!isDigit)(year),
+            enforce(all!isDigit(year),
                     new DateTimeException(format("Invalid string format: %s", simpleString)));
 
         return Date(to!short(year), month, to!ubyte(day));
@@ -14533,9 +14533,9 @@ assert(TimeOfDay.fromISOString(" 123033 ") == TimeOfDay(12, 30, 33));
         auto minutes = dstr[2 .. 4];
         auto seconds = dstr[4 .. $];
 
-        enforce(!canFind!(not!isDigit)(hours), new DateTimeException(format("Invalid ISO String: %s", isoString)));
-        enforce(!canFind!(not!isDigit)(minutes), new DateTimeException(format("Invalid ISO String: %s", isoString)));
-        enforce(!canFind!(not!isDigit)(seconds), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce(all!isDigit(hours), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce(all!isDigit(minutes), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce(all!isDigit(seconds), new DateTimeException(format("Invalid ISO String: %s", isoString)));
 
         return TimeOfDay(to!int(hours), to!int(minutes), to!int(seconds));
     }
@@ -14644,11 +14644,11 @@ assert(TimeOfDay.fromISOExtString(" 12:30:33 ") == TimeOfDay(12, 30, 33));
 
         enforce(dstr[2] == ':', new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
         enforce(dstr[5] == ':', new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        enforce(!canFind!(not!isDigit)(hours),
+        enforce(all!isDigit(hours),
                 new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        enforce(!canFind!(not!isDigit)(minutes),
+        enforce(all!isDigit(minutes),
                 new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        enforce(!canFind!(not!isDigit)(seconds),
+        enforce(all!isDigit(seconds),
                 new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
 
         return TimeOfDay(to!int(hours), to!int(minutes), to!int(seconds));
@@ -28951,8 +28951,8 @@ private:
         else
             hoursStr = dstr;
 
-        enforce(!canFind!(not!isDigit)(hoursStr), new DateTimeException(format("Invalid ISO String: %s", dstr)));
-        enforce(!canFind!(not!isDigit)(minutesStr), new DateTimeException(format("Invalid ISO String: %s", dstr)));
+        enforce(all!isDigit(hoursStr), new DateTimeException(format("Invalid ISO String: %s", dstr)));
+        enforce(all!isDigit(minutesStr), new DateTimeException(format("Invalid ISO String: %s", dstr)));
 
         immutable hours = to!int(hoursStr);
         immutable minutes = minutesStr.empty ? 0 : to!int(minutesStr);
@@ -32977,7 +32977,7 @@ static FracSec fracSecFromISOString(S)(in S isoString)
     dstr.popFront();
 
     enforce(!dstr.empty && dstr.length <= 7, new DateTimeException("Invalid ISO String"));
-    enforce(!canFind!(not!isDigit)(dstr), new DateTimeException("Invalid ISO String"));
+    enforce(all!isDigit(dstr), new DateTimeException("Invalid ISO String"));
 
     dchar[7] fullISOString;
 


### PR DESCRIPTION
- !canFind(not!isDigit) == all!isDigit
