### PR TITLE
Initialize `std.algorithm.filter` lazily

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1589,16 +1589,33 @@ unittest
 
 private struct FilterResult(alias pred, Range)
 {
+private:
+
     alias R = Unqual!Range;
     R _input;
+    bool _initialized = false;
 
-    this(R r)
+    void popFrontUntilNextMatch()
+    {
+        while (!_input.empty && !pred(_input.front))
+            _input.popFront();
+    }
+
+    void initialize()
+    {
+        if (!_initialized)
+        {
+            popFrontUntilNextMatch();
+            _initialized = true;
+        }
+    }
+
+public:
+
+    this(R r, bool _was_initialized = false)
     {
         _input = r;
-        while (!_input.empty && !pred(_input.front))
-        {
-            _input.popFront();
-        }
+        _initialized = _was_initialized;
     }
 
     auto opSlice() { return this; }
@@ -1609,19 +1626,23 @@ private struct FilterResult(alias pred, Range)
     }
     else
     {
-        @property bool empty() { return _input.empty; }
+        @property bool empty()
+        {
+            initialize();
+            return _input.empty;
+        }
     }
 
     void popFront()
     {
-        do
-        {
-            _input.popFront();
-        } while (!_input.empty && !pred(_input.front));
+        initialize();
+        _input.popFront();
+        popFrontUntilNextMatch();
     }
 
     @property auto ref front()
     {
+        initialize();
         return _input.front;
     }
 
@@ -1629,7 +1650,7 @@ private struct FilterResult(alias pred, Range)
     {
         @property auto save()
         {
-            return typeof(this)(_input.save);
+            return typeof(this)(_input.save, _initialized);
         }
     }
 }
@@ -1726,10 +1747,10 @@ unittest
  * $(D auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(Unqual!Range));)
  *
  * Similar to $(D filter), except it defines a bidirectional
- * range. There is a speed disadvantage - the constructor spends time
- * finding the last element in the range that satisfies the filtering
- * condition (in addition to finding the first one). The advantage is
- * that the filtered range can be spanned from both directions. Also,
+ * range. Merely constructing the range doesn't impose a performance
+ * penalty - only on first access time is spent finding the first and
+ * last element in the input range that satisfies the filtering condition.
+ * The filtered range can be spanned from both directions. Also,
  * $(XREF range, retro) can be applied against the filtered range.
  *
  */
@@ -1759,47 +1780,77 @@ unittest
 
 private struct FilterBidiResult(alias pred, Range)
 {
+private:
+
     alias R = Unqual!Range;
     R _input;
+    bool _initialized = false;
 
-    this(R r)
+    void popFrontUntilNextMatch()
     {
-        _input = r;
-        while (!_input.empty && !pred(_input.front)) _input.popFront();
-        while (!_input.empty && !pred(_input.back)) _input.popBack();
+        while (!_input.empty && !pred(_input.front))
+            _input.popFront();
     }
 
-    @property bool empty() { return _input.empty; }
+    void popBackUntilNextMatch()
+    {
+        while (!_input.empty && !pred(_input.back))
+            _input.popBack();
+    }
+
+    void initialize()
+    {
+        if (!_initialized)
+        {
+            popFrontUntilNextMatch();
+            popBackUntilNextMatch();
+            _initialized = true;
+        }
+    }
+
+public:
+
+    this(R r, bool _was_initialized = false)
+    {
+        _input = r;
+        _initialized = _was_initialized;
+    }
+
+    @property bool empty()
+    {
+        initialize();
+        return _input.empty;
+    }
 
     void popFront()
     {
-        do
-        {
-            _input.popFront();
-        } while (!_input.empty && !pred(_input.front));
+        initialize();
+        _input.popFront();
+        popFrontUntilNextMatch();
     }
 
     @property auto ref front()
     {
+        initialize();
         return _input.front;
     }
 
     void popBack()
     {
-        do
-        {
-            _input.popBack();
-        } while (!_input.empty && !pred(_input.back));
+        initialize();
+        _input.popBack();
+        popBackUntilNextMatch();
     }
 
     @property auto ref back()
     {
+        initialize();
         return _input.back;
     }
 
     @property auto save()
     {
-        return typeof(this)(_input.save);
+        return typeof(this)(_input.save, _initialized);
     }
 }
 


### PR DESCRIPTION
Timon Gehr recently complained [1] about the fact that `std.algorithm.filter` initializes itself in its constructor, i.e. potentially performs a lot of computation by calling `popFront()` repeatedly.

With this PR, I reworked `filter` and `filterBidirectional` to initialize themselves only when they are accessed the first time.

I don't know however whether it is actually worth it. Usually, a constructed filter range will be used at least once. This implementation needs to carry around an additional flag, and needs to check it before each operation, which will probably degrade performance slightly. On the other hand, there might be corner cases where initializing upon construction is too expensive, like when you construct hundreds of filters, but use only a handful of them and can't tell which one until you actually need them.

Comments?

[1] http://forum.dlang.org/thread/lfap6l$2eb1$1@digitalmars.com?page=3#post-lfenmi:241lve:241:40digitalmars.com
