### PR TITLE
Expose AscendingPageAllocator on dlang.org

### DIFF
--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -1,3 +1,7 @@
+// Written in the D programming language.
+/**
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_ascending_page_allocator.d)
+*/
 module std.experimental.allocator.building_blocks.ascending_page_allocator;
 import std.experimental.allocator.common;
 


### PR DESCRIPTION
Follow-up to https://github.com/dlang/phobos/pull/6006/files#r160067505

Note that the module title is too long for the menu atm.

![image](https://user-images.githubusercontent.com/4370550/34656649-7d3f02d2-f41d-11e7-8b03-a2f52a4b4858.png)

![image](https://user-images.githubusercontent.com/4370550/34656654-8b399168-f41d-11e7-9704-13080e263f51.png)

CC @Darredevil

BTW why don't we put everything into a `building_blocks.d` file like it's
done for all the other Phobos modules?
  