### PR TITLE
fix issue 15885 - float serialized to JSON loses precision

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1252,7 +1252,8 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                     }
                 }
                 else {
-                    json.put(to!string(val));
+                    import std.format : format;
+                    json.put("%.16g".format(val));
                 }
                 break;
 
@@ -1717,5 +1718,12 @@ pure nothrow @safe unittest // issue 15884
     Test!char();
     Test!wchar();
     Test!dchar();
+}
+
+@safe unittest // issue 15885
+{
+    double num = 30738.22;
+    JSONValue json = JSONValue(num);
+    assert(to!double(toJSON(json)) == num);
 }
 


### PR DESCRIPTION
In toJSON�, a float is converted to a string using `to!string()`. A best approach is to use the `"%.17g"` specifier with `format()`. With this specifier, the string returned may include non signifiant digits but the original value can be retrieved.

[Reference for this fix](http://stackoverflow.com/a/21162120).