### PR TITLE
std.datetime.stopwatch: Fix random test failure on Win32

### DIFF
--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -231,7 +231,7 @@ public:
         sw.stop();
         assert(!sw.running);
         immutable t2 = sw.peek();
-        assert(t2 > t1);
+        assert(t2 >= t1);
         immutable t3 = sw.peek();
         assert(t2 == t3);
     }


### PR DESCRIPTION
I'm seeing a bunch of random failures on Win32 on this line, e.g.:

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2557560&isPull=true

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2557534&isPull=true

I suppose an alternative would be to sleep for e.g. twice the timer resolution.

CC @jmdavis 