### PR TITLE
Deprecate std.typetuple

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -173,7 +173,7 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   conv csv datetime demangle encoding exception file format \
   functional getopt json math mathspecial meta mmfile numeric \
   outbuffer parallelism path process random signals socket stdint \
-  stdio stdiobase string system traits typecons typetuple uni \
+  stdio stdiobase string system traits typecons uni \
   uri utf uuid variant xml zip zlib
 PACKAGE_std_experimental = typecons
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
@@ -221,7 +221,8 @@ EXTRA_MODULES_INTERNAL := $(addprefix			\
 	unicode_comp unicode_decomp unicode_grapheme unicode_norm) \
 	$(addprefix std/internal/test/, dummyrange) \
 	$(addprefix std/experimental/ndslice/, internal) \
-	$(addprefix std/algorithm/, internal)
+	$(addprefix std/algorithm/, internal) \
+	std/typetuple
 
 EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(EXTRA_MODULES_INTERNAL)
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -162,7 +162,7 @@
  */
 module std.traits;
 
-import std.typetuple; // TypeTuple
+import std.meta; // AliasSeq
 
 ///////////////////////////////////////////////////////////////////////////////
 // Functions
@@ -248,25 +248,25 @@ private
 
     static if (is(ucent))
     {
-        alias CentTypeList         = TypeTuple!(cent, ucent);
-        alias SignedCentTypeList   = TypeTuple!(cent);
-        alias UnsignedCentTypeList = TypeTuple!(ucent);
+        alias CentTypeList         = AliasSeq!(cent, ucent);
+        alias SignedCentTypeList   = AliasSeq!(cent);
+        alias UnsignedCentTypeList = AliasSeq!(ucent);
     }
     else
     {
-        alias CentTypeList         = TypeTuple!();
-        alias SignedCentTypeList   = TypeTuple!();
-        alias UnsignedCentTypeList = TypeTuple!();
+        alias CentTypeList         = AliasSeq!();
+        alias SignedCentTypeList   = AliasSeq!();
+        alias UnsignedCentTypeList = AliasSeq!();
     }
 
-    alias IntegralTypeList      = TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong, CentTypeList);
-    alias SignedIntTypeList     = TypeTuple!(byte, short, int, long, SignedCentTypeList);
-    alias UnsignedIntTypeList   = TypeTuple!(ubyte, ushort, uint, ulong, UnsignedCentTypeList);
-    alias FloatingPointTypeList = TypeTuple!(float, double, real);
-    alias ImaginaryTypeList     = TypeTuple!(ifloat, idouble, ireal);
-    alias ComplexTypeList       = TypeTuple!(cfloat, cdouble, creal);
-    alias NumericTypeList       = TypeTuple!(IntegralTypeList, FloatingPointTypeList);
-    alias CharTypeList          = TypeTuple!(char, wchar, dchar);
+    alias IntegralTypeList      = AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong, CentTypeList);
+    alias SignedIntTypeList     = AliasSeq!(byte, short, int, long, SignedCentTypeList);
+    alias UnsignedIntTypeList   = AliasSeq!(ubyte, ushort, uint, ulong, UnsignedCentTypeList);
+    alias FloatingPointTypeList = AliasSeq!(float, double, real);
+    alias ImaginaryTypeList     = AliasSeq!(ifloat, idouble, ireal);
+    alias ComplexTypeList       = AliasSeq!(cfloat, cdouble, creal);
+    alias NumericTypeList       = AliasSeq!(IntegralTypeList, FloatingPointTypeList);
+    alias CharTypeList          = AliasSeq!(char, wchar, dchar);
 }
 
 package
@@ -324,7 +324,7 @@ template QualifierOf(T)
 
 version(unittest)
 {
-    alias TypeQualifierList = TypeTuple!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf);
+    alias TypeQualifierList = AliasSeq!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf);
 
     struct SubTypeOf(T)
     {
@@ -595,8 +595,8 @@ private template fqnType(T,
         _inout = 3
     }
 
-    alias qualifiers   = TypeTuple!(is(T == const), is(T == immutable), is(T == shared), is(T == inout));
-    alias noQualifiers = TypeTuple!(false, false, false, false);
+    alias qualifiers   = AliasSeq!(is(T == const), is(T == immutable), is(T == shared), is(T == inout));
+    alias noQualifiers = AliasSeq!(false, false, false, false);
 
     string storageClassesString(uint psc)() @property
     {
@@ -954,14 +954,14 @@ alias ParameterTypeTuple = Parameters;
 @safe unittest
 {
     int foo(int i, bool b) { return 0; }
-    static assert(is(ParameterTypeTuple!foo == TypeTuple!(int, bool)));
-    static assert(is(ParameterTypeTuple!(typeof(&foo)) == TypeTuple!(int, bool)));
+    static assert(is(ParameterTypeTuple!foo == AliasSeq!(int, bool)));
+    static assert(is(ParameterTypeTuple!(typeof(&foo)) == AliasSeq!(int, bool)));
 
     struct S { real opCall(real r, int i) { return 0.0; } }
     S s;
-    static assert(is(ParameterTypeTuple!S == TypeTuple!(real, int)));
-    static assert(is(ParameterTypeTuple!(S*) == TypeTuple!(real, int)));
-    static assert(is(ParameterTypeTuple!s == TypeTuple!(real, int)));
+    static assert(is(ParameterTypeTuple!S == AliasSeq!(real, int)));
+    static assert(is(ParameterTypeTuple!(S*) == AliasSeq!(real, int)));
+    static assert(is(ParameterTypeTuple!s == AliasSeq!(real, int)));
 
     class Test
     {
@@ -1039,14 +1039,14 @@ template ParameterStorageClassTuple(func...)
             enum rest = demang.rest;
 
             alias demangleNextParameter =
-                TypeTuple!(
+                AliasSeq!(
                     demang.value + 0, // workaround: "not evaluatable at ..."
                     demangleNextParameter!(rest[skip .. $], i + 1)
                 );
         }
         else // went thru all the parameters
         {
-            alias demangleNextParameter = TypeTuple!();
+            alias demangleNextParameter = AliasSeq!();
         }
     }
 
@@ -1148,15 +1148,15 @@ template ParameterIdentifierTuple(func...)
 
         // Define dummy entities to avoid pointless errors
         template Get(size_t i) { enum Get = ""; }
-        alias PT = TypeTuple!();
+        alias PT = AliasSeq!();
     }
 
     template Impl(size_t i = 0)
     {
         static if (i == PT.length)
-            alias Impl = TypeTuple!();
+            alias Impl = AliasSeq!();
         else
-            alias Impl = TypeTuple!(Get!i, Impl!(i+1));
+            alias Impl = AliasSeq!(Get!i, Impl!(i+1));
     }
 
     alias ParameterIdentifierTuple = Impl!();
@@ -1238,15 +1238,15 @@ template ParameterDefaults(func...)
 
         // Define dummy entities to avoid pointless errors
         template Get(size_t i) { enum Get = ""; }
-        alias PT = TypeTuple!();
+        alias PT = AliasSeq!();
     }
 
     template Impl(size_t i = 0)
     {
         static if (i == PT.length)
-            alias Impl = TypeTuple!();
+            alias Impl = AliasSeq!();
         else
-            alias Impl = TypeTuple!(Get!i, Impl!(i+1));
+            alias Impl = AliasSeq!(Get!i, Impl!(i+1));
     }
 
     alias ParameterDefaults = Impl!();
@@ -1274,20 +1274,20 @@ alias ParameterDefaultValueTuple = ParameterDefaults;
     static assert(PDVT!bar.length == 2);
     static assert(PDVT!bar[0] == 1);
     static assert(PDVT!bar[1] == "hello");
-    static assert(is(typeof(PDVT!bar) == typeof(TypeTuple!(1, "hello"))));
+    static assert(is(typeof(PDVT!bar) == typeof(AliasSeq!(1, "hello"))));
 
     void baz(int x, int n = 1, string s = "hello"){}
     static assert(PDVT!baz.length == 3);
     static assert(is(PDVT!baz[0] == void));
     static assert(   PDVT!baz[1] == 1);
     static assert(   PDVT!baz[2] == "hello");
-    static assert(is(typeof(PDVT!baz) == typeof(TypeTuple!(void, 1, "hello"))));
+    static assert(is(typeof(PDVT!baz) == typeof(AliasSeq!(void, 1, "hello"))));
 
     // bug 10800 - property functions return empty string
     @property void foo(int x = 3) { }
     static assert(PDVT!foo.length == 1);
     static assert(PDVT!foo[0] == 3);
-    static assert(is(typeof(PDVT!foo) == typeof(TypeTuple!(3))));
+    static assert(is(typeof(PDVT!foo) == typeof(AliasSeq!(3))));
 
     struct Colour
     {
@@ -1847,7 +1847,7 @@ template FunctionTypeOf(func...)
         int  test(int);
         int  test() @property;
     }
-    alias ov = TypeTuple!(__traits(getVirtualFunctions, Overloads, "test"));
+    alias ov = AliasSeq!(__traits(getVirtualFunctions, Overloads, "test"));
     alias F_ov0 = FunctionTypeOf!(ov[0]);
     alias F_ov1 = FunctionTypeOf!(ov[1]);
     alias F_ov2 = FunctionTypeOf!(ov[2]);
@@ -1984,10 +1984,10 @@ version (unittest)
     import std.algorithm.iteration : reduce;
 
     alias FA = FunctionAttribute;
-    foreach (BaseT; TypeTuple!(typeof(&sc), typeof(&novar), typeof(&cstyle),
+    foreach (BaseT; AliasSeq!(typeof(&sc), typeof(&novar), typeof(&cstyle),
         typeof(&dstyle), typeof(&typesafe)))
     {
-        foreach (T; TypeTuple!(BaseT, FunctionTypeOf!BaseT))
+        foreach (T; AliasSeq!(BaseT, FunctionTypeOf!BaseT))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum linkage = functionLinkage!T;
             enum attrs = functionAttributes!T;
@@ -1998,7 +1998,7 @@ version (unittest)
             // Check that all linkage types work (D-style variadics require D linkage).
             static if (variadicFunctionStyle!T != Variadic.d)
             {
-                foreach (newLinkage; TypeTuple!("D", "C", "Windows", "Pascal", "C++"))
+                foreach (newLinkage; AliasSeq!("D", "C", "Windows", "Pascal", "C++"))
                 {
                     alias New = SetFunctionAttributes!(T, newLinkage, attrs);
                     static assert(functionLinkage!New == newLinkage,
@@ -2200,14 +2200,14 @@ template Fields(T)
     else static if (is(T == class))
         alias Fields = typeof(T.tupleof);
     else
-        alias Fields = TypeTuple!T;
+        alias Fields = AliasSeq!T;
 }
 
 ///
 @safe unittest
 {
     struct S { int x; float y; }
-    static assert(is(Fields!S == TypeTuple!(int, float)));
+    static assert(is(Fields!S == AliasSeq!(int, float)));
 }
 
 /**
@@ -2217,24 +2217,24 @@ alias FieldTypeTuple = Fields;
 
 @safe unittest
 {
-    static assert(is(FieldTypeTuple!int == TypeTuple!int));
+    static assert(is(FieldTypeTuple!int == AliasSeq!int));
 
     static struct StaticStruct1 { }
-    static assert(is(FieldTypeTuple!StaticStruct1 == TypeTuple!()));
+    static assert(is(FieldTypeTuple!StaticStruct1 == AliasSeq!()));
 
     static struct StaticStruct2 { int a, b; }
-    static assert(is(FieldTypeTuple!StaticStruct2 == TypeTuple!(int, int)));
+    static assert(is(FieldTypeTuple!StaticStruct2 == AliasSeq!(int, int)));
 
     int i;
 
     struct NestedStruct1 { void f() { ++i; } }
-    static assert(is(FieldTypeTuple!NestedStruct1 == TypeTuple!()));
+    static assert(is(FieldTypeTuple!NestedStruct1 == AliasSeq!()));
 
     struct NestedStruct2 { int a; void f() { ++i; } }
-    static assert(is(FieldTypeTuple!NestedStruct2 == TypeTuple!int));
+    static assert(is(FieldTypeTuple!NestedStruct2 == AliasSeq!int));
 
     class NestedClass { int a; void f() { ++i; } }
-    static assert(is(FieldTypeTuple!NestedClass == TypeTuple!int));
+    static assert(is(FieldTypeTuple!NestedClass == AliasSeq!int));
 }
 
 
@@ -2256,37 +2256,37 @@ template FieldNameTuple(T)
     else static if (is(T == class))
         alias FieldNameTuple = staticMap!(NameOf, T.tupleof);
     else
-        alias FieldNameTuple = TypeTuple!"";
+        alias FieldNameTuple = AliasSeq!"";
 }
 
 ///
 @safe unittest
 {
     struct S { int x; float y; }
-    static assert(FieldNameTuple!S == TypeTuple!("x", "y"));
-    static assert(FieldNameTuple!int == TypeTuple!"");
+    static assert(FieldNameTuple!S == AliasSeq!("x", "y"));
+    static assert(FieldNameTuple!int == AliasSeq!"");
 }
 
 @safe unittest
 {
-    static assert(FieldNameTuple!int == TypeTuple!"");
+    static assert(FieldNameTuple!int == AliasSeq!"");
 
     static struct StaticStruct1 { }
-    static assert(is(FieldNameTuple!StaticStruct1 == TypeTuple!()));
+    static assert(is(FieldNameTuple!StaticStruct1 == AliasSeq!()));
 
     static struct StaticStruct2 { int a, b; }
-    static assert(FieldNameTuple!StaticStruct2 == TypeTuple!("a", "b"));
+    static assert(FieldNameTuple!StaticStruct2 == AliasSeq!("a", "b"));
 
     int i;
 
     struct NestedStruct1 { void f() { ++i; } }
-    static assert(is(FieldNameTuple!NestedStruct1 == TypeTuple!()));
+    static assert(is(FieldNameTuple!NestedStruct1 == AliasSeq!()));
 
     struct NestedStruct2 { int a; void f() { ++i; } }
-    static assert(FieldNameTuple!NestedStruct2 == TypeTuple!"a");
+    static assert(FieldNameTuple!NestedStruct2 == AliasSeq!"a");
 
     class NestedClass { int a; void f() { ++i; } }
-    static assert(FieldNameTuple!NestedClass == TypeTuple!"a");
+    static assert(FieldNameTuple!NestedClass == AliasSeq!"a");
 }
 
 
@@ -2300,7 +2300,7 @@ template RepresentationTypeTuple(T)
     {
         static if (T.length == 0)
         {
-            alias Impl = TypeTuple!();
+            alias Impl = AliasSeq!();
         }
         else
         {
@@ -2319,7 +2319,7 @@ template RepresentationTypeTuple(T)
             }
             else
             {
-                alias Impl = TypeTuple!(T[0], Impl!(T[1 .. $]));
+                alias Impl = AliasSeq!(T[0], Impl!(T[1 .. $]));
             }
         }
     }
@@ -2348,14 +2348,14 @@ template RepresentationTypeTuple(T)
 @safe unittest
 {
     alias S1 = RepresentationTypeTuple!int;
-    static assert(is(S1 == TypeTuple!int));
+    static assert(is(S1 == AliasSeq!int));
 
     struct S2 { int a; }
     struct S3 { int a; char b; }
     struct S4 { S1 a; int b; S3 c; }
-    static assert(is(RepresentationTypeTuple!S2 == TypeTuple!int));
-    static assert(is(RepresentationTypeTuple!S3 == TypeTuple!(int, char)));
-    static assert(is(RepresentationTypeTuple!S4 == TypeTuple!(int, int, int, char)));
+    static assert(is(RepresentationTypeTuple!S2 == AliasSeq!int));
+    static assert(is(RepresentationTypeTuple!S3 == AliasSeq!(int, char)));
+    static assert(is(RepresentationTypeTuple!S4 == AliasSeq!(int, int, int, char)));
 
     struct S11 { int a; float b; }
     struct S21 { char[] a; union { S11 b; S11 * c; } }
@@ -3552,11 +3552,11 @@ template BaseTypeTuple(A)
     interface I1 { }
     interface I2 { }
     interface I12 : I1, I2 { }
-    static assert(is(BaseTypeTuple!I12 == TypeTuple!(I1, I2)));
+    static assert(is(BaseTypeTuple!I12 == AliasSeq!(I1, I2)));
 
     interface I3 : I1 { }
     interface I123 : I1, I2, I3 { }
-    static assert(is(BaseTypeTuple!I123 == TypeTuple!(I1, I2, I3)));
+    static assert(is(BaseTypeTuple!I123 == AliasSeq!(I1, I2, I3)));
 }
 
 @safe unittest
@@ -3585,16 +3585,16 @@ template BaseClassesTuple(T)
 {
     static if (is(T == Object))
     {
-        alias BaseClassesTuple = TypeTuple!();
+        alias BaseClassesTuple = AliasSeq!();
     }
     else static if (is(BaseTypeTuple!T[0] == Object))
     {
-        alias BaseClassesTuple = TypeTuple!Object;
+        alias BaseClassesTuple = AliasSeq!Object;
     }
     else
     {
         alias BaseClassesTuple =
-            TypeTuple!(BaseTypeTuple!T[0],
+            AliasSeq!(BaseTypeTuple!T[0],
                        BaseClassesTuple!(BaseTypeTuple!T[0]));
     }
 }
@@ -3606,9 +3606,9 @@ template BaseClassesTuple(T)
     class C2 : C1 { }
     class C3 : C2 { }
     static assert(!BaseClassesTuple!Object.length);
-    static assert(is(BaseClassesTuple!C1 == TypeTuple!(Object)));
-    static assert(is(BaseClassesTuple!C2 == TypeTuple!(C1, Object)));
-    static assert(is(BaseClassesTuple!C3 == TypeTuple!(C2, C1, Object)));
+    static assert(is(BaseClassesTuple!C1 == AliasSeq!(Object)));
+    static assert(is(BaseClassesTuple!C2 == AliasSeq!(C1, Object)));
+    static assert(is(BaseClassesTuple!C3 == AliasSeq!(C2, C1, Object)));
 }
 
 @safe unittest
@@ -3619,7 +3619,7 @@ template BaseClassesTuple(T)
     static assert(!__traits(compiles, BaseClassesTuple!I));
     class C4 : I { }
     class C5 : C4, I { }
-    static assert(is(BaseClassesTuple!C5 == TypeTuple!(C4, Object)));
+    static assert(is(BaseClassesTuple!C5 == AliasSeq!(C4, Object)));
 }
 
 /**
@@ -3635,12 +3635,12 @@ template InterfacesTuple(T)
     {
         static if (T.length)
         {
-            alias Flatten = TypeTuple!(Flatten!H, Flatten!T);
+            alias Flatten = AliasSeq!(Flatten!H, Flatten!T);
         }
         else
         {
             static if (is(H == interface))
-                alias Flatten = TypeTuple!(H, InterfacesTuple!H);
+                alias Flatten = AliasSeq!(H, InterfacesTuple!H);
             else
                 alias Flatten = InterfacesTuple!H;
         }
@@ -3649,7 +3649,7 @@ template InterfacesTuple(T)
     static if (is(T S == super) && S.length)
         alias InterfacesTuple = NoDuplicates!(Flatten!S);
     else
-        alias InterfacesTuple = TypeTuple!();
+        alias InterfacesTuple = AliasSeq!();
 }
 
 @safe unittest
@@ -3677,9 +3677,9 @@ template InterfacesTuple(T)
     class B2 : J {}
     class C2 : B2, Ia, Ib {}
     static assert(is(InterfacesTuple!I ==
-                    TypeTuple!(Ia, Iaa, Iab, Ib, Iba, Ibb)));
+                    AliasSeq!(Ia, Iaa, Iab, Ib, Iba, Ibb)));
     static assert(is(InterfacesTuple!C2 ==
-                    TypeTuple!(J, Ia, Iaa, Iab, Ib, Iba, Ibb)));
+                    AliasSeq!(J, Ia, Iaa, Iab, Ib, Iba, Ibb)));
 
 }
 
@@ -3692,10 +3692,10 @@ template InterfacesTuple(T)
 template TransitiveBaseTypeTuple(T)
 {
     static if (is(T == Object))
-        alias TransitiveBaseTypeTuple = TypeTuple!();
+        alias TransitiveBaseTypeTuple = AliasSeq!();
     else
         alias TransitiveBaseTypeTuple =
-            TypeTuple!(BaseClassesTuple!T, InterfacesTuple!T);
+            AliasSeq!(BaseClassesTuple!T, InterfacesTuple!T);
 }
 
 ///
@@ -3736,28 +3736,28 @@ template MemberFunctionsTuple(C, string name)
             static if (__traits(hasMember, Node, name) && __traits(compiles, __traits(getMember, Node, name)))
             {
                 // Get all overloads in sight (not hidden).
-                alias inSight = TypeTuple!(__traits(getVirtualFunctions, Node, name));
+                alias inSight = AliasSeq!(__traits(getVirtualFunctions, Node, name));
 
                 // And collect all overloads in ancestor classes to reveal hidden
                 // methods.  The result may contain duplicates.
                 template walkThru(Parents...)
                 {
                     static if (Parents.length > 0)
-                        alias walkThru = TypeTuple!(
+                        alias walkThru = AliasSeq!(
                                     CollectOverloads!(Parents[0]),
                                     walkThru!(Parents[1 .. $])
                                 );
                     else
-                        alias walkThru = TypeTuple!();
+                        alias walkThru = AliasSeq!();
                 }
 
                 static if (is(Node Parents == super))
-                    alias CollectOverloads = TypeTuple!(inSight, walkThru!Parents);
+                    alias CollectOverloads = AliasSeq!(inSight, walkThru!Parents);
                 else
-                    alias CollectOverloads = TypeTuple!inSight;
+                    alias CollectOverloads = AliasSeq!inSight;
             }
             else
-                alias CollectOverloads = TypeTuple!(); // no overloads in this hierarchy
+                alias CollectOverloads = AliasSeq!(); // no overloads in this hierarchy
         }
 
         // duplicates in this tuple will be removed by shrink()
@@ -3792,13 +3792,13 @@ template MemberFunctionsTuple(C, string name)
                     alias shrinkOne = shrinkOne!(rest[0], rest[1 .. $]);
                 else
                     // target and rest[0] are distinct.
-                    alias shrinkOne = TypeTuple!(
+                    alias shrinkOne = AliasSeq!(
                                 shrinkOne!(target, rest[1 .. $]),
                                 rest[0] // keep
                             );
             }
             else
-                alias shrinkOne = TypeTuple!target; // done
+                alias shrinkOne = AliasSeq!target; // done
         }
 
         /*
@@ -3809,17 +3809,17 @@ template MemberFunctionsTuple(C, string name)
             static if (overloads.length > 0)
             {
                 alias temp = shrinkOne!overloads;
-                alias shrink = TypeTuple!(temp[0], shrink!(temp[1 .. $]));
+                alias shrink = AliasSeq!(temp[0], shrink!(temp[1 .. $]));
             }
             else
-                alias shrink = TypeTuple!(); // done
+                alias shrink = AliasSeq!(); // done
         }
 
         // done.
         alias MemberFunctionsTuple = shrink!overloads;
     }
     else
-        alias MemberFunctionsTuple = TypeTuple!();
+        alias MemberFunctionsTuple = AliasSeq!();
 }
 
 ///
@@ -3963,7 +3963,7 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
 @safe unittest
 {
     struct Foo(T, U) {}
-    static assert(is(TemplateArgsOf!(Foo!(int, real)) == TypeTuple!(int, real)));
+    static assert(is(TemplateArgsOf!(Foo!(int, real)) == AliasSeq!(int, real)));
 }
 
 @safe unittest
@@ -3980,15 +3980,15 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
 
     enum x = 123;
     enum y = "123";
-    static assert(is(TemplateArgsOf!(Foo1!(int)) == TypeTuple!(int)));
-    static assert(is(TemplateArgsOf!(Foo2!(int, int)) == TypeTuple!(int, int)));
-    static assert(__traits(isSame, TemplateArgsOf!(Foo3!(x)), TypeTuple!(x)));
-    static assert(TemplateArgsOf!(Foo4!(y)) == TypeTuple!(y));
-    static assert(is(TemplateArgsOf!(Foo5!(int)) == TypeTuple!(int)));
-    static assert(is(TemplateArgsOf!(Foo6!(int, int)) == TypeTuple!(int, int)));
-    static assert(__traits(isSame, TemplateArgsOf!(Foo7!(x)), TypeTuple!(x)));
-    static assert(is(TemplateArgsOf!(Foo8!(int).Foo9!(real)) == TypeTuple!(real)));
-    static assert(is(TemplateArgsOf!(Foo10!()) == TypeTuple!()));
+    static assert(is(TemplateArgsOf!(Foo1!(int)) == AliasSeq!(int)));
+    static assert(is(TemplateArgsOf!(Foo2!(int, int)) == AliasSeq!(int, int)));
+    static assert(__traits(isSame, TemplateArgsOf!(Foo3!(x)), AliasSeq!(x)));
+    static assert(TemplateArgsOf!(Foo4!(y)) == AliasSeq!(y));
+    static assert(is(TemplateArgsOf!(Foo5!(int)) == AliasSeq!(int)));
+    static assert(is(TemplateArgsOf!(Foo6!(int, int)) == AliasSeq!(int, int)));
+    static assert(__traits(isSame, TemplateArgsOf!(Foo7!(x)), AliasSeq!(x)));
+    static assert(is(TemplateArgsOf!(Foo8!(int).Foo9!(real)) == AliasSeq!(real)));
+    static assert(is(TemplateArgsOf!(Foo10!()) == AliasSeq!()));
 }
 
 
@@ -4094,62 +4094,62 @@ template ImplicitConversionTargets(T)
 {
     static if (is(T == bool))
         alias ImplicitConversionTargets =
-            TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong, CentTypeList,
+            AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong, CentTypeList,
                        float, double, real, char, wchar, dchar);
     else static if (is(T == byte))
         alias ImplicitConversionTargets =
-            TypeTuple!(short, ushort, int, uint, long, ulong, CentTypeList,
+            AliasSeq!(short, ushort, int, uint, long, ulong, CentTypeList,
                        float, double, real, char, wchar, dchar);
     else static if (is(T == ubyte))
         alias ImplicitConversionTargets =
-            TypeTuple!(short, ushort, int, uint, long, ulong, CentTypeList,
+            AliasSeq!(short, ushort, int, uint, long, ulong, CentTypeList,
                        float, double, real, char, wchar, dchar);
     else static if (is(T == short))
         alias ImplicitConversionTargets =
-            TypeTuple!(int, uint, long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T == ushort))
         alias ImplicitConversionTargets =
-            TypeTuple!(int, uint, long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T == int))
         alias ImplicitConversionTargets =
-            TypeTuple!(long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(long, ulong, CentTypeList, float, double, real);
     else static if (is(T == uint))
         alias ImplicitConversionTargets =
-            TypeTuple!(long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(long, ulong, CentTypeList, float, double, real);
     else static if (is(T == long))
-        alias ImplicitConversionTargets = TypeTuple!(float, double, real);
+        alias ImplicitConversionTargets = AliasSeq!(float, double, real);
     else static if (is(T == ulong))
-        alias ImplicitConversionTargets = TypeTuple!(float, double, real);
+        alias ImplicitConversionTargets = AliasSeq!(float, double, real);
     else static if (is(cent) && is(T == cent))
-        alias ImplicitConversionTargets = TypeTuple!(float, double, real);
+        alias ImplicitConversionTargets = AliasSeq!(float, double, real);
     else static if (is(ucent) && is(T == ucent))
-        alias ImplicitConversionTargets = TypeTuple!(float, double, real);
+        alias ImplicitConversionTargets = AliasSeq!(float, double, real);
     else static if (is(T == float))
-        alias ImplicitConversionTargets = TypeTuple!(double, real);
+        alias ImplicitConversionTargets = AliasSeq!(double, real);
     else static if (is(T == double))
-        alias ImplicitConversionTargets = TypeTuple!real;
+        alias ImplicitConversionTargets = AliasSeq!real;
     else static if (is(T == char))
         alias ImplicitConversionTargets =
-            TypeTuple!(wchar, dchar, byte, ubyte, short, ushort,
+            AliasSeq!(wchar, dchar, byte, ubyte, short, ushort,
                        int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T == wchar))
         alias ImplicitConversionTargets =
-            TypeTuple!(dchar, short, ushort, int, uint, long, ulong, CentTypeList,
+            AliasSeq!(dchar, short, ushort, int, uint, long, ulong, CentTypeList,
                        float, double, real);
     else static if (is(T == dchar))
         alias ImplicitConversionTargets =
-            TypeTuple!(int, uint, long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T : typeof(null)))
-        alias ImplicitConversionTargets = TypeTuple!(typeof(null));
+        alias ImplicitConversionTargets = AliasSeq!(typeof(null));
     else static if (is(T : Object))
         alias ImplicitConversionTargets = TransitiveBaseTypeTuple!(T);
     else static if (isDynamicArray!T && !is(typeof(T.init[0]) == const))
         alias ImplicitConversionTargets =
-            TypeTuple!(const(Unqual!(typeof(T.init[0])))[]);
+            AliasSeq!(const(Unqual!(typeof(T.init[0])))[]);
     else static if (is(T : void*))
-        alias ImplicitConversionTargets = TypeTuple!(void*);
+        alias ImplicitConversionTargets = AliasSeq!(void*);
     else
-        alias ImplicitConversionTargets = TypeTuple!();
+        alias ImplicitConversionTargets = AliasSeq!();
 }
 
 @safe unittest
@@ -4637,7 +4637,7 @@ int i = rvalueOf!int; // error, no actual value is returned
     static struct S { }
     int i;
     struct Nested { void f() { ++i; } }
-    foreach (T; TypeTuple!(int, immutable int, inout int, string, S, Nested, Object))
+    foreach (T; AliasSeq!(int, immutable int, inout int, string, S, Nested, Object))
     {
         static assert(!__traits(compiles, needLvalue(rvalueOf!T)));
         static assert( __traits(compiles, needLvalue(lvalueOf!T)));
@@ -4657,7 +4657,7 @@ int i = rvalueOf!int; // error, no actual value is returned
 
 private template AliasThisTypeOf(T) if (isAggregateType!T)
 {
-    alias members = TypeTuple!(__traits(getAliasThis, T));
+    alias members = AliasSeq!(__traits(getAliasThis, T));
 
     static if (members.length == 1)
     {
@@ -4687,14 +4687,14 @@ template BooleanTypeOf(T)
 @safe unittest
 {
     // unexpected failure, maybe dmd type-merging bug
-    foreach (T; TypeTuple!bool)
+    foreach (T; AliasSeq!bool)
         foreach (Q; TypeQualifierList)
         {
             static assert( is(Q!T == BooleanTypeOf!(            Q!T  )));
             static assert( is(Q!T == BooleanTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(void, NumericTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+    foreach (T; AliasSeq!(void, NumericTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(BooleanTypeOf!(            Q!T  )), Q!T.stringof);
@@ -4745,7 +4745,7 @@ template IntegralTypeOf(T)
             static assert( is(Q!T == IntegralTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(void, bool, FloatingPointTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+    foreach (T; AliasSeq!(void, bool, FloatingPointTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(IntegralTypeOf!(            Q!T  )));
@@ -4780,7 +4780,7 @@ template FloatingPointTypeOf(T)
             static assert( is(Q!T == FloatingPointTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(void, bool, IntegralTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+    foreach (T; AliasSeq!(void, bool, IntegralTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(FloatingPointTypeOf!(            Q!T  )));
@@ -4809,7 +4809,7 @@ template NumericTypeOf(T)
             static assert( is(Q!T == NumericTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(void, bool, CharTypeList, ImaginaryTypeList, ComplexTypeList))
+    foreach (T; AliasSeq!(void, bool, CharTypeList, ImaginaryTypeList, ComplexTypeList))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(NumericTypeOf!(            Q!T  )));
@@ -4870,14 +4870,14 @@ template CharTypeOf(T)
             static assert( is(CharTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(void, bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+    foreach (T; AliasSeq!(void, bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(CharTypeOf!(            Q!T  )));
             static assert(!is(CharTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; TypeTuple!(string, wstring, dstring, char[4]))
+    foreach (T; AliasSeq!(string, wstring, dstring, char[4]))
         foreach (Q; TypeQualifierList)
         {
             static assert(!is(CharTypeOf!(            Q!T  )));
@@ -4902,8 +4902,8 @@ template StaticArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
+    foreach (T; AliasSeq!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+        foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
         {
             static assert(is( Q!(   T[1] ) == StaticArrayTypeOf!( Q!(              T[1]  ) ) ));
 
@@ -4913,8 +4913,8 @@ template StaticArrayTypeOf(T)
             }
         }
 
-    foreach (T; TypeTuple!void)
-        foreach (Q; TypeTuple!TypeQualifierList)
+    foreach (T; AliasSeq!void)
+        foreach (Q; AliasSeq!TypeQualifierList)
         {
             static assert(is( StaticArrayTypeOf!( Q!(void[1]) ) == Q!(void[1]) ));
         }
@@ -4939,13 +4939,13 @@ template DynamicArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
+    foreach (T; AliasSeq!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+        foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
         {
             static assert(is( Q!T[]  == DynamicArrayTypeOf!( Q!T[] ) ));
             static assert(is( Q!(T[])  == DynamicArrayTypeOf!( Q!(T[]) ) ));
 
-            foreach (P; TypeTuple!(MutableOf, ConstOf, ImmutableOf))
+            foreach (P; AliasSeq!(MutableOf, ConstOf, ImmutableOf))
             {
                 static assert(is( Q!(P!T[]) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!T[])) ) ));
                 static assert(is( Q!(P!(T[])) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!(T[]))) ) ));
@@ -4995,7 +4995,7 @@ template StringTypeOf(T)
 @safe unittest
 {
     foreach (T; CharTypeList)
-        foreach (Q; TypeTuple!(MutableOf, ConstOf, ImmutableOf, InoutOf))
+        foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf, InoutOf))
         {
             static assert(is(Q!T[] == StringTypeOf!( Q!T[] )));
 
@@ -5010,7 +5010,7 @@ template StringTypeOf(T)
         }
 
     foreach (T; CharTypeList)
-        foreach (Q; TypeTuple!(SharedOf, SharedConstOf, SharedInoutOf))
+        foreach (Q; AliasSeq!(SharedOf, SharedConstOf, SharedInoutOf))
         {
             static assert(!is(StringTypeOf!( Q!T[] )));
         }
@@ -5040,19 +5040,19 @@ template AssocArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-        foreach (P; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
-            foreach (Q; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
-                foreach (R; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
+    foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
+        foreach (P; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+            foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+                foreach (R; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
                 {
                     static assert(is( P!(Q!T[R!T]) == AssocArrayTypeOf!(            P!(Q!T[R!T])  ) ));
                 }
 
-    foreach (T; TypeTuple!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-        foreach (O; TypeTuple!(TypeQualifierList, InoutOf, SharedInoutOf))
-            foreach (P; TypeTuple!TypeQualifierList)
-                foreach (Q; TypeTuple!TypeQualifierList)
-                    foreach (R; TypeTuple!TypeQualifierList)
+    foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
+        foreach (O; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+            foreach (P; AliasSeq!TypeQualifierList)
+                foreach (Q; AliasSeq!TypeQualifierList)
+                    foreach (R; AliasSeq!TypeQualifierList)
                     {
                         static assert(is( O!(P!(Q!T[R!T])) == AssocArrayTypeOf!( O!(SubTypeOf!(P!(Q!T[R!T]))) ) ));
                     }
@@ -5126,7 +5126,7 @@ enum bool isFloatingPoint(T) = is(FloatingPointTypeOf!T) && !isAggregateType!T;
 {
     enum EF : real { a = 1.414, b = 1.732, c = 2.236 }
 
-    foreach (T; TypeTuple!(FloatingPointTypeList, EF))
+    foreach (T; AliasSeq!(FloatingPointTypeList, EF))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5151,7 +5151,7 @@ enum bool isNumeric(T) = is(NumericTypeOf!T) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(NumericTypeList))
+    foreach (T; AliasSeq!(NumericTypeList))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5206,7 +5206,7 @@ enum bool isUnsigned(T) = is(UnsignedTypeOf!T) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(UnsignedIntTypeList))
+    foreach (T; AliasSeq!(UnsignedIntTypeList))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5223,7 +5223,7 @@ enum bool isSigned(T) = is(SignedTypeOf!T) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(SignedIntTypeList))
+    foreach (T; AliasSeq!(SignedIntTypeList))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5264,7 +5264,7 @@ enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
 {
     enum EC : char { a = 'x', b = 'y' }
 
-    foreach (T; TypeTuple!(CharTypeList, EC))
+    foreach (T; AliasSeq!(CharTypeList, EC))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5308,7 +5308,7 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(char[], dchar[], string, wstring, dstring))
+    foreach (T; AliasSeq!(char[], dchar[], string, wstring, dstring))
     {
         static assert( isSomeString!(           T ));
         static assert(!isSomeString!(SubTypeOf!(T)));
@@ -5337,16 +5337,16 @@ enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) &&
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(char[], string, wstring))
+    foreach (T; AliasSeq!(char[], string, wstring))
     {
-        foreach (Q; TypeTuple!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
+        foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
         {
             static assert( isNarrowString!(            Q!T  ));
             static assert(!isNarrowString!( SubTypeOf!(Q!T) ));
         }
     }
 
-    foreach (T; TypeTuple!(int, int[], byte[], dchar[], dstring, char[4]))
+    foreach (T; AliasSeq!(int, int[], byte[], dchar[], dstring, char[4]))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5453,7 +5453,7 @@ enum bool isStaticArray(T) = is(StaticArrayTypeOf!T) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(int[51], int[][2],
+    foreach (T; AliasSeq!(int[51], int[][2],
                            char[][int][11], immutable char[13u],
                            const(real)[1], const(real)[1][1], void[0]))
     {
@@ -5541,7 +5541,7 @@ enum bool isAssociativeArray(T) = is(AssocArrayTypeOf!T) && !isAggregateType!T;
         @property uint[] values() { return null; }
     }
 
-    foreach (T; TypeTuple!(int[int], int[string], immutable(char[5])[int]))
+    foreach (T; AliasSeq!(int[int], int[string], immutable(char[5])[int]))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -5607,7 +5607,7 @@ enum bool isPointer(T) = is(T == U*, U) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; TypeTuple!(int*, void*, char[]*))
+    foreach (T; AliasSeq!(int*, void*, char[]*))
     {
         foreach (Q; TypeQualifierList)
         {
@@ -6575,10 +6575,10 @@ template mostNegative(T)
 ///
 @safe unittest
 {
-    foreach (T; TypeTuple!(bool, byte, short, int, long))
+    foreach (T; AliasSeq!(bool, byte, short, int, long))
         static assert(mostNegative!T == T.min);
 
-    foreach (T; TypeTuple!(ubyte, ushort, uint, ulong, char, wchar, dchar))
+    foreach (T; AliasSeq!(ubyte, ushort, uint, ulong, char, wchar, dchar))
         static assert(mostNegative!T == 0);
 }
 
@@ -6607,14 +6607,14 @@ unittest
 unittest
 {
     // promote to int:
-    foreach (T; TypeTuple!(bool, byte, ubyte, short, ushort, char, wchar))
+    foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, char, wchar))
     {
         static assert(is(Promoted!T == int));
         static assert(is(Promoted!(shared(const T)) == shared(const int)));
     }
 
     // already promoted:
-    foreach (T; TypeTuple!(int, uint, long, ulong, float, double, real))
+    foreach (T; AliasSeq!(int, uint, long, ulong, float, double, real))
     {
         static assert(is(Promoted!T == T));
         static assert(is(Promoted!(immutable(T)) == immutable(T)));

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -7,32 +7,12 @@
  * Authors:
  * Source:    $(PHOBOSSRC std/_typetuple.d)
  */
+// @@@DEPRECATED_2017-12@@@
+deprecated("It will be removed from Phobos in December 2017. Use std.meta")
 module std.typetuple;
 
 public import std.meta;
 
-/**
- * Alternate name for $(REF AliasSeq, std,meta) for legacy compatibility.
- */
+// @@@DEPRECATED_2017-12@@@
+deprecated("TypeTuple has been renamed to std.meta.AliasSeq. It will be removed from Phobos in December 2017")
 alias TypeTuple = AliasSeq;
-
-///
-@safe unittest
-{
-    import std.typetuple;
-    alias TL = TypeTuple!(int, double);
-
-    int foo(TL td)  // same as int foo(int, double);
-    {
-        return td[0] + cast(int)td[1];
-    }
-}
-
-///
-@safe unittest
-{
-    alias TL = TypeTuple!(int, double);
-
-    alias Types = TypeTuple!(TL, char);
-    static assert(is(Types == TypeTuple!(int, double, char)));
-}


### PR DESCRIPTION
Split off #4954 that simply deprecates `std.typetuple : TypeTuple` in favor of `std.meta : AliasSeq`.
It also removes `typetuple` from the documentation build.

Note that the [documentation](https://dlang.org/phobos/std_typetuple.html) has stated the rename for quite a long time, but it didn't trigger deprecation warnings