### PR TITLE
Make owns pure nothrow @safe @nogc

### DIFF
--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -39,7 +39,8 @@ struct NullAllocator
     bool alignedReallocate(ref void[] b, size_t, uint) shared
     { assert(b is null); return false; }
     /// Returns $(D Ternary.no).
-    Ternary owns(void[]) shared const { return Ternary.no; }
+    pure nothrow @safe @nogc
+    Ternary owns(const void[]) shared const { return Ternary.no; }
     /**
     Returns $(D Ternary.no).
     */
@@ -79,7 +80,7 @@ struct NullAllocator
 
     import std.typecons : Ternary;
     assert(NullAllocator.instance.empty() == Ternary.yes);
-    assert(NullAllocator.instance.owns(null) == Ternary.no);
+    assert((() nothrow @safe @nogc => NullAllocator.instance.owns(null))() == Ternary.no);
     void[] p;
     assert(NullAllocator.instance.resolveInternalPointer(null, p) == Ternary.no);
 }


### PR DESCRIPTION
For allocators that implement their own `owns` method, such as `Region`, `owns` is a `pure nothrow @safe @nogc` function.
Allocators that are building on top of such allocators should infer the function attributes from their parents.

This PR is a subset of #5330, as this approach will provide us with better granularity. More smaller PRs to come :)