### PR TITLE
 	Add more convenient container-construction overload for std.container.make

### DIFF
--- a/std/container/util.d
+++ b/std/container/util.d
@@ -67,3 +67,52 @@ unittest
     assert(a != c);
     assert(a != d);
 }
+
+/**
+ * Convenience function for constructing a generic container.
+ */
+template make(alias Container, Args...)
+    if(!is(Container))
+{
+    import std.range : isInputRange;
+    import std.traits : isDynamicArray;
+
+    auto make(Range)(Range range)
+        if(!isDynamicArray!Range && isInputRange!Range)
+    {
+        import std.range : ElementType;
+        return .make!(Container!(ElementType!Range, Args))(range);
+    }
+
+    auto make(T)(T[] items...)
+    {
+        return .make!(Container!(T, Args))(items);
+    }
+}
+
+///
+unittest
+{
+    import std.container.array, std.container.rbtree, std.container.slist;
+    import std.range : iota;
+
+    auto arr = make!Array(iota(5));
+    assert(equal(arr[], [0, 1, 2, 3, 4]));
+
+    auto rbtmax = make!(RedBlackTree, "a > b")(iota(5));
+    assert(equal(rbtmax[], [4, 3, 2, 1, 0]));
+
+    auto rbtmin = make!RedBlackTree(4, 1, 3, 2);
+    assert(equal(rbtmin[], [1, 2, 3, 4]));
+
+    alias makeList = make!SList;
+    auto list = makeList(1, 7, 42);
+    assert(equal(list[], [1, 7, 42]));
+}
+
+unittest
+{
+    import std.container.rbtree;
+    auto rbtmin = make!(RedBlackTree, "a < b", false)(3, 2, 2, 1);
+    assert(equal(rbtmin[], [1, 2, 3]));
+}


### PR DESCRIPTION
**(Depends on ~~#2359~~ for the example/test to work)**

This unifies construction of containers in a generic fashion.

Current approach:

``` d
auto arr = Array!int(1, 2, 3);
auto list = SList!int(1, 2, 3);
auto rbtmax = redBlackTree!"a > b"(1, 2, 3);
alias makeIntegerList = make!(SList!int);
```

Proposed approach:

``` d
auto arr = make!Array(1, 2, 3);
auto list = make!SList(1, 2, 3);
auto rbtmax = make!(RedBlackTree, "a > b")(1, 2, 3);
alias makeList = make!SList;
```

Currently, a container may choose to do one of two things: 1) rely entirely on its constructors for construction, or 2) define a convenience function for constructing an instance of that particular container. 

The problem with 1) is that the user needs to explicitly supply redundant information - the element type - which can be particularly tedious if the element type is generic, such as when constructing from a range in a range algorithm.

The first problem with 2) is the maintenance burden of needing to define and test a bunch of helpers. The second problem is the cognitive overhead that results from the user having to remember inconsistently named convenience functions (`redBlackTree` vs `heapify`), and their varying interfaces (if range-construction was added to `redBlackTree`, it would have 8 overloads).

Amending `make` in this fashion solves these problems. This change is 100% backwards-compatible with `make`'s current interface.

`BinaryHeap` currently does not fit this model as it is a kind of higher-order container. It could be made to fit by adding another template overload, but it requires some dubious template constraints, so I'm pushing that back to a future PR if this PR ends up being accepted.

Also moved `make`'s old example to a documented unit test.
