### PR TITLE
[DDoc] Avoid auto-escaping of StopWatch in std.datetime

### DIFF
--- a/std/datetime/package.d
+++ b/std/datetime/package.d
@@ -177,7 +177,7 @@ deprecated("Use std.datetime.stopwatch.AutoStart.") alias AutoStart = Flag!"auto
           $(REF TickDuration,core,time)) has been deprecated. Use what's in
           std.datetime.stopwatch instead. It uses $(REF MonoTime,core,time) and
           $(REF Duration,core,time). See
-          $(REF StopWatch,std,datetime,stopwatch). This symbol will be removed
+          $(REF _StopWatch,std,datetime,stopwatch). This symbol will be removed
           from the documentation in October 2018 and fully removed from Phobos
           in October 2019.)
 


### PR DESCRIPTION
Ddoc's annoying auto-escaping strikes again!

Before:

![image](https://user-images.githubusercontent.com/4370550/33881322-be9f59b4-df34-11e7-8f60-b4fcb0509a16.png)

https://dlang.org/phobos/std_datetime.html#.StopWatch

After:

![image](https://user-images.githubusercontent.com/4370550/33881309-b6316f92-df34-11e7-8acd-42e0a1278725.png)
