### PR TITLE
Fix reduce regression 13304.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -865,10 +865,11 @@ private template ReduceSeedType(E)
     {
         E e = E.init;
         static alias ReduceSeedType = Unqual!(typeof(fun(e, e)));
-        static assert(is(typeof({
-            ReduceSeedType s = e;
-            s = fun(s, e);
-        })), algoFormat("Unable to deduce an acceptable seed type for %s with element type %s.", fullyQualifiedName!fun, E.stringof));
+
+        //Check the Seed type is useable.
+        ReduceSeedType s = ReduceSeedType.init;
+        static assert(is(typeof({ReduceSeedType s = e;})) && is(typeof(s = fun(s, e))),
+            algoFormat("Unable to deduce an acceptable seed type for %s with element type %s.", fullyQualifiedName!fun, E.stringof));
     }
 }
 
@@ -1107,6 +1108,12 @@ unittest //12569
     //"Incompatable function/seed/element: all(alias pred = "a")/int/dchar"
     static assert(!is(typeof(reduce!all(1, "hello"))));
     static assert(!is(typeof(reduce!(all, all)(tuple(1, 1), "hello"))));
+}
+
+unittest //13304
+{
+    int[] data;
+    static assert(is(typeof(reduce!((a, b)=>a+b)(data))));
 }
 
 // sum


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13304

Also cover test case 10709.
https://issues.dlang.org/show_bug.cgi?id=10709

Truth be told, I'm not yet entirely sure _what_ went wrong, and why this fixes the issue. It _seems_ that the compiler was trying to actually CTFE-evaluate the `fun` call in `s = fun(s, e);`, whereas the `is(typeof(s = fun(s, e))` merely checks the semantics are correct.

I'm still trying to reduce the actual cause, but in the mean time, this (should) fix a regression.
