### PR TITLE
std.range.nullSink - allow convenient use of the NullSink

### DIFF
--- a/changelog/std-range-nullsink.dd
+++ b/changelog/std-range-nullsink.dd
@@ -1,0 +1,20 @@
+`nullSink` was added to `std.range`
+
+$(REF nullSink, std, range) is a convenience wrapper for $(REF NullSink, std,range)
+and creates an output range that discards the data it receives. It's the range analog
+of `/dev/null`.
+
+---
+import std.csv : csvNextToken;
+
+string line = "a,b,c";
+
+// ignore the first column
+line.csvNextToken(nullSink, ',', '"');
+line.popFront;
+
+// look at the second column
+Appender!string app;
+line.csvNextToken(app, ',', '"');
+assert(app.data == "b");
+---

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -117,7 +117,7 @@ $(BOOKTABLE ,
         loop. Similar to $(D zip), except that $(D lockstep) is designed
         especially for $(D foreach) loops.
     ))
-    $(TR $(TD $(LREF NullSink))
+    $(TR $(TD $(LREF nullSink))
         $(TD An output _range that discards the data it receives.
     ))
     $(TR $(TD $(LREF only))
@@ -11547,14 +11547,46 @@ struct NullSink
     void put(E)(E){}
 }
 
+/// ditto
+auto ref nullSink()
+{
+    static NullSink sink;
+    return sink;
+}
+
 ///
-@safe unittest
+@safe nothrow unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.mutation : copy;
-    [4, 5, 6].map!(x => x * 2).copy(NullSink()); // data is discarded
+    [4, 5, 6].map!(x => x * 2).copy(nullSink); // data is discarded
 }
 
+///
+@safe unittest
+{
+    import std.csv : csvNextToken;
+
+    string line = "a,b,c";
+
+    // ignore the first column
+    line.csvNextToken(nullSink, ',', '"');
+    line.popFront;
+
+    // look at the second column
+    Appender!string app;
+    line.csvNextToken(app, ',', '"');
+    assert(app.data == "b");
+}
+
+@safe unittest
+{
+    auto r = 10.iota
+                .tee(nullSink)
+                .dropOne;
+
+    assert(r.front == 1);
+}
 
 /++
 


### PR DESCRIPTION
`nullSink` returns the `NullSink` by reference and thus allows using it
directly in code which expects an OutputRange by reference.

The pattern is providing convenience wrappers for struct construction is
very common in Phobos, e.g. `rebindable`, `nullable`, `refCounted`, ...