### PR TITLE
fix gdc-dmd test - remove the workound for Issue 15316

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2660,28 +2660,7 @@ Params:
  */
 struct Nullable(T, T nullValue)
 {
-    static if (_useNanWorkaround && is(T == float) && nullValue is T.init)
-        union
-        {
-            private uint _raw = 0x7fa00000; // float.init
-            private T _value;
-        }
-    else static if (_useNanWorkaround && is(T == double) && nullValue is T.init)
-        union
-        {
-            private ulong _raw = 0x7ff4000000000000UL; // double.init
-            private T _value;
-        }
-    else
-        private T _value = nullValue;
-
-    // workaround for bug 15316
-    version (X86_64)
-        private enum _useNanWorkaround = true;
-    else version (OSX)
-        private enum _useNanWorkaround = true;
-    else
-        private enum _useNanWorkaround = false;
+    private T _value = nullValue;
 
 /**
 Constructor initializing $(D this) with $(D value).
@@ -2748,8 +2727,9 @@ Returns:
     assert(!ni.isNull);
 }
 
-// Bugzilla 11135
-unittest
+// https://issues.dlang.org/show_bug.cgi?id=11135
+// disable test until https://issues.dlang.org/show_bug.cgi?id=15316 gets fixed
+version (none) unittest
 {
     foreach (T; AliasSeq!(float, double, real))
     {


### PR DESCRIPTION
- we can't really solve Issue 15316 w/ signaling NaNs
  b/c any optimization, copying et.al. might turn signaling into
  quiet NaNs, therefor we want to solve Issue 15316 by switching
  Float.init to use quiet NaNs
- the workaround depends on a specific dmd bug (see dlang/dmd#6163)
  that looses SNaNs when writing struct initializers but keeps
  them for Float.init
- this workaround might not be portable to GDC/LDC and
  will easily break w/ slightly different dmd optimizations
  (it's responsible for the test failure of the gdc-built dmd)
- this PR will reopen https://issues.dlang.org/show_bug.cgi?id=11135

this partially reverts commit 0efa1d3bf92bcaa6c4a99cad0b574185a537906a