### PR TITLE
[TRIVIAL] Remove last use of implicit string concatenation

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -290,7 +290,7 @@ version(unittest)
     {
         return "HTTP/1.1 200 OK\r\n"~
             "Content-Type: text/plain\r\n"~
-            "Content-Length: "~msg.length.to!string~"\r\n"
+            "Content-Length: "~msg.length.to!string~"\r\n"~
             "\r\n"~
             msg;
     }


### PR DESCRIPTION
This feature will hopefully be deprecated soon.