### PR TITLE
Integrate AscendingPageAllocator with AllocatorList

### DIFF
--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -476,7 +476,18 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         assert(special || !allocators.ptr);
         if (special)
         {
-            special.deallocate(allocators);
+            static if (stateSize!Allocator)
+            {
+                import core.stdc.string : memcpy;
+                Allocator specialCopy;
+                memcpy(&specialCopy, &special.a, Allocator.sizeof);
+                emplace(&special.a);
+                specialCopy.deallocate(allocators);
+            }
+            else
+            {
+                special.deallocate(allocators);
+            }
         }
         allocators = null;
         root = null;
@@ -644,4 +655,123 @@ version(Posix) @system unittest
     assert(b1.length == 64 * bs);
     assert(a.allocators.length == 2);
     a.deallocateAll();
+}
+
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.algorithm.comparison : max;
+    import std.typecons : Ternary;
+
+    enum pageSize = 4096;
+
+    static void testrw(void[] b)
+    {
+        ubyte* buf = cast(ubyte*) b.ptr;
+        for (int i = 0; i < b.length; i += pageSize)
+        {
+            buf[i] = cast(ubyte) (i % 256);
+            assert(buf[i] == cast(ubyte) (i % 256));
+        }
+    }
+
+    enum numPages = 2;
+    AllocatorList!((n) => AscendingPageAllocator(max(n, numPages * pageSize)), Mallocator) a;
+
+    void[] b1 = a.allocate(1);
+    assert(b1.length == 1);
+    b1 = a.allocate(2);
+    assert(b1.length == 2);
+    testrw(b1);
+    assert(a.root.a.parent.getAvailableSize() == 0);
+
+    void[] b2 = a.allocate((numPages + 1) * pageSize);
+    assert(b2.length == (numPages + 1) * pageSize);
+    testrw(b2);
+
+    void[] b3 = a.allocate(3);
+    assert(b3.length == 3);
+    testrw(b3);
+
+    void[] b4 = a.allocate(0);
+    assert(b4.length == 0);
+
+    assert(a.allocators.length == 3);
+    assert(a.owns(b1) == Ternary.yes);
+    assert(a.owns(b2) == Ternary.yes);
+    assert(a.owns(b3) == Ternary.yes);
+
+    assert(a.expand(b1, pageSize - b1.length));
+    assert(b1.length == pageSize);
+    assert(!a.expand(b1, 1));
+    assert(!a.expand(b2, 1));
+
+    testrw(b1);
+    testrw(b2);
+    testrw(b3);
+
+    assert(a.deallocate(b1));
+    assert(a.deallocate(b2));
+
+    assert(a.deallocateAll());
+}
+
+@system unittest
+{
+    import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.algorithm.comparison : max;
+    import std.typecons : Ternary;
+
+    enum pageSize = 4096;
+
+    static void testrw(void[] b)
+    {
+        ubyte* buf = cast(ubyte*) b.ptr;
+        for (int i = 0; i < b.length; i += pageSize)
+        {
+            buf[i] = cast(ubyte) (i % 256);
+            assert(buf[i] == cast(ubyte) (i % 256));
+        }
+    }
+
+    enum numPages = 2;
+    AllocatorList!((n) => AscendingPageAllocator(max(n, numPages * pageSize)), NullAllocator) a;
+
+    void[] b1 = a.allocate(1);
+    assert(b1.length == 1);
+    b1 = a.allocate(2);
+    assert(b1.length == 2);
+    testrw(b1);
+
+    void[] b2 = a.allocate((numPages + 1) * pageSize);
+    assert(b2.length == (numPages + 1) * pageSize);
+    testrw(b2);
+
+    void[] b3 = a.allocate(3);
+    assert(b3.length == 3);
+    testrw(b3);
+
+    void[] b4 = a.allocate(0);
+    assert(b4.length == 0);
+
+    assert(a.allocators.length == 3);
+    assert(a.owns(b1) == Ternary.yes);
+    assert(a.owns(b2) == Ternary.yes);
+    assert(a.owns(b3) == Ternary.yes);
+
+    assert(a.expand(b1, pageSize - b1.length));
+    assert(b1.length == pageSize);
+    assert(!a.expand(b1, 1));
+    assert(!a.expand(b2, 1));
+
+    testrw(b1);
+    testrw(b2);
+    testrw(b3);
+
+    assert(a.deallocate(b1));
+    assert(a.deallocate(b2));
+
+    assert(a.deallocateAll());
 }

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -476,17 +476,18 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         assert(special || !allocators.ptr);
         if (special)
         {
-            static if (stateSize!Allocator)
+            static if (stateSize!SAllocator)
             {
                 import core.stdc.string : memcpy;
-                Allocator specialCopy;
-                memcpy(&specialCopy, &special.a, Allocator.sizeof);
+                SAllocator specialCopy;
+                assert(special.a.sizeof == specialCopy.sizeof);
+                memcpy(&specialCopy, &special.a, specialCopy.sizeof);
                 emplace(&special.a);
-                specialCopy.deallocate(allocators);
+                specialCopy.deallocateAll();
             }
             else
             {
-                special.deallocate(allocators);
+                special.deallocateAll();
             }
         }
         allocators = null;


### PR DESCRIPTION
- Added a couple of tests for AllocatorList together with AscendingPageAllocator.
- AscendingPageAllocator returns null/false for allocate/deallocate in case of failure
- AscendingPageAllocator receives as a constructor parameter the size in bytes, instead of the number of pages
- Removed some unused functions from AscendingPageAllocator
- When in ouroboros mode, the allocator which holds all the other allocators does not simply call deallocate, since it may have state. In case it has state, it creates a copy and then calls deallocate from that copy.