### PR TITLE
fix Issue 13441 - joiner asserts with only(x) separator

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -3688,6 +3688,12 @@ unittest
     ], "+-");
 
     assert(equal(u, "+-abc+-+-def+-"));
+
+    // Issue 13441: only(x) as separator
+    string[][] lines = [null];
+    lines
+        .joiner(only("b"))
+        .array();
 }
 
 unittest

--- a/std/range.d
+++ b/std/range.d
@@ -7409,6 +7409,7 @@ private struct OnlyResult(T, size_t arity)
     private this(Values...)(auto ref Values values)
     {
         this.data = [values];
+        this.backIndex = arity;
     }
 
     bool empty() @property
@@ -7487,7 +7488,7 @@ private struct OnlyResult(T, size_t arity)
     }
 
     private size_t frontIndex = 0;
-    private size_t backIndex = arity;
+    private size_t backIndex = 0;
 
     // @@@BUG@@@ 10643
     version(none)
@@ -7512,6 +7513,12 @@ private struct OnlyResult(T, size_t arity : 1)
     void popFront() { assert(!_empty); _empty = true; }
     void popBack() { assert(!_empty); _empty = true; }
     alias opDollar = length;
+
+    private this()(auto ref T value)
+    {
+        this._value = value;
+        this._empty = false;
+    }
 
     T opIndex(size_t i)
     {
@@ -7543,7 +7550,7 @@ private struct OnlyResult(T, size_t arity : 1)
     }
 
     private Unqual!T _value;
-    private bool _empty = false;
+    private bool _empty = true;
 }
 
 // Specialize for the empty range
@@ -7685,6 +7692,7 @@ unittest
     assert(imm.front == 1);
     assert(imm.back == 1);
     assert(!imm.empty);
+    assert(imm.init.empty); // Issue 13441
     assert(imm.length == 1);
     assert(equal(imm, imm[]));
     assert(equal(imm, imm[0..1]));
@@ -7769,6 +7777,8 @@ unittest
     auto imm = only!(immutable int, immutable int)(42, 24);
     alias Imm = typeof(imm);
     static assert(is(ElementType!Imm == immutable(int)));
+    assert(!imm.empty);
+    assert(imm.init.empty); // Issue 13441
     assert(imm.front == 42);
     imm.popFront();
     assert(imm.front == 24);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13441

This patch could use review. Is there a better way to do this? Can we expect `_currentSep.init.empty` to be a valid expression that can be evaluated at compile-time?

Ping @quickfur 
