### PR TITLE
Split style target for CircleCi

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,9 @@ dependencies:
 test:
   override:
     - ./circleci.sh setup-repos
-    - ./circleci.sh style
+    - ./circleci.sh style_lint
+    - ./circleci.sh has_public_example
+    - ./circleci.sh publictests
     - ./circleci.sh coverage:
         parallel: true
         timeout: 1200

--- a/posix.mak
+++ b/posix.mak
@@ -499,7 +499,9 @@ $(TOOLS_DIR)/checkwhitespace.d:
 	mv dscanner_makefile_tmp ../dscanner/makefile
 	make -C ../dscanner githash debug
 
-style: ../dscanner/dsc $(LIB) has_public_example publictests
+style: has_public_example publictests style_lint
+
+style_lint: ../dscanner/dsc $(LIB)
 	@echo "Check for trailing whitespace"
 	grep -nr '[[:blank:]]$$' etc std ; test $$? -eq 1
 


### PR DESCRIPTION
CC @jmdavis @schveiguy 

One simple trick that we can do is simply splitting the target up into its subdependencies, s.t. it is easier to browse on CircleCi. Moreover, IIRC CircleCi will __continue to execute the subsequent tests__ (see e.g. [1](https://circleci.com/gh/dlang/phobos/2612) or [2](https://circleci.com/gh/dlang/phobos/2617)) 