### PR TITLE
Add std.math.quantize() for rounding to a multiple of some number.

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -47,6 +47,8 @@ $(BUGSTITLE Library Changes,
     `std.algorithm.searching.{min,max}Element` for ranges have been added.))
     $(LI $(REF Ternary, std,typecons) was added to represent three valued
     logic.)
+    $(LI $(RELATIVE_LINK2 quantize, Added `std.math.quantize`, for rounding to
+        the nearest multiple of some number.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -225,6 +227,27 @@ import std.typecons;
 assert([3, 1, 4].minElement == 1);
 assert([4, 7, 5].enumerate.maxElement!`a.value` == tuple(1, 7));
 -------
+)
+
+$(LI $(LNAME2 quantize, Added `std.math.quantize`.)
+    $(P $(XREF math, quantize) rounds to the nearest multiple of some number.
+        Features:)
+    $(UL
+        $(LI The rounding method can be specified using the `rfunc` parameter. By
+            default, the current rounding mode will be used, which is typically
+            "banker's rounding".)
+        $(LI Overloads are included for the common case of rounding to the $(I Nth)
+            digit place in some base.)
+        $(LI If known at compile time, the base and exponent (digit place) can be
+            supplied as template parameters for better performance.)
+    )
+---
+import std.math;
+
+assert(12345.6789L.quantize(20.0L) == 12340.0L);
+assert(12345.6789L.quantize!(10, -2) == 12345.68L);
+assert(12345.6789L.quantize!(10, floor)(-2) == 12345.67L);
+---
 )
 
 )


### PR DESCRIPTION
This is a generalization of @jamadagni 's PR #3759 . Changes:
- I flipped the sign for `prec` / `exp`.
- Very large and very small values are handled correctly.
- NaN and infinities are handled correctly.
- The base is now a parameter; it is not locked to `10` any more.
- The rounding function is a parameter, to allow reusing the same logic with `floor()`, `ceil()`, and `nearbyint()`. It defaults to `rint()`, since that seems to be the fastest method which respects the current rounding mode.
- A couple of overloads were added to allow optimizations when the `base` (and possibly `exp`) are known at compile time. In particular, I wanted to use `ldexp()` to speed up the case where `base` is a power of two. This is not currently implemented though, because so much of `std.math` doesn't work at CTFE yet.