### PR TITLE
Fix issue 17037 - std.concurrency has random segfaults

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1782,7 +1782,6 @@ unittest
                 tid.send(e);
             }
         });
-        scheduler = null;
     }
 
     testScheduler(new ThreadScheduler);
@@ -2534,7 +2533,6 @@ version( unittest )
     {
         scheduler = new ThreadScheduler;
         simpleTest();
-        scheduler = null;
     }
 }
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=17037

Setting ```scheduler``` to ```null``` once it has been set is bad news.
This is the solution I found given the current design / implementation.