### PR TITLE
std.traits: provide short alias for FunctionAttributes

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -655,7 +655,6 @@ private template fqnType(T,
 
     string functionAttributeString(T)() @property
     {
-        alias FA = FunctionAttribute;
         enum attrs = functionAttributes!T;
 
         static if (attrs == FA.none)
@@ -1315,6 +1314,8 @@ enum FunctionAttribute : uint
     return_    = 1 << 12, /// ditto
 }
 
+alias FA = FunctionAttribute; // shorten the enum name
+
 /// ditto
 template functionAttributes(func...)
     if (func.length == 1 && isCallable!func)
@@ -1330,9 +1331,7 @@ template functionAttributes(func...)
 ///
 unittest
 {
-    import std.traits : functionAttributes, FunctionAttribute;
-
-    alias FA = FunctionAttribute; // shorten the enum name
+    import std.traits : functionAttributes, FA;
 
     real func(real x) pure nothrow @safe
     {
@@ -1345,8 +1344,6 @@ unittest
 
 unittest
 {
-    alias FA = FunctionAttribute;
-
     struct S
     {
         int noF() { return 0; }
@@ -2016,7 +2013,6 @@ unittest
 {
     import std.algorithm : reduce;
 
-    alias FA = FunctionAttribute;
     foreach (BaseT; TypeTuple!(typeof(&sc), typeof(&novar), typeof(&cstyle),
         typeof(&dstyle), typeof(&typesafe)))
     {
@@ -4418,7 +4414,6 @@ template isCovariantWith(F, G)
          */
         template checkAttributes()
         {
-            alias FA = FunctionAttribute;
             enum uprAtts = functionAttributes!Upr;
             enum lwrAtts = functionAttributes!Lwr;
             //


### PR DESCRIPTION
It's quite common to abbreviate `FunctionAttribute` with `FA` - this just makes it official.
As you can see even all the tests use it.
The enum is only used for `functionAttributes`, e.g. `functionAttributes!func & FA.pure_` which already explains the name.

Note: it doesn't try to change the existing name nor deprecate it.

General question: why don't we provide the abstraction `hasFunctionAttributes!(func,FA.pure_)`? It just seems to me that's what the user wants anyways and bitwise OR-ing seems not really like a Phobos-style.

edit: you even already provide `isSafe` and `isUnsafe` ...