### PR TITLE
Fix Issue 11017 - Improve performance of toLower etc.

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6934,6 +6934,7 @@ private S toCase(alias indexFn, uint maxIdx, alias tableFn, S)(S s) @trusted pur
         if(idx == ushort.max)
             continue;
         auto result = appender!S(s[0..i]);
+        result.reserve(s.length);
         foreach(dchar c; s[i .. $])
         {
             idx = indexFn(c);


### PR DESCRIPTION
Changed to use `appender` instead of repeated `~=`.

https://d.puremagic.com/issues/show_bug.cgi?id=11017
