### PR TITLE
Make import of std.internal.unicode_tables lazy.

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -1588,7 +1588,7 @@ private auto packedArrayView(T)(inout(size_t)* ptr, size_t items) @trusted pure 
 // Partially unrolled binary search using Shar's method
 //============================================================================
 
-string genUnrolledSwitchSearch(size_t size) @safe pure nothrow
+auto genUnrolledSwitchSearch(size_t size) @safe pure nothrow
 {
     import core.bitop : bsr;
     import std.array : replace;
@@ -2760,7 +2760,7 @@ public:
         }
         ---
     */
-    string toSourceCode(string funcName="")
+    string toSourceCode()(string funcName="")
     {
         import std.array : array;
         auto range = byInterval.array();
@@ -6135,7 +6135,7 @@ package @trusted auto memoizeExpr(string expr)()
 }
 
 //property for \w character class
-package @property @safe CodepointSet wordCharacter()
+package @property @safe auto wordCharacter()
 {
     return memoizeExpr!("unicode.Alphabetic | unicode.Mn | unicode.Mc
         | unicode.Me | unicode.Nd | unicode.Pc")();
@@ -6212,7 +6212,7 @@ package dchar parseUniHex(Range)(ref Range str, size_t maxDigit)
       .canFind("invalid codepoint"));
 }
 
-auto caseEnclose(CodepointSet set)
+auto caseEnclose()(CodepointSet set)
 {
     auto cased = set & unicode.LC;
     foreach (dchar ch; cased.byCodepoint)
@@ -6226,7 +6226,7 @@ auto caseEnclose(CodepointSet set)
 /+
     fetch codepoint set corresponding to a name (InBlock or binary property)
 +/
-@trusted CodepointSet getUnicodeSet(in char[] name, bool negated,  bool casefold)
+@trusted CodepointSet getUnicodeSet()(in char[] name, bool negated,  bool casefold)
 {
     CodepointSet s = unicode(name);
     //FIXME: caseEnclose for new uni as Set | CaseEnclose(SET && LC)

--- a/std/uni.d
+++ b/std/uni.d
@@ -6239,7 +6239,6 @@ auto caseEnclose(CodepointSet set)
 
 @safe struct UnicodeSetParser(Range)
 {
-    import std.exception : enforce;
     import std.typecons : tuple, Tuple;
     Range range;
     bool casefold_;
@@ -6257,6 +6256,7 @@ auto caseEnclose(CodepointSet set)
     //also fetches next set operation
     Tuple!(CodepointSet,Operator) parseCharTerm()
     {
+        import std.exception : enforce;
         import std.range : drop;
         enum privateUseStart = '\U000F0000', privateUseEnd ='\U000FFFFD';
         enum State{ Start, Char, Escape, CharDash, CharDashEscape,
@@ -6563,6 +6563,7 @@ auto caseEnclose(CodepointSet set)
 
     CodepointSet parseSet()
     {
+        import std.exception : enforce;
         ValStack vstack;
         OpStack opstack;
         import std.functional : unaryFun;
@@ -6695,7 +6696,6 @@ auto caseEnclose(CodepointSet set)
 */
 @safe public struct unicode
 {
-    import std.exception : enforce;
     /**
         Performs the lookup of set of $(CODEPOINTS)
         with compile-time correctness checking.
@@ -6833,6 +6833,7 @@ auto caseEnclose(CodepointSet set)
     //parse control code of form \cXXX, c assumed to be the current symbol
     static package dchar parseControlCode(Parser)(ref Parser p)
     {
+        import std.exception : enforce;
         with(p)
         {
             popFront();
@@ -6849,6 +6850,7 @@ auto caseEnclose(CodepointSet set)
     static package CodepointSet parsePropertySpec(Range)(ref Range p,
         bool negated, bool casefold)
     {
+        import std.exception : enforce;
         static import std.ascii;
         with(p)
         {
@@ -7392,7 +7394,6 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 +/
 @trusted struct Grapheme
 {
-    import std.exception : enforce;
     import std.traits : isDynamicArray;
 
 public:

--- a/std/uni.d
+++ b/std/uni.d
@@ -5935,7 +5935,7 @@ else
     import std.algorithm.iteration : map;
     import std.range : assumeSorted;
     auto range = assumeSorted!((a,b) => propertyNameLess(a,b))
-        (table.map!"a.name"());
+        (table.map!(a => a.name)());
     size_t idx = range.lowerBound(name).length;
     if (idx < range.length && comparePropertyName(range[idx], name) == 0)
         return idx;


### PR DESCRIPTION
There's no need to open and open and parse the gigantic
`std.internal.unicode_tables` if it's never needed.

My journey:

`std.net.curl` -> `etc.c.curl` -> `std.socket` -> `std.stdio` -> `std.uni` -> `std.internal.unicode_tables`.

```shell
> cd std && echo "import std.uni;" > foo.d
> time dmd -c -o- foo.d
dmd -c -o- foo.d  0.10s user 0.00s system 99% cpu 0.101 total

> time dmd -c -o- foo.d -I..
dmd -c -o- foo.d -I..  0.04s user 0.01s system 99% cpu 0.050 total
```

Follow-up to https://github.com/dlang/phobos/pull/5916

Alternatively a benchmark with `avgtime`:

```
> avgtime -r100 dmd -c -o- foo.d
Total time (ms): 9942.26
Repetitions    : 100
Sample mode    : 96 (15 occurrences)
Median time    : 96.908
Avg time       : 99.4226
Std dev.       : 6.38707
Minimum        : 92.079
Maximum        : 120.269
95% conf.int.  : [86.9042, 111.941]  e = 12.5184
99% conf.int.  : [82.9706, 115.875]  e = 16.452
EstimatedAvg95%: [98.1707, 100.674]  e = 1.25184
EstimatedAvg99%: [97.7774, 101.068]  e = 1.6452

> avgtime -r100 dmd -c -o- foo.d -I..
Total time (ms): 4678.42
Repetitions    : 100
Sample mode    : 46 (40 occurrences)
Median time    : 46.537
Avg time       : 46.7842
Std dev.       : 1.39462
Minimum        : 44.338
Maximum        : 53.491
95% conf.int.  : [44.0508, 49.5176]  e = 2.73341
99% conf.int.  : [43.1919, 50.3765]  e = 3.59231
EstimatedAvg95%: [46.5108, 47.0575]  e = 0.273341
EstimatedAvg99%: [46.425, 47.1434]  e = 0.359231
```