### PR TITLE
Bump tools to bump libdparse to 0.7.2-alpha.6

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -130,7 +130,7 @@ publictests()
     if [ ! -d ../tools ] ; then
         clone https://github.com/dlang/tools.git ../tools master
     fi
-    git -C ../tools checkout 6ad91215253b52e6ecfc39fe1854815867c66f23
+    git -C ../tools checkout 1e547d263fca3a90faf9c19f1fb37ff8286129ef
 
     make -f posix.mak -j$N publictests DUB=$DUB BUILD=$BUILD
 }


### PR DESCRIPTION
FWIW locking the version of tools is really annoying. I would love to remove this.

Depends on
- https://github.com/dlang/tools/pull/300
- https://github.com/dlang-community/libdparse/pull/188