### PR TITLE
std.experimental.allocator.scoped_allocator: Fix double free

### DIFF
--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -29,7 +29,7 @@ struct ScopedAllocator(ParentAllocator)
 
     private struct Node
     {
-        Node* prev;
+        Node** prev;
         Node* next;
         size_t length;
     }
@@ -86,8 +86,9 @@ struct ScopedAllocator(ParentAllocator)
         auto b = parent.allocate(n);
         if (!b.ptr) return b;
         Node* toInsert = & parent.prefix(b);
-        toInsert.prev = null;
+        toInsert.prev = &root;
         toInsert.next = root;
+        if (root) root.prev = &toInsert.next;
         toInsert.length = n;
         root = toInsert;
         return b;
@@ -116,16 +117,15 @@ struct ScopedAllocator(ParentAllocator)
         if (b.ptr)
         {
             Node* n = & parent.prefix(b);
-            if (n.prev) n.prev.next = n.next;
-            else root = n.next;
-            if (n.next) n.next.prev = n.prev;
+            *(n.prev) = n.next;
+            if (n.next) n.next.prev = &n.next;
         }
         auto result = parent.reallocate(b, s);
         // Add back to list
         if (b.ptr)
         {
             Node* n = & parent.prefix(b);
-            n.prev = null;
+            n.prev = &root;
             n.next = root;
             n.length = s;
             root = n;
@@ -152,9 +152,8 @@ struct ScopedAllocator(ParentAllocator)
         if (b.ptr)
         {
             Node* n = & parent.prefix(b);
-            if (n.prev) n.prev.next = n.next;
-            else root = n.next;
-            if (n.next) n.next.prev = n.prev;
+            *(n.prev) = n.next;
+            if (n.next) n.next.prev = &n.next;
         }
         return parent.deallocate(b);
     }
@@ -194,9 +193,17 @@ unittest
     import std.typecons : Ternary;
     ScopedAllocator!Mallocator alloc;
     assert(alloc.empty == Ternary.yes);
-    const b = alloc.allocate(10);
+    auto b = alloc.allocate(10);
+    auto c = alloc.allocate(20);
     assert(b.length == 10);
+    assert(c.length == 20);
     assert(alloc.empty == Ternary.no);
+
+    alloc.deallocate(b);
+    assert(alloc.empty == Ternary.no);
+
+    alloc.deallocate(c);
+    assert(alloc.empty == Ternary.yes);
 }
 
 unittest


### PR DESCRIPTION
root.prev is not updated properly in scoped_allocator.allocate, causing potential double free.

Also uses double pointer to simplify the code a little.

Reference: http://forum.dlang.org/thread/lvzxnhgnjpttwdyzytbw@forum.dlang.org