### PR TITLE
Issue 11832: Fix mismatching param name.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1916,8 +1916,8 @@ public:
         $(LREF SysTime) which is less than a second).
 
         Params:
-            fracSec = The duration to set this $(LREF SysTime)'s fractional
-                      seconds to.
+            fracSecs = The duration to set this $(LREF SysTime)'s fractional
+                       seconds to.
 
         Throws:
             $(LREF DateTimeException) if the given duration is negative or if


### PR DESCRIPTION
Actually the original errors in [bug 11832](https://issues.dlang.org/show_bug.cgi?id=11832) have already been corrected, but Jonathan's latest PR introduced a new error, so I'm fixing that before closing the bug.
