### PR TITLE
[dox] Ddoc for std.parallelism.map() should be associated with the function itself.

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1553,86 +1553,86 @@ public:
         }
     }
 
-    /**
-    Eager parallel map.  The eagerness of this function means it has less
-    overhead than the lazily evaluated $(D TaskPool.map) and should be
-    preferred where the memory requirements of eagerness are acceptable.
-    $(D functions) are the functions to be evaluated, passed as template alias
-    parameters in a style similar to $(XREF algorithm, map).  The first
-    argument must be a random access range.
-
-    ---
-    auto numbers = iota(100_000_000.0);
-
-    // Find the square roots of numbers.
-    //
-    // Timings on an Athlon 64 X2 dual core machine:
-    //
-    // Parallel eager map:                   0.802 s
-    // Equivalent serial implementation:     1.768 s
-    auto squareRoots = taskPool.amap!sqrt(numbers);
-    ---
-
-    Immediately after the range argument, an optional work unit size argument
-    may be provided.  Work units as used by $(D amap) are identical to those
-    defined for parallel foreach.  If no work unit size is provided, the
-    default work unit size is used.
-
-    ---
-    // Same thing, but make work unit size 100.
-    auto squareRoots = taskPool.amap!sqrt(numbers, 100);
-    ---
-
-    An output range for returning the results may be provided as the last
-    argument.  If one is not provided, an array of the proper type will be
-    allocated on the garbage collected heap.  If one is provided, it must be a
-    random access range with assignable elements, must have reference
-    semantics with respect to assignment to its elements, and must have the
-    same length as the input range.  Writing to adjacent elements from
-    different threads must be safe.
-
-    ---
-    // Same thing, but explicitly allocate an array
-    // to return the results in.  The element type
-    // of the array may be either the exact type
-    // returned by functions or an implicit conversion
-    // target.
-    auto squareRoots = new float[numbers.length];
-    taskPool.amap!sqrt(numbers, squareRoots);
-
-    // Multiple functions, explicit output range, and
-    // explicit work unit size.
-    auto results = new Tuple!(float, real)[numbers.length];
-    taskPool.amap!(sqrt, log)(numbers, 100, results);
-    ---
-
-    Note:
-
-    A memory barrier is guaranteed to be executed after all results are written
-    but before returning so that results produced by all threads are visible
-    in the calling thread.
-
-    Tips:
-
-    To perform the mapping operation in place, provide the same range for the
-    input and output range.
-
-    To parallelize the copying of a range with expensive to evaluate elements
-    to an array, pass an identity function (a function that just returns
-    whatever argument is provided to it) to $(D amap).
-
-    $(B Exception Handling):
-
-    When at least one exception is thrown from inside the map functions,
-    the submission of additional $(D Task) objects is terminated as soon as
-    possible, in a non-deterministic manner.  All currently executing or
-    enqueued work units are allowed to complete.  Then, all exceptions that
-    were thrown from any work unit are chained using $(D Throwable.next) and
-    rethrown.  The order of the exception chaining is non-deterministic.
-     */
+    ///
     template amap(functions...)
     {
-        ///
+        /**
+        Eager parallel map.  The eagerness of this function means it has less
+        overhead than the lazily evaluated $(D TaskPool.map) and should be
+        preferred where the memory requirements of eagerness are acceptable.
+        $(D functions) are the functions to be evaluated, passed as template alias
+        parameters in a style similar to $(XREF algorithm, map).  The first
+        argument must be a random access range.
+
+        ---
+        auto numbers = iota(100_000_000.0);
+
+        // Find the square roots of numbers.
+        //
+        // Timings on an Athlon 64 X2 dual core machine:
+        //
+        // Parallel eager map:                   0.802 s
+        // Equivalent serial implementation:     1.768 s
+        auto squareRoots = taskPool.amap!sqrt(numbers);
+        ---
+
+        Immediately after the range argument, an optional work unit size argument
+        may be provided.  Work units as used by $(D amap) are identical to those
+        defined for parallel foreach.  If no work unit size is provided, the
+        default work unit size is used.
+
+        ---
+        // Same thing, but make work unit size 100.
+        auto squareRoots = taskPool.amap!sqrt(numbers, 100);
+        ---
+
+        An output range for returning the results may be provided as the last
+        argument.  If one is not provided, an array of the proper type will be
+        allocated on the garbage collected heap.  If one is provided, it must be a
+        random access range with assignable elements, must have reference
+        semantics with respect to assignment to its elements, and must have the
+        same length as the input range.  Writing to adjacent elements from
+        different threads must be safe.
+
+        ---
+        // Same thing, but explicitly allocate an array
+        // to return the results in.  The element type
+        // of the array may be either the exact type
+        // returned by functions or an implicit conversion
+        // target.
+        auto squareRoots = new float[numbers.length];
+        taskPool.amap!sqrt(numbers, squareRoots);
+
+        // Multiple functions, explicit output range, and
+        // explicit work unit size.
+        auto results = new Tuple!(float, real)[numbers.length];
+        taskPool.amap!(sqrt, log)(numbers, 100, results);
+        ---
+
+        Note:
+
+        A memory barrier is guaranteed to be executed after all results are written
+        but before returning so that results produced by all threads are visible
+        in the calling thread.
+
+        Tips:
+
+        To perform the mapping operation in place, provide the same range for the
+        input and output range.
+
+        To parallelize the copying of a range with expensive to evaluate elements
+        to an array, pass an identity function (a function that just returns
+        whatever argument is provided to it) to $(D amap).
+
+        $(B Exception Handling):
+
+        When at least one exception is thrown from inside the map functions,
+        the submission of additional $(D Task) objects is terminated as soon as
+        possible, in a non-deterministic manner.  All currently executing or
+        enqueued work units are allowed to complete.  Then, all exceptions that
+        were thrown from any work unit are chained using $(D Throwable.next) and
+        rethrown.  The order of the exception chaining is non-deterministic.
+        */
         auto amap(Args...)(Args args)
         if(isRandomAccessRange!(Args[0]))
         {
@@ -2334,92 +2334,91 @@ public:
         return asyncBuf(roundRobin, nBuffers / 2);
     }
 
-    /**
-    Parallel reduce on a random access range.  Except as otherwise noted, usage
-    is similar to $(XREF algorithm, _reduce).  This function works by splitting
-    the range to be reduced into work units, which are slices to be reduced in
-    parallel.  Once the results from all work units are computed, a final serial
-    reduction is performed on these results to compute the final answer.
-    Therefore, care must be taken to choose the seed value appropriately.
-
-    Because the reduction is being performed in parallel,
-    $(D functions) must be associative.  For notational simplicity, let # be an
-    infix operator representing $(D functions).  Then, (a # b) # c must equal
-    a # (b # c).  Floating point addition is not associative
-    even though addition in exact arithmetic is.  Summing floating
-    point numbers using this function may give different results than summing
-    serially.  However, for many practical purposes floating point addition
-    can be treated as associative.
-
-    Note that, since $(D functions) are assumed to be associative, additional
-    optimizations are made to the serial portion of the reduction algorithm.
-    These take advantage of the instruction level parallelism of modern CPUs,
-    in addition to the thread-level parallelism that the rest of this
-    module exploits.  This can lead to better than linear speedups relative
-    to $(XREF algorithm, _reduce), especially for fine-grained benchmarks
-    like dot products.
-
-    An explicit seed may be provided as the first argument.  If
-    provided, it is used as the seed for all work units and for the final
-    reduction of results from all work units.  Therefore, if it is not the
-    identity value for the operation being performed, results may differ from
-    those generated by $(XREF algorithm, _reduce) or depending on how many work
-    units are used.  The next argument must be the range to be reduced.
-    ---
-    // Find the sum of squares of a range in parallel, using
-    // an explicit seed.
-    //
-    // Timings on an Athlon 64 X2 dual core machine:
-    //
-    // Parallel reduce:                     72 milliseconds
-    // Using std.algorithm.reduce instead:  181 milliseconds
-    auto nums = iota(10_000_000.0f);
-    auto sumSquares = taskPool.reduce!"a + b"(
-        0.0, std.algorithm.map!"a * a"(nums)
-    );
-    ---
-
-    If no explicit seed is provided, the first element of each work unit
-    is used as a seed.  For the final reduction, the result from the first
-    work unit is used as the seed.
-    ---
-    // Find the sum of a range in parallel, using the first
-    // element of each work unit as the seed.
-    auto sum = taskPool.reduce!"a + b"(nums);
-    ---
-
-    An explicit work unit size may be specified as the last argument.
-    Specifying too small a work unit size will effectively serialize the
-    reduction, as the final reduction of the result of each work unit will
-    dominate computation time.  If $(D TaskPool.size) for this instance
-    is zero, this parameter is ignored and one work unit is used.
-    ---
-    // Use a work unit size of 100.
-    auto sum2 = taskPool.reduce!"a + b"(nums, 100);
-
-    // Work unit size of 100 and explicit seed.
-    auto sum3 = taskPool.reduce!"a + b"(0.0, nums, 100);
-    ---
-
-    Parallel reduce supports multiple functions, like
-    $(D std.algorithm.reduce).
-    ---
-    // Find both the min and max of nums.
-    auto minMax = taskPool.reduce!(min, max)(nums);
-    assert(minMax[0] == reduce!min(nums));
-    assert(minMax[1] == reduce!max(nums));
-    ---
-
-    $(B Exception Handling):
-
-    After this function is finished executing, any exceptions thrown
-    are chained together via $(D Throwable.next) and rethrown.  The chaining
-    order is non-deterministic.
-     */
+    ///
     template reduce(functions...)
     {
+        /**
+        Parallel reduce on a random access range.  Except as otherwise noted, usage
+        is similar to $(XREF algorithm, _reduce).  This function works by splitting
+        the range to be reduced into work units, which are slices to be reduced in
+        parallel.  Once the results from all work units are computed, a final serial
+        reduction is performed on these results to compute the final answer.
+        Therefore, care must be taken to choose the seed value appropriately.
 
-        ///
+        Because the reduction is being performed in parallel,
+        $(D functions) must be associative.  For notational simplicity, let # be an
+        infix operator representing $(D functions).  Then, (a # b) # c must equal
+        a # (b # c).  Floating point addition is not associative
+        even though addition in exact arithmetic is.  Summing floating
+        point numbers using this function may give different results than summing
+        serially.  However, for many practical purposes floating point addition
+        can be treated as associative.
+
+        Note that, since $(D functions) are assumed to be associative, additional
+        optimizations are made to the serial portion of the reduction algorithm.
+        These take advantage of the instruction level parallelism of modern CPUs,
+        in addition to the thread-level parallelism that the rest of this
+        module exploits.  This can lead to better than linear speedups relative
+        to $(XREF algorithm, _reduce), especially for fine-grained benchmarks
+        like dot products.
+
+        An explicit seed may be provided as the first argument.  If
+        provided, it is used as the seed for all work units and for the final
+        reduction of results from all work units.  Therefore, if it is not the
+        identity value for the operation being performed, results may differ from
+        those generated by $(XREF algorithm, _reduce) or depending on how many work
+        units are used.  The next argument must be the range to be reduced.
+        ---
+        // Find the sum of squares of a range in parallel, using
+        // an explicit seed.
+        //
+        // Timings on an Athlon 64 X2 dual core machine:
+        //
+        // Parallel reduce:                     72 milliseconds
+        // Using std.algorithm.reduce instead:  181 milliseconds
+        auto nums = iota(10_000_000.0f);
+        auto sumSquares = taskPool.reduce!"a + b"(
+            0.0, std.algorithm.map!"a * a"(nums)
+        );
+        ---
+
+        If no explicit seed is provided, the first element of each work unit
+        is used as a seed.  For the final reduction, the result from the first
+        work unit is used as the seed.
+        ---
+        // Find the sum of a range in parallel, using the first
+        // element of each work unit as the seed.
+        auto sum = taskPool.reduce!"a + b"(nums);
+        ---
+
+        An explicit work unit size may be specified as the last argument.
+        Specifying too small a work unit size will effectively serialize the
+        reduction, as the final reduction of the result of each work unit will
+        dominate computation time.  If $(D TaskPool.size) for this instance
+        is zero, this parameter is ignored and one work unit is used.
+        ---
+        // Use a work unit size of 100.
+        auto sum2 = taskPool.reduce!"a + b"(nums, 100);
+
+        // Work unit size of 100 and explicit seed.
+        auto sum3 = taskPool.reduce!"a + b"(0.0, nums, 100);
+        ---
+
+        Parallel reduce supports multiple functions, like
+        $(D std.algorithm.reduce).
+        ---
+        // Find both the min and max of nums.
+        auto minMax = taskPool.reduce!(min, max)(nums);
+        assert(minMax[0] == reduce!min(nums));
+        assert(minMax[1] == reduce!max(nums));
+        ---
+
+        $(B Exception Handling):
+
+        After this function is finished executing, any exceptions thrown
+        are chained together via $(D Throwable.next) and rethrown.  The chaining
+        order is non-deterministic.
+         */
         auto reduce(Args...)(Args args)
         {
             alias fun = reduceAdjoin!functions;


### PR DESCRIPTION
So that the ddoc will be properly formatted under the implementation rather than the outer template declaration, and also so that ddoc won't complain about mismatching params.
