### PR TITLE
Mark std.stdio.File.close as @trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -596,7 +596,7 @@ referring to the same handle will see a closed file henceforth.
 
 Throws: $(D ErrnoException) on error.
  */
-    void close()
+    void close() @trusted
     {
         import std.exception : errnoEnforce;
 


### PR DESCRIPTION
It uses system functions `core.stdc.stdlib.free`, `core.sys.posix.stdio.pclose` and `core.stdc.stdio.fclose` but we can verify that they will not cause undefined behaviors in `File.close`.
