### PR TITLE
Helper function for isInputRange to help with compile-time errors

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -148,15 +148,9 @@ Returns:
  */
 template isInputRange(R)
 {
-    enum bool isInputRange = is(typeof(
-    (inout int = 0)
-    {
-        R r = R.init;     // can define a range object
-        if (r.empty) {}   // can test for empty
-        r.popFront();     // can invoke popFront()
-        auto h = r.front; // can get the front of the range
-    }));
+    enum bool isInputRange = is(typeof(checkInputRange!R));
 }
+
 
 ///
 @safe unittest
@@ -174,6 +168,31 @@ template isInputRange(R)
     static assert( isInputRange!(char[]));
     static assert(!isInputRange!(char[4]));
     static assert( isInputRange!(inout(int)[]));
+}
+
+/**
+Helper function for $(D isInputRange), enabling its usage
+with $(D std.traits.models).
+*/
+void checkInputRange(R)(inout int = 0)
+{
+    R r = R.init;     // can define a range object
+    if (r.empty) {}   // can test for empty
+    r.popFront();     // can invoke popFront()
+    auto h = r.front; // can get the front of the range
+}
+
+///
+@safe unittest
+{
+    import std.traits;
+    @models!(Zeroes, isInputRange)
+    struct Zeroes
+    {
+        enum empty = false;
+        void popFront() {}
+        @property int front() { return 0; }
+    }
 }
 
 /+

--- a/std/traits.d
+++ b/std/traits.d
@@ -132,6 +132,7 @@
  *           $(LREF hasUDA)
  *           $(LREF getUDAs)
  *           $(LREF getSymbolsByUDA)
+ *           $(LREF models)
  * ))
  * )
  * )
@@ -6728,4 +6729,101 @@ unittest
     static assert(getSymbolsByUDA!(C, UDA).length == 2);
     static assert(getSymbolsByUDA!(C, UDA)[0].stringof == "C");
     static assert(getSymbolsByUDA!(C, UDA)[1].stringof == "d");
+}
+
+/**
+ * A static assertion that a type satisfies a given template constraint.
+ * It can be used as a $(LINK2 ../attribute.html#uda, UDA) or
+ * in a $(D static assert) to make sure that a type conforms
+ * to the compile-time interface the user expects it to.
+ * The difference between using $(D models) and a simple static assert
+ * with the template contraint is that $(D models) will instantiate the
+ * failing code when the constraint is not satisfied,
+ * yielding compiler error messages to aid the user.
+ *
+ * The template contraint predicate must start with the word $(D is)
+ * (e.g. $(D isInputRange)) and an associated template function
+ * with the "is" replaced by "check" should exist (e.g. $(D checkInputRange))
+ * and be defined in the same module.
+ */
+template models(T, alias P, A...)
+{
+    static assert(P.stringof[0..2] == "is",
+                  P.stringof ~ " does not begin with 'is', which is require by `models`");
+
+    static if(P!(T, A))
+    {
+        bool models()
+        {
+            return true;
+        }
+    }
+    else
+    {
+        bool models()
+        {
+            import std.algorithm;
+            enum openParenIndex = P.stringof.countUntil("(");
+            //2 to get rid of "is"
+            enum untilOpenParen = P.stringof[2 .. openParenIndex];
+            enum checkName = "check" ~ untilOpenParen;
+            enum mixinStr = checkName ~ "!(T, A);";
+            mixin("import " ~ moduleName!(P) ~ ";"); //make it visible first
+            mixin(mixinStr);
+            return false;
+        }
+    }
+}
+
+
+///
+unittest
+{
+    void checkFoo(T)()
+    {
+        T t = T.init;
+        t.foo();
+    }
+
+    enum isFoo(T) = is(typeof(checkFoo!T));
+
+    void checkBar(T, U)()
+    {
+        U _bar = T.init.bar;
+    }
+
+    template isBar(T, U)
+    {
+        enum isBar = is(typeof(checkBar!(T, U)));
+    }
+
+    @models!(Foo, isFoo) //as a UDA
+    struct Foo
+    {
+        void foo() {}
+        static assert(models!(Foo, isFoo)); //as a static assert
+    }
+
+    @models!(Bar, isBar, byte) //as a UDA
+    struct Bar
+    {
+        byte bar;
+        static assert(models!(Bar, isBar, byte)); //as a static assert
+    }
+
+    // can't assert that, e.g. !models!(Bar, isFoo) -
+    // the whole point of `models` is that it doesn't compile
+    // when the template constraint is not satisfied
+    static assert(!__traits(compiles, models!(Bar, isFoo)));
+    static assert(!__traits(compiles, models!(Foo, isBar, byte)));
+}
+
+unittest
+{
+    struct Foo {}
+    enum weirdPred(T) = true;
+    //always true, this is a sanity check
+    static assert(weirdPred!Foo);
+    //shouldn't compile since weirdPred doesn't begin with the word "is"
+    static assert(!__traits(compiles, models!(Foo, weirdPred)));
 }


### PR DESCRIPTION
As seen is Adam D. Ruppe's D Cookbook. This commit lets users assert that
their own types are input ranges and get meaninful compiler errors for
when their static assertions fail.