### PR TITLE
Issue 11834: std.net.curl abuses ddoc params section and causes ddoc warnings

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3418,15 +3418,12 @@ struct SMTP
         /**
          * The event handler that gets called to inform of upload/download progress.
          *
-         * Params:
-         * dlTotal = total bytes to download
-         * dlNow = currently downloaded bytes
-         * ulTotal = total bytes to upload
-         * ulNow = currently uploaded bytes
+         * Callback_parameters:
+         * $(CALLBACK_PARAMS)
          *
-         * Returns:
-         * Return 0 from the callback to signal success, return non-zero to abort
-         *          transfer
+         * Callback_returns:
+         * Return 0 from the callback to signal success, return non-zero to
+         * abort transfer.
          */
         @property void onProgress(int delegate(size_t dlTotal, size_t dlNow,
                                                size_t ulTotal, size_t ulNow) callback);


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=11834

Basically, the `Params:` section in `onProgress`'s ddoc was abused to document parameters that will be passed to the callback registered by `onProgress`. This confuses ddoc to spew warning messages, and also produces deceptive documentation that looks like those parameters are being passed to `onProgress`, whereas they are actually what _will_ be passed _by_ `onProgress` to `callback`.
