### PR TITLE
Add Specializations for SortedRange

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2864,6 +2864,76 @@ unittest
     assert(minPos!("a[0] < b[0]")(b) == [ [2, 4], [4], [4] ]);
 }
 
+import std.algorithm.comparison : min, max;
+
+/** Returns: Minimum Element in $(D range) or $(D unit) if $(D range) is empty.
+*/
+auto minElement(alias F = min, R)(R range,
+                                  ElementType!R unit = ElementType!R.max)
+    if (isInputRange!R)
+{
+    import std.range.primitives : isSortedRange;
+    static if (isSortedRange!(R, "a < b"))
+    {
+        import std.range.primitives : front;
+        return range.empty ? unit : range.front;
+    }
+    else static if (isSortedRange!(R, "a > b") &&
+                    isBidirectionalRange!R)
+    {
+        import std.range.primitives : back;
+        return range.empty ? unit : range.back;
+    }
+    else
+    {
+        import std.algorithm.iteration : reduce;
+        return reduce!F(unit, range);
+    }
+}
+
+@safe pure nothrow unittest
+{
+    import std.algorithm.sorting : sort, assumeSorted;
+    auto x = [2, 4, 1, 3];
+    assert(x.minElement == 1);
+    assert(x.sort!"a < b".minElement == 1);
+    assert(x.sort!"a > b".minElement == 1);
+}
+
+/** Returns: Maximum Element in $(D range) or $(D unit) if $(D range) is empty.
+ */
+auto maxElement(alias F = max, R)(R range,
+                                  ElementType!R unit = ElementType!R.min)
+    if (isInputRange!R)
+{
+    import std.range.primitives : isSortedRange;
+    static if (isSortedRange!(R, "a > b"))
+    {
+        import std.range.primitives : front;
+        return range.empty ? unit : range.front;
+    }
+    else static if (isSortedRange!(R, "a < b") &&
+                    isBidirectionalRange!R)
+    {
+        import std.range.primitives : back;
+        return range.empty ? unit : range.back;
+    }
+    else
+    {
+        import std.algorithm.iteration : reduce;
+        return reduce!F(unit, range);
+    }
+}
+
+@safe pure nothrow unittest
+{
+    import std.algorithm.sorting : sort, assumeSorted;
+    auto x = [2, 4, 1, 3];
+    assert(x.maxElement == 4);
+    assert(x.sort!"a < b".maxElement == 4);
+    assert(x.sort!"a > b".maxElement == 4);
+}
+
 /**
 Skip over the initial portion of the first given range that matches the second
 range, or do nothing if there is no match.

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2777,7 +2777,7 @@ smallest element and with the same ending as $(D range). The function
 can actually be used for finding the maximum or any other ordering
 predicate (that's why $(D maxPos) is not provided).
  */
-auto minPos(alias pred = "a < b", Range)(Range range)
+Range minPos(alias pred = "a < b", Range)(Range range)
     if (isForwardRange!Range && !isInfinite!Range &&
         is(typeof(binaryFun!pred(range.front, range.front))))
 {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2781,13 +2781,13 @@ auto minPos(alias pred = "a < b", Range)(Range range)
     if (isForwardRange!Range && !isInfinite!Range &&
         is(typeof(binaryFun!pred(range.front, range.front))))
 {
-    if (range.empty) return range;
     static if (isSortedRange!(Range, pred))
     {
         return range;
     }
     else
     {
+        if (range.empty) return range;
         auto result = range.save;
 
         for (range.popFront(); !range.empty; range.popFront())

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2867,7 +2867,7 @@ unittest
 import std.algorithm.comparison : min, max;
 
 /** Returns: Minimum Element in $(D range) or $(D unit) if $(D range) is empty.
-*/
+ */
 auto minElement(alias F = min, R)(R range,
                                   ElementType!R unit = ElementType!R.max)
     if (isInputRange!R)

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -131,39 +131,45 @@ less).
 */
 bool isSorted(alias less = "a < b", Range)(Range r) if (isForwardRange!(Range))
 {
-    if (r.empty) return true;
-
-    static if (isRandomAccessRange!Range && hasLength!Range)
+    static if (isSortedRange!(Range, less))
     {
-        immutable limit = r.length - 1;
-        foreach (i; 0 .. limit)
-        {
-            if (!binaryFun!less(r[i + 1], r[i])) continue;
-            assert(
-                !binaryFun!less(r[i], r[i + 1]),
-                "Predicate for isSorted is not antisymmetric. Both" ~
-                        " pred(a, b) and pred(b, a) are true for certain values.");
-            return false;
-        }
+        return true;
     }
     else
     {
-        auto ahead = r;
-        ahead.popFront();
-        size_t i;
-
-        for (; !ahead.empty; ahead.popFront(), r.popFront(), ++i)
+        if (r.empty) return true;
+        static if (isRandomAccessRange!Range && hasLength!Range)
         {
-            if (!binaryFun!less(ahead.front, r.front)) continue;
-            // Check for antisymmetric predicate
-            assert(
-                !binaryFun!less(r.front, ahead.front),
-                "Predicate for isSorted is not antisymmetric. Both" ~
-                        " pred(a, b) and pred(b, a) are true for certain values.");
-            return false;
+            immutable limit = r.length - 1;
+            foreach (i; 0 .. limit)
+            {
+                if (!binaryFun!less(r[i + 1], r[i])) continue;
+                assert(
+                    !binaryFun!less(r[i], r[i + 1]),
+                    "Predicate for isSorted is not antisymmetric. Both" ~
+                    " pred(a, b) and pred(b, a) are true for certain values.");
+                return false;
+            }
         }
+        else
+        {
+            auto ahead = r;
+            ahead.popFront();
+            size_t i;
+
+            for (; !ahead.empty; ahead.popFront(), r.popFront(), ++i)
+            {
+                if (!binaryFun!less(ahead.front, r.front)) continue;
+                // Check for antisymmetric predicate
+                assert(
+                    !binaryFun!less(r.front, ahead.front),
+                    "Predicate for isSorted is not antisymmetric. Both" ~
+                    " pred(a, b) and pred(b, a) are true for certain values.");
+                return false;
+            }
+        }
+        return true;
     }
-    return true;
 }
 
 ///
@@ -175,6 +181,7 @@ bool isSorted(alias less = "a < b", Range)(Range r) if (isForwardRange!(Range))
     assert(isSorted(arr));
     sort!("a > b")(arr);
     assert(isSorted!("a > b")(arr));
+    assert(isSorted(sort(arr)));
 }
 
 @safe unittest

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -954,7 +954,7 @@ See_Also:
 */
 SortedRange!(Range, less)
 sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
-        Range)(Range r)
+     Range)(Range r)
     if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
                                           hasAssignableElements!Range)) ||
          (ss != SwapStrategy.unstable && hasAssignableElements!Range)) &&
@@ -970,7 +970,7 @@ sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
     import std.range.primitives: isSortedRange;
     static if (isSortedRange!(Range, less))
     {
-        return r;
+        return r;               // already sorted, so just return $(D r) as is
     }
     else
     {

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -973,8 +973,7 @@ sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
        swaps using assignment.
        Stable sorting uses TimSort, which needs to copy elements into a buffer,
        requiring assignable elements. +/
-{
-    import std.range.primitives: isSortedRange;
+    {
     static if (isSortedRange!(Range, less))
     {
         return r;               // already sorted, so just return $(D r) as is

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7656,64 +7656,6 @@ unittest
 }
 
 /**
-   Returns true if $(D T) is an instance of the template $(D T) with template
-   parameters $(D Ps).
-*/
-template isSortedRange(T, alias pred = "a < b")
-{
-    import std.traits : TemplateArgsOf;
-
-    static if (TemplateArgsOf!T.length == 2)
-    {
-        import std.functional : binaryFun;
-
-        alias predArg = TemplateArgsOf!T[1];
-        static if (isSomeString!(typeof(pred)))
-        {
-            alias predFun = binaryFun!pred;
-        }
-        else
-        {
-            alias predFun = pred;
-        }
-
-        static if (isSomeString!(typeof(predArg)))
-        {
-            alias predArgFun = binaryFun!predArg;
-        }
-        else
-        {
-            alias predArgFun = predArg;
-        }
-
-        enum isSortedRange = (is(T == SortedRange!Args, Args...) &&
-                              is(typeof(predFun) == typeof(predArgFun)));
-    }
-    else
-    {
-        enum isSortedRange = false;
-    }
-}
-
-///
-unittest
-{
-    import std.functional : binaryFun;
-
-    alias R = int[];
-    enum pred = "a < b";
-    alias fun = binaryFun!pred;
-
-    alias SR = SortedRange!(R, pred);
-    static assert(isSortedRange!(SR, pred));
-    static assert(isSortedRange!(SR, fun));
-
-    alias SR2 = SortedRange!(R, binaryFun!pred);
-    static assert(isSortedRange!(SR2, pred));
-    static assert(isSortedRange!(SR2, fun));
-}
-
-/**
 $(D SortedRange) could accept ranges weaker than random-access, but it
 is unable to provide interesting functionality for them. Therefore,
 $(D SortedRange) is currently restricted to random-access ranges.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7656,6 +7656,43 @@ unittest
 }
 
 /**
+   Returns true if $(D T) is an instance of the template $(D T) with template
+   parameters $(D Ps).
+*/
+template isSortedRange(T, alias pred = "a < b")
+{
+    import std.traits : TemplateArgsOf;
+    import std.functional : binaryFun;
+
+    static if (isSomeString!(typeof(pred)))
+    {
+        alias predFun = binaryFun!pred;
+    }
+    else
+    {
+        alias predFun = pred;
+    }
+
+    enum isSortedRange = (is(T == SortedRange!Args, Args...) &&
+                          is(typeof(predFun) ==
+                             typeof(binaryFun!(TemplateArgsOf!T[1]))));
+}
+
+///
+unittest
+{
+    import std.functional : binaryFun;
+
+    alias R = int[];
+    enum pred = "a < b";
+
+    alias SR = SortedRange!(R, pred);
+    static assert(isSortedRange!(SR, pred));
+
+    static assert(isSortedRange!(SR, binaryFun!pred));
+}
+
+/**
 $(D SortedRange) could accept ranges weaker than random-access, but it
 is unable to provide interesting functionality for them. Therefore,
 $(D SortedRange) is currently restricted to random-access ranges.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7702,14 +7702,15 @@ unittest
 
     alias R = int[];
     enum pred = "a < b";
+    alias fun = binaryFun!pred;
 
     alias SR = SortedRange!(R, pred);
     static assert(isSortedRange!(SR, pred));
-    static assert(isSortedRange!(SR, binaryFun!pred));
+    static assert(isSortedRange!(SR, fun));
 
     alias SR2 = SortedRange!(R, binaryFun!pred);
     static assert(isSortedRange!(SR2, pred));
-    static assert(isSortedRange!(SR2, binaryFun!pred));
+    static assert(isSortedRange!(SR2, fun));
 }
 
 /**

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1072,7 +1072,7 @@ unittest
     alias fun = binaryFun!pred;
 
     enum rpred = "a > b";
-    alias rfun = binaryFun!pred;
+    alias rfun = binaryFun!rpred;
 
     import std.range : SortedRange;
 
@@ -1086,7 +1086,7 @@ unittest
 
     alias SR_ = SortedRange!(R, pred);
     static assert(!isSortedRange!(SR_, rpred));
-    // static assert(!isSortedRange!(SR_, rfun));
+    static assert(!isSortedRange!(SR_, rfun));
 
     alias IR = int[];
     static assert(!isSortedRange!(IR, pred));

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1004,47 +1004,53 @@ unittest
 */
 template isSortedRange(T, alias pred = "a < b")
 {
-    import std.traits : TemplateArgsOf;
     import std.range : SortedRange;
-
-    static if (is(T == SortedRange!Args, Args...) &&
-               TemplateArgsOf!T.length == 2)
+    static if (is(T == SortedRange!Args, Args...))
     {
-        import std.functional : binaryFun;
-
-        alias predArg = TemplateArgsOf!T[1];
-
-        static if (isSomeString!(typeof(pred)) &&
-                   isSomeString!(typeof(predArg)))
+        import std.traits : TemplateArgsOf;
+        alias TArgs = TemplateArgsOf!T;
+        static if (TArgs.length == 2)
         {
-            /*
-              TODO Remove this when we find a way to
-              - distinguish binaryFun!"a < b" from binaryFun!"a > b"
-              - equate binaryFun!"a < b" from binaryFun!"a<b"
-             */
-            enum isSortedRange = pred == predArg;
+            alias predArg = TArgs[1];
+
+            static if (isSomeString!(typeof(pred)) &&
+                       isSomeString!(typeof(predArg)))
+            {
+                /*
+                  TODO Remove this when we find a way to
+                  - distinguish binaryFun!"a < b" from binaryFun!"a > b"
+                  - equate binaryFun!"a < b" from binaryFun!"a<b"
+                */
+                enum isSortedRange = pred == predArg;
+            }
+            else
+            {
+                import std.functional : binaryFun;
+
+                static if (isSomeString!(typeof(pred)))
+                {
+                    alias predFun = binaryFun!pred;
+                }
+                else
+                {
+                    alias predFun = pred;
+                }
+
+                static if (isSomeString!(typeof(predArg)))
+                {
+                    alias predArgFun = binaryFun!predArg;
+                }
+                else
+                {
+                    alias predArgFun = predArg;
+                }
+
+                enum isSortedRange = is(typeof(predFun) == typeof(predArgFun));
+            }
         }
         else
         {
-            static if (isSomeString!(typeof(pred)))
-            {
-                alias predFun = binaryFun!pred;
-            }
-            else
-            {
-                alias predFun = pred;
-            }
-
-            static if (isSomeString!(typeof(predArg)))
-            {
-                alias predArgFun = binaryFun!predArg;
-            }
-            else
-            {
-                alias predArgFun = predArg;
-            }
-
-            enum isSortedRange = is(typeof(predFun) == typeof(predArgFun));
+            enum isSortedRange = false;
         }
     }
     else

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1005,8 +1005,10 @@ unittest
 template isSortedRange(T, alias pred = "a < b")
 {
     import std.traits : TemplateArgsOf;
+    import std.range: SortedRange;
 
-    static if (TemplateArgsOf!T.length == 2)
+    static if (is(T == SortedRange!Args, Args...) &&
+               TemplateArgsOf!T.length == 2)
     {
         import std.functional : binaryFun;
 
@@ -1029,9 +1031,7 @@ template isSortedRange(T, alias pred = "a < b")
             alias predArgFun = predArg;
         }
 
-        import std.range: SortedRange;
-        enum isSortedRange = (is(T == SortedRange!Args, Args...) &&
-                              is(typeof(predFun) == typeof(predArgFun)));
+        enum isSortedRange = is(typeof(predFun) == typeof(predArgFun));
     }
     else
     {
@@ -1057,6 +1057,10 @@ unittest
     alias SR2 = SortedRange!(R, binaryFun!pred);
     static assert(isSortedRange!(SR2, pred));
     static assert(isSortedRange!(SR2, fun));
+
+    alias IR = int[];
+    static assert(!isSortedRange!(IR, pred));
+    static assert(!isSortedRange!(IR, fun));
 }
 
 @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1004,12 +1004,12 @@ auto standardizePredicatePrefix(S)(S s) if (isSomeString!S)
         if (s[0] != 'a')
             return s;
 
-        size_t wsCount = 0;
-        while (1 + wsCount < s.length &&
-               s[1 + wsCount] == ' ')
-            ++wsCount;
+        size_t n = 0; // whitespace count
+        while (1 + n < s.length &&
+               s[1 + n] == ' ')
+            ++n;
 
-        return 'a' ~ s[1 + wsCount .. $];
+        return 'a' ~ s[1 + n .. $];
     }
     return s;
 }
@@ -1021,12 +1021,12 @@ auto standardizePredicateSuffix(S)(S s) if (isSomeString!S)
         if (s[$ - 1] != 'b')
             return s;
 
-        size_t wsCount = 0;
-        while (1 + wsCount < s.length &&
-               s[$ - 2 - wsCount] == ' ')
-            ++wsCount;
+        size_t n = 0; // whitespace count
+        while (1 + n < s.length &&
+               s[$ - 2 - n] == ' ')
+            ++n;
 
-        return s[0 .. $ - 1 - wsCount] ~ 'b';
+        return s[0 .. $ - 1 - n] ~ 'b';
     }
     return s;
 }

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1001,10 +1001,15 @@ auto standardizePredicatePrefix(S)(S s) if (isSomeString!S)
 {
     if (s.length >= 2)
     {
-        if (s[0 .. 2] == "a ")
-        {
-            return "a" ~ s[2 .. $];
-        }
+        if (s[0] != 'a')
+            return s;
+
+        size_t wsCount = 0;
+        while (1 + wsCount < s.length &&
+               s[1 + wsCount] == ' ')
+            ++wsCount;
+
+        return 'a' ~ s[1 + wsCount .. $];
     }
     return s;
 }
@@ -1013,10 +1018,15 @@ auto standardizePredicateSuffix(S)(S s) if (isSomeString!S)
 {
     if (s.length >= 2)
     {
-        if (s[2 .. $] == " b")
-        {
-            return s[0 .. $ - 2] ~ "b";
-        }
+        if (s[$ - 1] != 'b')
+            return s;
+
+        size_t wsCount = 0;
+        while (1 + wsCount < s.length &&
+               s[$ - 2 - wsCount] == ' ')
+            ++wsCount;
+
+        return s[0 .. $ - 1 - wsCount] ~ 'b';
     }
     return s;
 }
@@ -1029,6 +1039,8 @@ auto standardizePredicate(S)(S s) if (isSomeString!S)
 unittest
 {
     static assert(standardizePredicate("a < b") == "a<b");
+    static assert(standardizePredicate("a  < b") == "a<b");
+    static assert(standardizePredicate("a    <=    b") == "a<=b");
     static assert(standardizePredicate("a > b") == "a>b");
 }
 
@@ -1066,7 +1078,7 @@ template isSortedRange(T, alias pred = "a < b")
             }
             else
             {
-                alias predString = binaryFunString!(pred);
+                alias predString = binaryFunString!pred;
             }
 
             static if (isSomeString!(typeof(predArg)))
@@ -1075,7 +1087,7 @@ template isSortedRange(T, alias pred = "a < b")
             }
             else
             {
-                alias predArgString = binaryFunString!(predArg);
+                alias predArgString = binaryFunString!predArg;
             }
 
             enum isSortedRange = (standardizePredicate(predString) ==

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1001,6 +1001,8 @@ unittest
    Returns true if $(D T) is a Range Sorted on predicate $(D pred).
 
    Currently checks if $(D T) is an instance of $(D SortedRange).
+
+   See also: http://forum.dlang.org/post/mqskge$2968$1@digitalmars.com
 */
 template isSortedRange(T, alias pred = "a < b")
 {
@@ -1045,7 +1047,7 @@ template isSortedRange(T, alias pred = "a < b")
                     alias predArgFun = predArg;
                 }
 
-                enum isSortedRange = is(typeof(predFun) == typeof(predArgFun));
+                enum isSortedRange = __traits(isSame, predFun, predArgFun);
             }
         }
         else

--- a/std/traits.d
+++ b/std/traits.d
@@ -5544,7 +5544,7 @@ unittest
 }
 
 /**
- * Returns true if T is an instance of the template S.
+ Returns true if $(D T) is an instance of the template $(D T).
  */
 enum bool isInstanceOf(alias S, T) = is(T == S!Args, Args...);
 


### PR DESCRIPTION
Add new predicate function `std.range.primitives.isSortedRange`: **DONE**

Add specializations for `SortedRange` in the followings algorithms:
- `sort`: just return input argument if `pred` parameter matches: **DONE**
- `sort`-alikes: just return input argument if `pred` parameter matches:
- `isSorted`: return `true`: **DONE**
- `find` and alikes, should do some kind of binary search. These could take an extra param `SearchPolicy` for sorted ranges that defaults to binary search.
- Some of the functions that return a sub-range or a mutated range could probably be returning sorted ranges as well if its input is a sorted range, `remove`, `strip` and `split` at least could.
- `minPos`: return input as is, if `pred` matches: **DONE**

In compliance with C++ STL also add
- `minElement`: O(1) for `SortedRange`, O(n) otherwise: **DONE**
- `maxElement`: O(1) for `SortedRange!BidirectionalRange`, O(n) otherwise: **DONE**
- `minmaxElement`: O(1) for `SortedRange!BidirectionalRange`, O(n) otherwise.

See also: http://forum.dlang.org/post/yenezfjjteokzyvgmzcf@forum.dlang.org
See also: https://issues.dlang.org/show_bug.cgi?id=11667
See also: http://forum.dlang.org/post/mqskao$28vh$1@digitalmars.com

See also: http://en.cppreference.com/w/cpp/algorithm/min_element
