### PR TITLE
Fixes Issue 18116 - to!wchar([string, dstring]), and to!char([wstring, dstring]) don't compile

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1899,7 +1899,7 @@ if (isSomeChar!T && !is(typeof(parse!T(value))) &&
     is(typeof(parse!dchar(value))))
 {
     import std.utf : encode;
-    
+
     immutable dchar codepoint = parse!dchar(value);
     if (!value.empty)
         throw new ConvException(convFormat("Cannot convert \"%s\" to %s because it " ~


### PR DESCRIPTION
Fix for issue [18116](https://issues.dlang.org/show_bug.cgi?id=18116). Mentioning @schveiguy for review, due to discussion [here](https://github.com/dlang/phobos/pull/5946)