### PR TITLE
std.conv: Fix off-by-one regression in integer radix parse

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2401,7 +2401,7 @@ body
 
         bool overflow = false;
         auto nextv = v.mulu(radix, overflow).addu(c - '0', overflow);
-        enforce!ConvOverflowException(!overflow && nextv < Target.max, "Overflow in integral conversion");
+        enforce!ConvOverflowException(!overflow && nextv <= Target.max, "Overflow in integral conversion");
         v = cast(Target) nextv;
         s.popFront();
     } while (!s.empty);
@@ -2428,6 +2428,8 @@ body
 
     // 6609
     assert(parse!int(s = "-42", 10) == -42);
+
+    assert(parse!ubyte(s = "ff", 16) == 0xFF);
 }
 
 @safe pure unittest // bugzilla 7302


### PR DESCRIPTION
Introduced in c6fb78ed14449725d0f5d10f38852eefb1e5dbfe (#5067).