### PR TITLE
std/regex/package: Fix unmatched --- in DDoc comment

### DIFF
--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -284,7 +284,7 @@ import std.exception, std.traits, std.range;
     assert(nc.equal(["name", "var"]));
     assert(nc[0] == "name");
     assert(nc[1..$].equal(["var"]));
-
+    ----
 +/
 public alias Regex(Char) = std.regex.internal.ir.Regex!(Char);
 


### PR DESCRIPTION
Compiler complains when building documentation:

```
std\regex\package.d(289): Error: template std.regex.Regex(Char) unmatched --- in DDoc comment
```
