### PR TITLE
Refactor joiner to reduce symbol bloat.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2406,10 +2406,15 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
 }
 
 /// Ditto
-auto joiner(RoR)(RoR r)
+template joiner(RoR)
 if (isInputRange!RoR && isInputRange!(ElementType!RoR))
 {
-    static struct Result
+    auto joiner(RoR r)
+    {
+        return Result(r);
+    }
+
+    struct Result
     {
     private:
         RoR _items;
@@ -2509,7 +2514,6 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
             }
         }
     }
-    return Result(r);
 }
 
 @safe unittest


### PR DESCRIPTION
Using Steven Schveighoffer's "horcrux" trick.  In my range-heavy project, this single change resulted in a 50% reduction in executable size(!). This is on top of the reductions already realized by my own application of the same trick (see forum discussion below).

Relevant discussions:
* [Forum discussion 1](http://forum.dlang.org/post/mailman.4286.1499286065.31550.digitalmars-d@puremagic.com)
* [Forum discussion 2](http://forum.dlang.org/post/mailman.4739.1499974296.31550.digitalmars-d@puremagic.com)
* [Steven's blog post explaining the technique](http://www.schveiguy.com/blog/2016/05/have-your-voldemort-types-and-keep-your-disk-space-too/)
* [Relevant DMD pull (5855)](https://github.com/dlang/dmd/pull/5855)

This PR is just one of many to come.  Some of the most common range functions in Phobos are Voldemort types, which cause nasty symbol size bloat. These PRs aim to reduce this bloat and make heavily ranged-based code more viable for D. (At least until the DMD PR is pulled. But this problem is quickly becoming a showstopper for me in the meantime, because yesterday I started running into DMD's 10MB symbol size limit. Not to mention ELF errors caused by excessively large symbols.)