### PR TITLE
std/range - SortedRange: add const to public getters

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7948,7 +7948,7 @@ if (isInputRange!Range)
     }
 
     /// Range primitives.
-    @property bool empty()             //const
+    @property bool empty() const
     {
         return this._input.empty;
     }
@@ -7964,7 +7964,7 @@ if (isInputRange!Range)
     }
 
     /// Ditto
-    @property auto ref front()
+    @property auto ref front() const
     {
         return _input.front;
     }
@@ -7978,7 +7978,7 @@ if (isInputRange!Range)
     /// Ditto
     static if (isBidirectionalRange!Range)
     {
-        @property auto ref back()
+        @property auto ref back() const
         {
             return _input.back;
         }
@@ -8010,7 +8010,7 @@ if (isInputRange!Range)
     /// Ditto
     static if (hasLength!Range)
     {
-        @property size_t length()          //const
+        @property size_t length() const
         {
             return _input.length;
         }


### PR DESCRIPTION
any reason why this was partially disabled?