### PR TITLE
 [REG2.066a] Issue 13002: Add ddoc directory rule to posix.mak for std.container.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -395,6 +395,9 @@ $(DOC_OUTPUT_DIR)/std_c_linux_%.html : std/c/linux/%.d $(STDDOC)
 $(DOC_OUTPUT_DIR)/std_c_windows_%.html : std/c/windows/%.d $(STDDOC)
 	$(DDOC) -Df$@ $<
 
+$(DOC_OUTPUT_DIR)/std_container_%.html : std/container/%.d $(STDDOC)
+	$(DDOC) project.ddoc $(STDDOC) -Df$@ $<
+
 $(DOC_OUTPUT_DIR)/std_net_%.html : std/net/%.d $(STDDOC)
 	$(DDOC) project.ddoc $(STDDOC) -Df$@ $<
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13002
