### PR TITLE
[Issue 14485] .front of empty filtered zip range is accessible

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1115,6 +1115,7 @@ private struct FilterResult(alias pred, Range)
 
     @property auto ref front()
     {
+        assert(!empty);
         return _input.front;
     }
 
@@ -1297,6 +1298,7 @@ private struct FilterBidiResult(alias pred, Range)
 
     @property auto ref front()
     {
+        assert(!empty);
         return _input.front;
     }
 
@@ -1310,6 +1312,7 @@ private struct FilterBidiResult(alias pred, Range)
 
     @property auto ref back()
     {
+        assert(!empty);
         return _input.back;
     }
 


### PR DESCRIPTION
Also fixed `filterBidirectional` while I was at it.