### PR TITLE
Fix install directory on Mac OS X

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -355,11 +355,12 @@ zip :
 	zip $(ZIPFILE) $(MAKEFILE) $(ALL_D_FILES) $(ALL_C_FILES) win32.mak win64.mak
 
 install2 : all
-	mkdir -p $(INSTALL_DIR)/$(OS)/lib$(MODEL)
-	cp $(LIB) $(INSTALL_DIR)/$(OS)/lib$(MODEL)/
+	$(eval lib_dir=$(if $(filter $(OS),osx), lib, lib$(MODEL)))
+	mkdir -p $(INSTALL_DIR)/$(OS)/$(lib_dir)
+	cp $(LIB) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 ifneq (,$(findstring $(OS),linux))
-	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/lib$(MODEL)/
-	ln -s $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/lib$(MODEL)/libphobos2.so
+	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
+	ln -s $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
 endif
 	mkdir -p $(INSTALL_DIR)/src/phobos/etc
 	mkdir -p $(INSTALL_DIR)/src/phobos/std


### PR DESCRIPTION
Due to [request 2362](https://github.com/D-Programming-Language/phobos/pull/2362), Phobos lib is installed into `$(INSTALL_DIR)/lib64` on Max OS X 64bit systems
but it should be installed into `$(INSTALL_DIR)/lib`.
This pull request fixes this issue on Max OS X systems.

Related issue on druntime: [request 910](https://github.com/D-Programming-Language/druntime/pull/910)
