### PR TITLE
Fix issue 13632: Enhancement to std.string.strip

### DIFF
--- a/changelog/std-string-strip.dd
+++ b/changelog/std-string-strip.dd
@@ -1,0 +1,14 @@
+`std.string.strip` now accepts a string of characters to be stripped
+
+New overload functions of $(REF strip, std, string),
+$(REF stripLeft, std, string) and
+$(REF stripRight, std, string) accepts a string of characters to be
+stripped instead of stripping only whitespace.
+
+---
+import std.string: stripLeft, stripRight, strip;
+
+assert(stripLeft("www.dlang.org", "w.") == "dlang.org");
+assert(stripRight("dlang.org/", "/") == "dlang.org");
+assert(strip("www.dlang.org/", "w./") == "dlang.org");
+---


### PR DESCRIPTION
Added second argument similar to Python `str.strip`

Second argument accepts list of chars to strip and strips only
those chars.

Examples:

    "xyzhello".stripLeft("xyz") == ""hello"
    "helloxy ".stripRight("xy ") == "hello"
    "xhellox".strip("x") == "hello"

Signed-off-by: Aravinda VK <mail@aravindavk.in>