### PR TITLE
Fix docs for std.functional.partial

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -321,7 +321,8 @@ template not(alias pred)
 }
 
 /**
-Partially evaluates $(D fun) by tying its first argument to a particular value.
+$(LINK2 http://en.wikipedia.org/wiki/Partial_application, Partially 
+applies) $(D_PARAM fun) by tying its first argument to $(D_PARAM arg).
 
 Example:
 


### PR DESCRIPTION
- Change `Partially evaluates` to `Partially applies`. ([Partial evaluation](http://en.wikipedia.org/wiki/Partial_evaluation) is for optimization, whereas here we're just binding a function argument).
- Add link to Wikipedia: http://en.wikipedia.org/wiki/Partial_application
