### PR TITLE
Fix docs for encode overload

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1741,7 +1741,6 @@ body
 Encodes $(D c) in units of type $(D E) and writes the result to the
 output range $(D R). Returns the number of $(D E)s written.
  */
-
 size_t encode(E, R)(dchar c, auto ref R range)
 if (isNativeOutputRange!(R, E))
 {
@@ -1842,8 +1841,14 @@ body
 }
 
 /**
-Encodes $(D c) in units of type $(D E) and writes the result to the
-output range $(D R). Returns the number of $(D E)s written.
+Encodes the contents of $(D s) in units of type $(D Tgt), writing the result to an
+output range.
+
+Returns: The number of $(D Tgt) elements written.
+Params:
+Tgt = Element type of $(D range).
+s = Input array.
+range = Output range.
  */
 size_t encode(Tgt, Src, R)(in Src[] s, R range)
 {


### PR DESCRIPTION
Discussion: http://forum.dlang.org/post/m7nko1$udj$1@digitalmars.com

Fixed:

> 1. No 'Return:' block, though it obviously returns a value.
> 2. No 'Params:' block, though it obviously has parameters.
> 3. No description of what 'Tgt' is.
> 4. No clue where the variable 'c' comes from.
> 5. No clue where the type 'E' comes from.
> 6. 'R' is a type, not an instance. 

Not fixed (yet):

> 1. No 'Example:' block
> 2. No comparison with other 'encode' functions in the same module.

None of the `encode` functions have an example, and I'm no expert on encoding, so can't really help here.

> 1. No description of what 'Src' is.

I'm not sure whether to document this, because it perhaps should be inferred rather than explicitly passed.

Note: Github has renumbered my quoted items from Walter's post.
