### PR TITLE
Document std.complex .im 0 initialization

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -22,11 +22,10 @@ import std.traits;
 
     Params:
         R = (template parameter) type of real part of complex number
-        I = (template parameter) type of imaginary part of complex number,
-            0 if omitted.
+        I = (template parameter) type of imaginary part of complex number
 
         re = real part of complex number to be constructed
-        im = (optional) imaginary part of complex number
+        im = (optional) imaginary part of complex number, 0 if omitted.
 
     Returns:
         $(D Complex) instance with real and imaginary parts set

--- a/std/complex.d
+++ b/std/complex.d
@@ -22,7 +22,8 @@ import std.traits;
 
     Params:
         R = (template parameter) type of real part of complex number
-        I = (template parameter) type of imaginary part of complex number
+        I = (template parameter) type of imaginary part of complex number,
+            0 if omitted.
 
         re = real part of complex number to be constructed
         im = (optional) imaginary part of complex number
@@ -162,18 +163,25 @@ if (isFloatingPoint!T)
 
 @safe pure nothrow @nogc:
 
+    /** Construct a complex number with the specified real and
+    imaginary parts. In the case where a single argument is passed
+    that is not complex, the imaginary part of the result will be
+    zero.
+    */
     this(R : T)(Complex!R z)
     {
         re = z.re;
         im = z.im;
     }
 
+    /// ditto
     this(Rx : T, Ry : T)(Rx x, Ry y)
     {
         re = x;
         im = y;
     }
 
+    /// ditto
     this(R : T)(R r)
     {
         re = r;


### PR DESCRIPTION
Seeing as the constructors weren't documented, I half-expected there were none and that therefore `Complex!double(0)` would leave `.im == double.nan`