### PR TITLE
Fix issue 10165 (rework of PR #1302)

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1132,20 +1132,23 @@ risks usually associated with $(D cast).
  */
 template Rebindable(T) if (is(T == class) || is(T == interface) || isDynamicArray!T)
 {
-    static if (!is(T == const U, U) && !is(T == immutable U, U))
+    static if (is(T == const U, U) || is(T == immutable U, U))
     {
-        alias Rebindable = T;
-    }
-    else static if (isDynamicArray!T)
-    {
-        alias Rebindable = const(ElementEncodingType!T)[];
+        static if (isDynamicArray!T)
+        {
+            alias Rebindable = const(ElementEncodingType!T)[];
+        }
+        else
+        {
+            struct Rebindable
+            {
+                mixin RebindableCommon!(T, U, Rebindable);
+            }
+        }
     }
     else
     {
-        struct Rebindable
-        {
-            mixin RebindableCommon!(T, U, Rebindable);
-        }
+        alias Rebindable = T;
     }
 }
 
@@ -1262,19 +1265,19 @@ unittest
 template UnqualRef(T)
     if (is(T == class) || is(T == interface))
 {
-    static if (!is(T == const U, U)
-        && !is(T == immutable U, U)
-        && !is(T == shared U, U)
-        && !is(T == const shared U, U))
-    {
-        alias UnqualRef = T;
-    }
-    else
+    static if (is(T == const U, U)
+        || is(T == immutable U, U)
+        || is(T == shared U, U)
+        || is(T == const shared U, U))
     {
         struct UnqualRef
         {
             mixin RebindableCommon!(T, U, UnqualRef);
         }
+    }
+    else
+    {
+        alias UnqualRef = T;
     }
 }
 


### PR DESCRIPTION
http://issues.dlang.org/show_bug.cgi?id=10165
Issue 10165: No syntax to create thread-local shared variables

Adds `UnqualRef` templated alias/struct that is similar to Rebindable but
strips away all qualifiers completely (including shared)

An alternative to https://github.com/D-Programming-Language/phobos/pull/1302
