### PR TITLE
Faster octal conversion

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -4121,25 +4121,23 @@ private T octal(T)(const string num)
 {
     assert(isOctalLiteral(num));
 
-    ulong pow = 1;
     T value = 0;
 
-    foreach_reverse (immutable pos; 0 .. num.length)
+    foreach (immutable s; num)
     {
-        char s = num[pos];
         if (s < '0' || s > '7') // we only care about digits; skip the rest
         // safe to skip - this is checked out in the assert so these
         // are just suffixes
             continue;
 
-        value += pow * (s - '0');
-        pow *= 8;
+        value *= 8;
+        value += s - '0';
     }
 
     return value;
 }
 
-@system unittest
+unittest
 {
     int a = octal!int("10");
     assert(a == 8);

--- a/std/conv.d
+++ b/std/conv.d
@@ -4123,7 +4123,7 @@ private T octal(T)(const string num)
 
     T value = 0;
 
-    foreach (immutable s; num)
+    foreach (const char s; num)
     {
         if (s < '0' || s > '7') // we only care about digits; skip the rest
         // safe to skip - this is checked out in the assert so these

--- a/std/conv.d
+++ b/std/conv.d
@@ -4137,7 +4137,7 @@ private T octal(T)(const string num)
     return value;
 }
 
-unittest
+@safe unittest
 {
     int a = octal!int("10");
     assert(a == 8);


### PR DESCRIPTION
An optimization of the conversion to octal.

I also removed an unnecessary `@system` tag on its unittest.

Test benchmark on my machine:
```
$ cat test_octal.d
import std.stdio;
import std.conv : to;
import std.datetime : benchmark;

int octal_new(const string s) {  // Quick re-write of the new way
    int res = 0;
    foreach(c; s) {
        if(c < '0' || c > '7') continue;
        res *= 8;
        res += c - '0';
    }
    return res;
}

int octal_old(const string num) { // Quick re-write of the old way
    int pow = 1;
    int value = 0;
    foreach_reverse (immutable pos; 0 .. num.length) {
        char s = num[pos];
        if(s < '0' || s > '7') continue;
        value += pow*(s - '0');
        pow *= 8;
    }
    return value;
}

int main() {
    auto ds = benchmark!(() => octal_new("1234567"), () => octal_old("1234567"))(10_000_000);
    real new_ns = to!real(ds[0].nsecs);
    real old_ns = to!real(ds[1].nsecs);
    writefln("New: %s nsecs avg.", new_ns/10_000_000);
    writefln("Old: %s nsecs avg.", old_ns/10_000_000);
    writefln("The new octal is on average %s%% faster.", 100*(old_ns/new_ns - 1));
    return 0;
}
$ rdmd test_octal.d
New: 34.0917 nsecs avg.
Old: 42.4773 nsecs avg.
The new octal is on average 24.5973% faster.
```