### PR TITLE
alignedReallocate returns false on failure and FallbackAllocator needs stateless allocators for test

### DIFF
--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -401,6 +401,13 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     assert(a.primary.owns(b2) == Ternary.no);
 }
 
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    testAllocator!(() => fallbackAllocator(Region!GCAllocator(1024), GCAllocator.instance));
+}
+
 // Ensure `owns` inherits function attributes
 @system unittest
 {

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -24,7 +24,8 @@ struct FallbackAllocator(Primary, Fallback)
     import std.traits : hasMember;
     import std.typecons : Ternary;
 
-    // Need at least one stateless allocator for this to work
+    // Need both allocators to be stateless
+    // This is to avoid using default initialized stateful allocators
     static if (!stateSize!Primary && !stateSize!Fallback)
     @system unittest
     {

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -25,7 +25,7 @@ struct FallbackAllocator(Primary, Fallback)
     import std.typecons : Ternary;
 
     // Need at least one stateless allocator for this to work
-    static if (!stateSize!Primary || !stateSize!Fallback)
+    static if (!stateSize!Primary && !stateSize!Fallback)
     @system unittest
     {
         testAllocator!(() => FallbackAllocator());

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -391,6 +391,7 @@ bool alignedReallocate(Allocator)(ref Allocator alloc,
         if (b.length == s) return true;
     }
     auto newB = alloc.alignedAllocate(s, a);
+    if (newB.length != s) return false;
     if (newB.length <= b.length) newB[] = b[0 .. newB.length];
     else newB[0 .. b.length] = b[];
     static if (hasMember!(Allocator, "deallocate"))

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -380,6 +380,7 @@ implementation of $(D reallocate).
 */
 bool alignedReallocate(Allocator)(ref Allocator alloc,
         ref void[] b, size_t s, uint a)
+if (hasMember!(Allocator, "alignedAllocate"))
 {
     static if (hasMember!(Allocator, "expand"))
     {


### PR DESCRIPTION
alignedReallocate should return false if alignedAllocate fails.

This change however caused the FallbackAllocator tests to fail.
This is because testAllocator uses a FallbackAllocator with implicit constructor, which initializes its members, the primary and fallback allocators, to default values. 
Therefore stateful allocators used by the FallbackAllocator would be not properly initialized, causing tests to fail.

The change is to run tests for FallbackAllocator only for stateless allocators.

Thanks,
Alex 