### PR TITLE
Fix opIndex for single-length Only range (Issue 16522)

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7356,7 +7356,7 @@ private struct OnlyResult(T, size_t arity : 1)
 
     T opIndex(size_t i)
     {
-        assert(!_empty && i == 0, "Attempting to fetch an out of bounds index from an Only range");
+        assert(i == 0, "Attempting to fetch an out of bounds index from an Only range");
         return _value;
     }
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7518,6 +7518,11 @@ unittest
         static assert(hasLength!A);
         static assert(hasSlicing!A);
     }
+    
+    auto idxtest = only(1);
+    assert(idxtest[0] == 1);
+    idxtest.popFront();
+    assert(idxtest[0] == 1);
 
     auto imm = only!(immutable int)(1);
     immutable int[] imme = [];


### PR DESCRIPTION
Fixes this:

``` D
import std.range;

void main(){
    auto x = only(1);
    x[0]; // ok
    x.popFront();
    x[0]; // breaks
}
```