### PR TITLE
Issue #14403 - Change all SUB(MODULE/REF) macros to use the new globa…

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -170,8 +170,8 @@ sort(a);                   // no predicate, "a < b" is implicit
 
 Macros:
 WIKI = Phobos/StdAlgorithm
-SUBMODULE = $(LINK2 std_algorithm_$1.html, std.algorithm.$1)
-SUBREF = $(LINK2 std_algorithm_$1.html#.$2, $(TT $2))$(NBSP)
+SUBMODULE = $(MREF std, algorithm, $1)
+SUBREF = $(REF_ALTTEXT $2, $2, std, algorithm, $1)
 
 Copyright: Andrei Alexandrescu 2008-.
 

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -9,8 +9,6 @@ $(SCRIPT inhibitQuickIndex = 1;)
 
 Macros:
 WIKI = Phobos/StdDigestHMAC
-SUBMODULE = $(LINK2 std_digest_$1.html, std.digest.$1)
-SUBREF = $(LINK2 std_digest_$1.html#.$2, $(TT $2))$(NBSP)
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -92,8 +92,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_iteration.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBREF = $(REF_ALTTEXT $2, $2, std, experimental, ndslice, $1)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -310,8 +310,8 @@ Acknowledgements:   John Loughran Colvin
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_package.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
+SUBREF = $(REF_ALTTEXT $2, $2, std, experimental, ndslice, $1)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -47,8 +47,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_selection.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBREF = $(REF_ALTTEXT $2, $2, std, experimental, ndslice, $1)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -8,8 +8,6 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_slice.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 STD = $(TD $(SMALL $0))


### PR DESCRIPTION
…l (M)REF(_ALTTEXT) macros.

This fixes cross references in the Ddox based library documentation (apart from bad formatting, which needs to be fixed in a separate PR).