### PR TITLE
Fix "make install" on Linux.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -354,7 +354,7 @@ clean :
 zip :
 	zip $(ZIPFILE) $(MAKEFILE) $(ALL_D_FILES) $(ALL_C_FILES) win32.mak win64.mak
 
-install2 : release
+install2 : all
 	mkdir -p $(INSTALL_DIR)/lib
 	cp $(LIB) $(INSTALL_DIR)/lib/
 ifneq (,$(findstring $(OS),linux))


### PR DESCRIPTION
The "install" target requires the static library as well as
the shared onject version of Phobos. This fixes the target
dependencies to reflect that.
