### PR TITLE
Mark std.stdio.File.this, opAssign, open and popen as safe

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -344,7 +344,7 @@ object refers to it anymore.
 
 Throws: $(D ErrnoException) if the file could not be opened.
  */
-    this(string name, in char[] stdioOpenmode = "rb")
+    this(string name, in char[] stdioOpenmode = "rb") @safe
     {
         import std.conv : text;
         import std.exception : errnoEnforce;
@@ -372,7 +372,7 @@ Assigns a file to another. The target of the assignment gets detached
 from whatever file it was attached to, and attaches itself to the new
 file.
  */
-    void opAssign(File rhs)
+    void opAssign(File rhs) @safe
     {
         import std.algorithm : swap;
 
@@ -387,7 +387,7 @@ cplusplus.com/reference/clibrary/cstdio/fopen.html, fopen) function.
 
 Throws: $(D ErrnoException) in case of error.
  */
-    void open(string name, in char[] stdioOpenmode = "rb")
+    void open(string name, in char[] stdioOpenmode = "rb") @safe
     {
         detach();
         this = File(name, stdioOpenmode);
@@ -400,7 +400,7 @@ opengroup.org/onlinepubs/007908799/xsh/_popen.html, _popen).
 
 Throws: $(D ErrnoException) in case of error.
  */
-    version(Posix) void popen(string command, in char[] stdioOpenmode = "r")
+    version(Posix) void popen(string command, in char[] stdioOpenmode = "r") @safe
     {
         import std.exception : errnoEnforce;
 


### PR DESCRIPTION
Now they do not contain any unsafe operations.

After merging this pull request, the following code can be compiled and it works!

``` D
auto foo() @safe
{
  // File can be declared in the safe function!
  auto f = File("foo");
}
```
