### PR TITLE
Update DScanner to 6ba40537532fd795e83db0a7c8609512decdefc5

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -81,7 +81,7 @@ ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 DUB=dub
 TOOLS_DIR=../tools
-DSCANNER_HASH=bb32e9f1e3e5206deb11b3dbc43ad44e23fabf96
+DSCANNER_HASH=6ba40537532fd795e83db0a7c8609512decdefc5
 DSCANNER_DIR=../dscanner-$(DSCANNER_HASH)
 
 # Documentation-related stuff


### PR DESCRIPTION
See also:
- https://github.com/dlang-community/D-Scanner/pull/549 fix for DScanner
- https://github.com/dlang-community/D-Scanner/pull/550 (update PR for the `phobos` branch)
- https://github.com/dlang/dmd/pull/7766 (compiler fix + origin of the failures)