### PR TITLE
Fix Issue 15798 - std.algorithm.mutation.copy takes target by value

### DIFF
--- a/changelog/copy-auto-ref.dd
+++ b/changelog/copy-auto-ref.dd
@@ -1,0 +1,34 @@
+`std.algorithm.mutation.copy` Has Been Modified For `put`-style Output Ranges
+
+With this release, when the target output range in a call to
+$(REF copy, std, algorithm, mutation) is any `put` defining output range (and it
+doesn't have $(REF_ALTTEXT assignable elements, hasAssignableElements, std, range, primitives)),
+the target is taken as `auto ref`. This new overload is also `void` returning
+vs the other overloads which return the unfilled portion of the given range
+or array.
+
+Before this release, $(REF copy, std, algorithm, mutation) took all
+$(REF_ALTTEXT output ranges, isOutputRange, std, range, primitives) by value.
+This leads to some issues when output ranges aren't designed around a reference
+to heap memory, e.g. the hash ranges in $(MREF std,digest):
+
+-------
+// v2.078 and earlier
+import std.algorithm.mutation : copy;
+import std.digest.digest : toHexString;
+import std.digest.md : MD5;
+import std.range : put;
+
+auto s = "Hello!\n";
+auto h1 = makeDigest!MD5;
+auto h2 = makeDigest!MD5;
+
+put(h1, s); // takes h1 by ref
+copy(s, h2); // takes h2 by value
+
+assert(h1.finish().toHexString == "E134CED312B3511D88943D57CCD70C83");
+// Different result because copy didn't properly insert the contents of s
+assert(h2.finish().toHexString == "D41D8CD98F00B204E9800998ECF8427E");
+-------
+
+This issue no longer occurs in 2.079 and later as long as `target` is an lvalue.

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -78,7 +78,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.mutation;
 
 import std.range.primitives;
-import std.traits : isArray, isBlitAssignable, isNarrowString, Unqual, isSomeChar, isDynamicArray;
+import std.traits : isArray, isBlitAssignable, isNarrowString, Unqual, isSomeChar;
 // FIXME
 import std.typecons; // : tuple, Tuple;
 
@@ -369,7 +369,7 @@ Params:
 
 Returns:
     The unfilled part of `target` if `target` is not a `put` defining output
-    range.
+    range. `void` otherwise.
 
 See_Also:
     $(HTTP sgi.com/tech/stl/_copy.html, STL's _copy)

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -265,7 +265,7 @@ version(ExampleDigest)
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     auto ctx = makeDigest!MD5();
-    copy(oneMillionRange, &ctx); //Note: You must pass a pointer to copy!
+    oneMillionRange.copy(ctx);
     assert(ctx.finish().toHexString() == "7707D6AE4E027C70EEA2A935C2296F21");
 }
 
@@ -433,10 +433,10 @@ DigestType!Hash digest(Hash, Range)(auto ref Range range)
 if (!isArray!Range
     && isDigestibleRange!Range)
 {
-    import std.algorithm.mutation : copy;
+    import std.range.primitives : put;
     Hash hash;
     hash.start();
-    copy(range, &hash);
+    put(hash, range);
     return hash.finish();
 }
 
@@ -634,7 +634,7 @@ interface Digest
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     auto ctx = new MD5Digest();
-    copy(oneMillionRange, ctx);
+    oneMillionRange.copy(ctx);
     assert(ctx.finish().toHexString() == "7707D6AE4E027C70EEA2A935C2296F21");
 }
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -15,7 +15,6 @@ module std.stdio;
 
 import core.stdc.stddef; // wchar_t
 public import core.stdc.stdio;
-import std.algorithm.mutation; // copy
 import std.meta; // allSatisfy
 import std.range.primitives; // ElementEncodingType, empty, front,
     // isBidirectionalRange, isInputRange, put
@@ -3143,7 +3142,7 @@ void main()
 
     @system unittest
     {
-        import std.algorithm.mutation : reverse;
+        import std.algorithm.mutation : copy, reverse;
         import std.exception : collectException;
         static import std.file;
         import std.range : only, retro;
@@ -4572,16 +4571,17 @@ private struct ChunksImpl
 
 /**
 Writes an array or range to a file.
-Shorthand for $(D data.copy(File(fileName, "wb").lockingBinaryWriter)).
+Shorthand for `put(data, File(fileName, "wb").lockingBinaryWriter)`.
 Similar to $(REF write, std,file), strings are written as-is,
 rather than encoded according to the $(D File)'s $(HTTP
 en.cppreference.com/w/c/io#Narrow_and_wide_orientation,
 orientation).
 */
 void toFile(T)(T data, string fileName)
-if (is(typeof(copy(data, stdout.lockingBinaryWriter))))
+if (is(typeof({ auto w = stdout.lockingBinaryWriter; put(w, data); })))
 {
-    copy(data, File(fileName, "wb").lockingBinaryWriter);
+    auto w = File(fileName, "wb").lockingBinaryWriter;
+    put(w, data);
 }
 
 @system unittest


### PR DESCRIPTION
`copy` is designed in such a way that passing in a generic output range as the target value makes no sense, as `copy` is supposed to return the "remainder" of target. As such, its inputs should be restricted to inputs that are assignable input ranges or slices.

Consider the following from the stackoverflow example

```d
import std.stdio;
import std.digest.digest;
import std.digest.md;
import std.algorithm;

void main() {
    string s = "Hello!\n";
    auto d1 = makeDigest!MD5;
    auto d2 = makeDigest!MD5;
    foreach (ubyte b; s) {
        d1.put(b);
    }
    s.copy(d2);
    writeln(digest!MD5(s).toHexString);
    writeln(d1.finish().toHexString);
    writeln(d2.finish().toHexString);
}
```

This outputs

```
E134CED312B3511D88943D57CCD70C83
E134CED312B3511D88943D57CCD70C83
D41D8CD98F00B204E9800998ECF8427E
```

Because copy takes the target by value. What the user should have done is use `std.range.primitives.put` to copy an input range to an output range which is taken by reference.

This change adds a deprecation message that alerts the user. Any usage of `copy` in this way is very likely deprecating broken code. 