### PR TITLE
fix Issue 15803 - std.file should support sub-second file time precision on POSIX

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -127,6 +127,7 @@ else version(Posix)
 {
     import core.sys.posix.stdlib;
     import core.sys.posix.sys.time;
+    import core.sys.posix.signal : timespec;
 }
 
 version(unittest)
@@ -2661,6 +2662,50 @@ public:
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 58), usecs(17), UTC()).toTimeVal() == timeval(-1, -999_983));
     }
 
+
+    version(StdDdoc)
+    {
+        private struct timespec {}
+        /++
+            Returns a $(D timespec) which represents this $(LREF SysTime).
+
+            $(BLUE This function is Posix-Only.)
+          +/
+        timespec toTimeSpec() @safe const pure nothrow;
+    }
+    else
+    version(Posix)
+    {
+        timespec toTimeSpec() @safe const pure nothrow
+        {
+            immutable tv_sec = toUnixTime!(typeof(timespec.tv_sec))();
+            immutable fracHNSecs = removeUnitsFromHNSecs!"seconds"(_stdTime - 621_355_968_000_000_000L);
+            immutable tv_nsec = cast(typeof(timespec.tv_nsec))convert!("hnsecs", "nsecs")(fracHNSecs);
+            return timespec(tv_sec, tv_nsec);
+        }
+
+        unittest
+        {
+            assert(SysTime(DateTime(1970, 1, 1), UTC()).toTimeSpec() == timespec(0, 0));
+            assert(SysTime(DateTime(1970, 1, 1), hnsecs(9), UTC()).toTimeSpec() == timespec(0, 900));
+            assert(SysTime(DateTime(1970, 1, 1), hnsecs(10), UTC()).toTimeSpec() == timespec(0, 1000));
+            assert(SysTime(DateTime(1970, 1, 1), usecs(7), UTC()).toTimeSpec() == timespec(0, 7000));
+
+            assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), UTC()).toTimeSpec() == timespec(1, 0));
+            assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), hnsecs(9), UTC()).toTimeSpec() == timespec(1, 900));
+            assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), hnsecs(10), UTC()).toTimeSpec() == timespec(1, 1000));
+            assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), usecs(7), UTC()).toTimeSpec() == timespec(1, 7000));
+
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), hnsecs(9_999_999), UTC()).toTimeSpec() == timespec(0, -100));
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), hnsecs(9_999_990), UTC()).toTimeSpec() == timespec(0, -1000));
+
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), usecs(999_999), UTC()).toTimeSpec() == timespec(0, -1_000));
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), usecs(999), UTC()).toTimeSpec() == timespec(0, -999_001_000));
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), msecs(999), UTC()).toTimeSpec() == timespec(0, -1_000_000));
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), UTC()).toTimeSpec() == timespec(-1, 0));
+            assert(SysTime(DateTime(1969, 12, 31, 23, 59, 58), usecs(17), UTC()).toTimeSpec() == timespec(-1, -999_983_000));
+        }
+    }
 
     /++
         Returns a $(D tm) which represents this $(LREF SysTime).
@@ -27436,7 +27481,7 @@ public:
     }
 
     unittest
-{
+    {
         assert(LocalTime().stdName !is null);
 
         version(Posix)
@@ -27507,7 +27552,7 @@ public:
     }
 
     unittest
-{
+    {
         assert(LocalTime().dstName !is null);
 
         version(Posix)
@@ -27573,7 +27618,7 @@ public:
     }
 
     unittest
-{
+    {
         LocalTime().hasDST;
 
         version(Posix)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15803

~~Needs https://github.com/D-Programming-Language/druntime/pull/1513~~