### PR TITLE
Increase time limit

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -129,7 +129,7 @@ endif
 LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)
 
 # use timelimit to avoid deadlocks if available
-TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 60 ,)
+TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 90 ,)
 
 # Set VERSION, where the file is that contains the version string
 VERSION=../dmd/VERSION


### PR DESCRIPTION
On some FreeBSD the unittest timeout with increased frequency, hence this change.