### PR TITLE
convert docstring examples to unittests

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -2080,20 +2080,21 @@ public:
 
     /**
         Get range that spans all of the $(CODEPOINT) intervals in this $(LREF InversionList).
+    */
+    @property auto byInterval()
+    {
+        return Intervals!(typeof(data))(data);
+    }
 
-        Example:
-        -----------
+    ///
+    unittest
+    {
         import std.algorithm.comparison : equal;
         import std.typecons : tuple;
 
         auto set = CodepointSet('A', 'D'+1, 'a', 'd'+1);
 
         assert(set.byInterval.equal([tuple('A','E'), tuple('a','e')]));
-        -----------
-    */
-    @property auto byInterval()
-    {
-        return Intervals!(typeof(data))(data);
     }
 
     /**


### PR DESCRIPTION
I just went through my local branches and found #4049 which was closed due to:

> It still fails due to some magic related to dmd,

It now passes locally, so maybe this "magic" has been fixed.