### PR TITLE
Fix random coverage in std.algorithm.sorting

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -895,7 +895,7 @@ if (ss == SwapStrategy.unstable && isRandomAccessRange!Range
         auto a = new int[](uniform(0, 100, r));
         foreach (ref e; a)
         {
-            e = uniform(0, 50);
+            e = uniform(0, 50, r);
         }
         auto pieces = partition3(a, 25);
         assert(pieces[0].length + pieces[1].length + pieces[2].length == a.length);


### PR DESCRIPTION
The random coverage error appearing in https://github.com/dlang/phobos/pull/5570, is, as usual, our fault.

https://codecov.io/gh/dlang/phobos/compare/551ffa6e0d247dcdb560feb2e297346886de17d0...8cf459324303a19307ec173d36596dff99d71a11/changes

![image](https://user-images.githubusercontent.com/4370550/27974146-f59adf78-635c-11e7-8417-90b4d485d4b7.png)

However, this one can be fixed easily - we just need to use the fixed seeds for the random number generator ;-)