### PR TITLE
Fix issue 17229 - File.byChunk (ubyte) w/ stdout.lockingTextWriter corrupts utf-8 data (and is very slow)

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2642,7 +2642,8 @@ $(D Range) that locks the file and allows fast writing to it.
 
         /// Range primitive implementations.
         void put(A)(A writeme)
-            if (is(ElementType!A : const(dchar)) &&
+            if ((isSomeChar!(Unqual!(ElementType!A)) ||
+                  is(ElementType!A : const(ubyte))) &&
                 isInputRange!A &&
                 !isInfinite!A)
         {
@@ -2650,7 +2651,7 @@ $(D Range) that locks the file and allows fast writing to it.
 
             alias C = ElementEncodingType!A;
             static assert(!is(C == void));
-            static if (isSomeString!A && C.sizeof == 1)
+            static if (isSomeString!A && C.sizeof == 1 || is(A : const(ubyte)[]))
             {
                 if (orientation_ <= 0)
                 {
@@ -2662,15 +2663,16 @@ $(D Range) that locks the file and allows fast writing to it.
                 }
             }
 
-            // put each character in turn
-            foreach (dchar c; writeme)
+            // put each element in turn.
+            alias Elem = Unqual!(ElementType!A);
+            foreach (Elem c; writeme)
             {
                 put(c);
             }
         }
 
         /// ditto
-        void put(C)(C c) @safe if (is(C : const(dchar)))
+        void put(C)(C c) @safe if (isSomeChar!C || is(C : const(ubyte)))
         {
             import std.traits : Parameters;
             static auto trustedFPUTC(int ch, _iobuf* h) @trusted

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3165,8 +3165,9 @@ void main()
         writer.put('日');
         writer.put(chain(only('本'), only('語')));
         writer.put(repeat('#', 12)); // BUG 11945
+        writer.put(cast(immutable(ubyte)[])"日本語"); // Bug 17229
     }
-    assert(File(deleteme).readln() == "日本語日本語日本語日本語############");
+    assert(File(deleteme).readln() == "日本語日本語日本語日本語############日本語");
 }
 
 @safe unittest


### PR DESCRIPTION
The fix is basically to disallow compiling the putting of `ubyte` data into the output range. It will now only accept arrays of a character type, or ranges of a character type. Any other type is not really a character, and should be cast if that's what you really meant.

Note that the original code did really bad things. For instance, an array of `ubyte` was put into the output stream by integer promoting each `ubyte` into a `dchar`, and then encoding whatever the result of that was into utf-8 code units.

I'm not sure if we need a deprecation here, as code that is passing `ubyte[]` to `lockingTextWriter` is fundamentally broken, but maybe I'm wrong and there are some valid uses for this that need to be migrated to `char[]` casting?

Also updated the example to reflect the correct usage for "Efficient file copy", which was both broken and not efficient.