### PR TITLE
Fibonacci should only be calculated for values bigger than 2.

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -1067,9 +1067,10 @@ unittest
 {
     ulong fib(ulong n)
     {
-        return n <= 2 ? 1 : memoize!fib(n - 2) + memoize!fib(n - 1);
+        if (n == 0) return 0;
+        return n < 2 ? 1 : memoize!fib(n - 2) + memoize!fib(n - 1);
     }
-    assert(fib(10) == 89);
+    assert(fib(10) == 55);
 }
 
 /**

--- a/std/functional.d
+++ b/std/functional.d
@@ -1067,7 +1067,7 @@ unittest
 {
     ulong fib(ulong n)
     {
-        return n < 2 ? 1 : memoize!fib(n - 2) + memoize!fib(n - 1);
+        return n <= 2 ? 1 : memoize!fib(n - 2) + memoize!fib(n - 1);
     }
     assert(fib(10) == 89);
 }

--- a/std/functional.d
+++ b/std/functional.d
@@ -1067,8 +1067,7 @@ unittest
 {
     ulong fib(ulong n)
     {
-        if (n == 0) return 0;
-        return n < 2 ? 1 : memoize!fib(n - 2) + memoize!fib(n - 1);
+        return n < 2 ? n : memoize!fib(n - 2) + memoize!fib(n - 1);
     }
     assert(fib(10) == 55);
 }


### PR DESCRIPTION
In this case, there should be a less or equal comparison, instead of less than.