### PR TITLE
Bump tools repository

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -133,7 +133,7 @@ publictests()
     if [ ! -d ../tools ] ; then
         clone https://github.com/dlang/tools.git ../tools master
     fi
-    git -C ../tools checkout df3dfa3061d25996ac98158d3bdb3525c8d89445
+    git -C ../tools checkout 6ad91215253b52e6ecfc39fe1854815867c66f23
 
     make -f posix.mak -j$N publictests DUB=$DUB BUILD=$BUILD
 }


### PR DESCRIPTION
A specific version of the tools repo is cloned during the CircleCi build.
I'm not really happy about this procedure because this means that for a bug fix in libdparse,
we need to bump libdparse at tools first and then bump it here again.

See also: https://github.com/dlang/tools/pull/282