### PR TITLE
Make more modules publicly runnable on dlang.org

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -520,7 +520,7 @@ style: ../dscanner/dsc
 publictests: $(LIB)
 	# parse all public unittests from Phobos, for now some modules are excluded
 	rm -rf ./out
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --single ../tools/phobos_tests_extractor.d -- --inputdir . --ignore "allocator/allocator_list.d,allocator/building_blocks/allocator_list.d,allocator/building_blocks/free_list.d,allocator/building_blocks/quantizer,allocator/building_blocks/quantizer,allocator/building_blocks/stats_collector.d,base64.d,bitmanip.d,concurrency.d,conv.d,csv.d,datetime.d,digest/hmac.d,digest/sha.d,file.d,index.d,isemail.d,logger/core.d,logger/nulllogger.d,math.d,ndslice/selection.d,ndslice/slice.d,numeric.d,stdio.d,traits.d,typecons.d,uni.d,utf.d,uuid.d" --outputdir ./out
+	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --single ../tools/phobos_tests_extractor.d -- --inputdir . --ignore "base64.d,building_blocks/free_list,building_blocks/quantizer,digest/hmac.d,file.d,index.d,math.d,ndslice/selection.d,stdio.d,traits.d,typecons.d,uuid.d" --outputdir ./out
 	# execute all parsed tests
 	for file in $$(find out -name '*.d'); do echo "executing $${file}" && $(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main -unittest -run $$file || exit 1 ; done
 

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3015,6 +3015,7 @@ T read(T, Endian endianness = Endian.bigEndian, R)(ref R range)
 ///
 @safe unittest
 {
+    import std.range.primitives : empty;
     ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
     assert(buffer.length == 7);
 
@@ -3818,7 +3819,6 @@ private uint countBitsSet(T)(T value) @nogc pure nothrow
     return cast(uint)c;
 }
 
-///
 @safe unittest
 {
     assert(countBitsSet(1) == 1);

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2650,6 +2650,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 /// Use a separate mutex when init blocks on another thread that might also call initOnce.
 @system unittest
 {
+    import core.sync.mutex : Mutex;
+
     static shared bool varA, varB;
     __gshared Mutex m;
     m = new Mutex;

--- a/std/conv.d
+++ b/std/conv.d
@@ -3953,7 +3953,6 @@ private T octal(T)(const string num)
     return value;
 }
 
-///
 @system unittest
 {
     int a = octal!int("10");
@@ -5401,6 +5400,7 @@ auto unsigned(T)(T x) if (isIntegral!T)
 ///
 @safe unittest
 {
+    import std.traits : Unsigned;
     immutable int s = 42;
     auto u1 = unsigned(s); //not qualified
     static assert(is(typeof(u1) == uint));
@@ -5475,6 +5475,8 @@ auto signed(T)(T x) if (isIntegral!T)
 ///
 @safe unittest
 {
+    import std.traits : Signed;
+
     immutable uint u = 42;
     auto s1 = signed(u); //not qualified
     static assert(is(typeof(s1) == int));
@@ -5641,7 +5643,6 @@ private bool isHexLiteral(String)(scope const String hexData)
     return !(i & 1);
 }
 
-///
 @safe unittest
 {
     // test all the hex digits

--- a/std/csv.d
+++ b/std/csv.d
@@ -1102,7 +1102,7 @@ public:
 ///
 @safe pure unittest
 {
-    import std.algorithm;
+    import std.algorithm.comparison : equal;
 
     string str = `76;^26^;22`;
     int[] ans = [76,26,22];
@@ -1468,6 +1468,8 @@ void csvNextToken(Range, Malformed ErrorLevel = Malformed.throwException,
 @safe unittest
 {
     import std.array : appender;
+    import std.range.primitives : popFront;
+
     string str = "65,63\n123,3673";
 
     auto a = appender!(char[])();

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -4036,6 +4036,8 @@ public:
     ///
     @safe unittest
     {
+        import std.typecons : No;
+
         auto st1 = SysTime(DateTime(2010, 1, 1, 12, 33, 33));
         st1.roll!"months"(1);
         assert(st1 == SysTime(DateTime(2010, 2, 1, 12, 33, 33)));
@@ -10054,6 +10056,8 @@ public:
     ///
     @safe unittest
     {
+        import std.typecons : No;
+
         auto d1 = Date(2010, 1, 1);
         d1.add!"months"(11);
         assert(d1 == Date(2010, 12, 1));
@@ -10821,6 +10825,8 @@ public:
     ///
     @safe unittest
     {
+        import std.typecons : No;
+
         auto d1 = Date(2010, 1, 1);
         d1.roll!"months"(1);
         assert(d1 == Date(2010, 2, 1));
@@ -15851,6 +15857,8 @@ public:
     ///
     @safe unittest
     {
+        import std.typecons : No;
+
         auto dt1 = DateTime(2010, 1, 1, 12, 30, 33);
         dt1.add!"months"(11);
         assert(dt1 == DateTime(2010, 12, 1, 12, 30, 33));
@@ -15914,6 +15922,8 @@ public:
     ///
     @safe unittest
     {
+        import std.typecons : No;
+
         auto dt1 = DateTime(2010, 1, 1, 12, 33, 33);
         dt1.roll!"months"(1);
         assert(dt1 == DateTime(2010, 2, 1, 12, 33, 33));
@@ -26443,6 +26453,8 @@ static TP delegate(in TP) everyDuration(TP, Direction dir = Direction.fwd, D)
 ///
 @system unittest
 {
+    import std.typecons : Yes;
+
     auto interval = Interval!Date(Date(2010, 9, 2), Date(2025, 9, 27));
     auto func = everyDuration!Date(4, 1, Yes.allowDayOverflow, dur!"days"(2));
     auto range = interval.fwdRange(func);
@@ -33144,6 +33156,8 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
 ///
 @safe unittest
 {
+    import std.exception : assertThrown;
+
     auto tz = new immutable SimpleTimeZone(hours(-8));
     assert(parseRFC822DateTime("Sat, 6 Jan 1990 12:14:19 -0800") ==
            SysTime(DateTime(1990, 1, 6, 12, 14, 19), tz));

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -733,7 +733,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
             if (inputLen - i)
                 (&buffer[index])[0 .. inputLen-i] = (&input[i])[0 .. inputLen-i];
         }
-        ///
+
         unittest
         {
             typeof(this) dig;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -536,10 +536,11 @@ version(Posix) unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
-    import std.experimental.allocator.mmap_allocator : MmapAllocator;
+    import std.experimental.allocator.building_blocks.free_list : ContiguousFreeList;
     import std.experimental.allocator.building_blocks.segregator : Segregator;
-    import std.experimental.allocator.building_blocks.free_list
-        : ContiguousFreeList;
+    import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.experimental.allocator.mmap_allocator : MmapAllocator;
 
     // Ouroboros allocator list based upon 4MB regions, fetched directly from
     // mmap. All memory is released upon destruction.

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -117,6 +117,9 @@ struct FreeList(ParentAllocator,
         ///
         unittest
         {
+            import std.experimental.allocator.mallocator : Mallocator;
+            import std.experimental.allocator.common : chooseAtRuntime;
+
             FreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
             a.min = 64;
             a.max = 128;
@@ -674,6 +677,8 @@ unittest
     import std.experimental.allocator.building_blocks.allocator_list
         : AllocatorList;
 
+    import std.experimental.allocator.common : unbounded;
+
     alias ScalableFreeList = AllocatorList!((n) =>
         ContiguousFreeList!(GCAllocator, 0, unbounded)(4096)
     );
@@ -891,7 +896,10 @@ struct SharedFreeList(ParentAllocator,
         ///
         unittest
         {
-            SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
+            import std.experimental.allocator.mallocator : Mallocator;
+            import std.experimental.allocator.common : chooseAtRuntime;
+
+            shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
             // Set the maxSize first so setting the minSize doesn't throw
             a.max = 128;
             a.min = 64;
@@ -909,7 +917,10 @@ struct SharedFreeList(ParentAllocator,
         ///
         unittest
         {
-            SharedFreeList!(Mallocator, 50, 50, chooseAtRuntime) a;
+            import std.experimental.allocator.mallocator : Mallocator;
+            import std.experimental.allocator.common : chooseAtRuntime;
+
+            shared SharedFreeList!(Mallocator, 50, 50, chooseAtRuntime) a;
             // Set the maxSize first so setting the minSize doesn't throw
             a.approxMaxLength = 128;
             assert(a.approxMaxLength  == 128);

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -213,6 +213,8 @@ unittest
 {
     import std.experimental.allocator.building_blocks.free_tree : FreeTree;
     import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.experimental.allocator.common : roundUpToMultipleOf;
+
     // Quantize small allocations to a multiple of cache line, large ones to a
     // multiple of page size
     alias MyAlloc = Quantizer!(

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1784,6 +1784,7 @@ functions.
 /// Ditto
 unittest
 {
+    import std.experimental.logger.filelogger : FileLogger;
     import std.file : deleteme, remove;
     Logger l = stdThreadLocalLog;
     stdThreadLocalLog = new FileLogger(deleteme ~ "-someFile.log");

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -31,6 +31,8 @@ class NullLogger : Logger
 ///
 @safe unittest
 {
+    import std.experimental.logger.nulllogger : LogLevel;
+
     auto nl1 = new NullLogger(LogLevel.all);
     nl1.info("You will never read this.");
     nl1.fatal("You will never read this, either and it will not throw");

--- a/std/file.d
+++ b/std/file.d
@@ -53,7 +53,8 @@ else version (Posix)
 else
     static assert(0);
 
-package @property string deleteme() @safe
+// Purposefully not documented. Use at your own risk
+@property string deleteme() @safe
 {
     import std.conv : to;
     import std.path : buildPath;

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -61,7 +61,7 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = No.checkDns
     EmailStatusCode errorLevel = EmailStatusCode.none) if (isSomeChar!(Char))
 {
     import std.algorithm.iteration : uniq;
-    import std.algorithm.searching : canFind;
+    import std.algorithm.searching : canFind, maxElement;
     import std.exception : enforce;
     import std.array : array, split;
     import std.conv : to;
@@ -387,7 +387,7 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = No.checkDns
                 switch (token)
                 {
                     case Token.closeBracket:
-                        if (returnStatus.max() < EmailStatusCode.deprecated_)
+                        if (returnStatus.maxElement() < EmailStatusCode.deprecated_)
                         {
                             auto maxGroups = 8;
                             size_t index = -1;
@@ -687,11 +687,11 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = No.checkDns
                 throw new Exception("Unkown context: " ~ to!(string)(context));
         }
 
-        if (returnStatus.max() > EmailStatusCode.rfc5322)
+        if (returnStatus.maxElement() > EmailStatusCode.rfc5322)
             break;
     }
 
-    if (returnStatus.max() < EmailStatusCode.rfc5322)
+    if (returnStatus.maxElement() < EmailStatusCode.rfc5322)
     {
         if (context == EmailPart.contextQuotedString)
             returnStatus ~= EmailStatusCode.errorUnclosedQuotedString;
@@ -730,12 +730,12 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = No.checkDns
 
     auto dnsChecked = false;
 
-    if (checkDNS == Yes.checkDns && returnStatus.max() < EmailStatusCode.dnsWarning)
+    if (checkDNS == Yes.checkDns && returnStatus.maxElement() < EmailStatusCode.dnsWarning)
     {
         assert(false, "DNS check is currently not implemented");
     }
 
-    if (!dnsChecked && returnStatus.max() < EmailStatusCode.dnsWarning)
+    if (!dnsChecked && returnStatus.maxElement() < EmailStatusCode.dnsWarning)
     {
         if (elementCount == 0)
             returnStatus ~= EmailStatusCode.rfc5321TopLevelDomain;
@@ -745,7 +745,7 @@ EmailStatus isEmail (Char) (const(Char)[] email, CheckDns checkDNS = No.checkDns
     }
 
     returnStatus = array(uniq(returnStatus));
-    auto finalStatus = returnStatus.max();
+    auto finalStatus = returnStatus.maxElement();
 
     if (returnStatus.length != 1)
         returnStatus.popFront();
@@ -1744,34 +1744,6 @@ enum AsciiToken
 }
 
 /*
- * Returns the maximum of the values in the given array.
- *
- * Params:
- *     arr = the array containing the values to return the maximum of
- *
- * Returns: the maximum value
- */
-T max (T) (T[] arr)
-{
-    static import std.algorithm.comparison;
-
-    auto max = arr.front;
-
-    foreach (i ; 0 .. arr.length - 1)
-        max = std.algorithm.comparison.max(max, arr[i + 1]);
-
-    return max;
-}
-
-///
-unittest
-{
-    assert([1, 2, 3, 4].max() == 4);
-    assert([3, 5, 9, 2, 5].max() == 9);
-    assert([7, 13, 9, 12, 0].max() == 13);
-}
-
-/*
  * Returns the portion of string specified by the $(D_PARAM start) and
  * $(D_PARAM length) parameters.
  *
@@ -1846,7 +1818,6 @@ T[] substr (T) (T[] str, ptrdiff_t start = 0, ptrdiff_t length = ptrdiff_t.min)
     return str[start .. end];
 }
 
-///
 unittest
 {
     assert("abcdef".substr(-1) == "f");
@@ -1898,7 +1869,6 @@ int compareFirstN (alias pred = "a < b", S1, S2) (S1 s1, S2 s2, size_t length, b
     return caseInsensitive ? slice1.icmp(slice2) : slice1.cmp(slice2);
 }
 
-///
 unittest
 {
     assert("abc".compareFirstN("abcdef", 3) == 0);
@@ -1929,7 +1899,6 @@ auto grep (Range, Regex) (Range input, Regex pattern, bool invert = false)
     return filter!(dg)(input);
 }
 
-///
 unittest
 {
     import std.algorithm.comparison : equal;
@@ -1953,7 +1922,6 @@ ElementType!(A) pop (A) (ref A a) if (isDynamicArray!(A) && !isNarrowString!(A) 
     return e;
 }
 
-///
 unittest
 {
     auto array = [0, 1, 2, 3];

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -124,6 +124,8 @@ template CustomFloat(uint precision, uint exponentWidth, CustomFloatFlags flags 
 ///
 @safe unittest
 {
+    import std.math : sin, cos;
+
     // Define a 16-bit floating point values
     CustomFloat!16                                x;     // Using the number of bits
     CustomFloat!(10, 5)                           y;     // Using the precision and exponent width
@@ -687,6 +689,8 @@ template FPTemporary(F)
 ///
 @safe unittest
 {
+    import std.math : approxEqual;
+
     // Average numbers in an array
     double avg(in double[] a)
     {
@@ -730,6 +734,8 @@ template secantMethod(alias fun)
 ///
 @safe unittest
 {
+    import std.math : approxEqual, cos;
+
     float f(float x)
     {
         return cos(x) - x*x*x;
@@ -1568,6 +1574,8 @@ body
 ///
 @safe unittest
 {
+    import std.math : approxEqual;
+
     auto ret = findLocalMin((double x) => (x-4)^^2, -1e7, 1e7);
     assert(ret.x.approxEqual(4.0));
     assert(ret.y.approxEqual(0.0));
@@ -1901,6 +1909,8 @@ ElementType!Range sumOfLog2s(Range)(Range r)
 ///
 @safe unittest
 {
+    import std.math : isNaN;
+
     assert(sumOfLog2s(new double[0]) == 0);
     assert(sumOfLog2s([0.0L]) == -real.infinity);
     assert(sumOfLog2s([-0.0L]) == -real.infinity);
@@ -1995,6 +2005,8 @@ kullbackLeiblerDivergence(Range1, Range2)(Range1 a, Range2 b)
 ///
 @safe unittest
 {
+    import std.math : approxEqual;
+
     double[] p = [ 0.0, 0, 0, 1 ];
     assert(kullbackLeiblerDivergence(p, p) == 0);
     double[] p1 = [ 0.25, 0.25, 0.25, 0.25 ];
@@ -2076,6 +2088,8 @@ jensenShannonDivergence(Range1, Range2, F)(Range1 a, Range2 b, F limit)
 ///
 @safe unittest
 {
+    import std.math : approxEqual;
+
     double[] p = [ 0.0, 0, 0, 1 ];
     assert(jensenShannonDivergence(p, p) == 0);
     double[] p1 = [ 0.25, 0.25, 0.25, 0.25 ];
@@ -2264,6 +2278,8 @@ gapWeightedSimilarityNormalized(alias comp = "a == b", R1, R2, F)
 ///
 @system unittest
 {
+    import std.math : approxEqual, sqrt;
+
     string[] s = ["Hello", "brave", "new", "world"];
     string[] t = ["Hello", "new", "world"];
     assert(gapWeightedSimilarity(s, s, 1) == 15);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4342,7 +4342,10 @@ __gshared
     @safe unittest
     {
         // Read stdin, sort lines, write to stdout
-        import std.stdio, std.array, std.algorithm : sort, copy;
+        import std.array : array;
+        import std.algorithm.sorting : sort;
+        import std.algorithm.mutation : copy;
+        import std.typecons : Yes;
 
         void main() {
             stdin                       // read from stdin

--- a/std/utf.d
+++ b/std/utf.d
@@ -3168,6 +3168,8 @@ auto ref byCodeUnit(R)(R r)
 ///
 @safe unittest
 {
+    import std.range.primitives;
+
     auto r = "Hello, World!".byCodeUnit();
     static assert(hasLength!(typeof(r)));
     static assert(hasSlicing!(typeof(r)));


### PR DESCRIPTION
Follow-up to #4943: this PR reduces the module exclusion for modules that can be run on dlang.org

For this all tests within a module need to pass separately _without_ the module.