### PR TITLE
Fix Issue 12027 - Iterate set bits in BitArray.

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3437,7 +3437,7 @@ unittest
 Counts the number of trailing zeros in the binary representation of $(D value).
 For signed integers, the sign bit is included in the count.
 */
-uint countTrailingZeros(T)(T value)
+private uint countTrailingZeros(T)(T value)
     if (isIntegral!T)
 {
     // bsf doesn't give the correct result for 0.
@@ -3499,7 +3499,7 @@ unittest
 Counts the number of set bits in the binary representation of $(D value).
 For signed integers, the sign bit is included in the count.
 */
-uint countBitsSet(T)(T value)
+private uint countBitsSet(T)(T value)
     if (isIntegral!T)
 {
     // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel


### PR DESCRIPTION
Also adds:
- countTrailingZeros(v)
- countBitsSet(v)
- bitsSet(v)

Notes:
- There is a `popcnt` function in `core.bitops`, but it only works with `int`.
- `bitsSet(v)` could be a bidirectional and possibly even random access range, but I'll leave that for future work for now.

https://d.puremagic.com/issues/show_bug.cgi?id=12027
