### PR TITLE
Most of std.encoding is now @safe.

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2064,8 +2064,6 @@ unittest
  Standards: Unicode 5.0, ASCII, ISO-8859-1, ISO-8859-2, WINDOWS-1250,
  WINDOWS-1252
 
- Deprecated: 
-
  Params:
     c = the code point to be encoded
  */

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2140,7 +2140,7 @@ body
 
         Appender!(immutable(Dst)[]) array;
         array.reserve(s.length);
-        Dst[] buffer = new Dst[minReservePlace];
+        Dst[minReservePlace] buffer;
         const(Src)[] t = s;
 
         while (t.length != 0)

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -614,6 +614,7 @@ struct CodePoints(E)
 }
 
 deprecated("use encode!E(dchar) and const(E[]) instead")
+// This will be removed in March 2017.
 struct CodeUnits(E)
 {
     E[] s;
@@ -2069,6 +2070,7 @@ unittest
     c = the code point to be encoded
  */
 deprecated("use encode instead")
+// This will be removed in March 2017.
 CodeUnits!E codeUnits(E)(dchar c) @safe
 in
 {
@@ -2091,11 +2093,6 @@ unittest
     assert(a[0] == 0xE2);
     assert(a[1] == 0x82);
     assert(a[2] == 0xAC);
-}
-
-private void transcode(Src : AsciiChar, Dst)(immutable(Src)[] s, out immutable(Dst)[] r) @trusted  // @@@BUG@@@ 15762
-{
-    return transcode!(char, Dst)(cast(string)s, r);
 }
 
 /**
@@ -2128,10 +2125,6 @@ body
     {
         r = s;
     }
-    else static if(is(Src==AsciiChar))
-    {
-        transcodeFromAscii(s, r);
-    }
     else
     {
         static if(is(Dst == wchar))
@@ -2163,6 +2156,11 @@ body
         r = array.data;
     }
 }
+void transcode(Src : AsciiChar, Dst)(immutable(Src)[] s, out immutable(Dst)[] r) @trusted  // @@@BUG@@@ 15762
+{
+    return transcode!(char, Dst)(cast(string)s, r);
+}
+
 
 ///
 unittest


### PR DESCRIPTION
Due to https://issues.dlang.org/show_bug.cgi?id=15762 , a lot of small functions are @trusted. Specifically, std.encoding uses an 'enum : ubyte' pattern, and casts between const enum arrays and value types are not allowed in @safe code for no discernible reason.

Several templates are not marked @safe or @trusted so @safe can be inferred as appropriate.