### PR TITLE
Fix issue 16351

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3318,7 +3318,7 @@ void writeln(T...)(T args)
     {
         import std.exception : enforce;
 
-        enforce(fputc('\n', .trustedStdout._p.handle) == '\n', "fputc failed");
+        enforce(fputc('\n', .trustedStdout._p.handle) != EOF, "fputc failed");
     }
     else static if (T.length == 1 &&
                     is(typeof(args[0]) : const(char)[]) &&


### PR DESCRIPTION
When using nonstandard output libraries such as
https://github.com/sickill/stderred argumentless writeln() will fail on
the enforce because it check specifically for a newline to be returned.
Checking instead that the output is not EOF follows the documentation
and allows overridden write() functions from the standard library.