### PR TITLE
Revert "Remove -property switch"

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -129,7 +129,7 @@ ifneq (,$(filter cc% gcc% clang% icc% egcc%, $(CC)))
 endif
 
 # Set DFLAGS
-DFLAGS=-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -m$(MODEL) $(PIC)
+DFLAGS=-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -property -m$(MODEL) $(PIC)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
 else

--- a/win32.mak
+++ b/win32.mak
@@ -38,13 +38,13 @@ CFLAGS=-mn -6 -r
 
 ## Flags for dmd D compiler
 
-DFLAGS=-O -release -w
+DFLAGS=-O -release -w -property
 #DFLAGS=-unittest -g
 #DFLAGS=-unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-O -w
+UDFLAGS=-O -w -property
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -37,13 +37,13 @@ CFLAGS=/O2 /nologo /I"$(VCDIR)\INCLUDE" /I"$(SDKDIR)\Include"
 
 ## Flags for dmd D compiler
 
-DFLAGS=-m$(MODEL) -O -release -w
+DFLAGS=-m$(MODEL) -O -release -w -property
 #DFLAGS=-m$(MODEL) -unittest -g
 #DFLAGS=-m$(MODEL) -unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-g -m$(MODEL) -O -w
+UDFLAGS=-g -m$(MODEL) -O -w -property
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
This reverts commit adc153395dd02acbac0add8f0958bd0e03660569.

I don't know if we need to merge this in, but while `-property` is not outright deprecated, Phobos needs to compile with the `-property` switch.

Not meant to actually work, but rather keep track of what is broken.
