### PR TITLE
Rework of #1255 : add the `call` helper function

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -936,34 +936,46 @@ auto toDelegate(F)(auto ref F fp) if (isCallable!(F))
 }
 
 /**
- * Calls the delegate with the value as argument. Used for temporarily binding
- * a value as an argument.
- *
- * Example:
- * ----
- * assert(
- *         (1 + 2 * 3).bindTo!(x => x * x * x + 2 * x * x + 3 * x)()
- *         ==
- *         (1 + 2 * 3) * ( 1 + 2 * 3) * ( 1 + 2 * 3)
- *         + 2 * ( 1 + 2 * 3) * (1 + 2 * 3)
- *         + 3 * ( 1 + 2 * 3)
- *       );
- * ----
+ * Calls the delegate with the value/values as an argument.
+ * Useful for slightly more functional coding style,
+ * allows defining filter lambdas inside
  */
-auto bindTo(alias dlg, T)(T value) if(__traits(compiles, dlg(value)))
+auto call(alias dlg, T)(T value)
+    if (is(typeof(unaryFun!dlg(value))))
 {
-    return dlg(value);
+    alias Fun = unaryFun!dlg;
+    return Fun(value);
 }
 
-unittest//verify example
+///
+unittest
 {
-    assert(
-            (1 + 2 * 3).bindTo!(x => x * x * x + 2 * x * x + 3 * x)()
-            ==
-            (1 + 2 * 3) * ( 1 + 2 * 3) * ( 1 + 2 * 3)
-            + 2 * ( 1 + 2 * 3) * (1 + 2 * 3)
-            + 3 * ( 1 + 2 * 3)
-          );
+    assert(2.call!(a => 2 * a) == 4);
+
+    static dg = (int x) => x * x * x + 2 * x * x +3 * x;
+    assert((1 + 2 * 3).call!dg == dg(1 + 2 * 3));
+}
+
+unittest
+{
+    assert(2.call!"2*a" == 4);
+}
+
+import std.typecons : Tuple;
+
+/// ditto
+auto call(alias dlg, Args)(Args args)
+    if (   is(Args == Tuple!T, T...)
+        && is(typeof(dlg(args.expand))))
+{
+    return dlg(args.expand);
+}
+
+///
+unittest
+{
+    import std.typecons : tuple;
+    assert(tuple(1, 2).call!((a, b) => a + b) == 3);
 }
 
 unittest {


### PR DESCRIPTION
Adds `call` helper to std.functional that makes possible to do postfix notation
lambda calls.

Based on https://github.com/D-Programming-Language/phobos/pull/1255 , adds few enhancements
as discussed with original author, @idanarye

Should now fit all comments in original discussion thread. This helper function
may be of questionable utility but it is small and does no harm ;)
