### PR TITLE
Allmanify Phobos and add CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ install:
 script:
  - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
  # enforce whitespace between statements
- - grep -E "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
+ - grep -nE "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
  # enforce whitespace between colon(:) for import statements (doesn't catch everything)
- - grep 'import [^/,=]*:' **/*.d | grep -vE 'import ([^ ]+) : '; echo $?
+ - grep -n 'import [^/,=]*:' $(find . -name '*.d') | grep -vE 'import ([^ ]+) : '; echo $?
+ # enforce all-man style
+ - grep -nE "(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$"  $(find . -name '*.d'); test $? -eq 1
  # at the moment libdparse has problems to parse some modules (->excludes)
  - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.

--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -115,7 +115,8 @@ alias CURL = void;
 alias curl_socket_t = socket_t;
 
 /// jdrewsen - Would like to get socket error constant from std.socket by it is private atm.
-version(Windows) {
+version(Windows)
+{
   private import core.sys.windows.windows, core.sys.windows.winsock2;
   enum CURL_SOCKET_BAD = SOCKET_ERROR;
 }

--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -1284,7 +1284,8 @@ void gzclearerr (gzFile file);
 
      uint adler = adler32(0L, Z_NULL, 0);
 
-     while (read_buffer(buffer, length) != EOF) {
+     while (read_buffer(buffer, length) != EOF)
+     {
        adler = adler32(adler, buffer, length);
      }
      if (adler != original_adler) error();
@@ -1308,7 +1309,8 @@ uint crc32(uint crc, ubyte* buf, uint len);
 
      uint crc = crc32(0L, Z_NULL, 0);
 
-     while (read_buffer(buffer, length) != EOF) {
+     while (read_buffer(buffer, length) != EOF)
+     {
        crc = crc32(crc, buffer, length);
      }
      if (crc != original_crc) error();

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -923,13 +923,15 @@ private struct Levenshtein(Range, alias equals, CostType = size_t)
         EditOp[] result;
         size_t i = rows - 1, j = cols - 1;
         // restore the path
-        while (i || j) {
+        while (i || j)
+        {
             auto cIns = j == 0 ? CostType.max : matrix(i,j - 1);
             auto cDel = i == 0 ? CostType.max : matrix(i - 1,j);
             auto cSub = i == 0 || j == 0
                 ? CostType.max
                 : matrix(i - 1,j - 1);
-            switch (min_index(cSub, cIns, cDel)) {
+            switch (min_index(cSub, cIns, cDel))
+            {
             case 0:
                 result ~= matrix(i - 1,j - 1) == matrix(i,j)
                     ? EditOp.none
@@ -968,7 +970,8 @@ private:
     void AllocMatrix(size_t r, size_t c) @trusted {
         rows = r;
         cols = c;
-        if (_matrix.length < r * c) {
+        if (_matrix.length < r * c)
+        {
             import core.stdc.stdlib : realloc;
             import core.exception : onOutOfMemoryError;
             auto m = cast(CostType *)realloc(_matrix.ptr, r * c * _matrix[0].sizeof);

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3683,7 +3683,8 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     int[][] w = [ [1, 2], [], [3], [4, 5], [] ];
     static assert(isForwardRange!(typeof(splitter(a, 0))));
 
-    // foreach (x; splitter(a, 0)) {
+    // foreach (x; splitter(a, 0))
+    // {
     //     writeln("[", x, "]");
     // }
     assert(equal(splitter(a, 0), w));

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1154,12 +1154,14 @@ private struct FilterResult(alias pred, Range)
     static assert(isInfinite!(typeof(infinite)));
     static assert(isForwardRange!(typeof(infinite)));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType d;
         auto f = filter!"a & 1"(d);
         assert(equal(f, [1,3,5,7,9]));
 
-        static if (isForwardRange!DummyType) {
+        static if (isForwardRange!DummyType)
+        {
             static assert(isForwardRange!(typeof(f)));
         }
     }
@@ -1416,7 +1418,8 @@ struct Group(alias pred, R) if (isInputRange!R)
         return _current;
     }
 
-    static if (isForwardRange!R) {
+    static if (isForwardRange!R)
+    {
         ///
         @property typeof(this) save() {
             typeof(this) ret = this;
@@ -1451,7 +1454,8 @@ struct Group(alias pred, R) if (isInputRange!R)
                             tuple(4, 3u), tuple(5, 1u) ][]));
     static assert(isForwardRange!(typeof(group(arr))));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType d;
         auto g = group(d);
 
@@ -2480,7 +2484,8 @@ unittest
     // Can't use array() or equal() directly because they fail with transient
     // .front.
     int[] result;
-    foreach (c; rr.joiner()) {
+    foreach (c; rr.joiner())
+    {
         result ~= c;
     }
 
@@ -2525,7 +2530,8 @@ unittest
     // Can't use array() or equal() directly because they fail with transient
     // .front.
     dchar[] result;
-    foreach (c; rr.joiner()) {
+    foreach (c; rr.joiner())
+    {
         result ~= c;
     }
 
@@ -3715,7 +3721,8 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     assert(split.back == "r ");
 
     foreach (DummyType; AllDummyRanges) {  // Bug 4408
-        static if (isRandomAccessRange!DummyType) {
+        static if (isRandomAccessRange!DummyType)
+        {
             static assert(isBidirectionalRange!DummyType);
             DummyType d;
             auto s = splitter(d, 5);
@@ -4369,8 +4376,10 @@ if (isSomeChar!C)
     lines[0] = "line one".dup;
     lines[1] = "line \ttwo".dup;
     lines[2] = "yah            last   line\ryah".dup;
-    foreach (line; lines) {
-       foreach (word; splitter(strip(line))) {
+    foreach (line; lines)
+    {
+       foreach (word; splitter(strip(line)))
+       {
             if (word in dictionary) continue; // Nothing to do
             auto newID = dictionary.length;
             dictionary[to!string(word)] = cast(uint)newID;
@@ -4843,7 +4852,8 @@ private struct UniqResult(alias pred, Range)
         @property bool empty() { return _input.empty; }
     }
 
-    static if (isForwardRange!Range) {
+    static if (isForwardRange!Range)
+    {
         @property typeof(this) save() {
             return typeof(this)(_input.save);
         }
@@ -4865,14 +4875,16 @@ private struct UniqResult(alias pred, Range)
     assert(equal(r, [ 1, 2, 3, 4, 5 ][]));
     assert(equal(retro(r), retro([ 1, 2, 3, 4, 5 ][])));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType d;
         auto u = uniq(d);
         assert(equal(u, [1,2,3,4,5,6,7,8,9,10]));
 
         static assert(d.rt == RangeType.Input || isForwardRange!(typeof(u)));
 
-        static if (d.rt >= RangeType.Bidirectional) {
+        static if (d.rt >= RangeType.Bidirectional)
+        {
             assert(equal(retro(u), [10,9,8,7,6,5,4,3,2,1]));
         }
     }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2396,7 +2396,8 @@ Params:
 */
 void swapAt(R)(auto ref R r, size_t i1, size_t i2)
 {
-    static if (is(typeof(&r.swapAt))) {
+    static if (is(typeof(&r.swapAt)))
+    {
         r.swapAt(i1, i2);
     }
     else static if (is(typeof(&r[i1])))

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -305,7 +305,8 @@ is ignored.
         import std.algorithm.comparison : equal;
         ptrdiff_t virtual_begin = needle.length - offset - portion;
         ptrdiff_t ignore = 0;
-        if (virtual_begin < 0) {
+        if (virtual_begin < 0)
+        {
             ignore = -virtual_begin;
             virtual_begin = 0;
         }
@@ -2173,7 +2174,8 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find(a, b) == [ 1, 2, 3, 4, 5 ]);
     assert(find(b, a).empty);
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType d;
         auto findRes = find(d, 5);
         assert(equal(findRes, [5,6,7,8,9,10]));
@@ -2206,7 +2208,8 @@ Range1 find(Range1, alias pred, Range2)(
         "(.gnu.linkonce.tmain+0x74): In function `main' undefined reference"~
         " to `_Dmain':";
     string[] ns = ["libphobos", "function", " undefined", "`", ":"];
-    foreach (n ; ns) {
+    foreach (n ; ns)
+    {
         auto p = find(h, boyerMooreFinder(n));
         assert(!p.empty);
     }

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -998,7 +998,8 @@ private size_t getPivot(alias less, Range)(Range r)
                             ((cast(uint) (pred(r[0], r[len - 1]))) << 1) |
                             (cast(uint) (pred(r[mid], r[len - 1])));
 
-    switch (result) {
+    switch (result)
+    {
         case 0b001:
             r.swapAt(0, len - 1);
             r.swapAt(0, mid);
@@ -1070,7 +1071,8 @@ private void optimisticInsertionSort(alias less, Range)(Range r)
 
     auto rnd = Random(1);
     auto a = new int[uniform(100, 200, rnd)];
-    foreach (ref e; a) {
+    foreach (ref e; a)
+    {
         e = uniform(-100, 100, rnd);
     }
 
@@ -1216,7 +1218,8 @@ unittest
     // sort using delegate
     auto a = new int[100];
     auto rnd = Random(unpredictableSeed);
-    foreach (ref e; a) {
+    foreach (ref e; a)
+    {
         e = uniform(-100, 100, rnd);
     }
 
@@ -1231,7 +1234,8 @@ unittest
     assert(isSorted!("a < b")(a));
 
     // sort using function; all elements equal
-    foreach (ref e; a) {
+    foreach (ref e; a)
+    {
         e = 5;
     }
     static bool less(int a, int b) { return a < b; }
@@ -2223,7 +2227,8 @@ unittest
 
     static double entropy(double[] probs) {
         double result = 0;
-        foreach (p; probs) {
+        foreach (p; probs)
+        {
             if (!p) continue;
             //enforce(p > 0 && p <= 1, "Wrong probability passed to entropy");
             result -= p * log2(p);
@@ -2256,7 +2261,8 @@ unittest
 
     static double entropy(double[] probs) {
         double result = 0;
-        foreach (p; probs) {
+        foreach (p; probs)
+        {
             if (!p) continue;
             //enforce(p > 0 && p <= 1, "Wrong probability passed to entropy");
             result -= p * log2(p);
@@ -2799,7 +2805,8 @@ bool nextPermutation(alias less="a < b", BidirectionalRange)
             break;
     }
 
-    if (i.empty) {
+    if (i.empty)
+    {
         // Entire range is decreasing: it's lexicographically the greatest. So
         // wrap it around.
         range.reverse();

--- a/std/array.d
+++ b/std/array.d
@@ -2966,7 +2966,8 @@ if (isDynamicArray!A)
 }
 
 ///
-unittest{
+unittest
+{
     auto app = appender!string();
     string b = "abcdefg";
     foreach (char c; b)

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -719,7 +719,9 @@ public:
         Warning: Casting to/from $(D const) or $(D immutable) may break type
         system guarantees. Use with care.
      */
-    T opCast(T)() pure nothrow @nogc const if (is(Unqual!T == BigInt)) {
+    T opCast(T)() pure nothrow @nogc const
+    if (is(Unqual!T == BigInt))
+    {
         return this;
     }
 

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -223,10 +223,13 @@ public:
         }
         else static if (op=="*")
         {
-            if (y == 0) {
+            if (y == 0)
+            {
                 sign = false;
                 data = 0UL;
-            } else {
+            }
+            else
+            {
                 sign = ( sign != (y<0) );
                 data = BigUint.mulInt(data, u);
             }
@@ -1095,7 +1098,8 @@ Unsigned!T absUnsign(T)(T x) if (isIntegral!T)
 }
 
 nothrow pure
-unittest {
+unittest
+{
     BigInt a, b;
     a = 1;
     b = 2;
@@ -1103,7 +1107,8 @@ unittest {
 }
 
 nothrow pure
-unittest {
+unittest
+{
     long a;
     BigInt b;
     auto c = a + b;
@@ -1111,7 +1116,8 @@ unittest {
 }
 
 nothrow pure
-unittest {
+unittest
+{
     BigInt x = 1, y = 2;
     assert(x <  y);
     assert(x <= y);
@@ -1134,7 +1140,8 @@ unittest {
     assert(incr == BigInt(1));
 }
 
-unittest {
+unittest
+{
     // Radix conversion
     assert( toDecimalString(BigInt("-1_234_567_890_123_456_789"))
         == "-1234567890123456789");

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -311,7 +311,9 @@ The example above creates a tagged reference to an Object in the struct A. This 
 as $(D taggedPointer), except the first argument which must be a class type instead of a pointer type.
 */
 
-template taggedClassRef(T, string name, Ts...) if (is(T == class)) {
+template taggedClassRef(T, string name, Ts...)
+if (is(T == class))
+{
     enum taggedClassRef = createTaggedReference!(T, 8, name, Ts).result;
 }
 

--- a/std/complex.d
+++ b/std/complex.d
@@ -807,7 +807,8 @@ Complex!T cos(T)(Complex!T z)  @safe pure nothrow @nogc
 }
 
 ///
-unittest{
+unittest
+{
     import std.math;
     import std.complex;
     assert(cos(complex(0.0)) == 1.0);

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1716,11 +1716,16 @@ void yield(T)(T value)
 }
 
 
-version (Win64) {
+version (Win64)
+{
     // fibers are broken on Win64
-} else version (Win32) {
+}
+else version (Win32)
+{
     // fibers are broken in Win32 under server 2012: bug 13821
-} else unittest {
+}
+else unittest
+{
     import core.exception;
     import std.exception;
 

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1291,7 +1291,8 @@ unittest
 }
 
 // Test issue 11194
-unittest {
+unittest
+{
     static struct S {
         int i = 1337;
         void* p;

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -1051,6 +1051,7 @@ Complexity: $(BIGOH n)
     }
 }
 
-unittest {
+unittest
+{
     TotalContainer!int test;
 }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -2001,7 +2001,8 @@ pure unittest
     assert(array(rt4[]) == ["hello"]);
 }
 
-unittest {
+unittest
+{
     import std.conv : to;
 
     auto rt1 = redBlackTree!string();

--- a/std/cstream.d
+++ b/std/cstream.d
@@ -148,7 +148,8 @@ class CFile : Stream {
   }
 
   // run a few tests
-  unittest {
+  unittest
+  {
     import std.file : deleteme;
     import std.internal.cstring : tempCString;
 
@@ -203,7 +204,8 @@ class CFile : Stream {
     file.writeLine("That was blank");
     file.position = 0;
     char[][] lines;
-    foreach (char[] line; file) {
+    foreach (char[] line; file)
+    {
       lines ~= line.dup;
     }
     assert( lines.length == 5 );
@@ -213,7 +215,8 @@ class CFile : Stream {
     assert( lines[3] == "That was blank");
     file.position = 0;
     lines = new char[][5];
-    foreach (ulong n, char[] line; file) {
+    foreach (ulong n, char[] line; file)
+    {
       lines[cast(size_t)(n-1)] = line.dup;
     }
     assert( lines[0] == "Testing stream.d:");

--- a/std/csv.d
+++ b/std/csv.d
@@ -614,7 +614,8 @@ unittest
        (str, ["b","a"], ',', '"');
 
     auto ans2 = [["Hello","65"],["World","123"]];
-    foreach (record; records2) {
+    foreach (record; records2)
+    {
         assert(equal(record, ans2.front));
         ans2.popFront();
     }
@@ -624,7 +625,8 @@ unittest
        (str, ["a","b","c","d"], ',', '"');
 
     ans2 = [["Joe","Carpenter"],["Fred","Fly"]];
-    foreach (record; records2) {
+    foreach (record; records2)
+    {
         assert(equal(record, ans2.front));
         ans2.popFront();
     }
@@ -1161,7 +1163,8 @@ public:
         // to eliminate so many tokens. This calculates
         // how many will be skipped to get to the next header column
         size_t normalizer;
-        foreach (ref c; _popCount) {
+        foreach (ref c; _popCount)
+        {
             static if (ErrorLevel == Malformed.ignore)
             {
                 // If we are not throwing exceptions
@@ -1244,7 +1247,9 @@ public:
                                   "previous length of %s.", _input.row,
                                   _input.col, _input.rowLength));
             return;
-        } else {
+        }
+        else
+        {
             static if (ErrorLevel == Malformed.throwException)
                 if (_input.rowLength != 0)
                     if (_input.col > _input.rowLength)
@@ -1314,7 +1319,8 @@ public:
         if (!_popCount.empty)
             _popCount.popFront();
 
-        if (skipNum == size_t.max) {
+        if (skipNum == size_t.max)
+        {
             while (!recordEnd())
                 prime(1);
             _empty = true;

--- a/std/csv.d
+++ b/std/csv.d
@@ -828,7 +828,8 @@ public:
      * auto records = CsvReader!(int,Malformed.ignore,string,char,string[])
      *       (str, ';', '^');
      *
-     * foreach (record; records) {
+     * foreach (record; records)
+     * {
      *    assert(equal(record, ans));
      * }
      * -------
@@ -852,7 +853,8 @@ public:
      *       (str, ["high","low"], ';', '^');
      *
      * int[] ans = [76,22];
-     * foreach (record; records) {
+     * foreach (record; records)
+     * {
      *    assert(equal(record, ans));
      * }
      * -------

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -30314,7 +30314,8 @@ private:
                     throw new DateTimeException(format("Both timezone files %s and %s do not exist.",
                         combinedFile, indexFile));
 
-                foreach (Unused; 0 .. indexEntries) {
+                foreach (Unused; 0 .. indexEntries)
+                {
                     string tzName = to!string(readVal!(char[])(tzFile, 40).ptr);
                     uint tzOffset = readVal!uint(tzFile);
                     readVal!(uint[])(tzFile, 2);

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -131,7 +131,8 @@ if (Targets.length >= 1 && !allSatisfy!(isMutable, Targets))
     alias implementsInterface = .implementsInterface!(Source, staticMap!(Unqual, Targets));
 }
 
-unittest {
+unittest
+{
     interface Foo {
         void foo();
     }

--- a/std/format.d
+++ b/std/format.d
@@ -4884,7 +4884,8 @@ private TypeInfo primitiveTypeInfo(Mangle m)
 {
     // BUG: should fix this in static this() to avoid double checked locking bug
     __gshared TypeInfo[Mangle] dic;
-    if (!dic.length) {
+    if (!dic.length)
+    {
         dic = [
             Mangle.Tvoid : typeid(void),
             Mangle.Tbool : typeid(bool),

--- a/std/functional.d
+++ b/std/functional.d
@@ -373,7 +373,8 @@ private uint _ctfeMatchBinary(string fun, string name1, string name2)
     return fun.length == 0;
 }
 
-unittest {
+unittest
+{
 
     static assert(!_ctfeMatchBinary("sqrt(ё)", "ё", "b"));
     static assert(!_ctfeMatchBinary("ё.sqrt", "ё", "b"));
@@ -1272,7 +1273,8 @@ auto toDelegate(F)(auto ref F fp) if (isCallable!(F))
     }
 }
 
-unittest {
+unittest
+{
     static int inc(ref uint num) {
         num++;
         return 8675309;

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1123,7 +1123,8 @@ T intpow(T)(T x, ulong n) pure nothrow @safe
 
     default:
         p = 1;
-        while (1){
+        while (1)
+        {
             if (n & 1)
                 p *= x;
             n >>= 1;

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -262,7 +262,8 @@ unittest
    It is defined in this way to allow cache-efficient multiplication.
    This function is equivalent to:
     ----
-    for (size_t i = 0; i< right.length; ++i) {
+    for (size_t i = 0; i< right.length; ++i)
+    {
         dest[left.length + i] = multibyteMulAdd(dest[i..left.length+i],
                 left, right[i], 0);
     }

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -60,7 +60,8 @@ nothrow:
   (b) compiler bugs prevent the use of .ptr when a frame pointer is used.
 */
 
-version(D_InlineAsm_X86) {
+version(D_InlineAsm_X86)
+{
 
 private:
 
@@ -72,12 +73,15 @@ private:
 string indexedLoopUnroll(int n, string s) pure @safe
 {
     string u;
-    for (int i = 0; i<n; ++i) {
+    for (int i = 0; i<n; ++i)
+    {
         string nstr= (i>9 ? ""~ cast(char)('0'+i/10) : "") ~ cast(char)('0' + i%10);
 
         int last = 0;
-        for (int j = 0; j<s.length; ++j) {
-            if (s[j]=='@') {
+        for (int j = 0; j<s.length; ++j)
+        {
+            if (s[j]=='@')
+            {
                 u ~= s[last..j] ~ nstr;
                 last = j+1;
             }
@@ -203,7 +207,8 @@ unittest
     assert(a[11]==0);
     for (int i=0; i<10; ++i) if (i!=5) assert(a[i]==0);
 
-    for (int q=3; q<36;++q) {
+    for (int q=3; q<36;++q)
+    {
         for (int i=0; i<a.length; ++i)
         {
             a[i]=b[i]=c[i]=0;
@@ -741,9 +746,12 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
     // ESI = src
 
     enum string OP = (op=='+')? "add" : "sub";
-    version(D_PIC) {
+    version(D_PIC)
+    {
         enum { zero = 0 }
-    } else {
+    }
+    else
+    {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
         __gshared int zero = 0;
@@ -804,7 +812,8 @@ unittest
    It is defined in this way to allow cache-efficient multiplication.
    This function is equivalent to:
     ----
-    for (int i = 0; i< right.length; ++i) {
+    for (int i = 0; i< right.length; ++i)
+    {
         dest[left.length + i] = multibyteMulAdd(dest[i..left.length+i],
                 left, right[i], 0);
     }
@@ -821,9 +830,12 @@ void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
     // ESI = end of left. never changes
     // [ESP] = M = right[i] = multiplier for this pass through the loop.
     // right.length is changed into dest.ptr+dest.length
-    version(D_PIC) {
+    version(D_PIC)
+    {
         enum { zero = 0 }
-    } else {
+    }
+    else
+    {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
         __gshared int zero = 0;
@@ -1070,7 +1082,8 @@ unittest
 
 void multibyteTriangleAccumulateD(uint[] dest, uint[] x) pure
 {
-    for (int i = 0; i < x.length-3; ++i) {
+    for (int i = 0; i < x.length-3; ++i)
+    {
         dest[i+x.length] = multibyteMulAdd!('+')(
              dest[i+i+1 .. i+x.length], x[i+1..$], x[i], 0);
     }
@@ -1101,9 +1114,12 @@ void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure
     // ESI = end of src. never changes
     // [ESP] = M = src[i] = multiplier for this pass through the loop.
     // dest.length is changed into dest.ptr+dest.length
-    version(D_PIC) {
+    version(D_PIC)
+    {
         enum { zero = 0 }
-    } else {
+    }
+    else
+    {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
         __gshared int zero = 0;
@@ -1242,7 +1258,8 @@ unittest
 
 void multibyteSquare(BigDigit[] result, const BigDigit [] x) pure
 {
-    if (x.length < 4) {
+    if (x.length < 4)
+    {
         // Special cases, not worth doing triangular.
         result[x.length] = multibyteMul(result[0..x.length], x, x[0], 0);
         multibyteMultiplyAccumulate(result[1..$], x, x[1..$]);
@@ -1259,7 +1276,8 @@ void multibyteSquare(BigDigit[] result, const BigDigit [] x) pure
     multibyteAddDiagonalSquares(result, x);
 }
 
-version(BignumPerformanceTest) {
+version(BignumPerformanceTest)
+{
 import core.stdc.stdio;
 int clock() { asm { push EBX; xor EAX, EAX; cpuid; pop EBX; rdtsc; } }
 

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -124,7 +124,8 @@ real erfc(real a)
 
     real z = -a * a;
 
-    if (z < -MAXLOG){
+    if (z < -MAXLOG)
+    {
 //    mtherr( "erfcl", UNDERFLOW );
         if (a < 0) return 2.0;
         else return 0.0;
@@ -141,7 +142,8 @@ real erfc(real a)
     if (a < 0.0L)
         y = 2.0L - y;
 
-    if (y == 0.0) {
+    if (y == 0.0)
+    {
 //    mtherr( "erfcl", UNDERFLOW );
         if (a < 0) return 2.0;
         else return 0.0;
@@ -161,9 +163,12 @@ real erfce(real x)
 {
     real y = 1.0/x;
 
-    if (x < 8.0) {
+    if (x < 8.0)
+    {
         return rationalPoly( y, P, Q);
-    } else {
+    }
+    else
+    {
         return y * rationalPoly(y*y, R, S);
     }
 }
@@ -204,7 +209,8 @@ real erf(real x)
     return x * rationalPoly(z, T, U);
 }
 
-unittest {
+unittest
+{
    // High resolution test points.
     enum real erfc0_250 = 0.723663330078125 + 1.0279753638067014931732235184287934646022E-5;
     enum real erfc0_375 = 0.5958709716796875 + 1.2118885490201676174914080878232469565953E-5;
@@ -283,7 +289,8 @@ real expx2(real x, int sign)
     real u = m * m;
     real u1 = 2 * m * f  +  f * f;
 
-    if (sign < 0) {
+    if (sign < 0)
+    {
         u = -u;
         u1 = -u1;
     }
@@ -325,7 +332,8 @@ real normalDistributionImpl(real a)
 
     if ( z < 1.0 )
         return 0.5L + 0.5L * erf(x);
-    else {
+    else
+    {
         real y = 0.5L * erfce(z);
         /* Multiply by exp(-x^2 / 2)  */
         z = expx2(a, -1);
@@ -336,7 +344,8 @@ real normalDistributionImpl(real a)
     }
 }
 
-unittest {
+unittest
+{
 assert(fabs(normalDistributionImpl(1L) - (0.841344746068543))< 0.0000000000000005);
 assert(isIdentical(normalDistributionImpl(NaN(0x325)), NaN(0x325)));
 }
@@ -420,14 +429,16 @@ static immutable real[8] Q3 =
     }
     int code = 1;
     real y = p;
-    if ( y > (1.0L - EXP_2) ) {
+    if ( y > (1.0L - EXP_2) )
+    {
         y = 1.0L - y;
         code = 0;
     }
 
     real x, z, y2, x0, x1;
 
-    if ( y > EXP_2 ) {
+    if ( y > EXP_2 )
+    {
         y = y - 0.5L;
         y2 = y * y;
         x = y + y * (y2 * rationalPoly( y2, P0, Q0));
@@ -437,22 +448,29 @@ static immutable real[8] Q3 =
     x = sqrt( -2.0L * log(y) );
     x0 = x - log(x)/x;
     z = 1.0L/x;
-    if ( x < 8.0L ) {
+    if ( x < 8.0L )
+    {
         x1 = z * rationalPoly( z, P1, Q1);
-    } else if ( x < 32.0L ) {
+    }
+    else if ( x < 32.0L )
+    {
         x1 = z * rationalPoly( z, P2, Q2);
-    } else {
+    }
+    else
+    {
         x1 = z * rationalPoly( z, P3, Q3);
     }
     x = x0 - x1;
-    if ( code != 0 ) {
+    if ( code != 0 )
+    {
         x = -x;
     }
     return x;
 }
 
 
-unittest {
+unittest
+{
     // TODO: Use verified test points.
     // The values below are from Excel 2003.
     assert(fabs(normalDistributionInvImpl(0.001) - (-3.09023230616779))< 0.00000000000005);

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -102,26 +102,32 @@ real gammaStirling(real x)
 
     real w = 1.0L/x;
     real y = exp(x);
-    if ( x > 1024.0L ) {
+    if ( x > 1024.0L )
+    {
         // For large x, use rational coefficients from the analytical expansion.
         w = poly(w, LargeStirlingCoeffs);
         // Avoid overflow in pow()
         real v = pow( x, 0.5L * x - 0.25L );
         y = v * (v / y);
     }
-    else {
+    else
+    {
         w = 1.0L + w * poly( w, SmallStirlingCoeffs);
-        static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble) {
+        static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
+        {
             // Avoid overflow in pow() for 64-bit reals
-            if (x > 143.0) {
+            if (x > 143.0)
+            {
                 real v = pow( x, 0.5 * x - 0.25 );
                 y = v * (v / y);
             }
-            else {
+            else
+            {
                 y = pow( x, x - 0.5 ) / y;
             }
         }
-        else {
+        else
+        {
             y = pow( x, x - 0.5L ) / y;
         }
     }
@@ -291,12 +297,14 @@ real gamma(real x)
 
     q = fabs(x);
 
-    if ( q > 13.0L )    {
+    if ( q > 13.0L )
+    {
         // Large arguments are handled by Stirling's
         // formula. Large negative arguments are made positive using
         // the reflection formula.
 
-        if ( x < 0.0L ) {
+        if ( x < 0.0L )
+        {
             if (x < -1/real.epsilon)
             {
                 // Large negatives lose all precision
@@ -310,7 +318,8 @@ real gamma(real x)
             if ( (intpart & 1) == 0 )
                 sgngam = -1;
             z = q - p;
-            if ( z > 0.5L ) {
+            if ( z > 0.5L )
+            {
                 p += 1.0L;
                 z = q - p;
             }
@@ -318,7 +327,9 @@ real gamma(real x)
             z = fabs(z) * gammaStirling(q);
             if ( z <= PI/real.max ) return sgngam * real.infinity;
             return sgngam * PI/z;
-        } else {
+        }
+        else
+        {
             return gammaStirling(x);
         }
     }
@@ -328,30 +339,38 @@ real gamma(real x)
     // interval (2,3).
 
     z = 1.0L;
-    while ( x >= 3.0L ) {
+    while ( x >= 3.0L )
+    {
         x -= 1.0L;
         z *= x;
     }
 
-    while ( x < -0.03125L ) {
+    while ( x < -0.03125L )
+    {
         z /= x;
         x += 1.0L;
     }
 
-    if ( x <= 0.03125L ) {
+    if ( x <= 0.03125L )
+    {
         if ( x == 0.0L )
             return real.nan;
-        else {
-            if ( x < 0.0L ) {
+        else
+        {
+            if ( x < 0.0L )
+            {
                 x = -x;
                 return z / (x * poly( x, GammaSmallNegCoeffs ));
-            } else {
+            }
+            else
+            {
                 return z / (x * poly( x, GammaSmallCoeffs ));
             }
         }
     }
 
-    while ( x < 2.0L ) {
+    while ( x < 2.0L )
+    {
         z /= x;
         x += 1.0L;
     }
@@ -361,10 +380,12 @@ real gamma(real x)
     return z * poly( x, GammaNumeratorCoeffs ) / poly( x, GammaDenominatorCoeffs );
 }
 
-unittest {
+unittest
+{
     // gamma(n) = factorial(n-1) if n is an integer.
     real fact = 1.0L;
-    for (int i=1; fact<real.max; ++i) {
+    for (int i=1; fact<real.max; ++i)
+    {
         // Require exact equality for small factorials
         if (i<14) assert(gamma(i*1.0L) == fact);
         assert(feqrel(gamma(i*1.0L), fact) >= real.mant_dig-15);
@@ -441,7 +462,8 @@ real logGamma(real x)
         if ( (intpart & 1) == 0 )
             sgngam = -1;
         z = q - p;
-        if ( z > 0.5L ) {
+        if ( z > 0.5L )
+        {
             p += 1.0L;
             z = p - q;
         }
@@ -458,12 +480,14 @@ real logGamma(real x)
         z = 1.0L;
         nx = floor( x +  0.5L );
         f = x - nx;
-        while ( x >= 3.0L ) {
+        while ( x >= 3.0L )
+        {
             nx -= 1.0L;
             x = nx + f;
             z *= x;
         }
-        while ( x < 2.0L ) {
+        while ( x < 2.0L )
+        {
             if ( fabs(x) <= 0.03125 )
             {
                 if ( x == 0.0L )
@@ -500,7 +524,8 @@ real logGamma(real x)
     return q ;
 }
 
-unittest {
+unittest
+{
     assert(isIdentical(logGamma(NaN(0xDEF)), NaN(0xDEF)));
     assert(logGamma(real.infinity) == real.infinity);
     assert(logGamma(-1.0) == real.infinity);
@@ -531,9 +556,11 @@ unittest {
     -3.5L,  -1.30902099609375L  + 1.43111007079536392848E-5L, 1.38887092635952890151E0L
     ];
    // TODO: test derivatives as well.
-    for (int i=0; i<testpoints.length; i+=3) {
+    for (int i=0; i<testpoints.length; i+=3)
+    {
         assert( feqrel(logGamma(testpoints[i]), testpoints[i+1]) > real.mant_dig-5);
-        if (testpoints[i]<MAXGAMMA) {
+        if (testpoints[i]<MAXGAMMA)
+        {
             assert( feqrel(log(fabs(gamma(testpoints[i]))), testpoints[i+1]) > real.mant_dig-5);
         }
     }
@@ -548,11 +575,13 @@ unittest {
 
 
 private {
-static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended) {
+static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
+{
     enum real MAXLOG = 0x1.62e42fefa39ef358p+13L;  // log(real.max)
     enum real MINLOG = -0x1.6436716d5406e6d8p+13L; // log(real.min_normal*real.epsilon) = log(smallest denormal)
 }
-else static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble) {
+else static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
+{
     enum real MAXLOG = 0x1.62e42fefa39efp+9L;  // log(real.max)
     enum real MINLOG = -0x1.74385446d71c3p+9L; // log(real.min_normal*real.epsilon) = log(smallest denormal)
 }
@@ -591,13 +620,15 @@ real betaIncomplete(real aa, real bb, real xx )
          if ( isNaN(bb) ) return bb;
          return real.nan; // domain error
     }
-    if (!(xx>0 && xx<1.0)) {
+    if (!(xx>0 && xx<1.0))
+    {
         if (isNaN(xx)) return xx;
         if ( xx == 0.0L ) return 0.0;
         if ( xx == 1.0L )  return 1.0;
         return real.nan; // domain error
     }
-    if ( (bb * xx) <= 1.0L && xx <= 0.95L)   {
+    if ( (bb * xx) <= 1.0L && xx <= 0.95L)
+    {
         return betaDistPowerSeries(aa, bb, xx);
     }
     real x;
@@ -607,21 +638,25 @@ real betaIncomplete(real aa, real bb, real xx )
     int flag = 0;
 
     /* Reverse a and b if x is greater than the mean. */
-    if ( xx > (aa/(aa+bb)) ) {
+    if ( xx > (aa/(aa+bb)) )
+    {
         // here x > aa/(aa+bb) and (bb*x>1 or x>0.95)
         flag = 1;
         a = bb;
         b = aa;
         xc = xx;
         x = 1.0L - xx;
-    } else {
+    }
+    else
+    {
         a = aa;
         b = bb;
         xc = 1.0L - xx;
         x = xx;
     }
 
-    if ( flag == 1 && (b * x) <= 1.0L && x <= 0.95L) {
+    if ( flag == 1 && (b * x) <= 1.0L && x <= 0.95L)
+    {
         // here xx > aa/(aa+bb) and  ((bb*xx>1) or xx>0.95) and (aa*(1-xx)<=1) and xx > 0.05
         return 1.0 - betaDistPowerSeries(a, b, x); // note loss of precision
     }
@@ -631,9 +666,12 @@ real betaIncomplete(real aa, real bb, real xx )
     // One is for x * (a+b+2) < (a+1),
     // the other is for x * (a+b+2) > (a+1).
     real y = x * (a+b-2.0L) - (a-1.0L);
-    if ( y < 0.0L ) {
+    if ( y < 0.0L )
+    {
         w = betaDistExpansion1( a, b, x );
-    } else {
+    }
+    else
+    {
         w = betaDistExpansion2( a, b, x ) / xc;
     }
 
@@ -643,13 +681,16 @@ real betaIncomplete(real aa, real bb, real xx )
 
     y = a * log(x);
     real t = b * log(xc);
-    if ( (a+b) < MAXGAMMA && fabs(y) < MAXLOG && fabs(t) < MAXLOG ) {
+    if ( (a+b) < MAXGAMMA && fabs(y) < MAXLOG && fabs(t) < MAXLOG )
+    {
         t = pow(xc,b);
         t *= pow(x,a);
         t /= a;
         t *= w;
         t *= gamma(a+b) / (gamma(a) * gamma(b));
-    } else {
+    }
+    else
+    {
         /* Resort to logarithms.  */
         y += t + logGamma(a+b) - logGamma(a) - logGamma(b);
         y += log(w/a);
@@ -658,16 +699,21 @@ real betaIncomplete(real aa, real bb, real xx )
 /+
         // There seems to be a bug in Cephes at this point.
         // Problems occur for y > MAXLOG, not y < MINLOG.
-        if ( y < MINLOG ) {
+        if ( y < MINLOG )
+        {
             t = 0.0L;
-        } else {
+        }
+        else
+        {
             t = exp(y);
         }
 +/
     }
-    if ( flag == 1 ) {
+    if ( flag == 1 )
+    {
 /+   // CEPHES includes this code, but I think it is erroneous.
-        if ( t <= real.epsilon ) {
+        if ( t <= real.epsilon )
+        {
             t = 1.0L - real.epsilon;
         } else
 +/
@@ -700,7 +746,8 @@ real betaIncompleteInv(real aa, real bb, real yy0 )
     yl = 0.0L;
     x1 = 1.0L;
     yh = 1.0L;
-    if ( aa <= 1.0L || bb <= 1.0L ) {
+    if ( aa <= 1.0L || bb <= 1.0L )
+    {
         dithresh = 1.0e-7L;
         rflg = 0;
         a = aa;
@@ -710,7 +757,9 @@ real betaIncompleteInv(real aa, real bb, real yy0 )
         y = betaIncomplete( a, b, x );
         nflg = 0;
         goto ihalve;
-    } else {
+    }
+    else
+    {
         nflg = 0;
         dithresh = 1.0e-4L;
     }
@@ -719,13 +768,16 @@ real betaIncompleteInv(real aa, real bb, real yy0 )
 
     yp = -normalDistributionInvImpl( yy0 );
 
-    if ( yy0 > 0.5L ) {
+    if ( yy0 > 0.5L )
+    {
         rflg = 1;
         a = bb;
         b = aa;
         y0 = 1.0L - yy0;
         yp = -yp;
-    } else {
+    }
+    else
+    {
         rflg = 0;
         a = aa;
         b = bb;
@@ -738,7 +790,8 @@ real betaIncompleteInv(real aa, real bb, real yy0 )
         - ( 1.0L/(2.0L * b - 1.0L) - 1.0L/(2.0L * a - 1.0L) )
         * (lgm + (5.0L/6.0L) - 2.0L/(3.0L * x));
     d = 2.0L * d;
-    if ( d < MINLOG ) {
+    if ( d < MINLOG )
+    {
         x = 1.0L;
         goto under;
     }
@@ -753,13 +806,17 @@ ihalve:
 
     dir = 0;
     di = 0.5L;
-    for ( i=0; i<400; i++ ) {
-        if ( i != 0 ) {
+    for ( i=0; i<400; i++ )
+    {
+        if ( i != 0 )
+        {
             x = x0  +  di * (x1 - x0);
-            if ( x == 1.0L ) {
+            if ( x == 1.0L )
+            {
                 x = 1.0L - real.epsilon;
             }
-            if ( x == 0.0L ) {
+            if ( x == 0.0L )
+            {
                 di = 0.5;
                 x = x0  +  di * (x1 - x0);
                 if ( x == 0.0 )
@@ -773,10 +830,12 @@ ihalve:
             if ( fabs(yp) < dithresh )
                 goto newt;
         }
-        if ( y < y0 ) {
+        if ( y < y0 )
+        {
             x0 = x;
             yl = y;
-            if ( dir < 0 ) {
+            if ( dir < 0 )
+            {
                 dir = 0;
                 di = 0.5L;
             } else if ( dir > 3 )
@@ -786,13 +845,17 @@ ihalve:
             else
                 di = (y0 - y)/(yh - yl);
             dir += 1;
-            if ( x0 > 0.95L ) {
-                if ( rflg == 1 ) {
+            if ( x0 > 0.95L )
+            {
+                if ( rflg == 1 )
+                {
                     rflg = 0;
                     a = aa;
                     b = bb;
                     y0 = yy0;
-                } else {
+                }
+                else
+                {
                     rflg = 1;
                     a = bb;
                     b = aa;
@@ -806,14 +869,18 @@ ihalve:
                 yh = 1.0;
                 goto ihalve;
             }
-        } else {
+        }
+        else
+        {
             x1 = x;
-            if ( rflg == 1 && x1 < real.epsilon ) {
+            if ( rflg == 1 && x1 < real.epsilon )
+            {
                 x = 0.0L;
                 goto done;
             }
             yh = y;
-            if ( dir > 0 ) {
+            if ( dir > 0 )
+            {
                 dir = 0;
                 di = 0.5L;
             }
@@ -826,12 +893,14 @@ ihalve:
             dir -= 1;
             }
         }
-    if ( x0 >= 1.0L ) {
+    if ( x0 >= 1.0L )
+    {
         // partial loss of precision
         x = 1.0L - real.epsilon;
         goto done;
     }
-    if ( x <= 0.0L ) {
+    if ( x <= 0.0L )
+    {
 under:
         // underflow has occurred
         x = real.min_normal * real.min_normal;
@@ -840,26 +909,35 @@ under:
 
 newt:
 
-    if ( nflg ) {
+    if ( nflg )
+    {
         goto done;
     }
     nflg = 1;
     lgm = logGamma(a+b) - logGamma(a) - logGamma(b);
 
-    for ( i=0; i<15; i++ ) {
+    for ( i=0; i<15; i++ )
+    {
         /* Compute the function at this point. */
         if ( i != 0 )
             y = betaIncomplete(a,b,x);
-        if ( y < yl ) {
+        if ( y < yl )
+        {
             x = x0;
             y = yl;
-        } else if ( y > yh ) {
+        }
+        else if ( y > yh )
+        {
             x = x1;
             y = yh;
-        } else if ( y < y0 ) {
+        }
+        else if ( y < y0 )
+        {
             x0 = x;
             yl = y;
-        } else {
+        }
+        else
+        {
             x1 = x;
             yh = y;
         }
@@ -867,23 +945,27 @@ newt:
             break;
         /* Compute the derivative of the function at this point. */
         d = (a - 1.0L) * log(x) + (b - 1.0L) * log(1.0L - x) + lgm;
-        if ( d < MINLOG ) {
+        if ( d < MINLOG )
+        {
             goto done;
         }
-        if ( d > MAXLOG ) {
+        if ( d > MAXLOG )
+        {
             break;
         }
         d = exp(d);
         /* Compute the step to the next approximation of x. */
         d = (y - y0)/d;
         xt = x - d;
-        if ( xt <= x0 ) {
+        if ( xt <= x0 )
+        {
             y = (x - x0) / (x1 - x0);
             xt = x0 + 0.5L * y * (x - x0);
             if ( xt <= 0.0L )
                 break;
         }
-        if ( xt >= x1 ) {
+        if ( xt >= x1 )
+        {
             y = (x1 - x) / (x1 - x0);
             xt = x1 - 0.5L * y * (x1 - x);
             if ( xt >= 1.0L )
@@ -898,7 +980,8 @@ newt:
     goto ihalve;
 
 done:
-    if ( rflg ) {
+    if ( rflg )
+    {
         if ( x <= real.epsilon )
             x = 1.0L - real.epsilon;
         else
@@ -1025,10 +1108,13 @@ real betaDistExpansion1(real a, real b, real x )
 
         if ( qk != 0.0L )
             r = pk/qk;
-        if ( r != 0.0L ) {
+        if ( r != 0.0L )
+        {
             t = fabs( (ans - r)/r );
             ans = r;
-        } else {
+        }
+        else
+        {
            t = 1.0L;
         }
 
@@ -1044,13 +1130,15 @@ real betaDistExpansion1(real a, real b, real x )
         k7 += 2.0L;
         k8 += 2.0L;
 
-        if ( (fabs(qk) + fabs(pk)) > BETA_BIG ) {
+        if ( (fabs(qk) + fabs(pk)) > BETA_BIG )
+        {
             pkm2 *= BETA_BIGINV;
             pkm1 *= BETA_BIGINV;
             qkm2 *= BETA_BIGINV;
             qkm1 *= BETA_BIGINV;
             }
-        if ( (fabs(qk) < BETA_BIGINV) || (fabs(pk) < BETA_BIGINV) ) {
+        if ( (fabs(qk) < BETA_BIGINV) || (fabs(pk) < BETA_BIGINV) )
+        {
             pkm2 *= BETA_BIG;
             pkm1 *= BETA_BIG;
             qkm2 *= BETA_BIG;
@@ -1109,7 +1197,8 @@ real betaDistExpansion2(real a, real b, real x )
 
         if ( qk != 0.0L )
             r = pk/qk;
-        if ( r != 0.0L ) {
+        if ( r != 0.0L )
+        {
             t = fabs( (ans - r)/r );
             ans = r;
         } else
@@ -1126,13 +1215,15 @@ real betaDistExpansion2(real a, real b, real x )
         k7 += 2.0L;
         k8 += 2.0L;
 
-        if ( (fabs(qk) + fabs(pk)) > BETA_BIG ) {
+        if ( (fabs(qk) + fabs(pk)) > BETA_BIG )
+        {
             pkm2 *= BETA_BIGINV;
             pkm1 *= BETA_BIGINV;
             qkm2 *= BETA_BIGINV;
             qkm1 *= BETA_BIGINV;
         }
-        if ( (fabs(qk) < BETA_BIGINV) || (fabs(pk) < BETA_BIGINV) ) {
+        if ( (fabs(qk) < BETA_BIGINV) || (fabs(pk) < BETA_BIGINV) )
+        {
             pkm2 *= BETA_BIG;
             pkm1 *= BETA_BIG;
             qkm2 *= BETA_BIG;
@@ -1156,7 +1247,8 @@ real betaDistPowerSeries(real a, real b, real x )
     real n = 2.0L;
     real s = 0.0L;
     real z = real.epsilon * ai;
-    while ( fabs(v) > z ) {
+    while ( fabs(v) > z )
+    {
         u = (n - b) * x / n;
         t *= u;
         v = t / (a + n);
@@ -1167,13 +1259,17 @@ real betaDistPowerSeries(real a, real b, real x )
     s += ai;
 
     u = a * log(x);
-    if ( (a+b) < MAXGAMMA && fabs(u) < MAXLOG ) {
+    if ( (a+b) < MAXGAMMA && fabs(u) < MAXLOG )
+    {
         t = gamma(a+b)/(gamma(a)*gamma(b));
         s = s * t * pow(x,a);
-    } else {
+    }
+    else
+    {
         t = logGamma(a+b) - logGamma(a) - logGamma(b) + u + log(s);
 
-        if ( t < MINLOG ) {
+        if ( t < MINLOG )
+        {
             s = 0.0L;
         } else
             s = exp(t);
@@ -1285,11 +1381,14 @@ body {
         real yc = y * c;
         pk = pkm1 * z  -  pkm2 * yc;
         qk = qkm1 * z  -  qkm2 * yc;
-        if ( qk != 0.0L ) {
+        if ( qk != 0.0L )
+        {
             real r = pk/qk;
             t = fabs( (ans - r)/r );
             ans = r;
-        } else {
+        }
+        else
+        {
             t = 1.0L;
         }
     pkm2 = pkm1;
@@ -1299,7 +1398,8 @@ body {
 
         const real BIG = 9.223372036854775808e18L;
 
-        if ( fabs(pk) > BIG ) {
+        if ( fabs(pk) > BIG )
+        {
             pkm2 /= BIG;
             pkm1 /= BIG;
             qkm2 /= BIG;
@@ -1349,16 +1449,20 @@ body {
 
     lgm = logGamma(a);
 
-    for ( i=0; i<10; i++ ) {
+    for ( i=0; i<10; i++ )
+    {
         if ( x > x0 || x < x1 )
             goto ihalve;
         y = gammaIncompleteCompl(a,x);
         if ( y < yl || y > yh )
             goto ihalve;
-        if ( y < y0 ) {
+        if ( y < y0 )
+        {
             x0 = x;
             yl = y;
-        } else {
+        }
+        else
+        {
             x1 = x;
             yh = y;
         }
@@ -1377,13 +1481,16 @@ body {
     /* Resort to interval halving if Newton iteration did not converge. */
 ihalve:
     d = 0.0625L;
-    if ( x0 == real.max ) {
+    if ( x0 == real.max )
+    {
         if ( x <= 0.0L )
             x = 1.0L;
-        while ( x0 == real.max ) {
+        while ( x0 == real.max )
+        {
             x = (1.0L + d) * x;
             y = gammaIncompleteCompl( a, x );
-            if ( y < y0 ) {
+            if ( y < y0 )
+            {
                 x0 = x;
                 yl = y;
                 break;
@@ -1394,7 +1501,8 @@ ihalve:
     d = 0.5L;
     dir = 0;
 
-    for ( i=0; i<400; i++ ) {
+    for ( i=0; i<400; i++ )
+    {
         x = x1  +  d * (x0 - x1);
         y = gammaIncompleteCompl( a, x );
         lgm = (x0 - x1)/(x1 + x0);
@@ -1405,10 +1513,12 @@ ihalve:
             break;
         if ( x <= 0.0L )
             break;
-        if ( y > y0 ) {
+        if ( y > y0 )
+        {
             x1 = x;
             yh = y;
-            if ( dir < 0 ) {
+            if ( dir < 0 )
+            {
                 dir = 0;
                 d = 0.5L;
             } else if ( dir > 1 )
@@ -1416,10 +1526,13 @@ ihalve:
             else
                 d = (y0 - yl)/(yh - yl);
             dir += 1;
-        } else {
+        }
+        else
+        {
             x0 = x;
             yl = y;
-            if ( dir > 0 ) {
+            if ( dir > 0 )
+            {
                 dir = 0;
                 d = 0.5L;
             } else if ( dir < -1 )
@@ -1436,7 +1549,8 @@ ihalve:
     return x;
 }
 
-unittest {
+unittest
+{
 //Values from Excel's GammaInv(1-p, x, 1)
 assert(fabs(gammaIncompleteComplInv(1, 0.5) - 0.693147188044814) < 0.00000005);
 assert(fabs(gammaIncompleteComplInv(12, 0.99) - 5.42818075054289) < 0.00000005);
@@ -1489,36 +1603,44 @@ real digamma(real x)
     negative = 0;
     nz = 0.0;
 
-    if ( x <= 0.0 ) {
+    if ( x <= 0.0 )
+    {
         negative = 1;
         q = x;
         p = floor(q);
-        if ( p == q ) {
+        if ( p == q )
+        {
             return real.nan; // singularity.
         }
     /* Remove the zeros of tan(PI x)
      * by subtracting the nearest integer from x
      */
         nz = q - p;
-        if ( nz != 0.5 ) {
-            if ( nz > 0.5 ) {
+        if ( nz != 0.5 )
+        {
+            if ( nz > 0.5 )
+            {
                 p += 1.0;
                 nz = q - p;
             }
             nz = PI/tan(PI*nz);
-        } else {
+        }
+        else
+        {
             nz = 0.0;
         }
         x = 1.0 - x;
     }
 
     // check for small positive integer
-    if ((x <= 13.0) && (x == floor(x)) ) {
+    if ((x <= 13.0) && (x == floor(x)) )
+    {
         y = 0.0;
         n = lrint(x);
         // DAC: CEPHES bugfix. Cephes did this in reverse order, which
         // created a larger roundoff error.
-        for (i=n-1; i>0; --i) {
+        for (i=n-1; i>0; --i)
+        {
             y+=1.0L/i;
         }
         y -= EULERGAMMA;
@@ -1527,12 +1649,14 @@ real digamma(real x)
 
     s = x;
     w = 0.0;
-    while ( s < 10.0 ) {
+    while ( s < 10.0 )
+    {
         w += 1.0/s;
         s += 1.0;
     }
 
-    if ( s < 1.0e17 ) {
+    if ( s < 1.0e17 )
+    {
         z = 1.0/(s * s);
         y = z * poly(z, Bn_n);
     } else
@@ -1541,13 +1665,15 @@ real digamma(real x)
     y = log(s)  -  0.5L/s  -  y  -  w;
 
 done:
-    if ( negative ) {
+    if ( negative )
+    {
         y -= nz;
     }
     return y;
 }
 
-unittest {
+unittest
+{
     // Exact values
     assert(digamma(1.0)== -EULERGAMMA);
     assert(feqrel(digamma(0.25), -PI/2 - 3* LN2 - EULERGAMMA) >= real.mant_dig-7);
@@ -1556,9 +1682,11 @@ unittest {
     assert(feqrel(digamma(2.5), -EULERGAMMA - 2*LN2 + 2.0 + 2.0L/3) >= real.mant_dig-9);
     assert(isIdentical(digamma(NaN(0xABC)), NaN(0xABC)));
 
-    for (int k=1; k<40; ++k) {
+    for (int k=1; k<40; ++k)
+    {
         real y=0;
-        for (int u=k; u>=1; --u) {
+        for (int u=k; u>=1; --u)
+        {
             y += 1.0L/u;
         }
         assert(feqrel(digamma(k+1.0), -EULERGAMMA + y) >= real.mant_dig-2);
@@ -1587,13 +1715,15 @@ real logmdigamma(real x)
 
     real s = x;
     real w = 0.0;
-    while ( s < 10.0 ) {
+    while ( s < 10.0 )
+    {
         w += 1.0/s;
         s += 1.0;
     }
 
     real y;
-    if ( s < 1.0e17 ) {
+    if ( s < 1.0e17 )
+    {
         immutable real z = 1.0/(s * s);
         y = z * poly(z, Bn_n);
     } else
@@ -1602,7 +1732,8 @@ real logmdigamma(real x)
     return x == s ? y + 0.5L/s : (log(x/s) + 0.5L/s + y + w);
 }
 
-unittest {
+unittest
+{
     assert(logmdigamma(-5.0).isNaN());
     assert(isIdentical(logmdigamma(NaN(0xABC)), NaN(0xABC)));
     assert(logmdigamma(0.0) == real.infinity);
@@ -1654,7 +1785,8 @@ real logmdigammaInverse(real y)
     return y; //NaN
 }
 
-unittest {
+unittest
+{
     import std.typecons;
     //WolframAlpha, 22.02.2015
     immutable Tuple!(real, real)[5] testData = [

--- a/std/internal/unicode_tables.d
+++ b/std/internal/unicode_tables.d
@@ -3958,7 +3958,8 @@ bool isHangT(dchar ch) @safe pure nothrow
     return false;
 }
 
-static if (size_t.sizeof == 8) {
+static if (size_t.sizeof == 8)
+{
 //1536 bytes
 enum lowerCaseTrieEntries = TrieEntry!(bool, 8, 4, 9)([0x0, 0x20, 0x40],
         [0x100, 0x80, 0x2000], [0x402030202020100, 0x206020202020205,
@@ -7430,7 +7431,8 @@ enum toTitleSimpleIndexTrieEntries = TrieEntry!(ushort, 8, 7, 6)([0x0, 0x20,
 
 }
 
-static if (size_t.sizeof == 4) {
+static if (size_t.sizeof == 4)
+{
 //1536 bytes
 enum lowerCaseTrieEntries = TrieEntry!(bool, 8, 4, 9)([0x0, 0x40, 0x80],
         [0x100, 0x80, 0x2000], [0x2020100, 0x4020302, 0x2020205, 0x2060202,

--- a/std/json.d
+++ b/std/json.d
@@ -378,7 +378,8 @@ struct JSONValue
         {
             static assert(is(Key : string), "AA key must be string");
             type_tag = JSON_TYPE.OBJECT;
-            static if (is(Value : JSONValue)) {
+            static if (is(Value : JSONValue))
+            {
                 store.object = arg;
             }
             else
@@ -848,7 +849,8 @@ if (isInputRange!T)
     }
 
     bool tryGetSpecialFloat(string str, out double val) {
-        switch (str) {
+        switch (str)
+        {
             case JSONFloatLiteral.nan:
                 val = double.nan;
                 return true;
@@ -1233,25 +1235,32 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
 
                 auto val = value.store.floating;
 
-                if (val.isNaN) {
-                    if (options & JSONOptions.specialFloatLiterals) {
+                if (val.isNaN)
+                {
+                    if (options & JSONOptions.specialFloatLiterals)
+                    {
                         toString(JSONFloatLiteral.nan);
                     }
-                    else {
+                    else
+                    {
                         throw new JSONException(
                             "Cannot encode NaN. Consider passing the specialFloatLiterals flag.");
                     }
                 }
-                else if (val.isInfinity) {
-                    if (options & JSONOptions.specialFloatLiterals) {
+                else if (val.isInfinity)
+                {
+                    if (options & JSONOptions.specialFloatLiterals)
+                    {
                         toString((val > 0) ?  JSONFloatLiteral.inf : JSONFloatLiteral.negativeInf);
                     }
-                    else {
+                    else
+                    {
                         throw new JSONException(
                             "Cannot encode Infinity. Consider passing the specialFloatLiterals flag.");
                     }
                 }
-                else {
+                else
+                {
                     json.put(to!string(val));
                 }
                 break;
@@ -1570,7 +1579,8 @@ unittest
 }`);
 }
 
-unittest {
+unittest
+{
   auto json = `"hello\nworld"`;
   const jv = parseJSON(json);
   assert(jv.toString == json);

--- a/std/math.d
+++ b/std/math.d
@@ -3500,7 +3500,8 @@ real modf(real x, ref real i) @trusted nothrow @nogc
  */
 real scalbn(real x, int n) @trusted nothrow @nogc
 {
-    version(InlineAsm_X86_Any) {
+    version(InlineAsm_X86_Any)
+    {
         // scalbnl is not supported on DMD-Windows, so use asm pure nothrow @nogc.
         version (Win64)
         {
@@ -4393,7 +4394,8 @@ private:
         }
     }
 public:
-    version (IeeeFlagsSupport) {
+    version (IeeeFlagsSupport)
+    {
 
      /// The result cannot be represented exactly, so rounding occurred.
      /// (example: x = sin(0.1); )
@@ -6033,7 +6035,8 @@ typeof(Unqual!(F).init * Unqual!(G).init) pow(F, G)(F x, G n) @nogc @trusted pur
     default:
         v = x;
         p = 1;
-        while (1){
+        while (1)
+        {
             if (m & 1)
                 p *= v;
             m >>= 1;
@@ -6722,7 +6725,8 @@ body
     assert(poly(x, pp) == y);
 }
 
-unittest {
+unittest
+{
     static assert(poly(3.0, [1.0, 2.0, 3.0]) == 34);
 }
 

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -128,13 +128,15 @@ real sgnGamma(real x)
         return real.nan;
     }
     long n = rndtol(x);
-    if (x == n) {
+    if (x == n)
+    {
         return x == 0 ?  copysign(1, x) : real.nan;
     }
     return n & 1 ? 1.0 : -1.0;
 }
 
-unittest {
+unittest
+{
     assert(sgnGamma(5.0) == 1.0);
     assert(isNaN(sgnGamma(-3.0)));
     assert(sgnGamma(-0.1) == -1.0);
@@ -151,12 +153,14 @@ unittest {
  */
 real beta(real x, real y)
 {
-    if ((x+y)> MAXGAMMA) {
+    if ((x+y)> MAXGAMMA)
+    {
         return exp(logGamma(x) + logGamma(y) - logGamma(x+y));
     } else return gamma(x) * gamma(y) / gamma(x+y);
 }
 
-unittest {
+unittest
+{
     assert(isIdentical(beta(NaN(0xABC), 4), NaN(0xABC)));
     assert(isIdentical(beta(2, NaN(0xABC)), NaN(0xABC)));
 }

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -141,7 +141,8 @@ class MmFile
         size_t initial_map = (window && 2*window<size)
             ? 2*window : cast(size_t)size;
         auto p = mmap(address, initial_map, prot, flags, fd, 0);
-        if (p == MAP_FAILED) {
+        if (p == MAP_FAILED)
+        {
             errnoEnforce(false, "Could not map file into memory");
         }
         data = p[0 .. initial_map];
@@ -501,9 +502,12 @@ class MmFile
     private void unmap()
     {
         debug (MMFILE) printf("MmFile.unmap()\n");
-        version(Windows) {
+        version(Windows)
+        {
             wenforce(!data.ptr || UnmapViewOfFile(data.ptr) != FALSE, "UnmapViewOfFile");
-        } else {
+        }
+        else
+        {
             errnoEnforce(!data.ptr || munmap(cast(void*)data, data.length) == 0,
                     "munmap failed");
         }
@@ -517,11 +521,14 @@ class MmFile
         void* p;
         if (start+len > size)
             len = cast(size_t)(size-start);
-        version(Windows) {
+        version(Windows)
+        {
             uint hi = cast(uint)(start>>32);
             p = MapViewOfFileEx(hFileMap, dwDesiredAccess, hi, cast(uint)start, len, address);
             wenforce(p, "MapViewOfFileEx");
-        } else {
+        }
+        else
+        {
             p = mmap(address, len, prot, flags, fd, cast(off_t)start);
             errnoEnforce(p != MAP_FAILED);
         }
@@ -533,11 +540,15 @@ class MmFile
     private void ensureMapped(ulong i)
     {
         debug (MMFILE) printf("MmFile.ensureMapped(%lld)\n", i);
-        if (!mapped(i)) {
+        if (!mapped(i))
+        {
             unmap();
-            if (window == 0) {
+            if (window == 0)
+            {
                 map(0,cast(size_t)size);
-            } else {
+            }
+            else
+            {
                 ulong block = i/window;
                 if (block == 0)
                     map(0,2*window);
@@ -551,16 +562,23 @@ class MmFile
     private void ensureMapped(ulong i, ulong j)
     {
         debug (MMFILE) printf("MmFile.ensureMapped(%lld, %lld)\n", i, j);
-        if (!mapped(i) || !mapped(j-1)) {
+        if (!mapped(i) || !mapped(j-1))
+        {
             unmap();
-            if (window == 0) {
+            if (window == 0)
+            {
                 map(0,cast(size_t)size);
-            } else {
+            }
+            else
+            {
                 ulong iblock = i/window;
                 ulong jblock = (j-1)/window;
-                if (iblock == 0) {
+                if (iblock == 0)
+                {
                     map(0,cast(size_t)(window*(jblock+2)));
-                } else {
+                }
+                else
+                {
                     map(window*(iblock-1),cast(size_t)(window*(jblock-iblock+3)));
                 }
             }
@@ -619,13 +637,16 @@ unittest
 
     const size_t K = 1024;
     size_t win = 64*K; // assume the page size is 64K
-    version(Windows) {
+    version(Windows)
+    {
         /+ these aren't defined in core.sys.windows.windows so let's use default
          SYSTEM_INFO sysinfo;
          GetSystemInfo(&sysinfo);
          win = sysinfo.dwAllocationGranularity;
          +/
-    } else version (linux) {
+    }
+    else version (linux)
+    {
         // getpagesize() is not defined in the unix D headers so use the guess
     }
     string test_file = std.file.deleteme ~ "-testing.txt";

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1022,7 +1022,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     client.onReceiveHeader = (in char[] key,
                               in char[] value)
     {
-        if (key == "content-length") {
+        if (key == "content-length")
+        {
             import std.conv : to;
             content.reserve(value.to!size_t);
         }

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1215,7 +1215,8 @@ private:
             tail = task;
             tail.prev = null;
         }
-        else {
+        else
+        {
             assert(tail);
             task.prev = tail;
             tail.next = task;
@@ -2740,7 +2741,8 @@ public:
     {
         auto filesHandles = new File[taskPool.size + 1];
         scope(exit) {
-            foreach (ref handle; fileHandles) {
+            foreach (ref handle; fileHandles)
+            {
                 handle.close();
             }
         }
@@ -2825,7 +2827,8 @@ public:
             {
                 return num;
             }
-            else {
+            else
+            {
                 return ((num / cacheLineSize) + 1) * cacheLineSize;
             }
         }
@@ -3299,7 +3302,8 @@ Example:
 // default TaskPool instance.
 auto logs = new double[1_000_000];
 
-foreach (i, ref elem; parallel(logs)) {
+foreach (i, ref elem; parallel(logs))
+{
     elem = log(i + 1.0);
 }
 ---

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -275,7 +275,9 @@ class OutputRangeObject(R, E...) : staticMap!(OutputRange, E) {
 
 
 /**Returns the interface type that best matches $(D R).*/
-template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
+template MostDerivedInputRange(R)
+if (isInputRange!(Unqual!R))
+{
     private alias E = ElementType!R;
 
     static if (isRandomAccessRange!R)
@@ -332,7 +334,9 @@ template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
  * all relevant range primitives in virtual functions.  If $(D R) is already
  * derived from the $(D InputRange) interface, aliases itself away.
  */
-template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
+template InputRangeObject(R)
+if (isInputRange!(Unqual!R))
+{
     static if (is(R : InputRange!(ElementType!R)))
     {
         alias InputRangeObject = R;
@@ -465,7 +469,9 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
 /**Convenience function for creating an $(D InputRangeObject) of the proper type.
  * See $(LREF InputRange) for an example.
  */
-InputRangeObject!R inputRangeObject(R)(R range) if (isInputRange!R) {
+InputRangeObject!R inputRangeObject(R)(R range)
+if (isInputRange!R)
+{
     static if (is(R : InputRange!(ElementType!R)))
     {
         return range;

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -179,7 +179,8 @@ interface RandomAccessFinite(E) : BidirectionalRange!(E) {
 
     // Can't support slicing until issues with requiring slicing for all
     // finite random access ranges are fully resolved.
-    version(none) {
+    version(none)
+    {
         ///
         RandomAccessFinite!E opSlice(size_t, size_t);
     }
@@ -277,30 +278,51 @@ class OutputRangeObject(R, E...) : staticMap!(OutputRange, E) {
 template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
     private alias E = ElementType!R;
 
-    static if (isRandomAccessRange!R) {
-        static if (isInfinite!R) {
+    static if (isRandomAccessRange!R)
+    {
+        static if (isInfinite!R)
+        {
             alias MostDerivedInputRange = RandomAccessInfinite!E;
-        } else static if (hasAssignableElements!R) {
+        }
+        else static if (hasAssignableElements!R)
+        {
             alias MostDerivedInputRange = RandomFiniteAssignable!E;
-        } else {
+        }
+        else
+        {
             alias MostDerivedInputRange = RandomAccessFinite!E;
         }
-    } else static if (isBidirectionalRange!R) {
-        static if (hasAssignableElements!R) {
+    }
+    else static if (isBidirectionalRange!R)
+    {
+        static if (hasAssignableElements!R)
+        {
             alias MostDerivedInputRange = BidirectionalAssignable!E;
-        } else {
+        }
+        else
+        {
             alias MostDerivedInputRange = BidirectionalRange!E;
         }
-    } else static if (isForwardRange!R) {
-        static if (hasAssignableElements!R) {
+    }
+    else static if (isForwardRange!R)
+    {
+        static if (hasAssignableElements!R)
+        {
             alias MostDerivedInputRange = ForwardAssignable!E;
-        } else {
+        }
+        else
+        {
             alias MostDerivedInputRange = ForwardRange!E;
         }
-    } else {
-        static if (hasAssignableElements!R) {
+    }
+    else
+    {
+        static if (hasAssignableElements!R)
+        {
             alias MostDerivedInputRange = InputAssignable!E;
-        } else {
+        }
+        else
+        {
             alias MostDerivedInputRange = InputRange!E;
         }
     }
@@ -311,11 +333,16 @@ template MostDerivedInputRange(R) if (isInputRange!(Unqual!R)) {
  * derived from the $(D InputRange) interface, aliases itself away.
  */
 template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
-    static if (is(R : InputRange!(ElementType!R))) {
+    static if (is(R : InputRange!(ElementType!R)))
+    {
         alias InputRangeObject = R;
-    } else static if (!is(Unqual!R == R)) {
+    }
+    else static if (!is(Unqual!R == R))
+    {
         alias InputRangeObject = InputRangeObject!(Unqual!R);
-    } else {
+    }
+    else
+    {
 
         ///
         class InputRangeObject : MostDerivedInputRange!(R) {
@@ -335,19 +362,22 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
             void popFront() { _range.popFront(); }
             @property bool empty() { return _range.empty; }
 
-            static if (isForwardRange!R) {
+            static if (isForwardRange!R)
+            {
                 @property typeof(this) save() {
                     return new typeof(this)(_range.save);
                 }
             }
 
-            static if (hasAssignableElements!R) {
+            static if (hasAssignableElements!R)
+            {
                 @property void front(E newVal) {
                     _range.front = newVal;
                 }
             }
 
-            static if (isBidirectionalRange!R) {
+            static if (isBidirectionalRange!R)
+            {
                 @property E back() { return _range.back; }
 
                 E moveBack() {
@@ -356,14 +386,16 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
 
                 void popBack() { return _range.popBack(); }
 
-                static if (hasAssignableElements!R) {
+                static if (hasAssignableElements!R)
+                {
                     @property void back(E newVal) {
                         _range.back = newVal;
                     }
                 }
             }
 
-            static if (isRandomAccessRange!R) {
+            static if (isRandomAccessRange!R)
+            {
                 E opIndex(size_t index) {
                     return _range[index];
                 }
@@ -372,13 +404,15 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
                     return _range.moveAt(index);
                 }
 
-                static if (hasAssignableElements!R) {
+                static if (hasAssignableElements!R)
+                {
                     void opIndexAssign(E val, size_t index) {
                         _range[index] = val;
                     }
                 }
 
-                static if (!isInfinite!R) {
+                static if (!isInfinite!R)
+                {
                     @property size_t length() {
                         return _range.length;
                     }
@@ -388,7 +422,8 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
                     // Can't support slicing until all the issues with
                     // requiring slicing support for finite random access
                     // ranges are resolved.
-                    version(none) {
+                    version(none)
+                    {
                         typeof(this) opSlice(size_t lower, size_t upper) {
                             return new typeof(this)(_range[lower..upper]);
                         }
@@ -401,7 +436,8 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
             int opApply(int delegate(E) dg) {
                 int res;
 
-                for (auto r = _range; !r.empty; r.popFront()) {
+                for (auto r = _range; !r.empty; r.popFront())
+                {
                     res = dg(r.front);
                     if (res) break;
                 }
@@ -413,7 +449,8 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
                 int res;
 
                 size_t i = 0;
-                for (auto r = _range; !r.empty; r.popFront()) {
+                for (auto r = _range; !r.empty; r.popFront())
+                {
                     res = dg(i, r.front);
                     if (res) break;
                     i++;
@@ -429,9 +466,12 @@ template InputRangeObject(R) if (isInputRange!(Unqual!R)) {
  * See $(LREF InputRange) for an example.
  */
 InputRangeObject!R inputRangeObject(R)(R range) if (isInputRange!R) {
-    static if (is(R : InputRange!(ElementType!R))) {
+    static if (is(R : InputRange!(ElementType!R)))
+    {
         return range;
-    } else {
+    }
+    else
+    {
         return new InputRangeObject!R(range);
     }
 }
@@ -483,7 +523,8 @@ unittest
 
     assert(inputRangeObject(arrWrapped) is arrWrapped);
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         auto d = DummyType.init;
         static assert(propagatesRangeType!(DummyType,
                         typeof(inputRangeObject(d))));

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -349,10 +349,14 @@ if (isBidirectionalRange!(Unqual!Range))
 {
     import std.internal.test.dummyrange;
 
-    foreach (DummyType; AllDummyRanges) {
-        static if (!isBidirectionalRange!DummyType) {
+    foreach (DummyType; AllDummyRanges)
+    {
+        static if (!isBidirectionalRange!DummyType)
+        {
             static assert(!__traits(compiles, Retro!DummyType));
-        } else {
+        }
+        else
+        {
             DummyType dummyRange;
             dummyRange.reinit();
 
@@ -363,11 +367,13 @@ if (isBidirectionalRange!(Unqual!Range))
             assert(myRetro.moveFront() == 10);
             assert(myRetro.moveBack() == 1);
 
-            static if (isRandomAccessRange!DummyType && hasLength!DummyType) {
+            static if (isRandomAccessRange!DummyType && hasLength!DummyType)
+            {
                 assert(myRetro[0] == myRetro.front);
                 assert(myRetro.moveAt(2) == 8);
 
-                static if (DummyType.r == ReturnBy.Reference) {
+                static if (DummyType.r == ReturnBy.Reference)
+                {
                     {
                         myRetro[9]++;
                         scope(exit) myRetro[9]--;
@@ -689,7 +695,8 @@ debug unittest
     // Check for infiniteness propagation.
     static assert(isInfinite!(typeof(stride(repeat(1), 3))));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType dummyRange;
         dummyRange.reinit();
 
@@ -697,23 +704,27 @@ debug unittest
 
         // Should fail if no length and bidirectional b/c there's no way
         // to know how much slack we have.
-        static if (hasLength!DummyType || !isBidirectionalRange!DummyType) {
+        static if (hasLength!DummyType || !isBidirectionalRange!DummyType)
+        {
             static assert(propagatesRangeType!(typeof(myStride), DummyType));
         }
         assert(myStride.front == 1);
         assert(myStride.moveFront() == 1);
         assert(equal(myStride, [1, 5, 9]));
 
-        static if (hasLength!DummyType) {
+        static if (hasLength!DummyType)
+        {
             assert(myStride.length == 3);
         }
 
-        static if (isBidirectionalRange!DummyType && hasLength!DummyType) {
+        static if (isBidirectionalRange!DummyType && hasLength!DummyType)
+        {
             assert(myStride.back == 9);
             assert(myStride.moveBack() == 9);
         }
 
-        static if (isRandomAccessRange!DummyType && hasLength!DummyType) {
+        static if (isRandomAccessRange!DummyType && hasLength!DummyType)
+        {
             assert(myStride[0] == 1);
             assert(myStride[1] == 5);
             assert(myStride.moveAt(1) == 5);
@@ -722,7 +733,8 @@ debug unittest
             static assert(hasSlicing!(typeof(myStride)));
         }
 
-        static if (DummyType.r == ReturnBy.Reference) {
+        static if (DummyType.r == ReturnBy.Reference)
+        {
             // Make sure reference is propagated.
 
             {
@@ -736,7 +748,8 @@ debug unittest
                 assert(dummyRange.front == 4);
             }
 
-            static if (isBidirectionalRange!DummyType && hasLength!DummyType) {
+            static if (isBidirectionalRange!DummyType && hasLength!DummyType)
+            {
                 {
                     myStride.back++;
                     scope(exit) myStride.back--;
@@ -748,7 +761,8 @@ debug unittest
                     assert(myStride.back == 111);
                 }
 
-                static if (isRandomAccessRange!DummyType) {
+                static if (isRandomAccessRange!DummyType)
+                {
                     {
                         myStride[1]++;
                         scope(exit) myStride[1]--;
@@ -1172,9 +1186,11 @@ unittest
     // Check that chain at least instantiates and compiles with every possible
     // pair of DummyRange types, in either order.
 
-    foreach (DummyType1; AllDummyRanges) {
+    foreach (DummyType1; AllDummyRanges)
+    {
         DummyType1 dummy1;
-        foreach (DummyType2; AllDummyRanges) {
+        foreach (DummyType2; AllDummyRanges)
+        {
             DummyType2 dummy2;
             auto myChain = chain(dummy1, dummy2);
 
@@ -1183,7 +1199,8 @@ unittest
             );
 
             assert(myChain.front == 1);
-            foreach (i; 0..dummyLength) {
+            foreach (i; 0..dummyLength)
+            {
                 myChain.popFront();
             }
             assert(myChain.front == 1);
@@ -2030,18 +2047,22 @@ if (isInputRange!(Unqual!R) && (isInfinite!(Unqual!R) || !hasSlicing!(Unqual!R) 
     takeMyStrAgain = take(takeMyStr, 10);
     assert(equal(takeMyStrAgain, "This is"));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         DummyType dummy;
         auto t = take(dummy, 5);
         alias T = typeof(t);
 
-        static if (isRandomAccessRange!DummyType) {
+        static if (isRandomAccessRange!DummyType)
+        {
             static assert(isRandomAccessRange!T);
             assert(t[4] == 5);
 
             assert(moveAt(t, 1) == t[1]);
             assert(t.back == moveBack(t));
-        } else static if (isForwardRange!DummyType) {
+        }
+        else static if (isForwardRange!DummyType)
+        {
             static assert(isForwardRange!T);
         }
 
@@ -4011,7 +4032,8 @@ unittest
 
     alias FOO = Zip!(immutable(int)[], immutable(float)[]);
 
-    foreach (t; stuff.expand) {
+    foreach (t; stuff.expand)
+    {
         auto arr1 = t[0];
         auto arr2 = t[1];
         auto zShortest = zip(arr1, arr2);
@@ -4052,15 +4074,18 @@ unittest
     // make -fwin32.mak unittest makes the compiler completely run out of RAM.
     // You need to test just this module.
     /+
-     foreach (DummyType1; AllDummyRanges) {
+     foreach (DummyType1; AllDummyRanges)
+     {
          DummyType1 d1;
-         foreach (DummyType2; AllDummyRanges) {
+         foreach (DummyType2; AllDummyRanges)
+         {
              DummyType2 d2;
              auto r = zip(d1, d2);
              assert(equal(map!"a[0]"(r), [1,2,3,4,5,6,7,8,9,10]));
              assert(equal(map!"a[1]"(r), [1,2,3,4,5,6,7,8,9,10]));
 
-             static if (isForwardRange!DummyType1 && isForwardRange!DummyType2) {
+             static if (isForwardRange!DummyType1 && isForwardRange!DummyType2)
+             {
                  static assert(isForwardRange!(typeof(r)));
              }
 
@@ -4401,7 +4426,8 @@ unittest
         uint[] res1;
         float[] res2;
 
-        foreach (a, ref b; l) {
+        foreach (a, ref b; l)
+        {
             res1 ~= a;
             res2 ~= b;
         }
@@ -4760,7 +4786,8 @@ auto sequence(alias fun, State...)(State args)
 
     auto odds = Sequence!("a[0] + n * a[1]", Tuple!(int, int))(
         tuple(1, 2));
-    for (int currentOdd = 1; currentOdd <= 21; currentOdd += 2) {
+    for (int currentOdd = 1; currentOdd <= 21; currentOdd += 2)
+    {
         assert(odds.front == odds[0]);
         assert(odds[0] == currentOdd);
         odds.popFront();
@@ -5671,17 +5698,20 @@ FrontTransversal!(RangeOfRanges, opt) frontTransversal(
 
     static assert(is(FrontTransversal!(immutable int[][])));
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         auto dummies =
             [DummyType.init, DummyType.init, DummyType.init, DummyType.init];
 
-        foreach (i, ref elem; dummies) {
+        foreach (i, ref elem; dummies)
+        {
             // Just violate the DummyRange abstraction to get what I want.
             elem.arr = elem.arr[i..$ - (3 - i)];
         }
 
         auto ft = frontTransversal!(TransverseOptions.assumeNotJagged)(dummies);
-        static if (isForwardRange!DummyType) {
+        static if (isForwardRange!DummyType)
+        {
             static assert(isForwardRange!(typeof(ft)));
         }
 
@@ -5699,7 +5729,8 @@ FrontTransversal!(RangeOfRanges, opt) frontTransversal(
         // Test infiniteness propagation.
         static assert(isInfinite!(typeof(frontTransversal(repeat("foo")))));
 
-        static if (DummyType.r == ReturnBy.Reference) {
+        static if (DummyType.r == ReturnBy.Reference)
+        {
             {
                 ft.front++;
                 scope(exit) ft.front--;
@@ -6004,7 +6035,8 @@ Transversal!(RangeOfRanges, opt) transversal
     // Test w/o ref return.
     alias D = DummyRange!(ReturnBy.Value, Length.Yes, RangeType.Random);
     auto drs = [D.init, D.init];
-    foreach (num; 0..10) {
+    foreach (num; 0..10)
+    {
         auto t = transversal!(TransverseOptions.enforceNotJagged)(drs, num);
         assert(t[0] == t[1]);
         assert(t[1] == num + 1);

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1854,14 +1854,21 @@ void popBackExactly(Range)(ref Range r, size_t n)
 */
 ElementType!R moveFront(R)(R r)
 {
-    static if (is(typeof(&r.moveFront))) {
+    static if (is(typeof(&r.moveFront)))
+    {
         return r.moveFront();
-    } else static if (!hasElaborateCopyConstructor!(ElementType!R)) {
+    }
+    else static if (!hasElaborateCopyConstructor!(ElementType!R))
+    {
         return r.front;
-    } else static if (is(typeof(&(r.front())) == ElementType!R*)) {
+    }
+    else static if (is(typeof(&(r.front())) == ElementType!R*))
+    {
         import std.algorithm.mutation : move;
         return move(r.front);
-    } else {
+    }
+    else
+    {
         static assert(0,
                 "Cannot move front of a range with a postblit and an rvalue front.");
     }
@@ -1905,14 +1912,21 @@ ElementType!R moveFront(R)(R r)
 */
 ElementType!R moveBack(R)(R r)
 {
-    static if (is(typeof(&r.moveBack))) {
+    static if (is(typeof(&r.moveBack)))
+    {
         return r.moveBack();
-    } else static if (!hasElaborateCopyConstructor!(ElementType!R)) {
+    }
+    else static if (!hasElaborateCopyConstructor!(ElementType!R))
+    {
         return r.back;
-    } else static if (is(typeof(&(r.back())) == ElementType!R*)) {
+    }
+    else static if (is(typeof(&(r.back())) == ElementType!R*))
+    {
         import std.algorithm.mutation : move;
         return move(r.back);
-    } else {
+    }
+    else
+    {
         static assert(0,
                 "Cannot move back of a range with a postblit and an rvalue back.");
     }
@@ -1944,14 +1958,21 @@ ElementType!R moveBack(R)(R r)
 */
 ElementType!R moveAt(R)(R r, size_t i)
 {
-    static if (is(typeof(&r.moveAt))) {
+    static if (is(typeof(&r.moveAt)))
+    {
         return r.moveAt(i);
-    } else static if (!hasElaborateCopyConstructor!(ElementType!(R))) {
+    }
+    else static if (!hasElaborateCopyConstructor!(ElementType!(R)))
+    {
         return r[i];
-    } else static if (is(typeof(&r[i]) == ElementType!R*)) {
+    }
+    else static if (is(typeof(&r[i]) == ElementType!R*))
+    {
         import std.algorithm.mutation : move;
         return move(r[i]);
-    } else {
+    }
+    else
+    {
         static assert(0,
                 "Cannot move element of a range with a postblit and rvalue elements.");
     }
@@ -1971,15 +1992,18 @@ ElementType!R moveAt(R)(R r, size_t i)
 {
     import std.internal.test.dummyrange;
 
-    foreach (DummyType; AllDummyRanges) {
+    foreach (DummyType; AllDummyRanges)
+    {
         auto d = DummyType.init;
         assert(moveFront(d) == 1);
 
-        static if (isBidirectionalRange!DummyType) {
+        static if (isBidirectionalRange!DummyType)
+        {
             assert(moveBack(d) == 10);
         }
 
-        static if (isRandomAccessRange!DummyType) {
+        static if (isRandomAccessRange!DummyType)
+        {
             assert(moveAt(d, 2) == 3);
         }
     }

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -174,7 +174,8 @@ static assert (IRL!(IR.LookaheadStart) == 3);
 
 //how many parameters follow the IR, should be optimized fixing some IR bits
 int immediateParamsIR(IR i){
-    switch (i){
+    switch (i)
+    {
     case IR.OrEnd,IR.InfiniteEnd,IR.InfiniteQEnd:
         return 1;  // merge table index
     case IR.InfiniteBloomEnd:
@@ -740,7 +741,8 @@ struct BitTable {
     uint[4] filter;
 
     this(CodepointSet set){
-        foreach (iv; set.byInterval){
+        foreach (iv; set.byInterval)
+        {
             foreach (v; iv.a..iv.b)
                 add(v);
         }

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -136,7 +136,8 @@ public:
         ulong hash(uint[] tab)
         {
             ulong h = 0xcbf29ce484222325;
-            foreach (v; tab){
+            foreach (v; tab)
+            {
                 h ^= v;
                 h *= 0x100000001b3;
             }

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -617,7 +617,8 @@ unittest
         //issue 4574
         //empty successful match still advances the input
         string[] pres, posts, hits;
-        foreach (m; matchFn("abcabc", regex("","g"))) {
+        foreach (m; matchFn("abcabc", regex("","g")))
+        {
             pres ~= m.pre;
             posts ~= m.post;
             assert(m.hit.empty);
@@ -719,7 +720,8 @@ unittest
     auto w2 = ["", "abc", "de", "fg", "hi"];
 
     uint cnt;
-    foreach (e; sp2) {
+    foreach (e; sp2)
+    {
         assert(w2[cnt++] == e);
     }
     assert(equal(sp2, w2));

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -329,7 +329,8 @@ public alias StaticRegex(Char) = std.regex.internal.ir.StaticRegex!(Char);
     if (patterns.length > 1)
     {
         auto app = appender!S();
-        foreach (i, p; patterns){
+        foreach (i, p; patterns)
+        {
             if (i != 0)
                 app.put("|");
             app.put("(?:");

--- a/std/signals.d
+++ b/std/signals.d
@@ -351,7 +351,8 @@ unittest
     a.value = 7;
 }
 
-unittest {
+unittest
+{
     class Observer
     {
         int    i;

--- a/std/socket.d
+++ b/std/socket.d
@@ -3027,7 +3027,9 @@ public:
             return buf.length
                    ? .recv(sock, buf.ptr, capToInt(buf.length), cast(int)flags)
                    : 0;
-        } else {
+        }
+        else
+        {
             return buf.length
                    ? .recv(sock, buf.ptr, buf.length, cast(int)flags)
                    : 0;
@@ -3060,7 +3062,9 @@ public:
             assert(from.addressFamily == _family);
             // if (!read) //connection closed
             return read;
-        } else {
+        }
+        else
+        {
             auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, from.name, &nameLen);
             assert(from.addressFamily == _family);
             // if (!read) //connection closed
@@ -3087,7 +3091,9 @@ public:
             auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int)flags, null, null);
             // if (!read) //connection closed
             return read;
-        } else {
+        }
+        else
+        {
             auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, null, null);
             // if (!read) //connection closed
             return read;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1628,11 +1628,16 @@ is recommended if you want to process a complete file.
         auto last = terminator.back;
         C[] buf2;
         swap(buf, buf2);
-        for (;;) {
-            if (!readln(buf2, last) || endsWith(buf2, terminator)) {
-                if (buf.empty) {
+        for (;;)
+        {
+            if (!readln(buf2, last) || endsWith(buf2, terminator))
+            {
+                if (buf.empty)
+                {
                     buf = buf2;
-                } else {
+                }
+                else
+                {
                     buf ~= buf2;
                 }
                 break;
@@ -3950,7 +3955,8 @@ unittest
     alias TestedWith =
           AliasSeq!(string, wstring, dstring,
                     char[], wchar[], dchar[]);
-    foreach (T; TestedWith) {
+    foreach (T; TestedWith)
+    {
         // test looping with an empty file
         std.file.write(deleteme, "");
         auto f = File(deleteme, "r");
@@ -3991,7 +3997,8 @@ unittest
 
     // test with ubyte[] inputs
     alias TestedWith2 = AliasSeq!(immutable(ubyte)[], ubyte[]);
-    foreach (T; TestedWith2) {
+    foreach (T; TestedWith2)
+    {
         // test looping with an empty file
         std.file.write(deleteme, "");
         auto f = File(deleteme, "r");
@@ -4124,9 +4131,12 @@ private struct ChunksImpl
                 if (!f.eof) throw new StdioException(null);
                 buffer.length = r;
             }
-            static if (is(typeof(dg(tally, buffer)))) {
+            static if (is(typeof(dg(tally, buffer))))
+            {
                 if ((result = dg(tally, buffer)) != 0) break;
-            } else {
+            }
+            else
+            {
                 if ((result = dg(buffer)) != 0) break;
             }
             ++tally;
@@ -4451,9 +4461,11 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
          */
       L1:
         int c;
-        while ((c = FGETC(fp)) != -1) {
+        while ((c = FGETC(fp)) != -1)
+        {
             app.putchar(cast(char) c);
-            if (c == terminator) {
+            if (c == terminator)
+            {
                 buf = app.data;
                 return buf.length;
             }
@@ -4535,9 +4547,11 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     app.initialize(buf);
 
     int c;
-    while ((c = FGETC(fp)) != -1) {
+    while ((c = FGETC(fp)) != -1)
+    {
         app.putchar(cast(char) c);
-        if (c == terminator) {
+        if (c == terminator)
+        {
             buf = app.data;
             return buf.length;
         }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1,4 +1,4 @@
-﻿// Written in the D programming language.
+// Written in the D programming language.
 
 /**
 Standard I/O functions that extend $(B core.stdc.stdio).  $(B core.stdc.stdio)
@@ -2583,7 +2583,7 @@ $(D Range) that locks the file and allows fast writing to it.
         }
 
         // @@@BUG@@@ 2340
-        //void front(C)(C c) if (is(C : dchar)) {
+        //void front(C)(C c) if (is(C : dchar))
         /// ditto
         void put(C)(C c) @safe if (is(C : const(dchar)))
         {

--- a/std/stream.d
+++ b/std/stream.d
@@ -414,7 +414,8 @@ class Stream : InputStream, OutputStream {
   // reads block of data of specified size,
   // throws ReadException on error
   void readExact(void* buffer, size_t size) {
-    for (;;) {
+    for (;;)
+    {
       if (!size) return;
       size_t readsize = readBlock(buffer, size); // return 0 on eof
       if (readsize == 0) break;
@@ -479,14 +480,19 @@ class Stream : InputStream, OutputStream {
   char[] readLine(char[] result) {
     size_t strlen = 0;
     char ch = getc();
-    while (readable) {
-      switch (ch) {
+    while (readable)
+    {
+      switch (ch)
+      {
       case '\r':
-        if (seekable) {
+        if (seekable)
+        {
           ch = getc();
           if (ch != '\n')
             ungetc(ch);
-        } else {
+        }
+        else
+        {
           prevCr = true;
         }
         goto case;
@@ -496,9 +502,12 @@ class Stream : InputStream, OutputStream {
         return result;
 
       default:
-        if (strlen < result.length) {
+        if (strlen < result.length)
+        {
           result[strlen] = ch;
-        } else {
+        }
+        else
+        {
           result ~= ch;
         }
         strlen++;
@@ -522,14 +531,19 @@ class Stream : InputStream, OutputStream {
   wchar[] readLineW(wchar[] result) {
     size_t strlen = 0;
     wchar c = getcw();
-    while (readable) {
-      switch (c) {
+    while (readable)
+    {
+      switch (c)
+      {
       case '\r':
-        if (seekable) {
+        if (seekable)
+        {
           c = getcw();
           if (c != '\n')
             ungetcw(c);
-        } else {
+        }
+        else
+        {
           prevCr = true;
         }
         goto case;
@@ -539,9 +553,12 @@ class Stream : InputStream, OutputStream {
         return result;
 
       default:
-        if (strlen < result.length) {
+        if (strlen < result.length)
+        {
           result[strlen] = c;
-        } else {
+        }
+        else
+        {
           result ~= c;
         }
         strlen++;
@@ -556,7 +573,8 @@ class Stream : InputStream, OutputStream {
   int opApply(scope int delegate(ref char[] line) dg) {
     int res = 0;
     char[128] buf;
-    while (!eof) {
+    while (!eof)
+    {
       char[] line = readLine(buf);
       res = dg(line);
       if (res) break;
@@ -569,7 +587,8 @@ class Stream : InputStream, OutputStream {
     int res = 0;
     ulong n = 1;
     char[128] buf;
-    while (!eof) {
+    while (!eof)
+    {
       auto line = readLine(buf);
       res = dg(n,line);
       if (res) break;
@@ -582,7 +601,8 @@ class Stream : InputStream, OutputStream {
   int opApply(scope int delegate(ref wchar[] line) dg) {
     int res = 0;
     wchar[128] buf;
-    while (!eof) {
+    while (!eof)
+    {
       auto line = readLineW(buf);
       res = dg(line);
       if (res) break;
@@ -595,7 +615,8 @@ class Stream : InputStream, OutputStream {
     int res = 0;
     ulong n = 1;
     wchar[128] buf;
-    while (!eof) {
+    while (!eof)
+    {
       auto line = readLineW(buf);
       res = dg(n,line);
       if (res) break;
@@ -629,16 +650,20 @@ class Stream : InputStream, OutputStream {
   // returns char.init on eof.
   char getc() {
     char c;
-    if (prevCr) {
+    if (prevCr)
+    {
       prevCr = false;
       c = getc();
       if (c != '\n')
         return c;
     }
-    if (unget.length > 1) {
+    if (unget.length > 1)
+    {
       c = cast(char)unget[unget.length - 1];
       unget.length = unget.length - 1;
-    } else {
+    }
+    else
+    {
       readBlock(&c,1);
     }
     return c;
@@ -649,16 +674,20 @@ class Stream : InputStream, OutputStream {
   // returns wchar.init on eof.
   wchar getcw() {
     wchar c;
-    if (prevCr) {
+    if (prevCr)
+    {
       prevCr = false;
       c = getcw();
       if (c != '\n')
         return c;
     }
-    if (unget.length > 1) {
+    if (unget.length > 1)
+    {
       c = unget[unget.length - 1];
       unget.length = unget.length - 1;
-    } else {
+    }
+    else
+    {
       void* buf = &c;
       size_t n = readBlock(buf,2);
       if (n == 1 && readBlock(buf+1,1) == 0)
@@ -695,12 +724,15 @@ class Stream : InputStream, OutputStream {
     int count = 0, i = 0;
     char c;
     bool firstCharacter = true;
-    while ((j < arguments.length || i < fmt.length) && !eof) {
-      if (firstCharacter) {
+    while ((j < arguments.length || i < fmt.length) && !eof)
+    {
+      if (firstCharacter)
+      {
         c = getc();
         firstCharacter = false;
       }
-      if (fmt.length == 0 || i == fmt.length) {
+      if (fmt.length == 0 || i == fmt.length)
+      {
         i = 0;
         if (arguments[j] is typeid(string) || arguments[j] is typeid(char[])
             || arguments[j] is typeid(const(char)[])) {
@@ -725,7 +757,9 @@ class Stream : InputStream, OutputStream {
                    arguments[j] is typeid(wchar[]*) ||
                    arguments[j] is typeid(dchar[]*)) {
           fmt = "%s";
-        } else if (arguments[j] is typeid(char*)) {
+        }
+        else if (arguments[j] is typeid(char*))
+        {
           fmt = "%c";
         }
       }
@@ -738,7 +772,8 @@ class Stream : InputStream, OutputStream {
         }
         // read field width
         int width = 0;
-        while (isDigit(fmt[i])) {
+        while (isDigit(fmt[i]))
+        {
           width = width * 10 + (fmt[i] - '0');
           i++;
         }
@@ -748,7 +783,8 @@ class Stream : InputStream, OutputStream {
         if (fmt[i] == 'h' || fmt[i] == 'l' || fmt[i] == 'L')
           i++;
         // check the typechar and act accordingly
-        switch (fmt[i]) {
+        switch (fmt[i])
+        {
         case 'd':       // decimal/hexadecimal/octal integer
         case 'D':
         case 'u':
@@ -760,16 +796,20 @@ class Stream : InputStream, OutputStream {
         case 'i':
         case 'I':
           {
-            while (isWhite(c)) {
+            while (isWhite(c))
+            {
               c = getc();
               count++;
             }
             bool neg = false;
-            if (c == '-') {
+            if (c == '-')
+            {
               neg = true;
               c = getc();
               count++;
-            } else if (c == '+') {
+            }
+            else if (c == '+')
+            {
               c = getc();
               count++;
             }
@@ -794,7 +834,8 @@ class Stream : InputStream, OutputStream {
             {
                 case 'd':       // decimal
                 case 'u': {
-                  while (isDigit(c) && width) {
+                  while (isDigit(c) && width)
+                  {
                     n = n * 10 + (c - '0');
                     width--;
                     c = getc();
@@ -803,7 +844,8 @@ class Stream : InputStream, OutputStream {
                 } break;
 
                 case 'o': {     // octal
-                  while (isOctalDigit(c) && width) {
+                  while (isOctalDigit(c) && width)
+                  {
                     n = n * 8 + (c - '0');
                     width--;
                     c = getc();
@@ -812,7 +854,8 @@ class Stream : InputStream, OutputStream {
                 } break;
 
                 case 'x': {     // hexadecimal
-                  while (isHexDigit(c) && width) {
+                  while (isHexDigit(c) && width)
+                  {
                     n *= 0x10;
                     if (isDigit(c))
                       n += c - '0';
@@ -829,28 +872,43 @@ class Stream : InputStream, OutputStream {
             }
             if (neg)
               n = -n;
-            if (arguments[j] is typeid(int*)) {
+            if (arguments[j] is typeid(int*))
+            {
               int* p = va_arg!(int*)(args);
               *p = cast(int)n;
-            } else if (arguments[j] is typeid(short*)) {
+            }
+            else if (arguments[j] is typeid(short*))
+            {
               short* p = va_arg!(short*)(args);
               *p = cast(short)n;
-            } else if (arguments[j] is typeid(byte*)) {
+            }
+            else if (arguments[j] is typeid(byte*))
+            {
               byte* p = va_arg!(byte*)(args);
               *p = cast(byte)n;
-            } else if (arguments[j] is typeid(long*)) {
+            }
+            else if (arguments[j] is typeid(long*))
+            {
               long* p = va_arg!(long*)(args);
               *p = n;
-            } else if (arguments[j] is typeid(uint*)) {
+            }
+            else if (arguments[j] is typeid(uint*))
+            {
               uint* p = va_arg!(uint*)(args);
               *p = cast(uint)n;
-            } else if (arguments[j] is typeid(ushort*)) {
+            }
+            else if (arguments[j] is typeid(ushort*))
+            {
               ushort* p = va_arg!(ushort*)(args);
               *p = cast(ushort)n;
-            } else if (arguments[j] is typeid(ubyte*)) {
+            }
+            else if (arguments[j] is typeid(ubyte*))
+            {
               ubyte* p = va_arg!(ubyte*)(args);
               *p = cast(ubyte)n;
-            } else if (arguments[j] is typeid(ulong*)) {
+            }
+            else if (arguments[j] is typeid(ulong*))
+            {
               ulong* p = va_arg!(ulong*)(args);
               *p = cast(ulong)n;
             }
@@ -865,32 +923,39 @@ class Stream : InputStream, OutputStream {
         case 'g':
         case 'G':
           {
-            while (isWhite(c)) {
+            while (isWhite(c))
+            {
               c = getc();
               count++;
             }
             bool neg = false;
-            if (c == '-') {
+            if (c == '-')
+            {
               neg = true;
               c = getc();
               count++;
-            } else if (c == '+') {
+            }
+            else if (c == '+')
+            {
               c = getc();
               count++;
             }
             real r = 0;
-            while (isDigit(c) && width) {
+            while (isDigit(c) && width)
+            {
               r = r * 10 + (c - '0');
               width--;
               c = getc();
               count++;
             }
-            if (width && c == '.') {
+            if (width && c == '.')
+            {
               width--;
               c = getc();
               count++;
               double frac = 1;
-              while (isDigit(c) && width) {
+              while (isDigit(c) && width)
+              {
                 r = r * 10 + (c - '0');
                 frac *= 10;
                 width--;
@@ -899,47 +964,59 @@ class Stream : InputStream, OutputStream {
               }
               r /= frac;
             }
-            if (width && (c == 'e' || c == 'E')) {
+            if (width && (c == 'e' || c == 'E'))
+            {
               width--;
               c = getc();
               count++;
-              if (width) {
+              if (width)
+              {
                 bool expneg = false;
-                if (c == '-') {
+                if (c == '-')
+                {
                   expneg = true;
                   width--;
                   c = getc();
                   count++;
-                } else if (c == '+') {
+                }
+                else if (c == '+')
+                {
                   width--;
                   c = getc();
                   count++;
                 }
                 real exp = 0;
-                while (isDigit(c) && width) {
+                while (isDigit(c) && width)
+                {
                   exp = exp * 10 + (c - '0');
                   width--;
                   c = getc();
                   count++;
                 }
-                if (expneg) {
+                if (expneg)
+                {
                   while (exp--)
                     r /= 10;
-                } else {
+                }
+                else
+                {
                   while (exp--)
                     r *= 10;
                 }
               }
             }
-            if (width && (c == 'n' || c == 'N')) {
+            if (width && (c == 'n' || c == 'N'))
+            {
               width--;
               c = getc();
               count++;
-              if (width && (c == 'a' || c == 'A')) {
+              if (width && (c == 'a' || c == 'A'))
+              {
                 width--;
                 c = getc();
                 count++;
-                if (width && (c == 'n' || c == 'N')) {
+                if (width && (c == 'n' || c == 'N'))
+                {
                   width--;
                   c = getc();
                   count++;
@@ -947,15 +1024,18 @@ class Stream : InputStream, OutputStream {
                 }
               }
             }
-            if (width && (c == 'i' || c == 'I')) {
+            if (width && (c == 'i' || c == 'I'))
+            {
               width--;
               c = getc();
               count++;
-              if (width && (c == 'n' || c == 'N')) {
+              if (width && (c == 'n' || c == 'N'))
+              {
                 width--;
                 c = getc();
                 count++;
-                if (width && (c == 'f' || c == 'F')) {
+                if (width && (c == 'f' || c == 'F'))
+                {
                   width--;
                   c = getc();
                   count++;
@@ -965,13 +1045,18 @@ class Stream : InputStream, OutputStream {
             }
             if (neg)
               r = -r;
-            if (arguments[j] is typeid(float*)) {
+            if (arguments[j] is typeid(float*))
+            {
               float* p = va_arg!(float*)(args);
               *p = r;
-            } else if (arguments[j] is typeid(double*)) {
+            }
+            else if (arguments[j] is typeid(double*))
+            {
               double* p = va_arg!(double*)(args);
               *p = r;
-            } else if (arguments[j] is typeid(real*)) {
+            }
+            else if (arguments[j] is typeid(real*))
+            {
               real* p = va_arg!(real*)(args);
               *p = r;
             }
@@ -980,21 +1065,27 @@ class Stream : InputStream, OutputStream {
           } break;
 
         case 's': {     // string
-          while (isWhite(c)) {
+          while (isWhite(c))
+          {
             c = getc();
             count++;
           }
           char[] s;
           char[]* p;
           size_t strlen;
-          if (arguments[j] is typeid(char[]*)) {
+          if (arguments[j] is typeid(char[]*))
+          {
             p = va_arg!(char[]*)(args);
             s = *p;
           }
-          while (!isWhite(c) && c != char.init) {
-            if (strlen < s.length) {
+          while (!isWhite(c) && c != char.init)
+          {
+            if (strlen < s.length)
+            {
               s[strlen] = c;
-            } else {
+            }
+            else
+            {
               s ~= c;
             }
             strlen++;
@@ -1002,16 +1093,23 @@ class Stream : InputStream, OutputStream {
             count++;
           }
           s = s[0 .. strlen];
-          if (arguments[j] is typeid(char[]*)) {
+          if (arguments[j] is typeid(char[]*))
+          {
             *p = s;
-          } else if (arguments[j] is typeid(char*)) {
+          }
+          else if (arguments[j] is typeid(char*))
+          {
             s ~= 0;
             auto q = va_arg!(char*)(args);
             q[0 .. s.length] = s[];
-          } else if (arguments[j] is typeid(wchar[]*)) {
+          }
+          else if (arguments[j] is typeid(wchar[]*))
+          {
             auto q = va_arg!(const(wchar)[]*)(args);
             *q = toUTF16(s);
-          } else if (arguments[j] is typeid(dchar[]*)) {
+          }
+          else if (arguments[j] is typeid(dchar[]*))
+          {
             auto q = va_arg!(const(dchar)[]*)(args);
             *q = toUTF32(s);
           }
@@ -1024,11 +1122,13 @@ class Stream : InputStream, OutputStream {
           if (width < 0)
             width = 1;
           else
-            while (isWhite(c)) {
+            while (isWhite(c))
+            {
             c = getc();
             count++;
           }
-          while (width-- && !eof) {
+          while (width-- && !eof)
+          {
             *(s++) = c;
             c = getc();
             count++;
@@ -1080,7 +1180,8 @@ class Stream : InputStream, OutputStream {
   // throws WriteException on error
   void writeExact(const void* buffer, size_t size) {
     const(void)* p = buffer;
-    for (;;) {
+    for (;;)
+    {
       if (!size) return;
       size_t writesize = writeBlock(p, size);
       if (writesize == 0) break;
@@ -1176,14 +1277,18 @@ class Stream : InputStream, OutputStream {
     auto f = toStringz(format);
     size_t psize = buffer.length;
     size_t count;
-    while (true) {
-      version (Windows) {
+    while (true)
+    {
+      version (Windows)
+      {
         count = vsnprintf(p, psize, f, args);
         if (count != -1)
           break;
         psize *= 2;
         p = cast(char*) alloca(psize);
-      } else version (Posix) {
+      }
+      else version (Posix)
+      {
         count = vsnprintf(p, psize, f, args);
         if (count == -1)
           psize *= 2;
@@ -1239,14 +1344,18 @@ class Stream : InputStream, OutputStream {
    * This restores the file position of s so that it is unchanged.
    */
   void copyFrom(Stream s) {
-    if (seekable) {
+    if (seekable)
+    {
       ulong pos = s.position;
       s.position = 0;
       copyFrom(s, s.size);
       s.position = pos;
-    } else {
+    }
+    else
+    {
       ubyte[128] buf;
-      while (!s.eof) {
+      while (!s.eof)
+      {
         size_t m = s.readBlock(buf.ptr, buf.length);
         writeExact(buf.ptr, m);
       }
@@ -1260,7 +1369,8 @@ class Stream : InputStream, OutputStream {
    */
   void copyFrom(Stream s, ulong count) {
     ubyte[128] buf;
-    while (count > 0) {
+    while (count > 0)
+    {
       size_t n = cast(size_t)(count<buf.length ? count : buf.length);
       s.readExact(buf.ptr, n);
       writeExact(buf.ptr, n);
@@ -1347,21 +1457,26 @@ class Stream : InputStream, OutputStream {
         size_t rdlen;
         size_t blockSize;
         char[] result;
-        if (seekable) {
+        if (seekable)
+        {
           ulong orig_pos = position;
           scope(exit) position = orig_pos;
           position = 0;
           blockSize = cast(size_t)size;
           result = new char[blockSize];
-          while (blockSize > 0) {
+          while (blockSize > 0)
+          {
             rdlen = readBlock(&result[pos], blockSize);
             pos += rdlen;
             blockSize -= rdlen;
           }
-        } else {
+        }
+        else
+        {
           blockSize = 4096;
           result = new char[blockSize];
-          while ((rdlen = readBlock(&result[pos], blockSize)) > 0) {
+          while ((rdlen = readBlock(&result[pos], blockSize)) > 0)
+          {
             pos += rdlen;
             blockSize += rdlen;
             result.length = result.length + blockSize;
@@ -1537,12 +1652,15 @@ class FilterStream : Stream {
    * any readable, writeable, seekable, isopen and buffering flags.
    */
   void resetSource() {
-    if (s !is null) {
+    if (s !is null)
+    {
       readable = s.readable;
       writeable = s.writeable;
       seekable = s.seekable;
       isopen = s.isOpen;
-    } else {
+    }
+    else
+    {
       readable = writeable = seekable = false;
       isopen = false;
     }
@@ -1563,7 +1681,8 @@ class FilterStream : Stream {
 
   // close stream
   override void close() {
-    if (isopen) {
+    if (isopen)
+    {
       super.close();
       if (nestClose)
         s.close();
@@ -1642,7 +1761,8 @@ class BufferedStream : FilterStream {
     ubyte* outbuf = cast(ubyte*)result;
     size_t readsize = 0;
 
-    if (bufferCurPos + len < bufferLen) {
+    if (bufferCurPos + len < bufferLen)
+    {
       // buffer has all the data so copy it
       outbuf[0 .. len] = buffer[bufferCurPos .. bufferCurPos+len];
       bufferCurPos += len;
@@ -1651,7 +1771,8 @@ class BufferedStream : FilterStream {
     }
 
     readsize = bufferLen - bufferCurPos;
-    if (readsize > 0) {
+    if (readsize > 0)
+    {
       // buffer has some data so copy what is left
       outbuf[0 .. readsize] = buffer[bufferCurPos .. bufferLen];
       outbuf += readsize;
@@ -1661,12 +1782,15 @@ class BufferedStream : FilterStream {
 
     flush();
 
-    if (len >= buffer.length) {
+    if (len >= buffer.length)
+    {
       // buffer can't hold the data so fill output buffer directly
       size_t siz = super.readBlock(outbuf, len);
       readsize += siz;
       streamPos += siz;
-    } else {
+    }
+    else
+    {
       // read a new block into buffer
         bufferLen = super.readBlock(buffer.ptr, buffer.length);
         if (bufferLen < len) len = bufferLen;
@@ -1689,15 +1813,19 @@ class BufferedStream : FilterStream {
     ubyte* buf = cast(ubyte*)result;
     size_t writesize = 0;
 
-    if (bufferLen == 0) {
+    if (bufferLen == 0)
+    {
       // buffer is empty so fill it if possible
-      if ((len < buffer.length) && (readable)) {
+      if ((len < buffer.length) && (readable))
+      {
         // read in data if the buffer is currently empty
         bufferLen = s.readBlock(buffer.ptr, buffer.length);
         bufferSourcePos = bufferLen;
         streamPos += bufferLen;
 
-      } else if (len >= buffer.length) {
+      }
+      else if (len >= buffer.length)
+      {
         // buffer can't hold the data so write it directly and exit
         writesize = s.writeBlock(buf,len);
         streamPos += writesize;
@@ -1705,7 +1833,8 @@ class BufferedStream : FilterStream {
       }
     }
 
-    if (bufferCurPos + len <= buffer.length) {
+    if (bufferCurPos + len <= buffer.length)
+    {
       // buffer has space for all the data so copy it and exit
       buffer[bufferCurPos .. bufferCurPos+len] = buf[0 .. len];
       bufferCurPos += len;
@@ -1716,7 +1845,8 @@ class BufferedStream : FilterStream {
     }
 
     writesize = buffer.length - bufferCurPos;
-    if (writesize > 0) {
+    if (writesize > 0)
+    {
       // buffer can take some data
       buffer[bufferCurPos .. buffer.length] = buf[0 .. writesize];
       bufferCurPos = bufferLen = buffer.length;
@@ -1744,7 +1874,9 @@ class BufferedStream : FilterStream {
         (offset + bufferCurPos >= bufferLen)) {
       flush();
       streamPos = s.seek(offset,whence);
-    } else {
+    }
+    else
+    {
       bufferCurPos += offset;
     }
     readEOF = false;
@@ -1765,28 +1897,42 @@ class BufferedStream : FilterStream {
           ubyte*  pc = cast(ubyte*)&c;
 
         L0:
-          for (;;) {
+          for (;;)
+          {
               size_t start = bufferCurPos;
             L1:
-              foreach (ubyte b; buffer[start .. bufferLen]) {
+              foreach (ubyte b; buffer[start .. bufferLen])
+              {
                   bufferCurPos++;
                   pc[idx] = b;
-                  if (idx < T.sizeof - 1) {
+                  if (idx < T.sizeof - 1)
+                  {
                       idx++;
                       continue L1;
-                  } else {
+                  }
+                  else
+                  {
                       idx = 0;
                   }
-                  if (c == '\n' || haveCR) {
+                  if (c == '\n' || haveCR)
+                  {
                       if (haveCR && c != '\n') bufferCurPos--;
                       break L0;
-                  } else {
-                      if (c == '\r') {
+                  }
+                  else
+                  {
+                      if (c == '\r')
+                      {
                           haveCR = true;
-                      } else {
-                          if (lineSize < inBuffer.length) {
+                      }
+                      else
+                      {
+                          if (lineSize < inBuffer.length)
+                          {
                               inBuffer[lineSize] = c;
-                          } else {
+                          }
+                          else
+                          {
                               inBuffer ~= c;
                           }
                           lineSize++;
@@ -1826,20 +1972,24 @@ class BufferedStream : FilterStream {
     assert(bufferLen == 0);
   }
   body {
-    if (writeable && bufferDirty) {
-      if (bufferSourcePos != 0 && seekable) {
+    if (writeable && bufferDirty)
+    {
+      if (bufferSourcePos != 0 && seekable)
+      {
         // move actual file pointer to front of buffer
         streamPos = s.seek(-bufferSourcePos, SeekPos.Current);
       }
       // write buffer out
       bufferSourcePos = s.writeBlock(buffer.ptr, bufferLen);
-      if (bufferSourcePos != bufferLen) {
+      if (bufferSourcePos != bufferLen)
+      {
         throw new WriteException("Unable to write to stream");
       }
     }
     super.flush();
     long diff = cast(long)bufferCurPos-bufferSourcePos;
-    if (diff != 0 && seekable) {
+    if (diff != 0 && seekable)
+    {
       // move actual file pointer to current position
       streamPos = s.seek(diff, SeekPos.Current);
     }
@@ -1850,7 +2000,8 @@ class BufferedStream : FilterStream {
 
   // returns true if end of stream is reached, false otherwise
   override @property bool eof() {
-    if ((buffer.length == 0) || !readable) {
+    if ((buffer.length == 0) || !readable)
+    {
       return super.eof;
     }
     // some simple tests to avoid flushing
@@ -1897,14 +2048,16 @@ enum FileMode {
   Append = 10 /// Opens the file for writing, appending new data to the end of the file.
 }
 
-version (Windows) {
+version (Windows)
+{
   private import core.sys.windows.windows;
   extern (Windows) {
     void FlushFileBuffers(HANDLE hFile);
     DWORD  GetFileType(HANDLE hFile);
   }
 }
-version (Posix) {
+version (Posix)
+{
   private import core.sys.posix.fcntl;
   private import core.sys.posix.unistd;
   alias HANDLE = int;
@@ -1913,19 +2066,23 @@ version (Posix) {
 /// This subclass is for unbuffered file system streams.
 class File: Stream {
 
-  version (Windows) {
+  version (Windows)
+  {
     private HANDLE hFile;
   }
-  version (Posix) {
+  version (Posix)
+  {
     private HANDLE hFile = -1;
   }
 
   this() {
     super();
-    version (Windows) {
+    version (Windows)
+    {
       hFile = null;
     }
-    version (Posix) {
+    version (Posix)
+    {
       hFile = -1;
     }
     isopen = false;
@@ -1937,9 +2094,12 @@ class File: Stream {
     this.hFile = hFile;
     readable = cast(bool)(mode & FileMode.In);
     writeable = cast(bool)(mode & FileMode.Out);
-    version(Windows) {
+    version(Windows)
+    {
       seekable = GetFileType(hFile) == 1; // FILE_TYPE_DISK
-    } else {
+    }
+    else
+    {
       auto result = lseek(hFile, 0, 0);
       seekable = (result != ~0);
     }
@@ -1976,12 +2136,14 @@ class File: Stream {
     seekable = true;
     readable = cast(bool)(mode & FileMode.In);
     writeable = cast(bool)(mode & FileMode.Out);
-    version (Windows) {
+    version (Windows)
+    {
       hFile = CreateFileW(filename.tempCStringW(), access, share,
                           null, createMode, 0, null);
       isopen = hFile != INVALID_HANDLE_VALUE;
     }
-    version (Posix) {
+    version (Posix)
+    {
       hFile = core.sys.posix.fcntl.open(filename.tempCString(), access | createMode, share);
       isopen = hFile != -1;
     }
@@ -1996,33 +2158,42 @@ class File: Stream {
                          out int access,
                          out int share,
                          out int createMode) {
-    version (Windows) {
+    version (Windows)
+    {
       share |= FILE_SHARE_READ | FILE_SHARE_WRITE;
-      if (mode & FileMode.In) {
+      if (mode & FileMode.In)
+      {
         access |= GENERIC_READ;
         createMode = OPEN_EXISTING;
       }
-      if (mode & FileMode.Out) {
+      if (mode & FileMode.Out)
+      {
         access |= GENERIC_WRITE;
         createMode = OPEN_ALWAYS; // will create if not present
       }
-      if ((mode & FileMode.OutNew) == FileMode.OutNew) {
+      if ((mode & FileMode.OutNew) == FileMode.OutNew)
+      {
         createMode = CREATE_ALWAYS; // resets file
       }
     }
-    version (Posix) {
+    version (Posix)
+    {
       share = octal!666;
-      if (mode & FileMode.In) {
+      if (mode & FileMode.In)
+      {
         access = O_RDONLY;
       }
-      if (mode & FileMode.Out) {
+      if (mode & FileMode.Out)
+      {
         createMode = O_CREAT; // will create if not present
         access = O_WRONLY;
       }
-      if (access == (O_WRONLY | O_RDONLY)) {
+      if (access == (O_WRONLY | O_RDONLY))
+      {
         access = O_RDWR;
       }
-      if ((mode & FileMode.OutNew) == FileMode.OutNew) {
+      if ((mode & FileMode.OutNew) == FileMode.OutNew)
+      {
         access |= O_TRUNC; // resets file
       }
     }
@@ -2041,13 +2212,18 @@ class File: Stream {
 
   /// Close the current file if it is open; otherwise it does nothing.
   override void close() {
-    if (isopen) {
+    if (isopen)
+    {
       super.close();
-      if (hFile) {
-        version (Windows) {
+      if (hFile)
+      {
+        version (Windows)
+        {
           CloseHandle(hFile);
           hFile = null;
-        } else version (Posix) {
+        }
+        else version (Posix)
+        {
           core.sys.posix.unistd.close(hFile);
           hFile = -1;
         }
@@ -2058,7 +2234,8 @@ class File: Stream {
   // destructor, closes file if still opened
   ~this() { close(); }
 
-  version (Windows) {
+  version (Windows)
+  {
     // returns size of stream
     override @property ulong size() {
       assertSeekable();
@@ -2070,11 +2247,14 @@ class File: Stream {
 
   override size_t readBlock(void* buffer, size_t size) {
     assertReadable();
-    version (Windows) {
+    version (Windows)
+    {
       auto dwSize = to!DWORD(size);
       ReadFile(hFile, buffer, dwSize, &dwSize, null);
       size = dwSize;
-    } else version (Posix) {
+    }
+    else version (Posix)
+    {
       size = core.sys.posix.unistd.read(hFile, buffer, size);
       if (size == -1)
         size = 0;
@@ -2085,11 +2265,14 @@ class File: Stream {
 
   override size_t writeBlock(const void* buffer, size_t size) {
     assertWriteable();
-    version (Windows) {
+    version (Windows)
+    {
       auto dwSize = to!DWORD(size);
       WriteFile(hFile, buffer, dwSize, &dwSize, null);
       size = dwSize;
-    } else version (Posix) {
+    }
+    else version (Posix)
+    {
       size = core.sys.posix.unistd.write(hFile, buffer, size);
       if (size == -1)
         size = 0;
@@ -2099,13 +2282,16 @@ class File: Stream {
 
   override ulong seek(long offset, SeekPos rel) {
     assertSeekable();
-    version (Windows) {
+    version (Windows)
+    {
       int hi = cast(int)(offset>>32);
       uint low = SetFilePointer(hFile, cast(int)offset, &hi, rel);
       if ((low == INVALID_SET_FILE_POINTER) && (GetLastError() != 0))
         throw new SeekException("unable to move file pointer");
       ulong result = (cast(ulong)hi << 32) + low;
-    } else version (Posix) {
+    }
+    else version (Posix)
+    {
       auto result = lseek(hFile, cast(off_t)offset, rel);
       if (result == cast(typeof(result))-1)
         throw new SeekException("unable to move file pointer");
@@ -2120,7 +2306,8 @@ class File: Stream {
    */
 
   override @property size_t available() {
-    if (seekable) {
+    if (seekable)
+    {
       ulong lavail = size - position;
       if (lavail > size_t.max) lavail = size_t.max;
       return cast(size_t)lavail;
@@ -2133,7 +2320,8 @@ class File: Stream {
   HANDLE handle() { return hFile; }
 
   // run a few tests
-  unittest {
+  unittest
+  {
     import std.internal.cstring : tempCString;
     import core.stdc.stdio : remove;
 
@@ -2189,7 +2377,8 @@ class File: Stream {
     file.writeLine("That was blank");
     file.position = 0;
     char[][] lines;
-    foreach (char[] line; file) {
+    foreach (char[] line; file)
+    {
       lines ~= line.dup;
     }
     assert( lines.length == 4 );
@@ -2199,7 +2388,8 @@ class File: Stream {
     assert( lines[3] == "That was blank");
     file.position = 0;
     lines = new char[][4];
-    foreach (ulong n, char[] line; file) {
+    foreach (ulong n, char[] line; file)
+    {
       lines[cast(size_t)(n-1)] = line.dup;
     }
     assert( lines[0] == "Testing stream.d:");
@@ -2254,7 +2444,8 @@ class BufferedFile: BufferedStream {
   }
 
   // run a few tests same as File
-  unittest {
+  unittest
+  {
     import std.internal.cstring : tempCString;
     import core.stdc.stdio : remove;
 
@@ -2374,10 +2565,12 @@ class EndianStream : FilterStream {
     ubyte[4] BOM_buffer;
     int n = 0;       // the number of read bytes
     int result = -1; // the last match or -1
-    for (int i=0; i < NBOMS; ++i) {
+    for (int i=0; i < NBOMS; ++i)
+    {
       int j;
       immutable ubyte[] bom = ByteOrderMarks[i];
-      for (j=0; j < bom.length; ++j) {
+      for (j=0; j < bom.length; ++j)
+      {
         if (n <= j) { // have to read more
           if (eof)
             break;
@@ -2390,17 +2583,20 @@ class EndianStream : FilterStream {
         result = i;
     }
     ptrdiff_t m = 0;
-    if (result != -1) {
+    if (result != -1)
+    {
       endian = BOMEndian[result]; // set stream endianness
       m = ByteOrderMarks[result].length;
     }
-    if ((ungetCharSize == 1 && result == -1) || (result == BOM.UTF8)) {
+    if ((ungetCharSize == 1 && result == -1) || (result == BOM.UTF8))
+    {
       while (n-- > m)
         ungetc(BOM_buffer[n]);
     } else { // should eventually support unget for dchar as well
       if (n & 1) // make sure we have an even number of bytes
         readExact(&BOM_buffer[n++],1);
-      while (n > m) {
+      while (n > m)
+      {
         n -= 2;
         wchar cw = *(cast(wchar*)&BOM_buffer[n]);
         fixBO(&cw,2);
@@ -2415,10 +2611,12 @@ class EndianStream : FilterStream {
    * size must be even.
    */
   final void fixBO(const(void)* buffer, size_t size) {
-    if (endian != std.system.endian) {
+    if (endian != std.system.endian)
+    {
       ubyte* startb = cast(ubyte*)buffer;
       uint* start = cast(uint*)buffer;
-      switch (size) {
+      switch (size)
+      {
       case 0: break;
       case 2: {
         ubyte x = *startb;
@@ -2432,7 +2630,8 @@ class EndianStream : FilterStream {
       }
       default: {
         uint* end = cast(uint*)(buffer + size - uint.sizeof);
-        while (start < end) {
+        while (start < end)
+        {
           uint x = bswap(*start);
           *start = bswap(*end);
           *end = x;
@@ -2455,7 +2654,8 @@ class EndianStream : FilterStream {
    * size must be even.
    */
   final void fixBlockBO(void* buffer, uint size, size_t repeat) {
-    while (repeat--) {
+    while (repeat--)
+    {
       fixBO(buffer,size);
       buffer += size;
     }
@@ -2484,16 +2684,20 @@ class EndianStream : FilterStream {
 
   override wchar getcw() {
     wchar c;
-    if (prevCr) {
+    if (prevCr)
+    {
       prevCr = false;
       c = getcw();
       if (c != '\n')
         return c;
     }
-    if (unget.length > 1) {
+    if (unget.length > 1)
+    {
       c = unget[unget.length - 1];
       unget.length = unget.length - 1;
-    } else {
+    }
+    else
+    {
       void* buf = &c;
       size_t n = readBlock(buf,2);
       if (n == 1 && readBlock(buf+1,1) == 0)
@@ -2538,7 +2742,8 @@ class EndianStream : FilterStream {
   override void write(dchar x) { fixBO(&x,x.sizeof); writeExact(&x, x.sizeof); }
 
   override void writeStringW(const(wchar)[] str) {
-    foreach (wchar cw;str) {
+    foreach (wchar cw;str)
+    {
       fixBO(&cw,2);
       s.writeExact(&cw, 2);
     }
@@ -2547,7 +2752,8 @@ class EndianStream : FilterStream {
   override @property bool eof() { return s.eof && !ungetAvailable();  }
   override @property ulong size() { return s.size;  }
 
-  unittest {
+  unittest
+  {
     MemoryStream m;
     m = new MemoryStream ();
     EndianStream em = new EndianStream(m,Endian.bigEndian);
@@ -2565,7 +2771,8 @@ class EndianStream : FilterStream {
     em.position = 0;
     static ubyte[12] x3 = [1,2,3,4,5,6,7,8,9,10,11,12];
     em.fixBO(x3.ptr,12);
-    if (std.system.endian == Endian.littleEndian) {
+    if (std.system.endian == Endian.littleEndian)
+    {
       assert( x3[0] == 12 );
       assert( x3[1] == 11 );
       assert( x3[2] == 10 );
@@ -2589,7 +2796,8 @@ class EndianStream : FilterStream {
     assert( m.data[1] == 0x55 );
     em.position = 0;
     em.fixBO(x3.ptr,12);
-    if (std.system.endian == Endian.bigEndian) {
+    if (std.system.endian == Endian.bigEndian)
+    {
       assert( x3[0] == 12 );
       assert( x3[1] == 11 );
       assert( x3[2] == 10 );
@@ -2688,7 +2896,8 @@ class TArrayStream(Buffer): Stream {
     assertSeekable();
     long scur; // signed to saturate to 0 properly
 
-    switch (rel) {
+    switch (rel)
+    {
     case SeekPos.Set: scur = offset; break;
     case SeekPos.Current: scur = cast(long)(cur + offset); break;
     case SeekPos.End: scur = cast(long)(len + offset); break;
@@ -2723,7 +2932,8 @@ class TArrayStream(Buffer): Stream {
 }
 
 /* Test the TArrayStream */
-unittest {
+unittest
+{
   char[100] buf;
   TArrayStream!(char[]) m;
 
@@ -2777,7 +2987,8 @@ class MemoryStream: TArrayStream!(ubyte[]) {
     return super.writeBlock(buffer,size);
   }
 
-  unittest {
+  unittest
+  {
     MemoryStream m;
 
     m = new MemoryStream ();
@@ -2839,14 +3050,16 @@ class MmFileStream : TArrayStream!(MmFile) {
   }
 
   override void flush() {
-    if (isopen) {
+    if (isopen)
+    {
       super.flush();
       buf.flush();
     }
   }
 
   override void close() {
-    if (isopen) {
+    if (isopen)
+    {
       super.close();
       delete buf;
       buf = null;
@@ -2854,7 +3067,8 @@ class MmFileStream : TArrayStream!(MmFile) {
   }
 }
 
-unittest {
+unittest
+{
   auto test_file = std.file.deleteme ~ "-testing.txt";
   MmFile mf = new MmFile(test_file,MmFile.Mode.readWriteNew,100,null);
   MmFileStream m;
@@ -2955,7 +3169,8 @@ class SliceStream : FilterStream {
     if (seekable)
       s.position = low + pos;
     size_t ret = super.readBlock(buffer, size);
-    if (seekable) {
+    if (seekable)
+    {
       pos = s.position - low;
       s.position = bp;
     }
@@ -2970,7 +3185,8 @@ class SliceStream : FilterStream {
     if (seekable)
       s.position = low + pos;
     size_t ret = s.writeBlock(buffer, size);
-    if (seekable) {
+    if (seekable)
+    {
       pos = s.position - low;
       s.position = bp;
     }
@@ -2981,7 +3197,8 @@ class SliceStream : FilterStream {
     assertSeekable();
     long spos;
 
-    switch (rel) {
+    switch (rel)
+    {
       case SeekPos.Set:
         spos = offset;
         break;
@@ -3014,7 +3231,8 @@ class SliceStream : FilterStream {
   override @property size_t available() {
     size_t res = s.available;
     ulong bp = s.position;
-    if (bp <= pos+low && pos+low <= bp+res) {
+    if (bp <= pos+low && pos+low <= bp+res)
+    {
       if (!bounded || bp+res <= high)
         return cast(size_t)(bp + res - pos - low);
       else if (high <= bp+res)
@@ -3023,7 +3241,8 @@ class SliceStream : FilterStream {
     return 0;
   }
 
-  unittest {
+  unittest
+  {
     MemoryStream m;
     SliceStream s;
 

--- a/std/string.d
+++ b/std/string.d
@@ -1574,7 +1574,8 @@ ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
 }
 
 ///
-@safe pure unittest {
+@safe pure unittest
+{
     import std.conv : to;
 
     ptrdiff_t i = "helloWorld".indexOfAny("Wr");

--- a/std/traits.d
+++ b/std/traits.d
@@ -970,7 +970,8 @@ template arity(alias func)
 }
 
 ///
-unittest {
+unittest
+{
     void foo(){}
     static assert(arity!foo==0);
     void bar(uint){}
@@ -6739,9 +6740,12 @@ template getUDAs(alias symbol, alias attribute)
     import std.typetuple : Filter;
 
     template isDesiredUDA(alias S) {
-        static if (__traits(compiles, is(typeof(S) == attribute))) {
+        static if (__traits(compiles, is(typeof(S) == attribute)))
+        {
             enum isDesiredUDA = is(typeof(S) == attribute);
-        } else {
+        }
+        else
+        {
             enum isDesiredUDA = isInstanceOf!(attribute, typeof(S));
         }
     }

--- a/std/uni.d
+++ b/std/uni.d
@@ -5304,7 +5304,8 @@ unittest
     alias fails8 = AliasSeq!("\xC1", "\x80\x00","\xC0\x00", "\xCF\x79",
         "\xFF\x00\0x00\0x00\x00", "\xC0\0x80\0x80\x80", "\x80\0x00\0x00\x00",
         "\xCF\x00\0x00\0x00\x00");
-    foreach (msg; fails8){
+    foreach (msg; fails8)
+    {
         assert(collectException((){
             auto s = msg;
             size_t idx = 0;
@@ -5313,7 +5314,8 @@ unittest
     }
     //decode failure cases UTF-16
     alias fails16 = AliasSeq!([0xD811], [0xDC02]);
-    foreach (msg; fails16){
+    foreach (msg; fails16)
+    {
         assert(collectException((){
             auto s = msg.map!(x => cast(wchar)x);
             utf16.test(s);
@@ -5580,7 +5582,8 @@ unittest
     auto trie4 = buildTrie!(bool, size_t, max4,
             sliceBits!(13, 16), sliceBits!(9, 13), sliceBits!(6, 9) , sliceBits!(0, 6)
         )(redundant4.byInterval);
-    foreach (i; 0..max4){
+    foreach (i; 0..max4)
+    {
         if (i in redundant4)
             assert(trie4[i], text(cast(uint)i));
     }
@@ -5899,7 +5902,8 @@ else
         target |= asSet(uniProps.So);
         target |= asSet(uniProps.Po);
     }
-    else if (ucmp(name, "graphical") == 0){
+    else if (ucmp(name, "graphical") == 0)
+    {
         target = asSet(uniProps.Alphabetic);
 
         target |= asSet(uniProps.Mn);
@@ -7287,7 +7291,8 @@ ubyte combiningClass(dchar ch) @safe pure nothrow @nogc
 }
 
 ///
-unittest{
+unittest
+{
     // shorten the code
     alias CC = combiningClass;
 
@@ -7362,7 +7367,8 @@ public dchar compose(dchar first, dchar second) pure nothrow
 }
 
 ///
-unittest{
+unittest
+{
     assert(compose('A','\u0308') == '\u00C4');
     assert(compose('A', 'B') == dchar.init);
     assert(compose('C', '\u0301') == '\u0106');
@@ -7780,14 +7786,16 @@ private size_t recompose(size_t start, dchar[] input, ubyte[] ccc) pure nothrow
                 // current was merged so its CCC shouldn't affect
                 // composing with the next one
             }
-            else {
+            else
+            {
                 // if it was a starter then accumCC is now 0, end of loop
                 accumCC = curCC;
                 if (accumCC == 0)
                     break;
             }
         }
-        else{
+        else
+        {
             // ditto here
             accumCC = curCC;
             if (accumCC == 0)

--- a/std/uri.d
+++ b/std/uri.d
@@ -102,7 +102,8 @@ private string URI_Encode(dstring string, uint unescapedSet)
                 char* R2;
 
                 Rsize *= 2;
-                if (Rsize > 1024) {
+                if (Rsize > 1024)
+                {
                     R2 = (new char[Rsize]).ptr;
                 }
                 else
@@ -182,7 +183,8 @@ private string URI_Encode(dstring string, uint unescapedSet)
                 char *R2;
 
                 Rsize = 2 * (Rlen + L * 3);
-                if (Rsize > 1024) {
+                if (Rsize > 1024)
+                {
                     R2 = (new char[Rsize]).ptr;
                 }
                 else
@@ -232,7 +234,8 @@ private dstring URI_Decode(Char)(in Char[] uri, uint reservedSet) if (isSomeChar
 
     // Preallocate result buffer R guaranteed to be large enough for result
     auto Rsize = len;
-    if (Rsize > 1024 / dchar.sizeof) {
+    if (Rsize > 1024 / dchar.sizeof)
+    {
         R = (new dchar[Rsize]).ptr;
     }
     else
@@ -428,7 +431,8 @@ ptrdiff_t uriLength(Char)(in Char[] s) if (isSomeChar!Char)
     if (s.length <= 4)
         return -1;
 
-    if (s.length > 7 && icmp(s[0 .. 7], "http://") == 0) {
+    if (s.length > 7 && icmp(s[0 .. 7], "http://") == 0)
+    {
         i = 7;
     }
     else

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -686,31 +686,39 @@ unittest // by Dave
 
 
     // smallish buffers
-    for (int idx = 0; idx < 25; idx++) {
+    for (int idx = 0; idx < 25; idx++)
+    {
         char[] buf = new char[uniform(0, 100)];
 
         // Alternate between more & less compressible
         foreach (ref char c; buf)
             c = cast(char) (' ' + (uniform(0, idx % 2 ? 91 : 2)));
 
-        if (CompressThenUncompress(buf)) {
+        if (CompressThenUncompress(buf))
+        {
             debug(zlib) writeln("; Success.");
-        } else {
+        }
+        else
+        {
             return;
         }
     }
 
     // larger buffers
-    for (int idx = 0; idx < 25; idx++) {
+    for (int idx = 0; idx < 25; idx++)
+    {
         char[] buf = new char[uniform(0, 1000/*0000*/)];
 
         // Alternate between more & less compressible
         foreach (ref char c; buf)
             c = cast(char) (' ' + (uniform(0, idx % 2 ? 91 : 10)));
 
-        if (CompressThenUncompress(buf)) {
+        if (CompressThenUncompress(buf))
+        {
             debug(zlib) writefln("; Success.");
-        } else {
+        }
+        else
+        {
             return;
         }
     }


### PR DESCRIPTION
again with the power of regular expressions :)

```
# find common cases
sed -E "s/^(\s*)((if|static if|for|foreach|foreach_reverse|while|unittest|switch|else).*)\s*\{$/\1\2\n\1{/" -i **/*.d
# catch else-if
sed -E "s/^(\s*)} (else static if| if|else)(.*)\s*\{$/\1}\n\1\2\n\1{/" -i **/*.d
# remove created trailing whitespace
sed -i 's/[ \t]*$//' **/*.d
```

afterwards only a small manual fixup was needed.

edit:
1) In case you aren't that familar with regular expressions - the grep just check when there is a `{` at the end of the line, so `while (true) { }` is still valid
2) this PR doesn't check for the all-man style in functions, that will be a follow-up once Dscanner has this functionality.