### PR TITLE
append to an array by emplacement

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2840,18 +2840,18 @@ if (isDynamicArray!A)
         }
     }
 
-  // emplace an item onto an array.
-  void emplacePut(Args...)(Args args) {
-	import std.conv: emplaceRef;
+	// emplace an item onto an array.
+	void emplacePut(Args...)(Args args) {
+		import std.conv: emplaceRef;
 
-	ensureAddable(1);
-	immutable len = _data.arr.length;
+		ensureAddable(1);
+		immutable len = _data.arr.length;
 
-	auto bigData = (() @trusted => _data.arr.ptr[0..len + 1])();
-	emplaceRef!(Unqual!T)(bigData[len], args);
-	// don't set this back until we're sure we have the item initialized.
-	_data.arr = bigData;
-  }
+		auto bigData = (() @trusted => _data.arr.ptr[0..len + 1])();
+		emplaceRef!(Unqual!T)(bigData[len], args);
+		// don't set this back until we're sure we have the item initialized.
+		_data.arr = bigData;
+	}
 
 
     // Const fixing hack.
@@ -3017,21 +3017,21 @@ unittest
 }
 
 unittest {
-  struct Uncopyable {
-	@disable this(this);
-	int foo;
-	this(int foo) {
-	  this.foo = foo;
+	struct Uncopyable {
+		@disable this(this);
+		int foo;
+		this(int foo) {
+			this.foo = foo;
+		}
 	}
-  }
 
-  auto a = appender!(Uncopyable[])();
-  a.emplacePut(1);
-  a.emplacePut(2);
-  a.emplacePut(3);
-  import std.stdio;
-  writeln(a.data[0].foo);
-  assert(a.data == [Uncopyable(1),Uncopyable(2),Uncopyable(3)]);
+	auto a = appender!(Uncopyable[])();
+	a.emplacePut(1);
+	a.emplacePut(2);
+	a.emplacePut(3);
+	import std.stdio;
+	writeln(a.data[0].foo);
+	assert(a.data == [Uncopyable(1),Uncopyable(2),Uncopyable(3)]);
 }
 
 

--- a/std/array.d
+++ b/std/array.d
@@ -2840,6 +2840,20 @@ if (isDynamicArray!A)
         }
     }
 
+  // emplace an item onto an array.
+  void emplacePut(Args...)(Args args) {
+	import std.conv: emplaceRef;
+
+	ensureAddable(1);
+	immutable len = _data.arr.length;
+
+	auto bigData = (() @trusted => _data.arr.ptr[0..len + 1])();
+	emplaceRef!(Unqual!T)(bigData[len], args);
+	// don't set this back until we're sure we have the item initialized.
+	_data.arr = bigData;
+  }
+
+
     // Const fixing hack.
     void put(Range)(Range items) if (canPutConstRange!Range)
     {
@@ -3001,6 +3015,25 @@ unittest
     app.put(3);
     assert("%s".format(app) == "Appender!(int[])(%s)".format([1,2,3]));
 }
+
+unittest {
+  struct Uncopyable {
+	@disable this(this);
+	int foo;
+	this(int foo) {
+	  this.foo = foo;
+	}
+  }
+
+  auto a = appender!(Uncopyable[])();
+  a.emplacePut(1);
+  a.emplacePut(2);
+  a.emplacePut(3);
+  import std.stdio;
+  writeln(a.data[0].foo);
+  assert(a.data == [Uncopyable(1),Uncopyable(2),Uncopyable(3)]);
+}
+
 
 //Calculates an efficient growth scheme based on the old capacity
 //of data, and the minimum requested capacity.


### PR DESCRIPTION
Appender.emplacePut, to construct elements as they are appended. Works
for classes/structs that disable their this(this) copy constructor, and
cannot be copied.
