### PR TITLE
Upgrade D-Scanner: Compile D-Scanner with -fPIC

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -69,7 +69,7 @@ ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 DUB=dub
 TOOLS_DIR=../tools
-DSCANNER_HASH=30f7dd9662f639f1d06fdd4e3714a400d9da2943
+DSCANNER_HASH=285ef162f024cbd305d587e9e0fcfb2292ea93ce
 DSCANNER_DIR=../dscanner-$(DSCANNER_HASH)
 
 # Documentation-related stuff


### PR DESCRIPTION
tl:dr: yet another step to make the dev build work smoother with `-fPIC` - we are close to the finish line :)

[By default, DMD passes `-fPIC` to the linker](https://github.com/dlang/dmd/blob/master/ini/linux/bin64/dmd.conf), but sadly the development build of DMD uses a different config and thus doesn't pass `-fPIC` by default. The PR to change this doesn't seem to move into any direction: https://github.com/dlang/dmd/pull/7002
However, thanks to https://github.com/dlang/druntime/pull/1880 and https://github.com/dlang/phobos/pull/5586, which are both in `master` now, the development build of `libphobos2.a` is compiled with `-fPIC` :tada:  and we can thus compile D-Scanner with `-fPIC` as well.

Regarding PRs at D-Scanner:
- master: https://github.com/dlang-community/D-Scanner/pull/523
- phobos branch: https://github.com/dlang-community/D-Scanner/pull/524 (the "frozen" version of D-Scanner for Phobos)