### PR TITLE
[std.regex] Introduce Bit-NFA engine

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -186,7 +186,7 @@ PACKAGE_std_experimental_ndslice = package iteration selection slice
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \
-  backtracking kickstart tests thompson)
+  backtracking shiftor tests thompson)
 
 # Modules in std (including those in packages)
 STD_MODULES=$(call P2MODULES,$(STD_PACKAGES))

--- a/posix.mak
+++ b/posix.mak
@@ -186,7 +186,7 @@ PACKAGE_std_experimental_ndslice = package iteration selection slice
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \
-  backtracking shiftor tests thompson)
+  backtracking bitnfa tests thompson shiftor)
 
 # Modules in std (including those in packages)
 STD_MODULES=$(call P2MODULES,$(STD_PACKAGES))

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -216,7 +216,7 @@ template BacktrackingMatcher(bool CTregex)
             }
             static if(kicked)
             {
-                if(!re.kickstart.empty)
+                if(re.kickstart)
                 {
                     for(;;)
                     {

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -1,60 +1,542 @@
 //Written in the D programming language
 /*
     Implementation of a concept "NFA in a word" which is
-    bit-parallel impementation of regex where each bit represents 
+    bit-parallel impementation of regex where each bit represents
     a state in an NFA. Execution is Thompson-style achieved via bit tricks.
 
     There is a great number of limitations inlcuding not tracking any state (captures)
     and not supporting even basic assertions such as ^, $  or \b.
 */
+module std.regex.internal.bitnfa;
+
+package(std.regex):
+
 import std.regex.internal.ir;
 
-// since there is no way to mark a starting position
-// need 2 instance of BitNfa - one to find the end, and the other
+debug(std_regex_bitnfa) import std.stdio;
+
+
+
+struct HashTab()
+{
+    @disable this(this);
+
+    uint opIndex(uint key)
+    {
+        auto p = locate(key, table);
+        assert(p.occupied);
+        return p.value;
+    }
+
+    void opIndexAssign(uint value, uint key)
+    {
+        if(table.length == 0) grow();
+        auto p = locate(key, table);
+        if(!p.occupied)
+        {
+            items++;
+            if(4*items >= table.length*3)
+            {
+                grow();
+                p = locate(key, table);
+            }
+            p.occupied = true;
+            p.key = key;
+        }
+        p.value = value;
+    }
+
+    auto keys()
+    {
+        auto app = appender!(uint[])();
+        foreach(i, v; table)
+        {
+            if(v.occupied)
+                app.put(v.key);
+        }
+        return app.data;
+    }
+
+    auto values()
+    {
+        auto app = appender!(uint[])();
+        foreach(i, v; table)
+        {
+            if(v.occupied)
+                app.put(v.value);
+        }
+        return app.data;
+    }
+
+private:
+    static uint hashOf(uint val)
+    {
+        return (val >> 20) ^ (val>>8) ^ val;
+    }
+
+    struct Node
+    {
+        uint key;
+        uint value;
+        bool occupied;
+    }
+    Node[] table;
+    size_t items;
+
+    static Node* locate(uint key, Node[] table)
+    {
+        size_t slot = hashOf(key) & (table.length-1);
+        while(table.ptr[slot].occupied)
+        {
+            if(table.ptr[slot].key == key)
+                break;
+            slot += 1;
+            if(slot == table.length)
+                slot = 0;
+        }
+        return table.ptr+slot;
+    }
+
+    void grow()
+    {
+        Node[] newTable = new Node[table.length ? table.length*2 : 4];
+        foreach(i, v; table)
+        {
+            if(v.occupied)
+            {
+                auto p = locate(v.key, newTable);
+                *p = v;
+            }
+        }
+    }
+}
+
+
+// Specialized 2-level trie of uint masks for BitNfa.
+// Uses the concept of CoW: a page gets modified in place
+// if the block's ref-count is 1, else a newblock is allocated
+// and ref count is decreased
+struct UIntTrie2
+{
+    ushort[] index;             // pages --> blocks
+    ushort[] refCounts;         // ref counts for each block
+    uint[]   hashes;            // hashes of blocks
+    uint[]   blocks;            // linear array with blocks
+    uint[]   scratch;           // temporary block
+    enum     blockSize = 2<<8;  // size of block
+
+    static uint hash(uint[] data)
+    {
+        uint h = 5183;
+        foreach(v; data)
+        {
+            h = 31*h + v;
+        }
+        return h;
+    }
+
+    static UIntTrie2 opCall()
+    {
+        UIntTrie2 ut;
+        ut.index.length = 2<<13;
+        ut.blocks = new uint[blockSize];
+        ut.blocks[] = uint.max; // all ones
+        ut.scratch = new uint[blockSize];
+        ut.refCounts = new ushort[1];
+        ut.refCounts[0] = 2<<13;
+        ut.hashes = new uint[1];
+        ut.hashes[0] = hash(ut.blocks);
+        return ut;
+    }
+
+    bool opIndex(dchar ch)
+    {
+        return false; // TODO: stub
+    }
+
+    void opIndexOpAssign(string op)(uint val, dchar ch)
+    {
+        // TODO: stub
+    }
+
+    void opSliceOpAssign(string op)(uint val, uint start, uint end)
+    {
+        // TODO: stub
+    }
+}
+
+// Since there is no way to mark a starting position
+// we need 2 instances of BitNfa: one to find the end, and the other
 // to run backwards to find the start.
 struct BitNfa
 {
-    uint        asciiTab[128];    // state mask for ascii characters
-    UintTrie2   uniTab;           // state mask for unicode characters
+    uint[128]   asciiTab;         // state mask for ascii characters
+    UIntTrie2   uniTab;           // state mask for unicode characters
     uint[uint]  controlFlow;      // maps each bit pattern to resulting jumps pattern
     uint        controlFlowMask;  // masks all control flow bits
     uint        finalMask;        // marks final states terminating the NFA
+    bool        empty;            // if this engine is empty
+
+    void combineControlFlow()
+    {
+        uint[] keys = controlFlow.keys;
+        uint[] values = controlFlow.values;
+        auto selection = new bool[keys.length];
+        bool nextChoice()
+        {
+            uint i;
+            for(i=0;i<selection.length; i++)
+            {
+                selection[i] ^= true;
+                if(selection[i])
+                    break;
+            }
+            return i != selection.length;
+        }
+        // first prepare full mask
+        foreach(k; keys) controlFlowMask |= k;
+        // next set all combinations in cf
+        while(nextChoice())
+        {
+            uint kmask = 0, vmask = 0;
+            foreach(i,v; selection)
+                if(v)
+                {
+                    kmask |= keys[i];
+                    vmask |= values[i];
+                }
+            controlFlow[kmask] = vmask;
+        }
+    }
+
+    uint[] collectControlFlow(Bytecode[] ir, uint i)
+    {
+        uint[] result;
+        Stack!uint paths;
+        paths.push(i);
+        while(!paths.empty())
+        {
+            uint j = paths.pop();
+            switch(ir[j].code) with(IR)
+            {
+            case OrStart:
+                j += IRL!OrStart;
+                assert(ir[j].code == Option);
+                while(ir[j].code == Option)
+                {
+                    //import std.stdio;
+                    //writefln("> %d %s", j, ir[j].mnemonic);
+                    paths.push(j+IRL!Option);
+                    //writefln(">> %d", j+IRL!Option);
+                    j = j + ir[j].data + IRL!Option;
+                }
+                break;
+            case GotoEndOr:
+                paths.push(j+IRL!GotoEndOr+ir[j].data);
+                break;
+            case OrEnd, Wordboundary, Notwordboundary, Bol, Eol, Nop, GroupStart, GroupEnd:
+                paths.push(j+ir[j].length);
+                break;
+            case LookaheadStart, NeglookaheadStart, LookbehindStart,
+                NeglookbehindStart:
+                paths.push(j + IRL!LookaheadStart + ir[j].data + IRL!LookaheadEnd);
+                break;
+            case InfiniteStart, InfiniteQStart:
+                paths.push(j+IRL!InfiniteStart);
+                paths.push(j+ir[j].data+IRL!InfiniteEnd);
+                break;
+            case InfiniteBloomStart:
+                paths.push(j+IRL!InfiniteStart);
+                paths.push(j+ir[j].data+IRL!InfiniteBloomEnd);
+                break;
+            case InfiniteEnd, InfiniteQEnd:
+                paths.push(j-ir[j].data);
+                paths.push(j+IRL!InfiniteEnd);
+                break;
+            case InfiniteBloomEnd:
+                paths.push(j-ir[j].data);
+                paths.push(j+IRL!InfiniteBloomEnd);
+                break;
+            default:
+                result ~= j;
+            }
+        }
+        return result;
+    }
+
+    this(Char)(auto ref Regex!Char re)
+    {
+        asciiTab[] = uint.max; // all ones
+        uniTab = UIntTrie2();
+        controlFlow[0] = 0;
+        // pc -> bit number
+        uint[] bitMapping = new uint[re.ir.length];
+        uint bitCount = 0, nesting=0, lastNonnested=0;
+        bool stop = false;
+        with(re)
+outer:  for(uint i=0; i<ir.length; i += ir[i].length) with(IR)
+        {
+            if(nesting == 0) lastNonnested = i;
+            if(ir[i].isStart) nesting++;
+            if(ir[i].isEnd) nesting--;
+            switch(ir[i].code)
+            {
+            case Option, OrEnd, Nop, Bol,
+            GroupStart, GroupEnd,
+            Eol, Wordboundary, Notwordboundary:
+                bitMapping[i] = bitCount;
+                break;
+            // skipover complex assertions
+            case LookaheadStart, NeglookaheadStart, LookbehindStart,
+                NeglookbehindStart:
+                bitMapping[i] = bitCount;
+                nesting--;
+                i += IRL!LookbehindStart + ir[i].data; // IRL end gets skiped by 'for'
+                break;
+            // unsupported instructions
+            case RepeatStart, RepeatQStart, Backref:
+                stop = true;
+                break outer;
+            case OrChar:
+                uint s = ir[i].sequence;
+                for(uint j=i; j<i+s; j++)
+                    bitMapping[j] = bitCount;
+                i += (s-1)*IRL!OrChar;
+                bitCount++;
+                if(bitCount == 32)
+                    break outer;
+                break;
+            default:
+                bitMapping[i] = bitCount++;
+                if(bitCount == 32)
+                    break outer;
+            }
+        }
+        if(bitCount == 0)
+            empty = true;
+        debug(std_regex_bitnfa) writeln("LEN:", lastNonnested);
+        // the total processable length
+        uint length=lastNonnested;
+        finalMask |= 1u<<bitMapping[length];
+        if(stop)
+            finalMask <<= 1;
+        with(re)
+        for(uint i=0; i<length; i += ir[i].length)
+        {
+            switch(ir[i].code) with (IR)
+            {
+            case OrStart,GotoEndOr, InfiniteStart,
+            InfiniteBloomStart, InfiniteBloomEnd,
+            InfiniteEnd, InfiniteQEnd, InfiniteQStart:
+                // collect stops across all paths
+                auto rets = collectControlFlow(ir, i);
+                uint mask = 0;
+                debug(std_regex_bitnfa) writeln(rets);
+                foreach(pc; rets) mask |= 1u<<bitMapping[pc];
+                // map this individual c-f to all possible stops
+                controlFlow[1u<<bitMapping[i]] = mask;
+                break;
+            case Option, OrEnd, Nop, Bol,
+                GroupStart, GroupEnd,
+                Eol, Wordboundary, Notwordboundary:
+                break;
+            case LookaheadStart, NeglookaheadStart, LookbehindStart,
+                NeglookbehindStart:
+                i += IRL!LookaheadStart + ir[i].data;
+                break;
+            case End:
+                finalMask |= 1u<<bitMapping[i];
+                break;
+            case Char:
+                uint mask = 1u<<bitMapping[i];
+                auto ch = ir[i].data;
+                //import std.stdio;
+                //writefln("Char %c - %b", cast(dchar)ch, mask);
+                if(ch < 0x80)
+                    asciiTab[ch] &= ~mask;
+                else
+                    uniTab[ch] &= ~mask;
+                break;
+            case OrChar:
+                uint s = ir[i].sequence;
+                for(size_t j=i; j<i+s; j++)
+                {
+                    uint mask = 1u<<bitMapping[i];
+                    auto ch = ir[j].data;
+                    //import std.stdio;
+                    //writefln("OrChar %c - %b", cast(dchar)ch, mask);
+                    if(ch < 0x80)
+                        asciiTab[ch] &= ~mask;
+                    else
+                        uniTab[ch] &= ~mask;
+                }
+                i += s-1;
+                break;
+            case CodepointSet, Trie:
+                auto cset = charsets[ir[i].data];
+                uint mask = 1u<<bitMapping[i];
+                foreach(ival; cset.byInterval)
+                {
+                    if(ival.b < 0x80)
+                        asciiTab[ival.a..ival.b] &= ~mask;
+                    else
+                    {
+                        if(ival.a < 0x80)
+                            asciiTab[ival.a..0x80] &= ~mask;
+                        uniTab[ival.a..ival.b] &= ~mask;
+                    }
+                }
+                break;
+            default:
+                assert(0, "Unexpected instruction in BitNFA: "~ir[i].mnemonic);
+            }
+        }
+        combineControlFlow();
+    }
 
     bool opCall(Input)(ref Input r)
     {
+        bool matched = false;
+        size_t mIdx = 0;
         dchar ch;
         size_t idx;
         uint word = ~0u;
-        while(r.nextChar(ch, idx)){
+        for(;;)
+        {
             word <<= 1; // shift - create a state
             // cfMask has 1 for each control-flow op
-            uint cflow = ~word  & controlFlowMask; 
+            uint cflow = ~word  & controlFlowMask;
             word = word | controlFlowMask; // kill cflow
-            word |= controlFlow[cflow]; // map normal ops
-            if(word & finalMask != finalMask)
-                return true;
+            word &= ~controlFlow[cflow]; // map normal ops
+            debug(std_regex_bitnfa) writefln("%b %b %b %b", word, finalMask, cflow, controlFlowMask);
+            if((word & finalMask) != finalMask)
+            {
+                matched = true; // keep running to see if there is longer match
+                mIdx = r._index;
+            }
+            else if(matched)
+                break;
+            if(!r.nextChar(ch, idx))
+                break;
             // mask away failing states
             if(ch < 0x80)
-                word |= assciiTab[ch];
+                word |= asciiTab[ch];
             else
                 word |= uniTab[ch];
         }
-        return false;
+        if(matched)
+        {
+            r.reset(mIdx);
+        }
+        return matched;
     }
 }
 
 final class BitMatcher
 {
     BitNfa forward, backward;
+
+    this(Char)(auto ref Regex!Char re)
+    {
+        forward = BitNfa(re);
+        //reverse Bytecode
+        auto re2 = re;
+        re2.ir = re2.ir.dup;
+        // keep the end where it belongs
+        reverseBytecode(re2.ir[0..$-1]);
+        // check for the case of multiple patterns as one alternation
+        with(IR) with(re2) if(ir[0].code == OrStart)
+        {
+            size_t pc = IRL!OrStart;
+            while(ir[pc].code == Option)
+            {
+                size_t size = ir[pc].data;
+                if(ir[pc+size-IRL!GotoEndOr].code == GotoEndOr)
+                    size -= IRL!GotoEndOr;
+                size_t j = pc + IRL!Option;
+                if(ir[j].code == End)
+                {
+                    auto save = ir[j];
+                    foreach(k; j+1..j+size)
+                        ir[k-1] = ir[k];
+                    ir[j+size-1] = save;
+                }
+                pc = j + ir[pc].data;
+            }
+        }
+        backward = BitNfa(re2);
+    }
+
     bool opCall(Input)(ref Input r)
     {
         bool res = forward(r);
         if(res){
-            auto backward = r.loopBack
-            backward(backward);
-            r.reset(backward._index);
+            auto back = r.loopBack(r._index);
+            assert(backward(back));
+            r.reset(back._index);
         }
         return res;
     }
 }
 
+version(unittest)
+{
+    template check(alias make)
+    {
+        private void check(T)(string input, T re, size_t idx=uint.max)
+        {
+            import std.regex, std.conv;
+            import std.stdio;
+            auto rex = regex(re);
+            auto m = make(rex);
+            auto s = Input!char(input);
+            assert(m(s), "Failed "~input~" with "~to!string(re));
+            assert(s._index == idx || (idx ==uint.max && s._index == input.length));
+        }
+    }
+
+    template checkFail(alias make)
+    {
+        private void checkFail(T)(string input, T re, size_t idx=uint.max)
+        {
+            import std.regex, std.conv;
+            import std.stdio;
+            auto rex = regex(re);
+            auto m = make(rex);
+            auto s = Input!char(input);
+            assert(!m(s), "Should have failed "~input~" with "~to!string(re));
+            assert(s._index == idx || (idx ==uint.max && s._index == input.length));
+        }
+    }
+
+    alias checkBit = check!BitNfa;
+    alias checkBitFail = checkFail!BitNfa;
+    auto makeMatcher(R)(R regex){ return new BitMatcher(regex); }
+    alias checkM = check!makeMatcher;
+    alias checkMFail = checkFail!makeMatcher;
+}
+
+unittest
+{
+    "xabcd".checkBit("abc", 4);
+    "xabbbcdyy".checkBit("a[b-c]*c", 6);
+    "abc1".checkBit("([a-zA-Z_0-9]*)1");
+    "abbabc".checkBit("(a|b)*",5);
+    "abd".checkBitFail("abc");
+    // check truncation
+    "0123456789_0123456789_0123456789_012"
+        .checkBit("0123456789_0123456789_0123456789_0123456789", 31);
+    "0123456789_0123456789_0123456789_012"
+        .checkBit("0123456789(0123456789_0123456789_0123456789_0123456789|01234)",10);
+    // assertions ignored
+    "0abc1".checkBit("(?<![0-9])[a-c]*$", 4);
+    // stop on repetition
+    "abcdef1".checkBit("a[a-z]{5}", 1);
+    "ads@email.com".checkBit(`\S+@\S+`);
+}
+
+unittest
+{
+    "xxabcy".checkM("abc", 2);
+    "_10bcy".checkM([`\d+`, `[a-z]+`], 1);
+}

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -182,8 +182,9 @@ struct UIntTrie2
             mixin("scratch[lowIdx..highIdx] "~op~"= val;");
             uint h = hash(scratch);
             bool found = false;
-            foreach(i,_; hashes.enumerate.filter!(x => x[1] == h))
+            foreach(i,x; hashes)
             {
+                if(x != h) continue;
                 if(scratch[] == blocks[i*blockSize .. (i+1)*blockSize])
                 {
                     // re-route to existing page
@@ -423,6 +424,11 @@ outer:  for(uint i=0; i<ir.length; i += ir[i].length) with(IR)
                 break;
             case End:
                 finalMask |= 1u<<bitMapping[i];
+                break;
+            case Any:
+                uint mask = 1u<<bitMapping[i];
+                asciiTab[0..0x80] &= ~mask;
+                uniTab[0..0x11_0000] &= ~mask;
                 break;
             case Char:
                 uint mask = 1u<<bitMapping[i];

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -40,8 +40,8 @@ struct HashTab
                 grow();
                 p = locate(key, table);
             }
-            p.occupied = true;
-            p.key = key;
+            p.key_ = key;
+            p.setOccupied();
         }
         p.value = value;
     }
@@ -76,9 +76,12 @@ private:
 
     struct Node
     {
-        uint key;
+        uint key_;
         uint value;
-        bool occupied;
+        @property uint key()(){ return key_ & 0x7fff_ffff; }
+        @property bool occupied()(){ return (key_ & 0x8000_0000) != 0; }
+        void setOccupied(){ key_ |= 0x8000_0000; }
+
     }
     Node[] table;
     size_t items;

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -1,0 +1,60 @@
+//Written in the D programming language
+/*
+    Implementation of a concept "NFA in a word" which is
+    bit-parallel impementation of regex where each bit represents 
+    a state in an NFA. Execution is Thompson-style achieved via bit tricks.
+
+    There is a great number of limitations inlcuding not tracking any state (captures)
+    and not supporting even basic assertions such as ^, $  or \b.
+*/
+import std.regex.internal.ir;
+
+// since there is no way to mark a starting position
+// need 2 instance of BitNfa - one to find the end, and the other
+// to run backwards to find the start.
+struct BitNfa
+{
+    uint        asciiTab[128];    // state mask for ascii characters
+    UintTrie2   uniTab;           // state mask for unicode characters
+    uint[uint]  controlFlow;      // maps each bit pattern to resulting jumps pattern
+    uint        controlFlowMask;  // masks all control flow bits
+    uint        finalMask;        // marks final states terminating the NFA
+
+    bool opCall(Input)(ref Input r)
+    {
+        dchar ch;
+        size_t idx;
+        uint word = ~0u;
+        while(r.nextChar(ch, idx)){
+            word <<= 1; // shift - create a state
+            // cfMask has 1 for each control-flow op
+            uint cflow = ~word  & controlFlowMask; 
+            word = word | controlFlowMask; // kill cflow
+            word |= controlFlow[cflow]; // map normal ops
+            if(word & finalMask != finalMask)
+                return true;
+            // mask away failing states
+            if(ch < 0x80)
+                word |= assciiTab[ch];
+            else
+                word |= uniTab[ch];
+        }
+        return false;
+    }
+}
+
+final class BitMatcher
+{
+    BitNfa forward, backward;
+    bool opCall(Input)(ref Input r)
+    {
+        bool res = forward(r);
+        if(res){
+            auto backward = r.loopBack
+            backward(backward);
+            r.reset(backward._index);
+        }
+        return res;
+    }
+}
+

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -17,11 +17,11 @@ debug(std_regex_bitnfa) import std.stdio;
 import std.algorithm;
 
 
-struct HashTab()
+struct HashTab
 {
     @disable this(this);
 
-    uint opIndex(uint key)
+    uint opIndex()(uint key)
     {
         auto p = locate(key, table);
         assert(p.occupied);
@@ -69,7 +69,7 @@ struct HashTab()
     }
 
 private:
-    static uint hashOf(uint val)
+    static uint hashOf()(uint val)
     {
         return (val >> 20) ^ (val>>8) ^ val;
     }
@@ -83,12 +83,12 @@ private:
     Node[] table;
     size_t items;
 
-    static Node* locate(uint key, Node[] table)
+    static Node* locate()(uint key, Node[] table)
     {
         size_t slot = hashOf(key) & (table.length-1);
-        while(table.ptr[slot].occupied)
+        while(table[slot].occupied)
         {
-            if(table.ptr[slot].key == key)
+            if(table[slot].key == key)
                 break;
             slot += 1;
             if(slot == table.length)
@@ -108,6 +108,7 @@ private:
                 *p = v;
             }
         }
+        table = newTable;
     }
 }
 
@@ -248,7 +249,7 @@ struct BitNfa
 {
     uint[128]   asciiTab;         // state mask for ascii characters
     UIntTrie2   uniTab;           // state mask for unicode characters
-    uint[uint]  controlFlow;      // maps each bit pattern to resulting jumps pattern
+    HashTab     controlFlow;      // maps each bit pattern to resulting jumps pattern
     uint        controlFlowMask;  // masks all control flow bits
     uint        finalMask;        // marks final states terminating the NFA
     bool        empty;            // if this engine is empty
@@ -609,6 +610,7 @@ unittest
     // stop on repetition
     "abcdef1".checkBit("a[a-z]{5}", 1);
     "ads@email.com".checkBit(`\S+@\S+`);
+    //"abc".checkBit(`([^ ]*)?`);
 }
 
 unittest

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -352,7 +352,6 @@ struct BitNfa
         // pc -> bit number
         uint[] bitMapping = new uint[re.ir.length];
         uint bitCount = 0, nesting=0, lastNonnested=0;
-        bool stop = false;
         with(re)
 outer:  for(uint i=0; i<ir.length; i += ir[i].length) with(IR)
         {
@@ -375,7 +374,7 @@ outer:  for(uint i=0; i<ir.length; i += ir[i].length) with(IR)
                 break;
             // unsupported instructions
             case RepeatStart, RepeatQStart, Backref:
-                stop = true;
+                bitMapping[i] = bitCount;
                 break outer;
             case OrChar:
                 uint s = ir[i].sequence;
@@ -398,8 +397,6 @@ outer:  for(uint i=0; i<ir.length; i += ir[i].length) with(IR)
         // the total processable length
         uint length=lastNonnested;
         finalMask |= 1u<<bitMapping[length];
-        if(stop)
-            finalMask <<= 1;
         with(re)
         for(uint i=0; i<length; i += ir[i].length)
         {
@@ -613,7 +610,7 @@ unittest
     // stop on repetition
     "abcdef1".checkBit("a[a-z]{5}", 1);
     "ads@email.com".checkBit(`\S+@\S+`);
-    //"abc".checkBit(`([^ ]*)?`);
+    "abc@email.com".checkBit(`\S+@\S?1`, 4);
 }
 
 unittest

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -172,7 +172,7 @@ struct UIntTrie2
             immutable highIdx = high - low + lowIdx;
             mixin("blocks[lowIdx..highIdx] "~op~"= val;");
         }
-        else        
+        else
         {
             // create a new page
             refCounts[blk]--;

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -447,6 +447,17 @@ struct Group(DataIndex)
         writeln("\t", disassemble(slice, pc, dict));
 }
 
+/+
+    Generic interface for kickstart engine components.
+    The goal of kickstart is to advance input to the next potential match,
+    the more accurate & fast the better.
++/
+interface Kickstart(Char){
+@trusted:
+    bool opCall(ref Input!Char input);
+    @property bool empty() const;
+}
+
 /++
     $(D Regex) object holds regular expression pattern in compiled form.
     Instances of this object are constructed via calls to $(D regex).
@@ -508,7 +519,6 @@ struct Regex(Char)
     }
 
 package(std.regex):
-    import std.regex.internal.kickstart : Kickstart; //TODO: get rid of this dependency
     NamedGroup[] dict;                     // maps name -> user group number
     uint ngroup;                           // number of internal groups
     uint maxCounterDepth;                  // max depth of nested {n,m} repetitions
@@ -618,10 +628,10 @@ struct Input(Char)
     @property bool atEnd(){
         return _index == _origin.length;
     }
+
     bool search(Kickstart)(ref Kickstart kick, ref dchar res, ref size_t pos)
     {
-        size_t idx = kick.search(_origin, _index);
-        _index = idx;
+        kick(this);
         return nextChar(res, pos);
     }
 

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -458,6 +458,114 @@ interface Kickstart(Char){
     @property bool empty() const;
 }
 
+//basic stack, just in case it gets used anywhere else then Parser
+@trusted struct Stack(T)
+{
+    T[] data;
+    @property bool empty(){ return data.empty; }
+
+    @property size_t length(){ return data.length; }
+
+    void push(T val){ data ~= val;  }
+
+    T pop()
+    {
+        assert(!empty);
+        auto val = data[$ - 1];
+        data = data[0 .. $ - 1];
+        if(!__ctfe)
+            cast(void)data.assumeSafeAppend();
+        return val;
+    }
+
+    @property ref T top()
+    {
+        assert(!empty);
+        return data[$ - 1];
+    }
+}
+
+@trusted void reverseBytecode()(Bytecode[] code)
+{
+    import std.typecons;
+    Bytecode[] rev = new Bytecode[code.length];
+    uint revPc = cast(uint)rev.length;
+    Stack!(Tuple!(uint, uint, uint)) stack;
+    uint start = 0;
+    uint end = cast(uint)code.length;
+    for(;;)
+    {
+        for(uint pc = start; pc < end; )
+        {
+            uint len = code[pc].length;
+            if(code[pc].code == IR.GotoEndOr)
+                break; //pick next alternation branch
+            if(code[pc].isAtom)
+            {
+                rev[revPc - len .. revPc] = code[pc .. pc + len];
+                revPc -= len;
+                pc += len;
+            }
+            else if(code[pc].isStart || code[pc].isEnd)
+            {
+                //skip over other embedded lookbehinds they are reversed
+                if(code[pc].code == IR.LookbehindStart
+                    || code[pc].code == IR.NeglookbehindStart)
+                {
+                    uint blockLen = len + code[pc].data
+                         + code[pc].pairedLength;
+                    rev[revPc - blockLen .. revPc] = code[pc .. pc + blockLen];
+                    pc += blockLen;
+                    revPc -= blockLen;
+                    continue;
+                }
+                uint second = code[pc].indexOfPair(pc);
+                uint secLen = code[second].length;
+                rev[revPc - secLen .. revPc] = code[second .. second + secLen];
+                revPc -= secLen;
+                if(code[pc].code == IR.OrStart)
+                {
+                    //we pass len bytes forward, but secLen in reverse
+                    uint revStart = revPc - (second + len - secLen - pc);
+                    uint r = revStart;
+                    uint i = pc + IRL!(IR.OrStart);
+                    while(code[i].code == IR.Option)
+                    {
+                        if(code[i - 1].code != IR.OrStart)
+                        {
+                            assert(code[i - 1].code == IR.GotoEndOr);
+                            rev[r - 1] = code[i - 1];
+                        }
+                        rev[r] = code[i];
+                        auto newStart = i + IRL!(IR.Option);
+                        auto newEnd = newStart + code[i].data;
+                        auto newRpc = r + code[i].data + IRL!(IR.Option);
+                        if(code[newEnd].code != IR.OrEnd)
+                        {
+                            newRpc--;
+                        }
+                        stack.push(tuple(newStart, newEnd, newRpc));
+                        r += code[i].data + IRL!(IR.Option);
+                        i += code[i].data + IRL!(IR.Option);
+                    }
+                    pc = i;
+                    revPc = revStart;
+                    assert(code[pc].code == IR.OrEnd);
+                }
+                else
+                    pc += len;
+            }
+        }
+        if(stack.empty)
+            break;
+        start = stack.top[0];
+        end = stack.top[1];
+        revPc = stack.top[2];
+        stack.pop();
+    }
+    code[] = rev[];
+}
+
 /++
     $(D Regex) object holds regular expression pattern in compiled form.
     Instances of this object are constructed via calls to $(D regex).

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -4,7 +4,8 @@
 */
 module std.regex.internal.parser;
 
-import std.regex.internal.ir, std.regex.internal.shiftor;
+import std.regex.internal.ir, std.regex.internal.shiftor,
+    std.regex.internal.bitnfa;
 import std.algorithm, std.range, std.uni, std.meta,
     std.traits, std.typecons, std.exception;
 static import std.ascii;
@@ -179,7 +180,7 @@ dchar parseUniHex(Char)(ref Char[] str, size_t maxDigit)
     return val;
 }
 
-@system unittest //BUG canFind is system
+@safe unittest
 {
     string[] non_hex = [ "000j", "000z", "FffG", "0Z"];
     string[] hex = [ "01", "ff", "00af", "10FFFF" ];
@@ -1481,7 +1482,11 @@ struct Parser(R)
         {
             kickstart = new ShiftOr!Char(zis);
             if(kickstart.empty)
-                kickstart = null;
+            {
+                kickstart = new BitMatcher!Char(zis);
+                if(kickstart.empty)
+                    kickstart = null;
+            }
         }
         debug(std_regex_allocation) writefln("IR processed, max threads: %d", threadCount);
         optimize(zis);

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -4,7 +4,7 @@
 */
 module std.regex.internal.parser;
 
-import std.regex.internal.ir;
+import std.regex.internal.ir, std.regex.internal.shiftor;
 import std.algorithm, std.range, std.uni, std.meta,
     std.traits, std.typecons, std.exception;
 static import std.ascii;
@@ -1475,7 +1475,11 @@ struct Parser(R)
         }
         checkIfOneShot();
         if(!(flags & RegexInfo.oneShot))
-            kickstart = Kickstart!Char(zis, new uint[](256));
+        {
+            kickstart = new ShiftOr!Char(zis);
+            if(kickstart.empty)
+                kickstart = null;
+        }
         debug(std_regex_allocation) writefln("IR processed, max threads: %d", threadCount);
         optimize(zis);
     }

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1354,11 +1354,14 @@ struct Parser(R)
                 put(Bytecode(IR.End, current - privateUseStart + 1));
                 ngroup = max(ngroup, groupStack.top);
                 groupStack.top = 1; // reset group counter
-                break;
+                next();
             }
-            auto op = Bytecode(IR.Char, current);
-            next();
-            put(op);
+            else
+            {
+                auto op = Bytecode(IR.Char, current);
+                next();
+                put(op);
+            }
         }
     }
 

--- a/std/regex/internal/shiftor.d
+++ b/std/regex/internal/shiftor.d
@@ -335,25 +335,6 @@ public:
                         t.pc += IRL!(IR.RepeatEnd);
                     }
                     break;
-                case IR.InfiniteStart, IR.InfiniteQStart:
-                    t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteStart);
-                    goto case IR.InfiniteEnd; //both Q and non-Q
-                case IR.InfiniteEnd:
-                case IR.InfiniteQEnd:
-                    auto slot = re.ir[t.pc+1].raw+t.counter;
-                    auto val = hash(t.tab);
-                    if(val in merge[slot])
-                        goto L_StopThread; // merge equivalent
-                    merge[slot][val] = true;
-                    uint len = re.ir[t.pc].data;
-                    uint pc1, pc2; //branches to take in priority order
-                    if(++t.hops == 32)
-                        goto L_StopThread;
-                    pc1 = t.pc + IRL!(IR.InfiniteEnd);
-                    pc2 = t.pc - len;
-                    trs ~= fork(t, pc2, t.counter);
-                    t.pc = pc1;
-                    break;
                 case IR.GroupStart, IR.GroupEnd:
                     t.pc += IRL!(IR.GroupStart);
                     break;
@@ -381,7 +362,7 @@ public:
         }
     }
 
-    final @property bool empty() const {  return n_length == 0; }
+    final @property bool empty() const {  return n_length < 3 && fChar == uint.max; }
 
     final @property uint length() const{ return n_length/charSize; }
 
@@ -579,7 +560,7 @@ unittest
         searches("abdcdyabax".to!String, kick, 1, 3, 8);
 
         shiftOrLength(`...`.to!String, 0);
-        kick = shiftOrLength(`a(b+|c+)x`.to!String, 3);
+        kick = shiftOrLength(`a(b{1,2}|c{1,2})x`.to!String, 3);
         searches("ababx".to!String, kick, 2);
         searches("abaacba".to!String, kick, 3); //expected inexact
 

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -417,7 +417,7 @@ unittest
             alias Tests = Sequence!(220, tv.length);
         }
         else
-            alias Tests = AliasSeq!(Sequence!(0, 30), Sequence!(235, tv.length-5));
+            alias Tests = AliasSeq!(Sequence!(0, 25), Sequence!(238, tv.length-5));
         foreach(a, v; Tests)
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum tvd = tv[v];

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -772,7 +772,6 @@ template ThompsonOps(E,S, bool withInput:false)
     {
         bool search()
         {
-
             if(!s.search(re.kickstart, front, index))
             {
                 index = s.lastIndex;
@@ -896,7 +895,7 @@ template ThompsonOps(E,S, bool withInput:false)
             return matchOneShot(matches);
         }
         static if(kicked)
-            if(!re.kickstart.empty)
+            if(re.kickstart)
                 return matchImpl!(true)(matches);
         return matchImpl!(false)(matches);
     }

--- a/win32.mak
+++ b/win32.mak
@@ -226,7 +226,7 @@ SRC_STD_REGEX= \
 	std\regex\internal\tests.d \
 	std\regex\internal\backtracking.d \
 	std\regex\internal\thompson.d \
-	std\regex\internal\kickstart.d \
+	std\regex\internal\shiftor.d \
 	std\regex\internal\generator.d
 
 SRC_STD_C= \

--- a/win32.mak
+++ b/win32.mak
@@ -227,6 +227,7 @@ SRC_STD_REGEX= \
 	std\regex\internal\backtracking.d \
 	std\regex\internal\thompson.d \
 	std\regex\internal\shiftor.d \
+	std\regex\internal\bitnfa.d \
 	std\regex\internal\generator.d
 
 SRC_STD_C= \

--- a/win64.mak
+++ b/win64.mak
@@ -248,7 +248,7 @@ SRC_STD_REGEX= \
 	std\regex\internal\tests.d \
 	std\regex\internal\backtracking.d \
 	std\regex\internal\thompson.d \
-	std\regex\internal\kickstart.d \
+	std\regex\internal\shiftor.d \
 	std\regex\internal\generator.d
 
 SRC_STD_C= \

--- a/win64.mak
+++ b/win64.mak
@@ -249,6 +249,7 @@ SRC_STD_REGEX= \
 	std\regex\internal\backtracking.d \
 	std\regex\internal\thompson.d \
 	std\regex\internal\shiftor.d \
+	std\regex\internal\bitnfa.d \
 	std\regex\internal\generator.d
 
 SRC_STD_C= \


### PR DESCRIPTION
A new kickstart engine that can be used to match regex prefix accurately,
with the limitation of no longer then 31 states and no repetitions (for now).
Once we find accurate prefix we start the full slow engine.

A picture worth a thousand words:
![pic12](https://cloud.githubusercontent.com/assets/281770/14737682/003a5a68-0886-11e6-8e21-f5e9e56de955.png)
