### PR TITLE
std.format: Refactor argument indexing, improve exception messages

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -4066,7 +4066,7 @@ private int getNthInt(A...)(uint index, A args)
 
 private T getNth(alias Condition, T, A...)(uint index, A args)
 {
-    import std.conv : to;
+    import std.conv : text, to;
 
     switch (index)
     {
@@ -4084,14 +4084,14 @@ private T getNth(alias Condition, T, A...)(uint index, A args)
                 }
         }
         default:
-            throw new FormatException("missing argument #" ~ to!string(index + 1));
+            throw new FormatException(
+                text("Missing ", T.stringof, " for argument #", index + 1));
     }
 }
 
 @safe unittest
 {
-    assert(format("%*.d, %.*f", 3, 7, 2, 3.1415) == "  7, 3.14");
-
+    // width/precision
     assert(collectExceptionMsg!FormatException(format("%*.d", 5.1, 2))
         == "int expected, not double");
     assert(collectExceptionMsg!FormatException(format("%.*d", '5', 2))
@@ -4099,7 +4099,15 @@ private T getNth(alias Condition, T, A...)(uint index, A args)
     assert(collectExceptionMsg!FormatException(format("%.*d", 5))
         == "Orphan format specifier: %d");
     assert(collectExceptionMsg!FormatException(format("%*.*d", 5))
-        == "missing argument #2");
+        == "Missing int for argument #2");
+
+    // separatorCharPos
+    assert(collectExceptionMsg!FormatException(format("%,?d", 5))
+        == "dchar expected, not int");
+    assert(collectExceptionMsg!FormatException(format("%,?d", '?'))
+        == "Orphan format specifier: %d");
+    assert(collectExceptionMsg!FormatException(format("%.*,?d", 5))
+        == "Missing dchar for argument #2");
 }
 
 /* ======================== Unit Tests ====================================== */

--- a/std/format.d
+++ b/std/format.d
@@ -1021,19 +1021,17 @@ if (is(Unqual!Char == Char))
     int precision = UNSPECIFIED;
 
     /**
-       Separator. Its value defines how many digits are printed between
-       $(D SeparatorChar).
+       Number of digits printed between _separators.
     */
     int separators = UNSPECIFIED;
 
     /**
-       Separator. Its value defines how many digits are printed between
-       $(D SeparatorChar).
+       Set to `DYNAMIC` when the separator character is supplied at runtime.
     */
     int separatorCharPos = UNSPECIFIED;
 
     /**
-       SeparatorChar. The character that is inserted every $(D separators) character.
+       Character to insert between digits.
     */
     dchar separatorChar = ',';
 

--- a/std/format.d
+++ b/std/format.d
@@ -4060,29 +4060,27 @@ private int getNthInt(A...)(uint index, A args)
     return getNth!(isIntegral,int)(index, args);
 }
 
-private T getNth(alias Condition, T,A...)(uint index, A args)
+private T getNth(alias Condition, T, A...)(uint index, A args)
 {
     import std.conv : to;
 
-    static if (A.length)
+    switch (index)
     {
-        if (index)
+        foreach (n, _; A)
         {
-            return getNth!(Condition,T)(index - 1, args[1 .. $]);
+            case n:
+                static if (Condition!(typeof(args[n])))
+                {
+                    return to!T(args[n]);
+                }
+                else
+                {
+                    throw new FormatException(T.stringof ~ " expected, not " ~
+                            typeof(args[n]).stringof);
+                }
         }
-        static if (Condition!(typeof(args[0])))
-        {
-            return to!T(args[0]);
-        }
-        else
-        {
-            throw new FormatException(T.stringof ~ " expected, not " ~
-                    typeof(args[0]).stringof);
-        }
-    }
-    else
-    {
-        throw new FormatException("missing integer width/precision argument");
+        default:
+            throw new FormatException("missing argument #" ~ to!string(index + 1));
     }
 }
 
@@ -4095,7 +4093,7 @@ private T getNth(alias Condition, T,A...)(uint index, A args)
     assert(collectExceptionMsg!FormatException(format("%.*d", 5))
         == "Orphan format specifier: %d");
     assert(collectExceptionMsg!FormatException(format("%*.*d", 5))
-        == "missing integer width/precision argument");
+        == "missing argument #2");
 }
 
 /* ======================== Unit Tests ====================================== */

--- a/std/format.d
+++ b/std/format.d
@@ -4092,8 +4092,13 @@ private T getNth(string kind, alias Condition, T, A...)(uint index, A args)
     // width/precision
     assert(collectExceptionMsg!FormatException(format("%*.d", 5.1, 2))
         == "integer width expected, not double for argument #1");
+    assert(collectExceptionMsg!FormatException(format("%-1*.d", 5.1, 2))
+        == "integer width expected, not double for argument #1");
+
     assert(collectExceptionMsg!FormatException(format("%.*d", '5', 2))
         == "integer precision expected, not char for argument #1");
+    assert(collectExceptionMsg!FormatException(format("%-1.*d", 4.7, 3))
+        == "integer precision expected, not double for argument #1");
     assert(collectExceptionMsg!FormatException(format("%.*d", 5))
         == "Orphan format specifier: %d");
     assert(collectExceptionMsg!FormatException(format("%*.*d", 5))
@@ -5601,11 +5606,17 @@ private bool needToSwapEndianess(Char)(const ref FormatSpec!Char f)
     r = format("%-3d", 7);
     assert(r == "7  ");
 
+    r = format("%-1*d", 4, 3);
+    assert(r == "3   ");
+
     r = format("%*d", -3, 7);
     assert(r == "7  ");
 
     r = format("%.*d", -3, 7);
     assert(r == "7");
+
+    r = format("%-1.*f", 2, 3.1415);
+    assert(r == "3.14");
 
     r = format("abc"c);
     assert(r == "abc");

--- a/std/format.d
+++ b/std/format.d
@@ -4027,25 +4027,14 @@ private void formatGeneric(Writer, D, Char)(Writer w, const(void)* arg, const re
 
 private void formatNth(Writer, Char, A...)(Writer w, const ref FormatSpec!Char f, size_t index, A args)
 {
-    import std.conv : to;
-    static string gencode(size_t count)()
-    {
-        string result;
-        foreach (n; 0 .. count)
-        {
-            auto num = to!string(n);
-            result ~=
-                "case "~num~":"~
-                "    formatValue(w, args["~num~"], f);"~
-                "    break;";
-        }
-        return result;
-    }
-
     switch (index)
     {
-        mixin(gencode!(A.length)());
-
+        foreach (n, _; A)
+        {
+            case n:
+                formatValue(w, args[n], f);
+                return;
+        }
         default:
             assert(0, "n = "~cast(char)(index + '0'));
     }

--- a/std/format.d
+++ b/std/format.d
@@ -4042,6 +4042,11 @@ private void formatNth(Writer, Char, A...)(Writer w, const ref FormatSpec!Char f
 
 @safe pure unittest
 {
+    assert(format("%2$s, %1$s", "2nd", "1st") == "1st, 2nd");
+}
+
+@safe pure unittest
+{
     int[] a = [ 1, 3, 2 ];
     formatTest( "testing %(%s & %) embedded", a,
                 "testing 1 & 3 & 2 embedded");
@@ -4086,6 +4091,8 @@ private T getNth(alias Condition, T, A...)(uint index, A args)
 
 @safe unittest
 {
+    assert(format("%*.d, %.*f", 3, 7, 2, 3.1415) == "  7, 3.14");
+
     assert(collectExceptionMsg!FormatException(format("%*.d", 5.1, 2))
         == "int expected, not double");
     assert(collectExceptionMsg!FormatException(format("%.*d", '5', 2))


### PR DESCRIPTION
* Use `switch (index) foreach` to simplify code - see commits.
* Fix integer width/precision message which now applies to separator char too.
* Throw exception when positional format spec index exceeds `args.length`.

Note: `formatNth` is used for positional (and standard) formatting, `getNth` is used for reading integer width/precision and format separator char.