### PR TITLE
Fix Issue 9661 - LockingTextWriter should increment file handle reference count

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2717,7 +2717,10 @@ $(D Range) that locks the file and allows fast writing to it.
     {
     private:
         import std.range.primitives : ElementType, isInfinite, isInputRange;
-        // the shared file handle
+
+        // We need the 'file_' member to keep the object alive by refcounting.
+        // The 'fps_' member is also kept to avoid constant checking if 'file_'
+        // members are correctly initialized, when trying to get the 'FILE*' from the 'File' object
         FILE* fps_;
         File file_;
 
@@ -2898,6 +2901,10 @@ See $(LREF byChunk) for an example.
     {
         import std.traits : hasIndirections;
     private:
+
+        // We need the 'file_' member to keep the object alive by refcounting.
+        // The 'fps_' member is also kept to avoid constant checking if 'file_'
+        // members are correctly initialized, when trying to get the 'FILE*' from the 'File' object
         FILE* fps;
         File file;
         string name;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2717,10 +2717,11 @@ $(D Range) that locks the file and allows fast writing to it.
     {
     private:
         import std.range.primitives : ElementType, isInfinite, isInputRange;
-
+        // Access the FILE* handle through the 'file_' member
+        // to keep the object alive through refcounting
         File file_;
 
-        // the unshared version of fps
+        // the unshared version of FILE* handle, extracted from the File object
         @property _iobuf* handle_() @trusted { return cast(_iobuf*) file_._p.handle; }
 
         // the file's orientation (byte- or wide-oriented)
@@ -2910,6 +2911,8 @@ See $(LREF byChunk) for an example.
     {
         import std.traits : hasIndirections;
     private:
+        // Access the FILE* handle through the 'file_' member
+        // to keep the object alive through refcounting
         File file;
         string name;
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2913,7 +2913,7 @@ See $(LREF byChunk) for an example.
     private:
         // Access the FILE* handle through the 'file_' member
         // to keep the object alive through refcounting
-        File file;
+        File file_;
         string name;
 
         version (Windows)
@@ -2927,7 +2927,7 @@ See $(LREF byChunk) for an example.
         this(ref File f)
         {
             import std.exception : enforce;
-            file = f;
+            file_ = f;
             enforce(f._p && f._p.handle);
             name = f._name;
             FILE* fps = f._p.handle;
@@ -2955,9 +2955,9 @@ See $(LREF byChunk) for an example.
         {
             FILE* fps;
 
-            if (file._p)
+            if (file_._p)
             {
-                fps = file._p.handle;
+                fps = file_._p.handle;
             }
 
             if (!fps)
@@ -2982,7 +2982,7 @@ See $(LREF byChunk) for an example.
             import std.conv : text;
             import std.exception : errnoEnforce;
 
-            auto result = trustedFwrite(file._p.handle, buffer);
+            auto result = trustedFwrite(file_._p.handle, buffer);
             if (result == result.max) result = 0;
             errnoEnforce(result == buffer.length,
                     text("Wrote ", result, " instead of ", buffer.length,
@@ -3000,9 +3000,9 @@ See $(LREF byChunk) for an example.
             {
                 FILE* fps;
 
-                if (file._p)
+                if (file_._p)
                 {
-                    fps = file._p.handle;
+                    fps = file_._p.handle;
                 }
 
                 if (fps)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2742,31 +2742,17 @@ $(D Range) that locks the file and allows fast writing to it.
 
         ~this() @trusted
         {
-            FILE* fps;
-
-            if (file_._p)
+            if (auto p = file_._p)
             {
-                fps = file_._p.handle;
-            }
-
-            if (fps)
-            {
-                FUNLOCK(fps);
+                if (p.handle) FUNLOCK(p.handle);
             }
         }
 
         this(this) @trusted
         {
-            FILE* fps;
-
-            if (file_._p)
+            if (auto p = file_._p)
             {
-                fps = file_._p.handle;
-            }
-
-            if (fps)
-            {
-                FLOCK(fps);
+                if (p.handle) FLOCK(p.handle);
             }
         }
 
@@ -2953,15 +2939,10 @@ See $(LREF byChunk) for an example.
     public:
         ~this()
         {
-            FILE* fps;
-
-            if (file_._p)
-            {
-                fps = file_._p.handle;
-            }
-
-            if (!fps)
+            if (!file_._p || !file_._p.handle)
                 return;
+
+            FILE* fps = file_._p.handle;
 
             version (Windows)
             {
@@ -2998,16 +2979,9 @@ See $(LREF byChunk) for an example.
         {
             this(this)
             {
-                FILE* fps;
-
-                if (file_._p)
+                if (auto p = file_._p)
                 {
-                    fps = file_._p.handle;
-                }
-
-                if (fps)
-                {
-                    FLOCK(fps);
+                    if (p.handle) FLOCK(p.handle);
                 }
             }
         }


### PR DESCRIPTION
I also did the same for LockingBinaryWriter and added a test case for each.