### PR TITLE
make @safe to digest strings whose element encoding type is char

### DIFF
--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -542,7 +542,7 @@ unittest
 {
     import std.digest.md;
     auto md5 = makeDigest!MD5();
-    md5.put(0);
+    md5.put(ubyte(0));
     assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
 }
 
@@ -563,7 +563,7 @@ interface Digest
         /**
          * Use this to feed the digest with data.
          * Also implements the $(REF isOutputRange, std,range,primitives)
-         * interface for $(D ubyte) and $(D const(ubyte)[]).
+         * interface for `ubyte` and `const(ubyte)[])`.
          *
          * Example:
          * ----
@@ -577,6 +577,16 @@ interface Digest
          * ----
          */
         @trusted nothrow void put(scope const(ubyte)[] data...);
+
+        /**
+         * This is a conveniance function to digest strings (with `char`
+         * as element encoding type) or `byte[]`.
+         */
+        @trusted final void put(T)(scope const(T)[] data...)
+        if (is(T == char) || is(T == byte))
+        {
+            put(cast(const(ubyte)[]) data);
+        }
 
         /**
          * Resets the internal state of the digest.
@@ -649,7 +659,7 @@ unittest
     assert(crcHexString(crc32) == "414FA339");
 }
 
-unittest
+@safe unittest
 {
     import std.range : isOutputRange;
     assert(!isDigest!(Digest));
@@ -657,7 +667,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     void test(Digest dig)
     {
@@ -697,8 +707,8 @@ enum Order : bool
  * using the GC. The versions returning static arrays use pass-by-value for
  * the return value, effectively avoiding dynamic allocation.
  */
-char[num*2] toHexString(Order order = Order.increasing, size_t num, LetterCase letterCase = LetterCase.upper)
-(in ubyte[num] digest)
+char[num*2] toHexString(Order order = Order.increasing, size_t num,
+    LetterCase letterCase = LetterCase.upper) (in ubyte[num] digest) @safe
 {
     static if (letterCase == LetterCase.upper)
     {
@@ -865,12 +875,14 @@ class WrapperDigest(T) if (isDigest!T) : Digest
         /**
          * Use this to feed the digest with data.
          * Also implements the $(REF isOutputRange, std,range,primitives)
-         * interface for $(D ubyte) and $(D const(ubyte)[]).
+         * interface for `ubyte` and `const(ubyte)[])`.
          */
         @trusted nothrow void put(scope const(ubyte)[] data...)
         {
             _digest.put(data);
         }
+
+        alias put = Digest.put;
 
         /**
          * Resets the internal state of the digest.

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -58,7 +58,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
 module std.digest.sha;
 
 ///
-unittest
+@safe unittest
 {
     //Template API
     import std.digest.sha;
@@ -690,11 +690,12 @@ struct SHA(uint hashBlockSize, uint digestSize)
          * Also implements the $(REF isOutputRange, std,range,primitives)
          * interface for $(D ubyte) and $(D const(ubyte)[]).
          */
-        void put(scope const(ubyte)[] input...) @trusted pure nothrow @nogc
+        void put(T)(scope const(T)[] data...) @trusted @nogc
+        if (is(T == ubyte) || is(T == byte) || is(T == char))
         {
             enum blockSizeInBytes = blockSize/8;
             uint i, index, partLen;
-            auto inputLen = input.length;
+            auto inputLen = data.length;
 
             /* Compute number of bytes mod block size (64 or 128 bytes) */
             index = (cast(uint)count[0] >> 3) & (blockSizeInBytes - 1);
@@ -718,11 +719,11 @@ struct SHA(uint hashBlockSize, uint digestSize)
             /* Transform as many times as possible. */
             if (inputLen >= partLen)
             {
-                (&buffer[index])[0 .. partLen] = input.ptr[0 .. partLen];
+                (&buffer[index])[0 .. partLen] = cast(ubyte[]) data.ptr[0 .. partLen];
                 transform (&state, &buffer);
 
                 for (i = partLen; i + blockSizeInBytes-1 < inputLen; i += blockSizeInBytes)
-                   transform(&state, cast(ubyte[blockSizeInBytes]*)(input.ptr + i));
+                   transform(&state, cast(ubyte[blockSizeInBytes]*)(data.ptr + i));
 
                 index = 0;
             }
@@ -731,18 +732,24 @@ struct SHA(uint hashBlockSize, uint digestSize)
 
             /* Buffer remaining input */
             if (inputLen - i)
-                (&buffer[index])[0 .. inputLen-i] = (&input[i])[0 .. inputLen-i];
+                (&buffer[index])[0 .. inputLen-i] = cast(ubyte[])(&data[i])[0 .. inputLen-i];
         }
         ///
-        unittest
+        @safe pure unittest
         {
             typeof(this) dig;
-            dig.put(cast(ubyte)0); //single ubyte
-            dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+            dig.put(0); //single ubyte
+            dig.put(0, 0); //variadic
             ubyte[10] buf;
             dig.put(buf); //buffer
         }
 
+        // Backward compatibility overload that allows to put int literals.
+        version(D_Ddoc){} else
+        void put(scope const(ubyte)[] data...) @safe @nogc pure nothrow
+        {
+            put!ubyte(data);
+        }
 
         /**
          * Returns the finished SHA hash. This also calls $(LREF start) to
@@ -823,7 +830,7 @@ alias SHA512_224 = SHA!(1024, 224); /// SHA alias for SHA-512/224, hash is ubyte
 alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte[32]
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using sha1Of helper function
     ubyte[20] hash = sha1Of("abc");
@@ -836,7 +843,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Using the basic API
     SHA1 hash;
@@ -848,13 +855,13 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Let's use the template features:
     //Note: When passing a SHA1 to a function, it must be passed by reference!
     void doSomething(T)(ref T hash) if (isDigest!T)
     {
-      hash.put(cast(ubyte)0);
+      hash.put(0);
     }
     SHA1 sha;
     sha.start();
@@ -862,7 +869,7 @@ unittest
     assert(toHexString(sha.finish()) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
 }
 
-unittest
+@safe unittest
 {
     assert(isDigest!SHA1);
     assert(isDigest!SHA224);
@@ -873,7 +880,7 @@ unittest
     assert(isDigest!SHA512_256);
 }
 
-unittest
+@safe unittest
 {
     import std.range;
     import std.conv : hexString;
@@ -887,48 +894,48 @@ unittest
     ubyte[32] digest512_256;
 
     SHA1 sha;
-    sha.put(cast(ubyte[])"abcdef");
+    sha.put("abcdef");
     sha.start();
-    sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    sha.put("");
+    assert(sha.finish() == x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
     SHA224 sha224;
-    sha224.put(cast(ubyte[])"abcdef");
+    sha224.put("abcdef");
     sha224.start();
-    sha224.put(cast(ubyte[])"");
-    assert(sha224.finish() == cast(ubyte[])x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    sha224.put("");
+    assert(sha224.finish() == x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
 
     SHA256 sha256;
-    sha256.put(cast(ubyte[])"abcdef");
+    sha256.put("abcdef");
     sha256.start();
-    sha256.put(cast(ubyte[])"");
-    assert(sha256.finish() == cast(ubyte[])x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    sha256.put("");
+    assert(sha256.finish() == x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     SHA384 sha384;
-    sha384.put(cast(ubyte[])"abcdef");
+    sha384.put("abcdef");
     sha384.start();
-    sha384.put(cast(ubyte[])"");
-    assert(sha384.finish() == cast(ubyte[])hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
+    sha384.put("");
+    assert(sha384.finish() == hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
         ~"0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"));
 
     SHA512 sha512;
-    sha512.put(cast(ubyte[])"abcdef");
+    sha512.put("abcdef");
     sha512.start();
-    sha512.put(cast(ubyte[])"");
-    assert(sha512.finish() == cast(ubyte[])hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
+    sha512.put("");
+    assert(sha512.finish() == hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
         ~"5dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
 
     SHA512_224 sha512_224;
-    sha512_224.put(cast(ubyte[])"abcdef");
+    sha512_224.put("abcdef");
     sha512_224.start();
-    sha512_224.put(cast(ubyte[])"");
-    assert(sha512_224.finish() == cast(ubyte[])x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    sha512_224.put("");
+    assert(sha512_224.finish() == x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
 
     SHA512_256 sha512_256;
-    sha512_256.put(cast(ubyte[])"abcdef");
+    sha512_256.put("abcdef");
     sha512_256.start();
-    sha512_256.put(cast(ubyte[])"");
-    assert(sha512_256.finish() == cast(ubyte[])x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    sha512_256.put("");
+    assert(sha512_256.finish() == x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("");
     digest224     = sha224Of    ("");
@@ -937,15 +944,15 @@ unittest
     digest512     = sha512Of    ("");
     digest512_224 = sha512_224Of("");
     digest512_256 = sha512_256Of("");
-    assert(digest == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    assert(digest224 == cast(ubyte[])x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
-    assert(digest256 == cast(ubyte[])x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    assert(digest384 == cast(ubyte[])hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
+    assert(digest == x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(digest224 == x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    assert(digest256 == x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(digest384 == hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
         ~"0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"));
-    assert(digest512 == cast(ubyte[])hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83"
+    assert(digest512 == hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83"
         ~"f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
-    assert(digest512_224 == cast(ubyte[])x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
-    assert(digest512_256 == cast(ubyte[])x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(digest512_224 == x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    assert(digest512_256 == x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("a");
     digest224     = sha224Of    ("a");
@@ -954,15 +961,15 @@ unittest
     digest512     = sha512Of    ("a");
     digest512_224 = sha512_224Of("a");
     digest512_256 = sha512_256Of("a");
-    assert(digest == cast(ubyte[])x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
-    assert(digest224 == cast(ubyte[])x"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
-    assert(digest256 == cast(ubyte[])x"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
-    assert(digest384 == cast(ubyte[])hexString!("54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9"
+    assert(digest == x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(digest224 == x"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
+    assert(digest256 == x"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
+    assert(digest384 == hexString!("54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9"
         ~"cd697e85175033caa88e6d57bc35efae0b5afd3145f31"));
-    assert(digest512 == cast(ubyte[])hexString!("1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05ab"
+    assert(digest512 == hexString!("1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05ab"
         ~"c54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"));
-    assert(digest512_224 == cast(ubyte[])x"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
-    assert(digest512_256 == cast(ubyte[])x"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
+    assert(digest512_224 == x"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
+    assert(digest512_256 == x"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
 
     digest        = sha1Of      ("abc");
     digest224     = sha224Of    ("abc");
@@ -971,15 +978,15 @@ unittest
     digest512     = sha512Of    ("abc");
     digest512_224 = sha512_224Of("abc");
     digest512_256 = sha512_256Of("abc");
-    assert(digest == cast(ubyte[])x"a9993e364706816aba3e25717850c26c9cd0d89d");
-    assert(digest224 == cast(ubyte[])x"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
-    assert(digest256 == cast(ubyte[])x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-    assert(digest384 == cast(ubyte[])hexString!("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
+    assert(digest == x"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(digest224 == x"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
+    assert(digest256 == x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    assert(digest384 == hexString!("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
         ~"8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"));
-    assert(digest512 == cast(ubyte[])hexString!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9"
+    assert(digest512 == hexString!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9"
         ~"eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"));
-    assert(digest512_224 == cast(ubyte[])x"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
-    assert(digest512_256 == cast(ubyte[])x"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
+    assert(digest512_224 == x"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
+    assert(digest512_256 == x"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
 
     digest        = sha1Of      ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest224     = sha224Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
@@ -988,15 +995,15 @@ unittest
     digest512     = sha512Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_224 = sha512_224Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_256 = sha512_256Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
-    assert(digest224 == cast(ubyte[])x"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
-    assert(digest256 == cast(ubyte[])x"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
-    assert(digest384 == cast(ubyte[])hexString!("3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe"
+    assert(digest == x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+    assert(digest224 == x"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
+    assert(digest256 == x"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+    assert(digest384 == hexString!("3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe"
         ~"8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b"));
-    assert(digest512 == cast(ubyte[])hexString!("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a827"
+    assert(digest512 == hexString!("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a827"
         ~"9be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"));
-    assert(digest512_224 == cast(ubyte[])x"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
-    assert(digest512_256 == cast(ubyte[])x"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
+    assert(digest512_224 == x"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
+    assert(digest512_256 == x"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
 
     digest        = sha1Of      ("message digest");
     digest224     = sha224Of    ("message digest");
@@ -1005,15 +1012,15 @@ unittest
     digest512     = sha512Of    ("message digest");
     digest512_224 = sha512_224Of("message digest");
     digest512_256 = sha512_256Of("message digest");
-    assert(digest == cast(ubyte[])x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
-    assert(digest224 == cast(ubyte[])x"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
-    assert(digest256 == cast(ubyte[])x"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
-    assert(digest384 == cast(ubyte[])hexString!("473ed35167ec1f5d8e550368a3db39be54639f828868e9454c"
+    assert(digest == x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(digest224 == x"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
+    assert(digest256 == x"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
+    assert(digest384 == hexString!("473ed35167ec1f5d8e550368a3db39be54639f828868e9454c"
         ~"239fc8b52e3c61dbd0d8b4de1390c256dcbb5d5fd99cd5"));
-    assert(digest512 == cast(ubyte[])hexString!("107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c134"
+    assert(digest512 == hexString!("107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c134"
         ~"92ea45b0199f3309e16455ab1e96118e8a905d5597b72038ddb372a89826046de66687bb420e7c"));
-    assert(digest512_224 == cast(ubyte[])x"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
-    assert(digest512_256 == cast(ubyte[])x"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
+    assert(digest512_224 == x"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
+    assert(digest512_256 == x"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
 
     digest        = sha1Of      ("abcdefghijklmnopqrstuvwxyz");
     digest224     = sha224Of    ("abcdefghijklmnopqrstuvwxyz");
@@ -1022,15 +1029,15 @@ unittest
     digest512     = sha512Of    ("abcdefghijklmnopqrstuvwxyz");
     digest512_224 = sha512_224Of("abcdefghijklmnopqrstuvwxyz");
     digest512_256 = sha512_256Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
-    assert(digest224 == cast(ubyte[])x"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
-    assert(digest256 == cast(ubyte[])x"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
-    assert(digest384 == cast(ubyte[])hexString!("feb67349df3db6f5924815d6c3dc133f091809213731fe5c7b5"
+    assert(digest == x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(digest224 == x"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
+    assert(digest256 == x"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
+    assert(digest384 == hexString!("feb67349df3db6f5924815d6c3dc133f091809213731fe5c7b5"
         ~"f4999e463479ff2877f5f2936fa63bb43784b12f3ebb4"));
-    assert(digest512 == cast(ubyte[])hexString!("4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034"
+    assert(digest512 == hexString!("4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034"
         ~"898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"));
-    assert(digest512_224 == cast(ubyte[])x"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
-    assert(digest512_256 == cast(ubyte[])x"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
+    assert(digest512_224 == x"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
+    assert(digest512_256 == x"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
 
     digest        = sha1Of      ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest224     = sha224Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
@@ -1039,15 +1046,15 @@ unittest
     digest512     = sha512Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_224 = sha512_224Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_256 = sha512_256Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
-    assert(digest224 == cast(ubyte[])x"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
-    assert(digest256 == cast(ubyte[])x"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
-    assert(digest384 == cast(ubyte[])hexString!("1761336e3f7cbfe51deb137f026f89e01a448e3b1fafa64039"
+    assert(digest == x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+    assert(digest224 == x"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
+    assert(digest256 == x"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
+    assert(digest384 == hexString!("1761336e3f7cbfe51deb137f026f89e01a448e3b1fafa64039"
         ~"c1464ee8732f11a5341a6f41e0c202294736ed64db1a84"));
-    assert(digest512 == cast(ubyte[])hexString!("1e07be23c26a86ea37ea810c8ec7809352515a970e9253c26f"
+    assert(digest512 == hexString!("1e07be23c26a86ea37ea810c8ec7809352515a970e9253c26f"
         ~"536cfc7a9996c45c8370583e0a78fa4a90041d71a4ceab7423f19c71b9d5a3e01249f0bebd5894"));
-    assert(digest512_224 == cast(ubyte[])x"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
-    assert(digest512_256 == cast(ubyte[])x"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
+    assert(digest512_224 == x"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
+    assert(digest512_256 == x"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
 
     digest        = sha1Of      ("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
@@ -1063,15 +1070,15 @@ unittest
                                  "1234567890123456789012345678901234567890");
     digest512_256 = sha512_256Of("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"50abf5706a150990a08b2c5ea40fa0e585554732");
-    assert(digest224 == cast(ubyte[])x"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
-    assert(digest256 == cast(ubyte[])x"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
-    assert(digest384 == cast(ubyte[])hexString!("b12932b0627d1c060942f5447764155655bd4da0c9afa6dd9b"
+    assert(digest == x"50abf5706a150990a08b2c5ea40fa0e585554732");
+    assert(digest224 == x"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
+    assert(digest256 == x"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
+    assert(digest384 == hexString!("b12932b0627d1c060942f5447764155655bd4da0c9afa6dd9b"
         ~"9ef53129af1b8fb0195996d2de9ca0df9d821ffee67026"));
-    assert(digest512 == cast(ubyte[])hexString!("72ec1ef1124a45b047e8b7c75a932195135bb61de24ec0d191"
+    assert(digest512 == hexString!("72ec1ef1124a45b047e8b7c75a932195135bb61de24ec0d191"
         ~"4042246e0aec3a2354e093d76f3048b456764346900cb130d2a4fd5dd16abb5e30bcb850dee843"));
-    assert(digest512_224 == cast(ubyte[])x"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
-    assert(digest512_256 == cast(ubyte[])x"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
+    assert(digest512_224 == x"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
+    assert(digest512_256 == x"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
@@ -1082,15 +1089,29 @@ unittest
     digest512 = sha512Of(onemilliona);
     digest512_224 = sha512_224Of(onemilliona);
     digest512_256 = sha512_256Of(onemilliona);
-    assert(digest == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[])x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[])x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
-    assert(digest384 == cast(ubyte[])hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
+    assert(digest == x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest384 == hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
-    assert(digest512 == cast(ubyte[])hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
+    assert(digest512 == hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[])x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[])x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+}
+
+unittest
+{
+    import std.range;
+    import std.conv : hexString;
+
+    ubyte[20] digest;
+    ubyte[28] digest224;
+    ubyte[32] digest256;
+    ubyte[48] digest384;
+    ubyte[64] digest512;
+    ubyte[28] digest512_224;
+    ubyte[32] digest512_256;
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = sha1Of(oneMillionRange);
@@ -1100,15 +1121,15 @@ unittest
     digest512 = sha512Of(oneMillionRange);
     digest512_224 = sha512_224Of(oneMillionRange);
     digest512_256 = sha512_256Of(oneMillionRange);
-    assert(digest == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[])x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[])x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
-    assert(digest384 == cast(ubyte[])hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
+    assert(digest == x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest384 == hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
-    assert(digest512 == cast(ubyte[])hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
+    assert(digest512 == hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[])x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[])x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
     assert(toHexString(cast(ubyte[20])x"a9993e364706816aba3e25717850c26c9cd0d89d")
         == "A9993E364706816ABA3E25717850C26C9CD0D89D");
@@ -1155,7 +1176,7 @@ auto sha512_256Of(T...)(T data)
 }
 
 ///
-unittest
+@safe unittest
 {
     ubyte[20] hash = sha1Of("abc");
     assert(hash == digest!SHA1("abc"));
@@ -1179,7 +1200,7 @@ unittest
     assert(hash512_256 == digest!SHA512_256("abc"));
 }
 
-unittest
+@safe unittest
 {
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
@@ -1227,7 +1248,7 @@ unittest
     //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte)0);
+      dig.put(0);
     }
     auto sha = new SHA1Digest();
     test(sha);
@@ -1242,43 +1263,43 @@ unittest
 {
     auto sha = new SHA1Digest();
 
-    sha.put(cast(ubyte[])"abcdef");
+    sha.put("abcdef");
     sha.reset();
-    sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    sha.put("");
+    assert(sha.finish() == x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
-    sha.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
+    sha.put("abcdefghijklmnopqrstuvwxyz");
     ubyte[22] result;
     auto result2 = sha.finish(result[]);
-    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(result[0 .. 20] == result2 && result2 == x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     debug
         assertThrown!Error(sha.finish(result[0 .. 15]));
 
     assert(sha.length == 20);
 
-    assert(sha.digest("") == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.digest("") == x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
-    assert(sha.digest("a") == cast(ubyte[])x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(sha.digest("a") == x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
 
-    assert(sha.digest("abc") == cast(ubyte[])x"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(sha.digest("abc") == x"a9993e364706816aba3e25717850c26c9cd0d89d");
 
     assert(sha.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[])x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+           == x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
 
-    assert(sha.digest("message digest") == cast(ubyte[])x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(sha.digest("message digest") == x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
 
     assert(sha.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+           == x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     assert(sha.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[])x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+           == x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
 
     assert(sha.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[])x"50abf5706a150990a08b2c5ea40fa0e585554732");
+           == x"50abf5706a150990a08b2c5ea40fa0e585554732");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
-    assert(sha.digest(onemilliona) == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(sha.digest(onemilliona) == x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
 }


### PR DESCRIPTION
because in this context the code points don't matter, put can take char[] and process it as ubyte[].

Hashing strings is very common. In the current state, so that strings can be hashed, a cast is necessary and this forces the users who want to write safe code to annotate with `@trusted`. This PR simplify this. Strings will be hashable in `@safe` code without extra work for the user.

Another part of the digest API could be safe if the toHexString function is `@safe` but this relies on assumeUnique so this is for a possible other PR.