### PR TITLE
std.algorithm.searching.extremum - fix float comp in unittest

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1304,7 +1304,7 @@ private auto extremum(alias map = "a", alias selector = "a < b", Range,
     assert(arr2d.extremum([1]) == [1]);
 
     // allow seeds of different types (implicit casting)
-    assert([2, 3, 4].extremum(1.5) == 1.5);
+    assert(extremum([2, 3, 4], 1.5) == 1.5);
 }
 
 // find


### PR DESCRIPTION
@andralex @CyberShadow @Hackerpilot turns out that Dscanner also scans for this errors that slipped that slipped through. Travis should pass now ;-)

Maybe we should have autotester check Travis from now on...

Edit: for reference introduced by #4221 