### PR TITLE
Fix issue 15864 - chmgen triggers exception in std.regex

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1560,10 +1560,10 @@ void optimize(Char)(ref Regex!Char zis)
                 ir.insertInPlace(i+IRL!(InfiniteEnd),
                     Bytecode.fromRaw(cast(uint)zis.filters.length));
                 zis.filters ~= BitTable(set);
+                fixupBytecode(ir);
             }
         }
     }
-    fixupBytecode(zis.ir);
 }
 
 //IR code validator - proper nesting, illegal instructions, etc.

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -1004,6 +1004,12 @@ unittest
     assert("a b".matchFirst(rx));
 }
 
+// bugzilla 15864
+unittest
+{
+    regex(`(<a (?:(?:\w+=\"[^"]*\")?\s*)*href="\.\.?)"`);
+}
+
 unittest
 {
     auto r = regex("(?# comment)abc(?# comment2)");


### PR DESCRIPTION
<del>This was marked as blocked for release, no idea why it was shipped anyway.</del>

EDIT: This simply a bugfix for current master