### PR TITLE
Fix issue 17440: Nullable!Class should redirect to Nullable!(Class,null)

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2324,12 +2324,12 @@ string alignForSize(E...)(const char[][] names...)
 }
 
 /**
-Defines a value paired with a distinctive "null" state that denotes
-the absence of a value. If default constructed, a $(D
-Nullable!T) object starts in the null state. Assigning it renders it
-non-null. Calling $(D nullify) can nullify it again.
+Defines a value paired with a distinctive "null" state that denotes the absence
+of a value. If default constructed, a `Nullable!T` object starts in the null
+state. Assigning it renders it non-null. Calling `nullify` can nullify it
+again.
 
-Practically $(D Nullable!T) stores a $(D T) and a $(D bool).
+Practically `Nullable!T` stores a `T` and a `bool`.
 
 If `T` is a class, which already has null semantics, `Nullable!T` will alias
 itself to `Nullable!(T, null)` instead.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2330,6 +2330,9 @@ Nullable!T) object starts in the null state. Assigning it renders it
 non-null. Calling $(D nullify) can nullify it again.
 
 Practically $(D Nullable!T) stores a $(D T) and a $(D bool).
+
+If `T` is a class, which already has null semantics, `Nullable!T` will alias
+itself to `Nullable!(T, null)` instead.
  */
 template Nullable(T)
 {


### PR DESCRIPTION
The current implementation of `Nullable!T` (the overload with a single type parameter) is clearly designed for types T with by-value semantics, as evidenced by the use of `.destroy` in `.nullify`, along with other implementation decisions. As a result, nullifying a `Nullable!Class` also triggers destruction of the class object, which is surprising behaviour.  Furthermore, since class references already have a null state, `Nullable!Class` adds a second, distinct null state, which only adds to the confusion.

Since there's a second overload of `Nullable` that can be used for proxying a class reference's null semantics with the Nullable API (i.e., `isNull` and `nullify`), simply forward instantiations of `Nullable!Class` to `Nullable!(Class, null)` instead.

An alternative fix is to change `.nullify` so that it does not call `.destroy` on class references. However, this does not solve the problem of confusion caused by introducing two distinct null states in `Nullable!Class`.

As for why one would use `Nullable` on a type that already has a null state, to quote a comment from the bugzilla issue:

> For those confused as to why you'd want to wrap a Nullable around something that already has nullable semantics, it's mostly about making APIs that explicitly declare their optional return values. See: http://www.oracle.com/technetwork/articles/java/java8-optional-2175753.html