### PR TITLE
Update dscanner

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -69,7 +69,7 @@ ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 DUB=dub
 TOOLS_DIR=../tools
-DSCANNER_HASH=285ef162f024cbd305d587e9e0fcfb2292ea93ce
+DSCANNER_HASH=eb16fe4e8610e7477e09710fee1137d657a56f72
 DSCANNER_DIR=../dscanner-$(DSCANNER_HASH)
 
 # Documentation-related stuff

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4764,6 +4764,36 @@ if (isInputRange!R && !isInfinite!R && is(typeof(seed = seed + r.front)))
     }
 }
 
+/// Ditto
+@safe pure nothrow unittest
+{
+    import std.range;
+
+    //simple integral sumation
+    assert(sum([ 1, 2, 3, 4]) == 10);
+
+    //with integral promotion
+    assert(sum([false, true, true, false, true]) == 3);
+    assert(sum(ubyte.max.repeat(100)) == 25500);
+
+    //The result may overflow
+    assert(uint.max.repeat(3).sum()           ==  4294967293U );
+    //But a seed can be used to change the sumation primitive
+    assert(uint.max.repeat(3).sum(ulong.init) == 12884901885UL);
+
+    //Floating point sumation
+    assert(sum([1.0, 2.0, 3.0, 4.0]) == 10);
+
+    //Floating point operations have double precision minimum
+    static assert(is(typeof(sum([1F, 2F, 3F, 4F])) == double));
+    assert(sum([1F, 2, 3, 4]) == 10);
+
+    //Force pair-wise floating point sumation on large integers
+    import std.math : approxEqual;
+    assert(iota(ulong.max / 2, ulong.max / 2 + 4096).sum(0.0)
+               .approxEqual((ulong.max / 2) * 4096.0 + 4096^^2 / 2));
+}
+
 // Pairwise summation http://en.wikipedia.org/wiki/Pairwise_summation
 private auto sumPairwise(F, R)(R data)
 if (isInputRange!R && !isInfinite!R)
@@ -4872,36 +4902,6 @@ private auto sumKahan(Result, R)(Result result, R r)
         result = t;
     }
     return result;
-}
-
-/// Ditto
-@safe pure nothrow unittest
-{
-    import std.range;
-
-    //simple integral sumation
-    assert(sum([ 1, 2, 3, 4]) == 10);
-
-    //with integral promotion
-    assert(sum([false, true, true, false, true]) == 3);
-    assert(sum(ubyte.max.repeat(100)) == 25500);
-
-    //The result may overflow
-    assert(uint.max.repeat(3).sum()           ==  4294967293U );
-    //But a seed can be used to change the sumation primitive
-    assert(uint.max.repeat(3).sum(ulong.init) == 12884901885UL);
-
-    //Floating point sumation
-    assert(sum([1.0, 2.0, 3.0, 4.0]) == 10);
-
-    //Floating point operations have double precision minimum
-    static assert(is(typeof(sum([1F, 2F, 3F, 4F])) == double));
-    assert(sum([1F, 2, 3, 4]) == 10);
-
-    //Force pair-wise floating point sumation on large integers
-    import std.math : approxEqual;
-    assert(iota(ulong.max / 2, ulong.max / 2 + 4096).sum(0.0)
-               .approxEqual((ulong.max / 2) * 4096.0 + 4096^^2 / 2));
 }
 
 @safe pure nothrow unittest

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1485,6 +1485,17 @@ template multiSort(less...) //if (less.length > 1)
     }
 }
 
+///
+@safe unittest
+{
+    import std.algorithm.mutation : SwapStrategy;
+    static struct Point { int x, y; }
+    auto pts1 = [ Point(0, 0), Point(5, 5), Point(0, 1), Point(0, 2) ];
+    auto pts2 = [ Point(0, 0), Point(0, 1), Point(0, 2), Point(5, 5) ];
+    multiSort!("a.x < b.x", "a.y < b.y", SwapStrategy.unstable)(pts1);
+    assert(pts1 == pts2);
+}
+
 private bool multiSortPredFun(Range, funs...)(ElementType!Range a, ElementType!Range b)
 {
     foreach (f; funs)
@@ -1524,17 +1535,6 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     {
         sort!(lessFun, ss)(r);
     }
-}
-
-///
-@safe unittest
-{
-    import std.algorithm.mutation : SwapStrategy;
-    static struct Point { int x, y; }
-    auto pts1 = [ Point(0, 0), Point(5, 5), Point(0, 1), Point(0, 2) ];
-    auto pts2 = [ Point(0, 0), Point(0, 1), Point(0, 2), Point(5, 5) ];
-    multiSort!("a.x < b.x", "a.y < b.y", SwapStrategy.unstable)(pts1);
-    assert(pts1 == pts2);
 }
 
 @safe unittest
@@ -3130,6 +3130,17 @@ if (isRandomAccessRange!(Range) && hasLength!Range && hasSlicing!Range)
     return ret;
 }
 
+///
+@safe unittest
+{
+    int[] v = [ 25, 7, 9, 2, 0, 5, 21 ];
+    topN!"a < b"(v, 100);
+    assert(v == [ 25, 7, 9, 2, 0, 5, 21 ]);
+    auto n = 4;
+    topN!"a < b"(v, n);
+    assert(v[n] == 9);
+}
+
 private @trusted
 void topNImpl(alias less, R)(R r, size_t n, ref bool useSampling)
 {
@@ -3228,17 +3239,6 @@ void topNImpl(alias less, R)(R r, size_t n, ref bool useSampling)
             r = r[pivot + 1 .. r.length];
         }
     }
-}
-
-///
-@safe unittest
-{
-    int[] v = [ 25, 7, 9, 2, 0, 5, 21 ];
-    topN!"a < b"(v, 100);
-    assert(v == [ 25, 7, 9, 2, 0, 5, 21 ]);
-    auto n = 4;
-    topN!"a < b"(v, n);
-    assert(v[n] == 9);
 }
 
 private size_t topNPartition(alias lp, R)(R r, size_t n, bool useSampling)


### PR DESCRIPTION
https://github.com/dlang-community/D-Scanner/pull/527 changed the `has_public_example`. It previously ignored private declaration, however DMD's ddoc doesn't have this behavior. Hence it's necessary to copy the behavior of DMD.

Examples:
- https://dlang.org/phobos/std_algorithm_iteration.html#sum
- https://dlang.org/phobos/std_algorithm_sorting.html#multiSort

(No examples are displayed)