### PR TITLE
[CircleCi] updatebuild script: merge with upstream branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ test:
     - ./circleci.sh publictests
     - ./circleci.sh coverage:
         parallel: true
+        timeout: 1200
 
   post:
     - bash <(curl -s https://codecov.io/bash)

--- a/circleci.sh
+++ b/circleci.sh
@@ -42,7 +42,7 @@ clone() {
     local path="$2"
     local branch="$3"
     for i in {0..4}; do
-        if git clone --depth=1 --branch "$branch" "$url" "$path"; then
+        if git clone --branch "$branch" "$url" "$path" "${@:4}"; then
             break
         elif [ $i -lt 4 ]; then
             sleep $((1 << $i))
@@ -74,8 +74,8 @@ setup_repos()
         git merge -m "Automatic merge" $current_branch
     fi
 
-    clone https://github.com/dlang/dmd.git ../dmd $base_branch
-    clone https://github.com/dlang/druntime.git ../druntime $base_branch
+    clone https://github.com/dlang/dmd.git ../dmd $base_branch --depth 1
+    clone https://github.com/dlang/druntime.git ../druntime $base_branch --depth 1
 
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"

--- a/circleci.sh
+++ b/circleci.sh
@@ -63,10 +63,16 @@ setup_repos()
         base_branch=$CIRCLE_BRANCH
     fi
 
-    # merge with upstream branch, s.t. we check with the latest changes
-    git remote add upstream https://github.com/dlang/phobos.git
-    git fetch upstream
-    git merge upstream/$base_branch
+    # merge upstream branch with changes, s.t. we check with the latest changes
+    if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
+        local current_branch=$(git rev-parse --abbrev-ref HEAD)
+        git config user.name dummyuser
+        git config user.email dummyuser@dummyserver.com
+        git remote add upstream https://github.com/dlang/phobos.git
+        git fetch upstream
+        git checkout -f upstream/$base_branch
+        git merge -m "Automatic merge" $current_branch
+    fi
 
     clone https://github.com/dlang/dmd.git ../dmd $base_branch
     clone https://github.com/dlang/druntime.git ../druntime $base_branch


### PR DESCRIPTION
I just realized that for https://github.com/dlang/phobos/pull/4921 the style check fixes aren't included. In general it makes a lot of sense to merge to merge with the upstream branch, s.t. changes are always tested as they would be merged (@CyberShadow's DAutoTest behaves similarly). While I was at the file I did a few tiny improvements:

- provide default value for `CIRCLE_NODE_INDEX` (makes the script easier to run
manually)
- move setup_repos before style task, s.t. the latest style requirements
are enforced
- removed exclusion of failing modules for the individual module
coverage tests (this is due to @schveiguy's & @MartinNowak's [work](https://github.com/dlang/phobos/pull/4840) on [issue 16291](https://issues.dlang.org/show_bug.cgi?id=16291). Thanks!)

CC @MartinNowak 