### PR TITLE
Enforce successful ddoc run

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,8 @@ dependencies:
 
 test:
   override:
-    - ./circleci.sh style
     - ./circleci.sh setup-repos
+    - ./circleci.sh style
     - ./circleci.sh publictests
     - ./circleci.sh coverage:
         parallel: true

--- a/posix.mak
+++ b/posix.mak
@@ -494,7 +494,7 @@ checkwhitespace: $(LIB)
 	mv dscanner_makefile_tmp ../dscanner/makefile
 	make -C ../dscanner githash debug
 
-style: ../dscanner/dsc
+style: ../dscanner/dsc $(LIB)
 	@echo "Check for trailing whitespace"
 	grep -nr '[[:blank:]]$$' etc std ; test $$? -eq 1
 
@@ -526,7 +526,7 @@ style: ../dscanner/dsc
 	grep -nrE "[[:alnum:]](==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]] (==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]](==|!=|<=|<<|>>|>>>|^^) [[:alnum:]]" $$(find . -name '*.d'); test $$? -eq 1
 
 	@echo "Check that Ddoc runs without errors"
-	$(DMD) -w -D -main -c -o- $$(find etc std -type f -name '*.d' | grep -vE 'std/experimental/ndslice/iteration.d') 2>&1 | grep -v "Deprecation:"; test $$? -eq 1
+	$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -w -D -main -c -o- $$(find etc std -type f -name '*.d' | grep -vE 'std/experimental/ndslice/iteration.d') 2>&1 | grep -v "Deprecation:"; test $$? -eq 1
 
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"

--- a/posix.mak
+++ b/posix.mak
@@ -525,6 +525,9 @@ style: ../dscanner/dsc
 	@echo "Enforce space between binary operators"
 	grep -nrE "[[:alnum:]](==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]] (==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]](==|!=|<=|<<|>>|>>>|^^) [[:alnum:]]" $$(find . -name '*.d'); test $$? -eq 1
 
+	@echo "Check that Ddoc runs without errors"
+	$(DMD) -w -D -main -c -o- $$(find etc std -type f -name '*.d' | grep -vE 'std/experimental/ndslice/iteration.d') 2>&1 | grep -v "Deprecation:"; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -444,7 +444,7 @@ left to right for all elements $(D a) in $(D range). The original ranges are
 not changed. Evaluation is done lazily.
 
 Params:
-    fun = one or more functions
+    fun = one or more transformation functions
     r = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
 
 Returns:
@@ -2711,6 +2711,9 @@ seed (the range must be non-empty).
 Returns:
     the accumulated $(D result)
 
+Params:
+    fun = one or more functions
+
 See_Also:
     $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
 
@@ -3238,6 +3241,10 @@ This function is also known as
     $(HTTP docs.python.org/3/library/itertools.html#itertools.accumulate, accumulate),
     $(HTTP hackage.haskell.org/package/base-4.8.2.0/docs/Prelude.html#v:scanl, scan),
     $(HTTP mathworld.wolfram.com/CumulativeSum.html, Cumulative Sum).
+
+Params:
+    fun = one or more functions to use as fold operation
+
 Returns:
     The function returns a range containing the consecutive reduced values. If
     there is more than one `fun`, the element type will be $(REF Tuple,
@@ -3259,6 +3266,7 @@ if (fun.length >= 1)
     `ElementType!R`.
     Once `S` has been determined, then $(D S s = e;) and $(D s = f(s, e);) must
     both be legal.
+
     Params:
         range = An $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
     Returns:
@@ -3277,6 +3285,7 @@ if (fun.length >= 1)
     For convenience, if the seed is `const`, or has qualified fields, then
     `cumulativeFold` will operate on an unqualified copy. If this happens
     then the returned type will not perfectly match `S`.
+
     Params:
         range = An $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
         seed = the initial value of the accumulator

--- a/std/conv.d
+++ b/std/conv.d
@@ -1877,7 +1877,7 @@ This overload converts an character input range to a `bool`.
 
 Params:
     Target = the type to convert to
-    s = the lvalue of an input range
+    source = the lvalue of an input range
 
 Returns:
     A `bool`
@@ -2534,7 +2534,7 @@ if (isSomeString!Source && !is(Source == enum) &&
  *
  * Params:
  *     Target = a floating point type
- *     p = the lvalue of the range to _parse
+ *     source = the lvalue of the range to _parse
  *
  * Returns:
  *     A floating point number of type `Target`

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1612,18 +1612,18 @@ lengths = static array containing the size of each dimension
 Returns:
 An N-dimensional array with individual elements of type T.
 */
-auto makeMultidimensionalArray(T, Allocator, size_t n)(auto ref Allocator alloc, size_t[n] lengths...)
+auto makeMultidimensionalArray(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths...)
 {
-    static if (n == 1)
+    static if (N == 1)
     {
         return makeArray!T(alloc, lengths[0]);
     }
     else
     {
-        alias E = typeof(makeMultidimensionalArray!(T, Allocator, n - 1)(alloc, lengths[1 .. $]));
+        alias E = typeof(makeMultidimensionalArray!(T, Allocator, N - 1)(alloc, lengths[1 .. $]));
         auto ret = makeArray!E(alloc, lengths[0]);
         foreach (ref e; ret)
-            e = makeMultidimensionalArray!(T, Allocator, n - 1)(alloc, lengths[1 .. $]);
+            e = makeMultidimensionalArray!(T, Allocator, N - 1)(alloc, lengths[1 .. $]);
         return ret;
     }
 }

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -404,7 +404,6 @@ Params:
     slice = input slice
     Dimensions = indexes of dimensions to be brought to the first position
     dimensions = indexes of dimensions to be brought to the first position
-    dimension = index of dimension to be brought to the first position
 Returns:
     n-dimensional slice of the same type
 See_also: $(LREF swapped), $(LREF everted)
@@ -535,7 +534,6 @@ Params:
     slice = input slice
     Dimensions = indexes of dimensions to reverse order of iteration
     dimensions = indexes of dimensions to reverse order of iteration
-    dimension = index of dimension to reverse order of iteration
 Returns:
     n-dimensional slice of the same type
 +/
@@ -641,8 +639,7 @@ Multiplies the stride of the selected dimension by a factor.
 Params:
     slice = input slice
     Dimensions = indexes of dimensions to be strided
-    dimensions = indexes of dimensions to be strided
-    factors = list of step extension factors
+    factors = list of step extension factor
     factor = step extension factors
 Returns:
     n-dimensional slice of the same type
@@ -996,7 +993,6 @@ This makes `dropExactly` faster than `drop`.
 
 Params:
     slice = input slice
-    ns = list of numbers of elements to drop
     n = number of elements to drop
 Returns:
     n-dimensional slice of the same type

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -611,7 +611,6 @@ pure nothrow @system unittest
 Creates an uninitialized array and an n-dimensional slice over it.
 Params:
     lengths = list of lengths for each dimension
-    slice = slice to copy shape and data from
 Returns:
     uninitialized n-dimensional slice
 +/
@@ -749,8 +748,6 @@ See also $(MREF std, experimental, allocator).
 Params:
     alloc = allocator
     lengths = list of lengths for each dimension
-    init = default value for array initialization
-    slice = slice to copy shape and data from
 Returns:
     a structure with fields `array` and `slice`
 +/

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2897,7 +2897,7 @@ pure @safe nothrow @nogc unittest
         `range` with up to `n` elements dropped
 
     See_Also:
-        $(REF popFront, std, range, primitives),$(REF popBackN, std, range, primitives)
+        $(REF popFront, std, range, primitives), $(REF popBackN, std, range, primitives)
   +/
 R drop(R)(R range, size_t n)
 if (isInputRange!R)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2877,13 +2877,13 @@ pure @safe nothrow @nogc unittest
 
 /++
     Convenience function which calls
-    `range.$(REF popFrontN, std, range, primitives)(n)) and returns `range`.
+    `range.$(REF popFrontN, std, range, primitives)(n) and returns `range`.
     `drop` makes it easier to pop elements from a range
     and then pass it to another function within a single expression,
     whereas `popFrontN` would require multiple statements.
 
     `dropBack` provides the same functionality but instead calls
-    `range.$(REF popBackN, std, range, primitives)(n))
+    `range.$(REF popBackN, std, range, primitives)(n)
 
     Note: `drop` and `dropBack` will only pop $(I up to)
     `n` elements but will stop if the range is empty first.
@@ -9941,6 +9941,7 @@ bit, from the least significant bit to the most significant bit.
 
 Params:
     R = an integral input range to iterate over
+    range = range to consume bit by by
 
 Returns:
     A `Bitwise` input range with propagated forward, bidirectional

--- a/std/utf.d
+++ b/std/utf.d
@@ -3744,6 +3744,7 @@ int impureVariable;
  *
  * Params:
  *      C = `char`, `wchar`, or `dchar`
+ *
  * Returns:
  *      A forward range if `R` is a range and not auto-decodable, as defined by
  *      $(REF isAutodecodableString, std, traits), and if the base range is


### PR DESCRIPTION
Ddoc already triggers a nice warning if there's a parameter mismatch - this PR fixes the last remaining error (expect for a [eponymous templates](https://issues.dlang.org/show_bug.cgi?id=16988) in deprecated ndslice/iteration.d).

This PR also adds adds a CI check for sth. similar to `dmd -w -D -main -c -o- **/*.d`, s.t. future additions we can ensure that no new violations get in ;-)

Btw I was also looking at [public symbols without Returns/Params](https://github.com/Hackerpilot/Dscanner/pull/390) and it seems to be a lot :/

edit: [bugzilla issue for public symbols without return](https://issues.dlang.org/show_bug.cgi?id=16989)

