### PR TITLE
Solaris fixes for std.stdio and std.parallelism

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -147,6 +147,15 @@ else version(linux)
         totalCPUs = cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
     }
 }
+else version(Solaris)
+{
+    import core.sys.posix.unistd;
+
+    shared static this()
+    {
+        totalCPUs = cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
+    }
+}
 else version(Android)
 {
     import core.sys.posix.unistd;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -65,6 +65,11 @@ version (FreeBSD)
     version = GENERIC_IO;
 }
 
+version (Solaris)
+{
+    version = GENERIC_IO;
+}
+
 version (Android)
 {
     version = GENERIC_IO;


### PR DESCRIPTION
- Use GENERIC_IO
- Use sysconf to determine number of CPUs
