### PR TITLE
Make std.getopt.autoIncrementChar use private modifier

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1020,7 +1020,7 @@ dchar assignChar = '=';
  */
 string arraySep = "";
 
-enum autoIncrementChar = '+';
+private enum autoIncrementChar = '+';
 
 private struct configuration
 {


### PR DESCRIPTION
Looks like an useless(in outer code) enum constant exist in module std.getopt. The documentation keep silence about this too. I decided to make it private and make a small contribution to this amazing library and language.