### PR TITLE
Make the allocators' unittests and allocate, owns and resolveInternal…

### DIFF
--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -89,8 +89,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         @disable this(this);
 
         // Is this node unused?
-        void setUnused() { next = &this; }
-        bool unused() const { return next is &this; }
+        @trusted void setUnused() { next = &this; }
+        @safe bool unused() const { return next is &this; }
 
         // Just forward everything to the allocator
         alias a this;
@@ -162,7 +162,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     fails, subsequent calls to $(D allocate) will not cause more calls to $(D
     make).
     */
-    @safe void[] allocate(size_t s)
+    void[] allocate(size_t s)
     {
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
         {
@@ -194,11 +194,11 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         return null;
     }
 
-    private void moveAllocators(void[] newPlace)
+    private @safe void moveAllocators(void[] newPlace)
     {
-        assert(newPlace.ptr.alignedAt(Node.alignof));
+        assert((() @trusted => newPlace.ptr.alignedAt(Node.alignof))());
         assert(newPlace.length % Node.sizeof == 0);
-        auto newAllocators = cast(Node[]) newPlace;
+        auto newAllocators = (() @trusted => cast(Node[]) newPlace)();
         assert(allocators.length <= newAllocators.length);
 
         // Move allocators
@@ -210,11 +210,11 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
                 continue;
             }
             import core.stdc.string : memcpy;
-            memcpy(&newAllocators[i].a, &e.a, e.a.sizeof);
+            () @trusted { memcpy(&newAllocators[i].a, &e.a, e.a.sizeof); }();
             if (e.next)
             {
-                newAllocators[i].next = newAllocators.ptr
-                    + (e.next - allocators.ptr);
+                newAllocators[i].next = (() @trusted => newAllocators.ptr
+                                            + (e.next - allocators.ptr))();
             }
             else
             {
@@ -230,7 +230,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         auto toFree = allocators;
 
         // Change state
-        root = newAllocators.ptr + (root - allocators.ptr);
+        root = (() @trusted => newAllocators.ptr + (root - allocators.ptr))();
         allocators = newAllocators;
 
         // Free the olden buffer
@@ -238,16 +238,16 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         {
             static if (hasMember!(Allocator, "deallocate")
                     && hasMember!(Allocator, "owns"))
-                deallocate(toFree);
+                () @trusted { deallocate(toFree); }();
         }
         else
         {
-            bkalloc.deallocate(toFree);
+            () @trusted { bkalloc.deallocate(toFree); }();
         }
     }
 
     static if (ouroboros)
-    @trusted private Node* addAllocator(size_t atLeastBytes)
+    private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
         static if (hasMember!(Allocator, "expand")
@@ -263,25 +263,31 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         {
             import std.c.string : memcpy;
             assert(t.length % Node.sizeof == 0);
-            assert(t.ptr.alignedAt(Node.alignof));
-            allocators = cast(Node[]) t;
+            assert((() @trusted => t.ptr.alignedAt(Node.alignof))());
+            allocators = (() @trusted => cast(Node[]) t)();
             allocators[$ - 1].setUnused;
-            auto newAlloc = SAllocator(make(atLeastBytes));
-            memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
-            emplace(&newAlloc);
+            () @trusted {
+                auto newAlloc = SAllocator(make(atLeastBytes));
+                memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
+                emplace(&newAlloc);
+            }();
         }
         else
         {
             immutable toAlloc = (allocators.length + 1) * Node.sizeof
                 + atLeastBytes + 128;
-            auto newAlloc = SAllocator(make(toAlloc));
-            auto newPlace = newAlloc.allocate(
-                (allocators.length + 1) * Node.sizeof);
-            if (!newPlace) return null;
-            moveAllocators(newPlace);
-            import core.stdc.string : memcpy;
-            memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
-            emplace(&newAlloc);
+            bool ok = () @trusted {
+                auto newAlloc = SAllocator(make(toAlloc));
+                auto newPlace = newAlloc.allocate(
+                                    (allocators.length + 1) * Node.sizeof);
+                if (!newPlace) return false;
+                moveAllocators(newPlace);
+                import core.stdc.string : memcpy;
+                memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
+                emplace(&newAlloc);
+                return true;
+            }();
+            if (!ok) return null;
             assert(allocators[$ - 1].owns(allocators) == Ternary.yes);
         }
         // Insert as new root
@@ -300,7 +306,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     }
 
     static if (!ouroboros)
-    @trusted private Node* addAllocator(size_t atLeastBytes)
+    private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
         static if (hasMember!(BookkeepingAllocator, "expand"))
@@ -310,8 +316,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         if (expanded)
         {
             assert(t.length % Node.sizeof == 0);
-            assert(t.ptr.alignedAt(Node.alignof));
-            allocators = cast(Node[]) t;
+            assert((() @trusted => t.ptr.alignedAt(Node.alignof))());
+            allocators = (() @trusted => cast(Node[]) t)();
             allocators[$ - 1].setUnused;
         }
         else
@@ -319,14 +325,16 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
             // Could not expand, create a new block
             t = bkalloc.allocate((allocators.length + 1) * Node.sizeof);
             assert(t.length % Node.sizeof == 0);
-            if (!t.ptr) return null;
+            if (t is null) return null;
             moveAllocators(t);
         }
         assert(allocators[$ - 1].unused);
-        auto newAlloc = SAllocator(make(atLeastBytes));
-        import core.stdc.string : memcpy;
-        memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
-        emplace(&newAlloc);
+        () @trusted {
+            auto newAlloc = SAllocator(make(atLeastBytes));
+            import core.stdc.string : memcpy;
+            memcpy(&allocators[$ - 1].a, &newAlloc, newAlloc.sizeof);
+            emplace(&newAlloc);
+        }();
         // Creation succeeded, insert as root
         if (allocators.length == 1)
             allocators[$ - 1].next = null;
@@ -349,7 +357,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     returned  `Ternary.unknown`.
     */
     static if (hasMember!(Allocator, "owns"))
-    @safe Ternary owns(void[] b)
+    Ternary owns(void[] b)
     {
         auto result = Ternary.no;
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
@@ -583,10 +591,12 @@ version(Posix) @safe unittest
     import std.experimental.allocator.building_blocks.region : Region;
     AllocatorList!((n) => Region!GCAllocator(new ubyte[max(n, 1024 * 4096)]),
         NullAllocator) a;
-    const b1 = a.allocate(1024 * 8192);
-    assert(b1 !is null); // still works due to overdimensioning
-    const b2 = a.allocate(1024 * 10);
-    assert(b2.length == 1024 * 10);
+    () @safe {
+        const b1 = a.allocate(1024 * 8192);
+        assert(b1 !is null); // still works due to overdimensioning
+        const b2 = a.allocate(1024 * 10);
+        assert(b2.length == 1024 * 10);
+    }();
     a.deallocateAll();
 }
 
@@ -596,10 +606,12 @@ version(Posix) @safe unittest
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
     AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
-    auto b1 = a.allocate(1024 * 8192);
-    assert(b1 !is null); // still works due to overdimensioning
-    b1 = a.allocate(1024 * 10);
-    assert(b1.length == 1024 * 10);
+    () @safe {
+        auto b1 = a.allocate(1024 * 8192);
+        assert(b1 !is null); // still works due to overdimensioning
+        b1 = a.allocate(1024 * 10);
+        assert(b1.length == 1024 * 10);
+    }();
     a.deallocateAll();
 }
 
@@ -609,11 +621,13 @@ version(Posix) @safe unittest
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;
     AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
-    auto b1 = a.allocate(1024 * 8192);
-    assert(b1 !is null);
-    b1 = a.allocate(1024 * 10);
-    assert(b1.length == 1024 * 10);
-    a.allocate(1024 * 4095);
+    () @safe {
+        auto b1 = a.allocate(1024 * 8192);
+        assert(b1 !is null);
+        b1 = a.allocate(1024 * 10);
+        assert(b1.length == 1024 * 10);
+        a.allocate(1024 * 4095);
+    }();
     a.deallocateAll();
     assert(a.empty == Ternary.yes);
 }
@@ -623,18 +637,20 @@ version(Posix) @safe unittest
     import std.experimental.allocator.building_blocks.region : Region;
     enum bs = GCAllocator.alignment;
     AllocatorList!((n) => Region!GCAllocator(256 * bs)) a;
-    auto b1 = a.allocate(192 * bs);
-    assert(b1.length == 192 * bs);
-    assert(a.allocators.length == 1);
-    auto b2 = a.allocate(64 * bs);
-    assert(b2.length == 64 * bs);
-    assert(a.allocators.length == 1);
-    auto b3 = a.allocate(192 * bs);
-    assert(b3.length == 192 * bs);
-    assert(a.allocators.length == 2);
-    a.deallocate(b1);
-    b1 = a.allocate(64 * bs);
-    assert(b1.length == 64 * bs);
-    assert(a.allocators.length == 2);
+    () @safe {
+        auto b1 = a.allocate(192 * bs);
+        assert(b1.length == 192 * bs);
+        assert(a.allocators.length == 1);
+        auto b2 = a.allocate(64 * bs);
+        assert(b2.length == 64 * bs);
+        assert(a.allocators.length == 1);
+        auto b3 = a.allocate(192 * bs);
+        assert(b3.length == 192 * bs);
+        assert(a.allocators.length == 2);
+        () @trusted { a.deallocate(b1); }();
+        b1 = a.allocate(64 * bs);
+        assert(b1.length == 64 * bs);
+        assert(a.allocators.length == 2);
+    }();
     a.deallocateAll();
 }

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -162,7 +162,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     fails, subsequent calls to $(D allocate) will not cause more calls to $(D
     make).
     */
-    void[] allocate(size_t s)
+    @safe void[] allocate(size_t s)
     {
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
         {
@@ -247,7 +247,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     }
 
     static if (ouroboros)
-    private Node* addAllocator(size_t atLeastBytes)
+    @trusted private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
         static if (hasMember!(Allocator, "expand")
@@ -300,7 +300,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     }
 
     static if (!ouroboros)
-    private Node* addAllocator(size_t atLeastBytes)
+    @trusted private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
         static if (hasMember!(BookkeepingAllocator, "expand"))
@@ -349,7 +349,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     returned  `Ternary.unknown`.
     */
     static if (hasMember!(Allocator, "owns"))
-    Ternary owns(void[] b)
+    @safe Ternary owns(void[] b)
     {
         auto result = Ternary.no;
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
@@ -533,7 +533,7 @@ template AllocatorList(alias factoryFunction,
 }
 
 ///
-version(Posix) @system unittest
+version(Posix) @safe unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
@@ -569,7 +569,7 @@ version(Posix) @system unittest
     A4 a;
     auto small = a.allocate(64);
     assert(small);
-    a.deallocate(small);
+    () @trusted { a.deallocate(small); }();
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
     b1 = a.allocate(1024 * 10);

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1108,9 +1108,9 @@ struct SharedFreeList(ParentAllocator,
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
     auto c = a.allocate(64);
-    assert(a.reallocate(c, 96));
+    () @trusted { assert(a.reallocate(c, 96)); }();
     assert(c.length == 96);
-    a.deallocate(c);
+    () @trusted { a.deallocate(c); }();
 }
 
 @safe unittest

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -311,7 +311,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     n = Capacity desired. This constructor is defined only if $(D
     ParentAllocator) is not $(D NullAllocator).
     */
-    this(ubyte[] b)
+    @trusted this(ubyte[] b)
     {
         if (b.length < Node.sizeof)
         {
@@ -382,7 +382,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
 
     Returns: A word-aligned buffer of $(D n) bytes, or $(D null).
     */
-    void[] allocate(size_t n)
+    @trusted void[] allocate(size_t n)
     {
         if (!n || !root) return null;
         const actualBytes = goodAllocSize(n);
@@ -536,7 +536,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     at the front of the free list. These blocks get coalesced, whether
     $(D allocateAll) succeeds or fails due to fragmentation.
     */
-    void[] allocateAll()
+    @trusted void[] allocateAll()
     {
         if (regionMode) switchToFreeList;
         if (root && root.next == root)
@@ -578,7 +578,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     It does a simple $(BIGOH 1) range check. $(D b) should be a buffer either
     allocated with $(D this) or obtained through other means.
     */
-    Ternary owns(void[] b)
+    @trusted Ternary owns(void[] b)
     {
         debug(KRRegion) assertValid("owns");
         debug(KRRegion) scope(exit) assertValid("owns");
@@ -590,7 +590,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     Adjusts $(D n) to a size suitable for allocation (two words or larger,
     word-aligned).
     */
-    static size_t goodAllocSize(size_t n)
+    static @safe size_t goodAllocSize(size_t n)
     {
         import std.experimental.allocator.common : roundUpToMultipleOf;
         return n <= Node.sizeof
@@ -613,7 +613,7 @@ allocator if $(D deallocate) is needed, yet the actual deallocation traffic is
 relatively low. The example below shows a $(D KRRegion) using stack storage
 fronting the GC allocator.
 */
-@system unittest
+@safe unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.fallback_allocator

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -20,10 +20,13 @@ struct NullAllocator
     //size_t goodAllocSize(size_t n) shared const
     //{ return .goodAllocSize(this, n); }
     /// Always returns $(D null).
+    @safe pure nothrow
     void[] allocate(size_t) shared { return null; }
     /// Always returns $(D null).
+    @safe pure nothrow
     void[] alignedAllocate(size_t, uint) shared { return null; }
     /// Always returns $(D null).
+    @safe pure nothrow
     void[] allocateAll() shared { return null; }
     /**
     These methods return $(D false).
@@ -39,24 +42,29 @@ struct NullAllocator
     bool alignedReallocate(ref void[] b, size_t, uint) shared
     { assert(b is null); return false; }
     /// Returns $(D Ternary.no).
+    @safe pure nothrow
     Ternary owns(void[]) shared const { return Ternary.no; }
     /**
     Returns $(D Ternary.no).
     */
+    @safe pure nothrow
     Ternary resolveInternalPointer(const void*, ref void[]) shared const
     { return Ternary.no; }
     /**
     No-op.
     Precondition: $(D b is null)
     */
+    pure nothrow
     bool deallocate(void[] b) shared { assert(b is null); return true; }
     /**
     No-op.
     */
+    pure nothrow
     bool deallocateAll() shared { return true; }
     /**
     Returns $(D Ternary.yes).
     */
+    @safe pure nothrow
     Ternary empty() shared const { return Ternary.yes; }
     /**
     Returns the $(D shared) global instance of the $(D NullAllocator).
@@ -64,18 +72,20 @@ struct NullAllocator
     static shared NullAllocator instance;
 }
 
-@system unittest
+@safe unittest
 {
     assert(NullAllocator.instance.alignedAllocate(100, 0) is null);
     assert(NullAllocator.instance.allocateAll() is null);
     auto b = NullAllocator.instance.allocate(100);
     assert(b is null);
-    assert(NullAllocator.instance.expand(b, 0));
-    assert(!NullAllocator.instance.expand(b, 42));
-    assert(!NullAllocator.instance.reallocate(b, 42));
-    assert(!NullAllocator.instance.alignedReallocate(b, 42, 0));
-    NullAllocator.instance.deallocate(b);
-    NullAllocator.instance.deallocateAll();
+    () @trusted {
+        assert(NullAllocator.instance.expand(b, 0));
+        assert(!NullAllocator.instance.expand(b, 42));
+        assert(!NullAllocator.instance.reallocate(b, 42));
+        assert(!NullAllocator.instance.alignedReallocate(b, 42, 0));
+        NullAllocator.instance.deallocate(b);
+        NullAllocator.instance.deallocateAll();
+    }();
 
     import std.typecons : Ternary;
     assert(NullAllocator.instance.empty() == Ternary.yes);

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -33,6 +33,7 @@ struct NullAllocator
     Precondition: $(D b is null). This is because there is no other possible
     legitimate input.
     */
+    @safe pure nothrow
     bool expand(ref void[] b, size_t s) shared
     { assert(b is null); return s == 0; }
     /// Ditto

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -216,20 +216,20 @@ struct Region(ParentAllocator = NullAllocator,
     `No.growDownwards`.
     */
     static if (growDownwards == No.growDownwards)
-    bool expand(ref void[] b, size_t delta)
+    @safe bool expand(ref void[] b, size_t delta)
     {
         assert(owns(b) == Ternary.yes || b.ptr is null);
-        assert(b.ptr + b.length <= _current || b.ptr is null);
-        if (!b.ptr) return delta == 0;
+        assert((() @trusted => b.ptr + b.length <= _current || b.ptr is null)());
+        if (b is null) return delta == 0;
         auto newLength = b.length + delta;
-        if (_current < b.ptr + b.length + alignment)
+        if ((() @trusted => _current < b.ptr + b.length + alignment)())
         {
             // This was the last allocation! Allocate some more and we're done.
             if (this.goodAllocSize(b.length) == this.goodAllocSize(newLength)
                 || allocate(delta).length == delta)
             {
-                b = b.ptr[0 .. newLength];
-                assert(_current < b.ptr + b.length + alignment);
+                b = (() @trusted => b.ptr[0 .. newLength])();
+                assert((() @trusted => _current < b.ptr + b.length + alignment)());
                 return true;
             }
         }

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -72,7 +72,7 @@ struct ScopedAllocator(ParentAllocator)
     Forwards to $(D parent.goodAllocSize) (which accounts for the management
     overhead).
     */
-    size_t goodAllocSize(size_t n)
+    @safe size_t goodAllocSize(size_t n)
     {
         return parent.goodAllocSize(n);
     }
@@ -81,17 +81,19 @@ struct ScopedAllocator(ParentAllocator)
     Allocates memory. For management it actually allocates extra memory from
     the parent.
     */
-    void[] allocate(size_t n)
+    @safe void[] allocate(size_t n)
     {
         auto b = parent.allocate(n);
         if (!b.ptr) return b;
-        Node* toInsert = & parent.prefix(b);
-        toInsert.prev = null;
-        toInsert.next = root;
-        toInsert.length = n;
-        assert(!root || !root.prev);
-        if (root) root.prev = toInsert;
-        root = toInsert;
+        () @trusted {
+            Node* toInsert = & parent.prefix(b);
+            toInsert.prev = null;
+            toInsert.next = root;
+            toInsert.length = n;
+            assert(!root || !root.prev);
+            if (root) root.prev = toInsert;
+            root = toInsert;
+        }();
         return b;
     }
 
@@ -140,7 +142,7 @@ struct ScopedAllocator(ParentAllocator)
     Forwards to $(D parent.owns(b)).
     */
     static if (hasMember!(Allocator, "owns"))
-    Ternary owns(void[] b)
+    @safe Ternary owns(void[] b)
     {
         return parent.owns(b);
     }

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -134,14 +134,14 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
                 : _large.goodAllocSize(s);
         }
 
-        @safe void[] allocate(size_t s)
+        void[] allocate(size_t s)
         {
             return s <= threshold ? _small.allocate(s) : _large.allocate(s);
         }
 
         static if (hasMember!(SmallAllocator, "alignedAllocate")
                 && hasMember!(LargeAllocator, "alignedAllocate"))
-        @safe void[] alignedAllocate(size_t s, uint a)
+        void[] alignedAllocate(size_t s, uint a)
         {
             return s <= threshold
                 ? _small.alignedAllocate(s, a)
@@ -215,7 +215,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "owns")
                 && hasMember!(LargeAllocator, "owns"))
-        @safe Ternary owns(void[] b)
+        Ternary owns(void[] b)
         {
             return Ternary(b.length <= threshold
                 ? _small.owns(b) : _large.owns(b));
@@ -247,7 +247,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "resolveInternalPointer")
                 && hasMember!(LargeAllocator, "resolveInternalPointer"))
-        @safe Ternary resolveInternalPointer(const void* p, ref void[] result)
+        Ternary resolveInternalPointer(const void* p, ref void[] result)
         {
             Ternary r = _small.resolveInternalPointer(p, result);
             return r == Ternary.no ? _large.resolveInternalPointer(p, result) : r;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -127,21 +127,21 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
     private template Impl()
     {
-        size_t goodAllocSize(size_t s)
+        @safe size_t goodAllocSize(size_t s)
         {
             return s <= threshold
                 ? _small.goodAllocSize(s)
                 : _large.goodAllocSize(s);
         }
 
-        void[] allocate(size_t s)
+        @safe void[] allocate(size_t s)
         {
             return s <= threshold ? _small.allocate(s) : _large.allocate(s);
         }
 
         static if (hasMember!(SmallAllocator, "alignedAllocate")
                 && hasMember!(LargeAllocator, "alignedAllocate"))
-        void[] alignedAllocate(size_t s, uint a)
+        @safe void[] alignedAllocate(size_t s, uint a)
         {
             return s <= threshold
                 ? _small.alignedAllocate(s, a)
@@ -215,7 +215,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "owns")
                 && hasMember!(LargeAllocator, "owns"))
-        Ternary owns(void[] b)
+        @safe Ternary owns(void[] b)
         {
             return Ternary(b.length <= threshold
                 ? _small.owns(b) : _large.owns(b));
@@ -247,7 +247,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "resolveInternalPointer")
                 && hasMember!(LargeAllocator, "resolveInternalPointer"))
-        Ternary resolveInternalPointer(const void* p, ref void[] result)
+        @safe Ternary resolveInternalPointer(const void* p, ref void[] result)
         {
             Ternary r = _small.resolveInternalPointer(p, result);
             return r == Ternary.no ? _large.resolveInternalPointer(p, result) : r;
@@ -274,7 +274,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 }
 
 ///
-@system unittest
+@safe unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -292,7 +292,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
     A a;
     auto b = a.allocate(200);
     assert(b.length == 200);
-    a.deallocate(b);
+    () @trusted { a.deallocate(b); }();
 }
 
 /**
@@ -342,7 +342,7 @@ if (Args.length > 3)
 }
 
 ///
-@system unittest
+@safe unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -357,5 +357,5 @@ if (Args.length > 3)
     A a;
     auto b = a.allocate(201);
     assert(b.length == 201);
-    a.deallocate(b);
+    () @trusted { a.deallocate(b); }();
 }

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -286,14 +286,14 @@ public:
     static if (hasMember!(Allocator, "owns"))
     {
         static if ((perCallFlags & Options.numOwns) == 0)
-        @safe Ternary owns(void[] b)
+        Ternary owns(void[] b)
         { return ownsImpl(b); }
         else
-        @safe Ternary owns(string f = __FILE, uint n = line)(void[] b)
+        Ternary owns(string f = __FILE, uint n = line)(void[] b)
         { return ownsImpl!(f, n)(b); }
     }
 
-    @safe private Ternary ownsImpl(string f = null, uint n = 0)(void[] b)
+    private Ternary ownsImpl(string f = null, uint n = 0)(void[] b)
     {
         up!"numOwns";
         addPerCall!(f, n, "numOwns")(1);
@@ -310,17 +310,17 @@ public:
         & (Options.numAllocate | Options.numAllocateOK
             | Options.bytesAllocated)))
     {
-        @safe void[] allocate(size_t n)
+        void[] allocate(size_t n)
         { return allocateImpl(n); }
     }
     else
     {
-        @safe void[] allocate(string f = __FILE__, ulong n = __LINE__)
+        void[] allocate(string f = __FILE__, ulong n = __LINE__)
             (size_t bytes)
         { return allocateImpl!(f, n)(bytes); }
     }
 
-    @safe private void[] allocateImpl(string f = null, ulong n = 0)(size_t bytes)
+    private void[] allocateImpl(string f = null, ulong n = 0)(size_t bytes)
     {
         auto result = parent.allocate(bytes);
         add!"bytesUsed"(result.length);

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -158,7 +158,7 @@ Advances the beginning of `b` to start at alignment `a`. The resulting buffer
 may therefore be shorter. Returns the adjusted buffer, or null if obtaining a
 non-empty buffer is impossible.
 */
-@nogc nothrow pure
+@trusted @nogc nothrow pure
 package void[] roundUpToAlignment(void[] b, uint a)
 {
     auto e = b.ptr + b.length;
@@ -168,7 +168,7 @@ package void[] roundUpToAlignment(void[] b, uint a)
 }
 
 @nogc nothrow pure
-@system unittest
+@safe unittest
 {
     void[] empty;
     assert(roundUpToAlignment(empty, 4) == null);
@@ -190,7 +190,7 @@ package size_t divideRoundUp(size_t a, size_t b)
 /**
 Returns `s` rounded up to a multiple of `base`.
 */
-@nogc nothrow pure
+@trusted @nogc nothrow pure
 package void[] roundStartToMultipleOf(void[] s, uint base)
 {
     assert(base);
@@ -201,7 +201,7 @@ package void[] roundStartToMultipleOf(void[] s, uint base)
 }
 
 nothrow pure
-@system unittest
+@safe unittest
 {
     void[] p;
     assert(roundStartToMultipleOf(p, 16) is null);
@@ -300,7 +300,7 @@ package uint effectiveAlignment(void* ptr)
 Aligns a pointer down to a specified alignment. The resulting pointer is less
 than or equal to the given pointer.
 */
-@nogc nothrow pure
+@trusted @nogc nothrow pure
 package void* alignDownTo(void* ptr, uint alignment)
 {
     import std.math : isPowerOf2;
@@ -312,7 +312,7 @@ package void* alignDownTo(void* ptr, uint alignment)
 Aligns a pointer up to a specified alignment. The resulting pointer is greater
 than or equal to the given pointer.
 */
-@nogc nothrow pure
+@trusted @nogc nothrow pure
 package void* alignUpTo(void* ptr, uint alignment)
 {
     import std.math : isPowerOf2;

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -28,6 +28,7 @@ struct MmapAllocator
     version(Posix)
     {
         /// Allocator API.
+        @trusted @nogc nothrow
         void[] allocate(size_t bytes) shared
         {
             import core.sys.posix.sys.mman : mmap, MAP_ANON, PROT_READ,
@@ -40,6 +41,7 @@ struct MmapAllocator
         }
 
         /// Ditto
+        @system @nogc nothrow
         bool deallocate(void[] b) shared
         {
             import core.sys.posix.sys.mman : munmap;
@@ -53,6 +55,7 @@ struct MmapAllocator
             PAGE_READWRITE, MEM_RELEASE;
 
         /// Allocator API.
+        @trusted @nogc nothrow
         void[] allocate(size_t bytes) shared
         {
             if (!bytes) return null;
@@ -63,6 +66,7 @@ struct MmapAllocator
         }
 
         /// Ditto
+        @system @nogc nothrow
         bool deallocate(void[] b) shared
         {
             return b.ptr is null || VirtualFree(b.ptr, 0, MEM_RELEASE) != 0;
@@ -70,10 +74,12 @@ struct MmapAllocator
     }
 }
 
-@system unittest
+@safe unittest
 {
     alias alloc = MmapAllocator.instance;
     auto p = alloc.allocate(100);
     assert(p.length == 100);
-    alloc.deallocate(p);
+    () @trusted {
+        alloc.deallocate(p);
+    }();
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -385,18 +385,18 @@ interface ISharedAllocator
     /**
     Returns the alignment offered.
     */
-    @property uint alignment() shared;
+    @property uint alignment() shared @safe;
 
     /**
     Returns the good allocation size that guarantees zero internal
     fragmentation.
     */
-    size_t goodAllocSize(size_t s) shared;
+    size_t goodAllocSize(size_t s) shared @safe;
 
     /**
     Allocates `n` bytes of memory.
     */
-    void[] allocate(size_t, TypeInfo ti = null) shared;
+    void[] allocate(size_t, TypeInfo ti = null) shared @safe;
 
     /**
     Allocates `n` bytes of memory with specified alignment `a`. Implementations
@@ -430,13 +430,13 @@ interface ISharedAllocator
     cannot be determined. Implementations that don't support this primitive
     should always return `Ternary.unknown`.
     */
-    Ternary owns(void[] b) shared;
+    Ternary owns(void[] b) shared @safe;
 
     /**
     Resolves an internal pointer to the full block allocated. Implementations
     that don't support this primitive should always return `Ternary.unknown`.
     */
-    Ternary resolveInternalPointer(const void* p, ref void[] result) shared;
+    Ternary resolveInternalPointer(const void* p, ref void[] result) shared @safe;
 
     /**
     Deallocates a memory block. Implementations that don't support this
@@ -476,17 +476,17 @@ static this()
     */
     static class ThreadAllocator : IAllocator
     {
-        override @property uint alignment()
+        override @property @safe uint alignment()
         {
             return _processAllocator.alignment();
         }
 
-        override size_t goodAllocSize(size_t s)
+        override size_t goodAllocSize(size_t s) @safe
         {
             return _processAllocator.goodAllocSize(s);
         }
 
-        override void[] allocate(size_t n, TypeInfo ti = null)
+        override void[] allocate(size_t n, TypeInfo ti = null) @safe
         {
             return _processAllocator.allocate(n, ti);
         }
@@ -516,12 +516,13 @@ static this()
             return _processAllocator.alignedReallocate(b, size, alignment);
         }
 
-        override Ternary owns(void[] b)
+        override Ternary owns(void[] b) @safe
         {
             return _processAllocator.owns(b);
         }
 
-        override Ternary resolveInternalPointer(const void* p, ref void[] result)
+        override
+        Ternary resolveInternalPointer(const void* p, ref void[] result) @safe
         {
             return _processAllocator.resolveInternalPointer(p, result);
         }
@@ -2134,7 +2135,7 @@ class CAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     static if (indirect)
     {
         private Allocator* pimpl;
-        @safe ref Allocator impl()
+        ref Allocator impl() @safe
         {
             return *pimpl;
         }
@@ -2317,7 +2318,7 @@ class CSharedAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     static if (indirect)
     {
         private shared Allocator* pimpl;
-        ref Allocator impl() shared
+        ref Allocator impl() shared @safe
         {
             return *pimpl;
         }

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -39,15 +39,17 @@ alias StackFront(size_t stackSize, Allocator = GCAllocator) =
         Allocator);
 
 ///
-@system unittest
+@safe unittest
 {
     StackFront!4096 a;
     auto b = a.allocate(4000);
     assert(b.length == 4000);
     auto c = a.allocate(4000);
     assert(c.length == 4000);
-    a.deallocate(b);
-    a.deallocate(c);
+    () @trusted {
+        a.deallocate(b);
+        a.deallocate(c);
+    }();
 }
 
 /**


### PR DESCRIPTION
…Pointer methods safe

Allocating memory should be a safe operation and so should functions like owns and resolveInternalPointer.