### PR TITLE
[RFC] Make Output Ranges Using Methods The Preferred toString Option

### DIFF
--- a/changelog/toString.dd
+++ b/changelog/toString.dd
@@ -20,11 +20,11 @@ auto t = MyType();
 writeln(t); // writes "Custom toString"
 -------
 
-This has several benefits for the user. Firstly, this design is much friendlier
+This has several benefits for the user. First, this design is much friendlier
 to inlining than the `toString(scope void delegate(const(char)[]) sink)` method of
-`toString`. Secondly, this cuts down on memory usage, as characters are placed right
-into the output buffers of functions like $(REF format, std, format). Thirdly,
-because `toString` is now a template, can be made `@safe` via inference much more
+`toString`. Second, this cuts down on memory usage, as characters are placed right
+into the output buffers of functions like $(REF format, std, format). Third,
+because `toString` is now a template, can be marked `@safe` via inference much more
 often.
 
 All previous forms of `toString` will continue to work.

--- a/changelog/toString.dd
+++ b/changelog/toString.dd
@@ -1,0 +1,30 @@
+toString Can Now Use Output Ranges
+
+The standard library has been modified to recognize and use `toString` overloads
+that accept $(REF_ALTTEXT output ranges, isOutputRange, std, range, primitives)
+when such overloads exist.
+
+-------
+import std.range.primitives;
+import std.stdio;
+
+struct MyType
+{
+    void toString(W)(ref W writer) if (isOutputRange!(W, char))
+    {
+        put(writer, "Custom toString");
+    }
+}
+
+auto t = MyType();
+writeln(t); // writes "Custom toString"
+-------
+
+This has several benefits for the user. Firstly, this design is much friendlier
+to inlining than the `toString(scope void delegate(const(char)[]) sink)` method of
+`toString`. Secondly, this cuts down on memory usage, as characters are placed right
+into the output buffers of functions like $(REF format, std, format). Thirdly,
+because `toString` is now a template, can be made `@safe` via inference much more
+often.
+
+All previous forms of `toString` will continue to work.

--- a/changelog/toString.dd
+++ b/changelog/toString.dd
@@ -1,4 +1,4 @@
-toString Can Now Use Output Ranges
+`toString` Can Now Use Output Ranges
 
 The standard library has been modified to recognize and use `toString` overloads
 that accept $(REF_ALTTEXT output ranges, isOutputRange, std, range, primitives)


### PR DESCRIPTION
This proposal

* Modifies `std.format` to recognize any `toString` that accepts a character accepting output range as having a valid `toString` overload
* Modifies `std.format` to prioritize and use the output range method when formatting aggregate types if it exists
* De-emphasizes the `scope delegate` `toString` methods in the docs

## Rationale

Firstly, speed. [According to Walter](https://issues.dlang.org/show_bug.cgi?id=9785#c3), the delegate passed as a parameter can never be in-lined because of how DMD does data flow analysis. Using instead the defined `put` method of an output range would solve that problem.

Secondly, the vision of Phobos.  Ranges are the present and the future. Output ranges really need more support in Phobos (std.conv).

Thirdly, safety. The vast majority of the code I've seen doesn't mark the `delegate` as `@safe` to allow non-safe sinks to work with it. This means that the `toString` method itself can never be marked `@safe` either. Making `toString` a template who's safety relies on the `put` method of the output range side-steps this problem entirely.