### PR TITLE
Fix Issue 1998 - std.bitarray should have setAll / opSliceAssign

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -772,7 +772,7 @@ struct BitArray
 {
 private:
 
-    import core.bitop : bts, btr, bsf, bt;
+    import core.bitop : btc, bts, btr, bsf, bt;
     import std.format : FormatSpec;
 
     size_t _len;
@@ -884,6 +884,89 @@ public:
         else
             btr(_ptr, i);
         return b;
+    }
+
+    /**
+      Sets all the values in the $(D BitArray) to the
+      value specified by $(D val).
+     */
+    BitArray opSliceAssign(bool val)
+    {
+        for(size_t i = 0; i < _len; i++)
+            opIndexAssign(val, i);
+        return this;
+    }
+
+    ///
+    @system unittest
+    {
+        import std.algorithm.comparison : equal;
+
+        auto b = BitArray([1, 0, 1, 0, 1, 1]);
+
+        b[] = true;
+        // all bits are set
+        assert(b.bitsSet.equal([0, 1, 2, 3, 4, 5]));
+
+        b[] = false;
+        // none of the bits are set
+        assert(b.bitsSet.empty);
+    }
+
+    /**
+      Sets the bits of a slice of $(D BitArray) which
+      starts at the index $(D start) and ends at the
+      index ($D end) - 1 with the values specified by $(D val).
+     */
+    BitArray opSliceAssign(bool val, size_t start, size_t end)
+    in
+    {
+        assert(start >= 0 && start <= _len);
+        assert(end >=0 && end <= _len);
+        assert(start <= end);
+    }
+    body
+    {
+        for(size_t i = start; i < end; i++)
+            opIndexAssign(val, i);
+        return this;
+    }
+
+    ///
+    @system unittest
+    {
+        import std.algorithm.comparison : equal;
+
+        auto b = BitArray([1, 1, 0, 0, 0, 0]);
+
+        b[2 .. 6] = true;
+        assert(b.bitsSet.equal([0, 1, 2, 3, 4, 5]));
+    }
+
+    /**
+      Flips all the bits in the $(D BitArray)
+     */
+    BitArray opUnary(string op)()
+        if (op == "~")
+    {
+        for(size_t i = 0; i < _len; i++)
+            btc(_ptr, i);
+        return this;
+    }
+
+    ///
+    @system unittest
+    {
+        import std.algorithm.comparison : equal;
+        import std.stdio : writeln;
+        import std.format : format;
+
+        // positions 0, 2, 4 are set
+        auto b = BitArray([1, 0, 1, 0, 1, 0]);
+
+        b = ~b;
+        // after negation, position 1, 3, 5 are set
+        assert(b.bitsSet.equal([1, 3, 5]));
     }
 
     /**********************************************

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1027,6 +1027,50 @@ public:
         assert(b1.bitsSet.equal(iota(0, 270)));
     }
 
+    /**
+      Flips a single bit, specified by `pos`
+     */
+    void flip(size_t i)
+    {
+        bt(_ptr, i) ? btr(_ptr, i) : bts(_ptr, i);
+    }
+
+    @system unittest
+    {
+        auto ax = BitArray([1, 0, 0, 1]);
+        ax.flip(0);
+        assert(ax[0] == 0);
+
+        bool[200] y;
+        y[90 .. 130] = true;
+        auto ay = BitArray(y);
+        ay.flip(100);
+        assert(ay[100] == 0);
+    }
+
+    /**********************************************
+     * Counts all the set bits in the $(D BitArray)
+     */
+    size_t count()
+    {
+        size_t bitCount;
+        foreach (i; 0 .. fullWords)
+            bitCount += countBitsSet(_ptr[i]);
+        bitCount += countBitsSet(_ptr[fullWords] & endMask);
+        return bitCount;
+    }
+
+    @system unittest
+    {
+        auto a = BitArray([0, 1, 1, 0, 0, 1, 1]);
+        assert(a.count == 4);
+
+        bool[200] boolArray;
+        boolArray[45 .. 130] = true;
+        auto c = BitArray(boolArray);
+        assert(c.count == 85);
+    }
+
     /**********************************************
      * Duplicates the $(D BitArray) and its contents.
      */


### PR DESCRIPTION
This PR implements opSliceAssign(bool val)/opSliceAssign(bool val, size_t start, size_t end) and opUnary for the "~" operator.