### PR TITLE
Track errors that may happen in forked process on Posix

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1081,6 +1081,17 @@ version (Posix) @system unittest
     std.file.write(directory, "foo");
     scope(exit) remove(directory);
     assertThrown!ProcessException(spawnProcess([prog.path], null, Config.none, directory));
+
+    // can't run in directory if user does not have search permission on this directory
+    version(Posix)
+    {
+        import core.sys.posix.sys.stat : S_IRUSR;
+        auto directoryNoSearch = uniqueTempPath();
+        mkdir(directoryNoSearch);
+        scope(exit) rmdirRecurse(directoryNoSearch);
+        setAttributes(directoryNoSearch, S_IRUSR);
+        assertThrown!ProcessException(spawnProcess(prog.path, null, Config.none, directoryNoSearch));
+    }
 }
 
 @system unittest // Specifying empty working directory.

--- a/std/process.d
+++ b/std/process.d
@@ -559,7 +559,7 @@ private Pid spawnProcessImpl(in char[][] args,
             string errorMsg;
             readExecResult = read(forkPipe[0], &error, error.sizeof);
 
-            switch (status)
+            final switch (status)
             {
                 case InternalError.chdir:
                     errorMsg = "Failed to set working directory";
@@ -570,8 +570,8 @@ private Pid spawnProcessImpl(in char[][] args,
                 case InternalError.exec:
                     errorMsg = "Failed to execute program";
                     break;
-                default:
-                    assert(0);
+                case InternalError.noerror:
+                    assert(false);
             }
 
             if (readExecResult == error.sizeof) {

--- a/std/process.d
+++ b/std/process.d
@@ -434,16 +434,6 @@ private Pid spawnProcessImpl(in char[][] args,
         assert(0);
     }
 
-    static void ignorePipeErrors() nothrow
-    {
-        import core.sys.posix.signal;
-        import core.stdc.string : memset;
-        sigaction_t ignoreAction;
-        memset(&ignoreAction, 0, sigaction_t.sizeof);
-        ignoreAction.sa_handler = SIG_IGN;
-        sigaction(SIGPIPE, &ignoreAction, null);
-    }
-
     auto id = core.sys.posix.unistd.fork();
     if (id < 0)
     {
@@ -458,7 +448,6 @@ private Pid spawnProcessImpl(in char[][] args,
 
         // Child process
 
-        ignorePipeErrors();
         // no need for the read end of pipe on child side
         close(forkPipe[0]);
         immutable forkPipeOut = forkPipe[1];
@@ -570,7 +559,7 @@ private Pid spawnProcessImpl(in char[][] args,
             string errorMsg;
             readExecResult = read(forkPipe[0], &error, error.sizeof);
 
-            switch(status)
+            switch (status)
             {
                 case InternalError.chdir:
                     errorMsg = "Failed to set working directory";
@@ -582,8 +571,7 @@ private Pid spawnProcessImpl(in char[][] args,
                     errorMsg = "Failed to execute program";
                     break;
                 default:
-                    errorMsg = "Unknown error occured";
-                    break;
+                    assert(0);
             }
 
             if (readExecResult == error.sizeof) {

--- a/std/process.d
+++ b/std/process.d
@@ -1053,6 +1053,19 @@ version (Posix) @system unittest
     import std.exception : assertThrown;
     assertThrown!ProcessException(spawnProcess("ewrgiuhrifuheiohnmnvqweoijwf"));
     assertThrown!ProcessException(spawnProcess("./rgiuhrifuheiohnmnvqweoijwf"));
+
+    // can't execute malformed file with executable permissions
+    version(Posix)
+    {
+        import std.path : buildPath;
+        import std.file : remove, write, setAttributes;
+        import core.sys.posix.sys.stat : S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IXGRP, S_IROTH, S_IXOTH;
+        string deleteme = buildPath(tempDir(), "deleteme.std.process.unittest.pid") ~ to!string(thisProcessID);
+        write(deleteme, "");
+        scope(exit) remove(deleteme);
+        setAttributes(deleteme, S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+        assertThrown!ProcessException(spawnProcess(deleteme));
+    }
 }
 
 @system unittest // Specifying a working directory.

--- a/std/process.d
+++ b/std/process.d
@@ -333,6 +333,14 @@ Pid spawnProcess(in char[] program,
     return spawnProcess((&program)[0 .. 1], env, config, workDir);
 }
 
+version(Posix) private enum InternalError : ubyte
+{
+    noerror,
+    exec,
+    chdir,
+    getrlimit
+}
+
 /*
 Implementation of spawnProcess() for POSIX.
 
@@ -406,9 +414,42 @@ private Pid spawnProcessImpl(in char[][] args,
     auto stdoutFD = getFD(stdout);
     auto stderrFD = getFD(stderr);
 
+    int[2] forkPipe;
+    if (core.sys.posix.unistd.pipe(forkPipe) == 0)
+    {
+        setCLOEXEC(forkPipe[1], true);
+    }
+    else
+    {
+        throw ProcessException.newFromErrno("Could not create pipe to check startup of child");
+    }
+    scope(exit) close(forkPipe[0]);
+
+    static void abortOnError(int forkPipeOut, InternalError errorType, int error) nothrow
+    {
+        core.sys.posix.unistd.write(forkPipeOut, &errorType, errorType.sizeof);
+        core.sys.posix.unistd.write(forkPipeOut, &error, error.sizeof);
+        close(forkPipeOut);
+        core.sys.posix.unistd._exit(1);
+        assert(0);
+    }
+
+    static void ignorePipeErrors() nothrow
+    {
+        import core.sys.posix.signal;
+        import core.stdc.string : memset;
+        sigaction_t ignoreAction;
+        memset(&ignoreAction, 0, sigaction_t.sizeof);
+        ignoreAction.sa_handler = SIG_IGN;
+        sigaction(SIGPIPE, &ignoreAction, null);
+    }
+
     auto id = core.sys.posix.unistd.fork();
     if (id < 0)
+    {
+        close(forkPipe[1]);
         throw ProcessException.newFromErrno("Failed to spawn new process");
+    }
 
     void forkChild() nothrow @nogc
     {
@@ -417,6 +458,11 @@ private Pid spawnProcessImpl(in char[][] args,
 
         // Child process
 
+        ignorePipeErrors();
+        // no need for the read end of pipe on child side
+        close(forkPipe[0]);
+        immutable forkPipeOut = forkPipe[1];
+
         // Set the working directory.
         if (workDirFD >= 0)
         {
@@ -424,10 +470,7 @@ private Pid spawnProcessImpl(in char[][] args,
             {
                 // Fail. It is dangerous to run a program
                 // in an unexpected working directory.
-                core.sys.posix.stdio.perror("spawnProcess(): " ~
-                    "Failed to set working directory");
-                core.sys.posix.unistd._exit(1);
-                assert(0);
+                abortOnError(forkPipeOut, InternalError.chdir, .errno);
             }
             close(workDirFD);
         }
@@ -456,9 +499,7 @@ private Pid spawnProcessImpl(in char[][] args,
             rlimit r;
             if (getrlimit(RLIMIT_NOFILE, &r) != 0)
             {
-                core.sys.posix.stdio.perror("getrlimit");
-                core.sys.posix.unistd._exit(1);
-                assert(0);
+                abortOnError(forkPipeOut, InternalError.getrlimit, .errno);
             }
             immutable maxDescriptors = cast(int) r.rlim_cur;
 
@@ -477,6 +518,8 @@ private Pid spawnProcessImpl(in char[][] args,
             {
                 foreach (i; 0 .. maxToClose)
                 {
+                    // don't close pipe write end
+                    if (pfds[i].fd == forkPipeOut) continue;
                     // POLLNVAL will be set if the file descriptor is invalid.
                     if (!(pfds[i].revents & POLLNVAL)) close(pfds[i].fd);
                 }
@@ -484,7 +527,11 @@ private Pid spawnProcessImpl(in char[][] args,
             else
             {
                 // Fall back to closing everything.
-                foreach (i; 3 .. maxDescriptors) close(i);
+                foreach (i; 3 .. maxDescriptors)
+                {
+                    if (i == forkPipeOut) continue;
+                    close(i);
+                }
             }
         }
         else
@@ -501,8 +548,7 @@ private Pid spawnProcessImpl(in char[][] args,
         core.sys.posix.unistd.execve(argz[0], argz.ptr, envz);
 
         // If execution fails, exit as quickly as possible.
-        core.sys.posix.stdio.perror("spawnProcess(): Failed to execute program");
-        core.sys.posix.unistd._exit(1);
+        abortOnError(forkPipeOut, InternalError.exec, .errno);
     }
 
     if (id == 0)
@@ -512,6 +558,41 @@ private Pid spawnProcessImpl(in char[][] args,
     }
     else
     {
+        close(forkPipe[1]);
+        auto status = InternalError.noerror;
+        auto readExecResult = core.sys.posix.unistd.read(forkPipe[0], &status, status.sizeof);
+        if (readExecResult == -1)
+            throw ProcessException.newFromErrno("Could not read from pipe to get child status");
+
+        if (status != InternalError.noerror)
+        {
+            int error;
+            string errorMsg;
+            readExecResult = read(forkPipe[0], &error, error.sizeof);
+
+            switch(status)
+            {
+                case InternalError.chdir:
+                    errorMsg = "Failed to set working directory";
+                    break;
+                case InternalError.getrlimit:
+                    errorMsg = "getrlimit failed";
+                    break;
+                case InternalError.exec:
+                    errorMsg = "Failed to execute program";
+                    break;
+                default:
+                    errorMsg = "Unknown error occured";
+                    break;
+            }
+
+            if (readExecResult == error.sizeof) {
+                throw ProcessException.newFromErrno(error, errorMsg);
+            } else {
+                throw new ProcessException(errorMsg);
+            }
+        }
+
         // Parent process:  Close streams and return.
         if (!(config & Config.retainStdin ) && stdinFD  > STDERR_FILENO
                                             && stdinFD  != getFD(std.stdio.stdin ))
@@ -2329,18 +2410,27 @@ class ProcessException : Exception
                                          size_t line = __LINE__)
     {
         import core.stdc.errno : errno;
+        return newFromErrno(errno, customMsg, file, line);
+    }
+
+    // ditto, but error number is provided by caller
+    static ProcessException newFromErrno(int error,
+                                         string customMsg = null,
+                                         string file = __FILE__,
+                                         size_t line = __LINE__)
+    {
         import std.conv : to;
         version (CRuntime_Glibc)
         {
             import core.stdc.string : strerror_r;
             char[1024] buf;
             auto errnoMsg = to!string(
-                core.stdc.string.strerror_r(errno, buf.ptr, buf.length));
+                core.stdc.string.strerror_r(error, buf.ptr, buf.length));
         }
         else
         {
             import core.stdc.string : strerror;
-            auto errnoMsg = to!string(strerror(errno));
+            auto errnoMsg = to!string(strerror(error));
         }
         auto msg = customMsg.empty ? errnoMsg
                                    : customMsg ~ " (" ~ errnoMsg ~ ')';


### PR DESCRIPTION
This commit changes behavior of spawnProcess on Posix.
Previously spawnProcess just reported child errors via perror. But the true D way is to throw exception. The problem is that it's not easy to transfer error from forked process to parent. This commit uses pipes to solve this problem.
This commit also adds new overload for ProcessException.newFromErrno that allows to create exception object from arbitrary error number, not just from the current value of errno.

To check that it works:
```
touch emptyfile
chmod +x emptyfile
```

Then use spawnProcess on emptyfile. The old phobos will just report error to stderr. The patched one will throw an exception with message saying that exec format is invalid.