### PR TITLE
reimplement std.traits.ParameterStorageClassTuple()

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1086,29 +1086,32 @@ template ParameterStorageClassTuple(func...)
  * Returns:
  *      ParameterStorageClass bits
  */
-ParameterStorageClass extractParameterStorageClassFlags(Attribs...)()
+template extractParameterStorageClassFlags(Attribs...)
 {
-    auto result = ParameterStorageClass.none;
-    static if (Attribs.length > 0)
+    enum ParameterStorageClass extractParameterStorageClassFlags = ()
     {
-        foreach (attrib; [Attribs])
+        auto result = ParameterStorageClass.none;
+        static if (Attribs.length > 0)
         {
-            final switch (attrib) with (ParameterStorageClass)
+            foreach (attrib; [Attribs])
             {
-                case "scope":  result |= scope_;  break;
-                case "out":    result |= out_;    break;
-                case "ref":    result |= ref_;    break;
-                case "lazy":   result |= lazy_;   break;
-                case "return": result |= return_; break;
+                final switch (attrib) with (ParameterStorageClass)
+                {
+                    case "scope":  result |= scope_;  break;
+                    case "out":    result |= out_;    break;
+                    case "ref":    result |= ref_;    break;
+                    case "lazy":   result |= lazy_;   break;
+                    case "return": result |= return_; break;
+                }
             }
+            /* Mimic behavor of original version of ParameterStorageClassTuple()
+             * to avoid breaking existing code.
+             */
+            if (result == (ParameterStorageClass.ref_ | ParameterStorageClass.return_))
+                result = ParameterStorageClass.return_;
         }
-        /* Mimic behavor of original version of ParameterStorageClassTuple()
-         * to avoid breaking existing code.
-         */
-        if (result == (ParameterStorageClass.ref_ | ParameterStorageClass.return_))
-            result = ParameterStorageClass.return_;
-    }
-    return result;
+        return result;
+    }();
 }
 
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -1089,22 +1089,25 @@ template ParameterStorageClassTuple(func...)
 ParameterStorageClass extractParameterStorageClassFlags(Attribs...)()
 {
     auto result = ParameterStorageClass.none;
-    foreach (attrib; Attribs)
+    static if (Attribs.length > 0)
     {
-        final switch (attrib) with (ParameterStorageClass)
+        foreach (attrib; [Attribs])
         {
-            case "scope":  result |= scope_;  break;
-            case "out":    result |= out_;    break;
-            case "ref":    result |= ref_;    break;
-            case "lazy":   result |= lazy_;   break;
-            case "return": result |= return_; break;
+            final switch (attrib) with (ParameterStorageClass)
+            {
+                case "scope":  result |= scope_;  break;
+                case "out":    result |= out_;    break;
+                case "ref":    result |= ref_;    break;
+                case "lazy":   result |= lazy_;   break;
+                case "return": result |= return_; break;
+            }
         }
+        /* Mimic behavor of original version of ParameterStorageClassTuple()
+         * to avoid breaking existing code.
+         */
+        if (result == (ParameterStorageClass.ref_ | ParameterStorageClass.return_))
+            result = ParameterStorageClass.return_;
     }
-    /* Mimic behavor of original version of ParameterStorageClassTuple()
-     * to avoid breaking existing code.
-     */
-    if (result == (ParameterStorageClass.ref_ | ParameterStorageClass.return_))
-        result = ParameterStorageClass.return_;
     return result;
 }
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -1016,8 +1016,11 @@ template arity(alias func)
 }
 
 /**
-Returns a tuple consisting of the storage classes of the parameters of a
-function $(D func).
+Get tuple, one per function parameter, of the storage classes of the parameters.
+Params:
+    func = function symbol or type of function, delegate, or pointer to function
+Returns:
+    a tuple of ParameterStorageClass bits
  */
 enum ParameterStorageClass : uint
 {
@@ -1037,39 +1040,28 @@ enum ParameterStorageClass : uint
 template ParameterStorageClassTuple(func...)
     if (func.length == 1 && isCallable!func)
 {
-    alias Func = Unqual!(FunctionTypeOf!func);
+    alias Func = FunctionTypeOf!func;
 
-    /*
-     * TypeFuncion:
-     *     CallConvention FuncAttrs Arguments ArgClose Type
-     */
-    alias Params = Parameters!Func;
-
-    // chop off CallConvention and FuncAttrs
-    enum margs = demangleFunctionAttributes(mangledName!Func[1 .. $]).rest;
-
-    // demangle Arguments and store parameter storage classes in a tuple
-    template demangleNextParameter(string margs, size_t i = 0)
+    static if (is(Func PT == __parameters))
     {
-        static if (i < Params.length)
+        template StorageClass(size_t i)
         {
-            enum demang = demangleParameterStorageClass(margs);
-            enum skip = mangledName!(Params[i]).length; // for bypassing Type
-            enum rest = demang.rest;
-
-            alias demangleNextParameter =
-                AliasSeq!(
-                    demang.value + 0, // workaround: "not evaluatable at ..."
-                    demangleNextParameter!(rest[skip .. $], i + 1)
-                );
+            static if (i < PT.length)
+            {
+                alias StorageClass = AliasSeq!(
+                        extractParameterStorageClassFlags!(__traits(getParameterStorageClasses, Func, i)),
+                        StorageClass!(i + 1));
+            }
+            else
+                alias StorageClass = AliasSeq!();
         }
-        else // went thru all the parameters
-        {
-            alias demangleNextParameter = AliasSeq!();
-        }
+        alias ParameterStorageClassTuple = StorageClass!0;
     }
-
-    alias ParameterStorageClassTuple = demangleNextParameter!margs;
+    else
+    {
+        static assert(0, func[0].stringof ~ " is not a function");
+        alias ParameterStorageClassTuple = AliasSeq!();
+    }
 }
 
 ///
@@ -1085,6 +1077,35 @@ template ParameterStorageClassTuple(func...)
     static assert(pstc[0] == STC.ref_);
     static assert(pstc[1] == STC.out_);
     static assert(pstc[2] == STC.none);
+}
+
+/*****************
+ * Convert string tuple Attribs to ParameterStorageClass bits
+ * Params:
+ *      Attribs = string tuple
+ * Returns:
+ *      ParameterStorageClass bits
+ */
+ParameterStorageClass extractParameterStorageClassFlags(Attribs...)()
+{
+    auto result = ParameterStorageClass.none;
+    foreach (attrib; Attribs)
+    {
+        final switch (attrib) with (ParameterStorageClass)
+        {
+            case "scope":  result |= scope_;  break;
+            case "out":    result |= out_;    break;
+            case "ref":    result |= ref_;    break;
+            case "lazy":   result |= lazy_;   break;
+            case "return": result |= return_; break;
+        }
+    }
+    /* Mimic behavor of original version of ParameterStorageClassTuple()
+     * to avoid breaking existing code.
+     */
+    if (result == (ParameterStorageClass.ref_ | ParameterStorageClass.return_))
+        result = ParameterStorageClass.return_;
+    return result;
 }
 
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -1020,7 +1020,7 @@ Get tuple, one per function parameter, of the storage classes of the parameters.
 Params:
     func = function symbol or type of function, delegate, or pointer to function
 Returns:
-    a tuple of ParameterStorageClass bits
+    A tuple of ParameterStorageClass bits
  */
 enum ParameterStorageClass : uint
 {


### PR DESCRIPTION
reboot https://github.com/dlang/phobos/pull/5427 by @WalterBright as it is required for the new mangling in https://github.com/dlang/dmd/pull/6998

Maybe something else changes, but locally I cannot reproduce an error with `toDelegate!(void function(FreeListRef!(shared(int), true), int delegate(int, int) pure nothrow @nogc @safe, int, int) nothrow @nogc @system)` as in the previous attempts build logs.