### PR TITLE
CODEOWNERS: Add whitespace after # comments due to GitHub bug

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,59 +18,59 @@ std/* @andralex
 std/algorithm/* @andralex @JackStouffer @wilzbach @ZombineDev
 std/array.d @JackStouffer @wilzbach @ZombineDev
 std/ascii.d @JackStouffer @wilzbach
-#std/base64.d
+# std/base64.d
 std/bigint.d @Biotronic
-#std/bitmanip.d
+# std/bitmanip.d
 std/c/windows/* @CyberShadow
-#std/compiler.d
+# std/compiler.d
 std/complex.d @kyllingstad
 std/concurrency.d @MartinNowak
 std/container/ @ZombineDev
 std/conv.d @JackStouffer
-#std/csv.d
+# std/csv.d
 std/datetime/* @jmdavis
 std/demangle.d @MartinNowak @rainers
 std/digest/* @jpf91
-#std/encoding.d
-#std/exception.d
+# std/encoding.d
+# std/exception.d
 std/experimental/allocator/* @andralex @wilzbach @ZombineDev
 std/experimental/checkedint/* @andralex
 std/experimental/logger/* @burner
-#std/experimental/typecons.d
+# std/experimental/typecons.d
 std/file.d @CyberShadow
-#std/format.d
-#std/functional.d
-#std/getopt.d
-#std/internal/
+# std/format.d
+# std/functional.d
+# std/getopt.d
+# std/internal/
 std/json.d @CyberShadow
 std/math* @Biotronic @ibuclaw @klickverbot
 std/meta.d @Biotronic @klickverbot @MetaLang @ZombineDev
-#std/mmfile.d
+# std/mmfile.d
 std/net/curl.d @CyberShadow
 std/net/isemail.d @JackStouffer
-#std/numeric.d
-#std/outbuffer.d
-#std/parallelism.d
+# std/numeric.d
+# std/outbuffer.d
+# std/parallelism.d
 std/path.d @CyberShadow @kyllingstad
 std/process.d @CyberShadow @kyllingstad @schveiguy
 std/random.d @WebDrake @wilzbach
 std/range/* @andralex @JackStouffer @wilzbach @ZombineDev
 std/regex/* @DmitryOlshansky
-#std/signals.d
+# std/signals.d
 std/socket.d @CyberShadow @klickverbot
-#std/stdint.d
+# std/stdint.d
 std/stdio.d @CyberShadow @schveiguy
 std/string.d @burner @JackStouffer
-#std/system.d
+# std/system.d
 std/traits.d @Biotronic @klickverbot @ZombineDev
 std/typecons.d @Biotronic @MetaLang @ZombineDev
-#std/typetuple.d
+# std/typetuple.d
 std/uni.d @DmitryOlshansky
-#std/uri.d
+# std/uri.d
 std/utf.d @jmdavis
 std/uuid.d @jpf91
-#std/variant.d
+# std/variant.d
 std/windows/* @CyberShadow
-#std/xml.d
+# std/xml.d
 std/zip.d @CyberShadow
 std/zlib.d @CyberShadow


### PR DESCRIPTION
According to the friendly GitHub support:
> We currently have a bug with CODEOWNERS files where commenting out a line will __stop__ the feature working __entirely__. If you remove any lines with a # it should start to work correctly again. Alternatively - since you have a lot of commented out lines in that file - you can add a space after the # characters which should also fix the issue.

> Formatting it like this should fix the issue, with the space between the # and the filepath:

```
#abc <- Will break the whole file x_x
# abc <- should be good!
```

I hope this helps ...