### PR TITLE
[Trivial] Fix documentation typos in Phobos

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -926,7 +926,7 @@ static ~this()
 
 /**
  * Associates name with tid in a process-local map.  When the thread
- * represented by tid termiantes, any names associated with it will be
+ * represented by tid terminates, any names associated with it will be
  * automatically unregistered.
  *
  * Params:

--- a/std/container.d
+++ b/std/container.d
@@ -82,7 +82,7 @@ first element of the _container, in a _container-defined order.))
 $(TR $(TDNW $(D c.moveFront)) $(TDNW $(D log n$(SUB c))) $(TD
 Destructively reads and returns the first element of the
 _container. The slot is not removed from the _container; it is left
-initalized with $(D T.init). This routine need not be defined if $(D
+initialized with $(D T.init). This routine need not be defined if $(D
 front) returns a $(D ref).))
 
 $(TR $(TDNW $(D c.front = v)) $(TDNW $(D log n$(SUB c))) $(TD Assigns
@@ -94,7 +94,7 @@ last element of the _container, in a _container-defined order.))
 $(TR $(TDNW $(D c.moveBack)) $(TDNW $(D log n$(SUB c))) $(TD
 Destructively reads and returns the last element of the
 container. The slot is not removed from the _container; it is left
-initalized with $(D T.init). This routine need not be defined if $(D
+initialized with $(D T.init). This routine need not be defined if $(D
 front) returns a $(D ref).))
 
 $(TR $(TDNW $(D c.back = v)) $(TDNW $(D log n$(SUB c))) $(TD Assigns

--- a/std/conv.d
+++ b/std/conv.d
@@ -3544,7 +3544,7 @@ The $(D octal) facility is intended as an experimental facility to
 replace _octal literals starting with $(D '0'), which many find
 confusing. Using $(D octal!177) or $(D octal!"177") instead of $(D
 0177) as an _octal literal makes code clearer and the intent more
-visible. If use of this facility becomes preponderent, a future
+visible. If use of this facility becomes predominant, a future
 version of the language may deem old-style _octal literals deprecated.
 
 The rules for strings are the usual for literals: If it can fit in an

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -483,7 +483,7 @@ unittest
 unittest
 {
     //Let's use the template features:
-    //Note: When passing a SHA1 to a function, it must be passed by referece!
+    //Note: When passing a SHA1 to a function, it must be passed by reference!
     void doSomething(T)(ref T hash) if(isDigest!T)
     {
       hash.put(cast(ubyte)0);

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1242,8 +1242,8 @@ Returns true if c is a valid code point
  since these are valid code points (even though they are not valid
  characters).
 
- Supercedes:
- This function supercedes $(D std.utf.startsValidDchar()).
+ Supersedes:
+ This function supersedes $(D std.utf.startsValidDchar()).
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1284,7 +1284,7 @@ unittest
 }
 
 /**
- Returns true iff it is possible to represent the specifed codepoint
+ Returns true iff it is possible to represent the specified codepoint
  in the encoding.
 
  The type of encoding cannot be deduced. Therefore, it is necessary to
@@ -1341,10 +1341,10 @@ unittest
 /**
  Returns true if the string is encoded correctly
 
- Supercedes:
- This function supercedes std.utf.validate(), however note that this
+ Supersedes:
+ This function supersedes std.utf.validate(), however note that this
  function returns a bool indicating whether the input was valid or not,
- wheras the older funtion would throw an exception.
+ whereas the older function would throw an exception.
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1507,8 +1507,8 @@ unittest
  The input to this function MUST be validly encoded.
  This is enforced by the function's in-contract.
 
- Supercedes:
- This function supercedes std.utf.toUTFindex().
+ Supersedes:
+ This function supersedes std.utf.toUTFindex().
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1543,9 +1543,9 @@ unittest
  The input to this function MUST be validly encoded.
  This is enforced by the function's in-contract.
 
- Supercedes:
- This function supercedes std.utf.decode(), however, note that the
- function codePoints() supercedes it more conveniently.
+ Supersedes:
+ This function supersedes std.utf.decode(), however, note that the
+ function codePoints() supersedes it more conveniently.
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1650,9 +1650,9 @@ body
  The type of the output cannot be deduced. Therefore, it is necessary to
  explicitly specify the encoding as a template parameter.
 
- Supercedes:
- This function supercedes std.utf.encode(), however, note that the
- function codeUnits() supercedes it more conveniently.
+ Supersedes:
+ This function supersedes std.utf.encode(), however, note that the
+ function codeUnits() supersedes it more conveniently.
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1682,9 +1682,9 @@ body
  The type of the output cannot be deduced. Therefore, it is necessary to
  explicitly specify the encoding as a template parameter.
 
- Supercedes:
- This function supercedes std.utf.encode(), however, note that the
- function codeUnits() supercedes it more conveniently.
+ Supersedes:
+ This function supersedes std.utf.encode(), however, note that the
+ function codeUnits() supersedes it more conveniently.
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1719,9 +1719,9 @@ body
 //  * The type of the output cannot be deduced. Therefore, it is necessary to
 //  * explicitly specify the encoding as a template parameter.
 //  *
-//  * Supercedes:
-//  * This function supercedes std.utf.encode(), however, note that the
-//  * function codeUnits() supercedes it more conveniently.
+//  * Supersedes:
+//  * This function supersedes std.utf.encode(), however, note that the
+//  * function codeUnits() supersedes it more conveniently.
 //  *
 //  * Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 //  *
@@ -1820,9 +1820,9 @@ unittest
  The type of the output cannot be deduced. Therefore, it is necessary to
  explicitly specify the encoding as a template parameter.
 
- Supercedes:
- This function supercedes std.utf.encode(), however, note that the
- function codeUnits() supercedes it more conveniently.
+ Supersedes:
+ This function supersedes std.utf.encode(), however, note that the
+ function codeUnits() supersedes it more conveniently.
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1852,8 +1852,8 @@ body
  at each iteration with the offset into the string at which the code point
  begins.
 
- Supercedes:
- This function supercedes std.utf.decode().
+ Supersedes:
+ This function supersedes std.utf.decode().
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1903,8 +1903,8 @@ unittest
  The type of the output cannot be deduced. Therefore, it is necessary to
  explicitly specify the encoding type in the template parameter.
 
- Supercedes:
- This function supercedes std.utf.encode().
+ Supersedes:
+ This function supersedes std.utf.encode().
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -1968,10 +1968,10 @@ size_t encode(Tgt, Src, R)(in Src[] s, R range)
  The input to this function MUST be validly encoded.
  This is enforced by the function's in-contract.
 
- Supercedes:
- This function supercedes std.utf.toUTF8(), std.utf.toUTF16() and
+ Supersedes:
+ This function supersedes std.utf.toUTF8(), std.utf.toUTF16() and
  std.utf.toUTF32()
- (but note that to!() supercedes it more conveniently).
+ (but note that to!() supersedes it more conveniently).
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252
 
@@ -2083,8 +2083,8 @@ unittest
  The input to this function MUST be validly encoded.
  This is enforced by the function's in-contract.
 
- Supercedes:
- This function supercedes std.utf.toUTF8(), std.utf.toUTF16() and
+ Supersedes:
+ This function supersedes std.utf.toUTF8(), std.utf.toUTF16() and
  std.utf.toUTF32().
 
  Standards: Unicode 5.0, ASCII, ISO-8859-1, WINDOWS-1252

--- a/std/exception.d
+++ b/std/exception.d
@@ -702,7 +702,7 @@ enum emptyExceptionMsg = "<Empty Exception Message>";
  * but its name documents assumptions on the part of the
  * caller. $(D assumeUnique(arr)) should only be called when
  * there are no more active mutable aliases to elements of $(D
- * arr). To strenghten this assumption, $(D assumeUnique(arr))
+ * arr). To strengthen this assumption, $(D assumeUnique(arr))
  * also clears $(D arr) before returning. Essentially $(D
  * assumeUnique(arr)) indicates commitment from the caller that there
  * is no more mutable access to any of $(D arr)'s elements
@@ -727,7 +727,7 @@ enum emptyExceptionMsg = "<Empty Exception Message>";
  * ----
  *
  * The use in the example above is correct because $(D result)
- * was private to $(D letters) and is unaccessible in writing
+ * was private to $(D letters) and is inaccessible in writing
  * after the function returns. The following example shows an
  * incorrect use of $(D assumeUnique).
  *
@@ -1259,7 +1259,7 @@ class ErrnoException : Exception
     static assert(!__traits(compiles, (new Object()).ifThrown(1)));
     --------------------
 
-    If you need to use the actual thrown expection, you can use a delegate.
+    If you need to use the actual thrown exception, you can use a delegate.
     Example:
     --------------------
     //Use a lambda to get the thrown object.

--- a/std/math.d
+++ b/std/math.d
@@ -4,7 +4,7 @@
  * Elementary mathematical functions
  *
  * Contains the elementary mathematical functions (powers, roots,
- * and trignometric functions), and low-level floating-point operations.
+ * and trigonometric functions), and low-level floating-point operations.
  * Mathematical special functions are available in std.mathspecial.
  *
  * The functionality closely follows the IEEE754-2008 standard for
@@ -3615,7 +3615,7 @@ private:
 public:
     version (IeeeFlagsSupport) {
 
-     /// The result cannot be represented exactly, so rounding occured.
+     /// The result cannot be represented exactly, so rounding occurred.
      /// (example: x = sin(0.1); )
      @property bool inexact() { return (flags & INEXACT_MASK) != 0; }
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -123,7 +123,7 @@ http.perform();
 First, an instance of the reference-counted HTTP struct is created. Then the
 custom delegates are set. These will be called whenever the HTTP instance
 receives a header and a data buffer, respectively. In this simple example, the
-headers are writting to stdout and the data is ignored. If the request should be
+headers are written to stdout and the data is ignored. If the request should be
 stopped before it has finished then return something less than data.length from
 the onReceive callback. See $(LREF onReceiveHeader)/$(LREF onReceive) for more
 information. Finally the HTTP request is effected by calling perform(), which is
@@ -139,7 +139,7 @@ License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
 Authors: Jonas Drewsen. Some of the SMTP code contributed by Jimmy Cao.
 
 Credits: The functionally is based on $(WEB _curl.haxx.se/libcurl, libcurl).
-         LibCurl is licensed under an MIT/X derivate license.
+         LibCurl is licensed under an MIT/X derivative license.
 */
 /*
          Copyright Jonas Drewsen 2011 - 2012.

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -150,7 +150,7 @@ private template CustomFloatParams(uint precision, uint exponentWidth, CustomFlo
  * writeln(w);
  *
  * // Functions calls require conversion
- * z = sin(+x)           + cos(+y);                     // Use uniary plus to concisely convert to a real
+ * z = sin(+x)           + cos(+y);                     // Use unary plus to concisely convert to a real
  * z = sin(x.re)         + cos(y.re);                   // Or use the .re property to convert to a real
  * z = sin(x.get!float)  + cos(y.get!float);            // Or use get!T
  * z = sin(cast(float)x) + cos(cast(float)y);           // Or use cast(T) to explicitly convert

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2091,7 +2091,7 @@ public:
     Given a $(D source) range that is expensive to iterate over, returns an
     input range that asynchronously buffers the contents of
     $(D source) into a buffer of $(D bufSize) elements in a worker thread,
-    while making prevously buffered elements from a second buffer, also of size
+    while making previously buffered elements from a second buffer, also of size
     $(D bufSize), available via the range interface of the returned
     object.  The returned range has a length iff $(D hasLength!S).
     $(D asyncBuf) is useful, for example, when performing expensive operations
@@ -2104,7 +2104,7 @@ public:
     void main()
     {
         // Fetch lines of a file in a background thread
-        // while processing prevously fetched lines,
+        // while processing previously fetched lines,
         // dealing with byLine's buffer recycling by
         // eagerly duplicating every line.
         auto lines = File("foo.txt").byLine();
@@ -2296,7 +2296,7 @@ public:
     Examples:
     ---
     // Fetch lines of a file in a background
-    // thread while processing prevously fetched
+    // thread while processing previously fetched
     // lines, without duplicating any lines.
     auto file = File("foo.txt");
 
@@ -2965,7 +2965,7 @@ public:
 
     The proper way to instantiate this object is to call
     $(D WorkerLocalStorage.toRange).  Once instantiated, this object behaves
-    as a finite random-access range with assignable, lvalue elemends and
+    as a finite random-access range with assignable, lvalue elements and
     a length equal to the number of worker threads in the $(D TaskPool) that
     created it plus 1.
      */
@@ -3078,7 +3078,7 @@ public:
     a call to $(D Task.workForce), $(D Task.yieldForce) or $(D Task.spinForce)
     causes them to be executed.
 
-    Use only if you have waitied on every $(D Task) and therefore know the
+    Use only if you have waited on every $(D Task) and therefore know the
     queue is empty, or if you speculatively executed some tasks and no longer
     need the results.
      */

--- a/std/regex.d
+++ b/std/regex.d
@@ -5646,7 +5646,7 @@ public:
 unittest
 {
     auto c = matchFirst("@abc#", regex(`(\w)(\w)(\w)`));
-    assert(c.pre == "@"); // Part of input preceeding match
+    assert(c.pre == "@"); // Part of input preceding match
     assert(c.post == "#"); // Immediately after match
     assert(c.hit == c[0] && c.hit == "abc"); // The whole match
     assert(c[2] == "b");

--- a/std/string.d
+++ b/std/string.d
@@ -244,7 +244,7 @@ unittest
 enum CaseSensitive { no, yes }
 
 /++
-    Returns the index of the first occurence of $(D c) in $(D s). If $(D c)
+    Returns the index of the first occurrence of $(D c) in $(D s). If $(D c)
     is not found, then $(D -1) is returned.
 
     $(D cs) indicates whether the comparisons are case sensitive.
@@ -339,7 +339,7 @@ unittest
 }
 
 /++
-    Returns the index of the first occurence of $(D c) in $(D s) with respect
+    Returns the index of the first occurrence of $(D c) in $(D s) with respect
     to the start index $(D startIdx). If $(D c) is not found, then $(D -1) is
     returned. If $(D c) is found the value of the returned index is at least
     $(D startIdx). $(D startIdx) represents a codeunit index in $(D s). If the
@@ -404,7 +404,7 @@ unittest
 }
 
 /++
-    Returns the index of the first occurence of $(D sub) in $(D s). If $(D sub)
+    Returns the index of the first occurrence of $(D sub) in $(D s). If $(D sub)
     is not found, then $(D -1) is returned.
 
     $(D cs) indicates whether the comparisons are case sensitive.
@@ -480,7 +480,7 @@ unittest
 }
 
 /++
-    Returns the index of the first occurence of $(D sub) in $(D s) with
+    Returns the index of the first occurrence of $(D sub) in $(D s) with
     respect to the start index $(D startIdx). If $(D sub) is not found, then
     $(D -1) is returned. If $(D sub) is found the value of the returned index
     is at least $(D startIdx). $(D startIdx) represents a codeunit index in
@@ -563,7 +563,7 @@ unittest
 }
 
 /++
-    Returns the index of the last occurence of $(D c) in $(D s). If $(D c)
+    Returns the index of the last occurrence of $(D c) in $(D s). If $(D c)
     is not found, then $(D -1) is returned.
 
     $(D cs) indicates whether the comparisons are case sensitive.
@@ -668,7 +668,7 @@ unittest
 }
 
 /++
-    Returns the index of the last occurence of $(D c) in $(D s). If $(D c) is
+    Returns the index of the last occurrence of $(D c) in $(D s). If $(D c) is
     not found, then $(D -1) is returned. The $(D startIdx) slices $(D s) in
     the following way $(D s[0 .. startIdx]). $(D startIdx) represents a
     codeunit index in $(D s). If the sequence ending at $(D startIdx) does not
@@ -722,7 +722,7 @@ unittest
 }
 
 /++
-    Returns the index of the last occurence of $(D sub) in $(D s). If $(D sub)
+    Returns the index of the last occurrence of $(D sub) in $(D s). If $(D sub)
     is not found, then $(D -1) is returned.
 
     $(D cs) indicates whether the comparisons are case sensitive.
@@ -858,7 +858,7 @@ unittest
 }
 
 /++
-    Returns the index of the last occurence of $(D sub) in $(D s). If $(D sub)
+    Returns the index of the last occurrence of $(D sub) in $(D s). If $(D sub)
     is not found, then $(D -1) is returned. The $(D startIdx) slices $(D s) in
     the following way $(D s[0 .. startIdx]). $(D startIdx) represents a
     codeunit index in $(D s). If the sequence ending at $(D startIdx) does not
@@ -2941,7 +2941,7 @@ unittest
     $(D to) is taken to be the same as $(D from).
 
     If the modifier $(D 'd') is $(I not) present, and $(D to) is shorter than
-    $(D from), then $(D to) is extended by replicating the last charcter in
+    $(D from), then $(D to) is extended by replicating the last character in
     $(D to).
 
     Both $(D from) and $(D to) may contain ranges using the $(D '-') character

--- a/std/traits.d
+++ b/std/traits.d
@@ -3038,7 +3038,7 @@ unittest
    Classes and unions never have elaborate assignments.
 
    Note: Structs with (possibly nested) postblit operator(s) will have a
-   hidden yet elaborate compiler generated assignement operator (unless
+   hidden yet elaborate compiler generated assignment operator (unless
    explicitly disabled).
  */
 template hasElaborateAssign(S)

--- a/std/utf.d
+++ b/std/utf.d
@@ -154,7 +154,7 @@ unittest
         valid UTF-8 sequence.
 
     Notes:
-        $(D stride) will only analize the first $(D str[index]) element. It
+        $(D stride) will only analyze the first $(D str[index]) element. It
         will not fully verify the validity of UTF-8 sequence, nor even verify
         the presence of the sequence: it will not actually guarantee that
         $(D index + stride(str, index) <= str.length).
@@ -422,7 +422,7 @@ unittest
         valid UTF-16 sequence.
 
     Notes:
-        $(D stride) will only analize the first $(D str[index]) element. It
+        $(D stride) will only analyze the first $(D str[index]) element. It
         will not fully verify the validity of UTF-16 sequence, nor even verify
         the presence of the sequence: it will not actually guarantee that
         $(D index + stride(str, index) <= str.length).
@@ -534,7 +534,7 @@ uint stride(S)(auto ref S str)
         end of a valid UTF-16 sequence.
 
     Notes:
-        $(D stride) will only analize the element at $(D str[index - 1])
+        $(D stride) will only analyze the element at $(D str[index - 1])
         element. It will not fully verify the validity of UTF-16 sequence, nor
         even verify the presence of the sequence: it will not actually
         guarantee that $(D stride(str, index) <= index).

--- a/std/variant.d
+++ b/std/variant.d
@@ -1801,7 +1801,7 @@ unittest
  * with $(D_PARM variant)'s current value. Visiting handlers are passed
  * in the template parameter list.
  * It is statically ensured that all types of
- * $(D_PARAM variant) are handled accross all handlers.
+ * $(D_PARAM variant) are handled across all handlers.
  * $(D_PARAM visit) allows delegates and static functions to be passed
  * as parameters.
  *
@@ -1832,7 +1832,7 @@ unittest
  *                         == -1);
  * ----------------------
  * Returns: The return type of visit is deduced from the visiting functions and must be
- * the same accross all overloads.
+ * the same across all overloads.
  * Throws: If no parameter-less, error function is specified:
  * $(D_PARAM VariantException) if $(D_PARAM variant) doesn't hold a value.
  */
@@ -1930,7 +1930,7 @@ unittest
  * ----------------------
  *
  * Returns: The return type of tryVisit is deduced from the visiting functions and must be
- * the same accross all overloads.
+ * the same across all overloads.
  * Throws: If no parameter-less, error function is specified: $(D_PARAM VariantException) if
  *         $(D_PARAM variant) doesn't hold a value or
  *         if $(D_PARAM variant) holds a value which isn't handled by the visiting

--- a/std/xml.d
+++ b/std/xml.d
@@ -883,7 +883,7 @@ class Element : Item
         /**
          * Returns the decoded interior of an element.
          *
-         * The element is assumed to containt text <i>only</i>. So, for
+         * The element is assumed to contain text <i>only</i>. So, for
          * example, given XML such as "&lt;title&gt;Good &amp;amp;
          * Bad&lt;/title&gt;", will return "Good &amp; Bad".
          *
@@ -1289,7 +1289,7 @@ class CData : Item
     private string content;
 
     /**
-     * Construct a chraracter data section
+     * Construct a character data section
      *
      * Params:
      *      content = the body of the character data segment
@@ -1831,7 +1831,7 @@ class ElementParser
     /**
      * Register an alternative handler which will be called whenever text
      * is encountered. This differs from onText in that onText will decode
-     * the text, wheras onTextRaw will not. This allows you to make design
+     * the text, whereas onTextRaw will not. This allows you to make design
      * choices, since onText will be more accurate, but slower, while
      * onTextRaw will be faster, but less accurate. Of course, you can
      * still call decode() within your handler, if you want, but you'd
@@ -1856,7 +1856,7 @@ class ElementParser
 
     /**
      * Register a handler which will be called whenever a character data
-     * segement is encountered.
+     * segment is encountered.
      *
      * Examples:
      * --------------
@@ -1924,7 +1924,7 @@ class ElementParser
      * Examples:
      * --------------
      * // Call this function whenever an XML instruction is encountered
-     * // (Note: XML instructions may only occur preceeding the root tag of a
+     * // (Note: XML instructions may only occur preceding the root tag of a
      * // document).
      * onPI = (string s)
      * {
@@ -2624,7 +2624,7 @@ private
  *
  * Throws: CheckException if the document is not well formed
  *
- * CheckException's toString() method will yield the complete heirarchy of
+ * CheckException's toString() method will yield the complete hierarchy of
  * parse failure (the XML equivalent of a stack trace), giving the line and
  * column number of every failure at every level.
  */
@@ -2781,7 +2781,7 @@ class TagException : XMLException
  */
 class CheckException : XMLException
 {
-    CheckException err; /// Parent in heirarchy
+    CheckException err; /// Parent in hierarchy
     private string tail;
     /**
      * Name of production rule which failed to parse,


### PR DESCRIPTION
If it is preferable to squash all the changes in one commit, I'll do that.
I think I went through all of Phobos.
