### PR TITLE
Add std.traits.isStringLike to check for types similar to strings

### DIFF
--- a/changelog/std-traits-is-string-like.dd
+++ b/changelog/std-traits-is-string-like.dd
@@ -1,0 +1,29 @@
+Added `std.traits.isStringLike` to check for types that behave similar to strings.
+
+$(REF isStringLike, std, traits) checks whether `T` behaves similar to a string.
+In other words it requires `T`
+to be an $(B finite) `InputRange` with `char`, `wchar` or `dchar`
+as $(REF ElementEncodingType, std, range).
+Moreover `T` isn't allowed to be an aggregate type,
+implicitly convertible enum or static string array:
+
+-------
+import std.traits : isStringLike;
+
+static assert(isStringLike!string);
+static assert(isStringLike!wstring);
+static assert(isStringLike!string);
+static assert(!isStringLike!(char[10]));
+static assert(!isStringLike!(wchar[10]));
+static assert(!isStringLike!(dchar[10]));
+
+struct InputString(T)
+{
+    T[] payload;
+    T front() { return payload[0]; }
+    bool empty() const { return payload.length > 0; }
+    void popFront() { payload = payload[1..$]; }
+}
+static assert(isStringLike!(InputString!char));
+static assert(isStringLike!(InputString!wchar));
+-------


### PR DESCRIPTION
Follow-up to #5132 and the [NG discussion](http://forum.dlang.org/post/egudvlzgtwrqpdkmgwfb@forum.dlang.org).

The idea is that a common constraints combination like here with `isStringLike` can help to make the constraints easier to read.
It uses the definition as it is used e.g. by [`std.file`](https://github.com/dlang/phobos/blob/master/std/file.d#L235) though I have to admit that I am not quite sure whether to exclude `isConvertibleToString` types is a good idea as it excludes the following three types:

```d
// Static string arrays
char[10];
// string enums
enum StringEnum { a = "foo" }

// Aggregated strings
static struct Stringish
{
    string s;
    alias s this;
}
```

After all methods in `std.file` is usually just calls [`tempCString`](https://github.com/dlang/phobos/blob/master/std/internal/cstring.d#L89) which has these constraints for `From`:

```d
(isInputRange!From || isSomeString!From) &&
        isSomeChar!(ElementEncodingType!From)
```