### PR TITLE
Force overflow/underflow in generic std.math implementations

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -1653,14 +1653,24 @@ real exp(real x) @trusted pure nothrow @nogc
         else
             static assert(0, "Not implemented for this architecture");
 
-        // Special cases.
-        // FIXME: set IEEE flags accordingly
+        // Special cases. Raises an overflow or underflow flag accordingly,
+        // except in the case for CTFE, where there are no hardware controls.
         if (isNaN(x))
             return x;
         if (x > OF)
-            return real.infinity;
+        {
+            if (__ctfe)
+                return real.infinity;
+            else
+                return real.max * copysign(real.max, real.infinity);
+        }
         if (x < UF)
-            return 0.0;
+        {
+            if (__ctfe)
+                return 0.0;
+            else
+                return real.min_normal * copysign(real.min_normal, 0.0);
+        }
 
         // Express: e^^x = e^^g * 2^^n
         //   = e^^g * e^^(n * LOG2E)
@@ -1899,9 +1909,15 @@ L_largenegative:
         enum real OF =  1.1356523406294143949492E4L;
         enum real UF = -4.5054566736396445112120088E1L;
 
-        // Special cases.
+        // Special cases. Raises an overflow flag, except in the case
+        // for CTFE, where there are no hardware controls.
         if (x > OF)
-            return real.infinity;
+        {
+            if (__ctfe)
+                return real.infinity;
+            else
+                return real.max * copysign(real.max, real.infinity);
+        }
         if (x == 0.0)
             return x;
         if (x < UF)
@@ -2148,13 +2164,24 @@ L_was_nan:
         enum real OF =  16384.0L;
         enum real UF = -16382.0L;
 
-        // Special cases.
+        // Special cases. Raises an overflow or underflow flag accordingly,
+        // except in the case for CTFE, where there are no hardware controls.
         if (isNaN(x))
             return x;
         if (x > OF)
-            return real.infinity;
+        {
+            if (__ctfe)
+                return real.infinity;
+            else
+                return real.max * copysign(real.max, real.infinity);
+        }
         if (x < UF)
-            return 0.0;
+        {
+            if (__ctfe)
+                return 0.0;
+            else
+                return real.min_normal * copysign(real.min_normal, 0.0);
+        }
 
         // Separate into integer and fractional parts.
         int n = cast(int)floor(x + 0.5);


### PR DESCRIPTION
If an overflow or underflow occurred in one of ``exp``, ``expm1``, or ``exp2`` we should return infinity or 0.0 computationally at runtime, forcing overflow/underflow ``ieeeFlags`` to be set.   At the same time, this still respects the fast path in CTFE.

This should fix the ``exp``/``exp2`` and ``ieeeFlags`` unittests for non-x86 targets (though only tested on gdc x86_64).