### PR TITLE
Update Phobos documentation to use new MREF macro

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -164,7 +164,7 @@ sort(a);                   // no predicate, "a < b" is implicit
 
 Macros:
 WIKI = Phobos/StdAlgorithm
-SUBMODULE = $(LINK2 std_algorithm_$1.html, std.algorithm.$1)
+SUBMODULE = $(MREF std, algorithm, $1)
 SUBREF = $(LINK2 std_algorithm_$1.html#.$2, $(TT $2))$(NBSP)
 
 Copyright: Andrei Alexandrescu 2008-.

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -9,7 +9,7 @@
     to non-ASCII characters.
 
     For functions which operate on Unicode characters, see
-    $(LINK2 std_uni.html, std.uni).
+    $(MREF std, uni).
 
     References:
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -861,7 +861,7 @@ public:
 
     /**
         $(D toString) is rarely directly invoked; the usual way of using it is via
-        $(LINK2 std_format.html#format, std.format.format):
+        $(REF format, std, format):
      */
     unittest
     {

--- a/std/complex.d
+++ b/std/complex.d
@@ -111,7 +111,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     instead, it is used via $(XREF string,format), as shown in the examples
     below.  Supported format characters are 'e', 'f', 'g', 'a', and 's'.
 
-    See the $(LINK2 std_format.html, std.format) and $(XREF string, format)
+    See the $(MREF std, format) and $(XREF string, format)
     documentation for more information.
     */
     string toString() const /* TODO: @safe pure nothrow */

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -2,7 +2,7 @@
 This module provides an $(D Array) type with deterministic memory usage not
 reliant on the GC, as an alternative to the built-in arrays.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_array.d)
 Macros:

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -2,7 +2,7 @@
 This module provides a $(D BinaryHeap) (aka priority queue)
 adaptor that makes a binary heap out of any user-provided random-access range.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
 Macros:

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -2,7 +2,7 @@
 This module implements a generic doubly-linked list container.
 It can be used as a queue, dequeue or stack.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_dlist.d)
 Macros:

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -103,30 +103,29 @@ This module consists of the following submodules:
 
 $(UL
     $(LI
-        The $(LINK2 std_container_array.html, std._container.array) module provides
-        an array type with deterministic control of memory, not reliant on
-        the GC unlike built-in arrays.
+        The $(MREF std, _container, array) module provides an array type with
+        deterministic control of memory, not reliant on the GC unlike built-in
+        arrays.
     )
     $(LI
-        The $(LINK2 std_container_binaryheap.html, std._container.binaryheap) module
-        provides a binary heap implementation that can be applied to any
-        user-provided random-access range.
+        The $(MREF std, _container, binaryheap) module provides a binary heap
+        implementation that can be applied to any user-provided random-access
+        range.
     )
     $(LI
-        The $(LINK2 std_container_dlist.html, std._container.dlist) module provides
-        a doubly-linked list implementation.
+        The $(MREF std, _container, dlist) module provides a doubly-linked list
+        implementation.
     )
     $(LI
-        The $(LINK2 std_container_rbtree.html, std._container.rbtree) module
-        implements red-black trees.
+        The $(MREF std, _container, rbtree) module implements red-black trees.
     )
     $(LI
-        The $(LINK2 std_container_slist.html, std._container.slist) module
-        implements singly-linked lists.
+        The $(MREF std, _container, slist) module implements singly-linked
+        lists.
     )
     $(LI
-        The $(LINK2 std_container_util.html, std._container.util) module contains
-        some generic tools commonly used by _container implementations.
+        The $(MREF std, _container, util) module contains some generic tools
+        commonly used by _container implementations.
     )
 )
 

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1,7 +1,7 @@
 /**
 This module implements a red-black tree container.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_rbtree.d)
 Macros:

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -2,7 +2,7 @@
 This module implements a singly-linked list container.
 It can be used as a stack.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_slist.d)
 Macros:

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -1,7 +1,7 @@
 /**
 This module contains some common utilities used by containers.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_util.d)
 Macros:

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -9,7 +9,7 @@ $(SCRIPT inhibitQuickIndex = 1;)
 
 Macros:
 WIKI = Phobos/StdDigestHMAC
-SUBMODULE = $(LINK2 std_digest_$1.html, std.digest.$1)
+SUBMODULE = $(MREF std, digest, $1)
 SUBREF = $(LINK2 std_digest_$1.html#.$2, $(TT $2))$(NBSP)
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -1,7 +1,7 @@
 /**
 $(SCRIPT inhibitQuickIndex = 1;)
 
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 Operators only change strides and lengths of a slice.
 The range of a slice remains unmodified.
@@ -85,7 +85,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_iteration.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
 SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -294,7 +294,7 @@ Acknowledgements:   John Loughran Colvin
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_package.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
 SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -1,7 +1,7 @@
 /**
 $(SCRIPT inhibitQuickIndex = 1;)
 
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 Selectors create new views and iteration patterns over the same data, without copying.
 
@@ -46,7 +46,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_selection.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
 SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1,5 +1,5 @@
 /**
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
@@ -8,7 +8,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_slice.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
 SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
@@ -335,7 +335,7 @@ pure nothrow unittest
 
 /++
 Allocates an array through a specified allocator and creates an n-dimensional slice over it.
-See also $(LINK2 std_experimental_allocator.html, std.experimental.allocator).
+See also $(MREF std, experimental, allocator).
 +/
 unittest
 {

--- a/std/file.d
+++ b/std/file.d
@@ -4,17 +4,16 @@
 Utilities for manipulating files and scanning directories. Functions
 in this module handle files as a unit, e.g., read or write one _file
 at a time. For opening files and manipulating them via handles refer
-to module $(LINK2 std_stdio.html,$(D std.stdio)).
+to module $(MREF std, stdio).
 
 Macros:
 WIKI = Phobos/StdFile
 
 Copyright: Copyright Digital Mars 2007 - 2011.
 See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
-introduction to working with files in D, module
-$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them
-via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating
-path strings.
+introduction to working with files in D, module  $(MREF std, stdio) for opening
+files and manipulating them via handles, and module $(MREF std, path) for
+manipulating path strings.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),

--- a/std/format.d
+++ b/std/format.d
@@ -39,8 +39,8 @@ $(TR $(TH Function Name) $(TH Description)
     ))
 )
 
-   These two functions are publicly imported by $(LINK2 std_string.html,
-   std.string) to be easily available.
+   These two functions are publicly imported by $(MREF std, string) to be
+   easily available.
 
    The functions $(D $(LREF formatValue)) and $(D $(LREF unformatValue)) are
    used for the plumbing.

--- a/std/functional.d
+++ b/std/functional.d
@@ -5,8 +5,7 @@ Functions that manipulate other functions.
 
 This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
-$(LINK2 std_algorithm.html, std.algorithm) or $(LINK2 std_range.html,
-std.range).
+$(MREF std, algorithm) or $(MREF std, range).
 
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -1,5 +1,5 @@
 /**
-This module is a submodule of $(LINK2 std_range.html, std.range).
+This module is a submodule of $(MREF std, range).
 
 The main $(D std.range) module provides template-based tools for working with
 ranges, but sometimes an object-based interface for ranges is needed, such as

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -20,14 +20,13 @@ Submodules:
 
 This module has two submodules:
 
-The $(LINK2 std_range_primitives.html, $(D std._range.primitives)) submodule
-provides basic _range functionality. It defines several templates for testing
-whether a given object is a _range, what kind of _range it is, and provides
-some common _range operations.
+The $(MREF std, _range, primitives) submodule provides basic _range
+functionality. It defines several templates for testing whether a given object
+is a _range, what kind of _range it is, and provides some common _range
+operations.
 
-The $(LINK2 std_range_interfaces.html, $(D std._range.interfaces)) submodule
-provides object-based interfaces for working with ranges via runtime
-polymorphism.
+The $(MREF std, _range, interfaces) submodule provides object-based interfaces
+for working with ranges via runtime polymorphism.
 
 The remainder of this module provides a rich set of _range creation and
 composition templates that let you construct new ranges out of existing ranges:

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1,5 +1,5 @@
 /**
-This module is a submodule of $(LINK2 std_range.html, std.range).
+This module is a submodule of $(MREF std, range).
 
 It provides basic range functionality by defining several templates for testing
 whether a given object is a _range, and what kind of _range it is:

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -31,7 +31,7 @@
  *      See $(SAMPLESRC htmlget.d)
  * Authors: Christopher E. Miller
  * References:
- *      $(LINK2 std_stream.html, std.stream)
+ *      $(MREF std, stream)
  * Source:    $(PHOBOSSRC std/_socketstream.d)
  * Macros: WIKI=Phobos/StdSocketstream
  */

--- a/std/string.d
+++ b/std/string.d
@@ -116,22 +116,15 @@ $(LEADINGROW Publicly imported functions)
 )
 
 There is a rich set of functions for _string handling defined in other modules.
-Functions related to Unicode and ASCII are found in $(LINK2 std_uni.html, std.uni)
-and $(LINK2 std_ascii.html, std.ascii), respectively. Other functions that have a
-wider generality than just strings can be found in $(LINK2 std_algorithm.html,
-std.algorithm) and $(LINK2 std_range.html, std.range).
+Functions related to Unicode and ASCII are found in $(MREF std, uni) and
+$(MREF std, ascii), respectively. Other functions that have a wider generality
+than just strings can be found in $(MREF std, algorithm) and $(MREF std, range).
 
 See_Also:
     $(LIST
-    $(LINK2 std_algorithm.html, std.algorithm) and
-    $(LINK2 std_range.html, std.range)
-    for generic range algorithms
-    ,
-    $(LINK2 std_ascii.html, std.ascii)
-    for functions that work with ASCII strings
-    ,
-    $(LINK2 std_uni.html, std.uni)
-    for functions that work with unicode strings
+    $(MREF std, algorithm) and $(MREF std, range) for generic range algorithms,
+    $(MREF std, ascii) for functions that work with ASCII strings,
+    $(MREF std, uni) for functions that work with unicode strings
     )
 
 Macros: WIKI = Phobos/StdString
@@ -5459,7 +5452,7 @@ S squeeze(S)(S s, in S pattern = null)
 /***************************************************************
  Finds the position $(D_PARAM pos) of the first character in $(D_PARAM
  s) that does not match $(D_PARAM pattern) (in the terminology used by
- $(LINK2 std_string.html,inPattern)). Updates $(D_PARAM s =
+ $(XREF string, inPattern)). Updates $(D_PARAM s =
  s[pos..$]). Returns the slice from the beginning of the original
  (before update) string up to, and excluding, $(D_PARAM pos).
 

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -1,6 +1,6 @@
 /**
  * This module was renamed to disambiguate the term tuple, use
- * $(LINK2 std_meta.html, std.meta) instead.
+ * $(MREF std, meta) instead.
  *
  * Copyright: Copyright Digital Mars 2005 - 2015.
  * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/uni.d
+++ b/std/uni.d
@@ -9,7 +9,7 @@
 
     $(P All primitives listed operate on Unicode characters and
     sets of characters. For functions which operate on ASCII characters
-    and ignore Unicode $(CHARACTERS), see $(LINK2 std_ascii.html, std.ascii).
+    and ignore Unicode $(CHARACTERS), see $(MREF std, ascii).
     For definitions of Unicode $(CHARACTER), $(CODEPOINT) and other terms
     used throughout this module see the $(S_LINK Terminology, terminology) section
     below.


### PR DESCRIPTION
`MREF` was introduced in D-Programming-Language/dlang.org/pull/1177. `MREF` fixes module links for DDox and other doc engines (and looks nicer on the page).