### PR TITLE
[trivial] Fix docs for NullAllocator

### DIFF
--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -16,7 +16,7 @@ struct NullAllocator
     shouldn't be unnecessarily constrained.
     */
     enum uint alignment = 64 * 1024;
-    /// Returns $(D n).
+    // /// Returns $(D n).
     //size_t goodAllocSize(size_t n) shared const
     //{ return .goodAllocSize(this, n); }
     /// Always returns $(D null).


### PR DESCRIPTION
Commented out documentation for the commented out function goodAllocSize in NullAllocator

Previously, the docs showed the additional line "Returns n.". This documentation comment belongs to the goodAllocSize function, which is commented out, so commented out the doc comment, too.