### PR TITLE
Mark std.file.write and append as trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -312,7 +312,7 @@ void main()
 }
 ----
  */
-void write(in char[] name, const void[] buffer)
+void write(in char[] name, const void[] buffer) @trusted
 {
     version(Windows)
     {
@@ -325,7 +325,7 @@ void write(in char[] name, const void[] buffer)
         cenforce(h != INVALID_HANDLE_VALUE, name);
         scope(exit) cenforce(CloseHandle(h), name);
         DWORD numwritten;
-        cenforce(WriteFile(h, buffer.ptr, to!DWORD(buffer.length), &numwritten, null) == 1
+        cenforce(WriteFile(h, buffer.ptr, to!DWORD(buffer.length), &numwritten, null) != 0
                 && buffer.length == numwritten,
                 name);
     }
@@ -351,7 +351,7 @@ void main()
 }
 ----
  */
-void append(in char[] name, in void[] buffer)
+void append(in char[] name, in void[] buffer) @trusted
 {
     version(Windows)
     {
@@ -365,7 +365,7 @@ void append(in char[] name, in void[] buffer)
         scope(exit) cenforce(CloseHandle(h), name);
         DWORD numwritten;
         cenforce(SetFilePointer(h, 0, null, FILE_END) != INVALID_SET_FILE_POINTER
-                && WriteFile(h,buffer.ptr,to!DWORD(buffer.length),&numwritten,null) == 1
+                && WriteFile(h,buffer.ptr,to!DWORD(buffer.length),&numwritten,null) != 0
                 && buffer.length == numwritten,
                 name);
     }


### PR DESCRIPTION
On Posix systems, they are safe because `writeImpl` is safe.
On Windows systems, they include unsafe functions `CreateFileW`, `CloseHandle`, `SetFilePointer` (only `append`) and `WriteFile` but we can verify they can be trusted.

I also change expressions like `WriteFile(...) == 1` to `WriteFile(...) != 0` because the [document of `WriteFile`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365747%28v=vs.85%29.aspx) says it returns nonzero, not one.
I think comparing to one is already safe but it is clearer to be safe to follow the document.
