### PR TITLE
[trivial] Tweak moveFront example

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1875,16 +1875,18 @@ ElementType!R moveFront(R)(R r)
 {
     auto a = [ 1, 2, 3 ];
     assert(moveFront(a) == 1);
+    assert(a.length == 3);
 
     // define a perfunctory input range
     struct InputRange
     {
-        @property bool empty() { return false; }
-        @property int front() { return 42; }
+        enum bool empty = false;
+        enum int front = 7;
         void popFront() {}
         int moveFront() { return 43; }
     }
     InputRange r;
+    // calls r.moveFront
     assert(moveFront(r) == 43);
 }
 


### PR DESCRIPTION
* Show that range length/topology doesn't change calling `moveFront`.
* Use `enum` instead of `@property` for better readability. The property case is still covered in an undocumented unittest and for `moveBack`.