### PR TITLE
Wrong exception message in std.json

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -325,7 +325,7 @@ struct JSONValue
     @property inout(JSONValue[]) arrayNoRef() inout pure @trusted
     {
         enforce!JSONException(type == JSON_TYPE.ARRAY,
-                                "JSONValue is not an object");
+                                "JSONValue is not an array");
         return store.array;
     }
 


### PR DESCRIPTION
```d
    @property inout(JSONValue[]) arrayNoRef() inout pure @trusted
    {
        enforce!JSONException(type == JSON_TYPE.ARRAY,
                                "JSONValue is not an object");
        return store.array;
    }
```

changed to 
```d
enforce!JSONException(type == JSON_TYPE.ARRAY,
                                "JSONValue is not an array");
```
