### PR TITLE
Make std.range.choose{Among}? @safe & ctfe-able

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1378,8 +1378,8 @@ private struct ChooseResult(R1, R2)
 
     private union
     {
-        R1 _r1;
-        R2 _r2;
+        R1 r1;
+        R2 r2;
     }
     private bool r1Chosen;
 
@@ -1387,9 +1387,9 @@ private struct ChooseResult(R1, R2)
             auto ref ExtraArgs extraArgs)
     {
         if (r.r1Chosen)
-            return foo(r._r1, extraArgs);
+            return foo(r.r1, extraArgs);
         else
-            return foo(r._r2, extraArgs);
+            return foo(r.r2, extraArgs);
     }
 
     this(bool r1Chosen, R1 r1, R2 r2)
@@ -1401,13 +1401,13 @@ private struct ChooseResult(R1, R2)
         this.r1Chosen = r1Chosen;
         if (r1Chosen)
         {
-            _r2 = R2.init;
-            emplace(&_r1, r1);
+            this.r2 = R2.init;
+            emplace(&this.r1, r1);
         }
         else
         {
-            _r1 = R1.init;
-            emplace(&_r2, r2);
+            this.r1 = R1.init;
+            emplace(&this.r2, r2);
         }
     }
 
@@ -1456,7 +1456,7 @@ private struct ChooseResult(R1, R2)
         }
 
     @property void front(T)(T v)
-    if (is(typeof({ _r1.front = v; _r2.front = v; })))
+    if (is(typeof({ r1.front = v; r2.front = v; })))
     {
         actOnChosen!((ref r, T v) { r.front = v; })(this, v);
     }
@@ -1487,7 +1487,7 @@ private struct ChooseResult(R1, R2)
             }
 
         @property void back(T)(T v)
-        if (is(typeof({ _r1.back = v; _r2.back = v; })))
+        if (is(typeof({ r1.back = v; r2.back = v; })))
         {
             actOnChosen!((ref r, T v) { r.back = v; })(this, v);
         }
@@ -1518,7 +1518,7 @@ private struct ChooseResult(R1, R2)
             }
 
         void opIndexAssign(T)(T v, size_t index)
-        if (is(typeof({ _r1[1] = v; _r2[1] = v; })))
+        if (is(typeof({ r1[1] = v; r2[1] = v; })))
         {
             return actOnChosen!((ref r, size_t index, T v) { r[index] = v; })
                 (this, index, v);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1364,177 +1364,202 @@ Params:
 
 Returns:
     A range type dependent on $(D R1) and $(D R2).
-
-Bugs:
-    $(BUGZILLA 14660)
  */
 auto choose(R1, R2)(bool condition, R1 r1, R2 r2)
 if (isInputRange!(Unqual!R1) && isInputRange!(Unqual!R2) &&
     !is(CommonType!(ElementType!(Unqual!R1), ElementType!(Unqual!R2)) == void))
 {
-    static struct Result
+    return ChooseResult!(R1, R2)(condition, r1, r2);
+}
+
+private struct ChooseResult(R1, R2)
+{
+    import std.algorithm.comparison : max;
+    import std.algorithm.internal : addressOf;
+    import std.traits : hasElaborateCopyConstructor, hasElaborateDestructor;
+
+    private union
     {
-        import std.algorithm.comparison : max;
-        import std.algorithm.internal : addressOf;
-        import std.traits : hasElaborateCopyConstructor, hasElaborateDestructor;
+        R1 _r1;
+        R2 _r2;
+    }
+    private bool r1Chosen;
 
-        private union
+    private static auto actOnChosen(alias foo, ExtraArgs ...)(ref ChooseResult r,
+            auto ref ExtraArgs extraArgs)
+    {
+        if (r.r1Chosen)
         {
-            void[max(R1.sizeof, R2.sizeof)] buffer = void;
-            void* forAlignmentOnly = void;
+            ref getR1() @trusted { return r._r1; }
+            return foo(getR1(), extraArgs);
         }
-        private bool condition;
-        private @property ref R1 r1()
-        {
-            assert(condition);
-            return *cast(R1*) buffer.ptr;
-        }
-        private @property ref R2 r2()
-        {
-            assert(!condition);
-            return *cast(R2*) buffer.ptr;
-        }
-
-        this(bool condition, R1 r1, R2 r2)
-        {
-            this.condition = condition;
-            import std.conv : emplace;
-            if (condition) emplace(addressOf(this.r1), r1);
-            else emplace(addressOf(this.r2), r2);
-        }
-
-        // Carefully defined postblit to postblit the appropriate range
-        static if (hasElaborateCopyConstructor!R1
-            || hasElaborateCopyConstructor!R2)
-        this(this)
-        {
-            if (condition)
-            {
-                static if (hasElaborateCopyConstructor!R1) r1.__postblit();
-            }
-            else
-            {
-                static if (hasElaborateCopyConstructor!R2) r2.__postblit();
-            }
-        }
-
-        static if (hasElaborateDestructor!R1 || hasElaborateDestructor!R2)
-        ~this()
-        {
-            if (condition) destroy(r1);
-            else destroy(r2);
-        }
-
-        static if (isInfinite!R1 && isInfinite!R2)
-            // Propagate infiniteness.
-            enum bool empty = false;
         else
-            @property bool empty()
-            {
-                return condition ? r1.empty : r2.empty;
-            }
-
-        @property auto ref front()
         {
-            return condition ? r1.front : r2.front;
+            ref getR2() @trusted { return r._r2; }
+            return foo(getR2(), extraArgs);
+        }
+    }
+
+    // have to do this in a constructor because otherwise
+    // the compiler thinks they're not initialised.
+    // Don't want to make the whole constructor @trusted
+    // because would hide @system code in R{1,2}.__ctor,
+    // hence this dummy constructor
+    private this(char dummy) @trusted
+    {
+        _r1 = R1.init;
+        _r2 = R2.init;
+    }
+
+    this(bool r1Chosen, R1 r1, R2 r2)
+    {
+        import std.conv : emplace;
+
+        this('\0');
+
+        // This should be the only place r1Chosen is every assigned
+        // independently
+        this.r1Chosen = r1Chosen;
+
+        if (r1Chosen)
+        {
+            auto r1p = &_r1;
+            emplace(r1p, r1);
+        }
+        else
+        {
+            auto r2p = &_r2;
+            emplace(r2p, r2);
+        }
+    }
+
+    // Carefully defined postblit to postblit the appropriate range
+    static if (hasElaborateCopyConstructor!R1
+        || hasElaborateCopyConstructor!R2)
+    this(this)
+    {
+        this.actOnChosen!((ref r) {
+                static if (hasElaborateCopyConstructor!(typeof(r))) r.__postblit();
+            });
+    }
+
+    static if (hasElaborateDestructor!R1 || hasElaborateDestructor!R2)
+    ~this()
+    {
+        actOnChosen!((ref r) => destroy(r))(this);
+    }
+
+    static if (isInfinite!R1 && isInfinite!R2)
+        // Propagate infiniteness.
+        enum bool empty = false;
+    else
+        @property bool empty()
+        {
+            return actOnChosen!(r => r.empty)(this);
         }
 
-        void popFront()
+    @property auto ref front()
+    {
+        static auto ref getFront(R)(ref R r) { return r.front; }
+        return actOnChosen!getFront(this);
+    }
+
+    void popFront()
+    {
+        return actOnChosen!((ref r) { r.popFront; })(this);
+    }
+
+    static if (isForwardRange!R1 && isForwardRange!R2)
+        @property auto save()
         {
-            return condition ? r1.popFront : r2.popFront;
+            auto result = this;
+            actOnChosen!((ref r) { r = r.save; })(result);
+            return result;
         }
 
-        static if (isForwardRange!R1 && isForwardRange!R2)
-            @property auto save()
-            {
-                auto result = this;
-                if (condition) r1 = r1.save;
-                else r2 = r2.save;
-                return result;
-            }
+    @property void front(T)(T v)
+    if (is(typeof({ _r1.front = v; _r2.front = v; })))
+    {
+        actOnChosen!((ref r, T v) { r.front = v; })(this, v);
+    }
 
-        @property void front(T)(T v)
-        if (is(typeof({ r1.front = v; r2.front = v; })))
+    static if (hasMobileElements!R1 && hasMobileElements!R2)
+        auto moveFront()
         {
-            if (condition) r1.front = v; else r2.front = v;
+            return actOnChosen!((ref r) => r.moveFront)(this);
+        }
+
+    static if (isBidirectionalRange!R1 && isBidirectionalRange!R2)
+    {
+        @property auto ref back()
+        {
+            static auto ref getBack(R)(ref R r) { return r.back; }
+            return actOnChosen!getBack(this);
+        }
+
+        void popBack()
+        {
+            actOnChosen!((ref r) { r.popBack; })(this);
         }
 
         static if (hasMobileElements!R1 && hasMobileElements!R2)
-            auto moveFront()
+            auto moveBack()
             {
-                return condition ? r1.moveFront : r2.moveFront;
+                return actOnChosen!((ref r) => r.moveBack)(this);
             }
 
-        static if (isBidirectionalRange!R1 && isBidirectionalRange!R2)
+        @property void back(T)(T v)
+        if (is(typeof({ _r1.back = v; _r2.back = v; })))
         {
-            @property auto ref back()
-            {
-                return condition ? r1.back : r2.back;
-            }
-
-            void popBack()
-            {
-                return condition ? r1.popBack : r2.popBack;
-            }
-
-            static if (hasMobileElements!R1 && hasMobileElements!R2)
-                auto moveBack()
-                {
-                    return condition ? r1.moveBack : r2.moveBack;
-                }
-
-            @property void back(T)(T v)
-            if (is(typeof({ r1.back = v; r2.back = v; })))
-            {
-                if (condition) r1.back = v; else r2.back = v;
-            }
+            actOnChosen!((ref r, T v) { r.back = v; })(this, v);
         }
-
-        static if (hasLength!R1 && hasLength!R2)
-        {
-            @property size_t length()
-            {
-                return condition ? r1.length : r2.length;
-            }
-            alias opDollar = length;
-        }
-
-        static if (isRandomAccessRange!R1 && isRandomAccessRange!R2)
-        {
-            auto ref opIndex(size_t index)
-            {
-                return condition ? r1[index] : r2[index];
-            }
-
-            static if (hasMobileElements!R1 && hasMobileElements!R2)
-                auto moveAt(size_t index)
-                {
-                    return condition ? r1.moveAt(index) : r2.moveAt(index);
-                }
-
-            void opIndexAssign(T)(T v, size_t index)
-            if (is(typeof({ r1[1] = v; r2[1] = v; })))
-            {
-                if (condition) r1[index] = v; else r2[index] = v;
-            }
-        }
-
-        // BUG: this should work for infinite ranges, too
-        static if (hasSlicing!R1 && hasSlicing!R2 &&
-                !isInfinite!R2 && !isInfinite!R2)
-            auto opSlice(size_t begin, size_t end)
-            {
-                auto result = this;
-                if (condition) result.r1 = result.r1[begin .. end];
-                else result.r2 = result.r2[begin .. end];
-                return result;
-            }
     }
-    return Result(condition, r1, r2);
+
+    static if (hasLength!R1 && hasLength!R2)
+    {
+        @property size_t length()
+        {
+            return actOnChosen!(r => r.length)(this);
+        }
+        alias opDollar = length;
+    }
+
+    static if (isRandomAccessRange!R1 && isRandomAccessRange!R2)
+    {
+        auto ref opIndex(size_t index)
+        {
+            static auto ref get(R)(ref R r, size_t index) { return r[index]; }
+            return actOnChosen!get(this, index);
+        }
+
+        static if (hasMobileElements!R1 && hasMobileElements!R2)
+            auto moveAt(size_t index)
+            {
+                return actOnChosen!((ref r, size_t index) => r.moveAt(index))
+                    (this, index);
+            }
+
+        void opIndexAssign(T)(T v, size_t index)
+        if (is(typeof({ _r1[1] = v; _r2[1] = v; })))
+        {
+            return actOnChosen!((ref r, size_t index, T v) { r[index] = v; })
+                (this, index, v);
+        }
+    }
+
+    static if (hasSlicing!R1 && hasSlicing!R2)
+        auto opSlice(size_t begin, size_t end)
+        {
+            auto result = this;
+            actOnChosen!((ref r, size_t begin, size_t end)
+                    { r = r[begin .. end]; })(result, begin, end);
+            return result;
+        }
 }
 
+
 ///
-@system unittest
+@safe nothrow pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -1590,70 +1615,78 @@ if (Ranges.length >= 2
 }
 
 ///
-@system unittest
+@safe nothrow pure unittest
 {
-    import std.algorithm.comparison : equal;
+    auto test()
+    {
+        import std.algorithm.comparison : equal;
 
-    int[] arr1 = [ 1, 2, 3, 4 ];
-    int[] arr2 = [ 5, 6 ];
-    int[] arr3 = [ 7 ];
+        int[] arr1 = [ 1, 2, 3, 4 ];
+        int[] arr2 = [ 5, 6 ];
+        int[] arr3 = [ 7 ];
 
-    {
-        auto s = chooseAmong(0, arr1, arr2, arr3);
-        auto t = s.save;
-        assert(s.length == 4);
-        assert(s[2] == 3);
-        s.popFront();
-        assert(equal(t, [1, 2, 3, 4][]));
+        {
+            auto s = chooseAmong(0, arr1, arr2, arr3);
+            auto t = s.save;
+            assert(s.length == 4);
+            assert(s[2] == 3);
+            s.popFront();
+            assert(equal(t, [1, 2, 3, 4][]));
+        }
+        {
+            auto s = chooseAmong(1, arr1, arr2, arr3);
+            assert(s.length == 2);
+            s.front = 8;
+            assert(equal(s, [8, 6][]));
+        }
+        {
+            auto s = chooseAmong(1, arr1, arr2, arr3);
+            assert(s.length == 2);
+            s[1] = 9;
+            assert(equal(s, [8, 9][]));
+        }
+        {
+            auto s = chooseAmong(1, arr2, arr1, arr3)[1 .. 3];
+            assert(s.length == 2);
+            assert(equal(s, [2, 3][]));
+        }
+        {
+            auto s = chooseAmong(0, arr1, arr2, arr3);
+            assert(s.length == 4);
+            assert(s.back == 4);
+            s.popBack();
+            s.back = 5;
+            assert(equal(s, [1, 2, 5][]));
+            s.back = 3;
+            assert(equal(s, [1, 2, 3][]));
+        }
+        {
+            uint[] foo = [1,2,3,4,5];
+            uint[] bar = [6,7,8,9,10];
+            auto c = chooseAmong(1,foo, bar);
+            assert(c[3] == 9);
+            c[3] = 42;
+            assert(c[3] == 42);
+            assert(c.moveFront() == 6);
+            assert(c.moveBack() == 10);
+            assert(c.moveAt(4) == 10);
+        }
+        {
+            import std.range : cycle;
+            auto s = chooseAmong(1, cycle(arr2), cycle(arr3));
+            assert(isInfinite!(typeof(s)));
+            assert(!s.empty);
+            assert(s[100] == 7);
+        }
+        return 0;
     }
-    {
-        auto s = chooseAmong(1, arr1, arr2, arr3);
-        assert(s.length == 2);
-        s.front = 8;
-        assert(equal(s, [8, 6][]));
-    }
-    {
-        auto s = chooseAmong(1, arr1, arr2, arr3);
-        assert(s.length == 2);
-        s[1] = 9;
-        assert(equal(s, [8, 9][]));
-    }
-    {
-        auto s = chooseAmong(1, arr2, arr1, arr3)[1 .. 3];
-        assert(s.length == 2);
-        assert(equal(s, [2, 3][]));
-    }
-    {
-        auto s = chooseAmong(0, arr1, arr2, arr3);
-        assert(s.length == 4);
-        assert(s.back == 4);
-        s.popBack();
-        s.back = 5;
-        assert(equal(s, [1, 2, 5][]));
-        s.back = 3;
-        assert(equal(s, [1, 2, 3][]));
-    }
-    {
-        uint[] foo = [1,2,3,4,5];
-        uint[] bar = [6,7,8,9,10];
-        auto c = chooseAmong(1,foo, bar);
-        assert(c[3] == 9);
-        c[3] = 42;
-        assert(c[3] == 42);
-        assert(c.moveFront() == 6);
-        assert(c.moveBack() == 10);
-        assert(c.moveAt(4) == 10);
-    }
-    {
-        import std.range : cycle;
-        auto s = chooseAmong(1, cycle(arr2), cycle(arr3));
-        assert(isInfinite!(typeof(s)));
-        assert(!s.empty);
-        assert(s[100] == 7);
-    }
+    // works at runtime
+    auto a = test();
+    // and at compile time
+    static b = test();
 }
 
-@system unittest
+@safe nothrow pure unittest
 {
     int[] a = [1, 2, 3];
     long[] b = [4, 5, 6];

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1685,8 +1685,8 @@ if (Ranges.length >= 2
         int[] r;
         ref front() @property { return r[0]; }
         ref back() @property { return r[$ - 1]; }
-        auto popFront() { r = r[1 .. $]; }
-        auto popBack() { r = r[0 .. $ - 1]; }
+        void popFront() { r = r[1 .. $]; }
+        void popBack() { r = r[0 .. $ - 1]; }
         auto empty() @property { return r.empty; }
         ref opIndex(size_t i) { return r[i]; }
         auto length() @property { return r.length; }
@@ -1699,7 +1699,7 @@ if (Ranges.length >= 2
     int[2] b = [6, 5];
     auto c = chooseAmong(0, RefAccessRange(a[]), RefAccessRange(b[]));
 
-    auto refFunc(ref int a, int target) { assert(a == target); }
+    void refFunc(ref int a, int target) { assert(a == target); }
 
     refFunc(c[2], 2);
     refFunc(c.front, 4);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1396,15 +1396,19 @@ private struct ChooseResult(R1, R2)
     {
         import std.conv : emplace;
 
-        _r1 = R1.init; // avoid uninitialised member errors
-
         // This should be the only place r1Chosen is ever assigned
         // independently
         this.r1Chosen = r1Chosen;
         if (r1Chosen)
+        {
+            _r2 = R2.init;
             emplace(&_r1, r1);
+        }
         else
+        {
+            _r1 = R1.init;
             emplace(&_r2, r2);
+        }
     }
 
     // Carefully defined postblit to postblit the appropriate range

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1598,7 +1598,7 @@ if (Ranges.length >= 2
 ///
 @safe nothrow pure @nogc unittest
 {
-    auto test() @safe nothrow pure @nogc
+    auto test()
     {
         import std.algorithm.comparison : equal;
 


### PR DESCRIPTION
also extracted the voldemort type to avoid enormous symbol names for chooseAmong.

The core idea:
* Use a `union` to allow `ctfe`
* Slightly abuse `@trusted` by relying on the constructor to be the only place that modifies `r1Chosen`, therefore allowing `@trusted` access to the correct member of the `union` from that point onwards.

Fixes https://issues.dlang.org/show_bug.cgi?id=14660