### PR TITLE
Remove Catches of Throwable

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1067,7 +1067,7 @@ private:
         {
             job.job();
         }
-        catch (Throwable e)
+        catch (Exception e)
         {
             job.exception = e;
         }
@@ -2679,7 +2679,7 @@ public:
                 {
                     tasks[0].job();
                 }
-                catch (Throwable e)
+                catch (Exception e)
                 {
                     tasks[0].exception = e;
                 }
@@ -2704,7 +2704,7 @@ public:
                 {
                     task.yieldForce;
                 }
-                catch (Throwable e)
+                catch (Exception e)
                 {
                     addToChain(e, firstException, lastException);
                     continue;
@@ -3414,7 +3414,7 @@ private void submitAndExecute(
         {
             tasks[0].job();
         }
-        catch (Throwable e)
+        catch (Exception e)
         {
             tasks[0].exception = e;
         }
@@ -3435,7 +3435,7 @@ private void submitAndExecute(
         {
             task.yieldForce;
         }
-        catch (Throwable e)
+        catch (Exception e)
         {
             addToChain(e, firstException, lastException);
             continue;

--- a/std/socket.d
+++ b/std/socket.d
@@ -132,7 +132,7 @@ version(unittest)
     {
         try
             test();
-        catch (Throwable e)
+        catch (Exception e)
         {
             writefln(" --- std.socket(%d) test fails depending on environment ---", line);
             writefln(" (%s)", e);
@@ -2839,7 +2839,7 @@ public:
                 newSocket._blocking = _blocking;                 //inherits blocking mode
             newSocket._family = _family;             //same family
         }
-        catch (Throwable o)
+        catch (Exception o)
         {
             _close(newsock);
             throw o;

--- a/std/stream.d
+++ b/std/stream.d
@@ -1487,7 +1487,7 @@ class Stream : InputStream, OutputStream {
         }
         return cast(string) result[0 .. pos];
     }
-    catch (Throwable)
+    catch (Exception)
     {
         return super.toString();
     }
@@ -1524,7 +1524,7 @@ class Stream : InputStream, OutputStream {
         res.crcVal = crc.finish();
         return res.hash;
     }
-    catch (Throwable)
+    catch (Exception)
     {
         return super.toHash();
     }


### PR DESCRIPTION
There is one left in std.net.curl, which cannot be fixed as it's a legitimate bug workaround.

Once either https://github.com/Hackerpilot/Dscanner/issues/362 is fixed or Bugzilla 7018 is fixed, the check in dscanner can be enabled.