### PR TITLE
Mark std.file.read as @trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -179,7 +179,7 @@ Throws: $(D FileException) on error.
  */
 void[] read(in char[] name, size_t upTo = size_t.max) @safe
 {
-    static trustedRef(ref stat_t buf) @trusted
+    static trustedRef(T)(ref T buf) @trusted
     {
         return &buf;
     }


### PR DESCRIPTION
`std.file.read` contains the following unsafe operations, but we can verify that they can be trusted.

In Windows systems:
- Use of unsafe functions: `CreateFileW`, `CloseHandle`, `GetFileSize`, and `ReadFile`
- Taking address of a local variable (`numread`)

In Posix systems:
- Use of unsafe functions: `core.sys.posix.fcntl.open`, `core.sys.posix.sys.stat.fstat`, `core.sys.posix.unistd.read`, and `core.memory.GC.realloc`
- Taking address of a local variable (`statbuf`)
- Use of pointer arithmetic
- Use of pointer slicing

Question: In Windows systems, `read` checks the return value of `ReadFile(...)` by comparing with `1`. However, the [document of `ReadFile`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365467%28v=vs.85%29.aspx) says that it returns nonzero, not `1`.
Is there a reason to use `ReadFile(...) == 1` instead of `ReadFile(...) != 0` or should it be fixed?
