### PR TITLE
AutoImplement with baseclass

### DIFF
--- a/changelog/std-typecons-AutoImplement.dd
+++ b/changelog/std-typecons-AutoImplement.dd
@@ -1,0 +1,9 @@
+Added possibility to use a baseclass when auto-implementing an interface
+
+A second $(REF AutoImplement, std, typecons) template has been added, which
+differs from the existing one in accepting an extra type parameter. The extra
+parameter specifies a class to derive from while auto-implementing an interface.
+
+The base class used may contain non-default constructors. Matching constructors
+will be created in the auto-implemented class and be implemented as just a call
+to super with all arguments.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3588,6 +3588,9 @@ class NotImplementedError : Error
 $(D AutoImplement) automatically implements (by default) all abstract member
 functions in the class or interface $(D Base) in specified way.
 
+The second version of $(D AutoImplement) automatically implements
+$(D Interface), while deriving from $(D BaseClass).
+
 Params:
   how  = template which specifies _how functions will be implemented/overridden.
 
@@ -3668,9 +3671,21 @@ $(UL
 )
  */
 class AutoImplement(Base, alias how, alias what = isAbstractFunction) : Base
+    if (!is(how == class))
 {
     private alias autoImplement_helper_ =
-        AutoImplement_Helper!("autoImplement_helper_", "Base", Base, how, what);
+        AutoImplement_Helper!("autoImplement_helper_", "Base", Base, typeof(this), how, what);
+    mixin(autoImplement_helper_.code);
+}
+
+/// ditto
+class AutoImplement(
+    Interface, BaseClass, alias how,
+    alias what = isAbstractFunction) : BaseClass, Interface
+    if (is(Interface == interface) && is(BaseClass == class))
+{
+    private alias autoImplement_helper_ = AutoImplement_Helper!(
+            "autoImplement_helper_", "Interface", Interface, typeof(this), how, what);
     mixin(autoImplement_helper_.code);
 }
 
@@ -3680,7 +3695,7 @@ class AutoImplement(Base, alias how, alias what = isAbstractFunction) : Base
  * members, should be minimized.
  */
 private template AutoImplement_Helper(string myName, string baseName,
-        Base, alias generateMethodBody, alias cherrypickMethod)
+        Base, Self, alias generateMethodBody, alias cherrypickMethod)
 {
 private static:
     //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
@@ -3725,11 +3740,18 @@ private static:
     alias targetOverloadSets = enumerateOverloads!(Base, canonicalPicker);
 
     /*
+     * Super class of this AutoImplement instance
+     */
+    alias Super = BaseTypeTuple!(Self)[0];
+    static assert(is(Super == class));
+    static assert(is(Base == interface) || is(Super == Base));
+
+    /*
      * A tuple of the super class' constructors.  Used for forwarding
      * constructor calls.
      */
-    static if (__traits(hasMember, Base, "__ctor"))
-        alias ctorOverloadSet = OverloadSet!("__ctor", __traits(getOverloads, Base, "__ctor"));
+    static if (__traits(hasMember, Super, "__ctor"))
+        alias ctorOverloadSet = OverloadSet!("__ctor", __traits(getOverloads, Super, "__ctor"));
     else
         alias ctorOverloadSet = OverloadSet!("__ctor"); // empty
 
@@ -3924,6 +3946,41 @@ private static:
             void test_shared_const() shared const;
         }
         auto o = new BlackHole!I_8;
+    }
+    // use baseclass
+    {
+        static class C_9
+        {
+            private string foo_;
+
+            this(string s) {
+                foo_ = s;
+            }
+
+            protected string boilerplate() @property
+            {
+                return "Boilerplate stuff.";
+            }
+
+            public string foo() @property
+            {
+                return foo_;
+            }
+        }
+
+        interface I_10
+        {
+            string testMethod(size_t);
+        }
+
+        static string generateTestMethod(C, alias fun)() @property
+        {
+            return "return this.boilerplate[0 .. a0];";
+        }
+
+        auto o = new AutoImplement!(I_10, C_9, generateTestMethod)("Testing");
+        assert(o.testMethod(11) == "Boilerplate");
+        assert(o.foo == "Testing");
     }
     /+ // deep inheritance
     {


### PR DESCRIPTION
This PR adds an AutoImplement template very much like the existing one, but with the additional feature of deriving from a baseclass while auto-implementing an interface.