### PR TITLE
(trivial) (ddoc) more descriptive std.concurrency doc.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -17,7 +17,7 @@
  * import std.stdio;
  * import std.concurrency;
  *
- * void spawnedFunc(Tid tid)
+ * void spawnedFunc(Tid ownerTid)
  * {
  *     // Receive a message from the owner thread.
  *     receive(
@@ -26,16 +26,16 @@
  *
  *     // Send a message back to the owner thread
  *     // indicating success.
- *     send(tid, true);
+ *     send(ownerTid, true);
  * }
  *
  * void main()
  * {
  *     // Start spawnedFunc in a new thread.
- *     auto tid = spawn(&spawnedFunc, thisTid);
+ *     auto childTid = spawn(&spawnedFunc, thisTid);
  *
  *     // Send the number 42 to this new thread.
- *     send(tid, 42);
+ *     send(childTid, 42);
  *
  *     // Receive the result code.
  *     auto wasSuccessful = receiveOnly!(bool);


### PR DESCRIPTION
`ownerTid`/`childTid` are more descriptive/obvious when reading than just `tid` here.
