### PR TITLE
DList mutation: popFirstOf and popLastOf

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -872,6 +872,19 @@ private:
     r.popBack();
     dl.popLastOf(r);
     assert(equal(dl[], [1, 3, 5]));
+    DList!int empty_list;
+    dl.popFirstOf(empty_list[]);
+    assert(equal(dl[], [1, 3, 5]));
+    dl.popLastOf(empty_list[]);
+    assert(equal(dl[], [1, 3, 5]));
+    dl = DList!int([0]);
+    r = dl[];
+    dl.popFirstOf(r);
+    assert(dl.empty);
+    dl = DList!int([0]);
+    r = dl[];
+    dl.popLastOf(r);
+    assert(dl.empty);
 }
 
 @safe unittest

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -630,6 +630,54 @@ Complexity: $(BIGOH 1)
     }
 
 /**
+Removes first element of $(D r), wich must be a range obrained originally
+from this container.
+
+Returns: A range spanning the remaining elements in the container that
+initially were right after the first element of $(D r).
+
+Compexity: $(BIGOH 1)
+     */
+    Range popFirstOf(Range r)
+    {
+        if (r.empty)
+            return r;
+
+        assert(_root !is null, "Cannot remove from an un-initialized List");
+        assert(r._first, "Remove: Range is empty");
+        BaseNode.connect(r._first._prev, r._first._next);
+        auto after = r._first._next;
+        if (after is _root)
+            return Range(null, null);
+        else
+            return Range(after, _last);
+    }
+
+/**
+Removes last element of $(D r), wich must be a range obrained originally
+from this container.
+
+Returns: A range spanning the remaining elements in the container that
+initially were right before the last element of $(D r).
+
+Compexity: $(BIGOH 1)
+     */
+    Range popLastOf(Range r)
+    {
+        if (r.empty)
+            return r;
+
+        assert(_root !is null, "Cannot remove from an un-initialized List");
+        assert(r._last, "Remove: Range is empty");
+        BaseNode.connect(r._last._prev, r._last._next);
+        auto before = r._last._prev;
+        if (before is _root)
+            return Range(null, null);
+        else
+            return Range(_first, before);
+    }
+
+/**
 $(D linearRemove) functions as $(D remove), but also accepts ranges that are
 result the of a $(D take) operation. This is a convenient way to remove a
 fixed amount of elements from the range.
@@ -810,6 +858,20 @@ private:
         }
     }
     assert(equal(list[],[0,3]));
+}
+
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    auto dl = DList!int([1, 2, 3, 4, 5]);
+    auto r = dl[];
+    r.popFront();
+    dl.popFirstOf(r);
+    assert(equal(dl[], [1, 3, 4, 5]));
+    r.popBack();
+    dl.popLastOf(r);
+    assert(equal(dl[], [1, 3, 5]));
 }
 
 @safe unittest

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -52,9 +52,11 @@ module std.container.dlist;
 
     // DList.Range can be used to remove elements from the list
     auto nl = DList!int([1, 2, 3, 4, 5]);
-    for (auto rn = nl[]; !rn.empty; rn.popFront())
+    for (auto rn = nl[]; !rn.empty;)
         if (rn.front % 2 == 0)
-            nl.popFirstOf(rn);
+            rn = nl.popFirstOf(rn);
+        else
+            rn.popFront();
     assert(equal(nl[], [1, 3, 5]));
     auto rs = nl[];
     rs.popFront();
@@ -637,15 +639,14 @@ Complexity: $(BIGOH 1)
     /// ditto
     Range linearRemove(Range r)
     {
-         return remove(r);
+        return remove(r);
     }
 
 /**
 Removes first element of $(D r), wich must be a range obrained originally
 from this container.
 
-Returns: A range spanning the remaining elements in the container that
-initially were right after the first element of $(D r).
+Returns: A range spanning the remaining elements of $(D r).
 
 Compexity: $(BIGOH 1)
      */
@@ -658,15 +659,14 @@ Compexity: $(BIGOH 1)
         assert(r._first, "Remove: Range is empty");
         BaseNode.connect(r._first._prev, r._first._next);
         auto after = r._first._next;
-        return after is _root ? Range(null, null) : Range(after, _last);
+        return after is _root ? Range(null, null) : Range(after, r._last);
     }
 
 /**
 Removes last element of $(D r), wich must be a range obrained originally
 from this container.
 
-Returns: A range spanning the remaining elements in the container that
-initially were right before the last element of $(D r).
+Returns: A range spanning the remaining elements of $(D r).
 
 Compexity: $(BIGOH 1)
      */
@@ -679,7 +679,7 @@ Compexity: $(BIGOH 1)
         assert(r._last, "Remove: Range is empty");
         BaseNode.connect(r._last._prev, r._last._next);
         auto before = r._last._prev;
-        return before is _root ? Range(null, null) : Range(_first, before);
+        return before is _root ? Range(null, null) : Range(r._first, before);
     }
 
 /**
@@ -878,7 +878,7 @@ private:
     r.popBack();
     auto before = dl.popLastOf(r);
     assert(equal(dl[], [1, 3, 5]));
-    assert(equal(before, [1, 3]));
+    assert(equal(before, [3]));
     DList!int empty_list;
     dl.popFirstOf(empty_list[]);
     assert(equal(dl[], [1, 3, 5]));

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -643,8 +643,8 @@ Complexity: $(BIGOH 1)
     }
 
 /**
-Removes first element of $(D r), wich must be a range obrained originally
-from this container, from both DList instance and range.
+Removes first element of $(D r), wich must be a range obtained originally
+from this container, from both DList instance and range $(D r).
 
 Compexity: $(BIGOH 1)
      */
@@ -659,8 +659,8 @@ Compexity: $(BIGOH 1)
     }
 
 /**
-Removes last element of $(D r), wich must be a range obrained originally
-from this container, from both DList instance and range.
+Removes last element of $(D r), wich must be a range obtained originally
+from this container, from both DList instance and range $(D r).
 
 Compexity: $(BIGOH 1)
      */

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -50,11 +50,11 @@ module std.container.dlist;
     assert(r.equal([3]));
     assert(walkLength(r) == 1);
 
-    // DList.Range can be used to remove elements from the list
+    // DList.Range can be used to remove elements from the list it spans
     auto nl = DList!int([1, 2, 3, 4, 5]);
     for (auto rn = nl[]; !rn.empty;)
         if (rn.front % 2 == 0)
-            rn = nl.popFirstOf(rn);
+            nl.popFirstOf(rn);
         else
             rn.popFront();
     assert(equal(nl[], [1, 3, 5]));
@@ -644,42 +644,34 @@ Complexity: $(BIGOH 1)
 
 /**
 Removes first element of $(D r), wich must be a range obrained originally
-from this container.
-
-Returns: A range spanning the remaining elements of $(D r).
+from this container, from both DList instance and range.
 
 Compexity: $(BIGOH 1)
      */
-    Range popFirstOf(Range r)
+    void popFirstOf(ref Range r)
     {
-        if (r.empty)
-            return r;
-
         assert(_root !is null, "Cannot remove from an un-initialized List");
-        assert(r._first, "Remove: Range is empty");
-        BaseNode.connect(r._first._prev, r._first._next);
-        auto after = r._first._next;
-        return after is _root ? Range(null, null) : Range(after, r._last);
+        assert(r._first, "popFirstOf: Range is empty");
+        auto prev = r._first._prev;
+        auto next = r._first._next;
+        r.popFront();
+        BaseNode.connect(prev, next);
     }
 
 /**
 Removes last element of $(D r), wich must be a range obrained originally
-from this container.
-
-Returns: A range spanning the remaining elements of $(D r).
+from this container, from both DList instance and range.
 
 Compexity: $(BIGOH 1)
      */
-    Range popLastOf(Range r)
+    void popLastOf(ref Range r)
     {
-        if (r.empty)
-            return r;
-
         assert(_root !is null, "Cannot remove from an un-initialized List");
-        assert(r._last, "Remove: Range is empty");
-        BaseNode.connect(r._last._prev, r._last._next);
-        auto before = r._last._prev;
-        return before is _root ? Range(null, null) : Range(r._first, before);
+        assert(r._first, "popLastOf: Range is empty");
+        auto prev = r._last._prev;
+        auto next = r._last._next;
+        r.popBack();
+        BaseNode.connect(prev, next);
     }
 
 /**
@@ -872,18 +864,13 @@ private:
     auto dl = DList!int([1, 2, 3, 4, 5]);
     auto r = dl[];
     r.popFront();
-    auto after = dl.popFirstOf(r);
+    dl.popFirstOf(r);
     assert(equal(dl[], [1, 3, 4, 5]));
-    assert(equal(after, [3, 4, 5]));
+    assert(equal(r, [3, 4, 5]));
     r.popBack();
     auto before = dl.popLastOf(r);
     assert(equal(dl[], [1, 3, 5]));
-    assert(equal(before, [3]));
-    DList!int empty_list;
-    dl.popFirstOf(empty_list[]);
-    assert(equal(dl[], [1, 3, 5]));
-    dl.popLastOf(empty_list[]);
-    assert(equal(dl[], [1, 3, 5]));
+    assert(equal(r, [3]));
     dl = DList!int([0]);
     r = dl[];
     dl.popFirstOf(r);

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -868,7 +868,7 @@ private:
     assert(equal(dl[], [1, 3, 4, 5]));
     assert(equal(r, [3, 4, 5]));
     r.popBack();
-    auto before = dl.popLastOf(r);
+    dl.popLastOf(r);
     assert(equal(dl[], [1, 3, 5]));
     assert(equal(r, [3]));
     dl = DList!int([0]);

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -49,6 +49,17 @@ module std.container.dlist;
     popBackN(r, 2);
     assert(r.equal([3]));
     assert(walkLength(r) == 1);
+
+    // DList.Range can be used to remove elements from the list
+    auto nl = DList!int([1, 2, 3, 4, 5]);
+    for (auto rn = nl[]; !rn.empty; rn.popFront())
+        if (rn.front % 2 == 0)
+            nl.popFirstOf(rn);
+    assert(equal(nl[], [1, 3, 5]));
+    auto rs = nl[];
+    rs.popFront();
+    nl.remove(rs);
+    assert(equal(nl[], [1]));
 }
 
 import std.range.primitives;
@@ -647,10 +658,7 @@ Compexity: $(BIGOH 1)
         assert(r._first, "Remove: Range is empty");
         BaseNode.connect(r._first._prev, r._first._next);
         auto after = r._first._next;
-        if (after is _root)
-            return Range(null, null);
-        else
-            return Range(after, _last);
+        return after is _root ? Range(null, null) : Range(after, _last);
     }
 
 /**
@@ -671,10 +679,7 @@ Compexity: $(BIGOH 1)
         assert(r._last, "Remove: Range is empty");
         BaseNode.connect(r._last._prev, r._last._next);
         auto before = r._last._prev;
-        if (before is _root)
-            return Range(null, null);
-        else
-            return Range(_first, before);
+        return before is _root ? Range(null, null) : Range(_first, before);
     }
 
 /**
@@ -867,11 +872,13 @@ private:
     auto dl = DList!int([1, 2, 3, 4, 5]);
     auto r = dl[];
     r.popFront();
-    dl.popFirstOf(r);
+    auto after = dl.popFirstOf(r);
     assert(equal(dl[], [1, 3, 4, 5]));
+    assert(equal(after, [3, 4, 5]));
     r.popBack();
-    dl.popLastOf(r);
+    auto before = dl.popLastOf(r);
     assert(equal(dl[], [1, 3, 5]));
+    assert(equal(before, [1, 3]));
     DList!int empty_list;
     dl.popFirstOf(empty_list[]);
     assert(equal(dl[], [1, 3, 5]));


### PR DESCRIPTION
There are currently two ways to remove elements from DList while iterating over it:
* using `Range remove(Range r)` wich takes private DList.Range as a parameter.
* using `Range linearRemove(Take!Range r)` with r being of type Take!(DList.Range).

Both ways are unable to provide an efficient solution to the following problem:
`While iterating the list backwards, remove arbitrary elements.`

Two proposed methods exploit cursor nature of ranges, and provide means to remove elements form the list while iterating over it, in one loop.

Additionaly, I would like to bring up the idea of further encouragement of cursor properties of ranges in Phobos. Quick glance at std.container shows, that many of them share the abovementioned problem, or rely on Take!Range and may or may not be optimal (depends on the compiler) for one-element removals, invoked by take(r, 1).

Please, correct me if I'm wrong.