### PR TITLE
[DO NOT PULL] testing if shadowing shows up on the auto-tester

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4808,6 +4808,16 @@ unittest
     }
     ensureDefaults();
 
+    version(Posix)
+    {
+        double foo = 3.0;
+    }
+
+    if (FloatingPointControl.hasExceptionTraps)
+    {
+        double foo = 5.0;
+    }
+
     version(D_HardFloat)
     {
         {


### PR DESCRIPTION
A weird issue showed up on another PR where it passed on linux and FreeBSD, but only OSX said the variable was shadowed, in a situation just like this.  Seeing if I can reproduce...