### PR TITLE
Use medianOf 3 and 5 to estimate pivot

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1764,7 +1764,8 @@ unittest
 
     // This should get smaller with time. On occasion it may go larger, but only
     // if there's thorough justification.
-    enum uint watermark = 1676220;
+    debug enum uint watermark = 1676280;
+    else enum uint watermark = 1676220;
 
     import std.conv;
     assert(comps <= watermark, text("You seem to have pessimized sort! ",


### PR DESCRIPTION
This is a clean redo of https://github.com/dlang/phobos/pull/3922, which I'll close. Two ideas here:

1. Use the new medianOf functions to take the median of 3/5 as a pivot heuristic
2. Add a unittest that counts total comparisons so we don't regress performance
