### PR TITLE
Fixed 13871

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -606,7 +606,8 @@ public:
             ~ " in a " ~ VariantN.stringof ~ ". Valid types are "
                 ~ AllowedTypes.stringof);
         // Assignment should destruct previous value
-        fptr(OpID.destruct, &store, null);
+        // BUG 13871. fptr may be null here.
+        if (fptr) fptr(OpID.destruct, &store, null);
 
         static if (is(T : VariantN))
         {


### PR DESCRIPTION
This is a quick fix for [13871:  [REG] Segmentation fault from std/variant.d:609](https://issues.dlang.org/show_bug.cgi?id=13871)
Unfortunately I don't fully understand the root of the problem yet. Will investigate it more. Meanwhile this PR seems to fix it.
