### PR TITLE
Fix invalid undefined Ddoc macros

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -3,7 +3,7 @@
 /**
 This package implements generic algorithms oriented towards the processing of
 sequences. Sequences processed by these functions define range-based
-interfaces.  See also $(MREF_ALTTEF Reference on ranges, std, range) and
+interfaces.  See also $(MREF_ALTTEXT Reference on ranges, std, range) and
 $(HTTP ddili.org/ders/d.en/ranges.html, tutorial on ranges).
 
 $(SCRIPT inhibitQuickIndex = 1;)

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -9496,10 +9496,10 @@ bool yearIsLeapYear(int year) @safe pure nothrow
     function as a time point.
 
     1. $(D T) must define a static property named $(D min) which is the smallest
-       value of $(D T) as $(Unqual!T).
+       value of $(D T) as $(D Unqual!T).
 
     2. $(D T) must define a static property named $(D max) which is the largest
-       value of $(D T) as $(Unqual!T).
+       value of $(D T) as $(D Unqual!T).
 
     3. $(D T) must define an $(D opBinary) for addition and subtraction that
        accepts $(REF Duration, core,time) and returns $(D Unqual!T).

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -749,8 +749,8 @@ struct ContiguousFreeList(ParentAllocator,
 FreeList shared across threads. Allocation and deallocation are lock-free. The
 parameters have the same semantics as for $(D FreeList).
 
-$(D expand) is defined to forward to $(ParentAllocator.expand) (it must be also
-$(D shared)).
+$(D expand) is defined to forward to $(D ParentAllocator.expand)
+(it must be also $(D shared)).
 */
 struct SharedFreeList(ParentAllocator,
     size_t minSize, size_t maxSize = minSize, size_t approxMaxNodes = unbounded)

--- a/std/json.d
+++ b/std/json.d
@@ -1090,7 +1090,7 @@ Any Object types will be serialized in a key-sorted order.
 
 If $(D pretty) is false no whitespaces are generated.
 If $(D pretty) is true serialized string is formatted to be human-readable.
-Set the $(specialFloatLiterals) flag is set in $(D options) to encode NaN/Infinity as strings.
+Set the $(LREF JSONOptions.specialFloatLiterals) flag is set in $(D options) to encode NaN/Infinity as strings.
 */
 string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions options = JSONOptions.none) @safe
 {

--- a/std/math.d
+++ b/std/math.d
@@ -86,7 +86,13 @@ $(TR $(TDNW Hardware Control) $(TD
  *      SV  = $(TR $(TD $1) $(TD $2))
  *      TH3 = $(TR $(TH $1) $(TH $2) $(TH $3))
  *      TD3 = $(TR $(TD $1) $(TD $2) $(TD $3))
- *
+ *      TABLE_DOMRG = <table border="1" cellpadding="4" cellspacing="0">
+ *              $(SVH Domain X, Range Y)
+                $(SV $1, $2)
+ *              </table>
+ *      DOMAIN=$1
+ *      RANGE=$1
+
  *      NAN = $(RED NAN)
  *      SUP = <span style="vertical-align:super;font-size:smaller">$0</span>
  *      GAMMA = &#915;
@@ -1419,9 +1425,11 @@ public:
  *  Mathematically, acosh(x) = log(x + sqrt( x*x - 1))
  *
  * $(TABLE_DOMRG
- *  $(DOMAIN 1..$(INFIN))
- *  $(RANGE  1 .. log(real.max), $(INFIN)) )
- *      $(TABLE_SV
+ *    $(DOMAIN 1..$(INFIN)),
+ *    $(RANGE  0..$(INFIN))
+ * )
+ *
+ *  $(TABLE_SV
  *    $(SVH  x,     acosh(x) )
  *    $(SV  $(NAN), $(NAN) )
  *    $(SV  $(LT)1,     $(NAN) )
@@ -1501,10 +1509,11 @@ float asinh(float x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
  *
  * Mathematically, atanh(x) = log( (1+x)/(1-x) ) / 2
  *
- *
  * $(TABLE_DOMRG
- *  $(DOMAIN -$(INFIN)..$(INFIN))
- *  $(RANGE  -1 .. 1) )
+ *    $(DOMAIN -$(INFIN)..$(INFIN)),
+ *    $(RANGE  -1 .. 1)
+ * )
+ * $(BR)
  * $(TABLE_SV
  *    $(SVH  x,     acosh(x) )
  *    $(SV  $(NAN), $(NAN) )

--- a/std/random.d
+++ b/std/random.d
@@ -989,8 +989,9 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
  * Xorshift generator using 32bit algorithm.
  *
  * Implemented according to $(HTTP www.jstatsoft.org/v08/i14/paper, Xorshift RNGs).
+ * Supporting bits are below, $(D bits) means second parameter of XorshiftEngine.
  *
- * $(BOOKTABLE $(TEXTWITHCOMMAS Supporting bits are below, $(D bits) means second parameter of XorshiftEngine.),
+ * $(BOOKTABLE ,
  *  $(TR $(TH bits) $(TH period))
  *  $(TR $(TD 32)   $(TD 2^32 - 1))
  *  $(TR $(TD 64)   $(TD 2^64 - 1))

--- a/std/socket.d
+++ b/std/socket.d
@@ -3291,7 +3291,7 @@ public:
     }
 
     /**
-     * Wait for a socket to change status. A wait timeout of $(Duration) or
+     * Wait for a socket to change status. A wait timeout of $(REF Duration, core, time) or
      * $(D TimeVal), may be specified; if a timeout is not specified or the
      * $(D TimeVal) is $(D null), the maximum timeout is used. The $(D TimeVal)
      * timeout has an unspecified value when $(D select) returns.

--- a/std/traits.d
+++ b/std/traits.d
@@ -6852,7 +6852,7 @@ template CopyTypeQualifiers(FromType, ToType)
 }
 
 /**
-Returns the type of `Target` with the "constness" of `Source`. A type's $(BOLD constness)
+Returns the type of `Target` with the "constness" of `Source`. A type's $(B constness)
 refers to whether it is `const`, `immutable`, or `inout`. If `source` has no constness, the
 returned type will be the same as `Target`.
 */


### PR DESCRIPTION
Seems like we should really check for such errors automatically ...

Discovered in https://github.com/dlang/dlang.org/pull/1694#issuecomment-308663796