### PR TITLE
Fix issue 4509 - XML parser in std.xml throws TagException if the attr value is put in apostrophes.

### DIFF
--- a/std/xml.d
+++ b/std/xml.d
@@ -2732,11 +2732,15 @@ EOS";
                         </stream:stream></r>`;
 
     DocumentParser parser = new DocumentParser(test_xml);
+    bool tested = false;
     parser.onStartTag["stream:stream"] = (ElementParser p) {
         assert(p.tag.attr["xmlns"] == "jabber:'client'");
         assert(p.tag.attr["from"] == "jid.pl");
         assert(p.tag.attr["attr"] == "a\"b\"c");
+        tested = true;
     };
+    parser.parse();
+    assert(tested);
 }
 
 @system unittest

--- a/std/xml.d
+++ b/std/xml.d
@@ -1072,9 +1072,10 @@ class Tag
                 munch(s,whitespace);
                 reqc(s,'=');
                 munch(s,whitespace);
-                reqc(s,'"');
-                string val = decode(munch(s,"^\""), DecodeMode.LOOSE);
-                reqc(s,'"');
+                char quote = requireOneOf(s,"'\"");
+                char[2] notQuote = ['^', quote];
+                string val = decode(munch(s,notQuote[]), DecodeMode.LOOSE);
+                reqc(s,quote);
                 munch(s,whitespace);
                 attr[key] = val;
             }
@@ -2724,6 +2725,16 @@ EOS";
 
 @system unittest
 {
+    string test_xml = `<?xml version="1.0" encoding='UTF-8'?><stream:stream
+                        xmlns:stream="http://etherx.'jabber'.org/streams"
+                        xmlns="jabber:'client'" from='jid.pl' id="587a5767"
+                        xml:lang="en" version="1.0"></stream:stream>`;
+
+    DocumentParser parser = new DocumentParser(test_xml);
+}
+
+unittest
+{
     string s = q"EOS
 <?xml version="1.0" encoding="utf-8"?> <Tests>
     <Test thing="What &amp; Up">What &amp; Up Second</Test>
@@ -2868,6 +2879,15 @@ private
         s = s[1..$];
     }
 
+    char requireOneOf(ref string s, string chars)
+    {
+        if (s.length == 0 || indexOf(chars,s[0]) == -1)
+            throw new TagException("");
+        char ch = s[0];
+        s = s[1..$];
+        return ch;
+    }
+
     size_t hash(string s,size_t h=0) @trusted nothrow
     {
         return typeid(s).getHash(&s) + h;
@@ -2980,3 +3000,5 @@ private
         throw new XMLException(s);
     }
 }
+
+

--- a/std/xml.d
+++ b/std/xml.d
@@ -2725,15 +2725,21 @@ EOS";
 
 @system unittest
 {
-    string test_xml = `<?xml version="1.0" encoding='UTF-8'?><stream:stream
+    string test_xml = `<?xml version="1.0" encoding='UTF-8'?><r><stream:stream
                         xmlns:stream="http://etherx.'jabber'.org/streams"
                         xmlns="jabber:'client'" from='jid.pl' id="587a5767"
-                        xml:lang="en" version="1.0"></stream:stream>`;
+                        xml:lang="en" version="1.0" attr='a"b"c'>
+                        </stream:stream></r>`;
 
     DocumentParser parser = new DocumentParser(test_xml);
+    parser.onStartTag["stream:stream"] = (ElementParser p) {
+        assert(p.tag.attr["xmlns"] == "jabber:'client'");
+        assert(p.tag.attr["from"] == "jid.pl");
+        assert(p.tag.attr["attr"] == "a\"b\"c");
+    };
 }
 
-unittest
+@system unittest
 {
     string s = q"EOS
 <?xml version="1.0" encoding="utf-8"?> <Tests>
@@ -2879,7 +2885,7 @@ private
         s = s[1..$];
     }
 
-    char requireOneOf(ref string s, string chars)
+    char requireOneOf(ref string s, string chars) @safe
     {
         if (s.length == 0 || indexOf(chars,s[0]) == -1)
             throw new TagException("");
@@ -3000,5 +3006,3 @@ private
         throw new XMLException(s);
     }
 }
-
-


### PR DESCRIPTION
This is a resubmission of #4064 which @coderabhishek wasn't able to finish. I've added the requested asserts in a separate commit. CC @quickfur.

If this gets merged, #4064 can be closed.