### PR TITLE
Issue 3882: Add warning for unused returns of strictly pure function calls

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -364,7 +364,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
 
 @safe nothrow pure unittest
 {
-    minimallyInitializedArray!(int[][][][][])();
+    const iarr = minimallyInitializedArray!(int[][][][][])();
     double[] arr = minimallyInitializedArray!(double[])(100);
     assert(arr.length == 100);
 
@@ -2796,8 +2796,8 @@ Appender!(E[]) appender(A : E[], E)(A array)
     {
         auto w = appender!string();
         w.reserve(4);
-        w.capacity;
-        w.data;
+        const cap = w.capacity;
+        const dat = w.data;
         try
         {
             wchar wc = 'a';
@@ -2810,8 +2810,8 @@ Appender!(E[]) appender(A : E[], E)(A array)
     {
         auto w = appender!(int[])();
         w.reserve(4);
-        w.capacity;
-        w.data;
+        const cap = w.capacity;
+        const dat = w.data;
         w.put(10);
         w.put([10]);
         w.clear();

--- a/std/exception.d
+++ b/std/exception.d
@@ -1052,7 +1052,7 @@ unittest
         static struct NoCopy { this(this) { assert(0); } }
         static struct Holder { NoCopy a, b, c; }
         Holder h;
-        pointsTo(h, h);
+        const pt = pointsTo(h, h);
     }
 
     shared S3 sh3;
@@ -1381,6 +1381,6 @@ unittest
 version(unittest) package
 @property void assertCTFEable(alias dg)()
 {
-    static assert({ dg(); return true; }());
-    dg();
+    static assert({ cast(void)dg(); return true; }());
+    cast(void)dg();
 }

--- a/std/range.d
+++ b/std/range.d
@@ -7714,7 +7714,7 @@ unittest
 
     static struct Test { int* a; }
     immutable(Test) test;
-    only(test, test); // Works with mutable indirection
+    const value = only(test, test); // Works with mutable indirection
 }
 
 /**


### PR DESCRIPTION
Prevent warnings from being generated by Phobos' make unittest by explicitly capturing calls to strictly pure functions with non-void returns.
