### PR TITLE
Use builtin __traits when possible

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6288,13 +6288,9 @@ enum bool isAbstractClass(T) = __traits(isAbstractClass, T);
 }
 
 /**
- * Detect whether $(D T) is a a final class.
+ * Detect whether $(D T) is a final class.
  */
-template isFinalClass(T...)
-    if (T.length == 1)
-{
-    enum bool isFinalClass = __traits(isFinalClass, T[0]);
-}
+enum bool isFinalClass(T) = __traits(isFinalClass, T);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -6276,13 +6276,9 @@ template isNestedFunction(alias f)
 }
 
 /**
- * Detect whether $(D T) is a an abstract class.
+ * Detect whether $(D T) is an abstract class.
  */
-template isAbstractClass(T...)
-    if (T.length == 1)
-{
-    enum bool isAbstractClass = __traits(isAbstractClass, T[0]);
-}
+enum bool isAbstractClass(T) = __traits(isAbstractClass, T);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -6216,13 +6216,9 @@ template isCallable(T...)
 
 
 /**
- * Detect whether $(D T) is a an abstract function.
+ * Detect whether $(D T) is an abstract function.
  */
-template isAbstractFunction(T...)
-    if (T.length == 1)
-{
-    enum bool isAbstractFunction = __traits(isAbstractFunction, T[0]);
-}
+enum bool isAbstractFunction(alias f) = __traits(isAbstractFunction, f);
 
 @safe unittest
 {

--- a/std/traits.d
+++ b/std/traits.d
@@ -5636,7 +5636,7 @@ enum bool isAutodecodableString(T) = (is(T : const char[]) || is(T : const wchar
 /**
  * Detect whether type $(D T) is a static array.
  */
-enum bool isStaticArray(T) = is(StaticArrayTypeOf!T) && !isAggregateType!T;
+enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -5347,7 +5347,7 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T);
 Detect whether $(D T) is a built-in numeric type (integral or floating
 point).
  */
-enum bool isNumeric(T) = is(NumericTypeOf!T) && !isAggregateType!T;
+enum bool isNumeric(T) = __traits(isArithmetic, T);
 
 @safe unittest
 {

--- a/std/traits.d
+++ b/std/traits.d
@@ -5731,7 +5731,7 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 /**
  * Detect whether $(D T) is an associative array type
  */
-enum bool isAssociativeArray(T) = is(AssocArrayTypeOf!T) && !isAggregateType!T;
+enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 
 @safe unittest
 {

--- a/std/traits.d
+++ b/std/traits.d
@@ -5320,7 +5320,7 @@ enum bool isIntegral(T) = is(IntegralTypeOf!T) && !isAggregateType!T;
 /**
  * Detect whether $(D T) is a built-in floating point type.
  */
-enum bool isFloatingPoint(T) = is(FloatingPointTypeOf!T) && !isAggregateType!T;
+enum bool isFloatingPoint(T) = __traits(isFloating, T);
 
 @safe unittest
 {

--- a/std/traits.d
+++ b/std/traits.d
@@ -5429,10 +5429,16 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
 /**
 Detect whether $(D T) is a built-in signed numeric type.
  */
-enum bool isSigned(T) = is(SignedTypeOf!T) && !isAggregateType!T;
+enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 
 @safe unittest
 {
+    enum E { e1 = 0 }
+    static assert(isSigned!E);
+
+    enum Eubyte : ubyte { e1 = 0 }
+    static assert(!isSigned!Eubyte);
+
     foreach (T; TypeTuple!(SignedIntTypeList))
     {
         foreach (Q; TypeQualifierList)

--- a/std/traits.d
+++ b/std/traits.d
@@ -5344,8 +5344,8 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T);
 }
 
 /**
-   Detect whether $(D T) is a built-in numeric type (integral or floating
-point).
+ * Detect whether $(D T) is a built-in numeric type (integral or floating
+ * point).
  */
 enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
                                                         is(Unqual!T == wchar) ||
@@ -5367,7 +5367,8 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
 }
 
 /**
-Detect whether $(D T) is a scalar type (a built-in numeric, character or boolean type).
+ * Detect whether $(D T) is a scalar type (a built-in numeric, character or
+ * boolean type).
  */
 enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
 
@@ -5396,7 +5397,7 @@ enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
 }
 
 /**
-Detect whether $(D T) is a basic type (scalar type or void).
+ * Detect whether $(D T) is a basic type (scalar type or void).
  */
 enum bool isBasicType(T) = isScalarType!T || is(Unqual!T == void);
 
@@ -5419,7 +5420,7 @@ enum bool isBasicType(T) = isScalarType!T || is(Unqual!T == void);
 }
 
 /**
-Detect whether $(D T) is a built-in unsigned numeric type.
+ * Detect whether $(D T) is a built-in unsigned numeric type.
  */
 enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
                                                        is(Unqual!T == wchar) ||
@@ -5438,7 +5439,7 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
 }
 
 /**
-Detect whether $(D T) is a built-in signed numeric type.
+ * Detect whether $(D T) is a built-in signed numeric type.
  */
 enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 
@@ -5461,9 +5462,10 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 }
 
 /**
-Detect whether $(D T) is one of the built-in character types.
-
-The built-in char types are any of $(D char), $(D wchar) or $(D dchar), with or without qualifiers.
+ * Detect whether $(D T) is one of the built-in character types.
+ *
+ * The built-in char types are any of $(D char), $(D wchar) or $(D dchar), with
+ * or without qualifiers.
  */
 enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -6308,14 +6308,20 @@ template isAbstractClass(T...)
     static assert(!isAbstractClass!S);
     static assert(!isAbstractClass!C);
     static assert( isAbstractClass!AC);
-    AC c;
-    static assert(isAbstractClass!c);
+    C c;
+    static assert(!isAbstractClass!c);
+    AC ac;
+    static assert( isAbstractClass!ac);
 }
 
 /**
  * Detect whether $(D T) is a final class.
  */
-enum bool isFinalClass(T) = __traits(isFinalClass, T);
+template isFinalClass(T...)
+    if (T.length == 1)
+{
+    enum bool isFinalClass = __traits(isFinalClass, T[0]);
+}
 
 ///
 @safe unittest
@@ -6328,6 +6334,10 @@ enum bool isFinalClass(T) = __traits(isFinalClass, T);
     static assert(!isFinalClass!AC);
     static assert( isFinalClass!FC1);
     static assert( isFinalClass!FC2);
+    C c;
+    static assert(!isFinalClass!c);
+    FC1 fc1;
+    static assert( isFinalClass!fc1);
 }
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://

--- a/std/traits.d
+++ b/std/traits.d
@@ -6231,13 +6231,9 @@ enum bool isAbstractFunction(alias f) = __traits(isAbstractFunction, f);
 }
 
 /**
- * Detect whether $(D T) is a a final function.
+ * Detect whether $(D T) is a final function.
  */
-template isFinalFunction(T...)
-    if (T.length == 1)
-{
-    enum bool isFinalFunction = __traits(isFinalFunction, T[0]);
-}
+enum bool isFinalFunction(alias f) = __traits(isFinalFunction, f);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -5364,7 +5364,7 @@ enum bool isNumeric(T) = is(NumericTypeOf!T) && !isAggregateType!T;
 /**
 Detect whether $(D T) is a scalar type (a built-in numeric, character or boolean type).
  */
-enum bool isScalarType(T) = isNumeric!T || isSomeChar!T || isBoolean!T;
+enum bool isScalarType(T) = isNumeric!T || isSomeChar!T || isBoolean!T; // TODO make __traits(isScalar, T) work here
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -6254,7 +6254,7 @@ template isAbstractFunction(T...)
 template isFinalFunction(T...)
     if (T.length == 1)
 {
-        enum bool isFinalFunction = __traits(isFinalFunction, T[0]);
+    enum bool isFinalFunction = __traits(isFinalFunction, T[0]);
 }
 
 ///
@@ -6293,7 +6293,11 @@ template isNestedFunction(alias f)
 /**
  * Detect whether $(D T) is an abstract class.
  */
-enum bool isAbstractClass(T) = __traits(isAbstractClass, T);
+template isAbstractClass(T...)
+    if (T.length == 1)
+{
+    enum bool isAbstractClass = __traits(isAbstractClass, T[0]);
+}
 
 ///
 @safe unittest
@@ -6304,6 +6308,8 @@ enum bool isAbstractClass(T) = __traits(isAbstractClass, T);
     static assert(!isAbstractClass!S);
     static assert(!isAbstractClass!C);
     static assert( isAbstractClass!AC);
+    AC c;
+    static assert(isAbstractClass!c);
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -6251,7 +6251,11 @@ template isAbstractFunction(T...)
 /**
  * Detect whether $(D T) is a final function.
  */
-enum bool isFinalFunction(alias f) = __traits(isFinalFunction, f);
+template isFinalFunction(T...)
+    if (T.length == 1)
+{
+        enum bool isFinalFunction = __traits(isFinalFunction, T[0]);
+}
 
 ///
 @safe unittest
@@ -6263,6 +6267,7 @@ enum bool isFinalFunction(alias f) = __traits(isFinalFunction, f);
         void bar() { }
         final void foo();
     }
+    static assert(!isFinalFunction!(int));
     static assert(!isFinalFunction!(S.bar));
     static assert( isFinalFunction!(FC.foo));
     static assert(!isFinalFunction!(C.bar));

--- a/std/traits.d
+++ b/std/traits.d
@@ -5364,16 +5364,24 @@ enum bool isNumeric(T) = __traits(isArithmetic, T);
 /**
 Detect whether $(D T) is a scalar type (a built-in numeric, character or boolean type).
  */
-enum bool isScalarType(T) = isNumeric!T || isSomeChar!T || isBoolean!T; // TODO make __traits(isScalar, T) work here
+enum bool isScalarType(T) = is(T : real);
 
 ///
 @safe unittest
 {
     static assert(!isScalarType!void);
+    static assert( isScalarType!(immutable(bool)));
+    static assert( isScalarType!(immutable(byte)));
+    static assert( isScalarType!(immutable(short)));
     static assert( isScalarType!(immutable(int)));
     static assert( isScalarType!(shared(float)));
     static assert( isScalarType!(shared(const bool)));
+    static assert( isScalarType!(const(char)));
+    static assert( isScalarType!(const(wchar)));
     static assert( isScalarType!(const(dchar)));
+    static assert( isScalarType!(const(float)));
+    static assert( isScalarType!(const(double)));
+    static assert( isScalarType!(const(real)));
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -5402,7 +5402,9 @@ enum bool isBasicType(T) = isScalarType!T || is(Unqual!T == void);
 /**
 Detect whether $(D T) is a built-in unsigned numeric type.
  */
-enum bool isUnsigned(T) = is(UnsignedTypeOf!T) && !isAggregateType!T;
+enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
+                                                       is(Unqual!T == wchar) ||
+                                                       is(Unqual!T == dchar));
 
 @safe unittest
 {

--- a/std/traits.d
+++ b/std/traits.d
@@ -5370,16 +5370,15 @@ enum bool isScalarType(T) = is(T : real);
 @safe unittest
 {
     static assert(!isScalarType!void);
-    static assert( isScalarType!(immutable(bool)));
     static assert( isScalarType!(immutable(byte)));
-    static assert( isScalarType!(immutable(short)));
+    static assert( isScalarType!(immutable(ushort)));
     static assert( isScalarType!(immutable(int)));
+    static assert( isScalarType!(ulong));
     static assert( isScalarType!(shared(float)));
     static assert( isScalarType!(shared(const bool)));
     static assert( isScalarType!(const(char)));
-    static assert( isScalarType!(const(wchar)));
+    static assert( isScalarType!(wchar));
     static assert( isScalarType!(const(dchar)));
-    static assert( isScalarType!(const(float)));
     static assert( isScalarType!(const(double)));
     static assert( isScalarType!(const(real)));
 }

--- a/std/traits.d
+++ b/std/traits.d
@@ -5344,7 +5344,7 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T);
 }
 
 /**
-Detect whether $(D T) is a built-in numeric type (integral or floating
+   Detect whether $(D T) is a built-in numeric type (integral or floating
 point).
  */
 enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
@@ -5369,7 +5369,7 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
 /**
 Detect whether $(D T) is a scalar type (a built-in numeric, character or boolean type).
  */
-enum bool isScalarType(T) = is(T : real);
+enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
 
 ///
 @safe unittest
@@ -5386,6 +5386,13 @@ enum bool isScalarType(T) = is(T : real);
     static assert( isScalarType!(const(dchar)));
     static assert( isScalarType!(const(double)));
     static assert( isScalarType!(const(real)));
+
+    struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isScalarType!(S!int));
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -6231,13 +6231,18 @@ template isCallable(T...)
 /**
  * Detect whether $(D T) is an abstract function.
  */
-enum bool isAbstractFunction(alias f) = __traits(isAbstractFunction, f);
+template isAbstractFunction(T...)
+    if (T.length == 1)
+{
+    enum bool isAbstractFunction = __traits(isAbstractFunction, T[0]);
+}
 
 @safe unittest
 {
     struct S { void foo() { } }
     class C { void foo() { } }
     class AC { abstract void foo(); }
+    static assert(!isAbstractFunction!(int));
     static assert(!isAbstractFunction!(S.foo));
     static assert(!isAbstractFunction!(C.foo));
     static assert( isAbstractFunction!(AC.foo));

--- a/std/traits.d
+++ b/std/traits.d
@@ -5290,6 +5290,13 @@ enum bool isBoolean(T) = is(BooleanTypeOf!T) && !isAggregateType!T;
     enum EB : bool { a = true }
     static assert( isBoolean!EB);
     static assert(!isBoolean!(SubTypeOf!bool));
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isIntegral!(S!bool));
 }
 
 /**
@@ -5315,6 +5322,13 @@ enum bool isIntegral(T) = is(IntegralTypeOf!T) && !isAggregateType!T;
     enum EI : int { a = -1, b = 0, c = 1 }  // base type is signed (bug 7909)
     static assert(isIntegral!EU &&  isUnsigned!EU && !isSigned!EU);
     static assert(isIntegral!EI && !isUnsigned!EI &&  isSigned!EI);
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isIntegral!(S!int));
 }
 
 /**
@@ -5341,6 +5355,13 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T);
             static assert(!isFloatingPoint!(Q!T));
         }
     }
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isFloatingPoint!(S!float));
 }
 
 /**
@@ -5364,6 +5385,13 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
             static assert(!isNumeric!(SubTypeOf!(Q!T)));
         }
     }
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isNumeric!(S!int));
 }
 
 /**
@@ -5388,7 +5416,7 @@ enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
     static assert( isScalarType!(const(double)));
     static assert( isScalarType!(const(real)));
 
-    struct S(T)
+    static struct S(T)
     {
         T t;
         alias t this;

--- a/std/traits.d
+++ b/std/traits.d
@@ -5290,7 +5290,10 @@ enum bool isBoolean(T) = is(BooleanTypeOf!T) && !isAggregateType!T;
     enum EB : bool { a = true }
     static assert( isBoolean!EB);
     static assert(!isBoolean!(SubTypeOf!bool));
+}
 
+@safe unittest
+{
     static struct S(T)
     {
         T t;
@@ -5415,7 +5418,10 @@ enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
     static assert( isScalarType!(const(dchar)));
     static assert( isScalarType!(const(double)));
     static assert( isScalarType!(const(real)));
+}
 
+@safe unittest
+{
     static struct S(T)
     {
         T t;
@@ -5464,6 +5470,13 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
             static assert(!isUnsigned!(SubTypeOf!(Q!T)));
         }
     }
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isUnsigned!(S!uint));
 }
 
 /**
@@ -5487,6 +5500,13 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
             static assert(!isSigned!(SubTypeOf!(Q!T)));
         }
     }
+
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isSigned!(S!uint));
 }
 
 /**
@@ -5529,6 +5549,14 @@ enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
             static assert(!isSomeChar!( SubTypeOf!(Q!T) ));
         }
     }
+
+    // alias-this types are not allowed
+    static struct S(T)
+    {
+        T t;
+        alias t this;
+    }
+    static assert(!isSomeChar!(S!char));
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -5347,10 +5347,15 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T);
 Detect whether $(D T) is a built-in numeric type (integral or floating
 point).
  */
-enum bool isNumeric(T) = __traits(isArithmetic, T);
+enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == char) ||
+                                                        is(Unqual!T == wchar) ||
+                                                        is(Unqual!T == dchar));
 
 @safe unittest
 {
+    static assert(!isNumeric!(char));
+    static assert(!isNumeric!(wchar));
+    static assert(!isNumeric!(dchar));
     foreach (T; TypeTuple!(NumericTypeList))
     {
         foreach (Q; TypeQualifierList)


### PR DESCRIPTION
Use builtin `__traits` https://dlang.org/spec/traits.html in `std.traits` and perhaps others for less template instantiations.

- [ ] TODO check if `UnsignedTypeOf` can be removed or at least deprecated according to
http://forum.dlang.org/post/azthdyasrlsojztsyoqs@forum.dlang.org
