### PR TITLE
Added Iterate

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -699,6 +699,51 @@ unittest
 }
 
 /**
+ * Returns $(D F!(F!(...(F!(X))...))) with `n` iterations of `F`.
+ * If the last application of F returns an AliasSeq with length > 1, the result is an ALias
+ */
+template Iterate(alias F, size_t n, X...)
+{
+    static if (n == 0)
+    {
+        static if (X.length == 1)
+            alias Iterate = Alias!(X[0]);
+        else
+            alias Iterate = X;
+    }
+    else
+        alias Iterate = Iterate!(F, n - 1, F!X);
+}
+
+///
+pure nothrow @nogc @safe unittest
+{
+    alias Array(T) = T[];
+    static assert(is(Iterate!(Array, 0, int) == int));
+    static assert(is(Iterate!(Array, 1, int) == int[]));
+    static assert(is(Iterate!(Array, 3, int) == int[][][]));
+
+    alias Arrays(T...) = staticMap!(Array, T);
+    static assert(is(Iterate!(Arrays, 0, int, uint) == AliasSeq!(int, uint)));
+    static assert(is(Iterate!(Arrays, 1, int, uint) == AliasSeq!(int[], uint[])));
+    static assert(is(Iterate!(Arrays, 3, int, uint) == AliasSeq!(int[][][], uint[][][])));
+}
+
+/** Returns a template that, applied to arguments X, does the same as Iterate.
+  */
+template Pow(alias F, size_t n)
+{
+    alias Pow(X...) = Iterate!(F, n, X);
+}
+
+pure nothrow @nogc @safe unittest
+{
+    alias Ptr(T) = T*;
+    alias TPtr = Pow!(Ptr, 3);
+    static assert(is(TPtr!int == int***));
+}
+
+/**
 Evaluates to $(D AliasSeq!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
  */
 template staticMap(alias F, T...)


### PR DESCRIPTION
For the old discussion see https://github.com/dlang/phobos/pull/4145.

In an informal nutshell:
For `Xs` an alias or `AliasSeq`, `Iterate(F, n, Xs)  ==  F!(F!(...F!(Xs)...))` with `n` iterations of `F`.
Note that `F` can return an `AliasSeq` which makes most of its usefulness.

Example from the unit test:
```d
alias Arrays(T...) = staticMap!(Array, T);
static assert(is(Iterate!(Arrays, 3, int, uint) == AliasSeq!(int[][][], uint[][][])));
```

If someone has ideas to further generalize `Iterate`, please tell me.