### PR TITLE
Pass __FILE__ and __LINE__ into URIException

### DIFF
--- a/std/uri.d
+++ b/std/uri.d
@@ -39,14 +39,10 @@ import std.exception : assumeUnique;
 
 class URIException : Exception
 {
-    @safe pure nothrow this()
+    @safe pure nothrow
+    this(string msg, string file = __FILE__, size_t ln = __LINE__)
     {
-        super("URI Exception");
-    }
-
-    @safe pure nothrow this(string msg)
-    {
-        super("URI Exception: " ~ msg);
+        super("URI Exception: " ~ msg, file, ln);
     }
 }
 


### PR DESCRIPTION
`__FILE__` and `__LINE__` were not properly passed into URIException. However
passing them as arguments makes it ambigous. Therefore remove the unused
empty constructor.

The other option is to not remove it but pass it as a template parameter, e.g.:

``` D
this(string fn == __FILE__, size_t ln = __LINE__)(string msg)
```
