### PR TITLE
Add a StdUnittest version

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -138,6 +138,7 @@ endif
 ifdef ENABLE_COVERAGE
 DFLAGS  += -cov
 endif
+UDFLAGS=-unittest -version=StdUnittest
 
 # Set DOTOBJ and DOTEXE
 ifeq (,$(findstring win,$(OS)))
@@ -347,14 +348,14 @@ UT_D_OBJS:=$(addprefix $(ROOT)/unittest/,$(addsuffix .o,$(D_MODULES)))
 $(UT_D_OBJS): $(ALL_D_FILES)
 $(UT_D_OBJS): $(ROOT)/unittest/%.o: %.d
 	@mkdir -p $(dir $@)
-	$(DMD) $(DFLAGS) -unittest -c -of$@ $<
+	$(DMD) $(DFLAGS) $(UDFLAGS) -c -of$@ $<
 
 ifneq (1,$(SHARED))
 
 $(UT_D_OBJS): $(DRUNTIME)
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME)
-	$(DMD) $(DFLAGS) -unittest -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKDL) -defaultlib= -debuglib=
+	$(DMD) $(DFLAGS) $(UDFLAGS) -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKDL) -defaultlib= -debuglib=
 
 else
 
@@ -364,7 +365,7 @@ $(UT_D_OBJS): $(DRUNTIMESO)
 
 $(UT_LIBSO): override PIC:=-fPIC
 $(UT_LIBSO): $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO)
-	$(DMD) $(DFLAGS) -shared -unittest -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib=
+	$(DMD) $(DFLAGS) -shared $(UDFLAGS) -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib=
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_LIBSO)
 	$(DMD) $(DFLAGS) -of$@ $< -L$(UT_LIBSO) -defaultlib= -debuglib=
@@ -384,7 +385,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= $(LINKDL) -cov -run $< ;     \
+	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL) -cov -run $< ;     \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 
@@ -400,7 +401,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 # This forces all of phobos to have debug symbols, which we need as we don't
 # know where debugging is leading us.
 %.debug_with_debugger : %.d $(LIB)
-	$(DMD) $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= $(LINKDL) $<
+	$(DMD) $(DFLAGS) -main $(UDFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL) $<
 	$(DEBUGGER) ./$(basename $(notdir $<))
 
 # Target for quickly debugging a single module
@@ -607,7 +608,7 @@ $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 ################################################################################
 %.publictests: %.d $(LIB) $(TESTS_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
 	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
-	@$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main -unittest -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
+	@$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main $(UDFLAGS) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 
 .PHONY : auto-tester-build
 auto-tester-build: all checkwhitespace

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -707,7 +707,7 @@ do
 }
 
 // Make sure receive() works with free functions as well.
-version (unittest)
+version(StdUnittest)
 {
     private void receiveFunction(int x) {}
 }

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -367,7 +367,7 @@ public:
     }
 }
 
-version (unittest)
+version(StdUnittest)
 {
     static void testrw(void[] b)
     {

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -50,6 +50,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     import std.typecons : Ternary;
     import std.typecons : tuple, Tuple;
 
+    version(StdUnittest)
     @system unittest
     {
         import std.algorithm.comparison : max;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -26,6 +26,7 @@ struct FallbackAllocator(Primary, Fallback)
 
     // Need both allocators to be stateless
     // This is to avoid using default initialized stateful allocators
+    version(StdUnittest)
     static if (!stateSize!Primary && !stateSize!Fallback)
     @system unittest
     {

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -117,6 +117,7 @@ struct FreeList(ParentAllocator,
             _max = high;
         }
 
+        version(StdUnittest)
         @system unittest
         {
             import std.experimental.allocator.common : chooseAtRuntime;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -332,6 +332,7 @@ struct FreeTree(ParentAllocator)
         return true;
     }
 
+    version(StdUnittest)
     @system unittest // test a few simple configurations
     {
         import std.experimental.allocator.gc_allocator;
@@ -353,6 +354,7 @@ struct FreeTree(ParentAllocator)
         assert(a.formatSizes == "(_)", a.formatSizes);
     }
 
+    version(StdUnittest)
     @system unittest // build a complex free tree
     {
         import std.experimental.allocator.gc_allocator, std.range;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -551,6 +551,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
     }
 
     ///
+    version(StdUnittest)
     @system unittest
     {
         import std.experimental.allocator.gc_allocator : GCAllocator;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -20,6 +20,7 @@ struct ScopedAllocator(ParentAllocator)
     static if (!stateSize!ParentAllocator)
     {
         // This test is available only for stateless allocators
+        version(StdUnittest)
         @system unittest
         {
             testAllocator!(() => ScopedAllocator());

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -7,6 +7,7 @@ import std.experimental.allocator.common;
  */
 struct Mallocator
 {
+    version(StdUnittest)
     @system unittest { testAllocator!(() => Mallocator.instance); }
 
     /**

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -2618,7 +2618,7 @@ if (isIntegral!T && T.sizeof >= 4)
     testPow!ulong(3, 41);
 }
 
-version(unittest) private struct CountOverflows
+version(StdUnittest) private struct CountOverflows
 {
     uint calls;
     auto onOverflow(string op, Lhs)(Lhs lhs)
@@ -2643,7 +2643,7 @@ version(unittest) private struct CountOverflows
     }
 }
 
-version(unittest) private struct CountOpBinary
+version(StdUnittest) private struct CountOpBinary
 {
     uint calls;
     auto hookOpBinary(string op, Lhs, Rhs)(Lhs lhs, Rhs rhs)

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -218,7 +218,7 @@ private:
 
     To* _ptr;
     size_t _length;        // length of the string
-    version (unittest)
+    version (StdUnittest)
     {
         enum buffLength = 16 / To.sizeof;   // smaller size to trigger reallocations
     }

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -171,7 +171,7 @@ import std.internal.cstring;
 
 public import etc.c.curl : CurlOption;
 
-version(unittest)
+version(StdUnittest)
 {
     // Run unit test with the PHOBOS_TEST_ALLOW_NET=1 set in order to
     // allow net traffic

--- a/std/variant.d
+++ b/std/variant.d
@@ -545,8 +545,6 @@ private:
         return 0;
     }
 
-    enum doUnittest = is(VariantN == Variant);
-
 public:
     /** Constructs a $(D VariantN) value given an argument of a
      * generic type. Statically rejects disallowed types.
@@ -684,7 +682,7 @@ public:
     }
 
     ///
-    static if (doUnittest)
+    version(StdUnittest)
     @system unittest
     {
         Variant a;
@@ -717,7 +715,7 @@ public:
     }
 
     ///
-    static if (doUnittest)
+    version(StdUnittest)
     @system unittest
     {
         Variant a = 5;
@@ -1109,7 +1107,7 @@ public:
     }
 
     ///
-    static if (doUnittest)
+    version(StdUnittest)
     @system unittest
     {
         Variant a = new int[10];

--- a/win32.mak
+++ b/win32.mak
@@ -49,7 +49,7 @@ DFLAGS=-conf= -O -release -w -de -dip25 -I$(DRUNTIME)\import
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -O -w -dip25 -I$(DRUNTIME)\import
+UDFLAGS=-unittest -version=StdUnittest -conf= -O -w -dip25 -I$(DRUNTIME)\import
 
 ## C compiler
 
@@ -95,7 +95,7 @@ targets : $(LIB)
 test : test.exe
 
 test.obj : test.d
-	$(DMD) -conf= -c test -g -unittest
+	$(DMD) -conf= -c test -g $(UDFLAGS)
 
 test.exe : test.obj $(LIB)
 	$(DMD) -conf= test.obj -g -L/map
@@ -575,25 +575,25 @@ UNITTEST_OBJS= \
 		unittest8f.obj
 
 unittest : $(LIB)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest1.obj $(SRC_STD_1)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest2a.obj $(SRC_STD_2a)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3.obj $(SRC_STD_3)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3a.obj $(SRC_STD_3a)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest3b.obj $(SRC_STD_DATETIME)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest5.obj $(SRC_STD_ALGO)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6a.obj $(SRC_STD_EXP_ALLOC)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest7.obj $(SRC_STD_7)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8a.obj $(SRC_STD_REGEX)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8b.obj $(SRC_STD_NET)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
-	$(DMD) $(UDFLAGS) -L/co -c -unittest -ofunittest8f.obj $(SRC_STD_EXP)
-	$(DMD) $(UDFLAGS) -L/co -unittest unittest.d $(UNITTEST_OBJS) \
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest1.obj $(SRC_STD_1)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest2.obj $(SRC_STD_RANGE)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest2a.obj $(SRC_STD_2a)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest3.obj $(SRC_STD_3)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest3a.obj $(SRC_STD_3a)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest3b.obj $(SRC_STD_DATETIME)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5.obj $(SRC_STD_ALGO)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6a.obj $(SRC_STD_EXP_ALLOC)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest7.obj $(SRC_STD_7)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8a.obj $(SRC_STD_REGEX)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8b.obj $(SRC_STD_NET)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest8f.obj $(SRC_STD_EXP)
+	$(DMD) $(UDFLAGS) -L/co  unittest.d $(UNITTEST_OBJS) \
 		$(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
 
@@ -605,90 +605,90 @@ unittest : $(LIB)
 #	dmc unittest.obj -g
 
 cov : $(SRC_TO_COMPILE) $(LIB)
-#	$(DMD) -conf= -cov -unittest -ofcov.exe -main $(SRC_TO_COMPILE) $(LIB)
+#	$(DMD) -conf= -cov $(UDFLAGS) -ofcov.exe -main $(SRC_TO_COMPILE) $(LIB)
 #	cov
 	del *.lst
-	$(DMD) -conf= -cov=83 -unittest -main -run std\stdio.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\string.d
-	$(DMD) -conf= -cov=71 -unittest -main -run std\format.d
-	$(DMD) -conf= -cov=83 -unittest -main -run std\file.d
-	$(DMD) -conf= -cov=86 -unittest -main -run std\range\package.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\array.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\functional.d
-	$(DMD) -conf= -cov=96 -unittest -main -run std\path.d
-	$(DMD) -conf= -cov=41 -unittest -main -run std\outbuffer.d
-	$(DMD) -conf= -cov=89 -unittest -main -run std\utf.d
-	$(DMD) -conf= -cov=93 -unittest -main -run std\csv.d
-	$(DMD) -conf= -cov=91 -unittest -main -run std\math.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\complex.d
-	$(DMD) -conf= -cov=70 -unittest -main -run std\numeric.d
-	$(DMD) -conf= -cov=94 -unittest -main -run std\bigint.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\bitmanip.d
-	$(DMD) -conf= -cov=82 -unittest -main -run std\typecons.d
-	$(DMD) -conf= -cov=44 -unittest -main -run std\uni.d
-	$(DMD) -conf= -cov=91 -unittest -main -run std\base64.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\ascii.d
-	$(DMD) -conf= -cov=0  -unittest -main -run std\demangle.d
-	$(DMD) -conf= -cov=57 -unittest -main -run std\uri.d
-	$(DMD) -conf= -cov=51 -unittest -main -run std\mmfile.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\getopt.d
-	$(DMD) -conf= -cov=92 -unittest -main -run std\signals.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\meta.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\typetuple.d
-	$(DMD) -conf= -cov=85 -unittest -main -run std\traits.d
-	$(DMD) -conf= -cov=62 -unittest -main -run std\encoding.d
-	$(DMD) -conf= -cov=61 -unittest -main -run std\xml.d
-	$(DMD) -conf= -cov=79 -unittest -main -run std\random.d
-	$(DMD) -conf= -cov=92 -unittest -main -run std\exception.d
-	$(DMD) -conf= -cov=73 -unittest -main -run std\concurrency.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\date.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\interval.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\package.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\stopwatch.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\systime.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime\timezone.d
-	$(DMD) -conf= -cov=96 -unittest -main -run std\uuid.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\digest\crc.d
-	$(DMD) -conf= -cov=55 -unittest -main -run std\digest\sha.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\digest\md.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\digest\ripemd.d
-	$(DMD) -conf= -cov=75 -unittest -main -run std\digest\digest.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\digest\hmac.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\package.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\comparison.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\iteration.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\mutation.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\searching.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\setops.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\algorithm\sorting.d
-	$(DMD) -conf= -cov=83 -unittest -main -run std\variant.d
-	$(DMD) -conf= -cov=58 -unittest -main -run std\zlib.d
-	$(DMD) -conf= -cov=53 -unittest -main -run std\socket.d
-	$(DMD) -conf= -cov=95 -unittest -main -run std\container\array.d
-	$(DMD) -conf= -cov=68 -unittest -main -run std\container\binaryheap.d
-	$(DMD) -conf= -cov=91 -unittest -main -run std\container\dlist.d
-	$(DMD) -conf= -cov=93 -unittest -main -run std\container\rbtree.d
-	$(DMD) -conf= -cov=92 -unittest -main -run std\container\slist.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\container\util.d
-	$(DMD) -conf= -cov=100 -unittest -main -run std\container\package.d
-	$(DMD) -conf= -cov=90 -unittest -main -run std\conv.d
-	$(DMD) -conf= -cov=0  -unittest -main -run std\zip.d
-	$(DMD) -conf= -cov=77 -unittest -main -run std\regex\tests.d
-	$(DMD) -conf= -cov=92 -unittest -main -run std\json.d
-	$(DMD) -conf= -cov=87 -unittest -main -run std\parallelism.d
-	$(DMD) -conf= -cov=50 -unittest -main -run std\mathspecial.d
-	$(DMD) -conf= -cov=71 -unittest -main -run std\process.d
-	$(DMD) -conf= -cov=70 -unittest -main -run std\net\isemail.d
-	$(DMD) -conf= -cov=2  -unittest -main -run std\net\curl.d
-	$(DMD) -conf= -cov=60 -unittest -main -run std\windows\registry.d
-	$(DMD) -conf= -cov=0  -unittest -main -run std\internal\digest\sha_SSSE3.d
-	$(DMD) -conf= -cov=50 -unittest -main -run std\internal\math\biguintcore.d
-	$(DMD) -conf= -cov=75 -unittest -main -run std\internal\math\biguintnoasm.d
-#	$(DMD) -conf= -cov -unittest -main -run std\internal\math\biguintx86.d
-	$(DMD) -conf= -cov=94 -unittest -main -run std\internal\math\gammafunction.d
-	$(DMD) -conf= -cov=92 -unittest -main -run std\internal\math\errorfunction.d
-	$(DMD) -conf= -cov=31 -unittest -main -run std\internal\windows\advapi32.d
-	$(DMD) -conf= -cov=58 -unittest -main -run etc\c\zlib.d
+	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\stdio.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\string.d
+	$(DMD) -conf= -cov=71 $(UDFLAGS) -main -run std\format.d
+	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\file.d
+	$(DMD) -conf= -cov=86 $(UDFLAGS) -main -run std\range\package.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\array.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\functional.d
+	$(DMD) -conf= -cov=96 $(UDFLAGS) -main -run std\path.d
+	$(DMD) -conf= -cov=41 $(UDFLAGS) -main -run std\outbuffer.d
+	$(DMD) -conf= -cov=89 $(UDFLAGS) -main -run std\utf.d
+	$(DMD) -conf= -cov=93 $(UDFLAGS) -main -run std\csv.d
+	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\math.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\complex.d
+	$(DMD) -conf= -cov=70 $(UDFLAGS) -main -run std\numeric.d
+	$(DMD) -conf= -cov=94 $(UDFLAGS) -main -run std\bigint.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\bitmanip.d
+	$(DMD) -conf= -cov=82 $(UDFLAGS) -main -run std\typecons.d
+	$(DMD) -conf= -cov=44 $(UDFLAGS) -main -run std\uni.d
+	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\base64.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\ascii.d
+	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\demangle.d
+	$(DMD) -conf= -cov=57 $(UDFLAGS) -main -run std\uri.d
+	$(DMD) -conf= -cov=51 $(UDFLAGS) -main -run std\mmfile.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\getopt.d
+	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\signals.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\meta.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\typetuple.d
+	$(DMD) -conf= -cov=85 $(UDFLAGS) -main -run std\traits.d
+	$(DMD) -conf= -cov=62 $(UDFLAGS) -main -run std\encoding.d
+	$(DMD) -conf= -cov=61 $(UDFLAGS) -main -run std\xml.d
+	$(DMD) -conf= -cov=79 $(UDFLAGS) -main -run std\random.d
+	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\exception.d
+	$(DMD) -conf= -cov=73 $(UDFLAGS) -main -run std\concurrency.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\date.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\interval.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\package.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\stopwatch.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\systime.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\timezone.d
+	$(DMD) -conf= -cov=96 $(UDFLAGS) -main -run std\uuid.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\crc.d
+	$(DMD) -conf= -cov=55 $(UDFLAGS) -main -run std\digest\sha.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\md.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\ripemd.d
+	$(DMD) -conf= -cov=75 $(UDFLAGS) -main -run std\digest\digest.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\hmac.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\package.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\comparison.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\iteration.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\mutation.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\searching.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\setops.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\sorting.d
+	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\variant.d
+	$(DMD) -conf= -cov=58 $(UDFLAGS) -main -run std\zlib.d
+	$(DMD) -conf= -cov=53 $(UDFLAGS) -main -run std\socket.d
+	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\container\array.d
+	$(DMD) -conf= -cov=68 $(UDFLAGS) -main -run std\container\binaryheap.d
+	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\container\dlist.d
+	$(DMD) -conf= -cov=93 $(UDFLAGS) -main -run std\container\rbtree.d
+	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\container\slist.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\container\util.d
+	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\container\package.d
+	$(DMD) -conf= -cov=90 $(UDFLAGS) -main -run std\conv.d
+	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\zip.d
+	$(DMD) -conf= -cov=77 $(UDFLAGS) -main -run std\regex\tests.d
+	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\json.d
+	$(DMD) -conf= -cov=87 $(UDFLAGS) -main -run std\parallelism.d
+	$(DMD) -conf= -cov=50 $(UDFLAGS) -main -run std\mathspecial.d
+	$(DMD) -conf= -cov=71 $(UDFLAGS) -main -run std\process.d
+	$(DMD) -conf= -cov=70 $(UDFLAGS) -main -run std\net\isemail.d
+	$(DMD) -conf= -cov=2  $(UDFLAGS) -main -run std\net\curl.d
+	$(DMD) -conf= -cov=60 $(UDFLAGS) -main -run std\windows\registry.d
+	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\internal\digest\sha_SSSE3.d
+	$(DMD) -conf= -cov=50 $(UDFLAGS) -main -run std\internal\math\biguintcore.d
+	$(DMD) -conf= -cov=75 $(UDFLAGS) -main -run std\internal\math\biguintnoasm.d
+#	$(DMD) -conf= -cov $(UDFLAGS) -main -run std\internal\math\biguintx86.d
+	$(DMD) -conf= -cov=94 $(UDFLAGS) -main -run std\internal\math\gammafunction.d
+	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\internal\math\errorfunction.d
+	$(DMD) -conf= -cov=31 $(UDFLAGS) -main -run std\internal\windows\advapi32.d
+	$(DMD) -conf= -cov=58 $(UDFLAGS) -main -run etc\c\zlib.d
 
 html : $(DOCS)
 

--- a/win64.mak
+++ b/win64.mak
@@ -52,7 +52,7 @@ DFLAGS=-conf= -m$(MODEL) -O -release -w -de -dip25 -I$(DRUNTIME)\import
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import -version=StdUnittest
 
 ## C compiler, linker, librarian
 
@@ -99,7 +99,7 @@ targets : $(LIB)
 test : test.exe
 
 test.obj : test.d
-	$(DMD) -conf= -c -m$(MODEL) test -g -unittest
+	$(DMD) -conf= -c -m$(MODEL) test -g $(UDFLAGS)
 
 test.exe : test.obj $(LIB)
 	$(DMD) -conf= test.obj -m$(MODEL) -g -L/map
@@ -608,33 +608,33 @@ UNITTEST_OBJS= \
 		unittest9.obj
 
 unittest : $(LIB)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest1.obj $(SRC_STD_1)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest2.obj $(SRC_STD_RANGE)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest2a.obj $(SRC_STD_2a)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest3.obj $(SRC_STD_3)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest3a.obj $(SRC_STD_3a)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest3b.obj $(SRC_STD_3b)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest3c.obj $(SRC_STD_3c)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest3d.obj $(SRC_STD_3d) $(SRC_STD_DATETIME)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest5a.obj $(SRC_STD_ALGO_1)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest5b.obj $(SRC_STD_ALGO_2)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest5c.obj $(SRC_STD_ALGO_3)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6a.obj $(SRC_STD_6a)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6c.obj $(SRC_STD_6c)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6e.obj $(SRC_STD_6e)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6g.obj $(SRC_STD_CONTAINER)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6h.obj $(SRC_STD_6h)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest6i.obj $(SRC_STD_6i)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest7.obj $(SRC_STD_7) $(SRC_STD_EXP_LOGGER)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8a.obj $(SRC_STD_REGEX)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8b.obj $(SRC_STD_NET)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest8f.obj $(SRC_STD_EXP)
-	$(DMD) $(UDFLAGS) -c -unittest -ofunittest9.obj $(SRC_STD_EXP_ALLOC)
-	$(DMD) $(UDFLAGS) -L/OPT:NOICF -unittest unittest.d $(UNITTEST_OBJS) \
+	$(DMD) $(UDFLAGS) -c  -ofunittest1.obj $(SRC_STD_1)
+	$(DMD) $(UDFLAGS) -c  -ofunittest2.obj $(SRC_STD_RANGE)
+	$(DMD) $(UDFLAGS) -c  -ofunittest2a.obj $(SRC_STD_2a)
+	$(DMD) $(UDFLAGS) -c  -ofunittest3.obj $(SRC_STD_3)
+	$(DMD) $(UDFLAGS) -c  -ofunittest3a.obj $(SRC_STD_3a)
+	$(DMD) $(UDFLAGS) -c  -ofunittest3b.obj $(SRC_STD_3b)
+	$(DMD) $(UDFLAGS) -c  -ofunittest3c.obj $(SRC_STD_3c)
+	$(DMD) $(UDFLAGS) -c  -ofunittest3d.obj $(SRC_STD_3d) $(SRC_STD_DATETIME)
+	$(DMD) $(UDFLAGS) -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
+	$(DMD) $(UDFLAGS) -c  -ofunittest5a.obj $(SRC_STD_ALGO_1)
+	$(DMD) $(UDFLAGS) -c  -ofunittest5b.obj $(SRC_STD_ALGO_2)
+	$(DMD) $(UDFLAGS) -c  -ofunittest5c.obj $(SRC_STD_ALGO_3)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6a.obj $(SRC_STD_6a)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6c.obj $(SRC_STD_6c)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6e.obj $(SRC_STD_6e)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6g.obj $(SRC_STD_CONTAINER)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6h.obj $(SRC_STD_6h)
+	$(DMD) $(UDFLAGS) -c  -ofunittest6i.obj $(SRC_STD_6i)
+	$(DMD) $(UDFLAGS) -c  -ofunittest7.obj $(SRC_STD_7) $(SRC_STD_EXP_LOGGER)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8a.obj $(SRC_STD_REGEX)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8b.obj $(SRC_STD_NET)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
+	$(DMD) $(UDFLAGS) -c  -ofunittest8f.obj $(SRC_STD_EXP)
+	$(DMD) $(UDFLAGS) -c  -ofunittest9.obj $(SRC_STD_EXP_ALLOC)
+	$(DMD) $(UDFLAGS) -L/OPT:NOICF  unittest.d $(UNITTEST_OBJS) \
 	    $(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
 
@@ -646,7 +646,7 @@ unittest : $(LIB)
 #	dmc unittest.obj -g
 
 cov : $(SRC_TO_COMPILE) $(LIB)
-	$(DMD) -conf= -m$(MODEL) -cov -unittest -ofcov.exe unittest.d $(SRC_TO_COMPILE) $(LIB)
+	$(DMD) -conf= -m$(MODEL) -cov $(UDFLAGS) -ofcov.exe unittest.d $(SRC_TO_COMPILE) $(LIB)
 	cov
 
 html : $(DOCS)


### PR DESCRIPTION
There's still quite a bit of stuff in Phobos, that shouldn't be parsed & executed when Phobos is imported by a user who runs his tests.

For the motivation of excluding `unittest` in templates, please see https://wiki.dlang.org/DIP82

(I don't have any preferences on the name of this `version`.)