### PR TITLE
fix issue 14767 - Support CTFE of BigInt under x86

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1761,3 +1761,9 @@ unittest
     auto b = immutable BigInt("123");
     assert(b == 123);
 }
+
+@safe pure unittest // issue 14767
+{
+    static immutable a = BigInt("340282366920938463463374607431768211455");
+    assert(a == BigInt("340282366920938463463374607431768211455"));
+}

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1762,8 +1762,16 @@ unittest
     assert(b == 123);
 }
 
-@safe pure unittest // issue 14767
+@system pure unittest // issue 14767
 {
     static immutable a = BigInt("340282366920938463463374607431768211455");
     assert(a == BigInt("340282366920938463463374607431768211455"));
+
+    BigInt plusTwo(in BigInt n)
+    {
+        return n + 2;
+    }
+
+    enum BigInt test1 = BigInt(123);
+    enum BigInt test2 = plusTwo(test1);
 }

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -56,21 +56,23 @@ private:
 // dipatchers to the right low-level primitives. Added to allow BigInt CTFE for
 // 32 bit systems (issue 14767) although it's used by the other architectures too.
 // See comments below in case it has to be refactored.
-pragma(inline, true)
+version(X86)
 uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] src2, uint carry)
 {
-    // CTFE, no arch distinction
+    // must be checked before, otherwise D_InlineAsm_X86 is true.
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
-    // Run-time, X86 with asm
+    // Runtime.
     else version(D_InlineAsm_X86)
         return std.internal.math.biguintx86.multibyteAddSub!op(dest, src1, src2, carry);
-    // Run-time, not X86
+    // Runtime if no asm available.
     else
         return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
 }
+// Any other architecture
+else alias multibyteAddSub = std.internal.math.biguintnoasm.multibyteAddSub;
 
-pragma(inline, true)
+version(X86)
 uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
 {
     if (__ctfe)
@@ -80,8 +82,9 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
     else
         return std.internal.math.biguintnoasm.multibyteIncrementAssign!op(dest, carry);
 }
+else alias multibyteIncrementAssign = std.internal.math.biguintnoasm.multibyteIncrementAssign;
 
-pragma(inline, true)
+version(X86)
 uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits)
 {
     if (__ctfe)
@@ -91,8 +94,9 @@ uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits)
     else
         return std.internal.math.biguintnoasm.multibyteShl(dest, src, numbits);
 }
+else alias multibyteShl = std.internal.math.biguintnoasm.multibyteShl;
 
-pragma(inline, true)
+version(X86)
 void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits)
 {
     if (__ctfe)
@@ -102,8 +106,9 @@ void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits)
     else
         std.internal.math.biguintnoasm.multibyteShr(dest, src, numbits);
 }
+else alias multibyteShr = std.internal.math.biguintnoasm.multibyteShr;
 
-pragma(inline, true)
+version(X86)
 uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 {
     if (__ctfe)
@@ -113,8 +118,9 @@ uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
     else
         return std.internal.math.biguintnoasm.multibyteMul(dest, src, multiplier, carry);
 }
+else alias multibyteMul = std.internal.math.biguintnoasm.multibyteMul;
 
-pragma(inline, true)
+version(X86)
 uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 {
     if (__ctfe)
@@ -124,8 +130,9 @@ uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, u
     else
         return std.internal.math.biguintnoasm.multibyteMulAdd!op(dest, src, multiplier, carry);
 }
+else alias multibyteMulAdd = std.internal.math.biguintnoasm.multibyteMulAdd;
 
-pragma(inline, true)
+version(X86)
 void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[] right)
 {
     if (__ctfe)
@@ -135,8 +142,9 @@ void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[
     else
         std.internal.math.biguintnoasm.multibyteMultiplyAccumulate(dest, left, right);
 }
+else alias multibyteMultiplyAccumulate = std.internal.math.biguintnoasm.multibyteMultiplyAccumulate;
 
-pragma(inline, true)
+version(X86)
 uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow)
 {
     if (__ctfe)
@@ -146,8 +154,9 @@ uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow)
     else
         return std.internal.math.biguintnoasm.multibyteDivAssign(dest, divisor, overflow);
 }
+else alias multibyteDivAssign = std.internal.math.biguintnoasm.multibyteDivAssign;
 
-pragma(inline, true)
+version(X86)
 void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src)
 {
     if (__ctfe)
@@ -157,8 +166,9 @@ void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src)
     else
         std.internal.math.biguintnoasm.multibyteAddDiagonalSquares(dest, src);
 }
+else alias multibyteAddDiagonalSquares = std.internal.math.biguintnoasm.multibyteAddDiagonalSquares;
 
-pragma(inline, true)
+version(X86)
 void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x)
 {
     if (__ctfe)
@@ -168,8 +178,9 @@ void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x)
     else
         std.internal.math.biguintnoasm.multibyteTriangleAccumulate(dest, x);
 }
+else alias multibyteTriangleAccumulate = std.internal.math.biguintnoasm.multibyteTriangleAccumulate;
 
-pragma(inline, true)
+version(X86)
 void multibyteSquare()(BigDigit[] result, const(BigDigit)[] x)
 {
     if (__ctfe)
@@ -179,6 +190,7 @@ void multibyteSquare()(BigDigit[] result, const(BigDigit)[] x)
     else
         std.internal.math.biguintnoasm.multibyteSquare(result, x);
 }
+else alias multibyteSquare = std.internal.math.biguintnoasm.multibyteSquare;
 
 // Limits for when to switch between algorithms.
 // Half the size of the data cache.

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -53,10 +53,10 @@ import std.traits;
 
 private:
 
-// compile-time & run-time dipatchers to allows BigInt CTFE for 32 bit OS.
+// compile-time & run-time dipatchers to allows BigInt CTFE for 32 bit systems.
 
 pragma(inline, true)
-uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] src2, uint carry) pure
+uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] src2, uint carry)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
@@ -67,7 +67,7 @@ uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] sr
 }
 
 pragma(inline, true)
-uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
+uint multibyteIncrementAssign(char op)(uint[] dest, uint carry)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteIncrementAssign!op(dest, carry);
@@ -78,7 +78,7 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
 }
 
 pragma(inline, true)
-uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits) pure
+uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteShl(dest, src, numbits);
@@ -89,7 +89,7 @@ uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits) pure
 }
 
 pragma(inline, true)
-void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits) pure
+void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits)
 {
     if (__ctfe)
         std.internal.math.biguintnoasm.multibyteShr(dest, src, numbits);
@@ -100,7 +100,7 @@ void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits) pure
 }
 
 pragma(inline, true)
-uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry) pure
+uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteMul(dest, src, multiplier, carry);
@@ -111,7 +111,7 @@ uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 }
 
 pragma(inline, true)
-uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, uint carry) pure
+uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteMulAdd!op(dest, src, multiplier, carry);
@@ -122,7 +122,7 @@ uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, u
 }
 
 pragma(inline, true)
-void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[] right) pure
+void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[] right)
 {
     if (__ctfe)
         std.internal.math.biguintnoasm.multibyteMultiplyAccumulate(dest, left, right);
@@ -133,7 +133,7 @@ void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[
 }
 
 pragma(inline, true)
-uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow) pure
+uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow)
 {
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteDivAssign(dest, divisor, overflow);
@@ -144,7 +144,7 @@ uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow) pure
 }
 
 pragma(inline, true)
-void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src) pure
+void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src)
 {
     if (__ctfe)
         std.internal.math.biguintnoasm.multibyteAddDiagonalSquares(dest, src);
@@ -155,7 +155,7 @@ void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src) pure
 }
 
 pragma(inline, true)
-void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x) pure
+void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x)
 {
     if (__ctfe)
         std.internal.math.biguintnoasm.multibyteTriangleAccumulate(dest, x);
@@ -166,7 +166,7 @@ void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x) pure
 }
 
 pragma(inline, true)
-void multibyteSquare()(BigDigit[] result, const(BigDigit) [] x) pure
+void multibyteSquare()(BigDigit[] result, const(BigDigit)[] x)
 {
     if (__ctfe)
         std.internal.math.biguintnoasm.multibyteSquare(result, x);

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -37,10 +37,7 @@ version(D_InlineAsm_X86)
 {
     static import std.internal.math.biguintx86;
 }
-else
-{
-    static import std.internal.math.biguintnoasm;
-}
+static import std.internal.math.biguintnoasm;
 
 import std.internal.math.biguintnoasm : BigDigit, KARATSUBALIMIT,
     KARATSUBASQUARELIMIT;

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -53,15 +53,19 @@ import std.traits;
 
 private:
 
-// compile-time & run-time dipatchers to allows BigInt CTFE for 32 bit systems.
-
+// dipatchers to the right low-level primitives. Added to allow BigInt CTFE for
+// 32 bit systems (issue 14767) although it's used by the other architectures too.
+// See comments below in case it has to be refactored.
 pragma(inline, true)
 uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] src2, uint carry)
 {
+    // CTFE, no arch distinction
     if (__ctfe)
         return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
+    // Run-time, X86 with asm
     else version(D_InlineAsm_X86)
         return std.internal.math.biguintx86.multibyteAddSub!op(dest, src1, src2, carry);
+    // Run-time, not X86
     else
         return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
 }

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -35,12 +35,15 @@ module std.internal.math.biguintcore;
 
 version(D_InlineAsm_X86)
 {
-    import std.internal.math.biguintx86;
+    static import std.internal.math.biguintx86;
 }
 else
 {
-    import std.internal.math.biguintnoasm;
+    static import std.internal.math.biguintnoasm;
 }
+
+import std.internal.math.biguintnoasm : BigDigit, KARATSUBALIMIT,
+    KARATSUBASQUARELIMIT;
 
 alias multibyteAdd = multibyteAddSub!('+');
 alias multibyteSub = multibyteAddSub!('-');
@@ -52,6 +55,130 @@ import std.range.primitives;
 import std.traits;
 
 private:
+
+// compile-time & run-time dipatchers to allows BigInt CTFE for 32 bit OS.
+
+pragma(inline, true)
+uint multibyteAddSub(char op)(uint[] dest, const(uint)[] src1, const (uint)[] src2, uint carry) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteAddSub!op(dest, src1, src2, carry);
+    else
+        return std.internal.math.biguintnoasm.multibyteAddSub!op(dest, src1, src2, carry);
+}
+
+pragma(inline, true)
+uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteIncrementAssign!op(dest, carry);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteIncrementAssign!op(dest, carry);
+    else
+        return std.internal.math.biguintnoasm.multibyteIncrementAssign!op(dest, carry);
+}
+
+pragma(inline, true)
+uint multibyteShl()(uint[] dest, const(uint)[] src, uint numbits) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteShl(dest, src, numbits);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteShl(dest, src, numbits);
+    else
+        return std.internal.math.biguintnoasm.multibyteShl(dest, src, numbits);
+}
+
+pragma(inline, true)
+void multibyteShr()(uint[] dest, const(uint)[] src, uint numbits) pure
+{
+    if (__ctfe)
+        std.internal.math.biguintnoasm.multibyteShr(dest, src, numbits);
+    else version(D_InlineAsm_X86)
+        std.internal.math.biguintx86.multibyteShr(dest, src, numbits);
+    else
+        std.internal.math.biguintnoasm.multibyteShr(dest, src, numbits);
+}
+
+pragma(inline, true)
+uint multibyteMul()(uint[] dest, const(uint)[] src, uint multiplier, uint carry) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteMul(dest, src, multiplier, carry);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteMul(dest, src, multiplier, carry);
+    else
+        return std.internal.math.biguintnoasm.multibyteMul(dest, src, multiplier, carry);
+}
+
+pragma(inline, true)
+uint multibyteMulAdd(char op)(uint[] dest, const(uint)[] src, uint multiplier, uint carry) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteMulAdd!op(dest, src, multiplier, carry);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteMulAdd!op(dest, src, multiplier, carry);
+    else
+        return std.internal.math.biguintnoasm.multibyteMulAdd!op(dest, src, multiplier, carry);
+}
+
+pragma(inline, true)
+void multibyteMultiplyAccumulate()(uint[] dest, const(uint)[] left, const(uint)[] right) pure
+{
+    if (__ctfe)
+        std.internal.math.biguintnoasm.multibyteMultiplyAccumulate(dest, left, right);
+    else version(D_InlineAsm_X86)
+        std.internal.math.biguintx86.multibyteMultiplyAccumulate(dest, left, right);
+    else
+        std.internal.math.biguintnoasm.multibyteMultiplyAccumulate(dest, left, right);
+}
+
+pragma(inline, true)
+uint multibyteDivAssign()(uint[] dest, uint divisor, uint overflow) pure
+{
+    if (__ctfe)
+        return std.internal.math.biguintnoasm.multibyteDivAssign(dest, divisor, overflow);
+    else version(D_InlineAsm_X86)
+        return std.internal.math.biguintx86.multibyteDivAssign(dest, divisor, overflow);
+    else
+        return std.internal.math.biguintnoasm.multibyteDivAssign(dest, divisor, overflow);
+}
+
+pragma(inline, true)
+void multibyteAddDiagonalSquares()(uint[] dest, const(uint)[] src) pure
+{
+    if (__ctfe)
+        std.internal.math.biguintnoasm.multibyteAddDiagonalSquares(dest, src);
+    else version(D_InlineAsm_X86)
+        std.internal.math.biguintx86.multibyteAddDiagonalSquares(dest, src);
+    else
+        std.internal.math.biguintnoasm.multibyteAddDiagonalSquares(dest, src);
+}
+
+pragma(inline, true)
+void multibyteTriangleAccumulate()(uint[] dest, const(uint)[] x) pure
+{
+    if (__ctfe)
+        std.internal.math.biguintnoasm.multibyteTriangleAccumulate(dest, x);
+    else version(D_InlineAsm_X86)
+        std.internal.math.biguintx86.multibyteTriangleAccumulate(dest, x);
+    else
+        std.internal.math.biguintnoasm.multibyteTriangleAccumulate(dest, x);
+}
+
+pragma(inline, true)
+void multibyteSquare()(BigDigit[] result, const(BigDigit) [] x) pure
+{
+    if (__ctfe)
+        std.internal.math.biguintnoasm.multibyteSquare(result, x);
+    else version(D_InlineAsm_X86)
+        std.internal.math.biguintx86.multibyteSquare(result, x);
+    else
+        std.internal.math.biguintnoasm.multibyteSquare(result, x);
+}
+
 // Limits for when to switch between algorithms.
 // Half the size of the data cache.
 @nogc nothrow pure size_t getCacheLimit()


### PR DESCRIPTION
This allows to declare very big BigInt constants but has the same limitation as x86_64 BigInt CTFE.