### PR TITLE
Issue 7102: Add missing sig constraints to std.numeric.gcd.

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2603,6 +2603,7 @@ an efficient algorithm such as $(HTTPS en.wikipedia.org/wiki/Euclidean_algorithm
 or $(HTTPS en.wikipedia.org/wiki/Binary_GCD_algorithm, Stein's) algorithm.
  */
 T gcd(T)(T a, T b)
+    if (isIntegral!T)
 {
     static if (is(T == const) || is(T == immutable))
     {


### PR DESCRIPTION
First of all, it makes no sense to take arbitrary types (e.g.,
gcd("a","abc") should not even match the template).

Second of all, the current implementation only works with built-in
types, so the function should restrict itself to only accepting built-in
types so that it is overloadable for other types (e.g., BigInt).

This is only a first step towards fixing issue 7102, mainly to open the way for a BigInt specialization of gcd. That will be done in a followup PR.