### PR TITLE
Re-enable publictests checking on CircleCi

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -127,9 +127,16 @@ coverage()
     sed -i 's/^ *[0-9]*\(|.*nocoverage.*\)$/       \1/' ./*.lst
 }
 
+# extract publictests and run them independently
+publictests()
+{
+    make -f posix.mak -j$N publictests DUB=$DUB
+}
+
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     coverage) coverage ;;
+    publictests) publictests ;;
     style) style ;;
 esac

--- a/posix.mak
+++ b/posix.mak
@@ -588,15 +588,15 @@ style_lint: ../dscanner/dsc $(LIB)
 ################################################################################
 publictests: $(PUBLICTESTS)
 
-$(TEST_EXTRACTOR): $(TOOLS_DIR)/styles/tests_extractor.d
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --compiler=$${PWD}/$(DMD) --root=$(TOOLS_DIR)/styles -c tests_extractor
+$(TEST_EXTRACTOR): $(TOOLS_DIR)/styles/tests_extractor.d $(LIB)
+	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --root=$(TOOLS_DIR)/styles -c tests_extractor
 
 ################################################################################
 # Extract public tests of a module and test them in an separate file (i.e. without its module)
 # This is done to check for potentially missing imports in the examples, e.g.
 # make -f posix.mak std/format.publictests
 ################################################################################
-%.publictests: %.d $(LIB) $(TEST_EXTRACTOR)
+%.publictests: %.d $(LIB) $(TEST_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
 	@$(TEST_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
 	@$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main -unittest -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -7339,6 +7339,8 @@ public:
     ///
     @safe unittest
     {
+        import std.datetime.date : Date;
+
         auto st = SysTime(Date(1999, 7, 6));
         const cst = SysTime(Date(2010, 5, 1));
         immutable ist = SysTime(Date(2015, 10, 10));
@@ -8308,7 +8310,7 @@ public:
     ///
     @safe unittest
     {
-        import core.time : hours, msecs, usecs;
+        import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
         import std.datetime.timezone : SimpleTimeZone, UTC;
 
@@ -8557,7 +8559,7 @@ public:
     ///
     @safe unittest
     {
-        import core.time : hours, msecs, usecs;
+        import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
         import std.datetime.timezone : SimpleTimeZone, UTC;
 
@@ -8783,7 +8785,7 @@ public:
     ///
     @safe unittest
     {
-        import core.time : hours, msecs, usecs;
+        import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
         import std.datetime.timezone : SimpleTimeZone, UTC;
 


### PR DESCRIPTION
The publictests checking got accidentally broken as part of #5364 (and stayed silent, but green).
Luckily not much has slipped in since, so we better hurry to enable it again ...