### PR TITLE
[Style] Enforce a .. b opSlice style 

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -570,7 +570,7 @@ int deflateInit2(z_streamp strm,
    this version of the library.
 
      The windowBits parameter is the base two logarithm of the window size
-   (the size of the history buffer).  It should be in the range 8..15 for this
+   (the size of the history buffer).  It should be in the range 8 .. 15 for this
    version of the library.  Larger values of this parameter result in better
    compression at the expense of memory usage.  The default value is 15 if
    deflateInit is used instead.
@@ -728,7 +728,7 @@ int deflateParams(z_streamp strm, int level, int strategy);
    strategy is changed, and if any input has been consumed in a previous
    deflate() call, then the input available so far is compressed with the old
    level and strategy using deflate(strm, Z_BLOCK).  There are three approaches
-   for the compression levels 0, 1..3, and 4..9 respectively.  The new level
+   for the compression levels 0, 1 .. 3, and 4 .. 9 respectively.  The new level
    and strategy will take effect at the next call of deflate().
 
      If a deflate(strm, Z_BLOCK) is performed by deflateParams(), and it does
@@ -842,7 +842,7 @@ int inflateInit2(z_streamp strm, int windowBits)
    before by the caller.
 
      The windowBits parameter is the base two logarithm of the maximum window
-   size (the size of the history buffer).  It should be in the range 8..15 for
+   size (the size of the history buffer).  It should be in the range 8 .. 15 for
    this version of the library.  The default value is 15 if inflateInit is used
    instead.  windowBits must be greater than or equal to the windowBits value
    provided to deflateInit2() while compressing, or it must be equal to 15 if
@@ -1073,7 +1073,7 @@ int inflateBackInit(z_stream* strm, int windowBits, ubyte* window)
    calls.  The fields zalloc, zfree and opaque in strm must be initialized
    before the call.  If zalloc and zfree are Z_NULL, then the default library-
    derived memory allocation routines are used.  windowBits is the base two
-   logarithm of the window size, in the range 8..15.  window is a caller
+   logarithm of the window size, in the range 8 .. 15.  window is a caller
    supplied buffer of that size.  Except for special applications where it is
    assured that deflate was used with small window sizes, windowBits must be 15
    and a 32K byte window must be supplied to be able to decompress general
@@ -1127,7 +1127,7 @@ int inflateBack(z_stream* strm,
    number of bytes of provided input, and a pointer to that input in buf.  If
    there is no input available, in() must return zero -- buf is ignored in that
    case -- and inflateBack() will return a buffer error.  inflateBack() will
-   call out(out_desc, buf, len) to write the uncompressed data buf[0..len-1].
+   call out(out_desc, buf, len) to write the uncompressed data buf[0 .. len-1].
    out() should return zero on success, or non-zero on failure.  If out()
    returns non-zero, inflateBack() will return with an error.  Neither in() nor
    out() are permitted to change the contents of the window provided to
@@ -1684,7 +1684,7 @@ void gzclearerr(gzFile file);
 
 uint adler32(uint adler, const(ubyte)* buf, uint len);
 /*
-     Update a running Adler-32 checksum with the bytes buf[0..len-1] and
+     Update a running Adler-32 checksum with the bytes buf[0 .. len-1] and
    return the updated checksum.  If buf is Z_NULL, this function returns the
    required initial value for the checksum.
 
@@ -1718,7 +1718,7 @@ uint adler32_combine(uint adler1, uint adler2, z_off_t len2);
 
 uint crc32(uint crc, const(ubyte)* buf, uint len);
 /*
-     Update a running CRC-32 with the bytes buf[0..len-1] and return the
+     Update a running CRC-32 with the bytes buf[0 .. len-1] and return the
    updated CRC-32.  If buf is Z_NULL, this function returns the required
    initial value for the crc.  Pre- and post-conditioning (one's complement) is
    performed within this function so it shouldn't be done by the application.

--- a/posix.mak
+++ b/posix.mak
@@ -519,6 +519,9 @@ style: ../dscanner/dsc
 	@echo "Enforce space after cast(...)"
 	grep -nrE '[^"]cast\([^)]*?\)[[:alnum:]]' $$(find . -name '*.d') ; test $$? -eq 1
 
+	@echo "Enforce space between a .. b"
+	grep -nrE '[[:alnum:]][.][.][[:alnum:]]|[[:alnum:]] [.][.][[:alnum:]]|[[:alnum:]][.][.] [[:alnum:]]' $$(find . -name '*.d' | grep -vE 'std/string.d|std/uni.d') ; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -271,7 +271,7 @@ auto castSwitch(choices...)(Object switchObject)
 
                 // Check for overshadowing:
                 immutable indexOfOvershadowingChoice =
-                    indexOfFirstOvershadowingChoiceOnLast!(choices[0..index + 1]);
+                    indexOfFirstOvershadowingChoiceOnLast!(choices[0 .. index + 1]);
                 static assert(indexOfOvershadowingChoice == index,
                         "choice number %d(type %s) is overshadowed by choice number %d(type %s)".format(
                             index + 1, CastClass.stringof, indexOfOvershadowingChoice + 1,
@@ -335,7 +335,7 @@ auto castSwitch(choices...)(Object switchObject)
             static if (Parameters!(choice).length == 0)
             {
                 immutable indexOfOvershadowingChoice =
-                    indexOfFirstOvershadowingChoiceOnLast!(choices[0..index + 1]);
+                    indexOfFirstOvershadowingChoiceOnLast!(choices[0 .. index + 1]);
 
                 // Check for overshadowing:
                 static assert(indexOfOvershadowingChoice == index,

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -730,7 +730,7 @@ private struct MapResult(alias fun, Range)
     assert(squares[3] == 16);
 
     // Test slicing.
-    auto squareSlice = squares[1..squares.length - 1];
+    auto squareSlice = squares[1 .. squares.length - 1];
     assert(equal(squareSlice, [4, 9][]));
     assert(squareSlice.back == 9);
     assert(squareSlice[1] == 9);
@@ -770,9 +770,9 @@ private struct MapResult(alias fun, Range)
     static assert(!is(ms1[0])); //narrow strings can't be indexed
     assert(ms2[0] == '日');
     assert(ms3[0] == 'H');
-    static assert(!is(ms1[0..1])); //narrow strings can't be sliced
-    assert(equal(ms2[0..2], "日本"w));
-    assert(equal(ms3[0..2], "HE"));
+    static assert(!is(ms1[0 .. 1])); //narrow strings can't be sliced
+    assert(equal(ms2[0 .. 2], "日本"w));
+    assert(equal(ms3[0 .. 2], "HE"));
 
     // Issue 5753
     static void voidFun(int) {}
@@ -2985,7 +2985,7 @@ The number of seeds must be correspondingly increased.
             int res;
             if (actEmpty) return res;
 
-            foreach (i; 0..100)
+            foreach (i; 0 .. 100)
             {
                 res = dg(i);
                 if (res) break;
@@ -3002,7 +3002,7 @@ The number of seeds must be correspondingly increased.
     assert(reduce!("a + b", max)(tuple(5, 0), oa) == tuple(hundredSum + 5, 99));
 
     // Test for throwing on empty range plus no seed.
-    assertThrown(reduce!"a + b"([1, 2][0..0]));
+    assertThrown(reduce!"a + b"([1, 2][0 .. 0]));
 
     oa.actEmpty = true;
     assertThrown(reduce!"a + b"(oa));

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -496,8 +496,8 @@ $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 
     {
         int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        copy(a[5..10], a[4..9]);
-        assert(a[4..9] == [6, 7, 8, 9, 10]);
+        copy(a[5 .. 10], a[4 .. 9]);
+        assert(a[4 .. 9] == [6, 7, 8, 9, 10]);
     }
 
     {   // Test for bug 7898
@@ -2024,23 +2024,23 @@ if (isBidirectionalRange!Range
     import std.typecons : Tuple;
     alias S = Tuple!(int[2]);
     S[] soffsets;
-    foreach (start; 0..5)
+    foreach (start; 0 .. 5)
     foreach (end; min(start+1,5) .. 5)
           soffsets ~= S([start,end]);
     alias D = Tuple!(int[2],int[2]);
     D[] doffsets;
-    foreach (start1; 0..10)
+    foreach (start1; 0 .. 10)
     foreach (end1; min(start1+1,10) .. 10)
-    foreach (start2; end1 ..10)
+    foreach (start2; end1 .. 10)
     foreach (end2; min(start2+1,10) .. 10)
           doffsets ~= D([start1,end1],[start2,end2]);
     alias T = Tuple!(int[2],int[2],int[2]);
     T[] toffsets;
-    foreach (start1; 0..15)
+    foreach (start1; 0 .. 15)
     foreach (end1; min(start1+1,15) .. 15)
-    foreach (start2; end1..15)
+    foreach (start2; end1 .. 15)
     foreach (end2; min(start2+1,15) .. 15)
-    foreach (start3; end2..15)
+    foreach (start3; end2 .. 15)
     foreach (end3; min(start3+1,15) .. 15)
             toffsets ~= T([start1,end1],[start2,end2],[start3,end3]);
 

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2007,7 +2007,7 @@ unittest
         size_t[] arr;
         arr.length = 1024;
 
-        foreach (k; 0..arr.length) arr[k] = k;
+        foreach (k; 0 .. arr.length) arr[k] = k;
         swapRanges(arr[0..$/2], arr[$/2..$]);
 
         sort!(pred, SwapStrategy.unstable)(arr);

--- a/std/array.d
+++ b/std/array.d
@@ -233,7 +233,7 @@ if (isNarrowString!String)
         int opApply(scope int delegate(ref int) dg)
         {
             int res;
-            foreach (i; 0..10)
+            foreach (i; 0 .. 10)
             {
                 res = dg(i);
                 if (res) break;
@@ -862,7 +862,7 @@ if (!isSomeString!(T[])
 
             // Takes arguments array, pos, stuff
             // Spread apart array[] at pos by moving elements
-            (() @trusted { copyBackwards(array[pos..oldLen], array[pos+to_insert..$]); })();
+            (() @trusted { copyBackwards(array[pos .. oldLen], array[pos+to_insert..$]); })();
 
             // Initialize array[pos .. pos+to_insert] with stuff[]
             auto j = 0;
@@ -977,7 +977,7 @@ if (isSomeString!(T[]) && allSatisfy!(isCharOrStringOrDcharRange, U))
     {
         // immutable/const, just construct a new array
         auto app = appender!(T[])();
-        app.put(array[0..pos]);
+        app.put(array[0 .. pos]);
         foreach (i, E; U)
             app.put(stuff[i]);
         app.put(array[pos..$]);
@@ -1211,7 +1211,7 @@ pure nothrow bool sameHead(T)(in T[] lhs, in T[] rhs)
 @safe pure nothrow unittest
 {
     auto a = [1, 2, 3, 4, 5];
-    auto b = a[0..2];
+    auto b = a[0 .. 2];
 
     assert(a.sameHead(b));
 }
@@ -1668,7 +1668,7 @@ if (isInputRange!RoR &&
             import std.utf : encode;
             RetTypeElement[4 / RetTypeElement.sizeof] encodeSpace;
             immutable size_t sepArrLength = encode(encodeSpace, sep);
-            return join(ror, encodeSpace[0..sepArrLength]);
+            return join(ror, encodeSpace[0 .. sepArrLength]);
         }
         else
         {
@@ -2631,7 +2631,7 @@ body
 @system unittest
 {
     auto a = [1, 2, 3, 4, 5];
-    auto b = replaceSlice(a, a[1..4], [0, 0, 0]);
+    auto b = replaceSlice(a, a[1 .. 4], [0, 0, 0]);
 
     assert(b == [1, 0, 0, 0, 5]);
 }

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -30,14 +30,14 @@ version (unittest)
 }
 
 
-immutable fullHexDigits  = "0123456789ABCDEFabcdef";     /// 0..9A..Fa..f
-immutable hexDigits      = fullHexDigits[0..16];         /// 0..9A..F
-immutable lowerHexDigits = "0123456789abcdef";           /// 0..9a..f
-immutable digits         = hexDigits[0..10];             /// 0..9
-immutable octalDigits    = digits[0..8];                 /// 0..7
-immutable letters        = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"; /// A..Za..z
-immutable uppercase      = letters[0..26];               /// A..Z
-immutable lowercase      = letters[26..52];              /// a..z
+immutable fullHexDigits  = "0123456789ABCDEFabcdef";     /// 0 .. 9A .. Fa .. f
+immutable hexDigits      = fullHexDigits[0 .. 16];         /// 0 .. 9A .. F
+immutable lowerHexDigits = "0123456789abcdef";           /// 0 .. 9a .. f
+immutable digits         = hexDigits[0 .. 10];             /// 0 .. 9
+immutable octalDigits    = digits[0 .. 8];                 /// 0 .. 7
+immutable letters        = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"; /// A .. Za .. z
+immutable uppercase      = letters[0 .. 26];               /// A .. Z
+immutable lowercase      = letters[26 .. 52];              /// a .. z
 immutable whitespace     = " \t\v\r\n\f";                /// ASCII _whitespace
 
 /++
@@ -60,7 +60,7 @@ else
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is a letter or a number (0..9, a..z, A..Z).
+    Returns: Whether $(D c) is a letter or a number (0 .. 9, a .. z, A .. Z).
   +/
 bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 {
@@ -90,7 +90,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is an ASCII letter (A..Z, a..z).
+    Returns: Whether $(D c) is an ASCII letter (A .. Z, a .. z).
   +/
 bool isAlpha(dchar c) @safe pure nothrow @nogc
 {
@@ -121,7 +121,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is a lowercase ASCII letter (a..z).
+    Returns: Whether $(D c) is a lowercase ASCII letter (a .. z).
   +/
 bool isLower(dchar c) @safe pure nothrow @nogc
 {
@@ -152,7 +152,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is an uppercase ASCII letter (A..Z).
+    Returns: Whether $(D c) is an uppercase ASCII letter (A .. Z).
   +/
 bool isUpper(dchar c) @safe pure nothrow @nogc
 {
@@ -183,7 +183,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is a digit (0..9).
+    Returns: Whether $(D c) is a digit (0 .. 9).
   +/
 bool isDigit(dchar c) @safe pure nothrow @nogc
 {
@@ -215,7 +215,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is a digit in base 8 (0..7).
+    Returns: Whether $(D c) is a digit in base 8 (0 .. 7).
   +/
 bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 {
@@ -244,7 +244,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 
 /++
     Params: c = The character to test.
-    Returns: Whether $(D c) is a digit in base 16 (0..9, A..F, a..f).
+    Returns: Whether $(D c) is a digit in base 16 (0 .. 9, A .. F, a .. f).
   +/
 bool isHexDigit(dchar c) @safe pure nothrow @nogc
 {
@@ -465,7 +465,7 @@ bool isPrintable(dchar c) @safe pure nothrow @nogc
 /++
     Params: c = The character to test.
     Returns: Whether or not $(D c) is in the ASCII character set - i.e. in the
-    range 0..0x7F.
+    range 0 .. 0x7F.
   +/
 pragma(inline, true)
 bool isASCII(dchar c) @safe pure nothrow @nogc

--- a/std/base64.d
+++ b/std/base64.d
@@ -222,7 +222,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         auto      bufptr = buffer.ptr;
         auto      srcptr = source.ptr;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable val = srcptr[0] << 16 | srcptr[1] << 8 | srcptr[2];
             *bufptr++ = EncodeMap[val >> 18       ];
@@ -256,7 +256,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         }
 
         // encode method can't assume buffer length. So, slice needed.
-        return buffer[0..bufptr - buffer.ptr];
+        return buffer[0 .. bufptr - buffer.ptr];
     }
 
     ///
@@ -304,7 +304,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable remain = srcLen % 3;
         auto      bufptr = buffer.ptr;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = source.front; source.popFront();
             immutable v2 = source.front; source.popFront();
@@ -353,7 +353,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
             );
 
         // encode method can't assume buffer length. So, slice needed.
-        return buffer[0..bufptr - buffer.ptr];
+        return buffer[0 .. bufptr - buffer.ptr];
     }
 
 
@@ -392,7 +392,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         auto      srcptr = source.ptr;
         size_t    pcount;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable val = srcptr[0] << 16 | srcptr[1] << 8 | srcptr[2];
             put(range, EncodeMap[val >> 18       ]);
@@ -480,7 +480,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable remain = srcLen % 3;
         size_t    pcount;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = source.front; source.popFront();
             immutable v2 = source.front; source.popFront();
@@ -668,7 +668,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
                 encoder.range_   = range_.save;
                 encoder.buffer_  = buffer_.dup;
-                encoder.encoded_ = encoder.buffer_[0..encoded_.length];
+                encoder.encoded_ = encoder.buffer_[0 .. encoded_.length];
 
                 return encoder;
             }
@@ -1001,7 +1001,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         auto      srcptr = source.ptr;
         auto      bufptr = buffer.ptr;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = decodeChar(*srcptr++);
             immutable v2 = decodeChar(*srcptr++);
@@ -1037,7 +1037,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
             }
         }
 
-        return buffer[0..bufptr - buffer.ptr];
+        return buffer[0 .. bufptr - buffer.ptr];
     }
 
     ///
@@ -1086,7 +1086,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable blocks = srcLen / 4;
         auto      bufptr = buffer.ptr;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = decodeChar(source.front); source.popFront();
             immutable v2 = decodeChar(source.front); source.popFront();
@@ -1134,7 +1134,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                 "The length of result is smaller than expected length"
             );
 
-        return buffer[0..bufptr - buffer.ptr];
+        return buffer[0 .. bufptr - buffer.ptr];
     }
 
 
@@ -1178,7 +1178,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         auto      srcptr = source.ptr;
         size_t    pcount;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = decodeChar(*srcptr++);
             immutable v2 = decodeChar(*srcptr++);
@@ -1266,7 +1266,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable blocks = srcLen / 4;
         size_t    pcount;
 
-        foreach (Unused; 0..blocks)
+        foreach (Unused; 0 .. blocks)
         {
             immutable v1 = decodeChar(source.front); source.popFront();
             immutable v2 = decodeChar(source.front); source.popFront();
@@ -1447,7 +1447,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 
                 decoder.range_   = range_.save;
                 decoder.buffer_  = buffer_.dup;
-                decoder.decoded_ = decoder.buffer_[0..decoded_.length];
+                decoder.decoded_ = decoder.buffer_[0 .. decoded_.length];
 
                 return decoder;
             }

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -914,7 +914,7 @@ public:
                 sink(" ");
 
         if (signChar)
-            sink((&signChar)[0..1]);
+            sink((&signChar)[0 .. 1]);
 
         if (!f.flDash && f.flZero)
             foreach (i; 0 .. difw)

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1099,7 +1099,7 @@ public:
         auto p1 = this._ptr;
         auto p2 = a2._ptr;
 
-        if (p1[0..fullWords] != p2[0..fullWords])
+        if (p1[0 .. fullWords] != p2[0 .. fullWords])
             return false;
 
         if (!endBits)
@@ -1363,7 +1363,7 @@ public:
         BitArray result;
         result.length = _len;
 
-        result._ptr[0..dim] = ~this._ptr[0..dim];
+        result._ptr[0 .. dim] = ~this._ptr[0 .. dim];
 
         // Avoid putting garbage in extra bits
         // Remove once we zero on length extension
@@ -1407,9 +1407,9 @@ public:
         result.length = _len;
 
         static if (op == "-")
-            result._ptr[0..dim] = this._ptr[0..dim] & ~e2._ptr[0..dim];
+            result._ptr[0 .. dim] = this._ptr[0 .. dim] & ~e2._ptr[0 .. dim];
         else
-            mixin("result._ptr[0..dim] = this._ptr[0..dim]"~op~" e2._ptr[0..dim];");
+            mixin("result._ptr[0 .. dim] = this._ptr[0 .. dim]"~op~" e2._ptr[0 .. dim];");
 
         // Avoid putting garbage in extra bits
         // Remove once we zero on length extension
@@ -3836,7 +3836,7 @@ if (isIntegral!T)
         }
     }
     assert(countBitsSet(1_000_000) == 7);
-    foreach (i; 0..63)
+    foreach (i; 0 .. 63)
         assert(countBitsSet(1UL << i) == 1);
 }
 
@@ -3947,6 +3947,6 @@ if (isIntegral!T)
         }
     }
     assert(bitsSet(1_000_000).equal([6, 9, 14, 16, 17, 18, 19]));
-    foreach (i; 0..63)
+    foreach (i; 0 .. 63)
         assert(bitsSet(1UL << i).equal([i]));
 }

--- a/std/complex.d
+++ b/std/complex.d
@@ -566,7 +566,7 @@ if (isFloatingPoint!T)
     assert(rer4.im == 0.0);
 
     // Check Complex-int operations.
-    foreach (i; 0..6)
+    foreach (i; 0 .. 6)
     {
         auto cei = c1^^i;
         assert(approxEqual(abs(cei), abs(c1)^^i, EPS));

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -61,11 +61,11 @@ unittest
     assert(arr.length == 6);
 
     // slicing
-    assert(arr[1..3].equal([2, 3]));
+    assert(arr[1 .. 3].equal([2, 3]));
 
     // remove
-    arr.linearRemove(arr[1..3]);
-    assert(arr[0..2].equal([1, 11]));
+    arr.linearRemove(arr[1 .. 3]);
+    assert(arr[0 .. 2].equal([1, 11]));
 }
 
 /// `Array!bool` packs together values efficiently by allocating one bit per element
@@ -1127,7 +1127,7 @@ unittest
 
     assert(equal(retro(b), a));
     assert(a.length == 7);
-    assert(equal(a[1..4], [1, 2, 3]));
+    assert(equal(a[1 .. 4], [1, 2, 3]));
 }
 // Test issue 5920
 unittest
@@ -1147,7 +1147,7 @@ unittest
     uint dMask;
 
     auto arr = Array!S(cast(S[])[]);
-    foreach (i; 0..8)
+    foreach (i; 0 .. 8)
         arr.insertBack(S(i, &dMask));
     // don't check dMask now as S may be copied multiple times (it's ok?)
     {

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -495,7 +495,7 @@ unittest // 16072
     // test more multiple grows
     int[] arr;
     auto r = heapify!"a < b"(arr);
-    foreach (i; 0..100)
+    foreach (i; 0 .. 100)
         r.insert(i);
 
     assert(r.front == 99);

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1225,7 +1225,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         auto x = ts.removeAny();
         assert(ts.length == 4);
         Elem[] arr;
-        foreach (Elem i; 1..6)
+        foreach (Elem i; 1 .. 6)
             if (i != x) arr ~= i;
         assert(ts.arrayEqual(arr));
     }

--- a/std/conv.d
+++ b/std/conv.d
@@ -2415,7 +2415,7 @@ body
 @safe pure unittest
 {
     string s; // parse doesn't accept rvalues
-    foreach (i; 2..37)
+    foreach (i; 2 .. 37)
     {
         assert(parse!int(s = "0", i) == 0);
         assert(parse!int(s = "1", i) == 1);
@@ -3518,7 +3518,7 @@ if (isSomeString!Source && !is(Source == enum) &&
 
     //Check proper failure
     auto s = "[ 1 , 2 , 3 ]";
-    foreach (i ; 0..s.length-1)
+    foreach (i ; 0 .. s.length-1)
     {
         auto ss = s[0 .. i];
         assertThrown!ConvException(parse!(int[])(ss));
@@ -6069,7 +6069,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         auto r = toChars!2(2u);
         assert(r.length == 2);
         assert(r[0] == '1');
-        assert(r[1..2].array == "0");
+        assert(r[1 .. 2].array == "0");
         auto s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
@@ -6083,7 +6083,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         auto r = toChars!8(8u);
         assert(r.length == 2);
         assert(r[0] == '1');
-        assert(r[1..2].array == "0");
+        assert(r[1 .. 2].array == "0");
         auto s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
@@ -6099,7 +6099,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         auto r = toChars(10u);
         assert(r.length == 2);
         assert(r[0] == '1');
-        assert(r[1..2].array == "0");
+        assert(r[1 .. 2].array == "0");
         auto s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
@@ -6119,7 +6119,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         auto r = toChars!10(10);
         assert(r.length == 2);
         assert(r[0] == '1');
-        assert(r[1..2].array == "0");
+        assert(r[1 .. 2].array == "0");
         auto s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");
@@ -6133,7 +6133,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         auto r = toChars!(16)(16u);
         assert(r.length == 2);
         assert(r[0] == '1');
-        assert(r[1..2].array == "0");
+        assert(r[1 .. 2].array == "0");
         auto s = r.save;
         assert(r.array == "10");
         assert(s.retro.array == "01");

--- a/std/csv.d
+++ b/std/csv.d
@@ -1277,7 +1277,7 @@ public:
      */
     private void prime(size_t skipNum)
     {
-        foreach (i; 0..skipNum)
+        foreach (i; 0 .. skipNum)
         {
             _input.col++;
             _front.shrinkTo(0);

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -12252,7 +12252,7 @@ public:
         if (day <= 0 || day > (isLeapYear ? daysInLeapYear : daysInYear) )
             throw new DateTimeException("Invalid day of the year.");
 
-        foreach (i; 1..lastDay.length)
+        foreach (i; 1 .. lastDay.length)
         {
             if (day <= lastDay[i])
             {
@@ -17801,7 +17801,7 @@ public:
 
         enforce(t != -1, new DateTimeException(format("Invalid ISO String: %s", isoString)));
 
-        immutable date = Date.fromISOString(dstr[0..t]);
+        immutable date = Date.fromISOString(dstr[0 .. t]);
         immutable tod = TimeOfDay.fromISOString(dstr[t+1 .. $]);
 
         return DateTime(date, tod);
@@ -17889,7 +17889,7 @@ public:
 
         enforce(t != -1, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
 
-        immutable date = Date.fromISOExtString(dstr[0..t]);
+        immutable date = Date.fromISOExtString(dstr[0 .. t]);
         immutable tod = TimeOfDay.fromISOExtString(dstr[t+1 .. $]);
 
         return DateTime(date, tod);
@@ -17975,7 +17975,7 @@ public:
 
         enforce(t != -1, new DateTimeException(format("Invalid string format: %s", simpleString)));
 
-        immutable date = Date.fromSimpleString(dstr[0..t]);
+        immutable date = Date.fromSimpleString(dstr[0 .. t]);
         immutable tod = TimeOfDay.fromISOExtString(dstr[t+1 .. $]);
 
         return DateTime(date, tod);
@@ -31935,10 +31935,10 @@ private:
     enum n = 100;
     TickDuration[n] times;
     TickDuration last = TickDuration.from!"seconds"(0);
-    foreach (i; 0..n)
+    foreach (i; 0 .. n)
     {
        sw.start(); //start/resume mesuring.
-       foreach (unused; 0..1_000_000)
+       foreach (unused; 0 .. 1_000_000)
            bar();
        sw.stop();  //stop/pause measuring.
        //Return value of peek() after having stopped are the always same.
@@ -32724,11 +32724,11 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
         throw new DateTimeException("Invalid DosFileTime.");
 
     int year = ((dt >> 25) & 0x7F) + 1980;
-    int month = ((dt >> 21) & 0x0F);       // 1..12
-    int dayOfMonth = ((dt >> 16) & 0x1F);  // 1..31
-    int hour = (dt >> 11) & 0x1F;          // 0..23
-    int minute = (dt >> 5) & 0x3F;         // 0..59
-    int second = (dt << 1) & 0x3E;         // 0..58 (in 2 second increments)
+    int month = ((dt >> 21) & 0x0F);       // 1 .. 12
+    int dayOfMonth = ((dt >> 16) & 0x1F);  // 1 .. 31
+    int hour = (dt >> 11) & 0x1F;          // 0 .. 23
+    int minute = (dt >> 5) & 0x3F;         // 0 .. 59
+    int second = (dt << 1) & 0x3E;         // 0 .. 58 (in 2 second increments)
 
     try
         return SysTime(DateTime(year, month, dayOfMonth, hour, minute, second), tz);

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -740,8 +740,8 @@ unittest
     void testUnalignedHash(H)()
     {
         immutable ubyte[1025] data = 0xAC;
-        immutable alignedHash = digest!H(data[0 .. $ - 1]); // 0..1023
-        immutable unalignedHash = digest!H(data[1 .. $]); // 1..1024
+        immutable alignedHash = digest!H(data[0 .. $ - 1]); // 0 .. 1023
+        immutable unalignedHash = digest!H(data[1 .. $]); // 1 .. 1024
         assert(alignedHash == unalignedHash);
     }
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -778,7 +778,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
 
                 /* Zeroize sensitive information. */
                 start();
-                return data[0..digestSize/8];
+                return data[0 .. digestSize/8];
             }
             else static if (blockSize==1024)
             {
@@ -787,8 +787,8 @@ struct SHA(uint hashBlockSize, uint digestSize)
 
                 /* Save number of bits */
                 ubyte[16] bits;
-                bits[ 0..8] = nativeToBigEndian(count[1]);
-                bits[8..16] = nativeToBigEndian(count[0]);
+                bits[ 0 .. 8] = nativeToBigEndian(count[1]);
+                bits[8 .. 16] = nativeToBigEndian(count[0]);
 
                 /* Pad out to 112 mod 128. */
                 index = (cast(uint) count[0] >> 3) & (128 - 1);
@@ -804,7 +804,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
 
                 /* Zeroize sensitive information. */
                 start();
-                return data[0..digestSize/8];
+                return data[0 .. digestSize/8];
             }
             else
                 static assert(0);

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1655,7 +1655,7 @@ immutable(E)[] sanitize(E)(immutable(E)[] s)
 
     // Now do the write
     E[] array = new E[len];
-    array[0..n] = s[0..n];
+    array[0 .. n] = s[0 .. n];
     size_t offset = n;
 
     t = s[n..$];
@@ -1663,14 +1663,14 @@ immutable(E)[] sanitize(E)(immutable(E)[] s)
     {
         immutable c = EncoderInstance!(E).safeDecode(t);
         assert(c == INVALID_SEQUENCE);
-        array[offset..offset+repSeq.length] = repSeq[];
+        array[offset .. offset+repSeq.length] = repSeq[];
         offset += repSeq.length;
         n = validLength(t);
-        array[offset..offset+n] = t[0..n];
+        array[offset .. offset+n] = t[0 .. n];
         offset += n;
         t = t[n..$];
     }
-    return cast(immutable(E)[])array[0..offset];
+    return cast(immutable(E)[])array[0 .. offset];
 }
 
 ///
@@ -2580,7 +2580,7 @@ abstract class EncodingScheme
 
         // Now do the write
         ubyte[] array = new ubyte[len];
-        array[0..n] = s[0..n];
+        array[0 .. n] = s[0 .. n];
         auto offset = n;
 
         t = s[n..$];
@@ -2588,14 +2588,14 @@ abstract class EncodingScheme
         {
             immutable c = safeDecode(t);
             assert(c == INVALID_SEQUENCE);
-            array[offset..offset+repSeq.length] = repSeq[];
+            array[offset .. offset+repSeq.length] = repSeq[];
             offset += repSeq.length;
             n = validLength(t);
-            array[offset..offset+n] = t[0..n];
+            array[offset .. offset+n] = t[0 .. n];
             offset += n;
             t = t[n..$];
         }
-        return cast(immutable(ubyte)[])array[0..offset];
+        return cast(immutable(ubyte)[])array[0 .. offset];
     }
 
     /**

--- a/std/exception.d
+++ b/std/exception.d
@@ -1257,8 +1257,8 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     //But they do point their elements
     foreach (i; 0 .. 4)
         assert(doesPointTo(darr, darr[i]));
-    assert(doesPointTo(darr[0..3], darr[2]));
-    assert(!doesPointTo(darr[0..3], darr[3]));
+    assert(doesPointTo(darr[0 .. 3], darr[2]));
+    assert(!doesPointTo(darr[0 .. 3], darr[3]));
 }
 
 @system unittest
@@ -1476,7 +1476,7 @@ class ErrnoException : Exception
             import core.stdc.string : strerror;
             auto s = strerror(errno);
         }
-        super(msg ~ " (" ~ s[0..s.strlen].idup ~ ")", file, line);
+        super(msg ~ " (" ~ s[0 .. s.strlen].idup ~ ")", file, line);
     }
 
     unittest

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -867,7 +867,7 @@ unittest
         bufs ~= a.allocate(sizes[1] - word);
 
         a.deallocate(bufs[0]);
-        foreach (i; 2..bufs.length)
+        foreach (i; 2 .. bufs.length)
         {
             a.deallocate(bufs[i]);
         }

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -62,7 +62,7 @@ $(TR $(TDC void[] allocateAll();) $(TD Offers all of allocator's memory to the
 caller, so it's usually defined by fixed-size allocators. If the allocator is
 currently NOT managing any memory, then $(D allocateAll()) shall allocate and
 return all memory available to the allocator, and subsequent calls to all
-allocation primitives should not succeed (e .. g $(D allocate) shall return $(D
+allocation primitives should not succeed (e.g. $(D allocate) shall return $(D
 null) etc). Otherwise, $(D allocateAll) only works on a best-effort basis, and
 the allocator is allowed to return $(D null) even if does have available memory.
 Memory allocated with $(D allocateAll) is not otherwise special (e.g. can be

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -62,7 +62,7 @@ $(TR $(TDC void[] allocateAll();) $(TD Offers all of allocator's memory to the
 caller, so it's usually defined by fixed-size allocators. If the allocator is
 currently NOT managing any memory, then $(D allocateAll()) shall allocate and
 return all memory available to the allocator, and subsequent calls to all
-allocation primitives should not succeed (e..g $(D allocate) shall return $(D
+allocation primitives should not succeed (e .. g $(D allocate) shall return $(D
 null) etc). Otherwise, $(D allocateAll) only works on a best-effort basis, and
 the allocator is allowed to return $(D null) even if does have available memory.
 Memory allocated with $(D allocateAll) is not otherwise special (e.g. can be

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -3044,7 +3044,7 @@ unittest
     sharedLog = new IgnoredLog;
     Thread[] spawned;
 
-    foreach (i; 0..4)
+    foreach (i; 0 .. 4)
     {
         spawned ~= new Thread({
             stdThreadLocalLog = new TestLog;

--- a/std/experimental/ndslice/internal.d
+++ b/std/experimental/ndslice/internal.d
@@ -447,7 +447,7 @@ bool isPermutation(size_t N)(auto ref in size_t[N] perm)
 unittest
 {
     assert(isPermutation([0, 1]));
-    // all numbers 0..N-1 need to be part of the permutation
+    // all numbers 0 .. N-1 need to be part of the permutation
     assert(!isPermutation([1, 2]));
     assert(!isPermutation([0, 2]));
     // duplicates are not allowed

--- a/std/experimental/ndslice/selection.d
+++ b/std/experimental/ndslice/selection.d
@@ -2256,8 +2256,8 @@ pure nothrow unittest
     auto sums     = [[0, 2, 4], [6,  8, 10]];
     auto products = [[0, 1, 4], [9, 16, 25]];
 
-    foreach (i; 0..s.length!0)
-    foreach (j; 0..s.length!1)
+    foreach (i; 0 .. s.length!0)
+    foreach (j; 0 .. s.length!1)
     {
         auto values = s[i, j];
         assert(values[0] == sums[i][j]);

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -338,17 +338,17 @@ pure nothrow unittest
     auto data = new int[24];
     foreach (int i,ref e; data)
         e = i;
-    auto a = data[0..10].sliced(10)[0..6].sliced(2, 3);
-    auto b = iotaSlice(10)[0..6].sliced(2, 3);
+    auto a = data[0 .. 10].sliced(10)[0 .. 6].sliced(2, 3);
+    auto b = iotaSlice(10)[0 .. 6].sliced(2, 3);
     assert(a == b);
     a[] += b;
-    foreach (int i, e; data[0..6])
+    foreach (int i, e; data[0 .. 6])
         assert(e == 2*i);
     foreach (int i, e; data[6..$])
         assert(e == i+6);
-    auto c  = data.sliced(12, 2)[0..6].sliced(2, 3);
-    auto d  = iotaSlice(12, 2)[0..6].sliced(2, 3);
-    auto cc = data[0..12].sliced(2, 3, 2);
+    auto c  = data.sliced(12, 2)[0 .. 6].sliced(2, 3);
+    auto d  = iotaSlice(12, 2)[0 .. 6].sliced(2, 3);
+    auto cc = data[0 .. 12].sliced(2, 3, 2);
     auto dc = iotaSlice(2, 3, 2);
     assert(c._lengths == cc._lengths);
     assert(c._strides == cc._strides);
@@ -356,9 +356,9 @@ pure nothrow unittest
     assert(d._strides == dc._strides);
     assert(cc == c);
     assert(dc == d);
-    auto e = data.sliced(8, 3)[0..5].sliced(5);
-    auto f = iotaSlice(8, 3)[0..5].sliced(5);
-    assert(e == data[0..15].sliced(5, 3));
+    auto e = data.sliced(8, 3)[0 .. 5].sliced(5);
+    auto f = iotaSlice(8, 3)[0 .. 5].sliced(5);
+    assert(e == data[0 .. 15].sliced(5, 3));
     assert(f == iotaSlice(5, 3));
 }
 
@@ -1098,19 +1098,19 @@ in comments on operator overloading.
 $(BOOKTABLE
 $(TR $(TH Definition) $(TH Examples at `N == 3`))
 $(TR $(TD An $(B interval) is a part of a sequence of type `i .. j`.)
-    $(STD `2..$-3`, `0..4`))
+    $(STD `2..$-3`, `0 .. 4`))
 $(TR $(TD An $(B index) is a part of a sequence of type `i`.)
     $(STD `3`, `$-1`))
 $(TR $(TD A $(B partially defined slice) is a sequence composed of
     $(B intervals) and $(B indexes) with an overall length strictly less than `N`.)
-    $(STD `[3]`, `[0..$]`, `[3, 3]`, `[0..$,0..3]`, `[0..$,2]`))
+    $(STD `[3]`, `[0..$]`, `[3, 3]`, `[0..$,0 .. 3]`, `[0..$,2]`))
 $(TR $(TD A $(B fully defined index) is a sequence
     composed only of $(B indexes) with an overall length equal to `N`.)
     $(STD `[2,3,1]`))
 $(TR $(TD A $(B fully defined slice) is an empty sequence
     or a sequence composed of $(B indexes) and at least one
     $(B interval) with an overall length equal to `N`.)
-    $(STD `[]`, `[3..$,0..3,0..$-1]`, `[2,0..$,1]`))
+    $(STD `[]`, `[3..$,0 .. 3,0..$-1]`, `[2,0..$,1]`))
 )
 
 $(H3 Internal Binary Representation)
@@ -3070,7 +3070,7 @@ pure nothrow unittest
     auto matrix = slice!int(3, 4);
     auto vector = slice!int(3);
 
-    foreach (i; 0..3)
+    foreach (i; 0 .. 3)
         vector[i] = i;
 
     // fills matrix columns

--- a/std/file.d
+++ b/std/file.d
@@ -1421,7 +1421,7 @@ version (OSX) {} else
         remove(deleteme);
 
     SysTime lastTime;
-    foreach (n; 0..3)
+    foreach (n; 0 .. 3)
     {
         write(deleteme, "a");
         auto time = timeLastModified(deleteme);

--- a/std/format.d
+++ b/std/format.d
@@ -4057,11 +4057,11 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
 
     s = "helloworld";
     string r;
-    stream.clear(); formattedWrite(stream, "%.2s", s[0..5]);
+    stream.clear(); formattedWrite(stream, "%.2s", s[0 .. 5]);
     assert(stream.data == "he");
-    stream.clear(); formattedWrite(stream, "%.20s", s[0..5]);
+    stream.clear(); formattedWrite(stream, "%.20s", s[0 .. 5]);
     assert(stream.data == "hello");
-    stream.clear(); formattedWrite(stream, "%8s", s[0..5]);
+    stream.clear(); formattedWrite(stream, "%8s", s[0 .. 5]);
     assert(stream.data == "   hello");
 
     byte[] arrbyte = new byte[4];
@@ -5185,11 +5185,11 @@ private bool needToSwapEndianess(Char)(ref FormatSpec!Char f)
 
     s = "helloworld";
     string r;
-    r = format("%.2s", s[0..5]);
+    r = format("%.2s", s[0 .. 5]);
     assert(r == "he");
-    r = format("%.20s", s[0..5]);
+    r = format("%.20s", s[0 .. 5]);
     assert(r == "hello");
-    r = format("%8s", s[0..5]);
+    r = format("%8s", s[0 .. 5]);
     assert(r == "   hello");
 
     byte[] arrbyte = new byte[4];

--- a/std/functional.d
+++ b/std/functional.d
@@ -254,7 +254,7 @@ template binaryFun(alias fun, string parm1Name = "a",
     static assert(!is(typeof(binaryFun!FuncObj)));
 }
 
-// skip all ASCII chars except a..z, A..Z, 0..9, '_' and '.'.
+// skip all ASCII chars except a .. z, A .. Z, 0 .. 9, '_' and '.'.
 private uint _ctfeSkipOp(ref string op)
 {
     if (!__ctfe) assert(false);
@@ -292,7 +292,7 @@ private uint _ctfeSkipInteger(ref string op)
 private uint _ctfeSkipName(ref string op, string name)
 {
     if (!__ctfe) assert(false);
-    if (op.length >= name.length && op[0..name.length] == name)
+    if (op.length >= name.length && op[0 .. name.length] == name)
     {
         op = op[name.length..$];
         return 1;
@@ -1413,7 +1413,7 @@ template forward(args...)
 ///
 @safe unittest
 {
-    void foo(int n, ref string s) { s = null; foreach (i; 0..n) s ~= "Hello"; }
+    void foo(int n, ref string s) { s = null; foreach (i; 0 .. n) s ~= "Hello"; }
 
     // forwards all arguments which are bound to parameter tuple
     void bar(Args...)(auto ref Args args) { return foo(forward!args); }

--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -173,13 +173,13 @@ version(USE_SSSE3)
         return (i/4)&7;
     }
 
-    /** Returns reference to storage of vector W[i..i+4]. */
+    /** Returns reference to storage of vector W[i .. i+4]. */
     private nothrow pure string WiV(uint i)
     {
         return "["~SP~" + WI_PTR + "~to_string((i/4)&7)~"*16]";
     }
 
-    /** Returns reference to storage of vector (W + K)[i..i+4]. */
+    /** Returns reference to storage of vector (W + K)[i .. i+4]. */
     private nothrow pure string WiKiV(uint i)
     {
         return "["~SP~" + WI_PLUS_KI_PTR + "~to_string((i/4)&3)~"*16]";
@@ -230,7 +230,7 @@ version(USE_SSSE3)
         {
             if (i2 < seq2.length)
             {
-                res ~= seq2[i2..i2+1];
+                res ~= seq2[i2 .. i2+1];
                 i2 += 1;
             }
             if (i1 < seq1.length)

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -488,16 +488,16 @@ public:
         assert((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
         uint words = cast(uint)(y >> LG2BIGDIGITBITS);
         BigDigit [] result = new BigDigit[data.length + words+1];
-        result[0..words] = 0;
+        result[0 .. words] = 0;
         if (bits==0)
         {
-            result[words..words+data.length] = data[];
-            return BigUint(trustedAssumeUnique(result[0..words+data.length]));
+            result[words .. words+data.length] = data[];
+            return BigUint(trustedAssumeUnique(result[0 .. words+data.length]));
         }
         else
         {
-            immutable c = multibyteShl(result[words..words+data.length], data, bits);
-            if (c==0) return BigUint(trustedAssumeUnique(result[0..words+data.length]));
+            immutable c = multibyteShl(result[words .. words+data.length], data, bits);
+            if (c==0) return BigUint(trustedAssumeUnique(result[0 .. words+data.length]));
             result[$-1] = c;
             return BigUint(trustedAssumeUnique(result));
         }
@@ -585,10 +585,10 @@ public:
         uint hi = cast(uint)(y >>> 32);
         uint lo = cast(uint)(y & 0xFFFF_FFFF);
         uint [] result = new BigDigit[x.data.length+1+(hi!=0)];
-        result[x.data.length] = multibyteMul(result[0..x.data.length], x.data, lo, 0);
+        result[x.data.length] = multibyteMul(result[0 .. x.data.length], x.data, lo, 0);
         if (hi!=0)
         {
-            result[x.data.length+1] = multibyteMulAdd!('+')(result[1..x.data.length+1],
+            result[x.data.length+1] = multibyteMulAdd!('+')(result[1 .. x.data.length+1],
                 x.data, hi, 0);
         }
         return BigUint(removeLeadingZeros(trustedAssumeUnique(result)));
@@ -712,7 +712,7 @@ public:
         auto d1 = includeSign(x.data, y.uintLength, xSign);
         auto d2 = includeSign(y.data, x.uintLength, ySign);
 
-        foreach (i; 0..d1.length)
+        foreach (i; 0 .. d1.length)
         {
             mixin("d1[i] " ~ op ~ "= d2[i];");
         }
@@ -842,13 +842,13 @@ public:
         size_t result_start = cast(size_t)( firstnonzero * y
             + (singledigit ? ((evenbits * y) >> LG2BIGDIGITBITS) : 0));
 
-        resultBuffer[0..result_start] = 0;
+        resultBuffer[0 .. result_start] = 0;
         BigDigit [] t1 = resultBuffer[result_start..$];
         BigDigit [] r1;
 
         if (singledigit)
         {
-            r1 = t1[0..1];
+            r1 = t1[0 .. 1];
             r1[0] = x0;
             y = y0;
         }
@@ -856,7 +856,7 @@ public:
         {
             // It's not worth right shifting by evenbits unless we also shrink the length after each
             // multiply or squaring operation. That might still be worthwhile for large y.
-            r1 = t1[0..x.data.length - firstnonzero];
+            r1 = t1[0 .. x.data.length - firstnonzero];
             r1[0..$] = x.data[firstnonzero..$];
         }
 
@@ -1063,13 +1063,13 @@ private:
 void twosComplement(const(BigDigit) [] x, BigDigit[] result)
 pure nothrow @safe
 {
-    foreach (i; 0..x.length)
+    foreach (i; 0 .. x.length)
     {
         result[i] = ~x[i];
     }
     result[x.length..$] = BigDigit.max;
 
-    foreach (i; 0..result.length)
+    foreach (i; 0 .. result.length)
     {
         if (result[i] == BigDigit.max)
         {
@@ -1095,7 +1095,7 @@ pure nothrow @safe
     }
     else
     {
-        result[0..x.length] = x;
+        result[0 .. x.length] = x;
     }
     return result;
 }
@@ -1210,12 +1210,12 @@ pure nothrow
         BigDigit [] result = new BigDigit[last+1];
         if (x[last] < y[last])
         {   // we know result is negative
-            multibyteSub(result[0..last+1], y[0..last+1], x[0..last+1], 0);
+            multibyteSub(result[0 .. last+1], y[0 .. last+1], x[0 .. last+1], 0);
             *negative = true;
         }
         else
         {   // positive or zero result
-            multibyteSub(result[0..last+1], x[0..last+1], y[0..last+1], 0);
+            multibyteSub(result[0 .. last+1], x[0 .. last+1], y[0 .. last+1], 0);
             *negative = false;
         }
         while (result.length > 1 && result[$-1] == 0)
@@ -1241,7 +1241,7 @@ pure nothrow
 
 
     BigDigit [] result = new BigDigit[large.length];
-    BigDigit carry = multibyteSub(result[0..small.length], large[0..small.length], small, 0);
+    BigDigit carry = multibyteSub(result[0 .. small.length], large[0 .. small.length], small, 0);
     result[small.length..$] = large[small.length..$];
     if (carry)
     {
@@ -1271,7 +1271,7 @@ BigDigit [] add(const BigDigit [] a, const BigDigit [] b) pure nothrow
     // create result. add 1 in case it overflows
     BigDigit [] result = new BigDigit[x.length + 1];
 
-    BigDigit carry = multibyteAdd(result[0..y.length], x[0..y.length], y, 0);
+    BigDigit carry = multibyteAdd(result[0 .. y.length], x[0 .. y.length], y, 0);
     if (x.length != y.length)
     {
         result[y.length..$-1]= x[y.length..$];
@@ -1295,7 +1295,7 @@ BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow
     auto len = x.length;
     if (x.length < 2 && hi!=0) ++len;
     BigDigit [] result = new BigDigit[len+1];
-    result[0..x.length] = x[];
+    result[0 .. x.length] = x[];
     if (x.length < 2 && hi!=0)
     {
         result[1]=hi;
@@ -1351,7 +1351,7 @@ void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
         // Small multiplier, we'll just use the asm classic multiply.
         if (y.length == 1)
         {   // Trivial case, no cache effects to worry about
-            result[x.length] = multibyteMul(result[0..x.length], x, y[0], 0);
+            result[x.length] = multibyteMul(result[0 .. x.length], x, y[0], 0);
             return;
         }
 
@@ -1370,7 +1370,7 @@ void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
         }
 
         // Use schoolbook multiply.
-        mulSimple(result[0 .. chunksize + y.length], x[0..chunksize], y);
+        mulSimple(result[0 .. chunksize + y.length], x[0 .. chunksize], y);
         auto done = chunksize;
 
         while (done < x.length)
@@ -1378,9 +1378,9 @@ void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
             // result[done .. done+ylength] already has a value.
             chunksize = (done + (CACHELIMIT / y.length) < x.length) ? (CACHELIMIT / y.length) :  x.length - done;
             BigDigit [KARATSUBALIMIT] partial;
-            partial[0..y.length] = result[done..done+y.length];
-            mulSimple(result[done..done+chunksize+y.length], x[done..done+chunksize], y);
-            addAssignSimple(result[done..done+chunksize + y.length], partial[0..y.length]);
+            partial[0 .. y.length] = result[done .. done+y.length];
+            mulSimple(result[done .. done+chunksize+y.length], x[done .. done+chunksize], y);
+            addAssignSimple(result[done .. done+chunksize + y.length], partial[0 .. y.length]);
             done += chunksize;
         }
         return;
@@ -1439,7 +1439,7 @@ void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
         }
         else
         {   // We're padding X. Begin with the extra bit.
-            mulKaratsuba(result[0 .. y.length + extra], y, x[0..extra], scratchbuff);
+            mulKaratsuba(result[0 .. y.length + extra], y, x[0 .. extra], scratchbuff);
             done = extra;
             extra = 0;
         }
@@ -1480,7 +1480,7 @@ void squareInternal(BigDigit[] result, const BigDigit[] x) pure nothrow
   {
       if (x.length==1)
       {
-         result[1] = multibyteMul(result[0..1], x, x[0], 0);
+         result[1] = multibyteMul(result[0 .. 1], x, x[0], 0);
          return;
       }
       return squareSimple(result, x);
@@ -1535,8 +1535,8 @@ void divModInternal(BigDigit [] quotient, BigDigit[] remainder, const BigDigit [
     // Unnormalize remainder, if required.
     if (remainder != null)
     {
-        if (s == 0) remainder[] = un[0..vn.length];
-        else multibyteShr(remainder, un[0..vn.length+1], s);
+        if (s == 0) remainder[] = un[0 .. vn.length];
+        else multibyteShr(remainder, un[0 .. vn.length+1], s);
     }
     () @trusted { GC.free(un.ptr); GC.free(vn.ptr); } ();
 }
@@ -1569,7 +1569,7 @@ char [] biguintToHex(char [] buff, const BigDigit [] data, char separator=0,
     int x=0;
     for (ptrdiff_t i=data.length - 1; i>=0; --i)
     {
-        toHexZeroPadded(buff[x..x+8], data[i], letterCase);
+        toHexZeroPadded(buff[x .. x+8], data[i], letterCase);
         x+=8;
         if (separator)
         {
@@ -1685,7 +1685,7 @@ size_t biguintToDecimal(char [] buff, BigDigit [] data) pure nothrow
  * Params:
  *  data    The biguint to be receive the result. Must be large enough to
  *          store the result.
- *  s       The decimal string. May contain _ or 0..9
+ *  s       The decimal string. May contain _ or 0 .. 9
  *
  * The required length for the destination buffer is slightly less than
  *  1 + s.length/log2(10) = 1 + s.length/3.3219.
@@ -1716,7 +1716,7 @@ body
     // TODO: This is inefficient for very large strings (it is O(n^^2)).
     // We should take advantage of fast multiplication once the numbers exceed
     // Karatsuba size.
-    uint lo = 0; // number of powers of digits, 0..18
+    uint lo = 0; // number of powers of digits, 0 .. 18
     uint x = 0;
     ulong y = 0;
     uint hi = 0; // number of base 1e19 digits
@@ -1753,15 +1753,15 @@ body
             // Multiply existing number by 10^19, then add y1.
             if (hi>0)
             {
-                data[hi] = multibyteMul(data[0..hi], data[0..hi], 1220703125*2u, 0); // 5^13*2 = 0x9184_E72A
+                data[hi] = multibyteMul(data[0 .. hi], data[0 .. hi], 1220703125*2u, 0); // 5^13*2 = 0x9184_E72A
                 ++hi;
-                data[hi] = multibyteMul(data[0..hi], data[0..hi], 15625*262144u, 0); // 5^6*2^18 = 0xF424_0000
+                data[hi] = multibyteMul(data[0 .. hi], data[0 .. hi], 15625*262144u, 0); // 5^6*2^18 = 0xF424_0000
                 ++hi;
             }
             else
                 hi = 2;
-            uint c = multibyteIncrementAssign!('+')(data[0..hi], cast(uint)(y&0xFFFF_FFFF));
-            c += multibyteIncrementAssign!('+')(data[1..hi], cast(uint)(y>>32));
+            uint c = multibyteIncrementAssign!('+')(data[0 .. hi], cast(uint)(y&0xFFFF_FFFF));
+            c += multibyteIncrementAssign!('+')(data[1 .. hi], cast(uint)(y>>32));
             if (c!=0)
             {
                 data[hi]=c;
@@ -1804,7 +1804,7 @@ body
         {
             while (lo>0)
             {
-                immutable c = multibyteMul(data[0..hi], data[0..hi], 10, 0);
+                immutable c = multibyteMul(data[0 .. hi], data[0 .. hi], 10, 0);
                 if (c!=0)
                 {
                     data[hi]=c;
@@ -1812,10 +1812,10 @@ body
                 }
                 --lo;
             }
-            uint c = multibyteIncrementAssign!('+')(data[0..hi], cast(uint)(y&0xFFFF_FFFF));
+            uint c = multibyteIncrementAssign!('+')(data[0 .. hi], cast(uint)(y&0xFFFF_FFFF));
             if (y > 0xFFFF_FFFFL)
             {
-                c += multibyteIncrementAssign!('+')(data[1..hi], cast(uint)(y>>32));
+                c += multibyteIncrementAssign!('+')(data[1 .. hi], cast(uint)(y>>32));
             }
             if (c!=0)
             {
@@ -1845,7 +1845,7 @@ in
 }
 body
 {
-    result[left.length] = multibyteMul(result[0..left.length], left, right[0], 0);
+    result[left.length] = multibyteMul(result[0 .. left.length], left, right[0], 0);
     multibyteMultiplyAccumulate(result[1..$], left, right[1..$]);
 }
 
@@ -1875,11 +1875,11 @@ in
 }
 body
 {
-    uint carry = multibyteAdd(result[0..right.length],
-            left[0..right.length], right, 0);
+    uint carry = multibyteAdd(result[0 .. right.length],
+            left[0 .. right.length], right, 0);
     if (right.length < left.length)
     {
-        result[right.length..left.length] = left[right.length .. $];
+        result[right.length .. left.length] = left[right.length .. $];
         carry = multibyteIncrementAssign!('+')(result[right.length..$], carry);
     }
     return carry;
@@ -1897,11 +1897,11 @@ in
 }
 body
 {
-    BigDigit carry = multibyteSub(result[0..right.length],
-            left[0..right.length], right, 0);
+    BigDigit carry = multibyteSub(result[0 .. right.length],
+            left[0 .. right.length], right, 0);
     if (right.length < left.length)
     {
-        result[right.length..left.length] = left[right.length .. $];
+        result[right.length .. left.length] = left[right.length .. $];
         carry = multibyteIncrementAssign!('-')(result[right.length..$], carry);
     } //else if (result.length==left.length+1) { result[$-1] = carry; carry=0; }
     return carry;
@@ -1915,7 +1915,7 @@ BigDigit subAssignSimple(BigDigit [] result, const(BigDigit) [] right)
 pure nothrow
 {
     assert(result.length >= right.length);
-    uint c = multibyteSub(result[0..right.length], result[0..right.length], right, 0);
+    uint c = multibyteSub(result[0 .. right.length], result[0 .. right.length], right, 0);
     if (c && result.length > right.length)
         c = multibyteIncrementAssign!('-')(result[right.length .. $], c);
     return c;
@@ -1927,7 +1927,7 @@ BigDigit addAssignSimple(BigDigit [] result, const(BigDigit) [] right)
 pure nothrow
 {
     assert(result.length >= right.length);
-    uint c = multibyteAdd(result[0..right.length], result[0..right.length], right, 0);
+    uint c = multibyteAdd(result[0 .. right.length], result[0 .. right.length], right, 0);
     if (c && result.length > right.length)
        c = multibyteIncrementAssign!('+')(result[right.length .. $], c);
     return c;
@@ -1987,10 +1987,10 @@ bool inplaceSub(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
         large = x; small = y;
     }
 
-    BigDigit carry = multibyteSub(result[0..minlen], large[0..minlen], small[0..minlen], 0);
+    BigDigit carry = multibyteSub(result[0 .. minlen], large[0 .. minlen], small[0 .. minlen], 0);
     if (x.length != y.length)
     {
-        result[minlen..large.length]= large[minlen..$];
+        result[minlen .. large.length]= large[minlen..$];
         result[large.length..$] = 0;
         if (carry)
             multibyteIncrementAssign!('-')(result[minlen..$], carry);
@@ -2076,15 +2076,15 @@ void mulKaratsuba(BigDigit [] result, const(BigDigit) [] x,
             // divide x1 in two, then use schoolbook multiply on the two pieces.
             auto quarter = (x1.length >> 1) + (x1.length & 1);
             immutable ysmaller = (quarter >= y1.length);
-            mulKaratsuba(resultHigh[0..quarter+y1.length], ysmaller ? x1[0..quarter] : y1,
-                ysmaller ? y1 : x1[0..quarter], newscratchbuff);
+            mulKaratsuba(resultHigh[0 .. quarter+y1.length], ysmaller ? x1[0 .. quarter] : y1,
+                ysmaller ? y1 : x1[0 .. quarter], newscratchbuff);
             // Save the part which will be overwritten.
             immutable ysmaller2 = ((x1.length - quarter) >= y1.length);
-            newscratchbuff[0..y1.length] = resultHigh[quarter..quarter + y1.length];
+            newscratchbuff[0 .. y1.length] = resultHigh[quarter .. quarter + y1.length];
             mulKaratsuba(resultHigh[quarter..$], ysmaller2 ? x1[quarter..$] : y1,
                 ysmaller2 ? y1 : x1[quarter..$], newscratchbuff[y1.length..$]);
 
-            resultHigh[quarter..$].addAssignSimple(newscratchbuff[0..y1.length]);
+            resultHigh[quarter..$].addAssignSimple(newscratchbuff[0 .. y1.length]);
         }
     }
     else
@@ -2104,14 +2104,14 @@ void mulKaratsuba(BigDigit [] result, const(BigDigit) [] x,
         R3 = bHi + carry_from_R2
 
      It might actually be quicker to do it in two full-length additions:
-     newscratchbuff[2*half] = addSimple(newscratchbuff[0..2*half], result[0..2*half], result[2*half..$]);
-     addAssignSimple(result[half..$], newscratchbuff[0..2*half+1]);
+     newscratchbuff[2*half] = addSimple(newscratchbuff[0 .. 2*half], result[0 .. 2*half], result[2*half..$]);
+     addAssignSimple(result[half..$], newscratchbuff[0 .. 2*half+1]);
    */
-    BigDigit[] R1 = result[half..half*2];
-    BigDigit[] R2 = result[half*2..half*3];
+    BigDigit[] R1 = result[half .. half*2];
+    BigDigit[] R2 = result[half*2 .. half*3];
     BigDigit[] R3 = result[half*3..$];
     BigDigit c1 = multibyteAdd(R2, R2, R1, 0); // c1:R2 = R2 + R1
-    BigDigit c2 = multibyteAdd(R1, R2, result[0..half], 0); // c2:R1 = R2 + R1 + R0
+    BigDigit c2 = multibyteAdd(R1, R2, result[0 .. half], 0); // c2:R1 = R2 + R1 + R0
     BigDigit c3 = addAssignSimple(R2, R3); // R2 = R2 + R1 + R3
     if (c1+c2)
         multibyteIncrementAssign!('+')(result[half*2..$], c1+c2);
@@ -2158,11 +2158,11 @@ void squareKaratsuba(BigDigit [] result, const BigDigit [] x,
         R2 = aHI + bLO + aHI + carry_from_R1
         R3 = bHi + carry_from_R2
     */
-    BigDigit[] R1 = result[half..half*2];
-    BigDigit[] R2 = result[half*2..half*3];
+    BigDigit[] R1 = result[half .. half*2];
+    BigDigit[] R2 = result[half*2 .. half*3];
     BigDigit[] R3 = result[half*3..$];
     BigDigit c1 = multibyteAdd(R2, R2, R1, 0); // c1:R2 = R2 + R1
-    BigDigit c2 = multibyteAdd(R1, R2, result[0..half], 0); // c2:R1 = R2 + R1 + R0
+    BigDigit c2 = multibyteAdd(R1, R2, result[0 .. half], 0); // c2:R1 = R2 + R1 + R0
     BigDigit c3 = addAssignSimple(R2, R3); // R2 = R2 + R1 + R3
     if (c1+c2) multibyteIncrementAssign!('+')(result[half*2..$], c1+c2);
     if (c1+c3) multibyteIncrementAssign!('+')(R3, c1+c3);
@@ -2177,7 +2177,7 @@ void squareKaratsuba(BigDigit [] result, const BigDigit [] x,
  * Given u and v, calculates  quotient  = u / v, u = u % v.
  * v must be normalized (ie, the MSB of v must be 1).
  * The most significant words of quotient and u may be zero.
- * u[0..v.length] holds the remainder.
+ * u[0 .. v.length] holds the remainder.
  */
 void schoolbookDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
     pure nothrow
@@ -2246,13 +2246,13 @@ again:
             } // version(InlineAsm)
         }
         // Multiply and subtract.
-        uint carry = multibyteMulAdd!('-')(u[j..j + v.length], v, qhat, 0);
+        uint carry = multibyteMulAdd!('-')(u[j .. j + v.length], v, qhat, 0);
 
         if (u[j+v.length] < carry)
         {
             // If we subtracted too much, add back
             --qhat;
-            carry -= multibyteAdd(u[j..j + v.length],u[j..j + v.length], v, 0);
+            carry -= multibyteAdd(u[j .. j + v.length],u[j .. j + v.length], v, 0);
         }
         quotient[j] = qhat;
         u[j + v.length] = u[j + v.length] - carry;
@@ -2335,7 +2335,7 @@ int firstNonZeroDigit(const BigDigit [] x) pure nothrow @nogc @safe
     scratch is temporary storage space, length must be >= quotient + 1.
 
 Returns:
-    u[0..v.length] is the remainder. u[v.length..$] is corrupted.
+    u[0 .. v.length] is the remainder. u[v.length..$] is corrupted.
 
     Implements algorithm 1.8 from MCA.
     This algorithm has an annoying special case. After the first recursion, the
@@ -2391,19 +2391,19 @@ body
         scratch, mayOverflow);
 
     // quotient[k..$] is our guess at the high quotient.
-    // u[2*k.. 2.*k + v.length - k = k + v.length] is the high part of the
-    // first remainder. u[0..2*k] is the low part.
+    // u[2*k .. 2.*k + v.length - k = k + v.length] is the high part of the
+    // first remainder. u[0 .. 2*k] is the low part.
 
     // Calculate the full first remainder to be
     //    remainder - highQuotient * lowDivisor
     // reducing highQuotient until the remainder is positive.
-    // The low part of the remainder, u[0..k], cannot be altered by this.
+    // The low part of the remainder, u[0 .. k], cannot be altered by this.
 
     adjustRemainder(quotient[k .. $], u[k .. k + v.length], v, k,
             scratch[0 .. quotient.length], mayOverflow);
 
     // RECURSION 2: Calculate the low half of the quotient
-    // The full first remainder is now in u[0..k + v.length].
+    // The full first remainder is now in u[0 .. k + v.length].
 
     if (u[k + v.length - 1] & 0x8000_0000)
     {
@@ -2432,14 +2432,14 @@ body
         recursiveDivMod(quotient[0 .. k], u[k .. k + v.length], v[k .. $],
             scratch, false);
 
-        // high remainder is in u[k..k+(v.length-k)] == u[k .. v.length]
+        // high remainder is in u[k .. k+(v.length-k)] == u[k .. v.length]
 
         adjustRemainder(quotient[0 .. k], u[0 .. v.length], v, k,
             scratch[0 .. 2 * k]);
     }
 }
 
-// rem -= quot * v[0..k].
+// rem -= quot * v[0 .. k].
 // If would make rem negative, decrease quot until rem is >=0.
 // Needs (quot.length * k) scratch space to store the result of the multiply.
 void adjustRemainder(BigDigit[] quot, BigDigit[] rem, const(BigDigit)[] v,
@@ -2483,8 +2483,8 @@ pure nothrow
             u[m + v.length] = 0;
             saveq = quotient[m];
         }
-        recursiveDivMod(quotient[m-v.length..m + (mayOverflow? 1: 0)],
-            u[m - v.length..m + v.length + (mayOverflow? 1: 0)], v, scratch, mayOverflow);
+        recursiveDivMod(quotient[m-v.length .. m + (mayOverflow? 1: 0)],
+            u[m - v.length .. m + v.length + (mayOverflow? 1: 0)], v, scratch, mayOverflow);
         if (mayOverflow)
         {
             assert(quotient[m] == 0);
@@ -2492,7 +2492,7 @@ pure nothrow
         }
         m -= v.length;
     }
-    recursiveDivMod(quotient[0..m], u[0..m + v.length], v, scratch);
+    recursiveDivMod(quotient[0 .. m], u[0 .. m + v.length], v, scratch);
     () @trusted { GC.free(scratch.ptr); } ();
 }
 
@@ -2527,7 +2527,7 @@ unittest
     uint [] r1 = r.dup;
     uint [] q1 = q.dup;
     blockDivMod(q, b, a);
-    r = b[0..a.length];
+    r = b[0 .. a.length];
     assert(r[] == r1[]);
     assert(q[] == q1[]);
 }

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -60,7 +60,7 @@ unittest
         b[i]= 0x8000_0003;
     }
     c[19]=0x3333_3333;
-    uint carry = multibyteAddSub!('+')(c[0..18], b[0..18], a[0..18], 0);
+    uint carry = multibyteAddSub!('+')(c[0 .. 18], b[0 .. 18], a[0 .. 18], 0);
     assert(c[0]==0x8000_0003);
     assert(c[1]==4);
     assert(c[19]==0x3333_3333); // check for overrun
@@ -74,7 +74,7 @@ unittest
     a[10]=0x1D950C84;
     b[10]=0x1D950C84;
     a[5] =0x44444444;
-    carry = multibyteAddSub!('-')(a[0..12], a[0..12], b[0..12], 0);
+    carry = multibyteAddSub!('-')(a[0 .. 12], a[0 .. 12], b[0 .. 12], 0);
     assert(a[11] == 0);
     for (size_t i = 0; i < 10; ++i)
         if (i != 5)
@@ -88,7 +88,7 @@ unittest
         }
         a[q-2]=0x040000;
         b[q-2]=0x040000;
-       carry = multibyteAddSub!('-')(a[0..q], a[0..q], b[0..q], 0);
+       carry = multibyteAddSub!('-')(a[0 .. q], a[0 .. q], b[0 .. q], 0);
        assert(a[q-2]==0);
     }
 }
@@ -136,7 +136,7 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
 }
 
 /** dest[] = src[] << numbits
- *  numbits must be in the range 1..31
+ *  numbits must be in the range 1 .. 31
  */
 uint multibyteShl(uint [] dest, const(uint) [] src, uint numbits)
     pure @nogc @safe
@@ -153,7 +153,7 @@ uint multibyteShl(uint [] dest, const(uint) [] src, uint numbits)
 
 
 /** dest[] = src[] >> numbits
- *  numbits must be in the range 1..31
+ *  numbits must be in the range 1 .. 31
  */
 void multibyteShr(uint [] dest, const(uint) [] src, uint numbits)
     pure @nogc @safe
@@ -182,7 +182,7 @@ unittest
 
     aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD,
         0xEEEE_EEEE];
-    multibyteShl(aa[1..4], aa[1..$], 4);
+    multibyteShl(aa[1 .. 4], aa[1..$], 4);
     assert(aa[0] == 0xF0FF_FFFF && aa[1] == 0x2222_2230
         && aa[2]==0x5555_5561 && aa[3]==0x9999_99A4 && aa[4]==0x0BCCC_CCCD);
 }
@@ -208,14 +208,14 @@ unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A,
         0xBCCC_CCCD, 0xEEEE_EEEE];
-    multibyteMul(aa[1..4], aa[1..4], 16, 0);
+    multibyteMul(aa[1 .. 4], aa[1 .. 4], 16, 0);
     assert(aa[0] == 0xF0FF_FFFF && aa[1] == 0x2222_2230 && aa[2]==0x5555_5561
         && aa[3]==0x9999_99A4 && aa[4]==0x0BCCC_CCCD);
 }
 
 /**
- * dest[] += src[] * multiplier + carry(0..FFFF_FFFF).
- * Returns carry out of MSB (0..FFFF_FFFF).
+ * dest[] += src[] * multiplier + carry(0 .. FFFF_FFFF).
+ * Returns carry out of MSB (0 .. FFFF_FFFF).
  */
 uint multibyteMulAdd(char op)(uint [] dest, const(uint)[] src,
     uint multiplier, uint carry) pure @nogc @safe
@@ -257,14 +257,14 @@ unittest
 
 
 /**
-   Sets result = result[0..left.length] + left * right
+   Sets result = result[0 .. left.length] + left * right
 
    It is defined in this way to allow cache-efficient multiplication.
    This function is equivalent to:
     ----
     for (size_t i = 0; i< right.length; ++i)
     {
-        dest[left.length + i] = multibyteMulAdd(dest[i..left.length+i],
+        dest[left.length + i] = multibyteMulAdd(dest[i .. left.length+i],
                 left, right[i], 0);
     }
     ----
@@ -274,13 +274,13 @@ void multibyteMultiplyAccumulate(uint [] dest, const(uint)[] left, const(uint)
 {
     for (size_t i = 0; i < right.length; ++i)
     {
-        dest[left.length + i] = multibyteMulAdd!('+')(dest[i..left.length+i],
+        dest[left.length + i] = multibyteMulAdd!('+')(dest[i .. left.length+i],
                 left, right[i], 0);
     }
 }
 
 /**  dest[] /= divisor.
- * overflow is the initial remainder, and must be in the range 0..divisor-1.
+ * overflow is the initial remainder, and must be in the range 0 .. divisor-1.
  */
 uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
     pure @nogc @safe
@@ -310,7 +310,7 @@ unittest
     assert(r == 0x33FF_7461);
 
 }
-// Set dest[2*i..2*i+1]+=src[i]*src[i]
+// Set dest[2*i .. 2*i+1]+=src[i]*src[i]
 void multibyteAddDiagonalSquares(uint[] dest, const(uint)[] src)
     pure @nogc @safe
 {

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -82,7 +82,7 @@ string indexedLoopUnroll(int n, string s) pure @safe
         {
             if (s[j]=='@')
             {
-                u ~= s[last..j] ~ nstr;
+                u ~= s[last .. j] ~ nstr;
                 last = j+1;
             }
         }
@@ -152,7 +152,7 @@ L_unrolled:
         setc AL; // save carry
         add ECX, 8;
         ja L_unrolled;
-L2:     // Do the residual 1..7 ints.
+L2:     // Do the residual 1 .. 7 ints.
 
         sub ECX, 8;
         jz done;
@@ -189,7 +189,7 @@ unittest
         b[i]= 0x8000_0003;
     }
     c[19]=0x3333_3333;
-    uint carry = multibyteAddSub!('+')(c[0..18], a[0..18], b[0..18], 0);
+    uint carry = multibyteAddSub!('+')(c[0 .. 18], a[0 .. 18], b[0 .. 18], 0);
     assert(carry==1);
     assert(c[0]==0x8000_0003);
     assert(c[1]==4);
@@ -203,7 +203,7 @@ unittest
     a[10]=0x1D950C84;
     b[10]=0x1D950C84;
     a[5] =0x44444444;
-    carry = multibyteAddSub!('-')(a[0..12], a[0..12], b[0..12], 0);
+    carry = multibyteAddSub!('-')(a[0 .. 12], a[0 .. 12], b[0 .. 12], 0);
     assert(a[11]==0);
     for (int i=0; i<10; ++i) if (i!=5) assert(a[i]==0);
 
@@ -215,7 +215,7 @@ unittest
         }
         a[q-2]=0x040000;
         b[q-2]=0x040000;
-       carry = multibyteAddSub!('-')(a[0..q], a[0..q], b[0..q], 0);
+       carry = multibyteAddSub!('-')(a[0 .. q], a[0 .. q], b[0 .. q], 0);
        assert(a[q-2]==0);
     }
 }
@@ -251,13 +251,13 @@ L2:     dec EAX;
 }
 
 /** dest[#] = src[#] << numbits
- *  numbits must be in the range 1..31
+ *  numbits must be in the range 1 .. 31
  *  Returns the overflow
  */
 uint multibyteShlNoMMX(uint [] dest, const uint [] src, uint numbits) pure
 {
     // Timing: Optimal for P6 family.
-    // 2.0 cycles/int on PPro..PM (limited by execution port p0)
+    // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // 5.0 cycles/int on Athlon, which has 7 cycles for SHLD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
     asm pure nothrow {
@@ -302,7 +302,7 @@ L_last:
 }
 
 /** dest[#] = src[#] >> numbits
- *  numbits must be in the range 1..31
+ *  numbits must be in the range 1 .. 31
  * This version uses MMX.
  */
 uint multibyteShl(uint [] dest, const uint [] src, uint numbits) pure
@@ -473,12 +473,12 @@ L_length1:
 }
 
 /** dest[#] = src[#] >> numbits
- *  numbits must be in the range 1..31
+ *  numbits must be in the range 1 .. 31
  */
 void multibyteShrNoMMX(uint [] dest, const uint [] src, uint numbits) pure
 {
     // Timing: Optimal for P6 family.
-    // 2.0 cycles/int on PPro..PM (limited by execution port p0)
+    // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // Terrible performance on AMD64, which has 7 cycles for SHRD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
     asm pure nothrow {
@@ -543,13 +543,13 @@ unittest
 
 
     aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
-    uint r = multibyteShl(aa[2..4], aa[2..4], 4);
+    uint r = multibyteShl(aa[2 .. 4], aa[2 .. 4], 4);
     assert(aa[0] == 0xF0FF_FFFF && aa[1]==0x1222_2223
         && aa[2]==0x5555_5560 && aa[3]==0x9999_99A4 && aa[4]==0xBCCC_CCCD);
     assert(r==8);
 
     aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
-    r = multibyteShl(aa[1..4], aa[1..4], 4);
+    r = multibyteShl(aa[1 .. 4], aa[1 .. 4], 4);
     assert(aa[0] == 0xF0FF_FFFF
         && aa[2]==0x5555_5561);
         assert(aa[3]==0x9999_99A4 && aa[4]==0xBCCC_CCCD);
@@ -557,7 +557,7 @@ unittest
         assert(aa[1]==0x2222_2230);
 
     aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
-    r = multibyteShl(aa[0..4], aa[1..5], 31);
+    r = multibyteShl(aa[0 .. 4], aa[1 .. 5], 31);
 }
 
 /** dest[#] = src[#] * multiplier + carry.
@@ -627,7 +627,7 @@ L_odd:
 unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
-    multibyteMul(aa[1..4], aa[1..4], 16, 0);
+    multibyteMul(aa[1 .. 4], aa[1 .. 4], 16, 0);
     assert(aa[0] == 0xF0FF_FFFF && aa[1] == 0x2222_2230 &&
         aa[2]==0x5555_5561 && aa[3]==0x9999_99A4 && aa[4]==0x0BCCC_CCCD);
 }
@@ -725,9 +725,9 @@ string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure
 
 
 /**
- * dest[#] += src[#] * multiplier OP carry(0..FFFF_FFFF).
+ * dest[#] += src[#] * multiplier OP carry(0 .. FFFF_FFFF).
  * where op == '+' or '-'
- * Returns carry out of MSB (0..FFFF_FFFF).
+ * Returns carry out of MSB (0 .. FFFF_FFFF).
  */
 uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
         multiplier, uint carry) pure {
@@ -807,14 +807,14 @@ unittest
 }
 
 /**
-   Sets result[#] = result[0..left.length] + left[#] * right[#]
+   Sets result[#] = result[0 .. left.length] + left[#] * right[#]
 
    It is defined in this way to allow cache-efficient multiplication.
    This function is equivalent to:
     ----
     for (int i = 0; i< right.length; ++i)
     {
-        dest[left.length + i] = multibyteMulAdd(dest[i..left.length+i],
+        dest[left.length + i] = multibyteMulAdd(dest[i .. left.length+i],
                 left, right[i], 0);
     }
     ----
@@ -900,7 +900,7 @@ L_enter_odd:
 }
 
 /**  dest[#] /= divisor.
- * overflow is the initial remainder, and must be in the range 0..divisor-1.
+ * overflow is the initial remainder, and must be in the range 0 .. divisor-1.
  * divisor must not be a power of 2 (use right shift for that case;
  * A division by zero will occur if divisor is a power of 2).
  * Returns the final remainder
@@ -935,7 +935,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow) pure
 
         // Loop from msb to lsb
         lea     EDI, [EDI + 4*EBX];
-        mov EBP, EAX; // rem is the input remainder, in 0..divisor-1
+        mov EBP, EAX; // rem is the input remainder, in 0 .. divisor-1
         // Build the pseudo-inverse of divisor k: 2^64/k
         // First determine the shift in ecx to get the max number of bits in kinv
         xor     ECX, ECX;
@@ -991,7 +991,7 @@ Ld:     inc     ESI;
 
         // Adjust quotient and remainder on single word
 Lb:     cmp     EBP, [ESP + LASTPARAM+LOCALS]; //divisor;
-        jc      Lc; // rem in 0..divisor-1, OK
+        jc      Lc; // rem in 0 .. divisor-1, OK
         sub     EBP, [ESP + LASTPARAM+LOCALS]; //divisor;
         inc     ESI;
         jmp     Lb;
@@ -1025,7 +1025,7 @@ unittest
     assert(r==0x33FF_7461);
 }
 
-// Set dest[2*i..2*i+1]+=src[i]*src[i]
+// Set dest[2*i .. 2*i+1]+=src[i]*src[i]
 void multibyteAddDiagonalSquares(uint [] dest, const uint [] src) pure
 {
     /* Unlike mulAdd, the carry is only 1 bit,
@@ -1215,7 +1215,7 @@ L_enter_odd:
 unittest
 {
    uint [] aa = new uint[200];
-   uint [] a  = aa[0..100];
+   uint [] a  = aa[0 .. 100];
    uint [] b  = new uint [100];
    aa[] = 761;
    a[] = 0;
@@ -1223,8 +1223,8 @@ unittest
    a[3] = 6;
    b[0]=1;
    b[1] = 17;
-   b[50..100]=78;
-   multibyteTriangleAccumulateAsm(a, b[0..50]);
+   b[50 .. 100]=78;
+   multibyteTriangleAccumulateAsm(a, b[0 .. 50]);
    uint [] c = new uint[100];
    c[] = 0;
    c[1] = 17;
@@ -1239,7 +1239,7 @@ unittest
    b[2]=  0xdaa797ed;
    b[3] = 0;
 
-   multibyteTriangleAccumulateAsm(a[0..8], b[0..4]);
+   multibyteTriangleAccumulateAsm(a[0 .. 8], b[0 .. 4]);
    assert(a[1]==0x3a600964);
    assert(a[2]==0x339974f6);
    assert(a[3]==0x46736fce);
@@ -1248,7 +1248,7 @@ unittest
    b[3] = 0xe93ff9f4;
    b[4] = 0x184f03;
    a[]=0;
-   multibyteTriangleAccumulateAsm(a[0..14], b[0..7]);
+   multibyteTriangleAccumulateAsm(a[0 .. 14], b[0 .. 7]);
    assert(a[3]==0x79fff5c2);
    assert(a[4]==0xcf384241);
    assert(a[5]== 0x4a17fc8);
@@ -1261,7 +1261,7 @@ void multibyteSquare(BigDigit[] result, const BigDigit [] x) pure
     if (x.length < 4)
     {
         // Special cases, not worth doing triangular.
-        result[x.length] = multibyteMul(result[0..x.length], x, x[0], 0);
+        result[x.length] = multibyteMul(result[0 .. x.length], x, x[0], 0);
         multibyteMultiplyAccumulate(result[1..$], x, x[1..$]);
         return;
     }
@@ -1293,44 +1293,44 @@ void testPerformance() pure
     // The value for division is quite inconsistent.
     for (int i=0; i<X1.length; ++i) { X1[i]=i; Y1[i]=i; Z1[i]=i; }
     int t, t0;
-    multibyteShl(Z1[0..2000], X1[0..2000], 7);
+    multibyteShl(Z1[0 .. 2000], X1[0 .. 2000], 7);
     t0 = clock();
-    multibyteShl(Z1[0..1000], X1[0..1000], 7);
+    multibyteShl(Z1[0 .. 1000], X1[0 .. 1000], 7);
     t = clock();
-    multibyteShl(Z1[0..2000], X1[0..2000], 7);
+    multibyteShl(Z1[0 .. 2000], X1[0 .. 2000], 7);
     auto shltime = (clock() - t) - (t - t0);
     t0 = clock();
-    multibyteShr(Z1[2..1002], X1[4..1004], 13);
+    multibyteShr(Z1[2 .. 1002], X1[4 .. 1004], 13);
     t = clock();
-    multibyteShr(Z1[2..2002], X1[4..2004], 13);
+    multibyteShr(Z1[2 .. 2002], X1[4 .. 2004], 13);
     auto shrtime = (clock() - t) - (t - t0);
     t0 = clock();
-    multibyteAddSub!('+')(Z1[0..1000], X1[0..1000], Y1[0..1000], 0);
+    multibyteAddSub!('+')(Z1[0 .. 1000], X1[0 .. 1000], Y1[0 .. 1000], 0);
     t = clock();
-    multibyteAddSub!('+')(Z1[0..2000], X1[0..2000], Y1[0..2000], 0);
+    multibyteAddSub!('+')(Z1[0 .. 2000], X1[0 .. 2000], Y1[0 .. 2000], 0);
     auto addtime = (clock() - t) - (t-t0);
     t0 = clock();
-    multibyteMul(Z1[0..1000], X1[0..1000], 7, 0);
+    multibyteMul(Z1[0 .. 1000], X1[0 .. 1000], 7, 0);
     t = clock();
-    multibyteMul(Z1[0..2000], X1[0..2000], 7, 0);
+    multibyteMul(Z1[0 .. 2000], X1[0 .. 2000], 7, 0);
     auto multime = (clock() - t) - (t - t0);
-    multibyteMulAdd!('+')(Z1[0..2000], X1[0..2000], 217, 0);
+    multibyteMulAdd!('+')(Z1[0 .. 2000], X1[0 .. 2000], 217, 0);
     t0 = clock();
-    multibyteMulAdd!('+')(Z1[0..1000], X1[0..1000], 217, 0);
+    multibyteMulAdd!('+')(Z1[0 .. 1000], X1[0 .. 1000], 217, 0);
     t = clock();
-    multibyteMulAdd!('+')(Z1[0..2000], X1[0..2000], 217, 0);
+    multibyteMulAdd!('+')(Z1[0 .. 2000], X1[0 .. 2000], 217, 0);
     auto muladdtime = (clock() - t) - (t - t0);
-    multibyteMultiplyAccumulate(Z1[0..64], X1[0..32], Y1[0..32]);
+    multibyteMultiplyAccumulate(Z1[0 .. 64], X1[0 .. 32], Y1[0 .. 32]);
     t = clock();
-    multibyteMultiplyAccumulate(Z1[0..64], X1[0..32], Y1[0..32]);
+    multibyteMultiplyAccumulate(Z1[0 .. 64], X1[0 .. 32], Y1[0 .. 32]);
     auto accumtime = clock() - t;
     t0 = clock();
-    multibyteDivAssign(Z1[0..2000], 217, 0);
+    multibyteDivAssign(Z1[0 .. 2000], 217, 0);
     t = clock();
-    multibyteDivAssign(Z1[0..1000], 37, 0);
+    multibyteDivAssign(Z1[0 .. 1000], 37, 0);
     auto divtime = (t - t0) - (clock() - t);
         t= clock();
-    multibyteSquare(Z1[0..64], X1[0..32]);
+    multibyteSquare(Z1[0 .. 64], X1[0 .. 32]);
     auto squaretime = clock() - t;
 
     printf("-- BigInt asm performance (cycles/int) --\n");

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -43,14 +43,14 @@ void main()
     textbuf.put('x');
     textbuf.put("abc");
     assert(textbuf.length == 5);
-    assert(textbuf[1..3] == "xa");
+    assert(textbuf[1 .. 3] == "xa");
     assert(textbuf[3] == 'b');
 
     // Can shrink it
     textbuf.length = 3;
-    assert(textbuf[0..textbuf.length] == "axa");
+    assert(textbuf[0 .. textbuf.length] == "axa");
     assert(textbuf[textbuf.length - 1] == 'a');
-    assert(textbuf[1..3] == "xa");
+    assert(textbuf[1 .. 3] == "xa");
 
     textbuf.put('z');
     assert(textbuf[] == "axaz");
@@ -306,16 +306,16 @@ unittest
     textbuf.put('x');
     textbuf.put("abc");         // tickle put([])'s resize
     assert(textbuf.length == 5);
-    assert(textbuf[1..3] == "xa");
+    assert(textbuf[1 .. 3] == "xa");
     assert(textbuf[3] == 'b');
 
     textbuf.length = textbuf.length - 1;
-    assert(textbuf[0..textbuf.length] == "axab");
+    assert(textbuf[0 .. textbuf.length] == "axab");
 
     textbuf.length = 3;
-    assert(textbuf[0..textbuf.length] == "axa");
+    assert(textbuf[0 .. textbuf.length] == "axa");
     assert(textbuf[textbuf.length - 1] == 'a');
-    assert(textbuf[1..3] == "xa");
+    assert(textbuf[1 .. 3] == "xa");
 
     textbuf.put(cast(dchar)'z');
     assert(textbuf[] == "axaz");
@@ -355,10 +355,10 @@ unittest
     char[10] tmpbuf = void;
     auto textbuf = ScopeBuffer!char(tmpbuf);
     scope(exit) textbuf.free();
-    foreach (i; 0..10) textbuf.put('w');
+    foreach (i; 0 .. 10) textbuf.put('w');
     const csb = textbuf;
     const elem = csb[3];
-    const slice0 = csb[0..5];
+    const slice0 = csb[0 .. 5];
     const slice1 = csb[];
 }
 

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -32,7 +32,7 @@ import std.traits : isArray;
 
 // Range that's useful for testing other higher order ranges,
 // can be parametrized with attributes.  It just dumbs down an array of
-// numbers 1..10.
+// numbers 1 .. 10.
 struct DummyRange(ReturnBy _r, Length _l, RangeType _rt, T = uint[])
 if (isArray!T)
 {
@@ -166,7 +166,7 @@ if (isArray!T)
         typeof(this) opSlice(size_t lower, size_t upper)
         {
             auto ret = this;
-            ret.arr = arr[lower..upper];
+            ret.arr = arr[lower .. upper];
             return ret;
         }
 

--- a/std/internal/unicode_tables.d
+++ b/std/internal/unicode_tables.d
@@ -41,7 +41,7 @@ struct FullCaseEntry
 
     @property auto value() const @trusted pure nothrow @nogc return
     {
-        return seq[0..entry_len];
+        return seq[0 .. entry_len];
     }
 }
 

--- a/std/json.d
+++ b/std/json.d
@@ -825,7 +825,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                         }
                         char[4] buf;
                         immutable len = encode!(Yes.useReplacementDchar)(buf, val);
-                        str.put(buf[0..len]);
+                        str.put(buf[0 .. len]);
                         break;
 
                     default:
@@ -1461,12 +1461,12 @@ class JSONException : Exception
     // Adding new json element via array() / object() directly
 
     JSONValue jarr = JSONValue([10]);
-    foreach (i; 0..9)
+    foreach (i; 0 .. 9)
         jarr.array ~= JSONValue(i);
     assert(jarr.array.length == 10);
 
     JSONValue jobj = JSONValue(["key" : JSONValue("value")]);
-    foreach (i; 0..9)
+    foreach (i; 0 .. 9)
         jobj.object[text("key", i)] = JSONValue(text("value", i));
     assert(jobj.object.length == 10);
 }
@@ -1476,12 +1476,12 @@ class JSONException : Exception
     // Adding new json element without array() / object() access
 
     JSONValue jarr = JSONValue([10]);
-    foreach (i; 0..9)
+    foreach (i; 0 .. 9)
         jarr ~= [JSONValue(i)];
     assert(jarr.array.length == 10);
 
     JSONValue jobj = JSONValue(["key" : JSONValue("value")]);
-    foreach (i; 0..9)
+    foreach (i; 0 .. 9)
         jobj[text("key", i)] = JSONValue(text("value", i));
     assert(jobj.object.length == 10);
 

--- a/std/math.d
+++ b/std/math.d
@@ -1350,7 +1350,7 @@ public:
  *
  * $(TABLE_DOMRG
  *  $(DOMAIN 1..$(INFIN))
- *  $(RANGE  1..log(real.max), $(INFIN)) )
+ *  $(RANGE  1 .. log(real.max), $(INFIN)) )
  *      $(TABLE_SV
  *    $(SVH  x,     acosh(x) )
  *    $(SV  $(NAN), $(NAN) )
@@ -1434,7 +1434,7 @@ float asinh(float x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
  *
  * $(TABLE_DOMRG
  *  $(DOMAIN -$(INFIN)..$(INFIN))
- *  $(RANGE  -1..1) )
+ *  $(RANGE  -1 .. 1) )
  * $(TABLE_SV
  *    $(SVH  x,     acosh(x) )
  *    $(SV  $(NAN), $(NAN) )

--- a/std/meta.d
+++ b/std/meta.d
@@ -487,13 +487,13 @@ template NoDuplicates(TList...)
         }
         else
         {
-            alias EraseAllN = EraseAllN!(N-1, T[1..N], EraseAll!(T[0], T[N..$]));
+            alias EraseAllN = EraseAllN!(N-1, T[1 .. N], EraseAll!(T[0], T[N..$]));
         }
     }
     static if (TList.length > 500)
     {
         enum steps = 16;
-        alias first = NoDuplicates!(TList[0..steps]);
+        alias first = NoDuplicates!(TList[0 .. steps]);
         alias NoDuplicates = NoDuplicates!(EraseAllN!(first.length, first, TList[steps..$]));
     }
     else static if (TList.length == 0)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1027,7 +1027,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         {
             size_t minLen = min(buf.length, remainingData.length);
             if (minLen == 0) return 0;
-            buf[0..minLen] = remainingData[0..minLen];
+            buf[0 .. minLen] = remainingData[0 .. minLen];
             remainingData = remainingData[minLen..$];
             return minLen;
         };
@@ -1164,7 +1164,7 @@ private auto _basicFTP(T)(const(char)[] url, const(void)[] sendData, FTP client)
         {
             size_t minLen = min(buf.length, sendData.length);
             if (minLen == 0) return 0;
-            buf[0..minLen] = sendData[0..minLen];
+            buf[0 .. minLen] = sendData[0 .. minLen];
             sendData = sendData[minLen..$];
             return minLen;
         };
@@ -1393,7 +1393,7 @@ if (isCurlConn!(Conn))
         {
             size_t nextOffset = offset + chunkSize;
             if (nextOffset > _bytes.length) nextOffset = _bytes.length;
-            return _bytes[offset..nextOffset];
+            return _bytes[offset .. nextOffset];
         }
 
         @safe void popFront()
@@ -1582,7 +1582,7 @@ private static struct AsyncLineInputRange(Char)
         // Send buffers to other thread for it to use.  Since no mechanism is in
         // place for moving ownership a cast to shared is done here and casted
         // back to non-shared in the receiving end.
-        foreach (i ; 0..transmitBuffers)
+        foreach (i ; 0 .. transmitBuffers)
         {
             auto arr = new Char[](bufferSize);
             workerTid.send(cast(immutable(Char[]))arr);
@@ -1735,7 +1735,7 @@ private static struct AsyncChunkInputRange
         // Send buffers to other thread for it to use.  Since no mechanism is in
         // place for moving ownership a cast to shared is done here and a cast
         // back to non-shared in the receiving end.
-        foreach (i ; 0..transmitBuffers)
+        foreach (i ; 0 .. transmitBuffers)
         {
             ubyte[] arr = new ubyte[](chunkSize);
             workerTid.send(cast(immutable(ubyte[]))arr);
@@ -2176,7 +2176,7 @@ private mixin template Protocol()
      *     auto m = cast(void[]) msg;
      *     size_t length = m.length > data.length ? data.length : m.length;
      *     if (length == 0) return 0;
-     *     data[0..length] = m[0..length];
+     *     data[0 .. length] = m[0 .. length];
      *     msg = msg[length..$];
      *     return length;
      * };
@@ -2367,7 +2367,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *     auto m = cast(void[]) msg;
   *     size_t len = m.length > data.length ? data.length : m.length;
   *     if (len == 0) return len;
-  *     data[0..len] = m[0..len];
+  *     data[0 .. len] = m[0 .. len];
   *     msg = msg[len..$];
   *     return len;
   * };
@@ -2777,7 +2777,7 @@ struct HTTP
          *     auto m = cast(void[]) msg;
          *     size_t length = m.length > data.length ? data.length : m.length;
          *     if (length == 0) return 0;
-         *     data[0..length] = m[0..length];
+         *     data[0 .. length] = m[0 .. length];
          *     msg = msg[length..$];
          *     return length;
          * };
@@ -3732,7 +3732,7 @@ struct SMTP
             {
                 if (!msg.length) return 0;
                 size_t to_copy = min(data.length, _message.length);
-                data[0..to_copy] = (cast(void[])_message)[0..to_copy];
+                data[0 .. to_copy] = (cast(void[])_message)[0 .. to_copy];
                 _message = _message[to_copy..$];
                 return to_copy;
             };
@@ -4537,7 +4537,7 @@ struct Curl
       *     auto m = cast(void[]) msg;
       *     size_t length = m.length > data.length ? data.length : m.length;
       *     if (length == 0) return 0;
-      *     data[0..length] = m[0..length];
+      *     data[0 .. length] = m[0 .. length];
       *     msg = msg[length..$];
       *     return length;
       * };
@@ -4677,7 +4677,7 @@ struct Curl
     {
         auto b = cast(Curl*) ptr;
         if (b._onReceive != null)
-            return b._onReceive(cast(InData)(str[0..size*nmemb]));
+            return b._onReceive(cast(InData)(str[0 .. size*nmemb]));
         return size*nmemb;
     }
 
@@ -4688,7 +4688,7 @@ struct Curl
         import std.string : chomp;
 
         auto b = cast(Curl*) ptr;
-        auto s = str[0..size*nmemb].chomp();
+        auto s = str[0 .. size*nmemb].chomp();
         if (b._onReceiveHeader != null)
             b._onReceiveHeader(s);
 
@@ -4699,7 +4699,7 @@ struct Curl
     size_t _sendCallback(char *str, size_t size, size_t nmemb, void *ptr)
     {
         Curl* b = cast(Curl*) ptr;
-        auto a = cast(void[]) str[0..size*nmemb];
+        auto a = cast(void[]) str[0 .. size*nmemb];
         if (b._onSend == null)
             return 0;
         return b._onSend(a);
@@ -4841,7 +4841,7 @@ private static size_t _receiveAsyncChunks(ubyte[] data, ref ubyte[] outdata,
         auto copyBytes = outdata.length < data.length ?
             outdata.length : data.length;
 
-        outdata[0..copyBytes] = data[0..copyBytes];
+        outdata[0 .. copyBytes] = data[0 .. copyBytes];
         outdata = outdata[copyBytes..$];
         data = data[copyBytes..$];
 

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -816,7 +816,7 @@ if (isSomeChar!(Char))
     assert(`.test@iana.org`.isEmail(No.checkDns, EmailStatusCode.any).statusCode == EmailStatusCode.errorDotStart);
     assert(`test.@iana.org`.isEmail(No.checkDns, EmailStatusCode.any).statusCode == EmailStatusCode.errorDotEnd);
 
-    assert(`test..iana.org`.isEmail(No.checkDns, EmailStatusCode.any).statusCode ==
+    assert(`test .. iana.org`.isEmail(No.checkDns, EmailStatusCode.any).statusCode ==
         EmailStatusCode.errorConsecutiveDots);
 
     assert(`test_exa-mple.com`.isEmail(No.checkDns, EmailStatusCode.any).statusCode == EmailStatusCode.errorNoDomain);
@@ -861,7 +861,7 @@ if (isSomeChar!(Char))
 
     assert(`test@.iana.org`.isEmail(No.checkDns, EmailStatusCode.any).statusCode == EmailStatusCode.errorDotStart);
     assert(`test@iana.org.`.isEmail(No.checkDns, EmailStatusCode.any).statusCode == EmailStatusCode.errorDotEnd);
-    assert(`test@iana..com`.isEmail(No.checkDns, EmailStatusCode.any).statusCode ==
+    assert(`test@iana .. com`.isEmail(No.checkDns, EmailStatusCode.any).statusCode ==
         EmailStatusCode.errorConsecutiveDots);
 
     //assert(`a@a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z`

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -772,7 +772,7 @@ public:
 
 /**  Find a real root of a real function f(x) via bracketing.
  *
- * Given a function `f` and a range `[a..b]` such that `f(a)`
+ * Given a function `f` and a range `[a .. b]` such that `f(a)`
  * and `f(b)` have opposite signs or at least one of them equals ±0,
  * returns the value of `x` in
  * the range which is closest to a root of `f(x)`.  If `f(x)`
@@ -871,7 +871,7 @@ body
     // (www.netlib.org).  The changes to improve the worst-cast performance are
     // entirely original.
 
-    T a, b, d;  // [a..b] is our current bracket. d is the third best guess.
+    T a, b, d;  // [a .. b] is our current bracket. d is the third best guess.
     R fa, fb, fd; // Values of f at a, b, d.
     bool done = false; // Has a root been found?
 
@@ -947,10 +947,10 @@ body
         return c;
     }
 
-    /* Uses 'numsteps' newton steps to approximate the zero in [a..b] of the
+    /* Uses 'numsteps' newton steps to approximate the zero in [a .. b] of the
        quadratic polynomial interpolating f(x) at a, b, and d.
        Returns:
-         The approximate zero in [a..b] of the quadratic polynomial.
+         The approximate zero in [a .. b] of the quadratic polynomial.
     */
     T newtonQuadratic(int numsteps)
     {
@@ -963,7 +963,7 @@ body
         T c = oppositeSigns(a2, fa) ? a  : b;
 
         // start the safeguarded newton steps.
-        foreach (int i; 0..numsteps)
+        foreach (int i; 0 .. numsteps)
         {
             immutable T pc = a0 + (a1 + a2 * (c - b))*(c - a);
             immutable T pdc = a1 + a2*((2 * c) - (a + b));
@@ -1006,7 +1006,7 @@ whileloop:
         T a0 = a, b0 = b; // record the brackets
 
         // Do two higher-order (cubic or parabolic) interpolation steps.
-        foreach (int QQ; 0..2)
+        foreach (int QQ; 0 .. 2)
         {
             // Cubic inverse interpolation requires that
             // all four function values fa, fb, fd, and fe are distinct;
@@ -1134,7 +1134,7 @@ whileloop:
 
         if ((b - a) < T(0.25) * (b0 - a0))
             baditer = 1;
-        foreach (int QQ; 0..baditer)
+        foreach (int QQ; 0 .. baditer)
         {
             e = d;
             fe = fd;
@@ -1393,7 +1393,7 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
 
 /++
 Find a real minimum of a real function `f(x)` via bracketing.
-Given a function `f` and a range `(ax..bx)`,
+Given a function `f` and a range `(ax .. bx)`,
 returns the value of `x` in the range which is closest to a minimum of `f(x)`.
 `f` is never evaluted at the endpoints of `ax` and `bx`.
 If `f(x)` has more than one minimum in the range, one will be chosen arbitrarily.
@@ -2787,7 +2787,7 @@ private:
 
                 typeof(this) opSlice(size_t lower, size_t upper)
                 {
-                    return typeof(this)(source[lower * 2..upper * 2]);
+                    return typeof(this)(source[lower * 2 .. upper * 2]);
                 }
             }
 
@@ -2803,7 +2803,7 @@ private:
         evenFft[0].im = 0;
         // evenFft[0].re is already right b/c it's aliased with buf[0].re.
 
-        foreach (k; 1..halfN / 2 + 1)
+        foreach (k; 1 .. halfN / 2 + 1)
         {
             immutable bufk = buf[k];
             immutable bufnk = buf[buf.length / 2 - k];
@@ -2917,11 +2917,11 @@ private:
         auto table = new lookup_t[][bsf(size) + 1];
 
         table[$ - 1] = memSpace[$ - size..$];
-        memSpace = memSpace[0..size];
+        memSpace = memSpace[0 .. size];
 
         auto lastRow = table[$ - 1];
         lastRow[0] = 0;  // -sin(0) == 0.
-        foreach (ptrdiff_t i; 1..size)
+        foreach (ptrdiff_t i; 1 .. size)
         {
             // The hard coded cases are for improved accuracy and to prevent
             // annoying non-zeroness when stuff should be zero.
@@ -2937,7 +2937,7 @@ private:
         }
 
         // Fill in all the other rows with strided versions.
-        foreach (i; 1..table.length - 1)
+        foreach (i; 1 .. table.length - 1)
         {
             immutable strideLength = size / (2 ^^ i);
             auto strided = Stride!(lookup_t[])(lastRow, strideLength);
@@ -3108,7 +3108,7 @@ private enum string MakeLocalFft = q{
     import core.exception : onOutOfMemoryError;
 
     auto lookupBuf = (cast(lookup_t*) malloc(range.length * 2 * lookup_t.sizeof))
-                     [0..2 * range.length];
+                     [0 .. 2 * range.length];
     if (!lookupBuf.ptr)
         onOutOfMemoryError();
 
@@ -3273,12 +3273,12 @@ struct Stride(R)
     {
         if (range.length >= _nSteps)
         {
-            range = range[_nSteps..range.length];
+            range = range[_nSteps .. range.length];
             _length--;
         }
         else
         {
-            range = range[0..0];
+            range = range[0 .. 0];
             _length = 0;
         }
     }
@@ -3286,7 +3286,7 @@ struct Stride(R)
     // Pops half the range's stride.
     void popHalf()
     {
-        range = range[_nSteps / 2..range.length];
+        range = range[_nSteps / 2 .. range.length];
     }
 
     bool empty() const @property

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1726,8 +1726,8 @@ public:
 
                     static if (hasSlicing!R)
                     {
-                        auto subrange = range[start..end];
-                        foreach (i; start..end)
+                        auto subrange = range[start .. end];
+                        foreach (i; start .. end)
                         {
                             emplaceRef(buf[i], fun(subrange.front));
                             subrange.popFront();
@@ -1735,7 +1735,7 @@ public:
                     }
                     else
                     {
-                        foreach (i; start..end)
+                        foreach (i; start .. end)
                         {
                             emplaceRef(buf[i], fun(range[i]));
                         }
@@ -1854,7 +1854,7 @@ public:
 
                 void popSource()
                 {
-                    static if (__traits(compiles, source[0..source.length]))
+                    static if (__traits(compiles, source[0 .. source.length]))
                     {
                         source = source[min(buf1.length, source.length)..source.length];
                     }
@@ -1926,7 +1926,7 @@ public:
                         from[i++] = source.front;
                     }
 
-                    from = from[0..i];
+                    from = from[0 .. i];
                     return from;
                 }
             }
@@ -1984,7 +1984,7 @@ public:
                         auto toMap = dumpToFrom();
                     }
 
-                    buf = buf[0..min(buf.length, toMap.length)];
+                    buf = buf[0 .. min(buf.length, toMap.length)];
 
                     // Handle as a special case:
                     if (pool.size == 0)
@@ -2184,7 +2184,7 @@ public:
                     buf[i++] = source.front;
                 }
 
-                buf = buf[0..i];
+                buf = buf[0 .. i];
                 return buf;
             }
 
@@ -2517,7 +2517,7 @@ public:
                         lowerBound++;
                     }
 
-                    foreach (i; lowerBound..upperBound)
+                    foreach (i; lowerBound .. upperBound)
                     {
                         result = fun(result, range[i]);
                     }
@@ -2545,7 +2545,7 @@ public:
                 }
 
                 immutable nLoop = subSize - (!explicitSeed);
-                foreach (i; 0..nLoop)
+                foreach (i; 0 .. nLoop)
                 {
                     foreach (j; ilpTuple)
                     {
@@ -2555,7 +2555,7 @@ public:
                 }
 
                 // Finish the remainder.
-                foreach (i; nILP * subSize + lowerBound..upperBound)
+                foreach (i; nILP * subSize + lowerBound .. upperBound)
                 {
                     results[$ - 1] = fun(results[$ - 1], range[i]);
                 }
@@ -2605,7 +2605,7 @@ public:
             import core.stdc.stdlib : malloc, free;
             if (nBytesNeeded < maxStack)
             {
-                tasks = (cast(RTask*) buf.ptr)[0..nWorkUnits];
+                tasks = (cast(RTask*) buf.ptr)[0 .. nWorkUnits];
             }
             else
             {
@@ -2617,7 +2617,7 @@ public:
                     );
                 }
 
-                tasks = ptr[0..nWorkUnits];
+                tasks = ptr[0 .. nWorkUnits];
             }
 
             scope(exit)
@@ -2656,7 +2656,7 @@ public:
                 useTask(task);
             }
 
-            foreach (i; 1..tasks.length - 1)
+            foreach (i; 1 .. tasks.length - 1)
             {
                 tasks[i].next = tasks[i + 1].basePtr;
                 tasks[i + 1].prev = tasks[i].basePtr;
@@ -2858,7 +2858,7 @@ public:
             // Cache line align data ptr.
             data = cast(void*) roundToLine(cast(size_t) data);
 
-            foreach (i; 0..nElem)
+            foreach (i; 0 .. nElem)
             {
                 this.opIndex(i) = T.init;
             }
@@ -3044,7 +3044,7 @@ public:
     {
         WorkerLocalStorage!T ret;
         ret.initialize(this);
-        foreach (i; 0..size + 1)
+        foreach (i; 0 .. size + 1)
         {
             ret[i] = initialVal;
         }
@@ -3359,13 +3359,13 @@ private void submitAndExecute(
     PTask[] tasks;
     if (nThreads <= nBuf)
     {
-        tasks = (cast(PTask*) buf.ptr)[0..nThreads];
+        tasks = (cast(PTask*) buf.ptr)[0 .. nThreads];
     }
     else
     {
         auto ptr = cast(PTask*) malloc(nThreads * PTask.sizeof);
         if (!ptr) throw new OutOfMemoryError("Out of memory in std.parallelism.");
-        tasks = ptr[0..nThreads];
+        tasks = ptr[0 .. nThreads];
     }
 
     scope(exit)
@@ -3391,7 +3391,7 @@ private void submitAndExecute(
         t.pool = pool;
     }
 
-    foreach (i; 1..tasks.length - 1)
+    foreach (i; 1 .. tasks.length - 1)
     {
         tasks[i].next = tasks[i + 1].basePtr;
         tasks[i + 1].prev = tasks[i].basePtr;
@@ -3531,7 +3531,7 @@ private enum string parallelApplyMixinRandomAccess = q{
 
             immutable end = min(len, start + workUnitSize);
 
-            foreach (i; start..end)
+            foreach (i; start .. end)
             {
                 static if (withIndex)
                 {
@@ -3625,7 +3625,7 @@ enum string parallelApplyMixinInputRange = q{
                     temp[i] = addressOf(range.front);
                 }
 
-                temp = temp[0..i];
+                temp = temp[0 .. i];
                 auto ret = nPopped;
                 nPopped += temp.length;
                 return ret;
@@ -3655,7 +3655,7 @@ enum string parallelApplyMixinInputRange = q{
                     temp[i] = range.front;
                 }
 
-                temp = temp[0..i];
+                temp = temp[0 .. i];
                 auto ret = nPopped;
                 nPopped += temp.length;
                 return ret;
@@ -3695,7 +3695,7 @@ enum string parallelApplyMixinInputRange = q{
                 break;
             }
 
-            foreach (i; 0..temp.length)
+            foreach (i; 0 .. temp.length)
             {
                 scope(success) overallIndex++;
 
@@ -4076,8 +4076,8 @@ unittest
     auto wlRange = wl.toRange;
     auto parallelSum = poolInstance.reduce!"a + b"(wlRange);
     assert(parallelSum == 499500);
-    assert(wlRange[0..1][0] == wlRange[0]);
-    assert(wlRange[1..2][0] == wlRange[1]);
+    assert(wlRange[0 .. 1][0] == wlRange[0]);
+    assert(wlRange[1 .. 2][0] == wlRange[1]);
 
     // Test finish()
     {
@@ -4313,7 +4313,7 @@ version(parallelismStressTest)
             }
 
             // Make sure it works.
-            foreach (i; 0..numbers.length)
+            foreach (i; 0 .. numbers.length)
             {
                 assert(numbers[i] == i);
             }
@@ -4381,7 +4381,7 @@ version(parallelismStressTest)
     // as examples.
     unittest
     {
-        foreach (attempt; 0..10)
+        foreach (attempt; 0 .. 10)
         foreach (poolSize; [0, 4])
         {
             poolInstance = new TaskPool(poolSize);
@@ -4490,7 +4490,7 @@ version(parallelismStressTest)
                 // Test work waiting.
                 static void uselessFun()
                 {
-                    foreach (i; 0..1_000_000) {}
+                    foreach (i; 0 .. 1_000_000) {}
                 }
 
                 auto uselessTasks = new typeof(task(&uselessFun))[1000];

--- a/std/path.d
+++ b/std/path.d
@@ -356,7 +356,7 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
     {
         version (Windows) if (isUNC!(BaseOf!R)(path))
         {
-            return path[0..1];
+            return path[0 .. 1];
         }
         static if (is(StringTypeOf!R))
             return StringTypeOf!R.init[];   // which is null
@@ -470,7 +470,7 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
     isNarrowString!R) &&
     !isConvertibleToString!R)
 {
-    static auto result(bool dot, typeof(path[0..1]) p)
+    static auto result(bool dot, typeof(path[0 .. 1]) p)
     {
         static if (isSomeString!R)
             return dot ? "." : p;
@@ -649,7 +649,7 @@ Lnull:
     static if (is(StringTypeOf!R))
         return null; // legacy code may rely on null return rather than slice
     else
-        return path[0..0];
+        return path[0 .. 0];
 }
 
 ///
@@ -728,7 +728,7 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
     static if (isSomeString!R)
         return cast(ElementEncodingType!R[]) null; // legacy code may rely on null return rather than slice
     else
-        return path[0..0];
+        return path[0 .. 0];
 }
 
 ///
@@ -1742,7 +1742,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
     !isConvertibleToString!R)
 {
     alias C = Unqual!(ElementEncodingType!R);
-    alias S = typeof(path[0..0]);
+    alias S = typeof(path[0 .. 0]);
 
     static struct Result
     {
@@ -1770,7 +1770,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
             {
                 if (elements.empty)
                 {
-                    element = element[0..0];
+                    element = element[0 .. 0];
                     return;
                 }
                 element = elements.front;
@@ -1794,7 +1794,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
                             if (n == 0)
                             {
                                 elements = elements2;
-                                element = element[0..0];
+                                element = element[0 .. 0];
                                 continue L1;
                             }
                         }
@@ -1872,7 +1872,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
         bool rooted;    // the path starts with a root directory
         C c;
         S element;
-        typeof(pathSplitter(path[0..0])) elements;
+        typeof(pathSplitter(path[0 .. 0])) elements;
     }
 
     return Result(path);
@@ -3277,7 +3277,7 @@ body
                         else
                         {
                             /* Match for:
-                             *   pattern[pi0..pi-1] ~ pattern[piRemain..$]
+                             *   pattern[pi0 .. pi-1] ~ pattern[piRemain..$]
                              */
                             if (pattmp is null)
                                 // Allocate this only once per function invocation.

--- a/std/process.d
+++ b/std/process.d
@@ -2685,7 +2685,7 @@ private string escapeShellArguments(in char[][] args...)
             auto p = buf.length;
             buf.length = buf.length + 1 + size;
             buf[p++] = ' ';
-            return buf[p..p+size];
+            return buf[p .. p+size];
         }
     }
 
@@ -2820,8 +2820,8 @@ version(Windows) version(unittest)
         int numArgs;
         LPWSTR* args = CommandLineToArgvW(lpCommandLine, &numArgs);
         scope(exit) LocalFree(args);
-        return args[0..numArgs]
-            .map!(arg => to!string(arg[0..wcslen(arg)]))
+        return args[0 .. numArgs]
+            .map!(arg => to!string(arg[0 .. wcslen(arg)]))
             .array();
     }
 
@@ -2881,7 +2881,7 @@ if (is(typeof(allocator(size_t.init)[0] = char.init)))
     foreach (char c; arg)
         if (c == '\'')
         {
-            buf[p..p+4] = `'\''`;
+            buf[p .. p+4] = `'\''`;
             p += 4;
         }
         else
@@ -2971,10 +2971,10 @@ version(unittest_burnin)
     while (true)
     {
         string[] args;
-        foreach (n; 0..uniform(1, 4))
+        foreach (n; 0 .. uniform(1, 4))
         {
             string arg;
-            foreach (l; 0..uniform(0, 10))
+            foreach (l; 0 .. uniform(0, 10))
             {
                 dchar c;
                 while (true)
@@ -3002,7 +3002,7 @@ version(unittest_burnin)
 
         // generate filename
         string fn;
-        foreach (l; 0..uniform(1, 10))
+        foreach (l; 0 .. uniform(1, 10))
         {
             dchar c;
             while (true)

--- a/std/random.d
+++ b/std/random.d
@@ -2095,9 +2095,9 @@ if (isRandomAccessRange!Range)
 }
 
 /**
-Partially shuffles the elements of $(D r) such that upon returning $(D r[0..n])
-is a random subset of $(D r) and is randomly ordered.  $(D r[n..r.length])
-will contain the elements not in $(D r[0..n]).  These will be in an undefined
+Partially shuffles the elements of $(D r) such that upon returning $(D r[0 .. n])
+is a random subset of $(D r) and is randomly ordered.  $(D r[n .. r.length])
+will contain the elements not in $(D r[0 .. n]).  These will be in an undefined
 order, but will not be random in the sense that their order after
 $(D partialShuffle) returns will not be independent of their order before
 $(D partialShuffle) was called.
@@ -2147,13 +2147,13 @@ if (isRandomAccessRange!Range)
         immutable int LEN = 2;
         immutable int NUM = 750;
         int[][] chk;
-        foreach (step; 0..NUM)
+        foreach (step; 0 .. NUM)
         {
             partialShuffle(a, LEN, gen);
-            chk ~= a[0..LEN].dup;
+            chk ~= a[0 .. LEN].dup;
         }
 
-        // Check that each possible a[0..LEN] was produced at least once.
+        // Check that each possible a[0 .. LEN] was produced at least once.
         // For a perfectly random RandomGen, the probability that each
         // particular combination failed to appear would be at most
         // 0.95 ^^ NUM which is approximately 1,962e-17.

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -428,7 +428,7 @@ if (isInputRange!(Unqual!R))
                     version(none)
                     {
                         typeof(this) opSlice(size_t lower, size_t upper) {
-                            return new typeof(this)(_range[lower..upper]);
+                            return new typeof(this)(_range[lower .. upper]);
                         }
                     }
                 }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -623,7 +623,7 @@ body
 
                     assert(translatedLower <= translatedUpper);
 
-                    return typeof(this)(source[translatedLower..translatedUpper], _n);
+                    return typeof(this)(source[translatedLower .. translatedUpper], _n);
                 }
 
             static if (hasLength!R)
@@ -696,22 +696,22 @@ pure @safe nothrow unittest
 
     // Test slicing.
     auto s1 = stride(arr, 1);
-    assert(equal(s1[1..4], [2, 3, 4]));
-    assert(s1[1..4].length == 3);
-    assert(equal(s1[1..5], [2, 3, 4, 5]));
-    assert(s1[1..5].length == 4);
-    assert(s1[0..0].empty);
-    assert(s1[3..3].empty);
+    assert(equal(s1[1 .. 4], [2, 3, 4]));
+    assert(s1[1 .. 4].length == 3);
+    assert(equal(s1[1 .. 5], [2, 3, 4, 5]));
+    assert(s1[1 .. 5].length == 4);
+    assert(s1[0 .. 0].empty);
+    assert(s1[3 .. 3].empty);
     // assert(s1[$ .. $].empty);
     assert(s1[s1.opDollar .. s1.opDollar].empty);
 
     auto s2 = stride(arr, 2);
-    assert(equal(s2[0..2], [1,3]));
-    assert(s2[0..2].length == 2);
-    assert(equal(s2[1..5], [3, 5, 7, 9]));
-    assert(s2[1..5].length == 4);
-    assert(s2[0..0].empty);
-    assert(s2[3..3].empty);
+    assert(equal(s2[0 .. 2], [1,3]));
+    assert(s2[0 .. 2].length == 2);
+    assert(equal(s2[1 .. 5], [3, 5, 7, 9]));
+    assert(s2[1 .. 5].length == 4);
+    assert(s2[0 .. 0].empty);
+    assert(s2[3 .. 3].empty);
     // assert(s2[$ .. $].empty);
     assert(s2[s2.opDollar .. s2.opDollar].empty);
 
@@ -1264,7 +1264,7 @@ pure @safe nothrow unittest
             );
 
             assert(myChain.front == 1);
-            foreach (i; 0..dummyLength)
+            foreach (i; 0 .. dummyLength)
             {
                 myChain.popFront();
             }
@@ -1574,7 +1574,7 @@ unittest
         assert(equal(s, [8, 9][]));
     }
     {
-        auto s = chooseAmong(1, arr2, arr1, arr3)[1..3];
+        auto s = chooseAmong(1, arr2, arr1, arr3)[1 .. 3];
         assert(s.length == 2);
         assert(equal(s, [2, 3][]));
     }
@@ -3850,7 +3850,7 @@ unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
-    assertThrown!AssertError(cycle([0, 1, 2][0..0]));
+    assertThrown!AssertError(cycle([0, 1, 2][0 .. 0]));
 }
 
 private alias lengthType(R) = typeof(R.init.length.init);
@@ -4756,7 +4756,7 @@ unittest
     auto l = lockstep(foo, bar);
 
     // Should work twice.  These are forward ranges with implicit save.
-    foreach (i; 0..2)
+    foreach (i; 0 .. 2)
     {
         uint[] res1;
         float[] res2;
@@ -5194,7 +5194,7 @@ unittest
         // The following groups all produce the same output of:
         // 0 1 2 3 4
 
-        foreach (i; 0..5)
+        foreach (i; 0 .. 5)
             writef("%s ", i);
         writeln();
 
@@ -5536,7 +5536,7 @@ unittest
     assert(r[$ - 1] == 9);
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][]));
 
-    auto rSlice = r[2..8];
+    auto rSlice = r[2 .. 8];
     assert(equal(rSlice, [2, 3, 4, 5, 6, 7]));
 
     rSlice.popFront();
@@ -5547,7 +5547,7 @@ unittest
     assert(rSlice[rSlice.length - 1] == rSlice.back);
     assert(rSlice.back == 6);
 
-    rSlice = r[0..4];
+    rSlice = r[0 .. 4];
     assert(equal(rSlice, [0, 1, 2, 3]));
 
     auto rr = iota(10);
@@ -5555,23 +5555,23 @@ unittest
 
     r = iota(0, -10, -1);
     assert(equal(r, [0, -1, -2, -3, -4, -5, -6, -7, -8, -9][]));
-    rSlice = r[3..9];
+    rSlice = r[3 .. 9];
     assert(equal(rSlice, [-3, -4, -5, -6, -7, -8]));
 
     r = iota(0, -6, -3);
     assert(equal(r, [0, -3][]));
-    rSlice = r[1..2];
+    rSlice = r[1 .. 2];
     assert(equal(rSlice, [-3]));
 
     r = iota(0, -7, -3);
     assert(equal(r, [0, -3, -6][]));
-    rSlice = r[1..3];
+    rSlice = r[1 .. 3];
     assert(equal(rSlice, [-3, -6]));
 
     r = iota(0, 11, 3);
     assert(equal(r, [0, 3, 6, 9][]));
     assert(r[2] == 6);
-    rSlice = r[1..3];
+    rSlice = r[1 .. 3];
     assert(equal(rSlice, [3, 6]));
 
     auto rf = iota(0.0, 0.5, 0.1);
@@ -5581,7 +5581,7 @@ unittest
     rf.popFront();
     assert(rf.length == 4);
 
-    auto rfSlice = rf[1..4];
+    auto rfSlice = rf[1 .. 4];
     assert(rfSlice.length == 3);
     assert(approxEqual(rfSlice, [0.2, 0.3, 0.4]));
 
@@ -5591,7 +5591,7 @@ unittest
     rf.popFront();
     assert(rf.length == 3);
 
-    rfSlice = rf[1..3];
+    rfSlice = rf[1 .. 3];
     assert(rfSlice.length == 2);
     assert(approxEqual(rfSlice, [0.3, 0.4]));
     assert(approxEqual(rfSlice[0], 0.3));
@@ -5607,7 +5607,7 @@ unittest
     // going down
     rf = iota(0.0, -0.5, -0.1);
     assert(approxEqual(rf, [0.0, -0.1, -0.2, -0.3, -0.4][]));
-    rfSlice = rf[2..5];
+    rfSlice = rf[2 .. 5];
     assert(approxEqual(rfSlice, [-0.2, -0.3, -0.4]));
 
     rf = iota(0.0, nextDown(-0.5), -0.1);
@@ -5999,7 +5999,7 @@ struct FrontTransversal(Ror,
         {
             typeof(this) opSlice(size_t lower, size_t upper)
             {
-                return typeof(this)(_input[lower..upper]);
+                return typeof(this)(_input[lower .. upper]);
             }
         }
     }
@@ -6057,8 +6057,8 @@ FrontTransversal!(RangeOfRanges, opt) frontTransversal(
         assert(equal(ft, [1, 2, 3, 4]));
 
         // Test slicing.
-        assert(equal(ft[0..2], [1, 2]));
-        assert(equal(ft[1..3], [2, 3]));
+        assert(equal(ft[0 .. 2], [1, 2]));
+        assert(equal(ft[1 .. 3], [2, 3]));
 
         assert(ft.front == ft.moveFront());
         assert(ft.back == ft.moveBack());
@@ -6331,7 +6331,7 @@ struct Transversal(Ror,
         {
             typeof(this) opSlice(size_t lower, size_t upper)
             {
-                return typeof(this)(_input[lower..upper], _n);
+                return typeof(this)(_input[lower .. upper], _n);
             }
         }
     }
@@ -6406,7 +6406,7 @@ Transversal!(RangeOfRanges, opt) transversal
     // Test w/o ref return.
     alias D = DummyRange!(ReturnBy.Value, Length.Yes, RangeType.Random);
     auto drs = [D.init, D.init];
-    foreach (num; 0..10)
+    foreach (num; 0 .. 10)
     {
         auto t = transversal!(TransverseOptions.enforceNotJagged)(drs, num);
         assert(t[0] == t[1]);
@@ -6417,7 +6417,7 @@ Transversal!(RangeOfRanges, opt) transversal
 
     // Test slicing.
     auto mat = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]];
-    auto mat1 = transversal!(TransverseOptions.assumeNotJagged)(mat, 1)[1..3];
+    auto mat1 = transversal!(TransverseOptions.assumeNotJagged)(mat, 1)[1 .. 3];
     assert(mat1[0] == 6);
     assert(mat1[1] == 10);
 }
@@ -7599,9 +7599,9 @@ unittest
         assert(!a.empty);
         assert(a.length == 1);
         assert(equal(a, a[]));
-        assert(equal(a, a[0..1]));
-        assert(equal(a[0..0], e));
-        assert(equal(a[1..1], e));
+        assert(equal(a, a[0 .. 1]));
+        assert(equal(a[0 .. 0], e));
+        assert(equal(a[1 .. 1], e));
         assert(a[0] == x);
 
         auto b = a.save;
@@ -7628,9 +7628,9 @@ unittest
     assert(imm.init.empty); // Issue 13441
     assert(imm.length == 1);
     assert(equal(imm, imm[]));
-    assert(equal(imm, imm[0..1]));
-    assert(equal(imm[0..0], imme));
-    assert(equal(imm[1..1], imme));
+    assert(equal(imm, imm[0 .. 1]));
+    assert(equal(imm[0 .. 0], imme));
+    assert(equal(imm[1 .. 1], imme));
     assert(imm[0] == 1);
 }
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -64,7 +64,7 @@ $(BOOKTABLE ,
     ))
     $(TR $(TD $(D $(LREF hasSlicing)))
         $(TD Tests if a given _range supports the array slicing operation $(D
-        R[x..y]).
+        R[x .. y]).
     ))
 )
 
@@ -315,7 +315,7 @@ void put(R, E)(ref R r, E e)
             doPut(r, arr[]);
         }
         else
-            doPut(r, (ref e) @trusted { return (&e)[0..1]; }(e));
+            doPut(r, (ref e) @trusted { return (&e)[0 .. 1]; }(e));
     }
     //special case for char to string.
     else static if (isSomeChar!E && is(typeof(putChar(r, e))))
@@ -533,7 +533,7 @@ unittest
     static struct PutC(C)
     {
         string result;
-        void put(const(C) c) { result ~= to!string((&c)[0..1]); }
+        void put(const(C) c) { result ~= to!string((&c)[0 .. 1]); }
     }
     static struct PutS(C)
     {

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -279,7 +279,7 @@ template BacktrackingMatcher(bool CTregex)
                 lastState = 0;
                 auto start = s._index;
                 debug(std_regex_matcher)
-                    writeln("Try match starting at ", s[index..s.lastIndex]);
+                    writeln("Try match starting at ", s[index .. s.lastIndex]);
                 for (;;)
                 {
                     debug(std_regex_matcher)
@@ -400,7 +400,7 @@ template BacktrackingMatcher(bool CTregex)
                     case IR.Eol:
                         dchar back;
                         DataIndex bi;
-                        debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index..s.lastIndex]);
+                        debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index .. s.lastIndex]);
                         //no matching inside \r\n
                         if (atEnd || (endOfLine(front, s.loopBack(index).nextChar(back,bi)
                                 && back == '\r')))
@@ -551,7 +551,7 @@ template BacktrackingMatcher(bool CTregex)
                         immutable len = re.ir[pc].data;
                         auto save = index;
                         immutable ms = re.ir[pc+1].raw, me = re.ir[pc+2].raw;
-                        auto mem = malloc(initialMemory(re))[0..initialMemory(re)];
+                        auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
                         scope(exit) free(mem.ptr);
                         static if (Stream.isLoopback)
                         {
@@ -580,7 +580,7 @@ template BacktrackingMatcher(bool CTregex)
                     case IR.NeglookbehindStart:
                         immutable len = re.ir[pc].data;
                         immutable ms = re.ir[pc+1].raw, me = re.ir[pc+2].raw;
-                        auto mem = malloc(initialMemory(re))[0..initialMemory(re)];
+                        auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
                         scope(exit) free(mem.ptr);
                         static if (Stream.isLoopback)
                         {
@@ -660,7 +660,7 @@ template BacktrackingMatcher(bool CTregex)
                 import core.stdc.stdlib : free;
                 free(memory.ptr);//last segment is freed in RegexMatch
                 immutable size = initialStack*(stateSize + 2*re.ngroup);
-                memory = prev[0..size];
+                memory = prev[0 .. size];
                 lastState = size;
                 return true;
             }
@@ -678,7 +678,7 @@ template BacktrackingMatcher(bool CTregex)
         void stackPush(T)(T[] val)
         {
             static assert(T.sizeof % size_t.sizeof == 0);
-            (cast(T*)&memory[lastState])[0..val.length]
+            (cast(T*)&memory[lastState])[0 .. val.length]
                 = val[0..$];
             lastState += val.length*(T.sizeof/size_t.sizeof);
             debug(std_regex_matcher) writeln("push array SP= ", lastState);
@@ -700,7 +700,7 @@ template BacktrackingMatcher(bool CTregex)
         void stackPop(T)(ref T[] val)
         {
             lastState -= val.length*(T.sizeof/size_t.sizeof);
-            val[0..$] = (cast(T*)&memory[lastState])[0..val.length];
+            val[0..$] = (cast(T*)&memory[lastState])[0 .. val.length];
             debug(std_regex_matcher) writeln("pop array SP= ", lastState);
         }
 
@@ -721,7 +721,7 @@ template BacktrackingMatcher(bool CTregex)
                 lastState += 2*matches.length;
                 debug(std_regex_matcher)
                     writefln("Saved(pc=%s) front: %s src: %s",
-                        pc, front, s[index..s.lastIndex]);
+                        pc, front, s[index .. s.lastIndex]);
             }
 
             //helper function, restores engine state
@@ -748,7 +748,7 @@ template BacktrackingMatcher(bool CTregex)
                 next();
                 debug(std_regex_matcher)
                     writefln("Backtracked (pc=%s) front: %s src: %s",
-                        pc, front, s[index..s.lastIndex]);
+                        pc, front, s[index .. s.lastIndex]);
                 return true;
             }
         }
@@ -902,7 +902,7 @@ struct CtContext
             //start/end codegen
             //r.addr is at last test+ jump of loop, addr+1 is body of loop
             nir = ir[ir[0].length + len .. $];
-            r.code = ctGenFixupCode(ir[0..ir[0].length], addr, r.addr) ~ r.code;
+            r.code = ctGenFixupCode(ir[0 .. ir[0].length], addr, r.addr) ~ r.code;
             r.code ~= ctGenFixupCode(nir, r.addr, addr+1);
             r.addr += 2;   //account end instruction + restore state
             ir = nir;
@@ -943,7 +943,7 @@ struct CtContext
                         //(neg)lookaround piece ends
                     }
                     auto save = index;
-                    auto mem = malloc(initialMemory(re))[0..initialMemory(re)];
+                    auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
                     scope(exit) free(mem.ptr);
                     static if (typeof(matcher.s).isLoopback)
                         auto lookaround = $$;
@@ -1368,7 +1368,7 @@ struct CtContext
             code ~= ctSub(`
                     dchar back;
                     DataIndex bi;
-                    debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index..s.lastIndex]);
+                    debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index .. s.lastIndex]);
                     //no matching inside \r\n
                     if (atEnd || (endOfLine(front, s.loopBack(index).nextChar(back,bi)
                              && back == '\r')))
@@ -1442,7 +1442,7 @@ struct CtContext
             auto start = s._index;`;
         r ~= `
             goto StartLoop;
-            debug(std_regex_matcher) writeln("Try CT matching  starting at ",s[index..s.lastIndex]);
+            debug(std_regex_matcher) writeln("Try CT matching  starting at ",s[index .. s.lastIndex]);
         L_backtrack:
             if (lastState || prevStack())
             {

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -635,7 +635,7 @@ if (is(Char :dchar))
     //support for backtracker engine, might not be present
     void reset(size_t index){   _index = index;  }
 
-    String opSlice(size_t start, size_t end){   return _origin[start..end]; }
+    String opSlice(size_t start, size_t end){   return _origin[start .. end]; }
 
     auto loopBack(size_t index){   return BackLooper!Input(this, index); }
 }
@@ -671,7 +671,7 @@ struct BackLooperImpl(Input)
     //void reset(size_t index){   _index = index ? index-std.utf.strideBack(_origin, index) : 0;  }
     void reset(size_t index){   _index = index;  }
 
-    String opSlice(size_t start, size_t end){   return _origin[end..start]; }
+    String opSlice(size_t start, size_t end){   return _origin[end .. start]; }
     //index of at End position
     @property size_t lastIndex(){   return 0; }
 }
@@ -699,7 +699,7 @@ template BackLooper(E)
 //very unsafe, no initialization
 @system T[] arrayInChunk(T)(size_t len, ref void[] chunk)
 {
-    auto ret = (cast(T*) chunk.ptr)[0..len];
+    auto ret = (cast(T*) chunk.ptr)[0 .. len];
     chunk = chunk[len * T.sizeof .. $];
     return ret;
 }
@@ -747,7 +747,7 @@ struct BitTable {
     this(CodepointSet set){
         foreach (iv; set.byInterval)
         {
-            foreach (v; iv.a..iv.b)
+            foreach (v; iv.a .. iv.b)
                 add(v);
         }
     }

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -203,7 +203,7 @@ public:
                     for (uint i = 0; i < len; i++)
                     {
                         auto x = charLen(re.ir[t.pc+i].data);
-                        if (countUntil(s[0..numS], x) < 0)
+                        if (countUntil(s[0 .. numS], x) < 0)
                            s[numS++] = x;
                     }
                     for (uint i = t.pc; i < end; i++)

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1513,7 +1513,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
             enforce(current < 0x80, "invalid property name");
             result[k++] = cast(char) current;
         }
-        auto s = getUnicodeSet(result[0..k], negated,
+        auto s = getUnicodeSet(result[0 .. k], negated,
             cast(bool)(re_flags & RegexOption.casefold));
         enforce(!s.empty, "unrecognized unicode property spec");
         next();

--- a/std/regex/internal/shiftor.d
+++ b/std/regex/internal/shiftor.d
@@ -204,7 +204,7 @@ public:
                     for (uint i = 0; i < len; i++)
                     {
                         auto x = charLen(re.ir[t.pc+i].data);
-                        if (countUntil(s[0..numS], x) < 0)
+                        if (countUntil(s[0 .. numS], x) < 0)
                            s[numS++] = x;
                     }
                     for (uint i = t.pc; i < end; i++)
@@ -264,7 +264,7 @@ public:
                     if (chars > charsetThreshold)
                         goto L_StopThread;
                     foreach (ival; set)
-                    foreach (ch; ival.a..ival.b)
+                    foreach (ch; ival.a .. ival.b)
                     {
                         //avoid surrogate pairs
                         if (0xD800 <= ch && ch <= 0xDFFF)

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -485,11 +485,11 @@ template ThompsonOps(E, S, bool withInput:true)
             {
                 size_t idx = source[n].begin + t.uopCounter;
                 size_t end = source[n].end;
-                if (s[idx..end].front == front)
+                if (s[idx .. end].front == front)
                 {
                     import std.utf : stride;
 
-                    t.uopCounter += stride(s[idx..end], 0);
+                    t.uopCounter += stride(s[idx .. end], 0);
                     if (t.uopCounter + source[n].begin == source[n].end)
                     {//last codepoint
                         t.pc += IRL!(IR.Backref);
@@ -855,14 +855,14 @@ if (is(Char : dchar))
     {
         s = stream;
         re = matcher.re;
-        re.ir = re.ir[lo..hi];
+        re.ir = re.ir[lo .. hi];
         threadSize = matcher.threadSize;
         merge = matcher.merge;
         freelist = matcher.freelist;
-        opCacheTrue = matcher.opCacheTrue[lo..hi];
-        opCacheBackTrue = matcher.opCacheBackTrue[lo..hi];
-        opCacheFalse = matcher.opCacheFalse[lo..hi];
-        opCacheBackFalse = matcher.opCacheBackFalse[lo..hi];
+        opCacheTrue = matcher.opCacheTrue[lo .. hi];
+        opCacheBackTrue = matcher.opCacheBackTrue[lo .. hi];
+        opCacheFalse = matcher.opCacheFalse[lo .. hi];
+        opCacheBackFalse = matcher.opCacheBackFalse[lo .. hi];
         front = matcher.front;
         index = matcher.index;
     }
@@ -871,14 +871,14 @@ if (is(Char : dchar))
     {
         s = stream;
         re = matcher.re;
-        re.ir = re.ir[lo..hi];
+        re.ir = re.ir[lo .. hi];
         threadSize = matcher.threadSize;
         merge = matcher.merge;
         freelist = matcher.freelist;
-        opCacheTrue = matcher.opCacheBackTrue[lo..hi];
-        opCacheBackTrue = matcher.opCacheTrue[lo..hi];
-        opCacheFalse = matcher.opCacheBackFalse[lo..hi];
-        opCacheBackFalse = matcher.opCacheFalse[lo..hi];
+        opCacheTrue = matcher.opCacheBackTrue[lo .. hi];
+        opCacheBackTrue = matcher.opCacheTrue[lo .. hi];
+        opCacheFalse = matcher.opCacheBackFalse[lo .. hi];
+        opCacheBackFalse = matcher.opCacheFalse[lo .. hi];
         front = matcher.front;
         index = matcher.index;
     }
@@ -950,7 +950,7 @@ if (is(Char : dchar))
                 genCounter++;
                 debug(std_regex_matcher)
                 {
-                    writefln("Threaded matching threads at  %s", s[index..s.lastIndex]);
+                    writefln("Threaded matching threads at  %s", s[index .. s.lastIndex]);
                     foreach (t; clist[])
                     {
                         assert(t);
@@ -1028,7 +1028,7 @@ if (is(Char : dchar))
     +/
     void finish(const(Thread!DataIndex)* t, Group!DataIndex[] matches, int code)
     {
-        matches.ptr[0..re.ngroup] = t.matches.ptr[0..re.ngroup];
+        matches.ptr[0 .. re.ngroup] = t.matches.ptr[0 .. re.ngroup];
         debug(std_regex_matcher)
         {
             writef("FOUND pc=%s prog_len=%s",
@@ -1073,7 +1073,7 @@ if (is(Char : dchar))
         {
             debug(std_regex_matcher)
             {
-                writefln("-- Threaded matching threads at  %s",  s[index..s.lastIndex]);
+                writefln("-- Threaded matching threads at  %s",  s[index .. s.lastIndex]);
             }
             if (startPc!=RestartPc)
             {
@@ -1167,7 +1167,7 @@ if (is(Char : dchar))
     Thread!DataIndex* fork(Thread!DataIndex* master, uint pc, uint counter)
     {
         auto t = allocate();
-        t.matches.ptr[0..re.ngroup] = master.matches.ptr[0..re.ngroup];
+        t.matches.ptr[0 .. re.ngroup] = master.matches.ptr[0 .. re.ngroup];
         t.pc = pc;
         t.counter = counter;
         t.uopCounter = 0;
@@ -1178,7 +1178,7 @@ if (is(Char : dchar))
     Thread!DataIndex* createStart(DataIndex index, uint pc = 0)
     {
         auto t = allocate();
-        t.matches.ptr[0..re.ngroup] = (Group!DataIndex).init;
+        t.matches.ptr[0 .. re.ngroup] = (Group!DataIndex).init;
         t.matches[0].begin = index;
         t.pc = pc;
         t.counter = 0;

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -472,7 +472,7 @@ private:
                 calloc(Group!DataIndex.sizeof,n),
                 "Failed to allocate Captures struct"
             );
-            big_matches = p[0..n];
+            big_matches = p[0 .. n];
             _refcount = 1;
         }
         else
@@ -670,7 +670,7 @@ private:
         import std.exception : enforce;
         _input = input;
         immutable size = EngineType.initialMemory(prog)+size_t.sizeof;
-        _memory = (enforce(malloc(size), "malloc failed")[0..size]);
+        _memory = (enforce(malloc(size), "malloc failed")[0 .. size]);
         scope(failure) free(_memory.ptr);
         *cast(size_t*)_memory.ptr = 1;
         _engine = EngineType(prog, Input!Char(input), _memory[size_t.sizeof..$]);
@@ -746,8 +746,8 @@ public:
         {//do cow magic first
             counter--;//we abandon this reference
             immutable size = EngineType.initialMemory(_engine.re)+size_t.sizeof;
-            _memory = (enforce(malloc(size), "malloc failed")[0..size]);
-            _engine = _engine.dupTo(_memory[size_t.sizeof..size]);
+            _memory = (enforce(malloc(size), "malloc failed")[0 .. size]);
+            _engine = _engine.dupTo(_memory[size_t.sizeof .. size]);
             counter = 1;//points to new chunk
         }
 
@@ -781,7 +781,7 @@ private @trusted auto matchOnce(alias Engine, RegEx, R)(R input, RegEx re)
     alias EngineType = Engine!Char;
 
     size_t size = EngineType.initialMemory(re);
-    void[] memory = enforce(malloc(size), "malloc failed")[0..size];
+    void[] memory = enforce(malloc(size), "malloc failed")[0 .. size];
     scope(exit) free(memory.ptr);
     auto captures = Captures!(R, EngineType.DataIndex)(input, re.ngroup, re.dict);
     auto engine = EngineType(re, Input!Char(input), memory);

--- a/std/socket.d
+++ b/std/socket.d
@@ -1454,7 +1454,7 @@ public:
     /// Constructs an $(D Address) with a copy of the specified $(D sockaddr).
     this(const(sockaddr)* sa, socklen_t len) @system pure nothrow
     {
-        this.sa = cast(sockaddr*) (cast(ubyte*) sa)[0..len].dup.ptr;
+        this.sa = cast(sockaddr*) (cast(ubyte*) sa)[0 .. len].dup.ptr;
         this.len = len;
     }
 
@@ -1981,7 +1981,7 @@ static if (is(sockaddr_un))
         {
             enforce(path.length <= sun.sun_path.sizeof, new SocketParameterException("Path too long"));
             sun.sun_family = AddressFamily.UNIX;
-            sun.sun_path.ptr[0..path.length] = (cast(byte[]) path)[];
+            sun.sun_path.ptr[0 .. path.length] = (cast(byte[]) path)[];
             sun.sun_path.ptr[path.length] = 0;
         }
 
@@ -2154,7 +2154,7 @@ private:
 
         inout(socket_t)[] fds() @trusted inout @property pure nothrow @nogc
         {
-            return cast(inout(socket_t)[])set[FD_SET_OFFSET..FD_SET_OFFSET+count];
+            return cast(inout(socket_t)[])set[FD_SET_OFFSET .. FD_SET_OFFSET+count];
         }
     }
     else
@@ -2469,7 +2469,7 @@ public:
     assert(set.max >= 0);
 
     enum LIMIT = 4096;
-    foreach (n; 0..LIMIT)
+    foreach (n; 0 .. LIMIT)
         set.add(cast(socket_t) n);
     assert(set.max >= LIMIT);
 }
@@ -3142,7 +3142,7 @@ public:
         else version (Posix)
         {
             TimeVal tv;
-            getOption(level, option, (&tv.ctimeval)[0..1]);
+            getOption(level, option, (&tv.ctimeval)[0 .. 1]);
             result = dur!"seconds"(tv.seconds) + dur!"usecs"(tv.microseconds);
         }
         else static assert(false);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2869,7 +2869,7 @@ See $(LREF byChunk) for an example.
         if (!hasIndirections!T &&
             !isInputRange!T)
         {
-            rawWrite((&value)[0..1]);
+            rawWrite((&value)[0 .. 1]);
         }
 
         void put(T)(in T[] array)
@@ -4455,8 +4455,8 @@ private struct ReadlnAppender
     @property char[] data() @trusted
     {
         if (safeAppend)
-            assumeSafeAppend(buf.ptr[0..pos]);
-        return buf.ptr[0..pos];
+            assumeSafeAppend(buf.ptr[0 .. pos]);
+        return buf.ptr[0 .. pos];
     }
 
     bool reserveWithoutAllocating(size_t n)
@@ -4614,7 +4614,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
                     goto L1;
                 }
             }
-            app.putonly(p[0..i]);
+            app.putonly(p[0 .. i]);
             app.buf[i - 1] = cast(char) terminator;
             if (terminator == '\n' && c == '\r')
                 i++;
@@ -4630,7 +4630,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
                 if (c == terminator)
                     break;
             }
-            app.putonly(p[0..i]);
+            app.putonly(p[0 .. i]);
         }
         fp._cnt -= i;
         fp._ptr += i;
@@ -4889,7 +4889,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     f.readln(ln);
 
     assert(ln == "abcd\n");
-    char[] t = ln[0..2];
+    char[] t = ln[0 .. 2];
     t ~= 't';
     assert(t == "abt");
     assert(ln == "abcd\n");  // bug 13856: ln stomped to "abtd"

--- a/std/string.d
+++ b/std/string.d
@@ -286,7 +286,7 @@ body
 
     // Need to make a copy
     auto copy = new char[s.length + 1];
-    copy[0..s.length] = s[];
+    copy[0 .. s.length] = s[];
     copy[s.length] = 0;
 
     return &assumeUnique(copy)[0];
@@ -321,7 +321,7 @@ pure nothrow unittest
     auto p = toStringz("foo");
     assert(strlen(p) == 3);
     const(char)[] foo = "abbzxyzzy";
-    p = toStringz(foo[3..5]);
+    p = toStringz(foo[3 .. 5]);
     assert(strlen(p) == 2);
 
     string test = "";
@@ -5946,19 +5946,19 @@ if (isSomeString!S ||
             if (!sawDigits)
                 return false;
             // Integer Whole Number
-            if (asciiCmp(codeUnits[i..iLen], "ul") &&
+            if (asciiCmp(codeUnits[i .. iLen], "ul") &&
                     (!bDecimalPoint && !bExponent && !bComplex))
                 return true;
             // Floating-Point Number
-            if (codeUnits[i..iLen].among!((a, b) => asciiCmp(a, b))("fi", "li") &&
+            if (codeUnits[i .. iLen].among!((a, b) => asciiCmp(a, b))("fi", "li") &&
                     (bDecimalPoint || bExponent || bComplex))
                 return true;
-            if (asciiCmp(codeUnits[i..iLen], "ul") &&
+            if (asciiCmp(codeUnits[i .. iLen], "ul") &&
                     (bDecimalPoint || bExponent || bComplex))
                 return false;
             // Could be a Integer or a Float, thus
             // all these suffixes are valid for both
-            return codeUnits[i..iLen].among!((a, b) => asciiCmp(a, b))
+            return codeUnits[i .. iLen].among!((a, b) => asciiCmp(a, b))
                 ("ul", "fi", "li") != 0;
         }
         if (i == iLen - 1)
@@ -6111,7 +6111,7 @@ if (isSomeString!S ||
     assert(isNumeric("12345xxxx890") == false );
     assert(isNumeric("567L") == true );
     assert(isNumeric("23UL") == true );
-    assert(isNumeric("-123..56f") == false );
+    assert(isNumeric("-123 .. 56f") == false );
     assert(isNumeric("12.3.5.6") == false );
     assert(isNumeric(" 12.356") == false );
     assert(isNumeric("123 5.6") == false );
@@ -6139,9 +6139,9 @@ if (isSomeString!S ||
   }
 
     string s = "$250.99-";
-    assert(isNumeric(s[1..s.length - 2]) == true);
+    assert(isNumeric(s[1 .. s.length - 2]) == true);
     assert(isNumeric(s) == false);
-    assert(isNumeric(s[0..s.length - 1]) == false);
+    assert(isNumeric(s[0 .. s.length - 1]) == false);
     });
 
     assert(!isNumeric("-"));

--- a/std/string.d
+++ b/std/string.d
@@ -6111,7 +6111,7 @@ if (isSomeString!S ||
     assert(isNumeric("12345xxxx890") == false );
     assert(isNumeric("567L") == true );
     assert(isNumeric("23UL") == true );
-    assert(isNumeric("-123 .. 56f") == false );
+    assert(isNumeric("-123..56f") == false );
     assert(isNumeric("12.3.5.6") == false );
     assert(isNumeric(" 12.356") == false );
     assert(isNumeric("123 5.6") == false );

--- a/std/traits.d
+++ b/std/traits.d
@@ -1134,9 +1134,9 @@ template ParameterIdentifierTuple(func...)
         {
             static if (!isFunctionPointer!func && !isDelegate!func
                        // Unnamed parameters yield CT error.
-                       && is(typeof(__traits(identifier, PT[i..i+1]))))
+                       && is(typeof(__traits(identifier, PT[i .. i+1]))))
             {
-                enum Get = __traits(identifier, PT[i..i+1]);
+                enum Get = __traits(identifier, PT[i .. i+1]);
             }
             else
             {
@@ -1222,7 +1222,7 @@ template ParameterDefaults(func...)
             // workaround scope escape check, see
             // https://issues.dlang.org/show_bug.cgi?id=16582
             // should use return scope once available
-            enum get = (PT[i..i+1] __args) @trusted
+            enum get = (PT[i .. i+1] __args) @trusted
             {
                 // If __args[0] is lazy, we force it to be evaluated like this.
                 PT[i] __pd_value = __args[0];

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5646,12 +5646,12 @@ mixin template Proxy(alias a)
 
     auto ref opIndex(this X, D...)(auto ref D i)               { return a[i]; }
     auto ref opSlice(this X      )()                           { return a[]; }
-    auto ref opSlice(this X, B, E)(auto ref B b, auto ref E e) { return a[b..e]; }
+    auto ref opSlice(this X, B, E)(auto ref B b, auto ref E e) { return a[b .. e]; }
 
     auto ref opUnary     (string op, this X      )()                           { return mixin(op~"a"); }
     auto ref opIndexUnary(string op, this X, D...)(auto ref D i)               { return mixin(op~"a[i]"); }
     auto ref opSliceUnary(string op, this X      )()                           { return mixin(op~"a[]"); }
-    auto ref opSliceUnary(string op, this X, B, E)(auto ref B b, auto ref E e) { return mixin(op~"a[b..e]"); }
+    auto ref opSliceUnary(string op, this X, B, E)(auto ref B b, auto ref E e) { return mixin(op~"a[b .. e]"); }
 
     auto ref opBinary(string op, this X, B)(auto ref B b)
     if (op == "in" && is(typeof(a in b)) || op != "in")
@@ -5680,12 +5680,12 @@ mixin template Proxy(alias a)
     auto ref opAssign     (this X, V      )(auto ref V v) if (!is(V == typeof(this))) { return a       = v; }
     auto ref opIndexAssign(this X, V, D...)(auto ref V v, auto ref D i)               { return a[i]    = v; }
     auto ref opSliceAssign(this X, V      )(auto ref V v)                             { return a[]     = v; }
-    auto ref opSliceAssign(this X, V, B, E)(auto ref V v, auto ref B b, auto ref E e) { return a[b..e] = v; }
+    auto ref opSliceAssign(this X, V, B, E)(auto ref V v, auto ref B b, auto ref E e) { return a[b .. e] = v; }
 
     auto ref opOpAssign     (string op, this X, V      )(auto ref V v)                             { return mixin("a "      ~op~"= v"); }
     auto ref opIndexOpAssign(string op, this X, V, D...)(auto ref V v, auto ref D i)               { return mixin("a[i] "   ~op~"= v"); }
     auto ref opSliceOpAssign(string op, this X, V      )(auto ref V v)                             { return mixin("a[] "    ~op~"= v"); }
-    auto ref opSliceOpAssign(string op, this X, V, B, E)(auto ref V v, auto ref B b, auto ref E e) { return mixin("a[b..e] "~op~"= v"); }
+    auto ref opSliceOpAssign(string op, this X, V, B, E)(auto ref V v, auto ref B b, auto ref E e) { return mixin("a[b .. e] "~op~"= v"); }
 
     template opDispatch(string name)
     {
@@ -5893,17 +5893,17 @@ mixin template Proxy(alias a)
         assert(a ~ [10,11] == [1,2,3,4,10,11]);
         assert(a[0]    == 1);
         assert(a[]     == [1,2,3,4]);
-        assert(a[2..4] == [3,4]);
+        assert(a[2 .. 4] == [3,4]);
         static if (is(T == MyArray))    // mutable
         {
             a = a;
             a = [5,6,7,8];  assert(a == [5,6,7,8]);
             a[0]     = 0;   assert(a == [0,6,7,8]);
             a[]      = 1;   assert(a == [1,1,1,1]);
-            a[0..3]  = 2;   assert(a == [2,2,2,1]);
+            a[0 .. 3]  = 2;   assert(a == [2,2,2,1]);
             a[0]    += 2;   assert(a == [4,2,2,1]);
             a[]     *= 2;   assert(a == [8,4,4,2]);
-            a[0..2] /= 2;   assert(a == [4,2,4,2]);
+            a[0 .. 2] /= 2;   assert(a == [4,2,4,2]);
         }
     }
 }
@@ -6063,7 +6063,7 @@ mixin template Proxy(alias a)
     assert(f[1] == 'e');
 
     // opSlice
-    assert(f[2..4] == "ll");
+    assert(f[2 .. 4] == "ll");
 
     // opUnary
     assert(-(cast(MyClass2) c) == -5);
@@ -6384,11 +6384,11 @@ template TypedefType(T)
     static assert(typeof(sa).length == 3);
 
     Typedef!(int[3]) dollar1;
-    assert(dollar1[0..$] is dollar1[0..3]);
+    assert(dollar1[0..$] is dollar1[0 .. 3]);
 
     Typedef!(int[]) dollar2;
     dollar2.length = 3;
-    assert(dollar2[0..$] is dollar2[0..3]);
+    assert(dollar2[0..$] is dollar2[0 .. 3]);
 
     static struct Dollar1
     {
@@ -6400,7 +6400,7 @@ template TypedefType(T)
 
     Typedef!Dollar1 drange1;
     assert(drange1[0..$] == 1);
-    assert(drange1[0..1] == 2);
+    assert(drange1[0 .. 1] == 2);
 
     static struct Dollar2
     {

--- a/std/uni.d
+++ b/std/uni.d
@@ -855,11 +855,11 @@ struct MultiArray(Types...)
                     // len includes delta
                     size_t len = (storage.ptr+storage.length-start);
 
-                    copyBackwards(start[0..len-delta], start[delta..len]);
+                    copyBackwards(start[0 .. len-delta], start[delta .. len]);
 
-                    start[0..delta] = 0;
+                    start[0 .. delta] = 0;
                     // offsets are used for raw_slice, ptr etc.
-                    foreach (i; n+1..dim)
+                    foreach (i; n+1 .. dim)
                         offsets[i] += delta;
                 }
             }
@@ -873,10 +873,10 @@ struct MultiArray(Types...)
                 {
                     auto start = raw_ptr!(n+1);
                     size_t len = (storage.ptr+storage.length-start);
-                    copyForward(start[0..len-delta], start[delta..len]);
+                    copyForward(start[0 .. len-delta], start[delta .. len]);
 
                     // adjust offsets last, they affect raw_slice
-                    foreach (i; n+1..dim)
+                    foreach (i; n+1 .. dim)
                         offsets[i] -= delta;
                 }
                 storage.length -= delta;
@@ -932,25 +932,25 @@ private:
 
         static void check(size_t k, T)(ref T m, int n)
         {
-            foreach (i; 0..n)
-                assert(m.slice!(k)[i] == i+1, text("level:",i," : ",m.slice!(k)[0..n]));
+            foreach (i; 0 .. n)
+                assert(m.slice!(k)[i] == i+1, text("level:",i," : ",m.slice!(k)[0 .. n]));
         }
 
         static void checkB(size_t k, T)(ref T m, int n)
         {
-            foreach (i; 0..n)
-                assert(m.slice!(k)[i] == n-i, text("level:",i," : ",m.slice!(k)[0..n]));
+            foreach (i; 0 .. n)
+                assert(m.slice!(k)[i] == n-i, text("level:",i," : ",m.slice!(k)[0 .. n]));
         }
 
         static void fill(size_t k, T)(ref T m, int n)
         {
-            foreach (i; 0..n)
+            foreach (i; 0 .. n)
                 m.slice!(k)[i] = force!ubyte(i+1);
         }
 
         static void fillB(size_t k, T)(ref T m, int n)
         {
-            foreach (i; 0..n)
+            foreach (i; 0 .. n)
                 m.slice!(k)[i] = force!ubyte(n-i);
         }
 
@@ -1225,7 +1225,7 @@ pure nothrow:
         immutable pad_s = roundUp(s);
         if ( s >= e)
         {
-            foreach (i; s..e)
+            foreach (i; s .. e)
                 if (ptr[i])
                     return false;
             return true;
@@ -1297,7 +1297,7 @@ pure nothrow:
         if (pad_start >= end) //rounded up >= then end of slice
         {
             //nothing to gain, use per element assignment
-            foreach (i; start..end)
+            foreach (i; start .. end)
                 ptr[i] = val;
             return;
         }
@@ -1361,7 +1361,7 @@ private:
 private struct SliceOverIndexed(T)
 {
     enum assignableIndex = is(typeof((){ T.init[0] = Item.init; }));
-    enum assignableSlice = is(typeof((){ T.init[0..0] = Item.init; }));
+    enum assignableSlice = is(typeof((){ T.init[0 .. 0] = Item.init; }));
     auto opIndex(size_t idx)const
     in
     {
@@ -1481,8 +1481,8 @@ if (is(Unqual!T == T))
 
     int[] other = [2, 5];
     assert(sliced[] == sliceOverIndexed(1, 2, &other));
-    sliceOverIndexed(0, 2, &idxArray)[0..2] = -1;
-    assert(idxArray[0..2] == [-1, -1]);
+    sliceOverIndexed(0, 2, &idxArray)[0 .. 2] = -1;
+    assert(idxArray[0 .. 2] == [-1, -1]);
     uint[] nullArr = null;
     auto nullSlice = sliceOverIndexed(0, 0, &idxArray);
     assert(nullSlice.empty);
@@ -1509,7 +1509,7 @@ string genUnrolledSwitchSearch(size_t size) @safe pure nothrow
     auto power = bsr(m)+1;
     switch (power){`;
     size_t i = bsr(size);
-    foreach_reverse (val; 0..bsr(size))
+    foreach_reverse (val; 0 .. bsr(size))
     {
         auto v = 2^^val;
         code ~= `
@@ -1590,7 +1590,7 @@ template sharMethod(alias uniLowerBound)
             return range.length - k + uniLowerBound!pred(range[$-k..$], needle);
         }
         else
-            return uniLowerBound!pred(range[0..n], needle);
+            return uniLowerBound!pred(range[0 .. n], needle);
     }
 }
 
@@ -1609,7 +1609,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     immutable MAX = 5*1173;
     auto arr = array(iota(5, MAX, 5));
     assert(arr.length == MAX/5-1);
-    foreach (i; 0..MAX+5)
+    foreach (i; 0 .. MAX+5)
     {
         auto st = stdLowerBound(arr, i);
         assert(st == sharLowerBound(arr, i));
@@ -1640,20 +1640,20 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
             dest.length = dest.length+delta;//@@@BUG lame @property
         else
             dest = Policy.realloc(dest, dest.length+delta);
-        copyBackwards(dest[to..dest.length-delta],
-            dest[to+delta..dest.length]);
-        copyForward(stuff, dest[from..stuff_end]);
+        copyBackwards(dest[to .. dest.length-delta],
+            dest[to+delta .. dest.length]);
+        copyForward(stuff, dest[from .. stuff_end]);
     }
     else if (stuff.length == delta)
     {
-        copy(stuff, dest[from..to]);
+        copy(stuff, dest[from .. to]);
     }
     else
     {// replace decreases length by delta
         delta = delta - stuff.length;
-        copy(stuff, dest[from..stuff_end]);
-        copyForward(dest[to..dest.length],
-            dest[stuff_end..dest.length-delta]);
+        copy(stuff, dest[from .. stuff_end]);
+        copyForward(dest[to .. dest.length],
+            dest[stuff_end .. dest.length-delta]);
         static if (is(Policy == void))
             dest.length = dest.length - delta;//@@@BUG lame @property
         else
@@ -1741,7 +1741,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         if (overflow) assert(0);
 
         auto ptr = cast(T*) enforce(malloc(nbytes), "out of memory on C heap");
-        return ptr[0..size];
+        return ptr[0 .. size];
     }
 
     static T[] realloc(T)(T[] arr, size_t size)
@@ -1760,7 +1760,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         if (overflow) assert(0);
 
         auto ptr = cast(T*) enforce(realloc(arr.ptr, nbytes), "out of memory on C heap");
-        return ptr[0..size];
+        return ptr[0 .. size];
     }
 
     static void replaceImpl(T, Range)(ref T[] dest, size_t from, size_t to, Range stuff)
@@ -2341,7 +2341,7 @@ public:
         Example:
         ---
         import std.conv;
-        assert(unicode.ASCII.to!string == "[0..128$(RPAREN)");
+        assert(unicode.ASCII.to!string == "[0 .. 128$(RPAREN)");
         ---
     */
 
@@ -2352,9 +2352,9 @@ public:
      * in form of open-right intervals.
      *
      * The formatting flag is applied individually to each value, for example:
-     * $(LI $(B %s) and $(B %d) format the intervals as a [low..high$(RPAREN) range of integrals)
-     * $(LI $(B %x) formats the intervals as a [low..high$(RPAREN) range of lowercase hex characters)
-     * $(LI $(B %X) formats the intervals as a [low..high$(RPAREN) range of uppercase hex characters)
+     * $(LI $(B %s) and $(B %d) format the intervals as a [low .. high$(RPAREN) range of integrals)
+     * $(LI $(B %x) formats the intervals as a [low .. high$(RPAREN) range of lowercase hex characters)
+     * $(LI $(B %X) formats the intervals as a [low .. high$(RPAREN) range of uppercase hex characters)
      */
     void toString(Writer)(scope Writer sink,
                   FormatSpec!char fmt) /* const */
@@ -2387,18 +2387,18 @@ public:
         import std.uni : unicode;
 
         assert(unicode.Cyrillic.to!string ==
-            "[1024..1157) [1159..1320) [7467..7468) [7544..7545) [11744..11776) [42560..42648) [42655..42656)");
+            "[1024 .. 1157) [1159 .. 1320) [7467 .. 7468) [7544 .. 7545) [11744 .. 11776) [42560 .. 42648) [42655 .. 42656)");
 
         // The specs '%s' and '%d' are equivalent to the to!string call above.
         assert(format("%d", unicode.Cyrillic) == unicode.Cyrillic.to!string);
 
         assert(format("%#x", unicode.Cyrillic) ==
-            "[0x400..0x485) [0x487..0x528) [0x1d2b..0x1d2c) [0x1d78..0x1d79) [0x2de0..0x2e00) "
-            ~"[0xa640..0xa698) [0xa69f..0xa6a0)");
+            "[0x400 .. 0x485) [0x487 .. 0x528) [0x1d2b .. 0x1d2c) [0x1d78 .. 0x1d79) [0x2de0 .. 0x2e00) "
+            ~"[0xa640 .. 0xa698) [0xa69f .. 0xa6a0)");
 
         assert(format("%#X", unicode.Cyrillic) ==
-            "[0X400..0X485) [0X487..0X528) [0X1D2B..0X1D2C) [0X1D78..0X1D79) [0X2DE0..0X2E00) "
-            ~"[0XA640..0XA698) [0XA69F..0XA6A0)");
+            "[0X400 .. 0X485) [0X487 .. 0X528) [0X1D2B .. 0X1D2C) [0X1D78 .. 0X1D79) [0X2DE0 .. 0X2E00) "
+            ~"[0XA640 .. 0XA698) [0XA69F .. 0XA6A0)");
     }
 
     @safe unittest
@@ -2647,7 +2647,7 @@ public:
             string result = indent~"{\n";
             // less branch, < a
             result ~= format("%sif (ch < %s)\n%s",
-                deeper, range[idx][0], binaryScope(range[0..idx], deeper));
+                deeper, range[idx][0], binaryScope(range[0 .. idx], deeper));
             // middle point,  >= a && < b
             result ~= format("%selse if (ch < %s) return true;\n",
                 deeper, range[idx][1]);
@@ -2854,7 +2854,7 @@ private:
             data.append(a, b);
             return data.length-1;
         }
-        size_t b_idx = range[a_idx..range.length].lowerBound!(SearchPolicy.gallop)(b).length+a_idx;
+        size_t b_idx = range[a_idx .. range.length].lowerBound!(SearchPolicy.gallop)(b).length+a_idx;
         uint[3] buf = void;
         uint to_insert;
         debug(std_uni)
@@ -2876,7 +2876,7 @@ private:
                 buf[1] = b;
                 to_insert = 2;
             }
-            pos = genericReplace(data, a_idx, b_idx, buf[0..to_insert]);
+            pos = genericReplace(data, a_idx, b_idx, buf[0 .. to_insert]);
             return pos - 1;
         }
 
@@ -2904,7 +2904,7 @@ private:
                 {
                     assert(b_idx+1 < data.length);
                     buf[0] = data[b_idx+1];
-                    pos = genericReplace(data, a_idx, b_idx+2, buf[0..1]);
+                    pos = genericReplace(data, a_idx, b_idx+2, buf[0 .. 1]);
                     return pos - 1;
                 }
                 buf[0] = b;
@@ -2931,7 +2931,7 @@ private:
                     assert(b_idx+1 < data.length);
                     buf[0] = a;
                     buf[1] = data[b_idx+1];
-                    pos = genericReplace(data, a_idx, b_idx+2, buf[0..2]);
+                    pos = genericReplace(data, a_idx, b_idx+2, buf[0 .. 2]);
                     return pos - 1;
                 }
                 buf[0] = a;
@@ -2940,11 +2940,11 @@ private:
                 to_insert = 3;
             }
         }
-        pos = genericReplace(data, a_idx, b_idx+1, buf[0..to_insert]);
+        pos = genericReplace(data, a_idx, b_idx+1, buf[0 .. to_insert]);
         debug(std_uni)
         {
             writefln("marker idx: %d; length=%d", pos, data[pos], data.length);
-            writeln("inserting ", buf[0..to_insert]);
+            writeln("inserting ", buf[0 .. to_insert]);
         }
         return pos - 1;
     }
@@ -2957,7 +2957,7 @@ private:
     }
     body
     {
-        auto range = assumeSorted!"a<=b"(data[pos..data.length]);
+        auto range = assumeSorted!"a<=b"(data[pos .. data.length]);
         if (range.empty)
             return pos;
         size_t idx = pos;
@@ -2995,7 +2995,7 @@ private:
     body
     {
         assert(data.length % 2 == 0);
-        auto range = assumeSorted!"a<=b"(data[pos..data.length]);
+        auto range = assumeSorted!"a<=b"(data[pos .. data.length]);
         size_t idx = pos+range.lowerBound(a).length;
 
         if (idx >= data.length) // could have Marker point to recently removed stuff
@@ -3023,7 +3023,7 @@ private:
 @system unittest
 {
     import std.conv : to;
-    assert(unicode.ASCII.to!string() == "[0..128)");
+    assert(unicode.ASCII.to!string() == "[0 .. 128)");
 }
 
 // pedantic version for ctfe, and aligned-access only architectures
@@ -3179,7 +3179,7 @@ struct CowArray(SP=GcPolicy)
             auto new_data = SP.alloc!uint(total);
             // take shrinking into account
             auto to_copy = min(total, data.length) - 1;
-            copy(data[0..to_copy], new_data[0..to_copy]);
+            copy(data[0 .. to_copy], new_data[0 .. to_copy]);
             data = new_data; // before setting refCount!
             refCount = 1;
         }
@@ -3242,7 +3242,7 @@ struct CowArray(SP=GcPolicy)
     {
         size_t nl = length + range.length;
         length = nl;
-        copy(range, this[nl-range.length..nl]);
+        copy(range, this[nl-range.length .. nl]);
     }
 
     void append()(uint[] val...)
@@ -3380,13 +3380,13 @@ private:
         assert(arr[0] == 72);
         assert(arr2[0] == 11);
         // set this to about 100M to stress-test COW memory management
-        foreach (v; 0..10_000)
+        foreach (v; 0 .. 10_000)
             func2(arr);
         assert(equal(arr[], [72, 0xFE_FEFE, 100]));
 
         auto r2 = U24A(iota(0, 100));
         assert(equal(r2[], iota(0, 100)), text(r2[]));
-        copy(iota(10, 170, 2), r2[10..90]);
+        copy(iota(10, 170, 2), r2[10 .. 90]);
         assert(equal(r2[], chain(iota(0, 10), iota(10, 170, 2), iota(90, 100)))
                , text(r2[]));
     }
@@ -3681,7 +3681,7 @@ auto arrayRepr(T)(T x)
     import std.conv : text;
     if (x.length > 32)
     {
-        return text(x[0..16],"~...~", x[x.length-16..x.length]);
+        return text(x[0 .. 16],"~...~", x[x.length-16 .. x.length]);
     }
     else
         return text(x);
@@ -3806,7 +3806,7 @@ private:
         immutable n =  nextPB - j;// can fill right in this page
         if (numVals < n) //fits in current page
         {
-            ptr[j..j+numVals]  = val;
+            ptr[j .. j+numVals]  = val;
             j += numVals;
             return;
         }
@@ -3814,7 +3814,7 @@ private:
         {
             numVals -= n;
             //write till the end of current page
-            ptr[j..j+n]  = val;
+            ptr[j .. j+n]  = val;
             j += n;
             //spill to the next page
             spillToNextPage!level(ptr);
@@ -3832,7 +3832,7 @@ private:
                 while (numVals >= pageSize)
                 {
                     numVals -= pageSize;
-                    ptr[j..j+pageSize]  = val;
+                    ptr[j .. j+pageSize]  = val;
                     j += pageSize;
                     spillToNextPage!level(ptr);
                 }
@@ -3840,7 +3840,7 @@ private:
             if (numVals)
             {
                 // the leftovers, an incomplete page
-                ptr[j..j+numVals]  = val;
+                ptr[j .. j+numVals]  = val;
                 j += numVals;
             }
         }
@@ -3863,11 +3863,11 @@ private:
         enum pageSize = 1<<Prefix[level].bitSize;
         assert(idx!level % pageSize == 0);
         immutable last = idx!level-pageSize;
-        const slice = ptr[idx!level - pageSize..idx!level];
+        const slice = ptr[idx!level - pageSize .. idx!level];
         size_t j;
         for (j=0; j<last; j+=pageSize)
         {
-            if (ptr[j..j+pageSize] == slice)
+            if (ptr[j .. j+pageSize] == slice)
             {
                 // get index to it, reuse ptr space for the next block
                 next_lvl_index = force!NextIdx(j/pageSize);
@@ -3878,9 +3878,9 @@ private:
                         ,level
                         ,indices[level-1], pageSize, j, j+pageSize);
                 writeln("LEVEL(", level
-                        , ") mapped page is: ", slice, ": ", arrayRepr(ptr[j..j+pageSize]));
+                        , ") mapped page is: ", slice, ": ", arrayRepr(ptr[j .. j+pageSize]));
                 writeln("LEVEL(", level
-                        , ") src page is :", ptr, ": ", arrayRepr(slice[0..pageSize]));
+                        , ") src page is :", ptr, ": ", arrayRepr(slice[0 .. pageSize]));
                 }
                 idx!level -= pageSize; // reuse this page, it is duplicate
                 break;
@@ -3899,7 +3899,7 @@ private:
             {
             import std.stdio : writefln;
             writefln("LEVEL(%s) page allocated: %s"
-                     , level, arrayRepr(slice[0..pageSize]));
+                     , level, arrayRepr(slice[0 .. pageSize]));
             writefln("LEVEL(%s) index: %s ; page at this index %s"
                      , level
                      , next_lvl_index
@@ -4267,7 +4267,7 @@ if (sumOfIntegerTuple!sizes == 21)
         // e.g. arabic letter DDAL (\u0688) has a "luck factor" of 2
         ubyte[6] nibbles; // 6 4-bit chunks of code point
         uint value = ch;
-        foreach (i; 0..6)
+        foreach (i; 0 .. 6)
         {
             nibbles[i] = value & 0xF;
             value >>= 4;
@@ -4676,9 +4676,9 @@ template Utf8Matcher()
         std.utf.encode(buf, ch);
         char[sz] ret;
         buf[0] &= leadMask!sz;
-        foreach (n; 1..sz)
+        foreach (n; 1 .. sz)
             buf[n] = buf[n] & 0x3f; //keep 6 lower bits
-        ret[] = buf[0..sz];
+        ret[] = buf[0 .. sz];
         return ret;
     }
 
@@ -4857,7 +4857,7 @@ template Utf8Matcher()
             else static if (size == 4)
             {
                 //0x800-0xFFFF
-                //got 2x6=12 bits in needle[2..3] must use at least 17bits
+                //got 2x6=12 bits in needle[2 .. 3] must use at least 17bits
                 //must use 5 bits (or above) in needle[1] or anything in needle[0]
                 if (needle[0] == 0 && needle[1] < 0x10) badEncoding();
             }
@@ -5197,7 +5197,7 @@ if (is(C : wchar) || is(C : char))
         auto opIndex(size_t i){ return str[idx+i]; }
         @property size_t length(){ return str.length - idx; }
         alias opDollar = length;
-        auto opSlice(size_t a, size_t b){ return Decoder(str[0..idx+b], idx+a); }
+        auto opSlice(size_t a, size_t b){ return Decoder(str[0 .. idx+b], idx+a); }
     }
     static assert(isRandomAccessRange!Decoder);
     static assert(is(ElementType!Decoder : C));
@@ -5229,7 +5229,7 @@ if (is(C : wchar) || is(C : char))
     assert(!utf8.test(codec));
     assert(!utf8.skip(codec));
     assert(utf8.test(codec));
-    foreach (i; 0..7)
+    foreach (i; 0 .. 7)
     {
         assert(!asc.test(codec));
         assert(uni.test(codec));
@@ -5248,7 +5248,7 @@ if (is(C : wchar) || is(C : char))
     assert(!utf8.skip(codec));
     assert(!utf8.skip(codec));
 
-    foreach (i; 0..7)
+    foreach (i; 0 .. 7)
     {
         assert(!asc.test(codec));
         assert(utf8.test(codec));
@@ -5292,8 +5292,8 @@ if (is(C : wchar) || is(C : char))
         wchar[2] buf16;
         auto len = encode(buf, ch);
         auto len16 = encode(buf16, ch);
-        auto c8 = buf[0..len].decoder;
-        auto c16 = buf16[0..len16].decoder;
+        auto c8 = buf[0 .. len].decoder;
+        auto c16 = buf16[0 .. len16].decoder;
         assert(testAll(utf16, c16));
         assert(testAll(bmp, c16) || len16 != 1);
         assert(testAll(nonBmp, c16) || len16 != 2);
@@ -5542,7 +5542,7 @@ template Sequence(size_t start, size_t end)
             {
                 writeln("INDEX (excluding value level):");
                 foreach (i; staticIota!(0, t.table.dim-1) )
-                    writeln(t.table.slice!(i)[0..t.table.length!i]);
+                    writeln(t.table.slice!(i)[0 .. t.table.length!i]);
             }
             writeln("---------------------------");
         }
@@ -5569,7 +5569,7 @@ template Sequence(size_t start, size_t end)
     trieStats(trie2);
     foreach (e; redundant2.byCodepoint)
         assert(trie2[e], text(cast(uint) e, " - ", trie2[e]));
-    foreach (i; 0..1024)
+    foreach (i; 0 .. 1024)
     {
         assert(trie2[i] == (i in redundant2));
     }
@@ -5587,7 +5587,7 @@ template Sequence(size_t start, size_t end)
             sliceBits!(6,8), sliceBits!(4,6), sliceBits!(0,4)
         )(redundant3.byInterval);
     trieStats(trie3);
-    foreach (i; 0..max3)
+    foreach (i; 0 .. max3)
         assert(trie3[i] == (i in redundant3), text(cast(uint) i));
 
     auto redundant4 = Set(
@@ -5598,7 +5598,7 @@ template Sequence(size_t start, size_t end)
     auto trie4 = buildTrie!(bool, size_t, max4,
             sliceBits!(13, 16), sliceBits!(9, 13), sliceBits!(6, 9) , sliceBits!(0, 6)
         )(redundant4.byInterval);
-    foreach (i; 0..max4)
+    foreach (i; 0 .. max4)
     {
         if (i in redundant4)
             assert(trie4[i], text(cast(uint) i));
@@ -5619,7 +5619,7 @@ template Sequence(size_t start, size_t end)
     auto a = array(map!(x => to!ubyte(x))(iota(0, 256)));
     auto bt = buildTrie!(bool, ubyte, sliceBits!(7, 8), sliceBits!(5, 7), sliceBits!(0, 5))(a);
     trieStats(bt);
-    foreach (i; 0..256)
+    foreach (i; 0 .. 256)
         assert(bt[cast(ubyte) i]);
 }
 
@@ -5717,12 +5717,12 @@ if (is(Char1 : dchar) && is(Char2 : dchar))
 {
     import std.exception : enforce;
     immutable first = arr[idx++];
-    if (!(first & 0x80)) // no top bit -> [0..127]
+    if (!(first & 0x80)) // no top bit -> [0 .. 127]
         return first;
     immutable extra = ((first>>5) & 1) + 1; // [1, 2]
     uint val = (first & 0x1F);
     enforce(idx + extra <= arr.length, "bad code point interval encoding");
-    foreach (j; 0..extra)
+    foreach (j; 0 .. extra)
         val = (val<<8) | arr[idx+j];
     idx += extra;
     return val;
@@ -6164,7 +6164,7 @@ private:
         import std.internal.unicode_tables : blocks, scripts, uniProps; // generated file
         return isPrettyPropertyName(name)
             || findSetName!(uniProps.tab)(name) || findSetName!(scripts.tab)(name)
-            || (ucmp(name[0..2],"In") == 0 && findSetName!(blocks.tab)(name[2..$]));
+            || (ucmp(name[0 .. 2],"In") == 0 && findSetName!(blocks.tab)(name[2..$]));
     }
 
     static auto loadAny(Set=CodepointSet, C)(in C[] name) pure
@@ -6173,7 +6173,7 @@ private:
         import std.internal.unicode_tables : blocks, scripts; // generated file
         Set set;
         immutable loaded = loadProperty(name, set) || loadUnicodeSet!(scripts.tab)(name, set)
-            || (name.length > 2 && ucmp(name[0..2],"In") == 0
+            || (name.length > 2 && ucmp(name[0 .. 2],"In") == 0
                 && loadUnicodeSet!(blocks.tab)(name[2..$], set));
         if (loaded)
             return set;
@@ -6363,7 +6363,7 @@ if (is(C : dchar))
     string city = "A\u030Arhus";
     size_t first = graphemeStride(city, 0);
     assert(first == 3); //\u030A has 2 UTF-8 code units
-    assert(city[0..first] == "A\u030A");
+    assert(city[0 .. first] == "A\u030A");
     assert(city[first..$] == "rhus");
 }
 
@@ -6391,7 +6391,7 @@ if (isInputRange!Input && is(Unqual!(ElementType!Input) == dchar))
     gr = decodeGrapheme(s);
     assert(gr.length == 1 && gr[0] == ' ');
     gr = decodeGrapheme(s);
-    assert(gr.length == 2 && equal(gr[0..2], " \u0308"));
+    assert(gr.length == 2 && equal(gr[0 .. 2], " \u0308"));
     s = "\u0300\u0308\u1100";
     assert(equal(decodeGrapheme(s)[], "\u0300\u0308"));
     assert(equal(decodeGrapheme(s)[], "\u1100"));
@@ -6789,7 +6789,7 @@ public:
             if (overflow) assert(0);
 
             auto p = cast(ubyte*) enforce(malloc(raw_cap), "malloc failed");
-            p[0..raw_cap] = ptr_[0..raw_cap];
+            p[0 .. raw_cap] = ptr_[0 .. raw_cap];
             ptr_ = p;
         }
     }
@@ -6943,11 +6943,11 @@ static assert(Grapheme.sizeof == size_t.sizeof*4);
     copy[1] = '-';
     assert(g[0] == 'a' && copy[0] == 'X');
     assert(g[1] == 'b' && copy[1] == '-');
-    assert(equal(g[2..g.length], copy[2..copy.length]));
+    assert(equal(g[2 .. g.length], copy[2 .. copy.length]));
     copy = Grapheme("АБВГДЕЁЖЗИКЛМ");
-    assert(equal(copy[0..8], "АБВГДЕЁЖ"), text(copy[0..8]));
+    assert(equal(copy[0 .. 8], "АБВГДЕЁЖ"), text(copy[0 .. 8]));
     copy ~= "xyz";
-    assert(equal(copy[13..15], "xy"), text(copy[13..15]));
+    assert(equal(copy[13 .. 15], "xy"), text(copy[13 .. 15]));
     assert(!copy.valid);
 
     Grapheme h;
@@ -7077,7 +7077,7 @@ private int fullCasedCmp(Range)(dchar lhs, dchar rhs, ref Range rtail)
         }
         else
         {// OK it's a long chunk, like 'ss' for German
-            dstring seq = fTable[idx].seq[0..entryLen];
+            dstring seq = fTable[idx].seq[0 .. entryLen];
             if (rhs == seq[0]
                 && rtail.skipOver(seq[1..$]))
             {
@@ -7351,7 +7351,7 @@ ubyte combiningClass(dchar ch) @safe pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    foreach (ch; 0..0x80)
+    foreach (ch; 0 .. 0x80)
         assert(combiningClass(ch) == 0);
     assert(combiningClass('\u05BD') == 22);
     assert(combiningClass('\u0300') == 230);
@@ -7401,7 +7401,7 @@ public dchar compose(dchar first, dchar second) pure nothrow @safe
     // unpack offset and length
     immutable idx = packed & composeIdxMask, cnt = packed >> composeCntShift;
     // TODO: optimize this micro binary search (no more then 4-5 steps)
-    auto r = compositionTable[idx..idx+cnt].map!"a.rhs"().assumeSorted();
+    auto r = compositionTable[idx .. idx+cnt].map!"a.rhs"().assumeSorted();
     immutable target = r.lowerBound(second).length;
     if (target == cnt)
         return dchar.init;
@@ -7684,7 +7684,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
     auto app = appender!(C[])();
     do
     {
-        app.put(input[0..anchors[0]]);
+        app.put(input[0 .. anchors[0]]);
         foreach (dchar ch; input[anchors[0]..anchors[1]])
             static if (norm == NFD || norm == NFC)
             {
@@ -7708,7 +7708,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
             {
                 // found a stable code point after unstable ones
                 sort!("a[0] < b[0]", SwapStrategy.stable)
-                    (zip(ccc[firstNonStable..idx], decomposed[firstNonStable..idx]));
+                    (zip(ccc[firstNonStable .. idx], decomposed[firstNonStable .. idx]));
                 firstNonStable = decomposed.length;
             }
             else if (clazz != 0 && lastClazz == 0)
@@ -7754,7 +7754,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
         // and move on
         anchors = splitNormalized!norm(input);
     }while (anchors[0] != input.length);
-    app.put(input[0..anchors[0]]);
+    app.put(input[0 .. anchors[0]]);
     return cast(inout(C)[])app.data;
 }
 
@@ -7799,7 +7799,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
 private size_t recompose(size_t start, dchar[] input, ubyte[] ccc) pure nothrow @safe
 {
     assert(input.length == ccc.length);
-    int accumCC = -1;// so that it's out of 0..255 range
+    int accumCC = -1;// so that it's out of 0 .. 255 range
     // writefln("recomposing %( %04x %)", input);
     // first one is always a starter thus we start at i == 1
     size_t i = start+1;
@@ -7885,7 +7885,7 @@ private auto seekStable(NormalizationForm norm, C)(size_t idx, in C[] input)
     import std.typecons : tuple;
     import std.utf : codeLength;
 
-    auto br = input[0..idx];
+    auto br = input[0 .. idx];
     size_t region_start = 0;// default
     for (;;)
     {
@@ -7909,7 +7909,7 @@ private auto seekStable(NormalizationForm norm, C)(size_t idx, in C[] input)
             break;
         }
     }
-    // writeln("Region to normalize: ", input[region_start..region_end]);
+    // writeln("Region to normalize: ", input[region_start .. region_end]);
     return tuple(region_start, region_end);
 }
 
@@ -8025,7 +8025,7 @@ bool isLower(dchar c)
 @safe unittest
 {
     import std.ascii : isLower;
-    foreach (v; 0..0x80)
+    foreach (v; 0 .. 0x80)
         assert(isLower(v) == .isLower(v));
     assert(.isLower('я'));
     assert(.isLower('й'));
@@ -8058,7 +8058,7 @@ bool isUpper(dchar c)
 @safe unittest
 {
     import std.ascii : isLower;
-    foreach (v; 0..0x80)
+    foreach (v; 0 .. 0x80)
         assert(isLower(v) == .isLower(v));
     assert(!isUpper('й'));
     assert(isUpper('Ж'));
@@ -8112,7 +8112,7 @@ if (isSomeString!S)
         ushort idx = indexFn(cOuter);
         if (idx == ushort.max)
             continue;
-        auto result = appender!S(s[0..i]);
+        auto result = appender!S(s[0 .. i]);
         result.reserve(s.length);
         foreach (dchar c; s[i .. $])
         {
@@ -8136,7 +8136,7 @@ if (isSomeString!S)
                     // unpack length + codepoint
                     immutable uint len = val>>24;
                     result.put(cast(dchar)(val & 0xFF_FFFF));
-                    foreach (j; idx+1..idx+len)
+                    foreach (j; idx+1 .. idx+len)
                         result.put(tableFn(j));
                 }
             }
@@ -8150,7 +8150,7 @@ if (isSomeString!S)
 {
     import std.array : replicate;
     auto s = "abcdefghij".replicate(300);
-    s = s[0..10];
+    s = s[0 .. 10];
 
     toUpper(s);
 
@@ -8661,7 +8661,7 @@ if (is(C == char) || is(C == wchar)  || is(C == dchar))
         if (dest == from)
             return to;
         // got to copy
-        foreach (C c; str[from..to])
+        foreach (C c; str[from .. to])
             str[dest++] = c;
         return dest;
     }
@@ -8705,7 +8705,7 @@ if (is(C == char) || is(C == wchar)  || is(C == dchar))
     {
         destIdx = moveTo(s, destIdx, lastUnchanged, s.length);
     }
-    s = s[0..destIdx];
+    s = s[0 .. destIdx];
 }
 
 // helper to precalculate size of case-converted string
@@ -8739,7 +8739,7 @@ private template toCaseLength(alias indexFn, uint maxIdx, alias tableFn)
                 immutable len = val>>24;
                 immutable dchar cased = val & 0xFF_FFFF;
                 codeLen += codeLength!C(cased);
-                foreach (j; caseIndex+1..caseIndex+len)
+                foreach (j; caseIndex+1 .. caseIndex+len)
                     codeLen += codeLength!C(tableFn(j));
             }
         }
@@ -8768,7 +8768,7 @@ private template toCaseInPlaceAlloc(alias indexFn, uint maxIdx, alias tableFn)
         alias caseLength = toCaseLength!(indexFn, maxIdx, tableFn);
         auto trueLength = destIdx + caseLength(s[curIdx..$]);
         C[] ns = new C[trueLength];
-        ns[0..destIdx] = s[0..destIdx];
+        ns[0 .. destIdx] = s[0 .. destIdx];
         size_t lastUnchanged = curIdx;
         while (curIdx != s.length)
         {
@@ -8798,14 +8798,14 @@ private template toCaseInPlaceAlloc(alias indexFn, uint maxIdx, alias tableFn)
                 // unpack length + codepoint
                 immutable uint len = val>>24;
                 destIdx = encodeTo(ns, destIdx, cast(dchar)(val & 0xFF_FFFF));
-                foreach (j; caseIndex+1..caseIndex+len)
+                foreach (j; caseIndex+1 .. caseIndex+len)
                     destIdx = encodeTo(ns, destIdx, tableFn(j));
             }
         }
         if (lastUnchanged != s.length)
         {
             auto toCopy = s.length - lastUnchanged;
-            ns[destIdx..destIdx+toCopy] = s[lastUnchanged..$];
+            ns[destIdx .. destIdx+toCopy] = s[lastUnchanged..$];
             destIdx += toCopy;
         }
         assert(ns.length == destIdx);
@@ -8927,7 +8927,7 @@ if (isSomeString!S)
 {
     import std.format : format;
     static import std.ascii;
-    foreach (ch; 0..0x80)
+    foreach (ch; 0 .. 0x80)
         assert(std.ascii.toLower(ch) == toLower(ch));
     assert(toLower('Я') == 'я');
     assert(toLower('Δ') == 'δ');
@@ -8946,7 +8946,7 @@ if (isSomeString!S)
 @safe unittest
 {
     wchar[] test = "hello þ world"w.dup;
-    auto piece = test[6..7];
+    auto piece = test[6 .. 7];
     toUpperInPlace(piece);
     assert(test == "hello Þ world");
 }
@@ -9053,7 +9053,7 @@ dchar toUpper(dchar c)
 {
     import std.format : format;
     static import std.ascii;
-    foreach (ch; 0..0x80)
+    foreach (ch; 0 .. 0x80)
         assert(std.ascii.toUpper(ch) == toUpper(ch));
     assert(toUpper('я') == 'Я');
     assert(toUpper('δ') == 'Δ');
@@ -9176,9 +9176,9 @@ if (isSomeString!S)
         }
 
         // a few combinatorial runs
-        foreach (i; 0..options.length)
-        foreach (j; i..options.length)
-        foreach (k; j..options.length)
+        foreach (i; 0 .. options.length)
+        foreach (j; i .. options.length)
+        foreach (k; j .. options.length)
         {
             auto sample = options[i] ~ options[j] ~ options[k];
             auto sample2 = options[k] ~ options[j] ~ options[i];
@@ -9221,7 +9221,7 @@ bool isAlpha(dchar c)
     auto alpha = unicode("Alphabetic");
     foreach (ch; alpha.byCodepoint)
         assert(isAlpha(ch));
-    foreach (ch; 0..0x4000)
+    foreach (ch; 0 .. 0x4000)
         assert((ch in alpha) == isAlpha(ch));
 }
 
@@ -9241,7 +9241,7 @@ bool isMark(dchar c)
     auto mark = unicode("Mark");
     foreach (ch; mark.byCodepoint)
         assert(isMark(ch));
-    foreach (ch; 0..0x4000)
+    foreach (ch; 0 .. 0x4000)
         assert((ch in mark) == isMark(ch));
 }
 
@@ -9268,7 +9268,7 @@ bool isNumber(dchar c)
     auto n = unicode("N");
     foreach (ch; n.byCodepoint)
         assert(isNumber(ch));
-    foreach (ch; 0..0x4000)
+    foreach (ch; 0 .. 0x4000)
         assert((ch in n) == isNumber(ch));
 }
 
@@ -9309,7 +9309,7 @@ bool isAlphaNum(dchar c)
     foreach (ch; alpha.byCodepoint)
         assert(isAlphaNum(ch));
 
-    foreach (ch; 0..0x4000)
+    foreach (ch; 0 .. 0x4000)
     {
         assert(((ch in n) || (ch in alpha)) == isAlphaNum(ch));
     }
@@ -9388,7 +9388,7 @@ bool isSpace(dchar c)
     auto space = unicode.Zs;
     foreach (ch; space.byCodepoint)
         assert(isSpace(ch));
-    foreach (ch; 0..0x1000)
+    foreach (ch; 0 .. 0x1000)
         assert(isSpace(ch) == space[ch]);
 }
 
@@ -9411,7 +9411,7 @@ bool isGraphical(dchar c)
     import std.format : format;
     foreach (ch; set.byCodepoint)
         assert(isGraphical(ch), format("%4x", ch));
-    foreach (ch; 0..0x4000)
+    foreach (ch; 0 .. 0x4000)
         assert((ch in set) == isGraphical(ch));
 }
 
@@ -9435,7 +9435,7 @@ bool isControl(dchar c)
     auto cc = unicode.Cc;
     foreach (ch; cc.byCodepoint)
         assert(isControl(ch));
-    foreach (ch; 0..0x1000)
+    foreach (ch; 0 .. 0x1000)
         assert(isControl(ch) == cc[ch]);
 }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -2341,7 +2341,7 @@ public:
         Example:
         ---
         import std.conv;
-        assert(unicode.ASCII.to!string == "[0 .. 128$(RPAREN)");
+        assert(unicode.ASCII.to!string == "[0..128$(RPAREN)");
         ---
     */
 
@@ -2387,18 +2387,18 @@ public:
         import std.uni : unicode;
 
         assert(unicode.Cyrillic.to!string ==
-            "[1024 .. 1157) [1159 .. 1320) [7467 .. 7468) [7544 .. 7545) [11744 .. 11776) [42560 .. 42648) [42655 .. 42656)");
+            "[1024..1157) [1159..1320) [7467..7468) [7544..7545) [11744..11776) [42560..42648) [42655..42656)");
 
         // The specs '%s' and '%d' are equivalent to the to!string call above.
         assert(format("%d", unicode.Cyrillic) == unicode.Cyrillic.to!string);
 
         assert(format("%#x", unicode.Cyrillic) ==
-            "[0x400 .. 0x485) [0x487 .. 0x528) [0x1d2b .. 0x1d2c) [0x1d78 .. 0x1d79) [0x2de0 .. 0x2e00) "
-            ~"[0xa640 .. 0xa698) [0xa69f .. 0xa6a0)");
+            "[0x400..0x485) [0x487..0x528) [0x1d2b..0x1d2c) [0x1d78..0x1d79) [0x2de0..0x2e00) "
+            ~"[0xa640..0xa698) [0xa69f..0xa6a0)");
 
         assert(format("%#X", unicode.Cyrillic) ==
-            "[0X400 .. 0X485) [0X487 .. 0X528) [0X1D2B .. 0X1D2C) [0X1D78 .. 0X1D79) [0X2DE0 .. 0X2E00) "
-            ~"[0XA640 .. 0XA698) [0XA69F .. 0XA6A0)");
+            "[0X400..0X485) [0X487..0X528) [0X1D2B..0X1D2C) [0X1D78..0X1D79) [0X2DE0..0X2E00) "
+            ~"[0XA640..0XA698) [0XA69F..0XA6A0)");
     }
 
     @safe unittest
@@ -3023,7 +3023,7 @@ private:
 @system unittest
 {
     import std.conv : to;
-    assert(unicode.ASCII.to!string() == "[0 .. 128)");
+    assert(unicode.ASCII.to!string() == "[0..128)");
 }
 
 // pedantic version for ctfe, and aligned-access only architectures

--- a/std/uri.d
+++ b/std/uri.d
@@ -108,7 +108,7 @@ private string URI_Encode(dstring string, uint unescapedSet)
                     if (!R2)
                         throw new OutOfMemoryError("Alloca failure");
                 }
-                R2[0..Rlen] = R[0..Rlen];
+                R2[0 .. Rlen] = R[0 .. Rlen];
                 R = R2;
             }
             R[Rlen] = cast(char) C;
@@ -168,7 +168,7 @@ private string URI_Encode(dstring string, uint unescapedSet)
                     if (!R2)
                         throw new OutOfMemoryError("Alloca failure");
                 }
-                R2[0..Rlen] = R[0..Rlen];
+                R2[0 .. Rlen] = R[0 .. Rlen];
                 R = R2;
             }
 
@@ -183,7 +183,7 @@ private string URI_Encode(dstring string, uint unescapedSet)
         }
     }
 
-    return R[0..Rlen].idup;
+    return R[0 .. Rlen].idup;
 }
 
 private uint ascii2hex(dchar c) @nogc @safe pure nothrow
@@ -304,7 +304,7 @@ if (isSomeChar!Char)
     assert(Rlen <= Rsize);  // enforce our preallocation size guarantee
 
     // Copy array on stack to array in memory
-    return R[0..Rlen].idup;
+    return R[0 .. Rlen].idup;
 }
 
 /*************************************
@@ -408,7 +408,7 @@ package string urlEncode(in string[string] values)
  * Does string s[] start with a URL?
  * Returns:
  *  -1   it does not
- *  len  it does, and s[0..len] is the slice of s[] that is that URL
+ *  len  it does, and s[0 .. len] is the slice of s[] that is that URL
  */
 
 ptrdiff_t uriLength(Char)(in Char[] s)
@@ -478,7 +478,7 @@ if (isSomeChar!Char)
  * Does string s[] start with an email address?
  * Returns:
  *  -1    it does not
- *  len   it does, and s[0..i] is the slice of s[] that is that email address
+ *  len   it does, and s[0 .. i] is the slice of s[] that is that email address
  * References:
  *  RFC2822
  */

--- a/std/utf.d
+++ b/std/utf.d
@@ -3345,7 +3345,7 @@ if (isAutodecodableString!R)
         {
             auto opSlice(size_t lower, size_t upper)
             {
-                return ByCodeUnitImpl(r[lower..upper]);
+                return ByCodeUnitImpl(r[lower .. upper]);
             }
         }
 
@@ -3448,7 +3448,7 @@ pure nothrow @nogc unittest
         auto r = "hello".byCodeUnit();
         assert(r.length == 5);
         assert(r[3] == 'l');
-        assert(r[2..4][1] == 'l');
+        assert(r[2 .. 4][1] == 'l');
     }
     {
         char[5] buff = "hello";
@@ -3528,7 +3528,7 @@ alias byDchar = byUTF!dchar;
     char[5+2+3+4+3+3] s;
     int i;
     dchar[10] a;
-    a[0..8] = "hello\u07FF\uD7FF\U0010FFFF"d;
+    a[0 .. 8] = "hello\u07FF\uD7FF\U0010FFFF"d;
     a[8] = 0xD800;   // invalid
     a[9] = cast(dchar) 0x110000; // invalid
     foreach (c; a[].byChar())
@@ -3565,7 +3565,7 @@ alias byDchar = byUTF!dchar;
     wchar[11] s;
     int i;
     dchar[10] a;
-    a[0..8] = "hello\u07FF\uD7FF\U0010FFFF"d;
+    a[0 .. 8] = "hello\u07FF\uD7FF\U0010FFFF"d;
     a[8] = 0xD800;   // invalid
     a[9] = cast(dchar) 0x110000; // invalid
     foreach (c; a[].byWchar())

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -107,7 +107,7 @@ bool putSysError(Writer)(DWORD code, Writer w, /*WORD*/int langId = 0)
     if (lpMsgBuf)
     {
         import std.string : strip;
-        w.put(lpMsgBuf[0..res].strip());
+        w.put(lpMsgBuf[0 .. res].strip());
         return true;
     }
     else

--- a/std/xml.d
+++ b/std/xml.d
@@ -2217,7 +2217,7 @@ private
             n = i;
             break;
         }
-        name = s[0..n];
+        name = s[0 .. n];
         s = s[n..$];
     }
 
@@ -2926,7 +2926,7 @@ private
     string chop(ref string s, size_t n) @safe pure nothrow
     {
         if (n == -1) n = s.length;
-        string t = s[0..n];
+        string t = s[0 .. n];
         s = s[n..$];
         return t;
     }
@@ -3040,7 +3040,7 @@ private
             auto m = (table.length >> 1) & ~1;
             if (c < table[m])
             {
-                table = table[0..m];
+                table = table[0 .. m];
             }
             else if (c > table[m+1])
             {

--- a/std/zip.d
+++ b/std/zip.d
@@ -856,13 +856,13 @@ debug(print)
     import std.stdio, std.conv;
     MinstdRand0 gen;
     const uint itemCount = 20, minSize = 10, maxSize = 500;
-    foreach (variant; 0..2)
+    foreach (variant; 0 .. 2)
     {
         bool useZip64 = !!variant;
         zip1 = new ZipArchive();
         zip1.isZip64 = useZip64;
         ArchiveMember[itemCount] ams;
-        foreach (i; 0..itemCount)
+        foreach (i; 0 .. itemCount)
         {
             ams[i] = new ArchiveMember();
             ams[i].name = to!string(i);
@@ -894,7 +894,7 @@ debug(print)
     string[] names;
     int value = 0;
     // Generate a series of unique numbers as filenames.
-    foreach (i; 0..20)
+    foreach (i; 0 .. 20)
     {
         value += 1 + rand.front & 0xFFFF;
         rand.popFront;

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -180,7 +180,7 @@ uint crc32(uint crc, const(void)[] buf)
  *
  * Params:
  *     srcbuf = buffer containing the data to compress
- *     level = compression level. Legal values are -1..9, with -1 indicating
+ *     level = compression level. Legal values are -1 .. 9, with -1 indicating
  *             the default level (6), 0 indicating no compression, 1 being the
  *             least compression and 9 being the most.
  *
@@ -359,7 +359,7 @@ class Compress
      * Constructor.
      *
      * Params:
-     *    level = compression level. Legal values are 1..9, with 1 being the least
+     *    level = compression level. Legal values are 1 .. 9, with 1 being the least
      *            compression and 9 being the most. The default value is 6.
      *    header = sets the compression type to one of the options available
      *             in $(LREF HeaderFormat). Defaults to HeaderFormat.deflate.


### PR DESCRIPTION
Yet another check & automatic conversion.

@andralex I mainly did this because you keep nagging about this on PR reviews and there's really no point in wasting time during a review with such easily to check nits.
(for the record I prefer the `a..b`)

There were a few false positives with this very naive approach, hence I excluded the `std.string` and `std.uni` for the start.
Moreover, I hope you are aware of the following:

```d
import std.conv, std.uni;
assert(unicode.ASCII.to!string == "[0..128)");
```