### PR TITLE
fix issue 16238 - std.string.lastIndexOf fails compilation with -de

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -1175,6 +1175,7 @@ ptrdiff_t lastIndexOf(Char1, Char2)(const(Char1)[] s, const(Char2)[] sub,
     import std.algorithm.searching : endsWith;
     import std.conv : to;
     import std.range.primitives : walkLength;
+    static import std.uni;
     import std.utf : strideBack;
     if (sub.empty)
         return -1;


### PR DESCRIPTION
Lesson to learn here: We should be testing with -de.