### PR TITLE
support startingIndex == r.length for std.range.radial

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1703,6 +1703,9 @@ Iterates a random-access range starting from a given point and
 progressively extending left and right from that point. If no initial
 point is given, iteration starts from the middle of the
 range. Iteration spans the entire range.
+
+When `startingIndex` is 0 the range will be fully iterated in order
+and in reverse order when `r.length` is given.
  */
 auto radial(Range, I)(Range r, I startingIndex)
 if (isRandomAccessRange!(Unqual!Range) && hasLength!(Unqual!Range) && isIntegral!I)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1707,7 +1707,7 @@ range. Iteration spans the entire range.
 auto radial(Range, I)(Range r, I startingIndex)
 if (isRandomAccessRange!(Unqual!Range) && hasLength!(Unqual!Range) && isIntegral!I)
 {
-    if (!r.empty) ++startingIndex;
+    if (startingIndex != r.length) ++startingIndex;
     return roundRobin(retro(r[0 .. startingIndex]), r[startingIndex .. r.length]);
 }
 
@@ -1758,7 +1758,9 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R))
     test([ 1, 2, 3, 4, 5, 6 ], [ 3, 4, 2, 5, 1, 6 ]);
 
     int[] a = [ 1, 2, 3, 4, 5 ];
-    assert(equal(radial(a, 1), [ 2, 3, 1, 4, 5 ][]));
+    assert(equal(radial(a, 1), [ 2, 3, 1, 4, 5 ]));
+    assert(equal(radial(a, 0), [ 1, 2, 3, 4, 5 ])); // only right subrange
+    assert(equal(radial(a, a.length), [ 5, 4, 3, 2, 1 ])); // only left subrange
     static assert(isForwardRange!(typeof(radial(a, 1))));
 
     auto r = radial([1,2,3,4,5]);


### PR DESCRIPTION
- useful for searching around a mid-point in a sorted array,
  e.g. foreach (e; r.radial(r.lowerBound(pivot).length))
- symmetric support of both empty left and right subrange
- still throws when startingIndex is bigger than r.length