### PR TITLE
Add unittests: compare BigUint(0) to 0UL

### DIFF
--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -868,6 +868,12 @@ unittest
     BigUint a = [1];
     assert(a == 1);
     assert(a < 0x8000_0000_0000_0000UL); // bug 9548
+
+    // bug 12234
+    BigUint z = [0];
+    assert(z == 0UL);
+    assert(!(z > 0UL));
+    assert(!(z < 0UL));
 }
 
 // Remove leading zeros from x, to restore the BigUint invariant


### PR DESCRIPTION
to prevent regression of bug 12234.
