### PR TITLE
Fix issue 15949: Make readText handle mismatched BOMs.

### DIFF
--- a/changelog/std-file-readText.dd
+++ b/changelog/std-file-readText.dd
@@ -1,0 +1,15 @@
+$(REF readBOM, std, file) added and $(REF readText, std, file) now reports mismatched BOMs.
+
+$(REF readBOM, std, file) attempts to read the
+$(HTTP https://en.wikipedia.org/wiki/Byte_order_mark, BOM) from the front of the
+file and returns the corresponding $(REF BOMSeq, std, encoding).
+
+$(REF readText, std, file) now checks the BOM (if present) and throws a
+$(REF BOMException, std, encoding) if the the BOM is for an encoding that does
+not match the requested return type. A $(REF UTFException, std, utf) will still
+be thrown if the file contains invalid UTF, but now, if there isn't a BOM, it
+also checks whether the length of the file indicates that it can't have the
+requested encoding, in which case an $(REF UTFException, std, utf) is thrown.
+Previously, in that case, when $(REF readText, std, file) attempt to cast to
+the requested type, an Error was thrown because the resulting array was
+misaligned.

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -74,6 +74,7 @@ $(TR $(TD Representation) $(TD
 $(TR $(TD Exceptions) $(TD
     $(LREF INVALID_SEQUENCE)
     $(LREF EncodingException)
+    $(LREF BOMException))
 ))
 )
 
@@ -2502,11 +2503,18 @@ do
 //=============================================================================
 
 /** The base class for exceptions thrown by this module */
-class EncodingException : Exception { this(string msg) @safe pure { super(msg); } }
+class EncodingException : Exception
+{
+    import std.exception : basicExceptionCtors;
+    ///
+    mixin basicExceptionCtors;
+}
 
 class UnrecognizedEncodingException : EncodingException
 {
-    private this(string msg) @safe pure { super(msg); }
+    import std.exception : basicExceptionCtors;
+    ///
+    mixin basicExceptionCtors;
 }
 
 /** Abstract base class of all encoding schemes */
@@ -3907,3 +3915,23 @@ if (isForwardRange!Range && is(Unqual!(ElementType!Range) == ubyte))
 
 /** Constant defining a fully decoded BOM */
 enum dchar utfBOM = 0xfeff;
+
+
+/++
+    Used to indicate that a BOM was encountered that is considered invalid by
+    the function that encountered it (e.g. if a file's $(LREF BOM) says that
+    it's $(LREF BOM.utf16be), but the function tried to read it as
+    $(LREF BOM.utf8)).
+  +/
+class BOMException : EncodingException
+{
+    ///
+    this(string msg, immutable BOMSeq bomSeq, string file = __FILE__, size_t line = __LINE__) @nogc nothrow pure @safe
+    {
+        super(msg, file, line);
+        this.bomSeq = bomSeq;
+    }
+
+    /// The $(LREF BOMSeq) that was encountered.
+    immutable BOMSeq bomSeq;
+}


### PR DESCRIPTION
This adds a BOMException to std.encoding and makes readText check the
BOM. If there is one, and it doesn't match the requested type, then it
throws a BOMException. If the BOM matches and UTF validation fails or if
there is no BOM, and the size of the file mismatches with the requested
type (e.g. it's not divible by 2, so it can't be valid UTF-16), then a
UTFException is thrown.

readBOM was also added to read a BOM from a file. readText uses it, but
it's public so that anyone can use it.

I'm also looking into adding a function (probably called `readFileAsRange`) which returns a range of the requested character type and converts the file to that encoding regardless of whether it was UTF-8, UTF-16 BE, UTF-16 LE, UTF-32 BE, or UTF-32 LE, which would make it possible not to care about the file's encoding so long as it's at least UTF-8, UTF-16, or UTF-32. It would also make it possible to use the replacement character instead of throwing a `UTFException` when invalid UTF is encountered. But that function is clearly going to be a bit more involved to implement than this, so I'm doing it separately. These changes at least make it possible to cleanly deal with UTF-8, UTF-16 of the native endianness, and UTF-32 of the native endianness, whereas before they just resulted in a `UTFException` or possibly an `Error` (if the attempted cast to the requested string type would result in a misaligned array).