### PR TITLE
infer elementType for ranges in makeArray,makeSlice

### DIFF
--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -643,6 +643,16 @@ auto makeSlice(T,
 }
 
 /// ditto
+auto makeSlice(
+    Flag!`replaceArrayWithPointer` replaceArrayWithPointer = Yes.replaceArrayWithPointer,
+    Allocator,
+    size_t N, Range)(auto ref Allocator alloc, auto ref Slice!(N, Range) slice)
+{
+    alias T = Unqual!(slice.DeepElemType);
+    return makeSlice!(T, replaceArrayWithPointer)(alloc, slice);
+}
+
+/// ditto
 auto makeSlice(T,
     Flag!`replaceArrayWithPointer` replaceArrayWithPointer = Yes.replaceArrayWithPointer,
     Allocator,
@@ -701,7 +711,7 @@ auto makeSlice(T,
 
     // makes duplicate using `makeSlice`
     tup.slice[0, 0, 0] = 3;
-    auto dup = makeSlice!int(Mallocator.instance, tup.slice);
+    auto dup = makeSlice(Mallocator.instance, tup.slice);
     assert(dup.slice == tup.slice);
 
     Mallocator.instance.dispose(tup.array);
@@ -714,9 +724,22 @@ auto makeSlice(T,
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
 
-    auto tup = makeSlice!int(Mallocator.instance, [2, 3, 4], 10);
+    auto tup = makeSlice(Mallocator.instance, [2, 3, 4], 10);
     auto slice = tup.slice;
     assert(slice[1, 1, 1] == 10);
+    Mallocator.instance.dispose(tup.array);
+}
+
+
+@nogc unittest
+{
+    import std.experimental.allocator;
+    import std.experimental.allocator.mallocator;
+
+    // cast to your own type
+    auto tup = makeSlice!double(Mallocator.instance, [2, 3, 4], 10);
+    auto slice = tup.slice;
+    assert(slice[1, 1, 1] == 10.0);
     Mallocator.instance.dispose(tup.array);
 }
 


### PR DESCRIPTION
As discussed earlier, it's possible to infer the ElementType for `makeArray` with Ranges.
Even better we can keep full compatibility and make this feature opt-in - is anyone against this?

tl;dr: let's allow the variant b! (a is still possible)

```
auto a = alloc.makeArray!long([5, 42]);
auto b = alloc.makeArray([5, 42]);
```

Ping @9il @andralex 