### PR TITLE
Change semantics of expand: the null array cannot be expanded 'in place'

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -145,11 +145,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         static if (!stateSize!Suffix && hasMember!(Allocator, "expand"))
         bool expand(ref void[] b, size_t delta)
         {
-            if (!b.ptr)
-            {
-                b = allocate(delta);
-                return b.length == delta;
-            }
+            if (!b.ptr) return delta == 0;
             auto t = actualAllocation(b);
             const result = parent.expand(t, delta);
             if (!result) return false;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -379,11 +379,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         && hasMember!(Allocator, "owns"))
     bool expand(ref void[] b, size_t delta)
     {
-        if (!b.ptr)
-        {
-            b = allocate(delta);
-            return b.length == delta;
-        }
+        if (!b.ptr) return delta == 0;
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
         {
             if (n.owns(b) == Ternary.yes) return n.expand(b, delta);

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -493,11 +493,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     {
         // Dispose with trivial corner cases
         if (delta == 0) return true;
-        if (b is null)
-        {
-            b = allocate(delta);
-            return b !is null;
-        }
+        if (b is null) return false;
 
         /* To simplify matters, refuse to expand buffers that don't start at a block start (this may be the case for blocks allocated with alignedAllocate).
         */
@@ -966,11 +962,7 @@ struct BitmappedBlockWithInternalPointers(
     bool expand(ref void[] b, size_t bytes)
     {
         if (!bytes) return true;
-        if (b is null)
-        {
-            b = allocate(bytes);
-            return b !is null;
-        }
+        if (b is null) return false;
         immutable oldBlocks =
             (b.length + _heap.blockSize - 1) / _heap.blockSize;
         assert(oldBlocks);

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -92,11 +92,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     */
     bool expand(ref void[] b, size_t delta)
     {
-        if (!b.ptr)
-        {
-            b = allocate(delta);
-            return b.length == delta;
-        }
+        if (!b.ptr) return delta == 0;
         assert(b.length >= min && b.length <= max);
         const available = goodAllocSize(b.length);
         const desired = b.length + delta;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -95,11 +95,7 @@ struct FallbackAllocator(Primary, Fallback)
     bool expand(ref void[] b, size_t delta)
     {
         if (!delta) return true;
-        if (!b.ptr)
-        {
-            b = allocate(delta);
-            return b.length == delta;
-        }
+        if (!b.ptr) return false;
         if (primary.owns(b) == Ternary.yes)
         {
             static if (hasMember!(Primary, "expand"))

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -29,8 +29,8 @@ struct NullAllocator
     Precondition: $(D b is null). This is because there is no other possible
     legitimate input.
     */
-    bool expand(ref void[] b, size_t) shared
-    { assert(b is null); return false; }
+    bool expand(ref void[] b, size_t s) shared
+    { assert(b is null); return s == 0; }
     /// Ditto
     bool reallocate(ref void[] b, size_t) shared
     { assert(b is null); return false; }

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -70,8 +70,8 @@ reallocated or deallocated with the usual primitives, if defined).))
 
 $(TR $(TDC bool expand(ref void[] b, size_t delta);, $(POST !$(RES) || b.length
 == $(I old)(b).length + delta)) $(TD Expands $(D b) by $(D delta) bytes. If $(D
-delta == 0), succeeds without changing $(D b). If $(D b is null), the call
-evaluates $(D b = allocate(delta)) and returns $(D b !is null). Otherwise, $(D
+delta == 0), succeeds without changing $(D b). If $(D b is null), returns
+`false` (the null pointer cannot be expanded in place). Otherwise, $(D
 b) must be a buffer previously allocated with the same allocator. If expansion
 was successful, $(D expand) changes $(D b)'s length to $(D b.length + delta) and
 returns $(D true). Upon failure, the call effects no change upon the allocator

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -98,11 +98,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     */
     bool expand(ref void[] b, size_t delta)
     {
-        if (!b.ptr)
-        {
-            b = allocate(delta);
-            return b.length == delta;
-        }
+        if (!b.ptr) return delta == 0;
         immutable allocated = goodAllocSize(b.length),
             needed = b.length + delta,
             neededAllocation = goodAllocSize(needed);

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -217,11 +217,7 @@ struct Region(ParentAllocator = NullAllocator,
     {
         assert(owns(b) == Ternary.yes || b.ptr is null);
         assert(b.ptr + b.length <= _current || b.ptr is null);
-        if (!b.ptr)
-        {
-            b = allocate(delta);
-            return b.length == delta;
-        }
+        if (!b.ptr) return delta == 0;
         auto newLength = b.length + delta;
         if (_current < b.ptr + b.length + alignment)
         {
@@ -691,7 +687,7 @@ version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
     */
     bool expand(ref void[] b, size_t delta) shared
     {
-        if (b is null) return (b = allocate(delta)) !is null;
+        if (b is null) return delta == 0;
         assert(_brkInitial && _brkCurrent); // otherwise where did b come from?
         pthread_mutex_lock(cast(pthread_mutex_t*) &sbrkMutex) == 0 || assert(0);
         scope(exit) pthread_mutex_unlock(cast(pthread_mutex_t*) &sbrkMutex) == 0

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -150,6 +150,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
                 || hasMember!(LargeAllocator, "expand"))
         bool expand(ref void[] b, size_t delta)
         {
+            if (!delta) return true;
             if (b.length + delta <= threshold)
             {
                 // Old and new allocations handled by _small

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -649,8 +649,8 @@ package void testAllocator(alias make)()
         void[] b5 = null;
         assert(aa.expand(b5, 0));
         assert(b5 is null);
-        assert(aa.expand(b5, 1));
-        assert(b5.length == 1);
+        assert(!aa.expand(b5, 1));
+        assert(b5.length == 0);
     }}
 
     void[] b6 = null;

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -31,11 +31,7 @@ struct GCAllocator
     @system bool expand(ref void[] b, size_t delta) shared
     {
         if (delta == 0) return true;
-        if (b is null)
-        {
-            b = allocate(delta);
-            return b.ptr != null; // we assume allocate will achieve the correct size.
-        }
+        if (b is null) return false;
         immutable curLength = GC.sizeOf(b.ptr);
         assert(curLength != 0); // we have a valid GC pointer here
         immutable desired = b.length + delta;

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -899,6 +899,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
         size_t delta)
 {
     if (!delta) return true;
+    if (array is null) return false;
     immutable oldLength = array.length;
     void[] buf = array;
     if (!alloc.reallocate(buf, buf.length + T.sizeof * delta)) return false;
@@ -925,6 +926,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
     size_t delta, auto ref T init)
 {
     if (!delta) return true;
+    if (array is null) return false;
     void[] buf = array;
     if (!alloc.reallocate(buf, buf.length + T.sizeof * delta)) return false;
     immutable oldLength = array.length;
@@ -953,6 +955,7 @@ bool expandArray(T, Allocator, R)(auto ref Allocator alloc, ref T[] array,
         R range)
 if (isInputRange!R)
 {
+    if (array is null) return false;
     static if (isForwardRange!R)
     {
         immutable delta = walkLength(range.save);
@@ -1396,7 +1399,7 @@ class CAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
         static if (hasMember!(Allocator, "expand"))
             return impl.expand(b, s);
         else
-            return false;
+            return s == 0;
     }
 
     /// Returns $(D impl.reallocate(b, s)).


### PR DESCRIPTION
I had what now seems to be a wrong design: if `expand` is called with the `null` array, it attempts to allocate. That is counterintuitive because putative clients expect `expand` to either fail, or succeed without modifying the pointer in the array.

This PR embodies the new design: the null array cannot be expanded in place.