### PR TITLE
Set deployment target to the minimum supported version of OS X

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -30,6 +30,10 @@ QUIET:=
 
 include osmodel.mak
 
+ifeq (osx,$(OS))
+	export MACOSX_DEPLOYMENT_TARGET=10.7
+endif
+
 # Default to a release built, override with BUILD=debug
 ifeq (,$(BUILD))
 BUILD_WAS_SPECIFIED=0


### PR DESCRIPTION
Since the update to use native TLS on OS X the minimum deployment
target is now OS X Lion (10.7).