### PR TITLE
Ensure std.file.exists(StringEnum.name) compiles.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1481,6 +1481,11 @@ private bool existsImpl(const(FSChar)* namez) @trusted nothrow @nogc
     assert(exists(deleteme));
 }
 
+@safe unittest // Bugzilla 16573
+{
+    enum S : string { foo = "foo" }
+    assert(__traits(compiles, S.foo.exists));
+}
 
 /++
  Returns the attributes of the given file.

--- a/std/traits.d
+++ b/std/traits.d
@@ -5332,7 +5332,7 @@ enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) &&
 
 
 /**
- * Detect whether $(D T) is a struct or static array that is implicitly
+ * Detect whether $(D T) is a struct, static array, or enum that is implicitly
  * convertible to a string.
  */
 template isConvertibleToString(T)
@@ -5350,9 +5350,14 @@ template isConvertibleToString(T)
         string s;
         alias s this;
     }
+
+    enum StringEnum { a = "foo" }
+
     assert(!isConvertibleToString!string);
     assert(isConvertibleToString!AliasedString);
+    assert(isConvertibleToString!StringEnum);
     assert(isConvertibleToString!(char[25]));
+    assert(!isConvertibleToString!(char[]));
 }
 
 @safe unittest // Bugzilla 16573

--- a/std/traits.d
+++ b/std/traits.d
@@ -5336,7 +5336,9 @@ convertible to a string.
  */
 template isConvertibleToString(T)
 {
-    enum isConvertibleToString = (isAggregateType!T || isStaticArray!T) && is(StringTypeOf!T);
+    enum isConvertibleToString =
+        (isAggregateType!T || isStaticArray!T || is(T == enum))
+        && is(StringTypeOf!T);
 }
 
 @safe unittest
@@ -5349,6 +5351,14 @@ template isConvertibleToString(T)
     assert(!isConvertibleToString!string);
     assert(isConvertibleToString!AliasedString);
     assert(isConvertibleToString!(char[25]));
+}
+
+@safe unittest // Bugzilla 16573
+{
+    enum I : int { foo = 1 }
+    enum S : string { foo = "foo" }
+    assert(!isConvertibleToString!I);
+    assert(isConvertibleToString!S);
 }
 
 package template convertToString(T)

--- a/std/traits.d
+++ b/std/traits.d
@@ -92,6 +92,7 @@
  *           $(LREF isFloatingPoint)
  *           $(LREF isIntegral)
  *           $(LREF isNarrowString)
+ *           $(LREF isConvertibleToString)
  *           $(LREF isNumeric)
  *           $(LREF isPointer)
  *           $(LREF isScalarType)
@@ -5330,9 +5331,9 @@ enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) &&
 }
 
 
-/*
-Detect whether $(D T) is a struct or static array that is implicitly
-convertible to a string.
+/**
+ * Detect whether $(D T) is a struct or static array that is implicitly
+ * convertible to a string.
  */
 template isConvertibleToString(T)
 {
@@ -5341,6 +5342,7 @@ template isConvertibleToString(T)
         && is(StringTypeOf!T);
 }
 
+///
 @safe unittest
 {
     static struct AliasedString


### PR DESCRIPTION
A string-typed enum passes isSomeString but not isConvertibleToString.
Because isConvertibleToString is used as a template constraint for
std.file.exists, it could not be passed a string-typed enum.

Resolves [#16573](https://issues.dlang.org/show_bug.cgi?id=16573).

Also see [the forum discussion](http://forum.dlang.org/thread/zjkxomchxheycsgpevzh@forum.dlang.org).

@jmdavis 
