### PR TITLE
Allow iota implementation of custom types

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4342,8 +4342,9 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
 
 /// Ditto
 auto iota(E)(E end)
+if (is(typeof(iota(E(0), end))))
 {
-    E begin = 0;
+    E begin = E(0);
     return iota(begin, end);
 }
 


### PR DESCRIPTION
Change the phobos iota implementation so that it does not conflict with
custom types that have a custom implementation of iota.