### PR TITLE
Removed auto-decoding from the single needle version of startsWith

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4192,9 +4192,24 @@ bool startsWith(alias pred = "a == b", R, E)(R doesThisStart, E withThis)
 if (isInputRange!R &&
     is(typeof(binaryFun!pred(doesThisStart.front, withThis)) : bool))
 {
-    return doesThisStart.empty
-        ? false
-        : binaryFun!pred(doesThisStart.front, withThis);
+    if (doesThisStart.empty)
+        return false;
+
+    alias predFunc = binaryFun!pred;
+
+    // auto-decoding special case
+    static if (isNarrowString!R)
+    {
+        // specialize for ASCII as to not change previous behavior
+        if (withThis <= 0x7F)
+            return predFunc(doesThisStart[0], withThis);
+        else
+            return predFunc(doesThisStart.front, withThis);
+    }
+    else
+    {
+        return predFunc(doesThisStart.front, withThis);
+    }
 }
 
 /// Ditto


### PR DESCRIPTION
No need to auto decode if looking for a ASCII character

Results

```
$ ldc2 -O -release test.d && ./test
old	523 ms, 91 μs, and 5 hnsecs
new	302 ms, 142 μs, and 1 hnsec
```

Code

```d
import std.stdio;
import std.algorithm;
import std.conv;
import std.range;
import std.traits;
import std.string;
import std.datetime;
import std.functional;

enum testCount = 100_000_000;

bool startsWith1(alias pred = "a == b", R, E)(R doesThisStart, E withThis)
if (isInputRange!R &&
    is(typeof(binaryFun!pred(doesThisStart.front, withThis)) : bool))
{
   return doesThisStart.empty
       ? false
       : binaryFun!pred(doesThisStart.front, withThis);
}

bool startsWith2(alias pred = "a == b", R, E)(R doesThisStart, E withThis)
if (isInputRange!R &&
    is(typeof(binaryFun!pred(doesThisStart.front, withThis)) : bool))
{
    if (doesThisStart.empty)
        return false;

    // auto-decoding special case
    static if (isNarrowString!R && is(Unqual!(ElementEncodingType!R) == Unqual!E))
    {
        dchar front;
        if (withThis <= 0x7F)
            front = doesThisStart[0];
        else
            front = doesThisStart.front;
    }
    else
    {
        auto front = doesThisStart.front;
    }

    return binaryFun!pred(front, withThis);
}

void main()
{
    auto a = "+123456789";

    auto result = to!Duration(benchmark!(() => startsWith1(a, '+'))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => startsWith2(a, '+'))(testCount)[0]);

    writeln("old", "\t", result);
    writeln("new", "\t", result2);
}
```