### PR TITLE
improve adjoin

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -362,21 +362,20 @@ template adjoin(F...) if (F.length > 1)
 {
     auto adjoin(V...)(auto ref V a)
     {
-        import std.typecons : Tuple, tuple;
+        import std.typecons : tuple;
         static if (F.length == 2)
         {
             return tuple(F[0](a), F[1](a));
         }
+        else static if (F.length == 3)
+        {
+            return tuple(F[0](a), F[1](a), F[2](a));
+        }
         else
         {
-            import std.conv : emplaceRef;
-            alias Head = typeof(F[0](a));
-            Tuple!(Head, typeof(.adjoin!(F[1..$])(a)).Types) result = void;
-            foreach (i, Unused; result.Types)
-            {
-                emplaceRef(result[i], F[i](a));
-            }
-            return result;
+            import std.string : format;
+            import std.range : iota;
+            return mixin (q{tuple(%(F[%s](a)%|, %))}.format(iota(0, F.length)));
         }
     }
 }
@@ -416,6 +415,25 @@ unittest
     s.store = (int a) { return eff4(a); };
     auto x4 = s.fun();
     assert(x4 == 43);
+}
+
+unittest
+{
+    import std.typetuple : staticMap;
+    import std.typecons : Tuple, tuple;
+    alias funs = staticMap!(unaryFun, "a", "a * 2", "a * 3", "a * a", "-a");
+    alias afun = adjoin!funs;
+    assert(afun(5) == tuple(5, 10, 15, 25, -5));
+
+    static class C{}
+    alias IC = immutable(C);
+    IC foo(){return typeof(return).init;}
+    Tuple!(IC, IC, IC, IC) ret1 = adjoin!(foo, foo, foo, foo)();
+
+    static struct S{int* p;}
+    alias IS = immutable(S);
+    IS bar(){return typeof(return).init;}
+    enum Tuple!(IS, IS, IS, IS) ret2 = adjoin!(bar, bar, bar, bar)();
 }
 
 // /*private*/ template NaryFun(string fun, string letter, V...)


### PR DESCRIPTION
This is the last change I had planned in adjoin.

First, it provides "length == 1" and "length > 1" overloads as asked for by @AndrejMitrovic in #2008. It changes indentation, so I highly recommend viewing without takes whites into account ( https://github.com/D-Programming-Language/phobos/pull/2013/files?w=1 )

Second, it uses a mixin, to "in-place" build the returned tuple. This makes both the implementation and resulting code _much_ simpler, and removes the need to emplace. It is also generally more correct, since the old code never actually initialized any padding bits. Furthermore, it allows better and safer constructions of "hard to build" types (const types, for instance).

---

Thoughts:
1. I added a hand written case for `length == 3`, because it's 2 lines of code, and reduces dependencies. Also, it "would" be required to implement a trivial "recursive" implementation, so I think it is worth typing it.
2. The mixin could have been replaced by `return tuple(adjoin!(F[0 .. $/2])(a).expand, F[$/2 .. $])(a).expand)`. However, I think it's more complicated, and could cause extra un-needed runtime postblits, or generally more overhead in a non-optimized/inline build.
3. I could remove the `range` dependency with a local function, but I think the 1-liner is cleaner than rolling out a lambda with a foreach that writes into a string.
