### PR TITLE
Cast a void pointer to char* before subtracting it

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1416,7 +1416,7 @@ if (isInputRange!InputRange &&
                         import core.stdc.string : memchr;
                         auto ptr = memchr(haystack.ptr, needle, haystack.length);
                         return ptr ?
-                             haystack[ptr - haystack.ptr .. $] :
+                             haystack[cast(char*)ptr - haystack.ptr .. $] :
                              haystack[$ .. $];
                     }
                     return trustedMemchr(haystack, needle);
@@ -1593,10 +1593,13 @@ if (isInputRange!InputRange &&
             E e2 = 'c';
             assert(find              ("日c語", 'c') == "c語");
             assert(find!((a,b)=>a==b)("日c語", 'c') == "c語");
+            R r3 = "0123456789";
+            E e3 = 'A';
+            assert(find              ("0123456789", 'A').empty);
             static if (E.sizeof >= 2)
             {
-                R r3 = "hello world";
-                E e3 = 'w';
+                R r4 = "hello world";
+                E e4 = 'w';
                 assert(find              ("日本語", '本') == "本語");
                 assert(find!((a,b)=>a==b)("日本語", '本') == "本語");
             }


### PR DESCRIPTION
> If both operands are pointers, and the operator is -, the pointers are subtracted and the result is divided by the size of the type pointed to by the operands. **It is an error if the pointers point to different types**. The type of the result is ptrdiff_t.

See DMD's [PR](https://github.com/dlang/dmd/pull/6440)