### PR TITLE
SList improvements

### DIFF
--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -517,13 +517,26 @@ unittest
 
 unittest
 {
+    auto a = SList!int();
+    auto b = SList!int();
+    auto c = a ~ b[];
+    assert(c.empty);
+}
+
+unittest
+{
     auto a = SList!int(1, 2, 3);
     auto b = SList!int(4, 5, 6);
-    // @@@BUG@@@ in compiler
-    //auto c = a ~ b;
-    auto d = [ 4, 5, 6 ];
-    auto e = a ~ d;
-    assert(e == SList!int(1, 2, 3, 4, 5, 6));
+    auto c = a ~ b[];
+    assert(c == SList!int(1, 2, 3, 4, 5, 6));
+}
+
+unittest
+{
+    auto a = SList!int(1, 2, 3);
+    auto b = [4, 5, 6];
+    auto c = a ~ b;
+    assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
 unittest


### PR DESCRIPTION
I noticed that concatenation of two `SList`s wasn't working because `SList` itself missed `popFront` required by InputRange. So, simple alias fixed this.

Also someone wrote documentation comment about `opBinaryRight`, but forgot to add actual method. I fixed that.
