### PR TITLE
Mark std.range.cycle for static array and their unittests as system

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2689,7 +2689,7 @@ Cycle!R cycle(R)(R input)
     return input;
 }
 
-Cycle!R cycle(R)(ref R input, size_t index = 0)
+Cycle!R cycle(R)(ref R input, size_t index = 0) @system
     if (isStaticArray!R)
 {
     return Cycle!R(input, index);
@@ -2761,7 +2761,7 @@ Cycle!R cycle(R)(ref R input, size_t index = 0)
     }
 }
 
-unittest // For static arrays.
+@system unittest // For static arrays.
 {
     import std.algorithm : equal;
 
@@ -2813,7 +2813,7 @@ unittest // For static arrays.
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm : equal;
 
@@ -2833,7 +2833,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm : equal;
 


### PR DESCRIPTION
It is a system function because the constructr of `Cycle` is a system function.
This request clarifies that calling `cycle` for any static arrays is the unsafe operation.
