### PR TITLE
fix issue 16054 - can break immutable with std.typecons.Rebindable

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1584,7 +1584,7 @@ private mixin template RebindableCommon(T, U, alias This)
             opAssign(initializer);
         }
 
-        @property ref inout(T) get() inout
+        @property inout(T) get() inout
         {
             return original;
         }
@@ -1659,6 +1659,13 @@ unittest
     // a.x = 5;
     // Fine
     a = new Widget;
+}
+
+unittest // issue 16054
+{
+    Rebindable!(immutable Object) r;
+    static assert(__traits(compiles, r.get()));
+    static assert(!__traits(compiles, &r.get()));
 }
 
 /**


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=16054

Code from the bug report showing how immutable can be broken when `get` returns a reference:

```d
import std.typecons: Rebindable;

class C
{
    int x;
    this(int x) pure { this.x = x; }
}

void main()
{
    Rebindable!(immutable C) ic = new immutable C(1);
    
    immutable(C)* p = &ic.get();
    assert(p.x == 1); /* passes */
    scope (exit) assert(p.x == 1); /* fails */
    
    ic = new immutable C(2);
}
```