### PR TITLE
Eliminate druntime_libs target

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -272,8 +272,8 @@ $(ROOT)/%$(DOTOBJ) : %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
 	$(CC) -c $(CFLAGS) $< -o$@
 
-$(LIB) : $(OBJS) $(ALL_D_FILES) druntime_libs
-	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
+$(LIB) : $(ALL_D_FILES) $(OBJS) $(DRUNTIME)
+	$(DMD) $(DFLAGS) -lib -of$@ $(D_FILES) $(OBJS) $(DRUNTIME)
 
 dll : $(ROOT)/libphobos2.so
 
@@ -283,7 +283,7 @@ $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
 $(ROOT)/$(SONAME): $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
-$(LIBSO): $(OBJS) $(ALL_D_FILES) druntime_libs $(LIBCURL_STUB)
+$(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO) $(LIBCURL_STUB)
 	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(LINKCURL) $(D_FILES) $(OBJS)
 
 # stub library with soname of the real libcurl.so (Bugzilla 10710)
@@ -316,15 +316,15 @@ $(UT_D_OBJS): $(ROOT)/unittest/%.o: %.d
 
 ifneq (linux,$(OS))
 
-$(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) druntime_libs
-	$(DMD) $(DFLAGS) -unittest -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKCURL) -defaultlib= -debuglib=
+$(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME)
+	$(DMD) $(DFLAGS) -unittest -of$@ $^ $(LINKCURL) -defaultlib= -debuglib=
 
 else
 
 UT_LIBSO:=$(ROOT)/unittest/libphobos2-ut.so
 
 $(UT_LIBSO): override PIC:=-fPIC
-$(UT_LIBSO): $(UT_D_OBJS) $(OBJS) druntime_libs $(LIBCURL_STUB)
+$(UT_LIBSO): $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LIBCURL_STUB)
 	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) $(LINKCURL) -defaultlib= -debuglib=
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_LIBSO)
@@ -363,11 +363,12 @@ endif
 	cp -r etc/* $(INSTALL_DIR)/import/etc/
 	cp LICENSE_1_0.txt $(INSTALL_DIR)/phobos-LICENSE.txt
 
-# Target druntime_libs produces $(DRUNTIME) and $(DRUNTIMESO). See
-# http://stackoverflow.com/q/7081284 on why this setup makes sense.
-.PHONY: druntime_libs
-druntime_libs:
+$(DRUNTIME):
 	$(MAKE) -C $(DRUNTIME_PATH) -f posix.mak MODEL=$(MODEL) DMD=$(DMD) OS=$(OS)
+
+ifeq (,$(findstring win,$(OS)))
+$(DRUNTIMESO): $(DRUNTIME)
+endif
 
 ###########################################################
 # html documentation


### PR DESCRIPTION
I just noticed that two successive makes of phobos build the library twice:

make -f posix.mak
... runs dmd ...
make -f posix.mak
... runs dmd again ...

This shouldn't happen. A bit of investigation reveals that the druntime_libs phony rule is the culprit.

This pull request eliminates druntime_libs entirely. The disadvantage is that druntime is only made if libdruntime.a is missing, but not when it's out of date. Anyone knows how to improve that? Ideally make will always be invoked for druntime, but phobos will be remade only if druntime had been, in fact, changed.
