### PR TITLE
move changelog to a folder

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,42 @@
+This directory will get copied to dlang.org and cleared when master gets
+merged into stable prior to a new release.
+
+How to add a new changelog entry to the pending changelog?
+==========================================================
+
+Create a new file in the `changelog` folder. It should end with `.dd` and look
+similar to a git commit message. The first line represents the title of the change.
+After an empty line follows the long description:
+
+```
+My fancy title of the new feature
+
+A long description of the new feature in `std.range`.
+It can be followed by an example:
+-------
+import std.range : padLeft, padRight;
+import std.algorithm.comparison : equal;
+
+assert([1, 2, 3, 4, 5].padLeft(0, 7).equal([0, 0, 1, 2, 3, 4, 5]));
+
+assert("Hello World!".padRight('!', 15).equal("Hello World!!!!"));
+-------
+and links to the documentation, e.g. $(REF drop, std, range) or
+$(REF_ALTTEXT a custom name for the function, drop, std, range).
+
+Links to the spec can look like this $(LINK2 $(ROOT_DIR)spec/module.html, this)
+and of course you can link to other $(LINK2 https://forum.dlang.org/, external resources).
+```
+
+The title can't contain links (it's already one).
+For more infos, see the [Ddoc spec](https://dlang.org/spec/ddoc.html).
+
+Preview changes
+---------------
+
+If you have cloned the [tools](https://github.com/dlang/tools) and [dlang.org](https://github.com/dlang/dlang.org) repo),
+you can preview the changelog with:
+
+```
+make -C ../dlang.org -f posix.mak pending_changelog
+```

--- a/changelog/ndslice-removal.dd
+++ b/changelog/ndslice-removal.dd
@@ -1,0 +1,5 @@
+`std.experimental.ndslice` has been deprecated.
+
+The synchronization between Phobos and Mir turned out to be a lot of work
+with litte gain. Users of `std.experimental.ndslice` are advised to
+switch to the upstream $(LINK2 https://github.com/libmir/mir-algorithm, mir package).

--- a/changelog/std-algorithm-searching-maxindex.dd
+++ b/changelog/std-algorithm-searching-maxindex.dd
@@ -1,0 +1,13 @@
+Added `std.algorithm.searching.maxIndex` to get the index of the maximum element of a range.
+
+`std.algorithm.searching.maxIndex` gets the index of the maximum element of a range,
+according to a specified predicate. The default predicate is "a > b".
+
+-------
+import std.algorithm.searching : maxIndex;
+int[] a = [5, 4, 2, 1, 9, 10];
+assert(a.minIndex == 5);
+
+int[] a;
+assert(a.minIndex == -1);
+-------

--- a/changelog/std-algorithm-searching-minindex.dd
+++ b/changelog/std-algorithm-searching-minindex.dd
@@ -1,0 +1,13 @@
+Added `std.algorithm.searching.minIndex` to get the index of the minimum element of a range.
+
+`std.algorithm.searching.minIndex` gets the index of the minimum element of a range,
+according to a specified predicate. The default predicate is "a < b".
+
+-------
+import std.algorithm.searching : minIndex;
+int[] a = [5, 4, 2, 1, 9, 10];
+assert(a.minIndex == 3);
+
+int[] a;
+assert(a.minIndex == -1);
+-------

--- a/changelog/std-meta-statisissorted.dd
+++ b/changelog/std-meta-statisissorted.dd
@@ -1,0 +1,16 @@
+Added `std.meta.staticIsSorted` to check if an `AliasSeq` is sorted according to some template predicate.
+
+`std.meta.staticIsSorted` checks whether an `AliasSeq` is
+sorted according to some template predicate.
+------
+enum Comp(T1, T2) = T1.sizeof < T2.sizeof;
+
+import std.meta : staticIsSorted;
+static assert( staticIsSorted!(Comp, byte, uint, double));
+static assert(!staticIsSorted!(Comp, bool, long, dchar));
+------
+
+Additionally, the compile-time performance of `std.meta.staticSort` has been
+greatly improved. Nevertheless, due to compiler limitations it is still an
+extraordinarily expensive operation to perform on longer sequences; strive to
+minimize such use.

--- a/changelog/std-traits-hasFunctionAttributes.dd
+++ b/changelog/std-traits-hasFunctionAttributes.dd
@@ -1,0 +1,22 @@
+`std.traits.hasFunctionAttributes` has been added
+
+It exposes a user-friendly way to query for function attributes:
+-------
+import std.traits : hasFunctionAttributes;
+
+// manually annotated function
+real func(real x) pure nothrow @safe
+{
+    return x;
+}
+static assert(hasFunctionAttributes!(func, "@safe", "pure"));
+static assert(!hasFunctionAttributes!(func, "@trusted"));
+
+// for templated function types are automatically inferred
+bool myFunc(T)(T b)
+{
+    return !b;
+}
+static assert(hasFunctionAttributes!(myFunc!bool, "@safe", "pure", "@nogc", "nothrow"));
+static assert(!hasFunctionAttributes!(myFunc!bool, "shared"));
+-------

--- a/changelog/std-traits-promoted.dd
+++ b/changelog/std-traits-promoted.dd
@@ -1,0 +1,12 @@
+Added `std.traits.Promoted` to get the result of scalar type promotion in multi-term arithmetic expressions
+
+`std.traits.Promoted` gets the type to which a scalar type will be promoted
+in multi-term arithmetic expressions
+-------
+import std.traits : Promoted;
+static assert(is(typeof(ubyte(3) * ubyte(5)) == Promoted!ubyte));
+static assert(is(Promoted!ubyte == int));
+-------
+
+See the D specification on $(LINK2 $(ROOT_DIR)spec/type.html#integer-promotions,
+scalar type promotions) for more information.


### PR DESCRIPTION
As discussed at the [newsgroup](http://forum.dlang.org/post/pbfgjdvhvfgobcpnlvfb@forum.dlang.org) I think it would be more painless if we put the pending changes into a folder, s.t. that no merge conflicts arise anymore. 
- I also found that we can eliminate one main error source - the `$(LI )` ddoc macro and make it even easier to add entries as one entry is always one item
- For cross-platform compatibility (and maybe further improvements) I included a small script that builds the changelog from all pending entries.
- I added small README that should provides instructions to contributors
- I use a `p_` prefix, s.t. removing the pending entries is easier, but this is not required.
- I copied all pending entries into the new format

I am happy to hear your feedback.
Pinging @CyberShadow @schveiguy @MartinNowak 
