### PR TITLE
Prevent definition of non-disabled default constructors in template structs

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -541,9 +541,9 @@ struct Task(alias fun, Args...)
         enforce(this.pool !is null, "Job not submitted yet.");
     }
 
-    private this(Args args)
+    static if(Args.length > 0)
     {
-        static if(args.length > 0)
+        private this(Args args)
         {
             _args = args;
         }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -521,9 +521,12 @@ template Tuple(Specs...)
         /**
          * Constructor taking one value for each field.
          */
-        this(Types values)
+        static if (Types.length > 0)
         {
-            field[] = values[];
+            this(Types values)
+            {
+                field[] = values[];
+            }
         }
 
         /**


### PR DESCRIPTION
This is necessary for: https://github.com/D-Programming-Language/dmd/pull/3902
