### PR TITLE
Make std.file.mkdir safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1489,7 +1489,8 @@ void chdir(in char[] pathname) @safe
 /****************************************************
 Make directory $(D pathname).
 
-Throws: $(D FileException) on error.
+Throws: $(D FileException) on Posix or $(D WindowsException) on Windows
+        if an error occured.
  */
 void mkdir(in char[] pathname) @safe
 {


### PR DESCRIPTION
It contains the following unsafe operations but we can verify that they can be trusted.

On Windows systems:
- use of unsafe functions `core.sys.windows.windows.CreateDirectoryW` and `std.internal.cstring.tempCStringW`

On Posix systems:
- use of unsafe functions `core.sys.posix.sys.stat.mkdir` and `std.internal.cstring.tempCString`

Additionally, I replaced `enforce` with `cenforce` to obtain error information on Windows systems.
