### PR TITLE
Style: check for unnecessary parentheses after return

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -522,6 +522,9 @@ style: ../dscanner/dsc
 	@echo "Enforce space between a .. b"
 	grep -nrE '[[:alnum:]][.][.][[:alnum:]]|[[:alnum:]] [.][.][[:alnum:]]|[[:alnum:]][.][.] [[:alnum:]]' $$(find . -name '*.d' | grep -vE 'std/string.d|std/uni.d') ; test $$? -eq 1
 
+	@echo "Check for unnecessary parentheses after return (doesn't catch everything)"
+	grep -n 'return(' $$(find . -name '*.d') ; test $$? -eq 1
+
 	# at the moment libdparse has problems to parse some modules (->excludes)
 	@echo "Running DScanner"
 	../dscanner/dsc --config .dscanner.ini --styleCheck $$(find etc std -type f -name '*.d' | grep -vE 'std/traits.d|std/typecons.d') -I.

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1133,7 +1133,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         }
         else
         {
-            return(_add(stuff).added ? 1 : 0);
+            return _add(stuff).added ? 1 : 0;
         }
     }
 

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1319,7 +1319,7 @@ body {
     real ax = a * log(x) - x - logGamma(a);
 /+
     if ( ax < MINLOGL ) return 0; // underflow
-    //  { mtherr( "igaml", UNDERFLOW ); return( 0.0L ); }
+    //  { mtherr( "igaml", UNDERFLOW ); return 0.0L; }
 +/
     ax = exp(ax);
 


### PR DESCRIPTION
It seems like we have exhausted the capabilities of RegExps as we can only test for non-ambiguous cases which leads to two detected cases. Further work should continue extend this with Dscanner: https://github.com/Hackerpilot/Dscanner/issues/411