### PR TITLE
Move deprecations along

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -128,43 +128,6 @@ struct JSONValue
           assert(j["language"].type == JSON_TYPE.STRING);
     }
 
-    // Explicitly undocumented. It will be removed in June 2016. @@@DEPRECATED_2016-06@@@
-    deprecated("Please assign the value with the adequate type to JSONValue directly.")
-    @property JSON_TYPE type(JSON_TYPE newType) @safe
-    {
-        if (type_tag != newType
-         && ((type_tag != JSON_TYPE.INTEGER && type_tag != JSON_TYPE.UINTEGER)
-          || (newType  != JSON_TYPE.INTEGER && newType  != JSON_TYPE.UINTEGER)))
-        {
-            final switch (newType)
-            {
-                case JSON_TYPE.STRING:
-                    str = null;
-                    break;
-                case JSON_TYPE.INTEGER:
-                    integer = long.init;
-                    break;
-                case JSON_TYPE.UINTEGER:
-                    uinteger = ulong.init;
-                    break;
-                case JSON_TYPE.FLOAT:
-                    floating = double.init;
-                    break;
-                case JSON_TYPE.OBJECT:
-                    object = null;
-                    break;
-                case JSON_TYPE.ARRAY:
-                    array = null;
-                    break;
-                case JSON_TYPE.TRUE:
-                case JSON_TYPE.FALSE:
-                case JSON_TYPE.NULL:
-                    break;
-            }
-        }
-        return type_tag = newType;
-    }
-
     /// Value getter/setter for $(D JSON_TYPE.STRING).
     /// Throws: $(D JSONException) for read access if $(D type) is not
     /// $(D JSON_TYPE.STRING).
@@ -1591,31 +1554,6 @@ class JSONException : Exception
   const jv = parseJSON(json);
   assert(jv.toString == json);
   assert(jv.toPrettyString == json);
-}
-
-@safe deprecated unittest
-{
-    // Bugzilla 12332
-    import std.exception;
-
-    JSONValue jv;
-    jv.type = JSON_TYPE.INTEGER;
-    jv = 1;
-    assert(jv.type == JSON_TYPE.INTEGER);
-    assert(jv.integer == 1);
-    jv.type = JSON_TYPE.UINTEGER;
-    assert(jv.uinteger == 1);
-
-    jv.type = JSON_TYPE.STRING;
-    assertThrown!JSONException(jv.integer == 1);
-    assert(jv.str is null);
-    jv.str = "123";
-    assert(jv.str == "123");
-    jv.type = JSON_TYPE.STRING;
-    assert(jv.str == "123");
-
-    jv.type = JSON_TYPE.TRUE;
-    assert(jv.type == JSON_TYPE.TRUE);
 }
 
 @system pure unittest

--- a/std/math.d
+++ b/std/math.d
@@ -5014,14 +5014,6 @@ bool isNaN(X)(X x) @nogc @trusted pure nothrow
     assert(!isNaN(cast(real)-53.6));
 }
 
-// Explicitly undocumented. It will be removed in July 2016. @@@DEPRECATED_2016-07@@@
-deprecated("isNaN is not defined for integer types")
-bool isNaN(X)(X x) @nogc @trusted pure nothrow
-    if (isIntegral!(X))
-{
-    return isNaN(cast(float)x);
-}
-
 @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
@@ -5092,14 +5084,6 @@ bool isFinite(X)(X x) @trusted pure nothrow @nogc
     assert(isFinite(real.min_normal));
     assert(!isFinite(real.nan));
     assert(!isFinite(real.infinity));
-}
-
-// Explicitly undocumented. It will be removed in July 2016. @@@DEPRECATED_2016-07@@@
-deprecated("isFinite is not defined for integer types")
-int isFinite(X)(X x) @trusted pure nothrow @nogc
-    if (isIntegral!(X))
-{
-    return isFinite(cast(float)x);
 }
 
 
@@ -5216,14 +5200,6 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
         for (f = 1.0; !isSubnormal(f); f /= 2)
             assert(f != 0);
     }
-}
-
-// Explicitly undocumented. It will be removed in July 2016. @@@DEPRECATED_2016-07@@@
-deprecated("isSubnormal is not defined for integer types")
-int isSubnormal(X)(X x) @trusted pure nothrow @nogc
-    if (isIntegral!X)
-{
-    return isSubnormal(cast(double)x);
 }
 
 /*********************************
@@ -5414,14 +5390,6 @@ int signbit(X)(X x) @nogc @trusted pure nothrow
 }
 
 
-// Explicitly undocumented. It will be removed in July 2016. @@@DEPRECATED_2016-07@@@
-deprecated("signbit is not defined for integer types")
-int signbit(X)(X x) @nogc @trusted pure nothrow
-    if (isIntegral!X)
-{
-    return signbit(cast(float)x);
-}
-
 /*********************************
  * Return a value composed of to with from's sign bit.
  */
@@ -5479,14 +5447,6 @@ R copysign(R, X)(X to, R from) @trusted pure nothrow @nogc
             }
         }();
     }
-}
-
-// Explicitly undocumented. It will be removed in July 2016. @@@DEPRECATED_2016-07@@@
-deprecated("copysign : from can't be of integer type")
-R copysign(R, X)(X to, R from) @trusted pure nothrow @nogc
-    if (isIntegral!R)
-{
-    return copysign(to, cast(float)from);
 }
 
 /*********************************

--- a/std/traits.d
+++ b/std/traits.d
@@ -1637,51 +1637,6 @@ template isUnsafe(alias func)
 }
 
 
-// Explicitly undocumented. It will be removed in June 2016. @@@DEPRECATED_2016-06@@@
-deprecated("Please use allSatisfy(isSafe, ...) instead.")
-template areAllSafe(funcs...)
-    if (funcs.length > 0)
-{
-    static if (funcs.length == 1)
-    {
-        enum areAllSafe = isSafe!(funcs[0]);
-    }
-    else static if (isSafe!(funcs[0]))
-    {
-        enum areAllSafe = areAllSafe!(funcs[1..$]);
-    }
-    else
-    {
-        enum areAllSafe = false;
-    }
-}
-
-// Verify Example
-@safe deprecated unittest
-{
-    @safe    int add(int a, int b) {return a+b;}
-    @trusted int sub(int a, int b) {return a-b;}
-    @system  int mul(int a, int b) {return a*b;}
-
-    static assert( areAllSafe!(add, add));
-    static assert( areAllSafe!(add, sub));
-    static assert(!areAllSafe!(sub, mul));
-}
-
-@safe deprecated unittest
-{
-    interface Set
-    {
-        int systemF() @system;
-        int trustedF() @trusted;
-        int safeF() @safe;
-    }
-    static assert( areAllSafe!((int a){}, Set.safeF));
-    static assert( areAllSafe!((int a){}, Set.safeF, Set.trustedF));
-    static assert(!areAllSafe!(Set.trustedF, Set.systemF));
-}
-
-
 /**
 Returns the calling convention of function as a string.
 */
@@ -5582,18 +5537,6 @@ enum bool isPointer(T) = is(T == U*, U) && !isAggregateType!T;
 Returns the target type of a pointer.
 */
 alias PointerTarget(T : T*) = T;
-
-// Explicitly undocumented. It will be removed in June 2016. @@@DEPRECATED_2016-06@@@
-deprecated("Please use PointerTarget instead.")
-alias pointerTarget = PointerTarget;
-
-@safe unittest
-{
-    static assert( is(PointerTarget!(int*) == int));
-    static assert( is(PointerTarget!(long*) == long));
-
-    static assert(!is(PointerTarget!int));
-}
 
 /**
  * Detect whether type $(D T) is an aggregate type.


### PR DESCRIPTION
This deprecates the time zone name conversion functions and related functionality which was scheduled for deprecation. It also removes a few deprecated items that have reached the point where they're supposed to be permanently removed.