### PR TITLE
Removed auto-decoding from the bool version of std.conv.parse

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1887,16 +1887,27 @@ Note:
     All character input range conversions using $(LREF to) are forwarded
     to `parse` and do not require lvalues.
 */
-Target parse(Target, Source)(ref Source s)
+Target parse(Target, Source)(ref Source source)
     if (isInputRange!Source &&
         isSomeChar!(ElementType!Source) &&
         is(Unqual!Target == bool))
 {
     import std.ascii : toLower;
+
+    static if (isNarrowString!Source)
+    {
+        import std.string : representation, assumeUTF;
+        auto s = source.representation;
+    }
+    else
+    {
+        alias s = source;
+    }
+
     if (!s.empty)
     {
         auto c1 = toLower(s.front);
-        bool result = (c1 == 't');
+        bool result = c1 == 't';
         if (result || c1 == 'f')
         {
             s.popFront();
@@ -1906,6 +1917,10 @@ Target parse(Target, Source)(ref Source s)
                     goto Lerr;
                 s.popFront();
             }
+
+            static if (isNarrowString!Source)
+                source = s.assumeUTF;
+
             return result;
         }
     }


### PR DESCRIPTION
Small performance increase. But still, it makes this function `nothrow` for strings.

```
# new
Total time: 11 ms, 2 μs, and 4 hnsecs

# old
Total time: 14 ms, 978 μs, and 3 hnsecs
```

```d
import std.stdio;
import std.range;
import std.algorithm;
import std.traits;
import std.container;
import std.meta;
import std.conv;
import std.datetime;

Target parse1(Target, Source)(ref Source source)
    if (isInputRange!Source &&
        isSomeChar!(ElementType!Source) &&
        is(Unqual!Target == bool))
{
    import std.ascii : toLower;

    static if (isNarrowString!Source)
    {
        import std.string : representation, assumeUTF;
        auto s = source.representation;
    }
    else
    {
        alias s = source;
    }

    if (!s.empty)
    {
        auto c1 = toLower(s.front);
        bool result = (c1 == 't');
        if (result || c1 == 'f')
        {
            s.popFront();
            foreach (c; result ? "rue" : "alse")
            {
                if (s.empty || toLower(s.front) != c)
                    goto Lerr;
                s.popFront();
            }

            static if (isNarrowString!Source)
                source = s.assumeUTF;

            return result;
        }
    }
Lerr:
    throw new Exception("a");
}

__gshared char[] test = ['t', 'r', 'u', 'e'];

void main()
{
    import std.array : appender;

    enum n = 100_000_000;

    bool result;
    StopWatch sw;
    Duration sum;
    TickDuration last = TickDuration.from!"seconds"(0);

    foreach(i; 0 .. n)
    {
        sw.start();

        // New
        result = parse1!(bool)(test);

        // Old
        //result = parse!(bool)(test);

        sw.stop();

        test = ['t', 'r', 'u', 'e'];
        auto time = sw.peek() - last;
        last = sw.peek();

        sum += time.to!Duration();
    }

    writeln("Total time: ", sum);
}
```