### PR TITLE
Simplify and improve format positional argument output (+bonus test)

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -6055,3 +6055,10 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
     tmp = format("%19,?f", '.', -1234567.891011);
     assert(tmp == " -1.234.567.891.011", "'" ~ tmp ~ "'");
 }
+
+// Test for multiple indexes
+@safe unittest
+{
+    auto tmp = format("%2:5$s", 1, 2, 3, 4, 5);
+    assert(tmp == "2345", tmp);
+}


### PR DESCRIPTION
The first commit adds a test for a previously-untested / undocumented feature of `std.format`.
I didn't add documentation for it (it seems very non-standard and of little use), but since it's here, it should be tested to ensure no regression happens.

The second commit modernizes the code which calls `formatValue`. Commit message below:

```
The previous code was needlessly complicated, storing arguments' as `void*` in an array,
and having a matching array of delegates to cast them.
It was not ctfe-able which required an extra code path, and tricks such as an artificial call to the `formatValue` function to ensure correct inference of `@safe`ty.

The new code do away with those limitations by simply using a switch of which branches are CT-generated.
This simple technique makes the code faster, as less instructions are generated, inlining is possible, and a switch with not so many cases will usually result in a jump table being generated.
```

For reference I have the following test:
```D
version (Phobos)
{
    import std.format : sformat = formattedWrite;

    static immutable Formats = [
        "Hello world this is a text only string and should be super fast to copy",
        "This %s on %s other %s has %s lot %s useless %s. Let's also format an %s: %d",
        "%0f %1f %2d %3s"
    ];
}


void main ()
{
    size_t index;
    char[4096] buffer;
    scope writer = (const(char)[] s) { buffer[index .. index + s.length] = s[]; return index += s.length; };
    static assert(isOutputRange!(typeof(writer), char));

    foreach (i; 0 .. 10_000_000)
    {
     	index = 0;

	sformat(writer, Formats[0]);
	sformat(writer, Formats[1], "is", "adasdasd", "sfdsdfsdfs", "the",
		"hand", "fgiofgdfg", "sdfsdfsdf", 42424242);
        sformat(writer, Formats[2], 42.0f, float.init, 0x2A, "Hello world");
    }
```

Was originally benchmarking against Ocean's Formatter hence the slightly complicated code.
From a naive run:
```
% for i in {1..10}; do time ./oldversion; done
./oldversion  18.44s user 0.00s system 99% cpu 18.490 total
./oldversion  18.47s user 0.00s system 100% cpu 18.474 total
./oldversion  18.54s user 0.00s system 100% cpu 18.537 total
./oldversion  18.53s user 0.00s system 100% cpu 18.536 total
./oldversion  18.51s user 0.00s system 100% cpu 18.508 total
./oldversion  18.51s user 0.00s system 100% cpu 18.511 total
./oldversion  18.48s user 0.00s system 100% cpu 18.484 total
./oldversion  18.53s user 0.00s system 99% cpu 18.537 total
./oldversion  18.56s user 0.00s system 100% cpu 18.559 total
./oldversion  18.48s user 0.00s system 100% cpu 18.480 total
% for i in {1..10}; do time ./newversion; done
./newversion  17.96s user 0.00s system 100% cpu 17.962 total
./newversion  17.85s user 0.00s system 100% cpu 17.857 total
./newversion  17.84s user 0.00s system 100% cpu 17.843 total
./newversion  17.89s user 0.00s system 99% cpu 17.891 total
./newversion  17.87s user 0.00s system 100% cpu 17.872 total
./newversion  17.86s user 0.00s system 100% cpu 17.860 total
./newversion  17.85s user 0.00s system 100% cpu 17.848 total
./newversion  17.84s user 0.00s system 100% cpu 17.835 total
./newversion  18.03s user 0.00s system 100% cpu 18.031 total
./newversion  17.85s user 0.00s system 100% cpu 17.846 total
```

Which means a consistent 3% speedup. Not huge but since it also simplifies the code a lot, it's a win-win.