### PR TITLE
use the 'new' alias syntax

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -106,13 +106,13 @@ enum LIBCURL_TIMESTAMP = "Thu Feb 17 12:19:40 UTC 2011";
  * As an exception to the above, curl_off_t shall be typedef'ed to a
  * 32-bit wide signed integral data type if there is no 64-bit type.
  */
-alias long curl_off_t;
+alias curl_off_t = long;
 
 ///
-alias void CURL;
+alias CURL = void;
 
 /// jdrewsen - Get socket alias from std.socket
-alias socket_t curl_socket_t;
+alias curl_socket_t = socket_t;
 
 /// jdrewsen - Would like to get socket error constant from std.socket by it is private atm.
 version(Windows) {
@@ -158,7 +158,7 @@ enum HTTPPOST_CALLBACK    = 64; /** upload file contents by using the
                                     pointer */
 
 ///
-alias int function(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow) curl_progress_callback;
+alias curl_progress_callback = int function(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
 
 /** Tests have proven that 20K is a very bad buffer size for uploads on
    Windows, while 16K for some odd reason performed a lot better.
@@ -179,7 +179,7 @@ enum CURL_MAX_HTTP_HEADER = (100*1024);
 enum CURL_WRITEFUNC_PAUSE = 0x10000001;
 
 ///
-alias size_t  function(char *buffer, size_t size, size_t nitems, void *outstream)curl_write_callback;
+alias curl_write_callback = size_t function(char *buffer, size_t size, size_t nitems, void *outstream);
 
 /** enumeration of file types */
 enum CurlFileType {
@@ -195,7 +195,7 @@ enum CurlFileType {
 }
 
 ///
-alias int curlfiletype;
+alias curlfiletype = int;
 
 ///
 enum CurlFInfoFlagKnown {
@@ -256,7 +256,7 @@ enum CurlChunkBgnFunc {
 /** if splitting of data transfer is enabled, this callback is called before
    download of an individual chunk started. Note that parameter "remains" works
    only for FTP wildcard downloading (for now), otherwise is not used */
-alias c_long function(void *transfer_info, void *ptr, int remains)curl_chunk_bgn_callback;
+alias curl_chunk_bgn_callback = c_long function(void *transfer_info, void *ptr, int remains);
 
 /** return codes for CURLOPT_CHUNK_END_FUNCTION */
 enum CurlChunkEndFunc {
@@ -269,7 +269,7 @@ enum CurlChunkEndFunc {
    Even if downloading of this chunk was skipped in CHUNK_BGN_FUNC.
    This is the reason why we don't need "transfer_info" parameter in this
    callback and we are not interested in "remains" parameter too. */
-alias c_long function(void *ptr)curl_chunk_end_callback;
+alias curl_chunk_end_callback = c_long function(void *ptr);
 
 /** return codes for FNMATCHFUNCTION */
 enum CurlFnMAtchFunc {
@@ -280,7 +280,7 @@ enum CurlFnMAtchFunc {
 
 /** callback type for wildcard downloading pattern matching. If the
    string matches the pattern, return CURL_FNMATCHFUNC_MATCH value, etc. */
-alias int  function(void *ptr, in char *pattern, in char *string)curl_fnmatch_callback;
+alias curl_fnmatch_callback = int function(void *ptr, in char *pattern, in char *string);
 
 /// seek whence...
 enum CurlSeekPos {
@@ -298,7 +298,7 @@ enum CurlSeek {
 }
 
 ///
-alias int  function(void *instream, curl_off_t offset, int origin)curl_seek_callback;
+alias curl_seek_callback = int function(void *instream, curl_off_t offset, int origin);
 
 ///
 enum CurlReadFunc {
@@ -313,7 +313,7 @@ enum CurlReadFunc {
 }
 
 ///
-alias size_t  function(char *buffer, size_t size, size_t nitems, void *instream)curl_read_callback;
+alias curl_read_callback = size_t function(char *buffer, size_t size, size_t nitems, void *instream);
 
 ///
 enum CurlSockType {
@@ -321,10 +321,10 @@ enum CurlSockType {
     last   /** never use */
 }
 ///
-alias int curlsocktype;
+alias curlsocktype = int;
 
 ///
-alias int  function(void *clientp, curl_socket_t curlfd, curlsocktype purpose)curl_sockopt_callback;
+alias curl_sockopt_callback = int function(void *clientp, curl_socket_t curlfd, curlsocktype purpose);
 
 /** addrlen was a socklen_t type before 7.18.0 but it turned really
    ugly and painful on the systems that lack this type */
@@ -340,7 +340,7 @@ extern (C) struct curl_sockaddr
 }
 
 ///
-alias curl_socket_t  function(void *clientp, curlsocktype purpose, curl_sockaddr *address)curl_opensocket_callback;
+alias curl_opensocket_callback = curl_socket_t function(void *clientp, curlsocktype purpose, curl_sockaddr *address);
 
 ///
 enum CurlIoError
@@ -351,7 +351,7 @@ enum CurlIoError
     last           /** never use */
 }
 ///
-alias int curlioerr;
+alias curlioerr = int;
 
 ///
 enum CurlIoCmd {
@@ -360,10 +360,10 @@ enum CurlIoCmd {
     last,        /** never use */
 }
 ///
-alias int curliocmd;
+alias curliocmd = int;
 
 ///
-alias curlioerr  function(CURL *handle, int cmd, void *clientp)curl_ioctl_callback;
+alias curl_ioctl_callback = curlioerr function(CURL *handle, int cmd, void *clientp);
 
 /**
  * The following typedef's are signatures of malloc, free, realloc, strdup and
@@ -371,15 +371,15 @@ alias curlioerr  function(CURL *handle, int cmd, void *clientp)curl_ioctl_callba
  * curl_global_init_mem() function to set user defined memory management
  * callback routines.
  */
-alias void * function(size_t size)curl_malloc_callback;
+alias curl_malloc_callback = void* function(size_t size);
 /// ditto
-alias void  function(void *ptr)curl_free_callback;
+alias curl_free_callback = void function(void *ptr);
 /// ditto
-alias void * function(void *ptr, size_t size)curl_realloc_callback;
+alias curl_realloc_callback = void* function(void *ptr, size_t size);
 /// ditto
-alias char * function(in char *str)curl_strdup_callback;
+alias curl_strdup_callback = char * function(in char *str);
 /// ditto
-alias void * function(size_t nmemb, size_t size)curl_calloc_callback;
+alias curl_calloc_callback = void* function(size_t nmemb, size_t size);
 
 /** the kind of data that is passed to information_callback*/
 enum CurlCallbackInfo {
@@ -393,15 +393,16 @@ enum CurlCallbackInfo {
     end         ///
 }
 ///
-alias int curl_infotype;
+alias curl_infotype = int;
 
 ///
-alias int  function(CURL *handle,        /** the handle/transfer this concerns */
-                    curl_infotype type,  /** what kind of data */
-                    char *data,          /** points to the data */
-                    size_t size,         /** size of the data pointed to */
-                    void *userptr        /** whatever the user please */
-                    )curl_debug_callback;
+alias curl_debug_callback =
+        int function(CURL *handle,        /** the handle/transfer this concerns */
+                     curl_infotype type,  /** what kind of data */
+                     char *data,          /** points to the data */
+                     size_t size,         /** size of the data pointed to */
+                     void *userptr        /** whatever the user please */
+                    );
 
 /** All possible error codes from all sorts of curl functions. Future versions
    may return other values, stay prepared.
@@ -519,17 +520,17 @@ enum CurlError
     curl_last                    /** never use! */
 }
 ///
-alias int CURLcode;
+alias CURLcode = int;
 
 /** This prototype applies to all conversion callbacks */
-alias CURLcode  function(char *buffer, size_t length)curl_conv_callback;
+alias curl_conv_callback = CURLcode function(char *buffer, size_t length);
 
 /** actually an OpenSSL SSL_CTX */
-alias CURLcode  function(CURL *curl,    /** easy handle */
-                         void *ssl_ctx, /** actually an
-                                           OpenSSL SSL_CTX */
-                         void *userptr
-                         )curl_ssl_ctx_callback;
+alias curl_ssl_ctx_callback =
+        CURLcode function(CURL *curl,    /** easy handle */
+                          void *ssl_ctx, /** actually an OpenSSL SSL_CTX */
+                          void *userptr
+                         );
 
 ///
 enum CurlProxy {
@@ -543,7 +544,7 @@ enum CurlProxy {
                          in 7.18.0 */
 }
 ///
-alias int curl_proxytype;
+alias curl_proxytype = int;
 
 ///
 enum CurlAuth : long {
@@ -611,12 +612,13 @@ enum CurlKHMatch {
 }
 
 ///
-alias int  function(CURL *easy,            /** easy handle */
-                    curl_khkey *knownkey,  /** known */
-                    curl_khkey *foundkey,  /** found */
-                    CurlKHMatch m,         /** libcurl's view on the keys */
-                    void *clientp          /** custom pointer passed from app */
-                    )curl_sshkeycallback;
+alias curl_sshkeycallback =
+        int function(CURL *easy,            /** easy handle */
+                     curl_khkey *knownkey,  /** known */
+                     curl_khkey *foundkey,  /** found */
+                     CurlKHMatch m,         /** libcurl's view on the keys */
+                     void *clientp          /** custom pointer passed from app */
+                    );
 
 /** parameter for the CURLOPT_USE_SSL option */
 enum CurlUseSSL {
@@ -627,7 +629,7 @@ enum CurlUseSSL {
     last      /** not an option, never use */
 }
 ///
-alias int curl_usessl;
+alias curl_usessl = int;
 
 /** parameter for the CURLOPT_FTP_SSL_CCC option */
 enum CurlFtpSSL {
@@ -637,7 +639,7 @@ enum CurlFtpSSL {
     ccc_last      /** not an option, never use */
 }
 ///
-alias int curl_ftpccc;
+alias curl_ftpccc = int;
 
 /** parameter for the CURLOPT_FTPSSLAUTH option */
 enum CurlFtpAuth {
@@ -647,7 +649,7 @@ enum CurlFtpAuth {
     last         /** not an option, never use */
 }
 ///
-alias int curl_ftpauth;
+alias curl_ftpauth = int;
 
 /** parameter for the CURLOPT_FTP_CREATE_MISSING_DIRS option */
 enum CurlFtp {
@@ -659,7 +661,7 @@ enum CurlFtp {
     create_dir_last    /** not an option, never use */
 }
 ///
-alias int curl_ftpcreatedir;
+alias curl_ftpcreatedir = int;
 
 /** parameter for the CURLOPT_FTP_FILEMETHOD option */
 enum CurlFtpMethod {
@@ -670,7 +672,7 @@ enum CurlFtpMethod {
     last              /** not an option, never use */
 }
 ///
-alias int curl_ftpmethod;
+alias curl_ftpmethod = int;
 
 /** CURLPROTO_ defines are for the CURLOPT_*PROTOCOLS options */
 enum CurlProto {
@@ -718,14 +720,14 @@ enum CURLOPTTYPE_OFF_T = 30000;
    number is unique identifier */
 
 /** The macro "##" is ISO C, we assume pre-ISO C doesn't support it. */
-alias CURLOPTTYPE_LONG LONG;
+alias LONG = CURLOPTTYPE_LONG;
 /// ditto
-alias CURLOPTTYPE_OBJECTPOINT OBJECTPOINT;
+alias OBJECTPOINT = CURLOPTTYPE_OBJECTPOINT;
 /// ditto
-alias CURLOPTTYPE_FUNCTIONPOINT FUNCTIONPOINT;
+alias FUNCTIONPOINT = CURLOPTTYPE_FUNCTIONPOINT;
 
 /// ditto
-alias CURLOPTTYPE_OFF_T OFF_T;
+alias OFF_T = CURLOPTTYPE_OFF_T;
 
 ///
 enum CurlOption {
@@ -1260,7 +1262,7 @@ enum CurlOption {
   rtspheader = httpheader, /// ditto
 }
 ///
-alias int CURLoption;
+alias CURLoption = int;
 ///
 enum CURLOPT_SERVER_RESPONSE_TIMEOUT = CurlOption.ftp_response_timeout;
 
@@ -1356,7 +1358,7 @@ enum CurlTimeCond {
     last        ///
 }
 ///
-alias int curl_TimeCond;
+alias curl_TimeCond = int;
 
 
 /** curl_strequal() and curl_strnequal() are subject for removal in a future
@@ -1389,7 +1391,7 @@ enum CurlForm {
     stream,
     lastentry /** the last unused */
 }
-alias int CURLformoption;
+alias CURLformoption = int;
 
 
 /** structure to be used as parameter for CURLFORM_ARRAY */
@@ -1431,7 +1433,7 @@ enum CurlFormAdd {
     last        ///
 }
 ///
-alias int CURLFORMcode;
+alias CURLFORMcode = int;
 
 extern (C) {
 
@@ -1454,7 +1456,7 @@ CURLFORMcode  curl_formadd(curl_httppost **httppost, curl_httppost **last_post,.
  * Should return the buffer length passed to it as the argument "len" on
  *   success.
  */
-alias size_t  function(void *arg, in char *buf, size_t len)curl_formget_callback;
+alias curl_formget_callback = size_t function(void *arg, in char *buf, size_t len);
 
 /**
  * Name: curl_formget()
@@ -1688,7 +1690,7 @@ enum CurlInfo {
     lastone = 42
 }
 ///
-alias int CURLINFO;
+alias CURLINFO = int;
 
 /** CURLINFO_RESPONSE_CODE is the new name for the option previously known as
    CURLINFO_HTTP_CODE */
@@ -1705,7 +1707,7 @@ enum CurlClosePolicy {
     last        ///
 }
 ///
-alias int curl_closepolicy;
+alias curl_closepolicy = int;
 
 ///
 enum CurlGlobal {
@@ -1736,7 +1738,7 @@ enum CurlLockData {
     last        ///
 }
 ///
-alias int curl_lock_data;
+alias curl_lock_data = int;
 
 /** Different lock access types */
 enum CurlLockAccess {
@@ -1746,15 +1748,15 @@ enum CurlLockAccess {
     last             /** never use */
 }
 ///
-alias int curl_lock_access;
+alias curl_lock_access = int;
 
 ///
-alias void  function(CURL *handle, curl_lock_data data, curl_lock_access locktype, void *userptr)curl_lock_function;
+alias curl_lock_function = void function(CURL *handle, curl_lock_data data, curl_lock_access locktype, void *userptr);
 ///
-alias void  function(CURL *handle, curl_lock_data data, void *userptr)curl_unlock_function;
+alias curl_unlock_function = void function(CURL *handle, curl_lock_data data, void *userptr);
 
 ///
-alias void CURLSH;
+alias CURLSH = void;
 
 ///
 enum CurlShError {
@@ -1766,7 +1768,7 @@ enum CurlShError {
     last         /** never use */
 }
 ///
-alias int CURLSHcode;
+alias CURLSHcode = int;
 
 /** pass in a user data pointer used in the lock/unlock callback
    functions */
@@ -1781,7 +1783,7 @@ enum CurlShOption {
     last          /** never use */
 }
 ///
-alias int CURLSHoption;
+alias CURLSHoption = int;
 
 extern (C) {
 ///
@@ -1805,7 +1807,7 @@ enum CurlVer {
     last        ///
 }
 ///
-alias int CURLversion;
+alias CURLversion = int;
 
 /** The 'CURLVERSION_NOW' is the symbolic name meant to be used by
    basically all programs ever that want to get version information. It is
@@ -1838,7 +1840,7 @@ extern (C) struct _N28
   const(char) *libssh_version;  /** human readable string */
 }
 ///
-alias _N28 curl_version_info_data;
+alias curl_version_info_data = _N28;
 
 ///
 // CURL_VERSION_*
@@ -2049,7 +2051,7 @@ extern (C) CURLcode  curl_easy_send(CURL *curl, void *buffer, size_t buflen, siz
  ***************************************************************************/
 
 ///
-alias void CURLM;
+alias CURLM = void;
 
 ///
 enum CurlM {
@@ -2064,7 +2066,7 @@ enum CurlM {
     last,       ///
 }
 ///
-alias int CURLMcode;
+alias CURLMcode = int;
 
 /** just to make code nicer when using curl_multi_socket() you can now check
    for CURLM_CALL_MULTI_SOCKET too in the same style it works for
@@ -2080,7 +2082,7 @@ enum CurlMsg
     last, /** no used */
 }
 ///
-alias int CURLMSG;
+alias CURLMSG = int;
 
 ///
 extern (C) union _N31
@@ -2135,7 +2137,7 @@ extern (C) CURLMcode  curl_multi_remove_handle(CURLM *multi_handle, CURL *curl_h
   */
 
 /** tmp decl */
-alias int fd_set;
+alias fd_set = int;
 ///
 extern (C) CURLMcode  curl_multi_fdset(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd);
 
@@ -2228,7 +2230,7 @@ enum CurlPoll {
 }
 
 ///
-alias CURL_SOCKET_BAD CURL_SOCKET_TIMEOUT;
+alias CURL_SOCKET_TIMEOUT = CURL_SOCKET_BAD;
 
 ///
 enum CurlCSelect {
@@ -2239,11 +2241,12 @@ enum CurlCSelect {
 
 extern (C) {
   ///
-  alias int function(CURL *easy,                            /** easy handle */
-                     curl_socket_t s,                     /** socket */
-                     int what,                            /** see above */
-                     void *userp,                         /** private callback pointer */
-                     void *socketp)curl_socket_callback;          /** private socket pointer */
+  alias curl_socket_callback =
+        int function(CURL *easy,            /** easy handle */
+                     curl_socket_t s,       /** socket */
+                     int what,              /** see above */
+                     void *userp,           /** private callback pointer */
+                     void *socketp);        /** private socket pointer */
 }
 
 /**
@@ -2258,9 +2261,10 @@ extern (C) {
  */
 
 extern (C) {
-  alias int function(CURLM *multi,    /** multi handle */
-                     c_long timeout_ms,  /** see above */
-                     void *userp) curl_multi_timer_callback;  /** private callback pointer */
+  alias curl_multi_timer_callback =
+        int function(CURLM *multi,          /** multi handle */
+                     c_long timeout_ms,     /** see above */
+                     void *userp);          /** private callback pointer */
   /// ditto
   CURLMcode  curl_multi_socket(CURLM *multi_handle, curl_socket_t s, int *running_handles);
   /// ditto
@@ -2295,8 +2299,7 @@ enum CurlMOption {
     lastentry   ///
 }
 ///
-alias int CURLMoption;
-
+alias CURLMoption = int;
 
 /**
  * Name:    curl_multi_setopt()
@@ -2306,7 +2309,6 @@ alias int CURLMoption;
  * Returns: CURLM error code.
  */
 extern (C) CURLMcode  curl_multi_setopt(CURLM *multi_handle, CURLMoption option,...);
-
 
 /**
  * Name:    curl_multi_assign()

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -18,59 +18,59 @@ extern (Windows):
 //alias void *HANDLE;
 
 //alias ubyte   SQLCHAR;
-alias char    SQLCHAR;
-alias byte    SQLSCHAR;
-alias ubyte   SQLDATE;
-alias ubyte   SQLDECIMAL;
-alias double  SQLDOUBLE;
-alias double  SQLFLOAT;
-alias int     SQLINTEGER;
-alias ushort  SQLUINTEGER;
-alias ubyte   SQLNUMERIC;
-alias float   SQLREAL;
-alias ubyte   SQLTIME;
-alias ubyte   SQLTIMESTAMP;
-alias ubyte   SQLVARCHAR;
-alias void *  SQLPOINTER;
-alias short   SQLSMALLINT;
-alias ushort  SQLUSMALLINT;
+alias SQLCHAR      = char;
+alias SQLSCHAR     = byte;
+alias SQLDATE      = ubyte;
+alias SQLDECIMAL   = ubyte;
+alias SQLDOUBLE    = double;
+alias SQLFLOAT     = double;
+alias SQLINTEGER   = int;
+alias SQLUINTEGER  = ushort;
+alias SQLNUMERIC   = ubyte;
+alias SQLREAL      = float;
+alias SQLTIME      = ubyte;
+alias SQLTIMESTAMP = ubyte;
+alias SQLVARCHAR   = ubyte;
+alias SQLPOINTER   = void*;
+alias SQLSMALLINT   = short;
+alias SQLUSMALLINT = ushort;
 
 // * function return type *
-alias SQLSMALLINT SQLRETURN;
+alias SQLRETURN = SQLSMALLINT;
 
 // * generic data structures *
-alias void *    SQLHANDLE;
-alias SQLHANDLE SQLHENV;
-alias SQLHANDLE SQLHDBC;
-alias SQLHANDLE SQLHSTMT;
-alias SQLHANDLE SQLHDESC;
+alias SQLHANDLE = void*;
+alias SQLHENV   = SQLHANDLE;
+alias SQLHDBC   = SQLHANDLE;
+alias SQLHSTMT  = SQLHANDLE;
+alias SQLHDESC  = SQLHANDLE;
 
 // * SQL portable types for C *
 //alias ubyte  UCHAR;  // std.c.windows.windows has this alias
 //alias char   UCHAR;
-alias byte   SCHAR;
+alias SCHAR   = byte;
 //alias SCHAR  SQLSCHAR;
-alias uint   DWORD;
-alias int    SDWORD;
-alias short  SWORD;
-alias uint   UDWORD;
-alias ushort UWORD;
-alias short  WORD;
+alias DWORD   = uint;
+alias SDWORD  = int;
+alias SWORD   = short;
+alias UDWORD  = uint ;
+alias UWORD   = ushort;
+alias WORD    = short;
 //alias UDWORD SQLUINTEGER;
-alias long   SLONG;
-alias short  SSHORT;
-alias ulong  ULONG;
-alias ushort USHORT;
-alias double SDOUBLE;
-alias double LDOUBLE;
-alias float  SFLOAT;
-alias void*  PTR;
-alias void*  HENV;
-alias void*  HDBC;
-alias void*  HSTMT;
-alias short  RETCODE;
-alias SQLPOINTER HWND;
-alias HWND   SQLHWND;
+alias SLONG   = long;
+alias SSHORT  = short;
+alias ULONG   = ulong;
+alias USHORT  = ushort;
+alias SDOUBLE = double;
+alias LDOUBLE = double;
+alias SFLOAT  = float;
+alias PTR     = void*;
+alias HENV    = void*;
+alias HDBC    = void*;
+alias HSTMT   = void*;
+alias RETCODE = short;
+alias HWND    = SQLPOINTER;
+alias SQLHWND = HWND;
 
 // * transfer types for DATE, TIME, TIMESTAMP *
 struct DATE_STRUCT
@@ -80,7 +80,7 @@ struct DATE_STRUCT
     SQLUSMALLINT   day;
 };
 
-alias DATE_STRUCT SQL_DATE_STRUCT;
+alias SQL_DATE_STRUCT = DATE_STRUCT;
 
 struct TIME_STRUCT
 {
@@ -89,7 +89,7 @@ struct TIME_STRUCT
     SQLUSMALLINT second;
 };
 
-alias TIME_STRUCT SQL_TIME_STRUCT;
+alias SQL_TIME_STRUCT = TIME_STRUCT;
 
 struct TIMESTAMP_STRUCT
 {
@@ -102,7 +102,7 @@ struct TIMESTAMP_STRUCT
     SQLUINTEGER    fraction;
 };
 
-alias TIMESTAMP_STRUCT SQL_TIMESTAMP_STRUCT;
+alias SQL_TIMESTAMP_STRUCT = TIMESTAMP_STRUCT;
 
 /+
  ' enumerations for DATETIME_INTERVAL_SUBCODE values for interval data types
@@ -170,15 +170,15 @@ struct SQLGUID
     ubyte[ 8 ] Data4;
 };
 
-alias SQLGUID GUID;
-alias uint    BOOKMARK;
-alias ushort  SQLWCHAR;
+alias GUID     = SQLGUID;
+alias BOOKMARK = uint;
+alias SQLWCHAR = ushort;
 
 version( UNICODE )
 {
-alias SQLWCHAR SQLTCHAR;
+alias SQLTCHAR = SQLWCHAR;
 }
 else
 {
-alias SQLCHAR SQLTCHAR;
+alias SQLTCHAR = SQLCHAR;
 } // end version( UNICODE )

--- a/etc/c/sqlite3.d
+++ b/etc/c/sqlite3.d
@@ -74,9 +74,9 @@ int sqlite3_threadsafe();
 struct sqlite3;
 
 ///
-alias long sqlite3_int64;
+alias sqlite3_int64 = long;
 ///
-alias ulong sqlite3_uint64;
+alias sqlite3_uint64 = ulong;
 
 /**
 ** CAPI3REF: Closing A Database Connection
@@ -354,9 +354,9 @@ struct sqlite3_mutex;
 ** CAPI3REF: OS Interface Object
 */
 
-alias void * function() xDlSymReturn;
+alias xDlSymReturn = void * function();
 /// Ditto
-alias void function() sqlite3_syscall_ptr;
+alias sqlite3_syscall_ptr = void function();
 
 struct sqlite3_vfs
 {
@@ -1071,7 +1071,7 @@ void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void function (void*));
 /**
 ** CAPI3REF: Constants Defining Special Destructor Behavior
 */
-alias void function (void*) sqlite3_destructor_type;
+alias sqlite3_destructor_type = void function (void*);
 /// Ditto
 enum
 {
@@ -1353,7 +1353,7 @@ void sqlite3_reset_auto_extension();
 ** CAPI3REF: Virtual Table Object
 */
 
-alias void function (sqlite3_context*,int,sqlite3_value**) mapFunction;
+alias mapFunction = void function (sqlite3_context*,int,sqlite3_value**);
 
 /// Ditto
 struct sqlite3_module

--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -75,8 +75,8 @@ const ZLIB_VERNUM = 0x1280;
   crash even in case of corrupted input.
 */
 
-alias void* function (void* opaque, uint items, uint size) alloc_func;
-alias void  function (void* opaque, void* address) free_func;
+alias alloc_func = void* function (void* opaque, uint items, uint size);
+alias free_func = void  function (void* opaque, void* address);
 
 struct z_stream
 {
@@ -100,7 +100,7 @@ struct z_stream
     c_ulong reserved;   /* reserved for future use */
 }
 
-alias z_stream* z_streamp;
+alias z_streamp = z_stream*;
 
 /*
      gzip header information passed to and from zlib routines.  See RFC 1952
@@ -124,7 +124,7 @@ struct gz_header
                            when writing a gzip file) */
 }
 
-alias gz_header* gz_headerp;
+alias gz_headerp = gz_header*;
 
 /*
   The application must update next_in and avail_in when avail_in has
@@ -884,8 +884,8 @@ int inflateBackInit(z_stream* strm, int windowBits, ubyte* window)
    match the version of the header file.
 */
 
-alias uint function(void*, ubyte**) in_func;
-alias int function(void*, ubyte*, uint) out_func;
+alias in_func = uint function(void*, ubyte**);
+alias out_func = int function(void*, ubyte*, uint);
 
 int inflateBack(z_stream* strm,
                 in_func f_in,
@@ -1080,8 +1080,8 @@ int uncompress(ubyte* dest,
 */
 
 
-alias void* gzFile;
-alias int z_off_t;              // file offset
+alias gzFile = void*;
+alias z_off_t = int;              // file offset
 
 gzFile gzopen(const(char)* path, const(char)* mode);
 /*

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -357,7 +357,7 @@ unittest
 {
     import std.experimental.allocator.gc_allocator;
     import std.experimental.allocator;
-    alias AffixAllocator!(GCAllocator, uint) MyAllocator;
+    alias MyAllocator = AffixAllocator!(GCAllocator, uint);
     auto a = MyAllocator.instance.makeArray!(shared int)(100);
     static assert(is(typeof(&MyAllocator.instance.prefix(a)) == shared(uint)*));
     auto b = MyAllocator.instance.makeArray!(shared const int)(100);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -816,7 +816,7 @@ if (Ranges.length > 0 &&
             // This doesn't work yet
             static if (allSameType)
             {
-                alias ref RvalueElementType ElementType;
+                alias ElementType = ref RvalueElementType;
             }
             else
             {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1483,13 +1483,13 @@ template tuple(Names...)
             {
                 template and(B...) if (B.length == 1)
                 {
-                    alias AliasSeq!(A[0], B[0]) and;
+                    alias and = AliasSeq!(A[0], B[0]);
                 }
 
                 template and(B...) if (B.length != 1)
                 {
-                    alias AliasSeq!(A[0], B[0],
-                        Interleave!(A[1..$]).and!(B[1..$])) and;
+                    alias and = AliasSeq!(A[0], B[0],
+                        Interleave!(A[1..$]).and!(B[1..$]));
                 }
             }
             return Tuple!(Interleave!(Args).and!(Names))(args);


### PR DESCRIPTION
AFAICT we should only use one `alias` syntax in Phobos (and hopefully deprecate the older soon).
This PR deprecates the  old `alias type identifier`  in favor of the new `alias identifier = type` syntax.