### PR TITLE
[PoC] Add version(NoAutoDecode) to allow opt-out of auto-decoding

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -103,6 +103,10 @@ $(BOOKTABLE ,
     ))
 )
 
+$(B NEW:) `version(NoAutoDecode)` allows to use Phobos ranges without
+auto-decoding. This is an experimental option to test the feasibility
+of disabling auto-decoding by default. You have been warned.
+
 Source: $(PHOBOSSRC std/range/_primitives.d)
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
@@ -2325,14 +2329,25 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
     assert(c.front == 1);
 }
 
-/// ditto
-@property dchar front(T)(T[] a) @safe pure
-if (isNarrowString!(T[]))
+version(NoAutoDecode)
 {
-    import std.utf : decode;
-    assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
-    size_t i = 0;
-    return decode(a, i);
+    @property auto front(T)(T[] a) @safe pure
+    if (isNarrowString!(T[]))
+    {
+        return a[0];
+    }
+}
+else
+{
+    /// ditto
+    @property dchar front(T)(T[] a) @safe pure
+    if (isNarrowString!(T[]))
+    {
+        import std.utf : decode;
+        assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
+        size_t i = 0;
+        return decode(a, i);
+    }
 }
 
 /**
@@ -2368,13 +2383,24 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
     assert(c.back == 3);
 }
 
-/// ditto
-// Specialization for strings
-@property dchar back(T)(T[] a) @safe pure
-if (isNarrowString!(T[]))
+version(NoAutoDecode)
 {
-    import std.utf : decode, strideBack;
-    assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
-    size_t i = a.length - strideBack(a, a.length);
-    return decode(a, i);
+    @property auto back(T)(T[] a) @safe pure
+    if (isNarrowString!(T[]))
+    {
+        return a[$ - 1];
+    }
+}
+else
+{
+    /// ditto
+    // Specialization for strings
+    @property dchar back(T)(T[] a) @safe pure
+    if (isNarrowString!(T[]))
+    {
+        import std.utf : decode, strideBack;
+        assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
+        size_t i = a.length - strideBack(a, a.length);
+        return decode(a, i);
+    }
 }


### PR DESCRIPTION
This is a Proof of Concept (PoC) idea to allow people to opt-in to use Phobos without auto-decoding.
If this works well, it could be improved (e.g. per module) to allow gradual migration.

It's an adaption of an KISS idea posted on [the NG](http://forum.dlang.org/post/xzizleuozzqnjinbfgoc@forum.dlang.org) by @adamdruppe.

But I guess a code sample shows more than 1000 words:

```d
void main(string[] args)
{
    import std.range;
    string cStr = "abc";
    wstring wStr = "abc";
    pragma(msg, typeof(cStr.front));
    pragma(msg, typeof(wStr.front));
}
```

```
> ~/dlang/dmd/generated/linux/release/64/dmd  -run test2.d
dchar
dchar
```

```
> ~/dlang/dmd/generated/linux/release/64/dmd  -version=NoAutoDecode -run test.d
immutable(char)
immutable(wchar)
```

This obviously needs more work and maybe a real world test.
But before investing more time into this, I am interested: what do you think about this approach? Worth looking into?