### PR TITLE
Enforce Allman style for do {

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -508,6 +508,9 @@ style: ../dscanner/dsc
 	@echo "Enforce Allman style"
 	grep -nrE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$$' $$(find . -name '*.d'); test $$? -eq 1
 
+	@echo "Enforce do { to be in Allman style"
+	grep -nr 'do *{$$' $$(find . -name '*.d') ; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -1009,7 +1009,8 @@ private:
 
                 if (comp(next.front, r.front))
                 {
-                    do {
+                    do
+                    {
                         next.popFront();
                         if (next.empty) return;
                     } while (comp(next.front, r.front));

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1089,7 +1089,8 @@ real betaDistExpansion1(real a, real b, real x )
     r = 1.0L;
     n = 0;
     const real thresh = 3.0L * real.epsilon;
-    do  {
+    do
+    {
         xk = -( x * k1 * k2 )/( k3 * k4 );
         pk = pkm1 +  pkm2 * xk;
         qk = qkm1 +  qkm2 * xk;
@@ -1177,8 +1178,8 @@ real betaDistExpansion2(real a, real b, real x )
     r = 1.0L;
     int n = 0;
     const real thresh = 3.0L * real.epsilon;
-    do {
-
+    do
+    {
         xk = -( z * k1 * k2 )/( k3 * k4 );
         pk = pkm1 +  pkm2 * xk;
         qk = qkm1 +  qkm2 * xk;
@@ -1327,7 +1328,8 @@ body {
     real c = 1.0L;
     real ans = 1.0L;
 
-    do  {
+    do
+    {
         r += 1.0L;
         c *= x/r;
         ans += c;
@@ -1374,7 +1376,8 @@ body {
     real qkm1 = z * x;
     real ans = pkm1/qkm1;
 
-    do  {
+    do
+    {
         c += 1.0L;
         y += 1.0L;
         z += 2.0L;


### PR DESCRIPTION
As suggested [here](https://github.com/dlang/phobos/pull/4940#discussion_r91747540) this simply enforces a common style for `do` blocks, or in other words this will forbid the verbose `do {` followed a newline. Inline `do`s are still allowed, e.g.:

```
> grep -i 'do *{' **/*.d
std/path.d:            do { ++j; } while (j < path.length && isDirSeparator(path[j]));
std/path.d:                do { ++j; } while (j < path.length && !isDirSeparator(path[j]));
std/process.d:    do { s = tryWait(pid); } while (!s.terminated);
```