### PR TITLE
Issue 17127 - bad example code for std.concurrency.Generator

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1515,35 +1515,6 @@ private interface IsGenerator {}
 /**
  * A Generator is a Fiber that periodically returns values of type T to the
  * caller via yield.  This is represented as an InputRange.
- *
- * Example:
- * ---
- * import std.concurrency;
- * import std.stdio;
- *
- *
- * void main()
- * {
- *     auto tid = spawn(
- *     {
- *         while (true)
- *         {
- *             writeln(receiveOnly!int());
- *         }
- *     });
- *
- *     auto r = new Generator!int(
- *     {
- *         foreach (i; 1 .. 10)
- *             yield(i);
- *     });
- *
- *     foreach (e; r)
- *     {
- *         tid.send(e);
- *     }
- * }
- * ---
  */
 class Generator(T) :
     Fiber, IsGenerator, InputRange!T
@@ -1725,6 +1696,28 @@ class Generator(T) :
     }
 private:
     T* m_value;
+}
+
+///
+@system unittest
+{
+    auto tid = spawn({
+        size_t i;
+        while (i < 9)
+            i = receiveOnly!size_t;
+
+        ownerTid.send(i * 2);
+    });
+
+    auto r = new Generator!int({
+        foreach (i; 1 .. 10)
+            yield(i);
+    });
+
+    foreach (e; r)
+        tid.send(e);
+
+    assert(receiveOnly!size_t == 18);
 }
 
 /**

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1702,9 +1702,9 @@ private:
 @system unittest
 {
     auto tid = spawn({
-        size_t i;
+        int i;
         while (i < 9)
-            i = receiveOnly!size_t;
+            i = receiveOnly!int;
 
         ownerTid.send(i * 2);
     });
@@ -1717,7 +1717,7 @@ private:
     foreach (e; r)
         tid.send(e);
 
-    assert(receiveOnly!size_t == 18);
+    assert(receiveOnly!int == 18);
 }
 
 /**


### PR DESCRIPTION
Split-up of https://github.com/dlang/phobos/pull/5603 to see which test is failing for 32-bit on the auto-tester.