### PR TITLE
Fix issue 12446 - std.parallelism.amap: prefer iteration to indexing

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1711,9 +1711,21 @@ public:
 
                     immutable end = min(len, start + workUnitSize);
 
-                    foreach(i; start..end)
+                    static if (hasSlicing!R)
                     {
-                        buf[i] = fun(range[i]);
+                        auto subrange = range[start..end];
+                        foreach(i; start..end)
+                        {
+                            buf[i] = fun(subrange.front());
+                            subrange.popFront();
+                        }
+                    }
+                    else
+                    {
+                        foreach(i; start..end)
+                        {
+                            buf[i] = fun(range[i]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12446
