### PR TITLE
Mark std.file.getFileAttributesWin as trusted and makeUlong as safe pure nothrow nogc

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -501,14 +501,14 @@ void remove(in char[] name) @trusted
             "Failed to remove file " ~ name);
 }
 
-version(Windows) private WIN32_FILE_ATTRIBUTE_DATA getFileAttributesWin(in char[] name)
+version(Windows) private WIN32_FILE_ATTRIBUTE_DATA getFileAttributesWin(in char[] name) @trusted
 {
     WIN32_FILE_ATTRIBUTE_DATA fad;
     enforce(GetFileAttributesExW(std.utf.toUTF16z(name), GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, &fad), new FileException(name.idup));
     return fad;
 }
 
-version(Windows) private ulong makeUlong(DWORD dwLow, DWORD dwHigh)
+version(Windows) private ulong makeUlong(DWORD dwLow, DWORD dwHigh) @safe pure nothrow @nogc
 {
     ULARGE_INTEGER li;
     li.LowPart  = dwLow;


### PR DESCRIPTION
`getFileAttributesWin` includes a system function `core.sys.windows.GetFileAttributesExW` but we can verify it can be trusted.
`makeUlong` does not throw exceptions and does not contain any unsafe, impure, gc-related operations.
