### PR TITLE
Optimization for std.array.Appender

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2839,15 +2839,25 @@ if (isDynamicArray!A)
         }
         else
         {
-            import std.conv : emplaceRef;
-
             ensureAddable(1);
             immutable len = _data.arr.length;
 
-            auto bigData = (() @trusted => _data.arr.ptr[0 .. len + 1])();
-            emplaceRef!(Unqual!T)(bigData[len], cast(Unqual!T)item);
-            //We do this at the end, in case of exceptions
-            _data.arr = bigData;
+            static if (isBasicType!U)
+            {
+                () @trusted {
+                    _data.arr.ptr[len] = cast(Unqual!T) item;
+                    _data.arr = _data.arr.ptr[0 .. len + 1];
+                }();
+            }
+            else
+            {
+                import std.conv : emplaceRef;
+
+                auto bigData = (() @trusted => _data.arr.ptr[0 .. len + 1])();
+                emplaceRef!(Unqual!T)(bigData[len], cast(Unqual!T)item);
+                //We do this at the end, in case of exceptions
+                _data.arr = bigData;
+            }
         }
     }
 


### PR DESCRIPTION
This change brings the performance of appender to the relm of https://github.com/dlang/phobos/pull/5115 in all cases.

DMD for some reason is not able to inline the trusted function, making this almost twice as slow as it would otherwise be.

Benchmark using long ranges of `int`s:

```
# before
3 secs, 91 ms, 452 μs, and 6 hnsecs

# after
1 sec, 907 ms, 67 μs, and 1 hnsec

# after without trusted anonymous function
1 sec, 126 ms, 67 μs, and 4 hnsecs
```

