### PR TITLE
Simplify hasElaborateConstructor.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3395,8 +3395,7 @@ template hasElaborateCopyConstructor(S)
     }
     else static if (is(S == struct))
     {
-        enum hasElaborateCopyConstructor = hasMember!(S, "__postblit")
-            || anySatisfy!(.hasElaborateCopyConstructor, FieldTypeTuple!S);
+        enum hasElaborateCopyConstructor = hasMember!(S, "__xpostblit");
     }
     else
     {


### PR DESCRIPTION
__postblit represents a directly declared postblit constructor, but any
struct which either has a postblit constructor or which has a member
which has a postblit constructor will have __xpostblit. So, we should
only need to check for __xpostblit instead of recursively checking all
of the member variables for __postblit.