### PR TITLE
std.parallelism fatal flaw?

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4291,20 +4291,43 @@ unittest
     assertThrown!Exception(poolInstance.asyncBuf(ThrowingRange.init));
 }
 
+bool isNaN(float f)
+{
+    static import std.math;
+    return std.math.isNaN(f);
+}
+
+bool isNaN(double f)
+{
+    static import std.math;
+    return std.math.isNaN(f);
+}
+
+bool isNaN(real f)
+{
+    static import std.math;
+    return std.math.isNaN(f);
+}
+
 //version = parallelismStressTest;
 
 // These are more like stress tests than real unit tests.  They print out
 // tons of stuff and should not be run every time make unittest is run.
-version(parallelismStressTest)
+unittest
 {
-    unittest
+    testFunction(1);
+    testFunction2(1);
+}
+
+void testFunction(size_t runs)
     {
+        import std.stdio : stderr, writeln;
         size_t attempt;
-        for (; attempt < 10; attempt++)
+        for (; attempt < runs; attempt++)
             foreach (poolSize; [0, 4])
         {
 
-            poolInstance = new TaskPool(poolSize);
+            auto poolInstance = new TaskPool(poolSize);
 
             uint[] numbers = new uint[1_000];
 
@@ -4373,19 +4396,19 @@ version(parallelismStressTest)
             poolInstance.stop();
         }
 
-        assert(attempt == 10);
-        writeln("Press enter to go to next round of unittests.");
-        readln();
+        assert(attempt == runs);
     }
 
-    // These unittests are intended more for actual testing and not so much
-    // as examples.
-    unittest
+// These unittests are intended more for actual testing and not so much
+// as examples.
+void testFunction2(size_t runs)
     {
-        foreach (attempt; 0..10)
+        import std.stdio : stderr;
+
+        foreach (attempt; 0..runs)
         foreach (poolSize; [0, 4])
         {
-            poolInstance = new TaskPool(poolSize);
+            auto poolInstance = new TaskPool(poolSize);
 
             // Test indexing.
             stderr.writeln("Creator Raw Index:  ", poolInstance.threadIndex);
@@ -4540,7 +4563,6 @@ version(parallelismStressTest)
             poolInstance.stop();
         }
     }
-}
 
 version(unittest)
 {


### PR DESCRIPTION
Big parts of the std.parallelism unittests where not run for a very long time. 
Apparently they do not even compile anymore. This PR refactors the unittests 
so they are at least run once by default. While refactoring I found a couple of
problems with the unittests. Such as, local unittest function being unable to 
access the current stackframe. This destroyed some constructs used by 
std.parallelism.

I'm a noob when it comes to std.parallelism. I found this bug while scoping
imports. I need help on this!
