### PR TITLE
Avoid GC Allocations in sharedStaticDtor

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -976,9 +976,7 @@ private final class ParallelismThread : Thread
 // Kill daemon threads.
 shared static ~this()
 {
-    auto allThreads = Thread.getAll();
-
-    foreach (thread; allThreads)
+    foreach (ref thread; Thread)
     {
         auto pthread = cast(ParallelismThread) thread;
         if (pthread is null) continue;


### PR DESCRIPTION
The `Thread.opApply` static method will use `realloc` from `core.stdc.stdlib` instead of `gc.gc.GC.malloc` which sometimes fails with `onInvalidMemoryOperationError` when run within a `static ~this` module dtor

```
(gdb) bt
#0  0x00007f17edd2a9c8 in raise () from /lib64/libc.so.6
#1  0x00007f17edd2c65a in abort () from /lib64/libc.so.6
#2  0x0000000001352f5e in _d_throwdwarf ()
#3  0x00000000013d0a69 in onInvalidMemoryOperationError ()
#4  0x00000000013b832e in gc.gc.GC.runLocked!(_D2gc2gc2GC12mallocNoSyncMFNbmkKmxC8TypeInfoZPv, _D2gc2gc10mallocTimel, _D2gc2gc10numMallocsl, ulong, uint, ulong, const(TypeInfo)).runLocked(ref ulong, ref uint, ref ulong, ref const(TypeInfo)) ()
#5  0x00000000013b1c8a in gc.gc.GC.malloc(ulong, uint, ulong*, const(TypeInfo)) ()
#6  0x0000000001350be3 in gc_qalloc ()
#7  0x00000000013bac21 in rt.lifetime.__arrayAlloc(ulong, const(TypeInfo), const(TypeInfo)) ()
#8  0x0000000001355959 in _d_arraysetlengthT ()
#9  0x00000000013b0bd2 in core.thread.Thread.getAllImpl!(_D4core6thread6Thread6getAllFZ6resizeFKAC4core6thread6ThreadmZv).getAllImpl() ()
#10 0x00000000013b06dd in core.thread.Thread.getAll() ()
#11 0x000000000137d909 in std.parallelism._sharedStaticDtor1444() ()
#12 0x000000000137d9c1 in std.parallelism.__modshareddtor() ()
#13 0x00000000013bbd57 in _D2rt5minfo70__T17runModuleFuncsRevS442rt5minfo11ModuleGroup8runDtorsMFZ9__lambda1Z17runModuleFuncsRevMFAxPyS6object10ModuleInfoZv ()
#14 0x00000000013bb89d in rt.minfo.ModuleGroup.runDtors() ()
#15 0x000000000135865d in _d_dso_registry ()
#16 0x0000000000f50e4c in ?? ()
#17 0x0000000000000001 in ?? ()
#18 0x0000000001677970 in ?? ()
#19 0x00000000017625d0 in ?? ()
#20 0x0000000001763408 in __start_minfo ()
#21 0x0000000001763408 in __start_minfo ()
#22 0x0000000001763408 in __start_minfo ()
#23 0x00007fff37da3670 in ?? ()
#24 0x00007f17ef536ba7 in _dl_fini () from /lib64/ld-linux-x86-64.so.2
```