### PR TITLE
Generator implements InputRange

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1841,6 +1841,12 @@ void yield(T)(T value)
     assert(myIota.front == 2);
     myIota.popFront();
     assert(myIota.front == 3);
+
+    size_t[2] counter = [0, 0];
+    foreach (i, unused; myIota) counter[] += [1, i];
+
+    assert(myIota.empty);
+    assert(counter == [7, 21]);
 }
 
 // MessageBox Implementation

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -75,6 +75,7 @@ private
     import core.sync.mutex;
     import core.sync.condition;
     import std.range.primitives;
+    import std.range.interfaces;
     import std.traits;
     import std.concurrencybase;
 
@@ -1586,7 +1587,6 @@ private interface IsGenerator {}
  * }
  * ---
  */
-import std.range.interfaces : InputRange;
 class Generator(T) :
     Fiber, IsGenerator, InputRange!T
 {
@@ -1697,7 +1697,6 @@ class Generator(T) :
      */
     final T moveFront()
     {
-        import std.algorithm, std.range;
         static if (!hasElaborateCopyConstructor!T)
         {
             return front;

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1712,10 +1712,10 @@ class Generator(T) :
     final int opApply(scope int delegate(T) loopBody)
     {
         int broken;
-        for(; !empty; popFront())
+        for (; !empty; popFront())
         {
             broken = loopBody(front);
-            if(broken) break;
+            if (broken) break;
         }
         return broken;
     }
@@ -1723,10 +1723,10 @@ class Generator(T) :
     final int opApply(scope int delegate(size_t, T) loopBody)
     {
         int broken;
-        for(size_t i; !empty; ++i, popFront())
+        for (size_t i; !empty; ++i, popFront())
         {
             broken = loopBody(i, front);
-            if(broken) break;
+            if (broken) break;
         }
         return broken;
     }
@@ -1833,7 +1833,7 @@ void yield(T)(T value)
     //can be assigned to std.range.interfaces.InputRange directly
     myIota = new Generator!int(
     {
-        foreach(i; 0 .. 10) yield(i);
+        foreach (i; 0 .. 10) yield(i);
     });
 
     myIota.popFront();


### PR DESCRIPTION
Since std.concurrency.Generator is a class already, I made it to implement std.range.interfaces.InputRange without having to call inputRangeObject().