### PR TITLE
Mark std.exception.ErrnoException.this as @trusted

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1190,7 +1190,7 @@ unittest //alias this test
 class ErrnoException : Exception
 {
     uint errno;                 // operating system error code
-    this(string msg, string file = null, size_t line = 0)
+    this(string msg, string file = null, size_t line = 0) @trusted
     {
         errno = .errno;
         version (linux)


### PR DESCRIPTION
It uses system functions `std.c.string.strerror` and `std.conv.to!string(char*)` but we can verify that it can be trusted.
