### PR TITLE
std.datetime: Clarify range of integer month parameters

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -146,7 +146,7 @@ public:
     /++
         Params:
             year   = The year portion of the date.
-            month  = The month portion of the date.
+            month  = The month portion of the date (January is 1).
             day    = The day portion of the date.
             hour   = The hour portion of the time;
             minute = The minute portion of the time;
@@ -3609,7 +3609,7 @@ public:
             year  = Year of the Gregorian Calendar. Positive values are A.D.
                     Non-positive values are B.C. with year 0 being the year
                     prior to 1 A.D.
-            month = Month of the year.
+            month = Month of the year (January is 1).
             day   = Day of the month.
      +/
     this(int year, int month, int day) @safe pure
@@ -9239,7 +9239,7 @@ if (units == "months" ||
     Params:
         units = The units of time to validate.
         year  = The year of the day to validate.
-        month = The month of the day to validate.
+        month = The month of the day to validate (January is 1).
         day   = The day to validate.
   +/
 bool valid(string units)(int year, int month, int day) @safe pure nothrow @nogc

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -7690,7 +7690,8 @@ if (isTimePoint!TP &&
         dir   = The direction to iterate in. If passing the return value to
                 $(D fwdRange), use $(D Direction.fwd). If passing it to
                 $(D bwdRange), use $(D Direction.bwd).
-        month = The month that each time point in the range will be in.
+        month = The month that each time point in the range will be in
+                (January is 1).
   +/
 TP delegate(in TP) everyMonth(TP, Direction dir = Direction.fwd)(int month)
 if (isTimePoint!TP &&


### PR DESCRIPTION
Months are 0-11 in C's tm and the old std.date, so it's better to clarify the range for every instance of `int month` in the API.