### PR TITLE
Fix Issue 18024 - checkedint.Warn should be @safe

### DIFF
--- a/changelog/stdx-checkedint-debug.dd
+++ b/changelog/stdx-checkedint-debug.dd
@@ -1,0 +1,6 @@
+`std.experimental.checkedint.Abort` now only uses `assert`
+
+$(REF Abort, std,experimental,checkedint) no longer calls $(REF writeln, std,stdio) on an exception
+and immediately terminates the program with an `AssertError`.
+
+The old behavior of printing the error message to stdout before aborting the program is available as a new $(REF Debug, std,experimental,checkedint) hook.


### PR DESCRIPTION
Same pattern as in https://github.com/dlang/phobos/blob/5964600c8d15fa28d7a6c4321b1e3705d03e492c/std/stdio.d#L3575-L3578

Maybe instead of the `trustedStdout` workaround `makeGlobal` should have been made `@safe`?

https://github.com/dlang/phobos/blob/5964600c8d15fa28d7a6c4321b1e3705d03e492c/std/stdio.d#L4612