### PR TITLE
Fix Issue 12260 - Improve error of std.stdio.readf when involving whitespace

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -81,8 +81,15 @@ private auto convError(S, T)(S source, string fn = __FILE__, size_t ln = __LINE_
     if (source.empty)
         msg = "Unexpected end of input when converting from type " ~ S.stringof ~ " to type " ~ T.stringof;
     else
-        msg =  text("Unexpected '", source.front,
+    {
+        ElementType!S el = source.front;
+
+        if (el == '\n')
+            msg = text("Unexpected '\\n' when converting from type " ~ S.stringof ~ " to type " ~ T.stringof);
+        else
+            msg =  text("Unexpected '", el,
                  "' when converting from type " ~ S.stringof ~ " to type " ~ T.stringof);
+    }
 
     return new ConvException(msg, fn, ln);
 }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1897,6 +1897,28 @@ $(CONSOLE
         assert(b1 == true && b2 == false);
     }
 
+    @system unittest
+    {
+        static import std.file;
+
+        auto deleteme = testFilename();
+        std.file.write(deleteme, "1\n2");
+        scope(exit) std.file.remove(deleteme);
+        int input;
+        auto f = File(deleteme);
+        f.readf("%s", &input);
+
+        import std.conv : ConvException;
+        try
+        {
+            f.readf("%s", &input);
+        }
+        catch (ConvException e)
+        {
+            assert(e.msg == "Unexpected '\\n' when converting from type LockingTextReader to type int");
+        }
+    }
+
 /**
  Returns a temporary file by calling
  $(HTTP cplusplus.com/reference/clibrary/cstdio/_tmpfile.html, _tmpfile).


### PR DESCRIPTION
I added a test so that when the exception contains a '\n' it is outputted as "\\n" so the user knows exactly what the error refers to