### PR TITLE
std.conv: need cast(void) to address warning

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -573,7 +573,7 @@ private T toImpl(T, S)(S value)
             T opCast(U)() @safe pure { assert(false); }
         }
     }
-    to!(Test.T)(Test.S());
+    cast(void)to!(Test.T)(Test.S());
 
     // make sure std.conv.to is doing the same thing as initialization
     Test.S s;


### PR DESCRIPTION
This is a blocker for https://github.com/dlang/dmd/pull/5881