### PR TITLE
Replace pointer casts in std.math with union repainting

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5257,10 +5257,19 @@ bool isInfinity(X)(X x) @nogc @trusted pure nothrow
  */
 bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 {
+    // We're doing a bitwise comparison so the endianness is irrelevant.
     alias F = floatTraits!(real);
     F.Layout repX = { number : x }, repY = { number : y };
 
-    return repX.integral == repY.integral;
+    static if (F.realFormat == RealFormat.ieeeDouble)
+    {
+        return repX.integral == repY.integral;
+    }
+    else
+    {
+        return repX.integral[0] == repY.integral[0]
+            && repX.integral[1] == repY.integral[1];
+    }
 }
 
 /*********************************

--- a/std/math.d
+++ b/std/math.d
@@ -5692,7 +5692,7 @@ real nextUp(real x) @trusted pure nothrow @nogc
 /** ditto */
 double nextUp(double x) @trusted pure nothrow @nogc
 {
-    floatTraits!double.Layout rep = { number : x };
+    floatTraits!(double).Layout rep = { number : x };
 
     if ((rep.integral & 0x7FF0_0000_0000_0000) == 0x7FF0_0000_0000_0000)
     {
@@ -5719,7 +5719,7 @@ double nextUp(double x) @trusted pure nothrow @nogc
 /** ditto */
 float nextUp(float x) @trusted pure nothrow @nogc
 {
-    floatTraits!float.Layout rep = { number : x };
+    floatTraits!(float).Layout rep = { number : x };
 
     if ((rep.integral & 0x7F80_0000) == 0x7F80_0000)
     {
@@ -6546,9 +6546,9 @@ body
     // average them (avoiding overflow), and cast the result back to a floating-point number.
 
     alias F = floatTraits!(T);
-    F.Layout repX = { number : x },
-                repY = { number : y },
-                res;
+    F.Layout repX = { number : x };
+    F.Layout repY = { number : y };
+    F.Layout res;
 
     static if (F.realFormat == RealFormat.ieeeExtended)
     {
@@ -6579,7 +6579,7 @@ body
         else
             res.integral.significand = m; // ... unless exponent is 0 (subnormal or zero).
 
-        res.shorts[4]= e | (repX.shorts[F.EXPPOS_SHORT]& 0x8000); // restore sign bit
+        res.shorts[4] = e | (repX.shorts[F.EXPPOS_SHORT] & 0x8000); // restore sign bit
     }
     else static if (F.realFormat == RealFormat.ieeeQuadruple)
     {

--- a/std/math.d
+++ b/std/math.d
@@ -4125,9 +4125,7 @@ long lrint(real x) @trusted pure nothrow @nogc
                     else if (exp <= 31)
                         result = rep.ints[1] >> (31 - exp);
                     else
-                        result =
-                            (cast(long) rep.ints[1] << (exp - 31)) |
-                            (rep.ints[0] >> (63 - exp));
+                        result = (cast(long) rep.ints[1] << (exp - 31)) | (rep.ints[0] >> (63 - exp));
                 }
                 else
                 {
@@ -4136,9 +4134,7 @@ long lrint(real x) @trusted pure nothrow @nogc
                     else if (exp <= 31)
                         result = rep.ints[1] >> (31 - exp);
                     else
-                        result =
-                            (cast(long) rep.ints[1] << (exp - 31)) |
-                            (rep.ints[2] >> (63 - exp));
+                        result = (cast(long) rep.ints[1] << (exp - 31)) | (rep.ints[2] >> (63 - exp));
                 }
             }
             else

--- a/std/math.d
+++ b/std/math.d
@@ -5276,7 +5276,8 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 int signbit(X)(X x) @nogc @trusted pure nothrow
 {
     alias F = floatTraits!(X);
-    return ((cast(ubyte *)&x)[F.SIGNPOS_BYTE] & 0x80) != 0;
+    F.Repainter rep = { number : x };
+    return (rep.bytes[F.SIGNPOS_BYTE] & 0x80) != 0;
 }
 
 ///

--- a/std/math.d
+++ b/std/math.d
@@ -5264,25 +5264,10 @@ bool isInfinity(X)(X x) @nogc @trusted pure nothrow
  */
 bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 {
-    // We're doing a bitwise comparison so the endianness is irrelevant.
-    long*   pxs = cast(long *)&x;
-    long*   pys = cast(long *)&y;
     alias F = floatTraits!(real);
-    static if (F.realFormat == RealFormat.ieeeDouble)
-    {
-        return pxs[0] == pys[0];
-    }
-    else static if (F.realFormat == RealFormat.ieeeQuadruple
-                 || F.realFormat == RealFormat.ibmExtended)
-    {
-        return pxs[0] == pys[0] && pxs[1] == pys[1];
-    }
-    else
-    {
-        ushort* pxe = cast(ushort *)&x;
-        ushort* pye = cast(ushort *)&y;
-        return pxe[4] == pye[4] && pxs[0] == pys[0];
-    }
+    F.Repainter repX = { number : x }, repY = { number : y };
+
+    return repX.blob == repY.blob;
 }
 
 /*********************************

--- a/std/math.d
+++ b/std/math.d
@@ -4982,8 +4982,8 @@ bool isNaN(X)(X x) @nogc @trusted pure nothrow
 bool isFinite(X)(X x) @trusted pure nothrow @nogc
 {
     alias F = floatTraits!(X);
-    ushort* pe = cast(ushort *)&x;
-    return (pe[F.EXPPOS_SHORT] & F.EXPMASK) != F.EXPMASK;
+    F.Repainter rep = { number : x };
+    return (rep.shorts[F.EXPPOS_SHORT] & F.EXPMASK) != F.EXPMASK;
 }
 
 ///

--- a/std/math.d
+++ b/std/math.d
@@ -5087,30 +5087,26 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
         be converted to normal reals.
     */
     alias F = floatTraits!(X);
+    F.Repainter rep = { number : x };
     static if (F.realFormat == RealFormat.ieeeSingle)
     {
-        uint *p = cast(uint *)&x;
-        return (*p & F.EXPMASK_INT) == 0 && *p & F.MANTISSAMASK_INT;
+        return (rep.blob & F.EXPMASK_INT) == 0 && rep.blob & F.MANTISSAMASK_INT;
     }
     else static if (F.realFormat == RealFormat.ieeeDouble)
     {
-        uint *p = cast(uint *)&x;
-        return (p[MANTISSA_MSB] & F.EXPMASK_INT) == 0
-            && (p[MANTISSA_LSB] || p[MANTISSA_MSB] & F.MANTISSAMASK_INT);
+        return (rep.ints[MANTISSA_MSB] & F.EXPMASK_INT) == 0
+            && (rep.ints[MANTISSA_LSB] || rep.ints[MANTISSA_MSB] & F.MANTISSAMASK_INT);
     }
     else static if (F.realFormat == RealFormat.ieeeQuadruple)
     {
-        ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
-        long*   ps = cast(long *)&x;
+        ushort e = F.EXPMASK & rep.shorts[F.EXPPOS_SHORT];
         return (e == 0 &&
-          (((ps[MANTISSA_LSB]|(ps[MANTISSA_MSB]& 0x0000_FFFF_FFFF_FFFF))) != 0));
+          (((rep.longs[MANTISSA_LSB]|(rep.longs[MANTISSA_MSB]& 0x0000_FFFF_FFFF_FFFF))) != 0));
     }
     else static if (F.realFormat == RealFormat.ieeeExtended)
     {
-        ushort* pe = cast(ushort *)&x;
-        long*   ps = cast(long *)&x;
-
-        return (pe[F.EXPPOS_SHORT] & F.EXPMASK) == 0 && *ps > 0;
+        return (rep.shorts[F.EXPPOS_SHORT] & F.EXPMASK) == 0 &&
+            rep.blob.significand > 0;
     }
     else static if (F.realFormat == RealFormat.ibmExtended)
     {

--- a/std/math.d
+++ b/std/math.d
@@ -382,19 +382,21 @@ template floatTraits(T)
     else
         static assert(false, "No traits support for " ~ T.stringof);
 
+    // Intended to use for reinterpreting floating-point numbers
+    // as various integral types
     union Repainter
     {
         Unqual!T number;
         ubyte[T.sizeof] bytes;
         ushort[T.sizeof / 2] shorts;
         uint[T.sizeof / 4] ints;
-        Blob blob;
+        Blob blob; // Reinterpret into fewest integrals possible
 
         static if (T.sizeof % 8 == 0)
             ulong[T.sizeof / 8] longs;
 
         static if (realFormat == RealFormat.ibmExtended)
-            double[2] doubles;
+            double[2] doubles; // Because it *is* a pair of doubles
     }
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -5043,7 +5043,8 @@ bool isNormal(X)(X x) @trusted pure nothrow @nogc
     }
     else
     {
-        ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
+        F.Repainter rep = { number : x };
+        ushort e = F.EXPMASK & rep.shorts[F.EXPPOS_SHORT];
         return (e != F.EXPMASK && e != 0);
     }
 }

--- a/std/math.d
+++ b/std/math.d
@@ -5149,32 +5149,32 @@ bool isInfinity(X)(X x) @nogc @trusted pure nothrow
     if (isFloatingPoint!(X))
 {
     alias F = floatTraits!(X);
+    F.Repainter rep = { number : x };
     static if (F.realFormat == RealFormat.ieeeSingle)
     {
-        return ((*cast(uint *)&x) & 0x7FFF_FFFF) == 0x7F80_0000;
+        return (rep.blob & 0x7FFF_FFFF) == 0x7F80_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeDouble)
     {
-        return ((*cast(ulong *)&x) & 0x7FFF_FFFF_FFFF_FFFF)
+        return (rep.blob & 0x7FFF_FFFF_FFFF_FFFF)
             == 0x7FF0_0000_0000_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeExtended)
     {
-        const ushort e = cast(ushort)(F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT]);
-        const ulong ps = *cast(ulong *)&x;
+        const ushort e = cast(ushort)(F.EXPMASK & rep.shorts[F.EXPPOS_SHORT]);
 
         // On Motorola 68K, infinity can have hidden bit = 1 or 0. On x86, it is always 1.
-        return e == F.EXPMASK && (ps & 0x7FFF_FFFF_FFFF_FFFF) == 0;
+        return e == F.EXPMASK && (rep.blob.significand & 0x7FFF_FFFF_FFFF_FFFF) == 0;
     }
     else static if (F.realFormat == RealFormat.ibmExtended)
     {
-        return (((cast(ulong *)&x)[MANTISSA_MSB]) & 0x7FFF_FFFF_FFFF_FFFF)
+        return ((rep.blob[MANTISSA_MSB]) & 0x7FFF_FFFF_FFFF_FFFF)
             == 0x7FF8_0000_0000_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeQuadruple)
     {
-        const long psLsb = (cast(long *)&x)[MANTISSA_LSB];
-        const long psMsb = (cast(long *)&x)[MANTISSA_MSB];
+        const long psLsb = rep.longs[MANTISSA_LSB];
+        const long psMsb = rep.longs[MANTISSA_MSB];
         return (psLsb == 0)
             && (psMsb & 0x7FFF_FFFF_FFFF_FFFF) == 0x7FFF_0000_0000_0000;
     }

--- a/std/math.d
+++ b/std/math.d
@@ -5174,7 +5174,7 @@ bool isInfinity(X)(X x) @nogc @trusted pure nothrow
     }
     else static if (F.realFormat == RealFormat.ibmExtended)
     {
-        return ((rep.integral[MANTISSA_MSB]) & 0x7FFF_FFFF_FFFF_FFFF)
+        return ((rep.longs[MANTISSA_MSB]) & 0x7FFF_FFFF_FFFF_FFFF)
             == 0x7FF8_0000_0000_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeQuadruple)

--- a/std/math.d
+++ b/std/math.d
@@ -5326,14 +5326,14 @@ int signbit(X)(X x) @nogc @trusted pure nothrow
 R copysign(R, X)(R to, X from) @trusted pure nothrow @nogc
     if (isFloatingPoint!(R) && isFloatingPoint!(X))
 {
-    ubyte* pto   = cast(ubyte *)&to;
-    const ubyte* pfrom = cast(ubyte *)&from;
-
     alias T = floatTraits!(R);
     alias F = floatTraits!(X);
-    pto[T.SIGNPOS_BYTE] &= 0x7F;
-    pto[T.SIGNPOS_BYTE] |= pfrom[F.SIGNPOS_BYTE] & 0x80;
-    return to;
+    T.Repainter repTo = { number : to };
+    F.Repainter repFrom = { number : from };
+
+    repTo.bytes[T.SIGNPOS_BYTE] &= 0x7F;
+    repTo.bytes[T.SIGNPOS_BYTE] |= repFrom.bytes[F.SIGNPOS_BYTE] & 0x80;
+    return repTo.number;
 }
 
 // ditto

--- a/std/math.d
+++ b/std/math.d
@@ -267,6 +267,8 @@ template floatTraits(T)
             enum EXPPOS_SHORT = 0;
             enum SIGNPOS_BYTE = 0;
         }
+
+        alias Blob = uint;
     }
     else static if (T.mant_dig == 53)
     {
@@ -289,6 +291,8 @@ template floatTraits(T)
                 enum EXPPOS_SHORT = 0;
                 enum SIGNPOS_BYTE = 0;
             }
+
+            alias Blob = ulong;
         }
         else static if (T.sizeof == 12)
         {
@@ -307,6 +311,9 @@ template floatTraits(T)
                 enum EXPPOS_SHORT = 0;
                 enum SIGNPOS_BYTE = 0;
             }
+
+            import std.typecons : Tuple;
+            alias Blob = Tuple!(ulong, ushort);
         }
         else
             static assert(false, "No traits support for " ~ T.stringof);
@@ -328,6 +335,9 @@ template floatTraits(T)
             enum EXPPOS_SHORT = 0;
             enum SIGNPOS_BYTE = 0;
         }
+
+        import std.typecons : Tuple;
+        alias Blob = Tuple!(ulong, "significand", ushort);
     }
     else static if (T.mant_dig == 113)
     {
@@ -346,6 +356,8 @@ template floatTraits(T)
             enum EXPPOS_SHORT = 0;
             enum SIGNPOS_BYTE = 0;
         }
+
+        alias Blob = ulong[2];
     }
     else static if (T.mant_dig == 106)
     {
@@ -364,9 +376,22 @@ template floatTraits(T)
             enum EXPPOS_SHORT = 0; // [4] is also an exp short
             enum SIGNPOS_BYTE = 0;
         }
+
+        alias Blob = ulong[2];
     }
     else
         static assert(false, "No traits support for " ~ T.stringof);
+
+    union Repainter
+    {
+        Unqual!T number;
+        ubyte[T.sizeof] bytes;
+        ushort[T.sizeof / 2] shorts;
+        Blob blob;
+
+        static if (T.sizeof % 8 == 0)
+            ulong[T.sizeof / 8] longs;
+    }
 }
 
 // These apply to all floating-point types


### PR DESCRIPTION
From the comments received on #3022, I was left with an impression that unions are generally preferred to pointer casts, and should be used instead wherever possible. So I went ahead and replaced most of the pointer casts with unions.

This is mostly straightforward one-to-one replacement, with notable exception of `isIdentical`, because I couldn't resist the temptation.

I didn't touch `NaN` and `getNaNPayload`, because
1. I couldn't figure out what real formats are actually supported by them.
2. I've no idea how to translate these weird unaligned reads/stores [[1]](https://github.com/D-Programming-Language/phobos/blob/master/std/math.d#L5257-L5264)[[2]](https://github.com/D-Programming-Language/phobos/blob/master/std/math.d#L5309-L5316) into unions in a sane way.

Destroy!