### PR TITLE
Fix std.datetime autotester failure for FreeBSD 10.3/11.

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -728,17 +728,29 @@ public:
 
     @safe unittest
     {
-        assert(LocalTime().stdName !is null);
-
-        version(Posix)
+        version(FreeBSD)
         {
-            scope(exit) clearTZEnvVar();
+            // A bug on FreeBSD 9+ makes it so that this test fails.
+            // https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=168862
+        }
+        else version(NetBSD)
+        {
+            // The same bug on NetBSD 7+
+        }
+        else
+        {
+            assert(LocalTime().stdName !is null);
 
-            setTZEnvVar("America/Los_Angeles");
-            assert(LocalTime().stdName == "PST");
+            version(Posix)
+            {
+                scope(exit) clearTZEnvVar();
 
-            setTZEnvVar("America/New_York");
-            assert(LocalTime().stdName == "EST");
+                setTZEnvVar("America/Los_Angeles");
+                assert(LocalTime().stdName == "PST");
+
+                setTZEnvVar("America/New_York");
+                assert(LocalTime().stdName == "EST");
+            }
         }
     }
 


### PR DESCRIPTION
The tests fail depending on your timezone due to a known FreeBSD bug, so
we need to disable them until the bug in FreeBSD gets fixed.