### PR TITLE
Use the generated VERSION file instead of the outdated ../dmd/VERSION

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -143,7 +143,11 @@ LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)
 TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 90 ,)
 
 # Set VERSION, where the file is that contains the version string
+ifeq (,$(wildcard $(DMD_DIR)/generated))
 VERSION=$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/VERSION
+else
+VERSION=$(DMD_DIR)/VERSION
+endif
 
 # Set LIB, the ultimate target
 ifeq (,$(findstring win,$(OS)))

--- a/posix.mak
+++ b/posix.mak
@@ -143,7 +143,7 @@ LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)
 TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 90 ,)
 
 # Set VERSION, where the file is that contains the version string
-VERSION=$(DMD_DIR)/VERSION
+VERSION=$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/VERSION
 
 # Set LIB, the ultimate target
 ifeq (,$(findstring win,$(OS)))


### PR DESCRIPTION
The generated `VERSION` file is the source of truth - it's a dependency for `dmd`, so it's guaranteed to be there.

CC @CyberShadow @MartinNowak 

Before:

```
ln -sf libphobos2.so.0.74.0 generated/linux/release/64/libphobos2.so.0.74
ln -sf libphobos2.so.0.74.0 generated/linux/release/64/libphobos2.so
```

(due to the outdated `VERSION` file)

After:

```
ln -sf libphobos2.so.0.75.0 generated/linux/release/64/libphobos2.so.0.75
ln -sf libphobos2.so.0.75.0 generated/linux/release/64/libphobos2.so
```

And of course, future git tags will propagates automatically :)