### PR TITLE
Fix issue 17440: do not call .destroy on class instances in Nullable.nullify

### DIFF
--- a/changelog/nullable-class.dd
+++ b/changelog/nullable-class.dd
@@ -1,0 +1,27 @@
+`Nullable!C.nullify` no longer calls .destroy when `C` is a class or interface
+
+Previously, when `.nullify` is called on a `Nullable!C` where `C` is a class or
+interface, the underlying object is destructed immediately via the `.destroy`
+function. This led to bugs when there are still references to the object
+outside of the `Nullable` instance:
+
+------
+class C
+{
+    int canary = 0xA71FE;
+    ~this()
+    {
+        canary = 0x5050DEAD;
+    }
+}
+
+auto c = new C;
+assert(c.canary == 0xA71FE);
+
+Nullable!C nc = nullable(c);
+nc.nullify;
+assert(c.canary == 0xA71FE); // This would fail
+------
+
+The `.nullify` method has been fixed so that it no longer calls `.destroy` on
+class or interface instances, and the above code will now work correctly.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2508,7 +2508,10 @@ Forces $(D this) to the null state.
  */
     void nullify()()
     {
-        .destroy(_value);
+        static if (is(T == class))
+            _value = null;
+        else
+            .destroy(_value);
         _isNull = true;
     }
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2508,7 +2508,7 @@ Forces $(D this) to the null state.
  */
     void nullify()()
     {
-        static if (is(T == class))
+        static if (is(T == class) || is(T == interface))
             _value = null;
         else
             .destroy(_value);
@@ -2971,7 +2971,9 @@ auto nullable(T)(T t)
 // Issue 17440
 @system unittest
 {
-    static class C
+    static interface I { }
+
+    static class C : I
     {
         int canary;
         ~this()
@@ -2983,6 +2985,11 @@ auto nullable(T)(T t)
     c.canary = 0xA71FE;
     auto nc = nullable(c);
     nc.nullify;
+    assert(c.canary == 0xA71FE);
+
+    I i = c;
+    auto ni = nullable(i);
+    ni.nullify;
     assert(c.canary == 0xA71FE);
 }
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2968,6 +2968,24 @@ auto nullable(T)(T t)
     var.nullify;
 }
 
+// Issue 17440
+@system unittest
+{
+    static class C
+    {
+        int canary;
+        ~this()
+        {
+            canary = 0x5050DEAD;
+        }
+    }
+    auto c = new C;
+    c.canary = 0xA71FE;
+    auto nc = nullable(c);
+    nc.nullify;
+    assert(c.canary == 0xA71FE);
+}
+
 /**
 Just like $(D Nullable!T), except that the null state is defined as a
 particular value. For example, $(D Nullable!(uint, uint.max)) is an


### PR DESCRIPTION
This is a reboot of #6038 with a simpler fix that doesn't require extensive, backward-incompatible changes to `Nullable`.

It does *not* take care of the problem of `Nullable!Class` introducing a second, inequivalent null state to a class reference.