### PR TITLE
walkBack follow-up: Mention fold's potential in the examples

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3206,6 +3206,9 @@ if (fun.length >= 1)
 
     // Can be used in a UFCS chain
     assert(arr.map!(a => a + 1).fold!((a, b) => a + b) == 20);
+
+    // Return the last element of any range
+    assert(arr.fold!((a, b) => b) == 5);
 }
 
 @safe @nogc pure nothrow unittest


### PR DESCRIPTION
> Best outcome of this: a ddoc unittest of fold that prints the last line of a file.

Hmm we don't have many tests based on files and they usually are a bit clunky as one needs to write the file first.
So I simply added the "`walkBack` usage" to the existing unittests of `fold`.
However, I am happy to add a file example as well if you know a good spot ;-)