### PR TITLE
Removed auto-decoding from std.conv.parse

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2003,12 +2003,16 @@ Target parse(Target, Source)(ref Source s)
             enum bool sign = 0;
 
         enum char maxLastDigit = Target.min < 0 ? 7 : 5;
-        Unqual!(typeof(s.front)) c;
+        uint c;
 
         if (s.empty)
             goto Lerr;
 
-        c = s.front;
+        static if (isAutodecodableString!Source)
+            c = s[0];
+        else
+            c = s.front;
+
         static if (Target.min < 0)
         {
             switch (c)
@@ -2017,10 +2021,19 @@ Target parse(Target, Source)(ref Source s)
                     sign = true;
                     goto case '+';
                 case '+':
-                    s.popFront();
+                    static if (isAutodecodableString!Source)
+                        s = s[1 .. $];
+                    else
+                        s.popFront();
+
                     if (s.empty)
                         goto Lerr;
-                    c = s.front;
+
+                    static if (isAutodecodableString!Source)
+                        c = s[0];
+                    else
+                        c = s.front;
+
                     break;
 
                 default:
@@ -2031,10 +2044,19 @@ Target parse(Target, Source)(ref Source s)
         if (c <= 9)
         {
             Target v = cast(Target)c;
-            s.popFront();
+
+            static if (isAutodecodableString!Source)
+                s = s[1 .. $];
+            else
+                s.popFront();
+
             while (!s.empty)
             {
-                c = cast(typeof(c)) (s.front - '0');
+                static if (isAutodecodableString!Source)
+                    c = cast(typeof(c)) (s[0] - '0');
+                else
+                    c = cast(typeof(c)) (s.front - '0');
+
                 if (c > 9)
                     break;
 
@@ -2044,7 +2066,11 @@ Target parse(Target, Source)(ref Source s)
                     // Note: `v` can become negative here in case of parsing
                     // the most negative value:
                     v = cast(Target) (v * 10 + c);
-                    s.popFront();
+
+                    static if (isAutodecodableString!Source)
+                        s = s[1 .. $];
+                    else
+                        s.popFront();
                 }
                 else
                     throw new ConvOverflowException("Overflow in integral conversion");


### PR DESCRIPTION
Like the title says, I removed auto-decoding from `parse`, which only checked for things in the ASCII range anyway.

The reason why this is so messy is `parse` takes its range by `ref`, so `byCodeUnit` cannot be used without using `refRange`, which requires using `&r`, which is unsafe. So the only solution left is to do it manually with a bunch of `static if`s.

I tried putting the `refRange.byCodeUnit` in a `@trusted` block, but that resulted in a speed pessimization (I'm guessing due to the inability to inline at that point).

By my measurements, this is anywhere between 2.5-5x as fast as the original implementation.

```
# New
 $ ldc2 -O5 -release test.d && ./test
Total time: 41 ms, 366 μs, and 9 hnsecs

# Old
$ ldc2 -O5 -release test.d && ./test
Total time: 223 ms, 437 μs, and 5 hnsecs
```

Here's the code I used to benchmark

```
import std.stdio;
import std.range;
import std.algorithm;
import std.traits;
import std.container;
import std.meta;
import std.conv;
import std.datetime;

Target parse1(Target, Source)(ref Source s)
    if (isSomeChar!(ElementType!Source) &&
        isIntegral!Target && !is(Target == enum))
{
    static if (Target.sizeof < int.sizeof)
    {
        // smaller types are handled like integers
        auto v = .parse!(Select!(Target.min < 0, int, uint))(s);
        auto result = ()@trusted{ return cast(Target) v; }();
        if (result == v)
            return result;
        throw new ConvOverflowException("Overflow in integral conversion");
    }
    else
    {
        // int or larger types

        static if (Target.min < 0)
            bool sign = 0;
        else
            enum bool sign = 0;

        enum char maxLastDigit = Target.min < 0 ? 7 : 5;
        Unqual!(typeof(s.front)) c;

        if (s.empty)
            goto Lerr;

        static if (isAutodecodableString!Source)
            c = s[0];
        else
            c = s.front;

        static if (Target.min < 0)
        {
            switch (c)
            {
                case '-':
                    sign = true;
                    goto case '+';
                case '+':
                    static if (isAutodecodableString!Source)
                        s = s[1 .. $];
                    else
                        s.popFront();

                    if (s.empty)
                        goto Lerr;

                    static if (isAutodecodableString!Source)
                        c = s[0];
                    else
                        c = s.front;
                    
                    break;

                default:
                    break;
            }
        }
        c -= '0';
        if (c <= 9)
        {
            Target v = cast(Target)c;

            static if (isAutodecodableString!Source)
                s = s[1 .. $];
            else
                s.popFront();
            
            while (!s.empty)
            {
                static if (isAutodecodableString!Source)
                    c = cast(typeof(c)) (s[0] - '0');
                else
                    c = cast(typeof(c)) (s.front - '0');

                if (c > 9)
                    break;

                if (v >= 0 && (v < Target.max/10 ||
                    (v == Target.max/10 && c <= maxLastDigit + sign)))
                {
                    // Note: `v` can become negative here in case of parsing
                    // the most negative value:
                    v = cast(Target) (v * 10 + c);

                    static if (isAutodecodableString!Source)
                        s = s[1 .. $];
                    else
                        s.popFront();
                }
                else
                    throw new ConvOverflowException("Overflow in integral conversion");
            }

            if (sign)
                v = -v;
            return v;
        }
Lerr:
        throw new Exception("a");
    }
}

void main()
{
    enum n = 50_000_000;

    string test = "123456789";
    int result;
    StopWatch sw;
    Duration sum;
    TickDuration last = TickDuration.from!"seconds"(0);

    foreach(i; 0 .. n)
    {
        sw.start();

        result = parse!int(test);
        //result = parse1!int(test);

        sw.stop();

        test = "123456789";
        auto time = sw.peek() - last;
        last = sw.peek();

        sum += time.to!Duration();
    }

    writeln("Total time: ", sum);
}
```