### PR TITLE
remove incorrect use of 'scope'

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2635,7 +2635,8 @@ public:
             // making a closure.
             static auto scopedAddress(D)(scope D del)
             {
-                return del;
+                auto tmp = del;
+                return tmp;
             }
 
             size_t curPos = 0;


### PR DESCRIPTION
This is a blocker for https://github.com/dlang/dmd/pull/5903