### PR TITLE
fix .ptr safety problem in schwartzSort()

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2190,12 +2190,12 @@ schwartzSort(alias transform, alias less = "a < b",
         {
             foreach (i; 0 .. length) collectException(destroy(xform1[i]));
         }
-        static void trustedFree(T* p) @trusted
+        static void trustedFree(T[] p) @trusted
         {
             import core.stdc.stdlib : free;
-            free(p);
+            free(p.ptr);
         }
-        trustedFree(xform1.ptr);
+        trustedFree(xform1);
     }
     for (; length != r.length; ++length)
     {


### PR DESCRIPTION
Putting the schwartz back in `schwartsSort()`

Blocking https://github.com/dlang/dmd/pull/5860