### PR TITLE
Add @safe to unittests to fix CircleCi

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -1170,7 +1170,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with arrays
-unittest
+@safe unittest
 {
     int executed = 0;
     T median(T)(const T[] nums) {
@@ -1194,7 +1194,7 @@ unittest
 }
 
 // 16079: memoize should work with structs
-unittest
+@safe unittest
 {
     int executed = 0;
     T pickFirst(T)(T first)
@@ -1213,7 +1213,7 @@ unittest
 }
 
 // 16079: memoize should work with classes
-unittest
+@safe unittest
 {
     int executed = 0;
     T pickFirst(T)(T first)


### PR DESCRIPTION
Sorry for this ... we really need to automate to restart all CircleCi builds from time to time (e.g. https://github.com/dlang-bots/dlang-bot/issues/132).

See also: https://github.com/dlang/phobos/pull/4367