### PR TITLE
Fix Issue 15980: std.traits.Identity is undocumented but public

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3257,7 +3257,7 @@ unittest
     static assert( hasElaborateDestructor!S7);
 }
 
-alias Identity(alias A) = A;
+package alias Identity(alias A) = A;
 
 /**
    Yields $(D true) if and only if $(D T) is an aggregate that defines


### PR DESCRIPTION
On a slightly related note, @wilzbach I think the dscanner warning about undocumented public symbols should be enabled to avoid things like this.