### PR TITLE
Fix ddoc in std.json

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1112,7 +1112,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
 
 /**
 Parses a serialized string and returns a tree of JSON values.
-Throws: $(REF JSONException, std,json) if the depth exceeds the max depth.
+Throws: $(LREF JSONException) if the depth exceeds the max depth.
 Params:
     json = json-formatted string to parse
     options = enable decoding string representations of NaN/Inf as float values


### PR DESCRIPTION
Otherwise generated documentation contains hml source pieces like:
"json.html#.JSONException">std.json.JSONException if the depth exceeds the max depth."

see: https://dlang.org/phobos/std_json.html#.parseJSON.2