### PR TITLE
Sed "@safe pure nothrow"

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -3255,12 +3255,12 @@ if (isSomeChar!C)
             getFirst();
         }
 
-        @property bool empty() const pure nothrow @safe
+        @property bool empty() const @safe pure nothrow
         {
             return _s.empty;
         }
 
-        @property inout(Result) save() inout pure nothrow @safe
+        @property inout(Result) save() inout @safe pure nothrow
         {
             return this;
         }
@@ -4418,7 +4418,7 @@ unittest
 {
     import std.exception : assertCTFEable;
 
-    void dg() pure @safe nothrow
+    void dg() @safe pure nothrow
     {
         byte[]  sarr = [1, 2, 3, 4];
         ubyte[] uarr = [1, 2, 3, 4];

--- a/std/array.d
+++ b/std/array.d
@@ -385,7 +385,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
     return arrayAllocImpl!(true, T, ST)(sizes);
 }
 
-@safe nothrow pure unittest
+@safe pure nothrow unittest
 {
     cast(void)minimallyInitializedArray!(int[][][][][])();
     double[] arr = minimallyInitializedArray!(double[])(100);

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -524,7 +524,7 @@ private:
     }
 +/
 private:
-    void negate() pure nothrow @safe
+    void negate() @safe pure nothrow
     {
         if (!data.isZero())
             sign = !sign;

--- a/std/complex.d
+++ b/std/complex.d
@@ -119,7 +119,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     See the $(LINK2 std_format.html, std.format) and $(XREF string, format)
     documentation for more information.
     */
-    string toString() const /* TODO: pure @safe nothrow */
+    string toString() const /* TODO: @safe pure nothrow */
     {
         import std.exception : assumeUnique;
         char[] buf;

--- a/std/conv.d
+++ b/std/conv.d
@@ -3998,7 +3998,7 @@ address.
 Returns: A pointer to the newly constructed object (which is the same
 as $(D chunk)).
  */
-T* emplace(T)(T* chunk) @safe nothrow pure
+T* emplace(T)(T* chunk) @safe pure nothrow
 {
     emplaceRef!T(*chunk);
     return chunk;

--- a/std/functional.d
+++ b/std/functional.d
@@ -914,7 +914,7 @@ unittest {
         static assert(is(typeof(dg_trusted) == int delegate() @trusted));
         static assert(is(typeof(dg_system) == int delegate() @system));
         static assert(is(typeof(dg_pure_nothrow) == int delegate() pure nothrow));
-        //static assert(is(typeof(dg_pure_nothrow_safe) == int delegate() pure nothrow @safe));
+        //static assert(is(typeof(dg_pure_nothrow_safe) == int delegate() @safe pure nothrow));
 
         assert(dg_ref() == refvar);
         assert(dg_pure() == 1);

--- a/std/math.d
+++ b/std/math.d
@@ -5958,7 +5958,7 @@ unittest
     assert(fabs(r - 2.18504f) < .00001);
 }
 
-pure @safe nothrow unittest
+@safe pure nothrow unittest
 {
     // issue 6381: floor/ceil should be usable in pure function.
     auto x = floor(1.2);

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1392,7 +1392,7 @@ private:
 public:
     // This is used in parallel_algorithm but is too unstable to document
     // as public API.
-    size_t defaultWorkUnitSize(size_t rangeLen) const pure nothrow @safe
+    size_t defaultWorkUnitSize(size_t rangeLen) const @safe pure nothrow
     {
         if(this.size == 0)
         {
@@ -1922,7 +1922,7 @@ public:
             {
                 size_t _length;
 
-                public @property size_t length() const pure nothrow @safe
+                public @property size_t length() const @safe pure nothrow
                 {
                     return _length;
                 }
@@ -2138,7 +2138,7 @@ public:
                 size_t _length;
 
                 // Available if hasLength!S.
-                public @property size_t length() const pure nothrow @safe
+                public @property size_t length() const @safe pure nothrow
                 {
                     return _length;
                 }
@@ -3883,7 +3883,7 @@ private struct RoundRobinBuffer(C1, C2)
         primed = false;
     }
 
-    bool empty() @property const pure nothrow @safe
+    bool empty() @property const @safe pure nothrow
     {
         return _empty;
     }

--- a/std/traits.d
+++ b/std/traits.d
@@ -1214,7 +1214,7 @@ Example:
 --------------------
 alias FA = FunctionAttribute; // shorten the enum name
 
-real func(real x) pure nothrow @safe
+real func(real x) @safe pure nothrow
 {
     return x;
 }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1305,7 +1305,7 @@ Constructor initializing $(D this) with $(D value).
 /**
 Returns $(D true) if and only if $(D this) is in the null state.
  */
-    @property bool isNull() const pure nothrow @safe
+    @property bool isNull() const @safe pure nothrow
     {
         return _isNull;
     }
@@ -1333,7 +1333,7 @@ succeeds, $(D this) becomes non-null.
 Gets the value. $(D this) must not be in the null state.
 This function is also called for the implicit conversion to $(D T).
  */
-    @property ref inout(T) get() inout pure nothrow @safe
+    @property ref inout(T) get() inout @safe pure nothrow
     {
         enum message = "Called `get' on null Nullable!" ~ T.stringof ~ ".";
         assert(!isNull, message);
@@ -1408,7 +1408,7 @@ unittest
 unittest
 {
     // Ensure Nullable can be used in pure/nothrow/@safe environment.
-    function() pure nothrow @safe
+    function() @safe pure nothrow
     {
         Nullable!int n;
         assert(n.isNull);
@@ -1680,7 +1680,7 @@ unittest
 unittest
 {
     // Ensure Nullable can be used in pure/nothrow/@safe environment.
-    function() pure nothrow @safe
+    function() @safe pure nothrow
     {
         Nullable!(int, int.min) n;
         assert(n.isNull);
@@ -1749,7 +1749,7 @@ struct NullableRef(T)
 /**
 Constructor binding $(D this) with $(D value).
  */
-    this(T* value) pure nothrow @safe
+    this(T* value) @safe pure nothrow
     {
         _value = value;
     }
@@ -1757,7 +1757,7 @@ Constructor binding $(D this) with $(D value).
 /**
 Binds the internal state to $(D value).
  */
-    void bind(T* value) pure nothrow @safe
+    void bind(T* value) @safe pure nothrow
     {
         _value = value;
     }
@@ -1765,7 +1765,7 @@ Binds the internal state to $(D value).
 /**
 Returns $(D true) if and only if $(D this) is in the null state.
  */
-    @property bool isNull() const pure nothrow @safe
+    @property bool isNull() const @safe pure nothrow
     {
         return _value is null;
     }
@@ -1773,7 +1773,7 @@ Returns $(D true) if and only if $(D this) is in the null state.
 /**
 Forces $(D this) to the null state.
  */
-    void nullify() pure nothrow @safe
+    void nullify() @safe pure nothrow
     {
         _value = null;
     }
@@ -1793,7 +1793,7 @@ Assigns $(D value) to the internally-held state.
 Gets the value. $(D this) must not be in the null state.
 This function is also called for the implicit conversion to $(D T).
  */
-    @property ref inout(T) get() inout pure nothrow @safe
+    @property ref inout(T) get() inout @safe pure nothrow
     {
         enum message = "Called `get' on null NullableRef!" ~ T.stringof ~ ".";
         assert(!isNull, message);
@@ -1844,7 +1844,7 @@ unittest
 unittest
 {
     // Ensure NullableRef can be used in pure/nothrow/@safe environment.
-    function() pure nothrow @safe
+    function() @safe pure nothrow
     {
         auto storage = new int;
         *storage = 19902;
@@ -3474,7 +3474,7 @@ unittest
     alias int F2() pure nothrow;
     static assert(is(DerivedFunctionType!(F1, F2) == F2));
     alias int F3() @safe;
-    alias int F23() pure nothrow @safe;
+    alias int F23() @safe pure nothrow;
     static assert(is(DerivedFunctionType!(F2, F3) == F23));
 
     // return type covariance

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -108,7 +108,7 @@ import std.conv, std.digest.md, std.digest.sha, std.random, std.range, std.strin
 public struct UUID
 {
     private:
-        @safe nothrow pure char toChar(size_t i) const
+        @safe pure nothrow char toChar(size_t i) const
         {
             if(i <= 9)
                 return cast(char)('0' + i);
@@ -116,7 +116,7 @@ public struct UUID
                 return cast(char)('a' + (i-10));
         }
 
-        @safe nothrow pure char[36] _toString() const
+        @safe pure nothrow char[36] _toString() const
         {
             char[36] result;
 
@@ -625,7 +625,7 @@ public struct UUID
         /**
          * Swap the data of this UUID with the data of rhs.
          */
-        @safe nothrow pure void swap(ref UUID rhs)
+        @safe pure nothrow void swap(ref UUID rhs)
         {
             auto bck = data;
             data = rhs.data;


### PR DESCRIPTION
This simply makes all occurences of the trio "@safe pure nothrow" appear in _that_ order. It was already the case 90% of the time, so this only changes the remaining 10%.

Rationale for this change is to help with the ongoing effort to tag with `@nogc`: Having a single grep that can find the trivial functions, so we can easily track down the obvious candidates.

Also, consistency.

@WalterBright : Could you please confirm if this actually helps, and it doesn't create any conflicts on any of your potential current work?
