### PR TITLE
Fix ln command option on Linux systems

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -360,7 +360,7 @@ install2 : all
 	cp $(LIB) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 ifneq (,$(findstring $(OS),linux))
 	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
-	ln -s $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
+	ln -sf $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
 endif
 	mkdir -p $(INSTALL_DIR)/src/phobos/etc
 	mkdir -p $(INSTALL_DIR)/src/phobos/std


### PR DESCRIPTION
This pull request fixes the problem when we update the existing Phobos library by using `make install` on Linux systems.
