### PR TITLE
Move tools checkout to style_lint to avoid failing PRs

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -86,10 +86,6 @@ setup_repos()
         fi
     done
 
-    # checkout a specific version of https://github.com/dlang/tools
-    clone https://github.com/dlang/tools.git ../tools master
-    git -C ../tools checkout df3dfa3061d25996ac98158d3bdb3525c8d89445
-
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
@@ -129,6 +125,12 @@ coverage()
 # extract publictests and run them independently
 publictests()
 {
+    # checkout a specific version of https://github.com/dlang/tools
+    if [ ! -d ../tools ] ; then
+        clone https://github.com/dlang/tools.git ../tools master
+    fi
+    git -C ../tools checkout df3dfa3061d25996ac98158d3bdb3525c8d89445
+
     make -f posix.mak -j$N publictests DUB=$DUB
 }
 


### PR DESCRIPTION
I observed the following on https://github.com/dlang/phobos/pull/5557:

```
libdparse 0.7.0: building configuration "library"...
../.dub/packages/libdparse-0.7.0/libdparse/src/dparse/ast.d(1346,10): Deprecation: cannot implicitly override base class method object.Object.opEquals with dparse.ast.Declaration.opEquals; add override attribute
/home/ubuntu/phobos/../dmd/generated/linux/release/64/dmd failed with exit code 1.
make: *** [generated/linux/release/64/tests_extractor] Error 2
```

In `setup_repos` we merge with the master branch, thus only the later targets have an updated `circleci.sh`.
A long-term solution might also simply be building DScanner without `-de`, but this is the simpler fix for now (the other requires a bit of Makefile fiddling).

CC @CyberShadow 