### PR TITLE
Add `std.math.isPowerOf2()`. Supports floating-point and integers.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4632,7 +4632,8 @@ if (isForwardRange!R && !isRandomAccessRange!R)
 private auto sumPairwiseN(size_t N, bool needEmptyChecks, F, R)(ref R r)
 if (isForwardRange!R && !isRandomAccessRange!R)
 {
-    static assert(!(N & (N-1))); //isPow2
+    import std.math : isPowerOf2;
+    static assert(isPowerOf2(N));
     static if (N == 2) return sumPair!(needEmptyChecks, F)(r);
     else return sumPairwiseN!(N/2, needEmptyChecks, F)(r)
         + sumPairwiseN!(N/2, needEmptyChecks, F)(r);

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -21,6 +21,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     import std.conv, std.experimental.allocator.common, std.traits;
     import std.algorithm : min;
     import std.typecons : Ternary;
+    import std.math : isPowerOf2;
 
     static assert(
         !stateSize!Prefix || Allocator.alignment >= Prefix.alignof,

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -304,6 +304,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     */
     void[] alignedAllocate(size_t n, uint a)
     {
+        import std.math : isPowerOf2;
         assert(a.isPowerOf2);
         if (a <= alignment) return allocate(n);
 

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -163,6 +163,7 @@ struct Region(ParentAllocator = NullAllocator,
     */
     void[] alignedAllocate(size_t n, uint a)
     {
+        import std.math : isPowerOf2;
         assert(a.isPowerOf2);
         static if (growDownwards)
         {

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -7,6 +7,7 @@ Authors: $(WEB erdani.com, Andrei Alexandrescu), Timon Gehr (`Ternary`)
 */
 module std.experimental.allocator.common;
 import std.algorithm, std.traits;
+import std.math : isPowerOf2;
 
 /**
 Returns the size in bytes of the state that needs to be allocated to hold an
@@ -305,33 +306,6 @@ package void* alignUpTo(void* ptr, uint alignment)
     assert(alignment.isPowerOf2);
     immutable uint slack = cast(size_t) ptr & (alignment - 1U);
     return slack ? ptr + alignment - slack : ptr;
-}
-
-// Credit: Matthias Bentrup
-/**
-Returns `true` if `x` is a nonzero power of two.
-*/
-@safe @nogc nothrow pure
-package bool isPowerOf2(uint x)
-{
-    return (x & -x) > (x - 1);
-}
-
-@safe @nogc nothrow pure
-unittest
-{
-    assert(!isPowerOf2(0));
-    assert(isPowerOf2(1));
-    assert(isPowerOf2(2));
-    assert(!isPowerOf2(3));
-    assert(isPowerOf2(4));
-    assert(!isPowerOf2(5));
-    assert(!isPowerOf2(6));
-    assert(!isPowerOf2(7));
-    assert(isPowerOf2(8));
-    assert(!isPowerOf2(9));
-    assert(!isPowerOf2(10));
-    assert(isPowerOf2(1UL << 31));
 }
 
 @safe @nogc nothrow pure

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2630,7 +2630,7 @@ private:
     in
     {
         assert(range.length >= 4);
-        assert(isPowerOfTwo(range.length));
+        assert(isPowerOf2(range.length));
     }
     body
     {
@@ -2664,7 +2664,7 @@ private:
     in
     {
         assert(range.length >= 4);
-        assert(isPowerOfTwo(range.length));
+        assert(isPowerOf2(range.length));
     }
     body
     {
@@ -2772,7 +2772,7 @@ private:
     void butterfly(R)(R buf) const
     in
     {
-        assert(isPowerOfTwo(buf.length));
+        assert(isPowerOf2(buf.length));
     }
     body
     {
@@ -2859,7 +2859,7 @@ private:
             return;
         }
 
-        enforce(isPowerOfTwo(size),
+        enforce(isPowerOf2(size),
             "Can only do FFTs on ranges with a size that is a power of two.");
         auto table = new lookup_t[][bsf(size) + 1];
 
@@ -3285,13 +3285,6 @@ void slowFourier4(Ret, R)(R range, Ret buf)
     buf[1] = range[0] - range[1] * C(0, 1) - range[2] + range[3] * C(0, 1);
     buf[2] = range[0] - range[1] + range[2] - range[3];
     buf[3] = range[0] + range[1] * C(0, 1) - range[2] - range[3] * C(0, 1);
-}
-
-bool isPowerOfTwo(N)(N num)
-    if (isScalarType!N && !isFloatingPoint!N)
-{
-    import core.bitop : bsf, bsr;
-    return bsr(num) == bsf(num);
 }
 
 N roundDownToPowerOf2(N)(N num)

--- a/std/uni.d
+++ b/std/uni.d
@@ -1105,7 +1105,7 @@ template PackedPtr(T)
 @trusted struct PackedPtrImpl(T, size_t bits)
 {
 pure nothrow:
-    static assert(isPowerOf2(bits));
+    static assert(isPow2OrZero(bits));
 
     this(inout(size_t)* ptr)inout @safe @nogc
     {
@@ -1503,7 +1503,7 @@ string genUnrolledSwitchSearch(size_t size)
     import core.bitop : bsr;
     import std.array : replace;
     import std.conv : to;
-    assert(isPowerOf2(size));
+    assert(isPow2OrZero(size));
     string code = `
     import core.bitop : bsr;
     auto power = bsr(m)+1;
@@ -1533,15 +1533,16 @@ string genUnrolledSwitchSearch(size_t size)
     return code;
 }
 
-bool isPowerOf2(size_t sz) @safe pure nothrow @nogc
+bool isPow2OrZero(size_t sz) @safe pure nothrow @nogc
 {
+    // See also: std.math.isPowerOf2()
     return (sz & (sz-1)) == 0;
 }
 
 size_t uniformLowerBound(alias pred, Range, T)(Range range, T needle)
     if (is(T : ElementType!Range))
 {
-    assert(isPowerOf2(range.length));
+    assert(isPow2OrZero(range.length));
     size_t idx = 0, m = range.length/2;
     while (m != 0)
     {
@@ -1557,7 +1558,7 @@ size_t uniformLowerBound(alias pred, Range, T)(Range range, T needle)
 size_t switchUniformLowerBound(alias pred, Range, T)(Range range, T needle)
     if (is(T : ElementType!Range))
 {
-    assert(isPowerOf2(range.length));
+    assert(isPow2OrZero(range.length));
     size_t idx = 0, m = range.length/2;
     enum max = 1<<10;
     while (m >= max)
@@ -1580,7 +1581,7 @@ template sharMethod(alias uniLowerBound)
         alias pred = binaryFun!_pred;
         if (range.length == 0)
             return 0;
-        if (isPowerOf2(range.length))
+        if (isPow2OrZero(range.length))
             return uniLowerBound!pred(range, needle);
         size_t n = truncPow2(range.length);
         if (pred(range[n-1], needle))


### PR DESCRIPTION
This is intended to supersede [PR #4308](https://github.com/dlang/phobos/pull/4308), which adds `std.math.isPowerOf2()`. Improvements:
* Support floating-point numbers.
* Corrected handling of signed integers.
* Reduced template bloat, by marking `x` as `const`.