### PR TITLE
Fix issue 14137: std.socket.getAddressInfo breaks @safe

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -945,7 +945,7 @@ private string formatGaiError(int err) @trusted
  *     AddressFamily.INET6);
  * ---
  */
-AddressInfo[] getAddressInfo(T...)(in char[] node, T options) @trusted
+AddressInfo[] getAddressInfo(T...)(in char[] node, T options)
 {
     const(char)[] service = null;
     addrinfo hints;
@@ -971,7 +971,23 @@ AddressInfo[] getAddressInfo(T...)(in char[] node, T options) @trusted
             static assert(0, "Unknown getAddressInfo option type: " ~ typeof(option).stringof);
     }
 
-    return getAddressInfoImpl(node, service, &hints);
+    return () @trusted { return getAddressInfoImpl(node, service, &hints); }();
+}
+
+@system unittest
+{
+    struct Oops
+    {
+        const(char[]) breakSafety()
+        {
+            *cast(int*) 0xcafebabe = 0xdeadbeef;
+            return null;
+        }
+        alias breakSafety this;
+    }
+    assert(!__traits(compiles, () {
+        getAddressInfo("", Oops.init);
+    }), "getAddressInfo breaks @safe");
 }
 
 private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addrinfo* hints) @system
@@ -1009,7 +1025,7 @@ private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addr
 }
 
 
-unittest
+@safe unittest
 {
     softUnittest({
         if (getaddrinfoPointer)


### PR DESCRIPTION
Remove abuse of `@trusted` in template function `getAddressInfo` that cannot guarantee that the incoming type argument `T` is actually `@safe`. Localize `@trusted` to the single call to `getAddressInfoImpl`, so that any `@system` code in `T` will be caught by the type system.

Add unittest to ensure such examples of `T` will be rejected at compile-time.

Mark normal unittest for `getAddressInfo` as `@safe` to ensure that the function body itself does not introduce any non-`@safe` code.

The rest of this module has frightening amounts of `@trusted` functions, which need to be properly vetted (and probably the scope of `@trusted` reduced), but let's leave that for another battle.