### PR TITLE
[scope] add 'return scope' to std.utf.byUTF and std.string.leftJustifier

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -3734,12 +3734,6 @@ auto leftJustifier(Range)(Range r, size_t width, dchar fillChar = ' ')
             size_t len;
 
           public:
-            this(Range input, size_t width, dchar fillChar)
-            {
-                _input = input;
-                _width = width;
-                _fillChar = fillChar;
-            }
 
             @property bool empty()
             {
@@ -3760,7 +3754,7 @@ auto leftJustifier(Range)(Range r, size_t width, dchar fillChar = ' ')
 
             static if (isForwardRange!Range)
             {
-                @property typeof(this) save()
+                @property typeof(this) save() return scope
                 {
                     auto ret = this;
                     ret._input = _input.save;

--- a/std/utf.d
+++ b/std/utf.d
@@ -3844,7 +3844,10 @@ template byUTF(C) if (isSomeChar!C)
 
                 static if (isForwardRange!R)
                 {
-                    @property auto save()
+                    @property auto save() return scope
+                    /* `return scope` cannot be inferred because compiler does not
+                     * track it backwards from assignment to local `ret`
+                     */
                     {
                         auto ret = this;
                         ret.r = r.save;


### PR DESCRIPTION
The inference of `return scope` is a bit primitive in the compiler, sometimes it has to be specified.