### PR TITLE
Include NullSink in std.range ddocs.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -91,7 +91,7 @@ DOCSRC = ../dlang.org
 WEBSITE_DIR = ../web
 DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp
-SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(EXTRA_DOCUMENTABLES))
+SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_RANGE_MODULES) $(EXTRA_DOCUMENTABLES))
 STDDOC = $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
 BIGSTDDOC = $(DOCSRC)/std_consolidated.ddoc $(DOCSRC)/macros.ddoc
 # Set DDOC, the documentation generator

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -124,6 +124,9 @@ $(BOOKTABLE ,
     $(TR $(TD $(D $(LREF enumerate)))
         $(TD Iterates a _range with an attached index variable.
     ))
+    $(TR $(TD $(D $(LREF NullSink)))
+        $(TD An output _range that discards the data it receives.
+    ))
 )
 
 Ranges whose elements are sorted afford better efficiency with certain


### PR DESCRIPTION
Include `NullSink` in navigation header of `std.range` docs.

Also includes partial fix for makefile to build std.range docs, that was broken after
std.range was split. This is only a partial fix; the full fix will have
to be done as part of [issue 13766](https://issues.dlang.org/show_bug.cgi?id=13766).
