### PR TITLE
Propagate CodeCov + CircleCi updates from DMD

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -68,13 +68,10 @@ setup_repos()
 
     # merge upstream branch with changes, s.t. we check with the latest changes
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        local current_branch=$(git rev-parse --abbrev-ref HEAD)
-        git config user.name dummyuser
-        git config user.email dummyuser@dummyserver.com
-        git remote add upstream https://github.com/dlang/phobos.git
-        git fetch upstream
-        git checkout -f upstream/$base_branch
-        git merge -m "Automatic merge" $current_branch
+        local head=$(git rev-parse HEAD)
+        git remote add upstream "https://github.com/dlang/$CIRCLE_PROJECT_REPONAME.git"
+        git fetch -q upstream "+refs/pull/${CIRCLE_PR_NUMBER}/merge:"
+        git checkout -f FETCH_HEAD
     fi
 
     for proj in dmd druntime ; do

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,30 @@
 
 codecov:
   notify:
+    # We don't want to wait for the CodeCov report
+    # See https://github.com/codecov/support/issues/312
+    require_ci_to_pass: false
     after_n_builds: 1  # send notifications after the first upload
+    wait_for_ci: false
+
   bot: dlang-bot
+  ci:
+    # https://docs.codecov.io/docs/detecting-ci-services
+    # Only CircleCi generates coverages files atm.
+    # Don't wait for the other CIs
+    - circleci.com
+    - !dtest.dlang.io
+    - !auto-tester.puremagic.com
+    - !appveyor.com
+    - !ci.dlang.io
+    - !travis-ci.org
+
+  # At CircleCi, the PR is merged into `master` before the testsuite is run.
+  # This allows CodeCov to adjust the resulting coverage diff, s.t. it matches
+  # with the GitHub diff.
+  # https://github.com/codecov/support/issues/363
+  # https://docs.codecov.io/v4.3.6/docs/comparing-commits
+  allow_coverage_offsets: true
 
 coverage:
   precision: 3


### PR DESCRIPTION
See also:
- https://github.com/dlang/dmd/pull/7574 (Use GitHub's merge head)
- https://github.com/dlang/dmd/pull/7596 (Don't wait for other CIs, attempt IV)
- https://github.com/dlang/dmd/pull/7542 (Don't wait for other CIs, attempt III)
- https://github.com/dlang/dmd/pull/7540 (Use domains to ignore CI providers)
- https://github.com/dlang/dmd/pull/7532 (Fix 'No parent commit was found' by allowing coverage offsets)