### PR TITLE
Properly handle the case where an environment variable is an empty string

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -3204,7 +3204,16 @@ private:
 
             // Cache the last call's result.
             static string lastResult;
-            if (v != lastResult) lastResult = v.idup;
+            if (v.empty)
+            {
+                // Return non-null array for blank result to distinguish from
+                // not-present result.
+                lastResult = "";
+            }
+            else if (v != lastResult)
+            {
+                lastResult = v.idup;
+            }
             value = lastResult;
             return true;
         }
@@ -3233,10 +3242,17 @@ private:
     assertThrown(environment["std_process"]);
 
     // get() without default value
-    assert (environment.get("std_process") == null);
+    assert (environment.get("std_process") is null);
 
     // get() with default value
     assert (environment.get("std_process", "baz") == "baz");
+
+    version (Posix)
+    {
+        // get() on an empty (but present) value
+        environment["std_process"] = "";
+        assert(environment.get("std_process") !is null);
+    }
 
     // Convert to associative array
     auto aa = environment.toAA();


### PR DESCRIPTION
v.idup returns null when called on an empty but non-null array.  This is
undesirable because we want to differentiate between not-present and
empty-but-present.

This is a continuation of https://github.com/dlang/phobos/pull/4616 but with master as the base.