### PR TITLE
Make empty @safe

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -402,6 +402,20 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     });
 }
 
+// Test empty
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;
+    import std.typecons : Ternary;
+
+    auto a = AffixAllocator!(BitmappedBlock!128, ulong, ulong)
+                (BitmappedBlock!128(new ubyte[128 * 4096]));
+    assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.no);
+}
+
 @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -503,6 +503,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
      Returns `Ternary.yes` if no allocators are currently active,
     `Ternary.no` otherwise. This methods never returns `Ternary.unknown`.
     */
+    pure nothrow @safe @nogc
     Ternary empty() const
     {
         return Ternary(!allocators.length);
@@ -615,9 +616,10 @@ version(Posix) @system unittest
     b1 = a.allocate(1024 * 10);
     assert(b1.length == 1024 * 10);
     a.allocate(1024 * 4095);
+    assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.no);
     // Ensure deallocateAll infers from parent
     assert((() nothrow @nogc => a.deallocateAll())());
-    assert(a.empty == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
 }
 
 @system unittest

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -652,6 +652,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     allocator, otherwise `Ternary.no`. This method never returns
     `Ternary.unknown`.
     */
+    pure nothrow @safe @nogc
     Ternary empty()
     {
         return Ternary(_control.allAre0());
@@ -704,6 +705,17 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     static assert(hasMember!(InSituRegion!(10_240, 64), "allocateAll"));
     const b = a.allocate(100);
     assert(b.length == 100);
+}
+
+@system unittest
+{
+    import std.typecons : Ternary;
+
+    auto a = BitmappedBlock!(64, 64)(new ubyte[10_240]);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
+    const b = a.allocate(100);
+    assert(b.length == 100);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
 }
 
 @system unittest
@@ -1089,8 +1101,10 @@ struct BitmappedBlockWithInternalPointers(
     import std.typecons : Ternary;
 
     auto h = BitmappedBlockWithInternalPointers!(4096)(new ubyte[4096 * 1024]);
+    assert((() nothrow @safe @nogc => h.empty)() == Ternary.yes);
     auto b = h.allocate(123);
     assert(b.length == 123);
+    assert((() nothrow @safe @nogc => h.empty)() == Ternary.no);
 
     void[] p;
     void* offset = &b[0] + 17;
@@ -1354,7 +1368,7 @@ private struct BitVector
     }
 
     /// Are all bits zero?
-    nothrow @safe @nogc
+    pure nothrow @safe @nogc
     bool allAre0() const
     {
         foreach (w; _rep) if (w) return false;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -714,19 +714,19 @@ struct ContiguousFreeList(ParentAllocator,
     alias A = ContiguousFreeList!(NullAllocator, 0, 64);
     auto a = A(new ubyte[1024]);
 
-    assert(a.empty == Ternary.yes);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
 
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(15))() == 64);
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))()
             == (() nothrow @safe @nogc => NullAllocator.instance.goodAllocSize(65))());
 
     auto b = a.allocate(100);
-    assert(a.empty == Ternary.yes);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
     assert(b.length == 0);
     // Ensure deallocate inherits from parent
     () nothrow @nogc { a.deallocate(b); }();
     b = a.allocate(64);
-    assert(a.empty == Ternary.no);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
     assert(b.length == 64);
     assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
@@ -741,21 +741,21 @@ struct ContiguousFreeList(ParentAllocator,
     alias A = ContiguousFreeList!(Region!GCAllocator, 0, 64);
     auto a = A(Region!GCAllocator(1024 * 4), 1024);
 
-    assert(a.empty == Ternary.yes);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
 
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(15))() == 64);
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))()
             == (() pure nothrow @safe @nogc => a.parent.goodAllocSize(65))());
 
     auto b = a.allocate(100);
-    assert(a.empty == Ternary.no);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
     assert(a.allocated == 0);
     assert(b.length == 100);
     // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(b); }();
-    assert(a.empty == Ternary.yes);
+    assert((() nothrow @nogc => a.deallocate(b))());
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
     b = a.allocate(64);
-    assert(a.empty == Ternary.no);
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
     assert(b.length == 64);
     assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -605,6 +605,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     Returns: `Ternary.yes` if the allocator is empty, `Ternary.no` otherwise.
     Never returns `Ternary.unknown`.
     */
+    pure nothrow @safe @nogc
     Ternary empty()
     {
         return Ternary(root && root.size == payload.length);
@@ -832,7 +833,7 @@ it actually returns memory to the operating system when possible.
             () nothrow @nogc { a.deallocate(b); }();
         }
 
-        assert(a.empty == Ternary.yes);
+        assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
     }
 
     test(sizes64);
@@ -878,7 +879,7 @@ it actually returns memory to the operating system when possible.
             () nothrow @nogc { a.deallocate(bufs[i]); }();
         }
 
-        assert(a.empty == Ternary.yes);
+        assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
     }
 
     test(sizes64, word64);

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -61,6 +61,7 @@ struct NullAllocator
     /**
     Returns $(D Ternary.yes).
     */
+    pure nothrow @safe @nogc
     Ternary empty() shared const { return Ternary.yes; }
     /**
     Returns the $(D shared) global instance of the $(D NullAllocator).
@@ -82,7 +83,7 @@ struct NullAllocator
     assert((() nothrow @nogc => NullAllocator.instance.deallocateAll())());
 
     import std.typecons : Ternary;
-    assert(NullAllocator.instance.empty() == Ternary.yes);
+    assert((() nothrow @safe @nogc => NullAllocator.instance.empty)() == Ternary.yes);
     assert((() nothrow @safe @nogc => NullAllocator.instance.owns(null))() == Ternary.no);
 
     void[] p;

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -517,6 +517,7 @@ public:
     0).
     */
     static if (flags & Options.bytesUsed)
+    pure nothrow @safe @nogc
     Ternary empty()
     {
         return Ternary(_bytesUsed == 0);
@@ -681,8 +682,10 @@ public:
     void test(Allocator)()
     {
         import std.range : walkLength;
-        import std.stdio : writeln;
+        import std.typecons : Ternary;
+
         Allocator a;
+        assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
         auto b1 = a.allocate(100);
         assert(a.numAllocate == 1);
         assert(a.expand(b1, 0));
@@ -694,6 +697,7 @@ public:
         auto b3 = a.allocate(202);
         assert(a.numAllocate == 3);
         assert(a.bytesAllocated == 404);
+        assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.no);
 
         () nothrow @nogc { a.deallocate(b2); }();
         assert(a.numDeallocate == 1);
@@ -717,7 +721,6 @@ public:
     void test(Allocator)()
     {
         import std.range : walkLength;
-        import std.stdio : writeln;
         Allocator a;
         auto b1 = a.allocate(100);
         assert(a.expand(b1, 0));


### PR DESCRIPTION
For allocators that implement their own `empty` method, such as `KRRegion`, `empty` is a `pure nothrow @safe @nogc` function.
Allocators that are building on top of such allocators should infer the function attributes from their parents.

This PR is a subset of #5330, as this approach will provide us with better granularity. More smaller PRs to come :)

In this PR, there are also a couple of bug-fixes:
- `FallbackAllocator` should attempt to test only if it has supplied at least one stateless allocator
- `Region` didn't take into consideration the `growDownwards` flag
- `Segregator` should use the `Ternary` op `&` instead of `&&`