### PR TITLE
std.typecons.Proxy needs to import std.traits.isArray

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4117,6 +4117,8 @@ mixin template Proxy(alias a)
         }
     }
 
+    import std.traits : isArray;
+
     static if (isArray!(typeof(a)))
     {
         auto opDollar() const { return a.length; }


### PR DESCRIPTION
... because it is a mixin template which is evaluated at the place of
instantiation, where isArray is likely not available.

See here:
http://forum.dlang.org/thread/olvhztchmyxbedqmfanm@forum.dlang.org
