### PR TITLE
Fix Issue 18086 - BigInt DivMod

### DIFF
--- a/changelog/std-bigint-divmod.dd
+++ b/changelog/std-bigint-divmod.dd
@@ -1,0 +1,18 @@
+`divMod` was added to std.bigint.
+
+$(REF divMod, std, bigint) calculates both the quotient and the remainder in one go:
+
+-----
+void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, out BigInt remainder) pure nothrow
+{
+auto a = BigInt(123);
+auto b = BigInt(25);
+BigInt q, r;
+
+divMod(a, b, q, r);
+
+assert(q == 4);
+assert(r == 23);
+assert(q * b + r == a);
+}
+-----

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1836,3 +1836,65 @@ unittest
     enum BigInt test1 = BigInt(123);
     enum BigInt test2 = plusTwo(test1);
 }
+
+/**
+ * Finds the quotient and remainder for the given dividend and divisor in one operation.
+ *
+ * Params:
+ *     dividend = the $(LREF BigInt) to divide
+ *     divisor = the $(LREF BigInt) to divide the dividend by
+ *     quotient = is set to the result of the division
+ *     remainder = is set to the remainder of the division
+ */
+void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, out BigInt remainder) pure nothrow
+{
+    BigUint q, r;
+    BigUint.divMod(dividend.data, divisor.data, q, r);
+    quotient.sign = dividend.sign != divisor.sign;
+    quotient.data = q;
+    remainder.sign = dividend.sign;
+    remainder.data = r;
+}
+
+///
+@system pure nothrow unittest
+{
+    auto a = BigInt(123);
+    auto b = BigInt(25);
+    BigInt q, r;
+
+    divMod(a, b, q, r);
+
+    assert(q == 4);
+    assert(r == 23);
+    assert(q * b + r == a);
+}
+
+// Issue 18086
+@system pure nothrow unittest
+{
+    BigInt q = 1;
+    BigInt r = 1;
+    BigInt c = 1024;
+    BigInt d = 100;
+
+    divMod(c, d, q, r);
+    assert(q ==  10);
+    assert(r ==  24);
+    assert((q * d + r) == c);
+
+    divMod(c, -d, q, r);
+    assert(q == -10);
+    assert(r ==  24);
+    assert(q * -d + r == c);
+
+    divMod(-c, -d, q, r);
+    assert(q ==  10);
+    assert(r == -24);
+    assert(q * -d + r == -c);
+
+    divMod(-c, d, q, r);
+    assert(q == -10);
+    assert(r == -24);
+    assert(q * d + r == -c);
+}

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -847,6 +847,29 @@ public:
         return BigUint(removeLeadingZeros(trustedAssumeUnique(rem)));
     }
 
+    // Return x / y in quotient, x % y in remainder
+    static void divMod(BigUint x, BigUint y, out BigUint quotient, out BigUint remainder) pure nothrow
+    {
+        if (y.data.length > x.data.length)
+        {
+            quotient = 0uL;
+            remainder = x;
+        }
+        else if (y.data.length == 1)
+        {
+            quotient = divInt(x, y.data[0]);
+            remainder = BigUint([modInt(x, y.data[0])]);
+        }
+        else
+        {
+            BigDigit[] quot = new BigDigit[x.data.length - y.data.length + 1];
+            BigDigit[] rem = new BigDigit[y.data.length];
+            divModInternal(quot, rem, x.data, y.data);
+            quotient = BigUint(removeLeadingZeros(trustedAssumeUnique(quot)));
+            remainder = BigUint(removeLeadingZeros(trustedAssumeUnique(rem)));
+        }
+    }
+
     // return x op y
     static BigUint bitwiseOp(string op)(BigUint x, BigUint y, bool xSign, bool ySign, ref bool resultSign)
     pure nothrow @safe if (op == "|" || op == "^" || op == "&")


### PR DESCRIPTION
Made `divMod` accessible for `BigInt`. The function already exists in biguintcore, but is not publicly accessible.