### PR TITLE
Dramatically faster to import std.datetime (and anything under it)

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -7,9 +7,13 @@
 +/
 module std.datetime.systime;
 
-import core.time;
-import std.datetime.date;
-import std.datetime.timezone;
+// Note: reconsider using specific imports below after
+// https://issues.dlang.org/show_bug.cgi?id=17630 has been fixed
+import core.time;// : ClockType, convert, dur, Duration, seconds, TickDuration, TimeException;
+import std.datetime.date;// : _monthNames, AllowDayOverflow, CmpTimeUnits, Date,
+    //DateTime, DateTimeException, DayOfWeek, enforceValid, getDayOfWeek, maxDay,
+    //Month, splitUnitsFromHNSecs, TimeOfDay, validTimeUnits, yearIsLeapYear;
+import std.datetime.timezone;// : LocalTime, SimpleTimeZone, TimeZone, UTC;
 import std.exception : enforce;
 import std.format : format;
 import std.range.primitives;
@@ -70,6 +74,7 @@ public:
     {
         import std.format : format;
         import std.stdio : writefln;
+        import core.time;
         assert(currTime().timezone is LocalTime());
         assert(currTime(UTC()).timezone is UTC());
 
@@ -426,6 +431,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         static void test(DateTime dt, Duration fracSecs, immutable TimeZone tz, long expected)
         {
             auto sysTime = SysTime(dt, fracSecs, tz);
@@ -1729,6 +1735,7 @@ public:
     @safe unittest
     {
         import std.range : chain;
+        import core.time;
 
         assert(SysTime(0, UTC()).fracSecs == Duration.zero);
         assert(SysTime(1, UTC()).fracSecs == hnsecs(1));
@@ -1822,6 +1829,7 @@ public:
     @safe unittest
     {
         import std.range : chain;
+        import core.time;
 
         foreach (fracSec; testFracSecs)
         {
@@ -1856,6 +1864,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(0).stdTime == 0);
         assert(SysTime(1).stdTime == 1);
         assert(SysTime(-1).stdTime == -1);
@@ -1883,6 +1892,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         static void test(long stdTime, in SysTime expected, size_t line = __LINE__)
         {
             auto st = SysTime(0, UTC());
@@ -1967,6 +1977,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         {
             auto sysTime = SysTime(DateTime(1982, 1, 4, 8, 59, 7), hnsecs(27));
             assert(sysTime == sysTime.toLocalTime());
@@ -1999,6 +2010,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto sysTime = SysTime(DateTime(1982, 1, 4, 8, 59, 7), hnsecs(27));
         assert(sysTime == sysTime.toUTC());
         assert(sysTime._stdTime == sysTime.toUTC()._stdTime);
@@ -2022,6 +2034,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto stz = new immutable SimpleTimeZone(dur!"minutes"(11 * 60));
         auto sysTime = SysTime(DateTime(1982, 1, 4, 8, 59, 7), hnsecs(27));
         assert(sysTime == sysTime.toOtherTZ(stz));
@@ -2089,6 +2102,7 @@ public:
     @safe unittest
     {
         import std.meta : AliasSeq;
+        import core.time;
         assert(SysTime(DateTime(1970, 1, 1), UTC()).toUnixTime() == 0);
         foreach (units; AliasSeq!("hnsecs", "usecs", "msecs"))
             assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), dur!units(1), UTC()).toUnixTime() == 0);
@@ -2146,6 +2160,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime.fromUnixTime(0) == SysTime(DateTime(1970, 1, 1), UTC()));
         assert(SysTime.fromUnixTime(1) == SysTime(DateTime(1970, 1, 1, 0, 0, 1), UTC()));
         assert(SysTime.fromUnixTime(-1) == SysTime(DateTime(1969, 12, 31, 23, 59, 59), UTC()));
@@ -2181,6 +2196,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(DateTime(1970, 1, 1), UTC()).toTimeVal() == timeval(0, 0));
         assert(SysTime(DateTime(1970, 1, 1), hnsecs(9), UTC()).toTimeVal() == timeval(0, 0));
         assert(SysTime(DateTime(1970, 1, 1), hnsecs(10), UTC()).toTimeVal() == timeval(0, 1));
@@ -2224,6 +2240,7 @@ public:
 
         @safe unittest
         {
+            import core.time;
             assert(SysTime(DateTime(1970, 1, 1), UTC()).toTimeSpec() == timespec(0, 0));
             assert(SysTime(DateTime(1970, 1, 1), hnsecs(9), UTC()).toTimeSpec() == timespec(0, 900));
             assert(SysTime(DateTime(1970, 1, 1), hnsecs(10), UTC()).toTimeSpec() == timespec(0, 1000));
@@ -2284,11 +2301,13 @@ public:
     @system unittest
     {
         import std.conv : to;
+        import core.time;
 
         version(Posix)
         {
-            scope(exit) clearTZEnvVar();
+            import std.datetime.timezone : clearTZEnvVar, setTZEnvVar;
             setTZEnvVar("America/Los_Angeles");
+            scope(exit) clearTZEnvVar();
         }
 
         {
@@ -2411,6 +2430,7 @@ public:
     // Test add!"years"() with AllowDayOverflow.yes
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -2613,6 +2633,7 @@ public:
     // Test add!"years"() with AllowDayOverflow.no
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -2818,6 +2839,7 @@ public:
     // Test add!"months"() with AllowDayOverflow.yes
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -3164,6 +3186,7 @@ public:
     // Test add!"months"() with AllowDayOverflow.no
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -3600,6 +3623,7 @@ public:
     // Test roll!"months"() with AllowDayOverflow.yes
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -3978,6 +4002,7 @@ public:
     // Test roll!"months"() with AllowDayOverflow.no
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 7, 6));
@@ -4455,6 +4480,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         {
             auto sysTime = SysTime(Date(1999, 2, 28));
@@ -4773,6 +4799,7 @@ public:
     // Test roll!"hours"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, int hours, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"hours"(hours);
@@ -4990,6 +5017,7 @@ public:
     // Test roll!"minutes"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, int minutes, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"minutes"(minutes);
@@ -5200,6 +5228,7 @@ public:
     // Test roll!"seconds"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, int seconds, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"seconds"(seconds);
@@ -5417,6 +5446,7 @@ public:
     // Test roll!"msecs"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, int milliseconds, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"msecs"(milliseconds);
@@ -5522,6 +5552,7 @@ public:
     // Test roll!"usecs"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, long microseconds, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"usecs"(microseconds);
@@ -5651,6 +5682,7 @@ public:
     // Test roll!"hnsecs"().
     @safe unittest
     {
+        import core.time;
         static void testST(SysTime orig, long hnsecs, in SysTime expected, size_t line = __LINE__)
         {
             orig.roll!"hnsecs"(hnsecs);
@@ -5836,6 +5868,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
 
         assert(st + dur!"weeks"(7) == SysTime(DateTime(1999, 8, 24, 12, 30, 33), hnsecs(2_345_678)));
@@ -6016,6 +6049,7 @@ public:
 
     deprecated @safe unittest
     {
+        import core.time;
         // This probably only runs in cases where gettimeofday() is used, but it's
         // hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
@@ -6057,6 +6091,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto before = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(before + dur!"weeks"(7) == SysTime(DateTime(1999, 8, 24, 12, 30, 33)));
         assert(before + dur!"weeks"(-7) == SysTime(DateTime(1999, 5, 18, 12, 30, 33)));
@@ -6245,6 +6280,7 @@ public:
 
     deprecated @safe unittest
     {
+        import core.time;
         // This probably only runs in cases where gettimeofday() is used, but it's
         // hard to do this test correctly with variable ticksPerSec.
         if (TickDuration.ticksPerSec == 1_000_000)
@@ -6292,6 +6328,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(DateTime(1999, 7, 6, 12, 30, 33)) - SysTime(DateTime(1998, 7, 6, 12, 30, 33)) ==
                dur!"seconds"(31_536_000));
         assert(SysTime(DateTime(1998, 7, 6, 12, 30, 33)) - SysTime(DateTime(1999, 7, 6, 12, 30, 33)) ==
@@ -6345,9 +6382,15 @@ public:
                dur!"hnsecs"(-1));
 
         version(Posix)
+        {
+            import std.datetime.timezone : PosixTimeZone;
             immutable tz = PosixTimeZone.getTimeZone("America/Los_Angeles");
+        }
         else version(Windows)
+        {
+            import std.datetime.timezone : WindowsTimeZone;
             immutable tz = WindowsTimeZone.getTimeZone("Pacific Standard Time");
+        }
 
         {
             auto dt = DateTime(2011, 1, 13, 8, 17, 2);
@@ -6403,6 +6446,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : Date;
 
         assert(SysTime(Date(1999, 2, 1)).diffMonths(
@@ -6420,6 +6464,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6447,6 +6492,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6466,6 +6512,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6486,6 +6533,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : DateTime;
 
         assert(SysTime(DateTime(1999, 1, 1, 12, 22, 7)).dayOfYear == 1);
@@ -6495,6 +6543,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6527,6 +6576,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6559,6 +6609,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : DateTime;
 
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0)).dayOfGregorianCal == 1);
@@ -6575,6 +6626,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0)).dayOfGregorianCal == 1);
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0), hnsecs(1)).dayOfGregorianCal == 1);
@@ -6746,6 +6798,7 @@ public:
     // between Date and SysTime.
     @safe unittest
     {
+        import core.time;
         void test(Date date, SysTime st, size_t line = __LINE__)
         {
             if (date.dayOfGregorianCal != st.dayOfGregorianCal)
@@ -6933,6 +6986,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : DateTime;
 
         auto st = SysTime(DateTime(0, 1, 1, 12, 0, 0));
@@ -6963,6 +7017,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         void testST(SysTime orig, int day, in SysTime expected, size_t line = __LINE__)
         {
             orig.dayOfGregorianCal = day;
@@ -7175,6 +7230,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : Date;
 
         auto st = SysTime(Date(1999, 7, 6));
@@ -7237,6 +7293,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(Date(1999, 1, 1)).endOfMonth == SysTime(DateTime(1999, 1, 31, 23, 59, 59), hnsecs(9_999_999)));
         assert(SysTime(Date(1999, 2, 1)).endOfMonth == SysTime(DateTime(1999, 2, 28, 23, 59, 59), hnsecs(9_999_999)));
@@ -7288,6 +7345,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : DateTime;
 
         assert(SysTime(DateTime(1999, 1, 6, 0, 0, 0)).daysInMonth == 31);
@@ -7298,6 +7356,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(DateTime(1999, 1, 1, 12, 1, 13)).daysInMonth == 31);
         assert(SysTime(DateTime(1999, 2, 1, 17, 13, 12)).daysInMonth == 28);
@@ -7346,6 +7405,7 @@ public:
     ///
     @safe unittest
     {
+        import core.time;
         import std.datetime.date : DateTime;
 
         assert(SysTime(DateTime(1, 1, 1, 12, 7, 0)).isAD);
@@ -7356,6 +7416,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(DateTime(2010, 7, 4, 12, 0, 9)).isAD);
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0)).isAD);
         assert(!SysTime(DateTime(0, 12, 31, 23, 59, 59)).isAD);
@@ -7385,6 +7446,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(DateTime(-4713, 11, 24, 0, 0, 0)).julianDay == -1);
         assert(SysTime(DateTime(-4713, 11, 24, 12, 0, 0)).julianDay == 0);
 
@@ -7428,6 +7490,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(SysTime(DateTime(1858, 11, 17, 0, 0, 0)).modJulianDay == 0);
         assert(SysTime(DateTime(1858, 11, 17, 12, 0, 0)).modJulianDay == 0);
 
@@ -7452,6 +7515,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(cast(Date) SysTime(Date(1999, 7, 6)) == Date(1999, 7, 6));
         assert(cast(Date) SysTime(Date(2000, 12, 31)) == Date(2000, 12, 31));
         assert(cast(Date) SysTime(Date(2001, 1, 1)) == Date(2001, 1, 1));
@@ -7505,6 +7569,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(cast(DateTime) SysTime(DateTime(1, 1, 6, 7, 12, 22)) == DateTime(1, 1, 6, 7, 12, 22));
         assert(cast(DateTime) SysTime(DateTime(1, 1, 6, 7, 12, 22), msecs(22)) == DateTime(1, 1, 6, 7, 12, 22));
         assert(cast(DateTime) SysTime(Date(1999, 7, 6)) == DateTime(1999, 7, 6, 0, 0, 0));
@@ -7562,6 +7627,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         assert(cast(TimeOfDay) SysTime(Date(1999, 7, 6)) == TimeOfDay(0, 0, 0));
         assert(cast(TimeOfDay) SysTime(Date(2000, 12, 31)) == TimeOfDay(0, 0, 0));
         assert(cast(TimeOfDay) SysTime(Date(2001, 1, 1)) == TimeOfDay(0, 0, 0));
@@ -7689,6 +7755,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(DateTime.init, UTC()).toISOString() == "00010101T000000Z");
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0), hnsecs(1), UTC()).toISOString() == "00010101T000000.0000001Z");
@@ -7821,6 +7888,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(DateTime.init, UTC()).toISOExtString() == "0001-01-01T00:00:00Z");
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0), hnsecs(1), UTC()).toISOExtString() ==
@@ -7957,6 +8025,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         // Test A.D.
         assert(SysTime(DateTime.init, UTC()).toString() == "0001-Jan-01 00:00:00Z");
         assert(SysTime(DateTime(1, 1, 1, 0, 0, 0), hnsecs(1), UTC()).toString() == "0001-Jan-01 00:00:00.0000001Z");
@@ -8045,6 +8114,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -8204,6 +8274,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000", "20100704t000000",
                        "20100704T000000.", "20100704T000000.A", "20100704T000000.Z",
                        "20100704T000000.0000000A", "20100704T000000.00000000A",
@@ -8467,6 +8538,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000",
                        "20100704t000000", "20100704T000000.", "20100704T000000.0",
                        "2010-07:0400:00:00", "2010-07-04 00:00:00",
@@ -8560,6 +8632,7 @@ public:
     // bug# 17801
     @safe unittest
     {
+        import core.time;
         import std.conv : to;
         import std.meta : AliasSeq;
         foreach (C; AliasSeq!(char, wchar, dchar))
@@ -8709,6 +8782,7 @@ public:
 
     @safe unittest
     {
+        import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000",
                        "20100704t000000", "20100704T000000.", "20100704T000000.0",
                        "2010-07-0400:00:00", "2010-07-04 00:00:00", "2010-07-04t00:00:00",
@@ -8804,6 +8878,7 @@ public:
     // bug# 17801
     @safe unittest
     {
+        import core.time;
         import std.conv : to;
         import std.meta : AliasSeq;
         foreach (C; AliasSeq!(char, wchar, dchar))
@@ -9228,6 +9303,7 @@ else version(Windows)
 
         auto dt = DateTime(st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
 
+        import core.time : msecs;
         return SysTime(dt, msecs(st.wMilliseconds), tz);
     }
 
@@ -9237,7 +9313,7 @@ else version(Windows)
         SYSTEMTIME st = void;
         GetSystemTime(&st);
         auto converted = SYSTEMTIMEToSysTime(&st, UTC());
-
+        import core.time : abs;
         assert(abs((converted - sysTime)) <= dur!"seconds"(2));
     }
 
@@ -9314,6 +9390,7 @@ else version(Windows)
 
         auto converted = FILETIMEToSysTime(&ft);
 
+        import core.time : abs;
         assert(abs((converted - sysTime)) <= dur!"seconds"(2));
     }
 
@@ -9723,6 +9800,7 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
 
 @system unittest
 {
+    import core.time;
     import std.algorithm.iteration : filter, map;
     import std.algorithm.searching : canFind;
     import std.array : array;
@@ -10275,6 +10353,7 @@ if (isSomeString!S)
     import std.ascii : isDigit;
     import std.conv : to;
     import std.string : representation;
+    import core.time;
 
     if (isoString.empty)
         return Duration.zero;
@@ -10300,6 +10379,7 @@ if (isSomeString!S)
 
 @safe unittest
 {
+    import core.time;
     static void testFSInvalid(string isoString)
     {
         fracSecsFromISOString(isoString);
@@ -10914,6 +10994,7 @@ version(unittest)
 
     void initializeTests() @safe
     {
+        import core.time;
         import std.algorithm.sorting : sort;
         import std.typecons : Rebindable;
         immutable lt = LocalTime().utcToTZ(0);
@@ -10921,11 +11002,13 @@ version(unittest)
 
         version(Posix)
         {
+            import std.datetime.timezone : PosixTimeZone;
             immutable otherTZ = lt < 0 ? PosixTimeZone.getTimeZone("Australia/Sydney")
                                        : PosixTimeZone.getTimeZone("America/Denver");
         }
         else version(Windows)
         {
+            import std.datetime.timezone : WindowsTimeZone;
             immutable otherTZ = lt < 0 ? WindowsTimeZone.getTimeZone("AUS Eastern Standard Time")
                                        : WindowsTimeZone.getTimeZone("Mountain Standard Time");
         }


### PR DESCRIPTION
This has been an iterative process of pushing imports from the top level into the places where imports are being used. That helped not only clarifying dependencies, but also accelerates import time by about 3x. Further improvements are possible.