### PR TITLE
std.file: Fix rmdirRecurse and symlinks/junctions on Windows

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2389,8 +2389,13 @@ void rmdirRecurse(ref DirEntry de)
     if(!de.isDir)
         throw new FileException(de.name, "Not a directory");
 
-    if(de.isSymlink)
-        remove(de.name);
+    if (de.isSymlink)
+    {
+        version (Windows)
+            rmdir(de.name);
+        else
+            remove(de.name);
+    }
     else
     {
         // all children, recursively depth-first


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12165

Unfortunately I can't add tests because creating the symlinks/junctions is fairly involved, except for very recent Windows versions.
