### PR TITLE
Ddoc: add class "simple-cheatsheet"

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 among,
         Checks if a value is among a set of values, e.g.

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 among,
         Checks if a value is among a set of values, e.g.

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 cache,
         Eagerly evaluates and caches another range's $(D front).)

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 cache,
         Eagerly evaluates and caches another range's $(D front).)

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 bringToFront,
         If $(D a = [1, 2, 3]) and $(D b = [4, 5, 6, 7]),

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 bringToFront,
         If $(D a = [1, 2, 3]) and $(D b = [4, 5, 6, 7]),

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 all,
         $(D all!"a > 0"([1, 2, 3, 4])) returns $(D true) because all elements

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 all,
         $(D all!"a > 0"([1, 2, 3, 4])) returns $(D true) because all elements

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 cartesianProduct,
         Computes Cartesian product of two ranges.)

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 cartesianProduct,
         Computes Cartesian product of two ranges.)

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -3,7 +3,8 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.
 
-$(BOOKTABLE Cheat Sheet,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description))
 $(T2 completeSort,
         If $(D a = [10, 20, 30]) and $(D b = [40, 6, 15]), then

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -3,8 +3,7 @@
 This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description))
 $(T2 completeSort,
         If $(D a = [10, 20, 30]) and $(D b = [40, 6, 15]), then

--- a/std/array.d
+++ b/std/array.d
@@ -4,7 +4,8 @@ Functions and types that manipulate built-in arrays and associative arrays.
 
 This module provides all kinds of functions to create, manipulate or convert arrays:
 
-$(BOOKTABLE ,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(D $(LREF _array)))

--- a/std/array.d
+++ b/std/array.d
@@ -4,8 +4,7 @@ Functions and types that manipulate built-in arrays and associative arrays.
 
 This module provides all kinds of functions to create, manipulate or convert arrays:
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(D $(LREF _array)))

--- a/std/functional.d
+++ b/std/functional.d
@@ -7,8 +7,7 @@ This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
 $(MREF std, algorithm) or $(MREF std, range).
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(D $(LREF adjoin)))

--- a/std/functional.d
+++ b/std/functional.d
@@ -7,7 +7,8 @@ This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
 $(MREF std, algorithm) or $(MREF std, range).
 
-$(BOOKTABLE ,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(D $(LREF adjoin)))

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -7,7 +7,8 @@ when runtime polymorphism is required. For this purpose, this submodule
 provides a number of object and $(D interface) definitions that can be used to
 wrap around _range objects created by the $(D std.range) templates.
 
-$(BOOKTABLE ,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
     $(TR $(TD $(D $(LREF InputRange)))
         $(TD Wrapper for input ranges.
     ))

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -7,8 +7,7 @@ when runtime polymorphism is required. For this purpose, this submodule
 provides a number of object and $(D interface) definitions that can be used to
 wrap around _range objects created by the $(D std.range) templates.
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
     $(TR $(TD $(D $(LREF InputRange)))
         $(TD Wrapper for input ranges.
     ))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -32,8 +32,7 @@ polymorphism.
 The remainder of this module provides a rich set of _range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
-$(TC table, simple-cheatsheet,
-$(T caption, Cheat Sheet)
+$(SIMPLE_CHEATSHEET
     $(TR $(TD $(D $(LREF chain)))
         $(TD Concatenates several ranges into a single _range.
     ))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -32,7 +32,8 @@ polymorphism.
 The remainder of this module provides a rich set of _range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
-$(BOOKTABLE ,
+$(TC table, simple-cheatsheet,
+$(T caption, Cheat Sheet)
     $(TR $(TD $(D $(LREF chain)))
         $(TD Concatenates several ranges into a single _range.
     ))


### PR DESCRIPTION
So that DDOX can choose not to display them.

.simple-cheatsheet tables play the same role as the listings that DDOX
generates. Having them both, and right after another, is confusing for
the reader, and doesn't add any value.

There are similar tables in
- std.experimental.ndslice.{iteration,selection},
- std.format,
- std.net.curl, and
- std.range.primitives,
  but they contain additional information or are embedded in text. So their
  presence should be less confusing.
