### PR TITLE
better workaround for issue 16653, fix ketmar comment

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1224,8 +1224,8 @@ template ParameterDefaults(func...)
             enum get = (PT[i..i+1] __args) @trusted
             {
                 // If __args[0] is lazy, we force it to be evaluated like this.
-                PT[i] value = __args[0];
-                PT[i]* __pd_val = &value; // workaround Bugzilla 16582
+                PT[i] __pd_value = __args[0];
+                PT[i]* __pd_val = &__pd_value; // workaround Bugzilla 16582
                 return *__pd_val;
             };
             static if (is(typeof(get())))


### PR DESCRIPTION
ketmar said:
> and now one can't have argument with name `value` anymore, 'cause it conflicts with `value` variable in fix. dunno if it worth opening new bug, tho, 'cause fix is not in any release yet, so it can be... fixed right here. ;-)


So changing the name to be more wild, same as the line next to it, makes namespace collision less likely.