### PR TITLE
Fix style (space between a .. b) in std/json.d

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1176,7 +1176,7 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                         // of UTF-16 surrogate characters, as per RFC 4627.
                         wchar[2] wchars; // 1 or 2 UTF-16 code units
                         size_t wNum = encode(wchars, c); // number of UTF-16 code units
-                        foreach (wc; wchars[0..wNum])
+                        foreach (wc; wchars[0 .. wNum])
                         {
                             json.put("\\u");
                             foreach_reverse (i; 0 .. 4)


### PR DESCRIPTION
See also: https://github.com/dlang/phobos/pull/5541#issuecomment-313282541

CC @CyberShadow 

(will investigate how it managed to get through Circle)