### PR TITLE
[RFC] Add a pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+### All Submissions:
+
+* [ ] I followed the guidelines in the [Contributing document](https://wiki.dlang.org/Contributing_to_Phobos)
+* [ ] My code contains tests relevant for the problem I'm solving
+* [ ] I kept this pull requests small so that it can be easily reviewed
+
+### Bug fixes:
+
+- [ ] My PR is based of a Bugzilla issue, and I've [referenced it in the commit message](https://github.com/dlang-bots/dlang-bot#automated-references).
+- [ ] I included test(s) for the fixed issue(s)
+- [ ] I targeted `stable` (required for major, critical and regression fixes)
+
+### Core changes:
+
+* [ ] I have written new tests for my changes
+* [ ] I added a [changelog entry](https://github.com/dlang/phobos/tree/master/changelog)
+      (required for brand new features, breaking changes, or performance increases)
+
+### Description
+
+Be sure to include a detailed explanation of what your changes do
+and why you'd like us to include them.


### PR DESCRIPTION
This is a proposal for experimenting with a pull request template.

More details about this:
- https://github.com/blog/2111-issue-and-pull-request-templates
- https://help.github.com/articles/creating-a-pull-request-template-for-your-repository
- https://github.com/devspace/awesome-github-templates

I wasn't very good with coming up with essential questions or reminders.
- What did I forget?
- What isn't needed?