### PR TITLE
[bugfix] Initialize uncertain field value

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1872,6 +1872,7 @@ time and computes all matches of length 1.
  */
     this(Range s, Range t, F lambda) {
         enforce(lambda > 0);
+        this.gram = 0;
         this.lambda = lambda;
         this.lambda2 = lambda * lambda; // for efficiency only
 


### PR DESCRIPTION
Compiler does not guarantee the initial value of void-initialized field. So this is definitely a bug in Phobos code.
