### PR TITLE
Mark std.file.getSize as trusted

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -522,7 +522,7 @@ Get size of file $(D name) in bytes.
 
 Throws: $(D FileException) on error (e.g., file not found).
  */
-ulong getSize(in char[] name) @trusted
+ulong getSize(in char[] name) @safe
 {
     version(Windows)
     {
@@ -531,8 +531,16 @@ ulong getSize(in char[] name) @trusted
     }
     else version(Posix)
     {
+        static auto trustedStat(in char* path, stat_t* buf) @trusted
+        {
+            return stat(path, buf);
+        }
+        static stat_t* ptrOfLocalVariable(ref stat_t buf) @trusted
+        {
+            return &buf;
+        }
         stat_t statbuf = void;
-        cenforce(stat(toStringz(name), &statbuf) == 0, name);
+        cenforce(trustedStat(toStringz(name), ptrOfLocalVariable(statbuf)) == 0, name);
         return statbuf.st_size;
     }
 }


### PR DESCRIPTION
On Windows systems, it does not contain any unsafe operations.
On Posix systems, it uses an unsafe function `core.sys.posix.sys.stat.stat` and takes an address of a local variable (`statbuf`) but we can verify it can be trusted.
