### PR TITLE
win32: split unittest6.obj, it's becoming too large for OMF

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -561,6 +561,7 @@ UNITTEST_OBJS= \
 		unittest4.obj \
 		unittest5.obj \
 		unittest6.obj \
+		unittest6a.obj \
 		unittest6b.obj \
 		unittest7.obj \
 		unittest8a.obj \
@@ -579,7 +580,8 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3b.obj $(SRC_STD_DATETIME)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest5.obj $(SRC_STD_ALGO)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER) $(SRC_STD_EXP_ALLOC)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER)
+	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6a.obj $(SRC_STD_EXP_ALLOC)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest7.obj $(SRC_STD_7)
 	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8a.obj $(SRC_STD_REGEX)


### PR DESCRIPTION
The current object file has 31929 symbols, pushing some PRs over the OMF limit of 32767, for example https://github.com/dlang/druntime/pull/1603