### PR TITLE
Parameterized unittests and benchmarks

### DIFF
--- a/benchmarkplotter.d
+++ b/benchmarkplotter.d
@@ -1,0 +1,120 @@
+import std.stdio;
+import std.datetime : DateTime;
+
+struct Entry
+{
+    string name;
+    string date;
+    string measuringUnit;
+    long iterations;
+    bool failed;
+    double avgClockTime;
+    double q0;
+    double q25;
+    double q50;
+    double q75;
+    double q100;
+}
+
+struct EntrySorted {
+    Entry entry;
+    DateTime date;
+
+    int opCmp(const ref EntrySorted other) @safe const pure nothrow {
+        return this.date < other.date;
+    }
+}
+
+auto gnuplot = q"{set title "%s"
+set terminal pngcairo enhanced font 'Verdana,10'
+set output "%s"
+set ytics nomirror
+set ylabel "Time (usecs) Single Call"
+set bmargin 10
+set timefmt %s
+set format x %s
+set autoscale x
+set offset graph 0.10, 0.10
+set style fill empty
+set xtics rotate by -90 offset 0,0
+set grid
+plot "%s" using (column(0)):8:7:11:10:xticlabels(1) with candlesticks lt 8 lw 1 title "0.25 - 0.5 Quantil" whiskerbars, "%s" using (column(0)):9:9:9:9 with candlesticks lt 7 lw 2 notitle;
+}";
+
+int main(string[] args)
+{
+    if (args.length == 1)
+    {
+        stderr.writeln("You need to pass in a a filename");
+        return 1;
+    }
+
+    import std.csv : csvReader;
+    import std.file : readText;
+    import std.string : translate;
+
+    Entry[][string] entries;
+
+    foreach (entry; csvReader!Entry(readText(args[1])))
+    {
+        entries[entry.name] ~= entry;
+    }
+
+    immutable dchar[dchar] filenameTranslate = ['.' : '_', '(' : '_', ')' : '_',
+        ',' : '_'];
+
+    immutable dchar[dchar] gnuplotTranslate = [' ' : '-'];
+
+    foreach (key; entries.byKey)
+    {
+        import std.array : empty, front;
+        import std.algorithm.sorting : sort;
+        import std.string : lastIndexOf;
+        import std.conv : to;
+
+        auto dataFilename = key.translate(filenameTranslate);
+
+        EntrySorted[] sorted;
+        foreach (entry; entries[key])
+        {
+            string date = entry.date;
+            auto dotIdx = date.lastIndexOf('.');
+            sorted ~= EntrySorted(entry, DateTime.fromISOExtString(date[0 ..  dotIdx]));
+        }
+        sorted.sort();
+        assert(!sorted.empty);
+        writeln(sorted);
+
+        auto gnuplotFile = File(dataFilename ~ ".gp", "w");
+        gnuplotFile.writef(gnuplot, sorted.front.entry.name,
+            dataFilename ~ ".png", "'%Y-%m-%d-%H:%M:%S'", "'%Y-%m-%d-%H:%M:%S'",
+            dataFilename ~ ".dat", dataFilename ~ ".dat");
+
+        auto outputFile = File(dataFilename ~ ".dat", "w");
+        foreach (entry; sorted)
+        {
+            outputFile.writefln("%02d-%02d-%d-%02d:%02d:%02d %f %f %f %f %f "
+                 ~ "%f %f %f %f %f",
+                    entry.date.year,
+                    entry.date.month,
+                    entry.date.day,
+                    entry.date.hour,
+                    entry.date.minute,
+                    entry.date.second,
+
+                    entry.entry.q0,
+                    entry.entry.q25,
+                    entry.entry.q50,
+                    entry.entry.q75,
+                    entry.entry.q100,
+
+                    entry.entry.q0 / entry.entry.iterations,
+                    entry.entry.q25 / entry.entry.iterations,
+                    entry.entry.q50 / entry.entry.iterations,
+                    entry.entry.q75 / entry.entry.iterations,
+                    entry.entry.q100 / entry.entry.iterations);
+        }
+    }
+
+    return 0;
+}

--- a/posix.mak
+++ b/posix.mak
@@ -44,7 +44,9 @@ endif
 
 ifneq ($(BUILD),release)
     ifneq ($(BUILD),debug)
-        $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
+        ifneq ($(BUILD),benchmark)
+        	$(error Unrecognized BUILD=$(BUILD), must be 'debug', 'release' or 'benchmark')
+		endif
     endif
 endif
 
@@ -107,6 +109,10 @@ endif
 DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -dip25 $(MODEL_FLAG) $(PIC)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
+else ifeq ($(BENCHMARK),true)
+	DFLAGS += -O -release -version=randomized_unittest_benchmark
+else ifeq ($(TEST),true)
+	DFLAGS += -debug -version=randomized_unittest_benchmark
 else
 	DFLAGS += -O -release
 endif
@@ -164,6 +170,7 @@ STD_PACKAGES = std $(addprefix std/,\
   experimental/allocator/building_blocks experimental/logger \
   experimental/ndslice \
   net \
+  randomized_unittest_benchmark \
   experimental range regex)
 
 # Modules broken down per package
@@ -174,7 +181,9 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   outbuffer parallelism path process random signals socket socketstream stdint \
   stdio stdiobase stream string system traits typecons typetuple uni \
   uri utf uuid variant xml zip zlib
-PACKAGE_std_experimental = typecons
+
+PACKAGE_std_experimental = typecons randomized_unittest_benchmark	
+
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util
@@ -240,6 +249,15 @@ ALL_D_FILES = $(addsuffix .d, $(STD_MODULES) $(EXTRA_MODULES_COMMON) \
 # C files to be part of the build
 C_MODULES = $(addprefix etc/c/zlib/, adler32 compress crc32 deflate	\
 	gzclose gzlib gzread gzwrite infback inffast inflate inftrees trees uncompr zutil)
+C_FILES = $(addsuffix .c,$(C_MODULES))
+# C files that are not compiled (right now only zlib-related)
+C_EXTRAS = $(addprefix etc/c/zlib/, algorithm.txt ChangeLog crc32.h	\
+deflate.h example.c inffast.h inffixed.h inflate.h inftrees.h		\
+linux.mak minigzip.c osx.mak README trees.h win32.mak zconf.h		\
+win64.mak \
+gzguts.h zlib.3 zlib.h zutil.h)
+# Aggregate all C files over all OSs (this is for the zip file)
+ALL_C_FILES = $(C_FILES) $(C_EXTRAS)
 
 OBJS = $(addsuffix $(DOTOBJ),$(addprefix $(ROOT)/,$(C_MODULES)))
 

--- a/std/experimental/randomized_unittest_benchmark.d
+++ b/std/experimental/randomized_unittest_benchmark.d
@@ -1,0 +1,886 @@
+/** This module combines randomized unittests with benchmarking capabilites.
+
+To gain appropriate test coverage and to test unexpected inputs, randomized
+unittest are a possible approach.
+Additionally, they lend themselves for reproducible benchmarking and
+performance monitoring.
+*/
+module std.experimental.randomized_unittest_benchmark;
+
+debug import std.experimental.logger;
+
+/// The following examples show an overview of the given functionalities.
+unittest
+{
+    void theFunctionToTest(int a, float b, string c)
+    {
+        // super expensive operation
+        auto rslt = (a + b) * c.length;
+
+        /* Pass the result to doNotOptimizeAway so the compiler
+        can not remove the expensive operation, and thereby falsify the
+        benchmark.
+        */
+        doNotOptimizeAway(rslt);
+
+        debug
+        {
+            /* As the paramters to the function assume random values,
+            $(D benchmark) allows to quickly test function with various input
+            values. As the verification of computed value or state will at to
+            the runtime of the function to benchmark, it makes sense to only
+            execute these verifications in debug mode.
+            */
+            assert(c.length ? true : true);
+        }
+    }
+
+    /* $(D benchmark) will run the function $(D theFunctionToTest) as often as
+    possible in 1 second. The function will be called with randomly selected
+    values for its parameters.
+    */
+    benchmark!theFunctionToTest();
+}
+
+/// Ditto
+unittest
+{
+    /* This function takes two $(D Gen) types as parameter. These $(D Gen)
+     types are implicitly convertiable to the type given as the first template
+    type parameter. The second and third template parameter give the upper and
+    lower bound of the randomly selected value given to the parameter. This
+    allows to test functions which only work for a specific range of values.
+    */
+    void theFunctionToTest(Gen!(int, 1, 5) a, Gen!(float, 0.0, 10.0) b)
+    {
+        // This will always be true
+        assert(a >= 1 && a <= 5);
+        assert(a >= 0.0 && a <= 10.0);
+
+        // super expensive operation
+        auto rslt = (a + b);
+        doNotOptimizeAway(rslt);
+
+        debug
+        {
+            assert(rslt > 1.0);
+        }
+    }
+
+    benchmark!theFunctionToTest();
+}
+
+/// Ditto Manuel benchmarking
+unittest
+{
+    auto rnd = Random(1337); // we need a random generator
+    // a benchmark object that stores the
+    auto ben = Benchmark("aGoodName", 20, "filename");
+    // benchmark values
+
+    ben.dontWrite = true; // yes will prohibit the Benchmark
+    // instance from writing the benchmark
+    // results to a file
+
+    /* This instance of $(D RndValueGen) named $(D generator) will be used
+    later as the random parameter value source in the following call to the
+    function to benchmark. The $(D RndValueGen) takes one construction
+    parameter, the source of randomness.
+    */
+    auto generator = RndValueGen!(["a", "b", "c"],
+        int, // a random $(D int) between $(D int.min) and $(D int.max)
+        Gen!(float, 0.0, 10.0), // a random $(D float) between -10 and 10
+        Gen!(string, 0,
+        9)) // a random $(D string) with a length
+    (&rnd); // between 0 and 9
+
+    /* a, b and c will have random values created inside $(D generator) that
+    uses $(D rnd) as source of randomness
+    */
+    static void fun(int a, float b, string c)
+    {
+        auto rslt = cast(int) b + c.length;
+
+        assert(true); // some useful assertions.
+
+    }
+
+    /* This loops combines the three elements and executes the benchmark.
+    */
+    size_t rounds = 0;
+    while (ben.timeSpend <= 1.seconds && rounds < 1000)
+    {
+        generator.genValues(); // generate random values for a, b, and c
+
+        ben.start(); // start the benchmark timer
+        fun(generator.values); // run the function
+        ben.stop(); // stop the benchmark timer
+        ++rounds;
+    }
+
+    /* When a $(D Benchmark) object goes out of scope the destructor writes
+    the benchmark stats to a file, unless the $(D donWrite) member is set to
+    $(D true). The name of the output file is $(D __FILE__ ~  "_benchmark.csv).
+    The $(D Benchmark) instance will write a line of comma seperated values to
+    the file containing. The line contains the following information: the given
+    name, the date of execution, the measuring unit, the measurment, if the
+    execution was abnormaliy interrupted. */
+}
+
+/** The options  controlling the behaviour of benchmark. */
+struct BenchmarkOptions
+{
+    string funcname; // the name of the function to benchmark
+    string filename; // the name of the file the results will be appended to
+    Duration duration = 1.seconds; // the time after which the function to
+                                   // benchmark is not executed anymore
+    size_t maxRounds = 10000; // the maximum number of times the function
+                              // to benchmark is called
+    int seed = 1337; // the seed to the random number generator
+
+    this(string funcname)
+    {
+        this.funcname = funcname;
+    }
+}
+
+import core.time : MonoTimeImpl, Duration, ClockType, dur, seconds;
+import std.array : appender, array;
+import std.datetime : StopWatch, DateTime, Clock;
+import std.meta : staticMap;
+import std.conv : to;
+import std.random : Random, uniform;
+import std.traits : fullyQualifiedName, isFloatingPoint, isIntegral, isNumeric,
+    isSomeString, Parameters, ParameterIdentifierTuple;
+import std.typetuple : TypeTuple;
+import std.utf : byDchar, count;
+
+/* This function used $(D MonoTimeImpl!(ClockType.precise).currTime) to time
+how long $(D MonoTimeImpl!(ClockType.precise).currTime) takes to return
+the current time.
+*/
+private auto medianStopWatchTime()
+{
+    import core.time;
+    import std.algorithm : sort;
+
+    enum numRounds = 51;
+    Duration[numRounds] times;
+
+    MonoTimeImpl!(ClockType.precise) dummy;
+    for (size_t i = 0; i < numRounds; ++i)
+    {
+        auto sw = MonoTimeImpl!(ClockType.precise).currTime;
+        dummy = MonoTimeImpl!(ClockType.precise).currTime;
+        dummy = MonoTimeImpl!(ClockType.precise).currTime;
+        doNotOptimizeAway(dummy);
+        times[i] = MonoTimeImpl!(ClockType.precise).currTime - sw;
+    }
+
+    sort(times[]);
+
+    return times[$ / 2].total!"hnsecs";
+}
+
+private Duration getQuantilTick(double q)(Duration[] ticks) pure @safe
+{
+    size_t idx = cast(size_t)(ticks.length * q);
+
+    if (ticks.length % 2 == 1)
+    {
+        return ticks[idx];
+    }
+    else
+    {
+        return (ticks[idx] + ticks[idx - 1]) / 2;
+    }
+}
+
+unittest
+{
+    static import std.conv;
+    import std.algorithm.iteration : map;
+
+    auto ticks = [1, 2, 3, 4, 5].map!(a => dur!"seconds"(a)).array;
+
+    Duration q25 = getQuantilTick!0.25(ticks);
+    assert(q25 == dur!"seconds"(2), q25.toString());
+
+    Duration q50 = getQuantilTick!0.50(ticks);
+    assert(q50 == dur!"seconds"(3), q25.toString());
+
+    Duration q75 = getQuantilTick!0.75(ticks);
+    assert(q75 == dur!"seconds"(4), q25.toString());
+
+    q25 = getQuantilTick!0.25(ticks[0 .. 4]);
+    assert(q25 == dur!"seconds"(1) + dur!"msecs"(500), q25.toString());
+
+    q50 = getQuantilTick!0.50(ticks[0 .. 4]);
+    assert(q50 == dur!"seconds"(2) + dur!"msecs"(500), q25.toString());
+
+    q75 = getQuantilTick!0.75(ticks[0 .. 4]);
+    assert(q75 == dur!"seconds"(3) + dur!"msecs"(500), q25.toString());
+}
+
+/** This $(D struct) takes care of the time taking and outputting of the
+statistics.
+*/
+struct Benchmark
+{
+    import std.array : Appender;
+
+    string filename; // where to write the benchmark result to
+    string funcname; // the name of the benchmark
+    size_t rounds; // the number of times the functions is supposed to be
+    //executed
+    string timeScale; // the unit the benchmark is measuring in
+    real medianStopWatch; // the median time it takes to get the clocktime twice
+    bool dontWrite; // if set, no data is written to the the file name "filename"
+    // true if, RndValueGen opApply was interrupt unexpectitally
+    Appender!(Duration[]) ticks; // the stopped times, there will be rounds ticks
+    size_t ticksIndex = 0; // the index into ticks
+    size_t curRound = 0; // the number of rounds run
+    MonoTimeImpl!(ClockType.precise) startTime;
+    Duration timeSpend; // overall time spend running the benchmark function
+
+    /** The constructor for the $(D Benchmark).
+    Params:
+        funcname = The name of the $(D benchmark) instance. The $(D funcname)
+            will be used to associate the results with the function
+        filename = The $(D filename) will be used as a filename to store the
+            results.
+    */
+    this(in string funcname, in size_t rounds, in string filename)
+    {
+        this.filename = filename;
+        this.funcname = funcname;
+        this.rounds = rounds;
+        this.timeScale = "hnsecs";
+        this.ticks = appender!(Duration[])();
+        this.medianStopWatch = medianStopWatchTime();
+    }
+
+    /** A call to this method will start the time taking process */
+    void start()
+    {
+        this.startTime = MonoTimeImpl!(ClockType.precise).currTime;
+    }
+
+    /** A call to this method will stop the time taking process, and
+    appends the execution time to the $(D ticks) member.
+    */
+    void stop()
+    {
+        auto end = MonoTimeImpl!(ClockType.precise).currTime;
+        Duration dur = end - this.startTime;
+        this.timeSpend += dur;
+        this.ticks.put(dur);
+        ++this.curRound;
+    }
+
+    ~this()
+    {
+        import std.stdio : File;
+
+        if (!this.dontWrite && this.ticks.data.length)
+        {
+            import std.algorithm : sort;
+
+            auto sortedTicks = this.ticks.data;
+            sortedTicks.sort();
+
+            auto f = File(filename ~ "_bechmark.csv", "a");
+            scope (exit)
+                f.close();
+
+            auto q0 = sortedTicks[0].total!("hnsecs")() /
+                cast(double) this.rounds;
+            auto q25 = getQuantilTick!0.25(sortedTicks).total!("hnsecs")() /
+                cast(double) this.rounds;
+            auto q50 = getQuantilTick!0.50(sortedTicks).total!("hnsecs")() /
+                   cast(double) this.rounds;
+            auto q75 = getQuantilTick!0.75(sortedTicks).total!("hnsecs")() /
+                cast(double) this.rounds;
+            auto q100 = sortedTicks[$ - 1].total!("hnsecs")() /
+                cast(double) this.rounds;
+
+            // funcname, the data when the benchmark was created, unit of time,
+            // rounds, medianStopWatch, low, 0.25 quantil, median,
+            // 0.75 quantil, high
+            f.writefln(
+                "\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\""
+                ~ ",\"%s\"",
+                this.funcname, Clock.currTime.toISOExtString(),
+                this.timeScale, this.curRound, this.medianStopWatch,
+                q0 > this.medianStopWatch ? q0 - this.medianStopWatch : 0,
+                q25 > this.medianStopWatch ? q25 - this.medianStopWatch : 0,
+                q50 > this.medianStopWatch ? q50 - this.medianStopWatch : 0,
+                q75 > this.medianStopWatch ? q75 - this.medianStopWatch : 0,
+                q100 > this.medianStopWatch ? q100 - this.medianStopWatch : 0);
+        }
+    }
+}
+
+/* Return $(D true) if the passed $(D T) is a $(D Gen) struct.
+
+A $(D Gen!T) is something that implicitly converts to $(D T), has a method
+called $(D gen) that is accepting a $(D ref Random).
+
+This module already brings Gens for numeric types, strings and ascii strings.
+
+If a function needs to be benchmarked that has a parameter of custom type a
+custom $(D Gen) is required.
+*/
+template isGen(T)
+{
+    static if (is(T : Gen!(S), S...))
+        enum isGen = true;
+    else
+        enum isGen = false;
+}
+
+///
+unittest
+{
+    static assert(!isGen!int);
+    static assert(isGen!(Gen!(int, 0, 10)));
+}
+
+/** A $(D Gen) type that generates numeric values between the values of the
+template parameter $(D low) and $(D high).
+*/
+struct Gen(T, T low, T high) if (isNumeric!T)
+{
+    alias Value = T;
+
+    T value;
+
+    void gen(ref Random gen)
+    {
+        static assert(low <= high);
+        this.value = uniform!("[]")(low, high, gen);
+    }
+
+    ref T opCall()
+    {
+        return this.value;
+    }
+
+    void toString(scope void delegate(const(char)[]) sink)
+    {
+        import std.format : formattedWrite;
+
+        static if (isFloatingPoint!T)
+        {
+            static if (low == T.min_normal && high == T.max)
+            {
+                formattedWrite(sink, "'%s'", this.value);
+            }
+        }
+        else static if (low == T.min && high == T.max)
+        {
+            formattedWrite(sink, "'%s'", this.value);
+        }
+        else
+        {
+            formattedWrite(sink, "'%s' low = '%s' high = '%s'", this.value,
+                low, high);
+        }
+    }
+
+    alias opCall this;
+}
+
+/** A $(D Gen) type that generates unicode strings with a number of
+charatacters that is between template parameter $(D low) and $(D high).
+*/
+struct Gen(T, size_t low, size_t high) if (isSomeString!T)
+{
+    static T charSet;
+    static immutable size_t numCharsInCharSet;
+
+    T value;
+
+    static this()
+    {
+        import std.uni : unicode;
+        import std.format : format;
+        import std.range : chain, iota;
+        import std.algorithm : map, joiner;
+
+        Gen!(T, low, high).charSet = to!T(chain(iota(0x21,
+            0x7E).map!(a => to!T(cast(dchar) a)), iota(0xA1,
+            0x1EF).map!(a => to!T(cast(dchar) a))).joiner.array);
+
+        Gen!(T, low, high).numCharsInCharSet = count(charSet);
+    }
+
+    void gen(ref Random gen)
+    {
+        static assert(low <= high);
+        import std.range : drop;
+        import std.array : front;
+
+        auto app = appender!T();
+        app.reserve(high);
+        size_t numElems = uniform!("[]")(low, high, gen);
+
+        for (size_t i = 0; i < numElems; ++i)
+        {
+            size_t toSelect = uniform!("[)")(0, numCharsInCharSet, gen);
+            app.put(charSet.byDchar().drop(toSelect).front);
+        }
+
+        this.value = app.data;
+    }
+
+    ref T opCall()
+    {
+        return this.value;
+    }
+
+    void toString(scope void delegate(const(char)[]) sink)
+    {
+        import std.format : formattedWrite;
+
+        static if (low == 0 && high == 32)
+        {
+            formattedWrite(sink, "'%s'", this.value);
+        }
+        else
+        {
+            formattedWrite(sink, "'%s' low = '%s' high = '%s'", this.value,
+                low, high);
+        }
+    }
+
+    alias opCall this;
+}
+
+unittest
+{
+    import std.typetuple : TypeTuple;
+
+    import std.meta : aliasSeqOf; //TODO uncomment with next release
+    import std.range : iota;
+    import std.array : empty;
+
+    auto r = Random(1337);
+    foreach (T; TypeTuple!(string, wstring, dstring))
+    {
+        foreach (L; aliasSeqOf!(iota(0, 2)))
+        {
+            foreach (H; aliasSeqOf!(iota(L, 2)))
+            {
+                Gen!(T, L, H) a;
+                a.gen(r);
+                if (L)
+                {
+                    assert(!a.value.empty);
+                }
+            }
+        }
+    }
+}
+
+/// DITTO This random $(D string)s only consisting of ASCII character
+struct GenASCIIString(size_t low, size_t high)
+{
+    static string charSet;
+    static immutable size_t numCharsInCharSet;
+
+    string value;
+
+    static this()
+    {
+        import std.uni : unicode;
+        import std.format : format;
+        import std.range : chain, iota;
+        import std.algorithm : map, joiner;
+
+        GenASCIIString!(low, high).charSet = to!string(chain(iota(0x21,
+            0x7E).map!(a => to!char(cast(dchar) a)).array));
+
+        GenASCIIString!(low, high).numCharsInCharSet = count(charSet);
+    }
+
+    void gen(ref Random gen)
+    {
+        auto app = appender!string();
+        app.reserve(high);
+        size_t numElems = uniform!("[]")(low, high, gen);
+
+        for (size_t i = 0; i < numElems; ++i)
+        {
+            size_t toSelect = uniform!("[)")(0, numCharsInCharSet, gen);
+            app.put(charSet[toSelect]);
+        }
+
+        this.value = app.data;
+    }
+
+    ref string opCall()
+    {
+        return this.value;
+    }
+
+    void toString(scope void delegate(const(char)[]) sink)
+    {
+        import std.format : formattedWrite;
+
+        static if (low == 0 && high == 32)
+        {
+            formattedWrite(sink, "'%s'", this.value);
+        }
+        else
+        {
+            formattedWrite(sink, "'%s' low = '%s' high = '%s'", this.value,
+                low, high);
+        }
+    }
+
+    alias opCall this;
+}
+
+unittest
+{
+    import std.utf : validate;
+    import std.array : empty;
+    import std.exception : assertNotThrown;
+
+    auto rnd = Random(1337);
+
+    GenASCIIString!(5, 5) gen;
+    gen.gen(rnd);
+    auto str = gen();
+
+    assert(!str.empty);
+    assertNotThrown(validate(str));
+}
+
+/** This type will generate a $(D Gen!T) for all passed $(D T...).
+Every call to $(D genValues) will call $(D gen) of all $(D Gen) structs
+present in $(D values). The member $(D values) can be passed to every
+function accepting $(D T...).
+*/
+struct RndValueGen(T...)
+{
+    /* $(D Values) is a collection of $(D Gen) types created through
+    $(D ParameterToGen) of passed $(T ...).
+    */
+    alias Values = staticMap!(ParameterToGen, T[1 .. $]);
+    /// Ditto
+    Values values;
+
+    string[] parameterNames = T[0];
+
+    /* The constructor accepting the required random number generator.
+    Params:
+        rnd = The required random number generator.
+    */
+    this(Random* rnd)
+    {
+        this.rnd = rnd;
+    }
+
+    /* The random number generator used to generate new value for all
+    $(D values).
+    */
+    Random* rnd;
+
+    /** A call to this member function will call $(D gen) on all items in
+    $(D values) passing $(D the provided) random number generator
+    */
+    void genValues()
+    {
+        foreach (ref it; this.values)
+        {
+            it.gen(*this.rnd);
+        }
+    }
+
+    void toString(scope void delegate(const(char)[]) sink)
+    {
+        import std.format : formattedWrite;
+
+        foreach (idx, ref it; values)
+        {
+            formattedWrite(sink, "'%s' = %s ", parameterNames[idx], it);
+        }
+    }
+}
+
+///
+unittest
+{
+    auto rnd = Random(1337);
+    auto generator = RndValueGen!(["i", "f"], Gen!(int, 0, 10), Gen!(float,
+        0.0, 10.0))(&rnd);
+    generator.genValues();
+
+    static fun(int i, float f)
+    {
+        assert(i >= 0 && i <= 10);
+        assert(f >= 0.0 && i <= 10.0);
+    }
+
+    fun(generator.values);
+}
+
+unittest
+{
+    static fun(int i, float f)
+    {
+        assert(i >= 0 && i <= 10);
+        assert(f >= 0.0 && i <= 10.0);
+    }
+
+    auto rnd = Random(1337);
+    auto generator = RndValueGen!(["i", "f"], Gen!(int, 0, 10), Gen!(float,
+        0.0, 10.0))(&rnd);
+
+    generator.genValues();
+    foreach (i; 0 .. 1000)
+    {
+        fun(generator.values);
+    }
+}
+
+/** A template that turns a $(D T) into a $(D Gen!T) unless $(D T) is
+already a $(D Gen) or no $(D Gen) for given $(D T) is available.
+*/
+template ParameterToGen(T)
+{
+    static if (isGen!T)
+        alias ParameterToGen = T;
+    else static if (isIntegral!T)
+        alias ParameterToGen = Gen!(T, T.min, T.max);
+    else static if (isFloatingPoint!T)
+        alias ParameterToGen = Gen!(T, T.min_normal, T.max);
+    else static if (isSomeString!T)
+        alias ParameterToGen = Gen!(T, 0, 32);
+    else static if (is(T : GenASCIIString!(S), S...))
+        alias ParameterToGen = T;
+    else
+        static assert(false);
+}
+
+///
+unittest
+{
+    alias GenInt = ParameterToGen!int;
+
+    static fun(int i)
+    {
+        assert(i == 1337);
+    }
+
+    GenInt a;
+    a.value = 1337;
+    fun(a);
+}
+
+unittest
+{
+    foreach (T; TypeTuple!(byte, ubyte, ushort, short, uint, int, ulong, long,
+            float, double, real, string, wstring,
+            dstring))
+    {
+        alias TP = staticMap!(ParameterToGen, T);
+        static assert(isGen!TP);
+    }
+}
+
+unittest
+{
+    static void funToBenchmark(int a, float b, Gen!(int, -5, 5) c, string d,
+        GenASCIIString!(1, 10) e)
+    {
+        import core.thread;
+
+        Thread.sleep(1.seconds / 100000);
+        doNotOptimizeAway(a, b, c, d, e);
+    }
+
+    benchmark!funToBenchmark();
+    benchmark!funToBenchmark("Another Name");
+    benchmark!funToBenchmark("Another Name", 2.seconds);
+    benchmark!funToBenchmark(2.seconds);
+}
+
+/** This function runs the passed callable $(D T) for the duration of
+$(D maxRuntime). It will count how often $(D T) is run in the duration and
+how long each run took to complete.
+
+Unless compiled in release mode, statistics will be printed to $(D stderr).
+If compiled in release mode the statistics are appended to a file called
+$(D name).
+
+Params:
+    opts = A $(D BenchmarkOptions) instance that encompasses all possible
+        parameters of benchmark.
+    name = The name of the benchmark. The name is also used as filename to
+        save the benchmark results.
+    maxRuntime = The maximum time the benchmark is executed. The last run will
+        not be interrupted.
+    rndSeed = The seed to the random number generator used to populate the
+        parameter passed to the function to benchmark.
+    rounds = The maximum number of times the callable $(D T) is called.
+*/
+void benchmark(alias T)(const ref BenchmarkOptions opts)
+{
+    auto bench = Benchmark(opts.funcname, opts.maxRounds, opts.filename);
+    auto rnd = Random(opts.seed);
+    enum string[] parameterNames = [ParameterIdentifierTuple!T];
+    auto valueGenerator = RndValueGen!(parameterNames, Parameters!T)(&rnd);
+
+    while (bench.timeSpend <= opts.duration && bench.curRound < opts.maxRounds)
+    {
+        valueGenerator.genValues();
+
+        bench.start();
+        try
+        {
+            T(valueGenerator.values);
+        }
+        catch (Throwable t)
+        {
+            import std.experimental.logger : logf;
+
+            logf("unittest with name %s failed when parameter %s where passed",
+                opts.funcname, valueGenerator);
+            break;
+        }
+        finally
+        {
+            bench.stop();
+            ++bench.curRound;
+        }
+    }
+}
+
+/// Ditto
+void benchmark(alias T)(string funcname = "", string filename = __FILE__)
+{
+    import std.string : empty;
+
+    auto opt = BenchmarkOptions(
+        funcname.empty ? fullyQualifiedName!T : funcname
+    );
+    opt.filename = filename;
+    benchmark!(T)(opt);
+}
+
+/// Ditto
+void benchmark(alias T)(Duration maxRuntime, string filename = __FILE__)
+{
+    auto opt = BenchmarkOptions(fullyQualifiedName!T);
+    opt.filename = filename;
+    opt.duration = maxRuntime;
+    benchmark!(T)(opt);
+}
+
+/// Ditto
+/*void benchmark(alias T)(string name, string filename = __FILE__)
+{
+    auto opt = BenchmarkOptions(name);
+    opt.filename = filename;
+    benchmark!(T)(opt);
+}*/
+
+/// Ditto
+void benchmark(alias T)(string name, Duration maxRuntime,
+    string filename = __FILE__)
+{
+    auto opt = BenchmarkOptions(name);
+    opt.filename = filename;
+    opt.duration = maxRuntime;
+    benchmark!(T)(opt);
+}
+
+unittest
+{
+    import core.thread : Thread;
+
+    struct Foo
+    {
+        void superSlowMethod(int a, Gen!(int, -10, 10) b)
+        {
+            Thread.sleep(1.seconds / 250000);
+            doNotOptimizeAway(a);
+        }
+    }
+
+    Foo a;
+
+    auto del = delegate(int ai, Gen!(int, -10, 10) b) {
+        a.superSlowMethod(ai, b);
+    };
+
+    benchmark!(del)();
+}
+
+unittest // test that the function parameter names are correct
+{
+    import std.string : indexOf;
+    import std.experimental.logger;
+
+    class SingleLineLogger : Logger
+    {
+        this()
+        {
+            super(LogLevel.info);
+        }
+
+        override void writeLogMsg(ref LogEntry payload) @safe
+        {
+            this.line = payload.msg;
+        }
+
+        string line;
+    }
+
+    auto oldLogger = stdThreadLocalLog;
+    auto newLogger = new SingleLineLogger();
+    stdThreadLocalLog = newLogger;
+    scope (exit)
+        stdThreadLocalLog = oldLogger;
+
+    static int failingFun(int a, string b)
+    {
+        throw new Exception("Hello");
+    }
+
+    log();
+    benchmark!failingFun();
+
+    assert(newLogger.line.indexOf("'a'") != -1);
+    assert(newLogger.line.indexOf("'b'") != -1);
+}
+
+/** A function that makes sure that the passed parameters are not optimized
+away by the compiler. This function is required as optimizing compilers are
+able to figure out that a variable is not actually used, and therefore the
+computation of the value of the variable can be removed from code. As
+benchmarking functions sometimes include computing values that are not
+actually used, this function allows use to force the compiler not to remove
+the code that is benchmarked.
+*/
+void doNotOptimizeAway(T...)(ref T t)
+{
+    foreach (ref it; t)
+    {
+        doNotOptimizeAwayImpl(&it);
+    }
+}
+
+private void doNotOptimizeAwayImpl(void* p)
+{
+    import core.thread : getpid;
+    import std.stdio : writeln;
+
+    if (getpid() == 0)
+    {
+        writeln(p);
+    }
+}

--- a/std/string.d
+++ b/std/string.d
@@ -2362,6 +2362,7 @@ auto capitalize(S)(auto ref S s)
     });
 }
 
+
 /++
     Split $(D s) into an array of lines according to the unicode standard using
     $(D '\r'), $(D '\n'), $(D "\r\n"), $(REF lineSep, std,uni),
@@ -5223,7 +5224,6 @@ body
     translate("hello world", transTable1, "low", buffer);
     assert(buffer.data == "h5 rd");
 }
-
 
 /***********************************************
  * See if character c is in the pattern.

--- a/std/stringbenchmarks.d
+++ b/std/stringbenchmarks.d
@@ -1,0 +1,346 @@
+module std.stringbenchmarks;
+
+version(randomized_unittest_benchmark) unittest
+{
+    import std.string : indexOf;
+    import std.format : format;
+    import std.experimental.randomized_unittest_benchmark;
+
+    void fun(Gen!(string, 0, 10) toSearchIn,
+            Gen!(int, 0xDFFF, 0x10FFFF) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOf(cast(dchar)toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            foreach (int jdx, dchar it; toSearchIn)
+            {
+                if (it == cast(dchar)toSearchFor)
+                {
+                    assert(jdx == idx);
+                }
+            }
+
+            assert(idx == -1, format("%s in \n%s", toSearchFor, toSearchIn));
+        }
+    }
+
+    benchmark!fun("string.indexOf(dchar)");
+}
+
+version(randomized_unittest_benchmark) unittest
+{
+    import std.experimental.randomized_unittest_benchmark;
+    import std.range : chain, iota;
+    import std.conv : to;
+    import std.stdio : writefln;
+    import std.algorithm : equal;
+    import std.format : format;
+    import std.string : indexOf, indexOfAny, indexOfNeither,
+        lastIndexOf, front;
+
+    enum charsToSearch = chain(iota(0x21, 0x7E), iota(0xA1, 0x1FF))
+        .to!dstring();
+    enum size_t len = charsToSearch.length;
+
+    immutable rounds = 20000;
+    auto rnd = Random(1);
+
+    void funIndexOf(S)(S toSearchIn, Gen!(size_t, 0, len) toSearchFor)
+    {
+
+        immutable theChar = cast(dchar)charsToSearch[toSearchFor];
+        auto idx = toSearchIn.indexOf(theChar);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            bool didFind;
+            foreach (jdx, dchar it; toSearchIn)
+            {
+                if (it == theChar)
+                {
+                    assert(jdx == idx);
+                    didFind = true;
+                    break;
+                }
+            }
+
+            assert((didFind ? true : idx == -1),
+                format("%s in \n%s", toSearchFor, toSearchIn));
+        }
+
+    }
+
+
+    void funIndexOf2(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOf(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                assert(equal(
+                    toSearchIn[idx .. idx + to!S(toSearchFor).length],
+                    toSearchFor));
+            }
+        }
+    }
+
+    void funIndexOf3(S)(S toSearchIn, Gen!(size_t, 0, len) toSearchFor)
+    {
+        immutable theChar = cast(dchar)charsToSearch[toSearchFor];
+        auto idx = toSearchIn.lastIndexOf(theChar);
+
+        debug
+        {
+            bool didFind;
+            foreach_reverse (jdx, dchar it; toSearchIn)
+            {
+                if (it == theChar)
+                {
+                    assert(jdx == idx);
+                    didFind = true;
+                    break;
+                }
+            }
+
+            assert((didFind ? true : idx == -1),
+                format("%s in \n%s", toSearchFor, toSearchIn));
+        }
+    }
+
+    foreach (S; TypeTuple!(string, wstring, dstring))
+    {
+        benchmark!(funIndexOf!(S))();
+        benchmark!(funIndexOf3!(S))();
+    }
+
+    void funIndexOf4(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.lastIndexOf(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                assert(equal(
+                    toSearchIn[idx .. idx + to!S(toSearchFor).length],
+                    toSearchFor));
+            }
+        }
+    }
+
+    void funIndexOf5(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOfAny(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                bool canBeFound;
+                foreach (dchar it; toSearchFor)
+                {
+                    if (toSearchIn[idx .. $].front == it)
+                    {
+                        canBeFound = true;
+                        break;
+                    }
+                }
+
+                assert(canBeFound);
+            }
+        }
+    }
+
+    void funIndexOf6(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOfNeither(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                bool canBeFound;
+                foreach (dchar it; toSearchFor)
+                {
+                    if (toSearchIn[idx .. $].front == it)
+                    {
+                        canBeFound = true;
+                        break;
+                    }
+                }
+
+                assert(!canBeFound);
+            }
+        }
+    }
+
+    void funIndexOf7(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOfAny(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                bool canBeFound;
+                foreach (dchar it; toSearchFor)
+                {
+                    if (toSearchIn[idx .. $].front == it)
+                    {
+                        canBeFound = true;
+                        break;
+                    }
+                }
+
+                assert(canBeFound);
+            }
+        }
+    }
+
+    void funIndexOf8(S,R)(Gen!(S, 10, 500) toSearchIn,
+            Gen!(R, 1, 10) toSearchFor)
+    {
+        auto idx = toSearchIn.indexOfNeither(toSearchFor);
+        doNotOptimizeAway(idx);
+
+        debug
+        {
+            if (idx != -1)
+            {
+                bool canBeFound;
+                foreach (dchar it; toSearchFor)
+                {
+                    if (toSearchIn[idx .. $].front == it)
+                    {
+                        canBeFound = true;
+                        break;
+                    }
+                }
+
+                assert(!canBeFound);
+            }
+        }
+    }
+
+    foreach (S; TypeTuple!(string, wstring, dstring))
+    {
+        foreach (R; TypeTuple!(string, wstring, dstring))
+        {
+            benchmark!(funIndexOf2!(S,R))();
+            benchmark!(funIndexOf4!(S,R))();
+            benchmark!(funIndexOf5!(S,R))();
+            benchmark!(funIndexOf6!(S,R))();
+            benchmark!(funIndexOf7!(S,R))();
+            benchmark!(funIndexOf8!(S,R))();
+        }
+    }
+}
+
+version(randomized_unittest_benchmark) unittest
+{
+    import std.experimental.randomized_unittest_benchmark;
+    import std.range : chain, iota, lockstep;
+    import std.conv : to;
+    import std.array : empty;
+    import std.utf : isValidDchar;
+    import std.stdio : writefln, writeln;
+    import std.format : format;
+    import std.string : translate;
+
+    auto charsToSearch = chain(iota(0x21, 0x7E), iota(0xA1, 0x1FF));
+    size_t len = charsToSearch.length;
+    auto rnd = Random(1);
+
+    dchar[dchar] tt;
+    outer: while (tt.length < 50)
+    {
+        dchar k = charsToSearch[uniform(0, len/2, rnd)];
+        assert(isValidDchar(k));
+        dchar v = charsToSearch[uniform(len/2, len, rnd)];
+        assert(isValidDchar(v));
+
+        if (k == v)
+        {
+            continue;
+        }
+
+        foreach (dchar key, dchar value; tt)
+        {
+            if (key == k || key == v || value == k || value == v)
+            {
+                continue outer;
+            }
+        }
+        tt[k] = v;
+    }
+    assert(tt.length > 0);
+
+    void fun(S)(Gen!(S, 10, 2000) toTrans)
+    {
+        S afterTrans = translate(toTrans, tt);
+        doNotOptimizeAway(afterTrans);
+
+        foreach (dchar it; afterTrans)
+        {
+            foreach (dchar key; tt.byKey())
+            {
+                assert(it != key, format("%c %c", it, key));
+            }
+        }
+    }
+
+    foreach (S; TypeTuple!(string, wstring, dstring))
+    {
+        benchmark!(fun!S)();
+    }
+}
+
+version(randomized_unittest_benchmark) unittest
+{
+    import std.experimental.randomized_unittest_benchmark;
+    import std.uni : isUpper, isLower;
+    import std.string : capitalize, toLower, toUpper;
+    import std.format : format;
+
+    void fun(S)(Gen!(S, 0, 200) toUp)
+    {
+        auto cap = toUp.capitalize();
+        doNotOptimizeAway(cap);
+
+        debug
+        {
+            foreach (idx, dchar it; cap)
+            {
+                if (idx == 0u)
+                {
+                    assert(isUpper(it) ? true : toUpper(it) == it);
+                }
+                else
+                {
+                    assert(isLower(it) ? true : toLower(it) == it,
+                        format("%s %s", it, cap));
+                }
+            }
+        }
+    }
+
+    foreach (S; TypeTuple!(string, wstring, dstring))
+    {
+        benchmark!(fun!S)();
+    }
+}

--- a/win32.mak
+++ b/win32.mak
@@ -51,6 +51,9 @@ DFLAGS=-conf= -O -release -w -dip25 -I$(DRUNTIME)\import
 
 UDFLAGS=-conf= -O -w -dip25 -I$(DRUNTIME)\import
 
+## Flags for unittest benchmark
+UBDFLAGS=-conf= -O -w -version=randomized_unittest_benchmark -dip25 -I$(DRUNTIME)\import
+
 ## C compiler
 
 CC=dmc
@@ -320,7 +323,19 @@ SRC_STD_EXP_ALLOC= \
 	std\experimental\allocator\showcase.d \
 	std\experimental\allocator\typed.d \
 	std\experimental\allocator\package.d \
-	$(SRC_STD_EXP_ALLOC_BB)
+	$(SRC_STD_ALLOC_BB)
+
+SRC_STD_6= std\variant.d std\zlib.d \
+	std\stream.d std\socket.d std\socketstream.d \
+	std\conv.d std\zip.d std\cstream.d \
+	std\experimental\randomized_unittest_benchmark.d \
+	$(SRC_STD_CONTAINER) $(SRC_STD_LOGGER) $(SRC_STD_ALLOC)
+
+SRC_STD_REST= std\stdint.d \
+	std\json.d \
+	std\parallelism.d \
+	std\mathspecial.d \
+	std\process.d
 
 SRC_STD_EXP_LOGGER= \
 	std\experimental\logger\core.d \
@@ -335,6 +350,39 @@ SRC_STD_EXP_NDSLICE= \
 	std\experimental\ndslice\selection.d \
 	std\experimental\ndslice\slice.d \
 	std\experimental\ndslice\internal.d
+
+SRC_STD_NET= std\net\isemail.d std\net\curl.d
+
+SRC_STD_C= std\c\process.d std\c\stdlib.d std\c\time.d std\c\stdio.d \
+	std\c\math.d std\c\stdarg.d std\c\stddef.d std\c\fenv.d std\c\string.d \
+	std\c\locale.d std\c\wcharh.d
+
+SRC_STD_WIN= std\windows\registry.d \
+	std\windows\iunknown.d std\windows\syserror.d std\windows\charset.d
+
+SRC_STD_C_WIN= std\c\windows\windows.d std\c\windows\com.d \
+	std\c\windows\winsock.d std\c\windows\stat.d
+
+SRC_STD_C_LINUX= std\c\linux\linux.d \
+	std\c\linux\socket.d std\c\linux\pthread.d std\c\linux\termios.d \
+	std\c\linux\tipc.d
+
+SRC_STD_C_OSX= std\c\osx\socket.d
+
+SRC_STD_C_FREEBSD= std\c\freebsd\socket.d
+
+SRC_STD_INTERNAL= std\internal\cstring.d std\internal\processinit.d \
+	std\internal\unicode_tables.d std\internal\unicode_comp.d std\internal\unicode_decomp.d \
+	std\internal\unicode_grapheme.d std\internal\unicode_norm.d std\internal\scopebuffer.d \
+	std\internal\test\dummyrange.d
+
+SRC_STD_INTERNAL_DIGEST= std\internal\digest\sha_SSSE3.d
+
+SRC_STD_INTERNAL_MATH= std\internal\math\biguintcore.d \
+	std\internal\math\biguintnoasm.d std\internal\math\biguintx86.d \
+	std\internal\math\gammafunction.d std\internal\math\errorfunction.d
+
+SRC_STD_INTERNAL_WINDOWS= std\internal\windows\advapi32.d
 
 SRC_ETC=
 
@@ -406,7 +454,6 @@ SRC_ZLIB= \
 	etc\c\zlib\win64.mak \
 	etc\c\zlib\linux.mak \
 	etc\c\zlib\osx.mak
-
 
 DOCS= \
 	$(DOC)\object.html \
@@ -533,6 +580,7 @@ DOCS= \
 	$(DOC)\std_experimental_ndslice_slice.html \
 	$(DOC)\std_experimental_ndslice.html \
 	$(DOC)\std_experimental_typecons.html \
+	$(DOC)\std_experimental_randomized_unittest_benchmark.html \
 	$(DOC)\std_windows_charset.html \
 	$(DOC)\std_windows_registry.html \
 	$(DOC)\std_c_fenv.html \
@@ -598,6 +646,22 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8f.obj $(SRC_STD_EXP)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest9a.obj $(SRC_STD_EXP_NDSLICE)
 	$(DMD) $(UDFLAGS) -L/co -unittest unittest.d $(UNITTEST_OBJS) \
+		$(ZLIB) $(DRUNTIMELIB)
+	.\unittest.exe
+
+benchmark : $(LIB)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest1.obj $(SRC_STD_1_HEAVY)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest2a.obj $(SRC_STD_2a_HEAVY)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest3.obj $(SRC_STD_3)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest3a.obj $(SRC_STD_3a)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest3b.obj $(SRC_STD_3b)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest4.obj $(SRC_STD_4)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest5.obj $(SRC_STD_5_HEAVY)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest7.obj $(SRC_STD_REST)
+	$(DMD) $(UBDFLAGS) -L/co -c -unittest -ofunittest8.obj $(SRC_TO_COMPILE_NOT_STD)
+	$(DMD) $(UBDFLAGS) -L/co -unittest unittest.d $(UNITTEST_OBJS) \
 		$(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
 
@@ -1084,6 +1148,9 @@ $(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\
 
 $(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
+
+$(DOC)\std_experimental_randomized_unittest_benchmark.html : $(STDDOC) std\experimental\randomized_unittest_benchmark.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_randomized_unittest_benchmark.html $(STDDOC) std\experimental\randomized_unittest_benchmark.d
 
 $(DOC)\std_digest_crc.html : $(STDDOC) std\digest\crc.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_digest_crc.html $(STDDOC) std\digest\crc.d

--- a/win64.mak
+++ b/win64.mak
@@ -54,6 +54,10 @@ DFLAGS=-conf= -m$(MODEL) -O -release -w -dip25 -I$(DRUNTIME)\import
 
 UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import
 
+## Flags for benchmark
+
+UBDFLAGS=-conf= -m$(MODEL) -O -version=randomized_unittest_benchmark w -dip25 -I$(DRUNTIME)\import
+
 ## C compiler, linker, librarian
 
 CC="$(VCDIR)\bin\amd64\cl"
@@ -299,7 +303,8 @@ SRC_STD_INTERNAL= \
 	std\internal\unicode_grapheme.d \
 	std\internal\unicode_norm.d \
 	std\internal\scopebuffer.d \
-	std\internal\test\dummyrange.d
+	std\internal\test\dummyrange.d \
+	std\internal\test\randomized_unittest_benchmark.d
 
 SRC_STD_INTERNAL_DIGEST= \
 	std\internal\digest\sha_SSSE3.d
@@ -333,6 +338,15 @@ SRC_STD_EXP_ALLOC_BB= \
 	std\experimental\allocator\building_blocks\segregator.d \
 	std\experimental\allocator\building_blocks\stats_collector.d \
 	std\experimental\allocator\building_blocks\package.d
+
+SRC_STD_C_OSX= std\c\osx\socket.d
+
+SRC_STD_C_FREEBSD= std\c\freebsd\socket.d
+
+SRC_STD_INTERNAL= std\internal\cstring.d std\internal\processinit.d \
+	std\internal\unicode_tables.d std\internal\unicode_comp.d std\internal\unicode_decomp.d \
+	std\internal\unicode_grapheme.d std\internal\unicode_norm.d std\internal\scopebuffer.d \
+	std\internal\test\dummyrange.d
 
 SRC_STD_EXP_ALLOC= \
 	std\experimental\allocator\common.d \
@@ -390,6 +404,12 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_EXP_NDSLICE) \
 	$(SRC_ETC) \
 	$(SRC_ETC_C)
+
+SRC_TO_COMPILE= $(SRC_STD_ALL) \
+	$(SRC_STD_ALGO) \
+	$(SRC_STD_RANGE) \
+	$(SRC_STD_NDSLICE) \
+	$(SRC_TO_COMPILE_NOT_STD)
 
 SRC_ZLIB= \
 	etc\c\zlib\crc32.h \
@@ -646,6 +666,34 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/OPT:NOICF -unittest unittest.d $(UNITTEST_OBJS) \
 	    $(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
+
+benchmark : $(LIB)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest1.obj $(SRC_STD_1_HEAVY)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest2a.obj $(SRC_STD_2a_HEAVY)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittestM.obj $(SRC_STD_math)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest3.obj $(SRC_STD_3)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest3a.obj $(SRC_STD_3a)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest3b.obj $(SRC_STD_3b)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest3c.obj $(SRC_STD_3c)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest4.obj $(SRC_STD_4)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest5.obj $(SRC_STD_5_HEAVY)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6a.obj $(SRC_STD_6a)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6b.obj $(SRC_STD_6b)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6c.obj $(SRC_STD_6c)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6d.obj $(SRC_STD_6d)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6e.obj $(SRC_STD_6e)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6h.obj $(SRC_STD_6h)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6i.obj $(SRC_STD_6i)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6f.obj $(SRC_STD_6f)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6g.obj $(SRC_STD_CONTAINER)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest6j.obj $(SRC_STD_6j)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest7.obj $(SRC_STD_7) $(SRC_STD_LOGGER)
+	$(DMD) $(UBDFLAGS) -c -unittest -ofunittest8.obj $(SRC_TO_COMPILE_NOT_STD)
+	$(DMD) $(UBDFLAGS) -L/OPT:NOICF -unittest unittest.d $(UNITTEST_OBJS) \
+	    $(ZLIB) $(DRUNTIMELIB)
+	.\unittest.exe
+
 
 #unittest : unittest.exe
 #	unittest


### PR DESCRIPTION
Basically, Haskell Quickcheck with in build benchmarking for performance regression testing.

IMO phobos is missing something like Quickfix (randomized test data generation). Additionally, it would be nice to use the tests as a way to measure the performance of the functions and the code generation over time. 

The benchmark results are written to a file as csv. The program benchmarkplotter.d generates .dat and .gp files for all uniquely named benchmarks. gnuplot then generates a plot of the benchmark values over time. This could than be displayed on dlang.org to show our progress and be transparent about our performance.

make BUILD=benchmark enables all benchmarks. For more info see example in std/experimental/randomized_unittest_benchmark.d

![alt text](http://s22.postimg.org/h62nvhnv5/string_last_Index_Of_wstring_dstring.png)

``` d
/// The following examples show an overview of the given functionalities.
unittest
{
    void theFunctionToTest(int a, float b, string c)
    {
        // super expensive operation
        auto rslt = (a + b) * c.length;

        /* Pass the result to doNotOptimizeAway so the compiler
        can not remove the expensive operation, and thereby falsify the
        benchmark.
        */
        doNotOptimizeAway(rslt);

        debug
        {
            /* As the paramters to the function assume random values,
            $(D benchmark) allows to quickly test function with various input
            values. As the verification of computed value or state will at to
            the runtime of the function to benchmark, it makes sense to only
            execute these verifications in debug mode.
            */
            assert(c.length ? true : true);
        }
    }

    /* $(D benchmark) will run the function $(D theFunctionToTest) as often as
    possible in 1 second. The function will be called with randomly selected
    values for its parameters.
    */
    benchmark!theFunctionToTest();
}
```

dub: https://github.com/burner/std.benchmark
