### PR TITLE
std.getopt: Remove opinionated comment regarding option bundling

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -352,8 +352,8 @@ For more details about short options, refer also to the next section.
 $(B Bundling)
 
 Single-letter options can be bundled together, i.e. "-abc" is the same as
-$(D "-a -b -c"). By default, this confusing option is turned off. You can
-turn it on with the $(D std.getopt.config.bundling) directive:
+$(D "-a -b -c"). By default, this option is turned off. You can turn it on
+with the $(D std.getopt.config.bundling) directive:
 
 ---------
 bool foo, bar;


### PR DESCRIPTION
The behavior is standard in UNIX programs. Although it wouldn't make sense to change the default at this point, D documentation is not a good place for criticizing established standards.
