### PR TITLE
Fix Issue 7957 - std.functional untuple/untupleReversed too

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -15,6 +15,9 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Joins a couple of functions into one that executes the original
         functions independently and returns a tuple with all the results.
     ))
+    $(TR $(TD $(LREF apply))
+        $(TD Applies the items of a tuple as arguments to a function.
+    ))
     $(TR $(TD $(LREF compose), $(LREF pipe))
         $(TD Join a couple of functions into one that executes the original
         functions one after the other, using one function's result for the next
@@ -1561,4 +1564,46 @@ template forward(args...)
     static assert(!__traits(compiles, { auto x1 = bar(3); })); // case of NG
     int value = 3;
     auto x2 = bar(value); // case of OK
+}
+
+/**
+$(D auto apply(Tup)(Tup t)
+    if (isTuple!Tup && Parameters!callable.length == Tup.length))
+
+Applies the items of tuple `t` as arguments to the function `callable`.
+
+Returns:
+    The return value of the function `callable` for the arguments
+    represented by the items of `t`.
+
+*/
+template apply(alias callable)
+{
+    import std.typecons : isTuple;
+    auto apply(Tup)(Tup t)
+    if (isTuple!Tup && Parameters!callable.length == Tup.length)
+    {
+        return callable(t.tupleof);
+    }
+}
+
+///
+@safe unittest
+{
+    import std.range : zip;
+    import std.algorithm.comparison : equal;
+    import std.algorithm.iteration : map;
+    import std.typecons : tuple;
+
+    auto tup = tuple('a', 10);
+    auto a1 = "abcd"d;
+    auto a2 = [10, 20, 30, 40];
+    auto a3 = [100, 200, 300, 400];
+
+    int foo(dchar a, int b) { return a + b; }
+    assert(tup.apply!foo() == 107);
+    assert(zip(a1, a2).map!(apply!foo).equal([107, 118, 129, 140]));
+
+    int foo2(dchar a, int b, int c) { return a + b + c; }
+    assert(zip(a1, a2, a3).map!(apply!foo2).equal([207, 318, 429, 540]));
 }


### PR DESCRIPTION
I didn't implement the reversed part since I am not sure if this addition is going to make it to phobos and anyway there is the function reverse for tuples which can be used.