### PR TITLE
Fix CircleCi style checker

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -64,5 +64,11 @@ auto_ref_assignment_check="disabled" ; FIXME
 incorrect_infinite_range_check="enabled"
 ; Checks for asserts that are always true
 useless_assert_check="skip-unittest"
+; Check for uses of the old-style alias syntax
+alias_syntax_check="enabled"
+; Checks for else if that should be else static if
+static_if_else_check="enabled"
 ; Check for unclear lambda syntax
 lambda_return_check="enabled"
+; Check for auto function without return statement
+auto_function_check = "disabled"

--- a/circleci.sh
+++ b/circleci.sh
@@ -3,6 +3,7 @@
 set -uexo pipefail
 
 HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
+DSCANNER_DMD_VER=2.071.2 # dscanner needs a more up-to-date version
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 
@@ -75,8 +76,9 @@ setup_repos()
 # verify style guide
 style()
 {
-    # load dmd to build dscanner
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
+    # dscanner needs a more up-to-date DMD version
+    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
+
     make -f posix.mak style
 }
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -99,4 +99,5 @@ case $1 in
     install-deps) install_deps ;;
     coverage) coverage ;;
     setup-repos) setup_repos ;;
+    style) style ;;
 esac

--- a/posix.mak
+++ b/posix.mak
@@ -484,7 +484,7 @@ checkwhitespace: $(LIB)
 
 ../dscanner:
 	git clone https://github.com/Hackerpilot/Dscanner ../dscanner
-	git -C ../dscanner checkout tags/v0.4.0-alpha.8
+	git -C ../dscanner checkout tags/v0.4.0-beta.1
 	git -C ../dscanner submodule update --init --recursive
 
 ../dscanner/dsc: ../dscanner

--- a/posix.mak
+++ b/posix.mak
@@ -510,7 +510,7 @@ style: ../dscanner/dsc
 
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
-	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d|std/conv.d') -I.
+	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.
 
 .PHONY : auto-tester-build
 auto-tester-build: all checkwhitespace

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4586,7 +4586,7 @@ if (isInputRange!R && !isInfinite!R)
     F[64] store = void;
     size_t idx = 0;
 
-    auto collapseStore(T)(T k)
+    void collapseStore(T)(T k)
     {
         auto lastToKeep = idx - cast(uint)bsf(k+1);
         while (idx > lastToKeep)

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -737,13 +737,13 @@ void initializeAll(Range)(Range range)
         {
             for ( ; !range.empty ; range.popFront() )
             {
-                static if(__traits(isStaticArray, T))
+                static if (__traits(isStaticArray, T))
                 {
                     // static array initializer only contains initialization
                     // for one element of the static array.
                     auto elemp = cast(void *)addressOf(range.front);
                     auto endp = elemp + T.sizeof;
-                    while(elemp < endp)
+                    while (elemp < endp)
                     {
                         memcpy(elemp, p.ptr, p.length);
                         elemp += p.length;

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1364,7 +1364,7 @@ if (isInputRange!InputRange &&
     // If the haystack is a SortedRange we can use binary search to find the needle.
     // Works only for the default find predicate and any SortedRange predicate.
     // 8829 enhancement
-    import std.range: SortedRange;
+    import std.range : SortedRange;
     static if (is(InputRange : SortedRange!TT, TT) && isDefaultPred)
     {
         auto lb = haystack.lowerBound(needle);
@@ -1822,8 +1822,8 @@ if (isRandomAccessRange!R1 && hasLength!R1 && hasSlicing!R1 && isBidirectionalRa
     // of the first element of the needle in haystack.
     // When it is found O(walklength(needle)) steps are performed.
     // 8829 enhancement
-    import std.range;
-    import std.algorithm.comparison: mismatch;
+    import std.range : SortedRange;
+    import std.algorithm.comparison : mismatch;
     static if (is(R1 == R2)
             && is(R1 : SortedRange!TT, TT)
             && pred == "a == b")

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1298,8 +1298,8 @@ See_Also:
 auto setUnion(alias less = "a < b", Rs...)
 (Rs rs)
 {
-    import std.algorithm.iteration: uniq;
-    import std.algorithm.sorting: merge;
+    import std.algorithm.iteration : uniq;
+    import std.algorithm.sorting : merge;
     return merge!(less, Rs)(rs).uniq;
 }
 
@@ -1330,7 +1330,7 @@ auto setUnion(alias less = "a < b", Rs...)
 @safe unittest
 {
     // save
-    import std.range: dropOne;
+    import std.range : dropOne;
     int[] a = [0, 1, 2];
     int[] b = [0, 3];
     auto arr = a.setUnion(b);
@@ -1353,7 +1353,7 @@ auto setUnion(alias less = "a < b", Rs...)
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
-    import std.range: iota;
+    import std.range : iota;
 
     auto dummyResult1 = [1, 1.5, 2, 3, 4, 5, 5.5, 6, 7, 8, 9, 10];
     auto dummyResult2 = iota(1, 11);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1216,7 +1216,7 @@ Merge!(less, Rs) merge(alias less = "a < b", Rs...)
 @safe pure nothrow unittest
 {
     // save
-    import std.range: dropOne;
+    import std.range : dropOne;
     int[] a = [1, 2];
     int[] b = [0, 3];
     auto arr = a.merge(b);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1506,7 +1506,8 @@ private void shortSort(alias less, Range)(Range r)
     immutable maxJ = r.length - 2;
     for (size_t i = r.length - 6; ; --i)
     {
-        static if (is(typeof(() nothrow {
+        static if (is(typeof(() nothrow
+            {
                 auto t = r[0]; if (pred(t, r[0])) r[0] = r[0];
             }))) // Can we afford to temporarily invalidate the array?
         {

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1562,7 +1562,7 @@ private void sort5(alias lt, Range)(Range r)
 {
     assert(r.length >= 5);
 
-    import std.algorithm : swapAt;
+    import std.algorithm.mutation : swapAt;
 
     // 1. Sort first two pairs
     if (lt(r[1], r[0])) r.swapAt(0, 1);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -639,7 +639,7 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range)
             // Loop invariant
             version(unittest)
             {
-                import std.algorithm.searching;
+                import std.algorithm.searching : all;
                 assert(r[0 .. lo].all!(x => !lt(p, x)));
                 assert(r[hi + 1 .. r.length].all!(x => !lt(x, p)));
             }

--- a/std/array.d
+++ b/std/array.d
@@ -162,7 +162,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
     struct Foo
     {
         int a;
-        auto opAssign(Foo foo)
+        void opAssign(Foo foo)
         {
             assert(0);
         }
@@ -1055,7 +1055,7 @@ private template isInputRangeOrConvertible(E)
     assert(test([1, 2, 3, 4], 2, 23, [1, 2, 23, 3, 4]));
     assert(test([1, 2, 3, 4], 4, 24, [1, 2, 3, 4, 24]));
 
-    auto testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
+    void testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
     {
 
         auto l = to!T("hello");
@@ -2149,7 +2149,7 @@ T[] replace(T, Range)(T[] subject, size_t from, size_t to, Range stuff)
     assert(replace(a, 2, 4, filter!"true"([5, 6, 7])) == [1, 2, 5, 6, 7]);
     assert(a == [ 1, 2, 3, 4 ]);
 
-    auto testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
+    void testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
     {
 
         auto l = to!T("hello");
@@ -2370,7 +2370,7 @@ void replaceInPlace(T, Range)(ref T[] array, size_t from, size_t to, Range stuff
     assert(test([1, 2, 3, 4], 0, 2, filter!"true"([5, 6, 7]), [5, 6, 7, 3, 4]));
     assert(test([1, 2, 3, 4], 2, 4, filter!"true"([5, 6, 7]), [1, 2, 5, 6, 7]));
 
-    auto testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
+    void testStr(T, U)(string file = __FILE__, size_t line = __LINE__)
     {
 
         auto l = to!T("hello");
@@ -3057,7 +3057,7 @@ if (isDynamicArray!A)
         this.arr = arr;
     }
 
-    auto opDispatch(string fn, Args...)(Args args) if (is(typeof(mixin("impl." ~ fn ~ "(args)"))))
+    void opDispatch(string fn, Args...)(Args args) if (is(typeof(mixin("impl." ~ fn ~ "(args)"))))
     {
         // we do it this way because we can't cache a void return
         scope(exit) *this.arr = impl.data;

--- a/std/conv.d
+++ b/std/conv.d
@@ -1262,7 +1262,7 @@ body
         return cast(T)buffer[index .. $].dup;
     }
 
-    import std.array;
+    import std.array : array;
     switch (radix)
     {
         case 10:
@@ -5738,7 +5738,7 @@ if (hexData.isHexLiteral)
 @safe nothrow pure
 private auto hexStrImpl(String)(scope String hexData)
 {
-    import std.ascii;
+    import std.ascii : isHexDigit;
     alias C = Unqual!(ElementEncodingType!String);
     C[] result;
     result.length = hexData.length / 2;

--- a/std/csv.d
+++ b/std/csv.d
@@ -732,7 +732,7 @@ auto csvReader(Contents = string,
             return text.empty;
         }
 
-        auto popFront()
+        void popFront()
         {
             text.popFront();
         }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -34052,17 +34052,15 @@ static int daysToDayOfWeek(DayOfWeek currDoW, DayOfWeek dow) @safe pure nothrow
 }
 
 
-version(StdDdoc)
-{
-    /++
-        Function for starting to a stop watch time when the function is called
-        and stopping it when its return value goes out of scope and is destroyed.
+/++
+    Function for starting to a stop watch time when the function is called
+    and stopping it when its return value goes out of scope and is destroyed.
 
-        When the value that is returned by this function is destroyed,
-        $(D func) will run. $(D func) is a unary function that takes a
-        $(REF TickDuration, core,time).
+    When the value that is returned by this function is destroyed,
+    $(D func) will run. $(D func) is a unary function that takes a
+    $(REF TickDuration, core,time).
 
-        Example:
+    Example:
 --------------------
 {
     auto mt = measureTime!((TickDuration a)
@@ -34071,7 +34069,7 @@ version(StdDdoc)
 }
 --------------------
 
-        which is functionally equivalent to
+    which is functionally equivalent to
 
 --------------------
 {
@@ -34085,48 +34083,43 @@ version(StdDdoc)
 }
 --------------------
 
-        See_Also:
-            $(LREF benchmark)
-      +/
-    auto measureTime(alias func)();
-}
-else
+    See_Also:
+        $(LREF benchmark)
++/
+@safe auto measureTime(alias func)()
+    if (isSafe!((){StopWatch sw; unaryFun!func(sw.peek());}))
 {
-    @safe auto measureTime(alias func)()
-        if (isSafe!((){StopWatch sw; unaryFun!func(sw.peek());}))
+    struct Result
     {
-        struct Result
+        private StopWatch _sw = void;
+        this(AutoStart as)
         {
-            private StopWatch _sw = void;
-            this(AutoStart as)
-            {
-                _sw = StopWatch(as);
-            }
-            ~this()
-            {
-                unaryFun!(func)(_sw.peek());
-            }
+            _sw = StopWatch(as);
         }
-        return Result(Yes.autoStart);
+        ~this()
+        {
+            unaryFun!(func)(_sw.peek());
+        }
     }
+    return Result(Yes.autoStart);
+}
 
-    auto measureTime(alias func)()
-        if (!isSafe!((){StopWatch sw; unaryFun!func(sw.peek());}))
+auto measureTime(alias func)()
+    if (!isSafe!((){StopWatch sw; unaryFun!func(sw.peek());}))
+{
+    struct Result
     {
-        struct Result
+        private StopWatch _sw = void;
+        this(AutoStart as)
         {
-            private StopWatch _sw = void;
-            this(AutoStart as)
-            {
-                _sw = StopWatch(as);
-            }
-            ~this()
-            {
-                unaryFun!(func)(_sw.peek());
-            }
+            _sw = StopWatch(as);
         }
-        return Result(Yes.autoStart);
+        ~this()
+        {
+            unaryFun!(func)(_sw.peek());
+        }
     }
+    return Result(Yes.autoStart);
 }
 
 // Verify Example.

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -416,8 +416,8 @@ unittest
 
 unittest // issue 16506
 {
-    import std.experimental.allocator.gc_allocator: GCAllocator;
-    import std.experimental.allocator.mallocator: Mallocator;
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.experimental.allocator.mallocator : Mallocator;
 
     static void f(ParentAllocator)(size_t sz)
     {

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -588,7 +588,7 @@ nothrow @safe @nogc unittest
     import std.experimental.allocator.mallocator : Mallocator;
     alias alloc = Mallocator.instance;
 
-    auto test(T, Args...)(auto ref Args args)
+    void test(T, Args...)(auto ref Args args)
     {
         auto k = alloc.make!T(args);
         () @trusted { alloc.dispose(k); }();
@@ -607,7 +607,7 @@ nothrow @safe @nogc unittest
 
     alias alloc = GCAllocator.instance;
 
-    auto test(T, Args...)(auto ref Args args)
+    void test(T, Args...)(auto ref Args args)
     {
         auto k = alloc.make!T(args);
         (a) @trusted { a.dispose(k); }(alloc);

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -3080,7 +3080,7 @@ pure nothrow unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
-    auto fun(ref size_t x) { x *= 3; }
+    void fun(ref size_t x) { x *= 3; }
 
     auto tensor = iotaSlice(8, 9, 10).slice;
 

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -2195,7 +2195,7 @@ struct Slice(size_t _N, _Range)
     $(BOLD Fully defined index)
     +/
     auto ref opIndex(size_t I)(size_t[I] _indexes...)
-        if(I && I <= N)
+        if (I && I <= N)
     {
         static if (I == PureN)
             return _ptr[indexStride(_indexes)];

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -43,13 +43,13 @@ module std.parallelism;
 ///
 unittest
 {
-    import std.algorithm : map;
+    import std.algorithm.iteration : map;
     import std.range : iota;
     import std.math : approxEqual;
     import std.parallelism : taskPool;
 
     // Parallel reduce can be combined with
-    // std.algorithm.map to interesting effect.
+    // std.algorithm.iteration.map to interesting effect.
     // The following example (thanks to Russel Winder)
     // calculates pi by quadrature  using
     // std.algorithm.map and TaskPool.reduce.

--- a/std/random.d
+++ b/std/random.d
@@ -1878,7 +1878,7 @@ auto ref choice(Range, RandomGen = Random)(auto ref Range range,
 unittest
 {
     import std.algorithm.searching : canFind;
-    import std.algorith.iteration : map;
+    import std.algorithm.iteration : map;
 
     auto array = [1, 2, 3, 4, 5];
     auto elemAddr = &choice(array);

--- a/std/random.d
+++ b/std/random.d
@@ -1834,7 +1834,7 @@ auto ref choice(Range, RandomGen = Random)(auto ref Range range,
 ///
 @safe unittest
 {
-    import std.algorithm : canFind;
+    import std.algorithm.searching : canFind;
 
     auto array = [1, 2, 3, 4, 5];
     auto elem = choice(array);
@@ -1851,7 +1851,7 @@ auto ref choice(Range, RandomGen = Random)(auto ref Range range,
 
 @safe unittest
 {
-    import std.algorithm : canFind;
+    import std.algorithm.searching : canFind;
 
     class MyTestClass
     {
@@ -1864,7 +1864,7 @@ auto ref choice(Range, RandomGen = Random)(auto ref Range range,
     }
 
     MyTestClass[] testClass;
-    foreach(i; 0 .. 5)
+    foreach (i; 0 .. 5)
     {
         testClass ~= new MyTestClass(i);
     }
@@ -1877,7 +1877,8 @@ auto ref choice(Range, RandomGen = Random)(auto ref Range range,
 
 unittest
 {
-    import std.algorithm : canFind, map;
+    import std.algorithm.searching : canFind;
+    import std.algorith.iteration : map;
 
     auto array = [1, 2, 3, 4, 5];
     auto elemAddr = &choice(array);
@@ -1914,7 +1915,7 @@ void randomShuffle(Range)(Range r)
 
 @safe unittest
 {
-    import std.algorithm;
+    import std.algorithm.sorting : sort;
     foreach (RandomGen; PseudoRngTypes)
     {
         // Also tests partialShuffle indirectly.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -262,12 +262,12 @@ if (isBidirectionalRange!(Unqual!Range))
 
             static if (hasAssignableElements!R)
             {
-                @property auto front(ElementType!R val)
+                @property void front(ElementType!R val)
                 {
                     source.back = val;
                 }
 
-                @property auto back(ElementType!R val)
+                @property void back(ElementType!R val)
                 {
                     source.front = val;
                 }
@@ -539,7 +539,7 @@ body
 
             static if (hasAssignableElements!R)
             {
-                @property auto front(ElementType!R val)
+                @property void front(ElementType!R val)
                 {
                     source.front = val;
                 }
@@ -574,7 +574,7 @@ body
 
                 static if (hasAssignableElements!R)
                 {
-                    @property auto back(ElementType!R val)
+                    @property void back(ElementType!R val)
                     {
                         eliminateSlackElements();
                         source.back = val;
@@ -1911,7 +1911,7 @@ if (isInputRange!(Unqual!Range) &&
 
     static if (hasAssignableElements!R)
         /// ditto
-        @property auto front(ElementType!R v)
+        @property void front(ElementType!R v)
         {
             assert(!empty,
                 "Attempting to assign to the front of an empty "
@@ -1999,7 +1999,7 @@ if (isInputRange!(Unqual!Range) &&
         static if (hasAssignableElements!R)
         {
             /// ditto
-            @property auto back(ElementType!R v)
+            @property void back(ElementType!R v)
             {
                 // This has to return auto instead of void because of Bug 4706.
                 assert(!empty,
@@ -3364,7 +3364,7 @@ struct Cycle(R)
         static if (hasAssignableElements!R)
         {
             /// ditto
-            @property auto front(ElementType!R val)
+            @property void front(ElementType!R val)
             {
                 _original[_index] = val;
             }
@@ -3400,7 +3400,7 @@ struct Cycle(R)
         static if (hasAssignableElements!R)
         {
             /// ditto
-            auto opIndexAssign(ElementType!R val, size_t n)
+            void opIndexAssign(ElementType!R val, size_t n)
             {
                 _original[(n + _index) % _original.length] = val;
             }
@@ -5811,7 +5811,7 @@ struct FrontTransversal(Ror,
 
     static if (hasAssignableElements!RangeType)
     {
-        @property auto front(ElementType val)
+        @property void front(ElementType val)
         {
             _input.front.front = val;
         }
@@ -5868,7 +5868,7 @@ struct FrontTransversal(Ror,
 
         static if (hasAssignableElements!RangeType)
         {
-            @property auto back(ElementType val)
+            @property void back(ElementType val)
             {
                 _input.back.front = val;
             }
@@ -6127,7 +6127,7 @@ struct Transversal(Ror,
     /// Ditto
     static if (hasAssignableElements!InnerRange)
     {
-        @property auto front(E val)
+        @property void front(E val)
         {
             _input.front[_n] = val;
         }
@@ -6185,7 +6185,7 @@ struct Transversal(Ror,
         /// Ditto
         static if (hasAssignableElements!InnerRange)
         {
-            @property auto back(E val)
+            @property void back(E val)
             {
                 _input.back[_n] = val;
             }
@@ -8851,7 +8851,7 @@ public:
     }
 
     /++ +/
-    auto opAssign(typeof(null) rhs)
+    void opAssign(typeof(null) rhs)
     {
         _range = null;
     }

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -259,7 +259,6 @@ template BacktrackingMatcher(bool CTregex)
                             return val;
                         else
                         {
-                            import std.stdio;
                             if (atEnd)
                                 break;
                             search();

--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -673,8 +673,8 @@ version(unittest)
     {
         private void check(T)(string input, T re, size_t idx=uint.max, int line=__LINE__)
         {
-            import std.regex, std.conv;
-            import std.stdio;
+            import std.regex : regex;
+            import std.conv : text, to;
             auto rex = regex(re, "s");
             auto m = make(rex);
             auto s = Input!char(input);
@@ -688,8 +688,8 @@ version(unittest)
     {
         private void checkFail(T)(string input, T re, size_t idx=uint.max, int line=__LINE__)
         {
-            import std.regex, std.conv;
-            import std.stdio;
+            import std.regex : regex;
+            import std.conv : text, to;
             auto rex = regex(re, "s");
             auto m = make(rex);
             auto s = Input!char(input);
@@ -700,8 +700,8 @@ version(unittest)
 
     private void checkEmpty(T)(T re)
     {
-        import std.regex, std.conv;
-        import std.stdio;
+        import std.regex : regex;
+        import std.conv : to;
         auto rex = regex(re);
         auto m = BitNfa(rex);
         assert(m.empty, "Should be empty "~to!string(re));

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -490,7 +490,6 @@ pure:
 
 @trusted void reverseBytecode()(Bytecode[] code) pure
 {
-    import std.typecons;
     Bytecode[] rev = new Bytecode[code.length];
     uint revPc = cast(uint)rev.length;
     Stack!(Tuple!(uint, uint, uint)) stack;

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1506,7 +1506,7 @@ pure:
             kickstart = new ShiftOr!Char(zis);
             if (kickstart.empty)
             {
-                if(!__ctfe)
+                if (!__ctfe)
                     kickstart = new BitMatcher!Char(zis);
                 if (kickstart.empty)
                     kickstart = null;

--- a/std/regex/internal/shiftor.d
+++ b/std/regex/internal/shiftor.d
@@ -531,7 +531,7 @@ unittest
         assert(kick.length == length, text(C.stringof, " == ", kick.length));
         return kick;
     }
-    auto searches(C)(const (C)[] source, ShiftOr!C kick, uint[] results...)
+    void searches(C)(const (C)[] source, ShiftOr!C kick, uint[] results...)
     {
         auto inp = Input!C(source);
         foreach (r; results)

--- a/std/regex/internal/tests2.d
+++ b/std/regex/internal/tests2.d
@@ -147,7 +147,8 @@ unittest
         //issue 4574
         //empty successful match still advances the input
         string[] pres, posts, hits;
-        foreach (m; matchFn("abcabc", regex("","g"))) {
+        foreach (m; matchFn("abcabc", regex("","g")))
+        {
             pres ~= m.pre;
             posts ~= m.post;
             assert(m.hit.empty);
@@ -248,7 +249,8 @@ unittest
     auto w2 = ["", "abc", "de", "fg", "hi"];
 
     uint cnt;
-    foreach (e; sp2) {
+    foreach (e; sp2)
+    {
         assert(w2[cnt++] == e);
     }
     assert(equal(sp2, w2));

--- a/std/signals.d
+++ b/std/signals.d
@@ -193,7 +193,8 @@ mixin template Signal(T1...)
                 }
             }
         }
-        else {
+        else
+        {
             for (size_t i = 0; i < slots_idx; )
             {
                 if (slots[i].ptr == slot.ptr &&

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -860,9 +860,9 @@ template Tuple(Specs...)
                     {
                         import std.array : empty;
                         auto names = [fieldNames];
-                        foreach(ref n; names)
+                        foreach (ref n; names)
                             if (!n.empty)
-                                if(auto p = n in translate)
+                                if (auto p = n in translate)
                                     n = *p;
                         return names;
                     }()));
@@ -881,7 +881,7 @@ template Tuple(Specs...)
                 return this.rename!(aliasSeqOf!(
                     {
                         auto names = [fieldNames];
-                        foreach(k, v; translate)
+                        foreach (k, v; translate)
                             names[k] = v;
                         return names;
                     }()));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -843,7 +843,7 @@ template Tuple(Specs...)
         if (is(typeof(translate) : V[K], V, K) && isSomeString!V &&
                 (isSomeString!K || is(K : size_t)))
         {
-            import std.range: ElementType;
+            import std.range : ElementType;
             static if (isSomeString!(ElementType!(typeof(translate.keys))))
             {
                 {

--- a/std/uni.d
+++ b/std/uni.d
@@ -2701,7 +2701,7 @@ private:
 
         //may break sorted property - but we need std.sort to access it
         //hence package protection attribute
-        package @property auto front(CodepointInterval val)
+        package @property void front(CodepointInterval val)
         {
             slice[start] = val.a;
             slice[start+1] = val.b;
@@ -2715,7 +2715,7 @@ private:
         }
 
         //ditto about package
-        package @property auto back(CodepointInterval val)
+        package @property void back(CodepointInterval val)
         {
             slice[end-2] = val.a;
             slice[end-1] = val.b;
@@ -2739,7 +2739,7 @@ private:
         }
 
         //ditto about package
-        package auto opIndexAssign(CodepointInterval val, size_t idx)
+        package void opIndexAssign(CodepointInterval val, size_t idx)
         {
             slice[start+idx*2] = val.a;
             slice[start+idx*2+1] = val.b;

--- a/unittest.d
+++ b/unittest.d
@@ -70,7 +70,8 @@ int main(string[] args)
     uint ranseed = std.random.unpredictableSeed;
     thisTid;
     int[] a;
-    import std.algorithm : sort, reverse;
+    import std.algorithm.sorting : sort;
+    import std.algorithm.mutation : reverse;
     reverse(a);                         // adi
     sort(a);                            // qsort
     Clock.currTime();                   // datetime


### PR DESCRIPTION
It seems like we/I accidentally disabled the style target on CircleCi (`style` is not defined in the command switch). I take the full blame for this, but at least it's a good proof that the CI actually does catch quite a few things ;-)

I split up the fixes depending on their category.

There's only [one line](https://github.com/dlang/phobos/blob/master/std/regex/package.d#L421) left about which DScanner is complaining (hence the "blocked" label):

```
public static immutable ctRegex(alias pattern, alias flags=[]) = ctRegexImpl!(pattern, flags).nr;
```

It warns with:

```
std/regex/package.d(421:32)[error]: Declaration expected
std/regex/package.d(421:62)[error]: Declaration expected
std/regex/package.d(421:64)[error]: Declaration expected
std/regex/package.d(421:97)[warn]: Empty declaration
```

@Hackerpilot is there a simple fix? Otherwise I will add this file to the Dscanner blacklist.
