### PR TITLE
Mark a unittest for std.file.read as safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -309,7 +309,7 @@ void[] read(in char[] name, size_t upTo = size_t.max) @safe
     }
 }
 
-unittest
+@safe unittest
 {
     write(deleteme, "1234");
     scope(exit) { assert(exists(deleteme)); remove(deleteme); }


### PR DESCRIPTION
It does not contain any unsafe instructions.
