### PR TITLE
Fix docs for std.algorithm.remove (avoid Ddoc auto-escape)

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1776,7 +1776,7 @@ cases.))
 
 Params:
     s = a SwapStrategy to determine if the original order needs to be preserved
-    range = a $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives)
+    range = a $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,_range,primitives)
     with a length member
     offset = which element(s) to remove
 
@@ -2011,7 +2011,7 @@ if (s == SwapStrategy.stable
 
 /**
 Reduces the length of the
-$(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives) $(D range) by removing
+$(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,_range,primitives) $(D range) by removing
 elements that satisfy $(D pred). If $(D s = SwapStrategy.unstable),
 elements are moved from the right end of the range over the elements
 to eliminate. If $(D s = SwapStrategy.stable) (the default),


### PR DESCRIPTION
https://dlang.org/phobos-prerelease/std_algorithm_mutation.html#remove

![image](https://user-images.githubusercontent.com/4370550/28082821-d4ee9b6a-6673-11e7-80ea-bd36f0c31e33.png)

![image](https://user-images.githubusercontent.com/4370550/28082841-e00a0cbe-6673-11e7-8355-722b4d3ecad5.png)

We really need to turn off this Ddoc "feature".