### PR TITLE
Add final to classes in std.encoding

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2633,7 +2633,7 @@ abstract class EncodingScheme
                  "iso-ir-6",
                  "us"
  */
-class EncodingSchemeASCII : EncodingScheme
+final class EncodingSchemeASCII : EncodingScheme
 {
     shared static this()
     {
@@ -2718,7 +2718,7 @@ class EncodingSchemeASCII : EncodingScheme
                  "l1",
                  "latin1"
  */
-class EncodingSchemeLatin1 : EncodingScheme
+final class EncodingSchemeLatin1 : EncodingScheme
 {
     shared static this()
     {
@@ -2797,7 +2797,7 @@ class EncodingSchemeLatin1 : EncodingScheme
                  "ISO_8859-2:1999",
                  "Windows-28592"
  */
-class EncodingSchemeLatin2 : EncodingScheme
+final class EncodingSchemeLatin2 : EncodingScheme
 {
     shared static this()
     {
@@ -2868,7 +2868,7 @@ class EncodingSchemeLatin2 : EncodingScheme
  This scheme recognises the following names:
                  "windows-1250"
  */
-class EncodingSchemeWindows1250 : EncodingScheme
+final class EncodingSchemeWindows1250 : EncodingScheme
 {
     shared static this()
     {
@@ -2935,7 +2935,7 @@ class EncodingSchemeWindows1250 : EncodingScheme
  This scheme recognises the following names:
                  "windows-1252"
  */
-class EncodingSchemeWindows1252 : EncodingScheme
+final class EncodingSchemeWindows1252 : EncodingScheme
 {
     shared static this()
     {
@@ -3002,7 +3002,7 @@ class EncodingSchemeWindows1252 : EncodingScheme
  This scheme recognises the following names:
                  "UTF-8"
  */
-class EncodingSchemeUtf8 : EncodingScheme
+final class EncodingSchemeUtf8 : EncodingScheme
 {
     shared static this()
     {
@@ -3070,7 +3070,7 @@ class EncodingSchemeUtf8 : EncodingScheme
                  "UTF-16LE" (little-endian architecture only)
                  "UTF-16BE" (big-endian architecture only)
  */
-class EncodingSchemeUtf16Native : EncodingScheme
+final class EncodingSchemeUtf16Native : EncodingScheme
 {
     shared static this()
     {
@@ -3165,7 +3165,7 @@ unittest
                  "UTF-32LE" (little-endian architecture only)
                  "UTF-32BE" (big-endian architecture only)
  */
-class EncodingSchemeUtf32Native : EncodingScheme
+final class EncodingSchemeUtf32Native : EncodingScheme
 {
     shared static this()
     {


### PR DESCRIPTION
These are not designed to be inherited from, so speed things up a bit.