### PR TITLE
fix issue 11747 - Better error message with @disabled toString

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3609,7 +3609,7 @@ if (is(T == class) && !is(T == enum))
     // TODO: Change this once toString() works for shared objects.
     static assert(!is(T == shared), "unable to format shared objects");
 
-    // TODO: remove this check once `@dsiable override` deprecation cycle is finished
+    // TODO: remove this check once `@disable override` deprecation cycle is finished
     static if (__traits(hasMember, T, "toString") && isSomeFunction!(val.toString))
         static assert(!__traits(isDisabled, T.toString), T.stringof ~
             " cannot be formatted because its `toString` is marked with `@disable`");

--- a/std/format.d
+++ b/std/format.d
@@ -3609,6 +3609,11 @@ if (is(T == class) && !is(T == enum))
     // TODO: Change this once toString() works for shared objects.
     static assert(!is(T == shared), "unable to format shared objects");
 
+    // TODO: remove this check once `@dsiable override` deprecation cycle is finished
+    static if (__traits(hasMember, T, "toString") && isSomeFunction!(val.toString))
+        static assert(!__traits(isDisabled, T.toString), T.stringof ~
+            " cannot be formatted because its `toString` is marked with `@disable`");
+
     if (val is null)
         put(w, "null");
     else
@@ -3714,6 +3719,10 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
         put(w, "null");
     else
     {
+        static if (__traits(hasMember, T, "toString") && isSomeFunction!(val.toString))
+            static assert(!__traits(isDisabled, T.toString), T.stringof ~
+                " cannot be formatted because its `toString` is marked with `@disable`");
+
         static if (hasToString!(T, Char))
         {
             formatObject(w, val, f);
@@ -3789,6 +3798,11 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
 private void formatValueImpl(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref FormatSpec!Char f)
 if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is(T == enum))
 {
+
+    static if (__traits(hasMember, T, "toString") && isSomeFunction!(val.toString))
+        static assert(!__traits(isDisabled, T.toString), T.stringof ~
+            " cannot be formatted because its `toString` is marked with `@disable`");
+
     enforceValidFormatSpec!(T, Char)(f);
     static if (hasToString!(T, Char))
     {
@@ -3903,7 +3917,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
 
 @safe unittest
 {
-    import std.array;
+    import std.array : appender;
     static struct S{ @disable this(this); }
     S s;
 
@@ -3911,6 +3925,24 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     auto w = appender!string();
     formatValue(w, s, f);
     assert(w.data == "S()");
+}
+
+unittest
+{
+    //struct Foo { @disable string toString(); }
+    //Foo foo;
+
+    interface Bar { @disable string toString(); }
+    Bar bar;
+
+    import std.array : appender;
+    auto w = appender!(char[])();
+    FormatSpec!char f;
+
+    // NOTE: structs cant be tested : the assertion is correct so compilation
+    // continues and fails when trying to link the unimplemented toString.
+    //static assert(!__traits(compiles, formatValue(w, foo, f)));
+    static assert(!__traits(compiles, formatValue(w, bar, f)));
 }
 
 /*


### PR DESCRIPTION
This is not an important fix. It allows to stop compiling before the linker failure happening when an aggregate has its `to string` marked with `@disable`, so very unlikely to happen, ever. However since i managed to get the new trait accepted in the language, here is an example of usage.

Funnily enough the fix is impossible to test, see the note in the unittest.