### PR TITLE
Fix auto-tester heisenbug on OSX 32

### DIFF
--- a/std/regex/internal/tests3.d
+++ b/std/regex/internal/tests3.d
@@ -317,5 +317,6 @@ unittest
 
     enum issueRE = ctRegex!(`((close|fix|address)e?(s|d)? )` ~
         `?(ticket|bug|tracker item|issue)s?:? *([\d ,\+&#and]+)`, "i");
-    message.matchAll(issueRE).map!matchToRefs.joiner.array;
+    auto r = message.matchAll(issueRE);
+    r.map!matchToRefs.joiner.array;
 }


### PR DESCRIPTION
Seems to be compiler bug but have no time to dig down deeper, at least this fixes the auto-tester.