### PR TITLE
Eliminate bad use of alias

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -60,7 +60,7 @@ elements in $(D rhs).
     bool opEquals()(ref const DList rhs) const
     if (is(typeof(front == front)))
     {
-        alias lhs = this;
+        const lhs = this;
         const lroot = lhs._root;
         const rroot = rhs._root;
 


### PR DESCRIPTION
Quoting Walter: "Looking back on it, 2540 was probably a bad idea, but I think we're stuck with it."
See also: https://issues.dlang.org/show_bug.cgi?id=9597

The less we use this syntax the more we can pretend the change that allowed it never happened.
