### PR TITLE
Add std.concurrency.Generator overload to accept Fiber's stack guard'…

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1533,6 +1533,27 @@ class Generator(T) :
     }
 
     /**
+     * Initializes a generator object which is associated with a static
+     * D function.  The function will be called once to prepare the range
+     * for iteration.
+     *
+     * Params:
+     *  fn = The fiber function.
+     *  sz = The stack size for this fiber.
+     *  guardPageSize = size of the guard page to trap fiber's stack
+     *                  overflows. Refer to $(REF Fiber, core,thread)'s
+     *                  documentation for more details.
+     *
+     * In:
+     *  fn must not be null.
+     */
+    this(void function() fn, size_t sz, size_t guardPageSize)
+    {
+        super(fn, sz, guardPageSize);
+        call();
+    }
+
+    /**
      * Initializes a generator object which is associated with a dynamic
      * D function.  The function will be called once to prepare the range
      * for iteration.
@@ -1564,6 +1585,27 @@ class Generator(T) :
     this(void delegate() dg, size_t sz)
     {
         super(dg, sz);
+        call();
+    }
+
+    /**
+     * Initializes a generator object which is associated with a dynamic
+     * D function.  The function will be called once to prepare the range
+     * for iteration.
+     *
+     * Params:
+     *  dg = The fiber function.
+     *  sz = The stack size for this fiber.
+     *  guardPageSize = size of the guard page to trap fiber's stack
+     *                  overflows. Refer to $(REF Fiber, core,thread)'s
+     *                  documentation for more details.
+     *
+     * In:
+     *  dg must not be null.
+     */
+    this(void delegate() dg, size_t sz, size_t guardPageSize)
+    {
+        super(dg, sz, guardPageSize);
         call();
     }
 


### PR DESCRIPTION
…s size

As of 2.075 Fiber's stack protection pages are on by default, preventing
OS to merge mmaped ranges, so the total number of mmaped ranges is much
higher than before. In case there's no need for the stack overflow
protection and the high number of fibers, it may be wise to change this
setting, so the Generator's constructor overload is added which supports
this.