### PR TITLE
Make std.stdio.LockingTextWriter.put and lockingTextWriter @safe

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2129,11 +2129,11 @@ $(D Range) that locks the file and allows fast writing to it.
             version(DIGITAL_MARS_STDIO) alias WCTYPE = int;
             version(MICROSOFT_STDIO)    alias WCTYPE = int;
             else                        alias WCTYPE = wchar_t;
-            auto trustedFPUTC(int ch, _iobuf* h) @trusted
+            static auto trustedFPUTC(int ch, _iobuf* h) @trusted
             {
                 return FPUTC(ch, h);
             }
-            auto trustedFPUTWC(WCTYPE ch, _iobuf* h) @trusted
+            static auto trustedFPUTWC(WCTYPE ch, _iobuf* h) @trusted
             {
                 return FPUTWC(ch, h);
             }


### PR DESCRIPTION
We can mark `std.stdio.lockingTextWriter` as safe because the constructor of `LockingTextWriter` is safe.

`LockingTextWriter.put` for ranges uses `core.stdc.stdio.fwrite` but we can verify it can be trusted.
`LockingTextWriter.put` for char type uses `FPUTC` and `FPUTWC` but we can verify they can be trusted.
I define nested trusted functions for them.
