### PR TITLE
fix issue 17177.  AutoImplement fails on function overload sets with …

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3910,8 +3910,10 @@ private static:
 }
 
 // Issue 17177 - AutoImplement fails on function overload sets with "cannot infer type from overloaded function symbol"
-@system unittest {
-    static class Issue17177 {
+@system unittest
+{
+    static class Issue17177
+    {
         private string n_;
 
         public {
@@ -3936,7 +3938,9 @@ private static:
             return q{
                 return parent(args);
             };
-        } else {
+        }
+        else
+        {
             return q{
                 parent(args);
             };

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4175,8 +4175,7 @@ private static:
             {
                 preamble ~= "alias self = " ~ name ~ ";\n";
                 if (WITH_BASE_CLASS && !__traits(isAbstractFunction, func))
-                    //preamble ~= "alias super." ~ name ~ " parent;\n"; // [BUG 2540]
-                    preamble ~= "auto parent = &super." ~ name ~ ";\n";
+                    preamble ~= "alias parent = AliasSeq!(__traits(getMember, super, \"" ~ name ~ "\"))[0];";
             }
 
             // Function body

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3909,6 +3909,43 @@ private static:
     }+/
 }
 
+// Issue 17177 - AutoImplement fails on function overload sets with "cannot infer type from overloaded function symbol"
+@system unittest {
+    static class Issue17177 {
+        private string n_;
+
+        public {
+            Issue17177 overloaded(string n)
+            {
+                this.n_ = n;
+
+                return this;
+            }
+
+            string overloaded()
+            {
+                return this.n_;
+            }
+        }
+    }
+
+    static string how(C, alias fun)()
+    {
+        static if (!is(ReturnType!fun == void))
+        {
+            return q{
+                return parent(args);
+            };
+        } else {
+            return q{
+                parent(args);
+            };
+        }
+    }
+
+    alias Implementation = AutoImplement!(Issue17177, how, templateNot!isFinalFunction);
+}
+
 version(unittest)
 {
     // Issue 10647


### PR DESCRIPTION
Issue: https://issues.dlang.org/show_bug.cgi?id=17177
Problem found in generation of "parent" that is used to reference super.member in AutoImplement template.
Fixed it by, aliasing `parent` to getMember trait that gets `super.member`, instead of assigning `parent` to `super.member` delegate.