### PR TITLE
std.traits: Fix missing ) in documentation of isSomeString

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5284,7 +5284,7 @@ Detect whether $(D T) is one of the built-in string types.
 The built-in string types are $(D Char[]), where $(D Char) is any of $(D char),
 $(D wchar) or $(D dchar), with or without qualifiers.
 
-Static arrays of characters (like $(D char[80]) are not considered
+Static arrays of characters (like $(D char[80])) are not considered
 built-in string types.
  */
 enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStaticArray!T;


### PR DESCRIPTION
Compiler did not emit a warning:
https://issues.dlang.org/show_bug.cgi?id=13502
