### PR TITLE
Improvements to std.uni.sicmp and std.uni.icmp

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6930,8 +6930,8 @@ unittest
     than $(LREF icmp). However keep in mind the warning below.)
 
     Params:
-        str1 = a string or a $(D ForwardRange) of $(D dchar)s
-        str2 = a string or a $(D ForwardRange) of $(D dchar)s
+        str1 = a string
+        str2 = a string
 
     Returns:
         An $(D int) that is 0 if the strings match,
@@ -6947,17 +6947,16 @@ unittest
         $(LREF icmp)
         $(XREF_PACK algorithm,comparison,cmp)
 +/
-int sicmp(S1, S2)(S1 str1, S2 str2)
-    if (isForwardRange!S1 && is(Unqual!(ElementType!S1) == dchar)
-    && isForwardRange!S2 && is(Unqual!(ElementType!S2) == dchar))
+int sicmp(S1, S2)(S1 str1, S2 str2) if (isSomeString!S1 && isSomeString!S2)
 {
     alias sTable = simpleCaseTable;
+    import std.utf : decode;
+
     size_t ridx=0;
     foreach (dchar lhs; str1)
     {
         if (ridx == str2.length)
             return 1;
-        import std.utf : decode;
         dchar rhs = decode(str2, ridx);
         int diff = lhs - rhs;
         if (!diff)
@@ -6991,7 +6990,8 @@ int sicmp(S1, S2)(S1 str1, S2 str2)
 }
 
 ///
-unittest{
+unittest
+{
     assert(sicmp("Август", "авгусТ") == 0);
     // Greek also works as long as there is no 1:M mapping in sight
     assert(sicmp("ΌΎ", "όύ") == 0);

--- a/std/uni.d
+++ b/std/uni.d
@@ -7060,6 +7060,15 @@ private int fullCasedCmp(Range)(dchar lhs, dchar rhs, ref Range rtail)
     The cost of $(D icmp) being pedantically correct is
     slightly worse performance.
     )
+
+    Returns:
+        An $(D int) that is 0 if the strings match,
+        &lt;0 if $(D str1) is lexicographically "less" than $(D str2),
+        &gt;0 if $(D str1) is lexicographically "greater" than $(D str2)
+
+    See_Also:
+        $(LREF sicmp)
+        $(XREF_PACK algorithm,comparison,cmp)
 +/
 int icmp(S1, S2)(S1 str1, S2 str2)
     if (isForwardRange!S1 && is(Unqual!(ElementType!S1) == dchar)
@@ -7094,9 +7103,22 @@ int icmp(S1, S2)(S1 str1, S2 str2)
 }
 
 ///
-unittest{
+unittest
+{
     assert(icmp("Rußland", "Russland") == 0);
     assert(icmp("ᾩ -> \u1F70\u03B9", "\u1F61\u03B9 -> ᾲ") == 0);
+}
+
+/**
+ * By using $(XREF utf, byUTF) and its aliases, GC allocations via auto-decoding
+ * and thrown exceptions can be avoided, making `icmp` `@safe @nogc nothrow pure`.
+ */
+@safe @nogc nothrow pure unittest
+{
+    import std.utf : byDchar;
+
+    assert(icmp("Rußland".byDchar, "Russland".byDchar) == 0);
+    assert(icmp("ᾩ -> \u1F70\u03B9".byDchar, "\u1F61\u03B9 -> ᾲ".byDchar) == 0);
 }
 
 // overloads for the most common cases to reduce compile time


### PR DESCRIPTION
The main points:

1. The constraints for `sicmp` were completely wrong because `decode` cannot be called with forward ranges. In the future this could be made to work with forward ranges but for now this needs to be fixed
2. Emphasized the fact that `icmp` can be `@nogc @safe nothrow pure` if used with `byUTF`.
3. Added more detail to `icmp`'s docs