### PR TITLE
DDOC_BLANKLINE

### DIFF
--- a/index.d
+++ b/index.d
@@ -520,3 +520,5 @@ $(COMMENT
 Macros:
         TITLE=Phobos Runtime Library
         WIKI=Phobos
+        DDOC_BLANKLINE=
+        _=


### PR DESCRIPTION
Eh, this is the missing element that ties https://github.com/dlang/dmd/pull/5344 and https://github.com/dlang/dlang.org/pull/1282 together.