### PR TITLE
@safe'ty of find and canFind

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -5520,7 +5520,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find("abc", "bc").length == 2);
 }
 
-unittest
+@safe unittest
 {
     import std.string : toUpper;
 
@@ -5549,7 +5549,7 @@ unittest
     assert(find!(f)(s, "hello").length == 3);
 }
 
-unittest
+@safe unittest
 {
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -12109,7 +12109,7 @@ template canFind(alias pred="a == b")
 }
 
 ///
-unittest
+@safe unittest
 {
     assert(canFind([0, 1, 2, 3], 2) == true);
     assert(canFind([0, 1, 2, 3], [1, 2], [2, 3]));
@@ -12122,7 +12122,7 @@ unittest
     assert(canFind([0, 1, 2, 3], [1, 3], [2, 4]) == 0);
 }
 
-unittest
+@safe unittest
 {
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -12134,7 +12134,7 @@ unittest
     }
 }
 
-unittest
+@safe unittest
 {
     assert(equal!(canFind!"a < b")([[1, 2, 3], [7, 8, 9]], [2, 8]));
 }

--- a/std/random.d
+++ b/std/random.d
@@ -1114,7 +1114,7 @@ auto n = rnd.front;
 ----
 */
 
-@property uint unpredictableSeed()
+@property uint unpredictableSeed() @trusted
 {
     static bool seeded;
     static MinstdRand0 rand;
@@ -1128,7 +1128,7 @@ auto n = rnd.front;
     return cast(uint) (TickDuration.currSystemTick.length ^ rand.front);
 }
 
-unittest
+@safe unittest
 {
     // not much to test here
     auto a = unpredictableSeed;


### PR DESCRIPTION
Change find's tests to validate usability of @safe.
Eliminate the trustedFindRR case by pushing it down a layer in the find stack of functions.
Mark unpredictableSeed as @trusted (@safe is a stretch due to all the casting) so that it can be used in @safe contexts.
Mark canFind's tests to validate usability of @safe (which lead to the unpredictableSeed change)
