### PR TITLE
SList: correct reference semantics

### DIFF
--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -14,7 +14,6 @@ struct SList(T)
     {
         Node * _next;
         T _payload;
-        this(T a, Node* b) { _payload = a; _next = b; }
     }
     private struct NodeWithoutPayload
     {
@@ -279,7 +278,7 @@ Complexity: $(BIGOH m), where $(D m) is the length of $(D stuff)
         Node * n, newRoot;
         foreach (item; stuff)
         {
-            auto newNode = new Node(item, null);
+            auto newNode = new Node(null, item);
             (newRoot ? n._next : newRoot) = newNode;
             n = newNode;
             ++result;
@@ -296,7 +295,7 @@ Complexity: $(BIGOH m), where $(D m) is the length of $(D stuff)
     if (isImplicitlyConvertible!(Stuff, T))
     {
         initialize();
-        auto newRoot = new Node(stuff, _first);
+        auto newRoot = new Node(_first, stuff);
         _first = newRoot;
         return 1;
     }


### PR DESCRIPTION
With this changes `SList` will behave as `DList`:

``` d
unittest
{
    import std.algorithm : equal;

    auto a = SList!int(5);
    auto b = a;
    auto r = a[];
    a.insertFront(1);
    b.insertFront(2);
    assert(equal(a[], [2, 1, 5]));
    assert(equal(b[], [2, 1, 5]));
    r.front = 9;
    assert(equal(a[], [2, 1, 9]));
    assert(equal(b[], [2, 1, 9]));
}
```

PR probably incomplete, I have to check documentation and maybe deprecate some methods. (Opened it now to have more motivation.)

@monarchdodra's thread: http://forum.dlang.org/thread/gjhclwsuqyhrimdeoaec@forum.dlang.org
