### PR TITLE
file.d: fix unsafe use of .ptr

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -367,7 +367,8 @@ version (Windows) private void[] readImpl(const(char)[] name, const(FSChar)* nam
         () @trusted { delete buf; } ();
     }
 
-    cenforce(trustedReadFile(h, buf.ptr, size), name, namez);
+    if (size)
+        cenforce(trustedReadFile(h, &buf[0], size), name, namez);
     return buf[0 .. size];
 }
 


### PR DESCRIPTION
endless cases of these.
Blocks https://github.com/dlang/dmd/pull/5860