### PR TITLE
Removed useless comments from the tops of most d files

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic _comparison algorithms.

--- a/std/algorithm/internal.d
+++ b/std/algorithm/internal.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /// Helper functions for std.algorithm package.
 module std.algorithm.internal;
 

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic _iteration algorithms.

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic _mutation algorithms.

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This package implements generic algorithms oriented towards the processing of
 sequences. Sequences processed by these functions define range-based

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic _searching algorithms.

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic algorithms that implement set operations.

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
 It contains generic _sorting algorithms.

--- a/std/array.d
+++ b/std/array.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 Functions and types that manipulate built-in arrays and associative arrays.
 

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /++
     Functions which operate on ASCII characters.
 

--- a/std/base64.d
+++ b/std/base64.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Support for Base64 encoding and decoding.
  *

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Bit-level manipulation facilities.
 

--- a/std/c/freebsd/socket.d
+++ b/std/c/freebsd/socket.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 // @@@DEPRECATED_2017-06@@@
 
 /++

--- a/std/compiler.d
+++ b/std/compiler.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Identify the compiler used and its various features.
  *

--- a/std/complex.d
+++ b/std/complex.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /** This module contains the $(LREF Complex) type, which is used to represent
     _complex numbers, along with related mathematical operations and functions.
 

--- a/std/concurrencybase.d
+++ b/std/concurrencybase.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * The only purpose of this module is to do the static construction for
  * std.concurrency, to eliminate cyclic construction errors.

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module defines generic containers.
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 A one-stop shop for converting values from one type to another.
 

--- a/std/cstream.d
+++ b/std/cstream.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * $(RED Deprecated: This module is considered out-dated and not up to Phobos'
  *       current standards. It will be remove in October 2016.)

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Demangle D mangled names.
  *

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This package implements the hash-based message authentication code (_HMAC)
 algorithm as defined in $(WEB tools.ietf.org/html/rfc2104, RFC2104). See also

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
  * Computes SHA1 and SHA2 hashes of arbitrary data. SHA hashes are 20 to 64 byte
  * quantities (depending on the SHA algorithm) that are like a checksum or CRC,

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Classes and functions for handling and transcoding between various encodings.
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /++
     This module defines functions related to exceptions and general error
     handling. It also defines functions intended to aid in unit testing.

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 Allocator that collects useful statistics about allocations, both global and per
 calling point. The statistics collected can be configured statically by choosing

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 
 High-level interface for allocators. Implements bundled allocation/creation

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module implements experimental additions/modifications to $(MREF std, _typecons).
 

--- a/std/file.d
+++ b/std/file.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Utilities for manipulating files and scanning directories. Functions
 in this module handle files as a unit, e.g., read or write one _file

--- a/std/format.d
+++ b/std/format.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
    This module implements the formatting functionality for strings and
    I/O. It's comparable to C99's $(D vsprintf()) and uses a similar

--- a/std/functional.d
+++ b/std/functional.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Functions that manipulate other functions.
 

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Processing of command line options.
 

--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Computes SHA1 digests of arbitrary data, using an optimized algorithm with SSSE3 instructions.
  *

--- a/std/internal/processinit.d
+++ b/std/internal/processinit.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /++
     The only purpose of this module is to do the static construction for
     std.process in order to eliminate cyclic construction errors.

--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * The only purpose of this module is to do the static construction for
  * std.windows.registry, to eliminate cyclic construction errors.

--- a/std/json.d
+++ b/std/json.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 JavaScript Object Notation
 

--- a/std/math.d
+++ b/std/math.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Contains the elementary mathematical functions (powers, roots,
  * and trigonometric functions), and low-level floating-point operations.

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Mathematical Special Functions
  *

--- a/std/meta.d
+++ b/std/meta.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Templates to manipulate template argument lists (also known as type lists).
  *

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Read and write memory mapped files.
  * Copyright: Copyright Digital Mars 2004 - 2009.

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Networking client functionality as provided by $(WEB _curl.haxx.se/libcurl,
 libcurl). The libcurl library must be installed on the system in order to use

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module is a port of a growing fragment of the $(D_PARAM numeric)
 header in Alexander Stepanov's $(LINK2 http://sgi.com/tech/stl,

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Serialize data to $(D ubyte) arrays.
 

--- a/std/path.d
+++ b/std/path.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /** This module is used to manipulate _path strings.
 
     All functions, with the exception of $(LREF expandTilde) (and in some

--- a/std/process.d
+++ b/std/process.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Functions for starting and interacting with other processes, and for
 working with the current _process' execution environment.

--- a/std/random.d
+++ b/std/random.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Facilities for random number generation.
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module defines the notion of a range. Ranges generalize the concept of
 arrays, lists, or anything that involves sequential access. This abstraction

--- a/std/signals.d
+++ b/std/signals.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Signals and Slots are an implementation of the Observer Pattern.
  * Essentially, when a Signal is emitted, a list of connected Observers

--- a/std/stdint.d
+++ b/std/stdint.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  *
     D constrains integral types to specific sizes. But efficiency

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 Standard I/O functions that extend $(B core.stdc.stdio).  $(B core.stdc.stdio)
 is $(D_PARAM public)ally imported when importing $(B std.stdio).

--- a/std/stdiobase.d
+++ b/std/stdiobase.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * The only purpose of this module is to do the static construction for
  * std.stdio, to eliminate cyclic construction errors.

--- a/std/string.d
+++ b/std/string.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 String handling functions.
 

--- a/std/system.d
+++ b/std/system.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Information about the target operating system, environment, and CPU.
  *

--- a/std/traits.d
+++ b/std/traits.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Templates which extract information about types and symbols at compile time.
  *

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module implements a variety of type constructors, i.e., templates
 that allow construction of new, useful general-purpose types.

--- a/std/uni.d
+++ b/std/uni.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /++
     $(P The $(D std.uni) module provides an implementation
     of fundamental Unicode algorithms and data structures.

--- a/std/uri.d
+++ b/std/uri.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Encode and decode Uniform Resource Identifiers (URIs).
  * URIs are used in internet transfer protocols.

--- a/std/utf.d
+++ b/std/utf.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /++
     Encode and decode UTF-8, UTF-16 and UTF-32 strings.
 

--- a/std/variant.d
+++ b/std/variant.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 This module implements a
 $(WEB erdani.org/publications/cuj-04-2002.html,discriminated union)

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Support UTF-8 on Windows 95, 98 and ME systems.
  *

--- a/std/windows/iunknown.d
+++ b/std/windows/iunknown.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 // @@@DEPRECATED_2017-06@@@
 
 /++

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Convert Win32 error code to string.
  *

--- a/std/xml.d
+++ b/std/xml.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
 $(RED Warning: This module is considered out-dated and not up to Phobos'
       current standards. It will remain until we have a suitable replacement,

--- a/std/zip.d
+++ b/std/zip.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Read/write data in the $(LINK2 http://www.info-_zip.org, zip archive) format.
  * Makes use of the etc.c.zlib compression library.

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * Compress/decompress data using the $(WEB www._zlib.net, _zlib library).
  *

--- a/unittest.d
+++ b/unittest.d
@@ -1,5 +1,3 @@
-// Written in the D programming language.
-
 /**
  * This test program pulls in all the library modules in order to run the unit
  * tests on them.  Then, it prints out the arguments passed to main().


### PR DESCRIPTION
I think that people can infer that the code is in D from the fact that the extension is `.d` and it's sitting in the D standard library.