### PR TITLE
Constrain isSomeString

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -4260,7 +4260,7 @@ unittest
    Reads a string and returns it.
  */
 T unformatValue(T, Range, Char)(ref Range input, ref FormatSpec!Char spec)
-    if (isInputRange!Range && isSomeString!T && !is(T == enum))
+    if (isInputRange!Range && is(StringTypeOf!T) && !isAggregateType!T && !is(T == enum))
 {
     if (spec.spec == '(')
     {
@@ -4336,7 +4336,7 @@ unittest
    Reads an array (except for string types) and returns it.
  */
 T unformatValue(T, Range, Char)(ref Range input, ref FormatSpec!Char spec)
-    if (isInputRange!Range && isArray!T && !isSomeString!T && !is(T == enum))
+    if (isInputRange!Range && isArray!T && !is(StringTypeOf!T) && !isAggregateType!T && !is(T == enum))
 {
     if (spec.spec == '(')
     {

--- a/std/range.d
+++ b/std/range.d
@@ -1479,7 +1479,7 @@ $(D ElementType).
  */
 template ElementEncodingType(R)
 {
-    static if (isNarrowString!R && is(R : E[], E))
+    static if (is(StringTypeOf!R) && is(R : E[], E))
         alias ElementEncodingType = E;
     else
         alias ElementEncodingType = ElementType!R;


### PR DESCRIPTION
This pull adds a restriction to `isSomeString!S` to be an actual dynamic arrays you can iterate on, pop and save. A range in general:

``` D
char[], const(wchar)[], dstring; //YES
```

But not static arrays, which are more like static arrays, and can't be popped.

``` D
char[80] buf; //NO
```

The rationale for this is that as currently implemented, it `isSomeString` is virtually _useless_ in template constraint. For example:

``` D
if (isRandomAccessRange!R || isSomeString!R)
```

The problem here is that it makes `char[80]` an acceptable parameter, when it isn't an actual range. I don't think it is acceptable to burden template constraint to check that a string is also a range. Testing for a string should simply certify that the string is of the dynamic flavor that's actually expected...

After reviewing the restraint in `std.algorithm` or `std.range`, I can say that currently, a _lot_ of our constraint are wrong, and need fixing.

---

In case some code _REALLY_ want to accept a static array as a "string-like" input, I also changed `StringTypeOf` to always return the dynamic array of what you passed in. As such:

``` D
StringTypeOf!(char[80]) => char[];
```

This actually turned out useful, and there are a few places where it even solved a compile error.

---

Overall, this is breaking change. But it breaks relatively little code, and I think necessary to be able to work with generic objects while keeping your sanity...

Also fixes https://issues.dlang.org/show_bug.cgi?id=12796
