### PR TITLE
Make Rebindable @trusted.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1075,29 +1075,29 @@ template Rebindable(T) if (is(T == class) || is(T == interface) || isDynamicArra
                 T original;
                 U stripped;
             }
-            void opAssign(T another) pure nothrow
+            void opAssign(T another) @trusted pure nothrow
             {
                 stripped = cast(U) another;
             }
-            void opAssign(Rebindable another) pure nothrow
+            void opAssign(Rebindable another) @trusted pure nothrow
             {
                 stripped = another.stripped;
             }
             static if (is(T == const U))
             {
                 // safely assign immutable to const
-                void opAssign(Rebindable!(immutable U) another) pure nothrow
+                void opAssign(Rebindable!(immutable U) another) @trusted pure nothrow
                 {
                     stripped = another.stripped;
                 }
             }
 
-            this(T initializer) pure nothrow
+            this(T initializer) @safe pure nothrow
             {
                 opAssign(initializer);
             }
 
-            @property ref inout(T) get() inout pure nothrow
+            @property ref inout(T) get() @trusted inout pure nothrow
             {
                 return original;
             }


### PR DESCRIPTION
Maybe someone can come up with a reason why this isn't valid, but as far as I can tell, there's nothing unsafe going on here (particularly since `Rebindable` can't hold structs and thus have to deal with overloaded `opAssign`s and whatnot), and it's proving to be very annoying to add `@safe` to std.datetime with `Rebindable` being `@system`. So, if possible, I'd very much like to make this change.
