### PR TITLE
fix Issue 16308 - [ndslice] should always has save primitive

### DIFF
--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -226,12 +226,4 @@ pure nothrow unittest
     assert(lengthsProduct([3, 4, 5]) == 60);
 }
 
-enum canSave(T) = isPointer!T || isDynamicArray!T ||
-    __traits(compiles,
-    {
-        T r1 = T.init;
-        auto s1 = r1.save;
-        static assert (is(typeof(s1) == T));
-    });
-
 struct _Slice { size_t i, j; }

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -933,10 +933,9 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
             size_t _length;
             size_t[N] _indexes;
 
-            static if (canSave!PureRange)
             auto save() @property
             {
-                return typeof(this)(_slice.save, _length, _indexes);
+                return this;
             }
 
             bool empty() const @property
@@ -1448,10 +1447,9 @@ auto byElementInStandardSimplex(size_t N, Range)(auto ref Slice!(N, Range) slice
             size_t sum;
             size_t[N] _indexes;
 
-            static if (canSave!PureRange)
             auto save() @property
             {
-                return typeof(this)(_slice.save, _length, maxHypercubeLength, sum, _indexes);
+                return this;
             }
 
             bool empty() const @property
@@ -1688,12 +1686,6 @@ template IndexSlice(size_t N)
     {
         private size_t[N-1] _lengths;
 
-        IndexMap save() @property const
-        {
-            pragma(inline, true);
-            return this;
-        }
-
         size_t[N] opIndex(size_t index) const
         {
             pragma(inline, true);
@@ -1785,7 +1777,6 @@ template IotaSlice(size_t N)
 struct IotaMap()
 {
     enum bool empty = false;
-    enum IotaMap save = IotaMap.init;
 
     static size_t opIndex()(size_t index) @safe pure nothrow @nogc @property
     {


### PR DESCRIPTION
The reason is that Slice never calls front/popFront and others
primitives of underlaying range.