### PR TITLE
Require that popFront and popBack be callable without parens.

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -164,7 +164,7 @@ template isInputRange(R)
     {
         R r = R.init;     // can define a range object
         if (r.empty) {}   // can test for empty
-        r.popFront();     // can invoke popFront()
+        r.popFront;       // can invoke popFront()
         auto h = r.front; // can get the front of the range
     }));
 }
@@ -844,7 +844,7 @@ template isBidirectionalRange(R)
     (inout int = 0)
     {
         R r = R.init;
-        r.popBack();
+        r.popBack;
         auto t = r.back;
         auto w = r.front;
         static assert(is(typeof(t) == typeof(w)));


### PR DESCRIPTION
Technically, prior to this change, it was possible to define popFront
and popBack to be callables that required parens - such as member
variable with an overloaded opCall or a delegate. It's unlikely that
anyone has actually declared popFront or popBack in this manner, but
it's possible. Because of that, calling popFront or popBack without
parens would technically not work with some valid ranges (even if such
ranges are unlikely to exist) and thus without this change, it's
arguably not valid to call popFront or popBack without parens in generic
code - especially in the standard library.

Andrei wants to be able to call popFront without parens in generic code,
and when I pointed out the existing problem with that, he wanted me to
change it so that it's no longer legal to have a range where popFront or
popBack is a callable that requires parens. So, this PR fixes that.

Now, technically, this is a breaking change, but it's highly unlikely
that it actually breaks any code, and I don't know of any way to do this
change in a way which would allow for any kind of deprecation message
for anyone trying to declare a range with a popFront or popBack that
would not work without parens. So, as far as I can tell, if we want to
make this change, we're stuck making a breaking change, but the odds of
it actually mattering seem low.