### PR TITLE
Add std.meta.Stride

### DIFF
--- a/changelog/std-meta-stride.dd
+++ b/changelog/std-meta-stride.dd
@@ -1,0 +1,9 @@
+`std.meta.Stride` was added
+
+$(REF Stride, std,meta) allows selecting a subset of template by a step size and offset:
+
+---
+alias attribs = AliasSeq!(short, int, long, ushort, uint, ulong);
+static assert(is(Stride!(3, attribs) == AliasSeq!(short, ushort)));
+static assert(is(Stride!(3, attribs[1 .. $]) == AliasSeq!(int, uint)));
+---


### PR DESCRIPTION
As suggested in  https://github.com/dlang/phobos/pull/5596#discussion_r126774763 this adds `Stride` to std.meta.
`Stride` allows selecting a stride of the template argument list, e.g.:

```d
alias attribs = AliasSeq!(short, int, long, ushort, uint, ulong);
alias attribs = AliasSeq!(short, int, long, ushort, uint, ulong);
static assert(is(Stride!(3, attribs) == AliasSeq!(short, ushort)));
static assert(is(Stride!(3, attribs[1 .. $]) == AliasSeq!(int, uint)));
static assert(is(Stride!(-3, attribs[1 .. $]) == AliasSeq!(ulong, long)));
```