### PR TITLE
Issue 13000 - Casts should be removed to utilize features of inout

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2071,9 +2071,9 @@ private:
             return set.length - FD_SET_OFFSET;
         }
 
-        final socket_t[] fds() inout @property
+        final inout(socket_t)[] fds() inout @property
         {
-            return cast(socket_t[])set[FD_SET_OFFSET..FD_SET_OFFSET+count];
+            return cast(inout(socket_t)[])set[FD_SET_OFFSET..FD_SET_OFFSET+count];
         }
     }
     else

--- a/std/variant.d
+++ b/std/variant.d
@@ -657,7 +657,7 @@ public:
      * assert(a == 6);
      * ----
      */
-    @property T* peek(T)() inout
+    @property inout(T)* peek(T)() inout
     {
         static if (!is(T == void))
             static assert(allowed!(T), "Cannot store a " ~ T.stringof
@@ -665,9 +665,9 @@ public:
         if (type != typeid(T))
             return null;
         static if (T.sizeof <= size)
-            return cast(T*)&store;
+            return cast(inout T*)&store;
         else
-            return *cast(T**)&store;
+            return *cast(inout T**)&store;
     }
 
     /**


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13000

Apply `inout` on function return type.
