### PR TITLE
Fix deprecation: std.utf.toUTF8 -> encode

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -703,7 +703,8 @@ JSONValue parseJSON(T)(T json, int maxDepth = -1, JSONOptions options = JSONOpti
 if (isInputRange!T)
 {
     import std.ascii : isWhite, isDigit, isHexDigit, toUpper, toLower;
-    import std.utf : toUTF8;
+    import std.typecons : Yes;
+    import std.utf : encode;
 
     JSONValue root;
     root.type_tag = JSON_TYPE.NULL;
@@ -823,7 +824,8 @@ if (isInputRange!T)
                             val += (isDigit(hex) ? hex - '0' : hex - ('A' - 10)) << (4 * i);
                         }
                         char[4] buf;
-                        str.put(toUTF8(buf, val));
+                        immutable len = encode!(Yes.useReplacementDchar)(buf, val);
+                        str.put(buf[0..len]);
                         break;
 
                     default:

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2713,7 +2713,7 @@ $(D Range) that locks the file and allows fast writing to it.
             }
             else // 32-bit characters
             {
-                import std.utf : toUTF8;
+                import std.utf : encode;
 
                 if (orientation_ <= 0)
                 {
@@ -2724,9 +2724,9 @@ $(D Range) that locks the file and allows fast writing to it.
                     else
                     {
                         char[4] buf = void;
-                        auto b = toUTF8(buf, c);
-                        foreach (i ; 0 .. b.length)
-                            trustedFPUTC(b[i], handle_);
+                        immutable len = encode(buf, c);
+                        foreach (i ; 0 .. len)
+                            trustedFPUTC(buf[i], handle_);
                     }
                 }
                 else

--- a/std/uri.d
+++ b/std/uri.d
@@ -314,9 +314,11 @@ private dstring URI_Decode(Char)(in Char[] uri, uint reservedSet) if (isSomeChar
 
 string decode(Char)(in Char[] encodedURI) if (isSomeChar!Char)
 {
-    import std.utf : toUTF8;
+    // selective imports trigger wrong deprecation
+    // https://issues.dlang.org/show_bug.cgi?id=17193
+    static import std.utf;
     auto s = URI_Decode(encodedURI, URI_Reserved | URI_Hash);
-    return toUTF8(s);
+    return std.utf.toUTF8(s);
 }
 
 /*******************************
@@ -326,9 +328,11 @@ string decode(Char)(in Char[] encodedURI) if (isSomeChar!Char)
 
 string decodeComponent(Char)(in Char[] encodedURIComponent) if (isSomeChar!Char)
 {
-    import std.utf : toUTF8;
+    // selective imports trigger wrong deprecation
+    // https://issues.dlang.org/show_bug.cgi?id=17193
+    static import std.utf;
     auto s = URI_Decode(encodedURIComponent, 0);
-    return toUTF8(s);
+    return std.utf.toUTF8(s);
 }
 
 /*****************************


### PR DESCRIPTION
It seems like DMD doesn't like deprecating only one symbol. For selective imports it will always trigger a deprecation warning even if the symbol isn't used ([issue 17193](https://issues.dlang.org/show_bug.cgi?id=17193)).

This PR fixes the deprecation warnings from `toUTF8` on Posix. `grep` shows that there are more on Windows.