### PR TITLE
add external imports to documented unittests in std.algorithm

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1870,6 +1870,7 @@ unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
+    import std.range.primitives;
 
     // Grouping by particular attribute of each element:
     auto range =

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1487,6 +1487,7 @@ if (isInputRange!InputRange &&
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
+    import std.range.primitives : empty;
 
     assert(find("hello, world", ',') == ", world");
     assert(find([1, 2, 3, 5], 4) == []);
@@ -1736,6 +1737,8 @@ if (isForwardRange!R1 && isForwardRange!R2
 @safe unittest
 {
     import std.container : SList;
+    import std.range.primitives : empty;
+    import std.typecons : Tuple;
 
     assert(find("hello, world", "World").empty);
     assert(find("hello, world", "wo") == "world");
@@ -2126,6 +2129,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 ///
 @safe unittest
 {
+    import std.typecons : tuple;
     int[] a = [ 1, 4, 2, 3 ];
     assert(find(a, 4) == [ 4, 2, 3 ]);
     assert(find(a, [ 1, 4 ]) == [ 1, 4, 2, 3 ]);
@@ -2258,6 +2262,7 @@ Range1 find(Range1, alias pred, Range2)(
 ///
 @safe unittest
 {
+    import std.range.primitives : empty;
     int[] a = [ -1, 0, 1, 2, 3, 4, 5 ];
     int[] b = [ 1, 2, 3 ];
 
@@ -2529,6 +2534,7 @@ if (isForwardRange!R1 && isForwardRange!R2
 ///
 @safe unittest
 {
+    import std.range.primitives : empty;
     // Needle is found; s is replaced by the substring following the first
     // occurrence of the needle.
     string s = "abcdef";
@@ -2787,6 +2793,8 @@ if (isForwardRange!R1 && isForwardRange!R2)
 ///
 @safe pure nothrow unittest
 {
+    import std.range.primitives : empty;
+
     auto a = "Carl Sagan Memorial Station";
     auto r = findSplit(a, "Velikovsky");
     import std.typecons : isTuple;
@@ -2812,6 +2820,8 @@ if (isForwardRange!R1 && isForwardRange!R2)
 
 @safe pure nothrow unittest
 {
+    import std.range.primitives : empty;
+
     auto a = [ 1, 2, 3, 4, 5, 6, 7, 8 ];
     auto r = findSplit(a, [9, 1]);
     assert(!r);
@@ -3037,6 +3047,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 unittest
 {
     import std.conv : text;
+    import std.typecons : tuple;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -3171,6 +3182,7 @@ auto minElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 @safe pure unittest
 {
     import std.range : enumerate;
+    import std.typecons : tuple;
 
     assert([2, 1, 4, 3].minElement == 1);
 
@@ -3261,6 +3273,7 @@ auto maxElement(alias map = "a", Range, RangeElementType = ElementType!Range)
 @safe pure unittest
 {
     import std.range : enumerate;
+    import std.typecons : tuple;
     assert([2, 1, 4, 3].maxElement == 4);
 
     // allows to get the index of an element too
@@ -3795,6 +3808,8 @@ bool startsWith(alias pred, R)(R doesThisStart)
     assert(startsWith("abc", "x", "aa", "ab") == 3);
     assert(startsWith("abc", "x", "aaa", "sab") == 0);
     assert(startsWith("abc", "x", "aaa", "a", "sab") == 3);
+
+    import std.typecons : Tuple;
     alias C = Tuple!(int, "x", int, "y");
     assert(startsWith!"a.x == b"([ C(1,1), C(1,2), C(2,2) ], [1, 1]));
     assert(startsWith!"a.x == b"([ C(1,1), C(2,1), C(2,2) ], [1, 1], [1, 2], [1, 3]) == 2);

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -523,6 +523,7 @@ auto cartesianProduct(R1, R2, RR...)(R1 range1, R2 range2, RR otherRanges)
 
 pure @safe nothrow @nogc unittest
 {
+    import std.range.primitives : isForwardRange;
     int[2] A = [1,2];
     auto C = cartesianProduct(A[], A[], A[]);
     assert(isForwardRange!(typeof(C)));
@@ -954,6 +955,7 @@ SetDifference!(less, R1, R2) setDifference(alias less = "a < b", R1, R2)
 @safe unittest
 {
     import std.algorithm.comparison : equal;
+    import std.range.primitives : isForwardRange;
 
     int[] a = [ 1, 2, 4, 5, 7, 9 ];
     int[] b = [ 0, 1, 2, 4, 7, 8 ];
@@ -1243,6 +1245,7 @@ setSymmetricDifference(alias less = "a < b", R1, R2)
 @safe unittest
 {
     import std.algorithm.comparison : equal;
+    import std.range.primitives : isForwardRange;
 
     int[] a = [ 1, 2, 4, 5, 7, 9 ];
     int[] b = [ 0, 1, 2, 4, 7, 8 ];

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -501,6 +501,8 @@ Range partition(alias predicate,
 {
     import std.algorithm.searching : count, find;
     import std.conv : text;
+    import std.range.primitives : empty;
+    import std.algorithm.mutation : SwapStrategy;
 
     auto Arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     auto arr = Arr.dup;
@@ -933,6 +935,7 @@ template multiSort(less...) //if (less.length > 1)
 ///
 @safe unittest
 {
+    import std.algorithm.mutation : SwapStrategy;
     static struct Point { int x, y; }
     auto pts1 = [ Point(0, 0), Point(5, 5), Point(0, 1), Point(0, 2) ];
     auto pts2 = [ Point(0, 0), Point(0, 1), Point(0, 2), Point(5, 5) ];
@@ -1185,6 +1188,7 @@ sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable,
 unittest
 {
     // Showcase stable sorting
+    import std.algorithm.mutation : SwapStrategy;
     string[] words = [ "aBc", "a", "abc", "b", "ABC", "c" ];
     sort!("toUpper(a) < toUpper(b)", SwapStrategy.stable)(words);
     assert(words == [ "a", "aBc", "abc", "ABC", "b", "c" ]);


### PR DESCRIPTION
The higher motivation here is:
1) to have copy-able code for the users that works (without import errors)
2) to be able to run the unittest directly on dlang.org (see #1297)

This PR is done semi-automatically with a [small tool](https://github.com/wilzbach/d-scripts/blob/master/check_phobos_tests.d) that runs all tests in Phobos `outside` of the module scope, so further automation is planned & hopefully will be part of Phobos in the foreseeable future ;-)