### PR TITLE
ARM and Android fixes: version out some HardFloat tests, use TMPDIR logic and declaration from druntime, and correct comment

### DIFF
--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -103,10 +103,6 @@ struct Mallocator
     test!Mallocator();
 }
 
-version (Posix)
-@nogc nothrow
-private extern(C) int posix_memalign(void**, size_t, size_t);
-
 version (Windows)
 {
     // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
@@ -229,6 +225,7 @@ struct AlignedMallocator
     void[] alignedAllocate(size_t bytes, uint a) shared
     {
         import core.stdc.errno : ENOMEM, EINVAL;
+        import core.sys.posix.stdlib : posix_memalign;
         assert(a.isGoodDynamicAlignment);
         void* result;
         auto code = posix_memalign(&result, a, bytes);

--- a/std/file.d
+++ b/std/file.d
@@ -4353,11 +4353,6 @@ string tempDir() @trusted
             DWORD len = GetTempPathW(buf.length, buf.ptr);
             if (len) cache = buf[0 .. len].to!string;
         }
-        else version(Android)
-        {
-            // Don't check for a global temporary directory as
-            // Android doesn't have one.
-        }
         else version(Posix)
         {
             import std.process : environment;

--- a/std/math.d
+++ b/std/math.d
@@ -4816,7 +4816,7 @@ public:
     assert(ieeeFlags == f);
 }
 
-@system unittest
+version(D_HardFloat) @system unittest
 {
     import std.meta : AliasSeq;
 
@@ -5260,7 +5260,7 @@ private:
     ensureDefaults();
 }
 
-@system unittest // rounding
+version(D_HardFloat) @system unittest // rounding
 {
     import std.meta : AliasSeq;
 

--- a/std/system.d
+++ b/std/system.d
@@ -28,7 +28,7 @@ immutable
     {
         win32 = 1, /// Microsoft 32 bit Windows systems
         win64,     /// Microsoft 64 bit Windows systems
-        linux,     /// All Linux Systems
+        linux,     /// All Linux Systems, except for Android
         osx,       /// Mac OS X
         freeBSD,   /// FreeBSD
         netBSD,    /// NetBSD


### PR DESCRIPTION
x86/x64 has no problem with unaligned reads, but the llvm optimizer gets confused by the cast in the `foreach` and assumes the `Element` is 32-bit aligned, generating ARM instructions that require word alignment and causing problems with the last unaligned test.

As for `posix_memalign`, turns out its declared in druntime but wasn't for `OSX`, so added it in dlang/druntime#1819 and used the import instead.  That druntime PR will need to be merged first.