### PR TITLE
Revert pull request #2537 to fix git-head regression issue 13498

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -1986,15 +1986,16 @@ unittest
     Throws:
     $(D Exception) if the specified _base directory is not absolute.
 */
-inout(char)[] absolutePath(inout(char)[] path, lazy const(char)[] base = getcwd())
+string absolutePath(string path, lazy string base = getcwd())
     @safe pure
 {
     if (path.empty)  return null;
     if (isAbsolute(path))  return path;
-    const baseVar = base;
+    immutable baseVar = base;
     if (!isAbsolute(baseVar)) throw new Exception("Base directory must be absolute");
     return buildPath(baseVar, path);
 }
+
 
 unittest
 {
@@ -2020,13 +2021,7 @@ unittest
     assertThrown(absolutePath("bar", "foo"));
 }
 
-unittest
-{
-    // Issue 12083
-    char[] path = ".".dup;
-    auto abs = path.absolutePath;
-    assert(abs == getcwd() ~ dirSeparator ~ ".");
-}
+
 
 
 /** Translates $(D path) into a relative _path.


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13498

This reverts commit 875f2fe0314931ef86e597a3d87069c1b914c5bb, reversing
changes made to f5c7e97f2b4ee12e5e486da130ebf69483693bc5.

The changed absolutePath code essentially cannot work because the buildPath() result is not implicitly convertible to inout(char)[], but it was accidentally accepted by the regression 13498.
