### PR TITLE
Fix #12806

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5273,7 +5273,8 @@ unittest
 }
 
 /**
- * Detect whether type $(D T) is an array.
+ * Detect whether type $(D T) is an array (static or dynamic; for associative
+ *  arrays see $(LREF isAssociativeArray)).
  */
 enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 


### PR DESCRIPTION
Documentation improvement for `std.traits.isArray` to clarify whether associative arrays are handled.

Fixes #12806
