### PR TITLE
Rework MersenneTwisterEngine using Ilya Yaroshenko's faster algorithm

### DIFF
--- a/changelog/std-random-MersenneTwisterEngine.dd
+++ b/changelog/std-random-MersenneTwisterEngine.dd
@@ -1,0 +1,16 @@
+`MersenneTwisterEngine` has been updated so that its template signature
+matches the C++11 standard (adding two new template parameters, an extra
+tempering parameter `d` and the initialization multiplier `f`).
+
+For anyone using the standard template instantiation `Mt19937` this will
+have no noticeable effect.  However, this will be a breaking change for
+anyone using the `MersenneTwisterEngine` template directly.
+
+The internal implementation has been reworked to use Ilya Yaroshenko's
+highly optimized algorithm from `mir.random`.  This should have a very
+noticeable positive effect for anyone who cares about generating a lot
+of random numbers quickly.
+
+A new `Mt19937_64` template instantiation has been added, corresponding
+to the standard 64-bit implementation of the algorithm (MT19937-64).
+This fixes $(LINK https://issues.dlang.org/show_bug.cgi?id=10900).

--- a/std/random.d
+++ b/std/random.d
@@ -753,6 +753,7 @@ alias Mt19937 = MersenneTwisterEngine!(uint, 32, 624, 397, 31,
     static assert(isSeedable!(Mt19937, uint));
     static assert(isSeedable!(Mt19937, typeof(map!((a) => unpredictableSeed)(repeat(0)))));
     Mt19937 gen;
+    assert(gen.front == 3499211612);
     popFrontN(gen, 9999);
     assert(gen.front == 4123659995);
 }

--- a/std/random.d
+++ b/std/random.d
@@ -956,8 +956,20 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
                                                         0x9d2c5680, 15,
                                                         0xefc60000, 18, 1812433253);
 
-    foreach (R; std.meta.AliasSeq!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
+    ulong[] expectedFirstValue = [3499211612uL, 3499211612uL,
+                                  171143175841277uL, 1145028863177033374uL];
+
+    ulong[] expected10kValue = [4123659995uL, 4123659995uL,
+                                51991688252792uL, 3031481165133029945uL];
+
+    foreach (i, R; std.meta.AliasSeq!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
+    {
         auto a = R();
+        a.seed(a.defaultSeed); // checks that some alternative paths in `seed` are utilized
+        assert(a.front == expectedFirstValue[i]);
+        a.popFrontN(9999);
+        assert(a.front == expected10kValue[i]);
+    }
 }
 
 

--- a/std/random.d
+++ b/std/random.d
@@ -901,6 +901,10 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     assert(gen.front == 14514284786278117030uL);
     popFrontN(gen, 9999);
     assert(gen.front == 9981545732273789042uL);
+    try { gen.seed(iota(312uL)); } catch (Exception) { assert(false); }
+    assert(gen.front == 14660652410669508483uL);
+    popFrontN(gen, 9999);
+    assert(gen.front == 15956361063660440239uL);
 }
 
 @safe unittest

--- a/std/random.d
+++ b/std/random.d
@@ -756,6 +756,10 @@ alias Mt19937 = MersenneTwisterEngine!(uint, 32, 624, 397, 31,
     assert(gen.front == 3499211612);
     popFrontN(gen, 9999);
     assert(gen.front == 4123659995);
+    try { gen.seed(iota(624u)); } catch (Exception) { assert(false); }
+    assert(gen.front == 3708921088u);
+    popFrontN(gen, 9999);
+    assert(gen.front == 165737292u);
 }
 
 @safe unittest


### PR DESCRIPTION
These patches update `MersenneTwisterEngine`'s implementation to use the new and much faster implementation @9il prepared for `mir.random`.  The standard 64-bit Mersenne Twister implementation is added as a side benefit.

The original Mersenne Twister algorithm (as per the reference C code by Matsumoto and Nishimura) first regenerates the contents of the entire state array, before looping over the resulting values and tempering them in order to generate the actual variates.  Once the entire state array has been iterated over, the array's values are then regenerated, and so on and so forth.

Ilya's implementation reworks this idea to intertwine update of a single entry in the state array with the tempering of another value to produce the next variate.  This ensures that all the registers concerned stay 'hot' in the CPU's memory and hence ensures significant speedup.

(Just as a mention: as an experiment while adapting this code for phobos I tried splitting apart the lines responsible for updating the internal state array from those responsible for tempering the next variate, so that they could be run sequentially instead of mixed up together; this resulted in a fairly significant speed hit.)

Ilya's code also introduces an extra tempering variable `d`, used in more recent Mersenne Twister implementations (Boost.Random, hap.random) but previously missing from Phobos' implementation.  This is needed in order to implement the standard 64-bit version of the Mersenne Twister, which is added in the second patch of this PR.

The first patch reworks Ilya's code to work as a drop-in replacement for the existing Phobos implementation, which is currently implemented as a forward range (although it should ideally be an input range, but that design flaw should be fixed as a separate issue).  There appears to be no significant speed hit from implementing the algorithm as a range rather than as a functor.  However, other aspects of the original design have required some rather intrusive changes to Ilya's code in order to get the full speed benefits without introducing breaking change.

The original MersenneTwisterEngine allows for implicit instantiation of generator instances without providing a seed.  This is handled by checking in the `front` and `popFront` method whether the generator has been properly initialized, and seeding it with the default seed if not.  However, these runtime checks on every single call result in a massive speed hit.  The current implementation therefore takes a number of steps in order to ensure that the internal state of the generator can be set
to its default-seeded values at compile time:

* all the internal state variables have been wrapped up in a nested `State` struct to facilitate generation;

* the internals of the `seed` and `popFront` methods have been separated out into CTFE'able private static methods (`seedImpl` and `popFrontImpl`) which take a reference to a `State` instance as input;

* a CTFE'able private static `defaultState` method has been added which generates a `State` instance matching that generated by instantiating the generator with the `defaultSeed`.

The `defaultState` method is then used to initialize the default value of the internal `State` instance at compile-time, replicating the effect of the original runtime seeding check.

These latter workarounds could be removed in future if the generator were updated to `@disable this();` and therefore always require explicit seeding, but this would be a breaking change and so is avoided for now.