### PR TITLE
Replace deprecated hexstrings with std.conv.hexString

### DIFF
--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -347,117 +347,123 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
 
 @system unittest
 {
+    import std.conv : hexString;
     ubyte[4] digest;
 
     CRC32 crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[]) x"bd50274c");
+    assert(crc.peek() == cast(ubyte[]) hexString!"bd50274c");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[]) x"00000000");
+    assert(crc.finish() == cast(ubyte[]) hexString!"00000000");
 
     digest = crc32Of("");
-    assert(digest == cast(ubyte[]) x"00000000");
+    assert(digest == cast(ubyte[]) hexString!"00000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc32Of("The quick brown fox jumps over the lazy dog")) == "414FA339");
 
     digest = crc32Of("a");
-    assert(digest == cast(ubyte[]) x"43beb7e8");
+    assert(digest == cast(ubyte[]) hexString!"43beb7e8");
 
     digest = crc32Of("abc");
-    assert(digest == cast(ubyte[]) x"c2412435");
+    assert(digest == cast(ubyte[]) hexString!"c2412435");
 
     digest = crc32Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"5f3f1a17");
+    assert(digest == cast(ubyte[]) hexString!"5f3f1a17");
 
     digest = crc32Of("message digest");
-    assert(digest == cast(ubyte[]) x"7f9d1520");
+    assert(digest == cast(ubyte[]) hexString!"7f9d1520");
 
     digest = crc32Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"d2e6c21f");
+    assert(digest == cast(ubyte[]) hexString!"d2e6c21f");
 
     digest = crc32Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"724aa97c");
+    assert(digest == cast(ubyte[]) hexString!"724aa97c");
 
-    assert(crcHexString(cast(ubyte[4]) x"c3fcd3d7") == "D7D3FCC3");
+    enum ubyte[4] input = hexString!"c3fcd3d7";
+    assert(crcHexString(input) == "D7D3FCC3");
 }
 
 @system unittest
 {
+    import std.conv : hexString;
     ubyte[8] digest;
 
     CRC64ECMA crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[]) x"2f121b7575789626");
+    assert(crc.peek() == cast(ubyte[]) hexString!"2f121b7575789626");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[]) x"0000000000000000");
+    assert(crc.finish() == cast(ubyte[]) hexString!"0000000000000000");
     digest = crc64ECMAOf("");
-    assert(digest == cast(ubyte[]) x"0000000000000000");
+    assert(digest == cast(ubyte[]) hexString!"0000000000000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc64ECMAOf("The quick brown fox jumps over the lazy dog")) == "5B5EB8C2E54AA1C4");
 
     digest = crc64ECMAOf("a");
-    assert(digest == cast(ubyte[]) x"052b652e77840233");
+    assert(digest == cast(ubyte[]) hexString!"052b652e77840233");
 
     digest = crc64ECMAOf("abc");
-    assert(digest == cast(ubyte[]) x"2776271a4a09d82c");
+    assert(digest == cast(ubyte[]) hexString!"2776271a4a09d82c");
 
     digest = crc64ECMAOf("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"4b7cdce3746c449f");
+    assert(digest == cast(ubyte[]) hexString!"4b7cdce3746c449f");
 
     digest = crc64ECMAOf("message digest");
-    assert(digest == cast(ubyte[]) x"6f9b8a3156c9bc5d");
+    assert(digest == cast(ubyte[]) hexString!"6f9b8a3156c9bc5d");
 
     digest = crc64ECMAOf("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"2656b716e1bf0503");
+    assert(digest == cast(ubyte[]) hexString!"2656b716e1bf0503");
 
     digest = crc64ECMAOf("1234567890123456789012345678901234567890"~
                          "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"bd3eb7765d0a22ae");
+    assert(digest == cast(ubyte[]) hexString!"bd3eb7765d0a22ae");
 
-    assert(crcHexString(cast(ubyte[8]) x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
+    enum ubyte[8] input = hexString!"c3fcd3d7efbeadde";
+    assert(crcHexString(input) == "DEADBEEFD7D3FCC3");
 }
 
 @system unittest
 {
+    import std.conv : hexString;
     ubyte[8] digest;
 
     CRC64ISO crc;
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[]) x"f0494ab780989b42");
+    assert(crc.peek() == cast(ubyte[]) hexString!"f0494ab780989b42");
     crc.start();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[]) x"0000000000000000");
+    assert(crc.finish() == cast(ubyte[]) hexString!"0000000000000000");
     digest = crc64ISOOf("");
-    assert(digest == cast(ubyte[]) x"0000000000000000");
+    assert(digest == cast(ubyte[]) hexString!"0000000000000000");
 
     //Test vector from http://rosettacode.org/wiki/CRC-32
     assert(crcHexString(crc64ISOOf("The quick brown fox jumps over the lazy dog")) == "4EF14E19F4C6E28E");
 
     digest = crc64ISOOf("a");
-    assert(digest == cast(ubyte[]) x"0000000000002034");
+    assert(digest == cast(ubyte[]) hexString!"0000000000002034");
 
     digest = crc64ISOOf("abc");
-    assert(digest == cast(ubyte[]) x"0000000020c47637");
+    assert(digest == cast(ubyte[]) hexString!"0000000020c47637");
 
     digest = crc64ISOOf("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"5173f717971365e5");
+    assert(digest == cast(ubyte[]) hexString!"5173f717971365e5");
 
     digest = crc64ISOOf("message digest");
-    assert(digest == cast(ubyte[]) x"a2c355bbc0b93f86");
+    assert(digest == cast(ubyte[]) hexString!"a2c355bbc0b93f86");
 
     digest = crc64ISOOf("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"598B258292E40084");
+    assert(digest == cast(ubyte[]) hexString!"598B258292E40084");
 
     digest = crc64ISOOf("1234567890123456789012345678901234567890"~
                         "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"760cd2d3588bf809");
+    assert(digest == cast(ubyte[]) hexString!"760cd2d3588bf809");
 
-    assert(crcHexString(cast(ubyte[8]) x"c3fcd3d7efbeadde") == "DEADBEEFD7D3FCC3");
+    enum ubyte[8] input = hexString!"c3fcd3d7efbeadde";
+    assert(crcHexString(input) == "DEADBEEFD7D3FCC3");
 }
 
 /**
@@ -653,53 +659,54 @@ alias CRC64ISODigest = WrapperDigest!CRC64ISO;
 
 @system unittest
 {
+    import std.conv : hexString;
     import std.range;
 
     auto crc = new CRC32Digest();
 
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
-    assert(crc.peek() == cast(ubyte[]) x"bd50274c");
+    assert(crc.peek() == cast(ubyte[]) hexString!"bd50274c");
     crc.reset();
     crc.put(cast(ubyte[])"");
-    assert(crc.finish() == cast(ubyte[]) x"00000000");
+    assert(crc.finish() == cast(ubyte[]) hexString!"00000000");
 
     crc.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = crc.finish(result[]);
-    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[]) x"bd50274c");
+    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[]) hexString!"bd50274c");
 
     debug
         assertThrown!Error(crc.finish(result[0 .. 3]));
 
     assert(crc.length == 4);
 
-    assert(crc.digest("") == cast(ubyte[]) x"00000000");
+    assert(crc.digest("") == cast(ubyte[]) hexString!"00000000");
 
-    assert(crc.digest("a") == cast(ubyte[]) x"43beb7e8");
+    assert(crc.digest("a") == cast(ubyte[]) hexString!"43beb7e8");
 
-    assert(crc.digest("abc") == cast(ubyte[]) x"c2412435");
+    assert(crc.digest("abc") == cast(ubyte[]) hexString!"c2412435");
 
     assert(crc.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) x"5f3f1a17");
+           == cast(ubyte[]) hexString!"5f3f1a17");
 
-    assert(crc.digest("message digest") == cast(ubyte[]) x"7f9d1520");
+    assert(crc.digest("message digest") == cast(ubyte[]) hexString!"7f9d1520");
 
     assert(crc.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[]) x"bd50274c");
+           == cast(ubyte[]) hexString!"bd50274c");
 
     assert(crc.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) x"d2e6c21f");
+           == cast(ubyte[]) hexString!"d2e6c21f");
 
     assert(crc.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) x"724aa97c");
+           == cast(ubyte[]) hexString!"724aa97c");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     auto digest = crc32Of(onemilliona);
-    assert(digest == cast(ubyte[]) x"BCBF25DC");
+    assert(digest == cast(ubyte[]) hexString!"BCBF25DC");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = crc32Of(oneMillionRange);
-    assert(digest == cast(ubyte[]) x"BCBF25DC");
+    assert(digest == cast(ubyte[]) hexString!"BCBF25DC");
 }

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -445,6 +445,7 @@ struct MD5
 @system unittest
 {
     import std.range;
+    import std.conv : hexString;
 
     ubyte[16] digest;
 
@@ -452,44 +453,45 @@ struct MD5
     md5.put(cast(ubyte[])"abcdef");
     md5.start();
     md5.put(cast(ubyte[])"");
-    assert(md5.finish() == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.finish() == cast(ubyte[]) hexString!"d41d8cd98f00b204e9800998ecf8427e");
 
     digest = md5Of("");
-    assert(digest == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(digest == cast(ubyte[]) hexString!"d41d8cd98f00b204e9800998ecf8427e");
 
     digest = md5Of("a");
-    assert(digest == cast(ubyte[]) x"0cc175b9c0f1b6a831c399e269772661");
+    assert(digest == cast(ubyte[]) hexString!"0cc175b9c0f1b6a831c399e269772661");
 
     digest = md5Of("abc");
-    assert(digest == cast(ubyte[]) x"900150983cd24fb0d6963f7d28e17f72");
+    assert(digest == cast(ubyte[]) hexString!"900150983cd24fb0d6963f7d28e17f72");
 
     digest = md5Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"8215ef0796a20bcaaae116d3876c664a");
+    assert(digest == cast(ubyte[]) hexString!"8215ef0796a20bcaaae116d3876c664a");
 
     digest = md5Of("message digest");
-    assert(digest == cast(ubyte[]) x"f96b697d7cb7938d525a2f31aaf161d0");
+    assert(digest == cast(ubyte[]) hexString!"f96b697d7cb7938d525a2f31aaf161d0");
 
     digest = md5Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
+    assert(digest == cast(ubyte[]) hexString!"c3fcd3d76192e4007dfb496cca67e13b");
 
     digest = md5Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"d174ab98d277d9f5a5611c2c9f419d9f");
+    assert(digest == cast(ubyte[]) hexString!"d174ab98d277d9f5a5611c2c9f419d9f");
 
     digest = md5Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"57edf4a22be3c955ac49da2e2107b67a");
+    assert(digest == cast(ubyte[]) hexString!"57edf4a22be3c955ac49da2e2107b67a");
 
-    assert(toHexString(cast(ubyte[16]) x"c3fcd3d76192e4007dfb496cca67e13b")
+    enum ubyte[16] input = hexString!"c3fcd3d76192e4007dfb496cca67e13b";
+    assert(toHexString(input)
         == "C3FCD3D76192E4007DFB496CCA67E13B");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     digest = md5Of(onemilliona);
-    assert(digest == cast(ubyte[]) x"7707D6AE4E027C70EEA2A935C2296F21");
+    assert(digest == cast(ubyte[]) hexString!"7707D6AE4E027C70EEA2A935C2296F21");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = md5Of(oneMillionRange);
-    assert(digest == cast(ubyte[]) x"7707D6AE4E027C70EEA2A935C2296F21");
+    assert(digest == cast(ubyte[]) hexString!"7707D6AE4E027C70EEA2A935C2296F21");
 }
 
 /**
@@ -547,17 +549,18 @@ alias MD5Digest = WrapperDigest!MD5;
 
 @system unittest
 {
+    import std.conv : hexString;
     auto md5 = new MD5Digest();
 
     md5.put(cast(ubyte[])"abcdef");
     md5.reset();
     md5.put(cast(ubyte[])"");
-    assert(md5.finish() == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.finish() == cast(ubyte[]) hexString!"d41d8cd98f00b204e9800998ecf8427e");
 
     md5.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = md5.finish(result[]);
-    assert(result[0 .. 16] == result2 && result2 == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
+    assert(result[0 .. 16] == result2 && result2 == cast(ubyte[]) hexString!"c3fcd3d76192e4007dfb496cca67e13b");
 
     debug
     {
@@ -567,24 +570,24 @@ alias MD5Digest = WrapperDigest!MD5;
 
     assert(md5.length == 16);
 
-    assert(md5.digest("") == cast(ubyte[]) x"d41d8cd98f00b204e9800998ecf8427e");
+    assert(md5.digest("") == cast(ubyte[]) hexString!"d41d8cd98f00b204e9800998ecf8427e");
 
-    assert(md5.digest("a") == cast(ubyte[]) x"0cc175b9c0f1b6a831c399e269772661");
+    assert(md5.digest("a") == cast(ubyte[]) hexString!"0cc175b9c0f1b6a831c399e269772661");
 
-    assert(md5.digest("abc") == cast(ubyte[]) x"900150983cd24fb0d6963f7d28e17f72");
+    assert(md5.digest("abc") == cast(ubyte[]) hexString!"900150983cd24fb0d6963f7d28e17f72");
 
     assert(md5.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) x"8215ef0796a20bcaaae116d3876c664a");
+           == cast(ubyte[]) hexString!"8215ef0796a20bcaaae116d3876c664a");
 
-    assert(md5.digest("message digest") == cast(ubyte[]) x"f96b697d7cb7938d525a2f31aaf161d0");
+    assert(md5.digest("message digest") == cast(ubyte[]) hexString!"f96b697d7cb7938d525a2f31aaf161d0");
 
     assert(md5.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[]) x"c3fcd3d76192e4007dfb496cca67e13b");
+           == cast(ubyte[]) hexString!"c3fcd3d76192e4007dfb496cca67e13b");
 
     assert(md5.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) x"d174ab98d277d9f5a5611c2c9f419d9f");
+           == cast(ubyte[]) hexString!"d174ab98d277d9f5a5611c2c9f419d9f");
 
     assert(md5.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) x"57edf4a22be3c955ac49da2e2107b67a");
+           == cast(ubyte[]) hexString!"57edf4a22be3c955ac49da2e2107b67a");
 }

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -613,6 +613,7 @@ struct RIPEMD160
 
 @system unittest
 {
+    import std.conv : hexString;
     import std.range;
 
     ubyte[20] digest;
@@ -621,44 +622,45 @@ struct RIPEMD160
     md.put(cast(ubyte[])"abcdef");
     md.start();
     md.put(cast(ubyte[])"");
-    assert(md.finish() == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.finish() == cast(ubyte[]) hexString!"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     digest = ripemd160Of("");
-    assert(digest == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(digest == cast(ubyte[]) hexString!"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     digest = ripemd160Of("a");
-    assert(digest == cast(ubyte[]) x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
+    assert(digest == cast(ubyte[]) hexString!"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
 
     digest = ripemd160Of("abc");
-    assert(digest == cast(ubyte[]) x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
+    assert(digest == cast(ubyte[]) hexString!"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
 
     digest = ripemd160Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
+    assert(digest == cast(ubyte[]) hexString!"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
 
     digest = ripemd160Of("message digest");
-    assert(digest == cast(ubyte[]) x"5d0689ef49d2fae572b881b123a85ffa21595f36");
+    assert(digest == cast(ubyte[]) hexString!"5d0689ef49d2fae572b881b123a85ffa21595f36");
 
     digest = ripemd160Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+    assert(digest == cast(ubyte[]) hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     digest = ripemd160Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"b0e20b6e3116640286ed3a87a5713079b21f5189");
+    assert(digest == cast(ubyte[]) hexString!"b0e20b6e3116640286ed3a87a5713079b21f5189");
 
     digest = ripemd160Of("1234567890123456789012345678901234567890"~
                     "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
+    assert(digest == cast(ubyte[]) hexString!"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
 
-    assert(toHexString(cast(ubyte[20]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc")
+    enum ubyte[20] input = hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc";
+    assert(toHexString(input)
         == "F71C27109C692C1B56BBDCEB5B9D2865B3708DBC");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
     digest = ripemd160Of(onemilliona);
-    assert(digest == cast(ubyte[]) x"52783243c1697bdbe16d37f97f68f08325dc1528");
+    assert(digest == cast(ubyte[]) hexString!"52783243c1697bdbe16d37f97f68f08325dc1528");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = ripemd160Of(oneMillionRange);
-    assert(digest == cast(ubyte[]) x"52783243c1697bdbe16d37f97f68f08325dc1528");
+    assert(digest == cast(ubyte[]) hexString!"52783243c1697bdbe16d37f97f68f08325dc1528");
 }
 
 /**
@@ -716,17 +718,18 @@ alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
 
 @system unittest
 {
+    import std.conv : hexString;
     auto md = new RIPEMD160Digest();
 
     md.put(cast(ubyte[])"abcdef");
     md.reset();
     md.put(cast(ubyte[])"");
-    assert(md.finish() == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.finish() == cast(ubyte[]) hexString!"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
     md.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = md.finish(result[]);
-    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     debug
     {
@@ -736,27 +739,27 @@ alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
 
     assert(md.length == 20);
 
-    assert(md.digest("") == cast(ubyte[]) x"9c1185a5c5e9fc54612808977ee8f548b2258d31");
+    assert(md.digest("") == cast(ubyte[]) hexString!"9c1185a5c5e9fc54612808977ee8f548b2258d31");
 
-    assert(md.digest("a") == cast(ubyte[]) x"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
+    assert(md.digest("a") == cast(ubyte[]) hexString!"0bdc9d2d256b3ee9daae347be6f4dc835a467ffe");
 
-    assert(md.digest("abc") == cast(ubyte[]) x"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
+    assert(md.digest("abc") == cast(ubyte[]) hexString!"8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
 
     assert(md.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) x"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
+           == cast(ubyte[]) hexString!"12a053384a9c0c88e405a06c27dcf49ada62eb2b");
 
-    assert(md.digest("message digest") == cast(ubyte[]) x"5d0689ef49d2fae572b881b123a85ffa21595f36");
+    assert(md.digest("message digest") == cast(ubyte[]) hexString!"5d0689ef49d2fae572b881b123a85ffa21595f36");
 
     assert(md.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[]) x"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
+           == cast(ubyte[]) hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc");
 
     assert(md.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) x"b0e20b6e3116640286ed3a87a5713079b21f5189");
+           == cast(ubyte[]) hexString!"b0e20b6e3116640286ed3a87a5713079b21f5189");
 
     assert(md.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) x"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
+           == cast(ubyte[]) hexString!"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
 
     assert(md.digest(new ubyte[160/8]) // 160 zero bits
-           == cast(ubyte[]) x"5c00bd4aca04a9057c09b20b05f723f2e23deb65");
+           == cast(ubyte[]) hexString!"5c00bd4aca04a9057c09b20b05f723f2e23deb65");
 }

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -897,19 +897,19 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     sha.put(cast(ubyte[])"abcdef");
     sha.start();
     sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.finish() == cast(ubyte[]) hexString!"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
     SHA224 sha224;
     sha224.put(cast(ubyte[])"abcdef");
     sha224.start();
     sha224.put(cast(ubyte[])"");
-    assert(sha224.finish() == cast(ubyte[]) x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    assert(sha224.finish() == cast(ubyte[]) hexString!"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
 
     SHA256 sha256;
     sha256.put(cast(ubyte[])"abcdef");
     sha256.start();
     sha256.put(cast(ubyte[])"");
-    assert(sha256.finish() == cast(ubyte[]) x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(sha256.finish() == cast(ubyte[]) hexString!"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     SHA384 sha384;
     sha384.put(cast(ubyte[])"abcdef");
@@ -929,13 +929,13 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     sha512_224.put(cast(ubyte[])"abcdef");
     sha512_224.start();
     sha512_224.put(cast(ubyte[])"");
-    assert(sha512_224.finish() == cast(ubyte[]) x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    assert(sha512_224.finish() == cast(ubyte[]) hexString!"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
 
     SHA512_256 sha512_256;
     sha512_256.put(cast(ubyte[])"abcdef");
     sha512_256.start();
     sha512_256.put(cast(ubyte[])"");
-    assert(sha512_256.finish() == cast(ubyte[]) x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(sha512_256.finish() == cast(ubyte[]) hexString!"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("");
     digest224     = sha224Of    ("");
@@ -944,15 +944,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("");
     digest512_224 = sha512_224Of("");
     digest512_256 = sha512_256Of("");
-    assert(digest == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    assert(digest224 == cast(ubyte[]) x"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
-    assert(digest256 == cast(ubyte[]) x"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(digest == cast(ubyte[]) hexString!"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(digest224 == cast(ubyte[]) hexString!"d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f");
+    assert(digest256 == cast(ubyte[]) hexString!"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
     assert(digest384 == cast(ubyte[]) hexString!("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
         ~"0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"));
     assert(digest512 == cast(ubyte[]) hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83"
         ~"f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
-    assert(digest512_224 == cast(ubyte[]) x"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
-    assert(digest512_256 == cast(ubyte[]) x"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(digest512_224 == cast(ubyte[]) hexString!"6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4");
+    assert(digest512_256 == cast(ubyte[]) hexString!"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("a");
     digest224     = sha224Of    ("a");
@@ -961,15 +961,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("a");
     digest512_224 = sha512_224Of("a");
     digest512_256 = sha512_256Of("a");
-    assert(digest == cast(ubyte[]) x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
-    assert(digest224 == cast(ubyte[]) x"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
-    assert(digest256 == cast(ubyte[]) x"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
+    assert(digest == cast(ubyte[]) hexString!"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(digest224 == cast(ubyte[]) hexString!"abd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5");
+    assert(digest256 == cast(ubyte[]) hexString!"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb");
     assert(digest384 == cast(ubyte[]) hexString!("54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9"
         ~"cd697e85175033caa88e6d57bc35efae0b5afd3145f31"));
     assert(digest512 == cast(ubyte[]) hexString!("1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05ab"
         ~"c54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"));
-    assert(digest512_224 == cast(ubyte[]) x"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
-    assert(digest512_256 == cast(ubyte[]) x"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
+    assert(digest512_224 == cast(ubyte[]) hexString!"d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327");
+    assert(digest512_256 == cast(ubyte[]) hexString!"455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8");
 
     digest        = sha1Of      ("abc");
     digest224     = sha224Of    ("abc");
@@ -978,15 +978,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("abc");
     digest512_224 = sha512_224Of("abc");
     digest512_256 = sha512_256Of("abc");
-    assert(digest == cast(ubyte[]) x"a9993e364706816aba3e25717850c26c9cd0d89d");
-    assert(digest224 == cast(ubyte[]) x"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
-    assert(digest256 == cast(ubyte[]) x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    assert(digest == cast(ubyte[]) hexString!"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(digest224 == cast(ubyte[]) hexString!"23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7");
+    assert(digest256 == cast(ubyte[]) hexString!"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
     assert(digest384 == cast(ubyte[]) hexString!("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
         ~"8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"));
     assert(digest512 == cast(ubyte[]) hexString!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9"
         ~"eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"));
-    assert(digest512_224 == cast(ubyte[]) x"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
-    assert(digest512_256 == cast(ubyte[]) x"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
+    assert(digest512_224 == cast(ubyte[]) hexString!"4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa");
+    assert(digest512_256 == cast(ubyte[]) hexString!"53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23");
 
     digest        = sha1Of      ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest224     = sha224Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
@@ -995,15 +995,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_224 = sha512_224Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     digest512_256 = sha512_256Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest == cast(ubyte[]) x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
-    assert(digest224 == cast(ubyte[]) x"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
-    assert(digest256 == cast(ubyte[]) x"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+    assert(digest == cast(ubyte[]) hexString!"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+    assert(digest224 == cast(ubyte[]) hexString!"75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525");
+    assert(digest256 == cast(ubyte[]) hexString!"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
     assert(digest384 == cast(ubyte[]) hexString!("3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe"
         ~"8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b"));
     assert(digest512 == cast(ubyte[]) hexString!("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a827"
         ~"9be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"));
-    assert(digest512_224 == cast(ubyte[]) x"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
-    assert(digest512_256 == cast(ubyte[]) x"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
+    assert(digest512_224 == cast(ubyte[]) hexString!"e5302d6d54bb242275d1e7622d68df6eb02dedd13f564c13dbda2174");
+    assert(digest512_256 == cast(ubyte[]) hexString!"bde8e1f9f19bb9fd3406c90ec6bc47bd36d8ada9f11880dbc8a22a7078b6a461");
 
     digest        = sha1Of      ("message digest");
     digest224     = sha224Of    ("message digest");
@@ -1012,15 +1012,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("message digest");
     digest512_224 = sha512_224Of("message digest");
     digest512_256 = sha512_256Of("message digest");
-    assert(digest == cast(ubyte[]) x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
-    assert(digest224 == cast(ubyte[]) x"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
-    assert(digest256 == cast(ubyte[]) x"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
+    assert(digest == cast(ubyte[]) hexString!"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(digest224 == cast(ubyte[]) hexString!"2cb21c83ae2f004de7e81c3c7019cbcb65b71ab656b22d6d0c39b8eb");
+    assert(digest256 == cast(ubyte[]) hexString!"f7846f55cf23e14eebeab5b4e1550cad5b509e3348fbc4efa3a1413d393cb650");
     assert(digest384 == cast(ubyte[]) hexString!("473ed35167ec1f5d8e550368a3db39be54639f828868e9454c"
         ~"239fc8b52e3c61dbd0d8b4de1390c256dcbb5d5fd99cd5"));
     assert(digest512 == cast(ubyte[]) hexString!("107dbf389d9e9f71a3a95f6c055b9251bc5268c2be16d6c134"
         ~"92ea45b0199f3309e16455ab1e96118e8a905d5597b72038ddb372a89826046de66687bb420e7c"));
-    assert(digest512_224 == cast(ubyte[]) x"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
-    assert(digest512_256 == cast(ubyte[]) x"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
+    assert(digest512_224 == cast(ubyte[]) hexString!"ad1a4db188fe57064f4f24609d2a83cd0afb9b398eb2fcaeaae2c564");
+    assert(digest512_256 == cast(ubyte[]) hexString!"0cf471fd17ed69d990daf3433c89b16d63dec1bb9cb42a6094604ee5d7b4e9fb");
 
     digest        = sha1Of      ("abcdefghijklmnopqrstuvwxyz");
     digest224     = sha224Of    ("abcdefghijklmnopqrstuvwxyz");
@@ -1029,15 +1029,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("abcdefghijklmnopqrstuvwxyz");
     digest512_224 = sha512_224Of("abcdefghijklmnopqrstuvwxyz");
     digest512_256 = sha512_256Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
-    assert(digest224 == cast(ubyte[]) x"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
-    assert(digest256 == cast(ubyte[]) x"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
+    assert(digest == cast(ubyte[]) hexString!"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(digest224 == cast(ubyte[]) hexString!"45a5f72c39c5cff2522eb3429799e49e5f44b356ef926bcf390dccc2");
+    assert(digest256 == cast(ubyte[]) hexString!"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73");
     assert(digest384 == cast(ubyte[]) hexString!("feb67349df3db6f5924815d6c3dc133f091809213731fe5c7b5"
         ~"f4999e463479ff2877f5f2936fa63bb43784b12f3ebb4"));
     assert(digest512 == cast(ubyte[]) hexString!("4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034"
         ~"898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"));
-    assert(digest512_224 == cast(ubyte[]) x"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
-    assert(digest512_256 == cast(ubyte[]) x"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
+    assert(digest512_224 == cast(ubyte[]) hexString!"ff83148aa07ec30655c1b40aff86141c0215fe2a54f767d3f38743d8");
+    assert(digest512_256 == cast(ubyte[]) hexString!"fc3189443f9c268f626aea08a756abe7b726b05f701cb08222312ccfd6710a26");
 
     digest        = sha1Of      ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest224     = sha224Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
@@ -1046,15 +1046,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512     = sha512Of    ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_224 = sha512_224Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     digest512_256 = sha512_256Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest == cast(ubyte[]) x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
-    assert(digest224 == cast(ubyte[]) x"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
-    assert(digest256 == cast(ubyte[]) x"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
+    assert(digest == cast(ubyte[]) hexString!"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+    assert(digest224 == cast(ubyte[]) hexString!"bff72b4fcb7d75e5632900ac5f90d219e05e97a7bde72e740db393d9");
+    assert(digest256 == cast(ubyte[]) hexString!"db4bfcbd4da0cd85a60c3c37d3fbd8805c77f15fc6b1fdfe614ee0a7c8fdb4c0");
     assert(digest384 == cast(ubyte[]) hexString!("1761336e3f7cbfe51deb137f026f89e01a448e3b1fafa64039"
         ~"c1464ee8732f11a5341a6f41e0c202294736ed64db1a84"));
     assert(digest512 == cast(ubyte[]) hexString!("1e07be23c26a86ea37ea810c8ec7809352515a970e9253c26f"
         ~"536cfc7a9996c45c8370583e0a78fa4a90041d71a4ceab7423f19c71b9d5a3e01249f0bebd5894"));
-    assert(digest512_224 == cast(ubyte[]) x"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
-    assert(digest512_256 == cast(ubyte[]) x"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
+    assert(digest512_224 == cast(ubyte[]) hexString!"a8b4b9174b99ffc67d6f49be9981587b96441051e16e6dd036b140d3");
+    assert(digest512_256 == cast(ubyte[]) hexString!"cdf1cc0effe26ecc0c13758f7b4a48e000615df241284185c39eb05d355bb9c8");
 
     digest        = sha1Of      ("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
@@ -1070,15 +1070,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
                                  "1234567890123456789012345678901234567890");
     digest512_256 = sha512_256Of("1234567890123456789012345678901234567890"~
                                  "1234567890123456789012345678901234567890");
-    assert(digest == cast(ubyte[]) x"50abf5706a150990a08b2c5ea40fa0e585554732");
-    assert(digest224 == cast(ubyte[]) x"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
-    assert(digest256 == cast(ubyte[]) x"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
+    assert(digest == cast(ubyte[]) hexString!"50abf5706a150990a08b2c5ea40fa0e585554732");
+    assert(digest224 == cast(ubyte[]) hexString!"b50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e");
+    assert(digest256 == cast(ubyte[]) hexString!"f371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e");
     assert(digest384 == cast(ubyte[]) hexString!("b12932b0627d1c060942f5447764155655bd4da0c9afa6dd9b"
         ~"9ef53129af1b8fb0195996d2de9ca0df9d821ffee67026"));
     assert(digest512 == cast(ubyte[]) hexString!("72ec1ef1124a45b047e8b7c75a932195135bb61de24ec0d191"
         ~"4042246e0aec3a2354e093d76f3048b456764346900cb130d2a4fd5dd16abb5e30bcb850dee843"));
-    assert(digest512_224 == cast(ubyte[]) x"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
-    assert(digest512_256 == cast(ubyte[]) x"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
+    assert(digest512_224 == cast(ubyte[]) hexString!"ae988faaa47e401a45f704d1272d99702458fea2ddc6582827556dd2");
+    assert(digest512_256 == cast(ubyte[]) hexString!"2c9fdbc0c90bdd87612ee8455474f9044850241dc105b1e8b94b8ddf5fac9148");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
@@ -1089,15 +1089,15 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512 = sha512Of(onemilliona);
     digest512_224 = sha512_224Of(onemilliona);
     digest512_256 = sha512_256Of(onemilliona);
-    assert(digest == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[]) x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[]) x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest == cast(ubyte[]) hexString!"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == cast(ubyte[]) hexString!"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == cast(ubyte[]) hexString!"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
     assert(digest384 == cast(ubyte[]) hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
     assert(digest512 == cast(ubyte[]) hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[]) x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[]) x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == cast(ubyte[]) hexString!"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == cast(ubyte[]) hexString!"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
     auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
     digest = sha1Of(oneMillionRange);
@@ -1107,17 +1107,18 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     digest512 = sha512Of(oneMillionRange);
     digest512_224 = sha512_224Of(oneMillionRange);
     digest512_256 = sha512_256Of(oneMillionRange);
-    assert(digest == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
-    assert(digest224 == cast(ubyte[]) x"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
-    assert(digest256 == cast(ubyte[]) x"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+    assert(digest == cast(ubyte[]) hexString!"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(digest224 == cast(ubyte[]) hexString!"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67");
+    assert(digest256 == cast(ubyte[]) hexString!"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
     assert(digest384 == cast(ubyte[]) hexString!("9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
         ~"72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"));
     assert(digest512 == cast(ubyte[]) hexString!("e718483d0ce769644e2e42c7bc15b4638e1f98b13b20442856"
         ~"32a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"));
-    assert(digest512_224 == cast(ubyte[]) x"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
-    assert(digest512_256 == cast(ubyte[]) x"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
+    assert(digest512_224 == cast(ubyte[]) hexString!"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
+    assert(digest512_256 == cast(ubyte[]) hexString!"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
-    assert(toHexString(cast(ubyte[20]) x"a9993e364706816aba3e25717850c26c9cd0d89d")
+    enum ubyte[20] input = hexString!"a9993e364706816aba3e25717850c26c9cd0d89d";
+    assert(toHexString(input)
         == "A9993E364706816ABA3E25717850C26C9CD0D89D");
 }
 
@@ -1247,45 +1248,46 @@ alias SHA512_256Digest = WrapperDigest!SHA512_256; ///ditto
 
 @system unittest
 {
+    import std.conv : hexString;
     auto sha = new SHA1Digest();
 
     sha.put(cast(ubyte[])"abcdef");
     sha.reset();
     sha.put(cast(ubyte[])"");
-    assert(sha.finish() == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.finish() == cast(ubyte[]) hexString!"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
     sha.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
     ubyte[22] result;
     auto result2 = sha.finish(result[]);
-    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+    assert(result[0 .. 20] == result2 && result2 == cast(ubyte[]) hexString!"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     debug
         assertThrown!Error(sha.finish(result[0 .. 15]));
 
     assert(sha.length == 20);
 
-    assert(sha.digest("") == cast(ubyte[]) x"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert(sha.digest("") == cast(ubyte[]) hexString!"da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
-    assert(sha.digest("a") == cast(ubyte[]) x"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+    assert(sha.digest("a") == cast(ubyte[]) hexString!"86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
 
-    assert(sha.digest("abc") == cast(ubyte[]) x"a9993e364706816aba3e25717850c26c9cd0d89d");
+    assert(sha.digest("abc") == cast(ubyte[]) hexString!"a9993e364706816aba3e25717850c26c9cd0d89d");
 
     assert(sha.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) x"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
+           == cast(ubyte[]) hexString!"84983e441c3bd26ebaae4aa1f95129e5e54670f1");
 
-    assert(sha.digest("message digest") == cast(ubyte[]) x"c12252ceda8be8994d5fa0290a47231c1d16aae3");
+    assert(sha.digest("message digest") == cast(ubyte[]) hexString!"c12252ceda8be8994d5fa0290a47231c1d16aae3");
 
     assert(sha.digest("abcdefghijklmnopqrstuvwxyz")
-           == cast(ubyte[]) x"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
+           == cast(ubyte[]) hexString!"32d10c7b8cf96570ca04ce37f2a19d84240d3a89");
 
     assert(sha.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) x"761c457bf73b14d27e9e9265c46f4b4dda11f940");
+           == cast(ubyte[]) hexString!"761c457bf73b14d27e9e9265c46f4b4dda11f940");
 
     assert(sha.digest("1234567890123456789012345678901234567890",
                                    "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) x"50abf5706a150990a08b2c5ea40fa0e585554732");
+           == cast(ubyte[]) hexString!"50abf5706a150990a08b2c5ea40fa0e585554732");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
-    assert(sha.digest(onemilliona) == cast(ubyte[]) x"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
+    assert(sha.digest(onemilliona) == cast(ubyte[]) hexString!"34aa973cd4c4daa4f61eeb2bdbad27316534016f");
 }


### PR DESCRIPTION
Basically `s/x"/hexString!"/`

Required for the deprecation of hexstrings.

Revival of https://github.com/dlang/phobos/pull/5507