### PR TITLE
Faster to import std.regex, by lazy eval of wordMatcher

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -47,7 +47,11 @@ CharMatcher[CodepointSet] matcherCache;
     }
 }
 
-static CharMatcher wordMatcher = CharMatcher(wordCharacter);
+@property ref wordMatcher()()
+{
+    static CharMatcher matcher = CharMatcher(wordCharacter);
+    return matcher;
+}
 
 // some special Unicode white space characters
 private enum NEL = '\u0085', LS = '\u2028', PS = '\u2029';


### PR DESCRIPTION
After:
▶ time dmd test_case.d
dmd test_case.d  0.24s user 0.03s system 98% cpu 0.269 total

▶ gco master
Switched to branch 'master'

Before:
▶ time dmd test_case.d
dmd test_case.d  1.10s user 0.12s system 99% cpu 1.228 total

