### PR TITLE
Nicer error messages for std.typecons.experimental.Final

### DIFF
--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -848,7 +848,7 @@ else
         }
 
         // Attaching function attributes gives less noisy error messages
-        pure nothrow @safe @nogc @disable
+        pure nothrow @safe @nogc
         {
             /++
              + All operators, including member access, are forwarded to the

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -855,10 +855,32 @@ else
              + underlying value of type `T` except for these mutating operators,
              + which are disabled.
              +/
-            void opAssign(Other)(Other other);
-            void opOpAssign(string op, Other)(Other other); /// Ditto
-            void opUnary(string op : "--")(); /// Ditto
-            void opUnary(string op : "++")(); /// Ditto
+            void opAssign(Other)(Other other)
+            {
+                static assert(0, typeof(this).stringof ~
+                                 " cannot be reassigned.");
+            }
+
+            /// Ditto
+            void opOpAssign(string op, Other)(Other other)
+            {
+                static assert(0, typeof(this).stringof ~
+                                 " cannot be reassigned.");
+            }
+
+            /// Ditto
+            void opUnary(string op : "--")()
+            {
+                static assert(0, typeof(this).stringof ~
+                                 " cannot be mutated.");
+            }
+
+            /// Ditto
+            void opUnary(string op : "++")()
+            {
+                static assert(0, typeof(this).stringof ~
+                                 " cannot be mutated.");
+            }
         }
 
         /**


### PR DESCRIPTION
Code:
````
import std.experimental.typecons;
void main()
{
    Final!int s;
    s += 5;
}
````

Compiler output (before):
````
test.d(5): Error: function std.experimental.typecons.Final!int.Final.opOpAssign!("+", int).opOpAssign is not callable because it is annotated with @disable
````

Compiler output (after):
````
/usr/src/d/phobos/std/experimental/typecons.d(867): Error: static assert  "Final!int cannot be reassigned."
test.d(5):        instantiated from here: opOpAssign!("+", int)
````

The current error message (before) is rather unhelpful from the user's POV, and exposes too much implementation detail ("I just used `Final!int` to declare a variable, what does `@disable` have to do with it?").  The new error message is more informative and explains why the operation is not allowed.