### PR TITLE
remove invalid copyright notices

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -15,7 +15,6 @@
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),
         $(WEB en.wikipedia.org/wiki/Ascii, Wikipedia)
 
-    Copyright: Copyright 2000 - 2013
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis
     Source:    $(PHOBOSSRC std/_ascii.d)

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -97,7 +97,6 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
         $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones,
               List of Time Zones)<br>
 
-    Copyright: Copyright 2010 - 2015
     License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis and Kato Shoichi
     Source:    $(PHOBOSSRC std/_datetime.d)


### PR DESCRIPTION
Found two modules with weird copyright info.
The new default Ddoc macro is "Copyright © 1999-2016 by the D Language Foundation".

The copyright notice is only displayed at the bottom of the page.