### PR TITLE
Fix issue 12069

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -3173,7 +3173,7 @@ template BacktrackingMatcher(bool CTregex)
         }
         static assert(State.sizeof % size_t.sizeof == 0);
         enum stateSize = State.sizeof / size_t.sizeof;
-        enum initialStack = 1<<16;
+        enum initialStack = 1<<11; // items in a block of segmented stack
         alias const(Char)[] String;
         alias RegEx = Regex!Char;
         alias MatchFn = bool function (ref BacktrackingMatcher!(Char, Stream));


### PR DESCRIPTION
On Win32 allocating large blocks (>512K) is forwarded to
VirtualAlloc/VirtualFree. Doing these calls is expensive especially in a
loop. As a temporary solution a block size of a segmented stack is
decreased to ~1/8 of critical size.

The code needs to be adapted once allocators are in std.
