### PR TITLE
Make TakeExactly!R implicitly convertible to Take!R

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -3469,6 +3469,13 @@ if (isInputRange!R)
             @property size_t length() const { return _n; }
             alias opDollar = length;
 
+            Take!R _takeExactly_Result_asTake()
+            {
+                return typeof(return)(_input, _n);
+            }
+
+            alias _takeExactly_Result_asTake this;
+
             static if (isForwardRange!R)
                 @property auto save()
                 {
@@ -3588,6 +3595,15 @@ unittest
             }
         }
     }
+}
+
+unittest
+{
+    alias DummyType = DummyRange!(ReturnBy.Value, Length.No, RangeType.Forward);
+    auto te = takeExactly(DummyType(), 5);
+    Take!DummyType t = te;
+    assert(equal(t, [1, 2, 3, 4, 5]));
+    assert(equal(t, te));
 }
 
 /**
@@ -9918,14 +9934,14 @@ unittest
 /++
   Implements a "tee" style pipe, wrapping an input range so that elements
   of the range can be passed to a provided function or $(LREF OutputRange)
-  as they are iterated over. This is useful for printing out intermediate 
-  values in a long chain of range code, performing some operation with 
+  as they are iterated over. This is useful for printing out intermediate
+  values in a long chain of range code, performing some operation with
   side-effects on each call to $(D front) or $(D popFront), or diverting
-  the elements of a range into an auxiliary $(LREF OutputRange). 
+  the elements of a range into an auxiliary $(LREF OutputRange).
 
-  It is important to note that as the resultant range is evaluated lazily, 
+  It is important to note that as the resultant range is evaluated lazily,
   in the case of the version of $(D tee) that takes a function, the function
-  will not actually be executed until the range is "walked" using functions 
+  will not actually be executed until the range is "walked" using functions
   that evaluate ranges, such as $(LREF array) or $(LREF reduce).
 +/
 
@@ -9998,9 +10014,9 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     /*
         Distinguish between function literals and template lambdas
         when using either as an $(LREF OutputRange). Since a template
-        has no type, typeof(template) will always return void. 
-        If it's a template lambda, it's first necessary to instantiate 
-        it with the type of $(D inputRange.front). 
+        has no type, typeof(template) will always return void.
+        If it's a template lambda, it's first necessary to instantiate
+        it with the type of $(D inputRange.front).
     */
     static if (is(typeof(fun) == void))
     {


### PR DESCRIPTION
Many container methods accept `Take!Range` but not the result of `takeExactly`. This patch makes the latter implicitly convertible to the former, seamlessly allowing for code like this:

``` d
void main()
{
    import std.algorithm : equal, findSplitBefore;
    import std.container.slist;
    import std.range : only, takeExactly;

    auto list = make!SList(1, 2, 3, 4);
    auto split = list[].findSplitBefore(only(3));
    list.linearRemove(split[0]); // Currently an error, OK with this patch
    assert(list[].equal([3, 4]));
}
```

std.algorithm.commonPrefix and the `findSplit*` functions all document that they return the same type as `takeExactly` does on the same input.

However, while the `Take!Range` idiom is commonly supported among containers, it's not a formal part of those primitives, so I didn't add any documentation in this patch explaining this capability. It's just a nice extra until we formalize the `Take!Range` idiom or figure out something better to replace it.
