### PR TITLE
Add missing closing parenthesis to changelog entry

### DIFF
--- a/changelog/split-std-datetime.dd
+++ b/changelog/split-std-datetime.dd
@@ -28,7 +28,7 @@ $(MREF std,datetime,timezone) contains the time zone types.
 $(MREF std,datetime,package) contains StopWatch and the benchmarking functions
 (so, they can only be imported via std.datetime and not via a submodule). As
 those functions use $(REF TickDuration,core,time) (which is being replaced by
-$(REF MonoTime,core,time), they are slated for deprecation.
+$(REF MonoTime,core,time), they are slated for deprecation).
 
 $(MREF std,datetime,stopwatch) has been added. It contains versions of
 StopWatch and benchmark which have almost the same API as the existing symbols,


### PR DESCRIPTION
Fix the upcoming changelog (https://dlang.org/changelog/2.075.0_pre.html)

Ddoc is a really nasty engine, everyone gets punished if there's a missing parenthesis ...

@CyberShadow should we automatically replace all parenthesis which aren't in macros by the `LPAREN` or `RPAREN` to avoid stuff like this in the future?
Or maybe simply counting the braces and making it a hard error? (Ddoc doesn't support this)