### PR TITLE
[trivial] Remove issue stats badge from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![GitHub tag](https://img.shields.io/github/tag/dlang/phobos.svg?maxAge=86400)](#)
 [![Build status](https://img.shields.io/circleci/project/dlang/phobos/master.svg?maxAge=86400)](https://circleci.com/gh/dlang/phobos)
 [![Code coverage](https://img.shields.io/codecov/c/github/dlang/phobos.svg?maxAge=86400)](https://codecov.io/gh/dlang/phobos)
-[![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/phobos.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/phobos)
 
 Phobos is the standard library that comes with the
 [D Programming Language](http://dlang.org) Compiler.


### PR DESCRIPTION
It's most of the time broken and slightly slows down (full) loading.