### PR TITLE
Fix wrong "Orphaned format specifier" error message.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -455,7 +455,7 @@ uint formattedWrite(Writer, Char, A...)(Writer w, in Char[] fmt, A args)
         {
             // leftover spec?
             enforceFmt(fmt.length == 0,
-                text("Orphan format specifier: %", fmt));
+                text("Orphan format specifier: %", spec.spec));
             break;
         }
         if (spec.width == spec.DYNAMIC)


### PR DESCRIPTION
Print out the specifier, not the entire format string!

Fixes: https://issues.dlang.org/show_bug.cgi?id=11539
