### PR TITLE
std.process: Disambiguate fork calls

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -412,7 +412,7 @@ private Pid spawnProcessImpl(in char[][] args,
     auto stdoutFD = getFD(stdout);
     auto stderrFD = getFD(stderr);
 
-    auto id = fork();
+    auto id = core.sys.posix.unistd.fork();
     if (id < 0)
         throw ProcessException.newFromErrno("Failed to spawn new process");
     if (id == 0)
@@ -3365,7 +3365,7 @@ deprecated("Please use spawnProcess instead")
 int _spawnvp(int mode, in char *pathname, in char **argv)
 {
     int retval = 0;
-    pid_t pid = fork();
+    pid_t pid = core.sys.posix.unistd.fork();
 
     if (!pid)
     {   // child
@@ -3804,7 +3804,7 @@ else version (Posix)
         args[1] = url.tempCString();
         args[2] = null;
 
-        auto childpid = fork();
+        auto childpid = core.sys.posix.unistd.fork();
         if (childpid == 0)
         {
             core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);


### PR DESCRIPTION
Needed for https://github.com/dlang/druntime/pull/1569 to pass the autotester without requiring https://github.com/dlang/phobos/pull/4294, which depends on it.