### PR TITLE
partly fix Issue 9378 - SHA1 asm not PIC compatible

### DIFF
--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -101,17 +101,14 @@ unittest
     hash1 = sha1.finish();
 }
 
-version(D_PIC)
-{
-    // Do not use (Bug9378).
-}
-else version(Win64)
+version(Win64)
 {
     // wrong calling convention
 }
 else version(D_InlineAsm_X86)
 {
-    private version = USE_SSSE3;
+    version (D_PIC) {} // Bugzilla 9378
+    else private version = USE_SSSE3;
 }
 else version(D_InlineAsm_X86_64)
 {
@@ -216,11 +213,20 @@ struct SHA(uint hashBlockSize, uint digestSize)
         version(USE_SSSE3)
         {
             import core.cpuid : ssse3;
-            import std.internal.digest.sha_SSSE3 : transformSSSE3;
+            import std.internal.digest.sha_SSSE3 : sse3_constants=constants, transformSSSE3;
 
             static void transform(uint[5]* state, const(ubyte[64])* block) pure nothrow @nogc
             {
-               return ssse3 ? transformSSSE3(state, block) : transformX86(state, block);
+                if (ssse3)
+                {
+                    version (D_InlineAsm_X86_64)
+                        // constants as extra argument for PIC, see Bugzilla 9378
+                        transformSSSE3(state, block, &sse3_constants);
+                    else
+                        transformSSSE3(state, block);
+                }
+                else
+                    transformX86(state, block);
             }
         }
         else


### PR DESCRIPTION
- access SHA1 constants through extra register in x64 code
- tried same for x86 (several hours) but there is no register left and
  loading constants via stack was way too slow
- little to no interest in x86 PIC code, as the platform is almost dead, and PIC is too slow on x86 anyhow

Roughly 10x faster (now also with shared phobos library).
Prerequisite to fix [Issue 16794 – .deb not working on Ubuntu 16.10 because of default PIE linking](https://issues.dlang.org/show_bug.cgi?id=16794).