### PR TITLE
use @system to return pointers to stack

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2633,7 +2633,7 @@ public:
 
             // Hack to take the address of a nested function w/o
             // making a closure.
-            static auto scopedAddress(D)(scope D del)
+            static auto scopedAddress(D)(scope D del) @system
             {
                 auto tmp = del;
                 return tmp;


### PR DESCRIPTION
Monkey business with stack pointers now can only be done in explicit `@system` code.

This is blocking https://github.com/dlang/dmd/pull/5972

Please don't delay reviewing/pulling.