### PR TITLE
Change AliasSeq(0, ...) uses of foreach to static foreach

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -835,8 +835,8 @@ if (!isImplicitlyConvertible!(S, T) &&
     class C : B, I, J {}
     class D : I {}
 
-    foreach (m1; AliasSeq!(0,1,2,3,4)) // enumerate modifiers
-    foreach (m2; AliasSeq!(0,1,2,3,4)) // ditto
+    static foreach (m1; 0 .. 5) // enumerate modifiers
+    static foreach (m2; 0 .. 5) // ditto
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         alias srcmod = AddModifier!m1;
         alias tgtmod = AddModifier!m2;

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -9952,26 +9952,16 @@ private int cmpTimeUnitsCTFE(string lhs, string rhs) @safe pure nothrow @nogc
 
 @safe unittest
 {
-    import std.format : format;
-    import std.meta : AliasSeq;
-
-    static string genTest(size_t index)
+    static foreach (i; 0 .. timeStrings.length)
     {
-        auto currUnits = timeStrings[index];
-        auto test = format(`assert(CmpTimeUnits!("%s", "%s") == 0);`, currUnits, currUnits);
+        static assert(CmpTimeUnits!(timeStrings[i], timeStrings[i]) == 0);
 
-        foreach (units; timeStrings[index + 1 .. $])
-            test ~= format(`assert(CmpTimeUnits!("%s", "%s") == -1);`, currUnits, units);
+        static foreach (next; timeStrings[i + 1 .. $])
+            static assert(CmpTimeUnits!(timeStrings[i], next) == -1);
 
-        foreach (units; timeStrings[0 .. index])
-            test ~= format(`assert(CmpTimeUnits!("%s", "%s") == 1);`, currUnits, units);
-
-        return test;
+        static foreach (prev; timeStrings[0 .. i])
+            static assert(CmpTimeUnits!(timeStrings[i], prev) == 1);
     }
-
-    static assert(timeStrings.length == 10);
-    foreach (n; AliasSeq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
-        mixin(genTest(n));
 }
 
 

--- a/std/math.d
+++ b/std/math.d
@@ -8264,14 +8264,14 @@ if (isNumeric!X)
     {
         immutable min_sub = X.min_normal * X.epsilon;
 
-        foreach (x; AliasSeq!(smallP2, min_sub, X.min_normal, .25L, 0.5L, 1.0L,
-                              2.0L, 8.0L, pow(2.0L, X.max_exp - 1), bigP2))
+        foreach (x; [smallP2, min_sub, X.min_normal, .25L, 0.5L, 1.0L,
+                              2.0L, 8.0L, pow(2.0L, X.max_exp - 1), bigP2])
         {
             assert( isPowerOf2(cast(X) x));
             assert(!isPowerOf2(cast(X)-x));
         }
 
-        foreach (x; AliasSeq!(0.0L, 3 * min_sub, smallP7, 0.1L, 1337.0L, bigP7, X.max, real.nan, real.infinity))
+        foreach (x; [0.0L, 3 * min_sub, smallP7, 0.1L, 1337.0L, bigP7, X.max, real.nan, real.infinity])
         {
             assert(!isPowerOf2(cast(X) x));
             assert(!isPowerOf2(cast(X)-x));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7051,7 +7051,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
             byte[size] arr;
             alignmentTest();
         }
-        foreach (i; AliasSeq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        static foreach (i; 0 .. 11)
             test!i();
     }
 }

--- a/std/utf.d
+++ b/std/utf.d
@@ -630,7 +630,7 @@ if (is(S : const char[]) ||
 
     if (index >= 4) //single verification for most common case
     {
-        foreach (i; AliasSeq!(2, 3, 4))
+        static foreach (i; 2 .. 5)
         {
             if ((str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;
@@ -638,7 +638,7 @@ if (is(S : const char[]) ||
     }
     else
     {
-        foreach (i; AliasSeq!(2, 3))
+        static foreach (i; 2 .. 4)
         {
             if (index >= i && (str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;


### PR DESCRIPTION
I started to have a quick look at introducing more `static foreach` at Phobos. 
Sadly even the naive idea to mark all `foreach` loops which definitely are at Compile-Time - e.g. with `AliasSeq` doesn't work:

```d
sed -E "s/foreach(.*)AliasSeq/static foreach\1AliasSeq/" -i **/*.d
```

or in simpler words with a simplified example from Phobos (most of the uses of `foreach` + `AliasSeq` are like this):

```
import std.stdio, std.meta;
void main(string[] args)
{
    foreach (S; AliasSeq!(string, wstring, dstring))
    {
        auto s = S.stringof;
        writeln(s);
    }
}
```
https://run.dlang.io/gist/6ae32becc7ffaa1296a1a4752cebc294?compiler=dmd

And now with `static foreach` this fails due to the symbol being in the outer scope:

```
import std.stdio, std.meta;
void main(string[] args)
{
    static foreach (S; AliasSeq!(string, wstring, dstring))
    {
        auto s = S.stringof; // Error: declaration foo.main.s is already defined
        writeln(s);
    }
}
```

FWIW [Local Declarations](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1010.md#local-declarations) would solve this and FYI @tgehr mentioned that [he has a working implementation of `__local` already](http://forum.dlang.org/post/ooo9kt$1dnf$1@digitalmars.com).