### PR TITLE
Fix issue 17668 - assert failure regex(q"<[^]>")

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1304,6 +1304,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
             switch (op)
             {
             case Operator.Negate:
+                enforce(!stack.empty, "no operand for '^'");
                 stack.top = stack.top.inverted;
                 break;
             case Operator.Union:

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -1098,3 +1098,11 @@ alias Sequence(int B, int E) = staticIota!(B, E);
     willThrow([r"[a-\", r"123"], "invalid escape sequence");
     willThrow([r"\", r"123"], "invalid escape sequence");
 }
+
+// bugzilla 17668
+@safe unittest
+{
+    import std.algorithm.searching;
+    auto e = collectException!RegexException(regex(q"<[^]>"));
+    assert(e.msg.canFind("no operand for '^'"));
+}


### PR DESCRIPTION
Another mistake in charset parser code. 
It's rather baroque I wish we could use some parser combinators for it, should easily fit operator grammar.