### PR TITLE
enforce: whitespace after catch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ install:
 script:
  - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
  # enforce whitespace between statements
- - grep -E "(for|foreach|foreach_reverse|if|while)\(" $(find . -name '*.d'); test $? -eq 1
+ - grep -E "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
  # at the moment libdparse has problems to parse some modules (->excludes)
  - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1704,7 +1704,7 @@ assert(equal(rbt[], [5]));
             {
                 recurse(_end.left, "");
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 debug printTree(_end.left, 0);
                 throw e;

--- a/std/conv.d
+++ b/std/conv.d
@@ -2215,7 +2215,7 @@ Lerr:
             int x = input.to!int();
             assert(false, "Invalid conversion did not throw");
         }
-        catch(ConvException e)
+        catch (ConvException e)
         {
             // Ensure error message contains failing character, not the character
             // beyond.
@@ -2223,7 +2223,7 @@ Lerr:
             assert( e.msg.canFind(charInMsg) &&
                    !e.msg.canFind(charNotInMsg));
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             assert(false, "Did not throw ConvException");
         }

--- a/std/csv.d
+++ b/std/csv.d
@@ -606,7 +606,7 @@ unittest
         csvReader(str, ["c","b"]);
         assert(0);
     }
-    catch(HeaderMismatchException e)
+    catch (HeaderMismatchException e)
     {
         assert(e.col == 2);
     }
@@ -1041,7 +1041,7 @@ public:
                     aa[header[_input.col-1]] = recordRange.front;
                 }
             }
-            catch(ConvException e)
+            catch (ConvException e)
             {
                 throw new CSVException(e.msg, _input.row, _input.col, e);
             }
@@ -1086,7 +1086,7 @@ public:
                     recordRange.popFront();
                 }
             }
-            catch(ConvException e)
+            catch (ConvException e)
             {
                 throw new CSVException(e.msg, _input.row, colIndex, e);
             }
@@ -1280,14 +1280,14 @@ public:
             try
                 csvNextToken!(Range, ErrorLevel, Separator)
                                    (_input.range, _front, _separator, _quote,false);
-            catch(IncompleteCellException ice)
+            catch (IncompleteCellException ice)
             {
                 ice.row = _input.row;
                 ice.col = _input.col;
                 ice.partialData = _front.data.idup;
                 throw ice;
             }
-            catch(ConvException e)
+            catch (ConvException e)
             {
                 throw new CSVException(e.msg, _input.row, _input.col, e);
             }
@@ -1302,7 +1302,7 @@ public:
             csvNextToken!(Range, ErrorLevel, Separator)
                 (_input.range, _front, _separator, _quote,false);
         }
-        catch(IncompleteCellException ice)
+        catch (IncompleteCellException ice)
         {
             ice.row = _input.row;
             ice.col = _input.col;
@@ -1327,7 +1327,7 @@ public:
         auto data = _front.data;
         static if (!isSomeString!Contents) skipWS(data);
         try curContentsoken = to!Contents(data);
-        catch(ConvException e)
+        catch (ConvException e)
         {
             throw new CSVException(e.msg, _input.row, _input.col, e);
         }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -667,7 +667,7 @@ public:
     {
         try
             this(dateTime, Duration.zero, tz);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "SysTime's constructor threw when it shouldn't have.");
     }
 
@@ -783,7 +783,7 @@ public:
 
             this(standardTime, _timezone);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Date, TimeOfDay, or DateTime's constructor threw when it shouldn't have.");
     }
 
@@ -835,7 +835,7 @@ public:
 
             this(standardTime, _timezone);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Date's constructor through when it shouldn't have.");
     }
 
@@ -2197,7 +2197,7 @@ public:
 
             return FracSec.from!"hnsecs"(cast(int)hnsecs);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "FracSec.from!\"hnsecs\"() threw.");
     }
 
@@ -5232,7 +5232,7 @@ public:
             adjTime = newDaysHNSecs + hnsecs;
             return this;
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Either DateTime's constructor or TimeOfDay's constructor threw.");
     }
 
@@ -7978,7 +7978,7 @@ public:
 
             return DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Either DateTime's constructor or TimeOfDay's constructor threw.");
     }
 
@@ -8034,7 +8034,7 @@ public:
 
             return TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "TimeOfDay's constructor threw.");
     }
 
@@ -8139,7 +8139,7 @@ public:
                           fracSecsToISOString(cast(int)hnsecs),
                           SimpleTimeZone.toISOExtString(utcOffset));
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -8269,7 +8269,7 @@ public:
                           fracSecsToISOString(cast(int)hnsecs),
                           SimpleTimeZone.toISOExtString(utcOffset));
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -8403,7 +8403,7 @@ public:
                           fracSecsToISOString(cast(int)hnsecs),
                           SimpleTimeZone.toISOExtString(utcOffset));
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -8593,7 +8593,7 @@ public:
             {
                 try
                     parsedZone = SimpleTimeZone.fromISOString(zoneStr);
-                catch(DateTimeException dte)
+                catch (DateTimeException dte)
                     parsedZone = SimpleTimeZone.fromISOExtString(zoneStr);
             }
 
@@ -8604,7 +8604,7 @@ public:
 
             return retval;
         }
-        catch(DateTimeException dte)
+        catch (DateTimeException dte)
             throw new DateTimeException(format("Invalid ISO String: %s", isoString));
     }
 
@@ -8840,7 +8840,7 @@ public:
 
             return retval;
         }
-        catch(DateTimeException dte)
+        catch (DateTimeException dte)
             throw new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString));
     }
 
@@ -9053,7 +9053,7 @@ public:
 
             return retval;
         }
-        catch(DateTimeException dte)
+        catch (DateTimeException dte)
             throw new DateTimeException(format("Invalid Simple String: %s", simpleString));
     }
 
@@ -9411,7 +9411,7 @@ public:
 
                 try
                     dayOfYear = day;
-                catch(Exception e)
+                catch (Exception e)
                     assert(0, "dayOfYear assignment threw.");
             }
         }
@@ -9421,7 +9421,7 @@ public:
 
             try
                 dayOfYear = (daysInLeapYear + day);
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "dayOfYear assignment threw.");
         }
         else
@@ -9476,7 +9476,7 @@ public:
 
                 try
                     dayOfYear = newDoY;
-                catch(Exception e)
+                catch (Exception e)
                     assert(0, "dayOfYear assignment threw.");
             }
         }
@@ -12506,7 +12506,7 @@ public:
             else
                 return Date(_year - 1, 12, 31).isoWeek;
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Date's constructor threw.");
     }
 
@@ -12579,7 +12579,7 @@ public:
     {
         try
             return Date(_year, _month, maxDay(_year, _month));
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "Date's constructor threw.");
     }
 
@@ -12787,7 +12787,7 @@ public:
             else
                 return format("%06d%02d%02d", _year, _month, _day);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -12843,7 +12843,7 @@ public:
             else
                 return format("%06d-%02d-%02d", _year, _month, _day);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -12899,7 +12899,7 @@ public:
             else
                 return format("%06d-%s-%02d", _year, monthToString(_month), _day);
         }
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -14402,7 +14402,7 @@ public:
         import std.format : format;
         try
             return format("%02d%02d%02d", _hour, _minute, _second);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -14432,7 +14432,7 @@ public:
         import std.format : format;
         try
             return format("%02d:%02d:%02d", _hour, _minute, _second);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -17482,7 +17482,7 @@ public:
     {
         try
             return DateTime(_date.endOfMonth, TimeOfDay(23, 59, 59));
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "DateTime constructor threw.");
     }
 
@@ -17673,7 +17673,7 @@ public:
         import std.format : format;
         try
             return format("%sT%s", _date.toISOString(), _tod.toISOString());
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -17726,7 +17726,7 @@ public:
         import std.format : format;
         try
             return format("%sT%s", _date.toISOExtString(), _tod.toISOExtString());
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -17778,7 +17778,7 @@ public:
         import std.format : format;
         try
             return format("%s %s", _date.toSimpleString(), _tod.toString());
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -19875,7 +19875,7 @@ private:
         import std.format : format;
         try
             return format("[%s - %s)", _begin, _end);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -22590,7 +22590,7 @@ private:
         import std.format : format;
         try
             return format("[%s - ∞)", _begin);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -24819,7 +24819,7 @@ private:
         import std.format : format;
         try
             return format("[-∞ - %s)", _end);
-        catch(Exception e)
+        catch (Exception e)
             assert(0, "format() threw.");
     }
 
@@ -27769,7 +27769,7 @@ public:
             {
                 try
                     return WindowsTimeZone.getTimeZone(windowsTZName);
-                catch(DateTimeException dte)
+                catch (DateTimeException dte)
                 {
                     auto oldName = _getOldName(windowsTZName);
                     if (oldName != null)
@@ -28250,7 +28250,7 @@ public:
             import std.conv : to;
             try
                 return to!string(tzname[0]);
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "to!string(tzname[0]) failed.");
         }
         else version(Windows)
@@ -28280,7 +28280,7 @@ public:
 
                 return retval;
             }
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "GetTimeZoneInformation() returned invalid UTF-16.");
         }
     }
@@ -28321,7 +28321,7 @@ public:
             import std.conv : to;
             try
                 return to!string(tzname[1]);
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "to!string(tzname[1]) failed.");
         }
         else version(Windows)
@@ -28351,7 +28351,7 @@ public:
 
                 return retval;
             }
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "GetTimeZoneInformation() returned invalid UTF-16.");
         }
     }
@@ -28409,7 +28409,7 @@ public:
 
                     return janOffset != julyOffset;
                 }
-                catch(Exception e)
+                catch (Exception e)
                     assert(0, "Clock.currTime() threw.");
             }
         }
@@ -29915,9 +29915,9 @@ public:
 
             return new immutable PosixTimeZone(transitions.idup, leapSeconds.idup, name, stdName, dstName, hasDST);
         }
-        catch(DateTimeException dte)
+        catch (DateTimeException dte)
             throw dte;
-        catch(Exception e)
+        catch (Exception e)
             throw new DateTimeException("Not a valid TZ data file", __FILE__, __LINE__, e);
     }
 
@@ -30654,7 +30654,7 @@ else version(Windows)
 
                 return false;
             }
-            catch(Exception e)
+            catch (Exception e)
                 assert(0, "DateTime's constructor threw.");
         }
 
@@ -30771,7 +30771,7 @@ else version(Windows)
                     if (isDST)
                         return adjTime + convert!("minutes", "hnsecs")(tzInfo.Bias + tzInfo.DaylightBias);
                 }
-                catch(Exception e)
+                catch (Exception e)
                     assert(0, "SysTime's constructor threw.");
             }
 
@@ -31775,7 +31775,7 @@ public:
         bool doublestart = true;
         try
             sw.start();
-        catch(AssertError e)
+        catch (AssertError e)
             doublestart = false;
         assert(!doublestart);
         sw.stop();
@@ -31802,7 +31802,7 @@ public:
         bool doublestop = true;
         try
             sw.stop();
-        catch(AssertError e)
+        catch (AssertError e)
             doublestop = false;
         assert(!doublestop);
         assert((t1 - sw.peek()).to!("seconds", real)() == 0);
@@ -32700,7 +32700,7 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
 
     try
         return SysTime(DateTime(year, month, dayOfMonth, hour, minute, second), tz);
-    catch(DateTimeException dte)
+    catch (DateTimeException dte)
         throw new DateTimeException("Invalid DosFileTime", __FILE__, __LINE__, dte);
 }
 
@@ -33000,7 +33000,7 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
 
     try
         return SysTime(DateTime(year, month, day, hour, minute, second), tz);
-    catch(DateTimeException dte)
+    catch (DateTimeException dte)
         throw new DateTimeException("date-time format is correct, but the resulting SysTime is invalid.", dte);
 }
 
@@ -33032,7 +33032,7 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
 {
     try
         parseRFC822DateTime(cr(str));
-    catch(DateTimeException)
+    catch (DateTimeException)
         return;
     throw new AssertError("No DateTimeException was thrown", __FILE__, line);
 }
@@ -34562,7 +34562,7 @@ static string fracSecsToISOString(int hnsecs) @safe pure nothrow
 
         return isoString;
     }
-    catch(Exception e)
+    catch (Exception e)
         assert(0, "format() threw.");
 }
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -269,7 +269,7 @@ unittest
         assertThrown!Exception(throwEx(new Exception("It's an Exception")),
                                "It's a message");
     }
-    catch(AssertError) assert(0);
+    catch (AssertError) assert(0);
 
     try
     {
@@ -291,7 +291,7 @@ unittest
         bool thrown = false;
         try
             assertThrown!Exception(nothrowEx());
-        catch(AssertError)
+        catch (AssertError)
             thrown = true;
 
         assert(thrown);
@@ -301,7 +301,7 @@ unittest
         bool thrown = false;
         try
             assertThrown!Exception(nothrowEx(), "It's a message");
-        catch(AssertError)
+        catch (AssertError)
             thrown = true;
 
         assert(thrown);
@@ -311,7 +311,7 @@ unittest
         bool thrown = false;
         try
             assertThrown!AssertError(nothrowEx());
-        catch(AssertError)
+        catch (AssertError)
             thrown = true;
 
         assert(thrown);
@@ -321,7 +321,7 @@ unittest
         bool thrown = false;
         try
             assertThrown!AssertError(nothrowEx(), "It's a message");
-        catch(AssertError)
+        catch (AssertError)
             thrown = true;
 
         assert(thrown);
@@ -786,7 +786,7 @@ string collectExceptionMsg(T = Exception, E)(lazy E expression)
 
         return cast(string)null;
     }
-    catch(T e)
+    catch (T e)
         return e.msg.empty ? emptyExceptionMsg : e.msg;
 }
 ///
@@ -973,7 +973,7 @@ T assumeWontThrow(T)(lazy T expr,
     {
         return expr;
     }
-    catch(Exception e)
+    catch (Exception e)
     {
         import std.range.primitives : empty;
         immutable tail = msg.empty ? "." : ": " ~ msg;
@@ -1578,7 +1578,7 @@ CommonType!(T1, T2) ifThrown(E : Throwable = Exception, T1, T2)(lazy scope T1 ex
     {
         return expression();
     }
-    catch(E)
+    catch (E)
     {
         return errorHandler();
     }
@@ -1599,7 +1599,7 @@ CommonType!(T1, T2) ifThrown(E : Throwable, T1, T2)(lazy scope T1 expression, sc
     {
         return expression();
     }
-    catch(E e)
+    catch (E e)
     {
         return errorHandler(e);
     }
@@ -1620,7 +1620,7 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
     {
         return expression();
     }
-    catch(Exception e)
+    catch (Exception e)
     {
         return errorHandler(e);
     }
@@ -1773,7 +1773,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         return typeof(this)(range.save);
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         return typeof(this)(handler(exception, this.range));
                     }
@@ -1797,7 +1797,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         return this.range.empty;
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         return handler(exception, this.range);
                     }
@@ -1815,7 +1815,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                 {
                     return this.range.front;
                 }
-                catch(E exception)
+                catch (E exception)
                 {
                     return handler(exception, this.range);
                 }
@@ -1832,7 +1832,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                 {
                     this.range.popFront();
                 }
-                catch(E exception)
+                catch (E exception)
                 {
                     handler(exception, this.range);
                 }
@@ -1851,7 +1851,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         return this.range.back;
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         return handler(exception, this.range);
                     }
@@ -1868,7 +1868,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         this.range.popBack();
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         handler(exception, this.range);
                     }
@@ -1888,7 +1888,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         return this.range[index];
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         static if (__traits(compiles, handler(exception, this.range, index)))
                             return handler(exception, this.range, index);
@@ -1911,7 +1911,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                     {
                         return this.range.length;
                     }
-                    catch(E exception)
+                    catch (E exception)
                     {
                         return handler(exception, this.range);
                     }
@@ -1933,7 +1933,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                         {
                             return typeof(this)(this.range[lower .. upper]);
                         }
-                        catch(E exception)
+                        catch (E exception)
                         {
                             return typeof(this)(handler(exception, this.range));
                         }
@@ -1955,7 +1955,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                         {
                             return typeof(this)(this.range[lower .. $]);
                         }
-                        catch(E exception)
+                        catch (E exception)
                         {
                             return typeof(this)(handler(exception, this.range));
                         }
@@ -1972,7 +1972,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
                         {
                             return takeExactly(typeof(this)(this.range[lower .. $]), upper - 1);
                         }
-                        catch(E exception)
+                        catch (E exception)
                         {
                             return takeExactly(typeof(this)(handler(exception, this.range)), 0);
                         }

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -806,7 +806,7 @@ pure unittest
     {
         // Tries to reshape without allocation
         try return slice.reshape(lengths);
-        catch(ReshapeException e)
+        catch (ReshapeException e)
             //allocates the elements and creates a slice
             //Note: -1 length is not supported by reshape2
             return slice.byElement.array.sliced(lengths);

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1611,7 +1611,7 @@ unittest // Issue 14724
     {
         rslt = getopt(args, config.required, "foo|f", "bool a", &a);
     }
-    catch(Exception e)
+    catch (Exception e)
     {
         enum errorMsg = "If the request for help was passed required options" ~
                 "must not be set.";

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2416,7 +2416,7 @@ struct HTTP
                         callback(fieldName, m.captures[2]);
                     headersIn[fieldName] = m.captures[2].idup;
                 }
-                catch(UTFException e)
+                catch (UTFException e)
                 {
                     //munch it - a header should be all ASCII, any "wrong UTF" is broken header
                 }

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1069,7 +1069,7 @@ private:
         {
             job.job();
         }
-        catch(Throwable e)
+        catch (Throwable e)
         {
             job.exception = e;
         }
@@ -1262,7 +1262,7 @@ private:
         {
             toExecute.job();
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             toExecute.exception = e;
         }
@@ -2679,7 +2679,7 @@ public:
                 {
                     tasks[0].job();
                 }
-                catch(Throwable e)
+                catch (Throwable e)
                 {
                     tasks[0].exception = e;
                 }
@@ -2704,7 +2704,7 @@ public:
                 {
                     task.yieldForce;
                 }
-                catch(Throwable e)
+                catch (Throwable e)
                 {
                     addToChain(e, firstException, lastException);
                     continue;
@@ -3411,7 +3411,7 @@ private void submitAndExecute(
         {
             tasks[0].job();
         }
-        catch(Throwable e)
+        catch (Throwable e)
         {
             tasks[0].exception = e;
         }
@@ -3432,7 +3432,7 @@ private void submitAndExecute(
         {
             task.yieldForce;
         }
-        catch(Throwable e)
+        catch (Throwable e)
         {
             addToChain(e, firstException, lastException);
             continue;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7323,9 +7323,9 @@ in
         {
             Largest!(Enumerator, Signed!LengthType) signedLength;
             try signedLength = to!(typeof(signedLength))(range.length);
-            catch(ConvException)
+            catch (ConvException)
                 overflow = true;
-            catch(Exception)
+            catch (Exception)
                 assert(false);
 
             auto result = adds(start, signedLength, overflow);

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -624,7 +624,7 @@ struct Parser(R, Generator)
         {
             parseRegex();
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             error(e.msg);//also adds pattern location
         }
@@ -785,7 +785,7 @@ struct Parser(R, Generator)
                         bool enable = true;
                         do
                         {
-                            switch(current)
+                            switch (current)
                             {
                             case 's':
                                 if (enable)

--- a/std/socket.d
+++ b/std/socket.d
@@ -2841,7 +2841,7 @@ public:
                 newSocket._blocking = _blocking;                 //inherits blocking mode
             newSocket._family = _family;             //same family
         }
-        catch(Throwable o)
+        catch (Throwable o)
         {
             _close(newsock);
             throw o;

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1442,7 +1442,7 @@ UUID parseUUID(Range)(ref Range uuidRange) if (isInputRange!Range
 
                 dashAllowed = true;
             }
-            catch(ConvException e)
+            catch (ConvException e)
             {
                 parserError(consumed, UUIDParsingException.Reason.invalidChar,
                     "Couldn't parse ubyte", e);

--- a/std/xml.d
+++ b/std/xml.d
@@ -469,7 +469,7 @@ string decode(string s, DecodeMode mode=DecodeMode.LOOSE)
                     buffer ~= temp[0 .. encode(temp, d)];
                     i = s.length - t.length - 1;
                 }
-                catch(Err e)
+                catch (Err e)
                 {
                     if (mode == DecodeMode.STRICT)
                         throw new DecodeException("Unescaped &");
@@ -1015,13 +1015,13 @@ class Tag
 
         s = name;
         try { checkName(s,t); }
-        catch(Err e) { assert(false,"Invalid tag name:" ~ e.toString()); }
+        catch (Err e) { assert(false,"Invalid tag name:" ~ e.toString()); }
 
         foreach (k,v;attr)
         {
             s = k;
             try { checkName(s,t); }
-            catch(Err e)
+            catch (Err e)
                 { assert(false,"Invalid atrribute name:" ~ e.toString()); }
         }
     }
@@ -1088,7 +1088,7 @@ class Tag
             reqc(s,'>');
             tagString.length = (s.ptr - tagString.ptr);
         }
-        catch(XMLException e)
+        catch (XMLException e)
         {
             tagString.length = (s.ptr - tagString.ptr);
             throw new TagException(tagString);
@@ -2131,7 +2131,7 @@ private
             else if (s.startsWith("<?"))   { checkPI(s); }
             else                           { checkSpace(s); }
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkDocument(ref string s) // rule 1
@@ -2143,7 +2143,7 @@ private
             checkElement(s);
             star!(checkMisc)(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkChars(ref string s) // rule 2
@@ -2212,7 +2212,7 @@ private
             if (s.length == 0) fail("unterminated attribute value");
             if (s[0] == '<') fail("< found in attribute value");
             if (s[0] == c) break;
-            try { checkReference(s); } catch(Err e) { fail(e); }
+            try { checkReference(s); } catch (Err e) { fail(e); }
         }
         s = s[1..$];
     }
@@ -2234,11 +2234,11 @@ private
     {
         mixin Check!("Comment");
 
-        try { checkLiteral("<!--",s); } catch(Err e) { fail(e); }
+        try { checkLiteral("<!--",s); } catch (Err e) { fail(e); }
         ptrdiff_t n = s.indexOf("--");
         if (n == -1) fail("unterminated comment");
         s = s[n..$];
-        try { checkLiteral("-->",s); } catch(Err e) { fail(e); }
+        try { checkLiteral("-->",s); } catch (Err e) { fail(e); }
     }
 
     void checkPI(ref string s) // rule 16
@@ -2250,7 +2250,7 @@ private
             checkLiteral("<?",s);
             checkEnd("?>",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkCDSect(ref string s) // rule 18
@@ -2262,7 +2262,7 @@ private
             checkLiteral(cdata,s);
             checkEnd("]]>",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkProlog(ref string s) // rule 22
@@ -2279,7 +2279,7 @@ private
             star!(checkMisc)(s);
             opt!(seq!(checkDocTypeDecl,star!(checkMisc)))(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkXMLDecl(ref string s) // rule 23
@@ -2295,7 +2295,7 @@ private
             opt!(checkSpace)(s);
             checkLiteral("?>",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkVersionInfo(ref string s) // rule 24
@@ -2309,7 +2309,7 @@ private
             checkEq(s);
             quoted!(checkVersionNum)(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkEq(ref string s) // rule 25
@@ -2322,7 +2322,7 @@ private
             checkLiteral("=",s);
             opt!(checkSpace)(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkVersionNum(ref string s) // rule 26
@@ -2346,7 +2346,7 @@ private
             //
             checkEnd(">",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkSDDecl(ref string s) // rule 32
@@ -2359,7 +2359,7 @@ private
             checkLiteral("standalone",s);
             checkEq(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
 
         int n = 0;
              if (s.startsWith("'yes'") || s.startsWith("\"yes\"")) n = 5;
@@ -2374,7 +2374,7 @@ private
         mixin Check!("Element");
 
         string sname,ename,t;
-        try { checkTag(s,t,sname); } catch(Err e) { fail(e); }
+        try { checkTag(s,t,sname); } catch (Err e) { fail(e); }
 
         if (t == "STag")
         {
@@ -2384,7 +2384,7 @@ private
                 t = s;
                 checkETag(s,ename);
             }
-            catch(Err e) { fail(e); }
+            catch (Err e) { fail(e); }
 
             if (sname != ename)
             {
@@ -2414,7 +2414,7 @@ private
             }
             checkLiteral(">",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkAttribute(ref string s) // rule 41
@@ -2428,7 +2428,7 @@ private
             checkEq(s);
             checkAttValue(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkETag(ref string s, out string name) // rule 42
@@ -2442,7 +2442,7 @@ private
             opt!(checkSpace)(s);
             checkLiteral(">",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkContent(ref string s) // rule 43
@@ -2463,7 +2463,7 @@ private
                 else                               { checkCharData(s); }
             }
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkCharRef(ref string s, out dchar c) // rule 66
@@ -2471,7 +2471,7 @@ private
         mixin Check!("CharRef");
 
         c = 0;
-        try { checkLiteral("&#",s); } catch(Err e) { fail(e); }
+        try { checkLiteral("&#",s); } catch (Err e) { fail(e); }
         int radix = 10;
         if (s.length != 0 && s[0] == 'x')
         {
@@ -2525,7 +2525,7 @@ private
             if (s.startsWith("&#")) checkCharRef(s,c);
             else checkEntityRef(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkEntityRef(ref string s) // rule 68
@@ -2539,7 +2539,7 @@ private
             checkName(s,name);
             checkLiteral(";",s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     void checkEncName(ref string s) // rule 81
@@ -2562,7 +2562,7 @@ private
             checkEq(s);
             quoted!(checkEncName)(s);
         }
-        catch(Err e) { fail(e); }
+        catch (Err e) { fail(e); }
     }
 
     // Helper functions
@@ -2589,7 +2589,7 @@ private
 
     void opt(alias f)(ref string s)
     {
-        try { f(s); } catch(Err e) {}
+        try { f(s); } catch (Err e) {}
     }
 
     void plus(alias f)(ref string s)
@@ -2603,7 +2603,7 @@ private
         while (s.length != 0)
         {
             try { f(s); }
-            catch(Err e) { return; }
+            catch (Err e) { return; }
         }
     }
 
@@ -2650,7 +2650,7 @@ void check(string s)
         checkDocument(s);
         if (s.length != 0) throw new Err(s,"Junk found after document");
     }
-    catch(Err e)
+    catch (Err e)
     {
         e.complete(s);
         throw e;
@@ -2698,7 +2698,7 @@ unittest
         ]");
     assert(false);
     }
-    catch(CheckException e)
+    catch (CheckException e)
     {
         int n = e.toString().indexOf("end tag name \"genres\" differs"~
             " from start tag name \"genre\"");


### PR DESCRIPTION
I realized we forgot to add `catch` to the enforce whitespace after operator list.
`switch` was already sticking to the style guide. So this is the result of a simple `sed`:

```
sed -i "s/catch(/catch (/" **/*.d
```

Btw a short look the D spec yielded the following statements - do we consider one of them as operator?

```
mixin
version
scope
synchronized
with
```