### PR TITLE
Issue 17375 - use -fPIC by default for Phobos on Posix

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -54,7 +54,12 @@ ifneq ($(BUILD),release)
     endif
 endif
 
-override PIC:=$(if $(PIC),-fPIC,)
+# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
+ifeq ($(DISABLE_PIC),)
+    PIC_FLAG:=-fPIC
+else
+    PIC_FLAG:=
+endif
 
 # Configurable stuff that's rarely edited
 INSTALL_DIR = ../install
@@ -115,7 +120,7 @@ else
 endif
 
 # Set DFLAGS
-DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC)
+DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC_FLAG)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
 else
@@ -316,7 +321,6 @@ $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
 $(ROOT)/$(SONAME): $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
-$(LIBSO): override PIC:=-fPIC
 $(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO)
 	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
 
@@ -358,7 +362,6 @@ UT_LIBSO:=$(ROOT)/unittest/libphobos2-ut.so
 
 $(UT_D_OBJS): $(DRUNTIMESO)
 
-$(UT_LIBSO): override PIC:=-fPIC
 $(UT_LIBSO): $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO)
 	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib=
 


### PR DESCRIPTION
@MartinNowak already builds the official releases with `-fPIC` (since 2.072.2) as there was no measurable performance penalty. As more on OSes are switching to -fPIC ([ArchLinux is already in testing](http://forum.dlang.org/post/isncdeeeycbmsfjsmluo@forum.dlang.org)), building everything at Phobos with `-fPIC` only makes sense (we have already `-fPIC` enabled for the C source code in `etc`).

Moreover, as a nice benefit this solves
- the unittest issues from [17375](https://issues.dlang.org/show_bug.cgi?id=17375)
- solves the problem of building DScanner and the tests_extractor on OSes with `-fPIC` enabled (now `DFLAGS` are properly propagated)

CC @CyberShadow 

Other PRs:

- [x] https://github.com/dlang/druntime/pull/1880
- [ ] this PR
- [ ] https://github.com/dlang/dmd/pull/7002