### PR TITLE
Fix links from $(D $(LREF ...)) -> $(LREF ...)

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -8,60 +8,60 @@ $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF _array)))
+    $(TR $(TD $(LREF _array))
         $(TD Returns a copy of the input in a newly allocated dynamic _array.
     ))
-    $(TR $(TD $(D $(LREF appender)))
+    $(TR $(TD $(LREF appender))
         $(TD Returns a new $(LREF Appender) or $(LREF RefAppender) initialized with a given _array.
     ))
-    $(TR $(TD $(D $(LREF assocArray)))
+    $(TR $(TD $(LREF assocArray))
         $(TD Returns a newly allocated associative _array from a range of key/value tuples.
     ))
-    $(TR $(TD $(D $(LREF byPair)))
+    $(TR $(TD $(LREF byPair))
         $(TD Construct a range iterating over an associative _array by key/value tuples.
     ))
-    $(TR $(TD $(D $(LREF insertInPlace)))
+    $(TR $(TD $(LREF insertInPlace))
         $(TD Inserts into an existing _array at a given position.
     ))
-    $(TR $(TD $(D $(LREF join)))
+    $(TR $(TD $(LREF join))
         $(TD Concatenates a range of ranges into one _array.
     ))
-    $(TR $(TD $(D $(LREF minimallyInitializedArray)))
+    $(TR $(TD $(LREF minimallyInitializedArray))
         $(TD Returns a new _array of type $(D T).
     ))
-    $(TR $(TD $(D $(LREF replace)))
+    $(TR $(TD $(LREF replace))
         $(TD Returns a new _array with all occurrences of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceFirst)))
+    $(TR $(TD $(LREF replaceFirst))
         $(TD Returns a new _array with the first occurrence of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceInPlace)))
+    $(TR $(TD $(LREF replaceInPlace))
         $(TD Replaces all occurrences of a certain subrange and puts the result into a given _array.
     ))
-    $(TR $(TD $(D $(LREF replaceInto)))
+    $(TR $(TD $(LREF replaceInto))
         $(TD Replaces all occurrences of a certain subrange and puts the result into an output range.
     ))
-    $(TR $(TD $(D $(LREF replaceLast)))
+    $(TR $(TD $(LREF replaceLast))
         $(TD Returns a new _array with the last occurrence of a certain subrange replaced.
     ))
-    $(TR $(TD $(D $(LREF replaceSlice)))
+    $(TR $(TD $(LREF replaceSlice))
         $(TD Returns a new _array with a given slice replaced.
     ))
-    $(TR $(TD $(D $(LREF replicate)))
+    $(TR $(TD $(LREF replicate))
         $(TD Creates a new _array out of several copies of an input _array or range.
     ))
-    $(TR $(TD $(D $(LREF sameHead)))
+    $(TR $(TD $(LREF sameHead))
         $(TD Checks if the initial segments of two arrays refer to the same
         place in memory.
     ))
-    $(TR $(TD $(D $(LREF sameTail)))
+    $(TR $(TD $(LREF sameTail))
         $(TD Checks if the final segments of two arrays refer to the same place
         in memory.
     ))
-    $(TR $(TD $(D $(LREF split)))
+    $(TR $(TD $(LREF split))
         $(TD Eagerly split a range or string into an _array.
     ))
-    $(TR $(TD $(D $(LREF uninitializedArray)))
+    $(TR $(TD $(LREF uninitializedArray))
         $(TD Returns a new _array of type $(D T) without initializing its elements.
     ))
 )

--- a/std/base64.d
+++ b/std/base64.d
@@ -4,12 +4,12 @@
  * Support for Base64 encoding and decoding.
  *
  * This module provides two default implementations of Base64 encoding,
- * $(D $(LREF Base64)) with a standard encoding alphabet, and a variant
- * $(D $(LREF Base64URL)) that has a modified encoding alphabet designed to be
+ * $(LREF Base64) with a standard encoding alphabet, and a variant
+ * $(LREF Base64URL) that has a modified encoding alphabet designed to be
  * safe for embedding in URLs and filenames.
  *
  * Both variants are implemented as instantiations of the template
- * $(D $(LREF Base64Impl)). Most users will not need to use this template
+ * $(LREF Base64Impl). Most users will not need to use this template
  * directly; however, it can be used to create customized Base64 encodings,
  * such as one that omits padding characters, or one that is safe to embed
  * inside a regular expression.
@@ -76,7 +76,7 @@ import std.traits;     // isArray
 /**
  * Implementation of standard _Base64 encoding.
  *
- * See $(D $(LREF Base64Impl)) for a description of available methods.
+ * See $(LREF Base64Impl) for a description of available methods.
  */
 alias Base64 = Base64Impl!('+', '/');
 
@@ -92,7 +92,7 @@ alias Base64 = Base64Impl!('+', '/');
 /**
  * Variation of Base64 encoding that is safe for use in URLs and filenames.
  *
- * See $(D $(LREF Base64Impl)) for a description of available methods.
+ * See $(LREF Base64Impl) for a description of available methods.
  */
 alias Base64URL = Base64Impl!('-', '_');
 
@@ -109,8 +109,8 @@ alias Base64URL = Base64Impl!('-', '_');
  * Template for implementing Base64 encoding and decoding.
  *
  * For most purposes, direct usage of this template is not necessary; instead,
- * this module provides two default implementations: $(D $(LREF Base64)) and
- * $(D $(LREF Base64URL)), that implement basic Base64 encoding and a variant
+ * this module provides two default implementations: $(LREF Base64) and
+ * $(LREF Base64URL), that implement basic Base64 encoding and a variant
  * intended for use in URLs and filenames, respectively.
  *
  * Customized Base64 encoding schemes can be implemented by instantiating this

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -44,17 +44,17 @@ This module provides a few predefined hooks (below) that add useful behavior to
 `Checked`:
 
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF Abort))) $(TD
+    $(TR $(TD $(LREF Abort)) $(TD
         fails every incorrect operation with a message to $(REF
         stderr, std, stdio) followed by a call to `assert(0)`. It is the default
         second parameter, i.e. `Checked!short` is the same as
         $(D Checked!(short, Abort)).
     ))
-    $(TR $(TD $(D $(LREF Warn))) $(TD
+    $(TR $(TD $(LREF Warn)) $(TD
         prints incorrect operations to $(REF stderr, std, stdio)
         but otherwise preserves the built-in behavior.
     ))
-    $(TR $(TD $(D $(LREF ProperCompare))) $(TD
+    $(TR $(TD $(LREF ProperCompare)) $(TD
         fixes the comparison operators `==`, `!=`, `<`, `<=`, `>`, and `>=`
         to return correct results in all circumstances,
         at a slight cost in efficiency. For example,
@@ -64,14 +64,14 @@ $(BOOKTABLE ,
         integral can be converted to the floating-point number precisely,
         so as to preserve transitivity of equality.
     ))
-    $(TR $(TD $(D $(LREF WithNaN))) $(TD
+    $(TR $(TD $(LREF WithNaN)) $(TD
         reserves a special "Not a Number" (NaN) value akin to the homonym value
         reserved for floating-point values. Once a $(D Checked!(X, WithNaN))
         gets this special value, it preserves and propagates it until
         reassigned. $(LREF isNaN) can be used to query whether the object
         is not a number.
     ))
-    $(TR $(TD $(D $(LREF Saturate))) $(TD
+    $(TR $(TD $(LREF Saturate)) $(TD
         implements saturating arithmetic, i.e. $(D Checked!(int, Saturate))
         "stops" at `int.max` for all operations that would cause an `int` to
         overflow toward infinity, and at `int.min` for all operations that would

--- a/std/format.d
+++ b/std/format.d
@@ -14,16 +14,16 @@
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF formattedRead)))
+    $(TR $(TD $(LREF formattedRead))
         $(TD Reads values according to the _format string from an InputRange.
     ))
-    $(TR $(TD $(D $(LREF formattedWrite)))
+    $(TR $(TD $(LREF formattedWrite))
         $(TD Formats its arguments according to the _format string and puts them
         to an OutputRange.
     ))
 )
 
-   Please see the documentation of function $(D $(LREF formattedWrite)) for a
+   Please see the documentation of function $(LREF formattedWrite) for a
    description of the _format string.
 
    Two functions have been added for convenience:
@@ -31,10 +31,10 @@ $(TR $(TH Function Name) $(TH Description)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF _format)))
+    $(TR $(TD $(LREF _format))
         $(TD Returns a GC-allocated string with the formatting result.
     ))
-    $(TR $(TD $(D $(LREF sformat)))
+    $(TR $(TD $(LREF sformat))
         $(TD Puts the formatting result into a preallocated array.
     ))
 )
@@ -42,7 +42,7 @@ $(TR $(TH Function Name) $(TH Description)
    These two functions are publicly imported by $(MREF std, string)
    to be easily available.
 
-   The functions $(D $(LREF formatValue)) and $(D $(LREF unformatValue)) are
+   The functions $(LREF formatValue) and $(LREF unformatValue) are
    used for the plumbing.
    Copyright: Copyright Digital Mars 2000-2013.
 

--- a/std/functional.d
+++ b/std/functional.d
@@ -11,38 +11,38 @@ $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(D $(LREF adjoin)))
+    $(TR $(TD $(LREF adjoin))
         $(TD Joins a couple of functions into one that executes the original
         functions independently and returns a tuple with all the results.
     ))
-    $(TR $(TD $(D $(LREF compose)), $(D $(LREF pipe)))
+    $(TR $(TD $(LREF compose)), $(LREF pipe)
         $(TD Join a couple of functions into one that executes the original
         functions one after the other, using one function's result for the next
         function's argument.
     ))
-    $(TR $(TD $(D $(LREF forward)))
+    $(TR $(TD $(LREF forward))
         $(TD Forwards function arguments while saving ref-ness.
     ))
-    $(TR $(TD $(D $(LREF lessThan)), $(D $(LREF greaterThan)), $(D $(LREF equalTo)))
+    $(TR $(TD $(LREF lessThan)), $(LREF greaterThan)), $(D $(LREF equalTo)
         $(TD Ready-made predicate functions to compare two values.
     ))
-    $(TR $(TD $(D $(LREF memoize)))
+    $(TR $(TD $(LREF memoize))
         $(TD Creates a function that caches its result for fast re-evaluation.
     ))
-    $(TR $(TD $(D $(LREF not)))
+    $(TR $(TD $(LREF not))
         $(TD Creates a function that negates another.
     ))
-    $(TR $(TD $(D $(LREF partial)))
+    $(TR $(TD $(LREF partial))
         $(TD Creates a function that binds the first argument of a given function
         to a given value.
     ))
-    $(TR $(TD $(D $(LREF reverseArgs)), $(D $(LREF binaryReverseArgs)))
+    $(TR $(TD $(LREF reverseArgs)), $(LREF binaryReverseArgs)
         $(TD Predicate that reverses the order of its arguments.
     ))
-    $(TR $(TD $(D $(LREF toDelegate)))
+    $(TR $(TD $(LREF toDelegate))
         $(TD Converts a callable to a delegate.
     ))
-    $(TR $(TD $(D $(LREF unaryFun)), $(D $(LREF binaryFun)))
+    $(TR $(TD $(LREF unaryFun)), $(LREF binaryFun)
         $(TD Create a unary or binary function from a string. Most often
         used when defining algorithms on ranges.
     ))

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -9,52 +9,52 @@ wrap around _range objects created by the $(MREF std, range) templates.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF InputRange)))
+    $(TR $(TD $(LREF InputRange))
         $(TD Wrapper for input ranges.
     ))
-    $(TR $(TD $(D $(LREF InputAssignable)))
+    $(TR $(TD $(LREF InputAssignable))
         $(TD Wrapper for input ranges with assignable elements.
     ))
-    $(TR $(TD $(D $(LREF ForwardRange)))
+    $(TR $(TD $(LREF ForwardRange))
         $(TD Wrapper for forward ranges.
     ))
-    $(TR $(TD $(D $(LREF ForwardAssignable)))
+    $(TR $(TD $(LREF ForwardAssignable))
         $(TD Wrapper for forward ranges with assignable elements.
     ))
-    $(TR $(TD $(D $(LREF BidirectionalRange)))
+    $(TR $(TD $(LREF BidirectionalRange))
         $(TD Wrapper for bidirectional ranges.
     ))
-    $(TR $(TD $(D $(LREF BidirectionalAssignable)))
+    $(TR $(TD $(LREF BidirectionalAssignable))
         $(TD Wrapper for bidirectional ranges with assignable elements.
     ))
-    $(TR $(TD $(D $(LREF RandomAccessFinite)))
+    $(TR $(TD $(LREF RandomAccessFinite))
         $(TD Wrapper for finite random-access ranges.
     ))
-    $(TR $(TD $(D $(LREF RandomAccessAssignable)))
+    $(TR $(TD $(LREF RandomAccessAssignable))
         $(TD Wrapper for finite random-access ranges with assignable elements.
     ))
-    $(TR $(TD $(D $(LREF RandomAccessInfinite)))
+    $(TR $(TD $(LREF RandomAccessInfinite))
         $(TD Wrapper for infinite random-access ranges.
     ))
-    $(TR $(TD $(D $(LREF OutputRange)))
+    $(TR $(TD $(LREF OutputRange))
         $(TD Wrapper for output ranges.
     ))
-    $(TR $(TD $(D $(LREF OutputRangeObject)))
+    $(TR $(TD $(LREF OutputRangeObject))
         $(TD Class that implements the $(D OutputRange) interface and wraps the
         $(D put) methods in virtual functions.
-    $(TR $(TD $(D $(LREF outputRangeObject)))
+    $(TR $(TD $(LREF outputRangeObject))
         Convenience function for creating an $(D OutputRangeObject) with a base
         range of type R that accepts types E.
     ))
-    $(TR $(TD $(D $(LREF InputRangeObject)))
+    $(TR $(TD $(LREF InputRangeObject))
         $(TD Class that implements the $(D InputRange) interface and wraps the
         input _range methods in virtual functions.
     ))
-    $(TR $(TD $(D $(LREF InputRangeObject)))
+    $(TR $(TD $(LREF InputRangeObject))
         $(TD Convenience function for creating an $(D InputRangeObject)
         of the proper type.
     ))
-    $(TR $(TD $(D $(LREF MostDerivedInputRange)))
+    $(TR $(TD $(LREF MostDerivedInputRange))
         $(TD Returns the interface type that best matches the range.)
     ))
 )

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -33,133 +33,133 @@ The remainder of this module provides a rich set of _range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF chain)))
+    $(TR $(TD $(LREF chain))
         $(TD Concatenates several ranges into a single _range.
     ))
-    $(TR $(TD $(D $(LREF choose)))
+    $(TR $(TD $(LREF choose))
         $(TD Chooses one of two ranges at runtime based on a boolean condition.
     ))
-    $(TR $(TD $(D $(LREF chooseAmong)))
+    $(TR $(TD $(LREF chooseAmong))
         $(TD Chooses one of several ranges at runtime based on an index.
     ))
-    $(TR $(TD $(D $(LREF chunks)))
+    $(TR $(TD $(LREF chunks))
         $(TD Creates a _range that returns fixed-size chunks of the original
         _range.
     ))
-    $(TR $(TD $(D $(LREF cycle)))
+    $(TR $(TD $(LREF cycle))
         $(TD Creates an infinite _range that repeats the given forward _range
         indefinitely. Good for implementing circular buffers.
     ))
-    $(TR $(TD $(D $(LREF drop)))
+    $(TR $(TD $(LREF drop))
         $(TD Creates the _range that results from discarding the first $(I n)
         elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF dropExactly)))
+    $(TR $(TD $(LREF dropExactly))
         $(TD Creates the _range that results from discarding exactly $(I n)
         of the first elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF dropOne)))
+    $(TR $(TD $(LREF dropOne))
         $(TD Creates the _range that results from discarding
         the first elements from the given _range.
     ))
-    $(TR $(TD $(D $(LREF enumerate)))
+    $(TR $(TD $(LREF enumerate))
         $(TD Iterates a _range with an attached index variable.
     ))
-    $(TR $(TD $(D $(LREF evenChunks)))
+    $(TR $(TD $(LREF evenChunks))
         $(TD Creates a _range that returns a number of chunks of
         approximately equal length from the original _range.
     ))
-    $(TR $(TD $(D $(LREF frontTransversal)))
+    $(TR $(TD $(LREF frontTransversal))
         $(TD Creates a _range that iterates over the first elements of the
         given ranges.
     ))
-    $(TR $(TD $(D $(LREF indexed)))
+    $(TR $(TD $(LREF indexed))
         $(TD Creates a _range that offers a view of a given _range as though
         its elements were reordered according to a given _range of indices.
     ))
-    $(TR $(TD $(D $(LREF iota)))
+    $(TR $(TD $(LREF iota))
         $(TD Creates a _range consisting of numbers between a starting point
         and ending point, spaced apart by a given interval.
     ))
-    $(TR $(TD $(D $(LREF lockstep)))
+    $(TR $(TD $(LREF lockstep))
         $(TD Iterates $(I n) _ranges in lockstep, for use in a $(D foreach)
         loop. Similar to $(D zip), except that $(D lockstep) is designed
         especially for $(D foreach) loops.
     ))
-    $(TR $(TD $(D $(LREF NullSink)))
+    $(TR $(TD $(LREF NullSink))
         $(TD An output _range that discards the data it receives.
     ))
-    $(TR $(TD $(D $(LREF only)))
+    $(TR $(TD $(LREF only))
         $(TD Creates a _range that iterates over the given arguments.
     ))
-    $(TR $(TD $(D $(LREF padLeft)))
+    $(TR $(TD $(LREF padLeft))
         $(TD Pads a _range to a specified length by adding a given element to
         the front of the _range. Is lazy if the range has a known length.
     ))
-    $(TR $(TD $(D $(LREF padRight)))
+    $(TR $(TD $(LREF padRight))
         $(TD Lazily pads a _range to a specified length by adding a given element to
         the back of the _range.
     ))
-    $(TR $(TD $(D $(LREF radial)))
+    $(TR $(TD $(LREF radial))
         $(TD Given a random-access _range and a starting point, creates a
         _range that alternately returns the next left and next right element to
         the starting point.
     ))
-    $(TR $(TD $(D $(LREF recurrence)))
+    $(TR $(TD $(LREF recurrence))
         $(TD Creates a forward _range whose values are defined by a
         mathematical recurrence relation.
     ))
-    $(TR $(TD $(D $(LREF repeat)))
+    $(TR $(TD $(LREF repeat))
         $(TD Creates a _range that consists of a single element repeated $(I n)
         times, or an infinite _range repeating that element indefinitely.
     ))
-    $(TR $(TD $(D $(LREF retro)))
+    $(TR $(TD $(LREF retro))
         $(TD Iterates a bidirectional _range backwards.
     ))
-    $(TR $(TD $(D $(LREF roundRobin)))
+    $(TR $(TD $(LREF roundRobin))
         $(TD Given $(I n) ranges, creates a new _range that return the $(I n)
         first elements of each _range, in turn, then the second element of each
         _range, and so on, in a round-robin fashion.
     ))
-    $(TR $(TD $(D $(LREF sequence)))
+    $(TR $(TD $(LREF sequence))
         $(TD Similar to $(D recurrence), except that a random-access _range is
         created.
     ))
-    $(TR $(TD $(D $(LREF stride)))
+    $(TR $(TD $(LREF stride))
         $(TD Iterates a _range with stride $(I n).
     ))
-    $(TR $(TD $(D $(LREF tail)))
+    $(TR $(TD $(LREF tail))
         $(TD Return a _range advanced to within $(D n) elements of the end of
         the given _range.
     ))
-    $(TR $(TD $(D $(LREF take)))
+    $(TR $(TD $(LREF take))
         $(TD Creates a sub-_range consisting of only up to the first $(I n)
         elements of the given _range.
     ))
-    $(TR $(TD $(D $(LREF takeExactly)))
+    $(TR $(TD $(LREF takeExactly))
         $(TD Like $(D take), but assumes the given _range actually has $(I n)
         elements, and therefore also defines the $(D length) property.
     ))
-    $(TR $(TD $(D $(LREF takeNone)))
+    $(TR $(TD $(LREF takeNone))
         $(TD Creates a random-access _range consisting of zero elements of the
         given _range.
     ))
-    $(TR $(TD $(D $(LREF takeOne)))
+    $(TR $(TD $(LREF takeOne))
         $(TD Creates a random-access _range consisting of exactly the first
         element of the given _range.
     ))
-    $(TR $(TD $(D $(LREF tee)))
+    $(TR $(TD $(LREF tee))
         $(TD Creates a _range that wraps a given _range, forwarding along
         its elements while also calling a provided function with each element.
     ))
-    $(TR $(TD $(D $(LREF transposed)))
+    $(TR $(TD $(LREF transposed))
         $(TD Transposes a _range of ranges.
     ))
-    $(TR $(TD $(D $(LREF transversal)))
+    $(TR $(TD $(LREF transversal))
         $(TD Creates a _range that iterates over the $(I n)'th elements of the
         given random-access ranges.
     ))
-    $(TR $(TD $(D $(LREF zip)))
+    $(TR $(TD $(LREF zip))
         $(TD Given $(I n) _ranges, creates a _range that successively returns a
         tuple of all the first elements, a tuple of all the second elements,
         etc.
@@ -167,8 +167,8 @@ $(BOOKTABLE ,
 )
 
 Ranges whose elements are sorted afford better efficiency with certain
-operations. For this, the $(D $(LREF assumeSorted)) function can be used to
-construct a $(D $(LREF SortedRange)) from a pre-sorted _range. The $(REF
+operations. For this, the $(LREF assumeSorted) function can be used to
+construct a $(LREF SortedRange) from a pre-sorted _range. The $(REF
 sort, std, algorithm, sorting) function also conveniently
 returns a $(D SortedRange). $(D SortedRange) objects provide some additional
 _range operations that take advantage of the fact that the _range is sorted.

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -6,28 +6,28 @@ whether a given object is a _range, and what kind of _range it is:
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF isInputRange)))
+    $(TR $(TD $(LREF isInputRange))
         $(TD Tests if something is an $(I input _range), defined to be
         something from which one can sequentially read data using the
         primitives $(D front), $(D popFront), and $(D empty).
     ))
-    $(TR $(TD $(D $(LREF isOutputRange)))
+    $(TR $(TD $(LREF isOutputRange))
         $(TD Tests if something is an $(I output _range), defined to be
         something to which one can sequentially write data using the
-        $(D $(LREF put)) primitive.
+        $(LREF put) primitive.
     ))
-    $(TR $(TD $(D $(LREF isForwardRange)))
+    $(TR $(TD $(LREF isForwardRange))
         $(TD Tests if something is a $(I forward _range), defined to be an
         input _range with the additional capability that one can save one's
         current position with the $(D save) primitive, thus allowing one to
         iterate over the same _range multiple times.
     ))
-    $(TR $(TD $(D $(LREF isBidirectionalRange)))
+    $(TR $(TD $(LREF isBidirectionalRange))
         $(TD Tests if something is a $(I bidirectional _range), that is, a
         forward _range that allows reverse traversal using the primitives $(D
         back) and $(D popBack).
     ))
-    $(TR $(TD $(D $(LREF isRandomAccessRange)))
+    $(TR $(TD $(LREF isRandomAccessRange))
         $(TD Tests if something is a $(I random access _range), which is a
         bidirectional _range that also supports the array subscripting
         operation via the primitive $(D opIndex).
@@ -37,33 +37,33 @@ $(BOOKTABLE ,
 It also provides number of templates that test for various _range capabilities:
 
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF hasMobileElements)))
+    $(TR $(TD $(LREF hasMobileElements))
         $(TD Tests if a given _range's elements can be moved around using the
         primitives $(D moveFront), $(D moveBack), or $(D moveAt).
     ))
-    $(TR $(TD $(D $(LREF ElementType)))
+    $(TR $(TD $(LREF ElementType))
         $(TD Returns the element type of a given _range.
     ))
-    $(TR $(TD $(D $(LREF ElementEncodingType)))
+    $(TR $(TD $(LREF ElementEncodingType))
         $(TD Returns the encoding element type of a given _range.
     ))
-    $(TR $(TD $(D $(LREF hasSwappableElements)))
+    $(TR $(TD $(LREF hasSwappableElements))
         $(TD Tests if a _range is a forward _range with swappable elements.
     ))
-    $(TR $(TD $(D $(LREF hasAssignableElements)))
+    $(TR $(TD $(LREF hasAssignableElements))
         $(TD Tests if a _range is a forward _range with mutable elements.
     ))
-    $(TR $(TD $(D $(LREF hasLvalueElements)))
+    $(TR $(TD $(LREF hasLvalueElements))
         $(TD Tests if a _range is a forward _range with elements that can be
         passed by reference and have their address taken.
     ))
-    $(TR $(TD $(D $(LREF hasLength)))
+    $(TR $(TD $(LREF hasLength))
         $(TD Tests if a given _range has the $(D length) attribute.
     ))
-    $(TR $(TD $(D $(LREF isInfinite)))
+    $(TR $(TD $(LREF isInfinite))
         $(TD Tests if a given _range is an $(I infinite _range).
     ))
-    $(TR $(TD $(D $(LREF hasSlicing)))
+    $(TR $(TD $(LREF hasSlicing))
         $(TD Tests if a given _range supports the array slicing operation $(D
         R[x .. y]).
     ))
@@ -72,33 +72,33 @@ $(BOOKTABLE ,
 Finally, it includes some convenience functions for manipulating ranges:
 
 $(BOOKTABLE ,
-    $(TR $(TD $(D $(LREF popFrontN)))
+    $(TR $(TD $(LREF popFrontN))
         $(TD Advances a given _range by up to $(I n) elements.
     ))
-    $(TR $(TD $(D $(LREF popBackN)))
+    $(TR $(TD $(LREF popBackN))
         $(TD Advances a given bidirectional _range from the right by up to
         $(I n) elements.
     ))
-    $(TR $(TD $(D $(LREF popFrontExactly)))
+    $(TR $(TD $(LREF popFrontExactly))
         $(TD Advances a given _range by up exactly $(I n) elements.
     ))
-    $(TR $(TD $(D $(LREF popBackExactly)))
+    $(TR $(TD $(LREF popBackExactly))
         $(TD Advances a given bidirectional _range from the right by exactly
         $(I n) elements.
     ))
-    $(TR $(TD $(D $(LREF moveFront)))
+    $(TR $(TD $(LREF moveFront))
         $(TD Removes the front element of a _range.
     ))
-    $(TR $(TD $(D $(LREF moveBack)))
+    $(TR $(TD $(LREF moveBack))
         $(TD Removes the back element of a bidirectional _range.
     ))
-    $(TR $(TD $(D $(LREF moveAt)))
+    $(TR $(TD $(LREF moveAt))
         $(TD Removes the $(I i)'th element of a random-access _range.
     ))
-    $(TR $(TD $(D $(LREF walkLength)))
+    $(TR $(TD $(LREF walkLength))
         $(TD Computes the length of any _range in O(n) time.
     ))
-    $(TR $(TD $(D $(LREF put)))
+    $(TR $(TD $(LREF put))
         $(TD Outputs element $(D e) to a _range.
     ))
 )


### PR DESCRIPTION
From the [NG](http://forum.dlang.org/post/ohjurtkzhvufqsahmimj@forum.dlang.org)

> On second thought, yes, ddox shouldn't output invalid HTML if it can help it, but this is actually an antipattern I see a lot in Phobos and hate:
> $(D $(LREF Abort)))
> That's an unnecessary repetition! If it is an LREF in a D source file, then you *already know* it is a D symbol, so the `$(D)` macro is redundant anyway.
> I'd simplify that to just be `$(LREF ...)` in all cases it appears in the Phobos source, and then if you want it to be styled in the monospace font, do a css rule for *that*.

Your wish has been heard:

```
sed -E 's/[$]\(D [$]\(LREF (.*)\)\)/$(LREF \1)/' -i **/*.d
```

CC @andralex @adamdruppe 