### PR TITLE
Remove the WEB macro in favor of HTTP

### DIFF
--- a/etc/c/odbc/sql.d
+++ b/etc/c/odbc/sql.d
@@ -2,7 +2,7 @@
 Declarations for interfacing with the ODBC library.
 
 Adapted with minimal changes from the work of David L. Davis
-(refer to the $(WEB
+(refer to the $(HTTP
 forum.dlang.org/post/cfk7ql$(DOLLAR)1p4n$(DOLLAR)1@digitaldaemon.com,
 original announcement)).
 

--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -2,7 +2,7 @@
 Declarations for interfacing with the ODBC library.
 
 Adapted with minimal changes from the work of David L. Davis
-(refer to the $(WEB
+(refer to the $(HTTP
 forum.dlang.org/post/cfk7ql$(DOLLAR)1p4n$(DOLLAR)1@digitaldaemon.com,
 original announcement)).
 

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -2,7 +2,7 @@
 Declarations for interfacing with the ODBC library.
 
 Adapted with minimal changes from the work of David L. Davis
-(refer to the $(WEB
+(refer to the $(HTTP
 forum.dlang.org/post/cfk7ql$(DOLLAR)1p4n$(DOLLAR)1@digitaldaemon.com,
 original announcement)).
 

--- a/etc/c/odbc/sqlucode.d
+++ b/etc/c/odbc/sqlucode.d
@@ -2,7 +2,7 @@
 Declarations for interfacing with the ODBC library.
 
 Adapted with minimal changes from the work of David L. Davis
-(refer to the $(WEB
+(refer to the $(HTTP
 forum.dlang.org/post/cfk7ql$(DOLLAR)1p4n$(DOLLAR)1@digitaldaemon.com,
 original announcement)).
 

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -44,9 +44,9 @@ $(T2 predSwitch,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_comparison.d)
 
@@ -725,7 +725,7 @@ template equal(alias pred = "a == b")
         for element, according to binary predicate $(D pred).
 
     See_Also:
-        $(WEB sgi.com/tech/stl/_equal.html, STL's _equal)
+        $(HTTP sgi.com/tech/stl/_equal.html, STL's _equal)
     +/
     bool equal(Range1, Range2)(Range1 r1, Range2 r2)
     if (isInputRange!Range1 && isInputRange!Range2 && is(typeof(binaryFun!pred(r1.front, r2.front))))
@@ -921,7 +921,7 @@ private template MaxType(T...)
 
 // levenshteinDistance
 /**
-Encodes $(WEB realityinteractive.com/rgrzywinski/archives/000249.html,
+Encodes $(HTTP realityinteractive.com/rgrzywinski/archives/000249.html,
 edit operations) necessary to transform one sequence into
 another. Given sequences $(D s) (source) and $(D t) (target), a
 sequence of $(D EditOp) encodes the steps that need to be taken to
@@ -1116,7 +1116,7 @@ private:
 }
 
 /**
-Returns the $(WEB wikipedia.org/wiki/Levenshtein_distance, Levenshtein
+Returns the $(HTTP wikipedia.org/wiki/Levenshtein_distance, Levenshtein
 distance) between $(D s) and $(D t). The Levenshtein distance computes
 the minimal amount of edit operations necessary to transform $(D s)
 into $(D t).  Performs $(BIGOH s.length * t.length) evaluations of $(D
@@ -1490,7 +1490,7 @@ two mismatched values. Performs $(BIGOH min(r1.length, r2.length))
 evaluations of $(D pred).
 
 See_Also:
-    $(WEB sgi.com/tech/stl/_mismatch.html, STL's _mismatch)
+    $(HTTP sgi.com/tech/stl/_mismatch.html, STL's _mismatch)
 */
 Tuple!(Range1, Range2)
 mismatch(alias pred = "a == b", Range1, Range2)(Range1 r1, Range2 r2)

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -54,9 +54,9 @@ $(T2 uniq,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_iteration.d)
 
@@ -451,7 +451,7 @@ Returns:
     fun, the element type will be $(D Tuple) containing one element for each fun.
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Map_(higher-order_function), Map (higher-order function))
+    $(HTTP en.wikipedia.org/wiki/Map_(higher-order_function), Map (higher-order function))
 */
 template map(fun...) if (fun.length >= 1)
 {
@@ -1041,7 +1041,7 @@ Returns:
     which $(D predicate(x)) returns $(D true).
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Filter_(higher-order_function), Filter (higher-order function))
+    $(HTTP en.wikipedia.org/wiki/Filter_(higher-order_function), Filter (higher-order function))
  */
 template filter(alias predicate) if (is(typeof(unaryFun!predicate)))
 {
@@ -2571,7 +2571,7 @@ Returns:
     the accumulated $(D result)
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
+    $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
 
     $(LREF fold) is functionally equivalent to $(LREF reduce) with the argument order reversed,
     and without the need to use $(LREF tuple) for multiple seeds. This makes it easier
@@ -3017,7 +3017,7 @@ Returns:
     the accumulated $(D result)
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
+    $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
 
     $(LREF sum) is similar to $(D fold!((a, b) => a + b)) that offers
     precise summing of floating point numbers.
@@ -3085,17 +3085,17 @@ The one-argument version $(D cumulativeFold!(fun)(range)) works similarly, but
 it returns the first element unchanged and uses it as seed for the next
 elements.
 This function is also known as
-    $(WEB en.cppreference.com/w/cpp/algorithm/partial_sum, partial_sum),
-    $(WEB docs.python.org/3/library/itertools.html#itertools.accumulate, accumulate),
-    $(WEB hackage.haskell.org/package/base-4.8.2.0/docs/Prelude.html#v:scanl, scan),
-    $(WEB mathworld.wolfram.com/CumulativeSum.html, Cumulative Sum).
+    $(HTTP en.cppreference.com/w/cpp/algorithm/partial_sum, partial_sum),
+    $(HTTP docs.python.org/3/library/itertools.html#itertools.accumulate, accumulate),
+    $(HTTP hackage.haskell.org/package/base-4.8.2.0/docs/Prelude.html#v:scanl, scan),
+    $(HTTP mathworld.wolfram.com/CumulativeSum.html, Cumulative Sum).
 Returns:
     The function returns a range containing the consecutive reduced values. If
     there is more than one `fun`, the element type will be $(REF Tuple,
     std,typecons) containing one element for each `fun`.
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Prefix_sum, Prefix Sum)
+    $(HTTP en.wikipedia.org/wiki/Prefix_sum, Prefix Sum)
 +/
 template cumulativeFold(fun...)
 if (fun.length >= 1)
@@ -4479,11 +4479,11 @@ $(LI If $(D $(REF ElementType, std,range,primitives)!R) is a floating-point
 type and $(D R) is a
 $(REF_ALTTEXT random-access range, isRandomAccessRange, std,range,primitives) with
 length and slicing, then $(D sum) uses the
-$(WEB en.wikipedia.org/wiki/Pairwise_summation, pairwise summation)
+$(HTTP en.wikipedia.org/wiki/Pairwise_summation, pairwise summation)
 algorithm.)
 $(LI If $(D ElementType!R) is a floating-point type and $(D R) is a
 finite input range (but not a random-access range with slicing), then
-$(D sum) uses the $(WEB en.wikipedia.org/wiki/Kahan_summation,
+$(D sum) uses the $(HTTP en.wikipedia.org/wiki/Kahan_summation,
 Kahan summation) algorithm.)
 $(LI In all other cases, a simple element by element addition is done.)
 )
@@ -4761,7 +4761,7 @@ unittest
 // uniq
 /**
 Lazily iterates unique consecutive elements of the given range (functionality
-akin to the $(WEB wikipedia.org/wiki/_Uniq, _uniq) system
+akin to the $(HTTP wikipedia.org/wiki/_Uniq, _uniq) system
 utility). Equivalence of elements is assessed by using the predicate
 $(D pred), by default $(D "a == b"). The predicate is passed to
 $(REF binaryFun, std,functional), and can either accept a string, or any callable
@@ -4892,7 +4892,7 @@ private struct UniqResult(alias pred, Range)
 }
 
 /**
-Lazily computes all _permutations of $(D r) using $(WEB
+Lazily computes all _permutations of $(D r) using $(HTTP
 en.wikipedia.org/wiki/Heap%27s_algorithm, Heap's algorithm).
 
 Returns:

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -59,9 +59,9 @@ $(T2 uninitializedFill,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_mutation.d)
 
@@ -106,7 +106,7 @@ Returns:
     The number of elements brought to the front, i.e., the length of $(D back).
 
 See_Also:
-    $(WEB sgi.com/tech/stl/_rotate.html, STL's rotate)
+    $(HTTP sgi.com/tech/stl/_rotate.html, STL's rotate)
 */
 size_t bringToFront(Range1, Range2)(Range1 front, Range2 back)
     if (isInputRange!Range1 && isForwardRange!Range2)
@@ -303,7 +303,7 @@ Returns:
     The unfilled part of target
 
 See_Also:
-    $(WEB sgi.com/tech/stl/_copy.html, STL's _copy)
+    $(HTTP sgi.com/tech/stl/_copy.html, STL's _copy)
  */
 TargetRange copy(SourceRange, TargetRange)(SourceRange source, TargetRange target)
     if (areCopyCompatibleArrays!(SourceRange, TargetRange))
@@ -413,7 +413,7 @@ use $(LREF filter):
 
 /**
 $(REF retro, std,range) can be used to achieve behavior similar to
-$(WEB sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
+$(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 */
 @safe unittest
 {
@@ -1892,7 +1892,7 @@ Params:
     r = a bidirectional range with swappable elements or a random access range with a length member
 
 See_Also:
-    $(WEB sgi.com/tech/stl/_reverse.html, STL's _reverse)
+    $(HTTP sgi.com/tech/stl/_reverse.html, STL's _reverse)
 */
 void reverse(Range)(Range r)
 if (isBidirectionalRange!Range && !isRandomAccessRange!Range

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -4,7 +4,7 @@
 This package implements generic algorithms oriented towards the processing of
 sequences. Sequences processed by these functions define range-based
 interfaces.  See also $(LINK2 std_range.html, Reference on ranges) and
-$(WEB ddili.org/ders/d.en/ranges.html, tutorial on ranges).
+$(HTTP ddili.org/ders/d.en/ranges.html, tutorial on ranges).
 
 $(SCRIPT inhibitQuickIndex = 1;)
 
@@ -174,9 +174,9 @@ SUBREF = $(REF_ALTTEXT $(TT $2), $2, std, algorithm, $1)$(NBSP)
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/_algorithm/package.d)
  */

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -86,9 +86,9 @@ $(T2 until,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_searching.d)
 
@@ -1344,7 +1344,7 @@ that is, until $(D binaryFun!pred(haystack.front, needle)) is $(D true). If no
 such position exists, returns an empty $(D haystack).
 
 See_Also:
-     $(WEB sgi.com/tech/stl/_find.html, STL's _find)
+     $(HTTP sgi.com/tech/stl/_find.html, STL's _find)
  */
 InputRange find(alias pred = "a == b", InputRange, Element)(InputRange haystack, Element needle)
 if (isInputRange!InputRange &&
@@ -1628,7 +1628,7 @@ that is, until $(D binaryFun!pred(haystack.front, needle)) is $(D true). If no
 such position exists, returns an empty $(D haystack).
 
 See_Also:
-     $(WEB sgi.com/tech/stl/find_if.html, STL's find_if)
+     $(HTTP sgi.com/tech/stl/find_if.html, STL's find_if)
 */
 InputRange find(alias pred, InputRange)(InputRange haystack)
 if (isInputRange!InputRange)
@@ -2390,7 +2390,7 @@ the given predicate. If there are no such two elements, returns $(D r) advanced
 until empty.
 
 See_Also:
-     $(WEB sgi.com/tech/stl/adjacent_find.html, STL's adjacent_find)
+     $(HTTP sgi.com/tech/stl/adjacent_find.html, STL's adjacent_find)
 */
 Range findAdjacent(alias pred = "a == b", Range)(Range r)
     if (isForwardRange!(Range))
@@ -2467,7 +2467,7 @@ $(D seq) advanced to the first matching element, or until empty if there are no
 matching elements.
 
 See_Also:
-    $(WEB sgi.com/tech/stl/find_first_of.html, STL's find_first_of)
+    $(HTTP sgi.com/tech/stl/find_first_of.html, STL's find_first_of)
 */
 Range1 findAmong(alias pred = "a == b", Range1, Range2)(
     Range1 seq, Range2 choices)

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -28,9 +28,9 @@ $(T2 setUnion,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_setops.d)
 

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -56,9 +56,9 @@ $(T2 topNIndex,
 
 Copyright: Andrei Alexandrescu 2008-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/algorithm/_sorting.d)
 
@@ -382,8 +382,8 @@ the relative ordering of all elements $(D a), $(D b) in the left part of $(D r)
 for which $(D predicate(a) == predicate(b)).
 
 See_Also:
-    STL's $(WEB sgi.com/tech/stl/_partition.html, _partition)$(BR)
-    STL's $(WEB sgi.com/tech/stl/stable_partition.html, stable_partition)
+    STL's $(HTTP sgi.com/tech/stl/_partition.html, _partition)$(BR)
+    STL's $(HTTP sgi.com/tech/stl/stable_partition.html, stable_partition)
 */
 Range partition(alias predicate,
         SwapStrategy ss = SwapStrategy.unstable, Range)(Range r)
@@ -1114,8 +1114,8 @@ Params:
 Returns: The initial range wrapped as a $(D SortedRange) with the predicate
 $(D binaryFun!less).
 
-Algorithms: $(WEB en.wikipedia.org/wiki/Introsort) is used for unstable sorting and
-$(WEB en.wikipedia.org/wiki/Timsort, Timsort) is used for stable sorting.
+Algorithms: $(HTTP en.wikipedia.org/wiki/Introsort) is used for unstable sorting and
+$(HTTP en.wikipedia.org/wiki/Timsort, Timsort) is used for stable sorting.
 Each algorithm has benefits beyond stability. Introsort is generally faster but
 Timsort may achieve greater speeds on data with low entropy or if predicate calls
 are expensive. Introsort performs no allocations whereas Timsort will perform one
@@ -2123,7 +2123,7 @@ repeatedly computing it. Conversely, if the cost of `transform` is small
 compared to the cost of allocating and filling the precomputed array, `sort`
 may be faster and therefore preferable.
 
-This approach to sorting is akin to the $(WEB
+This approach to sorting is akin to the $(HTTP
 wikipedia.org/wiki/Schwartzian_transform, Schwartzian transform), also known as
 the decorate-sort-undecorate pattern in Python and Lisp. The complexity is the
 same as that of the corresponding `sort`, but `schwartzSort` evaluates
@@ -2350,7 +2350,7 @@ Params:
 
 See_Also:
     $(LREF topNIndex),
-    $(WEB sgi.com/tech/stl/nth_element.html, STL's nth_element)
+    $(HTTP sgi.com/tech/stl/nth_element.html, STL's nth_element)
 
 BUGS:
 
@@ -2570,7 +2570,7 @@ Copies the top $(D n) elements of the input range $(D source) into the
 random-access range $(D target), where $(D n =
 target.length). Elements of $(D source) are not touched. If $(D
 sorted) is $(D true), the target is sorted. Otherwise, the target
-respects the $(WEB en.wikipedia.org/wiki/Binary_heap, heap property).
+respects the $(HTTP en.wikipedia.org/wiki/Binary_heap, heap property).
 
 Params:
     less = The predicate to sort by.

--- a/std/array.d
+++ b/std/array.d
@@ -67,9 +67,9 @@ $(TR $(TH Function Name) $(TH Description)
 
 Copyright: Copyright Andrei Alexandrescu 2008- and Jonathan M Davis 2011-.
 
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors:   $(WEB erdani.org, Andrei Alexandrescu) and Jonathan M Davis
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu) and Jonathan M Davis
 
 Source: $(PHOBOSSRC std/_array.d)
 */

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -13,10 +13,10 @@
 
     References:
         $(LINK2 http://www.digitalmars.com/d/ascii-table.html, ASCII Table),
-        $(WEB en.wikipedia.org/wiki/Ascii, Wikipedia)
+        $(HTTP en.wikipedia.org/wiki/Ascii, Wikipedia)
 
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-    Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   $(HTTP digitalmars.com, Walter Bright) and Jonathan M Davis
     Source:    $(PHOBOSSRC std/_ascii.d)
   +/
 module std.ascii;

--- a/std/base64.d
+++ b/std/base64.d
@@ -45,11 +45,11 @@
  * -----
  *
  * References:
- * $(WEB tools.ietf.org/html/rfc4648, RFC 4648 - The Base16, Base32, and Base64
+ * $(HTTP tools.ietf.org/html/rfc4648, RFC 4648 - The Base16, Base32, and Base64
  * Data Encodings)
  *
  * Copyright: Masahiro Nakagawa 2010-.
- * License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Masahiro Nakagawa, Daniel Murphy (Single value Encoder and Decoder)
  * Source:    $(PHOBOSSRC std/_base64.d)
  * Macros:

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -11,9 +11,9 @@
  * $(LI Binary exponentiation)
  * )
  *
- * For very large numbers, consider using the $(WEB gmplib.org, GMP library) instead.
+ * For very large numbers, consider using the $(HTTP gmplib.org, GMP library) instead.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Don Clugston
  * Source: $(PHOBOSSRC std/_bigint.d)
  */

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4,9 +4,9 @@
 Bit-level manipulation facilities.
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           $(WEB erdani.org, Andrei Alexandrescu),
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright),
+           $(HTTP erdani.org, Andrei Alexandrescu),
            Jonathan M Davis,
            Alex Rønne Petersen,
            Damian Ziemba,

--- a/std/compiler.d
+++ b/std/compiler.d
@@ -4,8 +4,8 @@
  * Identify the compiler used and its various features.
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright), Alex Rønne Petersen
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright), Alex Rønne Petersen
  * Source:    $(PHOBOSSRC std/_compiler.d)
  */
 /*          Copyright Digital Mars 2000 - 2011.

--- a/std/complex.d
+++ b/std/complex.d
@@ -10,7 +10,7 @@
 
     Authors:    Lars Tandle Kyllingstad, Don Clugston
     Copyright:  Copyright (c) 2010, Lars T. Kyllingstad.
-    License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
+    License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:     $(PHOBOSSRC std/_complex.d)
 */
 module std.complex;

--- a/std/concurrencybase.d
+++ b/std/concurrencybase.d
@@ -4,7 +4,7 @@
  * The only purpose of this module is to do the static construction for
  * std.concurrency, to eliminate cyclic construction errors.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Source:    $(PHOBOSSRC std/_concurrencybase.d)
  */
 module std.concurrencybase;

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -10,10 +10,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.array;
 

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -10,10 +10,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.binaryheap;
 
@@ -36,7 +36,7 @@ unittest
 
 // BinaryHeap
 /**
-Implements a $(WEB en.wikipedia.org/wiki/Binary_heap, binary heap)
+Implements a $(HTTP en.wikipedia.org/wiki/Binary_heap, binary heap)
 container on top of a given random-access range type (usually $(D
 T[])) or a random-access container type (usually $(D Array!T)). The
 documentation of $(D BinaryHeap) will refer to the underlying range or

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -10,10 +10,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.dlist;
 

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -504,10 +504,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
  */
 
 module std.container;

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -9,10 +9,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.rbtree;
 

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -10,10 +10,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.slist;
 

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -9,10 +9,10 @@ Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Othe
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 
 License: Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE_1_0.txt or copy at $(WEB
+(See accompanying file LICENSE_1_0.txt or copy at $(HTTP
 boost.org/LICENSE_1_0.txt)).
 
-Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
+Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 */
 module std.container.util;
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -5,10 +5,10 @@ A one-stop shop for converting values from one type to another.
 
 Copyright: Copyright Digital Mars 2007-.
 
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           $(WEB erdani.org, Andrei Alexandrescu),
+Authors:   $(HTTP digitalmars.com, Walter Bright),
+           $(HTTP erdani.org, Andrei Alexandrescu),
            Shin Fujishiro,
            Adam D. Ruppe,
            Kenji Hara

--- a/std/cstream.d
+++ b/std/cstream.d
@@ -8,7 +8,7 @@
  * Both core.stdc.stdio and std.stream are publicly imported by std.cstream.
  *
  * Copyright: Copyright Ben Hinkle 2007 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Ben Hinkle
  * Source:    $(PHOBOSSRC std/_cstream.d)
  */

--- a/std/csv.d
+++ b/std/csv.d
@@ -7,7 +7,7 @@
  * Comma Separated Values provide a simple means to transfer and store
  * tabular data. It has been common for programs to use their own
  * variant of the CSV format. This parser will loosely follow the
- * $(WEB tools.ietf.org/html/rfc4180, RFC-4180). CSV input should adhere
+ * $(HTTP tools.ietf.org/html/rfc4180, RFC-4180). CSV input should adhere
  * to the following criteria (differences from RFC-4180 in parentheses):
  *
  * $(UL
@@ -81,11 +81,11 @@
  * closed.
  *
  *   See_Also:
- *      $(WEB en.wikipedia.org/wiki/Comma-separated_values, Wikipedia
+ *      $(HTTP en.wikipedia.org/wiki/Comma-separated_values, Wikipedia
  *      Comma-separated values)
  *
  *   Copyright: Copyright 2011
- *   License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ *   License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *   Authors:   Jesse Phillips
  *   Source:    $(PHOBOSSRC std/_csv.d)
  */

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -91,13 +91,13 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
     See_Also:
         $(DDLINK intro-to-_datetime, Introduction to std.datetime,
                  Introduction to std&#46;_datetime)<br>
-        $(WEB en.wikipedia.org/wiki/ISO_8601, ISO 8601)<br>
-        $(WEB en.wikipedia.org/wiki/Tz_database,
+        $(HTTP en.wikipedia.org/wiki/ISO_8601, ISO 8601)<br>
+        $(HTTP en.wikipedia.org/wiki/Tz_database,
               Wikipedia entry on TZ Database)<br>
-        $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones,
+        $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones,
               List of Time Zones)<br>
 
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis and Kato Shoichi
     Source:    $(PHOBOSSRC std/_datetime.d)
     Macros:
@@ -7657,7 +7657,7 @@ public:
         The ISO 8601 week of the year that this $(LREF SysTime) is in.
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/ISO_week_date, ISO Week Date).
+            $(HTTP en.wikipedia.org/wiki/ISO_week_date, ISO Week Date).
       +/
     @property ubyte isoWeek() @safe const nothrow
     {
@@ -7859,7 +7859,7 @@ public:
 
 
     /++
-        The $(WEB en.wikipedia.org/wiki/Julian_day, Julian day)
+        The $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day)
         for this $(LREF SysTime) at the given time. For example,
         prior to noon, 1996-03-31 would be the Julian day number 2_450_173, so
         this function returns 2_450_173, while from noon onward, the Julian
@@ -7906,7 +7906,7 @@ public:
 
 
     /++
-        The modified $(WEB en.wikipedia.org/wiki/Julian_day, Julian day) for any time on this date (since, the modified
+        The modified $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day) for any time on this date (since, the modified
         Julian day changes at midnight).
       +/
     @property long modJulianDay() @safe const nothrow
@@ -9261,7 +9261,7 @@ private:
 
 /++
     Represents a date in the
-    $(WEB en.wikipedia.org/wiki/Proleptic_Gregorian_calendar, Proleptic Gregorian Calendar)
+    $(HTTP en.wikipedia.org/wiki/Proleptic_Gregorian_calendar, Proleptic Gregorian Calendar)
     ranging from
     32,768 B.C. to 32,767 A.D. Positive years are A.D. Non-positive years are
     B.C.
@@ -9271,7 +9271,7 @@ private:
 
     $(D Date) uses the Proleptic Gregorian Calendar, so it assumes the Gregorian
     leap year calculations for its entire length. As per
-    $(WEB en.wikipedia.org/wiki/ISO_8601, ISO 8601), it treats 1 B.C. as
+    $(HTTP en.wikipedia.org/wiki/ISO_8601, ISO 8601), it treats 1 B.C. as
     year 0, i.e. 1 B.C. is 0, 2 B.C. is -1, etc. Use $(LREF yearBC) to use B.C. as
     a positive integer with 1 B.C. being the year prior to 1 A.D.
 
@@ -12484,7 +12484,7 @@ public:
         The ISO 8601 week of the year that this $(LREF Date) is in.
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/ISO_week_date, ISO Week Date)
+            $(HTTP en.wikipedia.org/wiki/ISO_week_date, ISO Week Date)
       +/
     @property ubyte isoWeek() @safe const pure nothrow
     {
@@ -12730,7 +12730,7 @@ public:
 
 
     /++
-        The $(WEB en.wikipedia.org/wiki/Julian_day, Julian day) for this $(LREF Date) at noon (since the Julian day changes
+        The $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day) for this $(LREF Date) at noon (since the Julian day changes
         at noon).
       +/
     @property long julianDay() @safe const pure nothrow
@@ -12757,7 +12757,7 @@ public:
 
 
     /++
-        The modified $(WEB en.wikipedia.org/wiki/Julian_day, Julian day) for any time on this date (since, the modified
+        The modified $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day) for any time on this date (since, the modified
         Julian day changes at midnight).
       +/
     @property long modJulianDay() @safe const pure nothrow
@@ -17467,7 +17467,7 @@ public:
         The ISO 8601 week of the year that this $(LREF DateTime) is in.
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/ISO_week_date, ISO Week Date)
+            $(HTTP en.wikipedia.org/wiki/ISO_week_date, ISO Week Date)
       +/
     @property ubyte isoWeek() @safe const pure nothrow
     {
@@ -17605,7 +17605,7 @@ public:
 
 
     /++
-        The $(WEB en.wikipedia.org/wiki/Julian_day, Julian day) for this
+        The $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day) for this
         $(LREF DateTime) at the given time. For example, prior to noon,
         1996-03-31 would be the Julian day number 2_450_173, so this function
         returns 2_450_173, while from noon onward, the julian day number would
@@ -17653,7 +17653,7 @@ public:
 
 
     /++
-        The modified $(WEB en.wikipedia.org/wiki/Julian_day, Julian day) for any
+        The modified $(HTTP en.wikipedia.org/wiki/Julian_day, Julian day) for any
         time on this date (since, the modified Julian day changes at midnight).
       +/
     @property long modJulianDay() @safe const pure nothrow
@@ -27646,9 +27646,9 @@ public:
         get a $(LREF2 .TimeZone, TimeZone) by name with $(D TimeZone.getTimeZone).
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
+            $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
               Database)<br>
-            $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
+            $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
               Time Zones)
       +/
     @property string name() @safe const nothrow
@@ -27762,11 +27762,11 @@ public:
         the same time zone names on both Windows and Posix systems.
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
+            $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
               Database)<br>
-            $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
+            $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
               Time Zones)<br>
-            $(WEB unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
+            $(HTTP unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
                   Windows <-> TZ Database Name Conversion Table)
 
         Params:
@@ -28243,9 +28243,9 @@ public:
             Database name of the local time zone.
 
             See_Also:
-                $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
+                $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
                   Database)<br>
-                $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List
+                $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List
                   of Time Zones)
           +/
         @property override string name() @safe const nothrow;
@@ -29459,9 +29459,9 @@ private:
         in the file).
 
     See_Also:
-        $(WEB www.iana.org/time-zones, Home of the TZ Database files)<br>
-        $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ Database)<br>
-        $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of Time
+        $(HTTP www.iana.org/time-zones, Home of the TZ Database files)<br>
+        $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ Database)<br>
+        $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of Time
           Zones)
   +/
 final class PosixTimeZone : TimeZone
@@ -29610,9 +29610,9 @@ public:
         given directory.
 
         See_Also:
-            $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
+            $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
               Database)<br>
-            $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
+            $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List of
               Time Zones)
 
         Params:
@@ -30401,7 +30401,7 @@ version(StdDdoc)
          $(D WindowsTimeZone) on Windows systems).
 
         See_Also:
-            $(WEB www.iana.org/time-zones, Home of the TZ Database files)
+            $(HTTP www.iana.org/time-zones, Home of the TZ Database files)
       +/
     final class WindowsTimeZone : TimeZone
     {
@@ -30458,9 +30458,9 @@ version(StdDdoc)
             registry.
 
             See_Also:
-                $(WEB en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
+                $(HTTP en.wikipedia.org/wiki/Tz_database, Wikipedia entry on TZ
                   Database)<br>
-                $(WEB en.wikipedia.org/wiki/List_of_tz_database_time_zones, List
+                $(HTTP en.wikipedia.org/wiki/List_of_tz_database_time_zones, List
                   of Time Zones)
 
             Params:
@@ -30883,7 +30883,7 @@ else version(Posix)
     Windows uses a different set of time zone names than the IANA time zone
     database does, and how they correspond to one another changes over time
     (particularly when Microsoft updates Windows).
-    $(WEB unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+    $(HTTP unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
     provides the current conversions (which may or may not match up with what's
     on a particular Windows box depending on how up-to-date it is), and
     parseTZConversions reads in those conversions from windowsZones.xml so that
@@ -30902,7 +30902,7 @@ else version(Posix)
 
     Params:
         windowsZonesXMLFileText The text from
-        $(WEB unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+        $(HTTP unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
 
     Throws:
         Exception if there is an error while parsing the given XML.
@@ -31100,7 +31100,7 @@ For terms of use, see http://www.unicode.org/copyright.html
     Returns null if the given time zone name cannot be converted.
 
     See_Also:
-        $(WEB unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
+        $(HTTP unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
               Windows <-> TZ Database Name Conversion Table)
 
     Params:
@@ -31569,7 +31569,7 @@ version(Windows) unittest
     Returns null if the given time zone name cannot be converted.
 
     See_Also:
-        $(WEB unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
+        $(HTTP unicode.org/repos/cldr-tmp/trunk/diff/supplemental/zone_tzid.html,
               Windows <-> TZ Database Name Conversion Table)
 
     Params:
@@ -32804,7 +32804,7 @@ unittest
 /++
     The given array of $(D char) or random-access range of $(D char) or
     $(D ubyte) is expected to be in the format specified in
-    $(WEB tools.ietf.org/html/rfc5322, RFC 5322) section 3.3 with the
+    $(HTTP tools.ietf.org/html/rfc5322, RFC 5322) section 3.3 with the
     grammar rule $(I date-time). It is the date-time format commonly used in
     internet messages such as e-mail and HTTP. The corresponding
     $(LREF SysTime) will be returned.

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -4,8 +4,8 @@
  * Demangle D mangled names.
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright),
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *                        Thomas K$(UUML)hne, Frits van Bommel
  * Source:    $(PHOBOSSRC std/_demangle.d)
  */

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -31,7 +31,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of))
  * to specify decreasing order for the correct result. The $(LREF crcHexString)
  * alias can also be used for this purpose.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *
  * Authors:   Pavel "EvilOne" Minayev, Alex Rønne Petersen, Johannes Pfau
  *

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -43,7 +43,7 @@ $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDi
  * In this simplest case, the template API can even be used without templates: Just use the "$(B x)" structs
  * directly.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
  * Johannes Pfau
  *

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -2,14 +2,14 @@
 
 /**
 This package implements the hash-based message authentication code (_HMAC)
-algorithm as defined in $(WEB tools.ietf.org/html/rfc2104, RFC2104). See also
-the corresponding $(WEB en.wikipedia.org/wiki/Hash-based_message_authentication_code, Wikipedia article).
+algorithm as defined in $(HTTP tools.ietf.org/html/rfc2104, RFC2104). See also
+the corresponding $(HTTP en.wikipedia.org/wiki/Hash-based_message_authentication_code, Wikipedia article).
 
 $(SCRIPT inhibitQuickIndex = 1;)
 
 Macros:
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Source: $(PHOBOSSRC std/digest/_hmac.d)
  */

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -24,7 +24,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
  * This module publicly imports $(D std.digest.digest) and can be used as a stand-alone
  * module.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *
  * CTFE:
  * Digests do not work in CTFE

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -26,7 +26,7 @@ This module conforms to the APIs defined in $(D std.digest.digest).
 
 This module publicly imports $(D std.digest.digest) and can be used as a stand-alone module.
 
-License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Guillaume Chatelet
 References: $(LINK2 https://github.com/aappleby/smhasher, Reference implementation)
 $(BR) $(LINK2 https://en.wikipedia.org/wiki/MurmurHash, Wikipedia)

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -24,7 +24,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
  * This module publicly imports $(D std.digest.digest) and can be used as a stand-alone
  * module.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *
  * CTFE:
  * Digests do not work in CTFE

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -29,7 +29,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  * This module publicly imports $(D std.digest.digest) and can be used as a stand-alone
  * module.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *
  * CTFE:
  * Digests do not work in CTFE

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -40,7 +40,7 @@ This library provides a mechanism whereby other modules may add $(D
 EncodingScheme) subclasses for any other _encoding.
 
 Copyright: Copyright Janice Caron 2008 - 2009.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron
 Source:    $(PHOBOSSRC std/_encoding.d)
 */

--- a/std/exception.d
+++ b/std/exception.d
@@ -34,8 +34,8 @@
     --------------------
 
     Copyright: Copyright Andrei Alexandrescu 2008-, Jonathan M Davis 2011-.
-    License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
-    Authors:   $(WEB erdani.org, Andrei Alexandrescu) and Jonathan M Davis
+    License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
+    Authors:   $(HTTP erdani.org, Andrei Alexandrescu) and Jonathan M Davis
     Source:    $(PHOBOSSRC std/_exception.d)
 
  +/
@@ -891,7 +891,7 @@ enum emptyExceptionMsg = "<Empty Exception Message>";
  *
  * For more on infering uniqueness see the $(B unique) and
  * $(B lent) keywords in the
- * $(WEB archjava.fluid.cs.cmu.edu/papers/oopsla02.pdf, ArchJava)
+ * $(HTTP archjava.fluid.cs.cmu.edu/papers/oopsla02.pdf, ArchJava)
  * language.
  *
  * The downside of using $(D assumeUnique)'s

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -6,7 +6,7 @@ import std.typecons : Flag, Yes, No;
 
 /**
 
-$(WEB en.wikipedia.org/wiki/Free_list, Free list allocator), stackable on top of
+$(HTTP en.wikipedia.org/wiki/Free_list, Free list allocator), stackable on top of
 another allocator. Allocation requests between $(D min) and $(D max) bytes are
 rounded up to $(D max) and served from a singly-linked list of buffers
 deallocated in the past. All other allocations are directed to $(D

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -10,9 +10,9 @@ version(unittest) import std.conv : text;
 /**
 $(D KRRegion) draws inspiration from the $(MREF_ALTTEXT region allocation
 strategy, std,experimental,allocator,building_blocks,region) and also the
-$(WEB stackoverflow.com/questions/13159564/explain-this-implementation-of-malloc-from-the-kr-book,
+$(HTTP stackoverflow.com/questions/13159564/explain-this-implementation-of-malloc-from-the-kr-book,
 famed allocator) described by Brian Kernighan and Dennis Ritchie in section 8.7
-of the book $(WEB amazon.com/exec/obidos/ASIN/0131103628/classicempire, "The C
+of the book $(HTTP amazon.com/exec/obidos/ASIN/0131103628/classicempire, "The C
 Programming Language"), Second Edition, Prentice Hall, 1988.
 
 $(H4 `KRRegion` = `Region` + Kernighan-Ritchie Allocator)

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -14,7 +14,7 @@ allocated. Put simply, the client must pass the allocated size upon
 deallocation. Storing the size in the _allocator has significant negative
 performance implications, and is virtually always redundant because client code
 needs knowledge of the allocated size in order to avoid buffer overruns. (See
-more discussion in a $(WEB open-
+more discussion in a $(HTTP open-
 std.org/JTC1/SC22/WG21/docs/papers/2013/n3536.html, proposal) for sized
 deallocation in C++.) For this reason, allocators herein traffic in $(D void[])
 as opposed to $(D void*).)
@@ -42,7 +42,7 @@ alignedReallocate) APIs.))
 $(TR $(TDC size_t goodAllocSize(size_t n);, $(POST $(RES) >= n)) $(TD Allocators
 customarily allocate memory in discretely-sized chunks. Therefore, a request for
 $(D n) bytes may result in a larger allocation. The extra memory allocated goes
-unused and adds to the so-called $(WEB goo.gl/YoKffF,internal fragmentation).
+unused and adds to the so-called $(HTTP goo.gl/YoKffF,internal fragmentation).
 The function $(D goodAllocSize(n)) returns the actual number of bytes that would
 be allocated upon a request for $(D n) bytes. This module defines a default
 implementation that returns $(D n) rounded up to a multiple of the allocator's
@@ -135,7 +135,7 @@ thread-safe or not, this instance may be $(D shared).))
 
 $(H2 Sample Assembly)
 
-The example below features an _allocator modeled after $(WEB goo.gl/m7329l,
+The example below features an _allocator modeled after $(HTTP goo.gl/m7329l,
 jemalloc), which uses a battery of free-list allocators spaced so as to keep
 internal fragmentation to a minimum. The $(D FList) definitions specify no
 bounds for the freelist because the $(D Segregator) does all size selection in
@@ -219,8 +219,8 @@ to leak.))
 
 $(TR $(TDC3 AlignedMallocator, mallocator) $(TD Interface to OS-specific _allocators that
 support specifying alignment:
-$(WEB man7.org/linux/man-pages/man3/posix_memalign.3.html, $(D posix_memalign))
-on Posix and $(WEB msdn.microsoft.com/en-us/library/fs9stz4e(v=vs.80).aspx,
+$(HTTP man7.org/linux/man-pages/man3/posix_memalign.3.html, $(D posix_memalign))
+on Posix and $(HTTP msdn.microsoft.com/en-us/library/fs9stz4e(v=vs.80).aspx,
 $(D __aligned_xxx)) on Windows.))
 
 $(TR $(TDC2 AffixAllocator, affix_allocator) $(TD Allocator that allows and manages allocating
@@ -235,7 +235,7 @@ $(TR $(TDC2 FallbackAllocator, fallback_allocator) $(TD Allocator that combines 
  upon failure are passed to the fallback. Useful for small and fast allocators
  fronting general-purpose ones.))
 
-$(TR $(TDC2 FreeList, free_list) $(TD Allocator that implements a $(WEB
+$(TR $(TDC2 FreeList, free_list) $(TD Allocator that implements a $(HTTP
 wikipedia.org/wiki/Free_list, free list) on top of any other allocator. The
 preferred size, tolerance, and maximum elements are configurable at compile- and
 run time.))

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -581,7 +581,7 @@ private extern(C) int brk(shared void*);
 /**
 
 Allocator backed by $(D $(LUCKY sbrk)) for Posix systems. Due to the fact that
-$(D sbrk) is not thread-safe $(WEB lifecs.likai.org/2010/02/sbrk-is-not-thread-
+$(D sbrk) is not thread-safe $(HTTP lifecs.likai.org/2010/02/sbrk-is-not-thread-
 safe.html, by design), $(D SbrkRegion) uses a mutex internally. This implies
 that uncontrolled calls to $(D brk) and $(D sbrk) may affect the workings of $(D
 SbrkRegion) adversely.

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -120,7 +120,7 @@ enum Options : ulong
     bytesNotMoved = 1u << 15,
     /**
     Measures the sum of extra bytes allocated beyond the bytes requested, i.e.
-    the $(WEB goo.gl/YoKffF, internal fragmentation). This is the current
+    the $(HTTP goo.gl/YoKffF, internal fragmentation). This is the current
     effective number of slack bytes, and it goes up and down with time.
     */
     bytesSlack = 1u << 16,

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -3,7 +3,7 @@ Utility and ancillary artifacts of `std.experimental.allocator`. This module
 shouldn't be used directly; its functionality will be migrated into more
 appropriate parts of `std`.
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu), Timon Gehr (`Ternary`)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu), Timon Gehr (`Ternary`)
 */
 module std.experimental.allocator.common;
 import std.algorithm, std.traits;

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -221,9 +221,9 @@ struct AlignedMallocator
     }
 
     /**
-    Uses $(WEB man7.org/linux/man-pages/man3/posix_memalign.3.html,
+    Uses $(HTTP man7.org/linux/man-pages/man3/posix_memalign.3.html,
     $(D posix_memalign)) on Posix and
-    $(WEB msdn.microsoft.com/en-us/library/8z34s9c6(v=vs.80).aspx,
+    $(HTTP msdn.microsoft.com/en-us/library/8z34s9c6(v=vs.80).aspx,
     $(D __aligned_malloc)) on Windows.
     */
     version(Posix)
@@ -259,7 +259,7 @@ struct AlignedMallocator
 
     /**
     Calls $(D free(b.ptr)) on Posix and
-    $(WEB msdn.microsoft.com/en-US/library/17b5h8td(v=vs.80).aspx,
+    $(HTTP msdn.microsoft.com/en-US/library/17b5h8td(v=vs.80).aspx,
     $(D __aligned_free(b.ptr))) on Windows.
     */
     version (Posix)
@@ -299,7 +299,7 @@ struct AlignedMallocator
     /**
     On Posix, uses $(D alignedAllocate) and copies data around because there is
     no realloc for aligned memory. On Windows, calls
-    $(WEB msdn.microsoft.com/en-US/library/y69db7sx(v=vs.80).aspx,
+    $(HTTP msdn.microsoft.com/en-US/library/y69db7sx(v=vs.80).aspx,
     $(D __aligned_realloc(b.ptr, newSize, a))).
     */
     version (Windows)

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -186,9 +186,9 @@ $(LREF allocatorObject)) only once, at client level.
 
 Copyright: Andrei Alexandrescu 2013-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu)
+Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
 Source: $(PHOBOSSRC std/experimental/_allocator)
 

--- a/std/experimental/logger/package.d
+++ b/std/experimental/logger/package.d
@@ -3,7 +3,7 @@ Implements logging facilities.
 
 Copyright: Copyright Robert "burner" Schadek 2013 --
 License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
-Authors: $(WEB www.svs.informatik.uni-oldenburg.de/60865.html, Robert burner Schadek)
+Authors: $(HTTP www.svs.informatik.uni-oldenburg.de/60865.html, Robert burner Schadek)
 
 $(H3 Basic Logging)
 

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -85,7 +85,7 @@ is identical to that of $(LREF strided).
 Bifacial interface of $(LREF dropOne) and $(LREF dropBackOne)
 is identical to that of $(LREF reversed).
 
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors:   Ilya Yaroshenko
 

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -301,7 +301,7 @@ At the same time, while working with `ndslice`, an engineer has access to the
 whole set of standard D library, so the functions he creates will be as
 efficient as if they were written in C.
 
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors:   Ilya Yaroshenko
 

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -40,7 +40,7 @@ $(T2 windows, n-dimensional slice of n-dimensional overlapping windows.
     If the slice has two dimensions, it is a sliding window.)
 )
 
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors:   Ilya Yaroshenko
 

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1,7 +1,7 @@
 /**
 This is a submodule of $(MREF std, experimental, ndslice).
 
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors:   Ilya Yaroshenko
 

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -11,9 +11,9 @@ functionality.
 Source:    $(PHOBOSSRC std/experimental/_typecons.d)
 
 Copyright: Copyright the respective authors, 2008-
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu),
-           $(WEB bartoszmilewski.wordpress.com, Bartosz Milewski),
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
+           $(HTTP bartoszmilewski.wordpress.com, Bartosz Milewski),
            Don Clugston,
            Shin Fujishiro,
            Kenji Hara

--- a/std/file.d
+++ b/std/file.d
@@ -7,14 +7,14 @@ at a time. For opening files and manipulating them via handles refer
 to module $(MREF std, stdio).
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
+See_Also:  The $(HTTP ddili.org/ders/d.en/files.html, official tutorial) for an
 introduction to working with files in D, module
 $(MREF std, stdio) for opening files and manipulating them via handles,
 and module $(MREF std, path) for manipulating path strings.
 
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           $(WEB erdani.org, Andrei Alexandrescu),
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright),
+           $(HTTP erdani.org, Andrei Alexandrescu),
            Jonathan M Davis
 Source:    $(PHOBOSSRC std/_file.d)
  */
@@ -1295,7 +1295,7 @@ unittest
     file does not exist, returns $(D returnIfMissing).
 
     A frequent usage pattern occurs in build automation tools such as
-    $(WEB gnu.org/software/make, make) or $(WEB
+    $(HTTP gnu.org/software/make, make) or $(HTTP
     en.wikipedia.org/wiki/Apache_Ant, ant). To check whether file $(D
     target) must be rebuilt from file $(D source) (i.e., $(D target) is
     older than $(D source) or does not exist), use the comparison
@@ -1471,10 +1471,10 @@ private bool existsImpl(const(FSChar)* namez) @trusted nothrow @nogc
 
  Note that the file attributes on Windows and Posix systems are
  completely different. On Windows, they're what is returned by
- $(WEB msdn.microsoft.com/en-us/library/aa364944(v=vs.85).aspx,
+ $(HTTP msdn.microsoft.com/en-us/library/aa364944(v=vs.85).aspx,
  GetFileAttributes), whereas on Posix systems, they're the $(LUCKY
  st_mode) value which is part of the $(D stat struct) gotten by
- calling the $(WEB en.wikipedia.org/wiki/Stat_%28Unix%29, $(D stat))
+ calling the $(HTTP en.wikipedia.org/wiki/Stat_%28Unix%29, $(D stat))
  function.
 
  On Posix systems, if the given file is a symbolic link, then
@@ -2780,7 +2780,7 @@ assert(!de2.isFile);
             Note that the file attributes on Windows and Posix systems are
             completely different. On, Windows, they're what is returned by
             $(D GetFileAttributes)
-            $(WEB msdn.microsoft.com/en-us/library/aa364944(v=vs.85).aspx, GetFileAttributes)
+            $(HTTP msdn.microsoft.com/en-us/library/aa364944(v=vs.85).aspx, GetFileAttributes)
             Whereas, an Posix systems, they're the $(D st_mode) value which is
             part of the $(D stat) struct gotten by calling $(D stat).
 

--- a/std/format.d
+++ b/std/format.d
@@ -46,9 +46,9 @@ $(TR $(TH Function Name) $(TH Description)
    used for the plumbing.
    Copyright: Copyright Digital Mars 2000-2013.
 
-   License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+   License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-   Authors: $(WEB walterbright.com, Walter Bright), $(WEB erdani.com,
+   Authors: $(HTTP walterbright.com, Walter Bright), $(HTTP erdani.com,
    Andrei Alexandrescu), and Kenji Hara
 
    Source: $(PHOBOSSRC std/_format.d)
@@ -107,7 +107,7 @@ private alias enforceFmt = enforceEx!FormatException;
    must satisfy $(D $(REF isOutputRange, std,range,primitives)!(Writer, Char)).
 
    The variadic arguments are normally consumed in order. POSIX-style
-   $(WEB opengroup.org/onlinepubs/009695399/functions/printf.html,
+   $(HTTP opengroup.org/onlinepubs/009695399/functions/printf.html,
    positional parameter syntax) is also supported. Each argument is
    formatted into a sequence of chars according to the format
    specification, and the characters are passed to $(D w). As many

--- a/std/functional.d
+++ b/std/functional.d
@@ -48,8 +48,8 @@ $(TR $(TH Function Name) $(TH Description)
 )
 
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu)
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
 Source:    $(PHOBOSSRC std/_functional.d)
 */
 /*
@@ -958,7 +958,7 @@ unittest
  * computation. The memoization structure is a hash table keyed by a
  * tuple of the function's arguments. There is a speed gain if the
  * function is repeatedly called with the same arguments and is more
- * expensive than a hash table lookup. For more information on memoization, refer to $(WEB docs.google.com/viewer?url=http%3A%2F%2Fhop.perl.plover.com%2Fbook%2Fpdf%2F03CachingAndMemoization.pdf, this book chapter).
+ * expensive than a hash table lookup. For more information on memoization, refer to $(HTTP docs.google.com/viewer?url=http%3A%2F%2Fhop.perl.plover.com%2Fbook%2Fpdf%2F03CachingAndMemoization.pdf, this book chapter).
 
 Example:
 ----

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -11,9 +11,9 @@ with the more traditional single-letter approach, is provided but not
 enabled by default.
 
 Copyright: Copyright Andrei Alexandrescu 2008 - 2015.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu)
-Credits:   This module and its documentation are inspired by Perl's $(WEB
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
+Credits:   This module and its documentation are inspired by Perl's $(HTTP
            perldoc.perl.org/Getopt/Long.html, Getopt::Long) module. The syntax of
            D's $(D getopt) is simpler than its Perl counterpart because $(D
            getopt) infers the expected parameter types from the static types of

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -1,7 +1,7 @@
 /**
  * Error Functions and Normal Distribution.
  *
- * License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Copyright: Based on the CEPHES math library, which is
  *            Copyright (C) 1994 Stephen L. Moshier (moshier@world.std.com).
  * Authors:   Stephen L. Moshier, ported to D by Don Clugston

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1,7 +1,7 @@
 /**
  * Implementation of the gamma and beta functions, and their integrals.
  *
- * License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Copyright: Based on the CEPHES math library, which is
  *            Copyright (C) 1994 Stephen L. Moshier (moshier@world.std.com).
  * Authors:   Stephen L. Moshier (original C code). Conversion to D by Don Clugston

--- a/std/internal/processinit.d
+++ b/std/internal/processinit.d
@@ -5,7 +5,7 @@
     std.process in order to eliminate cyclic construction errors.
 
     Copyright: Copyright 2011 -
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis and Kato Shoichi
     Source:    $(PHOBOSSRC std/internal/_processinit.d)
   +/

--- a/std/internal/unicode_tables.d
+++ b/std/internal/unicode_tables.d
@@ -1,6 +1,6 @@
 //Written in the D programming language
 /**
- * License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *
  * Authors: Dmitry Olshansky
  *

--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -4,7 +4,7 @@
  * The only purpose of this module is to do the static construction for
  * std.windows.registry, to eliminate cyclic construction errors.
  *
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Kenji Hara
  * Source:    $(PHOBOSSRC std/internal/windows/_advapi32.d)
  */

--- a/std/json.d
+++ b/std/json.d
@@ -39,7 +39,7 @@ Synopsis:
 ----
 
 Copyright: Copyright Jeremie Pelletier 2008 - 2009.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth
 References: $(LINK http://json.org/)
 Source:    $(PHOBOSSRC std/_json.d)

--- a/std/math.d
+++ b/std/math.d
@@ -114,8 +114,8 @@ $(TR $(TDNW Hardware Control) $(TD
  *            reserves the right to distribute this material elsewhere under different
  *            copying permissions.  These modifications are distributed here under
  *            the following terms:
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright), Don Clugston,
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
  *            Conversion of CEPHES math library to D by Iain Buclaw
  * Source: $(PHOBOSSRC std/_math.d)
  */
@@ -643,7 +643,7 @@ unittest
 }
 
 /***********************************
- * Returns $(WEB en.wikipedia.org/wiki/Sine, sine) of x. x is in $(WEB en.wikipedia.org/wiki/Radian, radians).
+ * Returns $(HTTP en.wikipedia.org/wiki/Sine, sine) of x. x is in $(HTTP en.wikipedia.org/wiki/Radian, radians).
  *
  *      $(TABLE_SV
  *      $(TH3 x           ,  sin(x)      ,  invalid?)

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -48,7 +48,7 @@
  *
  * Copyright: Based on the CEPHES math library, which is
  *            Copyright (C) 1994 Stephen L. Moshier (moshier@world.std.com).
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Stephen L. Moshier (original C code). Conversion to D by Don Clugston
  * Source:    $(PHOBOSSRC std/_mathspecial.d)
  */

--- a/std/meta.d
+++ b/std/meta.d
@@ -61,10 +61,10 @@
  *      Modern C++ Design),
  *   Andrei Alexandrescu (Addison-Wesley Professional, 2001)
  * Copyright: Copyright Digital Mars 2005 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
- *     $(WEB digitalmars.com, Walter Bright),
- *     $(WEB klickverbot.at, David Nadlinger)
+ *     $(HTTP digitalmars.com, Walter Bright),
+ *     $(HTTP klickverbot.at, David Nadlinger)
  * Source:    $(PHOBOSSRC std/_meta.d)
  */
 

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -3,8 +3,8 @@
 /**
  * Read and write memory mapped files.
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright),
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *            Matthew Wilson
  * Source:    $(PHOBOSSRC std/_mmfile.d)
  */

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
-Networking client functionality as provided by $(WEB _curl.haxx.se/libcurl,
+Networking client functionality as provided by $(HTTP _curl.haxx.se/libcurl,
 libcurl). The libcurl library must be installed on the system in order to use
 this module.
 
@@ -142,10 +142,10 @@ synchronous.
 Source: $(PHOBOSSRC std/net/_curl.d)
 
 Copyright: Copyright Jonas Drewsen 2011-2012
-License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Jonas Drewsen. Some of the SMTP code contributed by Jimmy Cao.
 
-Credits: The functionally is based on $(WEB _curl.haxx.se/libcurl, libcurl).
+Credits: The functionally is based on $(HTTP _curl.haxx.se/libcurl, libcurl).
          LibCurl is licensed under an MIT/X derivative license.
 */
 /*
@@ -1927,7 +1927,7 @@ private mixin template Protocol()
     // Network settings
 
     /** Proxy
-     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+     *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
      */
     @property void proxy(const(char)[] host)
     {
@@ -1935,7 +1935,7 @@ private mixin template Protocol()
     }
 
     /** Proxy port
-     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+     *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
      */
     @property void proxyPort(ushort port)
     {
@@ -1946,7 +1946,7 @@ private mixin template Protocol()
     alias CurlProxy = etc.c.curl.CurlProxy;
 
     /** Proxy type
-     *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+     *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
      */
     @property void proxyType(CurlProxy type)
     {
@@ -2011,7 +2011,7 @@ private mixin template Protocol()
     }
 
     /** Set the tcp no-delay socket option on or off.
-        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+        See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
     */
     @property void tcpNoDelay(bool on)
     {
@@ -2019,7 +2019,7 @@ private mixin template Protocol()
     }
 
     /** Sets whether SSL peer certificates should be verified.
-        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYPEER, verifypeer)
+        See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYPEER, verifypeer)
     */
     @property void verifyPeer(bool on)
     {
@@ -2027,7 +2027,7 @@ private mixin template Protocol()
     }
 
     /** Sets whether the host within an SSL certificate should be verified.
-        See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYHOST, verifypeer)
+        See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYHOST, verifypeer)
     */
     @property void verifyHost(bool on)
     {
@@ -2322,7 +2322,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * http.perform();
   * ---
   *
-  * See_Also: $(WEB www.ietf.org/rfc/rfc2616.txt, RFC2616)
+  * See_Also: $(HTTP www.ietf.org/rfc/rfc2616.txt, RFC2616)
   *
   */
 struct HTTP
@@ -2423,7 +2423,7 @@ struct HTTP
 
     /** Time condition enumeration as an alias of $(REF CurlTimeCond, etc,c,curl)
 
-        $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
+        $(HTTP www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
     */
     alias TimeCond = CurlTimeCond;
 
@@ -2594,12 +2594,12 @@ struct HTTP
         // Network settings
 
         /** Proxy
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
          */
         @property void proxy(const(char)[] host);
 
         /** Proxy port
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
          */
         @property void proxyPort(ushort port);
 
@@ -2607,7 +2607,7 @@ struct HTTP
         alias CurlProxy = etc.c.curl.CurlProxy;
 
         /** Proxy type
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
          */
         @property void proxyType(CurlProxy type);
 
@@ -2650,7 +2650,7 @@ struct HTTP
         @property void localPortRange(ushort range);
 
         /** Set the tcp no-delay socket option on or off.
-            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+            See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
         */
         @property void tcpNoDelay(bool on);
 
@@ -2901,7 +2901,7 @@ struct HTTP
        cond =  $(D CurlTimeCond.{none,ifmodsince,ifunmodsince,lastmod})
        timestamp = Timestamp for the condition
 
-       $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
+       $(HTTP www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25, _RFC2616 Section 14.25)
     */
     void setTimeCondition(HTTP.TimeCond cond, SysTime timestamp)
     {
@@ -3093,7 +3093,7 @@ struct HTTP
     }
 
     /** <a name="HTTP.Method"/>The standard HTTP methods :
-     *  $(WEB www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1, _RFC2616 Section 5.1.1)
+     *  $(HTTP www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1, _RFC2616 Section 5.1.1)
      */
     enum Method
     {
@@ -3144,7 +3144,7 @@ struct HTTP
 /**
    FTP client functionality.
 
-   See_Also: $(WEB tools.ietf.org/html/rfc959, RFC959)
+   See_Also: $(HTTP tools.ietf.org/html/rfc959, RFC959)
 */
 struct FTP
 {
@@ -3276,12 +3276,12 @@ struct FTP
         // Network settings
 
         /** Proxy
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
          */
         @property void proxy(const(char)[] host);
 
         /** Proxy port
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
          */
         @property void proxyPort(ushort port);
 
@@ -3289,7 +3289,7 @@ struct FTP
         alias CurlProxy = etc.c.curl.CurlProxy;
 
         /** Proxy type
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
          */
         @property void proxyType(CurlProxy type);
 
@@ -3332,7 +3332,7 @@ struct FTP
         @property void localPortRange(ushort range);
 
         /** Set the tcp no-delay socket option on or off.
-            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+            See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
         */
         @property void tcpNoDelay(bool on);
 
@@ -3475,7 +3475,7 @@ struct FTP
   * smtp.perform();
   * ---
   *
-  * See_Also: $(WEB www.ietf.org/rfc/rfc2821.txt, RFC2821)
+  * See_Also: $(HTTP www.ietf.org/rfc/rfc2821.txt, RFC2821)
   */
 struct SMTP
 {
@@ -3626,12 +3626,12 @@ struct SMTP
         // Network settings
 
         /** Proxy
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy)
          */
         @property void proxy(const(char)[] host);
 
         /** Proxy port
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYPORT, _proxy_port)
          */
         @property void proxyPort(ushort port);
 
@@ -3639,7 +3639,7 @@ struct SMTP
         alias CurlProxy = etc.c.curl.CurlProxy;
 
         /** Proxy type
-         *  See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
+         *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
          */
         @property void proxyType(CurlProxy type);
 
@@ -3682,7 +3682,7 @@ struct SMTP
         @property void localPortRange(ushort range);
 
         /** Set the tcp no-delay socket option on or off.
-            See: $(WEB curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
+            See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTTCPNODELAY, nodelay)
         */
         @property void tcpNoDelay(bool on);
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -7,8 +7,8 @@ Standard Template Library), with a few additions.
 
 Macros:
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu),
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
                    Don Clugston, Robert Jacques, Ilya Yaroshenko
 Source:    $(PHOBOSSRC std/_numeric.d)
 */
@@ -700,7 +700,7 @@ unittest
 }
 
 /**
-Implements the $(WEB tinyurl.com/2zb9yr, secant method) for finding a
+Implements the $(HTTP tinyurl.com/2zb9yr, secant method) for finding a
 root of the function $(D fun) starting from points $(D [xn_1, x_n])
 (ideally close to the root). $(D Num) may be $(D float), $(D double),
 or $(D real).
@@ -783,7 +783,7 @@ public:
  *
  * References: "On Enclosing Simple Roots of Nonlinear Equations",
  * G. Alefeld, F.A. Potra, Yixun Shi, Mathematics of Computation 61,
- * pp733-744 (1993).  Fortran code available from $(WEB
+ * pp733-744 (1993).  Fortran code available from $(HTTP
  * www.netlib.org,www.netlib.org) as algorithm TOMS478.
  *
  */
@@ -2273,7 +2273,7 @@ t.length). The time complexity is $(BIGOH s.length * t.length) time
 for computing each step. Continuing on the previous example:
 
 The implementation is based on the pseudocode in Fig. 4 of the paper
-$(WEB jmlr.csail.mit.edu/papers/volume6/rousu05a/rousu05a.pdf,
+$(HTTP jmlr.csail.mit.edu/papers/volume6/rousu05a/rousu05a.pdf,
 "Efﬁcient Computation of Gapped Substring Kernels on Large Alphabets")
 by Rousu et al., with additional algorithmic and systems-level
 optimizations.
@@ -2608,7 +2608,7 @@ private alias lookup_t = float;
  * one-off FFT.
  *
  * References:
- * $(WEB en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm)
+ * $(HTTP en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm)
  */
 final class Fft
 {

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -4,8 +4,8 @@
 Serialize data to $(D ubyte) arrays.
 
  * Copyright: Copyright Digital Mars 2000 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_outbuffer.d)
  */
 module std.outbuffer;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -70,7 +70,7 @@ void main() {
 Source:    $(PHOBOSSRC std/_parallelism.d)
 Author:  David Simcha
 Copyright:  Copyright (c) 2009-2011, David Simcha.
-License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
+License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
 */
 module std.parallelism;
 

--- a/std/path.d
+++ b/std/path.d
@@ -33,19 +33,19 @@
     allocates, this is explicitly mentioned in the documentation.
 
     Upgrading:
-        $(WEB digitalmars.com/d/1.0/phobos/std_path.html#fnmatch) can
+        $(HTTP digitalmars.com/d/1.0/phobos/std_path.html#fnmatch) can
         be replaced with $(D globMatch).
 
     Authors:
         Lars Tandle Kyllingstad,
-        $(WEB digitalmars.com, Walter Bright),
+        $(HTTP digitalmars.com, Walter Bright),
         Grzegorz Adam Hankiewicz,
         Thomas K$(UUML)hne,
-        $(WEB erdani.org, Andrei Alexandrescu)
+        $(HTTP erdani.org, Andrei Alexandrescu)
     Copyright:
         Copyright (c) 2000-2014, the authors. All rights reserved.
     License:
-        $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
+        $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:
         $(PHOBOSSRC std/_path.d)
 */

--- a/std/process.d
+++ b/std/process.d
@@ -72,11 +72,11 @@ $(LI
 Authors:
     $(LINK2 https://github.com/kyllingstad, Lars Tandle Kyllingstad),
     $(LINK2 https://github.com/schveiguy, Steven Schveighoffer),
-    $(WEB thecybershadow.net, Vladimir Panteleev)
+    $(HTTP thecybershadow.net, Vladimir Panteleev)
 Copyright:
     Copyright (c) 2013, the authors. All rights reserved.
 License:
-   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
@@ -1333,7 +1333,7 @@ its exit status.
 
 In general one should always _wait for child processes to terminate
 before exiting the parent process.  Otherwise, they may become
-"$(WEB en.wikipedia.org/wiki/Zombie_process,zombies)" – processes
+"$(HTTP en.wikipedia.org/wiki/Zombie_process,zombies)" – processes
 that are defunct, yet still occupy a slot in the OS process table.
 
 If the process has already terminated, this function returns directly.
@@ -3256,10 +3256,10 @@ unittest
 
 /*
 Copyright: Copyright Digital Mars 2007 - 2009.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           $(WEB erdani.org, Andrei Alexandrescu),
-           $(WEB thecybershadow.net, Vladimir Panteleev)
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright),
+           $(HTTP erdani.org, Andrei Alexandrescu),
+           $(HTTP thecybershadow.net, Vladimir Panteleev)
 Source:    $(PHOBOSSRC std/_process.d)
 */
 /*

--- a/std/random.d
+++ b/std/random.d
@@ -40,12 +40,12 @@ Source:    $(PHOBOSSRC std/_random.d)
 Macros:
 
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009, Joseph Rushton Wakeling 2012.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu)
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
            Masahiro Nakagawa (Xorshift random generator)
-           $(WEB braingam.es, Joseph Rushton Wakeling) (Algorithm D for random sampling)
+           $(HTTP braingam.es, Joseph Rushton Wakeling) (Algorithm D for random sampling)
 Credits:   The entire random number library architecture is derived from the
-           excellent $(WEB open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2461.pdf, C++0X)
+           excellent $(HTTP open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2461.pdf, C++0X)
            random number facility proposed by Jens Maurer and contributed to by
            researchers at the Fermi laboratory (excluding Xorshift).
 */
@@ -437,7 +437,7 @@ Always $(D false) (random generators are infinite ranges).
 /**
 Define $(D_PARAM LinearCongruentialEngine) generators with well-chosen
 parameters. $(D MinstdRand0) implements Park and Miller's "minimal
-standard" $(WEB
+standard" $(HTTP
 wikipedia.org/wiki/Park%E2%80%93Miller_random_number_generator,
 generator) that uses 16807 for the multiplier. $(D MinstdRand)
 implements a variant that has slightly better spectral behavior by
@@ -721,7 +721,7 @@ Always $(D false).
 
 /**
 A $(D MersenneTwisterEngine) instantiated with the parameters of the
-original engine $(WEB math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html,
+original engine $(HTTP math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html,
 MT19937), generating uniformly-distributed 32-bit numbers with a
 period of 2 to the power of 19937. Recommended for random number
 generation unless memory is severely restricted, in which case a $(D
@@ -818,7 +818,7 @@ unittest
 /**
  * Xorshift generator using 32bit algorithm.
  *
- * Implemented according to $(WEB www.jstatsoft.org/v08/i14/paper, Xorshift RNGs).
+ * Implemented according to $(HTTP www.jstatsoft.org/v08/i14/paper, Xorshift RNGs).
  *
  * $(BOOKTABLE $(TEXTWITHCOMMAS Supporting bits are below, $(D bits) means second parameter of XorshiftEngine.),
  *  $(TR $(TH bits) $(TH period))
@@ -2278,7 +2278,7 @@ Returns:
     and $(D rng) are forward ranges, an input range otherwise.
 
 $(D RandomSample) implements Jeffrey Scott Vitter's Algorithm D
-(see Vitter $(WEB dx.doi.org/10.1145/358105.893, 1984), $(WEB
+(see Vitter $(HTTP dx.doi.org/10.1145/358105.893, 1984), $(HTTP
 dx.doi.org/10.1145/23002.23003, 1987)), which selects a sample
 of size $(D n) in O(n) steps and requiring O(n) random variates,
 regardless of the size of the data being sampled.  The exception

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -54,11 +54,11 @@ $(BOOKTABLE ,
 
 Source: $(PHOBOSSRC std/range/_interfaces.d)
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu), David Simcha,
+Authors: $(HTTP erdani.com, Andrei Alexandrescu), David Simcha,
 and Jonathan M Davis. Credit for some of the ideas in building this module goes
-to $(WEB fantascienza.net/leonardo/so/, Leonardo Maffi).
+to $(HTTP fantascienza.net/leonardo/so/, Leonardo Maffi).
 */
 module std.range.interfaces;
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8,7 +8,7 @@ std.algorithm)) to be used with a vast variety of different concrete types. For
 example, a linear search algorithm such as $(LINK2 std_algorithm.html#find,
 std.algorithm.find) works not just for arrays, but for linked-lists, input
 files, incoming network data, etc. See also Ali Çehreli's
-$(WEB ddili.org/ders/d.en/ranges.html, tutorial on ranges) for the basics
+$(HTTP ddili.org/ders/d.en/ranges.html, tutorial on ranges) for the basics
 of working with and creating range-based code.
 
 For more detailed information about the conceptual aspect of ranges and the
@@ -175,11 +175,11 @@ _range operations that take advantage of the fact that the _range is sorted.
 
 Source: $(PHOBOSSRC std/_range/_package.d)
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu), David Simcha, Jonathan M Davis,
+Authors: $(HTTP erdani.com, Andrei Alexandrescu), David Simcha, Jonathan M Davis,
 and Jack Stouffer. Credit for some of the ideas in building this module goes
-to $(WEB fantascienza.net/leonardo/so/, Leonardo Maffi).
+to $(HTTP fantascienza.net/leonardo/so/, Leonardo Maffi).
  */
 module std.range;
 
@@ -2603,7 +2603,7 @@ auto takeNone(R)(R range)
  + $(D _range).
  +
  + Intended as the _range equivalent of the Unix
- + $(WEB en.wikipedia.org/wiki/Tail_%28Unix%29, _tail) utility. When the length
+ + $(HTTP en.wikipedia.org/wiki/Tail_%28Unix%29, _tail) utility. When the length
  + of $(D _range) is less than or equal to $(D _n), $(D _range) is returned
  + as-is.
  +
@@ -4650,7 +4650,7 @@ recurrence(alias fun, State...)(State initial)
 
 /**
    $(D Sequence) is similar to $(D Recurrence) except that iteration is
-   presented in the so-called $(WEB en.wikipedia.org/wiki/Closed_form,
+   presented in the so-called $(HTTP en.wikipedia.org/wiki/Closed_form,
    closed form). This means that the $(D n)th element in the series is
    computable directly from the initial values and $(D n) itself. This
    implies that the interface offered by $(D Sequence) is a random-access
@@ -7975,7 +7975,7 @@ if (isInputRange!Range)
    the range with elements strictly smaller than $(D value)). The search
    schedule and its complexity are documented in
    $(LREF SearchPolicy).  See also STL's
-   $(WEB sgi.com/tech/stl/lower_bound.html, lower_bound).
+   $(HTTP sgi.com/tech/stl/lower_bound.html, lower_bound).
 */
     auto lowerBound(SearchPolicy sp = SearchPolicy.binarySearch, V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V)
@@ -8006,7 +8006,7 @@ is the only policy allowed (and it must be specified explicitly lest it exposes
 user code to unexpected inefficiencies). For random-access searches, all
 policies are allowed, and $(D SearchPolicy.binarySearch) is the default.
 
-See_Also: STL's $(WEB sgi.com/tech/stl/lower_bound.html,upper_bound).
+See_Also: STL's $(HTTP sgi.com/tech/stl/lower_bound.html,upper_bound).
 */
     auto upperBound(SearchPolicy sp = SearchPolicy.binarySearch, V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V))
@@ -8050,7 +8050,7 @@ See_Also: STL's $(WEB sgi.com/tech/stl/lower_bound.html,upper_bound).
    policies are justified by the fact that the two boundaries are likely
    to be near the first found value (i.e., equal ranges are relatively
    small). Completes the entire search in $(BIGOH log(n)) time. See also
-   STL's $(WEB sgi.com/tech/stl/equal_range.html, equal_range).
+   STL's $(HTTP sgi.com/tech/stl/equal_range.html, equal_range).
 */
     auto equalRange(V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V)
@@ -8166,7 +8166,7 @@ equalRange). Completes the entire search in $(BIGOH log(n)) time.
 /**
 Returns $(D true) if and only if $(D value) can be found in $(D
 range), which is assumed to be sorted. Performs $(BIGOH log(r.length))
-evaluations of $(D pred). See also STL's $(WEB
+evaluations of $(D pred). See also STL's $(HTTP
 sgi.com/tech/stl/binary_search.html, binary_search).
  */
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -101,11 +101,11 @@ $(BOOKTABLE ,
 
 Source: $(PHOBOSSRC std/range/_primitives.d)
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB erdani.com, Andrei Alexandrescu), David Simcha,
+Authors: $(HTTP erdani.com, Andrei Alexandrescu), David Simcha,
 and Jonathan M Davis. Credit for some of the ideas in building this module goes
-to $(WEB fantascienza.net/leonardo/so/, Leonardo Maffi).
+to $(HTTP fantascienza.net/leonardo/so/, Leonardo Maffi).
 */
 module std.range.primitives;
 

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -58,11 +58,11 @@
 
   The basic syntax shouldn't surprise experienced users of regular expressions.
   For an introduction to $(D std.regex) see a
-  $(WEB dlang.org/regular-expression.html, short tour) of the module API
+  $(HTTP dlang.org/regular-expression.html, short tour) of the module API
   and its abilities.
 
   There are other web resources on regular expressions to help newcomers,
-  and a good $(WEB www.regular-expressions.info, reference with tutorial)
+  and a good $(HTTP www.regular-expressions.info, reference with tutorial)
   can easily be found.
 
   This library uses a remarkably common ECMAScript syntax flavor
@@ -196,7 +196,7 @@
   $(SECTION Unicode support)
 
   This library provides full Level 1 support* according to
-    $(WEB unicode.org/reports/tr18/, UTS 18). Specifically:
+    $(HTTP unicode.org/reports/tr18/, UTS 18). Specifically:
   $(UL
     $(LI 1.1 Hex notation via any of \uxxxx, \U00YYYYYY, \xZZ.)
     $(LI 1.2 Unicode properties.)
@@ -242,7 +242,7 @@
 
     Copyright: Copyright Dmitry Olshansky, 2011-
 
-  License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+  License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
   Authors: Dmitry Olshansky,
 

--- a/std/signals.d
+++ b/std/signals.d
@@ -49,8 +49,8 @@
  *      SIGNALS=signals
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_signals.d)
  */
 /*          Copyright Digital Mars 2000 - 2009.

--- a/std/socket.d
+++ b/std/socket.d
@@ -36,9 +36,9 @@
 /**
  * Socket primitives.
  * Example: See $(SAMPLESRC listener.d) and $(SAMPLESRC htmlget.d)
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors: Christopher E. Miller, $(WEB klickverbot.at, David Nadlinger),
- *      $(WEB thecybershadow.net, Vladimir Panteleev)
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors: Christopher E. Miller, $(HTTP klickverbot.at, David Nadlinger),
+ *      $(HTTP thecybershadow.net, Vladimir Panteleev)
  * Source:  $(PHOBOSSRC std/_socket.d)
  */
 

--- a/std/stdint.d
+++ b/std/stdint.d
@@ -116,8 +116,8 @@
  *  ATABLE=<table border="1" cellspacing="0" cellpadding="5">$0</table>
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_stdint.d)
  */
 /*          Copyright Digital Mars 2000 - 2009.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -6,9 +6,9 @@ is $(D_PARAM public)ally imported when importing $(B std.stdio).
 
 Source: $(PHOBOSSRC std/_stdio.d)
 Copyright: Copyright Digital Mars 2007-.
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB digitalmars.com, Walter Bright),
-           $(WEB erdani.org, Andrei Alexandrescu),
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright),
+           $(HTTP erdani.org, Andrei Alexandrescu),
            Alex Rønne Petersen
  */
 module std.stdio;
@@ -390,7 +390,7 @@ Params:
     name = range or string representing the file _name
     stdioOpenmode = range or string represting the open mode
         (with the same semantics as in the C standard library
-        $(WEB cplusplus.com/reference/clibrary/cstdio/fopen.html, fopen)
+        $(HTTP cplusplus.com/reference/clibrary/cstdio/fopen.html, fopen)
         function)
 
 Throws: $(D ErrnoException) if the file could not be opened.
@@ -474,7 +474,7 @@ file.
 /**
 First calls $(D detach) (throwing on failure), and then attempts to
 _open file $(D name) with mode $(D stdioOpenmode). The mode has the
-same semantics as in the C standard library $(WEB
+same semantics as in the C standard library $(HTTP
 cplusplus.com/reference/clibrary/cstdio/fopen.html, fopen) function.
 
 Throws: $(D ErrnoException) in case of error.
@@ -487,7 +487,7 @@ Throws: $(D ErrnoException) in case of error.
 
 /**
 First calls $(D detach) (throwing on failure), and then runs a command
-by calling the C standard library function $(WEB
+by calling the C standard library function $(HTTP
 opengroup.org/onlinepubs/007908799/xsh/_popen.html, _popen).
 
 Throws: $(D ErrnoException) in case of error.
@@ -606,7 +606,7 @@ Throws: $(D ErrnoException) in case of error.
     }
 
 /**
-Returns $(D true) if the file is at end (see $(WEB
+Returns $(D true) if the file is at end (see $(HTTP
 cplusplus.com/reference/clibrary/cstdio/feof.html, feof)).
 
 Throws: $(D Exception) if the file is not opened.
@@ -629,7 +629,7 @@ it has no name.*/
 
 /**
 If the file is not opened, returns $(D true). Otherwise, returns
-$(WEB cplusplus.com/reference/clibrary/cstdio/ferror.html, ferror) for
+$(HTTP cplusplus.com/reference/clibrary/cstdio/ferror.html, ferror) for
 the file handle.
  */
     @property bool error() const @trusted pure nothrow
@@ -684,7 +684,7 @@ Throws: $(D ErrnoException) on failure if closing the file.
 
 /**
 If the file was unopened, succeeds vacuously. Otherwise closes the
-file (by calling $(WEB
+file (by calling $(HTTP
 cplusplus.com/reference/clibrary/cstdio/fclose.html, fclose)),
 throwing on error. Even if an exception is thrown, afterwards the $(D
 File) object is empty. This is different from $(D detach) in that it
@@ -729,7 +729,7 @@ Throws: $(D ErrnoException) on error.
 
 /**
 If the file is not opened, succeeds vacuously. Otherwise, returns
-$(WEB cplusplus.com/reference/clibrary/cstdio/_clearerr.html,
+$(HTTP cplusplus.com/reference/clibrary/cstdio/_clearerr.html,
 _clearerr) for the file handle.
  */
     void clearerr() @safe pure nothrow
@@ -741,7 +741,7 @@ _clearerr) for the file handle.
 /**
 Flushes the C $(D FILE) buffers.
 
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/_fflush.html, _fflush)
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/_fflush.html, _fflush)
 for the file handle.
 
 Throws: $(D Exception) if the file is not opened or if the call to $(D fflush) fails.
@@ -773,9 +773,9 @@ Forces any data buffered by the OS to be written to disk.
 Call $(LREF flush) before calling this function to flush the C $(D FILE) buffers first.
 
 This function calls
-$(WEB msdn.microsoft.com/en-us/library/windows/desktop/aa364439%28v=vs.85%29.aspx,
+$(HTTP msdn.microsoft.com/en-us/library/windows/desktop/aa364439%28v=vs.85%29.aspx,
 $(D FlushFileBuffers)) on Windows and
-$(WEB pubs.opengroup.org/onlinepubs/7908799/xsh/fsync.html,
+$(HTTP pubs.opengroup.org/onlinepubs/7908799/xsh/fsync.html,
 $(D fsync)) on POSIX for the file handle.
 
 Throws: $(D Exception) if the file is not opened or if the OS call fails.
@@ -796,7 +796,7 @@ Throws: $(D Exception) if the file is not opened or if the OS call fails.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/fread.html, fread) for the
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/fread.html, fread) for the
 file handle. The number of items to read and the size of
 each item is inferred from the size and type of the input array, respectively.
 
@@ -857,7 +857,7 @@ $(D rawRead) always reads in binary mode on Windows.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/fwrite.html, fwrite) for the file
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/fwrite.html, fwrite) for the file
 handle. The number of items to write and the size of each
 item is inferred from the size and type of the input array, respectively. An
 error is thrown if the buffer could not be written in its entirety.
@@ -912,7 +912,7 @@ Throws: $(D ErrnoException) if the file is not opened or if the call to $(D fwri
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/fseek.html, fseek)
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/fseek.html, fseek)
 for the file handle.
 
 Throws: $(D Exception) if the file is not opened.
@@ -975,7 +975,7 @@ Throws: $(D Exception) if the file is not opened.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/ftell.html, ftell) for the
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/ftell.html, ftell) for the
 managed file handle.
 
 Throws: $(D Exception) if the file is not opened.
@@ -1020,7 +1020,7 @@ Throws: $(D Exception) if the file is not opened.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/_rewind.html, _rewind)
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/_rewind.html, _rewind)
 for the file handle.
 
 Throws: $(D Exception) if the file is not opened.
@@ -1034,7 +1034,7 @@ Throws: $(D Exception) if the file is not opened.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/_setvbuf.html, _setvbuf) for
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/_setvbuf.html, _setvbuf) for
 the file handle.
 
 Throws: $(D Exception) if the file is not opened.
@@ -1050,7 +1050,7 @@ Throws: $(D Exception) if the file is not opened.
     }
 
 /**
-Calls $(WEB cplusplus.com/reference/clibrary/cstdio/_setvbuf.html,
+Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/_setvbuf.html,
 _setvbuf) for the file handle.
 
 Throws: $(D Exception) if the file is not opened.
@@ -1705,7 +1705,7 @@ is recommended if you want to process a complete file.
     }
 
 /**
- Returns a temporary file by calling $(WEB
+ Returns a temporary file by calling $(HTTP
  cplusplus.com/reference/clibrary/cstdio/_tmpfile.html, _tmpfile).
  Note that the created file has no $(LREF name).*/
     static File tmpfile() @safe
@@ -4118,7 +4118,7 @@ unittest
 Writes an array or range to a file.
 Shorthand for $(D data.copy(File(fileName, "wb").lockingBinaryWriter)).
 Similar to $(REF write, std,file), strings are written as-is,
-rather than encoded according to the $(D File)'s $(WEB
+rather than encoded according to the $(D File)'s $(HTTP
 en.cppreference.com/w/c/io#Narrow_and_wide_orientation,
 orientation).
 */

--- a/std/stdiobase.d
+++ b/std/stdiobase.d
@@ -5,8 +5,8 @@
  * std.stdio, to eliminate cyclic construction errors.
  *
  * Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB erdani.org, Andrei Alexandrescu)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
  * Source:    $(PHOBOSSRC std/_stdiobase.d)
  */
 /*          Copyright Andrei Alexandrescu 2008 - 2009.

--- a/std/string.d
+++ b/std/string.d
@@ -136,10 +136,10 @@ See_Also:
 
 Copyright: Copyright Digital Mars 2007-.
 
-License: $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Authors: $(WEB digitalmars.com, Walter Bright),
-         $(WEB erdani.org, Andrei Alexandrescu),
+Authors: $(HTTP digitalmars.com, Walter Bright),
+         $(HTTP erdani.org, Andrei Alexandrescu),
         Jonathan M Davis,
         and David L. 'SpottedTiger' Davis
 
@@ -2373,7 +2373,7 @@ auto capitalize(S)(auto ref S s)
     Allocates memory; use $(LREF lineSplitter) for an alternative that
     does not.
 
-    Adheres to $(WEB www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
+    Adheres to $(HTTP www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
 
   Params:
     s = a string of $(D chars), $(D wchars), or $(D dchars), or any custom
@@ -2698,7 +2698,7 @@ public:
     Does not throw on invalid UTF; such is simply passed unchanged
     to the output.
 
-    Adheres to $(WEB www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
+    Adheres to $(HTTP www.unicode.org/versions/Unicode7.0.0/ch05.pdf, Unicode 7.0).
 
     Does not allocate memory.
 
@@ -5590,7 +5590,7 @@ S succ(S)(S s) @safe pure if (isSomeString!S)
     the corresponding characters in $(D to) and returns the resulting string.
 
     $(D tr) is based on
-    $(WEB pubs.opengroup.org/onlinepubs/9699919799/utilities/_tr.html, Posix's tr),
+    $(HTTP pubs.opengroup.org/onlinepubs/9699919799/utilities/_tr.html, Posix's tr),
     though it doesn't do everything that the Posix utility does.
 
     Params:

--- a/std/system.d
+++ b/std/system.d
@@ -4,8 +4,8 @@
  * Information about the target operating system, environment, and CPU.
  *
  *  Copyright: Copyright Digital Mars 2000 - 2011
- *  License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- *  Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis
+ *  License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ *  Authors:   $(HTTP digitalmars.com, Walter Bright) and Jonathan M Davis
  *  Source:    $(PHOBOSSRC std/_system.d)
  */
 module std.system;

--- a/std/traits.d
+++ b/std/traits.d
@@ -137,13 +137,13 @@
  * )
  *
  * Copyright: Copyright Digital Mars 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright),
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *            Tomasz Stachowiak ($(D isExpressions)),
- *            $(WEB erdani.org, Andrei Alexandrescu),
+ *            $(HTTP erdani.org, Andrei Alexandrescu),
  *            Shin Fujishiro,
- *            $(WEB octarineparrot.com, Robert Clipsham),
- *            $(WEB klickverbot.at, David Nadlinger),
+ *            $(HTTP octarineparrot.com, Robert Clipsham),
+ *            $(HTTP klickverbot.at, David Nadlinger),
  *            Kenji Hara,
  *            Shoichi Kato
  * Source:    $(PHOBOSSRC std/_traits.d)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -31,9 +31,9 @@ void bar()
 ----
 
 Copyright: Copyright the respective authors, 2008-
-License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu),
-           $(WEB bartoszmilewski.wordpress.com, Bartosz Milewski),
+License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
+           $(HTTP bartoszmilewski.wordpress.com, Bartosz Milewski),
            Don Clugston,
            Shin Fujishiro,
            Kenji Hara
@@ -3037,7 +3037,7 @@ auto-implemented function just returns the default value of the return type
 without doing anything.
 
 The name came from
-$(WEB search.cpan.org/~sburke/Class-_BlackHole-0.04/lib/Class/_BlackHole.pm, Class::_BlackHole)
+$(HTTP search.cpan.org/~sburke/Class-_BlackHole-0.04/lib/Class/_BlackHole.pm, Class::_BlackHole)
 Perl module by Sean M. Burke.
 
 Params:
@@ -3117,7 +3117,7 @@ simply throw an $(D Error) and never return. `Whitehole` is useful for
 trapping the use of class member functions that haven't been implemented.
 
 The name came from
-$(WEB search.cpan.org/~mschwern/Class-_WhiteHole-0.04/lib/Class/_WhiteHole.pm, Class::_WhiteHole)
+$(HTTP search.cpan.org/~mschwern/Class-_WhiteHole-0.04/lib/Class/_WhiteHole.pm, Class::_WhiteHole)
 Perl module by Michael G Schwern.
 
 Params:
@@ -5057,7 +5057,7 @@ unittest
  * Returns:
  *   An initialized $(D RefCounted) containing $(D val).
  * See_Also:
- *   $(WEB en.cppreference.com/w/cpp/memory/shared_ptr/make_shared, C++'s make_shared)
+ *   $(HTTP en.cppreference.com/w/cpp/memory/shared_ptr/make_shared, C++'s make_shared)
  */
 RefCounted!(T, RefCountedAutoInitialize.no) refCounted(T)(T val)
 {
@@ -7152,7 +7152,7 @@ $(UL
 Also known as trinary, trivalent, or trilean.
 
 See_Also:
-    $(WEB en.wikipedia.org/wiki/Three-valued_logic,
+    $(HTTP en.wikipedia.org/wiki/Three-valued_logic,
         Three Valued Logic on Wikipedia)
 */
 struct Ternary

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -3,7 +3,7 @@
  * $(MREF std, meta) instead.
  *
  * Copyright: Copyright Digital Mars 2005 - 2015.
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
  * Source:    $(PHOBOSSRC std/_typetuple.d)
  */

--- a/std/uni.d
+++ b/std/uni.d
@@ -84,7 +84,7 @@
             $(S_LINK Unicode properties, Supported sets) include Script,
             Block and General Category. The exact contents of a set can be
             observed in the CLDR utility, on the
-            $(WEB www.unicode.org/cldr/utility/properties.jsp, property index) page
+            $(HTTP www.unicode.org/cldr/utility/properties.jsp, property index) page
             of the Unicode website.
             See $(LREF unicode) for easy and (optionally) compile-time checked set
             queries.
@@ -155,7 +155,7 @@
     $(P The following is a list of important Unicode notions
     and definitions. Any conventions used specifically in this
     module alone are marked as such. The descriptions are based on the formal
-    definition as found in $(WEB www.unicode.org/versions/Unicode6.2.0/ch03.pdf,
+    definition as found in $(HTTP www.unicode.org/versions/Unicode6.2.0/ch03.pdf,
     chapter three of The Unicode Standard Core Specification.)
     )
     $(P $(DEF Abstract character) A unit of information used for the organization,
@@ -188,11 +188,11 @@
         mappings found in the Unicode Character Database
         and these described in Conjoining Jamo Behavior
         (section 12 of
-        $(WEB www.unicode.org/uni2book/ch03.pdf, Unicode Conformance)).
+        $(HTTP www.unicode.org/uni2book/ch03.pdf, Unicode Conformance)).
     )
     $(P $(DEF Canonical composition)
         The precise definition of the Canonical composition
-        is the algorithm as specified in $(WEB www.unicode.org/uni2book/ch03.pdf,
+        is the algorithm as specified in $(HTTP www.unicode.org/uni2book/ch03.pdf,
         Unicode Conformance) section 11.
         Informally it's the process that does the reverse of the canonical
         decomposition with the addition of certain rules
@@ -261,7 +261,7 @@
     )
     $(P $(DEF Grapheme cluster) Defined as the text between
         grapheme boundaries  as specified by Unicode Standard Annex #29,
-        $(WEB www.unicode.org/reports/tr29/, Unicode text segmentation).
+        $(HTTP www.unicode.org/reports/tr29/, Unicode text segmentation).
         Important general properties of a grapheme:
         $(UL
             $(LI The grapheme cluster represents a horizontally segmentable
@@ -348,7 +348,7 @@
     )
     $(P The recommended solution (see Unicode Implementation Guidelines)
         is using multi-stage tables that are an implementation of the
-        $(WEB en.wikipedia.org/wiki/Trie, Trie) data structure with integer
+        $(HTTP en.wikipedia.org/wiki/Trie, Trie) data structure with integer
         keys and a fixed number of stages. For the remainder of the section
         this will be called a fixed trie. The following describes a particular
         implementation that is aimed for the speed of access at the expense
@@ -400,7 +400,7 @@
     )
     $(P This is a full list of Unicode properties accessible through $(LREF unicode)
         with specific helpers per category nested within. Consult the
-        $(WEB www.unicode.org/cldr/utility/properties.jsp, CLDR utility)
+        $(HTTP www.unicode.org/cldr/utility/properties.jsp, CLDR utility)
         when in doubt about the contents of a particular set.
     )
     $(P General category sets listed below are only accessible with the
@@ -585,23 +585,23 @@
             $(TR $(TD V)   $(TD Vowel_Jamo))
     )
     References:
-        $(WEB www.digitalmars.com/d/ascii-table.html, ASCII Table),
-        $(WEB en.wikipedia.org/wiki/Unicode, Wikipedia),
-        $(WEB www.unicode.org, The Unicode Consortium),
-        $(WEB www.unicode.org/reports/tr15/, Unicode normalization forms),
-        $(WEB www.unicode.org/reports/tr29/, Unicode text segmentation)
-        $(WEB www.unicode.org/uni2book/ch05.pdf,
+        $(HTTP www.digitalmars.com/d/ascii-table.html, ASCII Table),
+        $(HTTP en.wikipedia.org/wiki/Unicode, Wikipedia),
+        $(HTTP www.unicode.org, The Unicode Consortium),
+        $(HTTP www.unicode.org/reports/tr15/, Unicode normalization forms),
+        $(HTTP www.unicode.org/reports/tr29/, Unicode text segmentation)
+        $(HTTP www.unicode.org/uni2book/ch05.pdf,
             Unicode Implementation Guidelines)
-        $(WEB www.unicode.org/uni2book/ch03.pdf,
+        $(HTTP www.unicode.org/uni2book/ch03.pdf,
             Unicode Conformance)
     Trademarks:
         Unicode(tm) is a trademark of Unicode, Inc.
 
     Copyright: Copyright 2013 -
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Dmitry Olshansky
     Source:    $(PHOBOSSRC std/_uni.d)
-    Standards: $(WEB www.unicode.org/versions/Unicode6.2.0/, Unicode v6.2)
+    Standards: $(HTTP www.unicode.org/versions/Unicode6.2.0/, Unicode v6.2)
 
 Macros:
 
@@ -1923,7 +1923,7 @@ pure:
 
     $(P Memory usage is 8 bytes per each contiguous interval in a set.
     The value semantics are achieved by using the
-    $(WEB en.wikipedia.org/wiki/Copy-on-write, COW) technique
+    $(HTTP en.wikipedia.org/wiki/Copy-on-write, COW) technique
     and thus it's $(RED not) safe to cast this type to $(D_KEYWORD shared).
     )
 

--- a/std/uri.d
+++ b/std/uri.d
@@ -12,8 +12,8 @@
  *  $(LINK2 http://www.ietf.org/rfc/rfc3986.txt, RFC 3986)<br>
  *  $(LINK2 http://en.wikipedia.org/wiki/Uniform_resource_identifier, Wikipedia)
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_uri.d)
  */
 /*          Copyright Digital Mars 2000 - 2009.

--- a/std/utf.d
+++ b/std/utf.d
@@ -11,8 +11,8 @@
         $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>
         $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
     Copyright: Copyright Digital Mars 2000 - 2012.
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-    Authors:   $(WEB digitalmars.com, Walter Bright) and Jonathan M Davis
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   $(HTTP digitalmars.com, Walter Bright) and Jonathan M Davis
     Source:    $(PHOBOSSRC std/_utf.d)
    +/
 module std.utf;
@@ -248,7 +248,7 @@ pure nothrow @safe @nogc unittest
 
     Returns:
         The number of code units in the UTF sequence. For UTF-8, this is a
-        value between 1 and 4 (as per $(WEB tools.ietf.org/html/rfc3629#section-3, RFC 3629$(COMMA) section 3)).
+        value between 1 and 4 (as per $(HTTP tools.ietf.org/html/rfc3629#section-3, RFC 3629$(COMMA) section 3)).
         For UTF-16, it is either 1 or 2. For UTF-32, it is always 1.
 
     Throws:
@@ -567,7 +567,7 @@ unittest
 
     Returns:
         The number of code units in the UTF sequence. For UTF-8, this is a
-        value between 1 and 4 (as per $(WEB tools.ietf.org/html/rfc3629#section-3, RFC 3629$(COMMA) section 3)).
+        value between 1 and 4 (as per $(HTTP tools.ietf.org/html/rfc3629#section-3, RFC 3629$(COMMA) section 3)).
         For UTF-16, it is either 1 or 2. For UTF-32, it is always 1.
 
     Throws:

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -82,7 +82,7 @@ $(TR $(TDNW UUID namespaces)
  * $(LINK http://en.wikipedia.org/wiki/Universally_unique_identifier)
  *
  * Copyright: Copyright Johannes Pfau 2011 - .
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Johannes Pfau
  * Source:    $(PHOBOSSRC std/_uuid.d)
  *

--- a/std/variant.d
+++ b/std/variant.d
@@ -2,10 +2,10 @@
 
 /**
 This module implements a
-$(WEB erdani.org/publications/cuj-04-2002.html,discriminated union)
+$(HTTP erdani.org/publications/cuj-04-2002.html,discriminated union)
 type (a.k.a.
-$(WEB en.wikipedia.org/wiki/Tagged_union,tagged union),
-$(WEB en.wikipedia.org/wiki/Algebraic_data_type,algebraic type)).
+$(HTTP en.wikipedia.org/wiki/Tagged_union,tagged union),
+$(HTTP en.wikipedia.org/wiki/Algebraic_data_type,algebraic type)).
 Such types are useful
 for type-uniform binary interfaces, interfacing with scripting
 languages, and comfortable exploratory programming.
@@ -59,8 +59,8 @@ Credits: Reviewed by Brad Roberts. Daniel Keep provided a detailed code review
 prompting the following improvements: (1) better support for arrays; (2) support
 for associative arrays; (3) friendlier behavior towards the garbage collector.
 Copyright: Copyright Andrei Alexandrescu 2007 - 2015.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors:   $(WEB erdani.org, Andrei Alexandrescu)
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
 Source:    $(PHOBOSSRC std/_variant.d)
 */
 module std.variant;

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -4,8 +4,8 @@
  * Support UTF-8 on Windows 95, 98 and ME systems.
  *
  * Copyright: Copyright Digital Mars 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  */
 /*          Copyright Digital Mars 2005 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -4,7 +4,7 @@
     Copyright: Copyright 2003-2004 by Matthew Wilson and Synesis Software
                Written by Matthew Wilson
 
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
     Author:    Matthew Wilson, Kenji Hara
 

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -4,8 +4,8 @@
  * Convert Win32 error code to string.
  *
  * Copyright: Copyright Digital Mars 2006 - 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Credits:   Based on code written by Regan Heath
  */
 /*          Copyright Digital Mars 2006 - 2013.

--- a/std/xml.d
+++ b/std/xml.d
@@ -113,7 +113,7 @@ void main()
 }
 -------------------------------------------------------------------------------
 Copyright: Copyright Janice Caron 2008 - 2009.
-License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron
 Source:    $(PHOBOSSRC std/_xml.d)
 */

--- a/std/zip.d
+++ b/std/zip.d
@@ -59,8 +59,8 @@ void main()
  * ---
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_zip.d)
  */
 

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
- * Compress/decompress data using the $(WEB www._zlib.net, _zlib library).
+ * Compress/decompress data using the $(HTTP www._zlib.net, _zlib library).
  *
  * Examples:
  *
@@ -41,11 +41,11 @@
  * -------
  *
  * References:
- *  $(WEB en.wikipedia.org/wiki/Zlib, Wikipedia)
+ *  $(HTTP en.wikipedia.org/wiki/Zlib, Wikipedia)
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_zlib.d)
  */
 /*          Copyright Digital Mars 2000 - 2011.

--- a/unittest.d
+++ b/unittest.d
@@ -5,8 +5,8 @@
  * tests on them.  Then, it prints out the arguments passed to main().
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  *
  *          Copyright Digital Mars 2000 - 2009.
  * Distributed under the Boost Software License, Version 1.0.


### PR DESCRIPTION
Small-scale follow-up to #4411 that just deprecates `WEB` in favor of `HTTP`.

```
sed 's/\$(WEB/\$(HTTP/g' -i **/*.d
```

Converting websites that support SSL to SSL will be a separate PR, s.t. DAutoTest can tell us whether there are any differences between the builds. For reasons and argumentation see #4411.