### PR TITLE
fix Issue 13380 - Conflict with std.typecons.Identity and std.traits.Identity

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -700,8 +700,6 @@ private enum bool isPrintable(T) =
         formattedWrite(w, "%s", T.init);
     }));
 
-private alias Identity(alias T) = T;
-
 /**
     Return a copy of a Tuple with its fields in reverse order.
  */


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13380

Just let std.typecons use std.traits' one.
