### PR TITLE
Relax a few unittests for double-precision reals

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -685,17 +685,17 @@ uint formattedRead(R, Char, S...)(ref R r, const(Char)[] fmt, auto ref S args)
     assert(a == "hello" && b == 124 && c == 34.5);
 
     // mix pointers and auto-ref
-    s = "world!200:42.2";
+    s = "world!200:42.25";
     formattedRead(s, "%s!%s:%s", a, &b, &c);
-    assert(a == "world" && b == 200 && c == 42.2);
+    assert(a == "world" && b == 200 && c == 42.25);
 
-    s = "world1!201:42.3";
+    s = "world1!201:42.5";
     formattedRead(s, "%s!%s:%s", &a, &b, c);
-    assert(a == "world1" && b == 201 && c == 42.3);
+    assert(a == "world1" && b == 201 && c == 42.5);
 
-    s = "world2!202:42.4";
+    s = "world2!202:42.75";
     formattedRead(s, "%s!%s:%s", a, b, &c);
-    assert(a == "world2" && b == 202 && c == 42.4);
+    assert(a == "world2" && b == 202 && c == 42.75);
 }
 
 // for backwards compatibility

--- a/std/json.d
+++ b/std/json.d
@@ -1706,12 +1706,14 @@ pure nothrow @safe unittest // issue 15884
 
 @safe unittest // issue 15885
 {
+    enum bool realInDoublePrecision = real.mant_dig == double.mant_dig;
+
     static bool test(const double num0)
     {
         import std.math : feqrel;
         const json0 = JSONValue(num0);
         const num1 = to!double(toJSON(json0));
-        version(Win32)
+        static if (realInDoublePrecision)
             return feqrel(num1, num0) >= (double.mant_dig - 1);
         else
             return num1 == num0;
@@ -1725,8 +1727,11 @@ pure nothrow @safe unittest // issue 15884
     assert(test(30738.22));
 
     assert(test(1 + double.epsilon));
-    assert(test(-double.max));
     assert(test(double.min_normal));
+    static if (realInDoublePrecision)
+        assert(test(-double.max / 2));
+    else
+        assert(test(-double.max));
 
     const minSub = double.min_normal * double.epsilon;
     assert(test(minSub));


### PR DESCRIPTION
A loss-less roundtrip (to string <=> parse) apparently isn't guaranteed when using double-precision reals.