### PR TITLE
Changed all instances of FormatSpec in toString to const ref

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2231,8 +2231,7 @@ public:
      * $(LI $(B %b) which prints the bits as 8-bit byte packets)
      * separated with an underscore.
      */
-    void toString(scope void delegate(const(char)[]) sink,
-                  FormatSpec!char fmt) const
+    void toString(scope void delegate(const(char)[]) sink, const ref FormatSpec!char fmt) const
     {
         switch (fmt.spec)
         {

--- a/std/complex.d
+++ b/std/complex.d
@@ -146,8 +146,7 @@ if (isFloatingPoint!T)
     }
 
     /// ditto
-    void toString(Writer, Char)(scope Writer w,
-                        FormatSpec!Char formatSpec) const
+    void toString(Writer, Char)(scope Writer w, const ref FormatSpec!Char formatSpec) const
         if (isOutputRange!(Writer, const(Char)[]))
     {
         import std.format : formatValue;

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1712,7 +1712,8 @@ assert(equal(rbt[], [5]));
      */
     static if (is(typeof((){FormatSpec!(char) fmt; formatValue((const(char)[]) {}, ConstRange.init, fmt);})))
     {
-        void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const {
+        void toString(scope void delegate(const(char)[]) sink, const ref FormatSpec!char fmt) const
+        {
             sink("RedBlackTree(");
             sink.formatValue(this[], fmt);
             sink(")");

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1189,11 +1189,12 @@ if (distinctFieldNames!(Specs))
              */
             void toString(DG)(scope DG sink) const
             {
-                toString(sink, FormatSpec!char());
+                auto f = FormatSpec!char();
+                toString(sink, f);
             }
 
             /// ditto
-            void toString(DG, Char)(scope DG sink, FormatSpec!Char fmt) const
+            void toString(DG, Char)(scope DG sink, const ref FormatSpec!Char fmt) const
             {
                 import std.format : formatElement, formattedWrite, FormatException;
                 if (fmt.nested)
@@ -2443,7 +2444,7 @@ Params:
     {
         import std.format : FormatSpec, formatValue;
         // Needs to be a template because of DMD @@BUG@@ 13737.
-        void toString()(scope void delegate(const(char)[]) sink, FormatSpec!char fmt)
+        void toString()(scope void delegate(const(char)[]) sink, const ref FormatSpec!char fmt)
         {
             if (isNull)
             {
@@ -2456,7 +2457,7 @@ Params:
         }
 
         // Issue 14940
-        void toString()(scope void delegate(const(char)[]) @safe sink, FormatSpec!char fmt)
+        void toString()(scope void delegate(const(char)[]) @safe sink, const ref FormatSpec!char fmt)
         {
             if (isNull)
             {
@@ -2996,7 +2997,7 @@ Params:
     {
         import std.format : FormatSpec, formatValue;
         // Needs to be a template because of DMD @@BUG@@ 13737.
-        void toString()(scope void delegate(const(char)[]) sink, FormatSpec!char fmt)
+        void toString()(scope void delegate(const(char)[]) sink, const ref FormatSpec!char fmt)
         {
             if (isNull)
             {
@@ -3350,7 +3351,7 @@ Params:
     {
         import std.format : FormatSpec, formatValue;
         // Needs to be a template because of DMD @@BUG@@ 13737.
-        void toString()(scope void delegate(const(char)[]) sink, FormatSpec!char fmt)
+        void toString()(scope void delegate(const(char)[]) sink, const ref FormatSpec!char fmt)
         {
             if (isNull)
             {

--- a/std/uni.d
+++ b/std/uni.d
@@ -2450,8 +2450,7 @@ public:
      * $(LI $(B %x) formats the intervals as a [low .. high$(RPAREN) range of lowercase hex characters)
      * $(LI $(B %X) formats the intervals as a [low .. high$(RPAREN) range of uppercase hex characters)
      */
-    void toString(Writer)(scope Writer sink,
-                  FormatSpec!char fmt) /* const */
+    void toString(Writer)(scope Writer sink, const ref FormatSpec!char fmt) /* const */
     {
         import std.format : formatValue;
         auto range = byInterval;


### PR DESCRIPTION
See https://github.com/dlang/phobos/pull/5991#issuecomment-355122818

While in this instance, the code compiled just fine, the problem is that a `const ref` parameter in `formatObject` ended up being copied in said function if `FormatSpec` wasn't marked as `ref`. This poses a problem because `FormatSpec` is quite a large struct, not to mention the fact that we've already gone through the trouble of making a pointer to one, so making a copy is just extra work.
  