### PR TITLE
Do not expose unmangled ZLIB_VERSION, Z_NULL and ZLIB_VERNUM needlessly

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -228,7 +228,8 @@ enum
 }
 /* The deflate compression method (the only one supported in this version) */
 
-const int Z_NULL = 0;  /* for initializing zalloc, zfree, opaque */
+/// for initializing zalloc, zfree, opaque (extern(D) for mangling)
+extern(D) immutable void* Z_NULL = null;
 
                         /* basic functions */
 

--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -40,8 +40,9 @@ import core.stdc.config;
 nothrow:
 extern (C):
 
-const char[] ZLIB_VERSION = "1.2.11";
-const ZLIB_VERNUM = 0x12b0;
+// Those are extern(D) as they should be mangled
+extern(D) immutable string ZLIB_VERSION = "1.2.11";
+extern(D) immutable ZLIB_VERNUM = 0x12b0;
 
 /*
     The 'zlib' compression library provides in-memory compression and


### PR DESCRIPTION
Before this change, ZLIB_VERSION and ZLIB_VERNUM were unmangled TLS variables.
That exposure was unneeded, and could lead to some clash with other zlib binding which would prevent linking.