### PR TITLE
Fix it so that isSomeString and isNarrowString are false for enums.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5996,7 +5996,7 @@ $(D wchar) or $(D dchar), with or without qualifiers.
 Static arrays of characters (like $(D char[80])) are not considered
 built-in string types.
  */
-enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStaticArray!T;
+enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStaticArray!T && !is(T == enum);
 
 ///
 @safe unittest
@@ -6008,15 +6008,22 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
     static assert( isSomeString!(typeof("aaa")));
     static assert( isSomeString!(const(char)[]));
 
-    enum ES : string { a = "aaa", b = "bbb" }
-    static assert( isSomeString!ES);
-
     //Non string types
     static assert(!isSomeString!int);
     static assert(!isSomeString!(int[]));
     static assert(!isSomeString!(byte[]));
     static assert(!isSomeString!(typeof(null)));
     static assert(!isSomeString!(char[4]));
+
+    enum ES : string { a = "aaa", b = "bbb" }
+    static assert(!isSomeString!ES);
+
+    static struct Stringish
+    {
+        string str;
+        alias str this;
+    }
+    static assert(!isSomeString!Stringish);
 }
 
 @safe unittest
@@ -6034,7 +6041,7 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
  * All arrays that use char, wchar, and their qualified versions are narrow
  * strings. (Those include string and wstring).
  */
-enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) && !isAggregateType!T && !isStaticArray!T;
+enum bool isNarrowString(T) = isSomeString!T && !is(T : const dchar[]);
 
 ///
 @safe unittest
@@ -6046,6 +6053,19 @@ enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) &&
 
     static assert(!isNarrowString!dstring);
     static assert(!isNarrowString!(dchar[]));
+
+    static assert(!isNarrowString!(typeof(null)));
+    static assert(!isNarrowString!(char[4]));
+
+    enum ES : string { a = "aaa", b = "bbb" }
+    static assert(!isNarrowString!ES);
+
+    static struct Stringish
+    {
+        string str;
+        alias str this;
+    }
+    static assert(!isNarrowString!Stringish);
 }
 
 @safe unittest


### PR DESCRIPTION
Having isSomeString and isNarrowString be true for enums whose base type
is a string type is a problem, because the enums will not work with the
same code that strings will, resulting either in compilation errors or
subtle bugs which result in variables of an enum type that contain
values that are not members of that enum type. As with other types that
implicitly convert to a string type, the enums need to be converted to
be used with the code that's designed for strings, which happens when
the function explicitly takes a string type or when the function takes
an array and is templated on the character/element type but does not
happen when the function is templated on the whole parameter type.

In addition to fixing isSomeString and isNarrowString for enums, these
changes catch and fix the fact that isNarrowString did not work
correctly with null - something that isSomeString did test for and
handle appropriately.

Under some circumstances, these changes might break existing code (specifically when the code happened to use the subset of operations that work with an enum, and an enum was used used with the function), but usually, a function taking strings is probably just going to take `string` or templatize on the character type rather than use `isSomeString`, and `isNarrowString` is almost certainly used pretty much exclusively in range-based code, which would already reject enums. So, in most cases, the changes will catch bugs or be irrelevant rather than break code. And it's really only going to matter for non-range-based code. These changes required no changes in Phobos outside of `isSomeString`, `isNarrowString`, and their unit tests.

Based on the recent newsgroup discussion on string-related traits, Andrei seemed to think that these changes were worth the minor code breakage that they risk causing, so I'm marking this as @andralex, and this pretty much needs an executive decision anyway, because while it's likely that the code breakage will be minor and that most of the breakage will actually be catching bugs, it still isn't guaranteed to not break any code. But unfortunately, we don't have good a way to make these changes while guranteeing that no code will break, and simply fixing `isSomeString` would cause _far_ less disruption than trying to replace it with another trait that did the correct thing.