### PR TITLE
Update numeric.d

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1175,13 +1175,13 @@ unittest
 */
 }
 
-
 //regression control
 unittest
 {
     static assert(__traits(compiles, findRoot((float x)=>cast(real)x, float.init, float.init)));
     static assert(__traits(compiles, findRoot!real((x)=>cast(double)x, real.init, real.init)));
 }
+
 
 /**
 Computes $(LUCKY Euclidean distance) between input ranges $(D a) and


### PR DESCRIPTION
Modify `private oppositeSigns`.
Reason: `findRoot!(double, real)` failed to compile.
