### PR TITLE
Issue 11778 - format for null does not verify fmt flags.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3042,6 +3042,14 @@ unittest
     format("%s", &i);
 }
 
+unittest
+{
+    // Test for issue 11778
+    int* p = null;
+    assertThrown(format("%d", p));
+    assertThrown(format("%04d", p + 2));
+}
+
 @safe pure unittest
 {
     // Test for issue 12505


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11778

Support `%d` and `%o` for pointer type formatting.
