### PR TITLE
std.getopt: Add unit tests for delegates as callbacks.

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1785,7 +1785,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
             import std.conv : to;
             dest += n.to!long;
         }
-        
+
         return (option, value) => addN(dest, value);
     }
 

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1777,7 +1777,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 @system unittest  // Delegates as callbacks
 {
     alias TwoArgOptionHandler = void delegate(string option, string value);
-    
+
     TwoArgOptionHandler makeAddNHandler(ref long dest)
     {
         void addN(ref long dest, string n)
@@ -1788,14 +1788,14 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
         
         return (option, value) => addN(dest, value);
     }
-    
+
     long x = 0;
     long y = 0;
-    
+
     string[] args =
         ["program", "--x-plus-1", "--x-plus-1", "--x-plus-5", "--x-plus-n", "10",
          "--y-plus-n", "25", "--y-plus-7", "--y-plus-n", "15", "--y-plus-3"];
-    
+
     getopt(args,
            "x-plus-1", "Add one to x", delegate void() { x += 1; },
            "x-plus-5", "Add five to x", delegate void(string option) { x += 5; },
@@ -1803,7 +1803,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
            "y-plus-7", "Add seven to y", delegate void() { y += 7; },
            "y-plus-3", "Add three to y", delegate void(string option) { y += 3; },
            "y-plus-n", "Add NUM to x", makeAddNHandler(y),);
-    
+
     assert(x == 17);
     assert(y == 50);
 }


### PR DESCRIPTION
At present there are no unit tests in std.getopt where delegates are used as callbacks. This adds a few basic tests.