### PR TITLE
Dscanner: check for conflicting variable names (part 1)

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -55,7 +55,7 @@ redundant_parens_check="true"
 ; Checks for mismatched argument and parameter names
 mismatched_args_check="disabled"
 ; Checks for labels with the same name as variables
-label_var_same_name_check="disabled"
+label_var_same_name_check="enabled"
 ; Checks for lines longer than 120 characters
 long_line_check="enabled"
 ; Checks for assignment to auto-ref function parameters

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3120,7 +3120,7 @@ private template ReduceSeedType(E)
 
         //Check the Seed type is useable.
         ReduceSeedType s = ReduceSeedType.init;
-        static assert(is(typeof({ReduceSeedType s = lvalueOf!E;})) &&
+        static assert(is(typeof({ReduceSeedType r = lvalueOf!E;})) &&
             is(typeof(lvalueOf!ReduceSeedType = fun(lvalueOf!ReduceSeedType, lvalueOf!E))),
             algoFormat(
                 "Unable to deduce an acceptable seed type for %s with element type %s.",

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2020,8 +2020,8 @@ unittest
         bool proxySwapCalled;
         struct S
         {
-            int i;
-            alias i this;
+            int m;
+            alias m this;
             void proxySwap(ref S other) { swap(i, other.i); proxySwapCalled = true; }
             @disable void opAssign(S value);
         }

--- a/std/array.d
+++ b/std/array.d
@@ -1156,10 +1156,10 @@ private template isInputRangeOrConvertible(E)
     {
         static bool testctfe()
         {
-            Int[] arr = [Int(1), Int(4), Int(5)];
-            assert(arr[0] == 1);
-            insertInPlace(arr, 1, Int(2), Int(3));
-            return equal(arr, [1, 2, 3, 4, 5]);  //check it works with postblit
+            Int[] _arr = [Int(1), Int(4), Int(5)];
+            assert(_arr[0] == 1);
+            insertInPlace(_arr, 1, Int(2), Int(3));
+            return equal(_arr, [1, 2, 3, 4, 5]);  //check it works with postblit
         }
         enum E = testctfe();
     }

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -153,9 +153,9 @@ public:
     @system unittest
     {
         // @system due to failure in FreeBSD32
-        ulong data = 1_000_000_000_000;
-        auto bigData = BigInt(data);
-        assert(data == BigInt("1_000_000_000_000"));
+        ulong _data = 1_000_000_000_000;
+        auto bigData = BigInt(_data);
+        assert(_data == BigInt("1_000_000_000_000"));
     }
 
     /// Construct a BigInt from another BigInt.

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2677,7 +2677,9 @@ if (canSwapEndianness!T &&
     is(ElementType!R : const ubyte))
 {
     static if (hasSlicing!R)
+    {
         const ubyte[T.sizeof] bytes = range[0 .. T.sizeof];
+    }
     else
     {
         ubyte[T.sizeof] bytes;

--- a/std/conv.d
+++ b/std/conv.d
@@ -617,9 +617,9 @@ if (!isImplicitlyConvertible!(S, T) &&
         int x;
         static Int3 opCall(int x) @safe pure
         {
-            Int3 i;
-            i.x = x;
-            return i;
+            Int3 i3;
+            i3.x = x;
+            return i3;
         }
     }
     Int3 i3 = to!Int3(1);
@@ -5122,7 +5122,6 @@ version(unittest)
 //opCall
 @system unittest
 {
-    int i;
     //Without constructor
     {
         static struct S1
@@ -5323,7 +5322,7 @@ version(unittest)
 
     struct S
     {
-        int* p;
+        int* p2;
     }
     alias IS = immutable(S);
     S s = void;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -26,10 +26,6 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
     version (StdDdoc)
     {
         /**
-        The alignment offered is the minimum of the two allocators' alignment.
-        */
-        enum uint alignment;
-        /**
         This method is defined only if at least one of the allocators defines
         it. The good allocation size is obtained from $(D SmallAllocator) if $(D
         s <= threshold), or $(D LargeAllocator) otherwise. (If one of the
@@ -122,6 +118,9 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             else return _large;
     }
 
+    /**
+    The alignment offered is the minimum of the two allocators' alignment.
+    */
     enum uint alignment = min(SmallAllocator.alignment,
         LargeAllocator.alignment);
 

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -961,15 +961,15 @@ pure nothrow @safe unittest
     a.i = 42;
     assert(a.i == 42);
 
-    Final!int i = 42;
-    static assert(!__traits(compiles, i = 24));
-    static assert(!__traits(compiles, --i));
-    static assert(!__traits(compiles, ++i));
-    assert(i == 42);
-    int iCopy = i;
-    assert(iCopy == 42);
-    iCopy = -i; // non-mutating unary operators must work
-    assert(iCopy == -42);
+    Final!int f = 42;
+    static assert(!__traits(compiles, f = 24));
+    static assert(!__traits(compiles, --f));
+    static assert(!__traits(compiles, ++f));
+    assert(f == 42);
+    int fCopy = f;
+    assert(fCopy == 42);
+    fCopy = -f; // non-mutating unary operators must work
+    assert(fCopy == -42);
 
     static struct S
     {

--- a/std/format.d
+++ b/std/format.d
@@ -947,9 +947,6 @@ if (is(Unqual!Char == Char))
          compatibility).
          */
         bool flHash;
-
-        // Fake field to allow compilation
-        ubyte allFlags;
     }
     else
     {
@@ -963,6 +960,8 @@ if (is(Unqual!Char == Char))
                         bool, "flPlus", 1,
                         bool, "flHash", 1,
                         ubyte, "", 3));
+
+            // Fake field to allow compilation
             ubyte allFlags;
         }
     }

--- a/std/utf.d
+++ b/std/utf.d
@@ -1575,7 +1575,9 @@ if (is(S : const wchar[]) || (isInputRange!S && is(Unqual!(ElementEncodingType!S
         }
 
         static if (canIndex)
+        {
             immutable uint u2 = pstr[1];
+        }
         else
         {
             immutable uint u2 = pstr.front;


### PR DESCRIPTION
Preparation as this depends on a fix in Dscanner (https://github.com/Hackerpilot/Dscanner/pull/407).
The remaining conflicts are false positives due to `version` not being considered by Dscanner:

```
std/internal/digest/sha_SSSE3.d(108:34)[warn]: Variable "SP" has the same name as a variable defined on line 96.
std/internal/digest/sha_SSSE3.d(109:34)[warn]: Variable "BUFFER_PTR" has the same name as a variable defined on line 97.
std/internal/digest/sha_SSSE3.d(110:34)[warn]: Variable "STATE_PTR" has the same name as a variable defined on line 98.
std/internal/digest/sha_SSSE3.d(118:34)[warn]: Variable "X_SHUFFLECTL" has the same name as a variable defined on line 101.
std/internal/digest/sha_SSSE3.d(121:34)[warn]: Variable "X_CONSTANT" has the same name as a variable defined on line 104.
std/internal/digest/sha_SSSE3.d(344:20)[warn]: Variable "W_TMP" has the same name as a variable defined on line 114.
std/internal/digest/sha_SSSE3.d(348:20)[warn]: Variable "W_TMP" has the same name as a variable defined on line 344.
std/internal/digest/sha_SSSE3.d(348:20)[warn]: Variable "W_TMP" has the same name as a variable defined on line 114.
std/internal/digest/sha_SSSE3.d(397:20)[warn]: Variable "W_TMP" has the same name as a variable defined on line 114.
std/internal/digest/sha_SSSE3.d(398:20)[warn]: Variable "W_TMP2" has the same name as a variable defined on line 115.
std/internal/digest/sha_SSSE3.d(454:20)[warn]: Variable "W_TMP" has the same name as a variable defined on line 114.
std/internal/digest/sha_SSSE3.d(455:20)[warn]: Variable "W_TMP2" has the same name as a variable defined on line 115.
std/internal/digest/sha_SSSE3.d(459:20)[warn]: Variable "W_minus_28" has the same name as a variable defined on line 452.
std/internal/digest/sha_SSSE3.d(460:20)[warn]: Variable "W_minus_32" has the same name as a variable defined on line 453.
std/encoding.d(3146:45)[warn]: Variable "NAME" has the same name as a variable defined on line 3145.
std/encoding.d(3216:18)[warn]: Variable "sample" has the same name as a variable defined on line 3211.
std/encoding.d(3242:45)[warn]: Variable "NAME" has the same name as a variable defined on line 3241.
std/encoding.d(3312:19)[warn]: Variable "sample" has the same name as a variable defined on line 3307.
std/experimental/ndslice/slice.d(3456:19)[warn]: Variable "isType" has the same name as a variable defined on line 3454.
std/process.d(896:32)[warn]: Variable "envProg" has the same name as a variable defined on line 885.
std/process.d(2396:44)[warn]: Variable "shellSwitch" has the same name as a variable defined on line 2395.
```