### PR TITLE
remove bad @trusted annotations from etc.c.curl

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -1507,10 +1507,10 @@ char * curl_version();
  * %XX versions). This function returns a new allocated string or NULL if an
  * error occurred.
  */
-char * curl_easy_escape(CURL *handle, in char *string, int length) @trusted;
+char * curl_easy_escape(CURL *handle, in char *string, int length);
 
 /** the previous version: */
-char * curl_escape(in char *string, int length) @trusted;
+char * curl_escape(in char *string, int length);
 
 
 /**
@@ -1524,10 +1524,10 @@ char * curl_escape(in char *string, int length) @trusted;
  * Conversion Note: On non-ASCII platforms the ASCII %XX codes are
  * converted into the host encoding.
  */
-char * curl_easy_unescape(CURL *handle, in char *string, int length, int *outlength) @trusted;
+char * curl_easy_unescape(CURL *handle, in char *string, int length, int *outlength);
 
 /** the previous version */
-char * curl_unescape(in char *string, int length) @trusted;
+char * curl_unescape(in char *string, int length);
 
 /**
  * Name: curl_free()


### PR DESCRIPTION
Functions that take pointer and length separately cannot be memory-safe.
The caller can pass a length that's too large, leading to an out-of-bounds
read.

These were added in #3190 by @braddr. Out-of-bounds reads were not addressed in the rationale.