### PR TITLE
Mark a unittest for std.file.thisExePath as safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1878,7 +1878,7 @@ else version (FreeBSD)
         static assert(0, "thisExePath is not supported on this platform");
 }
 
-unittest
+@safe unittest
 {
     auto path = thisExePath();
 


### PR DESCRIPTION
It does not contain any unsafe operations.
