### PR TITLE
Fix Ddoc links in std.datetime

### DIFF
--- a/std/datetime/package.d
+++ b/std/datetime/package.d
@@ -6,14 +6,14 @@
     This module provides:
     $(UL
         $(LI Types to represent points in time:
-             $(REF SysTime,std,datetime,systime),
-             $(REF Date,std,datetime,date),
-             $(REF TimeOfDay,std,datetime,date),
-             $(REF DateTime,std,datetime,date).)
+             $(REF SysTime,std,_datetime,systime),
+             $(REF Date,std,_datetime,date),
+             $(REF TimeOfDay,std,_datetime,date),
+             $(REF DateTime,std,_datetime,date).)
         $(LI Types to represent intervals of time.)
         $(LI Types to represent ranges over intervals of time.)
         $(LI Types to represent time zones (used by
-             $(REF SysTime,std,datetime,systime)).)
+             $(REF SysTime,std,_datetime,systime)).)
         $(LI A platform-independent, high precision stopwatch type:
              $(LREF StopWatch))
         $(LI Benchmarking functions.)
@@ -49,22 +49,22 @@
     be done on a series of time points.
 
     The types that the typical user is most likely to be interested in are
-    $(REF Date,std,datetime,date) (if they want dates but don't care about
-    time), $(REF DateTime,std,datetime,date) (if they want dates and times
-    but don't care about time zones), $(REF SysTime,std,datetime,systime) (if
+    $(REF Date,std,_datetime,date) (if they want dates but don't care about
+    time), $(REF DateTime,std,_datetime,date) (if they want dates and times
+    but don't care about time zones), $(REF SysTime,std,_datetime,systime) (if
     they want the date and time from the OS and/or do care about time zones),
     and StopWatch (a platform-independent, high precision stop watch).
-    $(REF Date,std,datetime,date) and $(REF DateTime,std,datetime,date) are
+    $(REF Date,std,_datetime,date) and $(REF DateTime,std,_datetime,date) are
     optimized for calendar-based operations, while
-    $(REF SysTime,std,datetime,systime) is designed for dealing with time from
+    $(REF SysTime,std,_datetime,systime) is designed for dealing with time from
     the OS. Check out their specific documentation for more details.
 
-    To get the current time, use $(REF Clock.currTime,std,datetime,systime).
-    It will return the current time as a $(REF SysTime,std,datetime,systime). To
+    To get the current time, use $(REF Clock.currTime,std,_datetime,systime).
+    It will return the current time as a $(REF SysTime,std,_datetime,systime). To
     print it, $(D toString) is sufficient, but if using $(D toISOString),
     $(D toISOExtString), or $(D toSimpleString), use the corresponding
     $(D fromISOString), $(D fromISOExtString), or $(D fromSimpleString) to
-    create a $(REF SysTime,std,datetime,systime) from the string.
+    create a $(REF SysTime,std,_datetime,systime) from the string.
 
 --------------------
 auto currentTime = Clock.currTime();
@@ -87,12 +87,12 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
     weren't).
 
     Note:
-        $(REF DateTimeException,std,datetime,date) is an alias for
+        $(REF DateTimeException,std,_datetime,date) is an alias for
         $(REF TimeException, core,time), so you don't need to worry about
         core.time functions and std.datetime functions throwing different
         exception types (except in the rare case that they throw something other
         than $(REF TimeException, core,time) or
-        $(REF DateTimeException,std,datetime,date)).
+        $(REF DateTimeException,std,_datetime,date)).
 
     See_Also:
         $(DDLINK intro-to-_datetime, Introduction to std.datetime,

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -2088,7 +2088,7 @@ public:
         returning.
 
         Params:
-            timezone = The $(REF TimeZone,std,datetime,timezone) to set this
+            timezone = The $(REF _TimeZone,std,datetime,_timezone) to set this
                        $(LREF SysTime)'s time zone to.
       +/
     @property void timezone(immutable TimeZone timezone) @safe pure nothrow


### PR DESCRIPTION
A baby-step to fix the most visible broken HTML links due to Ddoc's nice behavior of auto-escaping symbols ...

For reference please see: https://dlang.org/phobos-prerelease/std_datetime.html