### PR TITLE
Deprecate obsolete pattern matching functions in std.string

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -5230,8 +5230,13 @@ body
     assert(buffer.data == "h5 rd");
 }
 
-
+//@@@DEPRECATED_2018-05@@@
 /***********************************************
+ * $(RED This function is deprecated and will be removed May 2018.)
+ * Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ * instead. If you still need this function, it will be available in
+ * $(LINK2 https://github.com/dlang/undeaD, undeaD).
+ *
  * See if character c is in the pattern.
  * Patterns:
  *
@@ -5248,7 +5253,7 @@ body
  * Note: In the future, the pattern syntax may be improved
  *  to be more like regular expression character classes.
  */
-
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 bool inPattern(S)(dchar c, in S pattern) @safe pure @nogc
 if (isSomeString!S)
 {
@@ -5314,11 +5319,16 @@ if (isSomeString!S)
     });
 }
 
-
+//@@@DEPRECATED_2018-05@@@
 /***********************************************
+ * $(RED This function is deprecated and will be removed May 2018.)
+ * Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ * instead. If you still need this function, it will be available in
+ * $(LINK2 https://github.com/dlang/undeaD, undeaD).
+ *
  * See if character c is in the intersection of the patterns.
  */
-
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 bool inPattern(S)(dchar c, S[] patterns) @safe pure @nogc
 if (isSomeString!S)
 {
@@ -5332,11 +5342,16 @@ if (isSomeString!S)
     return true;
 }
 
-
+//@@@DEPRECATED_2018-05@@@
 /********************************************
+ * $(RED This function is deprecated and will be removed May 2018.)
+ * Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ * instead. If you still need this function, it will be available in
+ * $(LINK2 https://github.com/dlang/undeaD, undeaD).
+ *
  * Count characters in s that match pattern.
  */
-
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 size_t countchars(S, S1)(S s, in S1 pattern) @safe pure @nogc
 if (isSomeString!S && isSomeString!S1)
 {
@@ -5362,11 +5377,16 @@ if (isSomeString!S && isSomeString!S1)
     });
 }
 
-
+//@@@DEPRECATED_2018-05@@@
 /********************************************
+ * $(RED This function is deprecated and will be removed May 2018.)
+ * Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ * instead. If you still need this function, it will be available in
+ * $(LINK2 https://github.com/dlang/undeaD, undeaD).
+ *
  * Return string that is s with all characters removed that match pattern.
  */
-
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 S removechars(S)(S s, in S pattern) @safe pure
 if (isSomeString!S)
 {
@@ -5418,13 +5438,18 @@ if (isSomeString!S)
     assert(removechars("abc", "x") == "abc");
 }
 
-
+//@@@DEPRECATED_2018-05@@@
 /***************************************************
+ * $(RED This function is deprecated and will be removed May 2018.)
+ * Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ * instead. If you still need this function, it will be available in
+ * $(LINK2 https://github.com/dlang/undeaD, undeaD).
+ *
  * Return string where sequences of a character in s[] from pattern[]
  * are replaced with a single instance of that character.
  * If pattern is null, it defaults to all characters.
  */
-
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 S squeeze(S)(S s, in S pattern = null)
 {
     import std.utf : encode, stride;
@@ -5490,7 +5515,13 @@ S squeeze(S)(S s, in S pattern = null)
     });
 }
 
+//@@@DEPRECATED_2018-05@@@
 /***************************************************************
+ $(RED This function is deprecated and will be removed May 2018.)
+ Please use the functions in $(MREF std, regex) and $(MREF std, algorithm)
+ instead. If you still need this function, it will be available in
+ $(LINK2 https://github.com/dlang/undeaD, undeaD).
+
  Finds the position $(D_PARAM pos) of the first character in $(D_PARAM
  s) that does not match $(D_PARAM pattern) (in the terminology used by
  $(REF inPattern, std,string)). Updates $(D_PARAM s =
@@ -5501,6 +5532,7 @@ The $(D_PARAM munch) function is mostly convenient for skipping
 certain category of characters (e.g. whitespace) when parsing
 strings. (In such cases, the return value is not used.)
  */
+deprecated("This function is obsolete and will be removed May 2018. See the docs for more details")
 S1 munch(S1, S2)(ref S1 s, S2 pattern) @safe pure @nogc
 {
     size_t j = s.length;


### PR DESCRIPTION
These functions are old D1 string functions from before std.regex's existence. With std.regex and std.algorithm, these functions are no longer needed, and their use should be discouraged, as the std.algorithm versions will be faster (better search algorithms, better handling of auto-decoding).

Plus, this removes a domain specific language that's in use only in one minor part of D.