### PR TITLE
Fix ARM unittest (again) in std.math.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5878,7 +5878,7 @@ real NaN(ulong payload) @trusted pure nothrow @nogc
     }
 }
 
-@safe pure nothrow @nogc unittest
+@system pure nothrow @nogc unittest // not @safe because taking address of local.
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     {


### PR DESCRIPTION
See #4132 and the revert of it in #4592.

Added a comment so that the mistake is not done for the third time in a row.