### PR TITLE
Deprecate std.c.string and move its contents to druntime

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -16,7 +16,7 @@ import core.memory, core.bitop;
 import std.algorithm, std.ascii, std.conv, std.exception, std.functional,
        std.range, std.string, std.traits, std.typecons, std.typetuple,
        std.uni, std.utf;
-import std.c.string : memcpy;
+import core.stdc.string : memcpy;
 version(unittest) import core.exception, std.stdio;
 
 /**

--- a/std/c/string.d
+++ b/std/c/string.d
@@ -9,26 +9,5 @@
 
 module std.c.string;
 
+deprecated("Please import core.stdc.string instead.")
 public import core.stdc.string;
-
-extern (C):
-
-version (Windows)
-{
-    int memicmp(in char* s1, in char* s2, size_t n);
-}
-
-version (linux)
-{
-    const(char)* strerror_r(int errnum, char* buf, size_t buflen);
-}
-
-version (OSX)
-{
-    int strerror_r(int errnum, char* buf, size_t buflen);
-}
-
-version (FreeBSD)
-{
-    int strerror_r(int errnum, char* buf, size_t buflen);
-}

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -143,7 +143,7 @@ else version(Posix)
 
 version(unittest)
 {
-    import std.c.string;
+    import core.stdc.string;
     import std.stdio;
 }
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -44,8 +44,8 @@
  +/
 module std.exception;
 
-import std.array, std.c.string, std.conv, std.range, std.string, std.traits;
-import core.exception, core.stdc.errno;
+import std.array, std.conv, std.range, std.string, std.traits;
+import core.exception, core.stdc.errno, core.stdc.string;
 
 /++
     Asserts that the given expression does $(I not) throw the given type
@@ -1379,11 +1379,11 @@ class ErrnoException : Exception
         version (linux)
         {
             char[1024] buf = void;
-            auto s = std.c.string.strerror_r(errno, buf.ptr, buf.length);
+            auto s = core.stdc.string.strerror_r(errno, buf.ptr, buf.length);
         }
         else
         {
-            auto s = std.c.string.strerror(errno);
+            auto s = core.stdc.string.strerror(errno);
         }
         super(msg~" ("~to!string(s)~")", file, line);
     }

--- a/std/process.d
+++ b/std/process.d
@@ -2075,16 +2075,16 @@ class ProcessException : Exception
                                          size_t line = __LINE__)
     {
         import core.stdc.errno;
-        import std.c.string;
+        import core.stdc.string;
         version (linux)
         {
             char[1024] buf;
             auto errnoMsg = to!string(
-                std.c.string.strerror_r(errno, buf.ptr, buf.length));
+                core.stdc.string.strerror_r(errno, buf.ptr, buf.length));
         }
         else
         {
-            auto errnoMsg = to!string(std.c.string.strerror(errno));
+            auto errnoMsg = to!string(core.stdc.string.strerror(errno));
         }
         auto msg = customMsg.empty ? errnoMsg
                                    : customMsg ~ " (" ~ errnoMsg ~ ')';
@@ -2962,7 +2962,7 @@ import std.c.stdlib;
 import core.stdc.errno;
 import core.thread;
 import std.c.process;
-import std.c.string;
+import core.stdc.string;
 
 version (Windows)
 {

--- a/std/socket.d
+++ b/std/socket.d
@@ -45,7 +45,7 @@
 
 module std.socket;
 
-import core.stdc.stdint, std.string, std.c.string, std.c.stdlib, std.conv;
+import core.stdc.stdint, core.stdc.string, std.string, std.c.stdlib, std.conv;
 
 import core.stdc.config;
 import core.time : dur, Duration;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3365,16 +3365,16 @@ Initialize with a message and an error code. */
         errno = e;
         version (Posix)
         {
-            import std.c.string : strerror_r;
+            import core.stdc.string : strerror_r;
 
             char[256] buf = void;
             version (linux)
             {
-                auto s = std.c.string.strerror_r(errno, buf.ptr, buf.length);
+                auto s = core.stdc.string.strerror_r(errno, buf.ptr, buf.length);
             }
             else
             {
-                std.c.string.strerror_r(errno, buf.ptr, buf.length);
+                core.stdc.string.strerror_r(errno, buf.ptr, buf.length);
                 auto s = buf.ptr;
             }
         }

--- a/std/syserror.d
+++ b/std/syserror.d
@@ -16,7 +16,7 @@ deprecated("Please use std.windows.syserror.sysErrorString instead")
 class SysError
 {
     private import std.c.stdio;
-    private import std.c.string;
+    private import core.stdc.string;
     private import std.string;
 
     static string msg(uint errcode)

--- a/std/variant.d
+++ b/std/variant.d
@@ -65,7 +65,7 @@
  */
 module std.variant;
 
-import std.c.string, std.conv, std.exception, std.traits, std.typecons,
+import core.stdc.string, std.conv, std.exception, std.traits, std.typecons,
     std.typetuple;
 
 @trusted:


### PR DESCRIPTION
When I tried to modify this file in another pull, I was told it shouldn't be used anymore, so I'm moving its contents to druntime.  This pull will need to be merged alongside [druntime #796](https://github.com/D-Programming-Language/druntime/pull/796), which puts these `strerror_r` declarations in `core.stdc.string`.

I'm not sure what should be done with the `memicmp` declaration, as it isn't used anywhere in phobos.  If there's a chance that outside code might be using it, I can move it to druntime also.  Otherwise, maybe the `memicmp` declaration can be deleted altogether.

Also, if there's no chance of outside code importing `std.c.string`, maybe I can just remove the file without deprecating it and change all the imports in phobos to use `core.stdc.string` directly.

Let me know what's best, just trying to do some cleanup.
