### PR TITLE
Temporarily allow DScanner failures

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -101,6 +101,9 @@ style_lint()
     # dscanner needs a more up-to-date DMD version
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$DSCANNER_DMD_VER --activate)"
 
+    # Temporarily allow DScanner failures
+    # See also: https://github.com/dlang/phobos/pull/5929
+    sed -i 's/dscanner:/dscanner:\n\t@echo "Temporarily disabled. Failures allowed."\n\t-make -f posix.mak dscanner_allow_failures\n\ndscanner_allow_failures:/' posix.mak
     make -f posix.mak style_lint DUB=$DUB BUILD=$BUILD
 }
 


### PR DESCRIPTION
I really don't want to do this as we then most likely will forget about it, but the failures are getting more persistent :/

This works by replacing the Makefile target with `dscanner_disabled` and then executing it separately with the good old `|| true`.

See also:
- https://github.com/dlang/phobos/pull/5929
- https://github.com/dlang/phobos/pull/5930
- https://github.com/dlang/phobos/pull/5920#issuecomment-351355514