### PR TITLE
Fix Issue 8388 - std.traits.MemberFunctionsTuple doesn't work with constructors or destructors

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4212,8 +4212,11 @@ template MemberFunctionsTuple(C, string name)
                 alias CollectOverloads = AliasSeq!(); // no overloads in this hierarchy
         }
 
-        // duplicates in this tuple will be removed by shrink()
-        alias overloads = CollectOverloads!C;
+        static if (name == "__ctor" || name == "__dtor")
+            alias overloads = AliasSeq!(__traits(getOverloads, C, name));
+        else
+            // duplicates in this tuple will be removed by shrink()
+            alias overloads = CollectOverloads!C;
 
         // shrinkOne!args[0]    = the most derived one in the covariant siblings of target
         // shrinkOne!args[1..$] = non-covariant others
@@ -4309,6 +4312,35 @@ template MemberFunctionsTuple(C, string name)
     alias bfs = AliasSeq!(__traits(getOverloads, B, "f"));
     assert(__traits(isSame, fs[0], bfs[0]) || __traits(isSame, fs[0], bfs[1]));
     assert(__traits(isSame, fs[1], bfs[0]) || __traits(isSame, fs[1], bfs[1]));
+}
+
+@safe unittest // Issue 8388
+{
+    class C
+    {
+        this() {}
+        this(int i) {}
+        this(int i, float j) {}
+        this(string s) {}
+        static this() {}
+
+        ~this() {}
+    }
+
+    class D : C
+    {
+        this() {}
+        ~this() {}
+    }
+
+    alias test_ctor = MemberFunctionsTuple!(C, "__ctor");
+    assert(test_ctor.length == 4);
+    alias test_dtor = MemberFunctionsTuple!(C, "__dtor");
+    assert(test_dtor.length == 1);
+    alias test2_ctor = MemberFunctionsTuple!(D, "__ctor");
+    assert(test2_ctor.length == 1);
+    alias test2_dtor = MemberFunctionsTuple!(D, "__dtor");
+    assert(test2_dtor.length == 1);
 }
 
 @safe unittest


### PR DESCRIPTION
The template MemberFunctionsTuple calls getVirtualFunctions in order to avoid static functions, but it seems that the constructor and destructor are not grabbed (probably because those are not virtual?). In order to fix the issue I added a static if which tests if the name of the function called for is `__ctor` or `__dtor`; if that is the case, then the getOverloads function is called which correctly grabs all the ctor and dtor overloads.