### PR TITLE
Mark deallocate as nothrow @nogc

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -440,11 +440,16 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     assert(p.ptr is d.ptr && p.length >= d.length);
 }
 
-// Check that goodAllocSize inherits from parent, i.e. GCAllocator
 @system unittest
 {
     import std.experimental.allocator.gc_allocator;
     alias a = AffixAllocator!(GCAllocator, uint).instance;
 
+    // Check that goodAllocSize inherits from parent, i.e. GCAllocator
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(1))()));
+
+    // Ensure deallocate inherits from parent
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    () nothrow @nogc { a.deallocate(b); }();
 }

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -632,7 +632,8 @@ version(Posix) @system unittest
     auto b3 = a.allocate(192 * bs);
     assert(b3.length == 192 * bs);
     assert(a.allocators.length == 2);
-    a.deallocate(b1);
+    // Ensure deallocate inherits from parent allocators
+    () nothrow @nogc { a.deallocate(b1); }();
     b1 = a.allocate(64 * bs);
     assert(b1.length == 64 * bs);
     assert(a.allocators.length == 2);

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -31,10 +31,11 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     */
     Allocator[(max + 1 - min) / step] buckets;
 
+    pure nothrow @safe @nogc
     private Allocator* allocatorFor(size_t n)
     {
         const i = (n - min) / step;
-        return i < buckets.length ? buckets.ptr + i : null;
+        return i < buckets.length ? &buckets[i] : null;
     }
 
     /**
@@ -270,4 +271,6 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     // Free through realloc
     assert(a.reallocate(b, 0));
     assert(b is null);
+    // Ensure deallocate inherits from parent allocators
+    () nothrow @nogc { a.deallocate(b); }();
 }

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -268,8 +268,9 @@ struct FallbackAllocator(Primary, Fallback)
     // This large allocation will go to the GCAllocator
     auto b2 = a.allocate(1024 * 1024);
     assert((() pure nothrow @safe @nogc => a.primary.owns(b2))() == Ternary.no);
-    a.deallocate(b1);
-    a.deallocate(b2);
+    // Ensure deallocate inherits from parent allocators
+    () nothrow @nogc { a.deallocate(b1); }();
+    () nothrow @nogc { a.deallocate(b2); }();
 }
 
 /*

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -396,7 +396,8 @@ struct FreeList(ParentAllocator,
     auto b1 = fl.allocate(7);
     fl.allocate(8);
     assert(fl.root is null);
-    fl.deallocate(b1);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { fl.deallocate(b1); }();
     assert(fl.root !is null);
     fl.allocate(8);
     assert(fl.root is null);
@@ -645,8 +646,7 @@ struct ContiguousFreeList(ParentAllocator,
         if (support.ptr <= b.ptr && b.ptr < support.ptr + support.length)
         {
             // we own this guy
-            import std.conv : text;
-            assert(fl.freeListEligible(b.length), text(b.length));
+            assert(fl.freeListEligible(b.length));
             assert(allocated);
             --allocated;
             // Put manually in the freelist
@@ -712,13 +712,14 @@ struct ContiguousFreeList(ParentAllocator,
     auto b = a.allocate(100);
     assert(a.empty == Ternary.yes);
     assert(b.length == 0);
-    a.deallocate(b);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
     b = a.allocate(64);
     assert(a.empty == Ternary.no);
     assert(b.length == 64);
     assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
-    a.deallocate(b);
+    () nothrow @nogc { a.deallocate(b); }();
 }
 
 @system unittest
@@ -739,14 +740,15 @@ struct ContiguousFreeList(ParentAllocator,
     assert(a.empty == Ternary.no);
     assert(a.allocated == 0);
     assert(b.length == 100);
-    a.deallocate(b);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
     assert(a.empty == Ternary.yes);
     b = a.allocate(64);
     assert(a.empty == Ternary.no);
     assert(b.length == 64);
     assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
-    a.deallocate(b);
+    () nothrow @nogc { a.deallocate(b); }();
 }
 
 @system unittest
@@ -1100,7 +1102,8 @@ struct SharedFreeList(ParentAllocator,
     assert((() nothrow @safe @nogc => a.goodAllocSize(1))() == platformAlignment);
 
     auto b = a.allocate(96);
-    a.deallocate(b);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
 
     void fun()
     {
@@ -1108,7 +1111,7 @@ struct SharedFreeList(ParentAllocator,
         b[] = cast(size_t) &b;
 
         assert(b.equal(repeat(cast(size_t) &b, b.length)));
-        a.deallocate(b);
+        () nothrow @nogc { a.deallocate(b); }();
     }
 
     auto tg = new ThreadGroup;
@@ -1125,7 +1128,8 @@ struct SharedFreeList(ParentAllocator,
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
     auto b = a.allocate(100);
-    a.deallocate(b);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
     assert(a.nodes == 1);
     b = [];
     a.deallocateAll();
@@ -1138,12 +1142,13 @@ struct SharedFreeList(ParentAllocator,
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
     auto b = a.allocate(100);
     auto c = a.allocate(100);
-    a.deallocate(c);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(c); }();
     assert(a.nodes == 1);
     c = [];
     a.minimize();
     assert(a.nodes == 0);
-    a.deallocate(b);
+    () nothrow @nogc { a.deallocate(b); }();
     assert(a.nodes == 1);
     b = [];
     a.minimize();
@@ -1157,8 +1162,9 @@ struct SharedFreeList(ParentAllocator,
     auto b = a.allocate(100);
     auto c = a.allocate(100);
     assert(a.nodes == 0);
-    a.deallocate(b);
-    a.deallocate(c);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
+    () nothrow @nogc { a.deallocate(c); }();
     assert(a.nodes == 2);
     b = [];
     c = [];
@@ -1174,7 +1180,8 @@ struct SharedFreeList(ParentAllocator,
     auto c = a.allocate(64);
     assert(a.reallocate(c, 96));
     assert(c.length == 96);
-    a.deallocate(c);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(c); }();
 }
 
 @system unittest

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -340,9 +340,9 @@ struct FreeTree(ParentAllocator)
         auto b2 = a.allocate(20000);
         auto b3 = a.allocate(30000);
         assert(b1.ptr && b2.ptr && b3.ptr);
-        a.deallocate(b1);
-        a.deallocate(b3);
-        a.deallocate(b2);
+        () nothrow @nogc { a.deallocate(b1); }();
+        () nothrow @nogc { a.deallocate(b3); }();
+        () nothrow @nogc { a.deallocate(b2); }();
         assert(a.formatSizes == "(20480 (12288 32768))", a.formatSizes);
 
         b1 = a.allocate(10000);
@@ -365,7 +365,7 @@ struct FreeTree(ParentAllocator)
         foreach_reverse (b; allocs)
         {
             assert(b.ptr);
-            a.deallocate(b);
+            () nothrow @nogc { a.deallocate(b); }();
         }
         a.assertValid;
         allocs = null;
@@ -425,7 +425,7 @@ struct FreeTree(ParentAllocator)
         byte[] _payload = cast(byte[]) myAlloc.allocate(sz);
         assert(_payload, "_payload is null");
         _payload[] = 0;
-        myAlloc.deallocate(_payload);
+        () nothrow @nogc { myAlloc.deallocate(_payload); }();
     }
 
     f!Mallocator(33);
@@ -446,7 +446,7 @@ struct FreeTree(ParentAllocator)
 
     FreeTree!MyAllocator ft;
     void[] x = ft.allocate(1);
-    ft.deallocate(x);
+    () nothrow @nogc { ft.deallocate(x); }();
     ft.allocate(1000);
     MyAllocator.alive = false;
 }
@@ -475,7 +475,7 @@ struct FreeTree(ParentAllocator)
 
     FreeTree!MyAllocator ft;
     void[] x = ft.allocate(1);
-    ft.deallocate(x);
+    () nothrow @nogc { ft.deallocate(x); }();
     assert(myDeallocCounter == 0);
     x = ft.allocate(1000); // Triggers "desperation mode".
     assert(myDeallocCounter == 1);

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -443,6 +443,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
 
     Params: b = block to be deallocated
     */
+    nothrow @nogc
     bool deallocate(void[] b)
     {
         debug(KRRegion) writefln("KRRegion@%s: deallocate(%s[%s])", &this,
@@ -678,7 +679,7 @@ it actually returns memory to the operating system when possible.
     {
         assert(array[i].ptr);
         assert((() pure nothrow @safe @nogc => alloc.owns(array[i]))() == Ternary.yes);
-        alloc.deallocate(array[i]);
+        () nothrow @nogc { alloc.deallocate(array[i]); }();
     }
 }
 
@@ -716,7 +717,7 @@ it actually returns memory to the operating system when possible.
     foreach (i; 0 .. array.length)
     {
         assert((() pure nothrow @safe @nogc => alloc.owns(array[i]))() == Ternary.yes);
-        alloc.deallocate(array[i]);
+        () nothrow @nogc { alloc.deallocate(array[i]); }();
     }
 }
 
@@ -743,9 +744,9 @@ it actually returns memory to the operating system when possible.
         array ~= alloc.allocate(i);
         assert(array[$ - 1].length == i);
     }
-    alloc.deallocate(array[1]);
-    alloc.deallocate(array[0]);
-    alloc.deallocate(array[2]);
+    () nothrow @nogc { alloc.deallocate(array[1]); }();
+    () nothrow @nogc { alloc.deallocate(array[0]); }();
+    () nothrow @nogc { alloc.deallocate(array[2]); }();
     assert(alloc.allocateAll().length == 1024 * 1024);
 }
 
@@ -777,7 +778,7 @@ it actually returns memory to the operating system when possible.
     foreach (i; 0 .. array.length)
     {
         assert((() pure nothrow @safe @nogc => p.owns(array[i]))() == Ternary.yes);
-        p.deallocate(array[i]);
+        () nothrow @nogc { p.deallocate(array[i]); }();
     }
     auto b = p.allocateAll();
     assert(b.length == 1024 * 1024 - KRRegion!().sizeof, text(b.length));
@@ -790,7 +791,7 @@ it actually returns memory to the operating system when possible.
                     cast(ubyte[])(GCAllocator.instance.allocate(1024 * 1024)));
     auto p = alloc.allocateAll();
     assert(p.length == 1024 * 1024);
-    alloc.deallocateAll();
+    () nothrow @nogc { alloc.deallocateAll(); }();
     p = alloc.allocateAll();
     assert(p.length == 1024 * 1024);
 }
@@ -827,7 +828,7 @@ it actually returns memory to the operating system when possible.
 
         foreach (b; bufs.randomCover)
         {
-            a.deallocate(b);
+            () nothrow @nogc { a.deallocate(b); }();
         }
 
         assert(a.empty == Ternary.yes);
@@ -867,13 +868,13 @@ it actually returns memory to the operating system when possible.
             bufs ~= a.allocate(size);
         }
 
-        a.deallocate(bufs[1]);
+        () nothrow @nogc { a.deallocate(bufs[1]); }();
         bufs ~= a.allocate(sizes[1] - word);
 
-        a.deallocate(bufs[0]);
+        () nothrow @nogc { a.deallocate(bufs[0]); }();
         foreach (i; 2 .. bufs.length)
         {
-            a.deallocate(bufs[i]);
+            () nothrow @nogc { a.deallocate(bufs[i]); }();
         }
 
         assert(a.empty == Ternary.yes);

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -51,6 +51,7 @@ struct NullAllocator
     No-op.
     Precondition: $(D b is null)
     */
+    pure nothrow @nogc
     bool deallocate(void[] b) shared { assert(b is null); return true; }
     /**
     No-op.
@@ -76,7 +77,7 @@ struct NullAllocator
     assert(!NullAllocator.instance.expand(b, 42));
     assert(!NullAllocator.instance.reallocate(b, 42));
     assert(!NullAllocator.instance.alignedReallocate(b, 42, 0));
-    NullAllocator.instance.deallocate(b);
+    () nothrow @nogc { NullAllocator.instance.deallocate(b); }();
     NullAllocator.instance.deallocateAll();
 
     import std.typecons : Ternary;

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -238,6 +238,12 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     testAllocator!(() => MyAlloc());
 
     assert((() pure nothrow @safe @nogc => MyAlloc().goodAllocSize(1))() == 64);
+
+    auto a = MyAlloc();
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    // Ensure deallocate inherits from parent
+    () nothrow @nogc { a.deallocate(b); }();
 }
 
 // Check that owns inherits from parent, i.e. Region

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -228,4 +228,9 @@ struct ScopedAllocator(ParentAllocator)
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(0))()));
     // goodAllocSize is not pure because we are calling through Allocator.instance
     assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
+
+    // Ensure deallocate inherits from parent allocators
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    () nothrow @nogc { a.deallocate(b); }();
 }

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -399,7 +399,10 @@ if (Args.length > 3)
     assert(b.length == 256);
     assert(a.alignedReallocate(b, 42, 512));
     assert(b.length == 42);
-    a.deallocate(b);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
+    // Ensure deallocate inherits from parent allocators
+    () nothrow @nogc { a.deallocate(b); }();
 }
 
 @system unittest
@@ -413,8 +416,9 @@ if (Args.length > 3)
     assert(b.length == 201);
 
     void[] p;
+    assert((() nothrow @safe @nogc => a.resolveInternalPointer(&b[0], p))() == Ternary.yes);
     assert((() nothrow @safe @nogc => a.resolveInternalPointer(null, p))() == Ternary.no);
-    assert((() nothrow @safe @nogc => a.resolveInternalPointer(&b[0], p))(  ) == Ternary.yes);
 
-    a.deallocate(b);
+    // Ensure deallocate inherits from parent allocators
+    () nothrow @nogc { a.deallocate(b); }();
 }

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -695,11 +695,11 @@ public:
         assert(a.numAllocate == 3);
         assert(a.bytesAllocated == 404);
 
-        a.deallocate(b2);
+        () nothrow @nogc { a.deallocate(b2); }();
         assert(a.numDeallocate == 1);
-        a.deallocate(b1);
+        () nothrow @nogc { a.deallocate(b1); }();
         assert(a.numDeallocate == 2);
-        a.deallocate(b3);
+        () nothrow @nogc { a.deallocate(b3); }();
         assert(a.numDeallocate == 3);
         assert(a.numAllocate == a.numDeallocate);
         assert(a.bytesUsed == 0);
@@ -725,9 +725,9 @@ public:
         auto b2 = a.allocate(101);
         auto b3 = a.allocate(202);
 
-        a.deallocate(b2);
-        a.deallocate(b1);
-        a.deallocate(b3);
+        () nothrow @nogc { a.deallocate(b2); }();
+        () nothrow @nogc { a.deallocate(b1); }();
+        () nothrow @nogc { a.deallocate(b3); }();
     }
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.gc_allocator : GCAllocator;

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -80,7 +80,8 @@ struct GCAllocator
     }
 
     /// Ditto
-    pure nothrow @system bool deallocate(void[] b) shared
+    pure nothrow @system @nogc
+    bool deallocate(void[] b) shared
     {
         GC.free(b.ptr);
         return true;
@@ -148,7 +149,7 @@ struct GCAllocator
         assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(s - (s / 2) + 1))() == s);
 
         auto buffer = GCAllocator.instance.allocate(s);
-        scope(exit) GCAllocator.instance.deallocate(buffer);
+        scope(exit) () nothrow @nogc { GCAllocator.instance.deallocate(buffer); }();
 
         void[] p;
         assert((() nothrow @safe => GCAllocator.instance.resolveInternalPointer(null, p))() == Ternary.no);
@@ -158,7 +159,7 @@ struct GCAllocator
         assert(GC.sizeOf(buffer.ptr) == s);
 
         auto buffer2 = GCAllocator.instance.allocate(s - (s / 2) + 1);
-        scope(exit) GCAllocator.instance.deallocate(buffer2);
+        scope(exit) () nothrow @nogc { GCAllocator.instance.deallocate(buffer2); }();
 
         assert(GC.sizeOf(buffer2.ptr) == s);
     }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -84,7 +84,7 @@ struct Mallocator
     {
         int* p = null;
         p = cast(int*) A.instance.allocate(int.sizeof);
-        scope(exit) A.instance.deallocate(p[0 .. int.sizeof]);
+        scope(exit) () nothrow @nogc { A.instance.deallocate(p[0 .. int.sizeof]); }();
         *p = 42;
         assert(*p == 42);
     }

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -40,6 +40,7 @@ struct MmapAllocator
         }
 
         /// Ditto
+        nothrow @nogc
         bool deallocate(void[] b) shared
         {
             import core.sys.posix.sys.mman : munmap;
@@ -63,6 +64,7 @@ struct MmapAllocator
         }
 
         /// Ditto
+        nothrow @nogc
         bool deallocate(void[] b) shared
         {
             return b.ptr is null || VirtualFree(b.ptr, 0, MEM_RELEASE) != 0;
@@ -75,5 +77,5 @@ struct MmapAllocator
     alias alloc = MmapAllocator.instance;
     auto p = alloc.allocate(100);
     assert(p.length == 100);
-    alloc.deallocate(p);
+    () nothrow @nogc { alloc.deallocate(p); }();
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -2974,7 +2974,7 @@ unittest
 
     foreach (b; allox.randomCover)
     {
-        a.deallocate(b);
+        () nothrow @nogc { a.deallocate(b); }();
     }
 
     assert(a.empty == Ternary.yes);
@@ -3006,11 +3006,11 @@ unittest
             switch (uniform(0, 2))
             {
             case 0:
-                a.deallocate(bufs[j]);
+                () nothrow @nogc { a.deallocate(bufs[j]); }();
                 bufs[j] = a.allocate(uniform(0, 4096));
                 break;
             case 1:
-                a.deallocate(bufs[j]);
+                () nothrow @nogc { a.deallocate(bufs[j]); }();
                 bufs[j] = null;
                 break;
             default:


### PR DESCRIPTION
For allocators that define their own `deallocate`, this does not produce any garbage. All the other allocators must infer this from their parents.