### PR TITLE
Fix issue 16281 - std.format.formattedRead should use ref instead of requiring pointers

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -567,8 +567,7 @@ On success, the function returns the number of variables filled. This count
 can match the expected number of readings or fewer, even zero, if a
 matching failure happens.
  */
-uint formattedRead(R, Char, S...)(ref R r, const(Char)[] fmt, S args)
-if (allSatisfy!(isPointer, S))
+uint formattedRead(R, Char, S...)(ref R r, const(Char)[] fmt, auto ref S args)
 {
     import std.typecons : isTuple;
 
@@ -581,6 +580,8 @@ if (allSatisfy!(isPointer, S))
     }
     else
     {
+        enum hasPointer = isPointer!(typeof(args[0]));
+
         // The function below accounts for '*' == fields meant to be
         // read and skipped
         void skipUnstoredFields()
@@ -600,24 +601,57 @@ if (allSatisfy!(isPointer, S))
             // Input is empty, nothing to read
             return 0;
         }
-        alias A = typeof(*args[0]);
+        static if (hasPointer)
+            alias A = typeof(*args[0]);
+        else
+            alias A = typeof(args[0]);
+
         static if (isTuple!A)
         {
             foreach (i, T; A.Types)
             {
-                (*args[0])[i] = unformatValue!(T)(r, spec);
+                static if (hasPointer)
+                    (*args[0])[i] = unformatValue!(T)(r, spec);
+                else
+                    args[0][i] = unformatValue!(T)(r, spec);
                 skipUnstoredFields();
             }
         }
         else
         {
-            *args[0] = unformatValue!(A)(r, spec);
+            static if (hasPointer)
+                *args[0] = unformatValue!(A)(r, spec);
+            else
+                args[0] = unformatValue!(A)(r, spec);
         }
         return 1 + formattedRead(r, spec.trailing, args[1 .. $]);
     }
 }
 
 ///
+@safe pure unittest
+{
+    string s = "hello!124:34.5";
+    string a;
+    int b;
+    double c;
+    formattedRead(s, "%s!%s:%s", a, b, c);
+    assert(a == "hello" && b == 124 && c == 34.5);
+}
+
+@safe unittest
+{
+    import std.math;
+    string s = " 1.2 3.4 ";
+    double x, y, z;
+    assert(formattedRead(s, " %s %s %s ", x, y, z) == 2);
+    assert(s.empty);
+    assert(approxEqual(x, 1.2));
+    assert(approxEqual(y, 3.4));
+    assert(isNaN(z));
+}
+
+// for backwards compatibility
 @system pure unittest
 {
     string s = "hello!124:34.5";
@@ -626,8 +660,22 @@ if (allSatisfy!(isPointer, S))
     double c;
     formattedRead(s, "%s!%s:%s", &a, &b, &c);
     assert(a == "hello" && b == 124 && c == 34.5);
+
+    // mix pointers and auto-ref
+    s = "world!200:42.2";
+    formattedRead(s, "%s!%s:%s", a, &b, &c);
+    assert(a == "world" && b == 200 && c == 42.2);
+
+    s = "world1!201:42.3";
+    formattedRead(s, "%s!%s:%s", &a, &b, c);
+    assert(a == "world1" && b == 201 && c == 42.3);
+
+    s = "world2!202:42.4";
+    formattedRead(s, "%s!%s:%s", a, b, &c);
+    assert(a == "world2" && b == 202 && c == 42.4);
 }
 
+// for backwards compatibility
 @system pure unittest
 {
     import std.math;


### PR DESCRIPTION
This solution uses "dumb" `static if`s to guarantee backwards compatibility with raw pointer usage. Splitting it off into two functions and triggering deprecation warnings for pointer usage might also be an option.