### PR TITLE
Add warning to isConvertibleToString.

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6130,8 +6130,27 @@ deprecated
 }
 
 /**
- * Detect whether $(D T) is a struct, static array, or enum that is implicitly
- * convertible to a string.
+  $(RED Warning: This trait will be deprecated as soon as it is no longer used
+                 in Phobos. For a function parameter to safely accept a type
+                 that implicitly converts to string as a string, the conversion
+                 needs to happen at the callsite; otherwise, the conversion is
+                 done inside the function, and in many cases, that means that
+                 local memory is sliced (e.g. if a static array is passed to
+                 the function, then it's copied, and the resulting dynamic
+                 array will be a slice of a local variable). So, if the
+                 resulting string escapes the function, the string refers to
+                 invalid memory, and accessing it would mean accessing invalid
+                 memory. As such, the only safe way for a function to accept
+                 types that implicitly convert to string is for the implicit
+                 conversion to be done at the callsite, and that can only occur
+                 if the parameter is explicitly typed as an array, whereas
+                 using isConvertibleToString in a template constraint would
+                 result in the conversion being done inside the function. As
+                 such, isConvertibleToString is inherently unsafe and is going
+                 to be deprecated.)
+
+   Detect whether $(D T) is a struct, static array, or enum that is implicitly
+   convertible to a string.
  */
 template isConvertibleToString(T)
 {


### PR DESCRIPTION
I should have added this warning months ago, but here it is. Hopefully, it won't take all that long to remove uses of `isConvertibleToString` from Phobos so that we can deprecate it, but it is unfortunately used in a number of places, so it will take several PRs to remove them - especially if they sit and rot like my previous PRs for removing uses of `isConvertibleToString` sat and rotted.