### PR TITLE
remove spurious x identifier in IsExp

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1121,7 +1121,7 @@ template ParameterIdentifierTuple(func...)
         {
             static if (!isFunctionPointer!func && !isDelegate!func
                        // Unnamed parameters yield CT error.
-                       && is(typeof(__traits(identifier, PT[i..i+1]))x))
+                       && is(typeof(__traits(identifier, PT[i..i+1]))))
             {
                 enum Get = __traits(identifier, PT[i..i+1]);
             }


### PR DESCRIPTION
- gets parsed as is(Type Identifier) but an alias identifier isn't needed
- fixup of ee683ae79f (#2624)