### PR TITLE
Make std.digest.hmac @safe and runnable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -264,7 +264,7 @@ SHARED=$(if $(findstring $(OS),linux freebsd),1,)
 IGNORED_PUBLICTESTS= $(addprefix std/, \
 						$(addprefix experimental/allocator/, \
 								building_blocks/free_list building_blocks/quantizer \
-						) digest/hmac \
+						) \
 						math stdio traits)
 PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TESTS_EXTRACTOR=$(ROOT)/tests_extractor

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -31,18 +31,19 @@ import std.meta : allSatisfy;
  * This type conforms to $(REF isDigest, std,digest).
  */
 
-version(StdDdoc)
-/// Computes an HMAC over data read from stdin.
+/// Compute HMAC over an input string
 @safe unittest
 {
-    import std.digest.hmac, std.digest.sha, std.stdio;
+    import std.ascii : LetterCase;
+    import std.digest : toHexString;
+    import std.digest.sha : SHA1;
     import std.string : representation;
 
     auto secret = "secret".representation;
-    stdin.byChunk(4096)
-         .hmac!SHA1(secret)
-         .toHexString!(LetterCase.lower)
-         .writeln;
+    assert("The quick brown fox jumps over the lazy dog"
+            .representation
+            .hmac!SHA1(secret)
+            .toHexString!(LetterCase.lower) == "198ea1ea04c435c1246b586a06d5cf11c3ffcda6");
 }
 
 template HMAC(H)

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -19,6 +19,8 @@ module std.digest.hmac;
 import std.digest : isDigest, hasBlockSize, isDigestibleRange, DigestType;
 import std.meta : allSatisfy;
 
+@safe:
+
 /**
  * Template API HMAC implementation.
  *
@@ -258,15 +260,15 @@ if (isDigest!H)
     DigestType!H hmac(T...)(scope T data, scope const(ubyte)[] secret)
     if (allSatisfy!(isDigestibleRange, typeof(data)))
     {
-        import std.algorithm.mutation : copy;
+        import std.range.primitives : put;
         auto hash = HMAC!(H, blockSize)(secret);
         foreach (datum; data)
-            copy(datum, &hash);
+            put(hash, datum);
         return hash.finish();
     }
 
     ///
-    @system pure nothrow @nogc unittest
+    @safe pure nothrow @nogc unittest
     {
         import std.algorithm.iteration : map;
         import std.digest.hmac, std.digest.sha;
@@ -300,7 +302,7 @@ unittest
     static assert(hasBlockSize!(HMAC!MD5) && HMAC!MD5.blockSize == MD5.blockSize);
 }
 
-@system pure nothrow
+@safe pure nothrow
 unittest
 {
     import std.digest.md : MD5;


### PR DESCRIPTION
When I first encountered the `version(StdDdoc)` unittest in `std.digest.hmac`, I tried to go "the easy way" and ignore versioned unittest in the tests_extractor (-> https://github.com/dlang/tools/pull/249).
However @CyberShadow correctly reminded me that it makes more sense to fix the outlier and I even discovered another problem about the `version(StdDdoc)` approach - it's not part of the testsuite and apparently at some point in the time `std.digest.hmac` was `@safe` (it's not anymore). I fixed that as well and as a consequence `std.digest.hmac` is now completely `@safe` :tada: 
So I am really happy about @CyberShadow's remark to avoid working around the outlier with the tool!

CC @jpf91 