### PR TITLE
Issue 16142: Correct test for hasElaborateAssign

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3207,8 +3207,11 @@ unittest
     static struct SS8 { S8 s; }
     static struct SS9 { S9 s; }
     static assert( hasElaborateAssign!SS6);
-    static assert( hasElaborateAssign!SS7);
-    static assert( hasElaborateAssign!SS8);
+    version (none) // Enable once DMD P.R. 5854 / issue 16142 have been fixed.
+    {
+        static assert(!hasElaborateAssign!SS7);
+        static assert(!hasElaborateAssign!SS8);
+    }
     static assert( hasElaborateAssign!SS9);
 }
 


### PR DESCRIPTION
Nested member's `@disable opAssign` should propagate to parents.

Required by https://github.com/dlang/dmd/pull/5854