### PR TITLE
Fix for for issue 16182 - std.traits.fullyQualifiedName Bug

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -534,7 +534,7 @@ private template fqnSym(alias T : X!A, alias X, A...)
 private template fqnSym(alias T)
 {
     static if (__traits(compiles, __traits(parent, T)))
-        enum parentPrefix = fqnSym!(__traits(parent, T)) ~ '.';
+        enum parentPrefix = fqnSym!(__traits(parent, T)) ~ ".";
     else
         enum parentPrefix = null;
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=16182

It is beyond my comprension as to why this irrelevant change helps
fixes #16182. I believe there is something amiss becuase expression
fqnSym!(__traits(parent, T)) ~ '.' is returning a char[] while
fqnSym!(__traits(parent, T)) ~ "." returns a string. This while
expression fqnSym!(__traits(parent, T)) returns a string.