### PR TITLE
Issue 8425 - Do not assume __vector(float[4]) is a valid type on all targets

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5449,9 +5449,12 @@ enum bool isSIMDVector(T) = is(T : __vector(V[N]), V, size_t N);
 
 unittest
 {
-    alias __vector(float[4]) SimdVec;
-    static assert(isSIMDVector!(__vector(float[4])));
-    static assert(isSIMDVector!SimdVec);
+    static if (is(__vector(float[4])))
+    {
+        alias __vector(float[4]) SimdVec;
+        static assert(isSIMDVector!(__vector(float[4])));
+        static assert(isSIMDVector!SimdVec);
+    }
     static assert(!isSIMDVector!uint);
     static assert(!isSIMDVector!(float[4]));
 }


### PR DESCRIPTION
Required for https://github.com/D-Programming-Language/dmd/pull/2879

https://d.puremagic.com/issues/show_bug.cgi?id=8425
