### PR TITLE
fix issue 16512 - Nullify the argument passed to allocator.dispose

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -60,7 +60,7 @@ label_var_same_name_check="enabled"
 ; Checks for lines longer than 120 characters
 long_line_check="enabled"
 ; Checks for assignment to auto-ref function parameters
-auto_ref_assignment_check="enabled"
+auto_ref_assignment_check="disabled"
 ; Checks for incorrect infinite range definitions
 incorrect_infinite_range_check="enabled"
 ; Checks for asserts that are always true

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1738,7 +1738,8 @@ void dispose(A, T)(auto ref A alloc, auto ref T* p)
         destroy(*p);
     }
     alloc.deallocate((cast(void*) p)[0 .. T.sizeof]);
-    p = null;
+    static if (__traits(isRef, p))
+        p = null;
 }
 
 /// Ditto
@@ -1761,7 +1762,8 @@ if (is(T == class) || is(T == interface))
     auto support = (cast(void*) ob)[0 .. typeid(ob).initializer.length];
     destroy(p);
     alloc.deallocate(support);
-    p = null;
+    static if (__traits(isRef, p))
+        p = null;
 }
 
 /// Ditto
@@ -1775,7 +1777,8 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
         }
     }
     alloc.deallocate(array);
-    array = null;
+    static if (__traits(isRef, array))
+        array = null;
 }
 
 @system unittest
@@ -1919,7 +1922,8 @@ void disposeMultidimensionalArray(T, Allocator)(auto ref Allocator alloc, auto r
     }
 
     dispose(alloc, array);
-    array = null;
+    static if (__traits(isRef, array))
+        array = null;
 }
 
 ///

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1765,7 +1765,7 @@ if (is(T == class) || is(T == interface))
 }
 
 /// Ditto
-void dispose(A, T)(auto ref A alloc, T[] array)
+void dispose(A, T)(auto ref A alloc, auto ref T[] array)
 {
     static if (hasElaborateDestructor!(typeof(array[0])))
     {
@@ -1775,6 +1775,7 @@ void dispose(A, T)(auto ref A alloc, T[] array)
         }
     }
     alloc.deallocate(array);
+    array = null;
 }
 
 @system unittest
@@ -1830,6 +1831,10 @@ void dispose(A, T)(auto ref A alloc, T[] array)
     uint* u = Mallocator.instance.make!uint(0);
     Mallocator.instance.dispose((){return u;}());
     assert(u !is null);
+
+    uint[] ua = Mallocator.instance.makeArray!uint([0,1,2]);
+    Mallocator.instance.dispose(ua);
+    assert(ua is null);
 }
 
 @system unittest //bugzilla 15721
@@ -1905,7 +1910,7 @@ T = element type of an element of the multidimensional array
 alloc = the allocator used for getting memory
 array = the multidimensional array that is to be deallocated
 */
-void disposeMultidimensionalArray(T, Allocator)(auto ref Allocator alloc, T[] array)
+void disposeMultidimensionalArray(T, Allocator)(auto ref Allocator alloc, auto ref T[] array)
 {
     static if (isArray!T)
     {
@@ -1914,6 +1919,7 @@ void disposeMultidimensionalArray(T, Allocator)(auto ref Allocator alloc, T[] ar
     }
 
     dispose(alloc, array);
+    array = null;
 }
 
 ///


### PR DESCRIPTION
The parameter must be passed as `ref` (when possible), otherwise this has no effect. Statically checking if the parameter is `ref` would be possible but it is pointless because the operation that's added is super fast (usually `xor reg,reg`) so we can save a bit of compile-time complexity.