### PR TITLE
reduce ndslice template bloat

### DIFF
--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -334,42 +334,6 @@ enum indexError(size_t pos, size_t N) =
     ~ " from the range [0 .." ~ N.stringof ~ ")"
     ~ " must be less than corresponding length.";
 
-enum indexStrideCode = q{
-    static if (_indexes.length)
-    {
-        size_t stride = _strides[0] * _indexes[0];
-        assert(_indexes[0] < _lengths[0], indexError!(0, N));
-        foreach (i; Iota!(1, N)) //static
-        {
-            assert(_indexes[i] < _lengths[i], indexError!(i, N));
-            stride += _strides[i] * _indexes[i];
-        }
-        return stride;
-    }
-    else
-    {
-        return 0;
-    }
-};
-
-enum mathIndexStrideCode = q{
-    static if (_indexes.length)
-    {
-        size_t stride = _strides[0] * _indexes[N - 1];
-        assert(_indexes[N - 1] < _lengths[0], indexError!(N - 1, N));
-        foreach_reverse (i; Iota!(0, N - 1)) //static
-        {
-            assert(_indexes[i] < _lengths[N - 1 - i], indexError!(i, N));
-            stride += _strides[N - 1 - i] * _indexes[i];
-        }
-        return stride;
-    }
-    else
-    {
-        return 0;
-    }
-};
-
 enum string tailErrorMessage(
     string fun = __FUNCTION__,
     string pfun = __PRETTY_FUNCTION__) =

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -477,6 +477,8 @@ private bool isValidPartialPermutationImpl(size_t N)(in size_t[] perm, ref int[N
     return true;
 }
 
+enum toSize_t(size_t i) = i;
+enum isSize_t(alias i) = is(typeof(i) == size_t);
 enum isIndex(I) = is(I : size_t);
 enum is_Slice(S) = is(S : _Slice);
 

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -329,7 +329,7 @@ Returns:
     n-dimensional slice of the same type
 See_also: $(LREF swapped), $(LREF transposed)
 +/
-Slice!(N, Range) everted(size_t N, Range)(auto ref Slice!(N, Range) slice)
+Slice!(N, Range) everted(size_t N, Range)(Slice!(N, Range) slice)
 {
     mixin _DefineRet;
     with (slice)
@@ -378,7 +378,7 @@ private enum _transposedCode = q{
     }
 };
 
-private size_t[N] completeTranspose(size_t N)(in size_t[] dimensions)
+private size_t[N] completeTranspose(size_t N)(size_t[] dimensions)
 {
     assert(dimensions.length <= N);
     size_t[N] ctr;
@@ -410,7 +410,7 @@ See_also: $(LREF swapped), $(LREF everted)
 template transposed(Dimensions...)
     if (Dimensions.length)
 {
-    @fmb Slice!(N, Range) transposed(size_t N, Range)(auto ref Slice!(N, Range) slice)
+    @fmb Slice!(N, Range) transposed(size_t N, Range)(Slice!(N, Range) slice)
     {
         mixin DimensionsCountCTError;
         foreach (i, dimension; Dimensions)
@@ -425,22 +425,7 @@ template transposed(Dimensions...)
 }
 
 ///ditto
-Slice!(N, Range) transposed(size_t N, Range)(auto ref Slice!(N, Range) slice, size_t dimension)
-in
-{
-    mixin (DimensionRTError);
-}
-body
-{
-    size_t[1] permutation = void;
-    permutation[0] = dimension;
-    immutable perm = completeTranspose!N(permutation);
-    assert(perm.isPermutation, __PRETTY_FUNCTION__  ~ ": internal error.");
-    mixin (_transposedCode);
-}
-
-///ditto
-Slice!(N, Range) transposed(size_t N, Range)(auto ref Slice!(N, Range) slice, in size_t[] dimensions...)
+Slice!(N, Range) transposed(size_t N, Range, size_t M)(Slice!(N, Range) slice, size_t[M] dimensions...)
 in
 {
     mixin (DimensionsCountRTError);
@@ -458,7 +443,7 @@ body
 }
 
 ///ditto
-Slice!(2, Range) transposed(Range)(auto ref Slice!(2, Range) slice)
+Slice!(2, Range) transposed(Range)(Slice!(2, Range) slice)
 {
     return .transposed!(1, 0)(slice);
 }
@@ -564,19 +549,7 @@ template reversed(Dimensions...)
 }
 
 ///ditto
-Slice!(N, Range) reversed(size_t N, Range)(Slice!(N, Range) slice, size_t dimension)
-in
-{
-    mixin (DimensionRTError);
-}
-body
-{
-    mixin (_reversedCode);
-    return slice;
-}
-
-///ditto
-Slice!(N, Range) reversed(size_t N, Range)(Slice!(N, Range) slice, in size_t[] dimensions...)
+Slice!(N, Range) reversed(size_t N, Range, size_t M)(Slice!(N, Range) slice, size_t[M] dimensions...)
 in
 {
     foreach (dimension; dimensions)
@@ -584,8 +557,11 @@ in
 }
 body
 {
-    foreach (dimension; dimensions)
+    foreach (i; Iota!(0, M))
+    {
+        auto dimension = dimensions[i];
         mixin (_reversedCode);
+    }
     return slice;
 }
 
@@ -904,19 +880,7 @@ template dropOne(Dimensions...)
 }
 
 ///ditto
-Slice!(N, Range) dropOne(size_t N, Range)(Slice!(N, Range) slice, size_t dimension)
-in
-{
-    mixin (DimensionRTError);
-}
-body
-{
-    slice.popFront(dimension);
-    return slice;
-}
-
-///ditto
-Slice!(N, Range) dropOne(size_t N, Range)(Slice!(N, Range) slice, in size_t[] dimensions...)
+Slice!(N, Range) dropOne(size_t N, Range, size_t M)(Slice!(N, Range) slice, size_t[M] dimensions...)
 in
 {
     foreach (dimension; dimensions)
@@ -924,8 +888,11 @@ in
 }
 body
 {
-    foreach (dimension; dimensions)
+    foreach (i; Iota!(0, M))
+    {
+        auto dimension = dimensions[i];
         slice.popFront(dimension);
+    }
     return slice;
 }
 
@@ -945,19 +912,7 @@ template dropBackOne(Dimensions...)
 }
 
 ///ditto
-Slice!(N, Range) dropBackOne(size_t N, Range)(Slice!(N, Range) slice, size_t dimension)
-in
-{
-    mixin (DimensionRTError);
-}
-body
-{
-    slice.popBack(dimension);
-    return slice;
-}
-
-///ditto
-Slice!(N, Range) dropBackOne(size_t N, Range)(Slice!(N, Range) slice, in size_t[] dimensions...)
+Slice!(N, Range) dropBackOne(size_t N, Range, size_t M)(Slice!(N, Range) slice, size_t[M] dimensions...)
 in
 {
     foreach (dimension; dimensions)
@@ -965,8 +920,11 @@ in
 }
 body
 {
-    foreach (dimension; dimensions)
+    foreach (i; Iota!(0, M))
+    {
+        auto dimension = dimensions[i];
         slice.popBack(dimension);
+    }
     return slice;
 }
 

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -410,6 +410,9 @@ See_also: $(LREF swapped), $(LREF everted)
 template transposed(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias transposed = .transposed!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) transposed(size_t N, Range)(Slice!(N, Range) slice)
     {
         mixin DimensionsCountCTError;
@@ -537,6 +540,9 @@ Returns:
 template reversed(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias reversed = .reversed!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb auto reversed(size_t N, Range)(Slice!(N, Range) slice)
     {
         foreach (i, dimension; Dimensions)
@@ -642,6 +648,9 @@ Returns:
 template strided(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias strided = .strided!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb auto strided(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) factors)
     body
     {
@@ -868,6 +877,9 @@ Returns:
 template dropOne(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias dropOne = .dropOne!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) dropOne(size_t N, Range)(Slice!(N, Range) slice)
     {
         foreach (i, dimension; Dimensions)
@@ -900,6 +912,9 @@ body
 template dropBackOne(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias dropBackOne = .dropBackOne!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) dropBackOne(size_t N, Range)(Slice!(N, Range) slice)
     {
         foreach (i, dimension; Dimensions)
@@ -987,6 +1002,9 @@ Returns:
 template dropExactly(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias dropExactly = .dropExactly!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) dropExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
@@ -1015,6 +1033,9 @@ body
 template dropBackExactly(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias dropBackExactly = .dropBackExactly!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) dropBackExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
@@ -1076,6 +1097,9 @@ Returns:
 template drop(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias drop = .drop!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) drop(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
@@ -1104,6 +1128,9 @@ body
 template dropBack(Dimensions...)
     if (Dimensions.length)
 {
+    static if (!allSatisfy!(isSize_t, Dimensions))
+        alias dropBack = .dropBack!(staticMap!(toSize_t, Dimensions));
+    else
     @fmb Slice!(N, Range) dropBack(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -75,6 +75,9 @@ Returns:
 +/
 template pack(K...)
 {
+    static if (!allSatisfy!(isSize_t, K))
+        alias pack = .pack!(staticMap!(toSize_t, K));
+    else
     @fmb auto pack(size_t N, Range)(Slice!(N, Range) slice)
     {
         template Template(size_t NInner, Range, R...)

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -75,7 +75,7 @@ Returns:
 +/
 template pack(K...)
 {
-    @fmb auto pack(size_t N, Range)(auto ref Slice!(N, Range) slice)
+    @fmb auto pack(size_t N, Range)(Slice!(N, Range) slice)
     {
         template Template(size_t NInner, Range, R...)
         {
@@ -174,7 +174,7 @@ Returns:
 
 See_also: $(LREF pack), $(LREF evertPack)
 +/
-Slice!(N, Range).PureThis unpack(size_t N, Range)(auto ref Slice!(N, Range) slice)
+Slice!(N, Range).PureThis unpack(size_t N, Range)(Slice!(N, Range) slice)
 {
     with (slice) return PureThis(_lengths, _strides, _ptr);
 }
@@ -200,7 +200,7 @@ Returns:
 See_also: $(LREF pack), $(LREF unpack)
 +/
 SliceFromSeq!(Slice!(N, Range).PureRange, NSeqEvert!(Slice!(N, Range).NSeq))
-evertPack(size_t N, Range)(auto ref Slice!(N, Range) slice)
+evertPack(size_t N, Range)(Slice!(N, Range) slice)
 {
     mixin _DefineRet;
     static assert(Ret.NSeq.length > 0);
@@ -294,7 +294,7 @@ Params:
 Returns:
     1-dimensional slice composed of diagonal elements
 +/
-Slice!(1, Range) diagonal(size_t N, Range)(auto ref Slice!(N, Range) slice)
+Slice!(1, Range) diagonal(size_t N, Range)(Slice!(N, Range) slice)
 {
     auto NewN = slice.PureN - N + 1;
     mixin _DefineRet;
@@ -472,8 +472,7 @@ Params:
 Returns:
     packed `N`-dimensional slice composed of `N`-dimensional slices
 +/
-Slice!(N, Slice!(N+1, Range)) blocks(size_t N, Range, Lengths...)(auto ref Slice!(N, Range) slice, Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths) && Lengths.length == N)
+Slice!(N, Slice!(N+1, Range)) blocks(size_t N, Range)(Slice!(N, Range) slice, size_t[N] lengths...)
 in
 {
     foreach (i, length; lengths)
@@ -594,8 +593,7 @@ Params:
 Returns:
     packed `N`-dimensional slice composed of `N`-dimensional slices
 +/
-Slice!(N, Slice!(N+1, Range)) windows(size_t N, Range, Lengths...)(auto ref Slice!(N, Range) slice, Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths) && Lengths.length == N)
+Slice!(N, Slice!(N+1, Range)) windows(size_t N, Range)(Slice!(N, Range) slice, size_t[N] lengths...)
 in
 {
     foreach (i, length; lengths)
@@ -721,11 +719,10 @@ Returns:
 Throws:
     $(LREF ReshapeException) if the slice cannot be reshaped with the input lengths.
 +/
-Slice!(Lengths.length, Range)
+Slice!(M, Range)
     reshape
-        (         size_t N, Range       , Lengths...     )
-        (auto ref Slice!(N, Range) slice, Lengths lengths)
-    if ( allSatisfy!(isIndex, Lengths) && Lengths.length)
+        (size_t N, Range, size_t M)
+        (Slice!(N, Range) slice, size_t[M] lengths...)
 {
     mixin _DefineRet;
     foreach (i; Iota!(0, ret.N))
@@ -821,14 +818,13 @@ pure unittest
     import std.experimental.ndslice.iteration : reversed;
     import std.array : array;
 
-    auto reshape2(S, L...)(S slice, L lengths)
+    auto reshape2(S, size_t M)(S slice, size_t[M] lengths...)
     {
         // Tries to reshape without allocation
         try return slice.reshape(lengths);
         catch (ReshapeException e)
-            //allocates the elements and creates a slice
-            //Note: -1 length is not supported by reshape2
-            return slice.byElement.array.sliced(lengths);
+            // Allocates
+            return slice.slice.reshape(lengths);
     }
 
     auto slice =
@@ -923,7 +919,7 @@ Params:
 Returns:
     random access range composed of elements of the `slice`
 +/
-auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
+auto byElement(size_t N, Range)(Slice!(N, Range) slice)
 {
     with (Slice!(N, Range))
     {
@@ -1177,7 +1173,7 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
 }
 
 /// ditto
-Slice!(1, Range) byElement(size_t N : 1, Range)(auto ref Slice!(N, Range) slice)
+Slice!(1, Range) byElement(size_t N : 1, Range)(Slice!(N, Range) slice)
 {
     return slice;
 }
@@ -1430,7 +1426,7 @@ Params:
 Returns:
     forward range composed of all elements of standard simplex of the `slice`
 +/
-auto byElementInStandardSimplex(size_t N, Range)(auto ref Slice!(N, Range) slice, size_t maxHypercubeLength = size_t.max)
+auto byElementInStandardSimplex(size_t N, Range)(Slice!(N, Range) slice, size_t maxHypercubeLength = size_t.max)
 {
     with (Slice!(N, Range))
     {
@@ -1518,7 +1514,7 @@ auto byElementInStandardSimplex(size_t N, Range)(auto ref Slice!(N, Range) slice
 }
 
 /// ditto
-Slice!(1, Range) byElementInStandardSimplex(size_t N : 1, Range)(auto ref Slice!(N, Range) slice, size_t maxHypercubeLength = size_t.max)
+Slice!(1, Range) byElementInStandardSimplex(size_t N : 1, Range)(Slice!(N, Range) slice, size_t maxHypercubeLength = size_t.max)
 {
     if (maxHypercubeLength > slice._lengths[0])
         maxHypercubeLength = slice._lengths[0];
@@ -1617,14 +1613,7 @@ Returns:
     `N`-dimensional slice composed of indexes
 See_also: $(LREF IndexSlice), $(LREF iotaSlice)
 +/
-IndexSlice!(Lengths.length) indexSlice(Lengths...)(Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths))
-{
-    return .indexSlice!(Lengths.length)([lengths]);
-}
-
-///ditto
-IndexSlice!N indexSlice(size_t N)(auto ref size_t[N] lengths)
+IndexSlice!N indexSlice(size_t N)(size_t[N] lengths...)
 {
     import std.experimental.ndslice.slice : sliced;
     with (typeof(return)) return Range(lengths[1 .. $]).sliced(lengths);
@@ -1715,21 +1704,20 @@ Returns:
     `N`-dimensional slice composed of indexes
 See_also: $(LREF IotaSlice), $(LREF indexSlice)
 +/
-IotaSlice!(Lengths.length) iotaSlice(Lengths...)(Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths))
+IotaSlice!N iotaSlice(size_t N)(size_t[N] lengths...)
 {
-    return .iotaSlice!(Lengths.length)([lengths]);
+    return .iotaSlice(lengths, 0);
 }
 
 ///ditto
-IotaSlice!N iotaSlice(size_t N)(auto ref size_t[N] lengths, size_t shift = 0)
+IotaSlice!N iotaSlice(size_t N)(size_t[N] lengths, size_t shift)
 {
     import std.experimental.ndslice.slice : sliced;
     return IotaMap!().init.sliced(lengths, shift);
 }
 
 ///ditto
-IotaSlice!N iotaSlice(size_t N)(auto ref size_t[N] lengths, size_t shift, size_t step)
+IotaSlice!N iotaSlice(size_t N)(size_t[N] lengths, size_t shift, size_t step)
 {
     auto iota = iotaSlice(lengths, shift);
     foreach (i; Iota!(0, N))
@@ -1806,8 +1794,8 @@ Returns:
     `n`-dimensional slice composed of identical values, where `n` is dimension count.
 See_also: $(REF repeat, std,range)
 +/
-RepeatSlice!(Lengths.length, T) repeatSlice(T, Lengths...)(T value, Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths) && !is(T : Slice!(N, Range), size_t N, Range))
+RepeatSlice!(M, T) repeatSlice(T, size_t M)(T value, size_t[M] lengths...)
+    if (!is(T : Slice!(N, Range), size_t N, Range))
 {
     typeof(return) ret;
     foreach (i; Iota!(0, ret.N))
@@ -1817,10 +1805,8 @@ RepeatSlice!(Lengths.length, T) repeatSlice(T, Lengths...)(T value, Lengths leng
 }
 
 /// ditto
-Slice!(Lengths.length, Slice!(N + 1, Range)) repeatSlice(size_t N, Range, Lengths...)(auto ref Slice!(N, Range) slice, Lengths lengths)
-    if (allSatisfy!(isIndex, Lengths) && Lengths.length)
+Slice!(M, Slice!(N + 1, Range)) repeatSlice(size_t N, Range, size_t M)(Slice!(N, Range) slice, size_t[M] lengths...)
 {
-    enum M = Lengths.length;
     typeof(return) ret;
     ret._ptr = slice._ptr;
     foreach (i; Iota!(0, M))
@@ -1975,7 +1961,7 @@ template mapSlice(fun...)
 {
     ///
     @fmb auto mapSlice(size_t N, Range)
-        (auto ref Slice!(N, Range) tensor)
+        (Slice!(N, Range) tensor)
     {
         // this static if-else block
         // may be unified with std.algorithms.iteration.map


### PR DESCRIPTION
There are 2 commits with different template bloat optimizations. `auto ref` was also removed.
This PR follows suggestions from @aG0aep6G and @timotheecour  from the thread http://forum.dlang.org/thread/njcoyysqeqhbejxperyv@forum.dlang.org?page=1