### PR TITLE
Fix issue 16970 - Fix deprecations and warnings when compiling Phobos

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2654,7 +2654,6 @@ template reduce(fun...) if (fun.length >= 1)
     If $(D r) is empty, an $(D Exception) is thrown.
 
     Params:
-        fun = one or more functions
         r = an iterable value as defined by $(D isIterable)
 
     Returns:
@@ -2693,7 +2692,6 @@ template reduce(fun...) if (fun.length >= 1)
     Use $(D fold) instead of $(D reduce) to use the seed version in a UFCS chain.
 
     Params:
-        fun = one or more functions
         seed = the initial value of the accumulator
         r = an iterable value as defined by $(D isIterable)
 
@@ -3170,7 +3168,6 @@ if (fun.length >= 1)
     Once `S` has been determined, then $(D S s = e;) and $(D s = f(s, e);) must
     both be legal.
     Params:
-        fun = one or more functions
         range = an input range as defined by `isInputRange`
     Returns:
         a range containing the consecutive reduced values.
@@ -3189,7 +3186,6 @@ if (fun.length >= 1)
     `cumulativeFold` will operate on an unqualified copy. If this happens
     then the returned type will not perfectly match `S`.
     Params:
-        fun = one or more functions
         range = an input range as defined by `isInputRange`
         seed = the initial value of the accumulator
     Returns:

--- a/std/exception.d
+++ b/std/exception.d
@@ -2143,8 +2143,8 @@ pure nothrow @safe unittest
     Convenience mixin for trivially sub-classing exceptions
 
     Even trivially sub-classing an exception involves writing boilerplate code
-    for the constructor to: 1) correctly pass in the source file and line number
-    the exception was thrown from; 2) be usable with $(LREF enforce) which
+    for the constructor to: 1$(RPAREN) correctly pass in the source file and line number
+    the exception was thrown from; 2$(RPAREN) be usable with $(LREF enforce) which
     expects exception constructors to take arguments in a fixed order. This
     mixin provides that boilerplate code.
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1853,18 +1853,27 @@ Lazily takes only up to `n` elements of a range. This is
 particularly useful when using with infinite ranges.
 
 Unlike $(LREF takeExactly), `take` does not require that there
-are `n` or more elements in `r`. As a consequence, length
-information is not applied to the result unless `r` also has
+are `n` or more elements in `input`. As a consequence, length
+information is not applied to the result unless `input` also has
 length information.
 
 Params:
-    r = an input range to iterate over up to `n` times
+    input = an input range to iterate over up to `n` times
     n = the number of elements to take
 
 Returns:
     At minimum, an input range. If the range offers random access
     and `length`, `take` offers them as well.
  */
+Take!R take(R)(R input, size_t n)
+if (isInputRange!(Unqual!R) && !isInfinite!(Unqual!R) && hasSlicing!(Unqual!R) &&
+    !is(R T == Take!T))
+{
+    import std.algorithm.comparison : min;
+    return input[0 .. min(n, input.length)];
+}
+
+/// ditto
 struct Take(Range)
 if (isInputRange!(Unqual!Range) &&
     //take _cannot_ test hasSlicing on infinite ranges, because hasSlicing uses
@@ -2052,17 +2061,6 @@ if (isInputRange!(Unqual!Range) &&
     {
         return _maxAvailable;
     }
-}
-
-/// ditto
-Take!R take(R)(R input, size_t n)
-if (isInputRange!(Unqual!R) && !isInfinite!(Unqual!R) && hasSlicing!(Unqual!R) &&
-    !is(R T == Take!T))
-{
-    // @@@BUG@@@
-    //return input[0 .. min(n, $)];
-    import std.algorithm.comparison : min;
-    return input[0 .. min(n, input.length)];
 }
 
 /**

--- a/std/socket.d
+++ b/std/socket.d
@@ -629,7 +629,7 @@ private mixin template socketOSExceptionCtors()
 
 
 /**
- * Class for exceptions thrown from an $(D InternetHost).
+ * Class for exceptions thrown from an `InternetHost`.
  */
 class HostException: SocketOSException
 {
@@ -637,40 +637,10 @@ class HostException: SocketOSException
 }
 
 /**
- * $(D InternetHost) is a class for resolving IPv4 addresses.
+ * `InternetHost` is a class for resolving IPv4 addresses.
  *
- * Consider using $(D getAddress), $(D parseAddress) and $(D Address) methods
+ * Consider using `getAddress`, `parseAddress` and `Address` methods
  * instead of using this class directly.
- *
- * Example:
- * ---
- * auto ih = new InternetHost;
- *
- * // Forward lookup
- * writeln("About www.digitalmars.com:");
- * if (ih.getHostByName("www.digitalmars.com"))
- * {
- *     writefln("  Name: %s", ih.name);
- *     auto ip = InternetAddress.addrToString(ih.addrList[0]);
- *     writefln("  IP address: %s", ip);
- *     foreach (string s; ih.aliases)
- *          writefln("  Alias: %s", s);
- *     writeln("---");
- *
- *     // Reverse lookup
- *     writefln("About IP %s:", ip);
- *     if (ih.getHostByAddr(ih.addrList[0]))
- *     {
- *         writefln("  Name: %s", ih.name);
- *         foreach (string s; ih.aliases)
- *              writefln("  Alias: %s", s);
- *     }
- *     else
- *         writeln("  Reverse lookup failed");
- * }
- * else
- *     writeln("  Can't resolve www.digitalmars.com");
- * ---
  */
 class InternetHost
 {
@@ -824,7 +794,7 @@ class InternetHost
     }
 }
 
-
+///
 @safe unittest
 {
     InternetHost ih = new InternetHost;
@@ -834,29 +804,21 @@ class InternetHost
     ih.getHostByAddr("127.0.0.1");
     assert(ih.addrList[0] == 0x7F_00_00_01);
 
-    softUnittest({
-        if (!ih.getHostByName("www.digitalmars.com"))
-            return;             // don't fail if not connected to internet
-        //writefln("addrList.length = %d", ih.addrList.length);
-        assert(ih.addrList.length);
-        InternetAddress ia = new InternetAddress(ih.addrList[0], InternetAddress.PORT_ANY);
-        assert(ih.name == "www.digitalmars.com" || ih.name == "digitalmars.com",
-               ih.name);
-        // writefln("IP address = %s", ia.toAddrString());
-        // writefln("name = %s", ih.name);
-        // foreach (int i, string s; ih.aliases)
-        // {
-        //      writefln("aliases[%d] = %s", i, s);
-        // }
-        // writefln("---");
+    if (!ih.getHostByName("www.digitalmars.com"))
+        return;             // don't fail if not connected to internet
 
-        //assert(ih.getHostByAddr(ih.addrList[0]));
-        // writefln("name = %s", ih.name);
-        // foreach (int i, string s; ih.aliases)
-        // {
-        //      writefln("aliases[%d] = %s", i, s);
-        // }
-    });
+    assert(ih.addrList.length);
+    InternetAddress ia = new InternetAddress(ih.addrList[0], InternetAddress.PORT_ANY);
+    assert(ih.name == "www.digitalmars.com" || ih.name == "digitalmars.com",
+            ih.name);
+
+    assert(ih.getHostByAddr(ih.addrList[0]));
+    string getHostNameFromInt = ih.name.dup;
+
+    assert(ih.getHostByAddr(ia.toAddrString()));
+    string getHostNameFromStr = ih.name.dup;
+
+    assert(getHostNameFromInt == getHostNameFromStr);
 }
 
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2350,7 +2350,6 @@ $(REF readText, std,file)
     Range primitives may throw $(D StdioException) on I/O error.
 
     Params:
-        file = file handle to parse from
         format = tuple record $(REF_ALTTEXT _format, formattedRead, std, _format)
 
     Returns:

--- a/std/utf.d
+++ b/std/utf.d
@@ -3527,13 +3527,12 @@ int impureVariable;
  *
  * Params:
  *      C = `char`, `wchar`, or `dchar`
- *      r = input range of characters, or array of characters
  * Returns:
- *      A forward range if r is a range and not auto-decodable, as defined by
+ *      A forward range if `R` is a range and not auto-decodable, as defined by
  *      $(REF isAutodecodableString, std, traits), and if the base range is
  *      also a forward range.
  *
- *      Or, if r is a range and it is auto-decodable and
+ *      Or, if `R` is a range and it is auto-decodable and
  *      `is(ElementEncodingType!typeof(r) == C)`, then the range is passed
  *      to $(LREF byCodeUnit).
  *


### PR DESCRIPTION
Fixed ddocs in order to remove warnings when compiling html phobos, as mentioned on [bugzilla](https://issues.dlang.org/show_bug.cgi?id=16970).

I did not touch std/experimental/ndslice, since it's going to be deprecated.