### PR TITLE
enhancement issue 4851: add choice function to std.random

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1807,31 +1807,28 @@ F[] uniformDistribution(F = double)(size_t n, F[] useThis = null)
 }
 
 /**
-Returns a random, uniformly chosen, element $(D e) from the supplied
+Returns a random, uniformly chosen, element `e` from the supplied
 $(D Range range). If no random number generator is passed, the default
-$(D rndGen) is used.
+`rndGen` is used.
 
 Params:
-    range = a random access range that has the length property defined
+    range = a random access range that has the `length` property defined
     urng = (optional) random number generator to use;
-           if not specified, defaults to $(D rndGen)
+           if not specified, defaults to `rndGen`
 
 Returns:
-    A single random element drawn from the $(D range). If it can, it will
-    return a $(D ref) to the $(D range element), otherwise it will return
+    A single random element drawn from the `range`. If it can, it will
+    return a `ref` to the $(D range element), otherwise it will return
     a copy.
  */
-auto ref choice(Range, RandomGen=Random)(auto ref Range range,
-                                         ref RandomGen urng = rndGen)
+auto ref choice(Range, RandomGen = Random)(auto ref Range range,
+                                           ref RandomGen urng = rndGen)
     if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
 {
-    import std.conv : to, text;
-    import std.exception : enforce;
+    assert(range.length > 0,
+           __PRETTY_FUNCTION__ ~ ": invalid Range supplied. Range cannot be empty");
 
-    enforce(range.length > 0,
-            text("std.random.choice(): invalid Range supplied. Range cannot be empty"));
-
-    return range[uniform(to!size_t(0), $, urng)];
+    return range[uniform(size_t(0), $, urng)];
 }
 
 ///
@@ -1867,7 +1864,8 @@ auto ref choice(Range, RandomGen=Random)(auto ref Range range,
     }
 
     MyTestClass[] testClass;
-    foreach(i; 0 .. 5) {
+    foreach(i; 0 .. 5)
+    {
         testClass ~= new MyTestClass(i);
     }
 

--- a/std/random.d
+++ b/std/random.d
@@ -1807,6 +1807,90 @@ F[] uniformDistribution(F = double)(size_t n, F[] useThis = null)
 }
 
 /**
+Returns a random, uniformly chosen, element $(D e) from the supplied
+$(D Range range). If no random number generator is passed, the default
+$(D rndGen) is used.
+
+Params:
+    range = a random access range that has the length property defined
+    urng = (optional) random number generator to use;
+           if not specified, defaults to $(D rndGen)
+
+Returns:
+    A single random element drawn from the $(D range). If it can, it will
+    return a $(D ref) to the $(D range element), otherwise it will return
+    a copy.
+ */
+auto ref choice(Range, RandomGen=Random)(auto ref Range range,
+                                         ref RandomGen urng = rndGen)
+    if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
+{
+    import std.conv : to, text;
+    import std.exception : enforce;
+
+    enforce(range.length > 0,
+            text("std.random.choice(): invalid Range supplied. Range cannot be empty"));
+
+    return range[uniform(to!size_t(0), $, urng)];
+}
+
+///
+@safe unittest
+{
+    import std.algorithm : canFind;
+
+    auto array = [1, 2, 3, 4, 5];
+    auto elem = choice(array);
+
+    assert(canFind(array, elem),
+           "Choice did not return a valid element from the given Range");
+
+    auto urng = Random(unpredictableSeed);
+    elem = choice(array, urng);
+
+    assert(canFind(array, elem),
+           "Choice did not return a valid element from the given Range");
+}
+
+@safe unittest
+{
+    import std.algorithm : canFind;
+
+    class MyTestClass
+    {
+        int x;
+
+        this(int x)
+        {
+            this.x = x;
+        }
+    }
+
+    MyTestClass[] testClass;
+    foreach(i; 0 .. 5) {
+        testClass ~= new MyTestClass(i);
+    }
+
+    auto elem = choice(testClass);
+
+    assert(canFind!((ref MyTestClass a, ref MyTestClass b) => a.x == b.x)(testClass, elem),
+           "Choice did not return a valid element from the given Range");
+}
+
+unittest
+{
+    import std.algorithm : canFind, map;
+
+    auto array = [1, 2, 3, 4, 5];
+    auto elemAddr = &choice(array);
+
+    assert(array.map!((ref e) => &e).canFind(elemAddr),
+           "Choice did not return a ref to an element from the given Range");
+    assert(array.canFind(*(cast(int *)(elemAddr))),
+           "Choice did not return a valid element from the given Range");
+}
+
+/**
 Shuffles elements of $(D r) using $(D gen) as a shuffler. $(D r) must be
 a random-access range with length.  If no RNG is specified, $(D rndGen)
 will be used.


### PR DESCRIPTION
Added a choice() function to std.random as it was being discussed in the issue. The function returns a random element from a given Range. If no uniform random number generator is supplied, it will default to rndGen.

I read the D Style Guidelines and I hope I managed to comply with all of them.

https://issues.dlang.org/show_bug.cgi?id=4851