### PR TITLE
Remove unit test against object.clear

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3129,8 +3129,6 @@ unittest // check against .clear UFCS hijacking
 {
     Appender!string app;
     static assert(!__traits(compiles, app.clear()));
-    static assert(__traits(compiles, clear(app)),
-        "Remove me when object.clear is removed!");
 }
 
 unittest


### PR DESCRIPTION
Per the `static assert` message.

A pull request has been generated to remove (final deprecation) `object.clear`:  https://github.com/D-Programming-Language/druntime/pull/1000
