### PR TITLE
Handle structs with @disable this in Nullable

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2356,7 +2356,7 @@ struct Nullable(T)
     }
     else
     {
-        static assert(false, "Cannot construct Nullable("~T.stringof~"): type has no default constructor and overloaded assignment.");
+        static assert(false, "Cannot construct " ~ typeof(this).stringof ~ ": type has no default constructor and overloaded assignment.");
     }
 
     private bool _isNull = true;
@@ -2957,6 +2957,19 @@ auto nullable(T)(T t)
     }
     Nullable!TestToString ntts = new TestToString(2.5);
     assert(ntts.to!string() == "2.5");
+}
+
+// Bugzilla 14477
+@safe unittest
+{
+    static struct DisabledDefaultConstructor
+    {
+        @disable this();
+        this(int i) { }
+    }
+    Nullable!DisabledDefaultConstructor var;
+    var = DisabledDefaultConstructor(5);
+    var.nullify;
 }
 
 /**

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2357,7 +2357,7 @@ struct Nullable(T)
     else
     {
         static assert(false,
-                      "Cannot construct "~typeof(this).stringof~
+                      "Cannot construct " ~ typeof(this).stringof ~
                       ": type has no default constructor and overloaded assignment."
         );
     }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2356,7 +2356,10 @@ struct Nullable(T)
     }
     else
     {
-        static assert(false, "Cannot construct " ~ typeof(this).stringof ~ ": type has no default constructor and overloaded assignment.");
+        static assert(false,
+                      "Cannot construct "~typeof(this).stringof~
+                      ": type has no default constructor and overloaded assignment."
+        );
     }
 
     private bool _isNull = true;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2352,7 +2352,7 @@ struct Nullable(T)
     // that we're assigning to an uninitialized variable.
     else static if (!hasElaborateAssign!T)
     {
-        private T _value = void;
+        private T _value = T.init;
     }
     else
     {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2343,7 +2343,22 @@ Practically $(D Nullable!T) stores a $(D T) and a $(D bool).
  */
 struct Nullable(T)
 {
-    private T _value;
+    // simple case: type is freely constructable
+    static if (__traits(compiles, { T _value; }))
+    {
+        private T _value;
+    }
+    // type is not constructable, but also has no way to notice
+    // that we're assigning to an uninitialized variable.
+    else static if (!hasElaborateAssign!T)
+    {
+        private T _value = void;
+    }
+    else
+    {
+        static assert(false, "Cannot construct Nullable("~T.stringof~"): type has no default constructor and overloaded assignment.");
+    }
+
     private bool _isNull = true;
 
 /**


### PR DESCRIPTION
Currently, `Nullable` always constructs a default value for the type stored in it. This breaks the use of Nullable with types that `disable @this()`, for no good reason. If such types are detected, and the type in question does not use elaborate assignment (which would allow it to read uninitialized values via = void), then switch to `T _value = void;`. Otherwise, error.