### PR TITLE
etc.c.curl is missing "convenient" aliases

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -1250,7 +1250,12 @@ enum CurlOption {
   /** Set authentication type for authenticated TLS */
   tlsauth_type,
   /** the last unused */
-  lastentry
+  lastentry,
+
+  writedata = file, /// convenient alias
+  readdata = infile, /// ditto
+  headerdata = writeheader, /// ditto
+  rtspheader = httpheader, /// ditto
 }
 ///
 alias int CURLoption;


### PR DESCRIPTION
- those are used in all examples as if they
  were "real" options, so make them part of
  CurlOption enum
