### PR TITLE
Removed auto-decoding from the floating point version of std.conv.parse

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2543,11 +2543,11 @@ Target parse(Target, Source)(ref Source p)
 
     enforce(!p.empty, bailOut());
 
-    char sign = 0;                       /* indicating +                 */
+    bool sign = false;
     switch (p.front)
     {
     case '-':
-        sign++;
+        sign = true;
         p.popFront();
         enforce(!p.empty, bailOut());
         if (toLower(p.front) == 'i')

--- a/std/conv.d
+++ b/std/conv.d
@@ -2519,13 +2519,23 @@ Target parse(Target, Source)(ref Source s)
  *     A $(LREF ConvException) if `p` is empty, if no number could be
  *     parsed, or if an overflow occurred.
  */
-Target parse(Target, Source)(ref Source p)
+Target parse(Target, Source)(ref Source source)
     if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
         isFloatingPoint!Target && !is(Target == enum))
 {
     import std.ascii : isDigit, isAlpha, toLower, toUpper, isHexDigit;
     import std.exception : enforce;
     import core.stdc.math : HUGE_VAL;
+
+    static if (isNarrowString!Source)
+    {
+        import std.string : representation, assumeUTF;
+        auto p = source.representation;
+    }
+    else
+    {
+        alias p = source;
+    }
 
     static immutable real[14] negtab =
         [ 1e-4096L,1e-2048L,1e-1024L,1e-512L,1e-256L,1e-128L,1e-64L,1e-32L,
@@ -2540,6 +2550,7 @@ Target parse(Target, Source)(ref Source p)
             msg = "Floating point conversion error";
         return new ConvException(text(msg, " for input \"", p, "\"."), fn, ln);
     }
+
 
     enforce(!p.empty, bailOut());
 
@@ -2569,6 +2580,8 @@ Target parse(Target, Source)(ref Source p)
             {
                 // 'inf'
                 p.popFront();
+                static if (isNarrowString!Source)
+                    source = p.assumeUTF;
                 return sign ? -Target.infinity : Target.infinity;
             }
         }
@@ -2583,7 +2596,9 @@ Target parse(Target, Source)(ref Source p)
         p.popFront();
         if (p.empty)
         {
-            return (sign) ? -0.0 : 0.0;
+            static if (isNarrowString!Source)
+                source = p.assumeUTF;
+            return sign ? -0.0 : 0.0;
         }
 
         isHex = p.front == 'x' || p.front == 'X';
@@ -2805,6 +2820,8 @@ Target parse(Target, Source)(ref Source p)
                    new ConvException("error converting input to floating point"));
             // skip past the last 'n'
             p.popFront();
+            static if (isNarrowString!Source)
+                source = p.assumeUTF;
             return typeof(return).nan;
         }
 
@@ -2917,7 +2934,9 @@ Target parse(Target, Source)(ref Source p)
     enforce(ldval != HUGE_VAL, new ConvException("Range error"));
 
   L1:
-    return (sign) ? -ldval : ldval;
+    static if (isNarrowString!Source)
+        source = p.assumeUTF;
+    return sign ? -ldval : ldval;
 }
 
 ///


### PR DESCRIPTION
New version of https://github.com/dlang/phobos/pull/4674

13.5x faster! [Code here](https://gist.github.com/JackStouffer/0cf93d3cc861d699b334e18ea67fb66c#file-test-d).

```
# new
$ ldc2 -O5 -release test.d && ./test
Total time: 387 ms, 506 μs, and 8 hnsecs

# old
$ ldc2 -O5 -release test.d && ./test
Total time: 5 secs, 238 ms, 59 μs, and 4 hnsecs
```