### PR TITLE
trivial: remove @property from enums

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -20941,7 +20941,7 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
 assert(!PosInfInterval!Date(Date(1996, 1, 2)).empty);
 --------------------
       +/
-    @property enum bool empty = false;
+    enum bool empty = false;
 
 
     /++
@@ -23130,7 +23130,7 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
 assert(!NegInfInterval!Date(Date(1996, 1, 2)).empty);
 --------------------
       +/
-    @property enum bool empty = false;
+    enum bool empty = false;
 
 
     /++

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -163,7 +163,7 @@ module std.regex.internal.generator;
         return app.data;
     }
 
-    @property enum empty = false;
+    enum empty = false;
 
     void popFront()
     {


### PR DESCRIPTION
@klickverbot quickly removed the `@property`.
(follow-up to #4247)