### PR TITLE
[Trivial] Fix std.conv unittest compile error for double-precision reals

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3032,7 +3032,7 @@ Target parse(Target, Source)(ref Source source)
 }
 
 //Tests for the double implementation
-@safe unittest
+unittest
 {
     static if (real.mant_dig == 53)
     {

--- a/std/conv.d
+++ b/std/conv.d
@@ -1624,8 +1624,11 @@ private void testFloatingToIntegral(Floating, Integral)()
         assert(to!long(to!double(b)) == b);
         assert(to!long(to!double(-b)) == -b);
         // real
-        ulong c = 18_446_744_073_709_551_615UL; // 2^64 - 1
-        assert(to!ulong(to!real(c)) == c);
+        static if (real.mant_dig >= 64)
+        {
+            ulong c = 18_446_744_073_709_551_615UL; // 2^64 - 1
+            assert(to!ulong(to!real(c)) == c);
+        }
     }
     // test conversions floating => integral
     {


### PR DESCRIPTION
`strtod()` is `@system` and thus can't be called from a `@safe` unittest.