### PR TITLE
Update runnable module list

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -259,11 +259,7 @@ SHARED=$(if $(findstring $(OS),linux freebsd),1,)
 # Check for missing imports in public unittest examples.
 # A blacklist of ignored module is provided as not all public unittest in
 # Phobos are independently runnable yet
-IGNORED_PUBLICTESTS= $(addprefix std/, \
-						base64 $(addprefix experimental/allocator/, \
-								building_blocks/free_list building_blocks/quantizer \
-						) digest/hmac \
-						file math stdio traits typecons uuid)
+IGNORED_PUBLICTESTS= $(addprefix std/, experimental/allocator/building_blocks/free_list traits typecons)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TEST_EXTRACTOR=$(TOOLS_DIR)/styles/test_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests

--- a/std/base64.d
+++ b/std/base64.d
@@ -178,7 +178,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         ubyte[] data = [0x1a, 0x2b, 0x3c, 0x4d, 0x5d, 0x6e];
 
         // Allocate a buffer large enough to hold the encoded string.
-        auto buf = new char[encodeLength(data.length)];
+        auto buf = new char[Base64.encodeLength(data.length)];
 
         Base64.encode(data, buf);
         assert(buf == "Gis8TV1u");

--- a/std/csv.d
+++ b/std/csv.d
@@ -1099,7 +1099,7 @@ public:
     }
 }
 
-///
+//
 @safe pure unittest
 {
     import std.algorithm.comparison : equal;

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -208,7 +208,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
         "allocateAll", "owns", "deallocateAll", "empty"));
 }
 
-///
+//
 @system unittest
 {
     import std.experimental.allocator.building_blocks.free_tree : FreeTree;

--- a/std/file.d
+++ b/std/file.d
@@ -4222,6 +4222,8 @@ slurp(Types...)(string filename, in char[] format)
 ///
 @system unittest
 {
+    import std.typecons : tuple;
+
     scope(exit)
     {
         assert(exists(deleteme));

--- a/std/math.d
+++ b/std/math.d
@@ -2575,7 +2575,7 @@ if (isFloatingPoint!T)
     }
 }
 
-///
+//
 @system unittest
 {
     int exp;
@@ -3432,7 +3432,7 @@ real log2(real x) @safe pure nothrow @nogc
     }
 }
 
-///
+//
 @system unittest
 {
     // check if values are equal to 19 decimal digits of precision

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5132,7 +5132,7 @@ version(linux)
     }
 }
 
-version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
+string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
 {
     import std.conv : text;
     import std.file : deleteme;

--- a/std/uni.d
+++ b/std/uni.d
@@ -2546,7 +2546,7 @@ private:
         return this;
     }
 
-    ///
+    //
     @safe unittest
     {
         assert(unicode.Cyrillic.intersect('-').byInterval.empty);
@@ -4340,7 +4340,7 @@ if (sumOfIntegerTuple!sizes == 21)
     }
 }
 
-///
+//
 @system pure unittest
 {
     import std.algorithm.comparison : max;
@@ -4644,7 +4644,7 @@ public struct MatcherConcept
         return this;
     }
 
-    ///
+    //
     @safe unittest
     {
         auto m = utfMatcher!char(unicode.Number);

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1709,7 +1709,7 @@ public class UUIDParsingException : Exception
     }
 }
 
-///
+//
 @safe unittest
 {
     auto ex = new UUIDParsingException("foo", 10, UUIDParsingException.Reason.tooMuch);


### PR DESCRIPTION
Unittest examples are finally runnable on the releases docs :)
This fixes the remaining modules, s.t. all public examples can be run on dlang.org (except for `typecons.d` and `traits.d` as they aren't parsable with libdparse and `ndslice/selection.d` as its deprecated anyways)

This depends on https://github.com/dlang/tools/pull/215 (version bump to libdparse) and https://github.com/dlang/tools/pull/216 (small bug fix to the `tests_extractor`)