### PR TITLE
New trait std.traits.isInnerClass

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2020,9 +2020,16 @@ version (unittest)
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 
 /**
-Determines whether $(D T) is a class nested inside another class
-and that $(D T.outer) is the implicit reference to the outer class
-(i.e. $(D outer) has not been used as a field or method name)
+Determines whether `T` is a class nested inside another class
+and that `T.outer` is the implicit reference to the outer class
+(i.e. `outer` has not been used as a field or method name)
+
+Params:
+    T = type to test
+
+Returns:
+`true` if `T` is a class nested inside another, with the conditions described above;
+`false` otherwise
 */
 template isInnerClass(T)
     if (is(T == class))

--- a/std/traits.d
+++ b/std/traits.d
@@ -2027,7 +2027,7 @@ and that $(D T.outer) is the implicit reference to the outer class
 template isInnerClass(T)
     if (is(T == class))
 {
-    import std.meta: staticIndexOf;
+    import std.meta : staticIndexOf;
     
     enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
                      && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);

--- a/std/traits.d
+++ b/std/traits.d
@@ -2028,7 +2028,7 @@ template isInnerClass(T)
     if (is(T == class))
 {
     import std.meta : staticIndexOf;
-    
+
     enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
                      && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);
 }
@@ -2041,7 +2041,7 @@ template isInnerClass(T)
         int outer;
     }
     static assert(!isInnerClass!C);
-    
+
     class Outer1
     {
         class Inner
@@ -2049,7 +2049,7 @@ template isInnerClass(T)
         }
     }
     static assert(isInnerClass!(Outer1.Inner));
-    
+
     class Outer2
     {
         class Inner

--- a/std/traits.d
+++ b/std/traits.d
@@ -2020,6 +2020,47 @@ version (unittest)
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 
 /**
+Determines whether $(D T) is a class nested inside another class
+and that $(D T.outer) is the implicit reference to the outer class
+(i.e. $(D outer) has not been used as a field or method name)
+*/
+template isInnerClass(T)
+    if (is(T == class))
+{
+    import std.meta: staticIndexOf;
+    
+    enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
+                     && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);
+}
+
+///
+@safe unittest
+{
+    class C
+    {
+        int outer;
+    }
+    static assert(!isInnerClass!C);
+    
+    class Outer1
+    {
+        class Inner
+        {
+        }
+    }
+    static assert(isInnerClass!(Outer1.Inner));
+    
+    class Outer2
+    {
+        class Inner
+        {
+            int outer;
+        }
+    }
+    static assert(!isInnerClass!(Outer2.Inner));
+}
+
+/**
 Determines whether $(D T) has its own context pointer.
 $(D T) must be either $(D class), $(D struct), or $(D union).
 */


### PR DESCRIPTION
This new trait allows to check whether a class is nested inside another and `this.outer` can be used to access the enclosing class.

This is needed to implement a solution for issue 16319.