### PR TITLE
Fix Issue 4582 - distinct field names constraint for std.typecons.Tuple

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -447,16 +447,18 @@ private template sharedToString(alias field)
     alias sharedToString = field;
 }
 
-private bool distinctFieldNames(T...)()
+private enum bool distinctFieldNames(names...) = __traits(compiles,
 {
-    enum int tlen = T.length;
-    static foreach (i1; 0 .. tlen)
-        static if (is(typeof(T[i1]) : string))
-            static foreach (i2; 0 .. tlen)
-                static if (i1 != i2 && is(typeof(T[i2]) : string))
-                    if (T[i1] == T[i2])
-                        return false;
-    return true;
+    static foreach (name; names)
+        static if (is(typeof(name) : string))
+            mixin("enum int" ~ name ~ " = 0;");
+});
+
+@safe unittest
+{
+    static assert(!distinctFieldNames!(string, "abc", string, "abc"));
+    static assert(distinctFieldNames!(string, "abc", int, "abd"));
+    static assert(!distinctFieldNames!(int, "abc", string, "abd", int, "abc"));
 }
 
 /**
@@ -478,7 +480,7 @@ Params:
     Specs = A list of types (and optionally, member names) that the `Tuple` contains.
 */
 template Tuple(Specs...)
-if (distinctFieldNames!(Specs)())
+if (distinctFieldNames!(Specs))
 {
     import std.meta : staticMap;
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -447,6 +447,18 @@ private template sharedToString(alias field)
     alias sharedToString = field;
 }
 
+private bool distinctFieldNames(T...)()
+{
+    enum int tlen = T.length;
+    static foreach (i1; 0 .. tlen)
+        static if (is(typeof(T[i1]) : string))
+            static foreach (i2; 0 .. tlen)
+                static if (i1 != i2 && is(typeof(T[i2]) : string))
+                    if (T[i1] == T[i2])
+                        return false;
+    return true;
+}
+
 /**
 _Tuple of values, for example $(D Tuple!(int, string)) is a record that
 stores an $(D int) and a $(D string). $(D Tuple) can be used to bundle
@@ -466,6 +478,7 @@ Params:
     Specs = A list of types (and optionally, member names) that the `Tuple` contains.
 */
 template Tuple(Specs...)
+if (distinctFieldNames!(Specs)())
 {
     import std.meta : staticMap;
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1314,6 +1314,13 @@ if (distinctFieldNames!(Specs)())
     assert(!is(typeof(point1) == typeof(point2)));
 }
 
+@safe unittest
+{
+    // Bugzilla 4582
+    static assert(!__traits(compiles, Tuple!(string, "id", int, "id")));
+    static assert(!__traits(compiles, Tuple!(string, "str", int, "i", string, "str", float)));
+}
+
 /**
     Creates a copy of a $(LREF Tuple) with its fields in _reverse order.
 


### PR DESCRIPTION
I also did some testing and it seems that if Tuple has a list of types longer that 500 you get a recursive expansion error due to the fact that dmd does not support to expand more than 500 times [1]. Accordingly I did some measurements with and without the distincFieldNames constraints and it seems that the performance is not affected by this diff. The worst time without this patch was 3,263s and with patch 3,347s. I think that this is a negligible difference considering that the error message will be very helpful this way. Thanks to bearophile_hugs for his solution which is basically copy-pasted.  

[1] https://github.com/dlang/dmd/blob/master/src/ddmd/dtemplate.d#L7438