### PR TITLE
Mark std.uni.isRegionalIndicator as safe

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6249,7 +6249,7 @@ enum controlSwitch = `
 // TODO: redo the most of hangul stuff algorithmically in case of Graphemes too
 // kill unrolled switches
 
-private static bool isRegionalIndicator(dchar ch)
+private static bool isRegionalIndicator(dchar ch) @safe
 {
     return ch >= '\U0001F1E6' && ch <= '\U0001F1FF';
 }


### PR DESCRIPTION
It does not include any unsafe operations.
It is a preparation to fix issue 13560 (https://issues.dlang.org/show_bug.cgi?id=13560).
