### PR TITLE
remove the deprecated wiki macros

### DIFF
--- a/index.d
+++ b/index.d
@@ -527,6 +527,5 @@ $(COMMENT
 
 Macros:
         TITLE=Phobos Runtime Library
-        WIKI=Phobos
         DDOC_BLANKLINE=
         _=

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -169,7 +169,6 @@ sort(a);                   // no predicate, "a < b" is implicit
 ----
 
 Macros:
-WIKI = Phobos/StdAlgorithm
 SUBMODULE = $(MREF std, algorithm, $1)
 SUBREF = $(LINK2 std_algorithm_$1.html#.$2, $(TT $2))$(NBSP)
 

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -15,9 +15,6 @@
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),
         $(WEB en.wikipedia.org/wiki/Ascii, Wikipedia)
 
-    Macros:
-        WIKI=Phobos/StdASCII
-
     Copyright: Copyright 2000 - 2013
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3,10 +3,6 @@
 /**
 Bit-level manipulation facilities.
 
-Macros:
-
-WIKI = StdBitarray
-
 Copyright: Copyright Digital Mars 2007 - 2011.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/c/fenv.d
+++ b/std/c/fenv.d
@@ -7,8 +7,6 @@
  * C's &lt;fenv.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCFenv
  */
 deprecated("Import core.stdc.fenv instead")
 module std.c.fenv;

--- a/std/c/locale.d
+++ b/std/c/locale.d
@@ -8,8 +8,6 @@
  * License: Public Domain
  * Standards:
  *      ISO/IEC 9899:1999 7.11
- * Macros:
- *      WIKI=Phobos/StdCLocale
  */
 deprecated("Import core.stdc.locale instead")
 module std.c.locale;

--- a/std/c/math.d
+++ b/std/c/math.d
@@ -7,8 +7,6 @@
  * C's &lt;math.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCMath
  */
 deprecated("Import core.stdc.math instead")
 module std.c.math;

--- a/std/c/process.d
+++ b/std/c/process.d
@@ -8,8 +8,6 @@
  * C's &lt;process.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCProcess
  */
 deprecated("Import core.stdc.stdlib or the appropriate core.sys.posix.* modules instead")
 module std.c.process;

--- a/std/c/stdarg.d
+++ b/std/c/stdarg.d
@@ -7,8 +7,6 @@
  * C's &lt;stdarg.h&gt;
  * Authors: Hauke Duden and Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCStdarg
  */
 deprecated("Import core.stdc.stdarg instead")
 module std.c.stdarg;

--- a/std/c/stddef.d
+++ b/std/c/stddef.d
@@ -7,8 +7,6 @@
  * C's &lt;stddef.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCStddef
  */
 deprecated("Import core.stdc.stddef instead")
 module std.c.stddef;

--- a/std/c/stdio.d
+++ b/std/c/stdio.d
@@ -7,8 +7,6 @@
  * C's &lt;stdio.h&gt; for the D programming language
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCStdio
  */
 deprecated("Import core.stdc.stdio instead")
 module std.c.stdio;

--- a/std/c/stdlib.d
+++ b/std/c/stdlib.d
@@ -8,8 +8,6 @@
  * D Programming Language runtime library
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCStdlib
  */
 deprecated("Import core.stdc.stdlib or core.sys.posix.stdlib instead")
 module std.c.stdlib;

--- a/std/c/string.d
+++ b/std/c/string.d
@@ -7,8 +7,6 @@
  * C's &lt;string.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCString
  */
 deprecated("Import core.stdc.string instead")
 module std.c.string;

--- a/std/c/time.d
+++ b/std/c/time.d
@@ -7,8 +7,6 @@
  * C's &lt;time.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCTime
  */
 deprecated("Import core.stdc.time instead")
 module std.c.time;

--- a/std/c/wcharh.d
+++ b/std/c/wcharh.d
@@ -7,8 +7,6 @@
  * C's &lt;wchar.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
- * Macros:
- *      WIKI=Phobos/StdCWchar
  */
 deprecated("Import core.stdc.wchar_ instead")
 module std.c.wcharh;

--- a/std/compiler.d
+++ b/std/compiler.d
@@ -3,9 +3,6 @@
 /**
  * Identify the compiler used and its various features.
  *
- * Macros:
- *      WIKI = Phobos/StdCompiler
- *
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright), Alex Rønne Petersen

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -5,8 +5,6 @@ reliant on the GC, as an alternative to the built-in arrays.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_array.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -5,7 +5,6 @@ reliant on the GC, as an alternative to the built-in arrays.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_array.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -5,7 +5,6 @@ adaptor that makes a binary heap out of any user-provided random-access range.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -5,8 +5,6 @@ adaptor that makes a binary heap out of any user-provided random-access range.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -5,8 +5,6 @@ It can be used as a queue, dequeue or stack.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_dlist.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -5,7 +5,6 @@ It can be used as a queue, dequeue or stack.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_dlist.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -401,8 +401,6 @@ $(TR  $(TDNW $(D )) $(TDNW $(D )) $(TD ))
 )
 
 Source: $(PHOBOSSRC std/_container/package.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -401,7 +401,6 @@ $(TR  $(TDNW $(D )) $(TDNW $(D )) $(TD ))
 )
 
 Source: $(PHOBOSSRC std/_container/package.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -4,8 +4,6 @@ This module implements a red-black tree container.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_rbtree.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -4,7 +4,6 @@ This module implements a red-black tree container.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_rbtree.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -5,8 +5,6 @@ It can be used as a stack.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_slist.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -5,7 +5,6 @@ It can be used as a stack.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_slist.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -4,7 +4,6 @@ This module contains some common utilities used by containers.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_util.d)
-TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -4,8 +4,6 @@ This module contains some common utilities used by containers.
 This module is a submodule of $(MREF std, container).
 
 Source: $(PHOBOSSRC std/container/_util.d)
-Macros:
-WIKI = Phobos/StdContainer
 TEXTWITHCOMMAS = $0
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/conv.d
+++ b/std/conv.d
@@ -15,9 +15,6 @@ Authors:   $(WEB digitalmars.com, Walter Bright),
 
 Source:    $(PHOBOSSRC std/_conv.d)
 
-Macros:
-WIKI = Phobos/StdConv
-
 */
 module std.conv;
 

--- a/std/cstream.d
+++ b/std/cstream.d
@@ -7,9 +7,6 @@
  * The std.cstream module bridges core.stdc.stdio (or std.stdio) and std.stream.
  * Both core.stdc.stdio and std.stream are publicly imported by std.cstream.
  *
- * Macros:
- *      WIKI=Phobos/StdCstream
- *
  * Copyright: Copyright Ben Hinkle 2007 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Ben Hinkle

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -3,9 +3,6 @@
 /**
  * Demangle D mangled names.
  *
- * Macros:
- *  WIKI = Phobos/StdDemangle
- *
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -40,9 +40,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of))
  *
  * Source: $(PHOBOSSRC std/digest/_crc.d)
  *
- * Macros:
- * WIKI = Phobos/StdUtilDigestCRC32
- *
  * Standards:
  * Implements the 'common' IEEE CRC32 variant
  * (LSB-first order, Initial value uint.max, complement result)

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -38,8 +38,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
  *
  * Source: $(PHOBOSSRC std/digest/_md.d)
  *
- * Macros:
- * WIKI = Phobos/StdMd5
  */
 
 /* md5.d - RSA Data Security, Inc., MD5 message-digest algorithm

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -42,8 +42,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
  *
  * Source: $(PHOBOSSRC std/digest/_ripemd.d)
  *
- * Macros:
- * WIKI = Phobos/StdRipemd
  */
 
 module std.digest.ripemd;

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -48,8 +48,6 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  *
  * Source: $(PHOBOSSRC std/digest/_sha.d)
  *
- * Macros:
- *      WIKI = Phobos/StdSha1
  */
 
 /*          Copyright Kai Nacke 2012.

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -39,9 +39,6 @@ UTF-32LE; or (on big-endian architectures) UTF-16BE and UTF-32BE.
 This library provides a mechanism whereby other modules may add $(D
 EncodingScheme) subclasses for any other _encoding.
 
-Macros:
-    WIKI=Phobos/StdEncoding
-
 Copyright: Copyright Janice Caron 2008 - 2009.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron

--- a/std/exception.d
+++ b/std/exception.d
@@ -33,9 +33,6 @@
     }
     --------------------
 
-    Macros:
-        WIKI = Phobos/StdException
-
     Copyright: Copyright Andrei Alexandrescu 2008-, Jonathan M Davis 2011-.
     License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Authors:   $(WEB erdani.org, Andrei Alexandrescu) and Jonathan M Davis

--- a/std/file.d
+++ b/std/file.d
@@ -6,9 +6,6 @@ in this module handle files as a unit, e.g., read or write one _file
 at a time. For opening files and manipulating them via handles refer
 to module $(MREF std, stdio).
 
-Macros:
-WIKI = Phobos/StdFile
-
 Copyright: Copyright Digital Mars 2007 - 2011.
 See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
 introduction to working with files in D, module

--- a/std/format.d
+++ b/std/format.d
@@ -44,9 +44,6 @@ $(TR $(TH Function Name) $(TH Description)
 
    The functions $(D $(LREF formatValue)) and $(D $(LREF unformatValue)) are
    used for the plumbing.
-
-   Macros: WIKI = Phobos/StdFormat
-
    Copyright: Copyright Digital Mars 2000-2013.
 
    License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/functional.d
+++ b/std/functional.d
@@ -47,10 +47,6 @@ $(TR $(TH Function Name) $(TH Description)
     ))
 )
 
-Macros:
-
-WIKI = Phobos/StdFunctional
-
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB erdani.org, Andrei Alexandrescu)

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -10,10 +10,6 @@ supported in the form of long options introduced by a double dash
 with the more traditional single-letter approach, is provided but not
 enabled by default.
 
-Macros:
-
-WIKI = Phobos/StdGetopt
-
 Copyright: Copyright Andrei Alexandrescu 2008 - 2015.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB erdani.org, Andrei Alexandrescu)

--- a/std/math.d
+++ b/std/math.d
@@ -79,8 +79,6 @@ $(TR $(TDNW Hardware Control) $(TD
  * The semantics and names of feqrel and approxEqual will be revised.
  *
  * Macros:
- *      WIKI = Phobos/StdMath
- *
  *      TABLE_SV = <table border="1" cellpadding="4" cellspacing="0">
  *              <caption>Special Values</caption>
  *              $0</table>

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -20,8 +20,6 @@
  *  is not yet finalized and will probably change.
  *
  * Macros:
- *      WIKI = Phobos/StdMathSpecial
- *
  *      TABLE_SV = <table border="1" cellpadding="4" cellspacing="0">
  *              <caption>Special Values</caption>
  *              $0</table>

--- a/std/meta.d
+++ b/std/meta.d
@@ -17,9 +17,6 @@
  *  $(LINK2 http://amazon.com/exec/obidos/ASIN/0201704315/ref=ase_classicempire/102-2957199-2585768,
  *      Modern C++ Design),
  *   Andrei Alexandrescu (Addison-Wesley Professional, 2001)
- * Macros:
- *  WIKI = Phobos/StdMeta
- *
  * Copyright: Copyright Digital Mars 2005 - 2015.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -2,9 +2,6 @@
 
 /**
  * Read and write memory mapped files.
- * Macros:
- *  WIKI=Phobos/StdMmfile
- *
  * Copyright: Copyright Digital Mars 2004 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -6,9 +6,6 @@ header in Alexander Stepanov's $(LINK2 http://sgi.com/tech/stl,
 Standard Template Library), with a few additions.
 
 Macros:
-
-WIKI = Phobos/StdNumeric
-
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB erdani.org, Andrei Alexandrescu),

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -3,9 +3,6 @@
 /**
 Serialize data to $(D ubyte) arrays.
 
- * Macros:
- *      WIKI = Phobos/StdOutbuffer
- *
  * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)

--- a/std/path.d
+++ b/std/path.d
@@ -48,8 +48,6 @@
         $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:
         $(PHOBOSSRC std/_path.d)
-    Macros:
-        WIKI = Phobos/StdPath
 */
 module std.path;
 

--- a/std/process.d
+++ b/std/process.d
@@ -80,7 +80,6 @@ License:
 Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
-    WIKI=Phobos/StdProcess
     OBJECTREF=$(D $(LINK2 object.html#$0,$0))
     LREF=$(D $(LINK2 #.$0,$0))
 */
@@ -3243,10 +3242,6 @@ unittest
 
 
 /*
-Macros:
-
-WIKI=Phobos/StdProcess
-
 Copyright: Copyright Digital Mars 2007 - 2009.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/random.d
+++ b/std/random.d
@@ -39,9 +39,6 @@ Source:    $(PHOBOSSRC std/_random.d)
 
 Macros:
 
-WIKI = Phobos/StdRandom
-
-
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009, Joseph Rushton Wakeling 2012.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB erdani.org, Andrei Alexandrescu)

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -54,10 +54,6 @@ $(BOOKTABLE ,
 
 Source: $(PHOBOSSRC std/range/_interfaces.d)
 
-Macros:
-
-WIKI = Phobos/StdRange
-
 Copyright: Copyright by authors 2008-.
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -175,10 +175,6 @@ _range operations that take advantage of the fact that the _range is sorted.
 
 Source: $(PHOBOSSRC std/_range/_package.d)
 
-Macros:
-
-WIKI = Phobos/StdRange
-
 Copyright: Copyright by authors 2008-.
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -101,10 +101,6 @@ $(BOOKTABLE ,
 
 Source: $(PHOBOSSRC std/range/_primitives.d)
 
-Macros:
-
-WIKI = Phobos/StdRange
-
 Copyright: Copyright by authors 2008-.
 
 License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/signals.d
+++ b/std/signals.d
@@ -46,7 +46,6 @@
  *      Not safe for multiple threads operating on the same signals
  *      or slots.
  * Macros:
- *      WIKI = Phobos/StdSignals
  *      SIGNALS=signals
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.

--- a/std/socket.d
+++ b/std/socket.d
@@ -40,8 +40,6 @@
  * Authors: Christopher E. Miller, $(WEB klickverbot.at, David Nadlinger),
  *      $(WEB thecybershadow.net, Vladimir Panteleev)
  * Source:  $(PHOBOSSRC std/_socket.d)
- * Macros:
- *      WIKI=Phobos/StdSocket
  */
 
 module std.socket;

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -33,7 +33,6 @@
  * References:
  *      $(MREF std, stream)
  * Source:    $(PHOBOSSRC std/_socketstream.d)
- * Macros: WIKI=Phobos/StdSocketstream
  */
 deprecated("It will be removed from Phobos in October 2016. If you still need it, go to https://github.com/DigitalMars/undeaD") module std.socketstream;
 // @@@DEPRECATED_2016-10@@@

--- a/std/stdint.d
+++ b/std/stdint.d
@@ -113,7 +113,6 @@
     ))
 
  * Macros:
- *  WIKI=Phobos/StdStdint
  *  ATABLE=<table border="1" cellspacing="0" cellpadding="5">$0</table>
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5,9 +5,6 @@ Standard I/O functions that extend $(B core.stdc.stdio).  $(B core.stdc.stdio)
 is $(D_PARAM public)ally imported when importing $(B std.stdio).
 
 Source: $(PHOBOSSRC std/_stdio.d)
-Macros:
-WIKI=Phobos/StdStdio
-
 Copyright: Copyright Digital Mars 2007-.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/stream.d
+++ b/std/stream.d
@@ -5,8 +5,6 @@
  *       current standards. It will be remove in October 2016.)
  *
  * Source:    $(PHOBOSSRC std/_stream.d)
- * Macros:
- *      WIKI = Phobos/StdStream
  */
 
 /*

--- a/std/string.d
+++ b/std/string.d
@@ -134,7 +134,7 @@ See_Also:
     for functions that work with unicode strings
     )
 
-Macros: WIKI = Phobos/StdString
+Macros:
         SHORTXREF=$(XREF2 $1, $2, $(TT $2))
         SHORTXREF_PACK=$(XREF_PACK_NAMED $1,$2,$3, $(TT $3))
 

--- a/std/system.d
+++ b/std/system.d
@@ -3,9 +3,6 @@
 /**
  * Information about the target operating system, environment, and CPU.
  *
- * Macros:
- *      WIKI = Phobos/StdSystem
- *
  *  Copyright: Copyright Digital Mars 2000 - 2011
  *  License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *  Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis

--- a/std/traits.d
+++ b/std/traits.d
@@ -136,9 +136,6 @@
  * )
  * )
  *
- * Macros:
- *  WIKI = Phobos/StdTraits
- *
  * Copyright: Copyright Digital Mars 2005 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright),

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6,10 +6,6 @@ that allow construction of new, useful general-purpose types.
 
 Source:    $(PHOBOSSRC std/_typecons.d)
 
-Macros:
-
-WIKI = Phobos/StdVariant
-
 Synopsis:
 
 ----

--- a/std/uni.d
+++ b/std/uni.d
@@ -597,9 +597,6 @@
     Trademarks:
         Unicode(tm) is a trademark of Unicode, Inc.
 
-    Macros:
-        WIKI=Phobos/StdUni
-
     Copyright: Copyright 2013 -
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Dmitry Olshansky

--- a/std/uri.d
+++ b/std/uri.d
@@ -11,9 +11,6 @@
  * See_Also:
  *  $(LINK2 http://www.ietf.org/rfc/rfc3986.txt, RFC 3986)<br>
  *  $(LINK2 http://en.wikipedia.org/wiki/Uniform_resource_identifier, Wikipedia)
- * Macros:
- *  WIKI = Phobos/StdUri
- *
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)

--- a/std/utf.d
+++ b/std/utf.d
@@ -10,9 +10,6 @@
         $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
         $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>
         $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
-    Macros:
-        WIKI = Phobos/StdUtf
-
     Copyright: Copyright Digital Mars 2000 - 2012.
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis

--- a/std/variant.d
+++ b/std/variant.d
@@ -10,9 +10,6 @@ Such types are useful
 for type-uniform binary interfaces, interfacing with scripting
 languages, and comfortable exploratory programming.
 
-Macros:
- WIKI = Phobos/StdVariant
-
 Synopsis:
 ----
 Variant a; // Must assign before use, otherwise exception ensues

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -3,9 +3,6 @@
 /**
  * Support UTF-8 on Windows 95, 98 and ME systems.
  *
- * Macros:
- *      WIKI = Phobos/StdWindowsCharset
- *
  * Copyright: Copyright Digital Mars 2005 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)

--- a/std/xml.d
+++ b/std/xml.d
@@ -112,9 +112,6 @@ void main()
     writefln(join(doc.pretty(3),"\n"));
 }
 -------------------------------------------------------------------------------
-Macros:
-    WIKI=Phobos/StdXml
-
 Copyright: Copyright Janice Caron 2008 - 2009.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron

--- a/std/zip.d
+++ b/std/zip.d
@@ -14,9 +14,6 @@
  *      $(LI $(BUGZILLA 2137))
  *      )
  *
- * Macros:
- *      WIKI = Phobos/StdZip
- *
  * Example:
  * ---
 // Read existing zip file.

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -43,9 +43,6 @@
  * References:
  *  $(WEB en.wikipedia.org/wiki/Zlib, Wikipedia)
  *
- * Macros:
- *  WIKI = Phobos/StdZlib
- *
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)


### PR DESCRIPTION
WIKI is no longer used

> These tags are back from the days when the official D wiki was http://www.prowiki.org/wiki4d/wiki.cgi.

https://github.com/dlang/dlang.org/pull/1310

For interested: produced by this ugly perl expression

```
for file in **/*.d ; do perl -ne 'push @x, $_;                                                                                           6:25
          if (@x > 2) {
              if ($x[1] =~ /WIKI/) { if ($x[2] =~ /[a-zA-Z\/]/ ) {print $x[2] } undef @x}
                  else { print shift @x }
          }
          } END { print @x' $file > tmp.d && mv tmp.d $file; done
```

(and a manual correction for index.d and std/socketstream.d)