### PR TITLE
minor style fixes

### DIFF
--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -1565,7 +1565,7 @@ int SQL_POSITION_TO()
 )
 {
     return SQLSetPos( hstmt, irow, SQL_POSITION, SQL_LOCK_NO_CHANGE );
-};
+}
 
 int SQL_LOCK_RECORD()
 (

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -78,7 +78,7 @@ struct DATE_STRUCT
     SQLSMALLINT    year;
     SQLUSMALLINT   month;
     SQLUSMALLINT   day;
-};
+}
 
 alias DATE_STRUCT SQL_DATE_STRUCT;
 
@@ -87,7 +87,7 @@ struct TIME_STRUCT
     SQLUSMALLINT hour;
     SQLUSMALLINT minute;
     SQLUSMALLINT second;
-};
+}
 
 alias TIME_STRUCT SQL_TIME_STRUCT;
 
@@ -100,7 +100,7 @@ struct TIMESTAMP_STRUCT
     SQLUSMALLINT   minute;
     SQLUSMALLINT   second;
     SQLUINTEGER    fraction;
-};
+}
 
 alias TIMESTAMP_STRUCT SQL_TIMESTAMP_STRUCT;
 
@@ -129,7 +129,7 @@ struct SQL_YEAR_MONTH_STRUCT
 {
     SQLUINTEGER year;
     SQLUINTEGER month;
-};
+}
 
 struct SQL_DAY_SECOND_STRUCT
 {
@@ -138,7 +138,7 @@ struct SQL_DAY_SECOND_STRUCT
     SQLUINTEGER minute;
     SQLUINTEGER second;
     SQLUINTEGER fraction;
-};
+}
 
 struct SQL_INTERVAL_STRUCT
 {
@@ -148,8 +148,8 @@ struct SQL_INTERVAL_STRUCT
     union  intval {
         SQL_YEAR_MONTH_STRUCT year_month;
         SQL_DAY_SECOND_STRUCT day_second;
-    };
-};
+    }
+}
 
 // * internal representation of numeric data type *
 const int SQL_MAX_NUMERIC_LEN = 16;
@@ -159,7 +159,7 @@ struct SQL_NUMERIC_STRUCT
     SQLSCHAR scale;
     SQLCHAR  sign;    /* 1 if positive, 0 if negative */
     SQLCHAR[ SQL_MAX_NUMERIC_LEN ]  val;
-};
+}
 
 /* size is 16 */
 struct SQLGUID
@@ -168,7 +168,7 @@ struct SQLGUID
     WORD Data2;
     WORD Data3;
     ubyte[ 8 ] Data4;
-};
+}
 
 alias SQLGUID GUID;
 alias uint    BOOKMARK;

--- a/std/c/process.d
+++ b/std/c/process.d
@@ -31,7 +31,7 @@ int execlpe(in char *, in char *,...);
 
 //These constants are undefined elsewhere and only used in the deprecated part
 //of std.process.
-enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY };
+enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY }
 
 //These declarations are defined for Posix in core.sys.posix.unistd but unused
 //from here.

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1947,7 +1947,7 @@ private
                 assert( msg.convertsTo!(Tid) );
                 auto tid = msg.get!(Tid);
 
-                if ( bool* pDepends = (tid in thisInfo.links) )
+                if ( bool* pDepends = tid in thisInfo.links )
                 {
                     auto depends = *pDepends;
                     thisInfo.links.remove( tid );

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -20941,10 +20941,7 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
 assert(!PosInfInterval!Date(Date(1996, 1, 2)).empty);
 --------------------
       +/
-    @property bool empty() const pure nothrow
-    {
-        return false;
-    }
+    @property enum bool empty = false;
 
 
     /++
@@ -23133,10 +23130,7 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
 assert(!NegInfInterval!Date(Date(1996, 1, 2)).empty);
 --------------------
       +/
-    @property bool empty() const pure nothrow
-    {
-        return false;
-    }
+    @property enum bool empty = false;
 
 
     /++

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1613,8 +1613,9 @@ unittest // Issue 14724
     }
     catch(Exception e)
     {
-        assert(false, "If the request for help was passed required options"
-                "must not be set.");
+        enum errorMsg = "If the request for help was passed required options" ~
+                "must not be set.";
+        assert(false, errorMsg);
     }
 
     assert(rslt.helpWanted);

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -742,7 +742,7 @@ public:
             ++evenbits;
         }
 
-        if ((x.data.length- firstnonzero == 2))
+        if (x.data.length- firstnonzero == 2)
         {
             // Check for a single digit straddling a digit boundary
             BigDigit x1 = x.data[firstnonzero+1];

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -24,8 +24,8 @@ public:
 alias BigDigit = uint; // A Bignum is an array of BigDigits.
 
     // Limits for when to switch between multiplication algorithms.
-enum : int { KARATSUBALIMIT = 10 }; // Minimum value for which Karatsuba is worthwhile.
-enum : int { KARATSUBASQUARELIMIT=12 }; // Minimum value for which square Karatsuba is worthwhile
+enum int KARATSUBALIMIT = 10; // Minimum value for which Karatsuba is worthwhile.
+enum int KARATSUBASQUARELIMIT = 12; // Minimum value for which square Karatsuba is worthwhile
 
 
 /** Multi-byte addition or subtraction

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -36,7 +36,7 @@ import std.traits : isArray;
 struct DummyRange(ReturnBy _r, Length _l, RangeType _rt, T = uint[])
         if (isArray!T)
 {
-    private enum uinttestData =
+    private static immutable uinttestData =
         [1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U, 10U];
     // These enums are so that the template params are visible outside
     // this instantiation.
@@ -61,7 +61,7 @@ struct DummyRange(ReturnBy _r, Length _l, RangeType _rt, T = uint[])
         // Workaround for DMD bug 4378
         static if (is(T == uint[]))
         {
-            arr = uinttestData;
+            arr = uinttestData.dup;
         }
     }
 

--- a/std/math.d
+++ b/std/math.d
@@ -5056,7 +5056,7 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
         ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
         long*   ps = cast(long *)&x;
         return (e == 0 &&
-          (((ps[MANTISSA_LSB]|(ps[MANTISSA_MSB]& 0x0000_FFFF_FFFF_FFFF))) != 0));
+          ((ps[MANTISSA_LSB]|(ps[MANTISSA_MSB]& 0x0000_FFFF_FFFF_FFFF)) != 0));
     }
     else static if (F.realFormat == RealFormat.ieeeExtended)
     {

--- a/std/meta.d
+++ b/std/meta.d
@@ -1059,7 +1059,7 @@ unittest
 ///
 unittest
 {
-    enum REF = [0, 1, 2, 3];
+    static immutable REF = [0, 1, 2, 3];
     foreach (I, V; aliasSeqOf!([0, 1, 2, 3]))
     {
         static assert(V == I);

--- a/std/process.d
+++ b/std/process.d
@@ -3329,7 +3329,7 @@ private void toAStringz(in string[] a, const(char)**az)
 
 // Incorporating idea (for spawnvp() on Posix) from Dave Fladebo
 
-enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY };
+enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY }
 version(Windows) extern(C) int spawnvp(int, in char *, in char **);
 alias P_WAIT = _P_WAIT;
 alias P_NOWAIT = _P_NOWAIT;

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -581,7 +581,7 @@ unittest
     {
         char c;
         enum empty = false;
-        void popFront(){};
+        void popFront(){}
         ref char front() return @property
         {
             return c;

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -163,7 +163,7 @@ module std.regex.internal.generator;
         return app.data;
     }
 
-    @property empty(){  return false; }
+    @property enum empty = false;
 
     void popFront()
     {

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -592,7 +592,7 @@ struct Input(Char)
 {
     import std.utf;
     alias DataIndex = size_t;
-    enum { isLoopback = false };
+    enum bool isLoopback = false;
     alias String = const(Char)[];
     String _origin;
     size_t _index;
@@ -641,7 +641,7 @@ struct BackLooperImpl(Input)
     import std.utf;
     alias DataIndex = size_t;
     alias String = Input.String;
-    enum { isLoopback = true };
+    enum bool isLoopback = true;
     String _origin;
     size_t _index;
     this(Input input, size_t index)

--- a/std/string.d
+++ b/std/string.d
@@ -4380,7 +4380,7 @@ unittest
 
     assert(detabber(" \u2029\t".byChar, 9).array == " \u2029         ");
     auto r = "hel\tx".byWchar.detabber();
-    assert(r.front == 'h' && r.front == 'h');
+    assert(r.front == 'h');
     auto s = r.save;
     r.popFront();
     r.popFront();

--- a/std/traits.d
+++ b/std/traits.d
@@ -214,7 +214,7 @@ private
     /* Demangles mstr as FuncAttrs. */
     Demangle!uint demangleFunctionAttributes(string mstr)
     {
-        enum LOOKUP_ATTRIBUTE =
+        immutable LOOKUP_ATTRIBUTE =
         [
             'a': FunctionAttribute.pure_,
             'b': FunctionAttribute.nothrow_,
@@ -1916,7 +1916,7 @@ template SetFunctionAttributes(T, string linkage, uint attrs)
             !(attrs & FunctionAttribute.safe),
             "Cannot have a function/delegate that is both trusted and safe.");
 
-        enum linkages = ["D", "C", "Windows", "Pascal", "C++", "System"];
+        static immutable linkages = ["D", "C", "Windows", "Pascal", "C++", "System"];
         static assert(canFind(linkages, linkage), "Invalid linkage '" ~
             linkage ~ "', must be one of " ~ linkages.stringof ~ ".");
 
@@ -5651,7 +5651,7 @@ unittest
 {
     void foo();
     static int bar() { return 42; }
-    enum aa = [ 1: -1 ];
+    immutable aa = [ 1: -1 ];
     alias myint = int;
 
     static assert( isExpressionTuple!(42));

--- a/std/uni.d
+++ b/std/uni.d
@@ -7299,7 +7299,7 @@ enum UnicodeDecomposition {
 enum {
     Canonical = UnicodeDecomposition.Canonical,
     Compatibility = UnicodeDecomposition.Compatibility
-};
+}
 
 /++
     Try to canonically compose 2 $(CHARACTERS).
@@ -7571,7 +7571,7 @@ enum {
     NFKC = NormalizationForm.NFKC,
     ///ditto
     NFKD = NormalizationForm.NFKD
-};
+}
 
 /++
     Returns $(D input) string normalized to the chosen form.

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -344,7 +344,7 @@ public struct UUID
                 throw new UUIDParsingException(to!string(uuid), 35, UUIDParsingException.Reason.tooMuch,
                     "Input is too long, need exactly 36 characters");
             }
-            enum skipInd = [skipSeq];
+            static immutable skipInd = [skipSeq];
             foreach (pos; skipInd)
                 if (uuid[pos] != '-')
                     throw new UUIDParsingException(to!string(uuid), pos,


### PR DESCRIPTION
- remove empty statement - e.g. `struct {};`
- change infinite `empty` property functions  to `enum`
- removed unnecessary parenthesis 
- removed implicit string concatenation
- replaced `enum` with `static immutable` for arrays and `immutable` for dicts