### PR TITLE
Make goodAllocSize @safe

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -439,3 +439,12 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     Ternary r = MyAllocator.instance.resolveInternalPointer(d.ptr, p);
     assert(p.ptr is d.ptr && p.length >= d.length);
 }
+
+// Check that goodAllocSize inherits from parent, i.e. GCAllocator
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator;
+    alias a = AffixAllocator!(GCAllocator, uint).instance;
+
+    assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(1))()));
+}

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1100,9 +1100,7 @@ struct BitmappedBlockWithInternalPointers(
 @system unittest
 {
     auto h = BitmappedBlockWithInternalPointers!(4096)(new ubyte[4096 * 1024]);
-    () nothrow @safe @nogc {
-        assert(h.goodAllocSize(1) == 4096);
-    }();
+    assert((() pure nothrow @safe @nogc => h.goodAllocSize(1))() == 4096);
 }
 
 /**

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -258,7 +258,5 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
             0, unbounded),
         65, 512, 64) a;
 
-    () nothrow @safe @nogc {
-        assert(a.goodAllocSize(65) == 128);
-    }();
+    assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))() == 128);
 }

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -45,6 +45,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     /**
     Rounds up to the maximum size of the bucket in which $(D bytes) falls.
     */
+    pure nothrow @safe @nogc
     size_t goodAllocSize(size_t bytes) const
     {
         // round up bytes such that bytes - min + 1 is a multiple of step
@@ -239,4 +240,25 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     assert(a.owns(b) == Ternary.yes);
     void[] p;
     a.deallocate(b);
+}
+
+@system unittest
+{
+    import std.algorithm.comparison : max;
+    import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+    import std.experimental.allocator.building_blocks.free_list : FreeList;
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.common : unbounded;
+    import std.experimental.allocator.mallocator : Mallocator;
+
+    Bucketizer!(
+        FreeList!(
+            AllocatorList!(
+                (size_t n) => Region!Mallocator(max(n, 1024 * 1024))),
+            0, unbounded),
+        65, 512, 64) a;
+
+    () nothrow @safe @nogc {
+        assert(a.goodAllocSize(65) == 128);
+    }();
 }

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -485,3 +485,13 @@ struct FreeTree(ParentAllocator)
     assert(myDeallocCounter == 1);
     assert(y.ptr is null);
 }
+
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator;
+    FreeTree!GCAllocator a;
+
+    assert((() nothrow @safe @nogc => a.goodAllocSize(1))() == typeof(*a.root).sizeof);
+    // goodAllocSize is not pure because we are calling through GCAllocator.instance
+    assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
+}

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -887,7 +887,5 @@ it actually returns memory to the operating system when possible.
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
     auto a = KRRegion!GCAllocator(1024 * 1024);
-    () nothrow @safe @nogc {
-        assert(a.goodAllocSize(1) == typeof(*a.root).sizeof);
-    }();
+    assert((() pure nothrow @safe @nogc => a.goodAllocSize(1))() == typeof(*a.root).sizeof);
 }

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -590,6 +590,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     Adjusts $(D n) to a size suitable for allocation (two words or larger,
     word-aligned).
     */
+    pure nothrow @safe @nogc
     static size_t goodAllocSize(size_t n)
     {
         import std.experimental.allocator.common : roundUpToMultipleOf;
@@ -879,4 +880,14 @@ it actually returns memory to the operating system when possible.
 
     test(sizes64, word64);
     test(sizes32, word32);
+}
+
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+
+    auto a = KRRegion!GCAllocator(1024 * 1024);
+    () nothrow @safe @nogc {
+        assert(a.goodAllocSize(1) == typeof(*a.root).sizeof);
+    }();
 }

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -4,34 +4,34 @@ module std.experimental.allocator.building_blocks.quantizer;
 import std.experimental.allocator.common;
 
 /**
-This allocator sits on top of $(D ParentAllocator) and quantizes allocation
-sizes, usually from arbitrary positive numbers to a small set of round numbers
-(e.g. powers of two, page sizes etc). This technique is commonly used to:
+This allocator sits on top of `ParentAllocator` and quantizes allocation sizes,
+usually from arbitrary positive numbers to a small set of round numbers (e.g.
+powers of two, page sizes etc). This technique is commonly used to:
 
 $(UL
 $(LI Preallocate more memory than requested such that later on, when
 reallocation is needed (e.g. to grow an array), expansion can be done quickly
 in place. Reallocation to smaller sizes is also fast (in-place) when the new
 size requested is within the same quantum as the existing size. Code that's
-reallocation-heavy can therefore benefit from fronting a generic allocator
-with a $(D Quantizer). These advantages are present even if
-$(D ParentAllocator) does not support reallocation at all.)
-$(LI Improve behavior of allocators sensitive to allocation sizes, such as $(D
-FreeList) and $(D FreeTree). Rounding allocation requests up makes for smaller
+reallocation-heavy can therefore benefit from fronting a generic allocator with
+a `Quantizer`. These advantages are present even if `ParentAllocator` does not
+support reallocation at all.)
+$(LI Improve behavior of allocators sensitive to allocation sizes, such as
+`FreeList` and `FreeTree`. Rounding allocation requests up makes for smaller
 free lists/trees at the cost of slack memory (internal fragmentation).)
 )
 
 The following methods are forwarded to the parent allocator if present:
-$(D allocateAll), $(D owns), $(D deallocateAll), $(D empty).
+`allocateAll`, `owns`, `deallocateAll`, `empty`.
 
-Preconditions: $(D roundingFunction) must satisfy three constraints. These are
-not enforced (save for the use of $(D assert)) for the sake of efficiency.
+Preconditions: `roundingFunction` must satisfy three constraints. These are
+not enforced (save for the use of `assert`) for the sake of efficiency.
 $(OL
-$(LI $(D roundingFunction(n) >= n) for all $(D n) of type $(D size_t);)
-$(LI $(D roundingFunction) must be monotonically increasing, i.e. $(D
+$(LI $(D roundingFunction(n) >= n) for all `n` of type `size_t`;)
+$(LI `roundingFunction` must be monotonically increasing, i.e. $(D
 roundingFunction(n1) <= roundingFunction(n2)) for all $(D n1 < n2);)
-$(LI $(D roundingFunction) must be $(D pure), i.e. always return the same
-value for a given $(D n).)
+$(LI `roundingFunction` must be `nothrow`, `@safe`, `@nogc` and `pure`, i.e.
+always return the same value for a given `n`.)
 )
 */
 struct Quantizer(ParentAllocator, alias roundingFunction)
@@ -236,4 +236,8 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     alias MyAlloc = Quantizer!(GCAllocator,
         (size_t n) => n.roundUpToMultipleOf(64));
     testAllocator!(() => MyAlloc());
+
+    () nothrow @safe @nogc {
+        assert(MyAlloc().goodAllocSize(1) == 64);
+    }();
 }

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -237,7 +237,5 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
         (size_t n) => n.roundUpToMultipleOf(64));
     testAllocator!(() => MyAlloc());
 
-    () nothrow @safe @nogc {
-        assert(MyAlloc().goodAllocSize(1) == 64);
-    }();
+    assert((() pure nothrow @safe @nogc => MyAlloc().goodAllocSize(1))() == 64);
 }

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -219,3 +219,13 @@ struct ScopedAllocator(ParentAllocator)
     alloc.dispose(foo);
     alloc.dispose(bar); // segfault here
 }
+
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    ScopedAllocator!GCAllocator a;
+
+    assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(0))()));
+    // goodAllocSize is not pure because we are calling through Allocator.instance
+    assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
+}

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -359,3 +359,18 @@ if (Args.length > 3)
     assert(b.length == 201);
     a.deallocate(b);
 }
+
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.experimental.allocator.building_blocks.kernighan_ritchie : KRRegion;
+    Segregator!(128, GCAllocator, KRRegion!GCAllocator) alloc;
+    assert((() nothrow @safe @nogc => alloc.goodAllocSize(1))()
+            == GCAllocator.instance.goodAllocSize(1));
+
+    // Note: we infer `shared` from GCAllocator.goodAllocSize so we need a
+    // shared object in order to be able to use the function
+    shared Segregator!(128, GCAllocator, GCAllocator) sharedAlloc;
+    assert((() nothrow @safe @nogc => sharedAlloc.goodAllocSize(1))()
+            == GCAllocator.instance.goodAllocSize(1));
+}

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -733,3 +733,12 @@ public:
     import std.experimental.allocator.gc_allocator : GCAllocator;
     test!(StatsCollector!(GCAllocator, 0, 0));
 }
+
+@system unittest
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    StatsCollector!(GCAllocator, 0, 0) a;
+
+    // calls std.experimental.allocator.common.goodAllocSize
+    assert((() pure nothrow @safe @nogc => a.goodAllocSize(1))());
+}

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -83,6 +83,7 @@ enum uint platformAlignment = std.algorithm.comparison.max(double.alignof, real.
 The default good size allocation is deduced as $(D n) rounded up to the
 allocator's alignment.
 */
+pure nothrow @safe @nogc
 size_t goodAllocSize(A)(auto ref A a, size_t n)
 {
     return n.roundUpToMultipleOf(a.alignment);

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -83,7 +83,6 @@ enum uint platformAlignment = std.algorithm.comparison.max(double.alignof, real.
 The default good size allocation is deduced as $(D n) rounded up to the
 allocator's alignment.
 */
-pure nothrow @safe @nogc
 size_t goodAllocSize(A)(auto ref A a, size_t n)
 {
     return n.roundUpToMultipleOf(a.alignment);

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -141,15 +141,11 @@ struct GCAllocator
     import std.typecons : Ternary;
 
     // test allocation sizes
-    () nothrow @safe @nogc {
-        assert(GCAllocator.instance.goodAllocSize(1) == 16);
-    }();
+    assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(1))() == 16);
     for (size_t s = 16; s <= 8192; s *= 2)
     {
-        () nothrow @safe @nogc {
-            assert(GCAllocator.instance.goodAllocSize(s) == s);
-            assert(GCAllocator.instance.goodAllocSize(s - (s / 2) + 1) == s);
-        }();
+        assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(s))() == s);
+        assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(s - (s / 2) + 1))() == s);
 
         auto buffer = GCAllocator.instance.allocate(s);
         scope(exit) GCAllocator.instance.deallocate(buffer);
@@ -168,7 +164,5 @@ struct GCAllocator
     }
 
     // anything above a page is simply rounded up to next page
-    () nothrow @safe @nogc {
-        assert(GCAllocator.instance.goodAllocSize(4096 * 4 + 1) == 4096 * 5);
-    }();
+    assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(4096 * 4 + 1))() == 4096 * 5);
 }

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -87,6 +87,7 @@ struct GCAllocator
     }
 
     /// Ditto
+    pure nothrow @safe @nogc
     size_t goodAllocSize(size_t n) shared
     {
         if (n == 0)
@@ -140,11 +141,15 @@ struct GCAllocator
     import std.typecons : Ternary;
 
     // test allocation sizes
-    assert(GCAllocator.instance.goodAllocSize(1) == 16);
+    () nothrow @safe @nogc {
+        assert(GCAllocator.instance.goodAllocSize(1) == 16);
+    }();
     for (size_t s = 16; s <= 8192; s *= 2)
     {
-        assert(GCAllocator.instance.goodAllocSize(s) == s);
-        assert(GCAllocator.instance.goodAllocSize(s - (s / 2) + 1) == s);
+        () nothrow @safe @nogc {
+            assert(GCAllocator.instance.goodAllocSize(s) == s);
+            assert(GCAllocator.instance.goodAllocSize(s - (s / 2) + 1) == s);
+        }();
 
         auto buffer = GCAllocator.instance.allocate(s);
         scope(exit) GCAllocator.instance.deallocate(buffer);
@@ -163,5 +168,7 @@ struct GCAllocator
     }
 
     // anything above a page is simply rounded up to next page
-    assert(GCAllocator.instance.goodAllocSize(4096 * 4 + 1) == 4096 * 5);
+    () nothrow @safe @nogc {
+        assert(GCAllocator.instance.goodAllocSize(4096 * 4 + 1) == 4096 * 5);
+    }();
 }


### PR DESCRIPTION
For stand-alone allocators, such as `GCAllocator`, `goodAllocSize` is a `pure nothrow @safe @nogc` function.
Allocators that are building on top of such allocators should infer the function attributes from their parents.

This PR is a subset of #5330, as this approach will provide us with better granularity. More smaller PRs to come :)