### PR TITLE
Fix Issue 10930 - std.array.replace cannot simple replace an element in array

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -2336,9 +2336,8 @@ if (isInputRange!RoR &&
         $(REF substitute, std,algorithm,iteration) for a lazy replace.
  +/
 E[] replace(E, R1, R2)(E[] subject, R1 from, R2 to)
-if (isDynamicArray!(E[]) &&
-    ((isForwardRange!R1 && isForwardRange!R2 && (hasLength!R2 || isSomeString!R2)) ||
-    is(Unqual!E : Unqual!R1)))
+if ((isForwardRange!R1 && isForwardRange!R2 && (hasLength!R2 || isSomeString!R2)) ||
+    is(Unqual!E : Unqual!R1))
 {
     import std.algorithm.searching : find;
     import std.range : dropOne;
@@ -2433,7 +2432,7 @@ if (isDynamicArray!(E[]) &&
         $(REF substitute, std,algorithm,iteration) for a lazy replace.
  +/
 void replaceInto(E, Sink, R1, R2)(Sink sink, E[] subject, R1 from, R2 to)
-if (isOutputRange!(Sink, E) && isDynamicArray!(E[]) &&
+if (isOutputRange!(Sink, E) &&
     ((isForwardRange!R1 && isForwardRange!R2 && (hasLength!R2 || isSomeString!R2)) ||
     is(Unqual!E : Unqual!R1)))
 {


### PR DESCRIPTION
Follow-up to https://github.com/dlang/phobos/pull/6017


Currently there's no constraints that the ranges return similar types.
Should I add such a constraint too?
It would start to get a monster though:

```d
if (isOutputRange!(Sink, E) && isDynamicArray!(E[]) &&
    ((isForwardRange!R1 && isForwardRange!R2
    && (hasLength!R2 || isSomeString!R2))
    && is(typeof(R1.init.front) : typeof(R2.init.front)) ||
    is(Unqual!E : Unqual!R1)) && is(Unqual!R1 : Unqual!R2)))
```