### PR TITLE
Force Inlining of isASCII

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -471,6 +471,7 @@ unittest
     Returns: Whether or not $(D c) is in the ASCII character set - i.e. in the
     range 0..0x7F.
   +/
+pragma(inline, true)
 bool isASCII(dchar c) @safe pure nothrow @nogc
 {
     return c <= 0x7F;


### PR DESCRIPTION
There should never be a time where this isn't inline-able.