### PR TITLE
Tweak cache constructor

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -871,6 +871,19 @@ unittest
     auto d = c[0 .. 1];
 }
 
+unittest
+{
+    static struct Range
+    {
+        bool initialized = false;
+        bool front() @property {return initialized = true;}
+        void popFront() {initialized = false;}
+        enum empty = false;
+    }
+    auto r = Range().cache();
+    assert(r.source.initialized == true);
+}
+
 private struct Cache(R, bool bidir)
 {
     import core.exception : RangeError;
@@ -895,9 +908,9 @@ private struct Cache(R, bool bidir)
         source = range;
         if (!range.empty)
         {
-             caches[0] = range.front;
+             caches[0] = source.front;
              static if (bidir)
-                 caches[1] = range.back;
+                 caches[1] = source.back;
         }
     }
 


### PR DESCRIPTION
Fixes a minor unfilled bug with cache: The constructor would evaluate the cache from the passed in `range`, rather than the copied internal `source`.

There is no difference 99% of the time, but for those few ranges with a lazy `front` with side effects, it can make a difference.
