### PR TITLE
supplemental change for Issue 15907 fix

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -210,7 +210,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix			\
 	gammafunction errorfunction) $(addprefix std/internal/, \
 	cstring processinit unicode_tables scopebuffer\
 	unicode_comp unicode_decomp unicode_grapheme unicode_norm) \
-	$(addprefix std/internal/test/, dummyrange) \
+	$(addprefix std/internal/test/, dummyrange uda) \
 	$(addprefix std/experimental/ndslice/, internal) \
 	$(addprefix std/algorithm/, internal)
 

--- a/std/internal/test/uda.d
+++ b/std/internal/test/uda.d
@@ -14,3 +14,13 @@ struct HasPrivateMembers
   @Attr private int c;
   private int d;
 }
+
+// If getSymbolsByUDA is mixed into the same scope it also returns private members
+unittest
+{
+    import std.traits : getSymbolsByUDA, hasUDA;
+    mixin getSymbolsByUDA!(HasPrivateMembers, Attr) symbols;
+    static assert(symbols.getSymbolsByUDA.length == 2);
+    static assert(hasUDA!(symbols.getSymbolsByUDA[0], Attr));
+    static assert(hasUDA!(symbols.getSymbolsByUDA[1], Attr));
+}

--- a/std/traits.d
+++ b/std/traits.d
@@ -6801,11 +6801,17 @@ unittest
 // #15335: getSymbolsByUDA fails if type has private members
 unittest
 {
-    // HasPrivateMembers has, well, private members, one of which has a UDA.
+    // HasPrivateMembers has private members, but only the ones visible from std.traits are returned
     import std.internal.test.uda;
-    static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 2);
+    // whether allMembers returns private members, see dmd fix for Issue 15907
+    static if (__traits(allMembers, HasPrivateMembers).length == 2)
+        static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
+    else
+    {
+        static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 2);
+        static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[1], Attr));
+    }
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));
-    static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[1], Attr));
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -6798,6 +6798,23 @@ unittest
     static assert(getSymbolsByUDA!(C, UDA)[1].stringof == "d");
 }
 
+/// mixin getSymbolsByUDA to also find private members
+unittest
+{
+    import std.traits;
+    enum UDA;
+    struct S
+    {
+        @UDA int visible;
+        @UDA private int invisible;
+    }
+    // mixin the template instantiation, using a name to avoid namespace pollution
+    mixin getSymbolsByUDA!(S, UDA) symbols;
+    // as the template is instantiated in the current scope, it can see private members
+    // mixin templates don't perform eponymous expansion, so an additional `.getSymbolsByUDA` is needed
+    static assert(symbols.getSymbolsByUDA.length == 2);
+}
+
 // #15335: getSymbolsByUDA fails if type has private members
 unittest
 {

--- a/win32.mak
+++ b/win32.mak
@@ -238,7 +238,7 @@ SRC_STD_C_FREEBSD= std\c\freebsd\socket.d
 SRC_STD_INTERNAL= std\internal\cstring.d std\internal\processinit.d \
 	std\internal\unicode_tables.d std\internal\unicode_comp.d std\internal\unicode_decomp.d \
 	std\internal\unicode_grapheme.d std\internal\unicode_norm.d std\internal\scopebuffer.d \
-	std\internal\test\dummyrange.d
+	std\internal\test\dummyrange.d std\internal\test\uda.d
 
 SRC_STD_INTERNAL_DIGEST= std\internal\digest\sha_SSSE3.d
 


### PR DESCRIPTION
- change of __traits(allMembers) semantics cause getSymbolsByUDA to no
  longer return invisible (private) symbols
- add test for using getSymbolsByUDA as mixin template to still access
  private symbols