### PR TITLE
[blocker fix]: use auto return in std.datetime

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -17369,7 +17369,7 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).length ==
        dur!"days"(5903));
 --------------------
       +/
-    @property typeof(end - begin) length() const pure nothrow
+    @property auto length() const pure nothrow
     {
         return _end - _begin;
     }


### PR DESCRIPTION
This is a blocker for https://github.com/D-Programming-Language/dmd/pull/4136

Without it, the error is:

```
std\datetime.d(17341): Error: function std.datetime.Interval!(TimeOfDay).Interval.end need 'this' to access member end
std\datetime.d(17374):        called from here: end()
std\datetime.d(18699): Error: template instance std.datetime.Interval!(TimeOfDay) error instantiating
std\datetime.d(17341): Error: function std.datetime.Interval!(DateTime).Interval.end need 'this' to access member end
std\datetime.d(17374):        called from here: end()
std\datetime.d(18700): Error: template instance std.datetime.Interval!(DateTime) error instantiating
std\datetime.d(18685): Error: pure nested function '__invariant63' cannot access mutable data '_begin'
std\datetime.d(18685): Error: need 'this' for '_begin' of type 'TimeOfDay'
std\datetime.d(18685): Error: pure nested function '__invariant63' cannot access mutable data '_end'
std\datetime.d(18685): Error: need 'this' for '_end' of type 'TimeOfDay'
```
