### PR TITLE
Make std.typecons.Tuple betterC compatible

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -512,7 +512,7 @@ if (distinctFieldNames!(Specs))
     //      :
     // NOTE: field[k] is an expression (which yields a symbol of a
     //       variable) and can't be aliased directly.
-    string injectNamedFields()
+    enum injectNamedFields = ()
     {
         string decl = "";
         static foreach (i, val; fieldSpecs)
@@ -525,7 +525,7 @@ if (distinctFieldNames!(Specs))
             }
         }}
         return decl;
-    }
+    };
 
     // Returns Specs for a subtuple this[from .. to] preserving field
     // names if any.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1498,6 +1498,26 @@ if (distinctFieldNames!(Specs))
     assert(t == AliasSeq!(1, Bad(1), "asdf"));
 }
 
+// Ensure Tuple.toHash works
+@safe unittest
+{
+    Tuple!(int, int) point;
+    assert(point.toHash == typeof(point).init.toHash);
+    assert(tuple(1, 2) != point);
+    assert(tuple(1, 2) == tuple(1, 2));
+    point[0] = 1;
+    assert(tuple(1, 2) != point);
+    point[1] = 2;
+    assert(tuple(1, 2) == point);
+}
+
+@safe @betterC unittest
+{
+    auto t = tuple(1, 2);
+    assert(t == tuple(1, 2));
+    auto t3 = tuple(1, 'd');
+}
+
 /**
     Creates a copy of a $(LREF Tuple) with its fields in _reverse order.
 


### PR DESCRIPTION
I'm not sure how people want to start testing `-betterC` compatibility with Phobos. I assume the best way would be to do extract all unittests marked with `@betterC`?

```d
unittest @betterC
{
....
}
```

For now I went with a more simple and straight-forward way of simply executing all files in `test/betterC`.

~~~However, I still get an error when using the `alias BOMSeq = Tuple!(int, "schema");`  line:~~~

Also I need to define `main` manually as the default main with `void main` returns with `44` :/