### PR TITLE
Issue 15621 - std.file.rename does not allow moving files to a different drive

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -634,7 +634,7 @@ private void renameImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, 
 {
     version(Windows)
     {
-        auto result = MoveFileExW(fromz, toz, MOVEFILE_REPLACE_EXISTING);
+        auto result = MoveFileExW(fromz, toz, MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED);
         if (!result)
         {
             import core.stdc.wchar_ : wcslen;


### PR DESCRIPTION
I don't think it's possible to unittest this without making excessive assumptions.

https://issues.dlang.org/show_bug.cgi?id=15621
