### PR TITLE
Issue 17912: Add function for creating a temporary file.

### DIFF
--- a/changelog/std-file-createTempFile.dd
+++ b/changelog/std-file-createTempFile.dd
@@ -1,0 +1,15 @@
+`createTempFile` added to std.file
+
+$(REF std, file, createTempFile) creates a file in $(REF tempDir, std, file)
+with a random name (with an optionally provided prefix and suffix) and returns
+the file name. It also optionally takes data to write to the file when creating
+it (if no data is provided, then the newly created file will be empty).
+
+This is different from $(REF File.tmpfile, std, stdio), which creates a
+temporary file with no name, returns a $(REF File, std, stdio) to that file,
+and then deletes the file when the $(REF File, std, stdio) is closed. The file
+created by $(REF std, file, createTempFile) is a normal file which can be
+opened and closed as many times as desired and will only be deleted by the
+program if the program explicitly does so (though it is sitting in a temp
+directory and is subject to the normal things tha happen to such files - e.g.
+some OSes delete those files on boot).


### PR DESCRIPTION
This adds std.file.createTempFile, which creates a temporary file with a
random name (optionally with a specified prefix and/or suffix). By
default, the file is empty, but if data is passed to createTempFile,
then the file is populated with that data just like it would have been
with std.file.write. The name of the file that was created is returned.
So, essentially, createTempFile is like write except that it generates
the file name for you and returns it.

Previously, we added scratchFile to std.stdio, which was like
createTempFile except that it gave you an open File object, but it was
scrapped, because the dependencies that it added to std.stdio made
"hello world" bigger. See:
https://issues.dlang.org/show_bug.cgi?id=14599

Just like scratchFile did, createTempFile ensures that a filename is
selected which did not exist previously so that the file can't be
hijacked with different permissions by someone creating a file with the
same name beforehand (the randomness of the name should make that
effectively impossible, but the way that createTempFile opens the file
guarantees it).

These changes also consolidate some of write's implementation across
OSes, since the writing portion of writeImpl was esentially identical
across OSes but needlessly duplicated. That consolidated functionality
is then also used by createTempFile.

Unfortunately, I don't currently have a Windows setup that I can test this with, so depending on what happens with the autotester, I may need to make a revision or two to get it to pass on Windows. I might get lucky though.