### PR TITLE
Fix loop during unit tests between std.parallelism and std.range

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4561,3 +4561,9 @@ unittest
 
     auto result = taskPool.amap!__genPair_12733(data);
 }
+
+unittest
+{
+    // this test was in std.range, but caused cycles.
+    assert(__traits(compiles, { foreach (i; iota(0, 100UL).parallel) {} }));
+}

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -5354,9 +5354,6 @@ unittest
 
 unittest
 {
-    import std.parallelism : parallel;
-
-    assert(__traits(compiles, { foreach (i; iota(0, 100UL).parallel) {} }));
     assert(iota(1UL, 0UL).length == 0);
     assert(iota(1UL, 0UL, 1).length == 0);
     assert(iota(0, 1, 1).length == 1);


### PR DESCRIPTION
Hopefully this fixes the cycle detected in dlang/druntime#1602