### PR TITLE
Fix issue 18124 -- RegexMatch.front isn't clear as to what it returns

### DIFF
--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -764,7 +764,7 @@ public:
         assert(m.empty);
         ---
     +/
-    @property auto front()
+    @property inout(Captures!R) front() inout
     {
         return _captures;
     }
@@ -799,7 +799,7 @@ public:
     T opCast(T:bool)(){ return !empty; }
 
     /// Same as .front, provided for compatibility with original std.regex.
-    @property auto captures() inout { return _captures; }
+    @property inout(Captures!R) captures() inout { return _captures; }
 }
 
 private @trusted auto matchOnce(RegEx, R)(R input, const RegEx prog)


### PR DESCRIPTION
Easiest thing to do was explicitly type the result. It's probably less effort than documenting what it returns in ddoc, and is clearer to the user.

In all other cases in this file, the auto returns have explicit docs as to the return type. This really was the only anomaly.