### PR TITLE
don't escape slash in toJSON (issue 17587)

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -75,7 +75,8 @@ enum JSONOptions
 {
     none,                       /// standard parsing
     specialFloatLiterals = 0x1, /// encode NaN and Inf float values as strings
-    escapeNonAsciiChars = 0x2   /// encode non ascii characters with an unicode escape sequence
+    escapeNonAsciiChars = 0x2,   /// encode non ascii characters with an unicode escape sequence
+    doNotEscapeSlashes = 0x4, /// do not escape slashes ('/')
 }
 
 /**
@@ -1153,7 +1154,13 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
             {
                 case '"':       json.put("\\\"");       break;
                 case '\\':      json.put("\\\\");       break;
-                case '/':       json.put("\\/");        break;
+
+                case '/':
+                if (!(options & JSONOptions.doNotEscapeSlashes))
+                    json.put('\\');
+                json.put('/');
+                break;
+
                 case '\b':      json.put("\\b");        break;
                 case '\f':      json.put("\\f");        break;
                 case '\n':      json.put("\\n");        break;
@@ -1841,4 +1848,12 @@ pure nothrow @safe unittest // issue 15884
     import std.utf;
     assert(parseJSON("\"\xFF\"".byChar).str == "\xFF");
     assert(parseJSON("\"\U0001D11E\"".byChar).str == "\U0001D11E");
+}
+
+@safe unittest // JSONOptions.doNotEscapeSlashes (issue 17587)
+{
+    assert(parseJSON(`"/"`).toString == `"\/"`);
+    assert(parseJSON(`"\/"`).toString == `"\/"`);
+    assert(parseJSON(`"/"`).toString(JSONOptions.doNotEscapeSlashes) == `"/"`);
+    assert(parseJSON(`"\/"`).toString(JSONOptions.doNotEscapeSlashes) == `"/"`);
 }

--- a/std/json.d
+++ b/std/json.d
@@ -75,8 +75,8 @@ enum JSONOptions
 {
     none,                       /// standard parsing
     specialFloatLiterals = 0x1, /// encode NaN and Inf float values as strings
-    escapeNonAsciiChars = 0x2,   /// encode non ascii characters with an unicode escape sequence
-    doNotEscapeSlashes = 0x4, /// do not escape slashes ('/')
+    escapeNonAsciiChars = 0x2,  /// encode non ascii characters with an unicode escape sequence
+    doNotEscapeSlashes = 0x4,   /// do not escape slashes ('/')
 }
 
 /**
@@ -1156,10 +1156,10 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                 case '\\':      json.put("\\\\");       break;
 
                 case '/':
-                if (!(options & JSONOptions.doNotEscapeSlashes))
-                    json.put('\\');
-                json.put('/');
-                break;
+                    if (!(options & JSONOptions.doNotEscapeSlashes))
+                        json.put('\\');
+                    json.put('/');
+                    break;
 
                 case '\b':      json.put("\\b");        break;
                 case '\f':      json.put("\\f");        break;


### PR DESCRIPTION
On input, both escaped and unescaped slashes must be recognized. They don't
need to be escaped on output.

Fixes issue 17587 (enhancement request).

----

As far as I see, the argument for escaping slashes is that it turns `"</script>"` into `"<\/script>"`. The latter can be put into JavaScript code without breaking it. But one can still emit stuff like `"<!-- <script>"` which confuses JS engines. So this seems a weak argument.