### PR TITLE
[WIP] Use test_runner for coverage testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{c,h,d,di,dd}]
+[*.{c,h,d,di,dd,sh}]
 end_of_line = lf
 insert_final_newline = true
 indent_style = space

--- a/circleci.sh
+++ b/circleci.sh
@@ -87,12 +87,12 @@ coverage()
     # remove all existing coverage files (just in case)
     rm -rf $(find -name '*.lst')
 
-	# currently using the test_runner yields wrong code coverage results
-	# see https://github.com/dlang/phobos/pull/4719 for details
-    #ENABLE_COVERAGE="1" make -f posix.mak MODEL=$MODEL unittest-debug
+    # currently using the test_runner yields wrong code coverage results
+    # see https://github.com/dlang/phobos/pull/4719 for details
+    ENABLE_COVERAGE="1" make -f posix.mak MODEL=$MODEL unittest-debug
 
-	# instead we run all tests individually
-	make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/" | grep -vE '(std.algorithm.sorting|std.encoding|net.curl)' )
+    # instead we run all tests individually
+    make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/" | grep -vE '(std.algorithm.sorting|std.encoding|net.curl)' )
 }
 
 case $1 in


### PR DESCRIPTION
As discussed in #4719 we have run into some troubles with the reporting of the coverage between the `test_runner` and individual tests. This PR is there to continue testing for this problem.

(while this PR will increase coverage, it does so by running both the `test_runner` and individual builds)