### PR TITLE
Added std.range.orElse which provides a default value for empty ranges

### DIFF
--- a/changelog/std-range-or-else.dd
+++ b/changelog/std-range-or-else.dd
@@ -1,0 +1,26 @@
+Added `std.range.orElse` to use default values for empty ranges
+
+$(REF orElse, std, range, primitives) allows to provide a default value when dealing
+with possibly empty ranges:
+
+------
+import std.range : drop, orElse;
+
+auto arr = [0, 1, 2];
+
+// given a non-empty range, it is a pure proxy
+auto d = arr.orElse(42);
+writeln(d); // OrElse([0, 1, 2])
+assert(d.front == 0);
+assert(d.length == 3);
+
+// given an empty range, it uses the orElse
+auto e = arr.drop(3).orElse(42);
+writeln(e); // OrElse(42)
+assert(e.front == 42);
+
+// the orElse range has a length of 1
+assert(e.length == 1);
+e.popFront;
+assert(e.empty);
+------

--- a/changelog/std-range-seed.dd
+++ b/changelog/std-range-seed.dd
@@ -1,0 +1,26 @@
+Added `std.range.orElse` to use default values for empty ranges
+
+$(REF orElse, std, range) allows to provide a default value when dealing
+with possibly empty ranges:
+
+------
+import std.range : drop, orElse;
+
+auto arr = [0, 1, 2];
+
+// given a non-empty range, it is a pure proxy
+auto d = arr.orElse(42);
+writeln(d); // OrElse([0, 1, 2])
+assert(d.front == 0);
+assert(d.length == 3);
+
+// given an empty range, it uses the orElse
+auto e = arr.drop(3).orElse(42);
+writeln(e); // OrElse(42)
+assert(e.front == 42);
+
+// the orElse range has a length of 1
+assert(e.length == 1);
+e.popFront;
+assert(e.empty);
+------


### PR DESCRIPTION
As mentioned on #5153 if an API method could potentially return an "undefined response (aka `null`), there are a couple of strategies:

Method | Uses in Phobos
--------|---------
return [Nullable](https://dlang.org/phobos/std_typecons.html#.Nullable) | no precedent in Phobos (?)
use `enforce` (aka exceptions) | generally disliked, because exceptions allocate (and everybody wants to be `@nogc` nowadays
add an overload with a `seed` | [`std.algorithm.iteration.maxElement`](https://dlang.org/phobos/std_algorithm_searching.html#.maxElement)

As the third way seems to be the current strategy (e.g. `fold`, `reduce`, ...), it creates a lot of "redundant" code. Here I propose to add a `seed(<range>, <defaultValue>)` method that can be combined with any range method to solve this problem. The gist is very simple:

```d
import std.range : iota;
assert(0.iota(10).seed(42).front == 0);
assert(0.iota.seed(42).front == 42);
```

The simplest way to add such a `orElse` method would be to combine `choose` and `only` like this:

```d
auto orElse(Range, RangeElementType = ElementType!Range)(Range r, RangeElementType fallback)
if (isInputRange!(Unqual!(Range)) &&
    !is(CommonType!(ElementType!Range, RangeElementType) == void))
{
    import std.range : choose, only;
    return choose(!r.empty, r, only(seed));
}
```

However this has a couple of problems:

- no custom type - e.g. `static if (!hasDefaultValue!Range) enforce(!r.empty)`
- `choose` doesn't work in CTFE ([#14660](https://issues.dlang.org/show_bug.cgi?id=14660))
- not fully `@safe` (it uses `union` and `void[]`)
- doesn't work with ranges of `const` elements
- hasn't all `opSlice` overloads (e.g. `InfiniteRanges`)
- no `toString` for user convenience as that's generic
- would require a custom `only` that allows assigns, otherwise `hasAssignableElements` and `hasSwappableElements` won't work.

While most of these points are solvable with e.g. `template mixins`, I am not sure about all of them and hence this PR contains its an implementation of a `OrElseRange`.

Destroy this idea!

edit: renamed from `seed` to `orElse`