### PR TITLE
[std.regex] Optimize reads from hash table

### DIFF
--- a/std/regex/internal/bitnfa.d
+++ b/std/regex/internal/bitnfa.d
@@ -24,7 +24,7 @@ pure:
 
     uint opIndex()(uint key) const
     {
-        auto p = locate(key, table);
+        auto p = locateExisting(key, table);
         assert(p.occupied);
         return p.value;
     }
@@ -94,6 +94,19 @@ private:
     }
     Node[] table;
     size_t items;
+
+    static N* locateExisting(N)(uint key, N[] table)
+    {
+        size_t slot = hashOf(key) & (table.length-1);
+        key |= 0x8000_0000;
+        while (table[slot].key_ != key)
+        {
+            slot += 1;
+            if (slot == table.length)
+                slot = 0;
+        }
+        return table.ptr + slot;
+    }
 
     static N* locate(N)(uint key, N[] table)
     {


### PR DESCRIPTION
This speeds up BitNFA a little bit as all reads are for apriori existing items.
![image](https://cloud.githubusercontent.com/assets/281770/19273628/d1acb952-8fd5-11e6-8f39-4fd11210c1a6.png)



