### PR TITLE
Add possibility to specify custom path to tzdata dir

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -22,6 +22,9 @@
 #
 # make std/somemodule.test => only builds and unittests std.somemodule
 #
+# make TZ_DATABASE_DIR=path to the TZDatabase directory => This is useful to
+# overwrite the hardcoded path to the TZDatabase directory needed
+# for std/datetime/timezone.d
 
 ################################################################################
 # Configurable stuff, usually from the command line
@@ -139,6 +142,11 @@ endif
 ifdef ENABLE_COVERAGE
 DFLAGS  += -cov
 endif
+ifneq (,$(TZ_DATABASE_DIR))
+$(file > /tmp/TZDatabaseDirFile, ${TZ_DATABASE_DIR})
+DFLAGS += -version=TZDatabaseDir -J/tmp/
+endif
+
 UDFLAGS=-unittest -version=StdUnittest
 
 # Set DOTOBJ and DOTEXE

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -1967,7 +1967,16 @@ public:
     }
 
 
-    version(Android)
+    version(TZDatabaseDir)
+    {
+        import std.string : strip;
+        /++
+            The default directory where the TZ Database files are. It's empty
+            for Windows, since Windows doesn't have them.
+          +/
+        enum defaultTZDatabaseDir = strip(import("TZDatabaseDirFile"));
+    }
+    else version(Android)
     {
         // Android concatenates all time zone data into a single file and stores it here.
         enum defaultTZDatabaseDir = "/system/usr/share/zoneinfo/";


### PR DESCRIPTION
As mentioned in https://issues.dlang.org/show_bug.cgi?id=15391#c3 the hardcoded path to the tzdata directory does not work on NixOS.
To fix this I implemented a solution to provide the absolute path to tzdata via an import file. The path to the import file can be specified as parameter to make.