### PR TITLE
use mref macro instead of link2

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -170,7 +170,7 @@ sort(a);                   // no predicate, "a < b" is implicit
 
 Macros:
 WIKI = Phobos/StdAlgorithm
-SUBMODULE = $(LINK2 std_algorithm_$1.html, std.algorithm.$1)
+SUBMODULE = $(MREF std, algorithm, $1)
 SUBREF = $(LINK2 std_algorithm_$1.html#.$2, $(TT $2))$(NBSP)
 
 Copyright: Andrei Alexandrescu 2008-.

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-This is a submodule of $(LINK2 std_algorithm.html, std.algorithm).
+This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.
 
 $(BOOKTABLE Cheat Sheet,

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -9,7 +9,7 @@
     to non-ASCII characters.
 
     For functions which operate on Unicode characters, see
-    $(LINK2 std_uni.html, std.uni).
+    $(MREF std, uni).
 
     References:
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -912,7 +912,7 @@ public:
 
     /**
         $(D toString) is rarely directly invoked; the usual way of using it is via
-        $(LINK2 std_format.html#format, std.format.format):
+        $(REF format, std, format):
      */
     unittest
     {

--- a/std/complex.d
+++ b/std/complex.d
@@ -111,7 +111,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     instead, it is used via $(XREF string,format), as shown in the examples
     below.  Supported format characters are 'e', 'f', 'g', 'a', and 's'.
 
-    See the $(LINK2 std_format.html, std.format) and $(XREF string, format)
+    See the $(MREF std, format) and $(XREF string, format)
     documentation for more information.
     */
     string toString() const /* TODO: @safe pure nothrow */

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -2,7 +2,7 @@
 This module provides an $(D Array) type with deterministic memory usage not
 reliant on the GC, as an alternative to the built-in arrays.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_array.d)
 Macros:

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -2,7 +2,7 @@
 This module provides a $(D BinaryHeap) (aka priority queue)
 adaptor that makes a binary heap out of any user-provided random-access range.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
 Macros:

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -2,7 +2,7 @@
 This module implements a generic doubly-linked list container.
 It can be used as a queue, dequeue or stack.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_dlist.d)
 Macros:

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -103,29 +103,29 @@ This module consists of the following submodules:
 
 $(UL
     $(LI
-        The $(LINK2 std_container_array.html, std._container.array) module provides
+        The $(MREF std, _container, array) module provides
         an array type with deterministic control of memory, not reliant on
         the GC unlike built-in arrays.
     )
     $(LI
-        The $(LINK2 std_container_binaryheap.html, std._container.binaryheap) module
+        The $(MREF std, _container, binaryheap) module
         provides a binary heap implementation that can be applied to any
         user-provided random-access range.
     )
     $(LI
-        The $(LINK2 std_container_dlist.html, std._container.dlist) module provides
+        The $(MREF std, _container, dlist) module provides
         a doubly-linked list implementation.
     )
     $(LI
-        The $(LINK2 std_container_rbtree.html, std._container.rbtree) module
+        The $(MREF std, _container, rbtree) module
         implements red-black trees.
     )
     $(LI
-        The $(LINK2 std_container_slist.html, std._container.slist) module
+        The $(MREF std, _container, slist) module
         implements singly-linked lists.
     )
     $(LI
-        The $(LINK2 std_container_util.html, std._container.util) module contains
+        The $(MREF std, _container, util) module contains
         some generic tools commonly used by _container implementations.
     )
 )
@@ -135,7 +135,7 @@ The_primary_range_of_a_container:
 While some _containers offer direct access to their elements e.g. via
 $(D opIndex), $(D c.front) or $(D c.back), access
 and modification of a _container's contents is generally done through
-its primary $(LINK2 std_range.html, range) type,
+its primary $(MREF_ALTTEXT range, std, range) type,
 which is aliased as $(D C.Range). For example, the primary range type of
 $(D Array!int) is $(D Array!int.Range).
 
@@ -168,7 +168,7 @@ array.linearRemove(array[].find(2).take(1));
 assert(array[].equal([1, 3]));
 ---
 
-When any $(LINK2 std_range.html, range) can be passed as an argument to
+When any $(MREF_ALTTEXT range, std, range) can be passed as an argument to
 a member function, the documention usually refers to the parameter's templated
 type as $(D Stuff).
 
@@ -199,10 +199,10 @@ The primitive $(D c.remove(r)) guarantees
 $(BIGOH n$(SUBSCRIPT r) log n$(SUBSCRIPT c)) complexity in the worst case and
 $(D c.linearRemove(r)) relaxes this guarantee to $(BIGOH n$(SUBSCRIPT c)).
 
-Since a sequence of elements can be removed from a $(LINK2 std_container_dlist.html, doubly linked list)
+Since a sequence of elements can be removed from a $(MREF_ALTTEXT doubly linked list,std,_container,dlist)
 in constant time, $(D DList) provides the primitive $(D c.remove(r))
 as well as $(D c.linearRemove(r)). On the other hand
-$(LINK2 std_container_array.html, Array) only offers $(D c.linearRemove(r)).
+$(MREF_ALTTEXT Array, std,_container, array) only offers $(D c.linearRemove(r)).
 
 The following table describes the common set of primitives that containers
 implement.  A _container need not implement all primitives, but if a

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1,7 +1,7 @@
 /**
 This module implements a red-black tree container.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_rbtree.d)
 Macros:

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -2,7 +2,7 @@
 This module implements a singly-linked list container.
 It can be used as a stack.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_slist.d)
 Macros:

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -1,7 +1,7 @@
 /**
 This module contains some common utilities used by containers.
 
-This module is a submodule of $(LINK2 std_container.html, std.container).
+This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_util.d)
 Macros:

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -8,9 +8,6 @@ the corresponding $(WEB en.wikipedia.org/wiki/Hash-based_message_authentication_
 $(SCRIPT inhibitQuickIndex = 1;)
 
 Macros:
-WIKI = Phobos/StdDigestHMAC
-SUBMODULE = $(LINK2 std_digest_$1.html, std.digest.$1)
-SUBREF = $(LINK2 std_digest_$1.html#.$2, $(TT $2))$(NBSP)
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -1,7 +1,7 @@
 /**
 $(SCRIPT inhibitQuickIndex = 1;)
 
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 Operators only change strides and lengths of a slice.
 The range of a slice remains unmodified.
@@ -92,8 +92,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_iteration.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBREF = $(REF_ALTTEXT $(TT $2), $2, std,experimental, ndslice, $1)$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -310,8 +310,8 @@ Acknowledgements:   John Loughran Colvin
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_package.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBMODULE = $(MREF std, experimental, ndslice, $1)
+SUBREF = $(REF_ALTTEXT $(TT $2), $2, std,experimental, ndslice, $1)$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -1,7 +1,7 @@
 /**
 $(SCRIPT inhibitQuickIndex = 1;)
 
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 Selectors create new views and iteration patterns over the same data, without copying.
 
@@ -47,8 +47,7 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_selection.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
+SUBREF = $(REF_ALTTEXT $(TT $2), $2, std,experimental, ndslice, $1)$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */
@@ -1560,7 +1559,7 @@ pure nothrow unittest
 
 /++
 Returns a slice, the elements of which are equal to the initial multidimensional index value.
-This is multidimensional analog of $(LINK2 std_range.html#iota, std.range.iota).
+This is multidimensional analog of $(REF iota, std, range).
 For a flattened (continuous) index, see $(LREF iotaSlice).
 
 Params:

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1,5 +1,5 @@
 /**
-This is a submodule of $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+This is a submodule of $(MREF std, experimental, ndslice).
 
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
@@ -8,8 +8,6 @@ Authors:   Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_slice.d)
 
 Macros:
-SUBMODULE = $(LINK2 std_experimental_ndslice_$1.html, std.experimental.ndslice.$1)
-SUBREF = $(LINK2 std_experimental_ndslice_$1.html#.$2, $(TT $2))$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 STD = $(TD $(SMALL $0))
@@ -626,7 +624,7 @@ pure nothrow unittest
 
 /++
 Allocates an array through a specified allocator and creates an n-dimensional slice over it.
-See also $(LINK2 std_experimental_allocator.html, std.experimental.allocator).
+See also $(MREF std, experimental, allocator).
 Params:
     alloc = allocator
     lengths = list of lengths for each dimension
@@ -857,7 +855,7 @@ unittest
 }
 
 /++
-Base Exception class for $(LINK2 std_experimental_ndslice.html, std.experimental.ndslice).
+Base Exception class for $(MREF std, experimental, ndslice).
 +/
 class SliceException: Exception
 {
@@ -2538,7 +2536,7 @@ pure nothrow unittest
 
 /++
 Creating a slice from text.
-See also $(LINK2 std_format.html, std.format).
+See also $(MREF std, format).
 +/
 unittest
 {

--- a/std/file.d
+++ b/std/file.d
@@ -4,7 +4,7 @@
 Utilities for manipulating files and scanning directories. Functions
 in this module handle files as a unit, e.g., read or write one _file
 at a time. For opening files and manipulating them via handles refer
-to module $(LINK2 std_stdio.html,$(D std.stdio)).
+to module $(MREF std, stdio).
 
 Macros:
 WIKI = Phobos/StdFile
@@ -12,9 +12,9 @@ WIKI = Phobos/StdFile
 Copyright: Copyright Digital Mars 2007 - 2011.
 See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
 introduction to working with files in D, module
-$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them
-via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating
-path strings.
+$(MREF std, stdio) for opening files and manipulating them via handles,
+and module $(MREF std, path) for manipulating path strings.
+
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),

--- a/std/format.d
+++ b/std/format.d
@@ -39,8 +39,8 @@ $(TR $(TH Function Name) $(TH Description)
     ))
 )
 
-   These two functions are publicly imported by $(LINK2 std_string.html,
-   std.string) to be easily available.
+   These two functions are publicly imported by $(MREF std, string)
+   to be easily available.
 
    The functions $(D $(LREF formatValue)) and $(D $(LREF unformatValue)) are
    used for the plumbing.

--- a/std/functional.d
+++ b/std/functional.d
@@ -5,8 +5,7 @@ Functions that manipulate other functions.
 
 This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
-$(LINK2 std_algorithm.html, std.algorithm) or $(LINK2 std_range.html,
-std.range).
+$(MREF std, algorithm) or $(MREF std, range).
 
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -1,5 +1,5 @@
 /**
-This module is a submodule of $(LINK2 std_range.html, std.range).
+This module is a submodule of $(MREF std, range).
 
 The main $(D std.range) module provides template-based tools for working with
 ranges, but sometimes an object-based interface for ranges is needed, such as
@@ -76,8 +76,9 @@ import std.traits;
  * around input ranges with element type E.  This is useful where a well-defined
  * binary interface is required, such as when a DLL function or virtual function
  * needs to accept a generic range as a parameter. Note that
- * $(LINK2 std_range_primitives.html#isInputRange, isInputRange) and friends check for conformance to structural
- * interfaces, not for implementation of these $(D interface) types.
+ * $(REF_ALTTEXT isInputRange, isInputRange, std, range, primitives)
+ * and friends check for conformance to structural interfaces
+ * not for implementation of these $(D interface) types.
  *
  * Limitations:
  *

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -20,12 +20,12 @@ Submodules:
 
 This module has two submodules:
 
-The $(LINK2 std_range_primitives.html, $(D std._range.primitives)) submodule
+The $(MREF std, _range, primitives) submodule
 provides basic _range functionality. It defines several templates for testing
 whether a given object is a _range, what kind of _range it is, and provides
 some common _range operations.
 
-The $(LINK2 std_range_interfaces.html, $(D std._range.interfaces)) submodule
+The $(MREF std, _range, interfaces) submodule
 provides object-based interfaces for working with ranges via runtime
 polymorphism.
 
@@ -168,8 +168,8 @@ $(BOOKTABLE ,
 
 Ranges whose elements are sorted afford better efficiency with certain
 operations. For this, the $(D $(LREF assumeSorted)) function can be used to
-construct a $(D $(LREF SortedRange)) from a pre-sorted _range. The $(LINK2
-std_algorithm.html#sort, $(D std.algorithm.sort)) function also conveniently
+construct a $(D $(LREF SortedRange)) from a pre-sorted _range. The $(REF
+sort, std, algorithm, sorting) function also conveniently
 returns a $(D SortedRange). $(D SortedRange) objects provide some additional
 _range operations that take advantage of the fact that the _range is sorted.
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1,5 +1,5 @@
 /**
-This module is a submodule of $(LINK2 std_range.html, std.range).
+This module is a submodule of $(MREF std, range).
 
 It provides basic range functionality by defining several templates for testing
 whether a given object is a _range, and what kind of _range it is:

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -31,7 +31,7 @@
  *      See $(SAMPLESRC htmlget.d)
  * Authors: Christopher E. Miller
  * References:
- *      $(LINK2 std_stream.html, std.stream)
+ *      $(MREF std, stream)
  * Source:    $(PHOBOSSRC std/_socketstream.d)
  * Macros: WIKI=Phobos/StdSocketstream
  */

--- a/std/string.d
+++ b/std/string.d
@@ -116,21 +116,21 @@ $(LEADINGROW Publicly imported functions)
 )
 
 There is a rich set of functions for _string handling defined in other modules.
-Functions related to Unicode and ASCII are found in $(LINK2 std_uni.html, std.uni)
-and $(LINK2 std_ascii.html, std.ascii), respectively. Other functions that have a
-wider generality than just strings can be found in $(LINK2 std_algorithm.html,
-std.algorithm) and $(LINK2 std_range.html, std.range).
+Functions related to Unicode and ASCII are found in $(MREF std, uni)
+and $(MREF std, ascii), respectively. Other functions that have a
+wider generality than just strings can be found in $(MREF std, algorithm)
+and $(MREF std, range).
 
 See_Also:
     $(LIST
-    $(LINK2 std_algorithm.html, std.algorithm) and
-    $(LINK2 std_range.html, std.range)
+    $(MREF std, algorithm) and
+    $(MREF std, range)
     for generic range algorithms
     ,
-    $(LINK2 std_ascii.html, std.ascii)
+    $(MREF std, ascii)
     for functions that work with ASCII strings
     ,
-    $(LINK2 std_uni.html, std.uni)
+    $(MREF std, uni)
     for functions that work with unicode strings
     )
 
@@ -5209,16 +5209,15 @@ body
  * See if character c is in the pattern.
  * Patterns:
  *
- *  A <i>pattern</i> is an array of characters much like a <i>character
- *  class</i> in regular expressions. A sequence of characters
+ *  A $(I pattern) is an array of characters much like a $(I character
+ *  class) in regular expressions. A sequence of characters
  *  can be given, such as "abcde". The '-' can represent a range
  *  of characters, as "a-e" represents the same pattern as "abcde".
  *  "a-fA-F0-9" represents all the hex characters.
  *  If the first character of a pattern is '^', then the pattern
  *  is negated, i.e. "^0-9" means any character except a digit.
- *  The functions inPattern, <b>countchars</b>, <b>removeschars</b>,
- *  and <b>squeeze</b>
- *  use patterns.
+ *  The functions inPattern, $(B countchars), $(B removeschars),
+ *  and $(B squeeze) use patterns.
  *
  * Note: In the future, the pattern syntax may be improved
  *  to be more like regular expression character classes.
@@ -5459,7 +5458,7 @@ S squeeze(S)(S s, in S pattern = null)
 /***************************************************************
  Finds the position $(D_PARAM pos) of the first character in $(D_PARAM
  s) that does not match $(D_PARAM pattern) (in the terminology used by
- $(LINK2 std_string.html,inPattern)). Updates $(D_PARAM s =
+ $(XREF string,inPattern)). Updates $(D_PARAM s =
  s[pos..$]). Returns the slice from the beginning of the original
  (before update) string up to, and excluding, $(D_PARAM pos).
 
@@ -5467,7 +5466,6 @@ The $(D_PARAM munch) function is mostly convenient for skipping
 certain category of characters (e.g. whitespace) when parsing
 strings. (In such cases, the return value is not used.)
  */
-
 S1 munch(S1, S2)(ref S1 s, S2 pattern) @safe pure @nogc
 {
     size_t j = s.length;

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -1,6 +1,6 @@
 /**
  * This module was renamed to disambiguate the term tuple, use
- * $(LINK2 std_meta.html, std.meta) instead.
+ * $(MREF std, meta) instead.
  *
  * Copyright: Copyright Digital Mars 2005 - 2015.
  * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/uni.d
+++ b/std/uni.d
@@ -9,7 +9,7 @@
 
     $(P All primitives listed operate on Unicode characters and
     sets of characters. For functions which operate on ASCII characters
-    and ignore Unicode $(CHARACTERS), see $(LINK2 std_ascii.html, std.ascii).
+    and ignore Unicode $(CHARACTERS), see $(MREF std, ascii).
     For definitions of Unicode $(CHARACTER), $(CODEPOINT) and other terms
     used throughout this module see the $(S_LINK Terminology, terminology) section
     below.

--- a/std/variant.d
+++ b/std/variant.d
@@ -721,7 +721,7 @@ public:
      * Returns $(D true) if and only if the $(D VariantN)
      * object holds an object implicitly convertible to type $(D
      * U). Implicit convertibility is defined as per
-     * $(LINK2 std_traits.html#ImplicitConversionTargets,ImplicitConversionTargets).
+     * $(REF_ALTTEXT ImplicitConversionTargets, ImplicitConversionTargets, std,traits).
      */
 
     @property bool convertsTo(T)() const


### PR DESCRIPTION
Resubmission of #3926 plus a couple of REF_ALTTEXT.

If `REF_ALTTEXT` is a replacement for the LINK2 links within Phobos, there would be only

```
ack "LINK2" | grep std | wc -l
```

46 more occurrences of LINK2 to other Phobos modules to go.
This would be a short follow-up PR then.