### PR TITLE
[std.regex] Support for inline flags

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -126,8 +126,8 @@ enum IR:uint {
     OrChar             = 0b1_00100_00,
     Nop                = 0b1_00101_00, //no operation (padding)
     End                = 0b1_00110_00, //end of program
-    Bol                = 0b1_00111_00, //beginning of a string ^
-    Eol                = 0b1_01000_00, //end of a string $
+    Bol                = 0b1_00111_00, //beginning of a line ^
+    Eol                = 0b1_01000_00, //end of a line $
     Wordboundary       = 0b1_01001_00, //boundary of a word
     Notwordboundary    = 0b1_01010_00, //not a word boundary
     Backref            = 0b1_01011_00, //backreference to a group (that has to be pinned, i.e. locally unique) (group index)
@@ -135,6 +135,8 @@ enum IR:uint {
     GroupEnd           = 0b1_01101_00, //end of a group (x) (groupIndex+groupPinning(1bit))
     Option             = 0b1_01110_00, //start of an option within an alternation x | y (length)
     GotoEndOr          = 0b1_01111_00, //end of an option (length of the rest)
+    Bof                = 0b1_10000_00, //begining of "file" (string) ^
+    Eof                = 0b1_10001_00, //end of "file" (string) $
     //... any additional atoms here
 
     OrStart            = 0b1_00000_01, //start of alternation group  (length)
@@ -531,17 +533,16 @@ package(std.regex):
     //check if searching is not needed
     void checkIfOneShot()
     {
-        if (flags & RegexOption.multiline)
-            return;
     L_CheckLoop:
         for (uint i = 0; i < ir.length; i += ir[i].length)
         {
             switch (ir[i].code)
             {
-                case IR.Bol:
+                case IR.Bof:
                     flags |= RegexInfo.oneShot;
                     break L_CheckLoop;
-                case IR.GroupStart, IR.GroupEnd, IR.Eol, IR.Wordboundary, IR.Notwordboundary:
+                case IR.GroupStart, IR.GroupEnd, IR.Bol, IR.Eol, IR.Eof,
+                IR.Wordboundary, IR.Notwordboundary:
                     break;
                 default:
                     break L_CheckLoop;

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -160,7 +160,7 @@ public:
                 case IR.GroupStart, IR.GroupEnd:
                     i += IRL!(IR.GroupStart);
                     break;
-                case IR.Bol, IR.Wordboundary, IR.Notwordboundary:
+                case IR.Bof, IR.Bol, IR.Wordboundary, IR.Notwordboundary:
                     i += IRL!(IR.Bol);
                     break;
                 default:
@@ -357,7 +357,7 @@ public:
                 case IR.GroupStart, IR.GroupEnd:
                     t.pc += IRL!(IR.GroupStart);
                     break;
-                case IR.Bol, IR.Wordboundary, IR.Notwordboundary:
+                case IR.Bof, IR.Bol, IR.Wordboundary, IR.Notwordboundary:
                     t.pc += IRL!(IR.Bol);
                     break;
                 case IR.LookaheadStart, IR.NeglookaheadStart, IR.LookbehindStart, IR.NeglookbehindStart:

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -337,6 +337,11 @@ unittest
 //mixed lookaround
         TestVectors(   `a(?<=a(?=b))b`,    "ab", "y",      "$&", "ab"),
         TestVectors(   `a(?<=a(?!b))c`,    "ac", "y",      "$&", "ac"),
+        TestVectors(   `a(?i)bc`,         "aBc", "y",      "$&", "aBc"),
+        TestVectors(   `a(?i)bc`,         "Abc", "n",      "$&", "-"),
+        TestVectors(   `(?i)a(?-i)bc`, "aBcAbc", "y",      "$&", "Abc"),
+        TestVectors(   `(?s).(?-s).`, "\n\n\na", "y",      "$&", "\na"),
+        TestVectors(   `(?m)^a(?-m)$`,  "\na",   "y",      "$&", "a")
         ];
     string produceExpected(M,String)(auto ref M m, String fmt)
     {


### PR DESCRIPTION
Also should optimize a tiny bit things like '.' and '^' by separating e.g. beginning of line vs beginning of string on the instruction level rather then checking a run-time flag every time.