### PR TITLE
Fix Issue 17832 - std.random.choice cannot be used with other random generators

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -2018,13 +2018,19 @@ Returns:
     a copy.
  */
 auto ref choice(Range, RandomGen = Random)(auto ref Range range,
-                                           ref RandomGen urng = rndGen)
+                                           ref RandomGen urng)
 if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
 {
     assert(range.length > 0,
            __PRETTY_FUNCTION__ ~ ": invalid Range supplied. Range cannot be empty");
 
     return range[uniform(size_t(0), $, urng)];
+}
+
+/// ditto
+auto ref choice(Range)(auto ref Range range)
+{
+    return choice(range, rndGen);
 }
 
 ///
@@ -2041,6 +2047,10 @@ if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
     auto urng = Random(unpredictableSeed);
     elem = choice(array, urng);
 
+    assert(canFind(array, elem),
+           "Choice did not return a valid element from the given Range");
+    auto rng2 = Xorshift();
+    elem = choice(array, rng2);
     assert(canFind(array, elem),
            "Choice did not return a valid element from the given Range");
 }


### PR DESCRIPTION
Random choice default argument was deciding the type of the
template. I'm not sure if this is a deeper bug, but it can easily be
fixed with this patch which simply overloads the function.
Also added a unittest which would have failed under the old code.