### PR TITLE
move has{Mobile,Swappable}Elements, move{Front,Back,At} to std.algorithm.mutation

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1530,7 +1530,7 @@ private template TimSortImpl(alias pred, R)
     }
     body
     {
-        import std.algorithm.mutation : move;
+        import std.algorithm.mutation: move, moveAt;
 
         for (; sortedLen < range.length; ++sortedLen)
         {

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -20,6 +20,8 @@ Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
 */
 module std.container.binaryheap;
 
+
+import std.algorithm.mutation: moveFront, moveBack, moveAt;
 import std.range.primitives;
 import std.traits;
 

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -319,6 +319,7 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
     } else static if (!is(Unqual!R == R)) {
         alias InputRangeObject = InputRangeObject!(Unqual!R);
     } else {
+        import std.algorithm.mutation: moveFront, moveBack, moveAt;
 
         ///
         class InputRangeObject : MostDerivedInputRange!(R) {
@@ -465,6 +466,7 @@ unittest
     import std.internal.test.dummyrange;
     import std.algorithm : equal;
     import std.array;
+    import std.algorithm.mutation: moveFront, moveBack, moveAt;
 
     static void testEquality(R)(iInputRange r1, R r2) {
         assert(equal(r1, r2));

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -189,6 +189,7 @@ to $(WEB fantascienza.net/leonardo/so/, Leonardo Maffi).
  */
 module std.range;
 
+import std.algorithm.mutation: hasMobileElements, moveFront, moveBack, moveAt;
 public import std.range.primitives;
 public import std.range.interfaces;
 public import std.array;


### PR DESCRIPTION
As discussed in #4167, here is a proposal to move `moveAt`, `moveFront` and `moveBack` to std.algorithm.mutation. It also moves the two templates `hasMobileElements` and `hasSwappableElements`. The reasoning is that std.algorithm.mutation "contains generic mutation algorithms." and `move`, `moveAll`, `moveSome`, `swap`, `swapRanges`  and maybe soon`swapAt` are already there. The template `hasSwappableElements` already calls `swap` from std.algorithm.mutation.

This is just a proposal and I do understand that this commit might be controversial as it might add some deprecation warnings - however it does not break code and users should have enough to change their code. What is the exact deprecation policy within Phobos? 12 months?

(I guess that this might need a bit of rebasing soon as these PRS are merged #4127, #4165, #4167, #4168)