### PR TITLE
Add ApplyConstness template

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6288,6 +6288,111 @@ unittest
 }
 
 
+/**
+Returns the type of $(D Target) with the constness of $(D source). $(D source) may be a type,
+a literal value, or a symbol, but the symbol cannot be something that doesn't have a type, such as
+a module name. If $(D source) has no constness, the returned type will be the same as $(D Target).
+*/
+template CopyConstness(Target, source...)
+if (source.length == 1)
+{
+    import std.string: format;
+    //Templates have type void, so check for that
+    static if ((is(source[0] SourceT) || is(typeof(source[0]) SourceT)) && !is(SourceT == void))
+    {
+        alias Source = SourceT;
+    }
+    else
+    {
+        static assert(false, "'%s' is not a type or has an invalid type".format(source[0].stringof));
+    }
+
+    alias Unshared(T) = T;
+    alias Unshared(T: shared U, U) = U;
+    alias TargetType(T) = Target;
+
+    alias Result = ModifyTypePreservingSTC!(TargetType, Unshared!Source);
+    static assert(is(Result), "Type '%s' cannot be created".format(Result.stringof));
+
+    alias CopyConstness = Result;
+}
+
+///
+unittest
+{
+    const(int) i;
+    CopyConstness!(float, i) f;
+    assert(is(typeof(f) == const(float)));
+
+    CopyConstness!(uint, char) u;
+    assert(is(typeof(u) == uint));
+
+    //The 'shared' qualifier will not be copied
+    shared bool b;
+    assert(!is(CopyConstness!(int, b) == shared int));
+
+    //But the constness will be
+    shared const real s;
+    assert(is(CopyConstness!(double, s) == const double));
+
+    //Careful, const(int)[] is a mutable array of const(int)
+    alias MutArr = CopyConstness!(int, const(int)[]);
+    assert(!is(MutArr == const(int)));
+
+    //Okay, const(int[]) applies to array and contained ints
+    alias CstArr = CopyConstness!(int, const(int[]));
+    assert(is(CstArr == const(int)));
+
+    assert(!__traits(compiles, CopyConstness!(int, std.traits)));
+
+    assert(!__traits(compiles, CopyConstness!(char, CopyConstness)));
+}
+
+unittest
+{
+    struct Test
+    {
+        void method1() {}
+        void method2() const {}
+        void method3() immutable {}
+    }
+
+    assert(is(CopyConstness!(real, Test.method1) == real));
+
+    assert(is(CopyConstness!(byte, Test.method2) == const(byte)));
+
+    assert(is(CopyConstness!(string, Test.method3) == immutable(string)));
+}
+
+unittest
+{
+    (inout(int)[] ia)
+    {
+        assert(!is(CopyConstness!(int[], ia) == inout(int[])));
+    }
+    ([1, 2, 3]);
+
+    (inout(int[]) ia)
+    {
+        assert(is(CopyConstness!(int[], ia) == inout(int[])));
+    }
+    ([1, 2, 3]);
+}
+
+unittest
+{
+    static assert(is(CopyConstness!(int,                    real) ==             int));
+    static assert(is(CopyConstness!(int,              const real) ==       const int));
+    static assert(is(CopyConstness!(int,        inout       real) ==       inout int));
+    static assert(is(CopyConstness!(int,        inout const real) == inout const int));
+    static assert(is(CopyConstness!(int, shared             real) ==             int));
+    static assert(is(CopyConstness!(int, shared       const real) ==       const int));
+    static assert(is(CopyConstness!(int, shared inout       real) == inout       int));
+    static assert(is(CopyConstness!(int, shared inout const real) == inout const int));
+    static assert(is(CopyConstness!(int,          immutable real) ==   immutable int));
+}
+
+
 //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 // Misc.
 //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://


### PR DESCRIPTION
While experimenting a bit, I realized that there's no easy way to declare a variable with the same constness of another variable, but a different type. You can use typeof, but only if you want the second type/declaration to have the same constness **and** type as the first. For example:

```
const(int) i;
//No way to specify that n has the same
//constness as i, but a different type
typeof(i) n;
```

Unfortunately, you can't assign a bare "const" or "immutable", etc., to an alias, so the only way to store the bare qualifiers is as a string for mixing in. It's not ideal, but there is currently no other way besides the verbose:

```
static if (typeof(i) == const) const(float) n;
else static if(typeof(i) == immutable) immutable(float) n;
//...
```

With this PR, that code can be shortened to any of the following:

```
ApplyConstness(float, i) n; //typeof(n) == const(float)
ApplyConstness(float, typeof(i)) n;  //Same
ApplyConstness(float, const(int)) n; //Same
```

ApplyConstness is quite a long name, but it's the only sufficiently descriptive one I could think of. Suggestions for a better name are welcome.
