### PR TITLE
Fix issue 16291 --  phobosinit fails to register encodings on individual tests

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2671,11 +2671,10 @@ abstract class EncodingScheme
  */
 class EncodingSchemeASCII : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeASCII");
-    }*/
+    }
 
     const
     {
@@ -2757,11 +2756,10 @@ class EncodingSchemeASCII : EncodingScheme
  */
 class EncodingSchemeLatin1 : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeLatin1");
-    }*/
+    }
 
     const
     {
@@ -2837,11 +2835,10 @@ class EncodingSchemeLatin1 : EncodingScheme
  */
 class EncodingSchemeLatin2 : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeLatin2");
-    }*/
+    }
 
     const
     {
@@ -2909,11 +2906,10 @@ class EncodingSchemeLatin2 : EncodingScheme
  */
 class EncodingSchemeWindows1250 : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeWindows1250");
-    }*/
+    }
 
     const
     {
@@ -2977,11 +2973,10 @@ class EncodingSchemeWindows1250 : EncodingScheme
  */
 class EncodingSchemeWindows1252 : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeWindows1252");
-    }*/
+    }
 
     const
     {
@@ -3045,11 +3040,10 @@ class EncodingSchemeWindows1252 : EncodingScheme
  */
 class EncodingSchemeUtf8 : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeUtf8");
-    }*/
+    }
 
     const
     {
@@ -3114,11 +3108,10 @@ class EncodingSchemeUtf8 : EncodingScheme
  */
 class EncodingSchemeUtf16Native : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeUtf16Native");
-    }*/
+    }
 
     const
     {
@@ -3210,11 +3203,10 @@ class EncodingSchemeUtf16Native : EncodingScheme
  */
 class EncodingSchemeUtf32Native : EncodingScheme
 {
-    /* // moved to std.internal.phobosinit
     shared static this()
     {
         EncodingScheme.register("std.encoding.EncodingSchemeUtf32Native");
-    }*/
+    }
 
     const
     {

--- a/std/internal/phobosinit.d
+++ b/std/internal/phobosinit.d
@@ -20,16 +20,3 @@ version(OSX)
         std_process_shared_static_this();
     }
 }
-
-shared static this()
-{
-    import std.encoding : EncodingScheme;
-    EncodingScheme.register("std.encoding.EncodingSchemeASCII");
-    EncodingScheme.register("std.encoding.EncodingSchemeLatin1");
-    EncodingScheme.register("std.encoding.EncodingSchemeLatin2");
-    EncodingScheme.register("std.encoding.EncodingSchemeWindows1250");
-    EncodingScheme.register("std.encoding.EncodingSchemeWindows1252");
-    EncodingScheme.register("std.encoding.EncodingSchemeUtf8");
-    EncodingScheme.register("std.encoding.EncodingSchemeUtf16Native");
-    EncodingScheme.register("std.encoding.EncodingSchemeUtf32Native");
-}

--- a/std/process.d
+++ b/std/process.d
@@ -85,6 +85,7 @@ Macros:
 */
 module std.process;
 
+
 version (Posix)
 {
     import core.sys.posix.unistd;
@@ -101,6 +102,7 @@ version (Windows)
 import std.range.primitives;
 import std.stdio;
 import std.internal.cstring;
+import std.internal.phobosinit;
 
 
 // When the DMC runtime is used, we have to use some custom functions


### PR DESCRIPTION
I'm going to attempt moving these ctors back, and make sure the dependency graph is properly set up. Testing locally, I no longer have any cycles. The cycle detection code is now fixed, so if cycles return, I'll have to figure out a different way to solve this.

Please do NOT pull until the auto-tester has checked for cycles.

See related PRs for history: dlang/druntime#1602 and #4493