### PR TITLE
std.net.curl: RFC link at HTTP client docs is broken

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2377,7 +2377,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * http.perform();
   * ---
   *
-  * See_Also: $(HTTP www.ietf.org/rfc/rfc2616.txt, RFC2616)
+  * See_Also: $(_HTTP www.ietf.org/rfc/rfc2616.txt, RFC2616)
   *
   */
 struct HTTP


### PR DESCRIPTION
Please update link so it's clickable