### PR TITLE
Enhancement request 13022: add `std.complex.abs2`

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -703,6 +703,41 @@ unittest
 }
 
 
+/++
+   Calculates the squared modulus of a complex number.
+   For genericity, if called on a real number, $(D sqAbs) returns its square.
++/
+T sqAbs(T)(Complex!T z) @safe pure nothrow @nogc
+{
+	return z.re*z.re + z.im*z.im;
+}
+
+unittest
+{
+	assert (sqAbs(complex(0.0)) == 0.0);
+	assert (sqAbs(complex(1.0)) == 1.0);
+	assert (sqAbs(complex(0.0, 1.0)) == 1.0);
+	assert (approxEqual(sqAbs(complex(1.0L, -2.0L)), 5.0L));
+	assert (approxEqual(sqAbs(complex(-3.0L, 1.0L)), 10.0L));
+	assert (approxEqual(sqAbs(complex(1.0f,-1.0f)), 2.0f));
+}
+
+/// ditto
+T sqAbs(T)(T x) @safe pure nothrow @nogc
+	if (isFloatingPoint!T)
+{
+	return x*x;
+}
+
+unittest
+{
+	assert (sqAbs(0.0) == 0.0);
+	assert (sqAbs(-1.0) == 1.0);
+	assert (approxEqual(sqAbs(-3.0L), 9.0L));
+	assert (approxEqual(sqAbs(-5.0f), 25.0f));
+}
+
+
 /** Calculates the argument (or phase) of a complex number. */
 T arg(T)(Complex!T z) @safe pure nothrow @nogc
 {


### PR DESCRIPTION
Add `std.complex.abs2`, which returns the squared modulus of a 
`Complex` or real number.

Rationale:
- It is common to need the squared modulus of a complex number,
  and using `abs(z)*abs(z)` would be inefficient due to the
  computation of the square root. Moreover, `z*conj(z)` returns a 
  complex number, usually with nonzero imaginary part due to 
  rounding, and cannot be used in a generic algorithm that can work
  with real numbers as well.
- The name `abs2` has been chosen for consistency with `abs`, and
  for being mathematically more correct than `norm`, used by C++ STL
  for the equivalent function.
- For genericity, the function `abs2` is also declared for real
  floating point numbers, in which case it simply returns its
  square.

UPDATE: use `sqAbs` instead of `abs2`.

https://issues.dlang.org/show_bug.cgi?id=13022
