### PR TITLE
Fix Issue 17952 - std.range.transposed save is invalid

### DIFF
--- a/changelog/std-range-package-Transposed-deprecate-save.dd
+++ b/changelog/std-range-package-Transposed-deprecate-save.dd
@@ -1,7 +1,7 @@
-`std.range.package.Transposed` deprecate `save`
+Deprecate `savce` for `std.range.package.Transposed`
 
-Transposed incorrectly is marked as a forward range. It cannot be used
-without affecting any other copies made with `save`. `save` will be
+Transposed is incorrectly marked as a forward range. Its `popFront` primitive 
+cannot be used without affecting any other copies made with `save`. `save` will be
 removed from Transposed in November 2018.
 
 https://issues.dlang.org/show_bug.cgi?id=17952

--- a/changelog/std-range-package-Transposed-deprecate-save.dd
+++ b/changelog/std-range-package-Transposed-deprecate-save.dd
@@ -1,12 +1,14 @@
 `std.range.package.Transposed` deprecate `save`
 
-Consuming Transposed.save consumes the original range as well.
+Transposed incorrectly is marked as a forward range. It cannot be used
+without affecting any other copies made with `save`. `save` will be
+removed from Transposed in November 2018.
+
 https://issues.dlang.org/show_bug.cgi?id=17952
 
 -----
 auto x = [[1,2,3],[4,5,6]].transposed;
 auto y = x.save;
-assert(x.equal([[1,4],[2,5],[3,6]]));
 y.popFront;
 assert(x.equal([[1,4],[2,5],[3,6]])); // FAILS, x is really [[2,5],[3,6]]
 -----

--- a/changelog/std-range-package-Transposed-deprecate-save.dd
+++ b/changelog/std-range-package-Transposed-deprecate-save.dd
@@ -1,0 +1,12 @@
+`std.range.package.Transposed` deprecate `save`
+
+Consuming Transposed.save consumes the original range as well.
+https://issues.dlang.org/show_bug.cgi?id=17952
+
+-----
+auto x = [[1,2,3],[4,5,6]].transposed;
+auto y = x.save;
+assert(x.equal([[1,4],[2,5],[3,6]]));
+y.popFront;
+assert(x.equal([[1,4],[2,5],[3,6]])); // FAILS, x is really [[2,5],[3,6]]
+-----

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6644,6 +6644,10 @@ if (isForwardRange!RangeOfRanges &&
         return true;
     }
 
+    /**
+    "Do not use Transposed.save, consuming any saved range consumes the original range as well.")
+    */
+    deprecated("This function is obsolete and will be removed November 2018. See the docs for more details.")
     @property Transposed save()
     {
         return Transposed(_input.save);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6645,9 +6645,12 @@ if (isForwardRange!RangeOfRanges &&
     }
 
     /**
-    "Do not use Transposed.save, consuming any saved range consumes the original range as well.")
+       Save an independent copy of Transposed.
+       
+       $(RED `Transposed` does not work as a forward range, consuming a copy made with `save`
+       will consume all copies, even the original sub-ranges fed into `Transposed`.)
     */
-    deprecated("This function is obsolete and will be removed November 2018. See the docs for more details.")
+    deprecated("This function is incorrect and will be removed November 2018. See the docs for more details.")
     @property Transposed save()
     {
         return Transposed(_input.save);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6646,7 +6646,7 @@ if (isForwardRange!RangeOfRanges &&
 
     /**
        Save an independent copy of Transposed.
-       
+
        $(RED `Transposed` does not work as a forward range, consuming a copy made with `save`
        will consume all copies, even the original sub-ranges fed into `Transposed`.)
     */


### PR DESCRIPTION
After discussing with @andralex we decided to deprecate this.
CC @schveiguy 