### PR TITLE
Fix Issue 18092 - takeExactly cannot deduce function from generic forward range

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2393,9 +2393,9 @@ if (isInputRange!R)
             @property size_t length() const { return _n; }
             alias opDollar = length;
 
-            @property Take!R _takeExactly_Result_asTake()
+            @property auto _takeExactly_Result_asTake()
             {
-                return typeof(return)(_input, _n);
+                return take(_input, _n);
             }
 
             alias _takeExactly_Result_asTake this;
@@ -2543,6 +2543,22 @@ pure @safe nothrow unittest
     Take!DummyType t = te;
     assert(equal(t, [1, 2, 3, 4, 5]));
     assert(equal(t, te));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=18092
+// can't combine take and takeExactly
+unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.internal.test.dummyrange : AllDummyRanges;
+
+    static foreach (Range; AllDummyRanges)
+    {{
+        Range r;
+        assert(r.take(6).takeExactly(2).equal([1, 2]));
+        assert(r.takeExactly(6).takeExactly(2).equal([1, 2]));
+        assert(r.takeExactly(6).take(2).equal([1, 2]));
+    }}
 }
 
 /**


### PR DESCRIPTION
The problem is that  `Take` explicitly avoid nesting itself, which usually is really smart, because `take` takes care of removing nested `take` calls:


https://github.com/dlang/phobos/blob/2f539a4c34fbe3c26b2bb951040aac19ee1a51a7/std/range/package.d#L1994-L1998

https://github.com/dlang/phobos/blob/2f539a4c34fbe3c26b2bb951040aac19ee1a51a7/std/range/package.d#L1973-L1981

The fix is really easy in this case: use the logic which is already part of `take` :)