### PR TITLE
Use new cartesianProduct implementation for 2-argument case as well.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -13687,7 +13687,8 @@ unittest
     assert(canFind(N4, tuple(10, 31, 7, 12)));
 }
 
-/// Issue 9878
+// Issue 9878
+///
 unittest
 {
     auto A = [ 1, 2, 3 ];


### PR DESCRIPTION
The original implementation will now only be used when one or both the ranges is either non-forward or infinite. The new implementation is also more attribute-friendly (works with pure, nothrow, @nogc, @safe), so this also fixes [issue 13091](https://issues.dlang.org/show_bug.cgi?id=13091).
