### PR TITLE
Use iotaSlice instead of iota in one more place

### DIFF
--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -1213,10 +1213,8 @@ body
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.slice;
-    import std.range: iota, retro;
-    assert((5 * 3 * 6 * 7).iota
-        .sliced(5, 3, 6, 7)
+    import std.experimental.ndslice.selection: iotaSlice;
+    assert(iotaSlice(5, 3, 6, 7)
         .dropToHypercube
         .shape == cast(size_t[4])[3, 3, 3, 3]);
 }


### PR DESCRIPTION
There are couple of other places where `iota` is used throughout this module (such as [this](https://github.com/ZombineDev/phobos/blob/9e2268ca19691949266e622dc531c7c1ef7193dd/std/experimental/ndslice/iteration.d#L534)), but I chose to leave them as they are, because they're more clear that way, IMO.
Let me know if you want me to replace them all.
