### PR TITLE
fix issue 12582 Non-existant named capture groups cause runtime range vi...

### DIFF
--- a/std/regex.d
+++ b/std/regex.d
@@ -2281,7 +2281,8 @@ unittest
 @trusted uint lookupNamedGroup(String)(NamedGroup[] dict, String name)
 {//equal is @system?
     auto fnd = assumeSorted!"cmp(a,b) < 0"(map!"a.name"(dict)).lowerBound(name).length;
-    enforce(equal(dict[fnd].name, name), text("no submatch named ", name));
+    enforce(fnd < dict.length && equal(dict[fnd].name, name), 
+        text("no submatch named ", name));
     return dict[fnd].group;
 }
 
@@ -7468,6 +7469,13 @@ unittest
     assert("aaab".matchFirst(r).hit == "aaa");
     auto r2 = ctRegex!`.*(?!a)`;
     assert("aaab".matchFirst(r2).hit == "aaab");
+}
+
+// bugzilla 12582
+unittest
+{
+    auto r = regex(`(?P<a>abc)`);
+    assert(collectException("abc".matchFirst(r)["b"]));
 }
 
 }//version(unittest)


### PR DESCRIPTION
...olation or segmentation fault in regex
