### PR TITLE
std.traits: Make hasNested ignore class reference members

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2316,12 +2316,17 @@ have a context pointer.
 */
 template hasNested(T)
 {
-    import std.meta : anySatisfy;
+    import std.meta : anySatisfy, Filter;
+
     static if (isStaticArray!T && T.length)
         enum hasNested = hasNested!(typeof(T.init[0]));
     else static if (is(T == class) || is(T == struct) || is(T == union))
+    {
+        // prevent infinite recursion for class with member of same type
+        enum notSame(U) = !is(Unqual!T == Unqual!U);
         enum hasNested = isNested!T ||
-            anySatisfy!(.hasNested, Fields!T);
+            anySatisfy!(.hasNested, Filter!(notSame, Fields!T));
+    }
     else
         enum hasNested = false;
 }
@@ -2387,6 +2392,12 @@ template hasNested(T)
     static assert(!__traits(compiles, isNested!(NestedClass[1])));
     static assert( hasNested!(NestedClass[1]));
     static assert(!hasNested!(NestedClass[0]));
+
+    static class A
+    {
+        A a;
+    }
+    static assert(!hasNested!A);
 }
 
 


### PR DESCRIPTION
The first commit fixes infinite recursion when a class has a member of its own type. (Then I realized that class references don't own a context pointer, so `hasNested` should ignore class reference *members* of an aggregate - this has been dropped for now though).