### PR TITLE
prevent ambiguity when calling take with a Take!R 

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3415,7 +3415,7 @@ unittest //12731
 unittest //13151
 {
     auto r = take(repeat(1, 4), 3);
-    assert(r.equal(repeat(1, 3)));
+    assert(r.take(2).equal(repeat(1, 2)));
 }
 
 


### PR DESCRIPTION
If Take!R satisfied `isInputRange!(Unqual!R) && !isInfinite!(Unqual!R) && hasSlicing!(Unqual!R)` then you would get an ambiguity error calling take!(Take!R)

see https://issues.dlang.org/show_bug.cgi?id=13151
