### PR TITLE
std.experimental.logger: allow precise scanning of DATA/TLS segment

### DIFF
--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1763,7 +1763,7 @@ private @property Logger stdThreadLocalLogImpl() @trusted
 {
     import std.conv : emplace;
 
-    static align(StdForwardLogger.alignof) void[__traits(classInstanceSize, StdForwardLogger)] _buffer;
+    static void*[(__traits(classInstanceSize, StdForwardLogger) - 1) / (void*).sizeof + 1] _buffer;
 
     auto buffer = cast(ubyte[]) _buffer;
 

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1631,7 +1631,7 @@ private @property Logger defaultSharedLoggerImpl() @trusted
     import std.conv : emplace;
     import std.stdio : stderr;
 
-    static __gshared ubyte[__traits(classInstanceSize, FileLogger)] _buffer;
+    static __gshared align(FileLogger.alignof) void[__traits(classInstanceSize, FileLogger)] _buffer;
 
     synchronized (stdSharedLoggerMutex)
     {
@@ -1763,7 +1763,7 @@ private @property Logger stdThreadLocalLogImpl() @trusted
 {
     import std.conv : emplace;
 
-    static ubyte[__traits(classInstanceSize, StdForwardLogger)] _buffer;
+    static align(StdForwardLogger.alignof) void[__traits(classInstanceSize, StdForwardLogger)] _buffer;
 
     auto buffer = cast(ubyte[]) _buffer;
 


### PR DESCRIPTION
Buffers for preallocated class instances should be typed void[], not ubyte[] and must be properly aligned.

This blocks https://github.com/dlang/druntime/pull/1798.