### PR TITLE
Fix DMD path to ../generated

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -59,9 +59,10 @@ MAKE=make
 
 ## D compiler
 
-DMD=$(DIR)\bin\dmd
-#DMD=..\dmd
-DMD=dmd
+DMD_DIR=..\dmd
+BUILD=release
+OS=windows
+DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
 
 ## Location of where to write the html documentation files
 

--- a/win64.mak
+++ b/win64.mak
@@ -63,9 +63,10 @@ MAKE=make
 
 ## D compiler
 
-DMD=$(DIR)\bin\dmd
-#DMD=..\dmd
-DMD=dmd
+DMD_DIR=..\dmd
+BUILD=release
+OS=windows
+DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
 
 ## Location of where to write the html documentation files
 


### PR DESCRIPTION
So I'm trying to move ahead with the ddmd -> dmd transition (https://github.com/dlang/dmd/pull/7135) and due to https://github.com/braddr/at-client/pull/4 we are stuck at the moment.

Hence, this PR tries to set the `DMD` binary path by default to one in the `generated` directory. As I have no Windows machine, I'm doing this more or less blindly, but it looks trivial enough.

See also: https://github.com/dlang/druntime/pull/1978