### PR TITLE
Fix issue #13352 - Only perform Algebraic arithmetic with allowed types.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -931,10 +931,10 @@ public:
 
     private VariantN opArithmetic(T, string op)(T other)
     {
-        VariantN result;
         static if (isInstanceOf!(VariantN, T))
         {
-            string tryUseType(string tp) {
+            string tryUseType(string tp)
+            {
                 import std.string : format;
                 return q{
                     static if (allowed!%1$s && T.allowed!%1$s)
@@ -942,6 +942,7 @@ public:
                             return VariantN(get!%1$s %2$s other.get!%1$s);
                 }.format(tp, op);
             }
+
             mixin(tryUseType("uint"));
             mixin(tryUseType("int"));
             mixin(tryUseType("ulong"));


### PR DESCRIPTION
Adds a static check allowed!T before trying any particular numeric type. Also checks for an exact type match in case of a raw (non-Variant) operand and prefers that to one of the fixed numeric types. Finally, it loosens the restriction for opArithmetic to only work for equal Variant types.

https://issues.dlang.org/show_bug.cgi?id=13352
