### PR TITLE
Trigger a hard error on deprecation messages

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -88,7 +88,7 @@ setup_repos()
 
     # checkout a specific version of https://github.com/dlang/tools
     clone https://github.com/dlang/tools.git ../tools master
-    git -C ../tools checkout 87c63705dcacac38ba7c84d19699f656d834139d
+    git -C ../tools checkout df3dfa3061d25996ac98158d3bdb3525c8d89445
 
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"

--- a/posix.mak
+++ b/posix.mak
@@ -115,7 +115,7 @@ else
 endif
 
 # Set DFLAGS
-DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -dip25 $(MODEL_FLAG) $(PIC)
+DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
 else

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -637,7 +637,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(count("ababab", "abab") == 1);
     assert(count("ababab", "abx") == 0);
     // fuzzy count range in range
-    assert(count!((a, b) => std.uni.toLower(a) == std.uni.toLower(b))("AbcAdFaBf", "ab") == 2);
+    assert(count!((a, b) => toLower(a) == toLower(b))("AbcAdFaBf", "ab") == 2);
     // count predicate in range
     assert(count!("a > 1")(a) == 8);
 }

--- a/std/csv.d
+++ b/std/csv.d
@@ -1099,7 +1099,6 @@ public:
     }
 }
 
-///
 @safe pure unittest
 {
     import std.algorithm.comparison : equal;

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2991,8 +2991,6 @@ else version(Windows)
 
         static immutable(WindowsTimeZone) getTimeZone(string name) @trusted
         {
-            import std.utf : toUTF16;
-
             scope baseKey = Registry.localMachine.getKey(`Software\Microsoft\Windows NT\CurrentVersion\Time Zones`);
 
             foreach (tzKeyName; baseKey.keyNames)
@@ -3015,8 +3013,8 @@ else version(Windows)
 
                 TIME_ZONE_INFORMATION tzInfo;
 
-                auto wstdName = toUTF16(stdName);
-                auto wdstName = toUTF16(dstName);
+                auto wstdName = stdName.to!wstring;
+                auto wdstName = dstName.to!wstring;
                 auto wstdNameLen = wstdName.length > 32 ? 32 : wstdName.length;
                 auto wdstNameLen = wdstName.length > 32 ? 32 : wdstName.length;
 

--- a/std/string.d
+++ b/std/string.d
@@ -5288,6 +5288,7 @@ if (isSomeString!S)
 }
 
 
+deprecated
 @safe pure @nogc unittest
 {
     import std.conv : to;
@@ -5363,6 +5364,7 @@ if (isSomeString!S && isSomeString!S1)
     return count;
 }
 
+deprecated
 @safe pure @nogc unittest
 {
     import std.conv : to;
@@ -5417,6 +5419,7 @@ if (isSomeString!S)
         return s;
 }
 
+deprecated
 @safe pure unittest
 {
     import std.conv : to;
@@ -5433,6 +5436,7 @@ if (isSomeString!S)
     });
 }
 
+deprecated
 @safe pure unittest
 {
     assert(removechars("abc", "x") == "abc");
@@ -5493,6 +5497,7 @@ S squeeze(S)(S s, in S pattern = null)
     return changed ? ((r is null) ? s[0 .. lasti] : cast(S) r) : s;
 }
 
+deprecated
 @system pure unittest
 {
     import std.conv : to;
@@ -5549,6 +5554,7 @@ S1 munch(S1, S2)(ref S1 s, S2 pattern) @safe pure @nogc
 }
 
 ///
+deprecated
 @safe pure @nogc unittest
 {
     string s = "123abc";
@@ -5558,6 +5564,7 @@ S1 munch(S1, S2)(ref S1 s, S2 pattern) @safe pure @nogc
     assert(t == "" && s == "abc");
 }
 
+deprecated
 @safe pure @nogc unittest
 {
     string s = "123€abc";

--- a/std/uni.d
+++ b/std/uni.d
@@ -4762,9 +4762,9 @@ template Utf8Matcher()
     static auto encode(size_t sz)(dchar ch)
         if (sz > 1)
     {
-        import std.utf : encode;
+        import std.utf : encodeUTF = encode;
         char[4] buf;
-        std.utf.encode(buf, ch);
+        encodeUTF(buf, ch);
         char[sz] ret;
         buf[0] &= leadMask!sz;
         foreach (n; 1 .. sz)
@@ -7380,7 +7380,7 @@ package auto simpleCaseFoldings(dchar ch) @safe
             return len == 0;
         }
 
-        @property uint length() const
+        @property size_t length() const
         {
             if (isSmall)
             {

--- a/std/uni.d
+++ b/std/uni.d
@@ -2546,7 +2546,6 @@ private:
         return this;
     }
 
-    ///
     @safe unittest
     {
         assert(unicode.Cyrillic.intersect('-').byInterval.empty);
@@ -4340,7 +4339,6 @@ if (sumOfIntegerTuple!sizes == 21)
     }
 }
 
-///
 @system pure unittest
 {
     import std.algorithm.comparison : max;
@@ -4644,7 +4642,6 @@ public struct MatcherConcept
         return this;
     }
 
-    ///
     @safe unittest
     {
         auto m = utfMatcher!char(unicode.Number);

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -53,7 +53,6 @@ version (Windows):
 private import core.sys.windows.windows;
 private import std.conv;
 private import std.string;
-private import std.utf;
 private import std.windows.syserror;
 
 import std.internal.cstring;
@@ -114,7 +113,7 @@ string fromMBSz(immutable(char)* s, int codePage = 0)
                     sysErrorString(GetLastError()));
             }
 
-            return std.utf.toUTF8(result[0 .. result.length-1]); // omit trailing null
+            return result[0 .. result.length-1].to!string; // omit trailing null
         }
     }
     return s[0 .. c-s];         // string is ASCII, no conversion necessary

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -45,7 +45,6 @@ import std.exception;
 import std.internal.cstring;
 private import std.internal.windows.advapi32;
 import std.system : Endian, endian;
-import std.utf : toUTF8, toUTF16;
 import std.windows.syserror;
 
 //debug = winreg;
@@ -557,7 +556,7 @@ body
             if (wstr.length && wstr[$-1] == '\0')
                 wstr.length = wstr.length - 1;
             assert(wstr.length == 0 || wstr[$-1] != '\0');
-            value = toUTF8(wstr);
+            value = wstr.to!string;
             break;
 
         case REG_VALUE_TYPE.REG_DWORD_LITTLE_ENDIAN:
@@ -623,7 +622,7 @@ body
     value.length = list.length;
     foreach (i, ref v; value)
     {
-        v = toUTF8(list[i]);
+        v = list[i].to!string;
     }
 }
 
@@ -752,7 +751,7 @@ private void regProcessNthKey(HKEY hkey, scope void delegate(scope LONG delegate
         immutable res = regEnumKeyName(hkey, index, sName, cchName);
         if (res == ERROR_SUCCESS)
         {
-            name = toUTF8(sName[0 .. cchName]);
+            name = sName[0 .. cchName].to!string;
         }
         return res;
     });
@@ -774,7 +773,7 @@ private void regProcessNthValue(HKEY hkey, scope void delegate(scope LONG delega
         immutable res = regEnumValueName(hkey, index, sName, cchName);
         if (res == ERROR_SUCCESS)
         {
-            name = toUTF8(sName[0 .. cchName]);
+            name = sName[0 .. cchName].to!string;
         }
         return res;
     });
@@ -1098,7 +1097,7 @@ public:
         wstring[] data = new wstring[value.length+1];
         foreach (i, ref s; data[0..$-1])
         {
-            s = toUTF16(value[i]);
+            s = value[i].to!wstring;
         }
         data[$-1] = "\0";
         auto ws = std.array.join(data, "\0"w);
@@ -1235,7 +1234,7 @@ public:
             ExpandEnvironmentStringsW(srcTmp, newValue.ptr, to!DWORD(newValue.length)),
             "Failed to expand environment variables");
 
-        return toUTF8(newValue[0 .. count-1]); // remove trailing 0
+        return newValue[0 .. count-1].to!string; // remove trailing 0
     }
 
     /**

--- a/win32.mak
+++ b/win32.mak
@@ -43,7 +43,7 @@ DRUNTIMELIB=$(DRUNTIME)\lib\druntime.lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -O -release -w -dip25 -I$(DRUNTIME)\import
+DFLAGS=-conf= -O -release -w -de -dip25 -I$(DRUNTIME)\import
 #DFLAGS=-unittest -g
 #DFLAGS=-unittest -cov -g
 

--- a/win64.mak
+++ b/win64.mak
@@ -46,7 +46,7 @@ DRUNTIMELIB=$(DRUNTIME)\lib\druntime$(MODEL).lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -m$(MODEL) -O -release -w -dip25 -I$(DRUNTIME)\import
+DFLAGS=-conf= -m$(MODEL) -O -release -w -de -dip25 -I$(DRUNTIME)\import
 #DFLAGS=-m$(MODEL) -unittest -g
 #DFLAGS=-m$(MODEL) -unittest -cov -g
 


### PR DESCRIPTION
https://github.com/dlang/phobos/pull/5083#issuecomment-313140290

> Yeah but it doesn't make sense otherwise, does it? Seems antithetical to deprecate something for everyone else but not ourselves.
> Any reason not to enable `-de` on the test suite then?

CC @CyberShadow 