### PR TITLE
Replace use of FracSec in SysTime's API with Duration. 

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26298,10 +26298,11 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
 
         version(Posix)
         {
-            version(FreeBSD) enum utcZone = "Etc/UTC";
-            version(linux)   enum utcZone = "UTC";
-            version(OSX)     enum utcZone = "UTC";
-            version(Android) enum utcZone = "UTC";
+            version(FreeBSD)      enum utcZone = "Etc/UTC";
+            else version(linux)   enum utcZone = "UTC";
+            else version(OSX)     enum utcZone = "UTC";
+            else version(Android) enum utcZone = "UTC";
+            else static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");
 
             auto tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),
                         testTZ("America/New_York", "EST", "EDT", dur!"hours"(-5), dur!"hours"(1)),


### PR DESCRIPTION
Well, Steven, here you go...

FracSec is overly verbose and based on the recent discussions with
regards to Duration.get and Duration.split, it should be given the boot.
The only non-deprecated place which uses it in Phobos is SysTime, so
this deprecates the functions that use it, and replaces it with ones
that expect a Duration of less than one second.

This means replacing a SysTime constructor and SysTime's fracSec
property. fracSecs is introduced to replace fracSec. It uses a Duration
or takes a template argument for the units and then uses an int
(essentially then creating an overload which is a shortcut for calling
Duration.total or creating a Duration, depending on whether its the
getter or the setter).

So,

```
auto st = SysTime(DateTime(1982, 1, 4, 20, 59, 22), FracSec.from!"hnsecs"(1234567));
assert(st.fracSec == FracSec.from!"msecs"(123));
assert(st.fracSec == FracSec.from!"usecs"(123456));
assert(st.fracSec == FracSec.from!"hnsecs"(1234567));
assert(st.fracSec.msecs == 123);
assert(st.fracSec.usecs == 123456);
assert(st.fracSec.hnsecs == 1234567);
 st.fracSec = FracSec.from!"msecs"(572);
 st.fracSec = FracSec.from!"usecs"(572);
 st.fracSec = FracSec.from!"hnsecs"(572);
```

becomes something more like

```
auto st = SysTime(DateTime(1982, 1, 4, 20, 59, 22), hnsecs(1234567));
assert(st.fracSecs == hnsecs(1234567));
assert(st.fracSecs.total!"msecs" == 123);
assert(st.fracSecs.total!"usecs" == 123456);
assert(st.fracSecs.total!"hnsecs" == 1234567);
assert(st.fracSecs!"msecs" == 123);
assert(st.fracSecs!"usecs" == 123456);
assert(st.fracSecs!"hnsecs" == 1234567);
st.fracSecs = msecs(572);
st.fracSecs!"msecs" = 572;
st.fracSecs = usecs(572);
st.fracSecs!"usecs" = 572;
st.fracSecs = hnsecs(572);
st.fracSecs!"hnsecs" = 572;
```

which will hopefully be less confusing (particularly since `FracSec`'s getters all do `total`, whereas `Duration`'s now deprecated getters did `split`), and it will definitely be less verbose. Once this has been accepted and merged in, nothing undeprecated will be using `core.time.FracSec`, and so I'll deprecate `FracSec`, which will make it so that we have one fewer types in the date-time stuff to worry about. 

Hopefully, it's not too confusing for the new name to be the old one with an `s` tacked on, but it avoids having to come up with a totally different name, when the original was already good (and having an `s` on the end is probably more consistent anyway), and the types are different, so the worst that happens is that you get a compilation error. And once `fracSec` and `FracSec` or gone instead of just deprecated, that problem will go away.

The first commit is the really important one, since that's where `fracSec` is replaced with `fracSecs`. Most of the rest is just fixing up unit tests so that the use `Duration` instead of `FracSec`. Unfortunately, however, that means that it touches almost every single unit test for `SysTime` that uses fractional seconds. The changes to the tests are straightforward enough, but there's a lot of them. I split up the commits, but I probably still didn't split them up enough for them all to show up in the diff on github. Fortunately, it's likely the case that user code deals explicitly with fractional seconds a lot less frequently than `SysTime`'s unit tests do (since a `SysTime` is probably most frequently gotten from `Clock.getTime` or the file time functions in std.file), so I don't think that the amount of code breakage here is representative of how frequently users will have to change their code (and of course, they'll be getting deprecation messages rather than immediate breakage).
