### PR TITLE
Allmanify braces (use Dscanner instead of RegExps)

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -183,7 +183,8 @@ enum CURL_WRITEFUNC_PAUSE = 0x10000001;
 alias curl_write_callback = size_t function(char *buffer, size_t size, size_t nitems, void *outstream);
 
 /** enumeration of file types */
-enum CurlFileType {
+enum CurlFileType
+{
     file,       ///
     directory,  ///
     symlink,    ///
@@ -199,7 +200,8 @@ enum CurlFileType {
 alias curlfiletype = int;
 
 ///
-enum CurlFInfoFlagKnown {
+enum CurlFInfoFlagKnown
+{
   filename    = 1,      ///
   filetype    = 2,      ///
   time        = 4,      ///
@@ -248,7 +250,8 @@ extern (C) struct curl_fileinfo
 }
 
 /** return codes for CURLOPT_CHUNK_BGN_FUNCTION */
-enum CurlChunkBgnFunc {
+enum CurlChunkBgnFunc
+{
   ok = 0,   ///
   fail = 1, /** tell the lib to end the task */
   skip = 2 /** skip this chunk over */
@@ -260,7 +263,8 @@ enum CurlChunkBgnFunc {
 alias curl_chunk_bgn_callback = c_long function(void *transfer_info, void *ptr, int remains);
 
 /** return codes for CURLOPT_CHUNK_END_FUNCTION */
-enum CurlChunkEndFunc {
+enum CurlChunkEndFunc
+{
   ok = 0,       ///
   fail = 1,     ///
 }
@@ -273,7 +277,8 @@ enum CurlChunkEndFunc {
 alias curl_chunk_end_callback = c_long function(void *ptr);
 
 /** return codes for FNMATCHFUNCTION */
-enum CurlFnMAtchFunc {
+enum CurlFnMAtchFunc
+{
   match = 0,    ///
   nomatch = 1,  ///
   fail = 2      ///
@@ -284,14 +289,16 @@ enum CurlFnMAtchFunc {
 alias curl_fnmatch_callback = int function(void *ptr, in char *pattern, in char *string);
 
 /// seek whence...
-enum CurlSeekPos {
+enum CurlSeekPos
+{
   set,          ///
   current,      ///
   end           ///
 }
 
 /** These are the return codes for the seek callbacks */
-enum CurlSeek {
+enum CurlSeek
+{
   ok,       ///
   fail,     /** fail the entire transfer */
   cantseek  /** tell libcurl seeking can't be done, so
@@ -302,7 +309,8 @@ enum CurlSeek {
 alias curl_seek_callback = int function(void *instream, curl_off_t offset, int origin);
 
 ///
-enum CurlReadFunc {
+enum CurlReadFunc
+{
   /** This is a return code for the read callback that, when returned, will
      signal libcurl to immediately abort the current transfer. */
   abort = 0x10000000,
@@ -317,7 +325,8 @@ enum CurlReadFunc {
 alias curl_read_callback = size_t function(char *buffer, size_t size, size_t nitems, void *instream);
 
 ///
-enum CurlSockType {
+enum CurlSockType
+{
     ipcxn, /** socket created for a specific IP connection */
     last   /** never use */
 }
@@ -355,7 +364,8 @@ enum CurlIoError
 alias curlioerr = int;
 
 ///
-enum CurlIoCmd {
+enum CurlIoCmd
+{
     nop,         /** command was unknown to callback */
     restartread, /** failed to restart the read */
     last,        /** never use */
@@ -383,7 +393,8 @@ alias curl_strdup_callback = char * function(in char *str);
 alias curl_calloc_callback = void* function(size_t nmemb, size_t size);
 
 /** the kind of data that is passed to information_callback*/
-enum CurlCallbackInfo {
+enum CurlCallbackInfo
+{
     text,       ///
     header_in,  ///
     header_out, ///
@@ -534,7 +545,8 @@ alias curl_ssl_ctx_callback =
                          );
 
 ///
-enum CurlProxy {
+enum CurlProxy
+{
     http,         /** added in 7.10, new in 7.19.4 default is to use CONNECT HTTP/1.1 */
     http_1_0,     /** added in 7.19.4, force to use CONNECT HTTP/1.0  */
     socks4 = 4,   /** support added in 7.15.2, enum existed already in 7.10 */
@@ -548,7 +560,8 @@ enum CurlProxy {
 alias curl_proxytype = int;
 
 ///
-enum CurlAuth : long {
+enum CurlAuth : long
+{
   none =         0,
   basic =        1,  /** Basic (default) */
   digest =       2,  /** Digest */
@@ -563,7 +576,8 @@ enum CurlAuth : long {
 }
 
 ///
-enum CurlSshAuth {
+enum CurlSshAuth
+{
   any       = -1,     /** all types supported by the server */
   none      = 0,      /** none allowed, silly but complete */
   publickey = 1, /** public/private key files */
@@ -594,7 +608,8 @@ extern (C) struct curl_khkey
 
 /** this is the set of return values expected from the curl_sshkeycallback
    callback */
-enum CurlKHStat {
+enum CurlKHStat
+{
     fine_add_to_file, ///
     fine,       ///
     reject,  /** reject the connection, return an error */
@@ -605,7 +620,8 @@ enum CurlKHStat {
 }
 
 /** this is the set of status codes pass in to the callback */
-enum CurlKHMatch {
+enum CurlKHMatch
+{
     ok,       /** match */
     mismatch, /** host found, key mismatch! */
     missing,  /** no matching host/key found */
@@ -622,7 +638,8 @@ alias curl_sshkeycallback =
                     );
 
 /** parameter for the CURLOPT_USE_SSL option */
-enum CurlUseSSL {
+enum CurlUseSSL
+{
     none,     /** do not attempt to use SSL */
     tryssl,   /** try using SSL, proceed anyway otherwise */
     control,  /** SSL for the control connection or fail */
@@ -633,7 +650,8 @@ enum CurlUseSSL {
 alias curl_usessl = int;
 
 /** parameter for the CURLOPT_FTP_SSL_CCC option */
-enum CurlFtpSSL {
+enum CurlFtpSSL
+{
     ccc_none,     /** do not send CCC */
     ccc_passive,  /** Let the server initiate the shutdown */
     ccc_active,   /** Initiate the shutdown */
@@ -643,7 +661,8 @@ enum CurlFtpSSL {
 alias curl_ftpccc = int;
 
 /** parameter for the CURLOPT_FTPSSLAUTH option */
-enum CurlFtpAuth {
+enum CurlFtpAuth
+{
     defaultauth, /** let libcurl decide */
     ssl,         /** use "AUTH SSL" */
     tls,         /** use "AUTH TLS" */
@@ -653,7 +672,8 @@ enum CurlFtpAuth {
 alias curl_ftpauth = int;
 
 /** parameter for the CURLOPT_FTP_CREATE_MISSING_DIRS option */
-enum CurlFtp {
+enum CurlFtp
+{
     create_dir_none,   /** do NOT create missing dirs! */
     create_dir,        /** (FTP/SFTP) if CWD fails, try MKD and then CWD again if MKD
                           succeeded, for SFTP this does similar magic */
@@ -665,7 +685,8 @@ enum CurlFtp {
 alias curl_ftpcreatedir = int;
 
 /** parameter for the CURLOPT_FTP_FILEMETHOD option */
-enum CurlFtpMethod {
+enum CurlFtpMethod
+{
     defaultmethod,    /** let libcurl pick */
     multicwd,         /** single CWD operation for each path part */
     nocwd,            /** no CWD at all */
@@ -676,7 +697,8 @@ enum CurlFtpMethod {
 alias curl_ftpmethod = int;
 
 /** CURLPROTO_ defines are for the CURLOPT_*PROTOCOLS options */
-enum CurlProto {
+enum CurlProto
+{
   http   = 1,   ///
   https  = 2,   ///
   ftp    = 4,   ///
@@ -731,7 +753,8 @@ alias FUNCTIONPOINT = CURLOPTTYPE_FUNCTIONPOINT;
 alias OFF_T = CURLOPTTYPE_OFF_T;
 
 ///
-enum CurlOption {
+enum CurlOption
+{
   /** This is the FILE * or void * the regular output should be written to. */
   file = 10_001,
   /** The full URL to get/put */
@@ -1270,7 +1293,8 @@ enum CURLOPT_SERVER_RESPONSE_TIMEOUT = CurlOption.ftp_response_timeout;
 /** Below here follows defines for the CURLOPT_IPRESOLVE option. If a host
    name resolves addresses using more than one IP protocol version, this
    option might be handy to force libcurl to use a specific IP version. */
-enum CurlIpResolve {
+enum CurlIpResolve
+{
   whatever = 0, /** default, resolves addresses to all IP versions that your system allows */
   v4 = 1,       /** resolve to ipv4 addresses */
   v6 = 2        /** resolve to ipv6 addresses */
@@ -1286,7 +1310,8 @@ enum CURLOPT_HEADERDATA = CurlOption.writeheader;
 enum CURLOPT_RTSPHEADER = CurlOption.httpheader;
 
 /** These enums are for use with the CURLOPT_HTTP_VERSION option. */
-enum CurlHttpVersion {
+enum CurlHttpVersion
+{
     none, /** setting this means we don't care, and that we'd
              like the library to choose the best possible
              for us! */
@@ -1298,7 +1323,8 @@ enum CurlHttpVersion {
 /**
  * Public API enums for RTSP requests
  */
-enum CurlRtspReq {
+enum CurlRtspReq
+{
     none,       ///
     options,    ///
     describe,   ///
@@ -1315,7 +1341,8 @@ enum CurlRtspReq {
 }
 
  /** These enums are for use with the CURLOPT_NETRC option. */
-enum CurlNetRcOption {
+enum CurlNetRcOption
+{
     ignored,  /** The .netrc will never be read. This is the default. */
     optional  /** A user:password in the URL will be preferred to one in the .netrc. */,
     required, /** A user:password in the URL will be ignored.
@@ -1325,7 +1352,8 @@ enum CurlNetRcOption {
 }
 
 ///
-enum CurlSslVersion {
+enum CurlSslVersion
+{
     default_version,    ///
     tlsv1,      ///
     sslv2,      ///
@@ -1334,7 +1362,8 @@ enum CurlSslVersion {
 }
 
 ///
-enum CurlTlsAuth {
+enum CurlTlsAuth
+{
     none,       ///
     srp,        ///
     last /** never use */
@@ -1343,7 +1372,8 @@ enum CurlTlsAuth {
 /** symbols to use with CURLOPT_POSTREDIR.
    CURL_REDIR_POST_301 and CURL_REDIR_POST_302 can be bitwise ORed so that
    CURL_REDIR_POST_301 | CURL_REDIR_POST_302 == CURL_REDIR_POST_ALL */
-enum CurlRedir {
+enum CurlRedir
+{
   get_all = 0,  ///
   post_301 = 1, ///
   post_302 = 2, ///
@@ -1351,7 +1381,8 @@ enum CurlRedir {
   post_all = (1 | 2) // (CURL_REDIR_POST_301|CURL_REDIR_POST_302);
 }
 ///
-enum CurlTimeCond {
+enum CurlTimeCond
+{
     none,       ///
     ifmodsince, ///
     ifunmodsince,       ///
@@ -1364,12 +1395,14 @@ alias curl_TimeCond = int;
 
 /** curl_strequal() and curl_strnequal() are subject for removal in a future
    libcurl, see lib/README.curlx for details */
-extern (C) {
+extern (C)
+{
 int  curl_strequal(in char *s1, in char *s2);
 /// ditto
 int  curl_strnequal(in char *s1, in char *s2, size_t n);
 }
-enum CurlForm {
+enum CurlForm
+{
     nothing, /********** the first one is unused ************/
     copyname,
     ptrname,
@@ -1422,7 +1455,8 @@ extern (C) struct curl_forms
  * )
  *
  ***************************************************************************/
-enum CurlFormAdd {
+enum CurlFormAdd
+{
     ok, /** first, no error */
     memory,     ///
     option_twice,       ///
@@ -1436,7 +1470,8 @@ enum CurlFormAdd {
 ///
 alias CURLFORMcode = int;
 
-extern (C) {
+extern (C)
+{
 
 /**
  * Name: curl_formadd()
@@ -1585,7 +1620,8 @@ void  curl_global_cleanup();
 }
 
 /** linked-list structure for the CURLOPT_QUOTE option (and other) */
-extern (C) {
+extern (C)
+{
 
 struct curl_slist
 {
@@ -1650,7 +1686,8 @@ enum CURLINFO_MASK = 0x0fffff;
 enum CURLINFO_TYPEMASK = 0xf00000;
 
 ///
-enum CurlInfo {
+enum CurlInfo
+{
     none,       ///
     effective_url = 1_048_577,    ///
     response_code = 2_097_154,    ///
@@ -1705,7 +1742,8 @@ alias CURLINFO = int;
 enum CURLINFO_HTTP_CODE = CurlInfo.response_code;
 
 ///
-enum CurlClosePolicy {
+enum CurlClosePolicy
+{
     none,       ///
     oldest,     ///
     least_recently_used,        ///
@@ -1718,7 +1756,8 @@ enum CurlClosePolicy {
 alias curl_closepolicy = int;
 
 ///
-enum CurlGlobal {
+enum CurlGlobal
+{
   ssl = 1,      ///
   win32 = 2,    ///
   ///
@@ -1732,7 +1771,8 @@ enum CurlGlobal {
  */
 
 /** Different data locks for a single share */
-enum CurlLockData {
+enum CurlLockData
+{
     none,       ///
     /**  CURL_LOCK_DATA_SHARE is used internally to say that
      *  the locking is just made to change the internal state of the share
@@ -1749,7 +1789,8 @@ enum CurlLockData {
 alias curl_lock_data = int;
 
 /** Different lock access types */
-enum CurlLockAccess {
+enum CurlLockAccess
+{
     none,            /** unspecified action */
     shared_access,   /** for read perhaps */
     single,          /** for write perhaps */
@@ -1767,7 +1808,8 @@ alias curl_unlock_function = void function(CURL *handle, curl_lock_data data, vo
 alias CURLSH = void;
 
 ///
-enum CurlShError {
+enum CurlShError
+{
     ok,          /** all is fine */
     bad_option,  /** 1 */
     in_use,      /** 2 */
@@ -1780,7 +1822,8 @@ alias CURLSHcode = int;
 
 /** pass in a user data pointer used in the lock/unlock callback
    functions */
-enum CurlShOption {
+enum CurlShOption
+{
     none,         /** don't use */
     share,        /** specify a data type to share */
     unshare,      /** specify which data type to stop sharing */
@@ -1793,7 +1836,8 @@ enum CurlShOption {
 ///
 alias CURLSHoption = int;
 
-extern (C) {
+extern (C)
+{
 ///
 CURLSH * curl_share_init();
 ///
@@ -1807,7 +1851,8 @@ CURLSHcode  curl_share_cleanup(CURLSH *);
  */
 
 // CURLVERSION_*
-enum CurlVer {
+enum CurlVer
+{
     first,      ///
     second,     ///
     third,      ///
@@ -1852,7 +1897,8 @@ alias curl_version_info_data = _N28;
 
 ///
 // CURL_VERSION_*
-enum CurlVersion {
+enum CurlVersion
+{
   ipv6         = 1,     /** IPv6-enabled */
   kerberos4    = 2,     /** kerberos auth is supported */
   ssl          = 4,     /** SSL options are present */
@@ -1870,7 +1916,8 @@ enum CurlVersion {
   tlsauth_srp  = 16_384  /** TLS-SRP auth is supported */
 }
 
-extern (C) {
+extern (C)
+{
 /**
  * Name: curl_version_info()
  *
@@ -1917,7 +1964,8 @@ CURLcode  curl_easy_pause(CURL *handle, int bitmask);
 
 
 ///
-enum CurlPause {
+enum CurlPause
+{
   recv      = 1,        ///
   recv_cont = 0,        ///
   send      = 4,        ///
@@ -1952,7 +2000,8 @@ enum CurlPause {
  *
  ***************************************************************************/
 
-extern (C) {
+extern (C)
+{
   ///
   CURL * curl_easy_init();
   ///
@@ -2062,7 +2111,8 @@ extern (C) CURLcode  curl_easy_send(CURL *curl, void *buffer, size_t buflen, siz
 alias CURLM = void;
 
 ///
-enum CurlM {
+enum CurlM
+{
     call_multi_perform = -1, /** please call curl_multi_perform() or curl_multi_socket*() soon */
     ok, ///
     bad_handle,              /** the passed-in handle is not a valid CURLM handle */
@@ -2235,7 +2285,8 @@ extern (C) const(char)* curl_multi_strerror(CURLMcode );
  *          detected to have "action" on them and let libcurl perform.
  *          See man page for details.
  */
-enum CurlPoll {
+enum CurlPoll
+{
   none_ = 0,   /** jdrewsen - underscored in order not to clash with reserved D symbols */
   in_ = 1,      ///
   out_ = 2,     ///
@@ -2247,13 +2298,15 @@ enum CurlPoll {
 alias CURL_SOCKET_TIMEOUT = CURL_SOCKET_BAD;
 
 ///
-enum CurlCSelect {
+enum CurlCSelect
+{
   in_ = 0x01,  /** jdrewsen - underscored in order not to clash with reserved D symbols */
   out_ = 0x02,  ///
   err_ = 0x04   ///
 }
 
-extern (C) {
+extern (C)
+{
   ///
   alias curl_socket_callback =
         int function(CURL *easy,            /** easy handle */
@@ -2274,7 +2327,8 @@ extern (C) {
  * Returns: The callback should return zero.
  */
 
-extern (C) {
+extern (C)
+{
   alias curl_multi_timer_callback =
         int function(CURLM *multi,          /** multi handle */
                      c_long timeout_ms,     /** see above */
@@ -2303,7 +2357,8 @@ extern (C) {
 extern (C) CURLMcode  curl_multi_timeout(CURLM *multi_handle, c_long *milliseconds);
 
 ///
-enum CurlMOption {
+enum CurlMOption
+{
     socketfunction = 20_001,    /** This is the socket callback function pointer */
     socketdata = 10_002,        /** This is the argument passed to the socket callback */
     pipelining = 3,             /** set to 1 to enable pipelining for this multi handle */

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -146,7 +146,8 @@ struct SQL_INTERVAL_STRUCT
     SQLINTERVAL interval_type;
     SQLSMALLINT interval_sign;
 
-    union  intval {
+    union  intval
+    {
         SQL_YEAR_MONTH_STRUCT year_month;
         SQL_DAY_SECOND_STRUCT day_second;
     }

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1046,7 +1046,8 @@ private struct Levenshtein(Range, alias equals, CostType = size_t)
         return result;
     }
 
-    ~this() {
+    ~this()
+    {
         FreeMatrix();
     }
 
@@ -1060,7 +1061,8 @@ private:
     // Treat _matrix as a rectangular array
     ref CostType matrix(size_t row, size_t col) { return _matrix[row * cols + col]; }
 
-    void AllocMatrix(size_t r, size_t c) @trusted {
+    void AllocMatrix(size_t r, size_t c) @trusted
+    {
         import core.checkedint : mulu;
         bool overflow;
         const rc = mulu(r, c, overflow);
@@ -1081,14 +1083,16 @@ private:
         }
     }
 
-    void FreeMatrix() @trusted {
+    void FreeMatrix() @trusted
+    {
         import core.stdc.stdlib : free;
 
         free(_matrix.ptr);
         _matrix = null;
     }
 
-    void InitMatrix() {
+    void InitMatrix()
+    {
         foreach (r; 0 .. rows)
             matrix(r,0) = r * _deletionIncrement;
         foreach (c; 0 .. cols)

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -937,7 +937,8 @@ range of range (of range...) comparisons.
 
 @safe pure unittest
 {
-    struct R(bool _empty) {
+    struct R(bool _empty)
+    {
         enum empty = _empty;
         @property char front(){assert(0);}
         void popFront(){assert(0);}

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -871,13 +871,15 @@ private:
         (isRangeUnaryIterable!R || isRangeBinaryIterable!R);
 
     enum isForeachUnaryIterable(R) =
-        is(typeof((R r) {
+        is(typeof((R r)
+        {
             foreach (ref a; r)
                 cast(void) unaryFun!pred(a);
         }));
 
     enum isForeachBinaryIterable(R) =
-        is(typeof((R r) {
+        is(typeof((R r)
+        {
             foreach (ref i, ref a; r)
                 cast(void) binaryFun!BinaryArgs(i, a);
         }));
@@ -944,7 +946,8 @@ public:
         {
             // opApply with >2 parameters. count the delegate args.
             // only works if it is not templated (otherwise we cannot count the args)
-            auto dg(Parameters!(Parameters!(r.opApply)) params) {
+            auto dg(Parameters!(Parameters!(r.opApply)) params)
+            {
                 pred(params);
                 return 0; // tells opApply to continue iteration
             }
@@ -1491,7 +1494,8 @@ if (isInputRange!R)
     static if (isForwardRange!R)
     {
         ///
-        @property typeof(this) save() {
+        @property typeof(this) save()
+        {
             typeof(this) ret = this;
             ret._input = this._input.save;
             ret._current = this._current;
@@ -3893,7 +3897,8 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     assert(split.front == "b ");
     assert(split.back == "r ");
 
-    foreach (DummyType; AllDummyRanges) {  // Bug 4408
+    foreach (DummyType; AllDummyRanges)   // Bug 4408
+    {
         static if (isRandomAccessRange!DummyType)
         {
             static assert(isBidirectionalRange!DummyType);
@@ -4167,7 +4172,8 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     import std.algorithm.comparison : equal;
 
     // Test by-reference separator
-    class RefSep {
+    class RefSep
+    {
     @safe:
         string _impl;
         this(string s) { _impl = s; }
@@ -5031,7 +5037,8 @@ private struct UniqResult(alias pred, Range)
 
     static if (isForwardRange!Range)
     {
-        @property typeof(this) save() {
+        @property typeof(this) save()
+        {
             return typeof(this)(_input.save);
         }
     }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -375,9 +375,11 @@ if (areCopyCompatibleArrays!(SourceRange, TargetRange))
     assert(tlen >= slen,
             "Cannot copy a source range into a smaller target range.");
 
-    immutable overlaps = __ctfe || () @trusted {
+    immutable overlaps = __ctfe || () @trusted
+    {
         return source.ptr < target.ptr + tlen &&
-               target.ptr < source.ptr + slen; }();
+               target.ptr < source.ptr + slen;
+    }();
 
     if (overlaps)
     {
@@ -1003,12 +1005,14 @@ if (is(Range == char[]) || is(Range == wchar[]))
 // elaborate assigns.
 @system unittest
 {
-    struct Int {
+    struct Int
+    {
         ~this() {}
         int x = 3;
     }
     Int[2] xs = [Int(1), Int(2)];
-    struct R {
+    struct R
+    {
         bool done;
         bool empty() { return done; }
         ref Int[2] front() { return xs; }
@@ -1098,7 +1102,8 @@ pure nothrow @safe @nogc unittest
     import std.exception : assertCTFEable;
     import std.traits;
 
-    assertCTFEable!((){
+    assertCTFEable!(()
+    {
         Object obj1 = new Object;
         Object obj2 = obj1;
         Object obj3;
@@ -1212,7 +1217,8 @@ private T moveImpl(T)(ref T source)
     import std.exception : assertCTFEable;
     import std.traits;
 
-    assertCTFEable!((){
+    assertCTFEable!(()
+    {
         Object obj1 = new Object;
         Object obj2 = obj1;
         Object obj3 = move(obj2);

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -547,7 +547,8 @@ if (isNarrowString!R1 && isNarrowString!R2)
                           dchar[], const(dchar)[], dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(commonPrefix(to!S(""), to!T("")).empty);
             assert(commonPrefix(to!S(""), to!T("hello")).empty);
             assert(commonPrefix(to!S("hello"), to!T("")).empty);
@@ -1176,7 +1177,8 @@ if (isInputRange!R &&
         assert(endsWith(to!S("abc\uFF28"), 'a', '\uFF28', 'c') == 2);
 
         foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             //Lots of strings
             assert(endsWith(to!S("abc"), to!T("")));
             assert(!endsWith(to!S("abc"), to!T("a")));
@@ -4283,7 +4285,8 @@ if (isInputRange!R &&
         assert(startsWith(to!S("\uFF28abc"), 'a', '\uFF28', 'c') == 2);
 
         foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             //Lots of strings
             assert(startsWith(to!S("abc"), to!T("")));
             assert(startsWith(to!S("ab"), to!T("a")));

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1043,7 +1043,8 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
     auto index2 = new long[arr.length];
     makeIndex(arr, index2);
     assert(isSorted!
-            ((long a, long b){
+            ((long a, long b)
+            {
                 return arr[cast(size_t) a] < arr[cast(size_t) b];
             })(index2));
 

--- a/std/array.d
+++ b/std/array.d
@@ -1437,7 +1437,8 @@ if (isSomeString!S)
 @safe unittest //purity, ctfe ...
 {
     import std.exception;
-    void dg() @safe pure {
+    void dg() @safe pure
+    {
         assert(split("hello world"c) == ["hello"c, "world"c]);
         assert(split("hello world"w) == ["hello"w, "world"w]);
         assert(split("hello world"d) == ["hello"d, "world"d]);
@@ -1865,7 +1866,8 @@ if (isInputRange!RoR &&
         auto filteredWords    = filter!"true"(filteredWordsArr);
 
         foreach (S; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(join(filteredWords, to!S(", ")) == "日本語, paul, jerry");
             assert(join(filteredWords, to!(ElementType!S)(',')) == "日本語,paul,jerry");
             assert(join(filteredWordsArr, to!(ElementType!(S))(',')) == "日本語,paul,jerry");
@@ -2073,7 +2075,8 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
     foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
         foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             auto s = to!S("This is a foo foo list");
             auto from = to!T("foo");
             auto into = to!S("silly");
@@ -2519,7 +2522,8 @@ if (isDynamicArray!(E[]) &&
     {
         foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             auto s = to!S("This is a foo foo list");
             auto s2 = to!S("Thüs is a ßöö foo list");
             auto from = to!T("foo");
@@ -2634,7 +2638,8 @@ if (isDynamicArray!(E[]) &&
     {
         foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             auto s = to!S("This is a foo foo list");
             auto s2 = to!S("Thüs is a ßöö ßöö list");
             auto from = to!T("foo");
@@ -3425,7 +3430,8 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
 @safe unittest
 {
     //9528
-    const(E)[] fastCopy(E)(E[] src) {
+    const(E)[] fastCopy(E)(E[] src)
+    {
             auto app = appender!(const(E)[])();
             foreach (i, e; src)
                     app.put(e);
@@ -3443,10 +3449,12 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
 {
     import std.algorithm.iteration : map;
     //10753
-    struct Foo {
+    struct Foo
+    {
        immutable dchar d;
     }
-    struct Bar {
+    struct Bar
+    {
        immutable int x;
     }
     "12".map!Foo.array;

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1460,7 +1460,8 @@ unittest
 
 @system unittest // 6850
 {
-    pure long pureTest() {
+    pure long pureTest()
+    {
         BigInt a = 1;
         BigInt b = 1336;
         a += b;

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -310,7 +310,8 @@ Following arguments works the same way as $(D bitfield)'s. The bitfield must fit
 bits known to be zero because of the pointer alignment.
 */
 
-template taggedPointer(T : T*, string name, Ts...) {
+template taggedPointer(T : T*, string name, Ts...)
+{
     enum taggedPointer = createTaggedReference!(T*, T.alignof, name, Ts).result;
 }
 
@@ -482,7 +483,8 @@ unittest
             Object, "a",
             uint, "b", 4)));
 
-    struct S {
+    struct S
+    {
         mixin(taggedClassRef!(
             Object, "a",
             bool, "b", 1));
@@ -497,7 +499,8 @@ unittest
 @safe unittest
 {
     // Bug #6686
-    union  S {
+    union  S
+    {
         ulong bits = ulong.max;
         mixin (bitfields!(
             ulong, "back",  31,
@@ -556,7 +559,8 @@ unittest
 @safe unittest
 {
     {
-        static struct Integrals {
+        static struct Integrals
+        {
             bool checkExpectations(bool eb, int ei, short es) { return b == eb && i == ei && s == es; }
 
             mixin(bitfields!(
@@ -578,7 +582,8 @@ unittest
 
     //Bug# 8876
     {
-        struct MoreIntegrals {
+        struct MoreIntegrals
+        {
             bool checkExpectations(uint eu, ushort es, uint ei) { return u == eu && s == es && i == ei; }
 
             mixin(bitfields!(
@@ -601,7 +606,8 @@ unittest
 
     enum A { True, False }
     enum B { One, Two, Three, Four }
-    static struct Enums {
+    static struct Enums
+    {
         bool checkExpectations(A ea, B eb) { return a == ea && b == eb; }
 
         mixin(bitfields!(
@@ -616,7 +622,8 @@ unittest
     e.b = B.Three;
     assert(e.checkExpectations(A.False, B.Three));
 
-    static struct SingleMember {
+    static struct SingleMember
+    {
         bool checkExpectations(bool eb) { return b == eb; }
 
         mixin(bitfields!(
@@ -751,7 +758,8 @@ struct DoubleRep
 @safe unittest
 {
     // Issue #15305
-    struct S {
+    struct S
+    {
             mixin(bitfields!(
                     bool, "alice", 1,
                     ulong, "bob", 63,

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -747,13 +747,15 @@ body
 
     Tuple!(T) ret;
 
-    thisInfo.ident.mbox.get((T val) {
+    thisInfo.ident.mbox.get((T val)
+    {
         static if (T.length)
             ret.field = val;
     },
     (LinkTerminated e) { throw e; },
     (OwnerTerminated e) { throw e; },
-    (Variant val) {
+    (Variant val)
+    {
         static if (T.length > 1)
             string exp = T.stringof;
         else
@@ -813,20 +815,24 @@ body
 
 @safe unittest
 {
-    static assert(__traits(compiles, {
+    static assert(__traits(compiles,
+    {
         receiveTimeout(msecs(0), (Variant x) {});
         receiveTimeout(msecs(0), (int x) {}, (Variant x) {});
     }));
 
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles,
+    {
         receiveTimeout(msecs(0), (Variant x) {}, (int x) {});
     }));
 
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles,
+    {
         receiveTimeout(msecs(0), (int x) {}, (int x) {});
     }));
 
-    static assert(__traits(compiles, {
+    static assert(__traits(compiles,
+    {
         receiveTimeout(msecs(10), (int x) {}, (Variant x) {});
     }));
 }
@@ -1628,8 +1634,10 @@ void yield(T)(T value)
     static void testScheduler(Scheduler s)
     {
         scheduler = s;
-        scheduler.start({
-            auto tid = spawn({
+        scheduler.start(
+        {
+            auto tid = spawn(
+            {
                 int i;
 
                 try
@@ -1648,7 +1656,8 @@ void yield(T)(T value)
                 assert(i == 4);
             });
 
-            auto r = new Generator!int({
+            auto r = new Generator!int(
+            {
                 assertThrown!Exception(yield(2.0));
                 yield(); // ensure this is a no-op
                 yield(1);
@@ -2273,12 +2282,14 @@ version (unittest)
 
     void testfn(Tid tid)
     {
-        receive((float val) { assert(0); }, (int val, int val2) {
+        receive((float val) { assert(0); }, (int val, int val2)
+        {
             assert(val == 42 && val2 == 86);
         });
         receive((Tuple!(int, int) val) { assert(val[0] == 42 && val[1] == 86); });
         receive((Variant val) {  });
-        receive((string val) {
+        receive((string val)
+        {
             if ("the quick brown fox" != val)
                 return false;
             return true;
@@ -2436,7 +2447,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
     __gshared Mutex m;
     m = new Mutex;
 
-    spawn({
+    spawn(
+    {
         // use a different mutex for varB to avoid a dead-lock
         initOnce!varB(true, m);
         ownerTid.send(true);

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1389,7 +1389,8 @@ if (!is(Unqual!T == bool))
 // Test issue 11194
 @system unittest
 {
-    static struct S {
+    static struct S
+    {
         int i = 1337;
         void* p;
         this(this) { assert(i == 1337); }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1718,7 +1718,8 @@ assert(equal(rbt[], [5]));
      */
     static if (is(typeof((){FormatSpec!(char) fmt; formatValue((const(char)[]) {}, ConstRange.init, fmt);})))
     {
-        void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const {
+        void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const
+        {
             sink("RedBlackTree(");
             sink.formatValue(this[], fmt);
             sink(")");

--- a/std/conv.d
+++ b/std/conv.d
@@ -493,7 +493,8 @@ if (isImplicitlyConvertible!(S, T) &&
     import std.exception;
     // Conversion between same size
     foreach (S; AliasSeq!(byte, short, int, long))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         alias U = Unsigned!S;
 
         foreach (Sint; AliasSeq!(S, const S, immutable S))
@@ -514,7 +515,8 @@ if (isImplicitlyConvertible!(S, T) &&
     // Conversion between different size
     foreach (i, S1; AliasSeq!(byte, short, int, long))
     foreach (   S2; AliasSeq!(byte, short, int, long)[i+1..$])
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         alias U1 = Unsigned!S1;
         alias U2 = Unsigned!S2;
 
@@ -830,7 +832,8 @@ if (!isImplicitlyConvertible!(S, T) &&
 
     foreach (m1; AliasSeq!(0,1,2,3,4)) // enumerate modifiers
     foreach (m2; AliasSeq!(0,1,2,3,4)) // ditto
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         alias srcmod = AddModifier!m1;
         alias tgtmod = AddModifier!m2;
 
@@ -921,7 +924,8 @@ if (!(isImplicitlyConvertible!(S, T) &&
     else static if (isPointer!S && isSomeChar!(PointerTarget!S))
     {
         // This is unsafe because we cannot guarantee that the pointer is null terminated.
-        return () @system {
+        return () @system
+        {
             static if (is(S : const(char)*))
                 import core.stdc.string : strlen;
             else
@@ -1062,7 +1066,8 @@ if (!(isImplicitlyConvertible!(S, T) &&
 */
 private template isSwitchable(E)
 {
-    enum bool isSwitchable = is(typeof({
+    enum bool isSwitchable = is(typeof(
+    {
         switch (E.init) { default: }
     }));
 }

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -9848,7 +9848,8 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         alias testBad = testBadParse822!cr;
@@ -10114,7 +10115,8 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         {
@@ -10604,7 +10606,8 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
 
     foreach (cr; AliasSeq!(function(string a){return cast(ubyte[]) a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         scope(failure) writeln(typeof(cr).stringof);
 
         assert(_stripCFWS(cr("")).empty);

--- a/std/exception.d
+++ b/std/exception.d
@@ -496,7 +496,8 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
     {
         static int g;
         ~this() {}  // impure & unsafe destructor
-        bool opCast(T:bool)() {
+        bool opCast(T:bool)()
+        {
             int* p = cast(int*) 0;   // unsafe operation
             int n = g;              // impure operation
             return true;
@@ -2152,7 +2153,8 @@ pure nothrow @safe unittest
 
     auto save = f.handle!(Exception,
         RangePrimitive.save,
-        function(Exception e, ref ThrowingRange r) {
+        function(Exception e, ref ThrowingRange r)
+        {
             return ThrowingRange();
         })();
 

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -395,7 +395,8 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     import std.experimental.allocator.building_blocks.bitmapped_block
         : BitmappedBlock;
     import std.experimental.allocator.common : testAllocator;
-    testAllocator!({
+    testAllocator!(
+    {
         auto a = AffixAllocator!(BitmappedBlock!128, ulong, ulong)
             (BitmappedBlock!128(new ubyte[128 * 4096]));
         return a;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -693,7 +693,8 @@ it actually returns memory to the operating system when possible.
     from the garbage-collected heap. Each block is organized as a KR-style
     heap. More blocks are allocated and freed on a need basis.
     */
-    AllocatorList!((n) {
+    AllocatorList!((n)
+    {
         auto result = KRRegion!MmapAllocator(max(n * 2, 1024 * 1024));
         return result;
     }) alloc;

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -615,7 +615,8 @@ public:
             import std.range : repeat;
 
             static PerCallStatistics s = { f, n, [ opts ],
-                repeat(0UL, opts.length).array };
+                repeat(0UL, opts.length).array
+            };
             static bool inserted;
 
             if (!inserted)

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -462,7 +462,7 @@ version(unittest)
              {
                  a.alignedDeallocate(b3);
              }
-         }}
+        }}
         else
         {
             static assert(!hasMember!(A, "alignedDeallocate"));
@@ -483,7 +483,7 @@ version(unittest)
              assert(b4.length);
              // Can't get any more memory
              assert(!ab.allocate(1).ptr);
-         }}
+        }}
 
         static if (hasMember!(A, "expand"))
         {{
@@ -499,7 +499,7 @@ version(unittest)
              assert(b5 is null);
              assert(!aa.expand(b5, 1));
              assert(b5.length == 0);
-         }}
+        }}
 
         void[] b6 = null;
         assert(a.reallocate(b6, 0));
@@ -516,7 +516,7 @@ version(unittest)
              assert(a.owns(b1) == Ternary.yes);
              assert(a.owns(b2) == Ternary.yes);
              assert(a.owns(b6) == Ternary.yes);
-         }}
+        }}
 
         static if (hasMember!(A, "resolveInternalPointer"))
         {{
@@ -542,7 +542,7 @@ version(unittest)
              assert(a.resolveInternalPointer(b8.ptr, p) == Ternary.no);
              assert(a.resolveInternalPointer(b8.ptr + b8.length / 2, p) == Ternary.no);
              assert(a.resolveInternalPointer(b8.ptr + b8.length, p) == Ternary.no);
-         }}
+        }}
     }
 
     package void testAllocatorObject(AllocInterface)(AllocInterface a)

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -857,9 +857,10 @@ nothrow @safe @nogc unittest
     cast(void) Mallocator.instance.make!Pure(0);
 
     static int g = 0;
-    static struct Impure { this(int) nothrow @nogc @safe {
-        g++;
-    } }
+    static struct Impure
+    {
+        this(int) nothrow @nogc @safe { g++; }
+    }
     static assert(!__traits(compiles, cast(void) Mallocator.instance.make!Impure(0)));
 }
 
@@ -1394,7 +1395,8 @@ if (isInputRange!R && !isInfinite!R)
         int val;
         @disable this();
 
-        this(int b){
+        this(int b)
+        {
             this.val = i++;
         }
 

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -750,7 +750,8 @@ abstract class Logger
     this(LogLevel lv) @safe
     {
         this.logLevel_ = lv;
-        this.fatalHandler_ = delegate() {
+        this.fatalHandler_ = delegate()
+        {
             throw new Error("A fatal log message was logged");
         };
 
@@ -1627,7 +1628,8 @@ private @property Logger defaultSharedLoggerImpl() @trusted
     static __gshared align(FileLogger.alignof) void[__traits(classInstanceSize, FileLogger)] _buffer;
 
     import std.concurrency : initOnce;
-    initOnce!stdSharedDefaultLogger({
+    initOnce!stdSharedDefaultLogger(
+    {
         auto buffer = cast(ubyte[]) _buffer;
         return emplace!FileLogger(buffer, stderr, LogLevel.all);
     }());
@@ -1877,7 +1879,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(tl1.line == __LINE__ - 3);
 
     auto oldunspecificLogger = sharedLog;
-    scope(exit) {
+    scope(exit)
+    {
         sharedLog = oldunspecificLogger;
     }
 
@@ -1928,7 +1931,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
 {
     bool errorThrown = false;
     auto tl = new TestLogger;
-    auto dele = delegate() {
+    auto dele = delegate()
+    {
         errorThrown = true;
     };
     tl.fatalHandler = dele;
@@ -1979,7 +1983,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(l.line == lineNumber);
     assert(l.logLevel == LogLevel.all);
 
-    () @trusted {
+    () @trusted
+    {
         assertThrown!Throwable(l.logf(LogLevel.fatal, msg, "Yet"));
     } ();
     lineNumber = __LINE__ - 2;
@@ -1987,7 +1992,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(l.line == lineNumber);
     assert(l.logLevel == LogLevel.all);
 
-    () @trusted {
+    () @trusted
+    {
         assertThrown!Throwable(l.logf(LogLevel.fatal, true, msg, "Yet"));
     } ();
     lineNumber = __LINE__ - 2;
@@ -2056,7 +2062,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(l.logLevel == LogLevel.all);
 
     msg = "%s Another message";
-    () @trusted {
+    () @trusted
+    {
         assertThrown!Throwable(logf(LogLevel.fatal, msg, "Yet"));
     } ();
     lineNumber = __LINE__ - 2;
@@ -2064,7 +2071,8 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(l.line == lineNumber);
     assert(l.logLevel == LogLevel.all);
 
-    () @trusted {
+    () @trusted
+    {
         assertThrown!Throwable(logf(LogLevel.fatal, true, msg, "Yet"));
     } ();
     lineNumber = __LINE__ - 2;
@@ -3041,7 +3049,8 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 
     foreach (i; 0 .. 4)
     {
-        spawned ~= new Thread({
+        spawned ~= new Thread(
+        {
             stdThreadLocalLog = new TestLog;
             trace("zzzzzzzzzz");
         });

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -133,28 +133,35 @@ if (Targets.length >= 1 && !allSatisfy!(isMutable, Targets))
 
 @safe unittest
 {
-    interface Foo {
+    interface Foo
+    {
         void foo();
     }
-    interface Bar {
+    interface Bar
+    {
         void bar();
     }
-    interface FooBar : Foo, Bar {
+    interface FooBar : Foo, Bar
+    {
         void foobar();
     }
 
-    struct A {
+    struct A
+    {
         void foo() {}
     }
-    struct B {
+    struct B
+    {
         void bar() {}
         void foobar() {}
     }
-    class C {
+    class C
+    {
         void foo() {}
         void bar() {}
     }
-    struct D {
+    struct D
+    {
         void foo() {}
         void bar() {}
         void foobar() {}

--- a/std/file.d
+++ b/std/file.d
@@ -2554,7 +2554,8 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) ||
         enum maxCodeUnits = 6;
         char[bufferLen] buffer;
         const linkz = link.tempCString();
-        auto size = () @trusted {
+        auto size = () @trusted
+        {
             return posixReadlink(linkz, buffer.ptr, buffer.length);
         } ();
         cenforce(size != -1, to!string(link));
@@ -2566,7 +2567,8 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) ||
 
         foreach (i; 0 .. 10)
         {
-            size = () @trusted {
+            size = () @trusted
+            {
                 return posixReadlink(linkz, dynamicBuffer.ptr,
                     dynamicBuffer.length);
             } ();
@@ -2575,7 +2577,8 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) ||
             if (size <= dynamicBuffer.length - maxCodeUnits)
             {
                 dynamicBuffer.length = size;
-                return () @trusted {
+                return () @trusted
+                {
                     return assumeUnique(dynamicBuffer);
                 } ();
             }

--- a/std/format.d
+++ b/std/format.d
@@ -1696,7 +1696,8 @@ FormatSpec!Char singleSpec(Char)(Char[] fmt)
     enforce(fmt.length >= 2, "fmt must be at least 2 characters long");
     enforce(fmt.front == '%', "fmt must start with a '%' character");
 
-    static struct DummyOutputRange {
+    static struct DummyOutputRange
+    {
         void put(C)(C[] buf) {} // eat elements
     }
     auto a = DummyOutputRange();
@@ -1864,7 +1865,8 @@ if (is(IntegralTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     if (f.spec == 'r')
     {
         // raw write, skip all else and write the thing
-        auto raw = (ref val)@trusted{
+        auto raw = (ref val)@trusted
+        {
             return (cast(const char*) &val)[0 .. val.sizeof];
         }(val);
         if (needToSwapEndianess(f))
@@ -2144,7 +2146,8 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     if (fs.spec == 'r')
     {
         // raw write, skip all else and write the thing
-        auto raw = (ref val)@trusted{
+        auto raw = (ref val)@trusted
+        {
             return (cast(const char*) &val)[0 .. val.sizeof];
         }(val);
         if (needToSwapEndianess(f))
@@ -2220,7 +2223,8 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     //printf("format: '%s'; geeba: %g\n", sprintfSpec.ptr, val);
     char[512] buf = void;
 
-    immutable n = ()@trusted{
+    immutable n = ()@trusted
+    {
         import core.stdc.stdio : snprintf;
         return snprintf(buf.ptr, buf.length,
                         sprintfSpec.ptr,
@@ -3145,9 +3149,11 @@ if (is(StringTypeOf!T) && !is(T == enum))
     // Test for bug 8015
     import std.typecons;
 
-    struct MyStruct {
+    struct MyStruct
+    {
         string str;
-        @property string toStr() {
+        @property string toStr()
+        {
             return str;
         }
         alias toStr this;
@@ -3390,7 +3396,8 @@ void enforceValidFormatSpec(T, Char)(const ref FormatSpec!Char f)
     static class CF2 { override string toString() { return ""; } }
 
     static interface IK1 { void toString(scope void delegate(const(char)[]) sink,
-                           FormatSpec!char) const; }
+                           FormatSpec!char) const;
+    }
     static class CIK1 : IK1 { override void toString(scope void delegate(const(char)[]) sink,
                               FormatSpec!char) const { sink("CIK1"); } }
     static struct KS1 { void toString(scope void delegate(const(char)[]) sink,
@@ -3771,7 +3778,8 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     static struct Bug7230
     {
         string s = "hello";
-        union {
+        union
+        {
             string a;
             int b;
             double c;
@@ -5266,7 +5274,8 @@ body
 
                 result[key] = unformatElement!(typeof(T.init.values[0]))(input, fmt);
             }
-            debug (unformatRange) {
+            debug (unformatRange)
+            {
             if (input.empty) printf("-> front = [empty] ");
             else             printf("-> front = %c ", input.front);
             }
@@ -5281,7 +5290,8 @@ body
                 fmt.readUpToNextSpec(input);
             auto sep = spec.sep !is null ? spec.sep
                          : fmt.trailing;
-            debug (unformatRange) {
+            debug (unformatRange)
+            {
             if (!sep.empty && !input.empty) printf("-> %c, sep = %.*s\n", input.front, sep);
             else                            printf("\n");
             }
@@ -5975,7 +5985,8 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 
 @safe unittest
 {
-    assertCTFEable!({
+    assertCTFEable!(
+    {
     auto tmp = format("%,d", 1000);
     assert(tmp == "1,000", "'" ~ tmp ~ "'");
 

--- a/std/functional.d
+++ b/std/functional.d
@@ -84,7 +84,8 @@ private template needOpCallAlias(alias fun)
      */
     static if (is(typeof(fun.opCall) == function))
     {
-        enum needOpCallAlias = !is(typeof(fun)) && __traits(compiles, () {
+        enum needOpCallAlias = !is(typeof(fun)) && __traits(compiles, ()
+        {
             return fun(Parameters!fun.init);
         });
     }
@@ -1155,7 +1156,8 @@ template memoize(alias fun, uint maxSize)
     assert(fact(10) == 3628800);
 
     // Issue 12568
-    static uint len2(const string s) { // Error
+    static uint len2(const string s)  // Error
+    {
     alias mLen2 = memoize!len2;
     if (s.length == 0)
         return 0;
@@ -1264,12 +1266,15 @@ if (isCallable!(F))
     {
         alias DelType = typeof(&(new DelegateFaker!(F)).doIt);
 
-        static struct DelegateFields {
-            union {
+        static struct DelegateFields
+        {
+            union
+            {
                 DelType del;
                 //pragma(msg, typeof(del));
 
-                struct {
+                struct
+                {
                     void* contextPtr;
                     void* funcPtr;
                 }
@@ -1294,7 +1299,8 @@ if (isCallable!(F))
 ///
 @system unittest
 {
-    static int inc(ref uint num) {
+    static int inc(ref uint num)
+    {
         num++;
         return 8675309;
     }
@@ -1307,7 +1313,8 @@ if (isCallable!(F))
 
 @system unittest // not @safe due to toDelegate
 {
-    static int inc(ref uint num) {
+    static int inc(ref uint num)
+    {
         num++;
         return 8675309;
     }

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -465,7 +465,8 @@ GetoptResult getopt(T...)(ref string[] args, T opts)
    You can pass them to $(D getopt) in any position, except in between an option
    string and its bound pointer.
 */
-enum config {
+enum config
+{
     /// Turn case sensitivity on
     caseSensitive,
     /// Turn case sensitivity off (default)
@@ -490,14 +491,16 @@ enum config {
 
 $(D helpWanted) is set if the option `--help` or `-h` was passed to the option parser.
 */
-struct GetoptResult {
+struct GetoptResult
+{
     bool helpWanted; /// Flag indicating if help was requested
     Option[] options; /// All possible options
 }
 
 /** Information about an option.
 */
-struct Option {
+struct Option
+{
     string optShort; /// The short symbol for this option
     string optLong; /// The long symbol for this option
     string help; /// The description of this option
@@ -1443,7 +1446,8 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
 {
     import std.exception;
 
-    enum Foo {
+    enum Foo
+    {
         bar,
         baz
     }

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -113,7 +113,8 @@ private:
         opAssign(x);
     }
 
-    enum trustedAssumeUnique = function(BigDigit[] input) pure @trusted @nogc {
+    enum trustedAssumeUnique = function(BigDigit[] input) pure @trusted @nogc
+    {
         return assumeUnique(input);
     };
 public:

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -742,7 +742,7 @@ string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure
  */
 uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
         multiplier, uint carry) pure
-        {
+{
     // Timing: This is the most time-critical bignum function.
     // Pentium M: 5.4 cycles/operation, still has 2 resource stalls + 1load block/iteration
 
@@ -835,7 +835,7 @@ L_enter_odd:
  */
 void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
         const uint [] right) pure
-        {
+{
     // Register usage
     // EDX:EAX = used in multiply
     // EBX = index

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -121,7 +121,8 @@ uint multibyteAddSub(char op)(uint[] dest, const uint [] src1, const uint []
     // a resister (AL), and restoring it after the branch.
 
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push EDI;
         push EBX;
@@ -148,7 +149,8 @@ L_unrolled:
         ~ ( op == '+' ? "adc" : "sbb" ) ~ " EAX, [@*4-8*4+ESI+ECX*4];"
         ~ "mov [@*4-8*4+EDI+ECX*4], EAX;")
         ~ "}");
-    asm pure nothrow {
+    asm pure nothrow
+    {
         setc AL; // save carry
         add ECX, 8;
         ja L_unrolled;
@@ -164,7 +166,8 @@ L_residual:
         "mov EAX, [@*4+EDX+ECX*4];"
         ~ ( op == '+' ? "adc" : "sbb" ) ~ " EAX, [@*4+ESI+ECX*4];"
         ~ "mov [@*4+EDI+ECX*4], EAX;") ~ "}");
-    asm pure nothrow {
+    asm pure nothrow
+    {
         setc AL; // save carry
         add ECX, 1;
         jnz L_residual;
@@ -227,7 +230,8 @@ done:
 uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
 {
     enum { LASTPARAM = 1*4 } // 0* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         mov ECX, [ESP + LASTPARAM + 0*4]; // dest.length;
         mov EDX, [ESP + LASTPARAM + 1*4]; // dest.ptr
@@ -238,7 +242,8 @@ L1: ;
         asm pure nothrow { add [EDX], EAX; }
     else
         asm pure nothrow { sub [EDX], EAX; }
-    asm pure nothrow {
+    asm pure nothrow
+    {
         mov EAX, 1;
         jnc L2;
         add EDX, 4;
@@ -260,7 +265,8 @@ uint multibyteShlNoMMX(uint [] dest, const uint [] src, uint numbits) pure
     // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // 5.0 cycles/int on Athlon, which has 7 cycles for SHLD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -310,7 +316,8 @@ uint multibyteShl(uint [] dest, const uint [] src, uint numbits) pure
     // Timing:
     // K7 1.2/int. PM 1.7/int P4 5.3/int
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -391,7 +398,8 @@ L_length1:
 void multibyteShr(uint [] dest, const uint [] src, uint numbits) pure
 {
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -481,7 +489,8 @@ void multibyteShrNoMMX(uint [] dest, const uint [] src, uint numbits) pure
     // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // Terrible performance on AMD64, which has 7 cycles for SHRD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -581,7 +590,8 @@ uint multibyteMul(uint[] dest, const uint[] src, uint multiplier, uint carry)
     {
         __gshared int zero = 0;
     }
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -636,7 +646,8 @@ L_odd:
 // Multiples by M_ADDRESS which should be "ESP+LASTPARAM" or "ESP". OP must be "add" or "sub"
 // This is the most time-critical code in the BigInt library.
 // It is used by both MulAdd, multiplyAccumulate, and triangleAccumulate
-string asmMulAdd_innerloop(string OP, string M_ADDRESS) pure {
+string asmMulAdd_innerloop(string OP, string M_ADDRESS) pure
+{
     // The bottlenecks in this code are extremely complicated. The MUL, ADD, and ADC
     // need 4 cycles on each of the ALUs units p0 and p1. So we use memory load
     // (unit p2) for initializing registers to zero.
@@ -730,7 +741,8 @@ string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure
  * Returns carry out of MSB (0 .. FFFF_FFFF).
  */
 uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
-        multiplier, uint carry) pure {
+        multiplier, uint carry) pure
+        {
     // Timing: This is the most time-critical bignum function.
     // Pentium M: 5.4 cycles/operation, still has 2 resource stalls + 1load block/iteration
 
@@ -760,7 +772,8 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
     }
 
     enum { LASTPARAM = 5*4 } // 4* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
 
         push ESI;
@@ -783,7 +796,8 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
     }
     // Main loop, with entry point for even length
     mixin("asm pure nothrow {" ~ asmMulAdd_innerloop(OP, "ESP+LASTPARAM") ~ "}");
-    asm pure nothrow {
+    asm pure nothrow
+    {
         mov EAX, EBP; // get final carry
         pop EBP;
         pop EBX;
@@ -820,7 +834,8 @@ L_enter_odd:
     ----
  */
 void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
-        const uint [] right) pure {
+        const uint [] right) pure
+        {
     // Register usage
     // EDX:EAX = used in multiply
     // EBX = index
@@ -844,7 +859,8 @@ void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
 
         push ESI;
@@ -876,7 +892,8 @@ outer_loop:
     }
     // -- Inner loop, with even entry point
     mixin("asm pure nothrow { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
-    asm pure nothrow {
+    asm pure nothrow
+    {
         mov [-4+EDI+4*EBX], EBP;
         add EDI, 4;
         cmp EDI, [ESP + LASTPARAM + 4*0]; // is EDI = &dest[$]?
@@ -922,7 +939,8 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow) pure
     // [ESP] = kinv (2^64 /divisor)
     enum { LASTPARAM = 5*4 } // 4* pushes + return address.
     enum { LOCALS = 2*4} // MASK, KINV
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
 
         push ESI;
@@ -1037,7 +1055,8 @@ void multibyteAddDiagonalSquares(uint [] dest, const uint [] src) pure
            improve it by moving the mov EAX after the adc [EDI], EAX. Probably not worthwhile.
     */
     enum { LASTPARAM = 4*5 } // 4* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
         push ESI;
         push EDI;
@@ -1128,7 +1147,8 @@ void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.
-    asm pure nothrow {
+    asm pure nothrow
+    {
         naked;
 
         push ESI;
@@ -1173,7 +1193,8 @@ outer_loop:
     }
     // -- Inner loop, with even entry point
     mixin("asm pure nothrow { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
-    asm pure nothrow {
+    asm pure nothrow
+    {
         mov [-4+EDI+4*EBX], EBP;
         add EDI, 4;
         cmp EDI, [ESP + LASTPARAM + 4*2]; // is EDI = &dest[$-3]?

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -30,7 +30,8 @@ nothrow:
 @safe:
 @nogc:
 
-private {
+private
+{
 immutable real EXP_2  = 0.135335283236612691893999494972484403L; /* exp(-2) */
 enum real SQRT2PI = 2.50662827463100050241576528481104525L; // sqrt(2pi)
 
@@ -45,7 +46,8 @@ T rationalPoly(T)(T x, const(T) [] numerator, const(T) [] denominator) pure noth
 }
 
 
-private {
+private
+{
 
 /* erfc(x) = exp(-x^2) P(1/x)/Q(1/x)
    1/8 <= 1/x <= 1
@@ -747,7 +749,8 @@ real erfc(real a)
 }
 
 
-private {
+private
+{
 /* Exponentially scaled erfc function
    exp(x^2) erfc(x)
    valid for x > 1.
@@ -1021,7 +1024,8 @@ assert(isIdentical(normalDistributionImpl(NaN(0x325)), NaN(0x325)));
  */
 // TODO: isIEEEQuadruple (128 bit) real implementation; not available from CEPHES.
 real normalDistributionInvImpl(real p)
-in {
+in
+{
   assert(p >= 0.0L && p <= 1.0L, "Domain error");
 }
 body

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -27,7 +27,8 @@ nothrow:
 @safe:
 @nogc:
 
-private {
+private
+{
 
 enum real SQRT2PI = 2.50662827463100050242E0L; // sqrt(2pi)
 immutable real EULERGAMMA = 0.57721_56649_01532_86060_65120_90082_40243_10421_59335_93992L; /** Euler-Mascheroni constant 0.57721566.. */
@@ -574,7 +575,8 @@ real logGamma(real x)
 }
 
 
-private {
+private
+{
 static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
 {
     enum real MAXLOG = 0x1.62e42fefa39ef358p+13L;  // log(real.max)
@@ -990,7 +992,8 @@ done:
     return x;
 }
 
-@safe unittest { // also tested by the normal distribution
+@safe unittest  // also tested by the normal distribution
+{
     // check NaN propagation
     assert(isIdentical(betaIncomplete(NaN(0xABC),2,3), NaN(0xABC)));
     assert(isIdentical(betaIncomplete(7,NaN(0xABC),3), NaN(0xABC)));
@@ -1060,7 +1063,8 @@ done:
 }
 
 
-private {
+private
+{
 // Implementation functions
 
 // Continued fraction expansion #1 for incomplete beta integral
@@ -1296,11 +1300,13 @@ real betaDistPowerSeries(real a, real b, real x )
  * values of a and x.
  */
 real gammaIncomplete(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+body
+{
     /* left tail of incomplete gamma function:
      *
      *          inf.      k
@@ -1340,11 +1346,13 @@ body {
 
 /** ditto */
 real gammaIncompleteCompl(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+body
+{
     if (x == 0)
         return 1.0L;
     if ( (x < 1.0L) || (x < a) )
@@ -1426,11 +1434,13 @@ body {
  * root of incompleteGammaCompl(a,x) - p = 0.
  */
 real gammaIncompleteComplInv(real a, real p)
-in {
+in
+{
   assert(p >= 0 && p <= 1);
   assert(a>0);
 }
-body {
+body
+{
     if (p == 0) return real.infinity;
 
     real y0 = p;

--- a/std/json.d
+++ b/std/json.d
@@ -330,7 +330,8 @@ struct JSONValue
         {
             type_tag = JSON_TYPE.STRING;
             // FIXME: std.array.array(Range) is not deduced as 'pure'
-            () @trusted {
+            () @trusted
+            {
                 import std.utf : byUTF;
                 store.str = cast(immutable)(arg.byUTF!char.array);
             }();
@@ -842,7 +843,8 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
         return str.data.length ? str.data : "";
     }
 
-    bool tryGetSpecialFloat(string str, out double val) {
+    bool tryGetSpecialFloat(string str, out double val)
+    {
         switch (str)
         {
             case JSONFloatLiteral.nan:
@@ -1641,7 +1643,8 @@ EOF";
     import std.math : isInfinity, isNaN;
 
     // expected representations of NaN and Inf
-    enum {
+    enum
+    {
         nanString         = '"' ~ JSONFloatLiteral.nan         ~ '"',
         infString         = '"' ~ JSONFloatLiteral.inf         ~ '"',
         negativeInfString = '"' ~ JSONFloatLiteral.negativeInf ~ '"',
@@ -1692,7 +1695,8 @@ pure nothrow @safe @nogc unittest
 pure nothrow @safe unittest // issue 15884
 {
     import std.typecons;
-    void Test(C)() {
+    void Test(C)()
+    {
         C[] a = ['x'];
         JSONValue testVal = a;
         assert(testVal.type == JSON_TYPE.STRING);

--- a/std/math.d
+++ b/std/math.d
@@ -1204,7 +1204,8 @@ real atan2(real y, real x) @trusted pure nothrow @nogc
     {
         version (Win64)
         {
-            asm pure nothrow @nogc {
+            asm pure nothrow @nogc
+            {
                 naked;
                 fld real ptr [RDX]; // y
                 fld real ptr [RCX]; // x
@@ -1214,7 +1215,8 @@ real atan2(real y, real x) @trusted pure nothrow @nogc
         }
         else
         {
-            asm pure nothrow @nogc {
+            asm pure nothrow @nogc
+            {
                 fld y;
                 fld x;
                 fpatan;
@@ -2809,7 +2811,8 @@ if (isFloatingPoint!T)
 @safe unittest
 {
     import std.meta : AliasSeq;
-    void foo() {
+    void foo()
+    {
         foreach (T; AliasSeq!(real, double, float))
         {
             int exp;
@@ -3695,7 +3698,8 @@ real scalbn(real x, int n) @trusted nothrow @nogc
         // scalbnl is not supported on DMD-Windows, so use asm pure nothrow @nogc.
         version (Win64)
         {
-            asm pure nothrow @nogc {
+            asm pure nothrow @nogc
+            {
                 naked                           ;
                 mov     16[RSP],RCX             ;
                 fild    word ptr 16[RSP]        ;
@@ -3707,7 +3711,8 @@ real scalbn(real x, int n) @trusted nothrow @nogc
         }
         else
         {
-            asm pure nothrow @nogc {
+            asm pure nothrow @nogc
+            {
                 fild n;
                 fld x;
                 fscale;
@@ -4764,7 +4769,8 @@ public:
 ///
 @system unittest
 {
-    static void func() {
+    static void func()
+    {
         int a = 10 * 10;
     }
 
@@ -5734,7 +5740,8 @@ if (isIntegral!(X) && isFloatingPoint!(R))
     foreach (X; AliasSeq!(float, double, real, int, long))
     {
         foreach (Y; AliasSeq!(float, double, real))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             X x = 21;
             Y y = 23.8;
             Y e = void;

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -253,21 +253,25 @@ real betaIncompleteInverse(real a, real b, real y )
  * values of a and x.
  */
 real gammaIncomplete(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+body
+{
     return std.internal.math.gammafunction.gammaIncomplete(a, x);
 }
 
 /** ditto */
 real gammaIncompleteCompl(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+body
+{
     return std.internal.math.gammafunction.gammaIncompleteCompl(a, x);
 }
 
@@ -278,11 +282,13 @@ body {
  *  gammaIncompleteCompl( a, x ) = p.
  */
 real gammaIncompleteComplInverse(real a, real p)
-in {
+in
+{
   assert(p >= 0 && p <= 1);
   assert(a > 0);
 }
-body {
+body
+{
     return std.internal.math.gammafunction.gammaIncompleteComplInv(a, p);
 }
 
@@ -352,7 +358,8 @@ real normalDistribution(real x)
  * Note: This function is only implemented to 80 bit precision.
  */
 real normalDistributionInverse(real p)
-in {
+in
+{
   assert(p >= 0.0L && p <= 1.0L, "Domain error");
 }
 body

--- a/std/meta.d
+++ b/std/meta.d
@@ -1292,7 +1292,8 @@ private template SmartAlias(T...)
 
 @safe unittest
 {
-    static assert(is(typeof({
+    static assert(is(typeof(
+    {
         alias T(T0, int a, double b, alias T1, string c) = AliasSeq!(T0, a, b, T1, c);
         alias T0 = ApplyRight!(ApplyLeft, ApplyRight);
         alias T1 = T0!ApplyLeft;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -424,7 +424,8 @@ if (isCurlConn!Conn)
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             assert(s.recvReq.hdrs.canFind("GET /"));
             s.send(httpOK("Hello world"));
         });
@@ -493,7 +494,8 @@ if (isCurlConn!Conn)
         auto fn = std.file.deleteme;
         scope (exit) std.file.remove(fn);
         std.file.write(fn, "upload data\n");
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             assert(req.hdrs.canFind("PUT /path"));
             assert(req.bdy.canFind("upload data"));
@@ -559,7 +561,8 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             assert(s.recvReq.hdrs.canFind("GET /path"));
             s.send(httpOK("GETRESPONSE"));
         });
@@ -612,7 +615,8 @@ if (is(T == char) || is(T == ubyte))
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             assert(req.hdrs.canFind("POST /path"));
             assert(req.bdy.canFind("POSTBODY"));
@@ -631,7 +635,8 @@ if (is(T == char) || is(T == ubyte))
     foreach (i, ref ub; data)
         ub = cast(ubyte) i;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq!ubyte;
         assert(req.bdy.canFind(cast(ubyte[])[0, 1, 2, 3, 4]));
         assert(req.bdy.canFind(cast(ubyte[])[253, 254, 255]));
@@ -654,7 +659,8 @@ if (is(T == char) || is(T == ubyte))
 {
     foreach (host; [testServer.addr, "http://" ~ testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq!char;
             s.send(httpOK(req.bdy));
         });
@@ -719,7 +725,8 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             assert(req.hdrs.canFind("PUT /path"));
             assert(req.bdy.canFind("PUTBODY"));
@@ -786,7 +793,8 @@ if (isCurlConn!Conn)
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             assert(req.hdrs.canFind("DELETE /path"));
             s.send(httpOK());
@@ -830,7 +838,8 @@ if (is(T == char) || is(T == ubyte))
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("OPTIONS /path"));
         s.send(httpOK("OPTIONSRESPONSE"));
@@ -872,7 +881,8 @@ if (is(T == char) || is(T == ubyte))
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("TRACE /path"));
         s.send(httpOK("TRACERESPONSE"));
@@ -913,7 +923,8 @@ if (is(T == char) || is(T == ubyte))
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("CONNECT /path"));
         s.send(httpOK("CONNECTRESPONSE"));
@@ -959,7 +970,8 @@ if (is(T == char) || is(T == ubyte))
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("PATCH /path"));
         assert(req.bdy.canFind("PATCHBODY"));
@@ -1058,7 +1070,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("GET /path"));
         s.send(httpNotFound());
@@ -1072,7 +1085,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
 {
     import std.algorithm.searching : canFind;
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         auto req = s.recvReq;
         assert(req.hdrs.canFind("POST /"));
         assert(req.bdy.canFind("POSTBODY"));
@@ -1095,7 +1109,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
 
 @system unittest // charset detection and transcoding to T
 {
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         s.send("HTTP/1.1 200 OK\r\n"~
         "Content-Length: 4\r\n"~
         "Content-Type: text/plain; charset=utf-8\r\n" ~
@@ -1106,7 +1121,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     auto result = _basicHTTP!char(testServer.addr, "", client);
     assert(result == "äbc");
 
-    testServer.handle((s) {
+    testServer.handle((s)
+    {
         s.send("HTTP/1.1 200 OK\r\n"~
         "Content-Length: 3\r\n"~
         "Content-Type: text/plain; charset=iso-8859-1\r\n" ~
@@ -1329,7 +1345,8 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             s.send(httpOK("Line1\nLine2\nLine3"));
         });
@@ -1403,7 +1420,8 @@ if (isCurlConn!(Conn))
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
         });
@@ -1698,7 +1716,8 @@ auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char)
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             s.send(httpOK("Line1\nLine2\nLine3"));
         });
@@ -1846,7 +1865,8 @@ if (isCurlConn!(Conn))
 
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             s.send(httpOK(cast(ubyte[])[0, 1, 2, 3, 4, 5]));
         });
@@ -2111,7 +2131,8 @@ private mixin template Protocol()
     {
         import std.algorithm.searching : canFind;
 
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq;
             assert(req.hdrs.canFind("GET /"));
             assert(req.hdrs.canFind("Basic dXNlcjpwYXNz"));
@@ -3088,7 +3109,8 @@ struct HTTP
     {
         import std.algorithm.searching : canFind;
 
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             auto req = s.recvReq!ubyte;
             assert(req.hdrs.canFind("POST /path"));
             assert(req.bdy.canFind(cast(ubyte[])[0, 1, 2, 3, 4]));
@@ -3260,7 +3282,8 @@ struct HTTP
     foreach (c; AliasSeq!("charset", "Charset", "CHARSET", "CharSet", "charSet",
         "ChArSeT", "cHaRsEt"))
     {
-        testServer.handle((s) {
+        testServer.handle((s)
+        {
             s.send("HTTP/1.1 200 OK\r\n"~
                 "Content-Length: 0\r\n"~
                 "Content-Type: text/plain; " ~ c ~ "=foo\r\n" ~
@@ -4249,7 +4272,8 @@ struct Curl
         copy.handle = curl.easy_duphandle(handle);
         copy._stopped = false;
 
-        with (CurlOption) {
+        with (CurlOption)
+        {
             auto tt = AliasSeq!(file, writefunction, writeheader,
                 headerfunction, infile, readfunction, ioctldata, ioctlfunction,
                 seekdata, seekfunction, sockoptdata, sockoptfunction,

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -462,7 +462,8 @@ public:
     }
 
     /// Returns: smallest representable normalized value that's not 0
-    static @property CustomFloat min_normal() {
+    static @property CustomFloat min_normal()
+    {
         CustomFloat value;
         static if (flags & Flags.signed)
         value.sign        = 0;
@@ -2673,7 +2674,8 @@ T gcd(T)(T a, T b)
 {
     import std.algorithm.mutation : swap;
 
-    enum canUseBinaryGcd = is(typeof(() {
+    enum canUseBinaryGcd = is(typeof(()
+    {
         T t, u;
         t <<= 1;
         t >>= 1;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2352,7 +2352,8 @@ public:
         Parameters!C1.length == 1 &&
         Parameters!C2.length == 0 &&
         isArray!(Parameters!C1[0])
-    ) {
+    )
+    {
         auto roundRobin = RoundRobinBuffer!(C1, C2)(next, empty, initialBufSize, nBuffers);
         return asyncBuf(roundRobin, nBuffers / 2);
     }
@@ -3287,7 +3288,8 @@ terminating the main thread.
 {
     import std.concurrency : initOnce;
     __gshared TaskPool pool;
-    return initOnce!pool({
+    return initOnce!pool(
+    {
         auto p = new TaskPool(defaultPoolThreads);
         p.isDaemon = true;
         return p;
@@ -3867,7 +3869,8 @@ private struct RoundRobinBuffer(C1, C2)
         C2 emptyDel,
         size_t initialBufSize,
         size_t nBuffers
-    ) {
+    )
+    {
         this.nextDel = nextDel;
         this.emptyDel = emptyDel;
         bufs.length = nBuffers;
@@ -4004,7 +4007,8 @@ version(unittest)
     t3.spinForce++;
     assert(t3.args[0] == 1);
 
-    static void testSafe() @safe {
+    static void testSafe() @safe
+    {
         static int bump(int num)
         {
             return num + 1;
@@ -4620,7 +4624,8 @@ version(unittest)
     import std.algorithm.iteration : each;
 
     long[] arr;
-    static assert(is(typeof({
+    static assert(is(typeof(
+    {
         arr.parallel.each!"a++";
     })));
 }

--- a/std/process.d
+++ b/std/process.d
@@ -2445,7 +2445,8 @@ version (Windows) private immutable string shellSwitch = "/C";
     tidA = thisThreadID;
 
     import core.thread;
-    auto t = new Thread({
+    auto t = new Thread(
+    {
         pidB = thisProcessID;
         tidB = thisThreadID;
     });

--- a/std/random.d
+++ b/std/random.d
@@ -1918,7 +1918,8 @@ body
     {
 
         foreach (T; std.meta.AliasSeq!(float, double, real))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             UniformRNG rng = UniformRNG(unpredictableSeed);
 
             auto a = uniform01();

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -93,7 +93,8 @@ import std.traits;
  * See_Also:
  * $(LREF inputRangeObject)
  */
-interface InputRange(E) {
+interface InputRange(E)
+{
     ///
     @property E front();
 
@@ -131,7 +132,8 @@ interface InputRange(E) {
     import std.algorithm.iteration : map;
     import std.range : iota;
 
-    void useRange(InputRange!int range) {
+    void useRange(InputRange!int range)
+    {
         // Function body.
     }
 
@@ -146,13 +148,15 @@ interface InputRange(E) {
 }
 
 /**Interface for a forward range of type $(D E).*/
-interface ForwardRange(E) : InputRange!E {
+interface ForwardRange(E) : InputRange!E
+{
     ///
     @property ForwardRange!E save();
 }
 
 /**Interface for a bidirectional range of type $(D E).*/
-interface BidirectionalRange(E) : ForwardRange!(E) {
+interface BidirectionalRange(E) : ForwardRange!(E)
+{
     ///
     @property BidirectionalRange!E save();
 
@@ -167,7 +171,8 @@ interface BidirectionalRange(E) : ForwardRange!(E) {
 }
 
 /**Interface for a finite random access range of type $(D E).*/
-interface RandomAccessFinite(E) : BidirectionalRange!(E) {
+interface RandomAccessFinite(E) : BidirectionalRange!(E)
+{
     ///
     @property RandomAccessFinite!E save();
 
@@ -193,7 +198,8 @@ interface RandomAccessFinite(E) : BidirectionalRange!(E) {
 }
 
 /**Interface for an infinite random access range of type $(D E).*/
-interface RandomAccessInfinite(E) : ForwardRange!E {
+interface RandomAccessInfinite(E) : ForwardRange!E
+{
     ///
     E moveAt(size_t);
 
@@ -205,7 +211,8 @@ interface RandomAccessInfinite(E) : ForwardRange!E {
 }
 
 /**Adds assignable elements to InputRange.*/
-interface InputAssignable(E) : InputRange!E {
+interface InputAssignable(E) : InputRange!E
+{
     ///
     @property void front(E newVal);
 
@@ -218,13 +225,15 @@ interface InputAssignable(E) : InputRange!E {
 }
 
 /**Adds assignable elements to ForwardRange.*/
-interface ForwardAssignable(E) : InputAssignable!E, ForwardRange!E {
+interface ForwardAssignable(E) : InputAssignable!E, ForwardRange!E
+{
     ///
     @property ForwardAssignable!E save();
 }
 
 /**Adds assignable elements to BidirectionalRange.*/
-interface BidirectionalAssignable(E) : ForwardAssignable!E, BidirectionalRange!E {
+interface BidirectionalAssignable(E) : ForwardAssignable!E, BidirectionalRange!E
+{
     ///
     @property BidirectionalAssignable!E save();
 
@@ -233,7 +242,8 @@ interface BidirectionalAssignable(E) : ForwardAssignable!E, BidirectionalRange!E
 }
 
 /**Adds assignable elements to RandomAccessFinite.*/
-interface RandomFiniteAssignable(E) : RandomAccessFinite!E, BidirectionalAssignable!E {
+interface RandomFiniteAssignable(E) : RandomAccessFinite!E, BidirectionalAssignable!E
+{
     ///
     @property RandomFiniteAssignable!E save();
 
@@ -243,7 +253,8 @@ interface RandomFiniteAssignable(E) : RandomAccessFinite!E, BidirectionalAssigna
 
 /**Interface for an output range of type $(D E).  Usage is similar to the
  * $(D InputRange) interface and descendants.*/
-interface OutputRange(E) {
+interface OutputRange(E)
+{
     ///
     void put(E);
 }
@@ -274,13 +285,15 @@ private string putMethods(E...)()
 /**Implements the $(D OutputRange) interface for all types E and wraps the
  * $(D put) method for each type $(D E) in a virtual function.
  */
-class OutputRangeObject(R, E...) : staticMap!(OutputRange, E) {
+class OutputRangeObject(R, E...) : staticMap!(OutputRange, E)
+{
     // @BUG 4689:  There should be constraints on this template class, but
     // DMD won't let me put them in.
     private R _range;
 
     ///
-    this(R range) {
+    this(R range)
+    {
         this._range = range;
     }
 
@@ -363,17 +376,20 @@ if (isInputRange!(Unqual!R))
     {
 
         ///
-        class InputRangeObject : MostDerivedInputRange!(R) {
+        class InputRangeObject : MostDerivedInputRange!(R)
+        {
             private R _range;
             private alias E = ElementType!R;
 
-            this(R range) {
+            this(R range)
+            {
                 this._range = range;
             }
 
             @property E front() { return _range.front; }
 
-            E moveFront() {
+            E moveFront()
+            {
                 return _range.moveFront();
             }
 
@@ -382,14 +398,16 @@ if (isInputRange!(Unqual!R))
 
             static if (isForwardRange!R)
             {
-                @property typeof(this) save() {
+                @property typeof(this) save()
+                {
                     return new typeof(this)(_range.save);
                 }
             }
 
             static if (hasAssignableElements!R)
             {
-                @property void front(E newVal) {
+                @property void front(E newVal)
+                {
                     _range.front = newVal;
                 }
             }
@@ -398,7 +416,8 @@ if (isInputRange!(Unqual!R))
             {
                 @property E back() { return _range.back; }
 
-                E moveBack() {
+                E moveBack()
+                {
                     return _range.moveBack();
                 }
 
@@ -406,7 +425,8 @@ if (isInputRange!(Unqual!R))
 
                 static if (hasAssignableElements!R)
                 {
-                    @property void back(E newVal) {
+                    @property void back(E newVal)
+                    {
                         _range.back = newVal;
                     }
                 }
@@ -414,24 +434,28 @@ if (isInputRange!(Unqual!R))
 
             static if (isRandomAccessRange!R)
             {
-                E opIndex(size_t index) {
+                E opIndex(size_t index)
+                {
                     return _range[index];
                 }
 
-                E moveAt(size_t index) {
+                E moveAt(size_t index)
+                {
                     return _range.moveAt(index);
                 }
 
                 static if (hasAssignableElements!R)
                 {
-                    void opIndexAssign(E val, size_t index) {
+                    void opIndexAssign(E val, size_t index)
+                    {
                         _range[index] = val;
                     }
                 }
 
                 static if (!isInfinite!R)
                 {
-                    @property size_t length() {
+                    @property size_t length()
+                    {
                         return _range.length;
                     }
 
@@ -442,7 +466,8 @@ if (isInputRange!(Unqual!R))
                     // ranges are resolved.
                     version(none)
                     {
-                        typeof(this) opSlice(size_t lower, size_t upper) {
+                        typeof(this) opSlice(size_t lower, size_t upper)
+                        {
                             return new typeof(this)(_range[lower .. upper]);
                         }
                     }
@@ -451,7 +476,8 @@ if (isInputRange!(Unqual!R))
 
             // Optimization:  One delegate call is faster than three virtual
             // function calls.  Use opApply for foreach syntax.
-            int opApply(scope int delegate(E) dg) {
+            int opApply(scope int delegate(E) dg)
+            {
                 int res;
 
                 for (auto r = _range; !r.empty; r.popFront())
@@ -463,7 +489,8 @@ if (isInputRange!(Unqual!R))
                 return res;
             }
 
-            int opApply(scope int delegate(size_t, E) dg) {
+            int opApply(scope int delegate(size_t, E) dg)
+            {
                 int res;
 
                 size_t i = 0;
@@ -499,10 +526,12 @@ if (isInputRange!R)
 /**Convenience function for creating an $(D OutputRangeObject) with a base range
  * of type $(D R) that accepts types $(D E).
 */
-template outputRangeObject(E...) {
+template outputRangeObject(E...)
+{
 
     ///
-    OutputRangeObject!(R, E) outputRangeObject(R)(R range) {
+    OutputRangeObject!(R, E) outputRangeObject(R)(R range)
+    {
         return new OutputRangeObject!(R, E)(range);
     }
 }
@@ -523,7 +552,8 @@ template outputRangeObject(E...) {
     import std.array;
     import std.internal.test.dummyrange;
 
-    static void testEquality(R)(iInputRange r1, R r2) {
+    static void testEquality(R)(iInputRange r1, R r2)
+    {
         assert(equal(r1, r2));
     }
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1315,12 +1315,14 @@ pure @safe nothrow unittest
             assert(myChain.front == 1);
 
             static if (isBidirectionalRange!DummyType1 &&
-                      isBidirectionalRange!DummyType2) {
+                      isBidirectionalRange!DummyType2)
+                      {
                 assert(myChain.back == 10);
             }
 
             static if (isRandomAccessRange!DummyType1 &&
-                      isRandomAccessRange!DummyType2) {
+                      isRandomAccessRange!DummyType2)
+                      {
                 assert(myChain[0] == 1);
             }
 
@@ -3392,7 +3394,8 @@ public:
     int[10] arr;
     int idx;
 
-    ref int fun() {
+    ref int fun()
+    {
         auto x = idx++;
         idx %= arr.length;
         return arr[x];
@@ -4413,7 +4416,8 @@ enum StoppingPolicy
         assert(equal(map!"a[0]"(zShortest), [1, 2]));
         assert(equal(map!"a[1]"(zShortest), [1, 2]));
 
-        try {
+        try
+        {
             auto zSame = zip(StoppingPolicy.requireSameLength, arr1, arr2);
             foreach (elem; zSame) {}
             assert(0);
@@ -4844,7 +4848,8 @@ if (allSatisfy!(isInputRange, Ranges))
     arr2.popBack();
     ls = lockstep(arr1, arr2, StoppingPolicy.requireSameLength);
 
-    try {
+    try
+    {
         foreach (a, b; ls) {}
         assert(0);
     } catch (Exception) {}
@@ -4906,7 +4911,8 @@ if (allSatisfy!(isInputRange, Ranges))
 
     // Since r1 is by-value only, the compiler should reject attempts to
     // foreach over it with ref.
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles,
+    {
         foreach (ref a, ref b; lockstep(r1, r2)) { a++; }
     }));
 }
@@ -9174,7 +9180,8 @@ version(none) // @@@BUG@@@ 10939
 */
 template isTwoWayCompatible(alias fn, T1, T2)
 {
-    enum isTwoWayCompatible = is(typeof( (){
+    enum isTwoWayCompatible = is(typeof( ()
+    {
             T1 foo();
             T2 bar();
 
@@ -10737,7 +10744,8 @@ if (isInputRange!R && is(R == class))
     zip(r, r);
     roundRobin(r, r);
 
-    struct NRAR {
+    struct NRAR
+    {
         typeof(r) input;
         @property empty() { return input.empty; }
         @property front() { return input.front; }
@@ -10752,7 +10760,8 @@ if (isInputRange!R && is(R == class))
     // fix for std.range
     joiner([r], [9]);
 
-    struct NRAR2 {
+    struct NRAR2
+    {
         NRAR input;
         @property empty() { return true; }
         @property front() { return input; }

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -570,7 +570,8 @@ pure @safe unittest
         {
             //Testing PutC and PutS
             foreach (Type; AliasSeq!(PutC!TC, PutS!TC))
-            (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+            () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+            {
                 Type type;
                 auto sink = new Type();
 

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -86,7 +86,8 @@ alias Escapables = AliasSeq!('[', ']', '\\', '^', '$', '.', '|', '?', ',', '-',
 // casefold - case insensitive matching, do casefolding on match in unicode mode
 // freeform - ignore whitespace in pattern, to match space use [ ] or \s
 // multiline - switch  ^, $ detect start and end of linesinstead of just start and end of input
-enum RegexOption: uint {
+enum RegexOption: uint
+{
     global = 0x1,
     casefold = 0x2,
     freeform = 0x4,
@@ -113,7 +114,8 @@ enum RegexInfo : uint { oneShot = 0x80 }
 //* reorganize groups to make n args easier to find, or simplify the check for groups of similar ops
 //  (like lookaround), or make it easier to identify hotspots.
 
-enum IR:uint {
+enum IR:uint
+{
     Char              = 0b1_00000_00, //a character
     Any               = 0b1_00001_00, //any character
     CodepointSet      = 0b1_00010_00, //a most generic CodepointSet [...]
@@ -173,7 +175,8 @@ template IRL(IR code)
 static assert(IRL!(IR.LookaheadStart) == 3);
 
 //how many parameters follow the IR, should be optimized fixing some IR bits
-int immediateParamsIR(IR i){
+int immediateParamsIR(IR i)
+{
     switch (i)
     {
     case IR.OrEnd,IR.InfiniteEnd,IR.InfiniteQEnd:
@@ -502,7 +505,8 @@ struct Regex(Char)
                        "Requested named group is out of range.");
                 return groups[start+i].name;
             }
-            NamedGroupRange opSlice(size_t low, size_t high) {
+            NamedGroupRange opSlice(size_t low, size_t high)
+            {
                 assert(low <= high);
                 assert(start + high <= end);
                 return NamedGroupRange(groups, start + low, start + high);
@@ -619,7 +623,8 @@ if (is(Char :dchar))
             res = decode(_origin, _index);
         return n;
     }
-    @property bool atEnd(){
+    @property bool atEnd()
+    {
         return _index == _origin.length;
     }
     bool search(Kickstart)(ref Kickstart kick, ref dchar res, ref size_t pos)
@@ -741,10 +746,12 @@ public class RegexException : Exception
 }
 
 // simple 128-entry bit-table used with a hash function
-struct BitTable {
+struct BitTable
+{
     uint[4] filter;
 
-    this(CodepointSet set){
+    this(CodepointSet set)
+    {
         foreach (iv; set.byInterval)
         {
             foreach (v; iv.a .. iv.b)
@@ -752,22 +759,26 @@ struct BitTable {
         }
     }
 
-    void add()(dchar ch){
+    void add()(dchar ch)
+    {
         immutable i = index(ch);
         filter[i >> 5]  |=  1<<(i & 31);
     }
     // non-zero -> might be present, 0 -> absent
-    bool opIndex()(dchar ch) const{
+    bool opIndex()(dchar ch) const
+    {
         immutable i = index(ch);
         return (filter[i >> 5]>>(i & 31)) & 1;
     }
 
-    static uint index()(dchar ch){
+    static uint index()(dchar ch)
+    {
         return ((ch >> 7) ^ ch) & 0x7F;
     }
 }
 
-struct CharMatcher {
+struct CharMatcher
+{
     BitTable ascii; // fast path for ASCII
     Trie trie;      // slow path for Unicode
 

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -989,7 +989,8 @@ if (isForwardRange!R && is(ElementType!R : dchar))
 
 
     //CodepointSet operations relatively in order of priority
-    enum Operator:uint {
+    enum Operator:uint
+    {
         Open = 0, Negate,  Difference, SymDifference, Intersection, Union, None
     }
 
@@ -997,8 +998,11 @@ if (isForwardRange!R && is(ElementType!R : dchar))
     //also fetches next set operation
     Tuple!(CodepointSet,Operator) parseCharTerm()
     {
-        enum State{ Start, Char, Escape, CharDash, CharDashEscape,
-            PotentialTwinSymbolOperator }
+        enum State
+        {
+            Start, Char, Escape, CharDash, CharDashEscape,
+            PotentialTwinSymbolOperator
+        }
         Operator op = Operator.None;
         dchar last;
         CodepointSet set;

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -354,7 +354,8 @@ alias Sequence(int B, int E) = staticIota!(B, E);
     {
         int i;
         foreach (Char; AliasSeq!( char, wchar, dchar))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             alias String = immutable(Char)[];
             String produceExpected(M,Range)(auto ref M m, Range fmt)
             {
@@ -429,11 +430,13 @@ alias Sequence(int B, int E) = staticIota!(B, E);
         else
             alias Tests = AliasSeq!(Sequence!(0, 30), Sequence!(235, tv.length-5));
         foreach (a, v; Tests)
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             enum tvd = tv[v];
             static if (tvd.result == "c")
             {
-                static assert(!__traits(compiles, (){
+                static assert(!__traits(compiles, ()
+                {
                     enum r = regex(tvd.pattern, tvd.flags);
                 }), "errornously compiles regex pattern: " ~ tvd.pattern);
             }
@@ -788,7 +791,8 @@ alias Sequence(int B, int E) = staticIota!(B, E);
 {// bugzilla 7679
     import std.algorithm.comparison : equal;
     foreach (S; AliasSeq!(string, wstring, dstring))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         enum re = ctRegex!(to!S(r"\."));
         auto str = to!S("a.b");
         assert(equal(std.regex.splitter(str, re), [to!S("a"), to!S("b")]));
@@ -902,10 +906,12 @@ alias Sequence(int B, int E) = staticIota!(B, E);
     {
         return s.dup;
     }
-    () @system {
+    () @system
+    {
         replace!((a) => foo(a.hit))("blah", regex(`a`));
     }();
-    () @safe {
+    () @safe
+    {
         replace!((a) => bar(a.hit))("blah", regex(`a`));
     }();
 }

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1677,7 +1677,8 @@ auto escaper(Range)(Range r)
         Range r;
         bool escaped;
 
-        @property ElementType!Range front(){
+        @property ElementType!Range front()
+        {
           if (escaped)
               return '\\';
           else
@@ -1686,7 +1687,8 @@ auto escaper(Range)(Range r)
 
         @property bool empty(){ return r.empty; }
 
-        void popFront(){
+        void popFront()
+        {
           if (escaped) escaped = false;
           else
           {

--- a/std/signals.d
+++ b/std/signals.d
@@ -228,7 +228,8 @@ mixin template Signal(T1...)
      */
     final void unhook(Object o)
     in { assert( status == ST.idle ); }
-    body {
+    body
+    {
         debug (signal) writefln("Signal.unhook(o = %s)", cast(void*) o);
         for (size_t i = 0; i < slots_idx; )
         {
@@ -464,7 +465,8 @@ void linkin() { }
         mixin Signal!(string, long) s3;
     }
 
-    void test(T)(T a) {
+    void test(T)(T a)
+    {
         auto o1 = new Observer;
         auto o2 = new Observer;
         auto o3 = new Observer;

--- a/std/socket.d
+++ b/std/socket.d
@@ -486,7 +486,8 @@ class Protocol
 version(CRuntime_Bionic) {} else
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         Protocol proto = new Protocol;
         assert(proto.getProtocolByType(ProtocolType.TCP));
         //writeln("About protocol TCP:");
@@ -587,7 +588,8 @@ class Service
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         Service serv = new Service;
         if (serv.getServiceByName("epmap", "tcp"))
         {
@@ -970,7 +972,8 @@ AddressInfo[] getAddressInfo(T...)(in char[] node, T options)
         }
         alias breakSafety this;
     }
-    assert(!__traits(compiles, () {
+    assert(!__traits(compiles, ()
+    {
         getAddressInfo("", Oops.init);
     }), "getAddressInfo breaks @safe");
 }
@@ -1012,7 +1015,8 @@ private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addr
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         if (getaddrinfoPointer)
         {
             // Roundtrip DNS resolution
@@ -1127,7 +1131,8 @@ Address[] getAddress(in char[] hostname, ushort port)
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         auto addresses = getAddress("63.105.9.61");
         assert(addresses.length && addresses[0].toAddrString() == "63.105.9.61");
 
@@ -1207,7 +1212,8 @@ Address parseAddress(in char[] hostaddr, ushort port)
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         auto address = parseAddress("63.105.9.61");
         assert(address.toAddrString() == "63.105.9.61");
 
@@ -1674,12 +1680,14 @@ public:
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         const InternetAddress ia = new InternetAddress("63.105.9.61", 80);
         assert(ia.toString() == "63.105.9.61:80");
     });
 
-    softUnittest({
+    softUnittest(
+    {
         // test construction from a sockaddr_in
         sockaddr_in sin;
 
@@ -1691,7 +1699,8 @@ public:
         assert(ia.toString() == "127.0.0.1:80");
     });
 
-    softUnittest({
+    softUnittest(
+    {
         // test reverse lookup
         auto ih = new InternetHost;
         if (ih.getHostByName("digitalmars.com"))
@@ -1712,7 +1721,8 @@ public:
     });
 
     version (SlowTests)
-    softUnittest({
+    softUnittest(
+    {
         // test failing reverse lookup
         const InternetAddress ia = new InternetAddress("127.114.111.120", 80);
         assert(ia.toHostNameString() is null);
@@ -1881,12 +1891,14 @@ public:
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         const Internet6Address ia = new Internet6Address("::1", 80);
         assert(ia.toString() == "[::1]:80");
     });
 
-    softUnittest({
+    softUnittest(
+    {
         // test construction from a sockaddr_in6
         sockaddr_in6 sin;
 
@@ -2390,7 +2402,8 @@ public:
 
 @safe unittest
 {
-    softUnittest({
+    softUnittest(
+    {
         enum PAIRS = 768;
         version(Posix)
         () @trusted
@@ -2567,7 +2580,8 @@ private:
     @safe unittest
     {
         version(SlowTests)
-        softUnittest({
+        softUnittest(
+        {
             import std.datetime;
             import std.typecons;
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1359,7 +1359,8 @@ Removes the lock over the specified file segment.
         auto f = File(deleteme, "w+b");
 
         runForked
-        ({
+        (
+        {
             auto g = File(deleteme, "a+b");
             assert(g.tryLock());
             g.unlock();
@@ -1368,7 +1369,8 @@ Removes the lock over the specified file segment.
 
         assert(f.tryLock());
         runForked
-        ({
+        (
+        {
             auto g = File(deleteme, "a+b");
             assert(!g.tryLock());
             assert(!g.tryLock(LockType.read));
@@ -1377,7 +1379,8 @@ Removes the lock over the specified file segment.
 
         f.lock(LockType.read);
         runForked
-        ({
+        (
+        {
             auto g = File(deleteme, "a+b");
             assert(!g.tryLock());
             assert(g.tryLock(LockType.read));
@@ -4569,7 +4572,8 @@ alias stdin = makeGlobal!(core.stdc.stdio.stdin);
     import std.array : array;
     import std.typecons : Yes;
 
-    void main() {
+    void main()
+    {
         stdin                       // read from stdin
         .byLineCopy(Yes.keepTerminator) // copying each line
         .array()                    // convert to array of lines

--- a/std/string.d
+++ b/std/string.d
@@ -227,7 +227,8 @@ class StringException : Exception
     The original data is not changed and not copied.
 +/
 
-inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
+inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow
+{
     import core.stdc.string : strlen;
     return cString ? cString[0 .. strlen(cString)] : null;
 }
@@ -842,7 +843,8 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOf(cast(S) null, to!T("a")) == -1);
             assert(indexOf(to!S("def"), to!T("a")) == -1);
             assert(indexOf(to!S("abba"), to!T("a")) == 0);
@@ -911,7 +913,8 @@ unittest
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOf(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOf(to!S("def"), to!T("a"), 0) == -1);
             assert(indexOf(to!S("abba"), to!T("a"), 2) == 3);
@@ -1317,7 +1320,8 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
@@ -1393,7 +1397,8 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
@@ -1643,7 +1648,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOfAny(cast(S) null, to!T("a")) == -1);
             assert(indexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(indexOfAny(to!S("abba"), to!T("a")) == 0);
@@ -1682,7 +1688,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOfAny(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOfAny(to!S("def"), to!T("AaF"), 0) == -1);
             assert(indexOfAny(to!S("abba"), to!T("NSa"), 2) == 3);
@@ -1811,7 +1818,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(lastIndexOfAny(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(lastIndexOfAny(to!S("abba"), to!T("a")) == 3);
@@ -1866,7 +1874,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOfAny(cast(S) null, to!T("a"), 1337) == -1,
@@ -1993,7 +2002,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(indexOfNeither("abba", "a") == 1);
 
@@ -2039,7 +2049,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(indexOfNeither(cast(S) null, to!T("a"), 1) == -1);
             assert(indexOfNeither(to!S("def"), to!T("a"), 1) == 1,
                 to!string(indexOfNeither(to!S("def"), to!T("a"), 1)));
@@ -2151,7 +2162,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(lastIndexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("rsa")) == 2);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
@@ -2198,7 +2210,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
     foreach (S; AliasSeq!(string, wstring, dstring))
     {
         foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(lastIndexOfNeither(cast(S) null, to!T("a"), 1337) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("f")) == 1);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
@@ -3379,7 +3392,8 @@ if (isConvertibleToString!Range)
         assert(chomp(to!S("hello\u2029\u0185")) == "hello\u2029\u0185");
 
         foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             // @@@ BUG IN COMPILER, MUST INSERT CAST
             assert(chomp(cast(S) null, cast(T) null) is null);
             assert(chomp(to!S("hello\n"), cast(T) null) == "hello");
@@ -3484,7 +3498,8 @@ unittest
     foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(equal(chompPrefix(to!S("abcdefgh"), to!T("abcde")), "fgh"));
             assert(equal(chompPrefix(to!S("abcde"), to!T("abcdefgh")), "abcde"));
             assert(equal(chompPrefix(to!S("\uFF28el\uFF4co"), to!T("\uFF28el\uFF4co")), ""));
@@ -4847,7 +4862,8 @@ if (isSomeChar!C1 && isSomeChar!C2)
         foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             foreach (R; AliasSeq!(dchar[dchar], const dchar[dchar],
                         immutable dchar[dchar]))
             {
@@ -4908,7 +4924,8 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
         foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
 
             foreach (R; AliasSeq!(string[dchar], const string[dchar],
                         immutable string[dchar]))
@@ -5171,7 +5188,8 @@ body
                to!S("hello \U00010143 world"));
 
         foreach (T; AliasSeq!(char[], const(char)[], immutable(char)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(translate(to!S("hello world"), makeTransTable("hl", "q5"), to!T("r")) ==
                    to!S("qe55o wo5d"));
             assert(translate(to!S("hello \U00010143 world"), makeTransTable("hl", "q5"), to!T("r")) ==

--- a/std/uni.d
+++ b/std/uni.d
@@ -1016,7 +1016,8 @@ private:
 @system unittest
 {
     import std.conv : text;
-    enum dg = (){
+    enum dg = ()
+    {
         // sizes are:
         // lvl0: 3, lvl1 : 2, lvl2: 1
         auto m = MultiArray!(int, ubyte, int)(3,2,1);
@@ -1100,12 +1101,14 @@ private:
     alias fn2 = sliceBits!( 9, 13);
     alias fn3 = sliceBits!( 6,  9);
     alias fn4 = sliceBits!( 0,  6);
-    static void check(size_t lvl, MA)(ref MA arr){
+    static void check(size_t lvl, MA)(ref MA arr)
+    {
         for (size_t i = 0; i< arr.length!lvl; i++)
             assert(arr.slice!(lvl)[i] == i, text("Mismatch on lvl ", lvl, " idx ", i, " value: ", arr.slice!(lvl)[i]));
     }
 
-    static void fillIdx(size_t lvl, MA)(ref MA arr){
+    static void fillIdx(size_t lvl, MA)(ref MA arr)
+    {
         for (size_t i = 0; i< arr.length!lvl; i++)
             arr.slice!(lvl)[i] = i;
     }
@@ -4667,7 +4670,8 @@ public struct MatcherConcept
 /**
     Test if $(D M) is an UTF Matcher for ranges of $(D Char).
 */
-public enum isUtfMatcher(M, C) = __traits(compiles, (){
+public enum isUtfMatcher(M, C) = __traits(compiles, ()
+{
     C[] s;
     auto d = s.decoder;
     M m;
@@ -4692,7 +4696,8 @@ public enum isUtfMatcher(M, C) = __traits(compiles, (){
     static assert(isUtfMatcher!(WcharMatcher, immutable(wchar)));
 }
 
-enum Mode {
+enum Mode
+{
     alwaysSkip,
     neverSkip,
     skipOnMatch
@@ -5413,7 +5418,8 @@ if (is(C : wchar) || is(C : char))
         "\xCF\x00\0x00\0x00\x00");
     foreach (msg; fails8)
     {
-        assert(collectException((){
+        assert(collectException(()
+        {
             auto s = msg;
             size_t idx = 0;
             utf8.test(s);
@@ -5423,7 +5429,8 @@ if (is(C : wchar) || is(C : char))
     alias fails16 = AliasSeq!([0xD811], [0xDC02]);
     foreach (msg; fails16)
     {
-        assert(collectException((){
+        assert(collectException(()
+        {
             auto s = msg.map!(x => cast(wchar) x);
             utf16.test(s);
         }()));
@@ -6310,7 +6317,8 @@ template genericDecodeGrapheme(bool getValue)
     Value genericDecodeGrapheme(Input)(ref Input range)
     {
         import std.internal.unicode_tables : isHangL, isHangT, isHangV; // generated file
-        enum GraphemeState {
+        enum GraphemeState
+        {
             Start,
             CR,
             RI,
@@ -7288,7 +7296,8 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
     {
         foreach (S1; AliasSeq!(string, wstring, dstring))
         foreach (S2; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        () // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
             assert(cfunc("".to!S1(), "".to!S2()) == 0);
             assert(cfunc("A".to!S1(), "".to!S2()) > 0);
             assert(cfunc("".to!S1(), "0".to!S2()) < 0);
@@ -7413,7 +7422,8 @@ package auto simpleCaseFoldings(dchar ch) @safe
     import std.algorithm.searching : canFind;
     import std.array : array;
     import std.exception : assertCTFEable;
-    assertCTFEable!((){
+    assertCTFEable!(()
+    {
         auto r = simpleCaseFoldings('Э').array;
         assert(r.length == 2);
         assert(r.canFind('э') && r.canFind('Э'));
@@ -7459,7 +7469,8 @@ ubyte combiningClass(dchar ch) @safe pure nothrow @nogc
 }
 
 /// Unicode character decomposition type.
-enum UnicodeDecomposition {
+enum UnicodeDecomposition
+{
     /// Canonical decomposition. The result is canonically equivalent sequence.
     Canonical,
     /**
@@ -7474,7 +7485,8 @@ enum UnicodeDecomposition {
     Shorthand aliases for character decomposition type, passed as a
     template parameter to $(LREF decompose).
 */
-enum {
+enum
+{
     Canonical = UnicodeDecomposition.Canonical,
     Compatibility = UnicodeDecomposition.Compatibility
 }
@@ -7734,7 +7746,8 @@ dchar composeJamo(dchar lead, dchar vowel, dchar trailing=dchar.init) pure nothr
     Enumeration type for normalization forms,
     passed as template parameter for functions like $(LREF normalize).
 */
-enum NormalizationForm {
+enum NormalizationForm
+{
     NFC,
     NFD,
     NFKC,
@@ -7742,7 +7755,8 @@ enum NormalizationForm {
 }
 
 
-enum {
+enum
+{
     /**
         Shorthand aliases from values indicating normalization forms.
     */

--- a/std/uri.d
+++ b/std/uri.d
@@ -48,7 +48,8 @@ private enum
 private immutable char[16] hex2ascii = "0123456789ABCDEF";
 
 private immutable ubyte[128] uri_flags =      // indexed by character
-    ({
+    (
+    {
         ubyte[128] uflags;
 
         // Compile time initialize

--- a/std/utf.d
+++ b/std/utf.d
@@ -2101,11 +2101,13 @@ version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LIN
         static assert(isSafe!({ S str; size_t i = 0; decodeFront(str, i); }));
         static assert(isSafe!({ S str; decodeFront(str); }));
         static assert((functionAttributes!({ S str; size_t i = 0; decode(str, i); }) & FunctionAttribute.pure_) != 0);
-        static assert((functionAttributes!({
+        static assert((functionAttributes!(
+        {
             S str; size_t i = 0; decodeFront(str, i);
         }) & FunctionAttribute.pure_) != 0);
         static assert((functionAttributes!({ S str; decodeFront(str); }) & FunctionAttribute.pure_) != 0);
-        static assert((functionAttributes!({
+        static assert((functionAttributes!(
+        {
             S str; size_t i = 0; decodeBack(str, i);
         }) & FunctionAttribute.pure_) != 0);
         static assert((functionAttributes!({ S str; decodeBack(str); }) & FunctionAttribute.pure_) != 0);
@@ -2700,7 +2702,8 @@ if (isSomeString!S)
 @safe unittest // bugzilla 12923
 {
     import std.exception;
-    assertThrown((){
+    assertThrown(()
+    {
         char[3]a=[167, 133, 175];
         validate(a[]);
     }());

--- a/std/variant.d
+++ b/std/variant.d
@@ -157,7 +157,8 @@ private:
     // the "handler" function below.
     enum OpID { getTypeInfo, get, compare, equals, testConversion, toString,
             index, indexAssign, catAssign, copyOut, length,
-            apply, postblit, destruct }
+            apply, postblit, destruct
+    }
 
     // state
     ptrdiff_t function(OpID selector, ubyte[size]* store, void* data) fptr
@@ -1783,7 +1784,8 @@ static class VariantException : Exception
 
 @system unittest
 {
-    struct Huge {
+    struct Huge
+    {
         real a, b, c, d, e, f, g;
     }
 
@@ -1824,11 +1826,14 @@ static class VariantException : Exception
 // http://d.puremagic.com/issues/show_bug.cgi?id=5424
 @system unittest
 {
-    interface A {
+    interface A
+    {
         void func1();
     }
-    static class AC: A {
-        void func1() {
+    static class AC: A
+    {
+        void func1()
+        {
         }
     }
 
@@ -1865,15 +1870,18 @@ static class VariantException : Exception
 // Const parameters with opCall, issue 11361.
 @system unittest
 {
-    static string t1(string c) {
+    static string t1(string c)
+    {
         return c ~ "a";
     }
 
-    static const(char)[] t2(const(char)[] p) {
+    static const(char)[] t2(const(char)[] p)
+    {
         return p ~ "b";
     }
 
-    static char[] t3(int p) {
+    static char[] t3(int p)
+    {
         import std.conv : text;
         return p.text.dup;
     }
@@ -2107,7 +2115,8 @@ if (Handlers.length > 0)
                                                 )()
                                                 ));
 
-    static size_t func(string s) {
+    static size_t func(string s)
+    {
         return s.length;
     }
 
@@ -2264,7 +2273,8 @@ if (isAlgebraic!VariantType && Handler.length > 0)
      */
     auto visitGetOverloadMap()
     {
-        struct Result {
+        struct Result
+        {
             int[AllowedTypes.length] indices;
             int exceptionFuncIdx = -1;
             int generalFuncIdx = -1;
@@ -2375,7 +2385,8 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     struct Bar { int depth; }
     alias FooBar = Algebraic!(Foo, Bar);
 
-    int depth(in FooBar fb) {
+    int depth(in FooBar fb)
+    {
         return fb.visit!((Foo foo) => foo.depth,
                          (Bar bar) => bar.depth);
     }
@@ -2719,7 +2730,8 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 @system unittest
 {
     // Bugzilla 13534
-    static assert(!__traits(compiles, () @safe {
+    static assert(!__traits(compiles, () @safe
+    {
         auto foo() @system { return 3; }
         auto v = Variant(&foo);
         v(); // foo is called in safe code!?

--- a/std/xml.d
+++ b/std/xml.d
@@ -2810,7 +2810,8 @@ EOS";
 
     DocumentParser parser = new DocumentParser(test_xml);
     bool tested = false;
-    parser.onStartTag["stream:stream"] = (ElementParser p) {
+    parser.onStartTag["stream:stream"] = (ElementParser p)
+    {
         assert(p.tag.attr["xmlns"] == "jabber:'client'");
         assert(p.tag.attr["from"] == "jid.pl");
         assert(p.tag.attr["attr"] == "a\"b\"c");
@@ -2829,11 +2830,13 @@ EOS";
 EOS";
     auto xml = new DocumentParser(s);
 
-    xml.onStartTag["Test"] = (ElementParser xml) {
+    xml.onStartTag["Test"] = (ElementParser xml)
+    {
         assert(xml.tag.attr["thing"] == "What & Up");
     };
 
-    xml.onEndTag["Test"] = (in Element e) {
+    xml.onEndTag["Test"] = (in Element e)
+    {
         assert(e.text() == "What & Up Second");
     };
     xml.parse();

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -324,7 +324,8 @@ void arrayPrint(ubyte[] array)
 +/
 
 /// the header format the compressed stream is wrapped in
-enum HeaderFormat {
+enum HeaderFormat
+{
     deflate, /// a standard zlib header
     gzip, /// a gzip file format header
     determineFromData /// used when decompressing. Try to automatically detect the stream format by looking at the data


### PR DESCRIPTION
There's a new Dscanner plugin for checking allman style: https://github.com/dlang-community/D-Scanner/pull/446

It seems that this is quite a bit more precise than the RegExps used before.
I tried [to use a script](https://github.com/wilzbach/dscanner-fix/blob/master/brace_style_allman.d) for all trivial cases.
Once a small fix to the brace style checker (https://github.com/dlang-community/D-Scanner/pull/449) has been merged, we can enable the new allman dscanner check.

I hope this is a lot less controversial as it just improves the preciseness of the existing tests and hopefully soon let's use get rid of the ugly RegExps.

CC @CyberShadow @andralex 