### PR TITLE
Mark methods for random number generators in std.random as safe pure not...

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -402,7 +402,7 @@ $(D x0).
 /**
    Returns the current number in the random sequence.
 */
-    @property UIntType front() @safe pure nothrow
+    @property UIntType front() const @safe pure nothrow
     {
         return _x;
     }
@@ -884,7 +884,7 @@ struct XorshiftEngine(UIntType, UIntType bits, UIntType a, UIntType b, UIntType 
      * Returns the current number in the random sequence.
      */
     @property @safe
-    nothrow UIntType front() pure
+    nothrow UIntType front() const pure
     {
         static if (bits == 192)
             return value_;


### PR DESCRIPTION
...hrow

This pull request marks methods for `std.random.LinearCongruentialEngine`, `MersenneTwisterEngine`, and `XorshiftEngine` as safe, pure, and nothrow.
They only takes integral types as the template arguments and they do not use any unsafe/impure/throwable operations.

I leave some unittests for them as is because they use `unpredictableSeed` which is currently a system and nothrow function (of course it is an impure function).

Off topic:
`unpredictableSeed` uses unsafe cast (but I guess it can be trusted) and `core.thread.Thread.getThis`.
 I did not send pull request to make `Thread.getThis` safe and nothrow because I am not familiar with thread programming...
