### PR TITLE
restore mistakenly removed 'scope'

### DIFF
--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -608,7 +608,7 @@ interface Digest
         /**
          * This is a convenience function to calculate the hash of a value using the OOP API.
          */
-        final @trusted nothrow ubyte[] digest(const(void[])[] data...)
+        final @trusted nothrow ubyte[] digest(scope const(void[])[] data...)
         {
             this.reset();
             foreach (datum; data)


### PR DESCRIPTION
This reverts a part of commit 77aa18e3e5e3cfa6682d5f8ee961afe70f948d67 (PR #4549).

As noted in the discussion to #4549, the function does not return its argument. If I'm wrong here, I'd appreciate if someone could spell out how `digest` returns a reference to `data`. I just can't see it.