### PR TITLE
Add pivotPartition

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -575,9 +575,9 @@ $(LI All elements `e` in subrange $(D r[0 .. k]) satisfy $(D !less(r[k], e))
 (i.e. `r[k]` is greater than or equal to each element to its left according to
 predicate `less`))
 
-$(LI $(LI All elements `e` in subrange $(D r[0 .. k]) satisfy $(D !less(e,
+$(LI All elements `e` in subrange $(D r[0 .. k]) satisfy $(D !less(e,
 r[k])) (i.e. `r[k]` is less than or equal to each element to its right
-according to predicate `less`))))
+according to predicate `less`)))
 
 If `r` contains equivalent elements, multiple permutations of `r` satisfy these
 constraints. In such cases, `pivotPartition` attempts to distribute equivalent
@@ -586,7 +586,7 @@ r.length / 2).
 
 Params:
 less = The predicate used for comparison, modeled as a $(LUCKY strict weak
-ordering) (irreflexive, antisymmetric, transitive, and implies transitive
+ordering) (irreflexive, antisymmetric, transitive, and implying a transitive
 equivalence)
 r = The range being partitioned
 pivot = The index of the pivot for partitioning, must be less than `r.length` or

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -40,10 +40,15 @@ $(T2 partialSort,
         $(D a[0 .. 3] = [1, 2, 3]).
         The other elements of $(D a) are left in an unspecified order.)
 $(T2 partition,
-        Partitions a range according to a predicate.)
+        Partitions a range according to a unary predicate.)
 $(T2 partition3,
-        Partitions a range in three parts (less than, equal, greater than the
-        given pivot).)
+        Partitions a range according to a binary predicate in three parts (less
+        than, equal, greater than the given pivot). Pivot is not given as an
+        index, but instead as an element independent from the range's content.)
+$(T2 pivotPartition,
+        Partitions a range according to a binary predicate in two parts: less
+        than or equal, and greater than or equal to the given pivot, passed as
+        an index in the range.)
 $(T2 schwartzSort,
         Sorts with the help of the $(LUCKY Schwartzian transform).)
 $(T2 sort,

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2813,6 +2813,10 @@ schwartzSort(alias transform, alias less = "a < b",
     arr[2] = highEnt;
 
     schwartzSort!(entropy, q{a > b})(arr);
+
+    assert(arr[0] == highEnt);
+    assert(arr[1] == midEnt);
+    assert(arr[2] == lowEnt);
     assert(isSorted!("a > b")(map!(entropy)(arr)));
 }
 
@@ -2843,6 +2847,10 @@ schwartzSort(alias transform, alias less = "a < b",
     arr[2] = highEnt;
 
     schwartzSort!(entropy, q{a < b})(arr);
+
+    assert(arr[0] == lowEnt);
+    assert(arr[1] == midEnt);
+    assert(arr[2] == highEnt);
     assert(isSorted!("a < b")(map!(entropy)(arr)));
 }
 


### PR DESCRIPTION
New algorithm `pivotPartition`. I considered adding it as an overload to `partition` but the charter and working is sufficiently different. We should be able to use this in `sort`.