### PR TITLE
Fix issue #8260 - add template constraints for formattedRead parameters

### DIFF
--- a/changelog/std-format-formattedRead-only-pointers.dd
+++ b/changelog/std-format-formattedRead-only-pointers.dd
@@ -1,0 +1,2 @@
+`std.format.formattedRead` now only accepts pointers as input arguments.
+

--- a/std/format.d
+++ b/std/format.d
@@ -568,6 +568,7 @@ can match the expected number of readings or fewer, even zero, if a
 matching failure happens.
  */
 uint formattedRead(R, Char, S...)(ref R r, const(Char)[] fmt, S args)
+if (allSatisfy!(isPointer, S))
 {
     import std.typecons : isTuple;
 


### PR DESCRIPTION
Allow only types with unary `*` operator. Could be improved if `isLvalue` template constraint has existed.