### PR TITLE
Allow `make test` as `make unittest` alias

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -265,6 +265,7 @@ install :
 		DMD=$(DMD) install2
 
 .PHONY : unittest
+test: unittest
 ifeq (1,$(BUILD_WAS_SPECIFIED))
 unittest : $(addsuffix .run,$(addprefix unittest/,$(D_MODULES)))
 else

--- a/win32.mak
+++ b/win32.mak
@@ -585,6 +585,8 @@ UNITTEST_OBJS= \
 		unittest8h.obj \
 		unittest9a.obj
 
+test: unittest
+
 unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest1.obj $(SRC_STD_1)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)

--- a/win64.mak
+++ b/win64.mak
@@ -611,6 +611,8 @@ UNITTEST_OBJS= \
 		unittest9.obj \
 		unittest9a.obj
 
+test: unittest
+
 unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest1.obj $(SRC_STD_1)
 	$(DMD) $(UDFLAGS) -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)


### PR DESCRIPTION
Makes possible to write uniform scripts that work with dmd/druntime/phobos
repos (all using same build commands)