### PR TITLE
Use version-specific navbar when building docs.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -92,7 +92,7 @@ WEBSITE_DIR = ../web
 DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_RANGE_MODULES) $(EXTRA_DOCUMENTABLES))
-STDDOC = $(DOCSRC)/std_navbar-2.067.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
+STDDOC = $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
 BIGSTDDOC = $(DOCSRC)/std_consolidated.ddoc $(DOCSRC)/macros.ddoc
 # Set DDOC, the documentation generator
 DDOC=$(DMD) -m$(MODEL) -w -c -o- -version=StdDdoc \


### PR DESCRIPTION
Required by and depends on dlang.org pull https://github.com/D-Programming-Language/dlang.org/pull/713
