### PR TITLE
Fix Issue 15096 - std.array.array cannot be instantiated for pointers to ranges

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -139,7 +139,7 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
     }
 }
 
-///
+/// ditto
 ForeachType!(PointerTarget!Range)[] array(Range)(Range r)
 if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range && !isInfinite!Range)
 {
@@ -173,7 +173,15 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
         void popFront() {}
     }
 
-    static assert(__traits(compiles, (new MyRange).array));
+    auto arr = (new MyRange).array;
+    assert(arr.empty);
+}
+
+@system pure nothrow unittest
+{
+    immutable int[] a = [1, 2, 3, 4];
+    auto b = (&a).array;
+    assert(b == a);
 }
 
 @system unittest

--- a/std/array.d
+++ b/std/array.d
@@ -140,6 +140,13 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
 }
 
 ///
+ForeachType!(PointerTarget!Range)[] array(Range)(Range r)
+if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range && !isInfinite!Range)
+{
+    return array(*r);
+}
+
+///
 @safe pure nothrow unittest
 {
     auto a = array([1, 2, 3, 4, 5][]);
@@ -155,6 +162,18 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
     }
     auto a = array([Foo(1), Foo(2), Foo(3), Foo(4), Foo(5)][]);
     assert(equal(a, [Foo(1), Foo(2), Foo(3), Foo(4), Foo(5)]));
+}
+
+@safe pure nothrow unittest
+{
+    struct MyRange
+    {
+        enum front = 123;
+        enum empty = true;
+        void popFront() {}
+    }
+
+    static assert(__traits(compiles, (new MyRange).array));
 }
 
 @system unittest


### PR DESCRIPTION
I added an overload for array which accepts pointers to iterable ranges and calls the existing overload with the value of the pointer.