### PR TITLE
Upgrade to latest tools

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -86,6 +86,10 @@ setup_repos()
         fi
     done
 
+    # checkout a specific version of https://github.com/dlang/tools
+    clone https://github.com/dlang/tools.git ../tools master
+    git -C ../tools checkout 87c63705dcacac38ba7c84d19699f656d834139d
+
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
@@ -99,11 +103,6 @@ style_lint()
 {
     # dscanner needs a more up-to-date DMD version
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
-
-    # some style tools are at the tools repo
-    clone https://github.com/dlang/tools.git ../tools master
-    # fix to a specific version of https://github.com/dlang/tools/tree/master/styles
-    git -C ../tools checkout 60583c8363ff25d00017dffdb18c7ee7e7d9a343
 
     make -f posix.mak style_lint DUB=$DUB
 }

--- a/posix.mak
+++ b/posix.mak
@@ -266,7 +266,7 @@ IGNORED_PUBLICTESTS= $(addprefix std/, \
 						) digest/hmac \
 						file math stdio traits typecons uuid)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
-TEST_EXTRACTOR=$(TOOLS_DIR)/styles/test_extractor
+TESTS_EXTRACTOR=$(ROOT)/tests_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests
 
 ################################################################################
@@ -506,8 +506,9 @@ changelog.html: changelog.dd
 
 ${TOOLS_DIR}:
 	git clone --depth=1 ${GIT_HOME}/$(@F) $@
+
 $(TOOLS_DIR)/checkwhitespace.d: | $(TOOLS_DIR)
-$(TOOLS_DIR)/styles/tests_extractor.d: | $(TOOLS_DIR)
+$(TOOLS_DIR)/tests_extractor.d: | $(TOOLS_DIR)
 
 #################### test for undesired white spaces ##########################
 CWS_TOCHECK = posix.mak win32.mak win64.mak osmodel.mak
@@ -589,16 +590,17 @@ style_lint: dscanner $(LIB)
 ################################################################################
 publictests: $(PUBLICTESTS)
 
-$(TEST_EXTRACTOR): $(TOOLS_DIR)/styles/tests_extractor.d $(LIB)
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --root=$(TOOLS_DIR)/styles -c tests_extractor
+$(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d $(LIB)
+	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<
+	mv $(TOOLS_DIR)/tests_extractor $@
 
 ################################################################################
 # Extract public tests of a module and test them in an separate file (i.e. without its module)
 # This is done to check for potentially missing imports in the examples, e.g.
 # make -f posix.mak std/format.publictests
 ################################################################################
-%.publictests: %.d $(LIB) $(TEST_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
-	@$(TEST_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
+%.publictests: %.d $(LIB) $(TESTS_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
+	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
 	@$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main -unittest -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 
 .PHONY : auto-tester-build


### PR DESCRIPTION
After https://github.com/dlang/tools/pull/237, we can simplify the Makefile a bit.

CC @CyberShadow 

I considered for a bit doing sth. like:

```
TOOLS_HASH=87c63705dcacac38ba7c84d19699f656d834139d
TOOLS_DIR=../tools-$(TOOLS_HASH)
```

But then dropped it because from the developers we can expect to have moderately recent tools version around (they know how to pull if they get an error) and it would be probably pretty annoying to have multiple versions of `dlang/tools` around.