### PR TITLE
Fix Issue 12913 - DList.removeAny: documentation is inconsistent with behavior

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -362,7 +362,7 @@ $(D r) and $(D m) is the length of $(D stuff).
 /+ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ +/
 
 /**
-Picks one value from the front of the container, removes it from the
+Picks one value from the back of the container, removes it from the
 container, and returns it.
 
 Precondition: $(D !empty)


### PR DESCRIPTION
Was agreed to change documentation instead of implementation. See #2301.

https://issues.dlang.org/show_bug.cgi?id=12913
