### PR TITLE
[ARM] Some FPUs do not support exception trapping, disable test

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3786,9 +3786,31 @@ private:
         static assert(false, "Architecture not supported");
 
 public:
+    /// Returns true if the current FPU supports exception trapping
+    @property static bool hasExceptionTraps() @safe nothrow
+    {
+        version(X86)
+            return true;
+        else version(X86_64)
+            return true;
+        else version(ARM)
+        {
+            auto oldState = getControlState();
+            // If exceptions are not supported, we set the bit but read it back as zero
+            // https://sourceware.org/ml/libc-ports/2012-06/msg00091.html
+            setControlState(oldState | (divByZeroException & EXCEPTION_MASK));
+            bool result = (getControlState() & EXCEPTION_MASK) != 0;
+            setControlState(oldState);
+            return result;
+        }
+        else
+            static assert(false, "Not implemented for this architecture");
+    }
+
     /// Enable (unmask) specific hardware exceptions. Multiple exceptions may be ORed together.
     void enableExceptions(uint exceptions)
     {
+        assert(hasExceptionTraps);
         initialize();
         version(ARM)
             setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
@@ -3799,6 +3821,7 @@ public:
     /// Disable (mask) specific hardware exceptions. Multiple exceptions may be ORed together.
     void disableExceptions(uint exceptions)
     {
+        assert(hasExceptionTraps);
         initialize();
         version(ARM)
             setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
@@ -3816,6 +3839,7 @@ public:
     /// Return the exceptions which are currently enabled (unmasked)
     @property static uint enabledExceptions()
     {
+        assert(hasExceptionTraps);
         version(ARM)
             return (getControlState() & EXCEPTION_MASK);
         else
@@ -3952,6 +3976,7 @@ unittest
     }
     ensureDefaults();
 
+    if(FloatingPointControl.hasExceptionTraps)
     {
         FloatingPointControl ctrl;
         ctrl.enableExceptions(FloatingPointControl.divByZeroException


### PR DESCRIPTION
Some ARM FPUs do not support exception trapping ('signaling exceptions', exceptions which you don't have to poll for, but get a signal if they occur).

This pull adds:
- A `hasExceptionTraps` function which returns true if the current FPU supports exception trapping
- `assert(hasExceptionTraps)` checks for `enabledExceptions`, `enableExceptions`, `disableExceptions`
- A check for `hasExceptionTraps` to disable the unit test  if exception trapping isn't available

I'm not sure if it's always possible to get the `hasExceptionTraps` information for all architectures. Should we use an enum with `true/false/unknown` as a return value?
