### PR TITLE
std.algorithm.sort docu: use release to get the source back

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1062,17 +1062,20 @@ sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
 @safe pure nothrow unittest
 {
     int[] array = [ 1, 2, 3, 4 ];
+
     // sort in descending order
-    sort!("a > b")(array);
+    array.sort!("a > b");
     assert(array == [ 4, 3, 2, 1 ]);
+
     // sort in ascending order
-    sort(array);
+    array.sort();
     assert(array == [ 1, 2, 3, 4 ]);
-    // sort with a delegate
-    bool myComp(int x, int y) @safe pure nothrow { return x > y; }
-    sort!(myComp)(array);
-    assert(array == [ 4, 3, 2, 1 ]);
+
+    // sort with reusable comparator and chain
+    alias myComp = (x, y) => x > y;
+    assert(array.sort!(myComp).release == [ 4, 3, 2, 1 ]);
 }
+
 ///
 unittest
 {


### PR DESCRIPTION
I just realized that there is `release` for a SortedRange  that returns the original array.
I think we should document that better (I was looked for it one month ago without success), thus I propose to make parts of the `sort` doc look nicer ;-)