### PR TITLE
ddoc, add missing isSIMDVector to the index trait

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -99,6 +99,7 @@
  *           $(LREF isPointer)
  *           $(LREF isScalarType)
  *           $(LREF isSigned)
+ *           $(LREF isSIMDVector)
  *           $(LREF isSomeChar)
  *           $(LREF isSomeString)
  *           $(LREF isStaticArray)


### PR DESCRIPTION
The trait misses from the ddoc index.