### PR TITLE
Fix Issue 14402 - Prevent emplace without context pointer

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5027,6 +5027,12 @@ version(unittest) private class __conv_EmplaceTestClass
     auto ps = emplace!S(buf, s);
     ps.f;
     assert(i == 1);
+
+    S[3] sa = void;
+    static assert(!__traits(compiles, emplace(&sa)));
+    emplace(&sa, s);
+    sa[2].f;
+    assert(i == 2);
 }
 
 //Alias this

--- a/std/traits.d
+++ b/std/traits.d
@@ -2316,12 +2316,17 @@ have a context pointer.
 */
 template hasNested(T)
 {
-    import std.meta : anySatisfy;
+    import std.meta : anySatisfy, Filter;
+
     static if (isStaticArray!T && T.length)
         enum hasNested = hasNested!(typeof(T.init[0]));
     else static if (is(T == class) || is(T == struct) || is(T == union))
+    {
+        // prevent infinite recursion for class with member of same type
+        enum notSame(U) = !is(Unqual!T == Unqual!U);
         enum hasNested = isNested!T ||
-            anySatisfy!(.hasNested, Fields!T);
+            anySatisfy!(.hasNested, Filter!(notSame, Fields!T));
+    }
     else
         enum hasNested = false;
 }
@@ -2387,6 +2392,12 @@ template hasNested(T)
     static assert(!__traits(compiles, isNested!(NestedClass[1])));
     static assert( hasNested!(NestedClass[1]));
     static assert(!hasNested!(NestedClass[0]));
+
+    static class A
+    {
+        A a;
+    }
+    static assert(!hasNested!A);
 }
 
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5482,7 +5482,7 @@ pure @system nothrow @nogc unittest
 // 6436
 @system pure unittest
 {
-    struct S { this(ref int val) { assert(val == 3); ++val; } }
+    static struct S { pure this(ref int val) { assert(val == 3); ++val; } }
 
     int val = 3;
     auto s = RefCounted!S(val);
@@ -6648,7 +6648,7 @@ template scoped(T)
 ///
 @system unittest
 {
-    class A
+    static class A
     {
         int x;
         this()     {x = 0;}
@@ -6799,7 +6799,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest // Original Issue 6580 testcase
 {
-    class C { int i; byte b; }
+    static class C { int i; byte b; }
 
     auto sa = [scoped!C(), scoped!C()];
     assert(cast(uint)&sa[0].i % int.alignof == 0);
@@ -6808,7 +6808,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class A { int x = 1; }
+    static class A { int x = 1; }
     auto a1 = scoped!A();
     assert(a1.x == 1);
     auto a2 = scoped!A();
@@ -6819,7 +6819,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class A { int x = 1; this() { x = 2; } }
+    static class A { int x = 1; this() { x = 2; } }
     auto a1 = scoped!A();
     assert(a1.x == 2);
     auto a2 = scoped!A();
@@ -6830,7 +6830,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class A { int x = 1; this(int y) { x = y; } ~this() {} }
+    static class A { int x = 1; this(int y) { x = y; } ~this() {} }
     auto a1 = scoped!A(5);
     assert(a1.x == 5);
     auto a2 = scoped!A(42);
@@ -6841,8 +6841,8 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class A { static bool dead; ~this() { dead = true; } }
-    class B : A { static bool dead; ~this() { dead = true; } }
+    static class A { static bool dead; ~this() { dead = true; } }
+    static class B : A { static bool dead; ~this() { dead = true; } }
     {
         auto b = scoped!B();
     }
@@ -6876,7 +6876,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 @system unittest
 {
     // bug4500
-    class A
+    static class A
     {
         this() { a = this; }
         this(int i) { a = this; }
@@ -6954,7 +6954,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class C { this(ref int val) { assert(val == 3); ++val; } }
+    static class C { this(ref int val) { assert(val == 3); ++val; } }
 
     int val = 3;
     auto s = scoped!C(val);
@@ -6963,7 +6963,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
 
 @system unittest
 {
-    class C
+    static class C
     {
         this(){}
         this(int){}

--- a/std/variant.d
+++ b/std/variant.d
@@ -1602,8 +1602,8 @@ static class VariantException : Exception
     assertThrown!ConvException(a.coerce!bool);
 
     // Object tests
-    class B1 {}
-    class B2 : B1 {}
+    static class B1 {}
+    static class B2 : B1 {}
     a = new B2;
     assert(a.coerce!(B1) !is null);
     a = new B1;
@@ -2509,8 +2509,8 @@ if (isAlgebraic!VariantType && Handler.length > 0)
         assertThrown!VariantException(v.get!(qual!(int)[]));
     }
 
-    class A {}
-    class B : A {}
+    static class A {}
+    static class B : A {}
     B b = new B();
     v = b;
     foreach (qual; AliasSeq!(MutableOf, ConstOf))


### PR DESCRIPTION
Use `static assert` to ensure:
* A nested struct must only be emplaced when given an initializer argument of the same type.
* A static array must only be emplaced with an initializer argument of the same type, element type or slice of element type.
* A non-inner nested class cannot be emplaced, `emplace` doesn't support this.