### PR TITLE
Mark std.stdio.fopen and popen as trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2884,7 +2884,7 @@ unittest
  * (to $(D _wfopen) on Windows)
  * with appropriately-constructed C-style strings.
  */
-private FILE* fopen(in char[] name, in char[] mode = "r")
+private FILE* fopen(in char[] name, in char[] mode = "r") @trusted
 {
     import std.string : toStringz;
 
@@ -2917,7 +2917,7 @@ version (Posix)
      * Convenience function that forwards to $(D std.c.stdio.popen)
      * with appropriately-constructed C-style strings.
      */
-    FILE* popen(in char[] name, in char[] mode = "r")
+    FILE* popen(in char[] name, in char[] mode = "r") @trusted
     {
         import std.string : toStringz;
 


### PR DESCRIPTION
They use system functions `_wfopen`, `core.sys.posix.stdio.fopen`, or `core.stdc.stdio.fopen` but we can verify that they can be trusted.
