### PR TITLE
Simplify regex test case, fix issue 12394

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -7456,7 +7456,7 @@ unittest
 // bugzilla 12076
 unittest
 {
-    auto RE = ctRegex!(r"(?<!x\w+)\s(\w+)");
+    auto RE = ctRegex!(r"(?<!x[a-z]+)\s([a-z]+)");
     string s = "one two";
     auto m = match(s, RE);
 }


### PR DESCRIPTION
There is no point in using big character sets as it's not
important for the test case in question.

Big sets put a lot of burden on CTFE/compiler/time-to-compile.
