### PR TITLE
swapRanges: Remove redundant constraint tests

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2728,9 +2728,8 @@ Returns:
 */
 Tuple!(InputRange1, InputRange2)
 swapRanges(InputRange1, InputRange2)(InputRange1 r1, InputRange2 r2)
-    if (isInputRange!(InputRange1) && isInputRange!(InputRange2)
-            && hasSwappableElements!(InputRange1) && hasSwappableElements!(InputRange2)
-            && is(ElementType!(InputRange1) == ElementType!(InputRange2)))
+    if (hasSwappableElements!InputRange1 && hasSwappableElements!InputRange2
+        && is(ElementType!InputRange1 == ElementType!InputRange2))
 {
     for (; !r1.empty && !r2.empty; r1.popFront(), r2.popFront())
     {

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1261,7 +1261,7 @@ R r;
 static assert(isInputRange!R);
 swap(r.front, r.front);
 static if (isBidirectionalRange!R) swap(r.back, r.front);
-static if (isRandomAccessRange!R) swap(r[], r.front);
+static if (isRandomAccessRange!R) swap(r[0], r.front);
 ----
  */
 template hasSwappableElements(R)


### PR DESCRIPTION
Also fix related `hasSwappableElements `docs.

`hasSwappableElements` already tests for `isInputRange`.