### PR TITLE
fix Issue 16580 - spawnShell segfaults on macOS

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -216,7 +216,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix			\
 	std/internal/digest/, sha_SSSE3 ) $(addprefix \
 	std/internal/math/, biguintcore biguintnoasm biguintx86	\
 	gammafunction errorfunction) $(addprefix std/internal/, \
-	cstring phobosinit unicode_tables scopebuffer\
+	cstring phobosinit processinit unicode_tables scopebuffer\
 	unicode_comp unicode_decomp unicode_grapheme unicode_norm) \
 	$(addprefix std/internal/test/, dummyrange) \
 	$(addprefix std/experimental/ndslice/, internal) \

--- a/std/internal/phobosinit.d
+++ b/std/internal/phobosinit.d
@@ -11,16 +11,6 @@
   +/
 module std.internal.phobosinit;
 
-version(OSX)
-{
-    extern(C) void std_process_shared_static_this();
-
-    shared static this()
-    {
-        std_process_shared_static_this();
-    }
-}
-
 shared static this()
 {
     import std.encoding : EncodingScheme;

--- a/std/internal/processinit.d
+++ b/std/internal/processinit.d
@@ -1,0 +1,22 @@
+// Written in the D programming language.
+
+/++
+    The only purpose of this module is to do the static construction for
+    std.process in order to eliminate cyclic construction errors.
+
+    Copyright: Copyright 2011 -
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Jonathan M Davis and Kato Shoichi
+    Source:    $(PHOBOSSRC std/internal/_processinit.d)
+  +/
+module std.internal.processinit;
+
+version(OSX)
+{
+    extern(C) void std_process_shared_static_this();
+
+    shared static this()
+    {
+        std_process_shared_static_this();
+    }
+}

--- a/std/process.d
+++ b/std/process.d
@@ -100,6 +100,7 @@ version (Windows)
 
 import std.range.primitives;
 import std.stdio;
+import std.internal.processinit;
 import std.internal.cstring;
 
 

--- a/win32.mak
+++ b/win32.mak
@@ -268,6 +268,7 @@ SRC_STD_C_FREEBSD= \
 SRC_STD_INTERNAL= \
 	std\internal\cstring.d \
 	std\internal\phobosinit.d \
+	std\internal\processinit.d \
 	std\internal\unicode_tables.d \
 	std\internal\unicode_comp.d \
 	std\internal\unicode_decomp.d \

--- a/win64.mak
+++ b/win64.mak
@@ -287,6 +287,7 @@ SRC_STD_C_FREEBSD= \
 SRC_STD_INTERNAL= \
 	std\internal\cstring.d \
 	std\internal\phobosinit.d \
+	std\internal\processinit.d \
 	std\internal\unicode_tables.d \
 	std\internal\unicode_comp.d \
 	std\internal\unicode_decomp.d \


### PR DESCRIPTION
- partially Revert "Merge pull request #4493 from schveiguy/fixcycles2"
- recreate processinit (and import it from std.process)
  to call std.process shared ctor w/o creating a cycle
- keep it separate from phobosinit to not drag std.encoding
  into any binary using std.process