### PR TITLE
combine std.array.split() overloads into one

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1464,6 +1464,7 @@ alias splitter = std.algorithm.iteration.splitter;
     See_Also:
         $(REF splitter, std,algorithm,iteration) for the lazy version of this
         function.
+        $(REF split, std,regex) for splitting with a regular expression.
  +/
 auto split(Range, Separator)(Range range, Separator sep)
 if (isForwardRange!Range && is(typeof(ElementType!Range.init == Separator.init)))


### PR DESCRIPTION
This replaces 2 overloads of split() with complex constraints into one function, with the variants selected via `static if`. A custom error message is generated for incorrect arguments.

One behavior change of this is if someone has their `split(a,b)` function in another import, the compiler will complain about ambiguity for which one to call, as this new version will accept anything for `a` and `b`. The previous constraints are suspect anyway, as they would accept nonsense like `split("ab",1)`. I did not correct that issue in this PR.