### PR TITLE
Allow ignoring individual lines for coverage analysis

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -121,6 +121,10 @@ coverage()
 
     # instead we run all tests individually
     make -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test")
+
+    # Remove coverage information from lines with non-deterministic coverage.
+    # These lines are annotated with a comment containing "nocoverage".
+    sed -i 's/^ *[0-9]*\(|.*nocoverage.*\)$/       \1/' ./*.lst
 }
 
 case $1 in

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -629,7 +629,7 @@ struct Task(alias fun, Args...)
 
         if (exception)
         {
-            throw exception;
+            throw exception; // nocoverage
         }
 
         static if (!is(ReturnType == void))


### PR DESCRIPTION
This adds a work-around to the non-deterministic coverage fluctuations
in std.parallelism. Lines with `nocoverage` on them will be excluded
from coverage analysis, and be considered as not containing any code.