### PR TITLE
Improve emplaceRef for qualified construction

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -790,7 +790,7 @@ template reduce(fun...) if (fun.length >= 1)
                         result = void;
                     foreach (i, T; result.Types)
                     {
-                        emplaceRef(result[i], seed);
+                        emplaceRef!T(result[i], seed);
                     }
                     r.popFront();
                     return reduce(result, r);
@@ -856,7 +856,7 @@ template reduce(fun...) if (fun.length >= 1)
 
                     foreach (i, T; result.Types)
                     {
-                        emplaceRef(result[i], elem);
+                        emplaceRef!T(result[i], elem);
                     }
                 }
             }
@@ -1407,7 +1407,7 @@ void uninitializedFill(Range, Value)(Range range, Value filler)
 
         // Must construct stuff by the book
         for (; !range.empty; range.popFront())
-            emplaceRef(range.front, filler);
+            emplaceRef!T(range.front, filler);
     }
     else
         // Doesn't matter whether fill is initialized or not

--- a/std/conv.d
+++ b/std/conv.d
@@ -3845,170 +3845,169 @@ emplace, but takes its argument by ref (as opposed to "by pointer").
 
 This makes it easier to use, easier to be safe, and faster in a non-inline
 build.
+
+Furthermore, emplaceRef takes a type paremeter, which specifies the type we
+want to build. This helps to build qualified objects on mutable buffer,
+without breaking the type system with unsafe casts.
 +/
-package ref T emplaceRef(T)(ref T chunk)
+package template emplaceRef(T)
 {
-    static assert (is(T* : void*),
-        format("Cannot emplace a %s because it is qualified.", T.stringof));
+    alias UT = Unqual!T;
 
-    static assert (is(typeof({static T i;})),
-        format("Cannot emplace a %1$s because %1$s.this() is annotated with @disable.", T.stringof));
-
-    return emplaceInitializer(chunk);
-}
-// ditto
-package ref T emplaceRef(T, Args...)(ref T chunk, auto ref Args args)
-if (!is(T == struct) && Args.length == 1)
-{
-    alias Arg = Args[0];
-    alias arg = args[0];
-
-    static assert (is(T* : void*),
-        format("Cannot emplace a %s because it is qualified.", T.stringof));
-
-    static assert(is(typeof({T t = args[0];})),
-        format("%s cannot be emplaced from a %s.", T.stringof, Arg.stringof));
-
-    static if (isStaticArray!T)
+    ref UT emplaceRef()(ref UT chunk)
     {
-        alias UArg = Unqual!Arg;
-        alias E = typeof(chunk.ptr[0]);
-        enum N = T.length;
+        static assert (is(typeof({static T i;})),
+            format("Cannot emplace a %1$s because %1$s.this() is annotated with @disable.", T.stringof));
+    
+        return emplaceInitializer(chunk);
+    }
 
-        static if (is(Arg : T))
+    static if (!is(T == struct))
+    ref UT emplaceRef(Arg)(ref UT chunk, auto ref Arg arg)
+    {
+        static assert(is(typeof({T t = arg;})),
+            format("%s cannot be emplaced from a %s.", T.stringof, Arg.stringof));
+    
+        static if (isStaticArray!T)
         {
-            //Matching static array
-            static if (!hasElaborateAssign!T && isAssignable!(T, Arg))
-                chunk = arg;
-            else static if (is(UArg == T))
+            alias UArg = Unqual!Arg;
+            alias E = ElementEncodingType!(typeof(T.init[]));
+            alias UE = Unqual!E;
+            enum N = T.length;
+    
+            static if (is(Arg : T))
             {
-                memcpy(&chunk, &arg, T.sizeof);
-                static if (hasElaborateCopyConstructor!T)
-                    typeid(T).postblit(cast(void*)&chunk);
+                //Matching static array
+                static if (!hasElaborateAssign!UT && isAssignable!(UT, Arg))
+                    chunk = arg;
+                else static if (is(UArg == UT))
+                {
+                    memcpy(&chunk, &arg, T.sizeof);
+                    static if (hasElaborateCopyConstructor!T)
+                        typeid(T).postblit(cast(void*)&chunk);
+                }
+                else
+                    .emplaceRef!T(chunk, cast(T)arg);
+            }
+            else static if (is(Arg : E[]))
+            {
+                //Matching dynamic array
+                static if (!hasElaborateAssign!UT && is(typeof(chunk[] = arg[])))
+                    chunk[] = arg[];
+                else static if (is(Unqual!(ElementEncodingType!Arg) == UE))
+                {
+                    assert(N == chunk.length, "Array length missmatch in emplace");
+                    memcpy(cast(void*)&chunk, arg.ptr, T.sizeof);
+                    static if (hasElaborateCopyConstructor!T)
+                        typeid(T).postblit(cast(void*)&chunk);
+                }
+                else
+                    .emplaceRef!T(chunk, cast(E[])arg);
+            }
+            else static if (is(Arg : E))
+            {
+                //Case matching single element to array.
+                static if (!hasElaborateAssign!UT && is(typeof(chunk[] = arg)))
+                    chunk[] = arg;
+                else static if (is(UArg == Unqual!E))
+                {
+                    //Note: We copy everything, and then postblit just once.
+                    //This is as exception safe as what druntime can provide us.
+                    foreach(i; 0 .. N)
+                        memcpy(cast(void*)&(chunk[i]), &arg, E.sizeof);
+                    static if (hasElaborateCopyConstructor!T)
+                        typeid(T).postblit(cast(void*)&chunk);
+                }
+                else
+                    //Alias this. Coerce.
+                    .emplaceRef!T(chunk, cast(E)arg);
+            }
+            else static if (is(typeof(.emplaceRef!E(chunk[0], arg))))
+            {
+                //Final case for everything else:
+                //Types that don't match (int to uint[2])
+                //Recursion for multidimensions
+                static if (!hasElaborateAssign!UT && is(typeof(chunk[] = arg)))
+                    chunk[] = arg;
+                else
+                    foreach(i; 0 .. N)
+                        .emplaceRef!E(chunk[i], arg);
             }
             else
-                emplaceRef(chunk, cast(T)arg);
-        }
-        else static if (is(Arg : E[]))
-        {
-            //Matching dynamic array
-            static if (!hasElaborateAssign!T && is(typeof(chunk[] = arg[])))
-                chunk[] = arg[];
-            else static if (is(UArg == E[]))
-            {
-                assert(N == chunk.length, "Array length missmatch in emplace");
-                memcpy(cast(void*)&chunk, arg.ptr, T.sizeof);
-                static if (hasElaborateCopyConstructor!T)
-                    typeid(T).postblit(cast(void*)&chunk);
-            }
-            else
-                emplaceRef(chunk, cast(E[])arg);
-        }
-        else static if (is(Arg : E))
-        {
-            //Case matching single element to array.
-            static if (!hasElaborateAssign!T && is(typeof(chunk[] = arg)))
-                chunk[] = arg;
-            else static if (is(UArg == E))
-            {
-                //Note: We copy everything, and then postblit just once.
-                //This is as exception safe as what druntime can provide us.
-                foreach(i; 0 .. N)
-                    memcpy(cast(void*)&(chunk[i]), &arg, E.sizeof);
-                static if (hasElaborateCopyConstructor!T)
-                    typeid(T).postblit(cast(void*)&chunk);
-            }
-            else
-                //Alias this. Coerce.
-                emplaceRef(chunk, cast(E)arg);
-        }
-        else static if (is(typeof(emplaceRef(chunk[0], arg))))
-        {
-            //Final case for everything else:
-            //Types that don't match (int to uint[2])
-            //Recursion for multidimensions
-            static if (!hasElaborateAssign!T && is(typeof(chunk[] = arg)))
-                chunk[] = arg;
-            else
-                foreach(i; 0 .. N)
-                    emplaceRef(chunk[i], arg);
+                static assert(0, format("Sorry, this implementation doesn't know how to emplace a %s with a %s", T.stringof, Arg.stringof));
+    
+            return chunk;
         }
         else
-            static assert(0, format("Sorry, this implementation doesn't know how to emplace a %s with a %s", T.stringof, Arg.stringof));
-
-        return chunk;
-    }
-    else
-    {
-        chunk = arg;
-        return chunk;
-    }
-}
-// ditto
-package ref T emplaceRef(T, Args...)(ref T chunk, auto ref Args args)
-if (is(T == struct))
-{
-    static assert (is(T* : void*),
-        format("Cannot emplace a %s because it is qualified.", T.stringof));
-
-    static if (Args.length == 1 && is(Args[0] : T) &&
-        is (typeof({T t = args[0];})) //Check for legal postblit
-        )
-    {
-        static if (is(T == Unqual!(Args[0])))
         {
-            //Types match exactly: we postblit
-            static if (!hasElaborateAssign!T && isAssignable!T)
-                chunk = args[0];
-            else
+            chunk = arg;
+            return chunk;
+        }
+    }
+    // ditto
+    static if (is(T == struct))
+    ref UT emplaceRef(Args...)(ref UT chunk, auto ref Args args)
+    {
+        static if (Args.length == 1 && is(Args[0] : T) &&
+            is (typeof({T t = args[0];})) //Check for legal postblit
+            )
+        {
+            static if (is(Unqual!T == Unqual!(Args[0])))
             {
-                memcpy(&chunk, &args[0], T.sizeof);
-                static if (hasElaborateCopyConstructor!T)
-                    typeid(T).postblit(&chunk);
+                //Types match exactly: we postblit
+                static if (!hasElaborateAssign!UT && isAssignable!(UT, T))
+                    chunk = args[0];
+                else
+                {
+                    memcpy(&chunk, &args[0], T.sizeof);
+                    static if (hasElaborateCopyConstructor!T)
+                        typeid(T).postblit(&chunk);
+                }
+            }
+            else
+                //Alias this. Coerce to type T.
+                .emplaceRef!T(chunk, cast(T)args[0]);
+        }
+        else static if (is(typeof(chunk.__ctor(args))))
+        {
+            // T defines a genuine constructor accepting args
+            // Go the classic route: write .init first, then call ctor
+            emplaceInitializer(chunk);
+            chunk.__ctor(args);
+        }
+        else static if (is(typeof(T.opCall(args))))
+        {
+            //Can be built calling opCall
+            emplaceOpCaller(chunk, args); //emplaceOpCaller is deprecated
+        }
+        else static if (is(typeof(T(args))))
+        {
+            // Struct without constructor that has one matching field for
+            // each argument. Individually emplace each field
+            emplaceInitializer(chunk);
+            foreach (i, ref field; chunk.tupleof[0 .. Args.length])
+            {
+                alias Field = typeof(field);
+                alias UField = Unqual!Field;
+                static if (is(Field == UField))
+                    .emplaceRef!Field(field, args[i]);
+                else
+                    .emplaceRef!Field(*cast(Unqual!Field*)&field, args[i]);
             }
         }
         else
-            //Alias this. Coerce to type T.
-            emplaceRef(chunk, cast(T)args[0]);
-    }
-    else static if (is(typeof(chunk.__ctor(args))))
-    {
-        // T defines a genuine constructor accepting args
-        // Go the classic route: write .init first, then call ctor
-        emplaceInitializer(chunk);
-        chunk.__ctor(args);
-    }
-    else static if (is(typeof(T.opCall(args))))
-    {
-        //Can be built calling opCall
-        emplaceOpCaller(chunk, args); //emplaceOpCaller is deprecated
-    }
-    else static if (is(typeof(T(args))))
-    {
-        // Struct without constructor that has one matching field for
-        // each argument. Individually emplace each field
-        emplaceInitializer(chunk);
-        foreach (i, ref field; chunk.tupleof[0 .. Args.length])
         {
-            alias Field = typeof(field);
-            static if (is(Field == Unqual!Field))
-                emplaceRef(field, args[i]);
-            else
-                emplaceRef(*cast(Unqual!Field*)&field, args[i]);
+            //We can't emplace. Try to diagnose a disabled postblit.
+            static assert(!(Args.length == 1 && is(Args[0] : T)),
+                format("Cannot emplace a %1$s because %1$s.this(this) is annotated with @disable.", T.stringof));
+    
+            //We can't emplace.
+            static assert(false,
+                format("%s cannot be emplaced from %s.", T.stringof, Args[].stringof));
         }
+    
+        return chunk;
     }
-    else
-    {
-        //We can't emplace. Try to diagnose a disabled postblit.
-        static assert(!(Args.length == 1 && is(Args[0] : T)),
-            format("Cannot emplace a %1$s because %1$s.this(this) is annotated with @disable.", T.stringof));
-
-        //We can't emplace.
-        static assert(false,
-            format("%s cannot be emplaced from %s.", T.stringof, Args[].stringof));
-    }
-
-    return chunk;
 }
 //emplace helper functions
 private ref T emplaceInitializer(T)(ref T chunk) @trusted pure nothrow
@@ -4027,7 +4026,7 @@ ref T emplaceOpCaller(T, Args...)(ref T chunk, auto ref Args args)
 {
     static assert (is(typeof({T t = T.opCall(args);})),
         format("%s.opCall does not return adequate data for construction.", T.stringof));
-    return emplaceRef(chunk, chunk.opCall(args));
+    return emplaceRef!T(chunk, chunk.opCall(args));
 }
 
 
@@ -4042,7 +4041,7 @@ as $(D chunk)).
  */
 T* emplace(T)(T* chunk) @safe nothrow pure
 {
-    emplaceRef(*chunk);
+    emplaceRef!T(*chunk);
     return chunk;
 }
 
@@ -4060,14 +4059,14 @@ as $(D chunk)).
 T* emplace(T, Args...)(T* chunk, auto ref Args args)
 if (!is(T == struct) && Args.length == 1)
 {
-    emplaceRef(*chunk, args);
+    emplaceRef!T(*chunk, args);
     return chunk;
 }
 /// ditto
 T* emplace(T, Args...)(T* chunk, auto ref Args args)
 if (is(T == struct))
 {
-    emplaceRef(*chunk, args);
+    emplaceRef!T(*chunk, args);
     return chunk;
 }
 
@@ -4856,6 +4855,32 @@ unittest
     S s;
     S[2][2][2] sss = void;
     emplace(&sss, s);
+}
+
+unittest //Constness
+{
+    import std.stdio;
+
+    int a = void;
+    emplaceRef!(const int)(a, 5);
+
+    immutable i = 5;
+    const(int)* p = void;
+    emplaceRef!(const int*)(p, &i);
+
+    struct S
+    {
+        int* p;
+    }
+    alias IS = immutable(S);
+    S s = void;
+    emplaceRef!IS(s, IS()); 
+    S[2] ss = void;
+    emplaceRef!(IS[2])(ss, IS()); 
+
+    IS[2] iss = IS.init;
+    emplaceRef!(IS[2])(ss, iss); 
+    emplaceRef!(IS[2])(ss, iss[]); 
 }
 
 private void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment, string typeName)


### PR DESCRIPTION
This further refines the (package) `appenderRef`, to turn it into a template specialized for building a specific types. In particular, for building _qualified_ types. This has the advantages of:
1. Callers don't have to jump through hoops and worry about casting the rhs.
2. Avoids unsafe casts: Now, we are actually building const objects from other const objects, rather than casting away both the const, doing the build, and casting it back on.
3. Preserves (mostly) the type system: Instead of mutating immutable data, we place (explicitly) immutable data on a mutable buffer. I think it is a good compromise for the added correctness and convenience.

Point 2 is particularly important in terms of type safety, and in particular for any future "qualified construction/postblit" that @9rnsr is working on.

The simplifications in the `Appender` code, or how `array` now works on _any_ type, all in complete safety and without any special casing, I think speaks for itself.

Another nice point (IMO), is having a set of overloaded functions `emplace!T`. This is both convenient in terms of useage, but also in case of errors: The overload set is smaller and more explicit.

Because the design is currently package, I decided to make the type specification explicit. It helped me catch a few wrong cases. We may remove it if it ever becomes public, but for now, I'd rather we keep it that way.

Obligatory change of indentation:
https://github.com/D-Programming-Language/phobos/pull/2015/files?w=1
