### PR TITLE
Issue 8370 - Fix deprecated message during Linux Phobos build.

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -341,7 +341,8 @@ class MmFile
             else
             {
                 fd = -1;
-                flags |= MAP_ANON;
+		version(linux) import core.sys.linux.sys.mman : MAP_ANON;                
+		flags |= MAP_ANON;
             }
             this.size = size;
             size_t initial_map = (window && 2*window<size)


### PR DESCRIPTION
Fix deprecated message during Linux Phobos build.

This change fixes Linux builds only.  Other Posix based OS's will still use the deprecated alias from the Posix module.  (This is the same behavior as the garbage collector module.)
