### PR TITLE
std.experimental.allocator: add safe gc version for use with arrays

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -213,6 +213,8 @@ module std.experimental.allocator;
 public import std.experimental.allocator.common,
     std.experimental.allocator.typed;
 
+import std.experimental.allocator.gc_allocator;
+
 // Example in the synopsis above
 unittest
 {
@@ -625,6 +627,7 @@ overloads that involve copy initialization deallocate memory and propagate the
 exception if the copy operation throws.
 */
 T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
+if (!isGCSafeAllocator!Allocator)
 {
     if (!length) return null;
     auto m = alloc.allocate(T.sizeof * length);
@@ -661,6 +664,7 @@ unittest
 /// Ditto
 T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length,
     auto ref T init)
+if (!isGCSafeAllocator!Allocator)
 {
     if (!length) return null;
     auto m = alloc.allocate(T.sizeof * length);
@@ -722,7 +726,7 @@ unittest
 
 /// Ditto
 T[] makeArray(T, Allocator, R)(auto ref Allocator alloc, R range)
-if (isInputRange!R)
+if (isInputRange!R && !isGCSafeAllocator!Allocator)
 {
     static if (isForwardRange!R)
     {


### PR DESCRIPTION
Hey all,

I guess once the Allocator API gets stable, more people want to support it for their libraries.
One tricky thing is that once one includes the GCAllocator it breaks the `pure`, `nothrow` or `@safe` chain.
From our work at mir we went with the approach to separate allocation from the algorithms and then provide wrappers around those methods (e.g. `combinations` and `makeCombinations`).

However if one wants to have a nicer code and wants the allocation to be by default the GC one `(Allocator = GCAllocator)`, there needs to be a couple of changes to `makeArray`.

Here I propose an idea to have a `GCSafeAllocator` that only allows a subset of operations and replaces them with the native D analog. I imagine this to be quite useful for `std.algorithm` and `std.range`.

It's just a proposal - so let me know your ideas ;-)