### PR TITLE
Fix newly introduced FQN issue caused by 313

### DIFF
--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -93,7 +93,7 @@ textbuf = doSomething(textbuf, args);
  */
 
 @system
-struct ScopeBuffer(T, alias realloc = core.stdc.stdlib.realloc)
+struct ScopeBuffer(T, alias realloc = /*core.stdc.stdlib*/.realloc)
           if (isAssignable!T &&
               !hasElaborateDestructor!T &&
               !hasElaborateCopyConstructor!T &&


### PR DESCRIPTION
Selective import (at [line 14](https://github.com/D-Programming-Language/phobos/blob/master/std/internal/scopebuffer.d#L14)) should not make the fully qualified module name visible. So using the long name `core.stdc.stdlib.realloc` is invalid.
