### PR TITLE
Cherry-picking commits to stable: 17650 + CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,5 +72,5 @@ std/uuid.d @jpf91
 #std/variant.d
 std/windows/* @CyberShadow
 #std/xml.d
-std/zip.d * @CyberShadow
-std/zlib.d * @CyberShadow
+std/zip.d @CyberShadow
+std/zlib.d @CyberShadow

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,59 +18,59 @@ std/* @andralex
 std/algorithm/* @andralex @JackStouffer @wilzbach @ZombineDev
 std/array.d @JackStouffer @wilzbach @ZombineDev
 std/ascii.d @JackStouffer @wilzbach
-#std/base64.d
+# std/base64.d
 std/bigint.d @Biotronic
-#std/bitmanip.d
+# std/bitmanip.d
 std/c/windows/* @CyberShadow
-#std/compiler.d
+# std/compiler.d
 std/complex.d @kyllingstad
 std/concurrency.d @MartinNowak
 std/container/ @ZombineDev
 std/conv.d @JackStouffer
-#std/csv.d
+# std/csv.d
 std/datetime/* @jmdavis
 std/demangle.d @MartinNowak @rainers
 std/digest/* @jpf91
-#std/encoding.d
-#std/exception.d
+# std/encoding.d
+# std/exception.d
 std/experimental/allocator/* @andralex @wilzbach @ZombineDev
 std/experimental/checkedint/* @andralex
 std/experimental/logger/* @burner
-#std/experimental/typecons.d
+# std/experimental/typecons.d
 std/file.d @CyberShadow
-#std/format.d
-#std/functional.d
-#std/getopt.d
-#std/internal/
+# std/format.d
+# std/functional.d
+# std/getopt.d
+# std/internal/
 std/json.d @CyberShadow
 std/math* @Biotronic @ibuclaw @klickverbot
 std/meta.d @Biotronic @klickverbot @MetaLang @ZombineDev
-#std/mmfile.d
+# std/mmfile.d
 std/net/curl.d @CyberShadow
 std/net/isemail.d @JackStouffer
-#std/numeric.d
-#std/outbuffer.d
-#std/parallelism.d
+# std/numeric.d
+# std/outbuffer.d
+# std/parallelism.d
 std/path.d @CyberShadow @kyllingstad
 std/process.d @CyberShadow @kyllingstad @schveiguy
 std/random.d @WebDrake @wilzbach
 std/range/* @andralex @JackStouffer @wilzbach @ZombineDev
 std/regex/* @DmitryOlshansky
-#std/signals.d
+# std/signals.d
 std/socket.d @CyberShadow @klickverbot
-#std/stdint.d
+# std/stdint.d
 std/stdio.d @CyberShadow @schveiguy
 std/string.d @burner @JackStouffer
-#std/system.d
+# std/system.d
 std/traits.d @Biotronic @klickverbot @ZombineDev
 std/typecons.d @Biotronic @MetaLang @ZombineDev
-#std/typetuple.d
+# std/typetuple.d
 std/uni.d @DmitryOlshansky
-#std/uri.d
+# std/uri.d
 std/utf.d @jmdavis
 std/uuid.d @jpf91
-#std/variant.d
+# std/variant.d
 std/windows/* @CyberShadow
-#std/xml.d
+# std/xml.d
 std/zip.d @CyberShadow
 std/zlib.d @CyberShadow

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,76 @@
+# See also:
+# - https://github.com/blog/2392-introducing-code-owners
+# - https://help.github.com/articles/about-codeowners/
+
+# Each line is a file pattern followed by one or more owners (sorted alphabetically).
+# Please feel free to add yourself to a module or create a new mapping.
+# Ideally each module should have two or more owners.
+
+# Code owners are automatically requested for review
+# when someone opens a pull request that modifies code that they own.
+# Later matches take precedence.
+
+.dscanner.ini @wilzbach
+circleci.sh @CyberShadow @MartinNowak @wilzbach
+etc/c/* @CyberShadow
+posix.mak @CyberShadow @MartinNowak @wilzbach
+std/* @andralex
+std/algorithm/* @andralex @JackStouffer @wilzbach @ZombineDev
+std/array.d @JackStouffer @wilzbach @ZombineDev
+std/ascii.d @JackStouffer @wilzbach
+#std/base64.d
+std/bigint.d @Biotronic
+#std/bitmanip.d
+std/c/windows/* @CyberShadow
+#std/compiler.d
+std/complex.d @kyllingstad
+std/concurrency.d @MartinNowak
+std/container/ @ZombineDev
+std/conv.d @JackStouffer
+#std/csv.d
+std/datetime/* @jmdavis
+std/demangle.d @MartinNowak @rainers
+std/digest/* @jpf91
+#std/encoding.d
+#std/exception.d
+std/experimental/allocator/* @andralex @wilzbach @ZombineDev
+std/experimental/checkedint/* @andralex
+std/experimental/logger/* @burner
+#std/experimental/typecons.d
+std/file.d @CyberShadow
+#std/format.d
+#std/functional.d
+#std/getopt.d
+#std/internal/
+std/json.d @CyberShadow
+std/math* @Biotronic @ibuclaw @klickverbot
+std/meta.d @Biotronic @klickverbot @MetaLang @ZombineDev
+#std/mmfile.d
+std/net/curl.d @CyberShadow
+std/net/isemail.d @JackStouffer
+#std/numeric.d
+#std/outbuffer.d
+#std/parallelism.d
+std/path.d @CyberShadow @kyllingstad
+std/process.d @CyberShadow @kyllingstad @schveiguy
+std/random.d @WebDrake @wilzbach
+std/range/* @andralex @JackStouffer @wilzbach @ZombineDev
+std/regex/* @DmitryOlshansky
+#std/signals.d
+std/socket.d @CyberShadow @klickverbot
+#std/stdint.d
+std/stdio.d @CyberShadow @schveiguy
+std/string.d @burner @JackStouffer
+#std/system.d
+std/traits.d @Biotronic @klickverbot @ZombineDev
+std/typecons.d @Biotronic @MetaLang @ZombineDev
+#std/typetuple.d
+std/uni.d @DmitryOlshansky
+#std/uri.d
+std/utf.d @jmdavis
+std/uuid.d @jpf91
+#std/variant.d
+std/windows/* @CyberShadow
+#std/xml.d
+std/zip.d * @CyberShadow
+std/zlib.d * @CyberShadow

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1083,7 +1083,7 @@ private bool optMatch(string arg, string optPattern, ref string value,
     import std.uni : toUpper;
     //writeln("optMatch:\n  ", arg, "\n  ", optPattern, "\n  ", value);
     //scope(success) writeln("optMatch result: ", value);
-    if (!arg.length || arg[0] != optionChar) return false;
+    if (arg.length < 2 || arg[0] != optionChar) return false;
     // yank the leading '-'
     arg = arg[1 .. $];
     immutable isLong = arg.length > 1 && arg[0] == optionChar;
@@ -1811,4 +1811,25 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 
     assert(x == 17);
     assert(y == 50);
+}
+
+@system unittest // Hyphens at the start of option values; Issue 17650
+{
+    auto args = ["program", "-m", "-5", "-n", "-50", "-c", "-", "-f", "-"];
+
+    int m;
+    int n;
+    char c;
+    string f;
+
+    getopt(args,
+           "m|mm", "integer", &m,
+           "n|nn", "integer", &n,
+           "c|cc", "character", &c,
+           "f|file", "filename or hyphen for stdin", &f);
+
+    assert(m == -5);
+    assert(n == -50);
+    assert(c == '-');
+    assert(f == "-");
 }


### PR DESCRIPTION
https://github.com/dlang/phobos/pull/5612 should have been targeted at stable.

Also at https://github.com/dlang/phobos/pull/5614 I realized the CODEOWNERS file isn't part of `stable` and will take quite a long time to get be merged back into `stable` again, so I cherry-picked this as well while I was at it.

Note that due to the GH bugs in the CODEOWNERS implementation it took us [three PRS](https://github.com/dlang/phobos/pulls?utf8=%E2%9C%93&q=codeowners) to achieve a working CODEOWNERS file.