### PR TITLE
Fix Issue 11938 - Add std.traits.CompatibleUnqual

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -364,7 +364,7 @@ version(unittest)
 private T* addressOf(T)(ref T val) { return &val; }
 
 /**
-$(D auto map(Range)(Range r) if (isInputRange!(Unqual!Range));)
+$(D auto map(Range)(Range r) if (isInputRange!(CompatibleUnqual!Range));)
 
 Implements the homonym function (also known as $(D transform)) present
 in many languages of functional flavor. The call $(D map!(fun)(range))
@@ -374,7 +374,7 @@ not changed. Evaluation is done lazily.
 */
 template map(fun...) if (fun.length >= 1)
 {
-    auto map(Range)(Range r) if (isInputRange!(Unqual!Range))
+    auto map(Range)(Range r) if (isInputRange!(CompatibleUnqual!Range))
     {
         static if (fun.length > 1)
         {
@@ -433,7 +433,7 @@ unittest
 
 private struct MapResult(alias fun, Range)
 {
-    alias Unqual!Range R;
+    alias CompatibleUnqual!Range R;
     //alias typeof(fun(.ElementType!R.init)) ElementType;
     R _input;
 
@@ -711,7 +711,7 @@ template reduce(fun...) if (fun.length >= 1)
             {
                 alias args[0] seed;
                 alias args[1] r;
-                Unqual!(Args[0]) result = seed;
+                CompatibleUnqual!(Args[0]) result = seed;
                 for (; !r.empty; r.popFront())
                 {
                     static if (fun.length == 1)
@@ -745,7 +745,7 @@ template reduce(fun...) if (fun.length >= 1)
                     import std.conv : emplace;
 
                     static assert(fun.length > 1);
-                    Unqual!(typeof(r.front)) seed = r.front;
+                    CompatibleUnqual!(typeof(r.front)) seed = r.front;
                     typeof(adjoin!(staticMap!(binaryFun, fun))(seed, seed))
                         result = void;
                     foreach (i, T; result.Types)
@@ -771,11 +771,11 @@ template reduce(fun...) if (fun.length >= 1)
             {
                 static if (fun.length == 1)
                 {
-                    auto result = Tuple!(Unqual!(Args[0]))(args[0]);
+                    auto result = Tuple!(CompatibleUnqual!(Args[0]))(args[0]);
                 }
                 else
                 {
-                    Unqual!(Args[0]) result = args[0];
+                    CompatibleUnqual!(Args[0]) result = args[0];
                 }
 
                 enum bool initialized = true;
@@ -1382,7 +1382,7 @@ unittest
 }
 
 /**
-$(D auto filter(Range)(Range rs) if (isInputRange!(Unqual!Range));)
+$(D auto filter(Range)(Range rs) if (isInputRange!(CompatibleUnqual!Range));)
 
 Implements the homonym function present in various programming
 languages of functional flavor. The call $(D filter!(predicate)(range))
@@ -1391,7 +1391,7 @@ which $(D predicate(x)) is $(D true).
  */
 template filter(alias pred) if (is(typeof(unaryFun!pred)))
 {
-    auto filter(Range)(Range rs) if (isInputRange!(Unqual!Range))
+    auto filter(Range)(Range rs) if (isInputRange!(CompatibleUnqual!Range))
     {
         return FilterResult!(unaryFun!pred, Range)(rs);
     }
@@ -1426,7 +1426,7 @@ unittest
 
 private struct FilterResult(alias pred, Range)
 {
-    alias Unqual!Range R;
+    alias CompatibleUnqual!Range R;
     R _input;
 
     this(R r)
@@ -1560,7 +1560,7 @@ unittest
 }
 
 /**
- * $(D auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(Unqual!Range));)
+ * $(D auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(CompatibleUnqual!Range));)
  *
  * Similar to $(D filter), except it defines a bidirectional
  * range. There is a speed disadvantage - the constructor spends time
@@ -1572,7 +1572,7 @@ unittest
  */
 template filterBidirectional(alias pred)
 {
-    auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(Unqual!Range))
+    auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(CompatibleUnqual!Range))
     {
         return FilterBidiResult!(unaryFun!pred, Range)(r);
     }
@@ -1596,7 +1596,7 @@ unittest
 
 private struct FilterBidiResult(alias pred, Range)
 {
-    alias Unqual!Range R;
+    alias CompatibleUnqual!Range R;
     R _input;
 
     this(R r)

--- a/std/range.d
+++ b/std/range.d
@@ -1888,7 +1888,7 @@ assert(retro(retro(a)) is a);
 ----
  */
 auto retro(Range)(Range r)
-if (isBidirectionalRange!(Unqual!Range))
+if (isBidirectionalRange!(CompatibleUnqual!Range))
 {
     // Check for retro(retro(r)) and just return r in that case
     static if (is(typeof(retro(r.source)) == Range))
@@ -1899,7 +1899,7 @@ if (isBidirectionalRange!(Unqual!Range))
     {
         static struct Result()
         {
-            private alias Unqual!Range R;
+            private alias CompatibleUnqual!Range R;
 
             // User code can get and set source, too
             R source;
@@ -2097,7 +2097,7 @@ assert(stride(stride(a, 2), 3) == stride(a, 6));
 ----
  */
 auto stride(Range)(Range r, size_t n)
-if (isInputRange!(Unqual!Range))
+if (isInputRange!(CompatibleUnqual!Range))
 {
     import std.exception : enforce;
 
@@ -2112,7 +2112,7 @@ if (isInputRange!(Unqual!Range))
     {
         static struct Result
         {
-            private alias Unqual!Range R;
+            private alias CompatibleUnqual!Range R;
             public R source;
             private size_t _n;
 
@@ -2458,8 +2458,8 @@ assert(equal(s, [1, 2, 3, 4, 5, 6, 7][]));
  */
 auto chain(Ranges...)(Ranges rs)
 if (Ranges.length > 0 &&
-    allSatisfy!(isInputRange, staticMap!(Unqual, Ranges)) &&
-    !is(CommonType!(staticMap!(ElementType, staticMap!(Unqual, Ranges))) == void))
+    allSatisfy!(isInputRange, staticMap!(CompatibleUnqual, Ranges)) &&
+    !is(CommonType!(staticMap!(ElementType, staticMap!(CompatibleUnqual, Ranges))) == void))
 {
     static if (Ranges.length == 1)
     {
@@ -2470,7 +2470,7 @@ if (Ranges.length > 0 &&
         static struct Result
         {
         private:
-            alias staticMap!(Unqual, Ranges) R;
+            alias staticMap!(CompatibleUnqual, Ranges) R;
             alias CommonType!(staticMap!(.ElementType, R)) RvalueElementType;
             private template sameET(A)
             {
@@ -2890,7 +2890,7 @@ assert(equal(roundRobin(a, b), [1, 10, 2, 20, 3, 4]));
 ----
  */
 auto roundRobin(Rs...)(Rs rs)
-if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
+if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(CompatibleUnqual, Rs)))
 {
     struct Result
     {
@@ -2959,7 +2959,7 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
             mixin(makeSwitchIncrementCounter());
         }
 
-        static if (allSatisfy!(isForwardRange, staticMap!(Unqual, Rs)))
+        static if (allSatisfy!(isForwardRange, staticMap!(CompatibleUnqual, Rs)))
             @property auto save()
             {
                 Result result = this;
@@ -3012,7 +3012,7 @@ assert(equal(radial(a), [ 2, 3, 1, 4 ]));
 ----
  */
 auto radial(Range, I)(Range r, I startingIndex)
-if (isRandomAccessRange!(Unqual!Range) && hasLength!(Unqual!Range) && isIntegral!I)
+if (isRandomAccessRange!(CompatibleUnqual!Range) && hasLength!(CompatibleUnqual!Range) && isIntegral!I)
 {
     if (!r.empty) ++startingIndex;
     return roundRobin(retro(r[0 .. startingIndex]), r[startingIndex .. r.length]);
@@ -3020,7 +3020,7 @@ if (isRandomAccessRange!(Unqual!Range) && hasLength!(Unqual!Range) && isIntegral
 
 /// Ditto
 auto radial(R)(R r)
-if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R))
+if (isRandomAccessRange!(CompatibleUnqual!R) && hasLength!(CompatibleUnqual!R))
 {
     return .radial(r, (r.length - !r.empty) / 2);
 }
@@ -3084,12 +3084,12 @@ assert(equal(s, [ 1, 2, 3, 4, 5 ][]));
 ----
  */
 struct Take(Range)
-if (isInputRange!(Unqual!Range) &&
+if (isInputRange!(CompatibleUnqual!Range) &&
     //take _cannot_ test hasSlicing on infinite ranges, because hasSlicing uses
     //take for slicing infinite ranges.
     !((!isInfinite!(Unqual!Range) && hasSlicing!(Unqual!Range)) || is(Range T == Take!T)))
 {
-    private alias Unqual!Range R;
+    private alias CompatibleUnqual!Range R;
 
     // User accessible in read and write
     public R source;
@@ -3242,8 +3242,8 @@ if (isInputRange!(Unqual!Range) &&
 // This template simply aliases itself to R and is useful for consistency in
 // generic code.
 template Take(R)
-if (isInputRange!(Unqual!R) &&
-    ((!isInfinite!(Unqual!R) && hasSlicing!(Unqual!R)) || is(R T == Take!T)))
+if (isInputRange!(CompatibleUnqual!R) &&
+    ((!isInfinite!(CompatibleUnqual!R) && hasSlicing!(CompatibleUnqual!R)) || is(R T == Take!T)))
 {
     alias R Take;
 }
@@ -3251,7 +3251,7 @@ if (isInputRange!(Unqual!R) &&
 // take for finite ranges with slicing
 /// ditto
 Take!R take(R)(R input, size_t n)
-if (isInputRange!(Unqual!R) && !isInfinite!(Unqual!R) && hasSlicing!(Unqual!R))
+if (isInputRange!(CompatibleUnqual!R) && !isInfinite!(CompatibleUnqual!R) && hasSlicing!(CompatibleUnqual!R))
 {
     // @@@BUG@@@
     //return input[0 .. min(n, $)];
@@ -3267,7 +3267,7 @@ if (is(R T == Take!T))
 
 // Regular take for input ranges
 Take!(R) take(R)(R input, size_t n)
-if (isInputRange!(Unqual!R) && (isInfinite!(Unqual!R) || !hasSlicing!(Unqual!R) && !is(R T == Take!T)))
+if (isInputRange!(CompatibleUnqual!R) && (isInfinite!(CompatibleUnqual!R) || !hasSlicing!(CompatibleUnqual!R) && !is(R T == Take!T)))
 {
     return Take!R(input, n);
 }
@@ -5673,8 +5673,8 @@ if ((isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
 {
     import std.conv : unsigned;
 
-    alias CommonType!(Unqual!B, Unqual!E) Value;
-    alias Unqual!S StepType;
+    alias CommonType!(CompatibleUnqual!B, CompatibleUnqual!E) Value;
+    alias CompatibleUnqual!S StepType;
     alias typeof(unsigned((end - begin) / step)) IndexType;
 
     static struct Result
@@ -5769,7 +5769,7 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
 {
     import std.conv : unsigned;
 
-    alias CommonType!(Unqual!B, Unqual!E) Value;
+    alias CommonType!(CompatibleUnqual!B, CompatibleUnqual!E) Value;
     alias typeof(unsigned(end - begin)) IndexType;
 
     static struct Result
@@ -5837,7 +5837,7 @@ auto iota(E)(E end)
 auto iota(B, E, S)(B begin, E end, S step)
 if (isFloatingPoint!(CommonType!(B, E, S)))
 {
-    alias Unqual!(CommonType!(B, E, S)) Value;
+    alias CompatibleUnqual!(CommonType!(B, E, S)) Value;
     static struct Result
     {
         private Value start, step;
@@ -6132,7 +6132,7 @@ enum TransverseOptions
 struct FrontTransversal(Ror,
         TransverseOptions opt = TransverseOptions.assumeJagged)
 {
-    alias Unqual!(Ror)               RangeOfRanges;
+    alias CompatibleUnqual!(Ror)     RangeOfRanges;
     alias .ElementType!RangeOfRanges RangeType;
     alias .ElementType!RangeType     ElementType;
 
@@ -6409,7 +6409,7 @@ unittest {
 struct Transversal(Ror,
         TransverseOptions opt = TransverseOptions.assumeJagged)
 {
-    private alias Unqual!Ror RangeOfRanges;
+    private alias CompatibleUnqual!Ror RangeOfRanges;
     private alias ElementType!RangeOfRanges InnerRange;
     private alias ElementType!InnerRange E;
 
@@ -7438,7 +7438,7 @@ private struct OnlyResult(T, size_t arity : 1)
         return copy;
     }
 
-    private Unqual!T _value;
+    private CompatibleUnqual!T _value;
     private bool _empty = false;
 }
 
@@ -7983,7 +7983,7 @@ class OutputRangeObject(R, E...) : staticMap!(OutputRange, E) {
 
 
 /**Returns the interface type that best matches $(D R).*/
-template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
+template MostDerivedInputRange(R) if (isInputRange!(CompatibleUnqual!R)) {
     private alias ElementType!R E;
 
     static if (isRandomAccessRange!R) {
@@ -8019,11 +8019,11 @@ template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
  * all relevant range primitives in virtual functions.  If $(D R) is already
  * derived from the $(D InputRange) interface, aliases itself away.
  */
-template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
+template InputRangeObject(R) if (isInputRange!(CompatibleUnqual!R)) {
     static if (is(R : InputRange!(ElementType!R))) {
         alias R InputRangeObject;
-    } else static if (!is(Unqual!R == R)) {
-        alias InputRangeObject!(Unqual!R) InputRangeObject;
+    } else static if (!is(CompatibleUnqual!R == R)) {
+        alias InputRangeObject!(CompatibleUnqual!R) InputRangeObject;
     } else {
 
         ///
@@ -8834,9 +8834,9 @@ almost-sorted range is likely to pass it). To check for sortedness at
 cost $(BIGOH n), use $(XREF algorithm,isSorted).
  */
 auto assumeSorted(alias pred = "a < b", R)(R r)
-if (isRandomAccessRange!(Unqual!R))
+if (isRandomAccessRange!(CompatibleUnqual!R))
 {
-    return SortedRange!(Unqual!R, pred)(r);
+    return SortedRange!(CompatibleUnqual!R, pred)(r);
 }
 
 unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -107,7 +107,6 @@
  * ))
  * $(TR $(TD General Types) $(TD
  *           $(LREF Unqual)
- *           $(LREF CompatibleUnqual)
  *           $(LREF ForeachType)
  *           $(LREF OriginalType)
  *           $(LREF PointerTarget)
@@ -5614,7 +5613,7 @@ static assert(is(CompatibleUnqual!(const S) == S));
 static assert(is(CompatibleUnqual!(const P) == const P));
 ----
  */
-template CompatibleUnqual(T)
+package template CompatibleUnqual(T)
 {
     static if (is(T : Unqual!T))
         alias CompatibleUnqual = Unqual!T;


### PR DESCRIPTION
`CompatibleUnqual` is similar to `Unqual`, except it only removes qualifiers when the unqualified type is compatible with the original type, i.e. `is(T : CompatibleUnqual!T)` is always true.

https://d.puremagic.com/issues/show_bug.cgi?id=11938

As mentioned in the bug, this is useful when writing range algorithms and you want to get a mutable version of a range (when possible).
