### PR TITLE
Solaris changes for std.file and std.socket.

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -188,6 +188,14 @@ string formatSocketError(int err) @trusted
             else
                 return "Socket error " ~ to!string(err);
         }
+        else version (Solaris)
+        {
+            auto errs = strerror_r(err, buf.ptr, buf.length);
+            if (errs == 0)
+                cs = buf.ptr;
+            else
+                return "Socket error " ~ to!string(err);
+        }
         else version (Android)
         {
             auto errs = strerror_r(err, buf.ptr, buf.length);


### PR DESCRIPTION
std.file: Add implementation for `thisExePath()`, fix `struct DirEntry`
std.socket: Add implementation for `formatSocketError()`
