### PR TITLE
Fix whitespace for selective imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ script:
  - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
  # enforce whitespace between statements
  - grep -E "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
+ # enforce whitespace between colon(:) for import statements (doesn't catch everything)
+ - grep 'import [^/,=]*:' **/*.d | grep -vE 'import ([^ ]+) : '; echo $?
  # at the moment libdparse has problems to parse some modules (->excludes)
  - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2949,7 +2949,7 @@ unittest
 @safe unittest //12569
 {
     import std.algorithm.comparison : max, min;
-    import std.typecons: tuple;
+    import std.typecons : tuple;
     dchar c = 'a';
     reduce!(min, max)(tuple(c, c), "hello"); // OK
     static assert(!is(typeof(reduce!(min, max)(tuple(c), "hello"))));
@@ -3029,7 +3029,7 @@ template fold(fun...) if (fun.length >= 1)
         }
         else
         {
-            import std.typecons: tuple;
+            import std.typecons : tuple;
             return reduce!fun(tuple(seed), r);
         }
     }
@@ -3046,8 +3046,8 @@ template fold(fun...) if (fun.length >= 1)
     // Sum all elements with explicit seed
     assert(arr.fold!((a, b) => a + b)(6) == 21);
 
-    import std.algorithm.comparison: min, max;
-    import std.typecons: tuple;
+    import std.algorithm.comparison : min, max;
+    import std.typecons : tuple;
 
     // Compute minimum and maximum at the same time
     assert(arr.fold!(min, max) == tuple(1, 5));

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -111,8 +111,8 @@ See_Also:
 size_t bringToFront(Range1, Range2)(Range1 front, Range2 back)
     if (isInputRange!Range1 && isForwardRange!Range2)
 {
-    import std.range: take, Take;
-    import std.array: sameHead;
+    import std.range : take, Take;
+    import std.array : sameHead;
     enum bool sameHeadExists = is(typeof(front.sameHead(back)));
     size_t result;
     for (bool semidone; !front.empty && !back.empty; )
@@ -758,7 +758,7 @@ void initializeAll(Range)(Range range)
 ///
 unittest
 {
-    import core.stdc.stdlib: malloc, free;
+    import core.stdc.stdlib : malloc, free;
 
     struct S
     {
@@ -2416,7 +2416,7 @@ void swapAt(R)(auto ref R r, size_t i1, size_t i2)
 ///
 pure @safe nothrow unittest
 {
-    import std.algorithm.comparison: equal;
+    import std.algorithm.comparison : equal;
     auto a = [1, 2, 3];
     a.swapAt(1, 2);
     assert(a.equal([1, 3, 2]));
@@ -2424,7 +2424,7 @@ pure @safe nothrow unittest
 
 pure @safe nothrow unittest
 {
-    import std.algorithm.comparison: equal;
+    import std.algorithm.comparison : equal;
     auto a = [4, 5, 6];
     a.swapAt(1, 1);
     assert(a.equal([4, 5, 6]));
@@ -2433,8 +2433,8 @@ pure @safe nothrow unittest
 pure @safe nothrow unittest
 {
     // test non random access ranges
-    import std.algorithm.comparison: equal;
-    import std.array: array;
+    import std.algorithm.comparison : equal;
+    import std.array : array;
 
     char[] b = ['a', 'b', 'c'];
     b.swapAt(1, 2);

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3127,7 +3127,7 @@ auto minElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 ///
 @safe pure unittest
 {
-    import std.range: enumerate;
+    import std.range : enumerate;
 
     assert([2, 1, 4, 3].minElement == 1);
 
@@ -3144,7 +3144,7 @@ auto minElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 
 @safe pure unittest
 {
-    import std.range: enumerate, iota;
+    import std.range : enumerate, iota;
     // supports mapping
     assert([3, 4, 5, 1, 2].enumerate.minElement!"a.value" == tuple(3, 1));
     assert([5, 2, 4].enumerate.minElement!"a.value" == tuple(1, 2));
@@ -3217,7 +3217,7 @@ auto maxElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 ///
 @safe pure unittest
 {
-    import std.range: enumerate;
+    import std.range : enumerate;
     assert([2, 1, 4, 3].maxElement == 4);
 
     // allows to get the index of an element too
@@ -3233,7 +3233,7 @@ auto maxElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 
 @safe pure unittest
 {
-    import std.range: enumerate, iota;
+    import std.range : enumerate, iota;
 
     // supports mapping
     assert([3, 4, 5, 1, 2].enumerate.maxElement!"a.value" == tuple(2, 5));

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -339,7 +339,7 @@ auto cartesianProduct(R1, R2)(R1 range1, R2 range2)
 // Issue 13091
 pure nothrow @safe @nogc unittest
 {
-    import std.algorithm: cartesianProduct;
+    import std.algorithm : cartesianProduct;
     int[1] a = [1];
     foreach (t; cartesianProduct(a[], a[])) {}
 }

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -865,7 +865,7 @@ template multiSort(less...) //if (less.length > 1)
     if (validPredicates!(ElementType!Range, less))
     {
         import std.range : assumeSorted;
-        import std.meta: AliasSeq;
+        import std.meta : AliasSeq;
         static if (is(typeof(less[$ - 1]) == SwapStrategy))
         {
             enum ss = less[$ - 1];

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1420,7 +1420,7 @@ unittest
 
 unittest
 {
-    import std.math:abs;
+    import std.math : abs;
     auto r = abs(BigInt(-1000)); // 6486
     assert(r == 1000);
 

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -740,7 +740,7 @@ struct BitArray
 private:
 
     import std.format : FormatSpec;
-    import core.bitop: bts, btr, bsf, bt;
+    import core.bitop : bts, btr, bsf, bt;
 
     size_t _len;
     size_t* _ptr;
@@ -2182,13 +2182,13 @@ private ushort swapEndianImpl(ushort val) @safe pure nothrow @nogc
 
 private uint swapEndianImpl(uint val) @trusted pure nothrow @nogc
 {
-    import core.bitop: bswap;
+    import core.bitop : bswap;
     return bswap(val);
 }
 
 private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
 {
-    import core.bitop: bswap;
+    import core.bitop : bswap;
     immutable ulong res = bswap(cast(uint)val);
     return res << 32 | bswap(cast(uint)(val >> 32));
 }
@@ -3977,7 +3977,7 @@ unittest
 unittest
 {
     import std.algorithm : equal;
-    import std.range: iota;
+    import std.range : iota;
 
     import std.meta;
     foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))

--- a/std/c/stdlib.d
+++ b/std/c/stdlib.d
@@ -13,4 +13,4 @@ deprecated("Import core.stdc.stdlib or core.sys.posix.stdlib instead")
 module std.c.stdlib;
 
 public import core.stdc.stdlib;
-version(Posix) public import core.sys.posix.stdlib: setenv, unsetenv;
+version(Posix) public import core.sys.posix.stdlib : setenv, unsetenv;

--- a/std/complex.d
+++ b/std/complex.d
@@ -356,7 +356,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     ref Complex opOpAssign(string op, C)(C z)
         if (op == "^^" && is(C R == Complex!R))
     {
-        import std.math: exp, log, cos, sin;
+        import std.math : exp, log, cos, sin;
         immutable r = abs(this);
         immutable t = arg(this);
         immutable ab = r^^z.re * exp(-t*z.im);
@@ -388,7 +388,7 @@ struct Complex(T)  if (isFloatingPoint!T)
     ref Complex opOpAssign(string op, R)(R r)
         if (op == "^^" && isFloatingPoint!R)
     {
-        import std.math: cos, sin;
+        import std.math : cos, sin;
         immutable ab = abs(this)^^r;
         immutable ar = arg(this)*r;
         re = ab*cos(ar);

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -20,8 +20,8 @@ module std.container.dlist;
 ///
 unittest
 {
-    import std.container: DList;
-    import std.algorithm: equal;
+    import std.container : DList;
+    import std.algorithm : equal;
 
     auto s = DList!int(1, 2, 3);
     assert(equal(s[], [1, 2, 3]));
@@ -37,8 +37,8 @@ unittest
     assert(equal(s[], [4, 5, 2, 6, 7]));
 
     // If you want to apply range operations, simply slice it.
-    import std.algorithm: countUntil;
-    import std.range: popFrontN, popBackN, walkLength;
+    import std.algorithm : countUntil;
+    import std.range : popFrontN, popBackN, walkLength;
 
     auto sl = DList!int([1, 2, 3, 4, 5]);
     assert(countUntil(sl[], 2) == 1);

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -20,7 +20,7 @@ module std.container.rbtree;
 unittest
 {
     import std.container.rbtree;
-    import std.algorithm: equal;
+    import std.algorithm : equal;
 
     auto rbt = redBlackTree(3, 1, 4, 2, 5);
     assert(rbt.front == 1);
@@ -41,7 +41,7 @@ unittest
     assert(rbt.upperBound(3).equal([4, 5]));
 
     // A Red Black tree with the highest element at front:
-    import std.range: iota;
+    import std.range : iota;
     auto maxTree = redBlackTree!"a > b"(iota(5));
     assert(equal(maxTree[], [4, 3, 2, 1, 0]));
 
@@ -1853,8 +1853,8 @@ auto redBlackTree(alias less, bool allowDuplicates, E)(E[] elems...)
 }
 
 
-import std.range.primitives: isInputRange, isSomeString, ElementType;
-import std.traits: isArray;
+import std.range.primitives : isInputRange, isSomeString, ElementType;
+import std.traits : isArray;
 
 /++ Ditto +/
 auto redBlackTree(Stuff)(Stuff range)

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -20,8 +20,8 @@ module std.container.slist;
 ///
 unittest
 {
-    import std.container: SList;
-    import std.algorithm: equal;
+    import std.container : SList;
+    import std.algorithm : equal;
 
     auto s = SList!int(1, 2, 3);
     assert(equal(s[], [1, 2, 3]));
@@ -33,8 +33,8 @@ unittest
     assert(equal(s[], [5, 6, 2, 3]));
 
     // If you want to apply range operations, simply slice it.
-    import std.algorithm: countUntil;
-    import std.range: popFrontN, walkLength;
+    import std.algorithm : countUntil;
+    import std.range : popFrontN, walkLength;
 
     auto sl = SList!int(1, 2, 3, 4, 5);
     assert(countUntil(sl[], 2) == 1);
@@ -727,7 +727,7 @@ unittest
 unittest
 {
     static import std.algorithm;
-    import std.range: take;
+    import std.range : take;
 
     // insertAfter documentation example
     auto sl = SList!string(["a", "b", "d"]);

--- a/std/conv.d
+++ b/std/conv.d
@@ -4888,7 +4888,7 @@ unittest //@@@9559@@@
 {
     import std.algorithm : map;
     import std.typecons : Nullable;
-    import std.array: array;
+    import std.array : array;
     alias I = Nullable!int;
     auto ints = [0, 1, 2].map!(i => i & 1 ? I.init : I(i))();
     auto asArray = array(ints);

--- a/std/csv.d
+++ b/std/csv.d
@@ -753,8 +753,8 @@ unittest
 
 unittest // const/immutable dchars
 {
-    import std.algorithm: map;
-    import std.array: array;
+    import std.algorithm : map;
+    import std.array : array;
     const(dchar)[] c = "foo,bar\n";
     assert(csvReader(c).map!array.array == [["foo", "bar"]]);
     immutable(dchar)[] i = "foo,bar\n";

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -8640,7 +8640,7 @@ public:
 
     unittest
     {
-        import std.format: format;
+        import std.format : format;
 
         foreach (str; ["", "20100704000000", "20100704 000000", "20100704t000000",
                       "20100704T000000.", "20100704T000000.A", "20100704T000000.Z",

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -90,7 +90,7 @@ struct GCAllocator
         if (n <= 16)
             return 16;
 
-        import core.bitop: bsr;
+        import core.bitop : bsr;
 
         auto largestBit = bsr(n-1) + 1;
         if (largestBit <= 12) // 4096 or less
@@ -132,7 +132,7 @@ unittest
 
 unittest
 {
-    import core.memory: GC;
+    import core.memory : GC;
 
     // test allocation sizes
     assert(GCAllocator.instance.goodAllocSize(1) == 16);

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -132,7 +132,7 @@ version (Windows)
         @nogc nothrow
         private void* _aligned_malloc(size_t size, size_t alignment)
         {
-            import std.c.stdlib: malloc;
+            import std.c.stdlib : malloc;
             size_t offset = alignment + size_t.sizeof * 2 - 1;
 
             // unaligned chunk
@@ -154,8 +154,8 @@ version (Windows)
         @nogc nothrow
         private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
         {
-            import std.c.stdlib: free;
-            import std.c.string: memcpy;
+            import std.c.stdlib : free;
+            import std.c.string : memcpy;
 
             if (!ptr) return _aligned_malloc(size, alignment);
 
@@ -181,7 +181,7 @@ version (Windows)
         @nogc nothrow
         private void _aligned_free(void *ptr)
         {
-            import std.c.stdlib: free;
+            import std.c.stdlib : free;
             if (!ptr) return;
             AlignInfo* head = AlignInfo(ptr);
             free(head.basePtr);

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1208,7 +1208,7 @@ unittest
 
 unittest //bugzilla 15721
 {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import std.experimental.allocator.mallocator : Mallocator;
 
     interface Foo {}
     class Bar: Foo {}

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -135,7 +135,7 @@ template SliceFromSeq(Range, Seq...)
         alias SliceFromSeq = Range;
     else
     {
-        import std.experimental.ndslice.slice: Slice;
+        import std.experimental.ndslice.slice : Slice;
         alias SliceFromSeq = SliceFromSeq!(Slice!(Seq[$ - 1], Range), Seq[0 .. $ - 1]);
     }
 }

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -174,7 +174,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5, 6)
         .swapped!(3, 1)
         .shape == cast(size_t[4])[3, 6, 5, 4]);
@@ -184,7 +184,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5, 6)
         .swapped(1, 3)
         .shape == cast(size_t[4])[3, 6, 5, 4]);
@@ -194,7 +194,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4)
         .swapped
         .shape == cast(size_t[2])[4, 3]);
@@ -284,7 +284,7 @@ body
 @safe pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto slice = iotaSlice(2, 3);
 
     auto a = [[0, 1, 2],
@@ -351,7 +351,7 @@ Slice!(N, Range) everted(size_t N, Range)(auto ref Slice!(N, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5)
         .everted
         .shape == cast(size_t[3])[5, 4, 3]);
@@ -465,7 +465,7 @@ Slice!(2, Range) transposed(Range)(auto ref Slice!(2, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5, 6, 7)
         .transposed!(4, 1, 0)
         .shape == cast(size_t[5])[7, 4, 3, 5, 6]);
@@ -475,7 +475,7 @@ Slice!(2, Range) transposed(Range)(auto ref Slice!(2, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5, 6, 7)
         .transposed(4, 1, 0)
         .shape == cast(size_t[5])[7, 4, 3, 5, 6]);
@@ -485,7 +485,7 @@ Slice!(2, Range) transposed(Range)(auto ref Slice!(2, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4, 5, 6, 7)
         .transposed(4)
         .shape == cast(size_t[5])[7, 3, 4, 5, 6]);
@@ -495,7 +495,7 @@ Slice!(2, Range) transposed(Range)(auto ref Slice!(2, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(3, 4)
         .transposed
         .shape == cast(size_t[2])[4, 3]);
@@ -530,7 +530,7 @@ Slice!(N, Range) allReversed(size_t N, Range)(Slice!(N, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.range: iota, retro;
+    import std.range : iota, retro;
     auto a = 20.iota.sliced(4, 5).allReversed;
     auto b = 20.iota.retro.sliced(4, 5);
     assert(a == b);
@@ -615,8 +615,8 @@ pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.selection;
-    import std.algorithm.comparison: equal;
-    import std.range: iota, retro, chain;
+    import std.algorithm.comparison : equal;
+    import std.range : iota, retro, chain;
     auto i0 = iota(0,  4); auto r0 = i0.retro;
     auto i1 = iota(4,  8); auto r1 = i1.retro;
     auto i2 = iota(8, 12); auto r2 = i2.retro;
@@ -723,7 +723,7 @@ pure nothrow unittest
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     static assert(iotaSlice(13, 40).strided!(0, 1)(2, 5).shape == [7, 8]);
     static assert(iotaSlice(93).strided!(0, 0)(7, 3).shape == [5]);
 }
@@ -732,8 +732,8 @@ pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.selection;
-    import std.algorithm.comparison: equal;
-    import std.range: iota, stride, chain;
+    import std.algorithm.comparison : equal;
+    import std.range : iota, stride, chain;
     auto i0 = iota(0,  4); auto s0 = i0.stride(3);
     auto i1 = iota(4,  8); auto s1 = i1.stride(3);
     auto i2 = iota(8, 12); auto s2 = i2.stride(3);
@@ -778,7 +778,7 @@ Slice!(N, Range) allDropBackOne(size_t N, Range)(Slice!(N, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.allDropOne[0, 0] == 6);
@@ -823,7 +823,7 @@ Slice!(N, Range) allDropBackExactly(size_t N, Range)(Slice!(N, Range) slice, siz
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.allDropExactly(2)[0, 0] == 12);
@@ -865,7 +865,7 @@ Slice!(N, Range) allDropBack(size_t N, Range)(Slice!(N, Range) slice, size_t n)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.allDrop(2)[0, 0] == 12);
@@ -973,7 +973,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.dropOne!(1, 0)[0, 0] == 6);
@@ -998,7 +998,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.dropOne(0).dropOne(0)[0, 0] == 10);
@@ -1083,7 +1083,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.dropExactly    !(1, 0)(2, 3)[0, 0] == 17);
@@ -1173,7 +1173,7 @@ body
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(4, 5);
 
     assert(a.drop    !(1, 0)(2, 3)[0, 0] == 17);
@@ -1213,7 +1213,7 @@ body
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     assert(iotaSlice(5, 3, 6, 7)
         .dropToHypercube
         .shape == cast(size_t[4])[3, 3, 3, 3]);

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -168,8 +168,8 @@ Returns:
 Slice!(3, C*) movingWindowByChannel(alias filter, C)
 (Slice!(3, C*) image, size_t nr, size_t nc)
 {
-    import std.algorithm.iteration: map;
-    import std.array: array;
+    import std.algorithm.iteration : map;
+    import std.array : array;
 
         // 0. 3D
         // The last dimension represents the color channel.
@@ -219,7 +219,7 @@ Returns:
 +/
 T median(Range, T)(Range r, T[] buf)
 {
-    import std.algorithm.sorting: topN;
+    import std.algorithm.sorting : topN;
     size_t n;
     foreach (e; r)
         buf[n++] = e;
@@ -234,9 +234,9 @@ The `main` function:
 -------
 void main(string[] args)
 {
-    import std.conv: to;
-    import std.getopt: getopt, defaultGetoptPrinter;
-    import std.path: stripExtension;
+    import std.conv : to;
+    import std.getopt : getopt, defaultGetoptPrinter;
+    import std.path : stripExtension;
 
     uint nr, nc, def = 3;
     auto helpInformation = args.getopt(
@@ -339,8 +339,8 @@ unittest
     static Slice!(3, ubyte*) movingWindowByChannel
     (Slice!(3, ubyte*) image, size_t nr, size_t nc, ubyte delegate(Slice!(2, ubyte*)) filter)
     {
-        import std.algorithm.iteration: map;
-        import std.array: array;
+        import std.algorithm.iteration : map;
+        import std.array : array;
         auto wnds = image
             .pack!1
             .windows(nr, nc)
@@ -356,7 +356,7 @@ unittest
 
     static T median(Range, T)(Range r, T[] buf)
     {
-        import std.algorithm.sorting: topN;
+        import std.algorithm.sorting : topN;
         size_t n;
         foreach (e; r)
             buf[n++] = e;
@@ -365,9 +365,9 @@ unittest
         return buf[m];
     }
 
-    import std.conv: to;
-    import std.getopt: getopt, defaultGetoptPrinter;
-    import std.path: stripExtension;
+    import std.conv : to;
+    import std.getopt : getopt, defaultGetoptPrinter;
+    import std.path : stripExtension;
 
     auto args = ["std"];
     uint nr, nc, def = 3;
@@ -396,8 +396,8 @@ unittest
 
 @safe @nogc pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.range: iota;
+    import std.algorithm.comparison : equal;
+    import std.range : iota;
     immutable r = 1000.iota;
 
     auto t0 = r.sliced(1000);
@@ -425,9 +425,9 @@ unittest
 
 pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.array: array;
-    import std.range: iota;
+    import std.algorithm.comparison : equal;
+    import std.array : array;
+    import std.range : iota;
     auto r = 1000.iota.array;
 
     auto t0 = r.sliced(1000);
@@ -517,7 +517,7 @@ pure nothrow unittest
 
 @safe @nogc pure nothrow unittest
 {
-    import std.range: iota;
+    import std.range : iota;
     auto r = (10_000L * 2 * 3 * 4).iota;
 
     auto t0 = r.sliced(10, 20, 30, 40);
@@ -530,10 +530,10 @@ pure nothrow unittest
 
 pure nothrow unittest
 {
-    import std.experimental.ndslice.internal: Iota;
-    import std.meta: AliasSeq;
+    import std.experimental.ndslice.internal : Iota;
+    import std.meta : AliasSeq;
     import std.range;
-    import std.typecons: Tuple;
+    import std.typecons : Tuple;
     foreach (R; AliasSeq!(
         int*, int[], typeof(1.iota),
         const(int)*, const(int)[],
@@ -561,7 +561,7 @@ pure nothrow unittest
 
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: pack;
+    import std.experimental.ndslice.selection : pack;
     auto slice = new int[24].sliced(2, 3, 4);
     auto r0 = slice.pack!1[1, 2];
     slice.pack!1[1, 2][] = 4;

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -99,8 +99,8 @@ template pack(K...)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.range.primitives: ElementType;
-    import std.range: iota;
+    import std.range.primitives : ElementType;
+    import std.range : iota;
     auto r = (3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11).iota;
     auto a = r.sliced(3, 4, 5, 6, 7, 8, 9, 10, 11);
     auto b = a.pack!(2, 3); // same as `a.pack!2.pack!3`
@@ -203,7 +203,7 @@ evertPack(size_t N, Range)(auto ref Slice!(N, Range) slice)
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: transposed;
+    import std.experimental.ndslice.iteration : transposed;
     auto slice = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
     assert(slice
         .pack!2
@@ -218,10 +218,10 @@ evertPack(size_t N, Range)(auto ref Slice!(N, Range) slice)
 pure nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.iteration: transposed;
-    import std.range.primitives: ElementType;
-    import std.range: iota;
-    import std.algorithm.comparison: equal;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.range.primitives : ElementType;
+    import std.range : iota;
+    import std.algorithm.comparison : equal;
     auto r = (3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11).iota;
     auto a = r.sliced(3, 4, 5, 6, 7, 8, 9, 10, 11);
     auto b = a
@@ -310,8 +310,8 @@ Slice!(1, Range) diagonal(size_t N, Range)(auto ref Slice!(N, Range) slice)
 /// Non-square matrix
 @safe @nogc pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.range: only;
+    import std.algorithm.comparison : equal;
+    import std.range : only;
 
     //  -------
     // | 0 1 |
@@ -344,7 +344,7 @@ pure nothrow unittest
 /// Matrix, subdiagonal
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: dropOne;
+    import std.experimental.ndslice.iteration : dropOne;
     //  -------
     // | 0 1 2 |
     // | 3 4 5 |
@@ -358,7 +358,7 @@ pure nothrow unittest
 /// Matrix, antidiagonal
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: dropToHypercube, reversed;
+    import std.experimental.ndslice.iteration : dropToHypercube, reversed;
     //  -------
     // | 0 1 2 |
     // | 3 4 5 |
@@ -388,7 +388,7 @@ pure nothrow unittest
 /// 3D, subdiagonal
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: dropOne;
+    import std.experimental.ndslice.iteration : dropOne;
     //  -----------
     // |  0   1  2 |
     // |  3   4  5 |
@@ -405,7 +405,7 @@ pure nothrow unittest
 /// 3D, diagonal plain
 @nogc @safe pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: dropOne;
+    import std.experimental.ndslice.iteration : dropOne;
     //  -----------
     // |  0   1  2 |
     // |  3   4  5 |
@@ -783,7 +783,7 @@ Slice!(Lengths.length, Range)
 ///
 @safe pure unittest
 {
-    import std.experimental.ndslice.iteration: allReversed;
+    import std.experimental.ndslice.iteration : allReversed;
     auto slice = iotaSlice(3, 4)
         .allReversed
         .reshape(-1, 3);
@@ -798,8 +798,8 @@ Slice!(Lengths.length, Range)
 pure unittest
 {
     import std.experimental.ndslice.slice;
-    import std.experimental.ndslice.iteration: reversed;
-    import std.array: array;
+    import std.experimental.ndslice.iteration : reversed;
+    import std.array : array;
 
     auto reshape2(S, L...)(S slice, L lengths)
     {
@@ -827,7 +827,7 @@ pure unittest
 
 @safe pure unittest
 {
-    import std.experimental.ndslice.iteration: allReversed;
+    import std.experimental.ndslice.iteration : allReversed;
     auto slice = iotaSlice(1, 1, 3, 2, 1, 2, 1).allReversed;
     assert(slice.reshape(1, -1, 1, 1, 3, 1) ==
         [[[[[[11], [10], [9]]]],
@@ -845,8 +845,8 @@ unittest
 @safe pure unittest
 {
     import std.experimental.ndslice.slice;
-    import std.range: iota;
-    import std.exception: assertThrown;
+    import std.range : iota;
+    import std.exception : assertThrown;
 
     auto e = 1.iotaSlice(1);
     // resize to the wrong dimension
@@ -1165,8 +1165,8 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
 /// Regular slice
 @safe @nogc pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.range: iota;
+    import std.algorithm.comparison : equal;
+    import std.range : iota;
     assert(iotaSlice(4, 5)
         .byElement
         .equal(20.iota));
@@ -1177,7 +1177,7 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration;
-    import std.range: drop;
+    import std.range : drop;
     assert(iotaSlice(3, 4, 5, 6, 7)
         .pack!2
         .byElement()
@@ -1222,8 +1222,8 @@ pure nothrow unittest
 pure nothrow unittest
 {
     // test save
-    import std.range: dropOne;
-    import std.range: iota;
+    import std.range : dropOne;
+    import std.range : iota;
 
     auto elems = 12.iota.sliced(3, 4).byElement;
     assert(elems.front == 0);
@@ -1237,9 +1237,9 @@ Random access and slicing
 @nogc nothrow unittest
 {
     import std.experimental.ndslice.slice;
-    import std.algorithm.comparison: equal;
-    import std.array: array;
-    import std.range: iota, repeat;
+    import std.algorithm.comparison : equal;
+    import std.array : array;
+    import std.range : iota, repeat;
     static data = 20.iota.array;
     auto elems = data.sliced(4, 5).byElement;
 
@@ -1275,8 +1275,8 @@ Use $(SUBREF iteration, allReversed) in pipeline before
 +/
 @safe @nogc pure nothrow unittest
 {
-    import std.range: retro;
-    import std.experimental.ndslice.iteration: allReversed;
+    import std.range : retro;
+    import std.experimental.ndslice.iteration : allReversed;
 
     auto slice = iotaSlice(3, 4, 5);
 
@@ -1301,7 +1301,7 @@ Use $(SUBREF iteration, allReversed) in pipeline before
 
 @safe @nogc pure nothrow unittest
 {
-    import std.range.primitives: isRandomAccessRange, hasSlicing;
+    import std.range.primitives : isRandomAccessRange, hasSlicing;
     auto elems = iotaSlice(4, 5).byElement;
     static assert(isRandomAccessRange!(typeof(elems)));
     static assert(hasSlicing!(typeof(elems)));
@@ -1311,7 +1311,7 @@ Use $(SUBREF iteration, allReversed) in pipeline before
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.iteration;
-    import std.range: isRandomAccessRange;
+    import std.range : isRandomAccessRange;
     auto elems = iotaSlice(4, 5).everted.byElement;
     static assert(isRandomAccessRange!(typeof(elems)));
 
@@ -1328,8 +1328,8 @@ Use $(SUBREF iteration, allReversed) in pipeline before
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration;
-    import std.range: iota, isForwardRange, hasLength;
-    import std.algorithm.comparison: equal;
+    import std.range : iota, isForwardRange, hasLength;
+    import std.algorithm.comparison : equal;
 
     auto range = (3 * 4 * 5 * 6 * 7).iota;
     auto slice0 = range.sliced(3, 4, 5, 6, 7);
@@ -1532,7 +1532,7 @@ pure nothrow unittest
 /// Properties
 @safe @nogc pure nothrow unittest
 {
-    import std.range.primitives: popFrontN;
+    import std.range.primitives : popFrontN;
 
     auto elems = iotaSlice(3, 4).byElementInStandardSimplex;
 
@@ -1548,7 +1548,7 @@ pure nothrow unittest
 @safe @nogc pure nothrow unittest
 {
     auto elems = iotaSlice(3, 4).byElementInStandardSimplex;
-    import std.range: dropOne, popFrontN;
+    import std.range : dropOne, popFrontN;
     elems.popFrontN(4);
 
     assert(elems.save.dropOne.front == 8);
@@ -1578,7 +1578,7 @@ IndexSlice!(Lengths.length) indexSlice(Lengths...)(Lengths lengths)
 ///ditto
 IndexSlice!N indexSlice(size_t N)(auto ref size_t[N] lengths)
 {
-    import std.experimental.ndslice.slice: sliced;
+    import std.experimental.ndslice.slice : sliced;
     with (typeof(return)) return Range(lengths[1 .. $]).sliced(lengths);
 }
 
@@ -1612,7 +1612,7 @@ IndexSlice!N indexSlice(size_t N)(auto ref size_t[N] lengths)
 @safe pure nothrow unittest
 {
     // test save
-    import std.range: dropOne;
+    import std.range : dropOne;
 
     auto im = indexSlice(7, 9);
     auto imByElement = im.byElement;
@@ -1657,7 +1657,7 @@ template IndexSlice(size_t N)
 unittest
 {
     auto r = indexSlice(1);
-    import std.range.primitives: isRandomAccessRange;
+    import std.range.primitives : isRandomAccessRange;
     static assert(isRandomAccessRange!(typeof(r)));
 }
 
@@ -1682,7 +1682,7 @@ IotaSlice!(Lengths.length) iotaSlice(Lengths...)(Lengths lengths)
 ///ditto
 IotaSlice!N iotaSlice(size_t N)(auto ref size_t[N] lengths, size_t shift = 0)
 {
-    import std.experimental.ndslice.slice: sliced;
+    import std.experimental.ndslice.slice : sliced;
     with (typeof(return)) return Range.init.sliced(lengths, shift);
 }
 
@@ -1696,7 +1696,7 @@ IotaSlice!N iotaSlice(size_t N)(auto ref size_t[N] lengths, size_t shift = 0)
 
     assert(slice == array);
 
-    import std.range.primitives: isRandomAccessRange;
+    import std.range.primitives : isRandomAccessRange;
     static assert(isRandomAccessRange!(IotaSlice!2));
     static assert(is(IotaSlice!2 : Slice!(2, Range), Range));
     static assert(is(DeepElementType!(IotaSlice!2) == size_t));

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -166,7 +166,7 @@ template sliced(Names...)
     {
         alias RS = AliasSeq!(" ~ _Range_Types!Names ~ ");"
         ~ q{
-            import std.meta: staticMap;
+            import std.meta : staticMap;
             static assert(!anySatisfy!(_isSlice, RS),
                 `Packed slices are not allowed in slice tuples`
                 ~ tailErrorMessage!());
@@ -233,7 +233,7 @@ pure nothrow unittest
 /// Creates a slice using shift parameter.
 @safe @nogc pure nothrow unittest
 {
-    import std.range: iota;
+    import std.range : iota;
     auto slice = (5 * 6 * 7 + 9).iota.sliced([5, 6, 7], 9);
     assert(slice.length == 5);
     assert(slice.elementsCount == 5 * 6 * 7);
@@ -243,7 +243,7 @@ pure nothrow unittest
 /// Creates an 1-dimensional slice over a range.
 @safe @nogc pure nothrow unittest
 {
-    import std.range: iota;
+    import std.range : iota;
     auto slice = 10.iota.sliced;
     assert(slice.length == 10);
 }
@@ -276,9 +276,9 @@ to a given argument. See also $(LREF assumeSameStructure).
 +/
 pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.experimental.ndslice.selection: byElement;
-    import std.range: iota;
+    import std.algorithm.comparison : equal;
+    import std.experimental.ndslice.selection : byElement;
+    import std.range : iota;
 
     auto alpha = 12.iota;
     auto beta = new int[12];
@@ -353,7 +353,7 @@ pure nothrow @nogc unittest
 /// Slice tuple and flags
 pure nothrow @nogc unittest
 {
-    import std.typecons: Yes, No;
+    import std.typecons : Yes, No;
     static immutable a = [1, 2, 3, 4, 5, 6];
     static immutable b = [1.0, 2, 3, 4, 5, 6];
     alias namedSliced = sliced!("a", "b");
@@ -365,7 +365,7 @@ pure nothrow @nogc unittest
 // sliced slice
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto data = new int[24];
     foreach (int i,ref e; data)
         e = i;
@@ -452,7 +452,7 @@ template assumeSameStructure(Names...)
     {
         alias RS = AliasSeq!("  ~_Range_Types!Names ~ ");"
         ~ q{
-            import std.meta: staticMap;
+            import std.meta : staticMap;
             static assert(!anySatisfy!(_isSlice, RS),
                 `Packed slices not allowed in slice tuples`
                 ~ tailErrorMessage!());
@@ -485,8 +485,8 @@ template assumeSameStructure(Names...)
 ///
 pure nothrow unittest
 {
-    import std.algorithm.comparison: equal;
-    import std.experimental.ndslice.selection: byElement, iotaSlice;
+    import std.algorithm.comparison : equal;
+    import std.experimental.ndslice.selection : byElement, iotaSlice;
 
     auto alpha = iotaSlice(4, 3);
     auto beta = slice!int(4, 3);
@@ -506,9 +506,9 @@ pure nothrow unittest
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.algorithm.iteration: map, sum, reduce;
-    import std.algorithm.comparison: max;
-    import std.experimental.ndslice.iteration: transposed;
+    import std.algorithm.iteration : map, sum, reduce;
+    import std.algorithm.comparison : max;
+    import std.experimental.ndslice.iteration : transposed;
     /// Returns maximal column average.
     auto maxAvg(S)(S matrix) {
         return matrix.transposed.map!sum.reduce!max
@@ -523,9 +523,9 @@ pure nothrow unittest
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.algorithm.iteration: map, sum, reduce;
-    import std.algorithm.comparison: max;
-    import std.experimental.ndslice.iteration: transposed;
+    import std.algorithm.iteration : map, sum, reduce;
+    import std.algorithm.comparison : max;
+    import std.experimental.ndslice.iteration : transposed;
     /// Returns maximal column average.
     auto maxAvg(S)(S matrix) {
         return matrix.transposed.map!sum.reduce!max
@@ -617,7 +617,7 @@ pure nothrow unittest
 
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto tensor = iotaSlice(2, 3).slice;
     assert(tensor == [[0, 1, 2], [3, 4, 5]]);
 }
@@ -648,7 +648,7 @@ auto makeSlice(T,
     Allocator,
     size_t N)(auto ref Allocator alloc, auto ref in size_t[N] lengths)
 {
-    import std.experimental.allocator: makeArray;
+    import std.experimental.allocator : makeArray;
     static struct Result { T[] array; Slice!(N, Select!(replaceArrayWithPointer, T*, T[])) slice; }
     immutable len = lengthsProduct(lengths);
     auto array = alloc.makeArray!T(len);
@@ -662,7 +662,7 @@ auto makeSlice(T,
     Allocator,
     size_t N)(auto ref Allocator alloc, auto ref in size_t[N] lengths, auto ref T init)
 {
-    import std.experimental.allocator: makeArray;
+    import std.experimental.allocator : makeArray;
     static struct Result { T[] array; Slice!(N, Select!(replaceArrayWithPointer, T*, T[])) slice; }
     immutable len = lengthsProduct(lengths);
     auto array = alloc.makeArray!T(len, init);
@@ -676,8 +676,8 @@ auto makeSlice(T,
     Allocator,
     size_t N, Range)(auto ref Allocator alloc, auto ref Slice!(N, Range) slice)
 {
-    import std.experimental.allocator: makeArray;
-    import std.experimental.ndslice.selection: byElement;
+    import std.experimental.allocator : makeArray;
+    import std.experimental.ndslice.selection : byElement;
     static struct Result { T[] array; Slice!(N, Select!(replaceArrayWithPointer, T*, T[])) slice; }
     auto array = alloc.makeArray!T(slice.byElement);
     auto _slice = array.sliced!replaceArrayWithPointer(slice.shape);
@@ -729,14 +729,14 @@ Returns:
 +/
 auto ndarray(size_t N, Range)(auto ref Slice!(N, Range) slice)
 {
-    import std.array: array;
+    import std.array : array;
     static if (N == 1)
     {
         return array(slice);
     }
     else
     {
-        import std.algorithm.iteration: map;
+        import std.algorithm.iteration : map;
         return array(slice.map!(a => .ndarray(a)));
     }
 }
@@ -744,7 +744,7 @@ auto ndarray(size_t N, Range)(auto ref Slice!(N, Range) slice)
 ///
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto slice = iotaSlice(3, 4);
     auto m = slice.ndarray;
     static assert(is(typeof(m) == size_t[][]));
@@ -761,7 +761,7 @@ Returns:
 +/
 auto makeNdarray(T, Allocator, size_t N, Range)(auto ref Allocator alloc,  Slice!(N, Range) slice)
 {
-    import std.experimental.allocator: makeArray;
+    import std.experimental.allocator : makeArray;
     static if (N == 1)
     {
         return makeArray!T(alloc, slice);
@@ -781,7 +781,7 @@ auto makeNdarray(T, Allocator, size_t N, Range)(auto ref Allocator alloc,  Slice
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto slice = iotaSlice(3, 4);
     auto m = Mallocator.instance.makeNdarray!long(slice);
@@ -834,7 +834,7 @@ auto shape(T)(T[] array) @property
     size_t[2] shape = [[1, 2, 3], [4, 5, 6]].shape;
     assert(shape == [2, 3]);
 
-    import std.exception: assertThrown;
+    import std.exception : assertThrown;
     assertThrown([[1, 2], [4, 5, 6]].shape);
 }
 
@@ -879,7 +879,7 @@ alias DeepElementType(S : Slice!(N, Range), size_t N, Range) = S.DeepElemType;
 ///
 unittest
 {
-    import std.range: iota;
+    import std.range : iota;
     static assert(is(DeepElementType!(Slice!(4, const(int)[]))     == const(int)));
     static assert(is(DeepElementType!(Slice!(4, immutable(int)*))  == immutable(int)));
     static assert(is(DeepElementType!(Slice!(4, typeof(100.iota))) == int));
@@ -1040,7 +1040,7 @@ Definitions
 
 -------
 import std.experimental.ndslice;
-import std.range: iota;
+import std.range : iota;
 auto a = iota(24);
 alias A = typeof(a);
 Slice!(3, A) s = a.sliced(2, 3, 4);
@@ -1215,7 +1215,7 @@ struct Slice(size_t _N, _Range)
     @nogc nothrow pure
     unittest
     {
-        import std.experimental.ndslice.selection: byElement;
+        import std.experimental.ndslice.selection : byElement;
         import std.algorithm.comparison : equal;
         import std.range : only;
 
@@ -1276,7 +1276,7 @@ struct Slice(size_t _N, _Range)
     /// Regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         assert(iotaSlice(3, 4, 5)
             .shape == cast(size_t[3])[3, 4, 5]);
     }
@@ -1285,7 +1285,7 @@ struct Slice(size_t _N, _Range)
     /// Packed slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: pack, iotaSlice;
+        import std.experimental.ndslice.selection : pack, iotaSlice;
         assert(iotaSlice(3, 4, 5, 6, 7)
             .pack!2
             .shape == cast(size_t[3])[3, 4, 5]);
@@ -1305,7 +1305,7 @@ struct Slice(size_t _N, _Range)
     /// Regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         assert(iotaSlice(3, 4, 5)
             .structure == Structure!3([3, 4, 5], [20, 5, 1]));
     }
@@ -1314,8 +1314,8 @@ struct Slice(size_t _N, _Range)
     /// Modified regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: pack, iotaSlice;
-        import std.experimental.ndslice.iteration: reversed, strided, transposed;
+        import std.experimental.ndslice.selection : pack, iotaSlice;
+        import std.experimental.ndslice.iteration : reversed, strided, transposed;
         assert(iotaSlice(3, 4, 50)
             .reversed!2      //makes stride negative
             .strided!2(6)    //multiplies stride by 6 and changes corresponding length
@@ -1327,7 +1327,7 @@ struct Slice(size_t _N, _Range)
     /// Packed slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: pack, iotaSlice;
+        import std.experimental.ndslice.selection : pack, iotaSlice;
         assert(iotaSlice(3, 4, 5, 6, 7)
             .pack!2
             .structure == Structure!3([3, 4, 5], [20 * 42, 5 * 42, 1 * 42]));
@@ -1350,7 +1350,7 @@ struct Slice(size_t _N, _Range)
     /// Forward range
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         auto slice = iotaSlice(2, 3).save;
     }
 
@@ -1379,7 +1379,7 @@ struct Slice(size_t _N, _Range)
     ///
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         auto slice = iotaSlice(3, 4, 5);
         assert(slice.length   == 3);
         assert(slice.length!0 == 3);
@@ -1404,7 +1404,7 @@ struct Slice(size_t _N, _Range)
     /// Regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         auto slice = iotaSlice(3, 4, 5);
         assert(slice.stride   == 20);
         assert(slice.stride!0 == 20);
@@ -1416,8 +1416,8 @@ struct Slice(size_t _N, _Range)
     /// Modified regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.iteration: reversed, strided, swapped;
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.iteration : reversed, strided, swapped;
+        import std.experimental.ndslice.selection : iotaSlice;
         assert(iotaSlice(3, 4, 50)
             .reversed!2      //makes stride negative
             .strided!2(6)    //multiplies stride by 6 and changes the corresponding length
@@ -1569,7 +1569,7 @@ struct Slice(size_t _N, _Range)
         if (dimension < N)
     {
         pragma(inline, true);
-        import std.algorithm.comparison: min;
+        import std.algorithm.comparison : min;
         popFrontExactly!dimension(min(n, _lengths[dimension]));
     }
 
@@ -1578,7 +1578,7 @@ struct Slice(size_t _N, _Range)
         if (dimension < N)
     {
         pragma(inline, true);
-        import std.algorithm.comparison: min;
+        import std.algorithm.comparison : min;
         popBackExactly!dimension(min(n, _lengths[dimension]));
     }
 
@@ -1587,7 +1587,7 @@ struct Slice(size_t _N, _Range)
     @safe @nogc pure nothrow unittest
     {
         import std.range.primitives;
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         auto slice = iotaSlice(10, 20, 30);
 
         static assert(isRandomAccessRange!(typeof(slice)));
@@ -1653,14 +1653,14 @@ struct Slice(size_t _N, _Range)
     package void popFrontN(size_t dimension, size_t n)
     {
         assert(dimension < N, __FUNCTION__ ~ ": dimension should be less than N = " ~ N.stringof);
-        import std.algorithm.comparison: min;
+        import std.algorithm.comparison : min;
         popFrontExactly(dimension, min(n, _lengths[dimension]));
     }
 
     package void popBackN(size_t dimension, size_t n)
     {
         assert(dimension < N, __FUNCTION__ ~ ": dimension should be less than N = " ~ N.stringof);
-        import std.algorithm.comparison: min;
+        import std.algorithm.comparison : min;
         popBackExactly(dimension, min(n, _lengths[dimension]));
     }
 
@@ -1679,7 +1679,7 @@ struct Slice(size_t _N, _Range)
     /// Regular slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: iotaSlice;
+        import std.experimental.ndslice.selection : iotaSlice;
         assert(iotaSlice(3, 4, 5).elementsCount == 60);
     }
 
@@ -1688,7 +1688,7 @@ struct Slice(size_t _N, _Range)
     /// Packed slice
     @safe @nogc pure nothrow unittest
     {
-        import std.experimental.ndslice.selection: pack, evertPack, iotaSlice;
+        import std.experimental.ndslice.selection : pack, evertPack, iotaSlice;
         auto slice = iotaSlice(3, 4, 5, 6, 7, 8);
         auto p = slice.pack!2;
         assert(p.elementsCount == 360);
@@ -1820,10 +1820,10 @@ struct Slice(size_t _N, _Range)
     pure nothrow unittest
     {
         // check with different PureN
-        import std.experimental.ndslice.selection: pack, iotaSlice;
+        import std.experimental.ndslice.selection : pack, iotaSlice;
         auto pElements = iotaSlice(2, 3, 4, 5).pack!2;
-        import std.range: iota;
-        import std.algorithm.comparison: equal;
+        import std.range : iota;
+        import std.algorithm.comparison : equal;
 
         // D & C order
         assert(pElements[$-1, $-1][$-1].equal([5].iotaSlice(115)));
@@ -1929,7 +1929,7 @@ struct Slice(size_t _N, _Range)
                         {
                             static if (i != value.N - 1)
                             {
-                                import std.experimental.ndslice.iteration: swapped;
+                                import std.experimental.ndslice.iteration : swapped;
                                 slice = slice.swapped(i + d, slice.N - 1);
                                 value = value.swapped(i    , value.N - 1);
                             }
@@ -2498,8 +2498,8 @@ Slicing, indexing, and arithmetic operations.
 +/
 pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: transposed;
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto tensor = iotaSlice(3, 4, 5).slice;
 
     assert(tensor[1, 2] == tensor[1][2]);
@@ -2531,7 +2531,7 @@ Operations with rvalue slices.
 +/
 pure nothrow unittest
 {
-    import std.experimental.ndslice.iteration: transposed, everted;
+    import std.experimental.ndslice.iteration : transposed, everted;
 
     auto tensor = slice!int(3, 4, 5);
     auto matrix = slice!int(3, 4);
@@ -2596,7 +2596,7 @@ unittest
 // Slicing
 @safe @nogc pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(10, 20, 30, 40);
     auto b = a[0..$, 10, 4 .. 27, 4];
     auto c = b[2 .. 9, 5 .. 10];
@@ -2609,7 +2609,7 @@ unittest
 // Operator overloading. # 1
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto fun(ref size_t x) { x *= 3; }
 
@@ -2628,10 +2628,10 @@ pure nothrow unittest
 // Operator overloading. # 2
 pure nothrow unittest
 {
-    import std.algorithm.iteration: map;
-    import std.array: array;
+    import std.algorithm.iteration : map;
+    import std.array : array;
     import std.bigint;
-    import std.range: iota;
+    import std.range : iota;
 
     auto matrix = 72
         .iota
@@ -2651,7 +2651,7 @@ pure nothrow unittest
 // Operator overloading. # 3
 pure nothrow unittest
 {
-    import std.experimental.ndslice.selection: iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto matrix = iotaSlice(8, 9).slice;
     matrix[] = matrix;
@@ -2682,7 +2682,7 @@ unittest
     static assert(is(typeof(ar[].sliced(3, 4)) == Slice!(2, typeof(ar[]))));
 
     // Implicit conversion of a range to its unqualified type.
-    import std.range: iota;
+    import std.range : iota;
     auto      i0 = 60.iota;
     const     i1 = 60.iota;
     immutable i2 = 60.iota;
@@ -2694,7 +2694,7 @@ unittest
 // Test for map #1
 unittest
 {
-    import std.algorithm.iteration: map;
+    import std.algorithm.iteration : map;
     import std.range.primitives;
     auto slice = [1, 2, 3, 4].sliced(2, 2);
 
@@ -2716,7 +2716,7 @@ unittest
 // Test for map #2
 unittest
 {
-    import std.algorithm.iteration: map;
+    import std.algorithm.iteration : map;
     import std.range.primitives;
     auto data = [1, 2, 3, 4].map!(a => a * 2);
     static assert(hasSlicing!(typeof(data)));

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -23,7 +23,7 @@ module std.experimental.typecons;
 import std.meta; // : AliasSeq, allSatisfy;
 import std.traits;
 
-import std.typecons: Tuple, tuple, Bind, DerivedFunctionType,
+import std.typecons : Tuple, tuple, Bind, DerivedFunctionType,
        isImplicitlyConvertible, mixinAll, staticIota,
        GetOverloadedMethods;
 
@@ -568,7 +568,7 @@ template unwrap(Target)
                         break;
                 }
             } while (upCastSource);
-            import std.conv: ConvException;
+            import std.conv : ConvException;
             throw new ConvException(unwrapExceptionText!(Source,Target));
         }
         // structural downcast for class target

--- a/std/file.d
+++ b/std/file.d
@@ -2486,8 +2486,8 @@ version(Posix) unittest // input range of dchars
     mkdirRecurse(deleteme);
     scope(exit) if (deleteme.exists) rmdirRecurse(deleteme);
     write(deleteme ~ "/f", "");
-    import std.range.interfaces: InputRange, inputRangeObject;
-    import std.utf: byChar;
+    import std.range.interfaces : InputRange, inputRangeObject;
+    import std.utf : byChar;
     immutable string link = deleteme ~ "/l";
     symlink("f", link);
     InputRange!dchar linkr = inputRangeObject(link);
@@ -3459,7 +3459,7 @@ version(Windows) unittest
 
 version(Posix) unittest
 {
-    import std.process: executeShell;
+    import std.process : executeShell;
     collectException(rmdirRecurse(deleteme));
     auto d = deleteme~"/a/b/c/d/e/f/g";
     enforce(collectException(mkdir(d)));

--- a/std/functional.d
+++ b/std/functional.d
@@ -909,9 +909,9 @@ template compose(fun...)
 ///
 unittest
 {
-    import std.algorithm: equal, map;
-    import std.array: split;
-    import std.conv: to;
+    import std.algorithm : equal, map;
+    import std.array : split;
+    import std.conv : to;
 
     // First split a string in whitespace-separated tokens and then
     // convert each token into an integer

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -536,8 +536,8 @@ follow this pattern:
 */
 private template optionValidator(A...)
 {
-    import std.typecons: staticIota;
-    import std.format: format;
+    import std.typecons : staticIota;
+    import std.format : format;
 
     enum fmt = "getopt validator: %s (at position %d)";
     enum isReceiver(T) = isPointer!T || (is(T==function)) || (is(T==delegate));

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -20,9 +20,9 @@ unittest
 {
     version(Posix)
     {
-        import core.stdc.stdlib: free;
-        import core.sys.posix.stdlib: setenv;
-        import std.exception: enforce;
+        import core.stdc.stdlib : free;
+        import core.sys.posix.stdlib : setenv;
+        import std.exception : enforce;
 
         void setEnvironment(in char[] name, in char[] value)
         { enforce(setenv(name.tempCString(), value.tempCString(), 1) != -1); }
@@ -30,8 +30,8 @@ unittest
 
     version(Windows)
     {
-        import core.sys.windows.windows: SetEnvironmentVariableW;
-        import std.exception: enforce;
+        import core.sys.windows.windows : SetEnvironmentVariableW;
+        import std.exception : enforce;
 
         void setEnvironment(in char[] name, in char[] value)
         { enforce(SetEnvironmentVariableW(name.tempCStringW(), value.tempCStringW())); }
@@ -149,7 +149,7 @@ auto tempCString(To = char, From)(From str)
     {
         pragma(inline, false);  // because it's rarely called
 
-        import core.exception   : onOutOfMemoryError;
+        import core.exception : onOutOfMemoryError;
         import core.stdc.string : memcpy;
         import core.stdc.stdlib : malloc, realloc;
 

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -76,7 +76,7 @@ else static if (BigDigit.sizeof == long.sizeof)
 else static assert(0, "Unsupported BigDigit size");
 
 private import std.exception : assumeUnique;
-private import std.traits:isIntegral;
+private import std.traits : isIntegral;
 enum BigDigitBits = BigDigit.sizeof*8;
 template maxBigDigits(T) if (isIntegral!T)
 {

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1625,7 +1625,7 @@ unittest {
  */
 real logmdigammaInverse(real y)
 {
-    import std.numeric: findRoot;
+    import std.numeric : findRoot;
     // FIXME: should be returned back to enum.
     // Fix requires CTFEable `log` on non-x86 targets (check both LDC and GDC).
     immutable maxY = logmdigamma(real.min_normal);

--- a/std/json.d
+++ b/std/json.d
@@ -1652,7 +1652,7 @@ EOF";
 // handling of special float values (NaN, Inf, -Inf)
 unittest
 {
-    import std.math      : isNaN, isInfinity;
+    import std.math : isNaN, isInfinity;
     import std.exception : assertThrown;
 
     // expected representations of NaN and Inf

--- a/std/math.d
+++ b/std/math.d
@@ -2614,7 +2614,7 @@ unittest
 
 unittest
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
     void foo() {
         foreach (T; AliasSeq!(real, double, float))
         {
@@ -7466,7 +7466,7 @@ T nextPow2(T)(const T val) if (isFloatingPoint!T)
 
 @safe @nogc pure nothrow unittest
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
 
     foreach (T; AliasSeq!(float, double, real))
     {
@@ -7594,7 +7594,7 @@ T truncPow2(T)(const T val) if (isFloatingPoint!T)
 
 @safe @nogc pure nothrow unittest
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
 
     foreach (T; AliasSeq!(float, double, real))
     {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -494,7 +494,7 @@ public:
     void opAssign(F)(F input)
         if (__traits(compiles, cast(real)input))
     {
-        import std.conv: text;
+        import std.conv : text;
         static if (staticIndexOf!(Unqual!F, float, double, real) >= 0)
             auto value = ToBinary!(Unqual!F)(input);
         else
@@ -527,7 +527,7 @@ public:
     @property F get(F)()
         if (staticIndexOf!(Unqual!F, float, double, real) >= 0)
     {
-        import std.conv: text;
+        import std.conv : text;
 
         ToBinary!F result;
 
@@ -1572,7 +1572,7 @@ unittest
 
 unittest
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
     foreach (T; AliasSeq!(double, float, real))
     {
         {
@@ -2491,7 +2491,7 @@ unittest
 
 unittest
 {
-    import std.conv: text;
+    import std.conv : text;
     string[] s = ["Hello", "brave", "new", "world"];
     string[] t = ["Hello", "new", "world"];
     auto simIter = gapWeightedSimilarityIncremental(s, t, 1.0);
@@ -2621,7 +2621,7 @@ private:
 
     void enforceSize(R)(R range) const
     {
-        import std.conv: text;
+        import std.conv : text;
         enforce(range.length <= size, text(
             "FFT size mismatch.  Expected ", size, ", got ", range.length));
     }

--- a/std/path.d
+++ b/std/path.d
@@ -3914,7 +3914,7 @@ string expandTilde(string inputPath) nothrow
 }
 
 
-version(unittest) import std.process: environment;
+version(unittest) import std.process : environment;
 unittest
 {
     version (Posix)

--- a/std/process.d
+++ b/std/process.d
@@ -355,7 +355,7 @@ private Pid spawnProcessImpl(in char[][] args,
                              in char[] workDir)
     @trusted // TODO: Should be @safe
 {
-    import core.exception: RangeError;
+    import core.exception : RangeError;
     import std.path : isDirSeparator;
     import std.algorithm : any;
     import std.string : toStringz;
@@ -562,7 +562,7 @@ private Pid spawnProcessImpl(in char[] commandLine,
                              in char[] workDir)
     @trusted
 {
-    import core.exception: RangeError;
+    import core.exception : RangeError;
 
     if (commandLine.empty) throw new RangeError("Command line is empty");
 
@@ -1474,7 +1474,7 @@ $(D SIGTERM) signal will be sent.  (This matches the behaviour of the
 $(LINK2 http://pubs.opengroup.org/onlinepubs/9699919799/utilities/kill.html,
 $(D _kill)) shell command.)
 ---
-import core.sys.posix.signal: SIGKILL;
+import core.sys.posix.signal : SIGKILL;
 auto pid = spawnProcess("some_app");
 kill(pid, SIGKILL);
 assert (wait(pid) == -SIGKILL); // Negative return value on POSIX!
@@ -1490,7 +1490,7 @@ void kill(Pid pid)
     version (Windows) kill(pid, 1);
     else version (Posix)
     {
-        import core.sys.posix.signal: SIGTERM;
+        import core.sys.posix.signal : SIGTERM;
         kill(pid, SIGTERM);
     }
 }
@@ -1527,7 +1527,7 @@ unittest // tryWait() and kill()
     }
     else version (Posix)
     {
-        import core.sys.posix.signal: SIGTERM, SIGKILL;
+        import core.sys.posix.signal : SIGTERM, SIGKILL;
         TestScript prog = "while true; do sleep 1; done";
     }
     auto pid = spawnProcess(prog.path);
@@ -3468,7 +3468,7 @@ version (StdDdoc)
     }
     else version (Windows)
     {
-        import core.stdc.stdlib: _exit;
+        import core.stdc.stdlib : _exit;
         _exit(wait(spawnProcess(commandLine)));
     }
     ---
@@ -3492,7 +3492,7 @@ version (StdDdoc)
     else version (Windows)
     {
         spawnProcess(commandLine);
-        import core.stdc.stdlib: _exit;
+        import core.stdc.stdlib : _exit;
         _exit(0);
     }
     ---

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3903,7 +3903,7 @@ pure unittest
 ///
 pure unittest
 {
-    import std.conv: to;
+    import std.conv : to;
 
     int[] a = [ 1, 2, 3 ];
     string[] b = [ "a", "b", "c" ];
@@ -7957,7 +7957,7 @@ if (isInputRange!Range)
     ///
     unittest
     {
-        import std.algorithm: equal;
+        import std.algorithm : equal;
         auto a = assumeSorted([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
         auto p = a.lowerBound(4);
         assert(equal(p, [ 0, 1, 2, 3 ]));
@@ -8001,7 +8001,7 @@ See_Also: STL's $(WEB sgi.com/tech/stl/lower_bound.html,upper_bound).
     ///
     unittest
     {
-        import std.algorithm: equal;
+        import std.algorithm : equal;
         auto a = assumeSorted([ 1, 2, 3, 3, 3, 4, 4, 5, 6 ]);
         auto p = a.upperBound(3);
         assert(equal(p, [4, 4, 5, 6]));
@@ -8064,7 +8064,7 @@ See_Also: STL's $(WEB sgi.com/tech/stl/lower_bound.html,upper_bound).
     ///
     unittest
     {
-        import std.algorithm: equal;
+        import std.algorithm : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
         auto r = a.assumeSorted.equalRange(3);
         assert(equal(r, [ 3, 3, 3 ]));
@@ -8124,7 +8124,7 @@ equalRange). Completes the entire search in $(BIGOH log(n)) time.
     ///
     unittest
     {
-        import std.algorithm: equal;
+        import std.algorithm : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
         auto r = assumeSorted(a).trisect(3);
         assert(equal(r[0], [ 1, 2 ]));

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2160,7 +2160,7 @@ version(unittest)
 void popBack(T)(ref T[] a) @safe pure
 if (isNarrowString!(T[]))
 {
-    import std.utf: strideBack;
+    import std.utf : strideBack;
     assert(a.length, "Attempting to popBack() past the front of an array of " ~ T.stringof);
     a = a[0 .. $ - strideBack(a, $)];
 }

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1092,7 +1092,7 @@ package void replaceFmt(R, Capt, OutR)
         isOutputRange!(OutR, ElementEncodingType!(Capt.String)[]))
 {
     import std.algorithm, std.conv;
-    import std.ascii: isDigit, isAlpha;
+    import std.ascii : isDigit, isAlpha;
     enum State { Normal, Dollar }
     auto state = State.Normal;
     size_t offset;
@@ -1209,7 +1209,7 @@ public R replaceFirst(alias fun, R, RegEx)(R input, RegEx re)
 ///
 unittest
 {
-    import std.conv: to;
+    import std.conv : to;
     string list = "#21 out of 46";
     string newList = replaceFirst!(cap => to!string(to!int(cap.hit)+1))
         (list, regex(`[0-9]+`));
@@ -1577,7 +1577,7 @@ public Splitter!(keepSeparators, Range, RegEx) splitter(
 ///
 unittest
 {
-    import std.algorithm: equal;
+    import std.algorithm : equal;
     auto s1 = ", abc, de,  fg, hi, ";
     assert(equal(splitter(s1, regex(", *")),
         ["", "abc", "de", "fg", "hi", ""]));

--- a/std/socket.d
+++ b/std/socket.d
@@ -2027,7 +2027,7 @@ static if (is(sockaddr_un))
     unittest
     {
         import core.stdc.stdio : remove;
-        import std.file: deleteme;
+        import std.file : deleteme;
 
         immutable ubyte[] data = [1, 2, 3, 4];
         Socket[2] pair;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -756,7 +756,7 @@ Throws: $(D Exception) if the file is not opened or if the call to $(D fflush) f
     {
         // Issue 12349
         static import std.file;
-        import std.exception: assertThrown;
+        import std.exception : assertThrown;
 
         auto deleteme = testFilename();
         auto f = File(deleteme, "w");
@@ -3080,7 +3080,7 @@ unittest
 
 @safe unittest
 {
-    import std.exception: collectException;
+    import std.exception : collectException;
     auto e = collectException({ File f; f.writeln("Hello!"); }());
     assert(e && e.msg == "Attempting to write to closed File");
 }

--- a/std/string.d
+++ b/std/string.d
@@ -1468,7 +1468,7 @@ private ptrdiff_t indexOfAnyNeitherImpl(bool forward, bool any, Char, Char2)(
     }
     else
     {
-        import std.uni: toLower;
+        import std.uni : toLower;
         if (needles.length <= 16 && needles.walkLength(17))
         {
             size_t si = 0;
@@ -2287,7 +2287,7 @@ S capitalize(S)(S input) @trusted pure
     if (isSomeString!S)
 {
     import std.uni : asCapitalized;
-    import std.conv: to;
+    import std.conv : to;
     import std.array;
 
     return input.asCapitalized.array.to!S;
@@ -6356,7 +6356,7 @@ size_t column(Range)(Range str, in size_t tabsize = 8)
     static if (is(Unqual!(ElementEncodingType!Range) == char))
     {
         // decoding needed for chars
-        import std.utf: byDchar;
+        import std.utf : byDchar;
 
         return str.byDchar.column(tabsize);
     }
@@ -6477,7 +6477,7 @@ unittest
 S wrap(S)(S s, in size_t columns = 80, S firstindent = null,
         S indent = null, in size_t tabsize = 8) if (isSomeString!S)
 {
-    import std.uni: isWhite;
+    import std.uni : isWhite;
     typeof(s.dup) result;
     bool inword;
     bool first = true;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2075,7 +2075,7 @@ Returns:
 ///
 unittest
 {
-    import std.exception: assertThrown, assertNotThrown;
+    import std.exception : assertThrown, assertNotThrown;
 
     Nullable!int ni;
     //`get` is implicitly called. Will throw
@@ -2371,7 +2371,7 @@ unittest
 }
 unittest
 {
-    import std.conv: to;
+    import std.conv : to;
     import std.array;
 
     // Bugzilla 10915
@@ -2556,7 +2556,7 @@ Returns:
 ///
 unittest
 {
-    import std.exception: assertThrown, assertNotThrown;
+    import std.exception : assertThrown, assertNotThrown;
 
     Nullable!(int, -1) ni;
     //`get` is implicitly called. Will throw
@@ -2695,7 +2695,7 @@ unittest
 }
 unittest
 {
-    import std.conv: to;
+    import std.conv : to;
 
     // Bugzilla 10915
     Nullable!(int, 1) ni = 1;
@@ -2851,7 +2851,7 @@ Params:
     ///
     unittest
     {
-        import std.exception: assertThrown, assertNotThrown;
+        import std.exception : assertThrown, assertNotThrown;
 
         NullableRef!int nr;
         assert(nr.isNull);
@@ -2877,7 +2877,7 @@ This function is also called for the implicit conversion to $(D T).
     ///
     unittest
     {
-        import std.exception: assertThrown, assertNotThrown;
+        import std.exception : assertThrown, assertNotThrown;
 
         NullableRef!int nr;
         //`get` is implicitly called. Will throw
@@ -2997,7 +2997,7 @@ unittest
 }
 unittest
 {
-    import std.conv: to;
+    import std.conv : to;
 
     // Bugzilla 10915
     NullableRef!int nri;
@@ -3051,7 +3051,7 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
 ///
 unittest
 {
-    import std.math: isNaN;
+    import std.math : isNaN;
 
     static abstract class C
     {
@@ -3131,7 +3131,7 @@ alias WhiteHole(Base) = AutoImplement!(Base, generateAssertTrap, isAbstractFunct
 ///
 unittest
 {
-    import std.exception: assertThrown;
+    import std.exception : assertThrown;
 
     static class C
     {
@@ -5878,8 +5878,8 @@ template TypedefType(T)
 ///
 unittest
 {
-    import std.typecons: Typedef, TypedefType;
-    import std.conv: to;
+    import std.typecons : Typedef, TypedefType;
+    import std.conv : to;
 
     alias MyInt = Typedef!int;
     static assert(is(TypedefType!MyInt == int));

--- a/std/uni.d
+++ b/std/uni.d
@@ -8311,7 +8311,7 @@ unittest
     {
     }
 
-    import std.algorithm.comparison  : equal;
+    import std.algorithm.comparison : equal;
 
     "HELLo"w.asLowerCase.equal("hello"d);
     "HELLo"w.asUpperCase.equal("HELLO"d);
@@ -8516,7 +8516,7 @@ unittest
     {
     }
 
-    import std.algorithm.comparison  : equal;
+    import std.algorithm.comparison : equal;
 
     "HELLo"w.asCapitalized.equal("Hello"d);
     "hElLO"w.asCapitalized.equal("Hello"d);

--- a/std/utf.d
+++ b/std/utf.d
@@ -371,7 +371,7 @@ unittest
 
 unittest // invalid start bytes
 {
-    import std.exception: assertThrown;
+    import std.exception : assertThrown;
     immutable char[] invalidStartBytes = [
         0b1111_1000, // indicating a sequence length of 5
         0b1111_1100, // 6

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -897,7 +897,7 @@ public struct UUID
          */
         @trusted pure nothrow string toString() const
         {
-            import std.exception: assumeUnique;
+            import std.exception : assumeUnique;
             auto result = new char[36];
             toString(result);
             return result.assumeUnique;
@@ -913,7 +913,7 @@ public struct UUID
 
         @safe pure nothrow @nogc unittest
         {
-            import std.meta: AliasSeq;
+            import std.meta : AliasSeq;
             foreach (Char; AliasSeq!(char, wchar, dchar))
             {
                 alias String = immutable(Char)[];
@@ -934,7 +934,7 @@ public struct UUID
 
         pure nothrow @nogc unittest
         {
-            import std.encoding: Char = AsciiChar;
+            import std.encoding : Char = AsciiChar;
             enum  utfstr = "8ab3060e-2cba-4f23-b74c-b52db3bdfb46";
             alias String = immutable(Char)[];
             enum String s = cast(String)utfstr;

--- a/std/zip.d
+++ b/std/zip.d
@@ -38,8 +38,8 @@ void main(string[] args)
 }
 
 // Create and write new zip file.
-import std.file: write;
-import std.string: representation;
+import std.file : write;
+import std.string : representation;
 
 void main()
 {

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -29,8 +29,8 @@
  * -------
  * import std.zlib;
  * import std.stdio;
- * import std.conv: to;
- * import std.algorithm: map;
+ * import std.conv : to;
+ * import std.algorithm : map;
  *
  * UnCompress decmp = new UnCompress;
  * foreach (chunk; stdin.byChunk(4096).map!(x => decmp.uncompress(x)))
@@ -334,7 +334,7 @@ enum HeaderFormat {
 
 class Compress
 {
-    import std.conv: to;
+    import std.conv : to;
 
   private:
     z_stream zs;
@@ -511,7 +511,7 @@ class Compress
 
 class UnCompress
 {
-    import std.conv: to;
+    import std.conv : to;
 
   private:
     z_stream zs;


### PR DESCRIPTION
Having a space before and after the colon for selective imports seems to be an informal rule and has been critized in many PR's. 
I personally prefer import std.range: zip instead of std.range : zip, but the point is to make it a rule and standardize it, so we can automatically check it & no further time is wasted about such nitpicks.

It seems to me that this is can be easily unified and from now on checked with Travis
Command used:

```
sed -E "s/import\s*([^ ]+)\s*:\s*(.*(,|;))/import \1 : \2/" -i **/*.d
```

Disclaimer: Yes the `grep` check in Travis doesn't check all cases, but soon dscanner will catch up and this small loophole will be fixed.

There is also an accomponying [PR](https://github.com/dlang/dlang.org/pull/1316) to dlang.org to update the DStyle.

Ping @joakim-noah @schuetzm 