### PR TITLE
std.traits: prevent inference of attributes of test cases

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1405,10 +1405,10 @@ unittest
     static assert(functionAttributes!(S.pureF) == (FA.pure_ | FA.system));
     static assert(functionAttributes!(typeof(S.pureF)) == (FA.pure_ | FA.system));
 
-    int pure_nothrow() nothrow pure { return 0; }
-    void safe_nothrow() @safe nothrow { }
-    static ref int static_ref_property() @property { return *(new int); }
-    ref int ref_property() @property { return *(new int); }
+    int pure_nothrow() nothrow pure;
+    void safe_nothrow() @safe nothrow;
+    static ref int static_ref_property() @property;
+    ref int ref_property() @property;
 
     static assert(functionAttributes!(pure_nothrow) == (FA.pure_ | FA.nothrow_ | FA.system));
     static assert(functionAttributes!(typeof(pure_nothrow)) == (FA.pure_ | FA.nothrow_ | FA.system));
@@ -1842,9 +1842,9 @@ unittest
 
 unittest
 {
-    int test(int a) { return 0; }
-    int propGet() @property { return 0; }
-    int propSet(int a) @property { return 0; }
+    int test(int a);
+    int propGet() @property;
+    int propSet(int a) @property;
     int function(int) test_fp;
     int delegate(int) test_dg;
     static assert(is( typeof(test) == FunctionTypeOf!(typeof(test)) ));
@@ -6637,7 +6637,7 @@ unittest
     assert(foo_demangled[0 .. 4] == "int " && foo_demangled[$-3 .. $] == "foo",
         foo_demangled);
 
-    void bar(){}
+    void bar();
     auto bar_demangled = demangle(mangledName!bar);
     assert(bar_demangled[0 .. 5] == "void " && bar_demangled[$-5 .. $] == "bar()");
 }


### PR DESCRIPTION
Because the inference rules change, and this makes traits resistant to such changes. Yet another blocker for:

https://github.com/dlang/dmd/pull/5881

so please don't delay reviewing/pulling this.