### PR TITLE
Make std.file.chdir safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1474,8 +1474,7 @@ void chdir(in char[] pathname) @safe
         {
             return SetCurrentDirectoryW(path.tempCStringW());
         }
-        cenforce(trustedSetCurrentDirectoryW(pathname),
-                pathname);
+        cenforce(trustedSetCurrentDirectoryW(pathname), pathname);
     }
     else version(Posix)
     {
@@ -1483,8 +1482,7 @@ void chdir(in char[] pathname) @safe
         {
             return core.sys.posix.unistd.chdir(path.tempCString());
         }
-        cenforce(trustedChdir(pathname) == 0,
-                pathname);
+        cenforce(trustedChdir(pathname) == 0, pathname);
     }
 }
 


### PR DESCRIPTION
It contains the following unsafe operations but we can verify that they can be trusted.

On Windows systems:
- use of unsafe functions `core.sys.windows.windows.SetCurrentDirectoryW` and `std.internal.cstring.tempCStringW`.

On Posix systems:
- use of unsafe functions `core.sys.posix.unistd.chdir` and `std.internal.cstring.tempCString`

Additionally, I replaced `enforce` with `cenforce` to obtain error information on Windows systems.
