### PR TITLE
Really fix Issue 16478 - Don't allow to!T() in constraint

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -167,7 +167,7 @@ $(I UnsignedInteger):
 template to(T)
 {
     T to(A...)(A args)
-        if (A.length != 1 || !isStaticArray!(A[0]))
+        if (A.length > 0)
     {
         return toImpl!T(args);
     }


### PR DESCRIPTION
* Use specialization to prefer `to!S` when S is a static array.

(For background, see https://github.com/dlang/phobos/pull/4898#issuecomment-262796333)

Ping @schveiguy.