### PR TITLE
Unmarkdownify the secureCompare changelog entry

### DIFF
--- a/changelog/std-digest-digest-secureCompare.dd
+++ b/changelog/std-digest-digest-secureCompare.dd
@@ -6,7 +6,7 @@ constant time regardless of the equality of the two ranges in order to protect
 against timing attacks. For more information on the attack, please refer to
 the docs on $(REF secureEqual, std, digest, digest).
 
-```
+-----
 import std.digest.digest : secureEqual, toHexString;
 import std.digest.hmac : hmac;
 import std.digest.sha : SHA1;
@@ -26,4 +26,4 @@ void main()
     assert( secureEqual(hex1, hex2));
     assert(!secureEqual(hex1, hex3));
 }
-```
+-----


### PR DESCRIPTION
Unfortunately Ddoc doesn't support real Markdown. Imho we should extend the subset of Markdown that is accepted by Ddoc, but that's a challenge for another day.
This PR is simply intended to fix the changelog, as  it currently looks like this:

https://dlang.org/changelog/2.075.0_pre.html

![image](https://cloud.githubusercontent.com/assets/4370550/26320489/3fe11b3c-3f23-11e7-9cb3-2d793218a67b.png)