### PR TITLE
Fix typos in std.net.curl.byLineAsync&byChunkAsync

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1575,8 +1575,8 @@ private static struct AsyncLineInputRange(Char)
  * // Get a line in a background thread and wait in
  * // main thread for 2 seconds for it to arrive.
  * auto range3 = byLineAsync("dlang.com");
- * if (range.wait(dur!"seconds"(2)))
- *     writeln(range.front);
+ * if (range3.wait(dur!"seconds"(2)))
+ *     writeln(range3.front);
  * else
  *     writeln("No line received after 2 seconds!");
  * ----
@@ -1726,8 +1726,8 @@ private static struct AsyncChunkInputRange
  * // Get a line in a background thread and wait in
  * // main thread for 2 seconds for it to arrive.
  * auto range3 = byChunkAsync("dlang.com", 10);
- * if (range.wait(dur!"seconds"(2)))
- *     writeln(range.front);
+ * if (range3.wait(dur!"seconds"(2)))
+ *     writeln(range3.front);
  * else
  *     writeln("No chunk received after 2 seconds!");
  * ----


### PR DESCRIPTION
Documentation of async function : byLineAsync & byChunkAsync has a little typos.

There was no such a variable `range` in each of sample code's scope.

```diff
  * auto range3 = byLineAsync("dlang.com");
- * if (range.wait(dur!"seconds"(2)))
- *     writeln(range.front);
+ * if (range3.wait(dur!"seconds"(2)))
+ *     writeln(range3.front);
```

```diff
  * auto range3 = byChunkAsync("dlang.com", 10);
- * if (range.wait(dur!"seconds"(2)))
- *     writeln(range.front);
+ * if (range3.wait(dur!"seconds"(2)))
+ *     writeln(range3.front);
```

It must be `range3`, I fixed.