### PR TITLE
std.windows.syserror: Fix doc build error

### DIFF
--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -57,7 +57,8 @@ version (StdDdoc)
         --------------------
      +/
     T wenforce(T, S)(T value, lazy S msg = null,
-        string file = __FILE__, size_t line = __LINE__) if (isSomeString!S);
+        string file = __FILE__, size_t line = __LINE__) @safe
+        if (isSomeString!S);
 }
 else:
 


### PR DESCRIPTION
#2616 already incorporates this fix, but since it's not ready for merging, this is a quick fix until then.

The error this fixes:

```
std\file.d(1503): Error: safe function 'std.file.mkdir' cannot call system function 'std.windows.syserror.wenforce!(int, const(char)[]).wenforce'
```
