### PR TITLE
Fix issue 18084 - tempCString type should not change size when used in unittests.

### DIFF
--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -218,16 +218,19 @@ private:
 
     To* _ptr;
     size_t _length;        // length of the string
+
+    // the 'small string optimization'
     version (unittest)
     {
-        enum buffLength = 16 / To.sizeof;   // smaller size to trigger reallocations
+        // smaller size to trigger reallocations. Padding is to account for
+        // unittest/non-unittest cross-compilation (to avoid corruption)
+        To[16 / To.sizeof] _buff;
+        To[(256 - 16) / To.sizeof] _unittest_pad;
     }
     else
     {
-        enum buffLength = 256 / To.sizeof;   // production size
+        To[256 / To.sizeof] _buff; // production size
     }
-
-    To[buffLength] _buff;  // the 'small string optimization'
 
     static TempCStringBuffer trustedVoidInit() { TempCStringBuffer res = void; return res; }
 }


### PR DESCRIPTION
Fixes memory corruption introduced when (ironically) trying to support dip25: https://github.com/dlang/phobos/pull/4746

Instead of the original mechanism (which was to slice the buffer with an enum), I just added padding when in unittest mode to make sure the size is the same. Very hard to unittest this, since unittests actually change the layout in the original! I'm open to suggestions.

ping @WalterBright 