### PR TITLE
Add doc reference to std.uni, std.array

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -9,9 +9,9 @@ are preferable because they don't exhibit undesired aliasing, thus
 making code more robust.
 
 A number of common operations on strings are also found in the 
-Unicode $(B std.uni), and array $(B std.array) libraries. If a
+Unicode $(B std.uni), and array $(B std.array) modules. If a
 function you are looking for does not appear here, try looking
-in those libraries.
+in one of those modules.
 
 Macros: WIKI = Phobos/StdString
 


### PR DESCRIPTION
In a recent debate on forums there were some complaints the some functions to perform common string operations did not appear in std.string, but in std.uni or std.array.  Which made them hard to find. This update simply points readers to those libraries, in the event that they don't find the function they wanted in std.string.
