### PR TITLE
The word "tranforms" is a typo, should be "transforms"

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -2543,7 +2543,7 @@ else version (Posix)
 
 
 
-/** Tranforms $(D path) into an absolute _path.
+/** Transforms $(D path) into an absolute _path.
 
     The following algorithm is used:
     $(OL
@@ -2616,7 +2616,7 @@ string absolutePath(string path, lazy string base = getcwd())
     assertThrown(absolutePath("bar", "foo"));
 }
 
-/** Tranforms $(D path) into an absolute _path.
+/** Transforms $(D path) into an absolute _path.
 
     The following algorithm is used:
     $(OL


### PR DESCRIPTION
This typo is especially painful when you know you want to search for the word "transforms" and you don't get all the hits you know you should :/