### PR TITLE
fix issue_15421 [reloaded] - The behaviours of the topNs differ with the bottom

### DIFF
--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -169,6 +169,11 @@ struct DummyRange(ReturnBy _r, Length _l, RangeType _rt, T = uint[])
             ret.arr = arr[lower..upper];
             return ret;
         }
+
+        typeof(this) opSlice()
+        {
+            return this;
+        }
     }
 
     static if (l == Length.Yes)


### PR DESCRIPTION
I rebased https://github.com/dlang/phobos/pull/3865 which seems abandoned.

The test for ranges still fails unless I use the cheat to transform the range to an array before passing it to topN and sort (which defeats the purpose of the test actually). It might be a problem with DummyRange, I'm still looking into it, but ideas are welcome.

https://issues.dlang.org/show_bug.cgi?id=15421

