### PR TITLE
Added Runtime Field Getting and Setting

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -47,6 +47,8 @@ $(BUGSTITLE Library Changes,
     `std.algorithm.searching.{min,max}Element` for ranges have been added.))
     $(LI $(REF Ternary, std,typecons) was added to represent three valued
     logic.)
+    $(LI $(RELATIVE_LINK2 getField, Added runtime member getting and setting
+    via `std.typecons.getField` and `std.typecons.setField`.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -224,6 +226,28 @@ import std.range;
 import std.typecons;
 assert([3, 1, 4].minElement == 1);
 assert([4, 7, 5].enumerate.maxElement!`a.value` == tuple(1, 7));
+-------
+)
+
+$(LI $(LNAME2 getField, Added runtime member getting and setting
+    via `std.typecons.getField` and `std.typecons.setField`.)
+    $(P $(XREF typecons, getField), $(XREF typecons, refField), and
+    $(XREF typecons, setField) allow scripting language style setting of
+    type fields from runtime generated strings.
+    )
+
+-------
+import std.typecons;
+
+struct Foo
+{
+    int bar = 42;
+}
+
+Foo foo;
+int val;
+foo.getField("bar", val);
+assert(val == 42);
 -------
 )
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7496,11 +7496,17 @@ ref Field refField(Field, Obj)(return ref Obj obj, string name) if (!is(Obj == c
  *     name = the name of the field or property member
  *     value = the new value to assign to the member
  */
-void setField(Field, Obj)(auto ref Obj obj, string name, auto ref Field value)
+void setField(Field, Obj)(Obj obj, string name, auto ref Field value) if (is(Obj == class))
 {
-    enum refField = !is(Field == class) || (Field.sizeof > 16);
-    enum refObj = !is(Obj == class) || (Obj.sizeof > 16);
-    rtFieldDispatch!(true, Field, refField, Obj, refObj)(obj, name, value);
+    enum refField = !is(Field == class) && (Field.sizeof > 16);
+    rtFieldDispatch!(true, Field, refField, Obj, false)(obj, name, value);
+}
+
+/// ditto
+void setField(Field, Obj)(ref Obj obj, string name, auto ref Field value) if (!is(Obj == class))
+{
+    enum refField = !is(Field == class) && (Field.sizeof > 16);
+    rtFieldDispatch!(true, Field, refField, Obj, true)(obj, name, value);
 }
 
 ///

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7498,7 +7498,7 @@ public:
 
     public:
         int field = 564;
-        
+
     @property:
         int valProp() const
         {
@@ -7508,7 +7508,7 @@ public:
         {
             _valProp = val;
         }
-        
+
         ref inout(int) refProp() inout
         {
             return _refProp;
@@ -7529,7 +7529,7 @@ public:
         assert(obj.getField!int("valProp") == 31);
         assert(obj.getField!int("refProp") == -78);
         assert(obj.getField!int("field") == 564);
-        
+
         int got1, got2, got3;
         obj.getField("valProp", got1);
         assert(got1 == 31);
@@ -7537,7 +7537,7 @@ public:
         assert(got2 == -78);
         obj.getField("field", got3);
         assert(got3 == 564);
-        
+
         //assertThrown(obj.refField!(const int)("valProp"));
         assert(obj.refField!(const int)("refProp") == -78);
         assert(obj.refField!(const int)("field") == 564);
@@ -7549,7 +7549,7 @@ public:
         assert(obj.refProp == 22);
         obj.refField!int("field") = -100;
         assert(obj.field == -100);
-        
+
         obj.setField("valProp", 50);
         assert(obj.valProp == 50);
         obj.setField("refProp", -191);
@@ -7557,7 +7557,7 @@ public:
         obj.setField("field", -81320);
         assert(obj.field == -81320);
     }
-    
+
     S s;
     testRead(s);
     testWrite(s);


### PR DESCRIPTION
Due to various GH problems, this is a retry of https://github.com/D-Programming-Language/phobos/pull/4070

Added a new functions which allows someone to set and get a type field by accessing the member with a string at runtime.

This is useful when the member being changed can change due to some external factors. For example, I have a library that parses strings for timezone info. The string can contain information for regular UTC offsets or DST offsets, which are both attributes of an internal result type. The info on which to set is only available at runtime. A possible way to refactor such an example is to have a general offset variable and hold some state in the type as to which type of offset the value is referring to, but IMO this is much cleaner.