### PR TITLE
remove whitespace in ddoc output of std/algorithm

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 among,
         Checks if a value is among a set of values, e.g.
         $(D if (v.among(1, 2, 3)) // `v` is 1, 2 or 3))

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 cache,
         Eagerly evaluates and caches another range's $(D front).)
 $(T2 cacheBidirectional,

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 bringToFront,
         If $(D a = [1, 2, 3]) and $(D b = [4, 5, 6, 7]),
         $(D bringToFront(a, b)) leaves $(D a = [4, 5, 6]) and

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 all,
         $(D all!"a > 0"([1, 2, 3, 4])) returns $(D true) because all elements
         are positive)

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 cartesianProduct,
         Computes Cartesian product of two ranges.)
 $(T2 largestPartialIntersection,

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -4,9 +4,7 @@ This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.
 
 $(BOOKTABLE Cheat Sheet,
-
 $(TR $(TH Function Name) $(TH Description))
-
 $(T2 completeSort,
         If $(D a = [10, 20, 30]) and $(D b = [40, 6, 15]), then
         $(D completeSort(a, b)) leaves $(D a = [6, 10, 15]) and $(D b = [20,


### PR DESCRIPTION
As I use the Phobos docs recently I am quite annoyed by the whitespace ddoc produces - it turns out that one can't have `<br>`'s in table, thus this PR removes them and ... the whitespace is gone :)

https://dlang.org/phobos/std_algorithm.html
https://dlang.org/phobos/std_algorithm_mutation.html