### PR TITLE
Fix issue #13100 - std.process.setCLOEXEC() throws on invalid file descriptor

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -719,11 +719,7 @@ private void setCLOEXEC(int fd, bool on)
         else    flags &= ~(cast(typeof(flags)) FD_CLOEXEC);
         flags = fcntl(fd, F_SETFD, flags);
     }
-    if (flags == -1)
-    {
-        throw new StdioException("Failed to "~(on ? "" : "un")
-                                 ~"set close-on-exec flag on file descriptor");
-    }
+    assert (flags != -1 || .errno == EBADF);
 }
 
 unittest // Command line arguments in spawnProcess().


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13100

There are two cases in which the `fcntl()` calls may fail:

  1) the file descriptor is invalid, in which case `errno == EBADF`,
  2) they receive invalid arguments, in which case `errno == EINVAL`.

We just want to ignore the error in the former case, as evidenced by the bug report, and the latter means that we have an error in `std.process`, which is best handled by an assertion. (Note that it was never possible to catch the exception anyway, since it was thrown in the child process.)
