### PR TITLE
Issue 13013 - Converted real to double in std.json.JSONValue

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -58,7 +58,7 @@ struct JSONValue
         string                          str;
         long                            integer;
         ulong                           uinteger;
-        real                            floating;
+        double                          floating;
         JSONValue[string]               object;
         JSONValue[]                     array;
     }
@@ -161,14 +161,14 @@ struct JSONValue
 
     /// Value getter/setter for $(D JSON_TYPE.FLOAT).
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.FLOAT).
-    @property inout(real) floating() inout
+    @property inout(double) floating() inout
     {
         enforceEx!JSONException(type == JSON_TYPE.FLOAT,
                                 "JSONValue is not a floating type");
         return store.floating;
     }
     /// ditto
-    @property real floating(real v)
+    @property double floating(double v)
     {
         assign(v);
         return store.floating;
@@ -299,7 +299,7 @@ struct JSONValue
      * be copied.
      * Otherwise, $(D arg) must be implicitly convertible to one of the
      * following types: $(D typeof(null)), $(D string), $(D ulong),
-     * $(D long), $(D real), an associative array $(D V[K]) for any $(D V)
+     * $(D long), $(D double), an associative array $(D V[K]) for any $(D V)
      * and $(D K) i.e. a JSON object, any array or $(D bool). The type will
      * be set accordingly.
     */
@@ -644,7 +644,7 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1) if(isInputRange!T)
                 if(isFloat)
                 {
                     value.type_tag = JSON_TYPE.FLOAT;
-                    value.store.floating = parse!real(data);
+                    value.store.floating = parse!double(data);
                 }
                 else
                 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13013

1) When compiling with -m64 on Windows (when using the MSVC linker), the real type is unsupported. std.json unittests fail with the version of std.json in master because of this.
2) JSON only uses 64-bit floating point

=> Changed real to double, as it is more functional and no less correct.

One concern: ABI compatibility.

Tested this on both Windows and OSX.
