### PR TITLE
Regression Test 9184 - all with lambda predicate

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -11122,6 +11122,12 @@ unittest
     assert(all!(a => a > x)([2, 3]));
 }
 
+unittest
+{
+    // Issue 9184
+    assert(all!(a => a >= 0)([1, 2, 3]));
+}
+
 /**
 Copies the top $(D n) elements of the input range $(D source) into the
 random-access range $(D target), where $(D n =


### PR DESCRIPTION
The bug appears to have been fixed indirectly in 2.062 -> 2.063. This pull adds a regression test to make sure it doesn't come back.

https://d.puremagic.com/issues/show_bug.cgi?id=9184
