### PR TITLE
Have travis enforce Allman brace style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ script:
  - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
  # enforce whitespace between statements
  - grep -E "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
+ # enforce Allman brace style
+ - grep -E "(\)|unittest) {" $(find . -name '*.d'); test $? -eq 1
  # at the moment libdparse has problems to parse some modules (->excludes)
  - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.


### PR DESCRIPTION
I could use a little regex help with this one.

The given regex gives false positives for things like

```
xml.onEndTag["description"]  = (in Element e) { book.description = e.text(); };
```

which are legal. I have the following regex to detect this case

```
\{ ([[:print:]][^}])* \}
```

The problem is I don't know how to grep for all matches of the first regex but that don't also match the second pattern.