### PR TITLE
Fix changelog files & add a simple validator

### DIFF
--- a/changelog/std-format-formattedRead-only-pointers.dd
+++ b/changelog/std-format-formattedRead-only-pointers.dd
@@ -1,2 +1,14 @@
 `std.format.formattedRead` now only accepts pointers as input arguments.
 
+For example, the "bad" version of the following code lead to very confusing
+errors from Phobos.
+
+-------
+import std.format;
+void main() {
+    int[3] row;
+    auto text = "10 20 30";
+    //formattedRead(text, "%(%d %)", row);   // bad
+    formattedRead(text, "%(%d %)", &row);  // OK
+}
+-------

--- a/changelog/std-random-MersenneTwisterEngine.dd
+++ b/changelog/std-random-MersenneTwisterEngine.dd
@@ -1,3 +1,5 @@
+`MersenneTwisterEngine` has been updated so that its template signature matches the C++11 standard.
+
 `MersenneTwisterEngine` has been updated so that its template signature
 matches the C++11 standard (adding two new template parameters, an extra
 tempering parameter `d` and the initialization multiplier `f`).

--- a/changelog/std-range-bitwise.dd
+++ b/changelog/std-range-bitwise.dd
@@ -1,6 +1,6 @@
 Added `std.range.bitwise` to create a bitwise adapter over an integral type range, consuming the range elements bit by bit.
 
-`std.range.bitwise` creates a bit by bit adapter over an integral type range.
+`std.range.bitwise` creates a bit by bit adapter over an integral type range:
 -------
 import std.range : bitwise;
 ubyte[] arr = [3, 9];

--- a/changelog/std-stdio-readf-only-pointers.dd
+++ b/changelog/std-stdio-readf-only-pointers.dd
@@ -1,2 +1,14 @@
 `std.stdio.readf` now only accepts pointers as input arguments.
 
+For example, the "bad" version of the following code lead to very confusing
+errors from Phobos:
+
+-------
+import std.stdio;
+void main() {
+    int[3] row;
+    auto text = "10 20 30";
+    //readf(text, "%(%d %)", row);   // bad
+    readf(text, "%(%d %)", &row);  // OK
+}
+-------

--- a/changelog/std-utf-decodeBack.dd
+++ b/changelog/std-utf-decodeBack.dd
@@ -1,4 +1,5 @@
 Added `std.utf.decodeBack` which decodes the last UTF code point of given character range.
+
 -------
  import std.utf : decodeBack;
 

--- a/posix.mak
+++ b/posix.mak
@@ -525,6 +525,16 @@ style: ../dscanner/dsc $(LIB)
 	@echo "Enforce space between binary operators"
 	grep -nrE "[[:alnum:]](==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]] (==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]](==|!=|<=|<<|>>|>>>|^^) [[:alnum:]]" $$(find . -name '*.d'); test $$? -eq 1
 
+	@echo "Validate changelog files (Do _not_ use REF in the title!)"
+	@for file in $$(find changelog -name '*.dd') ; do  \
+		cat $$file | head -n1 | grep -nqE '\$$\((REF|LINK2|HTTP|MREF)' && \
+		{ echo "$$file: The title line can't contain links - it's already a link" && exit 1; } ;\
+		cat $$file | head -n2 | tail -n1 | grep -q '^$$' || \
+		{ echo "$$file: After the title line an empty, separating line is expected" && exit 1; } ;\
+		cat $$file | head -n3 | tail -n1 | grep -nqE '^.{1,}$$'  || \
+		{ echo "$$file: The title is supposed to be followed by a long description" && exit 1; } ;\
+	done
+
 	@echo "Check that Ddoc runs without errors"
 	$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -w -D -main -c -o- $$(find etc std -type f -name '*.d' | grep -vE 'std/experimental/ndslice/iteration.d') 2>&1 | grep -v "Deprecation:"; test $$? -eq 1
 


### PR DESCRIPTION
It seems that not everyone was consistent with the changelog format - some people even left out the description :O

> The changelog tool should enforce that there's a blank line after the title line.

Well the changelog tool isn't called here directly, but on DAutoTest.

I tried to fix the changelog files & added a simple validator, s.t. we can at least automatically ensure that
- the entry contains a description (and a separating line between them)
- has no `$(REF)` in the title

Yes in theory the `changed.d` could have a flag `---validate`, but I would like to have this check enforced before next summer (PRs at tools have a tendency to hang in the queue).

> Or, alternatively, allow multiple lines for the title, until the first blank line.

I don't think it's worth supporting this as (a) it's not the git commit format anymore and (b) a title shouldn't be that long anyways.
However in case this is wanted (and https://github.com/dlang/tools/pull/220 is merged), the validator would need a small update.

CC @aG0aep6G 

(This is a follow-up to https://github.com/dlang/phobos/pull/5192)