### PR TITLE
Remove quickIndex for modules with booktables or only one symbol

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -4,6 +4,7 @@ Functions and types that manipulate built-in arrays and associative arrays.
 
 This module provides all kinds of functions to create, manipulate or convert arrays:
 
+$(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
@@ -11,7 +12,7 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Returns a copy of the input in a newly allocated dynamic _array.
     ))
     $(TR $(TD $(D $(LREF appender)))
-        $(TD Returns a new Appender initialized with a given _array.
+        $(TD Returns a new $(LREF Appender) or $(LREF RefAppender) initialized with a given _array.
     ))
     $(TR $(TD $(D $(LREF assocArray)))
         $(TD Returns a newly allocated associative _array from a range of key/value tuples.

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -13,6 +13,8 @@ License: Distributed under the Boost Software License, Version 1.0.
 boost.org/LICENSE_1_0.txt)).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
+
+$(SCRIPT inhibitQuickIndex = 1;)
 */
 module std.container.array;
 

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -13,6 +13,8 @@ License: Distributed under the Boost Software License, Version 1.0.
 boost.org/LICENSE_1_0.txt)).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
+
+$(SCRIPT inhibitQuickIndex = 1;)
 */
 module std.container.dlist;
 

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -13,6 +13,8 @@ License: Distributed under the Boost Software License, Version 1.0.
 boost.org/LICENSE_1_0.txt)).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
+
+$(SCRIPT inhibitQuickIndex = 1;)
 */
 module std.container.slist;
 

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -12,6 +12,8 @@ License: Distributed under the Boost Software License, Version 1.0.
 boost.org/LICENSE_1_0.txt)).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
+
+$(SCRIPT inhibitQuickIndex = 1;)
 */
 module std.container.util;
 

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -8,6 +8,7 @@
  * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *                        Thomas K$(UUML)hne, Frits van Bommel
  * Source:    $(PHOBOSSRC std/_demangle.d)
+ * $(SCRIPT inhibitQuickIndex = 1;)
  */
 /*
  *          Copyright Digital Mars 2000 - 2009.

--- a/std/functional.d
+++ b/std/functional.d
@@ -7,6 +7,7 @@ This module provides functions for compile time function composition. These
 functions are helpful when constructing predicates for the algorithms in
 $(MREF std, algorithm) or $(MREF std, range).
 
+$(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -7,6 +7,8 @@
  * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *            Matthew Wilson
  * Source:    $(PHOBOSSRC std/_mmfile.d)
+ *
+ * $(SCRIPT inhibitQuickIndex = 1;)
  */
 /*          Copyright Digital Mars 2004 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -7,6 +7,8 @@ Serialize data to $(D ubyte) arrays.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_outbuffer.d)
+ *
+ * $(SCRIPT inhibitQuickIndex = 1;)
  */
 module std.outbuffer;
 

--- a/std/signals.d
+++ b/std/signals.d
@@ -52,6 +52,8 @@
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(PHOBOSSRC std/_signals.d)
+ *
+ * $(SCRIPT inhibitQuickIndex = 1;)
  */
 /*          Copyright Digital Mars 2000 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -6,6 +6,8 @@
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
  * Source:    $(PHOBOSSRC std/_typetuple.d)
+ *
+ * $(SCRIPT inhibitQuickIndex = 1;)
  */
 module std.typetuple;
 


### PR DESCRIPTION
One full sweep through the remaining Phobos modules:
- most didn't have a `BOOKTABLE` (or were already using `inhibitQuickIndex`)
- when there was only one symbol to jump to, it doesn't make sense to show the quick index table

Something interesting: even though `splitter` was deprecated in [std.array](http://dlang.org/phobos/std_array.html) and doesn't use ddoc comments, it's still visible in the quickIndex :/