### PR TITLE
Don't use alias this in chunks implementation.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -227,7 +227,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 		cstring digest/sha_SSSE3 \
 		$(addprefix math/, biguintcore biguintnoasm biguintx86	\
 						   errorfunction gammafunction ) \
-		scopebuffer test/dummyrange \
+		scopebuffer test/dummyrange test/range \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
 	) \
 	typetuple \

--- a/std/internal/test/range.d
+++ b/std/internal/test/range.d
@@ -1,0 +1,25 @@
+/**
+For testing only.
+Contains tests related to member privacy that cannot be verified inside
+std.range itself.
+*/
+module std.internal.test.range;
+
+// Note: currently can't be @safe because RefCounted, which is used by chunks,
+// isn't.
+@system /*@safe*/ unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range : chunks;
+
+    struct R
+    {
+        int state = 0;
+        @property bool empty() { return state >= 5; }
+        @property int front() { return state; }
+        void popFront() { state++; }
+    }
+
+    auto r = R().chunks(3);
+    assert(r.equal!equal([[ 0, 1, 2 ], [ 3, 4 ]]));
+}

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7229,14 +7229,13 @@ if (isInputRange!Source)
         }
 
         private RefCounted!Impl impl;
-        alias impl this;
 
         private this(Source r, size_t chunkSize)
         {
             impl = RefCounted!Impl(r, r.empty ? 0 : chunkSize, chunkSize);
         }
 
-        @property bool empty() { return chunkSize == 0; }
+        @property bool empty() { return impl.chunkSize == 0; }
         @property Chunk front() return { return Chunk(impl); }
 
         void popFront()

--- a/win32.mak
+++ b/win32.mak
@@ -276,7 +276,8 @@ SRC_STD_INTERNAL= \
 	std\internal\unicode_grapheme.d \
 	std\internal\unicode_norm.d \
 	std\internal\scopebuffer.d \
-	std\internal\test\dummyrange.d
+	std\internal\test\dummyrange.d \
+	std\internal\test\range.d
 
 SRC_STD_INTERNAL_DIGEST= \
 	std\internal\digest\sha_SSSE3.d

--- a/win64.mak
+++ b/win64.mak
@@ -301,7 +301,8 @@ SRC_STD_INTERNAL= \
 	std\internal\unicode_grapheme.d \
 	std\internal\unicode_norm.d \
 	std\internal\scopebuffer.d \
-	std\internal\test\dummyrange.d
+	std\internal\test\dummyrange.d \
+	std\internal\test\range.d
 
 SRC_STD_INTERNAL_DIGEST= \
 	std\internal\digest\sha_SSSE3.d


### PR DESCRIPTION
Due to an oversight in PR #5624, an unnecessary `alias this` was left in the implementation of `Chunks`.  This causes an import visibility error when `Chunks` is instantiated from another module.  There is actually no need for this at all, since `empty` can just refer to `impl` directly.

I need some help with the unittest, though: the bug doesn't show up in a unittest in this module, obviously, because it only happens when `Chunks` is instantiated in another module. How to write a Phobos unittest in this case?? As in, where to put it?