### PR TITLE
Replace `body` keyword with its replacement: `do`

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -69,7 +69,7 @@ ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 DUB=dub
 TOOLS_DIR=../tools
-DSCANNER_HASH=eb16fe4e8610e7477e09710fee1137d657a56f72
+DSCANNER_HASH=bb32e9f1e3e5206deb11b3dbc43ad44e23fabf96
 DSCANNER_DIR=../dscanner-$(DSCANNER_HASH)
 
 # Documentation-related stuff

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -535,7 +535,7 @@ in
     import std.functional : greaterThan;
     assert(!lower.greaterThan(upper));
 }
-body
+do
 {
     return max(lower, min(upper, val));
 }

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -430,7 +430,7 @@ private struct _Cache(R, bool bidir)
             {
                 assert(low <= high, "Bounds error when slicing cache.");
             }
-            body
+            do
             {
                 import std.range : takeExactly;
                 return this[low .. $].takeExactly(high - low);

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1278,7 +1278,7 @@ in
 {
     assert(!r.empty, "r is an empty range");
 }
-body
+do
 {
     alias Element = ElementType!Range;
     Unqual!Element seed = r.front;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2354,7 +2354,7 @@ private template TimSortImpl(alias pred, R)
     {
         assert(ret <= range.length);
     }
-    body
+    do
     {
         import std.algorithm.mutation : reverse;
 
@@ -2379,7 +2379,7 @@ private template TimSortImpl(alias pred, R)
     {
         if (!__ctfe) assert(isSorted!pred(range));
     }
-    body
+    do
     {
         import std.algorithm.mutation : move;
 
@@ -2412,7 +2412,7 @@ private template TimSortImpl(alias pred, R)
         assert(stack.length >= 2);
         assert(stack.length - at == 2 || stack.length - at == 3);
     }
-    body
+    do
     {
         immutable base = stack[at].base;
         immutable mid  = stack[at].length;
@@ -2437,7 +2437,7 @@ private template TimSortImpl(alias pred, R)
             assert(isSorted!pred(range[mid .. range.length]));
         }
     }
-    body
+    do
     {
         assert(mid < range.length);
 
@@ -2468,7 +2468,7 @@ private template TimSortImpl(alias pred, R)
     {
         assert(ret.length >= minCapacity);
     }
-    body
+    do
     {
         if (temp.length < minCapacity)
         {
@@ -2489,7 +2489,7 @@ private template TimSortImpl(alias pred, R)
     {
         if (!__ctfe) assert(isSorted!pred(range));
     }
-    body
+    do
     {
         import std.algorithm.mutation : copy;
 
@@ -2572,7 +2572,7 @@ private template TimSortImpl(alias pred, R)
     {
         if (!__ctfe) assert(isSorted!pred(range));
     }
-    body
+    do
     {
         import std.algorithm.mutation : copy;
 
@@ -2678,7 +2678,7 @@ private template TimSortImpl(alias pred, R)
         {
             assert(ret <= range.length);
         }
-        body
+        do
         {
             size_t lower = 0, center = 1, upper = range.length;
             alias gap = center;
@@ -3349,7 +3349,7 @@ out
     assert(r[0 .. pivot + 1].all!(x => !lp(r[pivot], x)));
     assert(r[pivot + 1 .. r.length].all!(x => !lp(x, r[pivot])));
 }
-body
+do
 {
     import std.algorithm.mutation : swapAt;
     import std.algorithm.searching : all;

--- a/std/array.d
+++ b/std/array.d
@@ -2787,7 +2787,7 @@ in
     // Verify that slice[] really is a slice of s[]
     assert(overlap(s, slice) is slice);
 }
-body
+do
 {
     auto result = new T[s.length - slice.length + replacement.length];
     immutable so = slice.ptr - s.ptr;

--- a/std/base64.d
+++ b/std/base64.d
@@ -227,7 +227,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     {
         assert(result.length == encodeLength(source.length), "The length of result is different from Base64");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -310,7 +310,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         // @@@BUG@@@ D's DbC can't caputre an argument of function and store the result of precondition.
         //assert(result.length == encodeLength(source.length), "The length of result is different from Base64");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -397,7 +397,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     {
         assert(result == encodeLength(source.length), "The number of put is different from the length of Base64");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -486,7 +486,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         // @@@BUG@@@ Workaround for DbC problem.
         //assert(result == encodeLength(source.length), "The number of put is different from the length of Base64");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -1005,7 +1005,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable expect = realDecodeLength(source);
         assert(result.length == expect, "The length of result is different from the expected length");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -1091,7 +1091,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         //immutable expect = decodeLength(source.length) - 2;
         //assert(result.length >= expect, "The length of result is smaller than expected length");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -1182,7 +1182,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         immutable expect = realDecodeLength(source);
         assert(result == expect, "The result of decode is different from the expected");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -1271,7 +1271,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         //immutable expect = decodeLength(source.length) - 2;
         //assert(result >= expect, "The length of result is smaller than expected length");
     }
-    body
+    do
     {
         immutable srcLen = source.length;
         if (srcLen == 0)

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -849,7 +849,7 @@ public:
     {
         assert(i < _len);
     }
-    body
+    do
     {
         return cast(bool) bt(_ptr, i);
     }
@@ -877,7 +877,7 @@ public:
     {
         assert(i < _len);
     }
-    body
+    do
     {
         if (b)
             bts(_ptr, i);
@@ -929,7 +929,7 @@ public:
         assert(start <= end);
         assert(end <= length);
     }
-    body
+    do
     {
         size_t startBlock = start / bitsPerSizeT;
         size_t endBlock = end / bitsPerSizeT;
@@ -1208,7 +1208,7 @@ public:
     {
         assert(result == this);
     }
-    body
+    do
     {
         if (_len >= 2)
         {
@@ -1252,7 +1252,7 @@ public:
     {
         assert(result == this);
     }
-    body
+    do
     {
         if (_len >= 2)
         {
@@ -1506,7 +1506,7 @@ public:
         assert(numbits <= v.length * 8);
         assert(v.length % size_t.sizeof == 0);
     }
-    body
+    do
     {
         _ptr = cast(size_t*) v.ptr;
         _len = numbits;
@@ -1615,7 +1615,7 @@ public:
     {
         assert(_len == e2.length);
     }
-    body
+    do
     {
         auto dim = this.dim;
 
@@ -1721,7 +1721,7 @@ public:
     {
         assert(_len == e2.length);
     }
-    body
+    do
     {
         foreach (i; 0 .. fullWords)
         {
@@ -1977,7 +1977,7 @@ public:
     {
         assert(nbits < bitsPerSizeT);
     }
-    body
+    do
     {
         if (nbits == 0)
             return lower;
@@ -2014,7 +2014,7 @@ public:
     {
         assert(nbits < bitsPerSizeT);
     }
-    body
+    do
     {
         if (nbits == 0)
             return upper;

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -649,7 +649,7 @@ in
            "Cannot receive a message until a thread was spawned "
            ~ "or thisTid was passed to a running thread.");
 }
-body
+do
 {
     checkops( ops );
 
@@ -737,7 +737,7 @@ in
     assert(thisInfo.ident.mbox !is null,
         "Cannot receive a message until a thread was spawned or thisTid was passed to a running thread.");
 }
-body
+do
 {
     import std.format : format;
     import std.typecons : Tuple;
@@ -801,7 +801,7 @@ in
     assert(thisInfo.ident.mbox !is null,
         "Cannot receive a message until a thread was spawned or thisTid was passed to a running thread.");
 }
-body
+do
 {
     checkops(ops);
 

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -185,7 +185,7 @@ struct RBNode(V)
     {
         assert(_left !is null);
     }
-    body
+    do
     {
         // sets _left._parent also
         if (isLeftNode)
@@ -228,7 +228,7 @@ struct RBNode(V)
     {
         assert(_right !is null);
     }
-    body
+    do
     {
         // sets _right._parent also
         if (isLeftNode)
@@ -257,7 +257,7 @@ struct RBNode(V)
     {
         assert(_parent !is null);
     }
-    body
+    do
     {
         return _parent._left is &this;
     }

--- a/std/conv.d
+++ b/std/conv.d
@@ -1324,7 +1324,7 @@ in
 {
     assert(radix >= 2 && radix <= 36);
 }
-body
+do
 {
     alias EEType = Unqual!(ElementEncodingType!T);
 
@@ -2444,7 +2444,7 @@ in
 {
     assert(radix >= 2 && radix <= 36);
 }
-body
+do
 {
     import core.checkedint : mulu, addu;
     import std.exception : enforce;

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -3398,7 +3398,7 @@ public:
         assert(result._date == Date.min);
         assert(result._tod == TimeOfDay.min);
     }
-    body
+    do
     {
         auto dt = DateTime.init;
         dt._date._year = short.min;
@@ -3425,7 +3425,7 @@ public:
         assert(result._date == Date.max);
         assert(result._tod == TimeOfDay.max);
     }
-    body
+    do
     {
         auto dt = DateTime.init;
         dt._date._year = short.max;
@@ -9996,7 +9996,7 @@ in
 {
     assert(valid!"months"(month));
 }
-body
+do
 {
     switch (month)
     {

--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -199,7 +199,7 @@ public:
       +/
     void start() @safe nothrow @nogc
     in { assert(!_running, "start was called when the StopWatch was already running."); }
-    body
+    do
     {
         _running = true;
         _timeStarted = MonoTime.currTime;
@@ -227,7 +227,7 @@ public:
       +/
     void stop() @safe nothrow @nogc
     in { assert(_running, "stop was called when the StopWatch was not running."); }
-    body
+    do
     {
         _running = false;
         _ticksElapsed += MonoTime.currTime.ticks - _timeStarted.ticks;

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -558,7 +558,7 @@ struct MurmurHash3(uint size /* 32 or 128 */ , uint opt = size_t.sizeof == 8 ? 6
         static assert(isUnsigned!T);
         debug assert(y >= 0 && y <= (T.sizeof * 8));
     }
-    body
+    do
     {
         return ((x << y) | (x >> ((T.sizeof * 8) - y)));
     }

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -933,7 +933,7 @@ if (isDigest!T) : Digest
         {
             assert(buf.length >= this.length);
         }
-        body
+        do
         {
             enum string msg = "Buffer needs to be at least " ~ digestLength!(T).stringof ~ " bytes " ~
                 "big, check " ~ typeof(this).stringof ~ ".length!";
@@ -969,7 +969,7 @@ if (isDigest!T) : Digest
             {
                 assert(buf.length >= this.length);
             }
-            body
+            do
             {
                 enum string msg = "Buffer needs to be at least " ~ digestLength!(T).stringof ~ " bytes " ~
                     "big, check " ~ typeof(this).stringof ~ ".length!";

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -603,7 +603,7 @@ struct CodePoints(E)
     {
         assert(isValid(s));
     }
-    body
+    do
     {
         this.s = s;
     }
@@ -671,7 +671,7 @@ struct CodeUnits(E)
     {
         assert(isValidCodePoint(d));
     }
-    body
+    do
     {
         s = encode!(E)(d);
     }
@@ -735,7 +735,7 @@ private template GenericEncoder()
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         return 1;
     }
@@ -827,7 +827,7 @@ template EncoderInstance(CharType : AsciiChar)
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         return 1;
     }
@@ -910,7 +910,7 @@ template EncoderInstance(CharType : Latin1Char)
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         return 1;
     }
@@ -1307,7 +1307,7 @@ template EncoderInstance(CharType : char)
     {
         assert(c >= 0x80);
     }
-    body
+    do
     {
         return tailTable[c-0x80];
     }
@@ -1317,7 +1317,7 @@ template EncoderInstance(CharType : char)
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         if (c < 0x80) return 1;
         if (c < 0x800) return 2;
@@ -1461,7 +1461,7 @@ template EncoderInstance(CharType : wchar)
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         return (c < 0x10000) ? 1 : 2;
     }
@@ -1558,7 +1558,7 @@ template EncoderInstance(CharType : dchar)
     {
         assert(canEncode(c));
     }
-    body
+    do
     {
         return 1;
     }
@@ -1857,7 +1857,7 @@ in
     const(E)[] u = s;
     assert(safeDecode(u) != INVALID_SEQUENCE);
 }
-body
+do
 {
     auto before = s.length;
     EncoderInstance!(E).skip(s);
@@ -1889,7 +1889,7 @@ in
     assert(s.length != 0);
     assert(isValid(s));
 }
-body
+do
 {
     const(E)[] t = s;
     EncoderInstance!(E).decodeReverse(s);
@@ -1925,7 +1925,7 @@ in
     assert(isValid(s));
     assert(n >= 0);
 }
-body
+do
 {
     const(E)[] t = s;
     for (size_t i=0; i<n; ++i) EncoderInstance!(E).skip(s);
@@ -1965,7 +1965,7 @@ in
     auto u = s;
     assert(safeDecode(u) != INVALID_SEQUENCE);
 }
-body
+do
 {
     return EncoderInstance!(typeof(s[0])).decode(s);
 }
@@ -1991,7 +1991,7 @@ in
     assert(s.length != 0);
     assert(isValid(s));
 }
-body
+do
 {
     return EncoderInstance!(E).decodeReverse(s);
 }
@@ -2017,7 +2017,7 @@ in
 {
     assert(s.length != 0);
 }
-body
+do
 {
     return EncoderInstance!(typeof(s[0])).safeDecode(s);
 }
@@ -2042,7 +2042,7 @@ in
 {
     assert(isValidCodePoint(c));
 }
-body
+do
 {
     return EncoderInstance!(E).encodedLength(c);
 }
@@ -2074,7 +2074,7 @@ in
 {
     assert(isValidCodePoint(c));
 }
-body
+do
 {
     return EncoderInstance!(E).encode(c);
 }
@@ -2111,7 +2111,7 @@ in
 {
     assert(isValidCodePoint(c));
 }
-body
+do
 {
     E[] t = array;
     EncoderInstance!(E).encode(c,t);
@@ -2217,7 +2217,7 @@ in
 {
     assert(isValidCodePoint(c));
 }
-body
+do
 {
     EncoderInstance!(E).encode(c,dg);
 }
@@ -2280,7 +2280,7 @@ in
 {
     assert(isValid(s));
 }
-body
+do
 {
     return CodePoints!(E)(s);
 }
@@ -2321,7 +2321,7 @@ in
 {
     assert(isValidCodePoint(c));
 }
-body
+do
 {
     return CodeUnits!(E)(c);
 }
@@ -2364,7 +2364,7 @@ in
 {
     assert(isValid(s));
 }
-body
+do
 {
     static if (is(Src == Dst) && is(Src == immutable))
     {
@@ -2790,7 +2790,7 @@ abstract class EncodingScheme
         const(ubyte)[] u = s;
         assert(safeDecode(u) != INVALID_SEQUENCE);
     }
-    body
+    do
     {
         const(ubyte)[] t = s;
         decode(s);
@@ -2811,7 +2811,7 @@ abstract class EncodingScheme
     {
         assert(isValid(s));
     }
-    body
+    do
     {
         size_t n = 0;
         while (s.length != 0)
@@ -2838,7 +2838,7 @@ abstract class EncodingScheme
         assert(isValid(s));
         assert(n >= 0);
     }
-    body
+    do
     {
         const(ubyte)[] t = s;
         for (size_t i=0; i<n; ++i) decode(s);
@@ -3489,7 +3489,7 @@ class EncodingSchemeUtf16Native : EncodingScheme
         {
             assert((s.length & 1) == 0);
         }
-        body
+        do
         {
             auto t = cast(const(wchar)[]) s;
             dchar c = std.encoding.decode(t);
@@ -3502,7 +3502,7 @@ class EncodingSchemeUtf16Native : EncodingScheme
         {
             assert((s.length & 1) == 0);
         }
-        body
+        do
         {
             auto t = cast(const(wchar)[]) s;
             dchar c = std.encoding.safeDecode(t);
@@ -3585,7 +3585,7 @@ class EncodingSchemeUtf32Native : EncodingScheme
         {
             assert((s.length & 3) == 0);
         }
-        body
+        do
         {
             auto t = cast(const(dchar)[]) s;
             dchar c = std.encoding.decode(t);
@@ -3598,7 +3598,7 @@ class EncodingSchemeUtf32Native : EncodingScheme
         {
             assert((s.length & 3) == 0);
         }
-        body
+        do
         {
             auto t = cast(const(dchar)[]) s;
             dchar c = std.encoding.safeDecode(t);

--- a/std/format.d
+++ b/std/format.d
@@ -5208,7 +5208,7 @@ in
 {
     assert(spec.spec == '(');
 }
-body
+do
 {
     debug (unformatRange) printf("unformatRange:\n");
 

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -45,7 +45,7 @@ version(unittest)
 @property inout(C)[] asArray(C)(inout C* cstr) pure nothrow @nogc @trusted
 if (isSomeChar!C)
 in { assert(cstr); }
-body
+do
 {
     size_t length = 0;
     while (cstr[length])

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1720,7 +1720,7 @@ in
     static if (hasLength!Range)
         assert((data.length >= 2) || (data.length == 1 && s.length == 1));
 }
-body
+do
 {
     import std.conv : ConvException;
 
@@ -1860,7 +1860,7 @@ in
     assert(result.length == left.length + right.length);
     assert(right.length>1);
 }
-body
+do
 {
     result[left.length] = multibyteMul(result[0 .. left.length], left, right[0], 0);
     multibyteMultiplyAccumulate(result[1..$], left, right[1..$]);
@@ -1873,7 +1873,7 @@ in
     assert(result.length == 2*x.length);
     assert(x.length>1);
 }
-body
+do
 {
     multibyteSquare(result, x);
 }
@@ -1890,7 +1890,7 @@ in
     assert(left.length >= right.length);
     assert(right.length>0);
 }
-body
+do
 {
     uint carry = multibyteAdd(result[0 .. right.length],
             left[0 .. right.length], right, 0);
@@ -1912,7 +1912,7 @@ in
     assert(left.length >= right.length);
     assert(right.length>0);
 }
-body
+do
 {
     BigDigit carry = multibyteSub(result[0 .. right.length],
             left[0 .. right.length], right, 0);
@@ -2390,7 +2390,7 @@ in
     assert((mayOverflow ? u.length-1 : u.length) >= v.length);
     assert(scratch.length >= quotient.length + (mayOverflow ? 0 : 1));
 }
-body
+do
 {
     if (quotient.length < FASTDIVLIMIT)
     {

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -1024,7 +1024,7 @@ real normalDistributionInvImpl(real p)
 in {
   assert(p >= 0.0L && p <= 1.0L, "Domain error");
 }
-body
+do
 {
 static immutable real[8] P0 =
 [ -0x1.758f4d969484bfdcp-7, 0x1.53cee17a59259dd2p-3,

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1300,7 +1300,7 @@ in {
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+do {
     /* left tail of incomplete gamma function:
      *
      *          inf.      k
@@ -1344,7 +1344,7 @@ in {
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+do {
     if (x == 0)
         return 1.0L;
     if ( (x < 1.0L) || (x < a) )
@@ -1430,7 +1430,7 @@ in {
   assert(p >= 0 && p <= 1);
   assert(a>0);
 }
-body {
+do {
     if (p == 0) return real.infinity;
 
     real y0 = p;

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1296,11 +1296,13 @@ real betaDistPowerSeries(real a, real b, real x )
  * values of a and x.
  */
 real gammaIncomplete(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-do {
+do
+{
     /* left tail of incomplete gamma function:
      *
      *          inf.      k
@@ -1340,11 +1342,13 @@ do {
 
 /** ditto */
 real gammaIncompleteCompl(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-do {
+do
+{
     if (x == 0)
         return 1.0L;
     if ( (x < 1.0L) || (x < a) )
@@ -1426,11 +1430,13 @@ do {
  * root of incompleteGammaCompl(a,x) - p = 0.
  */
 real gammaIncompleteComplInv(real a, real p)
-in {
+in
+{
   assert(p >= 0 && p <= 1);
   assert(a>0);
 }
-do {
+do
+{
     if (p == 0) return real.infinity;
 
     real y0 = p;

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -122,7 +122,7 @@ if (isAssignable!T &&
             assert(!(buf.length & wasResized));    // assure even length of scratch buffer space
             assert(buf.length <= uint.max);     // because we cast to uint later
         }
-    body
+    do
     {
         this.buf = buf.ptr;
         this.bufLen = cast(uint) buf.length;
@@ -203,7 +203,7 @@ if (isAssignable!T &&
             assert(upper <= bufLen);
             assert(lower <= upper);
         }
-    body
+    do
     {
         return buf[lower .. upper];
     }
@@ -244,7 +244,7 @@ if (isAssignable!T &&
         {
             assert(i <= this.used);
         }
-    body
+    do
     {
         this.used = cast(uint) i;
     }
@@ -263,7 +263,7 @@ if (isAssignable!T &&
         {
             assert(newsize <= uint.max);
         }
-    body
+    do
     {
         //writefln("%s: oldsize %s newsize %s", id, buf.length, newsize);
         newsize |= wasResized;

--- a/std/math.d
+++ b/std/math.d
@@ -7110,7 +7110,7 @@ in
     assert(signbit(x) == signbit(y));
     assert(x == x && y == y);
 }
-body
+do
 {
     // Runtime behaviour for contract violation:
     // If signs are opposite, or one is a NaN, return 0.
@@ -7244,7 +7244,7 @@ in
 {
     assert(A.length > 0);
 }
-body
+do
 {
     static if (is(Unqual!T2 == real))
     {

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -253,21 +253,25 @@ real betaIncompleteInverse(real a, real b, real y )
  * values of a and x.
  */
 real gammaIncomplete(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-do {
+do
+{
     return std.internal.math.gammafunction.gammaIncomplete(a, x);
 }
 
 /** ditto */
 real gammaIncompleteCompl(real a, real x )
-in {
+in
+{
    assert(x >= 0);
    assert(a > 0);
 }
-do {
+do
+{
     return std.internal.math.gammafunction.gammaIncompleteCompl(a, x);
 }
 
@@ -278,11 +282,13 @@ do {
  *  gammaIncompleteCompl( a, x ) = p.
  */
 real gammaIncompleteComplInverse(real a, real p)
-in {
+in
+{
   assert(p >= 0 && p <= 1);
   assert(a > 0);
 }
-do {
+do
+{
     return std.internal.math.gammafunction.gammaIncompleteComplInv(a, p);
 }
 
@@ -352,7 +358,8 @@ real normalDistribution(real x)
  * Note: This function is only implemented to 80 bit precision.
  */
 real normalDistributionInverse(real p)
-in {
+in
+{
   assert(p >= 0.0L && p <= 1.0L, "Domain error");
 }
 do

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -257,7 +257,7 @@ in {
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+do {
     return std.internal.math.gammafunction.gammaIncomplete(a, x);
 }
 
@@ -267,7 +267,7 @@ in {
    assert(x >= 0);
    assert(a > 0);
 }
-body {
+do {
     return std.internal.math.gammafunction.gammaIncompleteCompl(a, x);
 }
 
@@ -282,7 +282,7 @@ in {
   assert(p >= 0 && p <= 1);
   assert(a > 0);
 }
-body {
+do {
     return std.internal.math.gammafunction.gammaIncompleteComplInv(a, p);
 }
 
@@ -355,7 +355,7 @@ real normalDistributionInverse(real p)
 in {
   assert(p >= 0.0L && p <= 1.0L, "Domain error");
 }
-body
+do
 {
     return std.internal.math.errorfunction.normalDistributionInvImpl(p);
 }

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -869,7 +869,7 @@ in
     assert(!ax.isNaN() && !bx.isNaN(), "Limits must not be NaN");
     assert(signbit(fax) != signbit(fbx), "Parameters must bracket the root.");
 }
-body
+do
 {
     // Author: Don Clugston. This code is (heavily) modified from TOMS748
     // (www.netlib.org).  The changes to improve the worst-cast performance are
@@ -1451,7 +1451,7 @@ out (result)
 {
     assert(isFinite(result.x));
 }
-body
+do
 {
     alias R = Unqual!(CommonType!(ReturnType!DF, T));
     // c is the squared inverse of the golden ratio
@@ -2785,7 +2785,7 @@ private:
         assert(range.length >= 4);
         assert(isPowerOf2(range.length));
     }
-    body
+    do
     {
         auto recurseRange = range;
         recurseRange.doubleSteps();
@@ -2819,7 +2819,7 @@ private:
         assert(range.length >= 4);
         assert(isPowerOf2(range.length));
     }
-    body
+    do
     {
         alias E = ElementType!R;
 
@@ -2927,7 +2927,7 @@ private:
     {
         assert(isPowerOf2(buf.length));
     }
-    body
+    do
     {
         immutable n = buf.length;
         immutable localLookup = negSinLookup[bsf(n)];

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -59,7 +59,7 @@ class OutBuffer
         {
             assert(offset + nbytes <= data.length);
         }
-        body
+        do
         {
             if (data.length < offset + nbytes)
             {
@@ -195,7 +195,7 @@ class OutBuffer
     {
         assert((offset & (alignsize - 1)) == 0);
     }
-    body
+    do
     {
         auto nbytes = offset & (alignsize - 1);
         if (nbytes)
@@ -360,7 +360,7 @@ class OutBuffer
         {
             assert(index <= offset);
         }
-        body
+        do
         {
             reserve(nbytes);
 

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1197,7 +1197,7 @@ private:
             assert(returned.prev is null);
         }
     }
-    body
+    do
     {
         if (isSingleTask) return null;
 
@@ -1241,7 +1241,7 @@ private:
             assert(tail.prev.next is tail, text(tail.prev, '\t', tail.next));
         }
     }
-    body
+    do
     {
         // Not using enforce() to save on function call overhead since this
         // is a performance critical function.
@@ -3930,7 +3930,7 @@ private struct RoundRobinBuffer(C1, C2)
     {
         assert(!empty);
     }
-    body
+    do
     {
         scope(success) primed = true;
         nextDel(bufs[index]);
@@ -3942,7 +3942,7 @@ private struct RoundRobinBuffer(C1, C2)
     {
         assert(!empty);
     }
-    body
+    do
     {
         if (!primed) prime();
         return bufs[index];

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2075,7 +2075,8 @@ public:
                 {
                     assert(nextBufTask.prev is null);
                     assert(nextBufTask.next is null);
-                } body
+                }
+                do
                 {
                     // Hack to reuse the task object.
 
@@ -2261,7 +2262,8 @@ public:
             {
                 assert(nextBufTask.prev is null);
                 assert(nextBufTask.next is null);
-            } body
+            }
+            do
             {
                 // Hack to reuse the task object.
 

--- a/std/path.d
+++ b/std/path.d
@@ -201,7 +201,7 @@ version (Windows)
     if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
         isNarrowString!R)
         in { assert(isUNC(path)); }
-        body
+        do
     {
         ptrdiff_t i = 3;
         while (i < path.length && !isDirSeparator(path[i])) ++i;
@@ -3251,7 +3251,7 @@ in
     assert(balancedParens(pattern, '[', ']', 0));
     assert(balancedParens(pattern, '{', '}', 0));
 }
-body
+do
 {
     alias RC = Unqual!(ElementEncodingType!Range);
 

--- a/std/random.d
+++ b/std/random.d
@@ -1877,7 +1877,7 @@ out (result)
     assert(0 <= result);
     assert(result < 1);
 }
-body
+do
 {
     alias R = typeof(rng.front);
     static if (isIntegral!R)
@@ -2254,7 +2254,7 @@ in
     import std.algorithm.searching : all;
     assert(proportions.save.all!"a >= 0");
 }
-body
+do
 {
     import std.algorithm.iteration : reduce;
     import std.exception : enforce;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -504,7 +504,7 @@ in
 {
     assert(n != 0, "stride cannot have step zero.");
 }
-body
+do
 {
     import std.algorithm.comparison : min;
 
@@ -3177,7 +3177,7 @@ public:
             "Attempting to slice a Repeat with a larger first argument than the second."
         );
     }
-    body
+    do
     {
         return this.takeExactly(j - i);
     }
@@ -3543,7 +3543,7 @@ if (isForwardRange!R && !isInfinite!R)
             {
                 assert(i <= j);
             }
-            body
+            do
             {
                 return this[i .. $].takeExactly(j - i);
             }
@@ -3688,7 +3688,7 @@ nothrow:
             "Attempting to slice a Repeat with a larger first argument than the second."
         );
     }
-    body
+    do
     {
         return this[i .. $].takeExactly(j - i);
     }
@@ -5114,7 +5114,7 @@ public:
             "Attempting to slice a Sequence with a larger first argument than the second."
         );
     }
-    body
+    do
     {
         return typeof(this)(_state, _n + lower).take(upper - lower);
     }
@@ -5500,7 +5500,7 @@ in
     assert(step != 0, "iota: step must not be 0");
     assert((end - begin) / step >= 0, "iota: incorrect startup parameters");
 }
-body
+do
 {
     alias Value = Unqual!(CommonType!(B, E, S));
     static struct Result
@@ -9101,7 +9101,7 @@ in
         assert(!overflow && result <= Enumerator.max);
     }
 }
-body
+do
 {
     // TODO: Relax isIntegral!Enumerator to allow user-defined integral types
     static struct Result
@@ -9509,7 +9509,7 @@ if (isInputRange!Range)
         // moved out of the body as a workaround for Issue 12661
         dbgVerifySorted();
     }
-    body
+    do
     {
         this._input = input;
     }
@@ -11151,7 +11151,7 @@ public:
                 assert(n < length, "Index out of bounds");
             }
         }
-        body
+        do
         {
             immutable size_t remainingBits = bitsNum - maskPos + 1;
             // If n >= maskPos, then the bit sign will be 1, otherwise 0
@@ -11190,7 +11190,7 @@ public:
                         assert(n < length, "Index out of bounds");
                     }
                 }
-            body
+            do
             {
                 import core.bitop : bsf;
 
@@ -11217,7 +11217,7 @@ public:
         {
             assert(start < end, "Invalid bounds: end <= start");
         }
-        body
+        do
         {
             import core.bitop : bsf;
 

--- a/std/signals.d
+++ b/std/signals.d
@@ -239,7 +239,7 @@ mixin template Signal(T1...)
      */
     final void unhook(Object o)
     in { assert( status == ST.idle ); }
-    body {
+    do {
         debug (signal) writefln("Signal.unhook(o = %s)", cast(void*) o);
         for (size_t i = 0; i < slots_idx; )
         {

--- a/std/signals.d
+++ b/std/signals.d
@@ -239,7 +239,8 @@ mixin template Signal(T1...)
      */
     final void unhook(Object o)
     in { assert( status == ST.idle ); }
-    do {
+    do
+    {
         debug (signal) writefln("Signal.unhook(o = %s)", cast(void*) o);
         for (size_t i = 0; i < slots_idx; )
         {

--- a/std/socket.d
+++ b/std/socket.d
@@ -3399,7 +3399,7 @@ public:
             assert(checkWrite !is checkError);
         }
     }
-    body
+    do
     {
         fd_set* fr, fw, fe;
         int n = 0;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4465,7 +4465,7 @@ private struct ChunksImpl
     {
         assert(size, "size must be larger than 0");
     }
-    body
+    do
     {
         this.f = f;
         this.size = size;

--- a/std/string.d
+++ b/std/string.d
@@ -252,7 +252,7 @@ out (result)
         assert(result[0 .. slen] == s[0 .. slen]);
     }
 }
-body
+do
 {
     import std.exception : assumeUnique;
     /+ Unfortunately, this isn't reliable.
@@ -5007,7 +5007,7 @@ in
 {
     assert(transTable.length == 256);
 }
-body
+do
 {
     bool[256] remTable = false;
 
@@ -5076,7 +5076,7 @@ in
     foreach (char c; to)
         assert(isASCII(c));
 }
-body
+do
 {
     char[256] result = void;
 
@@ -5147,7 +5147,7 @@ in
 {
     assert(transTable.length == 256);
 }
-body
+do
 {
     bool[256] remTable = false;
 
@@ -6242,7 +6242,7 @@ out (result)
             assert(c >= '0' && c <= '6');
     }
 }
-body
+do
 {
     char[4] result = soundexer(str);
     if (result[0] == 0)

--- a/std/uni.d
+++ b/std/uni.d
@@ -1215,7 +1215,7 @@ pure nothrow:
         static if (isIntegral!T)
             assert(val <= mask);
     }
-    body
+    do
     {
         immutable q = n / factor;
         immutable r = n % factor;
@@ -1308,7 +1308,7 @@ pure nothrow:
     {
         assert(s <= e);
     }
-    body
+    do
     {
         s += ofs;
         e += ofs;
@@ -1340,7 +1340,7 @@ pure nothrow:
     {
         assert(idx < limit);
     }
-    body
+    do
     {
         return ptr[ofs + idx];
     }
@@ -1358,7 +1358,7 @@ pure nothrow:
     {
         assert(idx < limit);
     }
-    body
+    do
     {
         ptr[ofs + idx] = val;
     }
@@ -1377,7 +1377,7 @@ pure nothrow:
         assert(start <= end);
         assert(end <= limit);
     }
-    body
+    do
     {
         // account for ofsetted view
         start += ofs;
@@ -1412,7 +1412,7 @@ pure nothrow:
         assert(from <= to);
         assert(ofs + to <= limit);
     }
-    body
+    do
     {
         return typeof(this)(ptr.origin, ofs + from, to - from);
     }
@@ -1457,7 +1457,7 @@ private struct SliceOverIndexed(T)
     {
         assert(idx < to - from);
     }
-    body
+    do
     {
         return (*arr)[from+idx];
     }
@@ -1468,7 +1468,7 @@ private struct SliceOverIndexed(T)
     {
         assert(idx < to - from);
     }
-    body
+    do
     {
        (*arr)[from+idx] = val;
     }
@@ -2122,7 +2122,7 @@ pure:
             assert(a < b, text("illegal interval [a, b): ", a, " > ", b));
         }
     }
-    body
+    do
     {
         InversionList set;
         set.data = CowArray!(SP)(intervals);
@@ -2143,7 +2143,7 @@ pure:
             assert(a < b, text("illegal interval [a, b): ", a, " > ", b));
         }
     }
-    body
+    do
     {
         data = CowArray!(SP)(intervals);
         sanitize(); //enforce invariant: sort intervals etc.
@@ -2942,7 +2942,7 @@ private:
     {
         assert(a <= b);
     }
-    body
+    do
     {
         import std.range : assumeSorted, SearchPolicy;
         auto range = assumeSorted(data[]);
@@ -3056,7 +3056,7 @@ private:
     {
         assert(pos % 2 == 0); // at start of interval
     }
-    body
+    do
     {
         auto range = assumeSorted!"a <= b"(data[pos .. data.length]);
         if (range.empty)
@@ -3093,7 +3093,7 @@ private:
         assert(result % 2 == 0);// always start of interval
         //(may be  0-width after-split)
     }
-    body
+    do
     {
         assert(data.length % 2 == 0);
         auto range = assumeSorted!"a <= b"(data[pos .. data.length]);
@@ -3390,7 +3390,7 @@ private:
     {
         assert(!empty && count != 1 && count == refCount);
     }
-    body
+    do
     {
         import std.algorithm.mutation : copy;
         // dec shared ref-count
@@ -5590,7 +5590,7 @@ struct sliceBits(size_t from, size_t to)
     {
         assert(result < (1 << to-from));
     }
-    body
+    do
     {
         static assert(from < to);
         static if (from == 0)

--- a/std/utf.d
+++ b/std/utf.d
@@ -330,7 +330,7 @@ if (is(S : const char[]) ||
 
 private uint strideImpl(char c, size_t index) @trusted pure
 in { assert(c & 0x80); }
-body
+do
 {
     import core.bitop : bsr;
     immutable msbs = 7 - bsr((~uint(c)) & 0xFF);
@@ -1049,7 +1049,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     if (str[index] < codeUnitLimit!S)
         return str[index++];
@@ -1068,7 +1068,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     if (str[index] < codeUnitLimit!S)
         return str[index++];
@@ -1110,7 +1110,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     immutable fst = str.front;
 
@@ -1147,7 +1147,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     if (str[0] < codeUnitLimit!S)
     {
@@ -1204,7 +1204,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     if (str[$ - 1] < codeUnitLimit!S)
     {
@@ -1237,7 +1237,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     if (str.back < codeUnitLimit!S)
     {
@@ -1288,7 +1288,7 @@ out (result)
 {
     assert(isValidDchar(result));
 }
-body
+do
 {
     size_t numCodeUnits;
     return decodeBack!useReplacementDchar(str, numCodeUnits);

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -274,7 +274,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     /* No need to attempt to close any of the standard hive keys.
      * Although it's documented that calling RegCloseKey() on any of
@@ -309,7 +309,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     immutable res = RegFlushKey(hkey);
     enforceSucc(res, "Key cannot be flushed");
@@ -322,7 +322,7 @@ in
     assert(hkey !is null);
     assert(subKey !is null);
 }
-body
+do
 {
     HKEY hkeyResult;
     enforceSucc(RegCreateKeyExW(
@@ -340,7 +340,7 @@ in
     assert(hkey !is null);
     assert(subKey !is null);
 }
-body
+do
 {
     LONG res;
     if (haveWoW64Job(samDesired))
@@ -361,7 +361,7 @@ in
     assert(hkey !is null);
     assert(valueName !is null);
 }
-body
+do
 {
     enforceSucc(RegDeleteValueW(hkey, valueName.tempCStringW()),
         "Value cannot be deleted: \"" ~ valueName ~ "\"");
@@ -372,7 +372,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     /* Can't duplicate standard keys, but don't need to, so can just return */
     if (cast(uint) hkey & 0x80000000)
@@ -422,7 +422,7 @@ out(res)
 {
     assert(res != ERROR_MORE_DATA);
 }
-body
+do
 {
     // The Registry API lies about the lengths of a very few sub-key lengths
     // so we have to test to see if it whinges about more data, and provide
@@ -447,7 +447,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     for (;;)
     {
@@ -467,7 +467,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     return RegQueryInfoKeyW(hkey, null, null, null, &cSubKeys,
                             &cchSubKeyMaxLen, null, null, null, null, null, null);
@@ -478,7 +478,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     return RegQueryInfoKeyW(hkey, null, null, null, null, null, null,
                             &cValues, &cchValueMaxLen, null, null, null);
@@ -489,7 +489,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     REG_VALUE_TYPE type;
     enforceSucc(RegQueryValueExW(hkey, name.tempCStringW(), null, cast(LPDWORD) &type, null, null),
@@ -504,7 +504,7 @@ in
     assert(hkey !is null);
     assert(subKey !is null);
 }
-body
+do
 {
     HKEY hkeyResult;
     enforceSucc(RegOpenKeyExW(hkey, subKey.tempCStringW(), 0, compatibleRegsam(samDesired), &hkeyResult),
@@ -518,7 +518,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     import core.bitop : bswap;
 
@@ -589,7 +589,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     REG_VALUE_TYPE type;
 
@@ -631,7 +631,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     import core.bitop : bswap;
 
@@ -669,7 +669,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     REG_VALUE_TYPE type;
 
@@ -694,7 +694,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     REG_VALUE_TYPE type;
 
@@ -729,7 +729,7 @@ in
 {
     assert(hkey !is null);
 }
-body
+do
 {
     enforceSucc(RegSetValueExW(hkey, subKey.tempCStringW(), 0, type, cast(BYTE*) lpData, cbData),
         "Value cannot be set: \"" ~ subKey ~ "\"");
@@ -801,7 +801,7 @@ private:
     {
         assert(hkey !is null);
     }
-    body
+    do
     {
         m_hkey = hkey;
         m_name = name;
@@ -1168,7 +1168,7 @@ private:
     {
         assert(null !is key);
     }
-    body
+    do
     {
         m_key = key;
         m_type = type;

--- a/std/xml.d
+++ b/std/xml.d
@@ -556,7 +556,7 @@ class Document : Element
     {
         assert(s.length != 0);
     }
-    body
+    do
     {
         auto xml = new DocumentParser(s);
         string tagString = xml.tag.tagString;
@@ -1718,7 +1718,7 @@ class DocumentParser : ElementParser
             assert(false, "\n" ~ e.toString());
         }
     }
-    body
+    do
     {
         xmlText = xmlText_;
         s = &xmlText;

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -193,7 +193,7 @@ in
 {
     assert(-1 <= level && level <= 9);
 }
-body
+do
 {
     import core.memory : GC;
     auto destlen = srcbuf.length + ((srcbuf.length + 1023) / 1024) + 12;
@@ -372,7 +372,7 @@ class Compress
     {
         assert(1 <= level && level <= 9);
     }
-    body
+    do
     {
         this.level = level;
         this.gzip = header == HeaderFormat.gzip;
@@ -463,7 +463,7 @@ class Compress
     {
         assert(mode == Z_FINISH || mode == Z_SYNC_FLUSH || mode == Z_FULL_FLUSH);
     }
-    body
+    do
     {
         import core.memory : GC;
         ubyte[] destbuf;
@@ -574,7 +574,7 @@ class UnCompress
     {
         assert(!done);
     }
-    body
+    do
     {
         if (inputEnded || !buf.length)
             return null;
@@ -758,7 +758,7 @@ class UnCompress
     {
         assert(done);
     }
-    body
+    do
     {
         done = 1;
         return null;


### PR DESCRIPTION
Automatic replacement with

    sed -i "s/^\([ ]*\)body/\1do/" -i **/*.d


Prompted by https://github.com/dlang/dlang.org/pull/1929:

> Even in phobos you still use body.