### PR TITLE
Update zip documentation

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -5095,7 +5095,7 @@ unittest
 {
     int[] a = [ 1, 2, 3 ];
     string[] b = [ "a", "b", "c" ];
-    sort!("a[0] > b[0]")(zip(a, b));
+    sort!((c, d) => c[0] > d[0])(zip(a, b));
     assert(a == [ 3, 2, 1 ]);
     assert(b == [ "c", "b", "a" ]);
 }


### PR DESCRIPTION
The example of sorting a zipped range was very confusing as it used a string literal sorting predicate, requiring use of "a" and "b" which were already being used as the names of the two ranges being zipped.  Updated the sorting predicate to use a lambda with parameters "c" and "d".
