### PR TITLE
move std.{outbuffer,signals,socket,xml} to undeaD

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -178,9 +178,9 @@ STD_PACKAGES = std $(addprefix std/,\
 PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   conv csv demangle encoding exception file format \
   functional getopt json math mathspecial meta mmfile numeric \
-  outbuffer parallelism path process random signals socket stdint \
+  parallelism path process random stdint \
   stdio string system traits typecons typetuple uni \
-  uri utf uuid variant xml zip zlib
+  uri utf uuid variant zip zlib
 PACKAGE_std_experimental = checkedint typecons
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
@@ -227,6 +227,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 		processinit scopebuffer test/dummyrange \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
 	) \
+	outbuffer signals socket xml \
 )
 
 EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(EXTRA_MODULES_INTERNAL)

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -10,6 +10,8 @@ Serialize data to $(D ubyte) arrays.
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */
+// It will be removed in December 2018. @@@DEPRECATED_2018-12@@@
+deprecated("Please use undead.outbuffer instead. It will be removed in December 2018.")
 module std.outbuffer;
 
 import core.stdc.stdarg; // : va_list;

--- a/std/signals.d
+++ b/std/signals.d
@@ -60,6 +60,9 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
+
+// It will be removed in December 2018. @@@DEPRECATED_2018-12@@@
+deprecated("Please use undead.signals instead. It will be removed in December 2018.")
 module std.signals;
 
 import core.exception : onOutOfMemoryError;

--- a/std/socket.d
+++ b/std/socket.d
@@ -42,6 +42,8 @@
  * Source:  $(PHOBOSSRC std/_socket.d)
  */
 
+// It will be removed in December 2018. @@@DEPRECATED_2018-12@@@
+deprecated("Please use undead.socket instead. It will be removed in December 2018.")
 module std.socket;
 
 import core.stdc.stdint, core.stdc.stdlib, core.stdc.string, std.conv, std.string;

--- a/std/xml.d
+++ b/std/xml.d
@@ -123,6 +123,8 @@ Distributed under the Boost Software License, Version 1.0.
    (See accompanying file LICENSE_1_0.txt or copy at
          http://www.boost.org/LICENSE_1_0.txt)
 */
+// It will be removed in December 2018. @@@DEPRECATED_2018-12@@@
+deprecated("Please use undead.xml instead. It will be removed in December 2018.")
 module std.xml;
 
 enum cdata = "<![CDATA[";


### PR DESCRIPTION
> I'd be in favor of finally deprecating all sub-standard phobos module (moving them to https://github.com/dlang/undeaD) to make room for good implementations. Having a vacant place might be more encouraging than to wait for something better to come along.
>Of course discussing which modules should be obsoleted is a tricky question.
> std.signals
>std.xml
>std.outbuffer
>std.socket
>std.json // maybe ;)

http://forum.dlang.org/post/frhctqkzdsiojivpqqap@forum.dlang.org

I think this is a good list to start from :+1: 
Users should have more than enough time to switch to undeaD and it's really as simple as `sed -E 's/std[.](outbuffer|signals|socket|xml)/undead.\1/' -i **/*.d`

Sub PRS
------------

- [ ] [Hide modules from the sidenav on dlang.org](https://github.com/dlang/dlang.org/pull/1712)
- [ ] [Move to undeaD](https://github.com/dlang/undeaD/pull/23)

CC @MartinNowak @andralex 