### PR TITLE
Remove incorrect save in splitter

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2999,7 +2999,7 @@ private struct SplitterResult(alias isTerminator, Range)
         static if (fullSlicing)
             return _input[0 .. _end];
         else
-            return _input.save.takeExactly(_end);
+            return _input.takeExactly(_end);
     }
 
     void popFront()


### PR DESCRIPTION
According to this (https://github.com/D-Programming-Language/phobos/pull/1186#issuecomment-31254528) conversation with @andralex in regards to ranges "RoR" whose elements are themselves ranges "R", it is not "RoR" responsibility to save the _element_ before returning them.

So I'm removing this save I added when I rewrote `splitter!pred`.

The other flavors of `splitter` don't have this problem, since they (currently) only support sliceable ranges...

@andralex or @AndrejMitrovic : This should be trivial and up your alley?
