### PR TITLE
Allocators owns should take const void[]

### DIFF
--- a/changelog/std-experimental-allocator-iallocator-owns.dd
+++ b/changelog/std-experimental-allocator-iallocator-owns.dd
@@ -1,0 +1,4 @@
+`std.experimental.allocator.IAllocator.owns` takes `const void[]`
+
+The allocators implementing the IAllocator interface must define the `owns`
+method as taking a `const void[]` as input.

--- a/changelog/std-experimental-allocator-isharedallocator-owns.dd
+++ b/changelog/std-experimental-allocator-isharedallocator-owns.dd
@@ -1,0 +1,4 @@
+`std.experimental.allocator.ISharedAllocator.owns` takes `const void[]`
+
+The allocators implementing the ISharedAllocator interface must define the `owns`
+method as taking a `const void[]` as input.

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -112,7 +112,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             }
         }
 
-        private void[] actualAllocation(void[] b) const
+        private inout(void)[] actualAllocation(inout(void)[] b) const
         {
             assert(b !is null);
             return (b.ptr - stateSize!Prefix)
@@ -168,10 +168,11 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         }
 
         static if (hasMember!(Allocator, "owns"))
-        Ternary owns(void[] b)
+        //Ternary owns(const void[] b) const ?
+        Ternary owns(const void[] b)
         {
             if (b is null) return Ternary.no;
-            return parent.owns(actualAllocation(b));
+            return parent.owns((() @trusted => actualAllocation(b))());
         }
 
         static if (hasMember!(Allocator, "resolveInternalPointer"))
@@ -275,7 +276,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         /// Ditto
         void[] allocate(size_t);
         /// Ditto
-        Ternary owns(void[]);
+        Ternary owns(const void[]);
         /// Ditto
         bool expand(ref void[] b, size_t delta);
         /// Ditto
@@ -477,4 +478,18 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     auto b = a.allocate(42);
     assert(b.length == 42);
     assert((() nothrow @nogc => a.deallocateAll())());
+}
+
+// Check that owns inherits from parent, i.e. Region
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = AffixAllocator!(Region!(Mallocator), uint)(Region!Mallocator(1024 * 64));
+    const b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
 }

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -166,11 +166,11 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     static if (hasMember!(Allocator, "owns"))
     Ternary owns(void[] b)
     {
-        if (!b.ptr) return Ternary.no;
+        if (!b) return Ternary.no;
         if (auto a = allocatorFor(b.length))
         {
             const actual = goodAllocSize(b.length);
-            return a.owns(b.ptr[0 .. actual]);
+            return a.owns((() @trusted => b.ptr[0 .. actual])());
         }
         return Ternary.no;
     }
@@ -239,7 +239,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
         65, 512, 64) a;
     auto b = a.allocate(400);
     assert(b.length == 400);
-    assert(a.owns(b) == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
     a.deallocate(b);
 }
 

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -199,7 +199,8 @@ struct FallbackAllocator(Primary, Fallback)
     Returns $(D primary.owns(b) | fallback.owns(b)).
     */
     static if (hasMember!(Primary, "owns") && hasMember!(Fallback, "owns"))
-    Ternary owns(void[] b)
+    //Ternary owns(const void[] b) const ?
+    Ternary owns(const void[] b)
     {
         return primary.owns(b) | fallback.owns(b);
     }
@@ -415,7 +416,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     import std.typecons : Ternary;
 
     FallbackAllocator!(InSituRegion!16_384, InSituRegion!16_384) a;
-    auto buff = a.allocate(42);
+    const buff = a.allocate(42);
     assert((() pure nothrow @safe @nogc => a.owns(buff))() == Ternary.yes);
 }
 

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -677,7 +677,7 @@ struct ContiguousFreeList(ParentAllocator,
     */
     static if (hasMember!(SParent, "owns") || unchecked)
     // Ternary owns(const void[] b) const ?
-    Ternary owns(void[] b)
+    Ternary owns(const void[] b)
     {
         if ((() @trusted => support && b
                             && (&support[0] <= &b[0])

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -499,9 +499,13 @@ struct FreeTree(ParentAllocator)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
 
-    auto a = FreeTree!(Region!())(Region!()(new ubyte[1024 * 64]));
+    auto a = FreeTree!(Region!(Mallocator))(Region!Mallocator(1024 * 64));
     auto b = a.allocate(42);
     assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
     assert((() nothrow @nogc => a.deallocateAll())());
 }

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -588,7 +588,8 @@ struct KRRegion(ParentAllocator = NullAllocator)
     allocated with $(D this) or obtained through other means.
     */
     pure nothrow @trusted @nogc
-    Ternary owns(void[] b)
+    //Ternary owns(const void[] b) const ?
+    Ternary owns(const void[] b)
     {
         debug(KRRegion) assertValid("owns");
         debug(KRRegion) scope(exit) assertValid("owns");
@@ -637,7 +638,7 @@ fronting the GC allocator.
     // KRRegion fronting a general-purpose allocator
     ubyte[1024 * 128] buf;
     auto alloc = fallbackAllocator(KRRegion!()(buf), GCAllocator.instance);
-    auto b = alloc.allocate(100);
+    const b = alloc.allocate(100);
     assert(b.length == 100);
     assert((() pure nothrow @safe @nogc => alloc.primary.owns(b))() == Ternary.yes);
 }

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -297,3 +297,19 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert((() nothrow @nogc => a.deallocateAll())());
     assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
 }
+
+// Check that owns inherits from parent, i.e. Region
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    alias Alloc = Quantizer!(Region!(Mallocator),
+            (size_t n) => n.roundUpToMultipleOf(64));
+    auto a = Alloc(Region!Mallocator(1024 * 64));
+    const b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
+}

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -228,6 +228,8 @@ struct ScopedAllocator(ParentAllocator)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.typecons : Ternary;
+
     ScopedAllocator!GCAllocator a;
 
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(0))()));
@@ -275,4 +277,17 @@ struct ScopedAllocator(ParentAllocator)
     assert((() pure nothrow @safe @nogc => alloc.empty)() == Ternary.yes);
     const b = alloc.allocate(10);
     assert((() pure nothrow @safe @nogc => alloc.empty)() == Ternary.no);
+}
+
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = Region!(Mallocator)(1024 * 64);
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() pure nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() pure nothrow @safe @nogc => a.owns(null))() == Ternary.no);
 }

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -75,7 +75,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
         forwarded to $(D SmallAllocator) if $(D b.length <= threshold), or $(D
         LargeAllocator) otherwise.
         */
-        Ternary owns(void[] b);
+        Ternary owns(const void[] b);
         /**
         This function is defined only if both allocators define it, and forwards
         appropriately depending on $(D b.length).
@@ -215,7 +215,8 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 
         static if (hasMember!(SmallAllocator, "owns")
                 && hasMember!(LargeAllocator, "owns"))
-        Ternary owns(void[] b)
+        //Ternary owns(const void[] b) const ?
+        Ternary owns(const void[] b)
         {
             return Ternary(b.length <= threshold
                 ? _small.owns(b) : _large.owns(b));

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -286,14 +286,14 @@ public:
     static if (hasMember!(Allocator, "owns"))
     {
         static if ((perCallFlags & Options.numOwns) == 0)
-        Ternary owns(void[] b)
+        Ternary owns(const void[] b)
         { return ownsImpl(b); }
         else
-        Ternary owns(string f = __FILE__, uint n = __LINE__)(void[] b)
+        Ternary owns(string f = __FILE__, uint n = __LINE__)(const void[] b)
         { return ownsImpl!(f, n)(b); }
     }
 
-    private Ternary ownsImpl(string f = null, uint n = 0)(void[] b)
+    private Ternary ownsImpl(string f = null, uint n = 0)(const void[] b)
     {
         up!"numOwns";
         addPerCall!(f, n, "numOwns")(1);
@@ -740,6 +740,7 @@ public:
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.typecons : Ternary;
     StatsCollector!(GCAllocator, 0, 0) a;
 
     // calls std.experimental.allocator.common.goodAllocSize
@@ -755,4 +756,19 @@ public:
     auto b = a.allocate(42);
     assert(b.length == 42);
     assert((() nothrow @nogc => a.deallocateAll())());
+}
+
+// Check that owns inherits from parent, i.e. Region
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Ternary;
+
+    auto a = StatsCollector!(Region!(Mallocator), Options.all, Options.all)
+                (Region!Mallocator(1024 * 64));
+    const b = a.allocate(42);
+    assert(b.length == 42);
+    assert((() nothrow @safe @nogc => a.owns(b))() == Ternary.yes);
+    assert((() nothrow @safe @nogc => a.owns(null))() == Ternary.no);
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -334,7 +334,7 @@ interface IAllocator
     cannot be determined. Implementations that don't support this primitive
     should always return `Ternary.unknown`.
     */
-    Ternary owns(void[] b);
+    Ternary owns(const void[] b);
 
     /**
     Resolves an internal pointer to the full block allocated. Implementations
@@ -430,7 +430,7 @@ interface ISharedAllocator
     cannot be determined. Implementations that don't support this primitive
     should always return `Ternary.unknown`.
     */
-    Ternary owns(void[] b) shared;
+    Ternary owns(const void[] b) shared;
 
     /**
     Resolves an internal pointer to the full block allocated. Implementations
@@ -509,7 +509,7 @@ private IAllocator setupThreadAllocator() nothrow @nogc @safe
             return processAllocator.alignedReallocate(b, size, alignment);
         }
 
-        override Ternary owns(void[] b)
+        override Ternary owns(const void[] b)
         {
             return processAllocator.owns(b);
         }
@@ -2225,7 +2225,7 @@ class CAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     If `Allocator` implements `owns`, forwards to it. Otherwise, returns
     `Ternary.unknown`.
     */
-    override Ternary owns(void[] b)
+    override Ternary owns(const void[] b)
     {
         static if (hasMember!(Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
@@ -2408,7 +2408,7 @@ class CSharedAllocatorImpl(Allocator, Flag!"indirect" indirect = No.indirect)
     If `Allocator` implements `owns`, forwards to it. Otherwise, returns
     `Ternary.unknown`.
     */
-    override Ternary owns(void[] b) shared
+    override Ternary owns(const void[] b) shared
     {
         static if (hasMember!(Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
@@ -2897,7 +2897,7 @@ private struct InternalPointersTree(Allocator)
     }
 
     /// Ditto
-    Ternary owns(void[] b)
+    Ternary owns(const void[] b)
     {
         void[] result;
         return resolveInternalPointer(b.ptr, result);


### PR DESCRIPTION
`owns` should take a `const void[]` argument as it should also work with `const` and `immutable` memory chunks.

Added more unittests in order to ensure that allocators inherit from their parents.

This can now be safely merged as the vibe-d [patch](https://github.com/vibe-d/vibe.d/pull/1969) was merged. For more references see #5837 .