### PR TITLE
Re-enable unittest-debug Makefile to increase Phobos overall coverage

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -114,7 +114,7 @@ coverage()
     # https://issues.dlang.org/show_bug.cgi?id=16397
     ENABLE_COVERAGE="1" make -j$N -f posix.mak MODEL=$MODEL unittest-debug
 
-    # So instead we run all tests individually (hoping that that doesn't break any tests).
+    # So instead we run all tests individually (hoping that this doesn't break any tests).
     # -cov is enabled by the %.test target itself
     make -j$N -f posix.mak $(find std etc -name "*.d" | sed "s/[.]d$/.test/")
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -112,7 +112,7 @@ coverage()
 
     # Coverage information of the test runner can be missing for some template instatiations.
     # https://issues.dlang.org/show_bug.cgi?id=16397
-    # ENABLE_COVERAGE="1" make -j$N -f posix.mak MODEL=$MODEL unittest-debug
+    ENABLE_COVERAGE="1" make -j$N -f posix.mak MODEL=$MODEL unittest-debug
 
     # So instead we run all tests individually (hoping that that doesn't break any tests).
     # -cov is enabled by the %.test target itself

--- a/posix.mak
+++ b/posix.mak
@@ -379,7 +379,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= $(LINKDL) -cov -run $< ;     \
+	    $(DMD) -od$$T $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= $(LINKDL) -cov -run $< unittest_merge.d ; \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 

--- a/unittest_merge.d
+++ b/unittest_merge.d
@@ -1,0 +1,11 @@
+module unittest_merge;
+
+// A hack to set coverage to merge
+shared static this()
+{
+    version(D_Coverage)
+    {
+        import core.runtime : dmd_coverSetMerge;
+        dmd_coverSetMerge(true);
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/dlang/phobos/pull/5579

> I will have a look if coverSetMerge can help here to get the best from both worlds.

It's [already enabled](https://github.com/dlang/druntime/commit/8c66cad4eecfde441ddbb12bfb49e277ae2b55ec), so running the `unittest-debug` as an extra step might increase the build time a bit, but should increase the overall coverage a bit.
(this is an experiment)