### PR TITLE
[trivial] ARM fixes up to 2.065

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2777,7 +2777,7 @@ unittest
 //Tests for the double implementation
 unittest
 {
-    import core.stdc.stdlib;
+    import core.stdc.stdlib, std.math;
     static if(real.mant_dig == 53)
     {
         //Should be parsed exactly: 53 bit mantissa


### PR DESCRIPTION
A unittest needs a new import in 2.065.

ping @ibuclaw
