### PR TITLE
Fix issue 10777 - multiSort returns SortedRange

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7980,6 +7980,13 @@ sorting relation.
         import std.algorithm.iteration : chunkBy;
         return _input.chunkBy!((a, b) => !predFun(a, b) && !predFun(b, a));
     }
+
+    import std.algorithm.sorting: MultiPred;
+
+    static if( is( pred == MultiPred!P, P... ) )
+    auto shrinkPred( uint n )() {
+      return assumeSorted!( pred.shrink!n )( this );
+    }
 }
 
 ///


### PR DESCRIPTION
multiSort!( preds... ) returns SortedRange!( MultiPred!( preds ) ).

MultiPred!( preds... ) combines multiple predicates.
A proposed shrink function allows predicate reduction (a range sorted to preds[1..N] is also sorted to preds[1..(N-1)]).

https://issues.dlang.org/show_bug.cgi?id=10777
