### PR TITLE
Add a global convenience package file

### DIFF
--- a/changelog/std-experimental-scripting.dd
+++ b/changelog/std-experimental-scripting.dd
@@ -1,0 +1,39 @@
+`import std.experimental.scripting` as a global convenience import
+
+$(MREF std,experimental,scripting) allows convenient use of all Phobos modules
+with one import:
+
+---
+import std.experimental.scripting;
+void main()
+{
+    10.iota.map!log.sum.writeln;
+}
+---
+
+For short scripts a lot of imports are often needed to get all the
+modules from the standard library.
+With this release it's possible to use `import std.experimental.scripting` for importing the entire
+standard library at once. This can be used for fast prototyping or REPLs:
+
+---
+import std.experimental.scripting;
+void main()
+{
+    6.iota
+      .filter!(a => a % 2) // 0 2 4
+      .map!(a => a * 2) // 0 4 8
+      .tee!writeln
+      .sum
+      .reverseArgs!writefln("Sum: %d"); // 18
+}
+---
+
+As before, symbol conflicts will only arise if a symbol with collisions is used.
+In this case, $(LINK2 $(ROOT)spec/module.html#static_imports, static imports) or
+$(LINK2 $(ROOT)spec/module.html#renamed_imports, renamed imports) can be used
+to uniquely select a specific symbol.
+
+The baseline cost for `import std.experimental.scripting`
+is less than half a second (varying from system to system) and
+work is in progress to reduce this overhead even further.

--- a/posix.mak
+++ b/posix.mak
@@ -195,7 +195,7 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   outbuffer parallelism path process random signals socket stdint \
   stdio string system traits typecons uni \
   uri utf uuid variant xml zip zlib
-PACKAGE_std_experimental = checkedint typecons
+PACKAGE_std_experimental = checkedint typecons scripting
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util

--- a/std/experimental/scripting.d
+++ b/std/experimental/scripting.d
@@ -1,0 +1,81 @@
+/++
+Convenience file that allows to import entire Phobos in one command.
++/
+module std.experimental.scripting;
+
+///
+@safe unittest
+{
+    import std.experimental.scripting;
+
+    int len;
+    auto r = 6.iota
+              .filter!(a => a % 2) // 0 2 4
+              .map!(a => a * 2) // 0 4 8
+              .tee!(_ => len++)
+              .sum
+              .reverseArgs!format("Sum: %d");
+
+    assert(len == 3);
+    assert(r == "Sum: 18");
+}
+
+///
+@safe unittest
+{
+    import std.experimental.scripting;
+    assert(10.iota.map!(partial!(pow, 2)).sum == 1023);
+}
+
+public import std.algorithm;
+public import std.array;
+public import std.ascii;
+public import std.base64;
+public import std.bigint;
+public import std.bitmanip;
+public import std.compiler;
+public import std.complex;
+public import std.concurrency;
+public import std.container;
+public import std.conv;
+public import std.csv;
+public import std.datetime;
+public import std.demangle;
+public import std.digest;
+public import std.encoding;
+public import std.exception;
+public import std.file;
+public import std.format;
+public import std.functional;
+public import std.getopt;
+public import std.json;
+public import std.math;
+public import std.mathspecial;
+public import std.meta;
+public import std.mmfile;
+public import std.net.curl;
+public import std.numeric;
+public import std.outbuffer;
+public import std.parallelism;
+public import std.path;
+public import std.process;
+public import std.random;
+public import std.range;
+public import std.regex;
+public import std.signals;
+public import std.socket;
+public import std.stdint;
+public import std.stdio;
+public import std.string;
+public import std.system;
+public import std.traits;
+public import std.typecons;
+//public import std.typetuple; // this module is undocumented and about to be deprecated
+public import std.uni;
+public import std.uri;
+public import std.utf;
+public import std.uuid;
+public import std.variant;
+public import std.xml;
+public import std.zip;
+public import std.zlib;

--- a/win32.mak
+++ b/win32.mak
@@ -284,7 +284,7 @@ SRC_STD_INTERNAL_WINDOWS= \
 	std\internal\windows\advapi32.d
 
 SRC_STD_EXP= \
-	std\experimental\checkedint.d std\experimental\typecons.d
+	std\experimental\checkedint.d std\experimental\typecons.d std\experimental\scripting.d
 
 SRC_STD_EXP_ALLOC_BB= \
 	std\experimental\allocator\building_blocks\affix_allocator.d \

--- a/win64.mak
+++ b/win64.mak
@@ -309,7 +309,7 @@ SRC_STD_INTERNAL_WINDOWS= \
 	std\internal\windows\advapi32.d
 
 SRC_STD_EXP= \
-	std\experimental\checkedint.d std\experimental\typecons.d
+	std\experimental\checkedint.d std\experimental\typecons.d std\experimental\scripting.d
 
 SRC_STD_EXP_ALLOC_BB= \
 	std\experimental\allocator\building_blocks\affix_allocator.d \


### PR DESCRIPTION
So after I have been thinking about this for quite a while, I realized that I am almost weekly in a case where `import std` would make my life easier. 
Other reasons include:

- Very convenient for short scripts, REPLs and things like run.dlang.io
- Promotes and test the idiom of paying for what you use
- Phobos is usually almost entirely parsed anyways
- A good use case for making imports even more lazily and maybe pushing [DIP1005](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1005.md) forward
- It doesn't hurt/cost anything for people who don't like this

For now I didn't add this file to the documentation build.
Also I didn't include `std.experimental`.