### PR TITLE
Issue 17269: formattedWrite of struct with Nullable value fails

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3830,6 +3830,20 @@ if (is(AssocArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(w.data == "TestContainer(helloworld)", w.data);
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=17269
+@safe unittest
+{
+    import std.typecons : Nullable;
+
+    struct Foo
+    {
+        Nullable!string bar;
+    }
+
+    Foo f;
+    formatTest(f, "Foo(Nullable.null)");
+}
+
 @safe unittest
 {
     assert(collectExceptionMsg!FormatException(format("%d", [0:1])).back == 'd');


### PR DESCRIPTION
The bug was caused by formatElement [implicitly converting](https://github.com/dlang/phobos/blob/dc07f1ae3fe1a5b1fbf8a95f39861ce87964ec58/std/typecons.d#L3136) Nullable!string to string, that resulted in [an error](https://github.com/dlang/phobos/blob/dc07f1ae3fe1a5b1fbf8a95f39861ce87964ec58/std/typecons.d#L3114) when the Nullable was null.

New behavior is to use the toString method when available, instead of implicitly converting the value.