### PR TITLE
Add spawnProcessDetached

### DIFF
--- a/changelog/std-process-config-detached.dd
+++ b/changelog/std-process-config-detached.dd
@@ -1,0 +1,5 @@
+`Config.detached` flag for `spawnProcess` has been added
+
+Config.detached allows to $(REF_ALTTEXT spawn process, spawnProcess, std, process) independently from the caller.
+No need to wait on the process spawned that way - no zombie will left after process exits.
+Attempts to $(REF wait, std, process) on or $(REF kill, std, process) detached processes will throw.

--- a/changelog/std-process-config-detached.dd
+++ b/changelog/std-process-config-detached.dd
@@ -1,5 +1,4 @@
 `Config.detached` flag for `spawnProcess` has been added
 
-Config.detached allows to $(REF_ALTTEXT spawn process, spawnProcess, std, process) independently from the caller.
-No need to wait on the process spawned that way - no zombie will left after process exits.
-Attempts to $(REF wait, std, process) on or $(REF kill, std, process) detached processes will throw.
+`Config.detached` allows $(REF_ALTTEXT spawning processes, spawnProcess, std, process) which run independently from the current process. There is no need to wait on the processes created with this flag, and no $(HTTPS en.wikipedia.org/wiki/Zombie_process, zombie process) will be left after they exit.
+Attempts to call $(REF wait, std, process) or $(REF kill, std, process) on detached processes will throw.

--- a/std/process.d
+++ b/std/process.d
@@ -473,10 +473,7 @@ private Pid spawnProcessImpl(in char[][] args,
 
         // no need for the read end of pipe on child side
         if (config & Config.detached)
-        {
-            setsid();
             close(pidPipe[0]);
-        }
         close(forkPipe[0]);
         immutable forkPipeOut = forkPipe[1];
         immutable pidPipeOut = pidPipe[1];


### PR DESCRIPTION
spawnProcessDetached is function similar to spawnProcess, but user does not need to wait on spawned process to avoid zombies (resource leak). Instead of returning Pid instance spawnProcessDetached returns integer pid via pointer. Rationale: user should not be able to wait on detached process.

Currently only Posix version is implemented. It uses double fork technique and setsid to detach the new process from its caller. Since this implementation reuses a lot of stuff from spawnProcess I moved some implementation details to separate private functions to share them between spawnProcess and spawnProcessDetached.

THIS IS WIP
I'll add more unittests and Windows version later. For now say if you like the idea.