### PR TITLE
std.array.overlap made ctfe:able and redocumented.

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -777,9 +777,6 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
     enum b3 = minimallyInitializedArray!(S3[][])(2, 2);
 }
 
-// overlap
-
-
 /++
 Returns the overlapping portion, if any, of two arrays. Unlike $(D
 equal), $(D overlap) only compares the pointers and lengths in the
@@ -788,23 +785,22 @@ overlapping slice, returns that slice. Otherwise, returns the null
 slice.
 +/
 
-auto overlap(T, U)(T[] a, U[] b) @trusted
+CommonType!(T[], U[]) overlap(T, U)(T[] a, U[] b) @trusted
 if (is(typeof(a.ptr < b.ptr) == bool))
 {
     import std.algorithm.comparison : min;
 
-    alias RetPtr = CommonType!(T*, U*);
-
+    auto end = min(a.ptr + a.length, b.ptr + b.length);
+    // CTFE requires pairing pointer comparisons, which forces a
+    // slightly inefficient implementation.
     if (a.ptr <= b.ptr && b.ptr < a.ptr + a.length)
     {
-        auto end = min(a.ptr + a.length, b.ptr + b.length);
-        return (cast(RetPtr) b.ptr)[0 .. end - b.ptr];
+        return b.ptr[0 .. end - b.ptr];
     }
 
     if (b.ptr <= a.ptr && a.ptr < b.ptr + b.length)
     {
-        auto end = min(a.ptr + a.length, b.ptr + b.length);
-        return (cast(RetPtr) a.ptr)[0 .. end - a.ptr];
+        return a.ptr[0 .. end - a.ptr];
     }
 
     return null;

--- a/std/array.d
+++ b/std/array.d
@@ -798,13 +798,13 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     if (a.ptr <= b.ptr && b.ptr < a.ptr + a.length)
     {
         auto end = min(a.ptr + a.length, b.ptr + b.length);
-        return (cast(RetPtr)b.ptr)[0 .. end - b.ptr];
+        return (cast(RetPtr) b.ptr)[0 .. end - b.ptr];
     }
 
     if (b.ptr <= a.ptr && a.ptr < b.ptr + b.length)
     {
         auto end = min(a.ptr + a.length, b.ptr + b.length);
-        return (cast(RetPtr)a.ptr)[0 .. end - a.ptr];
+        return (cast(RetPtr) a.ptr)[0 .. end - a.ptr];
     }
 
     return null;
@@ -822,21 +822,19 @@ if (is(typeof(a.ptr < b.ptr) == bool))
 
     static test()() @nogc
     {
-        auto a = "Yet another overuse of static"d;
-        auto b = a[4 .. 11];
+        auto a = "It's three o'clock"d;
+        auto b = a[5 .. 10];
         return b.overlap(a);
     }
 
     //works at compile-time
-    static assert(test == "another"d);
+    static assert(test == "three"d);
 }
 
 @safe nothrow unittest
 {
     static void test(L, R)(L l, R r)
     {
-        import std.stdio;
-
         assert(overlap(l, r) == [ 100, 12 ]);
 
         assert(overlap(l, l[0 .. 2]) is l[0 .. 2]);

--- a/std/array.d
+++ b/std/array.d
@@ -820,15 +820,6 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     // overlap disappears even though the content is the same
     assert(overlap(a, b).empty);
 
-    //Enums are just literals, so they will never overlap anything.
-    enum x1 = [3, 5, 6, 2, 5];
-    enum ctfeOverlap = overlap(x1, x1);
-    assert(ctfeOverlap == []);
-
-    auto x2 = x1[1 .. 4];
-    auto runtimeOverlap = overlap(x1, x2);
-    assert(runtimeOverlap == []);
-
     static test()() @nogc
     {
         auto a = "Yet another overuse of static"d;
@@ -840,14 +831,11 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     static assert(test == "another"d);
 }
 
-
-
-@safe /*nothrow*/ unittest
+@safe nothrow unittest
 {
     static void test(L, R)(L l, R r)
     {
         import std.stdio;
-        scope(failure) writeln("Types: L %s  R %s", L.stringof, R.stringof);
 
         assert(overlap(l, r) == [ 100, 12 ]);
 
@@ -869,8 +857,6 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     test(c, d);
     assert(overlap(c, d.idup).empty);
 }
-
-
 
 @safe pure nothrow unittest // bugzilla 9836
 {


### PR DESCRIPTION
I was going to add this function because it's so basic. But then noticed it already existed, just undocumented. The comment said that was because it's not CTFE:able so I made it so.

I also made an unittest to verify it works with @nogc.