### PR TITLE
Fix Issue 18217: Don't repeatedly call unpredictableSeed to initialize rndGen

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1357,8 +1357,8 @@ A singleton instance of the default random number generator
     static bool initialized;
     if (!initialized)
     {
-        static if (isSeedable!(Random, typeof(map!((a) => unpredictableSeed)(repeat(0)))))
-            result.seed(map!((a) => unpredictableSeed)(repeat(0)));
+        static if (isSeedable!(Random, ReturnType!unpredictableSeed))
+            result.seed(unpredictableSeed); // Avoid unnecessary copy.
         else
             result = Random(unpredictableSeed);
         initialized = true;


### PR DESCRIPTION
Having this code in Phobos leads others to mistakenly copy it since Phobos is generally a model of good D programming practices. Calling unpredictableSeed just once would be faster and would give a better result.

Explanation from https://github.com/dlang/phobos/pull/5788#discussion_r146110307:
>This method of seeding calls `unpredictableSeed` 624 times to initialize the MersenneTwisterEngine's internal array. Currently this just means multiplying a number 624 times modulo 2^^31-1 and XOR-ing the result against the clock each time. This is pointless but fairly harmless, although it means that initially each number will probably have the same high bit. It would be faster and give a better result to just seed MersenneTwisterEngine with a single number. Also, if a proposal like #5230 to make `unpedictableSeed` more "unpredictable" is implemented, this mode of seeding could become pathological.