### PR TITLE
Fix the broken fallback algorithm for `std.math.isInfinity()`

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5140,7 +5140,7 @@ bool isInfinity(X)(X x) @nogc @trusted pure nothrow
     }
     else
     {
-        return (x - 1) == x;
+        return (x < -X.max) || (X.max < x);
     }
 }
 


### PR DESCRIPTION
The affected line cannot be directly tested right now, but the new algorithm has been verified:

* It passed at CTFE on all 10 auto-tester platforms, as part of a larger PR that I subsequently closed for unrelated reasons: https://github.com/dlang/phobos/pull/4328

* You can also see the test code just for this PR on [DPaste](https://dpaste.dzfl.pl/0ac4bdd211af).

* Unlike the old algorithm, this one actually makes sense...

