### PR TITLE
[BOOKTABLES]: Add BOOKTABLE to std.uni

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -4,8 +4,99 @@
     $(P The $(D std.uni) module provides an implementation
     of fundamental Unicode algorithms and data structures.
     This doesn't include UTF encoding and decoding primitives,
-    see $(REF decode, std,_utf) and $(REF encode, std,_utf) in std.utf
+    see $(REF decode, std,_utf) and $(REF encode, std,_utf) in $(MREF std, utf)
     for this functionality. )
+
+$(SCRIPT inhibitQuickIndex = 1;)
+$(BOOKTABLE,
+$(TR $(TH Category) $(TH Functions))
+$(TR $(TD Decode) $(TD
+    $(LREF byCodePoint)
+    $(LREF byGrapheme)
+    $(LREF decodeGrapheme)
+    $(LREF graphemeStride)
+))
+$(TR $(TD Comparison) $(TD
+    $(LREF icmp)
+    $(LREF sicmp)
+))
+$(TR $(TD Classification) $(TD
+    $(LREF isAlpha)
+    $(LREF isAlphaNum)
+    $(LREF isCodepointSet)
+    $(LREF isControl)
+    $(LREF isFormat)
+    $(LREF isGraphical)
+    $(LREF isIntegralPair)
+    $(LREF isMark)
+    $(LREF isNonCharacter)
+    $(LREF isNumber)
+    $(LREF isPrivateUse)
+    $(LREF isPunctuation)
+    $(LREF isSpace)
+    $(LREF isSurrogate)
+    $(LREF isSurrogateHi)
+    $(LREF isSurrogateLo)
+    $(LREF isSymbol)
+    $(LREF isWhite)
+))
+$(TR $(TD Normalization) $(TD
+    $(LREF NFC)
+    $(LREF NFD)
+    $(LREF NFKD)
+    $(LREF NormalizationForm)
+    $(LREF normalize)
+))
+$(TR $(TD Decompose) $(TD
+    $(LREF decompose)
+    $(LREF decomposeHangul)
+    $(LREF UnicodeDecomposition)
+))
+$(TR $(TD Compose) $(TD
+    $(LREF compose)
+    $(LREF composeJamo)
+))
+$(TR $(TD Sets) $(TD
+    $(LREF CodepointInterval)
+    $(LREF CodepointSet)
+    $(LREF InversionList)
+    $(LREF unicode)
+))
+$(TR $(TD Trie) $(TD
+    $(LREF codepointSetTrie)
+    $(LREF CodepointSetTrie)
+    $(LREF codepointTrie)
+    $(LREF CodepointTrie)
+    $(LREF toTrie)
+    $(LREF toDelegate)
+))
+$(TR $(TD Casing) $(TD
+    $(LREF asCapitalized)
+    $(LREF asLowerCase)
+    $(LREF asUpperCase)
+    $(LREF isLower)
+    $(LREF isUpper)
+    $(LREF toLower)
+    $(LREF toLowerInPlace)
+    $(LREF toUpper)
+    $(LREF toUpperInPlace)
+))
+$(TR $(TD Utf8Matcher) $(TD
+    $(LREF isUtfMatcher)
+    $(LREF MatcherConcept)
+    $(LREF utfMatcher)
+))
+$(TR $(TD Separators) $(TD
+    $(LREF lineSep)
+    $(LREF nelSep)
+    $(LREF paraSep)
+))
+$(TR $(TD Building blocks) $(TD
+    $(LREF allowedIn)
+    $(LREF combiningClass)
+    $(LREF Grapheme)
+))
+)
 
     $(P All primitives listed operate on Unicode characters and
         sets of characters. For functions which operate on ASCII characters


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4370550/23575740/950fd3c0-0092-11e7-9b1f-8447c4f1a922.png)

I am not really sure here what the best way to go is. The current documentation already contains a good introduction, which is pretty much destroyed by the quickIndex. 

### The current documentation looks like this:

![image](https://cloud.githubusercontent.com/assets/4370550/23575672/3de4cc82-0091-11e7-92d9-5c7a7dcce5cc.png)

https://dlang.org/phobos/std_uni.html

So we could also try to (a) include the missing functions in the "text-based" overview or (b) use the full-text information in a table overview as well.

Moreover for some symbols I wasn't entirely sure how to categorize them, e.g. `Grapheme` was a tough one.