### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -94,7 +94,7 @@ enum: int
     WSAEFAULT = (WSABASEERR+14),
     WSAEINVAL = (WSABASEERR+22),
     WSAEMFILE = (WSABASEERR+24),
-    
+
     /*
      * Windows Sockets definitions of regular Berkeley error constants
      */
@@ -135,30 +135,30 @@ enum: int
     WSAEDQUOT = (WSABASEERR+69),
     WSAESTALE = (WSABASEERR+70),
     WSAEREMOTE = (WSABASEERR+71),
-    
+
     /*
      * Extended Windows Sockets error constant definitions
      */
     WSASYSNOTREADY = (WSABASEERR+91),
     WSAVERNOTSUPPORTED = (WSABASEERR+92),
     WSANOTINITIALISED = (WSABASEERR+93),
-    
+
     /* Authoritative Answer: Host not found */
     WSAHOST_NOT_FOUND = (WSABASEERR+1001),
     HOST_NOT_FOUND = WSAHOST_NOT_FOUND,
-    
+
     /* Non-Authoritative: Host not found, or SERVERFAIL */
     WSATRY_AGAIN = (WSABASEERR+1002),
     TRY_AGAIN = WSATRY_AGAIN,
-    
+
     /* Non recoverable errors, FORMERR, REFUSED, NOTIMP */
     WSANO_RECOVERY = (WSABASEERR+1003),
     NO_RECOVERY = WSANO_RECOVERY,
-    
+
     /* Valid name, no data record of requested type */
     WSANO_DATA = (WSABASEERR+1004),
     NO_DATA = WSANO_DATA,
-    
+
     /* no address, look for MX record */
     WSANO_ADDRESS = WSANO_DATA,
     NO_ADDRESS = WSANO_ADDRESS

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -16,7 +16,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
 
  * Computes SHA1 and SHA2 hashes of arbitrary data. SHA hashes are 20 to 64 byte
  * quantities (depending on the SHA algorithm) that are like a checksum or CRC,
- * but are more robust. 
+ * but are more robust.
  *
  * SHA2 comes in several different versions, all supported by this module:
  * SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224 and SHA-512/256.
@@ -196,11 +196,11 @@ private nothrow pure ulong rotateRight(ulong x, uint n)
 /**
  * Template API SHA1/SHA2 implementation. Supports: SHA-1, SHA-224, SHA-256,
  * SHA-384, SHA-512, SHA-512/224 and SHA-512/256.
- * 
+ *
  * The blockSize and digestSize are in bits. However, it's likely easier to
  * simply use the convenience aliases: SHA1, SHA224, SHA256, SHA384, SHA512,
  * SHA512_224 and SHA512_256.
- * 
+ *
  * See $(D std.digest.digest) for differences between template and OOP API.
  */
 struct SHA(int blockSize, int digestSize)
@@ -338,7 +338,7 @@ struct SHA(int blockSize, int digestSize)
         }
         else
             static assert(0);
-        
+
         /*
          * number of bits, modulo 2^64 (ulong[1]) or 2^128 (ulong[2]),
          * should just use ucent instead of ulong[2] once it's available
@@ -365,10 +365,10 @@ struct SHA(int blockSize, int digestSize)
             /* All SHA1/SHA2 */
             T Ch(T)(T x, T y, T z) { return z ^ (x & (y ^ z)); }
             T Maj(T)(T x, T y, T z) { return (x & y) | (z & (x ^ y)); }
-            
+
             /* SHA-1 */
             uint Parity(uint x, uint y, uint z) { return x ^ y ^ z; }
-            
+
             /* SHA-224, SHA-256 */
             uint BigSigma0(uint x) { return rotateRight(x, 2) ^ rotateRight(x, 13) ^ rotateRight(x, 22); }
             uint BigSigma1(uint x) { return rotateRight(x, 6) ^ rotateRight(x, 11) ^ rotateRight(x, 25); }
@@ -627,7 +627,7 @@ struct SHA(int blockSize, int digestSize)
             T_SHA2_16_79!Word(61, W, D, E, F, G, H, A, B, C, constants[61]);
             T_SHA2_16_79!Word(62, W, C, D, E, F, G, H, A, B, constants[62]);
             T_SHA2_16_79!Word(63, W, B, C, D, E, F, G, H, A, constants[63]);
-            
+
             static if(is(Word==ulong))
             {
                 T_SHA2_16_79!Word(64, W, A, B, C, D, E, F, G, H, constants[64]);

--- a/std/regex.d
+++ b/std/regex.d
@@ -2272,7 +2272,7 @@ unittest
 @trusted uint lookupNamedGroup(String)(NamedGroup[] dict, String name)
 {//equal is @system?
     auto fnd = assumeSorted!"cmp(a,b) < 0"(map!"a.name"(dict)).lowerBound(name).length;
-    enforce(fnd < dict.length && equal(dict[fnd].name, name), 
+    enforce(fnd < dict.length && equal(dict[fnd].name, name),
         text("no submatch named ", name));
     return dict[fnd].group;
 }
@@ -2738,7 +2738,7 @@ public:
                     }
                     else
                     {
-                        
+
                         static if(charSize == 1)
                             static immutable codeBounds = [0x0, 0x7F, 0x80, 0x7FF, 0x800, 0xFFFF, 0x10000, 0x10FFFF];
                         else //== 2
@@ -7107,7 +7107,7 @@ unittest
     assert(equal(mx.captures, [ "B", "B"]));
     enum cx2 = ctRegex!"(A|B)*";
     assert(match("BAAA",cx2));
-    
+
     enum cx3 = ctRegex!("a{3,4}","i");
     auto mx3 = match("AaA",cx3);
     assert(mx3);

--- a/std/string.d
+++ b/std/string.d
@@ -946,7 +946,7 @@ unittest
 }
 
 private ptrdiff_t indexOfAnyImpl(bool forward, Char, Char2)(
-        const(Char)[] haystack, const(Char2)[] needles, 
+        const(Char)[] haystack, const(Char2)[] needles,
         CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!Char && isSomeChar!Char2)
 {
@@ -960,7 +960,7 @@ private ptrdiff_t indexOfAnyImpl(bool forward, Char, Char2)(
         else
         {
             size_t n = haystack.retro.findAmong(needles).source.length;
-            if (n) 
+            if (n)
             {
                 return n - haystack.strideBack(n);
             }
@@ -1035,7 +1035,7 @@ private ptrdiff_t indexOfAnyImpl(bool forward, Char, Char2)(
 
 /**
     Returns the index of the first occurence of any of the elements in $(D
-    needles) in $(D haystack). If no element of $(D needles) is found, 
+    needles) in $(D haystack). If no element of $(D needles) is found,
     then $(D -1) is returned.
 
     Params:
@@ -1044,7 +1044,7 @@ private ptrdiff_t indexOfAnyImpl(bool forward, Char, Char2)(
 ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
         CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!Char && isSomeChar!Char2)
-{    
+{
     return indexOfAnyImpl!(true)(haystack, needles, cs);
 }
 
@@ -1073,16 +1073,16 @@ unittest
             assert(indexOfAny(to!S("dfefffg"), to!T("fgh")) == 1);
             assert(indexOfAny(to!S("dfeffgfff"), to!T("feg")) == 1);
 
-            assert(indexOfAny(to!S("zfeffgfff"), to!T("ACDC"), 
+            assert(indexOfAny(to!S("zfeffgfff"), to!T("ACDC"),
                 CaseSensitive.no) == -1);
-            assert(indexOfAny(to!S("def"), to!T("MI6"), 
+            assert(indexOfAny(to!S("def"), to!T("MI6"),
                 CaseSensitive.no) == -1);
-            assert(indexOfAny(to!S("abba"), to!T("DEA"), 
+            assert(indexOfAny(to!S("abba"), to!T("DEA"),
                 CaseSensitive.no) == 0);
             assert(indexOfAny(to!S("def"), to!T("FBI"), CaseSensitive.no) == 2);
-            assert(indexOfAny(to!S("dfefffg"), to!T("NSA"), CaseSensitive.no) 
+            assert(indexOfAny(to!S("dfefffg"), to!T("NSA"), CaseSensitive.no)
                 == -1);
-            assert(indexOfAny(to!S("dfeffgfff"), to!T("BND"), 
+            assert(indexOfAny(to!S("dfeffgfff"), to!T("BND"),
                 CaseSensitive.no) == 0);
 
             assert(indexOfAny("\u0100", to!T("\u0100"), CaseSensitive.no) == 0);
@@ -1093,9 +1093,9 @@ unittest
 
 /**
     Returns the index of the first occurence of any of the elements in $(D
-    needles) in $(D haystack). If no element of $(D needles) is found, 
-    then $(D -1) is returned. The $(D startIdx) slices $(D s) in the following 
-    way $(D haystack[startIdx .. $]). $(D startIdx) represents a codeunit 
+    needles) in $(D haystack). If no element of $(D needles) is found,
+    then $(D -1) is returned. The $(D startIdx) slices $(D s) in the following
+    way $(D haystack[startIdx .. $]). $(D startIdx) represents a codeunit
     index in $(D haystack). If the sequence ending at $(D startIdx) does not
     represent a well formed codepoint, then a $(XREF utf,UTFException) may be
     thrown.
@@ -1109,7 +1109,7 @@ unittest
 ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
         const size_t startIdx, CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!Char && isSomeChar!Char2)
-{    
+{
     if (startIdx < haystack.length)
     {
         ptrdiff_t foundIdx = indexOfAny(haystack[startIdx .. $], needles, cs);
@@ -1147,32 +1147,32 @@ unittest
             assert(indexOfAny(to!S("dfefffg"), to!T("foo"), 2) == 3);
             assert(indexOfAny(to!S("dfeffgfff"), to!T("fsb"), 5) == 6);
 
-            assert(indexOfAny(to!S("dfeffgfff"), to!T("NDS"), 1, 
+            assert(indexOfAny(to!S("dfeffgfff"), to!T("NDS"), 1,
                 CaseSensitive.no) == -1);
-            assert(indexOfAny(to!S("def"), to!T("DRS"), 2, 
+            assert(indexOfAny(to!S("def"), to!T("DRS"), 2,
                 CaseSensitive.no) == -1);
-            assert(indexOfAny(to!S("abba"), to!T("SI"), 3, 
+            assert(indexOfAny(to!S("abba"), to!T("SI"), 3,
                 CaseSensitive.no) == -1);
-            assert(indexOfAny(to!S("deO"), to!T("ASIO"), 1, 
+            assert(indexOfAny(to!S("deO"), to!T("ASIO"), 1,
                 CaseSensitive.no) == 2);
-            assert(indexOfAny(to!S("dfefffg"), to!T("fbh"), 2, 
+            assert(indexOfAny(to!S("dfefffg"), to!T("fbh"), 2,
                 CaseSensitive.no) == 3);
-            assert(indexOfAny(to!S("dfeffgfff"), to!T("fEe"), 4, 
+            assert(indexOfAny(to!S("dfeffgfff"), to!T("fEe"), 4,
                 CaseSensitive.no) == 4);
             assert(indexOfAny(to!S("dfeffgffföä"), to!T("föä"), 9,
                 CaseSensitive.no) == 9);
 
-            assert(indexOfAny("\u0100", to!T("\u0100"), 0, 
+            assert(indexOfAny("\u0100", to!T("\u0100"), 0,
                 CaseSensitive.no) == 0);
         }
 
         foreach(cs; EnumMembers!CaseSensitive)
         {
-            assert(indexOfAny("hello\U00010143\u0100\U00010143", 
+            assert(indexOfAny("hello\U00010143\u0100\U00010143",
                 to!S("e\u0100"), 3, cs) == 9);
-            assert(indexOfAny("hello\U00010143\u0100\U00010143"w, 
+            assert(indexOfAny("hello\U00010143\u0100\U00010143"w,
                 to!S("h\u0100"), 3, cs) == 7);
-            assert(indexOfAny("hello\U00010143\u0100\U00010143"d, 
+            assert(indexOfAny("hello\U00010143\u0100\U00010143"d,
                 to!S("l\u0100"), 5, cs) == 6);
         }
     }
@@ -1180,16 +1180,16 @@ unittest
 
 /**
     Returns the index of the last occurence of any of the elements in $(D
-    needles) in $(D haystack). If no element of $(D needles) is found, 
+    needles) in $(D haystack). If no element of $(D needles) is found,
     then $(D -1) is returned.
 
     Params:
         cs = Indicates whether the comparisons are case sensitive.
 */
-ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack, 
+ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
         const(Char2)[] needles, CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!Char && isSomeChar!Char2)
-{    
+{
     return indexOfAnyImpl!(false)(haystack, needles, cs);
 }
 
@@ -1197,7 +1197,7 @@ ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
 unittest
 {
     ptrdiff_t i = "helloWorld".lastIndexOfAny("Wlo");
-    assert(i == 8); 
+    assert(i == 8);
 
     i = "Foo öäöllo world".lastIndexOfAny("öF");
     assert(i == 8);
@@ -1228,15 +1228,15 @@ unittest
             auto foundOeIdx = lastIndexOfAny(to!S("dfeffgföf"), to!T("feg"));
             assert(foundOeIdx == oeIdx, to!string(foundOeIdx));
 
-            assert(lastIndexOfAny(to!S("zfeffgfff"), to!T("ACDC"), 
+            assert(lastIndexOfAny(to!S("zfeffgfff"), to!T("ACDC"),
                 CaseSensitive.no) == -1);
-            assert(lastIndexOfAny(to!S("def"), to!T("MI6"), 
+            assert(lastIndexOfAny(to!S("def"), to!T("MI6"),
                 CaseSensitive.no) == -1);
-            assert(lastIndexOfAny(to!S("abba"), to!T("DEA"), 
+            assert(lastIndexOfAny(to!S("abba"), to!T("DEA"),
                 CaseSensitive.no) == 3);
-            assert(lastIndexOfAny(to!S("def"), to!T("FBI"), 
+            assert(lastIndexOfAny(to!S("def"), to!T("FBI"),
                 CaseSensitive.no) == 2);
-            assert(lastIndexOfAny(to!S("dfefffg"), to!T("NSA"), 
+            assert(lastIndexOfAny(to!S("dfefffg"), to!T("NSA"),
                 CaseSensitive.no) == -1);
 
             oeIdx = 2;
@@ -1244,10 +1244,10 @@ unittest
             {
                 oeIdx = 1;
             }
-            assert(lastIndexOfAny(to!S("ödfeffgfff"), to!T("BND"), 
+            assert(lastIndexOfAny(to!S("ödfeffgfff"), to!T("BND"),
                 CaseSensitive.no) == oeIdx);
 
-            assert(lastIndexOfAny("\u0100", to!T("\u0100"), 
+            assert(lastIndexOfAny("\u0100", to!T("\u0100"),
                 CaseSensitive.no) == 0);
         }
     }
@@ -1256,10 +1256,10 @@ unittest
 
 /**
     Returns the index of the last occurence of any of the elements in $(D
-    needles) in $(D haystack). If no element of $(D needles) is found, 
-    then $(D -1) is returned. The $(D stopIdx) slices $(D s) in the following 
-    way $(D s[0 .. stopIdx]). $(D stopIdx) represents a codeunit index in 
-    $(D s). If the sequence ending at $(D startIdx) does not represent a well 
+    needles) in $(D haystack). If no element of $(D needles) is found,
+    then $(D -1) is returned. The $(D stopIdx) slices $(D s) in the following
+    way $(D s[0 .. stopIdx]). $(D stopIdx) represents a codeunit index in
+    $(D s). If the sequence ending at $(D startIdx) does not represent a well
     formed codepoint, then a $(XREF utf,UTFException) may be thrown.
 
     Params:
@@ -1268,11 +1268,11 @@ unittest
         the stopIdx is greater equal the length of haystack the functions
         returns $(D -1).
 */
-ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack, 
-        const(Char2)[] needles, const size_t stopIdx, 
+ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
+        const(Char2)[] needles, const size_t stopIdx,
         CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!Char && isSomeChar!Char2)
-{    
+{
     if (stopIdx <= haystack.length)
     {
         return lastIndexOfAny(haystack[0u .. stopIdx], needles, cs);
@@ -1303,26 +1303,26 @@ unittest
         {
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
-            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337) == -1, 
+            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337) == -1,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("c"), 7) == 6, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("c"), 7) == 6,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("cd"), 5) == 3, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("cd"), 5) == 3,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("ef"), 6) == 5, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("ef"), 6) == 5,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefCdef"), to!T("c"), 8) == 2, 
+            assert(lastIndexOfAny(to!S("abcdefCdef"), to!T("c"), 8) == 2,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("x"), 7) == -1, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("x"), 7) == -1,
                 typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("xy"), 4) == -1, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("xy"), 4) == -1,
                 typeStr);
-            assert(lastIndexOfAny(to!S("öabcdefcdef"), to!T("ö"), 2) == 0, 
+            assert(lastIndexOfAny(to!S("öabcdefcdef"), to!T("ö"), 2) == 0,
                 typeStr);
 
-            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337, 
+            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337,
                 CaseSensitive.no) == -1, typeStr);
-            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("C"), 7, 
+            assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("C"), 7,
                 CaseSensitive.no) == 6, typeStr);
             assert(lastIndexOfAny(to!S("ABCDEFCDEF"), to!T("cd"), 5,
                 CaseSensitive.no) == 3, typeStr);

--- a/std/traits.d
+++ b/std/traits.d
@@ -2823,16 +2823,16 @@ unittest
 
 unittest //12000
 {
-    static struct S(T) 
+    static struct S(T)
     {
         static assert(hasIndirections!T);
     }
-    
-    static class A(T) 
+
+    static class A(T)
     {
         S!A a;
     }
-    
+
     A!int dummy;
 }
 

--- a/std/variant.d
+++ b/std/variant.d
@@ -256,8 +256,8 @@ private:
         {
             static if (is(typeof(*rhsPA == *zis)))
             {
-                // Work-around for bug 12164. 
-                // Without the check for if selector is -1, this function always returns 0. 
+                // Work-around for bug 12164.
+                // Without the check for if selector is -1, this function always returns 0.
                 // TODO: Remove this once 12164 is fixed.
                 if (*rhsPA == *zis && selector != cast(OpID)-1)
                 {
@@ -305,7 +305,7 @@ private:
                 alias AllTypes = ConstTypes;
             else //static if (isMutable!A)
                 alias AllTypes = TypeTuple!(MutaTypes, ConstTypes);
-                
+
             foreach (T ; AllTypes)
             {
                 if (targetType != typeid(T))
@@ -671,7 +671,7 @@ public:
             return null;
         static if (T.sizeof <= size)
             return cast(T*)&store;
-        else 
+        else
             return *cast(T**)&store;
     }
 
@@ -1649,7 +1649,7 @@ unittest
 }
 
 // Class and interface opEquals, issue 12157
-unittest 
+unittest
 {
     class Foo { }
 
@@ -1665,7 +1665,7 @@ unittest
     assert(v2 != v1);
     assert(v2 == f2);
 
-    // TODO: Remove once 12164 is fixed. 
+    // TODO: Remove once 12164 is fixed.
     // Verify our assumption that there is no -1 OpID.
     // Could also use std.algorithm.canFind at compile-time, but that may create bloat.
     foreach(member; EnumMembers!(Variant.OpID))
@@ -1743,14 +1743,14 @@ unittest
 }
 
 // Handling of empty types and arrays, e.g. issue 10958
-unittest 
+unittest
 {
     class EmptyClass { }
     struct EmptyStruct { }
     alias EmptyArray = void[0];
     alias Alg = Algebraic!(EmptyClass, EmptyStruct, EmptyArray);
 
-    Variant testEmpty(T)() 
+    Variant testEmpty(T)()
     {
         T inst;
         Variant v = inst;
@@ -1796,7 +1796,7 @@ unittest
         int val2;
     }
 
-    void testPeekWith(T)() 
+    void testPeekWith(T)()
     {
         T inst;
         inst.val1 = 3;
@@ -2226,14 +2226,14 @@ unittest
     assertNotThrown!VariantException(v.get!(immutable(Object)));
 }
 
-unittest 
+unittest
 {
     static struct DummyScope
     {
         // https://d.puremagic.com/issues/show_bug.cgi?id=12540
         alias Alias12540 = Algebraic!Class12540;
 
-        static class Class12540 
+        static class Class12540
         {
             Alias12540 entity;
         }


### PR DESCRIPTION
Removes all trailing whitespaces in phobos. I left out "container" to avoid conflicts with the current "package" pull.

```
grep -IlR " \+$" * | grep -v std/container | xargs sed -i 's/ \+$//'
```

Pinging @AndrejMitrovic for this.
