### PR TITLE
std.stdio.writeln should write strings with embedded nulls correctly

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2742,13 +2742,14 @@ unittest
     writeln("Hello!"c);
     writeln("Hello!"w);    // bug 8386
     writeln("Hello!"d);    // bug 8386
+    writeln("embedded\0null"c); // bug 8730
     stdout.close();
     version (Windows)
         assert(cast(char[]) std.file.read(deleteme) ==
-            "Hello!\r\nHello!\r\nHello!\r\n");
+            "Hello!\r\nHello!\r\nHello!\r\nembedded\0null\r\n");
     else
         assert(cast(char[]) std.file.read(deleteme) ==
-            "Hello!\nHello!\nHello!\n");
+            "Hello!\nHello!\nHello!\nembedded\0null\n");
 }
 
 unittest


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=8730

Basically, the problem is that `std.stdio.writeln` (N.B. _not_ `File.writeln` which works fine) has a specialization for writing strings, that forwards the D string to `fprintf`. The problem is that the string format `"%.*s"` specifies the _maximum_ number of characters written, not the _minimum_ (see man 3 printf under the precision modifier for s/S conversions). So when the D string contains embedded nulls, `fprintf` only prints the first section of the string up to the null.

The solution is to use `fwrite` on `stdout` instead, to ensure that the entire string is written to the output.
