### PR TITLE
Small clean-ups of architecture-specific code in FloatingPointControl

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4946,34 +4946,25 @@ struct FloatingPointControl
             roundToZero /// ditto
         }
     }
-    else version(ARM)
+    else version (CRuntime_Microsoft)
     {
-        enum : RoundingMode
-        {
-            roundToNearest = 0x000000,
-            roundDown      = 0x800000,
-            roundUp        = 0x400000,
-            roundToZero    = 0xC00000
-        }
-    }
-    else version(PPC_Any)
-    {
-        enum : RoundingMode
-        {
-            roundToNearest = 0x00000000,
-            roundDown      = 0x00000003,
-            roundUp        = 0x00000002,
-            roundToZero    = 0x00000001
-        }
-    }
-    else
-    {
+        // Microsoft uses hardware-incompatible custom constants in fenv.h (core.stdc.fenv).
         enum : RoundingMode
         {
             roundToNearest = 0x0000,
             roundDown      = 0x0400,
             roundUp        = 0x0800,
             roundToZero    = 0x0C00
+        }
+    }
+    else
+    {
+        enum : RoundingMode
+        {
+            roundToNearest = core.stdc.fenv.FE_TONEAREST,
+            roundDown      = core.stdc.fenv.FE_DOWNWARD,
+            roundUp        = core.stdc.fenv.FE_UPWARD,
+            roundToZero    = core.stdc.fenv.FE_TOWARDZERO,
         }
     }
 

--- a/std/math.d
+++ b/std/math.d
@@ -5213,17 +5213,13 @@ private:
 
                 /* In the FPU control register, rounding mode is in bits 10 and
                 11. In MXCSR it's in bits 13 and 14. */
-                enum ROUNDING_MASK_SSE = ROUNDING_MASK << 3;
-                immutable newRoundingModeSSE = (newState & ROUNDING_MASK) << 3;
-                mxcsr &= ~ROUNDING_MASK_SSE; // delete old rounding mode
-                mxcsr |= newRoundingModeSSE; // write new rounding mode
+                mxcsr &= ~(ROUNDING_MASK << 3);             // delete old rounding mode
+                mxcsr |= (newState & ROUNDING_MASK) << 3;   // write new rounding mode
 
                 /* In the FPU control register, masks are bits 0 through 5.
                 In MXCSR they're 7 through 12. */
-                enum EXCEPTION_MASK_SSE = allExceptions << 7;
-                immutable newExceptionMasks = (newState & allExceptions) << 7;
-                mxcsr &= ~EXCEPTION_MASK_SSE; // delete old masks
-                mxcsr |= newExceptionMasks; // write new exception masks
+                mxcsr &= ~(allExceptions << 7);            // delete old masks
+                mxcsr |= (newState & allExceptions) << 7;  // write new exception masks
 
                 asm nothrow @nogc { ldmxcsr mxcsr; }
             }

--- a/std/math.d
+++ b/std/math.d
@@ -5041,7 +5041,7 @@ struct FloatingPointControl
                                  | inexactException,
         }
     }
-    else
+    else version (X86_Any)
     {
         enum : ExceptionMask
         {
@@ -5057,6 +5057,8 @@ struct FloatingPointControl
                                  | inexactException | subnormalException,
         }
     }
+    else
+        static assert(false, "Not implemented for this architecture");
 
 public:
     /// Returns: true if the current FPU supports exception trapping

--- a/std/math.d
+++ b/std/math.d
@@ -5135,10 +5135,12 @@ private:
     {
         alias ControlState = uint;
     }
-    else
+    else version (X86_Any)
     {
         alias ControlState = ushort;
     }
+    else
+        static assert(false, "Not implemented for this architecture");
 
     void initialize() @nogc
     {

--- a/std/math.d
+++ b/std/math.d
@@ -5079,7 +5079,7 @@ public:
             return result;
         }
         else
-            static assert(false, "Not implemented for this architecture");
+            assert(0, "Not yet supported");
     }
 
     /// Enable (unmask) specific hardware exceptions. Multiple exceptions may be ORed together.

--- a/std/math.d
+++ b/std/math.d
@@ -4981,9 +4981,11 @@ struct FloatingPointControl
         return cast(RoundingMode)(getControlState() & ROUNDING_MASK);
     }
 
+    alias ExceptionMask = uint; ///
+
     version(StdDdoc)
     {
-        enum : uint
+        enum : ExceptionMask
         {
             /** IEEE hardware exceptions.
              *  By default, all exceptions are masked (disabled).
@@ -5003,7 +5005,7 @@ struct FloatingPointControl
     }
     else version(ARM)
     {
-        enum : uint
+        enum : ExceptionMask
         {
             subnormalException    = 0x8000,
             inexactException      = 0x1000,
@@ -5019,7 +5021,7 @@ struct FloatingPointControl
     }
     else version(PPC_Any)
     {
-        enum : uint
+        enum : ExceptionMask
         {
             inexactException      = 0x0008,
             divByZeroException    = 0x0010,
@@ -5034,7 +5036,7 @@ struct FloatingPointControl
     }
     else
     {
-        enum : uint
+        enum : ExceptionMask
         {
             inexactException      = 0x20,
             underflowException    = 0x10,
@@ -5092,7 +5094,7 @@ public:
     }
 
     /// Enable (unmask) specific hardware exceptions. Multiple exceptions may be ORed together.
-    void enableExceptions(uint exceptions) @nogc
+    void enableExceptions(ExceptionMask exceptions) @nogc
     {
         assert(hasExceptionTraps);
         initialize();
@@ -5103,7 +5105,7 @@ public:
     }
 
     /// Disable (mask) specific hardware exceptions. Multiple exceptions may be ORed together.
-    void disableExceptions(uint exceptions) @nogc
+    void disableExceptions(ExceptionMask exceptions) @nogc
     {
         assert(hasExceptionTraps);
         initialize();
@@ -5114,7 +5116,7 @@ public:
     }
 
     /// Returns: the exceptions which are currently enabled (unmasked)
-    @property static uint enabledExceptions() @nogc
+    @property static ExceptionMask enabledExceptions() @nogc
     {
         assert(hasExceptionTraps);
         version(X86_Any)

--- a/std/math.d
+++ b/std/math.d
@@ -5052,22 +5052,18 @@ struct FloatingPointControl
 private:
     version(ARM)
     {
-        enum uint EXCEPTION_MASK = 0x9F00;
         enum uint ROUNDING_MASK = 0xC00000;
     }
     else version(PPC_Any)
     {
-        enum uint EXCEPTION_MASK = 0x00F8;
         enum uint ROUNDING_MASK = 0x0003;
     }
     else version(X86)
     {
-        enum ushort EXCEPTION_MASK = 0x3F;
         enum ushort ROUNDING_MASK = 0xC00;
     }
     else version(X86_64)
     {
-        enum ushort EXCEPTION_MASK = 0x3F;
         enum ushort ROUNDING_MASK = 0xC00;
     }
     else
@@ -5086,8 +5082,8 @@ public:
             auto oldState = getControlState();
             // If exceptions are not supported, we set the bit but read it back as zero
             // https://sourceware.org/ml/libc-ports/2012-06/msg00091.html
-            setControlState(oldState | (divByZeroException & EXCEPTION_MASK));
-            immutable result = (getControlState() & EXCEPTION_MASK) != 0;
+            setControlState(oldState | (divByZeroException & allExceptions));
+            immutable result = (getControlState() & allExceptions) != 0;
             setControlState(oldState);
             return result;
         }
@@ -5101,9 +5097,9 @@ public:
         assert(hasExceptionTraps);
         initialize();
         version(X86_Any)
-            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() & ~(exceptions & allExceptions));
         else
-            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() | (exceptions & allExceptions));
     }
 
     /// Disable (mask) specific hardware exceptions. Multiple exceptions may be ORed together.
@@ -5112,9 +5108,9 @@ public:
         assert(hasExceptionTraps);
         initialize();
         version(X86_Any)
-            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() | (exceptions & allExceptions));
         else
-            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() & ~(exceptions & allExceptions));
     }
 
     /// Returns: the exceptions which are currently enabled (unmasked)
@@ -5122,9 +5118,9 @@ public:
     {
         assert(hasExceptionTraps);
         version(X86_Any)
-            return (getControlState() & EXCEPTION_MASK) ^ EXCEPTION_MASK;
+            return (getControlState() & allExceptions) ^ allExceptions;
         else
-            return (getControlState() & EXCEPTION_MASK);
+            return (getControlState() & allExceptions);
     }
 
     ///  Clear all pending exceptions, then restore the original exception state and rounding mode.
@@ -5222,8 +5218,8 @@ private:
 
                 /* In the FPU control register, masks are bits 0 through 5.
                 In MXCSR they're 7 through 12. */
-                enum EXCEPTION_MASK_SSE = EXCEPTION_MASK << 7;
-                immutable newExceptionMasks = (newState & EXCEPTION_MASK) << 7;
+                enum EXCEPTION_MASK_SSE = allExceptions << 7;
+                immutable newExceptionMasks = (newState & allExceptions) << 7;
                 mxcsr &= ~EXCEPTION_MASK_SSE; // delete old masks
                 mxcsr |= newExceptionMasks; // write new exception masks
 


### PR DESCRIPTION
Slight continuation of #4272.

Changes:

- `FloatingPointControl.roundingMask`: New public RoundingMode value
- `FloatingPointControl.ExceptionMask`: New public base type for exception mask enum.
- `EXCEPTION_MASK`, `ROUNDING_MODE`: Remove internal values.

Now, the only parts that need changing for adding ports are FPU exception masks, and the asm code which gets/set the control word.