### PR TITLE
Replace overload constraints with static if

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -604,84 +604,85 @@ Returns:
 
 */
 int cmp(alias pred = "a < b", R1, R2)(R1 r1, R2 r2)
-if (isInputRange!R1 && isInputRange!R2 && !(isSomeString!R1 && isSomeString!R2))
+if (isInputRange!R1 && isInputRange!R2 || isSomeString!R1 && isSomeString!R2)
 {
-    for (;; r1.popFront(), r2.popFront())
+    static if (isInputRange!R1 && isInputRange!R2)
     {
-        if (r1.empty) return -cast(int)!r2.empty;
-        if (r2.empty) return !r1.empty;
-        auto a = r1.front, b = r2.front;
-        if (binaryFun!pred(a, b)) return -1;
-        if (binaryFun!pred(b, a)) return 1;
-    }
-}
-
-/// ditto
-int cmp(alias pred = "a < b", R1, R2)(R1 r1, R2 r2) if (isSomeString!R1 && isSomeString!R2)
-{
-    import core.stdc.string : memcmp;
-    import std.utf : decode;
-
-    static if (is(typeof(pred) : string))
-        enum isLessThan = pred == "a < b";
-    else
-        enum isLessThan = false;
-
-    // For speed only
-    static int threeWay(size_t a, size_t b)
-    {
-        static if (size_t.sizeof == int.sizeof && isLessThan)
-            return a - b;
-        else
-            return binaryFun!pred(b, a) ? 1 : binaryFun!pred(a, b) ? -1 : 0;
-    }
-    // For speed only
-    // @@@BUG@@@ overloading should be allowed for nested functions
-    static int threeWayInt(int a, int b)
-    {
-        static if (isLessThan)
-            return a - b;
-        else
-            return binaryFun!pred(b, a) ? 1 : binaryFun!pred(a, b) ? -1 : 0;
-    }
-
-    static if (typeof(r1[0]).sizeof == typeof(r2[0]).sizeof && isLessThan)
-    {
-        static if (typeof(r1[0]).sizeof == 1)
+        for (;; r1.popFront(), r2.popFront())
         {
-            immutable len = min(r1.length, r2.length);
-            immutable result = __ctfe ?
-                {
-                    foreach (i; 0 .. len)
-                    {
-                        if (r1[i] != r2[i])
-                            return threeWayInt(r1[i], r2[i]);
-                    }
-                    return 0;
-                }()
-                : () @trusted { return memcmp(r1.ptr, r2.ptr, len); }();
-            if (result) return result;
+            if (r1.empty) return -cast(int)!r2.empty;
+            if (r2.empty) return !r1.empty;
+            auto a = r1.front, b = r2.front;
+            if (binaryFun!pred(a, b)) return -1;
+            if (binaryFun!pred(b, a)) return 1;
         }
+    }
+    else
+    {
+        import core.stdc.string : memcmp;
+        import std.utf : decode;
+
+        static if (is(typeof(pred) : string))
+            enum isLessThan = pred == "a < b";
         else
+            enum isLessThan = false;
+
+        // For speed only
+        static int threeWay(size_t a, size_t b)
         {
-            auto p1 = r1.ptr, p2 = r2.ptr,
-                pEnd = p1 + min(r1.length, r2.length);
-            for (; p1 != pEnd; ++p1, ++p2)
+            static if (size_t.sizeof == int.sizeof && isLessThan)
+                return a - b;
+            else
+                return binaryFun!pred(b, a) ? 1 : binaryFun!pred(a, b) ? -1 : 0;
+        }
+        // For speed only
+        // @@@BUG@@@ overloading should be allowed for nested functions
+        static int threeWayInt(int a, int b)
+        {
+            static if (isLessThan)
+                return a - b;
+            else
+                return binaryFun!pred(b, a) ? 1 : binaryFun!pred(a, b) ? -1 : 0;
+        }
+
+        static if (typeof(r1[0]).sizeof == typeof(r2[0]).sizeof && isLessThan)
+        {
+            static if (typeof(r1[0]).sizeof == 1)
             {
-                if (*p1 != *p2) return threeWayInt(cast(int) *p1, cast(int) *p2);
+                immutable len = min(r1.length, r2.length);
+                immutable result = __ctfe ?
+                    {
+                        foreach (i; 0 .. len)
+                        {
+                            if (r1[i] != r2[i])
+                                return threeWayInt(r1[i], r2[i]);
+                        }
+                        return 0;
+                    }()
+                    : () @trusted { return memcmp(r1.ptr, r2.ptr, len); }();
+                if (result) return result;
             }
+            else
+            {
+                auto p1 = r1.ptr, p2 = r2.ptr,
+                    pEnd = p1 + min(r1.length, r2.length);
+                for (; p1 != pEnd; ++p1, ++p2)
+                {
+                    if (*p1 != *p2) return threeWayInt(cast(int) *p1, cast(int) *p2);
+                }
+            }
+            return threeWay(r1.length, r2.length);
         }
-        return threeWay(r1.length, r2.length);
-    }
-    else
-    {
-        for (size_t i1, i2;;)
+        else
         {
-            if (i1 == r1.length) return threeWay(i2, r2.length);
-            if (i2 == r2.length) return threeWay(r1.length, i1);
-            immutable c1 = decode(r1, i1),
-                c2 = decode(r2, i2);
-            if (c1 != c2) return threeWayInt(cast(int) c1, cast(int) c2);
+            for (size_t i1, i2;;)
+            {
+                if (i1 == r1.length) return threeWay(i2, r2.length);
+                if (i2 == r2.length) return threeWay(r1.length, i1);
+                immutable c1 = decode(r1, i1),
+                    c2 = decode(r2, i2);
+                if (c1 != c2) return threeWayInt(cast(int) c1, cast(int) c2);
+            }
         }
     }
 }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -363,57 +363,57 @@ See_Also:
     $(HTTP sgi.com/tech/stl/_copy.html, STL's _copy)
  */
 TargetRange copy(SourceRange, TargetRange)(SourceRange source, TargetRange target)
-    if (areCopyCompatibleArrays!(SourceRange, TargetRange))
+    if (isInputRange!SourceRange && (
+        areCopyCompatibleArrays!(SourceRange, TargetRange) ||
+        isOutputRange!(TargetRange, ElementType!SourceRange)))
 {
-    const tlen = target.length;
-    const slen = source.length;
-    assert(tlen >= slen,
-            "Cannot copy a source range into a smaller target range.");
-
-    immutable overlaps = () @trusted {
-        return source.ptr < target.ptr + tlen &&
-               target.ptr < source.ptr + slen; }();
-
-    if (overlaps)
+    static if (areCopyCompatibleArrays!(SourceRange, TargetRange))
     {
-        foreach (idx; 0 .. slen)
-            target[idx] = source[idx];
-        return target[slen .. tlen];
+        const tlen = target.length;
+        const slen = source.length;
+        assert(tlen >= slen,
+                "Cannot copy a source range into a smaller target range.");
+
+        immutable overlaps = () @trusted {
+            return source.ptr < target.ptr + tlen &&
+                   target.ptr < source.ptr + slen; }();
+
+        if (overlaps)
+        {
+            foreach (idx; 0 .. slen)
+                target[idx] = source[idx];
+            return target[slen .. tlen];
+        }
+        else
+        {
+            // Array specialization.  This uses optimized memory copying
+            // routines under the hood and is about 10-20x faster than the
+            // generic implementation.
+            target[0 .. slen] = source[];
+            return target[slen .. $];
+        }
     }
     else
     {
-        // Array specialization.  This uses optimized memory copying
-        // routines under the hood and is about 10-20x faster than the
-        // generic implementation.
-        target[0 .. slen] = source[];
-        return target[slen .. $];
-    }
-}
-
-/// ditto
-TargetRange copy(SourceRange, TargetRange)(SourceRange source, TargetRange target)
-    if (!areCopyCompatibleArrays!(SourceRange, TargetRange) &&
-        isInputRange!SourceRange &&
-        isOutputRange!(TargetRange, ElementType!SourceRange))
-{
-    // Specialize for 2 random access ranges.
-    // Typically 2 random access ranges are faster iterated by common
-    // index than by x.popFront(), y.popFront() pair
-    static if (isRandomAccessRange!SourceRange &&
-               hasLength!SourceRange &&
-               hasSlicing!TargetRange &&
-               isRandomAccessRange!TargetRange &&
-               hasLength!TargetRange)
-    {
-        auto len = source.length;
-        foreach (idx; 0 .. len)
-            target[idx] = source[idx];
-        return target[len .. target.length];
-    }
-    else
-    {
-        put(target, source);
-        return target;
+        // Specialize for 2 random access ranges.
+        // Typically 2 random access ranges are faster iterated by common
+        // index than by x.popFront(), y.popFront() pair
+        static if (isRandomAccessRange!SourceRange &&
+                   hasLength!SourceRange &&
+                   hasSlicing!TargetRange &&
+                   isRandomAccessRange!TargetRange &&
+                   hasLength!TargetRange)
+        {
+            auto len = source.length;
+            foreach (idx; 0 .. len)
+                target[idx] = source[idx];
+            return target[len .. target.length];
+        }
+        else
+        {
+            put(target, source);
+            return target;
+        }
     }
 }
 
@@ -776,59 +776,60 @@ See_Also:
         $(LREF uninitializeFill)
  */
 void initializeAll(Range)(Range range)
-    if (isInputRange!Range && hasLvalueElements!Range && hasAssignableElements!Range)
+    if (isInputRange!Range && hasLvalueElements!Range && hasAssignableElements!Range ||
+            is(Range == char[]) || is(Range == wchar[]))
 {
-    import core.stdc.string : memset, memcpy;
-    import std.traits : hasElaborateAssign, isDynamicArray;
-
-    alias T = ElementType!Range;
-    static if (hasElaborateAssign!T)
+    static if (isInputRange!Range)
     {
-        import std.algorithm.internal : addressOf;
-        //Elaborate opAssign. Must go the memcpy road.
-        //We avoid calling emplace here, because our goal is to initialize to
-        //the static state of T.init,
-        //So we want to avoid any un-necassarilly CC'ing of T.init
-        auto p = typeid(T).initializer();
-        if (p.ptr)
+        import core.stdc.string : memset, memcpy;
+        import std.traits : hasElaborateAssign, isDynamicArray;
+
+        alias T = ElementType!Range;
+        static if (hasElaborateAssign!T)
         {
-            for ( ; !range.empty ; range.popFront() )
+            import std.algorithm.internal : addressOf;
+            //Elaborate opAssign. Must go the memcpy road.
+            //We avoid calling emplace here, because our goal is to initialize to
+            //the static state of T.init,
+            //So we want to avoid any un-necassarilly CC'ing of T.init
+            auto p = typeid(T).initializer();
+            if (p.ptr)
             {
-                static if (__traits(isStaticArray, T))
+                for ( ; !range.empty ; range.popFront() )
                 {
-                    // static array initializer only contains initialization
-                    // for one element of the static array.
-                    auto elemp = cast(void *)addressOf(range.front);
-                    auto endp = elemp + T.sizeof;
-                    while (elemp < endp)
+                    static if (__traits(isStaticArray, T))
                     {
-                        memcpy(elemp, p.ptr, p.length);
-                        elemp += p.length;
+                        // static array initializer only contains initialization
+                        // for one element of the static array.
+                        auto elemp = cast(void *)addressOf(range.front);
+                        auto endp = elemp + T.sizeof;
+                        while (elemp < endp)
+                        {
+                            memcpy(elemp, p.ptr, p.length);
+                            elemp += p.length;
+                        }
+                    }
+                    else
+                    {
+                        memcpy(addressOf(range.front), p.ptr, T.sizeof);
                     }
                 }
-                else
-                {
-                    memcpy(addressOf(range.front), p.ptr, T.sizeof);
-                }
             }
+            else
+                static if (isDynamicArray!Range)
+                    memset(range.ptr, 0, range.length * T.sizeof);
+                else
+                    for ( ; !range.empty ; range.popFront() )
+                        memset(addressOf(range.front), 0, T.sizeof);
         }
         else
-            static if (isDynamicArray!Range)
-                memset(range.ptr, 0, range.length * T.sizeof);
-            else
-                for ( ; !range.empty ; range.popFront() )
-                    memset(addressOf(range.front), 0, T.sizeof);
+            fill(range, T.init);
     }
     else
-        fill(range, T.init);
-}
-
-/// ditto
-void initializeAll(Range)(Range range)
-    if (is(Range == char[]) || is(Range == wchar[]))
-{
-    alias T = ElementEncodingType!Range;
-    range[] = T.init;
+    {
+        alias T = ElementEncodingType!Range;
+        range[] = T.init;
+    }
 }
 
 ///
@@ -1682,138 +1683,132 @@ Returns:
 Range remove
 (SwapStrategy s = SwapStrategy.stable, Range, Offset...)
 (Range range, Offset offset)
-if (s != SwapStrategy.stable
-    && isBidirectionalRange!Range
+if (isBidirectionalRange!Range
     && hasLvalueElements!Range
     && hasLength!Range
     && Offset.length >= 1)
 {
-    Tuple!(size_t, "pos", size_t, "len")[offset.length] blackouts;
-    foreach (i, v; offset)
+    static if (s != SwapStrategy.stable)
     {
-        static if (is(typeof(v[0]) : size_t) && is(typeof(v[1]) : size_t))
+        Tuple!(size_t, "pos", size_t, "len")[offset.length] blackouts;
+        foreach (i, v; offset)
         {
-            blackouts[i].pos = v[0];
-            blackouts[i].len = v[1] - v[0];
-        }
-        else
-        {
-            static assert(is(typeof(v) : size_t), typeof(v).stringof);
-            blackouts[i].pos = v;
-            blackouts[i].len = 1;
-        }
-        static if (i > 0)
-        {
-            import std.exception : enforce;
-
-            enforce(blackouts[i - 1].pos + blackouts[i - 1].len
-                    <= blackouts[i].pos,
-                "remove(): incorrect ordering of elements to remove");
-        }
-    }
-
-    size_t left = 0, right = offset.length - 1;
-    auto tgt = range.save;
-    size_t tgtPos = 0;
-
-    while (left <= right)
-    {
-        // Look for a blackout on the right
-        if (blackouts[right].pos + blackouts[right].len >= range.length)
-        {
-            range.popBackExactly(blackouts[right].len);
-
-            // Since right is unsigned, we must check for this case, otherwise
-            // we might turn it into size_t.max and the loop condition will not
-            // fail when it should.
-            if (right > 0)
+            static if (is(typeof(v[0]) : size_t) && is(typeof(v[1]) : size_t))
             {
-                --right;
-                continue;
+                blackouts[i].pos = v[0];
+                blackouts[i].len = v[1] - v[0];
             }
             else
-                break;
-        }
-        // Advance to next blackout on the left
-        assert(blackouts[left].pos >= tgtPos);
-        tgt.popFrontExactly(blackouts[left].pos - tgtPos);
-        tgtPos = blackouts[left].pos;
-
-        // Number of elements to the right of blackouts[right]
-        immutable tailLen = range.length - (blackouts[right].pos + blackouts[right].len);
-        size_t toMove = void;
-        if (tailLen < blackouts[left].len)
-        {
-            toMove = tailLen;
-            blackouts[left].pos += toMove;
-            blackouts[left].len -= toMove;
-        }
-        else
-        {
-            toMove = blackouts[left].len;
-            ++left;
-        }
-        tgtPos += toMove;
-        foreach (i; 0 .. toMove)
-        {
-            move(range.back, tgt.front);
-            range.popBack();
-            tgt.popFront();
-        }
-    }
-
-    return range;
-}
-
-/// Ditto
-Range remove
-(SwapStrategy s = SwapStrategy.stable, Range, Offset...)
-(Range range, Offset offset)
-if (s == SwapStrategy.stable
-    && isBidirectionalRange!Range
-    && hasLvalueElements!Range
-    && Offset.length >= 1)
-{
-    auto result = range;
-    auto src = range, tgt = range;
-    size_t pos;
-    foreach (pass, i; offset)
-    {
-        static if (is(typeof(i[0])) && is(typeof(i[1])))
-        {
-            auto from = i[0], delta = i[1] - i[0];
-        }
-        else
-        {
-            auto from = i;
-            enum delta = 1;
-        }
-
-        static if (pass > 0)
-        {
-            import std.exception : enforce;
-            enforce(pos <= from,
-                    "remove(): incorrect ordering of elements to remove");
-
-            for (; pos < from; ++pos, src.popFront(), tgt.popFront())
             {
-                move(src.front, tgt.front);
+                static assert(is(typeof(v) : size_t), typeof(v).stringof);
+                blackouts[i].pos = v;
+                blackouts[i].len = 1;
+            }
+            static if (i > 0)
+            {
+                import std.exception : enforce;
+
+                enforce(blackouts[i - 1].pos + blackouts[i - 1].len
+                        <= blackouts[i].pos,
+                    "remove(): incorrect ordering of elements to remove");
             }
         }
-        else
+
+        size_t left = 0, right = offset.length - 1;
+        auto tgt = range.save;
+        size_t tgtPos = 0;
+
+        while (left <= right)
         {
-            src.popFrontExactly(from);
-            tgt.popFrontExactly(from);
-            pos = from;
+            // Look for a blackout on the right
+            if (blackouts[right].pos + blackouts[right].len >= range.length)
+            {
+                range.popBackExactly(blackouts[right].len);
+
+                // Since right is unsigned, we must check for this case, otherwise
+                // we might turn it into size_t.max and the loop condition will not
+                // fail when it should.
+                if (right > 0)
+                {
+                    --right;
+                    continue;
+                }
+                else
+                    break;
+            }
+            // Advance to next blackout on the left
+            assert(blackouts[left].pos >= tgtPos);
+            tgt.popFrontExactly(blackouts[left].pos - tgtPos);
+            tgtPos = blackouts[left].pos;
+
+            // Number of elements to the right of blackouts[right]
+            immutable tailLen = range.length - (blackouts[right].pos + blackouts[right].len);
+            size_t toMove = void;
+            if (tailLen < blackouts[left].len)
+            {
+                toMove = tailLen;
+                blackouts[left].pos += toMove;
+                blackouts[left].len -= toMove;
+            }
+            else
+            {
+                toMove = blackouts[left].len;
+                ++left;
+            }
+            tgtPos += toMove;
+            foreach (i; 0 .. toMove)
+            {
+                move(range.back, tgt.front);
+                range.popBack();
+                tgt.popFront();
+            }
         }
-        // now skip source to the "to" position
-        src.popFrontExactly(delta);
-        result.popBackExactly(delta);
-        pos += delta;
+
+        return range;
     }
-    // leftover move
-    moveAll(src, tgt);
-    return result;
+    else
+    {
+        auto result = range;
+        auto src = range, tgt = range;
+        size_t pos;
+        foreach (pass, i; offset)
+        {
+            static if (is(typeof(i[0])) && is(typeof(i[1])))
+            {
+                auto from = i[0], delta = i[1] - i[0];
+            }
+            else
+            {
+                auto from = i;
+                enum delta = 1;
+            }
+
+            static if (pass > 0)
+            {
+                import std.exception : enforce;
+                enforce(pos <= from,
+                        "remove(): incorrect ordering of elements to remove");
+
+                for (; pos < from; ++pos, src.popFront(), tgt.popFront())
+                {
+                    move(src.front, tgt.front);
+                }
+            }
+            else
+            {
+                src.popFrontExactly(from);
+                tgt.popFrontExactly(from);
+                pos = from;
+            }
+            // now skip source to the "to" position
+            src.popFrontExactly(delta);
+            result.popBackExactly(delta);
+            pos += delta;
+        }
+        // leftover move
+        moveAll(src, tgt);
+        return result;
+    }
 }
 
 ///
@@ -2087,15 +2082,27 @@ See_Also:
     $(HTTP sgi.com/tech/stl/_reverse.html, STL's _reverse), $(REF retro, std,range) for a lazy reversed range view
 */
 void reverse(Range)(Range r)
-if (isBidirectionalRange!Range && !isRandomAccessRange!Range
-    && hasSwappableElements!Range)
+if (isBidirectionalRange!Range && (hasSwappableElements!Range || isRandomAccessRange!Range))
 {
-    while (!r.empty)
+    static if (isRandomAccessRange!Range)
     {
-        swap(r.front, r.back);
-        r.popFront();
-        if (r.empty) break;
-        r.popBack();
+        //swapAt is in fact the only way to swap non lvalue ranges
+        immutable last = r.length-1;
+        immutable steps = r.length/2;
+        for (size_t i = 0; i < steps; i++)
+        {
+            r.swapAt(i, last-i);
+        }
+    }
+    else
+    {
+        while (!r.empty)
+        {
+            swap(r.front, r.back);
+            r.popFront();
+            if (r.empty) break;
+            r.popBack();
+        }
     }
 }
 
@@ -2107,17 +2114,12 @@ if (isBidirectionalRange!Range && !isRandomAccessRange!Range
     assert(arr == [ 3, 2, 1 ]);
 }
 
-///ditto
-void reverse(Range)(Range r)
-if (isRandomAccessRange!Range && hasLength!Range)
+///
+@safe unittest
 {
-    //swapAt is in fact the only way to swap non lvalue ranges
-    immutable last = r.length-1;
-    immutable steps = r.length/2;
-    for (size_t i = 0; i < steps; i++)
-    {
-        r.swapAt(i, last-i);
-    }
+    char[] arr = "hello\U00010143\u0100\U00010143".dup;
+    reverse(arr);
+    assert(arr == "\U00010143\u0100\U00010143olleh");
 }
 
 @safe unittest
@@ -2172,14 +2174,6 @@ if (isNarrowString!(Char[]) && !is(Char == const) && !is(Char == immutable))
         }
     }
     reverse(r);
-}
-
-///
-@safe unittest
-{
-    char[] arr = "hello\U00010143\u0100\U00010143".dup;
-    reverse(arr);
-    assert(arr == "\U00010143\u0100\U00010143olleh");
 }
 
 @safe unittest


### PR DESCRIPTION
From a recent [NG thread](http://forum.dlang.org/post/o82qf6$2m8j$1@digitalmars.com) by @WalterBright:

> Also, as mentioned in the std.algorithm.mutation.remove case, constraints in Phobos often confuse "requirements" with "specializations".
> Requirements should be user-facing constraints, while specializations are implementation details better handled with internal static if.

This PR picks a couple of low-hanging fruits in `std.algorithm`. If this PR got too large, let me know.