### PR TITLE
Fix Issue 8472 - Replace walkLength() with an improved count()

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -696,11 +696,16 @@ size_t count(alias pred = "true", R)(R haystack)
 if (isInputRange!R && !isInfinite!R &&
     is(typeof(unaryFun!pred(haystack.front)) : bool))
 {
-    size_t result;
-    alias T = ElementType!R; //For narrow strings forces dchar iteration
-    foreach (T elem; haystack)
-        if (unaryFun!pred(elem)) ++result;
-    return result;
+    static if (hasLength!R && is(typeof(unary!fun(pred) == unary!fun("true"))))
+        return haystack.length;
+    else
+    {
+        size_t result;
+        alias T = ElementType!R; //For narrow strings forces dchar iteration
+        foreach (T elem; haystack)
+            if (unaryFun!pred(elem)) ++result;
+        return result;
+    }
 }
 
 @safe unittest

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -692,20 +692,25 @@ if (isForwardRange!R1 && !isInfinite!R1 &&
 }
 
 /// Ditto
-size_t count(alias pred = "true", R)(R haystack)
+size_t count(alias pred, R)(R haystack)
 if (isInputRange!R && !isInfinite!R &&
     is(typeof(unaryFun!pred(haystack.front)) : bool))
 {
-    static if (hasLength!R && is(typeof(unary!fun(pred) == unary!fun("true"))))
+    size_t result;
+    alias T = ElementType!R; //For narrow strings forces dchar iteration
+    foreach (T elem; haystack)
+        if (unaryFun!pred(elem)) ++result;
+    return result;
+}
+
+/// Ditto
+size_t count(R)(R haystack)
+if (isInputRange!R && !isInfinite!R)
+{
+    static if (hasLength!R)
         return haystack.length;
     else
-    {
-        size_t result;
-        alias T = ElementType!R; //For narrow strings forces dchar iteration
-        foreach (T elem; haystack)
-            if (unaryFun!pred(elem)) ++result;
-        return result;
-    }
+        return count!"true"(haystack);
 }
 
 @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1638,6 +1638,7 @@ upTo) steps have been taken and returns $(D upTo).
 Infinite ranges are compatible, provided the parameter $(D upTo) is
 specified, in which case the implementation simply returns upTo.
  */
+deprecated("use std.algorithm.searching.count instead.")
 auto walkLength(Range)(Range range)
 if (isInputRange!Range && !isInfinite!Range)
 {

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1625,34 +1625,16 @@ range.
 If $(D hasLength!Range), simply returns $(D range.length) without
 checking $(D upTo) (when specified).
 
-Otherwise, walks the range through its length and returns the number
-of elements seen. Performes $(BIGOH n) evaluations of $(D range.empty)
+Otherwise, walks the range for $(D upTo) elements. If $(D range.length) is smaller
+than $(D upTo), the walking stops returning $(D range.length).
+
+Performes $(BIGOH n) evaluations of $(D range.empty)
 and $(D range.popFront()), where $(D n) is the effective length of $(D
 range).
-
-The $(D upTo) parameter is useful to "cut the losses" in case
-the interest is in seeing whether the range has at least some number
-of elements. If the parameter $(D upTo) is specified, stops if $(D
-upTo) steps have been taken and returns $(D upTo).
 
 Infinite ranges are compatible, provided the parameter $(D upTo) is
 specified, in which case the implementation simply returns upTo.
  */
-deprecated("use std.algorithm.searching.count instead.")
-auto walkLength(Range)(Range range)
-if (isInputRange!Range && !isInfinite!Range)
-{
-    static if (hasLength!Range)
-        return range.length;
-    else
-    {
-        size_t result;
-        for ( ; !range.empty ; range.popFront() )
-            ++result;
-        return result;
-    }
-}
-/// ditto
 auto walkLength(Range)(Range range, const size_t upTo)
 if (isInputRange!Range)
 {
@@ -1664,6 +1646,22 @@ if (isInputRange!Range)
     {
         size_t result;
         for ( ; result < upTo && !range.empty ; range.popFront() )
+            ++result;
+        return result;
+    }
+}
+
+//@@@DEPRECATED_2018-07@@@
+deprecated("use std.algorithm.searching.count instead.")
+auto walkLength(Range)(Range range)
+if (isInputRange!Range && !isInfinite!Range)
+{
+    static if (hasLength!Range)
+        return range.length;
+    else
+    {
+        size_t result;
+        for ( ; !range.empty ; range.popFront() )
             ++result;
         return result;
     }


### PR DESCRIPTION
I am not sure how the deprecation cycle works, but I deprecated the first walkLength overload which is obsolete. I don't know if the walkLength overload which walks up to a given number of elements should be deprecated too. I think that the best way is to deprecated one overload of walkLength and keep the other.