### PR TITLE
Fix issue 12007 - cartesianProduct doesn't work with ranges of immutable...

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4632,11 +4632,8 @@ struct Zip(Ranges...)
  */
     this(R rs, StoppingPolicy s = StoppingPolicy.shortest)
     {
+        ranges[] = rs[];
         stoppingPolicy = s;
-        foreach (i, Unused; R)
-        {
-            ranges[i] = rs[i];
-        }
     }
 
 /**


### PR DESCRIPTION
...s

https://d.puremagic.com/issues/show_bug.cgi?id=12007

This makes a tweak to `Zip`'s `save`: Now, it _builds_ a new `Zip` object
from the saved ranges, rather than assigning each range individually.

This gives 2 advantages:
1. Better support for `save` (which doesn't actaully guarantee assignability)
2. Avoids useless `opAssign` overhead
