### PR TITLE
Fix emplace for inner classes

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -476,6 +476,19 @@ unittest
     assert(cust.id == uint.max); // default initialized
     cust = theAllocator.make!Customer(42);
     assert(cust.id == 42);
+
+    // explicit passing of outer pointer
+    static class Outer
+    {
+        int x = 3;
+        class Inner
+        {
+            auto getX() { return x; }
+        }
+    }
+    auto outer = theAllocator.make!Outer();
+    auto inner = theAllocator.make!(Outer.Inner)(outer);
+    assert(outer.x == inner.getX);
 }
 
 unittest // bugzilla 15639 & 15772

--- a/std/traits.d
+++ b/std/traits.d
@@ -46,6 +46,7 @@
  *           $(LREF hasNested)
  *           $(LREF hasUnsharedAliasing)
  *           $(LREF InterfacesTuple)
+ *           $(LREF isInnerClass)
  *           $(LREF isNested)
  *           $(LREF MemberFunctionsTuple)
  *           $(LREF RepresentationTypeTuple)
@@ -2036,8 +2037,11 @@ template isInnerClass(T)
 {
     import std.meta : staticIndexOf;
 
-    enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
-                     && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);
+    static if (is(typeof(T.outer)))
+        enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
+                         && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);
+    else
+        enum isInnerClass = false;
 }
 
 ///
@@ -2051,15 +2055,18 @@ template isInnerClass(T)
 
     class Outer1
     {
-        class Inner
+        class Inner1 { }
+        class Inner2
         {
+            int outer;
         }
     }
-    static assert(isInnerClass!(Outer1.Inner));
+    static assert(isInnerClass!(Outer1.Inner1));
+    static assert(!isInnerClass!(Outer1.Inner2));
 
-    class Outer2
+    static class Outer2
     {
-        class Inner
+        static class Inner
         {
             int outer;
         }


### PR DESCRIPTION
This changes `emplace` so that, when dealing with inner classes, the first argument after the memory pointer must be a pointer to an instance of the outer class, used to initialize the outer pointer of the emplaced object.
It also contains a related fix to `std.traits.isInnerClass`, which was recently introduced to address this issue.

Incidentally, this also solves issue 16319, representing a more complete solution wrt. #4732 , which this replaces.