### PR TITLE
fix a link and typo in the changelog

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -185,7 +185,7 @@ $(LI $(LNAME2 slice_ptr, `ptr` property and public constructor were added to
         `ptr` property is used in $(LINK2 https://github.com/libmir/mir, Mir)
         for $(LINK2 http://docs.mir.dlang.io/latest/mir_sparse_package.html, sparse tensors).
         `ndslice` developer mirror in Mir will be removed as
-        soon as LDC (LLVM D compiler) supports D version 2.072..
+        soon as LDC (LLVM D compiler) supports D version 2.072.
     )
     $(P Public constructor for `Slice` was added to support
         $(MREF std,experimental,ndslice) integration
@@ -193,7 +193,7 @@ $(LI $(LNAME2 slice_ptr, `ptr` property and public constructor were added to
     )
 )
 
-$(LI $(LNAME2 slice_toHash, $(P $(REF .Slice.toHash, std,experimental,ndslice,slice) method was added.)
+$(LI $(LNAME2 slice_toHash, $(P $(REF Slice.toHash, std,experimental,ndslice,slice) method was added.)
 ---
 import std.experimental.ndslice;
 


### PR DESCRIPTION
@MartinNowak First, I wanted to add this into stable. But stable changelog is empty