### PR TITLE
Allocators owns should take const void[]

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -112,7 +112,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             }
         }
 
-        private void[] actualAllocation(void[] b) const
+        private inout(void)[] actualAllocation(inout(void)[] b) const
         {
             assert(b !is null);
             return (b.ptr - stateSize!Prefix)
@@ -168,10 +168,11 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         }
 
         static if (hasMember!(Allocator, "owns"))
-        Ternary owns(void[] b)
+        //Ternary owns(const void[] b) const ?
+        Ternary owns(const void[] b)
         {
             if (b is null) return Ternary.no;
-            return parent.owns(actualAllocation(b));
+            return parent.owns((() @trusted => actualAllocation(b))());
         }
 
         static if (hasMember!(Allocator, "resolveInternalPointer"))
@@ -275,7 +276,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         /// Ditto
         void[] allocate(size_t);
         /// Ditto
-        Ternary owns(void[]);
+        Ternary owns(const void[]);
         /// Ditto
         bool expand(ref void[] b, size_t delta);
         /// Ditto
@@ -447,4 +448,18 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     alias a = AffixAllocator!(GCAllocator, uint).instance;
 
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(1))()));
+}
+
+// Check that owns inherits from parent, i.e. Region
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = AffixAllocator!(Region!(Mallocator), uint)(Region!Mallocator(1024 * 64));
+    const b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
 }

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -349,7 +349,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     returned  `Ternary.unknown`.
     */
     static if (hasMember!(Allocator, "owns"))
-    Ternary owns(void[] b)
+    //Ternary owns(const void[] b) const ?
+    Ternary owns(const void[] b)
     {
         auto result = Ternary.no;
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
@@ -581,12 +582,15 @@ version(Posix) @system unittest
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
+    import std.typecons : Ternary;
     AllocatorList!((n) => Region!GCAllocator(new ubyte[max(n, 1024 * 4096)]),
         NullAllocator) a;
     const b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
     const b2 = a.allocate(1024 * 10);
     assert(b2.length == 1024 * 10);
+    assert((() pure nothrow @safe @nogc => a.owns(b2))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
     a.deallocateAll();
 }
 
@@ -595,11 +599,14 @@ version(Posix) @system unittest
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
+    import std.typecons : Ternary;
     AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
     b1 = a.allocate(1024 * 10);
     assert(b1.length == 1024 * 10);
+    assert((() pure nothrow @safe @nogc => a.owns(b1))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
     a.deallocateAll();
 }
 

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -31,10 +31,10 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     */
     Allocator[(max + 1 - min) / step] buckets;
 
-    private Allocator* allocatorFor(size_t n)
+    private Allocator* allocatorFor(size_t n) @safe
     {
         const i = (n - min) / step;
-        return i < buckets.length ? buckets.ptr + i : null;
+        return i < buckets.length ? &buckets[i] : null;
     }
 
     /**
@@ -164,11 +164,11 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     static if (hasMember!(Allocator, "owns"))
     Ternary owns(void[] b)
     {
-        if (!b.ptr) return Ternary.no;
+        if (!b) return Ternary.no;
         if (auto a = allocatorFor(b.length))
         {
             const actual = goodAllocSize(b.length);
-            return a.owns(b.ptr[0 .. actual]);
+            return a.owns((() @trusted => b.ptr[0 .. actual])());
         }
         return Ternary.no;
     }
@@ -237,7 +237,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
         65, 512, 64) a;
     auto b = a.allocate(400);
     assert(b.length == 400);
-    assert(a.owns(b) == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     a.deallocate(b);
 }
 

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -196,7 +196,8 @@ struct FallbackAllocator(Primary, Fallback)
     Returns $(D primary.owns(b) | fallback.owns(b)).
     */
     static if (hasMember!(Primary, "owns") && hasMember!(Fallback, "owns"))
-    Ternary owns(void[] b)
+    //Ternary owns(const void[] b) const ?
+    Ternary owns(const void[] b)
     {
         return primary.owns(b) | fallback.owns(b);
     }
@@ -361,7 +362,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     import std.typecons : Ternary;
 
     FallbackAllocator!(InSituRegion!16_384, InSituRegion!16_384) a;
-    auto buff = a.allocate(42);
+    const buff = a.allocate(42);
     assert((() pure nothrow @safe @nogc => a.owns(buff))() == Ternary.yes);
 }
 

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -620,7 +620,7 @@ struct ContiguousFreeList(ParentAllocator,
     */
     static if (hasMember!(SParent, "owns") || unchecked)
     // Ternary owns(const void[] b) const ?
-    Ternary owns(void[] b)
+    Ternary owns(const void[] b)
     {
         if ((() @trusted => support && b
                             && (&support[0] <= &b[0])

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -495,3 +495,16 @@ struct FreeTree(ParentAllocator)
     // goodAllocSize is not pure because we are calling through GCAllocator.instance
     assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
 }
+
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = FreeTree!(Region!(Mallocator))(Region!Mallocator(1024 * 64));
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
+}

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -579,7 +579,8 @@ struct KRRegion(ParentAllocator = NullAllocator)
     allocated with $(D this) or obtained through other means.
     */
     pure nothrow @trusted @nogc
-    Ternary owns(void[] b)
+    //Ternary owns(const void[] b) const ?
+    Ternary owns(const void[] b)
     {
         debug(KRRegion) assertValid("owns");
         debug(KRRegion) scope(exit) assertValid("owns");
@@ -624,7 +625,7 @@ fronting the GC allocator.
     // KRRegion fronting a general-purpose allocator
     ubyte[1024 * 128] buf;
     auto alloc = fallbackAllocator(KRRegion!()(buf), GCAllocator.instance);
-    auto b = alloc.allocate(100);
+    const b = alloc.allocate(100);
     assert(b.length == 100);
     assert((() pure nothrow @safe @nogc => alloc.primary.owns(b))() == Ternary.yes);
 }

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -223,9 +223,24 @@ struct ScopedAllocator(ParentAllocator)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.typecons : Ternary;
+
     ScopedAllocator!GCAllocator a;
 
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(0))()));
     // goodAllocSize is not pure because we are calling through Allocator.instance
     assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
+}
+
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = Region!(Mallocator)(1024 * 64);
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -334,7 +334,7 @@ interface IAllocator
     cannot be determined. Implementations that don't support this primitive
     should always return `Ternary.unknown`.
     */
-    Ternary owns(void[] b);
+    Ternary owns(const void[] b);
 
     /**
     Resolves an internal pointer to the full block allocated. Implementations
@@ -430,7 +430,7 @@ interface ISharedAllocator
     cannot be determined. Implementations that don't support this primitive
     should always return `Ternary.unknown`.
     */
-    Ternary owns(void[] b) shared;
+    Ternary owns(const void[] b) shared;
 
     /**
     Resolves an internal pointer to the full block allocated. Implementations
@@ -509,7 +509,7 @@ private IAllocator setupThreadAllocator() nothrow @nogc @safe
             return processAllocator.alignedReallocate(b, size, alignment);
         }
 
-        override Ternary owns(void[] b)
+        override Ternary owns(const void[] b)
         {
             return processAllocator.owns(b);
         }
@@ -2225,7 +2225,7 @@ class CAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     If `Allocator` implements `owns`, forwards to it. Otherwise, returns
     `Ternary.unknown`.
     */
-    override Ternary owns(void[] b)
+    override Ternary owns(const void[] b)
     {
         static if (hasMember!(Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
@@ -2408,7 +2408,7 @@ class CSharedAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     If `Allocator` implements `owns`, forwards to it. Otherwise, returns
     `Ternary.unknown`.
     */
-    override Ternary owns(void[] b) shared
+    override Ternary owns(const void[] b) shared
     {
         static if (hasMember!(Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
@@ -2897,7 +2897,7 @@ private struct InternalPointersTree(Allocator)
     }
 
     /// Ditto
-    Ternary owns(void[] b)
+    Ternary owns(const void[] b)
     {
         void[] result;
         return resolveInternalPointer(b.ptr, result);


### PR DESCRIPTION
`owns` should take a `const void[]` argument as it should also work with `const` and `immutable` memory chunks.

Added more unittests in order to ensure that allocators inherit from their parents.