### PR TITLE
win64: build C files with /GS- to avoid "security" calls

### DIFF
--- a/etc/c/zlib/win64.mak
+++ b/etc/c/zlib/win64.mak
@@ -13,7 +13,7 @@ LDFLAGS=/nologo
 O=.obj
 
 # do not preselect a C runtime (extracted from the line above to make the auto tester happy)
-CFLAGS=$(CFLAGS) /Zl
+CFLAGS=$(CFLAGS) /Zl /GS-
 
 # variables
 


### PR DESCRIPTION
This avoids some symbol references into the VC compiler runtime and makes it easier to replace it with another runtime.
I suspect there are no similar security checks on other platforms.