### PR TITLE
Make std.file.timeLastModified(in char[]) safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -830,13 +830,8 @@ SysTime timeLastModified(in char[] name) @safe
 {
     version(Windows)
     {
-        static auto trustedVoidInit() @trusted
-        {
-            SysTime ret = void;
-            return ret;
-        }
-        SysTime dummy = trustedVoidInit();
-        SysTime ftm = trustedVoidInit();
+        SysTime dummy;
+        SysTime ftm;
 
         getTimesWin(name, dummy, dummy, ftm);
 


### PR DESCRIPTION
On Windows systems, it contains the following unsafe operation:
- (Fix) use of void initializer for `SysTime`

On Posix systems, it contains the following unsafe operations but we can verify they can be trusted.
- use of `core.sys.posix.sys.stat.stat`
- use of `std.internal.cstring.tempCString` and `tempCString.Res.~this`
- taking an address of a local variable (`statbuf`)

Edit: I missed void initializer for `SysTime`.
I define `trustedVoidInit` to wrap it but I'm not sure it does not affect to the performance (void initializer is used for performance).
