### PR TITLE
Dscanner: let unittest be @safe or @system

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -73,7 +73,7 @@ lambda_return_check="enabled"
 ; Check for auto function without return statement
 auto_function_check = "disabled"
 ; Check for explicitly annotated unittests
-explicitly_annotated_unittests = "disabled"
+explicitly_annotated_unittests = "enabled"
 ; Check for sortedness of imports
 imports_sortedness = "disabled"
 ; Check for useless usage of the final attribute

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -94,7 +94,7 @@ if (fun.length >= 1)
         return ror.map!(reduce!fun);
     }
 
-    unittest
+    @safe unittest
     {
         import std.algorithm.comparison : equal, max, min;
 
@@ -1037,7 +1037,7 @@ template each(alias pred = "a")
 }
 
 // #16255: `each` on opApply doesn't support ref
-unittest
+@safe unittest
 {
     int[] dynamicArray = [1, 2, 3, 4, 5];
     int[5] staticArray = [1, 2, 3, 4, 5];
@@ -1053,7 +1053,7 @@ unittest
 }
 
 // #16255: `each` on opApply doesn't support ref
-unittest
+@system unittest
 {
     struct S
     {
@@ -1889,7 +1889,7 @@ if (isInputRange!Range)
 }
 
 /// Showing usage with binary predicate:
-/*FIXME: @safe*/ unittest
+/*FIXME: @safe*/ @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1939,7 +1939,7 @@ version(none) // this example requires support for non-equivalence relations
 }
 
 /// Showing usage with unary predicate:
-/* FIXME: pure @safe nothrow*/ unittest
+/* FIXME: pure @safe nothrow*/ @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -1988,7 +1988,7 @@ version(none) // this example requires support for non-equivalence relations
     }
 }
 
-/*FIXME: pure @safe nothrow*/ unittest
+/*FIXME: pure @safe nothrow*/ @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -4958,7 +4958,7 @@ if (isInputRange!Range && is(typeof(binaryFun!pred(r.front, r.front)) == bool))
 }
 
 ///
-@trusted unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -832,7 +832,7 @@ if (is(Range == char[]) || is(Range == wchar[]))
 }
 
 ///
-unittest
+@system unittest
 {
     import core.stdc.stdlib : malloc, free;
 
@@ -848,7 +848,7 @@ unittest
     scope(exit) free(s.ptr);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.iteration : filter;
     import std.meta : AliasSeq;
@@ -937,7 +937,7 @@ unittest
 
 // test that initializeAll works for arrays of static arrays of structs with
 // elaborate assigns.
-unittest
+@system unittest
 {
     struct Int {
         ~this() {}
@@ -982,7 +982,7 @@ void move(T)(ref T source, ref T target)
 }
 
 /// For non-struct types, `move` just performs `target = source`:
-unittest
+@safe unittest
 {
     Object obj1 = new Object;
     Object obj2 = obj1;
@@ -1029,7 +1029,7 @@ pure nothrow @safe @nogc unittest
     assert(s22 == S2(3, 4));
 }
 
-unittest
+@safe unittest
 {
     import std.traits;
     debug(std_algorithm) scope(success)
@@ -1144,7 +1144,7 @@ private T moveImpl(T)(ref T source)
     return result;
 }
 
-unittest
+@safe unittest
 {
     import std.traits;
     debug(std_algorithm) scope(success)
@@ -1204,7 +1204,7 @@ unittest
     assert(s53 is s51);
 }
 
-unittest
+@system unittest
 {
     static struct S { int n = 0; ~this() @system { n = 0; } }
     S a, b;
@@ -1218,14 +1218,14 @@ unittest
     assert(a.n == 0);
 }
 
-unittest//Issue 6217
+@safe unittest//Issue 6217
 {
     import std.algorithm.iteration : map;
     auto x = map!"a"([1,2,3]);
     x = move(x);
 }
 
-unittest// Issue 8055
+@safe unittest// Issue 8055
 {
     static struct S
     {
@@ -1245,7 +1245,7 @@ unittest// Issue 8055
     assert(b.x == 0);
 }
 
-unittest// Issue 8057
+@system unittest// Issue 8057
 {
     int n = 10;
     struct S
@@ -1338,7 +1338,7 @@ void moveEmplace(T)(ref T source, ref T target) @system
 }
 
 ///
-pure nothrow @nogc unittest
+pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -1412,7 +1412,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @nogc unittest
+pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -1432,7 +1432,7 @@ pure nothrow @nogc unittest
     assert(dst[0 .. 3].all!(e => e._ptr !is null));
 }
 
-unittest
+@system unittest
 {
     struct InputRange
     {
@@ -1518,7 +1518,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @nogc unittest
+pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -2001,7 +2001,7 @@ if (isBidirectionalRange!Range
             [ 1, 3, 3, 4, 5, 5, 6 ]);
 }
 
-@nogc unittest
+@nogc @system unittest
 {
     // @nogc test
     int[10] arr = [0,1,2,3,4,5,6,7,8,9];
@@ -2525,7 +2525,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     SysTime a, b;
 }
 
-unittest // 9975
+@system unittest // 9975
 {
     import std.exception : doesPointTo, mayPointTo;
     static struct S2
@@ -2551,7 +2551,7 @@ unittest // 9975
     assertThrown!Error(swap(p, pp));
 }
 
-unittest
+@system unittest
 {
     static struct A
     {
@@ -2781,7 +2781,7 @@ if (isInputRange!Range && hasLvalueElements!Range && is(typeof(range.front = val
 }
 
 ///
-nothrow unittest
+nothrow @system unittest
 {
     import core.stdc.stdlib : malloc, free;
 

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3163,7 +3163,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.conv : text;
     import std.typecons : tuple;
@@ -3178,7 +3178,7 @@ unittest
     assert(a.maxCount == tuple(4, 2));
 }
 
-unittest
+@system unittest
 {
     import std.conv : text;
     import std.exception : assertThrown;
@@ -3199,7 +3199,7 @@ unittest
     assert(minCount(new ReferenceForwardRange!int([1, 2, 1, 0, 2, 0])) == tuple(0, 2));
 }
 
-unittest
+@system unittest
 {
     import std.conv : text;
     import std.meta : AliasSeq;
@@ -3546,7 +3546,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
     assert( equal( minPos(new ReferenceForwardRange!int([1, 2, 1, 0, 2, 0])), [0, 2, 0] ) );
 }
 
-unittest
+@system unittest
 {
     //Rvalue range
     import std.algorithm.comparison : equal;
@@ -4439,7 +4439,7 @@ if (isInputRange!Range)
     assert(equal(until!"a == 2"(a, No.openRight), [1, 2]));
 }
 
-unittest // bugzilla 13171
+@system unittest // bugzilla 13171
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -4457,7 +4457,7 @@ unittest // bugzilla 13171
     assert(equal(a, [0, 0, 3, 4]));
 }
 
-unittest // Issue 13124
+@safe unittest // Issue 13124
 {
     import std.algorithm.comparison : among;
     auto s = "hello how\nare you";

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -536,7 +536,7 @@ pure @safe nothrow @nogc unittest
 }
 
 // Issue 13935
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : map;
     auto seq = [1, 2].map!(x => x);
@@ -586,7 +586,7 @@ void largestPartialIntersection
 }
 
 ///
-unittest
+@system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -647,7 +647,7 @@ void largestPartialIntersectionWeighted
 }
 
 ///
-unittest
+@system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -670,7 +670,7 @@ unittest
     // 7.0 occurs 3 times -> 4.4 (3 * 1.1)
 }
 
-unittest
+@system unittest
 {
     import std.conv : text;
     import std.typecons : tuple, Tuple, Yes;
@@ -694,7 +694,7 @@ unittest
     assert(a[0].empty);
 }
 
-unittest
+@system unittest
 {
     import std.conv : text;
     import std.typecons : tuple, Tuple, Yes;
@@ -716,7 +716,7 @@ unittest
     assert(b == [ tuple("7", 4u), tuple("1", 3u) ][], text(b));
 }
 
-unittest
+@system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -739,7 +739,7 @@ unittest
     assert(b[0] == tuple(4.0, 2u));
 }
 
-unittest
+@system unittest
 {
     import std.container : Array;
     import std.typecons : Tuple;
@@ -845,7 +845,7 @@ NWayUnion!(less, RangeOfRanges) nWayUnion
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1001,7 +1001,7 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
 }
 
 ///
-unittest
+@system unittest
 {
     immutable(int[]) arr = [ 2, 3, 1, 5, 0 ];
     // index using pointers
@@ -1016,7 +1016,7 @@ unittest
         (index2));
 }
 
-unittest
+@system unittest
 {
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -1569,7 +1569,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     assert(arr == [[1, 0], [1, 1], [1, 2], [2, 0]]);
 }
 
-unittest //Issue 16413 - @system comparison function
+@safe unittest //Issue 16413 - @system comparison function
 {
     bool lt(int a, int b) { return a < b; } static @system
     auto a = [2, 1];
@@ -1904,7 +1904,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
     assert(numbers.equal!isIdentical(sorted));
 }
 
-unittest
+@safe unittest
 {
     // Simple regression benchmark
     import std.random, std.algorithm.iteration, std.algorithm.mutation;
@@ -3024,7 +3024,7 @@ if (isRandomAccessRange!(Range) && hasLength!(Range) && hasSlicing!(Range))
 }
 
 ///
-unittest
+@system unittest
 {
     int[] a = [ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 ];
     partialSort(a, 5);
@@ -3051,7 +3051,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
     sort!(less, ss)(r1);
 }
 ///
-unittest
+@system unittest
 {
     int[] a = [5, 7, 2, 6, 7];
     int[] b = [2, 1, 5, 6, 7, 3, 0];
@@ -3423,7 +3423,7 @@ done:
     return pivot;
 }
 
-unittest
+@safe unittest
 {
     auto a = [ 10, 5, 3, 4, 8,  11,  13, 3, 9, 4, 10 ];
     assert(expandPartition!((a, b) => a < b)(a, 4, 5, 6) == 9);
@@ -3561,7 +3561,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 ///
-unittest
+@system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3571,7 +3571,7 @@ unittest
 }
 
 // bug 15421
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -3615,7 +3615,7 @@ unittest
 }
 
 // bug 15421
-unittest
+@system unittest
 {
     auto a = [ 9, 8, 0, 3, 5, 25, 43, 4, 2, 0, 7 ];
     auto b = [ 9, 8, 0, 3, 5, 25, 43, 4, 2, 0, 7 ];
@@ -3634,7 +3634,7 @@ unittest
 }
 
 // bug 12987
-unittest
+@system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3644,7 +3644,7 @@ unittest
 }
 
 // bug 15420
-unittest
+@system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3687,7 +3687,7 @@ if (isInputRange!(SRange) && isRandomAccessRange!(TRange)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.typecons : Yes;
 
@@ -3697,7 +3697,7 @@ unittest
     assert(b == [ 0, 1, 2 ]);
 }
 
-unittest
+@system unittest
 {
     import std.random : Random, unpredictableSeed, uniform, randomShuffle;
     import std.typecons : Yes;
@@ -3811,7 +3811,7 @@ if (isRandomAccessRange!Range &&
 }
 
 ///
-unittest
+@system unittest
 {
     import std.typecons : Yes;
 
@@ -3827,7 +3827,7 @@ unittest
     assert(ptrIndex == [ &a[5], &a[1], &a[3] ]);
 }
 
-unittest
+@system unittest
 {
     import std.conv : text;
 
@@ -3998,7 +3998,7 @@ if (isRandomAccessRange!Range && hasLength!Range &&
     }
 }
 
-unittest
+@safe unittest
 {
     // Verify medianOf for all permutations of [1, 2, 2, 3, 4].
     int[5] data = [1, 2, 2, 3, 4];

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1673,7 +1673,7 @@ unittest
 }
 
 // Issue 6447
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1720,7 +1720,7 @@ void yield(T)(T value)
     yield(value);
 }
 
-unittest
+@system unittest
 {
     import core.exception;
     import std.exception;

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -23,7 +23,7 @@ import core.exception : RangeError;
 public import std.container.util;
 
 ///
-unittest
+@system unittest
 {
     auto arr = Array!int(0, 2, 3);
     assert(arr[0] == 0);
@@ -50,7 +50,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto arr = Array!int(1, 2, 3);
@@ -69,7 +69,7 @@ unittest
 }
 
 /// `Array!bool` packs together values efficiently by allocating one bit per element
-unittest
+@system unittest
 {
     Array!bool arr;
     arr.insert([true, true, false, true, false]);
@@ -995,13 +995,13 @@ $(D r)
     }
 }
 
-unittest
+@system unittest
 {
     Array!int a;
     assert(a.empty);
 }
 
-unittest
+@system unittest
 {
     Array!int a = Array!int(1, 2, 3);
     //a._data._refCountedDebug = true;
@@ -1012,13 +1012,13 @@ unittest
     assert(a == Array!int(1, 2, 3));
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3);
     assert(a.length == 3);
 }
 
-unittest
+@system unittest
 {
     const Array!int a = [1, 2];
 
@@ -1039,14 +1039,14 @@ unittest
     }
 }
 
-unittest
+@safe unittest
 {
     // REG https://issues.dlang.org/show_bug.cgi?id=13621
     import std.container : Array, BinaryHeap;
     alias Heap = BinaryHeap!(Array!int);
 }
 
-unittest
+@system unittest
 {
     Array!int a;
     a.reserve(1000);
@@ -1061,14 +1061,14 @@ unittest
     assert(p == a._data._payload.ptr);
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3);
     a[1] *= 42;
     assert(a[1] == 84);
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3);
     auto b = Array!int(11, 12, 13);
@@ -1078,7 +1078,7 @@ unittest
     assert(a ~ [4,5] == Array!int(1,2,3,4,5));
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3);
     auto b = Array!int(11, 12, 13);
@@ -1086,14 +1086,14 @@ unittest
     assert(a == Array!int(1, 2, 3, 11, 12, 13));
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3, 4);
     assert(a.removeAny() == 4);
     assert(a == Array!int(1, 2, 3));
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(1, 2, 3, 4, 5);
     auto r = a[2 .. a.length];
@@ -1104,7 +1104,7 @@ unittest
     assert(a == Array!int(1, 2, 8, 9, 42, 3, 4, 5));
 }
 
-unittest
+@system unittest
 {
     auto a = Array!int(0, 1, 2, 3, 4, 5, 6, 7, 8);
     a.linearRemove(a[4 .. 6]);
@@ -1112,7 +1112,7 @@ unittest
 }
 
 // Give the Range object some testing.
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : retro;
@@ -1130,7 +1130,7 @@ unittest
     assert(equal(a[1..4], [1, 2, 3]));
 }
 // Test issue 5920
-unittest
+@system unittest
 {
     struct structBug5920
     {
@@ -1169,7 +1169,7 @@ unittest
     assert(dMask == 0b1111_1111);   // make sure the d'tor is called once only.
 }
 // Test issue 5792 (mainly just to check if this piece of code is compilable)
-unittest
+@system unittest
 {
     auto a = Array!(int[])([[1,2],[3,4]]);
     a.reserve(4);
@@ -1185,7 +1185,7 @@ unittest
 }
 
 // test replace!Stuff with range Stuff
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int([1, 42, 5]);
@@ -1194,28 +1194,28 @@ unittest
 }
 
 // test insertBefore and replace with empty Arrays
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.insertBefore(a[], 1);
     assert(equal(a[], [1]));
 }
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.insertBefore(a[], [1, 2]);
     assert(equal(a[], [1, 2]));
 }
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.replace(a[], [1, 2]);
     assert(equal(a[], [1, 2]));
 }
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
@@ -1223,7 +1223,7 @@ unittest
     assert(equal(a[], [1]));
 }
 // make sure that Array instances refuse ranges that don't belong to them
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
 
@@ -1236,7 +1236,7 @@ unittest
     assertThrown(a.replace(r, [42]));
     assertThrown(a.linearRemove(r));
 }
-unittest
+@system unittest
 {
     auto a = Array!int([1, 1]);
     a[1]  = 0; //Check Array.opIndexAssign
@@ -1267,7 +1267,7 @@ unittest
     assert(~r[0] == ~3);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1313,7 +1313,7 @@ unittest
 }
 
 // Test issue 11194
-unittest
+@system unittest
 {
     static struct S {
         int i = 1337;
@@ -1327,7 +1327,7 @@ unittest
     arr ~= s;
 }
 
-unittest //11459
+@safe unittest //11459
 {
     static struct S
     {
@@ -1338,18 +1338,18 @@ unittest //11459
     alias B = Array!(shared bool);
 }
 
-unittest //11884
+@system unittest //11884
 {
     import std.algorithm.iteration : filter;
     auto a = Array!int([1, 2, 2].filter!"true"());
 }
 
-unittest //8282
+@safe unittest //8282
 {
     auto arr = new Array!int;
 }
 
-unittest //6998
+@system unittest //6998
 {
     static int i = 0;
     class C
@@ -1374,7 +1374,7 @@ unittest //6998
     //Just to make sure the GC doesn't collect before the above test.
     assert(c.dummy ==1);
 }
-unittest //6998-2
+@system unittest //6998-2
 {
     static class C {int i;}
     auto c = new C;
@@ -1385,13 +1385,13 @@ unittest //6998-2
     assert(c.i == 42); //fails
 }
 
-unittest
+@safe unittest
 {
     static assert(is(Array!int.Range));
     static assert(is(Array!int.ConstRange));
 }
 
-unittest // const/immutable Array and Ranges
+@system unittest // const/immutable Array and Ranges
 {
     static void test(A, R, E, S)()
     {
@@ -1421,7 +1421,7 @@ unittest // const/immutable Array and Ranges
 }
 
 // ensure @nogc
-@nogc unittest
+@nogc @system unittest
 {
     Array!int ai;
     ai ~= 1;
@@ -1579,7 +1579,7 @@ if (is(Unqual!T == bool))
         return !length;
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         //a._store._refCountedDebug = true;
@@ -1601,7 +1601,7 @@ if (is(Unqual!T == bool))
         return result;
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         assert(a.empty);
@@ -1625,7 +1625,7 @@ if (is(Unqual!T == bool))
         return length;
     }
 
-    unittest
+    @system unittest
     {
         import std.conv : to;
         Array!bool a;
@@ -1648,7 +1648,7 @@ if (is(Unqual!T == bool))
             : 0;
     }
 
-    unittest
+    @system unittest
     {
         import std.conv : to;
         Array!bool a;
@@ -1675,7 +1675,7 @@ if (is(Unqual!T == bool))
         _store._backend.reserve(to!size_t((e + bitsPerWord - 1) / bitsPerWord));
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         assert(a.capacity == 0);
@@ -1696,7 +1696,7 @@ if (is(Unqual!T == bool))
         return Range(this, 0, length);
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1715,7 +1715,7 @@ if (is(Unqual!T == bool))
         return Range(this, a, b);
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1742,7 +1742,7 @@ if (is(Unqual!T == bool))
         else data.ptr[0] &= ~cast(size_t) 1;
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1773,7 +1773,7 @@ if (is(Unqual!T == bool))
         }
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1823,7 +1823,7 @@ if (is(Unqual!T == bool))
         return this[i];
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1845,7 +1845,7 @@ if (is(Unqual!T == bool))
         return result ~= rhs;
     }
 
-    unittest
+    @system unittest
     {
         import std.algorithm.comparison : equal;
         Array!bool a;
@@ -1874,7 +1874,7 @@ if (is(Unqual!T == bool))
         return this;
     }
 
-    unittest
+    @system unittest
     {
         import std.algorithm.comparison : equal;
         Array!bool a;
@@ -1900,7 +1900,7 @@ if (is(Unqual!T == bool))
         this = Array();
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.insertBack([true, false, true, true]);
@@ -1928,7 +1928,7 @@ if (is(Unqual!T == bool))
         _store._length = newLength;
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.length = 1057;
@@ -1986,7 +1986,7 @@ if (is(Unqual!T == bool))
     /// ditto
     alias stableRemoveAny = removeAny;
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.length = 1057;
@@ -2049,7 +2049,7 @@ if (is(Unqual!T == bool))
     /// ditto
     alias stableInsertBack = insertBack;
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         for (int i = 0; i < 100; ++i)
@@ -2116,7 +2116,7 @@ if (is(Unqual!T == bool))
         return howMany;
     }
 
-    unittest
+    @system unittest
     {
         Array!bool a;
         a.length = 1057;
@@ -2155,7 +2155,7 @@ if (is(Unqual!T == bool))
     /// ditto
     alias stableInsertBefore = insertBefore;
 
-    unittest
+    @system unittest
     {
         import std.conv : to;
         Array!bool a;
@@ -2184,7 +2184,7 @@ if (is(Unqual!T == bool))
     /// ditto
     alias stableInsertAfter = insertAfter;
 
-    unittest
+    @system unittest
     {
         import std.conv : to;
         Array!bool a;
@@ -2213,7 +2213,7 @@ if (is(Unqual!T == bool))
     /// ditto
     alias stableReplace = replace;
 
-    unittest
+    @system unittest
     {
         import std.conv : to;
         Array!bool a;
@@ -2243,13 +2243,13 @@ if (is(Unqual!T == bool))
     }
 }
 
-unittest
+@system unittest
 {
     Array!bool a;
     assert(a.empty);
 }
 
-unittest
+@system unittest
 {
     Array!bool arr;
     arr.insert([false, false, false, false]);
@@ -2271,7 +2271,7 @@ unittest
 }
 
 // issue 16331 - uncomparable values are valid values for an array
-unittest
+@system unittest
 {
     double[] values = [double.nan, double.nan];
     auto arr = Array!double(values);

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -22,7 +22,7 @@ import std.traits;
 public import std.container.util;
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -403,7 +403,7 @@ leaves the heap unaffected and returns $(D false).
 }
 
 /// Example from "Introduction to Algorithms" Cormen et al, p 146
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
@@ -416,7 +416,7 @@ unittest
 
 /// $(D BinaryHeap) implements the standard input range interface, allowing
 /// lazy iteration of the underlying range in descending order.
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -436,7 +436,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     return BinaryHeap!(Store, less)(s, initialSize);
 }
 
-unittest
+@system unittest
 {
     import std.conv : to;
     {
@@ -466,7 +466,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     // Test range interface.
     import std.algorithm.comparison : equal;
@@ -476,7 +476,7 @@ unittest
     assert(h.equal([16, 14, 10, 9, 8, 7, 4, 3, 2, 1]));
 }
 
-unittest // 15675
+@system unittest // 15675
 {
     import std.container.array : Array;
 
@@ -485,7 +485,7 @@ unittest // 15675
     assert(heap.front == 12);
 }
 
-unittest // 16072
+@system unittest // 16072
 {
     auto q = heapify!"a > b"([2, 4, 5]);
     q.insert(1);
@@ -501,7 +501,7 @@ unittest // 16072
     assert(r.front == 99);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7];
@@ -510,7 +510,7 @@ unittest
     assert(dup.equal([16, 14, 10, 9, 8, 7, 4, 3, 2, 1]));
 }
 
-unittest
+@safe unittest
 {
     static struct StructWithoutDup
     {
@@ -540,7 +540,7 @@ unittest
         }));
 }
 
-unittest
+@safe unittest
 {
     static struct StructWithDup
     {
@@ -562,7 +562,7 @@ unittest
         }));
 }
 
-unittest
+@system unittest
 {
     import std.internal.test.dummyrange;
     import std.algorithm.comparison : equal;

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -17,7 +17,7 @@ Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 module std.container.dlist;
 
 ///
-unittest
+@safe unittest
 {
     import std.container : DList;
     import std.algorithm.comparison : equal;
@@ -90,7 +90,7 @@ The base DList Range. Contains Range primitives that don't depend on payload typ
  +/
 private struct DRange
 {
-    unittest
+    @safe unittest
     {
         static assert(isBidirectionalRange!DRange);
         static assert(is(ElementType!DRange == BaseNode*));

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -1150,7 +1150,7 @@ Complexity: $(BIGOH n)
     }
 }
 
-unittest
+@safe unittest
 {
     TotalContainer!int test;
 }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1081,7 +1081,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
                      (thisRange, thatRange);
     }
 
-    static if (doUnittest) unittest
+    static if (doUnittest) @system unittest
     {
         auto t1 = new RedBlackTree(1,2,3,4);
         auto t2 = new RedBlackTree(1,2,3,4);
@@ -2006,7 +2006,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
     assert(array(rt4[]) == ["hello"]);
 }
 
-unittest
+@system unittest
 {
     import std.conv : to;
 

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -17,7 +17,7 @@ Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 module std.container.slist;
 
 ///
-unittest
+@safe unittest
 {
     import std.container : SList;
     import std.algorithm.comparison : equal;
@@ -209,7 +209,7 @@ Defines the container's primary range, which embodies a forward range.
         }
     }
 
-    unittest
+    @safe unittest
     {
         static assert(isForwardRange!Range);
     }
@@ -261,7 +261,7 @@ Complexity: $(BIGOH 1)
         return _first._payload;
     }
 
-    unittest
+    @safe unittest
     {
         auto s = SList!int(1, 2, 3);
         s.front = 42;
@@ -589,7 +589,7 @@ Complexity: $(BIGOH n)
     alias stableLinearRemove = linearRemove;
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -605,21 +605,21 @@ unittest
     assert(equal(b[], [2, 1, 9]));
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int(1, 2, 3);
     auto n = s.findLastNode(s._root);
     assert(n && n._payload == 3);
 }
 
-unittest
+@safe unittest
 {
     import std.range.primitives;
     auto s = SList!int(1, 2, 5, 10);
     assert(walkLength(s[]) == 4);
 }
 
-unittest
+@safe unittest
 {
     import std.range : take;
     auto src = take([0, 1, 2, 3], 3);
@@ -627,7 +627,7 @@ unittest
     assert(s == SList!int(0, 1, 2));
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int();
     auto b = SList!int();
@@ -635,7 +635,7 @@ unittest
     assert(c.empty);
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = SList!int(4, 5, 6);
@@ -643,7 +643,7 @@ unittest
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = [4, 5, 6];
@@ -651,21 +651,21 @@ unittest
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto c = a ~ 4;
     assert(c == SList!int(1, 2, 3, 4));
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int(2, 3, 4);
     auto b = 1 ~ a;
     assert(b == SList!int(1, 2, 3, 4));
 }
 
-unittest
+@safe unittest
 {
     auto a = [1, 2, 3];
     auto b = SList!int(4, 5, 6);
@@ -673,14 +673,14 @@ unittest
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int(1, 2, 3, 4);
     s.insertFront([ 42, 43 ]);
     assert(s == SList!int(42, 43, 1, 2, 3, 4));
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int(1, 2, 3);
     assert(s.removeAny() == 1);
@@ -689,7 +689,7 @@ unittest
     assert(s == SList!int(3));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -700,21 +700,21 @@ unittest
     assert(equal(s[], [3]));
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int(1, 2, 3, 4, 5, 6, 7);
     assert(s.removeFront(3) == 3);
     assert(s == SList!int(4, 5, 6, 7));
 }
 
-unittest
+@safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = SList!int(1, 2, 3);
     assert(a.insertAfter(a[], b[]) == 3);
 }
 
-unittest
+@safe unittest
 {
     import std.range : take;
     auto s = SList!int(1, 2, 3, 4);
@@ -723,7 +723,7 @@ unittest
     assert(s == SList!int(1, 2, 5, 3, 4));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -736,7 +736,7 @@ unittest
     assert(equal(sl[], ["a", "b", "c", "d", "e"]));
 }
 
-unittest
+@safe unittest
 {
     import std.range.primitives;
     auto s = SList!int(1, 2, 3, 4, 5);
@@ -747,7 +747,7 @@ unittest
     assert(r1.empty);
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int(1, 2, 3, 4, 5);
     auto r = s[];
@@ -756,7 +756,7 @@ unittest
     assert(r1.empty);
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -771,7 +771,7 @@ unittest
     assert(equal(r2, [8, 9, 10]));
 }
 
-unittest
+@safe unittest
 {
     import std.range.primitives;
     auto lst = SList!int(1, 5, 42, 9);
@@ -786,12 +786,12 @@ unittest
     assert(walkLength(lst3[]) == 5);
 }
 
-unittest
+@safe unittest
 {
     auto s = make!(SList!int)(1, 2, 3);
 }
 
-unittest
+@safe unittest
 {
     // 5193
     static struct Data
@@ -801,7 +801,7 @@ unittest
     SList!Data list;
 }
 
-unittest
+@safe unittest
 {
     auto s = SList!int([1, 2, 3]);
     s.front = 5; //test frontAssign
@@ -811,7 +811,7 @@ unittest
     assert(r.front == 1);
 }
 
-unittest
+@safe unittest
 {
     // issue 14920
     SList!int s;
@@ -819,20 +819,20 @@ unittest
     assert(s.front == 1);
 }
 
-unittest
+@safe unittest
 {
     // issue 15659
     SList!int s;
     s.clear();
 }
 
-unittest
+@safe unittest
 {
     SList!int s;
     s.reverse();
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -50,7 +50,7 @@ if (is(T == struct) || is(T == class))
 
 
 ///
-unittest
+@system unittest
 {
     import std.container;
     import std.algorithm.comparison : equal;
@@ -66,7 +66,7 @@ unittest
     assert(equal(slist[], [1, 2, 3]));
 }
 
-unittest
+@system unittest
 {
     import std.container;
     import std.algorithm.comparison : equal;
@@ -83,7 +83,7 @@ unittest
 }
 
 // Issue 8895
-unittest
+@safe unittest
 {
     import std.container;
     import std.algorithm.comparison : equal;
@@ -121,7 +121,7 @@ if (!is(Container))
 }
 
 /// forbid construction from infinite range
-unittest
+@safe unittest
 {
     import std.container.array : Array;
     import std.range : only, repeat;
@@ -131,7 +131,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.container.array, std.container.rbtree, std.container.slist;
     import std.range : iota;
@@ -151,7 +151,7 @@ unittest
     assert(equal(list[], [1, 7, 42]));
 }
 
-unittest
+@safe unittest
 {
     import std.container.rbtree;
     import std.algorithm.comparison : equal;
@@ -161,7 +161,7 @@ unittest
 }
 
 // Issue 13872
-unittest
+@system unittest
 {
     import std.container;
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -3058,7 +3058,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 }
 
 //Tests for the double implementation
-unittest
+@safe unittest
 {
     static if (real.mant_dig == 53)
     {
@@ -4471,7 +4471,7 @@ if (is(T == class))
     assert(inner.getI == 3);
 }
 
-@nogc pure nothrow unittest
+@nogc pure nothrow @system unittest
 {
     int var = 6;
     align(__conv_EmplaceTestClass.alignof) ubyte[__traits(classInstanceSize, __conv_EmplaceTestClass)] buf;
@@ -5577,7 +5577,7 @@ if (isIntegral!T)
     immutable s3 = signed(u); //explicitly qualified
 }
 
-@safe unittest
+@system unittest
 {
     foreach (T; AliasSeq!(byte, ubyte))
     {
@@ -5691,7 +5691,7 @@ template castFrom(From)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16667
-unittest
+@system unittest
 {
     ubyte[] a = ['a', 'b', 'c'];
     assert(castFrom!(ubyte[]).to!(string)(a) == "abc");

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -65,7 +65,7 @@ version(unittest)
 
 
 ///
-unittest
+@safe unittest
 {
     //Template API
     import std.digest.crc;
@@ -83,7 +83,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //OOP API
     import std.digest.crc;
@@ -128,7 +128,7 @@ private uint[256][8] genTables(uint polynomial)
 
 private static immutable uint[256][8] crc32Tables = genTables(0xEDB88320);
 
-unittest
+@system unittest
 {
     auto tables = genTables(0xEDB88320);
     assert(tables[0][0] == 0x00000000 && tables[0][$ - 1] == 0x2d02ef8d && tables[7][$ - 1] == 0x264b06e6);
@@ -196,7 +196,7 @@ struct CRC32
             _state = crc;
         }
         ///
-        unittest
+        @safe unittest
         {
             CRC32 dig;
             dig.put(cast(ubyte) 0); //single ubyte
@@ -219,7 +219,7 @@ struct CRC32
             this = CRC32.init;
         }
         ///
-        unittest
+        @safe unittest
         {
             CRC32 digest;
             //digest.start(); //Not necessary
@@ -237,7 +237,7 @@ struct CRC32
             return tmp;
         }
         ///
-        unittest
+        @safe unittest
         {
             //Simple example
             CRC32 hash;
@@ -258,7 +258,7 @@ struct CRC32
 }
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using crc32Of helper function
     ubyte[4] hash = crc32Of("abc");
@@ -267,7 +267,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Using the basic API
     CRC32 hash;
@@ -278,7 +278,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Let's use the template features:
     //Note: When passing a CRC32 to a function, it must be passed by reference!
@@ -293,12 +293,12 @@ unittest
     assert(crcHexString(crc.finish()) == "D202EF8D");
 }
 
-unittest
+@safe unittest
 {
     assert(isDigest!CRC32);
 }
 
-unittest
+@system unittest
 {
     ubyte[4] digest;
 
@@ -356,7 +356,7 @@ ubyte[4] crc32Of(T...)(T data)
 }
 
 ///
-unittest
+@system unittest
 {
     ubyte[] data = [4,5,7,25];
     assert(data.crc32Of == [167, 180, 199, 131]);
@@ -391,7 +391,7 @@ public alias crcHexString = toHexString!(Order.decreasing, 16);
 alias CRC32Digest = WrapperDigest!CRC32;
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto crc = new CRC32Digest();
@@ -401,7 +401,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
      //Let's use the OOP features:
     void test(Digest dig)
@@ -418,7 +418,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Simple example
     auto hash = new CRC32Digest();
@@ -427,7 +427,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     //using a supplied buffer
     ubyte[4] buf;
@@ -439,7 +439,7 @@ unittest
     //length)
 }
 
-unittest
+@system unittest
 {
     import std.range;
 

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -69,7 +69,7 @@ public import std.ascii : LetterCase;
 
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
 
@@ -85,7 +85,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     //Generating the hashes of a file, idiomatic D way
     import std.digest.crc, std.digest.sha, std.digest.md;
@@ -111,7 +111,7 @@ unittest
     }
 }
 ///
-unittest
+@system unittest
 {
     //Generating the hashes of a file using the template API
     import std.digest.crc, std.digest.sha, std.digest.md;
@@ -151,7 +151,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc, std.digest.sha, std.digest.md;
     import std.stdio;
@@ -255,7 +255,7 @@ version(ExampleDigest)
 }
 
 ///
-unittest
+@system unittest
 {
     //Using the OutputRange feature
     import std.algorithm.mutation : copy;
@@ -296,13 +296,13 @@ template isDigest(T)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     static assert(isDigest!CRC32);
 }
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     void myFunction(T)()
@@ -334,13 +334,13 @@ template DigestType(T)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     assert(is(DigestType!(CRC32) == ubyte[4]));
 }
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     CRC32 dig;
@@ -370,14 +370,14 @@ template hasPeek(T)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc, std.digest.md;
     assert(!hasPeek!(MD5));
     assert(hasPeek!CRC32);
 }
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     void myFunction(T)()
@@ -402,7 +402,7 @@ if (isDigest!T)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md, std.digest.hmac;
     static assert(hasBlockSize!MD5        && MD5.blockSize      == 512);
@@ -440,7 +440,7 @@ if (!isArray!Range
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md;
     import std.range : repeat;
@@ -465,7 +465,7 @@ if (allSatisfy!(isArray, typeof(data)))
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md, std.digest.sha, std.digest.crc;
     auto md5   = digest!MD5(  "The quick brown fox jumps over the lazy dog");
@@ -475,7 +475,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
@@ -498,7 +498,7 @@ if (!isArray!Range && isDigestibleRange!Range)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md;
     import std.range : repeat;
@@ -520,13 +520,13 @@ if (allSatisfy!(isArray, typeof(data)))
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     assert(hexDigest!(CRC32, Order.decreasing)("The quick brown fox jumps over the lazy dog") == "414FA339");
 }
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     assert(hexDigest!(CRC32, Order.decreasing)("The quick ", "brown ", "fox jumps over the lazy dog") == "414FA339");
@@ -544,7 +544,7 @@ Hash makeDigest(Hash)()
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md;
     auto md5 = makeDigest!MD5();
@@ -624,7 +624,7 @@ interface Digest
 }
 
 ///
-unittest
+@system unittest
 {
     //Using the OutputRange feature
     import std.algorithm.mutation : copy;
@@ -638,7 +638,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md, std.digest.sha, std.digest.crc;
     ubyte[] md5   = (new MD5Digest()).digest("The quick brown fox jumps over the lazy dog");
@@ -648,14 +648,14 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.crc;
     ubyte[] crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
     assert(crcHexString(crc32) == "414FA339");
 }
 
-unittest
+@system unittest
 {
     import std.range : isOutputRange;
     assert(!isDigest!(Digest));
@@ -663,7 +663,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     void test(Digest dig)
     {
@@ -978,7 +978,7 @@ if (isDigest!T) : Digest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.digest.md;
     //Simple example
@@ -988,7 +988,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     //using a supplied buffer
     import std.digest.md;

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -31,7 +31,7 @@ import std.meta : allSatisfy;
 
 version(StdDdoc)
 /// Computes an HMAC over data read from stdin.
-unittest
+@safe unittest
 {
     import std.stdio, std.digest.hmac, std.digest.sha;
     import std.string : representation;

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -48,7 +48,7 @@ module std.digest.md;
 public import std.digest.digest;
 
 ///
-unittest
+@safe unittest
 {
     //Template API
     import std.digest.md;
@@ -64,7 +64,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //OOP API
     import std.digest.md;
@@ -391,7 +391,7 @@ struct MD5
             return data;
         }
         ///
-        unittest
+        @safe unittest
         {
             //Simple example
             MD5 hash;
@@ -402,7 +402,7 @@ struct MD5
 }
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using md5Of helper function
     ubyte[16] hash = md5Of("abc");
@@ -411,7 +411,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Using the basic API
     MD5 hash;
@@ -423,7 +423,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Let's use the template features:
     void doSomething(T)(ref T hash)
@@ -437,12 +437,12 @@ unittest
     assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
 }
 
-unittest
+@safe unittest
 {
     assert(isDigest!MD5);
 }
 
-unittest
+@system unittest
 {
     import std.range;
 
@@ -503,7 +503,7 @@ auto md5Of(T...)(T data)
 }
 
 ///
-unittest
+@safe unittest
 {
     ubyte[16] hash = md5Of("abc");
     assert(hash == digest!MD5("abc"));
@@ -519,7 +519,7 @@ unittest
 alias MD5Digest = WrapperDigest!MD5;
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto md5 = new MD5Digest();
@@ -529,7 +529,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
      //Let's use the OOP features:
     void test(Digest dig)
@@ -545,7 +545,7 @@ unittest
     assert(toHexString(result) == "93B885ADFE0DA089CDF634904FD59F71");
 }
 
-unittest
+@system unittest
 {
     auto md5 = new MD5Digest();
 

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -38,7 +38,7 @@ $(BR) $(LINK2 https://en.wikipedia.org/wiki/MurmurHash, Wikipedia)
 module std.digest.murmurhash;
 
 ///
-unittest
+@safe unittest
 {
     // MurmurHash3!32, MurmurHash3!(128, 32) and MurmurHash3!(128, 64) implement
     // the std.digest.digest Template API.
@@ -48,7 +48,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     // One can also hash ubyte data piecewise by instanciating a hasher and call
     // the 'put' method.
@@ -65,7 +65,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     // Using `putElements`, `putRemainder` and `finalize` you gain full
     // control over which part of the algorithm to run.
@@ -632,7 +632,7 @@ version (unittest)
     }
 }
 
-unittest
+@safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!32)([
@@ -666,7 +666,7 @@ unittest
     // dfmt on
 }
 
-unittest
+@safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!(128,32))([
@@ -700,7 +700,7 @@ unittest
     // dfmt on
 }
 
-unittest
+@safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!(128,64))([
@@ -734,7 +734,7 @@ unittest
     // dfmt on
 }
 
-unittest
+@safe unittest
 {
     // Pushing unaligned data and making sure the result is still coherent.
     void testUnalignedHash(H)()

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -49,7 +49,7 @@ module std.digest.ripemd;
 public import std.digest.digest;
 
 ///
-unittest
+@safe unittest
 {
     //Template API
     import std.digest.md;
@@ -68,7 +68,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //OOP API
     import std.digest.md;
@@ -560,7 +560,7 @@ struct RIPEMD160
 }
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using ripemd160Of helper function
     ubyte[20] hash = ripemd160Of("abc");
@@ -569,7 +569,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Using the basic API
     RIPEMD160 hash;
@@ -581,7 +581,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Let's use the template features:
     void doSomething(T)(ref T hash)
@@ -596,7 +596,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Simple example
     RIPEMD160 hash;
@@ -606,12 +606,12 @@ unittest
     assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
 
-unittest
+@safe unittest
 {
     assert(isDigest!RIPEMD160);
 }
 
-unittest
+@system unittest
 {
     import std.range;
 
@@ -672,7 +672,7 @@ auto ripemd160Of(T...)(T data)
 }
 
 ///
-unittest
+@safe unittest
 {
     ubyte[20] hash = ripemd160Of("abc");
     assert(hash == digest!RIPEMD160("abc"));
@@ -688,7 +688,7 @@ unittest
 alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto md = new RIPEMD160Digest();
@@ -698,7 +698,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     //Let's use the OOP features:
     void test(Digest dig)
@@ -714,7 +714,7 @@ unittest
     assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
 
-unittest
+@system unittest
 {
     auto md = new RIPEMD160Digest();
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -58,7 +58,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
 module std.digest.sha;
 
 ///
-unittest
+@safe unittest
 {
     //Template API
     import std.digest.sha;
@@ -80,7 +80,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //OOP API
     import std.digest.sha;
@@ -740,7 +740,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 (&buffer[index])[0 .. inputLen-i] = (&input[i])[0 .. inputLen-i];
         }
 
-        unittest
+        @safe unittest
         {
             typeof(this) dig;
             dig.put(cast(ubyte) 0); //single ubyte
@@ -810,7 +810,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 static assert(0);
         }
         ///
-        unittest
+        @safe unittest
         {
             //Simple example
             SHA1 hash;
@@ -829,7 +829,7 @@ alias SHA512_224 = SHA!(1024, 224); /// SHA alias for SHA-512/224, hash is ubyte
 alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte[32]
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using sha1Of helper function
     ubyte[20] hash = sha1Of("abc");
@@ -842,7 +842,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Using the basic API
     SHA1 hash;
@@ -854,7 +854,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     //Let's use the template features:
     //Note: When passing a SHA1 to a function, it must be passed by reference!
@@ -869,7 +869,7 @@ unittest
     assert(toHexString(sha.finish()) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
 }
 
-unittest
+@safe unittest
 {
     assert(isDigest!SHA1);
     assert(isDigest!SHA224);
@@ -880,7 +880,7 @@ unittest
     assert(isDigest!SHA512_256);
 }
 
-unittest
+@system unittest
 {
     import std.range;
     import std.conv : hexString;
@@ -1162,7 +1162,7 @@ auto sha512_256Of(T...)(T data)
 }
 
 ///
-unittest
+@safe unittest
 {
     ubyte[20] hash = sha1Of("abc");
     assert(hash == digest!SHA1("abc"));
@@ -1186,7 +1186,7 @@ unittest
     assert(hash512_256 == digest!SHA512_256("abc"));
 }
 
-unittest
+@safe unittest
 {
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
@@ -1213,7 +1213,7 @@ alias SHA512_224Digest = WrapperDigest!SHA512_224; ///ditto
 alias SHA512_256Digest = WrapperDigest!SHA512_256; ///ditto
 
 ///
-unittest
+@safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto sha = new SHA1Digest();
@@ -1229,7 +1229,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     //Let's use the OOP features:
     void test(Digest dig)
@@ -1245,7 +1245,7 @@ unittest
     assert(toHexString(result) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
 }
 
-unittest
+@system unittest
 {
     auto sha = new SHA1Digest();
 

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2302,7 +2302,7 @@ body
     }
 }
 
-unittest // mutable/const input/output
+@system unittest // mutable/const input/output
 {
     import std.meta : AliasSeq;
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -1479,7 +1479,7 @@ class ErrnoException : Exception
         super(msg ~ " (" ~ s[0..s.strlen].idup ~ ")", file, line);
     }
 
-    unittest
+    @system unittest
     {
         import core.stdc.errno : errno, EAGAIN;
 
@@ -1491,7 +1491,7 @@ class ErrnoException : Exception
         assert(ex.errno == EAGAIN);
     }
 
-    unittest
+    @system unittest
     {
         import core.stdc.errno : EAGAIN;
         auto ex = new ErrnoException("oh no", EAGAIN);

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -317,7 +317,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     // One word before and after each allocation.
@@ -329,7 +329,7 @@ unittest
         && A.instance.suffix(b) == 0xDEAD_BEEF);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block
         : BitmappedBlock;
@@ -341,7 +341,7 @@ unittest
     });
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     alias A = AffixAllocator!(Mallocator, size_t);
@@ -356,7 +356,7 @@ unittest
     assert(b is null);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator;
     import std.experimental.allocator;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -532,7 +532,7 @@ template AllocatorList(alias factoryFunction,
 }
 
 ///
-version(Posix) unittest
+version(Posix) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
@@ -575,7 +575,7 @@ version(Posix) unittest
     assert(b1.length == 1024 * 10);
 }
 
-unittest
+@system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
@@ -589,7 +589,7 @@ unittest
     a.deallocateAll();
 }
 
-unittest
+@system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
@@ -602,7 +602,7 @@ unittest
     a.deallocateAll();
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
@@ -617,7 +617,7 @@ unittest
     assert(a.empty == Ternary.yes);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     enum bs = GCAllocator.alignment;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -50,7 +50,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     import std.conv : text;
     import std.typecons : Ternary;
 
-    unittest
+    @system unittest
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;
         import std.algorithm.comparison : max;
@@ -690,7 +690,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
 }
 
 ///
-unittest
+@system unittest
 {
     // Create a block allocator on top of a 10KB stack region.
     import std.experimental.allocator.building_blocks.region : InSituRegion;
@@ -702,13 +702,13 @@ unittest
     assert(b.length == 100);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     testAllocator!(() => BitmappedBlock!(64, 8, GCAllocator)(1024 * 64));
 }
 
-unittest
+@system unittest
 {
     static void testAllocateAll(size_t bs)(uint blocks, uint blocksAtATime)
     {
@@ -823,7 +823,7 @@ unittest
 }
 
 // Test totalAllocation
-unittest
+@safe unittest
 {
     BitmappedBlock!(8, 8, NullAllocator) h1;
     assert(h1.totalAllocation(1) >= 8);
@@ -860,7 +860,7 @@ struct BitmappedBlockWithInternalPointers(
 {
     import std.conv : text;
     import std.typecons : Ternary;
-    unittest
+    @system unittest
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;
         auto m = AlignedMallocator.instance.alignedAllocate(1024 * 64,
@@ -1059,7 +1059,7 @@ struct BitmappedBlockWithInternalPointers(
     }
 }
 
-unittest
+@system unittest
 {
     auto h = BitmappedBlockWithInternalPointers!(4096)(new void[4096 * 1024]);
     auto b = h.allocate(123);
@@ -1092,7 +1092,7 @@ private uint leadingOnes(ulong x)
     return result;
 }
 
-unittest
+@system unittest
 {
     assert(leadingOnes(0) == 0);
     assert(leadingOnes(~0UL) == 64);
@@ -1117,7 +1117,7 @@ private uint findContigOnes(ulong x, uint n)
     return leadingOnes(~x);
 }
 
-unittest
+@system unittest
 {
     assert(findContigOnes(0x0000_0000_0000_0300, 2) == 54);
 
@@ -1141,7 +1141,7 @@ private void setBits(ref ulong w, uint lsb, uint msb)
     w |= mask;
 }
 
-unittest
+@system unittest
 {
     ulong w;
     w = 0; setBits(w, 0, 63); assert(w == ulong.max);
@@ -1339,7 +1339,7 @@ private struct BitVector
     }
 }
 
-unittest
+@system unittest
 {
     auto v = BitVector(new ulong[10]);
     assert(v.length == 640);

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -217,7 +217,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
     import std.experimental.allocator.building_blocks.free_list : FreeList;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -24,7 +24,7 @@ struct FallbackAllocator(Primary, Fallback)
     import std.traits : hasMember;
     import std.typecons : Ternary;
 
-    unittest
+    @system unittest
     {
         testAllocator!(() => FallbackAllocator());
     }
@@ -255,7 +255,7 @@ struct FallbackAllocator(Primary, Fallback)
     }
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.region : InSituRegion;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -289,7 +289,7 @@ private auto ref forward(alias arg)()
     }
 }
 
-unittest
+@safe unittest
 {
     void fun(T)(auto ref T, string) { /* ... */ }
     void gun(T...)(auto ref T args)
@@ -301,7 +301,7 @@ unittest
     gun(x, "hello");
 }
 
-unittest
+@safe unittest
 {
     static void checkByRef(T)(auto ref T value)
     {
@@ -341,7 +341,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.gc_allocator : GCAllocator;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -115,7 +115,7 @@ struct FreeList(ParentAllocator,
         }
 
         ///
-        unittest
+        @safe unittest
         {
             import std.experimental.allocator.mallocator : Mallocator;
             import std.experimental.allocator.common : chooseAtRuntime;
@@ -389,7 +389,7 @@ struct FreeList(ParentAllocator,
     }
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     FreeList!(GCAllocator, 0, 8) fl;
@@ -671,7 +671,7 @@ struct ContiguousFreeList(ParentAllocator,
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -684,7 +684,7 @@ unittest
     );
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.null_allocator
         : NullAllocator;
@@ -709,7 +709,7 @@ unittest
     a.deallocate(b);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -736,7 +736,7 @@ unittest
     a.deallocate(b);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     alias A = ContiguousFreeList!(GCAllocator, 64, 64);
@@ -894,7 +894,7 @@ struct SharedFreeList(ParentAllocator,
         /// Ditto
         void setBounds(size_t newMin, size_t newMax);
         ///
-        unittest
+        @safe unittest
         {
             import std.experimental.allocator.mallocator : Mallocator;
             import std.experimental.allocator.common : chooseAtRuntime;
@@ -915,7 +915,7 @@ struct SharedFreeList(ParentAllocator,
         /// ditto
         @property void approxMaxLength(size_t x) shared;
         ///
-        unittest
+        @safe unittest
         {
             import std.experimental.allocator.mallocator : Mallocator;
             import std.experimental.allocator.common : chooseAtRuntime;
@@ -1047,7 +1047,7 @@ struct SharedFreeList(ParentAllocator,
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : repeat;
@@ -1079,7 +1079,7 @@ unittest
     tg.joinAll();
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
@@ -1091,28 +1091,28 @@ unittest
     assert(a.nodes == 0);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
     a.allocate(64);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime, chooseAtRuntime) a;
     a.allocate(64);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40) a;
     a.allocate(64);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40, chooseAtRuntime) a;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -332,7 +332,7 @@ struct FreeTree(ParentAllocator)
         return true;
     }
 
-    unittest // test a few simple configurations
+    @system unittest // test a few simple configurations
     {
         import std.experimental.allocator.gc_allocator;
         FreeTree!GCAllocator a;
@@ -353,7 +353,7 @@ struct FreeTree(ParentAllocator)
         assert(a.formatSizes == "(_)", a.formatSizes);
     }
 
-    unittest // build a complex free tree
+    @system unittest // build a complex free tree
     {
         import std.experimental.allocator.gc_allocator, std.range;
         FreeTree!GCAllocator a;
@@ -408,13 +408,13 @@ struct FreeTree(ParentAllocator)
     }
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator;
     testAllocator!(() => FreeTree!GCAllocator());
 }
 
-unittest // issue 16506
+@system unittest // issue 16506
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -433,7 +433,7 @@ unittest // issue 16506
     f!GCAllocator(1);
 }
 
-unittest // issue 16507
+@system unittest // issue 16507
 {
     static struct MyAllocator
     {
@@ -451,7 +451,7 @@ unittest // issue 16507
     MyAllocator.alive = false;
 }
 
-unittest // "desperation mode"
+@system unittest // "desperation mode"
 {
     uint myDeallocCounter = 0;
 

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -545,7 +545,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     }
 
     ///
-    unittest
+    @system unittest
     {
         import std.experimental.allocator.gc_allocator : GCAllocator;
         auto alloc = KRRegion!GCAllocator(1024 * 64);
@@ -613,7 +613,7 @@ allocator if $(D deallocate) is needed, yet the actual deallocation traffic is
 relatively low. The example below shows a $(D KRRegion) using stack storage
 fronting the GC allocator.
 */
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.fallback_allocator
@@ -637,7 +637,7 @@ It should perform slightly better because instead of searching through one
 large free list, it searches through several shorter lists in LRU order. Also,
 it actually returns memory to the operating system when possible.
 */
-unittest
+@system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -647,7 +647,7 @@ unittest
     AllocatorList!(n => KRRegion!MmapAllocator(max(n * 16, 1024 * 1024))) alloc;
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -680,7 +680,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -718,7 +718,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -729,7 +729,7 @@ unittest
         n => KRRegion!GCAllocator(max(n * 16, 1024 * 1024)))());
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
@@ -747,7 +747,7 @@ unittest
     assert(alloc.allocateAll().length == 1024 * 1024);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
@@ -780,7 +780,7 @@ unittest
     assert(b.length == 1024 * 1024 - KRRegion!().sizeof, text(b.length));
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     auto alloc = KRRegion!()(GCAllocator.instance.allocate(1024 * 1024));
@@ -791,7 +791,7 @@ unittest
     assert(p.length == 1024 * 1024);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks;
     import std.random;
@@ -833,7 +833,7 @@ unittest
     test(sizes32);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks;
     import std.random;

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -63,7 +63,7 @@ struct NullAllocator
     static shared NullAllocator instance;
 }
 
-unittest
+@system unittest
 {
     auto b = NullAllocator.instance.allocate(100);
     assert(b is null);

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -209,7 +209,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.free_tree : FreeTree;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -225,7 +225,7 @@ unittest
     assert(buf.ptr);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     alias MyAlloc = Quantizer!(GCAllocator,

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -327,7 +327,7 @@ struct Region(ParentAllocator = NullAllocator,
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -346,7 +346,7 @@ unittest
     // Destructor will free the memory
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     // Create a 64 KB region allocated with malloc
@@ -528,7 +528,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
 }
 
 ///
-unittest
+@system unittest
 {
     // 128KB region, allocated to x86's cache line
     InSituRegion!(128 * 1024, 16) r1;
@@ -562,7 +562,7 @@ unittest
     assert(a4.length == 104);
 }
 
-unittest
+@system unittest
 {
     InSituRegion!(4096, 1) r1;
     auto a = r1.allocate(2001);
@@ -752,7 +752,7 @@ version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
     }
 }
 
-version(Posix) unittest
+version(Posix) @system unittest
 {
     // Let's test the assumption that sbrk(n) returns the old address
     const p1 = sbrk(0);
@@ -764,7 +764,7 @@ version(Posix) unittest
     sbrk(-4096);
 }
 
-version(Posix) unittest
+version(Posix) @system unittest
 {
     import std.typecons : Ternary;
     alias alloc = SbrkRegion!(8).instance;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -17,7 +17,7 @@ simpler design combining $(D AllocatorList) with $(D Region) is recommended.
 */
 struct ScopedAllocator(ParentAllocator)
 {
-    unittest
+    @system unittest
     {
         testAllocator!(() => ScopedAllocator());
     }
@@ -191,7 +191,7 @@ struct ScopedAllocator(ParentAllocator)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;
@@ -202,13 +202,13 @@ unittest
     assert(alloc.empty == Ternary.no);
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     testAllocator!(() => ScopedAllocator!GCAllocator());
 }
 
-unittest // https://issues.dlang.org/show_bug.cgi?id=16046
+@system unittest // https://issues.dlang.org/show_bug.cgi?id=16046
 {
     import std.exception;
     import std.experimental.allocator;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -274,7 +274,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -342,7 +342,7 @@ if (Args.length > 3)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -654,7 +654,7 @@ public:
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.free_list : FreeList;
@@ -676,7 +676,7 @@ unittest
     assert(File(f).byLine.walkLength == 22);
 }
 
-unittest
+@system unittest
 {
     void test(Allocator)()
     {
@@ -712,7 +712,7 @@ unittest
         Options.all));
 }
 
-unittest
+@system unittest
 {
     void test(Allocator)()
     {

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -158,7 +158,7 @@ package void[] roundUpToAlignment(void[] b, uint a)
 }
 
 @nogc nothrow pure
-unittest
+@system unittest
 {
     void[] empty;
     assert(roundUpToAlignment(empty, 4) == null);
@@ -191,7 +191,7 @@ package void[] roundStartToMultipleOf(void[] s, uint base)
 }
 
 nothrow pure
-unittest
+@system unittest
 {
     void[] p;
     assert(roundStartToMultipleOf(p, 16) is null);
@@ -280,7 +280,7 @@ package uint effectiveAlignment(void* ptr)
 }
 
 @nogc nothrow pure
-unittest
+@system unittest
 {
     int x;
     assert(effectiveAlignment(&x) >= int.alignof);

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -8,7 +8,7 @@ D's built-in garbage-collected allocator.
 struct GCAllocator
 {
     import core.memory : GC;
-    unittest { testAllocator!(() => GCAllocator.instance); }
+    @system unittest { testAllocator!(() => GCAllocator.instance); }
 
     /**
     The alignment is a static constant equal to $(D platformAlignment), which
@@ -117,7 +117,7 @@ struct GCAllocator
 }
 
 ///
-unittest
+@system unittest
 {
     auto buffer = GCAllocator.instance.allocate(1024 * 1024 * 4);
     // deallocate upon scope's end (alternatively: leave it to collection)
@@ -125,13 +125,13 @@ unittest
     //...
 }
 
-unittest
+@system unittest
 {
     auto b = GCAllocator.instance.allocate(10_000);
     assert(GCAllocator.instance.expand(b, 1));
 }
 
-unittest
+@system unittest
 {
     import core.memory : GC;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -7,7 +7,7 @@ import std.experimental.allocator.common;
  */
 struct Mallocator
 {
-    unittest { testAllocator!(() => Mallocator.instance); }
+    @system unittest { testAllocator!(() => Mallocator.instance); }
 
     /**
     The alignment is a static constant equal to $(D platformAlignment), which
@@ -69,7 +69,7 @@ struct Mallocator
 
 ///
 @nogc nothrow
-unittest
+@system unittest
 {
     auto buffer = Mallocator.instance.allocate(1024 * 1024 * 4);
     scope(exit) Mallocator.instance.deallocate(buffer);
@@ -77,7 +77,7 @@ unittest
 }
 
 @nogc nothrow
-unittest
+@system unittest
 {
     @nogc nothrow
     static void test(A)()
@@ -92,7 +92,7 @@ unittest
 }
 
 @nogc nothrow
-unittest
+@system unittest
 {
     static void test(A)()
     {
@@ -203,7 +203,7 @@ version (Windows)
  */
 struct AlignedMallocator
 {
-    unittest { testAllocator!(() => typeof(this).instance); }
+    @system unittest { testAllocator!(() => typeof(this).instance); }
 
     /**
     The default alignment is $(D platformAlignment).
@@ -328,7 +328,7 @@ struct AlignedMallocator
 
 ///
 @nogc nothrow
-unittest
+@system unittest
 {
     auto buffer = AlignedMallocator.instance.alignedAllocate(1024 * 1024 * 4,
         128);
@@ -342,7 +342,7 @@ size_t addr(ref void* ptr) { return cast(size_t) ptr; }
 
 version(CRuntime_DigitalMars)
 @nogc nothrow
-unittest
+@system unittest
 {
     void* m;
 

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -69,7 +69,7 @@ struct MmapAllocator
     }
 }
 
-unittest
+@system unittest
 {
     alias alloc = MmapAllocator.instance;
     auto p = alloc.allocate(100);

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -36,7 +36,7 @@ D's allocators have a layered structure in both implementation and documentation
 
 $(OL
 $(LI A high-level, dynamically-typed layer (described further down in this
-module). It consists of an interface called $(LREF IAllocator), which concrete
+module). It consists of an interface called $(LREF IAllocator), which concret;
 allocators need to implement. The interface primitives themselves are oblivious
 to the type of the objects being allocated; they only deal in `void[]`, by
 necessity of the interface being dynamic (as opposed to type-parameterized).
@@ -200,7 +200,7 @@ public import std.experimental.allocator.common,
     std.experimental.allocator.typed;
 
 // Example in the synopsis above
-unittest
+@system unittest
 {
     import std.algorithm.comparison : min, max;
     import std.experimental.allocator.building_blocks.free_list : FreeList;
@@ -371,7 +371,7 @@ nothrow @safe @nogc @property void theAllocator(IAllocator a)
 }
 
 ///
-unittest
+@system unittest
 {
     // Install a new allocator that is faster for 128-byte allocations.
     import std.experimental.allocator.building_blocks.free_list : FreeList;
@@ -402,7 +402,7 @@ allocator can be cast to $(D shared).
     _processAllocator = a;
 }
 
-unittest
+@system unittest
 {
     assert(processAllocator);
     assert(processAllocator is theAllocator);
@@ -471,7 +471,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
 }
 
 ///
-unittest
+@system unittest
 {
     // Dynamically allocate one integer
     const int* p1 = theAllocator.make!int;
@@ -517,7 +517,7 @@ unittest
     assert(outer.x == inner.getX);
 }
 
-unittest // bugzilla 15639 & 15772
+@system unittest // bugzilla 15639 & 15772
 {
     abstract class Foo {}
     class Bar: Foo {}
@@ -525,7 +525,7 @@ unittest // bugzilla 15639 & 15772
     static assert( is(typeof(theAllocator.make!Bar)));
 }
 
-unittest
+@system unittest
 {
     void test(Allocator)(auto ref Allocator alloc)
     {
@@ -683,7 +683,7 @@ private void fillWithMemcpy(T)(void[] array, auto ref T filler) nothrow
     }
 }
 
-unittest
+@system unittest
 {
     int[] a;
     fillWithMemcpy(a, 42);
@@ -701,7 +701,7 @@ private T[] uninitializedFillDefault(T)(T[] array) nothrow
 }
 
 pure nothrow @nogc
-unittest
+@system unittest
 {
     static struct S { int x = 42; @disable this(this); }
 
@@ -711,7 +711,7 @@ unittest
     assert((cast(int*) arr.ptr)[0 .. arr.length] == expected);
 }
 
-unittest
+@system unittest
 {
     int[] a = [1, 2, 4];
     uninitializedFillDefault(a);
@@ -746,7 +746,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
     return () @trusted { return cast(T[]) uninitializedFillDefault(cast(U[]) m); }();
 }
 
-unittest
+@system unittest
 {
     void test1(A)(auto ref A alloc)
     {
@@ -848,7 +848,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length,
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     static void test(T)()
@@ -1045,7 +1045,7 @@ if (isInputRange!R && !isInfinite!R)
     }
 }
 
-unittest
+@system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1066,7 +1066,7 @@ unittest
 }
 
 // infer types for strings
-unittest
+@system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1225,7 +1225,7 @@ version(unittest)
     }
 }
 
-unittest
+@system unittest
 {
     import std.array : array;
     import std.range : iota;
@@ -1284,7 +1284,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
     return true;
 }
 
-unittest
+@system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1313,7 +1313,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
     return true;
 }
 
-unittest
+@system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1387,7 +1387,7 @@ if (isInputRange!R)
 }
 
 ///
-unittest
+@system unittest
 {
     auto arr = theAllocator.makeArray!int([1, 2, 3]);
     assert(theAllocator.expandArray(arr, 2));
@@ -1397,7 +1397,7 @@ unittest
     assert(arr == [1, 2, 3, 0, 0, 4, 5]);
 }
 
-unittest
+@system unittest
 {
     auto arr = theAllocator.makeArray!int([1, 2, 3]);
     ForcedInputRange r;
@@ -1471,7 +1471,7 @@ bool shrinkArray(T, Allocator)(auto ref Allocator alloc,
 }
 
 ///
-unittest
+@system unittest
 {
     int[] a = theAllocator.makeArray!int(100, 42);
     assert(a.length == 100);
@@ -1480,7 +1480,7 @@ unittest
     assert(a == [42, 42]);
 }
 
-unittest
+@system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1548,7 +1548,7 @@ void dispose(A, T)(auto ref A alloc, T[] array)
     alloc.deallocate(array);
 }
 
-unittest
+@system unittest
 {
     static int x;
     static interface I
@@ -1586,7 +1586,7 @@ unittest
     theAllocator.dispose(arr);
 }
 
-unittest //bugzilla 15721
+@system unittest //bugzilla 15721
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -1629,7 +1629,7 @@ auto makeMultidimensionalArray(uint n, T, Allocator)(auto ref Allocator alloc, s
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -1672,7 +1672,7 @@ void disposeMultidimensionalArray(Allocator, T)(auto ref Allocator alloc, T[] ar
 }
 
 ///
-unittest
+@system unittest
 {
     struct TestAllocator
     {
@@ -1802,7 +1802,7 @@ CAllocatorImpl!(A, Yes.indirect) allocatorObject(A)(A* pa)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     IAllocator a = allocatorObject(Mallocator.instance);
@@ -2009,7 +2009,7 @@ class CAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
 }
 
 // Example in intro above
-unittest
+@system unittest
 {
     // Allocate an int, initialize it with 42
     int* p = theAllocator.make!int(42);

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -39,7 +39,7 @@ alias StackFront(size_t stackSize, Allocator = GCAllocator) =
         Allocator);
 
 ///
-unittest
+@system unittest
 {
     StackFront!4096 a;
     auto b = a.allocate(4000);
@@ -84,7 +84,7 @@ auto mmapRegionList(size_t bytesPerRegion)
 }
 
 ///
-unittest
+@system unittest
 {
     auto alloc = mmapRegionList(1024 * 1024);
     const b = alloc.allocate(100);

--- a/std/experimental/allocator/typed.d
+++ b/std/experimental/allocator/typed.d
@@ -391,7 +391,7 @@ struct TypedAllocator(PrimaryAllocator, Policies...)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -122,7 +122,7 @@ if (!moduleName.length)
 }
 
 ///
-unittest
+@system unittest
 {
     static assert(moduleLogLevel!"" == LogLevel.all);
 }
@@ -148,7 +148,7 @@ if (moduleName.length)
 }
 
 ///
-unittest
+@system unittest
 {
     static assert(moduleLogLevel!"not.amodule.path" == LogLevel.all);
 }
@@ -667,7 +667,7 @@ private void formatString(A...)(MsgRange oRange, A args)
     }
 }
 
-unittest
+@system unittest
 {
     void dummy() @safe
     {
@@ -1800,7 +1800,7 @@ functions.
 }
 
 /// Ditto
-unittest
+@system unittest
 {
     import std.experimental.logger.filelogger : FileLogger;
     import std.file : deleteme, remove;
@@ -2083,7 +2083,7 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(l.logLevel == LogLevel.all);
 }
 
-unittest // default logger
+@system unittest // default logger
 {
     import std.file : deleteme, exists, remove;
     import std.stdio : File;
@@ -2123,7 +2123,7 @@ unittest // default logger
     file.close();
 }
 
-unittest
+@system unittest
 {
     import std.file : deleteme, remove;
     import std.stdio : File;
@@ -2960,7 +2960,7 @@ unittest
     assert(tl.msg.indexOf("error") == 0);
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     auto tl = new TestLogger();
@@ -2968,7 +2968,7 @@ unittest
 }
 
 // log objects with non-safe toString
-unittest
+@system unittest
 {
     struct Test
     {
@@ -2999,7 +2999,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 
 // check that thread-local logging does not propagate
 // to shared logger
-unittest
+@system unittest
 {
     import std.concurrency, core.atomic, core.thread;
 
@@ -3083,7 +3083,7 @@ unittest
 }
 
 // Ensure @system toString methods work
-unittest
+@system unittest
 {
     enum SystemToStringMsg = "SystemToString";
     static struct SystemToString

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -129,7 +129,7 @@ class FileLogger : Logger
     private string filename;
 }
 
-unittest
+@system unittest
 {
     import std.file : deleteme, remove;
     import std.array : empty;
@@ -158,7 +158,7 @@ unittest
     assert(readLine.indexOf(notWritten) == -1, readLine);
 }
 
-unittest
+@system unittest
 {
     import std.file : deleteme, remove;
     import std.array : empty;

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -140,7 +140,7 @@ class MultiLogger : Logger
 }
 
 // Issue #16
-unittest
+@system unittest
 {
     import std.file : deleteme;
     import std.stdio : File;

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -70,7 +70,7 @@ template PtrTuple(Names...)
 }
 
 // ISSUE 16501
-unittest
+@system unittest
 {
     import std.experimental.ndslice;
     alias sab = sliced!("a", "b");
@@ -320,7 +320,7 @@ template isMemory(T)
         enum isMemory = false;
 }
 
-unittest
+@system unittest
 {
     import std.experimental.ndslice.slice : PtrTuple;
     import std.experimental.ndslice.selection : Map;
@@ -444,7 +444,7 @@ bool isPermutation(size_t N)(auto ref in size_t[N] perm)
     return isValidPartialPermutationImpl(perm, mask);
 }
 
-unittest
+@system unittest
 {
     assert(isPermutation([0, 1]));
     // all numbers 0..N-1 need to be part of the permutation
@@ -511,7 +511,7 @@ size_t lengthsProduct(size_t N)(auto ref in size_t[N] lengths)
     return length;
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     const size_t[3] lengths = [3, 4, 5];
     assert(lengthsProduct(lengths) == 60);

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -574,7 +574,7 @@ body
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = [1, 2, 3, 4].sliced(2, 2);
@@ -679,7 +679,7 @@ body
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -316,7 +316,7 @@ public import std.experimental.ndslice.slice;
 public import std.experimental.ndslice.iteration;
 public import std.experimental.ndslice.selection;
 
-unittest
+@system unittest
 {
     auto matrix = new double[12].sliced(3, 4);
     matrix[] = 0;
@@ -329,7 +329,7 @@ unittest
 }
 
 // relaxed example
-unittest
+@system unittest
 {
     static Slice!(3, ubyte*) movingWindowByChannel
     (Slice!(3, ubyte*) image, size_t nr, size_t nc, ubyte delegate(Slice!(2, ubyte*)) filter)
@@ -414,7 +414,7 @@ unittest
     assert(t1.equal(iota(12, 18)));
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.array : array;
@@ -519,7 +519,7 @@ pure nothrow unittest
     assert(t0.length!3 == 40);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.internal : Iota;
     import std.meta : AliasSeq;
@@ -543,14 +543,14 @@ pure nothrow unittest
     auto slice = im.sliced(2, 3);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto tensor = new int[3 * 4 * 8].sliced(3, 4, 8);
     assert(&(tensor.back.back.back()) is &tensor[2, 3, 7]);
     assert(&(tensor.front.front.front()) is &tensor[0, 0, 0]);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : pack;
     auto slice = new int[24].sliced(2, 3, 4);
@@ -560,7 +560,7 @@ pure nothrow unittest
     assert(slice[1, 2, 3] == 4);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto ar = new int[3 * 8 * 9];
 

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -186,7 +186,7 @@ Slice!(N, Range).PureThis unpack(size_t N, Range)(Slice!(N, Range) slice)
 }
 
 ///
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     auto a = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
     auto b = a.pack!(2, 3).unpack();
@@ -242,7 +242,7 @@ evertPack(size_t N, Range)(Slice!(N, Range) slice)
 }
 
 ///
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration : transposed;
@@ -354,7 +354,7 @@ Slice!(1, Range) diagonal(size_t N, Range)(Slice!(N, Range) slice)
 }
 
 /// Loop through diagonal
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
 
@@ -508,7 +508,7 @@ body
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 8);
@@ -534,7 +534,7 @@ pure nothrow unittest
 }
 
 /// Diagonal blocks
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 8);
@@ -565,7 +565,7 @@ pure nothrow unittest
 }
 
 /// Matrix divided into vertical blocks
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 13);
@@ -628,7 +628,7 @@ body
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 8);
@@ -647,7 +647,7 @@ pure nothrow unittest
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 8);
@@ -667,7 +667,7 @@ pure nothrow unittest
 }
 
 /// Multi-diagonal matrix
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(8, 8);
@@ -691,7 +691,7 @@ pure nothrow unittest
 }
 
 /// Sliding window over matrix columns
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(5, 8);
@@ -715,7 +715,7 @@ pure nothrow unittest
 }
 
 /// Overlapping blocks using windows
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     //  ----------------
     // |  0  1  2  3  4 |
@@ -795,7 +795,7 @@ Slice!(M, Range) reshape
          [ 2,  1, 0]]);
 }
 
-pure unittest
+pure @system unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration : reversed;
@@ -836,7 +836,7 @@ pure unittest
 }
 
 // Issue 15919
-unittest
+@safe unittest
 {
     assert(iotaSlice(3, 4, 5, 6, 7).pack!2.reshape(4, 3, 5)[0, 0, 0].shape == cast(size_t[2])[6, 7]);
 }
@@ -855,7 +855,7 @@ unittest
     assertThrown!ReshapeException(e.reshape(1));
 }
 
-unittest
+@safe unittest
 {
     auto pElements = iotaSlice(3, 4, 5, 6, 7)
         .pack!2
@@ -987,7 +987,7 @@ nothrow @safe pure unittest
 }
 
 /// Reshaping with memory allocation
-pure unittest
+pure @system unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration : reversed;
@@ -1057,7 +1057,7 @@ nothrow @nogc @safe pure unittest
     assert(err == ReshapeError.empty);
 }
 
-unittest
+@safe unittest
 {
     auto pElements = iotaSlice(3, 4, 5, 6, 7)
         .pack!2
@@ -1383,7 +1383,7 @@ auto byElement(size_t N, Range)(Slice!(N, Range) slice)
 }
 
 /// Properties
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     auto elems = iotaSlice(3, 4).byElement;
 
@@ -1397,7 +1397,7 @@ pure nothrow unittest
 }
 
 /// Index property
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = new long[20].sliced(5, 4);
@@ -1415,7 +1415,7 @@ pure nothrow unittest
          [40, 43, 46, 49]]);
 }
 
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     // test save
     import std.range : dropOne;
@@ -1430,7 +1430,7 @@ pure nothrow unittest
 /++
 Random access and slicing
 +/
-@nogc nothrow unittest
+@nogc nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     import std.algorithm.comparison : equal;
@@ -1563,7 +1563,7 @@ Use $(SUBREF iteration, allReversed) in pipeline before
 }
 
 // Issue 15549
-unittest
+@safe unittest
 {
     import std.range.primitives;
     alias A = typeof(iotaSlice(2, 5).sliced(1, 1, 1, 1));
@@ -1577,7 +1577,7 @@ unittest
 }
 
 // Issue 16010
-unittest
+@safe unittest
 {
     auto s = iotaSlice(3, 4).byElement;
     foreach (_; 0 .. s.length)
@@ -1685,7 +1685,7 @@ auto byElementInStandardSimplex(size_t N, Range)(Slice!(N, Range) slice, size_t 
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     auto slice = slice!int(4, 5);
@@ -1702,7 +1702,7 @@ pure nothrow unittest
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice;
     import std.experimental.ndslice.iteration;
@@ -1832,7 +1832,7 @@ if (N)
     alias IndexSlice = Slice!(N, IndexMap);
 }
 
-unittest
+@safe unittest
 {
     auto r = indexSlice(1);
     import std.range.primitives : isRandomAccessRange;
@@ -1994,7 +1994,7 @@ Slice!(M, Slice!(N + 1, Range)) repeatSlice(size_t N, Range, size_t M)(Slice!(N,
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice : slice;
 
@@ -2159,7 +2159,7 @@ if (fun.length)
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -2168,7 +2168,7 @@ pure nothrow unittest
                  [ 9, 12, 15]]);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -2176,7 +2176,7 @@ pure nothrow unittest
 }
 
 /// Packed tensors.
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice, windows;
 
@@ -2200,7 +2200,7 @@ pure nothrow unittest
     assert(s == [[8, 12]]);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice, windows;
 
@@ -2219,7 +2219,7 @@ pure nothrow unittest
 }
 
 /// Zipped tensors
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.slice : assumeSameStructure;
     import std.experimental.ndslice.selection : iotaSlice;
@@ -2247,7 +2247,7 @@ Multiple functions can be passed to `mapSlice`.
 In that case, the element type of `mapSlice` is a tuple containing
 one element for each function.
 +/
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -2268,7 +2268,7 @@ pure nothrow unittest
 /++
 You may alias `mapSlice` with some function(s) to a symbol and use it separately:
 +/
-pure nothrow unittest
+pure nothrow @safe unittest
 {
     import std.conv : to;
     import std.experimental.ndslice.selection : iotaSlice;

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -222,7 +222,7 @@ if (!isStaticArray!Range && !isNarrowString!Range && hasLength!Range)
 }
 
 /// Creates a slice from an array.
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto slice = slice!int(5, 6, 7);
     assert(slice.length == 5);
@@ -249,7 +249,7 @@ pure nothrow unittest
 }
 
 /// $(LINK2 https://en.wikipedia.org/wiki/Vandermonde_matrix, Vandermonde matrix)
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto vandermondeMatrix(Slice!(1, double*) x)
     {
@@ -274,7 +274,7 @@ pure nothrow unittest
 Creates a slice composed of named elements, each one of which corresponds
 to a given argument. See also $(LREF assumeSameStructure).
 +/
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.experimental.ndslice.selection : byElement;
@@ -296,7 +296,7 @@ pure nothrow unittest
 }
 
 /// Random access range primitives for slices over user defined types
-pure nothrow @nogc unittest
+pure nothrow @nogc @system unittest
 {
     struct MyIota
     {
@@ -320,7 +320,7 @@ pure nothrow @nogc unittest
 }
 
 /// Slice tuple and flags
-pure nothrow @nogc unittest
+pure nothrow @nogc @system unittest
 {
     import std.typecons : Yes, No;
     static immutable a = [1, 2, 3, 4, 5, 6];
@@ -332,7 +332,7 @@ pure nothrow @nogc unittest
 }
 
 // sliced slice
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
     auto data = new int[24];
@@ -362,7 +362,7 @@ pure nothrow unittest
     assert(f == iotaSlice(5, 3));
 }
 
-nothrow unittest
+nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -474,7 +474,7 @@ if (Names.length && !anySatisfy!(isType, Names) && allSatisfy!(isStringValue, Na
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.experimental.ndslice.selection : byElement, iotaSlice;
@@ -580,7 +580,7 @@ auto slice(
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto tensor = slice!int(5, 6, 7);
     assert(tensor.length == 5);
@@ -593,14 +593,14 @@ pure nothrow unittest
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto tensor = slice([2, 3], 5);
     assert(tensor.elementsCount == 2 * 3);
     assert(tensor[1, 1] == 5);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
     auto tensor = iotaSlice(2, 3).slice;
@@ -626,7 +626,7 @@ auto uninitializedSlice(T,
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto tensor = uninitializedSlice!int(5, 6, 7);
     assert(tensor.length == 5);
@@ -699,7 +699,7 @@ makeSlice(T,
 }
 
 ///
-@nogc unittest
+@nogc @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
@@ -720,7 +720,7 @@ makeSlice(T,
 }
 
 /// Initialization with default value
-@nogc unittest
+@nogc @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
@@ -731,7 +731,7 @@ makeSlice(T,
     Mallocator.instance.dispose(tup.array);
 }
 
-@nogc unittest
+@nogc @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
@@ -767,7 +767,7 @@ makeUninitializedSlice(T,
 }
 
 ///
-@nogc unittest
+@nogc @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
@@ -814,7 +814,7 @@ auto ndarray(size_t N, Range)(Slice!(N, Range) slice)
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
     auto slice = iotaSlice(3, 4);
@@ -849,7 +849,7 @@ auto makeNdarray(T, Allocator, size_t N, Range)(auto ref Allocator alloc,  Slice
 }
 
 ///
-@nogc unittest
+@nogc @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.mallocator;
@@ -896,7 +896,7 @@ auto shape(T)(T[] array) @property
     assertThrown([[1, 2], [4, 5, 6]].shape);
 }
 
-unittest
+@system unittest
 {
     auto array = [[1, 2, 3], [4, 5, 6]];
     auto slice = array.shape.slice!int;
@@ -960,7 +960,7 @@ nothrow @safe pure unittest
 }
 
 /// Slice from ndarray
-nothrow unittest
+nothrow @system unittest
 {
     int err;
     auto array = [[1, 2, 3], [4, 5, 6]];
@@ -1008,7 +1008,7 @@ template as(T)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.experimental.ndslice.slice : as;
     import std.experimental.ndslice.selection : diagonal;
@@ -1052,7 +1052,7 @@ Returns the element type of the `Slice` type.
 alias DeepElementType(S : Slice!(N, Range), size_t N, Range) = S.DeepElemType;
 
 ///
-unittest
+@system unittest
 {
     import std.range : iota;
     static assert(is(DeepElementType!(Slice!(4, const(int)[]))     == const(int)));
@@ -1408,7 +1408,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     static if (doUnittest)
     /// Creates a 2-dimentional slice with custom strides.
     @nogc nothrow pure
-    unittest
+    @system unittest
     {
         import std.experimental.ndslice.selection : byElement;
         import std.algorithm.comparison : equal;
@@ -1455,7 +1455,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     ///
-    unittest
+    @system unittest
     {
         Slice!(2, double*) nn;
         Slice!(2, immutable(double)*) ni;
@@ -1484,7 +1484,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     }
 
     static if (doUnittest)
-    unittest
+    @system unittest
     {
         Slice!(2, Slice!(2, double*)) nn;
         Slice!(2, Slice!(2, immutable(double)*)) ni;
@@ -1626,7 +1626,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     /// Pointer type.
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
          //slice type is `Slice!(2, int*)`
          auto slice = slice!int(2, 3).save;
@@ -1933,7 +1933,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     ///
-    unittest
+    @system unittest
     {
         import std.experimental.ndslice.selection : iotaSlice;
         auto s = iotaSlice(2, 3);
@@ -2039,7 +2039,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     ///
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         auto a = [1, 2, 3, 4].sliced(2, 2);
 
@@ -2054,7 +2054,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     }
 
     static if (doUnittest)
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         import std.experimental.ndslice.iteration : dropExactly;
         import std.experimental.ndslice.selection : iotaSlice;
@@ -2095,7 +2095,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     static if (doUnittest)
     ///
     pure nothrow
-    unittest
+    @system unittest
     {
         import std.experimental.ndslice.iteration : allReversed;
         import std.experimental.ndslice.selection : iotaSlice;
@@ -2281,7 +2281,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     ///
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         auto slice = slice!int(5, 2);
 
@@ -2299,7 +2299,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     }
 
     static if (doUnittest)
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         // check with different PureN
         import std.experimental.ndslice.selection : pack, iotaSlice;
@@ -2364,7 +2364,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
     static if (doUnittest)
     ///
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         auto slice = slice!int(5, 3);
 
@@ -2378,7 +2378,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
     }
 
     static if (doUnittest)
-    pure nothrow unittest
+    pure nothrow @system unittest
     {
         auto slice = slice!(int, No.replaceArrayWithPointer)(5, 3);
 
@@ -2407,7 +2407,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
             auto b = [1, 2, 3, 4].sliced(2, 2);
@@ -2428,7 +2428,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Left slice is packed
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks, iotaSlice;
             auto a = slice!size_t(4, 4);
@@ -2443,7 +2443,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Both slices are packed
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks, iotaSlice, pack;
             auto a = slice!size_t(4, 4);
@@ -2457,7 +2457,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
             auto b = [1, 2, 3, 4].sliced(2, 2);
@@ -2491,7 +2491,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
             auto b = [[1, 2], [3, 4]];
@@ -2514,7 +2514,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Packed slices
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks;
             auto a = slice!int(4, 4);
@@ -2528,7 +2528,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
             auto b = [[1, 2], [3, 4]];
@@ -2565,7 +2565,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2590,7 +2590,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Packed slices have the same behavior.
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : pack;
             auto a = slice!int(2, 3).pack!1;
@@ -2600,7 +2600,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2634,7 +2634,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2643,7 +2643,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2652,7 +2652,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced(2, 3);
 
@@ -2661,7 +2661,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
 
@@ -2680,7 +2680,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2689,7 +2689,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced(2, 3);
 
@@ -2698,7 +2698,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2707,7 +2707,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
 
@@ -2730,7 +2730,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
             auto b = [1, 2, 3, 4].sliced(2, 2);
@@ -2750,7 +2750,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Left slice is packed
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks, iotaSlice;
             auto a = slice!size_t(4, 4);
@@ -2765,7 +2765,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Both slices are packed
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks, iotaSlice, pack;
             auto a = slice!size_t(4, 4);
@@ -2779,7 +2779,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
             auto b = [1, 2, 3, 4].sliced(2, 2);
@@ -2813,7 +2813,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2832,7 +2832,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Packed slices
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : blocks;
             auto a = slice!int(4, 4);
@@ -2847,7 +2847,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         /// Packed slices have the same behavior.
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             import std.experimental.ndslice.selection : pack;
             auto a = slice!int(2, 3).pack!1;
@@ -2857,7 +2857,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2890,7 +2890,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2905,7 +2905,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2932,7 +2932,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -2942,14 +2942,14 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         // Issue 16473
         static if (doUnittest)
-        unittest
+        @system unittest
         {
             auto sl = slice!double(2, 5);
             auto d = -sl[0, 1];
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -2958,7 +2958,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced(2, 3);
 
@@ -2967,7 +2967,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
 
@@ -3001,7 +3001,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 
         static if (doUnittest)
         ///
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!int(2, 3);
 
@@ -3013,7 +3013,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
         }
 
         static if (doUnittest)
-        pure nothrow unittest
+        pure nothrow @system unittest
         {
             auto a = slice!(int, No.replaceArrayWithPointer)(2, 3);
 
@@ -3029,7 +3029,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
 /++
 Slicing, indexing, and arithmetic operations.
 +/
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.iteration : transposed;
     import std.experimental.ndslice.selection : iotaSlice;
@@ -3062,7 +3062,7 @@ pure nothrow unittest
 /++
 Operations with rvalue slices.
 +/
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.iteration : transposed, everted;
 
@@ -3095,7 +3095,7 @@ pure nothrow unittest
 Creating a slice from text.
 See also $(MREF std, format).
 +/
-unittest
+@system unittest
 {
     import std.algorithm,  std.conv, std.exception, std.format,
         std.functional, std.string, std.range;
@@ -3140,7 +3140,7 @@ unittest
 }
 
 // Operator overloading. # 1
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -3159,7 +3159,7 @@ pure nothrow unittest
 }
 
 // Operator overloading. # 2
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.algorithm.iteration : map;
     import std.array : array;
@@ -3182,7 +3182,7 @@ pure nothrow unittest
 }
 
 // Operator overloading. # 3
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.selection : iotaSlice;
 
@@ -3203,7 +3203,7 @@ pure nothrow unittest
 }
 
 // Type deduction
-unittest
+@system unittest
 {
     // Arrays
     foreach (T; AliasSeq!(int, const int, immutable int))
@@ -3226,7 +3226,7 @@ unittest
 }
 
 // Test for map #1
-unittest
+@system unittest
 {
     import std.algorithm.iteration : map;
     import std.range.primitives;
@@ -3248,7 +3248,7 @@ unittest
 }
 
 // Test for map #2
-unittest
+@system unittest
 {
     import std.algorithm.iteration : map;
     import std.range.primitives;
@@ -3334,7 +3334,7 @@ if (NL >= NR)
     _indexAssign!(false, op)(ls, rs);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.experimental.ndslice.iteration : dropExactly;
     import std.experimental.ndslice.selection : byElement;
@@ -3369,7 +3369,7 @@ if (!is(T : Slice!(NR, RangeR), size_t NR, RangeR))
     _indexAssign!(false, op)(ls, rs);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import std.internal.test.dummyrange;
     foreach (RB; AliasSeq!(ReturnBy.Reference, ReturnBy.Value))
@@ -3389,7 +3389,7 @@ pure nothrow unittest
 }
 
 // toHash test
-unittest
+@system unittest
 {
     import std.conv : to;
     import std.complex;
@@ -3415,7 +3415,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     int[] arr = [1, 2, 3];
     auto ptr = arr.ptrShell;
@@ -3426,7 +3426,7 @@ unittest
     assert(ptrCopy[0] == 2);
 }
 
-pure nothrow unittest
+pure nothrow @system unittest
 {
     auto a = new int[20], b = new int[20];
     alias T = PtrTuple!("a", "b");

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -58,7 +58,7 @@ if (is(T == class) || is(T == interface))
     }
 }
 
-unittest
+@system unittest
 {
     class C { @disable opCast(T)() {} }
     auto c = new C;
@@ -131,7 +131,7 @@ if (Targets.length >= 1 && !allSatisfy!(isMutable, Targets))
     alias implementsInterface = .implementsInterface!(Source, staticMap!(Unqual, Targets));
 }
 
-unittest
+@safe unittest
 {
     interface Foo {
         void foo();
@@ -377,7 +377,7 @@ private template wrapperSignature(alias fun)
         ~ name~"("~wrapperParameters~")"~mod;
 }
 
-unittest
+@safe unittest
 {
     interface M
     {
@@ -429,7 +429,7 @@ version(StdDdoc)
 }
 
 ///
-unittest
+@system unittest
 {
     interface Quack
     {
@@ -510,7 +510,7 @@ unittest
 }
 
 ///
-unittest
+@system unittest
 {
     import std.traits : functionAttributes, FunctionAttribute;
     interface A { int run(); }
@@ -611,7 +611,7 @@ template unwrap(Target)
     }
 }
 
-unittest
+@system unittest
 {
     // Validate const/immutable
     class A
@@ -658,7 +658,7 @@ unittest
         assert(d.draw(10) == 10);
     }
 }
-unittest
+@system unittest
 {
     // Bugzilla 10377
     import std.range, std.algorithm;
@@ -675,7 +675,7 @@ unittest
     auto r = iota(0,10,1).inputRangeObject().wrap!(MyInputRange!int)();
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 }
-unittest
+@system unittest
 {
     // Bugzilla 10536
     interface Interface
@@ -691,7 +691,7 @@ unittest
     Interface i = new Pluggable().wrap!Interface;
     assert(i.foo() == 1);
 }
-unittest
+@system unittest
 {
     // Enhancement 10538
     interface Interface

--- a/std/file.d
+++ b/std/file.d
@@ -203,7 +203,7 @@ private T cenforce(T)(T condition, const(char)[] name, const(FSChar)* namez,
     throw new FileException(name, .errno, file, line);
 }
 
-unittest
+@safe unittest
 {
     // issue 17102
     try
@@ -3438,7 +3438,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
     assert(readText(t2.byChar) == "2");
 }
 
-@safe version(Posix) unittest //issue 11434
+@safe version(Posix) @safe unittest //issue 11434
 {
     import std.conv : octal;
     auto t1 = deleteme, t2 = deleteme~"2";

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1685,7 +1685,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 }
 
 // throw on duplicate options
-unittest
+@system unittest
 {
     import core.exception;
     auto args = ["prog", "--abc", "1"];

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -16,7 +16,7 @@ COREREF = $(HTTP dlang.org/phobos/core_$1.html#$2, $(D core.$1.$2))
 module std.internal.cstring;
 
 ///
-unittest
+@safe unittest
 {
     version(Posix)
     {
@@ -220,7 +220,7 @@ if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
 }
 
 ///
-nothrow @nogc unittest
+nothrow @nogc @system unittest
 {
     import core.stdc.string;
 
@@ -255,7 +255,7 @@ nothrow @nogc unittest
 }
 
 // Bugzilla 14980
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     const(char[]) str = null;
     auto res = tempCString(str);

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -970,7 +970,7 @@ inout(BigDigit) [] removeLeadingZeros(inout(BigDigit) [] x) pure nothrow @safe
     return x[0 .. k];
 }
 
-pure unittest
+pure @system unittest
 {
    BigUint r = BigUint([5]);
    BigUint t = BigUint([7]);
@@ -992,7 +992,7 @@ pure unittest
 
 
 // Pow tests
-pure unittest
+pure @system unittest
 {
     BigUint r, s;
     r.fromHexString("80000000_00000001");
@@ -1541,7 +1541,7 @@ void divModInternal(BigDigit [] quotient, BigDigit[] remainder, const BigDigit [
     () @trusted { GC.free(un.ptr); GC.free(vn.ptr); } ();
 }
 
-pure unittest
+pure @system unittest
 {
     immutable(uint) [] u = [0, 0xFFFF_FFFE, 0x8000_0000];
     immutable(uint) [] v = [0xFFFF_FFFF, 0x8000_0000];
@@ -2496,7 +2496,7 @@ pure nothrow
     () @trusted { GC.free(scratch.ptr); } ();
 }
 
-unittest
+@system unittest
 {
     import core.stdc.stdio;
 
@@ -2533,7 +2533,7 @@ unittest
 }
 
 // biguintToOctal
-unittest
+@safe unittest
 {
     enum bufSize = 5 * BigDigitBits / 3 + 1;
     auto buf = new char[bufSize];

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -48,7 +48,7 @@ uint multibyteAddSub(char op)(uint[] dest, const(uint) [] src1,
     return cast(uint) c;
 }
 
-unittest
+@safe unittest
 {
     uint [] a = new uint[40];
     uint [] b = new uint[40];
@@ -167,7 +167,7 @@ void multibyteShr(uint [] dest, const(uint) [] src, uint numbits)
    }
 }
 
-unittest
+@safe unittest
 {
 
     uint [] aa = [0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -204,7 +204,7 @@ uint multibyteMul(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
     return cast(uint) c;
 }
 
-unittest
+@safe unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A,
         0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -241,7 +241,7 @@ uint multibyteMulAdd(char op)(uint [] dest, const(uint)[] src,
     return cast(uint) c;
 }
 
-unittest
+@safe unittest
 {
 
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A,
@@ -296,7 +296,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
     return cast(uint) c;
 }
 
-unittest
+@safe unittest
 {
     uint [] aa = new uint[101];
     for (uint i = 0; i < aa.length; ++i)

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -91,7 +91,7 @@ string indexedLoopUnroll(int n, string s) pure @safe
     }
     return u;
 }
-unittest
+@safe unittest
 {
     assert(indexedLoopUnroll(3, "@*23;")=="0*23;1*23;2*23;");
 }
@@ -177,7 +177,7 @@ done:
     }
 }
 
-unittest
+@system unittest
 {
     uint [] a = new uint[40];
     uint [] b = new uint[40];
@@ -522,7 +522,7 @@ L_last:
     }
 }
 
-unittest
+@system unittest
 {
 
     uint [] aa = [0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -624,7 +624,7 @@ L_odd:
     }
 }
 
-unittest
+@system unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
     multibyteMul(aa[1..4], aa[1..4], 16, 0);
@@ -795,7 +795,7 @@ L_enter_odd:
     mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd(OP, "ESP+LASTPARAM") ~ "}");
 }
 
-unittest
+@system unittest
 {
 
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -1015,7 +1015,7 @@ Lc:
     }
 }
 
-unittest
+@system unittest
 {
     uint [] aa = new uint[101];
     for (int i=0; i<aa.length; ++i) aa[i] = 0x8765_4321 * (i+3);
@@ -1068,7 +1068,7 @@ L1:
     }
 }
 
-unittest
+@system unittest
 {
     uint [] aa = new uint[13];
         uint [] bb = new uint[6];
@@ -1212,7 +1212,7 @@ L_enter_odd:
     mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
 }
 
-unittest
+@system unittest
 {
    uint [] aa = new uint[200];
    uint [] a  = aa[0..100];

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -209,7 +209,7 @@ real erf(real x)
     return x * rationalPoly(z, T, U);
 }
 
-unittest
+@safe unittest
 {
    // High resolution test points.
     enum real erfc0_250 = 0.723663330078125 + 1.0279753638067014931732235184287934646022E-5;
@@ -344,7 +344,7 @@ real normalDistributionImpl(real a)
     }
 }
 
-unittest
+@safe unittest
 {
 assert(fabs(normalDistributionImpl(1L) - (0.841344746068543))< 0.0000000000000005);
 assert(isIdentical(normalDistributionImpl(NaN(0x325)), NaN(0x325)));
@@ -469,7 +469,7 @@ static immutable real[8] Q3 =
 }
 
 
-unittest
+@safe unittest
 {
     // TODO: Use verified test points.
     // The values below are from Excel 2003.

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -380,7 +380,7 @@ real gamma(real x)
     return z * poly( x, GammaNumeratorCoeffs ) / poly( x, GammaDenominatorCoeffs );
 }
 
-unittest
+@safe unittest
 {
     // gamma(n) = factorial(n-1) if n is an integer.
     real fact = 1.0L;
@@ -524,7 +524,7 @@ real logGamma(real x)
     return q ;
 }
 
-unittest
+@safe unittest
 {
     assert(isIdentical(logGamma(NaN(0xDEF)), NaN(0xDEF)));
     assert(logGamma(real.infinity) == real.infinity);
@@ -990,7 +990,7 @@ done:
     return x;
 }
 
-unittest { // also tested by the normal distribution
+@safe unittest { // also tested by the normal distribution
     // check NaN propagation
     assert(isIdentical(betaIncomplete(NaN(0xABC),2,3), NaN(0xABC)));
     assert(isIdentical(betaIncomplete(7,NaN(0xABC),3), NaN(0xABC)));
@@ -1552,7 +1552,7 @@ ihalve:
     return x;
 }
 
-unittest
+@safe unittest
 {
 //Values from Excel's GammaInv(1-p, x, 1)
 assert(fabs(gammaIncompleteComplInv(1, 0.5) - 0.693147188044814) < 0.00000005);
@@ -1675,7 +1675,7 @@ done:
     return y;
 }
 
-unittest
+@safe unittest
 {
     // Exact values
     assert(digamma(1.0)== -EULERGAMMA);
@@ -1735,7 +1735,7 @@ real logmdigamma(real x)
     return x == s ? y + 0.5L/s : (log(x/s) + 0.5L/s + y + w);
 }
 
-unittest
+@safe unittest
 {
     assert(logmdigamma(-5.0).isNaN());
     assert(isIdentical(logmdigamma(NaN(0xABC)), NaN(0xABC)));
@@ -1788,7 +1788,7 @@ real logmdigammaInverse(real y)
     return y; //NaN
 }
 
-unittest
+@safe unittest
 {
     import std.typecons;
     //WolframAlpha, 22.02.2015

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -128,7 +128,7 @@ if (isAssignable!T &&
         this.bufLen = cast(uint) buf.length;
     }
 
-    unittest
+    @system unittest
     {
         ubyte[10] tmpbuf = void;
         auto sbuf = ScopeBuffer!ubyte(tmpbuf);
@@ -289,7 +289,7 @@ if (isAssignable!T &&
     }
 }
 
-unittest
+@system unittest
 {
     import core.stdc.stdio;
     import std.range;
@@ -332,7 +332,7 @@ unittest
 
 }
 
-unittest
+@system unittest
 {
     string cat(string s1, string s2)
     {
@@ -350,7 +350,7 @@ unittest
 }
 
 // const
-unittest
+@system unittest
 {
     char[10] tmpbuf = void;
     auto textbuf = ScopeBuffer!char(tmpbuf);
@@ -377,14 +377,14 @@ auto scopeBuffer(T)(T[] tmpbuf)
 }
 
 ///
-unittest
+@system unittest
 {
     ubyte[10] tmpbuf = void;
     auto sb = scopeBuffer(tmpbuf);
     scope(exit) sb.free();
 }
 
-unittest
+@system unittest
 {
     ScopeBuffer!(int*) b;
     int*[] s;

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -303,7 +303,7 @@ class ReferenceBidirectionalRange(T) : ReferenceForwardRange!T
     final void popBack(){_payload.popBack();}
 }
 
-unittest
+@safe unittest
 {
     static assert(isInputRange!(ReferenceInputRange!int));
     static assert(isInputRange!(ReferenceInfiniteInputRange!int));
@@ -417,7 +417,7 @@ if (is(T == TestFoo))
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota, retro, repeat;

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -135,7 +135,7 @@ real sgnGamma(real x)
     return n & 1 ? 1.0 : -1.0;
 }
 
-unittest
+@safe unittest
 {
     assert(sgnGamma(5.0) == 1.0);
     assert(isNaN(sgnGamma(-3.0)));
@@ -159,7 +159,7 @@ real beta(real x, real y)
     } else return gamma(x) * gamma(y) / gamma(x+y);
 }
 
-unittest
+@safe unittest
 {
     assert(isIdentical(beta(NaN(0xABC), 4), NaN(0xABC)));
     assert(isIdentical(beta(2, NaN(0xABC)), NaN(0xABC)));

--- a/std/meta.d
+++ b/std/meta.d
@@ -1486,7 +1486,7 @@ template staticIsSorted(alias cmp, Seq...)
 }
 
 ///
-unittest
+@safe unittest
 {
     enum Comp(int N1, int N2) = N1 < N2;
     static assert( staticIsSorted!(Comp, 2, 2));
@@ -1495,7 +1495,7 @@ unittest
 }
 
 ///
-unittest
+@safe unittest
 {
     enum Comp(T1, T2) = __traits(isUnsigned, T2) - __traits(isUnsigned, T1);
     static assert( staticIsSorted!(Comp, uint, ubyte, ulong, short, long));

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -417,7 +417,7 @@ if (isCurlConn!Conn)
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
     static import std.file;
@@ -483,7 +483,7 @@ if (isCurlConn!Conn)
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
     static import std.file;
@@ -553,7 +553,7 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -606,7 +606,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, postData, conn);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -623,7 +623,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -650,7 +650,7 @@ if (is(T == char) || is(T == ubyte))
     return post(url, urlEncode(postDict), conn);
 }
 
-unittest
+@system unittest
 {
     foreach (host; [testServer.addr, "http://" ~ testServer.addr])
     {
@@ -713,7 +713,7 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -780,7 +780,7 @@ if (isCurlConn!Conn)
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -836,7 +836,7 @@ if (is(T == char) || is(T == ubyte))
     return options!T(url, conn);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -878,7 +878,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, cast(void[]) null, conn);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -919,7 +919,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, cast(void[]) null, conn);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -965,7 +965,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, patchData, conn);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -1064,7 +1064,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     return _decodeContent!T(content.data, client.p.charset);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -1078,7 +1078,7 @@ unittest
 }
 
 // Bugzilla 14760 - content length must be reset after post
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -1103,7 +1103,7 @@ unittest
     assert(res == "TRACERESPONSE");
 }
 
-unittest // charset detection and transcoding to T
+@system unittest // charset detection and transcoding to T
 {
     testServer.handle((s) {
         s.send("HTTP/1.1 200 OK\r\n"~
@@ -1333,7 +1333,7 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
     return SyncLineInputRange(result, keepTerminator == Yes.keepTerminator, terminator);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1407,7 +1407,7 @@ if (isCurlConn!(Conn))
     return SyncChunkInputRange(result, chunkSize);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1702,7 +1702,7 @@ auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char)
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1850,7 +1850,7 @@ if (isCurlConn!(Conn))
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2117,7 +2117,7 @@ private mixin template Protocol()
         p.curl.set(CurlOption.userpwd, format("%s:%s", username, password));
     }
 
-    unittest
+    @system unittest
     {
         import std.algorithm.searching : canFind;
 
@@ -3094,7 +3094,7 @@ struct HTTP
             method = Method.post;
     }
 
-    unittest
+    @system unittest
     {
         import std.algorithm.searching : canFind;
 
@@ -3263,7 +3263,7 @@ struct HTTP
 
 } // HTTP
 
-unittest // charset/Charset/CHARSET/...
+@system unittest // charset/Charset/CHARSET/...
 {
     import std.meta : AliasSeq;
 
@@ -3665,7 +3665,7 @@ struct FTP
         return p.curl.getTiming(timing, val);
     }
 
-    unittest
+    @system unittest
     {
         auto client = FTP();
 

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -1843,14 +1843,14 @@ T[] substr (T) (T[] str, ptrdiff_t start = 0, ptrdiff_t length = ptrdiff_t.min)
     return str[start .. end];
 }
 
-unittest
+@safe unittest
 {
     assert("abcdef".substr(-1) == "f");
     assert("abcdef".substr(-2) == "ef");
     assert("abcdef".substr(-3, 1) == "d");
 }
 
-unittest
+@safe unittest
 {
     assert("abcdef".substr(0, -1) == "abcde");
     assert("abcdef".substr(2, -1) == "cde");
@@ -1893,7 +1893,7 @@ if (is(Unqual!(ElementType!(S1)) == dchar) && is(Unqual!(ElementType!(S2)) == dc
     return slice1.icmp(slice2);
 }
 
-unittest
+@safe unittest
 {
     assert("abc".compareFirstN("abcdef", 3) == 0);
     assert("abc".compareFirstN("Abc", 3) == 0);
@@ -1917,7 +1917,7 @@ if (isDynamicArray!(A) && !isNarrowString!(A) && isMutable!(A) && !is(A == void[
     return e;
 }
 
-unittest
+@safe unittest
 {
     auto array = [0, 1, 2, 3];
     auto result = array.pop();
@@ -1943,13 +1943,13 @@ const(T)[] get (T) (const(T)[] str, size_t index, dchar c)
     return str[index .. index + codeLength!(T)(c)];
 }
 
-unittest
+@safe unittest
 {
     assert("abc".get(1, 'b') == "b");
     assert("löv".get(1, 'ö') == "ö");
 }
 
-unittest
+@safe unittest
 {
     assert("abc".get(1, 'b') == "b");
     assert("löv".get(1, 'ö') == "ö");

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -41,7 +41,7 @@ License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
 module std.parallelism;
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.iteration : map;
     import std.range : iota;
@@ -248,7 +248,7 @@ private template isSafeTask(F)
         allSatisfy!(noUnsharedAliasing, Parameters!F);
 }
 
-unittest
+@safe unittest
 {
     alias F1 = void function() @safe;
     alias F2 = void function();
@@ -361,7 +361,7 @@ private template isRoundRobin(T)
     enum isRoundRobin = false;
 }
 
-unittest
+@safe unittest
 {
     static assert( isRoundRobin!(RoundRobinBuffer!(void delegate(char[]), bool delegate())));
     static assert(!isRoundRobin!(uint));
@@ -3894,7 +3894,7 @@ version(unittest)
 
 // These test basic functionality but don't stress test for threading bugs.
 // These are the tests that should be run every time Phobos is compiled.
-unittest
+@system unittest
 {
     poolInstance = new TaskPool(2);
     scope(exit) poolInstance.stop();
@@ -4296,7 +4296,7 @@ unittest
 // tons of stuff and should not be run every time make unittest is run.
 version(parallelismStressTest)
 {
-    unittest
+    @safe unittest
     {
         size_t attempt;
         for (; attempt < 10; attempt++)
@@ -4379,7 +4379,7 @@ version(parallelismStressTest)
 
     // These unittests are intended more for actual testing and not so much
     // as examples.
-    unittest
+    @safe unittest
     {
         foreach (attempt; 0..10)
         foreach (poolSize; [0, 4])
@@ -4555,20 +4555,20 @@ version(unittest)
     static auto __genPair_12733(ulong n) { return __S_12733(n); }
 }
 
-unittest
+@system unittest
 {
     immutable ulong[] data = [ 2UL^^59-1, 2UL^^59-1, 2UL^^59-1, 112_272_537_195_293UL ];
 
     auto result = taskPool.amap!__genPair_12733(data);
 }
 
-unittest
+@safe unittest
 {
     // this test was in std.range, but caused cycles.
     assert(__traits(compiles, { foreach (i; iota(0, 100UL).parallel) {} }));
 }
 
-unittest
+@safe unittest
 {
     long[] arr;
     static assert(is(typeof({

--- a/std/random.d
+++ b/std/random.d
@@ -2038,7 +2038,7 @@ if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
            "Choice did not return a valid element from the given Range");
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.searching : canFind;
     import std.algorithm.iteration : map;

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -118,7 +118,7 @@ interface InputRange(E) {
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : map;
     import std.range : iota;
@@ -493,7 +493,7 @@ template outputRangeObject(E...) {
 }
 
 ///
-unittest
+@safe unittest
 {
      import std.array;
      auto app = appender!(uint[])();
@@ -502,7 +502,7 @@ unittest
      static assert(is(typeof(appWrapped) : OutputRange!(uint)));
 }
 
-unittest
+@system unittest
 {
     import std.internal.test.dummyrange;
     import std.algorithm.comparison : equal;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -657,7 +657,7 @@ pure @safe nothrow @nogc unittest
     auto s = testArr[].stride(2);
 }
 
-debug pure nothrow unittest
+debug pure nothrow @system unittest
 {//check the contract
     int[4] testArr = [1,2,3,4];
     bool passed = false;
@@ -1485,7 +1485,7 @@ if (isInputRange!(Unqual!R1) && isInputRange!(Unqual!R2) &&
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -1545,7 +1545,7 @@ if (Ranges.length == 2 && is(typeof(choose(true, rs[0], rs[1]))))
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1608,7 +1608,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     int[] a = [1, 2, 3];
     long[] b = [4, 5, 6];
@@ -1740,7 +1740,7 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
  * roundRobin can be used to create "interleave" functionality which inserts
  * an element between each element in a range.
  */
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3260,7 +3260,7 @@ if (isCallable!fun)
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.format : format;
     import std.random : uniform;
@@ -3831,7 +3831,7 @@ if (isStaticArray!R)
     assert(cleS.front == 0);
 }
 
-unittest //10845
+@system unittest //10845
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -3846,7 +3846,7 @@ unittest //10845
 }
 
 // Issue 13390
-unittest
+@system unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -4230,7 +4230,7 @@ if (Ranges.length && allSatisfy!(isInputRange, Ranges))
 }
 
 ///
-pure unittest
+pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -4241,7 +4241,7 @@ pure unittest
 }
 
 ///
-pure unittest
+pure @safe unittest
 {
     import std.conv : to;
 
@@ -4267,7 +4267,7 @@ pure unittest
 }
 
 /// $(D zip) is powerful - the following code sorts two arrays in parallel:
-pure unittest
+pure @safe unittest
 {
     import std.algorithm.sorting : sort;
 
@@ -4301,7 +4301,7 @@ enum StoppingPolicy
     requireSameLength,
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -4423,7 +4423,7 @@ unittest
     +/
 }
 
-pure unittest
+pure @safe unittest
 {
     import std.algorithm.sorting : sort;
 
@@ -4478,7 +4478,7 @@ pure unittest
     auto zz = z.save;
 }
 
-pure unittest
+pure @system unittest
 {
     import std.typecons : tuple;
 
@@ -4700,7 +4700,7 @@ if (allSatisfy!(isInputRange, Ranges))
 }
 
 ///
-unittest
+@system unittest
 {
    auto arr1 = [1,2,3,4,5,100];
    auto arr2 = [6,7,8,9,10];
@@ -4720,7 +4720,7 @@ unittest
    }
 }
 
-unittest // Bugzilla 15860: foreach_reverse on lockstep
+@system unittest // Bugzilla 15860: foreach_reverse on lockstep
 {
     auto arr1 = [0, 1, 2, 3];
     auto arr2 = [4, 5, 6, 7];
@@ -4744,7 +4744,7 @@ unittest // Bugzilla 15860: foreach_reverse on lockstep
     }
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.iteration : filter;
     import std.conv : to;
@@ -4831,7 +4831,7 @@ unittest
     foreach (x, y; lockstep(iota(0, 10), iota(0, 10))) { }
 }
 
-unittest
+@system unittest
 {
     struct RvalueRange
     {
@@ -5157,7 +5157,7 @@ auto sequence(alias fun, State...)(State args)
 }
 
 // Issue 5036
-unittest
+@safe unittest
 {
     auto s = sequence!((a, n) => new int)(0);
     assert(s.front != s.front);  // no caching
@@ -5486,7 +5486,7 @@ body
     assert(approxEqual(rf, [0.0, 0.1, 0.2, 0.3, 0.4]));
 }
 
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     auto t0 = iota(0, 10);
     auto t1 = iota(0, 10, 2);
@@ -5494,7 +5494,7 @@ nothrow @nogc unittest
     //float overloads use std.conv.to so can't be @nogc or nothrow
 }
 
-debug unittest
+debug @system unittest
 {//check the contracts
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -5504,7 +5504,7 @@ debug unittest
     assertThrown!AssertError(iota(0f,1f,-0.1f));
 }
 
-unittest
+@system unittest
 {
     int[] a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     auto r1 = iota(a.ptr, a.ptr + a.length, 1);
@@ -5512,7 +5512,7 @@ unittest
     assert(r1.back == a.ptr + a.length - 1);
 }
 
-unittest
+@safe unittest
 {
     assert(iota(1UL, 0UL).length == 0);
     assert(iota(1UL, 0UL, 1).length == 0);
@@ -5672,7 +5672,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     //The ptr stuff can't be done at compile time, so we unfortunately end
     //up with some code duplication here.
@@ -5739,7 +5739,7 @@ if (!isIntegral!(CommonType!(B, E)) &&
     return Result(begin, end);
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -6493,7 +6493,7 @@ private:
 }
 
 // Issue 9507
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -6759,7 +6759,7 @@ if (isRandomAccessRange!Source && isInputRange!Indices &&
         }
 
         ///
-        unittest
+        @safe unittest
         {
             auto ind = indexed([1, 2, 3, 4, 5], [1, 3, 4]);
             assert(ind.physicalIndex(0) == 1);
@@ -7100,7 +7100,7 @@ if (isForwardRange!Source)
     assert(chunks1[$ / 2 .. $ - 1].equal([[2, 2], [3, 3]])); //Slow
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -7552,7 +7552,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
         .equal("T.D.P.L"));
 }
 
-unittest
+@safe unittest
 {
     // Verify that the same common type and same arity
     // results in the same template instantiation
@@ -8049,7 +8049,7 @@ pure @safe unittest
 version(none) // @@@BUG@@@ 10939
 {
     // Re-enable (or remove) if 10939 is resolved.
-    /+pure+/ unittest // Impure because of std.conv.to
+    /+pure+/ @safe unittest // Impure because of std.conv.to
     {
         import core.exception : RangeError;
         import std.exception : assertNotThrown, assertThrown;
@@ -8423,7 +8423,7 @@ if (isInputRange!Range)
     }
 
     ///
-    unittest
+    @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = assumeSorted([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
@@ -8467,7 +8467,7 @@ See_Also: STL's $(HTTP sgi.com/tech/stl/lower_bound.html,upper_bound).
     }
 
     ///
-    unittest
+    @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = assumeSorted([ 1, 2, 3, 3, 3, 4, 4, 5, 6 ]);
@@ -8530,7 +8530,7 @@ See_Also: STL's $(HTTP sgi.com/tech/stl/lower_bound.html,upper_bound).
     }
 
     ///
-    unittest
+    @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
@@ -8590,7 +8590,7 @@ equalRange). Completes the entire search in $(BIGOH log(n)) time.
     }
 
     ///
-    unittest
+    @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
@@ -8630,7 +8630,7 @@ sorting relation.
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.algorithm.sorting : sort;
     auto a = [ 1, 2, 3, 42, 52, 64 ];
@@ -8756,7 +8756,7 @@ that break its sortedness, $(D SortedRange) will work erratically.
     auto s = assumeSorted(arr);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     int[] arr = [100, 101, 102, 200, 201, 300];
@@ -8765,7 +8765,7 @@ unittest
 }
 
 // Test on an input range
-unittest
+@system unittest
 {
     import std.conv : text;
     import std.file : exists, remove, tempDir;
@@ -8871,7 +8871,7 @@ if (isInputRange!(Unqual!R))
     r = assumeSorted(a);
 }
 
-unittest
+@system unittest
 {
     bool ok = true;
     try
@@ -8886,7 +8886,7 @@ unittest
 }
 
 // issue 15003
-@nogc unittest
+@nogc @safe unittest
 {
     static immutable a = [1, 2, 3, 4];
     auto r = a.assumeSorted;
@@ -9249,7 +9249,7 @@ private:
 }
 
 /// Basic Example
-unittest
+@system unittest
 {
     import std.algorithm.searching : find;
     ubyte[] buffer = [1, 9, 45, 12, 22];
@@ -9276,7 +9276,7 @@ unittest
 }
 
 /// opAssign Example.
-unittest
+@system unittest
 {
     ubyte[] buffer1 = [1, 2, 3, 4, 5];
     ubyte[] buffer2 = [6, 7, 8, 9, 10];
@@ -9321,7 +9321,7 @@ unittest
     assert(buffer2 == [11, 12, 13, 14, 15]);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.iteration : filter;
     {
@@ -9408,7 +9408,7 @@ unittest
 }
 
 //Test assignment.
-unittest
+@system unittest
 {
     ubyte[] buffer1 = [1, 2, 3, 4, 5];
     ubyte[] buffer2 = [6, 7, 8, 9, 10];
@@ -9435,7 +9435,7 @@ unittest
     assert(buffer2 == [6, 7, 8, 9, 10]);
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.mutation : bringToFront;
@@ -9555,7 +9555,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     struct S
     {
@@ -9570,7 +9570,7 @@ unittest
     static assert(isInfinite!(typeof(wrapper)));
 }
 
-unittest
+@system unittest
 {
     class C
     {
@@ -9587,7 +9587,7 @@ unittest
     assert(cWrapper is c);
 }
 
-unittest // issue 14373
+@system unittest // issue 14373
 {
     static struct R
     {
@@ -9600,7 +9600,7 @@ unittest // issue 14373
     assert(r.empty);
 }
 
-unittest // issue 14575
+@system unittest // issue 14575
 {
     struct R
     {
@@ -10705,7 +10705,7 @@ if (
     assert("abc".padRight('_', 6).equal("abc___"));
 }
 
-pure unittest
+pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, ReferenceInputRange;

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -402,7 +402,7 @@ if (isSomeChar!E)
     }
 }
 
-pure unittest
+pure @safe unittest
 {
     auto f = delegate (const(char)[]) {};
     putChar(f, cast(dchar)'a');
@@ -416,7 +416,7 @@ pure unittest
     putChar(r, 'a');
 }
 
-unittest
+@safe unittest
 {
     struct A {}
     static assert(!isInputRange!(A));
@@ -428,7 +428,7 @@ unittest
     put(b, 5);
 }
 
-unittest
+@safe unittest
 {
     int[] a = [1, 2, 3], b = [10, 20];
     auto c = a;
@@ -437,7 +437,7 @@ unittest
     assert(a == [3]);
 }
 
-unittest
+@safe unittest
 {
     int[] a = new int[10];
     int b;
@@ -445,14 +445,14 @@ unittest
     put(a, b);
 }
 
-unittest
+@safe unittest
 {
     void myprint(in char[] s) { }
     auto r = &myprint;
     put(r, 'a');
 }
 
-unittest
+@safe unittest
 {
     int[] a = new int[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
@@ -468,7 +468,7 @@ unittest
     assert(a.length == 6);
 }
 
-unittest
+@safe unittest
 {
     char[] a = new char[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
@@ -478,7 +478,7 @@ unittest
     static assert(!__traits(compiles, put(a, "ABC")));
 }
 
-unittest
+@safe unittest
 {
     int[][] a = new int[][10];
     int[]   b = new int[10];
@@ -490,7 +490,7 @@ unittest
     static assert(!__traits(compiles, put(a, c)));
 }
 
-unittest
+@safe unittest
 {
     int[][] a = new int[][](3);
     int[]   b = [1];
@@ -505,7 +505,7 @@ unittest
     assert(a == [[2], [2], [2]]);
 }
 
-unittest
+@safe unittest
 {
     // Test fix for bug 7476.
     struct LockingTextWriter
@@ -524,7 +524,7 @@ unittest
     put(w, r);
 }
 
-unittest
+@system unittest
 {
     import std.conv : to;
     import std.meta : AliasSeq;
@@ -587,7 +587,7 @@ unittest
     }
 }
 
-unittest
+@safe unittest
 {
     static struct CharRange
     {
@@ -604,7 +604,7 @@ unittest
     put(c, "hello"d);
 }
 
-unittest
+@system unittest
 {
     // issue 9823
     const(char)[] r;
@@ -613,7 +613,7 @@ unittest
     assert(r == "ABC");
 }
 
-unittest
+@safe unittest
 {
     // issue 10571
     import std.format;
@@ -622,7 +622,7 @@ unittest
     assert(buf == "hello");
 }
 
-unittest
+@safe unittest
 {
     import std.format;
     import std.meta : AliasSeq;
@@ -851,7 +851,7 @@ template isBidirectionalRange(R)
 }
 
 ///
-unittest
+@safe unittest
 {
     alias R = int[];
     R r = [0,1];
@@ -932,7 +932,7 @@ template isRandomAccessRange(R)
 }
 
 ///
-unittest
+@safe unittest
 {
     import std.traits : isNarrowString;
 
@@ -2171,7 +2171,7 @@ if (isNarrowString!(C[]))
     static assert(checkCTFEW.empty);
 }
 
-unittest // issue 16090
+@safe unittest // issue 16090
 {
     string s = "\u00E4";
     assert(s.length == 2);
@@ -2181,7 +2181,7 @@ unittest // issue 16090
     assert(s.empty);
 }
 
-unittest
+@safe unittest
 {
     wstring s = "\U00010000";
     assert(s.length == 2);

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -175,7 +175,7 @@ module std.regex.internal.generator;
     }
 }
 
-unittest
+@system unittest
 {
     import std.range, std.regex;
     auto re = regex(`P[a-z]{3,}q`);

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -512,7 +512,7 @@ public:
     }
 }
 
-unittest
+@system unittest
 {
     import std.conv, std.regex;
     @trusted void test_fixed(alias Kick)()

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -43,7 +43,7 @@ if (isSomeString!S)
     return makeRegex(Parser!(S, CodeGen)(arg, ""));
 }
 
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto re = makeRegex(`(?P<name>\w+) = (?P<var>\d+)`);

--- a/std/regex/internal/shiftor.d
+++ b/std/regex/internal/shiftor.d
@@ -521,7 +521,7 @@ public:
     }
 }
 
-unittest
+@safe unittest
 {
     import std.conv, std.regex;
     auto shiftOrLength(C)(const(C)[] pat, uint length)

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -12,7 +12,7 @@ import std.regex.internal.parser : Escapables; // characters that need escaping
 
 alias Sequence(int B, int E) = staticIota!(B, E);
 
-unittest
+@safe unittest
 {//sanity checks
     regex("(a|b)*");
     regex(`(?:([0-9A-F]+)\.\.([0-9A-F]+)|([0-9A-F]+))\s*;\s*(.*)\s*#`);
@@ -54,7 +54,7 @@ unittest
 
  */
 
-unittest
+@safe unittest
 {
     struct TestVectors
     {
@@ -467,14 +467,14 @@ unittest
     run_tests!match(); //thompson VM
 }
 
-unittest
+@safe unittest
 {
     auto cr = ctRegex!("abc");
     assert(bmatch("abc",cr).hit == "abc");
     auto cr2 = ctRegex!("ab*c");
     assert(bmatch("abbbbc",cr2).hit == "abbbbc");
 }
-unittest
+@safe unittest
 {
     auto cr3 = ctRegex!("^abc$");
     assert(bmatch("abc",cr3).hit == "abc");
@@ -482,7 +482,7 @@ unittest
     assert(array(match("azb",cr4).captures) == ["azb", "azb"]);
 }
 
-unittest
+@safe unittest
 {
     auto cr5 = ctRegex!("(?:a{2,4}b{1,3}){1,2}");
     assert(bmatch("aaabaaaabbb", cr5).hit == "aaabaaaabbb");
@@ -490,7 +490,7 @@ unittest
     assert(bmatch("aaabaaaabbb"w,  cr6).hit == "aaab"w);
 }
 
-unittest
+@safe unittest
 {
     auto cr7 = ctRegex!(`\r.*?$`,"sm");
     assert(bmatch("abc\r\nxy",  cr7).hit == "\r\nxy");
@@ -499,7 +499,7 @@ unittest
             == "<packet>text</packet>");
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     auto cr8 = ctRegex!("^(a)(b)?(c*)");
@@ -514,7 +514,7 @@ unittest
     assert(equal(bmatch("xxqababqyy",cr9).captures, ["qababq", "b"]));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     auto rtr = regex("a|b|c");
@@ -527,7 +527,7 @@ unittest
     assert(equal(testCT.ir,testRT.ir));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.comparison : equal;
@@ -558,7 +558,7 @@ unittest
     assert(equal(map!"a.hit"(m9), ["First", "", "Second"]));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.comparison : equal;
@@ -601,7 +601,7 @@ unittest
 }
 
 //tests for accumulated std.regex issues and other regressions
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.comparison : equal;
@@ -683,7 +683,7 @@ unittest
 }
 
 // tests for replace
-unittest
+@safe unittest
 {
     void test(alias matchFn)()
     {
@@ -717,7 +717,7 @@ unittest
 }
 
 // tests for splitter
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,     fg, hi, ";
@@ -737,13 +737,13 @@ unittest
     assert(equal(sp2, w2));
 }
 
-unittest
+@safe unittest
 {
     char[] s1 = ", abc, de,  fg, hi, ".dup;
     auto sp2 = splitter(s1, regex(", *"));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,  fg, hi, ";
@@ -751,7 +751,7 @@ unittest
     assert(equal(split(s1, regex(", *")), w1[]));
 }
 
-unittest
+@safe unittest
 { // bugzilla 7141
     string pattern = `[a\--b]`;
     assert(match("-", pattern));
@@ -759,17 +759,17 @@ unittest
     string pattern2 = `[&-z]`;
     assert(match("b", pattern2));
 }
-unittest
+@safe unittest
 {//bugzilla 7111
     assert(match("", regex("^")));
 }
-unittest
+@safe unittest
 {//bugzilla 7300
     assert(!match("a"d, "aa"d));
 }
 
 // bugzilla 7551
-unittest
+@safe unittest
 {
     auto r = regex("[]abc]*");
     assert("]ab".matchFirst(r).hit == "]ab");
@@ -778,13 +778,13 @@ unittest
     assert("]ac".matchFirst(r2).hit == "]");
 }
 
-unittest
+@safe unittest
 {//bugzilla 7674
     assert("1234".replace(regex("^"), "$$") == "$1234");
     assert("hello?".replace(regex(r"\?", "g"), r"\?") == r"hello\?");
     assert("hello?".replace(regex(r"\?", "g"), r"\\?") != r"hello\?");
 }
-unittest
+@safe unittest
 {// bugzilla 7679
     import std.algorithm.comparison : equal;
     foreach (S; AliasSeq!(string, wstring, dstring))
@@ -795,7 +795,7 @@ unittest
         assert(split(str, re) == [to!S("a"), to!S("b")]);
     }();
 }
-unittest
+@safe unittest
 {//bugzilla 8203
     string data = "
     NAME   = XPAW01_STA:STATION
@@ -811,14 +811,14 @@ unittest
     auto r2 = regex(`([а-яА-Я\-_]+\s*)+(?<=[\s\.,\^])`);
     match("аллея Театральная", r2);
 }
-unittest
+@safe unittest
 {// bugzilla 8637 purity of enforce
     auto m = match("hello world", regex("world"));
     enforce(m);
 }
 
 // bugzilla 8725
-unittest
+@safe unittest
 {
   static italic = regex( r"\*
                 (?!\s+)
@@ -831,7 +831,7 @@ unittest
 }
 
 // bugzilla 8349
-unittest
+@safe unittest
 {
     enum peakRegexStr = r"\>(wgEncode.*Tfbs.*\.(?:narrow)|(?:broad)Peak.gz)</a>";
     enum peakRegex = ctRegex!(peakRegexStr);
@@ -840,7 +840,7 @@ unittest
 }
 
 // bugzilla 9211
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     auto rx_1 =  regex(r"^(\w)*(\d)");
@@ -852,7 +852,7 @@ unittest
 }
 
 // bugzilla 9280
-unittest
+@safe unittest
 {
     string tomatch = "a!b@c";
     static r = regex(r"^(?P<nick>.*?)!(?P<ident>.*?)@(?P<host>.*?)$");
@@ -865,7 +865,7 @@ unittest
 
 
 // bugzilla 9579
-unittest
+@safe unittest
 {
     char[] input = ['a', 'b', 'c'];
     string format = "($1)";
@@ -876,14 +876,14 @@ unittest
 }
 
 // bugzilla 9634
-unittest
+@safe unittest
 {
     auto re = ctRegex!"(?:a+)";
     assert(match("aaaa", re).hit == "aaaa");
 }
 
 //bugzilla 10798
-unittest
+@safe unittest
 {
     auto cr = ctRegex!("[abcd--c]*");
     auto m  = "abc".match(cr);
@@ -892,7 +892,7 @@ unittest
 }
 
 // bugzilla 10913
-unittest
+@system unittest
 {
     @system static string foo(const(char)[] s)
     {
@@ -911,7 +911,7 @@ unittest
 }
 
 // bugzilla 11262
-unittest
+@safe unittest
 {
     enum reg = ctRegex!(r",", "g");
     auto str = "This,List";
@@ -920,13 +920,13 @@ unittest
 }
 
 // bugzilla 11775
-unittest
+@safe unittest
 {
     assert(collectException(regex("a{1,0}")));
 }
 
 // bugzilla 11839
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     assert(regex(`(?P<var1>\w+)`).namedCaptures.equal(["var1"]));
@@ -937,7 +937,7 @@ unittest
 }
 
 // bugzilla 12076
-unittest
+@safe unittest
 {
     auto RE = ctRegex!(r"(?<!x[a-z]+)\s([a-z]+)");
     string s = "one two";
@@ -945,7 +945,7 @@ unittest
 }
 
 // bugzilla 12105
-unittest
+@safe unittest
 {
     auto r = ctRegex!`.*?(?!a)`;
     assert("aaab".matchFirst(r).hit == "aaa");
@@ -954,14 +954,14 @@ unittest
 }
 
 //bugzilla 11784
-unittest
+@safe unittest
 {
     assert("abcdefghijklmnopqrstuvwxyz"
         .matchFirst("[a-z&&[^aeiuo]]").hit == "b");
 }
 
 //bugzilla 12366
-unittest
+@safe unittest
 {
      auto re = ctRegex!(`^((?=(xx+?)\2+$)((?=\2+$)(?=(x+)(\4+$))\5){2})*x?$`);
      assert("xxxxxxxx".match(re).empty);
@@ -969,27 +969,27 @@ unittest
 }
 
 // bugzilla 12582
-unittest
+@safe unittest
 {
     auto r = regex(`(?P<a>abc)`);
     assert(collectException("abc".matchFirst(r)["b"]));
 }
 
 // bugzilla 12691
-unittest
+@safe unittest
 {
     assert(bmatch("e@", "^([a-z]|)*$").empty);
     assert(bmatch("e@", ctRegex!`^([a-z]|)*$`).empty);
 }
 
 //bugzilla  12713
-unittest
+@safe unittest
 {
     assertThrown(regex("[[a-z]([a-z]|(([[a-z])))"));
 }
 
 //bugzilla 12747
-unittest
+@safe unittest
 {
     assertThrown(regex(`^x(\1)`));
     assertThrown(regex(`^(x(\1))`));
@@ -997,14 +997,14 @@ unittest
 }
 
 // bugzilla 14504
-unittest
+@safe unittest
 {
     auto p = ctRegex!("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?" ~
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 }
 
 // bugzilla 14529
-unittest
+@safe unittest
 {
     auto ctPat2 = regex(r"^[CDF]$", "i");
     foreach (v; ["C", "c", "D", "d", "F", "f"])
@@ -1012,7 +1012,7 @@ unittest
 }
 
 // bugzilla 14615
-unittest
+@safe unittest
 {
     import std.stdio : writeln;
     import std.regex : replaceFirst, replaceFirstInto, regex;
@@ -1031,19 +1031,19 @@ unittest
 }
 
 // bugzilla 15573
-unittest
+@safe unittest
 {
     auto rx = regex("[c d]", "x");
     assert("a b".matchFirst(rx));
 }
 
 // bugzilla 15864
-unittest
+@safe unittest
 {
     regex(`(<a (?:(?:\w+=\"[^"]*\")?\s*)*href="\.\.?)"`);
 }
 
-unittest
+@safe unittest
 {
     auto r = regex("(?# comment)abc(?# comment2)");
     assert("abc".matchFirst(r));

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -358,7 +358,7 @@ if (isSomeString!(S))
 }
 
 ///
-unittest
+@system unittest
 {
     // multi-pattern regex example
     auto multi = regex([`([a-z]+):(\d+)`, `(\d+),\d+`]); // multi regex
@@ -586,7 +586,7 @@ public:
     @safe @property int whichPattern() const nothrow { return _nMatch; }
 
     ///
-    unittest
+    @system unittest
     {
         import std.regex;
         assert(matchFirst("abc", "[0-9]+", "[a-z]+").whichPattern == 2);
@@ -623,7 +623,7 @@ public:
 }
 
 ///
-unittest
+@system unittest
 {
     import std.range.primitives : popFrontN;
 
@@ -797,7 +797,7 @@ private auto matchMany(alias Engine, RegEx, R)(R input, RegEx re)
     return RegexMatch!(R, Engine)(input, re);
 }
 
-unittest
+@system unittest
 {
     //sanity checks for new API
     auto re = regex("abc");
@@ -1192,7 +1192,7 @@ if (isSomeString!R && is(C : dchar) && isRegexFor!(RegEx, R))
 }
 
 ///
-unittest
+@system unittest
 {
     assert(replaceFirst("noon", regex("n"), "[$&]") == "[n]oon");
 }
@@ -1219,7 +1219,7 @@ if (isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-unittest
+@system unittest
 {
     import std.conv : to;
     string list = "#21 out of 46";
@@ -1255,7 +1255,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-unittest
+@system unittest
 {
     import std.array;
     string m1 = "first message\n";
@@ -1310,7 +1310,7 @@ if (isSomeString!R && is(C : dchar) && isRegexFor!(RegEx, R))
 }
 
 ///
-unittest
+@system unittest
 {
     // insert comma as thousands delimiter
     auto re = regex(r"(?<=\d)(?=(\d\d\d)+\b)","g");
@@ -1344,7 +1344,7 @@ if (isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-unittest
+@system unittest
 {
     string baz(Captures!(string) m)
     {
@@ -1589,7 +1589,7 @@ if (
 }
 
 ///
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,  fg, hi, ";
@@ -1598,7 +1598,7 @@ unittest
 }
 
 /// Split on a pattern, but keep the matches in the resulting range
-unittest
+@system unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons;
@@ -1668,7 +1668,7 @@ auto escaper(Range)(Range r)
 }
 
 ///
-unittest
+@system unittest
 {
     import std.regex;
     import std.algorithm.comparison;
@@ -1676,7 +1676,7 @@ unittest
     assert(s.escaper.equal(`This is \{unfriendly\} to \*regex\*`));
 }
 
-unittest
+@system unittest
 {
     import std.conv;
     import std.algorithm.comparison;

--- a/std/socket.d
+++ b/std/socket.d
@@ -3500,7 +3500,7 @@ class UdpSocket: Socket
 }
 
 // Issue 16514
-unittest
+@safe unittest
 {
     class TestSocket : Socket
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -524,7 +524,7 @@ Throws: $(D ErrnoException) in case of error.
             _name = name;
     }
 
-    unittest // Test changing filename
+    @system unittest // Test changing filename
     {
         static import std.file;
         import std.exception : assertThrown, assertNotThrown;
@@ -546,7 +546,7 @@ Throws: $(D ErrnoException) in case of error.
 
     version (CRuntime_DigitalMars) {} else // Not implemented
     version (CRuntime_Microsoft) {} else // Not implemented
-    unittest // Test changing mode
+    @system unittest // Test changing mode
     {
         static import std.file;
         import std.exception : assertThrown, assertNotThrown;
@@ -1740,7 +1740,7 @@ is recommended if you want to process a complete file.
         return buf.length;
     }
 
-    unittest
+    @system unittest
     {
         static import std.file;
         import std.typecons : Tuple;

--- a/std/string.d
+++ b/std/string.d
@@ -313,7 +313,7 @@ immutable(char)* toStringz(in string s) @trusted pure nothrow
 }
 
 ///
-pure nothrow unittest
+pure nothrow @system unittest
 {
     import core.stdc.string : strlen;
     import std.conv : to;
@@ -6947,7 +6947,7 @@ if (staticIndexOf!(Unqual!T, ubyte, ushort, uint) != -1)
     assert(a == c);
 }
 
-pure unittest
+pure @system unittest
 {
     import std.algorithm.comparison : equal;
     foreach (T; AliasSeq!(char[], wchar[], dchar[]))

--- a/std/uni.d
+++ b/std/uni.d
@@ -8905,7 +8905,7 @@ if (isSomeString!S)
     dstring toLower(dstring s)
     { return toLower!dstring(s); }
 
-    unittest
+    @safe unittest
     {
         // https://issues.dlang.org/show_bug.cgi?id=16663
 
@@ -9087,7 +9087,7 @@ if (isSomeString!S)
     dstring toUpper(dstring s)
     { return toUpper!dstring(s); }
 
-    unittest
+    @safe unittest
     {
         // https://issues.dlang.org/show_bug.cgi?id=16663
 

--- a/std/utf.d
+++ b/std/utf.d
@@ -3414,7 +3414,7 @@ if (!isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingTyp
     assert(noel2.byCodeUnit[2] != 'ë');
 }
 
-pure nothrow @nogc unittest
+pure nothrow @nogc @safe unittest
 {
     import std.range;
     {

--- a/std/variant.d
+++ b/std/variant.d
@@ -668,7 +668,7 @@ public:
 
     ///
     static if (doUnittest)
-    unittest
+    @system unittest
     {
         Variant a;
         assert(!a.hasValue);
@@ -701,7 +701,7 @@ public:
 
     ///
     static if (doUnittest)
-    unittest
+    @system unittest
     {
         Variant a = 5;
         auto b = a.peek!(int);
@@ -1093,7 +1093,7 @@ public:
 
     ///
     static if (doUnittest)
-    unittest
+    @system unittest
     {
         Variant a = new int[10];
         a[5] = 42;
@@ -1177,7 +1177,7 @@ public:
     }
 }
 
-unittest
+@system unittest
 {
     import std.conv : to;
     Variant v;
@@ -1190,7 +1190,7 @@ unittest
     assert(v("43") == 43);
 }
 
-unittest
+@system unittest
 {
     int[int] hash = [ 42:24 ];
     Variant v = hash;
@@ -1200,7 +1200,7 @@ unittest
 }
 
 // opIndex with static arrays, issue 12771
-unittest
+@system unittest
 {
     int[4] elements = [0, 1, 2, 3];
     Variant v = elements;
@@ -1212,7 +1212,7 @@ unittest
     assert(v != elements);
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     Algebraic!(int[]) v = [2, 2];
@@ -1231,7 +1231,7 @@ unittest
 }
 
 //Issue# 8195
-unittest
+@system unittest
 {
     struct S
     {
@@ -1251,7 +1251,7 @@ unittest
 }
 
 // Issue #10961
-unittest
+@system unittest
 {
     // Primarily test that we can assign a void[] to a Variant.
     void[] elements = cast(void[])[1, 2, 3];
@@ -1261,7 +1261,7 @@ unittest
 }
 
 // Issue #13352
-unittest
+@system unittest
 {
     alias TP = Algebraic!(long);
     auto a = TP(1L);
@@ -1277,7 +1277,7 @@ unittest
 }
 
 // Issue #13354
-unittest
+@system unittest
 {
     alias A = Algebraic!(string[]);
     A a = ["a", "b"];
@@ -1295,14 +1295,14 @@ unittest
 }
 
 // Issue #14198
-unittest
+@system unittest
 {
     Variant a = true;
     assert(a.type == typeid(bool));
 }
 
 // Issue #14233
-unittest
+@system unittest
 {
     alias Atom = Algebraic!(string, This[]);
 
@@ -1311,7 +1311,7 @@ unittest
 }
 
 pure nothrow @nogc
-unittest
+@system unittest
 {
     Algebraic!(int, double) a;
     a = 100;
@@ -1319,7 +1319,7 @@ unittest
 }
 
 // Issue 14457
-unittest
+@system unittest
 {
     alias A = Algebraic!(int, float, double);
     alias B = Algebraic!(int, float);
@@ -1333,7 +1333,7 @@ unittest
 }
 
 // Issue 14585
-unittest
+@system unittest
 {
     static struct S
     {
@@ -1344,13 +1344,13 @@ unittest
 }
 
 // Issue 14586
-unittest
+@system unittest
 {
     const Variant v = new immutable Object;
     v.get!(immutable Object);
 }
 
-unittest
+@system unittest
 {
     static struct S
     {
@@ -1376,7 +1376,7 @@ template Algebraic(T...)
 }
 
 ///
-unittest
+@system unittest
 {
     auto v = Algebraic!(int, double, string)(5);
     assert(v.peek!(int));
@@ -1399,7 +1399,7 @@ will perform $(LUCKY alpha renaming) on its constituent types, replacing `This`
 with the self-referenced type. The structure of the type involving `This` may
 be arbitrarily complex.
 */
-unittest
+@system unittest
 {
     // A tree is either a leaf or a branch of two other trees
     alias Tree(Leaf) = Algebraic!(Leaf, Tuple!(This*, This*));
@@ -1445,7 +1445,7 @@ Variant[] variantArray(T...)(T args)
 }
 
 ///
-unittest
+@system unittest
 {
     auto a = variantArray(1, 3.14, "Hi!");
     assert(a[1] == 3.14);
@@ -1485,7 +1485,7 @@ static class VariantException : Exception
     }
 }
 
-unittest
+@system unittest
 {
     alias W1 = This2Variant!(char, int, This[int]);
     alias W2 = AliasSeq!(int, char[int]);
@@ -1495,7 +1495,7 @@ unittest
     var_t foo = "quux";
 }
 
-unittest
+@system unittest
 {
      alias A = Algebraic!(real, This[], This[int], This[This]);
      A v1, v2, v3;
@@ -1510,7 +1510,7 @@ unittest
      //writeln(v1);
 }
 
-unittest
+@system unittest
 {
     import std.conv : ConvException;
     import std.exception : assertThrown, collectException;
@@ -1607,7 +1607,7 @@ unittest
 
 // tests adapted from
 // http://www.dsource.org/projects/tango/browser/trunk/tango/core/Variant.d?rev=2601
-unittest
+@system unittest
 {
     Variant v;
 
@@ -1728,7 +1728,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     // check comparisons incompatible with AllowedTypes
     Algebraic!int v = 2;
@@ -1741,7 +1741,7 @@ unittest
     static assert(!__traits(compiles, {v > null;}));
 }
 
-unittest
+@system unittest
 {
     // bug 1558
     Variant va=1;
@@ -1750,7 +1750,7 @@ unittest
     assert((va-vb).get!(int) == 3);
 }
 
-unittest
+@system unittest
 {
     Variant a;
     a=5;
@@ -1761,14 +1761,14 @@ unittest
     assert(c[3] == "hello");
 }
 
-unittest
+@system unittest
 {
     Variant v = 5;
     assert(!__traits(compiles, v.coerce!(bool delegate())));
 }
 
 
-unittest
+@system unittest
 {
     struct Huge {
         real a, b, c, d, e, f, g;
@@ -1781,7 +1781,7 @@ unittest
     assert(v.get!(Huge).e == 42);
 }
 
-unittest
+@system unittest
 {
     const x = Variant(42);
     auto y1 = x.get!(const int);
@@ -1790,7 +1790,7 @@ unittest
 }
 
 // test iteration
-unittest
+@system unittest
 {
     auto v = Variant([ 1, 2, 3, 4 ][]);
     auto j = 0;
@@ -1802,14 +1802,14 @@ unittest
 }
 
 // test convertibility
-unittest
+@system unittest
 {
     auto v = Variant("abc".dup);
     assert(v.convertsTo!(char[]));
 }
 
 // http://d.puremagic.com/issues/show_bug.cgi?id=5424
-unittest
+@system unittest
 {
     interface A {
         void func1();
@@ -1824,7 +1824,7 @@ unittest
     Variant b = Variant(a);
 }
 
-unittest
+@system unittest
 {
     // bug 7070
     Variant v;
@@ -1832,7 +1832,7 @@ unittest
 }
 
 // Class and interface opEquals, issue 12157
-unittest
+@system unittest
 {
     class Foo { }
 
@@ -1850,7 +1850,7 @@ unittest
 }
 
 // Const parameters with opCall, issue 11361.
-unittest
+@system unittest
 {
     static string t1(string c) {
         return c ~ "a";
@@ -1881,7 +1881,7 @@ unittest
 }
 
 // issue 12071
-unittest
+@system unittest
 {
     static struct Structure { int data; }
     alias VariantTest = Algebraic!(Structure delegate() pure nothrow @nogc @safe);
@@ -1898,7 +1898,7 @@ unittest
 }
 
 // Ordering comparisons of incompatible types, e.g. issue 7990.
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     assertThrown!VariantException(Variant(3) < "a");
@@ -1910,7 +1910,7 @@ unittest
 }
 
 // Handling of unordered types, e.g. issue 9043.
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     static struct A { int a; }
@@ -1923,7 +1923,7 @@ unittest
 }
 
 // Handling of empty types and arrays, e.g. issue 10958
-unittest
+@system unittest
 {
     class EmptyClass { }
     struct EmptyStruct { }
@@ -1954,7 +1954,7 @@ unittest
 }
 
 // Handling of void function pointers / delegates, e.g. issue 11360
-unittest
+@system unittest
 {
     static void t1() { }
     Variant v = &t1;
@@ -1966,7 +1966,7 @@ unittest
 }
 
 // Using peek for large structs, issue 8580
-unittest
+@system unittest
 {
     struct TestStruct(bool pad)
     {
@@ -2031,7 +2031,7 @@ if (Handlers.length > 0)
 }
 
 ///
-unittest
+@system unittest
 {
     Algebraic!(int, string) variant;
 
@@ -2052,7 +2052,7 @@ unittest
     assert(rslt == -1);
 }
 
-unittest
+@system unittest
 {
     Algebraic!(size_t, string) variant;
 
@@ -2137,7 +2137,7 @@ if (Handlers.length > 0)
 }
 
 ///
-unittest
+@system unittest
 {
     Algebraic!(int, string) variant;
 
@@ -2153,7 +2153,7 @@ unittest
     assert(which == -100);
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     Algebraic!(int, string) variant;
@@ -2186,7 +2186,7 @@ private template isAlgebraic(Type)
         enum isAlgebraic = false;
 }
 
-unittest
+@system unittest
 {
     static assert(!isAlgebraic!(Variant));
     static assert( isAlgebraic!(Algebraic!(string)));
@@ -2306,7 +2306,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(false);
 }
 
-unittest
+@system unittest
 {
     // validate that visit can be called with a const type
     struct Foo { int depth; }
@@ -2322,7 +2322,7 @@ unittest
     assert(depth(fb) == 3);
 }
 
-unittest
+@system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=16383
     class Foo {this() immutable {}}
@@ -2334,7 +2334,7 @@ unittest
     assert(x == 3);
 }
 
-unittest
+@system unittest
 {
     // http://d.puremagic.com/issues/show_bug.cgi?id=5310
     const Variant a;
@@ -2344,13 +2344,13 @@ unittest
     assert(b == a);
 }
 
-unittest
+@system unittest
 {
     const Variant a = [2];
     assert(a[0] == 2);
 }
 
-unittest
+@system unittest
 {
     // http://d.puremagic.com/issues/show_bug.cgi?id=10017
     static struct S
@@ -2363,7 +2363,7 @@ unittest
     v2 = v1;  // AssertError: target must be non-null
     assert(v1 == v2);
 }
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     // http://d.puremagic.com/issues/show_bug.cgi?id=7069
@@ -2525,7 +2525,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     static struct DummyScope
     {
@@ -2539,7 +2539,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=10194
     // Also test for elaborate copying
@@ -2585,7 +2585,7 @@ unittest
     assert(S.cnt == 0);
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 13300
     static struct S
@@ -2615,7 +2615,7 @@ unittest
     auto a = appender!(T[]);
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 13871
     alias A = Algebraic!(int, typeof(null));
@@ -2626,7 +2626,7 @@ unittest
     var = C(B());
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown, assertNotThrown;
     // Make sure Variant can handle types with opDispatch but no length field.
@@ -2654,7 +2654,7 @@ unittest
     assertThrown!VariantException(v.length);
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 13534
     static assert(!__traits(compiles, () @safe {
@@ -2664,7 +2664,7 @@ unittest
     }));
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 15039
     import std.variant;
@@ -2682,7 +2682,7 @@ unittest
     );
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 15791
     int n = 3;
@@ -2696,7 +2696,7 @@ unittest
     assert(v.get!NS2.foo() == 30);
 }
 
-unittest
+@system unittest
 {
     // Bugzilla 15827
     static struct Foo15827 { Variant v; this(Foo15827 v) {} }

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -84,7 +84,7 @@ class Win32Exception : WindowsException
 
 version(unittest) import std.string : startsWith, endsWith;
 
-unittest
+@safe unittest
 {
     // Test that we can throw and catch one by its own type
     string message = "Test W1";
@@ -94,7 +94,7 @@ unittest
     assert(e.msg.startsWith(message));
 }
 
-unittest
+@system unittest
 {
     // ditto
     string message = "Test W2";
@@ -139,7 +139,7 @@ public:
     }
 }
 
-unittest
+@system unittest
 {
     // (i) Test that we can throw and catch one by its own type
     string message = "Test 1";
@@ -151,7 +151,7 @@ unittest
     assert(e.msg.startsWith(message));
 }
 
-unittest
+@safe unittest
 {
     // ditto
     string message = "Test 2";
@@ -1738,7 +1738,7 @@ private:
 }
 
 
-unittest
+@system unittest
 {
     debug(winreg) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
     debug(winreg) writefln("std.windows.registry.unittest read");
@@ -1771,7 +1771,7 @@ unittest
     }
 }
 
-unittest
+@system unittest
 {
     debug(winreg) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
     debug(winreg) writefln("std.windows.registry.unittest write");

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -178,7 +178,7 @@ T wenforce(T)(T condition, const(char)[] name, const(wchar)* namez, string file 
 }
 
 version(Windows)
-unittest
+@system unittest
 {
     import std.exception;
     import std.string;

--- a/std/xml.d
+++ b/std/xml.d
@@ -1299,7 +1299,7 @@ class Comment : Item
     override @property @safe @nogc pure nothrow bool isEmptyXML() const { return false; } /// Returns false always
 }
 
-unittest // issue 16241
+@safe unittest // issue 16241
 {
     import std.exception : assertThrown;
     auto c = new Comment("==");


### PR DESCRIPTION
This is a reboot of #4952 (check it for a motivation).

This enables a new [Dscanner plugin](https://github.com/Hackerpilot/Dscanner/pull/389) to enforce `@system` or `@safe` on unittest blocks.

I used [a script](https://github.com/wilzbach/dscanner-fix) that tried to add `@safe` to every unattributed `unittest` and checked whether it still compiles successfully.

CC @andralex 