### PR TITLE
fix docs in algorithm.iteration

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2591,7 +2591,7 @@ See_Also:
     to use in UFCS chains.
 
     $(LREF sum) is similar to $(D reduce!((a, b) => a + b)) that offers
-    precise summing of floating point numbers.
+    pairwise summing of floating point numbers.
 +/
 template reduce(fun...) if (fun.length >= 1)
 {


### PR DESCRIPTION
`sum` is not precise. Precise algorithms are Python `fsum` and Mir's [`sum!(Summation.precise)`](http://docs.mir.dlang.io/latest/mir_sum.html)
