### PR TITLE
Clarify deallocation done by std.typecons.Unique.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -49,7 +49,7 @@ debug(Unique) import std.stdio;
 /**
 Encapsulates unique ownership of a resource.
 
-When a $(D Unique!T) goes out of scope it will call $(REF destroy, object)
+When a $(D Unique!T) goes out of scope it will call $(D destroy)
 on the resource $(D T) that it manages, unless it is transferred.
 One important consequence of $(D destroy) is that it will call the
 destructor of the resource $(D T).  GC-managed references are not

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -47,11 +47,25 @@ import std.traits;
 debug(Unique) import std.stdio;
 
 /**
-Encapsulates unique ownership of a resource.  Resource of type $(D T) is
-deleted at the end of the scope, unless it is transferred.  The
-transfer can be explicit, by calling $(D release), or implicit, when
-returning Unique from a function. The resource can be a polymorphic
-class object, in which case Unique behaves polymorphically too.
+Encapsulates unique ownership of a resource.
+
+When a $(D Unique!T) goes out of scope it will call $(REF destroy, object)
+on the resource $(D T) that it manages, unless it is transferred.
+One important consequence of $(D destroy) is that it will call the
+destructor of the resource $(D T).  GC-managed references are not
+guaranteed to be valid during a destructor call, but other members of
+$(D T), such as file handles or pointers to $(D malloc) memory, will
+still be valid during the destructor call.  This allows the resource
+$(D T) to deallocate or clean up any non-GC resources.
+
+If it is desirable to persist a $(D Unique!T) outside of its original
+scope, then it can be transferred.  The transfer can be explicit, by
+calling $(D release), or implicit, when returning Unique from a
+function. The resource $(D T) can be a polymorphic class object, in
+which case Unique behaves polymorphically too.
+
+If $(D T) is a value type, then $(D Unique!T) will be implemented
+as a reference to a $(D T).
 */
 struct Unique(T)
 {


### PR DESCRIPTION
I had trouble understanding how Unique!T was supposed to help me manage resources.  These document changes should clarify the process and make it easier for others to understand.

Caveat: I'm not absolutely sure if $(REF destroy, object) will do what I intend after doc generation.  I don't have time to learn how to build Phobos' documentation to test it.  I intend it to reference https://dlang.org/library/object/destroy.html so that the reader can easily understand the implications.

This is follow-up after this post on the D learn forum: https://forum.dlang.org/post/qctmkqpqnreysxcjmrgm@forum.dlang.org

If this change goes well, then I will attempt to update RefCounted!T as well.