### PR TITLE
std.math.ieeeMean: Fix for 128 bit reals

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6823,8 +6823,8 @@ body
         ulong *yl = cast(ulong *)&y;
         ulong m = (((*xl) & 0x7FFF_FFFF_FFFF_FFFFL)
                    + ((*yl) & 0x7FFF_FFFF_FFFF_FFFFL)) >>> 1;
-                   m |= ((*xl) & 0x8000_0000_0000_0000L);
-                   *ul = m;
+        m |= ((*xl) & 0x8000_0000_0000_0000L);
+        *ul = m;
     }
     else static if (F.realFormat == RealFormat.ieeeSingle)
     {


### PR DESCRIPTION
The implementation previously failed the existing tests.

Verified on LDC/AArch64.