### PR TITLE
Issue 17224 - Remove std.typetuple from the documentation build

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -179,7 +179,7 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   conv csv demangle encoding exception file format \
   functional getopt json math mathspecial meta mmfile numeric \
   outbuffer parallelism path process random signals socket stdint \
-  stdio string system traits typecons typetuple uni \
+  stdio string system traits typecons uni \
   uri utf uuid variant xml zip zlib
 PACKAGE_std_experimental = checkedint typecons
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
@@ -227,6 +227,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 		processinit scopebuffer test/dummyrange \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
 	) \
+	typetuple \
 )
 
 EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(EXTRA_MODULES_INTERNAL)


### PR DESCRIPTION
Small-scale follow-up to https://github.com/dlang/phobos/pull/4968 as triggering deprecation isn't very welcome, but at least we can stop newcomers being confused.

Other PRs: https://github.com/dlang/phobos/pull/5484 and https://github.com/dlang/dlang.org/pull/1701