### PR TITLE
Fix issue 15534 - [std.experimental.logger.core] Documentation mismatch

### DIFF
--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -744,12 +744,14 @@ abstract class Logger
         Logger logger;
     }
 
-    /** This constructor takes a name of type $(D string), and a $(D LogLevel).
+    /**
+    Every subclass of `Logger` has to call this constructor from their
+    constructor. It sets the `LogLevel`, and creates a fatal handler. The fatal
+    handler will throw an `Error` if a log call is made with level
+    `LogLevel.fatal`.
 
-    Every subclass of $(D Logger) has to call this constructor from their
-    constructor. It sets the $(D LogLevel), the name of the $(D Logger), and
-    creates a fatal handler. The fatal handler will throw an $(D Error) if a
-    log call is made with a $(D LogLevel) $(D LogLevel.fatal).
+    Params:
+         lv = `LogLevel` to use for this `Logger` instance.
     */
     this(LogLevel lv) @safe
     {


### PR DESCRIPTION
Docs seem to refer to a string parameter, that apparently was removed.
Also reworked the docs to be more appropriate ddoc style (and modernized with backticks)

ping @burner 