### PR TITLE
ndslice.algorithm

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -184,7 +184,7 @@ PACKAGE_std_experimental_allocator_building_blocks = \
   fallback_allocator free_list free_tree bitmapped_block \
   kernighan_ritchie null_allocator package quantizer \
   region scoped_allocator segregator stats_collector
-PACKAGE_std_experimental_ndslice = package iteration selection slice
+PACKAGE_std_experimental_ndslice = package algorithm iteration selection slice
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -451,6 +451,8 @@ Returns:
     fun, the element type will be $(D Tuple) containing one element for each fun.
 
 See_Also:
+    $(REF_ALTTEXT Multidimensional map, ndMap, std,experimental,ndslice,computation)
+
     $(HTTP en.wikipedia.org/wiki/Map_(higher-order_function), Map (higher-order function))
 */
 template map(fun...) if (fun.length >= 1)
@@ -852,6 +854,7 @@ Params:
 
 See_Also: $(REF tee, std,range)
 
+    $(REF_ALTTEXT Multidimensional each, ndEach, std,experimental,ndslice,computation)
  */
 template each(alias pred = "a")
 {
@@ -2601,6 +2604,8 @@ See_Also:
 
     $(LREF sum) is similar to $(D reduce!((a, b) => a + b)) that offers
     pairwise summing of floating point numbers.
+
+    $(REF_ALTTEXT Multidimensional reduce, ndReduce, std,experimental,ndslice,computation)
 +/
 template reduce(fun...) if (fun.length >= 1)
 {
@@ -3053,6 +3058,8 @@ See_Also:
 
     This is functionally equivalent to $(LREF reduce) with the argument order reversed,
     and without the need to use $(LREF tuple) for multiple seeds.
+
+    $(REF_ALTTEXT Multidimensional fold, ndFold, std,experimental,ndslice,computation)
 +/
 template fold(fun...) if (fun.length >= 1)
 {

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -651,6 +651,7 @@ unittest
 /// Multiple tensors, dot product
 unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -673,6 +674,7 @@ unittest
 /// Zipped tensors, dot product
 pure unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.range : iota;
     import std.numeric : dotProduct;
@@ -699,6 +701,7 @@ pure unittest
 /// Tensor mutation on-the-fly
 unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.experimental.ndslice.slice : slice;
     import std.experimental.ndslice.selection : iotaSlice;
@@ -731,6 +734,7 @@ unittest
     // std.math prevents vectorization for now
     else
         import std.math : fmax, fmin;
+    import std.typecons : Yes;
     import std.conv : to;
     import std.experimental.ndslice.slice : slice;
     import std.experimental.ndslice.iteration : transposed;
@@ -843,6 +847,7 @@ template ndEach(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath
 /// Single tensor, multiply-add
 unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -860,6 +865,7 @@ unittest
 /// Swap two tensors
 unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.algorithm.mutation : swap;
     import std.experimental.ndslice.selection : iotaSlice;
@@ -880,6 +886,7 @@ unittest
 /// Swap two zipped tensors
 unittest
 {
+    import std.typecons : Yes;
     import std.conv : to;
     import std.algorithm.mutation : swap;
     import std.experimental.ndslice.slice : assumeSameStructure;

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -977,7 +977,7 @@ Constraints:
 See_also:
     $(LREF ndAny)
 
-    $(REF Slice.backward, std.experimenta,ndslice,slice)
+    $(REF Slice.backward, std,experimental,ndslice,slice)
 +/
 template ndFind(alias pred)
 {

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -66,7 +66,7 @@ private template TensorFronts(size_t length)
     static if (length)
     {
         enum i = length - 1;
-        enum TensorFronts = TensorFronts!(length - 1) ~ "tensors[" ~ i.stringof ~ "]._ptr[0], ";
+        enum TensorFronts = TensorFronts!(length - 1) ~ "tensors[" ~ i.stringof ~ "].front, ";
     }
     else
     {
@@ -686,9 +686,9 @@ pure unittest
     import std.experimental.ndslice.selection : iotaSlice;
     import std.experimental.ndslice.internal : fastmath;
 
-    static @fastmath T fmuladd(T)(const T a, const T b, const T c)
+    static @fastmath T fmuladd(T, Z)(const T a, Z z)
     {
-        return a + b * c;
+        return a + z.a * z.b;
     }
 
     // 0 1 2

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -1,0 +1,1465 @@
+/**
+$(SCRIPT inhibitQuickIndex = 1;)
+
+This is a submodule of $(MREF std, experimental, ndslice).
+It contains basic multidimensional iteration algorithms.
+
+$(BOOKTABLE Iteration operators,
+$(TR $(TH Operator Name) $(TH Type) $(TH Functions / Seeds #) $(TH Tensors #) $(TH Returns) $(TH First Argument))
+$(T6 ndMap, Lazy, `>=1`, `1`, Tensor, Tensor)
+$(T6 ndFold, Eagerly, `>=1`, `1`, Scalar, Tensor)
+$(T6 ndReduce, Eagerly, `1`, `>=1`, Scalar, Seed)
+$(T6 ndEach, Eagerly, `0`, `>=1`, `void`, Tensor)
+)
+
+$(BOOKTABLE Eagerly iteration operators with stop condition,
+$(TR $(TH Operator Name) $(TH Has Needle) $(TH Finds Index) $(TH Tensors #) $(TH Returns) $(TH Requires Equal Shapes))
+$(T6 ndFind, No, Yes, `>=1`, `void`, Yes)
+$(T6 ndAny, No, No, `>=1`, `bool`, Yes)
+$(T6 ndAll, No, No, `>=1`, `bool`, Yes)
+$(T6 ndEqual, No, No, `>=2`, `bool`, No)
+$(T6 ndCmp, No, No, `2`, `int`, No)
+)
+
+All operators are suitable to change tensors using `ref` argument qualification in a function declaration.
+
+$(H3 Lockstep Iteration)
+
+$(REF_ALTTEXT assumeSameStructure, assumeSameStructure, std,experimental,ndslice,slice)
+can be used as multidimensional `zip` analog if tensors have the same structure (shape and strides).
+`assumeSameStructure` allows to mutate elements of zipped tensors, which is not possible with common
+$(REF zip, std,range).
+
+Also tensors zipped with `assumeSameStructure` uses single set of lengths and strides.
+Thus, `assumeSameStructure` may significantly optimize iteration.
+
+If tensors have different strides, then most of existing operators in this module still
+can be used as they accept a set of tensors instead of single one.
+
+Note:
+    $(SUBREF iteration, transposed) and
+    $(SUBREF selection, pack) can be used to specify dimensions.
+
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors:   Ilya Yaroshenko
+
+Source:    $(PHOBOSSRC std/_experimental/_ndslice/_algorithm.d)
+
+Macros:
+SUBREF = $(REF_ALTTEXT $(TT $2), $2, std,experimental, ndslice, $1)$(NBSP)
+T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
+T6=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4) $(TD $5) $(TD $6))
+*/
+module std.experimental.ndslice.algorithm;
+
+import std.traits;
+import std.meta;
+import std.typecons : Flag, Yes, No;
+
+import std.experimental.ndslice.internal;
+import std.experimental.ndslice.slice;
+
+private template TensorFronts(size_t length)
+{
+    static if (length)
+    {
+        enum i = length - 1;
+        enum TensorFronts = TensorFronts!(length - 1) ~ "tensors[" ~ i.stringof ~ "].front, ";
+    }
+    else
+    {
+        enum TensorFronts = "";
+    }
+}
+
+private void checkShapesMatch(bool seed, Args...)(auto ref Args tensors)
+{
+    enum msg = seed ?
+        "all arguments except the first (seed) must be tensors" :
+        "all arguments must be tensors"
+        ~ tailErrorMessage!();
+    enum msgShape = "all tensors must have the same shape"  ~ tailErrorMessage!();
+    foreach (i, Arg; Args)
+    {
+        static assert (is(Arg == Slice!(N, Range), size_t N, Range), msg);
+        static if (i)
+        {
+            static assert (tensors[i].N == tensors[0].N, msgShape);
+            assert(tensors[i].shape == tensors[0].shape, msgShape);
+        }
+    }
+}
+
+private template naryFun(bool hasSeed, size_t argCount, alias fun)
+{
+    static if (argCount + hasSeed == 1)
+    {
+        import std.functional : unaryFun;
+        alias naryFun = unaryFun!fun;
+    }
+    else
+    static if (argCount + hasSeed == 2)
+    {
+        import std.functional : binaryFun;
+        alias naryFun = binaryFun!fun;
+    }
+    else
+    {
+        alias naryFun = fun;
+    }
+}
+
+/++
+Implements the homonym function (also known as `transform`) present
+in many languages of functional flavor. The call `ndMap!(fun)(tensor)`
+returns a tensor of which elements are obtained by applying `fun`
+for all elements in `tensor`. The original tensors are
+not changed. Evaluation is done lazily.
+
+Note:
+    $(SUBREF iteration, transposed) and
+    $(SUBREF selection, pack) can be used to specify dimensions.
+Params:
+    fun = One or more functions.
+    tensor = An input tensor.
+Returns:
+    a tensor with each fun applied to all the elements. If there is more than one
+    fun, the element type will be `Tuple` containing one element for each fun.
+See_Also:
+    $(REF map, std,algorithm,iteration)
+    $(HTTP en.wikipedia.org/wiki/Map_(higher-order_function), Map (higher-order function))
++/
+template ndMap(fun...)
+    if (fun.length)
+{
+    ///
+    auto ndMap(size_t N, Range)
+        (auto ref Slice!(N, Range) tensor)
+    {
+        // this static if-else block
+        // may be unified with std.algorithms.iteration.map
+        // after ndslice be removed from the Mir library.
+        static if (fun.length > 1)
+        {
+            import std.functional : adjoin, unaryFun;
+
+            alias _funs = staticMap!(unaryFun, fun);
+            alias _fun = adjoin!_funs;
+
+            // Once DMD issue #5710 is fixed, this validation loop can be moved into a template.
+            foreach (f; _funs)
+            {
+                static assert(!is(typeof(f(RE.init)) == void),
+                    "Mapping function(s) must not return void: " ~ _funs.stringof);
+            }
+        }
+        else
+        {
+            import std.functional : unaryFun;
+
+            alias _fun = unaryFun!fun;
+            alias _funs = AliasSeq!(_fun);
+
+            // Do the validation separately for single parameters due to DMD issue #15777.
+            static assert(!is(typeof(_fun(RE.init)) == void),
+                "Mapping function(s) must not return void: " ~ _funs.stringof);
+        }
+
+        // Specialization for packed tensors (tensors composed of tensors).
+        static if (is(Range : Slice!(NI, RangeI), size_t NI, RangeI))
+        {
+            alias Ptr = Pack!(NI - 1, RangeI);
+            alias M = Map!(Ptr, _fun);
+            alias R = Slice!(N, M);
+            return R(tensor._lengths[0 .. N], tensor._strides[0 .. N],
+                M(Ptr(tensor._lengths[N .. $], tensor._strides[N .. $], tensor._ptr)));
+        }
+        else
+        {
+            alias M = Map!(SlicePtr!Range, _fun);
+            alias R = Slice!(N, M);
+            with(tensor) return R(_lengths, _strides, M(_ptr));
+        }
+    }
+}
+
+///
+pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    auto s = iotaSlice(2, 3).ndMap!(a => a * 3);
+    assert(s == [[ 0,  3,  6],
+                 [ 9, 12, 15]]);
+}
+
+pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    assert(iotaSlice(2, 3).slice.ndMap!"a * 2" == [[0, 2, 4], [6, 8, 10]]);
+}
+
+/// Packed tensors.
+pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice, windows;
+
+    //  iotaSlice        windows     ndMap  sums ( ndFold!"a + b" )
+    //                --------------
+    //  -------      |  ---    ---  |      ------
+    // | 0 1 2 |  => || 0 1 || 1 2 ||  => | 8 12 |
+    // | 3 4 5 |     || 3 4 || 4 5 ||      ------
+    //  -------      |  ---    ---  |
+    //                --------------
+    auto s = iotaSlice(2, 3)
+        .windows(2, 2)
+        .ndMap!(a => a.ndFold!"a + b"(size_t(0)));
+
+    assert(s == [[8, 12]]);
+}
+
+pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice, windows;
+
+    auto s = iotaSlice(2, 3)
+        .slice
+        .windows(2, 2)
+        .ndMap!(a => a.ndFold!"a + b"(size_t(0)));
+
+    assert(s == [[8, 12]]);
+}
+
+/// Zipped tensors
+pure nothrow unittest
+{
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl1 = iotaSlice(2, 3);
+    // 1 2 3
+    // 4 5 6
+    auto sl2 = iotaSlice([2, 3], 1);
+
+    // tensors must have the same strides
+    assert(sl1.structure == sl2.structure);
+
+    auto zip = assumeSameStructure!("a", "b")(sl1, sl2);
+
+    auto lazySum = zip.ndMap!(z => z.a + z.b);
+
+    assert(lazySum == [[ 1,  3,  5],
+                       [ 7,  9, 11]]);
+}
+
+/++
+Multiple functions can be passed to `ndMap`.
+In that case, the element type of `ndMap` is a tuple containing
+one element for each function.
++/
+pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    auto s = iotaSlice(2, 3).ndMap!("a + a", "a * a");
+
+    auto sums     = [[0, 2, 4], [6,  8, 10]];
+    auto products = [[0, 1, 4], [9, 16, 25]];
+
+    foreach (i; 0..s.length!0)
+    foreach (j; 0..s.length!1)
+    {
+        auto values = s[i, j];
+        assert(values[0] == sums[i][j]);
+        assert(values[1] == products[i][j]);
+    }
+}
+
+/++
+You may alias `ndMap` with some function(s) to a symbol and use it separately:
++/
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    alias stringize = ndMap!(to!string);
+    assert(stringize(iotaSlice(2, 3)) == [["0", "1", "2"], ["3", "4", "5"]]);
+}
+
+private @LikePtr struct Pack(size_t N, Range)
+{
+    alias Elem = Slice!(N, Range);
+    alias PureN = Elem.PureN;
+    alias PureRange = Elem.PureRange;
+
+    size_t[PureN] _lengths;
+    sizediff_t[PureN] _strides;
+
+    SlicePtr!PureRange _ptr;
+    mixin PropagatePtr;
+
+    Elem opIndex(size_t index)
+    {
+        return Elem(_lengths, _strides, _ptr + index);
+    }
+}
+
+package @LikePtr struct Map(Range, alias fun)
+{
+    Range _ptr;
+    mixin PropagatePtr;
+
+    auto ref opIndex(size_t index)
+    {
+        return fun(_ptr[index]);
+    }
+}
+
+private mixin template PropagatePtr()
+{
+    void opOpAssign(string op)(sizediff_t shift)
+        if (op == `+` || op == `-`)
+    {
+        pragma(inline, true);
+        mixin (`_ptr ` ~ op ~ `= shift;`);
+    }
+
+    auto opBinary(string op)(sizediff_t shift)
+        if (op == `+` || op == `-`)
+    {
+        auto ret = this;
+        ret.opOpAssign!op(shift);
+        return ret;
+    }
+
+    auto opUnary(string op)()
+        if (op == `++` || op == `--`)
+    {
+        mixin(op ~ `_ptr;`);
+        return this;
+    }
+}
+
+/++
+Implements the homonym function (also known as `accumulate`,
+`compress`, `inject`, or `foldl`) present in various programming
+languages of functional flavor. The call `fold!(fun)(tensor, seed)`
+first assigns `seed` to an internal variable `result`,
+also called the accumulator. Then, for each element `x` in
+`tensor`, `result = fun(result, x)` gets evaluated. Finally,
+`result` is returned.
+
+$(LREF ndFold) allows to compute values for multiple functions.
+
+Note:
+    $(SUBREF iteration, transposed) and
+    $(SUBREF selection, pack) can be used to specify dimensions.
+Params:
+    fun = One or more functions.
+    tensor = An input tensor.
+    seed = One or more initial accumulation values (seeds count equals to `fun` count).
+Returns:
+    the accumulated `result`
+See_Also:
+    This is functionally similar to $(LREF ndReduce) with the argument order reversed.
+    $(LREF ndReduce) allows to iterate multiple tensors in the lockstep.
+
+    $(REF fold, std,algorithm,iteration)
+
+    $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
++/
+template ndFold(fun...)
+    if (fun.length)
+{
+    import std.functional : binaryFun;
+    private alias binfuns = staticMap!(binaryFun, fun);
+    static if (fun.length > 1)
+        import std.typecons : Tuple;
+
+    ///
+    auto ndFold(size_t N, Range, S...)(auto ref Slice!(N, Range) tensor, S seed)
+        if (S.length == fun.length)
+    {
+        alias US = staticMap!(Unqual, S);
+        if (tensor.anyEmpty)
+        {
+            static if (S.length == 1)
+                return cast(US[0]) seed[0];
+            else
+                return Tuple!US(seed);
+        }
+        return ndFoldImpl!(N, Range, staticMap!(Unqual, S))(tensor, seed);
+    }
+
+    private auto ndFoldImpl(size_t N, Range, S...)(Slice!(N, Range) tensor, S seed)
+    {
+        do
+        {
+            static if (N == 1)
+                static if (S.length == 1 || __traits(compiles, &(tensor.front)))
+                    foreach (i, f; binfuns)
+                        seed[i] = f(seed[i], tensor.front);
+                else
+                {
+                    auto elem = tensor.front;
+                    foreach (i, f; binfuns)
+                        seed[i] = f(seed[i], elem);
+                }
+            else
+            static if (S.length == 1)
+                seed[0] = ndFoldImpl!(N - 1, Range, S)(tensor.front, seed);
+            else
+                seed = ndFoldImpl!(N - 1, Range, S)(tensor.front, seed).expand;
+            tensor.popFront;
+        }
+        while (tensor.length);
+
+        static if (S.length == 1)
+            return seed[0];
+        else
+            return Tuple!S(seed);
+    }
+}
+
+/// Single seed
+unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 | => 3  |
+    //| 3 4 5 | => 12 | => 15
+    auto sl = iotaSlice(2, 3);
+
+    // sum of all element in the tensor
+    auto res = sl.ndFold!"a + b"(size_t(0));
+
+    assert(res == 15);
+}
+
+/// Multiple seeds
+unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 1 2 3 |
+    //| 4 5 6 |
+    auto sl = iotaSlice([2, 3], 1);
+
+    alias sumAndProduct = ndFold!("a + b", "a * b");
+    auto res = sumAndProduct(sl, size_t(0), size_t(1));
+
+    assert(res[0] == 21);
+    assert(res[1] == 720); // 6!
+}
+
+/// Zipped tensors, dot product
+pure unittest
+{
+    import std.conv : to;
+    import std.range : iota;
+    import std.numeric : dotProduct;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl1 = iotaSlice(2, 3).ndMap!(to!double).slice;
+    // 1 2 3
+    // 4 5 6
+    auto sl2 = iotaSlice([2, 3], 1).ndMap!(to!double).slice;
+
+    // tensors must have the same strides
+    assert(sl1.structure == sl2.structure);
+
+    auto zip = assumeSameStructure!("a", "b")(sl1, sl2);
+
+    auto dot = zip.ndFold!((seed, z) => seed + z.a * z.b)(0.0);
+
+    assert(dot == dotProduct(iota(0, 6), iota(1, 7)));
+}
+
+/// Tensor mutation on-the-fly
+unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    alias fun = (seed, ref elem) => seed + elem++;
+
+    auto res = sl.ndFold!fun(0.0);
+
+    assert(res == 15);
+
+    //| 1 2 3 |
+    //| 4 5 6 |
+    assert(sl == iotaSlice([2, 3], 1));
+}
+
+/++
+Packed tensors.
+
+Computes minimum value for maximum values for each row.
++/
+unittest
+{
+    import std.algorithm.comparison : min, max;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
+
+    alias maxVal = (a) => a.ndFold!max(size_t.min);
+    alias minVal = (a) => a.ndFold!min(size_t.max);
+    alias minimaxVal = (a) => minVal(a.pack!1.ndMap!maxVal);
+
+    auto sl = iotaSlice(2, 3);
+
+    //| 0 1 2 | => | 2 |
+    //| 3 4 5 | => | 5 | => 2
+    auto res = minimaxVal(sl);
+    assert(res == 2);
+
+    //| 0 1 2 |    | 0 3 | => | 3 |
+    //| 3 4 5 | => | 1 4 | => | 4 |
+    //             | 2 5 | => | 5 | => 3
+    auto resT = minimaxVal(sl.transposed);
+    assert(resT == 3);
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+    auto a = iotaSlice(1, 1).dropOne!0.ndFold!"a + b"(size_t(7));
+    auto b = iotaSlice(1, 1).dropOne!1.ndFold!("a + b", "a * b")(size_t(7), size_t(8));
+    assert(a == 7);
+    assert(b[0] == 7);
+    assert(b[1] == 8);
+}
+
+
+/++
+Implements the homonym function (also known as `accumulate`,
+`compress`, `inject`, or `foldl`) present in various programming
+languages of functional flavor. The call `fold!(fun)(seed, tensors1, ..., tesnsorN)`
+first assigns `seed` to an internal variable `result`,
+also called the accumulator. Then, for each set of element `x1, ..., xN` in
+`tensors1, ..., tensorN`, `result = fun(result, x1, ..., xN)` gets evaluated. Finally,
+`result` is returned.
+
+`ndReduce` allows to iterate multiple tensors in the lockstep.
+
+Note:
+    $(SUBREF iteration, transposed) and
+    $(SUBREF selection, pack) can be used to specify dimensions.
+Params:
+    fun = A function.
+    vec = Use vectorization friendly iteration without manual unrolling
+        in case of all tensors has the last (row) stride equal to 1.
+    fm = Allow a compiler to use unsafe floating-point mathematic transformations,
+        such as commutative transformation. `fm` is enabled by default if `vec` is enabled.
+    seed = An initial accumulation value.
+    tensors = One or more tensors.
+Returns:
+    the accumulated `result`
+See_Also:
+    $(HTTP llvm.org/docs/LangRef.html#fast-math-flags, LLVM IR: Fast Math Flags)
+
+    This is functionally similar to $(LREF ndReduce) with the argument order reversed.
+    $(LREF ndFold) allows to compute values for multiple functions.
+
+    $(REF reduce, std,algorithm,iteration)
+
+    $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
++/
+template ndReduce(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
+{
+    ///
+    auto ndReduce(S, Args...)(S seed, auto ref Args tensors)
+        if (Args.length)
+    {
+        tensors.checkShapesMatch!true;
+        if (tensors[0].anyEmpty)
+            return cast(Unqual!S) seed;
+        static if (vec && allSatisfy!(isMemory, staticMap!(RangeOf, Args)))
+        {
+            foreach (ref tensor; tensors)
+                if (tensor._strides[$-1] != 1)
+                    goto CommonL;
+            return ndReduceImpl!(true, Args[0].N, true, staticMap!(Unqual, S))(seed, tensors);
+            CommonL:
+        }
+        return ndReduceImpl!(false, Args[0].N, false, staticMap!(Unqual, S))(seed, tensors);
+    }
+
+    static if(fm)
+        alias attr = fastmath;
+    else
+        alias attr = fastmathDummy;
+
+    private @attr auto ndReduceImpl(bool dense, size_t N, bool first = false, S, Args...)(S seed, Args tensors)
+    {
+        static if (dense && first)
+            pragma(inline, false);
+        do
+        {
+            static if (N == 1)
+                enum _fun = `naryFun!(true, Args.length, fun)`;
+            else
+                enum _fun = `ndReduceImpl!(dense, N - 1)`;
+            seed = mixin(_fun ~  `(seed, ` ~ TensorFronts!(Args.length) ~ `)`);
+            static if (N == 1 && dense)
+            {
+                foreach_reverse (ref tensor; tensors)
+                    ++tensor._ptr;
+                --tensors[0]._lengths[0];
+            }
+            else
+            {
+                foreach_reverse (ref tensor; tensors)
+                    tensor.popFront;
+            }
+        }
+        while (tensors[0].length);
+        return seed;
+    }
+}
+
+/// Single tensor
+unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 | => 3  |
+    //| 3 4 5 | => 12 | => 15
+    auto sl = iotaSlice(2, 3);
+
+    // sum of all element in the tensor
+    auto res = size_t(0).ndReduce!"a + b"(sl);
+
+    assert(res == 15);
+}
+
+/// Multiple tensors, dot product
+unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto a = iotaSlice([2, 3], 0).ndMap!(to!double).slice;
+    //| 1 2 3 |
+    //| 4 5 6 |
+    auto b = iotaSlice([2, 3], 1).ndMap!(to!double).slice;
+
+    alias dot = ndReduce!((seed, a, b) => seed + a * b, Yes.vectorized);
+    auto res = dot(0.0, a, b);
+
+    // check the result:
+    import std.experimental.ndslice.selection : byElement;
+    import std.numeric : dotProduct;
+    assert(res == dotProduct(a.byElement, b.byElement));
+}
+
+/// Zipped tensors, dot product
+pure unittest
+{
+    import std.conv : to;
+    import std.range : iota;
+    import std.numeric : dotProduct;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl1 = iotaSlice(2, 3).ndMap!(to!double).slice;
+    // 1 2 3
+    // 4 5 6
+    auto sl2 = iotaSlice([2, 3], 1).ndMap!(to!double).slice;
+
+    // tensors must have the same strides
+    assert(sl1.structure == sl2.structure);
+
+    auto zip = assumeSameStructure!("a", "b")(sl1, sl2);
+
+    auto dot = ndReduce!((seed, z) => seed + z.a * z.b, Yes.vectorized)(0.0, zip);
+
+    assert(dot == dotProduct(iota(0, 6), iota(1, 7)));
+}
+
+/// Tensor mutation on-the-fly
+unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    alias fun = (seed, ref elem) => seed + elem++;
+
+    auto res = 0.0.ndReduce!(fun, Yes.vectorized)(sl);
+
+    assert(res == 15);
+
+    //| 1 2 3 |
+    //| 4 5 6 |
+    assert(sl == iotaSlice([2, 3], 1));
+}
+
+/++
+Packed tensors.
+
+Computes minimum value of maximum values for each row.
++/
+unittest
+{
+    // LDC is LLVM D Compiler
+    version(LDC)
+        import ldc.intrinsics : fmax = llvm_maxnum, fmin = llvm_minnum;
+    // std.math prevents vectorization for now
+    else
+        import std.math : fmax, fmin;
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
+
+    alias maxVal = (a) => ndReduce!(fmax, Yes.vectorized)(-double.infinity, a);
+    alias minVal = (a) => ndReduce!fmin(double.infinity, a);
+    alias minimaxVal = (a) => minVal(a.pack!1.ndMap!maxVal);
+
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    // Vectorized execution path: row stride equals 1.
+    //| 0 1 2 | => | 2 |
+    //| 3 4 5 | => | 5 | => 2
+    auto res = minimaxVal(sl);
+    assert(res == 2);
+
+    // Common execution path: row stride does not equal 1.
+    //| 0 1 2 |    | 0 3 | => | 3 |
+    //| 3 4 5 | => | 1 4 | => | 4 |
+    //             | 2 5 | => | 5 | => 3
+    auto resT = minimaxVal(sl.transposed);
+    assert(resT == 3);
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+    auto a = ndReduce!"a + b"(size_t(7), iotaSlice(1, 1).dropOne!0);
+    assert(a == 7);
+}
+
+/++
+The call `ndEach!(fun)(tensors1, ..., tesnsorN)`
+evaluates `fun` for each set of elements `x1, ..., xN` in
+`tensors1, ..., tensorN` respectively.
+
+`ndEach` allows to iterate multiple tensors in the lockstep.
+
+Note:
+    $(SUBREF iteration, transposed) and
+    $(SUBREF selection, pack) can be used to specify dimensions.
+Params:
+    fun = A function.
+    vec = Use vectorization friendly iteration without manual unrolling
+        in case of all tensors has the last (row) stride equal to 1.
+    fm = Allow a compiler to use unsafe floating-point mathematic transformations,
+        such as commutative transformation. `fm` is enabled by default if `vec` is enabled.
+    tensors = One or more tensors.
+See_Also:
+    $(HTTP llvm.org/docs/LangRef.html#fast-math-flags, LLVM IR: Fast Math Flags)
+
+    This is functionally similar to $(LREF ndReduce) but has not seed.
+
+    $(REF each, std,algorithm,iteration)
++/
+template ndEach(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
+{
+    ///
+    void ndEach(Args...)(auto ref Args tensors)
+        if (Args.length)
+    {
+        tensors.checkShapesMatch!false;
+        if (tensors[0].anyEmpty)
+            return;
+        static if (vec && allSatisfy!(isMemory, staticMap!(RangeOf, Args)))
+        {
+            foreach (ref tensor; tensors)
+                if (tensor._strides[$-1] != 1)
+                    goto CommonL;
+            return ndEachImpl!(true, Args[0].N, true)(tensors);
+            CommonL:
+        }
+        return ndEachImpl!(false, Args[0].N, false)(tensors);
+    }
+
+    static if(fm)
+        alias attr = fastmath;
+    else
+        alias attr = fastmathDummy;
+
+    private @attr void ndEachImpl(bool dense, size_t N, bool first = false, Args...)(Args tensors)
+    {
+        static if (dense && first)
+            pragma(inline, false);
+        do
+        {
+            static if (Args[0].N == 1)
+                enum _fun = `naryFun!(false, Args.length, fun)`;
+            else
+                enum _fun = `ndEachImpl!(dense, N - 1)`;
+            mixin(_fun ~ `(` ~ TensorFronts!(Args.length) ~ `);`);
+            static if (N == 1 && dense)
+            {
+                foreach_reverse (ref tensor; tensors)
+                    ++tensor._ptr;
+                --tensors[0]._lengths[0];
+            }
+            else
+            {
+                foreach_reverse (ref tensor; tensors)
+                    tensor.popFront;
+            }
+        }
+        while (tensors[0].length);
+    }
+}
+
+/// Single tensor, multiply-add
+unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    sl.ndEach!((ref a) { a = a * 10 + 5; }, Yes.vectorized);
+
+    assert(sl ==
+        [[ 5, 15, 25],
+         [35, 45, 55]]);
+}
+
+/// Swap two tensors
+unittest
+{
+    import std.conv : to;
+    import std.algorithm.mutation : swap;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto a = iotaSlice([2, 3], 0).ndMap!(to!double).slice;
+    //| 10 11 12 |
+    //| 13 14 15 |
+    auto b = iotaSlice([2, 3], 10).ndMap!(to!double).slice;
+
+    ndEach!(swap, Yes.vectorized)(a, b);
+
+    assert(a == iotaSlice([2, 3], 10));
+    assert(b == iotaSlice([2, 3], 0));
+}
+
+/// Swap two zipped tensors
+unittest
+{
+    import std.conv : to;
+    import std.algorithm.mutation : swap;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto a = iotaSlice([2, 3], 0).ndMap!(to!double).slice;
+    //| 10 11 12 |
+    //| 13 14 15 |
+    auto b = iotaSlice([2, 3], 10).ndMap!(to!double).slice;
+
+    auto zip = assumeSameStructure!("a", "b")(a, b);
+
+    zip.ndEach!(z => swap(z.a, z.b), Yes.vectorized);
+
+    assert(a == iotaSlice([2, 3], 10));
+    assert(b == iotaSlice([2, 3], 0));
+}
+
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+    size_t i;
+    iotaSlice(1, 2).dropOne!0.ndEach!((a){i++;});
+    assert(i == 0);
+}
+
+private void ndFindImpl(alias pred, size_t N, Args...)(ref size_t[N] backwardIndex, Args tensors)
+{
+    do
+    {
+        static if (Args[0].N == 1)
+        {
+            if (mixin(`naryFun!(false, Args.length, pred)(` ~ TensorFronts!(Args.length) ~ `)`))
+            {
+                backwardIndex[0] = tensors[0].length;
+                return;
+            }
+        }
+        else
+        {
+            mixin(`ndFindImpl!pred(backwardIndex[1 .. $], ` ~ TensorFronts!(Args.length) ~ `);`);
+            if (backwardIndex[$ - 1])
+            {
+                backwardIndex[0] = tensors[0].length;
+                return;
+            }
+        }
+        foreach_reverse (ref tensor; tensors)
+            tensor.popFront;
+    }
+    while (tensors[0].length);
+}
+
+/++
+Finds a backward index for which
+`pred(tensors[0].backward(index), ..., tensors[$-1].backward(index))` equals `true`.
+
+Params:
+    pred = The predicate.
+    backwardIndex = The variable passing by reference to be filled with the multidimensional backward index for which the predicate is true.
+        `backwardIndex` equals zeros, if the predicate evaluates `false` for all indexes.
+    tensors = One or more tensors.
+
+Optimization:
+To check if any element was found
+use the last dimension (row index).
+This will slightly optimize the code.
+--------
+// $-1 instead of 0
+if (backwardIndex[$-1])
+{
+    auto elem1 = slice1.backward(backwardIndex);
+    //...
+    auto elemK = sliceK.backward(backwardIndex);
+}
+else
+{
+    // not found
+}
+--------
+
+Constraints:
+    All tensors must have the same shape.
+
+See_also:
+    $(LREF ndAny)
+
+    $(REF Slice.backward, std.experimenta,ndslice,slice)
++/
+template ndFind(alias pred)
+{
+    ///
+    void ndFind(size_t N, Args...)(out size_t[N] backwardIndex, auto ref Args tensors)
+        if (Args.length)
+    {
+        tensors.checkShapesMatch!false;
+        if (!tensors[0].anyEmpty)
+            ndFindImpl!pred(backwardIndex, tensors);
+    }
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3);
+    size_t[2] bi;
+
+    ndFind!"a == 3"(bi, sl);
+    assert(sl.backward(bi) == 3);
+
+    ndFind!"a == 6"(bi, sl);
+    assert(bi[0] == 0);
+    assert(bi[1] == 0);
+}
+
+/// Multiple tensors
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto a = iotaSlice(2, 3);
+    // 10 11 12
+    // 13 14 15
+    auto b = iotaSlice([2, 3], 10);
+
+    size_t[2] bi;
+
+    ndFind!((a, b) => a * b == 39)(bi, a, b);
+    assert(a.backward(bi) == 3);
+    assert(b.backward(bi) == 13);
+}
+
+/// Zipped tensors
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto a = iotaSlice(2, 3);
+    // 10 11 12
+    // 13 14 15
+    auto b = iotaSlice([2, 3], 10);
+
+    // tensors must have the same strides
+    auto zip = assumeSameStructure!("a", "b")(a, b);
+    size_t[2] bi;
+
+    ndFind!((z) => z.a * z.b == 39)(bi, zip);
+
+    assert(a.backward(bi) == 3);
+    assert(b.backward(bi) == 13);
+}
+
+/// Mutation on-the-fly
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    static bool pred(T)(ref T a)
+    {
+        if (a == 5)
+            return true;
+        a = 8;
+        return false;
+    }
+
+    size_t[2] bi;
+    ndFind!pred(bi, sl);
+
+    assert(bi == [1, 1]);
+    assert(sl.backward(bi) == 5);
+
+    // sl was changed
+    assert(sl == [[8, 8, 8],
+                  [8, 8, 5]]);
+}
+
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+    size_t i;
+    size_t[2] bi;
+    ndFind!((elem){i++; return true;})
+        (bi, iotaSlice(2, 1).dropOne!1);
+    assert(i == 0);
+    assert(bi == [0, 0]);
+}
+
+
+/++
+Like $(LREF ndFind), but only returns whether or not the search was successful.
+
+Params:
+    pred = The predicate.
+    tensors = One or more tensors.
+
+Returns:
+    `true` if the search was successful and `false` otherwise.
+
+Constraints:
+    All tensors must have the same shape.
++/
+template ndAny(alias pred)
+{
+    ///
+    bool ndAny(Args...)(auto ref Args tensors)
+        if (Args.length)
+    {
+        tensors.checkShapesMatch!false;
+        if (tensors[0].anyEmpty)
+            return false;
+        size_t[Args[0].N] backwardIndex = void;
+        backwardIndex[$-1] = 0;
+        ndFindImpl!pred(backwardIndex, tensors);
+        return cast(bool) backwardIndex[$-1];
+    }
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3);
+
+    assert(sl.ndAny!"a == 3");
+    assert(!sl.ndAny!"a == 6");
+}
+
+/// Multiple tensors
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto a = iotaSlice(2, 3);
+    // 10 11 12
+    // 13 14 15
+    auto b = iotaSlice([2, 3], 10);
+
+    assert(ndAny!((a, b) => a * b == 39)(a, b));
+}
+
+/// Zipped tensors
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto a = iotaSlice(2, 3);
+    // 10 11 12
+    // 13 14 15
+    auto b = iotaSlice([2, 3], 10);
+
+    // tensors must have the same strides
+    auto zip = assumeSameStructure!("a", "b")(a, b);
+
+    assert(zip.ndAny!((z) => z.a * z.b == 39));
+}
+
+/// Mutation on-the-fly
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    static bool pred(T)(ref T a)
+    {
+        if (a == 5)
+            return true;
+        a = 8;
+        return false;
+    }
+
+    assert(sl.ndAny!pred);
+
+    // sl was changed
+    assert(sl == [[8, 8, 8],
+                  [8, 8, 5]]);
+}
+
+/++
+Checks if all of the elements verify `pred`.
+Params:
+    pred = The predicate.
+    tensors = One or more tensors.
+Returns:
+    `true` all of the elements verify `pred` and `false` otherwise.
+Constraints:
+    All tensors must have the same shape.
++/
+template ndAll(alias pred)
+{
+    ///
+    bool ndAll(Args...)(auto ref Args tensors)
+        if (Args.length)
+    {
+        tensors.checkShapesMatch!false;
+        return tensors[0].anyEmpty || ndAllImpl(tensors);
+    }
+
+    private bool ndAllImpl(Args...)(Args tensors)
+    {
+        do
+        {
+            static if (Args[0].N == 1)
+                enum _pred = `naryFun!(false, Args.length, pred)`;
+            else
+                enum _pred = `ndAllImpl`;
+            if (!mixin(_pred ~ `(` ~ TensorFronts!(Args.length) ~ `)`))
+                return false;
+            foreach_reverse (ref tensor; tensors)
+                tensor.popFront;
+        }
+        while (tensors[0].length);
+        return true;
+    }
+}
+
+///
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3);
+
+    assert(sl.ndAll!"a < 6");
+    assert(!sl.ndAll!"a < 5");
+}
+
+/// Multiple tensors
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3);
+
+    assert(ndAll!"a - b == 0"(sl, sl));
+}
+
+/// Zipped tensors
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3);
+
+    // tensors must have the same strides
+    auto zip = assumeSameStructure!("a", "b")(sl, sl);
+
+    assert(zip.ndAll!"a.a - a.b == 0");
+}
+
+/// Mutation on-the-fly
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    static bool pred(T)(ref T a)
+    {
+        if (a < 4)
+        {
+            a = 8;
+            return true;
+        }
+        return false;
+    }
+
+    assert(!sl.ndAll!pred);
+
+    // sl was changed
+    assert(sl == [[8, 8, 8],
+                  [8, 4, 5]]);
+}
+
+@safe pure nothrow unittest
+{
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+    size_t i;
+    assert(ndAll!((elem){i++; return true;})
+        (iotaSlice(2, 1).dropOne!1));
+    assert(i == 0);
+}
+
+/++
+Compares two or more tensors for equality, as defined by predicate `pred`.
+
+Params:
+    pred = The predicate.
+    tensors = Two or more tensors.
+
+Returns:
+    `true` any of the elements verify `pred` and `false` otherwise.
++/
+template ndEqual(alias pred)
+{
+    ///
+    bool ndEqual(Args...)(Args tensors)
+        if (Args.length >= 2)
+    {
+        enum msg = "all arguments must be tensors" ~ tailErrorMessage!();
+        enum msgShape = "all tensors must have the same dimension count"  ~ tailErrorMessage!();
+        foreach (i, Arg; Args)
+        {
+            static assert (is(Arg == Slice!(N, Range), size_t N, Range), msg);
+            static if (i)
+            {
+                static assert (tensors[i].N == tensors[0].N, msgShape);
+                foreach (j; Iota!(0, tensors[0].N))
+                    if (tensors[i]._lengths[j] != tensors[0]._lengths[j])
+                        goto False;
+            }
+        }
+        return ndAll!pred(tensors);
+        False: return false;
+    }
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.iteration : dropBackOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl1 = iotaSlice(2, 3);
+    // 1 2 3
+    // 4 5 6
+    auto sl2 = iotaSlice([2, 3], 1);
+
+    assert(ndEqual!"a == b"(sl1, sl1));
+    assert(ndEqual!"a < b"(sl1, sl2));
+
+    assert(!ndEqual!"a == b"(sl1.dropBackOne!0, sl1));
+    assert(!ndEqual!"a == b"(sl1.dropBackOne!1, sl1));
+
+}
+
+/++
+Performs three-way recursive lexicographical comparison on two tensors according to predicate `pred`.
+Iterating `sl1` and `sl2` in lockstep, `cmp` compares each `N-1` dimensional element `e1` of `sl1`
+with the corresponding element `e2` in `sl2` recursively.
+If one of the tensors has been finished,`cmp` returns a negative value if `sl1` has fewer elements than `sl2`,
+a positive value if `sl1` has more elements than `sl2`,
+and `0` if the ranges have the same number of elements.
+
+Params:
+    pred = The predicate.
+    sl1 = First tensor.
+    sl2 = Second tensor.
+
+Returns:
+    `0` if both ranges compare equal.
+    Negative value if the first differing element of `sl1` is less than the corresponding
+    element of `sl2` according to `pred`.
+    Positive value if the first differing element of `sl2` is less than the corresponding
+    element of `sl1` according to `pred`.
++/
+template ndCmp(alias pred = "a < b")
+{
+    ///
+    int ndCmp(size_t N, RangeA, RangeB)(Slice!(N, RangeA) sl1, Slice!(N, RangeB) sl2)
+    {
+        auto b = sl2.anyEmpty;
+        if (sl1.anyEmpty)
+        {
+            if (!b)
+                return -1;
+            foreach (i; Iota!(0, N))
+                if (sl1._lengths[i] < sl2._lengths[i])
+                    return -1;
+                else
+                if (sl1._lengths[i] > sl2._lengths[i])
+                    return 1;
+            return 0;
+        }
+        if (b)
+            return 1;
+        return ndCmpImpl(sl1, sl2);
+    }
+
+    private int ndCmpImpl(size_t N, RangeA, RangeB)(Slice!(N, RangeA) sl1, Slice!(N, RangeB) sl2)
+    {
+        for (;;)
+        {
+            auto a = sl1.front;
+            auto b = sl2.front;
+            static if (N == 1)
+            {
+                import std.functional : binaryFun;
+                if (binaryFun!pred(a, b))
+                    return -1;
+                if (binaryFun!pred(b, a))
+                    return 1;
+            }
+            else
+            {
+                if (auto res = ndCmpImpl(a, b))
+                    return res;
+            }
+            sl1.popFront;
+            if (sl1.empty)
+                return -cast(int)(sl2.length > 1);
+            sl2.popFront;
+            if (sl2.empty)
+                return 1;
+        }
+    }
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.iteration : dropBackOne;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // 0 1 2
+    // 3 4 5
+    auto sl1 = iotaSlice(2, 3);
+    // 1 2 3
+    // 4 5 6
+    auto sl2 = iotaSlice([2, 3], 1);
+
+    assert(ndCmp(sl1, sl1) == 0);
+    assert(ndCmp(sl1, sl2) < 0);
+    assert(ndCmp!"a >= b"(sl1, sl2) > 0);
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.experimental.ndslice.iteration : dropBackOne, dropExactly;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    auto sl1 = iotaSlice(2, 3);
+    auto sl2 = iotaSlice([2, 3], 1);
+
+    assert(ndCmp(sl1.dropBackOne!0, sl1) < 0);
+    assert(ndCmp(sl1, sl1.dropBackOne!1) > 0);
+
+    assert(ndCmp(sl1.dropExactly!0(2), sl1) < 0);
+    assert(ndCmp(sl1, sl1.dropExactly!1(3)) > 0);
+    assert(ndCmp(sl1.dropExactly!1(3), sl1.dropExactly!1(3)) == 0);
+    assert(ndCmp(sl1.dropExactly!1(3), sl1.dropExactly!(0, 1)(1, 3)) > 0);
+    assert(ndCmp(sl1.dropExactly!(0, 1)(1, 3), sl1.dropExactly!1(3)) < 0);
+}

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -652,6 +652,12 @@ unittest
     import std.typecons : Yes;
     import std.conv : to;
     import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
+
+    static @fastmath T fmuladd(T)(const T a, const T b, const T c)
+    {
+        return a + b * c;
+    }
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -660,7 +666,7 @@ unittest
     //| 4 5 6 |
     auto b = iotaSlice([2, 3], 1).ndMap!(to!double).slice;
 
-    alias dot = ndReduce!((seed, a, b) => seed + a * b, Yes.vectorized);
+    alias dot = ndReduce!(fmuladd, Yes.vectorized);
     auto res = dot(0.0, a, b);
 
     // check the result:
@@ -678,6 +684,12 @@ pure unittest
     import std.numeric : dotProduct;
     import std.experimental.ndslice.slice : assumeSameStructure;
     import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
+
+    static @fastmath T fmuladd(T)(const T a, const T b, const T c)
+    {
+        return a + b * c;
+    }
 
     // 0 1 2
     // 3 4 5
@@ -691,7 +703,7 @@ pure unittest
 
     auto zip = assumeSameStructure!("a", "b")(sl1, sl2);
 
-    auto dot = ndReduce!((seed, z) => seed + z.a * z.b, Yes.vectorized)(0.0, zip);
+    auto dot = ndReduce!(fmuladd, Yes.vectorized)(0.0, zip);
 
     assert(dot == dotProduct(iota(0, 6), iota(1, 7)));
 }
@@ -703,14 +715,18 @@ unittest
     import std.conv : to;
     import std.experimental.ndslice.slice : slice;
     import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
+
+    static @fastmath T fun(T)(const T a, ref T b)
+    {
+        return a + b++;
+    }
 
     //| 0 1 2 |
     //| 3 4 5 |
     auto sl = iotaSlice(2, 3).ndMap!(to!double).slice;
 
-    alias fun = (seed, ref elem) => seed + elem++;
-
-    auto res = 0.0.ndReduce!(fun, Yes.vectorized)(sl);
+    auto res = ndReduce!(fun, Yes.vectorized)(double(0), sl);
 
     assert(res == 15);
 

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -58,8 +58,8 @@ import std.traits;
 import std.meta;
 import std.typecons : Flag, Yes, No;
 
-import mir.ndslice.internal;
-import mir.ndslice.slice;
+import std.experimental.ndslice.internal;
+import std.experimental.ndslice.slice;
 
 private template TensorFronts(size_t length)
 {
@@ -211,7 +211,7 @@ template ndMap(fun...)
 ///
 pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto s = iotaSlice(2, 3).ndMap!(a => a * 3);
     assert(s == [[ 0,  3,  6],
@@ -220,7 +220,7 @@ pure nothrow unittest
 
 pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     assert(iotaSlice(2, 3).slice.ndMap!"a * 2" == [[0, 2, 4], [6, 8, 10]]);
 }
@@ -228,7 +228,7 @@ pure nothrow unittest
 /// Packed tensors.
 pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice, windows;
+    import std.experimental.ndslice.selection : iotaSlice, windows;
 
     //  iotaSlice        windows     ndMap  sums ( ndFold!"a + b" )
     //                --------------
@@ -246,7 +246,7 @@ pure nothrow unittest
 
 pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice, windows;
+    import std.experimental.ndslice.selection : iotaSlice, windows;
 
     auto s = iotaSlice(2, 3)
         .slice
@@ -259,8 +259,8 @@ pure nothrow unittest
 /// Zipped tensors
 pure nothrow unittest
 {
-    import mir.ndslice.slice : assumeSameStructure;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -287,7 +287,7 @@ one element for each function.
 +/
 pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto s = iotaSlice(2, 3).ndMap!("a + a", "a * a");
 
@@ -309,7 +309,7 @@ You may alias `ndMap` with some function(s) to a symbol and use it separately:
 pure nothrow unittest
 {
     import std.conv : to;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     alias stringize = ndMap!(to!string);
     assert(stringize(iotaSlice(2, 3)) == [["0", "1", "2"], ["3", "4", "5"]]);
@@ -739,7 +739,7 @@ template ndFold(fun...)
 /// Single seed
 unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 | => 3  |
     //| 3 4 5 | => 12 | => 15
@@ -754,7 +754,7 @@ unittest
 /// Multiple seeds
 unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 1 2 3 |
     //| 4 5 6 |
@@ -773,8 +773,8 @@ pure unittest
     import std.conv : to;
     import std.range : iota;
     import std.numeric : dotProduct;
-    import mir.ndslice.slice : assumeSameStructure;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -797,8 +797,8 @@ pure unittest
 unittest
 {
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -823,8 +823,8 @@ Computes minimum value for maximum values for each row.
 unittest
 {
     import std.algorithm.comparison : min, max;
-    import mir.ndslice.iteration : transposed;
-    import mir.ndslice.selection : iotaSlice, pack;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
 
     alias maxVal = (a) => a.ndFold!max(size_t.min);
     alias minVal = (a) => a.ndFold!min(size_t.max);
@@ -846,8 +846,8 @@ unittest
 
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.iteration : dropOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = iotaSlice(1, 1).dropOne!0.ndFold!"a + b"(size_t(7));
     auto b = iotaSlice(1, 1).dropOne!1.ndFold!("a + b", "a * b")(size_t(7), size_t(8));
     assert(a == 7);
@@ -921,7 +921,7 @@ template ndReduce(alias fun, Select select, Flag!"vectorized" vec = No.vectorize
 /// Single tensor
 unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 | => 3  |
     //| 3 4 5 | => 12 | => 15
@@ -938,8 +938,8 @@ unittest
 {
     import std.typecons : Yes;
     import std.conv : to;
-    import mir.ndslice.selection : iotaSlice;
-    import mir.ndslice.internal : fastmath;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
 
     static @fastmath T fmuladd(T)(const T a, const T b, const T c)
     {
@@ -957,7 +957,7 @@ unittest
     auto res = dot(0.0, a, b);
 
     // check the result:
-    import mir.ndslice.selection : byElement;
+    import std.experimental.ndslice.selection : byElement;
     import std.numeric : dotProduct;
     assert(res == dotProduct(a.byElement, b.byElement));
 }
@@ -969,9 +969,9 @@ pure unittest
     import std.conv : to;
     import std.range : iota;
     import std.numeric : dotProduct;
-    import mir.ndslice.slice : assumeSameStructure;
-    import mir.ndslice.selection : iotaSlice;
-    import mir.ndslice.internal : fastmath;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
 
     static @fastmath T fmuladd(T, Z)(const T a, Z z)
     {
@@ -1000,9 +1000,9 @@ unittest
 {
     import std.typecons : Yes;
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
-    import mir.ndslice.internal : fastmath;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.internal : fastmath;
 
     static @fastmath T fun(T)(const T a, ref T b)
     {
@@ -1037,9 +1037,9 @@ unittest
         import std.math : fmax, fmin;
     import std.typecons : Yes;
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.iteration : transposed;
-    import mir.ndslice.selection : iotaSlice, pack;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : transposed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
 
     alias maxVal = (a) => ndReduce!(fmax, Yes.vectorized)(-double.infinity, a);
     alias minVal = (a) => ndReduce!fmin(double.infinity, a);
@@ -1063,8 +1063,8 @@ unittest
 
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.iteration : dropOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
     auto a = ndReduce!"a + b"(size_t(7), iotaSlice(1, 1).dropOne!0);
     assert(a == 7);
 }
@@ -1129,7 +1129,7 @@ unittest
 {
     import std.typecons : Yes;
     import std.conv : to;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -1149,7 +1149,7 @@ unittest
     import std.typecons : Yes;
     import std.conv : to;
     import std.algorithm.mutation : swap;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -1170,8 +1170,8 @@ unittest
     import std.typecons : Yes;
     import std.conv : to;
     import std.algorithm.mutation : swap;
-    import mir.ndslice.slice : assumeSameStructure;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -1194,9 +1194,9 @@ pure nothrow unittest
     import std.typecons : Yes;
     import std.conv : to;
     import std.algorithm.mutation : swap;
-    import mir.ndslice.slice : assumeSameStructure;
-    import mir.ndslice.selection : iotaSlice;
-    import mir.ndslice.iteration : allReversed;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : allReversed;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -1212,8 +1212,8 @@ pure nothrow unittest
 {
     import std.conv : to;
     import std.algorithm.mutation : swap;
-    import mir.ndslice.selection : iotaSlice, pack;
-    import mir.ndslice.iteration : reversed, transposed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
+    import std.experimental.ndslice.iteration : reversed, transposed;
 
     //| 0 1 2 |
     //| 3 4 5 |
@@ -1236,8 +1236,8 @@ pure nothrow unittest
 {
     import std.conv : to;
     import std.algorithm.mutation : swap;
-    import mir.ndslice.selection : iotaSlice;
-    import mir.ndslice.iteration : dropOne, transposed;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne, transposed;
 
     // | 0 1 2 |
     // | 3 4 5 |
@@ -1256,8 +1256,8 @@ pure nothrow unittest
 
 @safe pure nothrow unittest
 {
-    import mir.ndslice.iteration : dropOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
     size_t i;
     iotaSlice(1, 2).dropOne!0.ndEach!((a){i++;});
     assert(i == 0);
@@ -1319,7 +1319,7 @@ template ndFind(alias pred, Select select = Select.full)
 ///
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     // 0 1 2
     // 3 4 5
     auto sl = iotaSlice(2, 3);
@@ -1336,7 +1336,7 @@ template ndFind(alias pred, Select select = Select.full)
 /// Multiple tensors
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1355,7 +1355,7 @@ template ndFind(alias pred, Select select = Select.full)
 /// Zipped tensors
 @safe pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1378,8 +1378,8 @@ template ndFind(alias pred, Select select = Select.full)
 pure nothrow unittest
 {
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1408,8 +1408,8 @@ pure nothrow unittest
 pure nothrow unittest
 {
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // |_0 1 2
     // 3 |_4 5
@@ -1423,9 +1423,9 @@ pure nothrow unittest
 /// Search of first non-palindrome row
 pure nothrow unittest
 {
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.iteration : reversed;
-    import mir.ndslice.selection : iotaSlice, pack;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : reversed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
 
     auto sl = slice!double(4, 5);
     sl[] =
@@ -1441,8 +1441,8 @@ pure nothrow unittest
 
 @safe pure nothrow unittest
 {
-    import mir.ndslice.iteration : dropOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
     size_t i;
     size_t[2] bi;
     ndFind!((elem){i++; return true;})
@@ -1487,7 +1487,7 @@ template ndAny(alias pred, Select select = Select.full)
 ///
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
     // 0 1 2
     // 3 4 5
     auto sl = iotaSlice(2, 3);
@@ -1499,7 +1499,7 @@ template ndAny(alias pred, Select select = Select.full)
 /// Multiple tensors
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1514,7 +1514,7 @@ template ndAny(alias pred, Select select = Select.full)
 /// Zipped tensors
 @safe pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1533,8 +1533,8 @@ template ndAny(alias pred, Select select = Select.full)
 pure nothrow unittest
 {
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1582,7 +1582,7 @@ template ndAll(alias pred, Select select = Select.full)
 ///
 @safe pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1595,7 +1595,7 @@ template ndAll(alias pred, Select select = Select.full)
 /// Multiple tensors
 @safe pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1607,7 +1607,7 @@ template ndAll(alias pred, Select select = Select.full)
 /// Zipped tensors
 @safe pure nothrow unittest
 {
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1623,8 +1623,8 @@ template ndAll(alias pred, Select select = Select.full)
 pure nothrow unittest
 {
     import std.conv : to;
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1649,8 +1649,8 @@ pure nothrow unittest
 
 @safe pure nothrow unittest
 {
-    import mir.ndslice.iteration : dropOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne;
+    import std.experimental.ndslice.selection : iotaSlice;
     size_t i;
     assert(ndAll!((elem){i++; return true;})
         (iotaSlice(2, 1).dropOne!1));
@@ -1696,9 +1696,9 @@ template ndEqual(alias pred, Select select = Select.full)
 ///
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.iteration : dropBackOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : dropBackOne;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1717,8 +1717,8 @@ template ndEqual(alias pred, Select select = Select.full)
 /// check if matrix is symmetric
 pure nothrow unittest
 {
-    import mir.ndslice.slice : slice;
-    import mir.ndslice.iteration : transposed;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : transposed;
 
     auto a = slice!double(3, 3);
     a[] = [[1, 3, 4],
@@ -1816,8 +1816,8 @@ template ndCmp(alias pred = "a < b")
 ///
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.iteration : dropBackOne;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropBackOne;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     // 0 1 2
     // 3 4 5
@@ -1833,8 +1833,8 @@ template ndCmp(alias pred = "a < b")
 
 @safe pure nothrow @nogc unittest
 {
-    import mir.ndslice.iteration : dropBackOne, dropExactly;
-    import mir.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropBackOne, dropExactly;
+    import std.experimental.ndslice.selection : iotaSlice;
 
     auto sl1 = iotaSlice(2, 3);
     auto sl2 = iotaSlice([2, 3], 1);

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -74,7 +74,7 @@ private template TensorFronts(size_t length)
     }
 }
 
-private void checkShapesMatch(bool seed, Args...)(auto ref Args tensors)
+private void checkShapesMatch(bool seed, Select select, Args...)(auto ref Args tensors)
 {
     enum msg = seed ?
         "all arguments except the first (seed) must be tensors" :
@@ -84,12 +84,35 @@ private void checkShapesMatch(bool seed, Args...)(auto ref Args tensors)
     foreach (i, Arg; Args)
     {
         static assert (is(Arg == Slice!(N, Range), size_t N, Range), msg);
-        static if (i)
+        static if (select == Select.halfPacked || select == Select.triangularPacked)
         {
-            static assert (tensors[i].N == tensors[0].N, msgShape);
-            assert(tensors[i].shape == tensors[0].shape, msgShape);
+            static assert (tensors[i].NSeq.length > 1, "halfPacked and triangularPacked selections require packed slices");
+            static if (i)
+            {
+                static assert (tensors[i].NSeq[0 .. 2] == tensors[0].NSeq[0 .. 2], msgShape);
+                enum M = tensors[0].NSeq[0] + tensors[0].NSeq[1] - 1;
+                assert(tensors[i]._lengths[0 .. M] == tensors[0]._lengths[0 .. M], msgShape);
+            }
+        }
+        else
+        {
+            static if (i)
+            {
+                static assert (tensors[i].N == tensors[0].N, msgShape);
+                assert(tensors[i].shape == tensors[0].shape, msgShape);
+            }
         }
     }
+}
+
+private bool anyEmpty(Select select, size_t N, Range)(ref Slice!(N, Range) slice)
+{
+    static if (select == Select.halfPacked || select == Select.triangularPacked)
+        static if (is(Range : Slice!(M, IRange), size_t M, IRange))
+            return Slice!(N + M - 1, IRange)(slice._lengths, slice._strides, slice._ptr).anyEmpty;
+        else static assert(0);
+    else
+        return slice.anyEmpty;
 }
 
 private template naryFun(bool hasSeed, size_t argCount, alias fun)
@@ -345,6 +368,293 @@ private mixin template PropagatePtr()
     }
 }
 
+private enum Iteration
+{
+    reduce,
+    each,
+    find,
+    all,
+}
+
+void prepareTensors(Select select, Args...)(ref Args tensors)
+{
+    static if (select == Select.triangular || select == Select.triangularPacked)
+    {
+        static if (select == Select.triangularPacked)
+            enum I = Iota!(tensors[0].N, tensors[0].N + tensors[0].front.N - 1);
+        else
+            enum I = Iota!(0, tensors[0].N - 1);
+        foreach_reverse (i; I)
+            if (tensors[0]._lengths[i] > tensors[0]._lengths[i + 1])
+                foreach (ref tensor; tensors)
+                    tensor._lengths[i] = tensors[0]._lengths[i + 1];
+    }
+}
+
+// one ring to rule them all
+private template implement(Iteration iteration, alias fun, Flag!"vectorized" vec, Flag!"fastmath" fm)
+{
+    static if (fm)
+        alias attr = fastmath;
+    else
+        alias attr = fastmathDummy;
+
+    static if (iteration == Iteration.reduce)
+        enum argStr = "S, Tensors...)(S seed, Tensors tensors)";
+    else
+    static if (iteration == Iteration.find)
+        enum argStr = "size_t M, Tensors...)(ref size_t[M] backwardIndex, Tensors tensors)";
+    else
+        enum argStr = "Tensors...)(Tensors tensors)";
+
+    mixin("@attr auto implement(size_t N, Select select, " ~ argStr ~ "{" ~ bodyStr ~ "}");
+    enum bodyStr = q{
+        static if (iteration == Iteration.find)
+        {
+            static if (select == Select.halfPacked || select == Select.triangularPacked)
+                enum S = N + tensors[0].front.N;
+            else
+                enum S = N;
+            static assert (M == S, "backwardIndex length should be equal to " ~ S.stringof);
+        }
+        static if (select == Select.half)
+        {
+            immutable lengthSave = tensors[0]._lengths[0];
+            tensors[0]._lengths[0] >>= 1;
+            if (tensors[0]._lengths[0] == 0)
+                goto End;
+        }
+        static if (select == Select.halfPacked)
+            static if (N == 1)
+                enum nextSelect = Select.half;
+            else
+                enum nextSelect = Select.halfPacked;
+        else
+        static if (select == Select.triangularPacked)
+            static if (N == 1)
+                enum nextSelect = Select.triangular;
+            else
+                enum nextSelect = Select.triangularPacked;
+        else
+        static if (N == 1)
+            enum nextSelect = -1;
+        else
+        static if (select == Select.half)
+            enum nextSelect = Select.full;
+        else
+            enum nextSelect = select;
+        static if (select == Select.triangular)
+            alias popSeq = Iota!(0, N);
+        else
+            alias popSeq = AliasSeq!(size_t(0));
+        static if (N == 1 && (select == Select.halfPacked || select == Select.triangularPacked))
+            enum M = tensors[0].front.N;
+        else
+            enum M = N - 1;
+        static if (iteration == Iteration.reduce)
+            static if (nextSelect == -1)
+                enum compute = `seed = naryFun!(true, Tensors.length, fun)(seed, ` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+                enum compute = `seed = implement!(M, nextSelect)(seed, ` ~ TensorFronts!(Tensors.length) ~ `);`;
+        else
+        static if (iteration == Iteration.each)
+            static if (nextSelect == -1)
+                enum compute = `naryFun!(false, Tensors.length, fun)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+                enum compute = `implement!(M, nextSelect)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+        else
+        static if (iteration == Iteration.find)
+            static if (nextSelect == -1)
+                enum compute = `auto val = naryFun!(false, Tensors.length, fun)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+                enum compute = `implement!(M, nextSelect)(backwardIndex[1 .. $] , ` ~ TensorFronts!(Tensors.length) ~ `);`;
+        else
+        static if (iteration == Iteration.all)
+            static if (nextSelect == -1)
+                enum compute = `auto val = naryFun!(false, Tensors.length, fun)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+                enum compute = `auto val = implement!(M, nextSelect)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+        else
+        static assert(0);
+        enum breakStr = q{
+            static if (iteration == Iteration.find)
+            {
+                static if (nextSelect != -1)
+                    auto val = backwardIndex[$ - 1];
+                if (val)
+                {
+                    backwardIndex[0] = tensors[0]._lengths[0];
+                    static if (select == Select.half)
+                        backwardIndex[0] += lengthSave - (lengthSave >> 1);
+                    return;
+                }
+            }
+            else
+            static if (iteration == Iteration.all)
+            {
+                if (!val)
+                    return false;
+            }
+        };
+        do
+        {
+            mixin(compute);
+            mixin(breakStr);
+            foreach_reverse (t, ref tensor; tensors)
+            {
+                foreach (d; popSeq)
+                {
+                    static if (d == M && vec)
+                    {
+                        ++tensor._ptr;
+                        static if (t == 0)
+                            --tensors[0]._lengths[0];
+                    }
+                    else
+                    {
+                        tensor.popFront!d;
+                    }
+                }
+            }
+        }
+        while(tensors[0]._lengths[0]);
+        End:
+        static if (select == Select.half && N > 1)
+        {
+            static if (iteration == Iteration.reduce)
+                enum computeHalf = `seed = implement!(N - 1, Select.half)(seed, ` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+            static if (iteration == Iteration.each)
+                enum computeHalf = `implement!(N - 1, Select.half)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+            static if (iteration == Iteration.find)
+                enum computeHalf = `implement!(N - 1, Select.half)(backwardIndex[1 .. $] , ` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+            static if (iteration == Iteration.all)
+                enum computeHalf = `auto val = implement!(N - 1, Select.half)(` ~ TensorFronts!(Tensors.length) ~ `);`;
+            else
+            static assert(0);
+            if (lengthSave & 1)
+            {
+                tensors[0]._lengths[0] = 1;
+                mixin(computeHalf);
+                mixin(breakStr);
+            }
+        }
+        static if (iteration == Iteration.reduce)
+            return seed;
+        else
+        static if (iteration == Iteration.all)
+            return true;
+    };
+}
+
+/++
+Selection type,
+`Select` can be used with
+$(MREF ndReduce),
+$(MREF ndEach),
+$(MREF ndFind),
+$(MREF ndAny),
+$(MREF ndAll),
+$(MREF ndEqual),
+$(MREF ndCmp).
+
+Any dimension count is supported.
+Types has examples for 1D, 2D, and 3D cases.
++/
+enum Select
+{
+    /++
+    `full` is the default selection type.
+
+    1D Example:
+    -----
+    1 2 3
+    -----
+    2D Example:
+    -----
+    | 1 2 3 |
+    | 4 5 6 |
+    | 7 8 9 |
+    -----
+    3D Example:
+    -----
+    | 1  2  3 | | 10 11 12 | | 19 20 21 |
+    | 4  5  6 | | 13 14 15 | | 22 23 24 |
+    | 7  8  9 | | 16 17 18 | | 25 26 27 |
+    -----
+    +/
+    full,
+    /++
+    `half` can be used to reverse elements in a tensor.
+
+    1D Example:
+    -----
+    1 x x
+    -----
+    2D Example:
+    -----
+    | 1 2 3 |
+    | 4 x x |
+    | x x x |
+    -----
+    3D Example:
+    -----
+    | 1  2  3 | | 10 11 12 | |  x  x  x |
+    | 4  5  6 | | 13  x  x | |  x  x  x |
+    | 7  8  9 | |  x  x  x | |  x  x  x |
+    -----
+    +/
+    half,
+    /++
+    `halfPacked` requires packed tensors.
+    For the first pack of dimensions elements are selected using `full` selection.
+    For the second pack of dimensions elements are selected using `half` selection.
+    +/
+    halfPacked,
+    /++
+    `upper` can be used to iterate on upper or lower triangular matrix.
+
+    1D Example:
+    -----
+    1 2 3
+    -----
+    2D Example #1:
+    -----
+    | 1 2 3 |
+    | x 4 5 |
+    | x x 6 |
+    -----
+    2D Example #2:
+    -----
+    | 1 2 3 4 |
+    | x 5 6 7 |
+    | x x 8 9 |
+    -----
+    2D Example #3:
+    -----
+    | 1 2 3 |
+    | x 4 5 |
+    | x x 6 |
+    | x x x |
+    -----
+    3D Example:
+    -----
+    |  1  2  3 | |  x  7  8 | |  x  x 10 |
+    |  x  4  5 | |  x  x  9 | |  x  x  x |
+    |  x  x  6 | |  x  x  x | |  x  x  x |
+    -----
+    +/
+    triangular,
+    /++
+    `triangularPacked` requires packed tensors.
+    For the first pack of dimensions elements are selected using `full` selection.
+    For the second pack of dimensions elements are selected using `triangular` selection.
+    +/
+    triangularPacked,
+}
+
 /++
 Implements the homonym function (also known as `accumulate`,
 `compress`, `inject`, or `foldl`) present in various programming
@@ -545,7 +855,6 @@ unittest
     assert(b[1] == 8);
 }
 
-
 /++
 Implements the homonym function (also known as `accumulate`,
 `compress`, `inject`, or `foldl`) present in various programming
@@ -580,54 +889,31 @@ See_Also:
 
     $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
 +/
-template ndReduce(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
+alias ndReduce(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec) =
+    .ndReduce!(fun, Select.full, vec, fm);
+
+/// ditto
+template ndReduce(alias fun, Select select, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
 {
     ///
-    auto ndReduce(S, Args...)(S seed, auto ref Args tensors)
+    auto ndReduce(S, Args...)(S seed, Args tensors)
         if (Args.length)
     {
-        tensors.checkShapesMatch!true;
-        if (tensors[0].anyEmpty)
+        tensors.checkShapesMatch!(true, select);
+        if (anyEmpty!select(tensors[0]))
             return cast(Unqual!S) seed;
+        prepareTensors!select(tensors);
+        alias impl = implement!(Iteration.reduce, fun, No.vectorized, fm);
         static if (vec && allSatisfy!(isMemory, staticMap!(RangeOf, Args)))
         {
             foreach (ref tensor; tensors)
                 if (tensor._strides[$-1] != 1)
                     goto CommonL;
-            return ndReduceImpl!(true, Args[0].N, true, staticMap!(Unqual, S))(seed, tensors);
+            alias implVec = implement!(Iteration.reduce, fun, Yes.vectorized, fm);
+            return implVec!(Args[0].N, select, staticMap!(Unqual, S))(seed, tensors);
             CommonL:
         }
-        return ndReduceImpl!(false, Args[0].N, false, staticMap!(Unqual, S))(seed, tensors);
-    }
-
-    static if (fm)
-        alias attr = fastmath;
-    else
-        alias attr = fastmathDummy;
-
-    private @attr auto ndReduceImpl(bool dense, size_t N, bool first = false, S, Args...)(S seed, Args tensors)
-    {
-        do
-        {
-            static if (N == 1)
-                enum _fun = `naryFun!(true, Args.length, fun)`;
-            else
-                enum _fun = `ndReduceImpl!(dense, N - 1)`;
-            seed = mixin(_fun ~  `(seed, ` ~ TensorFronts!(Args.length) ~ `)`);
-            static if (N == 1 && dense)
-            {
-                foreach_reverse (ref tensor; tensors)
-                    ++tensor._ptr;
-                --tensors[0]._lengths[0];
-            }
-            else
-            {
-                foreach_reverse (ref tensor; tensors)
-                    tensor.popFront;
-            }
-        }
-        while (tensors[0]._lengths[0]);
-        return seed;
+        return impl!(Args[0].N, select, staticMap!(Unqual, S))(seed, tensors);
     }
 }
 
@@ -806,53 +1092,33 @@ See_Also:
 
     $(REF each, std,algorithm,iteration)
 +/
-template ndEach(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
+alias ndEach(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec) =
+    .ndEach!(fun, Select.full, vec, fm);
+
+/// ditto
+template ndEach(alias fun, Select select, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath" fm = cast(Flag!"fastmath")vec)
 {
     ///
-    void ndEach(Args...)(auto ref Args tensors)
+    void ndEach(Args...)(Args tensors)
         if (Args.length)
     {
-        tensors.checkShapesMatch!false;
-        if (tensors[0].anyEmpty)
+        tensors.checkShapesMatch!(false, select);
+        if (anyEmpty!select(tensors[0]))
             return;
+        prepareTensors!select(tensors);
+        alias impl = implement!(Iteration.each, fun, No.vectorized, fm);
         static if (vec && allSatisfy!(isMemory, staticMap!(RangeOf, Args)))
         {
             foreach (ref tensor; tensors)
                 if (tensor._strides[$-1] != 1)
                     goto CommonL;
-            return ndEachImpl!(true, Args[0].N, true)(tensors);
+            alias implVec = implement!(Iteration.each, fun, Yes.vectorized, fm);
+            implVec!(Args[0].N, select)(tensors);
+            return;
+
             CommonL:
         }
-        return ndEachImpl!(false, Args[0].N, false)(tensors);
-    }
-
-    static if (fm)
-        alias attr = fastmath;
-    else
-        alias attr = fastmathDummy;
-
-    private @attr void ndEachImpl(bool dense, size_t N, bool first = false, Args...)(Args tensors)
-    {
-        do
-        {
-            static if (Args[0].N == 1)
-                enum _fun = `naryFun!(false, Args.length, fun)`;
-            else
-                enum _fun = `ndEachImpl!(dense, N - 1)`;
-            mixin(_fun ~ `(` ~ TensorFronts!(Args.length) ~ `);`);
-            static if (N == 1 && dense)
-            {
-                foreach_reverse (ref tensor; tensors)
-                    ++tensor._ptr;
-                --tensors[0]._lengths[0];
-            }
-            else
-            {
-                foreach_reverse (ref tensor; tensors)
-                    tensor.popFront;
-            }
-        }
-        while (tensors[0]._lengths[0]);
+        impl!(Args[0].N, select)(tensors);
     }
 }
 
@@ -869,6 +1135,7 @@ unittest
 
     sl.ndEach!((ref a) { a = a * 10 + 5; }, Yes.vectorized);
 
+    import std.stdio;
     assert(sl ==
         [[ 5, 15, 25],
          [35, 45, 55]]);
@@ -919,6 +1186,72 @@ unittest
     assert(b == iotaSlice([2, 3], 0));
 }
 
+/// Reverse rows and columns
+pure nothrow unittest
+{
+    import std.typecons : Yes;
+    import std.conv : to;
+    import std.algorithm.mutation : swap;
+    import std.experimental.ndslice.slice : assumeSameStructure;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : allReversed;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto a = iotaSlice(2, 3).ndMap!(to!double).slice;
+
+    ndEach!(swap, Select.half)(a, a.allReversed);
+
+    assert(a == iotaSlice(2, 3).allReversed);
+}
+
+/// Reverse rows or columns
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.algorithm.mutation : swap;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
+    import std.experimental.ndslice.iteration : reversed, transposed;
+
+    //| 0 1 2 |
+    //| 3 4 5 |
+    auto a = iotaSlice(2, 3).ndMap!(to!double).slice;
+    auto b = a.slice;
+
+    alias reverseRows = a => ndEach!(swap, Select.halfPacked)(a.pack!1, a.reversed!1.pack!1);
+
+    // reverse rows
+    reverseRows(a);
+    assert(a == iotaSlice(2, 3).reversed!1);
+
+    // reverse columns
+    reverseRows(b.transposed);
+    assert(b == iotaSlice(2, 3).reversed!0);
+}
+
+/// Transpose matrix
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.algorithm.mutation : swap;
+    import std.experimental.ndslice.selection : iotaSlice;
+    import std.experimental.ndslice.iteration : dropOne, transposed;
+
+    // | 0 1 2 |
+    // | 3 4 5 |
+    // | 6 7 8 |
+    auto a = iotaSlice(3, 3).ndMap!(to!double).slice;
+
+    // matrix should be square
+    assert(a.length!0 == a.length!1);
+
+    if (a.length)
+        // dropOne is used because we do not need to transpose the diagonal
+        ndEach!(swap, Select.triangular)(a.dropOne, a.transposed.dropOne);
+
+    assert(a == iotaSlice(3, 3).transposed);
+}
+
 @safe pure nothrow unittest
 {
     import std.experimental.ndslice.iteration : dropOne;
@@ -926,33 +1259,6 @@ unittest
     size_t i;
     iotaSlice(1, 2).dropOne!0.ndEach!((a){i++;});
     assert(i == 0);
-}
-
-private void ndFindImpl(alias pred, size_t N, Args...)(ref size_t[N] backwardIndex, Args tensors)
-{
-    do
-    {
-        static if (Args[0].N == 1)
-        {
-            if (mixin(`naryFun!(false, Args.length, pred)(` ~ TensorFronts!(Args.length) ~ `)`))
-            {
-                backwardIndex[0] = tensors[0].length;
-                return;
-            }
-        }
-        else
-        {
-            mixin(`ndFindImpl!pred(backwardIndex[1 .. $], ` ~ TensorFronts!(Args.length) ~ `);`);
-            if (backwardIndex[$ - 1])
-            {
-                backwardIndex[0] = tensors[0].length;
-                return;
-            }
-        }
-        foreach_reverse (ref tensor; tensors)
-            tensor.popFront;
-    }
-    while (tensors[0]._lengths[0]);
 }
 
 /++
@@ -991,15 +1297,19 @@ See_also:
 
     $(REF Slice.backward, std,experimental,ndslice,slice)
 +/
-template ndFind(alias pred)
+template ndFind(alias pred, Select select = Select.full)
 {
     ///
-    void ndFind(size_t N, Args...)(out size_t[N] backwardIndex, auto ref Args tensors)
+    void ndFind(size_t N, Args...)(out size_t[N] backwardIndex, Args tensors)
         if (Args.length)
     {
-        tensors.checkShapesMatch!false;
-        if (!tensors[0].anyEmpty)
-            ndFindImpl!pred(backwardIndex, tensors);
+        tensors.checkShapesMatch!(false, select);
+        if (!anyEmpty!select(tensors[0]))
+        {
+            prepareTensors!select(tensors);
+            alias impl = implement!(Iteration.find, pred, No.vectorized, No.fastmath);
+            impl!(Args[0].N, select)(backwardIndex, tensors);
+        }
     }
 }
 
@@ -1091,6 +1401,41 @@ pure nothrow unittest
                   [8, 8, 5]]);
 }
 
+/// Search in triangular matrix
+pure nothrow unittest
+{
+    import std.conv : to;
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.selection : iotaSlice;
+
+    // |_0 1 2
+    // 3 |_4 5
+    // 6 7 |_8
+    auto sl = iotaSlice(3, 3).ndMap!(to!double).slice;
+    size_t[2] bi;
+    ndFind!("a > 5", Select.triangular)(bi, sl);
+    assert(sl.backward(bi) == 8);
+}
+
+/// Search of first non-palindrome row
+pure nothrow unittest
+{
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : reversed;
+    import std.experimental.ndslice.selection : iotaSlice, pack;
+
+    auto sl = slice!double(4, 5);
+    sl[] =
+        [[0, 1, 2, 1, 0],
+         [2, 3, 4, 3, 2],
+         [6, 9, 8, 5, 6],
+         [6, 5, 8, 5, 6]];
+
+    size_t[2] bi;
+    ndFind!("a != b", Select.halfPacked)(bi, sl.pack!1, sl.reversed!1.pack!1);
+    assert(sl.backward(bi) == 9);
+}
+
 @safe pure nothrow unittest
 {
     import std.experimental.ndslice.iteration : dropOne;
@@ -1117,18 +1462,20 @@ Returns:
 Constraints:
     All tensors must have the same shape.
 +/
-template ndAny(alias pred)
+template ndAny(alias pred, Select select = Select.full)
 {
     ///
-    bool ndAny(Args...)(auto ref Args tensors)
+    bool ndAny(Args...)(Args tensors)
         if (Args.length)
     {
-        tensors.checkShapesMatch!false;
-        if (tensors[0].anyEmpty)
+        tensors.checkShapesMatch!(false, select);
+        if (anyEmpty!select(tensors[0]))
             return false;
         size_t[Args[0].N] backwardIndex = void;
         backwardIndex[$-1] = 0;
-        ndFindImpl!pred(backwardIndex, tensors);
+        prepareTensors!select(tensors);
+        alias impl = implement!(Iteration.find, pred, No.vectorized, No.fastmath);
+        impl!(Args[0].N, select)(backwardIndex, tensors);
         return cast(bool) backwardIndex[$-1];
     }
 }
@@ -1214,31 +1561,16 @@ Returns:
 Constraints:
     All tensors must have the same shape.
 +/
-template ndAll(alias pred)
+template ndAll(alias pred, Select select = Select.full)
 {
     ///
-    bool ndAll(Args...)(auto ref Args tensors)
+    bool ndAll(Args...)(Args tensors)
         if (Args.length)
     {
-        tensors.checkShapesMatch!false;
-        return tensors[0].anyEmpty || ndAllImpl(tensors);
-    }
-
-    private bool ndAllImpl(Args...)(Args tensors)
-    {
-        do
-        {
-            static if (Args[0].N == 1)
-                enum _pred = `naryFun!(false, Args.length, pred)`;
-            else
-                enum _pred = `ndAllImpl`;
-            if (!mixin(_pred ~ `(` ~ TensorFronts!(Args.length) ~ `)`))
-                return false;
-            foreach_reverse (ref tensor; tensors)
-                tensor.popFront;
-        }
-        while (tensors[0]._lengths[0]);
-        return true;
+        tensors.checkShapesMatch!(false, select);
+        prepareTensors!select(tensors);
+        alias impl = implement!(Iteration.all, pred, No.vectorized, No.fastmath);
+        return anyEmpty!select(tensors[0]) || impl!(Args[0].N, select)(tensors);
     }
 }
 
@@ -1330,7 +1662,7 @@ Params:
 Returns:
     `true` any of the elements verify `pred` and `false` otherwise.
 +/
-template ndEqual(alias pred)
+template ndEqual(alias pred, Select select = Select.full)
 {
     ///
     bool ndEqual(Args...)(Args tensors)
@@ -1338,6 +1670,7 @@ template ndEqual(alias pred)
     {
         enum msg = "all arguments must be tensors" ~ tailErrorMessage!();
         enum msgShape = "all tensors must have the same dimension count"  ~ tailErrorMessage!();
+        prepareTensors!select(tensors);
         foreach (i, Arg; Args)
         {
             static assert (is(Arg == Slice!(N, Range), size_t N, Range), msg);
@@ -1349,7 +1682,7 @@ template ndEqual(alias pred)
                         goto False;
             }
         }
-        return ndAll!pred(tensors);
+        return ndAll!(pred, select)(tensors);
         False: return false;
     }
 }
@@ -1357,6 +1690,7 @@ template ndEqual(alias pred)
 ///
 @safe pure nothrow @nogc unittest
 {
+    import std.experimental.ndslice.slice : slice;
     import std.experimental.ndslice.iteration : dropBackOne;
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -1372,7 +1706,33 @@ template ndEqual(alias pred)
 
     assert(!ndEqual!"a == b"(sl1.dropBackOne!0, sl1));
     assert(!ndEqual!"a == b"(sl1.dropBackOne!1, sl1));
+}
 
+/// check if matrix is symmetric
+pure nothrow unittest
+{
+    import std.experimental.ndslice.slice : slice;
+    import std.experimental.ndslice.iteration : transposed;
+
+    auto a = slice!double(3, 3);
+    a[] = [[1, 3, 4],
+           [3, 5, 8],
+           [4, 8, 2]];
+
+    alias isSymmetric = matrix => ndEqual!("a == b", Select.triangular)(matrix, matrix.transposed);
+
+    assert(isSymmetric(a));
+
+    a[0, 0] = double.nan;
+    assert(!isSymmetric(a)); // nan != nan
+    a[0, 0] = 1;
+
+    a[1, 0] = 2;
+    assert(!isSymmetric(a)); // 2 != 3
+    a[1, 0] = 3;
+
+    a.popFront;
+    assert(!isSymmetric(a)); // a is not square
 }
 
 /++

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -36,6 +36,10 @@ Thus, `assumeSameStructure` may significantly optimize iteration.
 If tensors have different strides, then most of existing operators in this module still
 can be used as they accept a set of tensors instead of single one.
 
+$(H3 Selection)
+$(LREF Select) allows to specify subset of elements to iterate.
+$(LREF Select) is useful in combination with $(SUBREF iteration, transposed) and $(SUBREF iteration, reversed).
+
 Note:
     $(SUBREF iteration, transposed) and
     $(SUBREF selection, pack) can be used to specify dimensions.
@@ -550,15 +554,15 @@ private template implement(Iteration iteration, alias fun, Flag!"vectorized" vec
 }
 
 /++
-Selection type,
+Selection type.
 `Select` can be used with
-$(MREF ndReduce),
-$(MREF ndEach),
-$(MREF ndFind),
-$(MREF ndAny),
-$(MREF ndAll),
-$(MREF ndEqual),
-$(MREF ndCmp).
+$(LREF ndReduce),
+$(LREF ndEach),
+$(LREF ndFind),
+$(LREF ndAny),
+$(LREF ndAll),
+$(LREF ndEqual),
+$(LREF ndCmp).
 
 Any dimension count is supported.
 Types has examples for 1D, 2D, and 3D cases.

--- a/std/experimental/ndslice/algorithm.d
+++ b/std/experimental/ndslice/algorithm.d
@@ -600,7 +600,7 @@ template ndReduce(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastma
         return ndReduceImpl!(false, Args[0].N, false, staticMap!(Unqual, S))(seed, tensors);
     }
 
-    static if(fm)
+    static if (fm)
         alias attr = fastmath;
     else
         alias attr = fastmathDummy;
@@ -812,7 +812,7 @@ template ndEach(alias fun, Flag!"vectorized" vec = No.vectorized, Flag!"fastmath
         return ndEachImpl!(false, Args[0].N, false)(tensors);
     }
 
-    static if(fm)
+    static if (fm)
         alias attr = fastmath;
     else
         alias attr = fastmathDummy;

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -15,9 +15,7 @@ else
 }
 
 enum FastmathDummy { init }
-FastmathDummy fastmathDummy() { return FastmathDummy.init; };
-
-alias RangeOf(T : Slice!(N, Range), size_t N, Range) = Range;
+FastmathDummy fastmathDummy() { return FastmathDummy.init; }
 
 template isMemory(T)
 {
@@ -37,6 +35,10 @@ template isMemory(T)
     else
         enum isMemory = false;
 }
+
+package:
+
+alias RangeOf(T : Slice!(N, Range), size_t N, Range) = Range;
 
 unittest
 {

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -2,10 +2,52 @@ module std.experimental.ndslice.internal;
 
 import std.traits;
 import std.meta; //: AliasSeq, anySatisfy, Filter, Reverse;
+import std.experimental.ndslice : Slice;
 
-package:
+version(LDC)
+{
+    static import ldc.attributes;
+    alias fastmath = ldc.attributes.fastmath;
+}
+else
+{
+    alias fastmath = fastmathDummy;
+}
 
-alias isMemory = isPointer;
+enum FastmathDummy { init }
+FastmathDummy fastmathDummy() { return FastmathDummy.init; };
+
+alias RangeOf(T : Slice!(N, Range), size_t N, Range) = Range;
+
+template isMemory(T)
+{
+    import std.experimental.ndslice.slice : PtrTuple;
+    import std.experimental.ndslice.algorithm : Map, Pack;
+    static if (isPointer!T)
+        enum isMemory = true;
+    else
+    static if (is(T : Map!(Range, fun), Range, alias fun))
+        enum isMemory = .isMemory!Range;
+    else
+    static if (__traits(compiles, __traits(isSame, PtrTuple, TemplateOf!(TemplateOf!T))))
+        static if (__traits(isSame, PtrTuple, TemplateOf!(TemplateOf!T)))
+            enum isMemory = allSatisfy!(.isMemory, TemplateArgsOf!T);
+        else
+            enum isMemory = false;
+    else
+        enum isMemory = false;
+}
+
+unittest
+{
+    import std.experimental.ndslice.slice : PtrTuple;
+    import std.experimental.ndslice.algorithm : Map;
+    static assert(isMemory!(int*));
+    alias R = PtrTuple!("a", "b");
+    alias F = R!(double*, double*);
+    static assert(isMemory!F);
+    static assert(isMemory!(Map!(F, a => a)));
+}
 
 enum indexError(size_t pos, size_t N) =
     "index at position " ~ pos.stringof

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -75,11 +75,11 @@ $(SCRIPT inhibitQuickIndex = 1;)
 
 $(DIVC quickindex,
 $(BOOKTABLE ,
-$(TR $(TH Category) $(TH Submodule) $(TH Declarations)
-)
-$(TR $(TDNW Basic Level
+
+$(TR $(TH Submodule) $(TH Declarations))
+
+$(TR $(TDNW $(SUBMODULE slice)
         $(BR) $(SMALL $(SUBREF slice, Slice), its properties, operator overloading))
-     $(TDNW $(SUBMODULE slice))
      $(TD
         $(SUBREF slice, sliced)
         $(SUBREF slice, Slice)
@@ -95,9 +95,8 @@ $(TR $(TDNW Basic Level
         $(SUBREF slice, SliceException)
     )
 )
-$(TR $(TDNW Medium Level
-        $(BR) $(SMALL Various iteration operators))
-     $(TDNW $(SUBMODULE iteration))
+$(TR $(TDNW $(SUBMODULE iteration)
+        $(BR) $(SMALL Basic iteration operators))
      $(TD
         $(SUBREF iteration, transposed)
         $(SUBREF iteration, strided)
@@ -109,10 +108,9 @@ $(TR $(TDNW Medium Level
         $(SUBREF iteration, dropToHypercube) and other `drop` primitives
     )
 )
-$(TR $(TDNW Advanced Level $(BR)
-        $(SMALL Abstract operators for loop free programming
-            $(BR) Take `movingWindowByChannel` as an example))
-     $(TDNW $(SUBMODULE selection))
+
+$(TR $(TDNW $(SUBMODULE selection)
+        $(BR) $(SMALL Subspace manipulations $(BR) Operators for loop free programming))
      $(TD
         $(SUBREF selection, blocks)
         $(SUBREF selection, windows)
@@ -128,6 +126,22 @@ $(TR $(TDNW Advanced Level $(BR)
         $(SUBREF selection, ReshapeException)
     )
 )
+
+$(TR $(TDNW $(SUBMODULE algorithm)
+        $(BR) $(SMALL Computation algorithms $(BR) Operators for loop free programming))
+     $(TD
+        $(SUBREF algorithm, ndMap)
+        $(SUBREF algorithm, ndFold)
+        $(SUBREF algorithm, ndReduce)
+        $(SUBREF algorithm, ndEach)
+        $(SUBREF algorithm, ndFind)
+        $(SUBREF algorithm, ndAny)
+        $(SUBREF algorithm, ndAll)
+        $(SUBREF algorithm, ndEqual)
+        $(SUBREF algorithm, ndCmp)
+    )
+)
+
 ))
 
 $(H2 Example: Image Processing)
@@ -168,12 +182,9 @@ Returns:
 Slice!(3, C*) movingWindowByChannel(alias filter, C)
 (Slice!(3, C*) image, size_t nr, size_t nc)
 {
-    import std.algorithm.iteration : map;
-    import std.array : array;
-
         // 0. 3D
         // The last dimension represents the color channel.
-    auto wnds = image
+    return image
         // 1. 2D composed of 1D
         // Packs the last dimension.
         .pack!1
@@ -188,21 +199,11 @@ Slice!(3, C*) movingWindowByChannel(alias filter, C)
         .transposed!(0, 1, 4)
         // 5. 3D Composed of 2D
         // Packs the last two dimensions.
-        .pack!2;
-
-    return wnds
-        // 6. Range composed of 2D
-        // Gathers all windows in the range.
-        .byElement
-        // 7. Range composed of pixels
+        .pack!2
         // 2D to pixel lazy conversion.
-        .map!filter
-        // 8. `C[]`
-        // The only memory allocation in this function.
-        .array
-        // 9. 3D
-        // Returns slice with corresponding shape.
-        .sliced(wnds.shape);
+        .ndMap!filter
+        // Creates the new image. The only memory allocation in this function.
+        .slice;
 }
 -------
 
@@ -217,15 +218,16 @@ Params:
 Returns:
     median value over the range `r`
 +/
-T median(Range, T)(Range r, T[] buf)
+T median(Range, T)(Slice!(2, Range) sl, T[] buf)
 {
     import std.algorithm.sorting : topN;
-    size_t n;
-    foreach (e; r)
-        buf[n++] = e;
-    auto m = n >> 1;
-    buf[0 .. n].topN(m);
-    return buf[m];
+    import std.experimental.ndslice.algorithm : ndFold;
+    // copy sl to the buffer
+    auto retPtr = sl.ndFold!((ptr, elem)
+        { *ptr = elem; return ptr + 1; })(buf.ptr);
+    auto n = retPtr - buf.ptr;
+    buf[0 .. n].topN(n / 2);
+    return buf[n / 2];
 }
 -------
 
@@ -263,7 +265,7 @@ void main(string[] args)
         auto ret = image.pixels
             .sliced(cast(size_t)image.h, cast(size_t)image.w, cast(size_t)image.c)
             .movingWindowByChannel
-                !(window => median(window.byElement, buf))
+                !(window => median(window, buf))
                  (nr, nc);
 
         write_image(
@@ -310,16 +312,17 @@ Acknowledgements:   John Loughran Colvin
 Source:    $(PHOBOSSRC std/_experimental/_ndslice/_package.d)
 
 Macros:
-SUBMODULE = $(MREF std, experimental, ndslice, $1)
+SUBMODULE = $(MREF_ALTTEXT $1, std, experimental, ndslice, $1)
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, std,experimental, ndslice, $1)$(NBSP)
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
-T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
+TDNW2 = <td class="donthyphenate nobr" rowspan="2">$0</td>
 */
 module std.experimental.ndslice;
 
 public import std.experimental.ndslice.slice;
 public import std.experimental.ndslice.iteration;
 public import std.experimental.ndslice.selection;
+public import std.experimental.ndslice.algorithm;
 
 unittest
 {
@@ -339,30 +342,29 @@ unittest
     static Slice!(3, ubyte*) movingWindowByChannel
     (Slice!(3, ubyte*) image, size_t nr, size_t nc, ubyte delegate(Slice!(2, ubyte*)) filter)
     {
-        import std.algorithm.iteration : map;
-        import std.array : array;
-        auto wnds = image
+        return image
             .pack!1
             .windows(nr, nc)
             .unpack
             .transposed!(0, 1, 4)
-            .pack!2;
-        return wnds
-            .byElement
-            .map!filter
-            .array
-            .sliced(wnds.shape);
+            .pack!2
+            .ndMap!filter
+            .slice;
     }
 
-    static T median(Range, T)(Range r, T[] buf)
+    static T median(Range, T)(Slice!(2, Range) sl, T[] buf)
     {
         import std.algorithm.sorting : topN;
-        size_t n;
-        foreach (e; r)
-            buf[n++] = e;
-        auto m = n >> 1;
-        buf[0 .. n].topN(m);
-        return buf[m];
+        import std.experimental.ndslice.algorithm : ndFold;
+        // copy sl to the buffer
+        auto retPtr = sl.ndFold!(
+            (ptr, elem) {
+                *ptr = elem;
+                return ptr + 1;
+            } )(buf.ptr);
+        auto n = retPtr - buf.ptr;
+        buf[0 .. n].topN(n / 2);
+        return buf[n / 2];
     }
 
     import std.conv : to;
@@ -390,7 +392,7 @@ unittest
     {
         auto ret =
             movingWindowByChannel
-                 (new ubyte[300].sliced(10, 10, 3), nr, nc, window => median(window.byElement, buf));
+                 (new ubyte[300].sliced(10, 10, 3), nr, nc, window => median(window, buf));
     }
 }
 

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1986,6 +1986,7 @@ struct Slice(size_t _N, _Range)
         return ndCmp(this.unpack, rslice.unpack);
     }
 
+    static if(doUnittest)
     ///
     @safe pure nothrow @nogc unittest
     {

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1677,7 +1677,7 @@ struct Slice(size_t _N, _Range)
     /++
     Returns: `true` if for any dimension the length equals to `0`, and `false` otherwise.
     +/
-    bool anyEmpty()
+    bool anyEmpty() const
     {
         foreach (i; Iota!(0, N))
             if (_lengths[i] == 0)

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -1986,7 +1986,7 @@ struct Slice(size_t _N, _Range)
         return ndCmp(this.unpack, rslice.unpack);
     }
 
-    static if(doUnittest)
+    static if (doUnittest)
     ///
     @safe pure nothrow @nogc unittest
     {

--- a/win32.mak
+++ b/win32.mak
@@ -331,6 +331,7 @@ SRC_STD_EXP_LOGGER= \
 
 SRC_STD_EXP_NDSLICE= \
 	std\experimental\ndslice\package.d \
+	std\experimental\ndslice\algorithm.d \
 	std\experimental\ndslice\iteration.d \
 	std\experimental\ndslice\selection.d \
 	std\experimental\ndslice\slice.d \
@@ -528,6 +529,7 @@ DOCS= \
 	$(DOC)\std_experimental_allocator_showcase.html \
 	$(DOC)\std_experimental_allocator_typed.html \
 	$(DOC)\std_experimental_allocator.html \
+	$(DOC)\std_experimental_ndslice_algorithm.html \
 	$(DOC)\std_experimental_ndslice_iteration.html \
 	$(DOC)\std_experimental_ndslice_selection.html \
 	$(DOC)\std_experimental_ndslice_slice.html \
@@ -1072,6 +1074,9 @@ $(DOC)\std_experimental_allocator.html : $(STDDOC) std\experimental\allocator\pa
 
 $(DOC)\std_experimental_typecons.html : $(STDDOC) std\experimental\typecons.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_typecons.html $(STDDOC) std\experimental\typecons.d
+
+$(DOC)\std_experimental_ndslice_algorithm.html : $(STDDOC) std\experimental\ndslice\algorithm.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_algorithm.html $(STDDOC) std\experimental\ndslice\algorithm.d
 
 $(DOC)\std_experimental_ndslice_iteration.html : $(STDDOC) std\experimental\ndslice\iteration.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_iteration.html $(STDDOC) std\experimental\ndslice\iteration.d

--- a/win64.mak
+++ b/win64.mak
@@ -353,6 +353,7 @@ SRC_STD_EXP_LOGGER= \
 
 SRC_STD_EXP_NDSLICE= \
 	std\experimental\ndslice\package.d \
+	std\experimental\ndslice\algorithm.d \
 	std\experimental\ndslice\iteration.d \
 	std\experimental\ndslice\selection.d \
 	std\experimental\ndslice\slice.d \
@@ -551,6 +552,7 @@ DOCS= \
 	$(DOC)\std_experimental_allocator_typed.html \
 	$(DOC)\std_experimental_allocator.html \
 	$(DOC)\std_experimental_ndslice_iteration.html \
+	$(DOC)\std_experimental_ndslice_algorithm.html \
 	$(DOC)\std_experimental_ndslice_selection.html \
 	$(DOC)\std_experimental_ndslice_slice.html \
 	$(DOC)\std_experimental_ndslice.html \
@@ -1050,6 +1052,9 @@ $(DOC)\std_experimental_allocator.html : $(STDDOC) std\experimental\allocator\pa
 
 $(DOC)\std_experimental_typecons.html : $(STDDOC) std\experimental\typecons.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_typecons.html $(STDDOC) std\experimental\typecons.d
+
+$(DOC)\std_experimental_ndslice_algorithm.html : $(STDDOC) std\experimental\ndslice\algorithm.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_algorithm.html $(STDDOC) std\experimental\ndslice\algorithm.d
 
 $(DOC)\std_experimental_ndslice_iteration.html : $(STDDOC) std\experimental\ndslice\iteration.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_iteration.html $(STDDOC) std\experimental\ndslice\iteration.d


### PR DESCRIPTION
PR is available in Mir >=v0.16.0-alpha7
Benchmarks: https://github.com/libmir/mir/tree/master/benchmarks/ndslice
Docs: http://docs.mir.dlang.io/latest/mir_ndslice_algorithm.html

### Difference with `std.algorithm`
1. It supports multidimensional iteration and map (`ndMap`) out of the box
2. It supports multidimensional `zip` analog - `assumeSameStructure`, which is faster
3. It allows to iterate efficiently multiple tensors without `zip`/`assumeSameStructure`
4. It allows to use vectorization if the last stride == 1 (two versions of algorithms with RT check).
5. It allows to select triangular part of the data or half of the data

### ndslice.algorithm

- [x] `ndMap` (multidimensional map type of `Slice(N, xxx)`)
- [x] `ndFold` (single tensor, multiple functions and seeds)
- [x] `ndReduce` (single seed, multiple tensors)
  - [x] Add `vectorization` and `fastmath` flags
- [x] `ndEach` (no seed, multiple tensors)
  - [x] Add `vectorization` and `fastmath` flags
- [x] `ndAll` (multiple tensors)
- [x] `ndAny` (multiple tensors)
- [x] `ndFind` (multiple tensors) [reworked]
- [x] `ndCmp` (multidimensional propagation)
- [x] `ndEqual` (multiple tensors)

`ndCanFindNeedle` and `ndFindNeedle` was removed.

### ndslice.slice
- [x] optimize memory allocations using `ndFold`. 
- [x] add `opCmp` using `ndCmp`

### ndslice.package
 - [x] Update example

## See Also
https://github.com/ldc-developers/ldc/issues/1669

## Asked Questions

> What if I want to implement my own algorithm that is not part of Phobos? It seems like I would want to be able to use LikePtr in such a situation to interface seamlessly with the rest of ndslice.

You can use random access range interface and sliced function. @LikePtr is for optimisation reasons. It may be exposed in the future, but I need to write a proper documentation of how it should be used first. The number of use cases for @LikePtr is very small, and all of them seems should be a part of the package.

> To come back to the bigger picture: Do we really need nd versions of all "scalar" functions like each, all, any and so on?

Yes, but not _all_ "scalar" functions should be adopted. Current list of functions is enough.
For example:

1. We do not need special sorting algorithms, because we need flattened slice anyway. If a slice is not flattened user may use `byElement` to get random access range of all elements or make a copy/index.

2. We don't need `ndSwap(a, b)` because we can just do `ndEach!swap(a, b)`.
3. We don't need `ndCount` because it can be easily implemented with `ndReduce`.

> I understand why map might be a bit non-trivial – it needs to preserve the input structure in the output. But wouldn't it be much more powerful and DRYer to offer a "flat" range interface for the operations for which structure is irrelevant? For example, in pseudocode ndAll!fun(a, b) == all!fun(zip(a.flattened, b.flattened)) (discounting for tuple expansion of the fun parameters). I suppose something like that probably even exists in ndslice already.

Yes, for performance reasons. `flattened` is called `byElement`, it is selector operator.

> I'm sure this has crossed your mind while designing the functions – why did you opt to go for the special ndslice variants instead? Potentially using the extra structural information for extra performance? (If it only comes down to auto-vectorization, that shouldn't really matter, though.) You could also think about adding annotation forwarding support of some kind (extra members, UDAs, …) to the length-preserving std.algorithm functions to propagate along the structure information.

I add this module because performance reasons. N is dimension count:

1. `byElement` requires additional computations :
    - One more `add` operations for forward access (empty, front, popFront).
    - N-1 `div`/`mod` pairs plus 2*N-1 more `add` for random and backward access. `div`/`mod` are expensive.
2. `byElement` requires N+1 additional general purpose registers. This is bad for iterating few matrixes in the lockstep.
3. ndX implementations has multidimension do-while loop optimisation.

> ndMap could also be implemented by reshape ∘ map ∘ reshape, I suppose.

This is true only for Slices, which have continues in-memory representation. Numpy just copies all ndarray, if the ndarray can not be reshaped.

The result of `ndMap` is a `Slice`. The result of `map` is the range, and if we want to use ndslice module with `map`, we need to `sliced` again. The real problem is that `byElement` has slow random access primitive to build a slice on top :
```d
auto lazyMap = sl.byElement.map!fun.sliced(sl.shape);
```

```d
auto lazyMap = sl.ndMap!fun;
```
In the same time #4647 provides vectorised  operations like `+=`, this PR also have vectorised algorithms. In addition, Mir will have BLAS soon, see [current benchmark](https://s3.amazonaws.com/media-p.slid.es/uploads/546207/images/2854632/Untitled_2.004.png). Mir has the same performance for large matrixes as OpenBLAS, this means that Mir's generic gemm SIMD kernels are optimal. For small matrixes I need to write generic SIMD transposition kernels for packing, but this is small effort comparing with gemm SIMD kernels.

> Being very much a bystander only—so this might be entirely unfounded—it seems like there is some danger of ndslice bit-by-bit involving into its own little parallel universe. To put it in a slightly more cynical way, if we can't use standard ranges to implement any on a multidimensional array ourselves, we might need to revise our marketing materials.

I don't think so. ndslice extends our universe. We have different types of ranges. ndslice is just the next after random access range:

1. Any slice is random access range composed of elements with dimension equals to N-1.
2. `byElement` is random access range, with fast forward iteration (as much fast as possible with Range API).
3. Slice can be created on top of any random access range with length. For example DOK format for sparse tensors was implemented in Mir, just creating a tiny wrapper on standard associative arrays.
4. ndX functions provide optimal multidimensional iteration pattern. We don't need `ndSwap` for example, because we can just write `ndEach!swap`. So, please do not think that I am rewriting std.algorithm: current functions provide only optimal loop construction with different stop criteria. 

