### PR TITLE
Partial fix of Issue 8384 - std.conv.to should allow conversion betwe…

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -29929,7 +29929,7 @@ else version(Windows)
         }
 
 
-        this(string name, TIME_ZONE_INFORMATION tzInfo) @safe immutable pure
+        this(string name, TIME_ZONE_INFORMATION tzInfo) @trusted immutable pure
         {
             super(name, to!string(tzInfo.StandardName.ptr), to!string(tzInfo.DaylightName.ptr));
             _tzInfo = tzInfo;


### PR DESCRIPTION
…en any pair of string/wstring/dstring/char*/wchar*/dchar*

std.conv.to currently fails uglily with 'object.Error@(0): array cast misalignment.' when casting from a char* to any wider string type, and does not support any kind of conversion from e.g. a wchar* to wchar[]. This should fix both those issues.

Note that Issue 8384 also mentions conversions from {X}char[] to {Y}char*. I have not tackled that problem, as std.conv.to does not currently support any kind of conversion in that direction.