### PR TITLE
Replace LUCKY links with actual links

### DIFF
--- a/etc/c/odbc/sql.d
+++ b/etc/c/odbc/sql.d
@@ -18,7 +18,8 @@ flags (e.g. for dmd, `-L-lodbc` on Posix and `-Lodbc32.lib` on Windows) to link
 with the ODBC library. On Windows, using $(D pragma(lib, "odbc32")) in D
 code at top level is also appropriate.
 
-See_Also: $(LUCKY ODBC API Reference on MSN Online)
+See_Also: $(LINK2 https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/odbc-api-reference,
+            ODBC API Reference on MSN Online)
 */
 
 module etc.c.odbc.sql;

--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -8,7 +8,8 @@ original announcement)).
 
 `etc.c.odbc.sqlext` corresponds to the `sqlext.h` C header file.
 
-See_Also: $(LUCKY ODBC API Reference on MSN Online)
+See_Also: $(LINK2 https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/odbc-api-reference,
+            ODBC API Reference on MSN Online)
 */
 
 module etc.c.odbc.sqlext;

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -8,7 +8,8 @@ original announcement)).
 
 `etc.c.odbc.sqlext.d` corresponds to the `sqlext.h` C header file.
 
-See_Also: $(LUCKY ODBC API Reference on MSN Online)
+See_Also: $(LINK2 https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/odbc-api-reference,
+          ODBC API Reference on MSN Online)
 */
 module etc.c.odbc.sqltypes;
 

--- a/etc/c/odbc/sqlucode.d
+++ b/etc/c/odbc/sqlucode.d
@@ -8,7 +8,8 @@ original announcement)).
 
 `etc.c.odbc.sqlucode` corresponds to the `sqlucode.h` C include file.
 
-See_Also: $(LUCKY ODBC API Reference on MSN Online)
+See_Also: $(LINK2 https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/odbc-api-reference,
+            ODBC API Reference on MSN Online)
 */
 
 /+

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -27,11 +27,13 @@ $(T2 isSameLength,
         $(D isSameLength([1, 2, 3], [4, 5, 6])) returns $(D true).)
 $(T2 levenshteinDistance,
         $(D levenshteinDistance("kitten", "sitting")) returns $(D 3) by using
-        the $(LUCKY Levenshtein distance _algorithm).)
+        the $(LINK2 https://en.wikipedia.org/wiki/Levenshtein_distance,
+        Levenshtein distance _algorithm).)
 $(T2 levenshteinDistanceAndPath,
         $(D levenshteinDistanceAndPath("kitten", "sitting")) returns
-        $(D tuple(3, "snnnsni")) by using the $(LUCKY Levenshtein distance
-        _algorithm).)
+        $(D tuple(3, "snnnsni")) by using the
+        $(LINK2 https://en.wikipedia.org/wiki/Levenshtein_distance,
+        Levenshtein distance _algorithm).)
 $(T2 max,
         $(D max(3, 4, 2)) returns $(D 4).)
 $(T2 min,

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -16,7 +16,8 @@ $(T2 balancedParens,
         string has balanced parentheses.)
 $(T2 boyerMooreFinder,
         $(D find("hello world", boyerMooreFinder("or"))) returns $(D "orld")
-        using the $(LUCKY Boyer-Moore _algorithm).)
+        using the $(LINK2 https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm,
+        Boyer-Moore _algorithm).)
 $(T2 canFind,
         $(D canFind("hello world", "or")) returns $(D true).)
 $(T2 count,
@@ -2343,7 +2344,8 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 
 /**
  * Finds $(D needle) in $(D haystack) efficiently using the
- * $(LUCKY Boyer-Moore) method.
+ * $(LINK2 https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm,
+ * Boyer-Moore) method.
  *
  * Params:
  * haystack = A random-access range with length and slicing.

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -558,7 +558,8 @@ Params:
     sorted = Whether the elements copied should be in sorted order.
 
 The function $(D largestPartialIntersection) is useful for
-e.g. searching an $(LUCKY inverted index) for the documents most
+e.g. searching an $(LINK2 https://en.wikipedia.org/wiki/Inverted_index,
+inverted index) for the documents most
 likely to contain some terms of interest. The complexity of the search
 is $(BIGOH n * log(tgt.length)), where $(D n) is the sum of lengths of
 all input ranges. This approach is faster than keeping an associative

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -50,7 +50,7 @@ $(T2 pivotPartition,
         than or equal, and greater than or equal to the given pivot, passed as
         an index in the range.)
 $(T2 schwartzSort,
-        Sorts with the help of the $(LUCKY Schwartzian transform).)
+        Sorts with the help of the $(LINK2 https://en.wikipedia.org/wiki/Schwartzian_transform, Schwartzian transform).)
 $(T2 sort,
         Sorts.)
 $(T2 topN,
@@ -573,7 +573,8 @@ if (ss != SwapStrategy.stable && isInputRange!Range && hasSwappableElements!Rang
 /**
 
 Partitions `r` around `pivot` using comparison function `less`, algorithm akin
-to $(LUCKY Hoare partition). Specifically, permutes elements of `r` and returns
+to $(LINK2 https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme,
+Hoare partition). Specifically, permutes elements of `r` and returns
 an index $(D k < r.length) such that:
 
 $(UL
@@ -594,9 +595,10 @@ elements fairly to the left and right of `k` such that `k` stays close to  $(D
 r.length / 2).
 
 Params:
-less = The predicate used for comparison, modeled as a $(LUCKY strict weak
-ordering) (irreflexive, antisymmetric, transitive, and implying a transitive
-equivalence)
+less = The predicate used for comparison, modeled as a
+        $(LINK2 https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings,
+        strict weak ordering) (irreflexive, antisymmetric, transitive, and implying a transitive
+        equivalence)
 r = The range being partitioned
 pivot = The index of the pivot for partitioning, must be less than `r.length` or
 `0` is `r.length` is `0`
@@ -3864,9 +3866,9 @@ with the median of `r[a]`, `r[b]`, and `r[c]`, but also puts the minimum in
 `r[a]` and the maximum in `r[c]`.
 
 Params:
-less = The comparison predicate used, modeled as a $(LUCKY strict weak
-ordering) (irreflexive, antisymmetric, transitive, and implying a transitive
-equivalence).
+less = The comparison predicate used, modeled as a
+    $(LINK2 https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings, strict weak ordering)
+    (irreflexive, antisymmetric, transitive, and implying a transitive equivalence).
 flag = Used only for even values of `T.length`. If `No.leanRight`, the median
 "leans left", meaning $(D medianOf(r, a, b, c, d)) puts the lower median of the
 four in `r[b]`, the minimum in `r[a]`, and the two others in `r[c]` and `r[d]`.

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -175,7 +175,8 @@ heap.
 
 /**
 Clears the heap. Returns the portion of the store from $(D 0) up to
-$(D length), which satisfies the $(LUCKY heap property).
+$(D length), which satisfies the $(LINK2 https://en.wikipedia.org/wiki/Heap_(data_structure),
+heap property).
      */
     auto release()
     {

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -716,7 +716,8 @@ private struct RBRange(N)
 }
 
 /**
- * Implementation of a $(LUCKY red-black tree) container.
+ * Implementation of a $(LINK2 https://en.wikipedia.org/wiki/Red%E2%80%93black_tree,
+ * red-black tree) container.
  *
  * All inserts, removes, searches, and any function in general has complexity
  * of $(BIGOH lg(n)).

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -11,7 +11,8 @@ version(unittest) import std.stdio;
 
 /**
 
-Given an $(LUCKY object factory) of type `Factory` or a factory function
+Given an $(LINK2 https://en.wikipedia.org/wiki/Factory_(object-oriented_programming),
+object factory) of type `Factory` or a factory function
 `factoryFunction`, and optionally also `BookkeepingAllocator` as a supplemental
 allocator for bookkeeping, `AllocatorList` creates an allocator that lazily
 creates as many allocators are needed for satisfying client allocation requests.

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -252,10 +252,11 @@ simple bump-the-pointer allocator.))
 $(TR $(TDC2 InSituRegion, region) $(TD Region holding its own allocation, most often on
 the stack. Has statically-determined size.))
 
-$(TR $(TDC2 SbrkRegion, region) $(TD Region using $(D $(LUCKY sbrk)) for allocating
-memory.))
+$(TR $(TDC2 SbrkRegion, region) $(TD Region using $(D $(LINK2 https://en.wikipedia.org/wiki/Sbrk,
+sbrk)) for allocating memory.))
 
-$(TR $(TDC3 MmapAllocator, mmap_allocator) $(TD Allocator using $(D $(LUCKY mmap)) directly.))
+$(TR $(TDC3 MmapAllocator, mmap_allocator) $(TD Allocator using
+            $(D $(LINK2 https://en.wikipedia.org/wiki/Mmap, mmap)) directly.))
 
 $(TR $(TDC2 StatsCollector, stats_collector) $(TD Collect statistics about any other
 allocator.))

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -581,9 +581,10 @@ private extern(C) int brk(shared void*);
 
 /**
 
-Allocator backed by $(D $(LUCKY sbrk)) for Posix systems. Due to the fact that
-$(D sbrk) is not thread-safe $(HTTP lifecs.likai.org/2010/02/sbrk-is-not-thread-
-safe.html, by design), $(D SbrkRegion) uses a mutex internally. This implies
+Allocator backed by $(D $(LINK2 https://en.wikipedia.org/wiki/Sbrk, sbrk))
+for Posix systems. Due to the fact that $(D sbrk) is not thread-safe
+$(HTTP lifecs.likai.org/2010/02/sbrk-is-not-thread-safe.html, by design),
+$(D SbrkRegion) uses a mutex internally. This implies
 that uncontrolled calls to $(D brk) and $(D sbrk) may affect the workings of $(D
 SbrkRegion) adversely.
 

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -4,7 +4,8 @@ module std.experimental.allocator.mmap_allocator;
 // MmapAllocator
 /**
 
-Allocator (currently defined only for Posix and Windows) using $(D $(LUCKY mmap))
+Allocator (currently defined only for Posix and Windows) using
+$(D $(LINK2 https://en.wikipedia.org/wiki/Mmap, mmap))
 and $(D $(LUCKY munmap)) directly (or their Windows equivalents). There is no
 additional structure: each call to $(D allocate(s)) issues a call to
 $(D mmap(null, s, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)),

--- a/std/functional.d
+++ b/std/functional.d
@@ -963,8 +963,8 @@ alias pipe(fun...) = compose!(Reverse!(fun));
 }
 
 /**
- * $(LUCKY Memoizes) a function so as to avoid repeated
- * computation. The memoization structure is a hash table keyed by a
+ * $(LINK2 https://en.wikipedia.org/wiki/Memoization, Memoizes) a function so as
+ * to avoid repeated computation. The memoization structure is a hash table keyed by a
  * tuple of the function's arguments. There is a speed gain if the
  * function is repeatedly called with the same arguments and is more
  * expensive than a hash table lookup. For more information on memoization, refer to $(HTTP docs.google.com/viewer?url=http%3A%2F%2Fhop.perl.plover.com%2Fbook%2Fpdf%2F03CachingAndMemoization.pdf, this book chapter).

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -40,20 +40,23 @@ public enum CustomFloatFlags
      * Store values in normalized form by default. The actual precision of the
      * significand is extended by 1 bit by assuming an implicit leading bit of 1
      * instead of 0. i.e. $(D 1.nnnn) instead of $(D 0.nnnn).
-     * True for all $(LUCKY IEE754) types
+     * True for all $(LINK2 https://en.wikipedia.org/wiki/IEEE_floating_point, IEE754) types
      */
     storeNormalized = 2,
 
     /**
-     * Stores the significand in $(LUCKY IEEE754 denormalized) form when the
-     * exponent is 0. Required to express the value 0.
+     * Stores the significand in $(LINK2 https://en.wikipedia.org/wiki/IEEE_754-1985#Denormalized_numbers,
+     * IEEE754 denormalized) form when the exponent is 0. Required to express the value 0.
      */
     allowDenorm = 4,
 
-    /// Allows the storage of $(LUCKY IEEE754 _infinity) values.
+    /**
+      * Allows the storage of $(LINK2 https://en.wikipedia.org/wiki/IEEE_754-1985#Positive_and_negative_infinity,
+      * IEEE754 _infinity) values.
+      */
     infinity = 8,
 
-    /// Allows the storage of $(LUCKY IEEE754 Not a Number) values.
+    /// Allows the storage of $(LINK2 https://en.wikipedia.org/wiki/NaN, IEEE754 Not a Number) values.
     nan = 16,
 
     /**
@@ -66,12 +69,13 @@ public enum CustomFloatFlags
     /// If set, unsigned custom floats are assumed to be negative.
     negativeUnsigned = 64,
 
-    /**If set, 0 is the only allowed $(LUCKY IEEE754 denormalized) number.
+    /**If set, 0 is the only allowed $(LINK2 https://en.wikipedia.org/wiki/IEEE_754-1985#Denormalized_numbers,
+     * IEEE754 denormalized) number.
      * Requires allowDenorm and storeNormalized.
      */
     allowDenormZeroOnly = 128 | allowDenorm | storeNormalized,
 
-    /// Include _all of the $(LUCKY IEEE754) options.
+    /// Include _all of the $(LINK2 https://en.wikipedia.org/wiki/IEEE_floating_point, IEEE754) options.
     ieee = signed | storeNormalized | allowDenorm | infinity | nan ,
 
     /// Include none of the above options.
@@ -1624,7 +1628,8 @@ body
 }
 
 /**
-Computes $(LUCKY Euclidean distance) between input ranges $(D a) and
+Computes $(LINK2 https://en.wikipedia.org/wiki/Euclidean_distance,
+Euclidean distance) between input ranges $(D a) and
 $(D b). The two ranges must have the same length. The three-parameter
 version stops computation as soon as the distance is greater than or
 equal to $(D limit) (this is useful to save computation if a small
@@ -1684,7 +1689,8 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 }
 
 /**
-Computes the $(LUCKY dot product) of input ranges $(D a) and $(D
+Computes the $(LINK2 https://en.wikipedia.org/wiki/Dot_product,
+dot product) of input ranges $(D a) and $(D
 b). The two ranges must have the same length. If both ranges define
 length, the check is done once; otherwise, it is done at each
 iteration.
@@ -1781,7 +1787,8 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
 }
 
 /**
-Computes the $(LUCKY cosine similarity) of input ranges $(D a) and $(D
+Computes the $(LINK2 https://en.wikipedia.org/wiki/Cosine_similarity,
+cosine similarity) of input ranges $(D a) and $(D
 b). The two ranges must have the same length. If both ranges define
 length, the check is done once; otherwise, it is done at each
 iteration. If either range has all-zero elements, return 0.
@@ -1924,7 +1931,8 @@ if (isInputRange!Range && isFloatingPoint!(ElementType!Range))
 }
 
 /**
-Computes $(LUCKY _entropy) of input range $(D r) in bits. This
+Computes $(LINK2 https://en.wikipedia.org/wiki/Entropy_(information_theory),
+_entropy) of input range $(D r) in bits. This
 function assumes (without checking) that the values in $(D r) are all
 in $(D [0, 1]). For the entropy to be meaningful, often $(D r) should
 be normalized too (i.e., its values should sum to 1). The
@@ -1972,7 +1980,8 @@ if (isInputRange!Range &&
 }
 
 /**
-Computes the $(LUCKY Kullback-Leibler divergence) between input ranges
+Computes the $(LINK2 https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence,
+Kullback-Leibler divergence) between input ranges
 $(D a) and $(D b), which is the sum $(D ai * log(ai / bi)). The base
 of logarithm is 2. The ranges are assumed to contain elements in $(D
 [0, 1]). Usually the ranges are normalized probability distributions,
@@ -2020,7 +2029,8 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 }
 
 /**
-Computes the $(LUCKY Jensen-Shannon divergence) between $(D a) and $(D
+Computes the $(LINK2 https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence,
+Jensen-Shannon divergence) between $(D a) and $(D
 b), which is the sum $(D (ai * log(2 * ai / (ai + bi)) + bi * log(2 *
 bi / (ai + bi))) / 2). The base of logarithm is 2. The ranges are
 assumed to contain elements in $(D [0, 1]). Usually the ranges are

--- a/std/random.d
+++ b/std/random.d
@@ -8,9 +8,11 @@ immune of threading issues. The generators feature a number of
 well-known and well-documented methods of generating random
 numbers. An overall fast and reliable means to generate random numbers
 is the $(D_PARAM Mt19937) generator, which derives its name from
-"$(LUCKY Mersenne Twister) with a period of 2 to the power of
-19937". In memory-constrained situations, $(LUCKY linear congruential)
-generators such as $(D MinstdRand0) and $(D MinstdRand) might be
+"$(LINK2 https://en.wikipedia.org/wiki/Mersenne_Twister, Mersenne Twister)
+with a period of 2 to the power of
+19937". In memory-constrained situations,
+$(LINK2 https://en.wikipedia.org/wiki/Linear_congruential_generator,
+linear congruential generators) such as $(D MinstdRand0) and $(D MinstdRand) might be
 useful. The standard library provides an alias $(D_PARAM Random) for
 whichever generator it considers the most fit for the target
 environment.
@@ -525,7 +527,7 @@ alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
 }
 
 /**
-The $(LUCKY Mersenne Twister) generator.
+The $(LINK2 https://en.wikipedia.org/wiki/Mersenne_Twister, Mersenne Twister) generator.
  */
 struct MersenneTwisterEngine(UIntType, size_t w, size_t n, size_t m, size_t r,
                              UIntType a, size_t u, UIntType d, size_t s,

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8139,7 +8139,8 @@ enum SearchPolicy
     trot,
 
     /**
-       Performs a $(LUCKY galloping search algorithm), i.e. searches
+       Performs a $(LINK2 https://en.wikipedia.org/wiki/Exponential_search,
+       galloping search algorithm), i.e. searches
        with a step that doubles every time, (1, 2, 4, 8, ...)  leading
        to an exponential search schedule (indexes tried are 0, 1, 3,
        7, 15, 31, 63,...) Once the search overshoots its target, the

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1,5 +1,6 @@
 /++
-  $(LUCKY Regular expressions) are a commonly used method of pattern matching
+  $(LINK2 https://en.wikipedia.org/wiki/Regular_expression, Regular expressions)
+  are a commonly used method of pattern matching
   on strings, with $(I regex) being a catchy word for a pattern in this domain
   specific language. Typical problems usually solved by regular expressions
   include validation of user input and the ubiquitous find $(AMP) replace
@@ -1058,7 +1059,8 @@ if (isSomeString!R && is(RegEx == StaticRegex!(BasicElementOf!R)))
 
 /++
     Start matching of $(D input) to regex pattern $(D re),
-    using traditional $(LUCKY backtracking) matching scheme.
+    using traditional $(LINK2 https://en.wikipedia.org/wiki/Backtracking,
+    backtracking) matching scheme.
 
     The use of this function is $(RED discouraged) - use either of
     $(LREF matchAll) or $(LREF matchFirst).

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2883,8 +2883,8 @@ See $(LREF byChunk) for an example.
 /** Returns an output range that locks the file and allows fast writing to it.
 
 Example:
-Produce a grayscale image of the $(LUCKY Mandelbrot set)
-in binary $(LUCKY Netpbm format) to standard output.
+Produce a grayscale image of the $(LINK2 https://en.wikipedia.org/wiki/Mandelbrot_set, Mandelbrot set)
+in binary $(LINK2 https://en.wikipedia.org/wiki/Netpbm_format, Netpbm format) to standard output.
 ---
 import std.algorithm, std.range, std.stdio;
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -55,7 +55,7 @@
         )
         $(LI
             A way to construct optimal packed multi-stage tables also known as a
-            special case of $(LUCKY Trie).
+            special case of $(LINK2 https://en.wikipedia.org/wiki/Trie, Trie).
             The functions $(LREF codepointTrie), $(LREF codepointSetTrie)
             construct custom tries that map dchar to value.
             The end result is a fast and predictable $(BIGOH 1) lookup that powers
@@ -1940,7 +1940,7 @@ pure:
     As seen this provides a space-efficient storage of highly redundant data
     that comes in long runs. A description which Unicode $(CHARACTER)
     properties fit nicely. The technique itself could be seen as a variation
-    on $(LUCKY RLE encoding).
+    on $(LINK2 https://en.wikipedia.org/wiki/Run-length_encoding, RLE encoding).
     )
 
     $(P Sets are value types (just like $(D int) is) thus they

--- a/std/variant.d
+++ b/std/variant.d
@@ -1395,7 +1395,8 @@ values of their own type within.
 
 This is achieved with `Algebraic` by using `This` as a placeholder whenever a
 reference to the type being defined is needed. The `Algebraic` instantiation
-will perform $(LUCKY alpha renaming) on its constituent types, replacing `This`
+will perform $(LINK2 https://en.wikipedia.org/wiki/Name_resolution_(programming_languages)#Alpha_renaming_to_make_name_resolution_trivial,
+alpha renaming) on its constituent types, replacing `This`
 with the self-referenced type. The structure of the type involving `This` may
 be arbitrarily complex.
 */


### PR DESCRIPTION
The Ddoc macro system seems to be able to continuously amaze me everyday.
So there's `LUCKY` which will insert a link to a lucky google search with the highlighted word.
I get the idea of this to avoid broken manual or book links, but not really for common terms for which there are high-quality Wikipedia articles on abundance.