### PR TITLE
std.traits: hasFunctionAttributes

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -10,13 +10,14 @@ $(BUGSTITLE Library Changes,
         in multi-term arithmetic expressions.))
     $(LI $(RELATIVE_LINK2 staticIsSorted, Added `std.meta.staticIsSorted` to check if
         an `AliasSeq` is sorted according to some template predicate.))
-	$(LI $(RELATIVE_LINK2 minIndex, Added `std.algorithm.searching.minIndex`
-		to get the index of the minimum element of a range.))
-	$(LI $(RELATIVE_LINK2 maxIndex, Added `std.algorithm.searching.maxIndex`
-		to get the index of the maximum element of a range.))
-	$(LI $(RELATIVE_LINK2 ndslice-removal, `std.experimental.ndslice`
-		has been deprecated.))
-
+    $(LI $(RELATIVE_LINK2 minIndex, Added `std.algorithm.searching.minIndex`
+        to get the index of the minimum element of a range.))
+    $(LI $(RELATIVE_LINK2 maxIndex, Added `std.algorithm.searching.maxIndex`
+        to get the index of the maximum element of a range.))
+    $(LI $(RELATIVE_LINK2 ndslice-removal, `std.experimental.ndslice`
+        has been deprecated.))
+    $(LI $(RELATIVE_LINK2 has-function-attributes, Added `std.traits.hasFunctionAttributes`
+        as a user-friendly way to query for function attributes.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -48,8 +49,8 @@ static assert(!staticIsSorted!(Comp, bool, long, dchar));
 )
 
 $(LI $(LNAME2 minIndex, `std.algorithm.searching.minIndex` gets the index of
-	the minimum element of a range, according to a specified predicate. The
-	default predicate is "a < b")
+    the minimum element of a range, according to a specified predicate. The
+    default predicate is "a < b")
 -------
 import std.algorithm.searching : minIndex;
 int[] a = [5, 4, 2, 1, 9, 10];
@@ -61,8 +62,8 @@ assert(a.minIndex == -1);
 )
 
 $(LI $(LNAME2 maxIndex, `std.algorithm.searching.maxIndex` gets the index of
-	the maximum element of a range, according to a specified predicate. The
-	default predicate is "a > b")
+    the maximum element of a range, according to a specified predicate. The
+    default predicate is "a > b")
 -------
 import std.algorithm.searching : maxIndex;
 int[] a = [5, 4, 2, 1, 9, 10];
@@ -79,6 +80,30 @@ deprecated.)
     with litte gain. Users of `std.experimental.ndslice` are advised to
     switch to the upstream $(LINK2 https://github.com/libmir/mir-algorithm,
     mir package).
+)
+
+$(LI $(LNAME2 has-function-attributes, `std.traits.hasFunctionAttributes` has
+    been added)
+    It exposes a user-friendly way to query for function attributes:
+-------
+import std.traits : hasFunctionAttributes;
+
+// manually annotated function
+real func(real x) pure nothrow @safe
+{
+    return x;
+}
+static assert(hasFunctionAttributes!(func, "@safe", "pure"));
+static assert(!hasFunctionAttributes!(func, "@trusted"));
+
+// for templated function types are automatically inferred
+bool myFunc(T)(T b)
+{
+    return !b;
+}
+static assert(hasFunctionAttributes!(myFunc!bool, "@safe", "pure", "@nogc", "nothrow"));
+static assert(!hasFunctionAttributes!(myFunc!bool, "shared"));
+-------
 )
 
 )


### PR DESCRIPTION
As discussed in #4274 the std.traits API for querying after function attributes is not very user-friendly.

```
functionAttributes!((int a) { }) == (FunctionAttributes.pure_ | FunctionAttributes.nothrow_ | FunctionAttributes.nogc | FunctionAttributes.safe
```

wouldn't it be nicer, if we have a dedicated function for this?

```
hasFunctionAttributes!((int a) { }, "pure", "nothrow", "@nogc", "@safe"); 
```

Imho this makes it a lot more intuitive for the user to read and easier for us to maintain.
I heard about a DIP to cleanup and unify function attributes, so having a function allows us to stay flexible for the future ;-)
Btw the `trait` `getFunctionAttributes` already returns a string tuple.

Ping @ntrel
