### PR TITLE
Issue 17232 - make std.algorithm table more digestable

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -12,10 +12,10 @@ Algorithms are categorized into the following submodules:
 
 $(DIVC quickindex,
 $(BOOKTABLE ,
-$(TR $(TH Category) $(TH Submodule) $(TH Functions)
+$(TR $(TH Submodule) $(TH Functions)
 )
-$(TR $(TDNW Searching)
-     $(TDNW $(SUBMODULE searching))
+$(TR
+     $(TDNW $(SUBMODULE Searching, searching))
      $(TD
         $(SUBREF searching, all)
         $(SUBREF searching, any)
@@ -46,8 +46,8 @@ $(TR $(TDNW Searching)
         $(SUBREF searching, until)
     )
 )
-$(TR $(TDNW Comparison)
-    $(TDNW $(SUBMODULE comparison))
+$(TR
+    $(TDNW $(SUBMODULE Comparison, comparison))
     $(TD
         $(SUBREF comparison, among)
         $(SUBREF comparison, castSwitch)
@@ -65,8 +65,8 @@ $(TR $(TDNW Comparison)
         $(SUBREF comparison, predSwitch)
     )
 )
-$(TR $(TDNW Iteration)
-    $(TDNW $(SUBMODULE iteration))
+$(TR
+    $(TDNW $(SUBMODULE Iteration, iteration))
     $(TD
         $(SUBREF iteration, cache)
         $(SUBREF iteration, cacheBidirectional)
@@ -86,8 +86,8 @@ $(TR $(TDNW Iteration)
         $(SUBREF iteration, uniq)
     )
 )
-$(TR $(TDNW Sorting)
-    $(TDNW $(SUBMODULE sorting))
+$(TR
+    $(TDNW $(SUBMODULE Sorting, sorting))
     $(TD
         $(SUBREF sorting, completeSort)
         $(SUBREF sorting, isPartitioned)
@@ -110,8 +110,8 @@ $(TR $(TDNW Sorting)
         $(SUBREF sorting, topNIndex)
     )
 )
-$(TR $(TDNW Set&nbsp;operations)
-    $(TDNW $(SUBMODULE setops))
+$(TR
+    $(TDNW $(SUBMODULE Set operations, setops))
     $(TD
         $(SUBREF setops, cartesianProduct)
         $(SUBREF setops, largestPartialIntersection)
@@ -122,8 +122,8 @@ $(TR $(TDNW Set&nbsp;operations)
         $(SUBREF setops, setSymmetricDifference)
     )
 )
-$(TR $(TDNW Mutation)
-    $(TDNW $(SUBMODULE mutation))
+$(TR
+    $(TDNW $(SUBMODULE Mutation, mutation))
     $(TD
         $(SUBREF mutation, bringToFront)
         $(SUBREF mutation, copy)
@@ -171,7 +171,7 @@ sort(a);                   // no predicate, "a < b" is implicit
 ----
 
 Macros:
-SUBMODULE = $(MREF std, algorithm, $1)
+SUBMODULE = $(MREF_ALTTEXT $1, std, algorithm, $2)
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, std, algorithm, $1)$(NBSP)
 
 Copyright: Andrei Alexandrescu 2008-.

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -111,7 +111,7 @@ $(TR
     )
 )
 $(TR
-    $(TDNW $(SUBMODULE Set operations, setops))
+    $(TDNW Set operations $(BR)($(SUBMODULE setops, setops)))
     $(TD
         $(SUBREF setops, cartesianProduct)
         $(SUBREF setops, largestPartialIntersection)


### PR DESCRIPTION
This isn't a complete fix of 17232, but it's a simple step to improve the current status and it also looks nicer on the Desktop as I think it's quite obvious to the reader that he's looking at `std.algorithm` (title, left sidebar, url, ...)

Before:

![2017-02-28-17-34-dlang org](https://cloud.githubusercontent.com/assets/4370550/23414429/3b1c8e20-fddc-11e6-972b-dcdefc5b4bcd.png)

After:

![2017-02-28-17-35-](https://cloud.githubusercontent.com/assets/4370550/23414444/5078f4ca-fddc-11e6-846d-5bdd76e37b60.png)
