### PR TITLE
Mark std.stdio.LockingTextWriter.this, ~this and this(this) as @trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2059,7 +2059,7 @@ $(D Range) that locks the file and allows fast writing to it.
         _iobuf* handle;     // the unshared version of fps
         int orientation;
 
-        this(ref File f)
+        this(ref File f) @trusted
         {
             import std.exception : enforce;
 
@@ -2070,7 +2070,7 @@ $(D Range) that locks the file and allows fast writing to it.
             handle = cast(_iobuf*)fps;
         }
 
-        ~this()
+        ~this() @trusted
         {
             if(fps)
             {
@@ -2080,7 +2080,7 @@ $(D Range) that locks the file and allows fast writing to it.
             }
         }
 
-        this(this)
+        this(this) @trusted
         {
             if(fps)
             {


### PR DESCRIPTION
They use an unsafe function `FLOCK` or `FUNLOCK` but we can verify that they can be trusted.
`LockingTextWriter.this` uses unsafe cast from `FILE*` to `_iobuf*` but it can be trusted.
