### PR TITLE
std.algorithm.sorting: enable CTFE test for Timsort

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2085,8 +2085,7 @@ unittest
     enum seed = 310614065;
     testSort(seed);
 
-    //@@BUG: Timsort fails with CTFE as of DMD 2.060
-    // enum result = testSort(seed);
+    enum result = testSort(seed);
 }
 
 unittest


### PR DESCRIPTION
Saw this while looking through the code,  seems like DMD has evolved since 2.060 ;-)