### PR TITLE
Add std.benchmark with benchmarking functions that use MonoTime and Duration

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -157,12 +157,12 @@ STD_PACKAGES = std $(addprefix std/,\
 
 # Modules broken down per package
 
-PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
-  concurrencybase conv cstream csv datetime demangle encoding exception file format \
-  functional getopt json math mathspecial meta metastrings mmfile numeric \
-  outbuffer parallelism path process random signals socket socketstream stdint \
-  stdio stdiobase stream string syserror system traits typecons typetuple uni \
-  uri utf uuid variant xml zip zlib
+PACKAGE_std = array ascii base64 benchmark bigint bitmanip compiler complex \
+  concurrency concurrencybase conv cstream csv datetime demangle encoding \
+  exception file format functional getopt json math mathspecial meta \
+  metastrings mmfile numeric outbuffer parallelism path process random signals \
+  socket socketstream stdint stdio stdiobase stream string syserror system \
+  traits typecons typetuple uni uri utf uuid variant xml zip zlib
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util

--- a/std/benchmark.d
+++ b/std/benchmark.d
@@ -1,0 +1,411 @@
+//Written in the D programming language
+
+/++
+    Module containing benchmarking and timing functionality.
+
+    For convenience, this module publicly imports core.time.
+
+    Copyright: Copyright 2010 - 2015
+    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Jonathan M Davis and Kato Shoichi
+    Source:    $(PHOBOSSRC std/_benchmark.d)
+    Macros:
+        LREF2=<a href="#$1">$(D $2)</a>
+  +/
+module std.benchmark;
+
+public import core.time;
+
+
+/++
+   Used by StopWatch to indicate whether it should start immediately upon
+   construction.
+  +/
+enum AutoStart
+{
+    /// No, don't start the StopWatch when it is constructed.
+    no,
+
+    /// Yes, do start the StopWatch when it is constructed.
+    yes
+}
+
+
+/++
+   StopWatch is used to measure time just like one would do with a physical
+   stopwatch, including stopping, restarting, and/or resetting it.
+
+   $(CXREF MonoTime) is used to hold the time, and it uses the system's
+   monotonic clock, which is high precision and never counts backwards (unlike
+   the wall clock time, which $(I can) count backwards, which is why
+   $(XREF datetime, SysTime) should not be used for timing).
+
+   Note that the precision of StopWatch differs from system to system. It is
+   impossible for it to be the same for all systems, since the precision of the
+   system clock and other system-dependent and situation-dependent factors
+   (such as the overhead of a context switch between threads) varies from system
+   to system and can affect StopWatch's accuracy.
+  +/
+struct StopWatch
+{
+public:
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        auto sw = StopWatch(AutoStart.yes);
+
+        Duration t1 = sw.peek();
+        Thread.sleep(usecs(1));
+        Duration t2 = sw.peek();
+        assert(t2 > t1);
+
+        Thread.sleep(usecs(1));
+        sw.stop();
+
+        Duration t3 = sw.peek();
+        assert(t3 > t2);
+        Duration t4 = sw.peek();
+        assert(t3 == t4);
+
+        sw.start();
+        Thread.sleep(usecs(1));
+
+        Duration t5 = sw.peek();
+        assert(t5 > t4);
+
+        // If stopping or resetting the StopWatch is not required, then
+        // MonoTime can easily be used by itself without StopWatch.
+        auto before = MonoTime.currTime;
+        // do stuff...
+        auto timeElapsed = MonoTime.currTime - before;
+    }
+
+    /++
+        Constructs a StopWatch. Whether it starts immediately depends on the
+        $(LREF AutoStart) argument.
+
+        If $(D StopWatch.init) is used, then the constructed StopWatch isn't
+        running (and can't be, since no constructor ran).
+      +/
+    this(AutoStart autostart) @safe nothrow @nogc
+    {
+        if(autostart)
+            start();
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        {
+            auto sw = StopWatch(AutoStart.yes);
+            assert(sw.running);
+            Thread.sleep(usecs(1));
+            assert(sw.peek() > Duration.zero);
+        }
+        {
+            auto sw = StopWatch(AutoStart.no);
+            assert(!sw.running);
+            Thread.sleep(usecs(1));
+            assert(sw.peek() == Duration.zero);
+        }
+        {
+            StopWatch sw;
+            assert(!sw.running);
+            Thread.sleep(usecs(1));
+            assert(sw.peek() == Duration.zero);
+        }
+
+        assert(StopWatch.init == StopWatch(AutoStart.no));
+        assert(StopWatch.init != StopWatch(AutoStart.yes));
+    }
+
+
+    /++
+       Resets the StopWatch.
+
+       The StopWatch can be reset while it's running, and resetting it while
+       it's running will not cause it to stop.
+      +/
+    void reset() @safe nothrow @nogc
+    {
+        if(_running)
+            _timeStarted = MonoTime.currTime;
+        _ticksElapsed = 0;
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        auto sw = StopWatch(AutoStart.yes);
+        Thread.sleep(usecs(1));
+        sw.stop();
+        assert(sw.peek() > Duration.zero);
+        sw.reset();
+        assert(sw.peek() == Duration.zero);
+    }
+
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        auto sw = StopWatch(AutoStart.yes);
+        Thread.sleep(msecs(1));
+        assert(sw.peek() > msecs(1));
+        immutable before = MonoTime.currTime;
+
+        // Just in case the system clock is slow enough or the system is fast
+        // enough for the call to MonoTime.currTime inside of reset to get
+        // the same that we just got by calling MonoTime.currTime.
+        Thread.sleep(usecs(1));
+
+        sw.reset();
+        assert(sw.peek() < msecs(1));
+        assert(sw._timeStarted > before);
+        assert(sw._timeStarted < MonoTime.currTime);
+    }
+
+
+    /++
+       Starts the StopWatch.
+
+       start should not be called if the StopWatch is already running.
+      +/
+    void start() @safe nothrow @nogc
+    in { assert(!running); }
+    body
+    {
+        _running = true;
+        _timeStarted = MonoTime.currTime;
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        StopWatch sw;
+        assert(!sw.running);
+        assert(sw.peek() == Duration.zero);
+        sw.start();
+        assert(sw.running);
+        Thread.sleep(usecs(1));
+        assert(sw.peek() > Duration.zero);
+    }
+
+
+    /++
+       Stops the StopWatch.
+
+       stop should not be called if the StopWatch is not running.
+      +/
+    void stop() @safe nothrow @nogc
+    in { assert(_running); }
+    body
+    {
+        _running = false;
+        _ticksElapsed += MonoTime.currTime.ticks - _timeStarted.ticks;
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        auto sw = StopWatch(AutoStart.yes);
+        assert(sw.running);
+        Thread.sleep(usecs(1));
+        immutable t1 = sw.peek();
+        assert(t1 > Duration.zero);
+
+        sw.stop();
+        assert(!sw.running);
+        immutable t2 = sw.peek();
+        assert(t2 > t1);
+        immutable t3 = sw.peek();
+        assert(t2 == t3);
+    }
+
+
+    /++
+       Peek at the amount of time that the the StopWatch has been running.
+
+       This does not include any time during which the StopWatch was stopped but
+       does include $(I all) of the time that it was running and not just the
+       time since it was started last.
+
+       Calling reset will reset this to $(D Duration.zero).
+      +/
+    Duration peek() @safe const nothrow @nogc
+    {
+        enum hnsecsPerSecond = convert!("seconds", "hnsecs")(1);
+        immutable hnsecsMeasured = convClockFreq(_ticksElapsed, MonoTime.ticksPerSecond, hnsecsPerSecond);
+        return _running ? MonoTime.currTime - _timeStarted + hnsecs(hnsecsMeasured)
+                        : hnsecs(hnsecsMeasured);
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        auto sw = StopWatch(AutoStart.no);
+        assert(sw.peek() == Duration.zero);
+        sw.start();
+
+        Thread.sleep(usecs(1));
+        assert(sw.peek() >= usecs(1));
+
+        Thread.sleep(usecs(1));
+        assert(sw.peek() >= usecs(2));
+
+        sw.stop();
+        immutable stopped = sw.peek();
+        Thread.sleep(usecs(1));
+        assert(sw.peek() == stopped);
+
+        sw.start();
+        Thread.sleep(usecs(1));
+        assert(sw.peek() > stopped);
+    }
+
+    @safe nothrow @nogc unittest
+    {
+        assert(StopWatch.init.peek() == Duration.zero);
+    }
+
+
+    /++
+       Sets the total time which the StopWatch has been running (i.e. what peek
+       returns).
+
+       The StopWatch does not have to be stopped for setTimeElapsed to be
+       called, nor will calling it cause the StopWatch to stop.
+      +/
+    void setTimeElapsed(Duration timeElapsed) @safe nothrow @nogc
+    {
+        enum hnsecsPerSecond = convert!("seconds", "hnsecs")(1);
+        _ticksElapsed = convClockFreq(timeElapsed.total!"hnsecs", hnsecsPerSecond, MonoTime.ticksPerSecond);
+        _timeStarted = MonoTime.currTime;
+    }
+
+    ///
+    @trusted nothrow unittest // Thread.sleep is @system for some reason (and not @nogc)
+    {
+        import core.thread;
+        StopWatch sw;
+        sw.setTimeElapsed(hours(1));
+
+        // As discussed in MonoTime's documentation, converting between
+        // Duration and ticks is not exact, though it will be close.
+        // How exact it is depends on the frequency/resolution of the
+        // system's monotonic clock.
+        assert(abs(sw.peek() - hours(1)) < usecs(1));
+
+        sw.start();
+        Thread.sleep(usecs(1));
+        assert(sw.peek() > hours(1) + usecs(1));
+    }
+
+
+    /++
+       Returns whether this StopWatch is currently running.
+      +/
+    @property bool running() @safe const pure nothrow @nogc
+    {
+        return _running;
+    }
+
+    ///
+    @safe nothrow @nogc unittest
+    {
+        StopWatch sw;
+        assert(!sw.running);
+        sw.start();
+        assert(sw.running);
+        sw.stop();
+        assert(!sw.running);
+    }
+
+
+private:
+
+    // We track the ticks for the elapsed time rather than a Duration so that we
+    // don't lose any precision.
+
+    bool _running = false; // Whether the StopWatch is currently running
+    MonoTime _timeStarted; // The time the StopWatch started measuring (i.e. when it was started or reset).
+    long _ticksElapsed;    // Total time that the StopWatch ran before it was stopped last.
+}
+
+
+/++
+    Benchmarks code for speed assessment and comparison.
+
+    Params:
+        fun = aliases of callable objects (e.g. function names). Each callable
+              object should take no arguments.
+        n   = The number of times each function is to be executed.
+
+    Returns:
+        The amount of time (as a $(CXREF time, Duration)) that it took to call
+        each function $(D n) times. The first value is the length of time that
+        it took to call $(D fun[0]) $(D n) times. The second value is the length
+        of time it took to call $(D fun[1]) $(D n) times. Etc.
+  +/
+Duration[fun.length] benchmark(fun...)(uint n)
+{
+    Duration[fun.length] result;
+    auto sw = StopWatch(AutoStart.yes);
+
+    foreach(i, unused; fun)
+    {
+        sw.reset();
+        foreach(j; 0 .. n)
+            fun[i]();
+        result[i] = sw.peek();
+    }
+
+    return result;
+}
+
+///
+@safe unittest
+{
+    import core.time, std.conv;
+    int a;
+    void f0() {}
+    void f1() { auto b = a; }
+    void f2() { auto b = to!string(a); }
+    auto r = benchmark!(f0, f1, f2)(10_000);
+    Duration f0Result = r[0]; // time f0 took to run 10,000 times
+    Duration f1Result = r[1]; // time f1 took to run 10,000 times
+    Duration f2Result = r[2]; // time f2 took to run 10,000 times
+}
+
+@safe nothrow unittest
+{
+    import std.conv;
+    int a;
+    void f0() nothrow {}
+    void f1() nothrow { auto b = to!string(a); }
+    auto r = benchmark!(f0, f1)(1000);
+    assert(r[0] > Duration.zero);
+    assert(r[1] > Duration.zero);
+    assert(r[1] > r[0]);
+    assert(r[0] < seconds(1));
+    assert(r[1] < seconds(1));
+}
+
+@safe nothrow @nogc unittest
+{
+    int f0Count;
+    int f1Count;
+    int f2Count;
+    void f0() nothrow @nogc { ++f0Count; }
+    void f1() nothrow @nogc { ++f1Count; }
+    void f2() nothrow @nogc { ++f2Count; }
+    auto r = benchmark!(f0, f1, f2)(552);
+    assert(f0Count == 552);
+    assert(f1Count == 552);
+    assert(f2Count == 552);
+}

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -29975,6 +29975,9 @@ version(Windows) unittest
 //==============================================================================
 
 /++
+    $(RED Note: This will be deprecated in 2.071. Please use
+          $(XREF benchmark, StopWatch) instead.)
+
    $(D StopWatch) measures time as precisely as possible.
 
    This class uses a high-performance counter. On Windows systems, it uses
@@ -30221,6 +30224,9 @@ private:
 
 
 /++
+    $(RED Note: This will be deprecated in 2.071. Please use
+          $(XREF benchmark, benchmark) instead.)
+
     Benchmarks code for speed assessment and comparison.
 
     Params:
@@ -30283,6 +30289,10 @@ unittest
 
 
 /++
+    $(RED Note: This will be deprecated in 2.071. $(LXREF comparingBenchmark)
+          is a simple wrapper around $(LXREF benchmark). Please use
+          $(XREF benchmark, benchmark) instead.)
+
    Return value of benchmark with two functions comparing.
   +/
 @safe struct ComparingBenchmarkResult
@@ -30331,6 +30341,10 @@ private:
 
 
 /++
+    $(RED Note: This will be deprecated in 2.071. comparingBenchmark is a simple
+          wrapper around $(LXREF benchmark). Please use
+          $(XREF benchmark, benchmark) instead.)
+
    Benchmark with two functions comparing.
 
    Params:
@@ -32173,6 +32187,10 @@ unittest
 version(StdDdoc)
 {
     /++
+        $(RED Note: This will be deprecated in 2.071. Please use either
+              $(XREF benchmark, StopWatch) instead or use
+              $(CXREF time, MonoTime) directly.)
+
         Function for starting to a stop watch time when the function is called
         and stopping it when its return value goes out of scope and is destroyed.
 

--- a/win32.mak
+++ b/win32.mak
@@ -110,8 +110,8 @@ SRC_STD_1_HEAVY= std\stdio.d std\stdiobase.d \
 
 SRC_STD_2a_HEAVY= std\array.d std\functional.d std\path.d std\outbuffer.d std\utf.d
 
-SRC_STD_3= std\csv.d std\math.d std\complex.d std\numeric.d std\bigint.d \
-	std\bitmanip.d std\typecons.d \
+SRC_STD_3= std\benchmark.d std\csv.d std\math.d std\complex.d std\numeric.d \
+	std\bigint.d std\bitmanip.d std\typecons.d \
 	std\uni.d std\base64.d std\ascii.d \
 	std\demangle.d std\uri.d std\metastrings.d std\mmfile.d std\getopt.d
 
@@ -164,7 +164,7 @@ SRC_STD_ALL= $(SRC_STD_1_HEAVY) $(SRC_STD_2a_HEAVY) \
 SRC=	unittest.d index.d
 
 SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
-	std\math.d std\string.d std\path.d std\datetime.d \
+	std\benchmark.d std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
 	std\meta.d std\metastrings.d std\mmfile.d \
@@ -311,6 +311,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_array.html \
 	$(DOC)\std_ascii.html \
 	$(DOC)\std_base64.html \
+	$(DOC)\std_benchmark.html \
 	$(DOC)\std_bigint.html \
 	$(DOC)\std_bitmanip.html \
 	$(DOC)\std_concurrency.html \
@@ -464,6 +465,7 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=91 -unittest -main -run std\math.d
 	$(DMD) -conf= -cov=95 -unittest -main -run std\complex.d
 	$(DMD) -conf= -cov=70 -unittest -main -run std\numeric.d
+	$(DMD) -conf= -cov=95 -unittest -main -run std\benchmark.d
 	$(DMD) -conf= -cov=94 -unittest -main -run std\bigint.d
 	$(DMD) -conf= -cov=95 -unittest -main -run std\bitmanip.d
 	$(DMD) -conf= -cov=82 -unittest -main -run std\typecons.d
@@ -631,6 +633,9 @@ $(DOC)\std_ascii.html : $(STDDOC) std\ascii.d
 
 $(DOC)\std_base64.html : $(STDDOC) std\base64.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_base64.html $(STDDOC) std\base64.d
+
+$(DOC)\std_benchmark.html : $(STDDOC) std\benchmark.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_benchmark.html $(STDDOC) std\benchmark.d
 
 $(DOC)\std_bigint.html : $(STDDOC) std\bigint.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_bigint.html $(STDDOC) std\bigint.d

--- a/win64.mak
+++ b/win64.mak
@@ -115,7 +115,7 @@ SRC_STD_1_HEAVY= std\stdio.d std\stdiobase.d \
 SRC_STD_2a_HEAVY= std\array.d std\functional.d std\path.d std\outbuffer.d std\utf.d
 
 SRC_STD_math=std\math.d
-SRC_STD_3= std\csv.d std\complex.d std\numeric.d std\bigint.d
+SRC_STD_3= std\benchmark.d std\csv.d std\complex.d std\numeric.d std\bigint.d
 SRC_STD_3c= std\datetime.d std\bitmanip.d std\typecons.d
 
 SRC_STD_3a= std\uni.d std\base64.d std\ascii.d \
@@ -187,7 +187,7 @@ SRC_STD_ALL= $(SRC_STD_1_HEAVY) $(SRC_STD_2a_HEAVY) \
 SRC=	unittest.d index.d
 
 SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
-	std\math.d std\string.d std\path.d std\datetime.d \
+	std\benchmark.d std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
 	std\meta.d std\metastrings.d std\mmfile.d \
@@ -334,6 +334,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_array.html \
 	$(DOC)\std_ascii.html \
 	$(DOC)\std_base64.html \
+	$(DOC)\std_benchmark.html \
 	$(DOC)\std_bigint.html \
 	$(DOC)\std_bitmanip.html \
 	$(DOC)\std_concurrency.html \
@@ -609,6 +610,9 @@ $(DOC)\std_ascii.html : $(STDDOC) std\ascii.d
 
 $(DOC)\std_base64.html : $(STDDOC) std\base64.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_base64.html $(STDDOC) std\base64.d
+
+$(DOC)\std_benchmark.html : $(STDDOC) std\benchmark.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_benchmark.html $(STDDOC) std\benchmark.d
 
 $(DOC)\std_bigint.html : $(STDDOC) std\bigint.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_bigint.html $(STDDOC) std\bigint.d


### PR DESCRIPTION
Okay. I've been working towards getting rid of `TickDuration` for a while now, since it's highly confusing (one, it conflates a timestamp of the monotonic clock and a duration of the monotonic clock, and two it means that we have two duration types). `MonoTime` was added so that we could use it and `Duration` instead of `TickDuration` and then remove `TickDuration`, but the one thing remaining that we have to get rid of in order to be able to get rid of `TickDuration` is the benchmarking functions in std.datetime. But of course, they need to be replaced with benchmarking functions which use `MonoTime` and `Duration` before we can get rid of them.

Unfortunately, because this involves function return types, we can't simply use overloads or anything like that to fix the problem, and the replacement functions need to go into another module so that they don't conflict or force us to come up with worse names. std.benchmark seems like the obvious choice, especially since there was talk of moving them there when Andrei's rejected std.benchmark was reviewed, so this PR creates those functions and puts them in the new module, std.benchmark (which just holds those functions and nothing really new). The std.datetime benchmarking functions can then be deprecated after std.benchmark has been out for a release (so that code that uses the benchmarking functions can build with both master and the previous release, whereas that wouldn't be the case if we deprecated the old stuff at the same time we added the new stuff), and then we can finally deprecate `TickDuration` in the release after that.

There were four benchmarking items in std.datetime, and this only keeps two. [`StopWatch`](http://dlang.org/phobos/std_datetime.html#StopWatch) and [`benchmark`](http://dlang.org/phobos/std_datetime.html#benchmark) have been ported over to std.benchmark. However, [`measureTime`](http://dlang.org/phobos/std_datetime.html#measureTime) and [`comparingBenchmark`](http://dlang.org/phobos/std_datetime.html#comparingBenchmark) have not.

I thought that we'd deprecated `measureTime` ages ago, but apparently not. It's trivially replaced with a scope statement, and its documentation even shows how. So, I see no reason to keep it - especially when any code using it is going to have to be updated after this PR anyway. And `comparingBenchmark` is just a wrapper around benchmark that only takes two functions and divides the results to give a ratio. I don't know how valuable that is (it doesn't seem all that useful to me), but it seems like an awful lot of code to keep for what amounts to a simple wrapper (particularly since it declares its own type to hold the results). It just doesn't seem like it adds any real value, it seems like it's pretty trivial for someone to write the wrapper themselves if they really want it. So, I left it out.

But `StopWatch` and `benchmark` have been ported over (which was surprisingly painful for `StopWatch` - mostly because `TickDuration` is incredibly confusing). So, I don't think that any real functionality has been lost. Their API in std.benchmark is pretty much the same as it was in std.datetime - just with `MonoTime` and `Duration` instead, and `MonoTime` doesn't even make it into the public API. I did consider adding alternate functions to `StopWatch` that exposed the ticks for the rare case when someone might want that level of precision but decided that it wasn't worth complicating the API and might encourage folks to use the ticks and and shoot themselves in the foot, since it's harder to get that right when you start having to worry about converting clock frequencies and whatnot. `Duration` should work just fine except in rare cases.

This PR _does_ create a new module, so maybe it should be brought up in the newsgroup or get more of a review than these functions normally would, but it's one function and one type added, both of which already exist in std.datetime - except they use `TickDuration` there. So, having a full-on module review for it seems like overkill.
