### PR TITLE
Allow a generic function for std.variant.visit.

### DIFF
--- a/changelog/std-variant-genericfunc.dd
+++ b/changelog/std-variant-genericfunc.dd
@@ -1,0 +1,23 @@
+Allow a generic function for std.variant.visit.
+
+If a lambda with a single generic parameter is provided as a handler
+to std.variant.visit, it is invoked for any type contained in the
+Algebraic which does not have a handler for that type.
+
+This allows something like:
+
+-------
+// Assume Circle, Square, and Triangle all define center()
+Algebraic!(Circle, Square, Triangle) someShape;
+auto center = someShape.visit!(x => x.center);
+-------
+
+This may be combined with explicitly typed handlers and a single
+fallback handler for an empty variant:
+
+-------
+Algebraic!(int, float, string) something;
+something.visit!((string s) => s.length, // called for string
+                 x          => x,        // called for int/float
+                 ()         => 0);       // called if empty
+-------


### PR DESCRIPTION
If a lambda with a single generic parameter is provided as a handler
to std.variant.visit, it is invoked for any type contained in the
Algebraic which does not have a handler for that type.

This allows something like:

```
// Assume Circle, Square, and Triangle all define center()
Algebraic!(Circle, Square, Triangle) someShape;
auto center = someShape.visit!(x => x.center);
```

This may be combined with explicitly typed handlers and a single
fallback handler for an empty variant:

```
Algebraic!(int, float, string) something;
something.visit!((string s) => s.length, // called for string
                 x          => x,        // called for int/float
                 ()         => 0);       // called if empty
```
