### PR TITLE
Update CodeCov configuration to be always green/successful

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,6 @@
-# Documentation: https://github.com/codecov/support/wiki/codecov.yml
+# Documentation: https://docs.codecov.io/docs/codecov-yaml
 
 codecov:
-  ci:
-    - "circleci.com"
   notify:
     after_n_builds: 1  # send notifications after the first upload
   bot: dlang-bot
@@ -12,11 +10,18 @@ coverage:
   round: down
   range: "80...100"
 
+  # Learn more at https://docs.codecov.io/docs/commit-status
   status:
-
-    # Learn more at https://codecov.io/docs#yaml_default_commit_status
-    project: true
-    patch: true
-    changes: false
+    project:
+      default:
+        informational: true
+        # Informational doesn't work with project yet
+        threshold: 0.1
+    patch:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true
 
 comment: false


### PR DESCRIPTION
Propagating the config from https://github.com/dlang/dmd/pull/7470.