### PR TITLE
disable fiber test on win32

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1652,6 +1652,8 @@ void yield(T)(T value)
 
 version (Win64) {
     // fibers are broken on Win64
+} else version (Win32) {
+    // fibers are broken in Win32 under server 2012: bug 13821
 } else unittest {
     import core.exception;
     import std.exception;


### PR DESCRIPTION
horrible workaround for https://issues.dlang.org/show_bug.cgi?id=13821

With win 2008 loosing support and thus security fixes in Jan 2015, I need to move the auto-testers up to windows server 2012.
