### PR TITLE
Make statTimeToStdTime public

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1826,7 +1826,7 @@ else version(Posix)
         return statTimeToStdTime!'c'(statbuf);
     }
 
-    unittest
+    @safe unittest
     {
         stat_t statbuf;
         // check that both lvalues and rvalues work

--- a/std/file.d
+++ b/std/file.d
@@ -1180,7 +1180,7 @@ if (isConvertibleToString!R)
 
 // Reads a time field from a stat_t with full precision.
 version(Posix)
-private SysTime statTimeToStdTime(char which)(ref stat_t statbuf)
+private SysTime statTimeToStdTime(char which)(ref const stat_t statbuf)
 {
     auto unixTime = mixin(`statbuf.st_` ~ which ~ `time`);
     long stdTime = unixTimeToStdTime(unixTime);
@@ -1793,7 +1793,7 @@ version(StdDdoc)
      Params:
         statbuf = stat_t retrieved from file.
      +/
-    SysTime timeLastModified(ref stat_t statbuf) pure nothrow;
+    SysTime timeLastModified()(auto ref stat_t statbuf) pure nothrow {assert(false);}
     /++
      $(BLUE This function is Posix-Only.)
 
@@ -1801,7 +1801,7 @@ version(StdDdoc)
      Params:
         statbuf = stat_t retrieved from file.
      +/
-    SysTime timeLastAccessed(ref stat_t statbuf) pure nothrow;
+    SysTime timeLastAccessed()(auto ref stat_t statbuf) pure nothrow {assert(false);}
     /++
      $(BLUE This function is Posix-Only.)
 
@@ -1809,22 +1809,29 @@ version(StdDdoc)
      Params:
         statbuf = stat_t retrieved from file.
      +/
-    SysTime timeStatusChanged(ref stat_t statbuf) pure nothrow;
+    SysTime timeStatusChanged()(auto ref stat_t statbuf) pure nothrow {assert(false);}
 }
-else
-version(Posix)
+else version(Posix)
 {
-    SysTime timeLastModified(ref stat_t statbuf) pure nothrow
+    SysTime timeLastModified()(auto ref stat_t statbuf) pure nothrow
     {
         return statTimeToStdTime!'m'(statbuf);
     }
-    SysTime timeLastAccessed(ref stat_t statbuf) pure nothrow
+    SysTime timeLastAccessed()(auto ref stat_t statbuf) pure nothrow
     {
         return statTimeToStdTime!'a'(statbuf);
     }
-    SysTime timeStatusChanged(ref stat_t statbuf) pure nothrow
+    SysTime timeStatusChanged()(auto ref stat_t statbuf) pure nothrow
     {
         return statTimeToStdTime!'c'(statbuf);
+    }
+
+    unittest
+    {
+        stat_t statbuf;
+        // check that both lvalues and rvalues work
+        timeLastAccessed(statbuf);
+        timeLastAccessed(stat_t.init);
     }
 }
 

--- a/std/file.d
+++ b/std/file.d
@@ -54,6 +54,8 @@ $(TR $(TD Timestamp) $(TD
           $(LREF getTimesWin)
           $(LREF setTimes)
           $(LREF timeLastModified)
+          $(LREF timeLastAccessed)
+          $(LREF timeStatusChanged)
 ))
 $(TR $(TD Other) $(TD
           $(LREF DirEntry)
@@ -1780,6 +1782,50 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R))
     assert(target.timeLastModified(SysTime.min) < source.timeLastModified);
     target.write(".");
     assert(target.timeLastModified(SysTime.min) >= source.timeLastModified);
+}
+
+version(StdDdoc)
+{
+    /++
+     $(BLUE This function is Posix-Only.)
+
+     Returns the time that the given file was last modified.
+     Params:
+        statbuf = stat_t retrieved from file.
+     +/
+    SysTime timeLastModified(ref stat_t statbuf) pure nothrow;
+    /++
+     $(BLUE This function is Posix-Only.)
+
+     Returns the time that the given file was last accessed.
+     Params:
+        statbuf = stat_t retrieved from file.
+     +/
+    SysTime timeLastAccessed(ref stat_t statbuf) pure nothrow;
+    /++
+     $(BLUE This function is Posix-Only.)
+
+     Returns the time that the given file was last changed.
+     Params:
+        statbuf = stat_t retrieved from file.
+     +/
+    SysTime timeStatusChanged(ref stat_t statbuf) pure nothrow;
+}
+else
+version(Posix)
+{
+    SysTime timeLastModified(ref stat_t statbuf) pure nothrow
+    {
+        return statTimeToStdTime!'m'(statbuf);
+    }
+    SysTime timeLastAccessed(ref stat_t statbuf) pure nothrow
+    {
+        return statTimeToStdTime!'a'(statbuf);
+    }
+    SysTime timeStatusChanged(ref stat_t statbuf) pure nothrow
+    {
+        return statTimeToStdTime!'c'(statbuf);
+    }
 }
 
 @safe unittest


### PR DESCRIPTION
That might be useful for someone who's working with stat structs and wants to avoid a call of std.file functions like getTimes which accept only filenames and have to call stat function internally again.

Note: I could not figure out why statTimeToStdTime does not appear in generated docs though I added doc comment and added the function to Timestamp category.