### PR TITLE
Fix all windows cycles

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -975,10 +975,15 @@ unittest
     assert(arr == [0, 1, 2, 3, 4]);
 
     // opApply iterators work as well
-    static assert(is(typeof({
-        import std.parallelism;
-        arr.parallel.each!"a++";
-    })));
+    static class S
+    {
+        int x;
+        int opApply(int delegate(ref int _x) dg) { return dg(x); }
+    }
+
+    auto s = new S;
+    s.each!"a++";
+    assert(s.x == 1);
 }
 
 // binary foreach with two ref args

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1670,3 +1670,20 @@ unittest
     assertThrown!ConvException(BigInt("0x1234BARF"));
     assertThrown!ConvException(BigInt("1234PUKE"));
 }
+
+// Issue 6447
+unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range : iota;
+
+    auto s = BigInt(1_000_000_000_000);
+    auto e = BigInt(1_000_000_000_003);
+    auto r = iota(s, e);
+    assert(r.equal([
+        BigInt(1_000_000_000_000),
+        BigInt(1_000_000_000_001),
+        BigInt(1_000_000_000_002)
+    ]));
+}
+

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4567,3 +4567,11 @@ unittest
     // this test was in std.range, but caused cycles.
     assert(__traits(compiles, { foreach (i; iota(0, 100UL).parallel) {} }));
 }
+
+unittest
+{
+    long[] arr;
+    static assert(is(typeof({
+        arr.parallel.each!"a++";
+    })));
+}

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -5576,6 +5576,9 @@ unittest
 
 /* Generic overload that handles arbitrary types that support arithmetic
  * operations.
+ *
+ * User-defined types such as $(REF BigInt, std,bigint) are also supported, as long
+ * as they can be incremented with $(D ++) and compared with $(D <) or $(D ==).
  */
 /// ditto
 auto iota(B, E)(B begin, E end)
@@ -5607,26 +5610,6 @@ auto iota(B, E)(B begin, E end)
         }
     }
     return Result(begin, end);
-}
-
-/**
-User-defined types such as $(REF BigInt, std,bigint) are also supported, as long
-as they can be incremented with $(D ++) and compared with $(D <) or $(D ==).
-*/
-// Issue 6447
-unittest
-{
-    import std.algorithm.comparison : equal;
-    import std.bigint : BigInt;
-
-    auto s = BigInt(1_000_000_000_000);
-    auto e = BigInt(1_000_000_000_003);
-    auto r = iota(s, e);
-    assert(r.equal([
-        BigInt(1_000_000_000_000),
-        BigInt(1_000_000_000_001),
-        BigInt(1_000_000_000_002)
-    ]));
 }
 
 unittest


### PR DESCRIPTION
Finally got a windows box test environment set up. This should fix all remaining cycles in Phobos.

Note that I had to move some documented examples. I tried to keep the spirit of the documentation, and still have the examples moved to different files where they won't cause cycles.