### PR TITLE
Regression Test 8282 - new Array!T

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -3712,8 +3712,7 @@ unittest //11884
 
 unittest //8282
 {
-    static struct Bug8282 {}
-    Array!(Bug8282)* arr = new Array!(Bug8282);
+    auto arr = new Array!int;
 }
 
 // BinaryHeap


### PR DESCRIPTION
This one doesn't have an equivalent test, so adding this to make sure the bug never comes back. The actual issue was fixed in 2.063.

https://d.puremagic.com/issues/show_bug.cgi?id=8282
