### PR TITLE
correct anySatisfy docs

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -852,8 +852,8 @@ template allSatisfy(alias F, T...)
 Tests whether any given items satisfy a template predicate, i.e. evaluates to
 $(D F!(T[0]) || F!(T[1]) || ... || F!(T[$ - 1])).
 
-Evaluation is $(I not) short-circuited if a true result is encountered; the
-template predicate must be instantiable with all the given items.
+Evaluation is short-circuited if a true result is encountered; the
+template predicate must be instantiable with one of the given items.
  */
 template anySatisfy(alias F, T...)
 {


### PR DESCRIPTION
the documentation of anySatisfy was identical to allSatisfy.
Which is of course wrong.