### PR TITLE
Add empty doc comments to all public Phobos modules to fix /library/.

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.affix_allocator;
 
 /**

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.allocator_list;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.bitmapped_block;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.bucketizer;
 
 /**

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.fallback_allocator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.free_list;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.free_tree;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.kernighan_ritchie;
 import std.experimental.allocator.building_blocks.null_allocator;
 

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.null_allocator;
 
 /**

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.quantizer;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.region;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.scoped_allocator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.building_blocks.segregator;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.gc_allocator;
 import std.experimental.allocator.common;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.mallocator;
 import std.experimental.allocator.common;
 

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.allocator.mmap_allocator;
 
 // MmapAllocator

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.core;
 
 import std.array;

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.filelogger;
 
 import std.stdio;

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.multilogger;
 
 import std.experimental.logger.core;

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -1,3 +1,4 @@
+///
 module std.experimental.logger.nulllogger;
 
 import std.experimental.logger.core;


### PR DESCRIPTION
The DDOX based documentation is configured to only show entities with doc comments and thus hides modules without one. This adds an empty comment to all public Phobos modules that have stayed undocumented so far.

They should probably get a proper documentation with description/license/copyright/.... This just fixes the documentation until then.