### PR TITLE
update dscanner to alpha 6

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -2,67 +2,67 @@
 [analysis.config.StaticAnalysisConfig]
 ; Check variable, class, struct, interface, union, and function names against
 ; the Phobos style guide
-style_check="false"
+style_check="disabled"
 ; Check for array literals that cause unnecessary allocation
-enum_array_literal_check="true"
+enum_array_literal_check="enabled"
 ; Check for poor exception handling practices
-exception_check="false" ; FIXME
+exception_check="disabled" ; FIXME
 ; Check for use of the deprecated 'delete' keyword
-delete_check="false" ; FIXME
+delete_check="disabled" ; FIXME
 ; Check for use of the deprecated floating point operators
-float_operator_check="true"
+float_operator_check="enabled"
 ; Check number literals for readability
-number_style_check="false" ; FIXME
+number_style_check="disabled" ; FIXME
 ; Checks that opEquals, opCmp, toHash, and toString are either const, immutable
 ; , or inout.
-object_const_check="false"
+object_const_check="disabled"
 ; Checks for .. expressions where the left side is larger than the right.
-backwards_range_check="true"
+backwards_range_check="enabled"
 ; Checks for if statements whose 'then' block is the same as the 'else' block
-if_else_same_check="true"
+if_else_same_check="enabled"
 ; Checks for some problems with constructors
-constructor_check="true"
+constructor_check="enabled"
 ; Checks for unused variables and function parameters
-unused_variable_check="false"
+unused_variable_check="disabled"
 ; Checks for unused labels
-unused_label_check="false" ; FIXME
+unused_label_check="disabled" ; FIXME
 ; Checks for duplicate attributes
-duplicate_attribute="true"
+duplicate_attribute="enabled"
 ; Checks that opEquals and toHash are both defined or neither are defined
-opequals_tohash_check="false"
+opequals_tohash_check="disabled"
 ; Checks for subtraction from .length properties
-length_subtraction_check="false"
+length_subtraction_check="disabled"
 ; Checks for methods or properties whose names conflict with built-in properties
-builtin_property_names_check="false"; FIXME
+builtin_property_names_check="disabled"; FIXME
 ; Checks for confusing code in inline asm statements
-asm_style_check="false"; FIXME
+asm_style_check="disabled"; FIXME
 ; Checks for confusing logical operator precedence
-logical_precedence_check="false"
+logical_precedence_check="disabled"
 ; Checks for undocumented public declarations
-undocumented_declaration_check="false"; FIXME
+undocumented_declaration_check="disabled"; FIXME
 ; Checks for poor placement of function attributes
-function_attribute_check="false"
+function_attribute_check="disabled"
 ; Checks for use of the comma operator
-comma_expression_check="false"
+comma_expression_check="disabled"
 ; Checks for local imports that are too broad
-local_import_check="false"
+local_import_check="disabled"
 ; Checks for variables that could be declared immutable
-could_be_immutable_check="false"
+could_be_immutable_check="disabled"
 ; Checks for redundant expressions in if statements
 redundant_if_check="true"
 ; Checks for redundant parenthesis
 redundant_parens_check="true"
 ; Checks for mismatched argument and parameter names
-mismatched_args_check="false"
+mismatched_args_check="disabled"
 ; Checks for labels with the same name as variables
-label_var_same_name_check="false"
+label_var_same_name_check="disabled"
 ; Checks for lines longer than 120 characters
-long_line_check="false" ; FIXME
+long_line_check="disabled" ; FIXME
 ; Checks for assignment to auto-ref function parameters
-auto_ref_assignment_check="false" ; FIXME
+auto_ref_assignment_check="disabled" ; FIXME
 ; Checks for incorrect infinite range definitions
-incorrect_infinite_range_check="true"
+incorrect_infinite_range_check="enabled"
 ; Checks for asserts that are always true
-useless_assert_check="false"; FIXME
+useless_assert_check="disabled"; FIXME
 ; Check for unclear lambda syntax
-lambda_return_check="false"
+lambda_return_check="disabled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ d: dmd-2.071.0
 install:
  - wget "https://raw.githubusercontent.com/dlang/dmd/master/src/checkwhitespace.d" -O ../checkwhitespace.d
  - git clone https://github.com/Hackerpilot/Dscanner
- - (cd Dscanner && git checkout tags/v0.4.0-alpha5)
+ - (cd Dscanner && git checkout tags/v0.4.0-alpha6)
  - (cd Dscanner && git submodule update --init --recursive)
  # debug build is faster, but disable 'missing import' messages (missing core from druntime)
  - (cd Dscanner && sed 's/dparse_verbose/StdLoggerDisableWarning/' -i makefile && make githash debug)


### PR DESCRIPTION
This PR updates dscanner and its configuration because the old file is not compatible with a recent change in dscanner (which is that a test can be _"enabled"_ | _"disabled"_ | _"skip-unittest"_)