### PR TITLE
[trivial] Issue 13689: byCodeUnit fails to be a random access range.

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -2719,7 +2719,7 @@ auto byCodeUnit(R)(R r) if (isNarrowString!R)
         void popFront()                      { r = r[1 .. $]; }
         auto ref opIndex(size_t index) inout { return r[index]; }
 
-        @property auto ref back() const
+        @property auto ref back() inout
         {
             return r[$ - 1];
         }
@@ -2748,6 +2748,8 @@ auto byCodeUnit(R)(R r) if (isNarrowString!R)
       private:
         R r;
     }
+
+    static assert(isRandomAccessRange!ByCodeUnitImpl);
 
     return ByCodeUnitImpl(r);
 }


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13689

The problem is that due to `.back` being declared `const` instead of `inout`, `.front` and `.back` don't have the same constness, thereby failing the `is(typeof(R.front)==typeof(R.back)` test in `isBidirectionalRange`, which is a prerequisite of `isRandomAccessRange`.
