### PR TITLE
[reg] Fix 13210 : libphobos2.so not being built

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -249,9 +249,9 @@ MAKEFILE = $(firstword $(MAKEFILE_LIST))
 
 # Main target (builds the dll on linux, too)
 ifeq (linux,$(OS))
-all : $(LIB) $(LIBSO)
+all : lib dll
 else
-all : $(LIB)
+all : lib
 endif
 
 install :
@@ -270,7 +270,7 @@ depend: $(addprefix $(ROOT)/unittest/,$(addsuffix .deps,$(D_MODULES)))
 
 .PHONY: lib dll
 lib: $(LIB)
-dll: $(LIBSO)
+dll: $(ROOT)/libphobos2.so
 
 $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
@@ -279,10 +279,7 @@ $(ROOT)/%$(DOTOBJ): %.c
 $(LIB): $(OBJS) $(ALL_D_FILES) druntime_libs
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
 
-$(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
-	ln -sf $(notdir $(LIBSO)) $@
-
-$(ROOT)/$(SONAME): $(LIBSO)
+$(ROOT)/libphobos2.so: $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
 $(LIBSO): override PIC:=-fPIC


### PR DESCRIPTION
Accidental side effect from changes in https://github.com/D-Programming-Language/phobos/pull/2345 : target for `libphobos2.so` symlink never got referenced and thus never got executed.

This PR defines a bit more strict dependency sequence `dll -> libphobos2.so -> libbphobos2.so.0.66.0`

@MartinNowak please confirm is does not interfere with actual fix

@AndrewEdwards FYI
