### PR TITLE
Optimized std.datetime.timezone.SimpleTimeZone.fromISOExtString

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -1699,43 +1699,51 @@ package:
     static immutable(SimpleTimeZone) fromISOExtString(S)(S isoExtString) @safe pure
         if (isSomeString!S)
     {
-        import std.algorithm.searching : startsWith, countUntil, all;
-        import std.ascii : isDigit;
-        import std.conv : to;
+        import std.algorithm.searching : startsWith;
+        import std.conv : ConvException, to;
+        import std.datetime.date : DateTimeException;
         import std.exception : enforce;
         import std.format : format;
+        import std.string : indexOf;
 
-        auto dstr = to!dstring(isoExtString);
+        auto whichSign = isoExtString.startsWith('-', '+');
+        enforce!DateTimeException(whichSign > 0, format("Invalid ISO String: %s", isoExtString));
+        auto sign = whichSign == 1 ? -1 : 1;
 
-        import std.datetime.date : DateTimeException;
-        enforce!DateTimeException(dstr.startsWith('-', '+'), "Invalid ISO String");
+        isoExtString = isoExtString[1 .. $];
+        enforce!DateTimeException(!isoExtString.empty, format("Invalid ISO String: %s", isoExtString));
 
-        auto sign = dstr.startsWith('-') ? -1 : 1;
-
-        dstr.popFront();
-        enforce!DateTimeException(!dstr.empty, "Invalid ISO String");
-
-        immutable colon = dstr.countUntil(':');
-
-        dstring hoursStr;
-        dstring minutesStr;
+        immutable colon = isoExtString.indexOf(':');
+        S hoursStr;
+        S minutesStr;
+        int hours, minutes;
 
         if (colon != -1)
         {
-            hoursStr = dstr[0 .. colon];
-            minutesStr = dstr[colon + 1 .. $];
-            enforce!DateTimeException(minutesStr.length == 2, format("Invalid ISO String: %s", dstr));
+            hoursStr = isoExtString[0 .. colon];
+            minutesStr = isoExtString[colon + 1 .. $];
+            enforce!DateTimeException(minutesStr.length == 2, format("Invalid ISO String: %s", isoExtString));
         }
         else
-            hoursStr = dstr;
+        {
+            hoursStr = isoExtString;
+        }
 
-        enforce!DateTimeException(hoursStr.length == 2, format("Invalid ISO String: %s", dstr));
-        enforce!DateTimeException(all!isDigit(hoursStr), format("Invalid ISO String: %s", dstr));
-        enforce!DateTimeException(all!isDigit(minutesStr), format("Invalid ISO String: %s", dstr));
+        enforce!DateTimeException(hoursStr.length == 2, format("Invalid ISO String: %s", isoExtString));
 
-        immutable hours = to!int(hoursStr);
-        immutable minutes = minutesStr.empty ? 0 : to!int(minutesStr);
-        enforce!DateTimeException(hours < 24 && minutes < 60, format("Invalid ISO String: %s", dstr));
+        try
+        {
+            // cast to int from uint is used because it checks for
+            // non digits without extra loops
+            hours = cast(int) to!uint(hoursStr);
+            minutes = cast(int) (minutesStr.empty ? 0 : to!uint(minutesStr));
+        }
+        catch (ConvException)
+        {
+            throw new DateTimeException(format("Invalid ISO String: %s", isoExtString));
+        }
+
+        enforce!DateTimeException(hours < 24 && minutes < 60, format("Invalid ISO String: %s", isoExtString));
 
         return new immutable SimpleTimeZone(sign * (dur!"hours"(hours) + dur!"minutes"(minutes)));
     }


### PR DESCRIPTION
Results

```
$ ldc2 -O -release test.d && ./test
old 2 secs, 411 ms, 644 μs, and 6 hnsecs
new 858 ms, 177 μs, and 6 hnsecs

$ dmd -O -inline -release test.d && ./test
old 4 secs, 936 ms, 985 μs, and 5 hnsecs
new 1 sec, 536 ms, 176 μs, and 1 hnsec
```

code

```d
import std.stdio;
import std.algorithm;
import std.conv;
import std.ascii;
import std.range;
import std.traits;
import std.string;
import std.datetime.timezone;
import std.datetime.stopwatch;
import std.utf;

enum testCount = 10_000_000;
__gshared a = "+01:30";

immutable(SimpleTimeZone) fromISOExtString1(S)(S isoExtString) @safe pure
        if (isSomeString!S)
{
    import std.algorithm.searching : startsWith, countUntil, all;
    import std.ascii : isDigit;
    import std.conv : to;
    import std.exception : enforce;
    import std.format : format;

    auto dstr = to!dstring(isoExtString);

    import std.datetime.date : DateTimeException;
    enforce!DateTimeException(dstr.startsWith('-', '+'), "Invalid ISO String");

    auto sign = dstr.startsWith('-') ? -1 : 1;

    dstr.popFront();
    enforce!DateTimeException(!dstr.empty, "Invalid ISO String");

    immutable colon = dstr.countUntil(':');

    dstring hoursStr;
    dstring minutesStr;

    if (colon != -1)
    {
        hoursStr = dstr[0 .. colon];
        minutesStr = dstr[colon + 1 .. $];
        enforce!DateTimeException(minutesStr.length == 2, format("Invalid ISO String: %s", dstr));
    }
    else
        hoursStr = dstr;

    enforce!DateTimeException(hoursStr.length == 2, format("Invalid ISO String: %s", dstr));
    enforce!DateTimeException(all!isDigit(hoursStr), format("Invalid ISO String: %s", dstr));
    enforce!DateTimeException(all!isDigit(minutesStr), format("Invalid ISO String: %s", dstr));

    immutable hours = to!int(hoursStr);
    immutable minutes = minutesStr.empty ? 0 : to!int(minutesStr);
    enforce!DateTimeException(hours < 24 && minutes < 60, format("Invalid ISO String: %s", dstr));

    return new immutable SimpleTimeZone(sign * (dur!"hours"(hours) + dur!"minutes"(minutes)));
}

immutable(SimpleTimeZone) fromISOExtString2(S)(S isoExtString) @safe pure
        if (isSomeString!S)
{
    import std.algorithm.searching : startsWith;
    import std.conv : to, ConvException;
    import std.datetime.date : DateTimeException;
    import std.exception : enforce;
    import std.string : indexOf;

    auto whichSign = isoExtString.startsWith('-', '+');
    enforce!DateTimeException(whichSign > 0, "Invalid ISO String: " ~ isoExtString);
    auto sign = whichSign == 1 ? -1 : 1;

    isoExtString = isoExtString[1 .. $];
    enforce!DateTimeException(!isoExtString.empty, "Invalid ISO String: " ~ isoExtString);

    immutable colon = isoExtString.indexOf(':');
    S hoursStr;
    S minutesStr;
    int hours, minutes;

    if (colon != -1)
    {
        hoursStr = isoExtString[0 .. colon];
        minutesStr = isoExtString[colon + 1 .. $];
        enforce!DateTimeException(minutesStr.length == 2, "Invalid ISO String: " ~ isoExtString);
    }
    else
    {
        hoursStr = isoExtString;
    }

    enforce!DateTimeException(hoursStr.length == 2, "Invalid ISO String: " ~ isoExtString);

    try
    {
        // cast to int from uint is used because it checks for
        // non digits without extra loops
        hours = cast(int) to!uint(hoursStr);
        minutes = cast(int) (minutesStr.empty ? 0 : to!uint(minutesStr));
    }
    catch (ConvException)
    {
        throw new DateTimeException("Invalid ISO String: " ~ isoExtString);
    }

    enforce!DateTimeException(hours < 24 && minutes < 60, "Invalid ISO String: " ~ isoExtString);

    return new immutable SimpleTimeZone(sign * (dur!"hours"(hours) + dur!"minutes"(minutes)));
}

void main()
{
    auto result = to!Duration(benchmark!(() => fromISOExtString1(a))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => fromISOExtString2(a))(testCount)[0]);

    writeln("old", "\t\t", result);
    writeln("new", "\t\t", result2);
}
```