### PR TITLE
std.functional: Fix more DDoc links

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -15,7 +15,7 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Joins a couple of functions into one that executes the original
         functions independently and returns a tuple with all the results.
     ))
-    $(TR $(TD $(LREF compose)), $(LREF pipe)
+    $(TR $(TD $(LREF compose), $(LREF pipe))
         $(TD Join a couple of functions into one that executes the original
         functions one after the other, using one function's result for the next
         function's argument.
@@ -36,13 +36,13 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Creates a function that binds the first argument of a given function
         to a given value.
     ))
-    $(TR $(TD $(LREF reverseArgs)), $(LREF binaryReverseArgs)
+    $(TR $(TD $(LREF reverseArgs), $(LREF binaryReverseArgs))
         $(TD Predicate that reverses the order of its arguments.
     ))
     $(TR $(TD $(LREF toDelegate))
         $(TD Converts a callable to a delegate.
     ))
-    $(TR $(TD $(LREF unaryFun)), $(LREF binaryFun)
+    $(TR $(TD $(LREF unaryFun), $(LREF binaryFun))
         $(TD Create a unary or binary function from a string. Most often
         used when defining algorithms on ranges.
     ))


### PR DESCRIPTION
There's even more broken stuff here here :/

With current CSS styling
---------------------------------

![image](https://user-images.githubusercontent.com/4370550/28445789-f0381482-6dc6-11e7-9c4c-4ac7c8cdd5ad.png)

@JackStouffer There was https://github.com/dlang/dlang.org/pull/1593, which mainly was about the `left-padding` here:

```css
```css
table.book tbody a:first-child + a {
    padding-left: .6em;
}
/*style.css:1034 */
table.book tbody a + a {
    padding-right: .6em;
}
```

Without:
-----------

If both left and right-padding are disabled:

![image](https://user-images.githubusercontent.com/4370550/28445760-c185c5b2-6dc6-11e7-8e7d-19ddf81c57f9.png)