### PR TITLE
Fix delegates in unit test so that they actually return void and do nothing

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -2613,9 +2613,9 @@ unittest
     Obj obj = 1;
 
     obj.visit!(
-        (int x) => {},
-        (IntTypedef x) => {},
-        (Obj[] x) => {},
+        (int x) {},
+        (IntTypedef x) {},
+        (Obj[] x) {},
     );
 }
 


### PR DESCRIPTION
Because {} looks like a delegate, block statement, struct literal, dessert topping, and floor wax.