### PR TITLE
Add const/inout to std.parallelism

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2093,7 +2093,7 @@ public:
                 else
                 {
 
-                    bool empty() @property
+                    bool empty() const @property
                     {
                         // popFront() sets this when source is empty
                         return buf1.length == 0;
@@ -2889,11 +2889,11 @@ public:
             }
         }
 
-        ref T opIndex(size_t index)
+        ref opIndex(this Qualified)(size_t index)
         {
             import std.conv : text;
             assert(index < size, text(index, '\t', uint.max));
-            return *(cast(T*) (data + elemSize * index));
+            return *(cast(CopyTypeQualifiers!(Qualified, T)*) (data + elemSize * index));
         }
 
         void opIndexAssign(T val, size_t index)
@@ -2916,7 +2916,7 @@ public:
         failure will result when calling this method.  This is not checked
         when assertions are disabled for performance reasons.
          */
-        ref T get() @property
+        ref get(this Qualified)() @property
         {
             assert(*stillThreadLocal,
                 "Cannot call get() on this instance of WorkerLocalStorage " ~
@@ -2996,12 +2996,12 @@ public:
         }
 
     public:
-        ref T front() @property
+        ref front(this Qualified)() @property
         {
             return this[0];
         }
 
-        ref T back() @property
+        ref back(this Qualified)() @property
         {
             return this[_length - 1];
         }
@@ -3028,7 +3028,7 @@ public:
             return this;
         }
 
-        ref T opIndex(size_t index)
+        ref opIndex(this Qualified)(size_t index)
         {
             assert(index < _length);
             return workerLocalStorage[index + beginOffset];
@@ -3049,12 +3049,12 @@ public:
             return typeof(this)(newWl);
         }
 
-        bool empty() @property
+        bool empty() const @property
         {
             return length == 0;
         }
 
-        size_t length() @property
+        size_t length() const @property
         {
             return _length;
         }


### PR DESCRIPTION
Ok, so apparently you cannot reopen a PR if you force push to it. Weird :/

So I think this is exactly what inout was designed to solve. Please destroy if still unsafe.

CC @andralex 