### PR TITLE
Remove old, redundant private import access specifier

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -117,7 +117,7 @@ alias curl_socket_t = socket_t;
 /// jdrewsen - Would like to get socket error constant from std.socket by it is private atm.
 version(Windows)
 {
-  private import core.sys.windows.windows, core.sys.windows.winsock2;
+  import core.sys.windows.windows, core.sys.windows.winsock2;
   enum CURL_SOCKET_BAD = SOCKET_ERROR;
 }
 version(Posix) enum CURL_SOCKET_BAD = -1;

--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -14,8 +14,8 @@ See_Also: $(LINK2 https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/odb
 
 module etc.c.odbc.sqlext;
 
-private import etc.c.odbc.sql;
-private import etc.c.odbc.sqltypes;
+import etc.c.odbc.sql;
+import etc.c.odbc.sqltypes;
 
 extern (Windows):
 

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -27,10 +27,10 @@ module std.bigint;
 
 import std.conv : ConvException;
 
-private import std.format : FormatSpec, FormatException;
-private import std.internal.math.biguintcore;
-private import std.range.primitives;
-private import std.traits;
+import std.format : FormatSpec, FormatException;
+import std.internal.math.biguintcore;
+import std.range.primitives;
+import std.traits;
 
 /** A struct representing an arbitrary precision integer.
  *

--- a/std/c/linux/socket.d
+++ b/std/c/linux/socket.d
@@ -13,7 +13,7 @@ deprecated("Import the appropriate core.sys.posix.* modules instead")
 module std.c.linux.socket;
 
 version (linux):
-private import core.stdc.stdint;
+import core.stdc.stdint;
 public import core.sys.posix.arpa.inet;
 public import core.sys.posix.netdb;
 public import core.sys.posix.netinet.in_;

--- a/std/c/osx/socket.d
+++ b/std/c/osx/socket.d
@@ -13,7 +13,7 @@ deprecated("Import the appropriate core.sys.posix.* instead")
 module std.c.osx.socket;
 
 version (OSX):
-private import core.stdc.stdint;
+import core.stdc.stdint;
 public import core.sys.posix.arpa.inet;
 public import core.sys.posix.netdb;
 public import core.sys.posix.netinet.in_;

--- a/std/c/process.d
+++ b/std/c/process.d
@@ -12,7 +12,7 @@
 deprecated("Import core.stdc.stdlib or the appropriate core.sys.posix.* modules instead")
 module std.c.process;
 
-private import core.stdc.stddef;
+import core.stdc.stddef;
 public import core.stdc.stdlib : exit, abort, system;
 
 extern (C):

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -591,7 +591,7 @@ SbrkRegion) adversely.
 */
 version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
 {
-    private import core.sys.posix.pthread : pthread_mutex_init, pthread_mutex_destroy,
+    import core.sys.posix.pthread : pthread_mutex_init, pthread_mutex_destroy,
         pthread_mutex_t, pthread_mutex_lock, pthread_mutex_unlock,
         PTHREAD_MUTEX_INITIALIZER;
     private static shared pthread_mutex_t sbrkMutex = PTHREAD_MUTEX_INITIALIZER;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -22,9 +22,9 @@ struct ScopedAllocator(ParentAllocator)
         testAllocator!(() => ScopedAllocator());
     }
 
-    private import std.experimental.allocator.building_blocks.affix_allocator
+    import std.experimental.allocator.building_blocks.affix_allocator
         : AffixAllocator;
-    private import std.traits : hasMember;
+    import std.traits : hasMember;
     import std.typecons : Ternary;
 
     private struct Node

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -61,10 +61,10 @@ auto mmapRegionList(size_t bytesPerRegion)
     static struct Factory
     {
         size_t bytesPerRegion;
-        private import std.algorithm.comparison : max;
-        private import std.experimental.allocator.building_blocks.region
+        import std.algorithm.comparison : max;
+        import std.experimental.allocator.building_blocks.region
             : Region;
-        private import std.experimental.allocator.mmap_allocator
+        import std.experimental.allocator.mmap_allocator
             : MmapAllocator;
         this(size_t n)
         {

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -46,10 +46,10 @@ alias multibyteAdd = multibyteAddSub!('+');
 alias multibyteSub = multibyteAddSub!('-');
 
 
-private import core.cpuid;
+import core.cpuid;
 public import std.ascii : LetterCase;
-private import std.range.primitives;
-private import std.traits;
+import std.range.primitives;
+import std.traits;
 
 shared static this()
 {
@@ -75,8 +75,8 @@ else static if (BigDigit.sizeof == long.sizeof)
 }
 else static assert(0, "Unsupported BigDigit size");
 
-private import std.exception : assumeUnique;
-private import std.traits : isIntegral;
+import std.exception : assumeUnique;
+import std.traits : isIntegral;
 enum BigDigitBits = BigDigit.sizeof*8;
 template maxBigDigits(T)
 if (isIntegral!T)

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -10,8 +10,8 @@ module std.internal.scopebuffer;
 
 //debug=ScopeBuffer;
 
-private import core.stdc.stdlib : realloc;
-private import std.traits;
+import core.stdc.stdlib : realloc;
+import std.traits;
 
 /**************************************
  * ScopeBuffer encapsulates using a local array as a temporary buffer.

--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -12,7 +12,7 @@ module std.internal.windows.advapi32;
 
 version(Windows):
 
-private import core.sys.windows.windows;
+import core.sys.windows.windows;
 
 pragma(lib, "advapi32.lib");
 

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -53,8 +53,8 @@
  * Source:    $(PHOBOSSRC std/_mathspecial.d)
  */
 module std.mathspecial;
-private import std.internal.math.errorfunction;
-private import std.internal.math.gammafunction;
+import std.internal.math.errorfunction;
+import std.internal.math.gammafunction;
 public import std.math;
 
 /* ***********************************************

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -17,13 +17,13 @@
  */
 module std.mmfile;
 
-private import core.stdc.errno;
-private import core.stdc.stdio;
-private import core.stdc.stdlib;
+import core.stdc.errno;
+import core.stdc.stdio;
+import core.stdc.stdlib;
 import std.conv, std.exception, std.stdio;
-private import std.file;
-private import std.path;
-private import std.string;
+import std.file;
+import std.path;
+import std.string;
 
 import std.internal.cstring;
 
@@ -31,16 +31,16 @@ import std.internal.cstring;
 
 version (Windows)
 {
-    private import core.sys.windows.windows;
-    private import std.utf;
-    private import std.windows.syserror;
+    import core.sys.windows.windows;
+    import std.utf;
+    import std.windows.syserror;
 }
 else version (Posix)
 {
-    private import core.sys.posix.fcntl;
-    private import core.sys.posix.sys.mman;
-    private import core.sys.posix.sys.stat;
-    private import core.sys.posix.unistd;
+    import core.sys.posix.fcntl;
+    import core.sys.posix.sys.mman;
+    import core.sys.posix.sys.stat;
+    import core.sys.posix.unistd;
 }
 else
 {

--- a/std/socket.d
+++ b/std/socket.d
@@ -60,7 +60,7 @@ version(Windows)
     pragma (lib, "ws2_32.lib");
     pragma (lib, "wsock32.lib");
 
-    private import core.sys.windows.windows, std.windows.syserror;
+    import core.sys.windows.windows, std.windows.syserror;
     public import core.sys.windows.winsock2;
     private alias _ctimeval = core.sys.windows.winsock2.timeval;
     private alias _clinger = core.sys.windows.winsock2.linger;
@@ -85,20 +85,20 @@ else version(Posix)
         }
     }
 
-    private import core.sys.posix.arpa.inet;
-    private import core.sys.posix.fcntl;
+    import core.sys.posix.arpa.inet;
+    import core.sys.posix.fcntl;
     import core.sys.posix.netdb;
-    private import core.sys.posix.netinet.in_;
-    private import core.sys.posix.netinet.tcp;
-    private import core.sys.posix.sys.select;
-    private import core.sys.posix.sys.socket;
-    private import core.sys.posix.sys.time;
+    import core.sys.posix.netinet.in_;
+    import core.sys.posix.netinet.tcp;
+    import core.sys.posix.sys.select;
+    import core.sys.posix.sys.socket;
+    import core.sys.posix.sys.time;
     import core.sys.posix.sys.un : sockaddr_un;
-    private import core.sys.posix.unistd;
+    import core.sys.posix.unistd;
     private alias _ctimeval = core.sys.posix.sys.time.timeval;
     private alias _clinger = core.sys.posix.sys.socket.linger;
 
-    private import core.stdc.errno;
+    import core.stdc.errno;
 
     enum socket_t : int32_t { init = -1 }
     private const int _SOCKET_ERROR = -1;
@@ -125,7 +125,7 @@ version(unittest)
     static assert(is(uint32_t == uint));
     static assert(is(uint16_t == ushort));
 
-    private import std.stdio : writefln;
+    import std.stdio : writefln;
 
     // Print a message on exception instead of failing the unittest.
     private void softUnittest(void delegate() @safe test, int line = __LINE__) @trusted

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5729,7 +5729,7 @@ mixin template Proxy(alias a)
 
     static if (!is(typeof(this) == class))
     {
-        private import std.traits;
+        import std.traits;
         static if (isAssignable!ValueType)
         {
             auto ref opAssign(this X)(auto ref typeof(this) v)

--- a/std/uni.d
+++ b/std/uni.d
@@ -2436,7 +2436,7 @@ public:
         ---
     */
 
-    private import std.format : FormatException, FormatSpec;
+    import std.format : FormatException, FormatSpec;
 
     /***************************************
      * Obtain a textual representation of this InversionList

--- a/std/uni.d
+++ b/std/uni.d
@@ -2069,8 +2069,6 @@ pure:
 {
     import std.range : assumeSorted;
 
-public:
-
     /**
         Construct from another code point set of any type.
     */
@@ -2436,7 +2434,7 @@ public:
         ---
     */
 
-    import std.format : FormatException, FormatSpec;
+    private import std.format : FormatSpec;
 
     /***************************************
      * Obtain a textual representation of this InversionList
@@ -2495,7 +2493,7 @@ public:
     @safe unittest
     {
         import std.exception : assertThrown;
-        import std.format : format;
+        import std.format : format, FormatException;
         assertThrown!FormatException(format("%a", unicode.ASCII));
     }
 

--- a/std/uri.d
+++ b/std/uri.d
@@ -24,8 +24,8 @@
 module std.uri;
 
 //debug=uri;        // uncomment to turn on debugging writefln's
-debug(uri) private import std.stdio;
-private import std.traits : isSomeChar;
+debug(uri) import std.stdio;
+import std.traits : isSomeChar;
 
 /** This Exception is thrown if something goes wrong when encoding or
 decoding a URI.

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -50,10 +50,10 @@ else:
 
 version (Windows):
 
-private import core.sys.windows.windows;
-private import std.conv;
-private import std.string;
-private import std.windows.syserror;
+import core.sys.windows.windows;
+import std.conv;
+import std.string;
+import std.windows.syserror;
 
 import std.internal.cstring;
 

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -43,7 +43,7 @@ import std.array;
 import std.conv;
 import std.exception;
 import std.internal.cstring;
-private import std.internal.windows.advapi32;
+import std.internal.windows.advapi32;
 import std.system : Endian, endian;
 import std.windows.syserror;
 
@@ -223,7 +223,7 @@ enum REG_VALUE_TYPE : DWORD
 
 /* ************* private *************** */
 
-private import core.sys.windows.winnt :
+import core.sys.windows.winnt :
     DELETE                  ,
     READ_CONTROL            ,
     WRITE_DAC               ,
@@ -240,7 +240,7 @@ private import core.sys.windows.winnt :
 
     SPECIFIC_RIGHTS_ALL     ;
 
-private import core.sys.windows.winreg :
+import core.sys.windows.winreg :
     REG_CREATED_NEW_KEY     ,
     REG_OPENED_EXISTING_KEY ;
 

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -674,8 +674,8 @@ class UnCompress
 
 /* ========================== unittest ========================= */
 
-private import std.random;
-private import std.stdio;
+import std.random;
+import std.stdio;
 
 @system unittest // by Dave
 {


### PR DESCRIPTION
Very very old versions of D (well into 0.x) had imports public by default,
like C header files. This modernizes the codebase and removes the
redundant `private` access specifier.
This has been done with:

    sed "s/private import/import/g" -i **/*.d

See also: https://github.com/dlang/phobos/pull/5546#discussion_r125759182

CC @CyberShadow 

I don't think it's worth adding a check here, because no one uses `private import` nowadays.