### PR TITLE
Style: enforce no space after assert

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -513,6 +513,9 @@ style: ../dscanner/dsc
 	@echo "Enforce do { to be in Allman style"
 	grep -nr 'do *{$$' $$(find . -name '*.d') ; test $$? -eq 1
 
+	@echo "Enforce no space between assert and the opening brace, i.e. assert("
+	grep -nrE 'assert +\(' $$(find . -name '*.d') ; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1393,7 +1393,7 @@ if (T.length >= 2)
     alias T1 = typeof(b);
 
     import std.algorithm.internal : algoFormat;
-    static assert (is(typeof(a < b)),
+    static assert(is(typeof(a < b)),
         algoFormat("Invalid arguments: Cannot compare types %s and %s.", T0.stringof, T1.stringof));
 
     //Do the "max" proper with a and b
@@ -1507,7 +1507,7 @@ if (T.length >= 2)
     alias T1 = typeof(b);
 
     import std.algorithm.internal : algoFormat;
-    static assert (is(typeof(a < b)),
+    static assert(is(typeof(a < b)),
         algoFormat("Invalid arguments: Cannot compare types %s and %s.", T0.stringof, T1.stringof));
 
     //Do the "min" proper with a and b

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2265,7 +2265,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     import std.range.interfaces;
     // joiner() should work for non-forward ranges too.
     auto r = inputRangeObject(["abc", "def"]);
-    assert (equal(joiner(r, "xyz"), "abcxyzdef"));
+    assert(equal(joiner(r, "xyz"), "abcxyzdef"));
 }
 
 @system unittest
@@ -4777,7 +4777,7 @@ if (isForwardRange!R && !isRandomAccessRange!R)
 // Kahan algo http://en.wikipedia.org/wiki/Kahan_summation_algorithm
 private auto sumKahan(Result, R)(Result result, R r)
 {
-    static assert (isFloatingPoint!Result && isMutable!Result);
+    static assert(isFloatingPoint!Result && isMutable!Result);
     Result c = 0;
     for (; !r.empty; r.popFront())
     {

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -894,14 +894,14 @@ unittest
         int i = 1;
         this(this){}
     }
-    static assert (!hasElaborateAssign!S1);
-    static assert (!hasElaborateAssign!S2);
-    static assert ( hasElaborateAssign!S3);
-    static assert ( hasElaborateAssign!S4);
-    assert (!typeid(S1).initializer().ptr);
-    assert ( typeid(S2).initializer().ptr);
-    assert (!typeid(S3).initializer().ptr);
-    assert ( typeid(S4).initializer().ptr);
+    static assert(!hasElaborateAssign!S1);
+    static assert(!hasElaborateAssign!S2);
+    static assert( hasElaborateAssign!S3);
+    static assert( hasElaborateAssign!S4);
+    assert(!typeid(S1).initializer().ptr);
+    assert( typeid(S2).initializer().ptr);
+    assert(!typeid(S3).initializer().ptr);
+    assert( typeid(S4).initializer().ptr);
 
     foreach (S; AliasSeq!(S1, S2, S3, S4))
     {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1614,10 +1614,10 @@ if (isInputRange!InputRange &&
 @safe unittest
 {
     //CTFE
-    static assert (find("abc", 'b') == "bc");
-    static assert (find("日b語", 'b') == "b語");
-    static assert (find("日本語", '本') == "本語");
-    static assert (find([1, 2, 3], 2)  == [2, 3]);
+    static assert(find("abc", 'b') == "bc");
+    static assert(find("日b語", 'b') == "b語");
+    static assert(find("日本語", '本') == "本語");
+    static assert(find([1, 2, 3], 2)  == [2, 3]);
 
     int[] a1 = [1, 2, 3];
     static assert(find              ([1, 2, 3], 2));
@@ -3079,7 +3079,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     alias UT = Unqual!T;
     alias RetType = Tuple!(T, size_t);
 
-    static assert (is(typeof(RetType(range.front, 1))),
+    static assert(is(typeof(RetType(range.front, 1))),
         algoFormat("Error: Cannot call minCount on a %s, because it is not possible "~
                "to copy the result value (a %s) into a Tuple.", Range.stringof, T.stringof));
 

--- a/std/array.d
+++ b/std/array.d
@@ -610,7 +610,7 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
 
     static if (I.length != 0)
     {
-        static assert (is(I[0] == size_t));
+        static assert(is(I[0] == size_t));
         alias size = sizes[0];
     }
 
@@ -3117,7 +3117,7 @@ if (isDynamicArray!A)
 /// ditto
 Appender!(E[]) appender(A : E[], E)(auto ref A array)
 {
-    static assert (!isStaticArray!A || __traits(isRef, array),
+    static assert(!isStaticArray!A || __traits(isRef, array),
         "Cannot create Appender from an rvalue static array");
 
     return Appender!(E[])(array);

--- a/std/complex.d
+++ b/std/complex.d
@@ -57,39 +57,39 @@ if (is(R : double) && is(I : double))
 @safe pure nothrow unittest
 {
     auto a = complex(1.0);
-    static assert (is(typeof(a) == Complex!double));
-    assert (a.re == 1.0);
-    assert (a.im == 0.0);
+    static assert(is(typeof(a) == Complex!double));
+    assert(a.re == 1.0);
+    assert(a.im == 0.0);
 
     auto b = complex(2.0L);
-    static assert (is(typeof(b) == Complex!real));
-    assert (b.re == 2.0L);
-    assert (b.im == 0.0L);
+    static assert(is(typeof(b) == Complex!real));
+    assert(b.re == 2.0L);
+    assert(b.im == 0.0L);
 
     auto c = complex(1.0, 2.0);
-    static assert (is(typeof(c) == Complex!double));
-    assert (c.re == 1.0);
-    assert (c.im == 2.0);
+    static assert(is(typeof(c) == Complex!double));
+    assert(c.re == 1.0);
+    assert(c.im == 2.0);
 
     auto d = complex(3.0, 4.0L);
-    static assert (is(typeof(d) == Complex!real));
-    assert (d.re == 3.0);
-    assert (d.im == 4.0L);
+    static assert(is(typeof(d) == Complex!real));
+    assert(d.re == 3.0);
+    assert(d.im == 4.0L);
 
     auto e = complex(1);
-    static assert (is(typeof(e) == Complex!double));
-    assert (e.re == 1);
-    assert (e.im == 0);
+    static assert(is(typeof(e) == Complex!double));
+    assert(e.re == 1);
+    assert(e.im == 0);
 
     auto f = complex(1L, 2);
-    static assert (is(typeof(f) == Complex!double));
-    assert (f.re == 1L);
-    assert (f.im == 2);
+    static assert(is(typeof(f) == Complex!double));
+    assert(f.re == 1L);
+    assert(f.im == 2);
 
     auto g = complex(3, 4.0L);
-    static assert (is(typeof(g) == Complex!real));
-    assert (g.re == 3);
-    assert (g.im == 4.0L);
+    static assert(is(typeof(g) == Complex!real));
+    assert(g.re == 3);
+    assert(g.im == 4.0L);
 }
 
 
@@ -442,73 +442,73 @@ if (isFloatingPoint!T)
     // Check unary operations.
     auto c2 = Complex!double(0.5, 2.0);
 
-    assert (c2 == +c2);
+    assert(c2 == +c2);
 
-    assert ((-c2).re == -(c2.re));
-    assert ((-c2).im == -(c2.im));
-    assert (c2 == -(-c2));
+    assert((-c2).re == -(c2.re));
+    assert((-c2).im == -(c2.im));
+    assert(c2 == -(-c2));
 
     // Check complex-complex operations.
     auto cpc = c1 + c2;
-    assert (cpc.re == c1.re + c2.re);
-    assert (cpc.im == c1.im + c2.im);
+    assert(cpc.re == c1.re + c2.re);
+    assert(cpc.im == c1.im + c2.im);
 
     auto cmc = c1 - c2;
-    assert (cmc.re == c1.re - c2.re);
-    assert (cmc.im == c1.im - c2.im);
+    assert(cmc.re == c1.re - c2.re);
+    assert(cmc.im == c1.im - c2.im);
 
     auto ctc = c1 * c2;
-    assert (approxEqual(abs(ctc), abs(c1)*abs(c2), EPS));
-    assert (approxEqual(arg(ctc), arg(c1)+arg(c2), EPS));
+    assert(approxEqual(abs(ctc), abs(c1)*abs(c2), EPS));
+    assert(approxEqual(arg(ctc), arg(c1)+arg(c2), EPS));
 
     auto cdc = c1 / c2;
-    assert (approxEqual(abs(cdc), abs(c1)/abs(c2), EPS));
-    assert (approxEqual(arg(cdc), arg(c1)-arg(c2), EPS));
+    assert(approxEqual(abs(cdc), abs(c1)/abs(c2), EPS));
+    assert(approxEqual(arg(cdc), arg(c1)-arg(c2), EPS));
 
     auto cec = c1^^c2;
-    assert (approxEqual(cec.re, 0.11524131979943839881, EPS));
-    assert (approxEqual(cec.im, 0.21870790452746026696, EPS));
+    assert(approxEqual(cec.re, 0.11524131979943839881, EPS));
+    assert(approxEqual(cec.im, 0.21870790452746026696, EPS));
 
     // Check complex-real operations.
     double a = 123.456;
 
     auto cpr = c1 + a;
-    assert (cpr.re == c1.re + a);
-    assert (cpr.im == c1.im);
+    assert(cpr.re == c1.re + a);
+    assert(cpr.im == c1.im);
 
     auto cmr = c1 - a;
-    assert (cmr.re == c1.re - a);
-    assert (cmr.im == c1.im);
+    assert(cmr.re == c1.re - a);
+    assert(cmr.im == c1.im);
 
     auto ctr = c1 * a;
-    assert (ctr.re == c1.re*a);
-    assert (ctr.im == c1.im*a);
+    assert(ctr.re == c1.re*a);
+    assert(ctr.im == c1.im*a);
 
     auto cdr = c1 / a;
-    assert (approxEqual(abs(cdr), abs(c1)/a, EPS));
-    assert (approxEqual(arg(cdr), arg(c1), EPS));
+    assert(approxEqual(abs(cdr), abs(c1)/a, EPS));
+    assert(approxEqual(arg(cdr), arg(c1), EPS));
 
     auto cer = c1^^3.0;
-    assert (approxEqual(abs(cer), abs(c1)^^3, EPS));
-    assert (approxEqual(arg(cer), arg(c1)*3, EPS));
+    assert(approxEqual(abs(cer), abs(c1)^^3, EPS));
+    assert(approxEqual(arg(cer), arg(c1)*3, EPS));
 
     auto rpc = a + c1;
-    assert (rpc == cpr);
+    assert(rpc == cpr);
 
     auto rmc = a - c1;
-    assert (rmc.re == a-c1.re);
-    assert (rmc.im == -c1.im);
+    assert(rmc.re == a-c1.re);
+    assert(rmc.im == -c1.im);
 
     auto rtc = a * c1;
-    assert (rtc == ctr);
+    assert(rtc == ctr);
 
     auto rdc = a / c1;
-    assert (approxEqual(abs(rdc), a/abs(c1), EPS));
-    assert (approxEqual(arg(rdc), -arg(c1), EPS));
+    assert(approxEqual(abs(rdc), a/abs(c1), EPS));
+    assert(approxEqual(arg(rdc), -arg(c1), EPS));
 
     rdc = a / c2;
-    assert (approxEqual(abs(rdc), a/abs(c2), EPS));
-    assert (approxEqual(arg(rdc), -arg(c2), EPS));
+    assert(approxEqual(abs(rdc), a/abs(c2), EPS));
+    assert(approxEqual(arg(rdc), -arg(c2), EPS));
 
     auto rec1a = 1.0 ^^ c1;
     assert(rec1a.re == 1.0);
@@ -569,10 +569,10 @@ if (isFloatingPoint!T)
     foreach (i; 0..6)
     {
         auto cei = c1^^i;
-        assert (approxEqual(abs(cei), abs(c1)^^i, EPS));
+        assert(approxEqual(abs(cei), abs(c1)^^i, EPS));
         // Use cos() here to deal with arguments that go outside
         // the (-pi,pi] interval (only an issue for i>3).
-        assert (approxEqual(std.math.cos(arg(cei)), std.math.cos(arg(c1)*i), EPS));
+        assert(approxEqual(std.math.cos(arg(cei)), std.math.cos(arg(c1)*i), EPS));
     }
 
     // Check operations between different complex types.
@@ -580,10 +580,10 @@ if (isFloatingPoint!T)
     auto cr = Complex!real(1.0, 1.0);
     auto c1pcf = c1 + cf;
     auto c1pcr = c1 + cr;
-    static assert (is(typeof(c1pcf) == Complex!double));
-    static assert (is(typeof(c1pcr) == Complex!real));
-    assert (c1pcf.re == c1pcr.re);
-    assert (c1pcf.im == c1pcr.im);
+    static assert(is(typeof(c1pcf) == Complex!double));
+    static assert(is(typeof(c1pcr) == Complex!real));
+    assert(c1pcf.re == c1pcr.re);
+    assert(c1pcf.im == c1pcr.im);
 
     auto c1c = c1;
     auto c2c = c2;
@@ -611,11 +611,11 @@ if (isFloatingPoint!T)
 {
     // Initialization
     Complex!double a = 1;
-    assert (a.re == 1 && a.im == 0);
+    assert(a.re == 1 && a.im == 0);
     Complex!double b = 1.0;
-    assert (b.re == 1.0 && b.im == 0);
+    assert(b.re == 1.0 && b.im == 0);
     Complex!double c = Complex!real(1.0, 2);
-    assert (c.re == 1.0 && c.im == 2);
+    assert(c.re == 1.0 && c.im == 2);
 }
 
 @safe pure nothrow unittest
@@ -624,26 +624,26 @@ if (isFloatingPoint!T)
     Complex!double z;
 
     z = 1;
-    assert (z == 1);
-    assert (z.re == 1.0  &&  z.im == 0.0);
+    assert(z == 1);
+    assert(z.re == 1.0  &&  z.im == 0.0);
 
     z = 2.0;
-    assert (z == 2.0);
-    assert (z.re == 2.0  &&  z.im == 0.0);
+    assert(z == 2.0);
+    assert(z.re == 2.0  &&  z.im == 0.0);
 
     z = 1.0L;
-    assert (z == 1.0L);
-    assert (z.re == 1.0  &&  z.im == 0.0);
+    assert(z == 1.0L);
+    assert(z.re == 1.0  &&  z.im == 0.0);
 
     auto w = Complex!real(1.0, 1.0);
     z = w;
-    assert (z == w);
-    assert (z.re == 1.0  &&  z.im == 1.0);
+    assert(z == w);
+    assert(z.re == 1.0  &&  z.im == 1.0);
 
     auto c = Complex!float(2.0, 2.0);
     z = c;
-    assert (z == c);
-    assert (z.re == 2.0  &&  z.im == 2.0);
+    assert(z == c);
+    assert(z.re == 2.0  &&  z.im == 2.0);
 }
 
 
@@ -668,7 +668,7 @@ if (is(T R == Complex!R))
 
 @safe pure nothrow unittest
 {
-    static assert (is(Complex!(Complex!real) == Complex!real));
+    static assert(is(Complex!(Complex!real) == Complex!real));
 
     Complex!T addI(T)(T x)
     {
@@ -676,11 +676,11 @@ if (is(T R == Complex!R))
     }
 
     auto z1 = addI(1.0);
-    assert (z1.re == 1.0 && z1.im == 1.0);
+    assert(z1.re == 1.0 && z1.im == 1.0);
 
     enum one = Complex!double(1.0, 0.0);
     auto z2 = addI(one);
-    assert (z1 == z2);
+    assert(z1 == z2);
 }
 
 
@@ -698,9 +698,9 @@ T abs(T)(Complex!T z) @safe pure nothrow @nogc
 @safe pure nothrow unittest
 {
     static import std.math;
-    assert (abs(complex(1.0)) == 1.0);
-    assert (abs(complex(0.0, 1.0)) == 1.0);
-    assert (abs(complex(1.0L, -2.0L)) == std.math.sqrt(5.0L));
+    assert(abs(complex(1.0)) == 1.0);
+    assert(abs(complex(0.0, 1.0)) == 1.0);
+    assert(abs(complex(1.0L, -2.0L)) == std.math.sqrt(5.0L));
 }
 
 
@@ -720,12 +720,12 @@ T sqAbs(T)(Complex!T z) @safe pure nothrow @nogc
 @safe pure nothrow unittest
 {
     import std.math;
-    assert (sqAbs(complex(0.0)) == 0.0);
-    assert (sqAbs(complex(1.0)) == 1.0);
-    assert (sqAbs(complex(0.0, 1.0)) == 1.0);
-    assert (approxEqual(sqAbs(complex(1.0L, -2.0L)), 5.0L));
-    assert (approxEqual(sqAbs(complex(-3.0L, 1.0L)), 10.0L));
-    assert (approxEqual(sqAbs(complex(1.0f,-1.0f)), 2.0f));
+    assert(sqAbs(complex(0.0)) == 0.0);
+    assert(sqAbs(complex(1.0)) == 1.0);
+    assert(sqAbs(complex(0.0, 1.0)) == 1.0);
+    assert(approxEqual(sqAbs(complex(1.0L, -2.0L)), 5.0L));
+    assert(approxEqual(sqAbs(complex(-3.0L, 1.0L)), 10.0L));
+    assert(approxEqual(sqAbs(complex(1.0f,-1.0f)), 2.0f));
 }
 
 /// ditto
@@ -738,10 +738,10 @@ if (isFloatingPoint!T)
 @safe pure nothrow unittest
 {
     import std.math;
-    assert (sqAbs(0.0) == 0.0);
-    assert (sqAbs(-1.0) == 1.0);
-    assert (approxEqual(sqAbs(-3.0L), 9.0L));
-    assert (approxEqual(sqAbs(-5.0f), 25.0f));
+    assert(sqAbs(0.0) == 0.0);
+    assert(sqAbs(-1.0) == 1.0);
+    assert(approxEqual(sqAbs(-3.0L), 9.0L));
+    assert(approxEqual(sqAbs(-5.0f), 25.0f));
 }
 
 
@@ -759,9 +759,9 @@ T arg(T)(Complex!T z) @safe pure nothrow @nogc
 @safe pure nothrow unittest
 {
     import std.math;
-    assert (arg(complex(1.0)) == 0.0);
-    assert (arg(complex(0.0L, 1.0L)) == PI_2);
-    assert (arg(complex(1.0L, 1.0L)) == PI_4);
+    assert(arg(complex(1.0)) == 0.0);
+    assert(arg(complex(0.0L, 1.0L)) == PI_2);
+    assert(arg(complex(1.0L, 1.0L)) == PI_4);
 }
 
 
@@ -777,8 +777,8 @@ Complex!T conj(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    assert (conj(complex(1.0)) == complex(1.0));
-    assert (conj(complex(1.0, 2.0)) == complex(1.0, -2.0));
+    assert(conj(complex(1.0)) == complex(1.0));
+    assert(conj(complex(1.0, 2.0)) == complex(1.0, -2.0));
 }
 
 
@@ -802,8 +802,8 @@ Complex!(CommonType!(T, U)) fromPolar(T, U)(T modulus, U argument)
 {
     import std.math;
     auto z = fromPolar(std.math.sqrt(2.0), PI_4);
-    assert (approxEqual(z.re, 1.0L, real.epsilon));
-    assert (approxEqual(z.im, 1.0L, real.epsilon));
+    assert(approxEqual(z.re, 1.0L, real.epsilon));
+    assert(approxEqual(z.im, 1.0L, real.epsilon));
 }
 
 
@@ -931,9 +931,9 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
 @safe pure nothrow unittest
 {
     static import std.math;
-    assert (sqrt(complex(0.0)) == 0.0);
-    assert (sqrt(complex(1.0L, 0)) == std.math.sqrt(1.0L));
-    assert (sqrt(complex(-1.0L, 0)) == complex(0, 1.0L));
+    assert(sqrt(complex(0.0)) == 0.0);
+    assert(sqrt(complex(1.0L, 0)) == std.math.sqrt(1.0L));
+    assert(sqrt(complex(-1.0L, 0)) == complex(0, 1.0L));
 }
 
 @safe pure nothrow unittest
@@ -944,12 +944,12 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
     auto c2 = Complex!double(0.5, 2.0);
 
     auto c1s = sqrt(c1);
-    assert (approxEqual(c1s.re, 1.09868411));
-    assert (approxEqual(c1s.im, 0.45508986));
+    assert(approxEqual(c1s.re, 1.09868411));
+    assert(approxEqual(c1s.im, 0.45508986));
 
     auto c2s = sqrt(c2);
-    assert (approxEqual(c2s.re, 1.1317134));
-    assert (approxEqual(c2s.im, 0.8836155));
+    assert(approxEqual(c2s.re, 1.1317134));
+    assert(approxEqual(c2s.im, 0.8836155));
 }
 
 // Issue 10881: support %f formatting of complex numbers

--- a/std/conv.d
+++ b/std/conv.d
@@ -3310,21 +3310,21 @@ if (!isSomeString!Source && isInputRange!Source && isSomeChar!(ElementType!Sourc
 {
     import std.exception;
 
-    assert (to!bool("TruE") == true);
-    assert (to!bool("faLse"d) == false);
+    assert(to!bool("TruE") == true);
+    assert(to!bool("faLse"d) == false);
     assertThrown!ConvException(to!bool("maybe"));
 
     auto t = "TrueType";
-    assert (parse!bool(t) == true);
-    assert (t == "Type");
+    assert(parse!bool(t) == true);
+    assert(t == "Type");
 
     auto f = "False killer whale"d;
-    assert (parse!bool(f) == false);
-    assert (f == " killer whale"d);
+    assert(parse!bool(f) == false);
+    assert(f == " killer whale"d);
 
     auto m = "maybe";
     assertThrown!ConvException(parse!bool(m));
-    assert (m == "maybe");  // m shouldn't change on failure
+    assert(m == "maybe");  // m shouldn't change on failure
 
     auto s = "true";
     auto b = parse!(const(bool))(s);
@@ -4217,9 +4217,9 @@ package void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
 {
     static if (args.length == 0)
     {
-        static assert (is(typeof({static T i;})),
+        static assert(is(typeof({static T i;})),
             convFormat("Cannot emplace a %1$s because %1$s.this() is annotated with @disable.", T.stringof));
-        static if (is(T == class)) static assert (!isAbstractClass!T,
+        static if (is(T == class)) static assert(!isAbstractClass!T,
             T.stringof ~ " is abstract and it can't be emplaced");
         emplaceInitializer(chunk);
     }
@@ -4404,7 +4404,7 @@ Returns: The newly constructed object.
 T emplace(T, Args...)(void[] chunk, auto ref Args args)
 if (is(T == class))
 {
-    static assert (!isAbstractClass!T, T.stringof ~
+    static assert(!isAbstractClass!T, T.stringof ~
         " is abstract and it can't be emplaced");
 
     enum classSize = __traits(classInstanceSize, T);
@@ -5641,13 +5641,13 @@ template castFrom(From)
      */
     auto ref to(To, T)(auto ref T value) @system
     {
-        static assert (
+        static assert(
             is(From == T),
             "the value to cast is not of specified type '" ~ From.stringof ~
                  "', it is of type '" ~ T.stringof ~ "'"
         );
 
-        static assert (
+        static assert(
             is(typeof(cast(To)value)),
             "can't cast from '" ~ From.stringof ~ "' to '" ~ To.stringof ~ "'"
         );
@@ -5681,7 +5681,7 @@ template castFrom(From)
     // allowing bad casts to be caught before it's too late:
     {
         long* x;
-        static assert (
+        static assert(
             !__traits(compiles, castFrom!long.to!int(x))
         );
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -402,18 +402,18 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
 
 @safe unittest
 {
-    assert (enforce(123) == 123);
+    assert(enforce(123) == 123);
 
     try
     {
         enforce(false, "error");
-        assert (false);
+        assert(false);
     }
     catch (Exception e)
     {
-        assert (e.msg == "error");
-        assert (e.file == __FILE__);
-        assert (e.line == __LINE__-7);
+        assert(e.msg == "error");
+        assert(e.file == __FILE__);
+        assert(e.line == __LINE__-7);
     }
 }
 
@@ -1488,14 +1488,14 @@ class ErrnoException : Exception
 
         errno = EAGAIN;
         auto ex = new ErrnoException("oh no");
-        assert (ex.errno == EAGAIN);
+        assert(ex.errno == EAGAIN);
     }
 
     unittest
     {
         import core.stdc.errno : EAGAIN;
         auto ex = new ErrnoException("oh no", EAGAIN);
-        assert (ex.errno == EAGAIN);
+        assert(ex.errno == EAGAIN);
     }
 }
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -243,7 +243,7 @@ struct AlignedMallocator
                 ~"multiple of (void*).sizeof, according to posix_memalign!");
         }
         else if (code != 0)
-            assert (0, "posix_memalign returned an unknown code!");
+            assert(0, "posix_memalign returned an unknown code!");
 
         else
             return result[0 .. bytes];

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -708,7 +708,7 @@ unittest
     int[5] expected = [42, 42, 42, 42, 42];
     S[5] arr = void;
     uninitializedFillDefault(arr);
-    assert ((cast(int*)arr.ptr)[0 .. arr.length] == expected);
+    assert((cast(int*)arr.ptr)[0 .. arr.length] == expected);
 }
 
 unittest

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -3056,7 +3056,7 @@ unittest
     foreach (t; spawned)
         t.join();
 
-    assert (atomicOp!"=="(logged_count, 4));
+    assert(atomicOp!"=="(logged_count, 4));
 }
 
 @safe unittest

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -2148,7 +2148,7 @@ if (_N && _N < 256LU && ((!is(Unqual!_Range : Slice!(N0, Range0), size_t N0, Ran
             }
             enum K = hasher.Element.sizeof / E.sizeof + bool(hasher.Element.sizeof % E.sizeof != 0);
             enum B = E.sizeof / hasher.Element.sizeof + bool(E.sizeof % hasher.Element.sizeof != 0);
-            static assert (K == 1 || B == 1);
+            static assert(K == 1 || B == 1);
             static union U
             {
                 hasher.Element[B] blocks;
@@ -3431,7 +3431,7 @@ pure nothrow unittest
     auto a = new int[20], b = new int[20];
     alias T = PtrTuple!("a", "b");
     alias S = T!(int*, int*);
-    static assert (hasUDA!(S, LikePtr));
+    static assert(hasUDA!(S, LikePtr));
     auto t = S(a.ptr, b.ptr);
     t[4].a++;
     auto r = t[4];

--- a/std/file.d
+++ b/std/file.d
@@ -4226,7 +4226,7 @@ string tempDir() @trusted
                                     "/var/tmp",
                                     "/usr/tmp");
         }
-        else static assert (false, "Unsupported platform");
+        else static assert(false, "Unsupported platform");
 
         if (cache is null) cache = getcwd();
     }

--- a/std/functional.d
+++ b/std/functional.d
@@ -451,7 +451,7 @@ if (S=="<"||S==">"||S=="<="||S==">="||S=="=="||S=="!=")
         }
         else
         {
-            static assert (is(typeof(mixin("a "~S~" b"))),
+            static assert(is(typeof(mixin("a "~S~" b"))),
                 "Invalid arguments: Cannot compare types " ~ T0.stringof ~ " and " ~ T1.stringof ~ ".");
 
             immutable result = mixin("a "~S~" b");

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -485,7 +485,7 @@ public:
         assert(y>0);
         if (isZero()) return this;
         uint bits = cast(uint)y & BIGDIGITSHIFTMASK;
-        assert ((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
+        assert((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
         uint words = cast(uint)(y >> LG2BIGDIGITBITS);
         BigDigit [] result = new BigDigit[data.length + words+1];
         result[0..words] = 0;

--- a/std/math.d
+++ b/std/math.d
@@ -2559,7 +2559,7 @@ if (isFloatingPoint!T)
     }
     else // static if (F.realFormat == RealFormat.ibmExtended)
     {
-        assert (0, "frexp not implemented");
+        assert(0, "frexp not implemented");
     }
 }
 
@@ -2816,7 +2816,7 @@ if (isIntegral!T && isUnsigned!T)
         return FP_ILOGB0;
     else
     {
-        static assert (T.sizeof <= ulong.sizeof, "integer size too large for the current ilogb implementation");
+        static assert(T.sizeof <= ulong.sizeof, "integer size too large for the current ilogb implementation");
         return bsr(x);
     }
 }
@@ -4281,7 +4281,7 @@ long lround(real x) @trusted nothrow @nogc
     version (Posix)
         return core.stdc.math.llroundl(x);
     else
-        assert (0, "lround not implemented");
+        assert(0, "lround not implemented");
 }
 
 version(Posix)
@@ -4380,7 +4380,7 @@ real remquo(real x, real y, out int n) @trusted nothrow @nogc  /// ditto
     version (Posix)
         return core.stdc.math.remquol(x, y, &n);
     else
-        assert (0, "remquo not implemented");
+        assert(0, "remquo not implemented");
 }
 
 /** IEEE exception status flags ('sticky bits')
@@ -5632,20 +5632,20 @@ debug(UnitTest)
         static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended
                 || floatTraits!(real).realFormat == RealFormat.ieeeQuadruple)
         {
-            assert (getNaNPayload(nan4) == 0x789_ABCD_EF12_3456);
+            assert(getNaNPayload(nan4) == 0x789_ABCD_EF12_3456);
         }
         else
         {
-            assert (getNaNPayload(nan4) == 0x1_ABCD_EF12_3456);
+            assert(getNaNPayload(nan4) == 0x1_ABCD_EF12_3456);
         }
         double nan5 = nan4;
-        assert (getNaNPayload(nan5) == 0x1_ABCD_EF12_3456);
+        assert(getNaNPayload(nan5) == 0x1_ABCD_EF12_3456);
         float nan6 = nan4;
-        assert (getNaNPayload(nan6) == 0x12_3456);
+        assert(getNaNPayload(nan6) == 0x12_3456);
         nan4 = NaN(0xFABCD);
-        assert (getNaNPayload(nan4) == 0xFABCD);
+        assert(getNaNPayload(nan4) == 0xFABCD);
         nan6 = nan4;
-        assert (getNaNPayload(nan6) == 0xFABCD);
+        assert(getNaNPayload(nan6) == 0xFABCD);
         nan5 = NaN(0x100_0000_0000_3456);
         assert(getNaNPayload(nan5) == 0x0000_0000_3456);
     }
@@ -5761,7 +5761,7 @@ real nextUp(real x) @trusted pure nothrow @nogc
     }
     else // static if (F.realFormat == RealFormat.ibmExtended)
     {
-        assert (0, "nextUp not implemented");
+        assert(0, "nextUp not implemented");
     }
 }
 
@@ -6512,7 +6512,7 @@ if (isFloatingPoint!(X))
     }
     else
     {
-        static assert (F.realFormat == RealFormat.ieeeSingle
+        static assert(F.realFormat == RealFormat.ieeeSingle
                     || F.realFormat == RealFormat.ieeeDouble
                     || F.realFormat == RealFormat.ieeeExtended
                     || F.realFormat == RealFormat.ieeeQuadruple);

--- a/std/path.d
+++ b/std/path.d
@@ -80,7 +80,7 @@ private:
 */
 version(Posix)          enum string dirSeparator = "/";
 else version(Windows)   enum string dirSeparator = "\\";
-else static assert (0, "unsupported platform");
+else static assert(0, "unsupported platform");
 
 
 
@@ -90,7 +90,7 @@ else static assert (0, "unsupported platform");
 */
 version(Posix)          enum string pathSeparator = ":";
 else version(Windows)   enum string pathSeparator = ";";
-else static assert (0, "unsupported platform");
+else static assert(0, "unsupported platform");
 
 
 
@@ -156,7 +156,7 @@ version (Windows)
     private ptrdiff_t uncRootLength(R)(R path)
     if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
         isNarrowString!R)
-        in { assert (isUNC(path)); }
+        in { assert(isUNC(path)); }
         body
     {
         ptrdiff_t i = 3;
@@ -295,7 +295,7 @@ enum CaseSensitive : bool
 version (Windows)    private enum osDefaultCaseSensitivity = false;
 else version (OSX)   private enum osDefaultCaseSensitivity = false;
 else version (Posix) private enum osDefaultCaseSensitivity = true;
-else static assert (0);
+else static assert(0);
 
 
 
@@ -317,16 +317,16 @@ else static assert (0);
 
     Example:
     ---
-    assert (baseName("dir/file.ext")         == "file.ext");
-    assert (baseName("dir/file.ext", ".ext") == "file");
-    assert (baseName("dir/file.ext", ".xyz") == "file.ext");
-    assert (baseName("dir/filename", "name") == "file");
-    assert (baseName("dir/subdir/")          == "subdir");
+    assert(baseName("dir/file.ext")         == "file.ext");
+    assert(baseName("dir/file.ext", ".ext") == "file");
+    assert(baseName("dir/file.ext", ".xyz") == "file.ext");
+    assert(baseName("dir/filename", "name") == "file");
+    assert(baseName("dir/subdir/")          == "subdir");
 
     version (Windows)
     {
-        assert (baseName(`d:file.ext`)      == "file.ext");
-        assert (baseName(`d:\dir\file.ext`) == "file.ext");
+        assert(baseName(`d:file.ext`)      == "file.ext");
+        assert(baseName(`d:\dir\file.ext`) == "file.ext");
     }
     ---
 
@@ -338,7 +338,7 @@ else static assert (0);
     To obtain the filename without leading directories and without
     an extension, combine the functions like this:
     ---
-    assert (baseName(stripExtension("dir/file.ext")) == "file");
+    assert(baseName(stripExtension("dir/file.ext")) == "file");
     ---
 
     Standards:
@@ -388,22 +388,22 @@ if (isSomeChar!C && isSomeChar!C1)
 
 @safe unittest
 {
-    assert (baseName("").empty);
-    assert (baseName("file.ext"w) == "file.ext");
-    assert (baseName("file.ext"d, ".ext") == "file");
-    assert (baseName("file", "file"w.dup) == "file");
-    assert (baseName("dir/file.ext"d.dup) == "file.ext");
-    assert (baseName("dir/file.ext", ".ext"d) == "file");
-    assert (baseName("dir/file"w, "file"d) == "file");
-    assert (baseName("dir///subdir////") == "subdir");
-    assert (baseName("dir/subdir.ext/", ".ext") == "subdir");
-    assert (baseName("dir/subdir/".dup, "subdir") == "subdir");
-    assert (baseName("/"w.dup) == "/");
-    assert (baseName("//"d.dup) == "/");
-    assert (baseName("///") == "/");
+    assert(baseName("").empty);
+    assert(baseName("file.ext"w) == "file.ext");
+    assert(baseName("file.ext"d, ".ext") == "file");
+    assert(baseName("file", "file"w.dup) == "file");
+    assert(baseName("dir/file.ext"d.dup) == "file.ext");
+    assert(baseName("dir/file.ext", ".ext"d) == "file");
+    assert(baseName("dir/file"w, "file"d) == "file");
+    assert(baseName("dir///subdir////") == "subdir");
+    assert(baseName("dir/subdir.ext/", ".ext") == "subdir");
+    assert(baseName("dir/subdir/".dup, "subdir") == "subdir");
+    assert(baseName("/"w.dup) == "/");
+    assert(baseName("//"d.dup) == "/");
+    assert(baseName("///") == "/");
 
-    assert (baseName!(CaseSensitive.yes)("file.ext", ".EXT") == "file.ext");
-    assert (baseName!(CaseSensitive.no)("file.ext", ".EXT") == "file");
+    assert(baseName!(CaseSensitive.yes)("file.ext", ".EXT") == "file.ext");
+    assert(baseName!(CaseSensitive.no)("file.ext", ".EXT") == "file");
 
     {
         auto r = MockRange!(immutable(char))(`dir/file.ext`);
@@ -414,23 +414,23 @@ if (isSomeChar!C && isSomeChar!C1)
 
     version (Windows)
     {
-        assert (baseName(`dir\file.ext`) == `file.ext`);
-        assert (baseName(`dir\file.ext`, `.ext`) == `file`);
-        assert (baseName(`dir\file`, `file`) == `file`);
-        assert (baseName(`d:file.ext`) == `file.ext`);
-        assert (baseName(`d:file.ext`, `.ext`) == `file`);
-        assert (baseName(`d:file`, `file`) == `file`);
-        assert (baseName(`dir\\subdir\\\`) == `subdir`);
-        assert (baseName(`dir\subdir.ext\`, `.ext`) == `subdir`);
-        assert (baseName(`dir\subdir\`, `subdir`) == `subdir`);
-        assert (baseName(`\`) == `\`);
-        assert (baseName(`\\`) == `\`);
-        assert (baseName(`\\\`) == `\`);
-        assert (baseName(`d:\`) == `\`);
-        assert (baseName(`d:`).empty);
-        assert (baseName(`\\server\share\file`) == `file`);
-        assert (baseName(`\\server\share\`) == `\`);
-        assert (baseName(`\\server\share`) == `\`);
+        assert(baseName(`dir\file.ext`) == `file.ext`);
+        assert(baseName(`dir\file.ext`, `.ext`) == `file`);
+        assert(baseName(`dir\file`, `file`) == `file`);
+        assert(baseName(`d:file.ext`) == `file.ext`);
+        assert(baseName(`d:file.ext`, `.ext`) == `file`);
+        assert(baseName(`d:file`, `file`) == `file`);
+        assert(baseName(`dir\\subdir\\\`) == `subdir`);
+        assert(baseName(`dir\subdir.ext\`, `.ext`) == `subdir`);
+        assert(baseName(`dir\subdir\`, `subdir`) == `subdir`);
+        assert(baseName(`\`) == `\`);
+        assert(baseName(`\\`) == `\`);
+        assert(baseName(`\\\`) == `\`);
+        assert(baseName(`d:\`) == `\`);
+        assert(baseName(`d:`).empty);
+        assert(baseName(`\\server\share\file`) == `file`);
+        assert(baseName(`\\server\share\`) == `\`);
+        assert(baseName(`\\server\share`) == `\`);
 
         auto r = MockRange!(immutable(char))(`\\server\share`);
         auto s = r.baseName();
@@ -438,10 +438,10 @@ if (isSomeChar!C && isSomeChar!C1)
             assert(s[i] == c);
     }
 
-    assert (baseName(stripExtension("dir/file.ext")) == "file");
+    assert(baseName(stripExtension("dir/file.ext")) == "file");
 
-    static assert (baseName("dir/file.ext") == "file.ext");
-    static assert (baseName("dir/file.ext", ".ext") == "file");
+    static assert(baseName("dir/file.ext") == "file.ext");
+    static assert(baseName("dir/file.ext", ".ext") == "file");
 
     static struct DirEntry { string s; alias s this; }
     assert(baseName(DirEntry("dir/file.ext")) == "file.ext");
@@ -517,38 +517,38 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 ///
 @safe unittest
 {
-    assert (dirName("") == ".");
-    assert (dirName("file"w) == ".");
-    assert (dirName("dir/"d) == ".");
-    assert (dirName("dir///") == ".");
-    assert (dirName("dir/file"w.dup) == "dir");
-    assert (dirName("dir///file"d.dup) == "dir");
-    assert (dirName("dir/subdir/") == "dir");
-    assert (dirName("/dir/file"w) == "/dir");
-    assert (dirName("/file"d) == "/");
-    assert (dirName("/") == "/");
-    assert (dirName("///") == "/");
+    assert(dirName("") == ".");
+    assert(dirName("file"w) == ".");
+    assert(dirName("dir/"d) == ".");
+    assert(dirName("dir///") == ".");
+    assert(dirName("dir/file"w.dup) == "dir");
+    assert(dirName("dir///file"d.dup) == "dir");
+    assert(dirName("dir/subdir/") == "dir");
+    assert(dirName("/dir/file"w) == "/dir");
+    assert(dirName("/file"d) == "/");
+    assert(dirName("/") == "/");
+    assert(dirName("///") == "/");
 
     version (Windows)
     {
-        assert (dirName(`dir\`) == `.`);
-        assert (dirName(`dir\\\`) == `.`);
-        assert (dirName(`dir\file`) == `dir`);
-        assert (dirName(`dir\\\file`) == `dir`);
-        assert (dirName(`dir\subdir\`) == `dir`);
-        assert (dirName(`\dir\file`) == `\dir`);
-        assert (dirName(`\file`) == `\`);
-        assert (dirName(`\`) == `\`);
-        assert (dirName(`\\\`) == `\`);
-        assert (dirName(`d:`) == `d:`);
-        assert (dirName(`d:file`) == `d:`);
-        assert (dirName(`d:\`) == `d:\`);
-        assert (dirName(`d:\file`) == `d:\`);
-        assert (dirName(`d:\dir\file`) == `d:\dir`);
-        assert (dirName(`\\server\share\dir\file`) == `\\server\share\dir`);
-        assert (dirName(`\\server\share\file`) == `\\server\share`);
-        assert (dirName(`\\server\share\`) == `\\server\share`);
-        assert (dirName(`\\server\share`) == `\\server\share`);
+        assert(dirName(`dir\`) == `.`);
+        assert(dirName(`dir\\\`) == `.`);
+        assert(dirName(`dir\file`) == `dir`);
+        assert(dirName(`dir\\\file`) == `dir`);
+        assert(dirName(`dir\subdir\`) == `dir`);
+        assert(dirName(`\dir\file`) == `\dir`);
+        assert(dirName(`\file`) == `\`);
+        assert(dirName(`\`) == `\`);
+        assert(dirName(`\\\`) == `\`);
+        assert(dirName(`d:`) == `d:`);
+        assert(dirName(`d:file`) == `d:`);
+        assert(dirName(`d:\`) == `d:\`);
+        assert(dirName(`d:\file`) == `d:\`);
+        assert(dirName(`d:\dir\file`) == `d:\dir`);
+        assert(dirName(`\\server\share\dir\file`) == `\\server\share\dir`);
+        assert(dirName(`\\server\share\file`) == `\\server\share`);
+        assert(dirName(`\\server\share\`) == `\\server\share`);
+        assert(dirName(`\\server\share`) == `\\server\share`);
     }
 }
 
@@ -565,44 +565,44 @@ if (isConvertibleToString!R)
 
 @system unittest
 {
-    static assert (dirName("dir/file") == "dir");
+    static assert(dirName("dir/file") == "dir");
 
     import std.array;
     import std.utf : byChar, byWchar, byDchar;
 
-    assert (dirName("".byChar).array == ".");
-    assert (dirName("file"w.byWchar).array == "."w);
-    assert (dirName("dir/"d.byDchar).array == "."d);
-    assert (dirName("dir///".byChar).array == ".");
-    assert (dirName("dir/subdir/".byChar).array == "dir");
-    assert (dirName("/dir/file"w.byWchar).array == "/dir"w);
-    assert (dirName("/file"d.byDchar).array == "/"d);
-    assert (dirName("/".byChar).array == "/");
-    assert (dirName("///".byChar).array == "/");
+    assert(dirName("".byChar).array == ".");
+    assert(dirName("file"w.byWchar).array == "."w);
+    assert(dirName("dir/"d.byDchar).array == "."d);
+    assert(dirName("dir///".byChar).array == ".");
+    assert(dirName("dir/subdir/".byChar).array == "dir");
+    assert(dirName("/dir/file"w.byWchar).array == "/dir"w);
+    assert(dirName("/file"d.byDchar).array == "/"d);
+    assert(dirName("/".byChar).array == "/");
+    assert(dirName("///".byChar).array == "/");
 
     version (Windows)
     {
-        assert (dirName(`dir\`.byChar).array == `.`);
-        assert (dirName(`dir\\\`.byChar).array == `.`);
-        assert (dirName(`dir\file`.byChar).array == `dir`);
-        assert (dirName(`dir\\\file`.byChar).array == `dir`);
-        assert (dirName(`dir\subdir\`.byChar).array == `dir`);
-        assert (dirName(`\dir\file`.byChar).array == `\dir`);
-        assert (dirName(`\file`.byChar).array == `\`);
-        assert (dirName(`\`.byChar).array == `\`);
-        assert (dirName(`\\\`.byChar).array == `\`);
-        assert (dirName(`d:`.byChar).array == `d:`);
-        assert (dirName(`d:file`.byChar).array == `d:`);
-        assert (dirName(`d:\`.byChar).array == `d:\`);
-        assert (dirName(`d:\file`.byChar).array == `d:\`);
-        assert (dirName(`d:\dir\file`.byChar).array == `d:\dir`);
-        assert (dirName(`\\server\share\dir\file`.byChar).array == `\\server\share\dir`);
-        assert (dirName(`\\server\share\file`) == `\\server\share`);
-        assert (dirName(`\\server\share\`.byChar).array == `\\server\share`);
-        assert (dirName(`\\server\share`.byChar).array == `\\server\share`);
+        assert(dirName(`dir\`.byChar).array == `.`);
+        assert(dirName(`dir\\\`.byChar).array == `.`);
+        assert(dirName(`dir\file`.byChar).array == `dir`);
+        assert(dirName(`dir\\\file`.byChar).array == `dir`);
+        assert(dirName(`dir\subdir\`.byChar).array == `dir`);
+        assert(dirName(`\dir\file`.byChar).array == `\dir`);
+        assert(dirName(`\file`.byChar).array == `\`);
+        assert(dirName(`\`.byChar).array == `\`);
+        assert(dirName(`\\\`.byChar).array == `\`);
+        assert(dirName(`d:`.byChar).array == `d:`);
+        assert(dirName(`d:file`.byChar).array == `d:`);
+        assert(dirName(`d:\`.byChar).array == `d:\`);
+        assert(dirName(`d:\file`.byChar).array == `d:\`);
+        assert(dirName(`d:\dir\file`.byChar).array == `d:\dir`);
+        assert(dirName(`\\server\share\dir\file`.byChar).array == `\\server\share\dir`);
+        assert(dirName(`\\server\share\file`) == `\\server\share`);
+        assert(dirName(`\\server\share\`.byChar).array == `\\server\share`);
+        assert(dirName(`\\server\share`.byChar).array == `\\server\share`);
     }
 
-    //static assert (dirName("dir/file".byChar).array == "dir");
+    //static assert(dirName("dir/file".byChar).array == "dir");
 }
 
 
@@ -642,9 +642,9 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
             return path[0 .. 3];
         }
     }
-    else static assert (0, "unsupported platform");
+    else static assert(0, "unsupported platform");
 
-    assert (!isRooted(path));
+    assert(!isRooted(path));
 Lnull:
     static if (is(StringTypeOf!R))
         return null; // legacy code may rely on null return rather than slice
@@ -655,23 +655,23 @@ Lnull:
 ///
 @safe unittest
 {
-    assert (rootName("") is null);
-    assert (rootName("foo") is null);
-    assert (rootName("/") == "/");
-    assert (rootName("/foo/bar") == "/");
+    assert(rootName("") is null);
+    assert(rootName("foo") is null);
+    assert(rootName("/") == "/");
+    assert(rootName("/foo/bar") == "/");
 
     version (Windows)
     {
-        assert (rootName("d:foo") is null);
-        assert (rootName(`d:\foo`) == `d:\`);
-        assert (rootName(`\\server\share\foo`) == `\\server\share`);
-        assert (rootName(`\\server\share`) == `\\server\share`);
+        assert(rootName("d:foo") is null);
+        assert(rootName(`d:\foo`) == `d:\`);
+        assert(rootName(`\\server\share\foo`) == `\\server\share`);
+        assert(rootName(`\\server\share`) == `\\server\share`);
     }
 }
 
 @safe unittest
 {
-    assert (testAliasedString!rootName("/foo/bar"));
+    assert(testAliasedString!rootName("/foo/bar"));
 }
 
 @safe unittest
@@ -679,17 +679,17 @@ Lnull:
     import std.array;
     import std.utf : byChar;
 
-    assert (rootName("".byChar).array == "");
-    assert (rootName("foo".byChar).array == "");
-    assert (rootName("/".byChar).array == "/");
-    assert (rootName("/foo/bar".byChar).array == "/");
+    assert(rootName("".byChar).array == "");
+    assert(rootName("foo".byChar).array == "");
+    assert(rootName("/".byChar).array == "/");
+    assert(rootName("/foo/bar".byChar).array == "/");
 
     version (Windows)
     {
-        assert (rootName("d:foo".byChar).array == "");
-        assert (rootName(`d:\foo`.byChar).array == `d:\`);
-        assert (rootName(`\\server\share\foo`.byChar).array == `\\server\share`);
-        assert (rootName(`\\server\share`.byChar).array == `\\server\share`);
+        assert(rootName("d:foo".byChar).array == "");
+        assert(rootName(`d:\foo`.byChar).array == `d:\`);
+        assert(rootName(`\\server\share\foo`.byChar).array == `\\server\share`);
+        assert(rootName(`\\server\share`.byChar).array == `\\server\share`);
     }
 }
 
@@ -735,18 +735,18 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 @safe unittest
 {
     import std.range : empty;
-    version (Posix)  assert (driveName("c:/foo").empty);
+    version (Posix)  assert(driveName("c:/foo").empty);
     version (Windows)
     {
-        assert (driveName(`dir\file`).empty);
-        assert (driveName(`d:file`) == "d:");
-        assert (driveName(`d:\file`) == "d:");
-        assert (driveName("d:") == "d:");
-        assert (driveName(`\\server\share\file`) == `\\server\share`);
-        assert (driveName(`\\server\share\`) == `\\server\share`);
-        assert (driveName(`\\server\share`) == `\\server\share`);
+        assert(driveName(`dir\file`).empty);
+        assert(driveName(`d:file`) == "d:");
+        assert(driveName(`d:\file`) == "d:");
+        assert(driveName("d:") == "d:");
+        assert(driveName(`\\server\share\file`) == `\\server\share`);
+        assert(driveName(`\\server\share\`) == `\\server\share`);
+        assert(driveName(`\\server\share`) == `\\server\share`);
 
-        static assert (driveName(`d:\file`) == "d:");
+        static assert(driveName(`d:\file`) == "d:");
     }
 }
 
@@ -766,18 +766,18 @@ if (isConvertibleToString!R)
     import std.array;
     import std.utf : byChar;
 
-    version (Posix)  assert (driveName("c:/foo".byChar).empty);
+    version (Posix)  assert(driveName("c:/foo".byChar).empty);
     version (Windows)
     {
-        assert (driveName(`dir\file`.byChar).empty);
-        assert (driveName(`d:file`.byChar).array == "d:");
-        assert (driveName(`d:\file`.byChar).array == "d:");
-        assert (driveName("d:".byChar).array == "d:");
-        assert (driveName(`\\server\share\file`.byChar).array == `\\server\share`);
-        assert (driveName(`\\server\share\`.byChar).array == `\\server\share`);
-        assert (driveName(`\\server\share`.byChar).array == `\\server\share`);
+        assert(driveName(`dir\file`.byChar).empty);
+        assert(driveName(`d:file`.byChar).array == "d:");
+        assert(driveName(`d:\file`.byChar).array == "d:");
+        assert(driveName("d:".byChar).array == "d:");
+        assert(driveName(`\\server\share\file`.byChar).array == `\\server\share`);
+        assert(driveName(`\\server\share\`.byChar).array == `\\server\share`);
+        assert(driveName(`\\server\share`.byChar).array == `\\server\share`);
 
-        static assert (driveName(`d:\file`).array == "d:");
+        static assert(driveName(`d:\file`).array == "d:");
     }
 }
 
@@ -808,8 +808,8 @@ if ((isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
 {
     version (Windows)
     {
-        assert (stripDrive(`d:\dir\file`) == `\dir\file`);
-        assert (stripDrive(`\\server\share\dir\file`) == `\dir\file`);
+        assert(stripDrive(`d:\dir\file`) == `\dir\file`);
+        assert(stripDrive(`\\server\share\dir\file`) == `\dir\file`);
     }
 }
 
@@ -828,9 +828,9 @@ if (isConvertibleToString!R)
 {
     version(Windows)
     {
-        assert (stripDrive(`d:\dir\file`) == `\dir\file`);
-        assert (stripDrive(`\\server\share\dir\file`) == `\dir\file`);
-        static assert (stripDrive(`d:\dir\file`) == `\dir\file`);
+        assert(stripDrive(`d:\dir\file`) == `\dir\file`);
+        assert(stripDrive(`\\server\share\dir\file`) == `\dir\file`);
+        static assert(stripDrive(`d:\dir\file`) == `\dir\file`);
 
         auto r = MockRange!(immutable(char))(`d:\dir\file`);
         auto s = r.stripDrive();
@@ -839,7 +839,7 @@ if (isConvertibleToString!R)
     }
     version(Posix)
     {
-        assert (stripDrive(`d:\dir\file`) == `d:\dir\file`);
+        assert(stripDrive(`d:\dir\file`) == `d:\dir\file`);
 
         auto r = MockRange!(immutable(char))(`d:\dir\file`);
         auto s = r.stripDrive();
@@ -871,38 +871,38 @@ if (isRandomAccessRange!R && hasLength!R && isSomeChar!(ElementType!R) ||
 
 @safe unittest
 {
-    assert (extSeparatorPos("file") == -1);
-    assert (extSeparatorPos("file.ext"w) == 4);
-    assert (extSeparatorPos("file.ext1.ext2"d) == 9);
-    assert (extSeparatorPos(".foo".dup) == -1);
-    assert (extSeparatorPos(".foo.ext"w.dup) == 4);
+    assert(extSeparatorPos("file") == -1);
+    assert(extSeparatorPos("file.ext"w) == 4);
+    assert(extSeparatorPos("file.ext1.ext2"d) == 9);
+    assert(extSeparatorPos(".foo".dup) == -1);
+    assert(extSeparatorPos(".foo.ext"w.dup) == 4);
 }
 
 @safe unittest
 {
-    assert (extSeparatorPos("dir/file"d.dup) == -1);
-    assert (extSeparatorPos("dir/file.ext") == 8);
-    assert (extSeparatorPos("dir/file.ext1.ext2"w) == 13);
-    assert (extSeparatorPos("dir/.foo"d) == -1);
-    assert (extSeparatorPos("dir/.foo.ext".dup) == 8);
+    assert(extSeparatorPos("dir/file"d.dup) == -1);
+    assert(extSeparatorPos("dir/file.ext") == 8);
+    assert(extSeparatorPos("dir/file.ext1.ext2"w) == 13);
+    assert(extSeparatorPos("dir/.foo"d) == -1);
+    assert(extSeparatorPos("dir/.foo.ext".dup) == 8);
 
     version(Windows)
     {
-        assert (extSeparatorPos("dir\\file") == -1);
-        assert (extSeparatorPos("dir\\file.ext") == 8);
-        assert (extSeparatorPos("dir\\file.ext1.ext2") == 13);
-        assert (extSeparatorPos("dir\\.foo") == -1);
-        assert (extSeparatorPos("dir\\.foo.ext") == 8);
+        assert(extSeparatorPos("dir\\file") == -1);
+        assert(extSeparatorPos("dir\\file.ext") == 8);
+        assert(extSeparatorPos("dir\\file.ext1.ext2") == 13);
+        assert(extSeparatorPos("dir\\.foo") == -1);
+        assert(extSeparatorPos("dir\\.foo.ext") == 8);
 
-        assert (extSeparatorPos("d:file") == -1);
-        assert (extSeparatorPos("d:file.ext") == 6);
-        assert (extSeparatorPos("d:file.ext1.ext2") == 11);
-        assert (extSeparatorPos("d:.foo") == -1);
-        assert (extSeparatorPos("d:.foo.ext") == 6);
+        assert(extSeparatorPos("d:file") == -1);
+        assert(extSeparatorPos("d:file.ext") == 6);
+        assert(extSeparatorPos("d:file.ext1.ext2") == 11);
+        assert(extSeparatorPos("d:.foo") == -1);
+        assert(extSeparatorPos("d:.foo.ext") == 6);
     }
 
-    static assert (extSeparatorPos("file") == -1);
-    static assert (extSeparatorPos("file.ext"w) == 4);
+    static assert(extSeparatorPos("file") == -1);
+    static assert(extSeparatorPos("file.ext"w) == 4);
 }
 
 
@@ -931,15 +931,15 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
 @safe unittest
 {
     import std.range : empty;
-    assert (extension("file").empty);
-    assert (extension("file.") == ".");
-    assert (extension("file.ext"w) == ".ext");
-    assert (extension("file.ext1.ext2"d) == ".ext2");
-    assert (extension(".foo".dup).empty);
-    assert (extension(".foo.ext"w.dup) == ".ext");
+    assert(extension("file").empty);
+    assert(extension("file.") == ".");
+    assert(extension("file.ext"w) == ".ext");
+    assert(extension("file.ext1.ext2"d) == ".ext2");
+    assert(extension(".foo".dup).empty);
+    assert(extension(".foo.ext"w.dup) == ".ext");
 
-    static assert (extension("file").empty);
-    static assert (extension("file.ext") == ".ext");
+    static assert(extension("file").empty);
+    static assert(extension("file.ext") == ".ext");
 }
 
 @safe unittest
@@ -952,7 +952,7 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
     }
 
     static struct DirEntry { string s; alias s this; }
-    assert (extension(DirEntry("file")).empty);
+    assert(extension(DirEntry("file")).empty);
 }
 
 
@@ -976,13 +976,13 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 ///
 @safe unittest
 {
-    assert (stripExtension("file")           == "file");
-    assert (stripExtension("file.ext")       == "file");
-    assert (stripExtension("file.ext1.ext2") == "file.ext1");
-    assert (stripExtension("file.")          == "file");
-    assert (stripExtension(".file")          == ".file");
-    assert (stripExtension(".file.ext")      == ".file");
-    assert (stripExtension("dir/file.ext")   == "dir/file");
+    assert(stripExtension("file")           == "file");
+    assert(stripExtension("file.ext")       == "file");
+    assert(stripExtension("file.ext1.ext2") == "file.ext1");
+    assert(stripExtension("file.")          == "file");
+    assert(stripExtension(".file")          == ".file");
+    assert(stripExtension(".file.ext")      == ".file");
+    assert(stripExtension("dir/file.ext")   == "dir/file");
 }
 
 auto stripExtension(R)(auto ref R path)
@@ -993,20 +993,20 @@ if (isConvertibleToString!R)
 
 @safe unittest
 {
-    assert (testAliasedString!stripExtension("file"));
+    assert(testAliasedString!stripExtension("file"));
 }
 
 @safe unittest
 {
-    assert (stripExtension("file.ext"w) == "file");
-    assert (stripExtension("file.ext1.ext2"d) == "file.ext1");
+    assert(stripExtension("file.ext"w) == "file");
+    assert(stripExtension("file.ext1.ext2"d) == "file.ext1");
 
     import std.array;
     import std.utf : byChar, byWchar, byDchar;
 
-    assert (stripExtension("file".byChar).array == "file");
-    assert (stripExtension("file.ext"w.byWchar).array == "file");
-    assert (stripExtension("file.ext1.ext2"d.byDchar).array == "file.ext1");
+    assert(stripExtension("file".byChar).array == "file");
+    assert(stripExtension("file.ext"w.byWchar).array == "file");
+    assert(stripExtension("file.ext1.ext2"d.byDchar).array == "file.ext1");
 }
 
 
@@ -1068,32 +1068,32 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
 ///
 @safe unittest
 {
-    assert (setExtension("file", "ext") == "file.ext");
-    assert (setExtension("file"w, ".ext"w) == "file.ext");
-    assert (setExtension("file."d, "ext"d) == "file.ext");
-    assert (setExtension("file.", ".ext") == "file.ext");
-    assert (setExtension("file.old"w, "new"w) == "file.new");
-    assert (setExtension("file.old"d, ".new"d) == "file.new");
+    assert(setExtension("file", "ext") == "file.ext");
+    assert(setExtension("file"w, ".ext"w) == "file.ext");
+    assert(setExtension("file."d, "ext"d) == "file.ext");
+    assert(setExtension("file.", ".ext") == "file.ext");
+    assert(setExtension("file.old"w, "new"w) == "file.new");
+    assert(setExtension("file.old"d, ".new"d) == "file.new");
 }
 
 @safe unittest
 {
-    assert (setExtension("file"w.dup, "ext"w) == "file.ext");
-    assert (setExtension("file"w.dup, ".ext"w) == "file.ext");
-    assert (setExtension("file."w, "ext"w.dup) == "file.ext");
-    assert (setExtension("file."w, ".ext"w.dup) == "file.ext");
-    assert (setExtension("file.old"d.dup, "new"d) == "file.new");
-    assert (setExtension("file.old"d.dup, ".new"d) == "file.new");
+    assert(setExtension("file"w.dup, "ext"w) == "file.ext");
+    assert(setExtension("file"w.dup, ".ext"w) == "file.ext");
+    assert(setExtension("file."w, "ext"w.dup) == "file.ext");
+    assert(setExtension("file."w, ".ext"w.dup) == "file.ext");
+    assert(setExtension("file.old"d.dup, "new"d) == "file.new");
+    assert(setExtension("file.old"d.dup, ".new"d) == "file.new");
 
-    static assert (setExtension("file", "ext") == "file.ext");
-    static assert (setExtension("file.old", "new") == "file.new");
+    static assert(setExtension("file", "ext") == "file.ext");
+    static assert(setExtension("file.old", "new") == "file.new");
 
-    static assert (setExtension("file"w.dup, "ext"w) == "file.ext");
-    static assert (setExtension("file.old"d.dup, "new"d) == "file.new");
+    static assert(setExtension("file"w.dup, "ext"w) == "file.ext");
+    static assert(setExtension("file.old"d.dup, "new"d) == "file.new");
 
     // Issue 10601
-    assert (setExtension("file", "") == "file");
-    assert (setExtension("file.ext", "") == "file");
+    assert(setExtension("file", "") == "file");
+    assert(setExtension("file.ext", "") == "file");
 }
 
 /************
@@ -1128,14 +1128,14 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 @safe unittest
 {
     import std.array;
-    assert (withExtension("file", "ext").array == "file.ext");
-    assert (withExtension("file"w, ".ext"w).array == "file.ext");
-    assert (withExtension("file.ext"w, ".").array == "file.");
+    assert(withExtension("file", "ext").array == "file.ext");
+    assert(withExtension("file"w, ".ext"w).array == "file.ext");
+    assert(withExtension("file.ext"w, ".").array == "file.");
 
     import std.utf : byChar, byWchar;
-    assert (withExtension("file".byChar, "ext").array == "file.ext");
-    assert (withExtension("file"w.byWchar, ".ext"w).array == "file.ext"w);
-    assert (withExtension("file.ext"w.byWchar, ".").array == "file."w);
+    assert(withExtension("file".byChar, "ext").array == "file.ext");
+    assert(withExtension("file"w.byWchar, ".ext"w).array == "file.ext"w);
+    assert(withExtension("file.ext"w.byWchar, ".").array == "file."w);
 }
 
 auto withExtension(R, C)(auto ref R path, C[] ext)
@@ -1146,7 +1146,7 @@ if (isConvertibleToString!R)
 
 @safe unittest
 {
-    assert (testAliasedString!withExtension("file", "ext"));
+    assert(testAliasedString!withExtension("file", "ext"));
 }
 
 /** Params:
@@ -1171,23 +1171,23 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
 ///
 @safe unittest
 {
-    assert (defaultExtension("file", "ext") == "file.ext");
-    assert (defaultExtension("file", ".ext") == "file.ext");
-    assert (defaultExtension("file.", "ext")     == "file.");
-    assert (defaultExtension("file.old", "new") == "file.old");
-    assert (defaultExtension("file.old", ".new") == "file.old");
+    assert(defaultExtension("file", "ext") == "file.ext");
+    assert(defaultExtension("file", ".ext") == "file.ext");
+    assert(defaultExtension("file.", "ext")     == "file.");
+    assert(defaultExtension("file.old", "new") == "file.old");
+    assert(defaultExtension("file.old", ".new") == "file.old");
 }
 
 @safe unittest
 {
-    assert (defaultExtension("file"w.dup, "ext"w) == "file.ext");
-    assert (defaultExtension("file.old"d.dup, "new"d) == "file.old");
+    assert(defaultExtension("file"w.dup, "ext"w) == "file.ext");
+    assert(defaultExtension("file.old"d.dup, "new"d) == "file.old");
 
-    static assert (defaultExtension("file", "ext") == "file.ext");
-    static assert (defaultExtension("file.old", "new") == "file.old");
+    static assert(defaultExtension("file", "ext") == "file.ext");
+    static assert(defaultExtension("file.old", "new") == "file.old");
 
-    static assert (defaultExtension("file"w.dup, "ext"w) == "file.ext");
-    static assert (defaultExtension("file.old"d.dup, "new"d) == "file.old");
+    static assert(defaultExtension("file"w.dup, "ext"w) == "file.ext");
+    static assert(defaultExtension("file.old"d.dup, "new"d) == "file.old");
 }
 
 
@@ -1230,16 +1230,16 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
 @safe unittest
 {
     import std.array;
-    assert (withDefaultExtension("file", "ext").array == "file.ext");
-    assert (withDefaultExtension("file"w, ".ext").array == "file.ext"w);
-    assert (withDefaultExtension("file.", "ext").array == "file.");
-    assert (withDefaultExtension("file", "").array == "file.");
+    assert(withDefaultExtension("file", "ext").array == "file.ext");
+    assert(withDefaultExtension("file"w, ".ext").array == "file.ext"w);
+    assert(withDefaultExtension("file.", "ext").array == "file.");
+    assert(withDefaultExtension("file", "").array == "file.");
 
     import std.utf : byChar, byWchar;
-    assert (withDefaultExtension("file".byChar, "ext").array == "file.ext");
-    assert (withDefaultExtension("file"w.byWchar, ".ext").array == "file.ext"w);
-    assert (withDefaultExtension("file.".byChar, "ext"d).array == "file.");
-    assert (withDefaultExtension("file".byChar, "").array == "file.");
+    assert(withDefaultExtension("file".byChar, "ext").array == "file.ext");
+    assert(withDefaultExtension("file"w.byWchar, ".ext").array == "file.ext"w);
+    assert(withDefaultExtension("file.".byChar, "ext"d).array == "file.");
+    assert(withDefaultExtension("file".byChar, "").array == "file.");
 }
 
 auto withDefaultExtension(R, C)(auto ref R path, C[] ext)
@@ -1250,7 +1250,7 @@ if (isConvertibleToString!R)
 
 @safe unittest
 {
-    assert (testAliasedString!withDefaultExtension("file", "ext"));
+    assert(testAliasedString!withDefaultExtension("file", "ext"));
 }
 
 /** Combines one or more path segments.
@@ -1328,18 +1328,18 @@ if (isSomeChar!C)
 {
     version (Posix)
     {
-        assert (buildPath("foo", "bar", "baz") == "foo/bar/baz");
-        assert (buildPath("/foo/", "bar/baz")  == "/foo/bar/baz");
-        assert (buildPath("/foo", "/bar")      == "/bar");
+        assert(buildPath("foo", "bar", "baz") == "foo/bar/baz");
+        assert(buildPath("/foo/", "bar/baz")  == "/foo/bar/baz");
+        assert(buildPath("/foo", "/bar")      == "/bar");
     }
 
     version (Windows)
     {
-        assert (buildPath("foo", "bar", "baz") == `foo\bar\baz`);
-        assert (buildPath(`c:\foo`, `bar\baz`) == `c:\foo\bar\baz`);
-        assert (buildPath("foo", `d:\bar`)     == `d:\bar`);
-        assert (buildPath("foo", `\bar`)       == `\bar`);
-        assert (buildPath(`c:\foo`, `\bar`)    == `c:\bar`);
+        assert(buildPath("foo", "bar", "baz") == `foo\bar\baz`);
+        assert(buildPath(`c:\foo`, `bar\baz`) == `c:\foo\bar\baz`);
+        assert(buildPath("foo", `d:\bar`)     == `d:\bar`);
+        assert(buildPath("foo", `\bar`)       == `\bar`);
+        assert(buildPath(`c:\foo`, `\bar`)    == `c:\bar`);
     }
 }
 
@@ -1351,75 +1351,75 @@ if (isSomeChar!C)
     InputRange!(C[]) ir(C)(C[][] p...) { return inputRangeObject(p); }
     version (Posix)
     {
-        assert (buildPath("foo") == "foo");
-        assert (buildPath("/foo/") == "/foo/");
-        assert (buildPath("foo", "bar") == "foo/bar");
-        assert (buildPath("foo", "bar", "baz") == "foo/bar/baz");
-        assert (buildPath("foo/".dup, "bar") == "foo/bar");
-        assert (buildPath("foo///", "bar".dup) == "foo///bar");
-        assert (buildPath("/foo"w, "bar"w) == "/foo/bar");
-        assert (buildPath("foo"w.dup, "/bar"w) == "/bar");
-        assert (buildPath("foo"w, "bar/"w.dup) == "foo/bar/");
-        assert (buildPath("/"d, "foo"d) == "/foo");
-        assert (buildPath(""d.dup, "foo"d) == "foo");
-        assert (buildPath("foo"d, ""d.dup) == "foo");
-        assert (buildPath("foo", "bar".dup, "baz") == "foo/bar/baz");
-        assert (buildPath("foo"w, "/bar"w, "baz"w.dup) == "/bar/baz");
+        assert(buildPath("foo") == "foo");
+        assert(buildPath("/foo/") == "/foo/");
+        assert(buildPath("foo", "bar") == "foo/bar");
+        assert(buildPath("foo", "bar", "baz") == "foo/bar/baz");
+        assert(buildPath("foo/".dup, "bar") == "foo/bar");
+        assert(buildPath("foo///", "bar".dup) == "foo///bar");
+        assert(buildPath("/foo"w, "bar"w) == "/foo/bar");
+        assert(buildPath("foo"w.dup, "/bar"w) == "/bar");
+        assert(buildPath("foo"w, "bar/"w.dup) == "foo/bar/");
+        assert(buildPath("/"d, "foo"d) == "/foo");
+        assert(buildPath(""d.dup, "foo"d) == "foo");
+        assert(buildPath("foo"d, ""d.dup) == "foo");
+        assert(buildPath("foo", "bar".dup, "baz") == "foo/bar/baz");
+        assert(buildPath("foo"w, "/bar"w, "baz"w.dup) == "/bar/baz");
 
-        static assert (buildPath("foo", "bar", "baz") == "foo/bar/baz");
-        static assert (buildPath("foo", "/bar", "baz") == "/bar/baz");
+        static assert(buildPath("foo", "bar", "baz") == "foo/bar/baz");
+        static assert(buildPath("foo", "/bar", "baz") == "/bar/baz");
 
         // The following are mostly duplicates of the above, except that the
         // range version does not accept mixed constness.
-        assert (buildPath(ir("foo")) == "foo");
-        assert (buildPath(ir("/foo/")) == "/foo/");
-        assert (buildPath(ir("foo", "bar")) == "foo/bar");
-        assert (buildPath(ir("foo", "bar", "baz")) == "foo/bar/baz");
-        assert (buildPath(ir("foo/".dup, "bar".dup)) == "foo/bar");
-        assert (buildPath(ir("foo///".dup, "bar".dup)) == "foo///bar");
-        assert (buildPath(ir("/foo"w, "bar"w)) == "/foo/bar");
-        assert (buildPath(ir("foo"w.dup, "/bar"w.dup)) == "/bar");
-        assert (buildPath(ir("foo"w.dup, "bar/"w.dup)) == "foo/bar/");
-        assert (buildPath(ir("/"d, "foo"d)) == "/foo");
-        assert (buildPath(ir(""d.dup, "foo"d.dup)) == "foo");
-        assert (buildPath(ir("foo"d, ""d)) == "foo");
-        assert (buildPath(ir("foo", "bar", "baz")) == "foo/bar/baz");
-        assert (buildPath(ir("foo"w.dup, "/bar"w.dup, "baz"w.dup)) == "/bar/baz");
+        assert(buildPath(ir("foo")) == "foo");
+        assert(buildPath(ir("/foo/")) == "/foo/");
+        assert(buildPath(ir("foo", "bar")) == "foo/bar");
+        assert(buildPath(ir("foo", "bar", "baz")) == "foo/bar/baz");
+        assert(buildPath(ir("foo/".dup, "bar".dup)) == "foo/bar");
+        assert(buildPath(ir("foo///".dup, "bar".dup)) == "foo///bar");
+        assert(buildPath(ir("/foo"w, "bar"w)) == "/foo/bar");
+        assert(buildPath(ir("foo"w.dup, "/bar"w.dup)) == "/bar");
+        assert(buildPath(ir("foo"w.dup, "bar/"w.dup)) == "foo/bar/");
+        assert(buildPath(ir("/"d, "foo"d)) == "/foo");
+        assert(buildPath(ir(""d.dup, "foo"d.dup)) == "foo");
+        assert(buildPath(ir("foo"d, ""d)) == "foo");
+        assert(buildPath(ir("foo", "bar", "baz")) == "foo/bar/baz");
+        assert(buildPath(ir("foo"w.dup, "/bar"w.dup, "baz"w.dup)) == "/bar/baz");
     }
     version (Windows)
     {
-        assert (buildPath("foo") == "foo");
-        assert (buildPath(`\foo/`) == `\foo/`);
-        assert (buildPath("foo", "bar", "baz") == `foo\bar\baz`);
-        assert (buildPath("foo", `\bar`) == `\bar`);
-        assert (buildPath(`c:\foo`, "bar") == `c:\foo\bar`);
-        assert (buildPath("foo"w, `d:\bar`w.dup) ==  `d:\bar`);
-        assert (buildPath(`c:\foo\bar`, `\baz`) == `c:\baz`);
-        assert (buildPath(`\\foo\bar\baz`d, `foo`d, `\bar`d) == `\\foo\bar\bar`d);
+        assert(buildPath("foo") == "foo");
+        assert(buildPath(`\foo/`) == `\foo/`);
+        assert(buildPath("foo", "bar", "baz") == `foo\bar\baz`);
+        assert(buildPath("foo", `\bar`) == `\bar`);
+        assert(buildPath(`c:\foo`, "bar") == `c:\foo\bar`);
+        assert(buildPath("foo"w, `d:\bar`w.dup) ==  `d:\bar`);
+        assert(buildPath(`c:\foo\bar`, `\baz`) == `c:\baz`);
+        assert(buildPath(`\\foo\bar\baz`d, `foo`d, `\bar`d) == `\\foo\bar\bar`d);
 
-        static assert (buildPath("foo", "bar", "baz") == `foo\bar\baz`);
-        static assert (buildPath("foo", `c:\bar`, "baz") == `c:\bar\baz`);
+        static assert(buildPath("foo", "bar", "baz") == `foo\bar\baz`);
+        static assert(buildPath("foo", `c:\bar`, "baz") == `c:\bar\baz`);
 
-        assert (buildPath(ir("foo")) == "foo");
-        assert (buildPath(ir(`\foo/`)) == `\foo/`);
-        assert (buildPath(ir("foo", "bar", "baz")) == `foo\bar\baz`);
-        assert (buildPath(ir("foo", `\bar`)) == `\bar`);
-        assert (buildPath(ir(`c:\foo`, "bar")) == `c:\foo\bar`);
-        assert (buildPath(ir("foo"w.dup, `d:\bar`w.dup)) ==  `d:\bar`);
-        assert (buildPath(ir(`c:\foo\bar`, `\baz`)) == `c:\baz`);
-        assert (buildPath(ir(`\\foo\bar\baz`d, `foo`d, `\bar`d)) == `\\foo\bar\bar`d);
+        assert(buildPath(ir("foo")) == "foo");
+        assert(buildPath(ir(`\foo/`)) == `\foo/`);
+        assert(buildPath(ir("foo", "bar", "baz")) == `foo\bar\baz`);
+        assert(buildPath(ir("foo", `\bar`)) == `\bar`);
+        assert(buildPath(ir(`c:\foo`, "bar")) == `c:\foo\bar`);
+        assert(buildPath(ir("foo"w.dup, `d:\bar`w.dup)) ==  `d:\bar`);
+        assert(buildPath(ir(`c:\foo\bar`, `\baz`)) == `c:\baz`);
+        assert(buildPath(ir(`\\foo\bar\baz`d, `foo`d, `\bar`d)) == `\\foo\bar\bar`d);
     }
 
     // Test that allocation works as it should.
     auto manyShort = "aaa".repeat(1000).array();
     auto manyShortCombined = join(manyShort, dirSeparator);
-    assert (buildPath(manyShort) == manyShortCombined);
-    assert (buildPath(ir(manyShort)) == manyShortCombined);
+    assert(buildPath(manyShort) == manyShortCombined);
+    assert(buildPath(ir(manyShort)) == manyShortCombined);
 
     auto fewLong = 'b'.repeat(500).array().repeat(10).array();
     auto fewLongCombined = join(fewLong, dirSeparator);
-    assert (buildPath(fewLong) == fewLongCombined);
-    assert (buildPath(ir(fewLong)) == fewLongCombined);
+    assert(buildPath(fewLong) == fewLongCombined);
+    assert(buildPath(ir(fewLong)) == fewLongCombined);
 }
 
 @safe unittest
@@ -1428,11 +1428,11 @@ if (isSomeChar!C)
     string[] ary = ["a", "b"];
     version (Posix)
     {
-        assert (buildPath(ary) == "a/b");
+        assert(buildPath(ary) == "a/b");
     }
     else version (Windows)
     {
-        assert (buildPath(ary) == `a\b`);
+        assert(buildPath(ary) == `a\b`);
     }
 }
 
@@ -1513,35 +1513,35 @@ if ((isRandomAccessRange!R1 && hasSlicing!R1 && hasLength!R1 && isSomeChar!(Elem
     import std.array;
     version (Posix)
     {
-        assert (chainPath("foo", "bar", "baz").array == "foo/bar/baz");
-        assert (chainPath("/foo/", "bar/baz").array  == "/foo/bar/baz");
-        assert (chainPath("/foo", "/bar").array      == "/bar");
+        assert(chainPath("foo", "bar", "baz").array == "foo/bar/baz");
+        assert(chainPath("/foo/", "bar/baz").array  == "/foo/bar/baz");
+        assert(chainPath("/foo", "/bar").array      == "/bar");
     }
 
     version (Windows)
     {
-        assert (chainPath("foo", "bar", "baz").array == `foo\bar\baz`);
-        assert (chainPath(`c:\foo`, `bar\baz`).array == `c:\foo\bar\baz`);
-        assert (chainPath("foo", `d:\bar`).array     == `d:\bar`);
-        assert (chainPath("foo", `\bar`).array       == `\bar`);
-        assert (chainPath(`c:\foo`, `\bar`).array    == `c:\bar`);
+        assert(chainPath("foo", "bar", "baz").array == `foo\bar\baz`);
+        assert(chainPath(`c:\foo`, `bar\baz`).array == `c:\foo\bar\baz`);
+        assert(chainPath("foo", `d:\bar`).array     == `d:\bar`);
+        assert(chainPath("foo", `\bar`).array       == `\bar`);
+        assert(chainPath(`c:\foo`, `\bar`).array    == `c:\bar`);
     }
 
     import std.utf : byChar;
     version (Posix)
     {
-        assert (chainPath("foo", "bar", "baz").array == "foo/bar/baz");
-        assert (chainPath("/foo/".byChar, "bar/baz").array  == "/foo/bar/baz");
-        assert (chainPath("/foo", "/bar".byChar).array      == "/bar");
+        assert(chainPath("foo", "bar", "baz").array == "foo/bar/baz");
+        assert(chainPath("/foo/".byChar, "bar/baz").array  == "/foo/bar/baz");
+        assert(chainPath("/foo", "/bar".byChar).array      == "/bar");
     }
 
     version (Windows)
     {
-        assert (chainPath("foo", "bar", "baz").array == `foo\bar\baz`);
-        assert (chainPath(`c:\foo`.byChar, `bar\baz`).array == `c:\foo\bar\baz`);
-        assert (chainPath("foo", `d:\bar`).array     == `d:\bar`);
-        assert (chainPath("foo", `\bar`.byChar).array       == `\bar`);
-        assert (chainPath(`c:\foo`, `\bar`w).array    == `c:\bar`);
+        assert(chainPath("foo", "bar", "baz").array == `foo\bar\baz`);
+        assert(chainPath(`c:\foo`.byChar, `bar\baz`).array == `c:\foo\bar\baz`);
+        assert(chainPath("foo", `d:\bar`).array     == `d:\bar`);
+        assert(chainPath("foo", `\bar`.byChar).array       == `\bar`);
+        assert(chainPath(`c:\foo`, `\bar`w).array    == `c:\bar`);
     }
 }
 
@@ -1603,102 +1603,102 @@ if (isSomeChar!C)
 ///
 @safe unittest
 {
-    assert (buildNormalizedPath("foo", "..") == ".");
+    assert(buildNormalizedPath("foo", "..") == ".");
 
     version (Posix)
     {
-        assert (buildNormalizedPath("/foo/./bar/..//baz/") == "/foo/baz");
-        assert (buildNormalizedPath("../foo/.") == "../foo");
-        assert (buildNormalizedPath("/foo", "bar/baz/") == "/foo/bar/baz");
-        assert (buildNormalizedPath("/foo", "/bar/..", "baz") == "/baz");
-        assert (buildNormalizedPath("foo/./bar", "../../", "../baz") == "../baz");
-        assert (buildNormalizedPath("/foo/./bar", "../../baz") == "/baz");
+        assert(buildNormalizedPath("/foo/./bar/..//baz/") == "/foo/baz");
+        assert(buildNormalizedPath("../foo/.") == "../foo");
+        assert(buildNormalizedPath("/foo", "bar/baz/") == "/foo/bar/baz");
+        assert(buildNormalizedPath("/foo", "/bar/..", "baz") == "/baz");
+        assert(buildNormalizedPath("foo/./bar", "../../", "../baz") == "../baz");
+        assert(buildNormalizedPath("/foo/./bar", "../../baz") == "/baz");
     }
 
     version (Windows)
     {
-        assert (buildNormalizedPath(`c:\foo\.\bar/..\\baz\`) == `c:\foo\baz`);
-        assert (buildNormalizedPath(`..\foo\.`) == `..\foo`);
-        assert (buildNormalizedPath(`c:\foo`, `bar\baz\`) == `c:\foo\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo`, `bar/..`) == `c:\foo`);
-        assert (buildNormalizedPath(`\\server\share\foo`, `..\bar`) ==
+        assert(buildNormalizedPath(`c:\foo\.\bar/..\\baz\`) == `c:\foo\baz`);
+        assert(buildNormalizedPath(`..\foo\.`) == `..\foo`);
+        assert(buildNormalizedPath(`c:\foo`, `bar\baz\`) == `c:\foo\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo`, `bar/..`) == `c:\foo`);
+        assert(buildNormalizedPath(`\\server\share\foo`, `..\bar`) ==
                 `\\server\share\bar`);
     }
 }
 
 @safe unittest
 {
-    assert (buildNormalizedPath(".", ".") == ".");
-    assert (buildNormalizedPath("foo", "..") == ".");
-    assert (buildNormalizedPath("", "") is null);
-    assert (buildNormalizedPath("", ".") == ".");
-    assert (buildNormalizedPath(".", "") == ".");
-    assert (buildNormalizedPath(null, "foo") == "foo");
-    assert (buildNormalizedPath("", "foo") == "foo");
-    assert (buildNormalizedPath("", "") == "");
-    assert (buildNormalizedPath("", null) == "");
-    assert (buildNormalizedPath(null, "") == "");
-    assert (buildNormalizedPath!(char)(null, null) == "");
+    assert(buildNormalizedPath(".", ".") == ".");
+    assert(buildNormalizedPath("foo", "..") == ".");
+    assert(buildNormalizedPath("", "") is null);
+    assert(buildNormalizedPath("", ".") == ".");
+    assert(buildNormalizedPath(".", "") == ".");
+    assert(buildNormalizedPath(null, "foo") == "foo");
+    assert(buildNormalizedPath("", "foo") == "foo");
+    assert(buildNormalizedPath("", "") == "");
+    assert(buildNormalizedPath("", null) == "");
+    assert(buildNormalizedPath(null, "") == "");
+    assert(buildNormalizedPath!(char)(null, null) == "");
 
     version (Posix)
     {
-        assert (buildNormalizedPath("/", "foo", "bar") == "/foo/bar");
-        assert (buildNormalizedPath("foo", "bar", "baz") == "foo/bar/baz");
-        assert (buildNormalizedPath("foo", "bar/baz") == "foo/bar/baz");
-        assert (buildNormalizedPath("foo", "bar//baz///") == "foo/bar/baz");
-        assert (buildNormalizedPath("/foo", "bar/baz") == "/foo/bar/baz");
-        assert (buildNormalizedPath("/foo", "/bar/baz") == "/bar/baz");
-        assert (buildNormalizedPath("/foo/..", "/bar/./baz") == "/bar/baz");
-        assert (buildNormalizedPath("/foo/..", "bar/baz") == "/bar/baz");
-        assert (buildNormalizedPath("/foo/../../", "bar/baz") == "/bar/baz");
-        assert (buildNormalizedPath("/foo/bar", "../baz") == "/foo/baz");
-        assert (buildNormalizedPath("/foo/bar", "../../baz") == "/baz");
-        assert (buildNormalizedPath("/foo/bar", ".././/baz/..", "wee/") == "/foo/wee");
-        assert (buildNormalizedPath("//foo/bar", "baz///wee") == "/foo/bar/baz/wee");
-        static assert (buildNormalizedPath("/foo/..", "/bar/./baz") == "/bar/baz");
+        assert(buildNormalizedPath("/", "foo", "bar") == "/foo/bar");
+        assert(buildNormalizedPath("foo", "bar", "baz") == "foo/bar/baz");
+        assert(buildNormalizedPath("foo", "bar/baz") == "foo/bar/baz");
+        assert(buildNormalizedPath("foo", "bar//baz///") == "foo/bar/baz");
+        assert(buildNormalizedPath("/foo", "bar/baz") == "/foo/bar/baz");
+        assert(buildNormalizedPath("/foo", "/bar/baz") == "/bar/baz");
+        assert(buildNormalizedPath("/foo/..", "/bar/./baz") == "/bar/baz");
+        assert(buildNormalizedPath("/foo/..", "bar/baz") == "/bar/baz");
+        assert(buildNormalizedPath("/foo/../../", "bar/baz") == "/bar/baz");
+        assert(buildNormalizedPath("/foo/bar", "../baz") == "/foo/baz");
+        assert(buildNormalizedPath("/foo/bar", "../../baz") == "/baz");
+        assert(buildNormalizedPath("/foo/bar", ".././/baz/..", "wee/") == "/foo/wee");
+        assert(buildNormalizedPath("//foo/bar", "baz///wee") == "/foo/bar/baz/wee");
+        static assert(buildNormalizedPath("/foo/..", "/bar/./baz") == "/bar/baz");
     }
     else version (Windows)
     {
-        assert (buildNormalizedPath(`\`, `foo`, `bar`) == `\foo\bar`);
-        assert (buildNormalizedPath(`foo`, `bar`, `baz`) == `foo\bar\baz`);
-        assert (buildNormalizedPath(`foo`, `bar\baz`) == `foo\bar\baz`);
-        assert (buildNormalizedPath(`foo`, `bar\\baz\\\`) == `foo\bar\baz`);
-        assert (buildNormalizedPath(`\foo`, `bar\baz`) == `\foo\bar\baz`);
-        assert (buildNormalizedPath(`\foo`, `\bar\baz`) == `\bar\baz`);
-        assert (buildNormalizedPath(`\foo\..`, `\bar\.\baz`) == `\bar\baz`);
-        assert (buildNormalizedPath(`\foo\..`, `bar\baz`) == `\bar\baz`);
-        assert (buildNormalizedPath(`\foo\..\..\`, `bar\baz`) == `\bar\baz`);
-        assert (buildNormalizedPath(`\foo\bar`, `..\baz`) == `\foo\baz`);
-        assert (buildNormalizedPath(`\foo\bar`, `../../baz`) == `\baz`);
-        assert (buildNormalizedPath(`\foo\bar`, `..\.\/baz\..`, `wee\`) == `\foo\wee`);
+        assert(buildNormalizedPath(`\`, `foo`, `bar`) == `\foo\bar`);
+        assert(buildNormalizedPath(`foo`, `bar`, `baz`) == `foo\bar\baz`);
+        assert(buildNormalizedPath(`foo`, `bar\baz`) == `foo\bar\baz`);
+        assert(buildNormalizedPath(`foo`, `bar\\baz\\\`) == `foo\bar\baz`);
+        assert(buildNormalizedPath(`\foo`, `bar\baz`) == `\foo\bar\baz`);
+        assert(buildNormalizedPath(`\foo`, `\bar\baz`) == `\bar\baz`);
+        assert(buildNormalizedPath(`\foo\..`, `\bar\.\baz`) == `\bar\baz`);
+        assert(buildNormalizedPath(`\foo\..`, `bar\baz`) == `\bar\baz`);
+        assert(buildNormalizedPath(`\foo\..\..\`, `bar\baz`) == `\bar\baz`);
+        assert(buildNormalizedPath(`\foo\bar`, `..\baz`) == `\foo\baz`);
+        assert(buildNormalizedPath(`\foo\bar`, `../../baz`) == `\baz`);
+        assert(buildNormalizedPath(`\foo\bar`, `..\.\/baz\..`, `wee\`) == `\foo\wee`);
 
-        assert (buildNormalizedPath(`c:\`, `foo`, `bar`) == `c:\foo\bar`);
-        assert (buildNormalizedPath(`c:foo`, `bar`, `baz`) == `c:foo\bar\baz`);
-        assert (buildNormalizedPath(`c:foo`, `bar\baz`) == `c:foo\bar\baz`);
-        assert (buildNormalizedPath(`c:foo`, `bar\\baz\\\`) == `c:foo\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo`, `bar\baz`) == `c:\foo\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo`, `\bar\baz`) == `c:\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo\..`, `\bar\.\baz`) == `c:\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo\..`, `bar\baz`) == `c:\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo\..\..\`, `bar\baz`) == `c:\bar\baz`);
-        assert (buildNormalizedPath(`c:\foo\bar`, `..\baz`) == `c:\foo\baz`);
-        assert (buildNormalizedPath(`c:\foo\bar`, `..\..\baz`) == `c:\baz`);
-        assert (buildNormalizedPath(`c:\foo\bar`, `..\.\\baz\..`, `wee\`) == `c:\foo\wee`);
+        assert(buildNormalizedPath(`c:\`, `foo`, `bar`) == `c:\foo\bar`);
+        assert(buildNormalizedPath(`c:foo`, `bar`, `baz`) == `c:foo\bar\baz`);
+        assert(buildNormalizedPath(`c:foo`, `bar\baz`) == `c:foo\bar\baz`);
+        assert(buildNormalizedPath(`c:foo`, `bar\\baz\\\`) == `c:foo\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo`, `bar\baz`) == `c:\foo\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo`, `\bar\baz`) == `c:\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo\..`, `\bar\.\baz`) == `c:\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo\..`, `bar\baz`) == `c:\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo\..\..\`, `bar\baz`) == `c:\bar\baz`);
+        assert(buildNormalizedPath(`c:\foo\bar`, `..\baz`) == `c:\foo\baz`);
+        assert(buildNormalizedPath(`c:\foo\bar`, `..\..\baz`) == `c:\baz`);
+        assert(buildNormalizedPath(`c:\foo\bar`, `..\.\\baz\..`, `wee\`) == `c:\foo\wee`);
 
-        assert (buildNormalizedPath(`\\server\share`, `foo`, `bar`) == `\\server\share\foo\bar`);
-        assert (buildNormalizedPath(`\\server\share\`, `foo`, `bar`) == `\\server\share\foo\bar`);
-        assert (buildNormalizedPath(`\\server\share\foo`, `bar\baz`) == `\\server\share\foo\bar\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo`, `\bar\baz`) == `\\server\share\bar\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\..`, `\bar\.\baz`) == `\\server\share\bar\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\..`, `bar\baz`) == `\\server\share\bar\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\..\..\`, `bar\baz`) == `\\server\share\bar\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\bar`, `..\baz`) == `\\server\share\foo\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\bar`, `..\..\baz`) == `\\server\share\baz`);
-        assert (buildNormalizedPath(`\\server\share\foo\bar`, `..\.\\baz\..`, `wee\`) == `\\server\share\foo\wee`);
+        assert(buildNormalizedPath(`\\server\share`, `foo`, `bar`) == `\\server\share\foo\bar`);
+        assert(buildNormalizedPath(`\\server\share\`, `foo`, `bar`) == `\\server\share\foo\bar`);
+        assert(buildNormalizedPath(`\\server\share\foo`, `bar\baz`) == `\\server\share\foo\bar\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo`, `\bar\baz`) == `\\server\share\bar\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\..`, `\bar\.\baz`) == `\\server\share\bar\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\..`, `bar\baz`) == `\\server\share\bar\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\..\..\`, `bar\baz`) == `\\server\share\bar\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\bar`, `..\baz`) == `\\server\share\foo\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\bar`, `..\..\baz`) == `\\server\share\baz`);
+        assert(buildNormalizedPath(`\\server\share\foo\bar`, `..\.\\baz\..`, `wee\`) == `\\server\share\foo\wee`);
 
-        static assert (buildNormalizedPath(`\foo\..\..\`, `bar\baz`) == `\bar\baz`);
+        static assert(buildNormalizedPath(`\foo\..\..\`, `bar\baz`) == `\bar\baz`);
     }
-    else static assert (0);
+    else static assert(0);
 }
 
 @safe unittest
@@ -1707,11 +1707,11 @@ if (isSomeChar!C)
     string[] ary = ["a", "b"];
     version (Posix)
     {
-        assert (buildNormalizedPath(ary) == "a/b");
+        assert(buildNormalizedPath(ary) == "a/b");
     }
     else version (Windows)
     {
-        assert (buildNormalizedPath(ary) == `a\b`);
+        assert(buildNormalizedPath(ary) == `a\b`);
     }
 }
 
@@ -1882,23 +1882,23 @@ if (isSomeChar!(ElementEncodingType!R) &&
 @safe unittest
 {
     import std.array;
-    assert (asNormalizedPath("foo/..").array == ".");
+    assert(asNormalizedPath("foo/..").array == ".");
 
     version (Posix)
     {
-        assert (asNormalizedPath("/foo/./bar/..//baz/").array == "/foo/baz");
-        assert (asNormalizedPath("../foo/.").array == "../foo");
-        assert (asNormalizedPath("/foo/bar/baz/").array == "/foo/bar/baz");
-        assert (asNormalizedPath("/foo/./bar/../../baz").array == "/baz");
+        assert(asNormalizedPath("/foo/./bar/..//baz/").array == "/foo/baz");
+        assert(asNormalizedPath("../foo/.").array == "../foo");
+        assert(asNormalizedPath("/foo/bar/baz/").array == "/foo/bar/baz");
+        assert(asNormalizedPath("/foo/./bar/../../baz").array == "/baz");
     }
 
     version (Windows)
     {
-        assert (asNormalizedPath(`c:\foo\.\bar/..\\baz\`).array == `c:\foo\baz`);
-        assert (asNormalizedPath(`..\foo\.`).array == `..\foo`);
-        assert (asNormalizedPath(`c:\foo\bar\baz\`).array == `c:\foo\bar\baz`);
-        assert (asNormalizedPath(`c:\foo\bar/..`).array == `c:\foo`);
-        assert (asNormalizedPath(`\\server\share\foo\..\bar`).array ==
+        assert(asNormalizedPath(`c:\foo\.\bar/..\\baz\`).array == `c:\foo\baz`);
+        assert(asNormalizedPath(`..\foo\.`).array == `..\foo`);
+        assert(asNormalizedPath(`c:\foo\bar\baz\`).array == `c:\foo\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\bar/..`).array == `c:\foo`);
+        assert(asNormalizedPath(`\\server\share\foo\..\bar`).array ==
                 `\\server\share\bar`);
     }
 }
@@ -1919,11 +1919,11 @@ if (isConvertibleToString!R)
     import std.array;
     import std.utf : byChar;
 
-    assert (asNormalizedPath("").array is null);
-    assert (asNormalizedPath("foo").array == "foo");
-    assert (asNormalizedPath(".").array == ".");
-    assert (asNormalizedPath("./.").array == ".");
-    assert (asNormalizedPath("foo/..").array == ".");
+    assert(asNormalizedPath("").array is null);
+    assert(asNormalizedPath("foo").array == "foo");
+    assert(asNormalizedPath(".").array == ".");
+    assert(asNormalizedPath("./.").array == ".");
+    assert(asNormalizedPath("foo/..").array == ".");
 
     auto save = asNormalizedPath("fob").save;
     save.popFront();
@@ -1931,75 +1931,75 @@ if (isConvertibleToString!R)
 
     version (Posix)
     {
-        assert (asNormalizedPath("/foo/bar").array == "/foo/bar");
-        assert (asNormalizedPath("foo/bar/baz").array == "foo/bar/baz");
-        assert (asNormalizedPath("foo/bar/baz").array == "foo/bar/baz");
-        assert (asNormalizedPath("foo/bar//baz///").array == "foo/bar/baz");
-        assert (asNormalizedPath("/foo/bar/baz").array == "/foo/bar/baz");
-        assert (asNormalizedPath("/foo/../bar/baz").array == "/bar/baz");
-        assert (asNormalizedPath("/foo/../..//bar/baz").array == "/bar/baz");
-        assert (asNormalizedPath("/foo/bar/../baz").array == "/foo/baz");
-        assert (asNormalizedPath("/foo/bar/../../baz").array == "/baz");
-        assert (asNormalizedPath("/foo/bar/.././/baz/../wee/").array == "/foo/wee");
-        assert (asNormalizedPath("//foo/bar/baz///wee").array == "/foo/bar/baz/wee");
+        assert(asNormalizedPath("/foo/bar").array == "/foo/bar");
+        assert(asNormalizedPath("foo/bar/baz").array == "foo/bar/baz");
+        assert(asNormalizedPath("foo/bar/baz").array == "foo/bar/baz");
+        assert(asNormalizedPath("foo/bar//baz///").array == "foo/bar/baz");
+        assert(asNormalizedPath("/foo/bar/baz").array == "/foo/bar/baz");
+        assert(asNormalizedPath("/foo/../bar/baz").array == "/bar/baz");
+        assert(asNormalizedPath("/foo/../..//bar/baz").array == "/bar/baz");
+        assert(asNormalizedPath("/foo/bar/../baz").array == "/foo/baz");
+        assert(asNormalizedPath("/foo/bar/../../baz").array == "/baz");
+        assert(asNormalizedPath("/foo/bar/.././/baz/../wee/").array == "/foo/wee");
+        assert(asNormalizedPath("//foo/bar/baz///wee").array == "/foo/bar/baz/wee");
 
-        assert (asNormalizedPath("foo//bar").array == "foo/bar");
-        assert (asNormalizedPath("foo/bar").array == "foo/bar");
+        assert(asNormalizedPath("foo//bar").array == "foo/bar");
+        assert(asNormalizedPath("foo/bar").array == "foo/bar");
 
         //Curent dir path
-        assert (asNormalizedPath("./").array == ".");
-        assert (asNormalizedPath("././").array == ".");
-        assert (asNormalizedPath("./foo/..").array == ".");
-        assert (asNormalizedPath("foo/..").array == ".");
+        assert(asNormalizedPath("./").array == ".");
+        assert(asNormalizedPath("././").array == ".");
+        assert(asNormalizedPath("./foo/..").array == ".");
+        assert(asNormalizedPath("foo/..").array == ".");
     }
     else version (Windows)
     {
-        assert (asNormalizedPath(`\foo\bar`).array == `\foo\bar`);
-        assert (asNormalizedPath(`foo\bar\baz`).array == `foo\bar\baz`);
-        assert (asNormalizedPath(`foo\bar\baz`).array == `foo\bar\baz`);
-        assert (asNormalizedPath(`foo\bar\\baz\\\`).array == `foo\bar\baz`);
-        assert (asNormalizedPath(`\foo\bar\baz`).array == `\foo\bar\baz`);
-        assert (asNormalizedPath(`\foo\..\\bar\.\baz`).array == `\bar\baz`);
-        assert (asNormalizedPath(`\foo\..\bar\baz`).array == `\bar\baz`);
-        assert (asNormalizedPath(`\foo\..\..\\bar\baz`).array == `\bar\baz`);
+        assert(asNormalizedPath(`\foo\bar`).array == `\foo\bar`);
+        assert(asNormalizedPath(`foo\bar\baz`).array == `foo\bar\baz`);
+        assert(asNormalizedPath(`foo\bar\baz`).array == `foo\bar\baz`);
+        assert(asNormalizedPath(`foo\bar\\baz\\\`).array == `foo\bar\baz`);
+        assert(asNormalizedPath(`\foo\bar\baz`).array == `\foo\bar\baz`);
+        assert(asNormalizedPath(`\foo\..\\bar\.\baz`).array == `\bar\baz`);
+        assert(asNormalizedPath(`\foo\..\bar\baz`).array == `\bar\baz`);
+        assert(asNormalizedPath(`\foo\..\..\\bar\baz`).array == `\bar\baz`);
 
-        assert (asNormalizedPath(`\foo\bar\..\baz`).array == `\foo\baz`);
-        assert (asNormalizedPath(`\foo\bar\../../baz`).array == `\baz`);
-        assert (asNormalizedPath(`\foo\bar\..\.\/baz\..\wee\`).array == `\foo\wee`);
+        assert(asNormalizedPath(`\foo\bar\..\baz`).array == `\foo\baz`);
+        assert(asNormalizedPath(`\foo\bar\../../baz`).array == `\baz`);
+        assert(asNormalizedPath(`\foo\bar\..\.\/baz\..\wee\`).array == `\foo\wee`);
 
-        assert (asNormalizedPath(`c:\foo\bar`).array == `c:\foo\bar`);
-        assert (asNormalizedPath(`c:foo\bar\baz`).array == `c:foo\bar\baz`);
-        assert (asNormalizedPath(`c:foo\bar\baz`).array == `c:foo\bar\baz`);
-        assert (asNormalizedPath(`c:foo\bar\\baz\\\`).array == `c:foo\bar\baz`);
-        assert (asNormalizedPath(`c:\foo\bar\baz`).array == `c:\foo\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\bar`).array == `c:\foo\bar`);
+        assert(asNormalizedPath(`c:foo\bar\baz`).array == `c:foo\bar\baz`);
+        assert(asNormalizedPath(`c:foo\bar\baz`).array == `c:foo\bar\baz`);
+        assert(asNormalizedPath(`c:foo\bar\\baz\\\`).array == `c:foo\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\bar\baz`).array == `c:\foo\bar\baz`);
 
-        assert (asNormalizedPath(`c:\foo\..\\bar\.\baz`).array == `c:\bar\baz`);
-        assert (asNormalizedPath(`c:\foo\..\bar\baz`).array == `c:\bar\baz`);
-        assert (asNormalizedPath(`c:\foo\..\..\\bar\baz`).array == `c:\bar\baz`);
-        assert (asNormalizedPath(`c:\foo\bar\..\baz`).array == `c:\foo\baz`);
-        assert (asNormalizedPath(`c:\foo\bar\..\..\baz`).array == `c:\baz`);
-        assert (asNormalizedPath(`c:\foo\bar\..\.\\baz\..\wee\`).array == `c:\foo\wee`);
-        assert (asNormalizedPath(`\\server\share\foo\bar`).array == `\\server\share\foo\bar`);
-        assert (asNormalizedPath(`\\server\share\\foo\bar`).array == `\\server\share\foo\bar`);
-        assert (asNormalizedPath(`\\server\share\foo\bar\baz`).array == `\\server\share\foo\bar\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\..\\bar\.\baz`).array == `\\server\share\bar\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\..\bar\baz`).array == `\\server\share\bar\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\..\..\\bar\baz`).array == `\\server\share\bar\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\bar\..\baz`).array == `\\server\share\foo\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\bar\..\..\baz`).array == `\\server\share\baz`);
-        assert (asNormalizedPath(`\\server\share\foo\bar\..\.\\baz\..\wee\`).array == `\\server\share\foo\wee`);
+        assert(asNormalizedPath(`c:\foo\..\\bar\.\baz`).array == `c:\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\..\bar\baz`).array == `c:\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\..\..\\bar\baz`).array == `c:\bar\baz`);
+        assert(asNormalizedPath(`c:\foo\bar\..\baz`).array == `c:\foo\baz`);
+        assert(asNormalizedPath(`c:\foo\bar\..\..\baz`).array == `c:\baz`);
+        assert(asNormalizedPath(`c:\foo\bar\..\.\\baz\..\wee\`).array == `c:\foo\wee`);
+        assert(asNormalizedPath(`\\server\share\foo\bar`).array == `\\server\share\foo\bar`);
+        assert(asNormalizedPath(`\\server\share\\foo\bar`).array == `\\server\share\foo\bar`);
+        assert(asNormalizedPath(`\\server\share\foo\bar\baz`).array == `\\server\share\foo\bar\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\..\\bar\.\baz`).array == `\\server\share\bar\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\..\bar\baz`).array == `\\server\share\bar\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\..\..\\bar\baz`).array == `\\server\share\bar\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\bar\..\baz`).array == `\\server\share\foo\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\bar\..\..\baz`).array == `\\server\share\baz`);
+        assert(asNormalizedPath(`\\server\share\foo\bar\..\.\\baz\..\wee\`).array == `\\server\share\foo\wee`);
 
-        static assert (asNormalizedPath(`\foo\..\..\\bar\baz`).array == `\bar\baz`);
+        static assert(asNormalizedPath(`\foo\..\..\\bar\baz`).array == `\bar\baz`);
 
-        assert (asNormalizedPath("foo//bar").array == `foo\bar`);
+        assert(asNormalizedPath("foo//bar").array == `foo\bar`);
 
         //Curent dir path
-        assert (asNormalizedPath(`.\`).array == ".");
-        assert (asNormalizedPath(`.\.\`).array == ".");
-        assert (asNormalizedPath(`.\foo\..`).array == ".");
-        assert (asNormalizedPath(`foo\..`).array == ".");
+        assert(asNormalizedPath(`.\`).array == ".");
+        assert(asNormalizedPath(`.\.\`).array == ".");
+        assert(asNormalizedPath(`.\foo\..`).array == ".");
+        assert(asNormalizedPath(`foo\..`).array == ".");
     }
-    else static assert (0);
+    else static assert(0);
 }
 
 @safe unittest
@@ -2009,105 +2009,105 @@ if (isConvertibleToString!R)
     version (Posix)
     {
         // Trivial
-        assert (asNormalizedPath("").empty);
-        assert (asNormalizedPath("foo/bar").array == "foo/bar");
+        assert(asNormalizedPath("").empty);
+        assert(asNormalizedPath("foo/bar").array == "foo/bar");
 
         // Correct handling of leading slashes
-        assert (asNormalizedPath("/").array == "/");
-        assert (asNormalizedPath("///").array == "/");
-        assert (asNormalizedPath("////").array == "/");
-        assert (asNormalizedPath("/foo/bar").array == "/foo/bar");
-        assert (asNormalizedPath("//foo/bar").array == "/foo/bar");
-        assert (asNormalizedPath("///foo/bar").array == "/foo/bar");
-        assert (asNormalizedPath("////foo/bar").array == "/foo/bar");
+        assert(asNormalizedPath("/").array == "/");
+        assert(asNormalizedPath("///").array == "/");
+        assert(asNormalizedPath("////").array == "/");
+        assert(asNormalizedPath("/foo/bar").array == "/foo/bar");
+        assert(asNormalizedPath("//foo/bar").array == "/foo/bar");
+        assert(asNormalizedPath("///foo/bar").array == "/foo/bar");
+        assert(asNormalizedPath("////foo/bar").array == "/foo/bar");
 
         // Correct handling of single-dot symbol (current directory)
-        assert (asNormalizedPath("/./foo").array == "/foo");
-        assert (asNormalizedPath("/foo/./bar").array == "/foo/bar");
+        assert(asNormalizedPath("/./foo").array == "/foo");
+        assert(asNormalizedPath("/foo/./bar").array == "/foo/bar");
 
-        assert (asNormalizedPath("./foo").array == "foo");
-        assert (asNormalizedPath("././foo").array == "foo");
-        assert (asNormalizedPath("foo/././bar").array == "foo/bar");
+        assert(asNormalizedPath("./foo").array == "foo");
+        assert(asNormalizedPath("././foo").array == "foo");
+        assert(asNormalizedPath("foo/././bar").array == "foo/bar");
 
         // Correct handling of double-dot symbol (previous directory)
-        assert (asNormalizedPath("/foo/../bar").array == "/bar");
-        assert (asNormalizedPath("/foo/../../bar").array == "/bar");
-        assert (asNormalizedPath("/../foo").array == "/foo");
-        assert (asNormalizedPath("/../../foo").array == "/foo");
-        assert (asNormalizedPath("/foo/..").array == "/");
-        assert (asNormalizedPath("/foo/../..").array == "/");
+        assert(asNormalizedPath("/foo/../bar").array == "/bar");
+        assert(asNormalizedPath("/foo/../../bar").array == "/bar");
+        assert(asNormalizedPath("/../foo").array == "/foo");
+        assert(asNormalizedPath("/../../foo").array == "/foo");
+        assert(asNormalizedPath("/foo/..").array == "/");
+        assert(asNormalizedPath("/foo/../..").array == "/");
 
-        assert (asNormalizedPath("foo/../bar").array == "bar");
-        assert (asNormalizedPath("foo/../../bar").array == "../bar");
-        assert (asNormalizedPath("../foo").array == "../foo");
-        assert (asNormalizedPath("../../foo").array == "../../foo");
-        assert (asNormalizedPath("../foo/../bar").array == "../bar");
-        assert (asNormalizedPath(".././../foo").array == "../../foo");
-        assert (asNormalizedPath("foo/bar/..").array == "foo");
-        assert (asNormalizedPath("/foo/../..").array == "/");
+        assert(asNormalizedPath("foo/../bar").array == "bar");
+        assert(asNormalizedPath("foo/../../bar").array == "../bar");
+        assert(asNormalizedPath("../foo").array == "../foo");
+        assert(asNormalizedPath("../../foo").array == "../../foo");
+        assert(asNormalizedPath("../foo/../bar").array == "../bar");
+        assert(asNormalizedPath(".././../foo").array == "../../foo");
+        assert(asNormalizedPath("foo/bar/..").array == "foo");
+        assert(asNormalizedPath("/foo/../..").array == "/");
 
         // The ultimate path
-        assert (asNormalizedPath("/foo/../bar//./../...///baz//").array == "/.../baz");
-        static assert (asNormalizedPath("/foo/../bar//./../...///baz//").array == "/.../baz");
+        assert(asNormalizedPath("/foo/../bar//./../...///baz//").array == "/.../baz");
+        static assert(asNormalizedPath("/foo/../bar//./../...///baz//").array == "/.../baz");
     }
     else version (Windows)
     {
         // Trivial
-        assert (asNormalizedPath("").empty);
-        assert (asNormalizedPath(`foo\bar`).array == `foo\bar`);
-        assert (asNormalizedPath("foo/bar").array == `foo\bar`);
+        assert(asNormalizedPath("").empty);
+        assert(asNormalizedPath(`foo\bar`).array == `foo\bar`);
+        assert(asNormalizedPath("foo/bar").array == `foo\bar`);
 
         // Correct handling of absolute paths
-        assert (asNormalizedPath("/").array == `\`);
-        assert (asNormalizedPath(`\`).array == `\`);
-        assert (asNormalizedPath(`\\\`).array == `\`);
-        assert (asNormalizedPath(`\\\\`).array == `\`);
-        assert (asNormalizedPath(`\foo\bar`).array == `\foo\bar`);
-        assert (asNormalizedPath(`\\foo`).array == `\\foo`);
-        assert (asNormalizedPath(`\\foo\\`).array == `\\foo`);
-        assert (asNormalizedPath(`\\foo/bar`).array == `\\foo\bar`);
-        assert (asNormalizedPath(`\\\foo\bar`).array == `\foo\bar`);
-        assert (asNormalizedPath(`\\\\foo\bar`).array == `\foo\bar`);
-        assert (asNormalizedPath(`c:\`).array == `c:\`);
-        assert (asNormalizedPath(`c:\foo\bar`).array == `c:\foo\bar`);
-        assert (asNormalizedPath(`c:\\foo\bar`).array == `c:\foo\bar`);
+        assert(asNormalizedPath("/").array == `\`);
+        assert(asNormalizedPath(`\`).array == `\`);
+        assert(asNormalizedPath(`\\\`).array == `\`);
+        assert(asNormalizedPath(`\\\\`).array == `\`);
+        assert(asNormalizedPath(`\foo\bar`).array == `\foo\bar`);
+        assert(asNormalizedPath(`\\foo`).array == `\\foo`);
+        assert(asNormalizedPath(`\\foo\\`).array == `\\foo`);
+        assert(asNormalizedPath(`\\foo/bar`).array == `\\foo\bar`);
+        assert(asNormalizedPath(`\\\foo\bar`).array == `\foo\bar`);
+        assert(asNormalizedPath(`\\\\foo\bar`).array == `\foo\bar`);
+        assert(asNormalizedPath(`c:\`).array == `c:\`);
+        assert(asNormalizedPath(`c:\foo\bar`).array == `c:\foo\bar`);
+        assert(asNormalizedPath(`c:\\foo\bar`).array == `c:\foo\bar`);
 
         // Correct handling of single-dot symbol (current directory)
-        assert (asNormalizedPath(`\./foo`).array == `\foo`);
-        assert (asNormalizedPath(`\foo/.\bar`).array == `\foo\bar`);
+        assert(asNormalizedPath(`\./foo`).array == `\foo`);
+        assert(asNormalizedPath(`\foo/.\bar`).array == `\foo\bar`);
 
-        assert (asNormalizedPath(`.\foo`).array == `foo`);
-        assert (asNormalizedPath(`./.\foo`).array == `foo`);
-        assert (asNormalizedPath(`foo\.\./bar`).array == `foo\bar`);
+        assert(asNormalizedPath(`.\foo`).array == `foo`);
+        assert(asNormalizedPath(`./.\foo`).array == `foo`);
+        assert(asNormalizedPath(`foo\.\./bar`).array == `foo\bar`);
 
         // Correct handling of double-dot symbol (previous directory)
-        assert (asNormalizedPath(`\foo\..\bar`).array == `\bar`);
-        assert (asNormalizedPath(`\foo\../..\bar`).array == `\bar`);
-        assert (asNormalizedPath(`\..\foo`).array == `\foo`);
-        assert (asNormalizedPath(`\..\..\foo`).array == `\foo`);
-        assert (asNormalizedPath(`\foo\..`).array == `\`);
-        assert (asNormalizedPath(`\foo\../..`).array == `\`);
+        assert(asNormalizedPath(`\foo\..\bar`).array == `\bar`);
+        assert(asNormalizedPath(`\foo\../..\bar`).array == `\bar`);
+        assert(asNormalizedPath(`\..\foo`).array == `\foo`);
+        assert(asNormalizedPath(`\..\..\foo`).array == `\foo`);
+        assert(asNormalizedPath(`\foo\..`).array == `\`);
+        assert(asNormalizedPath(`\foo\../..`).array == `\`);
 
-        assert (asNormalizedPath(`foo\..\bar`).array == `bar`);
-        assert (asNormalizedPath(`foo\..\../bar`).array == `..\bar`);
+        assert(asNormalizedPath(`foo\..\bar`).array == `bar`);
+        assert(asNormalizedPath(`foo\..\../bar`).array == `..\bar`);
 
-        assert (asNormalizedPath(`..\foo`).array == `..\foo`);
-        assert (asNormalizedPath(`..\..\foo`).array == `..\..\foo`);
-        assert (asNormalizedPath(`..\foo\..\bar`).array == `..\bar`);
-        assert (asNormalizedPath(`..\.\..\foo`).array == `..\..\foo`);
-        assert (asNormalizedPath(`foo\bar\..`).array == `foo`);
-        assert (asNormalizedPath(`\foo\..\..`).array == `\`);
-        assert (asNormalizedPath(`c:\foo\..\..`).array == `c:\`);
+        assert(asNormalizedPath(`..\foo`).array == `..\foo`);
+        assert(asNormalizedPath(`..\..\foo`).array == `..\..\foo`);
+        assert(asNormalizedPath(`..\foo\..\bar`).array == `..\bar`);
+        assert(asNormalizedPath(`..\.\..\foo`).array == `..\..\foo`);
+        assert(asNormalizedPath(`foo\bar\..`).array == `foo`);
+        assert(asNormalizedPath(`\foo\..\..`).array == `\`);
+        assert(asNormalizedPath(`c:\foo\..\..`).array == `c:\`);
 
         // Correct handling of non-root path with drive specifier
-        assert (asNormalizedPath(`c:foo`).array == `c:foo`);
-        assert (asNormalizedPath(`c:..\foo\.\..\bar`).array == `c:..\bar`);
+        assert(asNormalizedPath(`c:foo`).array == `c:foo`);
+        assert(asNormalizedPath(`c:..\foo\.\..\bar`).array == `c:..\bar`);
 
         // The ultimate path
-        assert (asNormalizedPath(`c:\foo\..\bar\\.\..\...\\\baz\\`).array == `c:\...\baz`);
-        static assert (asNormalizedPath(`c:\foo\..\bar\\.\..\...\\\baz\\`).array == `c:\...\baz`);
+        assert(asNormalizedPath(`c:\foo\..\bar\\.\..\...\\\baz\\`).array == `c:\...\baz`);
+        static assert(asNormalizedPath(`c:\foo\..\bar\\.\..\...\\\baz\\`).array == `c:\...\baz`);
     }
-    else static assert (false);
+    else static assert(false);
 }
 
 /** Slice up a path into its elements.
@@ -2233,7 +2233,7 @@ if ((isRandomAccessRange!R && hasSlicing!R ||
                 }
                 else
                 {
-                    assert (!isRooted(_path));
+                    assert(!isRooted(_path));
                     popFront();
                 }
             }
@@ -2250,7 +2250,7 @@ if ((isRandomAccessRange!R && hasSlicing!R ||
                     popFront();
                 }
             }
-            else static assert (0);
+            else static assert(0);
 
             if (ps == pe)
             {
@@ -2288,21 +2288,21 @@ if ((isRandomAccessRange!R && hasSlicing!R ||
     import std.algorithm.comparison : equal;
     import std.conv : to;
 
-    assert (equal(pathSplitter("/"), ["/"]));
-    assert (equal(pathSplitter("/foo/bar"), ["/", "foo", "bar"]));
-    assert (equal(pathSplitter("foo/../bar//./"), ["foo", "..", "bar", "."]));
+    assert(equal(pathSplitter("/"), ["/"]));
+    assert(equal(pathSplitter("/foo/bar"), ["/", "foo", "bar"]));
+    assert(equal(pathSplitter("foo/../bar//./"), ["foo", "..", "bar", "."]));
 
     version (Posix)
     {
-        assert (equal(pathSplitter("//foo/bar"), ["/", "foo", "bar"]));
+        assert(equal(pathSplitter("//foo/bar"), ["/", "foo", "bar"]));
     }
 
     version (Windows)
     {
-        assert (equal(pathSplitter(`foo\..\bar\/.\`), ["foo", "..", "bar", "."]));
-        assert (equal(pathSplitter("c:"), ["c:"]));
-        assert (equal(pathSplitter(`c:\foo\bar`), [`c:\`, "foo", "bar"]));
-        assert (equal(pathSplitter(`c:foo\bar`), ["c:foo", "bar"]));
+        assert(equal(pathSplitter(`foo\..\bar\/.\`), ["foo", "..", "bar", "."]));
+        assert(equal(pathSplitter("c:"), ["c:"]));
+        assert(equal(pathSplitter(`c:\foo\bar`), [`c:\`, "foo", "bar"]));
+        assert(equal(pathSplitter(`c:foo\bar`), ["c:foo", "bar"]));
     }
 }
 
@@ -2315,7 +2315,7 @@ if (isConvertibleToString!R)
 @safe unittest
 {
     import std.algorithm.comparison : equal;
-    assert (testAliasedString!pathSplitter("/"));
+    assert(testAliasedString!pathSplitter("/"));
 }
 
 @safe unittest
@@ -2326,60 +2326,60 @@ if (isConvertibleToString!R)
     import std.algorithm;
     bool equal2(R1, R2)(R1 r1, R2 r2)
     {
-        static assert (isBidirectionalRange!R1);
+        static assert(isBidirectionalRange!R1);
         return equal(r1, r2) && equal(retro(r1), retro(r2));
     }
 
-    assert (pathSplitter("").empty);
+    assert(pathSplitter("").empty);
 
     // Root directories
-    assert (equal2(pathSplitter("/"), ["/"]));
-    assert (equal2(pathSplitter("//"), ["/"]));
-    assert (equal2(pathSplitter("///"w), ["/"w]));
+    assert(equal2(pathSplitter("/"), ["/"]));
+    assert(equal2(pathSplitter("//"), ["/"]));
+    assert(equal2(pathSplitter("///"w), ["/"w]));
 
     // Absolute paths
-    assert (equal2(pathSplitter("/foo/bar".dup), ["/", "foo", "bar"]));
+    assert(equal2(pathSplitter("/foo/bar".dup), ["/", "foo", "bar"]));
 
     // General
-    assert (equal2(pathSplitter("foo/bar"d.dup), ["foo"d, "bar"d]));
-    assert (equal2(pathSplitter("foo//bar"), ["foo", "bar"]));
-    assert (equal2(pathSplitter("foo/bar//"w), ["foo"w, "bar"w]));
-    assert (equal2(pathSplitter("foo/../bar//./"d), ["foo"d, ".."d, "bar"d, "."d]));
+    assert(equal2(pathSplitter("foo/bar"d.dup), ["foo"d, "bar"d]));
+    assert(equal2(pathSplitter("foo//bar"), ["foo", "bar"]));
+    assert(equal2(pathSplitter("foo/bar//"w), ["foo"w, "bar"w]));
+    assert(equal2(pathSplitter("foo/../bar//./"d), ["foo"d, ".."d, "bar"d, "."d]));
 
     // save()
     auto ps1 = pathSplitter("foo/bar/baz");
     auto ps2 = ps1.save;
     ps1.popFront();
-    assert (equal2(ps1, ["bar", "baz"]));
-    assert (equal2(ps2, ["foo", "bar", "baz"]));
+    assert(equal2(ps1, ["bar", "baz"]));
+    assert(equal2(ps2, ["foo", "bar", "baz"]));
 
     // Platform specific
     version (Posix)
     {
-        assert (equal2(pathSplitter("//foo/bar"w.dup), ["/"w, "foo"w, "bar"w]));
+        assert(equal2(pathSplitter("//foo/bar"w.dup), ["/"w, "foo"w, "bar"w]));
     }
     version (Windows)
     {
-        assert (equal2(pathSplitter(`\`), [`\`]));
-        assert (equal2(pathSplitter(`foo\..\bar\/.\`), ["foo", "..", "bar", "."]));
-        assert (equal2(pathSplitter("c:"), ["c:"]));
-        assert (equal2(pathSplitter(`c:\foo\bar`), [`c:\`, "foo", "bar"]));
-        assert (equal2(pathSplitter(`c:foo\bar`), ["c:foo", "bar"]));
-        assert (equal2(pathSplitter(`\\foo\bar`), [`\\foo\bar`]));
-        assert (equal2(pathSplitter(`\\foo\bar\\`), [`\\foo\bar`]));
-        assert (equal2(pathSplitter(`\\foo\bar\baz`), [`\\foo\bar`, "baz"]));
+        assert(equal2(pathSplitter(`\`), [`\`]));
+        assert(equal2(pathSplitter(`foo\..\bar\/.\`), ["foo", "..", "bar", "."]));
+        assert(equal2(pathSplitter("c:"), ["c:"]));
+        assert(equal2(pathSplitter(`c:\foo\bar`), [`c:\`, "foo", "bar"]));
+        assert(equal2(pathSplitter(`c:foo\bar`), ["c:foo", "bar"]));
+        assert(equal2(pathSplitter(`\\foo\bar`), [`\\foo\bar`]));
+        assert(equal2(pathSplitter(`\\foo\bar\\`), [`\\foo\bar`]));
+        assert(equal2(pathSplitter(`\\foo\bar\baz`), [`\\foo\bar`, "baz"]));
     }
 
     import std.exception;
     assertCTFEable!(
     {
-        assert (equal(pathSplitter("/foo/bar".dup), ["/", "foo", "bar"]));
+        assert(equal(pathSplitter("/foo/bar".dup), ["/", "foo", "bar"]));
     });
 
     static assert(is(typeof(pathSplitter!(const(char)[])(null).front) == const(char)[]));
 
     import std.utf : byDchar;
-    assert (equal2(pathSplitter("foo/bar"d.byDchar), ["foo"d, "bar"d]));
+    assert(equal2(pathSplitter("foo/bar"d.byDchar), ["foo"d, "bar"d]));
 }
 
 
@@ -2395,10 +2395,10 @@ if (isConvertibleToString!R)
     ---
     version (Posix)
     {
-        assert (isRooted("/"));
-        assert (isRooted("/foo"));
-        assert (!isRooted("foo"));
-        assert (!isRooted("../foo"));
+        assert(isRooted("/"));
+        assert(isRooted("/foo"));
+        assert(!isRooted("foo"));
+        assert(!isRooted("../foo"));
     }
     ---
 
@@ -2408,12 +2408,12 @@ if (isConvertibleToString!R)
     ---
     version (Windows)
     {
-        assert (isRooted(`\`));
-        assert (isRooted(`\foo`));
-        assert (isRooted(`d:\foo`));
-        assert (isRooted(`\\foo\bar`));
-        assert (!isRooted("foo"));
-        assert (!isRooted("d:foo"));
+        assert(isRooted(`\`));
+        assert(isRooted(`\foo`));
+        assert(isRooted(`d:\foo`));
+        assert(isRooted(`\\foo\bar`));
+        assert(!isRooted("foo"));
+        assert(!isRooted("d:foo"));
     }
     ---
 */
@@ -2429,26 +2429,26 @@ if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
 
 @safe unittest
 {
-    assert (isRooted("/"));
-    assert (isRooted("/foo"));
-    assert (!isRooted("foo"));
-    assert (!isRooted("../foo"));
+    assert(isRooted("/"));
+    assert(isRooted("/foo"));
+    assert(!isRooted("foo"));
+    assert(!isRooted("../foo"));
 
     version (Windows)
     {
-    assert (isRooted(`\`));
-    assert (isRooted(`\foo`));
-    assert (isRooted(`d:\foo`));
-    assert (isRooted(`\\foo\bar`));
-    assert (!isRooted("foo"));
-    assert (!isRooted("d:foo"));
+    assert(isRooted(`\`));
+    assert(isRooted(`\foo`));
+    assert(isRooted(`d:\foo`));
+    assert(isRooted(`\\foo\bar`));
+    assert(!isRooted("foo"));
+    assert(!isRooted("d:foo"));
     }
 
-    static assert (isRooted("/foo"));
-    static assert (!isRooted("foo"));
+    static assert(isRooted("/foo"));
+    static assert(!isRooted("foo"));
 
     static struct DirEntry { string s; alias s this; }
-    assert (!isRooted(DirEntry("foo")));
+    assert(!isRooted(DirEntry("foo")));
 }
 
 
@@ -2466,10 +2466,10 @@ if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
     ---
     version (Posix)
     {
-        assert (isAbsolute("/"));
-        assert (isAbsolute("/foo"));
-        assert (!isAbsolute("foo"));
-        assert (!isAbsolute("../foo"));
+        assert(isAbsolute("/"));
+        assert(isAbsolute("/foo"));
+        assert(!isAbsolute("foo"));
+        assert(!isAbsolute("../foo"));
     }
     ---
 
@@ -2480,12 +2480,12 @@ if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
     ---
     version (Windows)
     {
-        assert (isAbsolute(`d:\`));
-        assert (isAbsolute(`d:\foo`));
-        assert (isAbsolute(`\\foo\bar`));
-        assert (!isAbsolute(`\`));
-        assert (!isAbsolute(`\foo`));
-        assert (!isAbsolute("d:foo"));
+        assert(isAbsolute(`d:\`));
+        assert(isAbsolute(`d:\foo`));
+        assert(isAbsolute(`\\foo\bar`));
+        assert(!isAbsolute(`\`));
+        assert(!isAbsolute(`\foo`));
+        assert(!isAbsolute("d:foo"));
     }
     ---
 */
@@ -2512,27 +2512,27 @@ else version (Posix)
 
 @safe unittest
 {
-    assert (!isAbsolute("foo"));
-    assert (!isAbsolute("../foo"w));
-    static assert (!isAbsolute("foo"));
+    assert(!isAbsolute("foo"));
+    assert(!isAbsolute("../foo"w));
+    static assert(!isAbsolute("foo"));
 
     version (Posix)
     {
-    assert (isAbsolute("/"d));
-    assert (isAbsolute("/foo".dup));
-    static assert (isAbsolute("/foo"));
+    assert(isAbsolute("/"d));
+    assert(isAbsolute("/foo".dup));
+    static assert(isAbsolute("/foo"));
     }
 
     version (Windows)
     {
-    assert (isAbsolute("d:\\"w));
-    assert (isAbsolute("d:\\foo"d));
-    assert (isAbsolute("\\\\foo\\bar"));
-    assert (!isAbsolute("\\"w.dup));
-    assert (!isAbsolute("\\foo"d.dup));
-    assert (!isAbsolute("d:"));
-    assert (!isAbsolute("d:foo"));
-    static assert (isAbsolute(`d:\foo`));
+    assert(isAbsolute("d:\\"w));
+    assert(isAbsolute("d:\\foo"d));
+    assert(isAbsolute("\\\\foo\\bar"));
+    assert(!isAbsolute("\\"w.dup));
+    assert(!isAbsolute("\\foo"d.dup));
+    assert(!isAbsolute("d:"));
+    assert(!isAbsolute("d:foo"));
+    static assert(isAbsolute(`d:\foo`));
     }
 
     {
@@ -2589,18 +2589,18 @@ string absolutePath(string path, lazy string base = getcwd())
 {
     version (Posix)
     {
-        assert (absolutePath("some/file", "/foo/bar")  == "/foo/bar/some/file");
-        assert (absolutePath("../file", "/foo/bar")    == "/foo/bar/../file");
-        assert (absolutePath("/some/file", "/foo/bar") == "/some/file");
+        assert(absolutePath("some/file", "/foo/bar")  == "/foo/bar/some/file");
+        assert(absolutePath("../file", "/foo/bar")    == "/foo/bar/../file");
+        assert(absolutePath("/some/file", "/foo/bar") == "/some/file");
     }
 
     version (Windows)
     {
-        assert (absolutePath(`some\file`, `c:\foo\bar`)    == `c:\foo\bar\some\file`);
-        assert (absolutePath(`..\file`, `c:\foo\bar`)      == `c:\foo\bar\..\file`);
-        assert (absolutePath(`c:\some\file`, `c:\foo\bar`) == `c:\some\file`);
-        assert (absolutePath(`\`, `c:\`)                   == `c:\`);
-        assert (absolutePath(`\some\file`, `c:\foo\bar`)   == `c:\some\file`);
+        assert(absolutePath(`some\file`, `c:\foo\bar`)    == `c:\foo\bar\some\file`);
+        assert(absolutePath(`..\file`, `c:\foo\bar`)      == `c:\foo\bar\..\file`);
+        assert(absolutePath(`c:\some\file`, `c:\foo\bar`) == `c:\some\file`);
+        assert(absolutePath(`\`, `c:\`)                   == `c:\`);
+        assert(absolutePath(`\some\file`, `c:\foo\bar`)   == `c:\some\file`);
     }
 }
 
@@ -2608,12 +2608,12 @@ string absolutePath(string path, lazy string base = getcwd())
 {
     version (Posix)
     {
-        static assert (absolutePath("some/file", "/foo/bar") == "/foo/bar/some/file");
+        static assert(absolutePath("some/file", "/foo/bar") == "/foo/bar/some/file");
     }
 
     version (Windows)
     {
-        static assert (absolutePath(`some\file`, `c:\foo\bar`) == `c:\foo\bar\some\file`);
+        static assert(absolutePath(`some\file`, `c:\foo\bar`) == `c:\foo\bar\some\file`);
     }
 
     import std.exception;
@@ -2734,44 +2734,44 @@ string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
 ///
 @system unittest
 {
-    assert (relativePath("foo") == "foo");
+    assert(relativePath("foo") == "foo");
 
     version (Posix)
     {
-        assert (relativePath("foo", "/bar") == "foo");
-        assert (relativePath("/foo/bar", "/foo/bar") == ".");
-        assert (relativePath("/foo/bar", "/foo/baz") == "../bar");
-        assert (relativePath("/foo/bar/baz", "/foo/woo/wee") == "../../bar/baz");
-        assert (relativePath("/foo/bar/baz", "/foo/bar") == "baz");
+        assert(relativePath("foo", "/bar") == "foo");
+        assert(relativePath("/foo/bar", "/foo/bar") == ".");
+        assert(relativePath("/foo/bar", "/foo/baz") == "../bar");
+        assert(relativePath("/foo/bar/baz", "/foo/woo/wee") == "../../bar/baz");
+        assert(relativePath("/foo/bar/baz", "/foo/bar") == "baz");
     }
     version (Windows)
     {
-        assert (relativePath("foo", `c:\bar`) == "foo");
-        assert (relativePath(`c:\foo\bar`, `c:\foo\bar`) == ".");
-        assert (relativePath(`c:\foo\bar`, `c:\foo\baz`) == `..\bar`);
-        assert (relativePath(`c:\foo\bar\baz`, `c:\foo\woo\wee`) == `..\..\bar\baz`);
-        assert (relativePath(`c:\foo\bar\baz`, `c:\foo\bar`) == "baz");
-        assert (relativePath(`c:\foo\bar`, `d:\foo`) == `c:\foo\bar`);
+        assert(relativePath("foo", `c:\bar`) == "foo");
+        assert(relativePath(`c:\foo\bar`, `c:\foo\bar`) == ".");
+        assert(relativePath(`c:\foo\bar`, `c:\foo\baz`) == `..\bar`);
+        assert(relativePath(`c:\foo\bar\baz`, `c:\foo\woo\wee`) == `..\..\bar\baz`);
+        assert(relativePath(`c:\foo\bar\baz`, `c:\foo\bar`) == "baz");
+        assert(relativePath(`c:\foo\bar`, `d:\foo`) == `c:\foo\bar`);
     }
 }
 
 @system unittest
 {
     import std.exception;
-    assert (relativePath("foo") == "foo");
+    assert(relativePath("foo") == "foo");
     version (Posix)
     {
         relativePath("/foo");
-        assert (relativePath("/foo/bar", "/foo/baz") == "../bar");
+        assert(relativePath("/foo/bar", "/foo/baz") == "../bar");
         assertThrown(relativePath("/foo", "bar"));
     }
     else version (Windows)
     {
         relativePath(`\foo`);
-        assert (relativePath(`c:\foo\bar\baz`, `c:\foo\bar`) == "baz");
+        assert(relativePath(`c:\foo\bar\baz`, `c:\foo\bar`) == "baz");
         assertThrown(relativePath(`c:\foo`, "bar"));
     }
-    else static assert (0);
+    else static assert(0);
 }
 
 /** Transforms `path` into a _path relative to `base`.
@@ -2868,22 +2868,22 @@ if ((isNarrowString!R1 ||
     import std.array;
     version (Posix)
     {
-        assert (asRelativePath("foo", "/bar").array == "foo");
-        assert (asRelativePath("/foo/bar", "/foo/bar").array == ".");
-        assert (asRelativePath("/foo/bar", "/foo/baz").array == "../bar");
-        assert (asRelativePath("/foo/bar/baz", "/foo/woo/wee").array == "../../bar/baz");
-        assert (asRelativePath("/foo/bar/baz", "/foo/bar").array == "baz");
+        assert(asRelativePath("foo", "/bar").array == "foo");
+        assert(asRelativePath("/foo/bar", "/foo/bar").array == ".");
+        assert(asRelativePath("/foo/bar", "/foo/baz").array == "../bar");
+        assert(asRelativePath("/foo/bar/baz", "/foo/woo/wee").array == "../../bar/baz");
+        assert(asRelativePath("/foo/bar/baz", "/foo/bar").array == "baz");
     }
     else version (Windows)
     {
-        assert (asRelativePath("foo", `c:\bar`).array == "foo");
-        assert (asRelativePath(`c:\foo\bar`, `c:\foo\bar`).array == ".");
-        assert (asRelativePath(`c:\foo\bar`, `c:\foo\baz`).array == `..\bar`);
-        assert (asRelativePath(`c:\foo\bar\baz`, `c:\foo\woo\wee`).array == `..\..\bar\baz`);
-        assert (asRelativePath(`c:/foo/bar/baz`, `c:\foo\woo\wee`).array == `..\..\bar\baz`);
-        assert (asRelativePath(`c:\foo\bar\baz`, `c:\foo\bar`).array == "baz");
-        assert (asRelativePath(`c:\foo\bar`, `d:\foo`).array == `c:\foo\bar`);
-        assert (asRelativePath(`\\foo\bar`, `c:\foo`).array == `\\foo\bar`);
+        assert(asRelativePath("foo", `c:\bar`).array == "foo");
+        assert(asRelativePath(`c:\foo\bar`, `c:\foo\bar`).array == ".");
+        assert(asRelativePath(`c:\foo\bar`, `c:\foo\baz`).array == `..\bar`);
+        assert(asRelativePath(`c:\foo\bar\baz`, `c:\foo\woo\wee`).array == `..\..\bar\baz`);
+        assert(asRelativePath(`c:/foo/bar/baz`, `c:\foo\woo\wee`).array == `..\..\bar\baz`);
+        assert(asRelativePath(`c:\foo\bar\baz`, `c:\foo\bar`).array == "baz");
+        assert(asRelativePath(`c:\foo\bar`, `d:\foo`).array == `c:\foo\bar`);
+        assert(asRelativePath(`\\foo\bar`, `c:\foo`).array == `\\foo\bar`);
     }
     else
         static assert(0);
@@ -2902,9 +2902,9 @@ if (isConvertibleToString!R1 || isConvertibleToString!R2)
 {
     import std.array;
     version (Posix)
-        assert (asRelativePath(TestAliasedString("foo"), TestAliasedString("/bar")).array == "foo");
+        assert(asRelativePath(TestAliasedString("foo"), TestAliasedString("/bar")).array == "foo");
     else version (Windows)
-        assert (asRelativePath(TestAliasedString("foo"), TestAliasedString(`c:\bar`)).array == "foo");
+        assert(asRelativePath(TestAliasedString("foo"), TestAliasedString(`c:\bar`)).array == "foo");
     assert(asRelativePath(TestAliasedString("foo"), "bar").array == "foo");
     assert(asRelativePath("foo", TestAliasedString("bar")).array == "foo");
     assert(asRelativePath(TestAliasedString("foo"), TestAliasedString("bar")).array == "foo");
@@ -2917,15 +2917,15 @@ if (isConvertibleToString!R1 || isConvertibleToString!R2)
     import std.array, std.utf : bCU=byCodeUnit;
     version (Posix)
     {
-        assert (asRelativePath("/foo/bar/baz".bCU, "/foo/bar".bCU).array == "baz");
-        assert (asRelativePath("/foo/bar/baz"w.bCU, "/foo/bar"w.bCU).array == "baz"w);
-        assert (asRelativePath("/foo/bar/baz"d.bCU, "/foo/bar"d.bCU).array == "baz"d);
+        assert(asRelativePath("/foo/bar/baz".bCU, "/foo/bar".bCU).array == "baz");
+        assert(asRelativePath("/foo/bar/baz"w.bCU, "/foo/bar"w.bCU).array == "baz"w);
+        assert(asRelativePath("/foo/bar/baz"d.bCU, "/foo/bar"d.bCU).array == "baz"d);
     }
     else version (Windows)
     {
-        assert (asRelativePath(`\\foo\bar`.bCU, `c:\foo`.bCU).array == `\\foo\bar`);
-        assert (asRelativePath(`\\foo\bar`w.bCU, `c:\foo`w.bCU).array == `\\foo\bar`w);
-        assert (asRelativePath(`\\foo\bar`d.bCU, `c:\foo`d.bCU).array == `\\foo\bar`d);
+        assert(asRelativePath(`\\foo\bar`.bCU, `c:\foo`.bCU).array == `\\foo\bar`);
+        assert(asRelativePath(`\\foo\bar`w.bCU, `c:\foo`w.bCU).array == `\\foo\bar`w);
+        assert(asRelativePath(`\\foo\bar`d.bCU, `c:\foo`d.bCU).array == `\\foo\bar`d);
     }
 }
 
@@ -2964,42 +2964,42 @@ int filenameCharCmp(CaseSensitive cs = CaseSensitive.osDefault)(dchar a, dchar b
 ///
 @safe unittest
 {
-    assert (filenameCharCmp('a', 'a') == 0);
-    assert (filenameCharCmp('a', 'b') < 0);
-    assert (filenameCharCmp('b', 'a') > 0);
+    assert(filenameCharCmp('a', 'a') == 0);
+    assert(filenameCharCmp('a', 'b') < 0);
+    assert(filenameCharCmp('b', 'a') > 0);
 
     version (linux)
     {
         // Same as calling filenameCharCmp!(CaseSensitive.yes)(a, b)
-        assert (filenameCharCmp('A', 'a') < 0);
-        assert (filenameCharCmp('a', 'A') > 0);
+        assert(filenameCharCmp('A', 'a') < 0);
+        assert(filenameCharCmp('a', 'A') > 0);
     }
     version (Windows)
     {
         // Same as calling filenameCharCmp!(CaseSensitive.no)(a, b)
-        assert (filenameCharCmp('a', 'A') == 0);
-        assert (filenameCharCmp('a', 'B') < 0);
-        assert (filenameCharCmp('A', 'b') < 0);
+        assert(filenameCharCmp('a', 'A') == 0);
+        assert(filenameCharCmp('a', 'B') < 0);
+        assert(filenameCharCmp('A', 'b') < 0);
     }
 }
 
 @safe unittest
 {
-    assert (filenameCharCmp!(CaseSensitive.yes)('A', 'a') < 0);
-    assert (filenameCharCmp!(CaseSensitive.yes)('a', 'A') > 0);
+    assert(filenameCharCmp!(CaseSensitive.yes)('A', 'a') < 0);
+    assert(filenameCharCmp!(CaseSensitive.yes)('a', 'A') > 0);
 
-    assert (filenameCharCmp!(CaseSensitive.no)('a', 'a') == 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('a', 'b') < 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('b', 'a') > 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('A', 'a') == 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('a', 'A') == 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('a', 'B') < 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('B', 'a') > 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('A', 'b') < 0);
-    assert (filenameCharCmp!(CaseSensitive.no)('b', 'A') > 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('a', 'a') == 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('a', 'b') < 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('b', 'a') > 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('A', 'a') == 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('a', 'A') == 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('a', 'B') < 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('B', 'a') > 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('A', 'b') < 0);
+    assert(filenameCharCmp!(CaseSensitive.no)('b', 'A') > 0);
 
-    version (Posix)   assert (filenameCharCmp('\\', '/') != 0);
-    version (Windows) assert (filenameCharCmp('\\', '/') == 0);
+    version (Posix)   assert(filenameCharCmp('\\', '/') != 0);
+    version (Windows) assert(filenameCharCmp('\\', '/') == 0);
 }
 
 
@@ -3068,25 +3068,25 @@ if (isInputRange!Range1 && !isInfinite!Range1 &&
 ///
 @safe unittest
 {
-    assert (filenameCmp("abc", "abc") == 0);
-    assert (filenameCmp("abc", "abd") < 0);
-    assert (filenameCmp("abc", "abb") > 0);
-    assert (filenameCmp("abc", "abcd") < 0);
-    assert (filenameCmp("abcd", "abc") > 0);
+    assert(filenameCmp("abc", "abc") == 0);
+    assert(filenameCmp("abc", "abd") < 0);
+    assert(filenameCmp("abc", "abb") > 0);
+    assert(filenameCmp("abc", "abcd") < 0);
+    assert(filenameCmp("abcd", "abc") > 0);
 
     version (linux)
     {
         // Same as calling filenameCmp!(CaseSensitive.yes)(filename1, filename2)
-        assert (filenameCmp("Abc", "abc") < 0);
-        assert (filenameCmp("abc", "Abc") > 0);
+        assert(filenameCmp("Abc", "abc") < 0);
+        assert(filenameCmp("abc", "Abc") > 0);
     }
     version (Windows)
     {
         // Same as calling filenameCmp!(CaseSensitive.no)(filename1, filename2)
-        assert (filenameCmp("Abc", "abc") == 0);
-        assert (filenameCmp("abc", "Abc") == 0);
-        assert (filenameCmp("Abc", "abD") < 0);
-        assert (filenameCmp("abc", "AbB") > 0);
+        assert(filenameCmp("Abc", "abc") == 0);
+        assert(filenameCmp("abc", "Abc") == 0);
+        assert(filenameCmp("Abc", "abD") < 0);
+        assert(filenameCmp("abc", "AbB") > 0);
     }
 }
 
@@ -3101,28 +3101,28 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
 
 @safe unittest
 {
-    assert (filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), "abc") < 0);
-    assert (filenameCmp!(CaseSensitive.yes)("Abc", TestAliasedString("abc")) < 0);
-    assert (filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), TestAliasedString("abc")) < 0);
+    assert(filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), "abc") < 0);
+    assert(filenameCmp!(CaseSensitive.yes)("Abc", TestAliasedString("abc")) < 0);
+    assert(filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), TestAliasedString("abc")) < 0);
 }
 
 @safe unittest
 {
-    assert (filenameCmp!(CaseSensitive.yes)("Abc", "abc") < 0);
-    assert (filenameCmp!(CaseSensitive.yes)("abc", "Abc") > 0);
+    assert(filenameCmp!(CaseSensitive.yes)("Abc", "abc") < 0);
+    assert(filenameCmp!(CaseSensitive.yes)("abc", "Abc") > 0);
 
-    assert (filenameCmp!(CaseSensitive.no)("abc", "abc") == 0);
-    assert (filenameCmp!(CaseSensitive.no)("abc", "abd") < 0);
-    assert (filenameCmp!(CaseSensitive.no)("abc", "abb") > 0);
-    assert (filenameCmp!(CaseSensitive.no)("abc", "abcd") < 0);
-    assert (filenameCmp!(CaseSensitive.no)("abcd", "abc") > 0);
-    assert (filenameCmp!(CaseSensitive.no)("Abc", "abc") == 0);
-    assert (filenameCmp!(CaseSensitive.no)("abc", "Abc") == 0);
-    assert (filenameCmp!(CaseSensitive.no)("Abc", "abD") < 0);
-    assert (filenameCmp!(CaseSensitive.no)("abc", "AbB") > 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "abc") == 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "abd") < 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "abb") > 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "abcd") < 0);
+    assert(filenameCmp!(CaseSensitive.no)("abcd", "abc") > 0);
+    assert(filenameCmp!(CaseSensitive.no)("Abc", "abc") == 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "Abc") == 0);
+    assert(filenameCmp!(CaseSensitive.no)("Abc", "abD") < 0);
+    assert(filenameCmp!(CaseSensitive.no)("abc", "AbB") > 0);
 
-    version (Posix)   assert (filenameCmp(`abc\def`, `abc/def`) != 0);
-    version (Windows) assert (filenameCmp(`abc\def`, `abc/def`) == 0);
+    version (Posix)   assert(filenameCmp(`abc\def`, `abc/def`) != 0);
+    version (Windows) assert(filenameCmp(`abc\def`, `abc/def`) == 0);
 }
 
 /** Matches a pattern against a path.
@@ -3318,26 +3318,26 @@ body
 ///
 @safe unittest
 {
-    assert (globMatch("foo.bar", "*"));
-    assert (globMatch("foo.bar", "*.*"));
-    assert (globMatch(`foo/foo\bar`, "f*b*r"));
-    assert (globMatch("foo.bar", "f???bar"));
-    assert (globMatch("foo.bar", "[fg]???bar"));
-    assert (globMatch("foo.bar", "[!gh]*bar"));
-    assert (globMatch("bar.fooz", "bar.{foo,bif}z"));
-    assert (globMatch("bar.bifz", "bar.{foo,bif}z"));
+    assert(globMatch("foo.bar", "*"));
+    assert(globMatch("foo.bar", "*.*"));
+    assert(globMatch(`foo/foo\bar`, "f*b*r"));
+    assert(globMatch("foo.bar", "f???bar"));
+    assert(globMatch("foo.bar", "[fg]???bar"));
+    assert(globMatch("foo.bar", "[!gh]*bar"));
+    assert(globMatch("bar.fooz", "bar.{foo,bif}z"));
+    assert(globMatch("bar.bifz", "bar.{foo,bif}z"));
 
     version (Windows)
     {
         // Same as calling globMatch!(CaseSensitive.no)(path, pattern)
-        assert (globMatch("foo", "Foo"));
-        assert (globMatch("Goo.bar", "[fg]???bar"));
+        assert(globMatch("foo", "Foo"));
+        assert(globMatch("Goo.bar", "[fg]???bar"));
     }
     version (linux)
     {
         // Same as calling globMatch!(CaseSensitive.yes)(path, pattern)
-        assert (!globMatch("foo", "Foo"));
-        assert (!globMatch("Goo.bar", "[fg]???bar"));
+        assert(!globMatch("foo", "Foo"));
+        assert(!globMatch("Goo.bar", "[fg]???bar"));
     }
 }
 
@@ -3351,13 +3351,13 @@ if (isConvertibleToString!Range)
 
 @safe unittest
 {
-    assert (testAliasedString!globMatch("foo.bar", "*"));
+    assert(testAliasedString!globMatch("foo.bar", "*"));
 }
 
 @safe unittest
 {
-    assert (globMatch!(CaseSensitive.no)("foo", "Foo"));
-    assert (!globMatch!(CaseSensitive.yes)("foo", "Foo"));
+    assert(globMatch!(CaseSensitive.no)("foo", "Foo"));
+    assert(!globMatch!(CaseSensitive.yes)("foo", "Foo"));
 
     assert(globMatch("foo", "*"));
     assert(globMatch("foo.bar"w, "*"w));
@@ -3473,7 +3473,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
         {
             if (c == 0 || c == '/') return false;
         }
-        else static assert (0);
+        else static assert(0);
     }
     version (Windows)
     {
@@ -3514,16 +3514,16 @@ unittest
     auto pfdep = [`foo\bar`, "*.txt"];
     version (Windows) invalid ~= pfdep;
     else version (Posix) valid ~= pfdep;
-    else static assert (0);
+    else static assert(0);
 
     import std.meta : AliasSeq;
     foreach (T; AliasSeq!(char[], const(char)[], string, wchar[],
         const(wchar)[], wstring, dchar[], const(dchar)[], dstring))
     {
         foreach (fn; valid)
-            assert (isValidFilename(to!T(fn)));
+            assert(isValidFilename(to!T(fn)));
         foreach (fn; invalid)
-            assert (!isValidFilename(to!T(fn)));
+            assert(!isValidFilename(to!T(fn)));
     }
 
     {
@@ -3594,7 +3594,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
     // isValidFilename.
     bool isValidComponent(Range component)
     {
-        assert (component.length > 0);
+        assert(component.length > 0);
         if (component[0] == '.')
         {
             if (component.length == 1) return true;
@@ -3661,7 +3661,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
     {
         remainder = path;
     }
-    else static assert (0);
+    else static assert(0);
     remainder = ltrimDirSeparators(remainder);
 
     // Check that each component satisfies isValidComponent.
@@ -3669,7 +3669,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
     {
         size_t i = 0;
         while (i < remainder.length && !isDirSeparator(remainder[i])) ++i;
-        assert (i > 0);
+        assert(i > 0);
         if (!isValidComponent(remainder[0 .. i])) return false;
         remainder = ltrimDirSeparators(remainder[i .. $]);
     }
@@ -3682,39 +3682,39 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
 @safe pure @nogc nothrow
 unittest
 {
-    assert (isValidPath("/foo/bar"));
-    assert (!isValidPath("/foo\0/bar"));
-    assert (isValidPath("/"));
-    assert (isValidPath("a"));
+    assert(isValidPath("/foo/bar"));
+    assert(!isValidPath("/foo\0/bar"));
+    assert(isValidPath("/"));
+    assert(isValidPath("a"));
 
     version (Windows)
     {
-        assert (isValidPath(`c:\`));
-        assert (isValidPath(`c:\foo`));
-        assert (isValidPath(`c:\foo\.\bar\\\..\`));
-        assert (!isValidPath(`!:\foo`));
-        assert (!isValidPath(`c::\foo`));
-        assert (!isValidPath(`c:\foo?`));
-        assert (!isValidPath(`c:\foo.`));
+        assert(isValidPath(`c:\`));
+        assert(isValidPath(`c:\foo`));
+        assert(isValidPath(`c:\foo\.\bar\\\..\`));
+        assert(!isValidPath(`!:\foo`));
+        assert(!isValidPath(`c::\foo`));
+        assert(!isValidPath(`c:\foo?`));
+        assert(!isValidPath(`c:\foo.`));
 
-        assert (isValidPath(`\\server\share`));
-        assert (isValidPath(`\\server\share\foo`));
-        assert (isValidPath(`\\server\share\\foo`));
-        assert (!isValidPath(`\\\server\share\foo`));
-        assert (!isValidPath(`\\server\\share\foo`));
-        assert (!isValidPath(`\\ser*er\share\foo`));
-        assert (!isValidPath(`\\server\sha?e\foo`));
-        assert (!isValidPath(`\\server\share\|oo`));
+        assert(isValidPath(`\\server\share`));
+        assert(isValidPath(`\\server\share\foo`));
+        assert(isValidPath(`\\server\share\\foo`));
+        assert(!isValidPath(`\\\server\share\foo`));
+        assert(!isValidPath(`\\server\\share\foo`));
+        assert(!isValidPath(`\\ser*er\share\foo`));
+        assert(!isValidPath(`\\server\sha?e\foo`));
+        assert(!isValidPath(`\\server\share\|oo`));
 
-        assert (isValidPath(`\\?\<>:"?*|/\..\.`));
-        assert (!isValidPath("\\\\?\\foo\0bar"));
+        assert(isValidPath(`\\?\<>:"?*|/\..\.`));
+        assert(!isValidPath("\\\\?\\foo\0bar"));
 
-        assert (!isValidPath(`\\.\PhysicalDisk1`));
-        assert (!isValidPath(`\\`));
+        assert(!isValidPath(`\\.\PhysicalDisk1`));
+        assert(!isValidPath(`\\`));
     }
 
     import std.utf : byCodeUnit;
-    assert (isValidPath("/foo/bar".byCodeUnit));
+    assert(isValidPath("/foo/bar".byCodeUnit));
 }
 
 bool isValidPath(Range)(auto ref Range path)

--- a/std/process.d
+++ b/std/process.d
@@ -833,8 +833,8 @@ version (Posix) @system unittest
     // Can't use this for arbitrary descriptors as many shells only support
     // single digit fds.
     TestScript testDefaults = `command >&0 && command >&1 && command >&2`;
-    assert (execute(testDefaults.path).status == 0);
-    assert (execute(testDefaults.path, null, Config.inheritFDs).status == 0);
+    assert(execute(testDefaults.path).status == 0);
+    assert(execute(testDefaults.path, null, Config.inheritFDs).status == 0);
 
     // try /proc/<pid>/fd/ on linux
     version (linux)
@@ -844,8 +844,8 @@ version (Posix) @system unittest
         if (procRes.status == 0)
         {
             auto fdStr = fd.to!string;
-            assert (!procRes.output.split.canFind(fdStr));
-            assert (execute(proc.path, null, Config.inheritFDs)
+            assert(!procRes.output.split.canFind(fdStr));
+            assert(execute(proc.path, null, Config.inheritFDs)
                     .output.split.canFind(fdStr));
             return;
         }
@@ -856,9 +856,9 @@ version (Posix) @system unittest
     auto fuserRes = execute(fuser.path, null);
     if (fuserRes.status == 0)
     {
-        assert (!reverseArgs!canFind(fuserRes
+        assert(!reverseArgs!canFind(fuserRes
                     .output.findSplitBefore("\n").expand));
-        assert (reverseArgs!canFind(execute(fuser.path, null, Config.inheritFDs)
+        assert(reverseArgs!canFind(execute(fuser.path, null, Config.inheritFDs)
                     .output.findSplitBefore("\n").expand));
         return;
     }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2154,7 +2154,7 @@ pure @safe nothrow unittest
     // Test fix for bug 5052.
     auto takeMyStrAgain = take(takeMyStr, 4);
     assert(assumeWontThrow(equal(takeMyStrAgain, "This")));
-    static assert (is (typeof(takeMyStrAgain) == typeof(takeMyStr)));
+    static assert(is (typeof(takeMyStrAgain) == typeof(takeMyStr)));
     takeMyStrAgain = take(takeMyStr, 10);
     assert(assumeWontThrow(equal(takeMyStrAgain, "This is")));
 
@@ -3777,7 +3777,7 @@ if (isStaticArray!R)
 
     InfRange i;
     auto c = cycle(i);
-    assert (c == i);
+    assert(c == i);
 }
 
 @safe unittest
@@ -7073,31 +7073,31 @@ if (isForwardRange!Source)
     auto chunks1 = [0, 0, 1, 1, 2, 2, 3, 3, 4].chunks(2);
     auto chunks2 = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4].chunks(2);
 
-    assert (chunks1.length == 5);
-    assert (chunks2.length == 5);
-    assert (chunks1[4] == [4]);
-    assert (chunks2[4] == [4, 4]);
-    assert (chunks1.back == [4]);
-    assert (chunks2.back == [4, 4]);
+    assert(chunks1.length == 5);
+    assert(chunks2.length == 5);
+    assert(chunks1[4] == [4]);
+    assert(chunks2[4] == [4, 4]);
+    assert(chunks1.back == [4]);
+    assert(chunks2.back == [4, 4]);
 
-    assert (chunks1[0 .. 1].equal([[0, 0]]));
-    assert (chunks1[0 .. 2].equal([[0, 0], [1, 1]]));
-    assert (chunks1[4 .. 5].equal([[4]]));
-    assert (chunks2[4 .. 5].equal([[4, 4]]));
+    assert(chunks1[0 .. 1].equal([[0, 0]]));
+    assert(chunks1[0 .. 2].equal([[0, 0], [1, 1]]));
+    assert(chunks1[4 .. 5].equal([[4]]));
+    assert(chunks2[4 .. 5].equal([[4, 4]]));
 
-    assert (chunks1[0 .. 0].equal((int[][]).init));
-    assert (chunks1[5 .. 5].equal((int[][]).init));
-    assert (chunks2[5 .. 5].equal((int[][]).init));
+    assert(chunks1[0 .. 0].equal((int[][]).init));
+    assert(chunks1[5 .. 5].equal((int[][]).init));
+    assert(chunks2[5 .. 5].equal((int[][]).init));
 
     //Fun with opDollar
-    assert (chunks1[$ .. $].equal((int[][]).init)); //Quick
-    assert (chunks2[$ .. $].equal((int[][]).init)); //Quick
-    assert (chunks1[$ - 1 .. $].equal([[4]]));      //Semiquick
-    assert (chunks2[$ - 1 .. $].equal([[4, 4]]));   //Semiquick
-    assert (chunks1[$ .. 5].equal((int[][]).init)); //Semiquick
-    assert (chunks2[$ .. 5].equal((int[][]).init)); //Semiquick
+    assert(chunks1[$ .. $].equal((int[][]).init)); //Quick
+    assert(chunks2[$ .. $].equal((int[][]).init)); //Quick
+    assert(chunks1[$ - 1 .. $].equal([[4]]));      //Semiquick
+    assert(chunks2[$ - 1 .. $].equal([[4, 4]]));   //Semiquick
+    assert(chunks1[$ .. 5].equal((int[][]).init)); //Semiquick
+    assert(chunks2[$ .. 5].equal((int[][]).init)); //Semiquick
 
-    assert (chunks1[$ / 2 .. $ - 1].equal([[2, 2], [3, 3]])); //Slow
+    assert(chunks1[$ / 2 .. $ - 1].equal([[2, 2], [3, 3]])); //Slow
 }
 
 unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -223,33 +223,33 @@ private void doPut(R, E)(ref R r, auto ref E e)
     }
     else
     {
-        static assert (false,
+        static assert(false,
             "Cannot put a " ~ E.stringof ~ " into a " ~ R.stringof ~ ".");
     }
 }
 
 @safe unittest
 {
-    static assert (!isNativeOutputRange!(int,     int));
-    static assert ( isNativeOutputRange!(int[],   int));
-    static assert (!isNativeOutputRange!(int[][], int));
+    static assert(!isNativeOutputRange!(int,     int));
+    static assert( isNativeOutputRange!(int[],   int));
+    static assert(!isNativeOutputRange!(int[][], int));
 
-    static assert (!isNativeOutputRange!(int,     int[]));
-    static assert (!isNativeOutputRange!(int[],   int[]));
-    static assert ( isNativeOutputRange!(int[][], int[]));
+    static assert(!isNativeOutputRange!(int,     int[]));
+    static assert(!isNativeOutputRange!(int[],   int[]));
+    static assert( isNativeOutputRange!(int[][], int[]));
 
-    static assert (!isNativeOutputRange!(int,     int[][]));
-    static assert (!isNativeOutputRange!(int[],   int[][]));
-    static assert (!isNativeOutputRange!(int[][], int[][]));
+    static assert(!isNativeOutputRange!(int,     int[][]));
+    static assert(!isNativeOutputRange!(int[],   int[][]));
+    static assert(!isNativeOutputRange!(int[][], int[][]));
 
-    static assert (!isNativeOutputRange!(int[4],   int));
-    static assert ( isNativeOutputRange!(int[4][], int)); //Scary!
-    static assert ( isNativeOutputRange!(int[4][], int[4]));
+    static assert(!isNativeOutputRange!(int[4],   int));
+    static assert( isNativeOutputRange!(int[4][], int)); //Scary!
+    static assert( isNativeOutputRange!(int[4][], int[4]));
 
-    static assert (!isNativeOutputRange!( char[],   char));
-    static assert (!isNativeOutputRange!( char[],  dchar));
-    static assert ( isNativeOutputRange!(dchar[],   char));
-    static assert ( isNativeOutputRange!(dchar[],  dchar));
+    static assert(!isNativeOutputRange!( char[],   char));
+    static assert(!isNativeOutputRange!( char[],  dchar));
+    static assert( isNativeOutputRange!(dchar[],   char));
+    static assert( isNativeOutputRange!(dchar[],  dchar));
 
 }
 
@@ -344,7 +344,7 @@ void put(R, E)(ref R r, E e)
     }
     else
     {
-        static assert (false, "Cannot put a " ~ E.stringof ~ " into a " ~ R.stringof ~ ".");
+        static assert(false, "Cannot put a " ~ E.stringof ~ " into a " ~ R.stringof ~ ".");
     }
 }
 
@@ -398,7 +398,7 @@ if (isSomeChar!E)
     }
     else
     {
-        static assert (false, "Cannot put a " ~ E.stringof ~ " into a " ~ R.stringof ~ ".");
+        static assert(false, "Cannot put a " ~ E.stringof ~ " into a " ~ R.stringof ~ ".");
     }
 }
 
@@ -775,7 +775,7 @@ The following code should compile for any forward range.
 static assert(isInputRange!R);
 R r1;
 auto s1 = r1.save;
-static assert (is(typeof(s1) == R));
+static assert(is(typeof(s1) == R));
 ----
 
 Saving a range is not duplicating it; in the example above, $(D r1)
@@ -797,7 +797,7 @@ template isForwardRange(R)
         // because typeof may not check the right type there, and
         // because we want to ensure the range can be copied.
         auto s1 = r1.save;
-        static assert (is(typeof(s1) == R));
+        static assert(is(typeof(s1) == R));
     }));
 }
 

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -170,7 +170,7 @@ template IRL(IR code)
 {
     enum uint IRL =  lengthOfIR(code);
 }
-static assert (IRL!(IR.LookaheadStart) == 3);
+static assert(IRL!(IR.LookaheadStart) == 3);
 
 //how many parameters follow the IR, should be optimized fixing some IR bits
 int immediateParamsIR(IR i){

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -917,7 +917,7 @@ $(D rawRead) always reads in binary mode on Windows.
             }
         }
         immutable freadResult = trustedFread(_p.handle, buffer);
-        assert (freadResult <= buffer.length); // fread return guarantee
+        assert(freadResult <= buffer.length); // fread return guarantee
         if (freadResult != buffer.length) // error or eof
         {
             errnoEnforce(!error);

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1634,7 +1634,7 @@ unittest
     import std.exception : assertThrown;
 
     // enum tupStr = tuple(1, 1.0).toString; // toString is *impure*.
-    //static assert (tupStr == `Tuple!(int, double)(1, 1)`);
+    //static assert(tupStr == `Tuple!(int, double)(1, 1)`);
 
     Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
 
@@ -2078,7 +2078,7 @@ template UnqualRef(T)
 {
     class C { }
     alias T = UnqualRef!(const shared C);
-    static assert (is(typeof(T.stripped) == C));
+    static assert(is(typeof(T.stripped) == C));
 }
 
 
@@ -7278,7 +7278,7 @@ public:
 
     // use & between BitFlags for intersection
     immutable BitFlags!Enum flags_BC = BitFlags!Enum(Enum.B, Enum.C);
-    assert (flags_B == (flags_BC & flags_AB));
+    assert(flags_B == (flags_BC & flags_AB));
 
     // All the binary operators work in their assignment version
     BitFlags!Enum temp = flags_empty;

--- a/std/uri.d
+++ b/std/uri.d
@@ -467,10 +467,10 @@ if (isSomeChar!Char)
 @safe unittest
 {
     string s1 = "http://www.digitalmars.com/~fred/fredsRX.html#foo end!";
-    assert (uriLength(s1) == 49);
+    assert(uriLength(s1) == 49);
     string s2 = "no uri here";
-    assert (uriLength(s2) == -1);
-    assert (uriLength("issue 14924") < 0);
+    assert(uriLength(s2) == -1);
+    assert(uriLength("issue 14924") < 0);
 }
 
 
@@ -534,10 +534,10 @@ if (isSomeChar!Char)
 @safe unittest
 {
     string s1 = "my.e-mail@www.example-domain.com with garbage added";
-    assert (emailLength(s1) == 32);
+    assert(emailLength(s1) == 32);
     string s2 = "no email address here";
-    assert (emailLength(s2) == -1);
-    assert (emailLength("issue 14924") < 0);
+    assert(emailLength(s2) == -1);
+    assert(emailLength("issue 14924") < 0);
 }
 
 

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1212,12 +1212,12 @@ UUID randomUUID(RNG)(ref RNG randomGen)
 if (isInputRange!RNG && isIntegral!(ElementType!RNG))
 {
     import std.random : isUniformRNG;
-    static assert (isUniformRNG!RNG, "randomGen must be a uniform RNG");
+    static assert(isUniformRNG!RNG, "randomGen must be a uniform RNG");
 
     alias E = ElementEncodingType!RNG;
     enum size_t elemSize = E.sizeof;
-    static assert (elemSize <= 16);
-    static assert (16 % elemSize == 0);
+    static assert(elemSize <= 16);
+    static assert(16 % elemSize == 0);
 
     UUID u;
     foreach (ref E e ; u.asArrayOf!E())

--- a/std/variant.d
+++ b/std/variant.d
@@ -1764,7 +1764,7 @@ unittest
 unittest
 {
     Variant v = 5;
-    assert (!__traits(compiles, v.coerce!(bool delegate())));
+    assert(!__traits(compiles, v.coerce!(bool delegate())));
 }
 
 


### PR DESCRIPTION
>> BTW (and I realize you're sticking to existing style) I think Phobos style is to treat `assert` like a function, not a keyword (i.e. no space before `(`).
> yah, no space after `assert`

First commit adds a simple check, the second one applies another RegExp (`s/assert +\(/assert(/`) over the Phobos codebase to be able to enforce the former automatically.

CC @andralex 