### PR TITLE
std.math: Check if dmd-style inline asm is available

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -61,6 +61,12 @@
  */
 module std.math;
 
+version (Win64)
+{
+    version (D_InlineAsm_X86_64)
+        version = Win64_DMD_InlineAsm;
+}
+
 import core.stdc.math;
 import std.traits;
 
@@ -2187,7 +2193,7 @@ unittest
  */
 int ilogb(real x)  @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -2737,7 +2743,7 @@ unittest
  */
 real logb(real x) @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -2861,7 +2867,10 @@ real cbrt(real x) @trusted nothrow
 {
     version (Win64)
     {
-        return copysign(exp2(yl2x(fabs(x), 1.0L/3.0L)), x);
+        version (INLINE_YL2X)
+            return copysign(exp2(yl2x(fabs(x), 1.0L/3.0L)), x);
+        else
+            return core.stdc.math.cbrtl(x);
     }
     else
         return core.stdc.math.cbrtl(x);
@@ -2991,7 +3000,7 @@ unittest
  */
 real ceil(real x)  @trusted pure nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -3044,7 +3053,7 @@ unittest
  */
 real floor(real x) @trusted pure nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -3394,7 +3403,7 @@ version(Posix)
  */
 real trunc(real x) @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {


### PR DESCRIPTION
GDC doesn't support dmd style inline asm and gdc/mingw builds fail because of this.
