### PR TITLE
Add unpackIterator for tuple ranges

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1230,7 +1230,7 @@ auto unpackIterator(Range)(Range r)
     return Result(r);
 }
 
-@safe unittest
+unittest
 {
     alias T = Tuple!(int,string);
     const T[] array = [ T(1, "a"), T(2, "b"), T(3, "c"), T(4, "d") ];

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1168,27 +1168,7 @@ template Tuple(Specs...)
     assert(!is(typeof(point1) == typeof(point2)));
 }
 
-/**
-    Allows to unpack a $(D Tuple) range to arguments when iterating using $(D foreach).
-
-    Examples:
-    ---
-    foreach (string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator)
-    {
-        writefln("name: %s, id: %s" name, id);
-    }
-    ---
-
-    Examples:
-    ---
-    alias T = Tuple!(string,string);
-    T[] array = [ T("a", "b"), T("c", "d") ];
-    foreach (size_t index, string first, string second; array.unpackIterator)
-    {
-        writefln("index: %s, first: %s, second: %s", index, first, second);
-    }
-    ---
-*/
+/// Allows to unpack a $(D Tuple) range to arguments when iterating using $(D foreach).
 auto unpackIterator(Range)(Range r)
     if (isInputRange!(Unqual!Range) && isTuple!(ElementType!Range))
 {
@@ -1196,7 +1176,7 @@ auto unpackIterator(Range)(Range r)
     {
         private alias R = Unqual!Range;
         private alias Types = ElementType!R.Types;
-        public R source;
+        R source;
 
         int opApply(scope int delegate(Types args) dg)
         {
@@ -1230,6 +1210,7 @@ auto unpackIterator(Range)(Range r)
     return Result(r);
 }
 
+///
 unittest
 {
     alias T = Tuple!(int,string);
@@ -1246,7 +1227,11 @@ unittest
         }
         assert( index == 4 );
     }
+}
 
+/// It is also possible to get item index as first argument
+unittest
+{
     {
         size_t index = 0;
         foreach (i, num, str; array.unpackIterator)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1188,27 +1188,32 @@ template Tuple(Specs...)
     ---
 */
 auto unpackIterator(Range)(Range r)
-    if( isInputRange!(Unqual!Range) && isTuple!(ElementType!Range) )
+    if(isInputRange!(Unqual!Range) && isTuple!(ElementType!Range))
 {
-    static struct Result {
+    static struct Result
+    {
         private alias R = Unqual!Range;
         private alias Types = ElementType!R.Types;
         public R source;
 
-        int opApply( scope int delegate(ref Types args) dg ) {
-            while( !range.empty ) {
+        int opApply(scope int delegate(ref Types args) dg)
+        {
+            while(!range.empty)
+            {
                 const int result = dg(range.front.expand);
                 range.popFront();
 
-                if( result )
+                if(result)
                     return result;
             }
             return 0;
 	    }
 
-        int opApply( scope int delegate(ref size_t, ref Types) dg ) {
+        int opApply(scope int delegate(ref size_t, ref Types) dg)
+        {
             size_t i = 0;
-            while(!range.empty) {
+            while(!range.empty)
+            {
                 const int result = dg(i, range.front.expand);
                 range.popFront();
                 i ++;
@@ -1220,7 +1225,7 @@ auto unpackIterator(Range)(Range r)
 	    }
     }
 
-    return Result( r );
+    return Result(r);
 }
 
 @safe unittest {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1169,11 +1169,12 @@ template Tuple(Specs...)
 }
 
 /**
-    Allows to unpack a $(D Tuple) ranges to arguments when iterating using $(D foreach).
+    Allows to unpack a $(D Tuple) range to arguments when iterating using $(D foreach).
 
     Examples:
     ---
-    foreach (string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator){
+    foreach (string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator)
+    {
         writefln("name: %s, id: %s" name, id);
     }
     ---
@@ -1182,7 +1183,8 @@ template Tuple(Specs...)
     ---
     alias T = Tuple!(string,string);
     T[] array = [ T("a", "b"), T("c", "d") ];
-    foreach (size_t index, string first, string second; array.unpackIterator) {
+    foreach (size_t index, string first, string second; array.unpackIterator)
+    {
         writefln("index: %s, first: %s, second: %s", index, first, second);
     }
     ---
@@ -1198,10 +1200,10 @@ auto unpackIterator(Range)(Range r)
 
         int opApply(scope int delegate(ref Types args) dg)
         {
-            while (!range.empty)
+            while (!source.empty)
             {
-                const int result = dg(range.front.expand);
-                range.popFront();
+                const int result = dg(source.front.expand);
+                source.popFront();
 
                 if (result)
                     return result;
@@ -1212,10 +1214,10 @@ auto unpackIterator(Range)(Range r)
         int opApply(scope int delegate(ref size_t, ref Types) dg)
         {
             size_t i = 0;
-            while (!range.empty)
+            while (!source.empty)
             {
-                const int result = dg(i, range.front.expand);
-                range.popFront();
+                const int result = dg(i, source.front.expand);
+                source.popFront();
                 i ++;
 
                 if (result)
@@ -1228,13 +1230,15 @@ auto unpackIterator(Range)(Range r)
     return Result(r);
 }
 
-@safe unittest {
+@safe unittest
+{
     alias T = Tuple!(int,string);
     const T[] array = [ T(1, "a"), T(2, "b"), T(3, "c"), T(4, "d") ];
 
     {
         size_t index = 0;
-        foreach ( int num, string str; array.unpackIterator ) {
+        foreach (int num, string str; array.unpackIterator)
+        {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
 
@@ -1245,7 +1249,8 @@ auto unpackIterator(Range)(Range r)
 
     {
         size_t index = 0;
-        foreach ( i, num, str; array.unpackIterator ) {
+        foreach (i, num, str; array.unpackIterator)
+        {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
             assert( i == index );

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1198,7 +1198,7 @@ auto unpackIterator(Range)(Range r)
         private alias Types = ElementType!R.Types;
         public R source;
 
-        int opApply(scope int delegate(ref Types args) dg)
+        int opApply(scope int delegate(Types args) dg)
         {
             while (!source.empty)
             {
@@ -1211,7 +1211,7 @@ auto unpackIterator(Range)(Range r)
             return 0;
 	    }
 
-        int opApply(scope int delegate(ref size_t, ref Types) dg)
+        int opApply(scope int delegate(size_t, Types) dg)
         {
             size_t i = 0;
             while (!source.empty)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -43,7 +43,7 @@ module std.typecons;
 import core.stdc.stdint : uintptr_t;
 import std.meta; // : AliasSeq, allSatisfy;
 import std.traits;
-import std.range : ElementType;
+import std.range : ElementType, isInputRange;
 
 debug(Unique) import std.stdio;
 
@@ -1169,7 +1169,7 @@ template Tuple(Specs...)
 }
 
 /**
-    Allows to unpack a $(D Tuple) to arguments when iterating using $(D foreach).
+    Allows to unpack a $(D Tuple) ranges to arguments when iterating using $(D foreach).
 
     Examples:
     ---
@@ -1234,7 +1234,7 @@ auto unpackIterator(Range)(Range r)
 
     {
         size_t index = 0;
-        foreach( int num, string str; array.unpackIterator ) {
+        foreach ( int num, string str; array.unpackIterator ) {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
 
@@ -1245,7 +1245,7 @@ auto unpackIterator(Range)(Range r)
 
     {
         size_t index = 0;
-        foreach( i, num, str; array.unpackIterator ) {
+        foreach ( i, num, str; array.unpackIterator ) {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
             assert( i == index );

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1173,7 +1173,7 @@ template Tuple(Specs...)
 
     Examples:
     ---
-    foreach(string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator){
+    foreach (string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator){
         writefln("name: %s, id: %s" name, id);
     }
     ---
@@ -1182,13 +1182,13 @@ template Tuple(Specs...)
     ---
     alias T = Tuple!(string,string);
     T[] array = [ T("a", "b"), T("c", "d") ];
-    foreach(size_t index, string first, string second; array.unpackIterator) {
+    foreach (size_t index, string first, string second; array.unpackIterator) {
         writefln("index: %s, first: %s, second: %s", index, first, second);
     }
     ---
 */
 auto unpackIterator(Range)(Range r)
-    if(isInputRange!(Unqual!Range) && isTuple!(ElementType!Range))
+    if (isInputRange!(Unqual!Range) && isTuple!(ElementType!Range))
 {
     static struct Result
     {
@@ -1198,12 +1198,12 @@ auto unpackIterator(Range)(Range r)
 
         int opApply(scope int delegate(ref Types args) dg)
         {
-            while(!range.empty)
+            while (!range.empty)
             {
                 const int result = dg(range.front.expand);
                 range.popFront();
 
-                if(result)
+                if (result)
                     return result;
             }
             return 0;
@@ -1212,13 +1212,13 @@ auto unpackIterator(Range)(Range r)
         int opApply(scope int delegate(ref size_t, ref Types) dg)
         {
             size_t i = 0;
-            while(!range.empty)
+            while (!range.empty)
             {
                 const int result = dg(i, range.front.expand);
                 range.popFront();
                 i ++;
 
-                if(result)
+                if (result)
                     return result;
             }
             return 0;
@@ -1234,7 +1234,7 @@ auto unpackIterator(Range)(Range r)
 
     {
         size_t index = 0;
-        foreach( int num, string str; array ) {
+        foreach( int num, string str; array.unpackIterator ) {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
 
@@ -1245,7 +1245,7 @@ auto unpackIterator(Range)(Range r)
 
     {
         size_t index = 0;
-        foreach( i, num, str; array ) {
+        foreach( i, num, str; array.unpackIterator ) {
             assert( num == index + 1 );
             assert( str == [ 'a' + index ] );
             assert( i == index );

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1182,7 +1182,7 @@ template Tuple(Specs...)
     ---
     alias T = Tuple!(string,string);
     T[] array = [ T("a", "b"), T("c", "d") ];
-    foreach(size_t index, string first, string second; array) {
+    foreach(size_t index, string first, string second; array.unpackIterator) {
         writefln("index: %s, first: %s, second: %s", index, first, second);
     }
     ---

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -43,7 +43,7 @@ module std.typecons;
 import core.stdc.stdint : uintptr_t;
 import std.meta; // : AliasSeq, allSatisfy;
 import std.traits;
-import std.range : ElementType, isInputRange;
+import std.range;
 
 debug(Unique) import std.stdio;
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1198,7 +1198,7 @@ auto unpackIterator(Range)(Range r)
             {
                 const int result = dg(i, source.front.expand);
                 source.popFront();
-                i ++;
+                i++;
 
                 if (result)
                     return result;
@@ -1216,34 +1216,33 @@ unittest
     alias T = Tuple!(int,string);
     const T[] array = [ T(1, "a"), T(2, "b"), T(3, "c"), T(4, "d") ];
 
+    size_t index = 0;
+    foreach (int num, string str; array.unpackIterator)
     {
-        size_t index = 0;
-        foreach (int num, string str; array.unpackIterator)
-        {
-            assert( num == index + 1 );
-            assert( str == [ 'a' + index ] );
+        assert( num == index + 1 );
+        assert( str == [ 'a' + index ] );
 
-            index ++;
-        }
-        assert( index == 4 );
+        index++;
     }
+    assert( index == 4 );
 }
 
 /// It is also possible to get item index as first argument
 unittest
 {
-    {
-        size_t index = 0;
-        foreach (i, num, str; array.unpackIterator)
-        {
-            assert( num == index + 1 );
-            assert( str == [ 'a' + index ] );
-            assert( i == index );
+    alias T = Tuple!(int,string);
+    const T[] array = [ T(1, "a"), T(2, "b"), T(3, "c"), T(4, "d") ];
 
-            index ++;
-        }
-        assert( index == 4 );
+    size_t index = 0;
+    foreach (i, num, str; array.unpackIterator)
+    {
+        assert( num == index + 1 );
+        assert( str == [ 'a' + index ] );
+        assert( i == index );
+
+        index++;
     }
+    assert( index == 4 );
 }
 
 /**


### PR DESCRIPTION
Allows to unpack a Tuple range to arguments when iterating using foreach.

Examples:
```d
foreach(string name, int id; [tuple("john", 5), tuple("jeff", 2)].unpackIterator){
    writefln("name: %s, id: %s" name, id);
}
```
```d
alias T = Tuple!(string,string);
T[] array = [ T("a", "b"), T("c", "d") ];
foreach(size_t index, string first, string second; array.unpackIterator) {
    writefln("index: %s, first: %s, second: %s", index, first, second);
}
```