### PR TITLE
Docs

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2549,6 +2549,7 @@ Implements the homonym function (also known as $(D accumulate), $(D
 compress), $(D inject), or $(D foldl)) present in various programming
 languages of functional flavor. There is also $(LREF fold) which does
 the same thing but with the opposite parameter order.
+
 The call $(D reduce!(fun)(seed, range)) first assigns $(D seed) to
 an internal variable $(D result), also called the accumulator.
 Then, for each element $(D x) in $(D range), $(D result = fun(result, x))
@@ -2569,6 +2570,9 @@ See_Also:
 
     $(LREF sum) is similar to $(D reduce!((a, b) => a + b)) that offers
     precise summing of floating point numbers.
+
+Tags:
+    accumulate, fold
 +/
 template reduce(fun...) if (fun.length >= 1)
 {

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -107,7 +107,7 @@ $(TR $(TDNW Sorting)
         $(SUBREF sorting, topNIndex)
     )
 )
-$(TR $(TDNW Set&nbsp;operations)
+$(TR $(TDNW Set operations)
     $(TDNW $(SUBMODULE setops))
     $(TD
         $(SUBREF setops, cartesianProduct)

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -35,7 +35,7 @@ $(T2 endsWith,
         $(D endsWith("rocks", "ks")) returns $(D true).)
 $(T2 find,
         $(D find("hello world", "or")) returns $(D "orld") using linear search.
-        (For binary search refer to $(XREF range,sortedRange).))
+        (For binary search refer to $(XREF range,SortedRange).))
 $(T2 findAdjacent,
         $(D findAdjacent([1, 2, 3, 3, 4])) returns the subrange starting with
         two equal adjacent elements, i.e. $(D [3, 3, 4]).)
@@ -2515,25 +2515,29 @@ if (isForwardRange!R1 && isForwardRange!R2
 }
 
 /**
-These functions find the first occurrence of `needle` in `haystack` and then
-split `haystack` as follows.
+These functions find the first occurrence of $(D needle) in $(D
+haystack) and then split $(D haystack) in their return values.
 
-`findSplit` returns a tuple `result` containing $(I three) ranges. `result[0]`
-is the portion of `haystack` before `needle`, `result[1]` is the portion of
-`haystack` that matches `needle`, and `result[2]` is the portion of `haystack`
-after the match. If `needle` was not found, `result[0]` comprehends `haystack`
-entirely and `result[1]` and `result[2]` are empty.
 
-`findSplitBefore` returns a tuple `result` containing two ranges. `result[0]` is
-the portion of `haystack` before `needle`, and `result[1]` is the balance of
-`haystack` starting with the match. If `needle` was not found, `result[0]`
-comprehends `haystack` entirely and `result[1]` is empty.
+$(D findSplit) returns a tuple $(D result) containing $(I three)
+ranges. $(D result[0]) is the portion of $(D haystack) before $(D
+needle), $(D result[1]) is the portion of $(D haystack) that matches
+$(D needle), and $(D result[2]) is the portion of $(D haystack) after
+the match. If $(D needle) was not found, $(D result[0])
+comprehends $(D haystack) entirely and $(D result[1]) and $(D result[2])
+are empty.
 
-`findSplitAfter` returns a tuple `result` containing two ranges.
-`result[0]` is the portion of `haystack` up to and including the
-match, and `result[1]` is the balance of `haystack` starting
-after the match. If `needle` was not found, `result[0]` is empty
-and `result[1]` is `haystack`.
+$(D findSplitBefore) returns a tuple $(D result) containing two
+ranges. $(D result[0]) is the portion of $(D haystack) before $(D
+needle), and $(D result[1]) is the balance of $(D haystack) starting
+with the match. If $(D needle) was not found, $(D result[0])
+comprehends $(D haystack) entirely and $(D result[1]) is empty.
+
+$(D findSplitAfter) returns a tuple $(D result) containing two ranges.
+$(D result[0]) is the portion of $(D haystack) up to and including the
+match, and $(D result[1]) is the balance of $(D haystack) starting
+after the match. If $(D needle) was not found, $(D result[0]) is empty
+and $(D result[1]) is $(D haystack).
 
 In all cases, the concatenation of the returned ranges spans the
 entire `haystack`.
@@ -2557,10 +2561,20 @@ details).  This sub-type of `Tuple!()` has `opCast` defined for `bool`.  This
 shown in the following example.
 
 Example:
+
+This example shows the use of the return value and the $(D bool opCast) idiom:
 ---
-if (const split = haystack.findSplit(needle))
+if (auto split = haystack.findSplit(needle))
 {
-     doSomethingWithSplit(split);
+     // needle was found. We can use the three parts of the returned tuple:
+     auto beforeNeedle = split[0];
+     auto needleMatch = split[1];
+     auto afterNeedle = split[2];
+     // you can now do something with these three parts
+}
+else
+{
+     // needle was not found in haystack
 }
 ---
  */
@@ -2743,7 +2757,8 @@ if (isForwardRange!R1 && isForwardRange!R2)
     }
 }
 
-///
+/// This example shows the difference in return values of $(LREF findSkip),
+/// $(LREF findSplitBefore), and $(LREF findSplitAfter).
 @safe unittest
 {
     auto a = "Carl Sagan Memorial Station";

--- a/std/array.d
+++ b/std/array.d
@@ -7,47 +7,47 @@ This module provides all kinds of functions to create, manipulate or convert arr
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(LREF _array))
-        $(TD Returns a copy of the input in a newly allocated dynamic _array.
+    $(TR $(TD $(LREF array))
+        $(TD Returns a copy of the input in a newly allocated dynamic array.
     ))
     $(TR $(TD $(LREF appender))
-        $(TD Returns a new Appender initialized with a given _array.
+        $(TD Returns a new Appender initialized with a given array.
     ))
     $(TR $(TD $(LREF assocArray))
-        $(TD Returns a newly allocated associative _array from a range of key/value tuples.
+        $(TD Returns a newly allocated associative array from a range of key/value tuples.
     ))
     $(TR $(TD $(LREF byPair))
-        $(TD Construct a range iterating over an associative _array by key/value tuples.
+        $(TD Construct a range iterating over an associative array by key/value tuples.
     ))
     $(TR $(TD $(LREF insertInPlace))
-        $(TD Inserts into an existing _array at a given position.
+        $(TD Inserts into an existing array at a given position.
     ))
     $(TR $(TD $(LREF join))
-        $(TD Concatenates a range of ranges into one _array.
+        $(TD Concatenates a range of ranges into one array.
     ))
     $(TR $(TD $(LREF minimallyInitializedArray))
-        $(TD Returns a new _array of type $(D T).
+        $(TD Returns a new array of type $(D T).
     ))
     $(TR $(TD $(LREF replace))
-        $(TD Returns a new _array with all occurrences of a certain subrange replaced.
+        $(TD Returns a new array with all occurrences of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceFirst))
-        $(TD Returns a new _array with the first occurrence of a certain subrange replaced.
+        $(TD Returns a new array with the first occurrence of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceInPlace))
-        $(TD Replaces all occurrences of a certain subrange and puts the result into a given _array.
+        $(TD Replaces all occurrences of a certain subrange and puts the result into a given array.
     ))
     $(TR $(TD $(LREF replaceInto))
         $(TD Replaces all occurrences of a certain subrange and puts the result into an output range.
     ))
     $(TR $(TD $(LREF replaceLast))
-        $(TD Returns a new _array with the last occurrence of a certain subrange replaced.
+        $(TD Returns a new array with the last occurrence of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceSlice))
-        $(TD Returns a new _array with a given slice replaced.
+        $(TD Returns a new array with a given slice replaced.
     ))
     $(TR $(TD $(LREF replicate))
-        $(TD Creates a new _array out of several copies of an input _array or range.
+        $(TD Creates a new array out of several copies of an input array or range.
     ))
     $(TR $(TD $(LREF sameHead))
         $(TD Checks if the initial segments of two arrays refer to the same
@@ -58,10 +58,10 @@ $(TR $(TH Function Name) $(TH Description)
         in memory.
     ))
     $(TR $(TD $(LREF split))
-        $(TD Eagerly split a range or string into an _array.
+        $(TD Eagerly split a range or string into an array.
     ))
     $(TR $(TD $(LREF uninitializedArray))
-        $(TD Returns a new _array of type $(D T) without initializing its elements.
+        $(TD Returns a new array of type $(D T) without initializing its elements.
     ))
 )
 
@@ -71,7 +71,7 @@ License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors:   $(WEB erdani.org, Andrei Alexandrescu) and Jonathan M Davis
 
-Source: $(PHOBOSSRC std/_array.d)
+Source: $(PHOBOSSRC std/array.d)
 */
 module std.array;
 
@@ -332,7 +332,7 @@ unittest
 }
 
 /**
-Returns a newly allocated associative _array from a range of key/value tuples.
+Returns a newly allocated associative array from a range of key/value tuples.
 Params: r = An input range of tuples of keys and values.
 Returns: A newly allocated associative array out of elements of the input
 range, which must be a range of tuples (Key, Value). Returns a null associative
@@ -1422,10 +1422,10 @@ unittest
 
 // @@@DEPRECATED_2017-01@@@
 /++
-    $(RED Deprecated. Use $(XREF_PACK algorithm,iteration,_splitter) instead.
+    $(RED Deprecated. Use $(XREF_PACK algorithm,iteration,splitter) instead.
           This will be removed in January 2017.)
 
-    Alias for $(XREF_PACK algorithm,iteration,_splitter).
+    Alias for $(XREF_PACK algorithm,iteration,splitter).
  +/
 deprecated("Please use std.algorithm.iteration.splitter instead.")
 alias splitter = std.algorithm.iteration.splitter;
@@ -1433,10 +1433,10 @@ alias splitter = std.algorithm.iteration.splitter;
 /++
     Eagerly splits $(D range) into an array, using $(D sep) as the delimiter.
 
-    The _range must be a
-    $(XREF_PACK_NAMED _range,primitives,isForwardRange,forward _range).
+    The range must be a
+    $(XREF_PACK_NAMED range,primitives,isForwardRange,forward range).
     The separator can be a value of the same type as the elements in $(D range)
-    or it can be another forward _range.
+    or it can be another forward range.
 
     Example:
         If $(D range) is a $(D string), $(D sep) can be a $(D char) or another
@@ -1445,7 +1445,7 @@ alias splitter = std.algorithm.iteration.splitter;
         The return type will be an array of $(D int) arrays.
 
     Params:
-        range = a forward _range.
+        range = a forward range.
         sep = a value of the same type as the elements of $(D range) or another
         forward range.
 

--- a/std/array.d
+++ b/std/array.d
@@ -7,60 +7,60 @@ This module provides all kinds of functions to create, manipulate or convert arr
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF _array)))
+    $(TR $(TD $(LREF _array))
         $(TD Returns a copy of the input in a newly allocated dynamic _array.
     ))
-    $(TR $(TD $(D $(LREF appender)))
+    $(TR $(TD $(LREF appender))
         $(TD Returns a new Appender initialized with a given _array.
     ))
-    $(TR $(TD $(D $(LREF assocArray)))
+    $(TR $(TD $(LREF assocArray))
         $(TD Returns a newly allocated associative _array from a range of key/value tuples.
     ))
-    $(TR $(TD $(D $(LREF byPair)))
+    $(TR $(TD $(LREF byPair))
         $(TD Construct a range iterating over an associative _array by key/value tuples.
     ))
-    $(TR $(TD $(D $(LREF insertInPlace)))
+    $(TR $(TD $(LREF insertInPlace))
         $(TD Inserts into an existing _array at a given position.
     ))
-    $(TR $(TD $(D $(LREF join)))
+    $(TR $(TD $(LREF join))
         $(TD Concatenates a range of ranges into one _array.
     ))
-    $(TR $(TD $(D $(LREF minimallyInitializedArray)))
+    $(TR $(TD $(LREF minimallyInitializedArray))
         $(TD Returns a new _array of type $(D T).
     ))
-    $(TR $(TD $(D $(LREF replace)))
+    $(TR $(TD $(LREF replace))
         $(TD Returns a new _array with all occurrences of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceFirst)))
+    $(TR $(TD $(LREF replaceFirst))
         $(TD Returns a new _array with the first occurrence of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceInPlace)))
+    $(TR $(TD $(LREF replaceInPlace))
         $(TD Replaces all occurrences of a certain subrange and puts the result into a given _array.
     ))
-    $(TR $(TD $(D $(LREF replaceInto)))
+    $(TR $(TD $(LREF replaceInto))
         $(TD Replaces all occurrences of a certain subrange and puts the result into an output range.
     ))
-    $(TR $(TD $(D $(LREF replaceLast)))
+    $(TR $(TD $(LREF replaceLast))
         $(TD Returns a new _array with the last occurrence of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceSlice)))
+    $(TR $(TD $(LREF replaceSlice))
         $(TD Returns a new _array with a given slice replaced.
     ))
-    $(TR $(TD $(D $(LREF replicate)))
+    $(TR $(TD $(LREF replicate))
         $(TD Creates a new _array out of several copies of an input _array or range.
     ))
-    $(TR $(TD $(D $(LREF sameHead)))
+    $(TR $(TD $(LREF sameHead))
         $(TD Checks if the initial segments of two arrays refer to the same
         place in memory.
     ))
-    $(TR $(TD $(D $(LREF sameTail)))
+    $(TR $(TD $(LREF sameTail))
         $(TD Checks if the final segments of two arrays refer to the same place
         in memory.
     ))
-    $(TR $(TD $(D $(LREF split)))
+    $(TR $(TD $(LREF split))
         $(TD Eagerly split a range or string into an _array.
     ))
-    $(TR $(TD $(D $(LREF uninitializedArray)))
+    $(TR $(TD $(LREF uninitializedArray))
         $(TD Returns a new _array of type $(D T) without initializing its elements.
     ))
 )
@@ -519,7 +519,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I) && hasIndirections!(ElementEn
     return arrayAllocImpl!(false, T, ST)(sizes);
 }
 
-///
+/// ditto
 auto uninitializedArray(T, I...)(I sizes) nothrow @trusted
 if (isDynamicArray!T && allSatisfy!(isIntegral, I) && !hasIndirections!(ElementEncodingType!T))
 {
@@ -551,6 +551,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I) && !hasIndirections!(ElementE
 
 /++
 Returns a new array of type $(D T) allocated on the garbage collected heap.
+
 
 Partial initialization is done for types with indirections, for preservation
 of memory safety. Note that elements will only be initialized to 0, but not
@@ -1545,12 +1546,19 @@ private enum bool hasCheapIteration(R) = isArray!R;
    Concatenates all of the ranges in $(D ror) together into one array using
    $(D sep) as the separator if present.
 
+   ---
+    string result = join(["a", "b", "c"], ", "); // result == "a, b, c";
+   ---
+
    Params:
         ror = Range of Ranges of Elements
         sep = Range of Elements
 
    Returns:
-        an allocated array of Elements
+        an allocated array of Elements. The returned value is of the same
+        type as the elements, so if you gave it a set of strings, it will
+        return a string. If you gave it a series of arrays of $(D int)s,
+        to join, it will return an array of $(D int)s.
 
    See_Also:
         $(XREF_PACK algorithm,iteration,joiner)

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -9,7 +9,7 @@
     to non-ASCII characters.
 
     For functions which operate on Unicode characters, see
-    $(LINK2 std_uni.html, std.uni).
+    $(MREF std,uni).
 
     References:
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),

--- a/std/base64.d
+++ b/std/base64.d
@@ -73,7 +73,7 @@ unittest
 }
 
 /**
- * Implementation of standard _Base64 encoding.
+ * Implementation of standard Base64 encoding.
  *
  *
  * See $(LREF Base64Impl) for a description of available methods.
@@ -247,8 +247,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * encoding.
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *           range) to _encode.
+     *  source = The [isInputRange|input range] to encode.
      *  buffer = The $(D char[]) buffer to store the encoded result.
      *
      * Returns:
@@ -416,14 +415,12 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
     /**
      * Encodes $(D_PARAM source) into an
-     * $(LINK2 std_range_primitives.html#isOutputRange, output range) using
+     * [isOutputRange|output range] using
      * Base64 encoding.
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *           range) to _encode.
-     *  range  = The $(LINK2 std_range_primitives.html#isOutputRange, output
-     *           range) to store the encoded result.
+     *  source = The [isInputRange|input range] to encode.
+     *  range  = The [isOutputRange|output range] to store the encoded result.
      *
      * Returns:
      *  The number of times the output range's $(D put) method was invoked.
@@ -600,8 +597,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * buffers.
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *           range) to _encode.
+     *  source = The [isInputRange|input range) to encode.
      *
      * Returns:
      *  A newly-allocated $(D char[]) buffer containing the encoded string.
@@ -631,12 +627,11 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
 
     /**
-     * An $(LINK2 std_range_primitives.html#isInputRange, input range) that
+     * An [isInputRange|input range] that
      * iterates over the respective Base64 encodings of a range of data items.
      *
-     * This range will be a $(LINK2 std_range_primitives.html#isForwardRange,
-     * forward range) if the underlying data source is at least a forward
-     * range.
+     * This range will be a [isForwardRange|forward range] if the underlying
+     * data source is at least a forward range.
      *
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF encoder) function instead.
@@ -709,8 +704,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
              * Save the current iteration state of the range.
              *
              * This method is only available if the underlying range is a
-             * $(LINK2 std_range_primitives.html#isForwardRange, forward
-             * range).
+             * [isForwardRange|forward range].
              *
              * Returns:
              *  A copy of $(D this).
@@ -743,11 +737,11 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
 
     /**
-     * An $(LINK2 std_range_primitives.html#isInputRange, input range) that
+     * An [isInputRange|input range] that
      * iterates over the encoded bytes of the given source data.
      *
-     * It will be a $(LINK2 std_range_primitives.html#isForwardRange, forward
-     * range) if the underlying data source is at least a forward range.
+     * It will be a [isForwardRange|forward range] if the underlying data
+     * source is at least a forward range.
      *
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF encoder) function instead.
@@ -874,8 +868,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
              * Save the current iteration state of the range.
              *
              * This method is only available if the underlying range is a
-             * $(LINK2 std_range_primitives.html#isForwardRange, forward
-             * range).
+             * [isForwardRange|forward range].
              *
              * Returns:
              *  A copy of $(D this).
@@ -893,11 +886,10 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
     /**
      * Construct an $(D Encoder) that iterates over the Base64 encoding of the
-     * given $(LINK2 std_range_primitives.html#isInputRange, input range).
+     * given [isInputRange|input range].
      *
      * Params:
-     *  range = An $(LINK2 std_range_primitives.html#isInputRange, input
-     *      range) over the data to be encoded.
+     *  range = An [isInputRange|input range] over the data to be encoded.
      *
      * Returns:
      *  If $(D_PARAM range) is a range of bytes, an $(D Encoder) that iterates
@@ -907,9 +899,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  iterates over the Base64 encoded strings of each element of the range.
      *
      *  In both cases, the returned $(D Encoder) will be a
-     *  $(LINK2 std_range_primitives.html#isForwardRange, forward range) if the
-     *  given $(D range) is at least a forward range, otherwise it will be only
-     *  an input range.
+     *  [isForwardRange|forward range] if the given $(D range) is at least a
+     * forward range, otherwise it will be only an input range.
      *
      * Example:
      * This example encodes the input one line at a time.
@@ -1021,8 +1012,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Decodes $(D_PARAM source) into the given buffer.
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *      range) to _decode.
+     *  source = The [isInputRange|input range] to decode.
      *  buffer = The buffer to store decoded result.
      *
      * Returns:
@@ -1197,14 +1187,11 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
 
     /**
-     * Decodes $(D_PARAM source) into a given
-     * $(LINK2 std_range_primitives.html#isOutputRange, output range).
+     * Decodes $(D_PARAM source) into a given [isOutputRange|output range].
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *           range) to _decode.
-     *  range  = The $(LINK2 std_range_primitives.html#isOutputRange, output
-     *           range) to store the decoded result.
+     *  source = The [isInputRange|input range] to decode.
+     *  range  = The [isOutputRange|output range] to store the decoded result.
      *
      * Returns:
      *  The number of times the output range's $(D put) method was invoked.
@@ -1385,8 +1372,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * buffers.
      *
      * Params:
-     *  source = The $(LINK2 std_range_primitives.html#isInputRange, input
-     *           range) to _decode.
+     *  source = The [isInputRange|input range] to decode.
      *
      * Returns:
      *  A newly-allocated $(D ubyte[]) buffer containing the decoded string.
@@ -1416,12 +1402,11 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
 
     /**
-     * An $(LINK2 std_range_primitives.html#isInputRange, input range) that
+     * An [isInputRange|input range] that
      * iterates over the decoded data of a range of Base64 encodings.
      *
-     * This range will be a $(LINK2 std_range_primitives.html#isForwardRange,
-     * forward range) if the underlying data source is at least a forward
-     * range.
+     * This range will be a [isForwardRange|forward range] if the
+     * underlying data source is at least a forward range.
      *
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF decoder) function instead.
@@ -1490,8 +1475,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
              * Saves the current iteration state.
              *
              * This method is only available if the underlying range is a
-             * $(LINK2 std_range_primitives.html#isForwardRange, forward
-             * range).
+             * [isForwardRange|forward range].
              *
              * Returns: A copy of $(D this).
              */
@@ -1541,12 +1525,11 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
 
     /**
-     * An $(LINK2 std_range_primitives.html#isInputRange, input range) that
+     * An [isInputRange|input range] that
      * iterates over the bytes of data decoded from a Base64 encoded string.
      *
-     * This range will be a $(LINK2 std_range_primitives.html#isForwardRange,
-     * forward range) if the underlying data source is at least a forward
-     * range.
+     * This range will be a [isForwardRange|forward range] if the underlying
+     * data source is at least a forward range.
      *
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF decoder) function instead.
@@ -1683,8 +1666,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
              * Saves the current iteration state.
              *
              * This method is only available if the underlying range is a
-             * $(LINK2 std_range_primitives.html#isForwardRange, forward
-             * range).
+             * [isForwardRange|forward range].
              *
              * Returns: A copy of $(D this).
              */
@@ -1704,8 +1686,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Base64 encoded data.
      *
      * Params:
-     *  range = An $(LINK2 std_range_primitives.html#isInputRange, input
-     *      range) over the data to be decoded.
+     *  range = An [isInputRange|input range) over the data to be decoded.
      *
      * Returns:
      *  If $(D_PARAM range) is a range of characters, a $(D Decoder) that
@@ -1714,13 +1695,12 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  If $(D_PARAM range) is a range of ranges of characters, a $(D Decoder)
      *  that iterates over the decoded strings corresponding to each element of
      *  the range. In this case, the length of each subrange must be a multiple
-     *  of 4; the returned _decoder does not keep track of Base64 decoding
+     *  of 4; the returned decoder does not keep track of Base64 decoding
      *  state across subrange boundaries.
      *
      *  In both cases, the returned $(D Decoder) will be a
-     *  $(LINK2 std_range_primitives.html#isForwardRange, forward range) if the
-     *  given $(D range) is at least a forward range, otherwise it will be only
-     *  an input range.
+     *  [isForwardRange|forward range] if the  given $(D range) is at least a
+     *  forward range, otherwise it will be only an input range.
      *
      * If the input data contains characters not found in the base alphabet of
      * the current Base64 encoding scheme, the returned range may throw a

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -912,7 +912,7 @@ public:
 
     /**
         $(D toString) is rarely directly invoked; the usual way of using it is via
-        $(LINK2 std_format.html#format, std.format.format):
+        $(XREF format,format):
      */
     unittest
     {

--- a/std/complex.d
+++ b/std/complex.d
@@ -111,7 +111,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     instead, it is used via $(XREF string,format), as shown in the examples
     below.  Supported format characters are 'e', 'f', 'g', 'a', and 's'.
 
-    See the $(LINK2 std_format.html, std.format) and $(XREF string, format)
+    See the $(MREF std,format) and $(XREF string, format)
     documentation for more information.
     */
     string toString() const /* TODO: @safe pure nothrow */

--- a/std/complex.d
+++ b/std/complex.d
@@ -1,23 +1,23 @@
 // Written in the D programming language.
 
 /** This module contains the $(LREF Complex) type, which is used to represent
-    _complex numbers, along with related mathematical operations and functions.
+    complex numbers, along with related mathematical operations and functions.
 
     $(LREF Complex) will eventually
-    $(DDLINK deprecate, Deprecated Features, replace)
+    [http://dlang.org/deprecate.html#Imaginary%20and%20complex%20types|replace]
     the built-in types $(D cfloat), $(D cdouble), $(D creal), $(D ifloat),
     $(D idouble), and $(D ireal).
 
     Authors:    Lars Tandle Kyllingstad, Don Clugston
     Copyright:  Copyright (c) 2010, Lars T. Kyllingstad.
     License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
-    Source:     $(PHOBOSSRC std/_complex.d)
+    Source:     $(PHOBOSSRC std/complex.d)
 */
 module std.complex;
 
 import std.traits;
 
-/** Helper function that returns a _complex number with the specified
+/** Helper function that returns a complex number with the specified
     real and imaginary parts.
 
     Params:

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -52,7 +52,7 @@
  * ---
  *
  * Copyright: Copyright Sean Kelly 2009 - 2014.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License:   [http://www.boost.org/LICENSE_1_0.txt|Boost License 1.0]
  * Authors:   Sean Kelly, Alex Rønne Petersen, Martin Nowak
  * Source:    $(PHOBOSSRC std/_concurrency.d)
  */

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -184,16 +184,17 @@ for the array is reclaimed as soon as possible; there is no reliance
 on the garbage collector. $(D Array) uses $(D malloc) and $(D free)
 for managing its own memory.
 
+
 This means that pointers to elements of an $(D Array) will become
 dangling as soon as the element is removed from the $(D Array). On the other hand
 the memory allocated by an $(D Array) will be scanned by the GC and
 GC managed objects referenced from an $(D Array) will be kept alive.
 
-Note:
-
-When using $(D Array) with range-based functions like those in $(D std.algorithm),
-$(D Array) must be sliced to get a range (for example, use $(D array[].map!)
-instead of $(D array.map!)). The container itself is not a range.
+$(TIP
+    When using $(D Array) with range-based functions like those in $(D std.algorithm),
+    $(D Array) must be sliced to get a range (for example, use $(D array[].map!)
+    instead of $(D array.map!)). The container itself is not a range.
+}
  */
 struct Array(T)
 if (!is(Unqual!T == bool))

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -6,7 +6,7 @@ This module defines generic containers.
 Construction:
 
 To implement the different containers both struct and class based
-approaches have been used. $(XREF_PACK _container,util,make) allows for
+approaches have been used. $(XREF_PACK container,util,make) allows for
 uniform construction with either approach.
 
 ---
@@ -34,7 +34,7 @@ Reference_semantics:
 All containers have reference semantics, which means that after
 assignment both variables refer to the same underlying data.
 
-To make a copy of a _container, use the $(D c._dup) _container primitive.
+To make a copy of a container, use the $(D c._dup) container primitive.
 ---
 import std.container, std.range;
 Array!int originalArray = make!(Array!int)(1, 2, 3);
@@ -52,7 +52,7 @@ secondArray[0] = 1;
 assert(originalArray[0] == 12);
 ---
 
-$(B Attention:) If the _container is implemented as a class, using an
+$(B Attention:) If the container is implemented as a class, using an
 uninitialized instance can cause a null pointer dereference.
 
 ---
@@ -62,8 +62,8 @@ RedBlackTree!int rbTree;
 rbTree.insert(5); // null pointer dereference
 ---
 
-Using an uninitialized struct-based _container will work, because the struct
-intializes itself upon use; however, up to this point the _container will not
+Using an uninitialized struct-based container will work, because the struct
+intializes itself upon use; however, up to this point the container will not
 have an identity and assignment does not create two references to the same
 data.
 
@@ -85,9 +85,9 @@ array1.removeBack();
 assert(array2.empty);
 ---
 It is therefore recommended to always construct containers using
-$(XREF_PACK _container,util,make).
+$(XREF_PACK container,util,make).
 
-This is in fact necessary to put containers into another _container.
+This is in fact necessary to put containers into another container.
 For example, to construct an $(D Array) of ten empty $(D Array)s, use
 the following that calls $(D make) ten times.
 
@@ -97,53 +97,20 @@ import std.container, std.range;
 auto arrOfArrs = make!Array(generate!(() => make!(Array!int)).take(10));
 ---
 
-Submodules:
-
-This module consists of the following submodules:
-
-$(UL
-    $(LI
-        The $(LINK2 std_container_array.html, std._container.array) module provides
-        an array type with deterministic control of memory, not reliant on
-        the GC unlike built-in arrays.
-    )
-    $(LI
-        The $(LINK2 std_container_binaryheap.html, std._container.binaryheap) module
-        provides a binary heap implementation that can be applied to any
-        user-provided random-access range.
-    )
-    $(LI
-        The $(LINK2 std_container_dlist.html, std._container.dlist) module provides
-        a doubly-linked list implementation.
-    )
-    $(LI
-        The $(LINK2 std_container_rbtree.html, std._container.rbtree) module
-        implements red-black trees.
-    )
-    $(LI
-        The $(LINK2 std_container_slist.html, std._container.slist) module
-        implements singly-linked lists.
-    )
-    $(LI
-        The $(LINK2 std_container_util.html, std._container.util) module contains
-        some generic tools commonly used by _container implementations.
-    )
-)
-
 The_primary_range_of_a_container:
 
-While some _containers offer direct access to their elements e.g. via
+While some containers offer direct access to their elements e.g. via
 $(D opIndex), $(D c.front) or $(D c.back), access
-and modification of a _container's contents is generally done through
-its primary $(LINK2 std_range.html, range) type,
+and modification of a container's contents is generally done through
+its primary [std.range|range] type,
 which is aliased as $(D C.Range). For example, the primary range type of
 $(D Array!int) is $(D Array!int.Range).
 
-If the documentation of a member function of a _container takes
+If the documentation of a member function of a container takes
 a parameter of type $(D Range), then it refers to the primary range type of
-this _container. Oftentimes $(D Take!Range) will be used, in which case
-the range refers to a span of the elements in the _container. Arguments to
-these parameters $(B must) be obtained from the same _container instance
+this container. Oftentimes $(D Take!Range) will be used, in which case
+the range refers to a span of the elements in the container. Arguments to
+these parameters $(B must) be obtained from the same container instance
 as the one being worked with. It is important to note that many generic range
 algorithms return the same range type as their input range.
 
@@ -168,7 +135,7 @@ array.linearRemove(array[].find(2).take(1));
 assert(array[].equal([1, 3]));
 ---
 
-When any $(LINK2 std_range.html, range) can be passed as an argument to
+When any [std.range|range] can be passed as an argument to
 a member function, the documention usually refers to the parameter's templated
 type as $(D Stuff).
 
@@ -191,216 +158,216 @@ Container_primitives:
 Containers do not form a class hierarchy, instead they implement a
 common set of primitives (see table below). These primitives each guarantee
 a specific worst case complexity and thus allow generic code to be written
-independently of the _container implementation.
+independently of the container implementation.
 
 For example the primitives $(D c.remove(r)) and $(D c.linearRemove(r)) both
-remove the sequence of elements in range $(D r) from the _container $(D c).
+remove the sequence of elements in range $(D r) from the container $(D c).
 The primitive $(D c.remove(r)) guarantees
-$(BIGOH n$(SUBSCRIPT r) log n$(SUBSCRIPT c)) complexity in the worst case and
-$(D c.linearRemove(r)) relaxes this guarantee to $(BIGOH n$(SUBSCRIPT c)).
+$(BIGOH n$(SUB r) log n$(SUB c)) complexity in the worst case and
+$(D c.linearRemove(r)) relaxes this guarantee to $(BIGOH n$(SUB c)).
 
-Since a sequence of elements can be removed from a $(LINK2 std_container_dlist.html, doubly linked list)
+Since a sequence of elements can be removed from a [DList|doubly linked list]
 in constant time, $(D DList) provides the primitive $(D c.remove(r))
 as well as $(D c.linearRemove(r)). On the other hand
-$(LINK2 std_container_array.html, Array) only offers $(D c.linearRemove(r)).
+[Array] only offers $(D c.linearRemove(r)).
 
 The following table describes the common set of primitives that containers
-implement.  A _container need not implement all primitives, but if a
+implement.  A container need not implement all primitives, but if a
 primitive is implemented, it must support the syntax described in the $(B
 syntax) column with the semantics described in the $(B description) column, and
 it must not have a worst-case complexity worse than denoted in big-O notation in
-the $(BIGOH &middot;) column.  Below, $(D C) means a _container type, $(D c) is
-a value of _container type, $(D n$(SUBSCRIPT x)) represents the effective length of
-value $(D x), which could be a single element (in which case $(D n$(SUBSCRIPT x)) is
-$(D 1)), a _container, or a range.
+the $(BIGOH &middot;) column.  Below, $(D C) means a container type, $(D c) is
+a value of container type, $(D n$(SUB x)) represents the effective length of
+value $(D x), which could be a single element (in which case $(D n$(SUB x)) is
+$(D 1)), a container, or a range.
 
 $(BOOKTABLE Container primitives,
 
 $(TR $(TH Syntax) $(TH $(BIGOH &middot;)) $(TH Description))
 
-$(TR $(TDNW $(D C(x))) $(TDNW $(D n$(SUBSCRIPT x))) $(TD Creates a
-_container of type $(D C) from either another _container or a range. The created _container must not be a null reference even if x is empty.))
+$(TR $(TDNW $(D C(x))) $(TDNW $(TT n$(SUB x))) $(TD Creates a
+container of type $(D C) from either another container or a range. The created container must not be a null reference even if x is empty.))
 
-$(TR $(TDNW $(D c.dup)) $(TDNW $(D n$(SUBSCRIPT c))) $(TD Returns a
-duplicate of the _container.))
+$(TR $(TDNW $(D c.dup)) $(TDNW $(TT n$(SUB c))) $(TD Returns a
+duplicate of the container.))
 
-$(TR $(TDNW $(D c ~ x)) $(TDNW $(D n$(SUBSCRIPT c) + n$(SUBSCRIPT x))) $(TD
+$(TR $(TDNW $(D c ~ x)) $(TDNW $(TT n$(SUB c) + n$(SUB x))) $(TD
 Returns the concatenation of $(D c) and $(D r). $(D x) may be a single
 element or an input range.))
 
-$(TR $(TDNW $(D x ~ c)) $(TDNW $(D n$(SUBSCRIPT c) + n$(SUBSCRIPT x))) $(TD
+$(TR $(TDNW $(D x ~ c)) $(TDNW $(TT n$(SUB c) + n$(SUB x))) $(TD
 Returns the concatenation of $(D x) and $(D c).  $(D x) may be a
 single element or an input range type.))
 
 $(LEADINGROWN 3, Iteration)
 
 $(TR  $(TD $(D c.Range)) $(TD) $(TD The primary range
-type associated with the _container.))
+type associated with the container.))
 
-$(TR $(TD $(D c[])) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns a range
-iterating over the entire _container, in a _container-defined order.))
+$(TR $(TD $(D c[])) $(TDNW $(TT log n$(SUB c))) $(TD Returns a range
+iterating over the entire container, in a container-defined order.))
 
-$(TR $(TDNW $(D c[a .. b])) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Fetches a
-portion of the _container from key $(D a) to key $(D b).))
+$(TR $(TDNW $(D c[a .. b])) $(TDNW $(TT log n$(SUB c))) $(TD Fetches a
+portion of the container from key $(D a) to key $(D b).))
 
 $(LEADINGROWN 3, Capacity)
 
 $(TR $(TD $(D c.empty)) $(TD $(D 1)) $(TD Returns $(D true) if the
-_container has no elements, $(D false) otherwise.))
+container has no elements, $(D false) otherwise.))
 
-$(TR  $(TD $(D c.length)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns the
-number of elements in the _container.))
+$(TR  $(TD $(D c.length)) $(TDNW $(TT log n$(SUB c))) $(TD Returns the
+number of elements in the container.))
 
-$(TR $(TDNW $(D c.length = n)) $(TDNW $(D n$(SUBSCRIPT c) + n)) $(TD Forces
-the number of elements in the _container to $(D n). If the _container
+$(TR $(TDNW $(TT c.length = n)) $(TDNW $(TT n$(SUB c) + n)) $(TD Forces
+the number of elements in the container to $(D n). If the container
 ends up growing, the added elements are initialized in a
-_container-dependent manner (usually with $(D T.init)).))
+container-dependent manner (usually with $(D T.init)).))
 
-$(TR $(TD $(D c.capacity)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns the
-maximum number of elements that can be stored in the _container
+$(TR $(TD $(D c.capacity)) $(TDNW $(TT log n$(SUB c))) $(TD Returns the
+maximum number of elements that can be stored in the container
 without triggering a reallocation.))
 
-$(TR $(TD $(D c.reserve(x))) $(TD $(D n$(SUBSCRIPT c))) $(TD Forces $(D
+$(TR $(TD $(D c.reserve(x))) $(TD $(TT n$(SUB c))) $(TD Forces $(D
 capacity) to at least $(D x) without reducing it.))
 
 $(LEADINGROWN 3, Access)
 
-$(TR $(TDNW $(D c.front)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns the
-first element of the _container, in a _container-defined order.))
+$(TR $(TDNW $(D c.front)) $(TDNW $(TT log n$(SUB c))) $(TD Returns the
+first element of the container, in a container-defined order.))
 
-$(TR $(TDNW $(D c.moveFront)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR $(TDNW $(D c.moveFront)) $(TDNW $(TT log n$(SUB c))) $(TD
 Destructively reads and returns the first element of the
-_container. The slot is not removed from the _container; it is left
+container. The slot is not removed from the container; it is left
 initialized with $(D T.init). This routine need not be defined if $(D
 front) returns a $(D ref).))
 
-$(TR $(TDNW $(D c.front = v)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Assigns
-$(D v) to the first element of the _container.))
+$(TR $(TDNW $(D c.front = v)) $(TDNW $(TT log n$(SUB c))) $(TD Assigns
+$(D v) to the first element of the container.))
 
-$(TR $(TDNW $(D c.back)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns the
-last element of the _container, in a _container-defined order.))
+$(TR $(TDNW $(D c.back)) $(TDNW $(TT log n$(SUB c))) $(TD Returns the
+last element of the container, in a container-defined order.))
 
-$(TR $(TDNW $(D c.moveBack)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR $(TDNW $(D c.moveBack)) $(TDNW $(TT log n$(SUB c))) $(TD
 Destructively reads and returns the last element of the
-_container. The slot is not removed from the _container; it is left
+container. The slot is not removed from the container; it is left
 initialized with $(D T.init). This routine need not be defined if $(D
 front) returns a $(D ref).))
 
-$(TR $(TDNW $(D c.back = v)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Assigns
-$(D v) to the last element of the _container.))
+$(TR $(TDNW $(D c.back = v)) $(TDNW $(TT log n$(SUB c))) $(TD Assigns
+$(D v) to the last element of the container.))
 
-$(TR $(TDNW $(D c[x])) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Provides
-indexed access into the _container. The index type is
-_container-defined. A _container may define several index types (and
+$(TR $(TDNW $(D c[x])) $(TDNW $(TT log n$(SUB c))) $(TD Provides
+indexed access into the container. The index type is
+container-defined. A container may define several index types (and
 consequently overloaded indexing).))
 
-$(TR  $(TDNW $(D c.moveAt(x))) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR  $(TDNW $(D c.moveAt(x))) $(TDNW $(TT log n$(SUB c))) $(TD
 Destructively reads and returns the value at position $(D x). The slot
-is not removed from the _container; it is left initialized with $(D
+is not removed from the container; it is left initialized with $(D
 T.init).))
 
-$(TR  $(TDNW $(D c[x] = v)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Sets
-element at specified index into the _container.))
+$(TR  $(TDNW $(D c[x] = v)) $(TDNW $(TT log n$(SUB c))) $(TD Sets
+element at specified index into the container.))
 
-$(TR  $(TDNW $(D c[x] $(I op)= v)) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c[x] $(I op)= v)) $(TDNW $(TT log n$(SUB c)))
 $(TD Performs read-modify-write operation at specified index into the
-_container.))
+container.))
 
 $(LEADINGROWN 3, Operations)
 
-$(TR $(TDNW $(D e in c)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR $(TDNW $(D e in c)) $(TDNW $(TT log n$(SUB c))) $(TD
 Returns nonzero if e is found in $(D c).))
 
-$(TR  $(TDNW $(D c.lowerBound(v))) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR  $(TDNW $(D c.lowerBound(v))) $(TDNW $(TT log n$(SUB c))) $(TD
 Returns a range of all elements strictly less than $(D v).))
 
-$(TR  $(TDNW $(D c.upperBound(v))) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR  $(TDNW $(D c.upperBound(v))) $(TDNW $(TT log n$(SUB c))) $(TD
 Returns a range of all elements strictly greater than $(D v).))
 
-$(TR  $(TDNW $(D c.equalRange(v))) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
+$(TR  $(TDNW $(D c.equalRange(v))) $(TDNW $(TT log n$(SUB c))) $(TD
 Returns a range of all elements in $(D c) that are equal to $(D v).))
 
 $(LEADINGROWN 3, Modifiers)
 
-$(TR $(TDNW $(D c ~= x)) $(TDNW $(D n$(SUBSCRIPT c) + n$(SUBSCRIPT x)))
+$(TR $(TDNW $(D c ~= x)) $(TDNW $(TT n$(SUB c) + n$(SUB x)))
 $(TD Appends $(D x) to $(D c). $(D x) may be a single element or an
 input range type.))
 
-$(TR  $(TDNW $(D c.clear())) $(TDNW $(D n$(SUBSCRIPT c))) $(TD Removes all
+$(TR  $(TDNW $(D c.clear())) $(TDNW $(TT n$(SUB c))) $(TD Removes all
 elements in $(D c).))
 
-$(TR  $(TDNW $(D c.insert(x))) $(TDNW $(D n$(SUBSCRIPT x) * log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.insert(x))) $(TDNW $(TT n$(SUB x) * log n$(SUB c)))
 $(TD Inserts $(D x) in $(D c) at a position (or positions) chosen by $(D c).))
 
 $(TR  $(TDNW $(D c.stableInsert(x)))
-$(TDNW $(D n$(SUBSCRIPT x) * log n$(SUBSCRIPT c))) $(TD Same as $(D c.insert(x)),
+$(TDNW $(TT n$(SUB x) * log n$(SUB c))) $(TD Same as $(D c.insert(x)),
 but is guaranteed to not invalidate any ranges.))
 
-$(TR  $(TDNW $(D c.linearInsert(v))) $(TDNW $(D n$(SUBSCRIPT c))) $(TD Same
+$(TR  $(TDNW $(D c.linearInsert(v))) $(TDNW $(TT n$(SUB c))) $(TD Same
 as $(D c.insert(v)) but relaxes complexity to linear.))
 
-$(TR  $(TDNW $(D c.stableLinearInsert(v))) $(TDNW $(D n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableLinearInsert(v))) $(TDNW $(TT n$(SUB c)))
 $(TD Same as $(D c.stableInsert(v)) but relaxes complexity to linear.))
 
-$(TR  $(TDNW $(D c.removeAny())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.removeAny())) $(TDNW $(TT log n$(SUB c)))
 $(TD Removes some element from $(D c) and returns it.))
 
-$(TR  $(TDNW $(D c.stableRemoveAny())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableRemoveAny())) $(TDNW $(TT log n$(SUB c)))
 $(TD Same as $(D c.removeAny()), but is guaranteed to not invalidate any
 iterators.))
 
-$(TR  $(TDNW $(D c.insertFront(v))) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.insertFront(v))) $(TDNW $(TT log n$(SUB c)))
 $(TD Inserts $(D v) at the front of $(D c).))
 
-$(TR  $(TDNW $(D c.stableInsertFront(v))) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableInsertFront(v))) $(TDNW $(TT log n$(SUB c)))
 $(TD Same as $(D c.insertFront(v)), but guarantees no ranges will be
 invalidated.))
 
-$(TR  $(TDNW $(D c.insertBack(v))) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.insertBack(v))) $(TDNW $(TT log n$(SUB c)))
 $(TD Inserts $(D v) at the back of $(D c).))
 
-$(TR  $(TDNW $(D c.stableInsertBack(v))) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableInsertBack(v))) $(TDNW $(TT log n$(SUB c)))
 $(TD Same as $(D c.insertBack(v)), but guarantees no ranges will be
 invalidated.))
 
-$(TR  $(TDNW $(D c.removeFront())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.removeFront())) $(TDNW $(TT log n$(SUB c)))
 $(TD Removes the element at the front of $(D c).))
 
-$(TR  $(TDNW $(D c.stableRemoveFront())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableRemoveFront())) $(TDNW $(TT log n$(SUB c)))
 $(TD Same as $(D c.removeFront()), but guarantees no ranges will be
 invalidated.))
 
-$(TR  $(TDNW $(D c.removeBack())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.removeBack())) $(TDNW $(TT log n$(SUB c)))
 $(TD Removes the value at the back of $(D c).))
 
-$(TR  $(TDNW $(D c.stableRemoveBack())) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableRemoveBack())) $(TDNW $(TT log n$(SUB c)))
 $(TD Same as $(D c.removeBack()), but guarantees no ranges will be
 invalidated.))
 
-$(TR  $(TDNW $(D c.remove(r))) $(TDNW $(D n$(SUBSCRIPT r) * log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.remove(r))) $(TDNW $(TT n$(SUB r) * log n$(SUB c)))
 $(TD Removes range $(D r) from $(D c).))
 
 $(TR  $(TDNW $(D c.stableRemove(r)))
-$(TDNW $(D n$(SUBSCRIPT r) * log n$(SUBSCRIPT c)))
+$(TDNW $(TT n$(SUB r) * log n$(SUB c)))
 $(TD Same as $(D c.remove(r)), but guarantees iterators are not
 invalidated.))
 
-$(TR  $(TDNW $(D c.linearRemove(r))) $(TDNW $(D n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.linearRemove(r))) $(TDNW $(TT n$(SUB c)))
 $(TD Removes range $(D r) from $(D c).))
 
-$(TR  $(TDNW $(D c.stableLinearRemove(r))) $(TDNW $(D n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.stableLinearRemove(r))) $(TDNW $(TT n$(SUB c)))
 $(TD Same as $(D c.linearRemove(r)), but guarantees iterators are not
 invalidated.))
 
-$(TR  $(TDNW $(D c.removeKey(k))) $(TDNW $(D log n$(SUBSCRIPT c)))
+$(TR  $(TDNW $(D c.removeKey(k))) $(TDNW $(TT log n$(SUB c)))
 $(TD Removes an element from $(D c) by using its key $(D k).
-The key's type is defined by the _container.))
+The key's type is defined by the container.))
 
 $(TR  $(TDNW $(D )) $(TDNW $(D )) $(TD ))
 
 )
 
-Source: $(PHOBOSSRC std/_container/package.d)
+Source: $(PHOBOSSRC std/container/package.d)
 Macros:
 WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0

--- a/std/conv.d
+++ b/std/conv.d
@@ -2,6 +2,7 @@
 
 /**
 A one-stop shop for converting values from one type to another.
+Typical usage: `$(LREF to)!SomeType(some_variable);`
 
 Copyright: Copyright Digital Mars 2007-.
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -2,7 +2,7 @@
 
 /**
 A one-stop shop for converting values from one type to another.
-Typical usage: `$(LREF to)!SomeType(some_variable);`
+Typical usage: $(TT $(LREF to)!SomeType(some_variable);)
 
 Copyright: Copyright Digital Mars 2007-.
 
@@ -151,19 +151,19 @@ class ConvOverflowException : ConvException
 }
 
 /**
-The `to` template converts a value from one type _to another.
+The `to` template converts a value from one type to another.
 The source type is deduced and the target type must be specified, for example the
 expression `to!int(42.0)` converts the number 42 from
-`double` _to `int`. The conversion is "safe", i.e.,
+`double` to `int`. The conversion is "safe", i.e.,
 it checks for overflow; `to!int(4.2e10)` would throw the
 `ConvOverflowException` exception. Overflow checks are only
 inserted when necessary, e.g., `to!double(42)` does not do
 any checking because any `int` fits in a `double`.
 
-Conversions from string _to numeric types differ from the C equivalents
+Conversions from string to numeric types differ from the C equivalents
 `atoi()` and `atol()` by checking for overflow and not allowing whitespace.
 
-For conversion of strings _to signed types, the grammar recognized is:
+For conversion of strings to signed types, the grammar recognized is:
 <pre>
 $(I Integer): $(I Sign UnsignedInteger)
 $(I UnsignedInteger)
@@ -172,7 +172,7 @@ $(I Sign):
     $(B -)
 </pre>
 
-For conversion _to unsigned types, the grammar recognized is:
+For conversion to unsigned types, the grammar recognized is:
 <pre>
 $(I UnsignedInteger):
     $(I DecimalDigit)
@@ -196,7 +196,7 @@ template to(T)
 }
 
 /**
- * Converting a value _to its own type (useful mostly for generic code)
+ * Converting a value to its own type (useful mostly for generic code)
  * simply returns its argument.
  */
 @safe pure unittest
@@ -207,12 +207,12 @@ template to(T)
 }
 
 /**
- * Converting among numeric types is a safe way _to cast them around.
+ * Converting among numeric types is a safe way to cast them around.
  *
- * Conversions from floating-point types _to integral types allow loss of
+ * Conversions from floating-point types to integral types allow loss of
  * precision (the fractional part of a floating-point number). The
  * conversion is truncating towards zero, the same way a cast would
- * truncate. (_To round a floating point value when casting _to an
+ * truncate. (_To round a floating point value when casting to an
  * integral, use `roundTo`.)
  */
 @safe pure unittest
@@ -231,9 +231,9 @@ template to(T)
 }
 
 /**
- * When converting strings _to numeric types, note that the D hexadecimal and binary
+ * When converting strings to numeric types, note that the D hexadecimal and binary
  * literals are not handled. Neither the prefixes that indicate the base, nor the
- * horizontal bar used _to separate groups of digits are recognized. This also
+ * horizontal bar used to separate groups of digits are recognized. This also
  * applies to the suffixes that indicate the type.
  *
  * _To work around this, you can specify a radix for conversions involving numbers.
@@ -247,7 +247,7 @@ template to(T)
 }
 
 /**
- * Conversions from integral types _to floating-point types always
+ * Conversions from integral types to floating-point types always
  * succeed, but might lose accuracy. The largest integers with a
  * predecessor representable in floating-point format are `2^24-1` for
  * `float`, `2^53-1` for `double`, and `2^64-1` for `real` (when
@@ -262,8 +262,8 @@ template to(T)
 }
 
 /**
- * Converting an array _to another array type works by converting each
- * element in turn. Associative arrays can be converted _to associative
+ * Converting an array to another array type works by converting each
+ * element in turn. Associative arrays can be converted to associative
  * arrays as long as keys and values can in turn be converted.
  */
 @safe pure unittest
@@ -287,9 +287,9 @@ template to(T)
  * Conversions operate transitively, meaning that they work on arrays and
  * associative arrays of any complexity.
  *
- * This conversion works because `to!short` applies _to an `int`, `to!wstring`
- * applies _to a `string`, `to!string` applies _to a `double`, and
- * `to!(double[])` applies _to an `int[]`. The conversion might throw an
+ * This conversion works because `to!short` applies to an `int`, `to!wstring`
+ * applies to a `string`, `to!string` applies to a `double`, and
+ * `to!(double[])` applies to an `int[]`. The conversion might throw an
  * exception because `to!short` might fail the range check.
  */
 unittest
@@ -318,30 +318,30 @@ unittest
 /**
  * Stringize conversion from all types is supported.
  * $(UL
- *   $(LI String _to string conversion works for any two string types having
+ *   $(LI String to string conversion works for any two string types having
  *        ($(D char), $(D wchar), $(D dchar)) character widths and any
  *        combination of qualifiers (mutable, $(D const), or $(D immutable)).)
- *   $(LI Converts array (other than strings) _to string.
+ *   $(LI Converts array (other than strings) to string.
  *        Each element is converted by calling $(D to!T).)
- *   $(LI Associative array _to string conversion.
+ *   $(LI Associative array to string conversion.
  *        Each element is printed by calling $(D to!T).)
- *   $(LI Object _to string conversion calls $(D toString) against the object or
+ *   $(LI Object to string conversion calls $(D toString) against the object or
  *        returns $(D "null") if the object is null.)
- *   $(LI Struct _to string conversion calls $(D toString) against the struct if
+ *   $(LI Struct to string conversion calls $(D toString) against the struct if
  *        it is defined.)
- *   $(LI For structs that do not define $(D toString), the conversion _to string
+ *   $(LI For structs that do not define $(D toString), the conversion to string
  *        produces the list of fields.)
- *   $(LI Enumerated types are converted _to strings as their symbolic names.)
+ *   $(LI Enumerated types are converted to strings as their symbolic names.)
  *   $(LI Boolean values are printed as $(D "true") or $(D "false").)
- *   $(LI $(D char), $(D wchar), $(D dchar) _to a string type.)
- *   $(LI Unsigned or signed integers _to strings.
+ *   $(LI $(D char), $(D wchar), $(D dchar) to a string type.)
+ *   $(LI Unsigned or signed integers to strings.
  *        $(DL $(DT [special case])
- *             $(DD Convert integral value _to string in $(D_PARAM radix) radix.
+ *             $(DD Convert integral value to string in $(D_PARAM radix) radix.
  *             radix must be a value from 2 to 36.
  *             value is treated as a signed value only if radix is 10.
  *             The characters A through Z are used to represent values 10 through 36
  *             and their case is determined by the $(D_PARAM letterCase) parameter.)))
- *   $(LI All floating point types _to all string types.)
+ *   $(LI All floating point types to all string types.)
  *   $(LI Pointer to string conversions prints the pointer as a $(D size_t) value.
  *        If pointer is $(D char*), treat it as C-style strings.
  *        In that case, this function is $(D @system).))
@@ -848,7 +848,7 @@ private T toImpl(T, S)(S value)
 }
 
 /**
-Handles type _to string conversions
+Handles type to string conversions
 */
 private T toImpl(T, S)(S value)
     if (!(isImplicitlyConvertible!(S, T) &&
@@ -5355,8 +5355,8 @@ template castFrom(From)
 {
     /**
         Params:
-            To    = The type _to cast _to.
-            value = The value _to cast. It must be of type $(D From),
+            To    = The type to cast to.
+            value = The value to cast. It must be of type $(D From),
                     otherwise a compile-time error is emitted.
 
         Returns:

--- a/std/csv.d
+++ b/std/csv.d
@@ -87,7 +87,7 @@
  *   Copyright: Copyright 2011
  *   License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *   Authors:   Jesse Phillips
- *   Source:    $(PHOBOSSRC std/_csv.d)
+ *   Source:    $(PHOBOSSRC std/csv.d)
  */
 module std.csv;
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -6,7 +6,7 @@
     This module provides:
     $(UL
         $(LI Types to represent points in time: $(LREF SysTime), $(LREF Date),
-             $(LREF TimeOfDay), and $(LREF2 .DateTime, DateTime).)
+             $(LREF TimeOfDay), and $(LREF DateTime).)
         $(LI Types to represent intervals of time.)
         $(LI Types to represent ranges over intervals of time.)
         $(LI Types to represent time zones (used by $(LREF SysTime)).)
@@ -16,7 +16,7 @@
         $(LI Various helper functions.)
     )
 
-    Closely related to std.datetime is <a href="core_time.html">$(D core.time)</a>,
+    Closely related to std.datetime is [core.time],
     and some of the time types used in std.datetime come from there - such as
     $(CXREF time, Duration), $(CXREF time, TickDuration), and
     $(CXREF time, FracSec).
@@ -53,7 +53,7 @@
     while $(LREF SysTime) is designed for dealing with time from the OS. Check out
     their specific documentation for more details.
 
-    To get the current time, use $(LREF2 .Clock.currTime, Clock.currTime).
+    To get the current time, use $(LREF Clock.currTime).
     It will return the current
     time as a $(LREF SysTime). To print it, $(D toString) is
     sufficient, but if using $(D toISOString), $(D toISOExtString), or
@@ -89,13 +89,12 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
         $(LREF DateTimeException)).
 
     See_Also:
-        $(DDLINK intro-to-_datetime, Introduction to std.datetime,
-                 Introduction to std&#46;_datetime)<br>
-        $(WEB en.wikipedia.org/wiki/ISO_8601, ISO 8601)<br>
-        $(WEB en.wikipedia.org/wiki/Tz_database,
-              Wikipedia entry on TZ Database)<br>
-        $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones,
-              List of Time Zones)<br>
+    $(LIST
+        * [http://dlang.org/intro-to-datetime.html|Introduction to std.datetime]
+        * [http://en.wikipedia.org/wiki/ISO_8601|ISO 8601]
+        * [http://en.wikipedia.org/wiki/Tz_database|Wikipedia entry on TZ Database]
+        * [http://en.wikipedia.org/wiki/List_of_tz_database_time_zones|List of Time Zones]
+    )
 
     Copyright: Copyright 2010 - 2015
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
@@ -214,7 +213,7 @@ enum AllowDayOverflow
 }
 
 /++
-    Indicates a direction in time. One example of its use is $(LREF2 .Interval, Interval)'s
+    Indicates a direction in time. One example of its use is $(LREF Interval)'s
     $(LREF expand, expand) function which uses it to indicate whether the interval should
     be expanded backwards (into the past), forwards (into the future), or both.
   +/
@@ -622,11 +621,11 @@ private:
     care about time zones, then $(LREF DateTime) would be the type to
     use. For system time, use $(D SysTime).
 
-    $(LREF2 .Clock.currTime, Clock.currTime) will return the current time as a $(D SysTime).
+    $(LREF Clock.currTime) will return the current time as a $(D SysTime).
     To convert a $(D SysTime) to a $(LREF Date) or $(LREF DateTime), simply cast
     it. To convert a $(LREF Date) or $(LREF DateTime) to a
     $(D SysTime), use $(D SysTime)'s constructor, and pass in the
-    intended time zone with it (or don't pass in a $(LREF2 .TimeZone, TimeZone), and the local
+    intended time zone with it (or don't pass in a $(LREF TimeZone), and the local
     time zone will be used). Be aware, however, that converting from a
     $(LREF DateTime) to a $(D SysTime) will not necessarily be 100% accurate due to
     DST (one hour of the year doesn't exist and another occurs twice).
@@ -639,11 +638,11 @@ private:
     Database files), and use $(LREF WindowsTimeZone) on Windows systems.
     The time in $(D SysTime) is kept internally in hnsecs from midnight,
     January 1st, 1 A.D. UTC. Conversion error cannot happen when changing
-    the time zone of a $(D SysTime). $(LREF LocalTime) is the $(LREF2 .TimeZone, TimeZone) class
-    which represents the local time, and $(D UTC) is the $(LREF2 .TimeZone, TimeZone) class
-    which represents UTC. $(D SysTime) uses $(LREF LocalTime) if no $(LREF2 .TimeZone, TimeZone)
+    the time zone of a $(D SysTime). $(LREF LocalTime) is the $(LREF TimeZone) class
+    which represents the local time, and $(D UTC) is the $(LREF TimeZone) class
+    which represents UTC. $(D SysTime) uses $(LREF LocalTime) if no $(LREF TimeZone)
     is provided. For more details on time zones, see the documentation for
-    $(LREF2 .TimeZone, TimeZone), $(LREF PosixTimeZone), and $(LREF WindowsTimeZone).
+    $(LREF TimeZone), $(LREF PosixTimeZone), and $(LREF WindowsTimeZone).
 
     $(D SysTime)'s range is from approximately 29,000 B.C. to approximately
     29,000 A.D.
@@ -659,7 +658,7 @@ public:
             dateTime = The $(LREF DateTime) to use to set this $(LREF SysTime)'s
                        internal std time. As $(LREF DateTime) has no concept of
                        time zone, tz is used as its time zone.
-            tz       = The $(LREF2 .TimeZone, TimeZone) to use for this $(LREF SysTime). If null,
+            tz       = The $(LREF TimeZone) to use for this $(LREF SysTime). If null,
                        $(LREF LocalTime) will be used. The given $(LREF DateTime) is
                        assumed to be in the given time zone.
       +/
@@ -700,7 +699,7 @@ public:
                        internal std time. As $(LREF DateTime) has no concept of
                        time zone, tz is used as its time zone.
             fracSecs = The fractional seconds portion of the time.
-            tz       = The $(LREF2 .TimeZone, TimeZone) to use for this $(LREF SysTime). If null,
+            tz       = The $(LREF TimeZone) to use for this $(LREF SysTime). If null,
                        $(LREF LocalTime) will be used. The given $(LREF DateTime) is
                        assumed to be in the given time zone.
 
@@ -759,7 +758,7 @@ public:
                        internal std time. As $(LREF DateTime) has no concept of
                        time zone, tz is used as its time zone.
             fracSec  = The fractional seconds portion of the time.
-            tz       = The $(LREF2 .TimeZone, TimeZone) to use for this $(LREF SysTime). If null,
+            tz       = The $(LREF TimeZone) to use for this $(LREF SysTime). If null,
                        $(LREF LocalTime) will be used. The given $(LREF DateTime) is
                        assumed to be in the given time zone.
 
@@ -820,7 +819,7 @@ public:
             date = The $(LREF Date) to use to set this $(LREF SysTime)'s internal std
                    time. As $(LREF Date) has no concept of time zone, tz is used as
                    its time zone.
-            tz   = The $(LREF2 .TimeZone, TimeZone) to use for this $(LREF SysTime). If null,
+            tz   = The $(LREF TimeZone) to use for this $(LREF SysTime). If null,
                    $(LREF LocalTime) will be used. The given $(LREF Date) is assumed
                    to be in the given time zone.
       +/
@@ -869,7 +868,7 @@ public:
 
         Params:
             stdTime = The number of hnsecs since midnight, January 1st, 1 A.D. UTC.
-            tz      = The $(LREF2 .TimeZone, TimeZone) to use for this $(LREF SysTime). If null,
+            tz      = The $(LREF TimeZone) to use for this $(LREF SysTime). If null,
                       $(LREF LocalTime) will be used.
       +/
     this(long stdTime, immutable TimeZone tz = null) @safe pure nothrow
@@ -2396,7 +2395,7 @@ public:
         adjust the time to this $(LREF SysTime)'s time zone before returning.
 
         Params:
-            timezone = The $(LREF2 .TimeZone, TimeZone) to set this $(LREF SysTime)'s time zone to.
+            timezone = The $(LREF TimeZone) to set this $(LREF SysTime)'s time zone to.
       +/
     @property void timezone(immutable TimeZone timezone) @safe pure nothrow
     {
@@ -18469,7 +18468,7 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"days"(3)) ==
 
     /++
         Params:
-            rhs = The $(LREF2 .Interval, Interval) to assign to this one.
+            rhs = The $(LREF Interval) to assign to this one.
       +/
     ref Interval opAssign(const ref Interval rhs) pure nothrow
     {
@@ -18481,7 +18480,7 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"days"(3)) ==
 
     /++
         Params:
-            rhs = The $(LREF2 .Interval, Interval) to assign to this one.
+            rhs = The $(LREF Interval) to assign to this one.
       +/
     ref Interval opAssign(Interval rhs) pure nothrow
     {
@@ -26482,14 +26481,14 @@ unittest
 
 
 /++
-    A range over an $(LREF2 .Interval, Interval).
+    A range over an $(LREF Interval).
 
-    $(D IntervalRange) is only ever constructed by $(LREF2 .Interval, Interval). However, when
+    $(D IntervalRange) is only ever constructed by $(LREF Interval). However, when
     it is constructed, it is given a function, $(D func), which is used to
     generate the time points which are iterated over. $(D func) takes a time
     point and returns a time point of the same type. For instance,
     to iterate over all of the days in
-    the interval $(D Interval!Date), pass a function to $(LREF2 .Interval, Interval)'s $(D fwdRange)
+    the interval $(D Interval!Date), pass a function to $(LREF Interval)'s $(D fwdRange)
     where that function took a $(LREF Date) and returned a $(LREF Date) which was one
     day later. That function would then be used by $(D IntervalRange)'s
     $(D popFront) to iterate over the $(LREF Date)s in the interval.
@@ -26516,10 +26515,10 @@ unittest
     it and its $(D end) is excluded from it, if $(D dir == Direction.bwd), then
     $(D begin) is treated as excluded and $(D end) is treated as included. This
     allows for the same behavior in both directions. This works because none of
-    $(LREF2 .Interval, Interval)'s functions which care about whether $(D begin) or $(D end) is
+    $(LREF Interval)'s functions which care about whether $(D begin) or $(D end) is
     included or excluded are ever called by $(D IntervalRange). $(D interval)
     returns a normal interval, regardless of whether $(D dir == Direction.fwd)
-    or if $(D dir == Direction.bwd), so any $(LREF2 .Interval, Interval) functions which are
+    or if $(D dir == Direction.bwd), so any $(LREF Interval) functions which are
     called on it which care about whether $(D begin) or $(D end) are included or
     excluded will treat $(D begin) as included and $(D end) as excluded.
   +/
@@ -27625,7 +27624,7 @@ public:
 
     /++
         The name of the time zone per the TZ Database. This is the name used to
-        get a $(LREF2 .TimeZone, TimeZone) by name with $(D TimeZone.getTimeZone).
+        get a $(LREF TimeZone) by name with $(D TimeZone.getTimeZone).
 
         See_Also:
             $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
@@ -27730,7 +27729,7 @@ public:
               too often for us to compile the conversions into Phobos and have
               them be properly up-to-date.)
 
-        Returns a $(LREF2 .TimeZone, TimeZone) with the give name per the TZ Database.
+        Returns a $(LREF TimeZone) with the give name per the TZ Database.
 
         This returns a $(LREF PosixTimeZone) on Posix systems and a
         $(LREF WindowsTimeZone) on Windows systems. For
@@ -28213,7 +28212,7 @@ public:
     {
         /++
             The name of the time zone per the TZ Database. This is the name used to
-            get a $(LREF2 .TimeZone, TimeZone) by name with $(D TimeZone.getTimeZone).
+            get a $(LREF TimeZone) by name with $(D TimeZone.getTimeZone).
 
             Note that this always returns the empty string. This is because time
             zones cannot be uniquely identified by the attributes given by the
@@ -28733,7 +28732,7 @@ private:
 
 
 /++
-    A $(LREF2 .TimeZone, TimeZone) which represents UTC.
+    A $(LREF TimeZone) which represents UTC.
   +/
 final class UTC : TimeZone
 {
@@ -29576,7 +29575,7 @@ public:
 
 
     /++
-        Returns a $(LREF2 .TimeZone, TimeZone) with the give name per the TZ Database. The time
+        Returns a $(LREF TimeZone) with the give name per the TZ Database. The time
         zone information is fetched from the TZ Database time zone files in the
         given directory.
 
@@ -30420,7 +30419,7 @@ version(StdDdoc)
 
 
         /++
-            Returns a $(LREF2 .TimeZone, TimeZone) with the given name per the Windows time
+            Returns a $(LREF TimeZone) with the given name per the Windows time
             zone names. The time zone information is fetched from the Windows
             registry.
 

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -9,8 +9,8 @@
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright),
- *                        Thomas K$(UUML)hne, Frits van Bommel
- * Source:    $(PHOBOSSRC std/_demangle.d)
+ *                        Thomas Kühne, Frits van Bommel
+ * Source:    $(PHOBOSSRC std/demangle.d)
  */
 /*
  *          Copyright Digital Mars 2000 - 2009.

--- a/std/exception.d
+++ b/std/exception.d
@@ -764,13 +764,13 @@ unittest
     returned. $(D E) can be $(D void).
 
     If an exception is thrown but it has an empty message, then
-    $(D emptyExceptionMsg) is returned.
+    $(LREF emptyExceptionMsg) is returned.
 
-    Note that while $(D collectExceptionMsg) $(I can) be used to collect any
-    $(D Throwable) and not just $(D Exception)s, it is generally ill-advised to
-    catch anything that is neither an $(D Exception) nor a type derived from
-    $(D Exception). So, do not use $(D collectExceptionMsg) to collect
-    non-$(D Exception)s unless you're sure that that's what you really want to
+    Note that while $(LREF collectExceptionMsg) $(I can) be used to collect any
+    $(LREF Throwable) and not just $(LREF Exception)s, it is generally ill-advised to
+    catch anything that is neither an $(LREF Exception) nor a type derived from
+    $(LREF Exception). So, do not use $(LREF collectExceptionMsg) to collect
+    non-$(LREF Exception)s unless you're sure that that's what you really want to
     do.
 
     Params:
@@ -803,7 +803,7 @@ unittest
 }
 
 /++
-    Value that collectExceptionMsg returns when it catches an exception
+    Value that $(LREF collectExceptionMsg) returns when it catches an exception
     with an empty exception message.
  +/
 enum emptyExceptionMsg = "<Empty Exception Message>";

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.affix_allocator;
 
 /**

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.allocator_list;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.bitmapped_block;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.bucketizer;
 
 /**

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.fallback_allocator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.free_list;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -36,7 +36,7 @@ struct FreeList(ParentAllocator,
     static assert(maxSize >= (void*).sizeof,
         "Maximum size must accommodate a pointer.");
 
-    private enum unchecked = minSize == 0 && maxSize == unbounded;
+    privat enum unchecked = minSize == 0 && maxSize == unbounded;
 
     private enum hasTolerance = !unchecked && (minSize != maxSize
         || maxSize == chooseAtRuntime);

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.free_tree;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.kernighan_ritchie;
 import std.experimental.allocator.building_blocks.null_allocator;
 

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.null_allocator;
 
 /*

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -239,84 +239,84 @@ $(TABLE_ROWS $(CLASS allocator-table)
 * + Allocator
   + Description
 
-* - [std.experimental.allocator.building_blocks.null_allocator.NullAllocator|NullAllocator]
+* - [NullAllocator]
   - Very good at doing absolutely nothing. A good starting point for defining
     other allocators or for studying the API.
 
-* - $(TDC3 GCAllocator, gc_allocator)
+* - [GCAllocator]
   - The system-provided garbage-collector allocator.  This should be the default
     fallback allocator tapping into system memory. It offers manual $(D free)
     and dutifully collects litter.
 
-* - $(TDC3 Mallocator, mallocator)
+* - [Mallocator]
   - The C heap _allocator, a.k.a. $(D malloc)/$(D realloc)/$(D free). Use
     sparingly and only for code that is unlikely to leak.
 
-* - $(TDC3 AlignedMallocator, mallocator)
+* - [AlignedMallocator]
   - Interface to OS-specific allocators that support specifying alignment:
     [http://man7.org/linux/man-pages/man3/posix_memalign.3.html|posix_memalign] on Posix and
     [http://msdn.microsoft.com/en-us/library/fs9stz4e(v=vs.80).aspx|__aligned_xxx] on Windows.
 
-* - [std.experimental.allocator.building_blocks.affix_allocator.AffixAllocator|AffixAllocator]
+* - [AffixAllocator]
   - Allocator that allows and manages allocating extra prefix and/or a suffix
     bytes for each block allocated.
 
-* - [std.experimental.allocator.building_blocks.bitmapped_block.BitmappedBlock|BitmappedBlock]
+* - [BitmappedBlock]
   - Organizes one contiguous chunk of memory in equal-size blocks and tracks
     allocation status at the cost of one bit per block.
 
-* - [std.experimental.allocator.building_blocks.fallback_allocator.FallbackAllocator|FallbackAllocator]
+* - [FallbackAllocator]
   - Allocator that combines two other allocators - primary and fallback.
     Allocation requests are first tried with primary, and upon failure are
     passed to the fallback. Useful for small and fast allocators fronting
     general-purpose ones.
 
-* - [std.experimental.allocator.building_blocks.FreeList, free_list]
+* - [FreeList]
   - Allocator that implements a [http://wikipedia.org/wiki/Free_list|free list]
     on top of any other allocator. The preferred size, tolerance, and maximum
     elements are configurable at compile- and run time.
 
-* - [std.experimental.allocator.building_blocks.SharedFreeList, free_list]
+* - [SharedFreeList]
   - Same features as $(D FreeList), but packaged as a $(D shared) structure that
     is accessible to several threads.
 
-* - [std.experimental.allocator.building_blocks.FreeTree, free_tree]
+* - [FreeTree]
   - Allocator similar to $(D FreeList) that uses a binary search tree to
     adaptively store not one, but many free lists.
 
-* - [std.experimental.allocator.building_blocks.Region, region]
+* - [Region]
   - Region allocator organizes a chunk of memory as a simple
     bump-the-pointer allocator.
 
-* - [std.experimental.allocator.building_blocks.InSituRegion, region]
+* - [InSituRegion]
   - Region holding its own allocation, most often on the stack. Has
     statically-determined size.
 
-* - [std.experimental.allocator.building_blocks.SbrkRegion, region]
+* - [SbrkRegion]
   - Region using $(D $(LUCKY sbrk)) for allocating memory.
 
-* - $(TDC3 MmapAllocator, mmap_allocator)
+* - [MmapAllocator]
   - Allocator using $(D $(LUCKY mmap)) directly.
 
-* - [std.experimental.allocator.building_blocks.StatsCollector, stats_collector]
+* - [StatsCollector]
   - Collect statistics about any other allocator.
 
-* - [std.experimental.allocator.building_blocks.Quantizer, quantizer]
+* - [Quantizer]
   - Allocates in coarse-grained quantas, thus improving performance of
     reallocations by often reallocating in place. The drawback is higher
     memory consumption because of allocated and unused memory.
 
-* - [std.experimental.allocator.building_blocks.AllocatorList, allocator_list]
+* - [AllocatorList]
   - Given an allocator factory, lazily creates as many allocators as needed
     to satisfy allocation requests. The allocators are stored in a linked list.
     Requests for allocation are satisfied by searching the list in a linear
     manner.
 
-* - [std.experimental.allocator.building_blocks.Segregator, segregator]
+* - [Segregator]
   - Segregates allocation requests by size and dispatches them to distinct
     allocators.
 
-* - [std.experimental.allocator.building_blocks.Bucketizer, bucketizer]
+* - [Bucketizer]
   - Divides allocation sizes in discrete buckets and uses an array of
     allocators, one per bucket, to satisfy requests.
 

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -1,4 +1,7 @@
 /**
+Building blocks for assembling your own allocator.
+
+
 $(H2 Assembling Your Own Allocator)
 
 In addition to defining the interfaces above, this package also implements
@@ -7,7 +10,7 @@ exclusively in $(D void[]) and have no notion of what type the memory allocated
 would be destined for. They are $(I composable) because the included allocators
 are building blocks that can be assembled in complex nontrivial allocators.
 
-$(P Unlike the allocators for the C and C++ programming languages, which manage
+Unlike the allocators for the C and C++ programming languages, which manage
 the allocated size internally, these allocators require that the client
 maintains (or knows $(I a priori)) the allocation size for each piece of memory
 allocated. Put simply, the client must pass the allocated size upon
@@ -17,9 +20,9 @@ needs knowledge of the allocated size in order to avoid buffer overruns. (See
 more discussion in a $(WEB open-
 std.org/JTC1/SC22/WG21/docs/papers/2013/n3536.html, proposal) for sized
 deallocation in C++.) For this reason, allocators herein traffic in $(D void[])
-as opposed to $(D void*).)
+as opposed to $(D void*).
 
-$(P In order to be usable as an _allocator, a type should implement the
+In order to be usable as an allocator, a type should implement the
 following methods with their respective semantics. Only $(D alignment) and  $(D
 allocate) are required. If any of the other methods is missing, the _allocator
 is assumed to not have that capability (for example some allocators do not offer
@@ -28,109 +31,137 @@ unsupported methods to always fail. For example, an allocator that lacks the
 capability to implement `alignedAllocate` should not define it at all (as
 opposed to defining it to always return `null` or throw an exception). The
 missing implementation statically informs other components about the
-allocator's capabilities and allows them to make design decisions accordingly.)
+allocator's capabilities and allows them to make design decisions accordingly.
 
-$(BOOKTABLE ,
-$(TR $(TH Method name) $(TH Semantics))
+$(TABLE_ROWS $(CLASS allocator-table)
 
-$(TR $(TDC uint alignment;, $(POST $(RES) > 0)) $(TD Returns the minimum
-alignment of all data returned by the allocator. An allocator may implement $(D
-alignment) as a statically-known $(D enum) value only. Applications that need
-dynamically-chosen alignment values should use the $(D alignedAllocate) and $(D
-alignedReallocate) APIs.))
+* + Method name
+  + Semantics
 
-$(TR $(TDC size_t goodAllocSize(size_t n);, $(POST $(RES) >= n)) $(TD Allocators
-customarily allocate memory in discretely-sized chunks. Therefore, a request for
-$(D n) bytes may result in a larger allocation. The extra memory allocated goes
-unused and adds to the so-called $(WEB goo.gl/YoKffF,internal fragmentation).
-The function $(D goodAllocSize(n)) returns the actual number of bytes that would
-be allocated upon a request for $(D n) bytes. This module defines a default
-implementation that returns $(D n) rounded up to a multiple of the allocator's
-alignment.))
+* - $(D uint alignment;)
+    $(POST $(RES) > 0)
+    
+  - Returns the minimum alignment of all data returned by the allocator.
+    An allocator may implement $(D alignment) as a statically-known $(D enum)
+    value only. Applications that need dynamically-chosen alignment values
+    should use the $(D alignedAllocate) and $(D alignedReallocate) APIs.
 
-$(TR $(TDC void[] allocate(size_t s);, $(POST $(RES) is null || $(RES).length ==
-s)) $(TD If $(D s == 0), the call may return any empty slice (including $(D
-null)). Otherwise, the call allocates $(D s) bytes of memory and returns the
-allocated block, or $(D null) if the request could not be satisfied.))
+* - $(D size_t goodAllocSize(size_t n);)
+    $(POST $(RES) >= n)
+     
+  - Allocators customarily allocate memory in discretely-sized chunks.
+    Therefore, a request for $(D n) bytes may result in a larger allocation.
+    The extra memory allocated goes unused and adds to the so-called
+    [https://en.wikipedia.org/wiki/Fragmentation_%28computing%29#Internal_fragmentation|internal fragmentation].
+    The function $(D goodAllocSize(n)) returns the actual number of bytes that
+    would be allocated upon a request for $(D n) bytes. This module defines a
+    default implementation that returns $(D n) rounded up to a multiple of the
+    allocator's alignment.
 
-$(TR $(TDC void[] alignedAllocate(size_t s, uint a);, $(POST $(RES) is null ||
-$(RES).length == s)) $(TD Similar to `allocate`, with the additional
-guarantee that the memory returned is aligned to at least `a` bytes. `a`
-must be a power of 2.))
+* - $(D void[] allocate(size_t s);)
+    $(POST $(RES) is null || $(RES).length == s)
+    
+  - If $(D s == 0), the call may return any empty slice (including $(D null)).
+    Otherwise, the call allocates $(D s) bytes of memory and returns the
+    allocated block, or $(D null) if the request could not be satisfied.
 
-$(TR $(TDC void[] allocateAll();) $(TD Offers all of allocator's memory to the
-caller, so it's usually defined by fixed-size allocators. If the allocator is
-currently NOT managing any memory, then $(D allocateAll()) shall allocate and
-return all memory available to the allocator, and subsequent calls to all
-allocation primitives should not succeed (e..g $(D allocate) shall return $(D
-null) etc). Otherwise, $(D allocateAll) only works on a best-effort basis, and
-the allocator is allowed to return $(D null) even if does have available memory.
-Memory allocated with $(D allocateAll) is not otherwise special (e.g. can be
-reallocated or deallocated with the usual primitives, if defined).))
+* - $(D void[] alignedAllocate(size_t s, uint a);)
+    $(POST $(RES) is null || $(RES).length == s)
 
-$(TR $(TDC bool expand(ref void[] b, size_t delta);, $(POST !$(RES) || b.length
-== $(I old)(b).length + delta)) $(TD Expands $(D b) by $(D delta) bytes. If $(D
-delta == 0), succeeds without changing $(D b). If $(D b is null), the call
-evaluates $(D b = allocate(delta)) and returns $(D b !is null). Otherwise, $(D
-b) must be a buffer previously allocated with the same allocator. If expansion
-was successful, $(D expand) changes $(D b)'s length to $(D b.length + delta) and
-returns $(D true). Upon failure, the call effects no change upon the allocator
-object, leaves $(D b) unchanged, and returns $(D false).))
+  - Similar to $(D allocate), with the additional guarantee that the memory returned
+    is aligned to at least `a` bytes. `a` must be a power of 2.
 
-$(TR $(TDC bool reallocate(ref void[] b, size_t s);, $(POST !$(RES) || b.length
-== s)) $(TD Reallocates $(D b) to size $(D s), possibly moving memory around.
-$(D b) must be $(D null) or a buffer allocated with the same allocator. If
-reallocation was successful, $(D reallocate) changes $(D b) appropriately and
-returns $(D true). Upon failure, the call effects no change upon the allocator
-object, leaves $(D b) unchanged, and returns $(D false). An allocator should
-implement $(D reallocate) if it can derive some advantage from doing so;
-otherwise, this module defines a $(D reallocate) free function implemented in
-terms of $(D expand), $(D allocate), and $(D deallocate).))
+* - $(D void[] allocateAll();)
 
-$(TR $(TDC bool alignedReallocate(ref void[] b,$(BR) size_t s, uint a);, $(POST
-!$(RES) || b.length == s)) $(TD Similar to $(D reallocate), but guarantees the
-reallocated memory is aligned at $(D a) bytes. The buffer must have been
-originated with a call to $(D alignedAllocate). $(D a) must be a power of 2
-greater than $(D (void*).sizeof). An allocator should implement $(D
-alignedReallocate) if it can derive some advantage from doing so; otherwise,
-this module defines a $(D alignedReallocate) free function implemented in terms
-of $(D expand), $(D alignedAllocate), and $(D deallocate).))
+  - Offers all of allocator's memory to the caller, so it's usually defined by
+    fixed-size allocators. If the allocator is currently NOT managing any memory,
+    then $(D allocateAll()) shall allocate and return all memory available to the
+    allocator, and subsequent calls to all allocation primitives should not
+    succeed (e..g $(D allocate) shall return $(D null) etc). Otherwise,
+    $(D allocateAll) only works on a best-effort basis, and the allocator is
+    allowed to return $(D null) even if does have available memory.  Memory
+    allocated with $(D allocateAll) is not otherwise special (e.g. can be
+    reallocated or deallocated with the usual primitives, if defined).
 
-$(TR $(TDC Ternary owns(void[] b);) $(TD Returns `Ternary.yes` if `b` has been
-allocated with this allocator. An allocator should define this method only if it
-can decide on ownership precisely and fast (in constant time, logarithmic time,
-or linear time with a low multiplication factor). Traditional allocators such as
-the C heap do not define such functionality. If $(D b is null), the allocator
-shall return `Ternary.no`, i.e. no allocator owns the `null` slice.))
+* - $(D bool expand(ref void[] b, size_t delta);)
+    $(POST !$(RES) || b.length == $(I old)(b).length + delta)
+    
+  - Expands $(D b) by $(D delta) bytes. If $(D delta == 0), succeeds without
+    changing $(D b). If $(D b is null), the call evaluates
+    $(D b = allocate(delta)) and returns $(D b !is null). Otherwise, $(D b)
+    must be a buffer previously allocated with the same allocator. If expansion
+    was successful, $(D expand) changes $(D b)'s length to $(D b.length + delta)
+    and returns $(D true). Upon failure, the call effects no change upon the
+    allocator object, leaves $(D b) unchanged, and returns $(D false).
 
-$(TR $(TDC void[] resolveInternalPointer(void* p);) $(TD If $(D p) is a pointer
-somewhere inside a block allocated with this allocator, returns a pointer to the
-beginning of the allocated block. Otherwise, returns $(D null). If the pointer
-points immediately after an allocated block, the result is implementation
-defined.))
+* - $(D bool reallocate(ref void[] b, size_t s);)
+    $(POST !$(RES) || b.length == s)
+    
+  - Reallocates $(D b) to size $(D s), possibly moving memory around.
+    $(D b) must be $(D null) or a buffer allocated with the same allocator. If
+    reallocation was successful, $(D reallocate) changes $(D b) appropriately and
+    returns $(D true). Upon failure, the call effects no change upon the allocator
+    object, leaves $(D b) unchanged, and returns $(D false). An allocator should
+    implement $(D reallocate) if it can derive some advantage from doing so;
+    otherwise, this module defines a $(D reallocate) free function implemented in
+    terms of $(D expand), $(D allocate), and $(D deallocate).
 
-$(TR $(TDC bool deallocate(void[] b);) $(TD If $(D b is null), does
-nothing and returns `true`. Otherwise, deallocates memory previously allocated
-with this allocator and returns `true` if successful, `false` otherwise. An
-implementation that would not support deallocation (i.e. would always return
-`false` should not define this primitive at all.)))
+* - $(D bool alignedReallocate(ref void[] b, size_t s, uint a);)
+    $(POST !$(RES) || b.length == s)
+    
+  - Similar to $(D reallocate), but guarantees the reallocated memory is aligned
+    at $(D a) bytes. The buffer must have been originated with a call to
+    $(D alignedAllocate). $(D a) must be a power of 2 greater than
+    $(D (void*).sizeof). An allocator should implement $(D alignedReallocate) if
+    it can derive some advantage from doing so; otherwise, this module defines a
+    $(D alignedReallocate) free function implemented in terms of $(D expand),
+    $(D alignedAllocate), and $(D deallocate).
 
-$(TR $(TDC bool deallocateAll();, $(POST empty)) $(TD Deallocates all memory
-allocated with this allocator. If an allocator implements this method, it must
-specify whether its destructor calls it, too.))
+* - $(D Ternary owns(void[] b);)
 
-$(TR $(TDC Ternary empty();) $(TD Returns `Ternary.yes` if and only if the
-allocator holds no memory (i.e. no allocation has occurred, or all allocations
-have been deallocated).))
+  - Returns `Ternary.yes` if `b` has been allocated with this allocator. An
+    allocator should define this method only if it can decide on ownership
+    precisely and fast (in constant time, logarithmic time, or linear time
+    with a low multiplication factor). Traditional allocators such as the C
+    heap do not define such functionality. If $(D b is null), the allocator
+    shall return `Ternary.no`, i.e. no allocator owns the `null` slice.
 
-$(TR $(TDC static Allocator instance;, $(POST instance $(I is a valid)
-Allocator $(I object))) $(TD Some allocators are $(I monostate), i.e. have only
-an instance and hold only global state. (Notable examples are C's own
-`malloc`-based allocator and D's garbage-collected heap.) Such allocators must
-define a static $(D instance) instance that serves as the symbolic placeholder
-for the global instance of the allocator. An allocator should not hold state
-and define `instance` simultaneously. Depending on whether the allocator is
-thread-safe or not, this instance may be $(D shared).))
+* - $(D void[] resolveInternalPointer(void* p);)
+
+  - If $(D p) is a pointer somewhere inside a block allocated with this allocator,
+    returns a pointer to the beginning of the allocated block. Otherwise, returns
+    $(D null). If the pointer points immediately after an allocated block, the
+    result is implementation defined.
+
+* - $(D bool deallocate(void[] b);)
+
+   - If $(D b is null), does nothing and returns $(D true). Otherwise, deallocates
+     memory previously allocated with this allocator and returns $(D true) if
+     successful, $(D false) otherwise. An implementation that would not support
+     deallocation (i.e. would always return $(D false) should not define this
+     primitive at all.)
+
+* - $(D bool deallocateAll();)
+    $(POST empty)
+    
+  - Deallocates all memory allocated with this allocator. If an allocator
+    implements this method, it must specify whether its destructor calls it, too.
+
+* - $(D Ternary empty();)
+
+  - Returns $(D Ternary.yes) if and only if the allocator holds no memory
+    (i.e. no allocation has occurred, or all allocations have been deallocated).
+
+* - $(D static Allocator instance;)
+    $(POST instance $(I is a valid) Allocator $(I object))
+    
+  - Some allocators are $(I monostate), i.e. have only an instance and hold only
+    global state. (Notable examples are C's own $(D malloc)-based allocator and D's
+    garbage-collected heap.) Such allocators must define a static $(D instance)
+    instance that serves as the symbolic placeholder for the global instance of
+    the allocator. An allocator should not hold state and define `instance`
+    simultaneously. Depending on whether the allocator is thread-safe or not,
+    this instance may be $(D shared).
 )
 
 $(H2 Sample Assembly)
@@ -195,88 +226,105 @@ or with the same allocator object after casting it to $(D shared)) is illegal.
 
 $(H2 Building Blocks)
 
-$(P The table below gives a synopsis of predefined allocator building blocks,
+The table below gives a synopsis of predefined allocator building blocks,
 with their respective modules. Either `import` the needed modules individually,
 or `import` `std.experimental.building_blocks`, which imports them all
 `public`ly. The building blocks can be assembled in unbounded ways and also
 combined with your own. For a collection of typical and useful preassembled
 allocators and for inspiration in defining more such assemblies, refer to
-$(LINK2 std_experimental_allocator_showcase.html,
-`std.experimental.allocator.building_blocks.showcase`).)
+[std.experimental.allocator.showcase].
 
-$(BOOKTABLE,
-$(TR $(TH Allocator$(BR)) $(TH Description))
+$(TABLE_ROWS $(CLASS allocator-table)
 
-$(TR $(TDC2 NullAllocator, null_allocator) $(TD Very good at doing absolutely nothing. A good
-starting point for defining other allocators or for studying the API.))
+* + Allocator
+  + Description
 
-$(TR $(TDC3 GCAllocator, gc_allocator) $(TD The system-provided garbage-collector allocator.
-This should be the default fallback allocator tapping into system memory. It
-offers manual $(D free) and dutifully collects litter.))
+* - [std.experimental.allocator.building_blocks.null_allocator.NullAllocator|NullAllocator]
+  - Very good at doing absolutely nothing. A good starting point for defining
+    other allocators or for studying the API.
 
-$(TR $(TDC3 Mallocator, mallocator) $(TD The C heap _allocator, a.k.a. $(D
-malloc)/$(D realloc)/$(D free). Use sparingly and only for code that is unlikely
-to leak.))
+* - $(TDC3 GCAllocator, gc_allocator)
+  - The system-provided garbage-collector allocator.  This should be the default
+    fallback allocator tapping into system memory. It offers manual $(D free)
+    and dutifully collects litter.
 
-$(TR $(TDC3 AlignedMallocator, mallocator) $(TD Interface to OS-specific _allocators that
-support specifying alignment:
-$(WEB man7.org/linux/man-pages/man3/posix_memalign.3.html, $(D posix_memalign))
-on Posix and $(WEB msdn.microsoft.com/en-us/library/fs9stz4e(v=vs.80).aspx,
-$(D __aligned_xxx)) on Windows.))
+* - $(TDC3 Mallocator, mallocator)
+  - The C heap _allocator, a.k.a. $(D malloc)/$(D realloc)/$(D free). Use
+    sparingly and only for code that is unlikely to leak.
 
-$(TR $(TDC2 AffixAllocator, affix_allocator) $(TD Allocator that allows and manages allocating
-extra prefix and/or a suffix bytes for each block allocated.))
+* - $(TDC3 AlignedMallocator, mallocator)
+  - Interface to OS-specific allocators that support specifying alignment:
+    [http://man7.org/linux/man-pages/man3/posix_memalign.3.html|posix_memalign] on Posix and
+    [http://msdn.microsoft.com/en-us/library/fs9stz4e(v=vs.80).aspx|__aligned_xxx] on Windows.
 
-$(TR $(TDC2 BitmappedBlock, bitmapped_block) $(TD Organizes one contiguous chunk of memory in
-equal-size blocks and tracks allocation status at the cost of one bit per
-block.))
+* - [std.experimental.allocator.building_blocks.affix_allocator.AffixAllocator|AffixAllocator]
+  - Allocator that allows and manages allocating extra prefix and/or a suffix
+    bytes for each block allocated.
 
-$(TR $(TDC2 FallbackAllocator, fallback_allocator) $(TD Allocator that combines two other allocators
- - primary and fallback. Allocation requests are first tried with primary, and
- upon failure are passed to the fallback. Useful for small and fast allocators
- fronting general-purpose ones.))
+* - [std.experimental.allocator.building_blocks.bitmapped_block.BitmappedBlock|BitmappedBlock]
+  - Organizes one contiguous chunk of memory in equal-size blocks and tracks
+    allocation status at the cost of one bit per block.
 
-$(TR $(TDC2 FreeList, free_list) $(TD Allocator that implements a $(WEB
-wikipedia.org/wiki/Free_list, free list) on top of any other allocator. The
-preferred size, tolerance, and maximum elements are configurable at compile- and
-run time.))
+* - [std.experimental.allocator.building_blocks.fallback_allocator.FallbackAllocator|FallbackAllocator]
+  - Allocator that combines two other allocators - primary and fallback.
+    Allocation requests are first tried with primary, and upon failure are
+    passed to the fallback. Useful for small and fast allocators fronting
+    general-purpose ones.
 
-$(TR $(TDC2 SharedFreeList, free_list) $(TD Same features as $(D FreeList), but packaged as
-a $(D shared) structure that is accessible to several threads.))
+* - [std.experimental.allocator.building_blocks.FreeList, free_list]
+  - Allocator that implements a [http://wikipedia.org/wiki/Free_list|free list]
+    on top of any other allocator. The preferred size, tolerance, and maximum
+    elements are configurable at compile- and run time.
 
-$(TR $(TDC2 FreeTree, free_tree) $(TD Allocator similar to $(D FreeList) that uses a
-binary search tree to adaptively store not one, but many free lists.))
+* - [std.experimental.allocator.building_blocks.SharedFreeList, free_list]
+  - Same features as $(D FreeList), but packaged as a $(D shared) structure that
+    is accessible to several threads.
 
-$(TR $(TDC2 Region, region) $(TD Region allocator organizes a chunk of memory as a
-simple bump-the-pointer allocator.))
+* - [std.experimental.allocator.building_blocks.FreeTree, free_tree]
+  - Allocator similar to $(D FreeList) that uses a binary search tree to
+    adaptively store not one, but many free lists.
 
-$(TR $(TDC2 InSituRegion, region) $(TD Region holding its own allocation, most often on
-the stack. Has statically-determined size.))
+* - [std.experimental.allocator.building_blocks.Region, region]
+  - Region allocator organizes a chunk of memory as a simple
+    bump-the-pointer allocator.
 
-$(TR $(TDC2 SbrkRegion, region) $(TD Region using $(D $(LUCKY sbrk)) for allocating
-memory.))
+* - [std.experimental.allocator.building_blocks.InSituRegion, region]
+  - Region holding its own allocation, most often on the stack. Has
+    statically-determined size.
 
-$(TR $(TDC3 MmapAllocator, mmap_allocator) $(TD Allocator using $(D $(LUCKY mmap)) directly.))
+* - [std.experimental.allocator.building_blocks.SbrkRegion, region]
+  - Region using $(D $(LUCKY sbrk)) for allocating memory.
 
-$(TR $(TDC2 StatsCollector, stats_collector) $(TD Collect statistics about any other
-allocator.))
+* - $(TDC3 MmapAllocator, mmap_allocator)
+  - Allocator using $(D $(LUCKY mmap)) directly.
 
-$(TR $(TDC2 Quantizer, quantizer) $(TD Allocates in coarse-grained quantas, thus
-improving performance of reallocations by often reallocating in place. The drawback is higher memory consumption because of allocated and unused memory.))
+* - [std.experimental.allocator.building_blocks.StatsCollector, stats_collector]
+  - Collect statistics about any other allocator.
 
-$(TR $(TDC2 AllocatorList, allocator_list) $(TD Given an allocator factory, lazily creates as
-many allocators as needed to satisfy allocation requests. The allocators are
-stored in a linked list. Requests for allocation are satisfied by searching the
-list in a linear manner.))
+* - [std.experimental.allocator.building_blocks.Quantizer, quantizer]
+  - Allocates in coarse-grained quantas, thus improving performance of
+    reallocations by often reallocating in place. The drawback is higher
+    memory consumption because of allocated and unused memory.
 
-$(TR $(TDC2 Segregator, segregator) $(TD Segregates allocation requests by size
-and dispatches them to distinct allocators.))
+* - [std.experimental.allocator.building_blocks.AllocatorList, allocator_list]
+  - Given an allocator factory, lazily creates as many allocators as needed
+    to satisfy allocation requests. The allocators are stored in a linked list.
+    Requests for allocation are satisfied by searching the list in a linear
+    manner.
 
-$(TR $(TDC2 Bucketizer, bucketizer) $(TD Divides allocation sizes in discrete buckets and
-uses an array of allocators, one per bucket, to satisfy requests.))
+* - [std.experimental.allocator.building_blocks.Segregator, segregator]
+  - Segregates allocation requests by size and dispatches them to distinct
+    allocators.
 
-$(COMMENT $(TR $(TDC2 InternalPointersTree) $(TD Adds support for resolving internal
-pointers on top of another allocator.)))
+* - [std.experimental.allocator.building_blocks.Bucketizer, bucketizer]
+  - Divides allocation sizes in discrete buckets and uses an array of
+    allocators, one per bucket, to satisfy requests.
+
+	$(COMMENT
+		* [std.experimental.allocator.building_blocks.InternalPointersTree]
+		  - Adds support for resolving internal
+		pointers on top of another allocator.
+	)
 )
 
 Macros:

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.quantizer;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.region;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.scoped_allocator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.segregator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.gc_allocator;
 import std.experimental.allocator.common;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.mallocator;
 import std.experimental.allocator.common;
 

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.mmap_allocator;
 
 // MmapAllocator

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.core;
 
 import std.array;

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.filelogger;
 
 import std.stdio;

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.multilogger;
 
 import std.experimental.logger.core;

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.nulllogger;
 
 import std.experimental.logger.core;

--- a/std/experimental/logger/package.d
+++ b/std/experimental/logger/package.d
@@ -2,7 +2,7 @@
 Implements logging facilities.
 
 Copyright: Copyright Robert "burner" Schadek 2013 --
-License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+License: [http://www.boost.org/LICENSE_1_0.txt|Boost License 1.0].
 Authors: $(WEB http://www.svs.informatik.uni-oldenburg.de/60865.html, Robert burner Schadek)
 
 $(H3 Basic Logging)

--- a/std/file.d
+++ b/std/file.d
@@ -4,17 +4,18 @@
 Utilities for manipulating files and scanning directories. Functions
 in this module handle files as a unit, e.g., read or write one _file
 at a time. For opening files and manipulating them via handles refer
-to module $(LINK2 std_stdio.html,$(D std.stdio)).
+to module $(MREF std,stdio). For functions to inspect a path string, see
+$(MREF std,path).
 
 Macros:
 WIKI = Phobos/StdFile
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
-introduction to working with files in D, module
-$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them
-via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating
-path strings.
+See_Also:
+    The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an introduction to working with files in D
+    module $(MREF std,stdio) for opening files and manipulating them via handles
+    and module $(MREF std,path) for manipulating path strings.
+
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),
@@ -1474,7 +1475,7 @@ private bool existsImpl(const(FSChar)* namez) @trusted nothrow @nogc
 
 
 /++
- Returns the attributes of the given file.
+ Returns the platform-specific attributes of the given file.
 
  Note that the file attributes on Windows and Posix systems are
  completely different. On Windows, they're what is returned by
@@ -1588,6 +1589,7 @@ uint getLinkAttributes(R)(R name)
     }
 }
 
+/// ditto
 uint getLinkAttributes(R)(auto ref R name)
     if (isConvertibleToString!R)
 {
@@ -1642,6 +1644,7 @@ void setAttributes(R)(R name, uint attributes)
     }
 }
 
+/// ditto
 void setAttributes(R)(auto ref R name, uint attributes)
     if (isConvertibleToString!R)
 {
@@ -1685,6 +1688,7 @@ assert("/usr/share/include".isDir);
     }
 }
 
+/// ditto
 @property bool isDir(R)(auto ref R name)
     if (isConvertibleToString!R)
 {
@@ -1831,6 +1835,7 @@ assert(!"/usr/share/include".isFile);
         return (getAttributes(name) & S_IFMT) == S_IFREG;
 }
 
+/// ditto
 @property bool isFile(R)(auto ref R name)
     if (isConvertibleToString!R)
 {
@@ -1965,6 +1970,7 @@ bool attrIsFile(uint attributes) @safe pure nothrow @nogc
         return (getLinkAttributes(name) & S_IFMT) == S_IFLNK;
 }
 
+/// ditto
 @property bool isSymlink(R)(auto ref R name)
     if (isConvertibleToString!R)
 {
@@ -2161,6 +2167,7 @@ void mkdir(R)(R pathname)
     }
 }
 
+/// ditto
 void mkdir(R)(auto ref R pathname)
     if (isConvertibleToString!R)
 {

--- a/std/format.d
+++ b/std/format.d
@@ -3,9 +3,9 @@
 /**
    This module implements the formatting functionality for strings and
    I/O. It's comparable to C99's $(D vsprintf()) and uses a similar
-   _format encoding scheme.
+   format encoding scheme.
 
-   For an introductory look at $(B std._format)'s capabilities and how to use
+   For an introductory look at $(B std.format)'s capabilities and how to use
    this module see the dedicated
    $(LINK2 http://wiki.dlang.org/Defining_custom_print_format_specifiers, DWiki article).
 
@@ -15,23 +15,23 @@ $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(LREF formattedRead))
-        $(TD Reads values according to the _format string from an InputRange.
+        $(TD Reads values according to the format string from an InputRange.
     ))
     $(TR $(TD $(LREF formattedWrite))
-        $(TD Formats its arguments according to the _format string and puts them
+        $(TD Formats its arguments according to the format string and puts them
         to an OutputRange.
     ))
 )
 
    Please see the documentation of function $(LREF formattedWrite) for a
-   description of the _format string.
+   description of the format string.
 
    Two functions have been added for convenience:
 
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(LREF _format))
+    $(TR $(TD $(LREF format))
         $(TD Returns a GC-allocated string with the formatting result.
     ))
     $(TR $(TD $(LREF sformat))
@@ -54,7 +54,7 @@ $(TR $(TH Function Name) $(TH Description)
    Authors: $(WEB walterbright.com, Walter Bright), $(WEB erdani.com,
    Andrei Alexandrescu), and Kenji Hara
 
-   Source: $(PHOBOSSRC std/_format.d)
+   Source: $(PHOBOSSRC std/format.d)
  */
 module std.format;
 
@@ -6419,7 +6419,7 @@ unittest
 /*****************************************************
  * Format arguments into a string.
  *
- * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
+ * Params: fmt  = Format string. For detailed specification, see $(XREF format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
 immutable(Char)[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)

--- a/std/format.d
+++ b/std/format.d
@@ -14,16 +14,16 @@
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF formattedRead)))
+    $(TR $(TD $(LREF formattedRead))
         $(TD Reads values according to the _format string from an InputRange.
     ))
-    $(TR $(TD $(D $(LREF formattedWrite)))
+    $(TR $(TD $(LREF formattedWrite))
         $(TD Formats its arguments according to the _format string and puts them
         to an OutputRange.
     ))
 )
 
-   Please see the documentation of function $(D $(LREF formattedWrite)) for a
+   Please see the documentation of function $(LREF formattedWrite) for a
    description of the _format string.
 
    Two functions have been added for convenience:
@@ -31,18 +31,18 @@ $(TR $(TH Function Name) $(TH Description)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF _format)))
+    $(TR $(TD $(LREF _format))
         $(TD Returns a GC-allocated string with the formatting result.
     ))
-    $(TR $(TD $(D $(LREF sformat)))
+    $(TR $(TD $(LREF sformat))
         $(TD Puts the formatting result into a preallocated array.
     ))
 )
 
-   These two functions are publicly imported by $(LINK2 std_string.html,
-   std.string) to be easily available.
+   These two functions are publicly imported by $(MREF std,string)
+   to be easily available.
 
-   The functions $(D $(LREF formatValue)) and $(D $(LREF unformatValue)) are
+   The functions $(LREF formatValue) and $(LREF unformatValue) are
    used for the plumbing.
 
    Macros: WIKI = Phobos/StdFormat
@@ -108,6 +108,7 @@ private alias enforceFmt = enforceEx!FormatException;
    to $(D fmt), and sends the resulting characters to $(D w). The
    encoding of the output is the same as $(D Char). The type $(D Writer)
    must satisfy $(D $(XREF_PACK range,primitives,isOutputRange)!(Writer, Char)).
+
 
    The variadic arguments are normally consumed in order. POSIX-style
    $(WEB opengroup.org/onlinepubs/009695399/functions/printf.html,

--- a/std/functional.d
+++ b/std/functional.d
@@ -957,8 +957,8 @@ unittest
 }
 
 /**
- * $(LUCKY Memoizes) a function so as to avoid repeated
- * computation.
+ * [https://en.wikipedia.org/wiki/Memoization|Memoizes] a function so as to
+ * avoid repeated computation.
  *
  * 
  * The memoization structure is a hash table keyed by a

--- a/std/functional.d
+++ b/std/functional.d
@@ -5,44 +5,43 @@ Functions that manipulate other functions.
 
 This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
-$(LINK2 std_algorithm.html, std.algorithm) or $(LINK2 std_range.html,
-std.range).
+$(MREF std,algorithm) or $(MREF std,range).
 
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF adjoin)))
+    $(TR $(TD $(LREF adjoin))
         $(TD Joins a couple of functions into one that executes the original
         functions independently and returns a tuple with all the results.
     ))
-    $(TR $(TD $(D $(LREF compose)), $(D $(LREF pipe)))
+    $(TR $(TD $(LREF compose), $(LREF pipe))
         $(TD Join a couple of functions into one that executes the original
         functions one after the other, using one function's result for the next
         function's argument.
     ))
-    $(TR $(TD $(D $(LREF forward)))
+    $(TR $(TD $(LREF forward))
         $(TD Forwards function arguments while saving ref-ness.
     ))
-    $(TR $(TD $(D $(LREF lessThan)), $(D $(LREF greaterThan)), $(D $(LREF equalTo)))
+    $(TR $(TD $(LREF lessThan), $(LREF greaterThan), $(LREF equalTo))
         $(TD Ready-made predicate functions to compare two values.
     ))
-    $(TR $(TD $(D $(LREF memoize)))
+    $(TR $(TD $(LREF memoize))
         $(TD Creates a function that caches its result for fast re-evaluation.
     ))
-    $(TR $(TD $(D $(LREF not)))
+    $(TR $(TD $(LREF not))
         $(TD Creates a function that negates another.
     ))
-    $(TR $(TD $(D $(LREF partial)))
+    $(TR $(TD $(LREF partial))
         $(TD Creates a function that binds the first argument of a given function
         to a given value.
     ))
-    $(TR $(TD $(D $(LREF reverseArgs)), $(D $(LREF binaryReverseArgs)))
+    $(TR $(TD $(LREF reverseArgs), $(LREF binaryReverseArgs))
         $(TD Predicate that reverses the order of its arguments.
     ))
-    $(TR $(TD $(D $(LREF toDelegate)))
+    $(TR $(TD $(LREF toDelegate))
         $(TD Converts a callable to a delegate.
     ))
-    $(TR $(TD $(D $(LREF unaryFun)), $(D $(LREF binaryFun)))
+    $(TR $(TD $(LREF unaryFun), $(LREF binaryFun))
         $(TD Create a unary or binary function from a string. Most often
         used when defining algorithms on ranges.
     ))
@@ -478,8 +477,8 @@ unittest //check user defined types
 }
 
 /**
-   Predicate that returns $(D_PARAM a < b).
-   Correctly compares signed and unsigned integers, ie. -1 < 2U.
+   Predicate that returns $(D a < b).
+   Correctly compares signed and unsigned integers, ie. $(D -1 < 2U).
 */
 alias lessThan = safeOp!"<";
 
@@ -499,8 +498,8 @@ pure @safe @nogc nothrow unittest
 }
 
 /**
-   Predicate that returns $(D_PARAM a > b).
-   Correctly compares signed and unsigned integers, ie. 2U > -1.
+   Predicate that returns $(D a > b).
+   Correctly compares signed and unsigned integers, ie. $(D 2U > -1).
 */
 alias greaterThan = safeOp!">";
 
@@ -520,8 +519,8 @@ unittest
 }
 
 /**
-   Predicate that returns $(D_PARAM a == b).
-   Correctly compares signed and unsigned integers, ie. !(-1 == ~0U).
+   Predicate that returns $(D a == b).
+   Correctly compares signed and unsigned integers, ie. $(D !(-1 == ~0U)).
 */
 alias equalTo = safeOp!"==";
 
@@ -654,7 +653,7 @@ unittest
 
 /**
 $(LINK2 http://en.wikipedia.org/wiki/Partial_application, Partially
-applies) $(D_PARAM fun) by tying its first argument to $(D_PARAM arg).
+applies) $(D fun) by tying its first argument to $(D arg).
  */
 template partial(alias fun, alias arg)
 {
@@ -959,7 +958,10 @@ unittest
 
 /**
  * $(LUCKY Memoizes) a function so as to avoid repeated
- * computation. The memoization structure is a hash table keyed by a
+ * computation.
+ *
+ * 
+ * The memoization structure is a hash table keyed by a
  * tuple of the function's arguments. There is a speed gain if the
  * function is repeatedly called with the same arguments and is more
  * expensive than a hash table lookup. For more information on memoization, refer to $(WEB docs.google.com/viewer?url=http%3A%2F%2Fhop.perl.plover.com%2Fbook%2Fpdf%2F03CachingAndMemoization.pdf, this book chapter).

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -55,6 +55,7 @@ static assert(is(typeof(new GetOptException("message", Exception.init))));
 /**
    Parse and remove command line options from a string array.
 
+
    Synopsis:
 
 ---------
@@ -118,10 +119,10 @@ void main(string[] args)
 ---------
 
     To set $(D verbose) to $(D true), invoke the program with either
-    $(D --verbose) or $(D --verbose=true).
+    `--verbose` or `--verbose=true`.
 
     To set $(D debugging) to $(D false), invoke the program with
-    $(D --debugging=false).
+    `--debugging=false`.
     )
 
     $(LI $(I Numeric options.) If an option is bound to a numeric type, a
@@ -134,7 +135,7 @@ void main(string[] args)
 ---------
 
     To set $(D timeout) to $(D 5), invoke the program with either
-    $(D --timeout=5) or $(D --timeout 5).
+    `--timeout=5` or `--timeout 5`.
     )
 
     $(LI $(I Incremental options.) If an option name has a "+" suffix and is
@@ -146,10 +147,10 @@ void main(string[] args)
   getopt(args, "paranoid+", &paranoid);
 ---------
 
-    Invoking the program with "--paranoid --paranoid --paranoid" will set $(D
+    Invoking the program with `--paranoid --paranoid --paranoid` will set $(D
     paranoid) to 3. Note that an incremental option never expects a parameter,
-    e.g., in the command line "--paranoid 42 --paranoid", the "42" does not set
-    $(D paranoid) to 42; instead, $(D paranoid) is set to 2 and "42" is not
+    e.g., in the command line `--paranoid 42 --paranoid`, the `42` does not set
+    $(D paranoid) to 42; instead, $(D paranoid) is set to 2 and `42` is not
     considered as part of the normal program arguments.
     )
 
@@ -1479,6 +1480,7 @@ unittest
 }
 
 /** This function prints the passed $(D Option)s and text in an aligned manner on $(D stdout).
+
 
 The passed text will be printed first, followed by a newline, then the short
 and long version of every option will be printed. The short and long version

--- a/std/json.d
+++ b/std/json.d
@@ -41,8 +41,8 @@ Synopsis:
 Copyright: Copyright Jeremie Pelletier 2008 - 2009.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth
-References: $(LINK http://json.org/)
-Source:    $(PHOBOSSRC std/_json.d)
+References: http://json.org/
+Source:    $(PHOBOSSRC std/json.d)
 */
 /*
          Copyright Jeremie Pelletier 2008 - 2009.

--- a/std/math.d
+++ b/std/math.d
@@ -480,7 +480,7 @@ enum real LOG2 =       0x1.34413509f79fef311f12b35816f92p-2L; /** $(SUB log, 10)
 enum real LOG10E =     0x1.bcb7b1526e50e32a6ab7555f5a67cp-2L; /** $(SUB log, 10)e = 0.434294... */
 enum real LN2 =        0x1.62e42fefa39ef35793c7673007e5fp-1L; /** ln 2  = 0.693147... */
 enum real LN10 =       0x1.26bb1bbb5551582dd4adac5705a61p+1L; /** ln 10 = 2.302585... */
-enum real PI =         0x1.921fb54442d18469898cc51701b84p+1L; /** $(_PI) = 3.141592... */
+enum real PI =         0x1.921fb54442d18469898cc51701b84p+1L; /** $(PI) = 3.141592... */
 enum real PI_2 =       PI/2;                                  /** $(PI) / 2 = 1.570796... */
 enum real PI_4 =       PI/4;                                  /** $(PI) / 4 = 0.785398... */
 enum real M_1_PI =     0x1.45f306dc9c882a53f84eafa3ea69cp-2L; /** 1 / $(PI) = 0.318309... */

--- a/std/math.d
+++ b/std/math.d
@@ -11,49 +11,49 @@ $(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Members) )
 $(TR $(TDNW Constants) $(TD
-    $(MYREF E) $(MYREF PI) $(MYREF PI_2) $(MYREF PI_4) $(MYREF M_1_PI)
-    $(MYREF M_2_PI) $(MYREF M_2_SQRTPI) $(MYREF LN10) $(MYREF LN2)
-    $(MYREF LOG2) $(MYREF LOG2E) $(MYREF LOG2T) $(MYREF LOG10E)
-    $(MYREF SQRT2) $(MYREF SQRT1_2)
+    $(LREF E) $(LREF PI) $(LREF PI_2) $(LREF PI_4) $(LREF M_1_PI)
+    $(LREF M_2_PI) $(LREF M_2_SQRTPI) $(LREF LN10) $(LREF LN2)
+    $(LREF LOG2) $(LREF LOG2E) $(LREF LOG2T) $(LREF LOG10E)
+    $(LREF SQRT2) $(LREF SQRT1_2)
 ))
 $(TR $(TDNW Classics) $(TD
-    $(MYREF abs) $(MYREF fabs) $(MYREF sqrt) $(MYREF cbrt) $(MYREF hypot)
-    $(MYREF poly) $(MYREF nextPow2) $(MYREF truncPow2)
+    $(LREF abs) $(LREF fabs) $(LREF sqrt) $(LREF cbrt) $(LREF hypot)
+    $(LREF poly) $(LREF nextPow2) $(LREF truncPow2)
 ))
 $(TR $(TDNW Trigonometry) $(TD
-    $(MYREF sin) $(MYREF cos) $(MYREF tan) $(MYREF asin) $(MYREF acos)
-    $(MYREF atan) $(MYREF atan2) $(MYREF sinh) $(MYREF cosh) $(MYREF tanh)
-    $(MYREF asinh) $(MYREF acosh) $(MYREF atanh) $(MYREF expi)
+    $(LREF sin) $(LREF cos) $(LREF tan) $(LREF asin) $(LREF acos)
+    $(LREF atan) $(LREF atan2) $(LREF sinh) $(LREF cosh) $(LREF tanh)
+    $(LREF asinh) $(LREF acosh) $(LREF atanh) $(LREF expi)
 ))
 $(TR $(TDNW Rounding) $(TD
-    $(MYREF ceil) $(MYREF floor) $(MYREF round) $(MYREF lround)
-    $(MYREF trunc) $(MYREF rint) $(MYREF lrint) $(MYREF nearbyint)
-    $(MYREF rndtol)
+    $(LREF ceil) $(LREF floor) $(LREF round) $(LREF lround)
+    $(LREF trunc) $(LREF rint) $(LREF lrint) $(LREF nearbyint)
+    $(LREF rndtol)
 ))
 $(TR $(TDNW Exponentiation & Logarithms) $(TD
-    $(MYREF pow) $(MYREF exp) $(MYREF exp2) $(MYREF expm1) $(MYREF ldexp)
-    $(MYREF frexp) $(MYREF log) $(MYREF log2) $(MYREF log10) $(MYREF logb)
-    $(MYREF ilogb) $(MYREF log1p) $(MYREF scalbn)
+    $(LREF pow) $(LREF exp) $(LREF exp2) $(LREF expm1) $(LREF ldexp)
+    $(LREF frexp) $(LREF log) $(LREF log2) $(LREF log10) $(LREF logb)
+    $(LREF ilogb) $(LREF log1p) $(LREF scalbn)
 ))
 $(TR $(TDNW Modulus) $(TD
-    $(MYREF fmod) $(MYREF modf) $(MYREF remainder)
+    $(LREF fmod) $(LREF modf) $(LREF remainder)
 ))
 $(TR $(TDNW Floating-point operations) $(TD
-    $(MYREF approxEqual) $(MYREF feqrel) $(MYREF fdim) $(MYREF fmax)
-    $(MYREF fmin) $(MYREF fma) $(MYREF nextDown) $(MYREF nextUp)
-    $(MYREF nextafter) $(MYREF NaN) $(MYREF getNaNPayload)
-    $(MYREF cmp)
+    $(LREF approxEqual) $(LREF feqrel) $(LREF fdim) $(LREF fmax)
+    $(LREF fmin) $(LREF fma) $(LREF nextDown) $(LREF nextUp)
+    $(LREF nextafter) $(LREF NaN) $(LREF getNaNPayload)
+    $(LREF cmp)
 ))
 $(TR $(TDNW Introspection) $(TD
-    $(MYREF isFinite) $(MYREF isIdentical) $(MYREF isInfinity) $(MYREF isNaN)
-    $(MYREF isNormal) $(MYREF isSubnormal) $(MYREF signbit) $(MYREF sgn)
-    $(MYREF copysign)
+    $(LREF isFinite) $(LREF isIdentical) $(LREF isInfinity) $(LREF isNaN)
+    $(LREF isNormal) $(LREF isSubnormal) $(LREF signbit) $(LREF sgn)
+    $(LREF copysign)
 ))
 $(TR $(TDNW Complex Numbers) $(TD
-  $(MYREF abs) $(MYREF conj) $(MYREF sin) $(MYREF cos) $(MYREF expi)
+  $(LREF abs) $(LREF conj) $(LREF sin) $(LREF cos) $(LREF expi)
 ))
 $(TR $(TDNW Hardware Control) $(TD
-    $(MYREF IeeeFlags) $(MYREF FloatingPointControl)
+    $(LREF IeeeFlags) $(LREF FloatingPointControl)
 ))
 )
 )
@@ -660,7 +660,7 @@ unittest
  * Returns:
  *      sine of x
  * See_Also:
- *      $(MYREF cos), $(MYREF tan), $(MYREF asin)
+ *      $(LREF cos), $(LREF tan), $(LREF asin)
  * Bugs:
  *      Results are undefined if |x| >= $(POWER 2,64).
  */
@@ -7116,7 +7116,7 @@ real yl2xp1(real x, real y) @nogc @safe pure nothrow;       // y * log2(x + 1)
  *      0 if $(D x) and $(D y) are identical, and positive value otherwise.
  *
  * See_Also:
- *      $(MYREF isIdentical)
+ *      $(LREF isIdentical)
  * Standards: Conforms to IEEE 754-2008
  */
 int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2136,6 +2136,9 @@ private mixin template Protocol()
       * incoming ubyte[] since it is not guaranteed to be valid after the
       * callback returns.
       *
+      * This function may be called multiple times as data comes in more than
+      * one chunk.
+      *
       * Returns:
       * The callback returns the number of incoming bytes read. If the entire array is
       * not read the request will abort.

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -44,7 +44,7 @@ public enum CustomFloatFlags
      * Store values in normalized form by default. The actual precision of the
      * significand is extended by 1 bit by assuming an implicit leading bit of 1
      * instead of 0. i.e. $(D 1.nnnn) instead of $(D 0.nnnn).
-     * True for all $(LUCKY IEE754) types
+     * True for all [https://en.wikipedia.org/wiki/IEEE_754-2008|IEEE 754] types
      */
     storeNormalized = 2,
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -775,6 +775,7 @@ public:
  * arbitrarily.  If `f(x)` returns NaN, NaN will be returned;
  * otherwise, this algorithm is guaranteed to succeed.
  *
+ *
  * Uses an algorithm based on TOMS748, which uses inverse cubic
  * interpolation whenever possible, otherwise reverting to parabolic
  * or secant interpolation. Compared to TOMS748, this implementation
@@ -788,6 +789,9 @@ public:
  * G. Alefeld, F.A. Potra, Yixun Shi, Mathematics of Computation 61,
  * pp733-744 (1993).  Fortran code available from $(WEB
  * www.netlib.org,www.netlib.org) as algorithm TOMS478.
+ *
+ * See_Also:
+ *    $(LINK2 http://d.darktech.org/findRoot.html, Blog: How to find the zeros of a function with dlang)
  *
  */
 T findRoot(T, DF, DT)(scope DF f, in T a, in T b,
@@ -2612,6 +2616,10 @@ private alias lookup_t = float;
  *
  * References:
  * $(WEB en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm)
+ *
+ * See_Also:
+ * $(LREF fft)
+ * $(LREF inverseFft)
  */
 final class Fft
 {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1,17 +1,17 @@
 /**
-$(D std._parallelism) implements high-level primitives for SMP _parallelism.
+$(D std.parallelism) implements high-level primitives for SMP parallelism.
 These include parallel foreach, parallel reduce, parallel eager map, pipelining
-and future/promise _parallelism.  $(D std._parallelism) is recommended when the
+and future/promise parallelism.  $(D std.parallelism) is recommended when the
 same operation is to be executed in parallel on different data, or when a
 function is to be executed in a background thread and its result returned to a
 well-defined main thread.  For communication between arbitrary threads, see
 $(D std.concurrency).
 
-$(D std._parallelism) is based on the concept of a $(D Task).  A $(D Task) is an
+$(D std.parallelism) is based on the concept of a $(D Task).  A $(D Task) is an
 object that represents the fundamental unit of work in this library and may be
 executed in parallel with any other $(D Task).  Using $(D Task)
 directly allows programming with a future/promise paradigm.  All other
-supported _parallelism paradigms (parallel foreach, map, reduce, pipelining)
+supported parallelism paradigms (parallel foreach, map, reduce, pipelining)
 represent an additional level of abstraction over $(D Task).  They
 automatically create one or more $(D Task) objects, or closely related types
 that are conceptually identical but not part of the public API.
@@ -29,9 +29,10 @@ more worker threads.  If the result of a $(D Task) is needed before execution
 by a worker thread has begun, the $(D Task) can be removed from the task queue
 and executed immediately in the thread where the result is needed.
 
-Warning:  Unless marked as $(D @trusted) or $(D @safe), artifacts in
-          this module allow implicit data sharing between threads and cannot
-          guarantee that client code is free from low level data races.
+$(WARNING  Unless marked as $(D @trusted) or $(D @safe), artifacts in
+           this module allow implicit data sharing between threads and cannot
+           guarantee that client code is free from low level data races.
+)
 
 Synopsis:
 
@@ -67,7 +68,7 @@ void main() {
 }
 ---
 
-Source:    $(PHOBOSSRC std/_parallelism.d)
+Source:    $(PHOBOSSRC std/parallelism.d)
 Author:  David Simcha
 Copyright:  Copyright (c) 2009-2011, David Simcha.
 License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
@@ -404,7 +405,7 @@ private struct AbstractTask
 /**
 $(D Task) represents the fundamental unit of work.  A $(D Task) may be
 executed in parallel with any other $(D Task).  Using this struct directly
-allows future/promise _parallelism.  In this paradigm, a function (or delegate
+allows future/promise parallelism.  In this paradigm, a function (or delegate
 or other callable) is executed in a thread other than the one it was called
 from.  The calling thread does not block while the function is being executed.
 A call to $(D workForce), $(D yieldForce), or $(D spinForce) is used to
@@ -2769,7 +2770,7 @@ public:
     Struct for creating worker-local storage.  Worker-local storage is
     thread-local storage that exists only for worker threads in a given
     $(D TaskPool) plus a single thread outside the pool.  It is allocated on the
-    garbage collected heap in a way that avoids _false sharing, and doesn't
+    garbage collected heap in a way that avoids false sharing, and doesn't
     necessarily have global scope within any thread.  It can be accessed from
     any worker thread in the $(D TaskPool) that created it, and one thread
     outside this $(D TaskPool).  All threads outside the pool that created a

--- a/std/path.d
+++ b/std/path.d
@@ -1,19 +1,27 @@
 // Written in the D programming language.
 
-/** This module is used to manipulate _path strings.
+/**
+    This module is used to manipulate and inspect _path strings
+    (and string-like objects).
 
     All functions, with the exception of $(LREF expandTilde) (and in some
     cases $(LREF absolutePath) and $(LREF relativePath)), are pure
     string manipulation functions; they don't depend on any state outside
     the program, nor do they perform any actual file system actions.
-    This has the consequence that the module does not make any distinction
-    between a _path that points to a directory and a _path that points to a
-    file, and it does not know whether or not the object pointed to by the
-    _path actually exists in the file system.
-    To differentiate between these cases, use $(XREF file,isDir) and
-    $(XREF file,exists).
 
-    Note that on Windows, both the backslash ($(D `\`)) and the slash ($(D `/`))
+    $(MREF std,file) can be used to work with the file system.
+    Notably, $(XREF file,dirEntries) can give you the names of files
+    in a directory, which you can then further inspect with this module.
+
+    The fact that std.path works only on strings also has the consequence
+    that the module does not make any distinction between a _path that points
+    to a directory and a _path that points to a file, and it does not know
+    whether or not the object pointed to by the _path actually exists in the
+    file system.  To differentiate between these cases, use $(XREF file,isDir)
+    and $(XREF file,exists).
+
+
+    Note that on Windows, both the backslash (`\`) and the slash (`/`)
     are in principle valid directory separators.  This module treats them
     both on equal footing, but in cases where a $(I new) separator is
     added, a backslash will be used.  Furthermore, the $(LREF buildNormalizedPath)
@@ -48,6 +56,9 @@
         $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:
         $(PHOBOSSRC std/_path.d)
+    See_Also:
+        module $(MREF std,stdio) for opening files and manipulating them via handles
+        module $(MREF std,file) for examining file attributes and directory entries
     Macros:
         WIKI = Phobos/StdPath
 */
@@ -99,8 +110,8 @@ else static assert (0, "unsupported platform");
 
 /** Determines whether the given character is a directory separator.
 
-    On Windows, this includes both $(D `\`) and $(D `/`).
-    On POSIX, it's just $(D `/`).
+    On Windows, this includes both `\` and `/`.
+    On POSIX, it's just `/`.
 */
 bool isDirSeparator(dchar c)  @safe pure nothrow @nogc
 {
@@ -1261,7 +1272,7 @@ unittest
     preceding segments will be dropped.
 
     On Windows, if one of the path segments are rooted, but not absolute
-    (e.g. $(D `\foo`)), all preceding path segments down to the previous
+    (e.g. `\foo`), all preceding path segments down to the previous
     root will be dropped.  (See below for an example.)
 
     This function always allocates memory to hold the resulting path.
@@ -2472,8 +2483,8 @@ unittest
     ---
 
     On Windows, an absolute path starts at the root directory of
-    a specific drive.  Hence, it must start with $(D `d:\`) or $(D `d:/`),
-    where $(D d) is the drive letter.  Alternatively, it may be a
+    a specific drive.  Hence, it must start with `d:\` or `d:/`,
+    where `d` is the drive letter.  Alternatively, it may be a
     network path, i.e. a path starting with a double (back)slash.
     ---
     version (Windows)
@@ -2682,14 +2693,14 @@ unittest
     taken to be the current working directory.  If specified,
     $(D base) must be an absolute _path, and it is always assumed
     to refer to a directory.  If $(D path) and $(D base) refer to
-    the same directory, the function returns $(D `.`).
+    the same directory, the function returns `.`.
 
     The following algorithm is used:
     $(OL
         $(LI If $(D path) is a relative directory, return it unaltered.)
         $(LI Find a common root between $(D path) and $(D base).
             If there is no common root, return $(D path) unaltered.)
-        $(LI Prepare a string with as many $(D `../`) or $(D `..\`) as
+        $(LI Prepare a string with as many `../` or `..\` as
             necessary to reach the common root from base path.)
         $(LI Append the remaining segments of $(D path) to the string
             and return.)
@@ -2932,7 +2943,7 @@ unittest
     comparison.  This is controlled through the $(D cs) template parameter
     which, if not specified, is given by $(LREF CaseSensitive)$(D .osDefault).
 
-    On Windows, the backslash and slash characters ($(D `\`) and $(D `/`))
+    On Windows, the backslash and slash characters (`\` and `/`)
     are considered equal.
 
     Params:
@@ -3556,13 +3567,13 @@ unittest
         $(LI If the second character of $(D path) is a colon ($(D ':')),
             the first character is interpreted as a drive letter, and
             must be in the range A-Z (case insensitive).)
-        $(LI If $(D path) is on the form $(D `\\$(I server)\$(I share)\...`)
+        $(LI If $(D path) is on the form `\\$(I server)\$(I share)\...`
             (UNC path), $(LREF isValidFilename) is applied to $(I server)
             and $(I share) as well.)
-        $(LI If $(D path) starts with $(D `\\?\`) (long UNC path), the
+        $(LI If $(D path) starts with `\\?\` (long UNC path), the
             only requirement for the rest of the string is that it does
             not contain the null character.)
-        $(LI If $(D path) starts with $(D `\\.\`) (Win32 device namespace)
+        $(LI If $(D path) starts with `\\.\` (Win32 device namespace)
             this function returns $(D false); such paths are beyond the scope
             of this module.)
     )

--- a/std/process.d
+++ b/std/process.d
@@ -42,11 +42,11 @@ $(LI
 
 The following table compactly summarises the different _process creation
 functions and how they relate to each other:
-$(BOOKTABLE,
+$(BOOKTABLE ,
     $(TR $(TH )
          $(TH Runs program directly)
          $(TH Runs shell command))
-    $(TR $(TD Low-level _process creation)
+    $(TR $(TD Low-level process creation)
          $(TD $(LREF spawnProcess))
          $(TD $(LREF spawnShell)))
     $(TR $(TD Automatic input/output redirection using pipes)
@@ -62,7 +62,7 @@ $(UL
 $(LI
     $(LREF pipe) is used to create unidirectional pipes.)
 $(LI
-    $(LREF environment) is an interface through which the current _process'
+    $(LREF environment) is an interface through which the current process'
     environment variables can be read and manipulated.)
 $(LI
     $(LREF escapeShellCommand) and $(LREF escapeShellFileName) are useful
@@ -78,7 +78,7 @@ Copyright:
 License:
    $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Source:
-    $(PHOBOSSRC std/_process.d)
+    $(PHOBOSSRC std/process.d)
 Macros:
     WIKI=Phobos/StdProcess
     LREF=$(D $(LINK2 #.$0,$0))
@@ -166,10 +166,10 @@ version (Posix)
 
 
 /**
-Spawns a new _process, optionally assigning it an arbitrary set of standard
+Spawns a new process, optionally assigning it an arbitrary set of standard
 input, output, and error streams.
 
-The function returns immediately, leaving the child _process to execute
+The function returns immediately, leaving the child process to execute
 in parallel with its parent.  It is recommended to always call $(LREF wait)
 on the returned $(LREF Pid), as detailed in the documentation for $(D wait).
 

--- a/std/process.d
+++ b/std/process.d
@@ -81,7 +81,6 @@ Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
     WIKI=Phobos/StdProcess
-    OBJECTREF=$(D $(LINK2 object.html#$0,$0))
     LREF=$(D $(LINK2 #.$0,$0))
 */
 module std.process;
@@ -2005,7 +2004,7 @@ struct ProcessPipes
     standard input stream.
 
     Throws:
-    $(OBJECTREF Error) if the child process' standard input stream hasn't
+    $(REF Error) if the child process' standard input stream hasn't
     been redirected.
     */
     @property File stdin() @safe nothrow
@@ -2021,7 +2020,7 @@ struct ProcessPipes
     standard output stream.
 
     Throws:
-    $(OBJECTREF Error) if the child process' standard output stream hasn't
+    $(REF Error) if the child process' standard output stream hasn't
     been redirected.
     */
     @property File stdout() @safe nothrow
@@ -2037,7 +2036,7 @@ struct ProcessPipes
     standard error stream.
 
     Throws:
-    $(OBJECTREF Error) if the child process' standard error stream hasn't
+    $(REF Error) if the child process' standard error stream hasn't
     been redirected.
     */
     @property File stderr() @safe nothrow
@@ -2478,7 +2477,7 @@ executeShell(
 ---
 
 Throws:
-$(OBJECTREF Exception) if any part of the command line contains unescapable
+$(REF Exception) if any part of the command line contains unescapable
 characters (NUL on all platforms, as well as CR and LF on Windows).
 */
 string escapeShellCommand(in char[][] args...) @safe pure
@@ -2968,7 +2967,7 @@ static:
     ---
 
     Throws:
-    $(OBJECTREF Exception) if the environment variable does not exist,
+    $(REF Exception) if the environment variable does not exist,
     or $(XREF utf,UTFException) if the variable contains invalid UTF-16
     characters (Windows only).
 
@@ -3024,8 +3023,14 @@ static:
     environment["foo"] = "bar";
     ---
 
+    $(WARNING
+        Environment variables are inherited by child processes, but are
+        not passed up to parent processes. Don't expect setting a value
+        through this to be seen in the shell after your program terminates.
+    )
+
     Throws:
-    $(OBJECTREF Exception) if the environment variable could not be added
+    $(REF Exception) if the environment variable could not be added
         (e.g. if the name is invalid).
     */
     inout(char)[] opIndexAssign(inout char[] value, in char[] name) @trusted
@@ -3077,7 +3082,7 @@ static:
     variable names in uppercase (e.g. $(D PATH)).
 
     Throws:
-    $(OBJECTREF Exception) if the environment variables could not
+    $(REF Exception) if the environment variables could not
         be retrieved (Windows only).
     */
     string[string] toAA() @trusted

--- a/std/random.d
+++ b/std/random.d
@@ -8,8 +8,9 @@ immune of threading issues. The generators feature a number of
 well-known and well-documented methods of generating random
 numbers. An overall fast and reliable means to generate random numbers
 is the $(D_PARAM Mt19937) generator, which derives its name from
-"$(LUCKY Mersenne Twister) with a period of 2 to the power of
-19937". In memory-constrained situations, $(LUCKY linear congruential)
+"[https://en.wikipedia.org/wiki/Mersenne_twister|Mersenne Twister] with
+a period of 2 to the power of 19937". In memory-constrained situations,
+[https://en.wikipedia.org/wiki/Linear_congruential_generator|linear congruential]
 generators such as $(D MinstdRand0) and $(D MinstdRand) might be
 useful. The standard library provides an alias $(D_PARAM Random) for
 whichever generator it considers the most fit for the target
@@ -35,7 +36,7 @@ distributions, which skew a generator's output statistical
 distribution in various ways. So far the uniform distribution for
 integers and real numbers have been implemented.
 
-Source:    $(PHOBOSSRC std/_random.d)
+Source:    $(PHOBOSSRC std/random.d)
 
 Macros:
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3,10 +3,8 @@
 /**
 This module defines the notion of a range. Ranges generalize the concept of
 arrays, lists, or anything that involves sequential access. This abstraction
-enables the same set of algorithms (see $(LINK2 std_algorithm.html,
-std.algorithm)) to be used with a vast variety of different concrete types. For
-example, a linear search algorithm such as $(LINK2 std_algorithm.html#find,
-std.algorithm.find) works not just for arrays, but for linked-lists, input
+enables the same set of algorithms (see [std.algorithm]) to be used with a vast variety of different concrete types. For
+example, a linear search algorithm such as [std.algorithm.searching.find] works not just for arrays, but for linked-lists, input
 files, incoming network data, etc. See also Ali Çehreli's
 $(WEB ddili.org/ders/d.en/ranges.html, tutorial on ranges) for the basics
 of working with and creating range-based code.
@@ -20,21 +18,21 @@ Submodules:
 
 This module has two submodules:
 
-The $(LINK2 std_range_primitives.html, $(D std._range.primitives)) submodule
-provides basic _range functionality. It defines several templates for testing
-whether a given object is a _range, what kind of _range it is, and provides
-some common _range operations.
+The [std.range.primitives] submodule
+provides basic range functionality. It defines several templates for testing
+whether a given object is a range, what kind of range it is, and provides
+some common range operations.
 
-The $(LINK2 std_range_interfaces.html, $(D std._range.interfaces)) submodule
+The [std.range.interfaces] submodule
 provides object-based interfaces for working with ranges via runtime
 polymorphism.
 
-The remainder of this module provides a rich set of _range creation and
+The remainder of this module provides a rich set of range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
 $(BOOKTABLE ,
     $(TR $(TD $(LREF chain))
-        $(TD Concatenates several ranges into a single _range.
+        $(TD Concatenates several ranges into a single range.
     ))
     $(TR $(TD $(LREF choose))
         $(TD Chooses one of two ranges at runtime based on a boolean condition.
@@ -43,124 +41,124 @@ $(BOOKTABLE ,
         $(TD Chooses one of several ranges at runtime based on an index.
     ))
     $(TR $(TD $(LREF chunks))
-        $(TD Creates a _range that returns fixed-size chunks of the original
-        _range.
+        $(TD Creates a range that returns fixed-size chunks of the original
+        range.
     ))
     $(TR $(TD $(LREF cycle))
-        $(TD Creates an infinite _range that repeats the given forward _range
+        $(TD Creates an infinite range that repeats the given forward range
         indefinitely. Good for implementing circular buffers.
     ))
     $(TR $(TD $(LREF drop))
-        $(TD Creates the _range that results from discarding the first $(I n)
-        elements from the given _range.
+        $(TD Creates the range that results from discarding the first $(I n)
+        elements from the given range.
     ))
     $(TR $(TD $(LREF dropExactly))
-        $(TD Creates the _range that results from discarding exactly $(I n)
-        of the first elements from the given _range.
+        $(TD Creates the range that results from discarding exactly $(I n)
+        of the first elements from the given range.
     ))
     $(TR $(TD $(LREF dropOne))
-        $(TD Creates the _range that results from discarding
-        the first elements from the given _range.
+        $(TD Creates the range that results from discarding
+        the first elements from the given range.
     ))
     $(TR $(TD $(LREF enumerate))
-        $(TD Iterates a _range with an attached index variable.
+        $(TD Iterates a range with an attached index variable.
     ))
     $(TR $(TD $(LREF evenChunks))
-        $(TD Creates a _range that returns a number of chunks of
-        approximately equal length from the original _range.
+        $(TD Creates a range that returns a number of chunks of
+        approximately equal length from the original range.
     ))
     $(TR $(TD $(LREF frontTransversal))
-        $(TD Creates a _range that iterates over the first elements of the
+        $(TD Creates a range that iterates over the first elements of the
         given ranges.
     ))
     $(TR $(TD $(LREF indexed))
-        $(TD Creates a _range that offers a view of a given _range as though
-        its elements were reordered according to a given _range of indices.
+        $(TD Creates a range that offers a view of a given range as though
+        its elements were reordered according to a given range of indices.
     ))
     $(TR $(TD $(LREF iota))
-        $(TD Creates a _range consisting of numbers between a starting point
+        $(TD Creates a range consisting of numbers between a starting point
         and ending point, spaced apart by a given interval.
     ))
     $(TR $(TD $(LREF lockstep))
-        $(TD Iterates $(I n) _ranges in lockstep, for use in a $(D foreach)
+        $(TD Iterates $(I n) ranges in lockstep, for use in a $(D foreach)
         loop. Similar to $(D zip), except that $(D lockstep) is designed
         especially for $(D foreach) loops.
     ))
     $(TR $(TD $(LREF NullSink))
-        $(TD An output _range that discards the data it receives.
+        $(TD An output range that discards the data it receives.
     ))
     $(TR $(TD $(LREF only))
-        $(TD Creates a _range that iterates over the given arguments.
+        $(TD Creates a range that iterates over the given arguments.
     ))
     $(TR $(TD $(LREF padLeft))
-        $(TD Pads a _range to a specified length by adding a given element to
-        the front of the _range. Is lazy if the range has a known length.
+        $(TD Pads a range to a specified length by adding a given element to
+        the front of the range. Is lazy if the range has a known length.
     ))
     $(TR $(TD $(LREF padRight))
-        $(TD Lazily pads a _range to a specified length by adding a given element to
-        the back of the _range.
+        $(TD Lazily pads a range to a specified length by adding a given element to
+        the back of the range.
     ))
     $(TR $(TD $(LREF radial))
-        $(TD Given a random-access _range and a starting point, creates a
-        _range that alternately returns the next left and next right element to
+        $(TD Given a random-access range and a starting point, creates a
+        range that alternately returns the next left and next right element to
         the starting point.
     ))
     $(TR $(TD $(LREF recurrence))
-        $(TD Creates a forward _range whose values are defined by a
+        $(TD Creates a forward range whose values are defined by a
         mathematical recurrence relation.
     ))
     $(TR $(TD $(LREF repeat))
-        $(TD Creates a _range that consists of a single element repeated $(I n)
-        times, or an infinite _range repeating that element indefinitely.
+        $(TD Creates a range that consists of a single element repeated $(I n)
+        times, or an infinite range repeating that element indefinitely.
     ))
     $(TR $(TD $(LREF retro))
-        $(TD Iterates a bidirectional _range backwards.
+        $(TD Iterates a bidirectional range backwards.
     ))
     $(TR $(TD $(LREF roundRobin))
-        $(TD Given $(I n) ranges, creates a new _range that return the $(I n)
-        first elements of each _range, in turn, then the second element of each
-        _range, and so on, in a round-robin fashion.
+        $(TD Given $(I n) ranges, creates a new range that return the $(I n)
+        first elements of each range, in turn, then the second element of each
+        range, and so on, in a round-robin fashion.
     ))
     $(TR $(TD $(LREF sequence))
-        $(TD Similar to $(D recurrence), except that a random-access _range is
+        $(TD Similar to $(D recurrence), except that a random-access range is
         created.
     ))
     $(TR $(TD $(LREF stride))
-        $(TD Iterates a _range with stride $(I n).
+        $(TD Iterates a range with stride $(I n).
     ))
     $(TR $(TD $(LREF tail))
-        $(TD Return a _range advanced to within $(D n) elements of the end of
-        the given _range.
+        $(TD Return a range advanced to within $(D n) elements of the end of
+        the given range.
     ))
     $(TR $(TD $(LREF take))
-        $(TD Creates a sub-_range consisting of only up to the first $(I n)
-        elements of the given _range.
+        $(TD Creates a sub-range consisting of only up to the first $(I n)
+        elements of the given range.
     ))
     $(TR $(TD $(LREF takeExactly))
-        $(TD Like $(D take), but assumes the given _range actually has $(I n)
+        $(TD Like $(D take), but assumes the given range actually has $(I n)
         elements, and therefore also defines the $(D length) property.
     ))
     $(TR $(TD $(LREF takeNone))
-        $(TD Creates a random-access _range consisting of zero elements of the
-        given _range.
+        $(TD Creates a random-access range consisting of zero elements of the
+        given range.
     ))
     $(TR $(TD $(LREF takeOne))
-        $(TD Creates a random-access _range consisting of exactly the first
-        element of the given _range.
+        $(TD Creates a random-access range consisting of exactly the first
+        element of the given range.
     ))
     $(TR $(TD $(LREF tee))
-        $(TD Creates a _range that wraps a given _range, forwarding along
+        $(TD Creates a range that wraps a given range, forwarding along
         its elements while also calling a provided function with each element.
     ))
     $(TR $(TD $(LREF transposed))
-        $(TD Transposes a _range of ranges.
+        $(TD Transposes a range of ranges.
     ))
     $(TR $(TD $(LREF transversal))
-        $(TD Creates a _range that iterates over the $(I n)'th elements of the
+        $(TD Creates a range that iterates over the $(I n)'th elements of the
         given random-access ranges.
     ))
     $(TR $(TD $(LREF zip))
-        $(TD Given $(I n) _ranges, creates a _range that successively returns a
+        $(TD Given $(I n) ranges, creates a range that successively returns a
         tuple of all the first elements, a tuple of all the second elements,
         etc.
     ))
@@ -168,12 +166,12 @@ $(BOOKTABLE ,
 
 Ranges whose elements are sorted afford better efficiency with certain
 operations. For this, the $(LREF assumeSorted) function can be used to
-construct a $(LREF SortedRange) from a pre-sorted _range. The $(LINK2
-std_algorithm.html#sort, $(D std.algorithm.sort)) function also conveniently
+construct a $(LREF SortedRange) from a pre-sorted range. The
+[std.algorithm.sorting.sort] function also conveniently
 returns a $(D SortedRange). $(D SortedRange) objects provide some additional
-_range operations that take advantage of the fact that the _range is sorted.
+range operations that take advantage of the fact that the range is sorted.
 
-Source: $(PHOBOSSRC std/_range/_package.d)
+Source: $(PHOBOSSRC std/range/package.d)
 
 Macros:
 
@@ -2584,23 +2582,23 @@ auto takeNone(R)(R range)
 }
 
 /++
- + Return a _range advanced to within $(D _n) elements of the end of
- + $(D _range).
+ + Return a range advanced to within $(D n) elements of the end of
+ + $(D range).
  +
- + Intended as the _range equivalent of the Unix
- + $(WEB en.wikipedia.org/wiki/Tail_%28Unix%29, _tail) utility. When the length
- + of $(D _range) is less than or equal to $(D _n), $(D _range) is returned
+ + Intended as the range equivalent of the Unix
+ + $(WEB en.wikipedia.org/wiki/Tail_%28Unix%29, tail) utility. When the length
+ + of $(D range) is less than or equal to $(D n), $(D range) is returned
  + as-is.
  +
  + Completes in $(BIGOH 1) steps for ranges that support slicing and have
- + length. Completes in $(BIGOH _range.length) time for all other ranges.
+ + length. Completes in $(BIGOH range.length) time for all other ranges.
  +
  + Params:
- +    range = _range to get _tail of
- +    n = maximum number of elements to include in _tail
+ +    range = range to get tail of
+ +    n = maximum number of elements to include in tail
  +
  + Returns:
- +    Returns the _tail of $(D _range) augmented with length information
+ +    Returns the tail of $(D range) augmented with length information
  +/
 auto tail(Range)(Range range, size_t n)
     if (isInputRange!Range && !isInfinite!Range &&

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -33,133 +33,133 @@ The remainder of this module provides a rich set of _range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF chain)))
+    $(TR $(TD $(LREF chain))
         $(TD Concatenates several ranges into a single _range.
     ))
-    $(TR $(TD $(D $(LREF choose)))
+    $(TR $(TD $(LREF choose))
         $(TD Chooses one of two ranges at runtime based on a boolean condition.
     ))
-    $(TR $(TD $(D $(LREF chooseAmong)))
+    $(TR $(TD $(LREF chooseAmong))
         $(TD Chooses one of several ranges at runtime based on an index.
     ))
-    $(TR $(TD $(D $(LREF chunks)))
+    $(TR $(TD $(LREF chunks))
         $(TD Creates a _range that returns fixed-size chunks of the original
         _range.
     ))
-    $(TR $(TD $(D $(LREF cycle)))
+    $(TR $(TD $(LREF cycle))
         $(TD Creates an infinite _range that repeats the given forward _range
         indefinitely. Good for implementing circular buffers.
     ))
-    $(TR $(TD $(D $(LREF drop)))
+    $(TR $(TD $(LREF drop))
         $(TD Creates the _range that results from discarding the first $(I n)
         elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF dropExactly)))
+    $(TR $(TD $(LREF dropExactly))
         $(TD Creates the _range that results from discarding exactly $(I n)
         of the first elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF dropOne)))
+    $(TR $(TD $(LREF dropOne))
         $(TD Creates the _range that results from discarding
         the first elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF enumerate)))
+    $(TR $(TD $(LREF enumerate))
         $(TD Iterates a _range with an attached index variable.
     ))
-    $(TR $(TD $(D $(LREF evenChunks)))
+    $(TR $(TD $(LREF evenChunks))
         $(TD Creates a _range that returns a number of chunks of
         approximately equal length from the original _range.
     ))
-    $(TR $(TD $(D $(LREF frontTransversal)))
+    $(TR $(TD $(LREF frontTransversal))
         $(TD Creates a _range that iterates over the first elements of the
         given ranges.
     ))
-    $(TR $(TD $(D $(LREF indexed)))
+    $(TR $(TD $(LREF indexed))
         $(TD Creates a _range that offers a view of a given _range as though
         its elements were reordered according to a given _range of indices.
     ))
-    $(TR $(TD $(D $(LREF iota)))
+    $(TR $(TD $(LREF iota))
         $(TD Creates a _range consisting of numbers between a starting point
         and ending point, spaced apart by a given interval.
     ))
-    $(TR $(TD $(D $(LREF lockstep)))
+    $(TR $(TD $(LREF lockstep))
         $(TD Iterates $(I n) _ranges in lockstep, for use in a $(D foreach)
         loop. Similar to $(D zip), except that $(D lockstep) is designed
         especially for $(D foreach) loops.
     ))
-    $(TR $(TD $(D $(LREF NullSink)))
+    $(TR $(TD $(LREF NullSink))
         $(TD An output _range that discards the data it receives.
     ))
-    $(TR $(TD $(D $(LREF only)))
+    $(TR $(TD $(LREF only))
         $(TD Creates a _range that iterates over the given arguments.
     ))
-    $(TR $(TD $(D $(LREF padLeft)))
+    $(TR $(TD $(LREF padLeft))
         $(TD Pads a _range to a specified length by adding a given element to
         the front of the _range. Is lazy if the range has a known length.
     ))
-    $(TR $(TD $(D $(LREF padRight)))
+    $(TR $(TD $(LREF padRight))
         $(TD Lazily pads a _range to a specified length by adding a given element to
         the back of the _range.
     ))
-    $(TR $(TD $(D $(LREF radial)))
+    $(TR $(TD $(LREF radial))
         $(TD Given a random-access _range and a starting point, creates a
         _range that alternately returns the next left and next right element to
         the starting point.
     ))
-    $(TR $(TD $(D $(LREF recurrence)))
+    $(TR $(TD $(LREF recurrence))
         $(TD Creates a forward _range whose values are defined by a
         mathematical recurrence relation.
     ))
-    $(TR $(TD $(D $(LREF repeat)))
+    $(TR $(TD $(LREF repeat))
         $(TD Creates a _range that consists of a single element repeated $(I n)
         times, or an infinite _range repeating that element indefinitely.
     ))
-    $(TR $(TD $(D $(LREF retro)))
+    $(TR $(TD $(LREF retro))
         $(TD Iterates a bidirectional _range backwards.
     ))
-    $(TR $(TD $(D $(LREF roundRobin)))
+    $(TR $(TD $(LREF roundRobin))
         $(TD Given $(I n) ranges, creates a new _range that return the $(I n)
         first elements of each _range, in turn, then the second element of each
         _range, and so on, in a round-robin fashion.
     ))
-    $(TR $(TD $(D $(LREF sequence)))
+    $(TR $(TD $(LREF sequence))
         $(TD Similar to $(D recurrence), except that a random-access _range is
         created.
     ))
-    $(TR $(TD $(D $(LREF stride)))
+    $(TR $(TD $(LREF stride))
         $(TD Iterates a _range with stride $(I n).
     ))
-    $(TR $(TD $(D $(LREF tail)))
+    $(TR $(TD $(LREF tail))
         $(TD Return a _range advanced to within $(D n) elements of the end of
         the given _range.
     ))
-    $(TR $(TD $(D $(LREF take)))
+    $(TR $(TD $(LREF take))
         $(TD Creates a sub-_range consisting of only up to the first $(I n)
         elements of the given _range.
     ))
-    $(TR $(TD $(D $(LREF takeExactly)))
+    $(TR $(TD $(LREF takeExactly))
         $(TD Like $(D take), but assumes the given _range actually has $(I n)
         elements, and therefore also defines the $(D length) property.
     ))
-    $(TR $(TD $(D $(LREF takeNone)))
+    $(TR $(TD $(LREF takeNone))
         $(TD Creates a random-access _range consisting of zero elements of the
         given _range.
     ))
-    $(TR $(TD $(D $(LREF takeOne)))
+    $(TR $(TD $(LREF takeOne))
         $(TD Creates a random-access _range consisting of exactly the first
         element of the given _range.
     ))
-    $(TR $(TD $(D $(LREF tee)))
+    $(TR $(TD $(LREF tee))
         $(TD Creates a _range that wraps a given _range, forwarding along
         its elements while also calling a provided function with each element.
     ))
-    $(TR $(TD $(D $(LREF transposed)))
+    $(TR $(TD $(LREF transposed))
         $(TD Transposes a _range of ranges.
     ))
-    $(TR $(TD $(D $(LREF transversal)))
+    $(TR $(TD $(LREF transversal))
         $(TD Creates a _range that iterates over the $(I n)'th elements of the
         given random-access ranges.
     ))
-    $(TR $(TD $(D $(LREF zip)))
+    $(TR $(TD $(LREF zip))
         $(TD Given $(I n) _ranges, creates a _range that successively returns a
         tuple of all the first elements, a tuple of all the second elements,
         etc.
@@ -167,8 +167,8 @@ $(BOOKTABLE ,
 )
 
 Ranges whose elements are sorted afford better efficiency with certain
-operations. For this, the $(D $(LREF assumeSorted)) function can be used to
-construct a $(D $(LREF SortedRange)) from a pre-sorted _range. The $(LINK2
+operations. For this, the $(LREF assumeSorted) function can be used to
+construct a $(LREF SortedRange) from a pre-sorted _range. The $(LINK2
 std_algorithm.html#sort, $(D std.algorithm.sort)) function also conveniently
 returns a $(D SortedRange). $(D SortedRange) objects provide some additional
 _range operations that take advantage of the fact that the _range is sorted.

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1,9 +1,9 @@
 /++
-  $(LUCKY Regular expressions) are a commonly used method of pattern matching
-  on strings, with $(I regex) being a catchy word for a pattern in this domain
-  specific language. Typical problems usually solved by regular expressions
-  include validation of user input and the ubiquitous find $(AMP) replace
-  in text processing utilities.
+  $(LINK2 https://en.wikipedia.org/wiki/Regular_expression, Regular expressions)
+  are a commonly used method of pattern matching on strings, with $(I regex)
+  being a catchy word for a pattern in this domain specific language. Typical
+  problems usually solved by regular expressions include validation of user
+  input and the ubiquitous find $(AMP) replace in text processing utilities.
 
   $(SECTION Synopsis)
   ---
@@ -49,6 +49,8 @@
 
 
   ---
+
+
   $(SECTION Syntax and general information)
   The general usage guideline is to keep regex complexity on the side of simplicity,
   as its capabilities reside in purely character-level manipulation.
@@ -318,7 +320,7 @@ public alias StaticRegex(Char) = std.regex.internal.ir.StaticRegex!(Char);
     pattern(s) = Regular expression(s) to match
     flags = The _attributes (g, i, m and x accepted)
 
-    Throws: $(D RegexException) if there were any errors during compilation.
+    Throws: $(LREF RegexException) if there were any errors during compilation.
 +/
 @trusted public auto regex(S)(S[] patterns, const(char)[] flags="")
     if (isSomeString!(S))
@@ -412,7 +414,7 @@ enum isRegexFor(RegEx, R) = is(RegEx == Regex!(BasicElementOf!R))
 
 /++
     $(D Captures) object contains submatches captured during a call
-    to $(D match) or iteration over $(D RegexMatch) range.
+    to $(D match) or iteration over $(LREF RegexMatch) range.
 
     First element of range is the whole match.
 +/
@@ -881,7 +883,7 @@ private R replaceAllWith(alias output,
     matching scheme to use depends highly on the pattern kind and
     can done automatically on case by case basis.
 
-    Returns: a $(D RegexMatch) object holding engine state after first match.
+    Returns: a $(LREF RegexMatch) object holding engine state after first match.
 +/
 
 public auto match(R, RegEx)(R input, RegEx re)
@@ -1048,7 +1050,9 @@ public auto matchAll(R, RegEx)(R input, RegEx re)
 
 /++
     Start matching of $(D input) to regex pattern $(D re),
-    using traditional $(LUCKY backtracking) matching scheme.
+    using traditional
+    $(LINK2 https://en.wikipedia.org/wiki/Backtracking, backtracking)
+    matching scheme.
 
     The use of this function is $(RED discouraged) - use either of
     $(LREF matchAll) or $(LREF matchFirst).
@@ -1059,7 +1063,7 @@ public auto matchAll(R, RegEx)(R input, RegEx re)
     matching scheme to use depends highly on the pattern kind and
     can done automatically on case by case basis.
 
-    Returns: a $(D RegexMatch) object holding engine
+    Returns: a $(LREF RegexMatch) object holding engine
     state after first match.
 
 +/

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -251,7 +251,7 @@
     API and utility constructs are modeled after the original $(D std.regex)
   by Walter Bright and Andrei Alexandrescu.
 
-  Source: $(PHOBOSSRC std/_regex/_package.d)
+  Source: $(PHOBOSSRC std/regex/package.d)
 
 Macros:
     REG_ROW = $(TR $(TD $(I $1 )) $(TD $+) )

--- a/std/socket.d
+++ b/std/socket.d
@@ -33,16 +33,29 @@
         Thanks to Benjamin Herr for his assistance.
  */
 
-/**
- * Socket primitives.
- * Example: See $(SAMPLESRC listener.d) and $(SAMPLESRC htmlget.d)
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors: Christopher E. Miller, $(WEB klickverbot.at, David Nadlinger),
- *      $(WEB thecybershadow.net, Vladimir Panteleev)
- * Source:  $(PHOBOSSRC std/_socket.d)
- * Macros:
- *      WIKI=Phobos/StdSocket
- */
+/++
+    This module wraps socket functionality with a cross-platform interface.
+
+
+    Example:
+    ---
+    // client
+    import std.socket;
+
+    void main() {
+        auto socket = new Socket(new InternetAddress("localhost", 2525));
+        socket.send("Hello!");
+    }
+    ---
+
+    Example: See $(SAMPLESRC listener.d) and $(SAMPLESRC htmlget.d)
+    License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors: Christopher E. Miller, $(WEB klickverbot.at, David Nadlinger),
+         $(WEB thecybershadow.net, Vladimir Panteleev)
+    Source:  $(PHOBOSSRC std/_socket.d)
+    Macros:
+         WIKI=Phobos/StdSocket
++/
 
 module std.socket;
 
@@ -417,8 +430,10 @@ class Protocol
 {
     /// These members are populated when one of the following functions are called successfully:
     ProtocolType type;
-    string name;                /// ditto
-    string[] aliases;           /// ditto
+    /// ditto
+    string name;
+    /// ditto
+    string[] aliases;
 
 
     void populate(protoent* proto) @system pure nothrow
@@ -448,7 +463,7 @@ class Protocol
         }
     }
 
-    /** Returns: false on failure */
+    /** Returns: $(D false) on failure */
     bool getProtocolByName(in char[] name) @trusted nothrow
     {
         protoent* proto;
@@ -460,7 +475,7 @@ class Protocol
     }
 
 
-    /** Returns: false on failure */
+    /** Returns: $(D false) on failure */
     // Same as getprotobynumber().
     bool getProtocolByType(ProtocolType type) @trusted nothrow
     {
@@ -552,7 +567,7 @@ class Service
 
     /**
      * If a protocol name is omitted, any protocol will be matched.
-     * Returns: false on failure.
+     * Returns: $(D false) on failure.
      */
     bool getServiceByName(in char[] name, in char[] protocolName = null) @trusted nothrow
     {
@@ -631,7 +646,7 @@ private mixin template socketOSExceptionCtors()
 
 
 /**
- * Class for exceptions thrown from an $(D InternetHost).
+ * Class for exceptions thrown from an $(LREF InternetHost).
  */
 class HostException: SocketOSException
 {
@@ -641,8 +656,8 @@ class HostException: SocketOSException
 /**
  * $(D InternetHost) is a class for resolving IPv4 addresses.
  *
- * Consider using $(D getAddress), $(D parseAddress) and $(D Address) methods
- * instead of using this class directly.
+ * Consider using $(LREF getAddress), $(LREF parseAddress) and $(LREF Address)
+ * methods instead of using this class directly.
  *
  * Example:
  * ---
@@ -763,7 +778,7 @@ class InternetHost
 
     /**
      * Resolve host name.
-     * Returns: false if unable to resolve.
+     * Returns: $(D false) if unable to resolve.
      */
     bool getHostByName(in char[] name) @trusted
     {
@@ -800,7 +815,7 @@ class InternetHost
      * Params:
      *   addr = The IPv4 address to resolve, in host byte order.
      * Returns:
-     *   false if unable to resolve.
+     *   $(D false) if unable to resolve.
      */
     bool getHostByAddr(uint addr) @trusted
     {
@@ -813,7 +828,7 @@ class InternetHost
     /**
      * Same as previous, but addr is an IPv4 address string in the
      * dotted-decimal form $(I a.b.c.d).
-     * Returns: false if unable to resolve.
+     * Returns: $(D false) if unable to resolve.
      */
     bool getHostByAddr(in char[] addr) @trusted
     {
@@ -862,27 +877,27 @@ unittest
 }
 
 
-/// Holds information about a socket _address retrieved by $(D getAddressInfo).
+/// Holds information about a socket _address retrieved by $(LREF getAddressInfo).
 struct AddressInfo
 {
     AddressFamily family;   /// Address _family
     SocketType type;        /// Socket _type
     ProtocolType protocol;  /// Protocol
     Address address;        /// Socket _address
-    string canonicalName;   /// Canonical name, when $(D AddressInfoFlags.CANONNAME) is used.
+    string canonicalName;   /// Canonical name, when $(REF AddressInfoFlags.CANONNAME) is used.
 }
 
 // A subset of flags supported on all platforms with getaddrinfo.
-/// Specifies option flags for $(D getAddressInfo).
+/// Specifies option flags for $(LREF getAddressInfo).
 enum AddressInfoFlags: int
 {
-    /// The resulting addresses will be used in a call to $(D Socket.bind).
+    /// The resulting addresses will be used in a call to $(LREF Socket.bind).
     PASSIVE = AI_PASSIVE,
 
-    /// The canonical name is returned in $(D canonicalName) member in the first $(D AddressInfo).
+    /// The canonical name is returned in $(LREF canonicalName) member in the first $(LREF AddressInfo).
     CANONNAME = AI_CANONNAME,
 
-    /// The $(D node) parameter passed to $(D getAddressInfo) must be a numeric string.
+    /// The $(D node) parameter passed to $(LREF getAddressInfo) must be a numeric string.
     /// This will suppress any potentially lengthy network host address lookups.
     NUMERICHOST = AI_NUMERICHOST,
 }
@@ -906,21 +921,22 @@ private string formatGaiError(int err) @trusted
 /**
  * Provides _protocol-independent translation from host names to socket
  * addresses. If advanced functionality is not required, consider using
- * $(D getAddress) for compatibility with older systems.
+ * $(LREF getAddress) for compatibility with older systems.
  *
- * Returns: Array with one $(D AddressInfo) per socket address.
+ * Returns: Array with one $(LREF AddressInfo) per socket address.
  *
- * Throws: $(D SocketOSException) on failure, or $(D SocketFeatureException)
- * if this functionality is not available on the current system.
+ * Throws: $(LREF SocketOSException) on failure, or
+ * $(LREF SocketFeatureException) if this functionality is not available
+ * on the current system.
  *
  * Params:
  *  node     = string containing host name or numeric address
  *  options  = optional additional parameters, identified by type:
  *             $(UL $(LI $(D string) - service name or port number)
- *                  $(LI $(D AddressInfoFlags) - option flags)
- *                  $(LI $(D AddressFamily) - address family to filter by)
- *                  $(LI $(D SocketType) - socket type to filter by)
- *                  $(LI $(D ProtocolType) - protocol to filter by))
+ *                  $(LI $(LREF AddressInfoFlags) - option flags)
+ *                  $(LI $(LREF AddressFamily) - address family to filter by)
+ *                  $(LI $(LREF SocketType) - socket type to filter by)
+ *                  $(LI $(LREF ProtocolType) - protocol to filter by))
  *
  * Example:
  * ---
@@ -1092,12 +1108,12 @@ private ushort serviceToPort(in char[] service)
 
 /**
  * Provides _protocol-independent translation from host names to socket
- * addresses. Uses $(D getAddressInfo) if the current system supports it,
- * and $(D InternetHost) otherwise.
+ * addresses. Uses $(LREF getAddressInfo) if the current system supports it,
+ * and $(LREF InternetHost) otherwise.
  *
- * Returns: Array with one $(D Address) instance per socket address.
+ * Returns: Array with one $(LREF Address) instance per socket address.
  *
- * Throws: $(D SocketOSException) on failure.
+ * Throws: $(LREF SocketOSException) on failure.
  *
  * Example:
  * ---
@@ -1171,13 +1187,13 @@ unittest
 
 /**
  * Provides _protocol-independent parsing of network addresses. Does not
- * attempt name resolution. Uses $(D getAddressInfo) with
- * $(D AddressInfoFlags.NUMERICHOST) if the current system supports it, and
- * $(D InternetAddress) otherwise.
+ * attempt name resolution. Uses $(LREF getAddressInfo) with
+ * $(REF AddressInfoFlags.NUMERICHOST) if the current system supports it, and
+ * $(LREF InternetAddress) otherwise.
  *
- * Returns: An $(D Address) instance representing specified address.
+ * Returns: An $(LREF Address) instance representing specified address.
  *
- * Throws: $(D SocketException) on failure.
+ * Throws: $(LREF SocketException) on failure.
  *
  * Example:
  * ---
@@ -1252,7 +1268,7 @@ unittest
 
 
 /**
- * Class for exceptions thrown from an $(D Address).
+ * Class for exceptions thrown from an $(LREF Address).
  */
 class AddressException: SocketOSException
 {
@@ -1363,9 +1379,9 @@ abstract class Address
     /**
      * Attempts to retrieve the host address as a human-readable string.
      *
-     * Throws: $(D AddressException) on failure, or $(D SocketFeatureException)
-     * if address retrieval for this address family is not available on the
-     * current system.
+     * Throws: $(LREF AddressException) on failure, or
+     * $(LREF SocketFeatureException) if address retrieval for this address
+     * family is not available on the current system.
      */
     string toAddrString() const
     {
@@ -1375,10 +1391,10 @@ abstract class Address
     /**
      * Attempts to retrieve the host name as a fully qualified domain name.
      *
-     * Returns: The FQDN corresponding to this $(D Address), or $(D null) if
+     * Returns: The FQDN corresponding to this $(LREF Address), or $(D null) if
      * the host name did not resolve.
      *
-     * Throws: $(D AddressException) on error, or $(D SocketFeatureException)
+     * Throws: $(LREF AddressException) on error, or $(LREF SocketFeatureException)
      * if host name lookup for this address family is not available on the
      * current system.
      */
@@ -1390,7 +1406,7 @@ abstract class Address
     /**
      * Attempts to retrieve the numeric port number as a string.
      *
-     * Throws: $(D AddressException) on failure, or $(D SocketFeatureException)
+     * Throws: $(LREF AddressException) on failure, or $(LREF SocketFeatureException)
      * if port number retrieval for this address family is not available on the
      * current system.
      */
@@ -1402,7 +1418,7 @@ abstract class Address
     /**
      * Attempts to retrieve the service name as a string.
      *
-     * Throws: $(D AddressException) on failure, or $(D SocketFeatureException)
+     * Throws: $(LREF AddressException) on failure, or $(LREF SocketFeatureException)
      * if service name lookup for this address family is not available on the
      * current system.
      */
@@ -1468,14 +1484,14 @@ protected:
     socklen_t len;
 
 public:
-    /// Constructs an $(D Address) with a reference to the specified $(D sockaddr).
+    /// Constructs an $(LREF Address) with a reference to the specified $(D sockaddr).
     this(sockaddr* sa, socklen_t len) pure nothrow @nogc
     {
         this.sa  = sa;
         this.len = len;
     }
 
-    /// Constructs an $(D Address) with a copy of the specified $(D sockaddr).
+    /// Constructs an $(LREF Address) with a copy of the specified $(D sockaddr).
     this(const(sockaddr)* sa, socklen_t len) @system pure nothrow
     {
         this.sa = cast(sockaddr*) (cast(ubyte*)sa)[0..len].dup.ptr;
@@ -1504,7 +1520,7 @@ public:
  * $(D InternetAddress) encapsulates an IPv4 (Internet Protocol version 4)
  * socket address.
  *
- * Consider using $(D getAddress), $(D parseAddress) and $(D Address) methods
+ * Consider using $(LREF getAddress), $(LREF parseAddress) and $(LREF Address) methods
  * instead of using this class directly.
  */
 class InternetAddress: Address
@@ -1553,12 +1569,12 @@ public:
     }
 
     /**
-     * Construct a new $(D InternetAddress).
+     * Construct a new $(LREF InternetAddress).
      * Params:
      *   addr = an IPv4 address string in the dotted-decimal form a.b.c.d,
-     *          or a host name which will be resolved using an $(D InternetHost)
+     *          or a host name which will be resolved using an $(LREF InternetHost)
      *          object.
-     *   port = port number, may be $(D PORT_ANY).
+     *   port = port number, may be $(LREF PORT_ANY).
      */
     this(in char[] addr, ushort port)
     {
@@ -1578,10 +1594,10 @@ public:
     }
 
     /**
-     * Construct a new $(D InternetAddress).
+     * Construct a new $(LREF InternetAddress).
      * Params:
-     *   addr = (optional) an IPv4 address in host byte order, may be $(D ADDR_ANY).
-     *   port = port number, may be $(D PORT_ANY).
+     *   addr = (optional) an IPv4 address in host byte order, may be $(LREF ADDR_ANY).
+     *   port = port number, may be $(LREF PORT_ANY).
      */
     this(uint addr, ushort port) pure nothrow @nogc
     {
@@ -1599,7 +1615,7 @@ public:
     }
 
     /**
-     * Construct a new $(D InternetAddress).
+     * Construct a new $(LREF InternetAddress).
      * Params:
      *   addr = A sockaddr_in as obtained from lower-level API calls such as getifaddrs.
      */
@@ -1624,10 +1640,10 @@ public:
     /**
      * Attempts to retrieve the host name as a fully qualified domain name.
      *
-     * Returns: The FQDN corresponding to this $(D InternetAddress), or
+     * Returns: The FQDN corresponding to this $(LREF InternetAddress), or
      * $(D null) if the host name did not resolve.
      *
-     * Throws: $(D AddressException) on error.
+     * Throws: $(LREF AddressException) on error.
      */
     override string toHostNameString() const
     {
@@ -1676,7 +1692,7 @@ public:
      * Parse an IPv4 address string in the dotted-decimal form $(I a.b.c.d)
      * and return the number.
      * Returns: If the string is not a legitimate IPv4 address,
-     * $(D ADDR_NONE) is returned.
+     * $(LREF ADDR_NONE) is returned.
      */
     static uint parse(in char[] addr) @trusted nothrow
     {
@@ -1755,11 +1771,11 @@ unittest
 
 
 /**
- * $(D Internet6Address) encapsulates an IPv6 (Internet Protocol version 6)
+ * $(LREF Internet6Address) encapsulates an IPv6 (Internet Protocol version 6)
  * socket address.
  *
- * Consider using $(D getAddress), $(D parseAddress) and $(D Address) methods
- * instead of using this class directly.
+ * Consider using $(LREF getAddress), $(LREF parseAddress) and $(LREF Address)
+ * methods instead of using this class directly.
  */
 class Internet6Address: Address
 {
@@ -1824,10 +1840,10 @@ public:
     }
 
     /**
-     * Construct a new $(D Internet6Address).
+     * Construct a new $(LREF Internet6Address).
      * Params:
      *   addr    = an IPv6 host address string in the form described in RFC 2373,
-     *             or a host name which will be resolved using $(D getAddressInfo).
+     *             or a host name which will be resolved using $(LREF getAddressInfo).
      *   service = (optional) service name.
      */
     this(in char[] addr, in char[] service = null) @trusted
@@ -1838,11 +1854,11 @@ public:
     }
 
     /**
-     * Construct a new $(D Internet6Address).
+     * Construct a new $(LREF Internet6Address).
      * Params:
      *   addr = an IPv6 host address string in the form described in RFC 2373,
-     *          or a host name which will be resolved using $(D getAddressInfo).
-     *   port = port number, may be $(D PORT_ANY).
+     *          or a host name which will be resolved using $(LREF getAddressInfo).
+     *   port = port number, may be $(LREF PORT_ANY).
      */
     this(in char[] addr, ushort port)
     {
@@ -1853,11 +1869,11 @@ public:
     }
 
     /**
-     * Construct a new $(D Internet6Address).
+     * Construct a new $(LREF Internet6Address).
      * Params:
      *   addr = (optional) an IPv6 host address in host byte order, or
-     *          $(D ADDR_ANY).
-     *   port = port number, may be $(D PORT_ANY).
+     *          $(LREF ADDR_ANY).
+     *   port = port number, may be $(LREF PORT_ANY).
      */
     this(ubyte[16] addr, ushort port) pure nothrow @nogc
     {
@@ -1875,7 +1891,7 @@ public:
     }
 
      /**
-     * Construct a new $(D Internet6Address).
+     * Construct a new $(LREF Internet6Address).
      * Params:
      *   addr = A sockaddr_in6 as obtained from lower-level API calls such as getifaddrs.
      */
@@ -1888,7 +1904,7 @@ public:
    /**
      * Parse an IPv6 host address string as described in RFC 2373, and return the
      * address.
-     * Throws: $(D SocketException) on error.
+     * Throws: $(LREF SocketException) on error.
      */
     static ubyte[16] parse(in char[] addr) @trusted
     {
@@ -1937,18 +1953,18 @@ version(StdDdoc)
     }
 
     /**
-     * $(D UnixAddress) encapsulates an address for a Unix domain socket
+     * $(LREF UnixAddress) encapsulates an address for a Unix domain socket
      * ($(D AF_UNIX)). Available only on supported systems.
      */
     class UnixAddress: Address
     {
         private this() pure nothrow @nogc {}
 
-        /// Construct a new $(D UnixAddress) from the specified path.
+        /// Construct a new $(LREF UnixAddress) from the specified path.
         this(in char[] path) { }
 
         /**
-         * Construct a new $(D UnixAddress).
+         * Construct a new $(LREF UnixAddress).
          * Params:
          *   addr = A sockaddr_un as obtained from lower-level API calls.
          */
@@ -2065,7 +2081,7 @@ static if (is(sockaddr_un))
 
 
 /**
- * Class for exceptions thrown by $(D Socket.accept).
+ * Class for exceptions thrown by $(LREF Socket.accept).
  */
 class SocketAcceptException: SocketOSException
 {
@@ -2131,9 +2147,9 @@ struct TimeVal
 
 
 /**
- * A collection of sockets for use with $(D Socket.select).
+ * A collection of sockets for use with $(LREF Socket.select).
  *
- * $(D SocketSet) wraps the platform $(D fd_set) type. However, unlike
+ * $(LREF SocketSet) wraps the platform $(D fd_set) type. However, unlike
  * $(D fd_set), $(D SocketSet) is not statically limited to $(D FD_SETSIZE)
  * or any other limit, and grows as needed.
  */
@@ -2292,7 +2308,7 @@ public:
         }
     }
 
-    /// Add a $(D Socket) to the collection.
+    /// Add a $(LREF Socket) to the collection.
     /// The socket must not already be in the collection.
     void add(Socket s) pure nothrow
     {
@@ -2320,7 +2336,7 @@ public:
     }
 
 
-    /// Remove this $(D Socket) from the collection.
+    /// Remove this $(LREF Socket) from the collection.
     /// Does nothing if the socket is not in the collection already.
     void remove(Socket s) pure nothrow
     {
@@ -2344,7 +2360,7 @@ public:
     }
 
 
-    /// Return nonzero if this $(D Socket) is in the collection.
+    /// Return nonzero if this $(LREF Socket) is in the collection.
     int isSet(Socket s) const pure nothrow @nogc
     {
         return isSet(s.sock);
@@ -2629,7 +2645,7 @@ public:
 
     /**
      * Create a blocking socket. If a single protocol type exists to support
-     * this socket type within the address family, the $(D ProtocolType) may be
+     * this socket type within the address family, the $(LREF ProtocolType) may be
      * omitted.
      */
     this(AddressFamily af, SocketType type, ProtocolType protocol) @trusted
@@ -2664,7 +2680,7 @@ public:
 
     /**
      * Create a blocking socket using the parameters from the specified
-     * $(D AddressInfo) structure.
+     * $(LREF AddressInfo) structure.
      */
     this(in AddressInfo info)
     {
@@ -2695,7 +2711,7 @@ public:
     /**
      * Get/set socket's blocking flag.
      *
-     * When a socket is blocking, calls to receive(), accept(), and send()
+     * When a socket is blocking, calls to $(REF receive)(), $(REF accept)(), and $(REF send)()
      * will block and wait for data/action.
      * A non-blocking socket will immediately return instead of blocking.
      */
@@ -2795,9 +2811,9 @@ public:
     }
 
     /**
-     * Listen for an incoming connection. $(D bind) must be called before you
+     * Listen for an incoming connection. $(LREF bind) must be called before you
      * can $(D listen). The $(D backlog) is a request of how many pending
-     * incoming connections are queued until $(D accept)ed.
+     * incoming connections are queued until $(LREF accept)ed.
      */
     void listen(int backlog) @trusted const
     {
@@ -2806,7 +2822,7 @@ public:
     }
 
     /**
-     * Called by $(D accept) when a new $(D Socket) must be created for a new
+     * Called by $(LREF accept) when a new $(D Socket) must be created for a new
      * connection. To use a derived class, override this method and return an
      * instance of your class. The returned $(D Socket)'s handle must not be
      * set; $(D Socket) has a protected constructor $(D this()) to use in this
@@ -2821,8 +2837,8 @@ public:
 
     /**
      * Accept an incoming connection. If the socket is blocking, $(D accept)
-     * waits for a connection request. Throws $(D SocketAcceptException) if
-     * unable to _accept. See $(D accepting) for use with derived classes.
+     * waits for a connection request. Throws $(LREF SocketAcceptException) if
+     * unable to _accept. See $(LREF accepting) for use with derived classes.
      */
     Socket accept() const @trusted
     {
@@ -2872,8 +2888,8 @@ public:
 
     /**
      * Immediately drop any connections and release socket resources.
-     * Calling $(D shutdown) before $(D close) is recommended for
-     * connection-oriented sockets. The $(D Socket) object is no longer
+     * Calling $(LREF shutdown) before $(D close) is recommended for
+     * connection-oriented sockets. The $(LREF Socket) object is no longer
      * usable after $(D close).
      */
     //calling shutdown() before this is recommended
@@ -2895,7 +2911,7 @@ public:
         return to!string(result.ptr);
     }
 
-    /// Remote endpoint $(D Address).
+    /// Remote endpoint $(LREF Address).
     @property Address remoteAddress() const @trusted
     {
         Address addr = createAddress();
@@ -2908,7 +2924,7 @@ public:
         return addr;
     }
 
-    /// Local endpoint $(D Address).
+    /// Local endpoint $(LREF Address).
     @property Address localAddress() const @trusted
     {
         Address addr = createAddress();
@@ -2922,8 +2938,8 @@ public:
     }
 
     /**
-     * Send or receive error code. See $(D wouldHaveBlocked),
-     * $(D lastSocketError) and $(D Socket.getErrorText) for obtaining more
+     * Send or receive error code. See $(LREF wouldHaveBlocked),
+     * $(LREF lastSocketError), and $(LREF Socket.getErrorText) for obtaining more
      * information about the error.
      */
     enum int ERROR = _SOCKET_ERROR;
@@ -2940,7 +2956,7 @@ public:
     /**
      * Send data on the connection. If the socket is blocking and there is no
      * buffer space left, $(D send) waits.
-     * Returns: The number of bytes actually sent, or $(D Socket.ERROR) on
+     * Returns: The number of bytes actually sent, or $(LREF Socket.ERROR) on
      * failure.
      */
     //returns number of bytes actually sent, or -1 on error
@@ -2967,7 +2983,7 @@ public:
      * Send data to a specific destination Address. If the destination address is
      * not specified, a connection must have been made and that address is used.
      * If the socket is blocking and there is no buffer space left, $(D sendTo) waits.
-     * Returns: The number of bytes actually sent, or $(D Socket.ERROR) on
+     * Returns: The number of bytes actually sent, or $(LREF Socket.ERROR) on
      * failure.
      */
     ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags, Address to) @trusted const nothrow @nogc
@@ -3019,7 +3035,7 @@ public:
      * Receive data on the connection. If the socket is blocking, $(D receive)
      * waits until there is data to be received.
      * Returns: The number of bytes actually received, $(D 0) if the remote side
-     * has closed the connection, or $(D Socket.ERROR) on failure.
+     * has closed the connection, or $(LREF Socket.ERROR) on failure.
      */
     //returns number of bytes actually received, 0 on connection closure, or -1 on error
     ptrdiff_t receive(void[] buf, SocketFlags flags) @trusted const nothrow @nogc
@@ -3043,11 +3059,11 @@ public:
     }
 
     /**
-     * Receive data and get the remote endpoint $(D Address).
+     * Receive data and get the remote endpoint $(LREF Address).
      * If the socket is blocking, $(D receiveFrom) waits until there is data to
      * be received.
      * Returns: The number of bytes actually received, $(D 0) if the remote side
-     * has closed the connection, or $(D Socket.ERROR) on failure.
+     * has closed the connection, or $(LREF Socket.ERROR) on failure.
      */
     ptrdiff_t receiveFrom(void[] buf, SocketFlags flags, ref Address from) @trusted const nothrow
     {
@@ -3179,27 +3195,28 @@ public:
     }
 
     /**
-     * Sets a timeout (duration) option, i.e. $(D SocketOption.SNDTIMEO) or
-     * $(D RCVTIMEO). Zero indicates no timeout.
+     * Sets a timeout (duration) option, i.e. $(REF SocketOption.SNDTIMEO) or
+     * $(REF SocketOption.RCVTIMEO). Zero indicates no timeout.
      *
      * In a typical application, you might also want to consider using
      * a non-blocking socket instead of setting a timeout on a blocking one.
      *
-     * Note: While the receive timeout setting is generally quite accurate
+     *
+     * $(NOTE While the receive timeout setting is generally quite accurate
      * on *nix systems even for smaller durations, there are two issues to
      * be aware of on Windows: First, although undocumented, the effective
      * timeout duration seems to be the one set on the socket plus half
      * a second. $(D setOption()) tries to compensate for that, but still,
      * timeouts under 500ms are not possible on Windows. Second, be aware
      * that the actual amount of time spent until a blocking call returns
-     * randomly varies on the order of 10ms.
+     * randomly varies on the order of 10ms.)
      *
      * Params:
      *   level  = The level at which a socket option is defined.
-     *   option = Either $(D SocketOption.SNDTIMEO) or $(D SocketOption.RCVTIMEO).
+     *   option = Either $(REF SocketOption.SNDTIMEO) or $(REF SocketOption.RCVTIMEO).
      *   value  = The timeout duration to set. Must not be negative.
      *
-     * Throws: $(D SocketException) if setting the options fails.
+     * Throws: $(LREF SocketException) if setting the options fails.
      *
      * Example:
      * ---
@@ -3218,6 +3235,9 @@ public:
      * writefln("Waited %s ms until the socket timed out.",
      *     sw.peek.msecs);
      * ---
+     *
+     * See_Also:
+     * $(REF blocking)
      */
     void setOption(SocketOptionLevel level, SocketOption option, Duration value) @trusted const
     {
@@ -3263,8 +3283,8 @@ public:
      *   interval = Number of seconds between when successive keep-alive
      *              packets are sent if no acknowledgement is received.
      *
-     * Throws: $(D SocketOSException) if setting the options fails, or
-     * $(D SocketFeatureException) if setting keep-alive parameters is
+     * Throws: $(LREF SocketOSException) if setting the options fails, or
+     * $(LREF SocketFeatureException) if setting keep-alive parameters is
      * unsupported on the current platform.
      */
     void setKeepAlive(int time, int interval) @trusted const
@@ -3295,13 +3315,13 @@ public:
     }
 
     /**
-     * Wait for a socket to change status. A wait timeout of $(Duration) or
-     * $(D TimeVal), may be specified; if a timeout is not specified or the
-     * $(D TimeVal) is $(D null), the maximum timeout is used. The $(D TimeVal)
+     * Wait for a socket to change status. A wait timeout of $(CXREF time,Duration) or
+     * $(LREF TimeVal), may be specified; if a timeout is not specified or the
+     * $(LREF TimeVal) is $(D null), the maximum timeout is used. The $(LREF TimeVal)
      * timeout has an unspecified value when $(D select) returns.
      * Returns: The number of sockets with status changes, $(D 0) on timeout,
      * or $(D -1) on interruption. If the return value is greater than $(D 0),
-     * the $(D SocketSets) are updated to only contain the sockets having status
+     * the $(LREF SocketSet)s are updated to only contain the sockets having status
      * changes. For a connecting socket, a write status change means the
      * connection is established and it's able to send. For a listening socket,
      * a read status change means there is an incoming connection request and
@@ -3472,7 +3492,7 @@ class TcpSocket: Socket
 
 
     //shortcut
-    /// Constructs a blocking TCP Socket and connects to an $(D Address).
+    /// Constructs a blocking TCP Socket and connects to an $(LREF Address).
     this(Address connectTo)
     {
         this(connectTo.addressFamily);
@@ -3503,7 +3523,7 @@ class UdpSocket: Socket
  *
  * The two sockets are indistinguishable.
  *
- * Throws: $(D SocketException) if creation of the sockets fails.
+ * Throws: $(LREF SocketException) if creation of the sockets fails.
  */
 Socket[2] socketPair() @trusted
 {

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -31,7 +31,7 @@
  *      See $(SAMPLESRC htmlget.d)
  * Authors: Christopher E. Miller
  * References:
- *      $(LINK2 std_stream.html, std.stream)
+ *      $(MREF std,stream)
  * Source:    $(PHOBOSSRC std/_socketstream.d)
  * Macros: WIKI=Phobos/StdSocketstream
  */

--- a/std/stdint.d
+++ b/std/stdint.d
@@ -5,8 +5,8 @@
     D constrains integral types to specific sizes. But efficiency
     of different sizes varies from machine to machine,
     pointer sizes vary, and the maximum integer size varies.
-    <b>stdint</b> offers a portable way of trading off size
-    vs efficiency, in a manner compatible with the <tt>stdint.h</tt>
+    $(B stdint) offers a portable way of trading off size
+    vs efficiency, in a manner compatible with the $(TT stdint.h)
     definitions in C.
 
     The exact aliases are types of exactly the specified number of bits.
@@ -17,7 +17,7 @@
 
     The aliases are:
 
-    $(ATABLE $(TR
+    $(TABLE $(TR
     $(TH Exact Alias)
     $(TH Description)
     $(TH At Least Alias)
@@ -88,7 +88,7 @@
     The ptr aliases are integral types guaranteed to be large enough
     to hold a pointer without losing bits:
 
-    $(ATABLE $(TR
+    $(TABLE $(TR
     $(TH Alias)
     $(TH Description)
     )$(TR
@@ -101,7 +101,7 @@
 
     The max aliases are the largest integral types:
 
-    $(ATABLE $(TR
+    $(TABLE $(TR
     $(TH Alias)
     $(TH Description)
     )$(TR

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1389,6 +1389,7 @@ Throws: $(D Exception) if the file is not opened.
 /**
 Read line from the file handle and return it as a specified type.
 
+
 This version manages its own read buffer, which means one memory allocation per call. If you are not
 retaining a reference to the read data, consider the $(D File.readln(buf)) version, which may offer
 better performance as it can reuse its read buffer.
@@ -1402,6 +1403,11 @@ Note:
 
 Returns:
     The line that was read, including the line terminator character.
+
+    $(TIP
+        Use $(REF std.string.chomp) to cut off the line terminator if you don't want it, such as when passing
+        it to $(REF std.conv.to). For example: $(D int a = to!int(readln.chomp);)
+    )
 
 Throws:
     $(D StdioException) on I/O error, or $(D UnicodeException) on Unicode conversion error.
@@ -1472,6 +1478,7 @@ void main()
 /**
 Read line from the file handle and write it to $(D buf[]), including
 terminating character.
+
 
 This can be faster than $(D line = File.readln()) because you can reuse
 the buffer for each call. Note that reusing the buffer means that you
@@ -3583,12 +3590,18 @@ unittest
 /**********************************
  * Read line from $(D stdin).
  *
+ *
  * This version manages its own read buffer, which means one memory allocation per call. If you are not
  * retaining a reference to the read data, consider the $(D readln(buf)) version, which may offer
  * better performance as it can reuse its read buffer.
  *
  * Returns:
  *        The line that was read, including the line terminator character.
+ *
+ *        $(TIP
+ *          Use $(REF std.string.chomp) to cut off the line terminator if you don't want it, such as when passing
+ *          it to $(REF std.conv.to). For example: $(D int a = to!int(readln.chomp);)
+ *         )
  * Params:
  *        S = Template parameter; the type of the allocated buffer, and the type returned. Defaults to $(D string).
  *        terminator = Line terminator (by default, $(D '\n')).
@@ -3608,6 +3621,22 @@ void main()
         write(line);
 }
 ---
+
+This reads an integer from stdin:
+---
+import std.stdio;
+import std.string : chomp;
+import std.conv : to;
+
+void main()
+{
+    // If you forget to use `.chomp` here, you will get a
+    // ConvException when you try to run the program.
+    int fromUser = to!int(readln().chomp);
+    writeln(fromUser);
+}
+---
+
 */
 S readln(S = string)(dchar terminator = '\n')
 if (isSomeString!S)
@@ -3617,6 +3646,7 @@ if (isSomeString!S)
 
 /**********************************
  * Read line from $(D stdin) and write it to buf[], including terminating character.
+ *
  *
  * This can be faster than $(D line = readln()) because you can reuse
  * the buffer for each call. Note that reusing the buffer means that you

--- a/std/string.d
+++ b/std/string.d
@@ -5215,15 +5215,15 @@ body
  * See if character c is in the pattern.
  * Patterns:
  *
- *  A <i>pattern</i> is an array of characters much like a <i>character
- *  class</i> in regular expressions. A sequence of characters
+ *  A $(I pattern) is an array of characters much like a $(I character
+ *  class) in regular expressions. A sequence of characters
  *  can be given, such as "abcde". The '-' can represent a range
  *  of characters, as "a-e" represents the same pattern as "abcde".
  *  "a-fA-F0-9" represents all the hex characters.
  *  If the first character of a pattern is '^', then the pattern
  *  is negated, i.e. "^0-9" means any character except a digit.
- *  The functions inPattern, <b>countchars</b>, <b>removeschars</b>,
- *  and <b>squeeze</b>
+ *  The functions [inPattern], [countchars], [removechars],
+ *  and [squeeze]
  *  use patterns.
  *
  * Note: In the future, the pattern syntax may be improved
@@ -6599,8 +6599,6 @@ S wrap(S)(S s, in size_t columns = 80, S firstindent = null,
  * This uniformly outdents the text as much as possible.
  * Whitespace-only lines are always converted to blank lines.
  *
- * Does not allocate memory if it does not throw.
- *
  * Params:
  *     str = multi-line string
  *
@@ -6642,6 +6640,8 @@ void main() {
  *
  * This uniformly outdents the text as much as possible.
  * Whitespace-only lines are always converted to blank lines.
+ *
+ * Does not allocate memory if it does not throw.
  *
  * Params:
  *     lines = array of single-line strings

--- a/std/string.d
+++ b/std/string.d
@@ -74,6 +74,7 @@ $(TR $(TDNW Miscellaneous)
     )
 )))
 
+
 Objects of types $(D _string), $(D wstring), and $(D dstring) are value types
 and cannot be mutated element-by-element. For using mutation during building
 strings, use $(D char[]), $(D wchar[]), or $(D dchar[]). The $(D xxxstring)
@@ -82,9 +83,8 @@ making code more robust.
 
 The following functions are publicly imported:
 
-$(BOOKTABLE ,
+$(BOOKTABLE Publicly imported functions,
 $(TR $(TH Module) $(TH Functions) )
-$(LEADINGROW Publicly imported functions)
     $(TR $(TD std.algorithm)
         $(TD
          $(SHORTXREF_PACK algorithm,comparison,cmp)
@@ -116,21 +116,20 @@ $(LEADINGROW Publicly imported functions)
 )
 
 There is a rich set of functions for _string handling defined in other modules.
-Functions related to Unicode and ASCII are found in $(LINK2 std_uni.html, std.uni)
-and $(LINK2 std_ascii.html, std.ascii), respectively. Other functions that have a
-wider generality than just strings can be found in $(LINK2 std_algorithm.html,
-std.algorithm) and $(LINK2 std_range.html, std.range).
+Functions related to Unicode and ASCII are found in $(MREF std,uni)
+and $(MREF std,ascii), respectively. Other functions that have a
+wider generality than just strings can be found in $(MREF std,algorithm) and $(MREF std,range).
 
 See_Also:
     $(LIST
-    $(LINK2 std_algorithm.html, std.algorithm) and
-    $(LINK2 std_range.html, std.range)
+    $(MREF std,algorithm) and
+    $(MREF std,range)
     for generic range algorithms
     ,
-    $(LINK2 std_ascii.html, std.ascii)
+    $(MREF std,ascii)
     for functions that work with ASCII strings
     ,
-    $(LINK2 std_uni.html, std.uni)
+    $(MREF std,uni)
     for functions that work with unicode strings
     )
 
@@ -226,14 +225,19 @@ class StringException : Exception
 
 
 /++
+    Slices a C-style $(D char*) into a D-style $(D char[]).
+
     Params:
         cString = A null-terminated c-style string.
 
     Returns: A D-style array of $(D char) referencing the same string.  The
     returned array will retain the same type qualifiers as the input.
 
-    $(RED Important Note:) The returned array is a slice of the original buffer.
-    The original data is not changed and not copied.
+    $(PITFALL The returned array is a slice of the original buffer.
+    The original data is not changed and not copied. This means if it
+    is freed by a later call to the C library, the returned string becomes
+    invalid too. You may want to call `.idup` on the returned string to make
+    a copy if you intend to keep it around.)
 +/
 
 inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
@@ -249,6 +253,8 @@ inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
 }
 
 /++
+    Converts a D-style $(D string) to a C-style $(D const char*).
+
     Params:
         s = A D-style string.
 
@@ -257,12 +263,32 @@ inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
     first $(D '\0') that it sees as the end of the string. If $(D s.empty) is
     $(D true), then a string containing only $(D '\0') is returned.
 
-    $(RED Important Note:) When passing a $(D char*) to a C function, and the C
+    $(PITFALL When passing a $(D char*) to a C function, and the C
     function keeps it around for any reason, make sure that you keep a
     reference to it in your D code. Otherwise, it may become invalid during a
     garbage collection cycle and cause a nasty bug when the C code tries to use
-    it.
+    it.)
   +/
+immutable(char)* toStringz(in string s) @trusted pure nothrow
+{
+    if (s.empty) return "".ptr;
+    /* Peek past end of s[], if it's 0, no conversion necessary.
+     * Note that the compiler will put a 0 past the end of static
+     * strings, and the storage allocator will put a 0 past the end
+     * of newly allocated char[]'s.
+     */
+    immutable p = s.ptr + s.length;
+    // Is p dereferenceable? A simple test: if the p points to an
+    // address multiple of 4, then conservatively assume the pointer
+    // might be pointing to a new block of memory, which might be
+    // unreadable. Otherwise, it's definitely pointing to valid
+    // memory.
+    if ((cast(size_t) p & 3) && *p == 0)
+        return s.ptr;
+    return toStringz(cast(const char[]) s);
+}
+
+/++ Ditto +/
 immutable(char)* toStringz(const(char)[] s) @trusted pure nothrow
 in
 {
@@ -305,26 +331,6 @@ body
     copy[s.length] = 0;
 
     return assumeUnique(copy).ptr;
-}
-
-/++ Ditto +/
-immutable(char)* toStringz(in string s) @trusted pure nothrow
-{
-    if (s.empty) return "".ptr;
-    /* Peek past end of s[], if it's 0, no conversion necessary.
-     * Note that the compiler will put a 0 past the end of static
-     * strings, and the storage allocator will put a 0 past the end
-     * of newly allocated char[]'s.
-     */
-    immutable p = s.ptr + s.length;
-    // Is p dereferenceable? A simple test: if the p points to an
-    // address multiple of 4, then conservatively assume the pointer
-    // might be pointing to a new block of memory, which might be
-    // unreadable. Otherwise, it's definitely pointing to valid
-    // memory.
-    if ((cast(size_t) p & 3) && *p == 0)
-        return s.ptr;
-    return toStringz(cast(const char[]) s);
 }
 
 pure nothrow unittest
@@ -5459,7 +5465,7 @@ S squeeze(S)(S s, in S pattern = null)
 /***************************************************************
  Finds the position $(D_PARAM pos) of the first character in $(D_PARAM
  s) that does not match $(D_PARAM pattern) (in the terminology used by
- $(LINK2 std_string.html,inPattern)). Updates $(D_PARAM s =
+ $(XREF string,inPattern)). Updates $(D_PARAM s =
  s[pos..$]). Returns the slice from the beginning of the original
  (before update) string up to, and excluding, $(D_PARAM pos).
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -8,12 +8,12 @@
  * $(DIVC quickindex,
  * $(BOOKTABLE ,
  * $(TR $(TH Category) $(TH Templates))
- * $(TR $(TD Symbol Name _traits) $(TD
+ * $(TR $(TD Symbol Name traits) $(TD
  *           $(LREF fullyQualifiedName)
  *           $(LREF moduleName)
  *           $(LREF packageName)
  * ))
- * $(TR $(TD Function _traits) $(TD
+ * $(TR $(TD Function traits) $(TD
  *           $(LREF arity)
  *           $(LREF functionAttributes)
  *           $(LREF functionLinkage)
@@ -28,7 +28,7 @@
  *           $(LREF SetFunctionAttributes)
  *           $(LREF variadicFunctionStyle)
  * ))
- * $(TR $(TD Aggregate Type _traits) $(TD
+ * $(TR $(TD Aggregate Type traits) $(TD
  *           $(LREF BaseClassesTuple)
  *           $(LREF BaseTypeTuple)
  *           $(LREF classInstanceAlignment)
@@ -149,7 +149,7 @@
  *            $(WEB klickverbot.at, David Nadlinger),
  *            Kenji Hara,
  *            Shoichi Kato
- * Source:    $(PHOBOSSRC std/_traits.d)
+ * Source:    $(PHOBOSSRC std/traits.d)
  */
 /*          Copyright Digital Mars 2005 - 2009.
  * Distributed under the Boost Software License, Version 1.0.
@@ -4636,7 +4636,7 @@ private template AliasThisTypeOf(T) if (isAggregateType!T)
         static assert(0, T.stringof~" does not have alias this type");
 }
 
-/*
+/**
  */
 template BooleanTypeOf(T)
 {
@@ -4687,7 +4687,7 @@ unittest
     static assert(is(BooleanTypeOf!S == bool));
 }
 
-/*
+/**
  */
 template IntegralTypeOf(T)
 {
@@ -4721,7 +4721,7 @@ unittest
         }
 }
 
-/*
+/**
  */
 template FloatingPointTypeOf(T)
 {
@@ -4755,7 +4755,7 @@ unittest
         }
 }
 
-/*
+/**
  */
 template NumericTypeOf(T)
 {
@@ -4784,7 +4784,7 @@ unittest
         }
 }
 
-/*
+/**
  */
 template UnsignedTypeOf(T)
 {
@@ -4795,7 +4795,7 @@ template UnsignedTypeOf(T)
         static assert(0, T.stringof~" is not an unsigned type.");
 }
 
-/*
+/**
  */
 template SignedTypeOf(T)
 {
@@ -4808,7 +4808,7 @@ template SignedTypeOf(T)
         static assert(0, T.stringof~" is not an signed type.");
 }
 
-/*
+/**
  */
 template CharTypeOf(T)
 {
@@ -4849,7 +4849,7 @@ unittest
         }
 }
 
-/*
+/**
  */
 template StaticArrayTypeOf(T)
 {
@@ -4884,7 +4884,7 @@ unittest
         }
 }
 
-/*
+/**
  */
 template DynamicArrayTypeOf(T)
 {
@@ -4921,7 +4921,7 @@ unittest
     static assert(!is(DynamicArrayTypeOf!(typeof(null))));
 }
 
-/*
+/**
  */
 template ArrayTypeOf(T)
 {
@@ -4933,7 +4933,7 @@ template ArrayTypeOf(T)
         static assert(0, T.stringof~" is not an array type");
 }
 
-/*
+/**
 Always returns the Dynamic Array version.
  */
 template StringTypeOf(T)
@@ -4985,7 +4985,7 @@ unittest
     static assert(is(StringTypeOf!(char[4]) == char[]));
 }
 
-/*
+/**
  */
 template AssocArrayTypeOf(T)
 {
@@ -5022,7 +5022,7 @@ unittest
                     }
 }
 
-/*
+/**
  */
 template BuiltinTypeOf(T)
 {
@@ -5313,7 +5313,7 @@ unittest
 }
 
 
-/*
+/**
 Detect whether $(D T) is a struct or static array that is implicitly
 convertible to a string.
  */

--- a/std/traits.d
+++ b/std/traits.d
@@ -160,9 +160,9 @@ module std.traits;
 
 import std.typetuple;
 
-///////////////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////////////
 // Functions
-///////////////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////////////
 
 // Petit demangler
 // (this or similar thing will eventually go to std.demangle if necessary
@@ -273,15 +273,15 @@ package
 
 /// Add specific qualifier to the given type T.
 template InoutOf(T)       { alias InoutOf       =        inout(T) ; }
-/// ditto.
+/// ditto
 template ConstOf(T)       { alias ConstOf       =        const(T) ; }
-/// ditto.
+/// ditto
 template SharedOf(T)      { alias SharedOf      =       shared(T) ; }
-/// ditto.
+/// ditto
 template SharedInoutOf(T) { alias SharedInoutOf = shared(inout(T)); }
-/// ditto.
+/// ditto
 template SharedConstOf(T) { alias SharedConstOf = shared(const(T)); }
-/// ditto.
+/// ditto
 template ImmutableOf(T)   { alias ImmutableOf   =    immutable(T) ; }
 
 unittest
@@ -295,7 +295,7 @@ unittest
     static assert(is(  ImmutableOf!int ==    immutable int));
 }
 
-// Get qualifier template from the given type T
+/// Get qualifier template from the given type T
 template QualifierOf(T)
 {
          static if (is(T == shared(const U), U)) alias QualifierOf = SharedConstOf;
@@ -6151,7 +6151,7 @@ unittest
 }
 
 /**
-Returns the type of `Target` with the "constness" of `Source`. A type's $(BOLD constness)
+Returns the type of `Target` with the "constness" of `Source`. A type's $(B constness)
 refers to whether it is `const`, `immutable`, or `inout`. If `source` has no constness, the
 returned type will be the same as `Target`.
 */

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1440,7 +1440,7 @@ unittest
 }
 
 /**
-    Constructs a $(D Tuple) object instantiated and initialized according to
+    Constructs a $(LREF Tuple) object instantiated and initialized according to
     the given arguments.
 
     Params:
@@ -3146,7 +3146,7 @@ unittest
     assertThrown!NotImplementedError(c.notYetImplemented()); // throws an Error
 }
 
-// / ditto
+/// Thrown when you ask for something that isn't implemented
 class NotImplementedError : Error
 {
     this(string method)
@@ -6526,7 +6526,11 @@ McConnell in the $(LUCKY Code Complete) book, along with three other
 kinds of coupling. The author argues citing several studies that
 coupling has a negative effect on code quality. $(D Flag) offers a
 simple structuring method for passing yes/no flags to APIs.
- */
+
+See_Also:
+    $(LREF Yes)
+    $(LREF No)
+*/
 template Flag(string name) {
     ///
     enum Flag : bool
@@ -6551,6 +6555,9 @@ template Flag(string name) {
 Convenience names that allow using e.g. $(D Yes.encryption) instead of
 $(D Flag!"encryption".yes) and $(D No.encryption) instead of $(D
 Flag!"encryption".no).
+
+See_Also:
+	$(LREF Flag)
 */
 struct Yes
 {

--- a/std/uni.d
+++ b/std/uni.d
@@ -9,7 +9,7 @@
 
     $(P All primitives listed operate on Unicode characters and
     sets of characters. For functions which operate on ASCII characters
-    and ignore Unicode $(CHARACTERS), see $(LINK2 std_ascii.html, std.ascii).
+    and ignore Unicode $(CHARACTERS), see $(MREF std,ascii).
     For definitions of Unicode $(CHARACTER), $(CODEPOINT) and other terms
     used throughout this module see the $(S_LINK Terminology, terminology) section
     below.

--- a/std/utf.d
+++ b/std/utf.d
@@ -7,9 +7,11 @@
     $(D '\u0000' &lt;= character &lt;= '\U0010FFFF').
 
     See_Also:
-        $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
-        $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>
-        $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
+    $(LIST
+        * $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)
+        * [http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8]
+        * [http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335]
+    )
     Macros:
         WIKI = Phobos/StdUtf
 

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -26,14 +26,14 @@ $(TR $(TDNW Generating UUIDs)
           )
      )
 $(TR $(TDNW Using UUIDs)
-     $(TD $(MYREF2 UUID.uuidVersion, uuidVersion)
-          $(MYREF2 UUID.variant, variant)
-          $(MYREF2 UUID.toString, toString)
-          $(MYREF2 UUID.data, data)
-          $(MYREF2 UUID.swap, swap)
-          $(MYREF2 UUID.opEquals, opEquals)
-          $(MYREF2 UUID.opCmp, opCmp)
-          $(MYREF2 UUID.toHash, toHash)
+     $(TD [UUID.uuidVersion|uuidVersion]
+          [UUID.variant|variant]
+          [UUID.toString|toString]
+          [UUID.data|data]
+          [UUID.swap|swap]
+          [UUID.opEquals|opEquals]
+          [UUID.opCmp|opCmp]
+          [UUID.toHash|toHash]
           )
      )
 $(TR $(TDNW UUID namespaces)
@@ -72,19 +72,19 @@ $(TR $(TDNW UUID namespaces)
  * Use UUID's constructors or the UUID generator functions to get an initialized UUID.
  *
  * This is a port of $(LINK2 http://www.boost.org/doc/libs/1_42_0/libs/uuid/uuid.html,
- * boost._uuid) from the Boost project with some minor additions and API
+ * boost.uuid) from the Boost project with some minor additions and API
  * changes for a more D-like API.
  *
  * Standards:
  * $(LINK2 http://www.ietf.org/rfc/rfc4122.txt, RFC 4122)
  *
  * See_Also:
- * $(LINK http://en.wikipedia.org/wiki/Universally_unique_identifier)
+ * http://en.wikipedia.org/wiki/Universally_unique_identifier
  *
  * Copyright: Copyright Johannes Pfau 2011 - .
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Johannes Pfau
- * Source:    $(PHOBOSSRC std/_uuid.d)
+ * Source:    $(PHOBOSSRC std/uuid.d)
  *
  * Macros:
  * MYREF2 = <a href="#$2">$(TT $1)</a>&nbsp;

--- a/std/variant.d
+++ b/std/variant.d
@@ -721,7 +721,7 @@ public:
      * Returns $(D true) if and only if the $(D VariantN)
      * object holds an object implicitly convertible to type $(D
      * U). Implicit convertibility is defined as per
-     * $(LINK2 std_traits.html#ImplicitConversionTargets,ImplicitConversionTargets).
+     * $(XREF traits,ImplicitConversionTargets).
      */
 
     @property bool convertsTo(T)() const

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -17,40 +17,6 @@
  */
 module std.windows.charset;
 
-version (StdDdoc)
-{
-    /******************************************
-     * Converts the UTF-8 string s into a null-terminated string in a Windows
-     * 8-bit character set.
-     *
-     * Params:
-     * s = UTF-8 string to convert.
-     * codePage = is the number of the target codepage, or
-     *   0 - ANSI,
-     *   1 - OEM,
-     *   2 - Mac
-     *
-     * Authors:
-     *      yaneurao, Walter Bright, Stewart Gordon
-     */
-    const(char)* toMBSz(in char[] s, uint codePage = 0);
-
-    /**********************************************
-     * Converts the null-terminated string s from a Windows 8-bit character set
-     * into a UTF-8 char array.
-     *
-     * Params:
-     * s = UTF-8 string to convert.
-     * codePage = is the number of the source codepage, or
-     *   0 - ANSI,
-     *   1 - OEM,
-     *   2 - Mac
-     * Authors: Stewart Gordon, Walter Bright
-     */
-    string fromMBSz(immutable(char)* s, int codePage = 0);
-}
-else:
-
 version (Windows):
 
 private import std.conv;
@@ -60,7 +26,20 @@ private import std.utf;
 private import std.string;
 
 import std.internal.cstring;
-
+/******************************************
+ * Converts the UTF-8 string s into a null-terminated string in a Windows
+ * 8-bit character set.
+ *
+ * Params:
+ * s = UTF-8 string to convert.
+ * codePage = is the number of the target codepage, or
+ *   0 - ANSI,
+ *   1 - OEM,
+ *   2 - Mac
+ *
+ * Authors:
+ *      yaneurao, Walter Bright, Stewart Gordon
+ */
 const(char)* toMBSz(in char[] s, uint codePage = 0)
 {
     // Only need to do this if any chars have the high bit set
@@ -92,6 +71,18 @@ const(char)* toMBSz(in char[] s, uint codePage = 0)
     return std.string.toStringz(s);
 }
 
+/**********************************************
+ * Converts the null-terminated string s from a Windows 8-bit character set
+ * into a UTF-8 char array.
+ *
+ * Params:
+ * s = UTF-8 string to convert.
+ * codePage = is the number of the source codepage, or
+ *   0 - ANSI,
+ *   1 - OEM,
+ *   2 - Mac
+ * Authors: Stewart Gordon, Walter Bright
+ */
 string fromMBSz(immutable(char)* s, int codePage = 0)
 {
     const(char)* c;

--- a/std/xml.d
+++ b/std/xml.d
@@ -10,7 +10,7 @@ Classes and functions for creating and parsing XML
 The basic architecture of this module is that there are standalone functions,
 classes for constructing an XML document from scratch (Tag, Element and
 Document), and also classes for parsing a pre-existing XML file (ElementParser
-and DocumentParser). The parsing classes <i>may</i> be used to build a
+and DocumentParser). The parsing classes $(I may) be used to build a
 Document, but that is not their primary purpose. The handling capabilities of
 DocumentParser and ElementParser are sufficiently customizable that you can
 make them do pretty much whatever you want.

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -331,9 +331,15 @@ enum HeaderFormat {
     determineFromData /// used when decompressing. Try to automatically detect the stream format by looking at the data
 }
 
-/*********************************************
- * Used when the data to be compressed is not all in one buffer.
- */
+/++
+    Used when the data to be compressed is not all in one buffer.
+
+
+    $(PITFALL
+        This will keep a reference to the buffer you pass in to compress.
+	Do not overwrite it while the operation is in progress.
+    )
++/
 
 class Compress
 {
@@ -399,6 +405,11 @@ class Compress
      * Compress the data in buf and return the compressed data.
      * Params:
      *    buf = data to compress
+     *
+     * $(PITFALL
+     *     This will keep a reference to the buffer you pass in to compress.
+     *     Do not overwrite it while the operation is in progress.
+     * )
      *
      * Returns:
      *    the compressed data. The buffers returned from successive calls to this should be concatenated together.
@@ -510,6 +521,11 @@ class Compress
 
 /******
  * Used when the data to be decompressed is not all in one buffer.
+ *
+ * $(PITFALL
+ *     This will keep a reference to the buffer you pass in to compress.
+ *     Do not overwrite it while the operation is in progress.
+ * )
  */
 
 class UnCompress
@@ -564,6 +580,11 @@ class UnCompress
      * Decompress the data in buf and return the decompressed data.
      * The buffers returned from successive calls to this should be concatenated
      * together.
+     *
+     * $(PITFALL
+     *     This will keep a reference to the buffer you pass in to compress.
+     *     Do not overwrite it while the operation is in progress.
+     * )
      */
     const(void)[] uncompress(const(void)[] buf)
     in

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
- * Compress/decompress data using the $(WEB www._zlib.net, _zlib library).
+ * Compress/decompress data using the $(WEB www.zlib.net, zlib library).
  *
  * Examples:
  *
@@ -49,7 +49,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_zlib.d)
+ * Source:    $(PHOBOSSRC std/zlib.d)
  */
 /*          Copyright Digital Mars 2000 - 2011.
  * Distributed under the Boost Software License, Version 1.0.


### PR DESCRIPTION
As I go through building my ddoc killer, I'm noticing a lot of deficiencies in the doc sources, some big, some small.

std.algorithm.searching had a typo, for example, leading to a broken link. std.base64 had a LINK2 title with commas in it, leading to cut off text.

Several of them have LINK2 modules, which breaks anywhere except /phobos (even ddox has these broken links).

Many of the examples don't say what they are trying to do or don't show enough information to actually be useful.

Functions don't refer to each other when they obviously could (obvious to someone who knows Phobos already that is, the new reader would have no idea). In general, browsing Phobos docs, it is easy to lose the forest for the trees. There's few examples of how to integrate modules.

There's an anti-pattern of two macros always appearing together, like `$(M1 $(M2 ...))`. That's silly, if M1 should _always_ be applied to M2, just change M2's definition.

A great many FAQs in the support arena are not answered in the docs. I am adding a new section called "Diagnostics" with sample compiler error messages and showing how to fix them.

New users go to std.path to see what is in the current path, but that is actually in std.file. Let's have them link to each other.

Some functions create their own `$(RED Important:) ...` constructs. I propose changing them to be a well-defined semantic macro like `$(PITFALL)`.

In a few places, I also add a blank line. This should be irrelevant to phobos, but it gives my doc generator a natural place to insert a table of contents after a brief introduction. The first line in ddoc is supposed to be a summary. Some functions lack this. Some write it with the assumption that it will be read immediately preceding the rest of the comment, making them read nonsensically if extracted into said table of contents. I reword a few of these.

I rearranged the `toStringz` overloads to put the one with the simpler signature first. Then a user browsing down will see that simple one as the entry point and the other one as an alternative. A small thing that has a bigger source diff than it really is, but makes things a bit more readable for the first-time browser.

I have a lot more in store. I'm willing to compromise a little to maintain compatibility with ddoc while still getting content enhancements merged, though my main goal here is to make better docs.
