### PR TITLE
Mark std.file.remove as @trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -426,7 +426,7 @@ unittest
 Delete file $(D name).
 Throws: $(D FileException) on error.
  */
-void remove(in char[] name)
+void remove(in char[] name) @trusted
 {
     version(Windows)
     {


### PR DESCRIPTION
It contains an unsafe function `core.sys.windows.windows.DeleteFileW` (on Windows) or `core.stdc.stdio.remove` (on Posix) but we can verify that it can be trusted.
