### PR TITLE
DScanner: check for auto function with void return statement

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -71,7 +71,7 @@ static_if_else_check="enabled"
 ; Check for unclear lambda syntax
 lambda_return_check="enabled"
 ; Check for auto function without return statement
-auto_function_check = "disabled"
+auto_function_check = "enabled"
 ; Check for explicitly annotated unittests
 explicitly_annotated_unittests = "disabled"
 ; Check for sortedness of imports

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -9032,26 +9032,31 @@ public:
     else static if (isForwardRange!R)
     {
         import std.traits : isSafe;
+        private alias S = typeof((*_range).save);
+
+        static if (is(typeof((*cast(const R*)_range).save)))
+            private alias CS = typeof((*cast(const R*)_range).save);
+
         static if (isSafe!((R* r) => (*r).save))
         {
-            @property auto save() @trusted
+            @property RefRange!S save() @trusted
             {
                 mixin(_genSave());
             }
 
-            static if (is(typeof((*cast(const R*)_range).save))) @property auto save() @trusted const
+            static if (is(typeof((*cast(const R*)_range).save))) @property RefRange!CS save() @trusted const
             {
                 mixin(_genSave());
             }
         }
         else
         {
-            @property auto save()
+            @property RefRange!S save()
             {
                 mixin(_genSave());
             }
 
-            static if (is(typeof((*cast(const R*)_range).save))) @property auto save() const
+            static if (is(typeof((*cast(const R*)_range).save))) @property RefRange!CS save() const
             {
                 mixin(_genSave());
             }
@@ -9217,14 +9222,20 @@ public:
     }
     else static if (hasSlicing!R)
     {
-        auto opSlice(IndexType1, IndexType2)
+        private alias T = typeof((*_range)[1 .. 2]);
+        static if (is(typeof((*cast(const R*)_range)[1 .. 2])))
+        {
+            private alias CT = typeof((*cast(const R*)_range)[1 .. 2]);
+        }
+
+        RefRange!T opSlice(IndexType1, IndexType2)
                     (IndexType1 begin, IndexType2 end)
             if (is(typeof((*_range)[begin .. end])))
         {
             mixin(_genOpSlice());
         }
 
-        auto opSlice(IndexType1, IndexType2)
+        RefRange!CT opSlice(IndexType1, IndexType2)
                     (IndexType1 begin, IndexType2 end) const
             if (is(typeof((*cast(const R*)_range)[begin .. end])))
         {


### PR DESCRIPTION
@BBasile created this nice plugin for Dscanner to check for `auto` function with `void` return statement:

https://github.com/Hackerpilot/Dscanner/pull/372

With its improvement in false-positive detection (https://github.com/Hackerpilot/Dscanner/pull/383), I think it is now ready for Phobos (apart from one minor "false-positive" in `std.range.RefRange`).

Btw is there any reason why we don't use `inout` in `RefRange`?

edit: there was a previous PR that did the ground work for this, but I can't find it atm.