### PR TITLE
Remove EArrayInit as it's no longer needed

### DIFF
--- a/std/range.d
+++ b/std/range.d
@@ -665,8 +665,6 @@ feature provided by $(D Range.put). $(D put(r, e)) is prefered.
  +/
 void put(R, E)(ref R r, E e)
 {
-    @property ref E[] EArrayInit(); //@@@9186@@@: Can't use (E[]).init
-
     //First level: simply straight up put.
     static if (is(typeof(doPut(r, e))))
     {


### PR DESCRIPTION
According to Steven Schveihoffer (and the code itself), EArrayInit is no longer needed or used.
http://forum.dlang.org/thread/nenooyjciemcmtlkalgo@forum.dlang.org

This is blocking a toString implementation for const, immutable, and inout Nullable!T when T is char, wchar, or dchar, so let's remove it for good.
