### PR TITLE
[GSoC] [new package] Add std.experimental.xml package

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -162,7 +162,7 @@ P2MODULES=$(foreach P,$1,$(addprefix $P/,$(PACKAGE_$(subst /,_,$P))))
 STD_PACKAGES = std $(addprefix std/,\
   algorithm container digest experimental/allocator \
   experimental/allocator/building_blocks experimental/logger \
-  experimental/ndslice \
+  experimental/ndslice experimental/xml \
   net \
   experimental range regex)
 
@@ -189,6 +189,8 @@ PACKAGE_std_experimental_allocator_building_blocks = \
   kernighan_ritchie null_allocator package quantizer \
   region scoped_allocator segregator stats_collector
 PACKAGE_std_experimental_ndslice = package iteration selection slice
+PACKAGE_std_experimental_xml = package appender cursor dom domimpl domparser \
+  faststrings interfaces lexers parser sax validation writer
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \

--- a/std/experimental/xml/appender.d
+++ b/std/experimental/xml/appender.d
@@ -14,7 +14,7 @@ module std.experimental.xml.appender;
 /*
 *   Appender implementation that uses a custom allocator. Meant for internal usage.
 */
-struct Appender(T, Alloc)
+package struct Appender(T, Alloc)
 {
     import std.experimental.allocator;
     import std.array;

--- a/std/experimental/xml/appender.d
+++ b/std/experimental/xml/appender.d
@@ -1,0 +1,198 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   Appender implementation that uses a custom allocator. Meant for internal usage.
++/
+
+module std.experimental.xml.appender;
+
+/++
++   Appender implementation that uses a custom allocator. Meant for internal usage.
++/
+struct Appender(T, Alloc)
+{
+    import std.experimental.allocator;
+    import std.array;
+    import std.range.primitives;
+    import std.traits;
+
+    Alloc* allocator;
+    private Unqual!T[] arr;
+    private size_t used;
+
+    public this(ref Alloc alloc)
+    {
+        allocator = &alloc;
+    }
+    public this(Alloc* alloc)
+    {
+        allocator = alloc;
+    }
+
+    public void put(U)(U item)
+        if(!isInputRange!U)
+    {
+        static if (isSomeChar!T && isSomeChar!U && T.sizeof < U.sizeof)
+        {
+            import std.utf : encode, UseReplacementDchar;
+            Unqual!T[T.sizeof == 1 ? 4 : 2] encoded;
+            auto len = encode!(UseReplacementDchar.yes)(encoded, item);
+            put(encoded[0 .. len]);
+        }
+        else
+        {
+            ensureAddable(1);
+            arr[used++] = cast(T)item;
+        }
+    }
+
+    public void put(Range)(Range range)
+        if (isInputRange!Range)
+    {
+        static if (isSomeChar!T && is(Unqual!(ElementEncodingType!Range) == Unqual!T))
+        {
+            auto len = range.length;
+            ensureAddable(len);
+            arr[used..(used+len)] = range[];
+            used += len;
+        }
+        else static if (!(isSomeChar!T && isSomeChar!(ElementType!Range)) &&
+                    is(typeof(range.length) == size_t))
+        {
+            auto len = range.length;
+            ensureAddable(len);
+
+            static if (is(typeof(arr[] = range[])))
+            {
+                arr[used..(used+len)] = range[];
+            }
+            else
+            {
+                import std.conv : emplaceRef;
+                foreach (ref it ; arr[used..(used+len)])
+                {
+                    emplaceRef!T(it, range.front);
+                    range.popFront();
+                }
+            }
+            used += len;
+        }
+        else
+        {
+            // Generic input range
+            for (; !range.empty; range.popFront())
+            {
+                put(range.front);
+            }
+        }
+    }
+
+    private void ensureAddable(size_t sz)
+    {
+        import std.algorithm : max;
+
+        if (arr.length - used >= sz)
+            return;
+
+        auto requiredGrowth = sz + used - arr.length;
+
+        size_t delta;
+        if (arr.length == 0)
+            delta = max(8, requiredGrowth);
+        if (arr.length < 512)
+            delta = max(arr.length, requiredGrowth);
+        else
+            delta = max(arr.length/2, requiredGrowth);
+
+        if (!arr.length)
+        {
+            arr = allocator.makeArray!(Unqual!T)(delta);
+            assert(arr, "Could not allocate array");
+        }
+        else
+        {
+            auto done = allocator.expandArray(arr, delta);
+            assert(done, "Could not grow appender array");
+        }
+    }
+
+    /**
+     * Reserve at least newCapacity elements for appending.  Note that more elements
+     * may be reserved than requested.  If newCapacity <= capacity, then nothing is
+     * done.
+     */
+    void reserve(size_t newCapacity)
+    {
+        if (arr)
+        {
+            if (newCapacity > arr.length)
+                ensureAddable(newCapacity - used);
+        }
+        else
+        {
+            ensureAddable(newCapacity);
+        }
+    }
+
+    /**
+     * Returns the capacity of the array (the maximum number of elements the
+     * managed array can accommodate before triggering a reallocation).  If any
+     * appending will reallocate, $(D capacity) returns $(D 0).
+     */
+    @property size_t capacity() const
+    {
+        return arr.length;
+    }
+
+    /**
+     * Returns the managed array.
+     */
+    @property inout(T)[] data() inout @trusted
+    {
+        /* @trusted operation:
+         * casting Unqual!T[] to inout(T)[]
+         */
+        return cast(typeof(return))(arr[0..used]);
+    }
+
+    /**
+     * Clears the managed array.  This allows the elements of the array to be reused
+     * for appending.
+     */
+    void clear() pure nothrow
+    {
+        used = 0;
+    }
+
+    /**
+     * Shrinks the managed array to the given length.
+     */
+    void shrinkTo(size_t newLength) pure nothrow
+    {
+        assert(used >= newLength, "Trying to shrink appender to a greater size");
+        used = newLength;
+    }
+}
+
+@nogc unittest
+{
+    import std.experimental.allocator.mallocator;
+
+    static immutable arr1 = [1];
+    static immutable arr234 = [2, 3, 4];
+    static immutable arr1234 = [1, 2, 3, 4];
+
+    auto app = Appender!(int, shared(Mallocator))(Mallocator.instance);
+    assert(app.data is null);
+
+    app.put(1);
+    assert(app.data == arr1);
+
+    app.put(arr234);
+    assert(app.data == arr1234);
+}

--- a/std/experimental/xml/appender.d
+++ b/std/experimental/xml/appender.d
@@ -5,15 +5,15 @@
 *            http://www.boost.org/LICENSE_1_0.txt)
 */
 
-/++
-+   Appender implementation that uses a custom allocator. Meant for internal usage.
-+/
+/*
+*   Appender implementation that uses a custom allocator. Meant for internal usage.
+*/
 
 module std.experimental.xml.appender;
 
-/++
-+   Appender implementation that uses a custom allocator. Meant for internal usage.
-+/
+/*
+*   Appender implementation that uses a custom allocator. Meant for internal usage.
+*/
 struct Appender(T, Alloc)
 {
     import std.experimental.allocator;
@@ -121,7 +121,7 @@ struct Appender(T, Alloc)
         }
     }
 
-    /**
+    /*
      * Reserve at least newCapacity elements for appending.  Note that more elements
      * may be reserved than requested.  If newCapacity <= capacity, then nothing is
      * done.
@@ -139,7 +139,7 @@ struct Appender(T, Alloc)
         }
     }
 
-    /**
+    /*
      * Returns the capacity of the array (the maximum number of elements the
      * managed array can accommodate before triggering a reallocation).  If any
      * appending will reallocate, $(D capacity) returns $(D 0).
@@ -149,7 +149,7 @@ struct Appender(T, Alloc)
         return arr.length;
     }
 
-    /**
+    /*
      * Returns the managed array.
      */
     @property inout(T)[] data() inout @trusted
@@ -160,7 +160,7 @@ struct Appender(T, Alloc)
         return cast(typeof(return))(arr[0..used]);
     }
 
-    /**
+    /*
      * Clears the managed array.  This allows the elements of the array to be reused
      * for appending.
      */
@@ -169,7 +169,7 @@ struct Appender(T, Alloc)
         used = 0;
     }
 
-    /**
+    /*
      * Shrinks the managed array to the given length.
      */
     void shrinkTo(size_t newLength) pure nothrow

--- a/std/experimental/xml/cursor.d
+++ b/std/experimental/xml/cursor.d
@@ -1,0 +1,967 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.cursor;
+
+import std.experimental.xml.interfaces;
+import std.experimental.xml.faststrings;
+
+import std.meta : staticIndexOf;
+import std.range.primitives;
+import std.typecons;
+
+/++
++ Enumeration of non-fatal errors that applications can intercept by setting
++ an handler on a cursor instance.
++/
+enum CursorError
+{
+    /// The document does not begin with an XML declaration
+    MISSING_XML_DECLARATION,
+    /// The attributes could not be parsed due to invalid syntax
+    INVALID_ATTRIBUTE_SYNTAX,
+}
+
+package struct Attribute(StringType)
+{
+    StringType value;
+    private StringType _name;
+    private size_t colon;
+
+    this(StringType qualifiedName, StringType value)
+    {
+        this.value = value;
+        name = qualifiedName;
+    }
+
+    @property auto name() inout
+    {
+        return _name;
+    }
+    @property void name(StringType _name)
+    {
+        import std.experimental.xml.faststrings;
+        this._name = _name;
+        auto i = _name.fastIndexOf(':');
+        if (i > 0)
+            colon = i;
+        else
+            colon = 0;
+    }
+    @property auto prefix() inout
+    {
+        return name[0..colon];
+    }
+    @property StringType localName()
+    {
+        if (colon)
+            return name[colon+1..$];
+        else
+            return name;
+    }
+}
+
+/++
++   An implementation of the $(LINK2 ../interfaces/isCursor, `isCursor`) trait.
++
++   This is the only provided cursor that builds on top of a parser (and not on top of
++   another cursor), so it is part of virtually every parsing chain.
++   All documented methods are implementations of the specifications dictated by
++   $(LINK2 ../interfaces/isCursor, `isCursor`).
++/
+struct Cursor(P, Flag!"conflateCDATA" conflateCDATA = Yes.conflateCDATA, ErrorHandler = void delegate(CursorError))
+    if (isLowLevelParser!P)
+{
+    /++
+    +   The type of input accepted by this parser,
+    +   i.e., the one accepted by the underlying low level parser.
+    +/
+    alias InputType = P.InputType;
+
+    /++ The type of characters in the input, as returned by the underlying low level parser. +/
+    alias CharacterType = P.CharacterType;
+
+    /++ The type of sequences of CharacterType, as returned by this parser +/
+    alias StringType = CharacterType[];
+
+    private P parser;
+    private ElementType!P currentNode;
+    private bool starting, _documentEnd, nextFailed;
+    private ptrdiff_t colon;
+    private size_t nameEnd;
+    private ErrorHandler handler;
+
+    /++ Generic constructor; forwards its arguments to the parser constructor +/
+    this(Args...)(Args args)
+    {
+        parser = P(args);
+    }
+
+    static if (isSaveableLowLevelParser!P)
+    {
+        public auto save()
+        {
+            auto result = this;
+            result.parser = parser.save;
+            return result;
+        }
+    }
+
+    private void callHandler(CursorError err)
+    {
+        if (handler != null)
+            handler(err);
+        else
+            assert(0);
+    }
+
+    private bool advanceInput()
+    {
+        colon = colon.max;
+        nameEnd = 0;
+        parser.popFront();
+        if (!parser.empty)
+        {
+            currentNode = parser.front;
+            return true;
+        }
+        _documentEnd = true;
+        return false;
+    }
+
+    /++
+    +   Overrides the current error handler with a new one.
+    +   It will be called whenever a non-fatal error occurs.
+    +   The default handler abort parsing by throwing an exception.
+    +/
+    void setErrorHandler(ErrorHandler handler)
+    {
+        assert(handler, "Trying to set null error handler");
+        this.handler = handler;
+    }
+
+    /++
+    +   Initializes this cursor (and the underlying low level parser) with the given input.
+    +/
+    void setSource(InputType input)
+    {
+        // reset private fields
+        nextFailed = false;
+        _documentEnd = false;
+        colon = colon.max;
+        nameEnd = 0;
+
+        parser.setSource(input);
+        if (!parser.empty)
+        {
+            if (parser.front.kind == XMLKind.PROCESSING_INSTRUCTION &&
+                parser.front.content.length >= 3 &&
+                fastEqual(parser.front.content[0..3], "xml"))
+            {
+                currentNode = parser.front;
+            }
+            else
+            {
+                // document without xml declaration???
+                callHandler(CursorError.MISSING_XML_DECLARATION);
+                currentNode.kind = XMLKind.PROCESSING_INSTRUCTION;
+                currentNode.content = "xml version = \"1.0\"";
+            }
+            starting = true;
+        }
+    }
+
+    /++ Returns whether the cursor is at the end of the document. +/
+    bool documentEnd()
+    {
+        return _documentEnd;
+    }
+
+    /++
+    +   Returns whether the cursor is at the beginning of the document
+    +   (i.e. whether no enter/next/exit has been performed successfully and thus
+    +   the cursor points to the xml declaration)
+    +/
+    bool atBeginning()
+    {
+        return starting;
+    }
+
+    /++
+    +   Advances to the first child of the current node and returns true.
+    +   If it returns false, the cursor is either on the same node (it wasn't
+    +   an element start) or it is at the close tag of the element it was called on
+    +   (it was a pair open/close tag without any content)
+    +/
+    bool enter()
+    {
+        if (starting)
+        {
+            starting = false;
+            if (currentNode.content is parser.front.content)
+                return advanceInput();
+            else
+                nameEnd = 0;
+
+            currentNode = parser.front;
+            return true;
+        }
+        else if (currentNode.kind == XMLKind.ELEMENT_START)
+        {
+            return advanceInput() && currentNode.kind != XMLKind.ELEMENT_END;
+        }
+        else if (currentNode.kind == XMLKind.DTD_START)
+        {
+            return advanceInput() && currentNode.kind != XMLKind.DTD_END;
+        }
+        else
+            return false;
+    }
+
+    /++ Advances to the end of the parent of the current node. +/
+    void exit()
+    {
+        if (!nextFailed)
+            while (next()) {}
+
+        nextFailed = false;
+    }
+
+    /++
+    +   Advances to the next sibling of the current node.
+    +   Returns whether it succeded. If it fails, either the
+    +   document has ended or the only meaningful operation is exit().
+    +/
+    bool next()
+    {
+        if (parser.empty || starting || nextFailed)
+            return false;
+        else if (currentNode.kind == XMLKind.DTD_START)
+        {
+            while (advanceInput && currentNode.kind != XMLKind.DTD_END) {}
+        }
+        else if (currentNode.kind == XMLKind.ELEMENT_START)
+        {
+            int count = 1;
+            while (count > 0 && !parser.empty)
+            {
+                if (!advanceInput)
+                    return false;
+                if (currentNode.kind == XMLKind.ELEMENT_START)
+                    count++;
+                else if (currentNode.kind == XMLKind.ELEMENT_END)
+                    count--;
+            }
+        }
+        if (!advanceInput || currentNode.kind == XMLKind.ELEMENT_END || currentNode.kind == XMLKind.DTD_END)
+        {
+            nextFailed = true;
+            return false;
+        }
+        return true;
+    }
+
+    /++ Returns the kind of the current node. +/
+    XMLKind getKind() const
+    {
+        if (starting)
+            return XMLKind.DOCUMENT;
+
+        static if (conflateCDATA == Yes.conflateCDATA)
+            if (currentNode.kind == XMLKind.CDATA)
+                return XMLKind.TEXT;
+
+        return currentNode.kind;
+    }
+
+    /++
+    +   If the current node is an element or a doctype, return its complete name;
+    +   it it is a processing instruction, return its target;
+    +   otherwise, return an empty string;
+    +/
+    StringType getName()
+    {
+        switch (currentNode.kind)
+        {
+            case XMLKind.DOCUMENT:
+            case XMLKind.TEXT:
+            case XMLKind.CDATA:
+            case XMLKind.COMMENT:
+            case XMLKind.DECLARATION:
+            case XMLKind.CONDITIONAL:
+            case XMLKind.DTD_START:
+            case XMLKind.DTD_EMPTY:
+            case XMLKind.DTD_END:
+                return [];
+            default:
+                if (!nameEnd)
+                {
+                    ptrdiff_t i;
+                    if ((i = fastIndexOfAny(currentNode.content, " \r\n\t")) >= 0)
+                        nameEnd = i;
+                    else
+                        nameEnd = currentNode.content.length;
+                }
+                return currentNode.content[0..nameEnd];
+        }
+    }
+
+    /++
+    +   If the current node is an element, return its local name (without namespace prefix);
+    +   otherwise, return the same result as getName().
+    +/
+    StringType getLocalName()
+    {
+        auto name = getName();
+        if (currentNode.kind == XMLKind.ELEMENT_START || currentNode.kind == XMLKind.ELEMENT_END)
+        {
+            if (colon == colon.max)
+                colon = fastIndexOf(name, ':');
+            return name[(colon+1)..$];
+        }
+        return name;
+    }
+
+    /++
+    +   If the current node is an element, return its namespace prefix;
+    +   otherwise, the result in unspecified;
+    +/
+    StringType getPrefix()
+    {
+        if (currentNode.kind == XMLKind.ELEMENT_START || currentNode.kind == XMLKind.ELEMENT_END)
+        {
+            auto name = getName;
+            if (colon == colon.max)
+                colon = fastIndexOf(name, ':');
+
+            if (colon >= 0)
+                return name[0..colon];
+            else
+                return [];
+        }
+        return [];
+    }
+
+    /++
+    +   If the current node is an element, return its attributes as a range of triplets
+    +   (prefix, name, value); if the current node is the document node, return the attributes
+    +   of the xml declaration (encoding, version, ...); otherwise, return an empty array.
+    +/
+    auto getAttributes()
+    {
+        struct AttributesRange
+        {
+            private StringType content;
+            private Attribute!StringType attr;
+            private Cursor* cursor;
+            private bool error;
+
+            private this(StringType str, ref Cursor cur)
+            {
+                content = str;
+                cursor = &cur;
+            }
+
+            bool empty()
+            {
+                if (error)
+                    return true;
+
+                auto i = content.fastIndexOfNeither(" \r\n\t");
+                if (i >= 0)
+                {
+                    content = content[i..$];
+                    return false;
+                }
+                return true;
+            }
+
+            auto front()
+            {
+                if (attr == attr.init)
+                {
+                    auto i = content.fastIndexOfNeither(" \r\n\t");
+                    assert(i >= 0, "No more attributes...");
+                    content = content[i..$];
+
+                    auto sep = fastIndexOf(content[0..$], '=');
+                    if (sep == -1)
+                    {
+                        // attribute without value???
+                        cursor.callHandler(CursorError.INVALID_ATTRIBUTE_SYNTAX);
+                        error = true;
+                        return attr.init;
+                    }
+
+                    auto name = content[0..sep];
+                    auto delta = fastIndexOfAny(name, " \r\n\t");
+                    if (delta >= 0)
+                    {
+                        auto j = name[delta..$].fastIndexOfNeither(" \r\n\t");
+                        if (j != -1)
+                        {
+                            // attribute name contains spaces???
+                            cursor.callHandler(CursorError.INVALID_ATTRIBUTE_SYNTAX);
+                            error = true;
+                            return attr.init;
+                        }
+                        name = name[0..delta];
+                    }
+                    attr.name = name;
+
+                    size_t attEnd;
+                    size_t quote;
+                    delta = (sep + 1 < content.length) ? fastIndexOfNeither(content[sep + 1..$], " \r\n\t") : -1;
+                    if (delta >= 0)
+                    {
+                        quote = sep + 1 + delta;
+                        if (content[quote] == '"' || content[quote] == '\'')
+                        {
+                            delta = fastIndexOf(content[(quote + 1)..$], content[quote]);
+                            if (delta == -1)
+                            {
+                                // attribute quotes never closed???
+                                cursor.callHandler(CursorError.INVALID_ATTRIBUTE_SYNTAX);
+                                error = true;
+                                return attr.init;
+                            }
+                            attEnd = quote + 1 + delta;
+                        }
+                        else
+                        {
+                            cursor.callHandler(CursorError.INVALID_ATTRIBUTE_SYNTAX);
+                            error = true;
+                            return attr.init;
+                        }
+                    }
+                    else
+                    {
+                        // attribute without value???
+                        cursor.callHandler(CursorError.INVALID_ATTRIBUTE_SYNTAX);
+                        error = true;
+                        return attr.init;
+                    }
+                    attr.value = content[(quote + 1)..attEnd];
+                    content = content[attEnd+1..$];
+                }
+                return attr;
+            }
+
+            auto popFront()
+            {
+                front();
+                attr = attr.init;
+            }
+        }
+
+        auto kind = currentNode.kind;
+        if (kind == XMLKind.ELEMENT_START || kind == XMLKind.ELEMENT_EMPTY || kind == XMLKind.PROCESSING_INSTRUCTION)
+        {
+            getName;
+            return AttributesRange(currentNode.content[nameEnd..$], this);
+        }
+        else
+            return AttributesRange();
+    }
+
+    /++
+    +   Return the text content of a CDATA section, a comment or a text node;
+    +   in all other cases, returns the entire node without the name
+    +/
+    StringType getContent()
+    {
+        return currentNode.content[nameEnd..$];
+    }
+
+    /++ Returns the entire text of the current node. +/
+    StringType getAll() const
+    {
+        return currentNode.content;
+    }
+}
+
+/++
++   Instantiates a specialized `Cursor` with the given underlying `parser` and
++   the given error handler (defaults to an error handler that just asserts 0).
++/
+template cursor(Flag!"conflateCDATA" conflateCDATA = Yes.conflateCDATA)
+{
+    auto cursor(T, EH)(auto ref T parser, EH errorHandler = (CursorError err) { assert(0); })
+        if(isLowLevelParser!T)
+    {
+        auto cursor = Cursor!(T, conflateCDATA, EH)();
+        cursor.parser = parser;
+        cursor.handler = errorHandler;
+        return cursor;
+    }
+}
+
+unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.string : lineSplitter, strip;
+    import std.algorithm : map;
+    import std.array : array;
+
+    wstring xml = q{
+    <?xml encoding = "utf-8" ?>
+    <!DOCTYPE mydoc https://myUri.org/bla [
+        <!ELEMENT myelem ANY>
+        <!ENTITY   myent    "replacement text">
+        <!ATTLIST myelem foo CDATA #REQUIRED >
+        <!NOTATION PUBLIC 'h'>
+        <!FOODECL asdffdsa >
+    ]>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    auto cursor = chooseLexer!xml.parse.cursor;
+    cursor.setSource(xml);
+
+    assert(cursor.atBeginning);
+
+    // <?xml encoding = "utf-8" ?>
+    assert(cursor.getKind() == XMLKind.DOCUMENT);
+    assert(cursor.getName() == "xml");
+    assert(cursor.getPrefix() == "");
+    assert(cursor.getLocalName() == "xml");
+    assert(cursor.getAttributes().array == [Attribute!wstring("encoding", "utf-8")]);
+    assert(cursor.getContent() == " encoding = \"utf-8\" ");
+
+    assert(cursor.enter());
+        assert(!cursor.atBeginning);
+
+        // <!DOCTYPE mydoc https://myUri.org/bla [
+        assert(cursor.getKind == XMLKind.DTD_START);
+        assert(cursor.getAll == " mydoc https://myUri.org/bla ");
+
+        assert(cursor.enter);
+            // <!ELEMENT myelem ANY>
+            assert(cursor.getKind == XMLKind.ELEMENT_DECL);
+            assert(cursor.getAll == " myelem ANY");
+
+            assert(cursor.next);
+            // <!ENTITY   myent    "replacement text">
+            assert(cursor.getKind == XMLKind.ENTITY_DECL);
+            assert(cursor.getAll == "   myent    \"replacement text\"");
+
+            assert(cursor.next);
+            // <!ATTLIST myelem foo CDATA #REQUIRED >
+            assert(cursor.getKind == XMLKind.ATTLIST_DECL);
+            assert(cursor.getAll == " myelem foo CDATA #REQUIRED ");
+
+            assert(cursor.next);
+            // <!NOTATION PUBLIC 'h'>
+            assert(cursor.getKind == XMLKind.NOTATION_DECL);
+            assert(cursor.getAll == " PUBLIC 'h'");
+
+            assert(cursor.next);
+            // <!FOODECL asdffdsa >
+            assert(cursor.getKind == XMLKind.DECLARATION);
+            assert(cursor.getAll == "FOODECL asdffdsa ");
+
+            assert(!cursor.next);
+        cursor.exit;
+
+        // ]>
+        assert(cursor.getKind == XMLKind.DTD_END);
+        assert(!cursor.getAll);
+        assert(cursor.next);
+
+        // <aaa xmlns:myns="something">
+        assert(cursor.getKind() == XMLKind.ELEMENT_START);
+        assert(cursor.getName() == "aaa");
+        assert(cursor.getPrefix() == "");
+        assert(cursor.getLocalName() == "aaa");
+        assert(cursor.getAttributes().array == [Attribute!wstring("xmlns:myns", "something")]);
+        assert(cursor.getContent() == " xmlns:myns=\"something\"");
+
+        assert(cursor.enter());
+            // <myns:bbb myns:att='>'>
+            assert(cursor.getKind() == XMLKind.ELEMENT_START);
+            assert(cursor.getName() == "myns:bbb");
+            assert(cursor.getPrefix() == "myns");
+            assert(cursor.getLocalName() == "bbb");
+            assert(cursor.getAttributes().array == [Attribute!wstring("myns:att", ">")]);
+            assert(cursor.getContent() == " myns:att='>'");
+
+            assert(cursor.enter());
+            cursor.exit();
+
+            // </myns:bbb>
+            assert(cursor.getKind() == XMLKind.ELEMENT_END);
+            assert(cursor.getName() == "myns:bbb");
+            assert(cursor.getPrefix() == "myns");
+            assert(cursor.getLocalName() == "bbb");
+            assert(cursor.getAttributes().empty);
+            assert(cursor.getContent() == []);
+
+            assert(cursor.next());
+            // <<![CDATA[ Ciaone! ]]>
+            assert(cursor.getKind() == XMLKind.TEXT);
+            assert(cursor.getName() == "");
+            assert(cursor.getPrefix() == "");
+            assert(cursor.getLocalName() == "");
+            assert(cursor.getAttributes().empty);
+            assert(cursor.getContent() == " Ciaone! ");
+
+            assert(cursor.next());
+            // <ccc/>
+            assert(cursor.getKind() == XMLKind.ELEMENT_EMPTY);
+            assert(cursor.getName() == "ccc");
+            assert(cursor.getPrefix() == "");
+            assert(cursor.getLocalName() == "ccc");
+            assert(cursor.getAttributes().empty);
+            assert(cursor.getContent() == []);
+
+            assert(!cursor.next());
+        cursor.exit();
+
+        // </aaa>
+        assert(cursor.getKind() == XMLKind.ELEMENT_END);
+        assert(cursor.getName() == "aaa");
+        assert(cursor.getPrefix() == "");
+        assert(cursor.getLocalName() == "aaa");
+        assert(cursor.getAttributes().empty);
+        assert(cursor.getContent() == []);
+
+        assert(!cursor.next());
+    cursor.exit();
+
+    assert(cursor.documentEnd);
+    assert(!cursor.atBeginning);
+}
+
+/++
++   Returns an input range of the children of the node currently pointed by `cursor`.
++
++   Advancing the range returned by this function also advances `cursor`. It is thus
++   not recommended to interleave usage of this function with raw usage of `cursor`.
++/
+auto children(T)(ref T cursor)
+    if (isCursor!T)
+{
+    struct XMLRange
+    {
+        T* cursor;
+        bool endReached;
+
+        bool empty() const { return endReached; }
+        void popFront() { endReached = !cursor.next(); }
+        ref T front() { return *cursor; }
+
+        ~this() { cursor.exit; }
+    }
+    return XMLRange(&cursor, cursor.enter);
+}
+
+@nogc unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.string : lineSplitter, strip;
+    import std.algorithm : map, equal;
+    import std.array : array;
+
+    string xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    import std.experimental.allocator.mallocator;
+
+    auto handler = () { assert(0, "Some problem here..."); };
+    auto lexer = RangeLexer!(string, typeof(handler), shared(Mallocator))(Mallocator.instance);
+    lexer.errorHandler = handler;
+    auto cursor = lexer.parse.cursor!(Yes.conflateCDATA);
+    cursor.setSource(xml);
+
+    // <?xml encoding = "utf-8" ?>
+    assert(cursor.getKind() == XMLKind.DOCUMENT);
+    assert(cursor.getName() == "xml");
+    assert(cursor.getPrefix() == "");
+    assert(cursor.getLocalName() == "xml");
+    auto attrs = cursor.getAttributes;
+    assert(attrs.front == Attribute!string("encoding", "utf-8"));
+    attrs.popFront;
+    assert(attrs.empty);
+    assert(cursor.getContent() == " encoding = \"utf-8\" ");
+
+    {
+        auto range1 = cursor.children;
+        // <aaa xmlns:myns="something">
+        assert(range1.front.getKind() == XMLKind.ELEMENT_START);
+        assert(range1.front.getName() == "aaa");
+        assert(range1.front.getPrefix() == "");
+        assert(range1.front.getLocalName() == "aaa");
+        attrs = range1.front.getAttributes;
+        assert(attrs.front == Attribute!string("xmlns:myns", "something"));
+        attrs.popFront;
+        assert(attrs.empty);
+        assert(range1.front.getContent() == " xmlns:myns=\"something\"");
+
+        {
+            auto range2 = range1.front.children();
+            // <myns:bbb myns:att='>'>
+            assert(range2.front.getKind() == XMLKind.ELEMENT_START);
+            assert(range2.front.getName() == "myns:bbb");
+            assert(range2.front.getPrefix() == "myns");
+            assert(range2.front.getLocalName() == "bbb");
+            attrs = range2.front.getAttributes;
+            assert(attrs.front == Attribute!string("myns:att", ">"));
+            attrs.popFront;
+            assert(attrs.empty);
+            assert(range2.front.getContent() == " myns:att='>'");
+
+            {
+                auto range3 = range2.front.children();
+                // <!-- lol -->
+                assert(range3.front.getKind() == XMLKind.COMMENT);
+                assert(range3.front.getName() == "");
+                assert(range3.front.getPrefix() == "");
+                assert(range3.front.getLocalName() == "");
+                assert(range3.front.getAttributes.empty);
+                assert(range3.front.getContent() == " lol ");
+
+                range3.popFront;
+                assert(!range3.empty);
+                // Lots of Text!
+                // On multiple lines!
+                assert(range3.front.getKind() == XMLKind.TEXT);
+                assert(range3.front.getName() == "");
+                assert(range3.front.getPrefix() == "");
+                assert(range3.front.getLocalName() == "");
+                assert(range3.front.getAttributes().empty);
+                // split and strip so the unittest does not depend on the newline policy or indentation of this file
+                static immutable linesArr = ["Lots of Text!", "            On multiple lines!", "        "];
+                assert(range3.front.getContent().lineSplitter.equal(linesArr));
+
+                range3.popFront;
+                assert(range3.empty);
+            }
+
+            range2.popFront;
+            assert(!range2.empty);
+            // <<![CDATA[ Ciaone! ]]>
+            assert(range2.front.getKind() == XMLKind.TEXT);
+            assert(range2.front.getName() == "");
+            assert(range2.front.getPrefix() == "");
+            assert(range2.front.getLocalName() == "");
+            assert(range2.front.getAttributes().empty);
+            assert(range2.front.getContent() == " Ciaone! ");
+
+            range2.popFront;
+            assert(!range2.empty());
+            // <ccc/>
+            assert(range2.front.getKind() == XMLKind.ELEMENT_EMPTY);
+            assert(range2.front.getName() == "ccc");
+            assert(range2.front.getPrefix() == "");
+            assert(range2.front.getLocalName() == "ccc");
+            assert(range2.front.getAttributes().empty);
+            assert(range2.front.getContent() == []);
+
+            range2.popFront;
+            assert(range2.empty());
+        }
+
+        range1.popFront;
+        assert(range1.empty);
+    }
+
+    assert(cursor.documentEnd());
+}
+
+import std.traits : isArray;
+import std.experimental.allocator.gc_allocator;
+
+/++
++   A cursor that wraps another cursor, copying all output strings.
++
++   The cursor specification ($(LINK2 ../interfaces/isCursor, `std.experimental.xml.interfaces.isCursor`))
++   clearly states that a cursor (as the underlying parser and lexer) is free to reuse
++   its internal buffers and thus invalidate every output. This wrapper returns freshly
++   allocated strings, thus allowing references to its outputs to outlive calls to advancing
++   methods.
++
++   This type should not be instantiated directly, but using the helper function
++   `copyingCursor`.
++/
+struct CopyingCursor(CursorType, Alloc = shared(GCAllocator), Flag!"intern" intern = No.intern)
+    if (isCursor!CursorType && isArray!(CursorType.StringType))
+{
+    alias StringType = CursorType.StringType;
+
+    mixin UsesAllocator!Alloc;
+
+    CursorType cursor;
+    alias cursor this;
+
+    static if (intern == Yes.intern)
+    {
+        import std.typecons: Rebindable;
+
+        Rebindable!(immutable StringType)[const StringType] interned;
+    }
+
+    private auto copy(StringType str)
+    {
+        static if (intern == Yes.intern)
+        {
+            auto match = str in interned;
+            if (match)
+                return *match;
+        }
+
+        import std.traits : Unqual;
+        import std.experimental.allocator;
+        import std.range.primitives : ElementEncodingType;
+        import core.stdc.string : memcpy;
+
+        alias ElemType = ElementEncodingType!StringType;
+        auto cp = cast(ElemType[]) allocator.makeArray!(Unqual!ElemType)(str.length);
+        memcpy(cast(void*)cp.ptr, cast(void*)str.ptr, str.length * ElemType.sizeof);
+
+        static if (intern == Yes.intern)
+        {
+            interned[str] = cp;
+        }
+
+        return cp;
+    }
+
+    auto getName()
+    {
+        return copy(cursor.getName);
+    }
+    auto getLocalName()
+    {
+        return copy(cursor.getLocalName);
+    }
+    auto getPrefix()
+    {
+        return copy(cursor.getPrefix);
+    }
+    auto getContent()
+    {
+        return copy(cursor.getContent);
+    }
+    auto getAll()
+    {
+        return copy(cursor.getAll);
+    }
+
+    auto getAttributes()
+    {
+        struct CopyRange
+        {
+            typeof(cursor.getAttributes()) attrs;
+            alias attrs this;
+
+            private CopyingCursor* parent;
+
+            auto front()
+            {
+                auto attr = attrs.front;
+                return Attribute!StringType(
+                        parent.copy(attr.name),
+                        parent.copy(attr.value),
+                    );
+            }
+        }
+        return CopyRange(cursor.getAttributes, &this);
+    }
+}
+
+/++
++   Instantiates a suitable `CopyingCursor` on top of the given `cursor` and allocator.
++/
+auto copyingCursor(Flag!"intern" intern = No.intern, CursorType, Alloc)(auto ref CursorType cursor, ref Alloc alloc)
+{
+    auto res = CopyingCursor!(CursorType, Alloc, intern)(alloc);
+    res.cursor = cursor;
+    return res;
+}
+/// ditto
+auto copyingCursor(Alloc = shared(GCAllocator), Flag!"intern" intern = No.intern, CursorType)
+                  (auto ref CursorType cursor)
+    if (is(typeof(Alloc.instance)))
+{
+    auto res = CopyingCursor!(CursorType, Alloc, intern)(Alloc.instance);
+    res.cursor = cursor;
+    return res;
+}
+
+unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.experimental.allocator.mallocator;
+
+    wstring xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa>
+        <bbb>
+            <aaa>
+            </aaa>
+        </bbb>
+        Hello, world!
+    </aaa>
+    };
+
+    auto cursor =
+         chooseLexer!xml
+        .parse
+        .cursor!(Yes.conflateCDATA)
+        .copyingCursor!(Yes.intern)(Mallocator.instance);
+    cursor.setSource(xml);
+
+    assert(cursor.enter);
+    auto a1 = cursor.getName;
+    assert(cursor.enter);
+    auto b1 = cursor.getName;
+    assert(cursor.enter);
+    auto a2 = cursor.getName;
+    assert(!cursor.enter);
+    auto a3 = cursor.getName;
+    cursor.exit;
+    auto b2 = cursor.getName;
+    cursor.exit;
+    auto a4 = cursor.getName;
+
+    assert(a1 is a2);
+    assert(a2 is a3);
+    assert(a3 is a4);
+    assert(b1 is b2);
+}

--- a/std/experimental/xml/dom.d
+++ b/std/experimental/xml/dom.d
@@ -1,0 +1,1230 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module declares the DOM Level 3 interfaces as stated in the W3C DOM
++   specification.
++
++   For a more complete reference, see the
++   $(LINK2 https://www.w3.org/TR/DOM-Level-3-Core/, official specification),
++   from which all documentation in this module is taken.
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.dom;
+
+import std.typecons : BitFlags;
+import std.variant : Variant;
+
+/++
++   The DOMUserData type is used to store application data inside DOM nodes.
++/
+alias UserData = Variant;
+
+/++
++   When associating an object to a key on a node using Node.setUserData() the
++   application can provide a handler that gets called when the node the object
++   is associated to is being cloned, imported, or renamed. This can be used by
++   the application to implement various behaviors regarding the data it associates
++   to the DOM nodes.
++/
+alias UserDataHandler(DOMString) =
+        void delegate(UserDataOperation, DOMString, UserData, Node!DOMString, Node!DOMString);
+
+/++
++   An integer indicating which type of node this is.
++
++   Note:
++   Numeric codes up to 200 are reserved to W3C for possible future use.
++/
+enum NodeType: ushort
+{
+    ELEMENT = 1,
+    ATTRIBUTE,
+    TEXT,
+    CDATA_SECTION,
+    ENTITY_REFERENCE,
+    ENTITY,
+    PROCESSING_INSTRUCTION,
+    COMMENT,
+    DOCUMENT,
+    DOCUMENT_TYPE,
+    DOCUMENT_FRAGMENT,
+    NOTATION,
+}
+
+/++
++   A bitmask indicating the relative document position of a node with respect to another node.
++   Returned by `Node.compareDocumentPosition`.
++/
+enum DocumentPosition: ushort
+{
+    /// Set when the two nodes are in fact the same
+    NONE         = 0,
+    /// Set when the two nodes are not in the same tree
+    DISCONNECTED = 1,
+    /// Set when the second node precedes the first
+    PRECEDING    = 2,
+    /// Set when the second node follows the first
+    FOLLOWING    = 4,
+    /// Set when the second node contains the first
+    CONTAINS     = 8,
+    /// Set when the second node is contained by the first
+    CONTAINED_BY = 16,
+    /++
+    +   Set when the returned ordering of the two nodes may be different across
+    +   DOM implementations; for example, for two attributes of the same node,
+    +   an implementation may return `PRECEDING | IMPLEMENTATION_SPECIFIC` and another
+    +   may return `FOLLOWING | IMPLEMENTATION_SPECIFIC`, because at the DOM level
+    +   the attributes ordering is unspecified
+    +/
+    IMPLEMENTATION_SPECIFIC = 32,
+}
+
+/++
++   An integer indicating the type of operation being performed on a node.
++/
+enum UserDataOperation: ushort
+{
+    /// The node is cloned, using `Node.cloneNode()`.
+    NODE_CLONED = 1,
+    /// The node is imported, using `Document.importNode()`.
+    NODE_IMPORTED,
+    /++
+    +   The node is deleted.
+    +   Note:
+    +   This may not be supported or may not be reliable in certain environments,
+    +   where the implementation has no real control over when objects are actually deleted.
+    +/
+    NODE_DELETED,
+    /// The node is renamed, using `Document.renameNode()`.
+    NODE_RENAMED,
+    /// The node is adopted, using `Document.adoptNode()`.
+    NODE_ADOPTED,
+}
+
+/++
++   An integer indicating the type of error generated.
++
++   Note:
++   Other numeric codes are reserved for W3C for possible future use.
++/
+enum ExceptionCode: ushort
+{
+    /// If index or size is negative, or greater than the allowed value.
+    INDEX_SIZE,
+    /// If the specified range of text does not fit into a `DOMString`.
+    DOMSTRING_SIZE,
+    /// If any `Node` is inserted somewhere it doesn't belong.
+    HIERARCHY_REQUEST,
+    /// If a `Node` is used in a different document than the one that created it (that doesn't support it).
+    WRONG_DOCUMENT,
+    /// If an invalid or illegal character is specified, such as in an XML name.
+    INVALID_CHARACTER,
+    /// If data is specified for a `Node` which does not support data.
+    NO_DATA_ALLOWED,
+    /// If an attempt is made to modify an object where modifications are not allowed.
+    NO_MODIFICATION_ALLOWED,
+    /// If an attempt is made to reference a `Node` in a context where it does not exist.
+    NOT_FOUND,
+    /// If the implementation does not support the requested type of object or operation.
+    NOT_SUPPORTED,
+    /// If an attempt is made to add an attribute that is already in use elsewhere.
+    INUSE_ATTRIBUTE,
+    /// If an attempt is made to use an object that is not, or is no longer, usable.
+    INVALID_STATE,
+    /// If an invalid or illegal string is specified.
+    SYNTAX,
+    /// If an attempt is made to modify the type of the underlying object.
+    INVALID_MODIFICATION,
+    /// If an attempt is made to create or change an object in a way which is incorrect with regard to namespaces.
+    NAMESPACE,
+    /// If a parameter or an operation is not supported by the underlying object.
+    INVALID_ACCESS,
+    /// If a call to a method such as insertBefore or removeChild would make the `Node` invalid.
+    VALIDATION,
+    /// If the type of an object is incompatible with the expected type of the parameter associated to the object.
+    TYPE_MISMATCH,
+}
+
+/// An integer indicating the severity of a `DOMError`.
+enum ErrorSeverity: ushort
+{
+    /++
+    +   The severity of the error described by the `DOMError` is warning. A `WARNING`
+    +   will not cause the processing to stop, unless the call of the `DOMErrorHandler`
+    +   returns `false`.
+    +/
+    WARNING,
+    /++
+    +   The severity of the error described by the `DOMError` is error. A `ERROR`
+    +   may not cause the processing to stop if the error can be recovered, unless
+    +   the call of the `DOMErrorHandler` returns `false`.
+    +/
+    ERROR,
+    /++
+    +   The severity of the error described by the `DOMError` is fatal error. A `FATAL_ERROR`
+    +   will cause the normal processing to stop. The return value of calling the `DOMErrorHandler`
+    +   is ignored unless the implementation chooses to continue, in which case
+    +   the behavior becomes undefined.
+    +/
+    FATAL_ERROR,
+}
+
+enum DerivationMethod: ulong
+{
+    DERIVATION_RESTRICTION = 0x00000001,
+    DERIVATION_EXTENSION   = 0x00000002,
+    DERIVATION_UNION       = 0x00000004,
+    DERIVATION_LIST        = 0x00000008,
+}
+
+/++
++   DOM operations only raise exceptions in "exceptional" circumstances, i.e.,
++   when an operation is impossible to perform (either for logical reasons, because
++   data is lost, or because the implementation has become unstable). In general,
++   DOM methods return specific error values in ordinary processing situations,
++   such as out-of-bound errors when using `NodeList`.
++
++   Implementations should raise other exceptions under other circumstances. For
++   example, implementations should raise an implementation-dependent exception
++   if a `null` argument is passed when `null` was not expected.
++/
+abstract class DOMException: Exception
+{
+    ///
+    @property ExceptionCode code();
+
+    ///
+    pure nothrow @nogc @safe this(string msg, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+}
+
+/++
++   The `DOMStringList` interface provides the abstraction of an ordered collection
++   of `DOMString` values, without defining or constraining how this collection is
++   implemented. The items in the DOMStringList are accessible via an integral index,
++   starting from `0`.
++/
+interface DOMStringList(DOMString)
+{
+    DOMString item(size_t index);
+    @property size_t length();
+    bool contains(DOMString str);
+};
+
+/++
++   The `DOMImplementationList` interface provides the abstraction of an ordered
++   collection of DOM implementations, without defining or constraining how this
++   collection is implemented. The items in the `DOMImplementationList` are accessible
++   via an integral index, starting from `0`.
++/
+interface DOMImplementationList(DOMString)
+{
+    DOMImplementation!DOMString item(size_t index);
+    @property size_t length();
+}
+
+/++
++   This interface permits a DOM implementer to supply one or more implementations,
++   based upon requested features and versions, as specified in DOM Features.
++   Each implemented DOMImplementationSource object is listed in the binding-specific
++   list of available sources so that its `DOMImplementation` objects are made available.
++/
+interface DOMImplementationSource(DOMString)
+{
+    /// A method to request the first DOM implementation that supports the specified features.
+    DOMImplementation!DOMString getDOMImplementation(DOMString features);
+    /// A method to request a list of DOM implementations that support the specified features and versions, as specified in DOM Features.
+    DOMImplementationList!DOMString getDOMImplementationList(DOMString features);
+}
+
+/++
++   The DOMImplementation interface provides a number of methods for performing
++   operations that are independent of any particular instance of the document object model.
++/
+interface DOMImplementation(DOMString)
+{
+    /++
+    +   Creates an empty DocumentType node. Entity declarations and notations are not
+    +   made available. Entity reference expansions and default attribute additions do not occur.
+    +/
+    DocumentType!DOMString createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
+
+    /++
+    +   Creates a DOM Document object of the specified type with its document element.
+    +
+    +   Note that based on the DocumentType given to create the document, the implementation
+    +   may instantiate specialized Document objects that support additional features than the "Core",
+    +   such as "HTML". On the other hand, setting the DocumentType after the document
+    +   was created makes this very unlikely to happen.
+    +/
+    Document!DOMString createDocument(DOMString namespaceURI, DOMString qualifiedName, DocumentType!DOMString doctype);
+
+    bool hasFeature(string feature, string version_);
+    Object getFeature(string feature, string version_);
+}
+
+/++
++   `DocumentFragment` is a "lightweight" or "minimal" `Document` object. It is very
++   common to want to be able to extract a portion of a document's tree or to create
++   a new fragment of a document. Imagine implementing a user command like cut or
++   rearranging a document by moving fragments around. It is desirable to have an
++   object which can hold such fragments and it is quite natural to use a `Node`
++   for this purpose. While it is true that a `Document` object could fulfill this
++   role, a `Document` object can potentially be a heavyweight object, depending
++   on the underlying implementation. What is really needed for this is a very lightweight
++   object. `DocumentFragment` is such an object.
++
++   Furthermore, various operations -- such as inserting nodes as children of another
++   `Node` -- may take `DocumentFragment` objects as arguments; this results in
++   all the child nodes of the `DocumentFragment` being moved to the child list of this node.
++
++   The children of a `DocumentFragment` node are zero or more nodes representing
++   the tops of any sub-trees defining the structure of the document. `DocumentFragment`
++   nodes do not need to be well-formed XML documents (although they do need to follow
++   the rules imposed upon well-formed XML parsed entities, which can have multiple
++   top nodes). For example, a `DocumentFragment` might have only one child and that
++   child node could be a `Text` node. Such a structure model represents neither
++   an HTML document nor a well-formed XML document.
++
++   When a `DocumentFragment` is inserted into a `Document` (or indeed any other
++   `Node` that may take children) the children of the `DocumentFragment` and not
++   the `DocumentFragment` itself are inserted into the `Node`. This makes the `DocumentFragment`
++   very useful when the user wishes to create nodes that are siblings; the `DocumentFragment`
++   acts as the parent of these nodes so that the user can use the standard methods
++   from the `Node` interface, such as `Node.insertBefore` and `Node.appendChild`.
++/
+interface DocumentFragment(DOMString): Node!DOMString
+{
+}
+
+/++
++   The `Document` interface represents the entire HTML or XML document. Conceptually,
++   it is the root of the document tree, and provides the primary access to the document's data.
++
++   Since elements, text nodes, comments, processing instructions, etc. cannot exist
++   outside the context of a `Document`, the `Document` interface also contains the
++   factory methods needed to create these objects. The `Node` objects created have
++   a `ownerDocument` attribute which associates them with the `Document` within
++   whose context they were created.
++/
+interface Document(DOMString): Node!DOMString
+{
+    /++
+    +   The `DocumentType` associated with this document. For XML documents without a
+    +   document type declaration this returns `null`.
+    +
+    +   This provides direct access to the `DocumentType` node, child node of this
+    +   `Document`. This node can be set at document creation time and later changed
+    +   through the use of child nodes manipulation methods, such as `Node.insertBefore`,
+    +   or `Node.replaceChild`.
+    +/
+    @property DocumentType!DOMString doctype();
+    /++
+    +   The `DOMImplementation` object that handles this document. A DOM application
+    +   may use objects from multiple implementations.
+    +/
+    @property DOMImplementation!DOMString implementation();
+    /++
+    +   This is a convenience attribute that allows direct access to the child node
+    +   that is the document element of the document.
+    +/
+    @property Element!DOMString documentElement();
+
+    /++
+    +   Creates an `Element` of the type specified.
+    +   In addition, if there are known attributes with default values, `Attr` nodes
+    +   representing them are automatically created and attached to the element.
+    +   To create an `Element` with a qualified name and namespace URI, use the
+    +   `createElementNS` method.
+    +/
+    Element!DOMString createElement(DOMString tagName);
+    /++
+    +   Creates an `Element` of the given qualified name and namespace URI.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Element!DOMString createElementNS(DOMString namespaceURI, DOMString qualifiedName);
+    /// Creates an empty `DocumentFragment` object.
+    DocumentFragment!DOMString createDocumentFragment();
+    /// Creates a `Text` node given the specified string.
+    Text!DOMString createTextNode(DOMString data);
+    /// Creates a `Comment` node given the specified string.
+    Comment!DOMString createComment(DOMString data);
+    /// Creates a `CDATASection` node whose value is the specified string.
+    CDATASection!DOMString createCDATASection(DOMString data);
+    /// Creates a `ProcessingInstruction` node given the specified name and data strings.
+    ProcessingInstruction!DOMString createProcessingInstruction(DOMString target, DOMString data);
+    /++
+    +   Creates an `Attr` of the given name. Note that the `Attr` instance can
+    +   then be set on an `Element` using the `setAttributeNode` method.
+    +   To create an attribute with a qualified name and namespace URI, use the
+    +   `createAttributeNS` method.
+    +/
+    Attr!DOMString createAttribute(DOMString name);
+    /++
+    +   Creates an attribute of the given qualified name and namespace URI.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Attr!DOMString createAttributeNS(DOMString namespaceURI, DOMString qualifiedName);
+    /++
+    +   Creates an `EntityReference` object. In addition, if the referenced entity
+    +   is known, the child list of the `EntityReference` node is made the same as
+    +   that of the corresponding `Entity` node.
+    +/
+    EntityReference!DOMString createEntityReference(DOMString name);
+
+    /++
+    +   Returns a `NodeList` of all the `Element`s in document order with a given
+    +   tag name and are contained in the document.
+    +/
+    NodeList!DOMString getElementsByTagName(DOMString tagname);
+    /++
+    +   Returns a `NodeList` of all the `Element`s with a given local name and
+    +   namespace URI in document order.
+    +/
+    NodeList!DOMString getElementsByTagNameNS(DOMString namespaceURI, DOMString localName);
+    /++
+    +   Returns the `Element` that has an ID attribute with the given value. If no
+    +   such element exists, this returns `null`. If more than one element has an
+    +   ID attribute with that value, what is returned is undefined.
+    +   The DOM implementation is expected to use the attribute `Attr.isId` to
+    +   determine if an attribute is of type ID.
+    +
+    +   Note: Attributes with the name "ID" or "id" are not of type ID unless so defined.
+    +/
+    Element!DOMString getElementById(DOMString elementId);
+
+    /++
+    +   Imports a node from another document to this document, without altering or
+    +   removing the source node from the original document; this method creates a
+    +   new copy of the source node. The returned node has no parent; (`parentNode` is `null`).
+    +
+    +   For all nodes, importing a node creates a node object owned by the importing
+    +   document, with attribute values identical to the source node's `nodeName` and
+    +   `nodeType`, plus the attributes related to namespaces (`prefix`, `localName`,
+    +   and `namespaceURI`). As in the `cloneNode` operation, the source node is
+    +   not altered. User data associated to the imported node is not carried over.
+    +   However, if any `UserData` handlers has been specified along with the associated
+    +   data these handlers will be called with the appropriate parameters before this
+    +   method returns.
+    +/
+    Node!DOMString importNode(Node!DOMString importedNode, bool deep);
+    Node!DOMString adoptNode(Node!DOMString source);
+
+    /++
+    +   An attribute specifying the encoding used for this document at the time of
+    +   the parsing. This is `null` when it is not known, such as when the `Document`
+    +   was created in memory.
+    +/
+    @property DOMString inputEncoding();
+    /++
+    +   An attribute specifying, as part of the XML declaration, the encoding of
+    +   this document. This is `null` when unspecified or when it is not known,
+    +   such as when the Document was created in memory.
+    +/
+    @property DOMString xmlEncoding();
+
+    /++
+    +   An attribute specifying, as part of the XML declaration, whether this document
+    +   is standalone. This is `false` when unspecified.
+    +/
+    @property bool xmlStandalone();
+    /// ditto
+    @property void xmlStandalone(bool);
+
+    /++
+    +   An attribute specifying, as part of the XML declaration, the version number
+    +   of this document. If there is no declaration and if this document supports
+    +   the "XML" feature, the value is "1.0". If this document does not support
+    +   the "XML" feature, the value is always `null`.
+    +/
+    @property DOMString xmlVersion();
+    /// ditto
+    @property void xmlVersion(DOMString);
+
+    /++
+    +   An attribute specifying whether error checking is enforced or not.
+    +   When set to `false`, the implementation is free to not test every possible
+    +   error case normally defined on DOM operations, and not raise any `DOMException`
+    +   on DOM operations or report errors while using `Document.normalizeDocument()`.
+    +   In case of error, the behavior is undefined. This attribute is `true` by default.
+    +/
+    @property bool strictErrorChecking();
+    /// ditto
+    @property void strictErrorChecking(bool);
+
+    /++
+    +   The location of the document or `null` if undefined or if the `Document`
+    +   was created using `DOMImplementation.createDocument`. No lexical checking
+    +   is performed when setting this attribute; this could result in a `null`
+    +   value returned when using `Node.baseURI`.
+    +/
+    @property DOMString documentURI();
+    /// ditto
+    @property void documentURI(DOMString);
+
+    /// The configuration used when `Document.normalizeDocument()` is invoked.
+    @property DOMConfiguration!DOMString domConfig();
+    /++
+    +   This method acts as if the document was going through a save and load cycle,
+    +   putting the document in a "normal" form. As a consequence, this method
+    +   updates the replacement tree of `EntityReference` nodes and normalizes `Text`
+    +   nodes, as defined in the method Node.normalize().
+    +/
+    void normalizeDocument();
+    /++
+    +   Rename an existing node of type `ELEMENT` or `ATTRIBUTE`.
+    +
+    +   When possible this simply changes the name of the given node, otherwise
+    +   this creates a new node with the specified name and replaces the existing
+    +   node with the new node as described below.
+    +   If simply changing the name of the given node is not possible, the following
+    +   operations are performed: a new node is created, any registered event
+    +   listener is registered on the new node, any user data attached to the old
+    +   node is removed from that node, the old node is removed from its parent
+    +   if it has one, the children are moved to the new node, if the renamed node
+    +   is an `Element` its attributes are moved to the new node, the new node is
+    +   inserted at the position the old node used to have in its parent's child
+    +   nodes list if it has one, the user data that was attached to the old node
+    +   is attached to the new node.
+    +/
+    Node!DOMString renameNode(Node!DOMString n, DOMString namespaceURI, DOMString qualifiedName);
+}
+
+/++
++   The `Node` interface is the primary datatype for the entire Document Object Model.
++   It represents a single node in the document tree. While all objects implementing
++   the `Node` interface expose methods for dealing with children, not all objects
++   implementing the `Node` interface may have children. For example, `Text` nodes
++   may not have children, and adding children to such nodes results in a `DOMException`
++   being raised.
++
++   The attributes `nodeName`, `nodeValue` and `attributes` are included as a mechanism
++   to get at node information without casting down to the specific derived interface.
++   In cases where there is no obvious mapping of these attributes for a specific `nodeType`
++   (e.g., `nodeValue` for an `Element` or attributes for a `Comment`), this returns `null`.
++   Note that the specialized interfaces may contain additional and more convenient
++   mechanisms to get and set the relevant information.
++/
+interface Node(DOMString)
+{
+    /// A code representing the type of the underlying object.
+    @property NodeType nodeType();
+    /// The name of this node, depending on its type.
+    @property DOMString nodeName();
+    /++
+    +   Returns the local part of the qualified name of this node.
+    +
+    +   For nodes of any type other than `ELEMENT` and `ATTRIBUTE` and nodes created
+    +   with a DOM Level 1 method, such as `Document.createElement`, this is always `null`.
+    +/
+    @property DOMString localName();
+    /++
+    +   The namespace prefix of this node, or `null` if it is unspecified.
+    +   When it is defined to be `null`, setting it has no effect, including if
+    +   the node is read-only.
+    +   Note that setting this attribute, when permitted, changes the `nodeName`
+    +   attribute, which holds the qualified name, as well as the `tagName` and
+    +   `name` attributes of the `Element` and `Attr` interfaces, when applicable.
+    +   Setting the prefix to `null` makes it unspecified, setting it to an empty
+    +   string is implementation dependent.
+    +   Note also that changing the prefix of an attribute that is known to have a
+    +   default value, does not make a new attribute with the default value and the
+    +   original prefix appear, since the `namespaceURI` and `localName` do not change.
+    +   For nodes of any type other than `ELEMENT` and `ATTRIBUTE` and nodes created
+    +   with a DOM Level 1 method, such as `createElement` from the `Document`
+    +   interface, this is always `null`.
+    +/
+    @property DOMString prefix();
+    /// ditto
+    @property void prefix(DOMString);
+    /++
+    +   The namespace URI of this node, or `null` if it is unspecified.
+    +   This is not a computed value that is the result of a namespace lookup based
+    +   on an examination of the namespace declarations in scope. It is merely the
+    +   namespace URI given at creation time.
+    +   For nodes of any type other than `ELEMENT` and `ATTRIBUTE` and nodes created
+    +   with a DOM Level 1 method, such as `Document.createElement`, this is always `null`.
+    +/
+    @property DOMString namespaceURI();
+    /// The absolute base URI of this node or null if the implementation wasn't able to obtain an absolute URI
+    @property DOMString baseURI();
+
+    /// The value of this node, depending on its type.
+    @property DOMString nodeValue();
+    /// ditto
+    @property void nodeValue(DOMString);
+    @property DOMString textContent();
+    @property void textContent(DOMString);
+
+    /++
+    +   The parent of this node. All nodes, except `Attr`, `Document`, `DocumentFragment`,
+    +   `Entity`, and `Notation` may have a parent. However, if a node has just been
+    +   created and not yet added to the tree, or if it has been removed from the tree,
+    +   this is `null`.
+    +/
+    @property Node!DOMString parentNode();
+    /// A `NodeList` that contains all children of this node. If there are no children, this is a `NodeList` containing no nodes.
+    @property NodeList!DOMString childNodes();
+    /// The first child of this node. If there is no such node, this returns `null`.
+    @property Node!DOMString firstChild();
+    /// The last child of this node. If there is no such node, this returns `null`.
+    @property Node!DOMString lastChild();
+    /// The node immediately preceding this node. If there is no such node, this returns `null`.
+    @property Node!DOMString previousSibling();
+    /// The node immediately following this node. If there is no such node, this returns `null`.
+    @property Node!DOMString nextSibling();
+    /++
+    +   The `Document` object associated with this node. This is also the `Document`
+    +   object used to create new nodes. When this node is a `Document` or a `DocumentType`
+    +   which is not used with any `Document` yet, this is `null`.
+    +/
+    @property Document!DOMString ownerDocument();
+
+    /// A `NamedNodeMap` containing the attributes of this node (if it is an `Element`) or `null` otherwise.
+    @property NamedNodeMap!DOMString attributes();
+    /// Returns whether this node (if it is an element) has any attributes.
+    bool hasAttributes();
+
+    /++
+    +   Inserts the node `newChild` before the existing child node `refChild`.
+    +   If `refChild` is `null`, insert `newChild` at the end of the list of children.
+    +   If `newChild` is a `DocumentFragment` object, all of its children are inserted,
+    +   in the same order, before `refChild`. If the `newChild` is already in the
+    +   tree, it is first removed.
+    +/
+    Node!DOMString insertBefore(Node!DOMString newChild, Node!DOMString refChild);
+    /++
+    +   Replaces the child node `oldChild` with `newChild` in the list of children,
+    +   and returns the `oldChild` node.
+    +   If `newChild` is a `DocumentFragment` object, `oldChild` is replaced by
+    +   all of the `DocumentFragment` children, which are inserted in the same
+    +   order. If the `newChild` is already in the tree, it is first removed.
+    +/
+    Node!DOMString replaceChild(Node!DOMString newChild, Node!DOMString oldChild);
+    /// Removes the child node indicated by `oldChild` from the list of children, and returns it.
+    Node!DOMString removeChild(Node!DOMString oldChild);
+    Node!DOMString appendChild(Node!DOMString newChild);
+    /// Returns whether this node has any children.
+    bool hasChildNodes();
+
+    /++
+    +   Returns a duplicate of this node, i.e., serves as a generic copy constructor
+    +   for nodes. The duplicate node has no parent (`parentNode` is `null`) and no
+    +   user data. User data associated to the imported node is not carried over.
+    +   However, if any `UserData` handlers has been specified along with the
+    +   associated data these handlers will be called with the appropriate parameters
+    +   before this method returns.
+    +/
+    Node!DOMString cloneNode(bool deep);
+    bool isSameNode(Node!DOMString other);
+    bool isEqualNode(Node!DOMString arg);
+
+    /++
+    +   Puts all `Text` nodes in the full depth of the sub-tree underneath this
+    +   `Node`, including attribute nodes, into a "normal" form where only structure
+    +   (e.g., elements, comments, processing instructions, CDATA sections, and entity
+    +   references) separates `Text` nodes, i.e., there are neither adjacent `Text`
+    +   nodes nor empty `Text` nodes. This can be used to ensure that the DOM view
+    +   of a document is the same as if it were saved and re-loaded.
+    +/
+    void normalize();
+
+    /// Tests whether the DOM implementation implements a specific feature and that feature is supported by this node.
+    bool isSupported(string feature, string version_);
+    Object getFeature(string feature, string version_);
+
+    /++
+    +   Retrieves the object associated to a key on a this node. The object must
+    +   first have been set to this node by calling `setUserData` with the same key.
+    +/
+    UserData getUserData(string key);
+    /++
+    +   Associate an object to a key on this node.
+    +   The object can later be retrieved from this node by calling `getUserData` with the same key.
+    +/
+    UserData setUserData(string key, UserData data, UserDataHandler!DOMString handler);
+
+    /++
+    +   Compares the reference node, i.e. the node on which this method is being
+    +   called, with a node, i.e. the one passed as a parameter, with regard to
+    +   their position in the document and according to the document order.
+    +/
+    BitFlags!DocumentPosition compareDocumentPosition(Node!DOMString other);
+
+    /++
+    +   Look up the prefix associated to the given namespace URI, starting from this node.
+    +   The default namespace declarations are ignored by this method.
+    +/
+    DOMString lookupPrefix(DOMString namespaceURI);
+    /// Look up the namespace URI associated to the given `prefix`, starting from this node.
+    DOMString lookupNamespaceURI(DOMString prefix);
+    /// This method checks if the specified `namespaceURI` is the default namespace or not.
+    bool isDefaultNamespace(DOMString namespaceURI);
+}
+
+/++
++   The `NodeList` interface provides the abstraction of an ordered collection of
++   nodes, without defining or constraining how this collection is implemented.
++   `NodeList` objects in the DOM are live.
++
++   The items in the `NodeList` are accessible via an integral index, starting from `0`.
++/
+interface NodeList(DOMString)
+{
+    /++
+    +   Returns the `index`th item in the collection. If `index` is greater than
+    +   or equal to the number of nodes in the list, this returns `null`.
+    +/
+    Node!DOMString item(size_t index);
+    /++
+    +   The number of nodes in the list. The range of valid child node indices is
+    +   `0` to `length-1` inclusive.
+    +/
+    @property size_t length();
+}
+
+/++
++   Objects implementing the `NamedNodeMap` interface are used to represent collections
++   of nodes that can be accessed by name. Note that `NamedNodeMap` does not inherit
++   from `NodeList`; `NamedNodeMaps` are not maintained in any particular order.
++   Objects contained in an object implementing `NamedNodeMap` may also be accessed
++   by an ordinal index, but this is simply to allow convenient enumeration of the
++   contents of a `NamedNodeMap`, and does not imply that the DOM specifies an order
++   to these `Node`s.
++
++   `NamedNodeMap` objects in the DOM are live.
++/
+interface NamedNodeMap(DOMString)
+{
+    /++
+    +   Returns the `index`th item in the collection. If `index` is greater than
+    +   or equal to the number of nodes in the list, this returns `null`.
+    +/
+    Node!DOMString item(size_t index);
+    /++
+    +   The number of nodes in the list. The range of valid child node indices is
+    +   `0` to `length-1` inclusive.
+    +/
+    @property size_t length();
+
+    /// Retrieves a node specified by name.
+    Node!DOMString getNamedItem(DOMString name);
+    /++
+    +   Adds a node using its `nodeName` attribute. If a node with that name is
+    +   already present in this map, it is replaced by the new one. Replacing a
+    +   node by itself has no effect.
+    +   As the `nodeName` attribute is used to derive the name which the node must
+    +   be stored under, multiple nodes of certain types (those that have a "special"
+    +   string value) cannot be stored as the names would clash. This is seen as
+    +   preferable to allowing nodes to be aliased.
+    +/
+    Node!DOMString setNamedItem(Node!DOMString arg);
+    /++
+    +   Removes a node specified by name. When this map contains the attributes
+    +   attached to an element, if the removed attribute is known to have a default
+    +   value, an attribute immediately appears containing the default value as
+    +   well as the corresponding namespace URI, local name, and prefix when applicable.
+    +/
+    Node!DOMString removeNamedItem(DOMString name);
+
+    /++
+    +   Retrieves a node specified by local name and namespace URI.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Node!DOMString getNamedItemNS(DOMString namespaceURI, DOMString localName);
+    /++
+    +   Adds a node using its `namespaceURI` and `localName`. If a node with that
+    +   namespace URI and that local name is already present in this map, it is
+    +   replaced by the new one. Replacing a node by itself has no effect.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the namespaceURI parameter for methods if they wish to have no namespace.
+    +/
+    Node!DOMString setNamedItemNS(Node!DOMString arg);
+    /++
+    +   Removes a node specified by local name and namespace URI. A removed attribute
+    +   may be known to have a default value when this map contains the attributes attached
+    +   to an element, as returned by the attributes attribute of the `Node` interface.
+    +   If so, an attribute immediately appears containing the default value as well
+    +   as the corresponding namespace URI, local name, and prefix when applicable.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Node!DOMString removeNamedItemNS(DOMString namespaceURI, DOMString localName);
+}
+
+/++
++   The `CharacterData` interface extends `Node` with a set of attributes and methods
++   for accessing character data in the DOM. For clarity this set is defined here
++   rather than on each object that uses these attributes and methods. No DOM objects
++   correspond directly to `CharacterData`, though `Text` and others do inherit
++   the interface from it. All offsets in this interface start from `0`.
++/
+interface CharacterData(DOMString): Node!DOMString
+{
+    @property DOMString data();
+    @property void data(DOMString);
+
+    @property size_t length();
+
+    /// Extracts a substring of `data` starting at `offset`, with length `count`.
+    DOMString substringData(size_t offset, size_t count);
+    /++
+    +   Append the string to the end of the character data of the node. Upon success,
+    +   data provides access to the concatenation of data and the DOMString specified.
+    +/
+    void appendData(DOMString arg);
+    /// Insert a string at the specified offset.
+    void insertData(size_t offset, DOMString arg);
+    /// Remove a range of characters from the node. Upon success, `data` and `length` reflect the change.
+    void deleteData(size_t offset, size_t count);
+    /// Replace `count` characters starting at the specified offset with the specified string.
+    void replaceData(size_t offset, size_t count, DOMString arg);
+}
+
+/++
++   The `Attr` interface represents an attribute in an `Element` object. Typically
++   the allowable values for the attribute are defined in a schema associated with the document.
++
++   `Attr` objects inherit the `Node` interface, but since they are not actually
++   child nodes of the element they describe, the DOM does not consider them part
++   of the document tree. Thus, the `Node` attributes `parentNode`, `previousSibling`
++   and `nextSibling` have a `null` value for `Attr` objects. The DOM takes the
++   view that attributes are properties of elements rather than having a separate
++   identity from the elements they are associated with; this should make it more
++   efficient to implement such features as default attributes associated with all
++   elements of a given type. Furthermore, `Attr` nodes may not be immediate children
++   of a `DocumentFragment`. However, they can be associated with `Element` nodes
++   contained within a `DocumentFragment`. In short, users and implementors of the
++   DOM need to be aware that `Attr` nodes have some things in common with other
++   objects inheriting the `Node` interface, but they also are quite distinct.
++/
+interface Attr(DOMString): Node!DOMString
+{
+    /++
+    +   Returns the _name of this attribute. If `Node.localName` is different from
+    +   `null`, this attribute is a qualified name.
+    +/
+    @property DOMString name();
+    /++
+    +   `true` if this attribute was explicitly given a value in the instance document,
+    +   `false` otherwise. If the application changed the value of this attribute
+    +   node (even if it ends up having the same value as the default value) then
+    +   it is set to `true`. The implementation may handle attributes with default
+    +   values from other schemas similarly but applications should use `Document.normalizeDocument`
+    +   to guarantee this information is up-to-date.
+    +/
+    @property bool specified();
+    /++
+    +   On retrieval, the value of the attribute is returned as a `DOMString`.
+    +   Character and general entity references are replaced with their values.
+    +   See also the method `getAttribute` on the `Element` interface.
+    +   On setting, this creates a `Text` node with the unparsed contents of the
+    +   string, i.e. any characters that an XML processor would recognize as markup
+    +   are instead treated as literal text.
+    +   See also the method `Element.setAttribute`.
+    +/
+    @property DOMString value();
+    /// ditto
+    @property void value(DOMString);
+
+    /// The `Element` node this attribute is attached to or `null` if this attribute is not in use.
+    @property Element!DOMString ownerElement();
+    /++
+    +   The type information associated with this attribute. While the type information
+    +   contained in this attribute is guarantee to be correct after loading the
+    +   document or invoking `Document.normalizeDocument`, `schemaTypeInfo` may
+    +   not be reliable if the node was moved.
+    +/
+    @property XMLTypeInfo!DOMString schemaTypeInfo();
+    /++
+    +   Returns whether this attribute is known to be of type ID (i.e. to contain
+    +   an identifier for its owner element) or not. When it is and its value is
+    +   unique, the ownerElement of this attribute can be retrieved using the method
+    +   `Document.getElementById`.
+    +/
+    @property bool isId();
+}
+
+interface Element(DOMString): Node!DOMString
+{
+    /// The name of the element. If `Node.localName` is different from `null`, this attribute is a qualified name.
+    @property DOMString tagName();
+
+    /// Retrieves an attribute value by name.
+    DOMString getAttribute(DOMString name);
+    /++
+    +   Adds a new attribute. If an attribute with that name is already present in
+    +   the element, its value is changed to be that of the value parameter. This
+    +   value is a simple string; it is not parsed as it is being set. So any markup
+    +   (such as syntax to be recognized as an entity reference) is treated as
+    +   literal text, and needs to be appropriately escaped by the implementation
+    +   when it is written out. In order to assign an attribute value that contains
+    +   entity references, the user must create an `Attr` node plus any `Text` and
+    +   `EntityReference` nodes, build the appropriate subtree, and use `setAttributeNode`
+    +   to assign it as the value of an attribute.
+    +   To set an attribute with a qualified name and namespace URI, use the `setAttributeNS` method.
+    +/
+    void setAttribute(DOMString name, DOMString value);
+    /++
+    +   Removes an attribute by name. If a default value for the removed attribute
+    +   is defined in the DTD, a new attribute immediately appears with the default
+    +   value as well as the corresponding namespace URI, local name, and prefix
+    +   when applicable.
+    +   To remove an attribute by local name and namespace URI, use the `removeAttributeNS` method.
+    +/
+    void removeAttribute(DOMString name);
+
+    /// Retrieves an attribute node by name.
+    Attr!DOMString getAttributeNode(DOMString name);
+    /++
+    +   Adds a new attribute node. If an attribute with that name (`nodeName`) is
+    +   already present in the element, it is replaced by the new one. Replacing an
+    +   attribute node by itself has no effect.
+    +   To add a new attribute node with a qualified name and namespace URI, use
+    +   the `setAttributeNodeNS` method.
+    +/
+    Attr!DOMString setAttributeNode(Attr!DOMString newAttr);
+    /++
+    +   Removes the specified attribute node. If a default value for the removed attribute
+    +   is defined in the DTD, a new attribute immediately appears with the default
+    +   value as well as the corresponding namespace URI, local name, and prefix
+    +   when applicable.
+    +/
+    Attr!DOMString removeAttributeNode(Attr!DOMString oldAttr);
+
+    /++
+    +   Retrieves an attribute value by local name and namespace URI.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    DOMString getAttributeNS(DOMString namespaceURI, DOMString localName);
+    /++
+    +   Adds a new attribute. If an attribute with the same local name and namespace
+    +   URI is already present on the element, its prefix is changed to be the prefix
+    +   part of the qualifiedName, and its value is changed to be the value parameter.
+    +   This value is a simple string; it is not parsed as it is being set. So any markup
+    +   (such as syntax to be recognized as an entity reference) is treated as
+    +   literal text, and needs to be appropriately escaped by the implementation
+    +   when it is written out. In order to assign an attribute value that contains
+    +   entity references, the user must create an `Attr` node plus any `Text` and
+    +   `EntityReference` nodes, build the appropriate subtree, and use `setAttributeNode`
+    +   to assign it as the value of an attribute.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    void setAttributeNS(DOMString namespaceURI, DOMString qualifiedName, DOMString value);
+    /++
+    +   Removes an attribute by local name and namespace URI. If a default value
+    +   for the removed attribute is defined in the DTD, a new attribute immediately
+    +   appears with the default value as well as the corresponding namespace URI,
+    +   local name, and prefix when applicable.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    void removeAttributeNS(DOMString namespaceURI, DOMString localName);
+
+    /++
+    +   Retrieves an `Attr` node by local name and namespace URI.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Attr!DOMString getAttributeNodeNS(DOMString namespaceURI, DOMString localName);
+    /++
+    +   Adds a new attribute. If an attribute with that local name and that namespace
+    +   URI is already present in the element, it is replaced by the new one. Replacing
+    +   an attribute node by itself has no effect.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    Attr!DOMString setAttributeNodeNS(Attr!DOMString newAttr);
+
+    /// Returns `true` when an attribute with a given `name` is specified on this element or has a default value, `false` otherwise.
+    bool hasAttribute(DOMString name);
+    /++
+    +   Returns `true` when an attribute with a given `localName` and `namespaceURI`
+    +   is specified on this element or has a default value, `false` otherwise.
+    +   Per the XML Namespaces specification, applications must use the value `null`
+    +   as the `namespaceURI` parameter for methods if they wish to have no namespace.
+    +/
+    bool hasAttributeNS(DOMString namespaceURI, DOMString localName);
+
+    /++
+    +   If the parameter `isId` is `true`, this method declares the specified
+    +   attribute to be a user-determined ID attribute. This affects the value of
+    +   `Attr.isId` and the behavior of `Document.getElementById`, but does not
+    +   change any schema that may be in use, in particular this does not affect
+    +   the `Attr.schemaTypeInfo` of the specified `Attr` node. Use the value `false`
+    +   for the parameter `isId` to undeclare an attribute for being a user-determined ID attribute.
+    +/
+    void setIdAttribute(DOMString name, bool isId);
+    /// ditto
+    void setIdAttributeNS(DOMString namespaceURI, DOMString localName, bool isId);
+    /// ditto
+    void setIdAttributeNode(Attr!DOMString idAttr, bool isId);
+
+    /// Returns a `NodeList` of all descendant `Element`s with a given tag name, in document order.
+    NodeList!DOMString getElementsByTagName(DOMString name);
+    /// Returns a `NodeList` of all the descendant `Element`s with a given local name and namespace URI in document order.
+    NodeList!DOMString getElementsByTagNameNS(DOMString namespaceURI, DOMString localName);
+
+    /// The type information associated with this element.
+    @property XMLTypeInfo!DOMString schemaTypeInfo();
+}
+
+/++
++   The `Text` interface inherits from `CharacterData` and represents the textual
++   content (termed character data in XML) of an `Element` or `Attr`. If there is
++   no markup inside an element's content, the text is contained in a single object
++   implementing the `Text` interface that is the only child of the element. If
++   there is markup, it is parsed into the information items (elements, comments,
++   etc.) and `Text` nodes that form the list of children of the element.
++/
+interface Text(DOMString): CharacterData!DOMString
+{
+    /++
+    +   Breaks this node into two nodes at the specified `offset`, keeping both
+    +   in the tree as siblings. After being split, this node will contain all
+    +   the content up to the `offset` point. A new node of the same type, which
+    +   contains all the content at and after the `offset` point, is returned.
+    +   If the original node had a parent node, the new node is inserted as the
+    +   next sibling of the original node. When the `offset` is equal to the length
+    +   of this node, the new node has no data.
+    +/
+    Text!DOMString splitText(size_t offset);
+
+    /// Returns whether this text node contains element content whitespace, often abusively called "ignorable whitespace".
+    @property bool isElementContentWhitespace();
+
+    @property DOMString wholeText();
+    Text!DOMString replaceWholeText(DOMString content);
+}
+
+/++
++   This interface inherits from `CharacterData` and represents the content of a
++   comment, i.e., all the characters between the starting '<!--' and ending '-->'.
++/
+interface Comment(DOMString): CharacterData!DOMString
+{
+}
+
+/++
++   The `TypeInfo` interface represents a type referenced from `Element` or `Attr`
++   nodes, specified in the schemas associated with the document. The type is a
++   pair of a namespace URI and name properties, and depends on the document's schema.
++/
+interface XMLTypeInfo(DOMString)
+{
+    @property DOMString typeName();
+    @property DOMString typeNamespace();
+
+    bool isDerivedFrom(DOMString typeNamespaceArg, DOMString typeNameArg, DerivationMethod derivationMethod);
+}
+
+/// DOMError is an interface that describes an error.
+interface DOMError(DOMString)
+{
+    @property ErrorSeverity severity();
+    @property DOMString message();
+    @property DOMString type();
+    @property Object relatedException();
+    @property Object relatedData();
+    @property DOMLocator!DOMString location();
+}
+
+/// `DOMLocator` is an interface that describes a location (e.g. where an error occurred).
+interface DOMLocator(DOMString)
+{
+    @property long lineNumber();
+    @property long columnNumber();
+    @property long byteOffset();
+    @property Node!DOMString relatedNode();
+    @property DOMString uri();
+}
+
+/++
++   The `DOMConfiguration` interface represents the configuration of a document
++   and maintains a table of recognized parameters. Using the configuration, it
++   is possible to change `Document.normalizeDocument` behavior, such as replacing
++   the `CDATASection` nodes with `Text` nodes or specifying the type of the schema
++   that must be used when the validation of the `Document` is requested.
++/
+interface DOMConfiguration(DOMString)
+{
+    void setParameter(string name, UserData value);
+    UserData getParameter(string name);
+    bool canSetParameter(string name, UserData value);
+    @property DOMStringList!string parameterNames();
+}
+
+/++
++   CDATA sections are used to escape blocks of text containing characters that would
++   otherwise be regarded as markup. The only delimiter that is recognized in a CDATA
++   section is the "]]>" string that ends the CDATA section. CDATA sections cannot be nested.
++   Their primary purpose is for including material such as XML fragments, without
++   needing to escape all the delimiters.
++
++   The `CDATASection` interface inherits from the `CharacterData` interface through
++   the `Text` interface. Adjacent `CDATASection` nodes are not merged by use of the
++   normalize method of the `Node` interface.
++/
+interface CDATASection(DOMString): Text!DOMString
+{
+}
+
+/++
++   Each `Document` has a `doctype` attribute whose value is either `null` or a
++   `DocumentType` object. The `DocumentType` interface in the DOM Core provides
++   an interface to the list of entities that are defined for the document, and
++   little else because the effect of namespaces and the various XML schema efforts
++   on DTD representation are not clearly understood as of this writing.
++
++   DOM Level 3 doesn't support editing `DocumentType` nodes. `DocumentType` nodes are read-only.
++/
+interface DocumentType(DOMString): Node!DOMString
+{
+    /// The name of DTD; i.e., the name immediately following the `DOCTYPE` keyword.
+    @property DOMString name();
+    /++
+    +   A `NamedNodeMap` containing the general entities, both external and internal,
+    +   declared in the DTD. Parameter entities are not contained. Duplicates are discarded.
+    +/
+    @property NamedNodeMap!DOMString entities();
+    /++
+    +   A `NamedNodeMap` containing the notations declared in the DTD. Duplicates are discarded.
+    +   Every node in this map also implements the `Notation` interface.
+    +/
+    @property NamedNodeMap!DOMString notations();
+    /// The public identifier of the external subset.
+    @property DOMString publicId();
+    /// The system identifier of the external subset. This may be an absolute URI or not.
+    @property DOMString systemId();
+    /++
+    +   The internal subset as a string, or `null` if there is none.
+    +   This is does not contain the delimiting square brackets.
+    +
+    +   Note:
+    +   The actual content returned depends on how much information is available
+    +   to the implementation. This may vary depending on various parameters,
+    +   including the XML processor used to build the document.
+    +/
+    @property DOMString internalSubset();
+}
+
+/++
++   This interface represents a notation declared in the DTD. A notation either
++   declares, by name, the format of an unparsed entity or is used for formal
++   declaration of processing instruction targets. The `nodeName` attribute
++   inherited from `Node` is set to the declared name of the notation.
++
++   The DOM Core does not support editing `Notation` nodes; they are therefore readonly.
++
++   A `Notation` node does not have any parent.
++/
+interface Notation(DOMString): Node!DOMString
+{
+    /// The public identifier of this notation. If the public identifier was not specified, this is `null`.
+    @property DOMString publicId();
+    /++
+    +   The system identifier of this notation. If the system identifier was not
+    +   specified, this is `null`. This may be an absolute URI or not.
+    +/
+    @property DOMString systemId();
+}
+
+/++
++   This interface represents a known entity, either parsed or unparsed, in an XML
++   document. Note that this models the entity itself not the entity declaration.
++
++   The `nodeName` attribute that is inherited from `Node` contains the name of the entity.
++
++   An XML processor may choose to completely expand entities before the structure
++   model is passed to the DOM; in this case there will be no `EntityReference`
++   nodes in the document tree.
++
++   DOM Level 3 does not support editing `Entity` nodes; if a user wants to make
++   changes to the contents of an `Entity`, every related `EntityReference` node
++   has to be replaced in the structure model by a clone of the `Entity`'s contents,
++   and then the desired changes must be made to each of those clones instead.
++   `Entity` nodes and all their descendants are readonly.
++
++   An `Entity` node does not have any parent.
++/
+interface Entity(DOMString): Node!DOMString
+{
+    /// The public identifier associated with the entity if specified, and `null` otherwise.
+    @property DOMString publicId();
+    /++
+    +   The system identifier associated with the entity if specified, and `null` otherwise.
+    +   This may be an absolute URI or not.
+    +/
+    @property DOMString systemId();
+    /// For unparsed entities, the name of the `Notation` for the entity. For parsed entities, this is `null`.
+    @property DOMString notationName();
+    /++
+    +   An attribute specifying the encoding used for this entity at the time of
+    +   parsing, when it is an external parsed entity. This is `null` if it an
+    +   entity from the internal subset or if it is not known.
+    +/
+    @property DOMString inputEncoding();
+    /++
+    +   An attribute specifying, as part of the text declaration, the encoding of
+    +   this entity, when it is an external parsed entity. This is `null` otherwise.
+    +/
+    @property DOMString xmlEncoding();
+    /++
+    +   An attribute specifying, as part of the text declaration, the version
+    +   number of this entity, when it is an external parsed entity. This is
+    +   `null` otherwise.
+    +/
+    @property DOMString xmlVersion();
+}
+
+/++
++   `EntityReference` nodes may be used to represent an entity reference in the tree.
++   When an `EntityReference` node represents a reference to an unknown entity, the
++   node has no children and its replacement value, when used by `Attr.value` for example, is empty.
++
++   As for `Entity` nodes, `EntityReference` nodes and all their descendants are readonly.
++/
+interface EntityReference(DOMString): Node!DOMString
+{
+}
+
+/++
++   The `ProcessingInstruction` interface represents a "processing instruction",
++   used in XML as a way to keep processor-specific information in the text of the document.
++/
+interface ProcessingInstruction(DOMString): Node!DOMString
+{
+    /++
+    +   The target of this processing instruction. XML defines this as being the
+    +   first token following the markup that begins the processing instruction.
+    +/
+    @property DOMString target();
+    /++
+    +   The content of this processing instruction. This is from the first non white
+    +   space character after the target to the character immediately preceding the `?>`.
+    +/
+    @property DOMString data();
+    /// ditto
+    @property void data(DOMString);
+}

--- a/std/experimental/xml/dom.d
+++ b/std/experimental/xml/dom.d
@@ -51,18 +51,18 @@ alias UserDataHandler(DOMString) =
 +/
 enum NodeType: ushort
 {
-    ELEMENT = 1,
-    ATTRIBUTE,
-    TEXT,
-    CDATA_SECTION,
-    ENTITY_REFERENCE,
-    ENTITY,
-    PROCESSING_INSTRUCTION,
-    COMMENT,
-    DOCUMENT,
-    DOCUMENT_TYPE,
-    DOCUMENT_FRAGMENT,
-    NOTATION,
+    element = 1,
+    attribute,
+    text,
+    cdataSection,
+    entityReference,
+    entity,
+    processingInstruction,
+    comment,
+    document,
+    documentType,
+    documentFragment,
+    notation,
 }
 
 /++
@@ -72,25 +72,25 @@ enum NodeType: ushort
 enum DocumentPosition: ushort
 {
     /// Set when the two nodes are in fact the same
-    NONE         = 0,
+    none         = 0,
     /// Set when the two nodes are not in the same tree
-    DISCONNECTED = 1,
+    disconnected = 1,
     /// Set when the second node precedes the first
-    PRECEDING    = 2,
+    preceding    = 2,
     /// Set when the second node follows the first
-    FOLLOWING    = 4,
-    /// Set when the second node contains the first
-    CONTAINS     = 8,
+    following    = 4,
+    /// Set when the second node _contains the first
+    contains     = 8,
     /// Set when the second node is contained by the first
-    CONTAINED_BY = 16,
+    containedBy = 16,
     /++
     +   Set when the returned ordering of the two nodes may be different across
     +   DOM implementations; for example, for two attributes of the same node,
-    +   an implementation may return `PRECEDING | IMPLEMENTATION_SPECIFIC` and another
-    +   may return `FOLLOWING | IMPLEMENTATION_SPECIFIC`, because at the DOM level
+    +   an implementation may return `preceding | implementationSpecific` and another
+    +   may return `following | implementationSpecific`, because at the DOM level
     +   the attributes ordering is unspecified
     +/
-    IMPLEMENTATION_SPECIFIC = 32,
+    implementationSpecific = 32,
 }
 
 /++
@@ -99,20 +99,21 @@ enum DocumentPosition: ushort
 enum UserDataOperation: ushort
 {
     /// The node is cloned, using `Node.cloneNode()`.
-    NODE_CLONED = 1,
+    nodeCloned = 1,
     /// The node is imported, using `Document.importNode()`.
-    NODE_IMPORTED,
+    nodeImported,
     /++
     +   The node is deleted.
+    +
     +   Note:
     +   This may not be supported or may not be reliable in certain environments,
     +   where the implementation has no real control over when objects are actually deleted.
     +/
-    NODE_DELETED,
+    nodeDeleted,
     /// The node is renamed, using `Document.renameNode()`.
-    NODE_RENAMED,
+    nodeRenamed,
     /// The node is adopted, using `Document.adoptNode()`.
-    NODE_ADOPTED,
+    nodeAdopted,
 }
 
 /++
@@ -124,39 +125,39 @@ enum UserDataOperation: ushort
 enum ExceptionCode: ushort
 {
     /// If index or size is negative, or greater than the allowed value.
-    INDEX_SIZE,
+    indexSize,
     /// If the specified range of text does not fit into a `DOMString`.
-    DOMSTRING_SIZE,
+    domStringSize,
     /// If any `Node` is inserted somewhere it doesn't belong.
-    HIERARCHY_REQUEST,
+    hierarchyRequest,
     /// If a `Node` is used in a different document than the one that created it (that doesn't support it).
-    WRONG_DOCUMENT,
+    wrongDocument,
     /// If an invalid or illegal character is specified, such as in an XML name.
-    INVALID_CHARACTER,
+    invalidCharacter,
     /// If data is specified for a `Node` which does not support data.
-    NO_DATA_ALLOWED,
+    noDataAllowed,
     /// If an attempt is made to modify an object where modifications are not allowed.
-    NO_MODIFICATION_ALLOWED,
+    noModificationAllowed,
     /// If an attempt is made to reference a `Node` in a context where it does not exist.
-    NOT_FOUND,
+    notFound,
     /// If the implementation does not support the requested type of object or operation.
-    NOT_SUPPORTED,
+    notSupported,
     /// If an attempt is made to add an attribute that is already in use elsewhere.
-    INUSE_ATTRIBUTE,
+    inuseAttribute,
     /// If an attempt is made to use an object that is not, or is no longer, usable.
-    INVALID_STATE,
+    invalidState,
     /// If an invalid or illegal string is specified.
-    SYNTAX,
+    syntax,
     /// If an attempt is made to modify the type of the underlying object.
-    INVALID_MODIFICATION,
+    invalidModification,
     /// If an attempt is made to create or change an object in a way which is incorrect with regard to namespaces.
-    NAMESPACE,
+    namespace,
     /// If a parameter or an operation is not supported by the underlying object.
-    INVALID_ACCESS,
+    invalidAccess,
     /// If a call to a method such as insertBefore or removeChild would make the `Node` invalid.
-    VALIDATION,
+    validation,
     /// If the type of an object is incompatible with the expected type of the parameter associated to the object.
-    TYPE_MISMATCH,
+    typeMismatch,
 }
 
 /// An integer indicating the severity of a `DOMError`.
@@ -167,28 +168,28 @@ enum ErrorSeverity: ushort
     +   will not cause the processing to stop, unless the call of the `DOMErrorHandler`
     +   returns `false`.
     +/
-    WARNING,
+    warning,
     /++
     +   The severity of the error described by the `DOMError` is error. A `ERROR`
     +   may not cause the processing to stop if the error can be recovered, unless
     +   the call of the `DOMErrorHandler` returns `false`.
     +/
-    ERROR,
+    error,
     /++
     +   The severity of the error described by the `DOMError` is fatal error. A `FATAL_ERROR`
     +   will cause the normal processing to stop. The return value of calling the `DOMErrorHandler`
     +   is ignored unless the implementation chooses to continue, in which case
     +   the behavior becomes undefined.
     +/
-    FATAL_ERROR,
+    fatalError,
 }
 
 enum DerivationMethod: ulong
 {
-    DERIVATION_RESTRICTION = 0x00000001,
-    DERIVATION_EXTENSION   = 0x00000002,
-    DERIVATION_UNION       = 0x00000004,
-    DERIVATION_LIST        = 0x00000008,
+    restriction = 0x00000001,
+    extension   = 0x00000002,
+    union_      = 0x00000004,
+    list        = 0x00000008,
 }
 
 /++

--- a/std/experimental/xml/domimpl.d
+++ b/std/experimental/xml/domimpl.d
@@ -1522,9 +1522,9 @@ class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = b
             // specific to NamedNodeMap
             public override
             {
-                ulong length()
+                size_t length()
                 {
-                    ulong res = 0;
+                    size_t res = 0;
                     auto attr = firstAttr;
                     while (attr)
                     {
@@ -1533,9 +1533,9 @@ class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = b
                     }
                     return res;
                 }
-                Attr item(ulong index)
+                Attr item(size_t index)
                 {
-                    ulong count = 0;
+                    size_t count = 0;
                     auto res = firstAttr;
                     while (res && count < index)
                     {

--- a/std/experimental/xml/domimpl.d
+++ b/std/experimental/xml/domimpl.d
@@ -1,0 +1,2062 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   Provides an implementation of the DOM Level 3 specification.
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.domimpl;
+
+import std.experimental.xml.interfaces;
+import dom = std.experimental.xml.dom;
+import std.typecons : rebindable, Flag, BitFlags;
+import std.experimental.allocator;
+import std.experimental.allocator.gc_allocator;
+
+/++
++   An implementation of $(LINK2 ../dom/DOMImplementation, `std.experimental.xml.dom.DOMImplementation`).
++
++   It allows to specify a custom allocator to be used when creating instances of the DOM classes.
++   As keeping track of the lifetime of every node would be very complex, this implementation
++   does not try to do so. Instead, no object is ever deallocated; it is the users responsibility
++   to directly free the allocator memory when all objects are no longer reachable.
++/
+class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = bool delegate(dom.DOMError!DOMString))
+                        : dom.DOMImplementation!DOMString
+{
+    mixin UsesAllocator!(Alloc, true);
+
+    override
+    {
+        DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId)
+        {
+            auto res = allocator.make!DocumentType(this);
+            res._name = qualifiedName;
+            res._publicId = publicId;
+            res._systemId = systemId;
+            return res;
+        }
+        Document createDocument(DOMString namespaceURI, DOMString qualifiedName, dom.DocumentType!DOMString _doctype)
+        {
+            auto doctype = cast(DocumentType)_doctype;
+            if (_doctype && !doctype)
+                throw allocator.make!DOMException(this, dom.ExceptionCode.WRONG_DOCUMENT);
+
+            auto doc = allocator.make!Document(this);
+            doc._ownerDocument = doc;
+            doc._doctype = doctype;
+            doc._config = allocator.make!DOMConfiguration(this);
+
+            if (namespaceURI)
+            {
+                if (!qualifiedName)
+                    throw allocator.make!DOMException(this, dom.ExceptionCode.NAMESPACE);
+                doc.appendChild(doc.createElementNS(namespaceURI, qualifiedName));
+            }
+            else if (qualifiedName)
+                doc.appendChild(doc.createElement(qualifiedName));
+
+            return doc;
+        }
+        bool hasFeature(string feature, string version_)
+        {
+            return (feature == "Core" || feature == "XML")
+                && (version_ == "1.0" || version_ == "2.0" || version_ == "3.0");
+        }
+        DOMImplementation getFeature(string feature, string version_)
+        {
+            if (hasFeature(feature, version_))
+                return this;
+            else
+                return null;
+        }
+    }
+
+    class DOMException: dom.DOMException
+    {
+        pure nothrow @nogc @safe this(dom.ExceptionCode code, string file = __FILE__, size_t line = __LINE__)
+        {
+            _code = code;
+            super("", file, line);
+        }
+        override @property dom.ExceptionCode code()
+        {
+            return _code;
+        }
+        private dom.ExceptionCode _code;
+    }
+    abstract class Node: dom.Node!DOMString
+    {
+        override
+        {
+            @property Node parentNode() { return _parentNode; }
+            @property Node previousSibling() { return _previousSibling; }
+            @property Node nextSibling() { return _nextSibling; }
+            @property Document ownerDocument() { return _ownerDocument; }
+
+            bool isSameNode(dom.Node!DOMString other)
+            {
+                return this is other;
+            }
+            bool isEqualNode(dom.Node!DOMString other)
+            {
+                import std.traits: AliasSeq;
+
+                if (!other || nodeType != other.nodeType)
+                    return false;
+
+                foreach (field; AliasSeq!("nodeName", "localName", "namespaceURI", "prefix", "nodeValue"))
+                {
+                    mixin("auto a = " ~ field ~ ";\n");
+                    mixin("auto b = other." ~ field ~ ";\n");
+                    if ((a is null && b !is null) || (b is null && a !is null) || (a !is null && b !is null && a != b))
+                        return false;
+                }
+
+                auto thisWithChildren = cast(NodeWithChildren)this;
+                if (thisWithChildren)
+                {
+                    auto otherChild = other.firstChild;
+                    foreach (child; thisWithChildren.childNodes)
+                    {
+                        if (!child.isEqualNode(otherChild))
+                            return false;
+                        otherChild = otherChild.nextSibling;
+                    }
+                    if (otherChild !is null)
+                        return false;
+                }
+
+                return true;
+            }
+
+            dom.UserData setUserData(string key, dom.UserData data, dom.UserDataHandler!DOMString handler)
+            {
+                userData[key] = data;
+                if (handler)
+                    userDataHandlers[key] = handler;
+                return data;
+            }
+            dom.UserData getUserData(string key) const
+            {
+                if (key in userData)
+                    return userData[key];
+                return dom.UserData(null);
+            }
+
+            bool isSupported(string feature, string version_)
+            {
+                return (feature == "Core" || feature == "XML")
+                    && (version_ == "1.0" || version_ == "2.0" || version_ == "3.0");
+            }
+            Node getFeature(string feature, string version_)
+            {
+                if (isSupported(feature, version_))
+                    return this;
+                else
+                    return null;
+            }
+
+            BitFlags!(dom.DocumentPosition) compareDocumentPosition(dom.Node!DOMString _other)
+            {
+                enum Ret(dom.DocumentPosition flag) = cast(BitFlags!(dom.DocumentPosition)) flag;
+
+                auto other = cast(Node)_other;
+                if (!other)
+                    return Ret!(dom.DocumentPosition.DISCONNECTED);
+
+                if (this is other)
+                    return Ret!(dom.DocumentPosition.NONE);
+
+                auto node1 = other;
+                auto node2 = this;
+                Attr attr1 = cast(Attr)node1;
+                Attr attr2 = cast(Attr)node2;
+
+                if (attr1 && attr1.ownerElement)
+                    node1 = attr1.ownerElement;
+                if (attr2 && attr2.ownerElement)
+                {
+                    node2 = attr2.ownerElement;
+                    if (attr1 && node2 is node1)
+                    {
+                        foreach (attr; (cast(Element)node2).attributes) with (dom.DocumentPosition)
+                        {
+                            if (attr is attr1)
+                                return Ret!IMPLEMENTATION_SPECIFIC | Ret!PRECEDING;
+                            else if (attr is attr2)
+                                return Ret!IMPLEMENTATION_SPECIFIC | Ret!FOLLOWING;
+                        }
+                    }
+                }
+
+                void rootAndDepth(ref Node node, out int depth)
+                {
+                    while (node.parentNode)
+                    {
+                        node = node.parentNode;
+                        depth++;
+                    }
+                }
+                Node root1 = node1, root2 = node2;
+                int depth1, depth2;
+                rootAndDepth(root1, depth1);
+                rootAndDepth(root2, depth2);
+
+                if (root1 !is root2) with (dom.DocumentPosition)
+                {
+                    if (cast(void*)root1 < cast(void*)root2)
+                        return Ret!DISCONNECTED | Ret!IMPLEMENTATION_SPECIFIC | Ret!PRECEDING;
+                    else
+                        return Ret!DISCONNECTED | Ret!IMPLEMENTATION_SPECIFIC | Ret!FOLLOWING;
+                }
+
+                bool swapped = depth1 < depth2;
+                if (swapped)
+                {
+                    import std.algorithm: swap;
+                    swap(depth1, depth2);
+                    swap(node1, node2);
+                    swapped = true;
+                }
+                while (depth1-- > depth2)
+                {
+                    node1 = node1.parentNode;
+                }
+                if (node1 is node2) with (dom.DocumentPosition)
+                {
+                    if (swapped)
+                        return Ret!CONTAINS | Ret!PRECEDING;
+                    else
+                        return Ret!CONTAINED_BY | Ret!FOLLOWING;
+                }
+                while(true)
+                {
+                    if (node1.parentNode is node2.parentNode)
+                    {
+                        while (node1.nextSibling)
+                        {
+                            node1 = node1.nextSibling;
+                            if (node1 is node2)
+                                return Ret!(dom.DocumentPosition.PRECEDING);
+                        }
+                        return Ret!(dom.DocumentPosition.FOLLOWING);
+                    }
+                    node1 = node1.parentNode;
+                    node2 = node2.parentNode;
+                }
+                assert(0, "Control flow should never reach this...\nPlease file an issue");
+            }
+        }
+        private
+        {
+            dom.UserData[string] userData;
+            dom.UserDataHandler!DOMString[string] userDataHandlers;
+            Node _previousSibling, _nextSibling, _parentNode;
+            Document _ownerDocument;
+
+            // internal methods
+            Element parentElement()
+            {
+                auto parent = parentNode;
+                while (parent && parent.nodeType != dom.NodeType.ELEMENT)
+                    parent = parent.parentNode;
+                return cast(Element)parent;
+            }
+            void performClone(Node dest, bool deep)
+            {
+                foreach (data; userDataHandlers.byKeyValue)
+                {
+                    auto value = data.value;
+                    // putting data.value directly in the following line causes an error; should investigate further
+                    value(dom.UserDataOperation.NODE_CLONED, data.key, userData[data.key], this, dest);
+                }
+            }
+        }
+        // method that must be overridden
+        // just because otherwise it doesn't work [bugzilla 16318]
+        abstract override DOMString nodeName();
+        // methods specialized in NodeWithChildren
+        override
+        {
+            @property ChildList childNodes()
+            {
+                static ChildList emptyList;
+                if (!emptyList)
+                {
+                    emptyList = allocator.make!ChildList(this);
+                    emptyList.currentChild = firstChild;
+                }
+                return emptyList;
+            }
+            @property Node firstChild() { return null; }
+            @property Node lastChild() { return null; }
+
+            Node insertBefore(dom.Node!DOMString _newChild, dom.Node!DOMString _refChild)
+            {
+                throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+            }
+            Node replaceChild(dom.Node!DOMString newChild, dom.Node!DOMString oldChild)
+            {
+                throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+            }
+            Node removeChild(dom.Node!DOMString oldChild)
+            {
+                throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+            }
+            Node appendChild(dom.Node!DOMString newChild)
+            {
+                throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+            }
+            bool hasChildNodes() const { return false; }
+        }
+        // methods specialized in Element
+        override
+        {
+            @property Element.Map attributes() { return null; }
+            bool hasAttributes() { return false; }
+        }
+        // methods specialized in various subclasses
+        override
+        {
+            @property DOMString nodeValue() { return null; }
+            @property void nodeValue(DOMString) {}
+            @property DOMString textContent() { return null; }
+            @property void textContent(DOMString) {}
+            @property DOMString baseURI()
+            {
+                if (parentNode)
+                    return parentNode.baseURI;
+                return null;
+            }
+
+            Node cloneNode(bool deep) { return null; }
+        }
+        // methods specialized in Element and Attribute
+        override
+        {
+            @property DOMString localName() { return null; }
+            @property DOMString prefix() { return null; }
+            @property void prefix(DOMString) { }
+            @property DOMString namespaceURI() { return null; }
+        }
+        // methods specialized in Document, Element and Attribute
+        override
+        {
+            DOMString lookupPrefix(DOMString namespaceURI)
+            {
+                if (!namespaceURI)
+                    return null;
+
+                switch (nodeType) with (dom.NodeType)
+                {
+                    case ENTITY:
+                    case NOTATION:
+                    case DOCUMENT_FRAGMENT:
+                    case DOCUMENT_TYPE:
+                        return null;
+                    case ATTRIBUTE:
+                        Attr attr = cast(Attr)this;
+                        if (attr.ownerElement)
+                            return attr.ownerElement.lookupNamespacePrefix(namespaceURI, attr.ownerElement);
+                        return null;
+                    default:
+                        auto parentElement = parentElement();
+                        if (parentElement)
+                            return parentElement.lookupNamespacePrefix(namespaceURI, parentElement);
+                        return null;
+                }
+            }
+            DOMString lookupNamespaceURI(DOMString prefix)
+            {
+                switch (nodeType) with (dom.NodeType)
+                {
+                    case ENTITY:
+                    case NOTATION:
+                    case DOCUMENT_TYPE:
+                    case DOCUMENT_FRAGMENT:
+                        return null;
+                    case ATTRIBUTE:
+                        auto attr = cast(Attr)this;
+                        if (attr.ownerElement)
+                            return attr.ownerElement.lookupNamespaceURI(prefix);
+                        return null;
+                    default:
+                        auto parentElement = parentElement();
+                        if (parentElement)
+                            return parentElement.lookupNamespaceURI(prefix);
+
+                        return null;
+                }
+            }
+            bool isDefaultNamespace(DOMString namespaceURI)
+            {
+                switch (nodeType) with (dom.NodeType)
+                {
+                    case ENTITY:
+                    case NOTATION:
+                    case DOCUMENT_TYPE:
+                    case DOCUMENT_FRAGMENT:
+                        return false;
+                    case ATTRIBUTE:
+                        auto attr = cast(Attr)this;
+                        if (attr.ownerElement)
+                            return attr.ownerElement.isDefaultNamespace(namespaceURI);
+                        return false;
+                    default:
+                        auto parentElement = parentElement();
+                        if (parentElement)
+                            return parentElement.isDefaultNamespace(namespaceURI);
+                        return false;
+                }
+            }
+        }
+        // TODO methods
+        override
+        {
+            void normalize() {}
+        }
+        // inner class for use in NodeWithChildren
+        class ChildList: dom.NodeList!DOMString
+        {
+            private Node currentChild;
+            // methods specific to NodeList
+            override
+            {
+                Node item(size_t index)
+                {
+                    auto result = rebindable(this.outer.firstChild);
+                    for (size_t i = 0; i < index && result !is null; i++)
+                    {
+                        result = result.nextSibling;
+                    }
+                    return result;
+                }
+                @property size_t length()
+                {
+                    auto child = rebindable(this.outer.firstChild);
+                    size_t result = 0;
+                    while (child)
+                    {
+                        result++;
+                        child = child.nextSibling;
+                    }
+                    return result;
+                }
+            }
+            // more idiomatic methods
+            auto opIndex(size_t i)
+            {
+                return item(i);
+            }
+            // range interface
+            auto front() { return currentChild; }
+            void popFront() { currentChild = currentChild.nextSibling; }
+            bool empty() { return currentChild is null; }
+        }
+        // method not required by the spec, specialized in NodeWithChildren
+        bool isAncestor(Node other) { return false; }
+    }
+    private abstract class NodeWithChildren: Node
+    {
+        override
+        {
+            @property ChildList childNodes()
+            {
+                auto res = allocator.make!ChildList(this);
+                res.currentChild = firstChild;
+                return res;
+            }
+            @property Node firstChild()
+            {
+                return _firstChild;
+            }
+            @property Node lastChild()
+            {
+                return _lastChild;
+            }
+
+            Node insertBefore(dom.Node!DOMString _newChild, dom.Node!DOMString _refChild)
+            {
+                if (!_refChild)
+                    return appendChild(_newChild);
+
+                auto newChild = cast(Node)_newChild;
+                auto refChild = cast(Node)_refChild;
+                if (!newChild || !refChild || newChild.ownerDocument !is ownerDocument)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.WRONG_DOCUMENT);
+                if (this is newChild || newChild.isAncestor(this) || newChild is refChild)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+                if (refChild.parentNode !is this)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+
+                if (newChild.nodeType == dom.NodeType.DOCUMENT_FRAGMENT)
+                {
+                    for (auto child = rebindable(newChild); child !is null; child = child.nextSibling)
+                        insertBefore(child, refChild);
+                    return newChild;
+                }
+
+                if (newChild.parentNode)
+                    newChild.parentNode.removeChild(newChild);
+                newChild._parentNode = this;
+                if (refChild.previousSibling)
+                {
+                    refChild.previousSibling._nextSibling = newChild;
+                    newChild._previousSibling = refChild.previousSibling;
+                }
+                refChild._previousSibling = newChild;
+                newChild._nextSibling = refChild;
+                if (firstChild is refChild)
+                    _firstChild = newChild;
+                return newChild;
+            }
+            Node replaceChild(dom.Node!DOMString newChild, dom.Node!DOMString oldChild)
+            {
+                insertBefore(newChild, oldChild);
+                return removeChild(oldChild);
+            }
+            Node removeChild(dom.Node!DOMString _oldChild)
+            {
+                auto oldChild = cast(Node)_oldChild;
+                if (!oldChild || oldChild.parentNode !is this)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+
+                if (oldChild is firstChild)
+                    _firstChild = oldChild.nextSibling;
+                else
+                    oldChild.previousSibling._nextSibling = oldChild.nextSibling;
+
+                if (oldChild is lastChild)
+                    _lastChild = oldChild.previousSibling;
+                else
+                    oldChild.nextSibling._previousSibling = oldChild.previousSibling;
+
+                oldChild._parentNode = null;
+                oldChild._previousSibling = null;
+                oldChild._nextSibling = null;
+                return oldChild;
+            }
+            Node appendChild(dom.Node!DOMString _newChild)
+            {
+                auto newChild = cast(Node)_newChild;
+                if (!newChild || newChild.ownerDocument !is ownerDocument)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.WRONG_DOCUMENT);
+                if (this is newChild || newChild.isAncestor(this))
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+                if (newChild.parentNode !is null)
+                    newChild.parentNode.removeChild(newChild);
+
+                if (newChild.nodeType == dom.NodeType.DOCUMENT_FRAGMENT)
+                {
+                    for (auto node = rebindable(newChild.firstChild); node !is null; node = node.nextSibling)
+                        appendChild(node);
+                    return newChild;
+                }
+
+                newChild._parentNode = this;
+                if (lastChild)
+                {
+                    newChild._previousSibling = lastChild;
+                    lastChild._nextSibling = newChild;
+                }
+                else
+                    _firstChild = newChild;
+                _lastChild = newChild;
+                return newChild;
+            }
+            bool hasChildNodes() const
+            {
+                return _firstChild !is null;
+            }
+            bool isAncestor(Node other)
+            {
+                for (auto child = rebindable(firstChild); child !is null; child = child.nextSibling)
+                {
+                    if (child is other)
+                        return true;
+                    if (child.isAncestor(other))
+                        return true;
+                }
+                return false;
+            }
+
+            @property DOMString textContent()
+            {
+                import std.experimental.xml.appender;
+
+                auto result = Appender!(typeof(this.textContent()[0]), typeof(*allocator))(allocator);
+                for (auto child = rebindable(firstChild); child !is null; child = child.nextSibling)
+                {
+                    if (child.nodeType != dom.NodeType.COMMENT &&
+                        child.nodeType != dom.NodeType.PROCESSING_INSTRUCTION)
+                    {
+                        result.put(child.textContent);
+                    }
+                }
+                return result.data;
+            }
+            @property void textContent(DOMString newVal)
+            {
+                while (firstChild)
+                    removeChild(firstChild);
+
+                _firstChild = _lastChild = ownerDocument.createTextNode(newVal);
+            }
+        }
+        private
+        {
+            Node _firstChild, _lastChild;
+
+            void performClone(NodeWithChildren dest, bool deep)
+            {
+                super.performClone(dest, deep);
+                if (deep)
+                    foreach (child; childNodes)
+                    {
+                        auto childClone = child.cloneNode(true);
+                        dest.appendChild(childClone);
+                    }
+            }
+        }
+    }
+    class DocumentFragment: NodeWithChildren, dom.DocumentFragment!DOMString
+    {
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.DOCUMENT_FRAGMENT; }
+            @property DOMString nodeName() { return "#document-fragment"; }
+        }
+    }
+    class Document: NodeWithChildren, dom.Document!DOMString
+    {
+        // specific to Document
+        override
+        {
+            @property DocumentType doctype() { return _doctype; }
+            @property DOMImplementation implementation() { return this.outer; }
+            @property Element documentElement() { return _root; }
+
+            Element createElement(DOMString tagName)
+            {
+                auto res = allocator.make!Element(this.outer);
+                res._name = tagName;
+                res._ownerDocument = this;
+                res._attrs = allocator.make!(Element.Map)(res);
+                return res;
+            }
+            Element createElementNS(DOMString namespaceURI, DOMString qualifiedName)
+            {
+                auto res = allocator.make!Element(this.outer);
+                res.setQualifiedName(qualifiedName);
+                res._namespaceURI = namespaceURI;
+                res._ownerDocument = this;
+                res._attrs = allocator.make!(Element.Map)(res);
+                return res;
+            }
+            DocumentFragment createDocumentFragment()
+            {
+                auto res = allocator.make!DocumentFragment(this.outer);
+                res._ownerDocument = this;
+                return res;
+            }
+            Text createTextNode(DOMString data)
+            {
+                auto res = allocator.make!Text(this.outer);
+                res._data = data;
+                res._ownerDocument = this;
+                return res;
+            }
+            Comment createComment(DOMString data)
+            {
+                auto res = allocator.make!Comment(this.outer);
+                res._data = data;
+                res._ownerDocument = this;
+                return res;
+            }
+            CDATASection createCDATASection(DOMString data)
+            {
+                auto res = allocator.make!CDATASection(this.outer);
+                res._data = data;
+                res._ownerDocument = this;
+                return res;
+            }
+            ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data)
+            {
+                auto res = allocator.make!ProcessingInstruction(this.outer);
+                res._target = target;
+                res._data = data;
+                res._ownerDocument = this;
+                return res;
+            }
+            Attr createAttribute(DOMString name)
+            {
+                auto res = allocator.make!Attr(this.outer);
+                res._name = name;
+                res._ownerDocument = this;
+                return res;
+            }
+            Attr createAttributeNS(DOMString namespaceURI, DOMString qualifiedName)
+            {
+                auto res = allocator.make!Attr(this.outer);
+                res.setQualifiedName(qualifiedName);
+                res._namespaceURI = namespaceURI;
+                res._ownerDocument = this;
+                return res;
+            }
+            EntityReference createEntityReference(DOMString name) { return null; }
+
+            ElementsByTagName getElementsByTagName(DOMString tagname)
+            {
+                auto res = allocator.make!ElementsByTagName;
+                res.root = this;
+                res.tagname = tagname;
+                res.current = res.item(0);
+                return res;
+            }
+            ElementsByTagNameNS getElementsByTagNameNS(DOMString namespaceURI, DOMString localName)
+            {
+                auto res = allocator.make!ElementsByTagNameNS;
+                res.root = this;
+                res.namespaceURI = namespaceURI;
+                res.localName = localName;
+                res.current = res.item(0);
+                return res;
+            }
+            Element getElementById(DOMString elementId)
+            {
+                Element find(Node node)
+                {
+                    if (node.nodeType == dom.NodeType.ELEMENT && node.hasAttributes)
+                        foreach (attr; node.attributes)
+                        {
+                            if (attr.isId && attr.nodeValue == elementId)
+                                return cast(Element)node;
+                        }
+                    foreach (child; node.childNodes)
+                    {
+                        auto res = find(child);
+                        if (res)
+                            return res;
+                    }
+                    return null;
+                }
+                return find(_root);
+            }
+
+            Node importNode(dom.Node!DOMString node, bool deep)
+            {
+                switch (node.nodeType) with (dom.NodeType)
+                {
+                    case ATTRIBUTE:
+                        Attr result;
+                        if (node.prefix)
+                            result = createAttributeNS(node.namespaceURI, node.nodeName);
+                        else
+                            result = createAttribute(node.nodeName);
+                        auto children = node.childNodes;
+                        foreach (i; 0..children.length)
+                            result.appendChild(importNode(children.item(i), true));
+                        return result;
+                    case DOCUMENT_FRAGMENT:
+                        auto result = createDocumentFragment();
+                        if (deep)
+                        {
+                            auto children = node.childNodes;
+                            foreach (i; 0..children.length)
+                                result.appendChild(importNode(children.item(i), deep));
+                        }
+                        return result;
+                    case ELEMENT:
+                        Element result;
+                        if (node.prefix)
+                            result = createElementNS(node.namespaceURI, node.nodeName);
+                        else
+                            result = createElement(node.nodeName);
+                        if (node.hasAttributes)
+                        {
+                            auto attributes = node.attributes;
+                            foreach (i; 0..attributes.length)
+                            {
+                                auto attr = cast(Attr)(importNode(attributes.item(i), deep));
+                                assert(attr);
+                                result.setAttributeNode(attr);
+                            }
+                        }
+                        if (deep)
+                        {
+                            auto children = node.childNodes;
+                            foreach (i; 0..children.length)
+                                result.appendChild(importNode(children.item(i), true));
+                        }
+                        return result;
+                    case PROCESSING_INSTRUCTION:
+                        return createProcessingInstruction(node.nodeName, node.nodeValue);
+                    default:
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_SUPPORTED);
+                }
+            }
+            Node adoptNode(dom.Node!DOMString source) { return null; }
+
+            @property DOMString inputEncoding() { return null; }
+            @property DOMString xmlEncoding() { return null; }
+
+            @property bool xmlStandalone() { return _standalone; }
+            @property void xmlStandalone(bool b) { _standalone = b; }
+
+            @property DOMString xmlVersion() { return _xmlVersion; }
+            @property void xmlVersion(DOMString ver)
+            {
+                if (ver == "1.0" || ver == "1.1")
+                    _xmlVersion = ver;
+                else
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_SUPPORTED);
+            }
+
+            @property bool strictErrorChecking() { return _strictErrorChecking; }
+            @property void strictErrorChecking(bool b) { _strictErrorChecking = b; }
+
+            @property DOMString documentURI() { return _documentURI; }
+            @property void documentURI(DOMString uri) { _documentURI = uri; }
+
+            @property DOMConfiguration domConfig() { return _config; }
+            void normalizeDocument() { }
+            Node renameNode(dom.Node!DOMString n, DOMString namespaceURI, DOMString qualifiedName)
+            {
+                auto node = cast(Node)n;
+                if (!node || node.ownerDocument !is this)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.WRONG_DOCUMENT);
+
+                auto type = node.nodeType;
+                if (type != dom.NodeType.ELEMENT && type != dom.NodeType.ATTRIBUTE)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_SUPPORTED);
+
+                auto withNs = (cast(NodeWithNamespace)node);
+                withNs.setQualifiedName(qualifiedName);
+                withNs._namespaceURI = namespaceURI;
+                return node;
+            }
+        }
+        private
+        {
+            DOMString _documentURI, _xmlVersion = "1.0";
+            DocumentType _doctype;
+            Element _root;
+            DOMConfiguration _config;
+            bool _strictErrorChecking = true, _standalone = false;
+        }
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.DOCUMENT; }
+            @property DOMString nodeName() { return "#document"; }
+
+            DOMString lookupPrefix(DOMString namespaceURI)
+            {
+                return documentElement.lookupPrefix(namespaceURI);
+            }
+            DOMString lookupNamespaceURI(DOMString prefix)
+            {
+                return documentElement.lookupNamespaceURI(prefix);
+            }
+            bool isDefaultNamespace(DOMString namespaceURI)
+            {
+                return documentElement.isDefaultNamespace(namespaceURI);
+            }
+        }
+        // inherited from NodeWithChildren
+        override
+        {
+            Node insertBefore(dom.Node!DOMString newChild, dom.Node!DOMString refChild)
+            {
+                if (newChild.nodeType == dom.NodeType.ELEMENT)
+                {
+                    if (_root)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.insertBefore(newChild, refChild);
+                    _root = cast(Element)newChild;
+                    return res;
+                }
+                else if (newChild.nodeType == dom.NodeType.DOCUMENT_TYPE)
+                {
+                    if (_doctype)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.insertBefore(newChild, refChild);
+                    _doctype = cast(DocumentType)newChild;
+                    return res;
+                }
+                else if (newChild.nodeType != dom.NodeType.COMMENT &&
+                         newChild.nodeType != dom.NodeType.PROCESSING_INSTRUCTION)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+                else
+                    return super.insertBefore(newChild, refChild);
+            }
+            Node replaceChild(dom.Node!DOMString newChild, dom.Node!DOMString oldChild)
+            {
+                if (newChild.nodeType == dom.NodeType.ELEMENT)
+                {
+                    if (oldChild !is _root)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.replaceChild(newChild, oldChild);
+                    _root = cast(Element)newChild;
+                    return res;
+                }
+                else if (newChild.nodeType == dom.NodeType.DOCUMENT_TYPE)
+                {
+                    if (oldChild !is _doctype)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.replaceChild(newChild, oldChild);
+                    _doctype = cast(DocumentType)newChild;
+                    return res;
+                }
+                else if (newChild.nodeType != dom.NodeType.COMMENT &&
+                         newChild.nodeType != dom.NodeType.PROCESSING_INSTRUCTION)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+                else
+                    return super.replaceChild(newChild, oldChild);
+            }
+            Node removeChild(dom.Node!DOMString oldChild)
+            {
+                if (oldChild.nodeType == dom.NodeType.ELEMENT)
+                {
+                    auto res = super.removeChild(oldChild);
+                    _root = null;
+                    return res;
+                }
+                else if (oldChild.nodeType == dom.NodeType.DOCUMENT_TYPE)
+                {
+                    auto res = super.removeChild(oldChild);
+                    _doctype = null;
+                    return res;
+                }
+                else
+                    return super.removeChild(oldChild);
+            }
+            Node appendChild(dom.Node!DOMString newChild)
+            {
+                if (newChild.nodeType == dom.NodeType.ELEMENT)
+                {
+                    if (_root)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.appendChild(newChild);
+                    _root = cast(Element)newChild;
+                    return res;
+                }
+                else if (newChild.nodeType == dom.NodeType.DOCUMENT_TYPE)
+                {
+                    if (_doctype)
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    auto res = super.appendChild(newChild);
+                    _doctype = cast(DocumentType)newChild;
+                    return res;
+                }
+                else
+                    return super.appendChild(newChild);
+            }
+        }
+    }
+    alias ElementsByTagName = ElementsByTagNameImpl!false;
+    alias ElementsByTagNameNS = ElementsByTagNameImpl!true;
+    static class ElementsByTagNameImpl(bool ns): dom.NodeList!DOMString
+    {
+        private Node root;
+        private Element current;
+        static if (ns)
+            private DOMString namespaceURI, localName;
+        else
+            private DOMString tagname;
+
+        private Element findNext(Node node)
+        {
+            foreach (item; node.childNodes)
+            {
+                static if (ns)
+                {
+                    if (item.nodeType == dom.NodeType.ELEMENT)
+                    {
+                        auto elem = cast(Element)item;
+                        if (elem.namespaceURI == namespaceURI && elem.localName == localName)
+                            return elem;
+                    }
+                }
+                else
+                    if (item.nodeType == dom.NodeType.ELEMENT && item.nodeName == tagname)
+                        return cast(Element)item;
+
+                auto res = findNext(item);
+                if (res !is null)
+                    return res;
+            }
+            return findNextBack(node);
+        }
+        private Element findNextBack(Node node)
+        {
+            if (node.nextSibling)
+            {
+                auto item = node.nextSibling;
+
+                static if (ns)
+                {
+                    if (item.nodeType == dom.NodeType.ELEMENT)
+                    {
+                        auto elem = cast(Element)item;
+                        if (elem.namespaceURI == namespaceURI && elem.localName == localName)
+                            return elem;
+                    }
+                }
+                else
+                    if (item.nodeType == dom.NodeType.ELEMENT && item.nodeName == tagname)
+                        return cast(Element)item;
+
+                return findNext(item);
+            }
+            else if (node.parentNode && node.parentNode !is root)
+            {
+                return findNextBack(node.parentNode);
+            }
+            else
+                return null;
+        }
+
+        // methods specific to NodeList
+        override
+        {
+            @property size_t length()
+            {
+                size_t res = 0;
+                auto node = findNext(root);
+                while (node !is null)
+                {
+                    res++;
+                    node = findNext(node);
+                }
+                return res;
+            }
+            Element item(size_t i)
+            {
+                auto res = findNext(root);
+                while (res && i > 0)
+                {
+                    res = findNext(res);
+                    i--;
+                }
+                return res;
+            }
+        }
+        // more idiomatic methods
+        auto opIndex(size_t i) { return item(i); }
+
+        // range interface
+        bool empty() { return current is null; }
+        void popFront() { current = findNext(current); }
+        auto front() { return current; }
+    }
+    abstract class CharacterData: Node, dom.CharacterData!DOMString
+    {
+        // specific to CharacterData
+        override
+        {
+            @property DOMString data() { return _data; }
+            @property void data(DOMString newVal) { _data = newVal; }
+            @property size_t length() { return _data.length; }
+
+            DOMString substringData(size_t offset, size_t count)
+            {
+                if (offset > length)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.INDEX_SIZE);
+
+                import std.algorithm : min;
+                return _data[offset..min(offset + count, length)];
+            }
+            void appendData(DOMString arg)
+            {
+                import std.traits : Unqual;
+
+                auto newData = allocator.makeArray!(Unqual!(typeof(_data[0])))(_data.length + arg.length);
+                newData[0 .. data.length] = _data[];
+                newData[data.length .. $] = arg[];
+
+                _data = cast(typeof(_data))newData;
+            }
+            void insertData(size_t offset, DOMString arg)
+            {
+                import std.traits : Unqual;
+
+                if (offset > length)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.INDEX_SIZE);
+
+                auto newData = allocator.makeArray!(Unqual!(typeof(_data[0])))(_data.length + arg.length);
+                newData[0 .. offset] = _data[0 .. offset];
+                newData[offset .. (offset + arg.length)] = arg;
+                newData[(offset + arg.length) .. $] = _data[offset .. $];
+
+                _data = cast(typeof(_data))newData;
+            }
+            void deleteData(size_t offset, size_t count)
+            {
+                import std.traits : Unqual;
+
+                if (offset > length)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.INDEX_SIZE);
+
+                import std.algorithm : min;
+                auto end = min(offset + count, length);
+
+                auto newData = allocator.makeArray!(Unqual!(typeof(_data[0])))(_data.length - end + offset);
+                newData[0 .. offset] = _data[0 .. offset];
+                newData[offset .. $] = data[end .. $];
+
+                _data = cast(typeof(_data))newData;
+            }
+            void replaceData(size_t offset, size_t count, DOMString arg)
+            {
+                import std.traits : Unqual;
+
+                if (offset > length)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.INDEX_SIZE);
+
+                import std.algorithm : min;
+                auto end = min(offset + count, length);
+
+                auto newData = allocator.makeArray!(Unqual!(typeof(_data[0])))
+                                                   (_data.length - end + offset + arg.length);
+                newData[0 .. offset] = _data[0 .. offset];
+                newData[offset .. (offset + arg.length)] = arg[];
+                newData[(offset + arg.length) .. $] = _data[end .. $];
+
+                _data = cast(typeof(_data))newData;
+            }
+        }
+        // inherited from Node
+        override
+        {
+            @property DOMString nodeValue() { return data; }
+            @property void nodeValue(DOMString newVal) { data = newVal; }
+            @property DOMString textContent() { return data; }
+            @property void textContent(DOMString newVal) { data = newVal; }
+        }
+        private
+        {
+            DOMString _data;
+
+            // internal method
+            private void performClone(CharacterData dest, bool deep)
+            {
+                super.performClone(dest, deep);
+                dest._data = _data;
+            }
+        }
+    }
+    private abstract class NodeWithNamespace: NodeWithChildren
+    {
+        private
+        {
+            DOMString _name, _namespaceURI;
+            size_t _colon;
+
+            void setQualifiedName(DOMString name)
+            {
+                import std.experimental.xml.faststrings;
+
+                _name = name;
+                ptrdiff_t i = name.fastIndexOf(':');
+                if (i > 0)
+                    _colon = i;
+            }
+            void performClone(NodeWithNamespace dest, bool deep)
+            {
+                super.performClone(dest, deep);
+                dest._name = _name;
+                dest._namespaceURI = namespaceURI;
+                dest._colon = _colon;
+            }
+        }
+        // inherited from Node
+        override
+        {
+            @property DOMString nodeName() { return _name; }
+
+            @property DOMString localName()
+            {
+                if (!_colon)
+                    return null;
+                return _name[(_colon+1)..$];
+            }
+            @property DOMString prefix()
+            {
+                return _name[0.._colon];
+            }
+            @property void prefix(DOMString pre)
+            {
+                import std.traits : Unqual;
+
+                auto newName = allocator.makeArray!(Unqual!(typeof(_name[0])))(pre.length + localName.length + 1);
+                newName[0 .. pre.length] = pre[];
+                newName[pre.length] = ':';
+                newName[(pre.length + 1) .. $] = localName[];
+
+                _name = cast(typeof(_name))newName;
+                _colon = pre.length;
+            }
+            @property DOMString namespaceURI() { return _namespaceURI; }
+        }
+    }
+    class Attr: NodeWithNamespace, dom.Attr!DOMString
+    {
+        // specific to Attr
+        override
+        {
+            @property DOMString name() { return _name; }
+            @property bool specified() { return _specified; }
+            @property DOMString value()
+            {
+                import std.experimental.xml.appender;
+
+                auto result = Appender!(typeof(_name[0]), typeof(*allocator))(allocator);
+                auto child = rebindable(firstChild);
+                while (child)
+                {
+                    result.put(child.textContent);
+                    child = child.nextSibling;
+                }
+                return result.data;
+            }
+            @property void value(DOMString newVal)
+            {
+                while (firstChild)
+                    removeChild(firstChild);
+                appendChild(ownerDocument.createTextNode(newVal));
+            }
+
+            @property Element ownerElement() { return _ownerElement; }
+            @property dom.XMLTypeInfo!DOMString schemaTypeInfo() { return null; }
+            @property bool isId() { return _isId; }
+        }
+        private
+        {
+            Element _ownerElement;
+            bool _specified = true, _isId = false;
+            @property Attr _nextAttr() { return cast(Attr)_nextSibling; }
+            @property Attr _previousAttr() { return cast(Attr)_previousSibling; }
+        }
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.ATTRIBUTE; }
+
+            @property DOMString nodeValue() { return value; }
+            @property void nodeValue(DOMString newVal) { value = newVal; }
+
+            // overridden because we reuse _nextSibling and _previousSibling with another meaning
+            @property Attr nextSibling() { return null; }
+            @property Attr previousSibling() { return null; }
+
+            Attr cloneNode(bool deep)
+            {
+                Attr cloned = allocator.make!Attr(this.outer);
+                cloned._ownerDocument = _ownerDocument;
+                super.performClone(cloned, true);
+                cloned._specified = true;
+                return cloned;
+            }
+
+            DOMString lookupPrefix(DOMString namespaceURI)
+            {
+                if (ownerElement)
+                    return ownerElement.lookupPrefix(namespaceURI);
+                return null;
+            }
+            DOMString lookupNamespaceURI(DOMString prefix)
+            {
+                if (ownerElement)
+                    return ownerElement.lookupNamespaceURI(prefix);
+                return null;
+            }
+            bool isDefaultNamespace(DOMString namespaceURI)
+            {
+                if (ownerElement)
+                    return ownerElement.isDefaultNamespace(namespaceURI);
+                return false;
+            }
+        }
+    }
+    class Element: NodeWithNamespace, dom.Element!DOMString
+    {
+        // specific to Element
+        override
+        {
+            @property DOMString tagName() { return _name; }
+
+            DOMString getAttribute(DOMString name)
+            {
+                return _attrs.getNamedItem(name).value;
+            }
+            void setAttribute(DOMString name, DOMString value)
+            {
+                auto attr = ownerDocument.createAttribute(name);
+                attr.value = value;
+                attr._ownerElement = this;
+                _attrs.setNamedItem(attr);
+            }
+            void removeAttribute(DOMString name)
+            {
+                _attrs.removeNamedItem(name);
+            }
+
+            Attr getAttributeNode(DOMString name)
+            {
+                return _attrs.getNamedItem(name);
+            }
+            Attr setAttributeNode(dom.Attr!DOMString newAttr)
+            {
+                return _attrs.setNamedItem(newAttr);
+            }
+            Attr removeAttributeNode(dom.Attr!DOMString oldAttr)
+            {
+                if (_attrs.getNamedItemNS(oldAttr.namespaceURI, oldAttr.name) is oldAttr)
+                    return _attrs.removeNamedItemNS(oldAttr.namespaceURI, oldAttr.name);
+                else if (_attrs.getNamedItem(oldAttr.name) is oldAttr)
+                    return _attrs.removeNamedItem(oldAttr.name);
+
+                throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+            }
+
+            DOMString getAttributeNS(DOMString namespaceURI, DOMString localName)
+            {
+                return _attrs.getNamedItemNS(namespaceURI, localName).value;
+            }
+            void setAttributeNS(DOMString namespaceURI, DOMString qualifiedName, DOMString value)
+            {
+                auto attr = ownerDocument.createAttributeNS(namespaceURI, qualifiedName);
+                attr.value = value;
+                attr._ownerElement = this;
+                _attrs.setNamedItem(attr);
+            }
+            void removeAttributeNS(DOMString namespaceURI, DOMString localName)
+            {
+                _attrs.removeNamedItemNS(namespaceURI, localName);
+            }
+
+            Attr getAttributeNodeNS(DOMString namespaceURI, DOMString localName)
+            {
+                return _attrs.getNamedItemNS(namespaceURI, localName);
+            }
+            Attr setAttributeNodeNS(dom.Attr!DOMString newAttr)
+            {
+                return _attrs.setNamedItemNS(newAttr);
+            }
+
+            bool hasAttribute(DOMString name)
+            {
+                return _attrs.getNamedItem(name) !is null;
+            }
+            bool hasAttributeNS(DOMString namespaceURI, DOMString localName)
+            {
+                return _attrs.getNamedItemNS(namespaceURI, localName) !is null;
+            }
+
+            void setIdAttribute(DOMString name, bool isId)
+            {
+                auto attr = _attrs.getNamedItem(name);
+                if (attr)
+                    attr._isId = isId;
+                else
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+            }
+            void setIdAttributeNS(DOMString namespaceURI, DOMString localName, bool isId)
+            {
+                auto attr = _attrs.getNamedItemNS(namespaceURI, localName);
+                if (attr)
+                    attr._isId = isId;
+                else
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+            }
+            void setIdAttributeNode(dom.Attr!DOMString idAttr, bool isId)
+            {
+                if (_attrs.getNamedItemNS(idAttr.namespaceURI, idAttr.name) is idAttr)
+                    (cast(Attr)idAttr)._isId = isId;
+                else if (_attrs.getNamedItem(idAttr.name) is idAttr)
+                    (cast(Attr)idAttr)._isId = isId;
+                else
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+            }
+
+            ElementsByTagName getElementsByTagName(DOMString tagname)
+            {
+                auto res = allocator.make!ElementsByTagName;
+                res.root = this;
+                res.tagname = tagname;
+                res.current = res.item(0);
+                return res;
+            }
+            ElementsByTagNameNS getElementsByTagNameNS(DOMString namespaceURI, DOMString localName)
+            {
+                auto res = allocator.make!ElementsByTagNameNS;
+                res.root = this;
+                res.namespaceURI = namespaceURI;
+                res.localName = localName;
+                res.current = res.item(0);
+                return res;
+            }
+
+            @property dom.XMLTypeInfo!DOMString schemaTypeInfo() { return null; }
+        }
+        private
+        {
+            Map _attrs;
+
+            // internal methods
+            DOMString lookupNamespacePrefix(DOMString namespaceURI, Element originalElement)
+            {
+                if (this.namespaceURI && this.namespaceURI == namespaceURI
+                    && this.prefix && originalElement.lookupNamespaceURI(this.prefix) == namespaceURI)
+                {
+                    return this.prefix;
+                }
+                if (hasAttributes)
+                    foreach (attr; attributes)
+                        if (attr.prefix == "xmlns" && attr.value == namespaceURI &&
+                            originalElement.lookupNamespaceURI(attr.localName) == namespaceURI)
+                        {
+                            return attr.localName;
+                        }
+                auto parentElement = parentElement();
+                if (parentElement)
+                    return parentElement.lookupNamespacePrefix(namespaceURI, originalElement);
+                return null;
+            }
+        }
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.ELEMENT; }
+
+            @property Map attributes() { return _attrs.length > 0 ? _attrs : null; }
+            bool hasAttributes() { return _attrs.length > 0; }
+
+            Element cloneNode(bool deep)
+            {
+                auto cloned = allocator.make!Element(this.outer);
+                cloned._ownerDocument = ownerDocument;
+                cloned._attrs = allocator.make!Map(this);
+                super.performClone(cloned, deep);
+                return cloned;
+            }
+
+            DOMString lookupPrefix(DOMString namespaceURI)
+            {
+                return lookupNamespacePrefix(namespaceURI, this);
+            }
+            DOMString lookupNamespaceURI(DOMString prefix)
+            {
+                if (namespaceURI && prefix == prefix)
+                    return namespaceURI;
+
+                if (hasAttributes)
+                {
+                    foreach (attr; attributes)
+                        if (attr.prefix == "xmlns" && attr.localName == prefix)
+                            return attr.value;
+                        else if (attr.nodeName == "xmlns" && !prefix)
+                            return attr.value;
+                }
+                auto parentElement = parentElement();
+                if (parentElement)
+                    return parentElement.lookupNamespaceURI(prefix);
+                return null;
+            }
+            bool isDefaultNamespace(DOMString namespaceURI)
+            {
+                if (!prefix)
+                    return this.namespaceURI == namespaceURI;
+                if (hasAttributes)
+                {
+                    foreach (attr; attributes)
+                        if (attr.nodeName == "xmlns")
+                            return attr.value == namespaceURI;
+                }
+                auto parentElement = parentElement();
+                if (parentElement)
+                    return parentElement.isDefaultNamespace(namespaceURI);
+                return false;
+            }
+        }
+
+        class Map: dom.NamedNodeMap!DOMString
+        {
+            // specific to NamedNodeMap
+            public override
+            {
+                ulong length()
+                {
+                    ulong res = 0;
+                    auto attr = firstAttr;
+                    while (attr)
+                    {
+                        res++;
+                        attr = attr._nextAttr;
+                    }
+                    return res;
+                }
+                Attr item(ulong index)
+                {
+                    ulong count = 0;
+                    auto res = firstAttr;
+                    while (res && count < index)
+                    {
+                        count++;
+                        res = res._nextAttr;
+                    }
+                    return res;
+                }
+
+                Attr getNamedItem(DOMString name)
+                {
+                    auto res = firstAttr;
+                    while (res && res.nodeName != name)
+                        res = res._nextAttr;
+                    return res;
+                }
+                Attr setNamedItem(dom.Node!DOMString arg)
+                {
+                    if (arg.ownerDocument !is this.outer.ownerDocument)
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.WRONG_DOCUMENT);
+
+                    Attr attr = cast(Attr)arg;
+                    if (!attr)
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    if (attr._previousAttr)
+                        attr._previousAttr._nextSibling = attr._nextAttr;
+                    if (attr._nextAttr)
+                        attr._nextAttr._previousSibling = attr._previousAttr;
+
+                    auto res = firstAttr;
+                    while (res && res.nodeName != attr.nodeName)
+                        res = res._nextAttr;
+
+                    if (res)
+                    {
+                        attr._previousSibling = res._previousAttr;
+                        attr._nextSibling = res._nextAttr;
+                        if (res is firstAttr) firstAttr = attr;
+                    }
+                    else
+                    {
+                        attr._nextSibling = firstAttr;
+                        firstAttr = attr;
+                        attr._previousSibling = null;
+                        currentAttr = firstAttr;
+                    }
+
+                    return res;
+                }
+                Attr removeNamedItem(DOMString name)
+                {
+                    auto res = firstAttr;
+                    while (res && res.nodeName != name)
+                        res = res._nextAttr;
+
+                    if (res)
+                    {
+                        if (res._previousAttr)
+                            res._previousAttr._nextSibling = res._nextAttr;
+                        if (res._nextAttr)
+                            res._nextAttr._previousSibling = res._previousAttr;
+                        return res;
+                    }
+                    else
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.NOT_FOUND);
+                }
+
+                Attr getNamedItemNS(DOMString namespaceURI, DOMString localName)
+                {
+                    auto res = firstAttr;
+                    while (res && (res.localName != localName || res.namespaceURI != namespaceURI))
+                        res = res._nextAttr;
+                    return res;
+                }
+                Attr setNamedItemNS(dom.Node!DOMString arg)
+                {
+                    if (arg.ownerDocument !is this.outer.ownerDocument)
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.WRONG_DOCUMENT);
+
+                    Attr attr = cast(Attr)arg;
+                    if (!attr)
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.HIERARCHY_REQUEST);
+
+                    if (attr._previousAttr)
+                        attr._previousAttr._nextSibling = attr._nextAttr;
+                    if (attr._nextAttr)
+                        attr._nextAttr._previousSibling = attr._previousAttr;
+
+                    auto res = firstAttr;
+                    while (res && (res.localName != attr.localName || res.namespaceURI != attr.namespaceURI))
+                        res = res._nextAttr;
+
+                    if (res)
+                    {
+                        attr._previousSibling = res._previousAttr;
+                        attr._nextSibling = res._nextAttr;
+                        if (res is firstAttr) firstAttr = attr;
+                    }
+                    else
+                    {
+                        attr._nextSibling = firstAttr;
+                        firstAttr = attr;
+                        attr._previousSibling = null;
+                        currentAttr = firstAttr;
+                    }
+
+                    return res;
+                }
+                Attr removeNamedItemNS(DOMString namespaceURI, DOMString localName)
+                {
+                    auto res = firstAttr;
+                    while (res && (res.localName != localName || res.namespaceURI != namespaceURI))
+                        res = res._nextAttr;
+
+                    if (res)
+                    {
+                        if (res._previousAttr)
+                            res._previousAttr._nextSibling = res._nextAttr;
+                        if (res._nextAttr)
+                            res._nextAttr._previousSibling = res._previousAttr;
+                        return res;
+                    }
+                    else
+                        throw allocator.make!DOMException(this.outer.outer, dom.ExceptionCode.NOT_FOUND);
+                }
+            }
+            private
+            {
+                Attr firstAttr;
+                Attr currentAttr;
+            }
+            // better methods
+            auto opIndex(size_t i) { return item(i); }
+
+            // range interface
+            auto opSlice()
+            {
+                struct Range
+                {
+                    Attr currentAttr;
+
+                    auto front() { return currentAttr; }
+                    void popFront() { currentAttr = currentAttr._nextAttr; }
+                    bool empty() { return currentAttr is null; }
+                }
+                return Range(firstAttr);
+            }
+        }
+    }
+    class Text: CharacterData, dom.Text!DOMString
+    {
+        // specific to Text
+        override
+        {
+            Text splitText(size_t offset)
+            {
+                if (offset > data.length)
+                    throw allocator.make!DOMException(this.outer, dom.ExceptionCode.INDEX_SIZE);
+                auto second = ownerDocument.createTextNode(data[offset..$]);
+                data = data[0..offset];
+                if (parentNode)
+                {
+                    if (nextSibling)
+                        parentNode.insertBefore(second, nextSibling);
+                    else
+                        parentNode.appendChild(second);
+                }
+                return second;
+            }
+            @property bool isElementContentWhitespace()
+            {
+                import std.experimental.xml.faststrings: fastIndexOfNeither;
+
+                return _data.fastIndexOfNeither(" \r\n\t") == -1;
+            }
+            @property DOMString wholeText() { return data; } // <-- TODO
+            @property Text replaceWholeText(DOMString newText) { return null; } // <-- TODO
+        }
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.TEXT; }
+            @property DOMString nodeName() { return "#text"; }
+
+            Text cloneNode(bool deep)
+            {
+                auto cloned = allocator.make!Text(this.outer);
+                cloned._ownerDocument = _ownerDocument;
+                super.performClone(cloned, deep);
+                return cloned;
+            }
+        }
+    }
+    class Comment: CharacterData, dom.Comment!DOMString
+    {
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.COMMENT; }
+            @property DOMString nodeName() { return "#comment"; }
+
+            Comment cloneNode(bool deep)
+            {
+                auto cloned = allocator.make!Comment(this.outer);
+                cloned._ownerDocument = _ownerDocument;
+                super.performClone(cloned, deep);
+                return cloned;
+            }
+        }
+    }
+    class DocumentType: Node, dom.DocumentType!DOMString
+    {
+        // specific to DocumentType
+        override
+        {
+            @property DOMString name() { return _name; }
+            @property dom.NamedNodeMap!DOMString entities() { return null; }
+            @property dom.NamedNodeMap!DOMString notations() { return null; }
+            @property DOMString publicId() { return _publicId; }
+            @property DOMString systemId() { return _systemId; }
+            @property DOMString internalSubset() { return _internalSubset; }
+        }
+        private DOMString _name, _publicId, _systemId, _internalSubset;
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.DOCUMENT_TYPE; }
+            @property DOMString nodeName() { return _name; }
+        }
+    }
+    class CDATASection: Text, dom.CDATASection!DOMString
+    {
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.CDATA_SECTION; }
+            @property DOMString nodeName() { return "#cdata-section"; }
+
+            CDATASection cloneNode(bool deep)
+            {
+                auto cloned = allocator.make!CDATASection(this.outer);
+                cloned._ownerDocument = _ownerDocument;
+                super.performClone(cloned, deep);
+                return cloned;
+            }
+        }
+    }
+    class ProcessingInstruction: Node, dom.ProcessingInstruction!DOMString
+    {
+        // specific to ProcessingInstruction
+        override
+        {
+            @property DOMString target() { return _target; }
+            @property DOMString data() { return _data; }
+            @property void data(DOMString newVal) { _data = newVal; }
+        }
+        private DOMString _target, _data;
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.PROCESSING_INSTRUCTION; }
+            @property DOMString nodeName() { return target; }
+            @property DOMString nodeValue() { return _data; }
+            @property void nodeValue(DOMString newVal) { _data = newVal; }
+
+            ProcessingInstruction cloneNode(bool deep)
+            {
+                auto cloned = allocator.make!ProcessingInstruction(this.outer);
+                cloned._ownerDocument = _ownerDocument;
+                super.performClone(cloned, deep);
+                cloned._target = _target;
+                cloned._data = _data;
+                return cloned;
+            }
+        }
+    }
+    class EntityReference: NodeWithChildren, dom.EntityReference!DOMString
+    {
+        // inherited from Node
+        override
+        {
+            @property dom.NodeType nodeType() { return dom.NodeType.ENTITY_REFERENCE; }
+            @property DOMString nodeName() { return _ent_name; }
+        }
+        private DOMString _ent_name;
+    }
+    class DOMConfiguration: dom.DOMConfiguration!DOMString
+    {
+        import std.meta;
+        import std.traits;
+
+        private
+        {
+            enum string always = "((x) => true)";
+
+            static struct Config
+            {
+                string name;
+                string type;
+                string settable;
+            }
+
+            struct Params
+            {
+                @Config("cdata-sections", "bool", always) bool cdata_sections;
+                @Config("comments", "bool", always) bool comments;
+                @Config("entities", "bool", always) bool entities;
+                @Config("error-handler", "ErrorHandler", always) ErrorHandler error_handler;
+                @Config("namespace-declarations", "bool", always) bool namespace_declarations;
+                @Config("split-cdata-sections", "bool", always) bool split_cdata_sections;
+            }
+            Params params;
+
+            void assign(string field, string type)(dom.UserData val)
+            {
+                mixin("if (val.convertsTo!(" ~ type ~ ")) params." ~ field ~ " = val.get!(" ~ type ~ "); \n");
+            }
+            bool canSet(string type, string settable)(dom.UserData val)
+            {
+                mixin("if (val.convertsTo!(" ~ type ~ ")) return " ~ settable ~ "(val.get!(" ~ type ~ ")); \n");
+                return false;
+            }
+        }
+        // specific to DOMConfiguration
+        override
+        {
+            void setParameter(string name, dom.UserData value)
+            {
+                switch (name)
+                {
+                    foreach (field; AliasSeq!(__traits(allMembers, Params)))
+                    {
+                        mixin("enum type = getUDAs!(Params." ~ field ~ ", Config)[0].type; \n");
+                        mixin("case getUDAs!(Params." ~ field ~ ", Config)[0].name: assign!(field, type)(value); \n");
+                    }
+                    default:
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+                }
+            }
+            dom.UserData getParameter(string name)
+            {
+                switch (name)
+                {
+                    foreach (field; AliasSeq!(__traits(allMembers, Params)))
+                    {
+                        mixin("case getUDAs!(Params." ~ field ~ ", Config)[0].name: \n" ~
+                                    "return dom.UserData(params." ~ field ~ "); \n");
+                    }
+                    default:
+                        throw allocator.make!DOMException(this.outer, dom.ExceptionCode.NOT_FOUND);
+                }
+            }
+            bool canSetParameter(string name, dom.UserData value)
+            {
+                switch (name)
+                {
+                    foreach (field; AliasSeq!(__traits(allMembers, Params)))
+                    {
+                        mixin("enum type = getUDAs!(Params." ~ field ~ ", Config)[0].type; \n");
+                        mixin("enum settable = getUDAs!(Params." ~ field ~ ", Config)[0].settable; \n");
+                        mixin("case getUDAs!(Params." ~ field ~ ", Config)[0].name: \n" ~
+                                    "return canSet!(type, settable)(value); \n");
+                    }
+                    default:
+                        return false;
+                }
+            }
+            @property dom.DOMStringList!string parameterNames()
+            {
+                return allocator.make!StringList(this);
+            }
+        }
+
+        class StringList: dom.DOMStringList!string
+        {
+            private template MapToConfigName(Members...)
+            {
+                static if (Members.length > 0)
+                    mixin("alias MapToConfigName = AliasSeq!(getUDAs!(Params." ~ Members[0] ~
+                            ", Config)[0].name, MapToConfigName!(Members[1..$])); \n");
+                else
+                    alias MapToConfigName = AliasSeq!();
+            }
+            private static immutable string[] arr = [MapToConfigName!(__traits(allMembers, Params))];
+
+            // specific to DOMStringList
+            override
+            {
+                string item(size_t i) { return arr[i]; }
+                size_t length() { return arr.length; }
+
+                bool contains(string str)
+                {
+                    import std.algorithm: canFind;
+                    return arr.canFind(str);
+                }
+            }
+            alias arr this;
+        }
+    }
+}
+
+/++
++   Instantiates a `DOMBuilder` specialized for the `DOMImplementation` implemented
++   in this module.
++/
+auto domBuilder(CursorType)(auto ref CursorType cursor)
+{
+    import std.experimental.allocator.gc_allocator;
+    import dompar = std.experimental.xml.domparser;
+    return dompar.domBuilder(cursor, new DOMImplementation!(CursorType.StringType, shared(GCAllocator))());
+}
+
+unittest
+{
+    import std.experimental.allocator.mallocator;
+    auto impl = Mallocator.instance.make!(DOMImplementation!(string, shared(Mallocator)))();
+
+    auto doc = impl.createDocument("myNamespaceURI", "myPrefix:myRootElement", null);
+    auto root = doc.documentElement;
+    assert(root.prefix == "myPrefix");
+
+    auto attr = doc.createAttributeNS("myAttrNamespace", "myAttrPrefix:myAttrName");
+    root.setAttributeNode(attr);
+    assert(root.attributes.length == 1);
+    assert(root.getAttributeNodeNS("myAttrNamespace", "myAttrName") is attr);
+
+    attr.value = "myAttrValue";
+    assert(attr.childNodes.length == 1);
+    assert(attr.firstChild.nodeType == dom.NodeType.TEXT);
+    assert(attr.firstChild.nodeValue == attr.value);
+
+    auto elem = doc.createElementNS("myOtherNamespace", "myOtherPrefix:myOtherElement");
+    assert(root.ownerDocument is doc);
+    assert(elem.ownerDocument is doc);
+    root.appendChild(elem);
+    assert(root.firstChild is elem);
+    assert(root.firstChild.namespaceURI == "myOtherNamespace");
+
+    auto comm = doc.createComment("myWonderfulComment");
+    doc.insertBefore(comm, root);
+    assert(doc.childNodes.length == 2);
+    assert(doc.firstChild is comm);
+
+    assert(comm.substringData(1, 4) == "yWon");
+    comm.replaceData(0, 2, "your");
+    comm.deleteData(4, 9);
+    comm.insertData(4, "Questionable");
+    assert(comm.data == "yourQuestionableComment");
+
+    auto pi = doc.createProcessingInstruction("myPITarget", "myPIData");
+    elem.appendChild(pi);
+    assert(elem.lastChild is pi);
+    auto cdata = doc.createCDATASection("myCDATAContent");
+    elem.replaceChild(cdata, pi);
+    assert(elem.lastChild is cdata);
+    elem.removeChild(cdata);
+    assert(elem.childNodes.length == 0);
+
+    assert(doc.getElementsByTagNameNS("myOtherNamespace", "myOtherElement").item(0) is elem);
+
+    doc.setUserData("userDataKey1", dom.UserData(3.14), null);
+    doc.setUserData("userDataKey2", dom.UserData(new Object()), null);
+    doc.setUserData("userDataKey3", dom.UserData(null), null);
+    assert(doc.getUserData("userDataKey1") == 3.14);
+    assert(doc.getUserData("userDataKey2").type == typeid(Object));
+    assert(doc.getUserData("userDataKey3").peek!long is null);
+
+    assert(elem.lookupNamespaceURI("myOtherPrefix") == "myOtherNamespace");
+    assert(doc.lookupPrefix("myNamespaceURI") == "myPrefix");
+
+    assert(elem.isEqualNode(elem.cloneNode(false)));
+    assert(root.isEqualNode(root.cloneNode(true)));
+    assert(comm.isEqualNode(comm.cloneNode(false)));
+    assert(pi.isEqualNode(pi.cloneNode(false)));
+};
+
+unittest
+{
+    import std.experimental.xml.parser;
+    import std.experimental.xml.cursor;
+    import std.experimental.xml.domparser;
+    import std.stdio;
+
+    string xml = q"{
+    <?xml version = '1.0' standalone = 'yes'?>
+    <books>
+        <book ISBN = '078-5342635362'>
+            <title>The D Programming Language</title>
+            <author>A. Alexandrescu</author>
+        </book>
+        <book ISBN = '978-1515074601'>
+            <title>Programming in D</title>
+            <author>Ali Çehreli</author>
+        </book>
+        <book ISBN = '978-0201704310' about-d = 'no'>
+            <title>Modern C++ Design</title>
+            <author>A. Alexandrescu</author>
+        </book>
+    </books>
+    }";
+
+    auto builder =
+         chooseParser!xml
+        .cursor
+        .domBuilder;
+
+    builder.setSource(xml);
+    builder.buildRecursive;
+
+    auto doc = builder.getDocument;
+    auto books = doc.getElementsByTagName("book");
+    auto authors = doc.getElementsByTagName("author");
+    auto titles = doc.getElementsByTagName("title");
+
+    assert(doc.xmlVersion == "1.0");
+    assert(doc.xmlStandalone);
+
+    enum Pos(dom.DocumentPosition pos) = cast(BitFlags!(dom.DocumentPosition))pos;
+    with (dom.DocumentPosition)
+    {
+        assert(books[1].compareDocumentPosition(authors[2]) == Pos!FOLLOWING);
+        assert(authors[2].compareDocumentPosition(titles[0]) == Pos!PRECEDING);
+        assert(books[1].compareDocumentPosition(titles[1]) == (Pos!CONTAINED_BY | Pos!FOLLOWING));
+        assert(authors[0].compareDocumentPosition(books[0]) == (Pos!CONTAINS | Pos!PRECEDING));
+        assert(titles[2].compareDocumentPosition(titles[2]) == Pos!NONE);
+        assert(books[2].attributes[0].compareDocumentPosition(books[2].attributes[1])
+                == (Pos!IMPLEMENTATION_SPECIFIC | Pos!FOLLOWING));
+        assert(books[2].attributes[1].compareDocumentPosition(books[2].attributes[0])
+                == (Pos!IMPLEMENTATION_SPECIFIC | Pos!PRECEDING));
+    }
+
+    assert(books[1].cloneNode(true).childNodes[1].isEqualNode(authors[1]));
+
+    books[2].setIdAttributeNode(books[2].attributes[1], true);
+    assert(books[2].attributes[1].isId);
+    assert(doc.getElementById("978-0201704310") is books[2]);
+}

--- a/std/experimental/xml/domimpl.d
+++ b/std/experimental/xml/domimpl.d
@@ -1294,7 +1294,7 @@ class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = b
 
             void setQualifiedName(DOMString name)
             {
-                import std.experimental.xml.faststrings;
+                import std.experimental.xml.faststrings : fastIndexOf;
 
                 _name = name;
                 ptrdiff_t i = name.fastIndexOf(':');
@@ -2514,7 +2514,8 @@ unittest
     }";
 
     auto builder =
-         chooseParser!xml
+         xml
+        .parser
         .cursor
         .domBuilder;
 

--- a/std/experimental/xml/domparser.d
+++ b/std/experimental/xml/domparser.d
@@ -241,8 +241,9 @@ unittest
     };
 
     auto builder =
-         chooseLexer!xml
-        .parse
+         xml
+        .lexer
+        .parser
         .cursor
         .copyingCursor
         .domBuilder(new DOMImplType());

--- a/std/experimental/xml/domparser.d
+++ b/std/experimental/xml/domparser.d
@@ -68,8 +68,8 @@ struct DOMBuilder(T, DOMImplementation = dom.DOMImplementation!(T.StringType))
         cursor.setSource(input);
         document = domImpl.createDocument(null, null, null);
 
-        if (cursor.getKind == XMLKind.DOCUMENT)
-            foreach (attr; cursor.getAttributes)
+        if (cursor.kind == XMLKind.document)
+            foreach (attr; cursor.attributes)
                 switch (attr.name)
                 {
                     case "version":
@@ -94,7 +94,7 @@ struct DOMBuilder(T, DOMImplementation = dom.DOMImplementation!(T.StringType))
         if (cursor.atBeginning)
             return cursor.enter;
 
-        if (cursor.getKind != XMLKind.ELEMENT_START)
+        if (cursor.kind != XMLKind.elementStart)
             return false;
 
         if (!already_built)
@@ -174,24 +174,24 @@ struct DOMBuilder(T, DOMImplementation = dom.DOMImplementation!(T.StringType))
     private NodeType createCurrent()
     // TODO: namespace handling
     {
-        switch (cursor.getKind) with(XMLKind)
+        switch (cursor.kind)
         {
-            case ELEMENT_START:
-            case ELEMENT_EMPTY:
-                auto elem = document.createElement(cursor.getName);
-                foreach (attr; cursor.getAttributes)
+            case XMLKind.elementStart:
+            case XMLKind.elementEmpty:
+                auto elem = document.createElement(cursor.name);
+                foreach (attr; cursor.attributes)
                 {
                     elem.setAttribute(attr.name, attr.value);
                 }
                 return elem;
-            case TEXT:
-                return document.createTextNode(cursor.getContent);
-            case CDATA:
-                return document.createCDATASection(cursor.getContent);
-            case PROCESSING_INSTRUCTION:
-                return document.createProcessingInstruction(cursor.getName, cursor.getContent);
-            case COMMENT:
-                return document.createComment(cursor.getContent);
+            case XMLKind.text:
+                return document.createTextNode(cursor.content);
+            case XMLKind.cdata:
+                return document.createCDATASection(cursor.content);
+            case XMLKind.processingInstruction:
+                return document.createProcessingInstruction(cursor.name, cursor.content);
+            case XMLKind.comment:
+                return document.createComment(cursor.content);
             default:
                 return null;
         }

--- a/std/experimental/xml/domparser.d
+++ b/std/experimental/xml/domparser.d
@@ -1,0 +1,256 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.domparser;
+
+import std.experimental.xml.interfaces;
+import std.experimental.xml.cursor;
+
+import dom = std.experimental.xml.dom;
+
+/++
++   Built on top of Cursor, the DOM builder adds to it the ability to
++   build the DOM tree of the document; as the cursor advances, nodes can be
++   selectively added to the tree, allowing to built a small representation
++   containing only the needed parts of the document.
++
++   This type should not be instantiated directly. Instead, the helper function
++   `domBuilder` should be used.
++/
+struct DOMBuilder(T, DOMImplementation = dom.DOMImplementation!(T.StringType))
+    if (isCursor!T && is(DOMImplementation : dom.DOMImplementation!(T.StringType)))
+{
+    import std.traits : ReturnType;
+
+    /++
+    +   The underlying Cursor methods are exposed, so that one can, query the properties
+    +   of the current node before deciding if building it or not.
+    +/
+    T cursor;
+    alias cursor this;
+
+    alias StringType = T.StringType;
+
+    alias DocumentType = ReturnType!(DOMImplementation.createDocument);
+    alias NodeType = typeof(DocumentType.firstChild);
+
+    private NodeType currentNode;
+    private DocumentType document;
+    private DOMImplementation domImpl;
+    private bool already_built;
+
+    this(Args...)(DOMImplementation impl, auto ref Args args)
+    {
+        cursor = typeof(cursor)(args);
+        domImpl = impl;
+    }
+
+    /++
+    +   Initializes this builder and the underlying components.
+    +/
+    void setSource(T.InputType input)
+    {
+        cursor.setSource(input);
+        document = domImpl.createDocument(null, null, null);
+
+        if (cursor.getKind == XMLKind.DOCUMENT)
+            foreach (attr; cursor.getAttributes)
+                switch (attr.name)
+                {
+                    case "version":
+                        document.xmlVersion = attr.value;
+                        break;
+                    case "standalone":
+                        document.xmlStandalone = attr.value == "yes";
+                        break;
+                    default:
+                        break;
+                }
+
+        currentNode = document;
+    }
+
+    /++
+    +   Same as `cursor.enter`. When entering a node, that node is automatically
+    +   built into the DOM, so that its children can then be safely built if needed.
+    +/
+    bool enter()
+    {
+        if (cursor.atBeginning)
+            return cursor.enter;
+
+        if (cursor.getKind != XMLKind.ELEMENT_START)
+            return false;
+
+        if (!already_built)
+        {
+            auto elem = createCurrent;
+
+            if (cursor.enter)
+            {
+                currentNode.appendChild(elem);
+                currentNode = elem;
+                return true;
+            }
+        }
+        else if (cursor.enter)
+        {
+            already_built = false;
+            currentNode = currentNode.lastChild;
+            return true;
+        }
+        return false;
+    }
+
+    /++
+    +   Same as `cursor.exit`
+    +/
+    void exit()
+    {
+        if (currentNode)
+            currentNode = currentNode.parentNode;
+        already_built = false;
+        cursor.exit;
+    }
+
+    /++
+    +   Same as `cursor.next`.
+    +/
+    bool next()
+    {
+        already_built = false;
+        return cursor.next;
+    }
+
+    /++
+    +   Adds the current node to the DOM. This operation does not advance the input.
+    +   Calling it more than once does not change the result.
+    +/
+    void build()
+    {
+        if (already_built || cursor.atBeginning)
+            return;
+
+        auto cur = createCurrent;
+        if (cur)
+            currentNode.appendChild(createCurrent);
+
+        already_built = true;
+    }
+
+    /++
+    +   Recursively adds the current node and all its children to the DOM tree.
+    +   Behaves as `cursor.next`: it advances the input to the next sibling, returning
+    +   `true` if and only if there exists such next sibling.
+    +/
+    bool buildRecursive()
+    {
+        if (enter)
+        {
+            while (buildRecursive) {}
+            exit;
+        }
+        else
+            build;
+
+        return next;
+    }
+
+    private NodeType createCurrent()
+    // TODO: namespace handling
+    {
+        switch (cursor.getKind) with(XMLKind)
+        {
+            case ELEMENT_START:
+            case ELEMENT_EMPTY:
+                auto elem = document.createElement(cursor.getName);
+                foreach (attr; cursor.getAttributes)
+                {
+                    elem.setAttribute(attr.name, attr.value);
+                }
+                return elem;
+            case TEXT:
+                return document.createTextNode(cursor.getContent);
+            case CDATA:
+                return document.createCDATASection(cursor.getContent);
+            case PROCESSING_INSTRUCTION:
+                return document.createProcessingInstruction(cursor.getName, cursor.getContent);
+            case COMMENT:
+                return document.createComment(cursor.getContent);
+            default:
+                return null;
+        }
+    }
+
+    /++
+    +   Returns the Document being built by this builder.
+    +/
+    auto getDocument() { return document; }
+}
+
+/++
++   Instantiates a suitable `DOMBuilder` on top of the given `cursor` and `DOMImplementation`.
++/
+auto domBuilder(CursorType, DOMImplementation)(auto ref CursorType cursor, DOMImplementation impl)
+    if (isCursor!CursorType && is(DOMImplementation : dom.DOMImplementation!(CursorType.StringType)))
+{
+    auto res = DOMBuilder!(CursorType, DOMImplementation)();
+    res.cursor = cursor;
+    res.domImpl = impl;
+    return res;
+}
+
+unittest
+{
+    import std.stdio;
+
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.experimental.xml.cursor;
+    import std.experimental.allocator.gc_allocator;
+    import domimpl = std.experimental.xml.domimpl;
+
+    alias DOMImplType = domimpl.DOMImplementation!string;
+
+    string xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    auto builder =
+         chooseLexer!xml
+        .parse
+        .cursor
+        .copyingCursor
+        .domBuilder(new DOMImplType());
+
+    builder.setSource(xml);
+    builder.buildRecursive;
+    auto doc = builder.getDocument;
+
+    assert(doc.getElementsByTagName("ccc").length == 1);
+    assert(doc.documentElement.getAttribute("xmlns:myns") == "something");
+}

--- a/std/experimental/xml/faststrings.d
+++ b/std/experimental/xml/faststrings.d
@@ -15,7 +15,7 @@
 module std.experimental.xml.faststrings;
 
 /++ Compares for equality; input slices must have equal length. +/
-bool fastEqual(T, S)(T[] t, S[] s) pure @nogc nothrow
+package bool fastEqual(T, S)(T[] t, S[] s) pure @nogc nothrow
 in
 {
     assert(t.length == s.length);

--- a/std/experimental/xml/faststrings.d
+++ b/std/experimental/xml/faststrings.d
@@ -1,0 +1,328 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module implements fast search and compare
++   functions on slices. In the future, these may be
++   optimized by means of aggressive specialization,
++   inline assembly and SIMD instructions.
++/
+
+module std.experimental.xml.faststrings;
+
+/++ Compares for equality; input slices must have equal length. +/
+bool fastEqual(T, S)(T[] t, S[] s) pure @nogc nothrow
+in
+{
+    assert(t.length == s.length);
+}
+body
+{
+    import std.traits;
+    static if (is(Unqual!S == Unqual!T))
+    {
+        import core.stdc.string : memcmp;
+        return memcmp(t.ptr, s.ptr, t.length * T.sizeof) == 0;
+    }
+    else
+    {
+        foreach (i; 0 .. t.length)
+            if (t[i] != s[i])
+                return false;
+        return true;
+    }
+}
+unittest
+{
+    assert( fastEqual("ciao"w, "ciao"w));
+    assert(!fastEqual("ciao", "ciAo"));
+    assert( fastEqual([1, 2], [1, 2]));
+    assert(!fastEqual([1, 2], [1, 3]));
+}
+
+/++ Returns the index of the first occurrence of a value in a slice. +/
+package ptrdiff_t fastIndexOf(T, S)(T[] t, S s) pure @nogc nothrow
+{
+    foreach (i; 0 .. t.length)
+        if (t[i] == s)
+            return i;
+    return -1;
+}
+unittest
+{
+    assert(fastIndexOf("FoO"w, 'O') == 2);
+    assert(fastIndexOf([1, 2], 3.14) == -1);
+}
+
+package ptrdiff_t fastLastIndexOf(T, S)(T[] t, S s)
+{
+    foreach_reverse (i; 0.. t.length)
+        if (t[i] == s)
+            return i;
+    return -1;
+}
+unittest
+{
+    assert(fastLastIndexOf("FoOo"w, 'o') == 3);
+    assert(fastLastIndexOf([1, 2], 3.14) == -1);
+}
+
+/++
++ Returns the index of the first occurrence of any of the values in the second
++ slice inside the first one.
++/
+package ptrdiff_t fastIndexOfAny(T, S)(T[] t, S[] s) pure @nogc nothrow
+{
+    foreach (i; 0 .. t.length)
+        if (fastIndexOf(s, t[i]) != -1)
+            return i;
+    return -1;
+}
+unittest
+{
+    assert(fastIndexOfAny([1, 2, 3, 4], [5, 4, 3]) == 2);
+    assert(fastIndexOfAny("Foo", "baz") == -1);
+}
+
+/++
++ Returns the index of the first occurrence of a value of the first slice that
++ does not appear in the second.
++/
+package ptrdiff_t fastIndexOfNeither(T, S)(T[] t, S[] s) pure @nogc nothrow
+{
+    foreach (i; 0 .. t.length)
+        if (fastIndexOf(s, t[i]) == -1)
+            return i;
+    return -1;
+}
+unittest
+{
+    assert(fastIndexOfNeither("lulublubla", "luck") == 4);
+    assert(fastIndexOfNeither([1, 3, 2], [2, 3, 1]) == -1);
+}
+
+import std.experimental.allocator.gc_allocator;
+
+/++
++   Returns a copy of the input string, after escaping all XML reserved characters.
++
++   If the string does not contain any reserved character, it is returned unmodified;
++   otherwise, a copy is made using the specified allocator.
++/
+T[] xmlEscape(T, Alloc)(T[] str)
+{
+    return xmlEscape(str, Alloc.instance);
+}
+/// ditto
+T[] xmlEscape(T, Alloc)(T[] str, ref Alloc alloc)
+{
+    if (str.fastIndexOfAny("&<>'\"") >= 0)
+    {
+        import std.experimental.xml.appender;
+
+        auto app = Appender!(T, Alloc)(alloc);
+        app.reserve(str.length + 3);
+
+        app.xmlEscapedWrite(str);
+        return app.data;
+    }
+    return str;
+}
+
+/++
++   Writes the input string to the given output range, after escaping all XML reserved characters.
++/
+void xmlEscapedWrite(Out, T)(ref Out output, T[] str)
+{
+    import std.conv : to;
+    static immutable amp = to!(T[])("&amp;");
+    static immutable lt = to!(T[])("&lt;");
+    static immutable gt = to!(T[])("&gt;");
+    static immutable apos = to!(T[])("&apos;");
+    static immutable quot = to!(T[])("&quot;");
+
+    ptrdiff_t i;
+    while ((i = str.fastIndexOfAny("&<>'\"")) >= 0)
+    {
+        output.put(str[0..i]);
+
+        if (str[i] == '&')
+            output.put(amp);
+        else if (str[i] == '<')
+            output.put(lt);
+        else if (str[i] == '>')
+            output.put(gt);
+        else if (str[i] == '\'')
+            output.put(apos);
+        else if (str[i] == '"')
+            output.put(quot);
+
+        str = str[i+1..$];
+    }
+    output.put(str);
+}
+
+struct xmlPredefinedEntities(T)
+{
+    static immutable T[] amp = "&";
+    static immutable T[] lt = "<";
+    static immutable T[] gt = ">";
+    static immutable T[] apos = "'";
+    static immutable T[] quot = "\"";
+
+    auto opBinaryRight(string op, U)(U key) const @nogc
+        if (op == "in")
+    {
+        switch (key)
+        {
+            case "amp":
+                return &amp;
+            case "lt":
+                return &lt;
+            case "gt":
+                return &gt;
+            case "apos":
+                return &apos;
+            case "quot":
+                return &quot;
+            default:
+                return null;
+        }
+    }
+}
+
+import std.typecons: Flag, Yes;
+
+/++
++   Returns a copy of the input string, after unescaping all known entity references.
++
++   If the string does not contain any entity reference, it is returned unmodified;
++   otherwise, a copy is made using the specified allocator.
++
++   The set of known entities can be specified with the last parameter, which must support
++   the `in` operator (it is treated as an associative array).
++/
+T[] xmlUnescape(Flag!"strict" strict = Yes.strict, T, Alloc, U)(T[] str, U replacements = xmlPredefinedEntities!T())
+    if (is(typeof(Alloc.instance)))
+{
+    return xmlUnescape!strict(str, Alloc.instance, replacements);
+}
+/// ditto
+T[] xmlUnescape(Flag!"strict" strict = Yes.strict, T, Alloc, U)
+               (T[] str, ref Alloc alloc, U replacements = xmlPredefinedEntities!T())
+{
+    if (str.fastIndexOf('&') >= 0)
+    {
+        import std.experimental.xml.appender;
+
+        auto app = Appender!(T, Alloc)(alloc);
+        app.reserve(str.length);
+
+        app.xmlUnescapedWrite!strict(str, replacements);
+        return app.data;
+    }
+    return str;
+}
+
+/++
++   Outputs the input string to the given output range, after unescaping all known entity references.
++
++   The set of known entities can be specified with the last parameter, which must support
++   the `in` operator (it is treated as an associative array).
++/
+void xmlUnescapedWrite(Flag!"strict" strict = Yes.strict, Out, T, U)
+                      (ref Out output, T[] str, U replacements = xmlPredefinedEntities!T())
+{
+    ptrdiff_t i;
+    while ((i = str.fastIndexOf('&')) >= 0)
+    {
+        output.put(str[0..i]);
+
+        ptrdiff_t j = str[(i+1)..$].fastIndexOf(';');
+        static if (strict == Yes.strict)
+            assert (j > 0, "Missing ';' ending XML entity");
+        else
+            if (j < 0) break;
+        auto ent = str[(i+1)..(i+j+1)];
+
+        // character entities
+        if (ent[0] == '#')
+        {
+            assert(ent.length > 1);
+            uint num;
+            // hex number
+            if (ent.length > 2 && ent[1] == 'x')
+            {
+                foreach(digit; ent[2..$])
+                {
+                    if ('0' <= digit && digit <= '9')
+                        num = (num << 4) + (digit - '0');
+                    else if ('a' <= digit && digit <= 'f')
+                        num = (num << 4) + (digit - 'a' + 10);
+                    else if ('A' <= digit && digit <= 'F')
+                        num = (num << 4) + (digit - 'A' + 10);
+                    else
+                        assert(0);
+                }
+            }
+            // decimal number
+            else
+            {
+                foreach(digit; ent[1..$])
+                {
+                    if ('0' <= digit && digit <= '9')
+                        num = (num * 10) + (digit - '0');
+                    else
+                        assert(0);
+                }
+            }
+            assert(num <= 0x10FFFF);
+            output.put(cast(dchar)num);
+        }
+        // named entities
+        else
+        {
+            auto repl = ent in replacements;
+            static if (strict == Yes.strict)
+                assert (repl, cast(string)str[(i+1)..(i+j+1)]);
+            else
+                if (!repl)
+                {
+                    app.put(str[i]);
+                    str = str[(i+1)..$];
+                    continue;
+                }
+            output.put(*repl);
+        }
+
+        str = str[(i+j+2)..$];
+    }
+    output.put(str);
+}
+
+@nogc unittest
+{
+    import std.experimental.allocator.mallocator;
+    auto alloc = Mallocator.instance;
+    assert(xmlEscape("some standard string"d, alloc) == "some standard string"d);
+    assert(xmlEscape("& \"some\" <standard> 'string'", alloc) ==
+                     "&amp; &quot;some&quot; &lt;standard&gt; &apos;string&apos;");
+    assert(xmlEscape("<&'>>>\"'\"<&&"w, alloc) ==
+                     "&lt;&amp;&apos;&gt;&gt;&gt;&quot;&apos;&quot;&lt;&amp;&amp;"w);
+}
+
+@nogc unittest
+{
+    import std.experimental.allocator.mallocator;
+    auto alloc = Mallocator.instance;
+    assert(xmlUnescape("some standard string"d, alloc) == "some standard string"d);
+    assert(xmlUnescape("some s&#116;range&#x20;string", alloc) == "some strange string");
+    assert(xmlUnescape("&amp; &quot;some&quot; &lt;standard&gt; &apos;string&apos;", alloc)
+                       == "& \"some\" <standard> 'string'");
+    assert(xmlUnescape("&lt;&amp;&apos;&gt;&gt;&gt;&quot;&apos;&quot;&lt;&amp;&amp;"w, alloc)
+                       == "<&'>>>\"'\"<&&"w);
+}

--- a/std/experimental/xml/interfaces.d
+++ b/std/experimental/xml/interfaces.d
@@ -134,16 +134,13 @@ template isLexer(L)
     (inout int = 0)
     {
         alias C = L.CharacterType;
-        alias T = L.InputType;
 
         L lexer;
-        T source;
         char c;
         bool b;
         string s;
         C[] cs;
 
-        lexer.setSource(source);
         b = lexer.empty;
         lexer.start();
         cs = lexer.get();
@@ -277,16 +274,7 @@ enum XMLKind
 template isLowLevelParser(P)
 {
     enum bool isLowLevelParser = isInputRange!P && is(typeof(ElementType!P.kind) == XMLKind)
-                                 && is(typeof(ElementType!P.content) == P.CharacterType[]) && is(typeof(
-    (inout int = 0)
-    {
-        alias InputType = P.InputType;
-
-        P parser;
-        InputType input;
-
-        parser.setSource(input);
-    }));
+                                 && is(typeof(ElementType!P.content) == P.CharacterType[]);
 }
 
 /++
@@ -431,14 +419,11 @@ template isCursor(CursorType)
     enum bool isCursor = is(typeof(
     (inout int = 0)
     {
-        alias T = CursorType.InputType;
         alias S = CursorType.StringType;
 
         CursorType cursor;
-        T input;
         bool b;
 
-        cursor.setSource(input);
         b = cursor.atBeginning;
         b = cursor.documentEnd;
         b = cursor.next;
@@ -512,6 +497,22 @@ template isWriter(WriterType)
         writer.startElement(s);
         writer.closeElement(s);
         writer.writeAttribute(s, s);
+    }));
+}
+
+// COMMON
+
+template needSource(T)
+{
+    enum bool needSource = is(typeof(
+    (inout int = 0)
+    {
+        alias InputType = T.InputType;
+
+        T component;
+        InputType input;
+
+        component.setSource(input);
     }));
 }
 

--- a/std/experimental/xml/interfaces.d
+++ b/std/experimental/xml/interfaces.d
@@ -1,0 +1,564 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module contains some templates to check whether a type exposes the correct
++   interface to be an xml lexer, parser or cursor; it also contains some simple
++   types used in various parts of the library;
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.interfaces;
+
+import std.range.primitives;
+import std.traits;
+
+// LEVEL 1: LEXERS
+
+/++
++   Checks whether its argument fulfills all requirements to be used as an XML lexer.
++
++   An XML lexer is the first component in the parsing chain. It masks from the parser
++   the shape of the input and the type of the characters in it. The slices returned by
++   the lexer are ephemeral: every reference to them may or may not be invalidated when a
++   new slice is requested by the parser. It is thus responsibility of the user to copy the
++   output if necessary.
++
++   Params:
++       L = the type to be tested
++
++   Returns:
++   `true` if L satisfies the XML lexer specification here stated; `false` otherwise
++
++   Specification:
++   A lexer shall support at least these methods and aliases:
++   $(UL
++       $(LI `alias CharacterType`: the type of a single source character; most
++             methods will deal with slices of this type;)
++       $(LI `alias InputType`: the type of the input which is used to feed this
++             lexer;)
++       $(LI `void setSource(InputType)`: sets the input source for this lexer;
++             the lexer may perform other initialization work and even consume
++             part of the input during this operation; after (partial or complete)
++             usage, a lexer may be reinitialized and used with another input
++             by calling this function;)
++       $(LI `bool empty()`: returns `true` if the entire input has been consumed;
++            `false` otherwise;)
++       $(LI `void start()`: instructs the lexer that a new token starts at the
++             current positions; the next calls to `get` will retrive the input
++             from the current position; this call may invalidate any reference
++             to any slice previosly returned from `get`)
++       $(LI `CharacterType[] get()`: returns the contents of the input going from
++             the last call to `start` till the current position;)
++       $(LI `bool testAndAdvance(CharacterType)`: tests whether the input character
++             at the current position matches the one passed as parameter; if
++             it is the case, this method returns `true` and advances the input
++             past the said character; otherwise, it returns `false` and no action
++             is performed;)
++       $(LI `void advanceUntil(CharacterType, bool)`: advances the input until
++             the given character is found; if the second parameter is true, the
++             input is then advanced past the found character;)
++       $(LI `void advanceUntilAny(CharacterType[], bool)`: advances the input
++             until any of the given characters is found; if the second parameter
++             is true, the input is then advanced past the found character;)
++       $(LI `void dropWhile(CharacterType[])`: advances the input until a character
++             different from the given ones is found; the characters advanced by
++             this method may or may not be included in the output of a subsequent
++             `get`; for this reason, this method should only be called immediately
++             before `start`, to skip unneeded characters between two tokens.)
++   )
++
++   Examples:
++   ---
++   /* extract a word surrounded by whitespaces */
++   auto getWord(L)(ref L lexer)
++       if (isLexer!L)
++   {
++       // drop leading whitespaces
++       lexer.dropWhile(" \n\r\t");
++
++       // start building the word
++       lexer.start;
++
++       // keep advancing until you find the trailing whitespaces
++       lexer.advanceUntilAny(" \n\r\t", false);
++
++       // return what you found
++       return lexer.get;
++   }
++
++   /* extract a key/value pair from a string like " key : value " */
++   auto getKeyValuePair(ref L lexer)
++       if (isLexer!L)
++   {
++       // drop leading whitespaces
++       lexer.dropWhile(" \n\r\t");
++
++       // here starts the key, which ends with either a whitespace or a colon
++       lexer.start;
++       lexer.advanceUntilAny(" \n\r\t:", false);
++       auto key = lexer.get;
++
++       // skip any spaces after the key
++       lexer.dropWhile(" \n\r\t");
++       // now there must be a colon
++       assert(lexer.testAndAdvance(':'));
++       // skip all space after the colon
++       lexer.dropWhile(" \n\r\t");
++
++       // here starts the value, which ends at the first whitespace
++       lexer.start;
++       lexer.advanceUntilAny(" \n\r\t", false);
++       auto value = lexer.get;
++
++       // return the pair
++       return tuple(key, value);
++   }
++   ---
++/
+template isLexer(L)
+{
+    enum bool isLexer = is(typeof(
+    (inout int = 0)
+    {
+        alias C = L.CharacterType;
+        alias T = L.InputType;
+
+        L lexer;
+        T source;
+        char c;
+        bool b;
+        string s;
+        C[] cs;
+
+        lexer.setSource(source);
+        b = lexer.empty;
+        lexer.start();
+        cs = lexer.get();
+        b = lexer.testAndAdvance(c);
+        lexer.advanceUntil(c, b);
+        lexer.advanceUntilAny(s, b);
+        lexer.dropWhile(s);
+    }));
+}
+
+/++
++   Checks whether its argument is a saveable lexer.
++
++   A saveable lexer is a lexer enhanced with a `save` method analogous to the `save`
++   method of `ForwardRange`s.
++
++   Params:
++       L = the type to be tested
++
++   Returns:
++   `true` if L is a lexer (as specified by `isLexer`) and also supports the `save`
++   method as specified here; `false` otherwise
++
++   Specification:
++   The type shall support at least:
++   $(UL
++       $(LI all methods and aliases specified by `isLexer`)
++       $(LI `L save()`: returns an independent copy of the current lexer; the
++             copy must start at the position the original lexer was when this method
++             was called; the two copies shall be independent, in that advancing one
++             does not advance the other.)
++   )
++/
+template isSaveableLexer(L)
+{
+    enum bool isSaveableLexer = isLexer!L && is(typeof(
+    (inout int = 0)
+    {
+        L lexer1;
+        L lexer2 = lexer1.save();
+    }));
+}
+
+// LEVEL 2: PARSERS
+
+/++
++   Enumeration of XML events/nodes, used by various components.
++/
+enum XMLKind
+{
+    /++ The `<?xml` `?>` declaration at the beginning of the entire document +/
+    DOCUMENT,
+
+    /++ The beginning of a document type declaration `<!DOCTYPE ... [` +/
+    DTD_START,
+    /++ The end of a document type declaration `] >` +/
+    DTD_END,
+    /++ A document type declaration without an internal subset +/
+    DTD_EMPTY,
+
+    /++ A start tag, delimited by `<` and `>` +/
+    ELEMENT_START,
+
+    /++ An end tag, delimited by `</` and `>` +/
+    ELEMENT_END,
+
+    /++ An empty tag, delimited by `<` and `/>` +/
+    ELEMENT_EMPTY,
+
+    /++ A text element, without any specific delimiter +/
+    TEXT,
+
+    /++ A CDATA section, delimited by `<![CDATA` and `]]>` +/
+    CDATA,
+
+    /++ A comment, delimited by `<!--` and `-->` +/
+    COMMENT,
+
+    /++ A processing instruction, delimited by `<?` and `?>` +/
+    PROCESSING_INSTRUCTION,
+
+    /++ An attlist declaration, delimited by `<!ATTLIST` and `>` +/
+    ATTLIST_DECL,
+    /++ An element declaration, delimited by `<!ELEMENT` and `>` +/
+    ELEMENT_DECL,
+    /++ An entity declaration, delimited by `<!ENTITY` and `>` +/
+    ENTITY_DECL,
+    /++ A notation declaration, delimited by `<!NOTATION` and `>` +/
+    NOTATION_DECL,
+    /++ Any unrecognized kind of declaration, delimited by `<!` and `>` +/
+    DECLARATION,
+
+    /++ A conditional section, delimited by `<![` `[` and `]]>` +/
+    CONDITIONAL,
+}
+
+/++
++   Checks whether its argument fulfills all requirements to be used as XML parser.
++
++   An XML parser is the second component in the parsing chain. It is usually built
++   on top of a lexer and used to feed a cursor.
++   The slices contained in the tokens returned by the parser are ephemeral: every
++   reference to them may or may not be invalidated by subsequent calls to `popFront`.
++   If the caller needs them, it has to copy them somewhere else.
++
++   Params:
++       P = the type to be tested
++
++   Returns:
++   `true` if P satisfies the XML parser specification here stated; `false` otherwise
++
++   Specification:
++   The parser shall at least:
++   $(UL
++       $(LI have `alias CharacterType`: the type of a single source character;)
++       $(LI have `alias InputType`: the type of the input which is used to feed this
++            parser;)
++       $(LI be an `InputRange`, whose elements shall support at least the following fields:
++            $(UL
++               $(LI `XMLKind kind`: the kind of this node;)
++               $(LI `P.CharacterType[] content`: the contents of this node, excluding
++                     the delimiters specified in the documentation of `XMLKind`;)
++            ))
++       $(LI have `void setSource(InputType)`: sets the input source for this parser
++            and eventual underlying components; the parser may perform other
++            initialization work and even consume part of the input during this
++            operation; after (partial or complete) usage, a parser may be reinitialized
++            and used with another input by calling this function;)
++   )
++/
+template isLowLevelParser(P)
+{
+    enum bool isLowLevelParser = isInputRange!P && is(typeof(ElementType!P.kind) == XMLKind)
+                                 && is(typeof(ElementType!P.content) == P.CharacterType[]) && is(typeof(
+    (inout int = 0)
+    {
+        alias InputType = P.InputType;
+
+        P parser;
+        InputType input;
+
+        parser.setSource(input);
+    }));
+}
+
+/++
++   Checks whether its argument is a saveable parser.
++
++   A saveable parser is a parser enhanced with a `save` method analogous to the `save`
++   method of `ForwardRange`s.
++
++   Params:
++       P = the type to be tested
++
++   Returns:
++   `true` if P is a parser (as specified by `isLowLevelParser`) and also supports the
++   `save` method as specified here; `false` otherwise
++
++   Specification:
++   The type shall support at least:
++   $(UL
++       $(LI all methods and aliases specified by `isLowLevelParser`)
++       $(LI `P save()`: returns an independent copy of the current parser; the
++             copy must start at the position the original parser was when this method
++             was called; the two copies shall be independent, in that advancing one
++             does not advance the other.)
++   )
++/
+template isSaveableLowLevelParser(P)
+{
+    enum bool isSaveableLowLevelParser = isLowLevelParser!P && isForwardRange!P;
+}
+
+// LEVEL 3: CURSORS
+
+/++
++   Checks whether its argument fulfills all requirements to be used as XML cursor.
++
++   The cursor is the hearth of the XML parsing chain. Every higher level component
++   (SAX, DOM, validations) builds on top of this concept.
++   A cursor is a logical pointer inside a stream of XML nodes. It can be queried
++   for properties of the current node (kind, name, attributes, ...) and it can be
++   advanced in the stream. It cannot move backwards. Any reference to the outputs
++   of a cursor may or may not be invalidated by advancing operations.
++
++   Params:
++       CursorType = the type to be tested
++
++   Returns:
++   `true` if CursorType satisfies the XML cursor specification here stated;
++   `false` otherwise
++
++   Specification:
++   A cursor shall support at least these methods and aliases:
++   $(UL
++       $(LI `alias StringType`: the type of an output string; most methods will
++             return instances of this type;)
++       $(LI `alias InputType`: the type of the input which is used to feed this
++             cursor;)
++       $(LI `void setSource(InputType)`: sets the input source for this cursor and
++             eventual underlying components; the cursor may perform other initialization
++             work and even consume part of the input during this operation; after
++            (partial or complete) usage, a cursor may be reinitialized and used with
++             another input by calling this function;)
++       $(LI `bool atBeginning()`: returns true if the cursor has never been advanced;
++             it is thus pointing to the node of type `XMLKind.DOCUMENT` representing
++             the XML declaration of the document;)
++       $(LI `bool documentEnd()`: returns `true` if the input has been completely
++             consumed; if it is the case, any advancing operation will perform no action)
++       $(LI  the following methods can be used to query the current node properties:
++             $(UL
++               $(LI `XMLKind getKind()`: returns the `XMLKind` of the current node;)
++               $(LI `StringType getName()`: returns the qualified name of the current
++                     element or the target of the current processing instruction;
++                     the empty string in all other cases;)
++               $(LI `StringType getLocalName()`: returns the local name of the
++                     current element, if it has a prefix; the empty string in all
++                     other cases;)
++               $(LI `StringType getPrefix()`: returns the prefix of the current element,
++                     if it has any; the empty string in all other cases;)
++               $(LI `auto getAttributes()`: returns a range of all attributes defined
++                     on the current element; if the current node is a processing
++                     instruction, its data section is parsed as if it was the attributes
++                     list of an element (which is quite common); for all other node
++                     kinds, an empty range is returned.
++                     The type returned by this range `front` method shall at least support
++                     the following fields:
++                     $(UL
++                       $(LI `StringType name`: the qualified name of the attribute;)
++                       $(LI `StringType prefix`: the prefix of the attribute, if it
++                             has any; the empty string otherwise;)
++                       $(LI `StringType localName`: the local name of the attribute,
++                             if it has any prefix; the empty string otherwise;)
++                       $(LI `StringType value`: the value of the attribute;)
++                     ))
++               $(LI `StringType getContent()`: returns the text content of the current
++                     comment, text node or CDATA section or the data of the current
++                     processing instruction; the empty string in all other cases;)
++               $(LI `StringType getAll()`: returns the entire content of the node;)
++             ))
++       $(LI  the following methods can be used to advance the cursor in the stream
++             of XML nodes:
++             $(UL
++               $(LI `bool enter()`: tries to advance the cursor to the first child
++                     of the current node; returns `true` if the operation succeeded;
++                     otherwise, if the cursor was positioned on the start tag of an
++                     element, it is now positioned on its closing tag; otherwise,
++                     the cursor did not advance;)
++               $(LI `bool next()`: tries to advance the cursor to the next sibling
++                     of the current node; returns `true` if the operation succeded;
++                     otherwise (i.e. the cursor was positioned on the last child
++                     of an element) it is now positioned on the closing tag of the
++                     parent element;)
++               $(LI `void exit()`: advances the cursor to the closing tag of the
++                     element containing the current node;)
++             ))
++   )
++
++   Examples:
++   ---
++   /* recursively prints the kind of each node */
++   void recursivePrint(CursorType)(ref CursorType cursor)
++       if (isCursor!CursorType)
++   {
++       do
++       {
++           // print the kind of the current node
++           writeln(cursor.getKind);
++           // if the node has children
++           if (cursor.enter)
++           {
++               // recursively print them
++               recursivePrint(cursor);
++               // back to the current level
++               cursor.exit;
++           }
++       }
++       // iterate on every sibling
++       while (cursor.next)
++   }
++   ---
++/
+template isCursor(CursorType)
+{
+    enum bool isCursor = is(typeof(
+    (inout int = 0)
+    {
+        alias T = CursorType.InputType;
+        alias S = CursorType.StringType;
+
+        CursorType cursor;
+        T input;
+        bool b;
+
+        cursor.setSource(input);
+        b = cursor.atBeginning;
+        b = cursor.documentEnd;
+        b = cursor.next;
+        b = cursor.enter;
+        cursor.exit;
+        XMLKind kind = cursor.getKind;
+        auto s = cursor.getName;
+        s = cursor.getLocalName;
+        s = cursor.getPrefix;
+        s = cursor.getContent;
+        s = cursor.getAll;
+        auto attrs = cursor.getAttributes;
+        s = attrs.front.prefix;
+        s = attrs.front.localName;
+        s = attrs.front.name;
+        s = attrs.front.value;
+    }
+    ));
+}
+
+/++
++   Checks whether its argument is a saveable cursor.
++
++   A saveable cursor is a cursor enhanced with a `save` method analogous to the `save`
++   method of `ForwardRange`s.
++
++   Params:
++       CursorType = the type to be tested
++
++   Returns:
++   `true` if CursorType is a cursor (as specified by `isCursor`) and also supports the
++   `save` method as specified here; `false` otherwise
++
++   Specification:
++   The type shall support at least:
++   $(UL
++       $(LI all methods and aliases specified by `isCursor`)
++       $(LI `CursorType save()`: returns an independent copy of the current cursor; the
++             copy must start at the position the original cursor was when this method
++             was called; the two copies shall be independent, in that advancing one
++             does not advance the other.)
++   )
++/
+template isSaveableCursor(CursorType)
+{
+    enum bool isSaveableCursor = isCursor!CursorType && is(typeof(
+    (inout int = 0)
+    {
+        CursorType cursor1;
+        CursorType cursor2 = cursor1.save();
+    }));
+}
+
+// WRITERS
+
+template isWriter(WriterType)
+{
+    enum bool isWriter = is(typeof(
+    (inout int = 0)
+    {
+        alias StringType = WriterType.StringType;
+
+        WriterType writer;
+        StringType s;
+
+        writer.writeXMLDeclaration(10, s, true);
+        writer.writeComment(s);
+        writer.writeText(s);
+        writer.writeCDATA(s);
+        writer.writeProcessingInstruction(s, s);
+        writer.startElement(s);
+        writer.closeElement(s);
+        writer.writeAttribute(s, s);
+    }));
+}
+
+// PRIVATE STUFF
+
+package mixin template UsesAllocator(Alloc, bool genDefaultCtor = false)
+{
+    static if (is(Alloc == class))
+        private alias TrueAlloc = Alloc;
+    else
+        private alias TrueAlloc = Alloc*;
+
+    static if (is(typeof(Alloc.instance) == Alloc))
+    {
+        static if (is(Alloc == class))
+            private TrueAlloc allocator = Alloc.instance;
+        else
+            private TrueAlloc allocator = &(Alloc.instance);
+
+        static if (genDefaultCtor)
+            this() {}
+    }
+    else
+    {
+        private TrueAlloc allocator;
+        @disable this();
+    }
+
+    this(TrueAlloc allocator)
+    {
+        this.allocator = allocator;
+    }
+
+    static if (!is(Alloc == class))
+        this(ref Alloc allocator)
+        {
+            this.allocator = &allocator;
+        }
+}
+
+package mixin template UsesErrorHandler(ErrorHandler)
+{
+    private ErrorHandler handler;
+    @property auto errorHandler() { return &handler; }
+    @property void errorHandler(ErrorHandler eh)
+    {
+        assert(eh, "Null errorHandler on setting");
+        handler = eh;
+    }
+}

--- a/std/experimental/xml/interfaces.d
+++ b/std/experimental/xml/interfaces.d
@@ -195,49 +195,49 @@ template isSaveableLexer(L)
 enum XMLKind
 {
     /++ The `<?xml` `?>` declaration at the beginning of the entire document +/
-    DOCUMENT,
+    document,
 
     /++ The beginning of a document type declaration `<!DOCTYPE ... [` +/
-    DTD_START,
+    dtdStart,
     /++ The end of a document type declaration `] >` +/
-    DTD_END,
+    dtdEnd,
     /++ A document type declaration without an internal subset +/
-    DTD_EMPTY,
+    dtdEmpty,
 
     /++ A start tag, delimited by `<` and `>` +/
-    ELEMENT_START,
+    elementStart,
 
     /++ An end tag, delimited by `</` and `>` +/
-    ELEMENT_END,
+    elementEnd,
 
     /++ An empty tag, delimited by `<` and `/>` +/
-    ELEMENT_EMPTY,
+    elementEmpty,
 
     /++ A text element, without any specific delimiter +/
-    TEXT,
+    text,
 
-    /++ A CDATA section, delimited by `<![CDATA` and `]]>` +/
-    CDATA,
+    /++ A cdata section, delimited by `<![cdata` and `]]>` +/
+    cdata,
 
     /++ A comment, delimited by `<!--` and `-->` +/
-    COMMENT,
+    comment,
 
     /++ A processing instruction, delimited by `<?` and `?>` +/
-    PROCESSING_INSTRUCTION,
+    processingInstruction,
 
     /++ An attlist declaration, delimited by `<!ATTLIST` and `>` +/
-    ATTLIST_DECL,
+    attlistDecl,
     /++ An element declaration, delimited by `<!ELEMENT` and `>` +/
-    ELEMENT_DECL,
+    elementDecl,
     /++ An entity declaration, delimited by `<!ENTITY` and `>` +/
-    ENTITY_DECL,
+    entityDecl,
     /++ A notation declaration, delimited by `<!NOTATION` and `>` +/
-    NOTATION_DECL,
+    notationDecl,
     /++ Any unrecognized kind of declaration, delimited by `<!` and `>` +/
-    DECLARATION,
+    declaration,
 
     /++ A conditional section, delimited by `<![` `[` and `]]>` +/
-    CONDITIONAL,
+    conditional,
 }
 
 /++
@@ -349,22 +349,22 @@ template isSaveableLowLevelParser(P)
 +            (partial or complete) usage, a cursor may be reinitialized and used with
 +             another input by calling this function;)
 +       $(LI `bool atBeginning()`: returns true if the cursor has never been advanced;
-+             it is thus pointing to the node of type `XMLKind.DOCUMENT` representing
++             it is thus pointing to the node of type `XMLKind.document` representing
 +             the XML declaration of the document;)
 +       $(LI `bool documentEnd()`: returns `true` if the input has been completely
 +             consumed; if it is the case, any advancing operation will perform no action)
 +       $(LI  the following methods can be used to query the current node properties:
 +             $(UL
-+               $(LI `XMLKind getKind()`: returns the `XMLKind` of the current node;)
-+               $(LI `StringType getName()`: returns the qualified name of the current
++               $(LI `XMLKind kind()`: returns the `XMLKind` of the current node;)
++               $(LI `StringType name()`: returns the qualified name of the current
 +                     element or the target of the current processing instruction;
 +                     the empty string in all other cases;)
-+               $(LI `StringType getLocalName()`: returns the local name of the
++               $(LI `StringType localName()`: returns the local name of the
 +                     current element, if it has a prefix; the empty string in all
 +                     other cases;)
-+               $(LI `StringType getPrefix()`: returns the prefix of the current element,
++               $(LI `StringType prefix()`: returns the prefix of the current element,
 +                     if it has any; the empty string in all other cases;)
-+               $(LI `auto getAttributes()`: returns a range of all attributes defined
++               $(LI `auto attributes()`: returns a range of all attributes defined
 +                     on the current element; if the current node is a processing
 +                     instruction, its data section is parsed as if it was the attributes
 +                     list of an element (which is quite common); for all other node
@@ -379,10 +379,10 @@ template isSaveableLowLevelParser(P)
 +                             if it has any prefix; the empty string otherwise;)
 +                       $(LI `StringType value`: the value of the attribute;)
 +                     ))
-+               $(LI `StringType getContent()`: returns the text content of the current
-+                     comment, text node or CDATA section or the data of the current
++               $(LI `StringType content()`: returns the text content of the current
++                     comment, text node or cdata section or the data of the current
 +                     processing instruction; the empty string in all other cases;)
-+               $(LI `StringType getAll()`: returns the entire content of the node;)
++               $(LI `StringType wholeContent()`: returns the entire content of the node;)
 +             ))
 +       $(LI  the following methods can be used to advance the cursor in the stream
 +             of XML nodes:
@@ -411,7 +411,7 @@ template isSaveableLowLevelParser(P)
 +       do
 +       {
 +           // print the kind of the current node
-+           writeln(cursor.getKind);
++           writeln(cursor.kind);
 +           // if the node has children
 +           if (cursor.enter)
 +           {
@@ -444,13 +444,13 @@ template isCursor(CursorType)
         b = cursor.next;
         b = cursor.enter;
         cursor.exit;
-        XMLKind kind = cursor.getKind;
-        auto s = cursor.getName;
-        s = cursor.getLocalName;
-        s = cursor.getPrefix;
-        s = cursor.getContent;
-        s = cursor.getAll;
-        auto attrs = cursor.getAttributes;
+        XMLKind kind = cursor.kind;
+        auto s = cursor.name;
+        s = cursor.localName;
+        s = cursor.prefix;
+        s = cursor.content;
+        s = cursor.wholeContent;
+        auto attrs = cursor.attributes;
         s = attrs.front.prefix;
         s = attrs.front.localName;
         s = attrs.front.name;
@@ -513,6 +513,18 @@ template isWriter(WriterType)
         writer.closeElement(s);
         writer.writeAttribute(s, s);
     }));
+}
+
+/++
++   Generic XML exception; thrown whenever a component experiences an error, unless
++   the user provided a custom error handler.
++/
+class XMLException: Exception
+{
+    this(string msg, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
 }
 
 // PRIVATE STUFF

--- a/std/experimental/xml/lexers.d
+++ b/std/experimental/xml/lexers.d
@@ -1,0 +1,908 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module implements various XML lexers.
++
++   The methods a lexer should implement are documented in
++   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`);
++   The different lexers here implemented are optimized for different kinds of input
++   and different tradeoffs between speed and memory usage.
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.lexers;
+
+import std.experimental.xml.interfaces;
+import std.experimental.xml.faststrings;
+
+import std.range.primitives;
+import std.traits : isArray;
+
+import std.experimental.allocator;
+import std.experimental.allocator.gc_allocator;
+
+import std.typecons : Flag, Yes;
+
+/++
++   A lexer that takes a sliceable input.
++
++   This lexer will always return slices of the original input; thus, it does not
++   allocate memory and calls to `start` don't invalidate the outputs of previous
++   calls to `get`.
++
++   This is the fastest of all lexers, as it only performs very quick searches and
++   slicing operations. It has the downside of requiring the entire input to be loaded
++   in memory at the same time; as such, it is optimal for small file but not suitable
++   for very big ones.
++
++   Parameters:
++       T = a sliceable type used as input for this lexer
++       ErrorHandler = a delegate type, used to report the impossibility to complete
++                      operations like `advanceUntil` or `advanceUntilAny`
++       Alloc = a dummy allocator parameter, never used; kept for uniformity with
++               the other lexers
++       reuseBuffer = a dummy flag, never used; kept for uniformity with the other
++                     lexers
++/
+struct SliceLexer(T, ErrorHandler, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer)
+{
+    package T input;
+    package size_t pos;
+    package size_t begin;
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    alias CharacterType = ElementEncodingType!T;
+    /// ditto
+    alias InputType = T;
+
+    mixin UsesAllocator!Alloc;
+    mixin UsesErrorHandler!ErrorHandler;
+
+    /// ditto
+    void setSource(T input)
+    {
+        this.input = input;
+        pos = 0;
+    }
+
+    static if(isForwardRange!T)
+    {
+        auto save()
+        {
+            SliceLexer result = this;
+            result.input = input.save;
+            return result;
+        }
+    }
+
+    /// ditto
+    auto empty() const
+    {
+        return pos >= input.length;
+    }
+
+    /// ditto
+    void start()
+    {
+        begin = pos;
+    }
+
+    /// ditto
+    CharacterType[] get() const
+    {
+        return input[begin..pos];
+    }
+
+    /// ditto
+    void dropWhile(string s)
+    {
+        while (pos < input.length && fastIndexOf(s, input[pos]) != -1)
+            pos++;
+    }
+
+    /// ditto
+    bool testAndAdvance(char c)
+    {
+        if (empty)
+            handler();
+        if (input[pos] == c)
+        {
+            pos++;
+            return true;
+        }
+        return false;
+    }
+
+    /// ditto
+    void advanceUntil(char c, bool included)
+    {
+        if (empty)
+            handler();
+        auto adv = fastIndexOf(input[pos..$], c);
+        if (adv != -1)
+        {
+            pos += adv;
+            if (empty)
+                handler();
+        }
+        else
+        {
+            pos = input.length;
+        }
+
+        if (included)
+        {
+            if (empty)
+                handler();
+            pos++;
+        }
+    }
+
+    /// ditto
+    size_t advanceUntilAny(string s, bool included)
+    {
+        if (empty)
+            handler();
+
+        ptrdiff_t res;
+        while ((res = fastIndexOf(s, input[pos])) == -1)
+            if (++pos >= input.length)
+                handler();
+        if (included)
+            pos++;
+        return res;
+    }
+}
+
+/++
++   A lexer that takes an InputRange.
++
++   This lexer copies the needed characters from the input range to an internal
++   buffer, returning slices of it. Whether the buffer is reused (and thus all
++   previously returned slices invalidated) depends on the instantiation parameters.
++
++   This is the most flexible lexer, as it imposes very few requirements on its input,
++   which only needs to be an InputRange. It is also the slowest lexer, as it copies
++   characters one by one, so it shall not be used unless it's the only option.
++
++   Params:
++       T           = the InputRange to be used as input for this lexer
++       ErrorHandler = a delegate type, used to report the impossibility to complete
++                      operations like `advanceUntil` or `advanceUntilAny`
++       Alloc       = the allocator used to manage internal buffers
++       reuseBuffer = if set to `Yes` (the default) this parser will always reuse
++                     the same buffers, invalidating all previously returned slices
++/
+struct RangeLexer(T, ErrorHandler, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer)
+    if (isInputRange!T)
+{
+    import std.experimental.xml.appender;
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    alias CharacterType = ElementEncodingType!T;
+    /// ditto
+    alias InputType = T;
+
+    mixin UsesAllocator!Alloc;
+    mixin UsesErrorHandler!ErrorHandler;
+
+    private Appender!(CharacterType, Alloc) app;
+
+    import std.string: representation;
+    static if (is(typeof(representation!CharacterType(""))))
+    {
+        private typeof(representation!CharacterType("")) input;
+        void setSource(T input)
+        {
+            this.input = input.representation;
+            app = typeof(app)(allocator);
+        }
+    }
+    else
+    {
+        private T input;
+        void setSource(T input)
+        {
+            this.input = input;
+            app = typeof(app)(allocator);
+        }
+    }
+
+    static if (isForwardRange!T)
+    {
+        auto save()
+        {
+            RangeLexer result;
+            result.input = input.save;
+            result.app = typeof(app)(allocator);
+            return result;
+        }
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    bool empty() const
+    {
+        return input.empty;
+    }
+
+    /// ditto
+    void start()
+    {
+        static if (reuseBuffer)
+            app.clear;
+        else
+            app = typeof(app)(allocator);
+    }
+
+    /// ditto
+    CharacterType[] get() const
+    {
+        return app.data;
+    }
+
+    /// ditto
+    void dropWhile(string s)
+    {
+        while (!input.empty && fastIndexOf(s, input.front) != -1)
+            input.popFront();
+    }
+
+    /// ditto
+    bool testAndAdvance(char c)
+    {
+        if (input.empty)
+            handler();
+        if (input.front == c)
+        {
+            app.put(input.front);
+            input.popFront();
+            return true;
+        }
+        return false;
+    }
+
+    /// ditto
+    void advanceUntil(char c, bool included)
+    {
+        if (input.empty)
+            handler();
+        while (input.front != c)
+        {
+            app.put(input.front);
+            input.popFront();
+            if (input.empty)
+                handler();
+        }
+        if (included)
+        {
+            app.put(input.front);
+            input.popFront();
+        }
+    }
+
+    /// ditto
+    size_t advanceUntilAny(string s, bool included)
+    {
+        if (input.empty)
+            handler();
+        size_t res;
+        while ((res = fastIndexOf(s, input.front)) == -1)
+        {
+            app.put(input.front);
+            input.popFront;
+            if (input.empty)
+                handler();
+        }
+        if (included)
+        {
+            app.put(input.front);
+            input.popFront;
+        }
+        return res;
+    }
+}
+
+/++
++   A lexer that takes a ForwardRange.
++
++   This lexer copies the needed characters from the forward range to an internal
++   buffer, returning slices of it. Whether the buffer is reused (and thus all
++   previously returned slices invalidated) depends on the instantiation parameters.
++
++   This is slightly faster than `RangeLexer`, but shoudn't be used if a faster
++   lexer is available.
++
++   Params:
++       T           = the InputRange to be used as input for this lexer
++       ErrorHandler = a delegate type, used to report the impossibility to complete
++                      operations like `advanceUntil` or `advanceUntilAny`
++       Alloc       = the allocator used to manage internal buffers
++       reuseBuffer = if set to `Yes` (the default) this parser will always reuse
++                     the same buffers, invalidating all previously returned slices
++/
+struct ForwardLexer(T, ErrorHandler, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer)
+    if (isForwardRange!T)
+{
+    import std.experimental.xml.appender;
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    alias CharacterType = ElementEncodingType!T;
+    /// ditto
+    alias InputType = T;
+
+    mixin UsesAllocator!Alloc;
+    mixin UsesErrorHandler!ErrorHandler;
+
+    private size_t count;
+    private Appender!(CharacterType, Alloc) app;
+
+    import std.string: representation;
+    static if (is(typeof(representation!CharacterType(""))))
+    {
+        private typeof(representation!CharacterType("")) input;
+        private typeof(input) input_start;
+        void setSource(T input)
+        {
+            app = typeof(app)(allocator);
+            this.input = input.representation;
+            this.input_start = this.input;
+        }
+    }
+    else
+    {
+        private T input;
+        private T input_start;
+        void setSource(T input)
+        {
+            app = typeof(app)(allocator);
+            this.input = input;
+            this.input_start = input;
+        }
+    }
+
+    auto save()
+    {
+        ForwardLexer result;
+        result.input = input.save();
+        result.input_start = input.save();
+        result.app = typeof(app)(allocator);
+        result.count = count;
+        return result;
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    bool empty() const
+    {
+        return input.empty;
+    }
+
+    /// ditto
+    void start()
+    {
+        static if (reuseBuffer)
+            app.clear;
+        else
+            app = typeof(app)(allocator);
+
+        input_start = input.save;
+        count = 0;
+    }
+
+    /// ditto
+    CharacterType[] get()
+    {
+        import std.range: take;
+        auto diff = count - app.data.length;
+        if (diff)
+        {
+            app.reserve(diff);
+            app.put(input_start.take(diff));
+        }
+        return app.data;
+    }
+
+    /// ditto
+    void dropWhile(string s)
+    {
+        while (!input.empty && fastIndexOf(s, input.front) != -1)
+            input.popFront();
+        input_start = input.save;
+    }
+
+    /// ditto
+    bool testAndAdvance(char c)
+    {
+        if (input.empty)
+            handler();
+        if (input.front == c)
+        {
+            count++;
+            input.popFront();
+            return true;
+        }
+        return false;
+    }
+
+    /// ditto
+    void advanceUntil(char c, bool included)
+    {
+        if (input.empty)
+            handler();
+        while (input.front != c)
+        {
+            count++;
+            input.popFront();
+            if (input.empty)
+                handler();
+        }
+        if (included)
+        {
+            count++;
+            input.popFront();
+        }
+    }
+
+    /// ditto
+    size_t advanceUntilAny(string s, bool included)
+    {
+        if (input.empty)
+            handler();
+        size_t res;
+        while ((res = fastIndexOf(s, input.front)) == -1)
+        {
+            count++;
+            input.popFront;
+            if (input.empty)
+                handler();
+        }
+        if (included)
+        {
+            count++;
+            input.popFront;
+        }
+        return res;
+    }
+}
+
+/++
++   A lexer that takes an InputRange of slices from the input.
++
++   This lexer tries to merge the speed of direct slicing with the low memory requirements
++   of ranges. Its input is a range whose elements are chunks of the input data; this
++   lexer returns slices of the original chunks, unless the output is split between two
++   chunks. If that's the case, a new array is allocated and returned. The various chunks
++   may have different sizes.
++
++   The bigger the chunks are, the better is the performance and higher the memory usage,
++   so finding the correct tradeoff is crucial for maximum performance. This lexer is
++   suitable for very large files, which are read chunk by chunk from the file system.
++
++   Params:
++       T           = the InputRange to be used as input for this lexer
++       ErrorHandler = a delegate type, used to report the impossibility to complete
++                      operations like `advanceUntil` or `advanceUntilAny`
++       Alloc       = the allocator used to manage internal buffers
++       reuseBuffer = if set to `Yes` (the default) this parser will always reuse
++                     the same buffers, invalidating all previously returned slices
++/
+struct BufferedLexer(T, ErrorHandler, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer)
+    if (isInputRange!T && isArray!(ElementType!T))
+{
+    import std.experimental.xml.appender;
+
+    alias BufferType = ElementType!T;
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    alias CharacterType = ElementEncodingType!BufferType;
+    /// ditto
+    alias InputType = T;
+
+    private InputType buffers;
+    private size_t pos;
+    private size_t begin;
+
+    private Appender!(CharacterType, Alloc) app;
+    private bool onEdge;
+
+    mixin UsesAllocator!Alloc;
+    mixin UsesErrorHandler!ErrorHandler;
+
+    import std.string: representation, assumeUTF;
+    static if (is(typeof(representation!CharacterType(""))))
+    {
+        private typeof(representation!CharacterType("")) buffer;
+        void popBuffer()
+        {
+            buffer = buffers.front.representation;
+            buffers.popFront;
+        }
+    }
+    else
+    {
+        private BufferType buffer;
+        void popBuffer()
+        {
+            buffer = buffers.front;
+            buffers.popFront;
+        }
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    void setSource(T input)
+    {
+        app = typeof(app)(allocator);
+        this.buffers = input;
+        popBuffer;
+    }
+
+    static if (isForwardRange!T)
+    {
+        auto save() const
+        {
+            BufferedLexer result;
+            result.buffers = buffers.save();
+            result.buffer = buffer;
+            result.pos = pos;
+            result.begin = begin;
+            result.app = typeof(app)(allocator);
+            return result;
+        }
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    bool empty()
+    {
+        return buffers.empty && pos >= buffer.length;
+    }
+
+    /// ditto
+    void start()
+    {
+        static if (reuseBuffer)
+            app.clear;
+        else
+            app = typeof(app)(allocator);
+
+        begin = pos;
+        onEdge = false;
+    }
+
+    private void advance()
+    {
+        if (empty)
+            handler();
+        if (pos + 1 >= buffer.length)
+        {
+            if (onEdge)
+                app.put(buffer[pos]);
+            else
+            {
+                app.put(buffer[begin..$]);
+                onEdge = true;
+            }
+            popBuffer;
+            begin = 0;
+            pos = 0;
+        }
+        else if (onEdge)
+            app.put(buffer[pos++]);
+        else
+            pos++;
+    }
+    private void advance(ptrdiff_t n)
+    {
+        foreach(i; 0..n)
+            advance();
+    }
+    private void advanceNextBuffer()
+    {
+        if (empty)
+            handler();
+        if (onEdge)
+            app.put(buffer[pos..$]);
+        else
+        {
+            app.put(buffer[begin..$]);
+            onEdge = true;
+        }
+        popBuffer;
+        begin = 0;
+        pos = 0;
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`)
+    +/
+    CharacterType[] get() const
+    {
+        if (onEdge)
+            return app.data;
+        else
+        {
+            static if (is(typeof(representation!CharacterType(""))))
+                return cast(CharacterType[])buffer[begin..pos];
+            else
+                return buffer[begin..pos];
+        }
+    }
+
+    /// ditto
+    void dropWhile(string s)
+    {
+        while (!empty && fastIndexOf(s, buffer[pos]) != -1)
+            advance();
+    }
+
+    /// ditto
+    bool testAndAdvance(char c)
+    {
+        if (empty)
+            handler();
+        if (buffer[pos] == c)
+        {
+            advance();
+            return true;
+        }
+        return false;
+    }
+
+    /// ditto
+    void advanceUntil(char c, bool included)
+    {
+        if (empty)
+            handler();
+        ptrdiff_t adv;
+        while ((adv = fastIndexOf(buffer[pos..$], c)) == -1)
+        {
+            advanceNextBuffer();
+        }
+        advance(adv);
+
+        if (included)
+            advance();
+    }
+
+    /// ditto
+    size_t advanceUntilAny(string s, bool included)
+    {
+        if (empty)
+            handler();
+        ptrdiff_t res;
+        while ((res = fastIndexOf(s, buffer[pos])) == -1)
+        {
+            advance();
+        }
+        if (included)
+            advance();
+        return res;
+    }
+}
+
+/++
++   Instantiates a specialized lexer for the given input type, allocator and error handler.
++
++   The default error handler just asserts 0.
++   If the type of the allocator is specified as template parameter, but no instance of it
++   is passed as runtime parameter, then the static method `instance` of the allocator type is
++   used. If no allocator type is specified, defaults to `shared(GCAllocator)`.
++/
+auto chooseLexer(Input, Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer, Alloc, Handler)
+                (ref Alloc alloc, Handler handler = () { assert(0, "Unexpected input end while lexing"); })
+{
+    static if (is(SliceLexer!(Input, Handler, Alloc, reuseBuffer)))
+    {
+        auto res = SliceLexer!(Input, Handler, Alloc, reuseBuffer)(alloc);
+        res.errorHandler = handler;
+        return res;
+    }
+    else static if (is(BufferedLexer!(Input, Handler, Alloc, reuseBuffer)))
+    {
+        auto res = BufferedLexer!(Input, Handler, Alloc, reuseBuffer)(alloc);
+        res.errorHandler = handler;
+        return res;
+    }
+    else static if (is(RangeLexer!(Input, Handler, Alloc, reuseBuffer)))
+    {
+        auto res = RangeLexer!(Input, Handler, Alloc, reuseBuffer)(alloc);
+        res.errorHandler = handler;
+        return res;
+    }
+    else static assert(0);
+}
+/// ditto
+auto chooseLexer(alias Input, Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer, Alloc, Handler)
+                (ref Alloc alloc, Handler handler = () { assert(0, "Unexpected input end while lexing"); })
+{
+    return chooseLexer!(typeof(Input), reuseBuffer, Alloc, Handler)(alloc, handler);
+}
+/// ditto
+auto chooseLexer(Input, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer, Handler)
+                (Handler handler = () { assert(0, "Unexpected input end while lexing"); })
+    if (is(typeof(Alloc.instance)))
+{
+    return chooseLexer!(Input, reuseBuffer, Alloc, Handler)(Alloc.instance, handler);
+}
+/// ditto
+auto chooseLexer(alias Input, Alloc = shared(GCAllocator), Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer, Handler)
+                (Handler handler = () { assert(0, "Unexpected input end while lexing"); })
+    if (is(typeof(Alloc.instance)))
+{
+    return chooseLexer!(typeof(Input), reuseBuffer, Alloc, Handler)(Alloc.instance, handler);
+}
+
+version(unittest)
+{
+    struct DumbBufferedReader
+    {
+        string content;
+        size_t chunk_size;
+
+        void popFront() @nogc
+        {
+            if (content.length > chunk_size)
+                content = content[chunk_size..$];
+            else
+                content = [];
+        }
+        string front() const @nogc
+        {
+            if (content.length >= chunk_size)
+                return content[0..chunk_size];
+            else
+                return content[0..$];
+        }
+        bool empty() const @nogc
+        {
+            return !content.length;
+        }
+    }
+}
+
+unittest
+{
+    auto handler = () { assert(0, "something went wrong..."); };
+
+    void testLexer(T)(T.InputType delegate(string) conv)
+    {
+        string xml = q{
+        <?xml encoding = "utf-8" ?>
+        <aaa xmlns:myns="something">
+            <myns:bbb myns:att='>'>
+                <!-- lol -->
+                Lots of Text!
+                On multiple lines!
+            </myns:bbb>
+            <![CDATA[ Ciaone! ]]>
+            <ccc/>
+        </aaa>
+        };
+
+        T lexer;
+        lexer.setSource(conv(xml));
+        lexer.errorHandler = handler;
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntilAny(":>", true);
+        assert(lexer.get() == "<?xml encoding = \"utf-8\" ?>");
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntilAny("=:", false);
+        assert(lexer.get() == "<aaa xmlns");
+
+        lexer.start();
+        lexer.advanceUntil('>', true);
+        assert(lexer.get() == ":myns=\"something\">");
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntil('\'', true);
+        assert(lexer.testAndAdvance('>'));
+        lexer.advanceUntil('>', false);
+        assert(lexer.testAndAdvance('>'));
+        assert(lexer.get() == "<myns:bbb myns:att='>'>");
+
+        assert(!lexer.empty);
+    }
+
+    testLexer!(SliceLexer!(string, typeof(handler)))(x => x);
+    testLexer!(RangeLexer!(string, typeof(handler)))(x => x);
+    testLexer!(ForwardLexer!(string, typeof(handler)))(x => x);
+    testLexer!(BufferedLexer!(DumbBufferedReader, typeof(handler)))(x => DumbBufferedReader(x, 10));
+}
+
+@nogc unittest
+{
+    import std.experimental.allocator.mallocator;
+
+    auto handler = () { assert(0, "something went wrong..."); };
+
+    void testLexer(T)(T.InputType delegate(string) @nogc conv)
+    {
+        string xml = q{
+        <?xml encoding = "utf-8" ?>
+        <aaa xmlns:myns="something">
+            <myns:bbb myns:att='>'>
+                <!-- lol -->
+                Lots of Text!
+                On multiple lines!
+            </myns:bbb>
+            <![CDATA[ Ciaone! ]]>
+            <ccc/>
+        </aaa>
+        };
+
+        auto alloc = Mallocator.instance;
+
+        T lexer = T(&alloc);
+        lexer.setSource(conv(xml));
+        lexer.errorHandler = handler;
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntilAny(":>", true);
+        assert(lexer.get() == "<?xml encoding = \"utf-8\" ?>");
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntilAny("=:", false);
+        assert(lexer.get() == "<aaa xmlns");
+
+        lexer.start();
+        lexer.advanceUntil('>', true);
+        assert(lexer.get() == ":myns=\"something\">");
+
+        lexer.dropWhile(" \r\n\t");
+        lexer.start();
+        lexer.advanceUntil('\'', true);
+        assert(lexer.testAndAdvance('>'));
+        lexer.advanceUntil('>', false);
+        assert(lexer.testAndAdvance('>'));
+        assert(lexer.get() == "<myns:bbb myns:att='>'>");
+
+        assert(!lexer.empty);
+    }
+
+    testLexer!(RangeLexer!(string, typeof(handler), shared(Mallocator)))(x => x);
+    testLexer!(ForwardLexer!(string, typeof(handler), shared(Mallocator)))(x => x);
+    testLexer!(BufferedLexer!(DumbBufferedReader, typeof(handler), shared(Mallocator)))(x => DumbBufferedReader(x, 10));
+}

--- a/std/experimental/xml/package.d
+++ b/std/experimental/xml/package.d
@@ -64,8 +64,8 @@
 +   {
 +       void onText(ref NodeType node)
 +       {
-+           if (node.getContent.splitter.find.canFind("D"))
-+               writeln("Match found: ", node.getContent);
++           if (node.content.splitter.find.canFind("D"))
++               writeln("Match found: ", node.content);
 +       }
 +   }
 +
@@ -88,7 +88,7 @@
 +   // the basic cursor only detects missing xml declarations and unparseable attributes
 +   auto callback1 = (CursorError err)
 +   {
-+       if (err == CursorError.MISSING_XML_DECLARATION)
++       if (err == CursorError.missingXMLDeclaration)
 +           assert(0, "Missing XML declaration");
 +       else
 +           assert(0, "Invalid attributes syntax");
@@ -122,7 +122,7 @@
 +       // cycle the current node and all its siblings
 +       do
 +       {
-+           writeln(cursor.getKind);
++           writeln(cursor.kind);
 +           // if the current node has children, inspect them recursively
 +           if (cursor.enter)
 +           {
@@ -264,10 +264,10 @@ public import dom = std.experimental.xml.dom;
     auto cursor =
          chooseLexer!xml
         .parse!(No.preserveWhitespace)
-        .cursor!(Yes.conflateCDATA)
+        .cursor!(Yes.conflateCDATA)((){})
         .checkXMLNames;
 
     cursor.setSource(xml);
 
-    assert(cursor.getKind == XMLKind.DOCUMENT);
+    assert(cursor.kind == XMLKind.document);
 }

--- a/std/experimental/xml/package.d
+++ b/std/experimental/xml/package.d
@@ -262,12 +262,11 @@ public import dom = std.experimental.xml.dom;
     };
 
     auto cursor =
-         chooseLexer!xml
-        .parse!(No.preserveWhitespace)
+         xml
+        .lexer((){})
+        .parser!(No.preserveWhitespace)
         .cursor!(Yes.conflateCDATA)((){})
         .checkXMLNames;
-
-    cursor.setSource(xml);
 
     assert(cursor.kind == XMLKind.document);
 }

--- a/std/experimental/xml/package.d
+++ b/std/experimental/xml/package.d
@@ -1,0 +1,273 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   An xml processing library.
++
++   $(H Quick start)
++   The library offers a simple fluid interface to build an XML parsing chain.
++   Let's see a first example: we want to change the name of an author in our book
++   catalogue, using DOM.
++   ---
++   string input = q"{
++   <?xml version = "1.0"?>
++   <books>
++       <book ISBN = "078-5342635362">
++           <title>The D Programming Language</title>
++           <author>A. Alexandrescu</author>
++       </book>
++       <book ISBN = "978-1515074601">
++           <title>Programming in D</title>
++           <author>Ali Çehreli</author>
++       </book>
++       <book ISBN = "978-0201704310">
++           <title>Modern C++ Design</title>
++           <author>A. Alexandrescu</author>
++       </book>
++   </books>
++   }";
++
++   // the following steps are all configurable
++   auto domBuilder =
++        chooseLexer!input  // instantiate the best lexer based on the type of input
++       .parser             // instantiate a parser on top of the lexer
++       .cursor             // instantiate a cursor on top of the parser
++       .domBuilder;        // and finally the DOM builder on top of the cursor
++
++   // the source is forwarded down the parsing chain and everything is initialized
++   domBuilder.setSource(input);
++
++   // recursively build the entire DOM tree
++   domBuilder.buildRecursive;
++   auto dom = domBuilder.getDocument;
++
++   // find and substitute all matching authors
++   foreach (author; dom.getElementsByTagName("author"))
++       if (author.textContent == "A. Alexandrescu")
++           author.textContent = "Andrei Alexandrescu";
++
++   // write it out to "catalogue.xml"
++   auto file = File("catalogue.xml", "w");
++   file.lockingTextWriter
++       .writerFor!string   // instatiates an xml writer on top of an output range
++       .writeDOM(dom);     // write the document with all of its children
++   ---
++   Also available is a SAX parser, which we will use to find all text nodes containing
++   a specific word:
++   ---
++   // don't bother about the type of a node: the library will do the right instantiations
++   static struct MyHandler(NodeType)
++   {
++       void onText(ref NodeType node)
++       {
++           if (node.getContent.splitter.find.canFind("D"))
++               writeln("Match found: ", node.getContent);
++       }
++   }
++
++   auto saxParser =
++        chooseParser!input     // this is a shorthand for chooseLexer!Input.parse
++       .cursor
++       .saxParser!MyHandler;   // only this call changed from the previous example chain
++
++   saxParser.setSource(input);
++   saxParser.processDocument;  // this call triggers the actual work
++
++   // With the same input of the first example, the output would be:
++   // Match found: The D Programming Language
++   // Match found: Programming in D
++   ---
++   You may want to perform extra checks on the input, to guarantee correctness;
++   this is achieved by plugging custom components in the chain.
++   Let's use this feature to validate our input and write it to a file
++   ---
++   // the basic cursor only detects missing xml declarations and unparseable attributes
++   auto callback1 = (CursorError err)
++   {
++       if (err == CursorError.MISSING_XML_DECLARATION)
++           assert(0, "Missing XML declaration");
++       else
++           assert(0, "Invalid attributes syntax");
++   }
++
++   // used by checkXMLNames, a pluggable validator
++   auto callback2 = (string s) { assert(0, "Invalid XML element name"); }
++   auto callback3 = (string s) { assert(0, "Invalid XML attribute name"); }
++
++   auto cursor =
++       .chooseParser!input((){ assert(0, "Parser error") })    // most components take an
++       .cursor(callback1)                                      // optional error handler
++        // time to plug-in a validator
++       .elementNestingValidator!(
++           (){ assert(0, "Wrong nesting of xml tags"); }       // called if tags are not well nested
++       );
++
++   auto writer =
++        myOutputRange                                          // a writer builds on top of an output range
++       .writerFor!(cursor.StringType)
++       .withValidation!checkXMLNames(callback2, callback3)     // we can also apply validations while writing back
++       .writeCursor(cursor)                                    // write the entire contents of the cursor
++   ---
++   While DOM and SAX are simple, standardized APIs, you may want to directly use
++   the underlying Cursor API, which provides great control, flexibility and speed,
++   at the price of a slightly lower abstraction level:
++   ---
++   // A function to inspect the entire document recursively, writing the kind of nodes encountered
++   void writeRecursive(T)(ref T cursor)
++   {
++       // cycle the current node and all its siblings
++       do
++       {
++           writeln(cursor.getKind);
++           // if the current node has children, inspect them recursively
++           if (cursor.enter)
++           {
++               writeRecursive(cursor);
++               cursor.exit;
++           }
++       }
++       while (cursor.next);
++   }
++
++   auto cursor =
++        chooseParser!input
++       .cursor;                // this time we stop here and use the cursor directly
++
++   cursor.setSource(input);
++   writeRecursive(cursor);     // call our function
++   ---
++
++   $(H Library overview)
++
++   $(HH The parsing chain)
++
++   The xml input may come into different forms: a big string, a range of smaller
++   strings, a range of characters, and so on. The first layer of the chain, the
++   lexer, has the purpose of hiding the input details from the higher levels.
++
++   Then comes the parser, which does the hard job of tokenizing the input, without
++   caring about the details, so that it is suitable for parsing many XML-like languages,
++   like HTML.
++
++   The third component is the cursor, the heart of this library. A cursor can be seen
++   as a pointer into the stream of xml nodes. It points to a single node, and provides
++   methods to access the details of that node. The cursor is forward-only: it cannot
++   get back to a previous node. But it can advance in smart ways: for example, it
++   knows how to skip all children of a node, if the user doesn't care about them.
++   The cursor API is the "intermediate language" of the library: many transformations
++   and validations happen at this stage, whose output is then used by all higher level
++   APIs (e.g. DOM and SAX).
++
++   Each component in this chain can be substituted with a custom one, providing high
++   flexibility. The entire library is built as a collection of small components with
++   standardized APIs that can easily be composed together as needed.
++
++   To allow fast and memory-light parsing, the parsing chain does not provide any
++   guarantee about the lifetime of its output: in general, every string returned
++   by any component must be considered invalidated by the advancement to another
++   component, unless stated otherwise. This allows lexers to reuse their buffers
++   for each input token, and every component that needs to store some data for later
++   use must copy it.
++
++   $(HH The cursor wrappers)
++
++   Transformations and validations of the xml nodes happen at the cursor level,
++   via a number of optional, pluggable and configurable components. These are constructed
++   on top of a cursor, and expose the cursor API themselves, thus being completely
++   transparent to higher levels that simply expect a cursor.
++
++   These components work by forwarding every API call to the underlying cursor,
++   applying custom operations, before and after, when needed. This is another area
++   in which the user is free to provide his own implementations with custom functionality,
++   but the library already provides a set of useful operations, ranging from
++   copying/interning strings for later use to checking the well-formedness of some
++   parts of the document.
++
++   $(HH The DOM)
++
++   The DOM, as described in the official specification, is purely object-oriented,
++   based on interfaces and runtime polymorphism. This library doesn't want to
++   change this approach, and provides a the set of interfaces specified by the
++   DOM Level 3 specification, so that the other libraries can provide custom implementations
++   that can still interact with this library (e.g. use the DOMBuilder provided here).
++
++   But D also provides powerful template programming facilities, and this libraries
++   uses them extensively; the DOMBuilder is templated on the DOM Implementation:
++   choosing to instantiate it with the generic interface will give a builder that can
++   construct any possible implementation, while instantiating it with a concrete
++   class will give a specialized builder that can work in `@safe`, `@nogc`, `pure`,
++   `nothrow` contexts (depending on the characterstics of the concrete implementation).
++   The default DOM implementation provided by this library is thought for @nogc usage,
++   with the ability to specify a custom allocator.
++
++   $(HH The writer API)
++
++   The writer API allows to output xml data to any OutputRange. Despite being simpler
++   than the input API, it is still very flexible and customizable. The user can
++   apply custom validations (built with the cursor API, so the same components
++   used for validating on input can be reused) and define custom pretty-printers
++   to write nicer or shorter xml.
++
++   The library also provides some custom higher level wrappers to directly write
++   the contents of cursors or entire DOM trees.
++
++   Macros:
++       H = <h2>$1</h2>
++       HH = <h3>$1</h3>
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml;
+
+public import std.experimental.xml.interfaces;
+public import std.experimental.xml.lexers;
+public import std.experimental.xml.parser;
+public import std.experimental.xml.cursor;
+public import std.experimental.xml.validation;
+public import std.experimental.xml.writer;
+public import std.experimental.xml.domparser;
+public import std.experimental.xml.domimpl;
+public import std.experimental.xml.sax;
+public import std.experimental.xml.faststrings;
+
+public import dom = std.experimental.xml.dom;
+
+@nogc unittest
+{
+    import std.typecons : Yes, No;
+
+    string xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    auto cursor =
+         chooseLexer!xml
+        .parse!(No.preserveWhitespace)
+        .cursor!(Yes.conflateCDATA)
+        .checkXMLNames;
+
+    cursor.setSource(xml);
+
+    assert(cursor.getKind == XMLKind.DOCUMENT);
+}

--- a/std/experimental/xml/parser.d
+++ b/std/experimental/xml/parser.d
@@ -146,7 +146,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
             {
                 handler();
             }
-            next.kind = XMLKind.DTD_END;
+            next.kind = XMLKind.dtdEnd;
             next.content = null;
             insideDTD = false;
         }
@@ -155,7 +155,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
         else if (!lexer.testAndAdvance('<'))
         {
             lexer.advanceUntil('<', false);
-            next.kind = XMLKind.TEXT;
+            next.kind = XMLKind.text;
             next.content = fetchContent();
         }
 
@@ -164,7 +164,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
         {
             lexer.advanceUntil('>', true);
             next.content = fetchContent(2, 1);
-            next.kind = XMLKind.ELEMENT_END;
+            next.kind = XMLKind.elementEnd;
         }
         // processing instruction
         else if (lexer.testAndAdvance('?'))
@@ -173,7 +173,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                 lexer.advanceUntil('?', true);
             while (!lexer.testAndAdvance('>'));
             next.content = fetchContent(2, 2);
-            next.kind = XMLKind.PROCESSING_INSTRUCTION;
+            next.kind = XMLKind.processingInstruction;
         }
         // tag start
         else if (!lexer.testAndAdvance('!'))
@@ -189,12 +189,12 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
             {
                 lexer.advanceUntil('>', true); // should be the first character after '/'
                 next.content = fetchContent(1, 2);
-                next.kind = XMLKind.ELEMENT_EMPTY;
+                next.kind = XMLKind.elementEmpty;
             }
             else
             {
                 next.content = fetchContent(1, 1);
-                next.kind = XMLKind.ELEMENT_START;
+                next.kind = XMLKind.elementStart;
             }
         }
 
@@ -209,7 +209,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                     lexer.advanceUntil('>', true);
                 while (!fastEqual(lexer.get()[($-3)..$], "]]>"));
                 next.content = fetchContent(9, 3);
-                next.kind = XMLKind.CDATA;
+                next.kind = XMLKind.cdata;
             }
             // conditional
             else
@@ -225,7 +225,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                 }
                 while (count > 0);
                 next.content = fetchContent(3, 3);
-                next.kind = XMLKind.CONDITIONAL;
+                next.kind = XMLKind.conditional;
             }
         }
         // comment
@@ -236,7 +236,7 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                 lexer.advanceUntil('>', true);
             while (!fastEqual(lexer.get()[($-3)..$], "-->"));
             next.content = fetchContent(4, 3);
-            next.kind = XMLKind.COMMENT;
+            next.kind = XMLKind.comment;
         }
         // declaration or doctype
         else
@@ -254,10 +254,10 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                 next.content = fetchContent(9, 1);
                 if (c == 2)
                 {
-                    next.kind = XMLKind.DTD_START;
+                    next.kind = XMLKind.dtdStart;
                     insideDTD = true;
                 }
-                else next.kind = XMLKind.DTD_EMPTY;
+                else next.kind = XMLKind.dtdEmpty;
             }
             // declaration
             else
@@ -275,27 +275,27 @@ struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No
                 if (len > 8 && fastEqual(lexer.get()[2..9], "ATTLIST"))
                 {
                     next.content = fetchContent(9, 1);
-                    next.kind = XMLKind.ATTLIST_DECL;
+                    next.kind = XMLKind.attlistDecl;
                 }
                 else if (len > 8 && fastEqual(lexer.get()[2..9], "ELEMENT"))
                 {
                     next.content = fetchContent(9, 1);
-                    next.kind = XMLKind.ELEMENT_DECL;
+                    next.kind = XMLKind.elementDecl;
                 }
                 else if (len > 9 && fastEqual(lexer.get()[2..10], "NOTATION"))
                 {
                     next.content = fetchContent(10, 1);
-                    next.kind = XMLKind.NOTATION_DECL;
+                    next.kind = XMLKind.notationDecl;
                 }
                 else if (len > 7 && fastEqual(lexer.get()[2..8], "ENTITY"))
                 {
                     next.content = fetchContent(8, 1);
-                    next.kind = XMLKind.ENTITY_DECL;
+                    next.kind = XMLKind.entityDecl;
                 }
                 else
                 {
                     next.content = fetchContent(2, 1);
-                    next.kind = XMLKind.DECLARATION;
+                    next.kind = XMLKind.declaration;
                 }
             }
         }
@@ -406,41 +406,41 @@ auto chooseParser(alias InputType, Alloc = shared(GCAllocator),
 
     alias XMLKind = typeof(parser.front.kind);
 
-    assert(parser.front.kind == XMLKind.PROCESSING_INSTRUCTION);
+    assert(parser.front.kind == XMLKind.processingInstruction);
     assert(parser.front.content == "xml encoding = \"utf-8\" ");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.ELEMENT_START);
+    assert(parser.front.kind == XMLKind.elementStart);
     assert(parser.front.content == "aaa xmlns:myns=\"something\"");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.ELEMENT_START);
+    assert(parser.front.kind == XMLKind.elementStart);
     assert(parser.front.content == "myns:bbb myns:att='>'");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.COMMENT);
+    assert(parser.front.kind == XMLKind.comment);
     assert(parser.front.content == " lol ");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.TEXT);
+    assert(parser.front.kind == XMLKind.text);
     // use lineSplitter so the unittest does not depend on the newline policy of this file
     static immutable linesArr = ["Lots of Text!", "            On multiple lines!", "        "];
     assert(parser.front.content.lineSplitter.equal(linesArr));
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.ELEMENT_END);
+    assert(parser.front.kind == XMLKind.elementEnd);
     assert(parser.front.content == "myns:bbb");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.CDATA);
+    assert(parser.front.kind == XMLKind.cdata);
     assert(parser.front.content == " Ciaone! ");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.ELEMENT_EMPTY);
+    assert(parser.front.kind == XMLKind.elementEmpty);
     assert(parser.front.content == "ccc");
     parser.popFront();
 
-    assert(parser.front.kind == XMLKind.ELEMENT_END);
+    assert(parser.front.kind == XMLKind.elementEnd);
     assert(parser.front.content == "aaa");
     parser.popFront();
 
@@ -457,7 +457,7 @@ unittest
     <!DOCTYPE mydoc https://myUri.org/bla [
         <!ELEMENT myelem ANY>
         <!ENTITY   myent    "replacement text">
-        <!ATTLIST myelem foo CDATA #REQUIRED >
+        <!ATTLIST myelem foo cdata #REQUIRED >
         <!NOTATION PUBLIC 'h'>
         <!FOODECL asdffdsa >
     ]>
@@ -468,31 +468,31 @@ unittest
 
     alias XMLKind = typeof(parser.front.kind);
 
-    assert(parser.front.kind == XMLKind.DTD_START);
+    assert(parser.front.kind == XMLKind.dtdStart);
     assert(parser.front.content == " mydoc https://myUri.org/bla ");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.ELEMENT_DECL);
+    assert(parser.front.kind == XMLKind.elementDecl);
     assert(parser.front.content == " myelem ANY");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.ENTITY_DECL);
+    assert(parser.front.kind == XMLKind.entityDecl);
     assert(parser.front.content == "   myent    \"replacement text\"");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.ATTLIST_DECL);
-    assert(parser.front.content == " myelem foo CDATA #REQUIRED ");
+    assert(parser.front.kind == XMLKind.attlistDecl);
+    assert(parser.front.content == " myelem foo cdata #REQUIRED ");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.NOTATION_DECL);
+    assert(parser.front.kind == XMLKind.notationDecl);
     assert(parser.front.content == " PUBLIC 'h'");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.DECLARATION);
+    assert(parser.front.kind == XMLKind.declaration);
     assert(parser.front.content == "FOODECL asdffdsa ");
     parser.popFront;
 
-    assert(parser.front.kind == XMLKind.DTD_END);
+    assert(parser.front.kind == XMLKind.dtdEnd);
     assert(!parser.front.content);
     parser.popFront;
 

--- a/std/experimental/xml/parser.d
+++ b/std/experimental/xml/parser.d
@@ -1,0 +1,500 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module implements a low level XML parser.
++
++   The methods a parser should implement are documented in
++   $(LINK2 ../interfaces/isParser, `std.experimental.xml.interfaces.isParser`);
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.parser;
+
+import std.experimental.xml.interfaces;
+import std.experimental.xml.faststrings;
+
+import std.typecons : Flag, Yes, No;
+
+/++
++   A low level XML parser.
++
++   The methods a parser should implement are documented in
++   $(LINK2 ../interfaces/isLexer, `std.experimental.xml.interfaces.isLexer`);
++
++   Params:
++       L = the underlying lexer type
++       ErrorHandler = a delegate type, used to report the impossibility to parse
++                      the file due to syntax errors
++       preserveWhitespace = if set to `Yes` (default is `No`), the parser will not remove
++       element content whitespace (i.e. the whitespace that separates tags), but will
++       report it as text
++/
+struct Parser(L, ErrorHandler, Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace)
+    if (isLexer!L)
+{
+    import std.meta : staticIndexOf;
+
+    /++
+    +   The structure returned in output from the low level parser.
+    +   Represents an XML token, delimited by specific patterns, based on its kind.
+    +   This delimiters are not present in the content field.
+    +/
+    struct XMLToken
+    {
+        /++ The content of the token, delimiters excluded +/
+        L.CharacterType[] content;
+
+        /++ Represents the kind of token +/
+        XMLKind kind;
+    }
+
+    private L lexer;
+    private bool ready, insideDTD;
+    private XMLToken next;
+
+    mixin UsesErrorHandler!ErrorHandler;
+
+    /++ Generic constructor; forwards its arguments to the lexer constructor +/
+    this(Args...)(Args args)
+    {
+        lexer = L(args);
+    }
+
+    alias InputType = L.InputType;
+    alias CharacterType = L.CharacterType;
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isParser, `std.experimental.xml.interfaces.isParser`)
+    +/
+    void setSource(InputType input)
+    {
+        lexer.setSource(input);
+        ready = false;
+        insideDTD = false;
+    }
+
+    static if (isSaveableLexer!L)
+    {
+        auto save()
+        {
+            Parser result = this;
+            result.lexer = lexer.save;
+            return result;
+        }
+    }
+
+    private CharacterType[] fetchContent(size_t start = 0, size_t stop = 0)
+    {
+        return lexer.get[start..($ - stop)];
+    }
+
+    /++
+    +   See detailed documentation in
+    +   $(LINK2 ../interfaces/isParser, `std.experimental.xml.interfaces.isParser`)
+    +/
+    bool empty()
+    {
+        static if (preserveWhitespace == No.preserveWhitespace)
+            lexer.dropWhile(" \r\n\t");
+
+        return !ready && lexer.empty;
+    }
+
+    /// ditto
+    auto front()
+    {
+        if (!ready)
+            fetchNext();
+        return next;
+    }
+
+    /// ditto
+    void popFront()
+    {
+        front();
+        ready = false;
+    }
+
+    private void fetchNext()
+    {
+        if (!preserveWhitespace || insideDTD)
+            lexer.dropWhile(" \r\n\t");
+
+        assert(!lexer.empty);
+
+        lexer.start();
+
+        // dtd end
+        if (insideDTD && lexer.testAndAdvance(']'))
+        {
+            lexer.dropWhile(" \r\n\t");
+            if (!lexer.testAndAdvance('>'))
+            {
+                handler();
+            }
+            next.kind = XMLKind.DTD_END;
+            next.content = null;
+            insideDTD = false;
+        }
+
+        // text element
+        else if (!lexer.testAndAdvance('<'))
+        {
+            lexer.advanceUntil('<', false);
+            next.kind = XMLKind.TEXT;
+            next.content = fetchContent();
+        }
+
+        // tag end
+        else if (lexer.testAndAdvance('/'))
+        {
+            lexer.advanceUntil('>', true);
+            next.content = fetchContent(2, 1);
+            next.kind = XMLKind.ELEMENT_END;
+        }
+        // processing instruction
+        else if (lexer.testAndAdvance('?'))
+        {
+            do
+                lexer.advanceUntil('?', true);
+            while (!lexer.testAndAdvance('>'));
+            next.content = fetchContent(2, 2);
+            next.kind = XMLKind.PROCESSING_INSTRUCTION;
+        }
+        // tag start
+        else if (!lexer.testAndAdvance('!'))
+        {
+            size_t c;
+            while ((c = lexer.advanceUntilAny("\"'/>", true)) < 2)
+                if (c == 0)
+                    lexer.advanceUntil('"', true);
+                else
+                    lexer.advanceUntil('\'', true);
+
+            if (c == 2)
+            {
+                lexer.advanceUntil('>', true); // should be the first character after '/'
+                next.content = fetchContent(1, 2);
+                next.kind = XMLKind.ELEMENT_EMPTY;
+            }
+            else
+            {
+                next.content = fetchContent(1, 1);
+                next.kind = XMLKind.ELEMENT_START;
+            }
+        }
+
+        // cdata or conditional
+        else if (lexer.testAndAdvance('['))
+        {
+            lexer.advanceUntil('[', true);
+            // cdata
+            if (lexer.get.length == 9 && fastEqual(lexer.get()[3..$], "CDATA["))
+            {
+                do
+                    lexer.advanceUntil('>', true);
+                while (!fastEqual(lexer.get()[($-3)..$], "]]>"));
+                next.content = fetchContent(9, 3);
+                next.kind = XMLKind.CDATA;
+            }
+            // conditional
+            else
+            {
+                int count = 1;
+                do
+                {
+                    lexer.advanceUntilAny("[>", true);
+                    if (lexer.get()[($-3)..$] == "]]>")
+                        count--;
+                    else if (lexer.get()[($-3)..$] == "<![")
+                        count++;
+                }
+                while (count > 0);
+                next.content = fetchContent(3, 3);
+                next.kind = XMLKind.CONDITIONAL;
+            }
+        }
+        // comment
+        else if (lexer.testAndAdvance('-'))
+        {
+            lexer.testAndAdvance('-'); // second '-'
+            do
+                lexer.advanceUntil('>', true);
+            while (!fastEqual(lexer.get()[($-3)..$], "-->"));
+            next.content = fetchContent(4, 3);
+            next.kind = XMLKind.COMMENT;
+        }
+        // declaration or doctype
+        else
+        {
+            size_t c;
+            while ((c = lexer.advanceUntilAny("\"'[>", true)) < 2)
+                if (c == 0)
+                    lexer.advanceUntil('"', true);
+                else
+                    lexer.advanceUntil('\'', true);
+
+            // doctype
+            if (lexer.get.length>= 9 && fastEqual(lexer.get()[2..9], "DOCTYPE"))
+            {
+                next.content = fetchContent(9, 1);
+                if (c == 2)
+                {
+                    next.kind = XMLKind.DTD_START;
+                    insideDTD = true;
+                }
+                else next.kind = XMLKind.DTD_EMPTY;
+            }
+            // declaration
+            else
+            {
+                if (c == 2)
+                {
+                    size_t cc;
+                    while ((cc = lexer.advanceUntilAny("\"'>", true)) < 2)
+                        if (cc == 0)
+                            lexer.advanceUntil('"', true);
+                        else
+                            lexer.advanceUntil('\'', true);
+                }
+                auto len = lexer.get().length;
+                if (len > 8 && fastEqual(lexer.get()[2..9], "ATTLIST"))
+                {
+                    next.content = fetchContent(9, 1);
+                    next.kind = XMLKind.ATTLIST_DECL;
+                }
+                else if (len > 8 && fastEqual(lexer.get()[2..9], "ELEMENT"))
+                {
+                    next.content = fetchContent(9, 1);
+                    next.kind = XMLKind.ELEMENT_DECL;
+                }
+                else if (len > 9 && fastEqual(lexer.get()[2..10], "NOTATION"))
+                {
+                    next.content = fetchContent(10, 1);
+                    next.kind = XMLKind.NOTATION_DECL;
+                }
+                else if (len > 7 && fastEqual(lexer.get()[2..8], "ENTITY"))
+                {
+                    next.content = fetchContent(8, 1);
+                    next.kind = XMLKind.ENTITY_DECL;
+                }
+                else
+                {
+                    next.content = fetchContent(2, 1);
+                    next.kind = XMLKind.DECLARATION;
+                }
+            }
+        }
+
+        ready = true;
+    }
+}
+
+/++
++   Returns an instance of `Parser` from the given lexer.
++
++   Params:
++       preserveWhitespace = whether the returned `Parser` shall skip element content
++                            whitespace or return it as text nodes
++       lexer = the _lexer to build this `Parser` from
++
++   Returns:
++   A `Parser` instance initialized with the given lexer
++/
+auto parse(Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace, T, ErrorHandler)
+          (auto ref T lexer, ErrorHandler handler = () { assert(0, "XML syntax error"); })
+    if (isLexer!T)
+{
+    auto parser = Parser!(T, ErrorHandler, preserveWhitespace)();
+    parser.errorHandler = handler;
+    parser.lexer = lexer;
+    return parser;
+}
+
+import std.experimental.xml.lexers;
+import std.experimental.allocator.gc_allocator;
+
+/++
++   Instantiates a parser suitable for the given `InputType`.
++
++   This is completely equivalent to
++   ---
++   auto parser = 
++        chooseLexer!(InputType, reuseBuffer)(alloc, handler)
++       .parse!(preserveWhitespace)(handler)
++   ---
++/
+auto chooseParser(InputType,
+                  Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace,
+                  Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer,
+                  Alloc, ErrorHandler)
+                 (ref Alloc alloc, ErrorHandler handler = () { assert(0, "XML syntax error"); })
+{
+    return chooseLexer!(InputType, reuseBuffer, Alloc, ErrorHandler)(alloc, handler)
+          .parse!(preserveWhitespace)(handler);
+}
+/// ditto
+auto chooseParser(alias InputType,
+                  Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace,
+                  Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer,
+                  Alloc, ErrorHandler)
+                 (ref Alloc alloc, ErrorHandler handler = () { assert(0, "XML syntax error"); })
+{
+    return chooseParser!(typeof(InputType), preserveWhitespace, reuseBuffer, Alloc, ErrorHandler)(alloc, handler);
+}
+/// ditto
+auto chooseParser(InputType, Alloc = shared(GCAllocator),
+                  Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace,
+                  Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer,
+                  ErrorHandler)
+                 (ErrorHandler handler = () { assert(0, "XML syntax error"); })
+    if (is(typeof(Alloc.instance)))
+{
+    return chooseParser!(InputType, preserveWhitespace, reuseBuffer, Alloc, ErrorHandler)(Alloc.instance, handler);
+}
+/// ditto
+auto chooseParser(alias InputType, Alloc = shared(GCAllocator),
+                  Flag!"preserveWhitespace" preserveWhitespace = No.preserveWhitespace,
+                  Flag!"reuseBuffer" reuseBuffer = Yes.reuseBuffer,
+                  ErrorHandler)
+                 (ErrorHandler handler = () { assert(0, "XML syntax error"); })
+    if (is(typeof(Alloc.instance)))
+{
+    return chooseParser!(typeof(InputType), preserveWhitespace, reuseBuffer, Alloc, ErrorHandler)
+                        (Alloc.instance, handler);
+}
+
+@nogc unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.allocator.mallocator;
+    import std.string : lineSplitter;
+    import std.algorithm : equal;
+
+    string xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    auto handler = () { assert(0, "Oopss..."); };
+    auto lexer = RangeLexer!(string, typeof(handler), shared(Mallocator))(Mallocator.instance);
+    lexer.errorHandler = handler;
+    auto parser = lexer.parse;
+    parser.setSource(xml);
+
+    alias XMLKind = typeof(parser.front.kind);
+
+    assert(parser.front.kind == XMLKind.PROCESSING_INSTRUCTION);
+    assert(parser.front.content == "xml encoding = \"utf-8\" ");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.ELEMENT_START);
+    assert(parser.front.content == "aaa xmlns:myns=\"something\"");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.ELEMENT_START);
+    assert(parser.front.content == "myns:bbb myns:att='>'");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.COMMENT);
+    assert(parser.front.content == " lol ");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.TEXT);
+    // use lineSplitter so the unittest does not depend on the newline policy of this file
+    static immutable linesArr = ["Lots of Text!", "            On multiple lines!", "        "];
+    assert(parser.front.content.lineSplitter.equal(linesArr));
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.ELEMENT_END);
+    assert(parser.front.content == "myns:bbb");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.CDATA);
+    assert(parser.front.content == " Ciaone! ");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.ELEMENT_EMPTY);
+    assert(parser.front.content == "ccc");
+    parser.popFront();
+
+    assert(parser.front.kind == XMLKind.ELEMENT_END);
+    assert(parser.front.content == "aaa");
+    parser.popFront();
+
+    assert(parser.empty);
+}
+
+unittest
+{
+    import std.experimental.xml.lexers;
+    import std.algorithm : find;
+    import std.string : stripRight;
+
+    string xml = q{
+    <!DOCTYPE mydoc https://myUri.org/bla [
+        <!ELEMENT myelem ANY>
+        <!ENTITY   myent    "replacement text">
+        <!ATTLIST myelem foo CDATA #REQUIRED >
+        <!NOTATION PUBLIC 'h'>
+        <!FOODECL asdffdsa >
+    ]>
+    };
+
+    auto parser = chooseParser!xml;
+    parser.setSource(xml);
+
+    alias XMLKind = typeof(parser.front.kind);
+
+    assert(parser.front.kind == XMLKind.DTD_START);
+    assert(parser.front.content == " mydoc https://myUri.org/bla ");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.ELEMENT_DECL);
+    assert(parser.front.content == " myelem ANY");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.ENTITY_DECL);
+    assert(parser.front.content == "   myent    \"replacement text\"");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.ATTLIST_DECL);
+    assert(parser.front.content == " myelem foo CDATA #REQUIRED ");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.NOTATION_DECL);
+    assert(parser.front.content == " PUBLIC 'h'");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.DECLARATION);
+    assert(parser.front.content == "FOODECL asdffdsa ");
+    parser.popFront;
+
+    assert(parser.front.kind == XMLKind.DTD_END);
+    assert(!parser.front.content);
+    parser.popFront;
+
+    assert(parser.empty);
+}

--- a/std/experimental/xml/parser.d
+++ b/std/experimental/xml/parser.d
@@ -333,7 +333,7 @@ import std.experimental.allocator.gc_allocator;
 +
 +   This is completely equivalent to
 +   ---
-+   auto parser = 
++   auto parser =
 +        chooseLexer!(InputType, reuseBuffer)(alloc, handler)
 +       .parse!(preserveWhitespace)(handler)
 +   ---

--- a/std/experimental/xml/sax.d
+++ b/std/experimental/xml/sax.d
@@ -68,53 +68,53 @@ struct SAXParser(T, alias H)
         import std.traits : hasMember;
         while (!cursor.documentEnd)
         {
-            switch (cursor.getKind)
+            switch (cursor.kind)
             {
                 static if(hasMember!(HandlerType, "onDocument"))
                 {
-                    case XMLKind.DOCUMENT:
+                    case XMLKind.document:
                         handler.onDocument(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onElementStart"))
                 {
-                    case XMLKind.ELEMENT_START:
+                    case XMLKind.elementStart:
                         handler.onElementStart(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onElementEnd"))
                 {
-                    case XMLKind.ELEMENT_END:
+                    case XMLKind.elementEnd:
                         handler.onElementEnd(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onElementEmpty"))
                 {
-                    case XMLKind.ELEMENT_EMPTY:
+                    case XMLKind.elementEmpty:
                         handler.onElementEmpty(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onText"))
                 {
-                    case XMLKind.TEXT:
+                    case XMLKind.text:
                         handler.onText(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onComment"))
                 {
-                    case XMLKind.COMMENT:
+                    case XMLKind.comment:
                         handler.onComment(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onProcessingInstruction"))
                 {
-                    case XMLKind.PROCESSING_INSTRUCTION:
+                    case XMLKind.processingInstruction:
                         handler.onProcessingInstruction(cursor);
                         break;
                 }
                 static if (hasMember!(HandlerType, "onCDataSection"))
                 {
-                    case XMLKind.CDATA:
+                    case XMLKind.cdata:
                         handler.onCDataSection(cursor);
                         break;
                 }
@@ -192,7 +192,7 @@ unittest
         void onText(ref T node) { total_invocations++; }
         void onDocument(ref T node)
         {
-            auto attrs = node.getAttributes;
+            auto attrs = node.attributes;
             assert(attrs.front == Attribute!dstring("encoding", "utf-8"));
             attrs.popFront;
             assert(attrs.empty);
@@ -200,7 +200,7 @@ unittest
         }
         void onComment(ref T node)
         {
-            assert(node.getContent == " lol ");
+            assert(node.content == " lol ");
             total_invocations++;
         }
     }

--- a/std/experimental/xml/sax.d
+++ b/std/experimental/xml/sax.d
@@ -206,8 +206,9 @@ unittest
     }
 
     auto parser =
-         chooseLexer!xml
-        .parse
+         xml
+        .lexer
+        .parser
         .cursor
         .saxParser!MyHandler;
 

--- a/std/experimental/xml/sax.d
+++ b/std/experimental/xml/sax.d
@@ -1,0 +1,220 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module implements a simple SAX parser.
++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.sax;
+
+import std.experimental.xml.interfaces;
+import std.experimental.xml.cursor;
+
+/++
++   A SAX parser built on top of a cursor.
++
++   It delegates all handling to `H`, which must be either a type or a template
++   that can be instantiated to a type applying the underlying cursor type (`T`) as parameter.
++/
+struct SAXParser(T, alias H)
+    if (isCursor!T)
+{
+    static if (__traits(isTemplate, H))
+        alias HandlerType = H!T;
+    else
+        alias HandlerType = H;
+
+    private T cursor;
+    public HandlerType handler;
+
+    /++
+    +   Initializes this parser (and the underlying low level one) with the given input.
+    +/
+    void setSource(T.InputType input)
+    {
+        cursor.setSource(input);
+    }
+
+    static if (isSaveableCursor!T)
+    {
+        auto save()
+        {
+            auto result = this;
+            result.cursor = cursor.save;
+            return result;
+        }
+    }
+
+    /++
+    +   Processes the entire document; every time a node of
+    +   `XMLKind` XXX is found, the corresponding method `onXXX(underlyingCursor)`
+    +   of the handler is called, if it exists.
+    +/
+    void processDocument()
+    {
+        import std.traits : hasMember;
+        while (!cursor.documentEnd)
+        {
+            switch (cursor.getKind)
+            {
+                static if(hasMember!(HandlerType, "onDocument"))
+                {
+                    case XMLKind.DOCUMENT:
+                        handler.onDocument(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onElementStart"))
+                {
+                    case XMLKind.ELEMENT_START:
+                        handler.onElementStart(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onElementEnd"))
+                {
+                    case XMLKind.ELEMENT_END:
+                        handler.onElementEnd(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onElementEmpty"))
+                {
+                    case XMLKind.ELEMENT_EMPTY:
+                        handler.onElementEmpty(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onText"))
+                {
+                    case XMLKind.TEXT:
+                        handler.onText(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onComment"))
+                {
+                    case XMLKind.COMMENT:
+                        handler.onComment(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onProcessingInstruction"))
+                {
+                    case XMLKind.PROCESSING_INSTRUCTION:
+                        handler.onProcessingInstruction(cursor);
+                        break;
+                }
+                static if (hasMember!(HandlerType, "onCDataSection"))
+                {
+                    case XMLKind.CDATA:
+                        handler.onCDataSection(cursor);
+                        break;
+                }
+                default: break;
+            }
+
+            if (cursor.enter)
+            {
+            }
+            else if (!cursor.next)
+                cursor.exit;
+        }
+    }
+}
+
+/++
++   Instantiates a suitable SAX parser from the given `cursor` and `handler`.
++/
+auto saxParser(alias HandlerType, CursorType)(auto ref CursorType cursor)
+    if (isCursor!CursorType)
+{
+    auto res = SAXParser!(CursorType, HandlerType)();
+    res.cursor = cursor;
+    return res;
+}
+/// ditto
+auto saxParser(alias HandlerType, CursorType)(auto ref CursorType cursor,
+                                        auto ref SAXParser!(CursorType, HandlerType).HandlerType handler)
+    if (isCursor!CursorType)
+{
+    auto res = SAXParser!(CursorType, HandlerType)();
+    res.cursor = cursor;
+    res.handler = handler;
+    return res;
+}
+
+unittest
+{
+    import std.experimental.xml.parser;
+    import std.experimental.xml.lexers;
+
+    dstring xml = q{
+    <?xml encoding = "utf-8" ?>
+    <aaa xmlns:myns="something">
+        <myns:bbb myns:att='>'>
+            <!-- lol -->
+            Lots of Text!
+            On multiple lines!
+        </myns:bbb>
+        <![CDATA[ Ciaone! ]]>
+        <ccc/>
+    </aaa>
+    };
+
+    static struct MyHandler(T)
+    {
+        int max_nesting;
+        int current_nesting;
+        int total_invocations;
+
+        void onElementStart(ref T node)
+        {
+            total_invocations++;
+            current_nesting++;
+            if (current_nesting > max_nesting)
+                max_nesting = current_nesting;
+        }
+        void onElementEnd(ref T node)
+        {
+            total_invocations++;
+            current_nesting--;
+        }
+        void onElementEmpty(ref T node) { total_invocations++; }
+        void onProcessingInstruction(ref T node) { total_invocations++; }
+        void onText(ref T node) { total_invocations++; }
+        void onDocument(ref T node)
+        {
+            auto attrs = node.getAttributes;
+            assert(attrs.front == Attribute!dstring("encoding", "utf-8"));
+            attrs.popFront;
+            assert(attrs.empty);
+            total_invocations++;
+        }
+        void onComment(ref T node)
+        {
+            assert(node.getContent == " lol ");
+            total_invocations++;
+        }
+    }
+
+    auto parser =
+         chooseLexer!xml
+        .parse
+        .cursor
+        .saxParser!MyHandler;
+
+    parser.setSource(xml);
+    parser.processDocument();
+
+    assert(parser.handler.max_nesting == 2);
+    assert(parser.handler.current_nesting == 0);
+    assert(parser.handler.total_invocations == 9);
+}

--- a/std/experimental/xml/validation.d
+++ b/std/experimental/xml/validation.d
@@ -75,9 +75,9 @@ struct ElementNestingValidator(CursorType, alias ErrorHandler)
 
     bool enter()
     {
-        if (cursor.getKind == XMLKind.ELEMENT_START)
+        if (cursor.kind == XMLKind.elementStart)
         {
-            stack.insertBack(cursor.getName);
+            stack.insertBack(cursor.name);
             if (!cursor.enter)
             {
                 stack.removeBack;
@@ -90,7 +90,7 @@ struct ElementNestingValidator(CursorType, alias ErrorHandler)
     void exit()
     {
         cursor.exit();
-        if (cursor.getKind == XMLKind.ELEMENT_END)
+        if (cursor.kind == XMLKind.elementEnd)
         {
             if (stack.empty)
             {
@@ -101,7 +101,7 @@ struct ElementNestingValidator(CursorType, alias ErrorHandler)
             {
                 import std.experimental.xml.faststrings;
 
-                if (!fastEqual(stack.back, cursor.getName))
+                if (!fastEqual(stack.back, cursor.name))
                 {
                     callHandler();
                 }
@@ -153,12 +153,12 @@ unittest
             {
                 import std.algorithm: canFind;
                 count++;
-                if (canFind(stack[], cursor.getName()))
+                if (canFind(stack[], cursor.name()))
                     do
                     {
                         stack.removeBack();
                     }
-                    while (stack.back != cursor.getName());
+                    while (stack.back != cursor.name());
                 stack.removeBack();
             });
 
@@ -271,23 +271,23 @@ struct CheckXMLNames(CursorType, InvalidTagHandler, InvalidAttrHandler)
     CursorType cursor;
     alias cursor this;
 
-    auto getName()
+    auto name()
     {
         import std.algorithm : all;
 
-        auto name = cursor.getName;
-        if (cursor.getKind != XMLKind.ELEMENT_END)
+        auto name = cursor.name;
+        if (cursor.kind != XMLKind.elementEnd)
             if (!name[0].isValidXMLNameStart || !name.all!isValidXMLNameChar)
                 onInvalidTagName(name);
         return name;
     }
 
-    auto getAttributes()
+    auto attributes()
     {
         struct CheckedAttributes
         {
             typeof(onInvalidAttrName) callback;
-            typeof(cursor.getAttributes()) attrs;
+            typeof(cursor.attributes()) attrs;
             alias attrs this;
 
             auto front()
@@ -299,7 +299,7 @@ struct CheckXMLNames(CursorType, InvalidTagHandler, InvalidAttrHandler)
                 return attr;
             }
         }
-        return CheckedAttributes(onInvalidAttrName, cursor.getAttributes);
+        return CheckedAttributes(onInvalidAttrName, cursor.attributes);
     }
 }
 
@@ -350,8 +350,8 @@ unittest
         import std.array;
         do
         {
-            auto name = cursor.getName;
-            auto attrs = cursor.getAttributes.array;
+            auto name = cursor.name;
+            auto attrs = cursor.attributes.array;
             if (cursor.enter)
             {
                 inspectOneLevel(cursor);

--- a/std/experimental/xml/validation.d
+++ b/std/experimental/xml/validation.d
@@ -1,0 +1,366 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+// TODO: write an in-depth explanation of this module, how to create validations,
+// how validations should behave, etc...
+
+/++
++   Authors:
++   Lodovico Giaretta
++
++   License:
++   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
++
++   Copyright:
++   Copyright Lodovico Giaretta 2016 --
++/
+
+module std.experimental.xml.validation;
+
+import std.experimental.xml.interfaces;
+
+/**
+*   Wrapper around a cursor that checks whether elements are correctly nested.
+*
+*   It will call `ErrorHandler` whenever it finds a closing tag that does not match
+*   the last start tag. `ErrorHandler` will be called with the first matching tuple
+*   from the following:
+*   $(UL
+*       $(LI `(CursorType, std.container.Array!(CursorType.StringType))`)
+*       $(LI `(CursorType)`)
+*       $(LI `(std.container.Array!(CursorType.StringType))`)
+*       $(LI `()`)
+*   )
+*   Any of these parameters can be taken by `ref`. The second parameter, of type
+*   `std.container.Array!(CursorType.StringType)` represents the stack of currently
+*   open tags. The handler is free to modify it (to implement erro recovery with
+*   automatic XML fixing).
+*
+*   This type should not be instantiated directly, but with the helper function
+*   `elementNestingValidator`.
+*/
+struct ElementNestingValidator(CursorType, alias ErrorHandler)
+    if (isCursor!CursorType)
+{
+    import std.experimental.xml.interfaces;
+
+    alias StringType = CursorType.StringType;
+
+    import std.container.array;
+    private Array!StringType stack;
+
+    private CursorType cursor;
+    alias cursor this;
+
+    this(Args...)(Args args)
+    {
+        cursor = CursorType(args);
+    }
+
+    private void callHandler()
+    {
+        static if (__traits(compiles, ErrorHandler(cursor, stack)))
+            ErrorHandler(cursor, stack);
+        else static if (__traits(compiles, ErrorHandler(cursor)))
+            ErrorHandler(cursor);
+        else static if (__traits(compiles, ErrorHandler(stack)))
+            ErrorHandler(stack);
+        else
+            ErrorHandler();
+    }
+
+    bool enter()
+    {
+        if (cursor.getKind == XMLKind.ELEMENT_START)
+        {
+            stack.insertBack(cursor.getName);
+            if (!cursor.enter)
+            {
+                stack.removeBack;
+                return false;
+            }
+            return true;
+        }
+        return cursor.enter;
+    }
+    void exit()
+    {
+        cursor.exit();
+        if (cursor.getKind == XMLKind.ELEMENT_END)
+        {
+            if (stack.empty)
+            {
+                if (!cursor.documentEnd)
+                    callHandler();
+            }
+            else
+            {
+                import std.experimental.xml.faststrings;
+
+                if (!fastEqual(stack.back, cursor.getName))
+                {
+                    callHandler();
+                }
+                else
+                    stack.removeBack();
+            }
+        }
+    }
+}
+/**
+*   Instantiates an `ElementNestingValidator` with the given `cursor` and `ErrorHandler`
+*/
+auto elementNestingValidator(alias ErrorHandler = (){ assert(0); }, CursorType) (auto ref CursorType cursor)
+{
+    auto res = ElementNestingValidator!(CursorType, ErrorHandler)();
+    res.cursor = cursor;
+    return res;
+}
+
+unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.experimental.xml.cursor;
+
+    auto xml = q{
+        <?xml?>
+        <aaa>
+            <eee>
+                <bbb>
+                    <ccc>
+                </bbb>
+                <ddd>
+                </ddd>
+            </eee>
+            <fff>
+            </fff>
+        </aaa>
+    };
+
+    int count = 0;
+
+    auto validator =
+         chooseLexer!xml
+        .parse
+        .cursor
+        .elementNestingValidator!(
+            (ref cursor, ref stack)
+            {
+                import std.algorithm: canFind;
+                count++;
+                if (canFind(stack[], cursor.getName()))
+                    do
+                    {
+                        stack.removeBack();
+                    }
+                    while (stack.back != cursor.getName());
+                stack.removeBack();
+            });
+
+    validator.setSource(xml);
+
+    void inspectOneLevel(T)(ref T cursor)
+    {
+        do
+        {
+            if (cursor.enter)
+            {
+                inspectOneLevel(cursor);
+                cursor.exit();
+            }
+        }
+        while (cursor.next());
+    }
+    inspectOneLevel(validator);
+
+    assert(count == 1);
+}
+
+/**
+*   Checks whether a character can appear in an XML 1.0 document.
+*/
+pure nothrow @nogc @safe bool isValidXMLCharacter10(dchar c)
+{
+    return c == '\r' || c == '\n' || c == '\t'
+        || (0x20 <= c && c <= 0xD7FF)
+        || (0xE000 <= c && c <= 0xFFFD)
+        || (0x10000 <= c && c <= 0x10FFFF);
+}
+
+/**
+*   Checks whether a character can appear in an XML 1.1 document.
+*/
+pure nothrow @nogc @safe bool isValidXMLCharacter11(dchar c)
+{
+    return (1 <= c && c <= 0xD7FF)
+        || (0xE000 <= c && c <= 0xFFFD)
+        || (0x10000 <= c && c <= 0x10FFFF);
+}
+
+/**
+*   Checks whether a character can start an XML name (tag name or attribute name).
+*/
+pure nothrow @nogc @safe bool isValidXMLNameStart(dchar c)
+{
+    return c == ':'
+        || ('A' <= c && c <= 'Z')
+        || c == '_'
+        || ('a' <= c && c <= 'z')
+        || (0xC0 <= c && c <= 0x2FF && c != 0xD7 && c != 0xF7)
+        || (0x370 <= c && c <= 0x1FFF && c != 0x37E)
+        || c == 0x200C
+        || c == 0x200D
+        || (0x2070 <= c && c <= 0x218F)
+        || (0x2C00 <= c && c <= 0x2FEF)
+        || (0x3001 <= c && c <= 0xD7FF)
+        || (0xF900 <= c && c <= 0xFDCF)
+        || (0xFDF0 <= c && c <= 0xEFFFF && c != 0xFFFE && c != 0xFFFF);
+}
+
+/**
+*   Checks whether a character can appear inside an XML name (tag name or attribute name).
+*/
+pure nothrow @nogc @safe bool isValidXMLNameChar(dchar c)
+{
+    return isValidXMLNameStart(c)
+        || c == '-'
+        || c == '.'
+        || ('0' <= c && c <= '9')
+        || c == 0xB7
+        || (0x300 <= c && c <= 0x36F)
+        || (0x203F <= c && c <= 2040);
+}
+
+/**
+*   Checks whether a character can appear in an XML public ID.
+*/
+pure nothrow @nogc @safe bool isValidXMLPublicIdCharacter(dchar c)
+{
+    import std.string: indexOf;
+    return c == ' '
+        || c == '\n'
+        || c == '\r'
+        || ('a' <= c && c <= 'z')
+        || ('A' <= c && c <= 'Z')
+        || ('0' <= c && c <= '9')
+        || "-'()+,./:=?;!*#@$_%".indexOf(c) != -1;
+}
+
+/**
+*   Wrapper around a cursor that checks whether tag names and attribute names
+*   are well-formed with respect to the specification.
+*
+*   Will call `InvalidTagHandler` every time it encounters an ill-formed tag name
+*   and `InvalidAttrHandler` every time it encounters an ill-formed attribute name.
+*
+*   This type should not be instantiated directly, but with the helper function
+*   `checkXMLNames`.
+*/
+struct CheckXMLNames(CursorType, InvalidTagHandler, InvalidAttrHandler)
+    if (isCursor!CursorType)
+{
+    alias StringType = CursorType.StringType;
+    InvalidTagHandler onInvalidTagName;
+    InvalidAttrHandler onInvalidAttrName;
+
+    CursorType cursor;
+    alias cursor this;
+
+    auto getName()
+    {
+        import std.algorithm : all;
+
+        auto name = cursor.getName;
+        if (cursor.getKind != XMLKind.ELEMENT_END)
+            if (!name[0].isValidXMLNameStart || !name.all!isValidXMLNameChar)
+                onInvalidTagName(name);
+        return name;
+    }
+
+    auto getAttributes()
+    {
+        struct CheckedAttributes
+        {
+            typeof(onInvalidAttrName) callback;
+            typeof(cursor.getAttributes()) attrs;
+            alias attrs this;
+
+            auto front()
+            {
+                import std.algorithm : all;
+                auto attr = attrs.front;
+                if (!attr.name[0].isValidXMLNameStart || !attr.name.all!isValidXMLNameChar)
+                    callback(attr.name);
+                return attr;
+            }
+        }
+        return CheckedAttributes(onInvalidAttrName, cursor.getAttributes);
+    }
+}
+
+/**
+*   Returns an instance of `CheckXMLNames` specialized for the given `cursor`,
+*   with the given error handlers;
+*/
+auto checkXMLNames(CursorType, InvalidTagHandler, InvalidAttrHandler)
+                  (auto ref CursorType cursor,
+                   InvalidTagHandler tagHandler = (CursorType.StringType s) {},
+                   InvalidAttrHandler attrHandler = (CursorType.StringType s) {})
+{
+    auto res = CheckXMLNames!(CursorType, InvalidTagHandler, InvalidAttrHandler)();
+    res.cursor = cursor;
+    res.onInvalidTagName = tagHandler;
+    res.onInvalidAttrName = attrHandler;
+    return res;
+}
+
+unittest
+{
+    import std.experimental.xml.lexers;
+    import std.experimental.xml.parser;
+    import std.experimental.xml.cursor;
+
+    auto xml = q{
+        <?xml?>
+        <aa.a at;t = "hi!">
+            <bbb>
+                <-ccc>
+            </bbb>
+            <dd-d xmlns:,="http://foo.bar/baz">
+            </dd-d>
+        </aa.a>
+    };
+
+    int count = 0;
+
+    auto cursor =
+         chooseLexer!xml
+        .parse
+        .cursor
+        .checkXMLNames((string s) { count++; }, (string s) { count++; });
+    cursor.setSource(xml);
+
+    void inspectOneLevel(T)(ref T cursor)
+    {
+        import std.array;
+        do
+        {
+            auto name = cursor.getName;
+            auto attrs = cursor.getAttributes.array;
+            if (cursor.enter)
+            {
+                inspectOneLevel(cursor);
+                cursor.exit();
+            }
+        }
+        while (cursor.next);
+    }
+    inspectOneLevel(cursor);
+
+    assert(count == 3);
+}

--- a/std/experimental/xml/validation.d
+++ b/std/experimental/xml/validation.d
@@ -99,7 +99,7 @@ struct ElementNestingValidator(CursorType, alias ErrorHandler)
             }
             else
             {
-                import std.experimental.xml.faststrings;
+                import std.experimental.xml.faststrings : fastEqual;
 
                 if (!fastEqual(stack.back, cursor.name))
                 {
@@ -145,8 +145,9 @@ unittest
     int count = 0;
 
     auto validator =
-         chooseLexer!xml
-        .parse
+         xml
+        .lexer
+        .parser
         .cursor
         .elementNestingValidator!(
             (ref cursor, ref stack)
@@ -339,11 +340,11 @@ unittest
     int count = 0;
 
     auto cursor =
-         chooseLexer!xml
-        .parse
+         xml
+        .lexer
+        .parser
         .cursor
         .checkXMLNames((string s) { count++; }, (string s) { count++; });
-    cursor.setSource(xml);
 
     void inspectOneLevel(T)(ref T cursor)
     {

--- a/std/experimental/xml/writer.d
+++ b/std/experimental/xml/writer.d
@@ -715,7 +715,7 @@ unittest
     "\t<!I_SAID_NO_CHECKS_AT_ALL_BY_DEFAULT>\n" ~
     "]>\n";
 
-    auto cursor = chooseParser!xml.cursor;
+    auto cursor = xml.parser.cursor;
     cursor.setSource(xml);
 
     auto app = Appender!string();

--- a/std/experimental/xml/writer.d
+++ b/std/experimental/xml/writer.d
@@ -1,0 +1,1004 @@
+/*
+*             Copyright Lodovico Giaretta 2016 - .
+*  Distributed under the Boost Software License, Version 1.0.
+*      (See accompanying file LICENSE_1_0.txt or copy at
+*            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/++
++   This module implements components to put XML data in `OutputRange`s
++/
+
+module std.experimental.xml.writer;
+
+import std.experimental.xml.interfaces;
+
+private string ifCompiles(string code)
+{
+    return "static if (__traits(compiles, " ~ code ~ ")) " ~ code ~ ";\n";
+}
+private string ifCompilesElse(string code, string fallback)
+{
+    return "static if (__traits(compiles, " ~ code ~ ")) " ~ code ~ "; else " ~ fallback ~ ";\n";
+}
+private string ifAnyCompiles(string code, string[] codes...)
+{
+    if (codes.length == 0)
+        return "static if (__traits(compiles, " ~ code ~ ")) " ~ code ~ ";";
+    else
+        return "static if (__traits(compiles, " ~ code ~ ")) " ~ code ~
+                "; else " ~ ifAnyCompiles(codes[0], codes[1..$]);
+}
+
+import std.typecons : tuple;
+private auto xmlDeclarationAttributes(StringType, Args...)(Args args)
+{
+    static assert(Args.length <= 3, "Too many arguments for xml declaration");
+
+    // version specification
+    static if (is(Args[0] == int))
+    {
+        assert(args[0] == 10 || args[0] == 11, "Invalid xml version specified");
+        StringType versionString = args[0] == 10 ? "1.0" : "1.1";
+        auto args1 = args[1..$];
+    }
+    else
+    {
+        StringType versionString = [];
+        auto args1 = args;
+    }
+
+    // encoding specification
+    static if (is(typeof(args1[0]) == StringType))
+    {
+        auto encodingString = args1[0];
+        auto args2 = args1[1..$];
+    }
+    else
+    {
+        StringType encodingString = [];
+        auto args2 = args1;
+    }
+
+    // standalone specification
+    static if (is(typeof(args2[0]) == bool))
+    {
+        StringType standaloneString = args2[0] ? "yes" : "no";
+        auto args3 = args2[1..$];
+    }
+    else
+    {
+        StringType standaloneString = [];
+        auto args3 = args2;
+    }
+
+    // catch other erroneous parameters
+    static assert(typeof(args3).length == 0,
+                  "Unrecognized attribute type for xml declaration: " ~ typeof(args3[0]).stringof);
+
+    return tuple(versionString, encodingString, standaloneString);
+}
+
+/++
++   A collection of ready-to-use pretty-printers
++/
+struct PrettyPrinters
+{
+    /++
+    +   The minimal pretty-printer. It just guarantees that the input satisfies
+    +   the xml grammar.
+    +/
+    struct Minimalizer(StringType)
+    {
+        // minimum requirements needed for correctness
+        enum StringType beforeAttributeName = " ";
+        enum StringType betweenPITargetData = " ";
+    }
+    /++
+    +   A pretty-printer that indents the nodes with a tabulation character
+    +   `'\t'` per level of nesting.
+    +/
+    struct Indenter(StringType)
+    {
+        // inherit minimum requirements
+        Minimalizer!StringType minimalizer;
+        alias minimalizer this;
+
+        enum StringType afterNode = "\n";
+        enum StringType attributeDelimiter = "'";
+
+        uint indentation;
+        enum StringType tab = "\t";
+        void decreaseLevel() { indentation--; }
+        void increaseLevel() { indentation++; }
+
+        void beforeNode(Out)(ref Out output)
+        {
+            foreach (i; 0..indentation)
+                output.put(tab);
+        }
+    }
+}
+
+/++
++   Component that outputs XML data to an `OutputRange`.
++
++   To format the XML data, it calls specific methods of the `PrettyPrinter`, if
++   they are defined. Otherwise, it just prints the data with the minimal markup required.
++   The currently available format callbacks are:
++   $(UL
++       $(LI `beforeNode`, called as the first operation of outputting every XML node;
++                          expected to return a string to be printed before the node)
++       $(LI `afterNode`, called as the last operation of outputting every XML node;
++                         expected to return a string to be printed after the node)
++       $(LI `increaseLevel`, called after the start of a node that may have children
++                             (like a start tag or a doctype with an internal subset))
++       $(LI `decreaseLevel`, called before the end of a node that had some children
++                             (i.e. before writing a closing tag or the end of a doctype
++                              with an internal subset))
++       $(LI `beforeAttributeName`, called to obtain a string to be used as spacing
++                                   between the tag name and the first attribute name
++                                   and between the attribute value and the name of the
++                                   next attribute; it is not used between the value
++                                   of the last attribute and the closing `>`, nor between
++                                   the tag name and the closing `>` if the element
++                                   has no attributes)
++       $(LI `beforeElementEnd`, called to obtain a string to be used as spacing
++                                before the closing `>` of a tag, that is after the
++                                last attribute name or after the tag name if the
++                                element has no attributes)
++       $(LI `afterAttributeName`, called to obtain a string to be used as spacing
++                                  between the name of an attribute and the `=` sign)
++       $(LI `beforeAttributeValue`, called to obtain a string to be used as spacing
++                                  between the `=` sign and the value of an attribute)
++       $(LI `formatAttribute(outputRange, attibuteValue)`, called to write out the value
++                                                           of an attribute)
++       $(LI `formatAttribute(attributeValue)`, called to obtain a string that represents
++                                               the formatted attribute to be printed; used
++                                               when the previous method is not defined)
++       $(LI `attributeDelimiter`, called to obtain a string that represents the delimiter
++                                  to be used when writing attributes; used when the previous
++                                  two methods are not defined; in this case the attribute
++                                  is not subject to any formatting, except prepending and
++                                  appending the string returned by this method)
++       $(LI `afterCommentStart`, called to obtain a string that represents the spacing
++                                 to be used between the `<!--` opening and the comment contents)
++       $(LI `beforeCommentEnd`, called to obtain a string that represents the spacing
++                                to be used between the comment contents and the closing `-->`)
++       $(LI `betweenPITargetData`, called to obtain a string to be used as spacing
++                                   between the target and data of a processing instruction)
++       $(LI `beforePIEnd`, called to obtain a string to be used as spacing between
++                           the processing instruction data and the closing `?>`)
++   )
++/
+struct Writer(_StringType, alias OutRange, alias PrettyPrinter = PrettyPrinters.Minimalizer)
+{
+    alias StringType = _StringType;
+
+    static if (is(PrettyPrinter))
+        private PrettyPrinter prettyPrinter;
+    else static if (is(PrettyPrinter!StringType))
+        private PrettyPrinter!StringType prettyPrinter;
+    else
+        static assert(0, "Invalid pretty printer type for string type " ~ StringType.stringof);
+
+    static if (is(OutRange))
+        private OutRange* output;
+    else static if (is(OutRange!StringType))
+        private OutRange!StringType* output;
+    else
+        static assert(0, "Invalid output range type for string type " ~ StringType.stringof);
+
+    bool startingTag = false, insideDTD = false;
+
+    this(typeof(prettyPrinter) pretty)
+    {
+        prettyPrinter = pretty;
+    }
+
+    void setSink(ref typeof(*output) output)
+    {
+        this.output = &output;
+    }
+    void setSink(typeof(output) output)
+    {
+        this.output = output;
+    }
+
+    private template expand(string methodName)
+    {
+        import std.meta : AliasSeq;
+        alias expand = AliasSeq!(
+            "prettyPrinter." ~ methodName ~ "(output)",
+            "output.put(prettyPrinter." ~ methodName ~ ")"
+        );
+    }
+    private template formatAttribute(string attribute)
+    {
+        import std.meta : AliasSeq;
+        alias formatAttribute = AliasSeq!(
+            "prettyPrinter.formatAttribute(output, " ~ attribute ~ ")",
+            "output.put(prettyPrinter.formatAttribute(" ~ attribute ~ "))",
+            "defaultFormatAttribute(" ~ attribute ~ ", prettyPrinter.attributeDelimiter)",
+            "defaultFormatAttribute(" ~ attribute ~ ")"
+        );
+    }
+
+    private void defaultFormatAttribute(StringType attribute, StringType delimiter = "'")
+    {
+        // TODO: delimiter escaping
+        output.put(delimiter);
+        output.put(attribute);
+        output.put(delimiter);
+    }
+
+    /++
+    +   Outputs an XML declaration.
+    +
+    +   Its arguments must be an `int` specifying the version
+    +   number (`10` or `11`), a string specifying the encoding (no check is performed on
+    +   this parameter) and a `bool` specifying the standalone property of the document.
+    +   Any argument can be skipped, but the specified arguments must respect the stated
+    +   ordering (which is also the ordering required by the XML specification).
+    +/
+    void writeXMLDeclaration(Args...)(Args args)
+    {
+        auto attrs = xmlDeclarationAttributes!StringType(args);
+
+        output.put("<?xml");
+
+        if (attrs[0])
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("version");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"attrs[0]"));
+        }
+        if (attrs[1])
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("encoding");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"attrs[1]"));
+        }
+        if (attrs[2])
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("standalone");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"attrs[2]"));
+        }
+
+        mixin(ifAnyCompiles(expand!"beforePIEnd"));
+        output.put("?>");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    void writeXMLDeclaration(StringType version_, StringType encoding, StringType standalone)
+    {
+        output.put("<?xml");
+
+        if (version_)
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("version");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"version_"));
+        }
+        if (encoding)
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("encoding");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"encoding"));
+        }
+        if (standalone)
+        {
+            mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+            output.put("standalone");
+            mixin(ifAnyCompiles(expand!"afterAttributeName"));
+            output.put("=");
+            mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+            mixin(ifAnyCompiles(formatAttribute!"standalone"));
+        }
+
+        output.put("?>");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+
+    /++
+    +   Outputs a comment with the given content.
+    +/
+    void writeComment(StringType comment)
+    {
+        closeOpenThings;
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<!--");
+        mixin(ifAnyCompiles(expand!"afterCommentStart"));
+
+        mixin(ifCompilesElse(
+            "prettyPrinter.formatComment(output, comment)",
+            "output.put(comment)"
+        ));
+
+        mixin(ifAnyCompiles(expand!"beforeCommentEnd"));
+        output.put("-->");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    /++
+    +   Outputs a text node with the given content.
+    +/
+    void writeText(StringType text)
+    {
+        //assert(!insideDTD);
+        closeOpenThings;
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        mixin(ifCompilesElse(
+            "prettyPrinter.formatText(output, comment)",
+            "output.put(text)"
+        ));
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    /++
+    +   Outputs a CDATA section with the given content.
+    +/
+    void writeCDATA(StringType cdata)
+    {
+        assert(!insideDTD);
+        closeOpenThings;
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<![CDATA[[");
+        output.put(cdata);
+        output.put("]]>");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    /++
+    +   Outputs a processing instruction with the given target and data.
+    +/
+    void writeProcessingInstruction(StringType target, StringType data)
+    {
+        closeOpenThings;
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<?");
+        output.put(target);
+        mixin(ifAnyCompiles(expand!"betweenPITargetData"));
+        output.put(data);
+
+        mixin(ifAnyCompiles(expand!"beforePIEnd"));
+        output.put("?>");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+
+    private void closeOpenThings()
+    {
+        if (startingTag)
+        {
+            mixin(ifAnyCompiles(expand!"beforeElementEnd"));
+            output.put(">");
+            mixin(ifAnyCompiles(expand!"afterNode"));
+            startingTag = false;
+            mixin(ifCompiles("prettyPrinter.increaseLevel"));
+        }
+    }
+
+    void startElement(StringType tagName)
+    {
+        closeOpenThings();
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<");
+        output.put(tagName);
+        startingTag = true;
+    }
+    void closeElement(StringType tagName)
+    {
+        bool selfClose;
+        mixin(ifCompilesElse(
+            "selfClose = prettyPrinter.selfClosingElements",
+            "selfClose = true"
+        ));
+
+        if (selfClose && startingTag)
+        {
+            mixin(ifAnyCompiles(expand!"beforeElementEnd"));
+            output.put("/>");
+            startingTag = false;
+        }
+        else
+        {
+            closeOpenThings;
+
+            mixin(ifCompiles("prettyPrinter.decreaseLevel"));
+            mixin(ifAnyCompiles(expand!"beforeNode"));
+            output.put("</");
+            output.put(tagName);
+            mixin(ifAnyCompiles(expand!"beforeElementEnd"));
+            output.put(">");
+        }
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    void writeAttribute(StringType name, StringType value)
+    {
+        assert(startingTag, "Cannot write attribute outside element start");
+
+        mixin(ifAnyCompiles(expand!"beforeAttributeName"));
+        output.put(name);
+        mixin(ifAnyCompiles(expand!"afterAttributeName"));
+        output.put("=");
+        mixin(ifAnyCompiles(expand!"beforeAttributeValue"));
+        mixin(ifAnyCompiles(formatAttribute!"value"));
+    }
+
+    void startDoctype(StringType content)
+    {
+        assert(!insideDTD && !startingTag);
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<!DOCTYPE");
+        output.put(content);
+        mixin(ifAnyCompiles(expand!"afterDoctypeId"));
+        output.put("[");
+        insideDTD = true;
+        mixin(ifAnyCompiles(expand!"afterNode"));
+        mixin(ifCompiles("prettyPrinter.increaseLevel"));
+    }
+    void closeDoctype()
+    {
+        assert(insideDTD);
+
+        mixin(ifCompiles("prettyPrinter.decreaseLevel"));
+        insideDTD = false;
+        mixin(ifAnyCompiles(expand!"beforeDTDEnd"));
+        output.put("]>");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+    void writeDeclaration(StringType decl, StringType content)
+    {
+        //assert(insideDTD);
+
+        mixin(ifAnyCompiles(expand!"beforeNode"));
+        output.put("<!");
+        output.put(decl);
+        output.put(content);
+        output.put(">");
+        mixin(ifAnyCompiles(expand!"afterNode"));
+    }
+}
+
+unittest
+{
+    import std.array : Appender;
+    auto app = Appender!string();
+    auto writer = Writer!(string, typeof(app))();
+    writer.setSink(&app);
+
+    writer.writeXMLDeclaration(10, "utf-8", false);
+    assert(app.data == "<?xml version='1.0' encoding='utf-8' standalone='no'?>");
+
+    static assert(isWriter!(typeof(writer)));
+}
+
+/++
++   Returns a `Writer` for the given `StringType`, `outRange` and `PrettyPrinter`.
++/
+auto writerFor(StringType, alias PrettyPrinter = PrettyPrinters.Indenter, OutRange)(ref OutRange outRange)
+{
+    auto res = Writer!(StringType, OutRange, PrettyPrinter)();
+    res.setSink(outRange);
+    return res;
+}
+/// ditto
+auto writerFor(StringType, OutRange, PrettyPrinter)(ref OutRange outRange, auto ref PrettyPrinter printer)
+{
+    auto res = Writer!(StringType, OutRange, PrettyPrinter)(printer);
+    res.setSink(outRange);
+    return res;
+}
+
+unittest
+{
+    import std.array : Appender;
+    auto app = Appender!string();
+    auto writer = app.writerFor!string;
+
+    writer.startElement("elem");
+    writer.writeAttribute("attr1", "val1");
+    writer.writeAttribute("attr2", "val2");
+    writer.writeComment("Wonderful comment");
+    writer.startElement("self-closing");
+    writer.closeElement("self-closing");
+    writer.writeText("Wonderful text");
+    writer.writeCDATA("Wonderful cdata");
+    writer.writeProcessingInstruction("pi", "it works");
+    writer.closeElement("elem");
+
+    import std.string : lineSplitter;
+    auto splitter = app.data.lineSplitter;
+
+    assert(splitter.front == "<elem attr1='val1' attr2='val2'>");
+    splitter.popFront;
+    assert(splitter.front == "\t<!--Wonderful comment-->");
+    splitter.popFront;
+    assert(splitter.front == "\t<self-closing/>");
+    splitter.popFront;
+    assert(splitter.front == "\tWonderful text");
+    splitter.popFront;
+    assert(splitter.front == "\t<![CDATA[[Wonderful cdata]]>");
+    splitter.popFront;
+    assert(splitter.front == "\t<?pi it works?>");
+    splitter.popFront;
+    assert(splitter.front == "</elem>");
+    splitter.popFront;
+    assert(splitter.empty);
+}
+
+import dom = std.experimental.xml.dom;
+
+/++
++   Outputs the entire DOM tree rooted at `node` using the given `writer`.
++/
+void writeDOM(WriterType, NodeType)(auto ref WriterType writer, NodeType node)
+    if (is(NodeType: dom.Node!(WriterType.StringType)))
+{
+    import std.traits : ReturnType;
+    alias Document = typeof(node.ownerDocument);
+    alias Element = ReturnType!(Document.documentElement);
+
+    switch (node.nodeType) with (dom.NodeType)
+    {
+        case DOCUMENT:
+            auto doc = cast(Document)node;
+            writer.writeXMLDeclaration(doc.xmlVersion, doc.xmlEncoding, dom.xmlStandalone);
+            foreach (child; doc.childNodes)
+                writer.writeDOM(child);
+            break;
+        case ELEMENT:
+            auto elem = cast(Element)node;
+            writer.startElement(elem.tagName);
+            if (elem.hasAttributes)
+                foreach (attr; elem.attributes)
+                    writer.writeAttribute(attr.nodeName, attr.value);
+            foreach (child; elem.childNodes)
+                writer.writeDOM(elem);
+            writer.closeElement(elem.tagName);
+            break;
+        case TEXT:
+            writer.writeText(node.value);
+            break;
+        case CDATA:
+            writer.writeCDATA(node.value);
+            break;
+        case COMMENT:
+            writer.writeComment(node.value);
+            break;
+        default:
+            break;
+    }
+}
+
+import std.typecons : Flag, No, Yes;
+
+/++
++   Writes the contents of a cursor to a writer.
++
++   This method advances the cursor till the end of the document, outputting all
++   nodes using the given writer. The actual work is done inside a fiber, which is
++   then returned. This means that if the methods of the cursor call `Fiber.yield`,
++   this method will not complete its work, but will return a fiber in `HOLD` status,
++   which the user can `call` to advance the work. This is useful if the cursor
++   has to wait for other nodes to be ready (e.g. if the cursor input is generated
++   programmatically).
++/
+auto writeCursor(Flag!"useFiber" useFiber = No.useFiber, WriterType, CursorType)
+                (auto ref WriterType writer, auto ref CursorType cursor)
+{
+    alias StringType = WriterType.StringType;
+    void inspectOneLevel()
+    {
+        do
+        {
+            switch (cursor.getKind) with (XMLKind)
+            {
+                case DOCUMENT:
+                    StringType version_, encoding, standalone;
+                    foreach (attr; cursor.getAttributes)
+                        if (attr.name == "version")
+                            version_ = attr.value;
+                        else if (attr.name == "encoding")
+                            encoding = attr.value;
+                        else if (attr.name == "standalone")
+                            standalone = attr.value;
+                    writer.writeXMLDeclaration(version_, encoding, standalone);
+                    if (cursor.enter)
+                    {
+                        inspectOneLevel();
+                        cursor.exit;
+                    }
+                    break;
+                case DTD_EMPTY:
+                case DTD_START:
+                    writer.startDoctype(cursor.getAll);
+                    if (cursor.enter)
+                    {
+                        inspectOneLevel();
+                        cursor.exit;
+                    }
+                    writer.closeDoctype();
+                    break;
+                case ATTLIST_DECL:
+                    writer.writeDeclaration("ATTLIST", cursor.getAll);
+                    break;
+                case ELEMENT_DECL:
+                    writer.writeDeclaration("ELEMENT", cursor.getAll);
+                    break;
+                case ENTITY_DECL:
+                    writer.writeDeclaration("ENTITY", cursor.getAll);
+                    break;
+                case NOTATION_DECL:
+                    writer.writeDeclaration("NOTATION", cursor.getAll);
+                    break;
+                case DECLARATION:
+                    writer.writeDeclaration(cursor.getName, cursor.getContent);
+                    break;
+                case TEXT:
+                    writer.writeText(cursor.getContent);
+                    break;
+                case CDATA:
+                    writer.writeCDATA(cursor.getContent);
+                    break;
+                case COMMENT:
+                    writer.writeComment(cursor.getContent);
+                    break;
+                case PROCESSING_INSTRUCTION:
+                    writer.writeProcessingInstruction(cursor.getName, cursor.getContent);
+                    break;
+                case ELEMENT_START:
+                case ELEMENT_EMPTY:
+                    writer.startElement(cursor.getName);
+                    for (auto attrs = cursor.getAttributes; !attrs.empty; attrs.popFront)
+                    {
+                        auto attr = attrs.front;
+                        writer.writeAttribute(attr.name, attr.value);
+                    }
+                    if (cursor.enter)
+                    {
+                        inspectOneLevel();
+                        cursor.exit;
+                    }
+                    writer.closeElement(cursor.getName);
+                    break;
+                default:
+                    break;
+                    //assert(0);
+            }
+        }
+        while (cursor.next);
+    }
+
+    static if (useFiber)
+    {
+        import core.thread: Fiber;
+        auto fiber = new Fiber(&inspectOneLevel);
+        fiber.call;
+        return fiber;
+    }
+    else
+        inspectOneLevel();
+}
+
+unittest
+{
+    import std.array : Appender;
+    import std.experimental.xml.parser;
+    import std.experimental.xml.cursor;
+
+    string xml =
+    "<?xml?>\n" ~
+    "<!DOCTYPE ciaone [\n" ~
+    "\t<!ELEMENT anything here>\n" ~
+    "\t<!ATTLIST no check at all...>\n" ~
+    "\t<!NOTATION dunno what to write>\n" ~
+    "\t<!ENTITY .....>\n" ~
+    "\t<!I_SAID_NO_CHECKS_AT_ALL_BY_DEFAULT>\n" ~
+    "]>\n";
+
+    auto cursor = chooseParser!xml.cursor;
+    cursor.setSource(xml);
+
+    auto app = Appender!string();
+    auto writer = Writer!(string, typeof(app), PrettyPrinters.Indenter)();
+
+    writer.setSink(app);
+    writer.writeCursor(cursor);
+
+    assert(app.data == xml);
+}
+
+/++
++   A wrapper around a writer that, before forwarding every write operation, validates
++   the input given by the user using a chain of validating cursors.
++
++   This type should not be instantiated directly, but with the helper function
++   `withValidation`.
++/
+struct CheckedWriter(WriterType, CursorType = void)
+    if (isWriter!(WriterType) && (is(CursorType == void) ||
+       (isCursor!CursorType && is(WriterType.StringType == CursorType.StringType))))
+{
+    import core.thread : Fiber;
+    private Fiber fiber;
+    private bool startingTag = false;
+
+    WriterType writer;
+    alias writer this;
+
+    alias StringType = WriterType.StringType;
+
+    static if (is(CursorType == void))
+    {
+        struct Cursor
+        {
+            import std.experimental.xml.cursor: Attribute;
+            import std.container.array;
+
+            alias StringType = WriterType.StringType;
+
+            private StringType name, content;
+            private Array!(Attribute!StringType) attrs;
+            private XMLKind kind;
+            private size_t colon;
+            private bool initialized;
+
+            void _setName(StringType name)
+            {
+                import std.experimental.xml.faststrings;
+                this.name = name;
+                auto i = name.fastIndexOf(':');
+                if (i > 0)
+                    colon = i;
+                else
+                    colon = 0;
+            }
+            void _addAttribute(StringType name, StringType value)
+            {
+                attrs.insertBack(Attribute!StringType(name, value));
+            }
+            void _setKind(XMLKind kind)
+            {
+                this.kind = kind;
+                initialized = true;
+                attrs.clear;
+            }
+            void _setContent(StringType content) { this.content = content; }
+
+            auto getKind()
+            {
+                if (!initialized)
+                    Fiber.yield;
+
+                return kind;
+            }
+            auto getName() { return name; }
+            auto getPrefix() { return name[0..colon]; }
+            auto getContent() { return content; }
+            auto getAttributes() { return attrs[]; }
+            StringType getLocalName()
+            {
+                if (colon)
+                    return name[colon+1..$];
+                else
+                    return [];
+            }
+
+            bool enter()
+            {
+                if (kind == XMLKind.DOCUMENT)
+                {
+                    Fiber.yield;
+                    return true;
+                }
+                if (kind != XMLKind.ELEMENT_START)
+                    return false;
+
+                Fiber.yield;
+                return kind != XMLKind.ELEMENT_END;
+            }
+            bool next()
+            {
+                Fiber.yield;
+                return kind != XMLKind.ELEMENT_END;
+            }
+            void exit() {}
+            bool atBeginning()
+            {
+                return !initialized || kind == XMLKind.DOCUMENT;
+            }
+            bool documentEnd() { return false; }
+
+            alias InputType = void*;
+            StringType getAll()
+            {
+                assert(0, "Cannot call getAll on this type of cursor");
+            }
+            void setSource(InputType)
+            {
+                assert(0, "Cannot set the source of this type of cursor");
+            }
+        }
+        Cursor cursor;
+    }
+    else
+    {
+        CursorType cursor;
+    }
+
+    void writeXMLDeclaration(Args...)(Args args)
+    {
+        auto attrs = xmlDeclarationAttributes!StringType(args);
+        cursor._setKind(XMLKind.DOCUMENT);
+        if (attrs[0])
+            cursor._addAttribute("version", attrs[0]);
+        if (attrs[1])
+            cursor._addAttribute("encoding", attrs[1]);
+        if (attrs[2])
+            cursor._addAttribute("standalone", attrs[2]);
+        fiber.call;
+    }
+    void writeXMLDeclaration(StringType version_, StringType encoding, StringType standalone)
+    {
+        cursor._setKind(XMLKind.DOCUMENT);
+        if (version_)
+            cursor._addAttribute("version", version_);
+        if (encoding)
+            cursor._addAttribute("encoding", encoding);
+        if (standalone)
+            cursor._addAttribute("standalone", standalone);
+        fiber.call;
+    }
+    void writeComment(StringType text)
+    {
+        if (startingTag)
+        {
+            fiber.call;
+            startingTag = false;
+        }
+        cursor._setKind(XMLKind.COMMENT);
+        cursor._setContent(text);
+        fiber.call;
+    }
+    void writeText(StringType text)
+    {
+        if (startingTag)
+        {
+            fiber.call;
+            startingTag = false;
+        }
+        cursor._setKind(XMLKind.TEXT);
+        cursor._setContent(text);
+        fiber.call;
+    }
+    void writeCDATA(StringType text)
+    {
+        if (startingTag)
+        {
+            fiber.call;
+            startingTag = false;
+        }
+        cursor._setKind(XMLKind.CDATA);
+        cursor._setContent(text);
+        fiber.call;
+    }
+    void writeProcessingInstruction(StringType target, StringType data)
+    {
+        if (startingTag)
+        {
+            fiber.call;
+            startingTag = false;
+        }
+        cursor._setKind(XMLKind.COMMENT);
+        cursor._setName(target);
+        cursor._setContent(data);
+        fiber.call;
+    }
+    void startElement(StringType tag)
+    {
+        if (startingTag)
+            fiber.call;
+
+        startingTag = true;
+        cursor._setKind(XMLKind.ELEMENT_START);
+        cursor._setName(tag);
+    }
+    void closeElement(StringType tag)
+    {
+        if (startingTag)
+        {
+            fiber.call;
+            startingTag = false;
+        }
+        cursor._setKind(XMLKind.ELEMENT_END);
+        cursor._setName(tag);
+        fiber.call;
+    }
+    void writeAttribute(StringType name, StringType value)
+    {
+        assert(startingTag);
+        cursor._addAttribute(name, value);
+    }
+}
+
+/++
++   Returns a new _writer that wraps the original one, applying a validation to every
++   output operation.
++
++   `validationFun` must return a value that fulfills the cursor API. This template
++   returns instances of `CheckedWriter`.
++
++   Params:
++       validationFun = a function or function template that produces an instance of
++                       a validating cursor
++       Params = the compile-time parameters used to instantiate `validationFun`
++       writer = the original writer, to be enhanced with the validation
++       args = the runtime arguments passed to `validationFun`
++/
+template withValidation(alias validationFun, Params...)
+{
+    import std.traits;
+
+    auto withValidation(Writer, Args...)(auto ref Writer writer, auto ref Args args)
+        if (isWriter!Writer)
+    {
+        static if (__traits(isSame, TemplateOf!Writer, CheckedWriter))
+        {
+            auto cursor = validationFun!Params(typeof(Writer.cursor)(), args);
+        }
+        else
+        {
+            auto cursor = validationFun!Params(CheckedWriter!Writer.Cursor(), args);
+        }
+
+        auto res = CheckedWriter!(Writer, typeof(cursor))();
+        res.cursor = cursor;
+        res.writer = writer;
+        res.fiber = writeCursor!(Yes.useFiber)(res.writer, res.cursor);
+        return res;
+    }
+}
+
+unittest
+{
+    import std.array : Appender;
+    import std.experimental.xml.validation;
+
+    int count = 0;
+
+    auto app = Appender!string();
+    auto writer =
+         Writer!(string, typeof(app), PrettyPrinters.Indenter)()
+        .withValidation!checkXMLNames((string s) { count++; }, (string s) { count++; });
+    writer.setSink(&app);
+
+    writer.writeXMLDeclaration(10, "utf-8", false);
+    assert(app.data == "<?xml version='1.0' encoding='utf-8' standalone='no'?>\n");
+
+    writer.writeComment("a nice comment");
+    writer.startElement("aa;bb");
+    writer.writeAttribute(";eh", "foo");
+    writer.writeText("a nice text");
+    writer.writeCDATA("a nice CDATA");
+    writer.closeElement("aabb");
+    assert(count == 2);
+}

--- a/win32.mak
+++ b/win32.mak
@@ -336,6 +336,21 @@ SRC_STD_EXP_NDSLICE= \
 	std\experimental\ndslice\slice.d \
 	std\experimental\ndslice\internal.d
 
+SRC_STD_EXP_XML= \
+	std\experimental\xml\package.d \
+	std\experimental\xml\appender.d \
+	std\experimental\xml\cursor.d \
+	std\experimental\xml\dom.d \
+	std\experimental\xml\domimpl.d \
+	std\experimental\xml\domparser.d \
+	std\experimental\xml\faststrings.d \
+	std\experimental\xml\interfaces.d \
+	std\experimental\xml\lexers.d \
+	std\experimental\xml\parser.d \
+	std\experimental\xml\sax.d \
+	std\experimental\xml\validation.d \
+	std\experimental\xml\writer.d \
+
 SRC_ETC=
 
 SRC_ETC_C= \
@@ -366,6 +381,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_EXP_ALLOC) \
 	$(SRC_STD_EXP_LOGGER) \
 	$(SRC_STD_EXP_NDSLICE) \
+	$(SRC_STD_EXP_XML) \
 	$(SRC_ETC) \
 	$(SRC_ETC_C)
 
@@ -533,6 +549,18 @@ DOCS= \
 	$(DOC)\std_experimental_ndslice_slice.html \
 	$(DOC)\std_experimental_ndslice.html \
 	$(DOC)\std_experimental_typecons.html \
+	$(DOC)\std_experimental_xml_cursor.html \
+	$(DOC)\std_experimental_xml_dom.html \
+	$(DOC)\std_experimental_xml_domimpl.html \
+	$(DOC)\std_experimental_xml_domparser.html \
+	$(DOC)\std_experimental_xml_faststrings.html \
+	$(DOC)\std_experimental_xml_interfaces.html \
+	$(DOC)\std_experimental_xml_lexers.html \
+	$(DOC)\std_experimental_xml_parser.html \
+	$(DOC)\std_experimental_xml_sax.html \
+	$(DOC)\std_experimental_xml_validation.html \
+	$(DOC)\std_experimental_xml_writer.html \
+	$(DOC)\std_experimental_xml \
 	$(DOC)\std_windows_charset.html \
 	$(DOC)\std_windows_registry.html \
 	$(DOC)\std_c_fenv.html \
@@ -577,7 +605,8 @@ UNITTEST_OBJS= \
 		unittest8d.obj \
 		unittest8e.obj \
 		unittest8f.obj \
-		unittest9a.obj
+		unittest9a.obj \
+		unittest9b.obj
 
 unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest1.obj $(SRC_STD_1)
@@ -597,6 +626,7 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8f.obj $(SRC_STD_EXP)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest9a.obj $(SRC_STD_EXP_NDSLICE)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest9b.obj $(SRC_STD_EXP_XML)
 	$(DMD) $(UDFLAGS) -L/co -unittest unittest.d $(UNITTEST_OBJS) \
 		$(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
@@ -1084,6 +1114,42 @@ $(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\
 
 $(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
+    
+$(DOC)\std_experimental_xml_cursor.html : $(STDDOC) std\experimental\xml\cursor.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_cursor.html $(STDDOC) std\experimental\xml\cursor.d
+    
+$(DOC)\std_experimental_xml_dom.html : $(STDDOC) std\experimental\xml\dom.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_dom.html $(STDDOC) std\experimental\xml\dom.d
+    
+$(DOC)\std_experimental_xml_domimpl.html : $(STDDOC) std\experimental\xml\domimpl.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domimpl.html $(STDDOC) std\experimental\xml\domimpl.d
+    
+$(DOC)\std_experimental_xml_domparser.html : $(STDDOC) std\experimental\xml\domparser.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domparser.html $(STDDOC) std\experimental\xml\domparser.d
+    
+$(DOC)\std_experimental_xml_faststrings.html : $(STDDOC) std\experimental\xml\faststrings.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_faststrings.html $(STDDOC) std\experimental\xml\faststrings.d
+    
+$(DOC)\std_experimental_xml_interfaces.html : $(STDDOC) std\experimental\xml\interfaces.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_interfaces.html $(STDDOC) std\experimental\xml\interfaces.d
+    
+$(DOC)\std_experimental_xml_lexers.html : $(STDDOC) std\experimental\xml\lexers.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_lexers.html $(STDDOC) std\experimental\xml\lexers.d
+    
+$(DOC)\std_experimental_xml_parser.html : $(STDDOC) std\experimental\xml\parser.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_parser.html $(STDDOC) std\experimental\xml\parser.d
+    
+$(DOC)\std_experimental_xml_sax.html : $(STDDOC) std\experimental\xml\sax.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_sax.html $(STDDOC) std\experimental\xml\sax.d
+
+$(DOC)\std_experimental_xml_validation.html : $(STDDOC) std\experimental\xml\validation.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_validation.html $(STDDOC) std\experimental\xml\validation.d
+
+$(DOC)\std_experimental_xml_writer.html : $(STDDOC) std\experimental\xml\writer.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_writer.html $(STDDOC) std\experimental\xml\writer.d
+
+$(DOC)\std_experimental_xml.html : $(STDDOC) std\experimental\xml\package.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml.html $(STDDOC) std\experimental\xml\package.d
 
 $(DOC)\std_digest_crc.html : $(STDDOC) std\digest\crc.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_digest_crc.html $(STDDOC) std\digest\crc.d

--- a/win32.mak
+++ b/win32.mak
@@ -1114,31 +1114,31 @@ $(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\
 
 $(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
-    
+
 $(DOC)\std_experimental_xml_cursor.html : $(STDDOC) std\experimental\xml\cursor.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_cursor.html $(STDDOC) std\experimental\xml\cursor.d
-    
+
 $(DOC)\std_experimental_xml_dom.html : $(STDDOC) std\experimental\xml\dom.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_dom.html $(STDDOC) std\experimental\xml\dom.d
-    
+
 $(DOC)\std_experimental_xml_domimpl.html : $(STDDOC) std\experimental\xml\domimpl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domimpl.html $(STDDOC) std\experimental\xml\domimpl.d
-    
+
 $(DOC)\std_experimental_xml_domparser.html : $(STDDOC) std\experimental\xml\domparser.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domparser.html $(STDDOC) std\experimental\xml\domparser.d
-    
+
 $(DOC)\std_experimental_xml_faststrings.html : $(STDDOC) std\experimental\xml\faststrings.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_faststrings.html $(STDDOC) std\experimental\xml\faststrings.d
-    
+
 $(DOC)\std_experimental_xml_interfaces.html : $(STDDOC) std\experimental\xml\interfaces.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_interfaces.html $(STDDOC) std\experimental\xml\interfaces.d
-    
+
 $(DOC)\std_experimental_xml_lexers.html : $(STDDOC) std\experimental\xml\lexers.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_lexers.html $(STDDOC) std\experimental\xml\lexers.d
-    
+
 $(DOC)\std_experimental_xml_parser.html : $(STDDOC) std\experimental\xml\parser.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_parser.html $(STDDOC) std\experimental\xml\parser.d
-    
+
 $(DOC)\std_experimental_xml_sax.html : $(STDDOC) std\experimental\xml\sax.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_sax.html $(STDDOC) std\experimental\xml\sax.d
 

--- a/win64.mak
+++ b/win64.mak
@@ -1092,31 +1092,31 @@ $(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\
 
 $(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
-    
+
 $(DOC)\std_experimental_xml_cursor.html : $(STDDOC) std\experimental\xml\cursor.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_cursor.html $(STDDOC) std\experimental\xml\cursor.d
-    
+
 $(DOC)\std_experimental_xml_dom.html : $(STDDOC) std\experimental\xml\dom.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_dom.html $(STDDOC) std\experimental\xml\dom.d
-    
+
 $(DOC)\std_experimental_xml_domimpl.html : $(STDDOC) std\experimental\xml\domimpl.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domimpl.html $(STDDOC) std\experimental\xml\domimpl.d
-    
+
 $(DOC)\std_experimental_xml_domparser.html : $(STDDOC) std\experimental\xml\domparser.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domparser.html $(STDDOC) std\experimental\xml\domparser.d
-    
+
 $(DOC)\std_experimental_xml_faststrings.html : $(STDDOC) std\experimental\xml\faststrings.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_faststrings.html $(STDDOC) std\experimental\xml\faststrings.d
-    
+
 $(DOC)\std_experimental_xml_interfaces.html : $(STDDOC) std\experimental\xml\interfaces.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_interfaces.html $(STDDOC) std\experimental\xml\interfaces.d
-    
+
 $(DOC)\std_experimental_xml_lexers.html : $(STDDOC) std\experimental\xml\lexers.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_lexers.html $(STDDOC) std\experimental\xml\lexers.d
-    
+
 $(DOC)\std_experimental_xml_parser.html : $(STDDOC) std\experimental\xml\parser.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_parser.html $(STDDOC) std\experimental\xml\parser.d
-    
+
 $(DOC)\std_experimental_xml_sax.html : $(STDDOC) std\experimental\xml\sax.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_sax.html $(STDDOC) std\experimental\xml\sax.d
 

--- a/win64.mak
+++ b/win64.mak
@@ -358,6 +358,21 @@ SRC_STD_EXP_NDSLICE= \
 	std\experimental\ndslice\slice.d \
 	std\experimental\ndslice\internal.d
 
+SRC_STD_EXP_XML= \
+	std\experimental\xml\package.d \
+	std\experimental\xml\appender.d \
+	std\experimental\xml\cursor.d \
+	std\experimental\xml\dom.d \
+	std\experimental\xml\domimpl.d \
+	std\experimental\xml\domparser.d \
+	std\experimental\xml\faststrings.d \
+	std\experimental\xml\interfaces.d \
+	std\experimental\xml\lexers.d \
+	std\experimental\xml\parser.d \
+	std\experimental\xml\sax.d \
+	std\experimental\xml\validation.d \
+	std\experimental\xml\writer.d \
+
 SRC_ETC=
 
 SRC_ETC_C= \
@@ -388,6 +403,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_EXP_ALLOC) \
 	$(SRC_STD_EXP_LOGGER) \
 	$(SRC_STD_EXP_NDSLICE) \
+	$(SRC_STD_EXP_XML) \
 	$(SRC_ETC) \
 	$(SRC_ETC_C)
 
@@ -555,6 +571,18 @@ DOCS= \
 	$(DOC)\std_experimental_ndslice_slice.html \
 	$(DOC)\std_experimental_ndslice.html \
 	$(DOC)\std_experimental_typecons.html \
+	$(DOC)\std_experimental_xml_cursor.html \
+	$(DOC)\std_experimental_xml_dom.html \
+	$(DOC)\std_experimental_xml_domimpl.html \
+	$(DOC)\std_experimental_xml_domparser.html \
+	$(DOC)\std_experimental_xml_faststrings.html \
+	$(DOC)\std_experimental_xml_interfaces.html \
+	$(DOC)\std_experimental_xml_lexers.html \
+	$(DOC)\std_experimental_xml_parser.html \
+	$(DOC)\std_experimental_xml_sax.html \
+	$(DOC)\std_experimental_xml_validation.html \
+	$(DOC)\std_experimental_xml_writer.html \
+	$(DOC)\std_experimental_xml \
 	$(DOC)\std_windows_charset.html \
 	$(DOC)\std_windows_registry.html \
 	$(DOC)\std_c_fenv.html \
@@ -611,7 +639,8 @@ UNITTEST_OBJS= \
 		unittest8e.obj \
 		unittest8f.obj \
 		unittest9.obj \
-		unittest9a.obj
+		unittest9a.obj \
+		unittest9b.obj
 
 unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest1.obj $(SRC_STD_1)
@@ -643,6 +672,7 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8f.obj $(SRC_STD_EXP)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest9.obj $(SRC_STD_EXP_ALLOC)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest9a.obj $(SRC_STD_EXP_NDSLICE)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest9b.obj $(SRC_STD_EXP_XML)
 	$(DMD) $(UDFLAGS) -L/OPT:NOICF -unittest unittest.d $(UNITTEST_OBJS) \
 	    $(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
@@ -1062,6 +1092,42 @@ $(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\
 
 $(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
+    
+$(DOC)\std_experimental_xml_cursor.html : $(STDDOC) std\experimental\xml\cursor.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_cursor.html $(STDDOC) std\experimental\xml\cursor.d
+    
+$(DOC)\std_experimental_xml_dom.html : $(STDDOC) std\experimental\xml\dom.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_dom.html $(STDDOC) std\experimental\xml\dom.d
+    
+$(DOC)\std_experimental_xml_domimpl.html : $(STDDOC) std\experimental\xml\domimpl.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domimpl.html $(STDDOC) std\experimental\xml\domimpl.d
+    
+$(DOC)\std_experimental_xml_domparser.html : $(STDDOC) std\experimental\xml\domparser.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_domparser.html $(STDDOC) std\experimental\xml\domparser.d
+    
+$(DOC)\std_experimental_xml_faststrings.html : $(STDDOC) std\experimental\xml\faststrings.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_faststrings.html $(STDDOC) std\experimental\xml\faststrings.d
+    
+$(DOC)\std_experimental_xml_interfaces.html : $(STDDOC) std\experimental\xml\interfaces.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_interfaces.html $(STDDOC) std\experimental\xml\interfaces.d
+    
+$(DOC)\std_experimental_xml_lexers.html : $(STDDOC) std\experimental\xml\lexers.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_lexers.html $(STDDOC) std\experimental\xml\lexers.d
+    
+$(DOC)\std_experimental_xml_parser.html : $(STDDOC) std\experimental\xml\parser.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_parser.html $(STDDOC) std\experimental\xml\parser.d
+    
+$(DOC)\std_experimental_xml_sax.html : $(STDDOC) std\experimental\xml\sax.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_sax.html $(STDDOC) std\experimental\xml\sax.d
+
+$(DOC)\std_experimental_xml_validation.html : $(STDDOC) std\experimental\xml\validation.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_validation.html $(STDDOC) std\experimental\xml\validation.d
+
+$(DOC)\std_experimental_xml_writer.html : $(STDDOC) std\experimental\xml\writer.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml_writer.html $(STDDOC) std\experimental\xml\writer.d
+
+$(DOC)\std_experimental_xml.html : $(STDDOC) std\experimental\xml\package.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_xml.html $(STDDOC) std\experimental\xml\package.d
 
 $(DOC)\std_digest_crc.html : $(STDDOC) std\digest\crc.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_digest_crc.html $(STDDOC) std\digest\crc.d


### PR DESCRIPTION
Here is the result of these months of work.
I want to thank my mentor Robert @burner Schadek for his great help, and everybody who already gave their feedback.

This is an (almost exact) copy of [my repository](https://github.com/lodo1995/experimental.xml) which is also available as a [dub package](https://code.dlang.org/packages/std-experimental-xml).
The documentation is available [here](https://lodo1995.github.io/experimental.xml/std/experimental/xml.html).

I would really love if feedback could focus on design considerations first, then naming issues (I'm not that good at naming things) and then small nitpicks.

I will try to keep low pressure on the testing environment by performing all further development based on your feedback on my repository (see above) and pushing here no more than twice a day.

Things still to do (work in progress):
- [ ] better DOM: the W3C specification is huge; by the way almost all functionality is there; only some small things are missing;
- [ ] better docs: should check if the docs are pretty with the Phobos styling, and should add docs for some functions;
- [ ] advanced DTD handling: this functionality is being worked on in my repo; can be added to this package in a second iteration
- [x] ~~legacy API: in my repo I have a crude wrapper that exposes the old `std.xml`, to ease transition; should it be included?~~ probably not a good idea
- [ ] check that integration is complete (makefiles, indexes and so on)
- [ ] more unittests (especially for `domimpl.d`)

Wishlist:
- [Issue 16410: attribute inference inside templated classes](http://forum.dlang.org/post/mailman.68.1471786940.3111.digitalmars-d-bugs@puremagic.com) (not a blocker, but would make `@nogc` DOM less impossible)
- `std.container.AA` with custom allocators; again, not a blocker, but would help `@nogc`
- an `Appender` with custom allocators, for the very same reason; currently this package uses a custom one.

Open questions:
- currently the DOM implementation tries to follow the W3C spec; what about the WHATWG spec? Which one should we try to adhere to?
- ~~to include or not to include the "legacy layer" to allow use of the old API backed by the new library, to ease transition?~~ probably not a good idea

(EDIT: of course this needs @andralex approval)
