### PR TITLE
Mark std.uni.MultiArray.this as safe, pure and nothrow

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -809,6 +809,7 @@ struct MultiArray(Types...)
 {
     this(size_t[] sizes...) @safe pure nothrow
     {
+        assert(dim == sizes.length);
         size_t full_size;
         foreach(i, v; Types)
         {


### PR DESCRIPTION
It does not contain any unsafe, impure and throwable operations.
It cannot be marked as nogc because it uses `new` expression.

Related issue: I found that it implicitly requires `Types.length == sizes.length` as a pre-condition.
In the current implimentation, if `Types.length < sizes.length`, some elements of `sizes` are accidentally ignored.
Can I add a pre-condition to clarify it?
