### PR TITLE
Issue 17385: Update findSplit doc so example compiles.

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2791,9 +2791,9 @@ shown in the following example.
 
 Example:
 ---
-if (const split = haystack.findSplit(needle))
+if (auto split = haystack.findSplit(needle))
 {
-     doSomethingWithSplit(split);
+    doSomethingWithSplit(split);
 }
 ---
  */


### PR DESCRIPTION
As described in [17835](https://issues.dlang.org/show_bug.cgi?id=17835), the code example does not compile. Investigation by Duncan Patterson indicated changing the code to support the use of 'const' shown in the example will be problematic. Instead changing the documentation to a form that works.