### PR TITLE
[automation] enable travis check for selected imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
  # enforce whitespace between statements
  - grep -nE "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
  # enforce whitespace between colon(:) for import statements (doesn't catch everything)
- - grep -n 'import [^/,=]*:.*;' $(find . -name '*.d') | grep -vE "import ([^ ]+) :\s"; echo $?
+ - grep -n 'import [^/,=]*:.*;' $(find . -name '*.d') | grep -vE "import ([^ ]+) :\s"; test $? -eq 1
  # enforce all-man style
  - grep -nE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$'  $(find . -name '*.d'); test $? -eq 1
  # at the moment libdparse has problems to parse some modules (->excludes)

--- a/std/conv.d
+++ b/std/conv.d
@@ -5847,7 +5847,7 @@ auto toChars(ubyte radix = 10, Char = char, LetterCase letterCase = LetterCase.l
 
 @safe unittest // opSlice (issue 16192)
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
 
     static struct Test { ubyte radix; uint number; }
 

--- a/std/string.d
+++ b/std/string.d
@@ -5809,8 +5809,8 @@ C1[] tr(C1, C2, C3, C4 = immutable char)
 
 @system pure unittest
 {
-    import std.exception: assertThrown;
-    import core.exception: AssertError;
+    import std.exception : assertThrown;
+    import core.exception : AssertError;
     assertThrown!AssertError(tr("abcdef", "cd", "CD", "X"));
 }
 


### PR DESCRIPTION
Seems like this one slipped through during our Travis setup. Hence let's actually enable the automatic check for the whitespace between selective imports ;-)