### PR TITLE
Issue 3882: Use cast(void) instead of value capture

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -381,7 +381,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
 
 @safe nothrow pure unittest
 {
-    const iarr = minimallyInitializedArray!(int[][][][][])();
+    cast(void)minimallyInitializedArray!(int[][][][][])();
     double[] arr = minimallyInitializedArray!(double[])(100);
     assert(arr.length == 100);
 
@@ -2813,8 +2813,8 @@ Appender!(E[]) appender(A : E[], E)(A array)
     {
         auto w = appender!string();
         w.reserve(4);
-        const cap = w.capacity;
-        const dat = w.data;
+        cast(void)w.capacity;
+        cast(void)w.data;
         try
         {
             wchar wc = 'a';
@@ -2827,8 +2827,8 @@ Appender!(E[]) appender(A : E[], E)(A array)
     {
         auto w = appender!(int[])();
         w.reserve(4);
-        const cap = w.capacity;
-        const dat = w.data;
+        cast(void)w.capacity;
+        cast(void)w.data;
         w.put(10);
         w.put([10]);
         w.clear();

--- a/std/exception.d
+++ b/std/exception.d
@@ -1052,7 +1052,7 @@ unittest
         static struct NoCopy { this(this) { assert(0); } }
         static struct Holder { NoCopy a, b, c; }
         Holder h;
-        const pt = pointsTo(h, h);
+        cast(void)pointsTo(h, h);
     }
 
     shared S3 sh3;

--- a/std/range.d
+++ b/std/range.d
@@ -583,7 +583,7 @@ package void doPut(R, E)(ref R r, auto ref E e)
     else
     {
         import std.string;
-        static assert (false, 
+        static assert (false,
             format("Cannot nativaly put a %s into a %s.", E.stringof, R.stringof));
     }
 }
@@ -7666,7 +7666,7 @@ unittest
 
     static struct Test { int* a; }
     immutable(Test) test;
-    const value = only(test, test); // Works with mutable indirection
+    cast(void)only(test, test); // Works with mutable indirection
 }
 
 /**

--- a/std/regex.d
+++ b/std/regex.d
@@ -882,7 +882,7 @@ auto memoizeExpr(string expr)()
         auto val = data[$ - 1];
         data = data[0 .. $ - 1];
         if(!__ctfe)
-            data.assumeSafeAppend();
+            cast(void)data.assumeSafeAppend();
         return val;
     }
 
@@ -2644,7 +2644,7 @@ private:
         auto t = worklist[$-1];
         worklist.length -= 1;
         if(!__ctfe)
-            worklist.assumeSafeAppend();
+            cast(void)worklist.assumeSafeAppend();
         return t;
     }
 
@@ -4201,7 +4201,7 @@ struct CtContext
                     $$
                 case $$://restore state and go inside loop
                     $$
-                    goto case $$;`, curInfLoop, addr+2, 
+                    goto case $$;`, curInfLoop, addr+2,
                     curInfLoop, testCode, saveCode(addr+1),
                     addr+2, altCode, addr+1, restoreCode(), fixup);
             ir = ir[ir[0].length..$];

--- a/unittest.d
+++ b/unittest.d
@@ -65,8 +65,8 @@ int main(char[][] args)
     // Bring in unit test for module by referencing function in it
 
     cmp("foo", "bar");                  // string
-    const fcc = filenameCharCmp('a', 'b');          // path
-    const inn = isNaN(1.0);                         // math
+    cast(void)filenameCharCmp('a', 'b');          // path
+    cast(void)isNaN(1.0);                         // math
     std.conv.to!double("1.0");          // std.conv
     OutBuffer b = new OutBuffer();      // outbuffer
     auto r = regex("");                 // regex
@@ -78,7 +78,7 @@ int main(char[][] args)
     Clock.currTime();                   // datetime
     Exception e = new ReadException(""); // stream
     din.eof();                           // cstream
-    const ivd = isValidDchar(cast(dchar)0);          // utf
+    cast(void)isValidDchar(cast(dchar)0);          // utf
     std.uri.ascii2hex(0);                // uri
     std.zlib.adler32(0,null);            // D.zlib
     auto t = task!cmp("foo", "bar");  // parallelism
@@ -101,12 +101,12 @@ int main(char[][] args)
     assert(x[1] == 3);
     assert(x[2] == 45);
 
-    const sin3 = std.math.sin(3.0);
+    cast(void)std.math.sin(3.0);
     std.mathspecial.gamma(6.2);
 
     std.demangle.demangle("hello");
 
-    const iaa = std.uni.isAlpha('A');
+    cast(void)std.uni.isAlpha('A');
 
     std.file.exists("foo");
 


### PR DESCRIPTION
After discussion at https://d.puremagic.com/issues/show_bug.cgi?id=3882 I changed to using

``` D
cast(void)
```

instead.
