### PR TITLE
Posix.mak: cleanup EXTRA_MODULES_INTERNAL + add stdiobase to internal

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -212,16 +212,17 @@ EXTRA_MODULES_COMMON := $(addprefix etc/c/,curl odbc/sql odbc/sqlext \
 
 EXTRA_DOCUMENTABLES := $(EXTRA_MODULES_LINUX) $(EXTRA_MODULES_WIN32) $(EXTRA_MODULES_COMMON)
 
-EXTRA_MODULES_INTERNAL := $(addprefix			\
-	std/concurrencybase \
-	std/internal/digest/, sha_SSSE3 ) $(addprefix \
-	std/internal/math/, biguintcore biguintnoasm biguintx86	\
-	gammafunction errorfunction) $(addprefix std/internal/, \
-	cstring encodinginit processinit unicode_tables scopebuffer\
-	unicode_comp unicode_decomp unicode_grapheme unicode_norm) \
-	$(addprefix std/internal/test/, dummyrange) \
-	$(addprefix std/experimental/ndslice/, internal) \
-	$(addprefix std/algorithm/, internal)
+EXTRA_MODULES_INTERNAL := $(addprefix std/, \
+	algorithm/internal concurrencybase \
+	experimental/ndslice/internal \
+	$(addprefix internal/, \
+		cstring digest/sha_SSSE3 encodinginit \
+		$(addprefix math/, biguintcore biguintnoasm biguintx86	\
+						   errorfunction gammafunction ) \
+		processinit scopebuffer test/dummyrange \
+		$(addprefix unicode_, comp decomp grapheme norm tables) \
+	) \
+)
 
 EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(EXTRA_MODULES_INTERNAL)
 

--- a/posix.mak
+++ b/posix.mak
@@ -173,7 +173,7 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   conv csv datetime demangle encoding exception file format \
   functional getopt json math mathspecial meta mmfile numeric \
   outbuffer parallelism path process random signals socket stdint \
-  stdio stdiobase string system traits typecons typetuple uni \
+  stdio string system traits typecons typetuple uni \
   uri utf uuid variant xml zip zlib
 PACKAGE_std_experimental = typecons
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
@@ -222,6 +222,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 		processinit scopebuffer test/dummyrange \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
 	) \
+	stdiobase \
 )
 
 EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(EXTRA_MODULES_INTERNAL)


### PR DESCRIPTION
This list was pretty hard to read. Hence:

First commit:

- only use `add_prefix` if actually saves space (i.e. don't use `add_prefix` for single words)
- sort alphabetically
- indent properly
- add `add_prefix` where it improves readability (e.g. `unicode`

Second commit (after cleanup): add `stdiobase` to the list internal modules

A PR to dlang.org to exclude it from the menu will follow soon.