### PR TITLE
[trivial] Correct truncation of std/base64.d "References" section

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -45,7 +45,7 @@
  * -----
  *
  * References:
- * $(HTTP tools.ietf.org/html/rfc4648, RFC 4648 - The Base16, Base32, and Base64
+ * $(LINK2 https://tools.ietf.org/html/rfc4648, RFC 4648 - The Base16, Base32, and Base64
  * Data Encodings)
  *
  * Copyright: Masahiro Nakagawa 2010-.


### PR DESCRIPTION
It looks like the commas in the text were causing:
> RFC 4648 - The Base16, Base32, and Base64 Data Encodings

To be truncated to 
> RFC 4648 - The Base16

Changing `$(HTTP)` to `$(LINK2)` appears to fix this.