### PR TITLE
Add public examples to std.algorithm

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1755,6 +1755,24 @@ if (s == SwapStrategy.stable
     return result;
 }
 
+///
+@safe pure unittest
+{
+    import std.typecons : tuple;
+
+    auto a = [ 0, 1, 2, 3, 4, 5 ];
+    assert(remove!(SwapStrategy.stable)(a, 1) == [ 0, 2, 3, 4, 5 ]);
+    a = [ 0, 1, 2, 3, 4, 5 ];
+    assert(remove!(SwapStrategy.stable)(a, 1, 3) == [ 0, 2, 4, 5] );
+    a = [ 0, 1, 2, 3, 4, 5 ];
+    assert(remove!(SwapStrategy.stable)(a, 1, tuple(3, 6)) == [ 0, 2 ]);
+
+    a = [ 0, 1, 2, 3, 4, 5 ];
+    assert(remove!(SwapStrategy.unstable)(a, 1) == [0, 5, 2, 3, 4]);
+    a = [ 0, 1, 2, 3, 4, 5 ];
+    assert(remove!(SwapStrategy.unstable)(a, tuple(1, 4)) == [0]);
+}
+
 @safe unittest
 {
     import std.exception : assertThrown;

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -270,14 +270,6 @@ if (isInputRange!(Range) && is(typeof(r.front == lPar)))
  * invoke the Boyer-Moore matching algorithm for finding of $(D needle) in a
  * given haystack.
  */
-BoyerMooreFinder!(binaryFun!(pred), Range) boyerMooreFinder
-(alias pred = "a == b", Range)
-(Range needle) if ((isRandomAccessRange!(Range) && hasSlicing!Range) || isSomeString!Range)
-{
-    return typeof(return)(needle);
-}
-
-/// Ditto
 struct BoyerMooreFinder(alias pred, Range)
 {
 private:
@@ -377,6 +369,29 @@ public:
 
     ///
     alias opDollar = length;
+}
+
+/// Ditto
+BoyerMooreFinder!(binaryFun!(pred), Range) boyerMooreFinder
+(alias pred = "a == b", Range)
+(Range needle) if ((isRandomAccessRange!(Range) && hasSlicing!Range) || isSomeString!Range)
+{
+    return typeof(return)(needle);
+}
+
+///
+@safe pure nothrow unittest
+{
+    auto bmFinder = boyerMooreFinder("TG");
+
+    string r = "TAGTGCCTGA";
+    // search for the first match in the haystack r
+    r = bmFinder.beFound(r);
+    assert(r == "TGCCTGA");
+
+    // continue search in haystack
+    r = bmFinder.beFound(r[2 .. $]);
+    assert(r == "TGA");
 }
 
 /**

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2938,6 +2938,52 @@ schwartzSort(alias transform, alias less = "a < b",
     return typeof(return)(r);
 }
 
+///
+@safe unittest
+{
+    import std.algorithm.iteration : map;
+    import std.numeric : entropy;
+
+    auto lowEnt = [ 1.0, 0, 0 ],
+         midEnt = [ 0.1, 0.1, 0.8 ],
+        highEnt = [ 0.31, 0.29, 0.4 ];
+    auto arr = new double[][3];
+    arr[0] = midEnt;
+    arr[1] = lowEnt;
+    arr[2] = highEnt;
+
+    schwartzSort!(entropy, "a > b")(arr);
+
+    assert(arr[0] == highEnt);
+    assert(arr[1] == midEnt);
+    assert(arr[2] == lowEnt);
+    assert(isSorted!("a > b")(map!(entropy)(arr)));
+}
+
+@safe unittest
+{
+    import std.algorithm.iteration : map;
+    import std.numeric : entropy;
+
+    debug(std_algorithm) scope(success)
+        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
+
+    auto lowEnt = [ 1.0, 0, 0 ],
+        midEnt = [ 0.1, 0.1, 0.8 ],
+        highEnt = [ 0.31, 0.29, 0.4 ];
+    auto arr = new double[][3];
+    arr[0] = midEnt;
+    arr[1] = lowEnt;
+    arr[2] = highEnt;
+
+    schwartzSort!(entropy, "a < b")(arr);
+
+    assert(arr[0] == lowEnt);
+    assert(arr[1] == midEnt);
+    assert(arr[2] == highEnt);
+    assert(isSorted!("a < b")(map!(entropy)(arr)));
+}
+
 @safe unittest
 {
     // issue 4909
@@ -2952,74 +2998,6 @@ schwartzSort(alias transform, alias less = "a < b",
     import std.typecons : Tuple;
     Tuple!(char)[] chars;
     schwartzSort!((Tuple!(char) c){ return c[0]; })(chars);
-}
-
-@safe unittest
-{
-    import std.algorithm.iteration : map;
-    import std.math : log2;
-
-    debug(std_algorithm) scope(success)
-        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
-
-    static double entropy(double[] probs) {
-        double result = 0;
-        foreach (ref p; probs)
-        {
-            if (!p) continue;
-            result -= p * log2(p);
-        }
-        return result;
-    }
-
-    auto lowEnt = [ 1.0, 0, 0 ],
-         midEnt = [ 0.1, 0.1, 0.8 ],
-        highEnt = [ 0.31, 0.29, 0.4 ];
-    auto arr = new double[][3];
-    arr[0] = midEnt;
-    arr[1] = lowEnt;
-    arr[2] = highEnt;
-
-    schwartzSort!(entropy, q{a > b})(arr);
-
-    assert(arr[0] == highEnt);
-    assert(arr[1] == midEnt);
-    assert(arr[2] == lowEnt);
-    assert(isSorted!("a > b")(map!(entropy)(arr)));
-}
-
-@safe unittest
-{
-    import std.algorithm.iteration : map;
-    import std.math : log2;
-
-    debug(std_algorithm) scope(success)
-        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
-
-    static double entropy(double[] probs) {
-        double result = 0;
-        foreach (ref p; probs)
-        {
-            if (!p) continue;
-            result -= p * log2(p);
-        }
-        return result;
-    }
-
-    auto lowEnt = [ 1.0, 0, 0 ],
-        midEnt = [ 0.1, 0.1, 0.8 ],
-        highEnt = [ 0.31, 0.29, 0.4 ];
-    auto arr = new double[][3];
-    arr[0] = midEnt;
-    arr[1] = lowEnt;
-    arr[2] = highEnt;
-
-    schwartzSort!(entropy, q{a < b})(arr);
-
-    assert(arr[0] == lowEnt);
-    assert(arr[1] == midEnt);
-    assert(arr[2] == highEnt);
-    assert(isSorted!("a < b")(map!(entropy)(arr)));
 }
 
 // partialSort


### PR DESCRIPTION
from the H2 2016 agenda:

> Make sure every function in Phobos has an example

So I went ahead a wrote a [small script](https://github.com/wilzbach/style-checkers/blob/master/has_public_example.d) that search for all public functions that violate don't come with an example.

This here is more a proof of concept of the script. However my plan would be to go similarly as with runnability of the tests and start with a exclude list of modules and gradually decrease it.

Ideally I would like to add such checks (like e.g. the other for [missing Returns/Params](https://github.com/Hackerpilot/Dscanner/pull/390)) to Dscanner (CC @Hackerpilot). Is this possible or should I add them somewhere else, e.g. the `tools` repo or directly here?

Related Bugzilla Issue: https://issues.dlang.org/show_bug.cgi?id=16990