### PR TITLE
use travis CI to lint Phobos

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -1,0 +1,66 @@
+; Configure which static analysis checks are enabled
+[analysis.config.StaticAnalysisConfig]
+; Check variable, class, struct, interface, union, and function names against
+; the Phobos style guide
+style_check="false"
+; Check for array literals that cause unnecessary allocation
+enum_array_literal_check="true"
+; Check for poor exception handling practices
+exception_check="false" ; FIXME
+; Check for use of the deprecated 'delete' keyword
+delete_check="false" ; FIXME
+; Check for use of the deprecated floating point operators
+float_operator_check="true"
+; Check number literals for readability
+number_style_check="false" ; FIXME
+; Checks that opEquals, opCmp, toHash, and toString are either const, immutable
+; , or inout.
+object_const_check="false"
+; Checks for .. expressions where the left side is larger than the right.
+backwards_range_check="true"
+; Checks for if statements whose 'then' block is the same as the 'else' block
+if_else_same_check="true"
+; Checks for some problems with constructors
+constructor_check="true"
+; Checks for unused variables and function parameters
+unused_variable_check="false"
+; Checks for unused labels
+unused_label_check="false" ; FIXME
+; Checks for duplicate attributes
+duplicate_attribute="true"
+; Checks that opEquals and toHash are both defined or neither are defined
+opequals_tohash_check="false"
+; Checks for subtraction from .length properties
+length_subtraction_check="false"
+; Checks for methods or properties whose names conflict with built-in properties
+builtin_property_names_check="false"; FIXME
+; Checks for confusing code in inline asm statements
+asm_style_check="false"; FIXME
+; Checks for confusing logical operator precedence
+logical_precedence_check="false"
+; Checks for undocumented public declarations
+undocumented_declaration_check="false"; FIXME
+; Checks for poor placement of function attributes
+function_attribute_check="false"
+; Checks for use of the comma operator
+comma_expression_check="false"
+; Checks for local imports that are too broad
+local_import_check="false"
+; Checks for variables that could be declared immutable
+could_be_immutable_check="false"
+; Checks for redundant expressions in if statements
+redundant_if_check="true"
+; Checks for redundant parenthesis
+redundant_parens_check="true"
+; Checks for mismatched argument and parameter names
+mismatched_args_check="false"
+; Checks for labels with the same name as variables
+label_var_same_name_check="false"
+; Checks for lines longer than 120 characters
+long_line_check="false" ; FIXME
+; Checks for assignment to auto-ref function parameters
+auto_ref_assignment_check="false" ; FIXME
+; Checks for incorrect infinite range definitions
+incorrect_infinite_range_check="true"
+; Checks for asserts that are always true
+useless_assert_check="false"; FIXME

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+os: linux
+language: d
+d: dmd-2.071.0
+install:
+ - wget "https://raw.githubusercontent.com/dlang/dmd/master/src/checkwhitespace.d" -O ../checkwhitespace.d
+ - wget -q -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
+ - chmod +x dscanner
+script:
+ - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
+ - grep -E "(for|foreach|foreach_reverse|if|while)\(" $(find . -name '*.d'); test $? -eq 1
+ - dscanResult=$(./dscanner --config .dscanner.ini --styleCheck std etc 2> /dev/null | grep -vE "(Empty declaration|Primary expression expected)") ; if [ -z "${dscanResult}" ] ; then echo "No warnings found" ; else echo $dscanResult && $(exit 1); fi


### PR DESCRIPTION
follow-up to #4239. Here's a simple setup with Travis.
Obviously a lot of stuff fails (= Phobos doesn't stick to it's own style), but I argue that we should fix this and then enable this bot to help submitters.

Using [DScanner](https://github.com/Hackerpilot/Dscanner) allows us to check for a couple of goodies:

- Check for array literals that cause unnecessary allocation
- Check for poor exception handling practices
- Check for use of the deprecated 'delete' keyword
- Check for use of the deprecated floating point operators
- Check number literals for readability
- Checks that opEquals, opCmp, toHash, and toString are either const, immutable or inout.
- Checks for .. expressions where the left side is larger than the right.
- Checks for if statements whose 'then' block is the same as the 'else' block
- Checks for some problems with constructors
- Checks for unused variables and function parameters
- Checks for unused labels
- Checks for duplicate attributes
- Checks that opEquals and toHash are both defined or neither are defined
- Checks for methods or properties whose names conflict with built-in properties
- Checks for confusing code in inline asm statements
- Checks for undocumented public declarations_
- Checks for poor placement of function attributes
- Checks for use of the comma operator
- Checks for redundant expressions in if statements
- Checks for redundant parenthesis
- Checks for lines longer than 120 characters
- Checks for assignment to auto-ref function parameters
- Checks for incorrect infinite range definitions
- Checks for asserts that are always true

Ping @Hackerpilot.

For mir we already had to disable a couple of flags due to bugs or coding practices (thus they are not listed here) and I assume as Phobos is a lot bigger, we might need to flip one or other flag, but hey in the end we will have a bot that does all the nitpicking for us!