### PR TITLE
Fix issue 17157 ctRegex.matchAll doesn't set last item in Captures

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -277,6 +277,7 @@ template BacktrackingMatcher(bool CTregex)
                 pc = 0;
                 counter = 0;
                 lastState = 0;
+                matches[] = Group!DataIndex.init;
                 auto start = s._index;
                 debug(std_regex_matcher)
                     writeln("Try match starting at ", s[index..s.lastIndex]);
@@ -1439,6 +1440,7 @@ struct CtContext
             pc = 0;
             counter = 0;
             lastState = 0;
+            matches[] = Group!DataIndex.init;
             auto start = s._index;`;
         r ~= `
             goto StartLoop;

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -1056,3 +1056,20 @@ unittest
     auto r = regex(" [a] ", "x");
     assert("a".matchFirst(r));
 }
+
+// bugzilla 17157
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    auto ctr = ctRegex!"(a)|(b)|(c)|(d)";
+    auto r = regex("(a)|(b)|(c)|(d)", "g");
+    auto s = "--a--b--c--d--";
+    auto outcomes = [
+        ["a", "a", "", "", ""],
+        ["b", "", "b", "", ""],
+        ["c", "", "", "c", ""],
+        ["d", "", "", "", "d"]
+    ];
+    assert(equal!equal(s.matchAll(ctr), outcomes));
+    assert(equal!equal(s.bmatch(r), outcomes));
+}


### PR DESCRIPTION
Backtracking engine reused stale data in matches from the previous run.