### PR TITLE
Add bookmark table to std.typecons

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4,7 +4,58 @@
 This module implements a variety of type constructors, i.e., templates
 that allow construction of new, useful general-purpose types.
 
-Source:    $(PHOBOSSRC std/_typecons.d)
+$(SCRIPT inhibitQuickIndex = 1;)
+$(BOOKTABLE,
+$(TR $(TH Category) $(TH Functions))
+$(TR $(TD Tuple) $(TD
+    $(LREF isTuple)
+    $(LREF Tuple)
+    $(LREF tuple)
+    $(LREF reverse)
+))
+$(TR $(TD Flags) $(TD
+    $(LREF BitFlags)
+    $(LREF isBitFlagEnum)
+    $(LREF Flag)
+    $(LREF No)
+    $(LREF Yes)
+))
+$(TR $(TD Memory allocation) $(TD
+    $(LREF RefCounted)
+    $(LREF refCounted)
+    $(LREF RefCountedAutoInitialize)
+    $(LREF scoped)
+    $(LREF Unique)
+))
+$(TR $(TD Code generation) $(TD
+    $(LREF AutoImplement)
+    $(LREF BlackHole)
+    $(LREF generateAssertTrap)
+    $(LREF generateEmptyFunction)
+    $(LREF WhiteHole)
+))
+$(TR $(TD Nullable) $(TD
+    $(LREF Nullable)
+    $(LREF nullable)
+    $(LREF NullableRef)
+    $(LREF nullableRef)
+))
+$(TR $(TD Proxies) $(TD
+    $(LREF Proxy)
+    $(LREF rebindable)
+    $(LREF Rebindable)
+    $(LREF ReplaceType)
+    $(LREF unwrap)
+    $(LREF wrap)
+))
+$(TR $(TD Types) $(TD
+    $(LREF alignForSize)
+    $(LREF Ternary)
+    $(LREF Typedef)
+    $(LREF TypedefType)
+    $(LREF UnqualRef)
+))
+)
 
 Synopsis:
 
@@ -30,6 +81,7 @@ void bar()
 }
 ----
 
+Source:    $(PHOBOSSRC std/_typecons.d)
 Copyright: Copyright the respective authors, 2008-
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu),


### PR DESCRIPTION
Found a weird-looking bookmark table in std.functional and then had a look at other bookmark tables and found that std.typecons was in deep need:

Before:

![image](https://user-images.githubusercontent.com/4370550/28437093-ac22e8b2-6d99-11e7-857b-0bc8f6a6e04e.png)


After:

![image](https://user-images.githubusercontent.com/4370550/28437055-7b9c584a-6d99-11e7-8b61-8a6cc87d4995.png)

Other interesting modules
- [std.process](https://dlang.org/phobos/std_process.html)
- [std.variant](https://dlang.org/phobos/std_variant.html)
- [std.uri](https://dlang.org/phobos/std_uri.html)
- [std.random](https://dlang.org/phobos/std_random.html)
- [std.parallelism](https://dlang.org/phobos/std_parallelism.html)
- [std.numeric](https://dlang.org/phobos/std_numeric.html)
- [std.mathspecial](https://dlang.org/phobos/std_mathspecial.html)
- [std.getopt](https://dlang.org/phobos/std_getopt.html)