### PR TITLE
Immediately send CodeCov notifications

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,10 @@
 # Documentation: https://github.com/codecov/support/wiki/codecov.yml
 
 codecov:
+  ci:
+    - "circleci.com"
+  notify:
+    after_n_builds: 1  # send notifications after the first upload
   bot: dlang-bot
 
 coverage:


### PR DESCRIPTION
Apparently CodeCov seems to wait until all CIs have finished:

![image](https://user-images.githubusercontent.com/4370550/26976482-3d3e517e-4d24-11e7-8ab0-3588e3cd44a0.png)

This is based on a CodeCov issue I found:

https://github.com/codecov/support/issues/312

On the CodeCov side it looks like this:

![image](https://user-images.githubusercontent.com/4370550/26976597-c4648a1a-4d24-11e7-97ab-11e1bf6bbea8.png)