### PR TITLE
Fix issue 16682: "privatization" of symbols in std.stdio breaks DFMT

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -88,7 +88,6 @@ else version (Posix)
 else
     static assert(0);
 
-private:
 version(Windows)
 {
     // core.stdc.stdio.fopen expects file names to be
@@ -247,7 +246,6 @@ version(HAS_GETDELIM) extern(C) nothrow @nogc
     ptrdiff_t getline(char**, size_t*, FILE*);
 }
 
-
 //------------------------------------------------------------------------------
 struct ByRecord(Fields...)
 {
@@ -312,7 +310,6 @@ template byRecord(Fields...)
     }
 }
 
-public:
 /**
 Encapsulates a $(D FILE*). Generally D does not attempt to provide
 thin wrappers over equivalent functions in the C standard library, but
@@ -650,7 +647,6 @@ Throws: $(D ErrnoException) in case of error.
     version(StdDdoc)
     void windowsHandleOpen(HANDLE handle, in char[] stdioOpenmode);
 
-    /// ditto
     version(Windows)
     void windowsHandleOpen(HANDLE handle, in char[] stdioOpenmode)
     {
@@ -1862,7 +1858,6 @@ Returns the underlying operating system $(D HANDLE) (Windows only).
     version(StdDdoc)
     @property HANDLE windowsHandle();
 
-    /// ditto
     version(Windows)
     @property HANDLE windowsHandle()
     {
@@ -1879,7 +1874,7 @@ Range that reads one line at a time.  Returned by $(LREF byLine).
 
 Allows to directly use range operations on lines of a file.
 */
-    private struct ByLine(Char, Terminator)
+    struct ByLine(Char, Terminator)
     {
     private:
         import std.typecons : RefCounted, RefCountedAutoInitialize;
@@ -2400,7 +2395,7 @@ $(REF readText, std,file)
     /*
      * Range that reads a chunk at a time.
      */
-    private struct ByChunk
+    struct ByChunk
     {
     private:
         File    file_;
@@ -2602,7 +2597,7 @@ $(D StdioException).
 /*
 $(D Range) that locks the file and allows fast writing to it.
  */
-    private struct LockingTextWriter
+    struct LockingTextWriter
     {
     private:
         import std.range.primitives : ElementType, isInfinite, isInputRange;
@@ -2779,7 +2774,7 @@ See $(LREF byChunk) for an example.
     // An output range which optionally locks the file and puts it into
     // binary mode (similar to rawWrite). Because it needs to restore
     // the file mode on destruction, it is RefCounted on Windows.
-    private struct BinaryWriterImpl(bool locking)
+    struct BinaryWriterImpl(bool locking)
     {
         import std.traits : hasIndirections;
     private:
@@ -3194,7 +3189,7 @@ enum LockType
     readWrite
 }
 
-private struct LockingTextReader
+struct LockingTextReader
 {
     private File _f;
     private char _front;
@@ -3914,7 +3909,6 @@ struct lines
         this.terminator = terminator;
     }
 
-    /// Implements `opApply` `foreach` support
     int opApply(D)(scope D dg)
     {
         import std.traits : Parameters;
@@ -3958,8 +3952,8 @@ struct lines
             return opApplyRaw(dg);
         }
     }
-
-    private int opApplyRaw(D)(scope D dg)
+    // no UTF checking
+    int opApplyRaw(D)(scope D dg)
     {
         import std.conv : to;
         import std.exception : assumeUnique;
@@ -4317,7 +4311,7 @@ Initialize with a message and an error code.
     }
 }
 
-package extern(C) void std_stdio_static_this()
+extern(C) void std_stdio_static_this()
 {
     static import core.stdc.stdio;
     //Bind stdin, stdout, stderr


### PR DESCRIPTION
@JackStouffer please redo that change against master (after the merge of stable) with symbols
undergoing deprecation phase for at least one release first.