### PR TITLE
Make allocate @safe

### DIFF
--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -59,6 +59,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     /**
     Directs the call to either one of the $(D buckets) allocators.
     */
+    //pure nothrow @safe @nogc
     void[] allocate(size_t bytes)
     {
         if (!bytes) return null;
@@ -66,7 +67,8 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
         {
             const actual = goodAllocSize(bytes);
             auto result = a.allocate(actual);
-            return result.ptr ? result.ptr[0 .. bytes] : null;
+            // TODO: Can't this just be 'result ? result[0 .. bytes] : null' ?;
+            return (() @trusted => result ? result.ptr[0 .. bytes] : null)();
         }
         return null;
     }
@@ -262,6 +264,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
 
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))() == 128);
 
+    //auto b = (() pure nothrow @safe @nogc => a.allocate(100))();
     auto b = a.allocate(100);
     assert(b.length == 100);
     // Make reallocate use extend

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -254,13 +254,14 @@ struct FreeList(ParentAllocator,
         return parent.goodAllocSize(bytes);
     }
 
+    //[>pure*/ nothrow @safe /*@nogc<]
     private void[] allocateEligible(size_t bytes)
     {
         assert(bytes);
         if (root)
         {
             // faster
-            auto result = (cast(ubyte*) root)[0 .. bytes];
+            auto result = (() @trusted => (cast(ubyte*) root)[0 .. bytes])();
             root = root.next;
             return result;
         }
@@ -277,7 +278,7 @@ struct FreeList(ParentAllocator,
         auto result = parent.allocate(toAllocate);
         static if (hasTolerance)
         {
-            if (result) result = result.ptr[0 .. bytes];
+            if (result) result = (() @trusted => result.ptr[0 .. bytes])();
         }
         static if (adaptive == Yes.adaptive)
         {
@@ -307,6 +308,7 @@ struct FreeList(ParentAllocator,
 
     Postcondition: $(D result.length == bytes || result is null)
     */
+    //[>pure*/ nothrow @safe/* @nogc <]
     void[] allocate(size_t n)
     {
         static if (adaptive == Yes.adaptive) ++accumSamples;
@@ -421,7 +423,7 @@ struct FreeList(ParentAllocator,
     }
 
     FreeList!(StatsCollectorWrapper, 16, 16) fl;
-    auto buf1 = fl.allocate(16);
+    auto buf1 = (() nothrow @safe @nogc => fl.allocate(16))();
     auto buf2 = fl.allocate(16);
     assert(fl.parent.bytesUsed == 32);
 
@@ -437,15 +439,18 @@ struct FreeList(ParentAllocator,
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     FreeList!(GCAllocator, 0, 8) fl;
-    assert(fl.root is null);
-    auto b1 = fl.allocate(7);
-    fl.allocate(8);
-    assert(fl.root is null);
-    // Ensure deallocate inherits from parent
-    () nothrow @nogc { fl.deallocate(b1); }();
-    assert(fl.root !is null);
-    fl.allocate(8);
-    assert(fl.root is null);
+    // Can't mark the unittest as @safe because of ~this
+    () nothrow @safe {
+        assert(fl.root is null);
+        auto b1 = fl.allocate(7);
+        fl.allocate(8);
+        assert(fl.root is null);
+        // Ensure deallocate inherits from parent
+        () @trusted @nogc { fl.deallocate(b1); }();
+        assert(fl.root !is null);
+        fl.allocate(8);
+        assert(fl.root is null);
+    }();
 }
 
 @system unittest
@@ -462,9 +467,11 @@ struct FreeList(ParentAllocator,
     import std.experimental.allocator.building_blocks.region : Region;
 
     auto fl = FreeList!(Region!(), 0, 16)(Region!()(new ubyte[1024 * 64]));
-    auto b = fl.allocate(42);
-    assert(b.length == 42);
-    assert((() nothrow @nogc => fl.deallocateAll())());
+    () nothrow @safe {
+        auto b = fl.allocate(42);
+        assert(b.length == 42);
+        assert((() @trusted @nogc => fl.deallocateAll())());
+    }();
 }
 
 /**
@@ -759,23 +766,24 @@ struct ContiguousFreeList(ParentAllocator,
     alias A = ContiguousFreeList!(NullAllocator, 0, 64);
     auto a = A(new ubyte[1024]);
 
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
+    () nothrow @safe @nogc {
+        assert(a.empty == Ternary.yes);
+        assert((() pure => a.goodAllocSize(15))() == 64);
+        assert((() pure => a.goodAllocSize(65))()
+                == NullAllocator.instance.goodAllocSize(65));
 
-    assert((() pure nothrow @safe @nogc => a.goodAllocSize(15))() == 64);
-    assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))()
-            == (() nothrow @safe @nogc => NullAllocator.instance.goodAllocSize(65))());
-
-    auto b = a.allocate(100);
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
-    assert(b.length == 0);
-    // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(b); }();
-    b = a.allocate(64);
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
-    assert(b.length == 64);
-    assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
-    assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
-    () nothrow @nogc { a.deallocate(b); }();
+        auto b = a.allocate(100);
+        assert(a.empty == Ternary.yes);
+        assert(b.length == 0);
+        // Ensure deallocate inherits from parent
+        () @trusted { a.deallocate(b); }();
+        b = a.allocate(64);
+        assert(a.empty == Ternary.no);
+        assert(b.length == 64);
+        assert(a.owns(b) == Ternary.yes);
+        assert(a.owns(null) == Ternary.no);
+        () @trusted { a.deallocate(b); }();
+    }();
 }
 
 @system unittest
@@ -786,27 +794,28 @@ struct ContiguousFreeList(ParentAllocator,
     alias A = ContiguousFreeList!(Region!GCAllocator, 0, 64);
     auto a = A(Region!GCAllocator(1024 * 4), 1024);
 
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
+    () nothrow @safe @nogc {
+        assert(a.empty == Ternary.yes);
+        assert((() pure => a.goodAllocSize(15))() == 64);
+        assert((() pure => a.goodAllocSize(65))()
+                == (() pure => a.parent.goodAllocSize(65))());
 
-    assert((() pure nothrow @safe @nogc => a.goodAllocSize(15))() == 64);
-    assert((() pure nothrow @safe @nogc => a.goodAllocSize(65))()
-            == (() pure nothrow @safe @nogc => a.parent.goodAllocSize(65))());
-
-    auto b = a.allocate(100);
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
-    assert(a.allocated == 0);
-    assert(b.length == 100);
-    // Ensure deallocate inherits from parent
-    assert((() nothrow @nogc => a.deallocate(b))());
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
-    b = a.allocate(64);
-    assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
-    assert(b.length == 64);
-    assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
-    assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
-    // Test deallocate infers from parent
-    assert((() nothrow @nogc => a.deallocate(b))());
-    assert((() nothrow @nogc => a.deallocateAll())());
+        auto b = a.allocate(100);
+        assert(a.empty == Ternary.no);
+        assert(a.allocated == 0);
+        assert(b.length == 100);
+        // Ensure deallocate inherits from parent
+        assert((() @trusted => a.deallocate(b))());
+        assert(a.empty == Ternary.yes);
+        b = a.allocate(64);
+        assert(a.empty == Ternary.no);
+        assert(b.length == 64);
+        assert(a.owns(b) == Ternary.yes);
+        assert(a.owns(null) == Ternary.no);
+        // Test deallocate infers from parent
+        assert((() @trusted => a.deallocate(b))());
+        assert((() @trusted => a.deallocateAll())());
+    }();
 }
 
 @system unittest
@@ -814,7 +823,7 @@ struct ContiguousFreeList(ParentAllocator,
     import std.experimental.allocator.gc_allocator : GCAllocator;
     alias A = ContiguousFreeList!(GCAllocator, 64, 64);
     auto a = A(1024);
-    const b = a.allocate(100);
+    const b = (() nothrow @safe => a.allocate(100))();
     assert(b.length == 100);
 }
 
@@ -1042,7 +1051,7 @@ struct SharedFreeList(ParentAllocator,
             _root = _root.next;
             decNodes();
             lock.unlock();
-            return (cast(ubyte*) oldRoot)[0 .. bytes];
+            return (() @trusted => (cast(ubyte*) oldRoot)[0 .. bytes])();
         }
     }
 
@@ -1157,15 +1166,16 @@ struct SharedFreeList(ParentAllocator,
 
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
 
-    assert((() nothrow @safe @nogc => a.goodAllocSize(1))() == platformAlignment);
-
-    auto b = a.allocate(96);
-    // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(b); }();
+    () nothrow @safe {
+        assert((() @nogc => a.goodAllocSize(1))() == platformAlignment);
+        auto b = a.allocate(96);
+        // Ensure deallocate inherits from parent
+        () @trusted @nogc { a.deallocate(b); }();
+    }();
 
     void fun()
     {
-        auto b = cast(size_t[]) a.allocate(96);
+        auto b = cast(size_t[]) (() nothrow @safe => a.allocate(96))();
         b[] = cast(size_t) &b;
 
         assert(b.equal(repeat(cast(size_t) &b, b.length)));
@@ -1181,39 +1191,39 @@ struct SharedFreeList(ParentAllocator,
     tg.joinAll();
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
     auto b = a.allocate(100);
     // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(b); }();
+    () @trusted { a.deallocate(b); }();
     assert(a.nodes == 1);
     b = [];
-    assert((() nothrow @nogc => a.deallocateAll())());
+    assert((() @trusted => a.deallocateAll())());
     assert(a.nodes == 0);
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
     auto b = a.allocate(100);
     auto c = a.allocate(100);
     // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(c); }();
+    () @trusted { a.deallocate(c); }();
     assert(a.nodes == 1);
     c = [];
-    a.minimize();
+    () @trusted { a.minimize(); }();
     assert(a.nodes == 0);
-    () nothrow @nogc { a.deallocate(b); }();
+    () @trusted { a.deallocate(b); }();
     assert(a.nodes == 1);
     b = [];
-    a.minimize();
+    () @trusted { a.minimize(); }();
     assert(a.nodes == 0);
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
@@ -1221,12 +1231,12 @@ struct SharedFreeList(ParentAllocator,
     auto c = a.allocate(100);
     assert(a.nodes == 0);
     // Ensure deallocate inherits from parent
-    () nothrow @nogc { a.deallocate(b); }();
-    () nothrow @nogc { a.deallocate(c); }();
+    () @trusted { a.deallocate(b); }();
+    () @trusted { a.deallocate(c); }();
     assert(a.nodes == 2);
     b = [];
     c = [];
-    a.minimize();
+    () @trusted { a.minimize(); }();
     assert(a.nodes == 0);
 }
 
@@ -1235,53 +1245,53 @@ struct SharedFreeList(ParentAllocator,
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
     scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
-    auto c = a.allocate(64);
+    auto c = (() nothrow @safe @nogc => a.allocate(64))();
     assert(a.reallocate(c, 96));
     assert(c.length == 96);
     // Ensure deallocate inherits from parent
     () nothrow @nogc { a.deallocate(c); }();
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime, chooseAtRuntime) a;
-    scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
+    scope(exit) assert((() @trusted => a.deallocateAll())());
     a.allocate(64);
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40) a;
-    scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
+    scope(exit) assert((() @trusted => a.deallocateAll())());
     a.allocate(64);
 }
 
-@system unittest
+nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40, chooseAtRuntime) a;
-    scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
+    scope(exit) assert((() @trusted => a.deallocateAll())());
     a.allocate(64);
 }
 
-@system unittest
+@safe unittest
 {
     // Pull request #5556
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 0, chooseAtRuntime) a;
-    scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
+    scope(exit) assert((() @trusted => a.deallocateAll())());
     a.max = 64;
-    a.allocate(64);
+    () nothrow @nogc { a.allocate(64); }();
 }
 
-@system unittest
+@safe unittest
 {
     // Pull request #5556
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, 64) a;
-    scope(exit) assert((() nothrow @nogc => a.deallocateAll())());
+    scope(exit) assert((() @trusted => a.deallocateAll())());
     a.min = 32;
-    a.allocate(64);
+    () nothrow @nogc { a.allocate(64); }();
 }

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -108,11 +108,13 @@ struct KRRegion(ParentAllocator = NullAllocator)
 
         this(this) @disable;
 
+        pure nothrow @trusted @nogc
         void[] payload() inout
         {
             return (cast(ubyte*) &this)[0 .. size];
         }
 
+        pure nothrow @trusted @nogc
         bool adjacent(in Node* right) const
         {
             assert(right);
@@ -120,6 +122,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
             return p.ptr < right && right < p.ptr + p.length + Node.sizeof;
         }
 
+        pure nothrow @trusted @nogc
         bool coalesce(void* memoryEnd = null)
         {
             // Coalesce the last node before the memory end with any possible gap
@@ -149,7 +152,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
             if (leftover >= Node.sizeof)
             {
                 // There's room for another node
-                auto newNode = cast(Node*) ((cast(ubyte*) &this) + bytes);
+                auto newNode = (() @trusted => cast(Node*) ((cast(ubyte*) &this) + bytes))();
                 newNode.size = leftover;
                 newNode.next = next == &this ? newNode : next;
                 assert(next);
@@ -401,7 +404,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
                 immutable balance = root.size - actualBytes;
                 if (balance >= Node.sizeof)
                 {
-                    auto newRoot = cast(Node*) (result + actualBytes);
+                    auto newRoot = (() @trusted => cast(Node*) (result + actualBytes))();
                     newRoot.next = root.next;
                     newRoot.size = balance;
                     root = newRoot;
@@ -411,7 +414,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
                     root = null;
                     switchToFreeList;
                 }
-                return result[0 .. n];
+                return (() @trusted => result[0 .. n])();
             }
 
             // Not enough memory, switch to freelist mode and fall through
@@ -753,7 +756,7 @@ it actually returns memory to the operating system when possible.
     void[][] array;
     foreach (i; 1 .. 4)
     {
-        array ~= alloc.allocate(i);
+        array ~= (() nothrow @safe => alloc.allocate(i))();
         assert(array[$ - 1].length == i);
     }
     () nothrow @nogc { alloc.deallocate(array[1]); }();
@@ -768,7 +771,7 @@ it actually returns memory to the operating system when possible.
     import std.typecons : Ternary;
     auto alloc = KRRegion!()(
                     cast(ubyte[])(GCAllocator.instance.allocate(1024 * 1024)));
-    const store = alloc.allocate(KRRegion!().sizeof);
+    const store = (() pure nothrow @safe @nogc => alloc.allocate(KRRegion!().sizeof))();
     auto p = cast(KRRegion!()* ) store.ptr;
     import core.stdc.string : memcpy;
     import std.algorithm.mutation : move;
@@ -781,7 +784,7 @@ it actually returns memory to the operating system when possible.
     foreach (i; 0 .. array.length)
     {
         auto length = 100 * i + 1;
-        array[i] = p.allocate(length);
+        array[i] = (() pure nothrow @safe @nogc => p.allocate(length))();
         assert(array[i].length == length, text(array[i].length));
         assert((() pure nothrow @safe @nogc => p.owns(array[i]))() == Ternary.yes);
     }
@@ -837,7 +840,7 @@ it actually returns memory to the operating system when possible.
 
         foreach (size; sizes)
         {
-            bufs ~= a.allocate(size);
+            bufs ~= (() pure nothrow @safe @nogc => a.allocate(size))();
         }
 
         foreach (b; bufs.randomCover)
@@ -879,11 +882,11 @@ it actually returns memory to the operating system when possible.
 
         foreach (size; sizes)
         {
-            bufs ~= a.allocate(size);
+            bufs ~= (() pure nothrow @safe @nogc => a.allocate(size))();
         }
 
         () nothrow @nogc { a.deallocate(bufs[1]); }();
-        bufs ~= a.allocate(sizes[1] - word);
+        bufs ~= (() pure nothrow @safe @nogc => a.allocate(sizes[1] - word))();
 
         () nothrow @nogc { a.deallocate(bufs[0]); }();
         foreach (i; 2 .. bufs.length)

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -20,6 +20,7 @@ struct NullAllocator
     //size_t goodAllocSize(size_t n) shared const
     //{ return .goodAllocSize(this, n); }
     /// Always returns $(D null).
+    pure nothrow @safe @nogc
     void[] allocate(size_t) shared { return null; }
     /// Always returns $(D null).
     void[] alignedAllocate(size_t, uint) shared { return null; }
@@ -73,7 +74,7 @@ struct NullAllocator
 {
     assert(NullAllocator.instance.alignedAllocate(100, 0) is null);
     assert(NullAllocator.instance.allocateAll() is null);
-    auto b = NullAllocator.instance.allocate(100);
+    auto b = (() nothrow @safe @nogc => NullAllocator.instance.allocate(100))();
     assert(b is null);
     assert(NullAllocator.instance.expand(b, 0));
     assert(!NullAllocator.instance.expand(b, 42));

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -686,15 +686,15 @@ public:
 
         Allocator a;
         assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
-        auto b1 = a.allocate(100);
+        auto b1 = (() nothrow @safe => a.allocate(100))();
         assert(a.numAllocate == 1);
         assert(a.expand(b1, 0));
         assert(a.reallocate(b1, b1.length + 1));
-        auto b2 = a.allocate(101);
+        auto b2 = (() nothrow @safe => a.allocate(101))();
         assert(a.numAllocate == 2);
         assert(a.bytesAllocated == 202);
         assert(a.bytesUsed == 202);
-        auto b3 = a.allocate(202);
+        auto b3 = (() nothrow @safe => a.allocate(202))();
         assert(a.numAllocate == 3);
         assert(a.bytesAllocated == 404);
         assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.no);
@@ -722,11 +722,11 @@ public:
     {
         import std.range : walkLength;
         Allocator a;
-        auto b1 = a.allocate(100);
+        auto b1 = (() nothrow @safe => a.allocate(100))();
         assert(a.expand(b1, 0));
         assert(a.reallocate(b1, b1.length + 1));
-        auto b2 = a.allocate(101);
-        auto b3 = a.allocate(202);
+        auto b2 = (() nothrow @safe => a.allocate(101))();
+        auto b3 = (() nothrow @safe => a.allocate(202))();
 
         () nothrow @nogc { a.deallocate(b2); }();
         () nothrow @nogc { a.deallocate(b1); }();
@@ -752,7 +752,7 @@ public:
     import std.experimental.allocator.building_blocks.region : Region;
 
     auto a = StatsCollector!(Region!(), Options.all, Options.all)(Region!()(new ubyte[1024 * 64]));
-    auto b = a.allocate(42);
+    auto b = (() nothrow @safe @nogc => a.allocate(42))();
     assert(b.length == 42);
     assert((() nothrow @nogc => a.deallocateAll())());
 }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -77,12 +77,11 @@ struct Mallocator
 
 @nogc @system nothrow unittest
 {
-    @nogc nothrow
     static void test(A)()
     {
         int* p = null;
         p = cast(int*) A.instance.allocate(int.sizeof);
-        scope(exit) () nothrow @nogc { A.instance.deallocate(p[0 .. int.sizeof]); }();
+        scope(exit) A.instance.deallocate(p[0 .. int.sizeof]);
         *p = 42;
         assert(*p == 42);
     }

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -28,6 +28,7 @@ struct MmapAllocator
     version(Posix)
     {
         /// Allocator API.
+        @trusted @nogc nothrow
         void[] allocate(size_t bytes) shared
         {
             import core.sys.posix.sys.mman : mmap, MAP_ANON, PROT_READ,
@@ -54,6 +55,7 @@ struct MmapAllocator
             PAGE_READWRITE, MEM_RELEASE;
 
         /// Allocator API.
+        @trusted @nogc nothrow
         void[] allocate(size_t bytes) shared
         {
             if (!bytes) return null;


### PR DESCRIPTION
For allocators that implement their own `allocate` method, this should be a `pure nothrow @safe` function.
Allocators that are building on top of such allocators should infer the function attributes from their parents.

This PR is a subset of #5330, as this approach will provide us with better granularity. More smaller PRs to come :)