### PR TITLE
Remove useless lambda

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2325,7 +2325,7 @@ struct Appender(A : T[], T)
         immutable len = _data.arr.length;
         immutable reqlen = len + nelems;
 
-        if (()@trusted{ return _data.capacity; }() >= reqlen)
+        if (_data.capacity >= reqlen)
             return;
 
         // need to increase capacity


### PR DESCRIPTION
Just removing a useless lambda in Appender: `capacity` is simply a data member of the `Data` struct. It was probably marked for trust when mistaken for a UFCS call to `capacity(T)(T[])`, which isn't safe.
