### PR TITLE
Deprecate std.process.execv function family on Windows

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -3264,8 +3264,17 @@ else
             return execvpe_(pathname, argv, envp);
         }
     };
-    version (Posix)        mixin (execvForwarderDefs);
-    else version (Windows) mixin ("deprecated {" ~ execvForwarderDefs ~ "}");
+    version (Posix)
+    {
+        mixin (execvForwarderDefs);
+    }
+    else version (Windows)
+    {
+        private enum execvDeprecationMsg =
+            "Please consult the API documentation for more information: "
+            ~"http://dlang.org/phobos/std_process.html#.execv";
+        mixin (`deprecated ("`~execvDeprecationMsg~`") {` ~ execvForwarderDefs ~ `}`);
+    }
     else static assert (false, "Unsupported platform");
 }
 


### PR DESCRIPTION
For the discussions that led to the decision of deprecating these functions on Windows, but not POSIX, see:

http://forum.dlang.org/thread/l4nav4$q9r$1@digitalmars.com
http://lists.puremagic.com/pipermail/phobos/2014-August/008827.html
