### PR TITLE
std.algorithm: set accidentally exposed methods to private

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -70,7 +70,7 @@ import std.functional; // : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 
-template aggregate(fun...) if (fun.length >= 1)
+private template aggregate(fun...) if (fun.length >= 1)
 {
     /* --Intentionally not ddoc--
      * Aggregates elements in each subrange of the given range of ranges using
@@ -4899,8 +4899,33 @@ Permutations!Range permutations(Range)(Range r)
 struct Permutations(Range)
     if (isRandomAccessRange!Range && hasLength!Range)
 {
-    size_t[] indices, state;
-    Range r;
+    private size_t[] _indices, _state;
+    private Range _r;
+    private bool _empty;
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Use front()")
+    @property size_t[] indices() pure nothrow @nogc @safe { return _indices; }
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Don't set it manually")
+    @property void indices(size_t[] indices) pure nothrow @nogc @safe { _indices = indices; }
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Use front()")
+    @property size_t[] state() pure nothrow @nogc @safe { return _state; }
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Don't set it manually")
+    @property void state(size_t[] state) pure nothrow @nogc @safe { state = state; }
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Access will be forbidden.")
+    @property Range r() pure nothrow @nogc @safe { return _r; }
+
+    // Explicitly undocumented. It will be removed in June 2017. @@@DEPRECATED_2017-06@@@
+    deprecated("Private variable. Don't set it manually")
+    @property void r(Range r) pure nothrow @nogc @safe { _r = r; }
 
     ///
     this(Range r)
@@ -4908,20 +4933,23 @@ struct Permutations(Range)
         import std.range : iota;
         import std.array : array;
 
-        this.r = r;
-        state = r.length ? new size_t[r.length-1] : null;
-        indices = iota(size_t(r.length)).array;
-        empty = r.length == 0;
+        this._r = r;
+        _state = r.length ? new size_t[r.length-1] : null;
+        _indices = iota(size_t(r.length)).array;
+        _empty = r.length == 0;
     }
 
     ///
-    bool empty;
+    @property bool empty() const pure nothrow @safe @nogc
+    {
+        return _empty;
+    }
 
     ///
     @property auto front()
     {
         import std.range : indexed;
-        return r.indexed(indices);
+        return _r.indexed(_indices);
     }
 
     ///
@@ -4931,20 +4959,20 @@ struct Permutations(Range)
         {
             import std.algorithm.mutation : swap;
 
-            if (n > indices.length)
+            if (n > _indices.length)
             {
-                empty = true;
+                _empty = true;
                 return;
             }
 
             if (n % 2 == 1)
-                swap(indices[0], indices[n-1]);
+                swap(_indices[0], _indices[n-1]);
             else
-                swap(indices[state[n-2]], indices[n-1]);
+                swap(_indices[_state[n-2]], _indices[n-1]);
 
-            if (++state[n-2] == n)
+            if (++_state[n-2] == n)
             {
-                state[n-2] = 0;
+                _state[n-2] = 0;
                 next(n+1);
             }
         }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2500,7 +2500,7 @@ pure @safe nothrow unittest
     assert(f.payload.equal([10, 12, 11]));
 }
 
-void swapFront(R1, R2)(R1 r1, R2 r2)
+private void swapFront(R1, R2)(R1 r1, R2 r2)
     if (isInputRange!R1 && isInputRange!R2)
 {
     static if (is(typeof(swap(r1.front, r2.front))))

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1922,9 +1922,8 @@ if (isRandomAccessRange!R1 && isForwardRange!R2 && !isBidirectionalRange!R2 &&
     assert(find(haystack, filter!"true"(needle)).empty);
 }
 
-// Internally used by some find() overloads above. Can't make it
-// private due to bugs in the compiler.
-/*private*/ R1 simpleMindedFind(alias pred, R1, R2)(R1 haystack, R2 needle)
+// Internally used by some find() overloads above
+private R1 simpleMindedFind(alias pred, R1, R2)(R1 haystack, R2 needle)
 {
     enum estimateNeedleLength = hasLength!R1 && !hasLength!R2;
 
@@ -3856,7 +3855,7 @@ bool startsWith(alias pred, R)(R doesThisStart)
 Consume all elements from $(D r) that are equal to one of the elements
 $(D es).
  */
-void skipAll(alias pred = "a == b", R, Es...)(ref R r, Es es)
+private void skipAll(alias pred = "a == b", R, Es...)(ref R r, Es es)
 //if (is(typeof(binaryFun!pred(r1.front, es[0]))))
 {
   loop:
@@ -3938,8 +3937,8 @@ struct Until(alias pred, Range, Sentinel) if (isInputRange!Range)
     //             uint, "", 6));
     //             OpenRight, "_openRight", 1,
     //             bool,  "_done", 1,
-    OpenRight _openRight;
-    bool _done;
+    private OpenRight _openRight;
+    private bool _done;
 
     static if (!is(Sentinel == void))
         ///

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -794,7 +794,7 @@ struct NWayUnion(alias less, RangeOfRanges)
         // revert comparison order so we get the smallest elements first
         return comp(b.front, a.front);
     }
-    BinaryHeap!(RangeOfRanges, compFront) _heap;
+    private BinaryHeap!(RangeOfRanges, compFront) _heap;
 
     ///
     this(RangeOfRanges ror)


### PR DESCRIPTION
follow-up to #4312. This includes a couple of accidentally exposed publicly exposed methods - they weren't documented.
For permutations I added deprecations, but I would prefer if we can live without them ;-)