### PR TITLE
Fix posix.mak

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -360,7 +360,7 @@ install2 : all
 	cp $(LIB) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 ifneq (,$(findstring $(OS),linux))
 	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
-	ln -s $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
+	ln -sf $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
 endif
 	mkdir -p $(INSTALL_DIR)/src/phobos/etc
 	mkdir -p $(INSTALL_DIR)/src/phobos/std


### PR DESCRIPTION
Fixes this error:

```
$ make -f posix.mak install
...
$ make -f posix.mak install
...
ln -s libphobos2.so.0.66.0 ../install/linux/lib64/libphobos2.so
ln: failed to create symbolic link '../install/linux/lib64/libphobos2.so': File exists
```
