### PR TITLE
Propagate attributes in std.allocator.make{,Array} [revived]

### DIFF
--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -21,7 +21,7 @@ struct GCAllocator
     deallocate) and $(D reallocate) methods are $(D @system) because they may
     move memory around, leaving dangling pointers in user code.
     */
-    @trusted void[] allocate(size_t bytes) shared
+    pure nothrow @trusted void[] allocate(size_t bytes) shared const
     {
         if (!bytes) return null;
         auto p = GC.malloc(bytes);
@@ -52,7 +52,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool reallocate(ref void[] b, size_t newSize) shared
+    pure nothrow @system bool reallocate(ref void[] b, size_t newSize) shared const
     {
         import core.exception : OutOfMemoryError;
         try
@@ -69,7 +69,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    void[] resolveInternalPointer(void* p) shared
+    pure nothrow void[] resolveInternalPointer(void* p) shared
     {
         auto r = GC.addrOf(p);
         if (!r) return null;
@@ -77,7 +77,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool deallocate(void[] b) shared
+    pure nothrow @system bool deallocate(void[] b) shared const
     {
         GC.free(b.ptr);
         return true;
@@ -106,11 +106,10 @@ struct GCAllocator
     allocator is thread-safe, therefore all of its methods and `instance` itself
     are $(D shared).
     */
-
     static shared GCAllocator instance;
 
     // Leave it undocummented for now.
-    @trusted void collect() shared
+    nothrow @trusted void collect() shared
     {
         GC.collect();
     }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -22,8 +22,7 @@ struct Mallocator
     paradoxically, $(D malloc) is $(D @safe) but that's only useful to safe
     programs that can afford to leak memory allocated.
     */
-    @trusted @nogc nothrow
-    void[] allocate(size_t bytes) shared
+    nothrow @nogc @trusted void[] allocate(size_t bytes) shared
     {
         import core.stdc.stdlib : malloc;
         if (!bytes) return null;
@@ -32,8 +31,7 @@ struct Mallocator
     }
 
     /// Ditto
-    @system @nogc nothrow
-    bool deallocate(void[] b) shared
+    nothrow @nogc @system bool deallocate(void[] b) shared
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
@@ -41,8 +39,7 @@ struct Mallocator
     }
 
     /// Ditto
-    @system @nogc nothrow
-    bool reallocate(ref void[] b, size_t s) shared
+    nothrow @nogc @system bool reallocate(ref void[] b, size_t s) shared
     {
         import core.stdc.stdlib : realloc;
         if (!s)


### PR DESCRIPTION
Awoken from the dead - here's a second comeback of #3031, after #3891 was abandoned.

The general idea is that
`make` and `makeArray` can be `pure nothrow @safe` for the `GCAllocator` and
`nothrow @safe @nogc` for other allocators.

The approach of @JakobOvrum is a bit strict as it requires `pure` constructors,
if anyone has an idea how we could widen this restriction, don't hesitate to share.
Moreover it doesn't work yet with Classes.