### PR TITLE
[trivial] Undocument unittest until `overlap` is documented

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -731,7 +731,7 @@ inout(T)[] overlap(T)(inout(T)[] r1, inout(T)[] r2) @trusted pure nothrow
     return b < e ? b[0 .. e - b] : null;
 }
 
-///
+// ///
 @safe pure /*nothrow*/ unittest
 {
     int[] a = [ 10, 11, 12, 13, 14 ];


### PR DESCRIPTION
Its example is showing up for `minimallyInitializedArray` instead:
https://dlang.org/library/std/array/minimally_initialized_array.html

dlang.org/phobos-prerelease doesn't seem to have this, maybe the ddox is more recent.