### PR TITLE
Fix 12564, 14493: add std.range.walkBack to get the last element of an input range

### DIFF
--- a/changelog/std-range-walkback.dd
+++ b/changelog/std-range-walkback.dd
@@ -1,0 +1,12 @@
+Added `std.range.walkBack` which returns the last element of any given range.
+
+$(REF walkBack, std, range) is intended for input ranges that can only be
+iterated linearly. Optionally to support infinite ranges, a maximal `upTo`
+parameter can be supplied.
+
+-----
+import std.algorithm.iteration : splitter;
+
+assert("a;b;c".splitter(";").walkBack == "c");
+assert("a;b;c;d;e".splitter(";").walkBack(2) == "b");
+-----


### PR DESCRIPTION
This seems to be a missing functionality (when I bumped into this I found two open issues). It behaves as [`walkLength`](https://dlang.org/library/std/range/primitives/walk_length.html).

It got a bit messy because `Rebindable` isn't a thing yet (see https://github.com/dlang/phobos/pull/4363 for more details).