### PR TITLE
Workaround deprecation of splitter.{back,popBack} in std.algorithm.map.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -481,12 +481,12 @@ private struct MapResult(alias fun, Range)
 
     static if (isBidirectionalRange!R)
     {
-        @property auto ref back()
+        @property auto ref back()()
         {
             return fun(_input.back);
         }
 
-        void popBack()
+        void popBack()()
         {
             _input.popBack();
         }


### PR DESCRIPTION
Workaround for [issue 13257](https://issues.dlang.org/show_bug.cgi?id=13257).
