### PR TITLE
Fix complexity in red-black tree documentation

### DIFF
--- a/std/container.d
+++ b/std/container.d
@@ -5792,7 +5792,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     /**
      * Fetch a range that spans all the elements in the container.
      *
-     * Complexity: $(BIGOH log(n))
+     * Complexity: $(BIGOH 1)
      */
     Range opSlice()
     {
@@ -5802,7 +5802,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     /**
      * The front element in the container
      *
-     * Complexity: $(BIGOH log(n))
+     * Complexity: $(BIGOH 1)
      */
     Elem front()
     {


### PR DESCRIPTION
For the existing implementation `front()` and `opSlice()` are O(1).
