### PR TITLE
Fix Issue 12921 - Module std.getopt does not respect property syntax

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -585,7 +585,7 @@ void handleOption(R)(string option, R receiver, ref string[] args,
                 }
                 else
                 {
-                    foreach (elem; val.splitter(arraySep).map!(a => to!E(a)))
+                    foreach (elem; val.splitter(arraySep).map!(a => to!E(a))())
                         *receiver ~= elem;
                 }
             }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12921
