### PR TITLE
Fix missing alignment for kernighan_ritchie allocator unittests

### DIFF
--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -811,7 +811,7 @@ it actually returns memory to the operating system when possible.
 
     void test(int[] sizes)
     {
-        ubyte[256 * 1024] buf;
+        align(size_t.sizeof) ubyte[256 * 1024] buf;
         auto a = KRRegion!()(buf);
 
         void[][] bufs;
@@ -853,7 +853,7 @@ it actually returns memory to the operating system when possible.
 
     void test(int[] sizes, int word)
     {
-        ubyte[256 * 1024] buf;
+        align(size_t.sizeof) ubyte[256 * 1024] buf;
         auto a = KRRegion!()(buf);
 
         void[][] bufs;


### PR DESCRIPTION
Otherwise LLVM sometimes chooses to align the stack buffers at a 4-bytes boundary (on x86_64) leading to an assertion in the `KRRegion` constructor.