### PR TITLE
Make the resolveInternalPointer method abide the IAllocator API

### DIFF
--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -206,13 +206,14 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     resolveInternalPointer), and tries it for each bucket in turn.
     */
     static if (hasMember!(Allocator, "resolveInternalPointer"))
-    void[] resolveInternalPointer(void* p)
+    Ternary resolveInternalPointer(void* p, ref void[] result)
     {
         foreach (ref a; buckets)
         {
-            if (auto r = a.resolveInternalPointer(p)) return r;
+            Ternary r = a.resolveInternalPointer(p, result);
+            if (r == Ternary.yes) return r;
         }
-        return null;
+        return Ternary.no;
     }
 }
 
@@ -235,5 +236,6 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     auto b = a.allocate(400);
     assert(b.length == 400);
     assert(a.owns(b) == Ternary.yes);
+    void[] p;
     a.deallocate(b);
 }

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -207,11 +207,10 @@ struct FallbackAllocator(Primary, Fallback)
     */
     static if (hasMember!(Primary, "resolveInternalPointer")
         && hasMember!(Fallback, "resolveInternalPointer"))
-    void[] resolveInternalPointer(void* p)
+    Ternary resolveInternalPointer(void* p, ref void[] result)
     {
-        if (auto r = primary.resolveInternalPointer(p)) return r;
-        if (auto r = fallback.resolveInternalPointer(p)) return r;
-        return null;
+        Ternary r = primary.resolveInternalPointer(p, result);
+        return r == Ternary.no ? fallback.resolveInternalPointer(p, result) : r;
     }
 
     /**

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -41,9 +41,10 @@ struct NullAllocator
     /// Returns $(D Ternary.no).
     Ternary owns(void[]) shared const { return Ternary.no; }
     /**
-    Returns $(D null).
+    Returns $(D Ternary.no).
     */
-    void[] resolveInternalPointer(void*) shared const { return null; }
+    Ternary resolveInternalPointer(void*, ref void[]) shared const
+    { return Ternary.no; }
     /**
     No-op.
     Precondition: $(D b is null)
@@ -65,10 +66,20 @@ struct NullAllocator
 
 @system unittest
 {
+    assert(NullAllocator.instance.alignedAllocate(100, 0) is null);
+    assert(NullAllocator.instance.allocateAll() is null);
     auto b = NullAllocator.instance.allocate(100);
     assert(b is null);
+    assert(NullAllocator.instance.expand(b, 0));
+    assert(!NullAllocator.instance.expand(b, 42));
+    assert(!NullAllocator.instance.reallocate(b, 42));
+    assert(!NullAllocator.instance.alignedReallocate(b, 42, 0));
     NullAllocator.instance.deallocate(b);
     NullAllocator.instance.deallocateAll();
+
     import std.typecons : Ternary;
+    assert(NullAllocator.instance.empty() == Ternary.yes);
     assert(NullAllocator.instance.owns(null) == Ternary.no);
+    void[] p;
+    assert(NullAllocator.instance.resolveInternalPointer(null, p) == Ternary.no);
 }

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -103,11 +103,12 @@ or linear time with a low multiplication factor). Traditional allocators such as
 the C heap do not define such functionality. If $(D b is null), the allocator
 shall return `Ternary.no`, i.e. no allocator owns the `null` slice.))
 
-$(TR $(TDC void[] resolveInternalPointer(void* p);) $(TD If $(D p) is a pointer
-somewhere inside a block allocated with this allocator, returns a pointer to the
-beginning of the allocated block. Otherwise, returns $(D null). If the pointer
-points immediately after an allocated block, the result is implementation
-defined.))
+$(TR $(TDC Ternary resolveInternalPointer(void* p, ref void[] result);) $(TD If
+`p` is a pointer somewhere inside a block allocated with this allocator,
+`result` holds a pointer to the beginning of the allocated block and returns
+`Ternary.yes`. Otherwise, `result` holds `null` and returns `Ternary.no`.
+If the pointer points immediately after an allocated block, the result is
+implementation defined.))
 
 $(TR $(TDC bool deallocate(void[] b);) $(TD If $(D b is null), does
 nothing and returns `true`. Otherwise, deallocates memory previously allocated

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -247,10 +247,10 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "resolveInternalPointer")
                 && hasMember!(LargeAllocator, "resolveInternalPointer"))
-        void[] resolveInternalPointer(void* p)
+        Ternary resolveInternalPointer(void* p, ref void[] result)
         {
-            if (auto r = _small.resolveInternalPointer(p)) return r;
-            return _large.resolveInternalPointer(p);
+            Ternary r = _small.resolveInternalPointer(p, result);
+            return r == Ternary.no ? _large.resolveInternalPointer(p, result) : r;
         }
     }
 

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -507,26 +507,27 @@ package void testAllocator(alias make)()
 
     static if (hasMember!(A, "resolveInternalPointer"))
     {{
-        assert(a.resolveInternalPointer(null) is null);
-        auto p = a.resolveInternalPointer(b1.ptr);
+        void[] p;
+        assert(a.resolveInternalPointer(null, p) == Ternary.no);
+        Ternary r = a.resolveInternalPointer(b1.ptr, p);
         assert(p.ptr is b1.ptr && p.length >= b1.length);
-        p = a.resolveInternalPointer(b1.ptr + b1.length / 2);
+        r = a.resolveInternalPointer(b1.ptr + b1.length / 2, p);
         assert(p.ptr is b1.ptr && p.length >= b1.length);
-        p = a.resolveInternalPointer(b2.ptr);
+        r = a.resolveInternalPointer(b2.ptr, p);
         assert(p.ptr is b2.ptr && p.length >= b2.length);
-        p = a.resolveInternalPointer(b2.ptr + b2.length / 2);
+        r = a.resolveInternalPointer(b2.ptr + b2.length / 2, p);
         assert(p.ptr is b2.ptr && p.length >= b2.length);
-        p = a.resolveInternalPointer(b6.ptr);
+        r = a.resolveInternalPointer(b6.ptr, p);
         assert(p.ptr is b6.ptr && p.length >= b6.length);
-        p = a.resolveInternalPointer(b6.ptr + b6.length / 2);
+        r = a.resolveInternalPointer(b6.ptr + b6.length / 2, p);
         assert(p.ptr is b6.ptr && p.length >= b6.length);
         static int[10] b7 = [ 1, 2, 3 ];
-        assert(a.resolveInternalPointer(b7.ptr) is null);
-        assert(a.resolveInternalPointer(b7.ptr + b7.length / 2) is null);
-        assert(a.resolveInternalPointer(b7.ptr + b7.length) is null);
+        assert(a.resolveInternalPointer(b7.ptr, p) == Ternary.no);
+        assert(a.resolveInternalPointer(b7.ptr + b7.length / 2, p) == Ternary.no);
+        assert(a.resolveInternalPointer(b7.ptr + b7.length, p) == Ternary.no);
         int[3] b8 = [ 1, 2, 3 ];
-        assert(a.resolveInternalPointer(b8.ptr).ptr is null);
-        assert(a.resolveInternalPointer(b8.ptr + b8.length / 2) is null);
-        assert(a.resolveInternalPointer(b8.ptr + b8.length) is null);
+        assert(a.resolveInternalPointer(b8.ptr, p) == Ternary.no);
+        assert(a.resolveInternalPointer(b8.ptr + b8.length / 2, p) == Ternary.no);
+        assert(a.resolveInternalPointer(b8.ptr + b8.length, p) == Ternary.no);
     }}
 }


### PR DESCRIPTION
Have the resolveInternalPointer method defined in the module's static allocators abide the IAllocator API.