### PR TITLE
Tweak Zip implementation

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -4659,6 +4659,8 @@ private alias lengthType(R) = typeof(R.init.length.init);
 struct Zip(Ranges...)
     if (Ranges.length && allSatisfy!(isInputRange, Ranges))
 {
+    import std.string : format; //for generic mixins
+
     alias R = Ranges;
     R ranges;
     alias ElementType = Tuple!(staticMap!(.ElementType, R));
@@ -4720,26 +4722,20 @@ struct Zip(Ranges...)
 
     static if (allSatisfy!(isForwardRange, R))
     {
-        private this(ref Zip other)
-        {
-            foreach (i, Unused; R)
-                ranges[i] = other.ranges[i].save;
-            stoppingPolicy = other.stoppingPolicy;
-        }
         @property Zip save()
         {
-            return Zip(this);
+            //Zip(ranges[0].save, ranges[1].save, ..., stoppingPolicy)
+            return mixin (q{Zip(%(ranges[%s]%|, %), stoppingPolicy)}.format(iota(0, R.length)));
         }
     }
 
-    private void emplaceIfCan(T)(T* addr)
+    private .ElementType!(R[i]) tryGetInit(size_t i)()
     {
-        import std.conv : emplace;
-
-        static if(__traits(compiles, emplace(addr)))
-            emplace(addr);
-        else
+        alias E = .ElementType!(R[i]);
+        static if (!is(typeof({static E i;})))
             throw new Exception("Range with non-default constructable elements exhausted.");
+        else
+            return E.init;
     }
 
 /**
@@ -4747,22 +4743,9 @@ struct Zip(Ranges...)
 */
     @property ElementType front()
     {
-        import std.conv : emplace;
-
-        ElementType result = void;
-        foreach (i, Unused; R)
-        {
-            auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-            if (ranges[i].empty)
-            {
-                emplaceIfCan(addr);
-            }
-            else
-            {
-                emplace(addr, ranges[i].front);
-            }
-        }
-        return result;
+        auto tryGetFront(size_t i)(){return ranges[i].empty ? tryGetInit!i() : ranges[i].front;}
+        //ElementType(tryGetFront!0, tryGetFront!1, ...)
+        return mixin(q{ElementType(%(tryGetFront!%s, %))}.format(iota(0, R.length)));
     }
 
 /**
@@ -4789,22 +4772,9 @@ struct Zip(Ranges...)
     {
         ElementType moveFront()
         {
-            import std.conv : emplace;
-
-            ElementType result = void;
-            foreach (i, Unused; R)
-            {
-                auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-                if (!ranges[i].empty)
-                {
-                    emplace(addr, .moveFront(ranges[i]));
-                }
-                else
-                {
-                    emplaceIfCan(addr);
-                }
-            }
-            return result;
+            auto tryMoveFront(size_t i)(){return ranges[i].empty ? tryGetInit!i() : .moveFront(ranges[i]);}
+            //ElementType(tryMoveFront!0, tryMoveFront!1, ...)
+            return mixin(q{ElementType(%(tryMoveFront!%s, %))}.format(iota(0, R.length)));
         }
     }
 
@@ -4815,22 +4785,11 @@ struct Zip(Ranges...)
     {
         @property ElementType back()
         {
-            import std.conv : emplace;
+            //TODO: Fixme! BackElement != back of all ranges in case of jagged-ness
 
-            ElementType result = void;
-            foreach (i, Unused; R)
-            {
-                auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-                if (!ranges[i].empty)
-                {
-                    emplace(addr, ranges[i].back);
-                }
-                else
-                {
-                    emplaceIfCan(addr);
-                }
-            }
-            return result;
+            auto tryGetBack(size_t i)(){return ranges[i].empty ? tryGetInit!i() : ranges[i].back;}
+            //ElementType(tryGetBack!0, tryGetBack!1, ...)
+            return mixin(q{ElementType(%(tryGetBack!%s, %))}.format(iota(0, R.length)));
         }
 
 /**
@@ -4840,22 +4799,11 @@ struct Zip(Ranges...)
         {
             ElementType moveBack()
             {
-                import std.conv : emplace;
+                //TODO: Fixme! BackElement != back of all ranges in case of jagged-ness
 
-                ElementType result = void;
-                foreach (i, Unused; R)
-                {
-                    auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-                    if (!ranges[i].empty)
-                    {
-                        emplace(addr, .moveBack(ranges[i]));
-                    }
-                    else
-                    {
-                        emplaceIfCan(addr);
-                    }
-                }
-                return result;
+                auto tryMoveBack(size_t i)(){return ranges[i].empty ? tryGetInit!i() : .moveFront(ranges[i]);}
+                //ElementType(tryMoveBack!0, tryMoveBack!1, ...)
+                return mixin(q{ElementType(%(tryMoveBack!%s, %))}.format(iota(0, R.length)));
             }
         }
 
@@ -4866,6 +4814,9 @@ struct Zip(Ranges...)
         {
             @property void back(ElementType v)
             {
+                //TODO: Fixme! BackElement != back of all ranges in case of jagged-ness.
+                //Not sure the call is even legal for StoppingPolicy.longest
+
                 foreach (i, Unused; R)
                 {
                     if (!ranges[i].empty)
@@ -4913,8 +4864,10 @@ struct Zip(Ranges...)
    Calls $(D popBack) for all controlled ranges.
 */
     static if (allSatisfy!(isBidirectionalRange, R))
+    {
         void popBack()
         {
+            //TODO: Fixme! In case of jaggedness, this is wrong.
             import std.exception : enforce;
 
             final switch (stoppingPolicy)
@@ -4941,6 +4894,7 @@ struct Zip(Ranges...)
                 break;
             }
         }
+    }
 
 /**
    Returns the length of this range. Defined only if all ranges define
@@ -4950,22 +4904,19 @@ struct Zip(Ranges...)
     {
         @property auto length()
         {
-            CommonType!(staticMap!(lengthType, R)) result = ranges[0].length;
-            if (stoppingPolicy == StoppingPolicy.requireSameLength)
-                return result;
-            foreach (i, Unused; R[1 .. $])
+            static if (Ranges.length == 1)
+                return ranges[0].length;
+            else
             {
+                if (stoppingPolicy == StoppingPolicy.requireSameLength)
+                    return ranges[0].length;
+
+                //[min|max](ranges[0].length, ranges[1].length, ...)
                 if (stoppingPolicy == StoppingPolicy.shortest)
-                {
-                    result = min(ranges[i + 1].length, result);
-                }
+                    return mixin(q{min(%(ranges[%s].length%|, %))}.format(iota(0, R.length)));
                 else
-                {
-                    assert(stoppingPolicy == StoppingPolicy.longest);
-                    result = max(ranges[i + 1].length, result);
-                }
+                    return mixin(q{max(%(ranges[%s].length%|, %))}.format(iota(0, R.length)));
             }
-            return result;
         }
 
         alias opDollar = length;
@@ -4976,20 +4927,17 @@ struct Zip(Ranges...)
    slicing.
 */
     static if (allSatisfy!(hasSlicing, R))
+    {
         auto opSlice(size_t from, size_t to)
         {
-            import std.conv : emplace;
-
             //Slicing an infinite range yields the type Take!R
             //For finite ranges, the type Take!R aliases to R
-            Zip!(staticMap!(Take, R)) result = void;
-            emplace(&result.stoppingPolicy, stoppingPolicy);
-            foreach (i, Unused; R)
-            {
-                emplace(&result.ranges[i], ranges[i][from .. to]);
-            }
-            return result;
+            alias ZipResult = Zip!(staticMap!(Take, R));
+
+            //ZipResult(ranges[0][from .. to], ranges[1][from .. to], ..., stoppingPolicy)
+            return mixin (q{ZipResult(%(ranges[%s][from .. to]%|, %), stoppingPolicy)}.format(iota(0, R.length)));
         }
+    }
 
 /**
    Returns the $(D n)th element in the composite range. Defined if all
@@ -4999,15 +4947,11 @@ struct Zip(Ranges...)
     {
         ElementType opIndex(size_t n)
         {
-            import std.conv : emplace;
+            //TODO: Fixme! This may create an out of bounds access
+            //for StoppingPolicy.longest
 
-            ElementType result = void;
-            foreach (i, Range; R)
-            {
-                auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-                emplace(addr, ranges[i][n]);
-            }
-            return result;
+            //ElementType(ranges[0][n], ranges[1][n], ...)
+            return mixin (q{ElementType(%(ranges[%s][n]%|, %))}.format(iota(0, R.length)));
         }
 
 /**
@@ -5018,6 +4962,7 @@ struct Zip(Ranges...)
         {
             void opIndexAssign(ElementType v, size_t n)
             {
+                //TODO: Fixme! Not sure the call is even legal for StoppingPolicy.longest
                 foreach (i, Range; R)
                 {
                     ranges[i][n] = v[i];
@@ -5033,15 +4978,11 @@ struct Zip(Ranges...)
         {
             ElementType moveAt(size_t n)
             {
-                import std.conv : emplace;
+                //TODO: Fixme! This may create an out of bounds access
+                //for StoppingPolicy.longest
 
-                ElementType result = void;
-                foreach (i, Range; R)
-                {
-                    auto addr = cast(Unqual!(typeof(result[i]))*) &result[i];
-                    emplace(addr, .moveAt(ranges[i], n));
-                }
-                return result;
+                //ElementType(.moveAt(ranges[0], n), .moveAt(ranges[1], n), ..., )
+                return mixin (q{ElementType(%(.moveAt(ranges[%s], n)%|, %))}.format(iota(0, R.length)));
             }
         }
     }
@@ -5208,7 +5149,8 @@ unittest
     assert(a == [1, 2, 3, 4, 5]);
     assert(b == [6, 5, 2, 1, 3]);
 }
-unittest
+
+@safe pure unittest
 {
     auto LL = iota(1L, 1000L);
     auto z = zip(LL, [4]);
@@ -5221,7 +5163,7 @@ unittest
 }
 
 // Text for Issue 11196
-unittest
+@safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -5231,7 +5173,7 @@ unittest
     assertThrown(zip(StoppingPolicy.longest, cast(S[]) null, new int[1]).front);
 }
 
-unittest //12007
+@safe pure unittest //12007
 {
     static struct R
     {


### PR DESCRIPTION
This pull replaces most of the `Zip` implementation to use mixins to for simple element construction, rather than using run-time emplaces.

It makes the code cleaner, and safer to boot.

I did not change any behavior here, just code. I did leave in some comments in places I found fishy though.
