### PR TITLE
Bump stable DMD and DUB version

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -2,8 +2,8 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
-DSCANNER_DMD_VER=2.071.2 # dscanner needs a more up-to-date version
+HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
+DSCANNER_DMD_VER=2.077.0 # dscanner needs a more up-to-date version
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 DUB=${DUB:-$HOME/dlang/dub/dub}
 N=2


### PR DESCRIPTION
With DUB 1.6.0 (part of the DMD 2.077.0 release), DUB will retry
downloads from the DUB registry and alternatively use fallback mirrors.
../dmd/src/posix.mak uses 2.072.0 atm, hence the bump of the host
version.