### PR TITLE
Fix Issue 16443 - Segmentation fault when option name is empty

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -649,6 +649,8 @@ private template optionValidator(A...)
     args = ["program", "-a"];
     getopt(args, config.caseSensitive, 'a', "help string", &opt);
     assert(opt);
+
+    assertThrown(getopt(args, "", "forgot to put a string", &opt));
 }
 
 private void getoptImpl(T...)(ref string[] args, ref configuration cfg,
@@ -671,6 +673,11 @@ private void getoptImpl(T...)(ref string[] args, ref configuration cfg,
         {
             // it's an option string
             auto option = to!string(opts[0]);
+            if (option.length == 0)
+            {
+                excep = new GetOptException("An option name may not be an empty string", excep);
+                return;
+            }
             Option optionHelp = splitAndGet(option);
             optionHelp.required = cfg.required;
 


### PR DESCRIPTION
Prevent a segmentation fault when the option name is empty.

I am not convinced the type of Exception is correct since this is not a user error, but a programming error.

Comments are appreciated.