### PR TITLE
Added tryAccept function (accept without throwing)

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2808,13 +2808,26 @@ public:
     /**
      * Accept an incoming connection. If the socket is blocking, $(D accept)
      * waits for a connection request. Throws $(D SocketAcceptException) if
-     * unable to _accept. See $(D accepting) for use with derived classes.
+     * unable to accept. See $(D accepting) for use with derived classes.
      */
-    Socket accept() @trusted
+    Socket accept() @safe
+    {
+        auto newSocket = tryAccept();
+        if (newSocket is null)
+            throw new SocketAcceptException("Unable to accept socket connection");
+        return newSocket;
+    }
+
+    /**
+     * Accept an incoming connection. If the socket is blocking, $(D tryAccept)
+     * waits for a connection request. Returns $(D null) if unable to accept.
+     * See $(D accepting) for use with derived classes.
+     */
+    Socket tryAccept() @trusted
     {
         auto newsock = cast(socket_t).accept(sock, null, null);
         if (socket_t.init == newsock)
-            throw new SocketAcceptException("Unable to accept socket connection");
+            return null;
 
         Socket newSocket;
         try

--- a/std/socket.d
+++ b/std/socket.d
@@ -2807,8 +2807,10 @@ public:
 
     /**
      * Accept an incoming connection. If the socket is blocking, $(D accept)
-     * waits for a connection request. Throws $(D SocketAcceptException) if
-     * unable to accept. See $(D accepting) for use with derived classes.
+     * waits for a connection request.
+     * Returns: the accepted $(D Socket) that connected to the socket.
+     * Throws: $(D SocketAcceptException) if unable to _accept.
+     * See_Also: $(REF accepting, std, socket) for use with derived classes.
      */
     Socket accept() @safe
     {
@@ -2820,8 +2822,10 @@ public:
 
     /**
      * Accept an incoming connection. If the socket is blocking, $(D tryAccept)
-     * waits for a connection request. Returns $(D null) if unable to accept.
-     * See $(D accepting) for use with derived classes.
+     * waits for a connection request.
+     * Returns: the accepted $(D Socket) that connected to the socket or
+     * $(D null) if unable to accept.
+     * See_Also: $(REF accepting, std, socket) for use with derived classes.
      */
     Socket tryAccept() @trusted
     {


### PR DESCRIPTION
accept throws a SocketAcceptException when it is non-blocking and there is no connection which is bad for performance. tryAccept simply returns null instead of throwing