### PR TITLE
Convert range constraints to Conjunctive Normal Form

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -772,9 +772,8 @@ object with $(D save) and using it later.
  */
 template isForwardRange(R)
 {
-    enum bool isForwardRange = isInputRange!R &&
-        is(typeof((ref R r) => r.save) : R function(ref R));
-        //hasGetter!(R, "save", R);
+    enum bool isForwardRange = isInputRange!R
+        && hasGetter!(R, "save", "std.range.primitives", R);
 }
 
 ///
@@ -813,9 +812,9 @@ $(UL $(LI $(D r.back) returns (possibly a reference to) the last
 element in the range. Calling $(D r.back) is allowed only if calling
 $(D r.empty) has, or would have, returned $(D false).))
  */
-enum bool isBidirectionalRange(R) = isForwardRange!R &&
-    is(typeof((ref R r) => r.popBack)) &&
-    is(typeof((ref R r) => r.back) : ElementType!R function(ref R));
+enum bool isBidirectionalRange(R) = isForwardRange!R
+    && hasGetter!(R, "popBack", "std.range.primitives")
+    && hasGetter!(R, "back", "std.range.primitives", ElementType!R);
 
 ///
 @safe unittest
@@ -875,7 +874,8 @@ variable-length encodings (UTF-8 and UTF-16 respectively). These types
 are bidirectional ranges only.
  */
 enum bool isRandomAccessRange(R) =
-    is(typeof((ref R r) => r[1]) : ElementType!R function(ref R))
+    //is(typeof((ref R r) => r[1]) : ElementType!R function(ref R))
+     is(IndexedType!(R, int, void) == ElementType!R)
     && !isNarrowString!R
     && (hasLength!R || isInfinite!R)
     && (isBidirectionalRange!R || isForwardRange!R && isInfinite!R)

--- a/std/traits.d
+++ b/std/traits.d
@@ -8021,7 +8021,8 @@ unittest
 enum bool callSupported(alias fun, string imports, Arg...) =
     is(typeof((ref Arg arg)
         {
-            static if (imports.length) mixin("import " ~ imports ~ ";"); fun(arg);
+            static if (imports.length) mixin("import " ~ imports ~ ";");
+            fun(arg);
         }
     ));
 
@@ -8040,4 +8041,62 @@ unittest
     static assert(callSupported!(fun, "", int, string));
     static assert(callSupported!(fun, "", short, string));
     static assert(!callSupported!(fun, "", double, string));
+}
+
+alias IndexedType(T, Index) =
+    typeof(((T* p, Index* i) => (*p)[*i])(null, null));
+///
+template IndexedType(T, Index, Default)
+{
+    static if (is(IndexedType!(T, Index) X))
+        alias IndexedType = X;
+    else
+        alias IndexedType = Default;
+}
+
+enum bool hasIndexing(T, Index, R) =
+    is(typeof(((T* p, Index* i) => (*p)[*i])(null, null)) == R);
+
+///
+unittest
+{
+    static assert(!hasIndexing!(int, size_t, int));
+    static assert(hasIndexing!(int[], size_t, int));
+}
+
+alias OpDollarType(T) = typeof(((T* p) => (*p)[$])(null));
+///
+template OpDollarType(T, Default)
+{
+    static if (is(OpDollarType!T X))
+        alias OpDollarType = X;
+    else
+        alias OpDollarType = Default;
+}
+
+///
+unittest
+{
+    static assert(is(OpDollarType!(int, void) == void));
+    static assert(is(OpDollarType!(int[], void) == int));
+    static assert(is(OpDollarType!(int[]) == int));
+}
+
+enum bool opDollarArrayCompatibleIfDefined(R) =
+    is(typeof((ref R r)
+    {
+        static if (is(typeof(r[$]) E))
+        {
+            import std.range.primitives;
+            static assert(is(E == ElementType!R));
+            static if (!isInfinite!R)
+                static assert(is(typeof(r[$ - 1]) == ElementType!R));
+        }
+    }));
+
+///
+unittest
+{
+    static assert(opDollarArrayCompatibleIfDefined!(int));
+    static assert(opDollarArrayCompatibleIfDefined!(int[]));
 }

--- a/std/traits.d
+++ b/std/traits.d
@@ -7989,3 +7989,55 @@ enum isCopyable(S) = is(typeof(
     static assert(isCopyable!C1);
     static assert(isCopyable!int);
 }
+
+enum bool hasGetter(T, string name, string imports, Result) =
+    is(typeof( ((T* x)
+        {
+            static if (imports.length)
+                mixin("import " ~ imports ~ ";");
+            return mixin("(*x)." ~ name);
+        }
+    )(null) ) == Result);
+
+enum bool hasGetter(T, string name, Result) =
+    hasGetter!(T, name, "", Result);
+
+enum bool hasGetter(T, string name, string imports) =
+    is(typeof(((T* x)
+        {
+            static if (imports.length)
+                mixin("import " ~ imports ~ ";");
+            return mixin("(*x)." ~ name);
+        }
+    )(null)));
+
+///
+unittest
+{
+    static assert(!hasGetter!(int, "empty", "std.range.primitives", bool));
+    static assert(hasGetter!(int[], "empty", "std.range.primitives", bool));
+}
+
+enum bool callSupported(alias fun, string imports, Arg...) =
+    is(typeof((ref Arg arg)
+        {
+            static if (imports.length) mixin("import " ~ imports ~ ";"); fun(arg);
+        }
+    ));
+
+enum bool callSupported(string fun, string imports, Arg...) =
+    is(typeof((ref Arg arg)
+        {
+            static if (imports.length) mixin("import " ~ imports ~ ";");
+            mixin(fun ~ "(arg);");
+        }
+    ));
+
+///
+unittest
+{
+    static void fun(int, string);
+    static assert(callSupported!(fun, "", int, string));
+    static assert(callSupported!(fun, "", short, string));
+    static assert(!callSupported!(fun, "", double, string));
+}


### PR DESCRIPTION
Convert the currently opaque and unstructured constraints for ranges to simple CNF formulae. This makes the constraints simpler and clearer. But the largest opportunity is having the compiler recognize these formulae and print the failing clause. There are plans to include a mechanism for user-defined messages, too.