### PR TITLE
fix Issue 17730 - move escapes scope variable in @safe code

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1160,7 +1160,7 @@ pure nothrow @safe @nogc unittest
 }
 
 /// Ditto
-T move(T)(ref T source)
+T move(T)(return scope ref T source)
 {
     // test @safe destructible
     static if (__traits(compiles, (T t) @safe {}))


### PR DESCRIPTION
- needs to be annotated with return scope, so that the return value
  lifetime depends on the argument's lifetime
- cannot be tested because phobos doesn't yet work with DIP1000 and
  also because of Issue 17932