### PR TITLE
Make emplaceRef parameter optional

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -4853,6 +4853,15 @@ unittest //Constness
     emplaceRef!(IS[2])(ss, iss[]);
 }
 
+unittest
+{
+    int i;
+    emplaceRef(i);
+    emplaceRef!int(i);
+    emplaceRef(i, 5);
+    emplaceRef!int(i, 5);
+}
+
 private void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment, string typeName)
 {
     enforceEx!ConvException(chunk.length >= typeSize,


### PR DESCRIPTION
After playing around with `emplaceRef`, I've decided that mandatory type specification is not a feature. So this makes it now possible to simply use `emplaceRef(myChunk, data)`, rather than `emplaceRef!(typeof(myChunk))(myChunk, data)`.

The implementation is kind of convoluted, but it was the only way to get it working without ambiguity (I'm open to ideas for improving the design).

This should be the last change before I try to make it a public function. I think it has proved its use.
