### PR TITLE
Issue 3882: Use cast(void) on calls to assumeSafeAppend

### DIFF
--- a/std/internal/uni.d
+++ b/std/internal/uni.d
@@ -313,7 +313,7 @@ struct CodepointSet
                 ivals[i-1] = ivals[i];//moveAll(ivals[1..$], ivals[0..$-1]);
             ivals = ivals[0..$-1];
             if(!__ctfe)
-                assumeSafeAppend(ivals);
+                cast(void)assumeSafeAppend(ivals);
         }
         if(ivals[$-1] != endOfRange)
             insertInPlaceAlt(ivals, ivals.length, endOfRange);
@@ -321,7 +321,7 @@ struct CodepointSet
         {
             ivals = ivals[0..$-1] ;
             if(!__ctfe)
-                assumeSafeAppend(ivals);
+                cast(void)assumeSafeAppend(ivals);
         }
         assert(!(ivals.length & 1));
         return this;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -4146,7 +4146,7 @@ private static size_t _receiveAsyncLines(Terminator, Unit)
                     {
                         buffer = cast(Unit[])buf;
                         buffer.length = 0;
-                        buffer.assumeSafeAppend();
+                        cast(void)buffer.assumeSafeAppend();
                         bufferValid = true;
                     },
                     (bool flag) { aborted = true; }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1623,7 +1623,7 @@ Allows to directly use range operations on lines of a file.
             import std.algorithm : endsWith;
 
             assert(file.isOpen);
-            assumeSafeAppend(line);
+            cast(void)assumeSafeAppend(line);
             file.readln(line, terminator);
             if (line.empty)
             {
@@ -1809,7 +1809,7 @@ the contents may well have changed).
         {
             static import std.file;
 
-            /* the C function tmpfile doesn't seem to work, even when called from C */ 
+            /* the C function tmpfile doesn't seem to work, even when called from C */
             auto deleteme = testFilename();
             auto file = File(deleteme, "w+");
             scope(success) std.file.remove(deleteme);

--- a/std/uni.d
+++ b/std/uni.d
@@ -6584,9 +6584,9 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
         }
         // reset variables
         decomposed.length = 0;
-        decomposed.assumeSafeAppend();
+        cast(void)decomposed.assumeSafeAppend();
         ccc.length = 0;
-        ccc.assumeSafeAppend();
+        cast(void)ccc.assumeSafeAppend();
         input = input[anchors[1]..$];
         // and move on
         anchors = splitNormalized!norm(input);
@@ -7921,4 +7921,3 @@ private:
 }
 
 }// version(!std_uni_bootstrap)
-


### PR DESCRIPTION
This should make https://github.com/D-Programming-Language/dmd/pull/3342 compile Phobos without warnings.
