### PR TITLE
Add a check to enforce space after cast(..) expressions

### DIFF
--- a/etc/c/odbc/sql.d
+++ b/etc/c/odbc/sql.d
@@ -284,13 +284,13 @@ enum
 }
 
 // * null handles returned by SQLAllocHandle() *
-enum SQLHANDLE SQL_NULL_HENV  = cast(SQLHANDLE)0;
-enum SQLHANDLE SQL_NULL_HDBC  = cast(SQLHANDLE)0;
-enum SQLHANDLE SQL_NULL_HSTMT = cast(SQLHANDLE)0;
-enum SQLHANDLE SQL_NULL_HDESC = cast(SQLHANDLE)0;
+enum SQLHANDLE SQL_NULL_HENV  = cast(SQLHANDLE) 0;
+enum SQLHANDLE SQL_NULL_HDBC  = cast(SQLHANDLE) 0;
+enum SQLHANDLE SQL_NULL_HSTMT = cast(SQLHANDLE) 0;
+enum SQLHANDLE SQL_NULL_HDESC = cast(SQLHANDLE) 0;
 
 // * null handle used in place of parent handle when allocating HENV *
-enum SQLHANDLE SQL_NULL_HANDLE = cast(SQLHANDLE)0L;
+enum SQLHANDLE SQL_NULL_HANDLE = cast(SQLHANDLE) 0L;
 
 // * Values that may appear in the result set of SQLSpecialColumns() *
 enum

--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -552,7 +552,7 @@ uint SQL_LEN_DATA_AT_EXEC()
     uint length
 )
 {
-    return ( ( -1 * length ) + cast(uint)SQL_LEN_DATA_AT_EXEC_OFFSET );
+    return ( ( -1 * length ) + cast(uint) SQL_LEN_DATA_AT_EXEC_OFFSET );
 }
 
 // * binary length for driver specific attributes *
@@ -563,7 +563,7 @@ uint SQL_LEN_BINARY_ATTR()
     uint length
 )
 {
-    return ( ( -1 * length ) + cast(uint)SQL_LEN_BINARY_ATTR_OFFSET );
+    return ( ( -1 * length ) + cast(uint) SQL_LEN_BINARY_ATTR_OFFSET );
 }
 
 // * Defines used by Driver Manager when mapping SQLSetParam to SQLBindParameter *

--- a/posix.mak
+++ b/posix.mak
@@ -516,6 +516,9 @@ style: ../dscanner/dsc
 	@echo "Enforce no space between assert and the opening brace, i.e. assert("
 	grep -nrE 'assert +\(' $$(find . -name '*.d') ; test $$? -eq 1
 
+	@echo "Enforce space after cast(...)"
+	grep -nrE '[^"]cast\([^)]*?\)[[:alnum:]]' $$(find . -name '*.d') ; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1074,7 +1074,7 @@ private:
             import core.exception : onOutOfMemoryError;
             const nbytes = mulu(rc, _matrix[0].sizeof, overflow);
             if (overflow) assert(0);
-            auto m = cast(CostType *)realloc(_matrix.ptr, nbytes);
+            auto m = cast(CostType *) realloc(_matrix.ptr, nbytes);
             if (!m)
                 onOutOfMemoryError();
             _matrix = m[0 .. r * c];

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -875,13 +875,13 @@ template each(alias pred = "a")
     enum isForeachUnaryIterable(R) =
         is(typeof((R r) {
             foreach (ref a; r)
-                cast(void)unaryFun!pred(a);
+                cast(void) unaryFun!pred(a);
         }));
 
     enum isForeachBinaryIterable(R) =
         is(typeof((R r) {
             foreach (ref i, ref a; r)
-                cast(void)binaryFun!BinaryArgs(i, a);
+                cast(void) binaryFun!BinaryArgs(i, a);
         }));
 
     enum isForeachIterable(R) =
@@ -896,7 +896,7 @@ template each(alias pred = "a")
         {
             while (!r.empty)
             {
-                cast(void)unaryFun!pred(r.front);
+                cast(void) unaryFun!pred(r.front);
                 r.popFront();
             }
         }
@@ -905,7 +905,7 @@ template each(alias pred = "a")
             size_t i = 0;
             while (!r.empty)
             {
-                cast(void)binaryFun!BinaryArgs(i, r.front);
+                cast(void) binaryFun!BinaryArgs(i, r.front);
                 r.popFront();
                 i++;
             }
@@ -919,12 +919,12 @@ template each(alias pred = "a")
         static if (isForeachUnaryIterable!Iterable)
         {
             foreach (ref e; r)
-                cast(void)unaryFun!pred(e);
+                cast(void) unaryFun!pred(e);
         }
         else // if (isForeachBinaryIterable!Iterable)
         {
             foreach (ref i, ref e; r)
-                cast(void)binaryFun!BinaryArgs(i, e);
+                cast(void) binaryFun!BinaryArgs(i, e);
         }
     }
 
@@ -4518,7 +4518,7 @@ if (isSomeChar!C)
        {
             if (word in dictionary) continue; // Nothing to do
             auto newID = dictionary.length;
-            dictionary[to!string(word)] = cast(uint)newID;
+            dictionary[to!string(word)] = cast(uint) newID;
         }
     }
     assert(dictionary.length == 5);
@@ -4692,7 +4692,7 @@ if (isInputRange!R && !isInfinite!R)
 
     void collapseStore(T)(T k)
     {
-        auto lastToKeep = idx - cast(uint)bsf(k+1);
+        auto lastToKeep = idx - cast(uint) bsf(k+1);
         while (idx > lastToKeep)
         {
             store[idx - 1] += store[idx];
@@ -4746,10 +4746,10 @@ if (isInputRange!R && !isInfinite!R)
 private auto sumPairwise16(F, R)(R r)
 if (isRandomAccessRange!R)
 {
-    return (((cast(F)r[ 0] + r[ 1]) + (cast(F)r[ 2] + r[ 3]))
-          + ((cast(F)r[ 4] + r[ 5]) + (cast(F)r[ 6] + r[ 7])))
-         + (((cast(F)r[ 8] + r[ 9]) + (cast(F)r[10] + r[11]))
-          + ((cast(F)r[12] + r[13]) + (cast(F)r[14] + r[15])));
+    return (((cast(F) r[ 0] + r[ 1]) + (cast(F) r[ 2] + r[ 3]))
+          + ((cast(F) r[ 4] + r[ 5]) + (cast(F) r[ 6] + r[ 7])))
+         + (((cast(F) r[ 8] + r[ 9]) + (cast(F) r[10] + r[11]))
+          + ((cast(F) r[12] + r[13]) + (cast(F) r[14] + r[15])));
 }
 
 private auto sumPair(bool needEmptyChecks, F, R)(ref R r)
@@ -4821,8 +4821,8 @@ private auto sumKahan(Result, R)(Result result, R r)
 
 @safe pure nothrow unittest
 {
-    static assert(is(typeof(sum([cast( byte)1])) ==  int));
-    static assert(is(typeof(sum([cast(ubyte)1])) ==  int));
+    static assert(is(typeof(sum([cast( byte) 1])) ==  int));
+    static assert(is(typeof(sum([cast(ubyte) 1])) ==  int));
     static assert(is(typeof(sum([  1,   2,   3,   4])) ==  int));
     static assert(is(typeof(sum([ 1U,  2U,  3U,  4U])) == uint));
     static assert(is(typeof(sum([ 1L,  2L,  3L,  4L])) ==  long));

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -258,8 +258,8 @@ Unicode integrity is not preserved:
 
     bringToFront(ar, br);
 
-    auto a = cast(char[])ar;
-    auto b = cast(char[])br;
+    auto a = cast(char[]) ar;
+    auto b = cast(char[]) br;
 
     // Illegal UTF-8
     assert(a == "\303");
@@ -798,7 +798,7 @@ if (isInputRange!Range && hasLvalueElements!Range && hasAssignableElements!Range
                 {
                     // static array initializer only contains initialization
                     // for one element of the static array.
-                    auto elemp = cast(void *)addressOf(range.front);
+                    auto elemp = cast(void *) addressOf(range.front);
                     auto endp = elemp + T.sizeof;
                     while (elemp < endp)
                     {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -538,9 +538,9 @@ if (isNarrowString!R1 && isNarrowString!R2)
     assert(commonPrefix([1, 2, 3, 4], [1, 2, 3, 4]) == [1, 2, 3, 4]);
     assert(commonPrefix([1, 2, 3], [7, 2, 3, 4, 5]).empty);
     assert(commonPrefix([7, 2, 3, 4, 5], [1, 2, 3]).empty);
-    assert(commonPrefix([1, 2, 3], cast(int[])null).empty);
-    assert(commonPrefix(cast(int[])null, [1, 2, 3]).empty);
-    assert(commonPrefix(cast(int[])null, cast(int[])null).empty);
+    assert(commonPrefix([1, 2, 3], cast(int[]) null).empty);
+    assert(commonPrefix(cast(int[]) null, [1, 2, 3]).empty);
+    assert(commonPrefix(cast(int[]) null, cast(int[]) null).empty);
 
     foreach (S; AliasSeq!(char[], const(char)[], string,
                           wchar[], const(wchar)[], wstring,
@@ -1208,7 +1208,7 @@ if (isInputRange!R &&
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 
         //RA range
-        assert(endsWith(arr, cast(int[])null));
+        assert(endsWith(arr, cast(int[]) null));
         assert(!endsWith(arr, 0));
         assert(!endsWith(arr, 4));
         assert(endsWith(arr, 5));
@@ -1420,7 +1420,7 @@ if (isInputRange!InputRange &&
                         import core.stdc.string : memchr;
                         auto ptr = memchr(haystack.ptr, needle, haystack.length);
                         return ptr ?
-                             haystack[cast(char*)ptr - haystack.ptr .. $] :
+                             haystack[cast(char*) ptr - haystack.ptr .. $] :
                              haystack[$ .. $];
                     }
                     return trustedMemchr(haystack, needle);
@@ -1781,7 +1781,7 @@ if (isForwardRange!R1 && isForwardRange!R2
             Select!(haystack[0].sizeof == 1, ubyte[],
                 Select!(haystack[0].sizeof == 2, ushort[], uint[]));
         // Will use the array specialization
-        static TO force(TO, T)(T r) @trusted { return cast(TO)r; }
+        static TO force(TO, T)(T r) @trusted { return cast(TO) r; }
         return force!R1(.find!(pred, Representation, Representation)
             (force!Representation(haystack), force!Representation(needle)));
     }
@@ -3112,7 +3112,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     {
         UT v = UT.init;
         static if (isAssignable!(UT, T)) v = range.front;
-        else                             v = cast(UT)range.front;
+        else                             v = cast(UT) range.front;
 
         for (range.popFront(); !range.empty; range.popFront())
         {
@@ -3121,7 +3121,7 @@ if (isInputRange!Range && !isInfinite!Range &&
             {
                 // change the min
                 static if (isAssignable!(UT, T)) v = range.front;
-                else                             v = cast(UT)range.front; //Safe because !hasElaborateAssign!UT
+                else                             v = cast(UT) range.front; //Safe because !hasElaborateAssign!UT
                 occurrences = 1;
             }
             else
@@ -4208,7 +4208,7 @@ if (isInputRange!R &&
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 
         //RA range
-        assert(startsWith(arr, cast(int[])null));
+        assert(startsWith(arr, cast(int[]) null));
         assert(!startsWith(arr, 5));
         assert(!startsWith(arr, 1));
         assert(startsWith(arr, 0));

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -92,7 +92,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
             // covering the right and bottom edges of an increasing square area
             // over the infinite table of combinations. This schedule allows us
             // to require only forward ranges.
-            return zip(sequence!"n"(cast(size_t)0), range1.save, range2.save,
+            return zip(sequence!"n"(cast(size_t) 0), range1.save, range2.save,
                        repeat(range1), repeat(range2))
                 .map!(function(a) => chain(
                     zip(repeat(a[1]), take(a[4].save, a[0])),

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -3846,7 +3846,7 @@ unittest
         auto b = new ubyte[5];
         topNIndex!("a > b")(a, b, Yes.sortOutput);
         //foreach (e; b) writeln(e, ":", a[e]);
-        assert(b == [ cast(ubyte) 0, cast(ubyte)2, cast(ubyte)1, cast(ubyte)6, cast(ubyte)5], text(b));
+        assert(b == [ cast(ubyte) 0, cast(ubyte) 2, cast(ubyte) 1, cast(ubyte) 6, cast(ubyte) 5], text(b));
     }
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -125,7 +125,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
             emplaceRef!E(result[i], e);
             ++i;
         }
-        return (() @trusted => cast(E[])result)();
+        return (() @trusted => cast(E[]) result)();
     }
     else
     {
@@ -587,7 +587,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
 
 @safe pure nothrow unittest
 {
-    cast(void)minimallyInitializedArray!(int[][][][][])();
+    cast(void) minimallyInitializedArray!(int[][][][][])();
     double[] arr = minimallyInitializedArray!(double[])(100);
     assert(arr.length == 100);
 
@@ -1759,7 +1759,7 @@ if (isInputRange!RoR &&
             foreach (e; r)
                 emplaceRef(result[len++], e);
         assert(len == result.length);
-        return (() @trusted => cast(RetType)result)();
+        return (() @trusted => cast(RetType) result)();
     }
     else
     {
@@ -2113,7 +2113,7 @@ if (isInputRange!Range &&
             copy(stuff, retval[from .. from + stuff.length]);
 
         retval[from + stuff.length .. $] = subject[to .. $];
-        return cast(T[])retval;
+        return cast(T[]) retval;
     }
     else
     {
@@ -2683,7 +2683,7 @@ if (isDynamicArray!A)
     {
         // initialize to a given array.
         _data = new Data;
-        _data.arr = cast(Unqual!T[])arr; //trusted
+        _data.arr = cast(Unqual!T[]) arr; //trusted
 
         if (__ctfe)
             return;
@@ -2799,7 +2799,7 @@ if (isDynamicArray!A)
             import core.stdc.string : memcpy;
             if (len)
                 memcpy(bi.base, _data.arr.ptr, len * T.sizeof);
-            _data.arr = (cast(Unqual!T*)bi.base)[0 .. len];
+            _data.arr = (cast(Unqual!T*) bi.base)[0 .. len];
             _data.canExtend = true;
             // leave the old data, for safety reasons
         }
@@ -2848,7 +2848,7 @@ if (isDynamicArray!A)
             immutable len = _data.arr.length;
 
             auto bigData = (() @trusted => _data.arr.ptr[0 .. len + 1])();
-            emplaceRef!(Unqual!T)(bigData[len], cast(Unqual!T)item);
+            emplaceRef!(Unqual!T)(bigData[len], cast(Unqual!T) item);
             //We do this at the end, in case of exceptions
             _data.arr = bigData;
         }
@@ -3232,8 +3232,8 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     {
         auto w = appender!string();
         w.reserve(4);
-        cast(void)w.capacity;
-        cast(void)w.data;
+        cast(void) w.capacity;
+        cast(void) w.data;
         try
         {
             wchar wc = 'a';
@@ -3246,8 +3246,8 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     {
         auto w = appender!(int[])();
         w.reserve(4);
-        cast(void)w.capacity;
-        cast(void)w.data;
+        cast(void) w.capacity;
+        cast(void) w.data;
         w.put(10);
         w.put([10]);
         w.clear();

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -511,7 +511,7 @@ if (is(C : dchar))
     else
         alias R = Unqual!OC;
 
-    return isUpper(c) ? cast(R)(cast(R)c + 'a' - 'A') : cast(R)c;
+    return isUpper(c) ? cast(R)(cast(R) c + 'a' - 'A') : cast(R) c;
 }
 
 ///
@@ -531,7 +531,7 @@ if (is(C : dchar))
     foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; uppercase)
-            assert(toLower(cast(C)c) == lowercase[i]);
+            assert(toLower(cast(C) c) == lowercase[i]);
 
         foreach (C c; 0 .. 128)
         {
@@ -573,7 +573,7 @@ if (is(C : dchar))
     else
         alias R = Unqual!OC;
 
-    return isLower(c) ? cast(R)(cast(R)c - ('a' - 'A')) : cast(R)c;
+    return isLower(c) ? cast(R)(cast(R) c - ('a' - 'A')) : cast(R) c;
 }
 
 ///
@@ -592,7 +592,7 @@ if (is(C : dchar))
     foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; lowercase)
-            assert(toUpper(cast(C)c) == uppercase[i]);
+            assert(toUpper(cast(C) c) == uppercase[i]);
 
         foreach (C c; 0 .. 128)
         {

--- a/std/base64.d
+++ b/std/base64.d
@@ -1717,7 +1717,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         if (chr > 0x7f)
             throw new Base64Exception("Base64-encoded character must be a single byte");
 
-        return decodeChar(cast(char)chr);
+        return decodeChar(cast(char) chr);
     }
 }
 
@@ -1985,17 +1985,17 @@ class Base64Exception : Exception
 
         foreach (u, e; tests)
         {
-            assert(equal(Base64.encoder(cast(ubyte[])u), e[0]));
-            assert(equal(Base64.decoder(Base64.encoder(cast(ubyte[])u)), u));
+            assert(equal(Base64.encoder(cast(ubyte[]) u), e[0]));
+            assert(equal(Base64.decoder(Base64.encoder(cast(ubyte[]) u)), u));
 
-            assert(equal(Base64URL.encoder(cast(ubyte[])u), e[1]));
-            assert(equal(Base64URL.decoder(Base64URL.encoder(cast(ubyte[])u)), u));
+            assert(equal(Base64URL.encoder(cast(ubyte[]) u), e[1]));
+            assert(equal(Base64URL.decoder(Base64URL.encoder(cast(ubyte[]) u)), u));
 
-            assert(equal(Base64NoPadding.encoder(cast(ubyte[])u), e[2]));
-            assert(equal(Base64NoPadding.decoder(Base64NoPadding.encoder(cast(ubyte[])u)), u));
+            assert(equal(Base64NoPadding.encoder(cast(ubyte[]) u), e[2]));
+            assert(equal(Base64NoPadding.decoder(Base64NoPadding.encoder(cast(ubyte[]) u)), u));
 
-            assert(equal(Base64Re.encoder(cast(ubyte[])u), e[3]));
-            assert(equal(Base64Re.decoder(Base64Re.encoder(cast(ubyte[])u)), u));
+            assert(equal(Base64Re.encoder(cast(ubyte[]) u), e[3]));
+            assert(equal(Base64Re.decoder(Base64Re.encoder(cast(ubyte[]) u)), u));
         }
     }
 }

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -175,7 +175,7 @@ public:
     /// Assignment from built-in integer types.
     BigInt opAssign(T)(T x) pure nothrow if (isIntegral!T)
     {
-        data = cast(ulong)absUnsign(x);
+        data = cast(ulong) absUnsign(x);
         sign = (x < 0);
         return this;
     }
@@ -241,7 +241,7 @@ public:
             assert(y!=0, "Division by zero");
             static if (T.sizeof <= uint.sizeof)
             {
-                data = BigUint.divInt(data, cast(uint)u);
+                data = BigUint.divInt(data, cast(uint) u);
             }
             else
             {
@@ -258,7 +258,7 @@ public:
             }
             else
             {
-                data = cast(ulong)BigUint.modInt(data, cast(uint)u);
+                data = cast(ulong) BigUint.modInt(data, cast(uint) u);
                 if (data.isZero())
                     sign = false;
             }
@@ -596,7 +596,7 @@ public:
     {
         if (sign != (y<0))
             return 0;
-        return data.opEquals(cast(ulong)absUnsign(y));
+        return data.opEquals(cast(ulong) absUnsign(y));
     }
 
     ///
@@ -653,7 +653,7 @@ public:
             if (isUnsigned!T || !sign)
             {
                 if (l <= T.max)
-                    return cast(T)l;
+                    return cast(T) l;
             }
             else
             {
@@ -755,7 +755,7 @@ public:
     {
         if (sign != (y<0) )
             return sign ? -1 : 1;
-        int cmp = data.opCmp(cast(ulong)absUnsign(y));
+        int cmp = data.opCmp(cast(ulong) absUnsign(y));
         return sign? -cmp: cmp;
     }
     /// ditto
@@ -1504,7 +1504,7 @@ unittest
             T2 t2 = t1;
 
             T2 t2_1 = to!T2(t1);
-            T2 t2_2 = cast(T2)t1;
+            T2 t2_2 = cast(T2) t1;
 
             assert(t2 == t1);
             assert(t2 == 2);
@@ -1648,7 +1648,7 @@ unittest
     assert(x.isZero());
 
     x = BigInt(-3);
-    x %= cast(ushort)3;
+    x %= cast(ushort) 3;
     assert(!x.isNegative());
     assert(x.isZero());
 

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -38,7 +38,7 @@ private string myToString(ulong n)
     import core.internal.string : UnsignedStringBuf, unsignedToTempString;
     UnsignedStringBuf buf;
     auto s = unsignedToTempString(n, buf);
-    return cast(string)s ~ (n > uint.max ? "UL" : "U");
+    return cast(string) s ~ (n > uint.max ? "UL" : "U");
 }
 
 private template createAccessors(
@@ -1247,7 +1247,7 @@ public:
         foreach (i; 0 .. fullBytes)
         {
             hash *= 3559;
-            hash += (cast(byte*)this._ptr)[i];
+            hash += (cast(byte*) this._ptr)[i];
         }
         foreach (i; 8*fullBytes .. _len)
         {
@@ -1292,7 +1292,7 @@ public:
     }
     body
     {
-        _ptr = cast(size_t*)v.ptr;
+        _ptr = cast(size_t*) v.ptr;
         _len = numbits;
         if (endBits)
         {
@@ -1310,7 +1310,7 @@ public:
         auto a = BitArray(ba);
         void[] v;
 
-        v = cast(void[])a;
+        v = cast(void[]) a;
         auto b = BitArray(v, a.length);
 
         assert(b[0] == 1);
@@ -1348,7 +1348,7 @@ public:
         static bool[] ba = [1,0,1,0,1];
 
         auto a = BitArray(ba);
-        void[] v = cast(void[])a;
+        void[] v = cast(void[]) a;
 
         assert(v.length == a.dim * size_t.sizeof);
     }
@@ -2153,11 +2153,11 @@ if (isIntegral!T || isSomeChar!T || isBoolean!T)
     else static if (isUnsigned!T)
         return swapEndianImpl(val);
     else static if (isIntegral!T)
-        return cast(T)swapEndianImpl(cast(Unsigned!T) val);
+        return cast(T) swapEndianImpl(cast(Unsigned!T) val);
     else static if (is(Unqual!T == wchar))
-        return cast(T)swapEndian(cast(ushort)val);
+        return cast(T) swapEndian(cast(ushort) val);
     else static if (is(Unqual!T == dchar))
-        return cast(T)swapEndian(cast(uint)val);
+        return cast(T) swapEndian(cast(uint) val);
     else
         static assert(0, T.stringof ~ " unsupported by swapEndian.");
 }
@@ -2177,7 +2177,7 @@ private uint swapEndianImpl(uint val) @trusted pure nothrow @nogc
 private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
 {
     import core.bitop : bswap;
-    immutable ulong res = bswap(cast(uint)val);
+    immutable ulong res = bswap(cast(uint) val);
     return res << 32 | bswap(cast(uint)(val >> 32));
 }
 
@@ -2209,7 +2209,7 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
         }
 
         static if (isSigned!T)
-            assert(swapEndian(swapEndian(cast(T)0)) == 0);
+            assert(swapEndian(swapEndian(cast(T) 0)) == 0);
 
         // used to trigger BUG6354
         static if (T.sizeof > 1 && isUnsigned!T)
@@ -2326,7 +2326,7 @@ if (isFloatOrDouble!T)
         assert(bigEndianToNative!T(nativeToBigEndian(T.max)) == T.max);
 
         static if (isSigned!T)
-            assert(bigEndianToNative!T(nativeToBigEndian(cast(T)0)) == 0);
+            assert(bigEndianToNative!T(nativeToBigEndian(cast(T) 0)) == 0);
 
         static if (!is(T == bool))
         {
@@ -2491,7 +2491,7 @@ if (isFloatOrDouble!T)
         assert(littleEndianToNative!T(nativeToLittleEndian(T.max)) == T.max);
 
         static if (isSigned!T)
-            assert(littleEndianToNative!T(nativeToLittleEndian(cast(T)0)) == 0);
+            assert(littleEndianToNative!T(nativeToLittleEndian(cast(T) 0)) == 0);
 
         static if (!is(T == bool))
         {
@@ -3736,7 +3736,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
         size_t length = 0;
         foreach (T; Types)
         {
-            toWrite.append!(T, endianness)(cast(T)values[index++]);
+            toWrite.append!(T, endianness)(cast(T) values[index++]);
             length += T.sizeof;
         }
 
@@ -3802,7 +3802,7 @@ if (isIntegral!T)
     {
         static assert(false, "countBitsSet only supports 1, 2, 4, or 8 byte sized integers.");
     }
-    return cast(uint)c;
+    return cast(uint) c;
 }
 
 @safe unittest
@@ -3818,13 +3818,13 @@ if (isIntegral!T)
     import std.meta;
     foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
-        assert(countBitsSet(cast(T)0) == 0);
-        assert(countBitsSet(cast(T)1) == 1);
-        assert(countBitsSet(cast(T)2) == 1);
-        assert(countBitsSet(cast(T)3) == 2);
-        assert(countBitsSet(cast(T)4) == 1);
-        assert(countBitsSet(cast(T)5) == 2);
-        assert(countBitsSet(cast(T)127) == 7);
+        assert(countBitsSet(cast(T) 0) == 0);
+        assert(countBitsSet(cast(T) 1) == 1);
+        assert(countBitsSet(cast(T) 2) == 1);
+        assert(countBitsSet(cast(T) 3) == 2);
+        assert(countBitsSet(cast(T) 4) == 1);
+        assert(countBitsSet(cast(T) 5) == 2);
+        assert(countBitsSet(cast(T) 127) == 7);
         static if (isSigned!T)
         {
             assert(countBitsSet(cast(T)-1) == 8 * T.sizeof);
@@ -3929,13 +3929,13 @@ if (isIntegral!T)
     import std.meta;
     foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
-        assert(bitsSet(cast(T)0).empty);
-        assert(bitsSet(cast(T)1).equal([0]));
-        assert(bitsSet(cast(T)2).equal([1]));
-        assert(bitsSet(cast(T)3).equal([0, 1]));
-        assert(bitsSet(cast(T)4).equal([2]));
-        assert(bitsSet(cast(T)5).equal([0, 2]));
-        assert(bitsSet(cast(T)127).equal(iota(7)));
+        assert(bitsSet(cast(T) 0).empty);
+        assert(bitsSet(cast(T) 1).equal([0]));
+        assert(bitsSet(cast(T) 2).equal([1]));
+        assert(bitsSet(cast(T) 3).equal([0, 1]));
+        assert(bitsSet(cast(T) 4).equal([2]));
+        assert(bitsSet(cast(T) 5).equal([0, 2]));
+        assert(bitsSet(cast(T) 127).equal(iota(7)));
         static if (isSigned!T)
         {
             assert(bitsSet(cast(T)-1).equal(iota(8 * T.sizeof)));

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -335,7 +335,7 @@ public:
     void toString(scope void delegate(const(char)[]) sink)
     {
         import std.format : formattedWrite;
-        formattedWrite(sink, "Tid(%x)", cast(void*)mbox);
+        formattedWrite(sink, "Tid(%x)", cast(void*) mbox);
     }
 
 }
@@ -567,16 +567,16 @@ if ( isSpawnable!(F, T) )
     static assert(!__traits(compiles, spawn(dg6, 6)));
 
     auto callable1  = new class{ void opCall(int) shared {} };
-    auto callable2  = cast(shared)new class{ void opCall(int) shared {} };
+    auto callable2  = cast(shared) new class{ void opCall(int) shared {} };
     auto callable3  = new class{ void opCall(int) immutable {} };
-    auto callable4  = cast(immutable)new class{ void opCall(int) immutable {} };
+    auto callable4  = cast(immutable) new class{ void opCall(int) immutable {} };
     auto callable5  = new class{ void opCall(int) {} };
-    auto callable6  = cast(shared)new class{ void opCall(int) immutable {} };
-    auto callable7  = cast(immutable)new class{ void opCall(int) shared {} };
-    auto callable8  = cast(shared)new class{ void opCall(int) const shared {} };
-    auto callable9  = cast(const shared)new class{ void opCall(int) shared {} };
-    auto callable10 = cast(const shared)new class{ void opCall(int) const shared {} };
-    auto callable11 = cast(immutable)new class{ void opCall(int) const shared {} };
+    auto callable6  = cast(shared) new class{ void opCall(int) immutable {} };
+    auto callable7  = cast(immutable) new class{ void opCall(int) shared {} };
+    auto callable8  = cast(shared) new class{ void opCall(int) const shared {} };
+    auto callable9  = cast(const shared) new class{ void opCall(int) shared {} };
+    auto callable10 = cast(const shared) new class{ void opCall(int) const shared {} };
+    auto callable11 = cast(immutable) new class{ void opCall(int) const shared {} };
     static assert(!__traits(compiles, spawn(callable1,  1)));
     static assert( __traits(compiles, spawn(callable2,  2)));
     static assert(!__traits(compiles, spawn(callable3,  3)));
@@ -2389,7 +2389,7 @@ private
 
                 if (sm_head)
                 {
-                    n = cast(Node*)sm_head;
+                    n = cast(Node*) sm_head;
                     sm_head = sm_head.next;
                 }
             }
@@ -2518,7 +2518,7 @@ private @property Mutex initOnceLock()
     if (auto mtx = atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock))
         return mtx;
     auto mtx = new Mutex;
-    if (cas(cast(shared)&lock, cast(shared)null, cast(shared)mtx))
+    if (cas(cast(shared)&lock, cast(shared) null, cast(shared) mtx))
         return mtx;
     return atomicLoad!(MemoryOrder.acq)(*cast(shared)&lock);
 }

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1755,7 +1755,7 @@ if (is(Unqual!T == bool))
     @property bool back()
     {
         enforce(!empty);
-        return cast(bool)(data.back & (cast(size_t)1 << ((_store._length - 1) % bitsPerWord)));
+        return cast(bool)(data.back & (cast(size_t) 1 << ((_store._length - 1) % bitsPerWord)));
     }
 
     /// Ditto
@@ -1764,12 +1764,12 @@ if (is(Unqual!T == bool))
         enforce(!empty);
         if (value)
         {
-            data.back |= (cast(size_t)1 << ((_store._length - 1) % bitsPerWord));
+            data.back |= (cast(size_t) 1 << ((_store._length - 1) % bitsPerWord));
         }
         else
         {
             data.back &=
-                ~(cast(size_t)1 << ((_store._length - 1) % bitsPerWord));
+                ~(cast(size_t) 1 << ((_store._length - 1) % bitsPerWord));
         }
     }
 
@@ -1790,7 +1790,7 @@ if (is(Unqual!T == bool))
         auto div = cast(size_t) (i / bitsPerWord);
         auto rem = i % bitsPerWord;
         enforce(div < data.length);
-        return cast(bool)(data.ptr[div] & (cast(size_t)1 << rem));
+        return cast(bool)(data.ptr[div] & (cast(size_t) 1 << rem));
     }
     /// ditto
     void opIndexAssign(bool value, size_t i)
@@ -1798,8 +1798,8 @@ if (is(Unqual!T == bool))
         auto div = cast(size_t) (i / bitsPerWord);
         auto rem = i % bitsPerWord;
         enforce(div < data.length);
-        if (value) data.ptr[div] |= (cast(size_t)1 << rem);
-        else data.ptr[div] &= ~(cast(size_t)1 << rem);
+        if (value) data.ptr[div] |= (cast(size_t) 1 << rem);
+        else data.ptr[div] &= ~(cast(size_t) 1 << rem);
     }
     /// ditto
     void opIndexOpAssign(string op)(bool value, size_t i)
@@ -1807,14 +1807,14 @@ if (is(Unqual!T == bool))
         auto div = cast(size_t) (i / bitsPerWord);
         auto rem = i % bitsPerWord;
         enforce(div < data.length);
-        auto oldValue = cast(bool) (data.ptr[div] & (cast(size_t)1 << rem));
+        auto oldValue = cast(bool) (data.ptr[div] & (cast(size_t) 1 << rem));
         // Do the deed
         auto newValue = mixin("oldValue "~op~" value");
         // Write back the value
         if (newValue != oldValue)
         {
-            if (newValue) data.ptr[div] |= (cast(size_t)1 << rem);
-            else data.ptr[div] &= ~(cast(size_t)1 << rem);
+            if (newValue) data.ptr[div] |= (cast(size_t) 1 << rem);
+            else data.ptr[div] &= ~(cast(size_t) 1 << rem);
         }
     }
     /// Ditto
@@ -2018,11 +2018,11 @@ if (is(Unqual!T == bool))
             // Fits within the current array
             if (stuff)
             {
-                data[$ - 1] |= (cast(size_t)1 << rem);
+                data[$ - 1] |= (cast(size_t) 1 << rem);
             }
             else
             {
-                data[$ - 1] &= ~(cast(size_t)1 << rem);
+                data[$ - 1] &= ~(cast(size_t) 1 << rem);
             }
         }
         else

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -995,7 +995,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         auto ts2 = ts.dup;
         assert(ts2.length == 5);
         assert(equal(ts[], ts2[]));
-        ts2.insert(cast(Elem)6);
+        ts2.insert(cast(Elem) 6);
         assert(!equal(ts[], ts2[]));
         assert(ts.length == 5 && ts2.length == 6);
     }
@@ -1056,8 +1056,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
     static if (doUnittest) @safe pure unittest
     {
         auto ts = new RedBlackTree(1, 2, 3, 4, 5);
-        assert(cast(Elem)3 in ts);
-        assert(cast(Elem)6 !in ts);
+        assert(cast(Elem) 3 in ts);
+        assert(cast(Elem) 6 !in ts);
     }
 
     /**
@@ -1069,7 +1069,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
     {
         import std.algorithm.comparison : equal;
 
-        RedBlackTree that = cast(RedBlackTree)rhs;
+        RedBlackTree that = cast(RedBlackTree) rhs;
         if (that is null) return false;
 
         // If there aren't the same number of nodes, we can't be equal.
@@ -1178,8 +1178,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
             assert(ts.length == 7);
             assert(ts.stableInsert(cast(Elem[])[7, 8, 6, 9, 10, 8]) == 6);
             assert(ts.length == 13);
-            assert(ts.stableInsert(cast(Elem)11) == 1 && ts.length == 14);
-            assert(ts.stableInsert(cast(Elem)7) == 1 && ts.length == 15);
+            assert(ts.stableInsert(cast(Elem) 11) == 1 && ts.length == 14);
+            assert(ts.stableInsert(cast(Elem) 7) == 1 && ts.length == 15);
 
             static if (less == "a < b")
                 assert(ts.arrayEqual([1,2,2,3,4,5,5,6,7,7,8,8,9,10,11]));
@@ -1191,8 +1191,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
             assert(ts.length == 5);
             assert(ts.stableInsert(cast(Elem[])[7, 8, 6, 9, 10, 8]) == 5);
             assert(ts.length == 10);
-            assert(ts.stableInsert(cast(Elem)11) == 1 && ts.length == 11);
-            assert(ts.stableInsert(cast(Elem)7) == 0 && ts.length == 11);
+            assert(ts.stableInsert(cast(Elem) 11) == 1 && ts.length == 11);
+            assert(ts.stableInsert(cast(Elem) 7) == 0 && ts.length == 11);
 
             static if (less == "a < b")
                 assert(ts.arrayEqual([1,2,3,4,5,6,7,8,9,10,11]));
@@ -1457,10 +1457,10 @@ assert(equal(rbt[], [5]));
         static if (allowDuplicates)
         {
             assert(rbt.length == 11);
-            assert(rbt.removeKey(cast(Elem)4) == 1 && rbt.length == 10);
+            assert(rbt.removeKey(cast(Elem) 4) == 1 && rbt.length == 10);
             assert(rbt.arrayEqual([1,2,2,3,5,6,7,7,19,45]) && rbt.length == 10);
 
-            assert(rbt.removeKey(cast(Elem)6, cast(Elem)2, cast(Elem)1) == 3);
+            assert(rbt.removeKey(cast(Elem) 6, cast(Elem) 2, cast(Elem) 1) == 3);
             assert(rbt.arrayEqual([2,3,5,7,7,19,45]) && rbt.length == 7);
 
             assert(rbt.removeKey(cast(Elem)(42)) == 0 && rbt.length == 7);
@@ -1474,10 +1474,10 @@ assert(equal(rbt[], [5]));
         else
         {
             assert(rbt.length == 9);
-            assert(rbt.removeKey(cast(Elem)4) == 1 && rbt.length == 8);
+            assert(rbt.removeKey(cast(Elem) 4) == 1 && rbt.length == 8);
             assert(rbt.arrayEqual([1,2,3,5,6,7,19,45]));
 
-            assert(rbt.removeKey(cast(Elem)6, cast(Elem)2, cast(Elem)1) == 3);
+            assert(rbt.removeKey(cast(Elem) 6, cast(Elem) 2, cast(Elem) 1) == 3);
             assert(rbt.arrayEqual([3,5,7,19,45]) && rbt.length == 5);
 
             assert(rbt.removeKey(cast(Elem)(42)) == 0 && rbt.length == 5);
@@ -1790,11 +1790,11 @@ assert(equal(rbt[], [5]));
         assert(equal(rbt[], [1, 2, 4, 12, 27, 500]));
         assert(rbt.removeKey(1u) == 1);
         assert(equal(rbt[], [2, 4, 12, 27, 500]));
-        assert(rbt.removeKey(cast(byte)1) == 0);
+        assert(rbt.removeKey(cast(byte) 1) == 0);
         assert(equal(rbt[], [2, 4, 12, 27, 500]));
-        assert(rbt.removeKey(1, 12u, cast(byte)27) == 2);
+        assert(rbt.removeKey(1, 12u, cast(byte) 27) == 2);
         assert(equal(rbt[], [2, 4, 500]));
-        assert(rbt.removeKey([cast(short)0, cast(short)500, cast(short)1]) == 1);
+        assert(rbt.removeKey([cast(short) 0, cast(short) 500, cast(short) 1]) == 1);
         assert(equal(rbt[], [2, 4]));
     }
 }
@@ -2054,5 +2054,5 @@ unittest
 @safe pure unittest
 {
     class C {}
-    RedBlackTree!(C, "cast(void*)a < cast(void*)b") tree;
+    RedBlackTree!(C, "cast(void*)a < cast(void*) b") tree;
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -422,7 +422,7 @@ if (isImplicitlyConvertible!(S, T) &&
     static if (isUnsignedInt!S && isSignedInt!T && S.sizeof == T.sizeof)
     {   // unsigned to signed & same size
         import std.exception : enforce;
-        enforce(value <= cast(S)T.max,
+        enforce(value <= cast(S) T.max,
                 new ConvOverflowException("Conversion positive overflow"));
     }
     else static if (isSignedInt!S && isUnsignedInt!T)
@@ -560,7 +560,7 @@ if (!isImplicitlyConvertible!(S, T) &&
             T opCast(U)() @safe pure { assert(false); }
         }
     }
-    cast(void)to!(Test.T)(Test.S());
+    cast(void) to!(Test.T)(Test.S());
 
     // make sure std.conv.to is doing the same thing as initialization
     Test.S s;
@@ -691,7 +691,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     }
 
     S.B b = new S.B();
-    S.A a = to!(S.A)(b);      // == cast(S.A)b
+    S.A a = to!(S.A)(b);      // == cast(S.A) b
                               // (do not run construction conversion like new S.A(b))
     assert(b is a);
 
@@ -929,7 +929,7 @@ if (!(isImplicitlyConvertible!(S, T) &&
         app.put(S.stringof);
         app.put(')');
         FormatSpec!char f;
-        formatValue(app, cast(OriginalType!S)value, f);
+        formatValue(app, cast(OriginalType!S) value, f);
         return app.data;
     }
     else
@@ -1189,7 +1189,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     }
 
     // Test an value not corresponding to an enum member.
-    auto o = cast(EU)5;
+    auto o = cast(EU) 5;
     assert(to! string(o) == "cast(EU)5"c);
     assert(to!wstring(o) == "cast(EU)5"w);
     assert(to!dstring(o) == "cast(EU)5"d);
@@ -1254,11 +1254,11 @@ body
             div = cast(S)(mValue / runtimeRadix );
             mod = cast(ubyte)(mValue % runtimeRadix);
             mod += mod < 10 ? '0' : baseChar - 10;
-            buffer[--index] = cast(char)mod;
+            buffer[--index] = cast(char) mod;
             mValue = div;
         } while (mValue);
 
-        return cast(T)buffer[index .. $].dup;
+        return cast(T) buffer[index .. $].dup;
     }
 
     import std.array : array;
@@ -1502,7 +1502,7 @@ if (isAssociativeArray!S &&
         result[to!K2(k1)] = cast(Unqual!V2) to!V2(v1);
     }
     // Cast back to original type
-    return cast(T)result;
+    return cast(T) result;
 }
 
 @safe unittest
@@ -2049,7 +2049,7 @@ if (isSomeChar!(ElementType!Source) &&
         c -= '0';
         if (c <= 9)
         {
-            Target v = cast(Target)c;
+            Target v = cast(Target) c;
 
             source.popFront();
 
@@ -2778,7 +2778,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
                 // shift one time less, do rounding, shift again
                 while ((msdec & 0xFFC0_0000_0000_0000) != 0)
                 {
-                    msdec  = ((cast(ulong)msdec) >> 1);
+                    msdec  = ((cast(ulong) msdec) >> 1);
                     e2++;
                 }
 
@@ -2788,7 +2788,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
                 {
                     auto roundUp = (msdec & 0x1);
 
-                    msdec  = ((cast(ulong)msdec) >> 1);
+                    msdec  = ((cast(ulong) msdec) >> 1);
                     e2++;
                     if (roundUp)
                     {
@@ -2984,7 +2984,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
             return 1;
 
         if (isNaN(rx))
-            return cast(bool)isNaN(ry);
+            return cast(bool) isNaN(ry);
 
         if (isNaN(ry))
             return 0;
@@ -3021,15 +3021,15 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 
     // min and max
     float f = to!float("1.17549e-38");
-    assert(feq(cast(real)f, cast(real)1.17549e-38));
-    assert(feq(cast(real)f, cast(real)float.min_normal));
+    assert(feq(cast(real) f, cast(real) 1.17549e-38));
+    assert(feq(cast(real) f, cast(real) float.min_normal));
     f = to!float("3.40282e+38");
     assert(to!string(f) == to!string(3.40282e+38));
 
     // min and max
     double d = to!double("2.22508e-308");
-    assert(feq(cast(real)d, cast(real)2.22508e-308));
-    assert(feq(cast(real)d, cast(real)double.min_normal));
+    assert(feq(cast(real) d, cast(real) 2.22508e-308));
+    assert(feq(cast(real) d, cast(real) double.min_normal));
     d = to!double("1.79769e+308");
     assert(to!string(d) == to!string(1.79769e+308));
     assert(to!string(d) == to!string(double.max));
@@ -4376,7 +4376,7 @@ if (is(T == struct) || Args.length == 1)
 private void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment, string typeName) @nogc pure nothrow
 {
     assert(chunk.length >= typeSize, "emplace: Chunk size too small.");
-    assert((cast(size_t)chunk.ptr) % typeAlignment == 0, "emplace: Chunk is not aligned.");
+    assert((cast(size_t) chunk.ptr) % typeAlignment == 0, "emplace: Chunk is not aligned.");
 }
 
 /**
@@ -5503,30 +5503,30 @@ if (isIntegral!T)
 {
     foreach (T; AliasSeq!(byte, ubyte))
     {
-        static assert(is(typeof(unsigned(cast(T)1)) == ubyte));
-        static assert(is(typeof(unsigned(cast(const T)1)) == ubyte));
-        static assert(is(typeof(unsigned(cast(immutable T)1)) == ubyte));
+        static assert(is(typeof(unsigned(cast(T) 1)) == ubyte));
+        static assert(is(typeof(unsigned(cast(const T) 1)) == ubyte));
+        static assert(is(typeof(unsigned(cast(immutable T) 1)) == ubyte));
     }
 
     foreach (T; AliasSeq!(short, ushort))
     {
-        static assert(is(typeof(unsigned(cast(T)1)) == ushort));
-        static assert(is(typeof(unsigned(cast(const T)1)) == ushort));
-        static assert(is(typeof(unsigned(cast(immutable T)1)) == ushort));
+        static assert(is(typeof(unsigned(cast(T) 1)) == ushort));
+        static assert(is(typeof(unsigned(cast(const T) 1)) == ushort));
+        static assert(is(typeof(unsigned(cast(immutable T) 1)) == ushort));
     }
 
     foreach (T; AliasSeq!(int, uint))
     {
-        static assert(is(typeof(unsigned(cast(T)1)) == uint));
-        static assert(is(typeof(unsigned(cast(const T)1)) == uint));
-        static assert(is(typeof(unsigned(cast(immutable T)1)) == uint));
+        static assert(is(typeof(unsigned(cast(T) 1)) == uint));
+        static assert(is(typeof(unsigned(cast(const T) 1)) == uint));
+        static assert(is(typeof(unsigned(cast(immutable T) 1)) == uint));
     }
 
     foreach (T; AliasSeq!(long, ulong))
     {
-        static assert(is(typeof(unsigned(cast(T)1)) == ulong));
-        static assert(is(typeof(unsigned(cast(const T)1)) == ulong));
-        static assert(is(typeof(unsigned(cast(immutable T)1)) == ulong));
+        static assert(is(typeof(unsigned(cast(T) 1)) == ulong));
+        static assert(is(typeof(unsigned(cast(const T) 1)) == ulong));
+        static assert(is(typeof(unsigned(cast(immutable T) 1)) == ulong));
     }
 }
 
@@ -5581,30 +5581,30 @@ if (isIntegral!T)
 {
     foreach (T; AliasSeq!(byte, ubyte))
     {
-        static assert(is(typeof(signed(cast(T)1)) == byte));
-        static assert(is(typeof(signed(cast(const T)1)) == byte));
-        static assert(is(typeof(signed(cast(immutable T)1)) == byte));
+        static assert(is(typeof(signed(cast(T) 1)) == byte));
+        static assert(is(typeof(signed(cast(const T) 1)) == byte));
+        static assert(is(typeof(signed(cast(immutable T) 1)) == byte));
     }
 
     foreach (T; AliasSeq!(short, ushort))
     {
-        static assert(is(typeof(signed(cast(T)1)) == short));
-        static assert(is(typeof(signed(cast(const T)1)) == short));
-        static assert(is(typeof(signed(cast(immutable T)1)) == short));
+        static assert(is(typeof(signed(cast(T) 1)) == short));
+        static assert(is(typeof(signed(cast(const T) 1)) == short));
+        static assert(is(typeof(signed(cast(immutable T) 1)) == short));
     }
 
     foreach (T; AliasSeq!(int, uint))
     {
-        static assert(is(typeof(signed(cast(T)1)) == int));
-        static assert(is(typeof(signed(cast(const T)1)) == int));
-        static assert(is(typeof(signed(cast(immutable T)1)) == int));
+        static assert(is(typeof(signed(cast(T) 1)) == int));
+        static assert(is(typeof(signed(cast(const T) 1)) == int));
+        static assert(is(typeof(signed(cast(immutable T) 1)) == int));
     }
 
     foreach (T; AliasSeq!(long, ulong))
     {
-        static assert(is(typeof(signed(cast(T)1)) == long));
-        static assert(is(typeof(signed(cast(const T)1)) == long));
-        static assert(is(typeof(signed(cast(immutable T)1)) == long));
+        static assert(is(typeof(signed(cast(T) 1)) == long));
+        static assert(is(typeof(signed(cast(const T) 1)) == long));
+        static assert(is(typeof(signed(cast(immutable T) 1)) == long));
     }
 }
 
@@ -5648,7 +5648,7 @@ template castFrom(From)
         );
 
         static assert(
-            is(typeof(cast(To)value)),
+            is(typeof(cast(To) value)),
             "can't cast from '" ~ From.stringof ~ "' to '" ~ To.stringof ~ "'"
         );
 
@@ -5930,27 +5930,27 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
                     {
                         lwr = 0;
                         upr = 1;
-                        buf[0] = cast(char)(cast(uint)value + '0');
+                        buf[0] = cast(char)(cast(uint) value + '0');
                         return;
                     }
                     value = -value;
                     neg = true;
                 }
-                auto i = cast(uint)buf.length - 1;
-                while (cast(Unsigned!UT)value >= 10)
+                auto i = cast(uint) buf.length - 1;
+                while (cast(Unsigned!UT) value >= 10)
                 {
-                    buf[i] = cast(ubyte)('0' + cast(Unsigned!UT)value % 10);
+                    buf[i] = cast(ubyte)('0' + cast(Unsigned!UT) value % 10);
                     value = unsigned(value) / 10;
                     --i;
                 }
-                buf[i] = cast(char)(cast(uint)value + '0');
+                buf[i] = cast(char)(cast(uint) value + '0');
                 if (neg)
                 {
                     buf[i - 1] = '-';
                     --i;
                 }
                 lwr = i;
-                upr = cast(uint)buf.length;
+                upr = cast(uint) buf.length;
             }
 
             @property size_t length() { return upr - lwr; }

--- a/std/csv.d
+++ b/std/csv.d
@@ -421,7 +421,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 {
     return CsvReader!(Contents,ErrorLevel,Range,
                     Unqual!(ElementType!Range),string[])
-        (input, cast(string[])null, delimiter, quote);
+        (input, cast(string[]) null, delimiter, quote);
 }
 
 // Test standard iteration over input.
@@ -745,12 +745,12 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
     auto ir = InputRange("Name,Occupation,Salary\r"d~
           "Joe,Carpenter,300000\nFred,Blacksmith,400000\r\n"d);
 
-    foreach (record; csvReader(ir, cast(string[])null))
+    foreach (record; csvReader(ir, cast(string[]) null))
         foreach (cell; record) {}
     foreach (record; csvReader!(Tuple!(string, string, int))
-            (ir,cast(string[])null)) {}
+            (ir,cast(string[]) null)) {}
     foreach (record; csvReader!(string[string])
-            (ir,cast(string[])null)) {}
+            (ir,cast(string[]) null)) {}
 }
 
 @safe unittest // const/immutable dchars
@@ -1678,7 +1678,7 @@ if (isSomeChar!Separator && isInputRange!Range
     size_t i = 0;
     foreach (data; csvReader!Data(csv)) with (data)
     {
-        int[] row = [cast(int)a, cast(int)b, cast(int)c];
+        int[] row = [cast(int) a, cast(int) b, cast(int) c];
         if (i == 0)
             assert(row == [1, 2, 3]);
         else
@@ -1692,7 +1692,7 @@ if (isSomeChar!Separator && isInputRange!Range
         auto a = data.front;    data.popFront();
         auto b = data.front;    data.popFront();
         auto c = data.front;
-        int[] row = [cast(int)a, cast(int)b, cast(int)c];
+        int[] row = [cast(int) a, cast(int) b, cast(int) c];
         if (i == 0)
             assert(row == [1, 2, 3]);
         else

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -5195,7 +5195,8 @@ public:
             immutable minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             immutable second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour,
+                                          cast(int) minute, cast(int) second));
             dateTime.roll!units(value);
             --days;
 
@@ -8091,7 +8092,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour,
+                                          cast(int) minute, cast(int) second));
             auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())
@@ -8221,7 +8223,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour,
+                                          cast(int) minute, cast(int) second));
             auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())
@@ -8355,7 +8358,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour,
+                                          cast(int) minute, cast(int) second));
             auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1068,7 +1068,7 @@ public:
      +/
     @property short year() @safe const nothrow
     {
-        return (cast(Date)this).year;
+        return (cast(Date) this).year;
     }
 
     @safe unittest
@@ -1130,7 +1130,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.year = year;
 
         immutable newDaysHNSecs = convert!("days", "hnsecs")(date.dayOfGregorianCal - 1);
@@ -1156,7 +1156,7 @@ public:
 
         foreach (st; chain(testSysTimesBC, testSysTimesAD))
         {
-            auto dt = cast(DateTime)st;
+            auto dt = cast(DateTime) st;
 
             foreach (year; chain(testYearsBC, testYearsAD))
             {
@@ -1201,7 +1201,7 @@ public:
      +/
     @property ushort yearBC() @safe const
     {
-        return (cast(Date)this).yearBC;
+        return (cast(Date) this).yearBC;
     }
 
     ///
@@ -1256,7 +1256,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.yearBC = year;
 
         immutable newDaysHNSecs = convert!("days", "hnsecs")(date.dayOfGregorianCal - 1);
@@ -1285,7 +1285,7 @@ public:
 
         foreach (st; chain(testSysTimesBC, testSysTimesAD))
         {
-            auto dt = cast(DateTime)st;
+            auto dt = cast(DateTime) st;
 
             foreach (year; testYearsBC)
             {
@@ -1337,7 +1337,7 @@ public:
      +/
     @property Month month() @safe const nothrow
     {
-        return (cast(Date)this).month;
+        return (cast(Date) this).month;
     }
 
     ///
@@ -1406,7 +1406,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.month = month;
 
         immutable newDaysHNSecs = convert!("days", "hnsecs")(date.dayOfGregorianCal - 1);
@@ -1420,13 +1420,13 @@ public:
 
         static void test(SysTime st, Month month, in SysTime expected)
         {
-            st.month = cast(Month)month;
+            st.month = cast(Month) month;
             assert(st == expected);
         }
 
         foreach (st; chain(testSysTimesBC, testSysTimesAD))
         {
-            auto dt = cast(DateTime)st;
+            auto dt = cast(DateTime) st;
 
             foreach (md; testMonthDays)
             {
@@ -1498,7 +1498,7 @@ public:
      +/
     @property ubyte day() @safe const nothrow
     {
-        return (cast(Date)this).day;
+        return (cast(Date) this).day;
     }
 
     ///
@@ -1569,7 +1569,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.day = day;
 
         immutable newDaysHNSecs = convert!("days", "hnsecs")(date.dayOfGregorianCal - 1);
@@ -1586,7 +1586,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
 
                 if (day > maxDay(dt.year, dt.month))
                     continue;
@@ -1663,7 +1663,7 @@ public:
             --days;
         }
 
-        return cast(ubyte)getUnitsFromHNSecs!"hours"(hnsecs);
+        return cast(ubyte) getUnitsFromHNSecs!"hours"(hnsecs);
     }
 
     @safe unittest
@@ -1752,7 +1752,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
                 auto expected = SysTime(DateTime(dt.year, dt.month, dt.day, hour, dt.minute, dt.second),
                                         st.fracSecs,
                                         st.timezone);
@@ -1788,7 +1788,7 @@ public:
 
         hnsecs = removeUnitsFromHNSecs!"hours"(hnsecs);
 
-        return cast(ubyte)getUnitsFromHNSecs!"minutes"(hnsecs);
+        return cast(ubyte) getUnitsFromHNSecs!"minutes"(hnsecs);
     }
 
     @safe unittest
@@ -1880,7 +1880,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
                 auto expected = SysTime(DateTime(dt.year, dt.month, dt.day, dt.hour, minute, dt.second),
                                         st.fracSecs,
                                         st.timezone);
@@ -1917,7 +1917,7 @@ public:
         hnsecs = removeUnitsFromHNSecs!"hours"(hnsecs);
         hnsecs = removeUnitsFromHNSecs!"minutes"(hnsecs);
 
-        return cast(ubyte)getUnitsFromHNSecs!"seconds"(hnsecs);
+        return cast(ubyte) getUnitsFromHNSecs!"seconds"(hnsecs);
     }
 
     @safe unittest
@@ -2011,7 +2011,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
                 auto expected = SysTime(DateTime(dt.year, dt.month, dt.day, dt.hour, dt.minute, second),
                                         st.fracSecs,
                                         st.timezone);
@@ -2157,7 +2157,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
                 auto expected = SysTime(dt, fracSec, st.timezone);
                 st.fracSecs = fracSec;
                 assert(st == expected, format("[%s] [%s]", st, expected));
@@ -2189,7 +2189,7 @@ public:
 
             hnsecs = removeUnitsFromHNSecs!"seconds"(hnsecs);
 
-            return FracSec.from!"hnsecs"(cast(int)hnsecs);
+            return FracSec.from!"hnsecs"(cast(int) hnsecs);
         }
         catch (Exception e)
             assert(0, "FracSec.from!\"hnsecs\"() threw.");
@@ -2281,7 +2281,7 @@ public:
         {
             foreach (st; chain(testSysTimesBC, testSysTimesAD))
             {
-                auto dt = cast(DateTime)st;
+                auto dt = cast(DateTime) st;
                 auto expected = SysTime(dt, fracSec, st.timezone);
                 st.fracSec = FracSec.from!"hnsecs"(fracSec.total!"hnsecs");
                 assert(st == expected, format("[%s] [%s]", st, expected));
@@ -2593,7 +2593,7 @@ public:
         assert(SysTime.fromUnixTime(-1) == SysTime(DateTime(1969, 12, 31, 23, 59, 59), UTC()));
 
         auto st = SysTime.fromUnixTime(0);
-        auto dt = cast(DateTime)st;
+        auto dt = cast(DateTime) st;
         assert(dt <= DateTime(1970, 2, 1) && dt >= DateTime(1969, 12, 31));
         assert(st.timezone is LocalTime());
 
@@ -2707,7 +2707,7 @@ public:
       +/
     tm toTM() @safe const nothrow
     {
-        auto dateTime = cast(DateTime)this;
+        auto dateTime = cast(DateTime) this;
         tm timeInfo;
 
         timeInfo.tm_sec = dateTime.second;
@@ -2723,7 +2723,7 @@ public:
         version(Posix)
         {
             import std.utf : toUTFz;
-            timeInfo.tm_gmtoff = cast(int)convert!("hnsecs", "seconds")(adjTime - _stdTime);
+            timeInfo.tm_gmtoff = cast(int) convert!("hnsecs", "seconds")(adjTime - _stdTime);
             auto zone = (timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName);
             timeInfo.tm_zone = zone.toUTFz!(char*)();
         }
@@ -2822,7 +2822,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.add!units(value, allowOverflow);
         days = date.dayOfGregorianCal - 1;
 
@@ -4032,7 +4032,7 @@ public:
             --days;
         }
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.roll!"months"(value, allowOverflow);
         days = date.dayOfGregorianCal - 1;
 
@@ -4831,7 +4831,7 @@ public:
             --gdays;
         }
 
-        auto date = Date(cast(int)gdays);
+        auto date = Date(cast(int) gdays);
         date.roll!"days"(value);
         gdays = date.dayOfGregorianCal - 1;
 
@@ -5195,7 +5195,7 @@ public:
             immutable minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             immutable second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
             dateTime.roll!units(value);
             --days;
 
@@ -6851,7 +6851,7 @@ public:
       +/
     int diffMonths(in SysTime rhs) @safe const nothrow
     {
-        return (cast(Date)this).diffMonths(cast(Date)rhs);
+        return (cast(Date) this).diffMonths(cast(Date) rhs);
     }
 
     ///
@@ -6894,7 +6894,7 @@ public:
      +/
     @property bool isLeapYear() @safe const nothrow
     {
-        return (cast(Date)this).isLeapYear;
+        return (cast(Date) this).isLeapYear;
     }
 
     @safe unittest
@@ -6932,7 +6932,7 @@ public:
       +/
     @property ushort dayOfYear() @safe const nothrow
     {
-        return (cast(Date)this).dayOfYear;
+        return (cast(Date) this).dayOfYear;
     }
 
     ///
@@ -6967,7 +6967,7 @@ public:
         immutable days = convert!("hnsecs", "days")(hnsecs);
         immutable theRest = hnsecs - convert!("days", "hnsecs")(days);
 
-        auto date = Date(cast(int)days);
+        auto date = Date(cast(int) days);
         date.dayOfYear = day;
 
         immutable newDaysHNSecs = convert!("days", "hnsecs")(date.dayOfGregorianCal - 1);
@@ -6998,10 +6998,10 @@ public:
         //which would be the 1st day of the Gregorian Calendar, not the 0th. So,
         //simply casting to days is one day off.
         if (adjustedTime > 0)
-            return cast(int)getUnitsFromHNSecs!"days"(adjustedTime) + 1;
+            return cast(int) getUnitsFromHNSecs!"days"(adjustedTime) + 1;
 
         long hnsecs = adjustedTime;
-        immutable days = cast(int)splitUnitsFromHNSecs!"days"(hnsecs);
+        immutable days = cast(int) splitUnitsFromHNSecs!"days"(hnsecs);
 
         return hnsecs == 0 ? days + 1 : days;
     }
@@ -7621,7 +7621,7 @@ public:
       +/
     @property ubyte isoWeek() @safe const nothrow
     {
-        return (cast(Date)this).isoWeek;
+        return (cast(Date) this).isoWeek;
     }
 
     @safe unittest
@@ -7644,7 +7644,7 @@ public:
         immutable hnsecs = adjTime;
         immutable days = getUnitsFromHNSecs!"days"(hnsecs);
 
-        auto date = Date(cast(int)days + 1).endOfMonth;
+        auto date = Date(cast(int) days + 1).endOfMonth;
         auto newDays = date.dayOfGregorianCal - 1;
         long theTimeHNSecs;
 
@@ -7900,26 +7900,26 @@ public:
 
     @safe unittest
     {
-        assert(cast(Date)SysTime(Date(1999, 7, 6)) == Date(1999, 7, 6));
-        assert(cast(Date)SysTime(Date(2000, 12, 31)) == Date(2000, 12, 31));
-        assert(cast(Date)SysTime(Date(2001, 1, 1)) == Date(2001, 1, 1));
+        assert(cast(Date) SysTime(Date(1999, 7, 6)) == Date(1999, 7, 6));
+        assert(cast(Date) SysTime(Date(2000, 12, 31)) == Date(2000, 12, 31));
+        assert(cast(Date) SysTime(Date(2001, 1, 1)) == Date(2001, 1, 1));
 
-        assert(cast(Date)SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == Date(1999, 7, 6));
-        assert(cast(Date)SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == Date(2000, 12, 31));
-        assert(cast(Date)SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == Date(2001, 1, 1));
+        assert(cast(Date) SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == Date(1999, 7, 6));
+        assert(cast(Date) SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == Date(2000, 12, 31));
+        assert(cast(Date) SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == Date(2001, 1, 1));
 
-        assert(cast(Date)SysTime(Date(-1999, 7, 6)) == Date(-1999, 7, 6));
-        assert(cast(Date)SysTime(Date(-2000, 12, 31)) == Date(-2000, 12, 31));
-        assert(cast(Date)SysTime(Date(-2001, 1, 1)) == Date(-2001, 1, 1));
+        assert(cast(Date) SysTime(Date(-1999, 7, 6)) == Date(-1999, 7, 6));
+        assert(cast(Date) SysTime(Date(-2000, 12, 31)) == Date(-2000, 12, 31));
+        assert(cast(Date) SysTime(Date(-2001, 1, 1)) == Date(-2001, 1, 1));
 
-        assert(cast(Date)SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == Date(-1999, 7, 6));
-        assert(cast(Date)SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == Date(-2000, 12, 31));
-        assert(cast(Date)SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == Date(-2001, 1, 1));
+        assert(cast(Date) SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == Date(-1999, 7, 6));
+        assert(cast(Date) SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == Date(-2000, 12, 31));
+        assert(cast(Date) SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == Date(-2001, 1, 1));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(Date)cst != Date.init);
-        //assert(cast(Date)ist != Date.init);
+        assert(cast(Date) cst != Date.init);
+        //assert(cast(Date) ist != Date.init);
     }
 
 
@@ -7944,7 +7944,7 @@ public:
             immutable minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             immutable second = getUnitsFromHNSecs!"seconds"(hnsecs);
 
-            return DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
+            return DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
         }
         catch (Exception e)
             assert(0, "Either DateTime's constructor or TimeOfDay's constructor threw.");
@@ -7952,33 +7952,33 @@ public:
 
     @safe unittest
     {
-        assert(cast(DateTime)SysTime(DateTime(1, 1, 6, 7, 12, 22)) == DateTime(1, 1, 6, 7, 12, 22));
-        assert(cast(DateTime)SysTime(DateTime(1, 1, 6, 7, 12, 22), msecs(22)) == DateTime(1, 1, 6, 7, 12, 22));
-        assert(cast(DateTime)SysTime(Date(1999, 7, 6)) == DateTime(1999, 7, 6, 0, 0, 0));
-        assert(cast(DateTime)SysTime(Date(2000, 12, 31)) == DateTime(2000, 12, 31, 0, 0, 0));
-        assert(cast(DateTime)SysTime(Date(2001, 1, 1)) == DateTime(2001, 1, 1, 0, 0, 0));
+        assert(cast(DateTime) SysTime(DateTime(1, 1, 6, 7, 12, 22)) == DateTime(1, 1, 6, 7, 12, 22));
+        assert(cast(DateTime) SysTime(DateTime(1, 1, 6, 7, 12, 22), msecs(22)) == DateTime(1, 1, 6, 7, 12, 22));
+        assert(cast(DateTime) SysTime(Date(1999, 7, 6)) == DateTime(1999, 7, 6, 0, 0, 0));
+        assert(cast(DateTime) SysTime(Date(2000, 12, 31)) == DateTime(2000, 12, 31, 0, 0, 0));
+        assert(cast(DateTime) SysTime(Date(2001, 1, 1)) == DateTime(2001, 1, 1, 0, 0, 0));
 
-        assert(cast(DateTime)SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == DateTime(1999, 7, 6, 12, 10, 9));
-        assert(cast(DateTime)SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == DateTime(2000, 12, 31, 13, 11, 10));
-        assert(cast(DateTime)SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == DateTime(2001, 1, 1, 14, 12, 11));
+        assert(cast(DateTime) SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == DateTime(1999, 7, 6, 12, 10, 9));
+        assert(cast(DateTime) SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == DateTime(2000, 12, 31, 13, 11, 10));
+        assert(cast(DateTime) SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == DateTime(2001, 1, 1, 14, 12, 11));
 
-        assert(cast(DateTime)SysTime(DateTime(-1, 1, 6, 7, 12, 22)) == DateTime(-1, 1, 6, 7, 12, 22));
-        assert(cast(DateTime)SysTime(DateTime(-1, 1, 6, 7, 12, 22), msecs(22)) == DateTime(-1, 1, 6, 7, 12, 22));
-        assert(cast(DateTime)SysTime(Date(-1999, 7, 6)) == DateTime(-1999, 7, 6, 0, 0, 0));
-        assert(cast(DateTime)SysTime(Date(-2000, 12, 31)) == DateTime(-2000, 12, 31, 0, 0, 0));
-        assert(cast(DateTime)SysTime(Date(-2001, 1, 1)) == DateTime(-2001, 1, 1, 0, 0, 0));
+        assert(cast(DateTime) SysTime(DateTime(-1, 1, 6, 7, 12, 22)) == DateTime(-1, 1, 6, 7, 12, 22));
+        assert(cast(DateTime) SysTime(DateTime(-1, 1, 6, 7, 12, 22), msecs(22)) == DateTime(-1, 1, 6, 7, 12, 22));
+        assert(cast(DateTime) SysTime(Date(-1999, 7, 6)) == DateTime(-1999, 7, 6, 0, 0, 0));
+        assert(cast(DateTime) SysTime(Date(-2000, 12, 31)) == DateTime(-2000, 12, 31, 0, 0, 0));
+        assert(cast(DateTime) SysTime(Date(-2001, 1, 1)) == DateTime(-2001, 1, 1, 0, 0, 0));
 
-        assert(cast(DateTime)SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == DateTime(-1999, 7, 6, 12, 10, 9));
-        assert(cast(DateTime)SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == DateTime(-2000, 12, 31, 13, 11, 10));
-        assert(cast(DateTime)SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == DateTime(-2001, 1, 1, 14, 12, 11));
+        assert(cast(DateTime) SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == DateTime(-1999, 7, 6, 12, 10, 9));
+        assert(cast(DateTime) SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == DateTime(-2000, 12, 31, 13, 11, 10));
+        assert(cast(DateTime) SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == DateTime(-2001, 1, 1, 14, 12, 11));
 
-        assert(cast(DateTime)SysTime(DateTime(2011, 1, 13, 8, 17, 2), msecs(296), LocalTime()) ==
+        assert(cast(DateTime) SysTime(DateTime(2011, 1, 13, 8, 17, 2), msecs(296), LocalTime()) ==
                DateTime(2011, 1, 13, 8, 17, 2));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(DateTime)cst != DateTime.init);
-        //assert(cast(DateTime)ist != DateTime.init);
+        assert(cast(DateTime) cst != DateTime.init);
+        //assert(cast(DateTime) ist != DateTime.init);
     }
 
 
@@ -8000,7 +8000,7 @@ public:
             immutable minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             immutable second = getUnitsFromHNSecs!"seconds"(hnsecs);
 
-            return TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second);
+            return TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second);
         }
         catch (Exception e)
             assert(0, "TimeOfDay's constructor threw.");
@@ -8008,26 +8008,26 @@ public:
 
     @safe unittest
     {
-        assert(cast(TimeOfDay)SysTime(Date(1999, 7, 6)) == TimeOfDay(0, 0, 0));
-        assert(cast(TimeOfDay)SysTime(Date(2000, 12, 31)) == TimeOfDay(0, 0, 0));
-        assert(cast(TimeOfDay)SysTime(Date(2001, 1, 1)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(1999, 7, 6)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(2000, 12, 31)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(2001, 1, 1)) == TimeOfDay(0, 0, 0));
 
-        assert(cast(TimeOfDay)SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == TimeOfDay(12, 10, 9));
-        assert(cast(TimeOfDay)SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == TimeOfDay(13, 11, 10));
-        assert(cast(TimeOfDay)SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == TimeOfDay(14, 12, 11));
+        assert(cast(TimeOfDay) SysTime(DateTime(1999, 7, 6, 12, 10, 9)) == TimeOfDay(12, 10, 9));
+        assert(cast(TimeOfDay) SysTime(DateTime(2000, 12, 31, 13, 11, 10)) == TimeOfDay(13, 11, 10));
+        assert(cast(TimeOfDay) SysTime(DateTime(2001, 1, 1, 14, 12, 11)) == TimeOfDay(14, 12, 11));
 
-        assert(cast(TimeOfDay)SysTime(Date(-1999, 7, 6)) == TimeOfDay(0, 0, 0));
-        assert(cast(TimeOfDay)SysTime(Date(-2000, 12, 31)) == TimeOfDay(0, 0, 0));
-        assert(cast(TimeOfDay)SysTime(Date(-2001, 1, 1)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(-1999, 7, 6)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(-2000, 12, 31)) == TimeOfDay(0, 0, 0));
+        assert(cast(TimeOfDay) SysTime(Date(-2001, 1, 1)) == TimeOfDay(0, 0, 0));
 
-        assert(cast(TimeOfDay)SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == TimeOfDay(12, 10, 9));
-        assert(cast(TimeOfDay)SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == TimeOfDay(13, 11, 10));
-        assert(cast(TimeOfDay)SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == TimeOfDay(14, 12, 11));
+        assert(cast(TimeOfDay) SysTime(DateTime(-1999, 7, 6, 12, 10, 9)) == TimeOfDay(12, 10, 9));
+        assert(cast(TimeOfDay) SysTime(DateTime(-2000, 12, 31, 13, 11, 10)) == TimeOfDay(13, 11, 10));
+        assert(cast(TimeOfDay) SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == TimeOfDay(14, 12, 11));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay)cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
+        assert(cast(TimeOfDay) cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
     }
 
 
@@ -8091,8 +8091,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
-            auto fracSecStr = fracSecsToISOString(cast(int)hnsecs);
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())
                 return dateTime.toISOString() ~ fracSecStr;
@@ -8177,8 +8177,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay)cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
+        assert(cast(TimeOfDay) cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
     }
 
 
@@ -8221,8 +8221,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
-            auto fracSecStr = fracSecsToISOString(cast(int)hnsecs);
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())
                 return dateTime.toISOExtString() ~ fracSecStr;
@@ -8313,8 +8313,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay)cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
+        assert(cast(TimeOfDay) cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
     }
 
     /++
@@ -8355,8 +8355,8 @@ public:
             auto minute = splitUnitsFromHNSecs!"minutes"(hnsecs);
             auto second = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-            auto dateTime = DateTime(Date(cast(int)days), TimeOfDay(cast(int)hour, cast(int)minute, cast(int)second));
-            auto fracSecStr = fracSecsToISOString(cast(int)hnsecs);
+            auto dateTime = DateTime(Date(cast(int) days), TimeOfDay(cast(int) hour, cast(int) minute, cast(int) second));
+            auto fracSecStr = fracSecsToISOString(cast(int) hnsecs);
 
             if (_timezone is LocalTime())
                 return dateTime.toSimpleString() ~ fracSecStr;
@@ -8448,8 +8448,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay)cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
+        assert(cast(TimeOfDay) cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
     }
 
 
@@ -9254,12 +9254,12 @@ public:
      +/
     this(int year, int month, int day) @safe pure
     {
-        enforceValid!"months"(cast(Month)month);
-        enforceValid!"days"(year, cast(Month)month, day);
+        enforceValid!"months"(cast(Month) month);
+        enforceValid!"days"(year, cast(Month) month, day);
 
-        _year  = cast(short)year;
-        _month = cast(Month)month;
-        _day   = cast(ubyte)day;
+        _year  = cast(short) year;
+        _month = cast(Month) month;
+        _day   = cast(ubyte) day;
     }
 
     @safe unittest
@@ -9376,7 +9376,7 @@ public:
             }
             else
             {
-                _year = cast(short)years;
+                _year = cast(short) years;
 
                 try
                     dayOfYear = day;
@@ -9440,7 +9440,7 @@ public:
             }
             else
             {
-                _year = cast(short)years;
+                _year = cast(short) years;
                 immutable newDoY = (yearIsLeapYear(_year) ? daysInLeapYear : daysInYear) + day + 1;
 
                 try
@@ -9618,7 +9618,7 @@ public:
     @property void year(int year) @safe pure
     {
         enforceValid!"days"(year, _month, _day);
-        _year = cast(short)year;
+        _year = cast(short) year;
     }
 
     ///
@@ -9775,7 +9775,7 @@ public:
     {
         enforceValid!"months"(month);
         enforceValid!"days"(_year, month, _day);
-        _month = cast(Month)month;
+        _month = cast(Month) month;
     }
 
     @safe unittest
@@ -9787,13 +9787,13 @@ public:
             assert(date == expected);
         }
 
-        assertThrown!DateTimeException(testDate(Date(1, 1, 1), cast(Month)0));
-        assertThrown!DateTimeException(testDate(Date(1, 1, 1), cast(Month)13));
-        assertThrown!DateTimeException(testDate(Date(1, 1, 29), cast(Month)2));
-        assertThrown!DateTimeException(testDate(Date(0, 1, 30), cast(Month)2));
+        assertThrown!DateTimeException(testDate(Date(1, 1, 1), cast(Month) 0));
+        assertThrown!DateTimeException(testDate(Date(1, 1, 1), cast(Month) 13));
+        assertThrown!DateTimeException(testDate(Date(1, 1, 29), cast(Month) 2));
+        assertThrown!DateTimeException(testDate(Date(0, 1, 30), cast(Month) 2));
 
-        testDate(Date(1, 1, 1), cast(Month)7, Date(1, 7, 1));
-        testDate(Date(-1, 1, 1), cast(Month)7, Date(-1, 7, 1));
+        testDate(Date(1, 1, 1), cast(Month) 7, Date(1, 7, 1));
+        testDate(Date(-1, 1, 1), cast(Month) 7, Date(-1, 7, 1));
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
@@ -9854,7 +9854,7 @@ public:
     @property void day(int day) @safe pure
     {
         enforceValid!"days"(_year, _month, day);
-        _day = cast(ubyte)day;
+        _day = cast(ubyte) day;
     }
 
     @safe unittest
@@ -10227,7 +10227,7 @@ public:
         }
 
         _year += years;
-        _month = cast(Month)newMonth;
+        _month = cast(Month) newMonth;
 
         immutable currMaxDay = maxDay(_year, _month);
         immutable overflow = _day - currMaxDay;
@@ -10237,10 +10237,10 @@ public:
             if (allowOverflow == Yes.allowDayOverflow)
             {
                 ++_month;
-                _day = cast(ubyte)overflow;
+                _day = cast(ubyte) overflow;
             }
             else
-                _day = cast(ubyte)currMaxDay;
+                _day = cast(ubyte) currMaxDay;
         }
 
         return this;
@@ -10808,7 +10808,7 @@ public:
                 newMonth -= 12;
         }
 
-        _month = cast(Month)newMonth;
+        _month = cast(Month) newMonth;
 
         immutable currMaxDay = maxDay(_year, _month);
         immutable overflow = _day - currMaxDay;
@@ -10818,10 +10818,10 @@ public:
             if (allowOverflow == Yes.allowDayOverflow)
             {
                 ++_month;
-                _day = cast(ubyte)overflow;
+                _day = cast(ubyte) overflow;
             }
             else
-                _day = cast(ubyte)currMaxDay;
+                _day = cast(ubyte) currMaxDay;
         }
 
         return this;
@@ -11400,7 +11400,7 @@ public:
         else if (newDay > limit)
             newDay -= limit;
 
-        _day = cast(ubyte)newDay;
+        _day = cast(ubyte) newDay;
         return this;
     }
 
@@ -12252,7 +12252,7 @@ public:
         {
             if (day <= lastDay[i])
             {
-                _month = cast(Month)(cast(int)Month.jan + i - 1);
+                _month = cast(Month)(cast(int) Month.jan + i - 1);
                 _day = cast(ubyte)(day - lastDay[i - 1]);
                 return;
             }
@@ -12458,7 +12458,7 @@ public:
                 }
             }
             else if (week > 0)
-                return cast(ubyte)week;
+                return cast(ubyte) week;
             else
                 return Date(_year - 1, 12, 31).isoWeek;
         }
@@ -13565,9 +13565,9 @@ public:
         enforceValid!"minutes"(minute);
         enforceValid!"seconds"(second);
 
-        _hour   = cast(ubyte)hour;
-        _minute = cast(ubyte)minute;
-        _second = cast(ubyte)second;
+        _hour   = cast(ubyte) hour;
+        _minute = cast(ubyte) minute;
+        _second = cast(ubyte) second;
     }
 
     @safe unittest
@@ -13701,7 +13701,7 @@ public:
     @property void hour(int hour) @safe pure
     {
         enforceValid!"hours"(hour);
-        _hour = cast(ubyte)hour;
+        _hour = cast(ubyte) hour;
     }
 
     @safe unittest
@@ -13752,7 +13752,7 @@ public:
     @property void minute(int minute) @safe pure
     {
         enforceValid!"minutes"(minute);
-        _minute = cast(ubyte)minute;
+        _minute = cast(ubyte) minute;
     }
 
     @safe unittest
@@ -13803,7 +13803,7 @@ public:
     @property void second(int second) @safe pure
     {
         enforceValid!"seconds"(second);
-        _second = cast(ubyte)second;
+        _second = cast(ubyte) second;
     }
 
     @safe unittest
@@ -13903,7 +13903,7 @@ public:
         else if (newVal >= 60)
             newVal -= 60;
 
-        mixin(format("_%s = cast(ubyte)newVal;", memberVarStr));
+        mixin(format("_%s = cast(ubyte) newVal;", memberVarStr));
         return this;
     }
 
@@ -14701,9 +14701,9 @@ private:
         immutable newMinutes = splitUnitsFromHNSecs!"minutes"(hnsecs);
         immutable newSeconds = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-        _hour = cast(ubyte)newHours;
-        _minute = cast(ubyte)newMinutes;
-        _second = cast(ubyte)newSeconds;
+        _hour = cast(ubyte) newHours;
+        _minute = cast(ubyte) newMinutes;
+        _second = cast(ubyte) newSeconds;
 
         return this;
     }
@@ -15410,17 +15410,17 @@ public:
             assert(dt == expected);
         }
 
-        assertThrown!DateTimeException(testDT(DateTime(Date(1, 1, 1), TimeOfDay(12, 30, 33)), cast(Month)0));
-        assertThrown!DateTimeException(testDT(DateTime(Date(1, 1, 1), TimeOfDay(12, 30, 33)), cast(Month)13));
+        assertThrown!DateTimeException(testDT(DateTime(Date(1, 1, 1), TimeOfDay(12, 30, 33)), cast(Month) 0));
+        assertThrown!DateTimeException(testDT(DateTime(Date(1, 1, 1), TimeOfDay(12, 30, 33)), cast(Month) 13));
 
         testDT(
             DateTime(Date(1, 1, 1), TimeOfDay(12, 30, 33)),
-            cast(Month)7,
+            cast(Month) 7,
             DateTime(Date(1, 7, 1), TimeOfDay(12, 30, 33))
         );
         testDT(
             DateTime(Date(-1, 1, 1), TimeOfDay(12, 30, 33)),
-            cast(Month)7,
+            cast(Month) 7,
             DateTime(Date(-1, 7, 1), TimeOfDay(12, 30, 33))
         );
 
@@ -18137,9 +18137,9 @@ private:
         immutable newMinutes = splitUnitsFromHNSecs!"minutes"(hnsecs);
         immutable newSeconds = splitUnitsFromHNSecs!"seconds"(hnsecs);
 
-        _tod._hour = cast(ubyte)newHours;
-        _tod._minute = cast(ubyte)newMinutes;
-        _tod._second = cast(ubyte)newSeconds;
+        _tod._hour = cast(ubyte) newHours;
+        _tod._minute = cast(ubyte) newMinutes;
+        _tod._second = cast(ubyte) newSeconds;
 
         return this;
     }
@@ -18365,8 +18365,8 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
         if (!_valid(begin, end))
             throw new DateTimeException("Arguments would result in an invalid Interval.");
 
-        _begin = cast(TP)begin;
-        _end = cast(TP)end;
+        _begin = cast(TP) begin;
+        _end = cast(TP) end;
     }
 
 
@@ -18388,7 +18388,7 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"days"(3)) ==
     this(D)(in TP begin, in D duration) pure
         if (__traits(compiles, begin + duration))
     {
-        _begin = cast(TP)begin;
+        _begin = cast(TP) begin;
         _end = begin + duration;
 
         if (!_valid(_begin, _end))
@@ -18402,8 +18402,8 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"days"(3)) ==
       +/
     ref Interval opAssign(const ref Interval rhs) pure nothrow
     {
-        _begin = cast(TP)rhs._begin;
-        _end = cast(TP)rhs._end;
+        _begin = cast(TP) rhs._begin;
+        _end = cast(TP) rhs._end;
         return this;
     }
 
@@ -18414,8 +18414,8 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"days"(3)) ==
       +/
     ref Interval opAssign(Interval rhs) pure nothrow
     {
-        _begin = cast(TP)rhs._begin;
-        _end = cast(TP)rhs._end;
+        _begin = cast(TP) rhs._begin;
+        _end = cast(TP) rhs._end;
         return this;
     }
 
@@ -21521,7 +21521,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     this(in TP begin) pure nothrow
     {
-        _begin = cast(TP)begin;
+        _begin = cast(TP) begin;
     }
 
 
@@ -21531,7 +21531,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     ref PosInfInterval opAssign(const ref PosInfInterval rhs) pure nothrow
     {
-        _begin = cast(TP)rhs._begin;
+        _begin = cast(TP) rhs._begin;
         return this;
     }
 
@@ -21542,7 +21542,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     ref PosInfInterval opAssign(PosInfInterval rhs) pure nothrow
     {
-        _begin = cast(TP)rhs._begin;
+        _begin = cast(TP) rhs._begin;
         return this;
     }
 
@@ -23737,7 +23737,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     this(in TP end) pure nothrow
     {
-        _end = cast(TP)end;
+        _end = cast(TP) end;
     }
 
 
@@ -23747,7 +23747,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     ref NegInfInterval opAssign(const ref NegInfInterval rhs) pure nothrow
     {
-        _end = cast(TP)rhs._end;
+        _end = cast(TP) rhs._end;
         return this;
     }
 
@@ -23758,7 +23758,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
       +/
     ref NegInfInterval opAssign(NegInfInterval rhs) pure nothrow
     {
-        _end = cast(TP)rhs._end;
+        _end = cast(TP) rhs._end;
         return this;
     }
 
@@ -25977,7 +25977,7 @@ if (isTimePoint!TP &&
 {
     TP func(in TP tp)
     {
-        TP retval = cast(TP)tp;
+        TP retval = cast(TP) tp;
         immutable days = daysToDayOfWeek(retval.dayOfWeek, dayOfWeek);
 
         static if (dir == Direction.fwd)
@@ -26083,7 +26083,7 @@ if (isTimePoint!TP &&
 
     TP func(in TP tp)
     {
-        TP retval = cast(TP)tp;
+        TP retval = cast(TP) tp;
         immutable months = monthsToMonth(retval.month, month);
 
         static if (dir == Direction.fwd)
@@ -26310,7 +26310,7 @@ if (isTimePoint!TP &&
     {
         static if (dir == Direction.fwd)
         {
-            TP retval = cast(TP)tp;
+            TP retval = cast(TP) tp;
 
             retval.add!"years"(years, allowOverflow);
             retval.add!"months"(months, allowOverflow);
@@ -26709,7 +26709,7 @@ private:
     {
         SysTime stFunc(in SysTime st)
         {
-            return cast(SysTime)st;
+            return cast(SysTime) st;
         }
 
         auto interval = Interval!SysTime(
@@ -27182,7 +27182,7 @@ private:
     {
         SysTime stFunc(in SysTime st)
         {
-            return cast(SysTime)st;
+            return cast(SysTime) st;
         }
 
         auto posInfInterval = PosInfInterval!SysTime(SysTime(DateTime(2010, 7, 4, 12, 1, 7)));
@@ -27800,8 +27800,8 @@ public:
             assert(tz.utcOffsetAt(std.stdTime) == utcOffset);
             assert(tz.utcOffsetAt(dst.stdTime) == utcOffset + dstOffset);
 
-            assert(cast(DateTime)std == stdDate);
-            assert(cast(DateTime)dst == dstDate);
+            assert(cast(DateTime) std == stdDate);
+            assert(cast(DateTime) dst == dstDate);
             assert(std == stdUTC);
 
             version(Posix)
@@ -28356,10 +28356,10 @@ public:
             {
                 try
                 {
-                    auto currYear = (cast(Date)Clock.currTime()).year;
-                    auto janOffset = SysTime(Date(currYear, 1, 4), cast(immutable)this).stdTime -
+                    auto currYear = (cast(Date) Clock.currTime()).year;
+                    auto janOffset = SysTime(Date(currYear, 1, 4), cast(immutable) this).stdTime -
                                      SysTime(Date(currYear, 1, 4), UTC()).stdTime;
-                    auto julyOffset = SysTime(Date(currYear, 7, 4), cast(immutable)this).stdTime -
+                    auto julyOffset = SysTime(Date(currYear, 7, 4), cast(immutable) this).stdTime -
                                       SysTime(Date(currYear, 7, 4), UTC()).stdTime;
 
                     return janOffset != julyOffset;
@@ -28502,11 +28502,11 @@ public:
             import core.stdc.time : localtime, tm;
             time_t unixTime = stdTimeToUnixTime(adjTime);
 
-            immutable past = unixTime - cast(time_t)convert!("days", "seconds")(1);
+            immutable past = unixTime - cast(time_t) convert!("days", "seconds")(1);
             tm* timeInfo = localtime(past < unixTime ? &past : &unixTime);
             immutable pastOffset = timeInfo.tm_gmtoff;
 
-            immutable future = unixTime + cast(time_t)convert!("days", "seconds")(1);
+            immutable future = unixTime + cast(time_t) convert!("days", "seconds")(1);
             timeInfo = localtime(future > unixTime ? &future : &unixTime);
             immutable futureOffset = timeInfo.tm_gmtoff;
 
@@ -28514,7 +28514,7 @@ public:
                 return adjTime - convert!("seconds", "hnsecs")(pastOffset);
 
             if (pastOffset < futureOffset)
-                unixTime -= cast(time_t)convert!("hours", "seconds")(1);
+                unixTime -= cast(time_t) convert!("hours", "seconds")(1);
 
             unixTime -= pastOffset;
             timeInfo = localtime(&unixTime);
@@ -30146,7 +30146,7 @@ private:
         _enforceValidTZFile(!tzFile.eof);
         tzFile.rawRead(buff);
 
-        return bigEndianToNative!T(cast(ubyte[T.sizeof])buff);
+        return bigEndianToNative!T(cast(ubyte[T.sizeof]) buff);
     }
 
     /+
@@ -30509,7 +30509,7 @@ else version(Windows)
                 scope tziVal = tzKey.getValue("TZI");
                 auto binVal = tziVal.value_BINARY;
                 assert(binVal.length == REG_TZI_FORMAT.sizeof);
-                auto tziFmt = cast(REG_TZI_FORMAT*)binVal.ptr;
+                auto tziFmt = cast(REG_TZI_FORMAT*) binVal.ptr;
 
                 TIME_ZONE_INFORMATION tzInfo;
 
@@ -30575,7 +30575,7 @@ else version(Windows)
                 if (tzInfo.DaylightDate.wMonth == 0)
                     return false;
 
-                auto utcDateTime = cast(DateTime)SysTime(stdTime, UTC());
+                auto utcDateTime = cast(DateTime) SysTime(stdTime, UTC());
 
                 //The limits of what SystemTimeToTzSpecificLocalTime will accept.
                 if (utcDateTime.year < 1601)
@@ -30616,7 +30616,7 @@ else version(Windows)
                 utcTime.wSecond = utcDateTime.second;
                 utcTime.wMilliseconds = 0;
 
-                immutable result = SystemTimeToTzSpecificLocalTime(cast(TIME_ZONE_INFORMATION*)tzInfo,
+                immutable result = SystemTimeToTzSpecificLocalTime(cast(TIME_ZONE_INFORMATION*) tzInfo,
                                                                    &utcTime,
                                                                    &otherTime);
                 assert(result);
@@ -30707,7 +30707,7 @@ else version(Windows)
                         localTime.wSecond = localDateTime.second;
                         localTime.wMilliseconds = 0;
 
-                        immutable result = TzSpecificLocalTimeToSystemTime(cast(TIME_ZONE_INFORMATION*)tzInfo,
+                        immutable result = TzSpecificLocalTimeToSystemTime(cast(TIME_ZONE_INFORMATION*) tzInfo,
                                                                            &localTime,
                                                                            &utcTime);
                         assert(result);
@@ -30730,7 +30730,7 @@ else version(Windows)
                         return false;
                     }
 
-                    auto localDateTime = cast(DateTime)SysTime(adjTime, UTC());
+                    auto localDateTime = cast(DateTime) SysTime(adjTime, UTC());
                     auto localDateTimeBefore = localDateTime - dur!"hours"(1);
                     auto localDateTimeAfter = localDateTime + dur!"hours"(1);
 
@@ -32356,7 +32356,7 @@ if (is(T == int) || is(T == long))
     {
         if (unixTime > int.max)
             return int.max;
-        return unixTime < int.min ? int.min : cast(int)unixTime;
+        return unixTime < int.min ? int.min : cast(int) unixTime;
     }
     else static assert(0, "Bug in template constraint. Only int and long allowed.");
 }
@@ -32585,7 +32585,7 @@ else version(Windows)
 
     SYSTEMTIME SysTimeToSYSTEMTIME(in SysTime sysTime) @safe
     {
-        immutable dt = cast(DateTime)sysTime;
+        immutable dt = cast(DateTime) sysTime;
 
         if (dt.year < 1601)
             throw new DateTimeException("SYSTEMTIME cannot hold dates prior to the year 1601.");
@@ -32599,7 +32599,7 @@ else version(Windows)
         st.wHour = dt.hour;
         st.wMinute = dt.minute;
         st.wSecond = dt.second;
-        st.wMilliseconds = cast(ushort)sysTime.fracSecs.total!"msecs";
+        st.wMilliseconds = cast(ushort) sysTime.fracSecs.total!"msecs";
 
         return st;
     }
@@ -32634,7 +32634,7 @@ else version(Windows)
         if (tempHNSecs > long.max - hnsecsFrom1601)
             throw new DateTimeException("The given FILETIME cannot be represented as a stdTime value.");
 
-        return cast(long)tempHNSecs + hnsecsFrom1601;
+        return cast(long) tempHNSecs + hnsecsFrom1601;
     }
 
     SysTime FILETIMEToSysTime(scope const FILETIME* ft, immutable TimeZone tz = LocalTime()) @safe
@@ -32666,7 +32666,7 @@ else version(Windows)
             throw new DateTimeException("The given stdTime value cannot be represented as a FILETIME.");
 
         ULARGE_INTEGER ul;
-        ul.QuadPart = cast(ulong)stdTime - hnsecsFrom1601;
+        ul.QuadPart = cast(ulong) stdTime - hnsecsFrom1601;
 
         FILETIME ft;
         ft.dwHighDateTime = ul.HighPart;
@@ -32714,7 +32714,7 @@ alias DosFileTime = uint;
   +/
 SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime()) @safe
 {
-    uint dt = cast(uint)dft;
+    uint dt = cast(uint) dft;
 
     if (dt == 0)
         throw new DateTimeException("Invalid DosFileTime.");
@@ -32757,7 +32757,7 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
   +/
 DosFileTime SysTimeToDosFileTime(SysTime sysTime) @safe
 {
-    auto dateTime = cast(DateTime)sysTime;
+    auto dateTime = cast(DateTime) sysTime;
 
     if (dateTime.year < 1980)
         throw new DateTimeException("DOS File Times cannot hold dates prior to 1980.");
@@ -32773,7 +32773,7 @@ DosFileTime SysTimeToDosFileTime(SysTime sysTime) @safe
     retval |= (dateTime.minute & 0x3F) << 5;
     retval |= (dateTime.second >> 1) & 0x1F;
 
-    return cast(DosFileTime)retval;
+    return cast(DosFileTime) retval;
 }
 
 @safe unittest
@@ -32855,7 +32855,7 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
     {
         static string sliceAsString(R str) @trusted
         {
-            return cast(string)str;
+            return cast(string) str;
         }
     }
     else
@@ -32865,7 +32865,7 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
         {
             size_t i = 0;
             foreach (c; str)
-                temp[i++] = cast(char)c;
+                temp[i++] = cast(char) c;
             return temp[0 .. str.length];
         }
     }
@@ -33094,10 +33094,10 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
         static auto start() { Rand3Letters retval; retval.popFront(); return retval; }
     }
 
-    foreach (cr; AliasSeq!(function(string a){return cast(char[])a;},
-                          function(string a){return cast(ubyte[])a;},
+    foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
+                          function(string a){return cast(ubyte[]) a;},
                           function(string a){return a;},
-                          function(string a){return map!(b => cast(char)b)(a.representation);}))
+                          function(string a){return map!(b => cast(char) b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
@@ -33283,9 +33283,9 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
             foreach (c; chain(iota(0, 33), ['('], iota(127, ubyte.max + 1)))
             {
                 scope(failure) writefln("c: %d", c);
-                test(format("21 Dec 2012 13:14:15 +0000%c", cast(char)c), SysTime(std1, UTC()));
-                test(format("21 Dec 2012 13:14:15 +0000%c  ", cast(char)c), SysTime(std1, UTC()));
-                test(format("21 Dec 2012 13:14:15 +0000%chello", cast(char)c), SysTime(std1, UTC()));
+                test(format("21 Dec 2012 13:14:15 +0000%c", cast(char) c), SysTime(std1, UTC()));
+                test(format("21 Dec 2012 13:14:15 +0000%c  ", cast(char) c), SysTime(std1, UTC()));
+                test(format("21 Dec 2012 13:14:15 +0000%chello", cast(char) c), SysTime(std1, UTC()));
             }
         }
 
@@ -33294,9 +33294,9 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
             foreach (c; chain(iota(33, '('), iota('(' + 1, 127)))
             {
                 scope(failure) writefln("c: %d", c);
-                testBad(format("21 Dec 2012 13:14:15 +0000%c", cast(char)c));
-                testBad(format("21 Dec 2012 13:14:15 +0000%c   ", cast(char)c));
-                testBad(format("21 Dec 2012 13:14:15 +0000%chello", cast(char)c));
+                testBad(format("21 Dec 2012 13:14:15 +0000%c", cast(char) c));
+                testBad(format("21 Dec 2012 13:14:15 +0000%c   ", cast(char) c));
+                testBad(format("21 Dec 2012 13:14:15 +0000%chello", cast(char) c));
             }
         }
 
@@ -33327,14 +33327,14 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
             auto currStr = str.dup;
             currStr[i] = 'x';
             scope(failure) writefln("failed: %s", currStr);
-            testBad(cast(string)currStr);
+            testBad(cast(string) currStr);
         }
         foreach (i; 2 .. str.length)
         {
             auto currStr = str[0 .. $ - i];
             scope(failure) writefln("failed: %s", currStr);
-            testBad(cast(string)currStr);
-            testBad((cast(string)currStr) ~ "                                    ");
+            testBad(cast(string) currStr);
+            testBad((cast(string) currStr) ~ "                                    ");
         }
     }();
 }
@@ -33360,10 +33360,10 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
     auto tooLate1 = SysTime(Date(10_000, 1, 1), UTC());
     auto tooLate2 = SysTime(DateTime(12_007, 12, 31, 12, 22, 19), UTC());
 
-    foreach (cr; AliasSeq!(function(string a){return cast(char[])a;},
-                          function(string a){return cast(ubyte[])a;},
+    foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
+                          function(string a){return cast(ubyte[]) a;},
                           function(string a){return a;},
-                          function(string a){return map!(b => cast(char)b)(a.representation);}))
+                          function(string a){return map!(b => cast(char) b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
@@ -33512,9 +33512,9 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
                 foreach (c; chain(iota(0, 33), ['('], iota(127, ubyte.max + 1)))
                 {
                     scope(failure) writefln("c: %d", c);
-                    test(format("21Dec1213:14:15+0000%c", cast(char)c), std1);
-                    test(format("21Dec1213:14:15+0000%c  ", cast(char)c), std1);
-                    test(format("21Dec1213:14:15+0000%chello", cast(char)c), std1);
+                    test(format("21Dec1213:14:15+0000%c", cast(char) c), std1);
+                    test(format("21Dec1213:14:15+0000%c  ", cast(char) c), std1);
+                    test(format("21Dec1213:14:15+0000%chello", cast(char) c), std1);
                 }
             }
 
@@ -33524,11 +33524,11 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
                 {
                     scope(failure) writefln("c: %d", c);
                     assertThrown!DateTimeException(
-                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%c", cast(char)c))));
+                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%c", cast(char) c))));
                     assertThrown!DateTimeException(
-                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%c  ", cast(char)c))));
+                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%c  ", cast(char) c))));
                     assertThrown!DateTimeException(
-                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%chello", cast(char)c))));
+                        parseRFC822DateTime(cr(format("21Dec1213:14:15+0000%chello", cast(char) c))));
                 }
             }
         }
@@ -34803,8 +34803,8 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
     import std.stdio : writeln;
     import std.string : representation;
 
-    foreach (cr; AliasSeq!(function(string a){return cast(ubyte[])a;},
-                          function(string a){return map!(b => cast(char)b)(a.representation);}))
+    foreach (cr; AliasSeq!(function(string a){return cast(ubyte[]) a;},
+                          function(string a){return map!(b => cast(char) b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
 
@@ -34953,7 +34953,7 @@ version(unittest)
 
         this(int m, short d)
         {
-            month = cast(Month)m;
+            month = cast(Month) m;
             day = d;
         }
     }

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -199,8 +199,8 @@ struct CRC32
         unittest
         {
             CRC32 dig;
-            dig.put(cast(ubyte)0); //single ubyte
-            dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+            dig.put(cast(ubyte) 0); //single ubyte
+            dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
             ubyte[10] buf;
             dig.put(buf); //buffer
         }
@@ -241,7 +241,7 @@ struct CRC32
         {
             //Simple example
             CRC32 hash;
-            hash.put(cast(ubyte)0);
+            hash.put(cast(ubyte) 0);
             ubyte[4] result = hash.finish();
         }
 
@@ -285,7 +285,7 @@ unittest
     void doSomething(T)(ref T hash)
     if (isDigest!T)
     {
-      hash.put(cast(ubyte)0);
+      hash.put(cast(ubyte) 0);
     }
     CRC32 crc;
     crc.start();
@@ -304,37 +304,37 @@ unittest
 
     CRC32 crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[])x"bd50274c");
+    assert(crc.peek() == cast(ubyte[]) x"bd50274c");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[])x"00000000");
+    assert(crc.finish() == cast(ubyte[]) x"00000000");
 
     digest = crc32Of("");
-    assert(digest == cast(ubyte[])x"00000000");
+    assert(digest == cast(ubyte[]) x"00000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc32Of("The quick brown fox jumps over the lazy dog")) == "414FA339");
 
     digest = crc32Of("a");
-    assert(digest == cast(ubyte[])x"43beb7e8");
+    assert(digest == cast(ubyte[]) x"43beb7e8");
 
     digest = crc32Of("abc");
-    assert(digest == cast(ubyte[])x"c2412435");
+    assert(digest == cast(ubyte[]) x"c2412435");
 
     digest = crc32Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"5f3f1a17");
+    assert(digest == cast(ubyte[]) x"5f3f1a17");
 
     digest = crc32Of("message digest");
-    assert(digest == cast(ubyte[])x"7f9d1520");
+    assert(digest == cast(ubyte[]) x"7f9d1520");
 
     digest = crc32Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"d2e6c21f");
+    assert(digest == cast(ubyte[]) x"d2e6c21f");
 
     digest = crc32Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"724aa97c");
+    assert(digest == cast(ubyte[]) x"724aa97c");
 
-    assert(crcHexString(cast(ubyte[4])x"c3fcd3d7") == "D7D3FCC3");
+    assert(crcHexString(cast(ubyte[4]) x"c3fcd3d7") == "D7D3FCC3");
 }
 
 /**
@@ -406,7 +406,7 @@ unittest
      //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte)0);
+      dig.put(cast(ubyte) 0);
     }
     auto crc = new CRC32Digest();
     test(crc);
@@ -422,7 +422,7 @@ unittest
 {
     //Simple example
     auto hash = new CRC32Digest();
-    hash.put(cast(ubyte)0);
+    hash.put(cast(ubyte) 0);
     ubyte[] result = hash.finish();
 }
 
@@ -432,7 +432,7 @@ unittest
     //using a supplied buffer
     ubyte[4] buf;
     auto hash = new CRC32Digest();
-    hash.put(cast(ubyte)0);
+    hash.put(cast(ubyte) 0);
     ubyte[] result = hash.finish(buf[]);
     //The result is now in result (and in buf. If you pass a buffer which is bigger than
     //necessary, result will have the correct length, but buf will still have it's original
@@ -446,48 +446,48 @@ unittest
     auto crc = new CRC32Digest();
 
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[])x"bd50274c");
+    assert(crc.peek() == cast(ubyte[]) x"bd50274c");
     crc.reset();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[])x"00000000");
+    assert(crc.finish() == cast(ubyte[]) x"00000000");
 
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = crc.finish(result[]);
-    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[])x"bd50274c");
+    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[]) x"bd50274c");
 
     debug
         assertThrown!Error(crc.finish(result[0 .. 3]));
 
     assert(crc.length == 4);
 
-    assert(crc.digest("") == cast(ubyte[])x"00000000");
+    assert(crc.digest("") == cast(ubyte[]) x"00000000");
 
-    assert(crc.digest("a") == cast(ubyte[])x"43beb7e8");
+    assert(crc.digest("a") == cast(ubyte[]) x"43beb7e8");
 
-    assert(crc.digest("abc") == cast(ubyte[])x"c2412435");
+    assert(crc.digest("abc") == cast(ubyte[]) x"c2412435");
 
     assert(crc.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[])x"5f3f1a17");
+           == cast(ubyte[]) x"5f3f1a17");
 
-    assert(crc.digest("message digest") == cast(ubyte[])x"7f9d1520");
+    assert(crc.digest("message digest") == cast(ubyte[]) x"7f9d1520");
 
     assert(crc.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[])x"bd50274c");
+           == cast(ubyte[]) x"bd50274c");
 
     assert(crc.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[])x"d2e6c21f");
+           == cast(ubyte[]) x"d2e6c21f");
 
     assert(crc.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[])x"724aa97c");
+           == cast(ubyte[]) x"724aa97c");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     auto digest = crc32Of(onemilliona);
-    assert(digest == cast(ubyte[])x"BCBF25DC");
+    assert(digest == cast(ubyte[]) x"BCBF25DC");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = crc32Of(oneMillionRange);
-    assert(digest == cast(ubyte[])x"BCBF25DC");
+    assert(digest == cast(ubyte[]) x"BCBF25DC");
 }

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -213,8 +213,8 @@ version(ExampleDigest)
              * Example:
              * ----
              * ExampleDigest dig;
-             * dig.put(cast(ubyte)0); //single ubyte
-             * dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+             * dig.put(cast(ubyte) 0); //single ubyte
+             * dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
              * ubyte[10] buf;
              * dig.put(buf); //buffer
              * ----
@@ -289,7 +289,7 @@ template isDigest(T)
         is(typeof(
         {
             T dig = void; //Can define
-            dig.put(cast(ubyte)0, cast(ubyte)0); //varags
+            dig.put(cast(ubyte) 0, cast(ubyte) 0); //varags
             dig.start(); //has start
             auto value = dig.finish(); //has finish
         }));
@@ -575,8 +575,8 @@ interface Digest
          * ----
          * void test(Digest dig)
          * {
-         *     dig.put(cast(ubyte)0); //single ubyte
-         *     dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+         *     dig.put(cast(ubyte) 0); //single ubyte
+         *     dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
          *     ubyte[10] buf;
          *     dig.put(buf); //buffer
          * }
@@ -618,7 +618,7 @@ interface Digest
         {
             this.reset();
             foreach (datum; data)
-                this.put(cast(ubyte[])datum);
+                this.put(cast(ubyte[]) datum);
             return this.finish();
         }
 }
@@ -667,8 +667,8 @@ unittest
 {
     void test(Digest dig)
     {
-        dig.put(cast(ubyte)0); //single ubyte
-        dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+        dig.put(cast(ubyte) 0); //single ubyte
+        dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
         ubyte[10] buf;
         dig.put(buf); //buffer
     }
@@ -837,7 +837,7 @@ string toHexString(LetterCase letterCase, Order order = Order.increasing)(in uby
 ref T[N] asArray(size_t N, T)(ref T[] source, string errorMsg = "")
 {
      assert(source.length >= N, errorMsg);
-     return *cast(T[N]*)source.ptr;
+     return *cast(T[N]*) source.ptr;
 }
 
 /**
@@ -911,7 +911,7 @@ if (isDigest!T) : Digest
          * import std.digest.md;
          * ubyte[16] buf;
          * auto hash = new WrapperDigest!MD5();
-         * hash.put(cast(ubyte)0);
+         * hash.put(cast(ubyte) 0);
          * auto result = hash.finish(buf[]);
          * //The result is now in result (and in buf). If you pass a buffer which is bigger than
          * //necessary, result will have the correct length, but buf will still have it's original
@@ -983,7 +983,7 @@ unittest
     import std.digest.md;
     //Simple example
     auto hash = new WrapperDigest!MD5();
-    hash.put(cast(ubyte)0);
+    hash.put(cast(ubyte) 0);
     auto result = hash.finish();
 }
 
@@ -994,7 +994,7 @@ unittest
     import std.digest.md;
     ubyte[16] buf;
     auto hash = new WrapperDigest!MD5();
-    hash.put(cast(ubyte)0);
+    hash.put(cast(ubyte) 0);
     auto result = hash.finish(buf[]);
     //The result is now in result (and in buf). If you pass a buffer which is bigger than
     //necessary, result will have the correct length, but buf will still have it's original

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -199,7 +199,7 @@ struct MD5
             }
             else
             {
-                (cast(ubyte*)x.ptr)[0 .. 64] = (cast(ubyte*)block)[0 .. 64];
+                (cast(ubyte*) x.ptr)[0 .. 64] = (cast(ubyte*) block)[0 .. 64];
             }
 
             //Round 1
@@ -294,8 +294,8 @@ struct MD5
          * Example:
          * ----
          * MD5 dig;
-         * dig.put(cast(ubyte)0); //single ubyte
-         * dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+         * dig.put(cast(ubyte) 0); //single ubyte
+         * dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
          * ubyte[10] buf;
          * dig.put(buf); //buffer
          * ----
@@ -396,7 +396,7 @@ struct MD5
             //Simple example
             MD5 hash;
             hash.start();
-            hash.put(cast(ubyte)0);
+            hash.put(cast(ubyte) 0);
             ubyte[16] result = hash.finish();
         }
 }
@@ -429,7 +429,7 @@ unittest
     void doSomething(T)(ref T hash)
     if (isDigest!T)
     {
-        hash.put(cast(ubyte)0);
+        hash.put(cast(ubyte) 0);
     }
     MD5 md5;
     md5.start();
@@ -452,44 +452,44 @@ unittest
     md5.put(cast(ubyte[])"abcdef");
     md5.start();
     md5.put(cast(ubyte[])"");
-    assert(md5.finish() == cast(ubyte[])x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.finish() == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
 
     digest = md5Of("");
-    assert(digest == cast(ubyte[])x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(digest == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
 
     digest = md5Of("a");
-    assert(digest == cast(ubyte[])x"0cc175b9c0f1b6a831c399e269772661");
+    assert(digest == cast(ubyte[]) x"0cc175b9c0f1b6a831c399e269772661");
 
     digest = md5Of("abc");
-    assert(digest == cast(ubyte[])x"900150983cd24fb0d6963f7d28e17f72");
+    assert(digest == cast(ubyte[]) x"900150983cd24fb0d6963f7d28e17f72");
 
     digest = md5Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"8215ef0796a20bcaaae116d3876c664a");
+    assert(digest == cast(ubyte[]) x"8215ef0796a20bcaaae116d3876c664a");
 
     digest = md5Of("message digest");
-    assert(digest == cast(ubyte[])x"f96b697d7cb7938d525a2f31aaf161d0");
+    assert(digest == cast(ubyte[]) x"f96b697d7cb7938d525a2f31aaf161d0");
 
     digest = md5Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[])x"c3fcd3d76192e4007dfb496cca67e13b");
+    assert(digest == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
 
     digest = md5Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"d174ab98d277d9f5a5611c2c9f419d9f");
+    assert(digest == cast(ubyte[]) x"d174ab98d277d9f5a5611c2c9f419d9f");
 
     digest = md5Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"57edf4a22be3c955ac49da2e2107b67a");
+    assert(digest == cast(ubyte[]) x"57edf4a22be3c955ac49da2e2107b67a");
 
-    assert(toHexString(cast(ubyte[16])x"c3fcd3d76192e4007dfb496cca67e13b")
+    assert(toHexString(cast(ubyte[16]) x"c3fcd3d76192e4007dfb496cca67e13b")
         == "C3FCD3D76192E4007DFB496CCA67E13B");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     digest = md5Of(onemilliona);
-    assert(digest == cast(ubyte[])x"7707D6AE4E027C70EEA2A935C2296F21");
+    assert(digest == cast(ubyte[]) x"7707D6AE4E027C70EEA2A935C2296F21");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = md5Of(oneMillionRange);
-    assert(digest == cast(ubyte[])x"7707D6AE4E027C70EEA2A935C2296F21");
+    assert(digest == cast(ubyte[]) x"7707D6AE4E027C70EEA2A935C2296F21");
 }
 
 /**
@@ -534,7 +534,7 @@ unittest
      //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte)0);
+      dig.put(cast(ubyte) 0);
     }
     auto md5 = new MD5Digest();
     test(md5);
@@ -552,12 +552,12 @@ unittest
     md5.put(cast(ubyte[])"abcdef");
     md5.reset();
     md5.put(cast(ubyte[])"");
-    assert(md5.finish() == cast(ubyte[])x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.finish() == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
 
     md5.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = md5.finish(result[]);
-    assert(result[0 .. 16] == result2 && result2 == cast(ubyte[])x"c3fcd3d76192e4007dfb496cca67e13b");
+    assert(result[0 .. 16] == result2 && result2 == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
 
     debug
     {
@@ -567,24 +567,24 @@ unittest
 
     assert(md5.length == 16);
 
-    assert(md5.digest("") == cast(ubyte[])x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.digest("") == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
 
-    assert(md5.digest("a") == cast(ubyte[])x"0cc175b9c0f1b6a831c399e269772661");
+    assert(md5.digest("a") == cast(ubyte[]) x"0cc175b9c0f1b6a831c399e269772661");
 
-    assert(md5.digest("abc") == cast(ubyte[])x"900150983cd24fb0d6963f7d28e17f72");
+    assert(md5.digest("abc") == cast(ubyte[]) x"900150983cd24fb0d6963f7d28e17f72");
 
     assert(md5.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[])x"8215ef0796a20bcaaae116d3876c664a");
+           == cast(ubyte[]) x"8215ef0796a20bcaaae116d3876c664a");
 
-    assert(md5.digest("message digest") == cast(ubyte[])x"f96b697d7cb7938d525a2f31aaf161d0");
+    assert(md5.digest("message digest") == cast(ubyte[]) x"f96b697d7cb7938d525a2f31aaf161d0");
 
     assert(md5.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[])x"c3fcd3d76192e4007dfb496cca67e13b");
+           == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
 
     assert(md5.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[])x"d174ab98d277d9f5a5611c2c9f419d9f");
+           == cast(ubyte[]) x"d174ab98d277d9f5a5611c2c9f419d9f");
 
     assert(md5.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[])x"57edf4a22be3c955ac49da2e2107b67a");
+           == cast(ubyte[]) x"57edf4a22be3c955ac49da2e2107b67a");
 }

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -244,7 +244,7 @@ struct RIPEMD160
             }
             else
             {
-                (cast(ubyte*)x.ptr)[0 .. 64] = (cast(ubyte*)block)[0 .. 64];
+                (cast(ubyte*) x.ptr)[0 .. 64] = (cast(ubyte*) block)[0 .. 64];
             }
 
             /* round 1 */
@@ -450,8 +450,8 @@ struct RIPEMD160
          * Example:
          * ----
          * RIPEMD160 dig;
-         * dig.put(cast(ubyte)0); //single ubyte
-         * dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+         * dig.put(cast(ubyte) 0); //single ubyte
+         * dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
          * ubyte[10] buf;
          * dig.put(buf); //buffer
          * ----
@@ -522,7 +522,7 @@ struct RIPEMD160
          * //Simple example
          * RIPEMD160 hash;
          * hash.start();
-         * hash.put(cast(ubyte)0);
+         * hash.put(cast(ubyte) 0);
          * ubyte[20] result = hash.finish();
          * assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
          * --------
@@ -587,7 +587,7 @@ unittest
     void doSomething(T)(ref T hash)
     if (isDigest!T)
     {
-        hash.put(cast(ubyte)0);
+        hash.put(cast(ubyte) 0);
     }
     RIPEMD160 md;
     md.start();
@@ -601,7 +601,7 @@ unittest
     //Simple example
     RIPEMD160 hash;
     hash.start();
-    hash.put(cast(ubyte)0);
+    hash.put(cast(ubyte) 0);
     ubyte[20] result = hash.finish();
     assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
@@ -621,44 +621,44 @@ unittest
     md.put(cast(ubyte[])"abcdef");
     md.start();
     md.put(cast(ubyte[])"");
-    assert(md.finish() == cast(ubyte[])x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.finish() == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     digest = ripemd160Of("");
-    assert(digest == cast(ubyte[])x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(digest == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     digest = ripemd160Of("a");
-    assert(digest == cast(ubyte[])x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
+    assert(digest == cast(ubyte[]) x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
 
     digest = ripemd160Of("abc");
-    assert(digest == cast(ubyte[])x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
+    assert(digest == cast(ubyte[]) x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
 
     digest = ripemd160Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
+    assert(digest == cast(ubyte[]) x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
 
     digest = ripemd160Of("message digest");
-    assert(digest == cast(ubyte[])x"5d0689ef49d2fae572b881b123a85ffa21595f36");
+    assert(digest == cast(ubyte[]) x"5d0689ef49d2fae572b881b123a85ffa21595f36");
 
     digest = ripemd160Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[])x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+    assert(digest == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     digest = ripemd160Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"b0e20b6e3116640286ed3a87a5713079b21f5189");
+    assert(digest == cast(ubyte[]) x"b0e20b6e3116640286ed3a87a5713079b21f5189");
 
     digest = ripemd160Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
+    assert(digest == cast(ubyte[]) x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
 
-    assert(toHexString(cast(ubyte[20])x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc")
+    assert(toHexString(cast(ubyte[20]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc")
         == "F71C27109C692C1B56BBDCEB5B9D2865B3708DBC");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     digest = ripemd160Of(onemilliona);
-    assert(digest == cast(ubyte[])x"52783243c1697bdbe16d37f97f68f08325dc1528");
+    assert(digest == cast(ubyte[]) x"52783243c1697bdbe16d37f97f68f08325dc1528");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = ripemd160Of(oneMillionRange);
-    assert(digest == cast(ubyte[])x"52783243c1697bdbe16d37f97f68f08325dc1528");
+    assert(digest == cast(ubyte[]) x"52783243c1697bdbe16d37f97f68f08325dc1528");
 }
 
 /**
@@ -703,7 +703,7 @@ unittest
     //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte)0);
+      dig.put(cast(ubyte) 0);
     }
     auto md = new RIPEMD160Digest();
     test(md);
@@ -721,12 +721,12 @@ unittest
     md.put(cast(ubyte[])"abcdef");
     md.reset();
     md.put(cast(ubyte[])"");
-    assert(md.finish() == cast(ubyte[])x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.finish() == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     md.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = md.finish(result[]);
-    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[])x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     debug
     {
@@ -736,27 +736,27 @@ unittest
 
     assert(md.length == 20);
 
-    assert(md.digest("") == cast(ubyte[])x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.digest("") == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
-    assert(md.digest("a") == cast(ubyte[])x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
+    assert(md.digest("a") == cast(ubyte[]) x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
 
-    assert(md.digest("abc") == cast(ubyte[])x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
+    assert(md.digest("abc") == cast(ubyte[]) x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
 
     assert(md.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[])x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
+           == cast(ubyte[]) x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
 
-    assert(md.digest("message digest") == cast(ubyte[])x"5d0689ef49d2fae572b881b123a85ffa21595f36");
+    assert(md.digest("message digest") == cast(ubyte[]) x"5d0689ef49d2fae572b881b123a85ffa21595f36");
 
     assert(md.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[])x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+           == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     assert(md.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[])x"b0e20b6e3116640286ed3a87a5713079b21f5189");
+           == cast(ubyte[]) x"b0e20b6e3116640286ed3a87a5713079b21f5189");
 
     assert(md.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[])x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
+           == cast(ubyte[]) x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
 
     assert(md.digest(new ubyte[160/8]) // 160 zero bits
-           == cast(ubyte[])x"5c00bd4aca04a9057c09b20b05f723f2e23deb65");
+           == cast(ubyte[]) x"5c00bd4aca04a9057c09b20b05f723f2e23deb65");
 }

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -703,7 +703,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
             auto inputLen = input.length;
 
             /* Compute number of bytes mod block size (64 or 128 bytes) */
-            index = (cast(uint)count[0] >> 3) & (blockSizeInBytes - 1);
+            index = (cast(uint) count[0] >> 3) & (blockSizeInBytes - 1);
 
             /* Update number of bits */
             static if (blockSize==512)
@@ -743,8 +743,8 @@ struct SHA(uint hashBlockSize, uint digestSize)
         unittest
         {
             typeof(this) dig;
-            dig.put(cast(ubyte)0); //single ubyte
-            dig.put(cast(ubyte)0, cast(ubyte)0); //variadic
+            dig.put(cast(ubyte) 0); //single ubyte
+            dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
             ubyte[10] buf;
             dig.put(buf); //buffer
         }
@@ -765,7 +765,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 ubyte[8] bits = nativeToBigEndian(count[0]);
 
                 /* Pad out to 56 mod 64. */
-                index = (cast(uint)count[0] >> 3) & (64 - 1);
+                index = (cast(uint) count[0] >> 3) & (64 - 1);
                 padLen = (index < 56) ? (56 - index) : (120 - index);
                 put(padding[0 .. padLen]);
 
@@ -791,7 +791,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 bits[8..16] = nativeToBigEndian(count[0]);
 
                 /* Pad out to 112 mod 128. */
-                index = (cast(uint)count[0] >> 3) & (128 - 1);
+                index = (cast(uint) count[0] >> 3) & (128 - 1);
                 padLen = (index < 112) ? (112 - index) : (240 - index);
                 put(padding[0 .. padLen]);
 
@@ -815,7 +815,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
             //Simple example
             SHA1 hash;
             hash.start();
-            hash.put(cast(ubyte)0);
+            hash.put(cast(ubyte) 0);
             ubyte[20] result = hash.finish();
         }
 }
@@ -861,7 +861,7 @@ unittest
     void doSomething(T)(ref T hash)
     if (isDigest!T)
     {
-      hash.put(cast(ubyte)0);
+      hash.put(cast(ubyte) 0);
     }
     SHA1 sha;
     sha.start();
@@ -897,45 +897,45 @@ unittest
     sha.put(cast(ubyte[])"abcdef");
     sha.start();
     sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.finish() == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
     SHA224 sha224;
     sha224.put(cast(ubyte[])"abcdef");
     sha224.start();
     sha224.put(cast(ubyte[])"");
-    assert(sha224.finish() == cast(ubyte[])x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    assert(sha224.finish() == cast(ubyte[]) x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
 
     SHA256 sha256;
     sha256.put(cast(ubyte[])"abcdef");
     sha256.start();
     sha256.put(cast(ubyte[])"");
-    assert(sha256.finish() == cast(ubyte[])x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(sha256.finish() == cast(ubyte[]) x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     SHA384 sha384;
     sha384.put(cast(ubyte[])"abcdef");
     sha384.start();
     sha384.put(cast(ubyte[])"");
-    assert(sha384.finish() == cast(ubyte[])hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
+    assert(sha384.finish() == cast(ubyte[]) hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
         ~"0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"));
 
     SHA512 sha512;
     sha512.put(cast(ubyte[])"abcdef");
     sha512.start();
     sha512.put(cast(ubyte[])"");
-    assert(sha512.finish() == cast(ubyte[])hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
+    assert(sha512.finish() == cast(ubyte[]) hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
         ~"5dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
 
     SHA512_224 sha512_224;
     sha512_224.put(cast(ubyte[])"abcdef");
     sha512_224.start();
     sha512_224.put(cast(ubyte[])"");
-    assert(sha512_224.finish() == cast(ubyte[])x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    assert(sha512_224.finish() == cast(ubyte[]) x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
 
     SHA512_256 sha512_256;
     sha512_256.put(cast(ubyte[])"abcdef");
     sha512_256.start();
     sha512_256.put(cast(ubyte[])"");
-    assert(sha512_256.finish() == cast(ubyte[])x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(sha512_256.finish() == cast(ubyte[]) x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("");
     digest224     = sha224Of    ("");
@@ -944,15 +944,15 @@ unittest
     digest512     = sha512Of    ("");
     digest512_224 = sha512_224Of("");
     digest512_256 = sha512_256Of("");
-    assert(digest == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    assert(digest224 == cast(ubyte[])x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
-    assert(digest256 == cast(ubyte[])x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    assert(digest384 == cast(ubyte[])hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
+    assert(digest == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(digest224 == cast(ubyte[]) x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    assert(digest256 == cast(ubyte[]) x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(digest384 == cast(ubyte[]) hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
         ~"0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"));
-    assert(digest512 == cast(ubyte[])hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83"
+    assert(digest512 == cast(ubyte[]) hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83"
         ~"f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
-    assert(digest512_224 == cast(ubyte[])x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
-    assert(digest512_256 == cast(ubyte[])x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(digest512_224 == cast(ubyte[]) x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    assert(digest512_256 == cast(ubyte[]) x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("a");
     digest224     = sha224Of    ("a");
@@ -961,15 +961,15 @@ unittest
     digest512     = sha512Of    ("a");
     digest512_224 = sha512_224Of("a");
     digest512_256 = sha512_256Of("a");
-    assert(digest == cast(ubyte[])x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
-    assert(digest224 == cast(ubyte[])x"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
-    assert(digest256 == cast(ubyte[])x"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
-    assert(digest384 == cast(ubyte[])hexString!("54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9"
+    assert(digest == cast(ubyte[]) x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(digest224 == cast(ubyte[]) x"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
+    assert(digest256 == cast(ubyte[]) x"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
+    assert(digest384 == cast(ubyte[]) hexString!("54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9"
         ~"cd697e85175033caa88e6d57bc35efae0b5afd3145f31"));
-    assert(digest512 == cast(ubyte[])hexString!("1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05ab"
+    assert(digest512 == cast(ubyte[]) hexString!("1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05ab"
         ~"c54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"));
-    assert(digest512_224 == cast(ubyte[])x"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
-    assert(digest512_256 == cast(ubyte[])x"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
+    assert(digest512_224 == cast(ubyte[]) x"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
+    assert(digest512_256 == cast(ubyte[]) x"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
 
     digest        = sha1Of      ("abc");
     digest224     = sha224Of    ("abc");
@@ -978,15 +978,15 @@ unittest
     digest512     = sha512Of    ("abc");
     digest512_224 = sha512_224Of("abc");
     digest512_256 = sha512_256Of("abc");
-    assert(digest == cast(ubyte[])x"a9993e364706816aba3e25717850c26c9cd0d89d");
-    assert(digest224 == cast(ubyte[])x"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
-    assert(digest256 == cast(ubyte[])x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
-    assert(digest384 == cast(ubyte[])hexString!("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
+    assert(digest == cast(ubyte[]) x"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(digest224 == cast(ubyte[]) x"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
+    assert(digest256 == cast(ubyte[]) x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    assert(digest384 == cast(ubyte[]) hexString!("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
         ~"8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"));
-    assert(digest512 == cast(ubyte[])hexString!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9"
+    assert(digest512 == cast(ubyte[]) hexString!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9"
         ~"eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"));
-    assert(digest512_224 == cast(ubyte[])x"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
-    assert(digest512_256 == cast(ubyte[])x"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
+    assert(digest512_224 == cast(ubyte[]) x"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
+    assert(digest512_256 == cast(ubyte[]) x"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
 
     digest        = sha1Of      ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest224     = sha224Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
@@ -995,15 +995,15 @@ unittest
     digest512     = sha512Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_224 = sha512_224Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_256 = sha512_256Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
-    assert(digest224 == cast(ubyte[])x"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
-    assert(digest256 == cast(ubyte[])x"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
-    assert(digest384 == cast(ubyte[])hexString!("3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe"
+    assert(digest == cast(ubyte[]) x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+    assert(digest224 == cast(ubyte[]) x"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
+    assert(digest256 == cast(ubyte[]) x"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+    assert(digest384 == cast(ubyte[]) hexString!("3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe"
         ~"8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b"));
-    assert(digest512 == cast(ubyte[])hexString!("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a827"
+    assert(digest512 == cast(ubyte[]) hexString!("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a827"
         ~"9be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"));
-    assert(digest512_224 == cast(ubyte[])x"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
-    assert(digest512_256 == cast(ubyte[])x"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
+    assert(digest512_224 == cast(ubyte[]) x"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
+    assert(digest512_256 == cast(ubyte[]) x"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
 
     digest        = sha1Of      ("message digest");
     digest224     = sha224Of    ("message digest");
@@ -1012,15 +1012,15 @@ unittest
     digest512     = sha512Of    ("message digest");
     digest512_224 = sha512_224Of("message digest");
     digest512_256 = sha512_256Of("message digest");
-    assert(digest == cast(ubyte[])x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
-    assert(digest224 == cast(ubyte[])x"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
-    assert(digest256 == cast(ubyte[])x"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
-    assert(digest384 == cast(ubyte[])hexString!("473ed35167ec1f5d8e550368a3db39be54639f828868e9454c"
+    assert(digest == cast(ubyte[]) x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(digest224 == cast(ubyte[]) x"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
+    assert(digest256 == cast(ubyte[]) x"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
+    assert(digest384 == cast(ubyte[]) hexString!("473ed35167ec1f5d8e550368a3db39be54639f828868e9454c"
         ~"239fc8b52e3c61dbd0d8b4de1390c256dcbb5d5fd99cd5"));
-    assert(digest512 == cast(ubyte[])hexString!("107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c134"
+    assert(digest512 == cast(ubyte[]) hexString!("107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c134"
         ~"92ea45b0199f3309e16455ab1e96118e8a905d5597b72038ddb372a89826046de66687bb420e7c"));
-    assert(digest512_224 == cast(ubyte[])x"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
-    assert(digest512_256 == cast(ubyte[])x"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
+    assert(digest512_224 == cast(ubyte[]) x"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
+    assert(digest512_256 == cast(ubyte[]) x"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
 
     digest        = sha1Of      ("abcdefghijklmnopqrstuvwxyz");
     digest224     = sha224Of    ("abcdefghijklmnopqrstuvwxyz");
@@ -1029,15 +1029,15 @@ unittest
     digest512     = sha512Of    ("abcdefghijklmnopqrstuvwxyz");
     digest512_224 = sha512_224Of("abcdefghijklmnopqrstuvwxyz");
     digest512_256 = sha512_256Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
-    assert(digest224 == cast(ubyte[])x"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
-    assert(digest256 == cast(ubyte[])x"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
-    assert(digest384 == cast(ubyte[])hexString!("feb67349df3db6f5924815d6c3dc133f091809213731fe5c7b5"
+    assert(digest == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(digest224 == cast(ubyte[]) x"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
+    assert(digest256 == cast(ubyte[]) x"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
+    assert(digest384 == cast(ubyte[]) hexString!("feb67349df3db6f5924815d6c3dc133f091809213731fe5c7b5"
         ~"f4999e463479ff2877f5f2936fa63bb43784b12f3ebb4"));
-    assert(digest512 == cast(ubyte[])hexString!("4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034"
+    assert(digest512 == cast(ubyte[]) hexString!("4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034"
         ~"898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"));
-    assert(digest512_224 == cast(ubyte[])x"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
-    assert(digest512_256 == cast(ubyte[])x"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
+    assert(digest512_224 == cast(ubyte[]) x"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
+    assert(digest512_256 == cast(ubyte[]) x"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
 
     digest        = sha1Of      ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest224     = sha224Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
@@ -1046,15 +1046,15 @@ unittest
     digest512     = sha512Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_224 = sha512_224Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_256 = sha512_256Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
-    assert(digest224 == cast(ubyte[])x"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
-    assert(digest256 == cast(ubyte[])x"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
-    assert(digest384 == cast(ubyte[])hexString!("1761336e3f7cbfe51deb137f026f89e01a448e3b1fafa64039"
+    assert(digest == cast(ubyte[]) x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+    assert(digest224 == cast(ubyte[]) x"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
+    assert(digest256 == cast(ubyte[]) x"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
+    assert(digest384 == cast(ubyte[]) hexString!("1761336e3f7cbfe51deb137f026f89e01a448e3b1fafa64039"
         ~"c1464ee8732f11a5341a6f41e0c202294736ed64db1a84"));
-    assert(digest512 == cast(ubyte[])hexString!("1e07be23c26a86ea37ea810c8ec7809352515a970e9253c26f"
+    assert(digest512 == cast(ubyte[]) hexString!("1e07be23c26a86ea37ea810c8ec7809352515a970e9253c26f"
         ~"536cfc7a9996c45c8370583e0a78fa4a90041d71a4ceab7423f19c71b9d5a3e01249f0bebd5894"));
-    assert(digest512_224 == cast(ubyte[])x"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
-    assert(digest512_256 == cast(ubyte[])x"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
+    assert(digest512_224 == cast(ubyte[]) x"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
+    assert(digest512_256 == cast(ubyte[]) x"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
 
     digest        = sha1Of      ("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
@@ -1070,15 +1070,15 @@ unittest
                                  "1234567890123456789012345678901234567890");
     digest512_256 = sha512_256Of("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"50abf5706a150990a08b2c5ea40fa0e585554732");
-    assert(digest224 == cast(ubyte[])x"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
-    assert(digest256 == cast(ubyte[])x"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
-    assert(digest384 == cast(ubyte[])hexString!("b12932b0627d1c060942f5447764155655bd4da0c9afa6dd9b"
+    assert(digest == cast(ubyte[]) x"50abf5706a150990a08b2c5ea40fa0e585554732");
+    assert(digest224 == cast(ubyte[]) x"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
+    assert(digest256 == cast(ubyte[]) x"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
+    assert(digest384 == cast(ubyte[]) hexString!("b12932b0627d1c060942f5447764155655bd4da0c9afa6dd9b"
         ~"9ef53129af1b8fb0195996d2de9ca0df9d821ffee67026"));
-    assert(digest512 == cast(ubyte[])hexString!("72ec1ef1124a45b047e8b7c75a932195135bb61de24ec0d191"
+    assert(digest512 == cast(ubyte[]) hexString!("72ec1ef1124a45b047e8b7c75a932195135bb61de24ec0d191"
         ~"4042246e0aec3a2354e093d76f3048b456764346900cb130d2a4fd5dd16abb5e30bcb850dee843"));
-    assert(digest512_224 == cast(ubyte[])x"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
-    assert(digest512_256 == cast(ubyte[])x"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
+    assert(digest512_224 == cast(ubyte[]) x"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
+    assert(digest512_256 == cast(ubyte[]) x"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
@@ -1089,15 +1089,15 @@ unittest
     digest512 = sha512Of(onemilliona);
     digest512_224 = sha512_224Of(onemilliona);
     digest512_256 = sha512_256Of(onemilliona);
-    assert(digest == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[])x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[])x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
-    assert(digest384 == cast(ubyte[])hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
+    assert(digest == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == cast(ubyte[]) x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == cast(ubyte[]) x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest384 == cast(ubyte[]) hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
-    assert(digest512 == cast(ubyte[])hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
+    assert(digest512 == cast(ubyte[]) hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[])x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[])x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == cast(ubyte[]) x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == cast(ubyte[]) x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = sha1Of(oneMillionRange);
@@ -1107,17 +1107,17 @@ unittest
     digest512 = sha512Of(oneMillionRange);
     digest512_224 = sha512_224Of(oneMillionRange);
     digest512_256 = sha512_256Of(oneMillionRange);
-    assert(digest == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[])x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[])x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
-    assert(digest384 == cast(ubyte[])hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
+    assert(digest == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == cast(ubyte[]) x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == cast(ubyte[]) x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest384 == cast(ubyte[]) hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
-    assert(digest512 == cast(ubyte[])hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
+    assert(digest512 == cast(ubyte[]) hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[])x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[])x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == cast(ubyte[]) x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == cast(ubyte[]) x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
-    assert(toHexString(cast(ubyte[20])x"a9993e364706816aba3e25717850c26c9cd0d89d")
+    assert(toHexString(cast(ubyte[20]) x"a9993e364706816aba3e25717850c26c9cd0d89d")
         == "A9993E364706816ABA3E25717850C26C9CD0D89D");
 }
 
@@ -1234,7 +1234,7 @@ unittest
     //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte)0);
+      dig.put(cast(ubyte) 0);
     }
     auto sha = new SHA1Digest();
     test(sha);
@@ -1252,40 +1252,40 @@ unittest
     sha.put(cast(ubyte[])"abcdef");
     sha.reset();
     sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.finish() == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
     sha.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[22] result;
     auto result2 = sha.finish(result[]);
-    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     debug
         assertThrown!Error(sha.finish(result[0 .. 15]));
 
     assert(sha.length == 20);
 
-    assert(sha.digest("") == cast(ubyte[])x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.digest("") == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
-    assert(sha.digest("a") == cast(ubyte[])x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(sha.digest("a") == cast(ubyte[]) x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
 
-    assert(sha.digest("abc") == cast(ubyte[])x"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(sha.digest("abc") == cast(ubyte[]) x"a9993e364706816aba3e25717850c26c9cd0d89d");
 
     assert(sha.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[])x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+           == cast(ubyte[]) x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
 
-    assert(sha.digest("message digest") == cast(ubyte[])x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(sha.digest("message digest") == cast(ubyte[]) x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
 
     assert(sha.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[])x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+           == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     assert(sha.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[])x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+           == cast(ubyte[]) x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
 
     assert(sha.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[])x"50abf5706a150990a08b2c5ea40fa0e585554732");
+           == cast(ubyte[]) x"50abf5706a150990a08b2c5ea40fa0e585554732");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
-    assert(sha.digest(onemilliona) == cast(ubyte[])x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(sha.digest(onemilliona) == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
 }

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -230,14 +230,14 @@ import std.internal.encodinginit;
     // Make sure everything that should be valid, is
     foreach (a;validStrings)
     {
-        string s = cast(string)a;
+        string s = cast(string) a;
         assert(isValid(s),"Failed to validate: "~makeReadable(s));
     }
 
     // Make sure everything that shouldn't be valid, isn't
     foreach (a;invalidStrings)
     {
-        string s = cast(string)a;
+        string s = cast(string) a;
         assert(!isValid(s),"Incorrectly validated: "~makeReadable(s));
     }
 
@@ -245,11 +245,11 @@ import std.internal.encodinginit;
     assert(invalidStrings.length == sanitizedStrings.length);
     for (int i=0; i<invalidStrings.length; ++i)
     {
-        string s = cast(string)invalidStrings[i];
+        string s = cast(string) invalidStrings[i];
         string t = sanitize(s);
         assert(isValid(t));
         assert(t == sanitizedStrings[i]);
-        ubyte[] u = cast(ubyte[])t;
+        ubyte[] u = cast(ubyte[]) t;
         validStrings ~= u;
     }
 
@@ -257,7 +257,7 @@ import std.internal.encodinginit;
     // and reverse iteration
     foreach (a; validStrings)
     {
-        string s = cast(string)a;
+        string s = cast(string) a;
         string s2;
         wstring ws, ws2;
         dstring ds, ds2;
@@ -334,10 +334,10 @@ import std.internal.encodinginit;
         assert(s == u);
         Latin1String v;
         transcode(s,v);
-        assert(cast(string)v == "?100");
+        assert(cast(string) v == "?100");
         AsciiString w;
         transcode(v,w);
-        assert(cast(string)w == "?100");
+        assert(cast(string) w == "?100");
         s = "\u017Dlu\u0165ou\u010Dk\u00FD k\u016F\u0148";
         Latin2String x;
         transcode(s,x);
@@ -693,14 +693,14 @@ private template GenericEncoder()
             {
                 if (bstMap[idx][0] == c)
                 {
-                    write(cast(E)bstMap[idx][1]);
+                    write(cast(E) bstMap[idx][1]);
                     return;
                 }
                 idx = bstMap[idx][0] > c ? 2 * idx + 1 : 2 * idx + 2; // next BST index
             }
             c = '?';
         }
-        write(cast(E)c);
+        write(cast(E) c);
     }
 
     void skipViaRead()()
@@ -783,7 +783,7 @@ template EncoderInstance(CharType : AsciiChar)
     void encodeViaWrite()(dchar c)
     {
         if (!canEncode(c)) c = '?';
-        write(cast(AsciiChar)c);
+        write(cast(AsciiChar) c);
     }
 
     void skipViaRead()()
@@ -860,7 +860,7 @@ template EncoderInstance(CharType : Latin1Char)
     void encodeViaWrite()(dchar c)
     {
         if (!canEncode(c)) c = '?';
-        write(cast(Latin1Char)c);
+        write(cast(Latin1Char) c);
     }
 
     void skipViaRead()()
@@ -1176,7 +1176,7 @@ template EncoderInstance(CharType : char)
     {
         if (c < 0x80)
         {
-            write(cast(char)c);
+            write(cast(char) c);
         }
         else if (c < 0x800)
         {
@@ -1317,7 +1317,7 @@ template EncoderInstance(CharType : wchar)
     {
         if (c < 0x10000)
         {
-            write(cast(wchar)c);
+            write(cast(wchar) c);
         }
         else
         {
@@ -1337,7 +1337,7 @@ template EncoderInstance(CharType : wchar)
     dchar decodeViaRead()()
     {
         wchar c = read();
-        if (c < 0xD800 || c >= 0xE000) return cast(dchar)c;
+        if (c < 0xD800 || c >= 0xE000) return cast(dchar) c;
         wchar d = read();
         c &= 0x3FF;
         d &= 0x3FF;
@@ -1347,7 +1347,7 @@ template EncoderInstance(CharType : wchar)
     dchar safeDecodeViaRead()()
     {
         wchar c = read();
-        if (c < 0xD800 || c >= 0xE000) return cast(dchar)c;
+        if (c < 0xD800 || c >= 0xE000) return cast(dchar) c;
         if (c >= 0xDC00) return INVALID_SEQUENCE;
         if (!canRead) return INVALID_SEQUENCE;
         wchar d = peek();
@@ -1361,7 +1361,7 @@ template EncoderInstance(CharType : wchar)
     dchar decodeReverseViaRead()()
     {
         wchar c = read();
-        if (c < 0xD800 || c >= 0xE000) return cast(dchar)c;
+        if (c < 0xD800 || c >= 0xE000) return cast(dchar) c;
         wchar d = read();
         c &= 0x3FF;
         d &= 0x3FF;
@@ -1422,7 +1422,7 @@ template EncoderInstance(CharType : dchar)
 
     dchar decodeViaRead()()
     {
-        return cast(dchar)read();
+        return cast(dchar) read();
     }
 
     dchar safeDecodeViaRead()()
@@ -1433,7 +1433,7 @@ template EncoderInstance(CharType : dchar)
 
     dchar decodeReverseViaRead()()
     {
-        return cast(dchar)read();
+        return cast(dchar) read();
     }
 
     @property EString replacementSequence() @safe pure nothrow @nogc
@@ -1524,7 +1524,7 @@ bool canEncode(E)(dchar c)
     assert( canEncode!(Windows1252Char)('\u20AC'));
     assert(!canEncode!(Windows1252Char)('\u20AD'));
     assert(!canEncode!(Windows1252Char)('\uFFFD'));
-    assert(!canEncode!(char)(cast(dchar)0x110000));
+    assert(!canEncode!(char)(cast(dchar) 0x110000));
 }
 
 /// How to check an entire string
@@ -1558,15 +1558,15 @@ bool isValidCodeUnit(E)(E c)
 ///
 @system pure unittest
 {
-    assert(!isValidCodeUnit(cast(char)0xC0));
-    assert(!isValidCodeUnit(cast(char)0xFF));
-    assert( isValidCodeUnit(cast(wchar)0xD800));
-    assert(!isValidCodeUnit(cast(dchar)0xD800));
-    assert(!isValidCodeUnit(cast(AsciiChar)0xA0));
-    assert( isValidCodeUnit(cast(Windows1250Char)0x80));
-    assert(!isValidCodeUnit(cast(Windows1250Char)0x81));
-    assert( isValidCodeUnit(cast(Windows1252Char)0x80));
-    assert(!isValidCodeUnit(cast(Windows1252Char)0x81));
+    assert(!isValidCodeUnit(cast(char) 0xC0));
+    assert(!isValidCodeUnit(cast(char) 0xFF));
+    assert( isValidCodeUnit(cast(wchar) 0xD800));
+    assert(!isValidCodeUnit(cast(dchar) 0xD800));
+    assert(!isValidCodeUnit(cast(AsciiChar) 0xA0));
+    assert( isValidCodeUnit(cast(Windows1250Char) 0x80));
+    assert(!isValidCodeUnit(cast(Windows1250Char) 0x81));
+    assert( isValidCodeUnit(cast(Windows1252Char) 0x80));
+    assert(!isValidCodeUnit(cast(Windows1252Char) 0x81));
 }
 
 /**
@@ -2133,7 +2133,7 @@ body
     string t;
     foreach (c;codePoints(s))
     {
-        t ~= cast(char)c;
+        t ~= cast(char) c;
     }
     assert(s == t);
 }
@@ -2244,7 +2244,7 @@ body
             EncoderInstance!(Unqual!Dst).encode(decode(s), tmpBuffer);
         }
 
-        r = cast(Dst[])buffer[0 .. buffer.length - tmpBuffer.length];
+        r = cast(Dst[]) buffer[0 .. buffer.length - tmpBuffer.length];
     }
 }
 
@@ -2387,7 +2387,7 @@ abstract class EncodingScheme
     deprecated("Please pass the EncodingScheme subclass as template argument instead.")
     static void register(string className)
     {
-        auto scheme = cast(EncodingScheme)ClassInfo.find(className).create();
+        auto scheme = cast(EncodingScheme) ClassInfo.find(className).create();
         if (scheme is null)
             throw new EncodingException("Unable to create class "~className);
         foreach (encodingName;scheme.names())
@@ -2419,7 +2419,7 @@ abstract class EncodingScheme
         if (p is null)
             throw new EncodingException("Unrecognized Encoding: "~encodingName);
         string className = *p;
-        auto scheme = cast(EncodingScheme)ClassInfo.find(className).create();
+        auto scheme = cast(EncodingScheme) ClassInfo.find(className).create();
         if (scheme is null) throw new EncodingException("Unable to create class "~className);
         return scheme;
     }
@@ -2734,7 +2734,7 @@ class EncodingSchemeASCII : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(AsciiChar[])buffer;
+            auto r = cast(AsciiChar[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -2818,7 +2818,7 @@ class EncodingSchemeLatin1 : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(Latin1Char[])buffer;
+            auto r = cast(Latin1Char[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -2894,7 +2894,7 @@ class EncodingSchemeLatin2 : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(Latin2Char[])buffer;
+            auto r = cast(Latin2Char[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -2962,7 +2962,7 @@ class EncodingSchemeWindows1250 : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(Windows1250Char[])buffer;
+            auto r = cast(Windows1250Char[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -3030,7 +3030,7 @@ class EncodingSchemeWindows1252 : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(Windows1252Char[])buffer;
+            auto r = cast(Windows1252Char[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -3098,7 +3098,7 @@ class EncodingSchemeUtf8 : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(char[])buffer;
+            auto r = cast(char[]) buffer;
             return std.encoding.encode(c,r);
         }
 
@@ -3167,7 +3167,7 @@ class EncodingSchemeUtf16Native : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(wchar[])buffer;
+            auto r = cast(wchar[]) buffer;
             return wchar.sizeof * std.encoding.encode(c,r);
         }
 
@@ -3263,7 +3263,7 @@ class EncodingSchemeUtf32Native : EncodingScheme
 
         override size_t encode(dchar c, ubyte[] buffer) @safe pure nothrow @nogc
         {
-            auto r = cast(dchar[])buffer;
+            auto r = cast(dchar[]) buffer;
             return dchar.sizeof * std.encoding.encode(c,r);
         }
 
@@ -3345,7 +3345,7 @@ version(unittest)
         }
         else static if (is(Src==AsciiChar))
         {
-            transcodeReverse!(char,Dst)(cast(string)s,r);
+            transcodeReverse!(char,Dst)(cast(string) s,r);
         }
         else
         {
@@ -3522,7 +3522,7 @@ if (isForwardRange!Range && is(Unqual!(ElementType!Range) == ubyte))
 
     auto ts = dchar(0x0000FEFF) ~ "Hello World"d;
 
-    auto entry = getBOM(cast(ubyte[])ts);
+    auto entry = getBOM(cast(ubyte[]) ts);
     version(BigEndian)
     {
         assert(entry.schema == BOM.utf32be, format("%s", entry.schema));

--- a/std/exception.d
+++ b/std/exception.d
@@ -333,7 +333,7 @@ void assertThrown(T : Throwable = Exception, E)
         file = The source file of the caller.
         line = The line number of the caller.
 
-    Returns: $(D value), if `cast(bool)value` is true. Otherwise,
+    Returns: $(D value), if `cast(bool) value` is true. Otherwise,
     $(D new Exception(msg)) is thrown.
 
     Note:
@@ -368,7 +368,7 @@ if (is(typeof({ if (!value) {} })))
         file = The source file of the caller.
         line = The line number of the caller.
 
-    Returns: $(D value), if `cast(bool)value` is true. Otherwise, the given
+    Returns: $(D value), if `cast(bool) value` is true. Otherwise, the given
     delegate is called.
 
     The safety and purity of this function are inferred from $(D Dg)'s safety
@@ -467,7 +467,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
         static int g;
         ~this() {}  // impure & unsafe destructor
         bool opCast(T:bool)() {
-            int* p = cast(int*)0;   // unsafe operation
+            int* p = cast(int*) 0;   // unsafe operation
             int n = g;              // impure operation
             return true;
         }
@@ -511,7 +511,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
         value = The value to test.
         ex = The exception to throw if the value evaluates to false.
 
-    Returns: $(D value), if `cast(bool)value` is true. Otherwise, $(D ex) is
+    Returns: $(D value), if `cast(bool) value` is true. Otherwise, $(D ex) is
     thrown.
 
     Example:
@@ -541,7 +541,7 @@ T enforce(T)(T value, lazy Throwable ex)
         value = The value to test.
         msg = The message to include in the `ErrnoException` if it is thrown.
 
-    Returns: $(D value), if `cast(bool)value` is true. Otherwise,
+    Returns: $(D value), if `cast(bool) value` is true. Otherwise,
     $(D new ErrnoException(msg)) is thrown.  It is assumed that the last
     operation set $(D errno) to an error code corresponding with the failed
     condition.
@@ -752,7 +752,7 @@ string collectExceptionMsg(T = Exception, E)(lazy E expression)
     {
         expression();
 
-        return cast(string)null;
+        return cast(string) null;
     }
     catch (T e)
         return e.msg.empty ? emptyExceptionMsg : e.msg;
@@ -961,7 +961,7 @@ T assumeWontThrow(T)(lazy T expr,
     {
         if (x < 0)
             throw new Exception("Tried to take root of negative number");
-        return cast(int)sqrt(cast(double)x);
+        return cast(int) sqrt(cast(double) x);
     }
 
     // This function never throws.
@@ -1057,7 +1057,7 @@ if (__traits(isRef, source) || isDynamicArray!S ||
     else static if (isDynamicArray!S)
     {
         import std.array : overlap;
-        return overlap(cast(void[])source, cast(void[])(&target)[0 .. 1]).length != 0;
+        return overlap(cast(void[]) source, cast(void[])(&target)[0 .. 1]).length != 0;
     }
     else
     {
@@ -1099,7 +1099,7 @@ if (__traits(isRef, source) || isDynamicArray!S ||
     else static if (isDynamicArray!S)
     {
         import std.array : overlap;
-        return overlap(cast(void[])source, cast(void[])(&target)[0 .. 1]).length != 0;
+        return overlap(cast(void[]) source, cast(void[])(&target)[0 .. 1]).length != 0;
     }
     else
     {
@@ -1241,7 +1241,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
         static struct NoCopy { this(this) { assert(0); } }
         static struct Holder { NoCopy a, b, c; }
         Holder h;
-        cast(void)doesPointTo(h, h);
+        cast(void) doesPointTo(h, h);
     }
 
     shared S3 sh3;
@@ -1375,8 +1375,8 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     S s = S(&j);
     assert(!doesPointTo(s, i));
     assert( doesPointTo(s, j));
-    assert( doesPointTo(cast(int*)s, i));
-    assert(!doesPointTo(cast(int*)s, j));
+    assert( doesPointTo(cast(int*) s, i));
+    assert(!doesPointTo(cast(int*) s, j));
 }
 @safe unittest //more alias this opCast
 {
@@ -1530,8 +1530,8 @@ class ErrnoException : Exception
     //Chaining multiple calls to ifThrown to attempt multiple things in a row:
     string s="true";
     assert(s.to!int().
-            ifThrown(cast(int)s.to!double()).
-            ifThrown(cast(int)s.to!bool())
+            ifThrown(cast(int) s.to!double()).
+            ifThrown(cast(int) s.to!bool())
             == 1);
 
     //Respond differently to different types of errors
@@ -1636,8 +1636,8 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
     //Chaining multiple calls to ifThrown to attempt multiple things in a row:
     string s="true";
     assert(s.to!int().
-            ifThrown(cast(int)s.to!double()).
-            ifThrown(cast(int)s.to!bool())
+            ifThrown(cast(int) s.to!double()).
+            ifThrown(cast(int) s.to!bool())
             == 1);
 
     //Respond differently to different types of errors
@@ -1698,8 +1698,8 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
 version(unittest) package
 @property void assertCTFEable(alias dg)()
 {
-    static assert({ cast(void)dg(); return true; }());
-    cast(void)dg();
+    static assert({ cast(void) dg(); return true; }());
+    cast(void) dg();
 }
 
 /** This $(D enum) is used to select the primitives of the range to handle by the

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -91,7 +91,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             static if (stateSize!Prefix)
             {
                 assert(result.ptr.alignedAt(Prefix.alignof));
-                emplace!Prefix(cast(Prefix*)result.ptr);
+                emplace!Prefix(cast(Prefix*) result.ptr);
             }
             static if (stateSize!Suffix)
             {
@@ -115,7 +115,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             static if (stateSize!Prefix)
             {
                 assert(result.length > stateSize!Prefix);
-                emplace!Prefix(cast(Prefix*)result.ptr);
+                emplace!Prefix(cast(Prefix*) result.ptr);
                 result = result[stateSize!Prefix .. $];
             }
             static if (stateSize!Suffix)

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -177,7 +177,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
                 // Overestimated
                 continue;
             }
-            _control = BitVector((cast(ulong*)data.ptr)[0 .. controlWords]);
+            _control = BitVector((cast(ulong*) data.ptr)[0 .. controlWords]);
             _control[] = 0;
             _payload = payload;
             break;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1036,7 +1036,7 @@ struct SharedFreeList(ParentAllocator,
             for (auto n = _root; n;)
             {
                 auto tmp = n.next;
-                if (!parent.deallocate((cast(ubyte*)n)[0 .. max]))
+                if (!parent.deallocate((cast(ubyte*) n)[0 .. max]))
                     result = false;
                 n = tmp;
             }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -370,7 +370,7 @@ unittest
     m = _aligned_malloc(16, 0x10);
     if (m)
     {
-        assert((cast(size_t)m & 0xF) == 0);
+        assert((cast(size_t) m & 0xF) == 0);
         m = _aligned_realloc(m, 32, 0x10000);
         if (m) assert((m.addr & 0xFFFF) == 0);
         _aligned_free(m);

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -446,7 +446,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
         else
         {
             // Assume cast is safe as allocation succeeded for `stateSize!T`
-            auto p = () @trusted { return cast(T*)m.ptr; }();
+            auto p = () @trusted { return cast(T*) m.ptr; }();
             emplaceRef(*p, args);
             return p;
         }
@@ -708,7 +708,7 @@ unittest
     int[5] expected = [42, 42, 42, 42, 42];
     S[5] arr = void;
     uninitializedFillDefault(arr);
-    assert((cast(int*)arr.ptr)[0 .. arr.length] == expected);
+    assert((cast(int*) arr.ptr)[0 .. arr.length] == expected);
 }
 
 unittest
@@ -1510,7 +1510,7 @@ void dispose(A, T)(auto ref A alloc, T* p)
     {
         destroy(*p);
     }
-    alloc.deallocate((cast(void*)p)[0 .. T.sizeof]);
+    alloc.deallocate((cast(void*) p)[0 .. T.sizeof]);
 }
 
 /// Ditto

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -171,7 +171,7 @@ if (isOutputRange!(OutputRange,string))
 {
     import std.format : formattedWrite;
 
-    const auto dt = cast(DateTime)time;
+    const auto dt = cast(DateTime) time;
     const auto fsec = time.fracSecs.total!"msecs";
 
     formattedWrite(o, "%04d-%02d-%02dT%02d:%02d:%02d.%03d",
@@ -3061,12 +3061,12 @@ unittest
 
 @safe unittest
 {
-    auto dl = cast(FileLogger)sharedLog;
+    auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);
     assert(dl.logLevel == LogLevel.all);
     assert(globalLogLevel == LogLevel.all);
 
-    auto tl = cast(StdForwardLogger)stdThreadLocalLog;
+    auto tl = cast(StdForwardLogger) stdThreadLocalLog;
     assert(tl !is null);
     stdThreadLocalLog.logLevel = LogLevel.all;
 }

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -191,12 +191,12 @@ unittest
 
 @safe unittest
 {
-    auto dl = cast(FileLogger)sharedLog;
+    auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);
     assert(dl.logLevel == LogLevel.all);
     assert(globalLogLevel == LogLevel.all);
 
-    auto tl = cast(StdForwardLogger)stdThreadLocalLog;
+    auto tl = cast(StdForwardLogger) stdThreadLocalLog;
     assert(tl !is null);
     stdThreadLocalLog.logLevel = LogLevel.all;
 }

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -186,12 +186,12 @@ unittest
 
 @safe unittest
 {
-    auto dl = cast(FileLogger)sharedLog;
+    auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);
     assert(dl.logLevel == LogLevel.all);
     assert(globalLogLevel == LogLevel.all);
 
-    auto tl = cast(StdForwardLogger)stdThreadLocalLog;
+    auto tl = cast(StdForwardLogger) stdThreadLocalLog;
     assert(tl !is null);
     stdThreadLocalLog.logLevel = LogLevel.all;
 }

--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -254,7 +254,7 @@ void main(string[] args)
         IFImage image = read_image(name);
 
         auto ret = image.pixels
-            .sliced(cast(size_t)image.h, cast(size_t)image.w, cast(size_t)image.c)
+            .sliced(cast(size_t) image.h, cast(size_t) image.w, cast(size_t) image.c)
             .movingWindowByChannel
                 !(window => median(window, buf))
                  (nr, nc);

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -485,12 +485,12 @@ pure nothrow unittest
     auto m = assumeSameStructure!("a", "b")(alpha, beta);
     foreach (r; m)
         foreach (e; r)
-            e.b = cast(int)e.a;
+            e.b = cast(int) e.a;
     assert(alpha == beta);
 
     beta[] = 0;
     foreach (e; m.byElement)
-        e.b = cast(int)e.a;
+        e.b = cast(int) e.a;
     assert(alpha == beta);
 }
 
@@ -565,7 +565,7 @@ auto slice(T,
         auto arr = new Unqual!T[len];
     }
     arr[] = init;
-    auto ret = .sliced!ra(cast(T[])arr, lengths);
+    auto ret = .sliced!ra(cast(T[]) arr, lengths);
     return ret;
 }
 

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -53,7 +53,7 @@ if (is(T == class) || is(T == interface))
         }
         else
         {
-            return cast(T)typecons_d_toObject(*cast(void**)(&source));
+            return cast(T) typecons_d_toObject(*cast(void**)(&source));
         }
     }
 }
@@ -62,7 +62,7 @@ unittest
 {
     class C { @disable opCast(T)() {} }
     auto c = new C;
-    static assert(!__traits(compiles, cast(Object)c));
+    static assert(!__traits(compiles, cast(Object) c));
     auto o = dynamicCast!Object(c);
     assert(c is o);
 
@@ -70,7 +70,7 @@ unittest
     interface J { @disable opCast(T)() {} Object instance(); }
     class D : I, J { Object instance() { return this; } }
     I i = new D();
-    static assert(!__traits(compiles, cast(J)i));
+    static assert(!__traits(compiles, cast(J) i));
     J j = dynamicCast!J(i);
     assert(i.instance() is j.instance());
 }

--- a/std/file.d
+++ b/std/file.d
@@ -424,7 +424,7 @@ if (isSomeString!S &&
     !isConvertibleToString!R)
 {
     import std.utf : validate;
-    static auto trustedCast(void[] buf) @trusted { return cast(S)buf; }
+    static auto trustedCast(void[] buf) @trusted { return cast(S) buf; }
     auto result = trustedCast(read(name));
     validate(result);
     return result;
@@ -1670,7 +1670,7 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) &&
             alias names = name;
         else
             string names = null;
-        cenforce(!trustedChmod(namez, cast(mode_t)attributes), names, namez);
+        cenforce(!trustedChmod(namez, cast(mode_t) attributes), names, namez);
     }
 }
 
@@ -2910,7 +2910,7 @@ else version(Windows)
             size_t clength = wcslen(fd.cFileName.ptr);
             _name = toUTF8(fd.cFileName[0 .. clength]);
             _name = buildPath(path, toUTF8(fd.cFileName[0 .. clength]));
-            _size = (cast(ulong)fd.nFileSizeHigh << 32) | fd.nFileSizeLow;
+            _size = (cast(ulong) fd.nFileSizeHigh << 32) | fd.nFileSizeLow;
             _timeCreated = std.datetime.FILETIMEToSysTime(&fd.ftCreationTime);
             _timeLastAccessed = std.datetime.FILETIMEToSysTime(&fd.ftLastAccessTime);
             _timeLastModified = std.datetime.FILETIMEToSysTime(&fd.ftLastWriteTime);
@@ -3414,8 +3414,8 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
         cenforce(core.sys.posix.unistd.close(fdw) != -1, f, fromz);
 
         utimbuf utim = void;
-        utim.actime = cast(time_t)statbufr.st_atime;
-        utim.modtime = cast(time_t)statbufr.st_mtime;
+        utim.actime = cast(time_t) statbufr.st_atime;
+        utim.modtime = cast(time_t) statbufr.st_mtime;
 
         cenforce(utime(toz, &utim) != -1, f, fromz);
     }
@@ -3472,7 +3472,7 @@ void rmdirRecurse(in char[] pathname)
 {
     //No references to pathname will be kept after rmdirRecurse,
     //so the cast is safe
-    rmdirRecurse(DirEntry(cast(string)pathname));
+    rmdirRecurse(DirEntry(cast(string) pathname));
 }
 
 /++
@@ -3556,7 +3556,7 @@ version(Posix) @system unittest
     void[] buf;
 
     buf = new void[10];
-    (cast(byte[])buf)[] = 3;
+    (cast(byte[]) buf)[] = 3;
     string unit_file = deleteme ~ "-unittest_write.tmp";
     if (exists(unit_file)) remove(unit_file);
     write(unit_file, buf);

--- a/std/format.d
+++ b/std/format.d
@@ -2343,7 +2343,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
 {
     static if (is(const(ArrayTypeOf!T) == const(void[])))
     {
-        formatValue(w, cast(const ubyte[])obj, f);
+        formatValue(w, cast(const ubyte[]) obj, f);
     }
     else static if (!isInputRange!T)
     {
@@ -2432,13 +2432,13 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     void[] val0;
     formatTest( val0, "[]" );
 
-    void[] val = cast(void[])cast(ubyte[])[1, 2, 3];
+    void[] val = cast(void[]) cast(ubyte[])[1, 2, 3];
     formatTest( val, "[1, 2, 3]" );
 
     void[0] sval0 = [];
     formatTest( sval0, "[]");
 
-    void[3] sval = cast(void[3])cast(ubyte[3])[1, 2, 3];
+    void[3] sval = cast(void[3]) cast(ubyte[3])[1, 2, 3];
     formatTest( sval, "[1, 2, 3]" );
 }
 
@@ -2668,7 +2668,7 @@ if (isInputRange!T)
         static if (is(DynamicArrayTypeOf!T))
         {
             alias ARR = DynamicArrayTypeOf!T;
-            foreach (e ; cast(ARR)val)
+            foreach (e ; cast(ARR) val)
             {
                 formatValue(w, e, f);
             }
@@ -2749,7 +2749,7 @@ private void formatChar(Writer)(Writer w, in dchar c, in char quote)
     else
         fmt = "\\U%08X";
 
-    formattedWrite(w, fmt, cast(uint)c);
+    formattedWrite(w, fmt, cast(uint) c);
 }
 
 // undocumented because of deprecation
@@ -2805,7 +2805,7 @@ if (is(StringTypeOf!T) && !is(T == enum))
             enum postfix = 'd';
             alias IntArr = const(uint)[];
         }
-        formattedWrite(w, "x\"%(%02X %)\"%s", cast(IntArr)str, postfix);
+        formattedWrite(w, "x\"%(%02X %)\"%s", cast(IntArr) str, postfix);
     }
     else
         formatValue(w, str, f);
@@ -3299,12 +3299,12 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
                 }
                 else
                 {
-                    formatValue(w, cast(Object)val, f);
+                    formatValue(w, cast(Object) val, f);
                 }
             }
             else
             {
-                formatValue(w, cast(Object)val, f);
+                formatValue(w, cast(Object) val, f);
             }
         }
     }
@@ -3345,7 +3345,7 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
         }
 
         IUnknown2 d = new D;
-        string expected = format("%X", cast(void*)d);
+        string expected = format("%X", cast(void*) d);
         formatTest(d, expected);
     }
 }
@@ -3501,11 +3501,11 @@ if (is(T == enum))
             }
         }
 
-        // val is not a member of T, output cast(T)rawValue instead.
+        // val is not a member of T, output cast(T) rawValue instead.
         put(w, "cast(" ~ T.stringof ~ ")");
         static assert(!is(OriginalType!T == T));
     }
-    formatValue(w, cast(OriginalType!T)val, f);
+    formatValue(w, cast(OriginalType!T) val, f);
 }
 
 ///
@@ -3526,7 +3526,7 @@ if (is(T == enum))
 {
     enum A { first, second, third }
     formatTest( A.second, "second" );
-    formatTest( cast(A)72, "cast(A)72" );
+    formatTest( cast(A) 72, "cast(A)72" );
 }
 @safe unittest
 {
@@ -3606,7 +3606,7 @@ if (isPointer!T && !is(T == enum) && !hasToString!(T, Char))
     p = null;
     formatTest( p, "null" );
 
-    auto q = ()@trusted{ return cast(void*)0xFFEECCAA; }();
+    auto q = ()@trusted{ return cast(void*) 0xFFEECCAA; }();
     formatTest( q, "FFEECCAA" );
 }
 
@@ -3620,7 +3620,7 @@ if (isPointer!T && !is(T == enum) && !hasToString!(T, Char))
     S* p = null;
     formatTest( p, "null" );
 
-    S* q = cast(S*)0xFFEECCAA;
+    S* q = cast(S*) 0xFFEECCAA;
     formatTest( q, "FFEECCAA" );
 }
 
@@ -4150,7 +4150,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     assert(stream.data == "ghi");
 
 here:
-    @trusted void* deadBeef() { return cast(void*)0xDEADBEEF; }
+    @trusted void* deadBeef() { return cast(void*) 0xDEADBEEF; }
     stream.clear(); formattedWrite(stream, "%s", deadBeef());
     assert(stream.data == "DEADBEEF", stream.data);
 
@@ -4237,7 +4237,7 @@ here:
     }
     stream.clear(); formattedWrite(stream, "%s", TestEnum.Value2);
     assert(stream.data == "Value2", stream.data);
-    stream.clear(); formattedWrite(stream, "%s", cast(TestEnum)5);
+    stream.clear(); formattedWrite(stream, "%s", cast(TestEnum) 5);
     assert(stream.data == "cast(TestEnum)5", stream.data);
 
     //immutable(char[5])[int] aa = ([3:"hello", 4:"betty"]);
@@ -5274,7 +5274,7 @@ private bool needToSwapEndianess(Char)(ref FormatSpec!Char f)
     dr = format("ghi"d);
     assert(dr == "ghi"d);
 
-    void* p = cast(void*)0xDEADBEEF;
+    void* p = cast(void*) 0xDEADBEEF;
     r = format("%s", p);
     assert(r == "DEADBEEF");
 

--- a/std/functional.d
+++ b/std/functional.d
@@ -425,7 +425,7 @@ if (S=="<"||S==">"||S=="<="||S==">="||S=="=="||S=="!=")
     {
         import std.traits : CommonType;
         alias T = CommonType!(ElementType1, ElementType2);
-        return mixin("cast(T)a "~S~" cast(T)b");
+        return mixin("cast(T)a "~S~" cast(T) b");
     }
 
     bool safeOp(T0, T1)(auto ref T0 a, auto ref T1 b)
@@ -1029,9 +1029,9 @@ template memoize(alias fun, uint maxSize)
             static assert(maxSize < size_t.max - (8 * size_t.sizeof - 1));
 
             enum attr = GC.BlkAttr.NO_INTERIOR | (hasIndirections!Value ? 0 : GC.BlkAttr.NO_SCAN);
-            memo = (cast(Value*)GC.malloc(Value.sizeof * maxSize, attr))[0 .. maxSize];
+            memo = (cast(Value*) GC.malloc(Value.sizeof * maxSize, attr))[0 .. maxSize];
             enum nwords = (maxSize + 8 * size_t.sizeof - 1) / (8 * size_t.sizeof);
-            initialized = (cast(size_t*)GC.calloc(nwords * size_t.sizeof, attr | GC.BlkAttr.NO_SCAN))[0 .. nwords];
+            initialized = (cast(size_t*) GC.calloc(nwords * size_t.sizeof, attr | GC.BlkAttr.NO_SCAN))[0 .. nwords];
         }
 
         import core.bitop : bt, bts;

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -93,7 +93,7 @@ if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
 
     alias CF = Unqual!(ElementEncodingType!From);
 
-    enum To* useStack = () @trusted { return cast(To*)size_t.max; }();
+    enum To* useStack = () @trusted { return cast(To*) size_t.max; }();
 
     static struct Res
     {
@@ -167,7 +167,7 @@ if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
             size_t newlen = res.length * 3 / 2;
             if (newlen <= strLength)
                 newlen = strLength + 1; // +1 for terminating 0
-            auto ptr = cast(To*)malloc(newlen * To.sizeof);
+            auto ptr = cast(To*) malloc(newlen * To.sizeof);
             if (!ptr)
                 onOutOfMemoryError();
             memcpy(ptr, res.ptr, i * To.sizeof);
@@ -178,7 +178,7 @@ if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
             if (buf.length >= size_t.max / (2 * To.sizeof))
                 onOutOfMemoryError();
             const newlen = buf.length * 3 / 2;
-            auto ptr = cast(To*)realloc(buf.ptr, newlen * To.sizeof);
+            auto ptr = cast(To*) realloc(buf.ptr, newlen * To.sizeof);
             if (!ptr)
                 onOutOfMemoryError();
             return ptr[0 .. newlen];

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -142,13 +142,13 @@ public:
         }
     }
 
-    // The value at (cast(ulong[])data)[n]
+    // The value at (cast(ulong[]) data)[n]
     ulong peekUlong(int n) pure nothrow const @safe @nogc
     {
         static if (BigDigit.sizeof == int.sizeof)
         {
             if (data.length == n*2 + 1) return data[n*2];
-            return data[n*2] + ((cast(ulong)data[n*2 + 1]) << 32 );
+            return data[n*2] + ((cast(ulong) data[n*2 + 1]) << 32 );
         }
         else static if (BigDigit.sizeof == long.sizeof)
         {
@@ -164,7 +164,7 @@ public:
         else
         {
             immutable x = data[n >> 1];
-            return (n & 1) ? cast(uint)(x >> 32) : cast(uint)x;
+            return (n & 1) ? cast(uint)(x >> 32) : cast(uint) x;
         }
     }
 public:
@@ -460,7 +460,7 @@ public:
     BigUint opShr(Tulong)(Tulong y) pure nothrow const if (is (Tulong == ulong))
     {
         assert(y>0);
-        uint bits = cast(uint)y & BIGDIGITSHIFTMASK;
+        uint bits = cast(uint) y & BIGDIGITSHIFTMASK;
         if ((y>>LG2BIGDIGITBITS) >= data.length) return BigUint(ZERO);
         uint words = cast(uint)(y >> LG2BIGDIGITBITS);
         if (bits==0)
@@ -484,7 +484,7 @@ public:
     {
         assert(y>0);
         if (isZero()) return this;
-        uint bits = cast(uint)y & BIGDIGITSHIFTMASK;
+        uint bits = cast(uint) y & BIGDIGITSHIFTMASK;
         assert((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
         uint words = cast(uint)(y >> LG2BIGDIGITBITS);
         BigDigit [] result = new BigDigit[data.length + words+1];
@@ -519,7 +519,7 @@ public:
             {   // could change sign!
                 ulong xx = x.data[0];
                 if (x.data.length > 1)
-                    xx += (cast(ulong)x.data[1]) << 32;
+                    xx += (cast(ulong) x.data[1]) << 32;
                 ulong d;
                 if (xx <= y)
                 {
@@ -647,7 +647,7 @@ public:
     if ( is(Unqual!T == ulong) )
     {
         if (y <= uint.max)
-            return divInt!uint(x, cast(uint)y);
+            return divInt!uint(x, cast(uint) y);
         if (x.data.length < 2)
             return BigUint(ZERO);
         uint hi = cast(uint)(y >>> 32);
@@ -797,7 +797,7 @@ public:
             immutable p = highestPowerBelowUintMax(x0);
             if (y <= p)
             {   // Just do it with pow
-                result = cast(ulong)intpow(x0, y);
+                result = cast(ulong) intpow(x0, y);
                 if (evenbits + firstnonzero == 0)
                     return result;
                 return result << (evenbits + firstnonzero * 8 * BigDigit.sizeof) * y;
@@ -836,7 +836,7 @@ public:
             assert(0, "Overflow in BigInt.pow");
 
         // The result buffer includes space for all the trailing zeros
-        BigDigit [] resultBuffer = new BigDigit[cast(size_t)estimatelength];
+        BigDigit [] resultBuffer = new BigDigit[cast(size_t) estimatelength];
 
         // Do all the powers of 2!
         size_t result_start = cast(size_t)( firstnonzero * y
@@ -1178,7 +1178,7 @@ version(unittest)
 int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
 {
      int pwr = 1;
-     for (ulong q = x;x*q < cast(ulong)uint.max; )
+     for (ulong q = x;x*q < cast(ulong) uint.max; )
      {
          q*=x; ++pwr;
      }
@@ -1789,7 +1789,7 @@ body
     {
         if (hi == 0)
         {
-            data[0] = cast(uint)y;
+            data[0] = cast(uint) y;
             if (data.length == 1)
             {
                 hi = 1;
@@ -2234,9 +2234,9 @@ div3by2done:    ;
                 ulong uu = (cast(ulong)(u[j + v.length]) << 32) | u[j + v.length - 1];
                 immutable bigqhat = uu / vhi;
                 ulong rhat =  uu - bigqhat * vhi;
-                qhat = cast(uint)bigqhat;
+                qhat = cast(uint) bigqhat;
 again:
-                if (cast(ulong)qhat * vlo > ((rhat << 32) + ulo))
+                if (cast(ulong) qhat * vlo > ((rhat << 32) + ulo))
                 {
                     --qhat;
                     rhat += vhi;

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -41,11 +41,11 @@ uint multibyteAddSub(char op)(uint[] dest, const(uint) [] src1,
     for (size_t i = 0; i < src2.length; ++i)
     {
         static if (op=='+') c = c  + src1[i] + src2[i];
-             else           c = cast(ulong)src1[i] - src2[i] - c;
-        dest[i] = cast(uint)c;
+             else           c = cast(ulong) src1[i] - src2[i] - c;
+        dest[i] = cast(uint) c;
         c = (c > 0xFFFF_FFFF);
     }
-    return cast(uint)c;
+    return cast(uint) c;
 }
 
 unittest
@@ -56,7 +56,7 @@ unittest
     for (size_t i = 0; i < a.length; ++i)
     {
         if (i&1) a[i]=cast(uint)(0x8000_0000 + i);
-        else a[i]=cast(uint)i;
+        else a[i]=cast(uint) i;
         b[i]= 0x8000_0003;
     }
     c[19]=0x3333_3333;
@@ -106,7 +106,7 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
     {
         ulong c = carry;
         c += dest[0];
-        dest[0] = cast(uint)c;
+        dest[0] = cast(uint) c;
         if (c<=0xFFFF_FFFF)
             return 0;
 
@@ -122,7 +122,7 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
     {
         ulong c = carry;
         c = dest[0] - c;
-        dest[0] = cast(uint)c;
+        dest[0] = cast(uint) c;
         if (c<=0xFFFF_FFFF)
             return 0;
         for (size_t i = 1; i < dest.length; ++i)
@@ -145,10 +145,10 @@ uint multibyteShl(uint [] dest, const(uint) [] src, uint numbits)
     for (size_t i = 0; i < dest.length; ++i)
     {
         c += (cast(ulong)(src[i]) << numbits);
-        dest[i] = cast(uint)c;
+        dest[i] = cast(uint) c;
         c >>>= 32;
    }
-   return cast(uint)c;
+   return cast(uint) c;
 }
 
 
@@ -162,7 +162,7 @@ void multibyteShr(uint [] dest, const(uint) [] src, uint numbits)
     for (ptrdiff_t i = dest.length; i!=0; --i)
     {
         c += (src[i-1] >>numbits) + (cast(ulong)(src[i-1]) << (64 - numbits));
-        dest[i-1] = cast(uint)c;
+        dest[i-1] = cast(uint) c;
         c >>>= 32;
    }
 }
@@ -198,10 +198,10 @@ uint multibyteMul(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
     for (size_t i = 0; i < src.length; ++i)
     {
         c += cast(ulong)(src[i]) * multiplier;
-        dest[i] = cast(uint)c;
+        dest[i] = cast(uint) c;
         c>>=32;
     }
-    return cast(uint)c;
+    return cast(uint) c;
 }
 
 unittest
@@ -227,18 +227,18 @@ uint multibyteMulAdd(char op)(uint [] dest, const(uint)[] src,
         static if (op=='+')
         {
             c += cast(ulong)(multiplier) * src[i]  + dest[i];
-            dest[i] = cast(uint)c;
+            dest[i] = cast(uint) c;
             c >>= 32;
         }
         else
         {
-            c += cast(ulong)multiplier * src[i];
-            ulong t = cast(ulong)dest[i] - cast(uint)c;
-            dest[i] = cast(uint)t;
+            c += cast(ulong) multiplier * src[i];
+            ulong t = cast(ulong) dest[i] - cast(uint) c;
+            dest[i] = cast(uint) t;
             c = cast(uint)((c>>32) - (t>>32));
         }
     }
-    return cast(uint)c;
+    return cast(uint) c;
 }
 
 unittest
@@ -285,7 +285,7 @@ void multibyteMultiplyAccumulate(uint [] dest, const(uint)[] left, const(uint)
 uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
     pure @nogc @safe
 {
-    ulong c = cast(ulong)overflow;
+    ulong c = cast(ulong) overflow;
     for (ptrdiff_t i = dest.length-1; i>= 0; --i)
     {
         c = (c<<32) + cast(ulong)(dest[i]);
@@ -293,7 +293,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
         c -= divisor * q;
         dest[i] = q;
     }
-    return cast(uint)c;
+    return cast(uint) c;
 }
 
 unittest
@@ -319,9 +319,9 @@ void multibyteAddDiagonalSquares(uint[] dest, const(uint)[] src)
     {
         // At this point, c is 0 or 1, since FFFF*FFFF+FFFF_FFFF = 1_0000_0000.
         c += cast(ulong)(src[i]) * src[i] + dest[2*i];
-        dest[2*i] = cast(uint)c;
+        dest[2*i] = cast(uint) c;
         c = (c>>=32) + dest[2*i+1];
-        dest[2*i+1] = cast(uint)c;
+        dest[2*i+1] = cast(uint) c;
         c >>= 32;
     }
 }
@@ -337,9 +337,9 @@ void multibyteTriangleAccumulate(uint[] dest, const(uint)[] x)
         if (x.length == 3)
         {
             ulong c = cast(ulong)(x[$-1]) * x[$-2]  + dest[2*x.length-3];
-            dest[2*x.length - 3] = cast(uint)c;
+            dest[2*x.length - 3] = cast(uint) c;
             c >>= 32;
-            dest[2*x.length - 2] = cast(uint)c;
+            dest[2*x.length - 2] = cast(uint) c;
         }
         return;
     }
@@ -350,15 +350,15 @@ void multibyteTriangleAccumulate(uint[] dest, const(uint)[] x)
     }
         // Unroll the last two entries, to reduce loop overhead:
     ulong  c = cast(ulong)(x[$-3]) * x[$-2] + dest[2*x.length-5];
-    dest[2*x.length-5] = cast(uint)c;
+    dest[2*x.length-5] = cast(uint) c;
     c >>= 32;
     c += cast(ulong)(x[$-3]) * x[$-1] + dest[2*x.length-4];
-    dest[2*x.length-4] = cast(uint)c;
+    dest[2*x.length-4] = cast(uint) c;
     c >>= 32;
     c += cast(ulong)(x[$-1]) * x[$-2];
-    dest[2*x.length-3] = cast(uint)c;
+    dest[2*x.length-3] = cast(uint) c;
     c >>= 32;
-    dest[2*x.length-2] = cast(uint)c;
+    dest[2*x.length-2] = cast(uint) c;
 }
 
 void multibyteSquare(BigDigit[] result, const(BigDigit) [] x) pure @nogc @safe

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -1088,16 +1088,16 @@ void multibyteTriangleAccumulateD(uint[] dest, uint[] x) pure
              dest[i+i+1 .. i+x.length], x[i+1..$], x[i], 0);
     }
     ulong c = cast(ulong)(x[$-3]) * x[$-2] + dest[$-5];
-    dest[$-5] = cast(uint)c;
+    dest[$-5] = cast(uint) c;
     c >>= 32;
     c += cast(ulong)(x[$-3]) * x[$-1] + dest[$-4];
-    dest[$-4] = cast(uint)c;
+    dest[$-4] = cast(uint) c;
     c >>= 32;
 length2:
     c += cast(ulong)(x[$-2]) * x[$-1];
-        dest[$-3] = cast(uint)c;
+        dest[$-3] = cast(uint) c;
         c >>= 32;
-        dest[$-2] = cast(uint)c;
+        dest[$-2] = cast(uint) c;
 }
 
 //dest += src[0]*src[1...$] + src[1]*src[2..$] + ... + src[$-3]*src[$-2..$]+ src[$-2]*src[$-1]

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -125,7 +125,7 @@ if (isAssignable!T &&
     body
     {
         this.buf = buf.ptr;
-        this.bufLen = cast(uint)buf.length;
+        this.bufLen = cast(uint) buf.length;
     }
 
     unittest
@@ -179,7 +179,7 @@ if (isAssignable!T &&
     void put(CT[] s)
     {
         const newlen = used + s.length;
-        assert((cast(ulong)used + s.length) <= uint.max);
+        assert((cast(ulong) used + s.length) <= uint.max);
         const len = bufLen;
         if (newlen > len)
         {
@@ -187,7 +187,7 @@ if (isAssignable!T &&
             resize(newlen <= len * 2 ? len * 2 : newlen);
         }
         buf[used .. newlen] = s[];
-        used = cast(uint)newlen;
+        used = cast(uint) newlen;
     }
 
     /******
@@ -246,7 +246,7 @@ if (isAssignable!T &&
         }
     body
     {
-        this.used = cast(uint)i;
+        this.used = cast(uint) i;
     }
 
     alias opDollar = length;
@@ -275,8 +275,8 @@ if (isAssignable!T &&
             memcpy(newBuf, buf, used * T.sizeof);
             debug(ScopeBuffer) buf[0 .. bufLen] = 0;
         }
-        buf = cast(T*)newBuf;
-        bufLen = cast(uint)newsize;
+        buf = cast(T*) newBuf;
+        bufLen = cast(uint) newsize;
 
         /* This function is called only rarely,
          * inlining results in poorer register allocation.

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -322,7 +322,7 @@ if (is(T == uint))
     static auto iota(size_t low = 1, size_t high = 11)
     {
         import std.range : iota;
-        return iota(cast(uint)low, cast(uint)high);
+        return iota(cast(uint) low, cast(uint) high);
     }
 
     static void initialize(ref uint[] arr)
@@ -345,7 +345,7 @@ if (is(T == double))
     static auto iota(size_t low = 1, size_t high = 11)
     {
         import std.range : iota;
-        return iota(cast(double)low, cast(double)high, 1.0);
+        return iota(cast(double) low, cast(double) high, 1.0);
     }
 
     static void initialize(ref double[] arr)
@@ -392,7 +392,7 @@ if (is(T == TestFoo))
     {
         import std.range : iota;
         import std.algorithm.iteration : map;
-        return iota(cast(int)low, cast(int)high).map!(a => TestFoo(a));
+        return iota(cast(int) low, cast(int) high).map!(a => TestFoo(a));
     }
 
     static void initialize(ref TestFoo[] arr)

--- a/std/json.d
+++ b/std/json.d
@@ -1355,7 +1355,7 @@ class JSONException : Exception
     assert(jv.type == JSON_TYPE.INTEGER);
     assertNotThrown(jv.integer);
 
-    jv = cast(uint)3;
+    jv = cast(uint) 3;
     assert(jv.type == JSON_TYPE.UINTEGER);
     assertNotThrown(jv.uinteger);
 

--- a/std/math.d
+++ b/std/math.d
@@ -578,7 +578,7 @@ if (is(Num* : const(cfloat*)) || is(Num* : const(cdouble*))
     //FIXME
     //Issue 14206
     static if (is(Num* : const(cdouble*)))
-        return cast(cdouble) conj(cast(creal)z);
+        return cast(cdouble) conj(cast(creal) z);
     else
         return z.re - z.im*1fi;
 }
@@ -631,10 +631,10 @@ if (is(Num* : const(ifloat*)) || is(Num* : const(idouble*))
 real cos(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.cos(x); }
 //FIXME
 ///ditto
-double cos(double x) @safe pure nothrow @nogc { return cos(cast(real)x); }
+double cos(double x) @safe pure nothrow @nogc { return cos(cast(real) x); }
 //FIXME
 ///ditto
-float cos(float x) @safe pure nothrow @nogc { return cos(cast(real)x); }
+float cos(float x) @safe pure nothrow @nogc { return cos(cast(real) x); }
 
 @safe unittest
 {
@@ -665,10 +665,10 @@ float cos(float x) @safe pure nothrow @nogc { return cos(cast(real)x); }
 real sin(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.sin(x); }
 //FIXME
 ///ditto
-double sin(double x) @safe pure nothrow @nogc { return sin(cast(real)x); }
+double sin(double x) @safe pure nothrow @nogc { return sin(cast(real) x); }
 //FIXME
 ///ditto
-float sin(float x) @safe pure nothrow @nogc { return sin(cast(real)x); }
+float sin(float x) @safe pure nothrow @nogc { return sin(cast(real) x); }
 
 ///
 @safe unittest
@@ -982,10 +982,10 @@ real acos(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double acos(double x) @safe pure nothrow @nogc { return acos(cast(real)x); }
+double acos(double x) @safe pure nothrow @nogc { return acos(cast(real) x); }
 
 /// ditto
-float acos(float x) @safe pure nothrow @nogc  { return acos(cast(real)x); }
+float acos(float x) @safe pure nothrow @nogc  { return acos(cast(real) x); }
 
 @system unittest
 {
@@ -1009,10 +1009,10 @@ real asin(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double asin(double x) @safe pure nothrow @nogc { return asin(cast(real)x); }
+double asin(double x) @safe pure nothrow @nogc { return asin(cast(real) x); }
 
 /// ditto
-float asin(float x) @safe pure nothrow @nogc  { return asin(cast(real)x); }
+float asin(float x) @safe pure nothrow @nogc  { return asin(cast(real) x); }
 
 @system unittest
 {
@@ -1097,10 +1097,10 @@ real atan(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double atan(double x) @safe pure nothrow @nogc { return atan(cast(real)x); }
+double atan(double x) @safe pure nothrow @nogc { return atan(cast(real) x); }
 
 /// ditto
-float atan(float x)  @safe pure nothrow @nogc { return atan(cast(real)x); }
+float atan(float x)  @safe pure nothrow @nogc { return atan(cast(real) x); }
 
 @system unittest
 {
@@ -1206,13 +1206,13 @@ real atan2(real y, real x) @trusted pure nothrow @nogc
 /// ditto
 double atan2(double y, double x) @safe pure nothrow @nogc
 {
-    return atan2(cast(real)y, cast(real)x);
+    return atan2(cast(real) y, cast(real) x);
 }
 
 /// ditto
 float atan2(float y, float x) @safe pure nothrow @nogc
 {
-    return atan2(cast(real)y, cast(real)x);
+    return atan2(cast(real) y, cast(real) x);
 }
 
 @system unittest
@@ -1237,10 +1237,10 @@ real cosh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double cosh(double x) @safe pure nothrow @nogc { return cosh(cast(real)x); }
+double cosh(double x) @safe pure nothrow @nogc { return cosh(cast(real) x); }
 
 /// ditto
-float cosh(float x) @safe pure nothrow @nogc  { return cosh(cast(real)x); }
+float cosh(float x) @safe pure nothrow @nogc  { return cosh(cast(real) x); }
 
 @system unittest
 {
@@ -1272,10 +1272,10 @@ real sinh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double sinh(double x) @safe pure nothrow @nogc { return sinh(cast(real)x); }
+double sinh(double x) @safe pure nothrow @nogc { return sinh(cast(real) x); }
 
 /// ditto
-float sinh(float x) @safe pure nothrow @nogc  { return sinh(cast(real)x); }
+float sinh(float x) @safe pure nothrow @nogc  { return sinh(cast(real) x); }
 
 @system unittest
 {
@@ -1304,10 +1304,10 @@ real tanh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double tanh(double x) @safe pure nothrow @nogc { return tanh(cast(real)x); }
+double tanh(double x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
 
 /// ditto
-float tanh(float x) @safe pure nothrow @nogc { return tanh(cast(real)x); }
+float tanh(float x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
 
 @system unittest
 {
@@ -1368,10 +1368,10 @@ real acosh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double acosh(double x) @safe pure nothrow @nogc { return acosh(cast(real)x); }
+double acosh(double x) @safe pure nothrow @nogc { return acosh(cast(real) x); }
 
 /// ditto
-float acosh(float x) @safe pure nothrow @nogc  { return acosh(cast(real)x); }
+float acosh(float x) @safe pure nothrow @nogc  { return acosh(cast(real) x); }
 
 
 @system unittest
@@ -1410,10 +1410,10 @@ real asinh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double asinh(double x) @safe pure nothrow @nogc { return asinh(cast(real)x); }
+double asinh(double x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
 
 /// ditto
-float asinh(float x) @safe pure nothrow @nogc { return asinh(cast(real)x); }
+float asinh(float x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
 
 @system  unittest
 {
@@ -1449,10 +1449,10 @@ real atanh(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double atanh(double x) @safe pure nothrow @nogc { return atanh(cast(real)x); }
+double atanh(double x) @safe pure nothrow @nogc { return atanh(cast(real) x); }
 
 /// ditto
-float atanh(float x) @safe pure nothrow @nogc { return atanh(cast(real)x); }
+float atanh(float x) @safe pure nothrow @nogc { return atanh(cast(real) x); }
 
 
 @system unittest
@@ -1474,10 +1474,10 @@ float atanh(float x) @safe pure nothrow @nogc { return atanh(cast(real)x); }
 long rndtol(real x) @nogc @safe pure nothrow { pragma(inline, true); return core.math.rndtol(x); }
 //FIXME
 ///ditto
-long rndtol(double x) @safe pure nothrow @nogc { return rndtol(cast(real)x); }
+long rndtol(double x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
 //FIXME
 ///ditto
-long rndtol(float x) @safe pure nothrow @nogc { return rndtol(cast(real)x); }
+long rndtol(float x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
 
 @safe unittest
 {
@@ -1674,7 +1674,7 @@ real exp(real x) @trusted pure nothrow @nogc
         // Express: e^^x = e^^g * 2^^n
         //   = e^^g * e^^(n * LOG2E)
         //   = e^^(g + n * LOG2E)
-        int n = cast(int)floor(LOG2E * x + 0.5);
+        int n = cast(int) floor(LOG2E * x + 0.5);
         x -= n * C1;
         x -= n * C2;
 
@@ -1693,10 +1693,10 @@ real exp(real x) @trusted pure nothrow @nogc
 }
 
 /// ditto
-double exp(double x) @safe pure nothrow @nogc  { return exp(cast(real)x); }
+double exp(double x) @safe pure nothrow @nogc  { return exp(cast(real) x); }
 
 /// ditto
-float exp(float x)  @safe pure nothrow @nogc   { return exp(cast(real)x); }
+float exp(float x)  @safe pure nothrow @nogc   { return exp(cast(real) x); }
 
 @system unittest
 {
@@ -1923,7 +1923,7 @@ L_largenegative:
             return -1.0;
 
         // Express x = LN2 (n + remainder), remainder not exceeding 1/2.
-        int n = cast(int)floor(0.5 + x / LN2);
+        int n = cast(int) floor(0.5 + x / LN2);
         x -= n * C1;
         x -= n * C2;
 
@@ -2183,7 +2183,7 @@ L_was_nan:
         }
 
         // Separate into integer and fractional parts.
-        int n = cast(int)floor(x + 0.5);
+        int n = cast(int) floor(x + 0.5);
         x -= n;
 
         // Rational approximation:
@@ -2570,7 +2570,7 @@ if (isFloatingPoint!T)
     real mantissa = frexp(123.456L, exp);
 
     // check if values are equal to 19 decimal digits of precision
-    assert(equalsDigit(mantissa * pow(2.0L, cast(real)exp), 123.456L, 19));
+    assert(equalsDigit(mantissa * pow(2.0L, cast(real) exp), 123.456L, 19));
 
     assert(frexp(-real.nan, exp) && exp == int.min);
     assert(frexp(real.nan, exp) && exp == int.min);
@@ -2628,7 +2628,7 @@ if (isFloatingPoint!T)
             {
                 T x = elem[0];
                 T e = elem[1];
-                int exp = cast(int)elem[2];
+                int exp = cast(int) elem[2];
                 int eptr;
                 T v = frexp(x, eptr);
                 assert(isIdentical(e, v));
@@ -2658,7 +2658,7 @@ if (isFloatingPoint!T)
  * Extracts the exponent of x as a signed integral value.
  *
  * If x is not a special value, the result is the same as
- * $(D cast(int)logb(x)).
+ * $(D cast(int) logb(x)).
  *
  *      $(TABLE_SV
  *      $(TR $(TH x)                $(TH ilogb(x))     $(TH Range error?))
@@ -2770,7 +2770,7 @@ if (isFloatingPoint!T)
         else
         {
             // subnormal
-            enum MANTISSAMASK_64 = ((cast(ulong)F.MANTISSAMASK_INT) << 32) | 0xFFFF_FFFF;
+            enum MANTISSAMASK_64 = ((cast(ulong) F.MANTISSAMASK_INT) << 32) | 0xFFFF_FFFF;
             return ((ex - F.EXPBIAS) >> 4) - T.mant_dig + 1 + bsr(y.vul[0] & MANTISSAMASK_64);
         }
     }
@@ -2902,10 +2902,10 @@ alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
 real ldexp(real n, int exp) @nogc @safe pure nothrow { pragma(inline, true); return core.math.ldexp(n, exp); }
 //FIXME
 ///ditto
-double ldexp(double n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)n, exp); }
+double ldexp(double n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real) n, exp); }
 //FIXME
 ///ditto
-float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)n, exp); }
+float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real) n, exp); }
 
 ///
 @nogc @safe pure nothrow unittest
@@ -2918,7 +2918,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
         r = ldexp(3.0L, 3);
         assert(r == 24);
 
-        r = ldexp(cast(T)3.0, cast(int) 3);
+        r = ldexp(cast(T) 3.0, cast(int) 3);
         assert(r == 24);
 
         T n = 3.0;
@@ -2996,7 +2996,7 @@ typed_allocator.d
     for (i = 0; i < vals.length; i++)
     {
         real x = vals[i][0];
-        int exp = cast(int)vals[i][1];
+        int exp = cast(int) vals[i][1];
         real z = vals[i][2];
         real l = ldexp(x, exp);
 
@@ -3600,10 +3600,10 @@ real cbrt(real x) @trusted nothrow @nogc
 real fabs(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.fabs(x); }
 //FIXME
 ///ditto
-double fabs(double x) @safe pure nothrow @nogc { return fabs(cast(real)x); }
+double fabs(double x) @safe pure nothrow @nogc { return fabs(cast(real) x); }
 //FIXME
 ///ditto
-float fabs(float x) @safe pure nothrow @nogc { return fabs(cast(real)x); }
+float fabs(float x) @safe pure nothrow @nogc { return fabs(cast(real) x); }
 
 @safe unittest
 {
@@ -4008,14 +4008,14 @@ Unqual!F quantize(real base, alias rfunc = rint, F, E)(const F val, const E exp)
 if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F && isIntegral!E)
 {
     // TODO: Compile-time optimization for power-of-two bases?
-    return quantize!rfunc(val, pow(cast(F)base, exp));
+    return quantize!rfunc(val, pow(cast(F) base, exp));
 }
 
 /// ditto
 Unqual!F quantize(real base, long exp = 1, alias rfunc = rint, F)(const F val)
 if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
 {
-    enum unit = cast(F)pow(base, exp);
+    enum unit = cast(F) pow(base, exp);
     return quantize!rfunc(val, unit);
 }
 
@@ -4038,7 +4038,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
     foreach (F; AliasSeq!(real, double, float))
     {
         const maxL10 = cast(int) F.max.log10.floor;
-        const maxR10 = pow(cast(F)10, maxL10);
+        const maxR10 = pow(cast(F) 10, maxL10);
         assert((cast(F) 0.9L * maxR10).quantize!10(maxL10) ==  maxR10);
         assert((cast(F)-0.9L * maxR10).quantize!10(maxL10) == -maxR10);
 
@@ -4079,10 +4079,10 @@ real nearbyint(real x) @trusted nothrow @nogc
 real rint(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.rint(x); }
 //FIXME
 ///ditto
-double rint(double x) @safe pure nothrow @nogc { return rint(cast(real)x); }
+double rint(double x) @safe pure nothrow @nogc { return rint(cast(real) x); }
 //FIXME
 ///ditto
-float rint(float x) @safe pure nothrow @nogc { return rint(cast(real)x); }
+float rint(float x) @safe pure nothrow @nogc { return rint(cast(real) x); }
 
 @safe unittest
 {
@@ -5024,7 +5024,7 @@ if (isFloatingPoint!(X))
     assert( isNaN(-double.init));
     assert( isNaN(real.nan));
     assert( isNaN(-real.nan));
-    assert(!isNaN(cast(float)53.6));
+    assert(!isNaN(cast(float) 53.6));
     assert(!isNaN(cast(real)-53.6));
 }
 
@@ -5041,7 +5041,7 @@ if (isFloatingPoint!(X))
         assert(isNaN(-T.nan));
         assert(!isNaN(T.infinity));
         assert(!isNaN(-T.infinity));
-        assert(!isNaN(cast(T)53.6));
+        assert(!isNaN(cast(T) 53.6));
         assert(!isNaN(cast(T)-53.6));
 
         // Runtime tests
@@ -5055,7 +5055,7 @@ if (isFloatingPoint!(X))
         f = T.infinity;
         assert(!isNaN(f));
         assert(!isNaN(-f));
-        f = cast(T)53.6;
+        f = cast(T) 53.6;
         assert(!isNaN(f));
         assert(!isNaN(-f));
     }
@@ -5424,7 +5424,7 @@ if (isFloatingPoint!(R) && isFloatingPoint!(X))
 R copysign(R, X)(X to, R from) @trusted pure nothrow @nogc
 if (isIntegral!(X) && isFloatingPoint!(R))
 {
-    return copysign(cast(R)to, from);
+    return copysign(cast(R) to, from);
 }
 
 @safe pure nothrow @nogc unittest
@@ -5671,7 +5671,7 @@ real nextUp(real x) @trusted pure nothrow @nogc
     alias F = floatTraits!(real);
     static if (F.realFormat == RealFormat.ieeeDouble)
     {
-        return nextUp(cast(double)x);
+        return nextUp(cast(double) x);
     }
     else static if (F.realFormat == RealFormat.ieeeQuadruple)
     {
@@ -6251,7 +6251,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
         {
             if (signbit(x))
             {
-                long i = cast(long)y;
+                long i = cast(long) y;
                 if (y > 0.0)
                 {
                     if (i == y && i & 1)
@@ -6280,7 +6280,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
         {
             if (signbit(x))
             {
-                long i = cast(long)y;
+                long i = cast(long) y;
                 if (y > 0.0)
                 {
                     if (i == y && i & 1)
@@ -6331,7 +6331,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
         }
         if (x <= -F.max)
         {
-            long i = cast(long)y;
+            long i = cast(long) y;
             if (y > 0.0)
             {
                 if (i == y && i & 1)
@@ -6349,7 +6349,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
         }
 
         // Integer power of x.
-        long iy = cast(long)y;
+        long iy = cast(long) y;
         if (iy == y && fabs(y) < 32768.0)
             return pow(x, iy);
 
@@ -6375,7 +6375,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
                 const absY = fabs(y);
                 if (absY <= maxOdd)
                 {
-                    const uy = cast(ulong)absY;
+                    const uy = cast(ulong) absY;
                     if (uy != absY)
                         return sqrt(x); // Complex result -- create a NaN
 
@@ -7385,7 +7385,7 @@ if (isFloatingPoint!T)
     import std.meta : AliasSeq;
     foreach (T; AliasSeq!(float, double, real))
     {
-        T[] values = [-cast(T)NaN(20), -cast(T)NaN(10), -T.nan, -T.infinity,
+        T[] values = [-cast(T) NaN(20), -cast(T) NaN(10), -T.nan, -T.infinity,
                       -T.max, -T.max / 2, T(-16.0), T(-1.0).nextDown,
                       T(-1.0), T(-1.0).nextUp,
                       T(-0.5), -T.min_normal, (-T.min_normal).nextUp,
@@ -7397,7 +7397,7 @@ if (isFloatingPoint!T)
                       T.min_normal.nextDown, T.min_normal, T(0.5),
                       T(1.0).nextDown, T(1.0),
                       T(1.0).nextUp, T(16.0), T.max / 2, T.max,
-                      T.infinity, T.nan, cast(T)NaN(10), cast(T)NaN(20)];
+                      T.infinity, T.nan, cast(T) NaN(10), cast(T) NaN(20)];
 
         foreach (i, x; values)
         {
@@ -7719,7 +7719,7 @@ if (isNumeric!X)
         int exp;
         const X sig = frexp(x, exp);
 
-        return (exp != int.min) && (sig is cast(X)0.5L);
+        return (exp != int.min) && (sig is cast(X) 0.5L);
     }
     else
     {
@@ -7802,6 +7802,6 @@ if (isNumeric!X)
         }
 
         foreach (x; [0, 3, 5, 13, 77, X.min, X.max])
-            assert(!isPowerOf2(cast(X)x));
+            assert(!isPowerOf2(cast(X) x));
     }
 }

--- a/std/meta.d
+++ b/std/meta.d
@@ -88,7 +88,7 @@ template AliasSeq(TList...)
 
     int foo(TL td)  // same as int foo(int, double);
     {
-        return td[0] + cast(int)td[1];
+        return td[0] + cast(int) td[1];
     }
 }
 

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -139,7 +139,7 @@ class MmFile
 
         // Map the file into memory!
         size_t initial_map = (window && 2*window<size)
-            ? 2*window : cast(size_t)size;
+            ? 2*window : cast(size_t) size;
         auto p = mmap(address, initial_map, prot, flags, fd, 0);
         if (p == MAP_FAILED)
         {
@@ -229,7 +229,7 @@ class MmFile
                         null,
                         dwCreationDisposition,
                         FILE_ATTRIBUTE_NORMAL,
-                        cast(HANDLE)null);
+                        cast(HANDLE) null);
                 wenforce(hFile != INVALID_HANDLE_VALUE, "CreateFileW");
             }
             else
@@ -246,7 +246,7 @@ class MmFile
 
             int hi = cast(int)(size>>32);
             hFileMap = CreateFileMappingW(hFile, null, flProtect,
-                    hi, cast(uint)size, null);
+                    hi, cast(uint) size, null);
             wenforce(hFileMap, "CreateFileMapping");
             scope(failure)
             {
@@ -260,12 +260,12 @@ class MmFile
                 uint sizelow = GetFileSize(hFile, &sizehi);
                 wenforce(sizelow != INVALID_FILE_SIZE || GetLastError() != ERROR_SUCCESS,
                     "GetFileSize");
-                size = (cast(ulong)sizehi << 32) + sizelow;
+                size = (cast(ulong) sizehi << 32) + sizelow;
             }
             this.size = size;
 
             size_t initial_map = (window && 2*window<size)
-                ? 2*window : cast(size_t)size;
+                ? 2*window : cast(size_t) size;
             p = MapViewOfFileEx(hFileMap, dwDesiredAccess, 0, 0,
                     initial_map, address);
             wenforce(p, "MapViewOfFileEx");
@@ -346,7 +346,7 @@ class MmFile
             }
             this.size = size;
             size_t initial_map = (window && 2*window<size)
-                ? 2*window : cast(size_t)size;
+                ? 2*window : cast(size_t) size;
             p = mmap(address, initial_map, prot, flags, fd, 0);
             if (p == MAP_FAILED)
             {
@@ -419,7 +419,7 @@ class MmFile
         else version (Posix)
         {
             int i;
-            i = msync(cast(void*)data, data.length, MS_SYNC);   // sys/mman.h
+            i = msync(cast(void*) data, data.length, MS_SYNC);   // sys/mman.h
             errnoEnforce(i == 0, "msync failed");
         }
         else
@@ -475,7 +475,7 @@ class MmFile
         debug (MMFILE) printf("MmFile.opIndex(%lld)\n", i);
         ensureMapped(i);
         size_t off = cast(size_t)(i-start);
-        return (cast(ubyte[])data)[off];
+        return (cast(ubyte[]) data)[off];
     }
 
     /**
@@ -486,7 +486,7 @@ class MmFile
         debug (MMFILE) printf("MmFile.opIndex(%lld, %d)\n", i, value);
         ensureMapped(i);
         size_t off = cast(size_t)(i-start);
-        return (cast(ubyte[])data)[off] = value;
+        return (cast(ubyte[]) data)[off] = value;
     }
 
 
@@ -508,7 +508,7 @@ class MmFile
         }
         else
         {
-            errnoEnforce(!data.ptr || munmap(cast(void*)data, data.length) == 0,
+            errnoEnforce(!data.ptr || munmap(cast(void*) data, data.length) == 0,
                     "munmap failed");
         }
         data = null;
@@ -524,12 +524,12 @@ class MmFile
         version(Windows)
         {
             uint hi = cast(uint)(start>>32);
-            p = MapViewOfFileEx(hFileMap, dwDesiredAccess, hi, cast(uint)start, len, address);
+            p = MapViewOfFileEx(hFileMap, dwDesiredAccess, hi, cast(uint) start, len, address);
             wenforce(p, "MapViewOfFileEx");
         }
         else
         {
-            p = mmap(address, len, prot, flags, fd, cast(off_t)start);
+            p = mmap(address, len, prot, flags, fd, cast(off_t) start);
             errnoEnforce(p != MAP_FAILED);
         }
         data = p[0 .. len];
@@ -545,7 +545,7 @@ class MmFile
             unmap();
             if (window == 0)
             {
-                map(0,cast(size_t)size);
+                map(0,cast(size_t) size);
             }
             else
             {
@@ -567,7 +567,7 @@ class MmFile
             unmap();
             if (window == 0)
             {
-                map(0,cast(size_t)size);
+                map(0,cast(size_t) size);
             }
             else
             {
@@ -654,17 +654,17 @@ private:
     MmFile mf = new MmFile(test_file,MmFile.Mode.readWriteNew,
             100*K,null,win);
     ubyte[] str = cast(ubyte[])"1234567890";
-    ubyte[] data = cast(ubyte[])mf[0 .. 10];
+    ubyte[] data = cast(ubyte[]) mf[0 .. 10];
     data[] = str[];
     assert( mf[0 .. 10] == str );
-    data = cast(ubyte[])mf[50 .. 60];
+    data = cast(ubyte[]) mf[50 .. 60];
     data[] = str[];
     assert( mf[50 .. 60] == str );
-    ubyte[] data2 = cast(ubyte[])mf[20*K .. 60*K];
+    ubyte[] data2 = cast(ubyte[]) mf[20*K .. 60*K];
     assert( data2.length == 40*K );
     assert( data2[$-1] == 0 );
     mf[100*K-1] = cast(ubyte)'b';
-    data2 = cast(ubyte[])mf[21*K .. 100*K];
+    data2 = cast(ubyte[]) mf[21*K .. 100*K];
     assert( data2.length == 79*K );
     assert( data2[$-1] == 'b' );
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -202,7 +202,7 @@ version(unittest)
                     handler = receiveOnly!(typeof(handler));
                 catch (OwnerTerminated)
                     return;
-                handler((cast()listener).accept);
+                handler((cast() listener).accept);
             }
             catch (Throwable e)
             {
@@ -219,7 +219,7 @@ version(unittest)
         sock.bind(new InternetAddress(INADDR_LOOPBACK, InternetAddress.PORT_ANY));
         sock.listen(1);
         auto addr = sock.localAddress.toString();
-        auto tid = spawn(&TestServer.loop, cast(shared)sock);
+        auto tid = spawn(&TestServer.loop, cast(shared) sock);
         return TestServer(addr, tid);
     }
 
@@ -256,7 +256,7 @@ version(unittest)
             if (bdy.empty)
                 continue;
 
-            auto hdrs = cast(string)buf[0 .. $ - bdy.length];
+            auto hdrs = cast(string) buf[0 .. $ - bdy.length];
             bdy.popFrontN(4);
             // no support for chunked transfer-encoding
             if (auto m = hdrs.matchFirst(ctRegex!(`Content-Length: ([0-9]+)`, "i")))
@@ -629,7 +629,7 @@ unittest
 
     auto data = new ubyte[](256);
     foreach (i, ref ub; data)
-        ub = cast(ubyte)i;
+        ub = cast(ubyte) i;
 
     testServer.handle((s) {
         auto req = s.recvReq!ubyte;
@@ -1036,7 +1036,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
             switch (mode)
             {
                 case CurlSeekPos.set:
-                    remainingData = sendData[cast(size_t)offset..$];
+                    remainingData = sendData[cast(size_t) offset..$];
                     return CurlSeek.ok;
                 default:
                     // As of curl 7.18.0, libcurl will not pass
@@ -1689,15 +1689,15 @@ auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char)
     static if (is(Conn : AutoProtocol))
     {
         if (isFTPUrl(url))
-            return byLineAsync(url, cast(void[])null, keepTerminator,
+            return byLineAsync(url, cast(void[]) null, keepTerminator,
                                terminator, transmitBuffers, FTP());
         else
-            return byLineAsync(url, cast(void[])null, keepTerminator,
+            return byLineAsync(url, cast(void[]) null, keepTerminator,
                                terminator, transmitBuffers, HTTP());
     }
     else
     {
-        return byLineAsync(url, cast(void[])null, keepTerminator,
+        return byLineAsync(url, cast(void[]) null, keepTerminator,
                            terminator, transmitBuffers, conn);
     }
 }
@@ -1837,15 +1837,15 @@ if (isCurlConn!(Conn))
     static if (is(Conn : AutoProtocol))
     {
         if (isFTPUrl(url))
-            return byChunkAsync(url, cast(void[])null, chunkSize,
+            return byChunkAsync(url, cast(void[]) null, chunkSize,
                                 transmitBuffers, FTP());
         else
-            return byChunkAsync(url, cast(void[])null, chunkSize,
+            return byChunkAsync(url, cast(void[]) null, chunkSize,
                                 transmitBuffers, HTTP());
     }
     else
     {
-        return byChunkAsync(url, cast(void[])null, chunkSize,
+        return byChunkAsync(url, cast(void[]) null, chunkSize,
                             transmitBuffers, conn);
     }
 }
@@ -1897,14 +1897,14 @@ private void _asyncDuplicateConnection(Conn, PostData)
             connDup.handle.set(CurlOption.copypostfields,
                                cast(void*) postData.ptr);
         }
-        tid.send(cast(ulong)connDup.handle.handle);
+        tid.send(cast(ulong) connDup.handle.handle);
         tid.send(connDup.method);
     }
     else
     {
         enforce!CurlException(postData is null,
                                 "Cannot put ftp data using byLineAsync()");
-        tid.send(cast(ulong)connDup.handle.handle);
+        tid.send(cast(ulong) connDup.handle.handle);
         tid.send(HTTP.Method.undefined);
     }
     connDup.p.curl.handle = null; // make sure handle is not freed
@@ -2054,7 +2054,7 @@ private mixin template Protocol()
     */
     @property void localPort(ushort port)
     {
-        p.curl.set(CurlOption.localport, cast(long)port);
+        p.curl.set(CurlOption.localport, cast(long) port);
     }
 
     /**
@@ -2066,7 +2066,7 @@ private mixin template Protocol()
     */
     @property void localPortRange(ushort range)
     {
-        p.curl.set(CurlOption.localportrange, cast(long)range);
+        p.curl.set(CurlOption.localportrange, cast(long) range);
     }
 
     /** Set the tcp no-delay socket option on or off.
@@ -2173,7 +2173,7 @@ private mixin template Protocol()
      * auto client = HTTP("dlang.org");
      * client.onSend = delegate size_t(void[] data)
      * {
-     *     auto m = cast(void[])msg;
+     *     auto m = cast(void[]) msg;
      *     size_t length = m.length > data.length ? data.length : m.length;
      *     if (length == 0) return 0;
      *     data[0..length] = m[0..length];
@@ -2267,7 +2267,7 @@ decodeString(Char = char)(const(ubyte)[] data,
         dchar dc = scheme.safeDecode(data);
         if (dc == INVALID_SEQUENCE)
         {
-            return typeof(return)(size_t.max, cast(Char[])null);
+            return typeof(return)(size_t.max, cast(Char[]) null);
         }
         charsDecoded++;
         res ~= dc;
@@ -2364,7 +2364,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * http.contentLength = msg.length;
   * http.onSend = (void[] data)
   * {
-  *     auto m = cast(void[])msg;
+  *     auto m = cast(void[]) msg;
   *     size_t len = m.length > data.length ? data.length : m.length;
   *     if (len == 0) return len;
   *     data[0..len] = m[0..len];
@@ -2774,7 +2774,7 @@ struct HTTP
          * auto client = HTTP("dlang.org");
          * client.onSend = delegate size_t(void[] data)
          * {
-         *     auto m = cast(void[])msg;
+         *     auto m = cast(void[]) msg;
          *     size_t length = m.length > data.length ? data.length : m.length;
          *     if (length == 0) return 0;
          *     data[0..length] = m[0..length];
@@ -2892,7 +2892,7 @@ struct HTTP
         if (!userAgent.length)
         {
             auto curlVer = Curl.curl.version_info(CURLVERSION_NOW).version_num;
-            userAgent = cast(immutable)sformat(
+            userAgent = cast(immutable) sformat(
                 buf, fmt, version_major, version_minor,
                 curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
         }
@@ -3088,7 +3088,7 @@ struct HTTP
         // cannot use callback when specifying data directly so it is disabled here.
         p.curl.clear(CurlOption.readfunction);
         addRequestHeader("Content-Type", contentType);
-        p.curl.set(CurlOption.postfields, cast(void*)data.ptr);
+        p.curl.set(CurlOption.postfields, cast(void*) data.ptr);
         p.curl.set(CurlOption.postfieldsize, data.length);
         if (method == Method.undefined)
             method = Method.post;
@@ -3107,7 +3107,7 @@ struct HTTP
         });
         auto data = new ubyte[](256);
         foreach (i, ref ub; data)
-            ub = cast(ubyte)i;
+            ub = cast(ubyte) i;
 
         auto http = HTTP(testServer.addr~"/path");
         http.postData = data;
@@ -4534,7 +4534,7 @@ struct Curl
       * string msg = "Hello world";
       * curl.onSend = (void[] data)
       * {
-      *     auto m = cast(void[])msg;
+      *     auto m = cast(void[]) msg;
       *     size_t length = m.length > data.length ? data.length : m.length;
       *     if (length == 0) return 0;
       *     data[0..length] = m[0..length];
@@ -4739,8 +4739,8 @@ struct Curl
             return 0;
 
         // return: 0 ok, 1 fail
-        return b._onProgress(cast(size_t)dltotal, cast(size_t)dlnow,
-                             cast(size_t)ultotal, cast(size_t)ulnow);
+        return b._onProgress(cast(size_t) dltotal, cast(size_t) dlnow,
+                             cast(size_t) ultotal, cast(size_t) ulnow);
     }
 
 }
@@ -4824,12 +4824,12 @@ private static size_t _receiveAsyncChunks(ubyte[] data, ref ubyte[] outdata,
             // them.
             receive((immutable(ubyte)[] buf)
                     {
-                        buffer = cast(ubyte[])buf;
+                        buffer = cast(ubyte[]) buf;
                         outdata = buffer[];
                     },
                     (bool flag) { aborted = true; }
                     );
-            if (aborted) return cast(size_t)0;
+            if (aborted) return cast(size_t) 0;
         }
         if (outdata.empty)
         {
@@ -4895,14 +4895,14 @@ private static size_t _receiveAsyncLines(Terminator, Unit)
             // reuse them.
             receive((immutable(Unit)[] buf)
                     {
-                        buffer = cast(Unit[])buf;
+                        buffer = cast(Unit[]) buf;
                         buffer.length = 0;
                         buffer.assumeSafeAppend();
                         bufferValid = true;
                     },
                     (bool flag) { aborted = true; }
                     );
-            if (aborted) return cast(size_t)0;
+            if (aborted) return cast(size_t) 0;
         }
         if (!bufferValid)
         {
@@ -4954,7 +4954,7 @@ private static size_t _receiveAsyncLines(Terminator, Unit)
         catch (CurlException ex)
         {
             prioritySend(fromTid, cast(immutable(CurlException))ex);
-            return cast(size_t)0;
+            return cast(size_t) 0;
         }
     }
     return datalen;
@@ -5004,7 +5004,7 @@ private static void _spawnAsync(Conn, Unit, Terminator = void)()
     }
 
     // no move semantic available in std.concurrency ie. must use casting.
-    auto connDup = cast(CURL*)receiveOnly!ulong();
+    auto connDup = cast(CURL*) receiveOnly!ulong();
     auto client = Conn();
     client.p.curl.handle = connDup;
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -138,7 +138,7 @@ if (((flags & flags.signed) + precision + exponentWidth) % 8 == 0 && precision +
     // Functions calls require conversion
     z = sin(+x)           + cos(+y);                     // Use unary plus to concisely convert to a real
     z = sin(x.get!float)  + cos(y.get!float);            // Or use get!T
-    z = sin(cast(float)x) + cos(cast(float)y);           // Or use cast(T) to explicitly convert
+    z = sin(cast(float) x) + cos(cast(float) y);           // Or use cast(T) to explicitly convert
 
     // Define a 8-bit custom float for storing probabilities
     alias Probability = CustomFloat!(4, 4, CustomFloatFlags.ieee^CustomFloatFlags.probability^CustomFloatFlags.signed );
@@ -477,7 +477,7 @@ public:
     static @property CustomFloat im() { return CustomFloat(0.0f); }
 
     /// Initialize from any $(D real) compatible type.
-    this(F)(F input) if (__traits(compiles, cast(real)input ))
+    this(F)(F input) if (__traits(compiles, cast(real) input ))
     {
         this = input;
     }
@@ -493,7 +493,7 @@ public:
 
     /// Assigns from any $(D real) compatible type.
     void opAssign(F)(F input)
-        if (__traits(compiles, cast(real)input))
+        if (__traits(compiles, cast(real) input))
     {
         import std.conv : text;
 
@@ -584,7 +584,7 @@ public:
 
     /// ditto
     int opCmp(T)(auto ref T b)
-        if (__traits(compiles, cast(real)b))
+        if (__traits(compiles, cast(real) b))
     {
         auto x = get!real;
         auto y = cast(real) b;
@@ -593,9 +593,9 @@ public:
 
     /// ditto
     void opOpAssign(string op, T)(auto ref T b)
-        if (__traits(compiles, mixin(`get!real`~op~`cast(real)b`)))
+        if (__traits(compiles, mixin(`get!real`~op~`cast(real) b`)))
     {
-        return mixin(`this = this `~op~` cast(real)b`);
+        return mixin(`this = this `~op~` cast(real) b`);
     }
 
     /// ditto
@@ -1386,9 +1386,9 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
 @system unittest
 {
     // @system due to the case in the 2nd line
-    static assert(__traits(compiles, findRoot((float x)=>cast(real)x, float.init, float.init)));
-    static assert(__traits(compiles, findRoot!real((x)=>cast(double)x, real.init, real.init)));
-    static assert(__traits(compiles, findRoot((real x)=>cast(double)x, real.init, real.init)));
+    static assert(__traits(compiles, findRoot((float x)=>cast(real) x, float.init, float.init)));
+    static assert(__traits(compiles, findRoot!real((x)=>cast(double) x, real.init, real.init)));
+    static assert(__traits(compiles, findRoot((real x)=>cast(double) x, real.init, real.init)));
 }
 
 /++
@@ -2185,7 +2185,7 @@ if (isRandomAccessRange!(R1) && hasLength!(R1) &&
     if (s.length < t.length) return gapWeightedSimilarity(t, s, lambda);
     if (!t.length) return 0;
 
-    auto dpvi = cast(F*)malloc(F.sizeof * 2 * t.length);
+    auto dpvi = cast(F*) malloc(F.sizeof * 2 * t.length);
     if (!dpvi)
         onOutOfMemoryError();
 
@@ -2366,7 +2366,7 @@ time and computes all matches of length 1.
         this.s = s;
         this.t = t;
 
-        kl = cast(F*)malloc(s.length * t.length * F.sizeof);
+        kl = cast(F*) malloc(s.length * t.length * F.sizeof);
         if (!kl)
             onOutOfMemoryError();
 
@@ -3107,7 +3107,7 @@ private enum string MakeLocalFft = q{
     import core.stdc.stdlib;
     import core.exception : onOutOfMemoryError;
 
-    auto lookupBuf = (cast(lookup_t*)malloc(range.length * 2 * lookup_t.sizeof))
+    auto lookupBuf = (cast(lookup_t*) malloc(range.length * 2 * lookup_t.sizeof))
                      [0..2 * range.length];
     if (!lookupBuf.ptr)
         onOutOfMemoryError();

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -63,7 +63,7 @@ class OutBuffer
             {
                 void[] vdata = data;
                 vdata.length = (offset + nbytes + 7) * 2; // allocates as void[] to not set BlkAttr.NO_SCAN
-                data = cast(ubyte[])vdata;
+                data = cast(ubyte[]) vdata;
             }
         }
 
@@ -100,9 +100,9 @@ class OutBuffer
             offset += ubyte.sizeof;
         }
 
-    void write(byte b) { write(cast(ubyte)b); }         /// ditto
-    void write(char c) { write(cast(ubyte)c); }         /// ditto
-    void write(dchar c) { write(cast(uint)c); }         /// ditto
+    void write(byte b) { write(cast(ubyte) b); }         /// ditto
+    void write(char c) { write(cast(ubyte) c); }         /// ditto
+    void write(dchar c) { write(cast(uint) c); }         /// ditto
 
     void write(ushort w) @trusted                /// ditto
     {
@@ -111,7 +111,7 @@ class OutBuffer
         offset += ushort.sizeof;
     }
 
-    void write(short s) { write(cast(ushort)s); }               /// ditto
+    void write(short s) { write(cast(ushort) s); }               /// ditto
 
     void write(wchar c) @trusted        /// ditto
     {
@@ -127,7 +127,7 @@ class OutBuffer
         offset += uint.sizeof;
     }
 
-    void write(int i) { write(cast(uint)i); }           /// ditto
+    void write(int i) { write(cast(uint) i); }           /// ditto
 
     void write(ulong l) @trusted         /// ditto
     {
@@ -136,7 +136,7 @@ class OutBuffer
         offset += ulong.sizeof;
     }
 
-    void write(long l) { write(cast(ulong)l); }         /// ditto
+    void write(long l) { write(cast(ulong) l); }         /// ditto
 
     void write(float f) @trusted         /// ditto
     {
@@ -161,7 +161,7 @@ class OutBuffer
 
     void write(in char[] s) @trusted             /// ditto
     {
-        write(cast(ubyte[])s);
+        write(cast(ubyte[]) s);
     }
 
     void write(OutBuffer buf)           /// ditto
@@ -207,7 +207,7 @@ class OutBuffer
     void align2()
     {
         if (offset & 1)
-            write(cast(byte)0);
+            write(cast(byte) 0);
     }
 
     /****************************************
@@ -374,7 +374,7 @@ class OutBuffer
 
     assert(buf.offset == 0);
     buf.write("hello"[]);
-    buf.write(cast(byte)0x20);
+    buf.write(cast(byte) 0x20);
     buf.write("world"[]);
     buf.printf(" %d", 62665);
     assert(cmp(buf.toString(), "hello world 62665") == 0);

--- a/std/path.d
+++ b/std/path.d
@@ -726,7 +726,7 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
             return path[0 .. uncRootLength(path)];
     }
     static if (isSomeString!R)
-        return cast(ElementEncodingType!R[])null; // legacy code may rely on null return rather than slice
+        return cast(ElementEncodingType!R[]) null; // legacy code may rely on null return rather than slice
     else
         return path[0..0];
 }
@@ -2655,7 +2655,7 @@ if ((isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
 @system unittest
 {
     import std.array;
-    assert(asAbsolutePath(cast(string)null).array == "");
+    assert(asAbsolutePath(cast(string) null).array == "");
     version (Posix)
     {
         assert(asAbsolutePath("/foo").array == "/foo");
@@ -3541,7 +3541,7 @@ unittest
         {
             char[3] buf;
             buf[0] = 'a';
-            buf[1] = i <= 31 ? cast(char)i : cases[i - 32];
+            buf[1] = i <= 31 ? cast(char) i : cases[i - 32];
             buf[2] = 'b';
             assert(!isValidFilename(buf[]));
         }
@@ -3850,7 +3850,7 @@ string expandTilde(string inputPath) nothrow
                 auto last_char = indexOf(path, dirSeparator[0]);
 
                 size_t username_len = (last_char == -1) ? path.length : last_char;
-                char* username = cast(char*)malloc(username_len * char.sizeof);
+                char* username = cast(char*) malloc(username_len * char.sizeof);
                 if (!username)
                     onOutOfMemoryError();
                 scope(exit) free(username);
@@ -3876,7 +3876,7 @@ string expandTilde(string inputPath) nothrow
                 passwd result;
                 while (1)
                 {
-                    extra_memory = cast(char*)realloc(extra_memory, extra_memory_size * char.sizeof);
+                    extra_memory = cast(char*) realloc(extra_memory, extra_memory_size * char.sizeof);
                     if (extra_memory == null)
                         onOutOfMemoryError();
 

--- a/std/process.d
+++ b/std/process.d
@@ -394,7 +394,7 @@ private Pid spawnProcessImpl(in char[][] args,
         if (fstat(workDirFD, &s) < 0)
             throw ProcessException.newFromErrno("Failed to stat working directory");
         if (!S_ISDIR(s.st_mode))
-            throw new ProcessException("Not a directory: " ~ cast(string)workDir);
+            throw new ProcessException("Not a directory: " ~ cast(string) workDir);
     }
 
     int getFD(ref File f) { return core.stdc.stdio.fileno(f.getFP()); }
@@ -460,13 +460,13 @@ private Pid spawnProcessImpl(in char[][] args,
                 core.sys.posix.unistd._exit(1);
                 assert(0);
             }
-            immutable maxDescriptors = cast(int)r.rlim_cur;
+            immutable maxDescriptors = cast(int) r.rlim_cur;
 
             // The above, less stdin, stdout, and stderr
             immutable maxToClose = maxDescriptors - 3;
 
             // Call poll() to see which ones are actually open:
-            pollfd* pfds = cast(pollfd*)malloc(pollfd.sizeof * maxToClose);
+            pollfd* pfds = cast(pollfd*) malloc(pollfd.sizeof * maxToClose);
             foreach (i; 0 .. maxToClose)
             {
                 pfds[i].fd = i + 3;
@@ -3495,7 +3495,7 @@ private void toAStringz(in string[] a, const(char)**az)
 //{
 //    int spawnvp(int mode, string pathname, string[] argv)
 //    {
-//      char** argv_ = cast(char**)core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
+//      char** argv_ = cast(char**) core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
 //      scope(exit) core.stdc.stdlib.free(argv_);
 //
 //      toAStringz(argv, argv_);
@@ -3748,12 +3748,12 @@ else version (OSX)
         auto childpid = core.sys.posix.unistd.fork();
         if (childpid == 0)
         {
-            core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);
+            core.sys.posix.unistd.execvp(args[0], cast(char**) args.ptr);
             perror(args[0]);                // failed to execute
             return;
         }
         if (browser)
-            free(cast(void*)browser);
+            free(cast(void*) browser);
     }
 }
 else version (Posix)
@@ -3781,12 +3781,12 @@ else version (Posix)
         auto childpid = core.sys.posix.unistd.fork();
         if (childpid == 0)
         {
-            core.sys.posix.unistd.execvp(args[0], cast(char**)args.ptr);
+            core.sys.posix.unistd.execvp(args[0], cast(char**) args.ptr);
             perror(args[0]);                // failed to execute
             return;
         }
         if (browser)
-            free(cast(void*)browser);
+            free(cast(void*) browser);
     }
 }
 else

--- a/std/random.d
+++ b/std/random.d
@@ -273,7 +273,7 @@ The parameters of this distribution. The random number is $(D_PARAM x
     static assert(m == 0 || a < m);
     static assert(m == 0 || c < m);
     static assert(m == 0 ||
-            (cast(ulong)a * (m-1) + c) % m == (c < a ? c - a + m : c - a));
+            (cast(ulong) a * (m-1) + c) % m == (c < a ? c - a + m : c - a));
 
     // Check for maximum range
     private static ulong gcd(ulong a, ulong b) @safe pure nothrow @nogc
@@ -896,7 +896,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     // generator, since it can't cover the full range of
     // possible seed values.  Ideally we need a 64-bit
     // unpredictable seed to complement the 32-bit one!
-    static assert(isSeedable!(Mt19937_64, typeof(map!((a) => (cast(ulong)unpredictableSeed))(repeat(0)))));
+    static assert(isSeedable!(Mt19937_64, typeof(map!((a) => (cast(ulong) unpredictableSeed))(repeat(0)))));
     Mt19937_64 gen;
     assert(gen.front == 14514284786278117030uL);
     popFrontN(gen, 9999);
@@ -1742,7 +1742,7 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T) && isUniformRNG!UniformRand
         else
         {
             static assert(T.sizeof == 8 && r.sizeof == 4);
-            T r1 = urng.front | (cast(T)r << 32);
+            T r1 = urng.front | (cast(T) r << 32);
             urng.popFront();
             return r1;
         }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3636,7 +3636,7 @@ nothrow:
     {
         static auto trustedCtor(typeof(_ptr) p, size_t idx) @trusted
         {
-            return cast(inout)Cycle(*cast(R*)(p), idx);
+            return cast(inout) Cycle(*cast(R*)(p), idx);
         }
         return trustedCtor(_ptr, _index + i);
     }
@@ -5283,7 +5283,7 @@ if ((isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         {
             assert(upper >= lower && upper <= this.length);
 
-            return cast(inout Result)Result(cast(Value)(current + lower * step),
+            return cast(inout Result) Result(cast(Value)(current + lower * step),
                                             cast(Value)(pastLast - (length - upper) * step),
                                             step);
         }
@@ -5362,7 +5362,7 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         {
             assert(upper >= lower && upper <= this.length);
 
-            return cast(inout Result)Result(cast(Value)(current + lower),
+            return cast(inout Result) Result(cast(Value)(current + lower),
                                             cast(Value)(pastLast - (length - upper)));
         }
         @property size_t length() const
@@ -5458,7 +5458,7 @@ body
             Result ret = this;
             ret.index += lower;
             ret.count = upper - lower + ret.index;
-            return cast(inout Result)ret;
+            return cast(inout Result) ret;
         }
         @property size_t length() const
         {
@@ -5641,7 +5641,7 @@ unittest
         int, uint, long, ulong))
     {
         Type val;
-        foreach (i; iota(cast(Type)0, cast(Type)10)) { val++; }
+        foreach (i; iota(cast(Type) 0, cast(Type) 10)) { val++; }
         assert(val == 10);
     }
 }
@@ -7723,7 +7723,7 @@ unittest
 
     static struct Test { int* a; }
     immutable(Test) test;
-    cast(void)only(test, test); // Works with mutable indirection
+    cast(void) only(test, test); // Works with mutable indirection
 }
 
 /**
@@ -8038,7 +8038,7 @@ pure @safe unittest
 
         foreach (T i; 0 .. 5)
         {
-            auto subset = values[cast(size_t)i .. $];
+            auto subset = values[cast(size_t) i .. $];
             auto offsetEnumerated = subset.enumerate(i);
             static assert(is(typeof(enumerated.front.index) == T));
             assert(offsetEnumerated.equal(subset.zip(subset)));
@@ -9074,7 +9074,7 @@ public:
                    `static assert(isForwardRange!S, S.stringof ~ " is not a forward range.");` ~
                    `auto mem = new void[S.sizeof];` ~
                    `emplace!S(mem, cast(S)(*_range).save);` ~
-                   `return RefRange!S(cast(S*)mem.ptr);`;
+                   `return RefRange!S(cast(S*) mem.ptr);`;
         }
 
         static assert(isForwardRange!RefRange);
@@ -9238,7 +9238,7 @@ public:
                    `static assert(hasSlicing!S, S.stringof ~ " is not sliceable.");` ~
                    `auto mem = new void[S.sizeof];` ~
                    `emplace!S(mem, cast(S)(*_range)[begin .. end]);` ~
-                   `return RefRange!S(cast(S*)mem.ptr);`;
+                   `return RefRange!S(cast(S*) mem.ptr);`;
         }
     }
 

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -122,7 +122,7 @@ template BacktrackingMatcher(bool CTregex)
         {
             merge = arrayInChunk!(Trace)(re.hotspotTableSize, memBlock);
             merge[] = Trace.init;
-            memory = cast(size_t[])memBlock;
+            memory = cast(size_t[]) memBlock;
             memory[0] = 0; //hidden pointer
             memory = memory[1..$];
         }
@@ -717,7 +717,7 @@ template BacktrackingMatcher(bool CTregex)
                 *cast(State*)&memory[lastState] =
                     State(index, pc, counter, infiniteNesting);
                 lastState += stateSize;
-                memory[lastState .. lastState + 2 * matches.length] = (cast(size_t[])matches)[];
+                memory[lastState .. lastState + 2 * matches.length] = (cast(size_t[]) matches)[];
                 lastState += 2*matches.length;
                 debug(std_regex_matcher)
                     writefln("Saved(pc=%s) front: %s src: %s",
@@ -730,7 +730,7 @@ template BacktrackingMatcher(bool CTregex)
                 if (!lastState)
                     return prevStack();
                 lastState -= 2*matches.length;
-                auto pm = cast(size_t[])matches;
+                auto pm = cast(size_t[]) matches;
                 pm[] = memory[lastState .. lastState + 2 * matches.length];
                 lastState -= stateSize;
                 State* state = cast(State*)&memory[lastState];
@@ -851,7 +851,7 @@ struct CtContext
                     {
                         newStack();
                         lastState = 0;
-                    }", match - reserved, cast(int)counter + 2);
+                    }", match - reserved, cast(int) counter + 2);
         if (match < total_matches)
             text ~= ctSub("
                     stackPush(matches[$$..$$]);", reserved, match);

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -47,18 +47,18 @@ module std.regex.internal.generator;
             switch (re.ir[pc].code)
             {
             case IR.Char:
-                    formattedWrite(app,"%s", cast(dchar)re.ir[pc].data);
+                    formattedWrite(app,"%s", cast(dchar) re.ir[pc].data);
                     pc += IRL!(IR.Char);
                     break;
                 case IR.OrChar:
                     uint len = re.ir[pc].sequence;
-                    formattedWrite(app, "%s", cast(dchar)re.ir[pc + rand(len)].data);
+                    formattedWrite(app, "%s", cast(dchar) re.ir[pc + rand(len)].data);
                     pc += len;
                     break;
                 case IR.CodepointSet:
                 case IR.Trie:
                     auto set = re.charsets[re.ir[pc].data];
-                    auto x = rand(cast(uint)set.byInterval.length);
+                    auto x = rand(cast(uint) set.byInterval.length);
                     auto y = rand(set.byInterval[x].b - set.byInterval[x].a);
                     formattedWrite(app, "%s", cast(dchar)(set.byInterval[x].a+y));
                     pc += IRL!(IR.CodepointSet);
@@ -69,7 +69,7 @@ module std.regex.internal.generator;
                     {
                         x = rand(0x11_000);
                     }while (x == '\r' || x == '\n' || !isValidDchar(x));
-                    formattedWrite(app, "%s", cast(dchar)x);
+                    formattedWrite(app, "%s", cast(dchar) x);
                     pc += IRL!(IR.Any);
                     break;
                 case IR.GotoEndOr:
@@ -144,7 +144,7 @@ module std.regex.internal.generator;
                         pc += IRL!(IR.InfiniteEnd);
                         break;
                     }
-                    dataLenOld = cast(uint)app.data.length;
+                    dataLenOld = cast(uint) app.data.length;
                     if (app.data.length < limit && rand(3) > 0)
                         pc = pc - len;
                     else

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -390,10 +390,10 @@ struct Group(DataIndex)
     switch (irb[pc].code)
     {
     case IR.Char:
-        formattedWrite(output, " %s (0x%x)",cast(dchar)irb[pc].data, irb[pc].data);
+        formattedWrite(output, " %s (0x%x)",cast(dchar) irb[pc].data, irb[pc].data);
         break;
     case IR.OrChar:
-        formattedWrite(output, " %s (0x%x) seq=%d", cast(dchar)irb[pc].data, irb[pc].data, irb[pc].sequence);
+        formattedWrite(output, " %s (0x%x) seq=%d", cast(dchar) irb[pc].data, irb[pc].data, irb[pc].sequence);
         break;
     case IR.RepeatStart, IR.InfiniteStart, IR.InfiniteBloomStart,
     IR.Option, IR.GotoEndOr, IR.OrStart:
@@ -693,13 +693,13 @@ template BackLooper(E)
 @system T[] mallocArray(T)(size_t len)
 {
     import core.stdc.stdlib : malloc;
-    return (cast(T*)malloc(len * T.sizeof))[0 .. len];
+    return (cast(T*) malloc(len * T.sizeof))[0 .. len];
 }
 
 //very unsafe, no initialization
 @system T[] arrayInChunk(T)(size_t len, ref void[] chunk)
 {
-    auto ret = (cast(T*)chunk.ptr)[0..len];
+    auto ret = (cast(T*) chunk.ptr)[0..len];
     chunk = chunk[len * T.sizeof .. $];
     return ret;
 }

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -116,14 +116,14 @@ private:
         auto t = worklist[$-1];
         worklist.length -= 1;
         if (!__ctfe)
-            cast(void)worklist.assumeSafeAppend();
+            cast(void) worklist.assumeSafeAppend();
         return t;
     }
 
     static uint charLen(uint ch)
     {
         assert(ch <= 0x10FFFF);
-        return codeLength!Char(cast(dchar)ch)*charSize;
+        return codeLength!Char(cast(dchar) ch)*charSize;
     }
 
 public:
@@ -405,7 +405,7 @@ public:
         if (fChar != uint.max)
         {
             const(ubyte)* end = cast(ubyte*)(haystack.ptr + haystack.length);
-            const orginalAlign = cast(size_t)p & (Char.sizeof-1);
+            const orginalAlign = cast(size_t) p & (Char.sizeof-1);
             while (p != end)
             {
                 if (!~state)
@@ -413,16 +413,16 @@ public:
                     for (;;)
                     {
                         assert(p <= end, text(p," vs ", end));
-                        p = cast(ubyte*)memchr(p, fChar, end - p);
+                        p = cast(ubyte*) memchr(p, fChar, end - p);
                         if (!p)
                             return haystack.length;
-                        if ((cast(size_t)p & (Char.sizeof-1)) == orginalAlign)
+                        if ((cast(size_t) p & (Char.sizeof-1)) == orginalAlign)
                             break;
                         if (++p == end)
                             return haystack.length;
                     }
                     state = ~1u;
-                    assert((cast(size_t)p & (Char.sizeof-1)) == orginalAlign);
+                    assert((cast(size_t) p & (Char.sizeof-1)) == orginalAlign);
                     static if (charSize == 3)
                     {
                         state = (state<<1) | table[p[1]];
@@ -433,7 +433,7 @@ public:
                         p++;
                     //first char is tested, see if that's all
                     if (!(state & limit))
-                        return (p-cast(ubyte*)haystack.ptr)/Char.sizeof
+                        return (p-cast(ubyte*) haystack.ptr)/Char.sizeof
                             -length;
                 }
                 else
@@ -452,7 +452,7 @@ public:
                         p++;
                     }
                     if (!(state & limit))
-                        return (p-cast(ubyte*)haystack.ptr)/Char.sizeof
+                        return (p-cast(ubyte*) haystack.ptr)/Char.sizeof
                             -length;
                 }
                 debug(std_regex_search) writefln("State: %32b", state);
@@ -471,7 +471,7 @@ public:
                     state = (state<<1) | table[p[2]];
                     p += 4;
                     if (!(state & limit))//division rounds down for dchar
-                        return (p-cast(ubyte*)haystack.ptr)/Char.sizeof
+                        return (p-cast(ubyte*) haystack.ptr)/Char.sizeof
                         -length;
                 }
             }

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -80,10 +80,10 @@ unittest
 @trusted void reverseBytecode()(Bytecode[] code)
 {
     Bytecode[] rev = new Bytecode[code.length];
-    uint revPc = cast(uint)rev.length;
+    uint revPc = cast(uint) rev.length;
     Stack!(Tuple!(uint, uint, uint)) stack;
     uint start = 0;
-    uint end = cast(uint)code.length;
+    uint end = cast(uint) code.length;
     for (;;)
     {
         for (uint pc = start; pc < end; )
@@ -238,7 +238,7 @@ auto caseEnclose(CodepointSet set)
         auto val = data[$ - 1];
         data = data[0 .. $ - 1];
         if (!__ctfe)
-            cast(void)data.assumeSafeAppend();
+            cast(void) data.assumeSafeAppend();
         return val;
     }
 
@@ -305,7 +305,7 @@ struct CodeGen
     //try to generate optimal IR code for this CodepointSet
     @trusted void charsetToIr(CodepointSet set)
     {//@@@BUG@@@ writeln is @system
-        uint chars = cast(uint)set.length;
+        uint chars = cast(uint) set.length;
         if (chars < Bytecode.maxSequence)
         {
             switch (chars)
@@ -328,21 +328,21 @@ struct CodeGen
             if (n >= 0)
             {
                 if (ivals.length*2 > maxCharsetUsed)
-                    put(Bytecode(IR.Trie, cast(uint)n));
+                    put(Bytecode(IR.Trie, cast(uint) n));
                 else
-                    put(Bytecode(IR.CodepointSet, cast(uint)n));
+                    put(Bytecode(IR.CodepointSet, cast(uint) n));
                 return;
             }
             if (ivals.length*2 > maxCharsetUsed)
             {
                 auto t  = getMatcher(set);
-                put(Bytecode(IR.Trie, cast(uint)matchers.length));
+                put(Bytecode(IR.Trie, cast(uint) matchers.length));
                 matchers ~= t;
                 debug(std_regex_allocation) writeln("Trie generated");
             }
             else
             {
-                put(Bytecode(IR.CodepointSet, cast(uint)charsets.length));
+                put(Bytecode(IR.CodepointSet, cast(uint) charsets.length));
                 matchers ~= CharMatcher.init;
             }
             charsets ~= set;
@@ -408,7 +408,7 @@ struct CodeGen
     {
         lookaroundNest--;
         ir[fix] = Bytecode(ir[fix].code,
-            cast(uint)ir.length - fix - IRL!(IR.LookaheadStart));
+            cast(uint) ir.length - fix - IRL!(IR.LookaheadStart));
         auto g = groupStack.pop();
         assert(!groupStack.empty);
         ir[fix+1] = Bytecode.fromRaw(groupStack.top);
@@ -441,7 +441,7 @@ struct CodeGen
         import std.algorithm.mutation : copy;
         import std.array : insertInPlace;
         immutable replace = ir[offset].code == IR.Nop;
-        immutable len = cast(uint)ir.length - offset - replace;
+        immutable len = cast(uint) ir.length - offset - replace;
         if (max != infinite)
         {
             if (min != 1 || max != 1)
@@ -507,9 +507,9 @@ struct CodeGen
         uint fix = fixupStack.top;
         if (ir.length > fix && ir[fix].code == IR.Option)
         {
-            ir[fix] = Bytecode(ir[fix].code, cast(uint)ir.length - fix);
+            ir[fix] = Bytecode(ir[fix].code, cast(uint) ir.length - fix);
             put(Bytecode(IR.GotoEndOr, 0));
-            fixupStack.top = cast(uint)ir.length; //replace latest fixup for Option
+            fixupStack.top = cast(uint) ir.length; //replace latest fixup for Option
             put(Bytecode(IR.Option, 0));
             return;
         }
@@ -517,19 +517,19 @@ struct CodeGen
         //start a new option
         if (fixupStack.length == 1)
         {//only root entry, effectively no fixup
-            len = cast(uint)ir.length + IRL!(IR.GotoEndOr);
+            len = cast(uint) ir.length + IRL!(IR.GotoEndOr);
             orStart = 0;
         }
         else
         {//IR.lookahead, etc. fixups that have length > 1, thus check ir[x].length
-            len = cast(uint)ir.length - fix - (ir[fix].length - 1);
+            len = cast(uint) ir.length - fix - (ir[fix].length - 1);
             orStart = fix + ir[fix].length;
         }
         insertInPlace(ir, orStart, Bytecode(IR.OrStart, 0), Bytecode(IR.Option, len));
         assert(ir[orStart].code == IR.OrStart);
         put(Bytecode(IR.GotoEndOr, 0));
         fixupStack.push(orStart); //fixup for StartOR
-        fixupStack.push(cast(uint)ir.length); //for second Option
+        fixupStack.push(cast(uint) ir.length); //for second Option
         put(Bytecode(IR.Option, 0));
     }
 
@@ -537,11 +537,11 @@ struct CodeGen
     void finishAlternation(uint fix)
     {
         enforce(ir[fix].code == IR.Option, "no matching ')'");
-        ir[fix] = Bytecode(ir[fix].code, cast(uint)ir.length - fix - IRL!(IR.OrStart));
+        ir[fix] = Bytecode(ir[fix].code, cast(uint) ir.length - fix - IRL!(IR.OrStart));
         fix = fixupStack.pop();
         enforce(ir[fix].code == IR.OrStart, "no matching ')'");
-        ir[fix] = Bytecode(IR.OrStart, cast(uint)ir.length - fix - IRL!(IR.OrStart));
-        put(Bytecode(IR.OrEnd, cast(uint)ir.length - fix - IRL!(IR.OrStart)));
+        ir[fix] = Bytecode(IR.OrStart, cast(uint) ir.length - fix - IRL!(IR.OrStart));
+        put(Bytecode(IR.OrEnd, cast(uint) ir.length - fix - IRL!(IR.OrStart)));
         uint pc = fix + IRL!(IR.OrStart);
         while (ir[pc].code == IR.Option)
         {
@@ -600,7 +600,7 @@ struct CodeGen
 
     @property size_t fixupLength(){ return fixupStack.data.length; }
 
-    @property uint length(){ return cast(uint)ir.length; }
+    @property uint length(){ return cast(uint) ir.length; }
 }
 
 // safety limits
@@ -630,7 +630,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
         parseFlags(flags);
         _current = ' ';//a safe default for freeform parsing
         next();
-        g.start(cast(uint)pat.length);
+        g.start(cast(uint) pat.length);
         try
         {
             parseRegex();
@@ -978,7 +978,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
                     g.put(Bytecode(IR.Char, range.front));
                 else
                     foreach (v; range)
-                        g.put(Bytecode(IR.OrChar, v, cast(uint)range.length));
+                        g.put(Bytecode(IR.OrChar, v, cast(uint) range.length));
             }
             else
                 g.put(Bytecode(IR.Char, current));
@@ -1458,7 +1458,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
             g.put(Bytecode(IR.Char, 0));//NUL character
             break;
         case '1': .. case '9':
-            uint nref = cast(uint)current - '0';
+            uint nref = cast(uint) current - '0';
             immutable maxBackref = sum(g.groupStack.data);
             enforce(nref < maxBackref, "Backref to unseen group");
             //perl's disambiguation rule i.e.
@@ -1504,14 +1504,14 @@ if (isForwardRange!R && is(ElementType!R : dchar))
         {
             while (k < MAX_PROPERTY && next() && current !='}' && current !=':')
                 if (current != '-' && current != ' ' && current != '_')
-                    result[k++] = cast(char)std.ascii.toLower(current);
+                    result[k++] = cast(char) std.ascii.toLower(current);
             enforce(k != MAX_PROPERTY, "invalid property name");
             enforce(current == '}', "} expected ");
         }
         else
         {//single char properties e.g.: \pL, \pN ...
             enforce(current < 0x80, "invalid property name");
-            result[k++] = cast(char)current;
+            result[k++] = cast(char) current;
         }
         auto s = getUnicodeSet(result[0..k], negated,
             cast(bool)(re_flags & RegexOption.casefold));
@@ -1581,7 +1581,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
                 cumRange += cntRange;
                 enforce(cumRange < maxCumulativeRepetitionLength,
                     "repetition length limit is exceeded");
-                counterRange.push(cast(uint)cntRange + counterRange.top);
+                counterRange.push(cast(uint) cntRange + counterRange.top);
                 threadCount += counterRange.top;
                 break;
             case IR.RepeatEnd, IR.RepeatQEnd:
@@ -1693,7 +1693,7 @@ void optimize(Char)(ref Regex!Char zis)
                 ir[i - ir[i].data - IRL!(InfiniteStart)] =
                     Bytecode(InfiniteBloomStart, ir[i].data);
                 ir.insertInPlace(i+IRL!(InfiniteEnd),
-                    Bytecode.fromRaw(cast(uint)zis.filters.length));
+                    Bytecode.fromRaw(cast(uint) zis.filters.length));
                 zis.filters ~= BitTable(set);
                 fixupBytecode(ir);
             }

--- a/std/regex/internal/shiftor.d
+++ b/std/regex/internal/shiftor.d
@@ -117,14 +117,14 @@ pure:
         auto t = worklist[$-1];
         worklist.length -= 1;
         //if (!__ctfe)
-        //    cast(void)worklist.assumeSafeAppend();
+        //    cast(void) worklist.assumeSafeAppend();
         return t;
     }
 
     static uint charLen(uint ch)
     {
         assert(ch <= 0x10FFFF);
-        return codeLength!Char(cast(dchar)ch)*charSize;
+        return codeLength!Char(cast(dchar) ch)*charSize;
     }
 
 public:
@@ -388,7 +388,7 @@ public:
         if (fChar != uint.max)
         {
             const(ubyte)* end = cast(ubyte*)(haystack.ptr + haystack.length);
-            const orginalAlign = cast(size_t)p & (Char.sizeof-1);
+            const orginalAlign = cast(size_t) p & (Char.sizeof-1);
             while (p != end)
             {
                 if (!~state)
@@ -396,13 +396,13 @@ public:
                     for (;;)
                     {
                         assert(p <= end, text(p," vs ", end));
-                        p = cast(ubyte*)memchr(p, fChar, end - p);
+                        p = cast(ubyte*) memchr(p, fChar, end - p);
                         if (!p)
                         {
                             s._index = haystack.length;
                             return false;
                         }
-                        if ((cast(size_t)p & (Char.sizeof-1)) == orginalAlign)
+                        if ((cast(size_t) p & (Char.sizeof-1)) == orginalAlign)
                             break;
                         if (++p == end)
                         {
@@ -411,7 +411,7 @@ public:
                         }
                     }
                     state = ~1u;
-                    assert((cast(size_t)p & (Char.sizeof-1)) == orginalAlign);
+                    assert((cast(size_t) p & (Char.sizeof-1)) == orginalAlign);
                     static if (charSize == 3)
                     {
                         state = (state<<1) | table[p[1]];
@@ -423,7 +423,7 @@ public:
                     //first char is tested, see if that's all
                     if (!(state & limit))
                     {
-                        s._index =  (p-cast(ubyte*)haystack.ptr)/Char.sizeof-length;
+                        s._index =  (p-cast(ubyte*) haystack.ptr)/Char.sizeof-length;
                         return true;
                     }
                 }
@@ -444,7 +444,7 @@ public:
                     }
                     if (!(state & limit))
                     {
-                        s._index = (p-cast(ubyte*)haystack.ptr)/Char.sizeof-length;
+                        s._index = (p-cast(ubyte*) haystack.ptr)/Char.sizeof-length;
                         return true;
                     }
                 }
@@ -465,7 +465,7 @@ public:
                     p += 4;
                     if (!(state & limit))//division rounds down for dchar
                     {
-                        s._index = (p-cast(ubyte*)haystack.ptr)/Char.sizeof-length;
+                        s._index = (p-cast(ubyte*) haystack.ptr)/Char.sizeof-length;
                         return true;
                     }
                 }

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -468,7 +468,7 @@ private:
         import std.exception : enforce;
         if (n > smallString)
         {
-            auto p = cast(Group!DataIndex*)enforce(
+            auto p = cast(Group!DataIndex*) enforce(
                 calloc(Group!DataIndex.sizeof,n),
                 "Failed to allocate Captures struct"
             );

--- a/std/signals.d
+++ b/std/signals.d
@@ -147,7 +147,7 @@ mixin template Signal(T1...)
                 auto p = core.stdc.stdlib.calloc(slot_t.sizeof, len);
                 if (!p)
                     core.exception.onOutOfMemoryError();
-                slots = (cast(slot_t*)p)[0 .. len];
+                slots = (cast(slot_t*) p)[0 .. len];
             }
             else
             {
@@ -160,7 +160,7 @@ mixin template Signal(T1...)
                 auto p = core.stdc.stdlib.realloc(slots.ptr, nbytes);
                 if (!p)
                     core.exception.onOutOfMemoryError();
-                slots = (cast(slot_t*)p)[0 .. len];
+                slots = (cast(slot_t*) p)[0 .. len];
                 slots[slots_idx + 1 .. $] = null;
             }
         }
@@ -227,7 +227,7 @@ mixin template Signal(T1...)
     final void unhook(Object o)
     in { assert( status == ST.idle ); }
     body {
-        debug (signal) writefln("Signal.unhook(o = %s)", cast(void*)o);
+        debug (signal) writefln("Signal.unhook(o = %s)", cast(void*) o);
         for (size_t i = 0; i < slots_idx; )
         {
             if (_d_toObject(slots[i].ptr) is o)

--- a/std/socket.d
+++ b/std/socket.d
@@ -430,7 +430,7 @@ class Protocol
 
     void populate(protoent* proto) @system pure nothrow
     {
-        type = cast(ProtocolType)proto.p_proto;
+        type = cast(ProtocolType) proto.p_proto;
         name = to!string(proto.p_name);
 
         int i;
@@ -532,7 +532,7 @@ class Service
     void populate(servent* serv) @system pure nothrow
     {
         name = to!string(serv.s_name);
-        port = ntohs(cast(ushort)serv.s_port);
+        port = ntohs(cast(ushort) serv.s_port);
         protocolName = to!string(serv.s_proto);
 
         int i;
@@ -661,7 +661,7 @@ class InternetHost
 
     void validHostent(in hostent* he)
     {
-        if (he.h_addrtype != cast(int)AddressFamily.INET || he.h_length != 4)
+        if (he.h_addrtype != cast(int) AddressFamily.INET || he.h_length != 4)
             throw new HostException("Address family mismatch");
     }
 
@@ -706,7 +706,7 @@ class InternetHost
             addrList = new uint[i];
             for (i = 0; i != addrList.length; i++)
             {
-                addrList[i] = ntohl(*(cast(uint*)he.h_addr_list[i]));
+                addrList[i] = ntohl(*(cast(uint*) he.h_addr_list[i]));
             }
         }
         else
@@ -783,7 +783,7 @@ class InternetHost
     {
         return getHost!q{
             auto x = htonl(param);
-            auto he = gethostbyaddr(&x, 4, cast(int)AddressFamily.INET);
+            auto he = gethostbyaddr(&x, 4, cast(int) AddressFamily.INET);
         }(addr);
     }
 
@@ -798,7 +798,7 @@ class InternetHost
             auto x = inet_addr(param.tempCString());
             enforce(x != INADDR_NONE,
                 new SocketParameterException("Invalid IPv4 address"));
-            auto he = gethostbyaddr(&x, 4, cast(int)AddressFamily.INET);
+            auto he = gethostbyaddr(&x, 4, cast(int) AddressFamily.INET);
         }(addr);
     }
 }
@@ -1293,7 +1293,7 @@ abstract class Address
             auto buf = new char[NI_MAXHOST];
             auto ret = getnameinfoPointer(
                         name, nameLen,
-                        buf.ptr, cast(uint)buf.length,
+                        buf.ptr, cast(uint) buf.length,
                         null, 0,
                         numeric ? NI_NUMERICHOST : NI_NAMEREQD);
 
@@ -1325,7 +1325,7 @@ abstract class Address
             enforce(getnameinfoPointer(
                         name, nameLen,
                         null, 0,
-                        buf.ptr, cast(uint)buf.length,
+                        buf.ptr, cast(uint) buf.length,
                         numeric ? NI_NUMERICSERV : NI_NAMEREQD
                     ) == 0, new AddressException("Could not get " ~
                         (numeric ? "port number" : "service name")));
@@ -1454,7 +1454,7 @@ public:
     /// Constructs an $(D Address) with a copy of the specified $(D sockaddr).
     this(const(sockaddr)* sa, socklen_t len) @system pure nothrow
     {
-        this.sa = cast(sockaddr*) (cast(ubyte*)sa)[0..len].dup.ptr;
+        this.sa = cast(sockaddr*) (cast(ubyte*) sa)[0..len].dup.ptr;
         this.len = len;
     }
 
@@ -1633,7 +1633,7 @@ public:
      */
     override bool opEquals(Object o) const
     {
-        auto other = cast(InternetAddress)o;
+        auto other = cast(InternetAddress) o;
         return other && this.sin.sin_addr.s_addr == other.sin.sin_addr.s_addr &&
             this.sin.sin_port == other.sin.sin_port;
     }
@@ -1810,7 +1810,7 @@ public:
     {
         auto results = getAddressInfo(addr, service, AddressFamily.INET6);
         assert(results.length && results[0].family == AddressFamily.INET6);
-        sin6 = *cast(sockaddr_in6*)results[0].address.name;
+        sin6 = *cast(sockaddr_in6*) results[0].address.name;
     }
 
     /**
@@ -1873,7 +1873,7 @@ public:
         // instead.
         auto results = getAddressInfo(addr, AddressInfoFlags.NUMERICHOST);
         if (results.length && results[0].family == AddressFamily.INET6)
-            return (cast(sockaddr_in6*)results[0].address.name).sin6_addr.s6_addr;
+            return (cast(sockaddr_in6*) results[0].address.name).sin6_addr.s6_addr;
         throw new AddressException("Not an IPv6 address", 0);
     }
 }
@@ -2178,7 +2178,7 @@ private:
 
         static fd_set_type mask(uint n) pure nothrow @nogc
         {
-            return (cast(fd_set_type)1) << (n % FD_NFDBITS);
+            return (cast(fd_set_type) 1) << (n % FD_NFDBITS);
         }
 
         // Array size to fit that many sockets
@@ -2343,13 +2343,13 @@ public:
      */
     @property uint max() const pure nothrow @nogc
     {
-        return cast(uint)capacity;
+        return cast(uint) capacity;
     }
 
 
     fd_set* toFd_set() @trusted pure nothrow @nogc
     {
-        return cast(fd_set*)set.ptr;
+        return cast(fd_set*) set.ptr;
     }
 
 
@@ -2369,7 +2369,7 @@ public:
 @safe unittest
 {
     auto fds = cast(socket_t[])
-        [cast(socket_t)1, 2, 0, 1024, 17, 42, 1234, 77, 77+32, 77+64];
+        [cast(socket_t) 1, 2, 0, 1024, 17, 42, 1234, 77, 77+32, 77+64];
     auto set = new SocketSet();
     foreach (fd; fds) assert(!set.isSet(fd));
     foreach (fd; fds) set.add(fd);
@@ -2378,7 +2378,7 @@ public:
     // Make sure SocketSet reimplements fd_set correctly
     auto fdset = set.toFd_set();
     foreach (fd; fds[0]..cast(socket_t)(fds[$-1]+1))
-        assert(cast(bool)set.isSet(fd) == cast(bool)(() @trusted => FD_ISSET(fd, fdset))());
+        assert(cast(bool) set.isSet(fd) == cast(bool)(() @trusted => FD_ISSET(fd, fdset))());
 
     foreach (fd; fds)
     {
@@ -2470,7 +2470,7 @@ public:
 
     enum LIMIT = 4096;
     foreach (n; 0..LIMIT)
-        set.add(cast(socket_t)n);
+        set.add(cast(socket_t) n);
     assert(set.max >= LIMIT);
 }
 
@@ -2599,7 +2599,7 @@ private:
         // has it (e.g. on OS X).
         static if (is(typeof(SO_NOSIGPIPE)))
         {
-            setOption(SocketOptionLevel.SOCKET, cast(SocketOption)SO_NOSIGPIPE, true);
+            setOption(SocketOptionLevel.SOCKET, cast(SocketOption) SO_NOSIGPIPE, true);
         }
     }
 
@@ -2632,7 +2632,7 @@ public:
         /* A single protocol exists to support this socket type within the
          * protocol family, so the ProtocolType is assumed.
          */
-        this(af, type, cast(ProtocolType)0);         // Pseudo protocol number.
+        this(af, type, cast(ProtocolType) 0);         // Pseudo protocol number.
     }
 
 
@@ -2643,7 +2643,7 @@ public:
         proto = getprotobyname(protocolName.tempCString());
         if (!proto)
             throw new SocketOSException("Unable to find the protocol");
-        this(af, type, cast(ProtocolType)proto.p_proto);
+        this(af, type, cast(ProtocolType) proto.p_proto);
     }
 
 
@@ -2839,7 +2839,7 @@ public:
     /// Disables sends and/or receives.
     void shutdown(SocketShutdown how) @trusted nothrow @nogc
     {
-        .shutdown(sock, cast(int)how);
+        .shutdown(sock, cast(int) how);
     }
 
 
@@ -2921,7 +2921,7 @@ public:
         // Luckily, the send/recv functions make no guarantee that
         // all the data is sent, so we use that to send at most
         // int.max bytes.
-        return size > size_t(int.max) ? int.max : cast(int)size;
+        return size > size_t(int.max) ? int.max : cast(int) size;
     }
 
     /**
@@ -2937,9 +2937,9 @@ public:
             flags = cast(SocketFlags)(flags | MSG_NOSIGNAL);
         }
         version( Windows )
-            auto sent = .send(sock, buf.ptr, capToInt(buf.length), cast(int)flags);
+            auto sent = .send(sock, buf.ptr, capToInt(buf.length), cast(int) flags);
         else
-            auto sent = .send(sock, buf.ptr, buf.length, cast(int)flags);
+            auto sent = .send(sock, buf.ptr, buf.length, cast(int) flags);
         return sent;
     }
 
@@ -2965,10 +2965,10 @@ public:
         version( Windows )
             return .sendto(
                        sock, buf.ptr, capToInt(buf.length),
-                       cast(int)flags, to.name, to.nameLen
+                       cast(int) flags, to.name, to.nameLen
                        );
         else
-            return .sendto(sock, buf.ptr, buf.length, cast(int)flags, to.name, to.nameLen);
+            return .sendto(sock, buf.ptr, buf.length, cast(int) flags, to.name, to.nameLen);
     }
 
     /// ditto
@@ -2987,9 +2987,9 @@ public:
             flags = cast(SocketFlags)(flags | MSG_NOSIGNAL);
         }
         version(Windows)
-            return .sendto(sock, buf.ptr, capToInt(buf.length), cast(int)flags, null, 0);
+            return .sendto(sock, buf.ptr, capToInt(buf.length), cast(int) flags, null, 0);
         else
-            return .sendto(sock, buf.ptr, buf.length, cast(int)flags, null, 0);
+            return .sendto(sock, buf.ptr, buf.length, cast(int) flags, null, 0);
     }
 
 
@@ -3012,13 +3012,13 @@ public:
         version(Windows)         // Does not use size_t
         {
             return buf.length
-                   ? .recv(sock, buf.ptr, capToInt(buf.length), cast(int)flags)
+                   ? .recv(sock, buf.ptr, capToInt(buf.length), cast(int) flags)
                    : 0;
         }
         else
         {
             return buf.length
-                   ? .recv(sock, buf.ptr, buf.length, cast(int)flags)
+                   ? .recv(sock, buf.ptr, buf.length, cast(int) flags)
                    : 0;
         }
     }
@@ -3045,14 +3045,14 @@ public:
         socklen_t nameLen = from.nameLen;
         version(Windows)
         {
-            auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int)flags, from.name, &nameLen);
+            auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int) flags, from.name, &nameLen);
             assert(from.addressFamily == _family);
             // if (!read) //connection closed
             return read;
         }
         else
         {
-            auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, from.name, &nameLen);
+            auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int) flags, from.name, &nameLen);
             assert(from.addressFamily == _family);
             // if (!read) //connection closed
             return read;
@@ -3075,13 +3075,13 @@ public:
             return 0;
         version(Windows)
         {
-            auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int)flags, null, null);
+            auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int) flags, null, null);
             // if (!read) //connection closed
             return read;
         }
         else
         {
-            auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int)flags, null, null);
+            auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int) flags, null, null);
             // if (!read) //connection closed
             return read;
         }
@@ -3104,7 +3104,7 @@ public:
     int getOption(SocketOptionLevel level, SocketOption option, void[] result) @trusted
     {
         socklen_t len = cast(socklen_t) result.length;
-        if (_SOCKET_ERROR == .getsockopt(sock, cast(int)level, cast(int)option, result.ptr, &len))
+        if (_SOCKET_ERROR == .getsockopt(sock, cast(int) level, cast(int) option, result.ptr, &len))
             throw new SocketOSException("Unable to get socket option");
         return len;
     }
@@ -3120,7 +3120,7 @@ public:
     /// Get the linger option.
     int getOption(SocketOptionLevel level, SocketOption option, out Linger result) @trusted
     {
-        //return getOption(cast(SocketOptionLevel)SocketOptionLevel.SOCKET, SocketOption.LINGER, (&result)[0 .. 1]);
+        //return getOption(cast(SocketOptionLevel) SocketOptionLevel.SOCKET, SocketOption.LINGER, (&result)[0 .. 1]);
         return getOption(level, option, (&result.clinger)[0 .. 1]);
     }
 
@@ -3151,8 +3151,8 @@ public:
     /// Set a socket option.
     void setOption(SocketOptionLevel level, SocketOption option, void[] value) @trusted
     {
-        if (_SOCKET_ERROR == .setsockopt(sock, cast(int)level,
-                                        cast(int)option, value.ptr, cast(uint) value.length))
+        if (_SOCKET_ERROR == .setsockopt(sock, cast(int) level,
+                                        cast(int) option, value.ptr, cast(uint) value.length))
             throw new SocketOSException("Unable to set socket option");
     }
 
@@ -3167,7 +3167,7 @@ public:
     /// Set the linger option.
     void setOption(SocketOptionLevel level, SocketOption option, Linger value) @trusted
     {
-        //setOption(cast(SocketOptionLevel)SocketOptionLevel.SOCKET, SocketOption.LINGER, (&value)[0 .. 1]);
+        //setOption(cast(SocketOptionLevel) SocketOptionLevel.SOCKET, SocketOption.LINGER, (&value)[0 .. 1]);
         setOption(level, option, (&value.clinger)[0 .. 1]);
     }
 
@@ -3281,8 +3281,8 @@ public:
         else
         static if (is(typeof(TCP_KEEPIDLE)) && is(typeof(TCP_KEEPINTVL)))
         {
-            setOption(SocketOptionLevel.TCP, cast(SocketOption)TCP_KEEPIDLE, time);
-            setOption(SocketOptionLevel.TCP, cast(SocketOption)TCP_KEEPINTVL, interval);
+            setOption(SocketOptionLevel.TCP, cast(SocketOption) TCP_KEEPIDLE, time);
+            setOption(SocketOptionLevel.TCP, cast(SocketOption) TCP_KEEPINTVL, interval);
             setOption(SocketOptionLevel.SOCKET, SocketOption.KEEPALIVE, true);
         }
         else
@@ -3315,8 +3315,8 @@ public:
     {
         auto vals = timeout.split!("seconds", "usecs")();
         TimeVal tv;
-        tv.seconds      = cast(tv.tv_sec_t )vals.seconds;
-        tv.microseconds = cast(tv.tv_usec_t)vals.usecs;
+        tv.seconds      = cast(tv.tv_sec_t ) vals.seconds;
+        tv.microseconds = cast(tv.tv_usec_t) vals.usecs;
         return select(checkRead, checkWrite, checkError, &tv);
     }
 
@@ -3565,7 +3565,7 @@ Socket[2] socketPair() @trusted
         Socket toSocket(size_t id)
         {
             auto s = new Socket;
-            s.setSock(cast(socket_t)socks[id]);
+            s.setSock(cast(socket_t) socks[id]);
             s._family = AddressFamily.UNIX;
             return s;
         }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -613,7 +613,7 @@ Throws: $(D ErrnoException) in case of error.
             auto fp = fopen("NUL", modez);
             errnoEnforce(fp, "Cannot open placeholder NUL stream");
             FLOCK(fp);
-            auto iob = cast(_iobuf*)fp;
+            auto iob = cast(_iobuf*) fp;
             .close(iob._file);
             iob._file = fd;
             iob._flag &= ~_IOTRAN;
@@ -673,7 +673,7 @@ Throws: $(D ErrnoException) in case of error.
                     default: break;
                 }
 
-            auto fd = _open_osfhandle(cast(intptr_t)handle, mode);
+            auto fd = _open_osfhandle(cast(intptr_t) handle, mode);
         }
 
         errnoEnforce(fd >= 0, "Cannot open Windows HANDLE");
@@ -1514,7 +1514,7 @@ void main()
     {
         Unqual!(ElementEncodingType!S)[] buf;
         readln(buf, terminator);
-        return cast(S)buf;
+        return cast(S) buf;
     }
 
     @system unittest
@@ -2564,7 +2564,7 @@ $(D StdioException).
 
         uint i;
         foreach (chunk; f.byChunk(4))
-            assert(chunk == cast(ubyte[])witness[i++]);
+            assert(chunk == cast(ubyte[]) witness[i++]);
 
         assert(i == witness.length);
     }
@@ -2589,7 +2589,7 @@ $(D StdioException).
 
         uint i;
         foreach (chunk; f.byChunk(new ubyte[4]))
-            assert(chunk == cast(ubyte[])witness[i++]);
+            assert(chunk == cast(ubyte[]) witness[i++]);
 
         assert(i == witness.length);
     }
@@ -3241,7 +3241,7 @@ struct LockingTextReader
                 .destroy(_f);
                 return true;
             }
-            _front = cast(char)c;
+            _front = cast(char) c;
             _hasChar = true;
         }
         return false;
@@ -4009,7 +4009,7 @@ struct lines
         ubyte[] buffer;
         static if (Parms.length == 2)
             Parms[0] line = 0;
-        while ((c = FGETC(cast(_iobuf*)f._p.handle)) != -1)
+        while ((c = FGETC(cast(_iobuf*) f._p.handle)) != -1)
         {
             buffer ~= to!(ubyte)(c);
             if (c == terminator)
@@ -4526,7 +4526,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     /* Since fps is now locked, we can create an "unshared" version
      * of fp.
      */
-    auto fp = cast(_iobuf*)fps;
+    auto fp = cast(_iobuf*) fps;
 
     ReadlnAppender app;
     app.initialize(buf);
@@ -4556,7 +4556,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
                     }
                     c = ((c - 0xD7C0) << 10) + (c2 - 0xDC00);
                 }
-                app.putdchar(cast(dchar)c);
+                app.putdchar(cast(dchar) c);
             }
         }
         if (ferror(fps))
@@ -4615,7 +4615,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
                 }
             }
             app.putonly(p[0..i]);
-            app.buf[i - 1] = cast(char)terminator;
+            app.buf[i - 1] = cast(char) terminator;
             if (terminator == '\n' && c == '\r')
                 i++;
         }
@@ -4649,7 +4649,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     /* Since fps is now locked, we can create an "unshared" version
      * of fp.
      */
-    auto fp = cast(_iobuf*)fps;
+    auto fp = cast(_iobuf*) fps;
 
     ReadlnAppender app;
     app.initialize(buf);
@@ -4685,7 +4685,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
          */
         FLOCK(fps);
         scope(exit) FUNLOCK(fps);
-        auto fp = cast(_iobuf*)fps;
+        auto fp = cast(_iobuf*) fps;
         version (Windows)
         {
             buf.length = 0;
@@ -4724,9 +4724,9 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
                 import std.utf : encode;
 
                 if ((c & ~0x7F) == 0)
-                    buf ~= cast(char)c;
+                    buf ~= cast(char) c;
                 else
-                    encode(buf, cast(dchar)c);
+                    encode(buf, cast(dchar) c);
                 if (c == terminator)
                     break;
             }
@@ -4781,7 +4781,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
 
     FLOCK(fps);
     scope(exit) FUNLOCK(fps);
-    auto fp = cast(_iobuf*)fps;
+    auto fp = cast(_iobuf*) fps;
     if (orientation == File.Orientation.wide)
     {
         /* Stream is in wide characters.
@@ -4824,9 +4824,9 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
             for (int c; (c = FGETWC(fp)) != -1; )
             {
                 if ((c & ~0x7F) == 0)
-                    buf ~= cast(char)c;
+                    buf ~= cast(char) c;
                 else
-                    encode(buf, cast(dchar)c);
+                    encode(buf, cast(dchar) c);
                 if (c == terminator)
                     break;
             }
@@ -4861,7 +4861,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     // Then, append to it
     for (int c; (c = FGETC(fp)) != -1; )
     {
-        buf ~= cast(char)c;
+        buf ~= cast(char) c;
         if (c == terminator)
         {
             // No need to test for errors in file

--- a/std/string.d
+++ b/std/string.d
@@ -394,7 +394,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
                     return p ? p - s.ptr : -1;
                 }
 
-                return trustedmemchr(s, cast(char)c);
+                return trustedmemchr(s, cast(char) c);
             }
         }
 
@@ -512,7 +512,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
             ptrdiff_t foundIdx = indexOf(s[startIdx .. $], c, cs);
             if (foundIdx != -1)
             {
-                return foundIdx + cast(ptrdiff_t)startIdx;
+                return foundIdx + cast(ptrdiff_t) startIdx;
             }
         }
     }
@@ -527,7 +527,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
         ptrdiff_t foundIdx = indexOf(s, c, cs);
         if (foundIdx != -1)
         {
-            return foundIdx + cast(ptrdiff_t)startIdx;
+            return foundIdx + cast(ptrdiff_t) startIdx;
         }
     }
     return -1;
@@ -586,7 +586,7 @@ if (isConvertibleToString!Range)
     {
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        assert(indexOf(cast(S)null, cast(dchar)'a') == -1);
+        assert(indexOf(cast(S) null, cast(dchar)'a') == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a') == -1);
         assert(indexOf(to!S("abba"), cast(dchar)'a') == 0);
         assert(indexOf(to!S("def"), cast(dchar)'f') == 2);
@@ -644,7 +644,7 @@ if (isConvertibleToString!Range)
 
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        assert(indexOf(cast(S)null, cast(dchar)'a', 1) == -1);
+        assert(indexOf(cast(S) null, cast(dchar)'a', 1) == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a', 1) == -1);
         assert(indexOf(to!S("abba"), cast(dchar)'a', 1) == 3);
         assert(indexOf(to!S("def"), cast(dchar)'f', 1) == 2);
@@ -660,10 +660,10 @@ if (isConvertibleToString!Range)
         assert(indexOf(to!S("def"), cast(dchar)'F', 2, No.caseSensitive) == 2);
 
         S sPlts = "Mars: the fourth Rock (Planet) from the Sun.";
-        assert(indexOf("def", cast(char)'f', cast(uint)2,
+        assert(indexOf("def", cast(char)'f', cast(uint) 2,
             No.caseSensitive) == 2);
         assert(indexOf(sPlts, cast(char)'P', 12, No.caseSensitive) == 23);
-        assert(indexOf(sPlts, cast(char)'R', cast(ulong)1,
+        assert(indexOf(sPlts, cast(char)'R', cast(ulong) 1,
             No.caseSensitive) == 2);
     }
 
@@ -788,7 +788,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
         ptrdiff_t foundIdx = indexOf(s[startIdx .. $], sub, cs);
         if (foundIdx != -1)
         {
-            return foundIdx + cast(ptrdiff_t)startIdx;
+            return foundIdx + cast(ptrdiff_t) startIdx;
         }
     }
     return -1;
@@ -843,7 +843,7 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOf(cast(S)null, to!T("a")) == -1);
+            assert(indexOf(cast(S) null, to!T("a")) == -1);
             assert(indexOf(to!S("def"), to!T("a")) == -1);
             assert(indexOf(to!S("abba"), to!T("a")) == 0);
             assert(indexOf(to!S("def"), to!T("f")) == 2);
@@ -912,7 +912,7 @@ unittest
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOf(cast(S)null, to!T("a"), 1337) == -1);
+            assert(indexOf(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOf(to!S("def"), to!T("a"), 0) == -1);
             assert(indexOf(to!S("abba"), to!T("a"), 2) == 3);
             assert(indexOf(to!S("def"), to!T("f"), 1) == 2);
@@ -1227,7 +1227,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             for (size_t i = s.length; !s.empty;)
             {
                 if (s.endsWith(sub))
-                    return cast(ptrdiff_t)i - to!(const(Char1)[])(sub).length;
+                    return cast(ptrdiff_t) i - to!(const(Char1)[])(sub).length;
 
                 i -= strideBack(s, i);
                 s = s[0 .. i];
@@ -1241,7 +1241,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             if (endsWith!((a, b) => std.uni.toLower(a) == std.uni.toLower(b))
                          (s, sub))
             {
-                return cast(ptrdiff_t)i - to!(const(Char1)[])(sub).length;
+                return cast(ptrdiff_t) i - to!(const(Char1)[])(sub).length;
             }
 
             i -= strideBack(s, i);
@@ -1320,7 +1320,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
-            assert(lastIndexOf(cast(S)null, to!T("a")) == -1, typeStr);
+            assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("c")) == 6, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("cd")) == 6, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("ef")) == 8, typeStr);
@@ -1331,7 +1331,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("")) == -1, typeStr);
             assert(lastIndexOf(to!S("öabcdefcdef"), to!T("ö")) == 0, typeStr);
 
-            assert(lastIndexOf(cast(S)null, to!T("a"), No.caseSensitive) == -1, typeStr);
+            assert(lastIndexOf(cast(S) null, to!T("a"), No.caseSensitive) == -1, typeStr);
             assert(lastIndexOf(to!S("abcdefCdef"), to!T("c"), No.caseSensitive) == 6, typeStr);
             assert(lastIndexOf(to!S("abcdefCdef"), to!T("cD"), No.caseSensitive) == 6, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("x"), No.caseSensitive) == -1, typeStr);
@@ -1396,7 +1396,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
-            assert(lastIndexOf(cast(S)null, to!T("a")) == -1, typeStr);
+            assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("c"), 5) == 2, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("cd"), 3) == -1, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("ef"), 6) == 4, typeStr ~
@@ -1409,7 +1409,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             assert(lastIndexOf(to!S("öafö"), to!T("ö"), 3) == 0, typeStr ~
                     to!string(lastIndexOf(to!S("öafö"), to!T("ö"), 3))); //BUG 10472
 
-            assert(lastIndexOf(cast(S)null, to!T("a"), 1, No.caseSensitive) == -1, typeStr);
+            assert(lastIndexOf(cast(S) null, to!T("a"), 1, No.caseSensitive) == -1, typeStr);
             assert(lastIndexOf(to!S("abcdefCdef"), to!T("c"), 5, No.caseSensitive) == 2, typeStr);
             assert(lastIndexOf(to!S("abcdefCdef"), to!T("cD"), 4, No.caseSensitive) == 2, typeStr ~
                 " " ~ to!string(lastIndexOf(to!S("abcdefCdef"), to!T("cD"), 3, No.caseSensitive)));
@@ -1584,7 +1584,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
         ptrdiff_t foundIdx = indexOfAny(haystack[startIdx .. $], needles, cs);
         if (foundIdx != -1)
         {
-            return foundIdx + cast(ptrdiff_t)startIdx;
+            return foundIdx + cast(ptrdiff_t) startIdx;
         }
     }
 
@@ -1644,7 +1644,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOfAny(cast(S)null, to!T("a")) == -1);
+            assert(indexOfAny(cast(S) null, to!T("a")) == -1);
             assert(indexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(indexOfAny(to!S("abba"), to!T("a")) == 0);
             assert(indexOfAny(to!S("def"), to!T("f")) == 2);
@@ -1683,7 +1683,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOfAny(cast(S)null, to!T("a"), 1337) == -1);
+            assert(indexOfAny(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOfAny(to!S("def"), to!T("AaF"), 0) == -1);
             assert(indexOfAny(to!S("abba"), to!T("NSa"), 2) == 3);
             assert(indexOfAny(to!S("def"), to!T("fbi"), 1) == 2);
@@ -1812,7 +1812,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(lastIndexOfAny(cast(S)null, to!T("a")) == -1);
+            assert(lastIndexOfAny(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(lastIndexOfAny(to!S("abba"), to!T("a")) == 3);
             assert(lastIndexOfAny(to!S("def"), to!T("f")) == 2);
@@ -1869,7 +1869,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
-            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337) == -1,
+            assert(lastIndexOfAny(cast(S) null, to!T("a"), 1337) == -1,
                 typeStr);
             assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("c"), 7) == 6,
                 typeStr);
@@ -1886,7 +1886,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
             assert(lastIndexOfAny(to!S("öabcdefcdef"), to!T("ö"), 2) == 0,
                 typeStr);
 
-            assert(lastIndexOfAny(cast(S)null, to!T("a"), 1337,
+            assert(lastIndexOfAny(cast(S) null, to!T("a"), 1337,
                 No.caseSensitive) == -1, typeStr);
             assert(lastIndexOfAny(to!S("abcdefcdef"), to!T("C"), 7,
                 No.caseSensitive) == 6, typeStr);
@@ -1942,7 +1942,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
             haystack[startIdx .. $], needles, cs);
         if (foundIdx != -1)
         {
-            return foundIdx + cast(ptrdiff_t)startIdx;
+            return foundIdx + cast(ptrdiff_t) startIdx;
         }
     }
     return -1;
@@ -1994,7 +1994,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOfNeither(cast(S)null, to!T("a")) == -1);
+            assert(indexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(indexOfNeither("abba", "a") == 1);
 
             assert(indexOfNeither(to!S("dfeffgfff"), to!T("a"),
@@ -2040,7 +2040,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(indexOfNeither(cast(S)null, to!T("a"), 1) == -1);
+            assert(indexOfNeither(cast(S) null, to!T("a"), 1) == -1);
             assert(indexOfNeither(to!S("def"), to!T("a"), 1) == 1,
                 to!string(indexOfNeither(to!S("def"), to!T("a"), 1)));
 
@@ -2152,7 +2152,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(lastIndexOfNeither(cast(S)null, to!T("a")) == -1);
+            assert(lastIndexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("rsa")) == 2);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
 
@@ -2199,7 +2199,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            assert(lastIndexOfNeither(cast(S)null, to!T("a"), 1337) == -1);
+            assert(lastIndexOfNeither(cast(S) null, to!T("a"), 1337) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("f")) == 1);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
 
@@ -2540,7 +2540,7 @@ if (!isSomeString!S && is(StringTypeOf!S))
 
 
         ubyte[] u = ['a', 0xFF, 0x12, 'b'];     // invalid UTF
-        auto ulines = splitLines(cast(char[])u);
+        auto ulines = splitLines(cast(char[]) u);
         assert(cast(ubyte[])(ulines[0]) == u);
 
         lines = splitLines(s, Yes.keepTerminator);
@@ -2792,7 +2792,7 @@ if (isConvertibleToString!Range)
 
 
         ubyte[] u = ['a', 0xFF, 0x12, 'b'];     // invalid UTF
-        auto ulines = lineSplitter(cast(char[])u).array;
+        auto ulines = lineSplitter(cast(char[]) u).array;
         assert(cast(ubyte[])(ulines[0]) == u);
 
         lines = lineSplitter!(Yes.keepTerminator)(s).array;
@@ -3082,13 +3082,13 @@ if (isConvertibleToString!Range)
     {
         foreach (s; invalidUTFstrings!C())
         {
-            cast(void)stripRight(s.byUTF!C).array;
+            cast(void) stripRight(s.byUTF!C).array;
         }
     }
 
-    cast(void)stripRight("a\x80".byUTF!char).array;
-    wstring ws = ['a', cast(wchar)0xDC00];
-    cast(void)stripRight(ws.byUTF!wchar).array;
+    cast(void) stripRight("a\x80".byUTF!char).array;
+    wstring ws = ['a', cast(wchar) 0xDC00];
+    cast(void) stripRight(ws.byUTF!wchar).array;
 }
 
 
@@ -3360,7 +3360,7 @@ if (isConvertibleToString!Range)
     foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         // @@@ BUG IN COMPILER, MUST INSERT CAST
-        assert(chomp(cast(S)null) is null);
+        assert(chomp(cast(S) null) is null);
         assert(chomp(to!S("hello")) == "hello");
         assert(chomp(to!S("hello\n")) == "hello");
         assert(chomp(to!S("hello\r")) == "hello");
@@ -3380,8 +3380,8 @@ if (isConvertibleToString!Range)
         foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             // @@@ BUG IN COMPILER, MUST INSERT CAST
-            assert(chomp(cast(S)null, cast(T)null) is null);
-            assert(chomp(to!S("hello\n"), cast(T)null) == "hello");
+            assert(chomp(cast(S) null, cast(T) null) is null);
+            assert(chomp(to!S("hello\n"), cast(T) null) == "hello");
             assert(chomp(to!S("hello"), to!T("o")) == "hell");
             assert(chomp(to!S("hello"), to!T("p")) == "hello");
             // @@@ BUG IN COMPILER, MUST INSERT CAST
@@ -4377,7 +4377,7 @@ if (isConvertibleToString!Range)
         S s = to!S("This \tis\t a fofof\tof list");
         assert(cmp(detab(s), "This    is       a fofof        of list") == 0);
 
-        assert(detab(cast(S)null) is null);
+        assert(detab(cast(S) null) is null);
         assert(detab("").empty);
         assert(detab("a") == "a");
         assert(detab("\t") == "        ");
@@ -4838,7 +4838,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
                to!S("qe55o \U00010143 wor5d"));
         assert(translate(to!S("hello \U00010143 world"), cast(dchar[dchar])['o' : '0', '\U00010143' : 'o']) ==
                to!S("hell0 o w0rld"));
-        assert(translate(to!S("hello world"), cast(dchar[dchar])null) == to!S("hello world"));
+        assert(translate(to!S("hello world"), cast(dchar[dchar]) null) == to!S("hello world"));
 
         foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
@@ -4899,7 +4899,7 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
                to!S("ello \U00010143 world"));
         assert(translate(to!S("hello \U00010143 world"), ['\U00010143' : ""]) ==
                to!S("hello  world"));
-        assert(translate(to!S("hello world"), cast(string[dchar])null) == to!S("hello world"));
+        assert(translate(to!S("hello world"), cast(string[dchar]) null) == to!S("hello world"));
 
         foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
@@ -5133,7 +5133,7 @@ body
     char[256] result = void;
 
     foreach (i; 0 .. result.length)
-        result[i] = cast(char)i;
+        result[i] = cast(char) i;
     foreach (i, c; from)
         result[c] = to[i];
     return result;
@@ -5567,7 +5567,7 @@ if (isSomeString!S)
                 c -= 'Z' - 'A';
                 carry = c;
             Lcarry:
-                r[i] = cast(char)c;
+                r[i] = cast(char) c;
                 if (i == 0)
                 {
                     auto t = new typeof(r[0])[r.length + 1];
@@ -6201,7 +6201,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
         }
         if (b == 0)
         {
-            result[0] = cast(char)c;
+            result[0] = cast(char) c;
             b++;
             lastc = dex[c - 'A'];
         }
@@ -6214,7 +6214,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
             c = dex[c - 'A'];
             if (c != '0' && c != lastc)
             {
-                result[b] = cast(char)c;
+                result[b] = cast(char) c;
                 b++;
                 lastc = c;
             }
@@ -6957,19 +6957,19 @@ pure unittest
 
         static if (is(T == char[]))
         {
-            auto gt = cast(ubyte[])jt;
+            auto gt = cast(ubyte[]) jt;
             auto gtc = cast(const(ubyte)[])jt;
             auto gti = cast(immutable(ubyte)[])jt;
         }
         else static if (is(T == wchar[]))
         {
-            auto gt = cast(ushort[])jt;
+            auto gt = cast(ushort[]) jt;
             auto gtc = cast(const(ushort)[])jt;
             auto gti = cast(immutable(ushort)[])jt;
         }
         else static if (is(T == dchar[]))
         {
-            auto gt = cast(uint[])jt;
+            auto gt = cast(uint[]) jt;
             auto gtc = cast(const(uint)[])jt;
             auto gti = cast(immutable(uint)[])jt;
         }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1405,9 +1405,9 @@ unittest
     }
     {
         Tuple!(wchar, dchar, int, "x", string, "y", char, byte, float) tup;
-        tup = tuple('a', 'b', 3, "4", 'c', cast(byte)0x0D, 0.00);
+        tup = tuple('a', 'b', 3, "4", 'c', cast(byte) 0x0D, 0.00);
         auto rev = tup.reverse;
-        assert(rev == tuple(0.00, cast(byte)0x0D, 'c', "4", 3, 'b', 'a'));
+        assert(rev == tuple(0.00, cast(byte) 0x0D, 'c', "4", 3, 'b', 'a'));
         assert(rev.x == 3 && rev.y == "4");
     }
 }
@@ -2882,7 +2882,7 @@ Params:
 @system unittest
 {
     //Passes
-    enum nullVal = cast(int*)0xCAFEBABE;
+    enum nullVal = cast(int*) 0xCAFEBABE;
     Nullable!(int*, nullVal) npi;
     assert(npi.isNull);
 
@@ -4317,7 +4317,7 @@ if (is(T == class) || is(T == interface))
         }
         else
         {
-            return cast(T)typecons_d_toObject(*cast(void**)(&source));
+            return cast(T) typecons_d_toObject(*cast(void**)(&source));
         }
     }
 }
@@ -4326,7 +4326,7 @@ if (is(T == class) || is(T == interface))
 {
     class C { @disable opCast(T)() {} }
     auto c = new C;
-    static assert(!__traits(compiles, cast(Object)c));
+    static assert(!__traits(compiles, cast(Object) c));
     auto o = dynamicCast!Object(c);
     assert(c is o);
 
@@ -4334,7 +4334,7 @@ if (is(T == class) || is(T == interface))
     interface J { @disable opCast(T)() {} Object instance(); }
     class D : I, J { Object instance() { return this; } }
     I i = new D();
-    static assert(!__traits(compiles, cast(J)i));
+    static assert(!__traits(compiles, cast(J) i));
     J j = dynamicCast!J(i);
     assert(i.instance() is j.instance());
 }
@@ -5106,7 +5106,7 @@ if (!is(T == class) && !(is(T == interface)))
             import core.exception : onOutOfMemoryError;
             import std.conv : emplace;
 
-            _store = cast(Impl*)pureMalloc(Impl.sizeof);
+            _store = cast(Impl*) pureMalloc(Impl.sizeof);
             if (_store is null)
                 onOutOfMemoryError();
             static if (hasIndirections!T)
@@ -5120,7 +5120,7 @@ if (!is(T == class) && !(is(T == interface)))
             import core.exception : onOutOfMemoryError;
             import core.stdc.string : memcpy, memset;
 
-            _store = cast(Impl*)pureMalloc(Impl.sizeof);
+            _store = cast(Impl*) pureMalloc(Impl.sizeof);
             if (_store is null)
                 onOutOfMemoryError();
             static if (hasIndirections!T)
@@ -5502,7 +5502,7 @@ mixin template Proxy(alias a)
      * 'static if' in the definition of Proxy or T.
      */
     private enum bool accessibleFrom(T) =
-        is(typeof((T* self){ cast(void)mixin("(*self)."~__traits(identifier, a)); }));
+        is(typeof((T* self){ cast(void) mixin("(*self)."~__traits(identifier, a)); }));
 
     static if (is(typeof(this) == class))
     {
@@ -5602,7 +5602,7 @@ mixin template Proxy(alias a)
 
     auto ref opCall(this X, Args...)(auto ref Args args) { return a(args); }
 
-    auto ref opCast(T, this X)() { return cast(T)a; }
+    auto ref opCast(T, this X)() { return cast(T) a; }
 
     auto ref opIndex(this X, D...)(auto ref D i)               { return a[i]; }
     auto ref opSlice(this X      )()                           { return a[]; }
@@ -5802,7 +5802,7 @@ mixin template Proxy(alias a)
         assert(m < 20);
         assert(+m == 10);
         assert(-m == -10);
-        assert(cast(double)m == 10.0);
+        assert(cast(double) m == 10.0);
         assert(m + 10 == 20);
         assert(m - 5 == 5);
         assert(m * 20 == 200);
@@ -5847,9 +5847,9 @@ mixin template Proxy(alias a)
         assert(a != [5,6,7,8]);
         assert(+a[0]    == 1);
         version (LittleEndian)
-            assert(cast(ulong[])a == [0x0000_0002_0000_0001, 0x0000_0004_0000_0003]);
+            assert(cast(ulong[]) a == [0x0000_0002_0000_0001, 0x0000_0004_0000_0003]);
         else
-            assert(cast(ulong[])a == [0x0000_0001_0000_0002, 0x0000_0003_0000_0004]);
+            assert(cast(ulong[]) a == [0x0000_0001_0000_0002, 0x0000_0003_0000_0004]);
         assert(a ~ [10,11] == [1,2,3,4,10,11]);
         assert(a[0]    == 1);
         assert(a[]     == [1,2,3,4]);
@@ -5934,10 +5934,10 @@ mixin template Proxy(alias a)
 
     // bug5896 test
     assert(h.opCast!int() == 0);
-    assert(cast(int)h == 0);
+    assert(cast(int) h == 0);
     const ih = new const Hoge(new Foo());
     static assert(!__traits(compiles, ih.opCast!int()));
-    static assert(!__traits(compiles, cast(int)ih));
+    static assert(!__traits(compiles, cast(int) ih));
 
     // template member function
     assert(h.tempfunc!int() == 0);
@@ -5974,9 +5974,9 @@ mixin template Proxy(alias a)
     Object c = new MyClass2(5);
     Object d = new MyClass3(5);
     assert(a == b);
-    assert((cast(MyClass)a) == 5);
-    assert(5 == (cast(MyClass)b));
-    assert(5 == cast(MyClass2)c);
+    assert((cast(MyClass) a) == 5);
+    assert(5 == (cast(MyClass) b));
+    assert(5 == cast(MyClass2) c);
     assert(a != d);
 
     assert(c != a);
@@ -5986,23 +5986,23 @@ mixin template Proxy(alias a)
     // MyClass.opEquals doesn't know MyClass2.
     // so, c.opEquals(a) is true, but a.opEquals(c) is false.
     // furthermore, opEquals(T) couldn't be invoked.
-    assert((cast(MyClass2)c) != (cast(MyClass)a));
+    assert((cast(MyClass2) c) != (cast(MyClass) a));
 
     // opCmp
     Object e = new MyClass2(7);
-    assert(a < cast(MyClass2)e); // OK. and
+    assert(a < cast(MyClass2) e); // OK. and
     assert(e > a); // OK, but...
     // assert(a < e); // RUNTIME ERROR!
-    // assert((cast(MyClass)a) < e); // RUNTIME ERROR!
-    assert(3 < cast(MyClass)a);
-    assert((cast(MyClass2)e) < 11);
+    // assert((cast(MyClass) a) < e); // RUNTIME ERROR!
+    assert(3 < cast(MyClass) a);
+    assert((cast(MyClass2) e) < 11);
 
     // opCall
-    assert((cast(MyClass2)e)("hello") == "hello");
+    assert((cast(MyClass2) e)("hello") == "hello");
 
     // opCast
-    assert((cast(MyClass)(cast(MyClass2)c)) == a);
-    assert((cast(int)(cast(MyClass2)c)) == 5);
+    assert((cast(MyClass)(cast(MyClass2) c)) == a);
+    assert((cast(int)(cast(MyClass2) c)) == 5);
 
     // opIndex
     class MyClass4
@@ -6026,24 +6026,24 @@ mixin template Proxy(alias a)
     assert(f[2..4] == "ll");
 
     // opUnary
-    assert(-(cast(MyClass2)c) == -5);
+    assert(-(cast(MyClass2) c) == -5);
 
     // opBinary
-    assert((cast(MyClass)a) + (cast(MyClass2)c) == 10);
-    assert(5 + cast(MyClass)a == 10);
+    assert((cast(MyClass) a) + (cast(MyClass2) c) == 10);
+    assert(5 + cast(MyClass) a == 10);
 
     // opAssign
-    (cast(MyClass2)c) = 11;
-    assert((cast(MyClass2)c) == 11);
-    (cast(MyClass2)c) = new MyClass(13);
-    assert((cast(MyClass2)c) == 13);
+    (cast(MyClass2) c) = 11;
+    assert((cast(MyClass2) c) == 11);
+    (cast(MyClass2) c) = new MyClass(13);
+    assert((cast(MyClass2) c) == 13);
 
     // opOpAssign
-    assert((cast(MyClass2)c) += 4);
-    assert((cast(MyClass2)c) == 17);
+    assert((cast(MyClass2) c) += 4);
+    assert((cast(MyClass2) c) == 17);
 
     // opDispatch
-    assert((cast(MyClass2)c).pow(2) == 289);
+    assert((cast(MyClass2) c).pow(2) == 289);
 
     // opDollar
     assert(f[2..$-1] == "ll");
@@ -6240,16 +6240,16 @@ struct Typedef(T, T init = T.init, string cookie=null)
         this(tdef.Typedef_payload);
     }
 
-    // We need to add special overload for cast(Typedef!X)exp,
+    // We need to add special overload for cast(Typedef!X) exp,
     // thus we can't simply inherit Proxy!Typedef_payload
     T2 opCast(T2 : Typedef!(T, Unused), this X, T, Unused...)()
     {
-        return T2(cast(T)Typedef_payload);
+        return T2(cast(T) Typedef_payload);
     }
 
     auto ref opCast(T2, this X)()
     {
-        return cast(T2)Typedef_payload;
+        return cast(T2) Typedef_payload;
     }
 
     mixin Proxy!Typedef_payload;
@@ -6312,7 +6312,7 @@ template TypedefType(T)
     assert(myInt == 5);
 
     // cast to the underlying type to get the value that's being wrapped
-    int x = cast(TypedefType!MyInt)myInt;
+    int x = cast(TypedefType!MyInt) myInt;
 
     alias MyIntInit = Typedef!(int, 42);
     static assert(is(TypedefType!MyIntInit == int));
@@ -6486,9 +6486,9 @@ template TypedefType(T)
     alias String = Typedef!(char[]);
     alias CString = Typedef!(const(char)[]);
     CString cs = "fubar";
-    String s = cast(String)cs;
+    String s = cast(String) cs;
     assert(cs == s);
-    char[] s2 = cast(char[])cs;
+    char[] s2 = cast(char[]) cs;
     const(char)[] cs2 = cast(const(char)[])s;
     assert(s2 == cs2);
 }
@@ -7305,7 +7305,7 @@ public:
     assert(flags_AB & Enum.A);
 
     // Finally, you can of course get you raw value out of flags
-    auto value = cast(int)flags_A;
+    auto value = cast(int) flags_A;
     assert(value == Enum.A);
 }
 

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -24,7 +24,7 @@ alias TypeTuple = AliasSeq;
 
     int foo(TL td)  // same as int foo(int, double);
     {
-        return td[0] + cast(int)td[1];
+        return td[0] + cast(int) td[1];
     }
 }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -748,14 +748,14 @@ auto force(T, F)(F from)
 if (isIntegral!T && !is(T == F))
 {
     assert(from <= T.max && from >= T.min);
-    return cast(T)from;
+    return cast(T) from;
 }
 
 auto force(T, F)(F from)
 if (isBitPacked!T && !is(T == F))
 {
     assert(from <= 2^^bitSizeOf!T-1);
-    return T(cast(TypeOfBitPacked!T)from);
+    return T(cast(TypeOfBitPacked!T) from);
 }
 
 auto force(T, F)(F from)
@@ -1132,7 +1132,7 @@ pure nothrow:
         immutable tgt_shift = bits*r;
         immutable word = origin[q];
         origin[q] = (word & ~(mask<<tgt_shift))
-            | (cast(size_t)val << tgt_shift);
+            | (cast(size_t) val << tgt_shift);
     }
 
     static if (factor == bytesPerWord// can safely pack by byte
@@ -1152,14 +1152,14 @@ pure nothrow:
         T opIndex(size_t idx) inout
         {
             return __ctfe ? simpleIndex(idx) :
-                cast(inout(T))(cast(U*)origin)[idx];
+                cast(inout(T))(cast(U*) origin)[idx];
         }
 
         static if (isBitPacked!T) // lack of user-defined implicit conversion
         {
             void opIndexAssign(T val, size_t idx)
             {
-                return opIndexAssign(cast(TypeOfBitPacked!T)val, idx);
+                return opIndexAssign(cast(TypeOfBitPacked!T) val, idx);
             }
         }
 
@@ -1168,7 +1168,7 @@ pure nothrow:
             if (__ctfe)
                 simpleWrite(val, idx);
             else
-                (cast(U*)origin)[idx] = cast(U)val;
+                (cast(U*) origin)[idx] = cast(U) val;
         }
     }
     else
@@ -1182,7 +1182,7 @@ pure nothrow:
         {
             void opIndexAssign(T val, size_t idx)
             {
-                return opIndexAssign(cast(TypeOfBitPacked!T)val, idx);
+                return opIndexAssign(cast(TypeOfBitPacked!T) val, idx);
             }
         }
 
@@ -1259,7 +1259,7 @@ pure nothrow:
     {
         void opIndexAssign(T val, size_t idx)
         {
-            return opIndexAssign(cast(TypeOfBitPacked!T)val, idx);
+            return opIndexAssign(cast(TypeOfBitPacked!T) val, idx);
         }
     }
 
@@ -1277,7 +1277,7 @@ pure nothrow:
     {
         void opSliceAssign(T val, size_t start, size_t end)
         {
-            opSliceAssign(cast(TypeOfBitPacked!T)val, start, end);
+            opSliceAssign(cast(TypeOfBitPacked!T) val, start, end);
         }
     }
 
@@ -1740,7 +1740,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         size_t nbytes = mulu(size, T.sizeof, overflow);
         if (overflow) assert(0);
 
-        auto ptr = cast(T*)enforce(malloc(nbytes), "out of memory on C heap");
+        auto ptr = cast(T*) enforce(malloc(nbytes), "out of memory on C heap");
         return ptr[0..size];
     }
 
@@ -1759,7 +1759,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         size_t nbytes = mulu(size, T.sizeof, overflow);
         if (overflow) assert(0);
 
-        auto ptr = cast(T*)enforce(realloc(arr.ptr, nbytes), "out of memory on C heap");
+        auto ptr = cast(T*) enforce(realloc(arr.ptr, nbytes), "out of memory on C heap");
         return ptr[0..size];
     }
 
@@ -2293,7 +2293,7 @@ public:
 
             @property dchar front() const
             {
-                return cast(dchar)cur;
+                return cast(dchar) cur;
             }
 
             @property bool empty() const
@@ -2511,13 +2511,13 @@ public:
         if (inversion.data[0] != 0)
             genericReplace(inversion.data, 0, 0, [0]);
         else
-            genericReplace(inversion.data, 0, 1, cast(uint[])null);
+            genericReplace(inversion.data, 0, 1, cast(uint[]) null);
         if (data[data.length-1] != lastDchar+1)
             genericReplace(inversion.data,
                 inversion.data.length, inversion.data.length, [lastDchar+1]);
         else
             genericReplace(inversion.data,
-                inversion.data.length-1, inversion.data.length, cast(uint[])null);
+                inversion.data.length-1, inversion.data.length, cast(uint[]) null);
 
         return inversion;
     }
@@ -3031,10 +3031,10 @@ private:
 {
     idx *= 3;
     version(LittleEndian)
-        return ptr[idx] + (cast(uint)ptr[idx+1]<<8)
-             + (cast(uint)ptr[idx+2]<<16);
+        return ptr[idx] + (cast(uint) ptr[idx+1]<<8)
+             + (cast(uint) ptr[idx+2]<<16);
     else
-        return (cast(uint)ptr[idx]<<16) + (cast(uint)ptr[idx+1]<<8)
+        return (cast(uint) ptr[idx]<<16) + (cast(uint) ptr[idx+1]<<8)
              + ptr[idx+2];
 }
 
@@ -3069,7 +3069,7 @@ private:
 // ditto
 @system private void unalignedWrite24(scope ubyte* ptr, uint val, size_t idx) pure nothrow @nogc
 {
-    uint* dest = cast(uint*)(cast(ubyte*)ptr + 3*idx);
+    uint* dest = cast(uint*)(cast(ubyte*) ptr + 3*idx);
     version(LittleEndian)
         *dest = val | (*dest & 0xFF00_0000);
     else
@@ -4069,7 +4069,7 @@ if (isValidPrefixForTrie!(Key, Args)
             assert(mapTrieIndex!Prefix(key) < maxIndex);
         size_t idx;
         alias p = Prefix;
-        idx = cast(size_t)p[0](key);
+        idx = cast(size_t) p[0](key);
         foreach (i, v; p[0..$-1])
             idx = cast(size_t)((_table.ptr!i[idx]<<p[i+1].bitSize) + p[i+1](key));
         return _table.ptr!(p.length-1)[idx];
@@ -4274,7 +4274,7 @@ if (sumOfIntegerTuple!sizes == 21)
         }
         uint luck;
         foreach (n; nibbles)
-            luck = cast(uint)max(luck, count(nibbles[], n));
+            luck = cast(uint) max(luck, count(nibbles[], n));
         return luck;
     }
 
@@ -4651,7 +4651,7 @@ template Utf8Matcher()
     );
     alias Table(int size) = Tables[size-1];
 
-    enum leadMask(size_t size) = (cast(size_t)1<<(7 - size))-1;
+    enum leadMask(size_t size) = (cast(size_t) 1<<(7 - size))-1;
     enum encMask(size_t size) = ((1<<size)-1)<<(8-size);
 
     char truncate()(char ch) pure @safe
@@ -4664,7 +4664,7 @@ template Utf8Matcher()
         else
         {
             badEncoding();
-            return cast(char)0;
+            return cast(char) 0;
         }
     }
 
@@ -4689,7 +4689,7 @@ template Utf8Matcher()
         auto utf8_2 = set & CodepointSet(0x80, 0x800);
         auto utf8_3 = set & CodepointSet(0x800, 0x1_0000);
         auto utf8_4 = set & CodepointSet(0x1_0000, lastDchar+1);
-        auto asciiT = ascii.byCodepoint.map!(x=>cast(char)x).buildTrie!(AsciiSpec);
+        auto asciiT = ascii.byCodepoint.map!(x=>cast(char) x).buildTrie!(AsciiSpec);
         auto utf8_2T = utf8_2.byCodepoint.map!(x=>encode!2(x)).buildTrie!(Utf8Spec2);
         auto utf8_3T = utf8_3.byCodepoint.map!(x=>encode!3(x)).buildTrie!(Utf8Spec3);
         auto utf8_4T = utf8_4.byCodepoint.map!(x=>encode!4(x)).buildTrie!(Utf8Spec4);
@@ -4943,8 +4943,8 @@ template Utf16Matcher()
         auto bmp = (set & CodepointSet.fromIntervals(0x80, 0xFFFF+1))
             - CodepointSet.fromIntervals(0xD800, 0xDFFF+1);
         auto other = set - (bmp | ascii);
-        auto asciiT = ascii.byCodepoint.map!(x=>cast(char)x).buildTrie!(AsciiSpec);
-        auto bmpT = bmp.byCodepoint.map!(x=>cast(wchar)x).buildTrie!(BmpSpec);
+        auto asciiT = ascii.byCodepoint.map!(x=>cast(char) x).buildTrie!(AsciiSpec);
+        auto bmpT = bmp.byCodepoint.map!(x=>cast(wchar) x).buildTrie!(BmpSpec);
         auto otherT = other.byCodepoint.map!(x=>encode2(x)).buildTrie!(UniSpec);
         alias Ret = Impl!(1,2);
         return Ret(asciiT, bmpT, otherT);
@@ -5326,14 +5326,14 @@ if (is(C : wchar) || is(C : char))
             auto s = msg;
             size_t idx = 0;
             utf8.test(s);
-        }()), format("%( %2x %)", cast(ubyte[])msg));
+        }()), format("%( %2x %)", cast(ubyte[]) msg));
     }
     //decode failure cases UTF-16
     alias fails16 = AliasSeq!([0xD811], [0xDC02]);
     foreach (msg; fails16)
     {
         assert(collectException((){
-            auto s = msg.map!(x => cast(wchar)x);
+            auto s = msg.map!(x => cast(wchar) x);
             utf16.test(s);
         }()));
     }
@@ -5568,7 +5568,7 @@ template Sequence(size_t start, size_t end)
     auto trie2 = buildTrie!(bool, uint, 1024, mlo8, lo8)(redundant2.byInterval);
     trieStats(trie2);
     foreach (e; redundant2.byCodepoint)
-        assert(trie2[e], text(cast(uint)e, " - ", trie2[e]));
+        assert(trie2[e], text(cast(uint) e, " - ", trie2[e]));
     foreach (i; 0..1024)
     {
         assert(trie2[i] == (i in redundant2));
@@ -5588,7 +5588,7 @@ template Sequence(size_t start, size_t end)
         )(redundant3.byInterval);
     trieStats(trie3);
     foreach (i; 0..max3)
-        assert(trie3[i] == (i in redundant3), text(cast(uint)i));
+        assert(trie3[i] == (i in redundant3), text(cast(uint) i));
 
     auto redundant4 = Set(
             10, 64, 64+10, 128, 128+10, 256, 256+10, 512,
@@ -5601,7 +5601,7 @@ template Sequence(size_t start, size_t end)
     foreach (i; 0..max4)
     {
         if (i in redundant4)
-            assert(trie4[i], text(cast(uint)i));
+            assert(trie4[i], text(cast(uint) i));
     }
     trieStats(trie4);
 
@@ -5620,7 +5620,7 @@ template Sequence(size_t start, size_t end)
     auto bt = buildTrie!(bool, ubyte, sliceBits!(7, 8), sliceBits!(5, 7), sliceBits!(0, 5))(a);
     trieStats(bt);
     foreach (i; 0..256)
-        assert(bt[cast(ubyte)i]);
+        assert(bt[cast(ubyte) i]);
 }
 
 template useItemAt(size_t idx, T)
@@ -5698,7 +5698,7 @@ if (is(Char1 : dchar) && is(Char2 : dchar))
 {
     // not optimized as usually done 1 time (and not public interface)
     if (val < 128)
-        arr ~= cast(ubyte)val;
+        arr ~= cast(ubyte) val;
     else if (val < (1<<13))
     {
         arr ~= (0b1_00<<5) | cast(ubyte)(val>>8);
@@ -5754,10 +5754,10 @@ if (isInputRange!Range && isIntegralPair!(ElementType!Range))
     import std.typecons : tuple;
 
     auto run = [tuple(80, 127), tuple(128, (1<<10)+128)];
-    ubyte[] enc = [cast(ubyte)80, 47, 1, (0b1_00<<5) | (1<<2), 0];
+    ubyte[] enc = [cast(ubyte) 80, 47, 1, (0b1_00<<5) | (1<<2), 0];
     assert(compressIntervals(run) == enc);
     auto run2 = [tuple(0, (1<<20)+512+1), tuple((1<<20)+512+4, lastDchar+1)];
-    ubyte[] enc2 = [cast(ubyte)0, (0b1_01<<5) | (1<<4), 2, 1, 3]; // odd length-ed
+    ubyte[] enc2 = [cast(ubyte) 0, (0b1_01<<5) | (1<<4), 2, 1, 3]; // odd length-ed
     assert(compressIntervals(run2) == enc2);
     size_t  idx = 0;
     assert(decompressFrom(enc, idx) == 80);
@@ -6722,7 +6722,7 @@ public:
                 auto nelems = mulu(3, addu(cap_, 1, overflow), overflow);
                 if (overflow) assert(0);
 
-                ptr_ = cast(ubyte*)enforce(realloc(ptr_, nelems),
+                ptr_ = cast(ubyte*) enforce(realloc(ptr_, nelems),
                     "realloc failed");
             }
             write24(ptr_, ch, len_++);
@@ -6788,7 +6788,7 @@ public:
             auto raw_cap = mulu(3, addu(cap_, 1, overflow), overflow);
             if (overflow) assert(0);
 
-            auto p = cast(ubyte*)enforce(malloc(raw_cap), "malloc failed");
+            auto p = cast(ubyte*) enforce(malloc(raw_cap), "malloc failed");
             p[0..raw_cap] = ptr_[0..raw_cap];
             ptr_ = p;
         }
@@ -6835,7 +6835,7 @@ private:
         static assert(grow.max / 3 - 1 >= grow);
         enum nbytes = 3 * (grow + 1);
         size_t k = smallLength;
-        ubyte* p = cast(ubyte*)enforce(malloc(nbytes), "malloc failed");
+        ubyte* p = cast(ubyte*) enforce(malloc(nbytes), "malloc failed");
         for (int i=0; i<k; i++)
             write24(p, read24(small_.ptr, i), i);
         // now we can overwrite small array data
@@ -7510,7 +7510,7 @@ bool isJamoV(dchar ch) pure nothrow @nogc @safe
 
 int hangulSyllableIndex(dchar ch) pure nothrow @nogc @safe
 {
-    int idxS = cast(int)ch - jamoSBase;
+    int idxS = cast(int) ch - jamoSBase;
     return idxS >= 0 && idxS < jamoSCount ? idxS : -1;
 }
 
@@ -7552,7 +7552,7 @@ public:
 */
 Grapheme decomposeHangul(dchar ch) @safe
 {
-    immutable idxS = cast(int)ch - jamoSBase;
+    immutable idxS = cast(int) ch - jamoSBase;
     if (idxS < 0 || idxS >= jamoSCount) return Grapheme(ch);
     immutable idxL = idxS / jamoNCount;
     immutable idxV = (idxS % jamoNCount) / jamoTCount;
@@ -8573,7 +8573,7 @@ private size_t encodeTo(scope char[] buf, size_t idx, dchar c) @trusted pure not
 {
     if (c <= 0x7F)
     {
-        buf[idx] = cast(char)c;
+        buf[idx] = cast(char) c;
         idx++;
     }
     else if (c <= 0x7FF)
@@ -8621,7 +8621,7 @@ private size_t encodeTo(scope wchar[] buf, size_t idx, dchar c) @trusted pure
     {
         if (0xD800 <= c && c <= 0xDFFF)
             throw (new UTFException("Encoding an isolated surrogate code point in UTF-16")).setSequence(c);
-        buf[idx] = cast(wchar)c;
+        buf[idx] = cast(wchar) c;
         idx++;
     }
     else if (c <= 0x10FFFF)
@@ -9146,9 +9146,9 @@ if (isSomeString!S)
         assert(low == trueLow, format(diff, low, trueLow));
         assert(up == trueUp,  format(diff, up, trueUp));
         assert(lowInp == trueLow,
-            format(diff, cast(ubyte[])s, cast(ubyte[])lowInp, cast(ubyte[])trueLow));
+            format(diff, cast(ubyte[]) s, cast(ubyte[]) lowInp, cast(ubyte[]) trueLow));
         assert(upInp == trueUp,
-            format(diff, cast(ubyte[])s, cast(ubyte[])upInp, cast(ubyte[])trueUp));
+            format(diff, cast(ubyte[]) s, cast(ubyte[]) upInp, cast(ubyte[]) trueUp));
     }
     foreach (S; AliasSeq!(dstring, wstring, string))
     {

--- a/std/uri.d
+++ b/std/uri.d
@@ -104,14 +104,14 @@ private string URI_Encode(dstring string, uint unescapedSet)
                 }
                 else
                 {
-                    R2 = cast(char *)alloca(Rsize * char.sizeof);
+                    R2 = cast(char *) alloca(Rsize * char.sizeof);
                     if (!R2)
                         throw new OutOfMemoryError("Alloca failure");
                 }
                 R2[0..Rlen] = R[0..Rlen];
                 R = R2;
             }
-            R[Rlen] = cast(char)C;
+            R[Rlen] = cast(char) C;
             Rlen++;
         }
         else
@@ -164,7 +164,7 @@ private string URI_Encode(dstring string, uint unescapedSet)
                 }
                 else
                 {
-                    R2 = cast(char *)alloca(Rsize * char.sizeof);
+                    R2 = cast(char *) alloca(Rsize * char.sizeof);
                     if (!R2)
                         throw new OutOfMemoryError("Alloca failure");
                 }
@@ -220,7 +220,7 @@ if (isSomeChar!Char)
     }
     else
     {
-        R = cast(dchar *)alloca(Rsize * dchar.sizeof);
+        R = cast(dchar *) alloca(Rsize * dchar.sizeof);
         if (!R)
             throw new OutOfMemoryError("Alloca failure");
     }

--- a/std/utf.d
+++ b/std/utf.d
@@ -74,7 +74,7 @@ class UTFException : Exception
              * it is const-compatible.
              */
             //return super.toString();
-            auto e = () @trusted { return cast(Exception)super; } ();
+            auto e = () @trusted { return cast(Exception) super; } ();
             return e.toString();
         }
 
@@ -160,21 +160,21 @@ if (isSomeChar!Char)
         static immutable wstring[5] result =
         [
             [
-              cast(wchar)0xDC00,
+              cast(wchar) 0xDC00,
             ],
             [
-              cast(wchar)0xDFFF,
+              cast(wchar) 0xDFFF,
             ],
             [
-              cast(wchar)0xDBFF,
-              cast(wchar)0xDBFF,
+              cast(wchar) 0xDBFF,
+              cast(wchar) 0xDBFF,
             ],
             [
-              cast(wchar)0xDBFF,
-              cast(wchar)0xE000,
+              cast(wchar) 0xDBFF,
+              cast(wchar) 0xE000,
             ],
             [
-              cast(wchar)0xD800,
+              cast(wchar) 0xD800,
             ],
         ];
 
@@ -184,9 +184,9 @@ if (isSomeChar!Char)
     {
         static immutable dstring[3] result =
         [
-            [ cast(dchar)0x110000 ],
-            [ cast(dchar)0x00D800 ],
-            [ cast(dchar)0x00DFFF ],
+            [ cast(dchar) 0x110000 ],
+            [ cast(dchar) 0x00D800 ],
+            [ cast(dchar) 0x00DFFF ],
         ];
 
         return result;
@@ -222,17 +222,17 @@ pure nothrow @safe @nogc unittest
     assertCTFEable!(
     {
     assert( isValidDchar(cast(dchar)'a') == true);
-    assert( isValidDchar(cast(dchar)0x1FFFFF) == false);
+    assert( isValidDchar(cast(dchar) 0x1FFFFF) == false);
 
-    assert(!isValidDchar(cast(dchar)0x00D800));
-    assert(!isValidDchar(cast(dchar)0x00DBFF));
-    assert(!isValidDchar(cast(dchar)0x00DC00));
-    assert(!isValidDchar(cast(dchar)0x00DFFF));
-    assert( isValidDchar(cast(dchar)0x00FFFE));
-    assert( isValidDchar(cast(dchar)0x00FFFF));
-    assert( isValidDchar(cast(dchar)0x01FFFF));
-    assert( isValidDchar(cast(dchar)0x10FFFF));
-    assert(!isValidDchar(cast(dchar)0x110000));
+    assert(!isValidDchar(cast(dchar) 0x00D800));
+    assert(!isValidDchar(cast(dchar) 0x00DBFF));
+    assert(!isValidDchar(cast(dchar) 0x00DC00));
+    assert(!isValidDchar(cast(dchar) 0x00DFFF));
+    assert( isValidDchar(cast(dchar) 0x00FFFE));
+    assert( isValidDchar(cast(dchar) 0x00FFFF));
+    assert( isValidDchar(cast(dchar) 0x01FFFF));
+    assert( isValidDchar(cast(dchar) 0x10FFFF));
+    assert(!isValidDchar(cast(dchar) 0x110000));
     });
 }
 
@@ -1605,7 +1605,7 @@ if (is(S : const wchar[]) || (isInputRange!S && is(Unqual!(ElementEncodingType!S
     // Note: u+FFFE and u+FFFF are specifically permitted by the
     // Unicode standard for application internal use (see isValidDchar)
 
-    return cast(dchar)u;
+    return cast(dchar) u;
 }
 
 @safe pure @nogc nothrow
@@ -1915,8 +1915,8 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
         }
 
         //Invalid UTF-8 sequence where the first code unit is valid.
-        testAllDecode(S("\xEF\xBF\xBE"), cast(dchar)0xFFFE, 3);
-        testAllDecode(S("\xEF\xBF\xBF"), cast(dchar)0xFFFF, 3);
+        testAllDecode(S("\xEF\xBF\xBE"), cast(dchar) 0xFFFE, 3);
+        testAllDecode(S("\xEF\xBF\xBF"), cast(dchar) 0xFFFF, 3);
 
         //Invalid UTF-8 sequence where the first code unit isn't valid.
         foreach (str; ["\xED\xA0\x80",
@@ -1944,17 +1944,17 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
                           (wstring s) => new RefBidirCU!wchar(s),
                           (wstring s) => new RefRandomCU!wchar(s)))
     {
-        testAllDecode(S([cast(wchar)0x1111]), cast(dchar)0x1111, 1);
-        testAllDecode(S([cast(wchar)0xD800, cast(wchar)0xDC00]), cast(dchar)0x10000, 2);
-        testAllDecode(S([cast(wchar)0xDBFF, cast(wchar)0xDFFF]), cast(dchar)0x10FFFF, 2);
-        testAllDecode(S([cast(wchar)0xFFFE]), cast(dchar)0xFFFE, 1);
-        testAllDecode(S([cast(wchar)0xFFFF]), cast(dchar)0xFFFF, 1);
+        testAllDecode(S([cast(wchar) 0x1111]), cast(dchar) 0x1111, 1);
+        testAllDecode(S([cast(wchar) 0xD800, cast(wchar) 0xDC00]), cast(dchar) 0x10000, 2);
+        testAllDecode(S([cast(wchar) 0xDBFF, cast(wchar) 0xDFFF]), cast(dchar) 0x10FFFF, 2);
+        testAllDecode(S([cast(wchar) 0xFFFE]), cast(dchar) 0xFFFE, 1);
+        testAllDecode(S([cast(wchar) 0xFFFF]), cast(dchar) 0xFFFF, 1);
 
-        testBadDecode(S([ cast(wchar)0xD801 ]), 0);
-        testBadDecode(S([ cast(wchar)0xD800, cast(wchar)0x1200 ]), 0);
+        testBadDecode(S([ cast(wchar) 0xD801 ]), 0);
+        testBadDecode(S([ cast(wchar) 0xD800, cast(wchar) 0x1200 ]), 0);
 
-        testBadDecodeBack(S([ cast(wchar)0xD801 ]));
-        testBadDecodeBack(S([ cast(wchar)0x0010, cast(wchar)0xD800 ]));
+        testBadDecodeBack(S([ cast(wchar) 0xD801 ]));
+        testBadDecodeBack(S([ cast(wchar) 0x0010, cast(wchar) 0xD800 ]));
 
         {
             auto range = S("ウェブサイト");
@@ -1977,15 +1977,15 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
 
     foreach (S; AliasSeq!(to!wstring, RandomCU!wchar, (wstring s) => new RefRandomCU!wchar(s)))
     {
-        auto str = S([cast(wchar)0xD800, cast(wchar)0xDC00,
-                      cast(wchar)0x1400,
-                      cast(wchar)0xDAA7, cast(wchar)0xDDDE]);
-        testDecode(str, 0, cast(dchar)0x10000, 2);
-        testDecode(str, 2, cast(dchar)0x1400, 3);
-        testDecode(str, 3, cast(dchar)0xB9DDE, 5);
-        testDecodeBack(str, cast(dchar)0xB9DDE, 2);
-        testDecodeBack(str, cast(dchar)0x1400, 1);
-        testDecodeBack(str, cast(dchar)0x10000, 2);
+        auto str = S([cast(wchar) 0xD800, cast(wchar) 0xDC00,
+                      cast(wchar) 0x1400,
+                      cast(wchar) 0xDAA7, cast(wchar) 0xDDDE]);
+        testDecode(str, 0, cast(dchar) 0x10000, 2);
+        testDecode(str, 2, cast(dchar) 0x1400, 3);
+        testDecode(str, 3, cast(dchar) 0xB9DDE, 5);
+        testDecodeBack(str, cast(dchar) 0xB9DDE, 2);
+        testDecodeBack(str, cast(dchar) 0x1400, 1);
+        testDecodeBack(str, cast(dchar) 0x10000, 2);
     }
     });
 }
@@ -2000,19 +2000,19 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
                           (dstring s) => new RefBidirCU!dchar(s),
                           (dstring s) => new RefRandomCU!dchar(s)))
     {
-        testAllDecode(S([cast(dchar)0x1111]), cast(dchar)0x1111, 1);
-        testAllDecode(S([cast(dchar)0x10000]), cast(dchar)0x10000, 1);
-        testAllDecode(S([cast(dchar)0x10FFFF]), cast(dchar)0x10FFFF, 1);
-        testAllDecode(S([cast(dchar)0xFFFE]), cast(dchar)0xFFFE, 1);
-        testAllDecode(S([cast(dchar)0xFFFF]), cast(dchar)0xFFFF, 1);
+        testAllDecode(S([cast(dchar) 0x1111]), cast(dchar) 0x1111, 1);
+        testAllDecode(S([cast(dchar) 0x10000]), cast(dchar) 0x10000, 1);
+        testAllDecode(S([cast(dchar) 0x10FFFF]), cast(dchar) 0x10FFFF, 1);
+        testAllDecode(S([cast(dchar) 0xFFFE]), cast(dchar) 0xFFFE, 1);
+        testAllDecode(S([cast(dchar) 0xFFFF]), cast(dchar) 0xFFFF, 1);
 
-        testBadDecode(S([cast(dchar)0xD800]), 0);
-        testBadDecode(S([cast(dchar)0xDFFE]), 0);
-        testBadDecode(S([cast(dchar)0x110000]), 0);
+        testBadDecode(S([cast(dchar) 0xD800]), 0);
+        testBadDecode(S([cast(dchar) 0xDFFE]), 0);
+        testBadDecode(S([cast(dchar) 0x110000]), 0);
 
-        testBadDecodeBack(S([cast(dchar)0xD800]));
-        testBadDecodeBack(S([cast(dchar)0xDFFE]));
-        testBadDecodeBack(S([cast(dchar)0x110000]));
+        testBadDecodeBack(S([cast(dchar) 0xD800]));
+        testBadDecodeBack(S([cast(dchar) 0xDFFE]));
+        testBadDecodeBack(S([cast(dchar) 0x110000]));
 
         {
             auto range = S("ウェブサイト");
@@ -2035,13 +2035,13 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
 
     foreach (S; AliasSeq!(to!dstring, RandomCU!dchar, (dstring s) => new RefRandomCU!dchar(s)))
     {
-        auto str = S([cast(dchar)0x10000, cast(dchar)0x1400, cast(dchar)0xB9DDE]);
+        auto str = S([cast(dchar) 0x10000, cast(dchar) 0x1400, cast(dchar) 0xB9DDE]);
         testDecode(str, 0, 0x10000, 1);
         testDecode(str, 1, 0x1400, 2);
         testDecode(str, 2, 0xB9DDE, 3);
-        testDecodeBack(str, cast(dchar)0xB9DDE, 1);
-        testDecodeBack(str, cast(dchar)0x1400, 1);
-        testDecodeBack(str, cast(dchar)0x10000, 1);
+        testDecodeBack(str, cast(dchar) 0xB9DDE, 1);
+        testDecodeBack(str, cast(dchar) 0x1400, 1);
+        testDecodeBack(str, cast(dchar) 0x10000, 1);
     }
     });
 }
@@ -2107,7 +2107,7 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     if (c <= 0x7F)
     {
         assert(isValidDchar(c));
-        buf[0] = cast(char)c;
+        buf[0] = cast(char) c;
         return 1;
     }
     if (c <= 0x7FF)
@@ -2163,13 +2163,13 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     assert(encode(buf, '\U00010000') == 4 && buf[0 .. 4] == "\U00010000");
     assert(encode(buf, '\U0010FFFF') == 4 && buf[0 .. 4] == "\U0010FFFF");
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
-    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000) == buf.stride);
+    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000) == buf.stride);
     assert(buf.front == replacementDchar);
     });
 }
@@ -2186,7 +2186,7 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
 
         assert(isValidDchar(c));
     L1:
-        buf[0] = cast(wchar)c;
+        buf[0] = cast(wchar) c;
         return 1;
     }
     if (c <= 0x10FFFF)
@@ -2216,13 +2216,13 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     assert(encode(buf, '\U00010000') == 2 && buf[0 .. 2] == "\U00010000");
     assert(encode(buf, '\U0010FFFF') == 2 && buf[0 .. 2] == "\U0010FFFF");
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
-    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000) == buf.stride);
+    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000) == buf.stride);
     assert(buf.front == replacementDchar);
     });
 }
@@ -2254,13 +2254,13 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     encode(buf, 0xFFFF ); assert(buf[0] == 0xFFFF);
     encode(buf, '\U0010FFFF'); assert(buf[0] == '\U0010FFFF');
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
-    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000) == buf.stride);
+    assert(encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000) == buf.stride);
     assert(buf.front == replacementDchar);
     });
 }
@@ -2280,7 +2280,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     if (c <= 0x7F)
     {
         assert(isValidDchar(c));
-        r ~= cast(char)c;
+        r ~= cast(char) c;
     }
     else
     {
@@ -2368,14 +2368,14 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     encode(buf, '\U00010000'); assert(buf[21 .. $] == "\U00010000");
     encode(buf, '\U0010FFFF'); assert(buf[25 .. $] == "\U0010FFFF");
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
     assert(buf.back != replacementDchar);
-    encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000);
+    encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000);
     assert(buf.back == replacementDchar);
     });
 }
@@ -2393,7 +2393,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
 
         assert(isValidDchar(c));
     L1:
-        r ~= cast(wchar)c;
+        r ~= cast(wchar) c;
     }
     else if (c <= 0x10FFFF)
     {
@@ -2429,14 +2429,14 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     encode(buf, '\U00010000'); assert(buf[5 .. $] == "\U00010000");
     encode(buf, '\U0010FFFF'); assert(buf[7 .. $] == "\U0010FFFF");
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
     assert(buf.back != replacementDchar);
-    encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000);
+    encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000);
     assert(buf.back == replacementDchar);
     });
 }
@@ -2466,14 +2466,14 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     encode(buf, 0xFFFF ); assert(buf[4] == 0xFFFF);
     encode(buf, '\U0010FFFF'); assert(buf[5] == '\U0010FFFF');
 
-    assertThrown!UTFException(encode(buf, cast(dchar)0xD800));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDBFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDC00));
-    assertThrown!UTFException(encode(buf, cast(dchar)0xDFFF));
-    assertThrown!UTFException(encode(buf, cast(dchar)0x110000));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xD800));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDBFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDC00));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0xDFFF));
+    assertThrown!UTFException(encode(buf, cast(dchar) 0x110000));
 
     assert(buf.back != replacementDchar);
-    encode!(Yes.useReplacementDchar)(buf, cast(dchar)0x110000);
+    encode!(Yes.useReplacementDchar)(buf, cast(dchar) 0x110000);
     assert(buf.back == replacementDchar);
     });
 }
@@ -2629,8 +2629,8 @@ if (isSomeChar!C)
     assert(!canSearchInCodeUnits! char('日'));
     assert( canSearchInCodeUnits!wchar('日'));
     assert( canSearchInCodeUnits!dchar('日'));
-    assert(!canSearchInCodeUnits!wchar(cast(wchar)0xDA00));
-    assert( canSearchInCodeUnits!dchar(cast(dchar)0xDA00));
+    assert(!canSearchInCodeUnits!wchar(cast(wchar) 0xDA00));
+    assert( canSearchInCodeUnits!dchar(cast(dchar) 0xDA00));
     assert(!canSearchInCodeUnits! char('\U00010001'));
     assert(!canSearchInCodeUnits!wchar('\U00010001'));
     assert( canSearchInCodeUnits!dchar('\U00010001'));
@@ -2670,7 +2670,7 @@ char[] toUTF8(return out char[4] buf, dchar c) nothrow @nogc @safe pure
 {
     if (c <= 0x7F)
     {
-        buf[0] = cast(char)c;
+        buf[0] = cast(char) c;
         return buf[0 .. 1];
     }
     else if (c <= 0x7FF)
@@ -2758,7 +2758,7 @@ body
 {
     if (c <= 0xFFFF)
     {
-        buf[0] = cast(wchar)c;
+        buf[0] = cast(wchar) c;
         return buf[0 .. 1];
     }
     else
@@ -2945,7 +2945,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
             // might be pointing to a new block of memory, which might be
             // unreadable. Otherwise, it's definitely pointing to valid
             // memory.
-            if ((cast(size_t)p & 3) && *p == '\0')
+            if ((cast(size_t) p & 3) && *p == '\0')
                 return &str[0];
         }
 
@@ -2972,7 +2972,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
             auto trustedPtrAdd(S s) @trusted { return s.ptr + s.length; }
             auto p = trustedPtrAdd(str);
 
-            if ((cast(size_t)p & 3) && *p == '\0')
+            if ((cast(size_t) p & 3) && *p == '\0')
                 return &str[0];
         }
 
@@ -2988,7 +2988,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
         copy[0 .. $ - 1] = str[];
         copy[$ - 1] = '\0';
 
-        auto trustedCast(typeof(copy) c) @trusted { return cast(P)c.ptr; }
+        auto trustedCast(typeof(copy) c) @trusted { return cast(P) c.ptr; }
         return trustedCast(copy);
     }
 }
@@ -3005,7 +3005,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
         retval.put(c);
     retval.put('\0');
 
-    return () @trusted { return cast(P)retval.data.ptr; } ();
+    return () @trusted { return cast(P) retval.data.ptr; } ();
 }
 
 @safe pure unittest
@@ -3530,7 +3530,7 @@ alias byDchar = byUTF!dchar;
     dchar[10] a;
     a[0..8] = "hello\u07FF\uD7FF\U0010FFFF"d;
     a[8] = 0xD800;   // invalid
-    a[9] = cast(dchar)0x110000; // invalid
+    a[9] = cast(dchar) 0x110000; // invalid
     foreach (c; a[].byChar())
     {
         //writefln("[%d] '%c'", i, c);
@@ -3567,7 +3567,7 @@ alias byDchar = byUTF!dchar;
     dchar[10] a;
     a[0..8] = "hello\u07FF\uD7FF\U0010FFFF"d;
     a[8] = 0xD800;   // invalid
-    a[9] = cast(dchar)0x110000; // invalid
+    a[9] = cast(dchar) 0x110000; // invalid
     foreach (c; a[].byWchar())
     {
         //writefln("[%d] '%c' x%x", i, c, c);

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -240,7 +240,7 @@ public struct UUID
             assert(tmp.data == cast(ubyte[16])[0,1,3,3,4,5,6,7,8,9,10,11,
                 12,13,14,15]);
 
-            auto tmp2 = cast(immutable UUID)tmp;
+            auto tmp2 = cast(immutable UUID) tmp;
             assert(tmp2.data == cast(ubyte[16])[0,1,3,3,4,5,6,7,8,9,10,11,
                 12,13,14,15]);
         }
@@ -935,7 +935,7 @@ public struct UUID
             import std.encoding : Char = AsciiChar;
             enum  utfstr = "8ab3060e-2cba-4f23-b74c-b52db3bdfb46";
             alias String = immutable(Char)[];
-            enum String s = cast(String)utfstr;
+            enum String s = cast(String) utfstr;
             enum id = UUID(utfstr);
             //nogc
             Char[36] str;

--- a/std/variant.d
+++ b/std/variant.d
@@ -495,7 +495,7 @@ private:
                 auto variantArgs = p[1 .. argCount + 1];
                 foreach (i, T; ParamTypes)
                 {
-                    t[i] = cast()variantArgs[i].get!T;
+                    t[i] = cast() variantArgs[i].get!T;
                 }
 
                 auto args = cast(Tuple!(ParamTypes))t;
@@ -860,7 +860,7 @@ public:
     // workaround for bug 10567 fix
     int opCmp(ref const VariantN rhs) const
     {
-        return (cast()this).opCmp!(VariantN)(cast()rhs);
+        return (cast() this).opCmp!(VariantN)(cast() rhs);
     }
 
     /**
@@ -2036,17 +2036,17 @@ unittest
     Algebraic!(int, string) variant;
 
     variant = 10;
-    assert(variant.visit!((string s) => cast(int)s.length,
+    assert(variant.visit!((string s) => cast(int) s.length,
                           (int i)    => i)()
                           == 10);
     variant = "string";
     assert(variant.visit!((int i) => i,
-                          (string s) => cast(int)s.length)()
+                          (string s) => cast(int) s.length)()
                           == 6);
 
     // Error function usage
     Algebraic!(int, string) emptyVar;
-    auto rslt = emptyVar.visit!((string s) => cast(int)s.length,
+    auto rslt = emptyVar.visit!((string s) => cast(int) s.length,
                           (int i)    => i,
                           () => -1)();
     assert(rslt == -1);
@@ -2059,7 +2059,7 @@ unittest
     // not all handled check
     static assert(!__traits(compiles, variant.visit!((size_t i){ })() ));
 
-    variant = cast(size_t)10;
+    variant = cast(size_t) 10;
     auto which = 0;
     variant.visit!( (string s) => which = 1,
                     (size_t i) => which = 0
@@ -2095,7 +2095,7 @@ unittest
     auto floatVisited = false;
 
     assert(variant3.visit!(
-                 (float f) { floatVisited = true; return cast(size_t)f; },
+                 (float f) { floatVisited = true; return cast(size_t) f; },
                  func,
                  (size_t i) { return i; }
                  )() == 10);
@@ -2103,11 +2103,11 @@ unittest
 
     Algebraic!(float, string) variant4;
 
-    assert(variant4.visit!(func, (float f) => cast(size_t)f, () => size_t.max)() == size_t.max);
+    assert(variant4.visit!(func, (float f) => cast(size_t) f, () => size_t.max)() == size_t.max);
 
     // double error func check
     static assert(!__traits(compiles,
-                            visit!(() => size_t.max, func, (float f) => cast(size_t)f, () => size_t.max)(variant4))
+                            visit!(() => size_t.max, func, (float f) => cast(size_t) f, () => size_t.max)(variant4))
                  );
 }
 

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -282,9 +282,9 @@ body
      * these hive keys is ignored, we'd rather not trust the Win32
      * API.
      */
-    if (cast(uint)hkey & 0x80000000)
+    if (cast(uint) hkey & 0x80000000)
     {
-        switch (cast(uint)hkey)
+        switch (cast(uint) hkey)
         {
             case HKEY_CLASSES_ROOT:
             case HKEY_CURRENT_USER:
@@ -376,9 +376,9 @@ in
 body
 {
     /* Can't duplicate standard keys, but don't need to, so can just return */
-    if (cast(uint)hkey & 0x80000000)
+    if (cast(uint) hkey & 0x80000000)
     {
-        switch (cast(uint)hkey)
+        switch (cast(uint) hkey)
         {
             case HKEY_CLASSES_ROOT:
             case HKEY_CURRENT_USER:
@@ -966,7 +966,7 @@ public:
         Params:
             name = The name of the key to delete. May not be $(D null).
      */
-    void deleteKey(string name, REGSAM access = cast(REGSAM)0)
+    void deleteKey(string name, REGSAM access = cast(REGSAM) 0)
     {
         enforce(!name.empty, new RegistryException("Key name is invalid"));
 

--- a/std/xml.d
+++ b/std/xml.d
@@ -30,7 +30,7 @@ import std.file;
 
 void main()
 {
-    string s = cast(string)std.file.read("books.xml");
+    string s = cast(string) std.file.read("books.xml");
 
     // Check for well-formedness
     check(s);
@@ -64,7 +64,7 @@ struct Book
 
 void main()
 {
-    string s = cast(string)std.file.read("books.xml");
+    string s = cast(string) std.file.read("books.xml");
 
     // Check for well-formedness
     check(s);
@@ -161,26 +161,26 @@ bool isChar(dchar c) @safe @nogc pure nothrow // rule 2
 
 @safe @nogc nothrow pure unittest
 {
-    assert(!isChar(cast(dchar)0x8));
-    assert( isChar(cast(dchar)0x9));
-    assert( isChar(cast(dchar)0xA));
-    assert(!isChar(cast(dchar)0xB));
-    assert(!isChar(cast(dchar)0xC));
-    assert( isChar(cast(dchar)0xD));
-    assert(!isChar(cast(dchar)0xE));
-    assert(!isChar(cast(dchar)0x1F));
-    assert( isChar(cast(dchar)0x20));
+    assert(!isChar(cast(dchar) 0x8));
+    assert( isChar(cast(dchar) 0x9));
+    assert( isChar(cast(dchar) 0xA));
+    assert(!isChar(cast(dchar) 0xB));
+    assert(!isChar(cast(dchar) 0xC));
+    assert( isChar(cast(dchar) 0xD));
+    assert(!isChar(cast(dchar) 0xE));
+    assert(!isChar(cast(dchar) 0x1F));
+    assert( isChar(cast(dchar) 0x20));
     assert( isChar('J'));
-    assert( isChar(cast(dchar)0xD7FF));
-    assert(!isChar(cast(dchar)0xD800));
-    assert(!isChar(cast(dchar)0xDFFF));
-    assert( isChar(cast(dchar)0xE000));
-    assert( isChar(cast(dchar)0xFFFD));
-    assert(!isChar(cast(dchar)0xFFFE));
-    assert(!isChar(cast(dchar)0xFFFF));
-    assert( isChar(cast(dchar)0x10000));
-    assert( isChar(cast(dchar)0x10FFFF));
-    assert(!isChar(cast(dchar)0x110000));
+    assert( isChar(cast(dchar) 0xD7FF));
+    assert(!isChar(cast(dchar) 0xD800));
+    assert(!isChar(cast(dchar) 0xDFFF));
+    assert( isChar(cast(dchar) 0xE000));
+    assert( isChar(cast(dchar) 0xFFFD));
+    assert(!isChar(cast(dchar) 0xFFFE));
+    assert(!isChar(cast(dchar) 0xFFFF));
+    assert( isChar(cast(dchar) 0x10000));
+    assert( isChar(cast(dchar) 0x10FFFF));
+    assert(!isChar(cast(dchar) 0x110000));
 
     debug (stdxml_TestHardcodedChecks)
     {
@@ -482,7 +482,7 @@ string decode(string s, DecodeMode mode=DecodeMode.LOOSE) @system pure
             }
         }
     }
-    return (buffer.length == 0) ? s : cast(string)buffer;
+    return (buffer.length == 0) ? s : cast(string) buffer;
 }
 
 @system pure unittest
@@ -593,7 +593,7 @@ class Document : Element
         {
             const doc = toType!(const Document)(o);
             return prolog == doc.prolog
-                && (cast()this).Element.opEquals(cast()doc)
+                && (cast() this).Element.opEquals(cast() doc)
                 && epilog == doc.epilog;
         }
 
@@ -614,7 +614,7 @@ class Document : Element
             const doc = toType!(const Document)(o);
             if (prolog != doc.prolog)
                 return prolog < doc.prolog ? -1 : 1;
-            if (int cmp = (cast()this).Element.opCmp(cast()doc))
+            if (int cmp = (cast() this).Element.opCmp(cast() doc))
                 return cmp;
             if (epilog != doc.epilog)
                 return epilog < doc.epilog ? -1 : 1;
@@ -629,7 +629,7 @@ class Document : Element
          */
         override size_t toHash() @trusted
         {
-            return hash(prolog, hash(epilog, (cast()this).Element.toHash()));
+            return hash(prolog, hash(epilog, (cast() this).Element.toHash()));
         }
 
         /**
@@ -842,7 +842,7 @@ class Element : Item
         if (len != element.items.length) return false;
         foreach (i; 0 .. len)
         {
-            if (!items[i].opEquals(cast()element.items[i])) return false;
+            if (!items[i].opEquals(cast() element.items[i])) return false;
         }
         return true;
     }
@@ -868,7 +868,7 @@ class Element : Item
             if (i == items.length) return -1;
             if (i == element.items.length) return 1;
             if (items[i] != element.items[i])
-                return items[i].opCmp(cast()element.items[i]);
+                return items[i].opCmp(cast() element.items[i]);
         }
     }
 
@@ -904,7 +904,7 @@ class Element : Item
             string buffer;
             foreach (item;items)
             {
-                Text t = cast(Text)item;
+                Text t = cast(Text) item;
                 if (t is null) throw new DecodeException(item.toString());
                 buffer ~= decode(t.toString(),mode);
             }
@@ -1134,7 +1134,7 @@ class Tag
             // Note that attr is an AA, so the comparison is nonsensical (bug 10381)
             return
                 ((name != tag.name) ? ( name < tag.name ? -1 : 1 ) :
-                ((attr != tag.attr) ? ( cast(void *)attr < cast(void*)tag.attr ? -1 : 1 ) :
+                ((attr != tag.attr) ? ( cast(void *) attr < cast(void*) tag.attr ? -1 : 1 ) :
                 ((type != tag.type) ? ( type < tag.type ? -1 : 1 ) :
             0 )));
         }
@@ -1259,7 +1259,7 @@ class Comment : Item
     override bool opEquals(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(Comment)item;
+        const t = cast(Comment) item;
         return t !is null && content == t.content;
     }
 
@@ -1278,7 +1278,7 @@ class Comment : Item
     override int opCmp(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(Comment)item;
+        const t = cast(Comment) item;
         return t !is null && (content != t.content
             ? (content < t.content ? -1 : 1 ) : 0 );
     }
@@ -1347,7 +1347,7 @@ class CData : Item
     override bool opEquals(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(CData)item;
+        const t = cast(CData) item;
         return t !is null && content == t.content;
     }
 
@@ -1366,7 +1366,7 @@ class CData : Item
     override int opCmp(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(CData)item;
+        const t = cast(CData) item;
         return t !is null && (content != t.content
             ? (content < t.content ? -1 : 1 ) : 0 );
     }
@@ -1424,7 +1424,7 @@ class Text : Item
     override bool opEquals(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(Text)item;
+        const t = cast(Text) item;
         return t !is null && content == t.content;
     }
 
@@ -1443,7 +1443,7 @@ class Text : Item
     override int opCmp(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(Text)item;
+        const t = cast(Text) item;
         return t !is null
             && (content != t.content ? (content < t.content ? -1 : 1 ) : 0 );
     }
@@ -1507,7 +1507,7 @@ class XMLInstruction : Item
     override bool opEquals(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(XMLInstruction)item;
+        const t = cast(XMLInstruction) item;
         return t !is null && content == t.content;
     }
 
@@ -1526,7 +1526,7 @@ class XMLInstruction : Item
     override int opCmp(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(XMLInstruction)item;
+        const t = cast(XMLInstruction) item;
         return t !is null
             && (content != t.content ? (content < t.content ? -1 : 1 ) : 0 );
     }
@@ -1587,7 +1587,7 @@ class ProcessingInstruction : Item
     override bool opEquals(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(ProcessingInstruction)item;
+        const t = cast(ProcessingInstruction) item;
         return t !is null && content == t.content;
     }
 
@@ -1606,7 +1606,7 @@ class ProcessingInstruction : Item
     override int opCmp(Object o)
     {
         const item = toType!(const Item)(o);
-        const t = cast(ProcessingInstruction)item;
+        const t = cast(ProcessingInstruction) item;
         return t !is null
             && (content != t.content ? (content < t.content ? -1 : 1 ) : 0 );
     }

--- a/std/zip.d
+++ b/std/zip.d
@@ -409,7 +409,7 @@ final class ZipArchive
 
                     case CompressionMethod.deflate:
                         import std.zlib : compress;
-                        de._compressedData = cast(ubyte[])compress(cast(void[])de._expandedData);
+                        de._compressedData = cast(ubyte[]) compress(cast(void[]) de._expandedData);
                         de._compressedData = de._compressedData[2 .. de._compressedData.length - 4];
                         break;
 
@@ -419,7 +419,7 @@ final class ZipArchive
 
                 de._compressedSize = to!uint(de._compressedData.length);
                 import std.zlib : crc32;
-                de._crc32 = crc32(0, cast(void[])de._expandedData);
+                de._crc32 = crc32(0, cast(void[]) de._expandedData);
             }
             assert(de._compressedData.length == de._compressedSize);
 
@@ -438,7 +438,7 @@ final class ZipArchive
 
         if (!isZip64 && _directory.length > ushort.max)
             _isZip64 = true;
-        uint dataSize = archiveSize + directorySize + 22 + cast(uint)comment.length;
+        uint dataSize = archiveSize + directorySize + 22 + cast(uint) comment.length;
         if (isZip64)
             dataSize += eocd64LocLength + eocd64Length;
 
@@ -455,17 +455,17 @@ final class ZipArchive
             putUshort(i + 4,  de.extractVersion);
             putUshort(i + 6,  de.flags);
             putUshort(i + 8,  de._compressionMethod);
-            putUint  (i + 10, cast(uint)de.time);
+            putUint  (i + 10, cast(uint) de.time);
             putUint  (i + 14, de.crc32);
             putUint  (i + 18, de.compressedSize);
             putUint  (i + 22, to!uint(de.expandedSize));
-            putUshort(i + 26, cast(ushort)de.name.length);
-            putUshort(i + 28, cast(ushort)de.extra.length);
+            putUshort(i + 26, cast(ushort) de.name.length);
+            putUshort(i + 28, cast(ushort) de.extra.length);
             i += 30;
 
-            _data[i .. i + de.name.length] = (cast(ubyte[])de.name)[];
+            _data[i .. i + de.name.length] = (cast(ubyte[]) de.name)[];
             i += de.name.length;
-            _data[i .. i + de.extra.length] = (cast(ubyte[])de.extra)[];
+            _data[i .. i + de.extra.length] = (cast(ubyte[]) de.extra)[];
             i += de.extra.length;
             _data[i .. i + de.compressedSize] = de.compressedData[];
             i += de.compressedSize;
@@ -481,24 +481,24 @@ final class ZipArchive
             putUshort(i + 6,  de.extractVersion);
             putUshort(i + 8,  de.flags);
             putUshort(i + 10, de._compressionMethod);
-            putUint  (i + 12, cast(uint)de.time);
+            putUint  (i + 12, cast(uint) de.time);
             putUint  (i + 16, de.crc32);
             putUint  (i + 20, de.compressedSize);
             putUint  (i + 24, de.expandedSize);
-            putUshort(i + 28, cast(ushort)de.name.length);
-            putUshort(i + 30, cast(ushort)de.extra.length);
-            putUshort(i + 32, cast(ushort)de.comment.length);
+            putUshort(i + 28, cast(ushort) de.name.length);
+            putUshort(i + 30, cast(ushort) de.extra.length);
+            putUshort(i + 32, cast(ushort) de.comment.length);
             putUshort(i + 34, de.diskNumber);
             putUshort(i + 36, de.internalAttributes);
             putUint  (i + 38, de._externalAttributes);
             putUint  (i + 42, de.offset);
             i += 46;
 
-            _data[i .. i + de.name.length] = (cast(ubyte[])de.name)[];
+            _data[i .. i + de.name.length] = (cast(ubyte[]) de.name)[];
             i += de.name.length;
-            _data[i .. i + de.extra.length] = (cast(ubyte[])de.extra)[];
+            _data[i .. i + de.extra.length] = (cast(ubyte[]) de.extra)[];
             i += de.extra.length;
-            _data[i .. i + de.comment.length] = (cast(ubyte[])de.comment)[];
+            _data[i .. i + de.comment.length] = (cast(ubyte[]) de.comment)[];
             i += de.comment.length;
             _numEntries++;
         }
@@ -531,20 +531,20 @@ final class ZipArchive
         // Write end record
         endrecOffset = i;
         _data[i .. i + 4] = cast(ubyte[])"PK\x05\x06";
-        putUshort(i + 4,  cast(ushort)diskNumber);
-        putUshort(i + 6,  cast(ushort)diskStartDir);
-        putUshort(i + 8,  (numEntries > ushort.max ? ushort.max : cast(ushort)numEntries));
-        putUshort(i + 10, (totalEntries > ushort.max ? ushort.max : cast(ushort)totalEntries));
+        putUshort(i + 4,  cast(ushort) diskNumber);
+        putUshort(i + 6,  cast(ushort) diskStartDir);
+        putUshort(i + 8,  (numEntries > ushort.max ? ushort.max : cast(ushort) numEntries));
+        putUshort(i + 10, (totalEntries > ushort.max ? ushort.max : cast(ushort) totalEntries));
         putUint  (i + 12, directorySize);
         putUint  (i + 16, directoryOffset);
-        putUshort(i + 20, cast(ushort)comment.length);
+        putUshort(i + 20, cast(ushort) comment.length);
         i += 22;
 
         // Write archive comment
         assert(i + comment.length == data.length);
-        _data[i .. data.length] = (cast(ubyte[])comment)[];
+        _data[i .. data.length] = (cast(ubyte[]) comment)[];
 
-        return cast(void[])data;
+        return cast(void[]) data;
     }
 
     /* ============ Reading an existing archive =================== */
@@ -682,8 +682,8 @@ final class ZipArchive
             de._madeVersion = getUshort(i + 4);
             de._extractVersion = getUshort(i + 6);
             de.flags = getUshort(i + 8);
-            de._compressionMethod = cast(CompressionMethod)getUshort(i + 10);
-            de.time = cast(DosFileTime)getUint(i + 12);
+            de._compressionMethod = cast(CompressionMethod) getUshort(i + 10);
+            de.time = cast(DosFileTime) getUint(i + 12);
             de._crc32 = getUint(i + 16);
             de._compressedSize = getUint(i + 20);
             de._expandedSize = getUint(i + 24);
@@ -735,8 +735,8 @@ final class ZipArchive
         // These values should match what is in the main zip archive directory
         de._extractVersion = getUshort(de.offset + 4);
         de.flags = getUshort(de.offset + 6);
-        de._compressionMethod = cast(CompressionMethod)getUshort(de.offset + 8);
-        de.time = cast(DosFileTime)getUint(de.offset + 10);
+        de._compressionMethod = cast(CompressionMethod) getUshort(de.offset + 8);
+        de.time = cast(DosFileTime) getUint(de.offset + 10);
         de._crc32 = getUint(de.offset + 14);
         de._compressedSize = max(getUint(de.offset + 18), de.compressedSize);
         de._expandedSize = max(getUint(de.offset + 22), de.expandedSize);
@@ -773,7 +773,7 @@ final class ZipArchive
                 // It has the effect of not requiring the 2 byte header
                 // and 4 byte trailer.
                 import std.zlib : uncompress;
-                de._expandedData = cast(ubyte[])uncompress(cast(void[])de.compressedData, de.expandedSize, -15);
+                de._expandedData = cast(ubyte[]) uncompress(cast(void[]) de.compressedData, de.expandedSize, -15);
                 return de.expandedData;
 
             default:
@@ -821,7 +821,7 @@ debug(print)
 {
     @safe void arrayPrint(ubyte[] array)
     {
-        printf("array %p,%d\n", cast(void*)array, array.length);
+        printf("array %p,%d\n", cast(void*) array, array.length);
         for (int i = 0; i < array.length; i++)
         {
             printf("%02x ", array[i]);
@@ -907,8 +907,8 @@ debug(print)
     {
         auto member = new ArchiveMember();
         member.name = name;
-        member.expandedData = cast(ubyte[])name;
-        member.index = cast(int)i;
+        member.expandedData = cast(ubyte[]) name;
+        member.index = cast(int) i;
         zip1.addMember(member);
     }
     auto data = zip1.build();
@@ -932,8 +932,8 @@ debug(print)
 "the quick brown fox jumps over the lazy dog\r
 the quick brown fox jumps over the lazy dog\r
 ";
-    auto dst = cast(ubyte[])compress(cast(void[])src);
-    auto after = cast(ubyte[])uncompress(cast(void[])dst);
+    auto dst = cast(ubyte[]) compress(cast(void[]) src);
+    auto after = cast(ubyte[]) uncompress(cast(void[]) dst);
     assert(src == after);
 }
 
@@ -980,7 +980,7 @@ version(Posix) @system unittest
     mkdirRecurse(deleteme);
     scope(exit) rmdirRecurse(deleteme);
     string zipFile = buildPath(deleteme, "foo.zip");
-    std.file.write(zipFile, cast(byte[])data2);
+    std.file.write(zipFile, cast(byte[]) data2);
 
     auto result = executeShell(format("unzip -l %s", zipFile));
     scope(failure) writeln(result.output);

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -19,7 +19,7 @@
  * ubyte[] result;
  *
  * dst = compress(src);
- * result = cast(ubyte[])uncompress(dst);
+ * result = cast(ubyte[]) uncompress(dst);
  * assert(result == src);
  * -------
  *
@@ -113,9 +113,9 @@ class ZlibException : Exception
 uint adler32(uint adler, const(void)[] buf)
 {
     import std.range : chunks;
-    foreach (chunk; (cast(ubyte[])buf).chunks(0xFFFF0000))
+    foreach (chunk; (cast(ubyte[]) buf).chunks(0xFFFF0000))
     {
-        adler = etc.c.zlib.adler32(adler, chunk.ptr, cast(uint)chunk.length);
+        adler = etc.c.zlib.adler32(adler, chunk.ptr, cast(uint) chunk.length);
     }
     return adler;
 }
@@ -156,9 +156,9 @@ uint adler32(uint adler, const(void)[] buf)
 uint crc32(uint crc, const(void)[] buf)
 {
     import std.range : chunks;
-    foreach (chunk; (cast(ubyte[])buf).chunks(0xFFFF0000))
+    foreach (chunk; (cast(ubyte[]) buf).chunks(0xFFFF0000))
     {
-        crc = etc.c.zlib.crc32(crc, chunk.ptr, cast(uint)chunk.length);
+        crc = etc.c.zlib.crc32(crc, chunk.ptr, cast(uint) chunk.length);
     }
     return crc;
 }
@@ -170,7 +170,7 @@ uint crc32(uint crc, const(void)[] buf)
     uint crc;
 
     debug(zlib) printf("D.zlib.crc32.unittest\n");
-    crc = crc32(0u, cast(void[])data);
+    crc = crc32(0u, cast(void[]) data);
     debug(zlib) printf("crc = %x\n", crc);
     assert(crc == 0x2520577b);
 }
@@ -198,7 +198,7 @@ body
     import core.memory : GC;
     auto destlen = srcbuf.length + ((srcbuf.length + 1023) / 1024) + 12;
     auto destbuf = new ubyte[destlen];
-    auto err = etc.c.zlib.compress2(destbuf.ptr, &destlen, cast(ubyte *)srcbuf.ptr, srcbuf.length, level);
+    auto err = etc.c.zlib.compress2(destbuf.ptr, &destlen, cast(ubyte *) srcbuf.ptr, srcbuf.length, level);
     if (err)
     {
         GC.free(destbuf.ptr);
@@ -291,7 +291,7 @@ the quick brown fox jumps over the lazy dog\r
     //arrayPrint(src);
     dst = compress(src);
     //arrayPrint(dst);
-    result = cast(ubyte[])uncompress(dst);
+    result = cast(ubyte[]) uncompress(dst);
     //arrayPrint(result);
     assert(result == src);
 }
@@ -312,7 +312,7 @@ the quick brown fox jumps over the lazy dog\r
 /+
 void arrayPrint(ubyte[] array)
 {
-    //printf("array %p,%d\n", cast(void*)array, array.length);
+    //printf("array %p,%d\n", cast(void*) array, array.length);
     for (size_t i = 0; i < array.length; i++)
     {
         printf("%02x ", array[i]);
@@ -684,7 +684,7 @@ private import std.random;
     bool CompressThenUncompress (void[] src)
     {
         ubyte[] dst = std.zlib.compress(src);
-        double ratio = (dst.length / cast(double)src.length);
+        double ratio = (dst.length / cast(double) src.length);
         debug(zlib) writef("src.length: %1$d, dst: %2$d, Ratio = %3$f", src.length, dst.length, ratio);
         ubyte[] uncompressedBuf;
         uncompressedBuf = cast(ubyte[]) std.zlib.uncompress(dst);
@@ -749,8 +749,8 @@ private import std.random;
     buf ~= cmp.flush();
     const(void)[] output = decmp.uncompress(buf);
 
-    //writefln("input = '%s'", cast(char[])input);
-    //writefln("output = '%s'", cast(char[])output);
+    //writefln("input = '%s'", cast(char[]) input);
+    //writefln("output = '%s'", cast(char[]) output);
     assert( output[] == input[] );
 }
 

--- a/unittest.d
+++ b/unittest.d
@@ -61,9 +61,9 @@ int main(string[] args)
 {
     // Bring in unit test for module by referencing function in it
 
-    cast(void)cmp("foo", "bar");                  // string
-    cast(void)filenameCharCmp('a', 'b');          // path
-    cast(void)isNaN(1.0);                         // math
+    cast(void) cmp("foo", "bar");                  // string
+    cast(void) filenameCharCmp('a', 'b');          // path
+    cast(void) isNaN(1.0);                         // math
     std.conv.to!double("1.0");          // std.conv
     OutBuffer b = new OutBuffer();      // outbuffer
     auto r = regex("");                 // regex
@@ -75,7 +75,7 @@ int main(string[] args)
     reverse(a);                         // adi
     sort(a);                            // qsort
     Clock.currTime();                   // datetime
-    cast(void)isValidDchar(cast(dchar)0);          // utf
+    cast(void) isValidDchar(cast(dchar) 0);          // utf
     string s1 = "http://www.digitalmars.com/~fred/fredsRX.html#foo end!";
     assert(uriLength(s1) == 49);
     std.zlib.adler32(0,null);            // D.zlib
@@ -99,12 +99,12 @@ int main(string[] args)
     assert(x[1] == 3);
     assert(x[2] == 45);
 
-    cast(void)std.math.sin(3.0);
-    cast(void)std.mathspecial.gamma(6.2);
+    cast(void) std.math.sin(3.0);
+    cast(void) std.mathspecial.gamma(6.2);
 
     std.demangle.demangle("hello");
 
-    cast(void)std.uni.isAlpha('A');
+    cast(void) std.uni.isAlpha('A');
 
     std.file.exists("foo");
 


### PR DESCRIPTION
Adds a check and unification for a space after a `cast` expression:

```d
cast(int) foo
```

CC @andralex 

(there are some edge cases that this check doesn't find, but this can be fixed by a soon-to-arrive Dscanner plugin).