### PR TITLE
use WindowsException for errors from windows api

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -3290,6 +3290,9 @@ private:
     assert (res !is null);
     assert (res == "");
 
+    // Important to do the following round-trip after the previous test
+    // because it tests toAA with an empty var
+
     // Convert to associative array
     auto aa = environment.toAA();
     assert (aa.length > 0);

--- a/std/process.d
+++ b/std/process.d
@@ -3196,7 +3196,7 @@ private:
                 // some other windows error. Might actually be NO_ERROR, because
                 // GetEnvironmentVariable doesn't specify whether it sets on all
                 // failures
-                throw new Exception(sysErrorString(err));
+                throw new WindowsException(err);
             }
             if (len == 1)
             {
@@ -3221,7 +3221,7 @@ private:
                     if (err == ERROR_ENVVAR_NOT_FOUND) // variable didn't exist
                         return false;
                     // some other windows error
-                    throw new Exception(sysErrorString(err));
+                    throw new WindowsException(err);
                 }
                 assert (lenRead != buf.length, "impossible according to msft docs");
                 if (lenRead < buf.length) // the buffer was long enough


### PR DESCRIPTION
In accordance with https://github.com/dlang/phobos/pull/4938#discussion_r91655136 and https://github.com/dlang/phobos/pull/4938#discussion_r91655158