### PR TITLE
Update std.container.* docs to reflect submodules

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1,3 +1,23 @@
+/**
+This module provides an $(D Array) type with deterministic memory usage not
+reliant on the GC, as an alternative to the built-in arrays.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_array.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.array;
 
 import std.range.primitives;

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -1,3 +1,23 @@
+/**
+This module provides a $(D BinaryHeap) adaptor that makes a binary heap out of
+any user-provided random-access range.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_binaryheap.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.binaryheap;
 
 import std.range.primitives;

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -1,3 +1,22 @@
+/**
+This module implements a generic doubly-linked list container.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_dlist.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.dlist;
 
 import std.range.primitives;

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -5,7 +5,7 @@ Defines generic containers.
 
 Submodules:
 
-This module consists of several submodules:
+This module consists of the following submodules:
 
 $(UL
     $(LI

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1,3 +1,22 @@
+/**
+This module implements a red-black tree container.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_rbtree.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.rbtree;
 
 // FIXME

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -1,3 +1,22 @@
+/**
+This module implements a singly-linked list container.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_slist.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.slist;
 
 public import std.container.util;

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -1,3 +1,22 @@
+/**
+This module contains some common utilities used by containers.
+
+This module is a submodule of $(LINK2 std_container_package, std.container).
+
+Source: $(PHOBOSSRC std/container/_util.d)
+Macros:
+WIKI = Phobos/StdContainer
+TEXTWITHCOMMAS = $0
+
+Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
+copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
+
+License: Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+boost.org/LICENSE_1_0.txt)).
+
+Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+*/
 module std.container.util;
 
 /**


### PR DESCRIPTION
After `std.container` was split into submodules, the docs were not properly updated to reflect the new state of things. This PR fixes that.

Depends on: https://github.com/D-Programming-Language/phobos/pull/2771 (otherwise the new docs won't actually get built by the makefile). Also https://github.com/D-Programming-Language/dlang.org/pull/717 to update the navbar on dlang.org.
