### PR TITLE
Optimized std.datetime.date.Date.fromISOString

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -7282,33 +7282,39 @@ public:
     {
         import std.algorithm.searching : all, startsWith;
         import std.ascii : isDigit;
-        import std.conv : to;
+        import std.conv : to, text, ConvException;
         import std.exception : enforce;
-        import std.format : format;
         import std.string : strip;
 
-        auto dstr = to!dstring(strip(isoString));
+        auto str = isoString.strip;
 
-        enforce(dstr.length >= 8, new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce!DateTimeException(str.length >= 8, text("Invalid ISO String: ", isoString));
 
-        auto day = dstr[$-2 .. $];
-        auto month = dstr[$-4 .. $-2];
-        auto year = dstr[0 .. $-4];
+        int day, month;
 
-        enforce(all!isDigit(day), new DateTimeException(format("Invalid ISO String: %s", isoString)));
-        enforce(all!isDigit(month), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        try
+        {
+            day = to!int(str[$ - 2 .. $]);
+            month = to!int(str[$ - 4 .. $ - 2]);
+        }
+        catch (ConvException)
+        {
+            throw new DateTimeException(text("Invalid ISO String: ", isoString));
+        }
+
+        auto year = str[0 .. $ - 4];
 
         if (year.length > 4)
         {
-            enforce(year.startsWith('-', '+'),
-                    new DateTimeException(format("Invalid ISO String: %s", isoString)));
-            enforce(all!isDigit(year[1..$]),
-                    new DateTimeException(format("Invalid ISO String: %s", isoString)));
+            enforce!DateTimeException(year.startsWith('-', '+'),
+                    text("Invalid ISO String: ", isoString));
+            enforce!DateTimeException(all!isDigit(year[1 .. $]),
+                    text("Invalid ISO String: ", isoString));
         }
         else
-            enforce(all!isDigit(year), new DateTimeException(format("Invalid ISO String: %s", isoString)));
+            enforce!DateTimeException(all!isDigit(year), text("Invalid ISO String: ", isoString));
 
-        return Date(to!short(year), to!ubyte(month), to!ubyte(day));
+        return Date(to!int(year), month, day);
     }
 
     ///


### PR DESCRIPTION
Here's a summary of the changes

* Replaces use of `format` with `text` for error messages, as format is slower due to string parsing when all you really need for this is concatenation
* The string being passed must be all ASCII characters to be valid, so there is no need to convert it to a `dstring`
* There's no need to check if the day and month strings are all digits if you're going to convert them anyway. Leave validation to the conversion functions. This eliminates some loops.
* Changed the conversion to `int` rather than `ubyte`s and `short`s, as they use slower paths inside of `std.conv.parse` than `int`.

Here's the results

```
$ ldc2 -O -release test.d && ./test
old	4 secs, 541 ms, 59 μs, and 1 hnsec
new	1 sec, 410 ms, 713 μs, and 4 hnsecs
```

Result with second commit

```
old	4 secs, 456 ms, 712 μs, and 1 hnsec
new	1 sec, 105 ms, 830 μs, and 8 hnsecs
```

Benchmark Code

```d
import std.stdio;
import std.algorithm;
import std.conv;
import std.ascii;
import std.range;
import std.traits;
import std.string;
import std.datetime;
import std.utf;

enum testCount = 20_000_000;

Date fromISOString1(S)(in S isoString) @safe pure
    if (isSomeString!S)
{
    import std.algorithm.searching : all, startsWith;
    import std.ascii : isDigit;
    import std.conv : to;
    import std.exception : enforce;
    import std.format : format;
    import std.string : strip;

    auto dstr = to!dstring(strip(isoString));

    enforce(dstr.length >= 8, new DateTimeException(format("Invalid ISO String: %s", isoString)));

    auto day = dstr[$-2 .. $];
    auto month = dstr[$-4 .. $-2];
    auto year = dstr[0 .. $-4];

    enforce(all!isDigit(day), new DateTimeException(format("Invalid ISO String: %s", isoString)));
    enforce(all!isDigit(month), new DateTimeException(format("Invalid ISO String: %s", isoString)));

    if (year.length > 4)
    {
        enforce(year.startsWith('-', '+'),
                new DateTimeException(format("Invalid ISO String: %s", isoString)));
        enforce(all!isDigit(year[1..$]),
                new DateTimeException(format("Invalid ISO String: %s", isoString)));
    }
    else
        enforce(all!isDigit(year), new DateTimeException(format("Invalid ISO String: %s", isoString)));

    return Date(to!short(year), to!ubyte(month), to!ubyte(day));
}

Date fromISOString2(S)(in S isoString) @safe pure
    if (isSomeString!S)
{
    import std.algorithm.searching : all, startsWith;
    import std.ascii : isDigit;
    import std.conv : to, text, ConvException;
    import std.exception : enforce;
    import std.string : strip;

    auto str = isoString.strip;

    enforce!DateTimeException(str.length >= 8, text("Invalid ISO String: ", isoString));

    int day, month, year;
    auto yearStr = str[0 .. $ - 4];

    try
    {
        // using conversion to uint plus cast because it checks for +/-
        // for us quickly while throwing ConvException
        day = cast(int) to!uint(str[$ - 2 .. $]);
        month = cast(int) to!uint(str[$ - 4 .. $ - 2]);

        if (yearStr.length > 4)
        {
            enforce!DateTimeException(yearStr.startsWith('-', '+'),
                    text("Invalid ISO String: ", isoString));
            year = to!int(yearStr);
        }
        else
        {
            year = cast(int) to!uint(yearStr);
        }
    }
    catch (ConvException)
    {
        throw new DateTimeException(text("Invalid ISO String: ", isoString));
    }

    return Date(year, month, day);
}

void main()
{
    auto result = to!Duration(benchmark!(() => fromISOString1("20100704"))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => fromISOString2("20100704"))(testCount)[0]);

    writeln("old", "\t", result);
    writeln("new", "\t", result2);
}
```

Ping @jmdavis 