### PR TITLE
Tweak enum tables in std/utf.d

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -1071,7 +1071,7 @@ private dchar decodeImpl(bool canIndex, S)(auto ref S str, ref size_t index)
 
     /* Dchar bitmask for different numbers of UTF-8 code units.
      */
-    enum bitMask = [(1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1];
+    alias bitMask = TypeTuple!((1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1);
 
     static if (is(S : const char[]))
         auto pstr = str.ptr + index;
@@ -3192,7 +3192,7 @@ auto ref byDchar(R)(R r)
 
                     /* Dchar bitmask for different numbers of UTF-8 code units.
                      */
-                    enum uint[4] bitMask = [(1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1];
+                    alias bitMask = TypeTuple!((1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1);
 
                     foreach (i; TypeTuple!(1, 2, 3))
                     {


### PR DESCRIPTION
This changes the enum tables into TypeTuples.
- It avoids easy breakage in case the code is changed and uses run-time accesses, as a TT _can't_ be run-time indexed.
- It avoids reader confusion (myself, Andrei, and others have been suspicious about that line of code): It relies on an optimization so that no allocation occurs. Only once you realize that, you understand why no allocation occurs. With a TT, there is no allocation. End of story.

So I think this is better style overall, and we should adopt it.

Note: I changed two places: One used inference, the other used explicit `uint`. I opted to use inference in both spots, so as to avoid un-necessary differences in the code. And it makes no difference in the end, so might as well keep copy pasted code the same.
