### PR TITLE
std.json: use proper block comments

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -130,9 +130,11 @@ struct JSONValue
           assert(j["language"].type == JSON_TYPE.STRING);
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.STRING).
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.STRING).
+    /***
+     * Value getter/setter for $(D JSON_TYPE.STRING).
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.STRING).
+     */
     @property string str() const pure @trusted
     {
         enforce!JSONException(type == JSON_TYPE.STRING,
@@ -158,9 +160,11 @@ struct JSONValue
         assert(j["language"].str == "Perl");
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.INTEGER).
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.INTEGER).
+    /***
+     * Value getter/setter for $(D JSON_TYPE.INTEGER).
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.INTEGER).
+     */
     @property inout(long) integer() inout pure @safe
     {
         enforce!JSONException(type == JSON_TYPE.INTEGER,
@@ -174,9 +178,11 @@ struct JSONValue
         return store.integer;
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.UINTEGER).
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.UINTEGER).
+    /***
+     * Value getter/setter for $(D JSON_TYPE.UINTEGER).
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.UINTEGER).
+     */
     @property inout(ulong) uinteger() inout pure @safe
     {
         enforce!JSONException(type == JSON_TYPE.UINTEGER,
@@ -190,10 +196,12 @@ struct JSONValue
         return store.uinteger;
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.FLOAT). Note that despite
-    /// the name, this is a $(B 64)-bit `double`, not a 32-bit `float`.
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.FLOAT).
+    /***
+     * Value getter/setter for $(D JSON_TYPE.FLOAT). Note that despite
+     * the name, this is a $(B 64)-bit `double`, not a 32-bit `float`.
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.FLOAT).
+     */
     @property inout(double) floating() inout pure @safe
     {
         enforce!JSONException(type == JSON_TYPE.FLOAT,
@@ -207,10 +215,11 @@ struct JSONValue
         return store.floating;
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.OBJECT).
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.OBJECT).
-    /* Note: this is @system because of the following pattern:
+    /***
+     * Value getter/setter for $(D JSON_TYPE.OBJECT).
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.OBJECT).
+     * Note: this is @system because of the following pattern:
        ---
        auto a = &(json.object());
        json.uinteger = 0;        // overwrite AA pointer
@@ -230,19 +239,21 @@ struct JSONValue
         return v;
     }
 
-    /// Value getter for $(D JSON_TYPE.OBJECT).
-    /// Unlike $(D object), this retrieves the object by value and can be used in @safe code.
-    ///
-    /// A caveat is that, if the returned value is null, modifications will not be visible:
-    /// ---
-    /// JSONValue json;
-    /// json.object = null;
-    /// json.objectNoRef["hello"] = JSONValue("world");
-    /// assert("hello" !in json.object);
-    /// ---
-    ///
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.OBJECT).
+    /***
+     * Value getter for $(D JSON_TYPE.OBJECT).
+     * Unlike $(D object), this retrieves the object by value and can be used in @safe code.
+     *
+     * A caveat is that, if the returned value is null, modifications will not be visible:
+     * ---
+     * JSONValue json;
+     * json.object = null;
+     * json.objectNoRef["hello"] = JSONValue("world");
+     * assert("hello" !in json.object);
+     * ---
+     *
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.OBJECT).
+     */
     @property inout(JSONValue[string]) objectNoRef() inout pure @trusted
     {
         enforce!JSONException(type == JSON_TYPE.OBJECT,
@@ -250,10 +261,11 @@ struct JSONValue
         return store.object;
     }
 
-    /// Value getter/setter for $(D JSON_TYPE.ARRAY).
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.ARRAY).
-    /* Note: this is @system because of the following pattern:
+    /***
+     * Value getter/setter for $(D JSON_TYPE.ARRAY).
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.ARRAY).
+     * Note: this is @system because of the following pattern:
        ---
        auto a = &(json.array());
        json.uinteger = 0;  // overwrite array pointer
@@ -273,20 +285,22 @@ struct JSONValue
         return v;
     }
 
-    /// Value getter for $(D JSON_TYPE.ARRAY).
-    /// Unlike $(D array), this retrieves the array by value and can be used in @safe code.
-    ///
-    /// A caveat is that, if you append to the returned array, the new values aren't visible in the
-    /// JSONValue:
-    /// ---
-    /// JSONValue json;
-    /// json.array = [JSONValue("hello")];
-    /// json.arrayNoRef ~= JSONValue("world");
-    /// assert(json.array.length == 1);
-    /// ---
-    ///
-    /// Throws: $(D JSONException) for read access if $(D type) is not
-    /// $(D JSON_TYPE.ARRAY).
+    /***
+     * Value getter for $(D JSON_TYPE.ARRAY).
+     * Unlike $(D array), this retrieves the array by value and can be used in @safe code.
+     *
+     * A caveat is that, if you append to the returned array, the new values aren't visible in the
+     * JSONValue:
+     * ---
+     * JSONValue json;
+     * json.array = [JSONValue("hello")];
+     * json.arrayNoRef ~= JSONValue("world");
+     * assert(json.array.length == 1);
+     * ---
+     *
+     * Throws: $(D JSONException) for read access if $(D type) is not
+     * $(D JSON_TYPE.ARRAY).
+     */
     @property inout(JSONValue[]) arrayNoRef() inout pure @trusted
     {
         enforce!JSONException(type == JSON_TYPE.ARRAY,
@@ -411,7 +425,7 @@ struct JSONValue
      * $(D long), $(D double), an associative array $(D V[K]) for any $(D V)
      * and $(D K) i.e. a JSON object, any array or $(D bool). The type will
      * be set accordingly.
-    */
+     */
     this(T)(T arg) if (!isStaticArray!T)
     {
         assign(arg);
@@ -450,8 +464,10 @@ struct JSONValue
         assignRef(arg);
     }
 
-    /// Array syntax for json arrays.
-    /// Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.ARRAY).
+    /***
+     * Array syntax for json arrays.
+     * Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.ARRAY).
+     */
     ref inout(JSONValue) opIndex(size_t i) inout pure @safe
     {
         auto a = this.arrayNoRef;
@@ -467,8 +483,10 @@ struct JSONValue
         assert( j[1].integer == 43 );
     }
 
-    /// Hash syntax for json objects.
-    /// Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT).
+    /***
+     * Hash syntax for json objects.
+     * Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT).
+     */
     ref inout(JSONValue) opIndex(string k) inout pure @safe
     {
         auto o = this.objectNoRef;
@@ -482,13 +500,15 @@ struct JSONValue
         assert( j["language"].str == "D" );
     }
 
-    /// Operator sets $(D value) for element of JSON object by $(D key).
-    ///
-    /// If JSON value is null, then operator initializes it with object and then
-    /// sets $(D value) for it.
-    ///
-    /// Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT)
-    /// or $(D JSON_TYPE.NULL).
+    /***
+     * Operator sets $(D value) for element of JSON object by $(D key).
+     *
+     * If JSON value is null, then operator initializes it with object and then
+     * sets $(D value) for it.
+     *
+     * Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT)
+     * or $(D JSON_TYPE.NULL).
+     */
     void opIndexAssign(T)(auto ref T value, string key) pure
     {
         enforceEx!JSONException(type == JSON_TYPE.OBJECT || type == JSON_TYPE.NULL,
@@ -649,18 +669,22 @@ struct JSONValue
         return result;
     }
 
-    /// Implicitly calls $(D toJSON) on this JSONValue.
-    ///
-    /// $(I options) can be used to tweak the conversion behavior.
+    /***
+     * Implicitly calls $(D toJSON) on this JSONValue.
+     *
+     * $(I options) can be used to tweak the conversion behavior.
+     */
     string toString(in JSONOptions options = JSONOptions.none) const @safe
     {
         return toJSON(this, false, options);
     }
 
-    /// Implicitly calls $(D toJSON) on this JSONValue, like $(D toString), but
-    /// also passes $(I true) as $(I pretty) argument.
-    ///
-    /// $(I options) can be used to tweak the conversion behavior
+    /***
+     * Implicitly calls $(D toJSON) on this JSONValue, like $(D toString), but
+     * also passes $(I true) as $(I pretty) argument.
+     *
+     * $(I options) can be used to tweak the conversion behavior
+     */
     string toPrettyString(in JSONOptions options = JSONOptions.none) const @safe
     {
         return toJSON(this, true, options);


### PR DESCRIPTION
Using line comments for blocks doesn't work with Ddoc, see https://github.com/dlang/dmd/pull/4745 for discussion. (It's ugly, too, and not in the Phobos style.)

Using `/* ... */` immediately after Ddoc comments is also poor style.