### PR TITLE
Fix Issue 16571 - Unittests should not list /tmp/ recursively

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -3306,11 +3306,9 @@ void copy(RF, RT)(auto ref RF from, auto ref RT to, PreserveAttributes preserve 
     copy!Types(from, to, preserve);
 }
 
-@system unittest // issue 15319
+@safe unittest // issue 15319
 {
-    import std.file : dirEntries;
-    auto fs = dirEntries(tempDir(), SpanMode.depth);
-    assert(__traits(compiles, copy(fs.front, fs.front)));
+    assert(__traits(compiles, copy("from.txt", "to.txt")));
 }
 
 private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, const(FSChar)* toz,


### PR DESCRIPTION
I removed the call to `dirEntries` altogether, as it's not needed to make sure the function compiles. As [the original bug writeup for 15319](https://issues.dlang.org/show_bug.cgi?id=15319) shows, this test is only to make sure this function always compiles, but the original author simply copied the testcase with `dirEntries` from bugzilla.  Since that adds nothing to a simple compile check, I just removed it.

__Update:__ also marked this test as `@safe` now.