### PR TITLE
COFF support for Win32

### DIFF
--- a/etc/c/zlib/win64.mak
+++ b/etc/c/zlib/win64.mak
@@ -1,5 +1,6 @@
 # Makefile for zlib64
 
+MODEL=64
 VCDIR=\Program Files (x86)\Microsoft Visual Studio 10.0\VC
 
 CC="$(VCDIR)\bin\amd64\cl"
@@ -78,14 +79,14 @@ example.obj: example.c zlib.h zconf.h
 minigzip.obj: minigzip.c zlib.h zconf.h
 	$(CC) /c $(cvarsdll) $(CFLAGS) $*.c
 
-zlib64.lib: $(OBJS)
-	$(LIB) $(LIBFLAGS) /OUT:zlib64.lib $(OBJS)
+zlib$(MODEL).lib: $(OBJS)
+	$(LIB) $(LIBFLAGS) /OUT:zlib$(MODEL).lib $(OBJS)
 
-example.exe: example.obj zlib64.lib
-	$(LD) $(LDFLAGS) example.obj zlib64.lib
+example.exe: example.obj zlib$(MODEL).lib
+	$(LD) $(LDFLAGS) example.obj zlib$(MODEL).lib
 
-minigzip.exe: minigzip.obj zlib64.lib
-	$(LD) $(LDFLAGS) minigzip.obj zlib64.lib
+minigzip.exe: minigzip.obj zlib$(MODEL).lib
+	$(LD) $(LDFLAGS) minigzip.obj zlib$(MODEL).lib
 
 test: example.exe minigzip.exe
 	example

--- a/std/conv.d
+++ b/std/conv.d
@@ -2891,7 +2891,7 @@ unittest
     ld = parse!real(s2);
     assert(s2.empty);
     x = *cast(longdouble *)&ld;
-    version (Win64)
+    version (CRuntime_Microsoft)
         ld1 = 0x1.FFFFFFFFFFFFFFFEp-16382L; // strtold currently mapped to strtod
     else version (Android)
         ld1 = 0x1.FFFFFFFFFFFFFFFEp-16382L; // strtold currently mapped to strtod

--- a/std/format.d
+++ b/std/format.d
@@ -29,7 +29,7 @@ import std.algorithm, std.ascii, std.conv,
     std.exception, std.range,
     std.system, std.traits, std.typetuple,
     std.utf;
-version (Win64) {
+version (CRuntime_Microsoft) {
     import std.math : isnan, isInfinity;
 }
 version(unittest) {
@@ -41,7 +41,7 @@ version(unittest) {
     import std.string;
 }
 
-version (Win32) version (DigitalMars)
+version(CRuntime_DigitalMars)
 {
     version = DigitalMarsC;
 }
@@ -1598,7 +1598,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     enforceFmt(std.algorithm.find("fgFGaAeEs", fs.spec).length,
         "floating");
 
-    version (Win64)
+    version (CRuntime_Microsoft)
     {
         double tval = val; // convert early to get "inf" in case of overflow
         string s;
@@ -3421,7 +3421,7 @@ unittest
         assert(stream.data == "1.67 -0XA.3D70A3D70A3D8P-3 nan",
                 stream.data);
     }
-    else version (Win64)
+    else version (CRuntime_Microsoft)
     {
         assert(stream.data == "1.67 -0X1.47AE14P+0 nan",
                 stream.data);
@@ -3458,7 +3458,7 @@ unittest
 
     formattedWrite(stream, "%a %A", 1.32, 6.78f);
     //formattedWrite(stream, "%x %X", 1.32);
-    version (Win64)
+    version (CRuntime_Microsoft)
         assert(stream.data == "0x1.51eb85p+0 0X1.B1EB86P+2");
     else version (Android)
     {
@@ -5147,7 +5147,7 @@ void doFormat(void delegate(dchar) putc, TypeInfo[] arguments, va_list argptr)
                 {
                     sl = fbuf.length;
                     int n;
-                    version (Win64)
+                    version (CRuntime_Microsoft)
                     {
                         if (isnan(v)) // snprintf writes 1.#QNAN
                             n = snprintf(fbuf.ptr, sl, "nan");
@@ -5970,7 +5970,7 @@ unittest
     //else
     version (MinGW)
         assert(s == "1.67 -0XA.3D70A3D70A3D8P-3 nan", s);
-    else version (Win64)
+    else version (CRuntime_Microsoft)
         assert(s == "1.67 -0X1.47AE14P+0 nan", s);
     else version (Android)
     {

--- a/std/process.d
+++ b/std/process.d
@@ -111,7 +111,7 @@ import std.internal.processinit;
 
 // When the DMC runtime is used, we have to use some custom functions
 // to convert between Windows file handles and FILE*s.
-version (Win32) version (DigitalMars) version = DMC_RUNTIME;
+version (Win32) version (CRuntime_DigitalMars) version = DMC_RUNTIME;
 
 
 // Some of the following should be moved to druntime.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -26,18 +26,15 @@ import std.range;
 import std.traits : Unqual, isSomeChar, isAggregateType, isSomeString,
     isIntegral, isBoolean, ParameterTypeTuple;
 
-version (DigitalMars)
+version (CRuntime_Microsoft)
 {
-    version (Win32)
-    {
-        // Specific to the way Digital Mars C does stdio
-        version = DIGITAL_MARS_STDIO;
-        import std.c.stdio : __fhnd_info, FHND_WCHAR, FHND_TEXT;
-    }
-    else version (Win64)
-    {
-        version = MICROSOFT_STDIO;
-    }
+    version = MICROSOFT_STDIO;
+}
+else version (CRuntime_DigitalMars)
+{
+    // Specific to the way Digital Mars C does stdio
+    version = DIGITAL_MARS_STDIO;
+    import std.c.stdio : __fhnd_info, FHND_WCHAR, FHND_TEXT;
 }
 
 version (Posix)

--- a/win64.mak
+++ b/win64.mak
@@ -69,7 +69,7 @@ DOC=..\..\html\d\phobos
 ## Location of druntime tree
 
 DRUNTIME=..\druntime
-DRUNTIMELIB=$(DRUNTIME)\lib\druntime64.lib
+DRUNTIMELIB=$(DRUNTIME)\lib\druntime$(MODEL).lib
 
 ## Zlib library
 
@@ -458,7 +458,7 @@ html : $(DOCS)
 
 $(ZLIB): $(SRC_ZLIB)
 	cd etc\c\zlib
-	$(MAKE) -f win$(MODEL).mak zlib$(MODEL).lib "CC=\$(CC)"\"" "LIB=\$(AR)"\"" "VCDIR=$(VCDIR)"
+	$(MAKE) -f win64.mak MODEL=$(MODEL) zlib$(MODEL).lib "CC=\$(CC)"\"" "LIB=\$(AR)"\"" "VCDIR=$(VCDIR)"
 	cd ..\..\..
 
 ################## DOCS ####################################
@@ -801,7 +801,7 @@ phobos.zip : zip
 
 clean:
 	cd etc\c\zlib
-	$(MAKE) -f win$(MODEL).mak clean
+	$(MAKE) -f win64.mak clean
 	cd ..\..\..
 	del $(DOCS)
 	del $(UNITTEST_OBJS) unittest.obj unittest.exe


### PR DESCRIPTION
These are the changes for COFF support for Win32. It uses CRuntime_DigitalMars/CRuntime_Microsoft instead of Win32/Win64 where appropriate. Most of the exisiting adhoc version identifiers are not yet replaced.

compile from the VS command line with

```
make -f win64.mak MODEL=32mscoff "CC=\"%VCINSTALLDIR%\bin\cl.exe\"" "AR=\"%VCINSTALLDIR%\bin\lib.exe\""
```

For building and running unittests, an appropriate curl.lib needs to be generated.
