### PR TITLE
proper filtering of dscanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ d: dmd-2.071.0
 install:
  - wget "https://raw.githubusercontent.com/dlang/dmd/master/src/checkwhitespace.d" -O ../checkwhitespace.d
  - git clone https://github.com/Hackerpilot/Dscanner
- - (cd Dscanner && git checkout tags/v0.4.0-alpha2)
+ - (cd Dscanner && git checkout tags/v0.4.0-alpha4)
  - (cd Dscanner && git submodule update --init --recursive)
- - (cd Dscanner && make githash debug)
+ # debug build is faster, but disable 'missing import' messages (missing core from druntime)
+ - (cd Dscanner && sed 's/dparse_verbose/StdLoggerDisableWarning/' -i makefile && make githash debug)
+ # avoid checking it's dscanner's directory
  - mv Dscanner/dsc .
  - rm -rf Dscanner
 script:
  - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
+ # enforce whitespace between statements
  - grep -E "(for|foreach|foreach_reverse|if|while)\(" $(find . -name '*.d'); test $? -eq 1
- - dscanResult=$(./dscanner --config .dscanner.ini --styleCheck std etc 2> /dev/null | grep -vE "(Empty declaration|Primary expression expected)") ; if [ -z "${dscanResult}" ] ; then echo "No warnings found" ; else echo $dscanResult && $(exit 1); fi
+ # at the moment libdparse has problems to parse some modules (->excludes)
+ - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.

--- a/std/traits.d
+++ b/std/traits.d
@@ -4253,15 +4253,18 @@ package template isBlitAssignable(T)
                 static if (i == 0)
                 {
                 }
-                else if (T.tupleof[i].offsetof == offset)
-                {
-                    if (assignable)
-                        continue;
-                }
                 else
                 {
-                    if (!assignable)
-                        return false;
+                    if (T.tupleof[i].offsetof == offset)
+                    {
+                        if (assignable)
+                            continue;
+                    }
+                    else
+                    {
+                        if (!assignable)
+                            return false;
+                    }
                 }
                 assignable = isBlitAssignable!(typeof(T.tupleof[i]));
                 offset = T.tupleof[i].offsetof;

--- a/std/variant.d
+++ b/std/variant.d
@@ -2195,7 +2195,7 @@ private auto visitImpl(bool Strict, VariantType, Handler...)(VariantType variant
                             result.exceptionFuncIdx = dgidx;
                         }
                     }
-                    else if (is(Unqual!(Params[0]) == T))
+                    else static if (is(Unqual!(Params[0]) == T))
                     {
                         if (added)
                             assert(false, "duplicate overload specified for type '" ~ T.stringof ~ "'");


### PR DESCRIPTION
It turns out that currently dscanner is failing, but we just silently filter these error messages.

1) Thus for (yet to be known reasons) dscanner throws exceptions for a couple of modules in `std` (and everything in `etc`). I will try to dig deeper into the assertion error, but for now this should actually test most of phobos with dscanner ;-)

2) the replacement `sed 's/dparse_verbose/StdLoggerDisableWarning/'` is to use the fast debug build without any debug logging ;-)

Ping @CyberShadow @Hackerpilot