### PR TITLE
Add shift(): wrapper for front and popFront

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -85,6 +85,12 @@ $(BOOKTABLE ,
         $(TD Advances a given bidirectional _range from the right by exactly
         $(I n) elements.
     ))
+    $(TR $(TD $(D $(LREF shift)))
+        $(TD Pops the first element from $(D r) and returns it.
+    ))
+    $(TR $(TD $(D $(LREF shiftBack)))
+        $(TD Pops the last element from $(D r) and returns it.
+    ))
     $(TR $(TD $(D $(LREF moveFront)))
         $(TD Removes the front element of a _range.
     ))
@@ -1986,6 +1992,156 @@ ElementType!R moveAt(R)(R r, size_t i)
             assert(moveAt(d, 2) == 3);
         }
     }
+}
+
+private enum int hasNothrowPopFront(Range) = (functionAttributes!(popFrontN!Range)
+                                               & FunctionAttribute.nothrow_);
+
+/**
+Pops the first element from a range or array $(D r) and returns it.
+It combines $(D front) and $(D popFront) in one method.
+
+Params:
+    r = range to consume the first element from
+
+Warning:
+    If a transient range is used, you should `dup`licate it to avoid it from
+    being overwritten.
+    Using shift with `popFront` that might `throw` could lead to a loss of the
+    `front` element and thus it is prohibited.
+
+Returns:
+    Next element of the input range
+ */
+auto shift(Range)(ref Range r)
+if (isInputRange!Range && hasNothrowPopFront!Range)
+in
+{
+    assert(!r.empty, "empty range");
+}
+body
+{
+    auto e = r.front;
+    r.popFront();
+    return e;
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    int[3] arr = [1, 2, 3];
+    int[] r = arr;
+    assert(r.shift == 1);
+
+    static immutable result = [2, 3];
+    assert(r == result);
+    assert(r.shift == 2);
+    assert(r.shift == 3);
+    assert(r.empty);
+
+    import std.algorithm.comparison: equal;
+    import std.range: iota;
+    // original array stays unmodified
+    assert(arr[].equal(iota(1, 4)));
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.range : iota;
+    auto r = iota(1, 3);
+    assert(r.shift == 1);
+    assert(r.shift == 2);
+    assert(r.empty);
+}
+
+unittest
+{
+    struct ThrowingRange
+    {
+        bool empty = false;
+        int[] front = [0];
+        void popFront(){}
+    }
+
+    ThrowingRange tRange;
+    assert(tRange.front == [0]);
+    // if popFront might throw, shift shouldn't be possible
+    static assert(!__traits(compiles, tRange.shift));
+}
+
+private enum int hasNothrowPopBack(Range) = (functionAttributes!(popBackN!Range)
+                                               & FunctionAttribute.nothrow_);
+
+/**
+Pops the last element from a range or array $(D r) and returns it.
+It combines $(D back) and $(D popBack) in one method.
+
+Params:
+    r = Bidirectional range or array to consume the last element from
+
+Warning:
+    If a transient range is used, you should `dup`licate it to avoid it from
+    being overwritten.
+    Using shift with `popFront` that might `throw` could lead to a loss of the
+    `front` element and thus it is prohibited.
+
+Returns:
+    Last element of the bidirectional range
+ */
+auto shiftBack(Range)(ref Range r)
+if (isBidirectionalRange!Range && hasNothrowPopBack!Range)
+in
+{
+    assert(!r.empty, "empty range");
+}
+body
+{
+    auto e = r.back;
+    r.popBack();
+    return e;
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    int[3] arr = [1, 2, 3];
+    int[] r = arr;
+    assert(r.shiftBack == 3);
+
+    static immutable result = [1, 2];
+    assert(r == result);
+    assert(r.shiftBack == 2);
+    assert(r.shiftBack == 1);
+    assert(r.empty);
+
+    import std.algorithm.comparison: equal;
+    import std.range: iota;
+    // original array stays unmodified
+    assert(arr[].equal(iota(1, 4)));
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.range : iota;
+    auto r = iota(1, 3);
+    assert(r.shiftBack == 2);
+    assert(r.shiftBack == 1);
+    assert(r.empty);
+}
+
+unittest
+{
+    struct ThrowingRange
+    {
+        bool empty = false;
+        int[] front = [0];
+        void popBack(){}
+    }
+
+    ThrowingRange tRange;
+    assert(tRange.front == [0]);
+    // if popBack might throw, shiftBack shouldn't be possible
+    static assert(!__traits(compiles, tRange.shiftBack));
 }
 
 /**


### PR DESCRIPTION
Hey all, 

I am quite new to D and I was wondering why there is no convenience wrapper which combines `front` and `popFront`. I know there is `takeOne` (which doesn't modify the source) and `dropOne` (which will return the resulting array after dropping one element).

I think the best example of such a method in other languages is the `next` method in [Python](https://docs.python.org/3/library/functions.html#next), thus the naming. However feel free to suggest other names. Other ideas would be `shift`, `takeFirst`, `removeFirst`, `shiftFirst`.
If it makes sense to you I am happy to add the opposite method (`takeLast`,`removeLast`,`shiftLast`).

Pros:
- syntactic sugar (see below for an example)
- supported natively in [most](http://rosettacode.org/wiki/Queue/Usage) languages
- I learned stack syntax with return at university (it's even on [wikipedia](https://en.wikipedia.org/wiki/Stack_(abstract_data_type))

```d
auto myFile = ["<crazy header>","1","2"];
// cut off the header
myFile.next.writeln;
// do sth with the body
myFile.map!(to!int).map!"a + 1".map!(to!string).joiner(",").writeln;
```

Cons:
- yet another method
- possible side effects?

As mentioned above I am just starting with D, so let me know if there is a better way to write this PR or you would add more checks (afaik `front` and `popFront` will throw an Assertion Error if the range is empty, so this behavior should be induced).

I initially asked this question at the DLang forum, which lead me to submit this PR.
https://forum.dlang.org/post/orcjkabkcffueduqkyml@forum.dlang.org