### PR TITLE
fix issue 16386: std.concurrency: destructors called twice on objects passed as Message

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2405,9 +2405,14 @@ private
                 }
             }
             if (n)
-                *n = Node(v);
+            {
+                import std.conv : emplace;
+                emplace!Node(n, v);
+            }
             else
+            {
                 n = new Node(v);
+            }
             return n;
         }
 


### PR DESCRIPTION
Avoid the assignment operator on an object that has been destroyed, it will call the destructor again.