### PR TITLE
Fix issue 12589 - std.random.randomCover fails for empty ranges

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -2043,7 +2043,6 @@ struct RandomCover(Range, UniformRNG = void)
     {
         if (_alreadyChosen == 0)
         {
-            _chosen[] = false;
             popFront();
         }
         return _input[_current];


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12589
