### PR TITLE
[DOCS] Document that parseUUID consumes its input range

### DIFF
--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1114,6 +1114,14 @@ unittest
  *     as long as these characters do not contain [0-9a-fA-F])
  * )
  *
+ * Note:
+ * Like most parsers, it consumes its argument. This means:
+ * -------------------------
+ * string s = "8AB3060E-2CBA-4F23-b74c-B52Db3BDFB46";
+ * parseUUID(s);
+ * assert(s == "");
+ * -------------------------
+ *
  * Throws:
  * $(LREF UUIDParsingException) if the input is invalid
  *


### PR DESCRIPTION
fixes https://d.puremagic.com/issues/show_bug.cgi?id=12148

(Although right now I'm not sure if this behavior is useful as parseUUID processes the complete input, unlike the normal parse functions.)
