### PR TITLE
[dox] Positive examples for isStaticArray.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6056,6 +6056,10 @@ enum bool isStaticArray(T) = __traits(isStaticArray, T);
 ///
 @safe unittest
 {
+    static assert( isStaticArray!(int[3]));
+    static assert( isStaticArray!(const(int)[5]));
+    static assert( isStaticArray!(const(int)[][5]));
+
     static assert(!isStaticArray!(const(int)[]));
     static assert(!isStaticArray!(immutable(int)[]));
     static assert(!isStaticArray!(const(int)[4][]));


### PR DESCRIPTION
The current doc for isStaticArray is pretty ridiculous: the ddoc'd unittest gives the user examples of what is *not* a static array, but not even a single example of what *is* a static array!