### PR TITLE
Fix Issue 12496 (Step 1): __traits(parent, x) returns incorrect symbol

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -593,16 +593,6 @@ private template fqnSym(alias T)
     static assert(fqn!Barrier == "core.sync.barrier.Barrier");
 }
 
-@safe unittest
-{
-    struct TemplatedStruct()
-    {
-        enum foo = 0;
-    }
-    alias TemplatedStructAlias = TemplatedStruct;
-    assert("TemplatedStruct.foo" == fullyQualifiedName!(TemplatedStructAlias!().foo));
-}
-
 private template fqnType(T,
     bool alreadyConst, bool alreadyImmutable, bool alreadyShared, bool alreadyInout)
 {


### PR DESCRIPTION
This is the first of 3 pull requests to fix issue 12496.  They must be done in order to ensure the test suite is green with each step.

Step 1 (This pull request):
This pull request deletes a unit test in `std.traits` which I believe is wrong and is preventing Step 2 from passing its test suite. 

```D
@safe unittest
{
    struct TemplatedStruct()
    {
        enum foo = 0;
    }
    alias TemplatedStructAlias = TemplatedStruct;
    assert("TemplatedStruct.foo" == fullyQualifiedName!(TemplatedStructAlias!().foo));
}
```
I don't think `TemplatedStruct.foo` is the fully qualified name because it doesn't include the module that this struct is in.  https://github.com/dlang/dmd/pull/7097 reveals this error because `fullyQualifiedName!(TemplatedStructAlias!().foo)` evaluates to `std.traits.unittest_xxx.TemplatedStruct.foo`, which is fully qualified.

Step 2: https://github.com/dlang/dmd/pull/7097 - The actual fix for issue 12496.  This DMD PR will not pass its test suite until Step 1 (this PR) is pulled.
Step 3: https://github.com/dlang/phobos/pull/5704 - Repairs the unittest that was deleted in Step 1 (this PR) so it properly tests for correct behavior.
