### PR TITLE
std.algorithm style fix: space between operators

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -280,7 +280,7 @@ auto castSwitch(choices...)(Object switchObject)
 
                 if (classInfo == typeid(CastClass))
                 {
-                    static if(is(ReturnType!(choice) == void))
+                    static if (is(ReturnType!(choice) == void))
                     {
                         choice(cast(CastClass) switchObject);
                         static if (areAllHandlersVoidResult)
@@ -308,7 +308,7 @@ auto castSwitch(choices...)(Object switchObject)
             {
                 if (auto castedObject = cast(choiceParameterTypes[0]) switchObject)
                 {
-                    static if(is(ReturnType!(choice) == void))
+                    static if (is(ReturnType!(choice) == void))
                     {
                         choice(castedObject);
                         static if (areAllHandlersVoidResult)
@@ -345,7 +345,7 @@ auto castSwitch(choices...)(Object switchObject)
 
                 if (switchObject is null)
                 {
-                    static if(is(ReturnType!(choice) == void))
+                    static if (is(ReturnType!(choice) == void))
                     {
                         choice();
                         static if (areAllHandlersVoidResult)

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -461,7 +461,7 @@ template map(fun...) if (fun.length >= 1)
             alias _fun = adjoin!_funs;
 
             // Once DMD issue #5710 is fixed, this validation loop can be moved into a template.
-            foreach(f; _funs)
+            foreach (f; _funs)
             {
                 static assert(!is(typeof(f(RE.init)) == void),
                     "Mapping function(s) must not return void: " ~ _funs.stringof);
@@ -4263,7 +4263,7 @@ unittest
 @safe pure nothrow @nogc unittest
 {
     import std.range;
-    foreach(n; iota(50))
+    foreach (n; iota(50))
         assert(repeat(1.0, n).sum == n);
 }
 

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -829,7 +829,7 @@ unittest
     assert (!typeid(S3).initializer().ptr);
     assert ( typeid(S4).initializer().ptr);
 
-    foreach(S; AliasSeq!(S1, S2, S3, S4))
+    foreach (S; AliasSeq!(S1, S2, S3, S4))
     {
         //initializeAll
         {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -514,7 +514,7 @@ if (isNarrowString!R1 && isNarrowString!R2)
                           wchar[], const(wchar)[], wstring,
                           dchar[], const(dchar)[], dstring))
     {
-        foreach(T; AliasSeq!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(commonPrefix(to!S(""), to!T("")).empty);
             assert(commonPrefix(to!S(""), to!T("hello")).empty);
@@ -1425,9 +1425,9 @@ if (isInputRange!InputRange &&
 @safe pure unittest
 {
     import std.meta : AliasSeq;
-    foreach(R; AliasSeq!(string, wstring, dstring))
+    foreach (R; AliasSeq!(string, wstring, dstring))
     {
-        foreach(E; AliasSeq!(char, wchar, dchar))
+        foreach (E; AliasSeq!(char, wchar, dchar))
         {
             R r1 = "hello world";
             E e1 = 'w';
@@ -1474,9 +1474,9 @@ if (isInputRange!InputRange &&
     {
         byte[]  sarr = [1, 2, 3, 4];
         ubyte[] uarr = [1, 2, 3, 4];
-        foreach(arr; AliasSeq!(sarr, uarr))
+        foreach (arr; AliasSeq!(sarr, uarr))
         {
-            foreach(T; AliasSeq!(byte, ubyte, int, uint))
+            foreach (T; AliasSeq!(byte, ubyte, int, uint))
             {
                 assert(find(arr, cast(T) 3) == arr[2 .. $]);
                 assert(find(arr, cast(T) 9) == arr[$ .. $]);

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1001,7 +1001,7 @@ private:
                     do {
                         next.popFront();
                         if (next.empty) return;
-                    } while(comp(next.front, r.front));
+                    } while (comp(next.front, r.front));
                     done = Rs.length;
                 }
                 if (--done == 0) return;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -964,7 +964,7 @@ private size_t getPivot(alias less, Range)(Range r)
                             ((cast(uint) (pred(r[0], r[len - 1]))) << 1) |
                             (cast(uint) (pred(r[mid], r[len - 1])));
 
-    switch(result) {
+    switch (result) {
         case 0b001:
             r.swapAt(0, len - 1);
             r.swapAt(0, mid);
@@ -1243,7 +1243,7 @@ unittest
         size_t[] arr;
         arr.length = 1024;
 
-        foreach(k; 0..arr.length) arr[k] = k;
+        foreach (k; 0..arr.length) arr[k] = k;
         swapRanges(arr[0..$/2], arr[$/2..$]);
 
         sort!(pred, SwapStrategy.unstable)(arr);
@@ -1538,7 +1538,7 @@ private template TimSortImpl(alias pred, R)
                 if (stackLen == 2) assert(stack[0].length > stack[1].length);
                 else if (stackLen > 2)
                 {
-                    foreach(k; 2 .. stackLen)
+                    foreach (k; 2 .. stackLen)
                     {
                         assert(stack[k - 2].length > stack[k - 1].length + stack[k].length);
                         assert(stack[k - 1].length > stack[k].length);
@@ -1729,7 +1729,7 @@ private template TimSortImpl(alias pred, R)
         immutable lef_end = temp.length - 1;
 
         if (lef < lef_end && rig < range.length)
-        outer: while(true)
+        outer: while (true)
         {
             count_lef = 0;
             count_rig = 0;
@@ -1740,14 +1740,14 @@ private template TimSortImpl(alias pred, R)
                 if (lessEqual(temp[lef], range[rig]))
                 {
                     range[i++] = temp[lef++];
-                    if(lef >= lef_end) break outer;
+                    if (lef >= lef_end) break outer;
                     ++count_lef;
                     count_rig = 0;
                 }
                 else
                 {
                     range[i++] = range[rig++];
-                    if(rig >= range.length) break outer;
+                    if (rig >= range.length) break outer;
                     count_lef = 0;
                     ++count_rig;
                 }
@@ -1758,14 +1758,14 @@ private template TimSortImpl(alias pred, R)
             {
                 count_lef = gallopForwardUpper(temp[lef .. $], range[rig]);
                 foreach (j; 0 .. count_lef) range[i++] = temp[lef++];
-                if(lef >= temp.length) break outer;
+                if (lef >= temp.length) break outer;
 
                 count_rig = gallopForwardLower(range[rig .. range.length], temp[lef]);
                 foreach (j; 0 .. count_rig) range[i++] = range[rig++];
-                if (rig >= range.length) while(true)
+                if (rig >= range.length) while (true)
                 {
                     range[i++] = temp[lef++];
-                    if(lef >= temp.length) break outer;
+                    if (lef >= temp.length) break outer;
                 }
 
                 if (minGallop > 0) --minGallop;
@@ -1811,24 +1811,24 @@ private template TimSortImpl(alias pred, R)
         size_t count_lef, count_rig;
 
         outer:
-        while(true)
+        while (true)
         {
             count_lef = 0;
             count_rig = 0;
 
             // Linear merge
-            while((count_lef | count_rig) < minGallop)
+            while ((count_lef | count_rig) < minGallop)
             {
-                if(greaterEqual(temp[rig], range[lef]))
+                if (greaterEqual(temp[rig], range[lef]))
                 {
                     range[i--] = temp[rig];
-                    if(rig == 1)
+                    if (rig == 1)
                     {
                         // Move remaining elements from left
-                        while(true)
+                        while (true)
                         {
                             range[i--] = range[lef];
-                            if(lef == 0) break;
+                            if (lef == 0) break;
                             --lef;
                         }
 
@@ -1844,10 +1844,10 @@ private template TimSortImpl(alias pred, R)
                 else
                 {
                     range[i--] = range[lef];
-                    if(lef == 0) while(true)
+                    if (lef == 0) while (true)
                     {
                         range[i--] = temp[rig];
-                        if(rig == 0) break outer;
+                        if (rig == 0) break outer;
                         --rig;
                     }
                     --lef;
@@ -1860,29 +1860,29 @@ private template TimSortImpl(alias pred, R)
             do
             {
                 count_rig = rig - gallopReverseLower(temp[0 .. rig], range[lef]);
-                foreach(j; 0 .. count_rig)
+                foreach (j; 0 .. count_rig)
                 {
                     range[i--] = temp[rig];
-                    if(rig == 0) break outer;
+                    if (rig == 0) break outer;
                     --rig;
                 }
 
                 count_lef = lef - gallopReverseUpper(range[0 .. lef], temp[rig]);
-                foreach(j; 0 .. count_lef)
+                foreach (j; 0 .. count_lef)
                 {
                     range[i--] = range[lef];
-                    if(lef == 0) while(true)
+                    if (lef == 0) while (true)
                     {
                         range[i--] = temp[rig];
-                        if(rig == 0) break outer;
+                        if (rig == 0) break outer;
                         --rig;
                     }
                     --lef;
                 }
 
-                if(minGallop > 0) --minGallop;
+                if (minGallop > 0) --minGallop;
             }
-            while(count_lef >= minimalGallop || count_rig >= minimalGallop);
+            while (count_lef >= minimalGallop || count_rig >= minimalGallop);
 
             minGallop += 2;
         }
@@ -1992,7 +1992,7 @@ unittest
         arr.length = 64 * 64;
 
         // We want duplicate values for testing stability
-        foreach(i, ref v; arr) v.value = i / 64;
+        foreach (i, ref v; arr) v.value = i / 64;
 
         // Swap ranges at random middle point (test large merge operation)
         immutable mid = uniform(arr.length / 4, arr.length / 4 * 3, rnd);
@@ -2002,7 +2002,7 @@ unittest
         randomShuffle(arr[$ / 8 * 7 .. $], rnd);
 
         // Swap few random elements (test galloping mode)
-        foreach(i; 0 .. arr.length / 64)
+        foreach (i; 0 .. arr.length / 64)
         {
             immutable a = uniform(0, arr.length, rnd), b = uniform(0, arr.length, rnd);
             swap(arr[a], arr[b]);
@@ -2010,7 +2010,7 @@ unittest
 
         // Now that our test array is prepped, store original index value
         // This will allow us to confirm the array was sorted stably
-        foreach(i, ref v; arr) v.index = i;
+        foreach (i, ref v; arr) v.index = i;
 
         return arr;
     }
@@ -2032,9 +2032,9 @@ unittest
         assert(isSorted!comp(arr));
 
         // Test that the array was sorted stably
-        foreach(i; 0 .. arr.length - 1)
+        foreach (i; 0 .. arr.length - 1)
         {
-            if(arr[i].value == arr[i + 1].value) assert(arr[i].index < arr[i + 1].index);
+            if (arr[i].value == arr[i + 1].value) assert(arr[i].index < arr[i + 1].index);
         }
 
         return true;
@@ -3047,7 +3047,7 @@ bool nextEvenPermutation(alias less="a < b", BidirectionalRange)
         reverse(takeExactly(retro(range), n));
         if ((n / 2) % 2 == 1)
             oddParity = !oddParity;
-    } while(oddParity);
+    } while (oddParity);
 
     return ret;
 }


### PR DESCRIPTION
basically just running:

```
sed -i "s/switch(/switch (/" **/*.d
sed -i "s/foreach(/foreach (/" **/*.d
sed -i "s/foreach_reverse(/foreach_reverse (/" **/*.d
sed -i "s/while(/while (/" **/*.d
sed -i "s/if(/if (/" **/*.d
```

over the codebase.