### PR TITLE
fix Issue 13446 - Can't use executeShell/escapeShellFileName to redirect to file whose name starts with &

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2589,7 +2589,19 @@ string escapeShellFileName(in char[] fileName) @trusted pure nothrow
     // preparation - see below.
 
     version (Windows)
+    {
+        // If a file starts with &, it can cause cmd.exe to misinterpret
+        // the file name as the stream redirection syntax:
+        //     command > "&foo.txt"
+        // gets interpreted as
+        //     command >&foo.txt
+        // Prepend .\ to disambiguate.
+
+        if (fileName.length && fileName[0] == '&')
+            return cast(string)(`".\` ~ fileName ~ '"');
+
         return cast(string)('"' ~ fileName ~ '"');
+    }
     else
         return escapePosixArgument(fileName);
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13446
