### PR TITLE
std.math and std.stdio: use more selective imports

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -129,10 +129,9 @@ version (Win64)
         version = Win64_DMD_InlineAsm;
 }
 
-import core.bitop;
-import core.math;
-import core.stdc.math;
-import std.traits;
+static import core.math;
+static import core.stdc.math;
+import std.traits;// CommonType, isFloatingPoint, isIntegral, isSigned, isUnsigned, Largest, Unqual
 
 version(LDC)
 {
@@ -161,7 +160,7 @@ else version(D_InlineAsm_X86_64)
 
 version(unittest)
 {
-    import core.stdc.stdio;
+    import core.stdc.stdio : sprintf;
 
     static if (real.sizeof > double.sizeof)
         enum uint useDigits = 16;
@@ -2558,7 +2557,8 @@ unittest
 
 unittest
 {
-    import std.meta, std.typecons;
+    import std.meta : AliasSeq;
+    import std.typecons : tuple, Tuple;
 
     foreach (T; AliasSeq!(real, double, float))
     {
@@ -2645,6 +2645,7 @@ unittest
 int ilogb(T)(const T x) @trusted pure nothrow @nogc
     if (isFloatingPoint!T)
 {
+    import core.bitop : bsr;
     alias F = floatTraits!T;
 
     union floatBits
@@ -2785,6 +2786,7 @@ int ilogb(T)(const T x) @trusted pure nothrow @nogc
 int ilogb(T)(const T x) @safe pure nothrow @nogc
     if (isIntegral!T && isUnsigned!T)
 {
+    import core.bitop : bsr;
     if (x == 0)
         return FP_ILOGB0;
     else
@@ -2797,6 +2799,7 @@ int ilogb(T)(const T x) @safe pure nothrow @nogc
 int ilogb(T)(const T x) @safe pure nothrow @nogc
     if (isIntegral!T && isSigned!T)
 {
+    import std.traits : Unsigned;
     // Note: abs(x) can not be used because the return type is not Unsigned and
     //       the return value would be wrong for x == int.min
     Unsigned!T absx =  x>=0 ? x : -x;
@@ -2808,7 +2811,8 @@ alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
 
 @trusted nothrow @nogc unittest
 {
-    import std.meta, std.typecons;
+    import std.meta : AliasSeq;
+    import std.typecons : Tuple;
     foreach (F; AliasSeq!(float, double, real))
     {
         alias T = Tuple!(F, int);
@@ -2881,7 +2885,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
 ///
 @nogc @safe pure nothrow unittest
 {
-    import std.meta;
+    import std.meta : AliasSeq;
     foreach (T; AliasSeq!(float, double, real))
     {
         T r;
@@ -4902,7 +4906,7 @@ bool isNaN(X)(X x) @nogc @trusted pure nothrow
 
 @safe pure nothrow @nogc unittest
 {
-    import std.meta;
+    import std.meta : AliasSeq;
 
     foreach (T; AliasSeq!(float, double, real))
     {
@@ -5086,7 +5090,7 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.meta;
+    import std.meta : AliasSeq;
 
     foreach (T; AliasSeq!(float, double, real))
     {
@@ -5326,7 +5330,7 @@ R copysign(R, X)(X to, R from) @trusted pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.meta;
+    import std.meta : AliasSeq;
 
     foreach (X; AliasSeq!(float, double, real, int, long))
     {
@@ -5907,6 +5911,7 @@ real fma(real x, real y, real z) @safe pure nothrow @nogc { return (x * y) + z; 
 Unqual!F pow(F, G)(F x, G n) @nogc @trusted pure nothrow
     if (isFloatingPoint!(F) && isIntegral!(G))
 {
+    import std.traits : Unsigned;
     real p = 1.0, v = void;
     Unsigned!(Unqual!G) m = n;
     if (n < 0)
@@ -6908,7 +6913,7 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
  */
 bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
 {
-    import std.range;
+    import std.range.primitives : empty, front, isInputRange, popFront;
     static if (isInputRange!T)
     {
         static if (isInputRange!U)
@@ -7301,7 +7306,7 @@ unittest
 
 unittest
 {
-    import std.meta;
+    import std.meta : AliasSeq;
     foreach (T; AliasSeq!(float, double, real))
     {
         T[] values = [-cast(T)NaN(20), -cast(T)NaN(10), -T.nan, -T.infinity,


### PR DESCRIPTION
The idea is that once leaking of symbols from module-level selective imports is considered fixed, ie in all downstream code too, and its use is enabled, someone can make the commented out symbols at the top selective and these modules won't have the compiler searching for any symbols afterwards.  These changes were made by hacking ldc to dump all the symbols that it had to search for ([as described previously with dmd](http://forum.dlang.org/thread/pbpckzwmfglzgwqveoza@forum.dlang.org) and [done before for `std.stdio`](https://github.com/dlang/phobos/pull/2809)), and then making them either selective or adding them to the commented out list at the top of the module, if the symbol was needed at module scope.