### PR TITLE
[trivial] Convert yes/no enums to std.typecons : Flag

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -102,7 +102,7 @@ import std.functional; // : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 // FIXME
-import std.typecons; // : Tuple;
+import std.typecons; // : Tuple, Flag;
 
 /++
 Checks if $(I _all) of the elements verify $(D pred).
@@ -3940,12 +3940,14 @@ private void skipAll(alias pred = "a == b", R, Es...)(ref R r, Es es)
 
 /**
 Interval option specifier for $(D until) (below) and others.
+
+If set to $(D OpenRight.yes), then the interval is open to the right
+(last element is not included).
+
+Otherwise if set to $(D OpenRight.no), then the interval is closed to the right
+(last element included).
  */
-enum OpenRight
-{
-    no, /// Interval is closed to the right (last element included)
-    yes /// Interval is open to the right (last element is not included)
-}
+alias OpenRight = Flag!"openRight";
 
 /**
 Lazily iterates $(D range) _until the element $(D e) for which

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -69,6 +69,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
  */
 module std.algorithm.sorting;
 
+import std.typecons : Flag;
 import std.algorithm.mutation : SwapStrategy;
 import std.functional; // : unaryFun, binaryFun;
 import std.range.primitives;
@@ -80,12 +81,12 @@ import std.meta; // : allSatisfy;
 /**
 Specifies whether the output of certain algorithm is desired in sorted
 format.
+
+If set to $(D SortOutput.no), the output should not be sorted.
+
+Otherwise if set to $(D SortOutput.yes), the output should be sorted.
  */
-enum SortOutput
-{
-    no,  /// Don't sort output
-    yes, /// Sort output
-}
+alias SortOutput = Flag!"sortOutput";
 
 // completeSort
 /**

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -27,6 +27,7 @@ module std.net.isemail;
 // FIXME
 import std.range.primitives; // : ElementType;
 import std.traits;
+import std.typecons : Flag;
 
 /**
  * Check that an email address conforms to RFCs 5321, 5322 and others.
@@ -1249,15 +1250,14 @@ unittest
     //     ` (OpenDNS does this, for instance).`); // DNS check is currently not implemented
 }
 
-/// Enum for indicating if the isEmail function should perform a DNS check or not.
-enum CheckDns
-{
-    /// Does not perform DNS checking
-    no,
-
-    /// Performs DNS checking
-    yes
-}
+/**
+ * Flag for indicating if the isEmail function should perform a DNS check or not.
+ *
+ * If set to $(D CheckDns.no), isEmail does not perform DNS checking.
+ *
+ * Otherwise if set to $(D CheckDns.yes), isEmail performs DNS checking.
+ */
+alias CheckDns = Flag!"checkDns";
 
 /// This struct represents the status of an email address
 struct EmailStatus


### PR DESCRIPTION
From looking at these enums it seems they can only be yes/no enums, so for the sake of being able to use Yes and No structs at the call site I changed these to be Flags.

Here's a relevant forum post from me: https://forum.dlang.org/post/dsveniziykybybgpfgnp@forum.dlang.org