### PR TITLE
ASCII optimization check in toCaser, for asLowerCase and asUpperCase

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -8111,7 +8111,8 @@ private auto toCaser(alias indexFn, uint maxIdx, alias tableFn, alias asciiConve
                     buf[0] = asciiConvert(c);
                     nLeft = 1;
                 }
-                else {
+                else
+                {
                     const idx = indexFn(c);
                     if (idx == ushort.max)
                     {

--- a/std/uni.d
+++ b/std/uni.d
@@ -8086,7 +8086,7 @@ unittest //12428
 
 
 // generic toUpper/toLower on whole range, returns range
-private auto toCaser(alias indexFn, uint maxIdx, alias tableFn, Range)(Range str)
+private auto toCaser(alias indexFn, uint maxIdx, alias tableFn, alias asciiConvert, Range)(Range str)
     // Accept range of dchar's
     if (isInputRange!Range &&
         isSomeChar!(ElementEncodingType!Range) &&
@@ -8101,31 +8101,40 @@ private auto toCaser(alias indexFn, uint maxIdx, alias tableFn, Range)(Range str
 
         @property auto front()
         {
+            import std.ascii : isASCII;
+
             if (!nLeft)
             {
                 dchar c = r.front;
-                const idx = indexFn(c);
-                if (idx == ushort.max)
+                if (c.isASCII)
                 {
-                    buf[0] = c;
+                    buf[0] = asciiConvert(c);
                     nLeft = 1;
                 }
-                else if (idx < maxIdx)
-                {
-                    buf[0] = tableFn(idx);
-                    nLeft = 1;
-                }
-                else
-                {
-                    auto val = tableFn(idx);
-                    // unpack length + codepoint
-                    nLeft = val >> 24;
-                    if (nLeft == 0)
+                else {
+                    const idx = indexFn(c);
+                    if (idx == ushort.max)
+                    {
+                        buf[0] = c;
                         nLeft = 1;
-                    assert(nLeft <= buf.length);
-                    buf[nLeft - 1] = cast(dchar)(val & 0xFF_FFFF);
-                    foreach (j; 1 .. nLeft)
-                        buf[nLeft - j - 1] = tableFn(idx + j);
+                    }
+                    else if (idx < maxIdx)
+                    {
+                        buf[0] = tableFn(idx);
+                        nLeft = 1;
+                    }
+                    else
+                    {
+                        auto val = tableFn(idx);
+                        // unpack length + codepoint
+                        nLeft = val >> 24;
+                        if (nLeft == 0)
+                            nLeft = 1;
+                        assert(nLeft <= buf.length);
+                        buf[nLeft - 1] = cast(dchar)(val & 0xFF_FFFF);
+                        foreach (j; 1 .. nLeft)
+                            buf[nLeft - j - 1] = tableFn(idx + j);
+                    }
                 }
             }
             return buf[nLeft - 1];
@@ -8186,11 +8195,12 @@ auto asLowerCase(Range)(Range str)
         import std.utf : byDchar;
 
         // Decode first
-        return toCaser!LowerTriple(str.byDchar);
+        return asLowerCase(str.byDchar);
     }
     else
     {
-        return toCaser!LowerTriple(str);
+        static import std.ascii;
+        return toCaser!(LowerTriple, std.ascii.toLower)(str);
     }
 }
 
@@ -8204,11 +8214,12 @@ auto asUpperCase(Range)(Range str)
         import std.utf : byDchar;
 
         // Decode first
-        return toCaser!UpperTriple(str.byDchar);
+        return asUpperCase(str.byDchar);
     }
     else
     {
-        return toCaser!UpperTriple(str);
+        static import std.ascii;
+        return toCaser!(UpperTriple, std.ascii.toUpper)(str);
     }
 }
 


### PR DESCRIPTION
This optimizes std.uni.asLowerCase and std.uni.asUpperCase by adding an ascii check in the shared std.uni.toCaser template. This is to help address issue: https://issues.dlang.org/show_bug.cgi?id=11229. There have been similar optimizations in other case conversion code recently to address this issue. This change tries to be consistent with the others.

In my tests, this change sped up asLowerCase in latin languages about 75% (English, German, Spanish, Finnish). For example, 1000 repetitions over a Finnish text went from 23 seconds to 5 seconds. Similarly, a German text from 31 seconds to 7 seconds. Japanese and Chinese texts were unchanged, as expected. Tests were done on OSX with dmd settings `-release -O -boundscheck=off -inline`.

Note: This is my first pull request, please review appropriately.