### PR TITLE
Fix broken WEB links

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -30848,7 +30848,7 @@ else version(Posix)
     Windows uses a different set of time zone names than the IANA time zone
     database does, and how they correspond to one another changes over time
     (particularly when Microsoft updates Windows).
-    $(WEB http://unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+    $(WEB unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
     provides the current conversions (which may or may not match up with what's
     on a particular Windows box depending on how up-to-date it is), and
     parseTZConversions reads in those conversions from windowsZones.xml so that
@@ -30867,7 +30867,7 @@ else version(Posix)
 
     Params:
         windowsZonesXMLFileText The text from
-        $(WEB http://unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+        $(WEB unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
 
     Throws:
         Exception if there is an error while parsing the given XML.

--- a/std/experimental/logger/package.d
+++ b/std/experimental/logger/package.d
@@ -3,7 +3,7 @@ Implements logging facilities.
 
 Copyright: Copyright Robert "burner" Schadek 2013 --
 License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
-Authors: $(WEB http://www.svs.informatik.uni-oldenburg.de/60865.html, Robert burner Schadek)
+Authors: $(WEB www.svs.informatik.uni-oldenburg.de/60865.html, Robert burner Schadek)
 
 $(H3 Basic Logging)
 

--- a/std/string.d
+++ b/std/string.d
@@ -2377,7 +2377,7 @@ auto capitalize(S)(auto ref S s)
     Allocates memory; use $(LREF lineSplitter) for an alternative that
     does not.
 
-    Adheres to $(WEB http://www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
+    Adheres to $(WEB www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
 
   Params:
     s = a string of $(D chars), $(D wchars), or $(D dchars), or any custom
@@ -2702,7 +2702,7 @@ public:
     Does not throw on invalid UTF; such is simply passed unchanged
     to the output.
 
-    Adheres to $(WEB http://www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
+    Adheres to $(WEB www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
 
     Does not allocate memory.
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5057,7 +5057,7 @@ unittest
  * Returns:
  *   An initialized $(D RefCounted) containing $(D val).
  * See_Also:
- *   $(WEB http://en.cppreference.com/w/cpp/memory/shared_ptr/make_shared, C++'s make_shared)
+ *   $(WEB en.cppreference.com/w/cpp/memory/shared_ptr/make_shared, C++'s make_shared)
  */
 RefCounted!(T, RefCountedAutoInitialize.no) refCounted(T)(T val)
 {
@@ -7152,7 +7152,7 @@ $(UL
 Also known as trinary, trivalent, or trilean.
 
 See_Also:
-    $(WEB https://en.wikipedia.org/wiki/Three-valued_logic,
+    $(WEB en.wikipedia.org/wiki/Three-valued_logic,
         Three Valued Logic on Wikipedia)
 */
 struct Ternary


### PR DESCRIPTION
As mentioned in https://github.com/dlang/dlang.org/pull/1337 and https://github.com/dlang/dlang.org/pull/1333, yet another `sed` adventure!
Today's purge are the `WEB`, `HTTP`, `HTTPS` macros. 

Reason: We still have way too many custom ddoc macros to make simple links - creating a link should be simple!
Have a look at this selection:

```
A = <a href="$1">$+</a>
AHTTP = <a href="http://$1">$+</a>
AHTTPS = <a class="https" href="https://$1">$+</a>
ALOCAL = <a href="#$1">$+</a>

LINK = $(A $0, $0)
LINK2 = $(A $1, $+)

HTTP = $(LINK2 http://$1,$2)
HTTPS = $(LINK2 https://$1,$2)
WEB = $(HTTP $1,$2)
```

Some people might argue that `WEB` is great, because it's a bit shorter, but
- it leads to problems if you think it's a normal link and use `http://` (happens quite often, even here in Phobos)
- it discourages the fact that we are in 2016 and SSL should be everywhere. `WEB` always resolves to `http://`
- yet another macro that does the same thing

Or to quote Andrei from a recent forum discussion:

> Yah, I wouldn't disagree things can be vastly improved. My point there is to make sure we distinguish > what's trivially fixable (e.g. redundant macro definitions) from larger issues. Again, if you find identical macros across dd/ddoc files, or redundant macros that do the same thing in just slightly different ways, please fix or file. Thanks!
>
> Andrei
http://forum.dlang.org/post/ni4b13$21go$1@digitalmars.com

Hence this PR replaces all `WEB`, `HTTP` and `HTTPS` macros with `LINK2`. Ideally in the future we can use "markdown-like" links in ddoc - we all love them from Github, right?

Commands
----------------

This PR is done fully automated - again regular expressions to the help!

1) fix broken WEB links `sed 's/(WEB http:\/\//(WEB /' -i **/*.d`
2) HTTP links `sed 's/(WEB /(LINK2 http:\/\//' -i */.d`
3) single-line WEB links `sed 's/\$(WEB$/\$(LINK2\nhttp:\/\//' -i **/*.d`
4) multi-line links `perl -0777 -i -pe 's/\$\(WEB\n(\s*)/\$(LINK2\n\1http:\/\//g' **/*.d`


Should I add a simple grep to `travis.yml` or can we ensure - with the help of DAutotester - that those macros aren't used in the future?