### PR TITLE
fix issue 17116 - std.typecons.ReplaceType is not able to process const delegates

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7414,7 +7414,7 @@ private template replaceTypeInFunctionType(From, To, fun)
         static if (attributes & FunctionAttribute.system)
             result ~= " @system";
         static if (attributes & FunctionAttribute.const_)
-            result ~= " @const";
+            result ~= " const";
         static if (attributes & FunctionAttribute.immutable_)
             result ~= " immutable";
         static if (attributes & FunctionAttribute.inout_)
@@ -7517,6 +7517,14 @@ private template replaceTypeInFunctionType(From, To, fun)
         ubyte, ubyte, T2, T2,
         ubyte, ubyte, T3, T3,
     );
+}
+
+@safe unittest // Bugzilla 17116
+{
+    alias ConstDg = void delegate(float) const;
+    alias B = void delegate(int) const;
+    alias A = ReplaceType!(float, int, ConstDg);
+    static assert(is(B == A));
 }
 
 /**


### PR DESCRIPTION
Interestingly enough this was found thanks to a code metric tool that indicates that the volume (as defined by the Halstead complexity) of this function is a bit excessive. Quickly after starting to review the function I saw the bug.