### PR TITLE
Update numeric.d

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -710,9 +710,10 @@ public:
  * www.netlib.org,www.netlib.org) as algorithm TOMS478.
  *
  */
-T findRoot(T, R)(scope R delegate(T) f, T a, T b)
+T findRoot(T, R)(scope R delegate(T) f, in T a, in T b, 
+    scope bool delegate(T lo, T hi) tolerance = (T a, T b) => false)
 {
-    auto r = findRoot(f, a, b, f(a), f(b), (T lo, T hi){ return false; });
+    auto r = findRoot(f, a, b, f(a), f(b), tolerance);
     // Return the first value if it is smaller or NaN
     return !(fabs(r[2]) > fabs(r[3])) ? r[0] : r[1];
 }
@@ -750,8 +751,8 @@ T findRoot(T, R)(scope R delegate(T) f, T a, T b)
  * root was found, both of the first two elements will contain the
  * root, and the second pair of elements will be 0.
  */
-Tuple!(T, T, R, R) findRoot(T,R)(scope R delegate(T) f, T ax, T bx, R fax, R fbx,
-    scope bool delegate(T lo, T hi) tolerance)
+Tuple!(T, T, R, R) findRoot(T,R)(scope R delegate(T) f, in T ax, in T bx, in R fax, in R fbx,
+    scope bool delegate(T lo, T hi) tolerance = (T a, T b) => false)
 in {
     assert(!ax.isNaN && !bx.isNaN, "Limits must not be NaN");
     assert(signbit(fax) != signbit(fbx), "Parameters must bracket the root.");


### PR DESCRIPTION
findRoot flexibility fix.

`in` for generic code with `const`:

``` D
const a = float.min_normal;
const b = float.max;
const fa = equation(a);
const fb = equation(b); 
const r = equation.findRoot(a, b, fa, fb);
```
