### PR TITLE
show code coverage with Codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,35 @@ sudo: false
 os: linux
 language: d
 d: dmd-2.071.0
+git:
+  depth: 1
 install:
- - wget "https://raw.githubusercontent.com/dlang/dmd/master/src/checkwhitespace.d" -O ../checkwhitespace.d
+ - mkdir phobos
+ - ls -1 | grep -v ^phobos | xargs -I{} mv {} phobos
+ - git clone --depth=1 https://github.com/dlang/dmd
+ - git clone --depth=1 https://github.com/dlang/druntime
+ # whitespace check
+ - wget "https://raw.githubusercontent.com/dlang/dmd/master/src/checkwhitespace.d" -O checkwhitespace.d
+ # dscanner
  - git clone https://github.com/Hackerpilot/Dscanner
  - (cd Dscanner && git checkout tags/v0.4.0-alpha6)
  - (cd Dscanner && git submodule update --init --recursive)
  # debug build is faster, but disable 'missing import' messages (missing core from druntime)
  - (cd Dscanner && sed 's/dparse_verbose/StdLoggerDisableWarning/' -i makefile && make githash debug)
  # avoid checking it's dscanner's directory
- - mv Dscanner/dsc .
- - rm -rf Dscanner
 script:
- - (cd .. && rdmd ./checkwhitespace.d $(find phobos -name '*.d'))
+ - rdmd ./checkwhitespace.d $(find phobos -name '*.d')
  # enforce whitespace between statements
- - grep -nE "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1
+ - (cd phobos && grep -nE "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find . -name '*.d'); test $? -eq 1)
  # enforce whitespace between colon(:) for import statements (doesn't catch everything)
- - grep -n 'import [^/,=]*:.*;' $(find . -name '*.d') | grep -vE "import ([^ ]+) :\s"; test $? -eq 1
+ - (cd phobos && grep -n 'import [^/,=]*:.*;' $(find . -name '*.d') | grep -vE "import ([^ ]+) :\s"; test $? -eq 1)
  # enforce all-man style
- - grep -nE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$'  $(find . -name '*.d'); test $? -eq 1
+ - (cd phobos && grep -nE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$'  $(find . -name '*.d'); test $? -eq 1)
  # at the moment libdparse has problems to parse some modules (->excludes)
- - ./dsc --config .dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.
+ - (cd phobos && ../Dscanner/dsc --config ../.dscanner.ini --styleCheck $(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.)
+ # test code coverage
+ - (cd dmd && make -f posix.mak)
+ - (cd druntime && make -f posix.mak)
+ - (cd phobos && make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/" | grep -vE '(std.encoding|net.curl)' ))
+after_success:
+ - (cd phobos && bash <(curl -s https://codecov.io/bash))

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
  # test code coverage
  - (cd dmd && make -f posix.mak)
  - (cd druntime && make -f posix.mak)
- - (cd phobos && make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/" | grep -vE '(std.encoding|net.curl)' ))
+ - (cd phobos && make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/" | grep -vE '(std.algorithm.sorting|std.encoding|net.curl)' ))
 after_success:
  - (cd phobos && bash <(curl -s https://codecov.io/bash))

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1923,10 +1923,10 @@ result is greater than or equal to $(D max).
 ElementType!Range entropy(Range)(Range r) if (isInputRange!Range)
 {
     Unqual!(typeof(return)) result = 0.0;
-    foreach (e; r)
+    for (;!r.empty; r.popFront)
     {
-        if (!e) continue;
-        result -= e * log2(e);
+        if (!r.front) continue;
+        result -= r.front * log2(r.front);
     }
     return result;
 }
@@ -1937,10 +1937,10 @@ if (isInputRange!Range &&
     !is(CommonType!(ElementType!Range, F) == void))
 {
     Unqual!(typeof(return)) result = 0.0;
-    foreach (e; r)
+    for (;!r.empty; r.popFront)
     {
-        if (!e) continue;
-        result -= e * log2(e);
+        if (!r.front) continue;
+        result -= r.front * log2(r.front);
         if (result >= max) break;
     }
     return result;


### PR DESCRIPTION
Hi all, the idea for this automation is simple, let's ensure (1) that no PR decreases the code coverage, (2) help reviewers judging code coverage improvements PRS, (3) provide simple tools for contributors to see which parts are uncovered.

You can preview this [here](https://codecov.io/gh/wilzbach/phobos/tree/5fc9eb90076101c0266fb3491ac68527d3520fba/std).

That being said, this won't be perfect in the near future as Travis can only run Linux and Mac OS builds, so special versioned paths will not be treated right. The idea here is to get an easy 90% solution that already helps reviewers in most cases (=a lot better than 0%). In the future we might add Codecov reporting to the AutoTester.

Now to this PR:

1) Thanks to the help from @stevepeak, Codecov.io is able to recognize the code coverage output from our builds
2) I haven't figured out yet how I can get the test runner to report the test coverage, for now I settled with
`make -f posix.mak std.test etc.test`
3) I ran into a couple of issues during my first attempt, so don't merge yet. At the moment I was lazy and just commented them out, but I/we should definitely investigate the root cause of them:
- `entropy` in std.numeric (and thus schwarzSort in std.algorithm.sorting)
- `utf-16le` in std.encoding
-  `iso-8859-1 not recognized` for std.net.curl
4) As the newest `druntime` and `dmd` are needed, we now have to move `phobos` in its own folder and then clone the other repos. It makes the Travis script a bit ugly, better ideas are of course welcome.

(if everything goes well, CodeCov should comment on this PR)