### PR TITLE
Mark random coverage line in std.concurrency

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2235,7 +2235,7 @@ private
             if (m_last is m_first)
                 m_last = null;
             else if (m_last is n.next)
-                m_last = n;
+                m_last = n; // nocoverage
             Node* to_free = n.next;
             n.next = n.next.next;
             freeNode(to_free);


### PR DESCRIPTION
Spotted here: https://codecov.io/gh/dlang/phobos/compare/e8ebd82eab15bf8b9378a9cd8d16090cec999a81...9efa504bdca2b2644375e86d3b1527170512b726/changes

(at https://github.com/dlang/phobos/pull/5620).

CC @CyberShadow 