### PR TITLE
Mark std.uni.MultiArray.this with array types as safe, pure, nothrow and...

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -824,7 +824,7 @@ struct MultiArray(Types...)
     }
 
     this(const(size_t)[] raw_offsets,
-        const(size_t)[] raw_sizes, const(size_t)[] data)const
+        const(size_t)[] raw_sizes, const(size_t)[] data)const @safe pure nothrow @nogc
     {
         offsets[] = raw_offsets[];
         sz[] = raw_sizes[];


### PR DESCRIPTION
... nogc

It does not contain any unsafe, impure, throwable and GC-related operations.

Note: It may throw `RangeError` but it does not affect `nothrow`-ness because it is not `Exception`.
