### PR TITLE
Make std.string.StringException use basicExceptionCtors.

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -209,20 +209,10 @@ public import std.array : join, replace, replaceInPlace, split, empty;
   +/
 class StringException : Exception
 {
-    /++
-        Params:
-            msg  = The message for the exception.
-            file = The file where the exception occurred.
-            line = The line number where the exception occurred.
-            next = The previous exception in the chain of exceptions, if any.
-      +/
-    this(string msg,
-         string file = __FILE__,
-         size_t line = __LINE__,
-         Throwable next = null) @safe pure nothrow
-    {
-        super(msg, file, line, next);
-    }
+    import std.exception : basicExceptionCtors;
+
+    ///
+    mixin basicExceptionCtors;
 }
 
 


### PR DESCRIPTION
This is a trivial change to take advantage of
std.exception.basicExceptionCtors and avoid having StringException
explicitly declare the normal exception constructors. It also has the
advantage of adding the second constructor that was missing from
StringException.