### PR TITLE
Fix regression 13393: cartesianProduct + joiner = runtime assertion failure

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -13265,8 +13265,7 @@ unittest
 unittest
 {
     // Issue 13393
-    import std.string : format;
-    auto result = format("%s", [cartesianProduct([0],[0],[0])].joiner);
+    assert(!cartesianProduct([0],[0],[0]).save.empty);
 }
 
 /// ditto


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13393

Caused by `.save` failing to save entire range state (it's missing `.empty`), causing inconsistency in `.save`d objects.
