### PR TITLE
DScanner: check for useless asserts

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -63,7 +63,7 @@ auto_ref_assignment_check="disabled" ; FIXME
 ; Checks for incorrect infinite range definitions
 incorrect_infinite_range_check="enabled"
 ; Checks for asserts that are always true
-useless_assert_check="skip-unittest"
+useless_assert_check="enabled"
 ; Check for uses of the old-style alias syntax
 alias_syntax_check="enabled"
 ; Checks for else if that should be else static if

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -417,7 +417,7 @@ auto castSwitch(choices...)(Object switchObject)
 
     // Void handlers are also allowed if all the handlers are void:
     new A().castSwitch!(
-        (A a) { assert(true); },
+        (A a) { },
         (B b) { assert(false); },
     )();
 }
@@ -485,7 +485,7 @@ auto castSwitch(choices...)(Object switchObject)
     // All-void handlers work for the null case:
     null.castSwitch!(
         (Object o) { assert(false); },
-        ()         { assert(true); },
+        ()         { },
     )();
 
     // Throwing void handlers work for the null case:


### PR DESCRIPTION
There were only two uses of `assert(true)` in Phobos.