### PR TITLE
Add @nogc unittest for std.range.retro.

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -2164,6 +2164,15 @@ unittest
     assert(equal(r, [3L, 2L, 1L]));
 }
 
+// Issue 12662
+@nogc unittest
+{
+    int[3] src = [1,2,3];
+    int[] data = src[];
+    foreach_reverse (x; data) {}
+    foreach (x; data.retro) {}
+}
+
 
 /**
 Iterates range $(D r) with stride $(D n). If the range is a


### PR DESCRIPTION
To prevent regression of [issue 12662](https://issues.dlang.org/show_bug.cgi?id=12662).
