### PR TITLE
Re-add has_public_example to circleci.sh for legacy compatibility

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -139,5 +139,7 @@ case $1 in
     coverage) coverage ;;
     publictests) publictests ;;
     style_lint) style_lint ;;
+    # has_public_example has been removed and is kept for compatibility with older PRs
+    has_public_example) echo "OK" ;;
     *) echo "Unknown command"; exit 1;;
 esac


### PR DESCRIPTION
This should fix the CircleCi build failures on older PRs and avoids the unnecessary need to rebase.

Background: we merge the PR branch into the target branch, hence the newest `circleci.sh` is always applied, but unfortunately we the `circle.yml` isn't updated. While we could use just one target e.g. `test`, using multiple has the advantage of visually grouping them nicely and thus helping a reader to track down the root of the failure.

CC @CyberShadow @schveiguy @JackStouffer @ZombineDev 