### PR TITLE
std.conv: Make constraint for `toImpl` with radix clearer

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1815,7 +1815,7 @@ if (isInputRange!S && isSomeChar!(ElementEncodingType!S) &&
 /// ditto
 private T toImpl(T, S)(S value, uint radix)
 if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S) &&
-    !isExactSomeString!T && is(typeof(parse!T(value, radix))))
+    isIntegral!T && is(typeof(parse!T(value, radix))))
 {
     scope(success)
     {


### PR DESCRIPTION
`parse` with radix requires `isIntegral!T` anyway.