### PR TITLE
Add toHash to SysTime

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1091,15 +1091,15 @@ public:
             enum ulong n = m * 16;
             enum uint r = 47;
 
-            ulong h = n;
-
             ulong k = _stdTime;
             k *= m;
             k ^= k >> r;
             k *= m;
 
+            ulong h = n;
             h ^= k;
             h *= m;
+
             return cast(size_t) h;
         }
     }
@@ -1109,6 +1109,30 @@ public:
         assert(SysTime(0).toHash == SysTime(0).toHash);
         assert(SysTime(0, LocalTime()).toHash == SysTime(0, LocalTime()).toHash);
         assert(SysTime(0, LocalTime()).toHash == SysTime(0, UTC()).toHash);
+
+        assert(
+            SysTime(
+                DateTime(2000, 1, 1), LocalTime()
+            ).toHash == SysTime(
+                DateTime(2000, 1, 1), LocalTime()
+            ).toHash
+        );
+
+        immutable zone = new SimpleTimeZone(dur!"minutes"(60));
+        assert(
+            SysTime(
+                DateTime(2000, 1, 1, 1), zone
+            ).toHash == SysTime(
+                DateTime(2000, 1, 1), UTC()
+            ).toHash
+        );
+        assert(
+            SysTime(
+                DateTime(2000, 1, 1), LocalTime()
+            ).toHash != SysTime(
+                DateTime(2000, 1, 1), UTC()
+            ).toHash
+        );
     }
 
     /++

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1107,9 +1107,12 @@ public:
     @safe unittest
     {
         assert(SysTime(0).toHash == SysTime(0).toHash);
+        assert(SysTime(DateTime(2000, 1, 1)).toHash == SysTime(DateTime(2000, 1, 1)).toHash);
+        assert(SysTime(DateTime(2000, 1, 1)).toHash != SysTime(DateTime(2000, 1, 2)).toHash);
+
+        // test that timezones aren't taken into account
         assert(SysTime(0, LocalTime()).toHash == SysTime(0, LocalTime()).toHash);
         assert(SysTime(0, LocalTime()).toHash == SysTime(0, UTC()).toHash);
-
         assert(
             SysTime(
                 DateTime(2000, 1, 1), LocalTime()
@@ -1117,7 +1120,6 @@ public:
                 DateTime(2000, 1, 1), LocalTime()
             ).toHash
         );
-
         immutable zone = new SimpleTimeZone(dur!"minutes"(60));
         assert(
             SysTime(
@@ -1128,7 +1130,7 @@ public:
         );
         assert(
             SysTime(
-                DateTime(2000, 1, 1), LocalTime()
+                DateTime(2000, 1, 1), zone
             ).toHash != SysTime(
                 DateTime(2000, 1, 1), UTC()
             ).toHash

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1105,10 +1105,9 @@ public:
 
     @safe unittest
     {
-        assert(SysTime(DateTime.init, UTC()).toHash == SysTime(0, UTC()).toHash);
-        assert(SysTime(DateTime.init, UTC()).toHash == SysTime(0).toHash);
-        assert(SysTime(Date.init, UTC()).toHash == SysTime(0).toHash);
         assert(SysTime(0).toHash == SysTime(0).toHash);
+        assert(SysTime(0, LocalTime()).toHash == SysTime(0, LocalTime()).toHash);
+        assert(SysTime(0, LocalTime()).toHash == SysTime(0, UTC()).toHash);
     }
 
     /++

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1086,20 +1086,21 @@ public:
         }
         else
         {
-            enum uint m = 0x5bd1e995;
-            enum uint n = 16;
-            enum uint r = 24;
-            uint h = n;
-            long k = _stdTime;
+            // MurmurHash2
+            enum ulong m = 0xc6a4a7935bd1e995UL;
+            enum ulong n = m * 16;
+            enum uint r = 47;
 
+            ulong h = n;
+
+            ulong k = _stdTime;
             k *= m;
             k ^= k >> r;
             k *= m;
 
-            h *= m;
             h ^= k;
-
-            return h;
+            h *= m;
+            return cast(size_t) h;
         }
     }
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1075,6 +1075,42 @@ public:
         //assert(ist.opCmp(ist) == 0);
     }
 
+    /**
+     * Returns: A hash of the $(LREF SysTime)
+     */
+    size_t toHash() const @nogc pure nothrow @safe
+    {
+        static if (is(size_t == ulong))
+        {
+            return _stdTime;
+        }
+        else
+        {
+            enum uint m = 0x5bd1e995;
+            enum uint n = 16;
+            enum uint r = 24;
+            uint h = n;
+            long k = _stdTime;
+
+            k *= m;
+            k ^= k >> r;
+            k *= m;
+
+            h *= m;
+            h ^= k;
+
+            return h;
+        }
+    }
+
+    @safe unittest
+    {
+        assert(SysTime(DateTime.init, UTC()).toHash == SysTime(0, UTC()).toHash);
+        assert(SysTime(DateTime.init, UTC()).toHash == SysTime(0).toHash);
+        assert(SysTime(Date.init, UTC()).toHash == SysTime(0).toHash);
+        assert(SysTime(0).toHash == SysTime(0).toHash);
+    }
+
     /++
         Year of the Gregorian Calendar. Positive numbers are A.D. Non-positive
         are B.C.


### PR DESCRIPTION
SysTime's opEquals only compares the _stdTime member, so do that for toHash as well.