### PR TITLE
style fix - remove wrong usages of the final attribute

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1433,7 +1433,7 @@ private:
         }
 
     private:
-        final void switchContext() nothrow
+        void switchContext() nothrow
         {
             mutex_nothrow.unlock_nothrow();
             scope(exit) mutex_nothrow.lock_nothrow();
@@ -1445,7 +1445,7 @@ private:
 
 
 private:
-    final void dispatch()
+    void dispatch()
     {
         import std.algorithm.mutation : remove;
 
@@ -1467,7 +1467,7 @@ private:
     }
 
 
-    final void create( void delegate() op ) nothrow
+    void create( void delegate() op ) nothrow
     {
         void wrap()
         {
@@ -1918,7 +1918,7 @@ private
          * if the owner thread terminates and no existing messages match the
          * supplied ops.
          */
-        final bool get(T...)( scope T vals )
+        bool get(T...)( scope T vals )
         {
             import std.meta : AliasSeq;
 
@@ -2194,20 +2194,20 @@ private
         //////////////////////////////////////////////////////////////////////
 
 
-        pure final bool isControlMsg( ref Message msg )
+        pure bool isControlMsg( ref Message msg )
         {
             return msg.type != MsgType.standard &&
                    msg.type != MsgType.priority;
         }
 
 
-        pure final bool isPriorityMsg( ref Message msg )
+        pure bool isPriorityMsg( ref Message msg )
         {
             return msg.type == MsgType.priority;
         }
 
 
-        pure final bool isLinkDeadMsg( ref Message msg )
+        pure bool isLinkDeadMsg( ref Message msg )
         {
             return msg.type == MsgType.linkDead;
         }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -755,7 +755,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
             enum doUnittest = false;
 
         // note, this must be final so it does not affect the vtable layout
-        final bool arrayEqual(T[] arr)
+        bool arrayEqual(T[] arr)
         {
             if (walkLength(this[]) == arr.length)
             {

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -271,7 +271,7 @@ if (Targets.length >= 1 && allSatisfy!(isInterface, Targets))
                 static if (is(Source == class) || is(Source == interface))
                 {
                     // BUG: making private should work with NVI.
-                    protected final inout(Object) _wrap_getSource() inout @safe
+                    protected inout(Object) _wrap_getSource() inout @safe
                     {
                         return dynamicCast!(inout Object)(_wrap_source);
                     }
@@ -279,7 +279,7 @@ if (Targets.length >= 1 && allSatisfy!(isInterface, Targets))
                 else
                 {
                     // BUG: making private should work with NVI.
-                    protected final inout(Source) _wrap_getSource() inout @safe
+                    protected inout(Source) _wrap_getSource() inout @safe
                     {
                         return _wrap_source;
                     }

--- a/std/socket.d
+++ b/std/socket.d
@@ -1261,7 +1261,7 @@ abstract class Address
     }
 
     // Common code for toAddrString and toHostNameString
-    private final string toHostString(bool numeric) @trusted const
+    private string toHostString(bool numeric) @trusted const
     {
         // getnameinfo() is the recommended way to perform a reverse (name)
         // lookup on both Posix and Windows. However, it is only available
@@ -1301,7 +1301,7 @@ abstract class Address
     }
 
     // Common code for toPortString and toServiceNameString
-    private final string toServiceString(bool numeric) @trusted const
+    private string toServiceString(bool numeric) @trusted const
     {
         // See toHostNameString() for details about getnameinfo().
         if (getnameinfoPointer)
@@ -2121,23 +2121,23 @@ private:
 
         fd_set_type[] set;
 
-        final void resize(size_t size) pure nothrow
+        void resize(size_t size) pure nothrow
         {
             set.length = FD_SET_OFFSET + size;
         }
 
-        final ref inout(fd_set_count_type) count() @trusted @property inout pure nothrow @nogc
+        ref inout(fd_set_count_type) count() @trusted @property inout pure nothrow @nogc
         {
             assert(set.length);
             return *cast(inout(fd_set_count_type)*)set.ptr;
         }
 
-        final size_t capacity() @property const pure nothrow @nogc
+        size_t capacity() @property const pure nothrow @nogc
         {
             return set.length - FD_SET_OFFSET;
         }
 
-        final inout(socket_t)[] fds() @trusted inout @property pure nothrow @nogc
+        inout(socket_t)[] fds() @trusted inout @property pure nothrow @nogc
         {
             return cast(inout(socket_t)[])set[FD_SET_OFFSET..FD_SET_OFFSET+count];
         }
@@ -2175,21 +2175,21 @@ private:
 
         fd_set_type[] set;
 
-        final void resize(size_t size) pure nothrow
+        void resize(size_t size) pure nothrow
         {
             set.length = lengthFor(size);
         }
 
         // Make sure we can fit that many sockets
 
-        final void setMinCapacity(size_t size) pure nothrow
+        void setMinCapacity(size_t size) pure nothrow
         {
             auto length = lengthFor(size);
             if (set.length < length)
                 set.length = length;
         }
 
-        final size_t capacity() @property const pure nothrow @nogc
+        size_t capacity() @property const pure nothrow @nogc
         {
             return set.length * FD_NFDBITS;
         }


### PR DESCRIPTION
very few actually since phobos almost always use `struct`. Mostly some `private final`. See also https://github.com/dlang/druntime/pull/1745.