### PR TITLE
Mark methods in std.range.Cycle for static array as system

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2627,9 +2627,9 @@ nothrow:
     {
         static ref auto trustedPtrIdx(typeof(_ptr) p, size_t idx) @trusted
         {
-            return p[idx];
+            return p[idx % R.length];
         }
-        return trustedPtrIdx(_ptr, (n + _index) % R.length);
+        return trustedPtrIdx(_ptr, n + _index);
     }
 
     @property inout(Cycle) save() inout @safe


### PR DESCRIPTION
`std.range.Cycle` for the static array is essentially unsafe struct because there is a possibility to dereference a dangling pointer.
Only the constructor, `popFront` and `save` are safe because they do not dereference `_ptr`.
