### PR TITLE
std.net.curl: Publicly import CurlOption

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -166,6 +166,8 @@ import std.traits;
 import std.typecons;
 import std.typetuple;
 
+public import etc.c.curl : CurlOption;
+
 version(unittest)
 {
     // Run unit test with the PHOBOS_TEST_ALLOW_NET=1 set in order to


### PR DESCRIPTION
CurlOption is a type declared in etc.c.curl (the C binding module), which is present in std.net.curl's interface. I'm not sure if it's the only declaration in etc.c.curl that's present in std.net.curl's interface, but by my experience it is certainly the most frequently needed one. One shouldn't need to import the C bindings module just to be able to pass the correct argument type to std.net.curl methods.
