### PR TITLE
[std.regex] Disable Bit-NFA in CTFE

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1506,7 +1506,8 @@ pure:
             kickstart = new ShiftOr!Char(zis);
             if (kickstart.empty)
             {
-                kickstart = new BitMatcher!Char(zis);
+                if(!__ctfe)
+                    kickstart = new BitMatcher!Char(zis);
                 if (kickstart.empty)
                     kickstart = null;
             }


### PR DESCRIPTION
Should fix out of memory problems with ctRegex.