### PR TITLE
Issue 17650: std.getopt range violation when option value is a hyphen

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1105,7 +1105,7 @@ private bool optMatch(string arg, string optPattern, ref string value,
     import std.uni : toUpper;
     //writeln("optMatch:\n  ", arg, "\n  ", optPattern, "\n  ", value);
     //scope(success) writeln("optMatch result: ", value);
-    if (!arg.length || arg[0] != optionChar) return false;
+    if (arg.length < 2 || arg[0] != optionChar) return false;
     // yank the leading '-'
     arg = arg[1 .. $];
     immutable isLong = arg.length > 1 && arg[0] == optionChar;
@@ -1833,4 +1833,25 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 
     assert(x == 17);
     assert(y == 50);
+}
+
+@system unittest // Hyphens at the start of option values; Issue 17650
+{
+    auto args = ["program", "-m", "-5", "-n", "-50", "-c", "-", "-f", "-"];
+
+    int m;
+    int n;
+    char c;
+    string f;
+
+    getopt(args,
+           "m|mm", "integer", &m,
+           "n|nn", "integer", &n,
+           "c|cc", "character", &c,
+           "f|file", "filename or hyphen for stdin", &f);
+
+    assert(m == -5);
+    assert(n == -50);
+    assert(c == '-');
+    assert(f == "-");
 }


### PR DESCRIPTION
This fixes an issue in std.getopt private function optMatch. This function is used to see if a command line argument represents an option (e.g. "--file", "-a", etc.). It looks at all the arguments on the command line, including option values. (In `$ command -f 1 -g 2`, "1" and "2" are option values.)

The range violation occurs if an option value is a single hyphen. The `optMatch` function sees the hyphen and assumes it might be an option argument (like "-f"). It then tests the next character in the string. When the value is a single hyphen the next character does not exist.

A single hyphen (or a single `optionChar`) only introduces an option, it is never an option by itself. So the easy fix is to also check that the length is at least 2.

Note: Looking through this code it appears there may be other problems like this. I've elected to fix only this case in this PR, as it is the most pressing issue.