### PR TITLE
Issue 13568: Add CT-checked format string overloads to std.format

### DIFF
--- a/changelog/std-format-formattedWrite.dd
+++ b/changelog/std-format-formattedWrite.dd
@@ -1,0 +1,19 @@
+`std.format.formattedWrite` now accepts a compile-time checked format string
+
+$(REF formattedWrite, std, format) and related functions now have overloads to
+take the format string as a compile-time argument. This allows the format
+specifiers to be matched against the argument types passed. Any mismatch or
+orphaned specifiers/arguments will cause a compile-time error:
+
+-------
+import std.format;
+
+void main() {
+    auto s = format!"%s is %s"("Pi", 3.14);
+    assert(s == "Pi is 3.14");
+
+    static assert(!__traits(compiles, {s = format!"%l"();}));     // missing arg
+    static assert(!__traits(compiles, {s = format!""(404);}));    // surplus arg
+    static assert(!__traits(compiles, {s = format!"%d"(4.03);})); // incompatible arg
+}
+-------

--- a/std/format.d
+++ b/std/format.d
@@ -419,6 +419,7 @@ My friends are John, Nancy.
 )
  */
 uint formattedWrite(alias fmt, Writer, A...)(Writer w, A args)
+if (isSomeString!(typeof(fmt)))
 {
     alias e = checkFormatException!(fmt, A);
     static assert(!e, e.msg);
@@ -581,6 +582,7 @@ Throws:
     An `Exception` if `S.length == 0` and `fmt` has format specifiers
  */
 uint formattedRead(alias fmt, R, S...)(ref R r, auto ref S args)
+if (isSomeString!(typeof(fmt)))
 {
     alias e = checkFormatException!(fmt, S);
     static assert(!e, e.msg);
@@ -5483,7 +5485,7 @@ package static const checkFormatException(alias fmt, Args...) =
     try
         .format(fmt, Args.init);
     catch (Exception e)
-        return (e.msg is ctfpMessage) ? null : e;
+        return (e.msg == ctfpMessage) ? null : e;
     return null;
 }();
 
@@ -5494,6 +5496,7 @@ package static const checkFormatException(alias fmt, Args...) =
  *         args = Variadic list of arguments to _format into returned string.
  */
 typeof(fmt) format(alias fmt, Args...)(Args args)
+if (isSomeString!(typeof(fmt)))
 {
     alias e = checkFormatException!(fmt, Args);
     static assert(!e, e.msg);
@@ -5581,6 +5584,7 @@ if (isSomeChar!Char)
  *     than the number of format specifiers in `fmt`.
  */
 char[] sformat(alias fmt, Args...)(char[] buf, Args args)
+if (isSomeString!(typeof(fmt)))
 {
     alias e = checkFormatException!(fmt, Args);
     static assert(!e, e.msg);


### PR DESCRIPTION
* Add overloads for formattedWrite, formattedRead, format, sformat.

Check compile-time format strings match the given argument types. I'm using CTFE to evaluate `format(fmtStr, Args.init)` and see if an exception was thrown; the actual runtime code is unchanged. This is not optimal but makes this PR easy to implement and avoids code duplication/refactoring of `formattedWrite`. Users can start to pass format strings as compile-time arguments.

* Throw FormatError when formatValue is called with CTFE and a floating point argument.

This allows `snprintf` to be avoided in CTFE when checking format strings so floating point arguments can be checked.

@quickfur 