### PR TITLE
Make std.container.rbtree.RedBlackTree._add @safe

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -17,7 +17,7 @@ Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 module std.container.rbtree;
 
 ///
-unittest
+@safe pure unittest
 {
     import std.container.rbtree;
     import std.algorithm.comparison : equal;
@@ -639,7 +639,7 @@ struct RBNode(V)
 }
 
 //constness checks
-unittest
+@safe pure unittest
 {
     const RBNode!int n;
     static assert(is(typeof(n.leftmost)));
@@ -812,7 +812,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     alias ConstRange = RBRange!(const(RBNode)*); /// Ditto
     alias ImmutableRange = RBRange!(immutable(RBNode)*); /// Ditto
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         import std.range.primitives;
@@ -891,7 +891,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         else
         {
             Node newParent = _end.left;
-            Node nxt = void;
+            Node nxt;
             while (true)
             {
                 if (_less(n, newParent.value))
@@ -987,7 +987,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         return new RedBlackTree(_end.dup(), _length);
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         auto ts = new RedBlackTree(1, 2, 3, 4, 5);
@@ -1053,7 +1053,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         return _find(e) !is null;
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(1, 2, 3, 4, 5);
         assert(cast(Elem)3 in ts);
@@ -1108,7 +1108,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         _length = 0;
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(1,2,3,4,5);
         assert(ts.length == 5);
@@ -1170,7 +1170,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     /// ditto
     alias insert = stableInsert;
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(2,1,3,4,5,2,5);
         static if (allowDuplicates)
@@ -1218,7 +1218,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         return result;
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(1,2,3,4,5);
         assert(ts.length == 5);
@@ -1262,7 +1262,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
             check();
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(1,2,3,4,5);
         assert(ts.length == 5);
@@ -1303,7 +1303,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         return Range(e, _end);
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         auto ts = new RedBlackTree(1,2,3,4,5);
@@ -1349,7 +1349,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
         return Range(b, _end);
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : take;
@@ -1445,7 +1445,7 @@ assert(equal(rbt[], [5]));
         enum isImplicitlyConvertibleToElem = isImplicitlyConvertible!(U, Elem);
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : take;
@@ -1600,7 +1600,7 @@ assert(equal(rbt[], [5]));
         }
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @safe pure unittest
     {
         import std.algorithm.comparison : equal;
         auto ts = new RedBlackTree(1, 2, 3, 4, 5);
@@ -1758,7 +1758,7 @@ assert(equal(rbt[], [5]));
 }
 
 //Verify Example for removeKey.
-pure unittest
+@safe pure unittest
 {
     import std.algorithm.comparison : equal;
     auto rbt = redBlackTree!true(0, 1, 1, 1, 4, 5, 7);
@@ -1769,7 +1769,7 @@ pure unittest
 }
 
 //Tests for removeKey
-pure unittest
+@safe pure unittest
 {
     import std.algorithm.comparison : equal;
     {
@@ -1799,7 +1799,7 @@ pure unittest
     }
 }
 
-pure unittest
+@safe pure unittest
 {
     void test(T)()
     {
@@ -1895,7 +1895,7 @@ auto redBlackTree(alias less, bool allowDuplicates, Stuff)(Stuff range)
 }
 
 ///
-pure unittest
+@safe pure unittest
 {
     import std.range : iota;
 
@@ -1913,7 +1913,7 @@ pure unittest
 }
 
 //Combinations not in examples.
-pure unittest
+@safe pure unittest
 {
     auto rbt1 = redBlackTree!(true, string)("hello", "hello");
     auto rbt2 = redBlackTree!((a, b){return a < b;}, double)(5.1, 2.3);
@@ -1921,7 +1921,7 @@ pure unittest
 }
 
 //Range construction.
-pure unittest
+@safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1931,7 +1931,7 @@ pure unittest
 
 
 // construction with arrays
-pure unittest
+@safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1961,7 +1961,7 @@ pure unittest
 }
 
 // convenience wrapper range construction
-pure unittest
+@safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : chain, iota;
@@ -1985,7 +1985,7 @@ pure unittest
     assert(equal(rbt6[], [7.2, 5.9, 5.9, 1.3, 0.1]));
 }
 
-pure unittest
+@safe pure unittest
 {
     import std.array : array;
 
@@ -2025,7 +2025,7 @@ unittest
 }
 
 //constness checks
-unittest
+@safe pure unittest
 {
     const rt1 = redBlackTree(5,4,3,2,1);
     static assert(is(typeof(rt1.length)));
@@ -2040,7 +2040,7 @@ unittest
 }
 
 //immutable checks
-unittest
+@safe pure unittest
 {
     immutable rt1 = redBlackTree(5,4,3,2,1);
     static assert(is(typeof(rt1.length)));
@@ -2051,7 +2051,7 @@ unittest
 }
 
 // issue 15941
-unittest
+@safe pure unittest
 {
     class C {}
     RedBlackTree!(C, "cast(void*)a < cast(void*)b") tree;


### PR DESCRIPTION
This request removes a void initializer from `_add` and makes most unittests in `std.container.rbtree` `@safe.`
I also added `pure` attribute for unittests.
