### PR TITLE
Move isPowerOf2 from std.experimental.allocator.common to std.math

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -20,6 +20,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
 {
     import std.conv, std.experimental.allocator.common, std.traits;
     import std.algorithm : min;
+    import std.math : isPowerOf2;
 
     static assert(
         !stateSize!Prefix || Allocator.alignment >= Prefix.alignof,

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -304,6 +304,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     */
     void[] alignedAllocate(size_t n, uint a)
     {
+        import std.math : isPowerOf2;
         assert(a.isPowerOf2);
         if (a <= alignment) return allocate(n);
 

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -164,6 +164,7 @@ struct Region(ParentAllocator = NullAllocator,
     */
     void[] alignedAllocate(size_t n, uint a)
     {
+        import std.math : isPowerOf2;
         assert(a.isPowerOf2);
         static if (growDownwards)
         {

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -251,6 +251,7 @@ Returns `n` rounded up to a multiple of alignment, which must be a power of 2.
 @safe @nogc nothrow pure
 package size_t roundUpToAlignment(size_t n, uint alignment)
 {
+    import std.math : isPowerOf2;
     assert(alignment.isPowerOf2);
     immutable uint slack = cast(uint) n & (alignment - 1);
     const result = slack
@@ -275,6 +276,7 @@ Returns `n` rounded down to a multiple of alignment, which must be a power of 2.
 @safe @nogc nothrow pure
 package size_t roundDownToAlignment(size_t n, uint alignment)
 {
+    import std.math : isPowerOf2;
     assert(alignment.isPowerOf2);
     return n & ~size_t(alignment - 1);
 }
@@ -438,6 +440,7 @@ than or equal to the given pointer.
 @nogc nothrow pure
 package void* alignDownTo(void* ptr, uint alignment)
 {
+    import std.math : isPowerOf2;
     assert(alignment.isPowerOf2);
     return cast(void*) (cast(size_t) ptr & ~(alignment - 1UL));
 }
@@ -449,47 +452,23 @@ than or equal to the given pointer.
 @nogc nothrow pure
 package void* alignUpTo(void* ptr, uint alignment)
 {
+    import std.math : isPowerOf2;
     assert(alignment.isPowerOf2);
     immutable uint slack = cast(size_t) ptr & (alignment - 1U);
     return slack ? ptr + alignment - slack : ptr;
 }
 
-// Credit: Matthias Bentrup
-/**
-Returns `true` if `x` is a nonzero power of two.
-*/
-@safe @nogc nothrow pure
-package bool isPowerOf2(uint x)
-{
-    return (x & -x) > (x - 1);
-}
-
-@safe @nogc nothrow pure
-unittest
-{
-    assert(!isPowerOf2(0));
-    assert(isPowerOf2(1));
-    assert(isPowerOf2(2));
-    assert(!isPowerOf2(3));
-    assert(isPowerOf2(4));
-    assert(!isPowerOf2(5));
-    assert(!isPowerOf2(6));
-    assert(!isPowerOf2(7));
-    assert(isPowerOf2(8));
-    assert(!isPowerOf2(9));
-    assert(!isPowerOf2(10));
-    assert(isPowerOf2(1UL << 31));
-}
-
 @safe @nogc nothrow pure
 package bool isGoodStaticAlignment(uint x)
 {
+    import std.math : isPowerOf2;
     return x.isPowerOf2;
 }
 
 @safe @nogc nothrow pure
 package bool isGoodDynamicAlignment(uint x)
 {
+    import std.math : isPowerOf2;
     return x.isPowerOf2 && x >= (void*).sizeof;
 }
 
@@ -605,6 +584,7 @@ package void testAllocator(alias make)()
 {
     import std.conv : text;
     import std.stdio : writeln, stderr;
+    import std.math : isPowerOf2;
     alias A = typeof(make());
     scope(failure) stderr.writeln("testAllocator failed for ", A.stringof);
 

--- a/std/math.d
+++ b/std/math.d
@@ -18,7 +18,7 @@ $(TR $(TDNW Constants) $(TD
 ))
 $(TR $(TDNW Classics) $(TD
     $(MYREF abs) $(MYREF fabs) $(MYREF sqrt) $(MYREF cbrt) $(MYREF hypot)
-    $(MYREF poly) $(MYREF nextPow2) $(MYREF truncPow2)
+    $(MYREF poly) $(MYREF isPowerOf2) $(MYREF nextPow2) $(MYREF truncPow2)
 ))
 $(TR $(TDNW Trigonometry) $(TD
     $(MYREF sin) $(MYREF cos) $(MYREF tan) $(MYREF asin) $(MYREF acos)
@@ -7606,4 +7606,52 @@ T truncPow2(T)(const T val) if (isFloatingPoint!T)
         assert(truncPow2(T.infinity) == T.infinity);
         assert(truncPow2(T.init).isNaN);
     }
+}
+
+// Credit: Matthias Bentrup
+/**
+Params:
+    x = the number to test
+
+Returns:
+    `true` if `x` is a nonzero power of two.
+*/
+@safe @nogc nothrow pure
+bool isPowerOf2(T)(T x) if (isIntegral!T)
+in
+{
+    static if (isSigned!T)
+        assert(x > -1, "isPowerOf2 only accepts non-negative arguments");
+}
+body
+{
+    static if (isSigned!T)
+    {
+        import std.conv : unsigned;
+
+        if (x == 0)
+            return false;
+
+        x = unsigned(x);
+    }
+
+    return (x & -x) > (x - 1);
+}
+
+///
+@safe @nogc nothrow pure
+unittest
+{
+    assert(!isPowerOf2(0));
+    assert( isPowerOf2(1));
+    assert( isPowerOf2(2));
+    assert(!isPowerOf2(3));
+    assert( isPowerOf2(4));
+    assert(!isPowerOf2(5));
+    assert(!isPowerOf2(6));
+    assert(!isPowerOf2(7));
+    assert( isPowerOf2(8));
+    assert(!isPowerOf2(9));
+    assert(!isPowerOf2(10));
+    assert( isPowerOf2(1UL << 31));
 }


### PR DESCRIPTION
This needs to be moved before std.experimental.allocator is moved anyway, better to do it sooner rather than later.

ping @andralex