### PR TITLE
Tweak std.internal.scopebuffer docs

### DIFF
--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -150,12 +150,6 @@ struct ScopeBuffer(T, alias realloc = /*core.stdc.stdlib*/.realloc)
         used = 0;
     }
 
-    /****************************
-     * Copying of ScopeBuffer is not allowed.
-     */
-    version(None)
-    @disable this(this);
-
     /************************
      * Append element c to the buffer.
      * This member function makes `ScopeBuffer` an Output Range.


### PR DESCRIPTION
* Respect `realloc` parameter.
* Fix ddoc for commented out `this(this)` concatenated into `put`'s docs.
* Fix missing ddoc for `put(CT[])` due to private `CT`.
* Use documented unittest for scopeBuffer instead of inline code (which had a typo).