### PR TITLE
Fix issue 16331 - std.container.array should allow uncomparable values

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -431,7 +431,6 @@ Constructor taking a number of items
         foreach (i, e; values)
         {
             emplace(p + i, e);
-            assert(p[i] == e);
         }
         _data = Data(p[0 .. values.length]);
     }
@@ -2234,4 +2233,11 @@ unittest
     assert(slice.moveFront == true);
     assert(slice.moveBack == true);
     assert(slice.moveAt(1) == true);
+}
+
+// issue 16331 - uncomparable values are valid values for an array
+unittest
+{
+    double[] values = [double.nan, double.nan];
+    auto arr = Array!double(values);
 }


### PR DESCRIPTION
Working with `std.container` is a huge pain as one bumps into bugs all the time :/

Are there any plan yet to rewrite this module?, e.g.  [emsi's container](https://github.com/economicmodeling/containers) could be a a good start.