### PR TITLE
Add std.experimental.logger.asynclogger

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -173,7 +173,7 @@ PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util
 PACKAGE_std_digest = crc digest hmac md ripemd sha
-PACKAGE_std_experimental = $(addprefix logger/, core filelogger \
+PACKAGE_std_experimental = $(addprefix logger/, asynclogger core filelogger \
   nulllogger multilogger package)
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives

--- a/std/experimental/logger/asynclogger.d
+++ b/std/experimental/logger/asynclogger.d
@@ -1,0 +1,141 @@
+module std.experimental.logger.asynclogger;
+
+import std.experimental.logger.core;
+import std.concurrency;
+public import std.typecons : Unique, unique;
+
+/** The $(D AsyncLogger) processes logs asynchronously by using another $(D Logger) implementation
+as a backend. Every data logged to this $(D AsyncLogger) will be send to separate logging thread
+in order to be logged there. It can help to improve logging performance for $(D log) caller,
+for example by removing waiting for flushing logs to a file.
+Example:
+-------------
+void main()
+{
+    import std.algorithm;
+    import std.conv;
+    import std.stdio;
+    import std.datetime;
+    import std.experimental.logger;
+
+    auto fl = new FileLogger("defaultFileLogger.log", LogLevel.all);
+    void logFileDefault()
+    {
+        fl.log("test message");
+    }
+
+    auto afl = new AsyncLogger(unique!FileLogger("asyncFileLogger.log", LogLevel.all));
+    void logFileAsync()
+    {
+        afl.log("test message");
+    }
+
+    auto r = benchmark!(logFileDefault, logFileAsync)(100_000);
+    writeln(map!(a => to!string(to!Duration(a)))(r[]));
+}
+-------------
+*/
+final class AsyncLogger : Logger
+{
+    import std.algorithm : move;
+    /// Shuntdown message
+    private struct ShutdownMsg {}
+
+    private static void spawnedFunc(shared Logger ptr) @trusted
+    {
+        auto l = cast(Logger)(ptr);
+        bool isRunning = true;
+        while (isRunning)
+        {
+            receive(
+                (LogEntryBase e)
+                {
+                    LogEntry tmp;
+                    tmp.base = e;
+                    tmp.threadId = ownerTid;
+                    tmp.logger = l;
+                    l.forwardMsg(tmp);
+                },
+                (ShutdownMsg msg) { isRunning = false; },
+                (OwnerTerminated ex) { isRunning = false; },
+                (Variant v) { throw new Error("unhandled message"); }
+            );
+        }
+    }
+
+    /** This constructor sets a LogLevel, takes $(D logger)'s ownership
+    and starts a new logging thread that logs every
+    entry asynchronously by using $(D logger).
+    */
+    this(T)(Unique!T logger, LogLevel lv = LogLevel.all) @trusted
+        if (__traits(compiles, { Unique!Logger l = move(logger); }))
+    {
+        Unique!Logger l = move(logger);
+        this(move(l), lv);
+    }
+
+    /// Ditto
+    this(Unique!Logger logger, LogLevel lv = LogLevel.all) @trusted
+    {
+        super(lv);
+        this.ownedLogger_ = move(logger);
+        this.logger_ = cast(shared Logger)(this.ownedLogger_.get());
+        this.tid_ = spawn(&spawnedFunc, this.logger_);
+    }
+
+    override void writeLogMsg(ref LogEntry payload) @trusted
+    {
+        LogEntryBase msg = payload;
+        send(this.tid_, msg);
+    }
+
+    /// Stops logging thread by sending ShutdownMsg to it.
+    ~this() @trusted
+    {
+        send(this.tid_, ShutdownMsg());
+    }
+
+    Tid tid_;
+    Unique!Logger ownedLogger_;
+    shared Logger logger_;
+}
+
+version (unittest)
+{
+    import core.sync.condition;
+    class TestConditionalLogger : TestLogger
+    {
+        this(const LogLevel lv, Condition condition) @safe
+        {
+            super(lv);
+            this.cond = condition;
+        }
+
+        override protected void writeLogMsg(ref LogEntry payload) @trusted
+        {
+            super.writeLogMsg(payload);
+            synchronized(this.cond.mutex()) { this.cond.notify(); }
+        }
+
+        private Condition cond;
+    }
+}
+
+unittest
+{
+    import std.algorithm : move;
+    auto mtx = new Mutex;
+    auto cond = new Condition(mtx);
+
+    auto tl = unique!TestConditionalLogger(LogLevel.all, cond);
+    auto al = new AsyncLogger(move(tl));
+    scope(exit) destroy(al);
+    string msg = "test_entry";
+    al.log(msg); enum line = __LINE__;
+
+    synchronized (cond.mutex()) { cond.wait(dur!"seconds"(1)); }
+
+    auto logger = cast(TestConditionalLogger)al.ownedLogger_.get();
+    assert(logger.msg == msg);
+    assert(logger.line == line);
+}

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -716,11 +716,8 @@ flexibility.
 */
 abstract class Logger
 {
-    /** LogEntry is a aggregation combining all information associated
-    with a log message. This aggregation will be passed to the method
-    writeLogMsg.
-    */
-    protected struct LogEntry
+    /// General information about a log message
+    protected struct LogEntryBase
     {
         /// the filename the log function was called from
         string file;
@@ -735,14 +732,39 @@ abstract class Logger
         string moduleName;
         /// the $(D LogLevel) associated with the log message
         LogLevel logLevel;
-        /// thread id of the log message
-        Tid threadId;
         /// the time the message was logged
         SysTime timestamp;
         /// the message of the log message
         string msg;
-        /// A refernce to the $(D Logger) used to create this $(D LogEntry)
+    }
+
+    /** LogEntry is an aggregation combining all information associated
+    with a log message. This aggregation will be passed to the method
+    writeLogMsg.
+    */
+    protected struct LogEntry
+    {
+        LogEntryBase base;
+        alias base this;
+
+        /// thread id of the log message
+        Tid threadId;
+        /// A reference to the $(D Logger) used to create this $(D LogEntry)
         Logger logger;
+
+        /// Default constructor
+        this(string file = string.init, int line = int.init,
+            string funcName = string.init, string prettyFuncName = string.init,
+            string moduleName = string.init, LogLevel logLevel = LogLevel.init,
+            Tid threadId = Tid.init, SysTime timestamp = SysTime.init,
+            string msg = string.init, Logger logger = Logger.init) @safe
+        {
+            this.base = LogEntryBase(file, line, funcName, prettyFuncName,
+                moduleName, logLevel, timestamp, msg);
+            this.threadId = threadId;
+            this.logger = logger;
+        }
+
     }
 
     /** This constructor takes a name of type $(D string), and a $(D LogLevel).

--- a/win32.mak
+++ b/win32.mak
@@ -141,9 +141,9 @@ SRC_STD_ALGO= std\algorithm\package.d std\algorithm\comparison.d \
 
 SRC_STD_5_HEAVY= $(SRC_STD_ALGO)
 
-SRC_STD_LOGGER= std\experimental\logger\core.d std\experimental\logger\filelogger.d \
-	std\experimental\logger\multilogger.d std\experimental\logger\nulllogger.d \
-	std\experimental\logger\package.d
+SRC_STD_LOGGER= std\experimental\logger\asynclogger.d std\experimental\logger\core.d \
+	std\experimental\logger\filelogger.d std\experimental\logger\multilogger.d \
+	std\experimental\logger\nulllogger.d std\experimental\logger\package.d
 
 SRC_STD_6= std\variant.d \
 	std\syserror.d std\zlib.d \
@@ -375,6 +375,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_zlib.html \
 	$(DOC)\std_net_isemail.html \
 	$(DOC)\std_net_curl.html \
+	$(DOC)\std_experimental_logger_asynclogger.html \
 	$(DOC)\std_experimental_logger_core.html \
 	$(DOC)\std_experimental_logger_filelogger.html \
 	$(DOC)\std_experimental_logger_multilogger.html \
@@ -804,6 +805,9 @@ $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 
 $(DOC)\std_net_curl.html : $(STDDOC) std\net\curl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_curl.html $(STDDOC) std\net\curl.d
+
+$(DOC)\std_experimental_logger_asynclogger.html : $(STDDOC) std\experimental\logger\asynclogger.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_logger_asynclogger.html $(STDDOC) std\experimental\logger\asynclogger.d
 
 $(DOC)\std_experimental_logger_core.html : $(STDDOC) std\experimental\logger\core.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_logger_core.html $(STDDOC) std\experimental\logger\core.d

--- a/win64.mak
+++ b/win64.mak
@@ -143,9 +143,9 @@ SRC_STD_ALGO= std\algorithm\package.d std\algorithm\comparison.d \
 	std\algorithm\searching.d std\algorithm\setops.d \
 	std\algorithm\sorting.d std\algorithm\internal.d
 
-SRC_STD_LOGGER= std\experimental\logger\core.d std\experimental\logger\filelogger.d \
-	std\experimental\logger\multilogger.d std\experimental\logger\nulllogger.d \
-	std\experimental\logger\package.d
+SRC_STD_LOGGER= std\experimental\logger\asynclogger.d std\experimental\logger\core.d \
+	std\experimental\logger\filelogger.d std\experimental\logger\multilogger.d \
+	std\experimental\logger\nulllogger.d std\experimental\logger\package.d
 
 SRC_STD_5_HEAVY= $(SRC_STD_ALGO)
 
@@ -396,6 +396,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_zlib.html \
 	$(DOC)\std_net_isemail.html \
 	$(DOC)\std_net_curl.html \
+	$(DOC)\std_experimental_logger_async.html \
 	$(DOC)\std_experimental_logger_core.html \
 	$(DOC)\std_experimental_logger_filelogger.html \
 	$(DOC)\std_experimental_logger_multilogger.html \
@@ -780,6 +781,9 @@ $(DOC)\std_net_isemail.html : $(STDDOC) std\net\isemail.d
 
 $(DOC)\std_net_curl.html : $(STDDOC) std\net\curl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_net_curl.html $(STDDOC) std\net\curl.d
+
+$(DOC)\std_experimental_logger_asynclogger.html : $(STDDOC) std\experimental\logger\asynclogger.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_logger_asynclogger.html $(STDDOC) std\experimental\logger\asynclogger.d
 
 $(DOC)\std_experimental_logger_core.html : $(STDDOC) std\experimental\logger\core.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_logger_core.html $(STDDOC) std\experimental\logger\core.d


### PR DESCRIPTION
Asynchronous wrapper for std.experimental.logger. It sends log-message to special logging thread where the message is logged finally.
Discussion: http://forum.dlang.org/thread/lcsjtxorbbagmbvbllns@forum.dlang.org
