### PR TITLE
Allocators should take a ubyte[] memory block instead of a void[] one

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -397,7 +397,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     import std.experimental.allocator.common : testAllocator;
     testAllocator!({
         auto a = AffixAllocator!(BitmappedBlock!128, ulong, ulong)
-            (BitmappedBlock!128(new void[128 * 4096]));
+            (BitmappedBlock!128(new ubyte[128 * 4096]));
         return a;
     });
 }

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -555,7 +555,7 @@ version(Posix) @system unittest
     // Ouroboros allocator list based upon 4MB regions, fetched from the garbage
     // collector. Memory is left to the collector.
     alias A3 = AllocatorList!(
-        (n) => Region!NullAllocator(new void[max(n, 1024 * 4096)]),
+        (n) => Region!NullAllocator(new ubyte[max(n, 1024 * 4096)]),
         NullAllocator);
 
     // Allocator list that creates one freelist for all objects
@@ -563,7 +563,7 @@ version(Posix) @system unittest
         Segregator!(
             64, AllocatorList!(
                 (n) => ContiguousFreeList!(NullAllocator, 0, 64)(
-                    GCAllocator.instance.allocate(4096))),
+                    cast(ubyte[])(GCAllocator.instance.allocate(4096)))),
             GCAllocator);
 
     A4 a;
@@ -581,7 +581,7 @@ version(Posix) @system unittest
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!GCAllocator(new void[max(n, 1024 * 4096)]),
+    AllocatorList!((n) => Region!GCAllocator(new ubyte[max(n, 1024 * 4096)]),
         NullAllocator) a;
     const b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
@@ -595,7 +595,7 @@ version(Posix) @system unittest
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!()(new void[max(n, 1024 * 4096)])) a;
+    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
     b1 = a.allocate(1024 * 10);
@@ -608,7 +608,7 @@ version(Posix) @system unittest
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;
-    AllocatorList!((n) => Region!()(new void[max(n, 1024 * 4096)])) a;
+    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null);
     b1 = a.allocate(1024 * 10);

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -54,8 +54,8 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;
         import std.algorithm.comparison : max;
-        auto m = AlignedMallocator.instance.alignedAllocate(1024 * 64,
-            max(theAlignment, cast(uint) size_t.sizeof));
+        auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
+                                max(theAlignment, cast(uint) size_t.sizeof)));
         scope(exit) AlignedMallocator.instance.deallocate(m);
         testAllocator!(() => BitmappedBlock(m));
     }
@@ -153,7 +153,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     ParentAllocator.deallocate).)
     )
     */
-    this(void[] data)
+    this(ubyte[] data)
     {
         immutable a = data.ptr.effectiveAlignment;
         assert(a >= size_t.alignof || !data.ptr,
@@ -189,7 +189,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     this(size_t capacity)
     {
         size_t toAllocate = totalAllocation(capacity);
-        auto data = parent.allocate(toAllocate);
+        auto data = cast(ubyte[])(parent.allocate(toAllocate));
         this(data);
         assert(_blocks * blockSize >= capacity);
     }
@@ -696,7 +696,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     import std.experimental.allocator.building_blocks.region : InSituRegion;
     import std.traits : hasMember;
     InSituRegion!(10_240, 64) r;
-    auto a = BitmappedBlock!(64, 64)(r.allocateAll());
+    auto a = BitmappedBlock!(64, 64)(cast(ubyte[])(r.allocateAll()));
     static assert(hasMember!(InSituRegion!(10_240, 64), "allocateAll"));
     const b = a.allocate(100);
     assert(b.length == 100);
@@ -716,7 +716,8 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
         assert(bs);
         import std.experimental.allocator.gc_allocator : GCAllocator;
         auto a = BitmappedBlock!(bs, min(bs, platformAlignment))(
-            GCAllocator.instance.allocate((blocks * bs * 8 + blocks) / 8)
+            cast(ubyte[])(GCAllocator.instance.allocate((blocks * bs * 8 +
+                        blocks) / 8))
         );
         import std.conv : text;
         assert(blocks >= a._blocks, text(blocks, " < ", a._blocks));
@@ -863,8 +864,8 @@ struct BitmappedBlockWithInternalPointers(
     @system unittest
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;
-        auto m = AlignedMallocator.instance.alignedAllocate(1024 * 64,
-            theAlignment);
+        auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
+            theAlignment));
         scope(exit) AlignedMallocator.instance.deallocate(m);
         testAllocator!(() => BitmappedBlockWithInternalPointers(m));
     }
@@ -878,7 +879,7 @@ struct BitmappedBlockWithInternalPointers(
     Constructors accepting desired capacity or a preallocated buffer, similar
     in semantics to those of $(D BitmappedBlock).
     */
-    this(void[] data)
+    this(ubyte[] data)
     {
         _heap = BitmappedBlock!(theBlockSize, theAlignment, ParentAllocator)(data);
     }
@@ -1064,7 +1065,7 @@ struct BitmappedBlockWithInternalPointers(
 {
     import std.typecons : Ternary;
 
-    auto h = BitmappedBlockWithInternalPointers!(4096)(new void[4096 * 1024]);
+    auto h = BitmappedBlockWithInternalPointers!(4096)(new ubyte[4096 * 1024]);
     auto b = h.allocate(123);
     assert(b.length == 123);
 

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -453,7 +453,7 @@ struct ContiguousFreeList(ParentAllocator,
     /// Alignment offered.
     enum uint alignment = (void*).alignof;
 
-    private void initialize(void[] buffer, size_t itemSize = fl.max)
+    private void initialize(ubyte[] buffer, size_t itemSize = fl.max)
     {
         assert(itemSize != unbounded && itemSize != chooseAtRuntime);
         assert(buffer.ptr.alignedAt(alignment));
@@ -497,14 +497,14 @@ struct ContiguousFreeList(ParentAllocator,
     initialized with $(D max).
     */
     static if (!stateSize!ParentAllocator)
-    this(void[] buffer)
+    this(ubyte[] buffer)
     {
         initialize(buffer);
     }
 
     /// ditto
     static if (stateSize!ParentAllocator)
-    this(ParentAllocator parent, void[] buffer)
+    this(ParentAllocator parent, ubyte[] buffer)
     {
         initialize(buffer);
         this.parent = SParent(parent);
@@ -514,14 +514,14 @@ struct ContiguousFreeList(ParentAllocator,
     static if (!stateSize!ParentAllocator)
     this(size_t bytes)
     {
-        initialize(ParentAllocator.instance.allocate(bytes));
+        initialize(cast(ubyte[])(ParentAllocator.instance.allocate(bytes)));
     }
 
     /// ditto
     static if (stateSize!ParentAllocator)
     this(ParentAllocator parent, size_t bytes)
     {
-        initialize(parent.allocate(bytes));
+        initialize(cast(ubyte[])(parent.allocate(bytes)));
         this.parent = SParent(parent);
     }
 
@@ -532,7 +532,7 @@ struct ContiguousFreeList(ParentAllocator,
     {
         static if (maxSize == chooseAtRuntime) fl.max = max;
         static if (minSize == chooseAtRuntime) fl.min = max;
-        initialize(parent.allocate(bytes), max);
+        initialize(cast(ubyte[])(parent.allocate(bytes)), max);
     }
 
     /// ditto
@@ -542,7 +542,7 @@ struct ContiguousFreeList(ParentAllocator,
     {
         static if (maxSize == chooseAtRuntime) fl.max = max;
         static if (minSize == chooseAtRuntime) fl.min = max;
-        initialize(parent.allocate(bytes), max);
+        initialize(cast(ubyte[])(parent.allocate(bytes)), max);
         this.parent = SParent(parent);
     }
 
@@ -554,7 +554,7 @@ struct ContiguousFreeList(ParentAllocator,
     {
         static if (maxSize == chooseAtRuntime) fl.max = max;
         fl.min = min;
-        initialize(parent.allocate(bytes), max);
+        initialize(cast(ubyte[])(parent.allocate(bytes)), max);
         static if (stateSize!ParentAllocator)
             this.parent = SParent(parent);
     }
@@ -567,7 +567,7 @@ struct ContiguousFreeList(ParentAllocator,
     {
         static if (maxSize == chooseAtRuntime) fl.max = max;
         fl.min = min;
-        initialize(parent.allocate(bytes), max);
+        initialize(cast(ubyte[])(parent.allocate(bytes)), max);
         static if (stateSize!ParentAllocator)
             this.parent = SParent(parent);
     }
@@ -690,7 +690,7 @@ struct ContiguousFreeList(ParentAllocator,
         : NullAllocator;
     import std.typecons : Ternary;
     alias A = ContiguousFreeList!(NullAllocator, 0, 64);
-    auto a = A(new void[1024]);
+    auto a = A(new ubyte[1024]);
 
     assert(a.empty == Ternary.yes);
 

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -311,7 +311,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     n = Capacity desired. This constructor is defined only if $(D
     ParentAllocator) is not $(D NullAllocator).
     */
-    this(void[] b)
+    this(ubyte[] b)
     {
         if (b.length < Node.sizeof)
         {
@@ -338,7 +338,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     this(size_t n)
     {
         assert(n > Node.sizeof);
-        this(parent.allocate(n));
+        this(cast(ubyte[])(parent.allocate(n)));
     }
 
     /// Ditto
@@ -751,7 +751,8 @@ it actually returns memory to the operating system when possible.
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
-    auto alloc = KRRegion!()(GCAllocator.instance.allocate(1024 * 1024));
+    auto alloc = KRRegion!()(
+                    cast(ubyte[])(GCAllocator.instance.allocate(1024 * 1024)));
     const store = alloc.allocate(KRRegion!().sizeof);
     auto p = cast(KRRegion!()* ) store.ptr;
     import std.conv : emplace;
@@ -783,7 +784,8 @@ it actually returns memory to the operating system when possible.
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
-    auto alloc = KRRegion!()(GCAllocator.instance.allocate(1024 * 1024));
+    auto alloc = KRRegion!()(
+                    cast(ubyte[])(GCAllocator.instance.allocate(1024 * 1024)));
     auto p = alloc.allocateAll();
     assert(p.length == 1024 * 1024);
     alloc.deallocateAll();

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -67,9 +67,9 @@ struct Region(ParentAllocator = NullAllocator,
     $(D parent.allocate(n)) returns $(D null), the region will be initialized
     as empty (correctly initialized but unable to allocate).
     */
-    this(void[] store)
+    this(ubyte[] store)
     {
-        store = store.roundUpToAlignment(alignment);
+        store = cast(ubyte[])(store.roundUpToAlignment(alignment));
         store = store[0 .. $.roundDownToAlignment(alignment)];
         assert(store.ptr.alignedAt(minAlign));
         assert(store.length % minAlign == 0);
@@ -85,7 +85,7 @@ struct Region(ParentAllocator = NullAllocator,
     static if (!is(ParentAllocator == NullAllocator))
     this(size_t n)
     {
-        this(parent.allocate(n.roundUpToAlignment(alignment)));
+        this(cast(ubyte[])(parent.allocate(n.roundUpToAlignment(alignment))));
     }
 
     /*
@@ -550,14 +550,14 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     // Reap with GC fallback.
     InSituRegion!(128 * 1024, 8) tmp3;
     FallbackAllocator!(BitmappedBlock!(64, 8), GCAllocator) r3;
-    r3.primary = BitmappedBlock!(64, 8)(tmp3.allocateAll());
+    r3.primary = BitmappedBlock!(64, 8)(cast(ubyte[])(tmp3.allocateAll()));
     const a3 = r3.allocate(103);
     assert(a3.length == 103);
 
     // Reap/GC with a freelist for small objects up to 16 bytes.
     InSituRegion!(128 * 1024, 64) tmp4;
     FreeList!(FallbackAllocator!(BitmappedBlock!(64, 64), GCAllocator), 0, 16) r4;
-    r4.parent.primary = BitmappedBlock!(64, 64)(tmp4.allocateAll());
+    r4.parent.primary = BitmappedBlock!(64, 64)(cast(ubyte[])(tmp4.allocateAll()));
     const a4 = r4.allocate(104);
     assert(a4.length == 104);
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -249,8 +249,9 @@ public import std.experimental.allocator.common,
         2048, Bucketizer!(FList, 1025, 2048, 256),
         3584, Bucketizer!(FList, 2049, 3584, 512),
         4072 * 1024, AllocatorList!(
-            (n) => BitmappedBlock!(4096)(GCAllocator.instance.allocate(
-                max(n, 4072 * 1024)))),
+            (n) => BitmappedBlock!(4096)(
+                    cast(ubyte[])(GCAllocator.instance.allocate(
+                        max(n, 4072 * 1024))))),
         GCAllocator
     );
     A tuMalloc;


### PR DESCRIPTION
Allocators that rely on taking a block of unused memory to manage and allocate
from it should take a ubyte[] instead of a void[] in order to prevent users
from accidentally passing valid data and cause memory corruption/leaks.