### PR TITLE
Remove deprecated std.metastrings

### DIFF
--- a/std/metastrings.d
+++ b/std/metastrings.d
@@ -1,52 +1,20 @@
 // Written in the D programming language.
 
-/**
-$(RED Deprecated. It will be removed in March 2014.
-      Please use $(XREF string, format), $(XREF conv, to), or
-      $(XREF conv, parse) instead of these templates (which one would depend on
-      which template is being replaced.) They now work in CTFE, and these
-      templates are very inefficient.)
-
-Templates with which to do compile-time manipulation of strings.
-
-Macros:
- WIKI = Phobos/StdMetastrings
-
-Copyright: Copyright Digital Mars 2007 - 2013.
-License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           Don Clugston
-Source:    $(PHOBOSSRC std/_metastrings.d)
-*/
+/*
+ * Explicitly undocumented. It will be removed in October 2014.
+ *
+ *    Please use $(XREF string, format), $(XREF conv, to), or
+ *    $(XREF conv, parse) instead of these templates (which one would depend on
+ *    which template is being replaced.) They now work in CTFE, and these
+ *    templates are very inefficient.)
+ */
 module std.metastrings;
 
-/**
-$(RED Deprecated.
-     Please use $(XREF string, format) instead. It now works in CTFE,
-     and this template is very inefficient.)
-
-Formats constants into a string at compile time.  Analogous to $(XREF
-string,format).
-
-Parameters:
-
-A = tuple of constants, which can be strings, characters, or integral
-    values.
-
-Formats:
- *    The formats supported are %s for strings, and %%
- *    for the % character.
-Example:
----
-import std.metastrings;
-import std.stdio;
-
-void main()
-{
-  string s = Format!("Arg %s = %s", "foo", 27);
-  writefln(s); // "Arg foo = 27"
-}
- * ---
+/*
+ * Explicitly undocumented. It will be removed in October 2014.
+ *
+ *   Please use $(XREF string, format) instead. It now works in CTFE,
+ *   and this template is very inefficient.)
  */
 
 deprecated("std.string.format now works in CTFE. Please use it instead.")
@@ -85,12 +53,11 @@ unittest
     assert(s == "helworldlo-138ctrue", "[" ~ s ~ "]");
 }
 
-/**
- * $(RED Deprecated.
+/*
+ * Explicitly undocumented. It will be removed in October 2014.
+ *
  *       Please use $(XREF conv, format) instead. It now works in CTFE,
  *       and this template is very inefficient.)
- *
- * Convert constant argument to a string.
  */
 
 deprecated("std.conv.to now works in CTFE. Please use it instead.")
@@ -107,7 +74,6 @@ unittest
     static assert(toStringNow!(1uL << 62) == "4611686018427387904");
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(long v)
 {
@@ -123,35 +89,30 @@ unittest
     static assert(toStringNow!(-138L) == "-138");
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(uint U)
 {
     enum toStringNow = toStringNow!(cast(ulong)U);
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(int I)
 {
     enum toStringNow = toStringNow!(cast(long)I);
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(bool B)
 {
     enum toStringNow = B ? "true" : "false";
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(string S)
 {
     enum toStringNow = S;
 }
 
-/// ditto
 deprecated("std.conv.to!string now works in CTFE. Please use it instead.")
 template toStringNow(char C)
 {
@@ -159,18 +120,11 @@ template toStringNow(char C)
 }
 
 
-/********
- * $(RED Deprecated.
+/*
+ * Explicitly undocumented. It will be removed in October 2014.
+ *
  *       Please use $(XREF conv, parse) instead. It now works in CTFE,
  *       and this template is very inefficient.)
- *
- * Parse unsigned integer literal from the start of string s.
- * returns:
- *    .value = the integer literal as a string,
- *    .rest = the string following the integer literal
- * Otherwise:
- *    .value = null,
- *    .rest = s
  */
 
 deprecated("to!string(std.conv.parse!uint(value)) now works in CTFE. Please use it instead.")
@@ -193,22 +147,12 @@ template parseUinteger(const(char)[] s)
     }
 }
 
-/********
-$(RED Deprecated.
-      Please use $(XREF conv, parse) instead. It now works in CTFE,
-      and this template is very inefficient.)
-
-Parse integer literal optionally preceded by $(D '-') from the start
-of string $(D s).
-
-Returns:
-   .value = the integer literal as a string,
-   .rest = the string following the integer literal
-
-Otherwise:
-   .value = null,
-   .rest = s
-*/
+/*
+ * Explicitly undocumented. It will be removed in October 2014.
+ *
+ *    Please use $(XREF conv, parse) instead. It now works in CTFE,
+ *    and this template is very inefficient.)
+ */
 
 deprecated("to!string(std.conv.parse!int(value)) now works in CTFE. Please use it instead.")
 template parseInteger(const(char)[] s)


### PR DESCRIPTION
Comment in the file says `It will be removed in March 2014`.
