### PR TITLE
Fix issue 12828: Fix return type of SimpleTimeZone.utcOffset.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26983,9 +26983,8 @@ public:
 
     /++
         Params:
-            utcOffset = This time zone's offset from UTC in minutes with west of
-                        UTC being negative (it is added to UTC to get the
-                        adjusted time).
+            utcOffset = This time zone's offset from UTC with west of UTC being
+                        negative (it is added to UTC to get the adjusted time).
             stdName   = The $(D stdName) for this time zone.
       +/
     this(Duration utcOffset, string stdName = "") immutable
@@ -26998,33 +26997,37 @@ public:
         this._utcOffset = utcOffset;
     }
 
-    /++ Ditto +/
-    this(int utcOffset, string stdName = "") immutable
+    /++
+        $(RED Deprecated. Please use the overload which takes a Duration. This
+              overload will be removed in December 2014).
+
+        Params:
+            utcOffset = This time zone's offset from UTC in minutes with west of
+                        negative (it is added to UTC to get the adjusted time).
+            stdName   = The $(D stdName) for this time zone.
+      +/
+    deprecated("Please use the overload which takes a Duration.") this(int utcOffset, string stdName = "") immutable
     {
         this(dur!"minutes"(utcOffset), stdName);
     }
 
     unittest
     {
-        foreach(stz; [new immutable SimpleTimeZone(dur!"hours"(-8), "PST"),
-                      new immutable SimpleTimeZone(-8 * 60, "PST")])
-
-        {
-            assert(stz.name == "");
-            assert(stz.stdName == "PST");
-            assert(stz.dstName == "");
-            assert(stz.utcOffset == -8 * 60);
-        }
+        auto stz = new immutable SimpleTimeZone(dur!"hours"(-8), "PST");
+        assert(stz.name == "");
+        assert(stz.stdName == "PST");
+        assert(stz.dstName == "");
+        assert(stz.utcOffset == dur!"hours"(-8));
     }
 
 
     /++
-        The number of minutes the offset from UTC is (negative is west of UTC,
+        The amount of time the offset from UTC is (negative is west of UTC,
         positive is east).
       +/
-    @property int utcOffset() @safe const pure nothrow
+    @property Duration utcOffset() @safe const pure nothrow
     {
-        return cast(int)_utcOffset.total!"minutes";
+        return _utcOffset;
     }
 
 
@@ -27222,9 +27225,9 @@ private:
         static void testSTZ(in string isoString, int expectedOffset, size_t line = __LINE__)
         {
             auto stz = SimpleTimeZone.fromISOString(isoString);
-            assert(stz.utcOffset == expectedOffset);
+            assert(stz.utcOffset == dur!"minutes"(expectedOffset));
 
-            auto result = SimpleTimeZone.toISOString(dur!"minutes"(stz.utcOffset));
+            auto result = SimpleTimeZone.toISOString(stz.utcOffset);
             assert(result == isoString);
         }
 


### PR DESCRIPTION
A longer explanation is in the bug report ( https://issues.dlang.org/show_bug.cgi?id=12828 ) but basically what it comes down to is that `SimpleTimeZone.utcOffset` should be a `Duration` like every other `utcOffset` is, particularly since we're not supposed to have any time values be naked integral values in druntime or Phobos. I got that right everywhere but in this case, where I guess I was being stupid when I  wrote it. I fixed the setter some time ago, but I haven't fixed the getter before now, because I was holding out on getting multiple alias thises in the hope that that could be used to make this change without immediately breaking any code, but it's looking like we're never going to get that feature, and depending on how it's implemented, it might not fix the problem anyway due to a conflict between `core.time.minutes` and `core.time.Duration.minutes`. So, I'm proposing that we simply make the change now and deal with the relatively small amount of code that it breaks rather than waiting for a feature that may never come and letting more code be written which has to deal with `utcOffset` being the wrong type. And while this _is_ unfortunately a breaking change, the fix is fortunately very simple. A line like

```
auto foo = stz.utcOffset;
```

becomes

```
auto foo = cast(int)stz.utcOffset.total!"minutes"();
```

and a line like

```
auto foo = minutes(stz.utcOffset);
```

becomes

```
auto foo = stz.utcOffset;
```

I'm not enthused about breaking code like this, but I am convinced that the amount of code broken will be relatively small and easily fixed, and I think that we're worse off if we leave this wart in Phobos. So, I think that this change is worth making.
