### PR TITLE
Remove spurious deprecation lookup warning

### DIFF
--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -17,8 +17,7 @@ for $(D Bucketizer). To handle them separately, $(D Segregator) may be of use.
 struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
 {
     import std.traits : hasMember;
-    import common = std.experimental.allocator.common : roundUpToMultipleOf,
-        reallocate;
+    import common = std.experimental.allocator.common : roundUpToMultipleOf;
     import std.typecons : Ternary;
 
     static assert((max - (min - 1)) % step == 0,


### PR DESCRIPTION
With the latest compiler, running unittests yields:

```
std/experimental/allocator/building_blocks/segregator.d(188): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 1LU, 128LU, 16LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
std/experimental/allocator/building_blocks/segregator.d(182): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 129LU, 256LU, 32LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
std/experimental/allocator/building_blocks/segregator.d(188): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 257LU, 512LU, 64LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
std/experimental/allocator/building_blocks/segregator.d(182): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 513LU, 1024LU, 128LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
std/experimental/allocator/building_blocks/segregator.d(188): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 1025LU, 2048LU, 256LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
std/experimental/allocator/building_blocks/segregator.d(182): Deprecation: std.experimental.allocator.building_blocks.bucketizer.Bucketizer!(FreeList!(GCAllocator, 0LU, 18446744073709551615LU, cast(Flag)false), 2049LU, 3584LU, 512LU).Bucketizer.reallocate is not visible from module std.experimental.allocator.building_blocks.segregator
```

These in all likelihood indicate a bug in the lookup/deprecation that should be looked at, so I filed https://issues.dlang.org/show_bug.cgi?id=16085.