### PR TITLE
Issue 17564: Eliminate "static this" for theAllocator

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -460,7 +460,7 @@ interface ISharedAllocator
 }
 
 private shared ISharedAllocator _processAllocator;
-IAllocator _threadAllocator;
+private IAllocator _threadAllocator;
 
 private void setupThreadAllocator()
 @safe nothrow @nogc {

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -462,8 +462,8 @@ interface ISharedAllocator
 private shared ISharedAllocator _processAllocator;
 IAllocator _threadAllocator;
 
-static this()
-{
+private void setupThreadAllocator()
+@safe nothrow @nogc {
     /*
     Forwards the `_threadAllocator` calls to the `processAllocator`
     */
@@ -538,7 +538,7 @@ static this()
     assert(!_threadAllocator);
     import std.conv : emplace;
     static ulong[stateSize!(ThreadAllocator).divideRoundUp(ulong.sizeof)] _threadAllocatorState;
-    _threadAllocator = emplace!(ThreadAllocator)(_threadAllocatorState[]);
+    _threadAllocator = () @trusted { return emplace!(ThreadAllocator)(_threadAllocatorState[]); } ();
 }
 
 /**
@@ -550,6 +550,7 @@ in turn uses the garbage collected heap.
 */
 nothrow @safe @nogc @property IAllocator theAllocator()
 {
+    if (!_threadAllocator) setupThreadAllocator();
     return _threadAllocator;
 }
 

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -462,8 +462,8 @@ interface ISharedAllocator
 private shared ISharedAllocator _processAllocator;
 private IAllocator _threadAllocator;
 
-private void setupThreadAllocator()
-@safe nothrow @nogc {
+private IAllocator setupThreadAllocator() nothrow @nogc @safe
+{
     /*
     Forwards the `_threadAllocator` calls to the `processAllocator`
     */
@@ -539,6 +539,7 @@ private void setupThreadAllocator()
     import std.conv : emplace;
     static ulong[stateSize!(ThreadAllocator).divideRoundUp(ulong.sizeof)] _threadAllocatorState;
     _threadAllocator = () @trusted { return emplace!(ThreadAllocator)(_threadAllocatorState[]); } ();
+    return _threadAllocator;
 }
 
 /**
@@ -550,8 +551,8 @@ in turn uses the garbage collected heap.
 */
 nothrow @safe @nogc @property IAllocator theAllocator()
 {
-    if (!_threadAllocator) setupThreadAllocator();
-    return _threadAllocator;
+    auto p = _threadAllocator;
+    return p !is null ? p : setupThreadAllocator();
 }
 
 /// Ditto


### PR DESCRIPTION
This switches to lazy initialization of theAllocator, so that accessing it form within `shared static this` works as expected.