### PR TITLE
Fix deprecation warnings in std.datetime.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27217,11 +27217,9 @@ private:
         immutable absOffset = abs(utcOffset);
         enforceEx!DateTimeException(absOffset < dur!"minutes"(1440),
                                     "Offset from UTC must be within range (-24:00 - 24:00).");
-
         if(utcOffset < Duration.zero)
-            return format("-%02d:%02d", absOffset.hours, absOffset.minutes);
-
-        return format("+%02d:%02d", absOffset.hours, absOffset.minutes);
+            return format("-%02d:%02d", absOffset.getOnly!"hours"(), absOffset.getOnly!"minutes"());
+        return format("+%02d:%02d", absOffset.getOnly!"hours"(), absOffset.getOnly!"minutes"());
     }
 
     unittest


### PR DESCRIPTION
With the deprecation of the individual unit getters on `Duration`, these lines need to be changed in 
std.datetime to get rid of the deprecation warnings.

https://issues.dlang.org/show_bug.cgi?id=12846
