### PR TITLE
Remove workarounds for some compiler bugs which were fixed

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -9279,7 +9279,7 @@ public:
             allowOverflow = Whether the day should be allowed to overflow,
                             causing the month to increment.
       +/
-    /+ref Date+/ void add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
+    ref Date add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
         if(units == "years")
     {
         immutable newYear = _year + value;
@@ -9296,6 +9296,8 @@ public:
             else
                 _day = 28;
         }
+
+        return this;
     }
 
     ///
@@ -9408,6 +9410,12 @@ public:
             assert(date == Date(-1, 3, 1));
         }
 
+        {
+            auto date = Date(4, 2, 29);
+            date.add!"years"(-5).add!"years"(7);
+            assert(date == Date(6, 3, 1));
+        }
+
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         static assert(!__traits(compiles, cdate.add!"years"(7)));
@@ -9503,11 +9511,17 @@ public:
             date.add!"years"(-5, AllowDayOverflow.no);
             assert(date == Date(-1, 2, 28));
         }
+
+        {
+            auto date = Date(4, 2, 29);
+            date.add!"years"(-5, AllowDayOverflow.no).add!"years"(7, AllowDayOverflow.no);
+            assert(date == Date(6, 2, 28));
+        }
     }
 
 
     //Shares documentation with "years" version.
-    /+ref Date+/ void add(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
+    ref Date add(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
         if(units == "months")
     {
         auto years = months / 12;
@@ -9544,6 +9558,8 @@ public:
             else
                 _day = cast(ubyte)currMaxDay;
         }
+
+        return this;
     }
 
     //Test add!"months"() with AllowDayOverlow.yes
@@ -9774,6 +9790,12 @@ public:
             assert(date == Date(-3, 3, 3));
             date.add!"months"(85);
             assert(date == Date(4, 4, 3));
+        }
+
+        {
+            auto date = Date(-3, 3, 31);
+            date.add!"months"(85).add!"months"(-83);
+            assert(date == Date(-3, 6, 1));
         }
 
         const cdate = Date(1999, 7, 6);
@@ -10011,6 +10033,12 @@ public:
             date.add!"months"(85, AllowDayOverflow.no);
             assert(date == Date(4, 3, 28));
         }
+
+        {
+            auto date = Date(-3, 3, 31);
+            date.add!"months"(85, AllowDayOverflow.no).add!"months"(-83, AllowDayOverflow.no);
+            assert(date == Date(-3, 5, 30));
+        }
     }
 
 
@@ -10033,10 +10061,10 @@ public:
             allowOverflow = Whether the day should be allowed to overflow,
                             causing the month to increment.
       +/
-    /+ref Date+/ void roll(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
+    ref Date roll(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
         if(units == "years")
     {
-        add!"years"(value, allowOverflow);
+        return add!"years"(value, allowOverflow);
     }
 
     ///
@@ -10077,7 +10105,7 @@ public:
 
 
     //Shares documentation with "years" version.
-    /+ref Date+/ void roll(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
+    ref Date roll(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) pure nothrow
         if(units == "months")
     {
         months %= 12;
@@ -10109,6 +10137,8 @@ public:
             else
                 _day = cast(ubyte)currMaxDay;
         }
+
+        return this;
     }
 
     //Test roll!"months"() with AllowDayOverlow.yes
@@ -10371,6 +10401,12 @@ public:
             assert(date == Date(-4, 3, 2));
             date.roll!"months"(85);
             assert(date == Date(-4, 4, 2));
+        }
+
+        {
+            auto date = Date(-3, 3, 31);
+            date.roll!"months"(85).roll!"months"(-83);
+            assert(date == Date(-3, 6, 1));
         }
 
         const cdate = Date(1999, 7, 6);
@@ -10640,6 +10676,12 @@ public:
             date.roll!"months"(85, AllowDayOverflow.no);
             assert(date == Date(-4, 3, 29));
         }
+
+        {
+            auto date = Date(-3, 3, 31);
+            date.roll!"months"(85, AllowDayOverflow.no).roll!"months"(-83, AllowDayOverflow.no);
+            assert(date == Date(-3, 5, 30));
+        }
     }
 
 
@@ -10657,7 +10699,7 @@ public:
             units = The units to add. Must be $(D "days").
             days  = The number of days to add to this $(LREF Date).
       +/
-    /+ref Date+/ void roll(string units)(long days) pure nothrow
+    ref Date roll(string units)(long days) pure nothrow
         if(units == "days")
     {
         immutable limit = maxDay(_year, _month);
@@ -10673,6 +10715,7 @@ public:
             newDay -= limit;
 
         _day = cast(ubyte)newDay;
+        return this;
     }
 
     ///
@@ -10866,6 +10909,12 @@ public:
             assert(date == Date(0, 7, 5));
         }
 
+        {
+            auto date = Date(0, 7, 6);
+            date.roll!"days"(-365).roll!"days"(362).roll!"days"(-12).roll!"days"(730);
+            assert(date == Date(0, 7, 8));
+        }
+
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         static assert(!__traits(compiles, cdate.roll!"days"(12)));
@@ -10899,7 +10948,7 @@ public:
         else static if(is(Unqual!D == TickDuration))
             immutable days = convert!("hnsecs", "days")(duration.hnsecs);
 
-        mixin(format("return retval.addDays(%sdays);", op));
+        mixin(format("return retval._addDays(%sdays);", op));
     }
 
     unittest
@@ -10985,7 +11034,7 @@ public:
         Params:
             duration = The duration to add to or subtract from this $(LREF Date).
       +/
-    /+ref+/ Date opOpAssign(string op, D)(in D duration) pure nothrow
+    ref Date opOpAssign(string op, D)(in D duration) pure nothrow
         if((op == "+" || op == "-") &&
            (is(Unqual!D == Duration) ||
             is(Unqual!D == TickDuration)))
@@ -10995,7 +11044,7 @@ public:
         else static if(is(Unqual!D == TickDuration))
             immutable days = convert!("hnsecs", "days")(duration.hnsecs);
 
-        mixin(format("return addDays(%sdays);", op));
+        mixin(format("return _addDays(%sdays);", op));
     }
 
     unittest
@@ -11035,6 +11084,12 @@ public:
         assert(Date(1999, 7, 6) - dur!"usecs"(86_400_000_000) == Date(1999, 7, 5));
         assert(Date(1999, 7, 6) - dur!"hnsecs"(-864_000_000_000) == Date(1999, 7, 7));
         assert(Date(1999, 7, 6) - dur!"hnsecs"(864_000_000_000) == Date(1999, 7, 5));
+
+        {
+            auto date = Date(0, 1, 31);
+            date += dur!"days"(507) += dur!"days"(-2);
+            assert(date == Date(1, 6, 19));
+        }
 
         auto duration = dur!"days"(12);
         auto date = Date(1999, 7, 6);
@@ -12559,16 +12614,15 @@ private:
         decrease) to the month would cause it to overflow (or underflow) the
         current year.
 
-        $(D addDays(numDays)) is effectively equivalent to
+        $(D _addDays(numDays)) is effectively equivalent to
         $(D date.dayOfGregorianCal = date.dayOfGregorianCal + days).
 
         Params:
             days = The number of days to add to this Date.
       +/
-    ref Date addDays(long days) pure nothrow
+    ref Date _addDays(long days) pure nothrow
     {
         dayOfGregorianCal = cast(int)(dayOfGregorianCal + days);
-
         return this;
     }
 
@@ -12577,157 +12631,157 @@ private:
         //Test A.D.
         {
             auto date = Date(1999, 2, 28);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(1999, 3, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(1999, 2, 28));
         }
 
         {
             auto date = Date(2000, 2, 28);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(2000, 2, 29));
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(2000, 3, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(2000, 2, 29));
         }
 
         {
             auto date = Date(1999, 6, 30);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(1999, 7, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(1999, 6, 30));
         }
 
         {
             auto date = Date(1999, 7, 31);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(1999, 8, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(1999, 7, 31));
         }
 
         {
             auto date = Date(1999, 1, 1);
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(1998, 12, 31));
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(1999, 1, 1));
         }
 
         {
             auto date = Date(1999, 7, 6);
-            date.addDays(9);
+            date._addDays(9);
             assert(date == Date(1999, 7, 15));
-            date.addDays(-11);
+            date._addDays(-11);
             assert(date == Date(1999, 7, 4));
-            date.addDays(30);
+            date._addDays(30);
             assert(date == Date(1999, 8, 3));
-            date.addDays(-3);
+            date._addDays(-3);
             assert(date == Date(1999, 7, 31));
         }
 
         {
             auto date = Date(1999, 7, 6);
-            date.addDays(365);
+            date._addDays(365);
             assert(date == Date(2000, 7, 5));
-            date.addDays(-365);
+            date._addDays(-365);
             assert(date == Date(1999, 7, 6));
-            date.addDays(366);
+            date._addDays(366);
             assert(date == Date(2000, 7, 6));
-            date.addDays(730);
+            date._addDays(730);
             assert(date == Date(2002, 7, 6));
-            date.addDays(-1096);
+            date._addDays(-1096);
             assert(date == Date(1999, 7, 6));
         }
 
         //Test B.C.
         {
             auto date = Date(-1999, 2, 28);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-1999, 3, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(-1999, 2, 28));
         }
 
         {
             auto date = Date(-2000, 2, 28);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-2000, 2, 29));
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-2000, 3, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(-2000, 2, 29));
         }
 
         {
             auto date = Date(-1999, 6, 30);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-1999, 7, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(-1999, 6, 30));
         }
 
         {
             auto date = Date(-1999, 7, 31);
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-1999, 8, 1));
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(-1999, 7, 31));
         }
 
         {
             auto date = Date(-1999, 1, 1);
-            date.addDays(-1);
+            date._addDays(-1);
             assert(date == Date(-2000, 12, 31));
-            date.addDays(1);
+            date._addDays(1);
             assert(date == Date(-1999, 1, 1));
         }
 
         {
             auto date = Date(-1999, 7, 6);
-            date.addDays(9);
+            date._addDays(9);
             assert(date == Date(-1999, 7, 15));
-            date.addDays(-11);
+            date._addDays(-11);
             assert(date == Date(-1999, 7, 4));
-            date.addDays(30);
+            date._addDays(30);
             assert(date == Date(-1999, 8, 3));
-            date.addDays(-3);
+            date._addDays(-3);
         }
 
         {
             auto date = Date(-1999, 7, 6);
-            date.addDays(365);
+            date._addDays(365);
             assert(date == Date(-1998, 7, 6));
-            date.addDays(-365);
+            date._addDays(-365);
             assert(date == Date(-1999, 7, 6));
-            date.addDays(366);
+            date._addDays(366);
             assert(date == Date(-1998, 7, 7));
-            date.addDays(730);
+            date._addDays(730);
             assert(date == Date(-1996, 7, 6));
-            date.addDays(-1096);
+            date._addDays(-1096);
             assert(date == Date(-1999, 7, 6));
         }
 
         //Test Both
         {
             auto date = Date(1, 7, 6);
-            date.addDays(-365);
+            date._addDays(-365);
             assert(date == Date(0, 7, 6));
-            date.addDays(365);
+            date._addDays(365);
             assert(date == Date(1, 7, 6));
-            date.addDays(-731);
+            date._addDays(-731);
             assert(date == Date(-1, 7, 6));
-            date.addDays(730);
+            date._addDays(730);
             assert(date == Date(1, 7, 5));
         }
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(!__traits(compiles, cdate.addDays(12)));
-        static assert(!__traits(compiles, idate.addDays(12)));
+        static assert(!__traits(compiles, cdate._addDays(12)));
+        static assert(!__traits(compiles, idate._addDays(12)));
     }
 
 
@@ -16735,7 +16789,7 @@ private:
             --days;
         }
 
-        _date.addDays(days);
+        _date._addDays(days);
 
         immutable newHours = splitUnitsFromHNSecs!"hours"(hnsecs);
         immutable newMinutes = splitUnitsFromHNSecs!"minutes"(hnsecs);


### PR DESCRIPTION
This fixes some issues in std.datetime which were forced due to compiler bugs which have now been fixed - namely you couldn't get the number of variadic arguments at compile time previously, and a number of functions in std.datetime were unable to return by ref (though I don't recall at the moment which compiler bugs prevented it).
