### PR TITLE
Make more modules runnable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -265,7 +265,7 @@ IGNORED_PUBLICTESTS= $(addprefix std/, \
 						base64 $(addprefix experimental/allocator/, \
 								building_blocks/free_list building_blocks/quantizer \
 						) digest/hmac \
-						file math stdio traits typecons uuid)
+						file math stdio traits typecons)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TESTS_EXTRACTOR=$(ROOT)/tests_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests

--- a/posix.mak
+++ b/posix.mak
@@ -265,7 +265,7 @@ IGNORED_PUBLICTESTS= $(addprefix std/, \
 						base64 $(addprefix experimental/allocator/, \
 								building_blocks/free_list building_blocks/quantizer \
 						) digest/hmac \
-						file math stdio traits typecons)
+						file math stdio traits)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TESTS_EXTRACTOR=$(ROOT)/tests_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests

--- a/posix.mak
+++ b/posix.mak
@@ -262,7 +262,7 @@ SHARED=$(if $(findstring $(OS),linux freebsd),1,)
 # A blacklist of ignored module is provided as not all public unittest in
 # Phobos are independently runnable yet
 IGNORED_PUBLICTESTS= $(addprefix std/, \
-						base64 $(addprefix experimental/allocator/, \
+						$(addprefix experimental/allocator/, \
 								building_blocks/free_list building_blocks/quantizer \
 						) digest/hmac \
 						file math stdio traits)

--- a/posix.mak
+++ b/posix.mak
@@ -265,7 +265,7 @@ IGNORED_PUBLICTESTS= $(addprefix std/, \
 						$(addprefix experimental/allocator/, \
 								building_blocks/free_list building_blocks/quantizer \
 						) digest/hmac \
-						file math stdio traits)
+						math stdio traits)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TESTS_EXTRACTOR=$(ROOT)/tests_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests

--- a/posix.mak
+++ b/posix.mak
@@ -591,7 +591,7 @@ style_lint: dscanner $(LIB)
 ################################################################################
 publictests: $(PUBLICTESTS)
 
-$(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d $(LIB)
+$(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<
 	mv $(TOOLS_DIR)/tests_extractor $@
 

--- a/std/base64.d
+++ b/std/base64.d
@@ -178,7 +178,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         ubyte[] data = [0x1a, 0x2b, 0x3c, 0x4d, 0x5d, 0x6e];
 
         // Allocate a buffer large enough to hold the encoded string.
-        auto buf = new char[encodeLength(data.length)];
+        auto buf = new char[Base64.encodeLength(data.length)];
 
         Base64.encode(data, buf);
         assert(buf == "Gis8TV1u");

--- a/std/file.d
+++ b/std/file.d
@@ -4232,6 +4232,8 @@ slurp(Types...)(string filename, in char[] format)
 ///
 @system unittest
 {
+    import std.typecons : tuple;
+
     scope(exit)
     {
         assert(exists(deleteme));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4706,6 +4706,7 @@ if (!isMutable!Target)
 ///
 @system unittest
 {
+    import std.traits : FunctionAttribute, functionAttributes;
     interface A { int run(); }
     interface B { int stop(); @property int status(); }
     class X
@@ -7329,6 +7330,8 @@ public:
 /// BitFlags can be manipulated with the usual operators
 @safe @nogc pure nothrow unittest
 {
+    import std.traits : EnumMembers;
+
     // You can use such an enum with BitFlags straight away
     enum Enum
     {

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1712,6 +1712,18 @@ public class UUIDParsingException : Exception
 ///
 @safe unittest
 {
+    import std.exception : collectException;
+
+    const inputUUID = "this-is-an-invalid-uuid";
+    auto ex = collectException!UUIDParsingException(UUID(inputUUID));
+    assert(ex !is null); // check that exception was thrown
+    assert(ex.input == inputUUID);
+    assert(ex.position == 0);
+    assert(ex.reason == UUIDParsingException.Reason.tooLittle);
+}
+
+@safe unittest
+{
     auto ex = new UUIDParsingException("foo", 10, UUIDParsingException.Reason.tooMuch);
     assert(ex.input == "foo");
     assert(ex.position == 10);


### PR DESCRIPTION
As no one seems to push this, I went into another round and pushed the status quo one step forward.

---


Outstanding modules
-----------------------------

Here's a list of all the modules that are sill missing - with a short explanation why it's currently blocked.

### `std.math`: `equalsDigit` is `private`

```
> pmake std/math.publictests
generated/linux/release/64/publictests/std_math.d(90): Deprecation: std.math.equalsDigit is not visible from module std_math
generated/linux/release/64/publictests/std_math.d(90): Error: function std.math.equalsDigit is not accessible from module std_math
generated/linux/release/64/publictests/std_math.d(145): Deprecation: std.math.equalsDigit is not visible from module std_math
generated/linux/release/64/publictests/std_math.d(145): Error: function std.math.equalsDigit is not accessible from module std_math
```

### `std.digest.hmac`

- `std.digest.hmac` is due to an error in the tests_extractor - it should ignore `version(StdDdoc)`. Fix: https://github.com/dlang/tools/pull/249

### std.stdio: `testFilename` is `version(unittest)`

```
> pmake std/stdio.publictests
std_stdio.o:__main.d:function _D9std_stdio14__unittestL2_1FZv: error: undefined reference to '_D3std5stdio12testFilenameFNfAyamZAya'
std_stdio.o:__main.d:function _D9std_stdio15__unittestL20_2FZv: error: undefined reference to '_D3std5stdio12testFilenameFNfAyamZAya'
std_stdio.o:__main.d:function _D9std_stdio15__unittestL37_3FZv: error: undefined reference to '_D3std5stdio12testFilenameFNfAyamZAya'
std_stdio.o:__main.d:function _D9std_stdio15__unittestL56_4FZv: error: undefined reference to '_D3std5stdio12testFilenameFNfAyamZAya'
```

### `stdx.allocator.building_blocks.qunatizer`:  `roundUpToMultipleOf`  isn't `public`

```
> pmake std/experimental/allocator/building_blocks/quantizer.publictests
generated/linux/release/64/publictests/std_experimental_allocator_building_blocks_quantizer.d(14): Error: function std.experimental.allocator.common.roundUpToMultipleOf is not accessible from module std_experimental_allocator_building_blocks_quantizer
generated/linux/release/64/publictests/std_experimental_allocator_building_blocks_quantizer.d(12):        instantiated from here: Quantizer!(FreeTree!(GCAllocator), (n) => n.roundUpToMultipleOf(n <= 16384 ? 64 : 4096))
```

### `stdx.allocator.building_blocks.free_list` (TBD)

```
> pmake std/experimental/allocator/building_blocks/free_list.publictests
std/experimental/allocator/building_blocks/free_list.d(124): Error: @safe function 'std.experimental.allocator.building_blocks.free_list.FreeList!(Mallocator, 18446744073709551614LU, 18446744073709551614LU, cast(Flag)false).FreeList.__unittestL118_1301' cannot call @system function 'std.experimental.allocator.building_blocks.free_list.FreeList!(Mallocator, 18446744073709551614LU, 18446744073709551614LU, cast(Flag)false).FreeList.min'
std/experimental/allocator/building_blocks/free_list.d(125): Error: @safe function 'std.experimental.allocator.building_blocks.free_list.FreeList!(Mallocator, 18446744073709551614LU, 18446744073709551614LU, cast(Flag)false).FreeList.__unittestL118_1301' cannot call @system function 'std.experimental.allocator.building_blocks.free_list.FreeList!(Mallocator, 18446744073709551614LU, 18446744073709551614LU, cast(Flag)false).FreeList.max'
std/experimental/allocator/building_blocks/free_list.d(244): Warning: statement is not reachable
std/experimental/allocator/building_blocks/free_list.d(252): Warning: statement is not reachable
generated/linux/release/64/publictests/std_experimental_allocator_building_blocks_free_list.d(9): Error: template instance std.experimental.allocator.building_blocks.free_list.FreeList!(Mallocator, 18446744073709551614LU, 18446744073709551614LU, cast(Flag)false) error instantiating
```

### `std.traits` (TBD)

For `std.traits` one needs to apply this patch first:

```diff
diff --git a/std/traits.d b/std/traits.d
index d32a5e967..40afc91c0 100644
--- a/std/traits.d
+++ b/std/traits.d
@@ -2429,6 +2429,7 @@ template Fields(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     struct S { int x; float y; }
     static assert(is(Fields!S == AliasSeq!(int, float)));
 }
@@ -2485,6 +2486,7 @@ template FieldNameTuple(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     struct S { int x; float y; }
     static assert(FieldNameTuple!S == AliasSeq!("x", "y"));
     static assert(FieldNameTuple!int == AliasSeq!"");
@@ -2631,7 +2633,7 @@ private template hasRawAliasing(T...)
     enum hasRawAliasing = Impl!(RepresentationTypeTuple!T);
 }
 
-///
+//
 @safe unittest
 {
     // simple types
@@ -2727,7 +2729,7 @@ private template hasRawUnsharedAliasing(T...)
     enum hasRawUnsharedAliasing = Impl!(RepresentationTypeTuple!T);
 }
 
-///
+//
 @safe unittest
 {
     // simple types
@@ -3948,6 +3950,8 @@ template BaseTypeTuple(A)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     interface I1 { }
     interface I2 { }
     interface I12 : I1, I2 { }
@@ -4001,6 +4005,8 @@ template BaseClassesTuple(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     class C1 { }
     class C2 : C1 { }
     class C3 : C2 { }
@@ -4361,6 +4367,8 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     struct Foo(T, U) {}
     static assert(is(TemplateArgsOf!(Foo!(int, real)) == AliasSeq!(int, real)));
 }
@@ -7207,6 +7215,8 @@ template mostNegative(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     foreach (T; AliasSeq!(bool, byte, short, int, long))
         static assert(mostNegative!T == T.min);
 
@@ -7273,6 +7283,7 @@ template mangledName(sth...)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     alias TL = staticMap!(mangledName, int, const int, immutable int);
     static assert(TL == AliasSeq!("i", "xi", "yi"));
 }
@@ -7727,7 +7738,7 @@ template getSymbolsByUDA(alias symbol, alias attribute)
     enum Attr;
     struct A
     {
-        alias int INT;
+        alias INT = int;
         alias void function(INT) SomeFunction;
         @Attr int a;
         int b;
```

```
> pmake std/traits.publictests
generated/linux/release/64/publictests/std_traits.d(1700): Error: static assert  1LU == 2LU is false
```