### PR TITLE
Make std.stdio.File.LockingTextWriter.put safe

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2213,9 +2213,11 @@ $(D Range) that locks the file and allows fast writing to it.
         int orientation_;
     public:
         deprecated("accessing fps/handle/orientation directly can break LockingTextWriter integrity")
-        alias fps = fps_;
-        deprecated alias handle = handle_;
-        deprecated alias orientation = orientation_;
+        {
+            alias fps = fps_;
+            alias handle = handle_;
+            alias orientation = orientation_;
+        }
 
         this(ref File f) @trusted
         {


### PR DESCRIPTION
This is a preliminary for the second attempt for #2225.
The objective of this pull request is to find the reason why #2225 fails on Windows systems.
~~Please do not merge this pull request because it may contain stub code.~~

Edit: It is OK to merge!
