### PR TITLE
Fix Issue 17314 - BinaryHeap crashes upon insertion if heapified with an array of length 1

### DIFF
--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -282,7 +282,7 @@ and $(D length == capacity), throws an exception.
             import std.traits : isDynamicArray;
             static if (isDynamicArray!Store)
             {
-                if (_store.length == 0)
+                if (_store.length < 5)
                     _store.length = 8;
                 else if (length == _store.length)
                     _store.length = length * 3 / 2;
@@ -585,4 +585,13 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
 
     assert(equal(heap, [ 5, 5, 4, 4, 3, 3, 2, 2, 1, 1]));
     assert(equal(b, [10, 9, 8, 7, 6, 6, 7, 8, 9, 10]));
+}
+
+@system unittest // Issue 17314
+{
+    import std.algorithm.comparison : equal;
+    int[] a = [5];
+    auto heap = heapify(a);
+    heap.insert(6);
+    assert(equal(heap, [6, 5]));
 }

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -282,10 +282,8 @@ and $(D length == capacity), throws an exception.
             import std.traits : isDynamicArray;
             static if (isDynamicArray!Store)
             {
-                if (_store.length < 6)
-                    _store.length = 8;
-                else if (length == _store.length)
-                    _store.length = length * 3 / 2;
+                if(length == _store.length)
+                    _store.length = (length < 6 ? 8 : length * 3 / 2);
                 _store[_length] = value;
             }
             else

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -282,7 +282,7 @@ and $(D length == capacity), throws an exception.
             import std.traits : isDynamicArray;
             static if (isDynamicArray!Store)
             {
-                if (_store.length < 5)
+                if (_store.length < 6)
                     _store.length = 8;
                 else if (length == _store.length)
                     _store.length = length * 3 / 2;

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -282,7 +282,7 @@ and $(D length == capacity), throws an exception.
             import std.traits : isDynamicArray;
             static if (isDynamicArray!Store)
             {
-                if(length == _store.length)
+                if (length == _store.length)
                     _store.length = (length < 6 ? 8 : length * 3 / 2);
                 _store[_length] = value;
             }


### PR DESCRIPTION
When length is 1, length * 3 / 2 is still 1, so insert didn't make room for the new item.

https://issues.dlang.org/show_bug.cgi?id=17314