### PR TITLE
Mark std.stdio.File.fdopen as safe and trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -417,12 +417,12 @@ be compatible with the mode of the file descriptor.
 
 Throws: $(D ErrnoException) in case of error.
  */
-    void fdopen(int fd, in char[] stdioOpenmode = "rb")
+    void fdopen(int fd, in char[] stdioOpenmode = "rb") @safe
     {
         fdopen(fd, stdioOpenmode, null);
     }
 
-    package void fdopen(int fd, in char[] stdioOpenmode, string name)
+    package void fdopen(int fd, in char[] stdioOpenmode, string name) @trusted
     {
         import std.string : toStringz;
         import std.exception : errnoEnforce;


### PR DESCRIPTION
This pull request marks public `std.stdio.File.fdopen` as safe and package `File.fdopen` as trusted.
- public `fdopen` can be naturally marked as safe if package `fdopen` is safe or trusted.
- package `fdopen` contains the following unsafe operations:
  - In DigitalMars Win32 systems:
    - use of `core.stdc.stdio.fopen`
    - use of `FLOCK` (== `__fp_lock`)
    - use of cast from `FILE*` to `iobuf*`
    - use of `close`
    - use of `FLOCK` (== `__fp_unlock`)
  - use of `_fdopen` in Windows systems.
  - use of `core.sys.posix.stdio.fdopen` in other systems

It is easy to verify that their use of `_fdopen` and `core.sys.posix.stdio.fdopen` can be trusted.

However, I am not sure for DigitalMars Win32 systems because I do not have any Windows 32bit machines
and because I do not know about internal representation of DigitalMars stdio.
Does anyone verify that DigitalMars Win32 version can be trusted?
