### PR TITLE
Move allSatisfy, anySatisfy and staticIndexOf to searching category in the quick index table

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -39,12 +39,12 @@
  *           $(LREF staticMap)
  *           $(LREF staticSort)
  * ))
- * $(TR $(TD Alias sequence indexing) $(TD
+ * $(TR $(TD Alias sequence searching) $(TD
+ *           $(LREF allSatisfy)
+ *           $(LREF anySatisfy)
  *           $(LREF staticIndexOf)
  * ))
  * $(TR $(TD Boolean template predicate operators) $(TD
- *           $(LREF allSatisfy)
- *           $(LREF anySatisfy)
  *           $(LREF templateAnd)
  *           $(LREF templateNot)
  *           $(LREF templateOr)


### PR DESCRIPTION
Follow up to #4376 