### PR TITLE
Use static foreach in Phobos

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4573,14 +4573,14 @@ if (isSomeChar!C)
 {
     import std.algorithm.comparison : equal;
     import std.meta : AliasSeq;
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         import std.conv : to;
         S a = " a     bcd   ef gh ";
         assert(equal(splitter(a), [to!S("a"), to!S("bcd"), to!S("ef"), to!S("gh")]));
         a = "";
         assert(splitter(a).empty);
-    }
+    }}
 
     immutable string s = " a     bcd   ef gh ";
     assert(equal(splitter(s), ["a", "bcd", "ef", "gh"][]));

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -528,14 +528,14 @@ $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 {
     // Issue 13650
     import std.meta : AliasSeq;
-    foreach (Char; AliasSeq!(char, wchar, dchar))
-    {
+    static foreach (Char; AliasSeq!(char, wchar, dchar))
+    {{
         Char[3] a1 = "123";
         Char[6] a2 = "456789";
         assert(copy(a1[], a2[]) is a2[3..$]);
         assert(a1[] == "123");
         assert(a2[] == "123789");
-    }
+    }}
 }
 
 /**
@@ -972,7 +972,7 @@ if (is(Range == char[]) || is(Range == wchar[]))
     assert(!typeid(S3).initializer().ptr);
     assert( typeid(S4).initializer().ptr);
 
-    foreach (S; AliasSeq!(S1, S2, S3, S4))
+    static foreach (S; AliasSeq!(S1, S2, S3, S4))
     {
         //initializeAll
         {
@@ -2154,7 +2154,7 @@ if (isBidirectionalRange!Range
         assert(r.all!(e => all!(o => e < o[0] || e >= o[1])(offsets.only)));
     }
 
-    foreach (offsets; AliasSeq!(soffsets,doffsets,toffsets))
+    static foreach (offsets; AliasSeq!(soffsets,doffsets,toffsets))
     foreach (os; offsets)
     {
         int len = 5*os.length;

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -542,12 +542,12 @@ if (isNarrowString!R1 && isNarrowString!R2)
     assert(commonPrefix(cast(int[]) null, [1, 2, 3]).empty);
     assert(commonPrefix(cast(int[]) null, cast(int[]) null).empty);
 
-    foreach (S; AliasSeq!(char[], const(char)[], string,
+    static foreach (S; AliasSeq!(char[], const(char)[], string,
                           wchar[], const(wchar)[], wstring,
                           dchar[], const(dchar)[], dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {
             assert(commonPrefix(to!S(""), to!T("")).empty);
             assert(commonPrefix(to!S(""), to!T("hello")).empty);
             assert(commonPrefix(to!S("hello"), to!T("")).empty);
@@ -567,7 +567,7 @@ if (isNarrowString!R1 && isNarrowString!R2)
                                 to!T("\U0010FFFF\U0010FFFB\U0010FFFE")) == to!S("\U0010FFFF\U0010FFFB"));
             assert(commonPrefix!"a != b"(to!S("Пиво"), to!T("онво")) == to!S("Пи"));
             assert(commonPrefix!"a != b"(to!S("онво"), to!T("Пиво")) == to!S("он"));
-        }();
+        }
 
         static assert(is(typeof(commonPrefix(to!S("Пиво"), filter!"true"("Пони"))) == S));
         assert(equal(commonPrefix(to!S("Пиво"), filter!"true"("Пони")), to!S("П")));
@@ -1180,7 +1180,7 @@ if (isInputRange!R &&
     import std.conv : to;
     import std.meta : AliasSeq;
 
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(!endsWith(to!S("abc"), 'a'));
         assert(endsWith(to!S("abc"), 'a', 'c') == 2);
@@ -1188,8 +1188,8 @@ if (isInputRange!R &&
         assert(endsWith(to!S("abc"), 'x', 'n', 'c') == 3);
         assert(endsWith(to!S("abc\uFF28"), 'a', '\uFF28', 'c') == 2);
 
-        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+        {
             //Lots of strings
             assert(endsWith(to!S("abc"), to!T("")));
             assert(!endsWith(to!S("abc"), to!T("a")));
@@ -1219,11 +1219,11 @@ if (isInputRange!R &&
             assert(endsWith(to!S("a"), T.init, "") == 1);
             assert(endsWith(to!S("a"), T.init, 'a') == 1);
             assert(endsWith(to!S("a"), 'a', T.init) == 2);
-        }();
+        }
     }
 
-    foreach (T; AliasSeq!(int, short))
-    {
+    static foreach (T; AliasSeq!(int, short))
+    {{
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 
         //RA range
@@ -1254,7 +1254,7 @@ if (isInputRange!R &&
         //Non-default pred
         assert(endsWith!("a%10 == b%10")(arr, [14, 15]));
         assert(!endsWith!("a%10 == b%10")(arr, [15, 14]));
-    }
+    }}
 }
 
 /**
@@ -1700,9 +1700,9 @@ if (isInputRange!InputRange &&
 @safe pure unittest
 {
     import std.meta : AliasSeq;
-    foreach (R; AliasSeq!(string, wstring, dstring))
+    static foreach (R; AliasSeq!(string, wstring, dstring))
     {
-        foreach (E; AliasSeq!(char, wchar, dchar))
+        static foreach (E; AliasSeq!(char, wchar, dchar))
         {
             assert(find              ("hello world", 'w') == "world");
             assert(find!((a,b)=>a == b)("hello world", 'w') == "world");
@@ -1741,9 +1741,9 @@ if (isInputRange!InputRange &&
     {
         byte[]  sarr = [1, 2, 3, 4];
         ubyte[] uarr = [1, 2, 3, 4];
-        foreach (arr; AliasSeq!(sarr, uarr))
+        static foreach (arr; AliasSeq!(sarr, uarr))
         {
-            foreach (T; AliasSeq!(byte, ubyte, int, uint))
+            static foreach (T; AliasSeq!(byte, ubyte, int, uint))
             {
                 assert(find(arr, cast(T) 3) == arr[2 .. $]);
                 assert(find(arr, cast(T) 9) == arr[$ .. $]);
@@ -3374,8 +3374,8 @@ if (isInputRange!Range && !isInfinite!Range &&
     }
     static assert(!isAssignable!S3);
 
-    foreach (Type; AliasSeq!(S1, IS1, S2, IS2, S3))
-    {
+    static foreach (Type; AliasSeq!(S1, IS1, S2, IS2, S3))
+    {{
         static if (is(Type == immutable)) alias V = immutable int;
         else                              alias V = int;
         V one = 1, two = 2;
@@ -3384,7 +3384,7 @@ if (isInputRange!Range && !isInfinite!Range &&
         assert(minCount!"a.i < b.i"(r1) == tuple(Type(one), 2));
         assert(minCount!"a.i < b.i"(r2) == tuple(Type(one), 2));
         assert(one == 1 && two == 2);
-    }
+    }}
 }
 
 /**
@@ -4341,7 +4341,7 @@ if (isInputRange!R &&
     import std.meta : AliasSeq;
     import std.range;
 
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(!startsWith(to!S("abc"), 'c'));
         assert(startsWith(to!S("abc"), 'a', 'c') == 1);
@@ -4349,8 +4349,8 @@ if (isInputRange!R &&
         assert(startsWith(to!S("abc"), 'x', 'n', 'a') == 3);
         assert(startsWith(to!S("\uFF28abc"), 'a', '\uFF28', 'c') == 2);
 
-        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+        {
             //Lots of strings
             assert(startsWith(to!S("abc"), to!T("")));
             assert(startsWith(to!S("ab"), to!T("a")));
@@ -4383,7 +4383,7 @@ if (isInputRange!R &&
             assert(startsWith(to!S("a"), T.init, "") == 1);
             assert(startsWith(to!S("a"), T.init, 'a') == 1);
             assert(startsWith(to!S("a"), 'a', T.init) == 2);
-        }();
+        }
     }
 
     //Length but no RA
@@ -4391,8 +4391,8 @@ if (isInputRange!R &&
     assert(startsWith("abc".takeExactly(3), "abcd".takeExactly(3)));
     assert(startsWith("abc".takeExactly(3), "abcd".takeExactly(1)));
 
-    foreach (T; AliasSeq!(int, short))
-    {
+    static foreach (T; AliasSeq!(int, short))
+    {{
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 
         //RA range
@@ -4423,7 +4423,7 @@ if (isInputRange!R &&
         //Non-default pred
         assert(startsWith!("a%10 == b%10")(arr, [10, 11]));
         assert(!startsWith!("a%10 == b%10")(arr, [10, 12]));
-    }
+    }}
 }
 
 /* (Not yet documented.)

--- a/std/array.d
+++ b/std/array.d
@@ -334,11 +334,11 @@ if (isNarrowString!String)
         int i;
     }
 
-    foreach (T; AliasSeq!(S, const S, immutable S))
-    {
+    static foreach (T; AliasSeq!(S, const S, immutable S))
+    {{
         auto arr = [T(1), T(2), T(3), T(4)];
         assert(array(arr) == arr);
-    }
+    }}
 }
 
 @safe unittest
@@ -1189,10 +1189,10 @@ private template isInputRangeOrConvertible(E)
                 new AssertError("testStr failure 3", file, line));
     }
 
-    foreach (T; AliasSeq!(char, wchar, dchar,
+    static foreach (T; AliasSeq!(char, wchar, dchar,
         immutable(char), immutable(wchar), immutable(dchar)))
     {
-        foreach (U; AliasSeq!(char, wchar, dchar,
+        static foreach (U; AliasSeq!(char, wchar, dchar,
             immutable(char), immutable(wchar), immutable(dchar)))
         {
             testStr!(T[], U[])();
@@ -1336,8 +1336,8 @@ pure nothrow bool sameTail(T)(in T[] lhs, in T[] rhs)
 
 @safe pure nothrow unittest
 {
-    foreach (T; AliasSeq!(int[], const(int)[], immutable(int)[], const int[], immutable int[]))
-    {
+    static foreach (T; AliasSeq!(int[], const(int)[], immutable(int)[], const int[], immutable int[]))
+    {{
         T a = [1, 2, 3, 4, 5];
         T b = a;
         T c = a[1 .. $];
@@ -1359,7 +1359,7 @@ pure nothrow bool sameTail(T)(in T[] lhs, in T[] rhs)
         //verifies R-value compatibilty
         assert(a.sameHead(a[0 .. 0]));
         assert(a.sameTail(a[$ .. $]));
-    }
+    }}
 }
 
 /**
@@ -1430,8 +1430,8 @@ if (isInputRange!S && !isDynamicArray!S)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+    {{
         immutable S t = "abc";
 
         assert(replicate(to!S("1234"), 0) is null);
@@ -1441,7 +1441,7 @@ if (isInputRange!S && !isDynamicArray!S)
         assert(replicate(to!S("1"), 4) == "1111");
         assert(replicate(t, 3) == "abcabcabc");
         assert(replicate(cast(S) null, 4) is null);
-    }
+    }}
 }
 
 /++
@@ -1527,8 +1527,8 @@ if (isSomeString!S)
     static auto makeEntry(S)(string l, string[] r)
     {return tuple(l.to!S(), r.to!(S[])());}
 
-    foreach (S; AliasSeq!(string, wstring, dstring,))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring,))
+    {{
         auto entries =
         [
             makeEntry!S("", []),
@@ -1543,7 +1543,7 @@ if (isSomeString!S)
         ];
         foreach (entry; entries)
             assert(entry[0].split() == entry[1], format("got: %s, expected: %s.", entry[0].split(), entry[1]));
-    }
+    }}
 
     //Just to test that an immutable is split-able
     immutable string s = " \t\npeter paul\tjerry \n";
@@ -1639,12 +1639,12 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
     import std.algorithm.comparison : cmp;
     import std.conv;
 
-    foreach (S; AliasSeq!(string, wstring, dstring,
+    static foreach (S; AliasSeq!(string, wstring, dstring,
                     immutable(string), immutable(wstring), immutable(dstring),
                     char[], wchar[], dchar[],
                     const(char)[], const(wchar)[], const(dchar)[],
                     const(char[]), immutable(char[])))
-    {
+    {{
         S s = to!S(",peter,paul,jerry,");
 
         auto words = split(s, ",");
@@ -1684,7 +1684,7 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
         words = split(s5, ",,");
         assert(words.length == 3);
         assert(cmp(words[0], "peter") == 0);
-    }
+    }}
 }
 
 /++
@@ -1929,36 +1929,36 @@ if (isInputRange!RoR &&
 {
     import std.conv : to;
 
-    foreach (T; AliasSeq!(string,wstring,dstring))
-    {
+    static foreach (T; AliasSeq!(string,wstring,dstring))
+    {{
         auto arr2 = "Здравствуй Мир Unicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
         assert(join(arr) == "ЗдравствуйМирUnicode");
-        foreach (S; AliasSeq!(char,wchar,dchar))
-        {
+        static foreach (S; AliasSeq!(char,wchar,dchar))
+        {{
             auto jarr = arr.join(to!S(' '));
             static assert(is(typeof(jarr) == T));
             assert(jarr == arr2);
-        }
-        foreach (S; AliasSeq!(string,wstring,dstring))
-        {
+        }}
+        static foreach (S; AliasSeq!(string,wstring,dstring))
+        {{
             auto jarr = arr.join(to!S(" "));
             static assert(is(typeof(jarr) == T));
             assert(jarr == arr2);
-        }
-    }
+        }}
+    }}
 
-    foreach (T; AliasSeq!(string,wstring,dstring))
-    {
+    static foreach (T; AliasSeq!(string,wstring,dstring))
+    {{
         auto arr2 = "Здравствуй\u047CМир\u047CUnicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
-        foreach (S; AliasSeq!(wchar,dchar))
-        {
+        static foreach (S; AliasSeq!(wchar,dchar))
+        {{
             auto jarr = arr.join(to!S('\u047C'));
             static assert(is(typeof(jarr) == T));
             assert(jarr == arr2);
-        }
-    }
+        }}
+    }}
 
     const string[] arr = ["apple", "banana"];
     assert(arr.join(',') == "apple,banana");
@@ -1970,8 +1970,8 @@ if (isInputRange!RoR &&
     import std.conv : to;
     import std.range;
 
-    foreach (R; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (R; AliasSeq!(string, wstring, dstring))
+    {{
         R word1 = "日本語";
         R word2 = "paul";
         R word3 = "jerry";
@@ -1987,8 +1987,8 @@ if (isInputRange!RoR &&
         auto filteredLenWordsArr = [filteredLenWord1, filteredLenWord2, filteredLenWord3];
         auto filteredWords    = filter!"true"(filteredWordsArr);
 
-        foreach (S; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (S; AliasSeq!(string, wstring, dstring))
+        {{
             assert(join(filteredWords, to!S(", ")) == "日本語, paul, jerry");
             assert(join(filteredWords, to!(ElementType!S)(',')) == "日本語,paul,jerry");
             assert(join(filteredWordsArr, to!(ElementType!(S))(',')) == "日本語,paul,jerry");
@@ -2022,7 +2022,7 @@ if (isInputRange!RoR &&
             assert(join(filteredLenWordsArr, filterComma) == "日本語, paul, jerry");
             assert(join(filter!"true"(words), filterComma) == "日本語, paul, jerry");
             assert(join(words, filterComma) == "日本語, paul, jerry");
-        }();
+        }}
 
         assert(join(filteredWords) == "日本語pauljerry");
         assert(join(filteredWordsArr) == "日本語pauljerry");
@@ -2048,7 +2048,7 @@ if (isInputRange!RoR &&
 
         assert(join(filter!"true"(cast(R[])[])).empty);
         assert(join(cast(R[])[]).empty);
-    }
+    }}
 
     assert(join([[1, 2], [41, 42]], [5, 6]) == [1, 2, 5, 6, 41, 42]);
     assert(join([[1, 2], [41, 42]], cast(int[])[]) == [1, 2, 41, 42]);
@@ -2191,10 +2191,10 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
     import std.algorithm.comparison : cmp;
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+        {{
             auto s = to!S("This is a foo foo list");
             auto from = to!T("foo");
             auto into = to!S("silly");
@@ -2210,7 +2210,7 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
             assert(i == 0);
 
             assert(replace(r, to!S("won't find this"), to!S("whatever")) is r);
-        }();
+        }}
     }
 
     immutable s = "This is a foo foo list";
@@ -2228,15 +2228,15 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
         this(C[] arr){ desired = arr; }
         void put(C[] part){ assert(skipOver(desired, part)); }
     }
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+    {{
         alias Char = ElementEncodingType!S;
         S s = to!S("yet another dummy text, yet another ...");
         S from = to!S("yet another");
         S into = to!S("some");
         replaceInto(CheckOutput!(Char)(to!S("some dummy text, some ..."))
                     , s, from, into);
-    }
+    }}
 }
 
 /++
@@ -2632,12 +2632,12 @@ if (isDynamicArray!(E[]) &&
     import std.algorithm.comparison : cmp;
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                           const(char[]), immutable(char[])))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
+        static foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {{
             auto s = to!S("This is a foo foo list");
             auto s2 = to!S("Thüs is a ßöö foo list");
             auto from = to!T("foo");
@@ -2659,7 +2659,7 @@ if (isDynamicArray!(E[]) &&
             assert(cmp(r3, "This is a foo foo list") == 0);
 
             assert(replaceFirst(r3, to!T("won't find"), to!T("whatever")) is r3);
-        }();
+        }}
     }
 }
 
@@ -2745,12 +2745,12 @@ if (isDynamicArray!(E[]) &&
     import std.algorithm.comparison : cmp;
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                           const(char[]), immutable(char[])))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
+        static foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {{
             auto s = to!S("This is a foo foo list");
             auto s2 = to!S("Thüs is a ßöö ßöö list");
             auto from = to!T("foo");
@@ -2772,7 +2772,7 @@ if (isDynamicArray!(E[]) &&
             assert(cmp(r3, "This is a foo foo list") == 0);
 
             assert(replaceLast(r3, to!T("won't find"), to!T("whatever")) is r3);
-        }();
+        }}
     }
 }
 
@@ -3394,7 +3394,7 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     catch (Exception) assert(0);
 
     // Issue 5663 & 9725 tests
-    foreach (S; AliasSeq!(char[], const(char)[], string))
+    static foreach (S; AliasSeq!(char[], const(char)[], string))
     {
         {
             Appender!S app5663i;

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -589,7 +589,7 @@ if (is(C : dchar))
 @safe pure nothrow unittest
 {
 
-    foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
+    static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; uppercase)
             assert(toLower(cast(C) c) == lowercase[i]);
@@ -650,7 +650,7 @@ if (is(C : dchar))
 
 @safe pure nothrow unittest
 {
-    foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
+    static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; lowercase)
             assert(toUpper(cast(C) c) == uppercase[i]);
@@ -689,7 +689,7 @@ if (is(C : dchar))
     enum UDDE : UDD {a = UDD('a'), A = UDD('A')}
 
     //User defined types with implicit cast to dchar test.
-    foreach (Char; AliasSeq!(UDC, UDW, UDD))
+    static foreach (Char; AliasSeq!(UDC, UDW, UDD))
     {
         assert(toLower(Char('a')) == 'a');
         assert(toLower(Char('A')) == 'a');
@@ -700,7 +700,7 @@ if (is(C : dchar))
     }
 
     //Various enum tests.
-    foreach (Enum; AliasSeq!(CE, WE, DE, UDCE, UDWE, UDDE))
+    static foreach (Enum; AliasSeq!(CE, WE, DE, UDCE, UDWE, UDDE))
     {
         assert(toLower(Enum.a) == 'a');
         assert(toLower(Enum.A) == 'a');
@@ -713,15 +713,15 @@ if (is(C : dchar))
     }
 
     //Return value type tests for enum of non-UDT. These should be the original type.
-    foreach (T; AliasSeq!(CE, WE, DE))
-    {
+    static foreach (T; AliasSeq!(CE, WE, DE))
+    {{
         alias C = OriginalType!T;
         static assert(is(typeof(toLower(T.init)) == C));
         static assert(is(typeof(toUpper(T.init)) == C));
-    }
+    }}
 
     //Return value tests for UDT and enum of UDT. These should be dchar
-    foreach (T; AliasSeq!(UDC, UDW, UDD, UDCE, UDWE, UDDE))
+    static foreach (T; AliasSeq!(UDC, UDW, UDD, UDCE, UDWE, UDDE))
     {
         static assert(is(typeof(toLower(T.init)) == dchar));
         static assert(is(typeof(toUpper(T.init)) == dchar));

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1560,10 +1560,10 @@ unittest
     import std.conv : to;
     import std.meta : AliasSeq;
 
-    foreach (T1; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
+    static foreach (T1; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
     {
-        foreach (T2; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
-        {
+        static foreach (T2; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
+        {{
             T1 t1 = 2;
             T2 t2 = t1;
 
@@ -1578,7 +1578,7 @@ unittest
 
             assert(t2_2 == t1);
             assert(t2_2 == 2);
-        }
+        }}
     }
 
     BigInt n = 2;
@@ -1640,7 +1640,7 @@ unittest
     BigInt x3 = "123456789123456789123456789";
 
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert((x1 * T.max) / T.max == x1);
         assert((x2 * T.max) / T.max == x2);
@@ -1668,7 +1668,7 @@ unittest
 {
     BigInt x = 1;
     import std.meta : AliasSeq;
-    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
+    static foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
     {
         assert(is(typeof(x % Int(1)) == int));
     }

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2428,8 +2428,8 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
-    {
+    static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
+    {{
         scope(failure) writefln("Failed type: %s", T.stringof);
         T val;
         const T cval;
@@ -2470,7 +2470,7 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
                 right <<= 8;
             }
         }
-    }
+    }}
 }
 
 
@@ -2544,7 +2544,7 @@ if (isFloatOrDouble!T)
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+    static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
                          char, wchar, dchar
         /* The trouble here is with floats and doubles being compared against nan
          * using a bit compare. There are two kinds of nans, quiet and signaling.
@@ -2556,7 +2556,7 @@ if (isFloatOrDouble!T)
          * I cannot think of a fix for this that makes consistent sense.
          */
                           /*,float, double*/))
-    {
+    {{
         scope(failure) writefln("Failed type: %s", T.stringof);
         T val;
         const T cval;
@@ -2607,7 +2607,7 @@ if (isFloatOrDouble!T)
             assert(nativeToBigEndian(T.min) == nativeToLittleEndian(T.min));
         else
             assert(nativeToBigEndian(T.min) != nativeToLittleEndian(T.min));
-    }
+    }}
 }
 
 
@@ -2718,10 +2718,10 @@ if (isFloatOrDouble!T)
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+    static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
                          char, wchar, dchar/*,
                          float, double*/))
-    {
+    {{
         scope(failure) writefln("Failed type: %s", T.stringof);
         T val;
         const T cval;
@@ -2750,7 +2750,7 @@ if (isFloatOrDouble!T)
                     assert(littleEndianToNative!T(nativeToLittleEndian(minI)) == minI);
             }
         }
-    }
+    }}
 }
 
 
@@ -2848,7 +2848,7 @@ private template isFloatOrDouble(T)
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(float, double))
+    static foreach (T; AliasSeq!(float, double))
     {
         static assert(isFloatOrDouble!(T));
         static assert(isFloatOrDouble!(const T));
@@ -2877,7 +2877,7 @@ private template canSwapEndianness(T)
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(bool, ubyte, byte, ushort, short, uint, int, ulong,
+    static foreach (T; AliasSeq!(bool, ubyte, byte, ushort, short, uint, int, ulong,
                          long, char, wchar, dchar, float, double))
     {
         static assert(canSwapEndianness!(T));
@@ -2889,7 +2889,7 @@ private template canSwapEndianness(T)
     }
 
     //!
-    foreach (T; AliasSeq!(real, string, wstring, dstring))
+    static foreach (T; AliasSeq!(real, string, wstring, dstring))
     {
         static assert(!canSwapEndianness!(T));
         static assert(!canSwapEndianness!(const T));
@@ -3994,9 +3994,9 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
 {
     import std.array;
     import std.format : format;
-    import std.meta;
-    foreach (endianness; AliasSeq!(Endian.bigEndian, Endian.littleEndian))
-    {
+    import std.meta : AliasSeq;
+    static foreach (endianness; [Endian.bigEndian, Endian.littleEndian])
+    {{
         auto toWrite = appender!(ubyte[])();
         alias Types = AliasSeq!(uint, int, long, ulong, short, ubyte, ushort, byte, uint);
         ulong[] values = [42, -11, long.max, 1098911981329L, 16, 255, 19012, 2, 17];
@@ -4004,7 +4004,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
 
         size_t index = 0;
         size_t length = 0;
-        foreach (T; Types)
+        static foreach (T; Types)
         {
             toWrite.append!(T, endianness)(cast(T) values[index++]);
             length += T.sizeof;
@@ -4014,7 +4014,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
         assert(toRead.length == length);
 
         index = 0;
-        foreach (T; Types)
+        static foreach (T; Types)
         {
             assert(toRead.peek!(T, endianness)() == values[index], format("Failed Index: %s", index));
             assert(toRead.peek!(T, endianness)(0) == values[index], format("Failed Index: %s", index));
@@ -4027,7 +4027,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
             ++index;
         }
         assert(toRead.empty);
-    }
+    }}
 }
 
 /**
@@ -4086,7 +4086,7 @@ if (isIntegral!T)
 @safe unittest
 {
     import std.meta;
-    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert(countBitsSet(cast(T) 0) == 0);
         assert(countBitsSet(cast(T) 1) == 1);
@@ -4197,7 +4197,7 @@ if (isIntegral!T)
     import std.range : iota;
 
     import std.meta;
-    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert(bitsSet(cast(T) 0).empty);
         assert(bitsSet(cast(T) 1).equal([0]));

--- a/std/conv.d
+++ b/std/conv.d
@@ -427,12 +427,12 @@ template to(T)
 @safe pure unittest
 {
     import std.exception;
-    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assertThrown!ConvException(to!T(" 0"));
         assertThrown!ConvException(to!T(" 0", 8));
     }
-    foreach (T; AliasSeq!(float, double, real))
+    static foreach (T; AliasSeq!(float, double, real))
     {
         assertThrown!ConvException(to!T(" 0"));
     }
@@ -499,13 +499,13 @@ if (isImplicitlyConvertible!(S, T) &&
 {
     import std.exception;
     // Conversion between same size
-    foreach (S; AliasSeq!(byte, short, int, long))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    static foreach (S; AliasSeq!(byte, short, int, long))
+    {{
         alias U = Unsigned!S;
 
-        foreach (Sint; AliasSeq!(S, const S, immutable S))
-        foreach (Uint; AliasSeq!(U, const U, immutable U))
-        {
+        static foreach (Sint; AliasSeq!(S, const S, immutable S))
+        static foreach (Uint; AliasSeq!(U, const U, immutable U))
+        {{
             // positive overflow
             Uint un = Uint.max;
             assertThrown!ConvOverflowException(to!Sint(un),
@@ -515,53 +515,53 @@ if (isImplicitlyConvertible!(S, T) &&
             Sint sn = -1;
             assertThrown!ConvOverflowException(to!Uint(sn),
                 text(Sint.stringof, ' ', Uint.stringof, ' ', un));
-        }
-    }();
+        }}
+    }}
 
     // Conversion between different size
-    foreach (i, S1; AliasSeq!(byte, short, int, long))
-    foreach (   S2; AliasSeq!(byte, short, int, long)[i+1..$])
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    static foreach (i, S1; AliasSeq!(byte, short, int, long))
+    static foreach (   S2; AliasSeq!(byte, short, int, long)[i+1..$])
+    {{
         alias U1 = Unsigned!S1;
         alias U2 = Unsigned!S2;
 
         static assert(U1.sizeof < S2.sizeof);
 
         // small unsigned to big signed
-        foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
-        foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
-        {
+        static foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
+        static foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
+        {{
             Uint un = Uint.max;
             assertNotThrown(to!Sint(un));
             assert(to!Sint(un) == un);
-        }
+        }}
 
         // big unsigned to small signed
-        foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
-        foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
-        {
+        static foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
+        static foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
+        {{
             Uint un = Uint.max;
             assertThrown(to!Sint(un));
-        }
+        }}
 
         static assert(S1.sizeof < U2.sizeof);
 
         // small signed to big unsigned
-        foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
-        foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
-        {
+        static foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
+        static foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
+        {{
             Sint sn = -1;
             assertThrown!ConvOverflowException(to!Uint(sn));
-        }
+        }}
 
         // big signed to small unsigned
-        foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
-        foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
-        {
+        static foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
+        static foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
+        {{
             Sint sn = -1;
             assertThrown!ConvOverflowException(to!Uint(sn));
-        }
-    }();
+        }}
+    }}
 }
 
 /*
@@ -837,7 +837,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 
     static foreach (m1; 0 .. 5) // enumerate modifiers
     static foreach (m2; 0 .. 5) // ditto
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {{
         alias srcmod = AddModifier!m1;
         alias tgtmod = AddModifier!m2;
 
@@ -871,7 +871,7 @@ if (!isImplicitlyConvertible!(S, T) &&
             static assert(!is(typeof(to!(tgtmod!C)(srcmod!I.init))));   // I to C
             static assert(!is(typeof(to!(tgtmod!J)(srcmod!I.init))));   // I to J
         }
-    }();
+    }}
 }
 
 /**
@@ -993,7 +993,7 @@ if (!(isImplicitlyConvertible!(S, T) &&
 {
     void test1(T)(T lp, string cmp)
     {
-        foreach (e; AliasSeq!(char, wchar, dchar))
+        static foreach (e; AliasSeq!(char, wchar, dchar))
         {
             test2!(e[])(lp, cmp);
             test2!(const(e)[])(lp, cmp);
@@ -1006,12 +1006,12 @@ if (!(isImplicitlyConvertible!(S, T) &&
         assert(to!string(to!D(lp)) == cmp);
     }
 
-    foreach (e; AliasSeq!("Hello, world!", "Hello, world!"w, "Hello, world!"d))
+    static foreach (e; AliasSeq!("Hello, world!", "Hello, world!"w, "Hello, world!"d))
     {
         test1(e, "Hello, world!");
         test1(e.ptr, "Hello, world!");
     }
-    foreach (e; AliasSeq!("", ""w, ""d))
+    static foreach (e; AliasSeq!("", ""w, ""d))
     {
         test1(e, "");
         test1(e.ptr, "");
@@ -1176,14 +1176,14 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     import std.exception;
     // Conversion representing integer values with string
 
-    foreach (Int; AliasSeq!(ubyte, ushort, uint, ulong))
+    static foreach (Int; AliasSeq!(ubyte, ushort, uint, ulong))
     {
         assert(to!string(Int(0)) == "0");
         assert(to!string(Int(9)) == "9");
         assert(to!string(Int(123)) == "123");
     }
 
-    foreach (Int; AliasSeq!(byte, short, int, long))
+    static foreach (Int; AliasSeq!(byte, short, int, long))
     {
         assert(to!string(Int(0)) == "0");
         assert(to!string(Int(9)) == "9");
@@ -1269,7 +1269,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     enum EC : char { a = 'x', b = 'y' }
     enum ES : string { a = "aaa", b = "bbb" }
 
-    foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
+    static foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
     {
         assert(to! string(E.a) == "a"c);
         assert(to!wstring(E.a) == "a"w);
@@ -1297,23 +1297,23 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(to!string(E.doo) == "foo");
     assert(to!string(E.bar) == "bar");
 
-    foreach (S; AliasSeq!(string, wstring, dstring, const(char[]), const(wchar[]), const(dchar[])))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring, const(char[]), const(wchar[]), const(dchar[])))
+    {{
         auto s1 = to!S(E.foo);
         auto s2 = to!S(E.foo);
         assert(s1 == s2);
         // ensure we don't allocate when it's unnecessary
         assert(s1 is s2);
-    }
+    }}
 
-    foreach (S; AliasSeq!(char[], wchar[], dchar[]))
-    {
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[]))
+    {{
         auto s1 = to!S(E.foo);
         auto s2 = to!S(E.foo);
         assert(s1 == s2);
         // ensure each mutable array is unique
         assert(s1 !is s2);
-    }
+    }}
 }
 
 // ditto
@@ -1373,7 +1373,7 @@ do
 
 @safe pure nothrow unittest
 {
-    foreach (Int; AliasSeq!(uint, ulong))
+    static foreach (Int; AliasSeq!(uint, ulong))
     {
         assert(to!string(Int(16), 16) == "10");
         assert(to!string(Int(15), 2u) == "1111");
@@ -1383,7 +1383,7 @@ do
         assert(to!string(Int(0x1234AF), 16u, LetterCase.lower) == "1234af");
     }
 
-    foreach (Int; AliasSeq!(int, long))
+    static foreach (Int; AliasSeq!(int, long))
     {
         assert(to!string(Int(-10), 10u) == "-10");
     }
@@ -1853,12 +1853,12 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S) &&
 
 @safe pure unittest
 {
-    foreach (Str; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (Str; AliasSeq!(string, wstring, dstring))
+    {{
         Str a = "123";
         assert(to!int(a) == 123);
         assert(to!double(a) == 123);
-    }
+    }}
 
     // 6255
     auto n = to!int("FF", 16);
@@ -1995,7 +1995,7 @@ template roundTo(Target)
 {
     import std.exception;
     // boundary values
-    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
+    static foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
     {
         assert(roundTo!Int(Int.min - 0.4L) == Int.min);
         assert(roundTo!Int(Int.max + 0.4L) == Int.max);
@@ -2259,7 +2259,7 @@ Lerr:
 
 @safe pure unittest
 {
-    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         {
             assert(to!Int("0") == 0);
@@ -2354,74 +2354,75 @@ Lerr:
 @safe pure unittest
 {
     import std.exception;
+
+    immutable string[] errors =
+    [
+        "",
+        "-",
+        "+",
+        "-+",
+        " ",
+        " 0",
+        "0 ",
+        "- 0",
+        "1-",
+        "xx",
+        "123h",
+        "-+1",
+        "--1",
+        "+-1",
+        "++1",
+    ];
+
+    immutable string[] unsignedErrors =
+    [
+        "+5",
+        "-78",
+    ];
+
     // parsing error check
-    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
-        {
-            immutable string[] errors1 =
-            [
-                "",
-                "-",
-                "+",
-                "-+",
-                " ",
-                " 0",
-                "0 ",
-                "- 0",
-                "1-",
-                "xx",
-                "123h",
-                "-+1",
-                "--1",
-                "+-1",
-                "++1",
-            ];
-            foreach (j, s; errors1)
-                assertThrown!ConvException(to!Int(s));
-        }
+        foreach (j, s; errors)
+            assertThrown!ConvException(to!Int(s));
 
         // parse!SomeUnsigned cannot parse head sign.
         static if (isUnsigned!Int)
         {
-            immutable string[] errors2 =
-            [
-                "+5",
-                "-78",
-            ];
-            foreach (j, s; errors2)
+            foreach (j, s; unsignedErrors)
                 assertThrown!ConvException(to!Int(s));
         }
     }
 
+    immutable string[] positiveOverflowErrors =
+    [
+        "128",                  // > byte.max
+        "256",                  // > ubyte.max
+        "32768",                // > short.max
+        "65536",                // > ushort.max
+        "2147483648",           // > int.max
+        "4294967296",           // > uint.max
+        "9223372036854775808",  // > long.max
+        "18446744073709551616", // > ulong.max
+    ];
     // positive overflow check
-    foreach (i, Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    static foreach (i, Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
-        immutable string[] errors =
-        [
-            "128",                  // > byte.max
-            "256",                  // > ubyte.max
-            "32768",                // > short.max
-            "65536",                // > ushort.max
-            "2147483648",           // > int.max
-            "4294967296",           // > uint.max
-            "9223372036854775808",  // > long.max
-            "18446744073709551616", // > ulong.max
-        ];
-        foreach (j, s; errors[i..$])
+        foreach (j, s; positiveOverflowErrors[i..$])
             assertThrown!ConvOverflowException(to!Int(s));
     }
 
+    immutable string[] negativeOverflowErrors =
+    [
+        "-129",                 // < byte.min
+        "-32769",               // < short.min
+        "-2147483649",          // < int.min
+        "-9223372036854775809", // < long.min
+    ];
     // negative overflow check
-    foreach (i, Int; AliasSeq!(byte, short, int, long))
+    static foreach (i, Int; AliasSeq!(byte, short, int, long))
     {
-        immutable string[] errors =
-        [
-            "-129",                 // < byte.min
-            "-32769",               // < short.min
-            "-2147483649",          // < int.min
-            "-9223372036854775809", // < long.min
-        ];
-        foreach (j, s; errors[i..$])
+        foreach (j, s; negativeOverflowErrors[i..$])
             assertThrown!ConvOverflowException(to!Int(s));
     }
 }
@@ -2659,7 +2660,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     enum EC : char { a = 'a', b = 'b', c = 'c' }
     enum ES : string { a = "aaa", b = "bbb", c = "ccc" }
 
-    foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
+    static foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
     {
         assert(to!E("a"c) == E.a);
         assert(to!E("b"w) == E.b);
@@ -3148,7 +3149,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         return f;
     }
 
-    foreach (Float; AliasSeq!(float, double, real))
+    static foreach (Float; AliasSeq!(float, double, real))
     {
         assert(to!Float("123") == Literal!Float(123));
         assert(to!Float("+123") == Literal!Float(+123));
@@ -3417,10 +3418,10 @@ if (isSomeString!Source && !is(Source == enum) &&
 
 @safe pure unittest
 {
-    foreach (Str; AliasSeq!(string, wstring, dstring))
+    static foreach (Str; AliasSeq!(string, wstring, dstring))
     {
-        foreach (Char; AliasSeq!(char, wchar, dchar))
-        {
+        static foreach (Char; AliasSeq!(char, wchar, dchar))
+        {{
             static if (is(Unqual!Char == dchar) ||
                        Char.sizeof == ElementEncodingType!Str.sizeof)
             {
@@ -3428,7 +3429,7 @@ if (isSomeString!Source && !is(Source == enum) &&
                 assert(parse!Char(s) == 'a');
                 assert(s == "aa");
             }
-        }
+        }}
     }
 }
 
@@ -5713,28 +5714,28 @@ if (isIntegral!T)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(byte, ubyte))
+    static foreach (T; AliasSeq!(byte, ubyte))
     {
         static assert(is(typeof(unsigned(cast(T) 1)) == ubyte));
         static assert(is(typeof(unsigned(cast(const T) 1)) == ubyte));
         static assert(is(typeof(unsigned(cast(immutable T) 1)) == ubyte));
     }
 
-    foreach (T; AliasSeq!(short, ushort))
+    static foreach (T; AliasSeq!(short, ushort))
     {
         static assert(is(typeof(unsigned(cast(T) 1)) == ushort));
         static assert(is(typeof(unsigned(cast(const T) 1)) == ushort));
         static assert(is(typeof(unsigned(cast(immutable T) 1)) == ushort));
     }
 
-    foreach (T; AliasSeq!(int, uint))
+    static foreach (T; AliasSeq!(int, uint))
     {
         static assert(is(typeof(unsigned(cast(T) 1)) == uint));
         static assert(is(typeof(unsigned(cast(const T) 1)) == uint));
         static assert(is(typeof(unsigned(cast(immutable T) 1)) == uint));
     }
 
-    foreach (T; AliasSeq!(long, ulong))
+    static foreach (T; AliasSeq!(long, ulong))
     {
         static assert(is(typeof(unsigned(cast(T) 1)) == ulong));
         static assert(is(typeof(unsigned(cast(const T) 1)) == ulong));
@@ -5752,7 +5753,7 @@ if (isSomeChar!T)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(char, wchar, dchar))
+    static foreach (T; AliasSeq!(char, wchar, dchar))
     {
         static assert(is(typeof(unsigned(cast(T)'A')) == T));
         static assert(is(typeof(unsigned(cast(const T)'A')) == T));
@@ -5791,28 +5792,28 @@ if (isIntegral!T)
 
 @system unittest
 {
-    foreach (T; AliasSeq!(byte, ubyte))
+    static foreach (T; AliasSeq!(byte, ubyte))
     {
         static assert(is(typeof(signed(cast(T) 1)) == byte));
         static assert(is(typeof(signed(cast(const T) 1)) == byte));
         static assert(is(typeof(signed(cast(immutable T) 1)) == byte));
     }
 
-    foreach (T; AliasSeq!(short, ushort))
+    static foreach (T; AliasSeq!(short, ushort))
     {
         static assert(is(typeof(signed(cast(T) 1)) == short));
         static assert(is(typeof(signed(cast(const T) 1)) == short));
         static assert(is(typeof(signed(cast(immutable T) 1)) == short));
     }
 
-    foreach (T; AliasSeq!(int, uint))
+    static foreach (T; AliasSeq!(int, uint))
     {
         static assert(is(typeof(signed(cast(T) 1)) == int));
         static assert(is(typeof(signed(cast(const T) 1)) == int));
         static assert(is(typeof(signed(cast(immutable T) 1)) == int));
     }
 
-    foreach (T; AliasSeq!(long, ulong))
+    static foreach (T; AliasSeq!(long, ulong))
     {
         static assert(is(typeof(signed(cast(T) 1)) == long));
         static assert(is(typeof(signed(cast(const T) 1)) == long));

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -3187,9 +3187,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(DateTime.fromISOString(to!S("20121221T141516")) == DateTime(2012, 12, 21, 14, 15, 16));
         }
     }
@@ -3286,9 +3286,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(DateTime.fromISOExtString(to!S("2012-12-21T14:15:16")) == DateTime(2012, 12, 21, 14, 15, 16));
         }
     }
@@ -3389,9 +3389,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(DateTime.fromSimpleString(to!S("2012-Dec-21 14:15:16")) == DateTime(2012, 12, 21, 14, 15, 16));
         }
     }
@@ -7525,9 +7525,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(Date.fromISOString(to!S("20121221")) == Date(2012, 12, 21));
         }
     }
@@ -7666,9 +7666,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(Date.fromISOExtString(to!S("2012-12-21")) == Date(2012, 12, 21));
         }
     }
@@ -7804,9 +7804,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(Date.fromSimpleString(to!S("2012-Dec-21")) == Date(2012, 12, 21));
         }
     }
@@ -9087,9 +9087,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(TimeOfDay.fromISOString(to!S("141516")) == TimeOfDay(14, 15, 16));
         }
     }
@@ -9214,9 +9214,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
                 assert(TimeOfDay.fromISOExtString(to!S("14:15:16")) == TimeOfDay(14, 15, 16));
         }
     }
@@ -9834,13 +9834,13 @@ private:
     import std.datetime.systime;
     import std.meta : AliasSeq;
 
-    foreach (TP; AliasSeq!(Date, DateTime, SysTime, TimeOfDay))
+    static foreach (TP; AliasSeq!(Date, DateTime, SysTime, TimeOfDay))
     {
         static assert(isTimePoint!(const TP), TP.stringof);
         static assert(isTimePoint!(immutable TP), TP.stringof);
     }
 
-    foreach (T; AliasSeq!(float, string, Duration, Interval!Date, PosInfInterval!Date, NegInfInterval!Date))
+    static foreach (T; AliasSeq!(float, string, Duration, Interval!Date, PosInfInterval!Date, NegInfInterval!Date))
         static assert(!isTimePoint!T, T.stringof);
 }
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -97,14 +97,14 @@ public:
         assert(abs(norm1 - norm2) <= seconds(2));
 
         import std.meta : AliasSeq;
-        foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
-        {
+        static foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
+        {{
             scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currTime!ct;
             auto value2 = Clock.currTime!ct(UTC());
             assert(value1 <= value2, format("%s %s", value1, value2));
             assert(abs(value1 - value2) <= seconds(2));
-        }
+        }}
     }
 
 
@@ -272,14 +272,14 @@ public:
         assert(norm1 <= norm2, format("%s %s", norm1, norm2));
         assert(abs(norm1 - norm2) <= limit);
 
-        foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
-        {
+        static foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
+        {{
             scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currStdTime!ct;
             auto value2 = Clock.currStdTime!ct;
             assert(value1 <= value2, format("%s %s", value1, value2));
             assert(abs(value1 - value2) <= limit);
-        }
+        }}
     }
 
 
@@ -2120,7 +2120,7 @@ public:
         import std.meta : AliasSeq;
         import core.time;
         assert(SysTime(DateTime(1970, 1, 1), UTC()).toUnixTime() == 0);
-        foreach (units; AliasSeq!("hnsecs", "usecs", "msecs"))
+        static foreach (units; ["hnsecs", "usecs", "msecs"])
             assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), dur!units(1), UTC()).toUnixTime() == 0);
         assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), UTC()).toUnixTime() == 1);
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), hnsecs(9_999_999), UTC()).toUnixTime() == 0);
@@ -8408,9 +8408,9 @@ public:
     {
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
             {
                 assert(SysTime.fromISOString(to!S("20121221T141516Z")) ==
                        SysTime(DateTime(2012, 12, 21, 14, 15, 16), UTC()));
@@ -8651,9 +8651,9 @@ public:
         import core.time;
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
             {
                 assert(SysTime.fromISOExtString(to!S("2012-12-21T14:15:16Z")) ==
                        SysTime(DateTime(2012, 12, 21, 14, 15, 16), UTC()));
@@ -8897,9 +8897,9 @@ public:
         import core.time;
         import std.conv : to;
         import std.meta : AliasSeq;
-        foreach (C; AliasSeq!(char, wchar, dchar))
+        static foreach (C; AliasSeq!(char, wchar, dchar))
         {
-            foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
+            static foreach (S; AliasSeq!(C[], const(C)[], immutable(C)[]))
             {
                 assert(SysTime.fromSimpleString(to!S("2012-Dec-21 14:15:16Z")) ==
                        SysTime(DateTime(2012, 12, 21, 14, 15, 16), UTC()));
@@ -9841,11 +9841,11 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
         static auto start() { Rand3Letters retval; retval.popFront(); return retval; }
     }
 
-    foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
+    static foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {{
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         alias testBad = testBadParse822!cr;
@@ -10083,7 +10083,7 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
             testBad(cast(string) currStr);
             testBad((cast(string) currStr) ~ "                                    ");
         }
-    }();
+    }}
 }
 
 // Obsolete Format per section 4.3 of RFC 5322.
@@ -10107,11 +10107,11 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
     auto tooLate1 = SysTime(Date(10_000, 1, 1), UTC());
     auto tooLate2 = SysTime(DateTime(12_007, 12, 31, 12, 22, 19), UTC());
 
-    foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
+    static foreach (cr; AliasSeq!(function(string a){return cast(char[]) a;},
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {{
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         {
@@ -10301,7 +10301,7 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
                 assert(collectExceptionMsg!DateTimeException(parseRFC822DateTime(value)) == tooShortMsg);
             }
         }
-    }();
+    }}
 }
 
 
@@ -10601,9 +10601,9 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
     import std.stdio : writeln;
     import std.string : representation;
 
-    foreach (cr; AliasSeq!(function(string a){return cast(ubyte[]) a;},
+    static foreach (cr; AliasSeq!(function(string a){return cast(ubyte[]) a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    {
         scope(failure) writeln(typeof(cr).stringof);
 
         assert(_stripCFWS(cr("")).empty);
@@ -10691,7 +10691,7 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
         assert(equal(_stripCFWS(cr(" \n (hello) \n (hello) \n \n hello")), cr("hello")));
         assert(equal(_stripCFWS(cr(" \n \n (hello)\t\n (hello) \n hello")), cr("hello")));
         assert(equal(_stripCFWS(cr(" \n\t\n\t(hello)\t\n (hello) \n hello")), cr("hello")));
-    }();
+    }
 }
 
 // This is so that we don't have to worry about std.conv.to throwing. It also

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2465,8 +2465,8 @@ do
 {
     import std.meta : AliasSeq;
 
-    foreach (O; AliasSeq!(Latin1Char, const Latin1Char, immutable Latin1Char))
-    {
+    static foreach (O; AliasSeq!(Latin1Char, const Latin1Char, immutable Latin1Char))
+    {{
         O[] output;
 
         char[] mutableInput = "äbc".dup;
@@ -2480,17 +2480,17 @@ do
         immutable char[] immutInput = "übc";
         transcode(immutInput, output);
         assert(output == [0xFC, 'b', 'c']);
-    }
+    }}
 
     // Make sure that const/mutable input is copied.
-    foreach (C; AliasSeq!(char, const char))
-    {
+    static foreach (C; AliasSeq!(char, const char))
+    {{
         C[] input = "foo".dup;
         C[] output;
         transcode(input, output);
         assert(input == output);
         assert(input !is output);
-    }
+    }}
 
     // But immutable input should not be copied.
     string input = "foo";

--- a/std/exception.d
+++ b/std/exception.d
@@ -457,14 +457,12 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
 // purity and safety inference test
 @system unittest
 {
-    import std.meta : AliasSeq;
-
-    foreach (EncloseSafe; AliasSeq!(false, true))
-    foreach (EnclosePure; AliasSeq!(false, true))
+    static foreach (EncloseSafe; [false, true])
+    static foreach (EnclosePure; [false, true])
     {
-        foreach (BodySafe; AliasSeq!(false, true))
-        foreach (BodyPure; AliasSeq!(false, true))
-        {
+        static foreach (BodySafe; [false, true])
+        static foreach (BodyPure; [false, true])
+        {{
             enum code =
                 "delegate void() " ~
                 (EncloseSafe ? "@safe " : "") ~
@@ -485,7 +483,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
                         "code = ", code);
 
             static assert(__traits(compiles, mixin(code)()) == expect);
-        }
+        }}
     }
 }
 

--- a/std/format.d
+++ b/std/format.d
@@ -2560,7 +2560,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 
     assert(collectExceptionMsg!FormatException(format("%d", 5.1)).back == 'd');
 
-    foreach (T; AliasSeq!(float, double, real))
+    static foreach (T; AliasSeq!(float, double, real))
     {
         formatTest( to!(          T)(5.5), "5.5" );
         formatTest( to!(    const T)(5.5), "5.5" );
@@ -2607,13 +2607,13 @@ if (is(Unqual!T : creal) && !is(T == enum) && !hasToString!(T, Char))
 @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
-    foreach (T; AliasSeq!(cfloat, cdouble, creal))
+    static foreach (T; AliasSeq!(cfloat, cdouble, creal))
     {
         formatTest( to!(          T)(1 + 1i), "1+1i" );
         formatTest( to!(    const T)(1 + 1i), "1+1i" );
         formatTest( to!(immutable T)(1 + 1i), "1+1i" );
     }
-    foreach (T; AliasSeq!(cfloat, cdouble, creal))
+    static foreach (T; AliasSeq!(cfloat, cdouble, creal))
     {
         formatTest( to!(          T)(0 - 3i), "0-3i" );
         formatTest( to!(    const T)(0 - 3i), "0-3i" );
@@ -2653,7 +2653,7 @@ if (is(Unqual!T : ireal) && !is(T == enum) && !hasToString!(T, Char))
 @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
-    foreach (T; AliasSeq!(ifloat, idouble, ireal))
+    static foreach (T; AliasSeq!(ifloat, idouble, ireal))
     {
         formatTest( to!(          T)(1i), "1i" );
         formatTest( to!(    const T)(1i), "1i" );
@@ -2957,7 +2957,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
 @system unittest
 {
     // string literal from valid UTF sequence is encoding free.
-    foreach (StrType; AliasSeq!(string, wstring, dstring))
+    static foreach (StrType; AliasSeq!(string, wstring, dstring))
     {
         // Valid and printable (ASCII)
         formatTest( [cast(StrType)"hello"],

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -540,7 +540,7 @@ if (is(T == TestFoo))
 
     import std.meta : AliasSeq;
 
-    foreach (S; AliasSeq!(uint, double, TestFoo))
+    static foreach (S; AliasSeq!(uint, double, TestFoo))
     {
         foreach (T; AllDummyRangesType!(S[]))
         {

--- a/std/math.d
+++ b/std/math.d
@@ -583,18 +583,18 @@ if (is(Num* : const(ifloat*)) || is(Num* : const(idouble*))
 @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         T f = 3;
         assert(abs(f) == f);
         assert(abs(-f) == f);
-    }
-    foreach (T; AliasSeq!(cfloat, cdouble, creal))
-    {
+    }}
+    static foreach (T; AliasSeq!(cfloat, cdouble, creal))
+    {{
         T f = -12+3i;
         assert(abs(f) == hypot(f.re, f.im));
         assert(abs(-f) == hypot(f.re, f.im));
-    }
+    }}
 }
 
 /***********************************
@@ -2810,8 +2810,8 @@ if (isFloatingPoint!T)
     import std.meta : AliasSeq;
     import std.typecons : tuple, Tuple;
 
-    foreach (T; AliasSeq!(real, double, float))
-    {
+    static foreach (T; AliasSeq!(real, double, float))
+    {{
         Tuple!(T, T, int)[] vals =     // x,frexp,exp
             [
              tuple(T(0.0),  T( 0.0 ), 0),
@@ -2861,21 +2861,21 @@ if (isFloatingPoint!T)
 
             }
         }
-    }
+    }}
 }
 
 @safe unittest
 {
     import std.meta : AliasSeq;
     void foo() {
-        foreach (T; AliasSeq!(real, double, float))
-        {
+        static foreach (T; AliasSeq!(real, double, float))
+        {{
             int exp;
             const T a = 1;
             immutable T b = 2;
             auto c = frexp(a, exp);
             auto d = frexp(b, exp);
-        }
+        }}
     }
 }
 
@@ -3063,8 +3063,8 @@ alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
 {
     import std.meta : AliasSeq;
     import std.typecons : Tuple;
-    foreach (F; AliasSeq!(float, double, real))
-    {
+    static foreach (F; AliasSeq!(float, double, real))
+    {{
         alias T = Tuple!(F, int);
         T[13] vals =   // x, ilogb(x)
         [
@@ -3087,7 +3087,7 @@ alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
         {
             assert(ilogb(elem[0]) == elem[1]);
         }
-    }
+    }}
 
     // min_normal and subnormals
     assert(ilogb(-float.min_normal) == -126);
@@ -3136,8 +3136,8 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
 @nogc @safe pure nothrow unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         T r;
 
         r = ldexp(3.0L, 3);
@@ -3150,7 +3150,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
         int exp = 3;
         r = ldexp(n, exp);
         assert(r == 24);
-    }
+    }}
 }
 
 @safe pure nothrow @nogc unittest
@@ -4260,8 +4260,8 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
 {
     import std.meta : AliasSeq;
 
-    foreach (F; AliasSeq!(real, double, float))
-    {
+    static foreach (F; AliasSeq!(real, double, float))
+    {{
         const maxL10 = cast(int) F.max.log10.floor;
         const maxR10 = pow(cast(F) 10, maxL10);
         assert((cast(F) 0.9L * maxR10).quantize!10(maxL10) ==  maxR10);
@@ -4273,7 +4273,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
         assert((-F.min_normal).quantize(F.max) == 0);
         assert(F.min_normal.quantize(F.min_normal) == F.min_normal);
         assert((-F.min_normal).quantize(F.min_normal) == -F.min_normal);
-    }
+    }}
 }
 
 /******************************************
@@ -4840,8 +4840,8 @@ version(D_HardFloat) @system unittest
         bool function() ieeeCheck;
     }
 
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         T x; /* Needs to be here to trick -O. It would optimize away the
             calculations if x were local to the function literals. */
         auto tests = [
@@ -4873,7 +4873,7 @@ version(D_HardFloat) @system unittest
             test.action();
             assert(test.ieeeCheck());
         }
-    }
+    }}
 }
 
 version(X86_Any)
@@ -5278,8 +5278,8 @@ version(D_HardFloat) @system unittest // rounding
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         FloatingPointControl fpctrl;
 
         fpctrl.rounding = FloatingPointControl.roundUp;
@@ -5311,7 +5311,7 @@ version(D_HardFloat) @system unittest // rounding
 
         assert(u > d);
         assert(z == u);
-    }
+    }}
 }
 
 
@@ -5374,8 +5374,8 @@ if (isFloatingPoint!(X))
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         // CTFE-able tests
         assert(isNaN(T.init));
         assert(isNaN(-T.init));
@@ -5400,7 +5400,7 @@ if (isFloatingPoint!(X))
         f = cast(T) 53.6;
         assert(!isNaN(f));
         assert(!isNaN(-f));
-    }
+    }}
 }
 
 /*********************************
@@ -5550,12 +5550,12 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         T f;
         for (f = 1.0; !isSubnormal(f); f /= 2)
             assert(f != 0);
-    }
+    }}
 }
 
 /*********************************
@@ -5773,10 +5773,10 @@ if (isIntegral!(X) && isFloatingPoint!(R))
 {
     import std.meta : AliasSeq;
 
-    foreach (X; AliasSeq!(float, double, real, int, long))
+    static foreach (X; AliasSeq!(float, double, real, int, long))
     {
-        foreach (Y; AliasSeq!(float, double, real))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (Y; AliasSeq!(float, double, real))
+        {{
             X x = 21;
             Y y = 23.8;
             Y e = void;
@@ -5801,7 +5801,7 @@ if (isIntegral!(X) && isFloatingPoint!(R))
                 e = copysign(X.nan, -y);
                 assert(isNaN(e) && signbit(e));
             }
-        }();
+        }}
     }
 }
 
@@ -7911,8 +7911,8 @@ if (isFloatingPoint!T)
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         T[] values = [-cast(T) NaN(20), -cast(T) NaN(10), -T.nan, -T.infinity,
                       -T.max, -T.max / 2, T(-16.0), T(-1.0).nextDown,
                       T(-1.0), T(-1.0).nextUp,
@@ -7936,7 +7936,7 @@ if (isFloatingPoint!T)
             }
             assert(cmp(x, x) == 0);
         }
-    }
+    }}
 }
 
 private enum PowType
@@ -8076,8 +8076,8 @@ if (isFloatingPoint!T)
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         enum T subNormal = T.min_normal / 2;
 
         static if (subNormal) assert(nextPow2(subNormal) == T.min_normal);
@@ -8101,7 +8101,7 @@ if (isFloatingPoint!T)
 
         assert(nextPow2(T.infinity) == T.infinity);
         assert(nextPow2(T.init).isNaN);
-    }
+    }}
 }
 
 @safe @nogc pure nothrow unittest // Issue 15973
@@ -8206,7 +8206,7 @@ if (isFloatingPoint!T)
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(float, double, real))
+    static foreach (T; AliasSeq!(float, double, real))
     {
         assert(truncPow2(T(0.0)) == 0.0);
 
@@ -8302,8 +8302,8 @@ if (isNumeric!X)
     immutable smallP7 = pow(7.0L, -35);
     immutable bigP7 = pow(7.0L, 30);
 
-    foreach (X; AliasSeq!(float, double, real))
-    {
+    static foreach (X; AliasSeq!(float, double, real))
+    {{
         immutable min_sub = X.min_normal * X.epsilon;
 
         foreach (x; [smallP2, min_sub, X.min_normal, .25L, 0.5L, 1.0L,
@@ -8318,10 +8318,10 @@ if (isNumeric!X)
             assert(!isPowerOf2(cast(X) x));
             assert(!isPowerOf2(cast(X)-x));
         }
-    }
+    }}
 
-    foreach (X; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
-    {
+    static foreach (X; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    {{
         foreach (x; [1, 2, 4, 8, (X.max >>> 1) + 1])
         {
             assert( isPowerOf2(cast(X) x));
@@ -8331,5 +8331,5 @@ if (isNumeric!X)
 
         foreach (x; [0, 3, 5, 13, 77, X.min, X.max])
             assert(!isPowerOf2(cast(X) x));
-    }
+    }}
 }

--- a/std/meta.d
+++ b/std/meta.d
@@ -989,7 +989,7 @@ template templateNot(alias pred)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int, staticMap, 42))
+    static foreach (T; AliasSeq!(int, staticMap, 42))
     {
         static assert(!Instantiate!(templateNot!testAlways, T));
         static assert(Instantiate!(templateNot!testNever, T));
@@ -1040,7 +1040,7 @@ template templateAnd(Preds...)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int, staticMap, 42))
+    static foreach (T; AliasSeq!(int, staticMap, 42))
     {
         static assert( Instantiate!(templateAnd!(), T));
         static assert( Instantiate!(templateAnd!(testAlways), T));
@@ -1098,7 +1098,7 @@ template templateOr(Preds...)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int, staticMap, 42))
+    static foreach (T; AliasSeq!(int, staticMap, 42))
     {
         static assert( Instantiate!(templateOr!(testAlways), T));
         static assert( Instantiate!(templateOr!(testAlways, testAlways), T));

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3303,12 +3303,11 @@ struct HTTP
 
 @system unittest // charset/Charset/CHARSET/...
 {
-    import std.meta : AliasSeq;
     import etc.c.curl;
 
-    foreach (c; AliasSeq!("charset", "Charset", "CHARSET", "CharSet", "charSet",
-        "ChArSeT", "cHaRsEt"))
-    {
+    static foreach (c; ["charset", "Charset", "CHARSET", "CharSet", "charSet",
+        "ChArSeT", "cHaRsEt"])
+    {{
         testServer.handle((s) {
             s.send("HTTP/1.1 200 OK\r\n"~
                 "Content-Length: 0\r\n"~
@@ -3338,7 +3337,7 @@ struct HTTP
         assert(code == CurlError.ok);
         code = http.getTiming(CurlInfo.appconnect_time, val);
         assert(code == CurlError.ok);
-    }
+    }}
 }
 
 /**

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1588,7 +1588,7 @@ do
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(double, float, real))
+    static foreach (T; AliasSeq!(double, float, real))
     {
         {
             auto ret = findLocalMin!T((T x) => (x-4)^^2, T.min_normal, 1e7);
@@ -1677,15 +1677,15 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(double, const double, immutable double))
-    {
+    static foreach (T; AliasSeq!(double, const double, immutable double))
+    {{
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 6.0, ];
         assert(euclideanDistance(a, b) == 5);
         assert(euclideanDistance(a, b, 5) == 5);
         assert(euclideanDistance(a, b, 4) == 5);
         assert(euclideanDistance(a, b, 2) == 3);
-    }
+    }}
 }
 
 /**
@@ -1770,13 +1770,13 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
     // @system due to dotProduct and assertCTFEable
     import std.exception : assertCTFEable;
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(double, const double, immutable double))
-    {
+    static foreach (T; AliasSeq!(double, const double, immutable double))
+    {{
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 6.0, ];
         assert(dotProduct(a, b) == 16);
         assert(dotProduct([1, 3, -5], [4, -2, -1]) == 3);
-    }
+    }}
 
     // Make sure the unrolled loop codepath gets tested.
     static const x =
@@ -1815,14 +1815,14 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(double, const double, immutable double))
-    {
+    static foreach (T; AliasSeq!(double, const double, immutable double))
+    {{
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 3.0, ];
         assert(approxEqual(
                     cosineSimilarity(a, b), 10.0 / sqrt(5.0 * 25),
                     0.01));
-    }
+    }}
 }
 
 /**
@@ -1969,14 +1969,14 @@ if (isInputRange!Range &&
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(double, const double, immutable double))
-    {
+    static foreach (T; AliasSeq!(double, const double, immutable double))
+    {{
         T[] p = [ 0.0, 0, 0, 1 ];
         assert(entropy(p) == 0);
         p = [ 0.25, 0.25, 0.25, 0.25 ];
         assert(entropy(p) == 2);
         assert(entropy(p, 1) == 1);
-    }
+    }}
 }
 
 /**

--- a/std/path.d
+++ b/std/path.d
@@ -3590,7 +3590,7 @@ unittest
     else static assert(0);
 
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(char[], const(char)[], string, wchar[],
+    static foreach (T; AliasSeq!(char[], const(char)[], string, wchar[],
         const(wchar)[], wstring, dchar[], const(dchar)[], dstring))
     {
         foreach (fn; valid)

--- a/std/random.d
+++ b/std/random.d
@@ -526,15 +526,15 @@ alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
     assert(rnd.front == 399268537);
 
     // Check .save works
-    foreach (Type; std.meta.AliasSeq!(MinstdRand0, MinstdRand))
-    {
+    static foreach (Type; std.meta.AliasSeq!(MinstdRand0, MinstdRand))
+    {{
         auto rnd1 = Type(unpredictableSeed);
         auto rnd2 = rnd1.save;
         assert(rnd1 == rnd2);
         // Enable next test when RNGs are reference types
         version(none) { assert(rnd1 !is rnd2); }
         assert(rnd1.take(100).array() == rnd2.take(100).array());
-    }
+    }}
 }
 
 @safe unittest
@@ -963,15 +963,15 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
 {
     import std.range;
     // Check .save works
-    foreach (Type; std.meta.AliasSeq!(Mt19937, Mt19937_64))
-    {
+    static foreach (Type; std.meta.AliasSeq!(Mt19937, Mt19937_64))
+    {{
         auto gen1 = Type(unpredictableSeed);
         auto gen2 = gen1.save;
         assert(gen1 == gen2);  // Danger, Will Robinson -- no opEquals for MT
         // Enable next test when RNGs are reference types
         version(none) { assert(gen1 !is gen2); }
         assert(gen1.take(100).array() == gen2.take(100).array());
-    }
+    }}
 }
 
 @safe pure nothrow unittest //11690
@@ -987,14 +987,14 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     ulong[] expected10kValue = [4123659995uL, 4123659995uL,
                                 51991688252792uL, 3031481165133029945uL];
 
-    foreach (i, R; std.meta.AliasSeq!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
-    {
+    static foreach (i, R; std.meta.AliasSeq!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
+    {{
         auto a = R();
         a.seed(a.defaultSeed); // checks that some alternative paths in `seed` are utilized
         assert(a.front == expectedFirstValue[i]);
         a.popFrontN(9999);
         assert(a.front == expected10kValue[i]);
-    }
+    }}
 }
 
 
@@ -1618,9 +1618,9 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
     auto c = uniform(0.0, 1.0);
     assert(0 <= c && c < 1);
 
-    foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
+    static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong, float, double, real))
-    {
+    {{
         T lo = 0, hi = 100;
 
         // Try tests with each of the possible bounds
@@ -1668,19 +1668,19 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
                 assert(u <= T.max, "Upper bound violation for uniform!\"[]\" with " ~ T.stringof);
             }
         }
-    }
+    }}
 
     auto reproRng = Xorshift(239842);
 
-    foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short,
+    static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short,
                           ushort, int, uint, long, ulong))
-    {
+    {{
         T lo = T.min + 10, hi = T.max - 10;
         T init = uniform(lo, hi, reproRng);
         size_t i = 50;
         while (--i && uniform(lo, hi, reproRng) == init) {}
         assert(i > 0);
-    }
+    }}
 
     {
         bool sawLB = false, sawUB = false;
@@ -1791,9 +1791,9 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
 
 @safe unittest
 {
-    foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
+    static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong))
-    {
+    {{
         T init = uniform!T();
         size_t i = 50;
         while (--i && uniform!T() == init) {}
@@ -1806,7 +1806,7 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
             assert(T.min <= u, "Lower bound violation for uniform!" ~ T.stringof);
             assert(u <= T.max, "Upper bound violation for uniform!" ~ T.stringof);
         }
-    }
+    }}
 }
 
 /**
@@ -1939,11 +1939,11 @@ do
 @safe unittest
 {
     import std.meta;
-    foreach (UniformRNG; PseudoRngTypes)
-    {
+    static foreach (UniformRNG; PseudoRngTypes)
+    {{
 
-        foreach (T; std.meta.AliasSeq!(float, double, real))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; std.meta.AliasSeq!(float, double, real))
+        {{
             UniformRNG rng = UniformRNG(unpredictableSeed);
 
             auto a = uniform01();
@@ -1967,8 +1967,8 @@ do
             while (--i && uniform01!T(rng) == init) {}
             assert(i > 0);
             assert(i < 50);
-        }();
-    }
+        }}
+    }}
 }
 
 /**
@@ -2485,8 +2485,8 @@ if (isRandomAccessRange!Range)
     import std.conv;
     int[] a = [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ];
     int[] c;
-    foreach (UniformRNG; std.meta.AliasSeq!(void, PseudoRngTypes))
-    {
+    static foreach (UniformRNG; std.meta.AliasSeq!(void, PseudoRngTypes))
+    {{
         static if (is(UniformRNG == void))
         {
             auto rc = randomCover(a);
@@ -2514,7 +2514,7 @@ if (isRandomAccessRange!Range)
         }
         sort(b);
         assert(a == b, text(b));
-    }
+    }}
 }
 
 @safe unittest

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2835,7 +2835,7 @@ pure @safe nothrow unittest
 
     import std.format : format;
 
-    foreach (range; AliasSeq!([1, 2, 3, 4, 5],
+    static foreach (range; AliasSeq!([1, 2, 3, 4, 5],
                              "hello world",
                              "hello world"w,
                              "hello world"d,
@@ -2849,7 +2849,7 @@ pure @safe nothrow unittest
         static assert(is(typeof(range) == typeof(takeNone(range))), typeof(range).stringof);
     }
 
-    foreach (range; AliasSeq!(NormalStruct([1, 2, 3]),
+    static foreach (range; AliasSeq!(NormalStruct([1, 2, 3]),
                              InitStruct([1, 2, 3])))
     {
         static assert(takeNone(range).empty, typeof(range).stringof);
@@ -5847,13 +5847,13 @@ pure @safe unittest
 
 
     // Issue 8920
-    foreach (Type; AliasSeq!(byte, ubyte, short, ushort,
+    static foreach (Type; AliasSeq!(byte, ubyte, short, ushort,
         int, uint, long, ulong))
-    {
+    {{
         Type val;
         foreach (i; iota(cast(Type) 0, cast(Type) 10)) { val++; }
         assert(val == 10);
-    }
+    }}
 }
 
 pure @safe nothrow unittest
@@ -5866,11 +5866,11 @@ pure @safe nothrow unittest
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (range; AliasSeq!(iota(2, 27, 4),
+    static foreach (range; AliasSeq!(iota(2, 27, 4),
                              iota(3, 9),
                              iota(2.7, 12.3, .1),
                              iota(3.2, 9.7)))
-    {
+    {{
         const cRange = range;
         const e = cRange.empty;
         const f = cRange.front;
@@ -5879,7 +5879,7 @@ pure @safe nothrow unittest
         const s1 = cRange[];
         const s2 = cRange[0 .. 3];
         const l = cRange.length;
-    }
+    }}
 }
 
 @system unittest
@@ -8497,8 +8497,8 @@ public:
         DummyRange!(ReturnBy.Value, Length.No, RangeType.Bidirectional)
     );
 
-    foreach (Range; AliasSeq!AllForwardDummyRanges)
-    {
+    static foreach (Range; AliasSeq!AllForwardDummyRanges)
+    {{
         Range r;
         assert(r.slide(1).equal!equal(
             [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
@@ -8519,15 +8519,15 @@ public:
         ));
 
         assert(r.slide!(No.withFewerElements)(15).empty);
-    }
+    }}
 
     alias BackwardsDummyRanges = AliasSeq!(
         DummyRange!(ReturnBy.Reference, Length.Yes, RangeType.Random),
         DummyRange!(ReturnBy.Value, Length.Yes, RangeType.Random),
     );
 
-    foreach (Range; AliasSeq!BackwardsDummyRanges)
-    {
+    static foreach (Range; AliasSeq!BackwardsDummyRanges)
+    {{
         Range r;
         assert(r.slide(1).retro.equal!equal(
             [[10], [9], [8], [7], [6], [5], [4], [3], [2], [1]]
@@ -8565,7 +8565,7 @@ public:
                 auto slider = r.slide(windowSize, stepSize);
                 assert(slider.retro.retro.equal!equal(slider));
             }
-    }
+    }}
 
     assert(iota(1, 12).slide(2, 4)[0 .. 3].equal!equal([[1, 2], [5, 6], [9, 10]]));
     assert(iota(1, 12).slide(2, 4)[0 .. $].equal!equal([[1, 2], [5, 6], [9, 10]]));
@@ -8636,8 +8636,8 @@ public:
         SliceableRange!(T, Yes.withOpDollar, Yes.withInfiniteness),
     );
 
-    foreach (Range; AliasSeq!SliceableDummyRanges)
-    {
+    static foreach (Range; AliasSeq!SliceableDummyRanges)
+    {{
         Range r;
         r.arr = 10.iota.array; // for clarity
 
@@ -8654,7 +8654,7 @@ public:
         assert(s[0 .. 2].equal!equal([[0, 1], [1, 2]]));
 
         assert(r.slide(3)[1 .. 3].equal!equal([[1, 2, 3], [2, 3, 4]]));
-    }
+    }}
 
     alias SliceableDummyRangesWithoutInfinity = AliasSeq!(
         DummyRange!(ReturnBy.Reference, Length.Yes, RangeType.Random, T),
@@ -8663,8 +8663,8 @@ public:
         SliceableRange!(T, Yes.withOpDollar, No.withInfiniteness),
     );
 
-    foreach (Range; AliasSeq!SliceableDummyRangesWithoutInfinity)
-    {
+    static foreach (Range; AliasSeq!SliceableDummyRangesWithoutInfinity)
+    {{
         static assert(hasSlicing!Range);
         static assert(hasLength!Range);
 
@@ -8684,7 +8684,7 @@ public:
         assert(r.slide(3).retro.equal!equal(
             [[7, 8, 9], [6, 7, 8], [5, 6, 7], [4, 5, 6], [3, 4, 5], [2, 3, 4], [1, 2, 3], [0, 1, 2]]
         ));
-    }
+    }}
 
     // separate checks for infinity
     auto infIndex = SliceableRange!(T, No.withOpDollar, Yes.withInfiniteness)([0, 1, 2, 3]);
@@ -9054,8 +9054,8 @@ if (!is(CommonType!Values == void) || Values.length == 0)
         ["one two", "one two three", "one two three four"];
     string[] joinedRange = joined;
 
-    foreach (argCount; AliasSeq!(2, 3, 4))
-    {
+    static foreach (argCount; 2 .. 5)
+    {{
         auto values = only(data[0 .. argCount]);
         alias Values = typeof(values);
         static assert(is(ElementType!Values == string));
@@ -9070,7 +9070,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
         assert(values[0 .. $].equal(values[0 .. values.length]));
         assert(values.joiner(" ").equal(joinedRange.front));
         joinedRange.popFront();
-    }
+    }}
 
     assert(saved.retro.equal(only(3, 2, 1)));
     assert(saved.length == 3);
@@ -9314,8 +9314,8 @@ pure @safe nothrow unittest
         }
     }
 
-    foreach (DummyType; AliasSeq!(AllDummyRanges, HasSlicing))
-    {
+    static foreach (DummyType; AliasSeq!(AllDummyRanges, HasSlicing))
+    {{
         alias R = typeof(enumerate(DummyType.init));
         static assert(isInputRange!R);
         static assert(isForwardRange!R == isForwardRange!DummyType);
@@ -9330,7 +9330,7 @@ pure @safe nothrow unittest
         }
 
         static assert(hasSlicing!R == hasSlicing!DummyType);
-    }
+    }}
 
     static immutable values = ["zero", "one", "two", "three"];
     auto enumerated = values[].enumerate();
@@ -9380,8 +9380,8 @@ pure @safe nothrow unittest
         assert(shifted.empty);
     }
 
-    foreach (T; AliasSeq!(ubyte, byte, uint, int))
-    {
+    static foreach (T; AliasSeq!(ubyte, byte, uint, int))
+    {{
         auto inf = 42.repeat().enumerate(T.max);
         alias Inf = typeof(inf);
         static assert(isInfinite!Inf);
@@ -9400,7 +9400,7 @@ pure @safe nothrow unittest
         assert(window.front == inf.front);
         window.popFront();
         assert(window.empty);
-    }
+    }}
 }
 
 pure @safe unittest
@@ -9408,8 +9408,8 @@ pure @safe unittest
     import std.algorithm.comparison : equal;
     import std.meta : AliasSeq;
     static immutable int[] values = [0, 1, 2, 3, 4];
-    foreach (T; AliasSeq!(ubyte, ushort, uint, ulong))
-    {
+    static foreach (T; AliasSeq!(ubyte, ushort, uint, ulong))
+    {{
         auto enumerated = values.enumerate!T();
         static assert(is(typeof(enumerated.front.index) == T));
         assert(enumerated.equal(values[].zip(values)));
@@ -9421,7 +9421,7 @@ pure @safe unittest
             static assert(is(typeof(enumerated.front.index) == T));
             assert(offsetEnumerated.equal(subset.zip(subset)));
         }
-    }
+    }}
 }
 
 version(none) // @@@BUG@@@ 10939
@@ -9450,7 +9450,7 @@ version(none) // @@@BUG@@@ 10939
         }
 
         SignedLengthRange svalues;
-        foreach (Enumerator; AliasSeq!(ubyte, byte, ushort, short, uint, int, ulong, long))
+        static foreach (Enumerator; AliasSeq!(ubyte, byte, ushort, short, uint, int, ulong, long))
         {
             assertThrown!RangeError(values[].enumerate!Enumerator(Enumerator.max));
             assertNotThrown!RangeError(values[].enumerate!Enumerator(Enumerator.max - values.length));
@@ -9461,7 +9461,7 @@ version(none) // @@@BUG@@@ 10939
             assertThrown!RangeError(svalues.enumerate!Enumerator(Enumerator.max - values.length + 1));
         }
 
-        foreach (Enumerator; AliasSeq!(byte, short, int))
+        static foreach (Enumerator; AliasSeq!(byte, short, int))
         {
             assertThrown!RangeError(repeat(0, uint.max).enumerate!Enumerator());
         }
@@ -11831,19 +11831,19 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     auto result3 = txt.tee(asink3).array;
     assert(equal(txt, result3) && equal(result3, asink3));
 
-    foreach (CharType; AliasSeq!(char, wchar, dchar))
-    {
+    static foreach (CharType; AliasSeq!(char, wchar, dchar))
+    {{
         auto appSink = appender!(CharType[])();
         auto appResult = txt.tee(appSink).array;
         assert(equal(txt, appResult) && equal(appResult, appSink.data));
-    }
+    }}
 
-    foreach (StringType; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (StringType; AliasSeq!(string, wstring, dstring))
+    {{
         auto appSink = appender!StringType();
         auto appResult = txt.tee(appSink).array;
         assert(equal(txt, appResult) && equal(appResult, appSink.data));
-    }
+    }}
 }
 
 @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -612,19 +612,19 @@ pure @safe unittest
     putChar(p, cast(dchar)'a');
 
     //Source Char
-    foreach (SC; AliasSeq!(char, wchar, dchar))
-    {
+    static foreach (SC; AliasSeq!(char, wchar, dchar))
+    {{
         SC ch = 'I';
         dchar dh = '♥';
         immutable(SC)[] s = "日本語！";
         immutable(SC)[][] ss = ["日本語", "が", "好き", "ですか", "？"];
 
         //Target Char
-        foreach (TC; AliasSeq!(char, wchar, dchar))
+        static foreach (TC; AliasSeq!(char, wchar, dchar))
         {
             //Testing PutC and PutS
-            foreach (Type; AliasSeq!(PutC!TC, PutS!TC))
-            (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+            static foreach (Type; AliasSeq!(PutC!TC, PutS!TC))
+            {{
                 Type type;
                 auto sink = new Type();
 
@@ -640,9 +640,9 @@ pure @safe unittest
                     put(value, ss);
                     assert(value.result == "I♥日本語！日本語が好きですか？");
                 }
-            }();
+            }}
         }
-    }
+    }}
 }
 
 @safe unittest
@@ -716,8 +716,8 @@ pure @safe unittest
     }
     void foo()
     {
-        foreach (C; AliasSeq!(char, wchar, dchar))
-        {
+        static foreach (C; AliasSeq!(char, wchar, dchar))
+        {{
             formattedWrite((C c){},        "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
             formattedWrite((const(C)[]){}, "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
             formattedWrite(PutC!C(),       "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
@@ -728,7 +728,7 @@ pure @safe unittest
             formattedWrite(callS,          "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
             formattedWrite(FrontC!C(),     "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
             formattedWrite(FrontS!C(),     "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
-        }
+        }}
         formattedWrite((dchar[]).init,     "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
     }
 }
@@ -2119,8 +2119,8 @@ if (isNarrowString!(C[]))
 {
     import std.meta : AliasSeq;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         S s = "\xC2\xA9hello";
         s.popFront();
         assert(s == "hello");
@@ -2135,7 +2135,7 @@ if (isNarrowString!(C[]))
 
         static assert(!is(typeof({          immutable S a; popFront(a); })));
         static assert(!is(typeof({ typeof(S.init[0])[4] a; popFront(a); })));
-    }
+    }}
 
     C[] _eatString(C)(C[] str)
     {
@@ -2212,8 +2212,8 @@ if (isNarrowString!(T[]))
 {
     import std.meta : AliasSeq;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         S s = "hello\xE2\x89\xA0";
         s.popBack();
         assert(s == "hello");
@@ -2233,7 +2233,7 @@ if (isNarrowString!(T[]))
 
         static assert(!is(typeof({          immutable S a; popBack(a); })));
         static assert(!is(typeof({ typeof(S.init[0])[4] a; popBack(a); })));
-    }
+    }}
 }
 
 /**

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -517,8 +517,8 @@ public:
     import std.conv, std.regex;
     @trusted void test_fixed(alias Kick)()
     {
-        foreach (i, v; AliasSeq!(char, wchar, dchar))
-        {
+        static foreach (i, v; AliasSeq!(char, wchar, dchar))
+        {{
             alias Char = v;
             alias String = immutable(v)[];
             auto r = regex(to!String(`abc$`));
@@ -539,12 +539,12 @@ public:
             assert(x == 3, text(Kick.stringof,v.stringof," == ", kick.length));
             x = kick.search("aabaacaa", x+1);
             assert(x == 8, text(Kick.stringof,v.stringof," == ", kick.length));
-        }
+        }}
     }
     @trusted void test_flex(alias Kick)()
     {
-        foreach (i, v; AliasSeq!(char, wchar, dchar))
-        {
+        static foreach (i, v; AliasSeq!(char, wchar, dchar))
+        {{
             alias Char = v;
             alias String = immutable(v)[];
             auto r = regex(to!String(`abc[a-z]`));
@@ -570,7 +570,7 @@ public:
             assert(kick.search("ababx",0) == 2);
             assert(kick.search("abaacba",0) == 3);//expected inexact
 
-        }
+        }}
     }
     test_fixed!(ShiftOr)();
     test_flex!(ShiftOr)();

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -353,8 +353,8 @@ alias Sequence(int B, int E) = staticIota!(B, E);
     void run_tests(alias matchFn)()
     {
         int i;
-        foreach (Char; AliasSeq!( char, wchar, dchar))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (Char; AliasSeq!( char, wchar, dchar))
+        {{
             alias String = immutable(Char)[];
             String produceExpected(M,Range)(auto ref M m, Range fmt)
             {
@@ -397,7 +397,7 @@ alias Sequence(int B, int E) = staticIota!(B, E);
                     }
                 }
             }
-        }();
+        }}
         debug(std_regex_test) writeln("!!! FReD bulk test done "~matchFn.stringof~" !!!");
     }
 
@@ -428,8 +428,8 @@ alias Sequence(int B, int E) = staticIota!(B, E);
         }
         else
             alias Tests = AliasSeq!(Sequence!(0, 30), Sequence!(235, tv.length-5));
-        foreach (a, v; Tests)
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (a, v; Tests)
+        {{
             enum tvd = tv[v];
             static if (tvd.result == "c")
             {
@@ -458,7 +458,7 @@ alias Sequence(int B, int E) = staticIota!(B, E);
                                 tvd.replace, " vs ", result);
                 }
             }
-        }();
+        }}
         debug(std_regex_test) writeln("!!! FReD C-T test done !!!");
     }
 
@@ -689,8 +689,8 @@ alias Sequence(int B, int E) = staticIota!(B, E);
     {
         import std.uni : toUpper;
 
-        foreach (i, v; AliasSeq!(string, wstring, dstring))
-        {
+        static foreach (i, v; AliasSeq!(string, wstring, dstring))
+        {{
             auto baz(Cap)(Cap m)
             if (is(Cap == Captures!(Cap.String)))
             {
@@ -709,7 +709,7 @@ alias Sequence(int B, int E) = staticIota!(B, E);
             auto s = std.regex.replace!(baz!(Captures!(String)))(to!String("Strap a rocket engine on a chicken."),
                     regex(to!String("[ar]"), "g"));
             assert(s == "StRAp A Rocket engine on A chicken.");
-        }
+        }}
         debug(std_regex_test) writeln("!!! Replace test done "~matchFn.stringof~"  !!!");
     }
     test!(bmatch)();
@@ -787,13 +787,13 @@ alias Sequence(int B, int E) = staticIota!(B, E);
 @safe unittest
 {// bugzilla 7679
     import std.algorithm.comparison : equal;
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         enum re = ctRegex!(to!S(r"\."));
         auto str = to!S("a.b");
         assert(equal(std.regex.splitter(str, re), [to!S("a"), to!S("b")]));
         assert(split(str, re) == [to!S("a"), to!S("b")]);
-    }();
+    }}
 }
 @safe unittest
 {//bugzilla 8203

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -1020,8 +1020,8 @@ if (isSomeString!R && isSomeString!String)
     import std.algorithm.iteration : map;
     import std.conv : to;
 
-    foreach (String; AliasSeq!(string, wstring, const(dchar)[]))
-    {
+    static foreach (String; AliasSeq!(string, wstring, const(dchar)[]))
+    {{
         auto str1 = "blah-bleh".to!String();
         auto pat1 = "bl[ae]h".to!String();
         auto mf = matchFirst(str1, pat1);
@@ -1052,7 +1052,7 @@ if (isSomeString!R && isSomeString!String)
         assert(cmAll.front.equal(cmf));
         cmAll.popFront();
         assert(cmAll.front.equal(["6/1", "6", "1"].map!(to!String)()));
-    }
+    }}
 }
 
 /++
@@ -1396,8 +1396,8 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
     import std.array : appender;
     import std.conv;
     // try and check first/all simple substitution
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+    {{
         S s1 = "curt trial".to!S();
         S s2 = "round dome".to!S();
         S t1F = "court trial".to!S();
@@ -1428,7 +1428,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
         assert(sink.data == t1F~t2F~t1A);
         replaceAllInto(sink, s2, re2, "ho");
         assert(sink.data == t1F~t2F~t1A~t2A);
-    }
+    }}
 }
 
 /++
@@ -1671,11 +1671,11 @@ auto escaper(Range)(Range r)
 {
     import std.algorithm.comparison;
     import std.conv;
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
       auto s = "^".to!S;
       assert(s.escaper.equal(`\^`));
       auto s2 = "";
       assert(s2.escaper.equal(""));
-    }
+    }}
 }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1631,8 +1631,8 @@ void main()
         auto deleteme = testFilename();
         std.file.write(deleteme, "hello\nworld\n");
         scope(exit) std.file.remove(deleteme);
-        foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
-        {
+        static foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
+        {{
             auto witness = [ "hello\n", "world\n" ];
             auto f = File(deleteme);
             uint i = 0;
@@ -1643,7 +1643,7 @@ void main()
                 assert(equal(buf, witness[i++]));
             }
             assert(i == witness.length);
-        }
+        }}
     }
 
     @system unittest
@@ -1655,13 +1655,13 @@ void main()
         std.file.write(deleteme, "cześć \U0002000D");
         scope(exit) std.file.remove(deleteme);
         uint[] lengths = [12,8,7];
-        foreach (uint i, C; Tuple!(char, wchar, dchar).Types)
-        {
+        static foreach (uint i, C; Tuple!(char, wchar, dchar).Types)
+        {{
             immutable(C)[] witness = "cześć \U0002000D";
             auto buf = File(deleteme).readln!(immutable(C)[])();
             assert(buf.length == lengths[i]);
             assert(buf == witness);
-        }
+        }}
     }
 
 /**
@@ -2270,13 +2270,13 @@ the contents may well have changed).
         scope(success) std.file.remove(deleteme);
 
         import std.meta : AliasSeq;
-        foreach (T; AliasSeq!(char, wchar, dchar))
-        {
+        static foreach (T; AliasSeq!(char, wchar, dchar))
+        {{
             auto blc = File(deleteme).byLine!(T, T);
             assert(blc.front == "hi");
             // check front is cached
             assert(blc.front is blc.front);
-        }
+        }}
     }
 
     private struct ByLineCopy(Char, Terminator)
@@ -4092,18 +4092,18 @@ if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum) &&
     {
         readln();
         readln('\t');
-        foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
+        static foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
         {
             readln!String();
             readln!String('\t');
         }
-        foreach (String; AliasSeq!(char[], wchar[], dchar[]))
-        {
+        static foreach (String; AliasSeq!(char[], wchar[], dchar[]))
+        {{
             String buf;
             readln(buf);
             readln(buf, '\t');
             readln(buf, "<br />");
-        }
+        }}
     }
 }
 
@@ -4439,7 +4439,7 @@ struct lines
 
     }
 
-    foreach (T; AliasSeq!(ubyte[]))
+    static foreach (T; AliasSeq!(ubyte[]))
     {
         // test looping with a file with three lines, last without a newline
         // using a counter too this time

--- a/std/string.d
+++ b/std/string.d
@@ -569,8 +569,8 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         assert(indexOf(cast(S) null, cast(dchar)'a') == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a') == -1);
         assert(indexOf(to!S("abba"), cast(dchar)'a') == 0);
@@ -586,7 +586,7 @@ if (isConvertibleToString!Range)
         assert(indexOf("def", cast(char)'f', No.caseSensitive) == 2);
         assert(indexOf(sPlts, cast(char)'P', No.caseSensitive) == 23);
         assert(indexOf(sPlts, cast(char)'R', No.caseSensitive) == 2);
-    }
+    }}
 
     foreach (cs; EnumMembers!CaseSensitive)
     {
@@ -626,8 +626,8 @@ if (isConvertibleToString!Range)
     assert("hello".byWchar.indexOf(cast(dchar)'l', 1) == 2);
     assert("hello".byWchar.indexOf(cast(dchar)'l', 6) == -1);
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         assert(indexOf(cast(S) null, cast(dchar)'a', 1) == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a', 1) == -1);
         assert(indexOf(to!S("abba"), cast(dchar)'a', 1) == 3);
@@ -649,7 +649,7 @@ if (isConvertibleToString!Range)
         assert(indexOf(sPlts, cast(char)'P', 12, No.caseSensitive) == 23);
         assert(indexOf(sPlts, cast(char)'R', cast(ulong) 1,
             No.caseSensitive) == 2);
-    }
+    }}
 
     foreach (cs; EnumMembers!CaseSensitive)
     {
@@ -822,10 +822,10 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             assert(indexOf(cast(S) null, to!T("a")) == -1);
             assert(indexOf(to!S("def"), to!T("a")) == -1);
             assert(indexOf(to!S("abba"), to!T("a")) == 0);
@@ -855,7 +855,7 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
             // Thanks to Carlos Santander B. and zwang
             assert(indexOf("sus mejores cortesanos. Se embarcaron en el puerto de Dubai y",
                            to!T("page-break-before"), No.caseSensitive) == -1);
-        }();
+        }}
 
         foreach (cs; EnumMembers!CaseSensitive)
         {
@@ -890,10 +890,10 @@ unittest
     import std.conv : to;
     import std.traits : EnumMembers;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             assert(indexOf(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOf(to!S("def"), to!T("a"), 0) == -1);
             assert(indexOf(to!S("abba"), to!T("a"), 2) == 3);
@@ -930,7 +930,7 @@ unittest
 
             // In order for indexOf with and without index to be consistent
             assert(indexOf(to!S(""), to!T("")) == indexOf(to!S(""), to!T(""), 0));
-        }();
+        }}
 
         foreach (cs; EnumMembers!CaseSensitive)
         {
@@ -1068,8 +1068,8 @@ if (isSomeChar!Char)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         assert(lastIndexOf(cast(S) null, 'a') == -1);
         assert(lastIndexOf(to!S("def"), 'a') == -1);
         assert(lastIndexOf(to!S("abba"), 'a') == 3);
@@ -1089,7 +1089,7 @@ if (isSomeChar!Char)
         assert(lastIndexOf(to!S("def"), 'f', No.caseSensitive) == 2);
         assert(lastIndexOf(sPlts, 'M', No.caseSensitive) == 34);
         assert(lastIndexOf(sPlts, 'S', No.caseSensitive) == 40);
-    }
+    }}
 
     foreach (cs; EnumMembers!CaseSensitive)
     {
@@ -1105,8 +1105,8 @@ if (isSomeChar!Char)
     import std.conv : to;
     import std.traits : EnumMembers;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         assert(lastIndexOf(cast(S) null, 'a') == -1);
         assert(lastIndexOf(to!S("def"), 'a') == -1);
         assert(lastIndexOf(to!S("abba"), 'a', 3) == 0);
@@ -1123,7 +1123,7 @@ if (isSomeChar!Char)
         assert(lastIndexOf(to!S("def"), 'f', 4, No.caseSensitive) == -1);
         assert(lastIndexOf(sPlts, 'M', sPlts.length -2, No.caseSensitive) == 34);
         assert(lastIndexOf(sPlts, 'S', sPlts.length -2, No.caseSensitive) == 40);
-    }
+    }}
 
     foreach (cs; EnumMembers!CaseSensitive)
     {
@@ -1270,8 +1270,8 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         auto r = to!S("").lastIndexOf("hello");
         assert(r == -1, to!string(r));
 
@@ -1280,7 +1280,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 
         r = to!S("").lastIndexOf("");
         assert(r == -1, to!string(r));
-    }
+    }}
 }
 
 @safe pure unittest
@@ -1291,10 +1291,10 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
@@ -1329,7 +1329,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             assert(lastIndexOf(sPlts, to!T("FOuRTh"), No.caseSensitive) == 10, typeStr);
             assert(lastIndexOf(sMars, to!T("whO\'s \'MY"), No.caseSensitive) == 0, typeStr);
             assert(lastIndexOf(sMars, to!T(sMars), No.caseSensitive) == 0, typeStr);
-        }();
+        }}
 
         foreach (cs; EnumMembers!CaseSensitive)
         {
@@ -1346,17 +1346,17 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 @safe pure unittest // issue13529
 {
     import std.conv : to;
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        {
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             enum typeStr = S.stringof ~ " " ~ T.stringof;
             auto idx = lastIndexOf(to!T("Hällö Wörldö ö"),to!S("ö ö"));
             assert(idx != -1, to!string(idx) ~ " " ~ typeStr);
 
             idx = lastIndexOf(to!T("Hällö Wörldö ö"),to!S("ö öd"));
             assert(idx == -1, to!string(idx) ~ " " ~ typeStr);
-        }
+        }}
     }
 }
 
@@ -1365,10 +1365,10 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     import std.conv : to;
     import std.traits : EnumMembers;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOf(cast(S) null, to!T("a")) == -1, typeStr);
@@ -1396,7 +1396,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("cd"), 4, No.caseSensitive) == 2, typeStr);
             assert(lastIndexOf(to!S("abcdefcdef"), to!T("def"), 6, No.caseSensitive) == 3, typeStr);
             assert(lastIndexOf(to!S(""), to!T(""), 0) == lastIndexOf(to!S(""), to!T("")), typeStr);
-        }();
+        }}
 
         foreach (cs; EnumMembers!CaseSensitive)
         {
@@ -1593,8 +1593,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         auto r = to!S("").indexOfAny("hello");
         assert(r == -1, to!string(r));
 
@@ -1603,7 +1603,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
         r = to!S("").indexOfAny("");
         assert(r == -1, to!string(r));
-    }
+    }}
 }
 
 @safe pure unittest
@@ -1613,10 +1613,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {
             assert(indexOfAny(cast(S) null, to!T("a")) == -1);
             assert(indexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(indexOfAny(to!S("abba"), to!T("a")) == 0);
@@ -1639,7 +1639,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
                 No.caseSensitive) == 0);
 
             assert(indexOfAny("\u0100", to!T("\u0100"), No.caseSensitive) == 0);
-        }();
+        }
     }
     }
     );
@@ -1650,10 +1650,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
     import std.conv : to;
     import std.traits : EnumMembers;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {
             assert(indexOfAny(cast(S) null, to!T("a"), 1337) == -1);
             assert(indexOfAny(to!S("def"), to!T("AaF"), 0) == -1);
             assert(indexOfAny(to!S("abba"), to!T("NSa"), 2) == 3);
@@ -1678,7 +1678,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
             assert(indexOfAny("\u0100", to!T("\u0100"), 0,
                 No.caseSensitive) == 0);
-        }();
+        }
 
         foreach (cs; EnumMembers!CaseSensitive)
         {
@@ -1757,8 +1757,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         auto r = to!S("").lastIndexOfAny("hello");
         assert(r == -1, to!string(r));
 
@@ -1767,7 +1767,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
         r = to!S("").lastIndexOfAny("");
         assert(r == -1, to!string(r));
-    }
+    }}
 }
 
 @safe pure unittest
@@ -1777,10 +1777,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             assert(lastIndexOfAny(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfAny(to!S("def"), to!T("rsa")) == -1);
             assert(lastIndexOfAny(to!S("abba"), to!T("a")) == 3);
@@ -1817,7 +1817,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
             assert(lastIndexOfAny("\u0100", to!T("\u0100"),
                 No.caseSensitive) == 0);
-        }();
+        }}
     }
     }
     );
@@ -1830,10 +1830,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
             assert(lastIndexOfAny(cast(S) null, to!T("a"), 1337) == -1,
@@ -1869,7 +1869,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
                 No.caseSensitive) == -1, typeStr);
             assert(lastIndexOfAny(to!S("ÖABCDEFCDEF"), to!T("ö"), 2,
                 No.caseSensitive) == 0, typeStr);
-        }();
+        }}
     }
     }
     );
@@ -1935,8 +1935,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         auto r = to!S("").indexOfNeither("hello");
         assert(r == -1, to!string(r));
 
@@ -1945,7 +1945,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
         r = to!S("").indexOfNeither("");
         assert(r == -1, to!string(r));
-    }
+    }}
 }
 
 @safe pure unittest
@@ -1955,10 +1955,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {
             assert(indexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(indexOfNeither("abba", "a") == 1);
 
@@ -1986,7 +1986,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
                     to!string(indexOfNeither(to!S("äDfEfffg"), to!T("ädFe"),
                     No.caseSensitive)));
             }
-        }();
+        }
     }
     }
     );
@@ -1999,10 +1999,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {
             assert(indexOfNeither(cast(S) null, to!T("a"), 1) == -1);
             assert(indexOfNeither(to!S("def"), to!T("a"), 1) == 1,
                 to!string(indexOfNeither(to!S("def"), to!T("a"), 1)));
@@ -2029,7 +2029,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
                     No.caseSensitive) == 2, to!string(indexOfNeither(
                     to!S("öDfEfffg"), to!T("äDi"), 2, No.caseSensitive)));
             }
-        }();
+        }
     }
     }
     );
@@ -2089,8 +2089,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
 {
     import std.conv : to;
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         auto r = to!S("").lastIndexOfNeither("hello");
         assert(r == -1, to!string(r));
 
@@ -2099,7 +2099,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
         r = to!S("").lastIndexOfNeither("");
         assert(r == -1, to!string(r));
-    }
+    }}
 }
 
 @safe pure unittest
@@ -2109,10 +2109,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             assert(lastIndexOfNeither(cast(S) null, to!T("a")) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("rsa")) == 2);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
@@ -2141,7 +2141,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
             assert(lastIndexOfNeither(to!S("dfeffgfffö"), to!T("BNDabCHIJKQEPÖÖSYXÄ??ß"),
                 No.caseSensitive) == 8, to!string(lastIndexOfNeither(to!S("dfeffgfffö"),
                 to!T("BNDabCHIJKQEPÖÖSYXÄ??ß"), No.caseSensitive)));
-        }();
+        }}
     }
     }
     );
@@ -2154,10 +2154,10 @@ if (isSomeChar!Char && isSomeChar!Char2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring))
+    static foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(string, wstring, dstring))
+        {{
             assert(lastIndexOfNeither(cast(S) null, to!T("a"), 1337) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("f")) == 1);
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("fgh")) == 2);
@@ -2185,7 +2185,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
             assert(lastIndexOfNeither(to!S("dfefffg"), to!T("NSA"), 2,
                 No.caseSensitive) == 1, to!string(lastIndexOfNeither(
                     to!S("dfefffg"), to!T("NSA"), 2, No.caseSensitive)));
-        }();
+        }}
     }
     }
     );
@@ -2233,10 +2233,10 @@ if (isSomeChar!Char)
         assert(representation(str) is cast(T[]) str);
     }
 
-    foreach (Type; AliasSeq!(Tuple!(char , ubyte ),
+    static foreach (Type; AliasSeq!(Tuple!(char , ubyte ),
                              Tuple!(wchar, ushort),
                              Tuple!(dchar, uint  )))
-    {
+    {{
         alias Char = Fields!Type[0];
         alias Int  = Fields!Type[1];
         enum immutable(Char)[] hello = "hello";
@@ -2246,7 +2246,7 @@ if (isSomeChar!Char)
         test!(             Char,              Int)(hello.dup);
         test!(      shared Char,       shared Int)(cast(shared) hello.dup);
         test!(const shared Char, const shared Int)(hello);
-    }
+    }}
     });
 }
 
@@ -2300,8 +2300,8 @@ if (!isSomeString!S && is(StringTypeOf!S))
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
+    {{
         S s1 = to!S("FoL");
         S s2;
 
@@ -2325,7 +2325,7 @@ if (!isSomeString!S && is(StringTypeOf!S))
         s2 = capitalize(s1);
         assert(cmp(s2, "\u0053 \u0069") == 0);
         assert(s2 !is s1);
-    }
+    }}
     });
 }
 
@@ -2472,8 +2472,8 @@ if (!isSomeString!S && is(StringTypeOf!S))
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    {{
         auto s = to!S(
             "\rpeter\n\rpaul\r\njerry\u2028ice\u2029cream\n\nsunday\n" ~
             "mon\u2030day\nschadenfreude\vkindergarten\f\vcookies\u0085"
@@ -2525,7 +2525,7 @@ if (!isSomeString!S && is(StringTypeOf!S))
         lines = splitLines(s, Yes.keepTerminator);
         assert(lines.length == 14);
         assert(lines[13] == "cookies");
-    }
+    }}
     });
 }
 
@@ -2721,8 +2721,8 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    {{
         auto s = to!S(
             "\rpeter\n\rpaul\r\njerry\u2028ice\u2029cream\n\n" ~
             "sunday\nmon\u2030day\nschadenfreude\vkindergarten\f\vcookies\u0085"
@@ -2775,7 +2775,7 @@ if (isConvertibleToString!Range)
         lines = lineSplitter!(Yes.keepTerminator)(s).array;
         assert(lines.length == 14);
         assert(lines[13] == "cookies");
-    }
+    }}
     });
 }
 
@@ -3034,7 +3034,7 @@ if (isConvertibleToString!Range)
     assert(stripRight("\u2028hello world\u2020\u2028".byChar).array == "\u2028hello world\u2020");
     assert(stripRight("hello world\U00010001"w.byWchar).array == "hello world\U00010001"w);
 
-    foreach (C; AliasSeq!(char, wchar, dchar))
+    static foreach (C; AliasSeq!(char, wchar, dchar))
     {
         foreach (s; invalidUTFstrings!C())
         {
@@ -3105,7 +3105,7 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!( char[], const  char[],  string,
+    static foreach (S; AliasSeq!( char[], const  char[],  string,
                           wchar[], const wchar[], wstring,
                           dchar[], const dchar[], dstring))
     {
@@ -3308,7 +3308,7 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         // @@@ BUG IN COMPILER, MUST INSERT CAST
         assert(chomp(cast(S) null) is null);
@@ -3328,8 +3328,8 @@ if (isConvertibleToString!Range)
         assert(chomp(to!S("hello\u2029\u2129")) == "hello\u2029\u2129");
         assert(chomp(to!S("hello\u2029\u0185")) == "hello\u2029\u0185");
 
-        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+        {
             // @@@ BUG IN COMPILER, MUST INSERT CAST
             assert(chomp(cast(S) null, cast(T) null) is null);
             assert(chomp(to!S("hello\n"), cast(T) null) == "hello");
@@ -3340,7 +3340,7 @@ if (isConvertibleToString!Range)
             assert(chomp(to!S("hello"), to!T("llo")) == "he");
             assert(chomp(to!S("\uFF28ello"), to!T("llo")) == "\uFF28e");
             assert(chomp(to!S("\uFF28el\uFF4co"), to!T("l\uFF4co")) == "\uFF28e");
-        }();
+        }
     }
     });
 
@@ -3431,16 +3431,16 @@ unittest
     import std.exception : assertCTFEable;
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
-        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+        {
             assert(equal(chompPrefix(to!S("abcdefgh"), to!T("abcde")), "fgh"));
             assert(equal(chompPrefix(to!S("abcde"), to!T("abcdefgh")), "abcde"));
             assert(equal(chompPrefix(to!S("\uFF28el\uFF4co"), to!T("\uFF28el\uFF4co")), ""));
             assert(equal(chompPrefix(to!S("\uFF28el\uFF4co"), to!T("\uFF28el")), "\uFF4co"));
             assert(equal(chompPrefix(to!S("\uFF28el"), to!T("\uFF28el\uFF4co")), "\uFF28el"));
-        }();
+        }
     }
     });
 
@@ -3597,7 +3597,7 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(chop(cast(S) null) is null);
         assert(equal(chop(to!S("hello")), "hell"));
@@ -3982,8 +3982,8 @@ unittest
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    {{
         S s = to!S("hello");
 
         assert(leftJustify(s, 2) == "hello");
@@ -4005,7 +4005,7 @@ unittest
         assert(leftJustify(s, 8, 'ö') == "helloööö");
         assert(rightJustify(s, 8, 'ö') == "öööhello");
         assert(center(s, 8, 'ö') == "öhelloöö");
-    }
+    }}
     });
 }
 
@@ -4320,8 +4320,8 @@ if (isConvertibleToString!Range)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    {{
         S s = to!S("This \tis\t a fofof\tof list");
         assert(cmp(detab(s), "This    is       a fofof        of list") == 0);
 
@@ -4338,7 +4338,7 @@ if (isConvertibleToString!Range)
         assert(detab("\u0085\t", 9) == "\u0085         ");
         assert(detab("\u2028\t", 9) == "\u2028         ");
         assert(detab(" \u2029\t", 9) == " \u2029         ");
-    }
+    }}
     });
 }
 
@@ -4772,10 +4772,10 @@ if (isSomeChar!C1 && isSomeChar!C2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
+    static foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
                           wchar[], const(wchar)[], immutable(wchar)[],
                           dchar[], const(dchar)[], immutable(dchar)[]))
-    {
+    {{
         assert(translate(to!S("hello world"), cast(dchar[dchar])['h' : 'q', 'l' : '5']) ==
                to!S("qe55o wor5d"));
         assert(translate(to!S("hello world"), cast(dchar[dchar])['o' : 'l', 'l' : '\U00010143']) ==
@@ -4786,13 +4786,13 @@ if (isSomeChar!C1 && isSomeChar!C2)
                to!S("hell0 o w0rld"));
         assert(translate(to!S("hello world"), cast(dchar[dchar]) null) == to!S("hello world"));
 
-        foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
+        static foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            foreach (R; AliasSeq!(dchar[dchar], const dchar[dchar],
+        {
+            static foreach (R; AliasSeq!(dchar[dchar], const dchar[dchar],
                         immutable dchar[dchar]))
-            {
+            {{
                 R tt = ['h' : 'q', 'l' : '5'];
                 assert(translate(to!S("hello world"), tt, to!T("r"))
                     == to!S("qe55o wo5d"));
@@ -4800,14 +4800,14 @@ if (isSomeChar!C1 && isSomeChar!C2)
                     == to!S(" wrd"));
                 assert(translate(to!S("hello world"), tt, to!T("q5"))
                     == to!S("qe55o wor5d"));
-            }
-        }();
+            }}
+        }
 
         auto s = to!S("hello world");
         dchar[dchar] transTable = ['h' : 'q', 'l' : '5'];
         static assert(is(typeof(s) == typeof(translate(s, transTable))));
         assert(translate(s, transTable) == "qe55o wor5d");
-    }
+    }}
     });
 }
 
@@ -4830,10 +4830,10 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
 
     assertCTFEable!(
     {
-    foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
+    static foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
                           wchar[], const(wchar)[], immutable(wchar)[],
                           dchar[], const(dchar)[], immutable(dchar)[]))
-    {
+    {{
         assert(translate(to!S("hello world"), ['h' : "yellow", 'l' : "42"]) ==
                to!S("yellowe4242o wor42d"));
         assert(translate(to!S("hello world"), ['o' : "owl", 'l' : "\U00010143\U00010143"]) ==
@@ -4848,14 +4848,14 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
                to!S("hello  world"));
         assert(translate(to!S("hello world"), cast(string[dchar]) null) == to!S("hello world"));
 
-        foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
+        static foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        {
 
-            foreach (R; AliasSeq!(string[dchar], const string[dchar],
+            static foreach (R; AliasSeq!(string[dchar], const string[dchar],
                         immutable string[dchar]))
-            {
+            {{
                 R tt = ['h' : "yellow", 'l' : "42"];
                 assert(translate(to!S("hello world"), tt, to!T("r")) ==
                        to!S("yellowe4242o wo42d"));
@@ -4867,14 +4867,14 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
                        to!S(""));
                 assert(translate(to!S("hello world"), tt, to!T("42")) ==
                        to!S("yellowe4242o wor42d"));
-            }
-        }();
+            }}
+        }
 
         auto s = to!S("hello world");
         string[dchar] transTable = ['h' : "silly", 'l' : "putty"];
         static assert(is(typeof(s) == typeof(translate(s, transTable))));
         assert(translate(s, transTable) == "sillyeputtyputtyo worputtyd");
-    }
+    }}
     });
 }
 
@@ -5094,17 +5094,17 @@ do
 
     assertCTFEable!(
     {
-    foreach (C; AliasSeq!(char, const char, immutable char))
-    {
+    static foreach (C; AliasSeq!(char, const char, immutable char))
+    {{
         assert(translate!C("hello world", makeTransTable("hl", "q5")) == to!(C[])("qe55o wor5d"));
 
         auto s = to!(C[])("hello world");
         auto transTable = makeTransTable("hl", "q5");
         static assert(is(typeof(s) == typeof(translate!C(s, transTable))));
         assert(translate(s, transTable) == "qe55o wor5d");
-    }
+    }}
 
-    foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[]))
+    static foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[]))
     {
         assert(translate(to!S("hello world"), makeTransTable("hl", "q5")) == to!S("qe55o wor5d"));
         assert(translate(to!S("hello \U00010143 world"), makeTransTable("hl", "q5")) ==
@@ -5115,8 +5115,8 @@ do
         assert(translate(to!S("hello \U00010143 world"), makeTransTable("12345", "67890")) ==
                to!S("hello \U00010143 world"));
 
-        foreach (T; AliasSeq!(char[], const(char)[], immutable(char)[]))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(char[], const(char)[], immutable(char)[]))
+        {
             assert(translate(to!S("hello world"), makeTransTable("hl", "q5"), to!T("r")) ==
                    to!S("qe55o wo5d"));
             assert(translate(to!S("hello \U00010143 world"), makeTransTable("hl", "q5"), to!T("r")) ==
@@ -5125,7 +5125,7 @@ do
                    to!S(" wrd"));
             assert(translate(to!S("hello world"), makeTransTable("hl", "q5"), to!T("q5")) ==
                    to!S("qe55o wor5d"));
-        }();
+        }
     }
     });
 }
@@ -6033,7 +6033,7 @@ if (isSomeString!S ||
 {
     import std.conv : to;
 
-    foreach (T; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
+    static foreach (T; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
     {
         assert("123".to!T.isNumeric());
         assert("123UL".to!T.isNumeric());
@@ -6811,8 +6811,8 @@ if (isSomeString!S)
     assertCTFEable!(
     {
 
-    foreach (S; AliasSeq!(string, wstring, dstring))
-    {
+    static foreach (S; AliasSeq!(string, wstring, dstring))
+    {{
         enum S blank = "";
         assert(blank.outdent() == blank);
         static assert(blank.outdent() == blank);
@@ -6868,7 +6868,7 @@ if (isSomeString!S)
         enum expected7 = "a \nb ";
         assert(testStr7.outdent() == expected7);
         static assert(testStr7.outdent() == expected7);
-    }
+    }}
     });
 }
 
@@ -6920,8 +6920,8 @@ if (staticIndexOf!(Unqual!T, ubyte, ushort, uint) != -1)
 pure @system unittest
 {
     import std.algorithm.comparison : equal;
-    foreach (T; AliasSeq!(char[], wchar[], dchar[]))
-    {
+    static foreach (T; AliasSeq!(char[], wchar[], dchar[]))
+    {{
         immutable T jti = "Hello World";
         T jt = jti.dup;
 
@@ -6950,5 +6950,5 @@ pure @system unittest
         assert(equal(jt, ht));
         assert(equal(jt, htc));
         assert(equal(jt, hti));
-    }
+    }}
 }

--- a/std/traits.d
+++ b/std/traits.d
@@ -1104,7 +1104,7 @@ template extractParameterStorageClassFlags(Attribs...)
         auto result = ParameterStorageClass.none;
         static if (Attribs.length > 0)
         {
-            foreach (attrib; [Attribs])
+            static foreach (attrib; Attribs)
             {
                 final switch (attrib) with (ParameterStorageClass)
                 {
@@ -1341,7 +1341,7 @@ template ParameterDefaults(func...)
     }
     alias Voids = ParameterDefaults!func;
     static assert(Voids.length == 12);
-    foreach (V; Voids) static assert(is(V == void));
+    static foreach (V; Voids) static assert(is(V == void));
 }
 
 /**
@@ -1555,7 +1555,7 @@ private FunctionAttribute extractAttribFlags(Attribs...)()
 {
     auto res = FunctionAttribute.none;
 
-    foreach (attrib; Attribs)
+    static foreach (attrib; Attribs)
     {
         switch (attrib) with (FunctionAttribute)
         {
@@ -1601,7 +1601,7 @@ template hasFunctionAttributes(args...)
         import std.algorithm.searching : canFind;
         import std.range : only;
         enum funcAttribs = only(__traits(getFunctionAttributes, args[0]));
-        foreach (attribute; args[1 .. $])
+        static foreach (attribute; args[1 .. $])
         {
             if (!funcAttribs.canFind(attribute))
                 return false;
@@ -2256,11 +2256,11 @@ version (unittest)
     import std.algorithm.iteration : reduce;
 
     alias FA = FunctionAttribute;
-    foreach (BaseT; AliasSeq!(typeof(&sc), typeof(&novar), typeof(&cstyle),
+    static foreach (BaseT; AliasSeq!(typeof(&sc), typeof(&novar), typeof(&cstyle),
         typeof(&dstyle), typeof(&typesafe)))
     {
-        foreach (T; AliasSeq!(BaseT, FunctionTypeOf!BaseT))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+        static foreach (T; AliasSeq!(BaseT, FunctionTypeOf!BaseT))
+        {{
             enum linkage = functionLinkage!T;
             enum attrs = functionAttributes!T;
 
@@ -2270,13 +2270,13 @@ version (unittest)
             // Check that all linkage types work (D-style variadics require D linkage).
             static if (variadicFunctionStyle!T != Variadic.d)
             {
-                foreach (newLinkage; AliasSeq!("D", "C", "Windows", "Pascal", "C++"))
-                {
+                static foreach (newLinkage; AliasSeq!("D", "C", "Windows", "Pascal", "C++"))
+                {{
                     alias New = SetFunctionAttributes!(T, newLinkage, attrs);
                     static assert(functionLinkage!New == newLinkage,
                         "Linkage test failed for: " ~ T.stringof ~ ", " ~ newLinkage ~
                         " (got " ~ New.stringof ~ ")");
-                }
+                }}
             }
 
             // Add @safe.
@@ -2294,7 +2294,7 @@ version (unittest)
             // Strip all attributes again.
             alias T3 = SetFunctionAttributes!(T2, functionLinkage!T, FA.none);
             static assert(is(T3 == T));
-        }();
+        }}
     }
 }
 
@@ -3856,7 +3856,7 @@ assert(sqrts == [ Sqrts.one, Sqrts.two, Sqrts.three ]);
 size_t rank(E)(E e)
     if (is(E == enum))
 {
-    foreach (i, member; EnumMembers!E)
+    static foreach (i, member; EnumMembers!E)
     {
         if (e == member)
             return i;
@@ -5121,7 +5121,7 @@ int i = rvalueOf!int; // error, no actual value is returned
     static struct S { }
     int i;
     struct Nested { void f() { ++i; } }
-    foreach (T; AliasSeq!(int, immutable int, inout int, string, S, Nested, Object))
+    static foreach (T; AliasSeq!(int, immutable int, inout int, string, S, Nested, Object))
     {
         static assert(!__traits(compiles, needLvalue(rvalueOf!T)));
         static assert( __traits(compiles, needLvalue(lvalueOf!T)));
@@ -5171,15 +5171,15 @@ template BooleanTypeOf(T)
 @safe unittest
 {
     // unexpected failure, maybe dmd type-merging bug
-    foreach (T; AliasSeq!bool)
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!bool)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( is(Q!T == BooleanTypeOf!(            Q!T  )));
             static assert( is(Q!T == BooleanTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(void, NumericTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(void, NumericTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(BooleanTypeOf!(            Q!T  )), Q!T.stringof);
             static assert(!is(BooleanTypeOf!( SubTypeOf!(Q!T) )));
@@ -5222,15 +5222,15 @@ template IntegralTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; IntegralTypeList)
-        foreach (Q; TypeQualifierList)
+    static foreach (T; IntegralTypeList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( is(Q!T == IntegralTypeOf!(            Q!T  )));
             static assert( is(Q!T == IntegralTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(void, bool, FloatingPointTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(void, bool, FloatingPointTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(IntegralTypeOf!(            Q!T  )));
             static assert(!is(IntegralTypeOf!( SubTypeOf!(Q!T) )));
@@ -5257,15 +5257,15 @@ template FloatingPointTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; FloatingPointTypeList)
-        foreach (Q; TypeQualifierList)
+    static foreach (T; FloatingPointTypeList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( is(Q!T == FloatingPointTypeOf!(            Q!T  )));
             static assert( is(Q!T == FloatingPointTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(void, bool, IntegralTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(void, bool, IntegralTypeList, ImaginaryTypeList, ComplexTypeList, CharTypeList))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(FloatingPointTypeOf!(            Q!T  )));
             static assert(!is(FloatingPointTypeOf!( SubTypeOf!(Q!T) )));
@@ -5286,15 +5286,15 @@ template NumericTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; NumericTypeList)
-        foreach (Q; TypeQualifierList)
+    static foreach (T; NumericTypeList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( is(Q!T == NumericTypeOf!(            Q!T  )));
             static assert( is(Q!T == NumericTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(void, bool, CharTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(void, bool, CharTypeList, ImaginaryTypeList, ComplexTypeList))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(NumericTypeOf!(            Q!T  )));
             static assert(!is(NumericTypeOf!( SubTypeOf!(Q!T) )));
@@ -5347,22 +5347,22 @@ template CharTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; CharTypeList)
-        foreach (Q; TypeQualifierList)
+    static foreach (T; CharTypeList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( is(CharTypeOf!(            Q!T  )));
             static assert( is(CharTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(void, bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(void, bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(CharTypeOf!(            Q!T  )));
             static assert(!is(CharTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    foreach (T; AliasSeq!(string, wstring, dstring, char[4]))
-        foreach (Q; TypeQualifierList)
+    static foreach (T; AliasSeq!(string, wstring, dstring, char[4]))
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!is(CharTypeOf!(            Q!T  )));
             static assert(!is(CharTypeOf!( SubTypeOf!(Q!T) )));
@@ -5386,19 +5386,19 @@ template StaticArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+    static foreach (T; AliasSeq!(bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+        static foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
         {
             static assert(is( Q!(   T[1] ) == StaticArrayTypeOf!( Q!(              T[1]  ) ) ));
 
-            foreach (P; TypeQualifierList)
+            static foreach (P; TypeQualifierList)
             { // SubTypeOf cannot have inout type
                 static assert(is( Q!(P!(T[1])) == StaticArrayTypeOf!( Q!(SubTypeOf!(P!(T[1]))) ) ));
             }
         }
 
-    foreach (T; AliasSeq!void)
-        foreach (Q; AliasSeq!TypeQualifierList)
+    static foreach (T; AliasSeq!void)
+        static foreach (Q; AliasSeq!TypeQualifierList)
         {
             static assert(is( StaticArrayTypeOf!( Q!(void[1]) ) == Q!(void[1]) ));
         }
@@ -5423,13 +5423,13 @@ template DynamicArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
-        foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+    static foreach (T; AliasSeq!(/*void, */bool, NumericTypeList, ImaginaryTypeList, ComplexTypeList))
+        static foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
         {
             static assert(is( Q!T[]  == DynamicArrayTypeOf!( Q!T[] ) ));
             static assert(is( Q!(T[])  == DynamicArrayTypeOf!( Q!(T[]) ) ));
 
-            foreach (P; AliasSeq!(MutableOf, ConstOf, ImmutableOf))
+            static foreach (P; AliasSeq!(MutableOf, ConstOf, ImmutableOf))
             {
                 static assert(is( Q!(P!T[]) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!T[])) ) ));
                 static assert(is( Q!(P!(T[])) == DynamicArrayTypeOf!( Q!(SubTypeOf!(P!(T[]))) ) ));
@@ -5478,23 +5478,23 @@ template StringTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; CharTypeList)
-        foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf, InoutOf))
+    static foreach (T; CharTypeList)
+        static foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf, InoutOf))
         {
             static assert(is(Q!T[] == StringTypeOf!( Q!T[] )));
 
             static if (!__traits(isSame, Q, InoutOf))
-            {
+            {{
                 static assert(is(Q!T[] == StringTypeOf!( SubTypeOf!(Q!T[]) )));
 
                 alias Str = Q!T[];
                 class C(S) { S val;  alias val this; }
                 static assert(is(StringTypeOf!(C!Str) == Str));
-            }
+            }}
         }
 
-    foreach (T; CharTypeList)
-        foreach (Q; AliasSeq!(SharedOf, SharedConstOf, SharedInoutOf))
+    static foreach (T; CharTypeList)
+        static foreach (Q; AliasSeq!(SharedOf, SharedConstOf, SharedInoutOf))
         {
             static assert(!is(StringTypeOf!( Q!T[] )));
         }
@@ -5524,19 +5524,19 @@ template AssocArrayTypeOf(T)
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-        foreach (P; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
-            foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
-                foreach (R; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+    static foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
+        static foreach (P; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+            static foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+                static foreach (R; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
                 {
                     static assert(is( P!(Q!T[R!T]) == AssocArrayTypeOf!(            P!(Q!T[R!T])  ) ));
                 }
 
-    foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
-        foreach (O; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
-            foreach (P; AliasSeq!TypeQualifierList)
-                foreach (Q; AliasSeq!TypeQualifierList)
-                    foreach (R; AliasSeq!TypeQualifierList)
+    static foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
+        static foreach (O; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
+            static foreach (P; AliasSeq!TypeQualifierList)
+                static foreach (Q; AliasSeq!TypeQualifierList)
+                    static foreach (R; AliasSeq!TypeQualifierList)
                     {
                         static assert(is( O!(P!(Q!T[R!T])) == AssocArrayTypeOf!( O!(SubTypeOf!(P!(Q!T[R!T]))) ) ));
                     }
@@ -5622,9 +5622,9 @@ enum bool isIntegral(T) = is(IntegralTypeOf!T) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; IntegralTypeList)
+    static foreach (T; IntegralTypeList)
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isIntegral!(Q!T));
             static assert(!isIntegral!(SubTypeOf!(Q!T)));
@@ -5682,17 +5682,17 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !(is(Unqual!T == cfloa
 {
     enum EF : real { a = 1.414, b = 1.732, c = 2.236 }
 
-    foreach (T; AliasSeq!(FloatingPointTypeList, EF))
+    static foreach (T; AliasSeq!(FloatingPointTypeList, EF))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isFloatingPoint!(Q!T));
             static assert(!isFloatingPoint!(SubTypeOf!(Q!T)));
         }
     }
-    foreach (T; IntegralTypeList)
+    static foreach (T; IntegralTypeList)
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!isFloatingPoint!(Q!T));
         }
@@ -5755,9 +5755,9 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == bool) ||
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(NumericTypeList))
+    static foreach (T; AliasSeq!(NumericTypeList))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isNumeric!(Q!T));
             static assert(!isNumeric!(SubTypeOf!(Q!T)));
@@ -5856,9 +5856,9 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(UnsignedIntTypeList))
+    static foreach (T; AliasSeq!(UnsignedIntTypeList))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isUnsigned!(Q!T));
             static assert(!isUnsigned!(SubTypeOf!(Q!T)));
@@ -5900,9 +5900,9 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
     enum Eubyte : ubyte { e1 = 0 }
     static assert(!isSigned!Eubyte);
 
-    foreach (T; AliasSeq!(SignedIntTypeList))
+    static foreach (T; AliasSeq!(SignedIntTypeList))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isSigned!(Q!T));
             static assert(!isSigned!(SubTypeOf!(Q!T)));
@@ -5956,9 +5956,9 @@ enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
 {
     enum EC : char { a = 'x', b = 'y' }
 
-    foreach (T; AliasSeq!(CharTypeList, EC))
+    static foreach (T; AliasSeq!(CharTypeList, EC))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isSomeChar!(            Q!T  ));
             static assert(!isSomeChar!( SubTypeOf!(Q!T) ));
@@ -6008,7 +6008,7 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(char[], dchar[], string, wstring, dstring))
+    static foreach (T; AliasSeq!(char[], dchar[], string, wstring, dstring))
     {
         static assert( isSomeString!(           T ));
         static assert(!isSomeString!(SubTypeOf!(T)));
@@ -6037,18 +6037,18 @@ enum bool isNarrowString(T) = (is(T : const char[]) || is(T : const wchar[])) &&
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(char[], string, wstring))
+    static foreach (T; AliasSeq!(char[], string, wstring))
     {
-        foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
+        static foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf)/*TypeQualifierList*/)
         {
             static assert( isNarrowString!(            Q!T  ));
             static assert(!isNarrowString!( SubTypeOf!(Q!T) ));
         }
     }
 
-    foreach (T; AliasSeq!(int, int[], byte[], dchar[], dstring, char[4]))
+    static foreach (T; AliasSeq!(int, int[], byte[], dchar[], dstring, char[4]))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert(!isNarrowString!(            Q!T  ));
             static assert(!isNarrowString!( SubTypeOf!(Q!T) ));
@@ -6210,11 +6210,11 @@ enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int[51], int[][2],
+    static foreach (T; AliasSeq!(int[51], int[][2],
                            char[][int][11], immutable char[13u],
                            const(real)[1], const(real)[1][1], void[0]))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isStaticArray!(            Q!T  ));
             static assert(!isStaticArray!( SubTypeOf!(Q!T) ));
@@ -6244,9 +6244,9 @@ enum bool isDynamicArray(T) = is(DynamicArrayTypeOf!T) && !isAggregateType!T;
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(int[], char[], string, long[3][], double[string][]))
+    static foreach (T; AliasSeq!(int[], char[], string, long[3][], double[string][]))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isDynamicArray!(            Q!T  ));
             static assert(!isDynamicArray!( SubTypeOf!(Q!T) ));
@@ -6275,9 +6275,9 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 @safe unittest
 {
     import std.meta : AliasSeq;
-    foreach (T; AliasSeq!(int[], int[5], void[]))
+    static foreach (T; AliasSeq!(int[], int[5], void[]))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isArray!(Q!T));
             static assert(!isArray!(SubTypeOf!(Q!T)));
@@ -6298,9 +6298,9 @@ enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
         @property uint[] values() { return null; }
     }
 
-    foreach (T; AliasSeq!(int[int], int[string], immutable(char[5])[int]))
+    static foreach (T; AliasSeq!(int[int], int[string], immutable(char[5])[int]))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isAssociativeArray!(Q!T));
             static assert(!isAssociativeArray!(SubTypeOf!(Q!T)));
@@ -6364,9 +6364,9 @@ enum bool isPointer(T) = is(T == U*, U) && !isAggregateType!T;
 
 @safe unittest
 {
-    foreach (T; AliasSeq!(int*, void*, char[]*))
+    static foreach (T; AliasSeq!(int*, void*, char[]*))
     {
-        foreach (Q; TypeQualifierList)
+        static foreach (Q; TypeQualifierList)
         {
             static assert( isPointer!(Q!T));
             static assert(!isPointer!(SubTypeOf!(Q!T)));
@@ -7351,10 +7351,10 @@ template mostNegative(T)
 {
     import std.meta : AliasSeq;
 
-    foreach (T; AliasSeq!(bool, byte, short, int, long))
+    static foreach (T; AliasSeq!(bool, byte, short, int, long))
         static assert(mostNegative!T == T.min);
 
-    foreach (T; AliasSeq!(ubyte, ushort, uint, ulong, char, wchar, dchar))
+    static foreach (T; AliasSeq!(ubyte, ushort, uint, ulong, char, wchar, dchar))
         static assert(mostNegative!T == 0);
 }
 
@@ -7383,14 +7383,14 @@ template Promoted(T)
 @safe unittest
 {
     // promote to int:
-    foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, char, wchar))
+    static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, char, wchar))
     {
         static assert(is(Promoted!T == int));
         static assert(is(Promoted!(shared(const T)) == shared(const int)));
     }
 
     // already promoted:
-    foreach (T; AliasSeq!(int, uint, long, ulong, float, double, real))
+    static foreach (T; AliasSeq!(int, uint, long, ulong, float, double, real))
     {
         static assert(is(Promoted!T == T));
         static assert(is(Promoted!(immutable(T)) == immutable(T)));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1638,8 +1638,8 @@ private template ReverseTupleSpecs(T...)
               inout V wv;   // OK <- NG
         inout const V wcv;  // OK <- NG
 
-        foreach (v1; AliasSeq!(mv, cv, iv, wv, wcv))
-        foreach (v2; AliasSeq!(mv, cv, iv, wv, wcv))
+        static foreach (v1; AliasSeq!(mv, cv, iv, wv, wcv))
+        static foreach (v2; AliasSeq!(mv, cv, iv, wv, wcv))
         {
             assert(!(v1 < v2));
         }
@@ -2167,7 +2167,7 @@ Rebindable!T rebindable(T)(Rebindable!T obj)
     immutable(char[]) s7654;
     Rebindable!(typeof(s7654)) r7654 = s7654;
 
-    foreach (T; AliasSeq!(char, wchar, char, int))
+    static foreach (T; AliasSeq!(char, wchar, char, int))
     {
         static assert(is(Rebindable!(immutable(T[])) == immutable(T)[]));
         static assert(is(Rebindable!(const(T[])) == const(T)[]));
@@ -2848,13 +2848,13 @@ auto nullable(T)(T t)
             ni = other.ni;
         }
     }
-    foreach (S; AliasSeq!(S1, S2))
-    {
+    static foreach (S; AliasSeq!(S1, S2))
+    {{
         S a;
         S b = a;
         S c;
         c = a;
-    }
+    }}
 }
 @system unittest
 {
@@ -3050,8 +3050,8 @@ Returns:
 // disable test until https://issues.dlang.org/show_bug.cgi?id=15316 gets fixed
 version (none) @system unittest
 {
-    foreach (T; AliasSeq!(float, double, real))
-    {
+    static foreach (T; AliasSeq!(float, double, real))
+    {{
         Nullable!(T, T.init) nf;
         //Initialized to "null" state
         assert(nf.isNull);
@@ -3062,7 +3062,7 @@ version (none) @system unittest
 
         nf.nullify();
         assert(nf.isNull);
-    }
+    }}
 }
 
 /**
@@ -3279,13 +3279,13 @@ auto nullable(alias nullValue, T)(T t)
             ni = other.ni;
         }
     }
-    foreach (S; AliasSeq!(S1, S2))
-    {
+    static foreach (S; AliasSeq!(S1, S2))
+    {{
         S a;
         S b = a;
         S c;
         c = a;
-    }
+    }}
 }
 @system unittest
 {
@@ -3588,13 +3588,13 @@ auto nullableRef(T)(T* t)
             ni = other.ni;
         }
     }
-    foreach (S; AliasSeq!(S1, S2))
-    {
+    static foreach (S; AliasSeq!(S1, S2))
+    {{
         S a;
         S b = a;
         S c;
         c = a;
-    }
+    }}
 }
 @system unittest
 {
@@ -6183,8 +6183,8 @@ mixin template Proxy(alias a)
         static immutable arr = [1,2,3];
     }
 
-    foreach (T; AliasSeq!(MyInt, const MyInt, immutable MyInt))
-    {
+    static foreach (T; AliasSeq!(MyInt, const MyInt, immutable MyInt))
+    {{
         T m = 10;
         static assert(!__traits(compiles, { int x = m; }));
         static assert(!__traits(compiles, { void func(int n){} func(m); }));
@@ -6216,7 +6216,7 @@ mixin template Proxy(alias a)
         static assert(T.init == int.init);
         static assert(T.str == "str");
         static assert(T.arr == [1,2,3]);
-    }
+    }}
 }
 @system unittest
 {
@@ -6228,8 +6228,8 @@ mixin template Proxy(alias a)
         this(immutable int[] arr) immutable { value = arr; }
     }
 
-    foreach (T; AliasSeq!(MyArray, const MyArray, immutable MyArray))
-    {
+    static foreach (T; AliasSeq!(MyArray, const MyArray, immutable MyArray))
+    {{
       static if (is(T == immutable) && !is(typeof({ T a = [1,2,3,4]; })))
         T a = [1,2,3,4].idup;   // workaround until qualified ctor is properly supported
       else
@@ -6256,7 +6256,7 @@ mixin template Proxy(alias a)
             a[]     *= 2;   assert(a == [8,4,4,2]);
             a[0 .. 2] /= 2;   assert(a == [4,2,4,2]);
         }
-    }
+    }}
 }
 @system unittest
 {
@@ -6536,11 +6536,11 @@ mixin template Proxy(alias a)
         assert(!(a>b));
         assert(!(a >= b));
     }
-    foreach (T1; AliasSeq!(MyFloatImpl, Typedef!float, Typedef!double,
+    static foreach (T1; AliasSeq!(MyFloatImpl, Typedef!float, Typedef!double,
         float, real, Typedef!int, int))
     {
-        foreach (T2; AliasSeq!(MyFloatImpl, Typedef!float))
-        {
+        static foreach (T2; AliasSeq!(MyFloatImpl, Typedef!float))
+        {{
             T1 a;
             T2 b;
 
@@ -6562,7 +6562,7 @@ mixin template Proxy(alias a)
             assert(a <= b);
             assert(!(a>b));
             assert(a >= b);
-        }
+        }}
     }
 }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -878,7 +878,7 @@ size_t replicateBits(size_t times, size_t bits)(size_t val) @safe pure nothrow @
     import std.range : iota;
     size_t m = 0b111;
     size_t m2 = 0b01;
-    foreach (i; AliasSeq!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    static foreach (i; AliasSeq!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
     {
         assert(replicateBits!(i, 3)(m)+1 == (1<<(3*i)));
         assert(replicateBits!(i, 2)(m2) == iota(0, i).map!"2^^(2*a)"().sum());
@@ -3457,8 +3457,8 @@ private:
         assert(u24 != u24_2);
     }
 
-    foreach (Policy; AliasSeq!(GcPolicy, ReallocPolicy))
-    {
+    static foreach (Policy; AliasSeq!(GcPolicy, ReallocPolicy))
+    {{
         alias Range = typeof(CowArray!Policy.init[]);
         alias U24A = CowArray!Policy;
         static assert(isForwardRange!Range);
@@ -3490,7 +3490,7 @@ private:
         copy(iota(10, 170, 2), r2[10 .. 90]);
         assert(equal(r2[], chain(iota(0, 10), iota(10, 170, 2), iota(90, 100)))
                , text(r2[]));
-    }
+    }}
 }
 
 version(unittest)
@@ -3738,8 +3738,8 @@ version(unittest)
     import std.conv : text;
     import std.typecons : tuple, Tuple;
 
-    foreach (CodeList; AliasSeq!(InversionList!(ReallocPolicy)))
-    {
+    static foreach (CodeList; AliasSeq!(InversionList!(ReallocPolicy)))
+    {{
         auto arr = "ABCDEFGHIJKLMabcdefghijklm"d;
         auto a = CodeList('A','N','a', 'n');
         assert(equal(a.byInterval,
@@ -3769,7 +3769,7 @@ version(unittest)
         }
         assert(equal(CodepointSet.init.byInterval, cast(Tuple!(uint, uint)[])[]));
         assert(equal(CodepointSet.init.byCodepoint, cast(dchar[])[]));
-    }
+    }}
 }
 
 //============================================================================
@@ -7236,8 +7236,8 @@ private static struct InputRangeString
     auto gReverse = reverse.byGrapheme;
     assert(gReverse.walkLength == 4);
 
-    foreach (text; AliasSeq!("noe\u0308l"c, "noe\u0308l"w, "noe\u0308l"d))
-    {
+    static foreach (text; AliasSeq!("noe\u0308l"c, "noe\u0308l"w, "noe\u0308l"d))
+    {{
         assert(text.walkLength == 5);
         static assert(isForwardRange!(typeof(text)));
 
@@ -7245,7 +7245,7 @@ private static struct InputRangeString
         static assert(isForwardRange!(typeof(gText)));
         assert(gText.walkLength == 4);
         assert(gText.array.retro.equal(gReverse));
-    }
+    }}
 
     auto nonForwardRange = InputRangeString("noe\u0308l").byGrapheme;
     static assert(!isForwardRange!(typeof(nonForwardRange)));
@@ -7976,11 +7976,11 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
     import std.exception : assertCTFEable;
     assertCTFEable!(
     {
-    foreach (cfunc; AliasSeq!(icmp, sicmp))
-    {
-        foreach (S1; AliasSeq!(string, wstring, dstring))
-        foreach (S2; AliasSeq!(string, wstring, dstring))
-        (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+    static foreach (cfunc; AliasSeq!(icmp, sicmp))
+    {{
+        static foreach (S1; AliasSeq!(string, wstring, dstring))
+        static foreach (S2; AliasSeq!(string, wstring, dstring))
+        {
             assert(cfunc("".to!S1(), "".to!S2()) == 0);
             assert(cfunc("A".to!S1(), "".to!S2()) > 0);
             assert(cfunc("".to!S1(), "0".to!S2()) < 0);
@@ -7992,12 +7992,12 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
             // Check example:
             assert(cfunc("Август".to!S1(), "авгусТ".to!S2()) == 0);
             assert(cfunc("ΌΎ".to!S1(), "όύ".to!S2()) == 0);
-        }();
+        }
         // check that the order is properly agnostic to the case
         auto strs = [ "Apple", "ORANGE",  "orAcle", "amp", "banana"];
         sort!((a,b) => cfunc(a,b) < 0)(strs);
         assert(strs == ["amp", "Apple",  "banana", "orAcle", "ORANGE"]);
-    }
+    }}
     assert(icmp("ßb", "ssa") > 0);
     // Check example:
     assert(icmp("Russland", "Rußland") == 0);
@@ -9941,8 +9941,8 @@ if (isSomeString!S)
         assert(upInp == trueUp,
             format(diff, cast(ubyte[]) s, cast(ubyte[]) upInp, cast(ubyte[]) trueUp));
     }
-    foreach (S; AliasSeq!(dstring, wstring, string))
-    {
+    static foreach (S; AliasSeq!(dstring, wstring, string))
+    {{
 
         S easy = "123";
         S good = "abCФеж";
@@ -9952,7 +9952,7 @@ if (isSomeString!S)
         S[] lower = ["123", "abcфеж", "\u0131\u023f\u03c9", "i\u0307\u1Fe2"];
         S[] upper = ["123", "ABCФЕЖ", "I\u2c7e\u2126", "\u0130\u03A5\u0308\u0300"];
 
-        foreach (val; AliasSeq!(easy, good))
+        foreach (val; [easy, good])
         {
             auto e = val.dup;
             auto g = e;
@@ -9978,7 +9978,7 @@ if (isSomeString!S)
             doTest(sample2, upper[k] ~ upper[j] ~ upper[i],
                 lower[k] ~ lower[j] ~ lower[i]);
         }
-    }
+    }}
 }
 
 

--- a/std/uri.d
+++ b/std/uri.d
@@ -574,8 +574,8 @@ if (isSomeChar!Char)
     debug(uri) writeln(result);
 
     import std.meta : AliasSeq;
-    foreach (StringType; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    static foreach (StringType; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
+    {{
         import std.conv : to;
         StringType decoded1 = source.to!StringType;
         string encoded1 = encode(decoded1);
@@ -588,5 +588,5 @@ if (isSomeChar!Char)
         assert(encoded2 == target.to!StringType); // check that `encoded2` wasn't changed
         assert(decoded2 == source);
         assert(encoded2 == encode(decoded2).to!StringType);
-    }
+    }}
 }

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -404,13 +404,13 @@ public struct UUID
         {
             import std.conv : to;
             import std.exception;
-            import std.meta;
+            import std.meta : AliasSeq;
 
-            foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[],
+            static foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[],
                                   wchar[], const(wchar)[], immutable(wchar)[],
                                   dchar[], const(dchar)[], immutable(dchar)[],
                                   immutable(char[]), immutable(wchar[]), immutable(dchar[])))
-            {
+            {{
                 //Test valid, working cases
                 assert(UUID(to!S("00000000-0000-0000-0000-000000000000")).empty);
 
@@ -456,7 +456,7 @@ public struct UUID
                     == UUID(cast(ubyte[16])[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,0x01,
                     0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]));
             }
-        }
+        }}
 
         /**
          * Returns true if and only if the UUID is equal
@@ -911,8 +911,8 @@ public struct UUID
         @safe pure nothrow @nogc unittest
         {
             import std.meta : AliasSeq;
-            foreach (Char; AliasSeq!(char, wchar, dchar))
-            {
+            static foreach (Char; AliasSeq!(char, wchar, dchar))
+            {{
                 alias String = immutable(Char)[];
                 //CTFE
                 enum String s = "8ab3060e-2cba-4f23-b74c-b52db3bdfb46";
@@ -926,7 +926,7 @@ public struct UUID
                 Char[36] str;
                 id.toString(str[]);
                 assert(str == s);
-            }
+            }}
         }
 
         @system pure nothrow @nogc unittest
@@ -1527,12 +1527,12 @@ if (isInputRange!Range
             return parseUUID(to!T(input));
     }
 
-    foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[],
+    static foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[],
                           wchar[], const(wchar)[], immutable(wchar)[],
                           dchar[], const(dchar)[], immutable(dchar)[],
                           immutable(char[]), immutable(wchar[]), immutable(dchar[]),
                           TestForwardRange, TestInputRange))
-    {
+    {{
         //Verify examples.
         auto id = parseHelper!S("8AB3060E-2CBA-4F23-b74c-B52Db3BDFB46");
         //no dashes
@@ -1608,7 +1608,7 @@ if (isInputRange!Range
         //multiple trailing/leading characters
         assert(parseHelper!S("///8ab3060e2cba4f23b74cb52db3bdfb46||")
             == parseUUID("8ab3060e-2cba-4f23-b74c-b52db3bdfb46"));
-    }
+    }}
 }
 
 /**

--- a/std/variant.d
+++ b/std/variant.d
@@ -2487,24 +2487,24 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     int i = 10;
     v = i;
-    foreach (qual; AliasSeq!(MutableOf, ConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ConstOf))
     {
         assert(v.get!(qual!int) == 10);
         assert(v.get!(qual!float) == 10.0f);
     }
-    foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!int));
     }
 
     const(int) ci = 20;
     v = ci;
-    foreach (qual; AliasSeq!(ConstOf))
+    static foreach (qual; AliasSeq!(ConstOf))
     {
         assert(v.get!(qual!int) == 20);
         assert(v.get!(qual!float) == 20.0f);
     }
-    foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!int));
         assertThrown!VariantException(v.get!(qual!float));
@@ -2512,12 +2512,12 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     immutable(int) ii = ci;
     v = ii;
-    foreach (qual; AliasSeq!(ImmutableOf, ConstOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(ImmutableOf, ConstOf, SharedConstOf))
     {
         assert(v.get!(qual!int) == 20);
         assert(v.get!(qual!float) == 20.0f);
     }
-    foreach (qual; AliasSeq!(MutableOf, SharedOf))
+    static foreach (qual; AliasSeq!(MutableOf, SharedOf))
     {
         assertThrown!VariantException(v.get!(qual!int));
         assertThrown!VariantException(v.get!(qual!float));
@@ -2525,12 +2525,12 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     int[] ai = [1,2,3];
     v = ai;
-    foreach (qual; AliasSeq!(MutableOf, ConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ConstOf))
     {
         assert(v.get!(qual!(int[])) == [1,2,3]);
         assert(v.get!(qual!(int)[]) == [1,2,3]);
     }
-    foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!(int[])));
         assertThrown!VariantException(v.get!(qual!(int)[]));
@@ -2538,12 +2538,12 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     const(int[]) cai = [4,5,6];
     v = cai;
-    foreach (qual; AliasSeq!(ConstOf))
+    static foreach (qual; AliasSeq!(ConstOf))
     {
         assert(v.get!(qual!(int[])) == [4,5,6]);
         assert(v.get!(qual!(int)[]) == [4,5,6]);
     }
-    foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!(int[])));
         assertThrown!VariantException(v.get!(qual!(int)[]));
@@ -2557,7 +2557,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(v.get!(const(int)[]) == [7,8,9]);
     //assert(v.get!(shared(const(int[]))) == cast(shared const)[7,8,9]);    // Bug ??? runtime error
     //assert(v.get!(shared(const(int))[]) == cast(shared const)[7,8,9]);    // Bug ??? runtime error
-    foreach (qual; AliasSeq!(MutableOf))
+    static foreach (qual; AliasSeq!(MutableOf))
     {
         assertThrown!VariantException(v.get!(qual!(int[])));
         assertThrown!VariantException(v.get!(qual!(int)[]));
@@ -2567,13 +2567,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     class B : A {}
     B b = new B();
     v = b;
-    foreach (qual; AliasSeq!(MutableOf, ConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ConstOf))
     {
         assert(v.get!(qual!B) is b);
         assert(v.get!(qual!A) is b);
         assert(v.get!(qual!Object) is b);
     }
-    foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!B));
         assertThrown!VariantException(v.get!(qual!A));
@@ -2582,13 +2582,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     const(B) cb = new B();
     v = cb;
-    foreach (qual; AliasSeq!(ConstOf))
+    static foreach (qual; AliasSeq!(ConstOf))
     {
         assert(v.get!(qual!B) is cb);
         assert(v.get!(qual!A) is cb);
         assert(v.get!(qual!Object) is cb);
     }
-    foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ImmutableOf, SharedOf, SharedConstOf))
     {
         assertThrown!VariantException(v.get!(qual!B));
         assertThrown!VariantException(v.get!(qual!A));
@@ -2597,13 +2597,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     immutable(B) ib = new immutable(B)();
     v = ib;
-    foreach (qual; AliasSeq!(ImmutableOf, ConstOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(ImmutableOf, ConstOf, SharedConstOf))
     {
         assert(v.get!(qual!B) is ib);
         assert(v.get!(qual!A) is ib);
         assert(v.get!(qual!Object) is ib);
     }
-    foreach (qual; AliasSeq!(MutableOf, SharedOf))
+    static foreach (qual; AliasSeq!(MutableOf, SharedOf))
     {
         assertThrown!VariantException(v.get!(qual!B));
         assertThrown!VariantException(v.get!(qual!A));
@@ -2612,13 +2612,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     shared(B) sb = new shared B();
     v = sb;
-    foreach (qual; AliasSeq!(SharedOf, SharedConstOf))
+    static foreach (qual; AliasSeq!(SharedOf, SharedConstOf))
     {
         assert(v.get!(qual!B) is sb);
         assert(v.get!(qual!A) is sb);
         assert(v.get!(qual!Object) is sb);
     }
-    foreach (qual; AliasSeq!(MutableOf, ImmutableOf, ConstOf))
+    static foreach (qual; AliasSeq!(MutableOf, ImmutableOf, ConstOf))
     {
         assertThrown!VariantException(v.get!(qual!B));
         assertThrown!VariantException(v.get!(qual!A));
@@ -2627,13 +2627,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
     shared(const(B)) scb = new shared const B();
     v = scb;
-    foreach (qual; AliasSeq!(SharedConstOf))
+    static foreach (qual; AliasSeq!(SharedConstOf))
     {
         assert(v.get!(qual!B) is scb);
         assert(v.get!(qual!A) is scb);
         assert(v.get!(qual!Object) is scb);
     }
-    foreach (qual; AliasSeq!(MutableOf, ConstOf, ImmutableOf, SharedOf))
+    static foreach (qual; AliasSeq!(MutableOf, ConstOf, ImmutableOf, SharedOf))
     {
         assertThrown!VariantException(v.get!(qual!B));
         assertThrown!VariantException(v.get!(qual!A));


### PR DESCRIPTION
All the cool kids in town use `static foreach`. Let's join the club.
Motivation: `static foreach` makes it clear to the reader that the loop is unrolled
during compile-time.
The replacements were done semi-automatically.

I also removed the workarounds against BUG 2396 - `static foreach` doesn't seem
to be affected by this as overall execution time of the entire Phobos testsuite
doesn't with this PR.

I know that this got quite large, but the changes itself are trivial.