### PR TITLE
fix issue 13314  - BinaryHeap assumes Store has dup property 

### DIFF
--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -198,8 +198,8 @@ Returns $(D true) if the heap is _empty, $(D false) otherwise.
     }
 
 /**
-Returns a duplicate of the heap. The underlying store must also
-support a $(D dup) method.
+Returns a duplicate of the heap. The $(D dup) method is available only if the
+underlying store supports it.
      */
     static if (is(typeof(Store.init.dup) == Store)) {
         @property BinaryHeap dup()

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -62,8 +62,14 @@ size of that range. If $(D Store) is a container that supports $(D
 insertBack), the $(D BinaryHeap) may grow by adding elements to the
 container.
      */
+
+template hasDup(T)
+{
+    const hasDup = __traits(compiles, (T t) { return t.dup(); });
+}
+
 struct BinaryHeap(Store, alias less = "a < b")
-if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
+if ((isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[]))) && hasDup!(Store))
 {
     import std.functional : binaryFun;
     import std.exception : enforce;

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -475,3 +475,12 @@ unittest // 16072
 
     assert(r.front == 99);
 }
+
+unittest
+{
+    import std.algorithm.comparison : equal;
+    int[] a = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7];
+    auto heap = heapify(a);
+    auto dup = heap.dup();
+    assert(dup.equal([16, 14, 10, 9, 8, 7, 4, 3, 2, 1]));
+}

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -62,14 +62,8 @@ size of that range. If $(D Store) is a container that supports $(D
 insertBack), the $(D BinaryHeap) may grow by adding elements to the
 container.
      */
-
-template hasDup(T)
-{
-    const hasDup = __traits(compiles, (T t) { return t.dup(); });
-}
-
 struct BinaryHeap(Store, alias less = "a < b")
-if ((isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[]))) && hasDup!(Store))
+if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
 {
     import std.functional : binaryFun;
     import std.exception : enforce;
@@ -207,12 +201,14 @@ Returns $(D true) if the heap is _empty, $(D false) otherwise.
 Returns a duplicate of the heap. The underlying store must also
 support a $(D dup) method.
      */
-    @property BinaryHeap dup()
-    {
-        BinaryHeap result;
-        if (!_payload.refCountedStore.isInitialized) return result;
-        result.assume(_store.dup, length);
-        return result;
+    static if (is(typeof(Store.init.dup) == Store)) {
+        @property BinaryHeap dup()
+        {
+            BinaryHeap result;
+            if (!_payload.refCountedStore.isInitialized) return result;
+            result.assume(_store.dup, length);
+            return result;
+        }
     }
 
 /**


### PR DESCRIPTION
If Store does not have the ```dup``` property, then dup is not available for the BinaryHeap either. 