### PR TITLE
Fix Issue #5240: faster std.random.uniform for [0.0, 1.0) range

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1594,9 +1594,23 @@ body
     {
         immutable T u = (rng.front - rng.min) * factor;
         rng.popFront();
-        if (u < 1)
+        static if (isIntegral!R)
         {
+            /* if RNG variates are integral, we're guaranteed
+             * by the definition of factor that u < 1.
+             */
             return u;
+        }
+        else
+        {
+            /* Otherwise we have to check, just in case a
+             * floating-point RNG returns a variate that is
+             * exactly equal to its maximum
+             */
+            if (u < 1)
+            {
+                return u;
+            }
         }
     }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5240

This is an alternative design to D-Programming-Language/phobos#1460 for a fast uniform random number generator in the unit interval.  It implements several fixes and design suggestions proposed in the comment thread of that pull request.

In particular, this version ensures that the interval that the distribution covers is the half-open interval `[0, 1)` rather than the inclusive interval `[0, 1]`.  This, together with the name `uniform01`, reflects typical practice from other languages and libraries.  The provided function can be templated on floating-point type, defaulting to double if none is specified.

The implementation is pretty much derived from its counterpart in Boost.Random, in particular in its taking account of the different requirements for integral versus floating-point RNG values, and in checking that the generated variate is less than 1 before returning.  This last check is necessary simply because we can't guarantee, in the case of a floating-point based RNG, that we will not get a result exactly equal to 1.

@bearophile I hope you don't mind me jumping ahead of your PR; I had this code ready and available, so I thought I'd throw it out there.  But I'd be very happy to see you just take what's good about this into your own patchset; we are all keen to see your first Phobos contribution :-)
