### PR TITLE
Issue 18244: std.math generic functions need to have sig constraints

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -136,6 +136,7 @@ version (Win64)
 static import core.math;
 static import core.stdc.math;
 static import core.stdc.fenv;
+import std.range.primitives : isInputRange, ElementType;
 import std.traits; // CommonType, isFloatingPoint, isIntegral, isSigned, isUnsigned, Largest, Unqual
 
 version(LDC)
@@ -7496,6 +7497,9 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
        pair of elements.
  */
 bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
+    if ((isNumeric!T || (isInputRange!T && isNumeric!(ElementType!T))) &&
+        (isNumeric!U || (isInputRange!U && isNumeric!(ElementType!U))) &&
+        isNumeric!V)
 {
     import std.range.primitives : empty, front, isInputRange, popFront;
     static if (isInputRange!T)

--- a/std/math.d
+++ b/std/math.d
@@ -5412,7 +5412,7 @@ if (isFloatingPoint!(X))
  *  $(D true) if $(D_PARAM x) is finite.
  */
 bool isFinite(X)(X x) @trusted pure nothrow @nogc
-    if (isFloatingPoint!X)
+if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     ushort* pe = cast(ushort *)&x;
@@ -5460,7 +5460,7 @@ bool isFinite(X)(X x) @trusted pure nothrow @nogc
  * be converted to normal reals.
  */
 bool isNormal(X)(X x) @trusted pure nothrow @nogc
-    if (isFloatingPoint!X)
+if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     static if (F.realFormat == RealFormat.ibmExtended)
@@ -5507,7 +5507,7 @@ bool isNormal(X)(X x) @trusted pure nothrow @nogc
  *  $(D true) if $(D_PARAM x) is a denormal number.
  */
 bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
-    if (isFloatingPoint!X)
+if (isFloatingPoint!X)
 {
     /*
         Need one for each format because subnormal floats might
@@ -5713,7 +5713,7 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
  * Return 1 if sign bit of e is set, 0 if not.
  */
 int signbit(X)(X x) @nogc @trusted pure nothrow
-    if (isFloatingPoint!X)
+if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     return ((cast(ubyte *)&x)[F.SIGNPOS_BYTE] & 0x80) != 0;
@@ -5815,7 +5815,7 @@ Returns $(D -1) if $(D x < 0), $(D x) if $(D x == 0), $(D 1) if
 $(D x > 0), and $(NAN) if x==$(NAN).
  */
 F sgn(F)(F x) @safe pure nothrow @nogc
-    if (isNumeric!F)
+if (isNumeric!F)
 {
     // @@@TODO@@@: make this faster
     return x > 0 ? 1 : x < 0 ? -1 : x;
@@ -6288,7 +6288,7 @@ float nextDown(float x) @safe pure nothrow @nogc
  * not equal to y.
  */
 T nextafter(T)(const T x, const T y) @safe pure nothrow @nogc
-    if (isFloatingPoint!T)
+if (isFloatingPoint!T)
 {
     if (x == y) return y;
     return ((y>x) ? nextUp(x) :  nextDown(x));
@@ -7497,9 +7497,9 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
        pair of elements.
  */
 bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
-    if ((isNumeric!T || (isInputRange!T && isNumeric!(ElementType!T))) &&
-        (isNumeric!U || (isInputRange!U && isNumeric!(ElementType!U))) &&
-        isNumeric!V)
+if ((isNumeric!T || (isInputRange!T && isNumeric!(ElementType!T))) &&
+    (isNumeric!U || (isInputRange!U && isNumeric!(ElementType!U))) &&
+    isNumeric!V)
 {
     import std.range.primitives : empty, front, isInputRange, popFront;
     static if (isInputRange!T)

--- a/std/math.d
+++ b/std/math.d
@@ -5411,6 +5411,7 @@ if (isFloatingPoint!(X))
  *  $(D true) if $(D_PARAM x) is finite.
  */
 bool isFinite(X)(X x) @trusted pure nothrow @nogc
+    if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     ushort* pe = cast(ushort *)&x;
@@ -5458,6 +5459,7 @@ bool isFinite(X)(X x) @trusted pure nothrow @nogc
  * be converted to normal reals.
  */
 bool isNormal(X)(X x) @trusted pure nothrow @nogc
+    if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     static if (F.realFormat == RealFormat.ibmExtended)
@@ -5504,6 +5506,7 @@ bool isNormal(X)(X x) @trusted pure nothrow @nogc
  *  $(D true) if $(D_PARAM x) is a denormal number.
  */
 bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
+    if (isFloatingPoint!X)
 {
     /*
         Need one for each format because subnormal floats might
@@ -5709,6 +5712,7 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
  * Return 1 if sign bit of e is set, 0 if not.
  */
 int signbit(X)(X x) @nogc @trusted pure nothrow
+    if (isFloatingPoint!X)
 {
     alias F = floatTraits!(X);
     return ((cast(ubyte *)&x)[F.SIGNPOS_BYTE] & 0x80) != 0;
@@ -5810,6 +5814,7 @@ Returns $(D -1) if $(D x < 0), $(D x) if $(D x == 0), $(D 1) if
 $(D x > 0), and $(NAN) if x==$(NAN).
  */
 F sgn(F)(F x) @safe pure nothrow @nogc
+    if (isNumeric!F)
 {
     // @@@TODO@@@: make this faster
     return x > 0 ? 1 : x < 0 ? -1 : x;
@@ -6282,6 +6287,7 @@ float nextDown(float x) @safe pure nothrow @nogc
  * not equal to y.
  */
 T nextafter(T)(const T x, const T y) @safe pure nothrow @nogc
+    if (isFloatingPoint!T)
 {
     if (x == y) return y;
     return ((y>x) ? nextUp(x) :  nextDown(x));


### PR DESCRIPTION
Not having any sig constraints causes needless conflicts with user-defined numerical types, e.g.:

````
// myNumber.d
module myNumber;
struct MyNumber { ... }
int signbit(T : MyNumber)(T num) { ... }

// usercode.d
import myNumber;
import std.math;
MyNumber num;
auto x = signbit(num); // tries to call std.math.signbit, and fails
````

To anticipate the objection "user code should not use the name `signbit`": sometimes, we *want* to deliberately reuse established names for certain operations, so that we can drop in a user-defined type as a replacement for built-in floats without having to modify a lot of user code. As long as it behaves similarly enough to a built-in float, it should be allowed with a minimum of roadblocks.