### PR TITLE
Fix Auto-Decoding Issue With DateTime From String Methods

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -3116,11 +3116,12 @@ public:
         import std.exception : enforce;
         import std.format : format;
         import std.string : strip;
+        import std.utf : byCodeUnit;
 
         auto str = strip(isoString);
 
         enforce(str.length >= 15, new DateTimeException(format("Invalid ISO String: %s", isoString)));
-        auto t = str.countUntil('T');
+        auto t = str.byCodeUnit.countUntil('T');
 
         enforce(t != -1, new DateTimeException(format("Invalid ISO String: %s", isoString)));
 
@@ -3216,11 +3217,12 @@ public:
         import std.exception : enforce;
         import std.format : format;
         import std.string : strip;
+        import std.utf : byCodeUnit;
 
         auto str = strip(isoExtString);
 
         enforce(str.length >= 15, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
-        auto t = str.countUntil('T');
+        auto t = str.byCodeUnit.countUntil('T');
 
         enforce(t != -1, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
 
@@ -3315,11 +3317,12 @@ public:
         import std.exception : enforce;
         import std.format : format;
         import std.string : strip;
+        import std.utf : byCodeUnit;
 
         auto str = strip(simpleString);
 
         enforce(str.length >= 15, new DateTimeException(format("Invalid string format: %s", simpleString)));
-        auto t = str.countUntil(' ');
+        auto t = str.byCodeUnit.countUntil(' ');
 
         enforce(t != -1, new DateTimeException(format("Invalid string format: %s", simpleString)));
 


### PR DESCRIPTION
`DateTime`'s from string methods use `countUntil` in order to check for the seperator between
the date and the time strings. This is fine until the result is used to slice the original
string, which can cause incorrect results. This is due to the problem that `countUntil` gives
the number of code points until the Needle and not the number of code units, which is the
how it's sliced.

Normally this doesn't actually pose a problem because actual time strings only contain ASCII
characters, but this does fix two things

1. No more auto decoding in the function, so it's faster
2. Better error messages if there are non-ASCII characters in the string because the break-up is correct