### PR TITLE
Remove more uses of isConvertibleToString from std.path

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -1235,10 +1235,20 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
  *      $(LREF setExtension)
  */
 auto withExtension(R, C)(R path, C[] ext)
-if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R) &&
-    !isConvertibleToString!R &&
-    isSomeChar!C)
+if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) &&
+    !isSomeString!R && isSomeChar!C)
+{
+    return _withExtension(path, ext);
+}
+
+/// Ditto
+auto withExtension(C1, C2)(C1[] path, C2[] ext)
+if (isSomeChar!C1 && isSomeChar!C2)
+{
+    return _withExtension(path, ext);
+}
+
+private auto _withExtension(R, C)(R path, C[] ext)
 {
     import std.range : only, chain;
     import std.utf : byUTF;
@@ -1264,15 +1274,17 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
     assert(withExtension("file.ext"w.byWchar, ".").array == "file."w);
 }
 
-auto withExtension(R, C)(auto ref R path, C[] ext)
-if (isConvertibleToString!R)
-{
-    return withExtension!(StringTypeOf!R)(path, ext);
-}
-
 @safe unittest
 {
+    import std.algorithm.comparison : equal;
+
     assert(testAliasedString!withExtension("file", "ext"));
+
+    enum S : string { a = "foo.bar" }
+    assert(equal(S.a.withExtension(".txt"), "foo.txt"));
+
+    char[S.a.length] sa = S.a[];
+    assert(equal(sa.withExtension(".txt"), "foo.txt"));
 }
 
 /** Params:

--- a/std/path.d
+++ b/std/path.d
@@ -1080,12 +1080,22 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
         slice of path with the extension (if any) stripped off
 */
 auto stripExtension(R)(R path)
-if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R) &&
-    !isConvertibleToString!R)
+if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) && !isSomeString!R)
 {
-    auto i = extSeparatorPos(path);
-    return (i == -1) ? path : path[0 .. i];
+    return _stripExtension(path);
+}
+
+/// Ditto
+auto stripExtension(C)(C[] path)
+if (isSomeChar!C)
+{
+    return _stripExtension(path);
+}
+
+private auto _stripExtension(R)(R path)
+{
+    immutable i = extSeparatorPos(path);
+    return i == -1 ? path : path[0 .. i];
 }
 
 ///
@@ -1100,15 +1110,15 @@ if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(Element
     assert(stripExtension("dir/file.ext")   == "dir/file");
 }
 
-auto stripExtension(R)(auto ref R path)
-if (isConvertibleToString!R)
-{
-    return stripExtension!(StringTypeOf!R)(path);
-}
-
 @safe unittest
 {
     assert(testAliasedString!stripExtension("file"));
+
+    enum S : string { a = "foo.bar" }
+    assert(S.a.stripExtension == "foo");
+
+    char[S.a.length] sa = S.a[];
+    assert(sa.stripExtension == "foo");
 }
 
 @safe unittest

--- a/std/path.d
+++ b/std/path.d
@@ -537,8 +537,6 @@ if (isSomeChar!C)
 }
 
 private auto _dirName(R)(R path)
-if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R)
 {
     static auto result(bool dot, typeof(path[0 .. 1]) p)
     {
@@ -701,8 +699,6 @@ if (isSomeChar!C)
 }
 
 private auto _rootName(R)(R path)
-if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R)
 {
     if (path.empty)
         goto Lnull;
@@ -809,8 +805,6 @@ if (isSomeChar!C)
 }
 
 private auto _driveName(R)(R path)
-if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R)
 {
     version (Windows)
     {
@@ -903,8 +897,6 @@ if (isSomeChar!C)
 }
 
 private auto _stripDrive(R)(R path)
-if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
-    isNarrowString!R)
 {
     version(Windows)
     {

--- a/std/path.d
+++ b/std/path.d
@@ -897,6 +897,7 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) && !isSo
 
 /// ditto
 auto stripDrive(C)(C[] path)
+if (isSomeChar!C)
 {
     return _stripDrive(path);
 }


### PR DESCRIPTION
Using `isConvertibleToString` is unsafe, because it results in the conversion being done inside the function instead of at the call site, which means that if the string escapes, it's invalid. The only way to make the conversion happen at the call site is for the function to explicitly accept an array. As such, we need to deprecate `isConvertibleToString`, but first, we need to remove uses of it from Phobos.