### PR TITLE
fix Issue 13780 - Empty ParameterIdentifierTuple for function literal

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1107,7 +1107,7 @@ unittest
 
 
 /**
-Get, as a tuple, the identifiers of the parameters to a function symbol.
+Get, as a tuple, the identifiers of the parameters of a function or delegate.
  */
 template ParameterIdentifierTuple(func...)
     if (func.length == 1 && isCallable!func)
@@ -1116,9 +1116,8 @@ template ParameterIdentifierTuple(func...)
     {
         template Get(size_t i)
         {
-            static if (!isFunctionPointer!func && !isDelegate!func
-                       // Unnamed parameters yield CT error.
-                       && is(typeof(__traits(identifier, PT[i..i+1]))x))
+            // Unnamed parameters yield CT error.
+            static if (is(typeof(__traits(identifier, PT[i..i+1]))x))
             {
                 enum Get = __traits(identifier, PT[i..i+1]);
             }
@@ -1162,13 +1161,11 @@ unittest
     void bar(int num, string name, int[] array){}
     static assert([PIT!bar] == ["num", "name", "array"]);
 
-    // might be changed in the future?
     void function(int num, string name) fp;
-    static assert([PIT!fp] == ["", ""]);
+    static assert([PIT!fp] == ["num", "name"]);
 
-    // might be changed in the future?
     void delegate(int num, string name, int[long] aa) dg;
-    static assert([PIT!dg] == ["", "", ""]);
+    static assert([PIT!dg] == ["num", "name", "aa"]);
 
     interface Test
     {


### PR DESCRIPTION
ParameterIdentifierTuple intentionally did not accept function pointers and delegates. This surprised people, particularly when using function literals, as indicated in issue 13780. This commit changes that, allowing the issue to be closed.

https://issues.dlang.org/show_bug.cgi?id=13780
