### PR TITLE
Mark `std.stdio.testFilename` as `@safe` and `pure`

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3802,7 +3802,7 @@ version(linux)
     }
 }
 
-version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__)
+version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe pure
 {
     import std.conv : text;
     import std.path : baseName;


### PR DESCRIPTION
It does not use unsafe operations and does not touch global states.
It will help us to make unittests in std.stdio `@safe` and `pure`.
