### PR TITLE
std.experimental.allocator: provide a @safe GC Allocator

### DIFF
--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -1,6 +1,9 @@
 module std.experimental.allocator.gc_allocator;
 import std.experimental.allocator.common;
 
+import std.range.primitives;
+import std.traits;
+
 /**
 D's built-in garbage-collected allocator.
  */
@@ -158,4 +161,120 @@ unittest
 
     // anything above a page is simply rounded up to next page
     assert(GCAllocator.instance.goodAllocSize(4096 * 4 + 1) == 4096 * 5);
+}
+
+/**
+A useful stub that only uses D builtin operations and can be used to built a
+`@safe`, `nothrow` and `pure` API with D's default garbage collector.
+At the moment it only can only be used to allocate arrays via `makeArray`.
+*/
+struct GCSafeAllocator
+{
+    import core.memory : GC;
+    enum uint alignment = platformAlignment;
+
+    nothrow pure @trusted void[] allocate(size_t bytes) const
+    {
+        import core.exception : OutOfMemoryError;
+        if (!bytes) return null;
+        try
+        {
+            auto p = GC.malloc(bytes);
+            return p ? p[0 .. bytes] : null;
+        }
+        catch (OutOfMemoryError)
+        {
+            return null;
+        }
+    }
+
+    bool expand(ref void[] b, size_t delta)
+    {
+        assert(0, "stub - should not be called");
+    }
+
+    bool reallocate(ref void[] b, size_t newSize)
+    {
+        assert(0, "stub - should not be called");
+    }
+
+    @safe pure bool deallocate(T)(T[] b) immutable
+    {
+        return true;
+    }
+
+    immutable static GCSafeAllocator instance;
+}
+
+package enum bool isGCSafeAllocator(T) = is(Unqual!T == GCSafeAllocator);
+
+///
+pure @safe nothrow unittest
+{
+    import std.experimental.allocator: dispose;
+    auto dummyAllloc(Allocator = GCSafeAllocator)()
+    {
+        return Allocator.instance.makeArraySafe!int(2);
+    }
+    auto arr = dummyAllloc();
+    assert(arr == [0, 0]);
+    GCSafeAllocator.instance.dispose(arr);
+}
+
+pure @safe nothrow unittest
+{
+
+    int[] arr = makeArraySafe!int(GCSafeAllocator.instance, 2);
+    assert(arr == [0, 0]);
+
+    int[] arr2 = makeArraySafe!int(GCSafeAllocator.instance, 2, 1);
+    assert(arr2 == [1, 1]);
+
+    import std.range: iota;
+    int[] arr3 = makeArraySafe!int(GCSafeAllocator.instance, 2.iota);
+    assert(arr3 == [0, 1]);
+}
+
+@trusted T[] makeArraySafe(T, Allocator)(auto ref Allocator alloc, size_t length)
+    if (isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator)(alloc, length);
+}
+
+T[] makeArraySafe(T, Allocator)(auto ref Allocator alloc, size_t length)
+    if (!isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator)(alloc, length);
+}
+
+@trusted T[] makeArraySafe(T, Allocator)(auto ref Allocator alloc, size_t length,
+    auto ref T init)
+    if (isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator)(alloc, length, init);
+}
+
+T[] makeArraySafe(T, Allocator)(auto ref Allocator alloc, size_t length,
+    auto ref T init)
+    if (!isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator)(alloc, length, init);
+}
+
+@trusted T[] makeArraySafe(T, Allocator, R)(auto ref Allocator alloc, R range)
+    if (isInputRange!R && isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator, R)(alloc, range);
+}
+
+T[] makeArraySafe(T, Allocator, R)(auto ref Allocator alloc, R range)
+    if (isInputRange!R && !isGCSafeAllocator!Allocator)
+{
+    import std.experimental.allocator: makeArray;
+    return makeArray!(T, Allocator, R)(alloc, range);
 }


### PR DESCRIPTION
Resubmission of #4190 (seems like Github doesn't allow reopening after force-pushing the HEAD) - sorry for the annoyance.

In brief the problem is that most operations like allocating an array are `@safe` (and `nothrow`) within normal D Code, so when the `GCAllocator` is used it should allow `@safe` code too. See #4190 for more details and a writeup of different ideas how one could design a API with the GCAllocator.

What happened so far:

- In #4190 I tried to set `expand` and `reallocate` to `@trusted`
   apart from the fact the `expand` can't be trusted, GCAllocator's `shared` instance is still problematic, so we most likely have to create a `GCSafeAllocator`
- In #4213 I tried to provide constraints for `makeArray`, so that `new T[..]` will be used for the safe allocator 

Here I combine both approaches and provide a `GCSafeAllocator` that
- stubs `expand` and `reallocate`
- catches the exceptions of `GC.malloc` ([afaict](http://forum.dlang.org/post/vkpcqpabhlxxenrnnhrd@forum.dlang.org) it's okay to return a false value  on a failed allocation)
- I proxy `makeArraySafe` to `makeArray`, s.t. I can set it to `@trusted` (`makeArray` does some pointer work)

Disadvantages:
- If someone wants to use this in his library, he needs to call `makeArraySafe`
- I am not sure whether we can set `makeArray` to `@safe`
- D allows to shrink and expand arrays in `@safe` - however this approach does forbid that
- We would have to proxy `make` too 

So as said - this approach is not perfect and your input is very welcome & feel free to propose your own ideas ;-)