### PR TITLE
Mark std.stdio.lockingTextWriter.this as safe

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2212,7 +2212,7 @@ $(D Range) that locks the file and allows fast writing to it.
 
 See $(LREF byChunk) for an example.
 */
-    auto lockingTextWriter()
+    auto lockingTextWriter() @safe
     {
         return LockingTextWriter(this);
     }


### PR DESCRIPTION
It is safe because a constructor of `LockingTextWriter` is safe.
