### PR TITLE
Add std.typecons.Rebindable!struct

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1821,14 +1821,16 @@ if (is(S == struct))
             Unqual!S mutPayload = void;
             S payload;
         }
+        
+    @trusted:
 
-        this(S s) @trusted
+        this(S s)
         {
             // we preserve tail immutable guarantees so mutable union is OK
             payload = s;
         }
 
-        void opAssign(S s) @trusted
+        void opAssign(S s)
         {
             auto rs = Rebindable(s);
             import std.algorithm.mutation : swap;
@@ -1836,14 +1838,14 @@ if (is(S == struct))
         }
 
         static if (!is(S == immutable))
-        ref S Rebindable_getRef() @property @trusted
+        ref S Rebindable_getRef() @property
         {
             // payload exposed as const ref when S is const
             return payload;
         }
 
         static if (is(S == immutable))
-        S Rebindable_get() @property @trusted
+        S Rebindable_get() @property
         {
             // we return a copy so mutable union is OK
             return payload;
@@ -1854,7 +1856,7 @@ if (is(S == struct))
         else
             alias Rebindable_getRef this;
 
-        ~this() @trusted
+        ~this()
         {
             import std.algorithm : move;
             // call destructor with proper constness

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1843,28 +1843,28 @@ if (is(S == struct))
 
         void opAssign(Rebindable other)
         {
-            this = other.getPayload;
+            this = other.trustedPayload;
         }
 
+        // must not escape when S is immutable
         private
-        ref const getPayload() @trusted
+        ref trustedPayload() @trusted
         {
-            // can only cast to const, not immutable
-            return *cast(const Unqual!S*)mutPayload.ptr;
+            return *cast(S*)mutPayload.ptr;
         }
 
         static if (!is(S == immutable))
         ref S Rebindable_getRef() @property
         {
             // payload exposed as const ref when S is const
-            return getPayload;
+            return trustedPayload;
         }
 
         static if (is(S == immutable))
         S Rebindable_get() @property
         {
             // we return a copy for immutable S
-            return getPayload;
+            return trustedPayload;
         }
 
         static if (is(S == immutable))

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1822,15 +1822,17 @@ if (is(S == struct))
             S payload;
         }
 
-        this()(S s) @trusted
+        this(S s) @trusted
         {
             // we preserve tail immutable guarantees so mutable union is OK
             payload = s;
         }
 
-        void opAssign()(S s)
+        void opAssign(S s) @trusted
         {
-            this = Rebindable(s);
+            auto rs = Rebindable(s);
+            import std.algorithm.mutation : swap;
+            swap(mutPayload, rs.mutPayload);
         }
 
         static if (!is(S == immutable))

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1829,15 +1829,27 @@ if (is(S == struct))
         }
 
     public:
-        // TODO: auto ref & for opAssign?
-        this(S s)
+        this()(auto ref S s)
         {
             emplace(s);
         }
 
-        void opAssign(S s)
+        // immutable S cannot be passed to auto ref S above
+        static if (!is(S == immutable))
+        this()(immutable S s)
+        {
+            emplace(s);
+        }
+
+        void opAssign()(auto ref S s)
         {
             movePayload;
+            emplace(s);
+        }
+
+        static if (!is(S == immutable))
+        void opAssign()(immutable S s)
+        {
             emplace(s);
         }
 
@@ -1986,11 +1998,11 @@ unittest
     }
     static assert(!__traits(compiles, Rebindable!ND()));
 
-    Rebindable!(const ND) rb = ND(1);
+    Rebindable!(const ND) rb = const ND(1);
     assert(rb.i == 1);
     rb = immutable ND(2);
     assert(rb.i == 2);
-    rb = rebindable(ND(3));
+    rb = rebindable(const ND(3));
     assert(rb.i == 3);
     static assert(!__traits(compiles, rb.i++));
 }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1821,7 +1821,7 @@ if (is(S == struct))
             Unqual!S mutPayload = void;
             S payload;
         }
-        
+
     @trusted:
 
         this(S s)
@@ -1835,6 +1835,11 @@ if (is(S == struct))
             auto rs = Rebindable(s);
             import std.algorithm.mutation : swap;
             swap(mutPayload, rs.mutPayload);
+        }
+
+        void opAssign(typeof(this) other)
+        {
+            this = other.payload;
         }
 
         static if (!is(S == immutable))
@@ -1918,6 +1923,25 @@ if (is(S == struct))
     ri = si;
     ri = S();
     assert(ri.ptr is null);
+
+    // Test RB!immutable -> RB!const
+    Rebindable!(const S) rc = ri;
+    assert(rc.ptr is null);
+    ri = S(new int);
+    rc = ri;
+    assert(rc.ptr !is null);
+
+    // test rebindable, opAssign
+    rc.destroy;
+    assert(rc.ptr is null);
+    rc = rebindable(cs3);
+    rc = rebindable(si);
+    assert(rc.ptr !is null);
+
+    ri.destroy;
+    assert(ri.ptr is null);
+    ri = rebindable(si);
+    assert(ri.ptr !is null);
 }
 
 // Test Rebindable!mutable

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1666,11 +1666,11 @@ Convenience function for creating a $(D Rebindable) using automatic type
 inference.
 
 Params:
-    obj = A reference to an object, interface, associative array, or an array slice
-          to initialize the `Rebindable` with.
+    obj = A reference to an object, interface, associative array, or an array slice.
+    s = Struct instance.
 
 Returns:
-    A newly constructed `Rebindable` initialized with the given reference.
+    A newly constructed `Rebindable` initialized with the given data.
 */
 Rebindable!T rebindable(T)(T obj)
     if (is(T == class) || is(T == interface) || isDynamicArray!T || isAssociativeArray!T)
@@ -1678,6 +1678,17 @@ Rebindable!T rebindable(T)(T obj)
     typeof(return) ret;
     ret = obj;
     return ret;
+}
+
+/// ditto
+Rebindable!S rebindable(S)(S s)
+if (is(S == struct) && !isInstanceOf!(Rebindable, S))
+{
+    // workaround for rebindableS = rebindable(s)
+    static if (isMutable!S)
+        return s;
+    else
+        return Rebindable!S(s);
 }
 
 /**
@@ -1786,6 +1797,155 @@ unittest
     assert(pr3341[321] == 543);
     assert(rebindable(pr3341_aa)[321] == 543);
 }
+
+/** Models safe reassignment of otherwise constant struct instances.
+ *
+ * A struct with a field of reference type cannot be assigned to a constant
+ * struct of the same type. `Rebindable!(const S)` allows assignment to
+ * a `const S` while enforcing only constant access to its fields.
+ *
+ * `Rebindable!(immutable S)` does the same but field access may create a
+ * temporary copy of `S` in order to enforce _true immutability.
+ */
+template Rebindable(S)
+if (is(S == struct))
+{
+    static if (isMutable!S)
+        alias Rebindable = S;
+    else
+    struct Rebindable
+    {
+        // fields of payload must be treated as tail const (unless S is mutable)
+        private Unqual!S payload;
+
+        this()(S s) @trusted
+        {
+            // we preserve tail immutable guarantees so cast is OK
+            payload = cast(Unqual!S)s;
+        }
+
+        void opAssign()(S s)
+        {
+            this = Rebindable(s);
+        }
+
+        static if (!is(S == immutable))
+        ref S Rebindable_getRef() @property
+        {
+            // payload exposed as const ref when S is const
+            return payload;
+        }
+
+        static if (is(S == immutable))
+        S Rebindable_get() @property @trusted
+        {
+            // we return a copy so cast to immutable is OK
+            return cast(S)payload;
+        }
+
+        static if (is(S == immutable))
+            alias Rebindable_get this;
+        else
+            alias Rebindable_getRef this;
+
+        ~this() @trusted
+        {
+            import std.algorithm : move;
+            // call destructor with proper constness
+            S s = cast(S)move(payload);
+        }
+    }
+}
+
+///
+@safe unittest
+{
+    static struct S
+    {
+        int* ptr;
+    }
+    S s = S(new int);
+
+    const cs = s;
+    // Can't assign s.ptr to cs.ptr
+    static assert(!__traits(compiles, {s = cs;}));
+
+    Rebindable!(const S) rs = s;
+    assert(rs.ptr is s.ptr);
+    // rs.ptr is const
+    static assert(!__traits(compiles, {rs.ptr = null;}));
+
+    // Can't assign s.ptr to rs.ptr
+    static assert(!__traits(compiles, {s = rs;}));
+
+    const S cs2 = rs;
+    // Rebind rs
+    rs = cs2;
+    rs = S();
+    assert(rs.ptr is null);
+}
+
+// Test Rebindable!immutable
+@safe unittest
+{
+    static struct S
+    {
+        int* ptr;
+    }
+    S s = S(new int);
+
+    Rebindable!(immutable S) ri = S(new int);
+    assert(ri.ptr !is null);
+    static assert(!__traits(compiles, {ri.ptr = null;}));
+
+    // ri is not compatible with mutable S
+    static assert(!__traits(compiles, {s = ri;}));
+    static assert(!__traits(compiles, {ri = s;}));
+
+    const S cs3 = ri;
+    static assert(!__traits(compiles, {ri = cs3;}));
+
+    immutable S si = ri;
+    // Rebind ri
+    ri = si;
+    ri = S();
+    assert(ri.ptr is null);
+}
+
+// Test Rebindable!mutable
+@safe unittest
+{
+    static struct S
+    {
+        int* ptr;
+    }
+    S s;
+
+    Rebindable!S rs = s;
+    static assert(is(typeof(rs) == S));
+    rs = rebindable(S());
+}
+
+// Test disabled default ctor
+unittest
+{
+    static struct ND
+    {
+        int i;
+        @disable this();
+        this(int i) inout {this.i = i;}
+    }
+    static assert(!__traits(compiles, Rebindable!ND()));
+
+    Rebindable!(const ND) rb = ND(1);
+    assert(rb.i == 1);
+    rb = immutable ND(2);
+    assert(rb.i == 2);
+    rb = rebindable(ND(3));
+    assert(rb.i == 3);
+    static assert(!__traits(compiles, rb.i++));
+}
+
 
 /**
     Similar to $(D Rebindable!(T)) but strips all qualifiers from the reference as

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1828,30 +1828,42 @@ if (is(S == struct))
             payload = s;
         }
 
-        void opAssign(S s) @trusted
+        private
+        void swapPayloads(ref Rebindable rs) @trusted
         {
-            auto rs = Rebindable(s);
             import std.algorithm.mutation : swap;
             swap(mutPayload, rs.mutPayload);
         }
 
-        void opAssign(typeof(this) other) @trusted
+        void opAssign(S s)
         {
-            this = other.payload;
+            auto rs = Rebindable(s);
+            swapPayloads(rs);
+        }
+
+        private
+        ref getPayload() @trusted
+        {
+            return payload;
+        }
+
+        void opAssign(typeof(this) other)
+        {
+            this = other.getPayload;
         }
 
         static if (!is(S == immutable))
-        ref S Rebindable_getRef() @property @trusted
+        ref S Rebindable_getRef() @property
         {
             // payload exposed as const ref when S is const
-            return payload;
+            return getPayload;
         }
 
         static if (is(S == immutable))
-        S Rebindable_get() @property @trusted
+        S Rebindable_get() @property
         {
             // we return a copy so mutable union is OK
-            return payload;
+            return getPayload;
         }
 
         static if (is(S == immutable))

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1945,6 +1945,9 @@ if (is(S == struct))
     static assert(!__traits(compiles, {s = ri;}));
     static assert(!__traits(compiles, {ri = s;}));
 
+    auto ri2 = ri;
+    assert(ri2.ptr == ri.ptr);
+
     const S cs3 = ri;
     static assert(!__traits(compiles, {ri = cs3;}));
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1850,6 +1850,7 @@ if (is(S == struct))
         static if (!is(S == immutable))
         void opAssign()(immutable S s)
         {
+            movePayload;
             emplace(s);
         }
 
@@ -1894,7 +1895,7 @@ if (is(S == struct))
         ~this()
         {
             // call destructor with proper constness
-            S s = movePayload;
+            movePayload;
         }
     }
 }


### PR DESCRIPTION
From the docs:

"Models safe reassignment of otherwise constant struct instances.

A struct with a field of reference type cannot be assigned to a constant struct of the same type. `Rebindable!(const S)` allows assignment to a `const S` while enforcing only constant access to its fields.

`Rebindable!(immutable S)` does the same but field access may create a temporary copy of `S` in order to enforce true immutability."
