### PR TITLE
Removed unnecessary atomicLoad inside initOnce

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2578,7 +2578,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init, shared Mutex mutex)
     {
         synchronized (mutex)
         {
-            if (!atomicLoad!(MemoryOrder.acq)(flag))
+            if (!atomicLoad!(MemoryOrder.raw)(flag))
             {
                 var = init;
                 atomicStore!(MemoryOrder.rel)(flag, true);


### PR DESCRIPTION
I believe the second `atomicLoad` in this double-checked lock is unnecessary.