### PR TITLE
Optimized sort, 4%-8% speed improvements

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1352,15 +1352,30 @@ private void shortSort(alias less, Range)(Range r)
     }
 }
 
+@safe unittest
+{
+    import std.random : Random, uniform;
+
+    debug(std_algorithm) scope(success)
+        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
+
+    auto rnd = Random(1);
+    auto a = new int[uniform(100, 200, rnd)];
+    foreach (ref e; a)
+    {
+        e = uniform(-100, 100, rnd);
+    }
+
+    shortSort!(binaryFun!("a < b"), int[])(a);
+    assert(isSorted(a));
+}
+
 /*
 Sorts the first 5 elements exactly of range r.
 */
 private void sort5(alias lt, Range)(Range r)
 {
     assert(r.length >= 5);
-    version(unittest) scope(success)
-        assert(!lt(r[1], r[0]) && !lt(r[2], r[1])
-            && !lt(r[3], r[2]) && !lt(r[4], r[3]));
 
     import std.algorithm : swapAt;
 
@@ -1411,20 +1426,16 @@ private void sort5(alias lt, Range)(Range r)
 
 @safe unittest
 {
-    import std.random : Random, uniform;
+    import std.algorithm.iteration : permutations;
+    import std.algorithm.mutation : copy;
 
-    debug(std_algorithm) scope(success)
-        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
-
-    auto rnd = Random(1);
-    auto a = new int[uniform(100, 200, rnd)];
-    foreach (ref e; a)
+    int[5] buf;
+    foreach (per; iota(5).permutations)
     {
-        e = uniform(-100, 100, rnd);
+        per.copy(buf[]);
+        sort5!((a, b) => a < b)(buf[]);
+        assert(buf[].isSorted);
     }
-
-    shortSort!(binaryFun!("a < b"), int[])(a);
-    assert(isSorted(a));
 }
 
 // sort

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1326,16 +1326,16 @@ private void shortSort(alias less, Range)(Range r)
                 auto t = r[0]; if (pred(t, r[0])) r[0] = r[0];
             }))) // Can we afford to temporarily invalidate the array?
         {
-            size_t j = i + 1;
-            if (pred(r[j], r[i]))
+            size_t j = i;
+            if (pred(r[j + 1], r[j]))
             {
-                auto temp = r[i];
+                auto temp = r[j];
                 do
                 {
-                    r[j - 1] = r[j];
+                    r[j] = r[j + 1];
                 }
-                while (++j < r.length && pred(r[j], temp));
-                r[j - 1] = temp;
+                while (++j + 1 < r.length && pred(r[j + 1], temp));
+                r[j] = temp;
             }
         }
         else

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1358,54 +1358,53 @@ Sorts the first 5 elements exactly of range r.
 private void sort5(alias lt, Range)(Range r)
 {
     assert(r.length >= 5);
-    enum a = 0, b = 1, c = 2, d = 3, e = 4;
     version(unittest) scope(success)
-        assert(!lt(r[b], r[a]) && !lt(r[c], r[b])
-            && !lt(r[d], r[c]) && !lt(r[e], r[d]));
+        assert(!lt(r[1], r[0]) && !lt(r[2], r[1])
+            && !lt(r[3], r[2]) && !lt(r[4], r[3]));
 
     import std.algorithm : swapAt;
 
     // 1. Sort first two pairs
-    if (lt(r[b], r[a])) r.swapAt(a, b);
-    if (lt(r[d], r[c])) r.swapAt(c, d);
+    if (lt(r[1], r[0])) r.swapAt(0, 1);
+    if (lt(r[3], r[2])) r.swapAt(2, 3);
 
     // 2. Arrange first two pairs by the largest element
-    if (lt(r[d], r[b]))
+    if (lt(r[3], r[1]))
     {
-        r.swapAt(a, c);
-        r.swapAt(b, d);
+        r.swapAt(0, 2);
+        r.swapAt(1, 3);
     }
-    assert(!lt(r[b], r[a]) && !lt(r[d], r[b]) && !lt(r[d], r[c]));
+    assert(!lt(r[1], r[0]) && !lt(r[3], r[1]) && !lt(r[3], r[2]));
 
-    // 3. Insert e into [a, b, d]
-    if (lt(r[e], r[b]))
+    // 3. Insert 4 into [0, 1, 3]
+    if (lt(r[4], r[1]))
     {
-        r.swapAt(d, e);
-        r.swapAt(b, d);
-        if (lt(r[b], r[a]))
+        r.swapAt(3, 4);
+        r.swapAt(1, 3);
+        if (lt(r[1], r[0]))
         {
-            r.swapAt(a, b);
+            r.swapAt(0, 1);
         }
     }
-    else if (lt(r[e], r[d]))
+    else if (lt(r[4], r[3]))
     {
-        r.swapAt(d, e);
+        r.swapAt(3, 4);
     }
-    assert(!lt(r[b], r[a]) && !lt(r[d], r[b]) && !lt(r[e], r[d]));
+    assert(!lt(r[1], r[0]) && !lt(r[3], r[1]) && !lt(r[4], r[3]));
 
-    // 4. Insert c into [a, b, d, e] (note: we already know the last is greater)
-    assert(!lt(r[e], r[c]));
-    if (lt(r[c], r[b]))
+    // 4. Insert 2 into [0, 1, 3, 4] (note: we already know the last is greater)
+    assert(!lt(r[4], r[2]));
+    if (lt(r[2], r[1]))
     {
-        r.swapAt(b, c);
-        if (lt(r[b], r[a]))
+        r.swapAt(1, 2);
+        if (lt(r[1], r[0]))
         {
-            r.swapAt(a, b);
+            r.swapAt(0, 1);
         }
     }
-    else if (lt(r[d], r[c]))
+    else if (lt(r[3], r[2]))
     {
-        r.swapAt(c, d);
+        r.swapAt(2, 3);
     }
     // 7 comparisons, 0-9 swaps
 }

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1326,16 +1326,17 @@ private void shortSort(alias less, Range)(Range r)
                 auto t = r[0]; if (pred(t, r[0])) r[0] = r[0];
             }))) // Can we afford to temporarily invalidate the array?
         {
-            size_t j = i;
-            if (pred(r[j + 1], r[j]))
+            size_t j = i + 1;
+            auto temp = r[i];
+            if (pred(r[j], temp))
             {
-                auto temp = r[j];
                 do
                 {
-                    r[j] = r[j + 1];
+                    r[j - 1] = r[j];
+                    ++j;
                 }
-                while (++j + 1 < r.length && pred(r[j + 1], temp));
-                r[j] = temp;
+                while (j < r.length && pred(r[j], temp));
+                r[j - 1] = temp;
             }
         }
         else

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1311,7 +1311,7 @@ private void shortSort(alias less, Range)(Range r)
             if (pred(r[2], r[1])) r.swapAt(1, 2);
             return;
         default:
-            sort5!pred(r[$ - 5 .. $]);
+            sort5!pred(r[r.length - 5 .. r.length]);
             if (r.length == 5) return;
             break;
     }


### PR DESCRIPTION
This introduces specialized routines for short arrays, which are the end game of quicksort. This allows being more aggressive with the small data threshold. Results show a 4% improvement for sorting large arrays of random doubles and 8% improvement for sorting real-world 1-gram frequencies (column 2 in the dataset https://issues.dlang.org/show_bug.cgi?id=16517).