### PR TITLE
Allow affix access from qualified data

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3934,7 +3934,6 @@ the type we want to build. This helps to build qualified objects on mutable
 buffer, without breaking the type system with unsafe casts.
 +/
 package void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
-if (is(UT == Unqual!T))
 {
     static if (args.length == 0)
     {
@@ -4085,6 +4084,13 @@ unittest
     int a;
     int b = 42;
     assert(*emplace!int(&a, b) == 42);
+}
+
+unittest
+{
+    shared int i;
+    emplace(&i, 42);
+    assert(i == 42);
 }
 
 private void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment, string typeName) @nogc pure nothrow

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -184,21 +184,40 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         mixin(forwardToMember("parent",
             "deallocateAll", "empty"));
 
+        // Computes suffix type given buffer type
+        private template Payload2Affix(Payload, Affix)
+        {
+            static if (is(Payload[] : void[]))
+                alias Payload2Affix = Affix;
+            else static if (is(Payload[] : shared(void)[]))
+                alias Payload2Affix = shared Affix;
+            else static if (is(Payload[] : immutable(void)[]))
+                alias Payload2Affix = shared Affix;
+            else static if (is(Payload[] : const(shared(void))[]))
+                alias Payload2Affix = shared Affix;
+            else static if (is(Payload[] : const(void)[]))
+                alias Payload2Affix = const Affix;
+            else
+                static assert(0, "Internal error for type " ~ Payload.stringof);
+        }
+
         // Extra functions
         static if (stateSize!Prefix)
-            static ref Prefix prefix(void[] b)
+        {
+            static auto ref prefix(T)(T[] b)
             {
                 assert(b.ptr && b.ptr.alignedAt(Prefix.alignof));
-                return (cast(Prefix*)b.ptr)[-1];
+                return (cast(Payload2Affix!(T, Prefix)*) b.ptr)[-1];
             }
+        }
         static if (stateSize!Suffix)
-            ref Suffix suffix(void[] b)
+            auto ref suffix(T)(T[] b)
             {
                 assert(b.ptr);
                 auto p = b.ptr - stateSize!Prefix
                     + actualAllocationSize(b.length);
                 assert(p && p.alignedAt(Suffix.alignof));
-                return (cast(Suffix*) p)[-1];
+                return (cast(Payload2Affix!(T, Suffix)*) p)[-1];
             }
     }
 
@@ -227,18 +246,59 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         Ternary empty();
 
         /**
-        The `instance` singleton is defined if and only if the parent allocator has no state and defines its own `it` object.
+        The `instance` singleton is defined if and only if the parent allocator
+        has no state and defines its own `it` object.
         */
         static AffixAllocator instance;
 
         /**
-        Affix access functions offering mutable references to the affixes of a block previously allocated with this allocator. $(D b) may not be null. They are defined if and only if the corresponding affix is not $(D void).
+        Affix access functions offering references to the affixes of a
+        block `b` previously allocated with this allocator. `b` may not be null.
+        They are defined if and only if the corresponding affix is not `void`.
 
-        Precondition: $(D b !is null)
+        The qualifiers of the affix are not always the same as the qualifiers
+        of the argument. This is because the affixes are not part of the data
+        itself, but instead are just $(I associated) with the data and known
+        to the allocator. The table below documents the type of `preffix(b)` and
+        `affix(b)` depending on the type of `b`.
+
+        $(BOOKTABLE Result of `prefix`/`suffix` depending on argument (`U` is
+        any unqualified type, `Affix` is `Prefix` or `Suffix`),
+            $(TR $(TH Argument$(NBSP)Type) $(TH Return) $(TH Comments))
+
+            $(TR $(TD `shared(U)[]`) $(TD `ref shared Affix`)
+            $(TD Data is shared across threads and the affix follows suit.))
+
+            $(TR $(TD `immutable(U)[]`) $(TD `ref shared Affix`)
+            $(TD Although the data is immutable, the allocator "knows" the
+            underlying memory is mutable, so `immutable` is elided for the affix
+            which is independent from the data itself. However, the result is
+            `shared` because `immutable` is implicitly shareable so multiple
+            threads may access and manipulate the affix for the same data.))
+
+            $(TR $(TD `const(shared(U))[]`) $(TD `ref shared Affix`)
+            $(TD The data is always shareable across threads. Even if the data
+            is `const`, the affix is modifiable by the same reasoning as for
+            `immutable`.))
+
+            $(TR $(TD `const(U)[]`) $(TD `ref const Affix`)
+            $(TD The input may have originated from `U[]` or `immutable(U)[]`,
+            so it may be actually shared or not. Returning an unqualified affix
+            may result in race conditions, whereas returning a `shared` affix
+            may result in inadvertent sharing of mutable thread-local data
+            across multiple threads. So the returned type is conservatively
+            `ref const`.))
+
+            $(TR $(TD `U[]`) $(TD `ref Affix`)
+            $(TD Unqualified data has unqualified affixes.))
+        )
+
+        Precondition: `b !is null` and `b` must have been allocated with
+        this allocator.
         */
-        static ref Prefix prefix(void[] b);
+        static ref auto prefix(T)(T[] b);
         /// Ditto
-        static ref Suffix suffix(void[] b);
+        ref auto suffix(T)(T[] b);
     }
     else static if (is(typeof(Allocator.instance) == shared))
     {
@@ -291,4 +351,21 @@ unittest
     alias B = AffixAllocator!(NullAllocator, size_t);
     b = B.instance.allocate(100);
     assert(b is null);
+}
+
+unittest
+{
+    import std.experimental.allocator.gc_allocator;
+    import std.experimental.allocator;
+    alias AffixAllocator!(GCAllocator, uint) MyAllocator;
+    auto a = MyAllocator.instance.makeArray!(shared int)(100);
+    static assert(is(typeof(&MyAllocator.instance.prefix(a)) == shared(uint)*));
+    auto b = MyAllocator.instance.makeArray!(shared const int)(100);
+    static assert(is(typeof(&MyAllocator.instance.prefix(b)) == shared(uint)*));
+    auto c = MyAllocator.instance.makeArray!(immutable int)(100);
+    static assert(is(typeof(&MyAllocator.instance.prefix(c)) == shared(uint)*));
+    auto d = MyAllocator.instance.makeArray!(int)(100);
+    static assert(is(typeof(&MyAllocator.instance.prefix(d)) == uint*));
+    auto e = MyAllocator.instance.makeArray!(const int)(100);
+    static assert(is(typeof(&MyAllocator.instance.prefix(e)) == const(uint)*));
 }

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -409,7 +409,7 @@ unittest
 Returns `true` if `ptr` is aligned at `alignment`.
 */
 @nogc nothrow pure
-package bool alignedAt(void* ptr, uint alignment)
+package bool alignedAt(T)(T* ptr, uint alignment)
 {
     return cast(size_t) ptr % alignment == 0;
 }


### PR DESCRIPTION
This PR is the first step toward implementing an idea by @Dicebot: use the allocator for storing metadata about objects (in particular reference counts).

An `AffixAllocator` offers systematic metadata storage before/after an allocation. Even if that allocation is later used to store `immutable` data, the allocator is able to return the affix as `shared` without violating the type system.

If data is unqualified/mutable, there is no burden of proof needed at all - just return the mutable affix.