### PR TITLE
Fix long lines in Phobos

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -102,7 +102,8 @@ imports_sortedness = "+std.algorithm.disabled" ; currently disabled, see https:/
 label_var_same_name_check="+std.algorithm.searching"
 length_subtraction_check="+std.algorithm.comparison"
 logical_precedence_check="+std.algorithm.internal"
-long_line_check="-std.regex.internal.thompson"; Dscanner bug: https://github.com/dlang-community/D-Scanner/pull/465
+; Checks for lines with more than 120 visual characters - see https://github.com/dlang/phobos/pull/5500 for details
+long_line_check="-std.datetime.timezone"
 mismatched_args_check="+std.algorithm"
 mismatched_args_check="+std.algorithm"
 number_style_check="+std.algorithm.searching"

--- a/posix.mak
+++ b/posix.mak
@@ -522,7 +522,7 @@ checkwhitespace: $(LIB) $(TOOLS_DIR)/checkwhitespace.d
 
 ../dscanner:
 	git clone https://github.com/dlang-community/Dscanner ../dscanner
-	git -C ../dscanner checkout phobos
+	git -C ../dscanner checkout 455cc3fe50e6d0742c866737b4ac24669d51a992
 	git -C ../dscanner submodule update --init --recursive
 
 ../dscanner/dsc: ../dscanner $(DMD) $(LIB)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4566,7 +4566,8 @@ private string lockstepMixin(Ranges...)(bool withIndex, bool reverse)
         {
             indexDef = q{
                 size_t index = ranges[0].length-1;
-                enforce(_stoppingPolicy == StoppingPolicy.requireSameLength, "lockstep can only be used with foreach_reverse when stoppingPolicy == requireSameLength");
+                enforce(_stoppingPolicy == StoppingPolicy.requireSameLength,
+                        "lockstep can only be used with foreach_reverse when stoppingPolicy == requireSameLength");
 
                 foreach (range; ranges[1..$])
                     enforce(range.length == ranges[0].length);

--- a/std/uni.d
+++ b/std/uni.d
@@ -6288,7 +6288,8 @@ enum EMPTY_CASE_TRIE = ushort.max;// from what gen_uni uses internally
 
 // control - '\r'
 enum controlSwitch = `
-    case '\u0000':..case '\u0008':case '\u000E':..case '\u001F':case '\u007F':..case '\u0084':case '\u0086':..case '\u009F': case '\u0009':..case '\u000C': case '\u0085':
+    case '\u0000':..case '\u0008':case '\u000E':..case '\u001F':case '\u007F':..
+    case '\u0084':case '\u0086':..case '\u009F': case '\u0009':..case '\u000C': case '\u0085':
 `;
 // TODO: redo the most of hangul stuff algorithmically in case of Graphemes too
 // kill unrolled switches


### PR DESCRIPTION
The Dscanner check for long lines turned out to be erroneous (see e.g. https://github.com/dlang-community/D-Scanner/pull/465 or https://github.com/dlang-community/D-Scanner/pull/440)

Hence, some bits of Phobos kept hidden.

Unfortunately I don't know a good way to deal with `std/datetime/timezone.d` (the parser expects every item to be on a single line), but in the worst case we can now (#5495) always do `-std.datetime.timezone`

Any ideas @jmdavis?