### PR TITLE
readd std.metastrings as deprecated module

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -179,7 +179,7 @@ STD_MODULES = $(addprefix std/, algorithm array ascii base64 bigint \
 		bitmanip compiler complex concurrency conv		\
 		cstream csv datetime demangle encoding exception	\
 		file format functional getopt json math mathspecial	\
-		mmfile numeric outbuffer parallelism path		\
+		metastrings mmfile numeric outbuffer parallelism path	\
 		process random range signals socket socketstream	\
 		stdint stdio stdiobase stream string syserror system traits		\
 		typecons typetuple uni uri utf uuid variant xml zip zlib)

--- a/std/metastrings.d
+++ b/std/metastrings.d
@@ -1,0 +1,3 @@
+// Scheduled for removal in April 2014.
+deprecated("Please use std.string.format, std.conv.to or std.conv.parse instead")
+module std.metastrings;

--- a/win32.mak
+++ b/win32.mak
@@ -115,7 +115,7 @@ SRC_STD_2a_HEAVY= std\array.d std\functional.d std\path.d std\outbuffer.d std\ut
 SRC_STD_3= std\csv.d std\math.d std\complex.d std\numeric.d std\bigint.d \
 	std\bitmanip.d std\typecons.d \
 	std\uni.d std\base64.d std\ascii.d \
-	std\demangle.d std\uri.d std\mmfile.d std\getopt.d
+	std\demangle.d std\uri.d std\metastrings.d std\mmfile.d std\getopt.d
 
 SRC_STD_3a= std\signals.d std\typetuple.d std\traits.d \
 	std\encoding.d std\xml.d \
@@ -129,11 +129,11 @@ SRC_STD_3b= std\datetime.d
 #can't place SRC_STD_DIGEST in SRC_STD_REST because of out-of-memory issues
 SRC_STD_DIGEST= std\digest\crc.d std\digest\sha.d std\digest\md.d \
 	std\digest\ripemd.d std\digest\digest.d
-	
+
 SRC_STD_CONTAINER= std\container\array.d std\container\binaryheap.d \
 	std\container\dlist.d std\container\rbtree.d std\container\slist.d \
 	std\container\util.d std\container\package.d
-	
+
 SRC_STD_4= std\uuid.d $(SRC_STD_DIGEST)
 
 SRC_STD_5_HEAVY= std\algorithm.d
@@ -160,7 +160,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
-	std\mmfile.d \
+	std\metastrings.d std\mmfile.d \
 	std\syserror.d \
 	std\random.d std\stream.d std\process.d \
 	std\socket.d std\socketstream.d std\format.d \

--- a/win64.mak
+++ b/win64.mak
@@ -117,7 +117,7 @@ SRC_STD_3= std\csv.d std\complex.d std\numeric.d std\bigint.d
 SRC_STD_3c= std\datetime.d std\bitmanip.d std\typecons.d
 
 SRC_STD_3a= std\uni.d std\base64.d std\ascii.d \
-	std\demangle.d std\uri.d std\mmfile.d std\getopt.d
+	std\demangle.d std\uri.d std\metastrings.d std\mmfile.d std\getopt.d
 
 SRC_STD_3b= std\signals.d std\typetuple.d std\traits.d \
 	std\encoding.d std\xml.d \
@@ -133,7 +133,7 @@ SRC_STD_DIGEST= std\digest\crc.d std\digest\sha.d std\digest\md.d \
 SRC_STD_CONTAINER= std\container\array.d std\container\binaryheap.d \
 	std\container\dlist.d std\container\rbtree.d std\container\slist.d \
 	std\container\util.d std\container\package.d
-	
+
 SRC_STD_4= std\uuid.d $(SRC_STD_DIGEST)
 
 
@@ -178,7 +178,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
-	std\mmfile.d \
+	std\metastrings.d std\mmfile.d \
 	std\syserror.d \
 	std\random.d std\stream.d std\process.d \
 	std\socket.d std\socketstream.d std\format.d \


### PR DESCRIPTION
- Removing the deprecated module **silently** broke
  any code that still imported the module without
  using it's functions.
