### PR TITLE
[BOOKTABLES]: Add BOOKTABLE to std.utf

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -6,6 +6,48 @@
     UTF character support is restricted to
     $(D '\u0000' &lt;= character &lt;= '\U0010FFFF').
 
+$(SCRIPT inhibitQuickIndex = 1;)
+$(BOOKTABLE,
+$(TR $(TH Category) $(TH Functions))
+$(TR $(TD Decode) $(TD
+    $(LREF decode)
+    $(LREF decodeFront)
+))
+$(TR $(TD Lazy decode) $(TD
+    $(LREF byCodeUnit)
+    $(LREF byChar)
+    $(LREF byWchar)
+    $(LREF byDchar)
+    $(LREF byUTF)
+))
+$(TR $(TD Encode) $(TD
+    $(LREF encode)
+    $(LREF toUTF8)
+    $(LREF toUTF16)
+    $(LREF toUTF32)
+    $(LREF toUTFz)
+    $(LREF toUTF16z)
+))
+$(TR $(TD Length) $(TD
+    $(LREF codeLength)
+    $(LREF count)
+    $(LREF stride)
+    $(LREF strideBack)
+))
+$(TR $(TD Index) $(TD
+    $(LREF toUCSindex)
+    $(LREF toUTFindex)
+))
+$(TR $(TD Validation) $(TD
+    $(LREF isValidDchar)
+    $(LREF validate)
+))
+$(TR $(TD Miscellaneous) $(TD
+    $(LREF replacementDchar)
+    $(LREF UseReplacementDchar)
+    $(LREF UTFException)
+))
+)
     See_Also:
         $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
         $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4370550/23481063/6bb88c02-feca-11e6-8865-306ee95606e2.png)

@jmdavis I think you are probably the best person to judge the grouping.

I wasn't sure whether:
- to show `byUTF` at all (the user is only interested in the three convenience overloads)
- combine "Decode" and "Lazy decode" (I went with the current option as I wanted to stress the laziness)