### PR TITLE
Add unittest for 12540

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -2225,3 +2225,17 @@ unittest
     assertNotThrown!VariantException(v.get!(const(Object)));
     assertNotThrown!VariantException(v.get!(immutable(Object)));
 }
+
+unittest 
+{
+    static struct DummyScope
+    {
+        // https://d.puremagic.com/issues/show_bug.cgi?id=12540
+        alias Alias12540 = Algebraic!Class12540;
+
+        static class Class12540 
+        {
+            Alias12540 entity;
+        }
+    }
+}


### PR DESCRIPTION
~~Fixes https://d.puremagic.com/issues/show_bug.cgi?id=12540~~

~~I had to put the unittest in a version(unittest) block because forward referencing `Class12540` does not work inside of a `unittest {}` block (and there's no code to run here; the 'test' is just to ensure that this case compiles). ~~

Modified to only add a unittest for 12540. 
