### PR TITLE
Fix Issue 18096 - Add fold() to std.parallelism

### DIFF
--- a/changelog/std-parallelism-fold.dd
+++ b/changelog/std-parallelism-fold.dd
@@ -1,0 +1,31 @@
+`fold` is added to `std.parallelism.TaskPool`
+
+$(REF fold, std, parallelism, TaskPool) is functionally equivalent to
+$(REF_ALTTEXT `reduce`, reduce, std, parallelism, TaskPool) except the range
+parameter comes first and there is no need to use $(REF_ALTTEXT
+`tuple`,tuple,std,typecons) for multiple seeds.
+
+---
+static int adder(int a, int b)
+{
+    return a + b;
+}
+static int multiplier(int a, int b)
+{
+    return a * b;
+}
+
+// Just the range
+auto x = taskPool.fold!adder([1, 2, 3, 4]);
+assert(x == 10);
+
+// The range and the seeds (0 and 1 below; also note multiple
+// functions in this example)
+auto y = taskPool.fold!(adder, multiplier)([1, 2, 3, 4], 0, 1);
+assert(y[0] == 10);
+assert(y[1] == 24);
+
+// The range, the seed (0), and the work unit size (20)
+auto z = taskPool.fold!adder([1, 2, 3, 4], 0, 20);
+assert(z == 10);
+---

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2747,9 +2747,9 @@ Params:
 See_Also:
     $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
 
-    $(LREF fold) is functionally equivalent to $(LREF _reduce) with the argument order reversed,
-    and without the need to use $(LREF tuple) for multiple seeds. This makes it easier
-    to use in UFCS chains.
+    $(LREF fold) is functionally equivalent to $(LREF _reduce) with the argument
+    order reversed, and without the need to use $(REF_ALTTEXT $(D tuple),tuple,std,typecons)
+    for multiple seeds. This makes it easier to use in UFCS chains.
 
     $(LREF sum) is similar to $(D reduce!((a, b) => a + b)) that offers
     pairwise summing of floating point numbers.
@@ -3206,8 +3206,9 @@ See_Also:
     $(LREF sum) is similar to $(D fold!((a, b) => a + b)) that offers
     precise summing of floating point numbers.
 
-    This is functionally equivalent to $(LREF reduce) with the argument order reversed,
-    and without the need to use $(LREF tuple) for multiple seeds.
+    This is functionally equivalent to $(LREF reduce) with the argument order
+    reversed, and without the need to use $(REF_ALTTEXT $(D tuple),tuple,std,typecons)
+    for multiple seeds.
 +/
 template fold(fun...)
 if (fun.length >= 1)

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2827,7 +2827,6 @@ public:
             apply.
 
             Params:
-
                 args = Just the range to _fold over; or the range and one seed
                        per function; or the range, one seed per function, and
                        the work unit size

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2920,27 +2920,18 @@ public:
     // recursive template instantiation, which is surprisingly not caught.)
     @system unittest
     {
-        static int adder(int a, int b)
-        {
-            return a + b;
-        }
-        static int multiplier(int a, int b)
-        {
-            return a * b;
-        }
-
         // Just the range
-        auto x = taskPool.fold!adder([1, 2, 3, 4]);
+        auto x = taskPool.fold!"a + b"([1, 2, 3, 4]);
         assert(x == 10);
 
         // The range and the seeds (0 and 1 below; also note multiple
         // functions in this example)
-        auto y = taskPool.fold!(adder, multiplier)([1, 2, 3, 4], 0, 1);
+        auto y = taskPool.fold!("a + b", "a * b")([1, 2, 3, 4], 0, 1);
         assert(y[0] == 10);
         assert(y[1] == 24);
 
         // The range, the seed (0), and the work unit size (20)
-        auto z = taskPool.fold!adder([1, 2, 3, 4], 0, 20);
+        auto z = taskPool.fold!"a + b"([1, 2, 3, 4], 0, 20);
         assert(z == 10);
     }
 
@@ -3482,25 +3473,20 @@ public:
     import std.range : iota;
     import std.typecons : tuple;
 
-    static int adder(int a, int b)
-    {
-        return a + b;
-    }
-
     enum N = 100;
     auto r = iota(1, N + 1);
     const expected = r.sum();
 
     // Just the range
-    assert(taskPool.fold!adder(r) == expected);
+    assert(taskPool.fold!"a + b"(r) == expected);
 
     // Range and seeds
-    assert(taskPool.fold!adder(r, 0) == expected);
-    assert(taskPool.fold!(adder, adder)(r, 0, 0) == tuple(expected, expected));
+    assert(taskPool.fold!"a + b"(r, 0) == expected);
+    assert(taskPool.fold!("a + b", "a + b")(r, 0, 0) == tuple(expected, expected));
 
     // Range, seeds, and work unit size
-    assert(taskPool.fold!adder(r, 0, 42) == expected);
-    assert(taskPool.fold!(adder, adder)(r, 0, 0, 42) == tuple(expected, expected));
+    assert(taskPool.fold!"a + b"(r, 0, 42) == expected);
+    assert(taskPool.fold!("a + b", "a + b")(r, 0, 0, 42) == tuple(expected, expected));
 }
 
 /**


### PR DESCRIPTION
Implement TaskPool.fold similar to std.algorithm.fold: Seeds come after the range and need not be a tuple.

Plus a couple of link corrections in std.algorithm documentation.