### PR TITLE
FIX 12661: [REG2.066a] std.regex with -debug causes linker errors

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -8335,8 +8335,19 @@ if (isInputRange!Range)
     // Undocummented because a clearer way to invoke is by calling
     // assumeSorted.
     this(Range input)
+    out
+    {
+        // moved out of the body as a workaround for Issue 12661
+        dbgVerifySorted();
+    }
+    body
     {
         this._input = input;
+    }
+
+    // Assertion only.
+    private void dbgVerifySorted()
+    {
         if(!__ctfe)
         debug
         {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12661

I have no idea what is the actual cause of regression.
This pull is a minimum workaround to remove the inference mismatch from std.range.SortedRange.
