### PR TITLE
Removed debug lines from example unittest

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2425,8 +2425,6 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     import std.range.interfaces : inputRangeObject;
     import std.range : repeat;
 
-    debug(std_algorithm) scope(success)
-        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
     static assert(isInputRange!(typeof(joiner([""]))));
     static assert(isForwardRange!(typeof(joiner([""]))));
     assert(equal(joiner([""]), ""));


### PR DESCRIPTION
Removed a scoped debug line for the ```auto joiner(RoR)(RoR r)``` unittest. It was removed since it obscured the example in the Phobos docs.
https://dlang.org/phobos/std_algorithm_iteration.html#joiner