### PR TITLE
Fix issue 13647: improve std.traits navigation table

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1,8 +1,7 @@
 // Written in the D programming language.
 
 /**
- * Templates with which to extract information about types and symbols at
- * compile time.
+ * Templates which extract information about types and symbols at compile time.
  *
  * <script type="text/javascript">inhibitQuickIndex = 1</script>
  *


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13647

Give more meaningful name to 'xxx' category. (Note: the link problem described in the bug appears to have been fixed in the compiler since, so no changes to that effect are required in this PR.)

Sort identifiers in each category so that they're easier to find.

Improve awkward sentence at top of docs.
