### PR TITLE
Fix issue 12771 - Variant opIndex for static arrays is not implemented.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -424,8 +424,7 @@ private:
         case OpID.index:
             // Added allowed!(...) prompted by a bug report by Chris
             // Nicholson-Sauls.
-            static if ((isStaticArray!(A) || isDynamicArray!(A))
-                    && !is(Unqual!(typeof(A.init[0])) == void) && allowed!(typeof(A.init[0])))
+            static if (isArray!(A) && !is(Unqual!(typeof(A.init[0])) == void) && allowed!(typeof(A.init[0])))
             {
                 // array type; input and output are the same VariantN
                 auto result = cast(VariantN*) parm;


### PR DESCRIPTION
I don't know why static arrays were handled differently before, the code should be the same for both, just assign the result parameter to the value of the array at the requested index.
