### PR TITLE
Revert #4961 (uniq.back)

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4951,48 +4951,9 @@ if (isInputRange!Range && is(typeof(binaryFun!pred(r.front, r.front)) == bool))
     assert(equal(uniq([ 1, 1, 2, 1, 1, 3, 1]), [1, 2, 1, 3, 1]));
 }
 
-///
-@system unittest
-{
-    import std.algorithm.comparison : equal;
-
-    struct S
-    {
-        int i;
-        string s;
-    }
-
-    auto arr = [ S(1, "a"), S(1, "b"), S(2, "c"), S(2, "d") ];
-
-    // Let's consider just the 'i' member for equality
-    auto r = arr.uniq!((a, b) => a.i == b.i);
-    assert(r.equal([S(1, "a"), S(2, "c")]));
-    assert(r.front == S(1, "a"));
-    assert(r.back == S(2, "c"));
-
-    r.popBack;
-    assert(r.back == S(1, "a"));
-    assert(r.front == r.back);
-
-    r.popBack;
-    assert(r.empty);
-
-    import std.exception : assertThrown;
-
-    assertThrown!Error(r.front);
-    assertThrown!Error(r.back);
-    assertThrown!Error(r.popFront);
-    assertThrown!Error(r.popBack);
-}
-
 private struct UniqResult(alias pred, Range)
 {
-    private Range _input;
-    static if (isBidirectionalRange!Range)
-    {
-        private ElementType!Range _back;
-        private bool _isInBack;
-    }
+    Range _input;
 
     this(Range input)
     {
@@ -5007,19 +4968,10 @@ private struct UniqResult(alias pred, Range)
     void popFront()
     {
         assert(!empty, "Attempting to popFront an empty uniq.");
-        static if (isBidirectionalRange!Range)
-        {
-            if (_input.empty)
-            {
-                _isInBack = false;
-                return;
-            }
-        }
-
         auto last = _input.front;
         do
         {
-            _input.popFront;
+            _input.popFront();
         }
         while (!_input.empty && pred(last, _input.front));
     }
@@ -5027,13 +4979,6 @@ private struct UniqResult(alias pred, Range)
     @property ElementType!Range front()
     {
         assert(!empty, "Attempting to fetch the front of an empty uniq.");
-        static if (isBidirectionalRange!Range)
-        {
-            if (_input.empty && _isInBack)
-            {
-                return _back;
-            }
-        }
         return _input.front;
     }
 
@@ -5042,33 +4987,18 @@ private struct UniqResult(alias pred, Range)
         void popBack()
         {
             assert(!empty, "Attempting to popBack an empty uniq.");
-            if (_input.empty)
+            auto last = _input.back;
+            do
             {
-                _isInBack = false;
+                _input.popBack();
             }
-            else
-            {
-                _isInBack = true;
-                _back = _input.back;
-                ElementType!Range last;
-                do
-                {
-                    last = _input.back;
-                    _input.popBack;
-                }
-                while (!_input.empty && pred(_back, _input.back));
-                _back = last;
-            }
+            while (!_input.empty && pred(last, _input.back));
         }
 
         @property ElementType!Range back()
         {
             assert(!empty, "Attempting to fetch the back of an empty uniq.");
-            if (!_isInBack)
-            {
-                popBack;
-            }
-            return _back;
+            return _input.back;
         }
     }
 
@@ -5078,17 +5008,7 @@ private struct UniqResult(alias pred, Range)
     }
     else
     {
-        @property bool empty()
-        {
-            static if (isBidirectionalRange!Range)
-            {
-                return _input.empty && !_isInBack;
-            }
-            else
-            {
-                return _input.empty;
-            }
-        }
+        @property bool empty() { return _input.empty; }
     }
 
     static if (isForwardRange!Range)

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -5047,6 +5047,14 @@ private struct UniqResult(alias pred, Range)
     }
 }
 
+@safe unittest // https://issues.dlang.org/show_bug.cgi?id=17264
+{
+    import std.algorithm.comparison : equal;
+
+    const(int)[] var = [0, 1, 1, 2];
+    assert(var.uniq.equal([0, 1, 2]));
+}
+
 /**
 Lazily computes all _permutations of $(D r) using $(HTTP
 en.wikipedia.org/wiki/Heap%27s_algorithm, Heap's algorithm).


### PR DESCRIPTION
This reverts #4961 and fixes https://issues.dlang.org/show_bug.cgi?id=17264.

Rationale:

1. The PR introduced a performance regression for the most common case.
   - As it added additional state to the type, it is unlikely that it can be optimized away by an optimizing compiler.
2. It introduced a regression (issue 17264).
   - The PR author has not responded to the regression notification within 5 days now.
3. The PR fixes a rare use case. To run into the bug, you must use `uniq` in combination with two uncommonly-used features:
   - Using `uniq` with a custom predicate, i.e. filtering items only when they are partially equal.
   - Using `uniq`'s `BidirectionalRange` primitives (i.e. `.back`).

As for fixing the original bug ([16588](https://issues.dlang.org/show_bug.cgi?id=16588)), I can think of two other solutions:

1. "Don't do that" - simply documenting the behaviour, and instructing users to use `uniq` in combination with `retro` to achieve the desired result.
2. Deprecating then removing `.back` when a custom predicate is specified. Not sure if this makes sense.