### PR TITLE
Fix issue 15941 -- rbtree no longer supports classes

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1711,13 +1711,18 @@ assert(equal(rbt[], [5]));
     }
 
     /**
-    Formats the RedBlackTree into a sink function. For more info see
-    $(D std.format.formatValue)
-    */
-    void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const {
-        sink("RedBlackTree(");
-        sink.formatValue(this[], fmt);
-        sink(")");
+      Formats the RedBlackTree into a sink function. For more info see $(D
+      std.format.formatValue). Note that this only is available when the
+      element type can be formatted. Otherwise, the default toString from
+      Object is used.
+     */
+    static if(is(typeof((){FormatSpec!(char) fmt; formatValue((const(char)[]) {}, ConstRange.init, fmt);})))
+    {
+        void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const {
+            sink("RedBlackTree(");
+            sink.formatValue(this[], fmt);
+            sink(")");
+        }
     }
 
     /**
@@ -2043,4 +2048,11 @@ unittest
     static assert(is(typeof(rt1.upperBound(3).front) == immutable(int)));
     import std.algorithm : equal;
     assert(rt1.upperBound(2).equal([3, 4, 5]));
+}
+
+// issue 15941
+unittest
+{
+    class C {}
+    RedBlackTree!(C, "cast(void*)a < cast(void*)b") tree;
 }


### PR DESCRIPTION
Simple -- if type doesn't support formatting the range, then don't define `toString`. This means it defaults to `Object.toString` in those cases, but this isn't really a problem.

There are likely better ways to do this, but this fixes the regression now.
Need to see how docs get generated to find out if I did that part right.