### PR TITLE
Better static array support in std.array

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -403,14 +403,17 @@ if (isIterable!Iterable)
     assert(arr == [ 5, 5, 5, 5 ]);
 }
 
-/// `staticArray!n` will fail if given a range with more than `n` elements
-@safe pure nothrow unittest
+/// `staticArray!n` will fail if given a range with less than `n` elements
+pure unittest
 {
-    import std.range : only, chain;
-    // int[5] arr = only(1,2,3).staticArray!5; -- this will fail!
+    import std.range : only, chain, repeat;
+    import std.exception : assertThrown;
+    import core.exception : AssertError;
+
+    assertThrown!AssertError(only(1,2,3).staticArray!5);
 
     // extend the range to the desired length before handing it to staticArray
-    int[5] arr = only(1,2,3).chain(only(0, 0)).staticArray!5;
+    int[5] arr = only(1,2,3).chain(0.repeat).staticArray!5;
     assert(arr == [ 1, 2, 3, 0, 0 ]);
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -335,12 +335,9 @@ unittest
 }
 
 /**
- * Initializes a static array of the given size from the range `r`.
+ * Initializes a static array from the first `n` elements of the range `r`.
  *
- * If `r` has less than `n` elements, only the first `n` are copied, and the
- * remaining elements are default-initialized.
- *
- * A range violation will occur if `r` has more than `n` elements.
+ * Preconditions: `r` has at least `n` elements.
  *
  * Params:
  *      r = range (or aggregate with $(D opApply) function) whose elements are

--- a/std/array.d
+++ b/std/array.d
@@ -448,6 +448,7 @@ unittest
  */
 T[n] staticArray(T, size_t n)(T[n] arr)
 {
+    pragma(inline, true);
     return arr;
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -391,8 +391,7 @@ if (isIterable!Iterable)
 @safe pure nothrow unittest
 {
     import std.range : only;
-    auto arr = only(1, 2, 3).staticArray!3;
-    static assert(is(typeof(arr) == int[3]));
+    int[3] arr = only(1, 2, 3).staticArray!3;
     assert(arr == [ 1, 2, 3 ]);
 }
 
@@ -400,8 +399,7 @@ if (isIterable!Iterable)
 @safe pure nothrow unittest
 {
     import std.range : take, repeat;
-    auto arr = repeat(5).staticArray!4;
-    static assert(is(typeof(arr) == int[4]));
+    int[4] arr = repeat(5).staticArray!4;
     assert(arr == [ 5, 5, 5, 5 ]);
 }
 
@@ -415,7 +413,7 @@ pure unittest
     assertThrown!AssertError(only(1,2,3).staticArray!5);
 
     // extend the range to the desired length before handing it to staticArray
-    auto arr = only(1,2,3).chain(0.repeat).staticArray!5;
+    int[5] arr = only(1,2,3).chain(0.repeat).staticArray!5;
     assert(arr == [ 1, 2, 3, 0, 0 ]);
 }
 
@@ -437,8 +435,7 @@ unittest
         }
     }
 
-    auto arr = OpApply().staticArray!5;
-    static assert(is(typeof(arr) == int[5]));
+    int[5] arr = OpApply().staticArray!5;
     assert(arr == [ 0, 1, 2, 3, 4 ]);
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -351,9 +351,9 @@ unittest
  * ---
  * See $(LINK2 http://issues.dlang.org/show_bug.cgi?id=12625, Issue 12625).
  */
+pragma(inline, true)
 @nogc T[n] staticArray(T, size_t n)(T[n] arr)
 {
-    pragma(inline, true);
     return arr;
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -444,7 +444,7 @@ unittest
  *
  * Returns: static array of size `arr.length`
  */
-T[n] staticArray(T, size_t n)(T[n] arr)
+@nogc T[n] staticArray(T, size_t n)(T[n] arr)
 {
     pragma(inline, true);
     return arr;

--- a/std/array.d
+++ b/std/array.d
@@ -350,7 +350,7 @@ unittest
  *      A static array of size `n` initialized from `r`
  */
 ForeachType!Iterable[n] staticArray(size_t n, Iterable)(Iterable r)
-if (isIterable!Iterable)
+if (isIterable!Iterable && !isInfinite!Iterable)
 {
     import std.conv : emplaceRef;
 

--- a/std/array.d
+++ b/std/array.d
@@ -458,6 +458,14 @@ T[n] staticArray(T, size_t n)(T[n] arr)
     auto arr = [1,2,3,4].staticArray;         // no need to declare size
     static assert(is(typeof(arr) == int[4])); // i is a static array
     assert(arr == [1,2,3,4]);
+
+    version(Bug)
+    {
+        // Note that you should _not_ assign staticArray to a dynamic array.
+        // `invalid` will point to memory in an expiring stack.
+        // In general, assign to `auto` as shown above.
+        int[] invalid = [1,2,3,4].staticArray;
+    }
 }
 
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -364,7 +364,7 @@ if (isIterable!Iterable)
     static if (isInputRange!Iterable)
     {
         // we cannot foreach over r, it may have too many elements
-        foreach(i; 0..n)
+        foreach (i; 0..n)
         {
             assert(!r.empty, "r had less than n elements");
             emplaceRef!E(result[i], r.front);
@@ -375,7 +375,7 @@ if (isIterable!Iterable)
     {
         // we may not have an indexed overload, so we need to count
         size_t i;
-        foreach(e; r)
+        foreach (e; r)
         {
             if (i == n) break; // got all the elements we need
             emplaceRef!E(result[i++], e);

--- a/std/array.d
+++ b/std/array.d
@@ -465,6 +465,15 @@ unittest
  *      arr = An array literal.
  *
  * Returns: A static array of size `arr.length`.
+ *
+ * Warning:
+ * Do not initialize a dynamic array with a call to staticArray.
+ * The dynamic array slice would point to stack memory no longer in use.
+ * Instead define the static array first using type inference (or `int[4]`).
+ * ---
+ * int[] invalid = [1,2,3,4].staticArray; // Wrong
+ * ---
+ * See $(LINK2 http://issues.dlang.org/show_bug.cgi?id=12625, Issue 12625).
  */
 @nogc T[n] staticArray(T, size_t n)(T[n] arr)
 {
@@ -472,20 +481,22 @@ unittest
     return arr;
 }
 
-///
+/// Array size and type can be inferred:
 @safe @nogc pure nothrow unittest
 {
-    auto arr = [1,2,3,4].staticArray;         // no need to declare size
+    auto arr = [1,2,3,4].staticArray;
     static assert(is(typeof(arr) == int[4])); // arr is a static array
     assert(arr == [1,2,3,4]);
+}
 
-    version(Bug)
-    {
-        // Do not initialize a dynamic array with a call to staticArray.
-        // `invalid` will be a slice to stack memory no longer in use.
-        // Instead use type inference (or int[4]).
-        int[] invalid = [1,2,3,4].staticArray;
-    }
+// dmd doesn't support inference of n, but not T for staticArray!immutable
+// http://issues.dlang.org/show_bug.cgi?id=15890
+/// The element type can also be supplied:
+@safe @nogc pure nothrow unittest
+{
+    auto arr = [1,2].staticArray!(immutable int, 2);
+    static assert(is(typeof(arr) == immutable(int)[2]));
+    assert(arr == [1,2].staticArray);
 }
 
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -335,6 +335,47 @@ unittest
 }
 
 /**
+ * Interprets an array literal as a static array.
+ *
+ * Params:
+ *      arr = An array literal.
+ *
+ * Returns: A static array of size `arr.length`.
+ *
+ * Warning:
+ * Do not initialize a dynamic array with a call to staticArray.
+ * The dynamic array slice would point to stack memory no longer in use.
+ * Instead define the static array first using type inference (or `int[4]`).
+ * ---
+ * int[] invalid = [1,2,3,4].staticArray; // Wrong
+ * ---
+ * See $(LINK2 http://issues.dlang.org/show_bug.cgi?id=12625, Issue 12625).
+ */
+@nogc T[n] staticArray(T, size_t n)(T[n] arr)
+{
+    pragma(inline, true);
+    return arr;
+}
+
+/// Array size and type can be inferred:
+@safe @nogc pure nothrow unittest
+{
+    auto arr = [1,2,3,4].staticArray;
+    static assert(is(typeof(arr) == int[4])); // arr is a static array
+    assert(arr == [1,2,3,4]);
+}
+
+// dmd doesn't support inference of n, but not T for staticArray!immutable
+// http://issues.dlang.org/show_bug.cgi?id=15890
+/// The element type can also be supplied:
+@safe @nogc pure nothrow unittest
+{
+    auto arr = [1,2].staticArray!(immutable int, 2);
+    static assert(is(typeof(arr) == immutable(int)[2]));
+    assert(arr == [1,2].staticArray);
+}
+
+/**
  * Initializes a static array from the first `n` elements of the range `r`.
  *
  * Preconditions: `r` has at least `n` elements.
@@ -450,47 +491,6 @@ unittest
     auto arr1 = S(1).only.staticArray!1;
     static assert(is(typeof(arr1) == S[1]));
     assert(arr1 == [ S(1) ]);
-}
-
-/**
- * Interprets an array literal as a static array.
- *
- * Params:
- *      arr = An array literal.
- *
- * Returns: A static array of size `arr.length`.
- *
- * Warning:
- * Do not initialize a dynamic array with a call to staticArray.
- * The dynamic array slice would point to stack memory no longer in use.
- * Instead define the static array first using type inference (or `int[4]`).
- * ---
- * int[] invalid = [1,2,3,4].staticArray; // Wrong
- * ---
- * See $(LINK2 http://issues.dlang.org/show_bug.cgi?id=12625, Issue 12625).
- */
-@nogc T[n] staticArray(T, size_t n)(T[n] arr)
-{
-    pragma(inline, true);
-    return arr;
-}
-
-/// Array size and type can be inferred:
-@safe @nogc pure nothrow unittest
-{
-    auto arr = [1,2,3,4].staticArray;
-    static assert(is(typeof(arr) == int[4])); // arr is a static array
-    assert(arr == [1,2,3,4]);
-}
-
-// dmd doesn't support inference of n, but not T for staticArray!immutable
-// http://issues.dlang.org/show_bug.cgi?id=15890
-/// The element type can also be supplied:
-@safe @nogc pure nothrow unittest
-{
-    auto arr = [1,2].staticArray!(immutable int, 2);
-    static assert(is(typeof(arr) == immutable(int)[2]));
-    assert(arr == [1,2].staticArray);
 }
 
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -391,7 +391,8 @@ if (isIterable!Iterable)
 @safe pure nothrow unittest
 {
     import std.range : only;
-    int[3] arr = only(1, 2, 3).staticArray!3;
+    auto arr = only(1, 2, 3).staticArray!3;
+    static assert(is(typeof(arr) == int[3]));
     assert(arr == [ 1, 2, 3 ]);
 }
 
@@ -399,7 +400,8 @@ if (isIterable!Iterable)
 @safe pure nothrow unittest
 {
     import std.range : take, repeat;
-    int[4] arr = repeat(5).staticArray!4;
+    auto arr = repeat(5).staticArray!4;
+    static assert(is(typeof(arr) == int[4]));
     assert(arr == [ 5, 5, 5, 5 ]);
 }
 
@@ -413,7 +415,7 @@ pure unittest
     assertThrown!AssertError(only(1,2,3).staticArray!5);
 
     // extend the range to the desired length before handing it to staticArray
-    int[5] arr = only(1,2,3).chain(0.repeat).staticArray!5;
+    auto arr = only(1,2,3).chain(0.repeat).staticArray!5;
     assert(arr == [ 1, 2, 3, 0, 0 ]);
 }
 
@@ -435,7 +437,8 @@ unittest
         }
     }
 
-    int[5] arr = OpApply().staticArray!5;
+    auto arr = OpApply().staticArray!5;
+    static assert(is(typeof(arr) == int[5]));
     assert(arr == [ 0, 1, 2, 3, 4 ]);
 }
 


### PR DESCRIPTION
Better static array support in `std.array`.

The main change I wanted to introduce is `array!n`, which functions like `array` but creates a static array.

For example:

    int[5] = only(1,2,3,4,5).array!5;

This also implements `staticArray`, which is a sort of library-level static array literal:

    auto i = staticArray(1,2,3); // i is an int[3], you don't have to deduce the size manually.

I'm mostly interested in `array!size`, but figured I'd throw in `staticArray` as well just to see what people think.