### PR TITLE
Fix issue 12923

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -1134,8 +1134,8 @@ private dchar decodeImpl(bool canIndex, S)(auto ref S str, ref size_t index)
         else
            return new UTFException("Attempted to decode past the end of a string");
     }
-
-    assert(fst & 0x80);
+    if((fst & 0b1100_0000) != 0b1100_0000)
+        throw invalidUTF(); // starter must have at least 2 first bits set
     ubyte tmp = void;
     dchar d = fst; // upper control bits are masked out later
     fst <<= 1;
@@ -2019,6 +2019,14 @@ void validate(S)(in S str) @safe pure
     }
 }
 
+
+unittest // bugzilla 12923
+{
+  assertThrown((){
+    char[3]a=[167, 133, 175];
+    validate(a[]);
+  }());
+}
 
 /* =================== Conversion to UTF8 ======================= */
 


### PR DESCRIPTION
UTF exception in stride even though passes validate.
https://issues.dlang.org/show_bug.cgi?id=12923

The root cause is that decode has very lax checking of the first
code unit. Apparently is a blocker.
