### PR TITLE
Show warnings about outdated Phobos modules

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -4,6 +4,9 @@
  *
  * This module is a submodule of $(MREF std, container).
  *
+ * $(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+ *   to make containers `@nogc` and `@safe`.)
+ *
  * Source: $(PHOBOSSRC std/container/_array.d)
  *
  * Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -4,6 +4,9 @@ adaptor that makes a binary heap out of any user-provided random-access range.
 
 This module is a submodule of $(MREF std, container).
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -4,6 +4,9 @@ It can be used as a queue, dequeue or stack.
 
 This module is a submodule of $(MREF std, container).
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 Source: $(PHOBOSSRC std/container/_dlist.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -215,6 +215,9 @@ a value of _container type, $(D n$(SUBSCRIPT x)) represents the effective length
 value $(D x), which could be a single element (in which case $(D n$(SUBSCRIPT x)) is
 $(D 1)), a _container, or a range.
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 $(BOOKTABLE Container primitives,
 $(TR
     $(TH Syntax)

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -3,6 +3,9 @@ This module implements a red-black tree container.
 
 This module is a submodule of $(MREF std, container).
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 Source: $(PHOBOSSRC std/container/_rbtree.d)
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -4,6 +4,9 @@ It can be used as a stack.
 
 This module is a submodule of $(MREF std, container).
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 Source: $(PHOBOSSRC std/container/_slist.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -3,6 +3,9 @@ This module contains some common utilities used by containers.
 
 This module is a submodule of $(MREF std, container).
 
+$(MESSAGE_BOX orange, This module will be reworked $(LINK2 http://dconf.org/2017/talks/staniloiu.html, soon)
+to make containers `@nogc` and `@safe`.)
+
 Source: $(PHOBOSSRC std/container/_util.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/json.d
+++ b/std/json.d
@@ -3,6 +3,10 @@
 /**
 JavaScript Object Notation
 
+$(MESSAGE_BOX red, Warning - This module is considered out-dated and not up to Phobos'
+current standards. Have a look at $(LINK2 std.data.json, https://github.com/s-ludwig/std_data_json)
+for an upcoming replacement.)
+
 Copyright: Copyright Jeremie Pelletier 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1,6 +1,10 @@
 // Written in the D programming language.
 
 /**
+$(MESSAGE_BOX gray, $(LINK2 https://github.com/ikod/dlang-requests, `requests`) provides
+a simple, high-level API with a native D implementation. Moreover, `requests`
+can be used with $(LINK2 http://vibed.org/, Vibe.d) for asynchronous requests.)
+
 Networking client functionality as provided by $(HTTP _curl.haxx.se/libcurl,
 libcurl). The libcurl library must be installed on the system in order to use
 this module.

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -3,6 +3,9 @@
 /**
 Serialize data to $(D ubyte) arrays.
 
+$(MESSAGE_BOX red, Warning - This module is considered out-dated and not up to Phobos'
+current standards.)
+
  * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)

--- a/std/signals.d
+++ b/std/signals.d
@@ -10,6 +10,10 @@
  * using it simpler and less error prone. In particular, it is no
  * longer necessary to instrument the slots.
  *
+ * $(MESSAGE_BOX red, Warning - This module is considered out-dated and not up to Phobos'
+ * current standards. Have a look at $(LINK2 vibe-core, https://github.com/vibe-d/vibe-core)
+ * for a modern approach.)
+ *
  * References:
  *      $(LUCKY A Deeper Look at Signals and Slots)$(BR)
  *      $(LINK2 http://en.wikipedia.org/wiki/Observer_pattern, Observer pattern)$(BR)

--- a/std/socket.d
+++ b/std/socket.d
@@ -35,6 +35,10 @@
 
 /**
  * Socket primitives.
+ * $(MESSAGE_BOX red, Warning - This module is considered out-dated and not up to Phobos'
+ * current standards. Have a look at $(LINK2 vibe-core, https://github.com/vibe-d/vibe-core)
+ * for a modern approach.)
+ *
  * Example: See $(SAMPLESRC listener.d) and $(SAMPLESRC htmlget.d)
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors: Christopher E. Miller, $(HTTP klickverbot.at, David Nadlinger),

--- a/std/xml.d
+++ b/std/xml.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
-$(RED Warning: This module is considered out-dated and not up to Phobos'
+$(MESSAGE_BOX red, Warning - This module is considered out-dated and not up to Phobos'
       current standards. It will remain until we have a suitable replacement,
       but be aware that it will not remain long term.)
 


### PR DESCRIPTION
As moving old & ugly Phobos modules to undeaD doesn't seem to be [an option](https://github.com/dlang/phobos/pull/5488) for now, let's at least try to warn the user.
I used the same message as we already display on std.xml.

Are there other modules that you would like to be included on this list?

Previous discussion: https://github.com/dlang/dlang.org/pull/1778