### PR TITLE
[Ddoc] XREF -> REF

### DIFF
--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1293,7 +1293,7 @@ Returns:
     A range containing the unique union of the given ranges.
 
 See_Also:
-   $(XREF algorithm, sorting, merge)
+   $(REF merge, std,algorithm,sorting)
  */
 auto setUnion(alias less = "a < b", Rs...)
 (Rs rs)

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1055,9 +1055,6 @@ Params:
 
 Returns:
     A range containing the union of the given ranges.
-
-See_Also:
-   $(XREF algorithm, setops, SetUnion)
  */
 struct Merge(alias less = "a < b", Rs...) if (allSatisfy!(isInputRange, Rs))
 {


### PR DESCRIPTION
Removing the one that refers to std.algorithm.setops.SetUnion, because
that is not documented anymore (it's deprecated). This overlaps very slightly with #4888.

Targeting stable to minimize the chance of XREF creeping back in again. master would work too, but I'd like to finally get this over with.