### PR TITLE
Issue 12125: do not enforce specific MS runtime

### DIFF
--- a/etc/c/zlib/win64.mak
+++ b/etc/c/zlib/win64.mak
@@ -12,6 +12,9 @@ LIBFLAGS=/nologo
 LDFLAGS=/nologo
 O=.obj
 
+# do not preselect a C runtime (extracted from the line above to make the auto tester happy)
+CFLAGS=$(CFLAGS) /Zl
+
 # variables
 
 OBJS = adler32$(O) compress$(O) crc32$(O) deflate$(O) gzclose$(O) gzlib$(O) gzread$(O) \


### PR DESCRIPTION
phobos.lib is agnostic to the used MS C runtime, but preselects one. Creating the automatic reference when building main/WinMain/DllMain is good enough.

Needs corresponding druntime change to be effective: https://github.com/dlang/druntime/pull/1691