### PR TITLE
Run DScanner with gdb to catch the stack on a SEGFAULT

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -545,7 +545,7 @@ style: publictests style_lint
 # runs static code analysis with Dscanner
 dscanner: | $(DSCANNER_DIR)/dsc
 	@echo "Running DScanner"
-	$(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
+	$(DEBUGGER) -ex=r -ex=backtrace -ex=quit --args $(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
 
 style_lint: dscanner $(LIB)
 	@echo "Check for trailing whitespace"


### PR DESCRIPTION
As neither @MartinNowak nor I can reproduce the spurious DScanner failures locally, getting a stack trace on a SEFAULT is probably the best thing we can do.

CC @CyberShadow @ZombineDev @JackStouffer 