### PR TITLE
Fix compiler error in std/random.d

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -547,7 +547,7 @@ Parameter for the generator.
     enum UIntType min = 0;
     /// Largest generated value.
     enum UIntType max =
-        w == UIntType.sizeof * 8 ? UIntType.max : (1u << w) - 1;
+        w == UIntType.sizeof * 8 ? UIntType.max : (1uL << w) - 1;
     /// The default seed value.
     enum UIntType defaultSeed = 5489u;
 


### PR DESCRIPTION
Fix compiler error in std/random.d due to trying to shift unsigned int 32 bits.
