### PR TITLE
Better static assertion on template contraints with 'models'

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6941,16 +6941,16 @@ unittest
 /**
  * A static assertion that a type satisfies a given template constraint.
  * It can be used as a $(LINK2 ../attribute.html#uda, UDA) or
- * in a $(D static assert) to make sure that a type conforms
+ * in a `static assert` to make sure that a type conforms
  * to the compile-time interface the user expects it to.
- * The difference between using $(D models) and a simple static assert
- * with the template contraint is that $(D models) will instantiate the
+ * The difference between using `models` and a simple static assert
+ * with the template contraint is that `models` will instantiate the
  * failing code when the constraint is not satisfied,
  * yielding compiler error messages to aid the user.
  *
- * The template contraint predicate must start with the word $(D is)
- * (e.g. $(D isInputRange)) and an associated template function
- * with the "is" replaced by "check" should exist (e.g. $(D checkInputRange))
+ * The template contraint predicate must start with the word `is`
+ * (e.g. `isInputRange`) and an associated template function
+ * with the "is" replaced by "check" should exist (e.g. `checkInputRange`)
  * and be defined in the same module.
  */
 template models(T, alias P, A...)
@@ -6969,10 +6969,9 @@ template models(T, alias P, A...)
     {
         bool models()
         {
-            import std.algorithm;
+            import std.algorithm.searching.countUntil;
             enum openParenIndex = P.stringof.countUntil("(");
-            //2 to get rid of "is"
-            enum untilOpenParen = P.stringof[2 .. openParenIndex];
+            enum untilOpenParen = P.stringof["is".length .. openParenIndex];
             enum checkName = "check" ~ untilOpenParen;
             enum mixinStr = checkName ~ "!(T, A);";
             mixin("import " ~ moduleName!(P) ~ ";"); //make it visible first

--- a/std/traits.d
+++ b/std/traits.d
@@ -132,6 +132,7 @@
  *           $(LREF hasUDA)
  *           $(LREF getUDAs)
  *           $(LREF getSymbolsByUDA)
+ *           $(LREF models)
  * ))
  * )
  * )
@@ -6935,4 +6936,101 @@ unittest
     static assert(allSatisfy!(ifTestable, AliasSeq!(bool, int, float, double, string)));
     struct BoolWrapper { bool value; }
     static assert(!ifTestable!(bool, a => BoolWrapper(a)));
+}
+
+/**
+ * A static assertion that a type satisfies a given template constraint.
+ * It can be used as a $(LINK2 ../attribute.html#uda, UDA) or
+ * in a $(D static assert) to make sure that a type conforms
+ * to the compile-time interface the user expects it to.
+ * The difference between using $(D models) and a simple static assert
+ * with the template contraint is that $(D models) will instantiate the
+ * failing code when the constraint is not satisfied,
+ * yielding compiler error messages to aid the user.
+ *
+ * The template contraint predicate must start with the word $(D is)
+ * (e.g. $(D isInputRange)) and an associated template function
+ * with the "is" replaced by "check" should exist (e.g. $(D checkInputRange))
+ * and be defined in the same module.
+ */
+template models(T, alias P, A...)
+{
+    static assert(P.stringof[0..2] == "is",
+                  P.stringof ~ " does not begin with 'is', which is require by `models`");
+
+    static if(P!(T, A))
+    {
+        bool models()
+        {
+            return true;
+        }
+    }
+    else
+    {
+        bool models()
+        {
+            import std.algorithm;
+            enum openParenIndex = P.stringof.countUntil("(");
+            //2 to get rid of "is"
+            enum untilOpenParen = P.stringof[2 .. openParenIndex];
+            enum checkName = "check" ~ untilOpenParen;
+            enum mixinStr = checkName ~ "!(T, A);";
+            mixin("import " ~ moduleName!(P) ~ ";"); //make it visible first
+            mixin(mixinStr);
+            return false;
+        }
+    }
+}
+
+
+///
+unittest
+{
+    void checkFoo(T)()
+    {
+        T t = T.init;
+        t.foo();
+    }
+
+    enum isFoo(T) = is(typeof(checkFoo!T));
+
+    void checkBar(T, U)()
+    {
+        U _bar = T.init.bar;
+    }
+
+    template isBar(T, U)
+    {
+        enum isBar = is(typeof(checkBar!(T, U)));
+    }
+
+    @models!(Foo, isFoo) //as a UDA
+    struct Foo
+    {
+        void foo() {}
+        static assert(models!(Foo, isFoo)); //as a static assert
+    }
+
+    @models!(Bar, isBar, byte) //as a UDA
+    struct Bar
+    {
+        byte bar;
+        static assert(models!(Bar, isBar, byte)); //as a static assert
+    }
+
+    // can't assert that, e.g. !models!(Bar, isFoo) -
+    // the whole point of `models` is that it doesn't compile
+    // when the template constraint is not satisfied
+    static assert(!__traits(compiles, models!(Bar, isFoo)));
+    static assert(!__traits(compiles, models!(Foo, isBar, byte)));
+}
+
+unittest
+{
+    struct Foo {}
+    enum weirdPred(T) = true;
+    //always true, this is a sanity check
+    static assert(weirdPred!Foo);
+    //shouldn't compile since weirdPred doesn't begin with the word "is"
+    static assert(!__traits(compiles, models!(Foo, weirdPred)));
 }


### PR DESCRIPTION
This is similar to the work done on [this PR](https://github.com/D-Programming-Language/phobos/pull/3520), which is now dependent on the current one.

The idea is to have compiler error messages when a type that was intended to satisfy a template constraint but doesn't. Currently, when a template contraint isn't satisfied by accident, it's hard to know why. This PR attempts to make that process easier, with a similar intent as C++ concepts.

Also, I wanted to add a static assert if `models` is true but `checkXXX` doesn't compile; I didn't because I'd have to move the `isFoo` and `checkFoo` functions used in the accompanying unit tests to global scope.
