### PR TITLE
Removed auto-decoding from std.conv.parse (part 2)

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -5,6 +5,9 @@ $(COMMENT Pending changelog for 2.073. This will get copied to dlang.org and
 )
 
 $(BUGSTITLE Library Changes,
+    $(LI Conversions from strings to number types using $(REF to, std,conv)
+        and $(REF parse, std,conv) were optimized. On average, integer types
+        are three times faster, and floating point types are 40% faster.)
 )
 
 $(BUGSTITLE Library Changes,


### PR DESCRIPTION
Benchmark code here: https://gist.github.com/JackStouffer/af53d497532a864f56a5b53cb35cd438

Gives about a 40% speed increase:

```
# old
$ ldc2 -O5 -release -boundscheck=off test.d && ./test
Total time: 5 secs, 266 ms, 64 μs, and 3 hnsecs

# new
$ ldc2 -O5 -release -boundscheck=off test.d && ./test
Total time: 3 secs, 295 ms, 663 μs, and 7 hnsecs
```
