### PR TITLE
Use dfmt on std/concurrency.d

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -63,24 +63,21 @@
  */
 module std.concurrency;
 
+public import std.variant;
 
-public
-{
-    import std.variant;
-}
+import core.atomic;
+import core.sync.condition;
+import core.sync.mutex;
+import core.thread;
+import std.concurrencybase;
+import std.range.primitives;
+import std.traits;
+
 private
 {
-    import core.atomic;
-    import core.thread;
-    import core.sync.mutex;
-    import core.sync.condition;
-    import std.range.primitives;
-    import std.traits;
-    import std.concurrencybase;
-
     template hasLocalAliasing(T...)
     {
-        static if ( !T.length )
+        static if (!T.length)
             enum hasLocalAliasing = false;
         else
             enum hasLocalAliasing = (std.traits.hasUnsharedAliasing!(T[0]) && !is(T[0] == Tid)) ||
@@ -117,10 +114,9 @@ private
 
         @property auto convertsTo(T...)()
         {
-            static if ( T.length == 1 )
+            static if (T.length == 1)
             {
-                return is( T[0] == Variant ) ||
-                       data.convertsTo!(T);
+                return is(T[0] == Variant) || data.convertsTo!(T);
             }
             else
             {
@@ -131,9 +127,9 @@ private
 
         @property auto get(T...)()
         {
-            static if ( T.length == 1 )
+            static if (T.length == 1)
             {
-                static if ( is( T[0] == Variant ) )
+                static if (is(T[0] == Variant))
                     return data;
                 else
                     return data.get!(T);
@@ -145,47 +141,46 @@ private
             }
         }
 
-        auto map(Op)( Op op )
+        auto map(Op)(Op op)
         {
             alias Args = Parameters!(Op);
 
-            static if ( Args.length == 1 )
+            static if (Args.length == 1)
             {
-                static if ( is( Args[0] == Variant ) )
-                    return op( data );
+                static if (is(Args[0] == Variant))
+                    return op(data);
                 else
-                    return op( data.get!(Args) );
+                    return op(data.get!(Args));
             }
             else
             {
                 import std.typecons : Tuple;
-                return op( data.get!(Tuple!(Args)).expand );
+                return op(data.get!(Tuple!(Args)).expand);
             }
         }
     }
 
-    void checkops(T...)( T ops )
+    void checkops(T...)(T ops)
     {
-        foreach ( i, t1; T )
+        foreach (i, t1; T)
         {
-            static assert( isFunctionPointer!t1 || isDelegate!t1 );
+            static assert(isFunctionPointer!t1 || isDelegate!t1);
             alias a1 = Parameters!(t1);
             alias r1 = ReturnType!(t1);
 
-            static if ( i < T.length - 1 && is( r1 == void ) )
+            static if (i < T.length - 1 && is(r1 == void))
             {
-                static assert( a1.length != 1 || !is( a1[0] == Variant ),
-                               "function with arguments " ~ a1.stringof ~
-                               " occludes successive function" );
+                static assert(a1.length != 1 || !is(a1[0] == Variant),
+                              "function with arguments " ~ a1.stringof ~
+                              " occludes successive function");
 
-                foreach ( t2; T[i+1 .. $] )
+                foreach (t2; T[i + 1 .. $])
                 {
-                    static assert( isFunctionPointer!t2 || isDelegate!t2 );
+                    static assert(isFunctionPointer!t2 || isDelegate!t2);
                     alias a2 = Parameters!(t2);
 
-                    static assert( !is( a1 == a2 ),
-                                   "function with arguments " ~ a1.stringof ~
-                                   " occludes successive function" );
+                    static assert(!is(a1 == a2),
+                        "function with arguments " ~ a1.stringof ~ " occludes successive function");
                 }
             }
         }
@@ -193,21 +188,18 @@ private
 
     @property ref ThreadInfo thisInfo() nothrow
     {
-        if ( scheduler is null )
+        if (scheduler is null)
             return ThreadInfo.thisInfo;
         return scheduler.thisInfo;
     }
 }
-
 
 static ~this()
 {
     thisInfo.cleanup();
 }
 
-
 // Exceptions
-
 
 /**
  * Thrown on calls to $(D receiveOnly) if a message other than the type
@@ -216,12 +208,11 @@ static ~this()
 class MessageMismatch : Exception
 {
     ///
-    this( string msg = "Unexpected message type" ) @safe pure nothrow @nogc
+    this(string msg = "Unexpected message type") @safe pure nothrow @nogc
     {
-        super( msg );
+        super(msg);
     }
 }
-
 
 /**
  * Thrown on calls to $(D receive) if the thread that spawned the receiving
@@ -230,15 +221,14 @@ class MessageMismatch : Exception
 class OwnerTerminated : Exception
 {
     ///
-    this( Tid t, string msg = "Owner terminated" ) @safe pure nothrow @nogc
+    this(Tid t, string msg = "Owner terminated") @safe pure nothrow @nogc
     {
-        super( msg );
+        super(msg);
         tid = t;
     }
 
     Tid tid;
 }
-
 
 /**
  * Thrown if a linked thread has terminated.
@@ -246,15 +236,14 @@ class OwnerTerminated : Exception
 class LinkTerminated : Exception
 {
     ///
-    this( Tid t, string msg = "Link terminated" ) @safe pure nothrow @nogc
+    this(Tid t, string msg = "Link terminated") @safe pure nothrow @nogc
     {
-        super( msg );
+        super(msg);
         tid = t;
     }
 
     Tid tid;
 }
-
 
 /**
  * Thrown if a message was sent to a thread via
@@ -264,9 +253,9 @@ class LinkTerminated : Exception
 class PriorityMessageException : Exception
 {
     ///
-    this( Variant vals )
+    this(Variant vals)
     {
-        super( "Priority message" );
+        super("Priority message");
         message = vals;
     }
 
@@ -276,7 +265,6 @@ class PriorityMessageException : Exception
     Variant message;
 }
 
-
 /**
  * Thrown on mailbox crowding if the mailbox is configured with
  * $(D OnCrowding.throwException).
@@ -284,15 +272,14 @@ class PriorityMessageException : Exception
 class MailboxFull : Exception
 {
     ///
-    this( Tid t, string msg = "Mailbox full" ) @safe pure nothrow @nogc
+    this(Tid t, string msg = "Mailbox full") @safe pure nothrow @nogc
     {
-        super( msg );
+        super(msg);
         tid = t;
     }
 
     Tid tid;
 }
-
 
 /**
  * Thrown when a Tid is missing, e.g. when $(D ownerTid) doesn't
@@ -315,13 +302,12 @@ class TidMissingException : Exception
 struct Tid
 {
 private:
-    this( MessageBox m ) @safe pure nothrow @nogc
+    this(MessageBox m) @safe pure nothrow @nogc
     {
         mbox = m;
     }
 
-
-    MessageBox  mbox;
+    MessageBox mbox;
 
 public:
 
@@ -352,7 +338,6 @@ public:
     assert(text(tid2) == text(tid3));
 }
 
-
 /**
  * Returns: The $(LREF Tid) of the caller's thread.
  */
@@ -361,9 +346,9 @@ public:
     // TODO: remove when concurrency is safe
     static auto trus() @trusted
     {
-        if ( thisInfo.ident != Tid.init )
+        if (thisInfo.ident != Tid.init)
             return thisInfo.ident;
-        thisInfo.ident = Tid( new MessageBox );
+        thisInfo.ident = Tid(new MessageBox);
         return thisInfo.ident;
     }
 
@@ -380,8 +365,7 @@ public:
 {
     import std.exception : enforce;
 
-    enforce!TidMissingException(thisInfo.owner.mbox !is null,
-                                  "Error: Thread has no owner thread.");
+    enforce!TidMissingException(thisInfo.owner.mbox !is null, "Error: Thread has no owner thread.");
     return thisInfo.owner;
 }
 
@@ -407,7 +391,7 @@ public:
 
 private template isSpawnable(F, T...)
 {
-    template isParamsImplicitlyConvertible(F1, F2, int i=0)
+    template isParamsImplicitlyConvertible(F1, F2, int i = 0)
     {
         alias param1 = Parameters!F1;
         alias param2 = Parameters!F2;
@@ -416,15 +400,15 @@ private template isSpawnable(F, T...)
         else static if (param1.length == i)
             enum isParamsImplicitlyConvertible = true;
         else static if (isImplicitlyConvertible!(param2[i], param1[i]))
-            enum isParamsImplicitlyConvertible = isParamsImplicitlyConvertible!(F1, F2, i+1);
+            enum isParamsImplicitlyConvertible = isParamsImplicitlyConvertible!(F1,
+                    F2, i + 1);
         else
             enum isParamsImplicitlyConvertible = false;
     }
-    enum isSpawnable = isCallable!F
-      && is(ReturnType!F == void)
-      && isParamsImplicitlyConvertible!(F, void function(T))
-      && ( isFunctionPointer!F
-        || !hasUnsharedAliasing!F);
+
+    enum isSpawnable = isCallable!F && is(ReturnType!F == void)
+            && isParamsImplicitlyConvertible!(F, void function(T))
+            && (isFunctionPointer!F || !hasUnsharedAliasing!F);
 }
 
 /**
@@ -478,14 +462,11 @@ private template isSpawnable(F, T...)
  * }
  * ---
  */
-Tid spawn(F, T...)( F fn, T args )
-if ( isSpawnable!(F, T) )
+Tid spawn(F, T...)(F fn, T args) if (isSpawnable!(F, T))
 {
-    static assert( !hasLocalAliasing!(T),
-                   "Aliases to mutable thread-local data not allowed." );
-    return _spawn( false, fn, args );
+    static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
+    return _spawn(false, fn, args);
 }
-
 
 /**
  * Starts fn(args) in a logical thread and will receive a LinkTerminated
@@ -506,38 +487,34 @@ if ( isSpawnable!(F, T) )
  * Returns:
  *  A Tid representing the new thread.
  */
-Tid spawnLinked(F, T...)( F fn, T args )
-if ( isSpawnable!(F, T) )
+Tid spawnLinked(F, T...)(F fn, T args) if (isSpawnable!(F, T))
 {
-    static assert( !hasLocalAliasing!(T),
-                   "Aliases to mutable thread-local data not allowed." );
-    return _spawn( true, fn, args );
+    static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
+    return _spawn(true, fn, args);
 }
-
 
 /*
  *
  */
-private Tid _spawn(F, T...)( bool linked, F fn, T args )
-if ( isSpawnable!(F, T) )
+private Tid _spawn(F, T...)(bool linked, F fn, T args) if (isSpawnable!(F, T))
 {
     // TODO: MessageList and &exec should be shared.
-    auto spawnTid = Tid( new MessageBox );
+    auto spawnTid = Tid(new MessageBox);
     auto ownerTid = thisTid;
 
     void exec()
     {
         thisInfo.ident = spawnTid;
         thisInfo.owner = ownerTid;
-        fn( args );
+        fn(args);
     }
 
     // TODO: MessageList and &exec should be shared.
-    if ( scheduler !is null )
-        scheduler.spawn( &exec );
+    if (scheduler !is null)
+        scheduler.spawn(&exec);
     else
     {
-        auto t = new Thread( &exec );
+        auto t = new Thread(&exec);
         t.start();
     }
     thisInfo.links[spawnTid] = linked;
@@ -546,24 +523,24 @@ if ( isSpawnable!(F, T) )
 
 @system unittest
 {
-    void function()                                fn1;
-    void function(int)                             fn2;
-    static assert( __traits(compiles, spawn(fn1)));
-    static assert( __traits(compiles, spawn(fn2, 2)));
+    void function() fn1;
+    void function(int) fn2;
+    static assert(__traits(compiles, spawn(fn1)));
+    static assert(__traits(compiles, spawn(fn2, 2)));
     static assert(!__traits(compiles, spawn(fn1, 1)));
     static assert(!__traits(compiles, spawn(fn2)));
 
-    void delegate(int) shared                      dg1;
-    shared(void delegate(int))                     dg2;
-    shared(void delegate(long) shared)             dg3;
-    shared(void delegate(real, int , long) shared) dg4;
-    void delegate(int) immutable                   dg5;
-    void delegate(int)                             dg6;
-    static assert( __traits(compiles, spawn(dg1, 1)));
-    static assert( __traits(compiles, spawn(dg2, 2)));
-    static assert( __traits(compiles, spawn(dg3, 3)));
-    static assert( __traits(compiles, spawn(dg4, 4, 4, 4)));
-    static assert( __traits(compiles, spawn(dg5, 5)));
+    void delegate(int) shared dg1;
+    shared(void delegate(int)) dg2;
+    shared(void delegate(long) shared) dg3;
+    shared(void delegate(real, int, long) shared) dg4;
+    void delegate(int) immutable dg5;
+    void delegate(int) dg6;
+    static assert(__traits(compiles, spawn(dg1, 1)));
+    static assert(__traits(compiles, spawn(dg2, 2)));
+    static assert(__traits(compiles, spawn(dg3, 3)));
+    static assert(__traits(compiles, spawn(dg4, 4, 4, 4)));
+    static assert(__traits(compiles, spawn(dg5, 5)));
     static assert(!__traits(compiles, spawn(dg6, 6)));
 
     auto callable1  = new class{ void opCall(int) shared {} };
@@ -590,23 +567,17 @@ if ( isSpawnable!(F, T) )
     static assert( __traits(compiles, spawn(callable11, 11)));
 }
 
-
-// Sending and Receiving Messages
-
-
 /**
  * Places the values as a message at the back of tid's message queue.
  *
  * Sends the supplied value to the thread represented by tid.  As with
  * $(REF spawn, std,concurrency), $(D T) must not have unshared aliasing.
  */
-void send(T...)( Tid tid, T vals )
+void send(T...)(Tid tid, T vals)
 {
-    static assert( !hasLocalAliasing!(T),
-                   "Aliases to mutable thread-local data not allowed." );
-    _send( tid, vals );
+    static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
+    _send(tid, vals);
 }
-
 
 /**
  * Places the values as a message on the front of tid's message queue.
@@ -615,33 +586,29 @@ void send(T...)( Tid tid, T vals )
  * queue instead of at the back.  This function is typically used for
  * out-of-band communication, to signal exceptional conditions, etc.
  */
-void prioritySend(T...)( Tid tid, T vals )
+void prioritySend(T...)(Tid tid, T vals)
 {
-    static assert( !hasLocalAliasing!(T),
-                   "Aliases to mutable thread-local data not allowed." );
-    _send( MsgType.priority, tid, vals );
+    static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
+    _send(MsgType.priority, tid, vals);
 }
-
 
 /*
  * ditto
  */
-private void _send(T...)( Tid tid, T vals )
+private void _send(T...)(Tid tid, T vals)
 {
-    _send( MsgType.standard, tid, vals );
+    _send(MsgType.standard, tid, vals);
 }
-
 
 /*
  * Implementation of send.  This allows parameter checking to be different for
  * both Tid.send() and .send().
  */
-private void _send(T...)( MsgType type, Tid tid, T vals )
+private void _send(T...)(MsgType type, Tid tid, T vals)
 {
-    auto msg = Message( type, vals );
-    tid.mbox.put( msg );
+    auto msg = Message(type, vals);
+    tid.mbox.put(msg);
 }
-
 
 /**
  * Receives a message from another thread.
@@ -771,8 +738,7 @@ receiveOnlyRet!(T) receiveOnly(T...)()
 in
 {
     assert(thisInfo.ident.mbox !is null,
-           "Cannot receive a message until a thread was spawned "
-           ~ "or thisTid was passed to a running thread.");
+        "Cannot receive a message until a thread was spawned or thisTid was passed to a running thread.");
 }
 body
 {
@@ -781,32 +747,22 @@ body
 
     Tuple!(T) ret;
 
-    thisInfo.ident.mbox.get(
-        ( T val )
-        {
-            static if ( T.length )
-                ret.field = val;
-        },
-        ( LinkTerminated e )
-        {
-            throw e;
-        },
-        ( OwnerTerminated e )
-        {
-            throw e;
-        },
-        ( Variant val )
-        {
-            static if (T.length > 1)
-                string exp = T.stringof;
-            else
-                string exp = T[0].stringof;
+    thisInfo.ident.mbox.get((T val) {
+        static if (T.length)
+            ret.field = val;
+    },
+    (LinkTerminated e) { throw e; },
+    (OwnerTerminated e) { throw e; },
+    (Variant val) {
+        static if (T.length > 1)
+            string exp = T.stringof;
+        else
+            string exp = T[0].stringof;
 
-            throw new MessageMismatch(
-                format("Unexpected message type: expected '%s', got '%s'",
-                       exp, val.type.toString()));
-        } );
-    static if ( T.length == 1 )
+        throw new MessageMismatch(
+            format("Unexpected message type: expected '%s', got '%s'", exp, val.type.toString()));
+    });
+    static if (T.length == 1)
         return ret[0];
     else
         return ret;
@@ -842,79 +798,68 @@ body
  * $(REF Duration, core,time) has passed. It returns $(D true) if it received a
  * message and $(D false) if it timed out waiting for one.
  */
-bool receiveTimeout(T...)( Duration duration, T ops )
+bool receiveTimeout(T...)(Duration duration, T ops)
 in
 {
     assert(thisInfo.ident.mbox !is null,
-           "Cannot receive a message until a thread was spawned "
-           ~ "or thisTid was passed to a running thread.");
+        "Cannot receive a message until a thread was spawned or thisTid was passed to a running thread.");
 }
 body
 {
-    checkops( ops );
+    checkops(ops);
 
-    return thisInfo.ident.mbox.get( duration, ops );
+    return thisInfo.ident.mbox.get(duration, ops);
 }
 
 @safe unittest
 {
-    static assert( __traits( compiles,
-                      {
-                          receiveTimeout( msecs(0), (Variant x) {} );
-                          receiveTimeout( msecs(0), (int x) {}, (Variant x) {} );
-                      } ) );
+    static assert(__traits(compiles, {
+        receiveTimeout(msecs(0), (Variant x) {});
+        receiveTimeout(msecs(0), (int x) {}, (Variant x) {});
+    }));
 
-    static assert( !__traits( compiles,
-                       {
-                           receiveTimeout( msecs(0), (Variant x) {}, (int x) {} );
-                       } ) );
+    static assert(!__traits(compiles, {
+        receiveTimeout(msecs(0), (Variant x) {}, (int x) {});
+    }));
 
-    static assert( !__traits( compiles,
-                       {
-                           receiveTimeout( msecs(0), (int x) {}, (int x) {} );
-                       } ) );
+    static assert(!__traits(compiles, {
+        receiveTimeout(msecs(0), (int x) {}, (int x) {});
+    }));
 
-    static assert( __traits( compiles,
-                      {
-                          receiveTimeout( msecs(10), (int x) {}, (Variant x) {} );
-                      } ) );
+    static assert(__traits(compiles, {
+        receiveTimeout(msecs(10), (int x) {}, (Variant x) {});
+    }));
 }
 
-
 // MessageBox Limits
-
 
 /**
  * These behaviors may be specified when a mailbox is full.
  */
 enum OnCrowding
 {
-    block,          /// Wait until room is available.
+    block, /// Wait until room is available.
     throwException, /// Throw a MailboxFull exception.
-    ignore          /// Abort the send and return.
+    ignore /// Abort the send and return.
 }
-
 
 private
 {
-    bool onCrowdingBlock( Tid tid ) @safe pure nothrow @nogc
+    bool onCrowdingBlock(Tid tid) @safe pure nothrow @nogc
     {
         return true;
     }
 
-
-    bool onCrowdingThrow( Tid tid ) @safe pure
+    bool onCrowdingThrow(Tid tid) @safe pure
     {
-        throw new MailboxFull( tid );
+        throw new MailboxFull(tid);
     }
 
-
-    bool onCrowdingIgnore( Tid tid ) @safe pure nothrow @nogc
+    bool onCrowdingIgnore(Tid tid) @safe pure nothrow @nogc
     {
         return false;
     }
 }
-
 
 /**
  * Sets a maximum mailbox size.
@@ -930,19 +875,18 @@ private
  *  doThis   = The behavior executed when a message is sent to a full
  *             mailbox.
  */
-void setMaxMailboxSize( Tid tid, size_t messages, OnCrowding doThis ) @safe pure
+void setMaxMailboxSize(Tid tid, size_t messages, OnCrowding doThis) @safe pure
 {
-    final switch ( doThis )
+    final switch (doThis)
     {
     case OnCrowding.block:
-        return tid.mbox.setMaxMsgs( messages, &onCrowdingBlock );
+        return tid.mbox.setMaxMsgs(messages, &onCrowdingBlock);
     case OnCrowding.throwException:
-        return tid.mbox.setMaxMsgs( messages, &onCrowdingThrow );
+        return tid.mbox.setMaxMsgs(messages, &onCrowdingThrow);
     case OnCrowding.ignore:
-        return tid.mbox.setMaxMsgs( messages, &onCrowdingIgnore );
+        return tid.mbox.setMaxMsgs(messages, &onCrowdingIgnore);
     }
 }
-
 
 /**
  * Sets a maximum mailbox size.
@@ -957,46 +901,39 @@ void setMaxMailboxSize( Tid tid, size_t messages, OnCrowding doThis ) @safe pure
  *  onCrowdingDoThis = The routine called when a message is sent to a full
  *                     mailbox.
  */
-void setMaxMailboxSize( Tid tid, size_t messages, bool function(Tid) onCrowdingDoThis )
+void setMaxMailboxSize(Tid tid, size_t messages, bool function(Tid) onCrowdingDoThis)
 {
-    tid.mbox.setMaxMsgs( messages, onCrowdingDoThis );
+    tid.mbox.setMaxMsgs(messages, onCrowdingDoThis);
 }
-
-
-// Name Registration
-
 
 private
 {
-    __gshared Tid[string]   tidByName;
+    __gshared Tid[string] tidByName;
     __gshared string[][Tid] namesByTid;
-    __gshared Mutex         registryLock;
+    __gshared Mutex registryLock;
 }
-
 
 extern (C) void std_concurrency_static_this()
 {
     registryLock = new Mutex;
 }
 
-
 private void unregisterMe()
 {
     auto me = thisInfo.ident;
     if (thisInfo.ident != Tid.init)
     {
-        synchronized( registryLock )
+        synchronized (registryLock)
         {
-            if ( auto allNames = me in namesByTid )
+            if (auto allNames = me in namesByTid)
             {
-                foreach ( name; *allNames )
-                    tidByName.remove( name );
-                namesByTid.remove( me );
+                foreach (name; *allNames)
+                    tidByName.remove(name);
+                namesByTid.remove(me);
             }
         }
     }
 }
-
 
 /**
  * Associates name with tid.
@@ -1013,20 +950,19 @@ private void unregisterMe()
  *  true if the name is available and tid is not known to represent a
  *  defunct thread.
  */
-bool register( string name, Tid tid )
+bool register(string name, Tid tid)
 {
-    synchronized( registryLock )
+    synchronized (registryLock)
     {
-        if ( name in tidByName )
+        if (name in tidByName)
             return false;
-        if ( tid.mbox.isClosed )
+        if (tid.mbox.isClosed)
             return false;
         namesByTid[tid] ~= name;
         tidByName[name] = tid;
         return true;
     }
 }
-
 
 /**
  * Removes the registered name associated with a tid.
@@ -1037,25 +973,24 @@ bool register( string name, Tid tid )
  * Returns:
  *  true if the name is registered, false if not.
  */
-bool unregister( string name )
+bool unregister(string name)
 {
     import std.algorithm.searching : countUntil;
     import std.algorithm.mutation : remove, SwapStrategy;
 
-    synchronized( registryLock )
+    synchronized (registryLock)
     {
-        if ( auto tid = name in tidByName )
+        if (auto tid = name in tidByName)
         {
             auto allNames = *tid in namesByTid;
-            auto pos      = countUntil( *allNames, name );
-            remove!(SwapStrategy.unstable)( *allNames, pos );
-            tidByName.remove( name );
+            auto pos = countUntil(*allNames, name);
+            remove!(SwapStrategy.unstable)(*allNames, pos);
+            tidByName.remove(name);
             return true;
         }
         return false;
     }
 }
-
 
 /**
  * Gets the Tid associated with name.
@@ -1066,19 +1001,15 @@ bool unregister( string name )
  * Returns:
  *  The associated Tid or Tid.init if name is not registered.
  */
-Tid locate( string name )
+Tid locate(string name)
 {
-    synchronized( registryLock )
+    synchronized (registryLock)
     {
-        if ( auto tid = name in tidByName )
+        if (auto tid = name in tidByName)
             return *tid;
         return Tid.init;
     }
 }
-
-
-// Scheduler
-
 
 /**
  * Encapsulates all implementation-level data needed for scheduling.
@@ -1089,9 +1020,9 @@ Tid locate( string name )
  */
 struct ThreadInfo
 {
-    Tid       ident;
+    Tid ident;
     bool[Tid] links;
-    Tid       owner;
+    Tid owner;
 
     /**
      * Gets a thread-local instance of ThreadInfo.
@@ -1106,7 +1037,6 @@ struct ThreadInfo
         return val;
     }
 
-
     /**
      * Cleans up this ThreadInfo.
      *
@@ -1116,16 +1046,15 @@ struct ThreadInfo
      */
     void cleanup()
     {
-        if ( ident.mbox !is null )
+        if (ident.mbox !is null)
             ident.mbox.close();
-        foreach ( tid; links.keys )
-            _send( MsgType.linkDead, tid, ident );
-        if ( owner != Tid.init )
-            _send( MsgType.linkDead, owner, ident );
+        foreach (tid; links.keys)
+            _send(MsgType.linkDead, tid, ident);
+        if (owner != Tid.init)
+            _send(MsgType.linkDead, owner, ident);
         unregisterMe(); // clean up registry entries
     }
 }
-
 
 /**
  * A Scheduler controls how threading is performed by spawn.
@@ -1175,7 +1104,7 @@ interface Scheduler
      *       absence of a custom scheduler.  It will be automatically executed
      *       via a call to spawn by the Scheduler.
      */
-    void start( void delegate() op );
+    void start(void delegate() op);
 
     /**
      * Assigns a logical thread to execute the supplied op.
@@ -1190,7 +1119,7 @@ interface Scheduler
      *  op = The function to execute.  This may be the actual function passed
      *       by the user to spawn itself, or may be a wrapper function.
      */
-    void spawn( void delegate() op );
+    void spawn(void delegate() op);
 
     /**
      * Yields execution to another logical thread.
@@ -1227,9 +1156,8 @@ interface Scheduler
      *      cases a Scheduler may need to hold this reference and unlock the
      *      mutex before yielding execution to another logical thread.
      */
-    Condition newCondition( Mutex m ) nothrow;
+    Condition newCondition(Mutex m) nothrow;
 }
-
 
 /**
  * An example Scheduler using kernel threads.
@@ -1239,28 +1167,25 @@ interface Scheduler
  * and may be instantiated and used, but is not a necessary part of the
  * default functioning of this module.
  */
-class ThreadScheduler :
-    Scheduler
+class ThreadScheduler : Scheduler
 {
     /**
      * This simply runs op directly, since no real scheduling is needed by
      * this approach.
      */
-    void start( void delegate() op )
+    void start(void delegate() op)
     {
         op();
     }
 
-
     /**
      * Creates a new kernel thread and assigns it to run the supplied op.
      */
-    void spawn( void delegate() op )
+    void spawn(void delegate() op)
     {
-        auto t = new Thread( op );
+        auto t = new Thread(op);
         t.start();
     }
-
 
     /**
      * This scheduler does no explicit multiplexing, so this is a no-op.
@@ -1269,7 +1194,6 @@ class ThreadScheduler :
     {
         // no explicit yield needed
     }
-
 
     /**
      * Returns ThreadInfo.thisInfo, since it is a thread-local instance of
@@ -1280,16 +1204,14 @@ class ThreadScheduler :
         return ThreadInfo.thisInfo;
     }
 
-
     /**
      * Creates a new Condition variable.  No custom behavior is needed here.
      */
-    Condition newCondition( Mutex m ) nothrow
+    Condition newCondition(Mutex m) nothrow
     {
-        return new Condition( m );
+        return new Condition(m);
     }
 }
-
 
 /**
  * An example Scheduler using Fibers.
@@ -1297,30 +1219,27 @@ class ThreadScheduler :
  * This is an example scheduler that creates a new Fiber per call to spawn
  * and multiplexes the execution of all fibers within the main thread.
  */
-class FiberScheduler :
-    Scheduler
+class FiberScheduler : Scheduler
 {
     /**
      * This creates a new Fiber for the supplied op and then starts the
      * dispatcher.
      */
-    void start( void delegate() op )
+    void start(void delegate() op)
     {
-        create( op );
+        create(op);
         dispatch();
     }
-
 
     /**
      * This created a new Fiber for the supplied op and adds it to the
      * dispatch list.
      */
-    void spawn( void delegate() op ) nothrow
+    void spawn(void delegate() op) nothrow
     {
-        create( op );
+        create(op);
         yield();
     }
-
 
     /**
      * If the caller is a scheduled Fiber, this yields execution to another
@@ -1335,7 +1254,6 @@ class FiberScheduler :
             Fiber.yield();
     }
 
-
     /**
      * Returns an appropriate ThreadInfo instance.
      *
@@ -1347,38 +1265,33 @@ class FiberScheduler :
     {
         auto f = cast(InfoFiber) Fiber.getThis();
 
-        if ( f !is null )
+        if (f !is null)
             return f.info;
         return ThreadInfo.thisInfo;
     }
 
-
     /**
      * Returns a Condition analog that yields when wait or notify is called.
      */
-    Condition newCondition( Mutex m ) nothrow
+    Condition newCondition(Mutex m) nothrow
     {
-        return new FiberCondition( m );
+        return new FiberCondition(m);
     }
 
-
 private:
-    static class InfoFiber :
-        Fiber
+    static class InfoFiber : Fiber
     {
         ThreadInfo info;
 
-        this( void delegate() op ) nothrow
+        this(void delegate() op) nothrow
         {
-            super( op );
+            super(op);
         }
     }
 
-
-    class FiberCondition :
-        Condition
+    class FiberCondition : Condition
     {
-        this( Mutex m ) nothrow
+        this(Mutex m) nothrow
         {
             super(m);
             notified = false;
@@ -1386,20 +1299,21 @@ private:
 
         override void wait() nothrow
         {
-            scope(exit) notified = false;
+            scope (exit) notified = false;
 
-            while ( !notified )
+            while (!notified)
                 switchContext();
         }
 
-        override bool wait( Duration period ) nothrow
+        override bool wait(Duration period) nothrow
         {
             import core.time : MonoTime;
-            scope(exit) notified = false;
 
-            for ( auto limit = MonoTime.currTime + period;
+            scope (exit) notified = false;
+
+            for (auto limit = MonoTime.currTime + period;
                  !notified && !period.isNegative;
-                 period = limit - MonoTime.currTime )
+                 period = limit - MonoTime.currTime)
             {
                 yield();
             }
@@ -1422,56 +1336,55 @@ private:
         void switchContext() nothrow
         {
             mutex_nothrow.unlock_nothrow();
-            scope(exit) mutex_nothrow.lock_nothrow();
+            scope (exit) mutex_nothrow.lock_nothrow();
             yield();
         }
 
         private bool notified;
     }
 
-
 private:
     void dispatch()
     {
         import std.algorithm.mutation : remove;
 
-        while ( m_fibers.length > 0 )
+        while (m_fibers.length > 0)
         {
-            auto t = m_fibers[m_pos].call( Fiber.Rethrow.no );
+            auto t = m_fibers[m_pos].call(Fiber.Rethrow.no);
             if (t !is null && !(cast(OwnerTerminated) t))
-                throw t;
-            if ( m_fibers[m_pos].state == Fiber.State.TERM )
             {
-                if ( m_pos >= (m_fibers = remove( m_fibers, m_pos )).length )
+                throw t;
+            }
+            if (m_fibers[m_pos].state == Fiber.State.TERM)
+            {
+                if (m_pos >= (m_fibers = remove(m_fibers, m_pos)).length)
                     m_pos = 0;
             }
-            else if ( m_pos++ >= m_fibers.length - 1 )
+            else if (m_pos++ >= m_fibers.length - 1)
             {
                 m_pos = 0;
             }
         }
     }
 
-
-    void create( void delegate() op ) nothrow
+    void create(void delegate() op) nothrow
     {
         void wrap()
         {
-            scope(exit)
+            scope (exit)
             {
                 thisInfo.cleanup();
             }
             op();
         }
-        m_fibers ~= new InfoFiber( &wrap );
-    }
 
+        m_fibers ~= new InfoFiber(&wrap);
+    }
 
 private:
     Fiber[] m_fibers;
-    size_t  m_pos;
+    size_t m_pos;
 }
-
 
 @system unittest
 {
@@ -1504,7 +1417,7 @@ private:
     auto cond = fs.newCondition(mtx);
 
     size_t received, sent;
-    auto waiter = new Fiber({receive(cond, received);}), notifier = new Fiber({send(cond, sent);});
+    auto waiter = new Fiber({ receive(cond, received); }), notifier = new Fiber({ send(cond, sent); });
     waiter.call();
     assert(received == 0);
     notifier.call();
@@ -1516,7 +1429,6 @@ private:
     assert(received == 1);
 }
 
-
 /**
  * Sets the Scheduler behavior within the program.
  *
@@ -1526,9 +1438,7 @@ private:
  */
 __gshared Scheduler scheduler;
 
-
 // Generator
-
 
 /**
  * If the caller is a Fiber and is not a Generator, this function will call
@@ -1544,10 +1454,10 @@ void yield() nothrow
             if (fiber)
                 return Fiber.yield();
         }
-        else scheduler.yield();
+        else
+            scheduler.yield();
     }
 }
-
 
 /// Used to determine whether a Generator is running.
 private interface IsGenerator {}
@@ -1586,8 +1496,7 @@ private interface IsGenerator {}
  * }
  * ---
  */
-class Generator(T) :
-    Fiber, IsGenerator
+class Generator(T) : Fiber, IsGenerator
 {
     /**
      * Initializes a generator object which is associated with a static
@@ -1605,7 +1514,6 @@ class Generator(T) :
         super(fn);
         call();
     }
-
 
     /**
      * Initializes a generator object which is associated with a static
@@ -1625,7 +1533,6 @@ class Generator(T) :
         call();
     }
 
-
     /**
      * Initializes a generator object which is associated with a dynamic
      * D function.  The function will be called once to prepare the range
@@ -1642,7 +1549,6 @@ class Generator(T) :
         super(dg);
         call();
     }
-
 
     /**
      * Initializes a generator object which is associated with a dynamic
@@ -1662,7 +1568,6 @@ class Generator(T) :
         call();
     }
 
-
     /**
      * Returns true if the generator is empty.
      */
@@ -1670,7 +1575,6 @@ class Generator(T) :
     {
         return m_value is null || state == State.TERM;
     }
-
 
     /**
      * Obtains the next value from the underlying function.
@@ -1680,7 +1584,6 @@ class Generator(T) :
         call();
     }
 
-
     /**
      * Returns the most recently generated value.
      */
@@ -1689,11 +1592,9 @@ class Generator(T) :
         return *m_value;
     }
 
-
 private:
-    T*  m_value;
+    T* m_value;
 }
-
 
 /**
  * Yields a value of type T to the caller of the currently executing
@@ -1713,7 +1614,6 @@ void yield(T)(ref T value)
     throw new Exception("yield(T) called with no active generator for the supplied type");
 }
 
-
 /// ditto
 void yield(T)(T value)
 {
@@ -1728,18 +1628,15 @@ void yield(T)(T value)
     static void testScheduler(Scheduler s)
     {
         scheduler = s;
-        scheduler.start(
-        {
-            auto tid = spawn(
-            {
+        scheduler.start({
+            auto tid = spawn({
                 int i;
 
                 try
                 {
                     for (i = 1; i < 10; i++)
                     {
-                        assertNotThrown!AssertError(
-                            assert(receiveOnly!int() == i));
+                        assertNotThrown!AssertError(assert(receiveOnly!int() == i));
                     }
                 }
                 catch (OwnerTerminated e)
@@ -1751,8 +1648,7 @@ void yield(T)(T value)
                 assert(i == 4);
             });
 
-            auto r = new Generator!int(
-            {
+            auto r = new Generator!int({
                 assertThrown!Exception(yield(2.0));
                 yield(); // ensure this is a no-op
                 yield(1);
@@ -1773,10 +1669,6 @@ void yield(T)(T value)
     testScheduler(new FiberScheduler);
 }
 
-
-// MessageBox Implementation
-
-
 private
 {
     /*
@@ -1790,25 +1682,25 @@ private
     {
         this() @trusted nothrow /* TODO: make @safe after relevant druntime PR gets merged */
         {
-            m_lock      = new Mutex;
-            m_closed    = false;
+            m_lock = new Mutex;
+            m_closed = false;
 
-            if ( scheduler is null )
+            if (scheduler is null)
             {
-                m_putMsg  = new Condition( m_lock );
-                m_notFull = new Condition( m_lock );
+                m_putMsg = new Condition(m_lock);
+                m_notFull = new Condition(m_lock);
             }
             else
             {
-                m_putMsg  = scheduler.newCondition( m_lock );
-                m_notFull = scheduler.newCondition( m_lock );
+                m_putMsg = scheduler.newCondition(m_lock);
+                m_notFull = scheduler.newCondition(m_lock);
             }
         }
 
         ///
         final @property bool isClosed() @safe @nogc pure
         {
-            synchronized( m_lock )
+            synchronized (m_lock)
             {
                 return m_closed;
             }
@@ -1825,15 +1717,14 @@ private
          *         unbounded.
          *  call = The routine to call when the queue is full.
          */
-        final void setMaxMsgs( size_t num, bool function(Tid) call ) @safe @nogc pure
+        final void setMaxMsgs(size_t num, bool function(Tid) call) @safe @nogc pure
         {
-            synchronized( m_lock )
+            synchronized (m_lock)
             {
-                m_maxMsgs   = num;
+                m_maxMsgs = num;
                 m_onMaxMsgs = call;
             }
         }
-
 
         /*
          * If maxMsgs is not set, the message is added to the queue and the
@@ -1849,29 +1740,29 @@ private
          * Throws:
          *  An exception if the queue is full and onCrowdingDoThis throws.
          */
-        final void put( ref Message msg )
+        final void put(ref Message msg)
         {
-            synchronized( m_lock )
+            synchronized (m_lock)
             {
                 // TODO: Generate an error here if m_closed is true, or maybe
                 //       put a message in the caller's queue?
-                if ( !m_closed )
+                if (!m_closed)
                 {
-                    while ( true )
+                    while (true)
                     {
-                        if ( isPriorityMsg( msg ) )
+                        if (isPriorityMsg(msg))
                         {
-                            m_sharedPty.put( msg );
+                            m_sharedPty.put(msg);
                             m_putMsg.notify();
                             return;
                         }
-                        if ( !mboxFull() || isControlMsg( msg ) )
+                        if (!mboxFull() || isControlMsg(msg))
                         {
-                            m_sharedBox.put( msg );
+                            m_sharedBox.put(msg);
                             m_putMsg.notify();
                             return;
                         }
-                        if ( m_onMaxMsgs !is null && !m_onMaxMsgs( thisTid ) )
+                        if (m_onMaxMsgs !is null && !m_onMaxMsgs(thisTid))
                         {
                             return;
                         }
@@ -1882,7 +1773,6 @@ private
                 }
             }
         }
-
 
         /*
          * Matches ops against each message in turn until a match is found.
@@ -1900,13 +1790,13 @@ private
          * if the owner thread terminates and no existing messages match the
          * supplied ops.
          */
-        bool get(T...)( scope T vals )
+        bool get(T...)(scope T vals)
         {
             import std.meta : AliasSeq;
 
-            static assert( T.length );
+            static assert(T.length);
 
-            static if ( isImplicitlyConvertible!(T[0], Duration) )
+            static if (isImplicitlyConvertible!(T[0], Duration))
             {
                 alias Ops = AliasSeq!(T[1 .. $]);
                 alias ops = vals[1 .. $];
@@ -1920,22 +1810,22 @@ private
                 enum timedWait = false;
             }
 
-            bool onStandardMsg( ref Message msg )
+            bool onStandardMsg(ref Message msg)
             {
-                foreach ( i, t; Ops )
+                foreach (i, t; Ops)
                 {
                     alias Args = Parameters!(t);
-                    auto  op   = ops[i];
+                    auto op = ops[i];
 
-                    if ( msg.convertsTo!(Args) )
+                    if (msg.convertsTo!(Args))
                     {
-                        static if ( is( ReturnType!(t) == bool ) )
+                        static if (is(ReturnType!(t) == bool))
                         {
-                            return msg.map( op );
+                            return msg.map(op);
                         }
                         else
                         {
-                            msg.map( op );
+                            msg.map(op);
                             return true;
                         }
                     }
@@ -1943,59 +1833,60 @@ private
                 return false;
             }
 
-            bool onLinkDeadMsg( ref Message msg )
+            bool onLinkDeadMsg(ref Message msg)
             {
-                assert( msg.convertsTo!(Tid) );
+                assert(msg.convertsTo!(Tid));
                 auto tid = msg.get!(Tid);
 
-                if ( bool* pDepends = tid in thisInfo.links )
+                if (bool* pDepends = tid in thisInfo.links)
                 {
                     auto depends = *pDepends;
-                    thisInfo.links.remove( tid );
+                    thisInfo.links.remove(tid);
                     // Give the owner relationship precedence.
-                    if ( depends && tid != thisInfo.owner )
+                    if (depends && tid != thisInfo.owner)
                     {
-                        auto e = new LinkTerminated( tid );
-                        auto m = Message( MsgType.standard, e );
-                        if ( onStandardMsg( m ) )
+                        auto e = new LinkTerminated(tid);
+                        auto m = Message(MsgType.standard, e);
+                        if (onStandardMsg(m))
                             return true;
                         throw e;
                     }
                 }
-                if ( tid == thisInfo.owner )
+                if (tid == thisInfo.owner)
                 {
                     thisInfo.owner = Tid.init;
-                    auto e = new OwnerTerminated( tid );
-                    auto m = Message( MsgType.standard, e );
-                    if ( onStandardMsg( m ) )
+                    auto e = new OwnerTerminated(tid);
+                    auto m = Message(MsgType.standard, e);
+                    if (onStandardMsg(m))
                         return true;
                     throw e;
                 }
                 return false;
             }
 
-            bool onControlMsg( ref Message msg )
+            bool onControlMsg(ref Message msg)
             {
-                switch ( msg.type )
+                switch (msg.type)
                 {
                 case MsgType.linkDead:
-                    return onLinkDeadMsg( msg );
+                    return onLinkDeadMsg(msg);
                 default:
                     return false;
                 }
             }
 
-            bool scan( ref ListT list )
+            bool scan(ref ListT list)
             {
-                for ( auto range = list[]; !range.empty; )
+                for (auto range = list[]; !range.empty;)
                 {
                     // Only the message handler will throw, so if this occurs
                     // we can be certain that the message was handled.
-                    scope(failure) list.removeAt( range );
+                    scope (failure)
+                        list.removeAt(range);
 
-                    if ( isControlMsg( range.front ) )
+                    if (isControlMsg(range.front))
                     {
-                        if ( onControlMsg( range.front ) )
+                        if (onControlMsg(range.front))
                         {
                             // Although the linkDead message is a control message,
                             // it can be handled by the user.  Since the linkDead
@@ -2003,12 +1894,12 @@ private
                             // it has been handled and we can return from receive.
                             // This is a weird special case that will have to be
                             // handled in a more general way if more are added.
-                            if ( !isLinkDeadMsg( range.front ) )
+                            if (!isLinkDeadMsg(range.front))
                             {
-                                list.removeAt( range );
+                                list.removeAt(range);
                                 continue;
                             }
-                            list.removeAt( range );
+                            list.removeAt(range);
                             return true;
                         }
                         range.popFront();
@@ -2016,9 +1907,9 @@ private
                     }
                     else
                     {
-                        if ( onStandardMsg( range.front ) )
+                        if (onStandardMsg(range.front))
                         {
-                            list.removeAt( range );
+                            list.removeAt(range);
                             return true;
                         }
                         range.popFront();
@@ -2028,47 +1919,46 @@ private
                 return false;
             }
 
-
-            bool pty( ref ListT list )
+            bool pty(ref ListT list)
             {
-                if ( !list.empty )
+                if (!list.empty)
                 {
                     auto range = list[];
 
-                    if ( onStandardMsg( range.front ) )
+                    if (onStandardMsg(range.front))
                     {
-                        list.removeAt( range );
+                        list.removeAt(range);
                         return true;
                     }
-                    if ( range.front.convertsTo!(Throwable) )
+                    if (range.front.convertsTo!(Throwable))
                         throw range.front.get!(Throwable);
-                    else if ( range.front.convertsTo!(shared(Throwable)) )
+                    else if (range.front.convertsTo!(shared(Throwable)))
                         throw range.front.get!(shared(Throwable));
-                    else throw new PriorityMessageException( range.front.data );
+                    else
+                        throw new PriorityMessageException(range.front.data);
                 }
                 return false;
             }
 
-            static if ( timedWait )
+            static if (timedWait)
             {
                 import core.time : MonoTime;
                 auto limit = MonoTime.currTime + period;
             }
 
-            while ( true )
+            while (true)
             {
                 ListT arrived;
 
-                if ( pty( m_localPty ) ||
-                    scan( m_localBox ) )
+                if (pty(m_localPty) || scan(m_localBox))
                 {
                     return true;
                 }
                 yield();
-                synchronized( m_lock )
+                synchronized (m_lock)
                 {
                     updateMsgCount();
-                    while ( m_sharedPty.empty && m_sharedBox.empty )
+                    while (m_sharedPty.empty && m_sharedBox.empty)
                     {
                         // NOTE: We're notifying all waiters here instead of just
                         //       a few because the onCrowding behavior may have
@@ -2076,11 +1966,11 @@ private
                         //       unnecessarily if the new behavior is not to block.
                         //       This will admittedly result in spurious wakeups
                         //       in other situations, but what can you do?
-                        if ( m_putQueue && !mboxFull() )
+                        if (m_putQueue && !mboxFull())
                             m_notFull.notifyAll();
-                        static if ( timedWait )
+                        static if (timedWait)
                         {
-                            if ( period <= Duration.zero || !m_putMsg.wait( period ) )
+                            if (period <= Duration.zero || !m_putMsg.wait(period))
                                 return false;
                         }
                         else
@@ -2088,29 +1978,30 @@ private
                             m_putMsg.wait();
                         }
                     }
-                    m_localPty.put( m_sharedPty );
-                    arrived.put( m_sharedBox );
+                    m_localPty.put(m_sharedPty);
+                    arrived.put(m_sharedBox);
                 }
-                if ( m_localPty.empty )
+                if (m_localPty.empty)
                 {
-                    scope(exit) m_localBox.put( arrived );
-                    if ( scan( arrived ) )
+                    scope (exit) m_localBox.put(arrived);
+                    if (scan(arrived))
+                    {
                         return true;
+                    }
                     else
                     {
-                        static if ( timedWait )
+                        static if (timedWait)
                         {
                             period = limit - MonoTime.currTime;
                         }
                         continue;
                     }
                 }
-                m_localBox.put( arrived );
-                pty( m_localPty );
+                m_localBox.put(arrived);
+                pty(m_localPty);
                 return true;
             }
         }
-
 
         /*
          * Called on thread termination.  This routine processes any remaining
@@ -2119,110 +2010,82 @@ private
          */
         final void close()
         {
-            static void onLinkDeadMsg( ref Message msg )
+            static void onLinkDeadMsg(ref Message msg)
             {
-                assert( msg.convertsTo!(Tid) );
+                assert(msg.convertsTo!(Tid));
                 auto tid = msg.get!(Tid);
 
-                thisInfo.links.remove( tid );
-                if ( tid == thisInfo.owner )
+                thisInfo.links.remove(tid);
+                if (tid == thisInfo.owner)
                     thisInfo.owner = Tid.init;
             }
 
-            static void sweep( ref ListT list )
+            static void sweep(ref ListT list)
             {
-                for ( auto range = list[]; !range.empty; range.popFront() )
+                for (auto range = list[]; !range.empty; range.popFront())
                 {
-                    if ( range.front.type == MsgType.linkDead )
-                        onLinkDeadMsg( range.front );
+                    if (range.front.type == MsgType.linkDead)
+                        onLinkDeadMsg(range.front);
                 }
             }
 
             ListT arrived;
 
-            sweep( m_localBox );
-            synchronized( m_lock )
+            sweep(m_localBox);
+            synchronized (m_lock)
             {
-                arrived.put( m_sharedBox );
+                arrived.put(m_sharedBox);
                 m_closed = true;
             }
             m_localBox.clear();
-            sweep( arrived );
+            sweep(arrived);
         }
 
-
     private:
-        // Routines involving shared data, m_lock must be held.
-
+        // Routines involving local data only, no lock needed.
 
         bool mboxFull() @safe @nogc pure nothrow
         {
-            return m_maxMsgs &&
-                   m_maxMsgs <= m_localMsgs + m_sharedBox.length;
+            return m_maxMsgs && m_maxMsgs <= m_localMsgs + m_sharedBox.length;
         }
-
 
         void updateMsgCount() @safe @nogc pure nothrow
         {
             m_localMsgs = m_localBox.length;
         }
 
-
-    private:
-        // Routines involving local data only, no lock needed.
-
-
-        bool isControlMsg( ref Message msg ) @safe @nogc pure nothrow
+        bool isControlMsg(ref Message msg) @safe @nogc pure nothrow
         {
-            return msg.type != MsgType.standard &&
-                   msg.type != MsgType.priority;
+            return msg.type != MsgType.standard && msg.type != MsgType.priority;
         }
 
-
-        bool isPriorityMsg( ref Message msg ) @safe @nogc pure nothrow
+        bool isPriorityMsg(ref Message msg) @safe @nogc pure nothrow
         {
             return msg.type == MsgType.priority;
         }
 
-
-        bool isLinkDeadMsg( ref Message msg ) @safe @nogc pure nothrow
+        bool isLinkDeadMsg(ref Message msg) @safe @nogc pure nothrow
         {
             return msg.type == MsgType.linkDead;
         }
 
-
-    private:
-        // Type declarations.
-
-
         alias OnMaxFn = bool function(Tid);
-        alias ListT   = List!(Message);
+        alias ListT = List!(Message);
 
-    private:
-        // Local data, no lock needed.
+        ListT m_localBox;
+        ListT m_localPty;
 
-
-        ListT       m_localBox;
-        ListT       m_localPty;
-
-
-    private:
-        // Shared data, m_lock must be held on access.
-
-
-        Mutex       m_lock;
-        Condition   m_putMsg;
-        Condition   m_notFull;
-        size_t      m_putQueue;
-        ListT       m_sharedBox;
-        ListT       m_sharedPty;
-        OnMaxFn     m_onMaxMsgs;
-        size_t      m_localMsgs;
-        size_t      m_maxMsgs;
-        bool        m_closed;
-
+        Mutex m_lock;
+        Condition m_putMsg;
+        Condition m_notFull;
+        size_t m_putQueue;
+        ListT m_sharedBox;
+        ListT m_sharedPty;
+        OnMaxFn m_onMaxMsgs;
+        size_t m_localMsgs;
+        size_t m_maxMsgs;
+        bool m_closed;
     }
-
 
     /*
      *
@@ -2240,29 +2103,23 @@ private
 
             @property ref T front()
             {
-                enforce( m_prev.next, "invalid list node" );
+                enforce(m_prev.next, "invalid list node");
                 return m_prev.next.val;
             }
 
-            @property void front( T val )
+            @property void front(T val)
             {
-                enforce( m_prev.next, "invalid list node" );
+                enforce(m_prev.next, "invalid list node");
                 m_prev.next.val = val;
             }
 
             void popFront()
             {
-                enforce( m_prev.next, "invalid list node" );
+                enforce(m_prev.next, "invalid list node");
                 m_prev = m_prev.next;
             }
 
-            //T moveFront()
-            //{
-            //    enforce( m_prev.next );
-            //    return move( m_prev.next.val );
-            //}
-
-            private this( Node* p )
+            private this(Node* p)
             {
                 m_prev = p;
             }
@@ -2270,102 +2127,73 @@ private
             private Node* m_prev;
         }
 
-
-        /*
-         *
-         */
-        void put( T val )
+        void put(T val)
         {
-            put( newNode( val ) );
+            put(newNode(val));
         }
 
-
-        /*
-         *
-         */
-        void put( ref List!(T) rhs )
+        void put(ref List!(T) rhs)
         {
-            if ( !rhs.empty )
+            if (!rhs.empty)
             {
-                put( rhs.m_first );
-                while ( m_last.next !is null )
+                put(rhs.m_first);
+                while (m_last.next !is null)
                 {
                     m_last = m_last.next;
                     m_count++;
                 }
                 rhs.m_first = null;
-                rhs.m_last  = null;
+                rhs.m_last = null;
                 rhs.m_count = 0;
             }
         }
 
-
-        /*
-         *
-         */
         Range opSlice()
         {
-            return Range( cast(Node*) &m_first );
+            return Range(cast(Node*)&m_first);
         }
 
-
-        /*
-         *
-         */
-        void removeAt( Range r )
+        void removeAt(Range r)
         {
             import std.exception : enforce;
 
-            assert( m_count );
+            assert(m_count);
             Node* n = r.m_prev;
-            enforce( n && n.next, "attempting to remove invalid list node" );
+            enforce(n && n.next, "attempting to remove invalid list node");
 
-            if ( m_last is m_first )
+            if (m_last is m_first)
                 m_last = null;
-            else if ( m_last is n.next )
+            else if (m_last is n.next)
                 m_last = n;
             Node* to_free = n.next;
             n.next = n.next.next;
-            freeNode( to_free );
+            freeNode(to_free);
             m_count--;
         }
 
-
-        /*
-         *
-         */
         @property size_t length()
         {
             return m_count;
         }
 
-
-        /*
-         *
-         */
         void clear()
         {
             m_first = m_last = null;
             m_count = 0;
         }
 
-
-        /*
-         *
-         */
         @property bool empty()
         {
             return m_first is null;
         }
 
-
     private:
         struct Node
         {
-            Node*   next;
-            T       val;
+            Node* next;
+            T val;
 
-            this( T v )
+            this(T v)
             {
                 val = v;
             }
@@ -2377,12 +2205,13 @@ private
             void unlock() { atomicStore!(MemoryOrder.rel)(locked, false); }
             bool locked;
         }
+
         static shared SpinLock sm_lock;
         static shared Node* sm_head;
 
         Node* newNode(T v)
         {
-            Node *n;
+            Node* n;
             {
                 sm_lock.lock();
                 scope (exit) sm_lock.unlock();
@@ -2413,19 +2242,15 @@ private
             sm_lock.lock();
             scope (exit) sm_lock.unlock();
 
-            auto sn = cast(shared(Node)*)n;
+            auto sn = cast(shared(Node)*) n;
             sn.next = sm_head;
             sm_head = sn;
         }
 
-
-        /*
-         *
-         */
-        void put( Node* n )
+        void put(Node* n)
         {
             m_count++;
-            if ( !empty )
+            if (!empty)
             {
                 m_last.next = n;
                 m_last = n;
@@ -2435,72 +2260,56 @@ private
             m_last = n;
         }
 
-
-        Node*   m_first;
-        Node*   m_last;
-        size_t  m_count;
+        Node* m_first;
+        Node* m_last;
+        size_t m_count;
     }
 }
 
-
-version( unittest )
+version (unittest)
 {
     import std.stdio;
     import std.typecons : tuple, Tuple;
 
-    void testfn( Tid tid )
+    void testfn(Tid tid)
     {
-        receive( (float val) { assert(0); },
-                 (int val, int val2)
-                 {
-                     assert( val == 42 && val2 == 86 );
-                 } );
-        receive( (Tuple!(int, int) val)
-                 {
-                     assert( val[0] == 42 &&
-                             val[1] == 86 );
-                 } );
-        receive( (Variant val) {} );
-        receive( (string val)
-                 {
-                     if ( "the quick brown fox" != val )
-                         return false;
-                     return true;
-                 },
-                 (string val)
-                 {
-                     assert( false );
-                 } );
-        prioritySend( tid, "done" );
+        receive((float val) { assert(0); }, (int val, int val2) {
+            assert(val == 42 && val2 == 86);
+        });
+        receive((Tuple!(int, int) val) { assert(val[0] == 42 && val[1] == 86); });
+        receive((Variant val) {  });
+        receive((string val) {
+            if ("the quick brown fox" != val)
+                return false;
+            return true;
+        }, (string val) { assert(false); });
+        prioritySend(tid, "done");
     }
 
-    void runTest( Tid tid )
+    void runTest(Tid tid)
     {
-        send( tid, 42, 86 );
-        send( tid, tuple(42, 86) );
-        send( tid, "hello", "there" );
-        send( tid, "the quick brown fox" );
-        receive( (string val) { assert(val == "done"); } );
+        send(tid, 42, 86);
+        send(tid, tuple(42, 86));
+        send(tid, "hello", "there");
+        send(tid, "the quick brown fox");
+        receive((string val) { assert(val == "done"); });
     }
-
 
     void simpleTest()
     {
-        auto tid = spawn( &testfn, thisTid );
-        runTest( tid );
+        auto tid = spawn(&testfn, thisTid);
+        runTest(tid);
 
         // Run the test again with a limited mailbox size.
-        tid = spawn( &testfn, thisTid );
-        setMaxMailboxSize( tid, 2, OnCrowding.block );
-        runTest( tid );
+        tid = spawn(&testfn, thisTid);
+        setMaxMailboxSize(tid, 2, OnCrowding.block);
+        runTest(tid);
     }
-
 
     @system unittest
     {
         simpleTest();
     }
-
 
     @system unittest
     {
@@ -2509,8 +2318,6 @@ version( unittest )
         scheduler = null;
     }
 }
-
-// initOnce
 
 private @property Mutex initOnceLock()
 {
@@ -2555,6 +2362,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
             return initOnce!inst(new MySingleton);
         }
     }
+
     assert(MySingleton.instance !is null);
 }
 
@@ -2567,6 +2375,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
             static __gshared MySingleton inst;
             return initOnce!inst(new MySingleton);
         }
+
     private:
         this() { val = ++cnt; }
         size_t val;
@@ -2574,7 +2383,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
     }
 
     foreach (_; 0 .. 10)
-        spawn({ownerTid.send(MySingleton.instance.val);});
+        spawn({ ownerTid.send(MySingleton.instance.val); });
     foreach (_; 0 .. 10)
         assert(receiveOnly!size_t == MySingleton.instance.val);
     assert(MySingleton.cnt == 1);
@@ -2599,7 +2408,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
 auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 {
     // check that var is global, can't take address of a TLS variable
-    static assert(is(typeof({__gshared p = &var;})), "var must be 'static shared' or '__gshared'.");
+    static assert(is(typeof({ __gshared p = &var; })),
+        "var must be 'static shared' or '__gshared'.");
     import core.atomic : atomicLoad, MemoryOrder, atomicStore;
 
     static shared bool flag;
@@ -2639,8 +2449,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 
 @system unittest
 {
-     static shared bool a;
-     __gshared bool b;
+    static shared bool a;
+    __gshared bool b;
     static bool c;
     bool d;
     initOnce!a(true);


### PR DESCRIPTION
std/concurrency.d uses a non standard style, this brings it into line with the rest of the codebase

used the default dfmt options with some manual fixes.

CC @wilzbach 