### PR TITLE
Optimized format with compile time format strings

### DIFF
--- a/changelog/compile-time-format-optimized.dd
+++ b/changelog/compile-time-format-optimized.dd
@@ -1,0 +1,25 @@
+`std.format` with strings passed during compile-time has been optimized
+
+Giving $(REF format, std, format) a string as a template parameter allows
+the type correctness of the parameters to be checked at compile time:
+
+-------
+import std.format : format;
+
+auto s1 = format!"%d"(4); // works fine
+auto s2 = format("%d"); // runtime exception
+auto s3 = format!"%d"(); // compile time error
+-------
+
+Now, using this overload also allows std.format to make an educated guess at
+the length of the resulting string, reducing the total number of reallocations
+made to the output buffer.
+
+-------
+import std.format : format;
+
+auto s1 = format!"%02d:%02d:%02d"(10, 30, 50); // known for certain to be 8 chars long
+auto s2 = format!"%s %d"("Error Code: ", 42); // Makes an educated guess
+-------
+
+Longer format strings benefit the most from this change.


### PR DESCRIPTION
Added function to std.format to make an educated guess at the length of the resulting string when it's given at compile time, and use that data to reserve capacity in the appender before anything is written to it.

Performance wise, I only saw differences outside of random-ness in longer format strings.

```
$ ldc2 -O -release test.d && ./test
old 1			1 sec, 223 ms, 469 μs, and 8 hnsecs
old 2			2 secs, 427 ms, 447 μs, and 1 hnsec
old 3			2 secs, 448 ms, 949 μs, and 8 hnsecs
old 4			2 secs, 655 ms, 333 μs, and 4 hnsecs

new 1			1 sec, 191 ms, 30 μs, and 2 hnsecs
new 2			2 secs, 432 ms, 636 μs, and 8 hnsecs
new 3			2 secs, 489 ms, 238 μs, and 6 hnsecs
new 4			2 secs, 155 ms, 551 μs, and 3 hnsecs
```

```d
import std.stdio;
import std.algorithm;
import std.conv;
import std.format;
import std.range;
import std.traits;
import std.string;
import std.datetime.stopwatch;
import std.utf;

enum testCount = 6_000_000;

typeof(fmt) format1(alias fmt, Args...)(Args args)
if (isSomeString!(typeof(fmt)))
{
    alias e = checkFormatException!(fmt, Args);
    static assert(!e, e.msg);
    return format(fmt, args);
}

typeof(fmt) format2(alias fmt, Args...)(Args args)
if (isSomeString!(typeof(fmt)))
{
    import std.array : appender;

    alias e = checkFormatException!(fmt, Args);
    alias Char = Unqual!(ElementEncodingType!(typeof(fmt)));

    static assert(!e, e.msg);
    auto w = appender!(immutable(Char)[]);

    // no need to traverse the string twice during compile time
    if (!__ctfe)
    {
        enum len = guessLength!(fmt, Char)();
        w.reserve(len);
    }

    formattedWrite(w, fmt, args);
    return w.data;
}

private size_t guessLength(alias fmtString, Char)()
{
    import std.array : appender;
    pragma(msg, fmtString);

    size_t len;
    auto output = appender!(immutable(Char)[])();
    auto spec = FormatSpec!Char(fmtString);
    while (spec.writeUpToNextSpec(output))
    {
        // take a guess
        if (spec.width == 0 && (spec.precision == spec.UNSPECIFIED || spec.precision == spec.DYNAMIC))
        {
            if (spec.spec == 's')
                len += 6;
            else if (spec.spec == 'd' || spec.spec == 'x' || spec.spec == 'x')
                len += 3;
            else if (spec.spec == 'b')
                len += 8;
            else if (spec.spec == 'e' || spec.spec == 'E')
                len += 12;
            else if (spec.spec == 'f' || spec.spec == 'F')
                len += 10;
            else if (spec.spec == 'c')
                ++len;

            continue;
        }

        if ((spec.spec == 'e' || spec.spec == 'E') && spec.precision != spec.UNSPECIFIED && spec.precision == spec.DYNAMIC)
        {
            len += spec.precision + 5;
            continue;
        }

        if (spec.width == spec.precision)
            len += spec.width;
        else if (spec.width > 0 && (spec.precision == spec.UNSPECIFIED || spec.width > spec.precision))
            len += spec.width;
        else if (spec.precision != spec.UNSPECIFIED && spec.precision > spec.width)
            len += spec.precision;
    }
    len += output.data.length;
    return len;
}

void main()
{
    string res;

    auto result1 = to!Duration(benchmark!(() => res = format1!"%d"(42))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => res = format1!"%e"(4.2))(testCount)[0]);
    auto result3 = to!Duration(benchmark!(() => res = format1!"%02d%02d%02d"(10, 30, 50))(testCount)[0]);
    auto result4 = to!Duration(benchmark!(() => res = format1!"Error code %d: longer format string to represent real world work (%s)"(10, 3000))(testCount)[0]);

    writeln("old 1", "\t\t\t", result1);
    writeln("old 2", "\t\t\t", result2);
    writeln("old 3", "\t\t\t", result3);
    writeln("old 4", "\t\t\t", result4);
    writeln;

    result1 = to!Duration(benchmark!(() => res = format2!"%d"(42))(testCount)[0]);
    result2 = to!Duration(benchmark!(() => res = format2!"%e"(4.2))(testCount)[0]);
    result3 = to!Duration(benchmark!(() => res = format2!"%02d%02d%02d"(10, 30, 50))(testCount)[0]);
    result4 = to!Duration(benchmark!(() => res = format2!"Error code %d: longer format string to represent real world work (%s)"(10, 3000))(testCount)[0]);

    writeln("new 1", "\t\t\t", result1);
    writeln("new 2", "\t\t\t", result2);
    writeln("new 3", "\t\t\t", result3);
    writeln("new 4", "\t\t\t", result4);
    writeln;
}
```