### PR TITLE
Enable runnable examples - remove the last modules from the blacklist

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -264,15 +264,6 @@ MAKEFILE = $(firstword $(MAKEFILE_LIST))
 # build with shared library support (defaults to true on supported platforms)
 SHARED=$(if $(findstring $(OS),linux freebsd),1,)
 
-# Check for missing imports in public unittest examples.
-# A blacklist of ignored module is provided as not all public unittest in
-# Phobos are independently runnable yet
-IGNORED_PUBLICTESTS= $(addprefix std/, \
-						$(addprefix experimental/allocator/, \
-								building_blocks/free_list building_blocks/quantizer \
-						) \
-						math stdio traits)
-PUBLICTESTS= $(addsuffix .publictests,$(filter-out $(IGNORED_PUBLICTESTS), $(D_MODULES)))
 TESTS_EXTRACTOR=$(ROOT)/tests_extractor
 PUBLICTESTS_DIR=$(ROOT)/publictests
 
@@ -593,7 +584,7 @@ style_lint: dscanner $(LIB)
 ################################################################################
 # Check for missing imports in public unittest examples.
 ################################################################################
-publictests: $(PUBLICTESTS)
+publictests: $(addsuffix .publictests,$(D_MODULES))
 
 $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -114,8 +114,7 @@ struct FreeList(ParentAllocator,
             _max = high;
         }
 
-        ///
-        @safe unittest
+        @system unittest
         {
             import std.experimental.allocator.common : chooseAtRuntime;
             import std.experimental.allocator.mallocator : Mallocator;
@@ -895,20 +894,6 @@ struct SharedFreeList(ParentAllocator,
         @property void max(size_t newMaxSize);
         /// Ditto
         void setBounds(size_t newMin, size_t newMax);
-        ///
-        @safe unittest
-        {
-            import std.experimental.allocator.common : chooseAtRuntime;
-            import std.experimental.allocator.mallocator : Mallocator;
-
-            shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
-            // Set the maxSize first so setting the minSize doesn't throw
-            a.max = 128;
-            a.min = 64;
-            a.setBounds(64, 128); // equivalent
-            assert(a.max == 128);
-            assert(a.min == 64);
-        }
 
         /**
         Properties for getting (and possibly setting) the approximate maximum length of a shared freelist.
@@ -916,21 +901,6 @@ struct SharedFreeList(ParentAllocator,
         @property size_t approxMaxLength() const shared;
         /// ditto
         @property void approxMaxLength(size_t x) shared;
-        ///
-        @safe unittest
-        {
-            import std.experimental.allocator.common : chooseAtRuntime;
-            import std.experimental.allocator.mallocator : Mallocator;
-
-            shared SharedFreeList!(Mallocator, 50, 50, chooseAtRuntime) a;
-            // Set the maxSize first so setting the minSize doesn't throw
-            a.approxMaxLength = 128;
-            assert(a.approxMaxLength  == 128);
-            a.approxMaxLength = 1024;
-            assert(a.approxMaxLength  == 1024);
-            a.approxMaxLength = 1;
-            assert(a.approxMaxLength  == 1);
-        }
     }
 
     /**
@@ -1069,6 +1039,34 @@ struct SharedFreeList(ParentAllocator,
         _root = null;
         resetNodes();
     }
+}
+
+///
+@safe unittest
+{
+    import std.experimental.allocator.common : chooseAtRuntime;
+    import std.experimental.allocator.mallocator : Mallocator;
+
+    shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
+    a.setBounds(64, 128);
+    assert(a.max == 128);
+    assert(a.min == 64);
+}
+
+///
+@safe unittest
+{
+    import std.experimental.allocator.common : chooseAtRuntime;
+    import std.experimental.allocator.mallocator : Mallocator;
+
+    shared SharedFreeList!(Mallocator, 50, 50, chooseAtRuntime) a;
+    // Set the maxSize first so setting the minSize doesn't throw
+    a.approxMaxLength = 128;
+    assert(a.approxMaxLength  == 128);
+    a.approxMaxLength = 1024;
+    assert(a.approxMaxLength  == 1024);
+    a.approxMaxLength = 1;
+    assert(a.approxMaxLength  == 1);
 }
 
 @system unittest

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -212,14 +212,19 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.free_tree : FreeTree;
-    import std.experimental.allocator.common : roundUpToMultipleOf;
     import std.experimental.allocator.gc_allocator : GCAllocator;
+
+    size_t roundUpToMultipleOf(size_t s, uint base)
+    {
+        auto rem = s % base;
+        return rem ? s + base - rem : s;
+    }
 
     // Quantize small allocations to a multiple of cache line, large ones to a
     // multiple of page size
     alias MyAlloc = Quantizer!(
         FreeTree!GCAllocator,
-        n => n.roundUpToMultipleOf(n <= 16_384 ? 64 : 4096));
+        n => roundUpToMultipleOf(n, n <= 16_384 ? 64 : 4096));
     MyAlloc alloc;
     const buf = alloc.allocate(256);
     assert(buf.ptr);

--- a/std/math.d
+++ b/std/math.d
@@ -2771,8 +2771,7 @@ if (isFloatingPoint!T)
     int exp;
     real mantissa = frexp(123.456L, exp);
 
-    // check if values are equal to 19 decimal digits of precision
-    assert(equalsDigit(mantissa * pow(2.0L, cast(real) exp), 123.456L, 19));
+    assert(approxEqual(mantissa * pow(2.0L, cast(real) exp), 123.456L));
 
     assert(frexp(-real.nan, exp) && exp == int.min);
     assert(frexp(real.nan, exp) && exp == int.min);
@@ -2780,6 +2779,15 @@ if (isFloatingPoint!T)
     assert(frexp(real.infinity, exp) == real.infinity && exp == int.max);
     assert(frexp(-0.0, exp) == -0.0 && exp == 0);
     assert(frexp(0.0, exp) == 0.0 && exp == 0);
+}
+
+@system unittest
+{
+    int exp;
+    real mantissa = frexp(123.456L, exp);
+
+    // check if values are equal to 19 decimal digits of precision
+    assert(equalsDigit(mantissa * pow(2.0L, cast(real) exp), 123.456L, 19));
 }
 
 @safe unittest
@@ -3619,6 +3627,11 @@ real log2(real x) @safe pure nothrow @nogc
 }
 
 ///
+@system unittest
+{
+    assert(approxEqual(log2(1024.0L), 10));
+}
+
 @system unittest
 {
     // check if values are equal to 19 decimal digits of precision

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -930,7 +930,7 @@ $(D rawRead) always reads in binary mode on Windows.
     {
         static import std.file;
 
-        auto testFile = testFilename();
+        auto testFile = std.file.deleteme();
         std.file.write(testFile, "\r\n\n\r\n");
         scope(exit) std.file.remove(testFile);
 
@@ -985,7 +985,7 @@ Throws: $(D ErrnoException) if the file is not opened or if the call to $(D fwri
     {
         static import std.file;
 
-        auto testFile = testFilename();
+        auto testFile = std.file.deleteme();
         auto f = File(testFile, "w");
         scope(exit) std.file.remove(testFile);
 
@@ -1092,7 +1092,7 @@ Throws: $(D Exception) if the file is not opened.
         import std.conv : text;
         static import std.file;
 
-        auto testFile = testFilename();
+        auto testFile = std.file.deleteme();
         std.file.write(testFile, "abcdefghijklmnopqrstuvwqxyz");
         scope(exit) { std.file.remove(testFile); }
 
@@ -1839,7 +1839,7 @@ $(CONSOLE
     {
         static import std.file;
 
-        auto deleteme = testFilename();
+        auto deleteme = std.file.deleteme();
         std.file.write(deleteme, "hello\nworld\ntrue\nfalse\n");
         scope(exit) std.file.remove(deleteme);
         string s;
@@ -2491,7 +2491,7 @@ $(REF readText, std,file)
          import std.typecons : tuple;
 
          // prepare test file
-         auto testFile = testFilename();
+         auto testFile = std.file.deleteme();
          scope(failure) printf("Failed test at line %d\n", __LINE__);
          std.file.write(testFile, "1 2\n4 1\n5 100");
          scope(exit) std.file.remove(testFile);

--- a/std/traits.d
+++ b/std/traits.d
@@ -2490,6 +2490,7 @@ template Fields(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     struct S { int x; float y; }
     static assert(is(Fields!S == AliasSeq!(int, float)));
 }
@@ -2546,6 +2547,7 @@ template FieldNameTuple(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     struct S { int x; float y; }
     static assert(FieldNameTuple!S == AliasSeq!("x", "y"));
     static assert(FieldNameTuple!int == AliasSeq!"");
@@ -2692,7 +2694,7 @@ private template hasRawAliasing(T...)
     enum hasRawAliasing = Impl!(RepresentationTypeTuple!T);
 }
 
-///
+//
 @safe unittest
 {
     // simple types
@@ -2788,7 +2790,7 @@ private template hasRawUnsharedAliasing(T...)
     enum hasRawUnsharedAliasing = Impl!(RepresentationTypeTuple!T);
 }
 
-///
+//
 @safe unittest
 {
     // simple types
@@ -4009,6 +4011,8 @@ template BaseTypeTuple(A)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     interface I1 { }
     interface I2 { }
     interface I12 : I1, I2 { }
@@ -4062,6 +4066,8 @@ template BaseClassesTuple(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     class C1 { }
     class C2 : C1 { }
     class C3 : C2 { }
@@ -4422,6 +4428,8 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     struct Foo(T, U) {}
     static assert(is(TemplateArgsOf!(Foo!(int, real)) == AliasSeq!(int, real)));
 }
@@ -7331,6 +7339,8 @@ template mostNegative(T)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
+
     foreach (T; AliasSeq!(bool, byte, short, int, long))
         static assert(mostNegative!T == T.min);
 
@@ -7397,6 +7407,7 @@ template mangledName(sth...)
 ///
 @safe unittest
 {
+    import std.meta : AliasSeq;
     alias TL = staticMap!(mangledName, int, const int, immutable int);
     static assert(TL == AliasSeq!("i", "xi", "yi"));
 }
@@ -7845,13 +7856,13 @@ template getSymbolsByUDA(alias symbol, alias attribute)
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));
 }
 
-///
+//
 @safe unittest
 {
     enum Attr;
     struct A
     {
-        alias int INT;
+        alias INT = int;
         alias void function(INT) SomeFunction;
         @Attr int a;
         int b;

--- a/std/traits.d
+++ b/std/traits.d
@@ -7856,7 +7856,7 @@ template getSymbolsByUDA(alias symbol, alias attribute)
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));
 }
 
-//
+///
 @safe unittest
 {
     enum Attr;
@@ -7866,14 +7866,10 @@ template getSymbolsByUDA(alias symbol, alias attribute)
         alias void function(INT) SomeFunction;
         @Attr int a;
         int b;
-        @Attr private int c;
-        private int d;
     }
 
-    // Here everything is fine, we have access to private member c
-    static assert(getSymbolsByUDA!(A, Attr).length == 2);
+    static assert(getSymbolsByUDA!(A, Attr).length == 1);
     static assert(hasUDA!(getSymbolsByUDA!(A, Attr)[0], Attr));
-    static assert(hasUDA!(getSymbolsByUDA!(A, Attr)[1], Attr));
 }
 
 // #16387: getSymbolsByUDA works with structs but fails with classes


### PR DESCRIPTION
After quite a bit of work, we are heading for an end :)
This PR removes the last five modules from the runnable blacklist, s.t. with 2.076 all unittests are runnable

(FYI: the effort started in https://github.com/dlang/phobos/pull/4943)

For some modules, I wasn't sure sure on the best approach and I will mark these bits individually.