### PR TITLE
Improve wording in the Transposed changelog entry

### DIFF
--- a/changelog/std-range-package-Transposed-deprecate-save.dd
+++ b/changelog/std-range-package-Transposed-deprecate-save.dd
@@ -4,11 +4,12 @@ Transposed is incorrectly marked as a forward range. Its `popFront` primitive
 cannot be used without affecting any other copies made with `save`. `save` will be
 removed from Transposed in November 2018.
 
-https://issues.dlang.org/show_bug.cgi?id=17952
-
 -----
 auto x = [[1,2,3],[4,5,6]].transposed;
 auto y = x.save;
 y.popFront;
 assert(x.equal([[1,4],[2,5],[3,6]])); // FAILS, x is really [[2,5],[3,6]]
 -----
+
+For more details, please see the respective $(LINK2 https://issues.dlang.org/show_bug.cgi?id=17952,
+Bugzilla issue).


### PR DESCRIPTION
The current changelog can be previewed at https://dlang.org/changelog/pending.html

@ reviewers DAutotest builds the pending changelog too, s.t. changes to it can be conveniently previewed.

In this case, just dropping the Bugzilla link as plain text looks a bit weird.

Before:

![image](https://user-images.githubusercontent.com/4370550/33885007-3af6927c-df42-11e7-86d8-ceaded47e913.png)

After:

![image](https://user-images.githubusercontent.com/4370550/33885020-469a80ca-df42-11e7-9f91-5e0775d7b0a5.png)