### PR TITLE
Add construction-from-range capability to RedBlackTree

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1572,45 +1572,29 @@ assert(std.algorithm.equal(rbt[], [5]));
         }
     }
 
-    /+
-        For the moment, using templatized contstructors doesn't seem to work
-        very well (likely due to bug# 436 and/or bug# 1528). The redBlackTree
-        helper function seems to do the job well enough though.
-
     /**
-     * Constructor.  Pass in an array of elements, or individual elements to
+     * Constructor. Pass in an array of elements, or individual elements to
      * initialize the tree with.
      */
-    this(U)(U[] elems...) if (isImplicitlyConvertible!(U, Elem))
-    {
-        _setup();
-        stableInsert(elems);
-    }
-
-    /**
-     * Constructor.  Pass in a range of elements to initialize the tree with.
-     */
-    this(Stuff)(Stuff stuff) if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem) && !is(Stuff == Elem[]))
-    {
-        _setup();
-        stableInsert(stuff);
-    }
-    +/
-
-    /++ +/
-    this()
-    {
-        _setup();
-    }
-
-    /++
-       Constructor.  Pass in an array of elements, or individual elements to
-       initialize the tree with.
-     +/
     this(Elem[] elems...)
     {
         _setup();
         stableInsert(elems);
+    }
+
+    /**
+     * Constructor. Pass in a range of elements to initialize the tree with.
+     */
+    this(Stuff)(Stuff stuff) if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem))
+    {
+        _setup();
+        stableInsert(stuff);
+    }
+
+    ///
+    this()
+    {
+        _setup();
     }
 
     private this(Node end, size_t length)
@@ -1728,6 +1712,13 @@ unittest
     auto rbt1 = redBlackTree!(true, string)("hello", "hello");
     auto rbt2 = redBlackTree!((a, b){return a < b;}, double)(5.1, 2.3);
     auto rbt3 = redBlackTree!("a > b", true, string)("hello", "world");
+}
+
+//Range construction.
+unittest
+{
+    auto rbt = new RedBlackTree!(int, "a > b")(iota(5));
+    assert(equal(rbt[], [4, 3, 2, 1, 0]));
 }
 
 unittest


### PR DESCRIPTION
Construction from a range is one of the most fundamental container primitives and there's no reason `RedBlackTree` shouldn't support it. According to code comments, it looks like it was left out because of compiler bugs.

the `redBlackTree` convenience function was not updated because the combinatorial explosion is getting ridiculous, it would require either 8 overloads or an unreadable soup of templates that is only marginally shorter. It's a terrible design.

Also moved some examples to documented unit tests.

edit:

The patch for the second commit looks a bit weird because the code was already there, just commented out.
