### PR TITLE
Temporarily disable project coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,7 +11,7 @@ coverage:
   status:
 
     # Learn more at https://codecov.io/docs#yaml_default_commit_status
-    project: true
+    project: false
     patch: true
     changes: false
 


### PR DESCRIPTION
At CircleCi we merge the PR into the respective Phobos branch (e.g. `master`, `stable`, ...) to simulate its effect on the regarding branch and to auto-update the `circleci.sh` and `posix.mak`.
However, CodeCov doesn't these merges very well. In particular they completely ignore the new `parent_ref` and assume it to be the one of the PR. This means that all commits between the `parent_ref` of a PR and the current `upstream/master` are also counted in the `codecov/project` information output.
Hence, it usually looks pretty random and often shows red warnings.

-> a solution is to remove the `codecov/project` report until CodeCov can handle `parent_ref` properly. The information on the coverage changes introduced by a PR was and will stay correct, except for CTFE and DMD bugs.
To the people using the CodeCov extension to look at PRs: it's worth noting that due the incorrect handling of `parent_ref` CodeCov the coverage report might also be shifted by X lines (as there might have been a commit to the same file between the `parent_ref` of the respective PR and `upstream/master`)

Learn more:

https://github.com/codecov/support/issues/360