### PR TITLE
Fix Issue 7822 - lseek cast(int)offset should be lseek cast(off_t)offset

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -127,7 +127,7 @@ class MmFile
         if (prot & PROT_WRITE && size > statbuf.st_size)
         {
             // Need to make the file size bytes big
-            lseek(fd, cast(int)(size - 1), SEEK_SET);
+            lseek(fd, cast(off_t)(size - 1), SEEK_SET);
             char c = 0;
             core.sys.posix.unistd.write(fd, &c, 1);
         }
@@ -331,7 +331,7 @@ class MmFile
                 if (prot & PROT_WRITE && size > statbuf.st_size)
                 {
                     // Need to make the file size bytes big
-                    .lseek(fd, cast(int)(size - 1), SEEK_SET);
+                    .lseek(fd, cast(off_t)(size - 1), SEEK_SET);
                     char c = 0;
                     core.sys.posix.unistd.write(fd, &c, 1);
                 }
@@ -509,7 +509,7 @@ class MmFile
             p = MapViewOfFileEx(hFileMap, dwDesiredAccess, hi, cast(uint)start, len, address);
             errnoEnforce(p);
         } else {
-            p = mmap(address, len, prot, flags, fd, cast(int)start);
+            p = mmap(address, len, prot, flags, fd, cast(off_t)start);
             errnoEnforce(p != MAP_FAILED);
         }
         data = p[0 .. len];

--- a/std/stream.d
+++ b/std/stream.d
@@ -2099,7 +2099,7 @@ class File: Stream {
         throw new SeekException("unable to move file pointer");
       ulong result = (cast(ulong)hi << 32) + low;
     } else version (Posix) {
-      auto result = lseek(hFile, cast(int)offset, rel);
+      auto result = lseek(hFile, cast(off_t)offset, rel);
       if (result == cast(typeof(result))-1)
         throw new SeekException("unable to move file pointer");
     }


### PR DESCRIPTION
Currently, files bigger than around 2GB are truncated when mmap is used. This fixes it by using off_t instead of int as this is what the system call requires on Linux and Mac OSX.

Tested on Mac OSX.
