### PR TITLE
Remove invalid stars from the CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,5 +72,5 @@ std/uuid.d @jpf91
 #std/variant.d
 std/windows/* @CyberShadow
 #std/xml.d
-std/zip.d * @CyberShadow
-std/zlib.d * @CyberShadow
+std/zip.d @CyberShadow
+std/zlib.d @CyberShadow


### PR DESCRIPTION
Let's hope that this solves the problem with the CODEOWNERS file. Thanks for noticing @JackStouffer!