### PR TITLE
Fix issue 17075 ctRegex BacktrackingMatcher.prevStack: free(): invali…

### DIFF
--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -1050,6 +1050,15 @@ unittest
     assertThrown(regex("(?#..."));
 }
 
+// bugzilla 17075
+@safe unittest
+{
+    enum titlePattern = `<title>(.+)</title>`;
+    static titleRegex = ctRegex!titlePattern;
+    string input = "<title>" ~ "<".repeat(100_000).join;
+    assert(input.matchFirst(titleRegex).empty);
+}
+
 // bugzilla 17212
 unittest
 {

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -625,6 +625,8 @@ public:
 ///
 unittest
 {
+    import std.range.primitives : popFrontN;
+
     auto c = matchFirst("@abc#", regex(`(\w)(\w)(\w)`));
     assert(c.pre == "@"); // Part of input preceding match
     assert(c.post == "#"); // Immediately after match
@@ -1598,6 +1600,7 @@ unittest
 unittest
 {
     import std.algorithm.comparison : equal;
+    import std.typecons : Yes;
 
     auto pattern = regex(`([\.,])`);
 


### PR DESCRIPTION
Backtracking engine memory management was horribly broken in multiple ways.
This fixes the mentioned issue and a couple other subtle bugs.

Finally I can pass the test suite with memory chunk size of 1 state, so things are more robust.