### PR TITLE
[std.regex] Split code generation and parsing, almost completely.

### DIFF
--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -373,7 +373,7 @@ public auto regexImpl(S)(S pattern, const(char)[] flags="")
     if(isSomeString!(S))
 {
     import std.regex.internal.parser;
-    auto parser = Parser!(Unqual!(typeof(pattern)))(pattern, flags);
+    auto parser = Parser!(Unqual!(typeof(pattern)), CodeGen)(pattern, flags);
     auto r = parser.program;
     return r;
 }


### PR DESCRIPTION
This should aid readability and reduce the obscurity of the parser.
Also potentially non-generating parser is possible reusing the same code.