### PR TITLE
Fix deprecation warning in std.concurrency.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1389,7 +1389,7 @@ private:
 
         while( m_fibers.length > 0 )
         {
-            auto t = m_fibers[m_pos].call( false );
+            auto t = m_fibers[m_pos].call( Fiber.Rethrow.no );
             if (t !is null && !(cast(OwnerTerminated) t))
                 throw t;
             if( m_fibers[m_pos].state == Fiber.State.TERM )


### PR DESCRIPTION
Replace false with Fiber.Rethrow.no to remove the warning.
