### PR TITLE
style fix: add space after 'for' operator

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1870,14 +1870,14 @@ bool isPermutation(alias pred = "a == b", Range1, Range2)
     // of item in the scanning loop has an index smaller than the current index,
     // then you know that the element has been seen before
     size_t index;
-    outloop: for(auto r1s1 = r1.save; !r1s1.empty; r1s1.popFront, index++)
+    outloop: for (auto r1s1 = r1.save; !r1s1.empty; r1s1.popFront, index++)
     {
         auto item = r1s1.front;
         r1_count = 0;
         r2_count = 0;
 
         size_t i;
-        for(auto r1s2 = r1.save; !r1s2.empty; r1s2.popFront, i++)
+        for (auto r1s2 = r1.save; !r1s2.empty; r1s2.popFront, i++)
         {
             auto e = r1s2.front;
             if (predEquals(e, item) && i < index)

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1620,7 +1620,7 @@ private template TimSortImpl(alias pred, R)
             //11 instructions vs 7 in the innermost loop [checked on Win32]
             //moveAll(retro(range[lower .. sortedLen]),
             //            retro(range[lower+1 .. sortedLen+1]));
-            for(upper=sortedLen; upper > lower; upper--)
+            for (upper=sortedLen; upper > lower; upper--)
                 range[upper] = range.moveAt(upper - 1);
             range[lower] = move(item);
         }

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2241,7 +2241,7 @@ unittest
             left <<= (T.sizeof - 1) * 8;
             T right = 0xffU;
 
-            for(size_t i = 1; i < T.sizeof; ++i)
+            for (size_t i = 1; i < T.sizeof; ++i)
             {
                 assert(swapEndian(left) == right);
                 assert(swapEndian(right) == left);

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1390,7 +1390,7 @@ private:
             import core.time;
             scope(exit) notified = false;
 
-            for( auto limit = MonoTime.currTime + period;
+            for ( auto limit = MonoTime.currTime + period;
                  !notified && !period.isNegative;
                  period = limit - MonoTime.currTime )
             {
@@ -1986,7 +1986,7 @@ private
 
             bool scan( ref ListT list )
             {
-                for( auto range = list[]; !range.empty; )
+                for ( auto range = list[]; !range.empty; )
                 {
                     // Only the message handler will throw, so if this occurs
                     // we can be certain that the message was handled.
@@ -2130,7 +2130,7 @@ private
 
             void sweep( ref ListT list )
             {
-                for( auto range = list[]; !range.empty; range.popFront() )
+                for ( auto range = list[]; !range.empty; range.popFront() )
                 {
                     if ( range.front.type == MsgType.linkDead )
                         onLinkDeadMsg( range.front );

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -771,7 +771,7 @@ private:
     alias IntList = DList!int;
     IntList list = IntList([0,1,2,3]);
     auto range = list[];
-    for( ; !range.empty; range.popFront())
+    for ( ; !range.empty; range.popFront())
     {
         int item = range.front;
         if (item == 2)
@@ -784,7 +784,7 @@ private:
 
     list = IntList([0,1,2,3]);
     range = list[];
-    for( ; !range.empty; range.popFront())
+    for ( ; !range.empty; range.popFront())
     {
         int item = range.front;
         if (item == 2)
@@ -797,7 +797,7 @@ private:
 
     list = IntList([0,1,2,3]);
     range = list[];
-    for( ; !range.empty; range.popFront())
+    for ( ; !range.empty; range.popFront())
     {
         int item = range.front;
         if (item == 0)
@@ -810,7 +810,7 @@ private:
 
     list = IntList([0,1,2,3]);
     range = list[];
-    for( ; !range.empty; range.popFront())
+    for ( ; !range.empty; range.popFront())
     {
         int item = range.front;
         if (item == 1)

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1638,14 +1638,14 @@ assert(equal(rbt[], [5]));
             if (n !is null)
             {
                 printTree(n.right, indent + 2);
-                for(int i = 0; i < indent; i++)
+                for (int i = 0; i < indent; i++)
                     write(".");
                 writeln(n.color == n.color.Black ? "B" : "R");
                 printTree(n.left, indent + 2);
             }
             else
             {
-                for(int i = 0; i < indent; i++)
+                for (int i = 0; i < indent; i++)
                     write(".");
                 writeln("N");
             }

--- a/std/csv.d
+++ b/std/csv.d
@@ -1036,7 +1036,7 @@ public:
             T[U] aa;
             try
             {
-                for(; !recordRange.empty; recordRange.popFront())
+                for (; !recordRange.empty; recordRange.popFront())
                 {
                     aa[header[_input.col-1]] = recordRange.front;
                 }
@@ -1057,7 +1057,7 @@ public:
             size_t colIndex;
             try
             {
-                for(; !recordRange.empty;)
+                for (; !recordRange.empty;)
                 {
                     auto colData = recordRange.front;
                     scope(exit) colIndex++;

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -33898,7 +33898,7 @@ R _stripCFWS(R)(R range)
        (is(Unqual!(ElementType!R) == char) || is(Unqual!(ElementType!R) == ubyte)))
 {
     immutable e = range.length;
-    outer: for(size_t i = 0; i < e; )
+    outer: for (size_t i = 0; i < e; )
     {
         switch (range[i])
         {

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -194,7 +194,7 @@ struct MD5
             {
                 import std.bitmanip : littleEndianToNative;
 
-                for(size_t i = 0; i < 16; i++)
+                for (size_t i = 0; i < 16; i++)
                 {
                     x[i] = littleEndianToNative!uint(*cast(ubyte[4]*)&(*block)[i*4]);
                 }
@@ -321,7 +321,7 @@ struct MD5
                 (&_buffer[index])[0 .. partLen] = data.ptr[0 .. partLen];
                 transform(&_buffer);
 
-                for(i = partLen; i + 63 < inputLen; i += 64)
+                for (i = partLen; i + 63 < inputLen; i += 64)
                 {
                     transform(cast(const(ubyte[64])*)(data[i .. i + 64].ptr));
                 }

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -239,7 +239,7 @@ struct RIPEMD160
             {
                 import std.bitmanip : littleEndianToNative;
 
-                for(size_t i = 0; i < 16; i++)
+                for (size_t i = 0; i < 16; i++)
                 {
                     x[i] = littleEndianToNative!uint(*cast(ubyte[4]*)&(*block)[i*4]);
                 }
@@ -477,7 +477,7 @@ struct RIPEMD160
                 (&_buffer[index])[0 .. partLen] = data.ptr[0 .. partLen];
                 transform(&_buffer);
 
-                for(i = partLen; i + 63 < inputLen; i += 64)
+                for (i = partLen; i + 63 < inputLen; i += 64)
                 {
                     transform(cast(const(ubyte[64])*)(data[i .. i + 64].ptr));
                 }

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -244,7 +244,7 @@ unittest
 
     // Make sure we can sanitize everything bad
     assert(invalidStrings.length == sanitizedStrings.length);
-    for(int i=0; i<invalidStrings.length; ++i)
+    for (int i=0; i<invalidStrings.length; ++i)
     {
         string s = cast(string)invalidStrings[i];
         string t = sanitize(s);
@@ -2114,7 +2114,7 @@ size_t encode(Tgt, Src, R)(in Src[] s, R range)
  }
  --------------------------------------------------------
 
- Note that, currently, foreach (c:codePoints(s)) is superior to foreach(c;s)
+ Note that, currently, foreach (c:codePoints(s)) is superior to foreach (c;s)
  in that the latter will fall over on encountering U+FFFF.
  */
 CodePoints!(E) codePoints(E)(immutable(E)[] s)

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -140,7 +140,7 @@ unittest
 
     // test allocation sizes
     assert(GCAllocator.instance.goodAllocSize(1) == 16);
-    for(size_t s = 16; s <= 8192; s *= 2)
+    for (size_t s = 16; s <= 8192; s *= 2)
     {
         assert(GCAllocator.instance.goodAllocSize(s) == s);
         assert(GCAllocator.instance.goodAllocSize(s - (s / 2) + 1) == s);

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -1206,7 +1206,7 @@ pure nothrow unittest
     import std.experimental.ndslice.slice;
     auto slice = new long[20].sliced(5, 4);
 
-    for(auto elems = slice.byElement; !elems.empty; elems.popFront)
+    for (auto elems = slice.byElement; !elems.empty; elems.popFront)
     {
         size_t[2] index = elems.index;
         elems.front = index[0] * 10 + index[1] * 3;

--- a/std/file.d
+++ b/std/file.d
@@ -3612,7 +3612,7 @@ private struct DirIteratorImpl
         {
             if (_stack.data.empty)
                 return false;
-            for(dirent* fdata; (fdata = readdir(_stack.data[$-1].h)) != null; )
+            for (dirent* fdata; (fdata = readdir(_stack.data[$-1].h)) != null; )
             {
                 // Skip "." and ".."
                 if (core.stdc.string.strcmp(fdata.d_name.ptr, ".")  &&

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -2260,7 +2260,7 @@ void toHexZeroPadded(char[] output, uint value,
     ptrdiff_t x = output.length - 1;
     static immutable string upperHexDigits = "0123456789ABCDEF";
     static immutable string lowerHexDigits = "0123456789abcdef";
-    for( ; x>=0; --x)
+    for ( ; x>=0; --x)
     {
         if (letterCase == LetterCase.upper)
         {

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -159,7 +159,7 @@ void multibyteShr(uint [] dest, const(uint) [] src, uint numbits)
     pure @nogc @safe
 {
     ulong c = 0;
-    for(ptrdiff_t i = dest.length; i!=0; --i)
+    for (ptrdiff_t i = dest.length; i!=0; --i)
     {
         c += (src[i-1] >>numbits) + (cast(ulong)(src[i-1]) << (64 - numbits));
         dest[i-1] = cast(uint)c;
@@ -195,7 +195,7 @@ uint multibyteMul(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 {
     assert(dest.length == src.length);
     ulong c = carry;
-    for(size_t i = 0; i < src.length; ++i)
+    for (size_t i = 0; i < src.length; ++i)
     {
         c += cast(ulong)(src[i]) * multiplier;
         dest[i] = cast(uint)c;
@@ -222,7 +222,7 @@ uint multibyteMulAdd(char op)(uint [] dest, const(uint)[] src,
 {
     assert(dest.length == src.length);
     ulong c = carry;
-    for(size_t i = 0; i < src.length; ++i)
+    for (size_t i = 0; i < src.length; ++i)
     {
         static if (op=='+')
         {
@@ -285,7 +285,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
     pure @nogc @safe
 {
     ulong c = cast(ulong)overflow;
-    for(ptrdiff_t i = dest.length-1; i>= 0; --i)
+    for (ptrdiff_t i = dest.length-1; i>= 0; --i)
     {
         c = (c<<32) + cast(ulong)(dest[i]);
         uint q = cast(uint)(c/divisor);
@@ -314,7 +314,7 @@ void multibyteAddDiagonalSquares(uint[] dest, const(uint)[] src)
     pure @nogc @safe
 {
     ulong c = 0;
-    for(size_t i = 0; i < src.length; ++i)
+    for (size_t i = 0; i < src.length; ++i)
     {
         // At this point, c is 0 or 1, since FFFF*FFFF+FFFF_FFFF = 1_0000_0000.
         c += cast(ulong)(src[i]) * src[i] + dest[2*i];

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -753,7 +753,7 @@ ihalve:
 
     dir = 0;
     di = 0.5L;
-    for( i=0; i<400; i++ ) {
+    for ( i=0; i<400; i++ ) {
         if ( i != 0 ) {
             x = x0  +  di * (x1 - x0);
             if ( x == 1.0L ) {
@@ -846,7 +846,7 @@ newt:
     nflg = 1;
     lgm = logGamma(a+b) - logGamma(a) - logGamma(b);
 
-    for( i=0; i<15; i++ ) {
+    for ( i=0; i<15; i++ ) {
         /* Compute the function at this point. */
         if ( i != 0 )
             y = betaIncomplete(a,b,x);
@@ -1346,7 +1346,7 @@ body {
 
     lgm = logGamma(a);
 
-    for( i=0; i<10; i++ ) {
+    for ( i=0; i<10; i++ ) {
         if ( x > x0 || x < x1 )
             goto ihalve;
         y = gammaIncompleteCompl(a,x);
@@ -1391,7 +1391,7 @@ ihalve:
     d = 0.5L;
     dir = 0;
 
-    for( i=0; i<400; i++ ) {
+    for ( i=0; i<400; i++ ) {
         x = x1  +  d * (x0 - x1);
         y = gammaIncompleteCompl( a, x );
         lgm = (x0 - x1)/(x1 + x0);
@@ -1603,9 +1603,9 @@ unittest {
     assert(logmdigamma(-5.0).isNaN());
     assert(isIdentical(logmdigamma(NaN(0xABC)), NaN(0xABC)));
     assert(logmdigamma(0.0) == real.infinity);
-    for(auto x = 0.01; x < 1.0; x += 0.1)
+    for (auto x = 0.01; x < 1.0; x += 0.1)
         assert(approxEqual(digamma(x), log(x) - logmdigamma(x)));
-    for(auto x = 1.0; x < 15.0; x += 1.0)
+    for (auto x = 1.0; x < 15.0; x += 1.0)
         assert(approxEqual(digamma(x), log(x) - logmdigamma(x)));
 }
 

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1922,7 +1922,7 @@ public:
                     assert(from !is null);
 
                     size_t i;
-                    for(; !source.empty && i < from.length; source.popFront())
+                    for (; !source.empty && i < from.length; source.popFront())
                     {
                         from[i++] = source.front;
                     }
@@ -2180,7 +2180,7 @@ public:
                 assert(buf !is null);
 
                 size_t i;
-                for(; !source.empty && i < buf.length; source.popFront())
+                for (; !source.empty && i < buf.length; source.popFront())
                 {
                     buf[i++] = source.front;
                 }
@@ -3617,7 +3617,7 @@ enum string parallelApplyMixinInputRange = q{
                 scope(exit) rangeMutex.unlock();
 
                 size_t i = 0;
-                for(; i < workUnitSize && !range.empty; range.popFront(), i++)
+                for (; i < workUnitSize && !range.empty; range.popFront(), i++)
                 {
                     temp[i] = addressOf(range.front);
                 }
@@ -3647,7 +3647,7 @@ enum string parallelApplyMixinInputRange = q{
                 scope(exit) rangeMutex.unlock();
 
                 size_t i = 0;
-                for(; i < workUnitSize && !range.empty; range.popFront(), i++)
+                for (; i < workUnitSize && !range.empty; range.popFront(), i++)
                 {
                     temp[i] = range.front;
                 }
@@ -4296,7 +4296,7 @@ version(parallelismStressTest)
     unittest
     {
         size_t attempt;
-        for(; attempt < 10; attempt++)
+        for (; attempt < 10; attempt++)
             foreach (poolSize; [0, 4])
         {
 

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -404,7 +404,7 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
             int opApply(int delegate(E) dg) {
                 int res;
 
-                for(auto r = _range; !r.empty; r.popFront()) {
+                for (auto r = _range; !r.empty; r.popFront()) {
                     res = dg(r.front);
                     if (res) break;
                 }
@@ -416,7 +416,7 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
                 int res;
 
                 size_t i = 0;
-                for(auto r = _range; !r.empty; r.popFront()) {
+                for (auto r = _range; !r.empty; r.popFront()) {
                     res = dg(i, r.front);
                     if (res) break;
                     i++;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1718,7 +1718,7 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R))
     static assert(isForwardRange!(typeof(radial(a, 1))));
 
     auto r = radial([1,2,3,4,5]);
-    for(auto rr = r.save; !rr.empty; rr.popFront())
+    for (auto rr = r.save; !rr.empty; rr.popFront())
     {
         assert(rr.front == moveFront(rr));
     }
@@ -2021,7 +2021,7 @@ if (isInputRange!(Unqual!R) && (isInfinite!(Unqual!R) || !hasSlicing!(Unqual!R) 
             static assert(isForwardRange!T);
         }
 
-        for(auto tt = t; !tt.empty; tt.popFront())
+        for (auto tt = t; !tt.empty; tt.popFront())
         {
             assert(tt.front == moveFront(tt));
         }
@@ -4735,7 +4735,7 @@ auto sequence(alias fun, State...)(State args)
 
     auto odds = Sequence!("a[0] + n * a[1]", Tuple!(int, int))(
         tuple(1, 2));
-    for(int currentOdd = 1; currentOdd <= 21; currentOdd += 2) {
+    for (int currentOdd = 1; currentOdd <= 21; currentOdd += 2) {
         assert(odds.front == odds[0]);
         assert(odds[0] == currentOdd);
         odds.popFront();

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -218,7 +218,7 @@ template BacktrackingMatcher(bool CTregex)
             {
                 if (!re.kickstart.empty)
                 {
-                    for(;;)
+                    for (;;)
                     {
                         int val = matchFinalize();
                         if (val)
@@ -240,7 +240,7 @@ template BacktrackingMatcher(bool CTregex)
                 }
             }
             //no search available - skip a char at a time
-            for(;;)
+            for (;;)
             {
                 int val = matchFinalize();
                 if (val)
@@ -280,7 +280,7 @@ template BacktrackingMatcher(bool CTregex)
                 auto start = s._index;
                 debug(std_regex_matcher)
                     writeln("Try match starting at ", s[index..s.lastIndex]);
-                for(;;)
+                for (;;)
                 {
                     debug(std_regex_matcher)
                         writefln("PC: %s\tCNT: %s\t%s \tfront: %s src: %s",
@@ -295,7 +295,7 @@ template BacktrackingMatcher(bool CTregex)
                         uint end = pc + len;
                         if (re.ir[pc].data != front && re.ir[pc+1].data != front)
                         {
-                            for(pc = pc+2; pc < end; pc++)
+                            for (pc = pc+2; pc < end; pc++)
                                 if (re.ir[pc].data == front)
                                     break;
                             if (pc == end)
@@ -976,7 +976,7 @@ struct CtContext
         CtState[] pieces;
         CtState r;
         enum optL = IRL!(IR.Option);
-        for(;;)
+        for (;;)
         {
             assert(ir[0].code == IR.Option);
             auto len = ir[0].data;
@@ -998,7 +998,7 @@ struct CtContext
             }
         }
         r = pieces[0];
-        for(uint i = 1; i < pieces.length; i++)
+        for (uint i = 1; i < pieces.length; i++)
         {
             r.code ~= ctSub(`
                 case $$:
@@ -1230,7 +1230,7 @@ struct CtContext
                     if (atEnd)
                         $$`, bailOut);
             uint len = ir[0].sequence;
-            for(uint i = 0; i < len; i++)
+            for (uint i = 0; i < len; i++)
             {
                 code ~= ctSub( `
                     if (front == $$)

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -39,7 +39,7 @@ module std.regex.internal.generator;
     void compose()
     {
         uint pc = 0, counter = 0, dataLenOld = uint.max;
-        for(;;)
+        for (;;)
         {
             switch (re.ir[pc].code)
             {
@@ -90,7 +90,7 @@ module std.regex.internal.generator;
                     }
                     nOpt++;
                     nOpt = rand(nOpt);
-                    for(;nOpt; nOpt--)
+                    for (;nOpt; nOpt--)
                     {
                         pc += re.ir[pc].data + IRL!(IR.Option);
                     }

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -443,7 +443,7 @@ struct Group(DataIndex)
 @trusted void printBytecode()(in Bytecode[] slice, in NamedGroup[] dict=[])
 {
     import std.stdio;
-    for(uint pc=0; pc<slice.length; pc += slice[pc].length)
+    for (uint pc=0; pc<slice.length; pc += slice[pc].length)
         writeln("\t", disassemble(slice, pc, dict));
 }
 
@@ -534,7 +534,7 @@ package(std.regex):
         if (flags & RegexOption.multiline)
             return;
     L_CheckLoop:
-        for(uint i = 0; i < ir.length; i += ir[i].length)
+        for (uint i = 0; i < ir.length; i += ir[i].length)
         {
             switch (ir[i].code)
             {
@@ -552,7 +552,7 @@ package(std.regex):
     //print out disassembly a program's IR
     @trusted debug(std_regex_parser) void print() const
     {//@@@BUG@@@ write is system
-        for(uint i = 0; i < ir.length; i += ir[i].length)
+        for (uint i = 0; i < ir.length; i += ir[i].length)
         {
             writefln("%d\t%s ", i, disassemble(ir, i, dict));
         }

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -81,7 +81,7 @@ private:
                 Char[dchar.sizeof/Char.sizeof] buf;
                 uint tmask = mask;
                 size_t total = encode(buf, ch);
-                for(size_t i = 0; i < total; i++, tmask<<=1)
+                for (size_t i = 0; i < total; i++, tmask<<=1)
                 {
                     static if (charSize == 1)
                         setBits(buf[i], tmask);
@@ -143,7 +143,7 @@ public:
             return h;
         }
     L_FindChar:
-        for(size_t i = 0;;)
+        for (size_t i = 0;;)
         {
             switch (re.ir[i].code)
             {
@@ -176,10 +176,10 @@ public:
         ShiftThread t = ShiftThread(0, 0, table);
         //locate first fixed char if any
         n_length = 32;
-        for(;;)
+        for (;;)
         {
         L_Eval_Thread:
-            for(;;)
+            for (;;)
             {
                 switch (re.ir[t.pc].code)
                 {
@@ -196,17 +196,17 @@ public:
                     uint end = t.pc + len;
                     uint[Bytecode.maxSequence] s;
                     uint numS;
-                    for(uint i = 0; i < len; i++)
+                    for (uint i = 0; i < len; i++)
                     {
                         auto x = charLen(re.ir[t.pc+i].data);
                         if (countUntil(s[0..numS], x) < 0)
                            s[numS++] = x;
                     }
-                    for(uint i = t.pc; i < end; i++)
+                    for (uint i = t.pc; i < end; i++)
                     {
                         t.add(re.ir[i].data);
                     }
-                    for(uint i = 0; i < numS; i++)
+                    for (uint i = 0; i < numS; i++)
                     {
                         auto tx = fork(t, t.pc + len, t.counter);
                         if (tx.idx + s[i] <= n_length)
@@ -245,7 +245,7 @@ public:
                             arr[ofs++] = ival.b;
                         }
                         auto srange = assumeSorted!"a <= b"(arr);
-                        for(uint i = 0; i < codeBounds.length/2; i++)
+                        for (uint i = 0; i < codeBounds.length/2; i++)
                         {
                             auto start = srange.lowerBound(codeBounds[2*i]).length;
                             auto end = srange.lowerBound(codeBounds[2*i+1]).length;
@@ -265,7 +265,7 @@ public:
                             continue;
                         t.add(ch);
                     }
-                    for(uint i = 0; i < numS; i++)
+                    for (uint i = 0; i < numS; i++)
                     {
                         auto tx =  fork(t, t.pc + IRL!(IR.CodepointSet), t.counter);
                         tx.advance(s[i]);
@@ -405,7 +405,7 @@ public:
             {
                 if (!~state)
                 {//speed up seeking first matching place
-                    for(;;)
+                    for (;;)
                     {
                         assert(p <= end, text(p," vs ", end));
                         p = cast(ubyte*)memchr(p, fChar, end - p);
@@ -500,7 +500,7 @@ public:
     @system debug static void dump(uint[] table)
     {//@@@BUG@@@ writef(ln) is @system
         import std.stdio;
-        for(size_t i = 0; i < table.length; i += 4)
+        for (size_t i = 0; i < table.length; i += 4)
         {
             writefln("%32b %32b %32b %32b",table[i], table[i+1], table[i+2], table[i+3]);
         }

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -83,9 +83,9 @@ unittest
     Stack!(Tuple!(uint, uint, uint)) stack;
     uint start = 0;
     uint end = cast(uint)code.length;
-    for(;;)
+    for (;;)
     {
-        for(uint pc = start; pc < end; )
+        for (uint pc = start; pc < end; )
         {
             uint len = code[pc].length;
             if (code[pc].code == IR.GotoEndOr)
@@ -163,7 +163,7 @@ dchar parseUniHex(Char)(ref Char[] str, size_t maxDigit)
     //std.conv.parse is both @system and bogus
     enforce(str.length >= maxDigit,"incomplete escape sequence");
     uint val;
-    for(int k = 0; k < maxDigit; k++)
+    for (int k = 0; k < maxDigit; k++)
     {
         auto current = str[k];//accepts ascii only, so it's OK to index directly
         if ('0' <= current && current <= '9')
@@ -729,7 +729,7 @@ struct Parser(R, Generator)
                     switch (current)
                     {
                     case '#':
-                        for(;;)
+                        for (;;)
                         {
                             if (!next())
                                 error("Unexpected end of pattern");
@@ -969,7 +969,7 @@ struct Parser(R, Generator)
         }
 
         L_CharTermLoop:
-        for(;;)
+        for (;;)
         {
             final switch (state)
             {
@@ -1144,7 +1144,7 @@ struct Parser(R, Generator)
                     enforce(last <= current, "inverted range");
                     if (re_flags & RegexOption.casefold)
                     {
-                        for(uint ch = last; ch <= current; ch++)
+                        for (uint ch = last; ch <= current; ch++)
                             addWithFlags(set, ch, re_flags);
                     }
                     else
@@ -1493,7 +1493,7 @@ struct Parser(R, Generator)
         auto counterRange = FixedStack!uint(new uint[maxCounterDepth+1], -1);
         counterRange.push(1);
         ulong cumRange = 0;
-        for(uint i = 0; i < ir.length; i += ir[i].length)
+        for (uint i = 0; i < ir.length; i += ir[i].length)
         {
             if (ir[i].hotspot)
             {
@@ -1548,7 +1548,7 @@ void fixupBytecode()(Bytecode[] ir)
 {
     Stack!uint fixups;
 
-    with(IR) for(uint i=0; i<ir.length; i+= ir[i].length)
+    with(IR) for (uint i=0; i<ir.length; i+= ir[i].length)
     {
         if (ir[i].isStart || ir[i].code == Option)
             fixups.push(i);
@@ -1564,7 +1564,7 @@ void fixupBytecode()(Bytecode[] ir)
             // fixup all GotoEndOrs
             j = j + IRL!(OrStart);
             assert(ir[j].code == Option);
-            for(;;)
+            for (;;)
             {
                 auto next = j + ir[j].data + IRL!(Option);
                 if (ir[next].code == IR.OrEnd)
@@ -1595,7 +1595,7 @@ void optimize(Char)(ref Regex!Char zis)
         CodepointSet set;
         with(zis) with(IR)
     Outer:
-        for(uint i = idx; i < ir.length; i += ir[i].length)
+        for (uint i = idx; i < ir.length; i += ir[i].length)
         {
             switch (ir[i].code)
             {
@@ -1615,7 +1615,7 @@ void optimize(Char)(ref Regex!Char zis)
         return set;
     }
 
-    with(zis) with(IR) for(uint i = 0; i < ir.length; i += ir[i].length)
+    with(zis) with(IR) for (uint i = 0; i < ir.length; i += ir[i].length)
     {
         if (ir[i].code == InfiniteEnd)
         {
@@ -1640,7 +1640,7 @@ void optimize(Char)(ref Regex!Char zis)
     import std.conv;
     with(zis)
     {
-        for(uint pc = 0; pc < ir.length; pc += ir[pc].length)
+        for (uint pc = 0; pc < ir.length; pc += ir[pc].length)
         {
             if (ir[pc].isStart || ir[pc].isEnd)
             {

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -781,7 +781,7 @@ unittest
     auto r = regex(
        r"^NAME   = (?P<comp>[a-zA-Z0-9_]+):*(?P<blk>[a-zA-Z0-9_]*)","gm");
     auto uniCapturesNew = match(uniFileOld, r);
-    for(int i = 0; i < 20; i++)
+    for (int i = 0; i < 20; i++)
         foreach (matchNew; uniCapturesNew) {}
     //a second issue with same symptoms
     auto r2 = regex(`([а-яА-Я\-_]+\s*)+(?<=[\s\.,\^])`);

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -562,7 +562,7 @@ template ThompsonOps(E, S, bool withInput:true)
             uint len = re.ir[t.pc].sequence;
             uint end = t.pc + len;
             static assert(IRL!(IR.OrChar) == 1);
-            for(; t.pc < end; t.pc++)
+            for (; t.pc < end; t.pc++)
                 if (re.ir[t.pc].data == front)
                     break;
             if (t.pc != end)
@@ -796,7 +796,7 @@ template ThompsonOps(E,S, bool withInput:false)
         opCacheBackTrue = arrayInChunk!(OpBackFunc)(re.ir.length, memory);
         opCacheBackFalse = arrayInChunk!(OpBackFunc)(re.ir.length, memory);
 
-        for(uint pc = 0; pc<re.ir.length; pc += re.ir[pc].length)
+        for (uint pc = 0; pc<re.ir.length; pc += re.ir[pc].length)
         {
         L_dispatch:
             switch (re.ir[pc].code)
@@ -919,7 +919,7 @@ template ThompsonOps(E,S, bool withInput:false)
         state.matches = matches;
 
         if (!atEnd)//if no char
-            for(;;)
+            for (;;)
             {
                 genCounter++;
                 debug(std_regex_matcher)
@@ -933,7 +933,7 @@ template ThompsonOps(E,S, bool withInput:false)
                         writeln();
                     }
                 }
-                for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
+                for (state.t = clist.fetch(); state.t; state.t = clist.fetch())
                 {
                     eval!true(&state);
                 }
@@ -974,7 +974,7 @@ template ThompsonOps(E,S, bool withInput:false)
         genCounter++; //increment also on each end
         debug(std_regex_matcher) writefln("Threaded matching threads at end");
         //try out all zero-width posibilities
-        for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
+        for (state.t = clist.fetch(); state.t; state.t = clist.fetch())
         {
             eval!false(&state);
         }
@@ -1055,7 +1055,7 @@ template ThompsonOps(E,S, bool withInput:false)
                 genCounter++;
                 evalFn!true(&state);
             }
-            for(;;)
+            for (;;)
             {
                 debug(std_regex_matcher) writeln("\n-- Started iteration of main cycle");
                 genCounter++;
@@ -1066,7 +1066,7 @@ template ThompsonOps(E,S, bool withInput:false)
                         assert(t);
                     }
                 }
-                for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
+                for (state.t = clist.fetch(); state.t; state.t = clist.fetch())
                 {
                     evalFn!true(&state);
                 }
@@ -1085,7 +1085,7 @@ template ThompsonOps(E,S, bool withInput:false)
         genCounter++; //increment also on each end
         debug(std_regex_matcher) writefln("-- Matching threads at end");
         //try out all zero-width posibilities
-        for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
+        for (state.t = clist.fetch(); state.t; state.t = clist.fetch())
         {
             evalFn!false(&state);
         }
@@ -1113,7 +1113,7 @@ template ThompsonOps(E,S, bool withInput:false)
         memory = memory[threadSize * size .. $];
         freelist = cast(Thread!DataIndex*)&mem[0];
         size_t i;
-        for(i = threadSize; i < threadSize*size; i += threadSize)
+        for (i = threadSize; i < threadSize*size; i += threadSize)
             (cast(Thread!DataIndex*)&mem[i-threadSize]).next = cast(Thread!DataIndex*)&mem[i];
         (cast(Thread!DataIndex*)&mem[i-threadSize]).next = null;
     }

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1098,7 +1098,7 @@ L_Replace_Loop:
         final switch (state)
         {
         case State.Normal:
-            for(offset = 0; offset < format.length; offset++)//no decoding
+            for (offset = 0; offset < format.length; offset++)//no decoding
             {
                 if (format[offset] == '$')
                 {

--- a/std/socket.d
+++ b/std/socket.d
@@ -427,7 +427,7 @@ class Protocol
         name = to!string(proto.p_name);
 
         int i;
-        for(i = 0;; i++)
+        for (i = 0;; i++)
         {
             if (!proto.p_aliases[i])
                 break;
@@ -436,7 +436,7 @@ class Protocol
         if (i)
         {
             aliases = new string[i];
-            for(i = 0; i != aliases.length; i++)
+            for (i = 0; i != aliases.length; i++)
             {
                 aliases[i] =
                     to!string(proto.p_aliases[i]);
@@ -529,7 +529,7 @@ class Service
         protocolName = to!string(serv.s_proto);
 
         int i;
-        for(i = 0;; i++)
+        for (i = 0;; i++)
         {
             if (!serv.s_aliases[i])
                 break;
@@ -538,7 +538,7 @@ class Service
         if (i)
         {
             aliases = new string[i];
-            for(i = 0; i != aliases.length; i++)
+            for (i = 0; i != aliases.length; i++)
             {
                 aliases[i] =
                     to!string(serv.s_aliases[i]);
@@ -696,7 +696,7 @@ class InternetHost
 
         name = to!string(he.h_name);
 
-        for(i = 0;; i++)
+        for (i = 0;; i++)
         {
             p = he.h_aliases[i];
             if (!p)
@@ -706,7 +706,7 @@ class InternetHost
         if (i)
         {
             aliases = new string[i];
-            for(i = 0; i != aliases.length; i++)
+            for (i = 0; i != aliases.length; i++)
             {
                 aliases[i] =
                     to!string(he.h_aliases[i]);
@@ -717,7 +717,7 @@ class InternetHost
             aliases = null;
         }
 
-        for(i = 0;; i++)
+        for (i = 0;; i++)
         {
             p = he.h_addr_list[i];
             if (!p)
@@ -727,7 +727,7 @@ class InternetHost
         if (i)
         {
             addrList = new uint[i];
-            for(i = 0; i != addrList.length; i++)
+            for (i = 0; i != addrList.length; i++)
             {
                 addrList[i] = ntohl(*(cast(uint*)he.h_addr_list[i]));
             }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3231,7 +3231,7 @@ unittest // bugzilla 14861
     static import std.file;
     auto deleteme = testFilename();
     File fw = File(deleteme, "w");
-    for(int i; i != 5000; i++)
+    for (int i; i != 5000; i++)
         fw.writeln(i, ";", "Иванов;Пётр;Петрович");
     fw.close();
     scope(exit) std.file.remove(deleteme);

--- a/std/stream.d
+++ b/std/stream.d
@@ -416,7 +416,7 @@ class Stream : InputStream, OutputStream {
   // reads block of data of specified size,
   // throws ReadException on error
   void readExact(void* buffer, size_t size) {
-    for(;;) {
+    for (;;) {
       if (!size) return;
       size_t readsize = readBlock(buffer, size); // return 0 on eof
       if (readsize == 0) break;
@@ -1082,7 +1082,7 @@ class Stream : InputStream, OutputStream {
   // throws WriteException on error
   void writeExact(const void* buffer, size_t size) {
     const(void)* p = buffer;
-    for(;;) {
+    for (;;) {
       if (!size) return;
       size_t writesize = writeBlock(p, size);
       if (writesize == 0) break;
@@ -1767,7 +1767,7 @@ class BufferedStream : FilterStream {
           ubyte*  pc = cast(ubyte*)&c;
 
         L0:
-          for(;;) {
+          for (;;) {
               size_t start = bufferCurPos;
             L1:
               foreach (ubyte b; buffer[start .. bufferLen]) {

--- a/std/uni.d
+++ b/std/uni.d
@@ -696,14 +696,14 @@ else
 void copyBackwards(T,U)(T[] src, U[] dest)
 {
     assert(src.length == dest.length);
-    for(size_t i=src.length; i-- > 0; )
+    for (size_t i=src.length; i-- > 0; )
         dest[i] = src[i];
 }
 
 void copyForward(T,U)(T[] src, U[] dest)
 {
     assert(src.length == dest.length);
-    for(size_t i=0; i<src.length; i++)
+    for (size_t i=0; i<src.length; i++)
         dest[i] = src[i];
 }
 
@@ -1044,12 +1044,12 @@ unittest
     alias fn3 = sliceBits!( 6,  9);
     alias fn4 = sliceBits!( 0,  6);
     static void check(size_t lvl, MA)(ref MA arr){
-        for(size_t i = 0; i< arr.length!lvl; i++)
+        for (size_t i = 0; i< arr.length!lvl; i++)
             assert(arr.slice!(lvl)[i] == i, text("Mismatch on lvl ", lvl, " idx ", i, " value: ", arr.slice!(lvl)[i]));
     }
 
     static void fillIdx(size_t lvl, MA)(ref MA arr){
-        for(size_t i = 0; i< arr.length!lvl; i++)
+        for (size_t i = 0; i< arr.length!lvl; i++)
             arr.slice!(lvl)[i] = i;
     }
     Bitty m1;
@@ -1062,7 +1062,7 @@ unittest
 
     m1.length!4 = 2^^16;
 
-    for(size_t i = 0; i< m1.length!4; i++)
+    for (size_t i = 0; i< m1.length!4; i++)
         m1.slice!(4)[i] = i % 2;
 
     fillIdx!1(m1);
@@ -1076,7 +1076,7 @@ unittest
     check!3(m1);
     check!2(m1);
     check!1(m1);
-    for(size_t i=0; i < 2^^16; i++)
+    for (size_t i=0; i < 2^^16; i++)
     {
         m1.slice!(4)[i] = i % 2;
         m1.slice!(0)[fn1(i)] = fn1(i);
@@ -1084,7 +1084,7 @@ unittest
         m1.slice!(2)[fn3(i)] = fn3(i);
         m1.slice!(3)[fn4(i)] = fn4(i);
     }
-    for(size_t i=0; i < 2^^16; i++)
+    for (size_t i=0; i < 2^^16; i++)
     {
         assert(m1.slice!(4)[i] == i % 2);
         assert(m1.slice!(0)[fn1(i)] == fn1(i));
@@ -1263,14 +1263,14 @@ pure nothrow:
         }
         size_t pad_e = roundDown(e);
         size_t i;
-        for(i=s; i<pad_s; i++)
+        for (i=s; i<pad_s; i++)
             if (ptr[i])
                 return false;
         // all in between is x*factor elements
-        for(size_t j=i/factor; i<pad_e; i+=factor, j++)
+        for (size_t j=i/factor; i<pad_e; i+=factor, j++)
             if (ptr.origin[j])
                 return false;
-        for(; i<e; i++)
+        for (; i<e; i++)
             if (ptr[i])
                 return false;
         return true;
@@ -1334,16 +1334,16 @@ pure nothrow:
         }
         size_t pad_end = roundDown(end); // rounded down
         size_t i;
-        for(i=start; i<pad_start; i++)
+        for (i=start; i<pad_start; i++)
             ptr[i] = val;
         // all in between is x*factor elements
         if (pad_start != pad_end)
         {
             size_t repval = replicateBits!(factor, bits)(val);
-            for(size_t j=i/factor; i<pad_end; i+=factor, j++)
+            for (size_t j=i/factor; i<pad_end; i+=factor, j++)
                 ptr.origin[j] = repval;// so speed it up by factor
         }
-        for(; i<end; i++)
+        for (; i<end; i++)
             ptr[i] = val;
     }
 
@@ -1371,7 +1371,7 @@ pure nothrow:
             return ptr.origin[s1/factor .. e1/factor]
                 == arr.ptr.origin[s2/factor .. e2/factor];
         }
-        for(size_t i=0;i<limit; i++)
+        for (size_t i=0;i<limit; i++)
             if (this[i] != arr[i])
                 return false;
         return true;
@@ -1456,7 +1456,7 @@ private struct SliceOverIndexed(T)
     {
         if (arr.length != length)
             return false;
-        for(size_t i=0; i <length; i++)
+        for (size_t i=0; i <length; i++)
             if (this[i] != arr[i])
                 return false;
         return true;
@@ -1917,7 +1917,7 @@ pure:
 //@@@BUG another forward reference workaround
 @trusted bool equalS(R1, R2)(R1 lhs, R2 rhs)
 {
-    for(;;){
+    for (;;){
         if (lhs.empty)
             return rhs.empty;
         if (rhs.empty)
@@ -2137,7 +2137,7 @@ public:
     package auto scanFor()(dchar ch) const
     {
         immutable len = data.length;
-        for(size_t i = 0; i < len; i++)
+        for (size_t i = 0; i < len; i++)
             if (ch < data[i])
                 return i & 1;
         return 0;
@@ -3862,7 +3862,7 @@ private:
         auto last = idx!level-pageSize;
         auto slice = ptr[idx!level - pageSize..idx!level];
         size_t j;
-        for(j=0; j<last; j+=pageSize)
+        for (j=0; j<last; j+=pageSize)
         {
             if (ptr[j..j+pageSize] == slice)
             {
@@ -5564,13 +5564,13 @@ unittest
     alias Set = CodepointSet;
     auto set = Set('A','Z','a','z');
     auto trie = buildTrie!(bool, uint, 256, lo8)(set.byInterval);// simple bool array
-    for(int a='a'; a<'z';a++)
+    for (int a='a'; a<'z';a++)
         assert(trie[a]);
-    for(int a='A'; a<'Z';a++)
+    for (int a='A'; a<'Z';a++)
         assert(trie[a]);
-    for(int a=0; a<'A'; a++)
+    for (int a=0; a<'A'; a++)
         assert(!trie[a]);
-    for(int a ='Z'; a<'a'; a++)
+    for (int a ='Z'; a<'a'; a++)
         assert(!trie[a]);
     trieStats(trie);
 
@@ -6809,7 +6809,7 @@ private:
     {
         size_t k = smallLength;
         ubyte* p = cast(ubyte*)enforce(malloc(3*(grow+1)), "malloc failed");
-        for(int i=0; i<k; i++)
+        for (int i=0; i<k; i++)
             write24(p, read24(small_.ptr, i), i);
         // now we can overwrite small array data
         ptr_ = p;
@@ -7028,7 +7028,7 @@ private int fullCasedCmp(Range)(dchar lhs, dchar rhs, ref Range rtail)
     size_t start = idx - fTable[idx].n;
     size_t end = fTable[idx].size + start;
     assert(fTable[start].entry_len == 1);
-    for(idx=start; idx<end; idx++)
+    for (idx=start; idx<end; idx++)
     {
         auto entryLen = fTable[idx].entry_len;
         if (entryLen == 1)
@@ -7066,7 +7066,7 @@ int icmp(S1, S2)(S1 str1, S2 str2)
     if (isForwardRange!S1 && is(Unqual!(ElementType!S1) == dchar)
     && isForwardRange!S2 && is(Unqual!(ElementType!S2) == dchar))
 {
-    for(;;)
+    for (;;)
     {
         if (str1.empty)
             return str2.empty ? 0 : -1;
@@ -7435,7 +7435,7 @@ int hangulSyllableIndex(dchar ch) pure nothrow @nogc
 // internal helper: compose hangul syllables leaving dchar.init in holes
 void hangulRecompose(dchar[] seq) pure nothrow @nogc
 {
-    for(size_t idx = 0; idx + 1 < seq.length; )
+    for (size_t idx = 0; idx + 1 < seq.length; )
     {
         if (isJamoL(seq[idx]) && isJamoV(seq[idx+1]))
         {
@@ -7643,7 +7643,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
             auto first = countUntil(ccc, 0);
             if (first >= 0) // no starters?? no recomposition
             {
-                for(;;)
+                for (;;)
                 {
                     auto second = recompose(first, decomposed, ccc);
                     if (second == decomposed.length)
@@ -7721,7 +7721,7 @@ private size_t recompose(size_t start, dchar[] input, ubyte[] ccc) pure nothrow
     // writefln("recomposing %( %04x %)", input);
     // first one is always a starter thus we start at i == 1
     size_t i = start+1;
-    for(; ; )
+    for (; ; )
     {
         if (i == input.length)
             break;
@@ -7804,7 +7804,7 @@ private auto seekStable(NormalizationForm norm, C)(size_t idx, in C[] input)
 
     auto br = input[0..idx];
     size_t region_start = 0;// default
-    for(;;)
+    for (;;)
     {
         if (br.empty)// start is 0
             break;

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -494,7 +494,7 @@ public struct UUID
                 return data;
             }
 
-            for(size_t i = 0; i < 16; i++)
+            for (size_t i = 0; i < 16; i++)
             {
                 assert(!UUID(getData(i)).empty);
             }
@@ -504,7 +504,7 @@ public struct UUID
 
             bool ctfeTest()
             {
-                for(size_t i = 0; i < 16; i++)
+                for (size_t i = 0; i < 16; i++)
                 {
                     auto ctfeEmpty2 = UUID(getData(i)).empty;
                     assert(!ctfeEmpty2);

--- a/std/xml.d
+++ b/std/xml.d
@@ -2206,7 +2206,7 @@ private
         if (c != '\u0022' && c != '\u0027')
             fail("attribute value requires quotes");
         s = s[1..$];
-        for(;;)
+        for (;;)
         {
             munch(s,"^<&"~c);
             if (s.length == 0) fail("unterminated attribute value");

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -689,7 +689,7 @@ unittest // by Dave
 
 
     // smallish buffers
-    for(int idx = 0; idx < 25; idx++) {
+    for (int idx = 0; idx < 25; idx++) {
         char[] buf = new char[uniform(0, 100)];
 
         // Alternate between more & less compressible
@@ -704,7 +704,7 @@ unittest // by Dave
     }
 
     // larger buffers
-    for(int idx = 0; idx < 25; idx++) {
+    for (int idx = 0; idx < 25; idx++) {
         char[] buf = new char[uniform(0, 1000/*0000*/)];
 
         // Alternate between more & less compressible


### PR DESCRIPTION
It turns out that I forgot to sed for `for` and there was an double occurrence of `foreach` in `std/encoding.d`.
I am terribly sorry for the spam.