### PR TITLE
errors with getSymbolsByUDA to get a private members

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -7659,13 +7659,13 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
                   .format(names[0]));
     }
 
-    // filtering not compiled members such as not accessible members
-    enum noNotCompiledMembers(string name) = (__traits(compiles, __traits(getMember, symbol, name)));
-    alias membersWithoutNotCompiled = Filter!(noNotCompiledMembers, __traits(allMembers, symbol));
+    // filtering not compiled members such as inaccessible members
+    enum noInaccessibleMembers(string name) = (__traits(compiles, __traits(getMember, symbol, name)));
+    alias withoutInaccessibleMembers = Filter!(noInaccessibleMembers, __traits(allMembers, symbol));
 
     // filtering out nested class context
     enum noThisMember(string name) = (name != "this");
-    alias membersWithoutNestedCC = Filter!(noThisMember, membersWithoutNotCompiled);
+    alias membersWithoutNestedCC = Filter!(noThisMember, withoutInaccessibleMembers);
 
     enum hasSpecificUDA(string name) = mixin("hasUDA!(symbol.%s, attribute)".format(name));
     alias membersWithUDA = toSymbols!(Filter!(hasSpecificUDA, membersWithoutNestedCC));
@@ -7747,7 +7747,7 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
 {
     // HasPrivateMembers has, well, private members, one of which has a UDA.
     import std.internal.test.uda : Attr, HasPrivateMembers;
-    // Trying acces to private member from another file therefore we do not have access
+    // Trying access to private member from another file therefore we do not have access
     // for this otherwise we get deprecation warning - not visible from module
     static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));

--- a/std/traits.d
+++ b/std/traits.d
@@ -7660,18 +7660,14 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
     }
 
     // filtering inaccessible members
-    enum noInaccessibleMembers(string name) = (__traits(compiles, __traits(getMember, symbol, name)));
-    alias withoutInaccessibleMembers = Filter!(noInaccessibleMembers, __traits(allMembers, symbol));
-
-    // filtering out nested class context
-    enum noThisMember(string name) = (name != "this");
-    alias membersWithoutNestedCC = Filter!(noThisMember, withoutInaccessibleMembers);
+    enum isAccessibleMember(string name) = __traits(compiles, __traits(getMember, symbol, name));
+    alias withoutInaccessibleMembers = Filter!(isAccessibleMember, __traits(allMembers, symbol));
 
     // filtering not compiled members such as alias of basic types
     enum hasSpecificUDA(string name) = mixin("hasUDA!(symbol." ~ name ~ ", attribute)");
-    enum noIncorrectMembers(string name) = (__traits(compiles, hasSpecificUDA!(name)));
+    enum isCorrectMember(string name) = __traits(compiles, hasSpecificUDA!(name));
 
-    alias withoutIncorrectMembers = Filter!(noIncorrectMembers, membersWithoutNestedCC);
+    alias withoutIncorrectMembers = Filter!(isCorrectMember, withoutInaccessibleMembers);
     alias membersWithUDA = toSymbols!(Filter!(hasSpecificUDA, withoutIncorrectMembers));
 
     // if the symbol itself has the UDA, tack it on to the front of the list

--- a/std/traits.d
+++ b/std/traits.d
@@ -7668,10 +7668,10 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
     alias membersWithoutNestedCC = Filter!(noThisMember, withoutInaccessibleMembers);
 
     // filtering not compiled members such as alias of basic types
-    enum noIncorrectMembers(string name) = (__traits(compiles, mixin("hasUDA!(symbol.%s, attribute)".format(name))));
-    alias withoutIncorrectMembers = Filter!(noIncorrectMembers, membersWithoutNestedCC);
+    enum hasSpecificUDA(string name) = mixin("hasUDA!(symbol." ~ name ~ ", attribute)");
+    enum noIncorrectMembers(string name) = (__traits(compiles, hasSpecificUDA!(name)));
 
-    enum hasSpecificUDA(string name) = mixin("hasUDA!(symbol.%s, attribute)".format(name));
+    alias withoutIncorrectMembers = Filter!(noIncorrectMembers, membersWithoutNestedCC);
     alias membersWithUDA = toSymbols!(Filter!(hasSpecificUDA, withoutIncorrectMembers));
 
     // if the symbol itself has the UDA, tack it on to the front of the list

--- a/std/traits.d
+++ b/std/traits.d
@@ -7661,14 +7661,14 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
 
     // filtering inaccessible members
     enum isAccessibleMember(string name) = __traits(compiles, __traits(getMember, symbol, name));
-    alias withoutInaccessibleMembers = Filter!(isAccessibleMember, __traits(allMembers, symbol));
+    alias accessibleMembers = Filter!(isAccessibleMember, __traits(allMembers, symbol));
 
     // filtering not compiled members such as alias of basic types
     enum hasSpecificUDA(string name) = mixin("hasUDA!(symbol." ~ name ~ ", attribute)");
     enum isCorrectMember(string name) = __traits(compiles, hasSpecificUDA!(name));
 
-    alias withoutIncorrectMembers = Filter!(isCorrectMember, withoutInaccessibleMembers);
-    alias membersWithUDA = toSymbols!(Filter!(hasSpecificUDA, withoutIncorrectMembers));
+    alias correctMembers = Filter!(isCorrectMember, accessibleMembers);
+    alias membersWithUDA = toSymbols!(Filter!(hasSpecificUDA, correctMembers));
 
     // if the symbol itself has the UDA, tack it on to the front of the list
     static if (hasUDA!(symbol, attribute))
@@ -7751,7 +7751,12 @@ template getSymbolsByUDA(alias symbol, alias attribute) {
     // for this otherwise we get deprecation warning - not visible from module
     static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));
+}
 
+///
+@safe unittest
+{
+    enum Attr;
     struct A
     {
         alias int INT;


### PR DESCRIPTION
Resolve #15335 Remove ability in getSymbolsByUDA to get a private members If it is located in another module.
If you trying to get symbols from another module you will get errors. This commit resolve this. Now you can access to all attributes if you have access otherwise you will not get private members but also not throws errors.
examples:
**uda.d**
```D
enum Attr;

struct HasPrivateMembers
{
    @Attr int a;
    int b;
    @Attr private int c;
    private int d;
}
```
**main.d**
```D
unittest
{
    import uda : Attr, HasPrivateMembers;
    // Trying access to private member from another file therefore we do not have access
    // for this otherwise we get deprecation warning - not visible from module
    static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
    static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));

    struct A
    {
        @Attr int a;
        int b;
        @Attr private int c;
        private int d;
    }

    // Here everything is fine, we have access to private member c
    static assert(getSymbolsByUDA!(A, Attr).length == 2);
    static assert(hasUDA!(getSymbolsByUDA!(A, Attr)[0], Attr));
    static assert(hasUDA!(getSymbolsByUDA!(A, Attr)[1], Attr));
}
```
In my program I do not get deprecation warning instead of this I get a bunch of errors.
With this patch all works fine.
```
/usr/include/dlang/dmd/std/traits.d-mixin-7671(7671,1): Deprecation: editor.mapeditor.MyView.a is not visible from module traits
/usr/include/dlang/dmd/std/traits.d-mixin-7671(7671,1): Deprecation: ui.views.view.View.layoutData is not visible from class MyView
/usr/include/dlang/dmd/std/traits.d-mixin-7671(7671,1): Deprecation: ui.views.view.View.layoutData is not visible from module std.traits
/usr/include/dlang/dmd/std/traits.d-mixin-7671(7671,1): Error: class editor.mapeditor.MyView member layoutData is not accessible
/usr/include/dlang/dmd/std/meta.d(900,20): Error: template instance std.traits.getSymbolsByUDA!(MyView, OnClickListener).pred!"layoutData" error instantiating
/usr/include/dlang/dmd/std/traits.d(7672,39):        5 recursive instantiations from here: Filter!(hasSpecificUDA, "__ctor", "onOkButtonClick", "onCancelButtonClick", "a", "app", "createFromFile", "layoutData", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory")
src/ui/views/view.d(58,26):        instantiated from here: getSymbolsByUDA!(MyView, OnClickListener)
src/editor/mapeditor.d(34,14):        instantiated from here: __ctor!(MyView)
dmd failed with exit code 1.
```