### PR TITLE
Fix issue #16323 - implement utf.encodeBack function

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -1754,7 +1754,8 @@ version(unittest) private void testDecodeBack(R)(ref R range,
                                                  size_t expectedNumCodeUnits,
                                                  size_t line = __LINE__)
 {
-    static if (!isSomeString!R && !isBidirectionalRange!R)
+    // This condition is to allow unit testing all `decode` functions together
+    static if (!isBidirectionalRange!R)
         return;
     else
     {
@@ -1821,7 +1822,8 @@ version(unittest) private void testBadDecode(R)(R range, size_t index, size_t li
 
 version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
 {
-    static if (!isSomeString!R && !isBidirectionalRange!R)
+    // This condition is to allow unit testing all `decode` functions together
+    static if (!isBidirectionalRange!R)
         return;
     else
     {

--- a/std/utf.d
+++ b/std/utf.d
@@ -1229,10 +1229,7 @@ body
             const Char[] codePoint = codeUnits[0 .. numCodeUnits];
             size_t index = 0;
             immutable retval = decodeImpl!(true, useReplacementDchar)(codePoint, index);
-
-            import std.algorithm.mutation : swap;
-            swap(str, tmp);
-
+            str = tmp;
             return retval;
         }
     }
@@ -1757,7 +1754,7 @@ version(unittest) private void testDecodeBack(R)(ref R range,
                                                  size_t expectedNumCodeUnits,
                                                  size_t line = __LINE__)
 {
-    static if (!isSomeString!R || !isBidirectionalRange!R || (isRandomAccessRange!R && !hasLength!R))
+    static if (!isSomeString!R && !isBidirectionalRange!R)
         return;
     else
     {
@@ -1824,7 +1821,7 @@ version(unittest) private void testBadDecode(R)(R range, size_t index, size_t li
 
 version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
 {
-    static if (!isSomeString!R || !isBidirectionalRange!R || (isRandomAccessRange!R && !hasLength!R))
+    static if (!isSomeString!R && !isBidirectionalRange!R)
         return;
     else
     {
@@ -1951,7 +1948,7 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
         testBadDecode(S([ cast(wchar)0xD800, cast(wchar)0x1200 ]), 0);
 
         testBadDecodeBack(S([ cast(wchar)0xD801 ]));
-        testBadDecodeBack(S([ cast(wchar)0xD800, cast(wchar)0x1200 ]));
+        testBadDecodeBack(S([ cast(wchar)0x0010, cast(wchar)0xD800 ]));
 
         {
             auto range = S("ウェブサイト");


### PR DESCRIPTION
decodeBack consists of 4 overloads: one not taking an index as an argument and underneath calling one of the 3 remaining overloads:
1. taking a string which is `@trusted` and `pure`
2. taking a finite random access range
3. taking a bidirectional (but not random access) range

I added unit tests for this function to existing `decode` tests, modifying them a bit.