### PR TITLE
Fix CircleCi: auto functions that return null should be void

### DIFF
--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -2974,12 +2974,12 @@ version(unittest) private struct CountOpBinary
     static struct Hook2
     {
         uint calls;
-        auto hookOpUnary(string op, T)(ref T value) if (op == "++")
+        void hookOpUnary(string op, T)(ref T value) if (op == "++")
         {
             ++calls;
             --value;
         }
-        auto hookOpUnary(string op, T)(ref T value) if (op == "--")
+        void hookOpUnary(string op, T)(ref T value) if (op == "--")
         {
             ++calls;
             ++value;


### PR DESCRIPTION
As CircleCi builds doesn't get re-run, there's the slight potential that `master` has evolved. This has just happened with the newly enabled Dscanner check in https://github.com/dlang/phobos/pull/5160

tl;dr: `std.experimental.checkedint` has two `auto` function that don't return a value.