### PR TITLE
Fix CircleCi: actually run the style targets

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -95,7 +95,7 @@ setup_repos()
 }
 
 # verify style guide
-style()
+style_lint()
 {
     # dscanner needs a more up-to-date DMD version
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
@@ -105,7 +105,7 @@ style()
     # fix to a specific version of https://github.com/dlang/tools/tree/master/styles
     git -C ../tools checkout 60583c8363ff25d00017dffdb18c7ee7e7d9a343
 
-    make -f posix.mak style DUB=$DUB
+    make -f posix.mak style_lint DUB=$DUB
 }
 
 # run unittest with coverage
@@ -133,10 +133,18 @@ publictests()
     make -f posix.mak -j$N publictests DUB=$DUB
 }
 
+# check modules for public unittests
+has_public_example()
+{
+    make -f posix.mak -j$N has_public_example DUB=$DUB
+}
+
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     coverage) coverage ;;
     publictests) publictests ;;
-    style) style ;;
+    has_public_example) has_public_example;;
+    style_lint) style_lint ;;
+    *) echo "Unknown command"; exit 1;;
 esac

--- a/posix.mak
+++ b/posix.mak
@@ -602,7 +602,7 @@ $(TEST_EXTRACTOR): $(TOOLS_DIR)/styles/tests_extractor.d $(LIB)
 has_public_example: $(LIB)
 	#  checks whether public function have public examples (for now some modules are excluded)
 	rm -rf ./out
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) --compiler=$${PWD}/$(DMD) --root=../tools/styles -c has_public_example -- --inputdir . --ignore "etc,array.d,allocator,base64.d,bitmanip.d,concurrency.d,conv.d,csv.d,datetime/date.d,datetime/interval.d,datetime/package.d,datetime/stopwatch.d,datetime/systime.d,datetime/timezone.d,demangle.d,digest/hmac.d,digest/sha.d,encoding.d,exception.d,file.d,format.d,getopt.d,index.d,internal,isemail.d,json.d,logger/core.d,logger/nulllogger.d,math.d,mathspecial.d,net/curl.d,numeric.d,parallelism.d,path.d,process.d,random.d,range,regex/package.d,socket.d,stdio.d,string.d,traits.d,typecons.d,uni.d,unittest.d,uri.d,utf.d,uuid.d,xml.d,zlib.d"
+	DFLAGS="$(DFLAGS) $(LIB) $(LINKDL)" $(DUB) -v --compiler=$${PWD}/$(DMD) --root=../tools/styles -c has_public_example -- --inputdir std --ignore "array.d,allocator,base64.d,bitmanip.d,concurrency.d,conv.d,csv.d,datetime/date.d,datetime/interval.d,datetime/package.d,datetime/stopwatch.d,datetime/systime.d,datetime/timezone.d,demangle.d,digest/hmac.d,digest/sha.d,encoding.d,exception.d,file.d,format.d,getopt.d,index.d,internal,isemail.d,json.d,logger/core.d,logger/nulllogger.d,math.d,mathspecial.d,net/curl.d,numeric.d,parallelism.d,path.d,process.d,random.d,range,regex/package.d,socket.d,stdio.d,string.d,traits.d,typecons.d,uni.d,unittest.d,uri.d,utf.d,uuid.d,xml.d,zlib.d"
 
 .PHONY : auto-tester-build
 auto-tester-build: all checkwhitespace

--- a/std/conv.d
+++ b/std/conv.d
@@ -5534,7 +5534,8 @@ pure nothrow @safe /* @nogc */ unittest
 void toTextRange(T, W)(T value, W writer)
 if (isIntegral!T && isOutputRange!(W, char))
 {
-    import core.internal.string;
+    import core.internal.string : SignedStringBuf, signedToTempString,
+                                  UnsignedStringBuf, unsignedToTempString;
 
     if (value < 0)
     {
@@ -5712,7 +5713,7 @@ OriginalType!E asOriginalType(E)(E value) if (is(E == enum))
 }
 
 ///
-unittest
+@safe unittest
 {
     enum A { a = 42 }
     static assert(is(typeof(A.a.asOriginalType) == int));

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -390,36 +390,36 @@ unittest
 
     CRC64ECMA crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[])x"2f121b7575789626");
+    assert(crc.peek() == cast(ubyte[]) x"2f121b7575789626");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[])x"0000000000000000");
+    assert(crc.finish() == cast(ubyte[]) x"0000000000000000");
     digest = crc64ECMAOf("");
-    assert(digest == cast(ubyte[])x"0000000000000000");
+    assert(digest == cast(ubyte[]) x"0000000000000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc64ECMAOf("The quick brown fox jumps over the lazy dog")) == "5B5EB8C2E54AA1C4");
 
     digest = crc64ECMAOf("a");
-    assert(digest == cast(ubyte[])x"052b652e77840233");
+    assert(digest == cast(ubyte[]) x"052b652e77840233");
 
     digest = crc64ECMAOf("abc");
-    assert(digest == cast(ubyte[])x"2776271a4a09d82c");
+    assert(digest == cast(ubyte[]) x"2776271a4a09d82c");
 
     digest = crc64ECMAOf("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"4b7cdce3746c449f");
+    assert(digest == cast(ubyte[]) x"4b7cdce3746c449f");
 
     digest = crc64ECMAOf("message digest");
-    assert(digest == cast(ubyte[])x"6f9b8a3156c9bc5d");
+    assert(digest == cast(ubyte[]) x"6f9b8a3156c9bc5d");
 
     digest = crc64ECMAOf("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"2656b716e1bf0503");
+    assert(digest == cast(ubyte[]) x"2656b716e1bf0503");
 
     digest = crc64ECMAOf("1234567890123456789012345678901234567890"~
                          "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"bd3eb7765d0a22ae");
+    assert(digest == cast(ubyte[]) x"bd3eb7765d0a22ae");
 
-    assert(crcHexString(cast(ubyte[8])x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
+    assert(crcHexString(cast(ubyte[8]) x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
 }
 
 unittest
@@ -428,36 +428,36 @@ unittest
 
     CRC64ISO crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[])x"f0494ab780989b42");
+    assert(crc.peek() == cast(ubyte[]) x"f0494ab780989b42");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[])x"0000000000000000");
+    assert(crc.finish() == cast(ubyte[]) x"0000000000000000");
     digest = crc64ISOOf("");
-    assert(digest == cast(ubyte[])x"0000000000000000");
+    assert(digest == cast(ubyte[]) x"0000000000000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc64ISOOf("The quick brown fox jumps over the lazy dog")) == "4EF14E19F4C6E28E");
 
     digest = crc64ISOOf("a");
-    assert(digest == cast(ubyte[])x"0000000000002034");
+    assert(digest == cast(ubyte[]) x"0000000000002034");
 
     digest = crc64ISOOf("abc");
-    assert(digest == cast(ubyte[])x"0000000020c47637");
+    assert(digest == cast(ubyte[]) x"0000000020c47637");
 
     digest = crc64ISOOf("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[])x"5173f717971365e5");
+    assert(digest == cast(ubyte[]) x"5173f717971365e5");
 
     digest = crc64ISOOf("message digest");
-    assert(digest == cast(ubyte[])x"a2c355bbc0b93f86");
+    assert(digest == cast(ubyte[]) x"a2c355bbc0b93f86");
 
     digest = crc64ISOOf("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[])x"598B258292E40084");
+    assert(digest == cast(ubyte[]) x"598B258292E40084");
 
     digest = crc64ISOOf("1234567890123456789012345678901234567890"~
                         "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[])x"760cd2d3588bf809");
+    assert(digest == cast(ubyte[]) x"760cd2d3588bf809");
 
-    assert(crcHexString(cast(ubyte[8])x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
+    assert(crcHexString(cast(ubyte[8]) x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
 }
 
 /**

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -384,7 +384,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
     assert(crcHexString(cast(ubyte[4]) x"c3fcd3d7") == "D7D3FCC3");
 }
 
-unittest
+@system unittest
 {
     ubyte[8] digest;
 
@@ -422,7 +422,7 @@ unittest
     assert(crcHexString(cast(ubyte[8]) x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
 }
 
-unittest
+@system unittest
 {
     ubyte[8] digest;
 

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -513,6 +513,24 @@ ubyte[8] crc64ECMAOf(T...)(T data)
     return digest!(CRC64ECMA, T)(data);
 }
 
+///
+@system unittest
+{
+    ubyte[] data = [4,5,7,25];
+    assert(data.crc64ECMAOf == [58, 142, 220, 214, 118, 98, 105, 69]);
+
+    import std.utf : byChar;
+    assert("hello"d.byChar.crc64ECMAOf == [177, 55, 185, 219, 229, 218, 30, 155]);
+
+    ubyte[8] hash = "abc".crc64ECMAOf();
+    assert("abc".crc64ECMAOf == [39, 118, 39, 26, 74, 9, 216, 44]);
+    assert(hash == digest!CRC64ECMA("ab", "c"));
+
+    import std.range : iota;
+    enum ubyte S = 5, F = 66;
+    assert(iota(S, F).crc64ECMAOf == [6, 184, 91, 238, 46, 213, 127, 188]);
+}
+
 /**
  * This is a convenience alias for $(REF digest, std,digest,digest) using the
  * CRC64-ISO implementation.
@@ -529,6 +547,25 @@ ubyte[8] crc64ECMAOf(T...)(T data)
 ubyte[8] crc64ISOOf(T...)(T data)
 {
     return digest!(CRC64ISO, T)(data);
+}
+
+///
+@system unittest
+{
+    ubyte[] data = [4,5,7,25];
+    assert(data.crc64ISOOf == [0, 0, 0, 80, 137, 232, 203, 120]);
+
+    import std.utf : byChar;
+    assert("hello"d.byChar.crc64ISOOf == [0, 0, 16, 216, 226, 238, 62, 60]);
+
+    ubyte[8] hash = "abc".crc64ISOOf();
+    assert("abc".crc64ISOOf == [0, 0, 0, 0, 32, 196, 118, 55]);
+    assert(hash == digest!CRC64ISO("ab", "c"));
+
+    import std.range : iota;
+    enum ubyte S = 5, F = 66;
+
+    assert(iota(S, F).crc64ISOOf == [21, 185, 116, 95, 219, 11, 54, 7]);
 }
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7638,14 +7638,14 @@ public:
                 * Notice that we only need to move for windowSize - 1 to the right:
                 * source = [0, 1, 2, 3] (length: 4)
                 * - source.slide(2) -> s = [[0, 1], [1, 2], [2, 3]]
-                *   right pos for s[0..3]: 3 (upper) + 2 (windowSize) - 1 = 4
+                *   right pos for s[0 .. 3]: 3 (upper) + 2 (windowSize) - 1 = 4
                 *
                 * - source.slide(3) -> s = [[0, 1, 2], [1, 2, 3]]
-                *   right pos for s[0..2]: 2 (upper) + 3 (windowSize) - 1 = 4
+                *   right pos for s[0 .. 2]: 2 (upper) + 3 (windowSize) - 1 = 4
                 *
                 * source = [0, 1, 2, 3, 4] (length: 5)
                 * - source.slide(4) -> s = [[0, 1, 2, 3], [1, 2, 3, 4]]
-                *   right pos for s[0..2]: 2 (upper) + 4 (windowSize) - 1 = 5
+                *   right pos for s[0 .. 2]: 2 (upper) + 4 (windowSize) - 1 = 5
                 */
                 return typeof(this)
                     (_source[min(lower, len) .. min(upper + _windowSize - 1, len)],
@@ -8250,17 +8250,17 @@ unittest
         ));
 
         // front = back
-        foreach (windowSize; 1..10)
-            foreach (stepSize; 1..10)
+        foreach (windowSize; 1 .. 10)
+            foreach (stepSize; 1 .. 10)
             {
                 auto slider = r.slide(windowSize, stepSize);
                 assert(slider.retro.retro.equal!equal(slider));
             }
     }
 
-    assert(iota(1, 12).slide(2, 4)[0..3].equal!equal([[1, 2], [5, 6], [9, 10]]));
-    assert(iota(1, 12).slide(2, 4)[0..$].equal!equal([[1, 2], [5, 6], [9, 10]]));
-    assert(iota(1, 12).slide(2, 4)[$/2..$].equal!equal([[5, 6], [9, 10]]));
+    assert(iota(1, 12).slide(2, 4)[0 .. 3].equal!equal([[1, 2], [5, 6], [9, 10]]));
+    assert(iota(1, 12).slide(2, 4)[0 .. $].equal!equal([[1, 2], [5, 6], [9, 10]]));
+    assert(iota(1, 12).slide(2, 4)[$/2 .. $].equal!equal([[5, 6], [9, 10]]));
 
     // reverse
     assert(iota(1, 12).slide(2, 4).retro.equal!equal([[9, 10], [5, 6], [1, 2]]));

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8332,7 +8332,7 @@ unittest
         Range r;
         r.arr = 10.iota.array; // for clarity
 
-        static assert (isForwardRange!Range);
+        static assert(isForwardRange!Range);
         enum hasSliceToEnd = hasSlicing!Range && is(typeof(Range.init[0 .. $]) == Range);
 
         assert(r.slide(2)[0].equal([0, 1]));
@@ -8356,8 +8356,8 @@ unittest
 
     foreach (Range; AliasSeq!SliceableDummyRangesWithoutInfinity)
     {
-        static assert (hasSlicing!Range);
-        static assert (hasLength!Range);
+        static assert(hasSlicing!Range);
+        static assert(hasLength!Range);
 
         Range r;
         r.arr = 10.iota.array; // for clarity

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7888,7 +7888,7 @@ public:
     assert(iota(1, 4).slide(3).equal!equal([[1, 2, 3]]));
 }
 
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6918,7 +6918,7 @@ divisible by $(D chunkSize), the back element of this range will contain
 fewer than $(D chunkSize) elements.
 
 Params:
-    r = Range from which the chunks will be selected
+    source = Range from which the chunks will be selected
     chunkSize = Chunk size
 
 See_Also: $(LREF slide)
@@ -7429,7 +7429,7 @@ Params:
         elements than `windowSize`. This can only happen if the initial range
         contains less elements than `windowSize`. In this case
         if `No.withFewerElements` an empty range will be returned.
-    r = Range from which the slide will be selected
+    source = Range from which the slide will be selected
     windowSize = Sliding window size
     stepSize = Steps between the windows (by default 1)
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4532,7 +4532,7 @@ Initialize with a message and an error code.
     // `handle` at once and steal the high bit to indicate that the globals have
     // been initialized.
     static shared uint spinlock;
-    import core.atomic;
+    import core.atomic : atomicLoad, atomicOp, MemoryOrder;
     if (atomicLoad!(MemoryOrder.acq)(spinlock) <= uint.max / 2)
     {
         for (;;)
@@ -4621,7 +4621,7 @@ alias stderr = makeGlobal!(core.stdc.stdio.stderr);
     }
 }
 
-unittest
+@safe unittest
 {
     // Retain backwards compatibility
     // https://issues.dlang.org/show_bug.cgi?id=17472


### PR DESCRIPTION
Seems like we silently have disabled the style targets on CircleCi during the Makefile re-organization at DConf.
Luckily the number of "violations" that got in is fairly small, but there was a great variety...

CC @CyberShadow @andralex @JackStouffer 