### PR TITLE
Remove trailing whitespace in transposed changelog entry

### DIFF
--- a/changelog/std-range-package-Transposed-deprecate-save.dd
+++ b/changelog/std-range-package-Transposed-deprecate-save.dd
@@ -1,6 +1,6 @@
 Deprecate `save` for `std.range.package.Transposed`
 
-Transposed is incorrectly marked as a forward range. Its `popFront` primitive 
+Transposed is incorrectly marked as a forward range. Its `popFront` primitive
 cannot be used without affecting any other copies made with `save`. `save` will be
 removed from Transposed in November 2018.
 


### PR DESCRIPTION
https://github.com/dlang/dlang.org/pull/1921 is failing due to the trailing whitespace in the
changelog entry.

Ideally we should build the preview changelog again, s.t. new changelog files will be tested during the stable/master cutoff.