### PR TITLE
add @safe to test structs

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2517,6 +2517,7 @@ auto takeNone(R)(R range)
     {
         mixin template genInput()
         {
+        @safe:
             @property bool empty() { return _arr.empty; }
             @property auto front() { return _arr.front; }
             void popFront() { _arr.popFront(); }
@@ -2569,6 +2570,7 @@ auto takeNone(R)(R range)
 
     static class SliceClass
     {
+    @safe:
         this(int[] arr) { _arr = arr; }
         mixin genInput;
         @property auto save() { return new typeof(this)(_arr); }
@@ -2579,6 +2581,7 @@ auto takeNone(R)(R range)
 
     static class TakeNoneClass
     {
+    @safe:
         this(int[] arr) { _arr = arr; }
         mixin genInput;
         auto takeNone() { return new typeof(this)(null); }


### PR DESCRIPTION
Necessary for the better rules on function attribute inference (nested functions should not inherit @safe from enclosing function).