### PR TITLE
std.conv: Disable to!String(infiniteRange)

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -819,7 +819,7 @@ $(UL
 T toImpl(T, S)(S value)
     if (!(isImplicitlyConvertible!(S, T) &&
           !isEnumStrToStr!(S, T) && !isNullToStr!(S, T)) &&
-        isExactSomeString!T)
+        !isInfinite!S && isExactSomeString!T)
 {
     static if (isExactSomeString!S && value[0].sizeof == ElementEncodingType!T.sizeof)
     {


### PR DESCRIPTION
This conversion is essentially impossible.
std.array.array also does not accept an infinite range.
