### PR TITLE
Remove requirement that GCAllocator must be shared

### DIFF
--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -20,7 +20,7 @@ struct GCAllocator
     deallocate) and $(D reallocate) methods are $(D @system) because they may
     move memory around, leaving dangling pointers in user code.
     */
-    @trusted void[] allocate(size_t bytes) shared
+    static @trusted void[] allocate(size_t bytes)
     {
         if (!bytes) return null;
         auto p = GC.malloc(bytes);
@@ -28,7 +28,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool expand(ref void[] b, size_t delta) shared
+    static @system bool expand(ref void[] b, size_t delta)
     {
         if (delta == 0) return true;
         if (b is null)
@@ -55,7 +55,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool reallocate(ref void[] b, size_t newSize) shared
+    static @system bool reallocate(ref void[] b, size_t newSize)
     {
         import core.exception : OutOfMemoryError;
         try
@@ -72,22 +72,22 @@ struct GCAllocator
     }
 
     /// Ditto
-    void[] resolveInternalPointer(void* p) shared
+    static void[] resolveInternalPointer(void* p)
     {
-        auto r = GC.addrOf(p);
-        if (!r) return null;
-        return r[0 .. GC.sizeOf(r)];
+        auto info = GC.query(p);
+        if (!info.base) return null;
+        return info.base[0 .. info.size];
     }
 
     /// Ditto
-    @system bool deallocate(void[] b) shared
+    static @system bool deallocate(void[] b)
     {
         GC.free(b.ptr);
         return true;
     }
 
     /// Ditto
-    size_t goodAllocSize(size_t n) shared
+    static size_t goodAllocSize(size_t n)
     {
         if (n == 0)
             return 0;
@@ -113,7 +113,7 @@ struct GCAllocator
     static shared GCAllocator instance;
 
     // Leave it undocummented for now.
-    @trusted void collect() shared
+    static @trusted void collect()
     {
         GC.collect();
     }

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -72,7 +72,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    static void[] resolveInternalPointer(void* p)
+    static void[] resolveInternalPointer(void* p) @trusted
     {
         auto info = GC.query(p);
         if (!info.base) return null;
@@ -106,8 +106,8 @@ struct GCAllocator
 
     /**
     Returns the global instance of this allocator type. The garbage collected
-    allocator is thread-safe, therefore all of its methods and `instance` itself
-    are $(D shared).
+    allocator is thread-safe and based entirely on external storage, therefore
+    all of its methods and `instance` itself can be $(D shared).
     */
 
     static shared GCAllocator instance;


### PR DESCRIPTION
There is no internal state in `GCAllocator`, it just uses the state of the GC via global variable access.

Requiring one to use `shared(GCAllocator)` everywhere is annoying. Often times one wants to have an allocator inside an object or otherwise, and it sucks to have to mark it shared.

This change allows access via shared OR unshared `GCAllocator`.

I also saw an inefficiency in `resolveInternalPointer`. I can create a separate pull if this is controversial.

Flagging @andralex, this is somewhat of a design decision, even though the change is transparent.