### PR TITLE
std.traits: remove html comment

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -60,7 +60,7 @@
  *           $(LREF isCovariantWith)
  *           $(LREF isImplicitlyConvertible)
  * ))
- * <!--$(TR $(TD SomethingTypeOf) $(TD
+ * $(TR $(TD SomethingTypeOf) $(TD
  *           $(LREF BooleanTypeOf)
  *           $(LREF IntegralTypeOf)
  *           $(LREF FloatingPointTypeOf)
@@ -74,7 +74,7 @@
  *           $(LREF StringTypeOf)
  *           $(LREF AssocArrayTypeOf)
  *           $(LREF BuiltinTypeOf)
- * ))-->
+ * ))
  * $(TR $(TD Categories of types) $(TD
  *           $(LREF isAggregateType)
  *           $(LREF isArray)


### PR DESCRIPTION
Have a look at

https://dlang.org/library-prerelease/std/traits.html
https://dlang.org/library/std/traits.html

`<!---->` shows up there. Did you want to hide this from the user?