### PR TITLE
[Trivial] Hide bugfix unittest from ddoc.

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -503,7 +503,10 @@ template NoDuplicates(TList...)
 
     alias TL = NoDuplicates!(Types);
     static assert(is(TL == AliasSeq!(int, long, float)));
+}
 
+@safe unittest
+{
     // Bugzilla 14561: huge enums
     alias LongList = Repeat!(1500, int);
     static assert(NoDuplicates!LongList.length == 1);


### PR DESCRIPTION
This particular unittest does not give any additional information to the user, and the bugzilla note only serves to confuse. So it should not be part of the ddoc'd unittest.