### PR TITLE
Fix issue 10958 - Variant fails to compile for types with sizeof == 0.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1720,7 +1720,6 @@ unittest
     class EmptyClass { }
     struct EmptyStruct { }
     alias EmptyArray = void[0];
-
     alias Alg = Algebraic!(EmptyClass, EmptyStruct, EmptyArray);
 
     Variant testEmpty(T)() 
@@ -1739,9 +1738,11 @@ unittest
     testEmpty!EmptyStruct();
     testEmpty!EmptyArray();
 
-    EmptyArray e = EmptyArray.init;
-    Variant v2 = e;
-    assert(v2.length == 0);
+    // EmptyClass/EmptyStruct sizeof is 1, so we have this to test just size 0.
+    EmptyArray arr = EmptyArray.init;
+    Algebraic!(EmptyArray) a = arr;
+    assert(a.length == 0);
+    assert(a.get!EmptyArray == arr);
 }
 
 // Handling of void function pointers / delegates, e.g. issue 11360


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10958

So far as I can tell that static assert that was removed has no purpose. Behaviour is as expected for types with no size, and I've looked through each instance where "size" is mentioned to make sure there's nothing that would break if it's too small. I couldn't find any problems with smaller types with the current version of DMD, so I just removed the static assert.

Can anyone who knows the original reason for this static assert verify this is safe to remove?
