### PR TITLE
prepare for fix of druntime issue 16230

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2397,12 +2397,12 @@ version (unittest)
 private @property Mutex initOnceLock()
 {
     __gshared Mutex lock;
-    if (auto mtx = atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock))
+    if (auto mtx = cast() atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock))
         return mtx;
     auto mtx = new Mutex;
     if (cas(cast(shared)&lock, cast(shared) null, cast(shared) mtx))
         return mtx;
-    return atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock);
+    return cast() atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock);
 }
 
 /**

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1665,7 +1665,8 @@ if (sharedLog !is myLogger)
     static auto trustedLoad(ref shared Logger logger) @trusted
     {
         import core.atomic : atomicLoad, MemoryOrder;
-        return atomicLoad!(MemoryOrder.acq)(logger);
+        return cast() atomicLoad!(MemoryOrder.acq)(logger);
+            //FIXME: Casting shared away here. Not good. See issue 16232.
     }
 
     // If we have set up our own logger use that


### PR DESCRIPTION
[Issue 16230](https://issues.dlang.org/show_bug.cgi?id=16230) is being fixed in https://github.com/dlang/druntime/pull/1605. There, `atomicLoad`'s return type is changed to be `shared` for aggregates with indirections. So some casts need to be added where the result of `atomicLoad` used to be wrongly unshared.

**https://github.com/dlang/druntime/pull/1605 should be reviewed and approved before this gets pulled.**

I believe that the cast in std.experimental.logger.core is wrong. See [issue 16232](https://issues.dlang.org/show_bug.cgi?id=16232). But it's pre-existing condition, and I'm not sure how to fix it.
