### PR TITLE
Declare variables as immutable

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1408,10 +1408,10 @@ if (T.length >= 2)
     int a = 5;
     short b = 6;
     double c = 2;
-    immutable d = max(a, b);
+    auto d = max(a, b);
     assert(is(typeof(d) == int));
     assert(d == 6);
-    immutable e = min(a, b, c);
+    auto e = min(a, b, c);
     assert(is(typeof(e) == double));
     assert(e == 2);
 }

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1408,10 +1408,10 @@ if (T.length >= 2)
     int a = 5;
     short b = 6;
     double c = 2;
-    auto d = max(a, b);
+    immutable d = max(a, b);
     assert(is(typeof(d) == int));
     assert(d == 6);
-    auto e = min(a, b, c);
+    immutable e = min(a, b, c);
     assert(is(typeof(e) == double));
     assert(e == 2);
 }
@@ -2131,7 +2131,7 @@ if (alternatives.length >= 1 &&
 
     immutable p = 1;
     immutable q = 2;
-    auto pq = either(p, q);
+    immutable pq = either(p, q);
     static assert(is(typeof(pq) == immutable(int)));
     assert(pq == p);
 

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -98,7 +98,7 @@ if (fun.length >= 1)
     {
         import std.algorithm.comparison : equal, max, min;
 
-        auto data = [[4, 2, 1, 3], [4, 9, -1, 3, 2], [3]];
+        immutable data = [[4, 2, 1, 3], [4, 9, -1, 3, 2], [3]];
 
         // Single aggregating function
         auto agg1 = data.aggregate!max;
@@ -297,7 +297,7 @@ same cost or side effects.
         void popFront() {initialized = false;}
         enum empty = false;
     }
-    auto r = Range().cache();
+    immutable r = Range().cache();
     assert(r.source.initialized == true);
 }
 
@@ -833,7 +833,7 @@ private struct MapResult(alias fun, Range)
 {
     import std.range;
     struct S {int* p;}
-    auto m = immutable(S).init.repeat().map!"a".save;
+    immutable m = immutable(S).init.repeat().map!"a".save;
 }
 
 // each
@@ -1522,11 +1522,11 @@ if (isInputRange!R)
 {
     // Issue 13857
     immutable(int)[] a1 = [1,1,2,2,2,3,4,4,5,6,6,7,8,9,9,9];
-    auto g1 = group(a1);
+    immutable g1 = group(a1);
 
     // Issue 13162
     immutable(ubyte)[] a2 = [1, 1, 1, 0, 0, 0];
-    auto g2 = a2.group;
+    immutable g2 = a2.group;
 
     // Issue 10104
     const a3 = [1, 1, 2, 2];
@@ -1538,7 +1538,7 @@ if (isInputRange!R)
     auto g4 = a4.group!"a is b";
 
     immutable I[] a5 = [new immutable C()];
-    auto g5 = a5.group!"a is b";
+    immutable g5 = a5.group!"a is b";
 
     const(int[][]) a6 = [[1], [1]];
     auto g6 = a6.group;
@@ -1876,7 +1876,7 @@ if (isInputRange!Range)
     import std.algorithm.comparison : equal;
 
     // Grouping by particular attribute of each element:
-    auto data = [
+    immutable data = [
         [1, 1],
         [1, 2],
         [2, 2],
@@ -1900,7 +1900,7 @@ if (isInputRange!Range)
 version(none) // this example requires support for non-equivalence relations
 @safe unittest
 {
-    auto data = [
+    immutable data = [
         [1, 1],
         [1, 2],
         [2, 2],
@@ -2628,7 +2628,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     auto r = joiner([inputRangeObject("ab"), inputRangeObject("cd")]);
     assert(isForwardRange!(typeof(r)));
 
-    auto str = to!string(r);
+    immutable str = to!string(r);
     assert(str == "abcd");
 }
 
@@ -2868,17 +2868,17 @@ remarkable power and flexibility.
     assert(largest == 5);
 
     // Compute the number of odd elements
-    auto odds = reduce!((a,b) => a + (b & 1))(0, arr);
+    immutable odds = reduce!((a,b) => a + (b & 1))(0, arr);
     assert(odds == 3);
 
     // Compute the sum of squares
-    auto ssquares = reduce!((a,b) => a + b * b)(0, arr);
+    immutable ssquares = reduce!((a,b) => a + b * b)(0, arr);
     assert(ssquares == 55);
 
     // Chain multiple ranges into seed
     int[] a = [ 3, 4 ];
     int[] b = [ 100 ];
-    auto r = reduce!("a + b")(chain(a, b));
+    immutable r = reduce!("a + b")(chain(a, b));
     assert(r == 107);
 
     // Mixing convertible types is fair game, too
@@ -2918,7 +2918,7 @@ The number of seeds must be correspondingly increased.
     assert(approxEqual(r[1], 233)); // sum of squares
     // Compute average and standard deviation from the above
     auto avg = r[0] / a.length;
-    auto stdev = sqrt(r[1] / a.length - avg * avg);
+    immutable stdev = sqrt(r[1] / a.length - avg * avg);
 }
 
 @safe unittest
@@ -2935,7 +2935,7 @@ The number of seeds must be correspondingly increased.
     r = reduce!(min)(a);
     assert(r == 3);
     double[] b = [ 100 ];
-    auto r1 = reduce!("a + b")(chain(a, b));
+    immutable r1 = reduce!("a + b")(chain(a, b));
     assert(r1 == 107);
 
     // two funs
@@ -3021,8 +3021,8 @@ The number of seeds must be correspondingly increased.
 
     enum foo = "a + 0.5 * b";
     auto r = [0, 1, 2, 3];
-    auto r1 = reduce!foo(r);
-    auto r2 = reduce!(foo, foo)(r);
+    immutable r1 = reduce!foo(r);
+    immutable r2 = reduce!(foo, foo)(r);
     assert(r1 == 3);
     assert(r2 == tuple(3, 3));
 }
@@ -3056,12 +3056,12 @@ The number of seeds must be correspondingly increased.
         auto b = reduce!(fun, fun)([1, 2, 3]);
         auto c = reduce!(fun)(0, [1, 2, 3]);
         auto d = reduce!(fun, fun)(tuple(0, 0), [1, 2, 3]);
-        auto e = reduce!(fun)(0, OpApply());
-        auto f = reduce!(fun, fun)(tuple(0, 0), OpApply());
+        immutable e = reduce!(fun)(0, OpApply());
+        immutable f = reduce!(fun, fun)(tuple(0, 0), OpApply());
 
         return max(a, b.expand, c, d.expand);
     }
-    auto a = foo();
+    immutable a = foo();
     enum b = foo();
 }
 
@@ -3513,7 +3513,7 @@ The number of seeds must be correspondingly increased.
     import std.typecons : tuple;
 
     enum foo = "a + 0.5 * b";
-    auto r = [0, 1, 2, 3];
+    immutable r = [0, 1, 2, 3];
     auto r1 = r.cumulativeFold!foo;
     auto r2 = r.cumulativeFold!(foo, foo);
     assert(approxEqual(r1, [0, 0.5, 1.5, 3]));
@@ -4517,7 +4517,7 @@ if (isSomeChar!C)
        foreach (word; splitter(strip(line)))
        {
             if (word in dictionary) continue; // Nothing to do
-            auto newID = dictionary.length;
+            immutable newID = dictionary.length;
             dictionary[to!string(word)] = cast(uint)newID;
         }
     }
@@ -4870,8 +4870,8 @@ private auto sumKahan(Result, R)(Result result, R r)
 @safe pure nothrow unittest // 12434
 {
     immutable a = [10, 20];
-    auto s1 = sum(a);             // Error
-    auto s2 = a.map!(x => x).sum; // Error
+    immutable s1 = sum(a);             // Error
+    immutable s2 = a.map!(x => x).sum; // Error
 }
 
 @system unittest
@@ -4881,8 +4881,8 @@ private auto sumKahan(Result, R)(Result result, R r)
 
     immutable BigInt[] a = BigInt("1_000_000_000_000_000_000").repeat(10).array();
     immutable ulong[]  b = (ulong.max/2).repeat(10).array();
-    auto sa = a.sum();
-    auto sb = b.sum(BigInt(0)); //reduce ulongs into bigint
+    immutable sa = a.sum();
+    immutable sb = b.sum(BigInt(0)); //reduce ulongs into bigint
     assert(sa == BigInt("10_000_000_000_000_000_000"));
     assert(sb == (BigInt(ulong.max/2) * 10));
 }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2599,8 +2599,8 @@ void swapAt(R)(auto ref R r, size_t i1, size_t i2)
     else
     {
         if (i1 == i2) return;
-        immutable t1 = r.moveAt(i1);
-        immutable t2 = r.moveAt(i2);
+        auto t1 = r.moveAt(i1);
+        auto t2 = r.moveAt(i2);
         r[i2] = t1;
         r[i1] = t2;
     }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -208,7 +208,7 @@ buffer. For example:
 @safe unittest
 {
     auto arr = [4, 5, 6, 7, 1, 2, 3];
-    auto p = bringToFront(arr[0 .. 4], arr[4 .. $]);
+    immutable p = bringToFront(arr[0 .. 4], arr[4 .. $]);
     assert(p == arr.length - 4);
     assert(arr == [ 1, 2, 3, 4, 5, 6, 7 ]);
 }
@@ -286,7 +286,7 @@ Unicode integrity is not preserved:
         int[] c = a ~ b;
         // writeln("a= ", a);
         // writeln("b= ", b);
-        auto n = bringToFront(c[0 .. a.length], c[a.length .. $]);
+        immutable n = bringToFront(c[0 .. a.length], c[a.length .. $]);
         //writeln("c= ", c);
         assert(n == b.length);
         assert(c == b ~ a, text(c, "\n", a, "\n", b));
@@ -308,7 +308,7 @@ Unicode integrity is not preserved:
         }
         auto a = R!int([1, 2, 3, 4, 5]);
         auto b = R!real([6, 7, 8, 9]);
-        auto n = bringToFront(a, b);
+        immutable n = bringToFront(a, b);
         assert(n == 4);
         assert(a.data == [6, 7, 8, 9, 1]);
         assert(b.data == [2, 3, 4, 5]);
@@ -334,7 +334,7 @@ Unicode integrity is not preserved:
 
     // Bugzilla 16959
     auto arr = ['4', '5', '6', '7', '1', '2', '3'];
-    auto p = bringToFront(arr[0 .. 4], arr[4 .. $]);
+    immutable p = bringToFront(arr[0 .. 4], arr[4 .. $]);
 
     assert(p == arr.length - 4);
     assert(arr == ['1', '2', '3', '4', '5', '6', '7']);
@@ -1241,7 +1241,7 @@ unittest// Issue 8055
     }
     S a;
     a.x = 0;
-    auto b = foo(a);
+    immutable b = foo(a);
     assert(b.x == 0);
 }
 
@@ -1906,7 +1906,7 @@ if (s == SwapStrategy.stable
     import std.range;
     // Bug# 12889
     int[1][] arr = [[0], [1], [2], [3], [4], [5], [6]];
-    auto orig = arr.dup;
+    immutable orig = arr.dup;
     foreach (i; iota(arr.length))
     {
         assert(orig == arr.remove!(SwapStrategy.unstable)(tuple(i,i)));
@@ -2599,8 +2599,8 @@ void swapAt(R)(auto ref R r, size_t i1, size_t i2)
     else
     {
         if (i1 == i2) return;
-        auto t1 = r.moveAt(i1);
-        auto t2 = r.moveAt(i2);
+        immutable t1 = r.moveAt(i1);
+        immutable t2 = r.moveAt(i2);
         r[i2] = t1;
         r[i1] = t2;
     }

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1860,7 +1860,7 @@ if (isRandomAccessRange!R1 && hasLength!R1 && hasSlicing!R1 && isBidirectionalRa
     {
         auto needleFirstElem = needle[0];
         auto partitions      = haystack.trisect(needleFirstElem);
-        auto firstElemLen    = partitions[1].length;
+        immutable firstElemLen    = partitions[1].length;
         size_t count         = 0;
 
         if (firstElemLen == 0)
@@ -1984,7 +1984,7 @@ if (isRandomAccessRange!R1 && hasLength!R1 && hasSlicing!R1 && isBidirectionalRa
         void popBack() { return payload.popBack(); }
     }
     //static assert(isBidirectionalRange!BiRange);
-    auto r = BiRange([1, 2, 3, 10, 11, 4]);
+    immutable r = BiRange([1, 2, 3, 10, 11, 4]);
     //assert(equal(find(r, [3, 10]), BiRange([3, 10, 11, 4])));
     //assert(find("abc", "bc").length == 2);
     debug(std_algorithm) scope(success)
@@ -2175,7 +2175,7 @@ private R1 simpleMindedFind(alias pred, R1, R2)(R1 haystack, scope R2 needle)
 
     // If issue 7992 occurs, this will throw an exception from calling
     // popFront() on an empty range.
-    auto r = find(CustomString("a"), CustomString("b"));
+    immutable r = find(CustomString("a"), CustomString("b"));
 }
 
 /**
@@ -2366,7 +2366,7 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
     string[] ns = ["libphobos", "function", " undefined", "`", ":"];
     foreach (n ; ns)
     {
-        auto p = find(h, boyerMooreFinder(n));
+        immutable p = find(h, boyerMooreFinder(n));
         assert(!p.empty);
     }
 }
@@ -2385,7 +2385,7 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
 @safe unittest
 {
     auto bm = boyerMooreFinder("for");
-    auto match = find("Moor", bm);
+    immutable match = find("Moor", bm);
     assert(match.empty);
 }
 
@@ -4460,6 +4460,6 @@ unittest // bugzilla 13171
 unittest // Issue 13124
 {
     import std.algorithm.comparison : among;
-    auto s = "hello how\nare you";
+    immutable s = "hello how\nare you";
     s.until!(c => c.among!('\n', '\r'));
 }

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -430,7 +430,7 @@ if (ranges.length >= 2 &&
 @safe unittest
 {
     // .init value of cartesianProduct should be empty
-    auto cprod = cartesianProduct([0,0], [1,1], [2,2]);
+    immutable cprod = cartesianProduct([0,0], [1,1], [2,2]);
     assert(!cprod.empty);
     assert(cprod.init.empty);
 }
@@ -529,7 +529,7 @@ pure @safe nothrow @nogc unittest
     assert(isForwardRange!(typeof(C)));
 
     C.popFront();
-    auto front1 = C.front;
+    immutable front1 = C.front;
     auto D = C.save;
     C.popFront();
     assert(D.front == front1);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -502,7 +502,7 @@ if (ss != SwapStrategy.stable && isInputRange!Range && hasSwappableElements!Rang
                 }
                 else
                 {
-                    auto t1 = r.moveFront(), t2 = r.moveBack();
+                    immutable t1 = r.moveFront(), t2 = r.moveBack();
                     r.front = t2;
                     r.back = t1;
                 }
@@ -1509,7 +1509,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     import std.algorithm.mutation : SwapStrategy;
     static struct Point { int x, y; }
     auto pts1 = [ Point(0, 0), Point(5, 5), Point(0, 1), Point(0, 2) ];
-    auto pts2 = [ Point(0, 0), Point(0, 1), Point(0, 2), Point(5, 5) ];
+    immutable pts2 = [ Point(0, 0), Point(0, 1), Point(0, 2), Point(5, 5) ];
     multiSort!("a.x < b.x", "a.y < b.y", SwapStrategy.unstable)(pts1);
     assert(pts1 == pts2);
 }
@@ -3104,7 +3104,7 @@ if (isRandomAccessRange!(Range) && hasLength!Range && hasSlicing!Range)
         // Workaround for https://issues.dlang.org/show_bug.cgi?id=16528
         // Safety checks: enumerate all potentially unsafe generic primitives
         // then use a @trusted implementation.
-        auto b = binaryFun!less(r[0], r[r.length - 1]);
+        immutable b = binaryFun!less(r[0], r[r.length - 1]);
         import std.algorithm.mutation : swapAt;
         r.swapAt(size_t(0), size_t(0));
         auto len = r.length;
@@ -3510,12 +3510,12 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     topN(a, k);
     if (k > 0)
     {
-        auto left = reduce!max(a[0 .. k]);
+        immutable left = reduce!max(a[0 .. k]);
         assert(left <= a[k]);
     }
     if (k + 1 < a.length)
     {
-        auto right = reduce!min(a[k + 1 .. $]);
+        immutable right = reduce!min(a[k + 1 .. $]);
         assert(right >= a[k]);
     }
 }

--- a/std/array.d
+++ b/std/array.d
@@ -260,7 +260,7 @@ if (isNarrowString!String)
     //writeln(c);
 
     immutable d = array([1.0, 2.2, 3][]);
-    assert(is(typeof(d) == double[]));
+    assert(is(typeof(d) == immutable double[]));
     //writeln(d);
 
     auto e = [OpAssign(1), OpAssign(2)];

--- a/std/array.d
+++ b/std/array.d
@@ -141,7 +141,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
 ///
 @safe pure nothrow unittest
 {
-    auto a = array([1, 2, 3, 4, 5][]);
+    immutable a = array([1, 2, 3, 4, 5][]);
     assert(a == [ 1, 2, 3, 4, 5 ]);
 }
 
@@ -187,7 +187,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
 {
     import std.range;
     static struct S{int* p;}
-    auto a = array(immutable(S).init.repeat(5));
+    immutable a = array(immutable(S).init.repeat(5));
 }
 
 /**
@@ -243,11 +243,11 @@ if (isNarrowString!String)
         }
     }
 
-    auto a = array([1, 2, 3, 4, 5][]);
+    immutable a = array([1, 2, 3, 4, 5][]);
     //writeln(a);
     assert(a == [ 1, 2, 3, 4, 5 ]);
 
-    auto b = array([TestArray(1), TestArray(2)][]);
+    immutable b = array([TestArray(1), TestArray(2)][]);
     //writeln(b);
 
     class C
@@ -259,7 +259,7 @@ if (isNarrowString!String)
     auto c = array([new C(1), new C(2)][]);
     //writeln(c);
 
-    auto d = array([1.0, 2.2, 3][]);
+    immutable d = array([1.0, 2.2, 3][]);
     assert(is(typeof(d) == double[]));
     //writeln(d);
 
@@ -400,7 +400,7 @@ if (isInputRange!Range)
 {
     import std.typecons;
     auto a = [tuple!(const string, string)("foo", "bar")];
-    auto b = [tuple!(string, const string)("foo", "bar")];
+    immutable b = [tuple!(string, const string)("foo", "bar")];
     assert(assocArray(a) == [cast(const(string)) "foo": "bar"]);
     static assert(!__traits(compiles, assocArray(b)));
 }
@@ -664,8 +664,8 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
 
 @safe nothrow pure unittest
 {
-    auto s1 = uninitializedArray!(int[])();
-    auto s2 = minimallyInitializedArray!(int[])();
+    immutable s1 = uninitializedArray!(int[])();
+    immutable s2 = minimallyInitializedArray!(int[])();
     assert(s1.length == 0);
     assert(s2.length == 0);
 }
@@ -712,21 +712,21 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
         this() @disable;
         this(this) @disable;
     }
-    auto a1 = minimallyInitializedArray!(S1[][])(2, 2);
+    immutable a1 = minimallyInitializedArray!(S1[][])(2, 2);
     //enum b1 = minimallyInitializedArray!(S1[][])(2, 2);
     static struct S2
     {
         this() @disable;
         //this(this) @disable;
     }
-    auto a2 = minimallyInitializedArray!(S2[][])(2, 2);
+    immutable a2 = minimallyInitializedArray!(S2[][])(2, 2);
     enum b2 = minimallyInitializedArray!(S2[][])(2, 2);
     static struct S3
     {
         //this() @disable;
         this(this) @disable;
     }
-    auto a3 = minimallyInitializedArray!(S3[][])(2, 2);
+    immutable a3 = minimallyInitializedArray!(S3[][])(2, 2);
     enum b3 = minimallyInitializedArray!(S3[][])(2, 2);
 }
 
@@ -1307,7 +1307,7 @@ if (isInputRange!S && !isDynamicArray!S)
 @safe unittest
 {
     auto a = "abc";
-    auto s = replicate(a, 3);
+    immutable s = replicate(a, 3);
 
     assert(s == "abcabcabc");
 
@@ -1437,7 +1437,7 @@ if (isSomeString!S)
     assert(split("hello world") == ["hello","world"]);
     assert(split("192.168.0.1", ".") == ["192", "168", "0", "1"]);
 
-    auto a = split([1, 2, 3, 4, 5, 1, 2, 3, 4, 5], [2, 3]);
+    immutable a = split([1, 2, 3, 4, 5, 1, 2, 3, 4, 5], [2, 3]);
     assert(a == [[1], [4, 5, 1], [4, 5]]);
 }
 
@@ -1724,7 +1724,7 @@ if (isInputRange!RoR &&
     }
     auto a = [new A(`foo`)];
     assert(a[0].length == 3);
-    auto temp = join(a, " ");
+    immutable temp = join(a, " ");
     assert(a[0].length == 3);
 }
 
@@ -1790,7 +1790,7 @@ if (isInputRange!RoR &&
 
     foreach (T; AliasSeq!(string,wstring,dstring))
     {
-        auto arr2 = "Здравствуй Мир Unicode".to!(T);
+        immutable arr2 = "Здравствуй Мир Unicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
         assert(join(arr) == "ЗдравствуйМирUnicode");
         foreach (S; AliasSeq!(char,wchar,dchar))
@@ -1809,7 +1809,7 @@ if (isInputRange!RoR &&
 
     foreach (T; AliasSeq!(string,wstring,dstring))
     {
-        auto arr2 = "Здравствуй\u047CМир\u047CUnicode".to!(T);
+        immutable arr2 = "Здравствуй\u047CМир\u047CUnicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
         foreach (S; AliasSeq!(wchar,dchar))
         {
@@ -1841,7 +1841,7 @@ if (isInputRange!RoR &&
         auto filteredWord1    = filter!"true"(word1);
         auto filteredLenWord1 = takeExactly(filteredWord1, word1.walkLength());
         auto filteredWord2    = filter!"true"(word2);
-        auto filteredLenWord2 = takeExactly(filteredWord2, word2.walkLength());
+        immutable filteredLenWord2 = takeExactly(filteredWord2, word2.walkLength());
         auto filteredWord3    = filter!"true"(word3);
         auto filteredLenWord3 = takeExactly(filteredWord3, word3.walkLength());
         auto filteredWordsArr = [filteredWord1, filteredWord2, filteredWord3];
@@ -2455,7 +2455,7 @@ if (isDynamicArray!(E[]) &&
     assert(b == [1, 1337, 2, 3, 4, 5]);
 
     auto s = "This is a foo foo list";
-    auto r = s.replaceFirst("foo", "silly");
+    immutable r = s.replaceFirst("foo", "silly");
     assert(r == "This is a silly foo list");
 }
 
@@ -2563,7 +2563,7 @@ if (isDynamicArray!(E[]) &&
     assert(b == [1, 2, 1337, 3, 4, 5]);
 
     auto s = "This is a foo foo list";
-    auto r = s.replaceLast("foo", "silly");
+    immutable r = s.replaceLast("foo", "silly");
     assert(r == "This is a foo silly list", r);
 }
 

--- a/std/base64.d
+++ b/std/base64.d
@@ -679,7 +679,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         void doEncoding()
         {
             auto data = cast(const(ubyte)[])range_.front;
-            auto size = encodeLength(data.length);
+            immutable size = encodeLength(data.length);
             if (size > buffer_.length)
                 buffer_.length = size;
 
@@ -1476,7 +1476,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                 }
             }
 
-            auto size = decodeLength(data.length);
+            immutable size = decodeLength(data.length);
             if (size > buffer_.length)
                 buffer_.length = size;
 

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -127,15 +127,15 @@ public:
         import std.exception : assertThrown;
 
         auto r1 = new ReferenceBidirectionalRange!dchar("101");
-        auto big1 = BigInt(r1);
+        immutable big1 = BigInt(r1);
         assert(big1 == BigInt(101));
 
         auto r2 = new ReferenceBidirectionalRange!dchar("1_000");
-        auto big2 = BigInt(r2);
+        immutable big2 = BigInt(r2);
         assert(big2 == BigInt(1000));
 
         auto r3 = new ReferenceBidirectionalRange!dchar("0x0");
-        auto big3 = BigInt(r3);
+        immutable big3 = BigInt(r3);
         assert(big3 == BigInt(0));
 
         auto r4 = new ReferenceBidirectionalRange!dchar("0x");
@@ -154,7 +154,7 @@ public:
     {
         // @system due to failure in FreeBSD32
         ulong data = 1_000_000_000_000;
-        auto bigData = BigInt(data);
+        immutable bigData = BigInt(data);
         assert(data == BigInt("1_000_000_000_000"));
     }
 
@@ -199,7 +199,7 @@ public:
     ///
     @system unittest
     {
-        auto b1 = BigInt("123");
+        immutable b1 = BigInt("123");
         auto b2 = BigInt("456");
         b2 = b1;
         assert(b2 == BigInt("123"));
@@ -363,7 +363,7 @@ public:
     {
         // @system because opOpAssign is @system
         auto x = BigInt("123");
-        auto y = BigInt("321");
+        immutable y = BigInt("321");
         x += y;
         assert(x == BigInt("444"));
     }
@@ -383,8 +383,8 @@ public:
     ///
     @system unittest
     {
-        auto x = BigInt("123");
-        auto y = BigInt("456");
+        immutable x = BigInt("123");
+        immutable y = BigInt("456");
         BigInt z = x * y;
         assert(z == BigInt("56088"));
     }
@@ -456,7 +456,7 @@ public:
     ///
     @system unittest
     {
-        auto  x  = BigInt("1_000_000_500");
+        immutable  x  = BigInt("1_000_000_500");
         long  l  = 1_000_000L;
         ulong ul = 2_000_000UL;
         int   i  = 500_000;
@@ -481,7 +481,7 @@ public:
     ///
     @system unittest
     {
-        auto x = BigInt("100");
+        immutable x = BigInt("100");
         BigInt y = 123 + x;
         assert(y == BigInt("223"));
 
@@ -602,8 +602,8 @@ public:
     ///
     @system unittest
     {
-        auto x = BigInt("12345");
-        auto y = BigInt("12340");
+        immutable x = BigInt("12345");
+        immutable y = BigInt("12340");
         int z = 12345;
         int w = 54321;
 
@@ -626,13 +626,13 @@ public:
     @system unittest
     {
         // Non-zero values are regarded as true
-        auto x = BigInt("1");
-        auto y = BigInt("10");
+        immutable x = BigInt("1");
+        immutable y = BigInt("10");
         assert(x);
         assert(y);
 
         // Zero value is regarded as false
-        auto z = BigInt("0");
+        immutable z = BigInt("0");
         assert(!z);
     }
 
@@ -770,8 +770,8 @@ public:
     ///
     @system unittest
     {
-        auto x = BigInt("100");
-        auto y = BigInt("10");
+        immutable x = BigInt("100");
+        immutable y = BigInt("10");
         int z = 50;
         const int w = 200;
 
@@ -996,7 +996,7 @@ private:
 {
     BigInt a = "9588669891916142";
     BigInt b = "7452469135154800";
-    auto c = a * b;
+    immutable c = a * b;
     assert(c == BigInt("71459266416693160362545788781600"));
     auto d = b * a;
     assert(d == BigInt("71459266416693160362545788781600"));
@@ -1005,7 +1005,7 @@ private:
     assert(d == BigInt("56783581982794522489042432639320434378739200"));
     auto e = c + d;
     assert(e == BigInt("56783581982865981755459125799682980167520800"));
-    auto f = d + c;
+    immutable f = d + c;
     assert(f == e);
     auto g = f - c;
     assert(g == d);
@@ -1013,8 +1013,8 @@ private:
     assert(g == c);
     e = 12345678;
     g = c + e;
-    auto h = g / b;
-    auto i = g % b;
+    immutable h = g / b;
+    immutable i = g % b;
     assert(h == a);
     assert(i == e);
     BigInt j = "-0x9A56_57f4_7B83_AB78";
@@ -1044,7 +1044,7 @@ string toDecimalString(const(BigInt) x)
     x *= 1000;
     x += 456;
 
-    auto xstr = x.toDecimalString();
+    immutable xstr = x.toDecimalString();
     assert(xstr == "123456");
 }
 
@@ -1072,7 +1072,7 @@ string toHex(const(BigInt) x)
     x *= 1000;
     x += 456;
 
-    auto xstr = x.toHex();
+    immutable xstr = x.toHex();
     assert(xstr == "1E240");
 }
 
@@ -1110,7 +1110,7 @@ unittest
     BigInt a, b;
     a = 1;
     b = 2;
-    auto c = a + b;
+    immutable c = a + b;
 }
 
 nothrow pure @system
@@ -1118,8 +1118,8 @@ unittest
 {
     long a;
     BigInt b;
-    auto c = a + b;
-    auto d = b + a;
+    immutable c = a + b;
+    immutable d = b + a;
 }
 
 nothrow pure @system
@@ -1142,7 +1142,7 @@ unittest
     assert(r3 == 5);
 
     BigInt[] arr = [BigInt(1)];
-    auto incr = arr[0]++;
+    immutable incr = arr[0]++;
     assert(arr == [BigInt(2)]);
     assert(incr == BigInt(1));
 }
@@ -1237,7 +1237,7 @@ unittest
     BigInt n7793 = 10;
     assert( n7793 / 1 == 10);
     // Bug 7973
-    auto a7973 = 10_000_000_000_000_000;
+    immutable a7973 = 10_000_000_000_000_000;
     const c7973 = 10_000_000_000_000_000;
     immutable i7973 = 10_000_000_000_000_000;
     BigInt v7973 = 2551700137;
@@ -1435,12 +1435,12 @@ unittest
 @safe unittest
 {
     import std.math : abs;
-    auto r = abs(BigInt(-1000)); // 6486
+    immutable r = abs(BigInt(-1000)); // 6486
     assert(r == 1000);
 
-    auto r2 = abs(const(BigInt)(-500)); // 11188
+    immutable r2 = abs(const(BigInt)(-500)); // 11188
     assert(r2 == 500);
-    auto r3 = abs(immutable(BigInt)(-733)); // 11188
+    immutable r3 = abs(immutable(BigInt)(-733)); // 11188
     assert(r3 == 733);
 
     // opCast!bool
@@ -1609,8 +1609,8 @@ unittest
     assert(is(typeof(x % 1L) == long));
     assert(is(typeof(x % 1UL) == BigInt));
 
-    auto x1 = BigInt(8);
-    auto x2 = -BigInt(long.min) + 1;
+    immutable x1 = BigInt(8);
+    immutable x2 = -BigInt(long.min) + 1;
 
     // long
     assert(x1 % 2L == 0L);

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -829,7 +829,7 @@ public:
 
         void Fun(const BitArray arr)
         {
-            auto x = arr[0];
+            immutable x = arr[0];
             assert(x == 1);
         }
         BitArray a;
@@ -1121,13 +1121,13 @@ public:
         static bool[] bf = [1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
         static bool[] bg = [1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 
-        auto a = BitArray(ba);
-        auto b = BitArray(bb);
-        auto c = BitArray(bc);
-        auto d = BitArray(bd);
-        auto e = BitArray(be);
-        auto f = BitArray(bf);
-        auto g = BitArray(bg);
+        immutable a = BitArray(ba);
+        immutable b = BitArray(bb);
+        immutable c = BitArray(bc);
+        immutable d = BitArray(bd);
+        immutable e = BitArray(be);
+        immutable f = BitArray(bf);
+        immutable g = BitArray(bg);
 
         assert(a != b);
         assert(a != c);
@@ -1187,12 +1187,12 @@ public:
         static bool[] bf = [1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
         static bool[] bg = [1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0];
 
-        auto a = BitArray(ba);
+        immutable a = BitArray(ba);
         auto b = BitArray(bb);
         auto c = BitArray(bc);
         auto d = BitArray(bd);
         auto e = BitArray(be);
-        auto f = BitArray(bf);
+        immutable f = BitArray(bf);
         auto g = BitArray(bg);
 
         assert(a >  b);
@@ -1212,7 +1212,7 @@ public:
         {
             v.length = i;
             v[] = false;
-            auto x = BitArray(v);
+            immutable x = BitArray(v);
             v[i-1] = true;
             auto y = BitArray(v);
             assert(x < y);
@@ -1379,7 +1379,7 @@ public:
 
         static bool[] ba = [1,0,1,0,1];
 
-        auto a = BitArray(ba);
+        immutable a = BitArray(ba);
         BitArray b = ~a;
 
         assert(b[0] == 0);
@@ -1426,8 +1426,8 @@ public:
         static bool[] ba = [1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
 
-        auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable a = BitArray(ba);
+        immutable b = BitArray(bb);
 
         BitArray c = a & b;
 
@@ -1445,8 +1445,8 @@ public:
         static bool[] ba = [1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
 
-        auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable a = BitArray(ba);
+        immutable b = BitArray(bb);
 
         BitArray c = a | b;
 
@@ -1464,8 +1464,8 @@ public:
         static bool[] ba = [1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
 
-        auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable a = BitArray(ba);
+        immutable b = BitArray(bb);
 
         BitArray c = a ^ b;
 
@@ -1483,8 +1483,8 @@ public:
         static bool[] ba = [1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
 
-        auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable a = BitArray(ba);
+        immutable b = BitArray(bb);
 
         BitArray c = a - b;
 
@@ -1533,7 +1533,7 @@ public:
         static bool[] ba = [1,0,1,0,1,1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
         auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable b = BitArray(bb);
         BitArray c = a;
         c.length = 5;
         c &= b;
@@ -1552,7 +1552,7 @@ public:
         static bool[] bb = [1,0,1,1,0];
 
         auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable b = BitArray(bb);
 
         a &= b;
         assert(a[0] == 1);
@@ -1570,7 +1570,7 @@ public:
         static bool[] bb = [1,0,1,1,0];
 
         auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable b = BitArray(bb);
 
         a |= b;
         assert(a[0] == 1);
@@ -1588,7 +1588,7 @@ public:
         static bool[] bb = [1,0,1,1,0];
 
         auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable b = BitArray(bb);
 
         a ^= b;
         assert(a[0] == 0);
@@ -1606,7 +1606,7 @@ public:
         static bool[] bb = [1,0,1,1,0];
 
         auto a = BitArray(ba);
-        auto b = BitArray(bb);
+        immutable b = BitArray(bb);
 
         a -= b;
         assert(a[0] == 0);
@@ -1728,7 +1728,7 @@ public:
         static bool[] ba = [1,0];
         static bool[] bb = [0,1,0];
 
-        auto a = BitArray(ba);
+        immutable a = BitArray(ba);
         auto b = BitArray(bb);
         BitArray c;
 
@@ -2009,10 +2009,10 @@ public:
         debug(bitarray) printf("BitArray.toString unittest\n");
         auto b = BitArray([0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]);
 
-        auto s1 = format("%s", b);
+        immutable s1 = format("%s", b);
         assert(s1 == "[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]");
 
-        auto s2 = format("%b", b);
+        immutable s2 = format("%b", b);
         assert(s2 == "00001111_00001111");
     }
 
@@ -3708,7 +3708,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
 
     {
         //enum - real
-        auto buffer = appender!(const ubyte[])();
+        immutable buffer = appender!(const ubyte[])();
 
         enum Real: real
         {

--- a/std/complex.d
+++ b/std/complex.d
@@ -327,7 +327,7 @@ if (isFloatingPoint!T)
     ref Complex opOpAssign(string op, C)(C z)
         if (op == "*" && is(C R == Complex!R))
     {
-        auto temp = re*z.re - im*z.im;
+        immutable temp = re*z.re - im*z.im;
         im = im*z.re + re*z.im;
         re = temp;
         return this;
@@ -420,7 +420,7 @@ if (isFloatingPoint!T)
             this *= this;
             break;
         case 3:
-            auto z = this;
+            immutable z = this;
             this *= z;
             this *= z;
             break;
@@ -449,11 +449,11 @@ if (isFloatingPoint!T)
     assert (c2 == -(-c2));
 
     // Check complex-complex operations.
-    auto cpc = c1 + c2;
+    immutable cpc = c1 + c2;
     assert (cpc.re == c1.re + c2.re);
     assert (cpc.im == c1.im + c2.im);
 
-    auto cmc = c1 - c2;
+    immutable cmc = c1 - c2;
     assert (cmc.re == c1.re - c2.re);
     assert (cmc.im == c1.im - c2.im);
 
@@ -472,15 +472,15 @@ if (isFloatingPoint!T)
     // Check complex-real operations.
     double a = 123.456;
 
-    auto cpr = c1 + a;
+    immutable cpr = c1 + a;
     assert (cpr.re == c1.re + a);
     assert (cpr.im == c1.im);
 
-    auto cmr = c1 - a;
+    immutable cmr = c1 - a;
     assert (cmr.re == c1.re - a);
     assert (cmr.im == c1.im);
 
-    auto ctr = c1 * a;
+    immutable ctr = c1 * a;
     assert (ctr.re == c1.re*a);
     assert (ctr.im == c1.im*a);
 
@@ -492,14 +492,14 @@ if (isFloatingPoint!T)
     assert (approxEqual(abs(cer), abs(c1)^^3, EPS));
     assert (approxEqual(arg(cer), arg(c1)*3, EPS));
 
-    auto rpc = a + c1;
+    immutable rpc = a + c1;
     assert (rpc == cpr);
 
-    auto rmc = a - c1;
+    immutable rmc = a - c1;
     assert (rmc.re == a-c1.re);
     assert (rmc.im == -c1.im);
 
-    auto rtc = a * c1;
+    immutable rtc = a * c1;
     assert (rtc == ctr);
 
     auto rdc = a / c1;
@@ -510,11 +510,11 @@ if (isFloatingPoint!T)
     assert (approxEqual(abs(rdc), a/abs(c2), EPS));
     assert (approxEqual(arg(rdc), -arg(c2), EPS));
 
-    auto rec1a = 1.0 ^^ c1;
+    immutable rec1a = 1.0 ^^ c1;
     assert(rec1a.re == 1.0);
     assert(rec1a.im == 0.0);
 
-    auto rec2a = 1.0 ^^ c2;
+    immutable rec2a = 1.0 ^^ c2;
     assert(rec2a.re == 1.0);
     assert(rec2a.im == 0.0);
 
@@ -576,8 +576,8 @@ if (isFloatingPoint!T)
     }
 
     // Check operations between different complex types.
-    auto cf = Complex!float(1.0, 1.0);
-    auto cr = Complex!real(1.0, 1.0);
+    immutable cf = Complex!float(1.0, 1.0);
+    immutable cr = Complex!real(1.0, 1.0);
     auto c1pcf = c1 + cf;
     auto c1pcr = c1 + cr;
     static assert (is(typeof(c1pcf) == Complex!double));
@@ -635,12 +635,12 @@ if (isFloatingPoint!T)
     assert (z == 1.0L);
     assert (z.re == 1.0  &&  z.im == 0.0);
 
-    auto w = Complex!real(1.0, 1.0);
+    immutable w = Complex!real(1.0, 1.0);
     z = w;
     assert (z == w);
     assert (z.re == 1.0  &&  z.im == 1.0);
 
-    auto c = Complex!float(2.0, 2.0);
+    immutable c = Complex!float(2.0, 2.0);
     z = c;
     assert (z == c);
     assert (z.re == 2.0  &&  z.im == 2.0);
@@ -675,11 +675,11 @@ if (is(T R == Complex!R))
         return x + Complex!T(0.0, 1.0);
     }
 
-    auto z1 = addI(1.0);
+    immutable z1 = addI(1.0);
     assert (z1.re == 1.0 && z1.im == 1.0);
 
     enum one = Complex!double(1.0, 0.0);
-    auto z2 = addI(one);
+    immutable z2 = addI(one);
     assert (z1 == z2);
 }
 
@@ -873,8 +873,8 @@ Complex!real expi(real y)  @trusted pure nothrow @nogc
 
     assert(expi(1.3e5L) == complex(std.math.cos(1.3e5L), std.math.sin(1.3e5L)));
     assert(expi(0.0L) == 1.0L);
-    auto z1 = expi(1.234);
-    auto z2 = std.math.expi(1.234);
+    immutable z1 = expi(1.234);
+    immutable z2 = std.math.expi(1.234);
     assert(z1.re == z2.re && z1.im == z2.im);
 }
 
@@ -972,7 +972,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
     {
         import std.array : appender;
         auto w = appender!wstring();
-        auto n = formattedWrite(w, format, c);
+        immutable n = formattedWrite(w, format, c);
         return w.data;
     }
 

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1787,7 +1787,7 @@ if (is(Unqual!T == bool))
      */
     bool opIndex(size_t i)
     {
-        auto div = cast(size_t) (i / bitsPerWord);
+        immutable div = cast(size_t) (i / bitsPerWord);
         auto rem = i % bitsPerWord;
         enforce(div < data.length);
         return cast(bool)(data.ptr[div] & (cast(size_t)1 << rem));

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -849,10 +849,10 @@ private:
 // Issue 8895
 @safe unittest
 {
-    auto a = make!(DList!int)(1,2,3,4);
-    auto b = make!(DList!int)(1,2,3,4);
-    auto c = make!(DList!int)(1,2,3,5);
-    auto d = make!(DList!int)(1,2,3,4,5);
+    immutable a = make!(DList!int)(1,2,3,4);
+    immutable b = make!(DList!int)(1,2,3,4);
+    immutable c = make!(DList!int)(1,2,3,5);
+    immutable d = make!(DList!int)(1,2,3,4,5);
     assert(a == b); // this better terminate!
     assert(!(a == c));
     assert(!(a == d));

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -394,8 +394,8 @@ struct RBNode(V)
             yp = y._parent;
             yl = y._left;
             yr = y._right;
-            auto yc = y.color;
-            auto isyleft = y.isLeftNode;
+            immutable yc = y.color;
+            immutable isyleft = y.isLeftNode;
 
             //
             // replace y's structure with structure of this node.
@@ -828,8 +828,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
         assert(r.front == vals.front);
         assert(r.back != r.front);
-        auto oldfront = r.front;
-        auto oldback = r.back;
+        immutable oldfront = r.front;
+        immutable oldback = r.back;
         r.popFront();
         r.popBack();
         assert(r.front != r.back);
@@ -1055,7 +1055,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
     static if (doUnittest) @safe pure unittest
     {
-        auto ts = new RedBlackTree(1, 2, 3, 4, 5);
+        immutable ts = new RedBlackTree(1, 2, 3, 4, 5);
         assert(cast(Elem)3 in ts);
         assert(cast(Elem)6 !in ts);
     }
@@ -1083,11 +1083,11 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
     static if (doUnittest) unittest
     {
-        auto t1 = new RedBlackTree(1,2,3,4);
-        auto t2 = new RedBlackTree(1,2,3,4);
-        auto t3 = new RedBlackTree(1,2,3,5);
-        auto t4 = new RedBlackTree(1,2,3,4,5);
-        auto o = new Object();
+        immutable t1 = new RedBlackTree(1,2,3,4);
+        immutable t2 = new RedBlackTree(1,2,3,4);
+        immutable t3 = new RedBlackTree(1,2,3,5);
+        immutable t4 = new RedBlackTree(1,2,3,4,5);
+        immutable o = new Object();
 
         assert(t1 == t1);
         assert(t1 == t2);
@@ -1222,7 +1222,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
     {
         auto ts = new RedBlackTree(1,2,3,4,5);
         assert(ts.length == 5);
-        auto x = ts.removeAny();
+        immutable x = ts.removeAny();
         assert(ts.length == 4);
         Elem[] arr;
         foreach (Elem i; 1..6)
@@ -1803,10 +1803,10 @@ assert(equal(rbt[], [5]));
 {
     void test(T)()
     {
-        auto rt1 = new RedBlackTree!(T, "a < b", false)();
-        auto rt2 = new RedBlackTree!(T, "a < b", true)();
-        auto rt3 = new RedBlackTree!(T, "a > b", false)();
-        auto rt4 = new RedBlackTree!(T, "a > b", true)();
+        immutable rt1 = new RedBlackTree!(T, "a < b", false)();
+        immutable rt2 = new RedBlackTree!(T, "a < b", true)();
+        immutable rt3 = new RedBlackTree!(T, "a > b", false)();
+        immutable rt4 = new RedBlackTree!(T, "a > b", true)();
     }
 
     test!long();
@@ -1899,25 +1899,25 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 {
     import std.range : iota;
 
-    auto rbt1 = redBlackTree(0, 1, 5, 7);
-    auto rbt2 = redBlackTree!string("hello", "world");
-    auto rbt3 = redBlackTree!true(0, 1, 5, 7, 5);
-    auto rbt4 = redBlackTree!"a > b"(0, 1, 5, 7);
-    auto rbt5 = redBlackTree!("a > b", true)(0.1, 1.3, 5.9, 7.2, 5.9);
+    immutable rbt1 = redBlackTree(0, 1, 5, 7);
+    immutable rbt2 = redBlackTree!string("hello", "world");
+    immutable rbt3 = redBlackTree!true(0, 1, 5, 7, 5);
+    immutable rbt4 = redBlackTree!"a > b"(0, 1, 5, 7);
+    immutable rbt5 = redBlackTree!("a > b", true)(0.1, 1.3, 5.9, 7.2, 5.9);
 
     // also works with ranges
-    auto rbt6 = redBlackTree(iota(3));
-    auto rbt7 = redBlackTree!true(iota(3));
-    auto rbt8 = redBlackTree!"a > b"(iota(3));
-    auto rbt9 = redBlackTree!("a > b", true)(iota(3));
+    immutable rbt6 = redBlackTree(iota(3));
+    immutable rbt7 = redBlackTree!true(iota(3));
+    immutable rbt8 = redBlackTree!"a > b"(iota(3));
+    immutable rbt9 = redBlackTree!("a > b", true)(iota(3));
 }
 
 //Combinations not in examples.
 @safe pure unittest
 {
-    auto rbt1 = redBlackTree!(true, string)("hello", "hello");
+    immutable rbt1 = redBlackTree!(true, string)("hello", "hello");
     auto rbt2 = redBlackTree!((a, b){return a < b;}, double)(5.1, 2.3);
-    auto rbt3 = redBlackTree!("a > b", true, string)("hello", "world");
+    immutable rbt3 = redBlackTree!("a > b", true, string)("hello", "world");
 }
 
 //Range construction.
@@ -2010,17 +2010,17 @@ unittest
 {
     import std.conv : to;
 
-    auto rt1 = redBlackTree!string();
+    immutable rt1 = redBlackTree!string();
     assert(rt1.to!string == "RedBlackTree([])");
 
-    auto rt2 = redBlackTree!string("hello");
+    immutable rt2 = redBlackTree!string("hello");
     assert(rt2.to!string == "RedBlackTree([\"hello\"])");
 
-    auto rt3 = redBlackTree!string("hello", "world", "!");
+    immutable rt3 = redBlackTree!string("hello", "world", "!");
     assert(rt3.to!string == "RedBlackTree([\"!\", \"hello\", \"world\"])");
 
     // type deduction can be done automatically
-    auto rt4 = redBlackTree(["hello"]);
+    immutable rt4 = redBlackTree(["hello"]);
     assert(rt4.to!string == "RedBlackTree([\"hello\"])");
 }
 

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -646,7 +646,7 @@ unittest
 unittest
 {
     auto a = SList!int(1, 2, 3);
-    auto b = [4, 5, 6];
+    immutable b = [4, 5, 6];
     auto c = a ~ b;
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
@@ -667,7 +667,7 @@ unittest
 
 unittest
 {
-    auto a = [1, 2, 3];
+    immutable a = [1, 2, 3];
     auto b = SList!int(4, 5, 6);
     auto c = a ~ b;
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
@@ -788,7 +788,7 @@ unittest
 
 unittest
 {
-    auto s = make!(SList!int)(1, 2, 3);
+    immutable s = make!(SList!int)(1, 2, 3);
 }
 
 unittest

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -88,10 +88,10 @@ unittest
     import std.container;
     import std.algorithm.comparison : equal;
 
-    auto a = make!(DList!int)(1,2,3,4);
-    auto b = make!(DList!int)(1,2,3,4);
-    auto c = make!(DList!int)(1,2,3,5);
-    auto d = make!(DList!int)(1,2,3,4,5);
+    immutable a = make!(DList!int)(1,2,3,4);
+    immutable b = make!(DList!int)(1,2,3,4);
+    immutable c = make!(DList!int)(1,2,3,5);
+    immutable d = make!(DList!int)(1,2,3,4,5);
     assert(a == b); // this better terminate!
     assert(a != c);
     assert(a != d);

--- a/std/conv.d
+++ b/std/conv.d
@@ -1608,7 +1608,7 @@ private void testFloatingToIntegral(Floating, Integral)()
         foreach (T; AllNumerics)
         {
             T a = 42;
-            immutable b = to!T(a);
+            auto b = to!T(a);
             assert(is(typeof(a) == typeof(b)) && a == b);
         }
     }

--- a/std/conv.d
+++ b/std/conv.d
@@ -225,7 +225,7 @@ template to(T)
 {
     auto str = to!string(42, 16);
     assert(str == "2A");
-    auto i = to!int(str, 16);
+    immutable i = to!int(str, 16);
     assert(i == 42);
 }
 
@@ -254,10 +254,10 @@ template to(T)
     import std.string : split;
 
     int[] a = [1, 2, 3];
-    auto b = to!(float[])(a);
+    immutable b = to!(float[])(a);
     assert(b == [1.0f, 2, 3]);
     string str = "1 2 3 4 5 6";
-    auto numbers = to!(double[])(split(str));
+    immutable numbers = to!(double[])(split(str));
     assert(numbers == [1.0, 2, 3, 4, 5, 6]);
     int[string] c;
     c["a"] = 1;
@@ -345,11 +345,11 @@ template to(T)
     assert(to!string("foo\0".ptr) == "foo");
 
     // Conversion reinterpreting void array to string
-    auto w = "abcx"w;
+    immutable w = "abcx"w;
     const(void)[] b = w;
     assert(b.length == 8);
 
-    auto c = to!(wchar[])(b);
+    immutable c = to!(wchar[])(b);
     assert(c == "abcx");
 }
 
@@ -438,14 +438,14 @@ if (isImplicitlyConvertible!(S, T) &&
 @safe pure nothrow unittest
 {
     enum E { a }  // Issue 9523 - Allow identity enum conversion
-    auto e = to!E(E.a);
+    immutable e = to!E(E.a);
     assert(e == E.a);
 }
 
 @safe pure nothrow unittest
 {
     int a = 42;
-    auto b = to!long(a);
+    immutable b = to!long(a);
     assert(a == b);
 }
 
@@ -634,7 +634,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     }
 
     string s = "101";
-    auto i3 = to!FakeBigInt(s);
+    immutable i3 = to!FakeBigInt(s);
 }
 
 /// ditto
@@ -665,14 +665,14 @@ if (!isImplicitlyConvertible!(S, T) &&
     }
 
     S s = S(1);
-    auto b1 = to!B(s);  // == new B(s)
+    immutable b1 = to!B(s);  // == new B(s)
     assert(b1.value == 1);
 
     C c = new C(2);
     auto b2 = to!B(c);  // == new B(c)
     assert(b2.value == 2);
 
-    auto c2 = to!C(3);   // == new C(3)
+    immutable c2 = to!C(3);   // == new C(3)
     assert(c2.x == 3);
 }
 
@@ -943,7 +943,7 @@ if (!(isImplicitlyConvertible!(S, T) &&
 @system unittest
 {
     immutable(char)* ptr = "hello".ptr;
-    auto result = ptr.to!(char[]);
+    immutable result = ptr.to!(char[]);
 }
 // Bugzilla 8384
 @system unittest
@@ -1211,8 +1211,8 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
 
     foreach (S; AliasSeq!(string, wstring, dstring, const(char[]), const(wchar[]), const(dchar[])))
     {
-        auto s1 = to!S(E.foo);
-        auto s2 = to!S(E.foo);
+        immutable s1 = to!S(E.foo);
+        immutable s2 = to!S(E.foo);
         assert(s1 == s2);
         // ensure we don't allocate when it's unnecessary
         assert(s1 is s2);
@@ -1220,8 +1220,8 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
 
     foreach (S; AliasSeq!(char[], wchar[], dchar[]))
     {
-        auto s1 = to!S(E.foo);
-        auto s2 = to!S(E.foo);
+        immutable s1 = to!S(E.foo);
+        immutable s2 = to!S(E.foo);
         assert(s1 == s2);
         // ensure each mutable array is unique
         assert(s1 !is s2);
@@ -1466,7 +1466,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     immutable s4 = [1, 2, 3, 4];
     foreach (i; [1, 4])
     {
-        auto ex = collectException(s4[0 .. i].to!(int[2]));
+        immutable ex = collectException(s4[0 .. i].to!(int[2]));
             assert(ex && ex.msg == "Length mismatch when converting to static array: 2 vs " ~ [cast(char)(i + '0')],
                 ex ? ex.msg : "Exception was not thrown!");
     }
@@ -1525,10 +1525,10 @@ if (isAssociativeArray!S &&
 @system unittest // Extra cases for AA with qualifiers conversion
 {
     int[][int[]] a;// = [[], []];
-    auto b = to!(immutable(short[])[immutable short[]])(a);
+    immutable b = to!(immutable(short[])[immutable short[]])(a);
 
     double[dstring][int[long[]]] c;
-    auto d = to!(immutable(short[immutable wstring])[immutable string[double[]]])(c);
+    immutable d = to!(immutable(short[immutable wstring])[immutable string[double[]]])(c);
 }
 
 private void testIntegralToFloating(Integral, Floating)()
@@ -1544,7 +1544,7 @@ private void testFloatingToIntegral(Floating, Integral)()
     bool convFails(Source, Target, E)(Source src)
     {
         try
-            auto t = to!Target(src);
+            immutable t = to!Target(src);
         catch (E)
             return true;
         return false;
@@ -1608,7 +1608,7 @@ private void testFloatingToIntegral(Floating, Integral)()
         foreach (T; AllNumerics)
         {
             T a = 42;
-            auto b = to!T(a);
+            immutable b = to!T(a);
             assert(is(typeof(a) == typeof(b)) && a == b);
         }
     }
@@ -1705,7 +1705,7 @@ private void testFloatingToIntegral(Floating, Integral)()
     // test enum to int conversion
     enum Testing { Test1, Test2 }
     Testing t;
-    auto a = to!string(t);
+    immutable a = to!string(t);
     assert(a == "Test1");
 }
 
@@ -1763,7 +1763,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S) &&
     }
 
     // 6255
-    auto n = to!int("FF", 16);
+    immutable n = to!int("FF", 16);
     assert(n == 255);
 }
 
@@ -1908,7 +1908,7 @@ if (isInputRange!Source &&
 
     if (!s.empty)
     {
-        auto c1 = toLower(s.front);
+        immutable c1 = toLower(s.front);
         bool result = c1 == 't';
         if (result || c1 == 'f')
         {
@@ -2093,7 +2093,7 @@ Lerr:
 @safe pure unittest
 {
     string s = "123";
-    auto a = parse!int(s);
+    immutable a = parse!int(s);
     assert(a == 123);
 
     // parse only accepts lvalues
@@ -2105,12 +2105,12 @@ Lerr:
 {
     import std.string : munch;
     string test = "123 \t  76.14";
-    auto a = parse!uint(test);
+    immutable a = parse!uint(test);
     assert(a == 123);
     assert(test == " \t  76.14"); // parse bumps string
     munch(test, " \t\n\r"); // skip ws
     assert(test == "76.14");
-    auto b = parse!double(test);
+    immutable b = parse!double(test);
     assert(b == 76.14);
     assert(test == "");
 }
@@ -2434,7 +2434,7 @@ body
 {
     import std.range : cycle;
     auto r = cycle("2A!");
-    auto u = parse!uint(r, 16);
+    immutable u = parse!uint(r, 16);
     assert(u == 42);
     assert(r.front == '!');
 }
@@ -2786,7 +2786,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
                 //and do rounding
                 if ((msdec & 0xFFE0_0000_0000_0000) != 0)
                 {
-                    auto roundUp = (msdec & 0x1);
+                    immutable roundUp = (msdec & 0x1);
 
                     msdec  = ((cast(ulong)msdec) >> 1);
                     e2++;
@@ -3200,7 +3200,7 @@ unittest
     // Bugzilla 4959
     {
         auto s = "0 ";
-        auto x = parse!double(s);
+        immutable x = parse!double(s);
         assert(s == " ");
         assert(x == 0.0);
     }
@@ -3327,7 +3327,7 @@ if (!isSomeString!Source && isInputRange!Source && isSomeChar!(ElementType!Sourc
     assert (m == "maybe");  // m shouldn't change on failure
 
     auto s = "true";
-    auto b = parse!(const(bool))(s);
+    immutable b = parse!(const(bool))(s);
     assert(b == true);
 }
 
@@ -3609,11 +3609,11 @@ Lfewerr:
     import std.exception;
 
     auto s1 = "[1,2,3,4]";
-    auto sa1 = parse!(int[4])(s1);
+    immutable sa1 = parse!(int[4])(s1);
     assert(sa1 == [1,2,3,4]);
 
     auto s2 = "[[1],[2,3],[4]]";
-    auto sa2 = parse!(int[][3])(s2);
+    immutable sa2 = parse!(int[][3])(s2);
     assert(sa2 == [[1],[2,3],[4]]);
 
     auto s3 = "[1,2,3]";
@@ -4009,11 +4009,11 @@ if (isIntegral!(typeof(decimalInteger)))
 @safe unittest
 {
     // same as 0177
-    auto x = octal!177;
+    immutable x = octal!177;
     // octal is a compile-time device
     enum y = octal!160;
     // Create an unsigned octal
-    auto z = octal!"1_000_000u";
+    immutable z = octal!"1_000_000u";
 }
 
 /*
@@ -4140,7 +4140,7 @@ private bool isOctalLiteral(const string num)
 @safe unittest
 {
     // ensure that you get the right types, even with embedded underscores
-    auto w = octal!"100_000_000_000";
+    immutable w = octal!"100_000_000_000";
     static assert(!is(typeof(w) == int));
     auto w2 = octal!"1_000_000_000";
     static assert(is(typeof(w2) == int));
@@ -4898,7 +4898,7 @@ version(unittest) private class __conv_EmplaceTestClass
         }
         static assert(!is(immutable(S2) : S2));
         S2 sa = void;
-        auto sb = immutable(S2)(null);
+        immutable sb = immutable(S2)(null);
         assert(!__traits(compiles, emplace(&sa, sb)));
     }
 }
@@ -5075,11 +5075,11 @@ version(unittest)
     enum c = bar!S2;
     static assert(c.i == 5);
     // runtime
-    auto aa = bar!int;
+    immutable aa = bar!int;
     assert(aa == 5);
-    auto bb = bar!S1;
+    immutable bb = bar!S1;
     assert(bb.i == 5);
-    auto cc = bar!S2;
+    immutable cc = bar!S2;
     assert(cc.i == 5);
 }
 
@@ -5613,7 +5613,7 @@ if (isIntegral!T)
     // issue 10874
     enum Test { a = 0 }
     ulong l = 0;
-    auto t = l.to!Test;
+    immutable t = l.to!Test;
 }
 
 /**
@@ -5674,7 +5674,7 @@ template castFrom(From)
     // castFrom provides a more reliable alternative to casting:
     {
         long x;
-        auto y = castFrom!long.to!int(x);
+        immutable y = castFrom!long.to!int(x);
     }
 
     // Changing the type of 'x' will now issue a compiler error,
@@ -5686,7 +5686,7 @@ template castFrom(From)
         );
 
         // if cast is still needed, must be changed to:
-        auto y = castFrom!(long*).to!int(x);
+        immutable y = castFrom!(long*).to!int(x);
     }
 }
 
@@ -5834,11 +5834,11 @@ if (hexData.isHexLiteral)
 @safe unittest
 {
     // conversion at compile time
-    auto string1 = hexString!"304A314B";
+    immutable string1 = hexString!"304A314B";
     assert(string1 == "0J1K");
-    auto string2 = hexString!"304A314B"w;
+    immutable string2 = hexString!"304A314B"w;
     assert(string2 == "0J1K"w);
-    auto string3 = hexString!"304A314B"d;
+    immutable string3 = hexString!"304A314B"d;
     assert(string3 == "0J1K"d);
 }
 
@@ -6070,7 +6070,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         assert(r.length == 2);
         assert(r[0] == '1');
         assert(r[1..2].array == "0");
-        auto s = r.save;
+        immutable s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
     }
@@ -6084,7 +6084,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         assert(r.length == 2);
         assert(r[0] == '1');
         assert(r[1..2].array == "0");
-        auto s = r.save;
+        immutable s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
     }
@@ -6100,7 +6100,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         assert(r.length == 2);
         assert(r[0] == '1');
         assert(r[1..2].array == "0");
-        auto s = r.save;
+        immutable s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
     }
@@ -6120,7 +6120,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         assert(r.length == 2);
         assert(r[0] == '1');
         assert(r[1..2].array == "0");
-        auto s = r.save;
+        immutable s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
     }
@@ -6134,7 +6134,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         assert(r.length == 2);
         assert(r[0] == '1');
         assert(r[1..2].array == "0");
-        auto s = r.save;
+        immutable s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
     }

--- a/std/csv.d
+++ b/std/csv.d
@@ -636,7 +636,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 @safe unittest
 {
     string str = "a,b,c\nHello,65,63.63\nWorld,123,3673.562";
-    auto records = csvReader(str, ["a"]);
+    immutable records = csvReader(str, ["a"]);
 
     assert(records.header == ["a","b","c"]);
 }
@@ -1689,9 +1689,9 @@ if (isSomeChar!Separator && isInputRange!Range
     i = 0;
     foreach (data; csvReader!real(csv))
     {
-        auto a = data.front;    data.popFront();
-        auto b = data.front;    data.popFront();
-        auto c = data.front;
+        immutable a = data.front;    data.popFront();
+        immutable b = data.front;    data.popFront();
+        immutable c = data.front;
         int[] row = [cast(int)a, cast(int)b, cast(int)c];
         if (i == 0)
             assert(row == [1, 2, 3]);

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26772,7 +26772,8 @@ private:
         ).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
         assertThrown!DateTimeException((in IntervalRange!(Date, Direction.fwd) range){range.front;}(emptyRange));
 
-        immutable range = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
+        immutable range = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7))
+                                    .fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
         assert(range.front == Date(2010, 7, 4));
 
         immutable poppedRange = Interval!Date(
@@ -27197,7 +27198,8 @@ private:
     immutable range = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
     assert(range.front == Date(2010, 7, 4));
 
-    immutable poppedRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
+    immutable poppedRange = PosInfInterval!Date(Date(2010, 7, 4))
+                                .fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
     assert(poppedRange.front == Date(2010, 7, 7));
 
     const cRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
@@ -27483,7 +27485,8 @@ private:
 //Test NegInfIntervalRange's front.
 @system unittest
 {
-    immutable range = NegInfInterval!Date(Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed));
+    immutable range = NegInfInterval!Date(Date(2012, 1, 7))
+                            .bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed));
     assert(range.front == Date(2012, 1, 7));
 
     immutable poppedRange = NegInfInterval!Date(

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -146,7 +146,7 @@ else version(Posix)
 {
     auto currentTime = Clock.currTime();
     auto timeString = currentTime.toISOExtString();
-    auto restoredTime = SysTime.fromISOExtString(timeString);
+    immutable restoredTime = SysTime.fromISOExtString(timeString);
 }
 
 //Verify Examples for core.time.Duration which couldn't be in core.time.
@@ -540,8 +540,8 @@ public:
 
     deprecated @safe unittest
     {
-        auto a = Clock.currSystemTick;
-        auto b = Clock.currAppTick;
+        immutable a = Clock.currSystemTick;
+        immutable b = Clock.currAppTick;
         assert(a.length);
         assert(b.length);
         assert(a > b);
@@ -628,7 +628,7 @@ public:
         import std.format : format;
         static void test(DateTime dt, immutable TimeZone tz, long expected)
         {
-            auto sysTime = SysTime(dt, tz);
+            immutable sysTime = SysTime(dt, tz);
             assert(sysTime._stdTime == expected);
             assert(sysTime._timezone is (tz is null ? LocalTime() : tz),
                    format("Given DateTime: %s", dt));
@@ -680,7 +680,7 @@ public:
         import std.format : format;
         static void test(DateTime dt, Duration fracSecs, immutable TimeZone tz, long expected)
         {
-            auto sysTime = SysTime(dt, fracSecs, tz);
+            immutable sysTime = SysTime(dt, fracSecs, tz);
             assert(sysTime._stdTime == expected);
             assert(sysTime._timezone is (tz is null ? LocalTime() : tz),
                    format("Given DateTime: %s, Given Duration: %s", dt, fracSecs));
@@ -731,7 +731,7 @@ public:
                          immutable TimeZone tz,
                          long expected)
         {
-            auto sysTime = SysTime(dt, fracSec, tz);
+            immutable sysTime = SysTime(dt, fracSec, tz);
             assert(sysTime._stdTime == expected);
             assert(sysTime._timezone is (tz is null ? LocalTime() : tz),
                    format("Given DateTime: %s, Given FracSec: %s", dt, fracSec));
@@ -779,7 +779,7 @@ public:
         static void test(Date d, immutable TimeZone tz, long expected)
         {
             import std.format : format;
-            auto sysTime = SysTime(d, tz);
+            immutable sysTime = SysTime(d, tz);
             assert(sysTime._stdTime == expected);
             assert(sysTime._timezone is (tz is null ? LocalTime() : tz),
                    format("Given Date: %s", d));
@@ -818,7 +818,7 @@ public:
         static void test(long stdTime, immutable TimeZone tz)
         {
             import std.format : format;
-            auto sysTime = SysTime(stdTime, tz);
+            immutable sysTime = SysTime(stdTime, tz);
             assert(sysTime._stdTime == stdTime);
             assert(sysTime._timezone is (tz is null ? LocalTime() : tz),
                    format("Given stdTime: %s", stdTime));
@@ -903,7 +903,7 @@ public:
             }
         }
 
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         assert(st == st);
@@ -2575,12 +2575,12 @@ public:
         assert(SysTime.fromUnixTime(28800) ==
                SysTime(DateTime(1970, 1, 1), pst));
 
-        auto st1 = SysTime.fromUnixTime(1_198_311_285, UTC());
+        immutable st1 = SysTime.fromUnixTime(1_198_311_285, UTC());
         assert(st1 == SysTime(DateTime(2007, 12, 22, 8, 14, 45), UTC()));
         assert(st1.timezone is UTC());
         assert(st1 == SysTime(DateTime(2007, 12, 22, 0, 14, 45), pst));
 
-        auto st2 = SysTime.fromUnixTime(1_198_311_285, pst);
+        immutable st2 = SysTime.fromUnixTime(1_198_311_285, pst);
         assert(st2 == SysTime(DateTime(2007, 12, 22, 8, 14, 45), UTC()));
         assert(st2.timezone is pst);
         assert(st2 == SysTime(DateTime(2007, 12, 22, 0, 14, 45), pst));
@@ -2592,7 +2592,7 @@ public:
         assert(SysTime.fromUnixTime(1) == SysTime(DateTime(1970, 1, 1, 0, 0, 1), UTC()));
         assert(SysTime.fromUnixTime(-1) == SysTime(DateTime(1969, 12, 31, 23, 59, 59), UTC()));
 
-        auto st = SysTime.fromUnixTime(0);
+        immutable st = SysTime.fromUnixTime(0);
         auto dt = cast(DateTime)st;
         assert(dt <= DateTime(1970, 2, 1) && dt >= DateTime(1969, 12, 31));
         assert(st.timezone is LocalTime());
@@ -6288,7 +6288,7 @@ public:
 
     @safe unittest
     {
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
 
         assert(st + dur!"weeks"(7) == SysTime(DateTime(1999, 8, 24, 12, 30, 33), hnsecs(2_345_678)));
         assert(st + dur!"weeks"(-7) == SysTime(DateTime(1999, 5, 18, 12, 30, 33), hnsecs(2_345_678)));
@@ -6447,7 +6447,7 @@ public:
         testST(beforeBoth2, 20_000_000, SysTime(DateTime(1, 1, 1, 0, 0, 1), hnsecs(9_999_999)));
         testST(beforeBoth2, 20_888_888, SysTime(DateTime(1, 1, 1, 0, 0, 2), hnsecs(888_887)));
 
-        auto duration = dur!"seconds"(12);
+        immutable duration = dur!"seconds"(12);
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
@@ -6473,7 +6473,7 @@ public:
         //hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
         {
-            auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
+            immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
 
             assert(st + TickDuration.from!"usecs"(7) == SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_748)));
             assert(st + TickDuration.from!"usecs"(-7) == SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_608)));
@@ -6510,7 +6510,7 @@ public:
 
     @safe unittest
     {
-        auto before = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable before = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(before + dur!"weeks"(7) == SysTime(DateTime(1999, 8, 24, 12, 30, 33)));
         assert(before + dur!"weeks"(-7) == SysTime(DateTime(1999, 5, 18, 12, 30, 33)));
         assert(before + dur!"days"(7) == SysTime(DateTime(1999, 7, 13, 12, 30, 33)));
@@ -6679,7 +6679,7 @@ public:
             assert(st == SysTime(DateTime(0, 12, 31, 23, 44, 53), hnsecs(51)));
         }
 
-        auto duration = dur!"seconds"(12);
+        immutable duration = dur!"seconds"(12);
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst += duration));
@@ -6811,7 +6811,7 @@ public:
             assert(SysTime(dt, d, UTC()) - SysTime(dt, d, tz) == hours(-8));
         }
 
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st - st == Duration.zero);
@@ -6899,7 +6899,7 @@ public:
 
     @safe unittest
     {
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(!st.isLeapYear);
@@ -6918,7 +6918,7 @@ public:
 
     @safe unittest
     {
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.dayOfWeek == DayOfWeek.tue);
@@ -6945,7 +6945,7 @@ public:
 
     @safe unittest
     {
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.dayOfYear == 187);
@@ -7626,7 +7626,7 @@ public:
 
     @safe unittest
     {
-        auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.isoWeek == 27);
@@ -9682,7 +9682,7 @@ public:
     {
         assertThrown!DateTimeException((in Date date){date.yearBC;}(Date(1, 1, 1)));
 
-        auto date = Date(0, 7, 6);
+        immutable date = Date(0, 7, 6);
         const cdate = Date(0, 7, 6);
         immutable idate = Date(0, 7, 6);
         assert(date.yearBC == 1);
@@ -11642,7 +11642,7 @@ public:
 
     @safe unittest
     {
-        auto date = Date(1999, 7, 6);
+        immutable date = Date(1999, 7, 6);
 
         assert(date + dur!"weeks"(7) == Date(1999, 8, 24));
         assert(date + dur!"weeks"(-7) == Date(1999, 5, 18));
@@ -11680,7 +11680,7 @@ public:
         assert(date - dur!"hnsecs"(-864_000_000_000) == Date(1999, 7, 7));
         assert(date - dur!"hnsecs"(864_000_000_000) == Date(1999, 7, 5));
 
-        auto duration = dur!"days"(12);
+        immutable duration = dur!"days"(12);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         assert(date + duration == Date(1999, 7, 18));
@@ -11708,7 +11708,7 @@ public:
         //hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
         {
-            auto date = Date(1999, 7, 6);
+            immutable date = Date(1999, 7, 6);
 
             assert(date + TickDuration.from!"usecs"(86_400_000_000) == Date(1999, 7, 7));
             assert(date + TickDuration.from!"usecs"(-86_400_000_000) == Date(1999, 7, 5));
@@ -11785,7 +11785,7 @@ public:
             assert(date == Date(1, 6, 19));
         }
 
-        auto duration = dur!"days"(12);
+        immutable duration = dur!"days"(12);
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
@@ -11857,7 +11857,7 @@ public:
 
     @safe unittest
     {
-        auto date = Date(1999, 7, 6);
+        immutable date = Date(1999, 7, 6);
 
         assert(Date(1999, 7, 6) - Date(1998, 7, 6) == dur!"days"(365));
         assert(Date(1998, 7, 6) - Date(1999, 7, 6) == dur!"days"(-365));
@@ -12148,7 +12148,7 @@ public:
 
     @safe unittest
     {
-        auto date = Date(1999, 7, 6);
+        immutable date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         static assert(!__traits(compiles, date.isLeapYear = true));
@@ -12366,7 +12366,7 @@ public:
         foreach (gd; chain(testGregDaysBC, testGregDaysAD))
             assert(gd.date.dayOfGregorianCal == gd.day);
 
-        auto date = Date(1999, 7, 6);
+        immutable date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         assert(date.dayOfGregorianCal == 729_941);
@@ -13575,21 +13575,21 @@ public:
         assert(TimeOfDay(0, 0) == TimeOfDay.init);
 
         {
-            auto tod = TimeOfDay(0, 0);
+            immutable tod = TimeOfDay(0, 0);
             assert(tod._hour == 0);
             assert(tod._minute == 0);
             assert(tod._second == 0);
         }
 
         {
-            auto tod = TimeOfDay(12, 30, 33);
+            immutable tod = TimeOfDay(12, 30, 33);
             assert(tod._hour == 12);
             assert(tod._minute == 30);
             assert(tod._second == 33);
         }
 
         {
-            auto tod = TimeOfDay(23, 59, 59);
+            immutable tod = TimeOfDay(23, 59, 59);
             assert(tod._hour == 23);
             assert(tod._minute == 59);
             assert(tod._second == 59);
@@ -14105,7 +14105,7 @@ public:
 
     @safe unittest
     {
-        auto tod = TimeOfDay(12, 30, 33);
+        immutable tod = TimeOfDay(12, 30, 33);
 
         assert(tod + dur!"hours"(7) == TimeOfDay(19, 30, 33));
         assert(tod + dur!"hours"(-7) == TimeOfDay(5, 30, 33));
@@ -14135,7 +14135,7 @@ public:
         assert(tod - dur!"hnsecs"(-70_000_000) == TimeOfDay(12, 30, 40));
         assert(tod - dur!"hnsecs"(70_000_000) == TimeOfDay(12, 30, 26));
 
-        auto duration = dur!"hours"(11);
+        immutable duration = dur!"hours"(11);
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
         assert(tod + duration == TimeOfDay(23, 30, 33));
@@ -14163,7 +14163,7 @@ public:
         //hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
         {
-            auto tod = TimeOfDay(12, 30, 33);
+            immutable tod = TimeOfDay(12, 30, 33);
 
             assert(tod + TickDuration.from!"usecs"(7_000_000) == TimeOfDay(12, 30, 40));
             assert(tod + TickDuration.from!"usecs"(-7_000_000) == TimeOfDay(12, 30, 26));
@@ -14200,7 +14200,7 @@ public:
 
     @safe unittest
     {
-        auto duration = dur!"hours"(12);
+        immutable duration = dur!"hours"(12);
 
         assert(TimeOfDay(12, 30, 33) + dur!"hours"(7) == TimeOfDay(19, 30, 33));
         assert(TimeOfDay(12, 30, 33) + dur!"hours"(-7) == TimeOfDay(5, 30, 33));
@@ -14307,7 +14307,7 @@ public:
 
     @safe unittest
     {
-        auto tod = TimeOfDay(12, 30, 33);
+        immutable tod = TimeOfDay(12, 30, 33);
 
         assert(TimeOfDay(7, 12, 52) - TimeOfDay(12, 30, 33) == dur!"seconds"(-19_061));
         assert(TimeOfDay(12, 30, 33) - TimeOfDay(7, 12, 52) == dur!"seconds"(19_061));
@@ -14837,19 +14837,19 @@ public:
     @safe unittest
     {
         {
-            auto dt = DateTime.init;
+            immutable dt = DateTime.init;
             assert(dt._date == Date.init);
             assert(dt._tod == TimeOfDay.init);
         }
 
         {
-            auto dt = DateTime(Date(1999, 7 ,6));
+            immutable dt = DateTime(Date(1999, 7 ,6));
             assert(dt._date == Date(1999, 7, 6));
             assert(dt._tod == TimeOfDay.init);
         }
 
         {
-            auto dt = DateTime(Date(1999, 7 ,6), TimeOfDay(12, 30, 33));
+            immutable dt = DateTime(Date(1999, 7 ,6), TimeOfDay(12, 30, 33));
             assert(dt._date == Date(1999, 7, 6));
             assert(dt._tod == TimeOfDay(12, 30, 33));
         }
@@ -14874,13 +14874,13 @@ public:
     @safe unittest
     {
         {
-            auto dt = DateTime(1999, 7 ,6);
+            immutable dt = DateTime(1999, 7 ,6);
             assert(dt._date == Date(1999, 7, 6));
             assert(dt._tod == TimeOfDay.init);
         }
 
         {
-            auto dt = DateTime(1999, 7 ,6, 12, 30, 33);
+            immutable dt = DateTime(1999, 7 ,6, 12, 30, 33);
             assert(dt._date == Date(1999, 7, 6));
             assert(dt._tod == TimeOfDay(12, 30, 33));
         }
@@ -15115,12 +15115,12 @@ public:
     @safe unittest
     {
         {
-            auto dt = DateTime.init;
+            immutable dt = DateTime.init;
             assert(dt.date == Date.init);
         }
 
         {
-            auto dt = DateTime(Date(1999, 7, 6));
+            immutable dt = DateTime(Date(1999, 7, 6));
             assert(dt.date == Date(1999, 7, 6));
         }
 
@@ -15167,12 +15167,12 @@ public:
     @safe unittest
     {
         {
-            auto dt = DateTime.init;
+            immutable dt = DateTime.init;
             assert(dt.timeOfDay == TimeOfDay.init);
         }
 
         {
-            auto dt = DateTime(Date.init, TimeOfDay(12, 30, 33));
+            immutable dt = DateTime(Date.init, TimeOfDay(12, 30, 33));
             assert(dt.timeOfDay == TimeOfDay(12, 30, 33));
         }
 
@@ -16830,7 +16830,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+        immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
 
         assert(dt + dur!"weeks"(7) == DateTime(Date(1999, 8, 24), TimeOfDay(12, 30, 33)));
         assert(dt + dur!"weeks"(-7) == DateTime(Date(1999, 5, 18), TimeOfDay(12, 30, 33)));
@@ -16868,7 +16868,7 @@ public:
         assert(dt - dur!"hnsecs"(-70_000_000) == DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 40)));
         assert(dt - dur!"hnsecs"(70_000_000) == DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 26)));
 
-        auto duration = dur!"seconds"(12);
+        immutable duration = dur!"seconds"(12);
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         assert(cdt + duration == DateTime(1999, 7, 6, 12, 30, 45));
@@ -16893,7 +16893,7 @@ public:
         //hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
         {
-            auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+            immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
 
             assert(dt + TickDuration.from!"usecs"(7_000_000) == DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 40)));
             assert(dt + TickDuration.from!"usecs"(-7_000_000) == DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 26)));
@@ -17010,7 +17010,7 @@ public:
         (dt += dur!"seconds"(92)) -= dur!"days"(-500);
         assert(dt == DateTime(2001, 6, 14, 9, 8, 38));
 
-        auto duration = dur!"seconds"(12);
+        immutable duration = dur!"seconds"(12);
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         static assert(!__traits(compiles, cdt += duration));
@@ -17082,7 +17082,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(1999, 7, 6, 12, 30, 33);
+        immutable dt = DateTime(1999, 7, 6, 12, 30, 33);
 
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33)) -
                      DateTime(Date(1998, 7, 6), TimeOfDay(12, 30, 33)) ==
@@ -17218,7 +17218,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+        immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         assert(!dt.isLeapYear);
@@ -17237,7 +17237,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+        immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         assert(dt.dayOfWeek == DayOfWeek.tue);
@@ -17264,7 +17264,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+        immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         assert(dt.dayOfYear == 187);
@@ -17394,7 +17394,7 @@ public:
 
     @safe unittest
     {
-        auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
+        immutable dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         assert(dt.isoWeek == 27);
@@ -22536,7 +22536,7 @@ private:
     PosInfInterval!SysTime(SysTime(0));
 
     //Verify Examples.
-    auto interval = PosInfInterval!Date(Date(1996, 1, 2));
+    immutable interval = PosInfInterval!Date(Date(1996, 1, 2));
 }
 
 //Test PosInfInterval's begin.
@@ -23334,7 +23334,7 @@ private:
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
+    immutable negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     assert(!posInfInterval.merge(interval).empty);
@@ -23454,7 +23454,7 @@ private:
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
+    immutable negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     assert(!posInfInterval.span(interval).empty);
@@ -25564,7 +25564,7 @@ private:
     auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    auto posInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
+    immutable posInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
@@ -25684,7 +25684,7 @@ private:
     auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    auto posInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
+    immutable posInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
@@ -26681,7 +26681,7 @@ private:
 
         auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
 
-        auto ir = IntervalRange!(Date, Direction.fwd)(interval, &dateFunc);
+        immutable ir = IntervalRange!(Date, Direction.fwd)(interval, &dateFunc);
     }
 
     {
@@ -26692,7 +26692,7 @@ private:
 
         auto interval = Interval!TimeOfDay(TimeOfDay(12, 1, 7), TimeOfDay(14, 0, 0));
 
-        auto ir = IntervalRange!(TimeOfDay, Direction.fwd)(interval, &todFunc);
+        immutable ir = IntervalRange!(TimeOfDay, Direction.fwd)(interval, &todFunc);
     }
 
     {
@@ -26703,7 +26703,7 @@ private:
 
         auto interval = Interval!DateTime(DateTime(2010, 7, 4, 12, 1, 7), DateTime(2012, 1, 7, 14, 0, 0));
 
-        auto ir = IntervalRange!(DateTime, Direction.fwd)(interval, &dtFunc);
+        immutable ir = IntervalRange!(DateTime, Direction.fwd)(interval, &dtFunc);
     }
 
     {
@@ -26717,7 +26717,7 @@ private:
             SysTime(DateTime(2012, 1, 7, 14, 0, 0))
         );
 
-        auto ir = IntervalRange!(SysTime, Direction.fwd)(interval, &stFunc);
+        immutable ir = IntervalRange!(SysTime, Direction.fwd)(interval, &stFunc);
     }
 }
 
@@ -26772,10 +26772,10 @@ private:
         ).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
         assertThrown!DateTimeException((in IntervalRange!(Date, Direction.fwd) range){range.front;}(emptyRange));
 
-        auto range = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
+        immutable range = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
         assert(range.front == Date(2010, 7, 4));
 
-        auto poppedRange = Interval!Date(
+        immutable poppedRange = Interval!Date(
             Date(2010, 7, 4),
             Date(2012, 1, 7)
         ).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
@@ -26793,13 +26793,13 @@ private:
         ).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed), Yes.popFirst);
         assertThrown!DateTimeException((in IntervalRange!(Date, Direction.bwd) range){range.front;}(emptyRange));
 
-        auto range = Interval!Date(
+        immutable range = Interval!Date(
             Date(2010, 7, 4),
             Date(2012, 1, 7)
         ).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed));
         assert(range.front == Date(2012, 1, 7));
 
-        auto poppedRange = Interval!Date(
+        immutable poppedRange = Interval!Date(
             Date(2010, 7, 4),
             Date(2012, 1, 7)
         ).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed), Yes.popFirst);
@@ -26902,7 +26902,7 @@ private:
     {
         auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
         auto func = everyDayOfWeek!Date(DayOfWeek.fri);
-        auto range = interval.fwdRange(func);
+        immutable range = interval.fwdRange(func);
 
         assert(range.interval == interval);
 
@@ -26914,7 +26914,7 @@ private:
     {
         auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
         auto func = everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri);
-        auto range = interval.bwdRange(func);
+        immutable range = interval.bwdRange(func);
 
         assert(range.interval == interval);
 
@@ -26952,7 +26952,7 @@ private:
     {
         auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
         auto func = everyDayOfWeek!Date(DayOfWeek.fri);
-        auto range = interval.fwdRange(func);
+        immutable range = interval.fwdRange(func);
 
         assert(range.direction == Direction.fwd);
 
@@ -26964,7 +26964,7 @@ private:
     {
         auto interval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
         auto func = everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri);
-        auto range = interval.bwdRange(func);
+        immutable range = interval.bwdRange(func);
 
         assert(range.direction == Direction.bwd);
 
@@ -27154,7 +27154,7 @@ private:
 
         auto posInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
 
-        auto ir = PosInfIntervalRange!Date(posInfInterval, &dateFunc);
+        immutable ir = PosInfIntervalRange!Date(posInfInterval, &dateFunc);
     }
 
     {
@@ -27165,7 +27165,7 @@ private:
 
         auto posInfInterval = PosInfInterval!TimeOfDay(TimeOfDay(12, 1, 7));
 
-        auto ir = PosInfIntervalRange!(TimeOfDay)(posInfInterval, &todFunc);
+        immutable ir = PosInfIntervalRange!(TimeOfDay)(posInfInterval, &todFunc);
     }
 
     {
@@ -27176,7 +27176,7 @@ private:
 
         auto posInfInterval = PosInfInterval!DateTime(DateTime(2010, 7, 4, 12, 1, 7));
 
-        auto ir = PosInfIntervalRange!(DateTime)(posInfInterval, &dtFunc);
+        immutable ir = PosInfIntervalRange!(DateTime)(posInfInterval, &dtFunc);
     }
 
     {
@@ -27187,17 +27187,17 @@ private:
 
         auto posInfInterval = PosInfInterval!SysTime(SysTime(DateTime(2010, 7, 4, 12, 1, 7)));
 
-        auto ir = PosInfIntervalRange!(SysTime)(posInfInterval, &stFunc);
+        immutable ir = PosInfIntervalRange!(SysTime)(posInfInterval, &stFunc);
     }
 }
 
 //Test PosInfIntervalRange's front.
 @system unittest
 {
-    auto range = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
+    immutable range = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed));
     assert(range.front == Date(2010, 7, 4));
 
-    auto poppedRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
+    immutable poppedRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.wed), Yes.popFirst);
     assert(poppedRange.front == Date(2010, 7, 7));
 
     const cRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
@@ -27236,7 +27236,7 @@ private:
 {
     auto interval = PosInfInterval!Date(Date(2010, 7, 4));
     auto func = everyDayOfWeek!Date(DayOfWeek.fri);
-    auto range = interval.fwdRange(func);
+    immutable range = interval.fwdRange(func);
 
     assert(range.interval == interval);
 
@@ -27443,7 +27443,7 @@ private:
 
         auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
 
-        auto ir = NegInfIntervalRange!Date(negInfInterval, &dateFunc);
+        immutable ir = NegInfIntervalRange!Date(negInfInterval, &dateFunc);
     }
 
     {
@@ -27454,7 +27454,7 @@ private:
 
         auto negInfInterval = NegInfInterval!TimeOfDay(TimeOfDay(14, 0, 0));
 
-        auto ir = NegInfIntervalRange!(TimeOfDay)(negInfInterval, &todFunc);
+        immutable ir = NegInfIntervalRange!(TimeOfDay)(negInfInterval, &todFunc);
     }
 
     {
@@ -27465,7 +27465,7 @@ private:
 
         auto negInfInterval = NegInfInterval!DateTime(DateTime(2012, 1, 7, 14, 0, 0));
 
-        auto ir = NegInfIntervalRange!(DateTime)(negInfInterval, &dtFunc);
+        immutable ir = NegInfIntervalRange!(DateTime)(negInfInterval, &dtFunc);
     }
 
     {
@@ -27476,17 +27476,17 @@ private:
 
         auto negInfInterval = NegInfInterval!SysTime(SysTime(DateTime(2012, 1, 7, 14, 0, 0)));
 
-        auto ir = NegInfIntervalRange!(SysTime)(negInfInterval, &stFunc);
+        immutable ir = NegInfIntervalRange!(SysTime)(negInfInterval, &stFunc);
     }
 }
 
 //Test NegInfIntervalRange's front.
 @system unittest
 {
-    auto range = NegInfInterval!Date(Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed));
+    immutable range = NegInfInterval!Date(Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed));
     assert(range.front == Date(2012, 1, 7));
 
-    auto poppedRange = NegInfInterval!Date(
+    immutable poppedRange = NegInfInterval!Date(
         Date(2012, 1, 7)
     ).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.wed), Yes.popFirst);
     assert(poppedRange.front == Date(2012, 1, 4));
@@ -27530,7 +27530,7 @@ private:
 {
     auto interval = NegInfInterval!Date(Date(2012, 1, 7));
     auto func = everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri);
-    auto range = interval.bwdRange(func);
+    immutable range = interval.bwdRange(func);
 
     assert(range.interval == interval);
 
@@ -27724,7 +27724,7 @@ public:
     ///
     deprecated @safe unittest
     {
-        auto tz = TimeZone.getTimeZone("America/Los_Angeles");
+        immutable tz = TimeZone.getTimeZone("America/Los_Angeles");
     }
 
     // The purpose of this is to handle the case where a Windows time zone is
@@ -27792,8 +27792,8 @@ public:
             immutable dstDate = DateTime(2010, north ? 7 : 1, 1, 6, 0, 0);
             auto std = SysTime(stdDate, tz);
             auto dst = SysTime(dstDate, tz);
-            auto stdUTC = SysTime(stdDate - utcOffset, UTC());
-            auto dstUTC = SysTime(stdDate - utcOffset + dstOffset, UTC());
+            immutable stdUTC = SysTime(stdDate - utcOffset, UTC());
+            immutable dstUTC = SysTime(stdDate - utcOffset + dstOffset, UTC());
 
             assert(!std.dstInEffect);
             assert(dst.dstInEffect == hasDST);
@@ -27848,8 +27848,8 @@ public:
                     //assert(leapTZ.dstName == dstName);  //Locale-dependent
                     assert(leapTZ.hasDST == hasDST);
 
-                    auto leapSTD = SysTime(std.stdTime, leapTZ);
-                    auto leapDST = SysTime(dst.stdTime, leapTZ);
+                    immutable leapSTD = SysTime(std.stdTime, leapTZ);
+                    immutable leapDST = SysTime(dst.stdTime, leapTZ);
 
                     assert(!leapSTD.dstInEffect);
                     assert(leapDST.dstInEffect == hasDST);
@@ -27883,7 +27883,7 @@ public:
             else version(OSX)     enum utcZone = "UTC";
             else static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");
 
-            auto tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),
+            immutable tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),
                         testTZ("America/New_York", "EST", "EDT", dur!"hours"(-5), dur!"hours"(1)),
                         //testTZ("America/Santiago", "CLT", "CLST", dur!"hours"(-4), dur!"hours"(1), false),
                         testTZ("Europe/London", "GMT", "BST", dur!"hours"(0), dur!"hours"(1)),
@@ -27900,7 +27900,7 @@ public:
         }
         else version(Windows)
         {
-            auto tzs = [testTZ("Pacific Standard Time", "Pacific Standard Time",
+            immutable tzs = [testTZ("Pacific Standard Time", "Pacific Standard Time",
                                "Pacific Daylight Time", dur!"hours"(-8), dur!"hours"(1)),
                         testTZ("Eastern Standard Time", "Eastern Standard Time",
                                "Eastern Daylight Time", dur!"hours"(-5), dur!"hours"(1)),
@@ -27991,10 +27991,10 @@ public:
             //time zone results in the correct time during and surrounding
             //a DST switch.
             bool first = true;
-            auto springSwitch = SysTime(dstSwitches[i][0] + dur!"hours"(spring), UTC()) - stdOffset;
-            auto fallSwitch = SysTime(dstSwitches[i][1] + dur!"hours"(fall), UTC()) - dstOffset;
+            immutable springSwitch = SysTime(dstSwitches[i][0] + dur!"hours"(spring), UTC()) - stdOffset;
+            immutable fallSwitch = SysTime(dstSwitches[i][1] + dur!"hours"(fall), UTC()) - dstOffset;
             //@@@BUG@@@ 3659 makes this necessary.
-            auto fallSwitchMinus1 = fallSwitch - dur!"hours"(1);
+            immutable fallSwitchMinus1 = fallSwitch - dur!"hours"(1);
 
             foreach (hour; -24 .. 25)
             {
@@ -28624,10 +28624,10 @@ public:
                 //time zone results in the correct time during and surrounding
                 //a DST switch.
                 bool first = true;
-                auto springSwitch = SysTime(tzInfos[i][1] + dur!"hours"(spring), UTC()) - stdOffset;
-                auto fallSwitch = SysTime(tzInfos[i][2] + dur!"hours"(fall), UTC()) - dstOffset;
+                immutable springSwitch = SysTime(tzInfos[i][1] + dur!"hours"(spring), UTC()) - stdOffset;
+                immutable fallSwitch = SysTime(tzInfos[i][2] + dur!"hours"(fall), UTC()) - dstOffset;
                 //@@@BUG@@@ 3659 makes this necessary.
-                auto fallSwitchMinus1 = fallSwitch - dur!"hours"(1);
+                immutable fallSwitchMinus1 = fallSwitch - dur!"hours"(1);
 
                 foreach (hour; -24 .. 25)
                 {
@@ -28958,7 +28958,7 @@ public:
 
     @safe unittest
     {
-        auto stz = new immutable SimpleTimeZone(dur!"hours"(-8), "PST");
+        immutable stz = new immutable SimpleTimeZone(dur!"hours"(-8), "PST");
         assert(stz.name == "");
         assert(stz.stdName == "PST");
         assert(stz.dstName == "");
@@ -29871,7 +29871,7 @@ public:
 
             foreach (transition; retro(transitions))
             {
-                auto ttInfo = transition.ttInfo;
+                immutable ttInfo = transition.ttInfo;
 
                 if (ttInfo.isDST)
                 {
@@ -29903,7 +29903,7 @@ public:
     {
         version(Posix)
         {
-            auto tz = PosixTimeZone.getTimeZone("America/Los_Angeles");
+            immutable tz = PosixTimeZone.getTimeZone("America/Los_Angeles");
 
             assert(tz.name == "America/Los_Angeles");
             assert(tz.stdName == "PST");
@@ -30507,7 +30507,7 @@ else version(Windows)
                 auto dstName = dstVal.value_SZ;
 
                 scope tziVal = tzKey.getValue("TZI");
-                auto binVal = tziVal.value_BINARY;
+                immutable binVal = tziVal.value_BINARY;
                 assert(binVal.length == REG_TZI_FORMAT.sizeof);
                 auto tziFmt = cast(REG_TZI_FORMAT*)binVal.ptr;
 
@@ -30734,9 +30734,9 @@ else version(Windows)
                     auto localDateTimeBefore = localDateTime - dur!"hours"(1);
                     auto localDateTimeAfter = localDateTime + dur!"hours"(1);
 
-                    auto dstInEffectNow = dstInEffectForLocalDateTime(localDateTime);
-                    auto dstInEffectBefore = dstInEffectForLocalDateTime(localDateTimeBefore);
-                    auto dstInEffectAfter = dstInEffectForLocalDateTime(localDateTimeAfter);
+                    immutable dstInEffectNow = dstInEffectForLocalDateTime(localDateTime);
+                    immutable dstInEffectBefore = dstInEffectForLocalDateTime(localDateTimeBefore);
+                    immutable dstInEffectAfter = dstInEffectForLocalDateTime(localDateTimeAfter);
 
                     bool isDST;
 
@@ -31852,10 +31852,10 @@ public:
     {
         StopWatch sw;
         sw.start();
-        auto t1 = sw.peek();
+        immutable t1 = sw.peek();
         sw.stop();
-        auto t2 = sw.peek();
-        auto t3 = sw.peek();
+        immutable t2 = sw.peek();
+        immutable t3 = sw.peek();
         assert(t1 <= t2);
         assert(t2 == t3);
     }
@@ -31877,7 +31877,7 @@ public:
         TickDuration t0;
         t0.length = 100;
         sw.setMeasured(t0);
-        auto t1 = sw.peek();
+        immutable t1 = sw.peek();
         assert(t0 == t1);
     }
 
@@ -32000,9 +32000,9 @@ TickDuration[fun.length] benchmark(fun...)(uint n)
     void f1() {auto b = a;}
     void f2() {auto b = to!string(a);}
     auto r = benchmark!(f0, f1, f2)(10_000);
-    auto f0Result = to!Duration(r[0]); // time f0 took to run 10,000 times
-    auto f1Result = to!Duration(r[1]); // time f1 took to run 10,000 times
-    auto f2Result = to!Duration(r[2]); // time f2 took to run 10,000 times
+    immutable f0Result = to!Duration(r[0]); // time f0 took to run 10,000 times
+    immutable f1Result = to!Duration(r[1]); // time f1 took to run 10,000 times
+    immutable f2Result = to!Duration(r[2]); // time f2 took to run 10,000 times
 }
 
 @safe unittest
@@ -32011,7 +32011,7 @@ TickDuration[fun.length] benchmark(fun...)(uint n)
     void f0() {}
     //void f1() {auto b = to!(string)(a);}
     void f2() {auto b = (a);}
-    auto r = benchmark!(f0, f2)(100);
+    immutable r = benchmark!(f0, f2)(100);
 }
 
 
@@ -32086,7 +32086,7 @@ ComparingBenchmarkResult comparingBenchmark(alias baseFunc,
     void f2x() {}
     @safe void f1o() {}
     @safe void f2o() {}
-    auto b1 = comparingBenchmark!(f1o, f2o, 1)(); // OK
+    immutable b1 = comparingBenchmark!(f1o, f2o, 1)(); // OK
     //writeln(b1.point);
 }
 
@@ -32096,12 +32096,12 @@ ComparingBenchmarkResult comparingBenchmark(alias baseFunc,
     @safe    void safeFunc() {}
     @trusted void trustFunc() {}
     @system  void sysFunc() {}
-    auto safeResult  = comparingBenchmark!((){safeFunc();}, (){safeFunc();})();
-    auto trustResult = comparingBenchmark!((){trustFunc();}, (){trustFunc();})();
-    auto sysResult   = comparingBenchmark!((){sysFunc();}, (){sysFunc();})();
-    auto mixedResult1  = comparingBenchmark!((){safeFunc();}, (){trustFunc();})();
-    auto mixedResult2  = comparingBenchmark!((){trustFunc();}, (){sysFunc();})();
-    auto mixedResult3  = comparingBenchmark!((){safeFunc();}, (){sysFunc();})();
+    immutable safeResult  = comparingBenchmark!((){safeFunc();}, (){safeFunc();})();
+    immutable trustResult = comparingBenchmark!((){trustFunc();}, (){trustFunc();})();
+    immutable sysResult   = comparingBenchmark!((){sysFunc();}, (){sysFunc();})();
+    immutable mixedResult1  = comparingBenchmark!((){safeFunc();}, (){trustFunc();})();
+    immutable mixedResult2  = comparingBenchmark!((){trustFunc();}, (){sysFunc();})();
+    immutable mixedResult3  = comparingBenchmark!((){safeFunc();}, (){sysFunc();})();
 }
 
 
@@ -33467,7 +33467,7 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
         foreach (i; 0 .. 10)
         {
             auto str1 = cr(format("1 Jan %d 00:00 GMT", i));
-            auto str2 = cr(format("1 Jan %d 00:00 -1200", i));
+            immutable str2 = cr(format("1 Jan %d 00:00 -1200", i));
             assertThrown!DateTimeException(parseRFC822DateTime(str1));
             assertThrown!DateTimeException(parseRFC822DateTime(str1));
         }
@@ -34276,7 +34276,7 @@ if (validTimeUnits(units) &&
 @safe unittest
 {
     auto hnsecs = 2595000000007L;
-    auto returned = removeUnitsFromHNSecs!"days"(hnsecs);
+    immutable returned = removeUnitsFromHNSecs!"days"(hnsecs);
     assert(returned == 3000000007);
     assert(hnsecs == 2595000000007L);
 }

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -197,7 +197,7 @@ if (hashBlockSize % 8 == 0)
         import std.string : representation;
         string data1 = "Hello, world", data2 = "Hola mundo";
         auto hmac = HMAC!SHA1("My s3cR3T keY".representation);
-        auto digest = hmac.put(data1.representation)
+        immutable digest = hmac.put(data1.representation)
                           .put(data2.representation)
                           .finish();
         static immutable expected = [
@@ -236,7 +236,7 @@ if (isDigest!H)
         import std.digest.sha, std.digest.hmac;
         import std.string : representation;
         string data1 = "Hello, world", data2 = "Hola mundo";
-        auto digest = hmac!SHA1("My s3cR3T keY".representation)
+        immutable digest = hmac!SHA1("My s3cR3T keY".representation)
                           .put(data1.representation)
                           .put(data2.representation)
                           .finish();

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -60,7 +60,7 @@ unittest
     md5.put(data[]);
     md5.start(); //Start again
     md5.put(data[]);
-    auto hash = md5.finish();
+    immutable hash = md5.finish();
 }
 
 ///

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -61,7 +61,7 @@ unittest
     // The call to 'finish' ensures:
     // - the remaining bits are processed
     // - the hash gets finalized
-    auto hashed = hasher.finish();
+    immutable hashed = hasher.finish();
 }
 
 ///
@@ -85,7 +85,7 @@ unittest
     // Call finalize to incorporate data length in the hash.
     hasher.finalize();
     // Finally get the hashed value.
-    auto hashed = hasher.getBytes();
+    immutable hashed = hasher.getBytes();
 }
 
 public import std.digest.digest;

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -711,7 +711,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
             else static if (blockSize==1024)
             {
                 /* ugly hack to work around lack of ucent */
-                auto oldCount0 = count[0];
+                immutable oldCount0 = count[0];
                 count[0] += inputLen * 8;
                 if (count[0] < oldCount0)
                     count[1]++;

--- a/std/exception.d
+++ b/std/exception.d
@@ -888,7 +888,7 @@ immutable(T)[] assumeUnique(T)(ref T[] array) pure nothrow
 {
     // @system due to assumeUnique
     int[] arr = new int[1];
-    immutable arr1 = assumeUnique(arr);
+    auto arr1 = assumeUnique(arr);
     assert(is(typeof(arr1) == immutable(int)[]) && arr == null);
 }
 
@@ -903,7 +903,7 @@ immutable(T[U]) assumeUnique(T, U)(ref T[U] array) pure nothrow
 version(none) @system unittest
 {
     int[string] arr = ["a":1];
-    immutable arr1 = assumeUnique(arr);
+    auto arr1 = assumeUnique(arr);
     assert(is(typeof(arr1) == immutable(int[string])) && arr == null);
 }
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -608,7 +608,7 @@ if (is(typeof(new E(__FILE__, __LINE__))) && !is(typeof(new E("", __FILE__, __LI
     assertNotThrown(enforceEx!OutOfMemoryError(true));
 
     {
-        auto e = collectException(enforceEx!Exception(false));
+        immutable e = collectException(enforceEx!Exception(false));
         assert(e !is null);
         assert(e.msg.empty);
         assert(e.file == __FILE__);
@@ -616,7 +616,7 @@ if (is(typeof(new E(__FILE__, __LINE__))) && !is(typeof(new E("", __FILE__, __LI
     }
 
     {
-        auto e = collectException(enforceEx!Exception(false, "hello", "file", 42));
+        immutable e = collectException(enforceEx!Exception(false, "hello", "file", 42));
         assert(e !is null);
         assert(e.msg == "hello");
         assert(e.file == "file");
@@ -624,7 +624,7 @@ if (is(typeof(new E(__FILE__, __LINE__))) && !is(typeof(new E("", __FILE__, __LI
     }
 
     {
-        auto e = collectException!Error(enforceEx!OutOfMemoryError(false));
+        immutable e = collectException!Error(enforceEx!OutOfMemoryError(false));
         assert(e !is null);
         assert(e.msg == "Memory allocation failed");
         assert(e.file == __FILE__);
@@ -632,7 +632,7 @@ if (is(typeof(new E(__FILE__, __LINE__))) && !is(typeof(new E("", __FILE__, __LI
     }
 
     {
-        auto e = collectException!Error(enforceEx!OutOfMemoryError(false, "file", 42));
+        immutable e = collectException!Error(enforceEx!OutOfMemoryError(false, "file", 42));
         assert(e !is null);
         assert(e.msg == "Memory allocation failed");
         assert(e.file == "file");
@@ -888,7 +888,7 @@ immutable(T)[] assumeUnique(T)(ref T[] array) pure nothrow
 {
     // @system due to assumeUnique
     int[] arr = new int[1];
-    auto arr1 = assumeUnique(arr);
+    immutable arr1 = assumeUnique(arr);
     assert(is(typeof(arr1) == immutable(int)[]) && arr == null);
 }
 
@@ -903,7 +903,7 @@ immutable(T[U]) assumeUnique(T, U)(ref T[U] array) pure nothrow
 version(none) @system unittest
 {
     int[string] arr = ["a":1];
-    auto arr1 = assumeUnique(arr);
+    immutable arr1 = assumeUnique(arr);
     assert(is(typeof(arr1) == immutable(int[string])) && arr == null);
 }
 
@@ -1483,7 +1483,7 @@ class ErrnoException : Exception
     {
         import core.stdc.errno : errno, EAGAIN;
 
-        auto old = errno;
+        immutable old = errno;
         scope(exit) errno = old;
 
         errno = EAGAIN;
@@ -2012,7 +2012,7 @@ pure @safe unittest
     import std.range : retro;
     import std.utf : UTFException;
 
-    auto str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
+    immutable str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
 
     auto handled = str.handle!(UTFException, RangePrimitive.access,
             (e, r) => ' '); // Replace invalid code points with spaces
@@ -2131,7 +2131,7 @@ pure nothrow @safe unittest
     auto slice = f.handle!(Exception,
         RangePrimitive.opSlice, (e, r) => ThrowingRange())();
 
-    auto sliced = slice[0 .. 1337]; // this would throw otherwise
+    immutable sliced = slice[0 .. 1337]; // this would throw otherwise
 
     static struct Infinite
     {
@@ -2159,7 +2159,7 @@ pure nothrow @safe unittest
     auto infinite = Infinite.init.handle!(Exception,
         RangePrimitive.opSlice, (e, r) => Infinite())();
 
-    auto infSlice = infinite[0 .. $]; // this would throw otherwise
+    immutable infSlice = infinite[0 .. $]; // this would throw otherwise
 }
 
 

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -365,7 +365,7 @@ unittest
     static assert(is(typeof(&MyAllocator.instance.prefix(a)) == shared(uint)*));
     auto b = MyAllocator.instance.makeArray!(shared const int)(100);
     static assert(is(typeof(&MyAllocator.instance.prefix(b)) == shared(uint)*));
-    auto c = MyAllocator.instance.makeArray!(immutable int)(100);
+    immutable c = MyAllocator.instance.makeArray!(immutable int)(100);
     static assert(is(typeof(&MyAllocator.instance.prefix(c)) == shared(uint)*));
     auto d = MyAllocator.instance.makeArray!(int)(100);
     static assert(is(typeof(&MyAllocator.instance.prefix(d)) == uint*));

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -360,12 +360,12 @@ public:
         Signed!size_t slack = 0;
         static if (!hasMember!(Allocator, "expand"))
         {
-            auto result = s == 0;
+            immutable result = s == 0;
         }
         else
         {
             immutable bytesSlackB4 = this.goodAllocSize(b.length) - b.length;
-            auto result = parent.expand(b, s);
+            immutable result = parent.expand(b, s);
             if (result)
             {
                 up!"numExpandOK";

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -233,7 +233,7 @@ struct AlignedMallocator
         import core.stdc.errno : ENOMEM, EINVAL;
         assert(a.isGoodDynamicAlignment);
         void* result;
-        auto code = posix_memalign(&result, a, bytes);
+        immutable code = posix_memalign(&result, a, bytes);
         if (code == ENOMEM)
             return null;
 

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -36,7 +36,7 @@ D's allocators have a layered structure in both implementation and documentation
 
 $(OL
 $(LI A high-level, dynamically-typed layer (described further down in this
-module). It consists of an interface called $(LREF IAllocator), which concret;
+module). It consists of an interface called $(LREF IAllocator), which concrete
 allocators need to implement. The interface primitives themselves are oblivious
 to the type of the objects being allocated; they only deal in `void[]`, by
 necessity of the interface being dynamic (as opposed to type-parameterized).

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -36,7 +36,7 @@ D's allocators have a layered structure in both implementation and documentation
 
 $(OL
 $(LI A high-level, dynamically-typed layer (described further down in this
-module). It consists of an interface called $(LREF IAllocator), which concrete
+module). It consists of an interface called $(LREF IAllocator), which concret;
 allocators need to implement. The interface primitives themselves are oblivious
 to the type of the objects being allocated; they only deal in `void[]`, by
 necessity of the interface being dynamic (as opposed to type-parameterized).

--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -291,17 +291,17 @@ body
     import std.experimental.ndslice.selection : iotaSlice;
     auto slice = iotaSlice(2, 3);
 
-    auto a = [[0, 1, 2],
+    immutable a = [[0, 1, 2],
               [3, 4, 5]];
 
-    auto b = [[2, 5],
+    immutable b = [[2, 5],
               [1, 4],
               [0, 3]];
 
-    auto c = [[5, 4, 3],
+    immutable c = [[5, 4, 3],
               [2, 1, 0]];
 
-    auto d = [[3, 0],
+    immutable d = [[3, 0],
               [4, 1],
               [5, 2]];
 
@@ -523,7 +523,7 @@ Slice!(N, Range) allReversed(size_t N, Range)(Slice!(N, Range) slice)
 {
     import std.experimental.ndslice.slice;
     import std.range : iota, retro;
-    auto a = 20.iota.sliced(4, 5).allReversed;
+    immutable a = 20.iota.sliced(4, 5).allReversed;
     auto b = 20.iota.retro.sliced(4, 5);
     assert(a == b);
 }
@@ -567,7 +567,7 @@ body
 {
     foreach (i; Iota!(0, M))
     {
-        auto dimension = dimensions[i];
+        immutable dimension = dimensions[i];
         mixin (_reversedCode);
     }
     return slice;

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -511,7 +511,7 @@ pure nothrow unittest
     import std.range : iota;
     auto r = (10_000L * 2 * 3 * 4).iota;
 
-    auto t0 = r.sliced(10, 20, 30, 40);
+    immutable t0 = r.sliced(10, 20, 30, 40);
     assert(t0.length == 10);
     assert(t0.length!0 == 10);
     assert(t0.length!1 == 20);
@@ -540,7 +540,7 @@ pure nothrow unittest
     }
 
     immutable int[] im = [1,2,3,4,5,6];
-    auto slice = im.sliced(2, 3);
+    immutable slice = im.sliced(2, 3);
 }
 
 pure nothrow unittest

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -111,7 +111,7 @@ template pack(K...)
     import std.range : iota;
 
     auto r = (3 * 4 * 5 * 6).iota;
-    auto a = r.sliced(3, 4, 5, 6);
+    immutable a = r.sliced(3, 4, 5, 6);
     auto b = a.pack!2;
 
     static immutable res1 = [3, 4];
@@ -134,7 +134,7 @@ template pack(K...)
     auto c = b[1, 2, 3, 4];
     auto d = c[5, 6, 7];
     auto e = d[8, 9];
-    auto g = a[1, 2, 3, 4, 5, 6, 7, 8, 9];
+    immutable g = a[1, 2, 3, 4, 5, 6, 7, 8, 9];
     assert(e == g);
     assert(a == b);
     assert(c == a[1, 2, 3, 4]);
@@ -148,8 +148,8 @@ template pack(K...)
 
 @safe @nogc pure nothrow unittest
 {
-    auto a = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
-    auto b = a.pack!(2, 3);
+    immutable a = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
+    immutable b = a.pack!(2, 3);
     static assert(b.shape.length == 4);
     static assert(b.structure.lengths.length == 4);
     static assert(b.structure.strides.length == 4);
@@ -231,7 +231,7 @@ evertPack(size_t N, Range)(Slice!(N, Range) slice)
 @safe @nogc pure nothrow unittest
 {
     import std.experimental.ndslice.iteration : transposed;
-    auto slice = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
+    immutable slice = iotaSlice(3, 4, 5, 6, 7, 8, 9, 10, 11);
     assert(slice
         .pack!2
         .evertPack
@@ -257,7 +257,7 @@ pure nothrow unittest
     auto c = b[8, 9];
     auto d = c[5, 6, 7];
     auto e = d[1, 2, 3, 4];
-    auto g = a[1, 2, 3, 4, 5, 6, 7, 8, 9];
+    immutable g = a[1, 2, 3, 4, 5, 6, 7, 8, 9];
     assert(e == g);
     assert(a == b.evertPack);
     assert(c == a.transposed!(7, 8, 4, 5, 6)[8, 9]);
@@ -302,7 +302,7 @@ Returns:
 +/
 Slice!(1, Range) diagonal(size_t N, Range)(Slice!(N, Range) slice)
 {
-    auto NewN = slice.PureN - N + 1;
+    immutable NewN = slice.PureN - N + 1;
     mixin _DefineRet;
     ret._lengths[0] = slice._lengths[0];
     ret._strides[0] = slice._strides[0];
@@ -1799,7 +1799,7 @@ IndexSlice!N indexSlice(size_t N)(size_t[N] lengths...)
     // test save
     import std.range : dropOne;
 
-    auto im = indexSlice(7, 9);
+    immutable im = indexSlice(7, 9);
     auto imByElement = im.byElement;
     assert(imByElement.front == [0, 0]);
     assert(imByElement.save.dropOne.front == [0, 1]);
@@ -2234,7 +2234,7 @@ pure nothrow unittest
     // tensors must have the same strides
     assert(sl1.structure == sl2.structure);
 
-    auto zip = assumeSameStructure!("a", "b")(sl1, sl2);
+    immutable zip = assumeSameStructure!("a", "b")(sl1, sl2);
 
     auto lazySum = zip.mapSlice!(z => z.a + z.b);
 

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -63,7 +63,7 @@ unittest
     class C { @disable opCast(T)() {} }
     auto c = new C;
     static assert(!__traits(compiles, cast(Object)c));
-    auto o = dynamicCast!Object(c);
+    immutable o = dynamicCast!Object(c);
     assert(c is o);
 
     interface I { @disable opCast(T)() {} Object instance(); }
@@ -639,7 +639,7 @@ unittest
 
     auto ma = new A();
     auto sa = new shared A();
-    auto ia = new immutable A();
+    immutable ia = new immutable A();
     {
                      Drawable  md = ma.wrap!Drawable;
                const Drawable  cd = ma.wrap!Drawable;
@@ -1019,7 +1019,7 @@ pure nothrow @safe unittest
 
 pure nothrow @safe unittest
 {
-    auto arr = makeFinal([1, 2, 3]);
+    immutable arr = makeFinal([1, 2, 3]);
     static assert(!__traits(compiles, arr = null));
     static assert(!__traits(compiles, arr ~= 4));
     assert((arr ~ 4) == [1, 2, 3, 4]);

--- a/std/functional.d
+++ b/std/functional.d
@@ -857,7 +857,7 @@ if (F.length > 1)
     }
     S s;
     s.store = (int a) { return eff4(a); };
-    auto x4 = s.fun();
+    immutable x4 = s.fun();
     assert(x4 == 43);
 }
 
@@ -1143,7 +1143,7 @@ template memoize(alias fun, uint maxSize)
         return n < 2 ? 1 : mfib(n - 2) + mfib(n - 1);
     }
 
-    auto z = fib(10);
+    immutable z = fib(10);
     assert(z == 89);
 
     static ulong fact(ulong n) @safe
@@ -1283,7 +1283,7 @@ if (isCallable!(F))
         df.contextPtr = cast(void*) fp;
 
         DelegateFaker!(F) dummy;
-        auto dummyDel = &dummy.doIt;
+        immutable dummyDel = &dummy.doIt;
         df.funcPtr = dummyDel.funcptr;
 
         return df.del;
@@ -1300,7 +1300,7 @@ if (isCallable!(F))
     uint myNum = 0;
     auto incMyNumDel = toDelegate(&inc);
     int delegate(ref uint) dg = incMyNumDel;
-    auto returnVal = incMyNumDel(myNum);
+    immutable returnVal = incMyNumDel(myNum);
     assert(myNum == 1);
 
     interface I { int opCall(); }
@@ -1369,8 +1369,8 @@ if (isCallable!(F))
             extern(C) static void xtrnC() {}
             extern(D) static void xtrnD() {}
         }
-        auto dg_xtrnC = toDelegate(&S.xtrnC);
-        auto dg_xtrnD = toDelegate(&S.xtrnD);
+        immutable dg_xtrnC = toDelegate(&S.xtrnC);
+        immutable dg_xtrnD = toDelegate(&S.xtrnD);
         static assert(! is(typeof(dg_xtrnC) == typeof(dg_xtrnD)));
     }
 }
@@ -1468,5 +1468,5 @@ template forward(args...)
     }
     static assert(!__traits(compiles, { auto x1 = bar(3); })); // case of NG
     int value = 3;
-    auto x2 = bar(value); // case of OK
+    immutable x2 = bar(value); // case of OK
 }

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -710,7 +710,7 @@ public:
     pure nothrow @safe if (op == "|" || op == "^" || op == "&")
     {
         auto d1 = includeSign(x.data, y.uintLength, xSign);
-        auto d2 = includeSign(y.data, x.uintLength, ySign);
+        immutable d2 = includeSign(y.data, x.uintLength, ySign);
 
         foreach (i; 0..d1.length)
         {

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -345,7 +345,7 @@ unittest
         return textbuf[].idup;
     }
 
-    auto s = cat("hello", "betty");
+    immutable s = cat("hello", "betty");
     assert(s == "hellobettyeven more");
 }
 

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -447,7 +447,7 @@ unittest
             }
 
             assert(!Cmp.cmp(it.front, Cmp.dummyValue));
-            auto s = it.front;
+            immutable s = it.front;
             it.front = Cmp.dummyValue;
             assert(Cmp.cmp(it.front, Cmp.dummyValue));
             it.front = s;

--- a/std/json.d
+++ b/std/json.d
@@ -1630,7 +1630,7 @@ EOF";
 
     import std.exception;
 
-    auto e = collectException!JSONException(parseJSON(s));
+    immutable e = collectException!JSONException(parseJSON(s));
     assert(e.msg == "Unexpected character 'p'. (Line 5:3)", e.msg);
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -2648,8 +2648,8 @@ if (isFloatingPoint!T)
             int exp;
             const T a = 1;
             immutable T b = 2;
-            auto c = frexp(a, exp);
-            auto d = frexp(b, exp);
+            immutable c = frexp(a, exp);
+            immutable d = frexp(b, exp);
         }
     }
 }
@@ -6610,7 +6610,7 @@ if (isFloatingPoint!(X))
 
        const F Const = 2;
        immutable F Immutable = 2;
-       auto Compiles = feqrel(Const, Immutable);
+       immutable Compiles = feqrel(Const, Immutable);
     }
 
     assert(feqrel(7.1824L, 7.1824L) == real.mant_dig);
@@ -7179,8 +7179,8 @@ deprecated("Phobos1 math functions are deprecated, use isInfinity ") alias isinf
 @safe pure nothrow unittest
 {
     // issue 6381: floor/ceil should be usable in pure function.
-    auto x = floor(1.2);
-    auto y = ceil(1.2);
+    immutable x = floor(1.2);
+    immutable y = ceil(1.2);
 }
 
 /***********************************

--- a/std/meta.d
+++ b/std/meta.d
@@ -1373,7 +1373,7 @@ if (n > 0)
         return a;
     }
 
-    immutable a = staticArray!(long, 3)(3, 1, 4);
+    auto a = staticArray!(long, 3)(3, 1, 4);
     assert(is(typeof(a) == long[3]));
     assert(a == [3, 1, 4]);
 }

--- a/std/meta.d
+++ b/std/meta.d
@@ -1373,7 +1373,7 @@ if (n > 0)
         return a;
     }
 
-    auto a = staticArray!(long, 3)(3, 1, 4);
+    immutable a = staticArray!(long, 3)(3, 1, 4);
     assert(is(typeof(a) == long[3]));
     assert(a == [3, 1, 4]);
 }

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -694,7 +694,7 @@ version(linux)
     auto f = File(fn);
     auto fd = f.fileno;
     {
-        auto mf = scoped!MmFile(f);
+        immutable mf = scoped!MmFile(f);
         f = File.init;
     }
     assert(.close(fd) == -1);

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -476,7 +476,7 @@ if (isCurlConn!Conn)
         import std.stdio : File;
         auto f = File(loadFromPath, "rb");
         conn.onSend = buf => f.rawRead(buf).length;
-        auto sz = f.size;
+        immutable sz = f.size;
         if (sz != ulong.max)
             conn.contentLength = sz;
         conn.perform();
@@ -1073,7 +1073,7 @@ unittest
         assert(req.hdrs.canFind("GET /path"));
         s.send(httpNotFound());
     });
-    auto e = collectException!CurlException(get(testServer.addr ~ "/path"));
+    immutable e = collectException!CurlException(get(testServer.addr ~ "/path"));
     assert(e.msg == "HTTP request returned status code 404 (Not Found)");
 }
 
@@ -1340,7 +1340,7 @@ unittest
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
         testServer.handle((s) {
-            auto req = s.recvReq;
+            immutable req = s.recvReq;
             s.send(httpOK("Line1\nLine2\nLine3"));
         });
         assert(byLine(host).equal(["Line1", "Line2", "Line3"]));
@@ -1414,7 +1414,7 @@ unittest
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
         testServer.handle((s) {
-            auto req = s.recvReq;
+            immutable req = s.recvReq;
             s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
         });
         assert(byChunk(host, 2).equal([[0, 1], [2, 3], [4, 5]]));
@@ -1709,7 +1709,7 @@ unittest
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
         testServer.handle((s) {
-            auto req = s.recvReq;
+            immutable req = s.recvReq;
             s.send(httpOK("Line1\nLine2\nLine3"));
         });
         assert(byLineAsync(host).equal(["Line1", "Line2", "Line3"]));
@@ -1857,7 +1857,7 @@ unittest
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
         testServer.handle((s) {
-            auto req = s.recvReq;
+            immutable req = s.recvReq;
             s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
         });
         assert(byChunkAsync(host, 2).equal([[0, 1], [2, 3], [4, 5]]));

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -729,7 +729,7 @@ if (isSomeChar!(Char))
             returnStatus ~= EmailStatusCode.rfc5322LabelTooLong;
     }
 
-    auto dnsChecked = false;
+    immutable dnsChecked = false;
 
     if (checkDNS == Yes.checkDns && returnStatus.maxElement() < EmailStatusCode.dnsWarning)
     {
@@ -1927,7 +1927,7 @@ if (isDynamicArray!(A) && !isNarrowString!(A) && isMutable!(A) && !is(A == void[
 unittest
 {
     auto array = [0, 1, 2, 3];
-    auto result = array.pop();
+    immutable result = array.pop();
 
     assert(array == [0, 1, 2]);
     assert(result == 3);

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -142,7 +142,7 @@ if (((flags & flags.signed) + precision + exponentWidth) % 8 == 0 && precision +
 
     // Define a 8-bit custom float for storing probabilities
     alias Probability = CustomFloat!(4, 4, CustomFloatFlags.ieee^CustomFloatFlags.probability^CustomFloatFlags.signed );
-    auto p = Probability(0.5);
+    immutable p = Probability(0.5);
 }
 
 /// ditto
@@ -244,7 +244,7 @@ private:
             if (sig > 0)
             {
                 import core.bitop : bsr;
-                auto shift2 = precision - bsr(sig);
+                immutable shift2 = precision - bsr(sig);
                 exp  -= shift2-1;
                 shift += shift2;
             }
@@ -1378,8 +1378,8 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
         (1.0*powercalls)/powerProblems);
 */
     //Issue 14231
-    auto xp = findRoot((float x) => x, 0f, 1f);
-    auto xn = findRoot((float x) => x, -1f, -0f);
+    immutable xp = findRoot((float x) => x, 0f, 1f);
+    immutable xn = findRoot((float x) => x, -1f, -0f);
 }
 
 //regression control
@@ -1598,7 +1598,7 @@ body
             assert(ret.error <= 10 * T.epsilon);
         }
         {
-            auto ret = findLocalMin!T((T x) => T.init, 0, 1, T.min_normal, 2*T.epsilon);
+            immutable ret = findLocalMin!T((T x) => T.init, 0, 1, T.min_normal, 2*T.epsilon);
             assert(!ret.x.isNaN);
             assert(ret.y.isNaN);
             assert(ret.error.isNaN);
@@ -1609,7 +1609,7 @@ body
             assert(ret.x >= 0 && ret.x <= ret.error);
         }
         {
-            auto ret = findLocalMin!T((T x) => log(x), 0, T.max, T.min_normal, 2*T.epsilon);
+            immutable ret = findLocalMin!T((T x) => log(x), 0, T.max, T.min_normal, 2*T.epsilon);
             assert(ret.y < -18);
             assert(ret.error < 5e-08);
             assert(ret.x >= 0 && ret.x <= ret.error);

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3902,7 +3902,7 @@ unittest
     // The only way this can be verified is manually.
     debug(std_parallelism) stderr.writeln("totalCPUs = ", totalCPUs);
 
-    auto oldPriority = poolInstance.priority;
+    immutable oldPriority = poolInstance.priority;
     poolInstance.priority = Thread.PRIORITY_MAX;
     assert(poolInstance.priority == Thread.PRIORITY_MAX);
 
@@ -4074,7 +4074,7 @@ unittest
     }
 
     auto wlRange = wl.toRange;
-    auto parallelSum = poolInstance.reduce!"a + b"(wlRange);
+    immutable parallelSum = poolInstance.reduce!"a + b"(wlRange);
     assert(parallelSum == 499500);
     assert(wlRange[0..1][0] == wlRange[0]);
     assert(wlRange[1..2][0] == wlRange[1]);
@@ -4348,7 +4348,7 @@ version(parallelismStressTest)
             uint mySum = sumFuture.spinForce();
             assert(mySum == 999 * 1000 / 2);
 
-            auto mySumParallel = poolInstance.reduce!"a + b"(numbers);
+            immutable mySumParallel = poolInstance.reduce!"a + b"(numbers);
             assert(mySum == mySumParallel);
             stderr.writeln("Done sums.");
 

--- a/std/path.d
+++ b/std/path.d
@@ -1211,7 +1211,7 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 
     alias CR = Unqual!(ElementEncodingType!R);
     auto dot = only(CR('.'));
-    auto i = extSeparatorPos(path);
+    immutable i = extSeparatorPos(path);
     if (i == -1)
     {
         if (ext.length > 0 && ext[0] == '.')
@@ -1412,7 +1412,7 @@ if (isSomeChar!C)
 
     // Test that allocation works as it should.
     auto manyShort = "aaa".repeat(1000).array();
-    auto manyShortCombined = join(manyShort, dirSeparator);
+    immutable manyShortCombined = join(manyShort, dirSeparator);
     assert (buildPath(manyShort) == manyShortCombined);
     assert (buildPath(ir(manyShort)) == manyShortCombined);
 
@@ -2214,7 +2214,7 @@ if ((isRandomAccessRange!R && hasSlicing!R ||
             {
                 if (isUNC(_path))
                 {
-                    auto i = uncRootLength(_path);
+                    immutable i = uncRootLength(_path);
                     fs = 0;
                     fe = i;
                     ps = ltrim(fe, pe);
@@ -3477,7 +3477,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
     }
     version (Windows)
     {
-        auto last = filename[filename.length - 1];
+        immutable last = filename[filename.length - 1];
         if (last == '.' || last == ' ') return false;
     }
 
@@ -3930,7 +3930,7 @@ version(unittest) import std.process : environment;
     version (Posix)
     {
         // Retrieve the current home variable.
-        auto oldHome = environment.get("HOME");
+        immutable oldHome = environment.get("HOME");
 
         // Testing when there is no environment variable.
         environment.remove("HOME");

--- a/std/process.d
+++ b/std/process.d
@@ -770,7 +770,7 @@ version (Posix) @safe unittest
     assert (!lsPath.empty);
     assert (lsPath[0] == '/');
     assert (lsPath.endsWith("ls"));
-    auto unlikely = searchPathFor("lkmqwpoialhggyaofijadsohufoiqezm");
+    immutable unlikely = searchPathFor("lkmqwpoialhggyaofijadsohufoiqezm");
     assert (unlikely is null, "Are you kidding me?");
 }
 
@@ -1031,7 +1031,7 @@ version (Posix) @system unittest
         std.stdio.stdout.close();
     }
 
-    auto lines = readText(tmpFile).splitLines();
+    immutable lines = readText(tmpFile).splitLines();
     assert(lines == ["foo", "bar"]);
 }
 
@@ -1044,7 +1044,7 @@ version (Windows)
     auto f = File(fn, "a");
     spawnProcess(["cmd", "/c", "echo BBBBB"], std.stdio.stdin, f).wait();
 
-    auto data = readText(fn);
+    immutable data = readText(fn);
     assert(data == "AAAAAAAAAABBBBB\r\n", data);
 }
 
@@ -1088,7 +1088,7 @@ Pid spawnShell(in char[] command,
         // It does not use CommandLineToArgvW.
         // Instead, it treats the first and last quote specially.
         // See CMD.EXE /? for details.
-        auto args = escapeShellFileName(shellPath)
+        immutable args = escapeShellFileName(shellPath)
                     ~ ` ` ~ shellSwitch ~ ` "` ~ command ~ `"`;
     }
     else version (Posix)
@@ -1135,7 +1135,7 @@ Pid spawnShell(in char[] command,
     version(CRuntime_Microsoft) f.seek(0, SEEK_END); // MSVCRT probably seeks to the end when writing, not before
     assert (wait(spawnShell(cmd, std.stdio.stdin, f, std.stdio.stderr, env)) == 0);
     f.close();
-    auto output = std.file.readText(tmpFile);
+    immutable output = std.file.readText(tmpFile);
     assert (output == "bar\nbar\n" || output == "bar\r\nbar\r\n");
 }
 
@@ -1147,7 +1147,7 @@ version (Windows)
     auto outputFn = uniqueTempPath();
     scope(exit) if (exists(outputFn)) remove(outputFn);
     auto args = [`a b c`, `a\b\c\`, `a"b"c"`];
-    auto result = executeShell(
+    immutable result = executeShell(
         escapeShellCommand([prog.path] ~ args)
         ~ " > " ~
         escapeShellFileName(outputFn));
@@ -1287,7 +1287,7 @@ private:
         while (true)
         {
             int status;
-            auto check = waitpid(_processID, &status, block ? 0 : WNOHANG);
+            immutable check = waitpid(_processID, &status, block ? 0 : WNOHANG);
             if (check == -1)
             {
                 if (errno == ECHILD)
@@ -1334,7 +1334,7 @@ private:
             assert (_handle != INVALID_HANDLE_VALUE);
             if (block)
             {
-                auto result = WaitForSingleObject(_handle, INFINITE);
+                immutable result = WaitForSingleObject(_handle, INFINITE);
                 if (result != WAIT_OBJECT_0)
                     throw ProcessException.newFromLastError("Wait failed.");
             }
@@ -2299,7 +2299,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     auto r2 = executeShell("echo bar 1>&2");
     assert (r2.status == 0);
     assert (r2.output.chomp().stripRight() == "bar");
-    auto r3 = executeShell("exit 123");
+    immutable r3 = executeShell("exit 123");
     assert (r3.status == 123);
     assert (r3.output.empty);
 }
@@ -2334,7 +2334,7 @@ class ProcessException : Exception
         {
             import core.stdc.string : strerror_r;
             char[1024] buf;
-            auto errnoMsg = to!string(
+            immutable errnoMsg = to!string(
                 core.stdc.string.strerror_r(errno, buf.ptr, buf.length));
         }
         else
@@ -2353,7 +2353,7 @@ class ProcessException : Exception
                                              string file = __FILE__,
                                              size_t line = __LINE__)
     {
-        auto lastMsg = sysErrorString(GetLastError());
+        immutable lastMsg = sysErrorString(GetLastError());
         auto msg = customMsg.empty ? lastMsg
                                    : customMsg ~ " (" ~ lastMsg ~ ')';
         return new ProcessException(msg, file, line);
@@ -2472,7 +2472,7 @@ private struct TestScript
         import std.file : write;
         version (Windows)
         {
-            auto ext = ".cmd";
+            immutable ext = ".cmd";
             auto firstLine = "@echo off";
         }
         else version (Posix)
@@ -2958,7 +2958,7 @@ version(unittest_burnin)
         {
             scope(failure) writefln(
                 "executeShell() with redirect failed.\nExpected:\t%s\nFilename:\t%s\nEncoded:\t%s", s, [fn], [e]);
-            auto result = executeShell(e);
+            immutable result = executeShell(e);
             assert(result.status == 0, "std_process_unittest_helper failed");
             assert(!result.output.length, "No output expected, got:\n" ~ result.output);
             g = readText(fn).split("\0")[1..$];
@@ -3231,7 +3231,7 @@ static:
                 // and it is just as much of a security issue there.  Moreso,
                 // in fact, due to the case insensensitivity of variable names,
                 // which is not handled correctly by all programs.
-                auto val = toUTF8(envBlock[start .. i]);
+                immutable val = toUTF8(envBlock[start .. i]);
                 if (name !in aa) aa[name] = val is null ? "" : val;
             }
         }
@@ -3356,7 +3356,7 @@ private:
 
     // get() on an empty (but present) value
     environment["std_process"] = "";
-    auto res = environment.get("std_process");
+    immutable res = environment.get("std_process");
     assert (res !is null);
     assert (res == "");
 
@@ -3682,7 +3682,7 @@ else version (OSX)
     {
         const(char)*[5] args;
 
-        auto curl = url.tempCString();
+        immutable curl = url.tempCString();
         const(char)* browser = core.stdc.stdlib.getenv("BROWSER");
         if (browser)
         {   browser = strdup(browser);
@@ -3697,7 +3697,7 @@ else version (OSX)
             args[2] = null;
         }
 
-        auto childpid = core.sys.posix.unistd.fork();
+        immutable childpid = core.sys.posix.unistd.fork();
         if (childpid == 0)
         {
             core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);
@@ -3730,7 +3730,7 @@ else version (Posix)
         args[1] = url.tempCString();
         args[2] = null;
 
-        auto childpid = core.sys.posix.unistd.fork();
+        immutable childpid = core.sys.posix.unistd.fork();
         if (childpid == 0)
         {
             core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -667,7 +667,7 @@ debug pure nothrow unittest
     // @@@BUG@@@ 12647
     try
     {
-        immutable unused = testArr[].stride(0);
+        auto unused = testArr[].stride(0);
     }
     catch (AssertError unused)
     {

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -352,7 +352,7 @@ pure @safe nothrow unittest
     test([ 1, 2, 3, 4, 5, 6 ], [ 6, 5, 4, 3, 2, 1 ]);
 
    immutable foo = [1,2,3].idup;
-   auto r = retro(foo);
+   immutable r = retro(foo);
 }
 
 pure @safe nothrow unittest
@@ -667,7 +667,7 @@ debug pure nothrow unittest
     // @@@BUG@@@ 12647
     try
     {
-        auto unused = testArr[].stride(0);
+        immutable unused = testArr[].stride(0);
     }
     catch (AssertError unused)
     {
@@ -1234,7 +1234,7 @@ pure @safe nothrow unittest
 
     // Make sure bug 3311 is fixed.  ChainImpl should compile even if not all
     // elements are mutable.
-    auto c = chain( iota(0, 10), iota(0, 10) );
+    immutable c = chain( iota(0, 10), iota(0, 10) );
 
     // Test the case where infinite ranges are present.
     auto inf = chain([0,1,2][], cycle([4,5,6][]), [7,8,9][]); // infinite range
@@ -1297,7 +1297,7 @@ pure @safe nothrow @nogc unittest
     class Foo{}
     immutable(Foo)[] a;
     immutable(Foo)[] b;
-    auto c = chain(a, b);
+    immutable c = chain(a, b);
 }
 
 /**
@@ -1674,7 +1674,7 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
                 }
             }
 
-            auto next = _current == (Rs.length - 1) ? 0 : (_current + 1);
+            immutable next = _current == (Rs.length - 1) ? 0 : (_current + 1);
             final switch (next)
             {
                 foreach (i, R; Rs)
@@ -2586,7 +2586,7 @@ if (isInputRange!R)
 ///
 pure @safe nothrow @nogc unittest
 {
-    auto range = takeNone!(int[])();
+    immutable range = takeNone!(int[])();
     assert(range.length == 0);
     assert(range.empty);
 }
@@ -3197,7 +3197,7 @@ pure @safe nothrow unittest //12007
     immutable int[] A = [1,2,3];
     immutable int[] B = [4,5,6];
 
-    auto AB = cartesianProduct(A,B);
+    immutable AB = cartesianProduct(A,B);
 }
 
 /**
@@ -3367,7 +3367,7 @@ public:
 {
     int i;
     auto g = generate!(() => ++i);
-    auto f = g.front;
+    immutable f = g.front;
     assert(f == g.front);
     g = g.drop(5); // reassign because generate caches
     assert(g.front == f + 5);
@@ -3699,7 +3699,7 @@ if (isStaticArray!R)
     assert(nums[0] == 2);
 
     immutable int[] immarr = [1, 2, 3];
-    auto cycleimm = cycle(immarr);
+    immutable cycleimm = cycle(immarr);
 
     foreach (DummyType; AllDummyRanges)
     {
@@ -3842,7 +3842,7 @@ unittest //10845
 
 @safe unittest // 12177
 {
-    auto a = recurrence!q{a[n - 1] ~ a[n - 2]}("1", "0");
+    immutable a = recurrence!q{a[n - 1] ~ a[n - 2]}("1", "0");
 }
 
 // Issue 13390
@@ -4475,7 +4475,7 @@ pure unittest
     }
     R r;
     auto z = zip(r, r);
-    auto zz = z.save;
+    immutable zz = z.save;
 }
 
 pure unittest
@@ -4799,7 +4799,7 @@ unittest
 
     // Just make sure 1-range case instantiates.  This hangs the compiler
     // when no explicit stopping policy is specified due to Bug 4652.
-    auto stuff = lockstep([1,2,3,4,5], StoppingPolicy.shortest);
+    immutable stuff = lockstep([1,2,3,4,5], StoppingPolicy.shortest);
 
     // Test with indexing.
     uint[] res1;
@@ -5409,7 +5409,7 @@ body
             this.step = step;
             immutable fcount = (end - start) / step;
             count = to!size_t(fcount);
-            auto pastEnd = start + count * step;
+            immutable pastEnd = start + count * step;
             if (step > 0)
             {
                 if (pastEnd < end) ++count;
@@ -5488,9 +5488,9 @@ body
 
 nothrow @nogc unittest
 {
-    auto t0 = iota(0, 10);
-    auto t1 = iota(0, 10, 2);
-    auto t2 = iota(1, 1, 0);
+    immutable t0 = iota(0, 10);
+    immutable t1 = iota(0, 10, 2);
+    immutable t2 = iota(1, 1, 0);
     //float overloads use std.conv.to so can't be @nogc or nothrow
 }
 
@@ -5614,7 +5614,7 @@ unittest
     assert(approxEqual(rf, [0.0, -0.1, -0.2, -0.3, -0.4, -0.5][]));
 
     // iota of longs
-    auto rl = iota(5_000_000L);
+    immutable rl = iota(5_000_000L);
     assert(rl.length == 5_000_000L);
 
     // iota of longs with steps
@@ -7251,8 +7251,8 @@ private:
             and right-most column, respectively.
         */
 
-        auto div = _source.length / _chunkCount;
-        auto mod = _source.length % _chunkCount;
+        immutable div = _source.length / _chunkCount;
+        immutable mod = _source.length % _chunkCount;
         auto pos = i <= mod
             ? i   * (div+1)
             : mod * (div+1) + (i-mod) * div
@@ -7777,7 +7777,7 @@ in
         alias LengthType = typeof(range.length);
         bool overflow;
         static if (isSigned!Enumerator && isSigned!LengthType)
-            auto result = adds(start, range.length, overflow);
+            immutable result = adds(start, range.length, overflow);
         else static if (isSigned!Enumerator)
         {
             Largest!(Enumerator, Signed!LengthType) signedLength;
@@ -7787,13 +7787,13 @@ in
             catch (Exception)
                 assert(false);
 
-            auto result = adds(start, signedLength, overflow);
+            immutable result = adds(start, signedLength, overflow);
         }
         else
         {
             static if (isSigned!LengthType)
                 assert(range.length >= 0);
-            auto result = addu(start, range.length, overflow);
+            immutable result = addu(start, range.length, overflow);
         }
 
         assert(!overflow && result <= Enumerator.max);
@@ -7994,7 +7994,7 @@ pure @safe nothrow unittest
         assert(shifted.front == tuple(i, "zero"));
         assert(shifted[0] == shifted.front);
 
-        auto next = tuple(i + 1, "one");
+        immutable next = tuple(i + 1, "one");
         assert(shifted[1] == next);
         shifted.popFront();
         assert(shifted.front == next);
@@ -8753,7 +8753,7 @@ that break its sortedness, $(D SortedRange) will work erratically.
 @safe unittest
 {
     immutable(int)[] arr = [ 1, 2, 3 ];
-    auto s = assumeSorted(arr);
+    immutable s = assumeSorted(arr);
 }
 
 unittest
@@ -8855,7 +8855,7 @@ if (isInputRange!(Unqual!R))
     int[] a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
     if (a.length)
     {
-        auto b = a[a.length / 2];
+        immutable b = a[a.length / 2];
         //auto r = sort(a);
         //assert(r.contains(b));
     }
@@ -8876,7 +8876,7 @@ unittest
     bool ok = true;
     try
     {
-        auto r2 = assumeSorted([ 677, 345, 34, 7, 5 ]);
+        immutable r2 = assumeSorted([ 677, 345, 34, 7, 5 ]);
         debug ok = false;
     }
     catch (Throwable)
@@ -8889,7 +8889,7 @@ unittest
 @nogc unittest
 {
     static immutable a = [1, 2, 3, 4];
-    auto r = a.assumeSorted;
+    immutable r = a.assumeSorted;
 }
 
 /++
@@ -9328,19 +9328,19 @@ unittest
         ubyte[] buffer = [1, 2, 3, 4, 5];
         auto wrapper = refRange(&buffer);
         auto p = wrapper.ptr;
-        auto f = wrapper.front;
+        immutable f = wrapper.front;
         wrapper.front = f;
-        auto e = wrapper.empty;
+        immutable e = wrapper.empty;
         wrapper.popFront();
         auto s = wrapper.save;
-        auto b = wrapper.back;
+        immutable b = wrapper.back;
         wrapper.back = b;
         wrapper.popBack();
-        auto i = wrapper[0];
+        immutable i = wrapper[0];
         wrapper.moveFront();
         wrapper.moveBack();
         wrapper.moveAt(0);
-        auto l = wrapper.length;
+        immutable l = wrapper.length;
         auto sl = wrapper[0 .. 1];
         assert(wrapper[0 .. $].length == buffer[0 .. $].length);
     }
@@ -9363,9 +9363,9 @@ unittest
         auto filtered = filter!"true"(buffer);
         auto wrapper = refRange(&filtered);
         auto p = wrapper.ptr;
-        auto f = wrapper.front;
+        immutable f = wrapper.front;
         wrapper.front = f;
-        auto e = wrapper.empty;
+        immutable e = wrapper.empty;
         wrapper.popFront();
         auto s = wrapper.save;
         wrapper.moveFront();
@@ -9389,11 +9389,11 @@ unittest
         string str = "hello world";
         auto wrapper = refRange(&str);
         auto p = wrapper.ptr;
-        auto f = wrapper.front;
-        auto e = wrapper.empty;
+        immutable f = wrapper.front;
+        immutable e = wrapper.empty;
         wrapper.popFront();
         auto s = wrapper.save;
-        auto b = wrapper.back;
+        immutable b = wrapper.back;
         wrapper.popBack();
     }
 
@@ -9544,8 +9544,8 @@ unittest
         int[] arr = [1, 42, 2, 41, 3, 40, 4, 42, 9];
         auto wrapper = refRange(&arr);
 
-        auto t1 = wrapper.moveFront();
-        auto t2 = wrapper.moveBack();
+        immutable t1 = wrapper.moveFront();
+        immutable t2 = wrapper.moveBack();
         wrapper.front = t2;
         wrapper.back = t1;
         assert(arr == [9, 42, 2, 41, 3, 40, 4, 42, 1]);
@@ -9881,8 +9881,8 @@ public:
                 immutable size_t elemMaskPos = (sign ^ 1) * (maskPos + n)
                     + sign * (1 + ((n - remainingBits) & (bitsNum - 1)));
 
-                auto elem = parent[elemIndex];
-                auto elemMask = mask(elemMaskPos);
+                immutable elem = parent[elemIndex];
+                immutable elemMask = mask(elemMaskPos);
                 parent[elemIndex] = cast(UnsignedElemType)(flag * (elem | elemMask)
                         + (flag ^ 1) * (elem & ~elemMask));
             }
@@ -10082,7 +10082,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
                 bw.popFront();
             }
 
-            auto rangeLen = numCalls / (IntegralType.sizeof * 8);
+            immutable rangeLen = numCalls / (IntegralType.sizeof * 8);
             assert(numCalls == (IntegralType.sizeof * 8 * rangeLen));
             assert(bw.empty);
             static if (isForwardRange!T)

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -743,7 +743,7 @@ template isOutputRange(R, E)
     import std.array;
     import std.stdio : writeln;
 
-    auto app = appender!string();
+    immutable app = appender!string();
     string s;
     static assert( isOutputRange!(Appender!string, string));
     static assert( isOutputRange!(Appender!string*, string));
@@ -1087,7 +1087,7 @@ template hasMobileElements(R)
         this(this) {}
     }
 
-    auto nonMobile = map!"a"(repeat(HasPostblit.init));
+    immutable nonMobile = map!"a"(repeat(HasPostblit.init));
     static assert(!hasMobileElements!(typeof(nonMobile)));
     static assert( hasMobileElements!(int[]));
     static assert( hasMobileElements!(inout(int)[]));
@@ -1146,7 +1146,7 @@ template ElementType(R)
 @safe unittest
 {
     enum XYZ : string { a = "foo" }
-    auto x = XYZ.a.front;
+    immutable x = XYZ.a.front;
     immutable char[3] a = "abc";
     int[] i;
     void[] buf;
@@ -1228,7 +1228,7 @@ template ElementEncodingType(R)
 @safe unittest
 {
     enum XYZ : string { a = "foo" }
-    auto x = XYZ.a.front;
+    immutable x = XYZ.a.front;
     immutable char[3] a = "abc";
     int[] i;
     void[] buf;
@@ -1766,7 +1766,7 @@ if (isBidirectionalRange!Range)
     import std.algorithm.comparison : equal;
     import std.range : iota;
     auto LL = iota(1L, 7L);
-    auto r = popFrontN(LL, 2);
+    immutable r = popFrontN(LL, 2);
     assert(equal(LL, [3L, 4L, 5L, 6L]));
     assert(r == 2);
 }
@@ -1787,7 +1787,7 @@ if (isBidirectionalRange!Range)
     import std.algorithm.comparison : equal;
     import std.range : iota;
     auto LL = iota(1L, 7L);
-    auto r = popBackN(LL, 2);
+    immutable r = popBackN(LL, 2);
     assert(equal(LL, [1L, 2L, 3L, 4L]));
     assert(r == 2);
 }
@@ -1968,7 +1968,7 @@ ElementType!R moveBack(R)(R r)
     }
     static assert(isBidirectionalRange!TestRange);
     TestRange r;
-    auto x = moveBack(r);
+    immutable x = moveBack(r);
     assert(x == 5);
 }
 
@@ -2064,8 +2064,8 @@ content of the array, it simply returns its argument.
 ///
 @safe pure nothrow unittest
 {
-    auto a = [ 1, 2, 3 ];
-    auto b = a.save;
+    immutable a = [ 1, 2, 3 ];
+    immutable b = a.save;
     assert(b is a);
 }
 
@@ -2239,7 +2239,7 @@ if (isNarrowString!(T[]))
         s.popBack();
         assert(s == "hello");
         S s3 = "\xE2\x89\xA0";
-        auto c = s3.back;
+        immutable c = s3.back;
         assert(c == cast(dchar)'\u2260');
         s3.popBack();
         assert(s3 == "");

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -251,15 +251,15 @@ public:
                         auto srange = assumeSorted!"a <= b"(arr);
                         for (uint i = 0; i < codeBounds.length/2; i++)
                         {
-                            auto start = srange.lowerBound(codeBounds[2*i]).length;
-                            auto end = srange.lowerBound(codeBounds[2*i+1]).length;
+                            immutable start = srange.lowerBound(codeBounds[2*i]).length;
+                            immutable end = srange.lowerBound(codeBounds[2*i+1]).length;
                             if (end > start || (end == start && (end & 1)))
                                s[numS++] = (i+1)*charSize;
                         }
                     }
                     if (numS == 0 || t.idx + s[numS-1] > n_length)
                         goto L_StopThread;
-                    auto  chars = set.length;
+                    immutable  chars = set.length;
                     if (chars > charsetThreshold)
                         goto L_StopThread;
                     foreach (ch; set.byCodepoint)

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -642,7 +642,7 @@ unittest
             "a",
             ""
         ];
-        auto tails = [
+        immutable tails = [
             "abcabc",
              "bcabc",
               "cabc",
@@ -706,7 +706,7 @@ unittest
             assert(std.regex.replace!(matchFn)(
                 to!String("test1 test2"), regex(to!String(`\w+`),"g"), to!String("$`:$'")
             ) == to!String(": test2 test1 :"));
-            auto s = std.regex.replace!(baz!(Captures!(String)))(to!String("Strap a rocket engine on a chicken."),
+            immutable s = std.regex.replace!(baz!(Captures!(String)))(to!String("Strap a rocket engine on a chicken."),
                     regex(to!String("[ar]"), "g"));
             assert(s == "StRAp A Rocket engine on A chicken.");
         }
@@ -999,7 +999,7 @@ unittest
 // bugzilla 14504
 unittest
 {
-    auto p = ctRegex!("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?" ~
+    immutable p = ctRegex!("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?" ~
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 }
 
@@ -1020,7 +1020,7 @@ unittest
 
     auto example = "Hello, world!";
     auto pattern = regex("^Hello, (bug)");  // won't find this one
-    auto result = replaceFirst(example, pattern, "$1 Sponge Bob");
+    immutable result = replaceFirst(example, pattern, "$1 Sponge Bob");
     assert(result == "Hello, world!");  // Ok.
 
     auto sink = appender!string;

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -522,7 +522,7 @@ template ThompsonOps(E, S, bool withInput:true)
             matcher.re.ngroup = me - ms;
             matcher.backrefed = backrefed.empty ? t.matches : backrefed;
             //backMatch
-            auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookbehindStart));
+            immutable mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookbehindStart));
             freelist = matcher.freelist;
             subCounters[t.pc] = matcher.genCounter;
             if ((mRes != 0 ) ^ positive)
@@ -539,7 +539,7 @@ template ThompsonOps(E, S, bool withInput:true)
     {
         with(e) with(state)
         {
-            auto save = index;
+            immutable save = index;
             uint len = re.ir[t.pc].data;
             uint ms = re.ir[t.pc+1].raw, me = re.ir[t.pc+2].raw;
             uint end = t.pc+len+IRL!(IR.LookaheadEnd)+IRL!(IR.LookaheadStart);
@@ -550,7 +550,7 @@ template ThompsonOps(E, S, bool withInput:true)
                 auto matcher = fwdMatcher(t.pc, end, subCounters.get(t.pc, 0));
             matcher.re.ngroup = me - ms;
             matcher.backrefed = backrefed.empty ? t.matches : backrefed;
-            auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookaheadStart));
+            immutable mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookaheadStart));
             freelist = matcher.freelist;
             subCounters[t.pc] = matcher.genCounter;
             s.reset(index);

--- a/std/socket.d
+++ b/std/socket.d
@@ -165,7 +165,7 @@ string formatSocketError(int err) @trusted
         }
         else version (OSX)
         {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
+            immutable errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
                 cs = buf.ptr;
             else
@@ -173,7 +173,7 @@ string formatSocketError(int err) @trusted
         }
         else version (FreeBSD)
         {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
+            immutable errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
                 cs = buf.ptr;
             else
@@ -181,7 +181,7 @@ string formatSocketError(int err) @trusted
         }
         else version (NetBSD)
         {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
+            immutable errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
                 cs = buf.ptr;
             else
@@ -189,7 +189,7 @@ string formatSocketError(int err) @trusted
         }
         else version (Solaris)
         {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
+            immutable errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
                 cs = buf.ptr;
             else
@@ -197,7 +197,7 @@ string formatSocketError(int err) @trusted
         }
         else version (CRuntime_Bionic)
         {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
+            immutable errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
                 cs = buf.ptr;
             else
@@ -3313,7 +3313,7 @@ public:
      */
     static int select(SocketSet checkRead, SocketSet checkWrite, SocketSet checkError, Duration timeout) @trusted
     {
-        auto vals = timeout.split!("seconds", "usecs")();
+        immutable vals = timeout.split!("seconds", "usecs")();
         TimeVal tv;
         tv.seconds      = cast(tv.tv_sec_t )vals.seconds;
         tv.microseconds = cast(tv.tv_usec_t)vals.usecs;
@@ -3581,7 +3581,7 @@ Socket[2] socketPair() @trusted
         auto listener = new TcpSocket();
         listener.setOption(SocketOptionLevel.SOCKET, SocketOption.REUSEADDR, true);
         listener.bind(new InternetAddress(INADDR_LOOPBACK, InternetAddress.PORT_ANY));
-        auto addr = listener.localAddress;
+        immutable addr = listener.localAddress;
         listener.listen(1);
 
         result[0] = new TcpSocket(addr);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1553,7 +1553,7 @@ void main()
         foreach (uint i, C; Tuple!(char, wchar, dchar).Types)
         {
             immutable(C)[] witness = "cześć \U0002000D";
-            auto buf = File(deleteme).readln!(immutable(C)[])();
+            immutable buf = File(deleteme).readln!(immutable(C)[])();
             assert(buf.length == lengths[i]);
             assert(buf == witness);
         }
@@ -1648,7 +1648,7 @@ is recommended if you want to process a complete file.
             if (_p.orientation == Orientation.unknown)
             {
                 import core.stdc.wchar_ : fwide;
-                auto w = fwide(_p.handle, 0);
+                immutable w = fwide(_p.handle, 0);
                 if (w < 0) _p.orientation = Orientation.narrow;
                 else if (w > 0) _p.orientation = Orientation.wide;
             }
@@ -2656,7 +2656,7 @@ $(D Range) that locks the file and allows fast writing to it.
                 {
                     //file.write(writeme); causes infinite recursion!!!
                     //file.rawWrite(writeme);
-                    auto result = trustedFwrite(fps_, writeme);
+                    immutable result = trustedFwrite(fps_, writeme);
                     if (result != writeme.length) errnoEnforce(0);
                     return;
                 }
@@ -3170,7 +3170,7 @@ void main()
 @safe unittest
 {
     import std.exception : collectException;
-    auto e = collectException({ File f; f.writeln("Hello!"); }());
+    immutable e = collectException({ File f; f.writeln("Hello!"); }());
     assert(e && e.msg == "Attempting to write to closed File");
 }
 
@@ -4323,14 +4323,14 @@ Initialize with a message and an error code.
             else
             {
                 strerror_r(errno, buf.ptr, buf.length);
-                auto s = buf.ptr;
+                immutable s = buf.ptr;
             }
         }
         else
         {
             import core.stdc.string : strerror;
 
-            auto s = strerror(errno);
+            immutable s = strerror(errno);
         }
         auto sysmsg = to!string(s);
         // If e is 0, we don't use the system error message.  (The message
@@ -4625,7 +4625,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
             {
                 if (i == u)         // if end of buffer
                     goto L1;        // give up
-                auto c = p[i];
+                immutable c = p[i];
                 i++;
                 if (c == terminator)
                     break;

--- a/std/string.d
+++ b/std/string.d
@@ -2848,7 +2848,7 @@ if (isConvertibleToString!Range)
 
 @safe pure unittest
 {
-    auto s = "line1\nline2";
+    immutable s = "line1\nline2";
     auto spl0 = s.lineSplitter!(Yes.keepTerminator);
     auto spl1 = spl0.save;
     spl0.popFront;
@@ -5151,7 +5151,7 @@ body
         assert(translate!C("hello world", makeTransTable("hl", "q5")) == to!(C[])("qe55o wor5d"));
 
         auto s = to!(C[])("hello world");
-        auto transTable = makeTransTable("hl", "q5");
+        immutable transTable = makeTransTable("hl", "q5");
         static assert(is(typeof(s) == typeof(translate!C(s, transTable))));
     }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -722,7 +722,7 @@ public enum dchar nelSep  = '\u0085'; /// Constant $(CODEPOINT) (0x0085) - next 
     // build the trie with the most sensible trie level
     // and bind it as a functor
     auto cyrillicOrArmenian = toDelegate(set);
-    auto balance = find!(cyrillicOrArmenian)("Hello ընկեր!");
+    immutable balance = find!(cyrillicOrArmenian)("Hello ընկեր!");
     assert(balance == "ընկեր!");
     // compatible with bool delegate(dchar)
     bool delegate(dchar) bindIt = cyrillicOrArmenian;
@@ -732,7 +732,7 @@ public enum dchar nelSep  = '\u0085'; /// Constant $(CODEPOINT) (0x0085) - next 
     assert(s is normalize(s));// is the same string
 
     string nonS = "A\u0308ffin"; // A ligature
-    auto nS = normalize(nonS); // to NFC, the W3C endorsed standard
+    immutable nS = normalize(nonS); // to NFC, the W3C endorsed standard
     assert(nS == "Äffin");
     assert(nS != nonS);
     string composed = "Äffin";
@@ -992,7 +992,7 @@ private:
         return 0;
     };
     enum ct = dg();
-    auto rt = dg();
+    immutable rt = dg();
 }
 
 @system unittest
@@ -1611,12 +1611,12 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     assert(arr.length == MAX/5-1);
     foreach (i; 0..MAX+5)
     {
-        auto st = stdLowerBound(arr, i);
+        immutable st = stdLowerBound(arr, i);
         assert(st == sharLowerBound(arr, i));
         assert(st == sharSwitchLowerBound(arr, i));
     }
     arr = [];
-    auto st = stdLowerBound(arr, 33);
+    immutable st = stdLowerBound(arr, 33);
     assert(st == sharLowerBound(arr, 33));
     assert(st == sharSwitchLowerBound(arr, 33));
 }
@@ -5254,7 +5254,7 @@ if (is(C : wchar) || is(C : char))
         assert(utf8.test(codec));
         assert(utf8.match(codec));
     }
-    auto i = codec.idx;
+    immutable i = codec.idx;
     assert(!utf8.match(codec));
     assert(codec.idx == i);
 }
@@ -5265,7 +5265,7 @@ if (is(C : wchar) || is(C : char))
     static bool testAll(Matcher, Range)(ref Matcher m, ref Range r)
     {
         bool t = m.test(r);
-        auto save = r.idx;
+        immutable save = r.idx;
         assert(t == m.match(r));
         assert(r.idx == save || t); //ether no change or was match
         r.idx = save;
@@ -6453,7 +6453,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
     import std.algorithm.comparison : equal;
     import std.range : take, drop;
     import std.range.primitives : walkLength;
-    auto text = "noe\u0308l"; // noël using e + combining diaeresis
+    immutable text = "noe\u0308l"; // noël using e + combining diaeresis
     assert(text.walkLength == 5); // 5 code points
 
     auto gText = text.byGrapheme;
@@ -6482,7 +6482,7 @@ private static struct InputRangeString
     import std.range.primitives : walkLength;
     assert("".byGrapheme.walkLength == 0);
 
-    auto reverse = "le\u0308on";
+    immutable reverse = "le\u0308on";
     assert(reverse.walkLength == 5);
 
     auto gReverse = reverse.byGrapheme;
@@ -8345,9 +8345,9 @@ if (isConvertibleToString!Range)
     {
         import std.utf : byChar;
 
-        auto sx = slwr.asUpperCase.byChar.array;
+        immutable sx = slwr.asUpperCase.byChar.array;
         assert(sx == toUpper(slwr));
-        auto sy = upper[i].asLowerCase.byChar.array;
+        immutable sy = upper[i].asLowerCase.byChar.array;
         assert(sy == toLower(upper[i]));
     }
 
@@ -8547,8 +8547,8 @@ if (isConvertibleToString!Range)
     {
         import std.utf : byChar;
 
-        auto r = cases[i][0].asCapitalized.byChar.array;
-        auto result = cases[i][1];
+        immutable r = cases[i][0].asCapitalized.byChar.array;
+        immutable result = cases[i][1];
         assert(r == result);
     }
 
@@ -8917,7 +8917,7 @@ if (isSomeString!S)
 
         void foo()
         {
-            auto u = toLower(String(""));
+            immutable u = toLower(String(""));
         }
     }
 }
@@ -9099,7 +9099,7 @@ if (isSomeString!S)
 
         void foo()
         {
-            auto u = toUpper(String(""));
+            immutable u = toUpper(String(""));
         }
     }
 }

--- a/std/uri.d
+++ b/std/uri.d
@@ -81,7 +81,7 @@ private string URI_Encode(dstring string, uint unescapedSet)
     uint Rlen;
     uint Rsize; // alloc'd size
 
-    auto len = string.length;
+    immutable len = string.length;
 
     R = buffer.ptr;
     Rsize = buffer.length;
@@ -209,7 +209,7 @@ if (isSomeChar!Char)
     dchar* R;
     uint Rlen;
 
-    auto len = uri.length;
+    immutable len = uri.length;
     auto s = uri.ptr;
 
     // Preallocate result buffer R guaranteed to be large enough for result

--- a/std/utf.d
+++ b/std/utf.d
@@ -2900,12 +2900,12 @@ template toUTFz(P)
 ///
 @safe pure unittest
 {
-    auto p1 = toUTFz!(char*)("hello world");
-    auto p2 = toUTFz!(const(char)*)("hello world");
-    auto p3 = toUTFz!(immutable(char)*)("hello world");
-    auto p4 = toUTFz!(char*)("hello world"d);
-    auto p5 = toUTFz!(const(wchar)*)("hello world");
-    auto p6 = toUTFz!(immutable(dchar)*)("hello world"w);
+    immutable p1 = toUTFz!(char*)("hello world");
+    immutable p2 = toUTFz!(const(char)*)("hello world");
+    immutable p3 = toUTFz!(immutable(char)*)("hello world");
+    immutable p4 = toUTFz!(char*)("hello world"d);
+    immutable p5 = toUTFz!(const(wchar)*)("hello world");
+    immutable p6 = toUTFz!(immutable(dchar)*)("hello world"w);
 }
 
 private P toUTFzImpl(P, S)(S str) @safe pure
@@ -3392,7 +3392,7 @@ if (!isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingTyp
     static assert(is(ElementType!(typeof(r)) == immutable char));
 
     // contrast with the range capabilities of standard strings
-    auto s = "Hello, World!";
+    immutable s = "Hello, World!";
     static assert(isBidirectionalRange!(typeof(r)));
     static assert(is(ElementType!(typeof(s)) == dchar));
 
@@ -3461,7 +3461,7 @@ pure nothrow @nogc unittest
     {
         auto r = "hello".byCodeUnit().byCodeUnit();
         static assert(isForwardRange!(typeof(r)));
-        auto s = r.save;
+        immutable s = r.save;
         r.popFront();
         assert(s.front == 'h');
     }
@@ -3491,7 +3491,7 @@ pure nothrow @nogc unittest
         }
 
         auto fn = Stringish("test.d");
-        auto x = fn.byCodeUnit();
+        immutable x = fn.byCodeUnit();
         assert(x.front == 't');
     }
 }
@@ -3791,7 +3791,7 @@ if (isSomeChar!C)
                     if (pos == fill)
                     {
                         pos = 0;
-                        auto c = r.front;
+                        immutable c = r.front;
 
                         if (c <= 0x7F)
                         {

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -263,7 +263,7 @@ public struct UUID
         @safe pure unittest
         {
             enum ubyte[16] data = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
-            auto uuid = UUID(data);
+            immutable uuid = UUID(data);
             enum ctfe = UUID(data);
             assert(uuid.data == data);
             assert(ctfe.data == data);
@@ -288,7 +288,7 @@ public struct UUID
         ///
         @safe unittest
         {
-            auto tmp = UUID(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+            immutable tmp = UUID(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
             assert(tmp.data == cast(ubyte[16])[0,1,2,3,4,5,6,7,8,9,10,11,
                 12,13,14,15]);
         }
@@ -506,7 +506,7 @@ public struct UUID
             {
                 for (size_t i = 0; i < 16; i++)
                 {
-                    auto ctfeEmpty2 = UUID(getData(i)).empty;
+                    immutable ctfeEmpty2 = UUID(getData(i)).empty;
                     assert(!ctfeEmpty2);
                 }
                 return true;
@@ -528,7 +528,7 @@ public struct UUID
         {
             //variant is stored in octet 7
             //which is index 8, since indexes count backwards
-            auto octet7 = data[8]; //octet 7 is array index 8
+            immutable octet7 = data[8]; //octet 7 is array index 8
 
             if ((octet7 & 0x80) == 0x00) //0b0xxxxxxx
                 return Variant.ncs;
@@ -589,7 +589,7 @@ public struct UUID
         {
             //version is stored in octet 9
             //which is index 6, since indexes count backwards
-            auto octet9 = data[6];
+            immutable octet9 = data[6];
             if ((octet9 & 0xF0) == 0x10)
                 return Version.timeBased;
             else if ((octet9 & 0xF0) == 0x20)
@@ -643,7 +643,7 @@ public struct UUID
          */
         @safe pure nothrow @nogc void swap(ref UUID rhs)
         {
-            auto bck = data;
+            immutable bck = data;
             data = rhs.data;
             rhs.data = bck;
         }
@@ -822,7 +822,7 @@ public struct UUID
                           UUID("7c351fd4-b860-4ee3-bbdc-7f79f3dfb00a"),
                           UUID("9ac0a4e5-10ee-493a-86fc-d29eeb82ecc1")];
             sort(ids);
-            auto id2 = ids.dup;
+            immutable id2 = ids.dup;
 
             ids = [UUID("7c351fd4-b860-4ee3-bbdc-7f79f3dfb00a"),
                    UUID("8a94f585-d180-44f7-8929-6fca0189c7d0"),
@@ -1036,16 +1036,16 @@ public struct UUID
 @safe unittest
 {
     //Use default UUID.init namespace
-    auto simpleID = md5UUID("test.uuid.any.string");
+    immutable simpleID = md5UUID("test.uuid.any.string");
 
     //use a name-based id as namespace
     auto namespace = md5UUID("my.app");
-    auto id = md5UUID("some-description", namespace);
+    immutable id = md5UUID("some-description", namespace);
 }
 
 @safe pure unittest
 {
-    auto simpleID = md5UUID("test.uuid.any.string");
+    immutable simpleID = md5UUID("test.uuid.any.string");
     assert(simpleID.data == cast(ubyte[16])[126, 206, 86, 72, 29, 233, 62, 213, 178, 139, 198, 136,
         188, 135, 153, 123]);
     auto namespace = md5UUID("my.app");
@@ -1067,9 +1067,9 @@ public struct UUID
     assert(id.variant == UUID.Variant.rfc4122);
     assert(id.uuidVersion == UUID.Version.nameBasedMD5);
 
-    auto correct = UUID("3d813cbb-47fb-32ba-91df-831e1593ac29");
+    immutable correct = UUID("3d813cbb-47fb-32ba-91df-831e1593ac29");
 
-    auto u = md5UUID("www.widgets.com", dnsNamespace);
+    immutable u = md5UUID("www.widgets.com", dnsNamespace);
     //enum ctfeId = md5UUID("www.widgets.com", dnsNamespace);
     //assert(ctfeId == u);
     assert(u == correct);
@@ -1150,16 +1150,16 @@ public struct UUID
 @safe unittest
 {
     //Use default UUID.init namespace
-    auto simpleID = sha1UUID("test.uuid.any.string");
+    immutable simpleID = sha1UUID("test.uuid.any.string");
 
     //use a name-based id as namespace
     auto namespace = sha1UUID("my.app");
-    auto id = sha1UUID("some-description", namespace);
+    immutable id = sha1UUID("some-description", namespace);
 }
 
 @safe pure unittest
 {
-    auto simpleID = sha1UUID("test.uuid.any.string");
+    immutable simpleID = sha1UUID("test.uuid.any.string");
     assert(simpleID.data == cast(ubyte[16])[16, 209, 239, 61, 99, 12, 94, 70, 159, 79, 255, 250,
         131, 79, 14, 147]);
     auto namespace = sha1UUID("my.app");
@@ -1178,9 +1178,9 @@ public struct UUID
     assert(id.data == cast(ubyte[16])[60, 65, 92, 240, 96, 46, 95, 238, 149, 100, 12, 64, 199, 194,
         243, 12]);
 
-    auto correct = UUID("21f7f8de-8051-5b89-8680-0195ef798b6a");
+    immutable correct = UUID("21f7f8de-8051-5b89-8680-0195ef798b6a");
 
-    auto u = sha1UUID("www.widgets.com", dnsNamespace);
+    immutable u = sha1UUID("www.widgets.com", dnsNamespace);
     assert(u == correct);
     assert(u.variant == UUID.Variant.rfc4122);
     assert(u.uuidVersion == UUID.Version.nameBasedSHA1);
@@ -1245,13 +1245,13 @@ if (isInputRange!RNG && isIntegral!(ElementType!RNG))
     import std.random : Xorshift192, unpredictableSeed;
 
     //simple call
-    auto uuid = randomUUID();
+    immutable uuid = randomUUID();
 
     //provide a custom RNG. Must be seeded manually.
     Xorshift192 gen;
 
     gen.seed(unpredictableSeed);
-    auto uuid3 = randomUUID(gen);
+    immutable uuid3 = randomUUID(gen);
 }
 
 /*
@@ -1270,15 +1270,15 @@ if (isInputRange!RNG && isIntegral!(ElementType!RNG))
 {
     import std.random : Xorshift192, unpredictableSeed;
     //simple call
-    auto uuid = randomUUID();
+    immutable uuid = randomUUID();
 
     //provide a custom RNG. Must be seeded manually.
     Xorshift192 gen;
     gen.seed(unpredictableSeed);
-    auto uuid3 = randomUUID(gen);
+    immutable uuid3 = randomUUID(gen);
 
-    auto u1 = randomUUID();
-    auto u2 = randomUUID();
+    immutable u1 = randomUUID();
+    immutable u2 = randomUUID();
     assert(u1 != u2);
     assert(u1.variant == UUID.Variant.rfc4122);
     assert(u1.uuidVersion == UUID.Version.randomNumberBased);
@@ -1721,7 +1721,7 @@ public class UUIDParsingException : Exception
 ///
 @safe unittest
 {
-    auto ex = new UUIDParsingException("foo", 10, UUIDParsingException.Reason.tooMuch);
+    immutable ex = new UUIDParsingException("foo", 10, UUIDParsingException.Reason.tooMuch);
     assert(ex.input == "foo");
     assert(ex.position == 10);
     assert(ex.reason == UUIDParsingException.Reason.tooMuch);

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -1796,8 +1796,8 @@ unittest
     bool foundCologne, foundMinsk, foundBeijing;
     foreach (Value v; cityKey.values)
     {
-        auto vname = v.name;
-        auto vvalue_SZ = v.value_SZ;
+        immutable vname = v.name;
+        immutable vvalue_SZ = v.value_SZ;
         if (v.name == "K\u00f6ln")
         {
             foundCologne = true;

--- a/std/xml.d
+++ b/std/xml.d
@@ -646,7 +646,7 @@ class Document : Element
 @system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=14966
-    auto xml = `<?xml version="1.0" encoding="UTF-8"?><foo></foo>`;
+    immutable xml = `<?xml version="1.0" encoding="UTF-8"?><foo></foo>`;
 
     auto a = new Document(xml);
     auto b = new Document(xml);
@@ -1302,7 +1302,7 @@ class Comment : Item
 unittest // issue 16241
 {
     import std.exception : assertThrown;
-    auto c = new Comment("==");
+    immutable c = new Comment("==");
     assert(c.content == "==");
     assertThrown!CommentException(new Comment("--"));
 }
@@ -2747,7 +2747,7 @@ void check(string s) pure
     }
     catch (CheckException e)
     {
-        auto n = e.toString().indexOf("end tag name \"genres\" differs"~
+        immutable n = e.toString().indexOf("end tag name \"genres\" differs"~
                                       " from start tag name \"genre\"");
         assert(n != -1);
     }


### PR DESCRIPTION
Uses an [automated](https://github.com/wilzbach/dscanner-fix) approach to declare variables as immutable. This brings down the list of "potential immutable" variables detected by Dscanner from 2K to 1.4K (a lot of false positives are detected).

@JackStouffer I believe you will like this ;-)

(as mentioned this was done automatically, but I am happy to split it up if needed).