### PR TITLE
Fix documentation for std.path.dirName

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -508,7 +508,7 @@ if (isSomeChar!C && isSomeChar!C1)
     assert(sa.baseName == "test");
 }
 
-/** Returns the directory part of a path.  On Windows, this
+/** Returns the parent directory of path. On Windows, this
     includes the drive letter if present.
 
     Params:


### PR DESCRIPTION
The documentation currently says "Returns the directory part of a path." That is incorrect, because it actually returns the parent directory no matter what the argument `path` is (even if `path` is a directory).

https://issues.dlang.org/show_bug.cgi?id=18294