### PR TITLE
fix Issue 17996 - don't build libphobos2.a with PIC for i386

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -54,12 +54,7 @@ ifneq ($(BUILD),release)
     endif
 endif
 
-# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
-ifeq ($(DISABLE_PIC),)
-    PIC_FLAG:=-fPIC
-else
-    PIC_FLAG:=
-endif
+override PIC:=$(if $(PIC),-fPIC,)
 
 # Configurable stuff that's rarely edited
 INSTALL_DIR = ../install
@@ -120,7 +115,7 @@ else
 endif
 
 # Set DFLAGS
-DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC_FLAG)
+DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC)
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
 else
@@ -312,6 +307,7 @@ $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
 $(ROOT)/$(SONAME): $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
+$(LIBSO): override PIC:=-fPIC
 $(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO)
 	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
 
@@ -353,6 +349,7 @@ UT_LIBSO:=$(ROOT)/unittest/libphobos2-ut.so
 
 $(UT_D_OBJS): $(DRUNTIMESO)
 
+$(UT_LIBSO): override PIC:=-fPIC
 $(UT_LIBSO): $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO)
 	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib=
 

--- a/posix.mak
+++ b/posix.mak
@@ -40,7 +40,7 @@ ifeq (osx,$(OS))
 	export MACOSX_DEPLOYMENT_TARGET=10.7
 endif
 
-# Default to a release built, override with BUILD=debug
+# Default to a release build, override with BUILD=debug
 ifeq (,$(BUILD))
 BUILD_WAS_SPECIFIED=0
 BUILD=release
@@ -54,7 +54,20 @@ ifneq ($(BUILD),release)
     endif
 endif
 
-override PIC:=$(if $(PIC),-fPIC,)
+# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# Note that shared libraries and C files are always compiled with PIC.
+ifeq ($(PIC),)
+    ifeq ($(MODEL),64) # x86_64
+        PIC:=1
+    else
+        PIC:=0
+    endif
+endif
+ifeq ($(PIC),1)
+    override PIC:=-fPIC
+else
+    override PIC:=
+endif
 
 # Configurable stuff that's rarely edited
 INSTALL_DIR = ../install


### PR DESCRIPTION
- use MODEL=64/32 to decide on default
- allow overriding default with explicit PIC=0/1 make args