### PR TITLE
Flush stdout after writeln (fixes issue #13241)

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2861,7 +2861,8 @@ void writeln(T...)(T args)
         w.put("\n");
 
         // Issue 13241
-        .trustedStdout.flush();
+        version(DIGITAL_MARS_STDIO)
+            .trustedStdout.flush();
     }
     else
     {


### PR DESCRIPTION
Followup to pull https://github.com/D-Programming-Language/phobos/pull/2334

Fixes: https://issues.dlang.org/show_bug.cgi?id=13241

Not sure if the `.flush` call should be inside a version block for DMC, since apparently this isn't an issue on other platforms.
