### PR TITLE
Fixup Repeat condition

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4150,7 +4150,7 @@ private:
         import std.typecons;
         alias UT = Rebindable!T;
     }
-    else static if (is(T : Unqual!T))
+    else static if (is(T : Unqual!T) && is(Unqual!T : T))
         alias UT = Unqual!T;
     else
         alias UT = T;


### PR DESCRIPTION
Fixup of #1895 : I just realized we needed two way conversion (for returning the value from mutable to qualified), and that `qualified : mutable` is not necessarily equivalent (say, as struct with a const alias this that returns a mutable).

I'm leaving on a 10 day leave, so I won't be able to reply for a little while. I also didn't have time to write a unittest for this. Sorry. Since this was a potential reg though, I figured it was important to submit it sooner rather than later.
