### PR TITLE
Fix LREF in inline code blocks (part 2)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -524,6 +524,9 @@ style: ../dscanner/dsc $(LIB) has_public_example publictests
 	@echo "Enforce space between binary operators"
 	grep -nrE "[[:alnum:]](==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]] (==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]](==|!=|<=|<<|>>|>>>|^^) [[:alnum:]]" $$(find . -name '*.d'); test $$? -eq 1
 
+	@echo "Check for usage of D macros within D code"
+	grep -nrE "[$$]\(D [$$]\(" . ; test $$? -eq 1
+
 	@echo "Validate changelog files (Do _not_ use REF in the title!)"
 	@for file in $$(find changelog -name '*.dd') ; do  \
 		cat $$file | head -n1 | grep -nqE '\$$\((REF|LINK2|HTTP|MREF)' && \

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4611,12 +4611,12 @@ if (isSomeChar!C)
 /**
 Sums elements of $(D r), which must be a finite
 $(REF_ALTTEXT input range, isInputRange, std,range,primitives). Although
-conceptually $(D sum(r)) is equivalent to $(LREF fold)!((a, b) => a +
-b)(r, 0), $(D sum) uses specialized algorithms to maximize accuracy,
+conceptually $(D sum(r)) is equivalent to $(LREF fold)$(D !((a, b) => a +
+b)(r, 0)), $(D sum) uses specialized algorithms to maximize accuracy,
 as follows.
 
 $(UL
-$(LI If $(D $(REF ElementType, std,range,primitives)!R) is a floating-point
+$(LI If $(REF ElementType, std,range,primitives)$(D !R) is a floating-point
 type and $(D R) is a
 $(REF_ALTTEXT random-access range, isRandomAccessRange, std,range,primitives) with
 length and slicing, then $(D sum) uses the

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -11,7 +11,7 @@ $(T2 completeSort,
         $(D completeSort(a, b)) leaves $(D a = [6, 10, 15]) and $(D b = [20,
         30, 40]).
         The range $(D a) must be sorted prior to the call, and as a result the
-        combination $(D $(REF chain, std,range)(a, b)) is sorted.)
+        combination $(REF chain, std,range)$(D (a, b)) is sorted.)
 $(T2 isPartitioned,
         $(D isPartitioned!"a < 0"([-1, -2, 1, 0, 2])) returns $(D true) because
         the predicate is $(D true) for a portion of the range and $(D false)

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -385,7 +385,7 @@ public alias crcHexString = toHexString!(Order.decreasing, 16);
  * OOP API CRC32 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
  *
- * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!CRC32), see
+ * This is an alias for $(REF WrapperDigest, std,digest,digest)$(D !CRC32), see
  * there for more information.
  */
 alias CRC32Digest = WrapperDigest!CRC32;

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -513,7 +513,7 @@ auto md5Of(T...)(T data)
  * OOP API MD5 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
  *
- * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!MD5), see
+ * This is an alias for $(REF WrapperDigest, std,digest,digest)$(D !MD5), see
  * there for more information.
  */
 alias MD5Digest = WrapperDigest!MD5;

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -682,7 +682,7 @@ auto ripemd160Of(T...)(T data)
  * OOP API RIPEMD160 implementation.
  * See $(D std.digest.digest) for differences between template and OOP API.
  *
- * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!RIPEMD160),
+ * This is an alias for $(REF WrapperDigest, std,digest,digest)$(D !RIPEMD160),
  * see there for more information.
  */
 alias RIPEMD160Digest = WrapperDigest!RIPEMD160;

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -1201,7 +1201,7 @@ auto sha512_256Of(T...)(T data)
  * OOP API SHA1 and SHA2 implementations.
  * See $(D std.digest.digest) for differences between template and OOP API.
  *
- * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!SHA1), see
+ * This is an alias for $(REF WrapperDigest, std,digest,digest)$(D !SHA1), see
  * there for more information.
  */
 alias SHA1Digest = WrapperDigest!SHA1;

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -252,11 +252,11 @@ simple bump-the-pointer allocator.))
 $(TR $(TDC2 InSituRegion, region) $(TD Region holding its own allocation, most often on
 the stack. Has statically-determined size.))
 
-$(TR $(TDC2 SbrkRegion, region) $(TD Region using $(D $(LINK2 https://en.wikipedia.org/wiki/Sbrk,
-sbrk)) for allocating memory.))
+$(TR $(TDC2 SbrkRegion, region) $(TD Region using $(LINK2 https://en.wikipedia.org/wiki/Sbrk,
+`sbrk`) for allocating memory.))
 
 $(TR $(TDC3 MmapAllocator, mmap_allocator) $(TD Allocator using
-            $(D $(LINK2 https://en.wikipedia.org/wiki/Mmap, mmap)) directly.))
+            $(LINK2 https://en.wikipedia.org/wiki/Mmap, `mmap`) directly.))
 
 $(TR $(TDC2 StatsCollector, stats_collector) $(TD Collect statistics about any other
 allocator.))
@@ -283,9 +283,9 @@ Macros:
 MYREF2 = $(REF_SHORT $1, std,experimental,allocator,building_blocks,$2)
 MYREF3 = $(REF_SHORT $1, std,experimental,allocator,$2)
 TDC = $(TDNW $(D $1)$+)
-TDC2 = $(TDNW $(D $(MYREF2 $1,$+))$(BR)$(SMALL
+TDC2 = $(TDNW $(MYREF2 $1,$+)$(BR)$(SMALL
 $(D std.experimental.allocator.building_blocks.$2)))
-TDC3 = $(TDNW $(D $(MYREF3 $1,$+))$(BR)$(SMALL
+TDC3 = $(TDNW $(MYREF3 $1,$+)$(BR)$(SMALL
 $(D std.experimental.allocator.$2)))
 RES = $(I result)
 POST = $(BR)$(SMALL $(I Post:) $(BLUE $(D $0)))

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -581,7 +581,7 @@ private extern(C) int brk(shared void*);
 
 /**
 
-Allocator backed by $(D $(LINK2 https://en.wikipedia.org/wiki/Sbrk, sbrk))
+Allocator backed by $(LINK2 https://en.wikipedia.org/wiki/Sbrk, `sbrk`)
 for Posix systems. Due to the fact that $(D sbrk) is not thread-safe
 $(HTTP lifecs.likai.org/2010/02/sbrk-is-not-thread-safe.html, by design),
 $(D SbrkRegion) uses a mutex internally. This implies

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -5,8 +5,8 @@ module std.experimental.allocator.mmap_allocator;
 /**
 
 Allocator (currently defined only for Posix and Windows) using
-$(D $(LINK2 https://en.wikipedia.org/wiki/Mmap, mmap))
-and $(D $(LUCKY munmap)) directly (or their Windows equivalents). There is no
+$(LINK2 https://en.wikipedia.org/wiki/Mmap, `mmap`)
+and $(LUCKY munmap) directly (or their Windows equivalents). There is no
 additional structure: each call to $(D allocate(s)) issues a call to
 $(D mmap(null, s, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)),
 and each call to $(D deallocate(b)) issues $(D munmap(b.ptr, b.length)).

--- a/std/format.d
+++ b/std/format.d
@@ -89,7 +89,7 @@ private alias enforceFmt = enforceEx!FormatException;
    Interprets variadic argument list $(D args), formats them according
    to $(D fmt), and sends the resulting characters to $(D w). The
    encoding of the output is the same as $(D Char). The type $(D Writer)
-   must satisfy $(D $(REF isOutputRange, std,range,primitives)!(Writer, Char)).
+   must satisfy $(REF isOutputRange, std,range,primitives)$(D !(Writer, Char)).
 
    The variadic arguments are normally consumed in order. POSIX-style
    $(HTTP opengroup.org/onlinepubs/009695399/functions/printf.html,

--- a/std/functional.d
+++ b/std/functional.d
@@ -15,7 +15,7 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Joins a couple of functions into one that executes the original
         functions independently and returns a tuple with all the results.
     ))
-    $(TR $(TD $(LREF compose)), $(LREF pipe)
+    $(TR $(TD $(LREF compose), $(LREF pipe))
         $(TD Join a couple of functions into one that executes the original
         functions one after the other, using one function's result for the next
         function's argument.
@@ -23,7 +23,7 @@ $(TR $(TH Function Name) $(TH Description)
     $(TR $(TD $(LREF forward))
         $(TD Forwards function arguments while saving ref-ness.
     ))
-    $(TR $(TD $(LREF lessThan)), $(LREF greaterThan)), $(D $(LREF equalTo)
+    $(TR $(TD $(LREF lessThan), $(LREF greaterThan), $(LREF equalTo))
         $(TD Ready-made predicate functions to compare two values.
     ))
     $(TR $(TD $(LREF memoize))
@@ -36,13 +36,13 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Creates a function that binds the first argument of a given function
         to a given value.
     ))
-    $(TR $(TD $(LREF reverseArgs)), $(LREF binaryReverseArgs)
+    $(TR $(TD $(LREF reverseArgs), $(LREF binaryReverseArgs))
         $(TD Predicate that reverses the order of its arguments.
     ))
     $(TR $(TD $(LREF toDelegate))
         $(TD Converts a callable to a delegate.
     ))
-    $(TR $(TD $(LREF unaryFun)), $(LREF binaryFun)
+    $(TR $(TD $(LREF unaryFun), $(LREF binaryFun))
         $(TD Create a unary or binary function from a string. Most often
         used when defining algorithms on ranges.
     ))

--- a/std/process.d
+++ b/std/process.d
@@ -80,8 +80,7 @@ License:
 Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
-    OBJECTREF=$(D $(LINK2 object.html#$0,$0))
-    LREF=$(D $(LINK2 #.$0,$0))
+    OBJECTREF=$(LINK2 object.html#$0,$(D $0)))
 */
 module std.process;
 

--- a/std/process.d
+++ b/std/process.d
@@ -80,7 +80,7 @@ License:
 Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
-    OBJECTREF=$(LINK2 object.html#$0,$(D $0)))
+    OBJECTREF=$(REF_ALTTEXT $1, object, $1)
 */
 module std.process;
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -6294,7 +6294,7 @@ template isSomeFunction(T...)
 
 /**
 Detect whether $(D T) is a callable object, which can be called with the
-function call operator $(D $(LPAREN)...$(RPAREN)).
+function call operator `(...)`.
  */
 template isCallable(T...)
     if (T.length == 1)


### PR DESCRIPTION
Follow-up to https://github.com/dlang/phobos/pull/5242 that 
- adds a check
- fixes up std.functional (however see screenshot below!)
- fixes other instances like `REF` or `LINK2`

### std.functional:

![image](https://cloud.githubusercontent.com/assets/4370550/23589497/8ef9fc76-01ce-11e7-8c0c-15416d016aba.png)

So I am marking this as "needs work" until the padding issue with std.functional has been resolved and all other manual replacements are verified to _not_ break the documentation.

CC @adamdruppe 