### PR TITLE
Deprecate Obsolete Encoding Functions in std.utf

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2690,7 +2690,7 @@ $(D Range) that locks the file and allows fast writing to it.
             }
             else static if (c.sizeof == 2)
             {
-                import std.utf : toUTF8;
+                import std.utf : encode, UseReplacementDchar;
 
                 if (orientation_ <= 0)
                 {
@@ -2701,9 +2701,9 @@ $(D Range) that locks the file and allows fast writing to it.
                     else
                     {
                         char[4] buf;
-                        auto b = toUTF8(buf, c);
-                        foreach (i ; 0 .. b.length)
-                            trustedFPUTC(b[i], handle_);
+                        immutable size = encode!(UseReplacementDchar.yes)(buf, c);
+                        foreach (i ; 0 .. size)
+                            trustedFPUTC(buf[i], handle_);
                     }
                 }
                 else
@@ -4462,12 +4462,12 @@ private struct ReadlnAppender
     }
     void putdchar(dchar dc) @trusted
     {
-        import std.utf : toUTF8;
+        import std.utf : encode, UseReplacementDchar;
 
         char[4] ubuf;
-        char[] u = toUTF8(ubuf, dc);
-        reserve(u.length);
-        foreach (c; u)
+        immutable size = encode!(UseReplacementDchar.yes)(ubuf, dc);
+        reserve(size);
+        foreach (c; ubuf)
             buf.ptr[pos++] = c;
     }
     void putonly(char[] b) @trusted

--- a/std/utf.d
+++ b/std/utf.d
@@ -2654,7 +2654,8 @@ void validate(S)(in S str) @safe pure
     }());
 }
 
-/* =================== Conversion to UTF8 ======================= */
+//@@@DEPRECATED_2017-10@@@
+deprecated("To be removed November 2017. Please use std.utf.encode instead.")
 char[] toUTF8(return out char[4] buf, dchar c) nothrow @nogc @safe pure
 {
     if (c <= 0x7F)
@@ -2735,9 +2736,8 @@ string toUTF8(S)(S s) if (isInputRange!S && isSomeChar!(ElementEncodingType!S))
     assert(r2.toUTF8.equal([0xF0, 0x90, 0x90, 0xB7]));
 }
 
-
-/* =================== Conversion to UTF16 ======================= */
-
+//@@@DEPRECATED_2017-10@@@
+deprecated("To be removed November 2017. Please use std.utf.encode instead.")
 wchar[] toUTF16(return ref wchar[2] buf, dchar c) nothrow @nogc @safe pure
 in
 {


### PR DESCRIPTION
These functions are exactly the same as `std.utf.encode`. And they are quite old, originating in 2007 according to git blame. So they probably existed before `std.utf.encode`. 

They also return a slice over a static array, which is a Bad Idea<sup>TM</sup>.

Doing a deprecation cycle because they are publicly accessible and were used in other parts of Phobos.