### PR TITLE
CircleCI badge: only show build status for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ===================================================================
 
 [![GitHub tag](https://img.shields.io/github/tag/dlang/phobos.svg?maxAge=86400)](#)
-[![Build status](https://img.shields.io/circleci/project/dlang/phobos.svg?maxAge=86400)](https://circleci.com/gh/dlang/phobos)
+[![Build status](https://img.shields.io/circleci/project/dlang/phobos/master.svg?maxAge=86400)](https://circleci.com/gh/dlang/phobos)
 [![Code coverage](https://img.shields.io/codecov/c/github/dlang/phobos.svg?maxAge=86400)](https://codecov.io/gh/dlang/phobos)
 [![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/phobos.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/phobos)
 


### PR DESCRIPTION
The CircleCI badges seems to use the _lastest_ build by default and thus it's
[currently](https://github.com/dlang/phobos/blob/master/README.md) showing "Failed" even though everything is green.

This fixes the CircleCi badge/shield to the `master` branch. [Preview](https://github.com/wilzbach/phobos/blob/a4182ab6dc2327cd0b146aea62e22bb6b16b08a6/README.md).