### PR TITLE
Add dontOptimizeAway to std.datetime.stopwatch

### DIFF
--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -393,7 +393,6 @@ private:
     auto timeElapsed = MonoTime.currTime - before;
 }
 
-
 /++
     Benchmarks code for speed assessment and comparison.
 
@@ -413,11 +412,25 @@ Duration[fun.length] benchmark(fun...)(uint n)
     Duration[fun.length] result;
     auto sw = StopWatch(AutoStart.yes);
 
-    foreach (i, unused; fun)
+    static foreach (i, unused; fun)
     {
         sw.reset();
         foreach (_; 0 .. n)
-            fun[i]();
+        {
+            static if (!is(typeof(fun[i]()) == void))
+            {
+                // avoid optimization
+                asm
+                {
+                    call [fun + i];
+                    ret;
+                }
+            }
+            else
+            {
+                fun[i]();
+            }
+        }
         result[i] = sw.peek();
     }
 


### PR DESCRIPTION
As mentioned on #5367, it would be great if the benchmarking function wouldn't allow compilers to optimize its to-be-tested functions away.

There are a couple of tricks to avoid this behavior, at least:
- assigning return value to `__gshared`
- using the `doNotOptimizeAway` trick (see below or #2995)
- [`@optStrategy("none)` in LDC](https://wiki.dlang.org/LDC-specific_language_changes#.40.28ldc.attributes.optStrategy.28.22strategy.22.29.29)
- ...

I guess this might be a controversial change, so I am very interested to hear your opinions. What strategy to avoid the optimization do you prefer?