### PR TITLE
Mark std.stdio.File.seek as @trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -791,7 +791,7 @@ for the file handle.
 Throws: $(D Exception) if the file is not opened.
         $(D ErrnoException) if the call to $(D fseek) fails.
  */
-    void seek(long offset, int origin = SEEK_SET)
+    void seek(long offset, int origin = SEEK_SET) @trusted
     {
         import std.exception : enforce, errnoEnforce;
         import std.conv : to, text;


### PR DESCRIPTION
`std.stdio.File.seek` contains `core.stdc.stdio.fseek` (on Windows) or `core.sys.posix.stdio.fseeko` (on other systems) but we can easily verify it can be trusted.
