### PR TITLE
Don't merge with upstream/master on CircleCi due to CodeCov issues

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -74,6 +74,11 @@ setup_repos()
         git fetch upstream
         git checkout -f upstream/$base_branch
         git merge -m "Automatic merge" $current_branch
+        # CodeCov doesn't handle a changed parent_ref well.
+        # It will assume all merged changes as part of this commit.
+        # Hence we temporarily revert the merge for .d files (we keep the updated configs)
+        # https://github.com/codecov/support/issues/360
+        git checkout $current_branch etc std
     fi
 
     for proj in dmd druntime ; do


### PR DESCRIPTION
This is an alternative to #5197.

Instead of disabling CodeCov, we simply revert the merged source code changes, but keep the updated `circleci.sh` and `posix.mak` file. This means that we just test the coverage information for the current PR, which should be fine as the auto-tester does test the PR for test correctness anyways.