### PR TITLE
Fix missing local import in std.math.expi.

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -797,7 +797,8 @@ unittest{
 */
 Complex!real expi(real y)  @trusted pure nothrow @nogc
 {
-    return Complex!real(std.math.cos(y), std.math.sin(y));
+    import std.math : cos, sin;
+    return Complex!real(cos(y), sin(y));
 }
 
 unittest


### PR DESCRIPTION
For some strange reason, this missing import does not cause a compile failure when building Phobos normally; the compile error only happens when building Phobos docs with `make -f posix.mak html`. I'll try to reduce the dmd bug and file an issue for it separately.
