### PR TITLE
Use more selective imports at module imports

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -59,12 +59,12 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.comparison;
 
 // FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 // FIXME
 import std.meta : allSatisfy;
-import std.typecons; // : tuple, Tuple, Flag, Yes;
+import std.typecons : tuple, Tuple, Flag, Yes;
 
 /**
 Find `value` _among `values`, returning the 1-based index

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -67,7 +67,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.iteration;
 
 // FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -80,7 +80,7 @@ module std.algorithm.mutation;
 import std.range.primitives;
 import std.traits : isArray, isBlitAssignable, isNarrowString, Unqual, isSomeChar;
 // FIXME
-import std.typecons; // : tuple, Tuple;
+import std.typecons : tuple, Tuple;
 
 // bringToFront
 /**

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -106,11 +106,11 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.searching;
 
 // FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 // FIXME
-import std.typecons; // : Tuple, Flag, Yes, No;
+import std.typecons : Tuple, tuple, Flag, Yes, No;
 
 /++
 Checks if $(I _all) of the elements verify `pred`.

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -50,12 +50,12 @@ module std.algorithm.setops;
 import std.range.primitives;
 
 // FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.traits;
 // FIXME
-import std.meta; // : AliasSeq, staticMap, allSatisfy, anySatisfy;
+import std.meta : AliasSeq, staticMap, allSatisfy, anySatisfy;
 
-import std.algorithm.sorting; // : Merge;
+import std.algorithm.sorting : Merge;
 import std.typecons : No;
 
 // cartesianProduct

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -76,12 +76,12 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.sorting;
 
 import std.algorithm.mutation : SwapStrategy;
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
-import std.typecons : Flag;
+import std.typecons : Flag, Yes, No;
 // FIXME
-import std.meta; // : allSatisfy;
-import std.range; // : SortedRange;
+import std.meta : allSatisfy;
+import std.range : SortedRange;
 import std.traits;
 
 /**
@@ -747,7 +747,9 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range)
         assert(a == [ 42, 42 ]);
 
         import std.algorithm.iteration : map;
+        import std.array : array;
         import std.random;
+        import std.range : iota;
         import std.stdio;
         auto s = unpredictableSeed;
         auto g = Random(s);
@@ -1059,6 +1061,7 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
 @safe unittest
 {
     import std.algorithm.comparison : equal;
+    import std.range : iota;
 
     ubyte[256] index = void;
     iota(256).makeIndex(index[]);
@@ -1537,7 +1540,8 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
 @safe unittest
 {
     import std.algorithm.comparison : equal;
-    import std.range;
+    import std.array : array;
+    import std.range : indexed, iota, retro;
 
     static struct Point { int x, y; }
     auto pts1 = [ Point(5, 6), Point(1, 0), Point(5, 7), Point(1, 1), Point(1, 2), Point(0, 1) ];
@@ -1784,6 +1788,7 @@ private void sort5(alias lt, Range)(Range r)
 {
     import std.algorithm.iteration : permutations;
     import std.algorithm.mutation : copy;
+    import std.range : iota;
 
     int[5] buf;
     foreach (per; iota(5).permutations)
@@ -1925,6 +1930,9 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 {
     // Simple regression benchmark
     import std.algorithm.iteration, std.algorithm.mutation, std.random;
+    import std.array : array;
+    import std.range : iota;
+
     Random rng;
     int[] a = iota(20148).map!(_ => uniform(-1000, 1000, rng)).array;
     static uint comps;
@@ -3436,6 +3444,8 @@ done:
 
 @safe unittest
 {
+    import std.array : array;
+
     auto a = [ 10, 5, 3, 4, 8,  11,  13, 3, 9, 4, 10 ];
     assert(expandPartition!((a, b) => a < b)(a, 4, 5, 6) == 9);
     a = randomArray;
@@ -3450,7 +3460,10 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     T minValue = 0, T maxValue = 255)
 {
     import std.algorithm.iteration : map;
+    import std.array : array;
     import std.random : unpredictableSeed, Random, uniform;
+    import std.range : iota;
+
     auto size = flag == Yes.exactSize ? maxSize : uniform(1, maxSize);
     return iota(0, size).map!(_ => uniform(minValue, maxValue)).array;
 }

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -62,9 +62,9 @@ module std.ascii;
 version (unittest)
 {
     // FIXME: When dmd bug #314 is fixed, make these selective.
-    import std.meta; // : AliasSeq;
-    import std.range; // : chain;
-    import std.traits; // : functionAttributes, FunctionAttribute, isSafe;
+    import std.meta : AliasSeq;
+    import std.range : chain;
+    import std.traits : functionAttributes, FunctionAttribute, isSafe;
 }
 
 
@@ -675,6 +675,8 @@ if (is(C : dchar))
 
 @safe unittest //Test both toUpper and toLower with non-builtin
 {
+    import std.traits : OriginalType;
+
     //User Defined [Char|Wchar|Dchar]
     static struct UDC {  char c; alias c this; }
     static struct UDW { wchar c; alias c this; }

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -20,7 +20,7 @@ Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
  */
 module std.experimental.typecons;
 
-import std.meta; // : AliasSeq, allSatisfy;
+import std.meta : AliasSeq, allSatisfy;
 import std.traits;
 
 import std.typecons : Tuple, tuple, Bind, DerivedFunctionType, GetOverloadedMethods;

--- a/std/functional.d
+++ b/std/functional.d
@@ -61,8 +61,8 @@ Distributed under the Boost Software License, Version 1.0.
 */
 module std.functional;
 
-import std.meta; // AliasSeq, Reverse
-import std.traits; // isCallable, Parameters
+import std.meta : AliasSeq, Reverse;
+import std.traits : isCallable, Parameters;
 
 
 private template needOpCallAlias(alias fun)

--- a/std/math.d
+++ b/std/math.d
@@ -134,7 +134,7 @@ static import core.math;
 static import core.stdc.math;
 static import core.stdc.fenv;
 import std.range.primitives : isInputRange, ElementType;
-import std.traits; // CommonType, isFloatingPoint, isIntegral, isSigned, isUnsigned, Largest, Unqual
+import std.traits : CommonType, isFloatingPoint, isIntegral, isNumeric, isSigned, isUnsigned, Largest, Unqual;
 
 version(LDC)
 {
@@ -175,7 +175,7 @@ else
 
 version(unittest)
 {
-    import core.stdc.stdio; // : sprintf;
+    import core.stdc.stdio : sprintf;
 
     static if (real.sizeof > double.sizeof)
         enum uint useDigits = 16;

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -26,7 +26,7 @@
 module std.net.isemail;
 
 // FIXME
-import std.range.primitives; // : ElementType;
+import std.range.primitives : back, ElementType, front, empty, popFront;
 import std.regex;
 import std.traits;
 import std.typecons : Flag, Yes, No;
@@ -1821,6 +1821,7 @@ if (is(Unqual!(ElementType!(S1)) == dchar) && is(Unqual!(ElementType!(S2)) == dc
 ElementType!(A) pop (A) (ref A a)
 if (isDynamicArray!(A) && !isNarrowString!(A) && isMutable!(A) && !is(A == void[]))
 {
+    import std.range.primitives : popBack;
     auto e = a.back;
     a.popBack();
     return e;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -232,9 +232,9 @@ public import std.range.interfaces;
 public import std.range.primitives;
 public import std.typecons : Flag, Yes, No;
 
-import std.meta; // allSatisfy, staticMap
-import std.traits; // CommonType, isCallable, isFloatingPoint, isIntegral,
-    // isPointer, isSomeFunction, isStaticArray, Unqual
+import std.meta : allSatisfy, staticMap;
+import std.traits : CommonType, isCallable, isFloatingPoint, isIntegral,
+    isPointer, isSomeFunction, isStaticArray, Unqual;
 
 
 /**
@@ -3397,12 +3397,13 @@ private struct Generator(Fun...)
     static assert(isInputRange!Generator);
 
 private:
+    import std.traits : FunctionAttribute, functionAttributes, ReturnType;
     static if (is(Fun[0]))
         Fun[0] fun;
     else
         alias fun = Fun[0];
 
-    enum returnByRef_ = (functionAttributes!fun & FunctionAttribute.ref_) ? true : false;
+    enum returnByRef_ = functionAttributes!fun & FunctionAttribute.ref_;
     static if (returnByRef_)
         ReturnType!fun *elem_;
     else
@@ -5670,6 +5671,8 @@ pure @safe unittest
 
 pure nothrow @nogc @safe unittest
 {
+    import std.traits : Signed;
+
    //float overloads use std.conv.to so can't be @nogc or nothrow
     alias ssize_t = Signed!size_t;
     assert(iota(ssize_t.max, 0, -1).length == ssize_t.max);
@@ -11218,6 +11221,7 @@ private struct Bitwise(R)
 if (isInputRange!R && isIntegral!(ElementType!R))
 {
 private:
+    import std.traits : Unsigned;
     alias ElemType = ElementType!R;
     alias UnsignedElemType = Unsigned!ElemType;
 
@@ -11533,6 +11537,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 @safe pure nothrow unittest
 {
     import std.internal.test.dummyrange;
+    import std.meta : AliasSeq;
 
     alias IntegralTypes = AliasSeq!(byte, ubyte, short, ushort, int, uint,
             long, ulong);
@@ -11628,6 +11633,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 // Test opIndex and opSlice
 @system unittest
 {
+    import std.meta : AliasSeq;
     alias IntegralTypes = AliasSeq!(byte, ubyte, short, ushort, int, uint,
             long, ulong);
     foreach (IntegralType; IntegralTypes)

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -298,7 +298,7 @@ module std.regex;
 
 import std.range.primitives, std.traits;
 import std.regex.internal.ir;
-import std.typecons; // : Flag, Yes, No;
+import std.typecons : Flag, Yes, No;
 
 /++
     $(D Regex) object holds regular expression pattern in compiled form.
@@ -704,6 +704,7 @@ public:
 @trusted public struct RegexMatch(R)
 if (isSomeString!R)
 {
+    import std.typecons : Rebindable;
 private:
     alias Char = BasicElementOf!R;
     Matcher!Char _engine;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -13,14 +13,14 @@ Authors:   $(HTTP digitalmars.com, Walter Bright),
  */
 module std.stdio;
 
-import core.stdc.stddef; // wchar_t
+import core.stdc.stddef : wchar_t;
 public import core.stdc.stdio;
-import std.algorithm.mutation; // copy
-import std.meta; // allSatisfy
-import std.range.primitives; // ElementEncodingType, empty, front,
-    // isBidirectionalRange, isInputRange, put
-import std.traits; // isSomeChar, isSomeString, Unqual, isPointer
-import std.typecons; // Flag
+import std.algorithm.mutation : copy;
+import std.meta : allSatisfy;
+import std.range.primitives : ElementEncodingType, empty, front,
+    isBidirectionalRange, isInputRange, put;
+import std.traits : isSomeChar, isSomeString, Unqual, isPointer;
+import std.typecons : Flag, Yes, No;
 
 /++
 If flag $(D KeepTerminator) is set to $(D KeepTerminator.yes), then the delimiter

--- a/std/string.d
+++ b/std/string.d
@@ -175,13 +175,13 @@ public import std.format : format, sformat;
 import std.typecons : Flag, Yes, No;
 public import std.uni : icmp, toLower, toLowerInPlace, toUpper, toUpperInPlace;
 
-import std.meta; // AliasSeq, staticIndexOf
-import std.range.primitives; // back, ElementEncodingType, ElementType, front,
-    // hasLength, hasSlicing, isBidirectionalRange, isForwardRange, isInfinite,
-    // isInputRange, isOutputRange, isRandomAccessRange, popBack, popFront, put,
-    // save;
-import std.traits; // isConvertibleToString, isNarrowString, isSomeChar,
-    // isSomeString, StringTypeOf, Unqual
+import std.meta : AliasSeq, staticIndexOf;
+import std.range.primitives : back, ElementEncodingType, ElementType, front,
+     hasLength, hasSlicing, isBidirectionalRange, isForwardRange, isInfinite,
+     isInputRange, isOutputRange, isRandomAccessRange, popBack, popFront, put,
+     save;
+import std.traits : isConvertibleToString, isNarrowString, isSomeChar,
+     isSomeString, StringTypeOf, Unqual;
 
 //public imports for backward compatibility
 public import std.algorithm.comparison : cmp;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -69,7 +69,7 @@ Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
 module std.typecons;
 
 import core.stdc.stdint : uintptr_t;
-import std.meta; // : AliasSeq, allSatisfy;
+import std.meta : Alias, AliasSeq, aliasSeqOf, allSatisfy;
 import std.traits;
 
 ///
@@ -4260,6 +4260,7 @@ private static:
             };
         }
     }
+    import std.meta : templateNot;
 
     alias Implementation = AutoImplement!(Issue17177, how, templateNot!isFinalFunction);
 }

--- a/std/uni.d
+++ b/std/uni.d
@@ -707,15 +707,15 @@ CLUSTER = $(S_LINK Grapheme cluster, grapheme cluster)
 +/
 module std.uni;
 
-import std.meta; // AliasSeq
-import std.range.primitives; // back, ElementEncodingType, ElementType, empty,
-    // front, isForwardRange, isInputRange, isRandomAccessRange, popFront, put,
-    // save
-import std.traits; // isConvertibleToString, isIntegral, isSomeChar,
-    // isSomeString, Unqual
+import std.meta : AliasSeq;
+import std.range.primitives :back, ElementEncodingType, ElementType, empty,
+    front, isForwardRange, isInputRange, isRandomAccessRange, popFront, popFrontN,
+    put, save;
+import std.traits :isConvertibleToString, isIntegral, isSomeChar,
+    isSomeString, Unqual;
 // debug = std_uni;
 
-debug(std_uni) import std.stdio; // writefln, writeln
+debug(std_uni) import std.stdio : writefln, writeln;
 
 private:
 
@@ -2809,6 +2809,8 @@ private:
             immutable b = slice[start+1];
             return CodepointInterval(a, b);
         }
+
+        import std.range.primitives : hasAssignableElements;
 
         //may break sorted property - but we need std.sort to access it
         //hence package protection attribute
@@ -8783,7 +8785,7 @@ else
 // trusted -> avoid bounds check
 @trusted pure nothrow @nogc private
 {
-    import std.internal.unicode_tables; // : toLowerTable, toTitleTable, toUpperTable; // generated file
+    import std.internal.unicode_tables : toLowerTable, toTitleTable, toUpperTable; // generated file
 
     // hide template instances behind functions (Bugzilla 13232)
     ushort toLowerIndex(dchar c) { return toLowerIndexTrie[c]; }


### PR DESCRIPTION
AFAICT selective imports have been fixed in [2.071.0](http://dlang.org/changelog/2.071.0.html#imports-314) and now enough time has passed down the road.

FWIW I still hope that we get [Dependency-Carrying Declarations (DIP1005)](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1005.md) at some point and can completely get rid of these global imports and make Phobos entirely pay for what you need.