### PR TITLE
Mark std.file.isDir and its unittest as safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1116,7 +1116,7 @@ assert(!"/etc/fonts/fonts.conf".isDir);
 assert("/usr/share/include".isDir);
 --------------------
   +/
-@property bool isDir(in char[] name)
+@property bool isDir(in char[] name) @safe
 {
     version(Windows)
     {
@@ -1128,7 +1128,7 @@ assert("/usr/share/include".isDir);
     }
 }
 
-unittest
+@safe unittest
 {
     version(Windows)
     {


### PR DESCRIPTION
They do not contain any unsafe operations.
