### PR TITLE
JSON object and JSON array operator overloads

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -372,7 +372,7 @@ struct JSONValue
                                 "JSONValue is not an array");
         static if(isArray!T)
         {
-            JSONValue newArray = this;
+            JSONValue newArray = JSONValue(this.store.array.dup);
             newArray.store.array ~= JSONValue(arg).store.array;
             return newArray;
         }
@@ -380,7 +380,7 @@ struct JSONValue
         {
             enforceEx!JSONException(arg.type == JSON_TYPE.ARRAY,
                                     "JSONValue is not an array");
-            JSONValue newArray = this;
+            JSONValue newArray = JSONValue(this.store.array.dup);
             newArray.store.array ~= arg.store.array;
             return newArray;
         }


### PR DESCRIPTION
This patch adds the necessary operator overloads for appending to JSON objects and JSON arrays, so that the user doesn't need anymore to manipulate the underlying `JSONValue` structures.

Examples:

```
JSONValue foo = JSONValue([10, 12]);
foo ~= ["abc"];  // foo contains [JSONValue(10), JSONValue(12), JSONValue("abc")];

JSONValue bar = JSONValue(["key1": 10]);
bar["key2"] = "abc";  // bar contains ["key1": JSONValue(10), "key2": JSONValue("abc")];
```
