### PR TITLE
Fix erroneous imports in unittests

### DIFF
--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -34,8 +34,7 @@ class NullLogger : Logger
 ///
 @safe unittest
 {
-    import std.experimental.logger.nulllogger : LogLevel;
-
+    import std.experimental.logger.core : LogLevel;
     auto nl1 = new NullLogger(LogLevel.all);
     nl1.info("You will never read this.");
     nl1.fatal("You will never read this, either and it will not throw");

--- a/std/file.d
+++ b/std/file.d
@@ -2291,7 +2291,7 @@ if (isConvertibleToString!R)
 
 @safe unittest
 {
-    import std.path : mkdir;
+    import std.file : mkdir;
     static assert(__traits(compiles, mkdir(TestAliasedString(null))));
 }
 
@@ -4073,7 +4073,8 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
     import std.algorithm.searching : startsWith;
     import std.array : array;
     import std.conv : to;
-    import std.path : dirEntries, buildPath, absolutePath;
+    import std.path : buildPath, absolutePath;
+    import std.file : dirEntries;
     import std.process : thisProcessID;
     import std.range.primitives : walkLength;
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -11650,7 +11650,6 @@ if (isInputRange!R && isIntegral!(ElementType!R))
         bw.popFront();
         assert(bw[2 * bitsNum - 3] == true);
 
-        import core.exception : Error;
         import std.exception : assertThrown;
 
         // Check out of bounds error

--- a/std/socket.d
+++ b/std/socket.d
@@ -85,10 +85,10 @@ else version(Posix)
         }
     }
 
+    public import core.sys.posix.netinet.in_;
     import core.sys.posix.arpa.inet;
     import core.sys.posix.fcntl;
     import core.sys.posix.netdb;
-    import core.sys.posix.netinet.in_;
     import core.sys.posix.netinet.tcp;
     import core.sys.posix.sys.select;
     import core.sys.posix.sys.socket;


### PR DESCRIPTION
This is part 2 of #6048 and is currently blocking : dlang/dmd#7760 because deprecations are treated as errors.