### PR TITLE
netbsd small changes

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -507,7 +507,7 @@ Throws: $(D ErrnoException) in case of error.
 
         enforce(isOpen, "Attempting to reopen() an unopened file");
 
-        auto namez = name.tempCString!FSChar();
+        auto namez = (name == null ? _name : name).tempCString!FSChar();
         auto modez = stdioOpenmode.tempCString!FSChar();
 
         FILE* fd = _p.handle;


### PR DESCRIPTION
datetime.d - for some reason NetBSD return EPT for America/New_York
stdio.d - It contains note: "Note: Calling `reopen` with a `null` `name` is not implemented
in all C runtimes." and NetBSD is example of such runtime. I decided pass name from File struct, because as I remember we should not use "version" blocks in phobos if possible.