### PR TITLE
Fix Issue 12496 (Step 3): __traits(parent, x) returns incorrect symbol

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -593,14 +593,18 @@ private template fqnSym(alias T)
     static assert(fqn!Barrier == "core.sync.barrier.Barrier");
 }
 
+version(unittest)
+{
+     struct TemplatedStruct()
+     {
+         enum foo = 0;
+     }
+     alias TemplatedStructAlias = TemplatedStruct;
+}
+
 @safe unittest
 {
-    struct TemplatedStruct()
-    {
-        enum foo = 0;
-    }
-    alias TemplatedStructAlias = TemplatedStruct;
-    assert("TemplatedStruct.foo" == fullyQualifiedName!(TemplatedStructAlias!().foo));
+    assert("std.traits.TemplatedStruct!().foo" == fullyQualifiedName!(TemplatedStructAlias!().foo));
 }
 
 private template fqnType(T,


### PR DESCRIPTION
This is the 3rd of 3 pull requests to fix issue 12496.  They must be done in order to ensure the test suite is green with each step.

Step 1: https://github.com/dlang/phobos/pull/5709 - Deletes a unit test in `std.traits` which I believe is wrong and is preventing Step 2 from passing its test suite.
Step 2: https://github.com/dlang/dmd/pull/7097 - The actual fix for issue 12496.
Step 3: https://github.com/dlang/phobos/pull/5704 - (This PR) Repairs the unittest that was deleted in Step 1 so it properly tests for correct behavior.  This should pass the test suite after Step 2 is pulled.
