### PR TITLE
Removed auto decoding from a helper function in std.conv

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3416,7 +3416,7 @@ package void skipWS(R)(ref R r)
     static if (isSomeString!R)
     {
         //Implementation inspired from stripLeft.
-        foreach (i, dchar c; r)
+        foreach (i, c; r)
         {
             if (!isWhite(c))
             {


### PR DESCRIPTION
Only checking for ASCII whitespace anyway.

Gives performance boost of about 7% on DMD