### PR TITLE
Update badge links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ===================================================================
 
 [![GitHub tag](https://img.shields.io/github/tag/dlang/phobos.svg?maxAge=86400)](#)
-[![Build Status](https://travis-ci.org/dlang/phobos.svg?branch=master)](https://travis-ci.org/dlang/phobos)
-[![Codecov](https://img.shields.io/codecov/c/github/dlang/phobos.svg?maxAge=86400)](https://codecov.io/gh/dlang/phobos)
-[![Issue Stats](http://www.issuestats.com/github/dlang/phobos/badge/pr)](http://www.issuestats.com/github/dlang/phobos)
+[![Build status](https://img.shields.io/circleci/project/dlang/phobos.svg?maxAge=86400)](https://circleci.com/gh/dlang/phobos)
+[![Code coverage](https://img.shields.io/codecov/c/github/dlang/phobos.svg?maxAge=86400)](https://codecov.io/gh/dlang/phobos)
+[![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/phobos.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/phobos)
 
 Phobos is the standard library that comes with the
 [D Programming Language](http://dlang.org) Compiler.


### PR DESCRIPTION
We finally made the switch to CircleCi -> updated badge.

Moreover I have seen that the Issuestats badge sometimes wasn't displayed correctly.
[Since one month](https://github.com/badges/shields/pull/656) Shields.io supports IssueStats, so I use d the opportunity to give them a try.