### PR TITLE
Issue 13607: Make more of BigInt usable from @safe.

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -540,7 +540,8 @@ public:
     /**
         Implements BigInt unary operators.
      */
-    BigInt opUnary(string op)() pure nothrow const if (op=="+" || op=="-" || op=="~")
+    BigInt opUnary(string op)() pure nothrow const @safe
+    if (op=="+" || op=="-" || op=="~")
     {
        static if (op=="-")
        {
@@ -558,7 +559,7 @@ public:
 
     // non-const unary operations
     /// ditto
-    BigInt opUnary(string op)() pure nothrow if (op=="++" || op=="--")
+    BigInt opUnary(string op)() pure nothrow @safe if (op=="++" || op=="--")
     {
         static if (op=="++")
         {
@@ -744,7 +745,7 @@ public:
         Implements 3-way comparisons of BigInt with BigInt or BigInt with
         built-in integers.
      */
-    int opCmp(ref const BigInt y) pure nothrow @nogc const
+    int opCmp(ref const BigInt y) pure nothrow @nogc const @safe
     {
         // Simply redirect to the "real" opCmp implementation.
         return this.opCmp!BigInt(y);
@@ -1672,7 +1673,7 @@ unittest
 }
 
 // issue 15678
-@system unittest
+@safe unittest
 {
     import std.exception : assertThrown;
     assertThrown!ConvException(BigInt(""));
@@ -1681,7 +1682,7 @@ unittest
 }
 
 // Issue 6447
-@system unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1695,4 +1696,3 @@ unittest
         BigInt(1_000_000_000_002)
     ]));
 }
-

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -540,7 +540,7 @@ public:
     /**
         Implements BigInt unary operators.
      */
-    BigInt opUnary(string op)() pure nothrow const @safe
+    BigInt opUnary(string op)() pure nothrow const
     if (op=="+" || op=="-" || op=="~")
     {
        static if (op=="-")
@@ -559,7 +559,7 @@ public:
 
     // non-const unary operations
     /// ditto
-    BigInt opUnary(string op)() pure nothrow @safe if (op=="++" || op=="--")
+    BigInt opUnary(string op)() pure nothrow if (op=="++" || op=="--")
     {
         static if (op=="++")
         {

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -506,7 +506,8 @@ public:
     // If wantSub is false, return x + y, leaving sign unchanged
     // If wantSub is true, return abs(x - y), negating sign if x < y
     static BigUint addOrSubInt(Tulong)(const BigUint x, Tulong y,
-            bool wantSub, ref bool sign) pure nothrow if (is(Tulong == ulong))
+            bool wantSub, ref bool sign) pure nothrow @safe
+    if (is(Tulong == ulong))
     {
         BigUint r;
         if (wantSub)
@@ -1288,7 +1289,7 @@ BigDigit [] add(const BigDigit [] a, const BigDigit [] b) pure nothrow
 
 /**  return x + y
  */
-BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow
+BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow @safe
 {
     uint hi = cast(uint)(y >>> 32);
     uint lo = cast(uint)(y& 0xFFFF_FFFF);
@@ -1315,7 +1316,7 @@ BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow
 /** Return x - y.
  *  x must be greater than y.
  */
-BigDigit [] subInt(const BigDigit[] x, ulong y) pure nothrow
+BigDigit [] subInt(const BigDigit[] x, ulong y) pure nothrow @safe
 {
     uint hi = cast(uint)(y >>> 32);
     uint lo = cast(uint)(y & 0xFFFF_FFFF);


### PR DESCRIPTION
This is only a first step, and will be part of an ongoing effort to make as much of BigInt `@safe` as possible, the goal being to eventually make all of it `@safe`.

No `@trusted` is used here at all, just marking up a bunch of non-template functions with `@safe` and letting the compiler do the verification for us.

I was originally going to make all of it `@safe`, but ran into a very, very deep rabbit hole where a single address-taking of a local was causing a big chunk of BigInt to be `@system`. It compiles with `-dip1000` but runs into other problems. It will take a lot more effort to figure out what needs to be fixed, where. But in the meantime, this PR is at least a first step in that direction.