### PR TITLE
Avoid accidental call to object.clear

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2560,24 +2560,26 @@ struct Appender(A : T[], T)
         put(items);
     }
 
+    /**
+     * Clears the managed array.  This allows the elements of the array to be reused
+     * for appending.
+     *
+     * Note that clear is disabled for immutable or const element types, due to the
+     * possibility that $(D Appender) might overwrite immutable data.
+     */
+    void clear()() @safe pure nothrow
+    {
+        static assert(isMutable!T,
+            "Appender.clear is disabled for immutable or const element types");
+        if (_data)
+        {
+            _data.arr = ()@trusted{ return _data.arr.ptr[0 .. 0]; }();
+        }
+    }
+
     // only allow overwriting data on non-immutable and non-const data
     static if (isMutable!T)
     {
-        /**
-         * Clears the managed array.  This allows the elements of the array to be reused
-         * for appending.
-         *
-         * Note that clear is disabled for immutable or const element types, due to the
-         * possibility that $(D Appender) might overwrite immutable data.
-         */
-        void clear() @safe pure nothrow
-        {
-            if (_data)
-            {
-                _data.arr = ()@trusted{ return _data.arr.ptr[0 .. 0]; }();
-            }
-        }
-
         /**
          * Shrinks the managed array to the given length.
          *


### PR DESCRIPTION
This is not an ideal solution, but it's better than not doing anything. Once object.clear is completely disposed of we can revert this change.

Other possibilities:
1) use a template constraint. Gives a terrible error message.
2) use a runtime assert: it's _much_ better to complain at compile-time.
