### PR TITLE
Fix Issue 17250 - ProcessPipes (std.process) should provide a test for a null pid

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2168,7 +2168,6 @@ struct ProcessPipes
     /// The $(LREF Pid) of the child process.
     @property Pid pid() @safe nothrow
     {
-        assert(_pid !is null);
         return _pid;
     }
 


### PR DESCRIPTION
The pid() property of the ProcessPipes struct asserts that the pid is not null. This makes it impossible to check for a null pid (see bug description for a more detailed description). The solutions are : either remove the assert and expect the user to check for a null pid or add a new function isNullPid. In my opinion, the first solution is the better one as checking for a null pid can be simply done and doesn't need a one liner function. Either way, if for some reason, the latter solution is preferred, I will update my commit.  