### PR TITLE
Added Base64URLNoPadding (backport from vibe.d)

### DIFF
--- a/changelog/std-base64-base64urlnopadding.dd
+++ b/changelog/std-base64-base64urlnopadding.dd
@@ -1,0 +1,11 @@
+`Base64URLNoPadding` (URL-safe Base64 without padding) was added
+
+$(REF Base64URLNoPadding, std, base64) allows encoding/decoding without padding:
+
+---
+import std.base64 : Base64URLNoPadding;
+
+ubyte[] data = [0x83, 0xd7, 0x30, 0x7b, 0xef];
+assert(Base64URLNoPadding.encode(data) == "g9cwe-8");
+assert(Base64URLNoPadding.decode("g9cwe-8") == data);
+---

--- a/std/base64.d
+++ b/std/base64.d
@@ -104,14 +104,30 @@ alias Base64URL = Base64Impl!('-', '_');
     assert(Base64URL.decode("g9cwegE_") == data);
 }
 
+/**
+ * Unpadded variation of Base64 encoding that is safe for use in URLs and
+ * filenames, as used in RFCs 4648 and 7515 (JWS/JWT/JWE).
+ *
+ * See $(LREF Base64Impl) for a description of available methods.
+ */
+alias Base64URLNoPadding = Base64Impl!('-', '_', Base64.NoPadding);
+
+///
+@safe unittest
+{
+    ubyte[] data = [0x83, 0xd7, 0x30, 0x7b, 0xef];
+    assert(Base64URLNoPadding.encode(data) == "g9cwe-8");
+    assert(Base64URLNoPadding.decode("g9cwe-8") == data);
+}
 
 /**
  * Template for implementing Base64 encoding and decoding.
  *
  * For most purposes, direct usage of this template is not necessary; instead,
- * this module provides two default implementations: $(LREF Base64) and
- * $(LREF Base64URL), that implement basic Base64 encoding and a variant
- * intended for use in URLs and filenames, respectively.
+ * this module provides default implementations: $(LREF Base64), implementing
+ * basic Base64 encoding, and $(LREF Base64URL) and $(LREF Base64URLNoPadding),
+ * that implement the Base64 variant for use in URLs and filenames, with
+ * and without padding, respectively.
  *
  * Customized Base64 encoding schemes can be implemented by instantiating this
  * template with the appropriate arguments. For example:


### PR DESCRIPTION
Many applications require Base64URL without the padding: RFC4648, RFC7515.

Vibe.d provides this alias, but many other libs (jwtd) have their own non-trivial implementation, even though Phobos is flexible enough.