### PR TITLE
Fix more 404s links

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -702,7 +702,7 @@ struct JSONValue
 
 /**
 Parses a serialized string and returns a tree of JSON values.
-Throws: $(REF JSONException, std,json) if the depth exceeds the max depth.
+Throws: $(LREF JSONException) if the depth exceeds the max depth.
 Params:
     json = json-formatted string to parse
     maxDepth = maximum depth of nesting allowed, -1 disables depth checking

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3568,7 +3568,7 @@ unittest
 /**
  * Read data from $(D stdin) according to the specified
  * $(LINK2 std_format.html#format-string, format specifier) using
- * $(REF formattedRead, std,format).
+ * $(REF formattedRead, std,_format).
  */
 uint readf(A...)(in char[] format, A args)
 {


### PR DESCRIPTION
I used [linkchecker](https://github.com/wummel/linkchecker) to find these.
Unfortunately it doesn't build by default and I had to patch it, hence the setup is a bit more complicated. If someone wants to try it for himself, here's my "simple" script

```
git clone https://github.com/wummel/linkchecker && cd linkchecker
wget http://sprunge.us/VIWV > my.diff # maybe you don't need that, I do
git apply my.diff
virtualenv build/python -p /usr/bin/python
build/python/bin/pip install -r requirements.txt
build/python/bin/python setup.py install
# build dlang.org with `make -f posix.mak all` and start a simple web server serving `web`
build/python/bin/linkchecker -t 100 http://localhost:8080 --no-warnings --check-extern -o html --ignore-url "bugstats.php" --ignore-url "dlangspec.pdf" --ignore-url "https://code.dlang.org" --ignore-url="dlangspec.mobi" --ignore-url="/library/" --ignore-url="/phobos/" > dlang.html
```

@CyberShadow maybe we can run a more stripped down version (or simpler tools) for `library-prerelease` with DAutotest?