### PR TITLE
Ddoc: clean up macros in std.experimental.allocator

### DIFF
--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -201,8 +201,7 @@ or `import` `std.experimental.building_blocks`, which imports them all
 `public`ly. The building blocks can be assembled in unbounded ways and also
 combined with your own. For a collection of typical and useful preassembled
 allocators and for inspiration in defining more such assemblies, refer to
-$(LINK2 std_experimental_allocator_showcase.html,
-`std.experimental.allocator.building_blocks.showcase`).)
+$(MREF std,experimental,allocator,showcase).)
 
 $(BOOKTABLE,
 $(TR $(TH Allocator$(BR)) $(TH Description))
@@ -280,9 +279,8 @@ pointers on top of another allocator.)))
 )
 
 Macros:
-MYREF = $(LINK2 std_experimental_allocator_building_blocks_$2.html, $1)&nbsp;
-MYREF2 = $(LINK2 std_experimental_allocator_building_blocks_$2.html#$1, $1)&nbsp;
-MYREF3 = $(LINK2 std_experimental_allocator_$2.html#$1, $1)&nbsp;
+MYREF2 = $(REF_SHORT $1, std,experimental,allocator,building_blocks,$2)
+MYREF3 = $(REF_SHORT $1, std,experimental,allocator,$2)
 TDC = $(TDNW $(D $1)$+)
 TDC2 = $(TDNW $(D $(MYREF2 $1,$+))$(BR)$(SMALL
 $(D std.experimental.allocator.building_blocks.$2)))

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -54,7 +54,7 @@ layer is all needed for most casual uses of allocation primitives.)
 $(LI A mid-level, statically-typed layer for assembling several allocators into
 one. It uses properties of the type of the objects being created to route
 allocation requests to possibly specialized allocators. This layer is relatively
-thin and implemented and documented in the $(XREF2
+thin and implemented and documented in the $(MREF
 std,experimental,_allocator,typed) module. It allows an interested user to e.g.
 use different allocators for arrays versus fixed-sized objects, to the end of
 better overall performance.)
@@ -63,10 +63,10 @@ $(LI A low-level collection of highly generic $(I heap building blocks)$(MDASH)
 Lego-like pieces that can be used to assemble application-specific allocators.
 The real allocation smarts are occurring at this level. This layer is of
 interest to advanced applications that want to configure their own allocators.
-A good illustration of typical uses of these building blocks is module $(XREF2
+A good illustration of typical uses of these building blocks is module $(MREF
 std,experimental,_allocator,showcase) which defines a collection of frequently-
 used preassembled allocator objects. The implementation and documentation entry
-point is $(XREF2 std,experimental,_allocator,building_blocks). By design, the
+point is $(MREF std,experimental,_allocator,building_blocks). By design, the
 primitives of the static interface have the same signatures as the $(LREF
 IAllocator) primitives but are for the most part optional and driven by static
 introspection. The parameterized class $(LREF CAllocatorImpl) offers an
@@ -74,8 +74,8 @@ immediate and useful means to package a static low-level _allocator into an
 implementation of $(LREF IAllocator).)
 
 $(LI Core _allocator objects that interface with D's garbage collected heap
-($(XREF2 std,experimental,_allocator,gc_allocator)), the C `malloc` family
-($(XREF2 std,experimental,_allocator,mallocator)), and the OS ($(XREF2
+($(MREF std,experimental,_allocator,gc_allocator)), the C `malloc` family
+($(MREF std,experimental,_allocator,mallocator)), and the OS ($(MREF
 std,experimental,_allocator,mmap_allocator)). Most custom allocators would
 ultimately obtain memory from one of these core allocators.)
 )
@@ -106,10 +106,10 @@ void fun(size_t n)
 
 To experiment with alternative allocators, set $(LREF theAllocator) for the
 current thread. For example, consider an application that allocates many 8-byte
-objects. These are not well supported by the default _allocator, so a $(A
-$(MY_JOIN_LINE std,experimental,_allocator,building_blocks,free_list).html, free
-list _allocator) would be recommended. To install one in `main`, the
-application would use:
+objects. These are not well supported by the default _allocator, so a
+$(MREF_ALTTEXT free list _allocator,
+std,experimental,_allocator,building_blocks,free_list) would be recommended.
+To install one in `main`, the application would use:
 
 ----
 void main()
@@ -183,20 +183,6 @@ allocators are almost always faster than allocators that go through
 to `IAllocator` after". A good allocator implements intricate logic by means of
 template assembly, and gets wrapped with `IAllocator` (usually by means of
 $(LREF allocatorObject)) only once, at client level.
-
-Macros:
-MYREF = $(LINK2 std_experimental_allocator_$2.html, $1)&nbsp;
-MYREF2 = $(LINK2 std_experimental_allocator_$2.html#$1, $1)&nbsp;
-TDC = <td nowrap>$(D $1)$+</td>
-TDC2 = <td nowrap>$(D $(MYREF $1,$+))</td>
-TDC3 = <td nowrap>$(D $(MYREF2 $1,$+))</td>
-RES = $(I result)
-POST = $(BR)$(SMALL $(I Post:) $(BLUE $(D $0)))
-MY_JOIN_LINE = $1$(MY_JOIN_LINE_TAIL $+)
-MY_JOIN_LINE_TAIL = _$1$(MY_JOIN_LINE_TAIL $+)
-JOIN_DOT = $1$(JOIN_DOT_TAIL $+)
-JOIN_DOT_TAIL = .$1$(JOIN_DOT_TAIL $+)
-XREF2 = $(A $(MY_JOIN_LINE $1,$+).html,$(D $(JOIN_DOT $1,$+)))
 
 Copyright: Andrei Alexandrescu 2013-.
 


### PR DESCRIPTION
Replacing LINK2, A, and the custom XREF2 with MREF and friends. Also
removing other unused macros.

This fixes the links on DDOX pages.