### PR TITLE
Renamed curry->partial to better match semantics

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -244,7 +244,8 @@ template partial(alias fun, alias arg)
 Deprecated alias for $(D partial), kept for backwards compatibility
  */
 
-deprecated alias curry = partial;
+deprecated("Please use std.functional.partial instead")
+alias curry = partial;
 
 // tests for partially evaluating callables
 unittest


### PR DESCRIPTION
Documentation was updated to match, and a deprecated alias was inserted for compatibility.

This sets up the library in preparation for Issue 4391, which would provide a proper "curry" template that follows currying semantics properly.
