### PR TITLE
std.digest link cleanup

### DIFF
--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -19,9 +19,9 @@ $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of) $(MYREF crc64EC
 
  *
  * This module conforms to the APIs defined in $(D std.digest). To understand the
- * differences between the template and the OOP API, see $(D std.digest).
+ * differences between the template and the OOP API, see $(MREF std, digest).
  *
- * This module publicly imports $(D std.digest) and can be used as a stand-alone
+ * This module publicly imports $(MREF std, digest) and can be used as a stand-alone
  * module.
  *
  * Note:

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -19,9 +19,9 @@ $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
 )
 
  * This module conforms to the APIs defined in $(D std.digest). To understand the
- * differences between the template and the OOP API, see $(D std.digest).
+ * differences between the template and the OOP API, see $(MREF std, digest).
  *
- * This module publicly imports $(D std.digest) and can be used as a stand-alone
+ * This module publicly imports $(MREF std, digest) and can be used as a stand-alone
  * module.
  *
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -22,10 +22,11 @@ $(LI The current implementation is optimized for little endian architectures.
   less uniform distribution.)
 )
 
-This module conforms to the APIs defined in $(D std.digest).
+This module conforms to the APIs defined in $(MREF std, digest).
 
-This module publicly imports $(D std.digest) and can be used as a stand-alone module.
+This module publicly imports $(MREF std, digest) and can be used as a stand-alone module.
 
+Source: $(PHOBOSSRC std/digest/_murmurhash.d)
 License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Guillaume Chatelet
 References: $(LINK2 https://github.com/aappleby/smhasher, Reference implementation)
@@ -45,6 +46,7 @@ module std.digest.murmurhash;
     static assert(isDigest!(MurmurHash3!32));
     // The convenient digest template allows for quick hashing of any data.
     ubyte[4] hashed = digest!(MurmurHash3!32)([1, 2, 3, 4]);
+    assert(hashed == [0, 173, 69, 68]);
 }
 
 ///
@@ -62,6 +64,7 @@ module std.digest.murmurhash;
     // - the remaining bits are processed
     // - the hash gets finalized
     auto hashed = hasher.finish();
+    assert(hashed == [181, 151, 88, 252]);
 }
 
 ///
@@ -86,6 +89,7 @@ module std.digest.murmurhash;
     hasher.finalize();
     // Finally get the hashed value.
     auto hashed = hasher.getBytes();
+    assert(hashed == [188, 165, 108, 2]);
 }
 
 public import std.digest;

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -18,8 +18,8 @@ $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
 )
 )
 
- * This module conforms to the APIs defined in $(D std.digest). To understand the
- * differences between the template and the OOP API, see $(D std.digest).
+ * This module conforms to the APIs defined in $(MREF std, digest). To understand the
+ * differences between the template and the OOP API, see $(MREF std, digest).
  *
  * This module publicly imports $(D std.digest) and can be used as a stand-alone
  * module.

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -23,8 +23,8 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  * SHA2 comes in several different versions, all supported by this module:
  * SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224 and SHA-512/256.
  *
- * This module conforms to the APIs defined in $(D std.digest). To understand the
- * differences between the template and the OOP API, see $(D std.digest).
+ * This module conforms to the APIs defined in $(MREF std, digest). To understand the
+ * differences between the template and the OOP API, see $(MREF std, digest).
  *
  * This module publicly imports $(D std.digest) and can be used as a stand-alone
  * module.


### PR DESCRIPTION
Clickable links are nicer!

- Convert references to MREFs
- Add source link to std.digest.murmurhash
- Add assert to the examples in std.digest.murmurhash