### PR TITLE
Extend std.range.chunks to work with non-forward input ranges.

### DIFF
--- a/changelog/std-range-input-chunks.dd
+++ b/changelog/std-range-input-chunks.dd
@@ -1,0 +1,21 @@
+`std.range.chunks` was extended to support non-forward input ranges.
+
+Now `std.range.chunks` can be used with input ranges that are not forward
+ranges, albeit with limited semantics as imposed by the underlying range.
+
+---
+import std.algorithm.comparison : equal;
+
+int i;
+
+// The generator doesn't save state, so it cannot be a forward range.
+auto inputRange = generate!(() => ++i).take(10);
+
+// We can still process it in chunks, but it will be single-pass only.
+auto chunked = inputRange.chunks(2);
+
+assert(chunked.front.equal([1, 2]));
+assert(chunked.front.empty); // Iterating the chunk has consumed it
+chunked.popFront;
+assert(chunked.front.equal([3, 4]));
+---


### PR DESCRIPTION
Rationale: sometimes all you can get is an input range (e.g., `File.byLine`), and it is undesirable to have to buffer the entire input range just to be able to call `chunks` on it. This extension of `chunks` to support non-forward input ranges allows for the possibility of caching such ranges by chunks so that you process it incrementally while offering better range primitives on the cached portion of the range.

For example:
````
File("data").byLineCopy
    .chunks(bufSize)
    .map!(chunk => chunk.array) // cache each chunk on a buffer
    ... // now each chunk is a forward range and
        // you can do more stuff with it
        // Even though outer range is still only input range
````

For now, I'm implementing this as a separate overload of `Chunks`, due to the unfortunate historical accident that `Chunks` was exposed as a public API rather than encapsulated as a Voldemort or private module-global struct.  The implementation is fundamentally different, since without forward range primitives the current code simply cannot be made to work correctly.  Originally I tried to use static if inside the struct to separate the two implementations, but it was very messy and the diff was a sight to behold. So I'm keeping it as a separate overload for now.