### PR TITLE
Fix the arguments for std.windows.syserror.wenforce

### DIFF
--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -14,6 +14,7 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module std.windows.syserror;
+import std.traits : isSomeString;
 
 version (StdDdoc)
 {


### PR DESCRIPTION
This request contains the following changes:
- The argument types of `wenforce` in `StdDdoc` version are different from `Windows` version: `wenforce(T, string, size_t)(T, lazy string)` and `wenforce(T)(T, lazy string, string, size_t)`.
  They should have the same argument types.
- The second argument type should be `lazy const(char)[]` instead of `lazy string` to be consistent with the argument type of `std.exception.enforce`.
