### PR TITLE
[Trivial] Replace usage of enforceEx with enforce

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -344,7 +344,7 @@ private:
  */
 @property Tid ownerTid()
 {
-    enforceEx!TidMissingException(owner.mbox !is null, "Error: Thread has no owner thread.");
+    enforce!TidMissingException(owner.mbox !is null, "Error: Thread has no owner thread.");
     return owner;
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -1375,7 +1375,7 @@ T toImpl(T, S)(S value)
     static if (isStaticArray!T)
     {
         auto res = to!(E[])(value);
-        enforceEx!ConvException(T.length == res.length,
+        enforce!ConvException(T.length == res.length,
             format("Length mismatch when converting to static array: %s vs %s", T.length, res.length));
         return res[0 .. T.length];
     }
@@ -4886,10 +4886,10 @@ unittest
 
 private void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment, string typeName)
 {
-    enforceEx!ConvException(chunk.length >= typeSize,
+    enforce!ConvException(chunk.length >= typeSize,
         format("emplace: Chunk size too small: %s < %s size = %s",
         chunk.length, typeName, typeSize));
-    enforceEx!ConvException((cast(size_t) chunk.ptr) % typeAlignment == 0,
+    enforce!ConvException((cast(size_t) chunk.ptr) % typeAlignment == 0,
         format("emplace: Misaligned memory block (0x%X): it must be %s-byte aligned for type %s",
         chunk.ptr, typeAlignment, typeName));
 }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27347,7 +27347,7 @@ public:
     this(Duration utcOffset, string stdName = "") @safe immutable pure
     {
         //FIXME This probably needs to be changed to something like (-12 - 13).
-        enforceEx!DateTimeException(abs(utcOffset) < dur!"minutes"(1440),
+        enforce!DateTimeException(abs(utcOffset) < dur!"minutes"(1440),
                                     "Offset from UTC must be within range (-24:00 - 24:00).");
 
         super("", stdName, "");
@@ -27403,7 +27403,7 @@ private:
     static string toISOString(Duration utcOffset) @safe pure
     {
         immutable absOffset = abs(utcOffset);
-        enforceEx!DateTimeException(absOffset < dur!"minutes"(1440),
+        enforce!DateTimeException(absOffset < dur!"minutes"(1440),
                                     "Offset from UTC must be within range (-24:00 - 24:00).");
         int hours;
         int minutes;

--- a/std/format.d
+++ b/std/format.d
@@ -3287,7 +3287,7 @@ void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __F
     FormatSpec!char f;
     auto w = appender!string();
     formatValue(w, val, f);
-    enforceEx!AssertError(
+    enforce!AssertError(
             w.data == expected,
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
@@ -3297,7 +3297,7 @@ void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, str
 {
     auto w = appender!string();
     formattedWrite(w, fmt, val);
-    enforceEx!AssertError(
+    enforce!AssertError(
             w.data == expected,
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
@@ -3312,7 +3312,7 @@ void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = _
     {
         if(w.data == cur) return;
     }
-    enforceEx!AssertError(
+    enforce!AssertError(
             false,
             text("expected one of `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
@@ -3326,7 +3326,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     {
         if(w.data == cur) return;
     }
-    enforceEx!AssertError(
+    enforce!AssertError(
             false,
             text("expected one of `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
@@ -3916,7 +3916,7 @@ void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = _
     formattedWrite(w, fmt, val);
 
     auto input = w.data;
-    enforceEx!AssertError(
+    enforce!AssertError(
             input == formatted,
             input, fn, ln);
 
@@ -3944,7 +3944,7 @@ void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = _
         //    assert(aa2.values[i] == aa2[key]);
         return;
     }
-    enforceEx!AssertError(
+    enforce!AssertError(
             val == val2,
             input, fn, ln);
 }
@@ -3961,7 +3961,7 @@ void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn =
     {
         if(input == cur) return;
     }
-    enforceEx!AssertError(
+    enforce!AssertError(
             false,
             input,
             fn,
@@ -3991,7 +3991,7 @@ void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn =
         //    assert(aa2.values[i] == aa2[key]);
         return;
     }
-    enforceEx!AssertError(
+    enforce!AssertError(
             val == val2,
             input, fn, ln);
 }

--- a/std/json.d
+++ b/std/json.d
@@ -118,7 +118,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.STRING).
     @property inout(string) str() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.STRING,
+        enforce!JSONException(type == JSON_TYPE.STRING,
                                 "JSONValue is not a string");
         return store.str;
     }
@@ -133,7 +133,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.INTEGER).
     @property inout(long) integer() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.INTEGER,
+        enforce!JSONException(type == JSON_TYPE.INTEGER,
                                 "JSONValue is not an integer");
         return store.integer;
     }
@@ -148,7 +148,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.UINTEGER).
     @property inout(ulong) uinteger() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.UINTEGER,
+        enforce!JSONException(type == JSON_TYPE.UINTEGER,
                                 "JSONValue is not an unsigned integer");
         return store.uinteger;
     }
@@ -163,7 +163,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.FLOAT).
     @property inout(double) floating() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.FLOAT,
+        enforce!JSONException(type == JSON_TYPE.FLOAT,
                                 "JSONValue is not a floating type");
         return store.floating;
     }
@@ -178,7 +178,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.OBJECT).
     @property ref inout(JSONValue[string]) object() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSON_TYPE.OBJECT,
                                 "JSONValue is not an object");
         return store.object;
     }
@@ -193,7 +193,7 @@ struct JSONValue
     /// Throws $(D JSONException) for read access if $(D type) is not $(D JSON_TYPE.ARRAY).
     @property ref inout(JSONValue[]) array() inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.ARRAY,
+        enforce!JSONException(type == JSON_TYPE.ARRAY,
                                 "JSONValue is not an array");
         return store.array;
     }
@@ -333,7 +333,7 @@ struct JSONValue
     /// Throws $(D JSONException) if $(D type) is not $(D JSON_TYPE.ARRAY).
     ref inout(JSONValue) opIndex(size_t i) inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.ARRAY,
+        enforce!JSONException(type == JSON_TYPE.ARRAY,
                                 "JSONValue is not an array");
         return store.array[i];
     }
@@ -342,15 +342,15 @@ struct JSONValue
     /// Throws $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT).
     ref inout(JSONValue) opIndex(string k) inout
     {
-        enforceEx!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSON_TYPE.OBJECT,
                                 "JSONValue is not an object");
-        return *enforceEx!JSONException(k in store.object,
+        return *enforce!JSONException(k in store.object,
                                         "Key not found: " ~ k);
     }
 
     auto opBinaryRight(string op : "in")(string k) const
     {
-        enforceEx!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSON_TYPE.OBJECT,
                                 "JSONValue is not an object");
         return k in store.object;
     }
@@ -358,7 +358,7 @@ struct JSONValue
     /// Implements the foreach $(D opApply) interface for json arrays.
     int opApply(int delegate(size_t index, ref JSONValue) dg)
     {
-        enforceEx!JSONException(type == JSON_TYPE.ARRAY,
+        enforce!JSONException(type == JSON_TYPE.ARRAY,
                                 "JSONValue is not an array");
         int result;
 
@@ -375,7 +375,7 @@ struct JSONValue
     /// Implements the foreach $(D opApply) interface for json objects.
     int opApply(int delegate(string key, ref JSONValue) dg)
     {
-        enforceEx!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSON_TYPE.OBJECT,
                                 "JSONValue is not an object");
         int result;
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -581,11 +581,11 @@ void del(Conn = AutoProtocol)(const(char)[] url, Conn conn = Conn())
         auto trimmed = url.findSplitAfter("ftp://")[1];
         auto t = trimmed.findSplitAfter("/");
         enum minDomainNameLength = 3;
-        enforceEx!CurlException(t[0].length > minDomainNameLength,
+        enforce!CurlException(t[0].length > minDomainNameLength,
                                 text("Invalid FTP URL for delete ", url));
         conn.url = t[0];
 
-        enforceEx!CurlException(!t[1].empty,
+        enforce!CurlException(!t[1].empty,
                                 text("No filename specified to delete for URL ", url));
         conn.addCommand("DELE " ~ t[1]);
         conn.perform();
@@ -807,7 +807,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     };
     client.onReceiveStatusLine = (HTTP.StatusLine l) { statusLine = l; };
     client.perform();
-    enforceEx!CurlException(statusLine.code / 100 == 2,
+    enforce!CurlException(statusLine.code / 100 == 2,
                             format("HTTP request returned status code %s",
                                    statusLine.code));
 
@@ -887,11 +887,11 @@ private auto _decodeContent(T)(ubyte[] content, string encoding)
 
         // The content has to be re-encoded to utf8
         auto scheme = EncodingScheme.create(encoding);
-        enforceEx!CurlException(scheme !is null,
+        enforce!CurlException(scheme !is null,
                                 format("Unknown encoding '%s'", encoding));
 
         auto strInfo = decodeString(content, scheme);
-        enforceEx!CurlException(strInfo[0] != size_t.max,
+        enforce!CurlException(strInfo[0] != size_t.max,
                                 format("Invalid encoding sequence for encoding '%s'",
                                        encoding));
 
@@ -984,13 +984,13 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
 
         @property @safe Char[] front()
         {
-            enforceEx!CurlException(currentValid, "Cannot call front() on empty range");
+            enforce!CurlException(currentValid, "Cannot call front() on empty range");
             return current;
         }
 
         void popFront()
         {
-            enforceEx!CurlException(currentValid, "Cannot call popFront() on empty range");
+            enforce!CurlException(currentValid, "Cannot call popFront() on empty range");
             if (lines.empty)
             {
                 currentValid = false;
@@ -1594,7 +1594,7 @@ private void _asyncDuplicateConnection(Conn, PostData)
     }
     else
     {
-        enforceEx!CurlException(postData is null,
+        enforce!CurlException(postData is null,
                                 "Cannot put ftp data using byLineAsync()");
         tid.send(cast(ulong)connDup.handle.handle);
         tid.send(HTTP.Method.undefined);
@@ -1979,7 +1979,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
         dchar dc = scheme.safeDecode(basesrc);
         if (dc == INVALID_SEQUENCE)
         {
-            enforceEx!CurlException(len != 4, "Invalid code sequence");
+            enforce!CurlException(len != 4, "Invalid code sequence");
             return false;
         }
         dst ~= dc;
@@ -3256,7 +3256,7 @@ struct SMTP
         }
         else
         {
-            enforceEx!CurlException(lowered.startsWith("smtp://"),
+            enforce!CurlException(lowered.startsWith("smtp://"),
                                     "The url must be for the smtp protocol.");
         }
         p.curl.set(CurlOption.url, url);
@@ -3528,7 +3528,7 @@ struct Curl
     shared static this()
     {
         // initialize early to prevent thread races
-        enforceEx!CurlException(!curl_global_init(CurlGlobal.all),
+        enforce!CurlException(!curl_global_init(CurlGlobal.all),
                                 "Couldn't initialize libcurl");
     }
 
@@ -3561,9 +3561,9 @@ struct Curl
     */
     void initialize()
     {
-        enforceEx!CurlException(!handle, "Curl instance already initialized");
+        enforce!CurlException(!handle, "Curl instance already initialized");
         handle = curl_easy_init();
-        enforceEx!CurlException(handle, "Curl instance couldn't be initialized");
+        enforce!CurlException(handle, "Curl instance couldn't be initialized");
         stopped = false;
         set(CurlOption.nosignal, 1);
     }
@@ -3633,10 +3633,10 @@ struct Curl
 
     private void _check(CurlCode code)
     {
-        enforceEx!CurlTimeoutException(code != CurlError.operation_timedout,
+        enforce!CurlTimeoutException(code != CurlError.operation_timedout,
                                        errorString(code));
 
-        enforceEx!CurlException(code == CurlError.ok,
+        enforce!CurlException(code == CurlError.ok,
                                 errorString(code));
     }
 
@@ -3652,7 +3652,7 @@ struct Curl
     private void throwOnStopped(string message = null)
     {
         auto def = "Curl instance called after being cleaned up";
-        enforceEx!CurlException(!stopped,
+        enforce!CurlException(!stopped,
                                 message == null ? def : message);
     }
 
@@ -4103,7 +4103,7 @@ private struct Pool(Data)
 
     @safe Data pop()
     {
-        enforceEx!Exception(root != null, "pop() called on empty pool");
+        enforce!Exception(root != null, "pop() called on empty pool");
         auto d = root.data;
         auto n = root.next;
         root.next = freeList;
@@ -4250,7 +4250,7 @@ private static size_t _receiveAsyncLines(Terminator, Unit)
                 // Could not decode an entire line. Save
                 // bytes left in data for next call to
                 // onReceive. Can be up to a max of 4 bytes.
-                enforceEx!CurlException(data.length <= 4,
+                enforce!CurlException(data.length <= 4,
                                         format(
                                         "Too many bytes left not decoded %s"~
                                         " > 4. Maybe the charset specified in"~

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -1236,7 +1236,7 @@ public:
         DWORD   cchRequired =   ExpandEnvironmentStringsW(srcTmp, null, 0);
         wchar[]  newValue   =   new wchar[cchRequired];
 
-        immutable DWORD count = enforceEx!Win32Exception(
+        immutable DWORD count = enforce!Win32Exception(
             ExpandEnvironmentStringsW(srcTmp, newValue.ptr, to!DWORD(newValue.length)),
             "Failed to expand environment variables");
 


### PR DESCRIPTION
The only place where it can't be replaced is this alias in std.format:

```
private alias enforceFmt = enforceEx!FormatException;
```
