### PR TITLE
Fix issue 7102: std.numeric.gcd overload that works with non-builtin types

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2603,6 +2603,7 @@ an efficient algorithm such as $(HTTPS en.wikipedia.org/wiki/Euclidean_algorithm
 or $(HTTPS en.wikipedia.org/wiki/Binary_GCD_algorithm, Stein's) algorithm.
  */
 T gcd(T)(T a, T b)
+    if (isIntegral!T)
 {
     static if (is(T == const) || is(T == immutable))
     {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2720,7 +2720,7 @@ T gcd(T)(T a, T b)
 }
 
 // Issue 7102
-unittest
+@system pure unittest
 {
     import std.bigint : BigInt;
     assert(gcd(BigInt("71_000_000_000_000_000_000"),
@@ -2728,7 +2728,7 @@ unittest
            BigInt("1_000_000_000_000_000_000"));
 }
 
-unittest
+@safe pure nothrow unittest
 {
     // A numerical type that only supports % and - (to force gcd implementation
     // to use Euclidean algorithm).

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2601,6 +2601,13 @@ GapWeightedSimilarityIncremental!(R, F) gapWeightedSimilarityIncremental(R, F)
 Computes the greatest common divisor of $(D a) and $(D b) by using
 an efficient algorithm such as $(HTTPS en.wikipedia.org/wiki/Euclidean_algorithm, Euclid's)
 or $(HTTPS en.wikipedia.org/wiki/Binary_GCD_algorithm, Stein's) algorithm.
+
+Params:
+    T = Any numerical type that supports the modulo operator `%`. If
+        bit-shifting `<<` and `>>` are also supported, Stein's algorithm will
+        be used; otherwise, Euclid's algorithm is used as _a fallback.
+Returns:
+    The greatest common divisor of the given arguments.
  */
 T gcd(T)(T a, T b)
     if (isIntegral!T)


### PR DESCRIPTION
This PR does the following:

1. Add sig constraints to the current version of `std.numeric.gcd` so that it won't pick up types that it actually can't support. The current implementation is dependent on builtin types and fails in ugly ways with non-builtin types (including `BigInt`).
2. Add a generic overload of `gcd` that implements both Euclid's algorithm and Stein's algorithm in a minimalistic way of doing the most while requiring the least.  While I realize that this involves a lot of copy-pasta, I couldn't find a nice way to do it without potentially breaking existing code or turning the code into an unmaintainable mess of `static if`s, due to the original overload being a rat's nest of dependencies on properties of builtin integer types and other implementation details.  Also, another reason I did a separate overload is because the current algorithms are suboptimal with BigInt, and an optimal BigInt GCD algorithm is beyond my ability to implement. But for the sake of not letting the perfect be the enemy of the good, this overload is intended to be a temporary stop-gap measure to at least allow a *working* implementation of BigInt GCD until a better-optimized version is implemented -- it is better than the current ludicrous situation where Phobos doesn't come with a GCD algorithm for BigInt.
3. Improve the gcd documentation with standard ddoc sections.