### PR TITLE
fix issue 16372 - Broken links in documentation

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1683,7 +1683,7 @@ is recommended if you want to process a complete file.
 
     /**
      * Read data from the file according to the specified
-     * $(LINK2 std_format.html#_format-string, format specifier) using
+     * $(LINK2 std_format.html#_format-string, _format specifier) using
      * $(REF formattedRead, std,_format).
      */
     uint readf(Data...)(in char[] format, Data data)
@@ -3562,7 +3562,7 @@ void writefln(T...)(T args)
 
 /**
  * Read data from $(D stdin) according to the specified
- * $(LINK2 std_format.html#format-string, format specifier) using
+ * $(LINK2 std_format.html#_format-string, _format specifier) using
  * $(REF formattedRead, std,_format).
  */
 uint readf(A...)(in char[] format, A args)


### PR DESCRIPTION
Also fixing another mistakenly highlighted "format".