### PR TITLE
Fix Issue 16993 - Documentation for toSimpleString and toString does explain how they differ

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -3047,7 +3047,8 @@ public:
 
 
     /++
-        Converts this $(LREF DateTime) to a string.
+        Converts this $(LREF DateTime) to a string. It calls `toSimpleString` and
+        returns the result.
       +/
     string toString() const @safe pure nothrow
     {
@@ -7280,7 +7281,8 @@ public:
 
 
     /++
-        Converts this $(LREF Date) to a string.
+        Converts this $(LREF Date) to a string. It calls `toSimpleString` and
+        returns the result.
       +/
     string toString() const @safe pure nothrow
     {
@@ -8803,7 +8805,8 @@ public:
 
 
     /++
-        Converts this TimeOfDay to a string.
+        Converts this TimeOfDay to a string. It calls `toISOExtString` and
+        returns the result.
       +/
     string toString() const @safe pure nothrow
     {


### PR DESCRIPTION
That is because they don't differ at all. toString just calls toSimpleString. Is there a reason for having toSimpleString? Can't we just put the implementation in toString and just deprecate toSimpleString? We can either merge this which clarifies the toString and toSimpleString are the same thing, or we could deprecate one of them (toSimpleString is my suggestion) or we can make an alias.