### PR TITLE
fix issue 6895 - isCovariantWith doesn't work for function pointer and delegate

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4869,7 +4869,9 @@ Determines whether the function type $(D F) is covariant with $(D G), i.e.,
 functions of the type $(D F) can override ones of the type $(D G).
  */
 template isCovariantWith(F, G)
-    if (is(F == function) && is(G == function))
+    if ((is(F == function) && is(G == function)) ||
+        (is(F == delegate) && is(G == delegate)) ||
+        (isFunctionPointer!F && isFunctionPointer!G))
 {
     static if (is(F : G))
         enum isCovariantWith = true;
@@ -5055,6 +5057,29 @@ template isCovariantWith(F, G)
     }
     static assert( isCovariantWith!(DerivF.test1, BaseF.test1));
     static assert( isCovariantWith!(DerivF.test2, BaseF.test2));
+}
+
+@safe unittest
+{
+    interface I     {}
+    interface J : I {}
+    interface K     {}
+    J function() derived_function;
+    I function() base_function;
+    K function() invalid_function;
+    J delegate() derived_delegate;
+    I delegate() base_delegate;
+    K delegate() invalid_delegate;
+
+    static assert(isCovariantWith!(typeof(derived_function), typeof(derived_function)));
+    static assert(isCovariantWith!(typeof(base_delegate), typeof(base_delegate)));
+
+    static assert(isCovariantWith!(typeof(derived_function), typeof(base_function)));
+    static assert(isCovariantWith!(typeof(*derived_function), typeof(*base_function)));
+    static assert(isCovariantWith!(typeof(derived_delegate), typeof(base_delegate)));
+
+    static assert(!isCovariantWith!(typeof(invalid_function), typeof(base_function)));
+    static assert(!isCovariantWith!(typeof(invalid_delegate), typeof(base_delegate)));
 }
 
 


### PR DESCRIPTION
This is mostly a copy and paste of a patch sent to the bug tracker and I'm not 100% convinced by the validity of the issue.