### PR TITLE
Issue 12625 - [scope] [DIP1000] implicit slicing of RValue static array should be illegal

### DIFF
--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -1190,11 +1190,11 @@ auto sha512_256Of(T...)(T data)
 {
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
-    string d = toHexString(sha1Of(a, b, c));
+    auto d = toHexString(sha1Of(a, b, c));
     version(LittleEndian)
-        assert(d == "CDBB611D00AC2387B642D3D7BDF4C3B342237110", d);
+        assert(d[] == "CDBB611D00AC2387B642D3D7BDF4C3B342237110", d);
     else
-        assert(d == "A0F1196C7A379C09390476D9CA4AA11B71FD11C8", d);
+        assert(d[] == "A0F1196C7A379C09390476D9CA4AA11B71FD11C8", d);
 }
 
 /**


### PR DESCRIPTION
This PR refactors some unittest code in `std.digest.sha` to support https://github.com/dlang/dmd/pull/7110.

https://github.com/dlang/dmd/pull/7110 has languished for so long in the PR queue that it has reach the maximum 1000 status updates that Github allows for any given commit.  Therefore, you can't rely on the test status reported on the front page of the PR.  But you can still see the auto-tester results by following the "details" link.

See also https://github.com/dlang/phobos/pull/5714 which was a similar fix.

ping @schveiguy 