### PR TITLE
[CircleCi] Update bootstrap compiler to 2.072.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,4 @@ test:
         timeout: 1200
 
   post:
-    - bash <(curl -s --retry 5 https://codecov.io/bash)
+    - ./circleci.sh codecov

--- a/circle.yml
+++ b/circle.yml
@@ -6,12 +6,12 @@ dependencies:
 
 test:
   override:
-    - ./circleci.sh style
     - ./circleci.sh setup-repos
+    - ./circleci.sh style
     - ./circleci.sh publictests
     - ./circleci.sh coverage:
         parallel: true
         timeout: 1200
 
   post:
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s --retry 5 https://codecov.io/bash)

--- a/circleci.sh
+++ b/circleci.sh
@@ -2,8 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
-DSCANNER_DMD_VER=2.071.2 # dscanner needs a more up-to-date version
+HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 DUB=${DUB:-$HOME/dlang/dub/dub}
 N=2
@@ -59,7 +58,7 @@ setup_repos()
     # set a default in case we run into rate limit restrictions
     local base_branch=""
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        base_branch=$((curl -fsSL https://api.github.com/repos/dlang/phobos/pulls/$CIRCLE_PR_NUMBER || echo) | jq -r '.base.ref')
+        base_branch=$((curl -fsSL https://api.github.com/repos/dlang/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER || echo) | jq -r '.base.ref')
     else
         base_branch=$CIRCLE_BRANCH
     fi
@@ -97,8 +96,8 @@ setup_repos()
 # verify style guide
 style()
 {
-    # dscanner needs a more up-to-date DMD version
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
+    # load compiler for dscanner
+    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
     make -f posix.mak style
 }

--- a/circleci.sh
+++ b/circleci.sh
@@ -7,29 +7,37 @@ CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 DUB=${DUB:-$HOME/dlang/dub/dub}
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-phobos}
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
     1) MODEL=32 ;;
 esac
 
-install_deps() {
-    if [ $MODEL -eq 32 ]; then
-        sudo apt-get update
-        sudo apt-get install g++-multilib
-    fi
-
+download() {
+    local url="$1"
+    local fallbackurl="$2"
+    local outputfile="$3"
     for i in {0..4}; do
-        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://dlang.org/install.sh -O ||
-           curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://nightlies.dlang.org/install.sh -O ; then
+        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$url" -O "$outputfile" ||
+           curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$fallbackurl" -o "$outputfile" ; then
             break
         elif [ $i -ge 4 ]; then
             sleep $((1 << $i))
         else
-            echo 'Failed to download install script' 1>&2
+            echo "Failed to download script ${outputfile}" 1>&2
             exit 1
         fi
     done
+}
+
+install_deps() {
+    if [ $MODEL -eq 32 ]; then
+        sudo apt-get update --quiet=2
+        sudo aptitude install g++-multilib --assume-yes --quiet=2
+    fi
+
+    download "https://dlang.org/install.sh" "https://nightlies.dlang.org/install.sh" "install.sh"
 
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh dmd-$HOST_DMD_VER --activate)"
     $DC --version
@@ -66,13 +74,13 @@ setup_repos()
 
     # merge upstream branch with changes, s.t. we check with the latest changes
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        local current_branch=$(git rev-parse --abbrev-ref HEAD)
-        git config user.name dummyuser
-        git config user.email dummyuser@dummyserver.com
-        git remote add upstream https://github.com/dlang/phobos.git
-        git fetch upstream
-        git checkout -f upstream/$base_branch
-        git merge -m "Automatic merge" $current_branch
+        local head=$(git rev-parse HEAD)
+        git fetch https://github.com/dlang/$CIRCLE_PROJECT_REPONAME.git $base_branch
+        git checkout -f FETCH_HEAD
+        local base=$(git rev-parse HEAD)
+        git config user.name 'CI'
+        git config user.email '<>'
+        git merge -m "Merge $head into $base" $head
     fi
 
     for proj in dmd druntime ; do
@@ -126,10 +134,19 @@ publictests()
     make -f posix.mak publictests DUB=$DUB
 }
 
+codecov()
+{
+    # CodeCov gets confused by lst files which it can't matched
+    rm -rf test/runnable/extra-files
+    download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
+    bash codecov.sh
+}
+
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     coverage) coverage ;;
     style) style ;;
     publictests) publictests ;;
+    codecov) codecov ;;
 esac


### PR DESCRIPTION
Bump CircleCi bootstrap compiler to 2.072.2 - it should be in sync with the [`dmd` repo](https://github.com/dlang/dmd/blob/master/circleci.sh#L5). I also did a minor cleanup of the CircleCi files.