### PR TITLE
Split unittest6.obj to get past the 32767 max symbols limitation

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -561,6 +561,7 @@ UNITTEST_OBJS= \
 		unittest4.obj \
 		unittest5.obj \
 		unittest6.obj \
+		unittest6b.obj \
 		unittest7.obj \
 		unittest8a.obj \
 		unittest8b.obj \
@@ -578,7 +579,8 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3b.obj $(SRC_STD_DATETIME)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest5.obj $(SRC_STD_ALGO)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER) $(SRC_STD_EXP_ALLOC) $(SRC_STD_EXP_LOGGER)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER) $(SRC_STD_EXP_ALLOC)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest7.obj $(SRC_STD_7)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8a.obj $(SRC_STD_REGEX)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8b.obj $(SRC_STD_NET)


### PR DESCRIPTION
On #5331 I've ran into the following issue:
On Windows 32bit, dmd fails to generate `unittest6.obj` because this object has more than 32767 symbols. This PR fixes this issue.