### PR TITLE
std.format: deprecate doFormat()

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -5176,6 +5176,8 @@ void main()
 }
 ------------------------
  */
+deprecated("It will be removed from Phobos in October 2016. If you still need it, go to https://github.com/DigitalMars/undeaD")
+// @@@DEPRECATED_2016-10@@@
 void doFormat()(scope void delegate(dchar) putc, TypeInfo[] arguments, va_list ap)
 {
     import std.utf : toUCSindex, isValidDchar, UTFException, toUTF8;


### PR DESCRIPTION
This has been "planned for deprecation" pretty much since the beginning of D2. It's only user in Phobos is in std.stream, so I figure it should follow std.stream into undeaD. I've already copied it to undeaD.