### PR TITLE
let transcode accept mutable/const characters

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2303,7 +2303,7 @@ body
 
 unittest // mutable/const input/output
 {
-    import std.meta: AliasSeq;
+    import std.meta : AliasSeq;
 
     foreach (O; AliasSeq!(Latin1Char, const Latin1Char, immutable Latin1Char))
     {

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2231,17 +2231,16 @@ body
 
         auto buffer = new Unqual!Dst[s.length];
         auto tmpBuffer = buffer;
-        const(Src)[] t = s;
 
-        while (t.length != 0)
+        while (s.length != 0)
         {
             if (tmpBuffer.length < minReservePlace)
             {
                 size_t prevLength = buffer.length;
-                buffer.length += t.length + minReservePlace;
+                buffer.length += s.length + minReservePlace;
                 tmpBuffer = buffer[prevLength - tmpBuffer.length .. $];
             }
-            EncoderInstance!(Unqual!Dst).encode(decode(t), tmpBuffer);
+            EncoderInstance!(Unqual!Dst).encode(decode(s), tmpBuffer);
         }
 
         r = cast(Dst[])buffer[0 .. buffer.length - tmpBuffer.length];


### PR DESCRIPTION
Because requiring immutable characters doesn't make sense.

See also <http://forum.dlang.org/post/noashv$1bgv$1@digitalmars.com>.

The second commit ("remove pointless variable t") is just a little cleanup I noticed when looking at this.