### PR TITLE
Add std.meta.Apply

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -23,6 +23,8 @@ $(BUGSTITLE Library Changes,
     of the type being iterated)
     $(LI $(XREF algorithm, sorting, isStrictlyMonotonic) which doesn't allow
     equal values was added.)
+    $(LI $(XREF meta, Apply) was added to instantiate templates which would
+    otherwise be disallowed by D's grammar.)
 )
 
 $(BUGSTITLE Library Changes,


### PR DESCRIPTION
Instantiates templates when D would otherwise need a separate alias. See unittest for details.

Naming follows [ApplyLeft, ApplyRight](http://dlang.org/phobos-prerelease/std_meta.html#.ApplyLeft) (and is shorter than existing `Instantiate`).

@klickverbot @schveiguy 