### PR TITLE
Propagate attributes in std.allocator.make[Array]

### DIFF
--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -20,7 +20,7 @@ struct GCAllocator
     deallocate) and $(D reallocate) methods are $(D @system) because they may
     move memory around, leaving dangling pointers in user code.
     */
-    @trusted void[] allocate(size_t bytes) shared
+    pure nothrow @trusted void[] allocate(size_t bytes) shared
     {
         if (!bytes) return null;
         auto p = GC.malloc(bytes);
@@ -28,7 +28,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @trusted bool expand(ref void[] b, size_t delta) shared
+    pure nothrow @trusted bool expand(ref void[] b, size_t delta) shared
     {
         if (delta == 0) return true;
         if (b is null)
@@ -49,7 +49,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool reallocate(ref void[] b, size_t newSize) shared
+    pure nothrow @system bool reallocate(ref void[] b, size_t newSize) shared
     {
         import core.exception : OutOfMemoryError;
         try
@@ -66,7 +66,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    void[] resolveInternalPointer(void* p) shared
+    pure nothrow void[] resolveInternalPointer(void* p) shared
     {
         auto r = GC.addrOf(p);
         if (!r) return null;
@@ -74,7 +74,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool deallocate(void[] b) shared
+    pure nothrow @system bool deallocate(void[] b) shared
     {
         GC.free(b.ptr);
         return true;
@@ -85,11 +85,10 @@ struct GCAllocator
     allocator is thread-safe, therefore all of its methods and `instance` itself
     are $(D shared).
     */
-
     static shared GCAllocator instance;
 
     // Leave it undocummented for now.
-    @trusted void collect() shared
+    nothrow @trusted void collect() shared
     {
         GC.collect();
     }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -21,7 +21,7 @@ struct Mallocator
     paradoxically, $(D malloc) is $(D @safe) but that's only useful to safe
     programs that can afford to leak memory allocated.
     */
-    @nogc @trusted void[] allocate(size_t bytes) shared
+    nothrow @nogc @trusted void[] allocate(size_t bytes) shared
     {
         import core.stdc.stdlib : malloc;
         if (!bytes) return null;
@@ -30,7 +30,7 @@ struct Mallocator
     }
 
     /// Ditto
-    @nogc @system bool deallocate(void[] b) shared
+    nothrow @nogc @system bool deallocate(void[] b) shared
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
@@ -38,7 +38,7 @@ struct Mallocator
     }
 
     /// Ditto
-    @nogc @system bool reallocate(ref void[] b, size_t s) shared
+    nothrow @nogc @system bool reallocate(ref void[] b, size_t s) shared
     {
         import core.stdc.stdlib : realloc;
         if (!s)


### PR DESCRIPTION
#3031 reduxed for std.allocator.

I missed previously the fact that `checkedMalloc`ing an object by calling a non-trivial constructor is not provably safe, as the constructor might escape references to its own memory before throwing an exception, leaving `checkedMalloc` to deallocate still-referenced memory.

So, this implementation assumes the deallocation on failure is safe only when construction was pure. This isn't ideal: it's overly strict - what we really want to query is whether the constructor can escape references to its own memory, ala `scope`. Still, `pure` covers a lot of ground. I'm also not sure it's always safe when the constructor is only weakly pure - it could escape references to itself through mutable arguments. I'm not sure how to best check for strong purity.

TODO
- [x] Implement for `makeArray`
- [ ] Port initial use case applications to this PR
- [ ] Possibly add wrappers for `make[Array]` that throw on OOM
- [ ] Figure out whether it's possible to propagate `@safe` when emplacing classes