### PR TITLE
Fixup 5591 - Shorten unittest

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1897,6 +1897,7 @@ $(CONSOLE
         assert(b1 == true && b2 == false);
     }
 
+    // Issue 12260 - Nice error of std.stdio.readf with newlines
     @system unittest
     {
         static import std.file;
@@ -1909,14 +1910,9 @@ $(CONSOLE
         f.readf("%s", &input);
 
         import std.conv : ConvException;
-        try
-        {
-            f.readf("%s", &input);
-        }
-        catch (ConvException e)
-        {
-            assert(e.msg == "Unexpected '\\n' when converting from type LockingTextReader to type int");
-        }
+        import std.exception : collectException;
+        assert(collectException!ConvException(f.readf("%s", &input)).msg ==
+            "Unexpected '\\n' when converting from type LockingTextReader to type int");
     }
 
 /**


### PR DESCRIPTION
As discussed in https://github.com/dlang/phobos/pull/5591/files#r127962554, using `collectException` is nicer as:
- less, more obvious code
- _ensures_ that an exception is thrown