### PR TITLE
Mark std.file.rename as @trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -396,7 +396,7 @@ version(Posix) private void writeImpl(in char[] name,
  * If the target file exists, it is overwritten.
  * Throws: $(D FileException) on error.
  */
-void rename(in char[] from, in char[] to)
+void rename(in char[] from, in char[] to) @trusted
 {
     version(Windows)
     {


### PR DESCRIPTION
It contains an unsafe function `MoveFileExW` (on Windows) or `core.stdc.stdio.rename` (on Posix) but we can verify that it can be trusted.
