### PR TITLE
Check public functions for public examples

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ test:
   override:
     - ./circleci.sh setup-repos
     - ./circleci.sh style
-    - ./circleci.sh publictests
     - ./circleci.sh coverage:
         parallel: true
         timeout: 1200

--- a/circleci.sh
+++ b/circleci.sh
@@ -100,7 +100,12 @@ style()
     # dscanner needs a more up-to-date DMD version
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
 
-    make -f posix.mak style
+    # some style tools are at the tools repo
+    clone https://github.com/dlang/tools.git ../tools master
+    # fix to a specific version of https://github.com/dlang/tools/tree/master/styles
+    git -C ../tools checkout 60583c8363ff25d00017dffdb18c7ee7e7d9a343
+
+    make -f posix.mak style DUB=$DUB
 }
 
 # run unittest with coverage
@@ -118,19 +123,9 @@ coverage()
     make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test")
 }
 
-# compile all public unittests separately
-publictests()
-{
-    clone https://github.com/dlang/tools.git ../tools master
-    # fix to a specific version of https://github.com/dlang/tools/tree/master/styles
-    git -C ../tools checkout 60583c8363ff25d00017dffdb18c7ee7e7d9a343
-    make -f posix.mak publictests DUB=$DUB
-}
-
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     coverage) coverage ;;
     style) style ;;
-    publictests) publictests ;;
 esac

--- a/circleci.sh
+++ b/circleci.sh
@@ -122,8 +122,8 @@ coverage()
 publictests()
 {
     clone https://github.com/dlang/tools.git ../tools master
-    # fix to a specific version of https://github.com/dlang/tools/blob/master/phobos_tests_extractor.d
-    git -C ../tools checkout 184f5e60372d6dd36d3451b75fb6f21e23f7275b
+    # fix to a specific version of https://github.com/dlang/tools/tree/master/styles
+    git -C ../tools checkout 60583c8363ff25d00017dffdb18c7ee7e7d9a343
     make -f posix.mak publictests DUB=$DUB
 }
 

--- a/posix.mak
+++ b/posix.mak
@@ -496,7 +496,7 @@ checkwhitespace: $(LIB)
 	mv dscanner_makefile_tmp ../dscanner/makefile
 	make -C ../dscanner githash debug
 
-style: ../dscanner/dsc $(LIB)
+style: ../dscanner/dsc $(LIB) has_public_example publictests
 	@echo "Check for trailing whitespace"
 	grep -nr '[[:blank:]]$$' etc std ; test $$? -eq 1
 
@@ -545,11 +545,16 @@ style: ../dscanner/dsc $(LIB)
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.
 
 publictests: $(LIB)
-	# parse all public unittests from Phobos, for now some modules are excluded
+	# parse all public unittests from Phobos and runs them (for now some modules are excluded)
 	rm -rf ./out
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --single ../tools/phobos_tests_extractor.d -- --inputdir . --ignore "base64.d,building_blocks/free_list,building_blocks/quantizer,digest/hmac.d,file.d,index.d,math.d,ndslice/selection.d,stdio.d,traits.d,typecons.d,uuid.d" --outputdir ./out
+	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --root=../tools/styles -c tests_extractor -- --inputdir . --ignore "base64.d,building_blocks/free_list,building_blocks/quantizer,digest/hmac.d,file.d,index.d,math.d,ndslice/selection.d,stdio.d,traits.d,typecons.d,uuid.d" --outputdir ./out
 	# execute all parsed tests
 	for file in $$(find out -name '*.d'); do echo "executing $${file}" && $(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main -unittest -run $$file || exit 1 ; done
+
+has_public_example: $(LIB)
+	#  checks whether public function have public examples (for now some modules are excluded)
+	rm -rf ./out
+	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --root=../tools/styles -c has_public_example -- --inputdir . --ignore "etc,array.d,allocator,base64.d,bitmanip.d,concurrency.d,conv.d,csv.d,datetime.d,demangle.d,digest/hmac.d,digest/sha.d,encoding.d,exception.d,file.d,format.d,getopt.d,index.d,internal,isemail.d,json.d,logger/core.d,logger/nulllogger.d,math.d,mathspecial.d,net/curl.d,ndslice/selection.d,ndslice/slice.d,numeric.d,parallelism.d,path.d,process.d,random.d,range,regex/package.d,socket.d,stdio.d,string.d,traits.d,typecons.d,uni.d,unittest.d,uri.d,utf.d,uuid.d,xml.d,zlib.d"
 
 .PHONY : auto-tester-build
 auto-tester-build: all checkwhitespace

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -223,6 +223,7 @@ the example below, $(D r2) is a right subrange of $(D r1).
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
+    import std.range.primitives : popFrontN;
 
     auto list = SList!(int)(4, 5, 6, 7, 1, 2, 3);
     auto r1 = list[];

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1104,6 +1104,14 @@ if (isIntegral!T)
     }
 }
 
+///
+nothrow pure @system
+unittest
+{
+    assert((-1).absUnsign == 1);
+    assert(1.absUnsign == 1);
+}
+
 nothrow pure @system
 unittest
 {

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -439,6 +439,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
 @system unittest
 {
     import std.conv : to;
+    import std.range.primitives;
     {
         // example from "Introduction to Algorithms" Cormen et al., p 146
         int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -436,6 +436,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     return BinaryHeap!(Store, less)(s, initialSize);
 }
 
+///
 @system unittest
 {
     import std.conv : to;

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1819,6 +1819,9 @@ assert(equal(rbt[], [5]));
     test!byte();
 }
 
+import std.range.primitives : isInputRange, isSomeString, ElementType;
+import std.traits : isArray;
+
 /++
     Convenience function for creating a $(D RedBlackTree!E) from a list of
     values.
@@ -1856,10 +1859,6 @@ if (is(typeof(binaryFun!less(E.init, E.init))))
     //takes less but not allowDuplicates works just fine).
     return new RedBlackTree!(E, binaryFun!less, allowDuplicates)(elems);
 }
-
-
-import std.range.primitives : isInputRange, isSomeString, ElementType;
-import std.traits : isArray;
 
 /++ Ditto +/
 auto redBlackTree(Stuff)(Stuff range)

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -853,7 +853,7 @@ if (isDigest!T)
 unittest
 {
     import std.digest.md : MD5;
-    import std.digest.sha: SHA1, SHA256, SHA512;
+    import std.digest.sha : SHA1, SHA256, SHA512;
     assert(digestLength!MD5 == 16);
     assert(digestLength!SHA1 == 20);
     assert(digestLength!SHA256 == 32);

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -841,14 +841,23 @@ ref T[N] asArray(size_t N, T)(ref T[] source, string errorMsg = "")
 }
 
 /*
- * This helper is used internally in the WrapperDigest template, but it might be
- * useful for other purposes as well. It returns the length (in bytes) of the hash value
- * produced by T.
+ * Returns the length (in bytes) of the hash value produced by T.
  */
 template digestLength(T)
 if (isDigest!T)
 {
     enum size_t digestLength = (ReturnType!(T.finish)).length;
+}
+
+@safe pure nothrow @nogc
+unittest
+{
+    import std.digest.md : MD5;
+    import std.digest.sha: SHA1, SHA256, SHA512;
+    assert(digestLength!MD5 == 16);
+    assert(digestLength!SHA1 == 20);
+    assert(digestLength!SHA256 == 32);
+    assert(digestLength!SHA512 == 64);
 }
 
 /**

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -840,7 +840,7 @@ ref T[N] asArray(size_t N, T)(ref T[] source, string errorMsg = "")
      return *cast(T[N]*) source.ptr;
 }
 
-/**
+/*
  * This helper is used internally in the WrapperDigest template, but it might be
  * useful for other purposes as well. It returns the length (in bytes) of the hash value
  * produced by T.

--- a/std/format.d
+++ b/std/format.d
@@ -1844,8 +1844,7 @@ private void formatUnsigned(Writer, T, Char)(Writer w, T arg, const ref FormatSp
             rightpad = spacesToPrint;
     }
 
-    /**** Print ****/
-
+    // Print
     foreach (i ; 0 .. leftpad)
         put(w, ' ');
 

--- a/std/functional.d
+++ b/std/functional.d
@@ -1290,6 +1290,20 @@ if (isCallable!(F))
     }
 }
 
+///
+@system unittest
+{
+    static int inc(ref uint num) {
+        num++;
+        return 8675309;
+    }
+
+    uint myNum = 0;
+    auto incMyNumDel = toDelegate(&inc);
+    auto returnVal = incMyNumDel(myNum);
+    assert(myNum == 1);
+}
+
 @system unittest // not @safe due to toDelegate
 {
     static int inc(ref uint num) {

--- a/std/variant.d
+++ b/std/variant.d
@@ -83,6 +83,16 @@ template maxSize(T...)
     }
 }
 
+///
+unittest
+{
+    static assert(maxSize!(int, long) == 8);
+    static assert(maxSize!(bool, byte) == 1);
+
+    struct Cat { int a, b, c; }
+    static assert(maxSize!(bool, Cat) == 12);
+}
+
 struct This;
 
 private alias This2Variant(V, T...) = AliasSeq!(ReplaceType!(This, V, T));

--- a/std/variant.d
+++ b/std/variant.d
@@ -1401,6 +1401,8 @@ be arbitrarily complex.
 */
 @system unittest
 {
+    import std.typecons : Tuple, tuple;
+
     // A tree is either a leaf or a branch of two other trees
     alias Tree(Leaf) = Algebraic!(Leaf, Tuple!(This*, This*));
     Tree!int tree = tuple(new Tree!int(42), new Tree!int(43));

--- a/std/variant.d
+++ b/std/variant.d
@@ -84,7 +84,7 @@ template maxSize(T...)
 }
 
 ///
-unittest
+@safe unittest
 {
     static assert(maxSize!(int, long) == 8);
     static assert(maxSize!(bool, byte) == 1);


### PR DESCRIPTION
To improve Phobos's documentation, here's another addition to the `style` Makefile target.
Here's the idea that _every public function should have at least one public example_ as stated in the [high-level vision](https://wiki.dlang.org/Vision/2016H2) (btw for all public examples the `publictests` Makefile target we will enforce that it's runnable on dlang.org) 

[Script is at the tools repo](https://github.com/dlang/tools/blob/master/styles/has_public_example.d).

Note: this just adds the tool and comes with quite a long blacklist. While I started to fix some modules (e.g. https://github.com/dlang/phobos/pull/4973 and trivial ones in this PR), it's quite a lot of effort. However, once this has been enabled, everyone should be able to help to reduce the blacklist :)