### PR TITLE
Simplify string escaping in win64.mak

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -458,7 +458,7 @@ html : $(DOCS)
 
 $(ZLIB): $(SRC_ZLIB)
 	cd etc\c\zlib
-	$(MAKE) -f win$(MODEL).mak zlib$(MODEL).lib "CC=\$(CC)"\"" "LIB=\$(AR)"\"" "VCDIR=$(VCDIR)"
+	$(MAKE) -f win$(MODEL).mak zlib$(MODEL).lib CC=\"$(CC)\" LIB=\"$(AR)\" VCDIR="$(VCDIR)"
 	cd ..\..\..
 
 ################## DOCS ####################################


### PR DESCRIPTION
I am not 100% sure what was rationale for original approach but it was causing problems with unqualified paths
like `CC=cl`. New version seems to work for me in both cases but I'd like someone who actually uses Windows to check.
