### PR TITLE
Add errnoString to remove code duplication from some modules

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1478,7 +1478,7 @@ private bool isUnionAliasedImpl(T)(size_t offset)
         static assert( isUnionAliased!(S.A5, 1)); //a5.b1;
 }
 
-package string errnoString(int errno)
+package string errnoString(int errno) nothrow @trusted
 {
     import core.stdc.string : strlen;
     version (CRuntime_Glibc)

--- a/std/exception.d
+++ b/std/exception.d
@@ -1496,7 +1496,7 @@ package string errnoString(int errno) nothrow @trusted
         if (strerror_r(errno, buf.ptr, buf.length) == 0)
             s = buf.ptr;
         else
-            s = "Unknown error";
+            return "Unknown error";
     }
     else
     {

--- a/std/exception.d
+++ b/std/exception.d
@@ -1478,6 +1478,34 @@ private bool isUnionAliasedImpl(T)(size_t offset)
         static assert( isUnionAliased!(S.A5, 1)); //a5.b1;
 }
 
+package string errnoString(int errno)
+{
+    import core.stdc.string : strlen;
+    version (CRuntime_Glibc)
+    {
+        import core.stdc.string : strerror_r;
+        char[1024] buf = void;
+        auto s = strerror_r(errno, buf.ptr, buf.length);
+    }
+    else version (Posix)
+    {
+        // XSI-compliant
+        import core.stdc.string : strerror_r;
+        char[1024] buf = void;
+        const(char)* s;
+        if (strerror_r(errno, buf.ptr, buf.length) == 0)
+            s = buf.ptr;
+        else
+            s = "Unknown error";
+    }
+    else
+    {
+        import core.stdc.string : strerror;
+        auto s = strerror(errno);
+    }
+    return s[0 .. s.strlen].idup;
+}
+
 /*********************
  * Thrown if errors that set $(D errno) occur.
  */
@@ -1494,21 +1522,8 @@ class ErrnoException : Exception
     /// Constructor which takes an error message and error code.
     this(string msg, int errno, string file = null, size_t line = 0) @trusted
     {
-        import core.stdc.string : strlen;
-
         _errno = errno;
-        version (CRuntime_Glibc)
-        {
-            import core.stdc.string : strerror_r;
-            char[1024] buf = void;
-            auto s = strerror_r(errno, buf.ptr, buf.length);
-        }
-        else
-        {
-            import core.stdc.string : strerror;
-            auto s = strerror(errno);
-        }
-        super(msg ~ " (" ~ s[0 .. s.strlen].idup ~ ")", file, line);
+        super(msg ~ " (" ~ errnoString(errno) ~ ")", file, line);
     }
 
     @system unittest

--- a/std/file.d
+++ b/std/file.d
@@ -208,8 +208,8 @@ class FileException : Exception
                              string file = __FILE__,
                              size_t line = __LINE__) @trusted
     {
-        auto s = strerror(errno);
-        this(name, to!string(s), file, line);
+        import std.exception : errnoString;
+        this(name, errnoString(errno), file, line);
         this.errno = errno;
     }
 }

--- a/std/process.d
+++ b/std/process.d
@@ -2433,19 +2433,8 @@ class ProcessException : Exception
                                          string file = __FILE__,
                                          size_t line = __LINE__)
     {
-        import std.conv : to;
-        version (CRuntime_Glibc)
-        {
-            import core.stdc.string : strerror_r;
-            char[1024] buf;
-            auto errnoMsg = to!string(
-                core.stdc.string.strerror_r(error, buf.ptr, buf.length));
-        }
-        else
-        {
-            import core.stdc.string : strerror;
-            auto errnoMsg = to!string(strerror(error));
-        }
+        import std.exception : errnoString;
+        auto errnoMsg = errnoString(error);
         auto msg = customMsg.empty ? errnoMsg
                                    : customMsg ~ " (" ~ errnoMsg ~ ')';
         return new ProcessException(msg, file, line);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4477,31 +4477,9 @@ Initialize with a message and an error code.
 */
     this(string message, uint e = core.stdc.errno.errno) @trusted
     {
-        import std.conv : to;
-
+        import std.exception : errnoString;
         errno = e;
-        version (Posix)
-        {
-            import core.stdc.string : strerror_r;
-
-            char[256] buf = void;
-            version (CRuntime_Glibc)
-            {
-                auto s = strerror_r(errno, buf.ptr, buf.length);
-            }
-            else
-            {
-                strerror_r(errno, buf.ptr, buf.length);
-                auto s = buf.ptr;
-            }
-        }
-        else
-        {
-            import core.stdc.string : strerror;
-
-            auto s = strerror(errno);
-        }
-        auto sysmsg = to!string(s);
+        auto sysmsg = errnoString(errno);
         // If e is 0, we don't use the system error message.  (The message
         // is "Success", which is rather pointless for an exception.)
         super(e == 0 ? message


### PR DESCRIPTION
I found too many similar pieces of code in phobos code related to errno string handling.
Make it into one errnoString function. For now it's package function, but can be made public.
There's also a lot of duplication in std.socket code related to the same thing, but I did not touch it yet.