### PR TITLE
Fix issue 12007 - cartesianProduct does'nt work with ranges of immutable...

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4145,7 +4145,20 @@ Models an infinite bidirectional and random access range, with slicing.
 */
 struct Repeat(T)
 {
-    private T _value;
+private:
+    //Store a non-qualified T when possible: This is to make Repeat assignable
+    static if ((is(T == class) || is(T == interface)) && (is(T == const) || is(T == immutable)))
+    {
+        import std.typecons;
+        alias UT = Rebindable!T;
+    }
+    else static if (is(T : Unqual!T))
+        alias UT = Unqual!T;
+    else
+        alias UT = T;
+    UT _value;
+
+public:
     @property inout(T) front() inout { return _value; }
     @property inout(T) back() inout { return _value; }
     enum bool empty = false;
@@ -4207,6 +4220,21 @@ Take!(Repeat!T) repeat(T)(T value, size_t n)
 unittest
 {
     assert(equal(5.repeat(4), 5.repeat().take(4)));
+}
+
+unittest //12007
+{
+    static class C{}
+    Repeat!(immutable int) ri;
+    ri = ri.save;
+    Repeat!(immutable C) rc;
+    rc = rc.save;
+
+    import std.algorithm;
+    immutable int[] A = [1,2,3];
+    immutable int[] B = [4,5,6];
+
+    auto AB = cartesianProduct(A,B);
 }
 
 /**


### PR DESCRIPTION
...s

https://d.puremagic.com/issues/show_bug.cgi?id=12007

The fix consists in making Repeat!T assignable, even if T itself is not. This is important to be able to store copies of a saved range (the `save` trait only checks for copy constructible).

For the case of const/immutable classes, I used a `Rebindable`. This is _slightly_ sub-optimal, as it adds a dependency on `std.typecons`, and gives `Repeat` an elaborate assign. That said, it's a trivial 1 line fix, so totally worth it.
