### PR TITLE
Group documentation in std.algorithm

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -541,12 +541,22 @@ $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 /**
 Assigns `value` to each element of input _range `range`.
 
+Alternatively, instead of using a single `value` to fill the `range`,
+a `filter` $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives)
+can be provided. The length of `filler` and `range` do not need to match, but
+`filler` must not be empty.
+
 Params:
         range = An
                 $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
                 that exposes references to its elements and has assignable
                 elements
         value = Assigned to each element of range
+        filler = A
+                $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives)
+                representing the _fill pattern.
+
+Throws: If `filler` is empty.
 
 See_Also:
         $(LREF uninitializedFill)
@@ -712,18 +722,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
     }
 }
 
-/**
-Fills `range` with a pattern copied from `filler`. The length of
-`range` does not have to be a multiple of the length of $(D
-filler). If `filler` is empty, an exception is thrown.
-
-Params:
-    range = An $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
-            that exposes references to its elements and has assignable elements.
-    filler = The
-             $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives)
-             representing the _fill pattern.
- */
+/// ditto
 void fill(InputRange, ForwardRange)(InputRange range, ForwardRange filler)
 if (isInputRange!InputRange
     && (isForwardRange!ForwardRange
@@ -2181,14 +2180,19 @@ if (isBidirectionalRange!Range
 
 // reverse
 /**
-Reverses `r` in-place.  Performs `r.length / 2` evaluations of $(D
-swap).
+Reverses `r` in-place.  Performs `r.length / 2` evaluations of `swap`.
+UTF sequences consisting of multiple code units are preserved properly.
+
 Params:
     r = a $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives)
-    with swappable elements or a random access range with a length member
+        with either swappable elements, a random access range with a length member,
+        or a narrow string
 
-See_Also:
-    $(HTTP sgi.com/tech/stl/_reverse.html, STL's _reverse), $(REF retro, std,range) for a lazy reversed range view
+Note:
+    When passing a string with unicode modifiers on characters, such as `\u0301`,
+    this function will not properly keep the position of the modifier. For example,
+    reversing `ba\u0301d` ("bád") will result in d\u0301ab ("d́ab") instead of
+    `da\u0301b` ("dáb").
 */
 void reverse(Range)(Range r)
 if (isBidirectionalRange!Range && !isRandomAccessRange!Range
@@ -2239,20 +2243,7 @@ if (isRandomAccessRange!Range && hasLength!Range)
     assert(range == [3, 2, 1]);
 }
 
-/**
-Reverses `r` in-place, where `r` is a narrow string (having
-elements of type `char` or `wchar`). UTF sequences consisting of
-multiple code units are preserved properly.
-
-Params:
-    s = a narrow string
-
-Bugs:
-    When passing a sting with unicode modifiers on characters, such as `\u0301`,
-    this function will not properly keep the position of the modifier. For example,
-    reversing `ba\u0301d` ("bád") will result in d\u0301ab ("d́ab") instead of
-    `da\u0301b` ("dáb").
-*/
+///ditto
 void reverse(Char)(Char[] s)
 if (isNarrowString!(Char[]) && !is(Char == const) && !is(Char == immutable))
 {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -748,7 +748,8 @@ if (isInputRange!R && !isInfinite!R)
     `haystack` before reaching an element for which
     `startsWith!pred(haystack, needles)` is `true`. If
     `startsWith!pred(haystack, needles)` is not `true` for any element in
-    `haystack`, then `-1` is returned.
+    `haystack`, then `-1` is returned. If only `pred` is provided,
+    `pred(haystack)` is tested for each element.
 
     See_Also: $(REF indexOf, std,string)
   +/
@@ -898,18 +899,7 @@ if (isInputRange!R &&
     assert(countUntil("hello world", "world", 'l') == 2);
 }
 
-/++
-    Similar to the previous overload of `countUntil`, except that this one
-    evaluates only the predicate `pred`.
-
-    Params:
-        pred = Predicate to when to stop counting.
-        haystack = An
-          $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of
-          elements to be counted.
-    Returns: The number of elements which must be popped from `haystack`
-    before `pred(haystack.front)` is `true`.
-  +/
+/// ditto
 ptrdiff_t countUntil(alias pred, R)(R haystack)
 if (isInputRange!R &&
     is(typeof(unaryFun!pred(haystack.front)) : bool))
@@ -1457,35 +1447,51 @@ private auto extremum(alias selector = "a < b", Range,
 
 // find
 /**
-Finds an individual element in an input range. Elements of $(D
-haystack) are compared with `needle` by using predicate $(D
-pred). Performs $(BIGOH walkLength(haystack)) evaluations of $(D
-pred).
+Finds an individual element in an $(REF_ALTTEXT input range, isInputRange, std,range,primitives).
+Elements of `haystack` are compared with `needle` by using predicate
+`pred` with `pred(haystack.front, needle)`.
+`find` performs $(BIGOH walkLength(haystack)) evaluations of `pred`.
 
-To _find the last occurrence of `needle` in `haystack`, call $(D
-find(retro(haystack), needle)). See $(REF retro, std,range).
+To _find the last occurrence of `needle` in a
+$(REF_ALTTEXT bidirectional, isBidirectionalRange, std,range,primitives) `haystack`,
+call `find(retro(haystack), needle)`. See $(REF retro, std,range).
+
+If no `needle` is provided, `pred(haystack.front)` will be evaluated on each
+element of the input range.
+
+If `input` is a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives),
+`needle` can be a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) too.
+In this case `startsWith!pred(haystack, needle)` is evaluated on each evaluation.
+
+Note:
+    `find` behaves similar to `dropWhile` in other languages.
+
+Complexity:
+    `find` performs $(BIGOH walkLength(haystack)) evaluations of `pred`.
+    There are specializations that improve performance by taking
+    advantage of $(REF_ALTTEXT bidirectional, isBidirectionalRange, std,range,primitives)
+    or $(REF_ALTTEXT random access, isRandomAccess, std,range,primitives)
+    ranges (where possible).
 
 Params:
 
-pred = The predicate for comparing each element with the needle, defaulting to
-`"a == b"`.
-The negated predicate `"a != b"` can be used to search instead for the first
-element $(I not) matching the needle.
+    pred = The predicate for comparing each element with the needle, defaulting to equality `"a == b"`.
+           The negated predicate `"a != b"` can be used to search instead for the first
+           element $(I not) matching the needle.
 
-haystack = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
-searched in.
+    haystack = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+               searched in.
 
-needle = The element searched for.
+    needle = The element searched for.
 
 Returns:
 
-`haystack` advanced such that the front element is the one searched for;
-that is, until `binaryFun!pred(haystack.front, needle)` is `true`. If no
-such position exists, returns an empty `haystack`.
+    `haystack` advanced such that the front element is the one searched for;
+    that is, until `binaryFun!pred(haystack.front, needle)` is `true`. If no
+    such position exists, returns an empty `haystack`.
 
-See_Also:
-     $(HTTP sgi.com/tech/stl/_find.html, STL's _find)
- */
+See_ALso: $(LREF findAdjacent), $(LREF findAmong), $(LREF findSkip), $(LREF findSplit), $(LREF startsWith)
+*/
 InputRange find(alias pred = "a == b", InputRange, Element)(InputRange haystack, scope Element needle)
 if (isInputRange!InputRange &&
     is (typeof(binaryFun!pred(haystack.front, needle)) : bool))
@@ -1760,35 +1766,7 @@ if (isInputRange!InputRange &&
     assert([x].find(x).empty == false);
 }
 
-/**
-Advances the input range `haystack` by calling `haystack.popFront`
-until either `pred(haystack.front)`, or $(D
-haystack.empty). Performs $(BIGOH haystack.length) evaluations of $(D
-pred).
-
-To _find the last element of a
-$(REF_ALTTEXT bidirectional, isBidirectionalRange, std,range,primitives) `haystack` satisfying
-`pred`, call `find!(pred)(retro(haystack))`. See $(REF retro, std,range).
-
-`find` behaves similar to `dropWhile` in other languages.
-
-Params:
-
-pred = The predicate for determining if a given element is the one being
-searched for.
-
-haystack = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to
-search in.
-
-Returns:
-
-`haystack` advanced such that the front element is the one searched for;
-that is, until `binaryFun!pred(haystack.front, needle)` is `true`. If no
-such position exists, returns an empty `haystack`.
-
-See_Also:
-     $(HTTP sgi.com/tech/stl/find_if.html, STL's find_if)
-*/
+/// ditto
 InputRange find(alias pred, InputRange)(InputRange haystack)
 if (isInputRange!InputRange)
 {
@@ -1842,31 +1820,7 @@ if (isInputRange!InputRange)
     assert(find!(a=>a%4 == 0)("日本語") == "本語");
 }
 
-/**
-Finds the first occurrence of a forward range in another forward range.
-
-Performs $(BIGOH walkLength(haystack) * walkLength(needle)) comparisons in the
-worst case.  There are specializations that improve performance by taking
-advantage of $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives)
-or random access in the given ranges (where possible), depending on the statistics
-of the two ranges' content.
-
-Params:
-
-pred = The predicate to use for comparing respective elements from the haystack
-and the needle. Defaults to simple equality `"a == b"`.
-
-haystack = The $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
-searched in.
-
-needle = The $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
-searched for.
-
-Returns:
-
-`haystack` advanced such that `needle` is a prefix of it (if no
-such position exists, returns `haystack` advanced to termination).
- */
+/// ditto
 R1 find(alias pred = "a == b", R1, R2)(R1 haystack, scope R2 needle)
 if (isForwardRange!R1 && isForwardRange!R2
         && is(typeof(binaryFun!pred(haystack.front, needle.front)) : bool))
@@ -2664,8 +2618,7 @@ Returns:
 `seq` advanced to the first matching element, or until empty if there are no
 matching elements.
 
-See_Also:
-    $(HTTP sgi.com/tech/stl/find_first_of.html, STL's find_first_of)
+See_Also: $(LREF find), $(REF std,algorithm,comparison,among)
 */
 InputRange findAmong(alias pred = "a == b", InputRange, ForwardRange)(
     InputRange seq, ForwardRange choices)
@@ -2700,6 +2653,11 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
  * Finds `needle` in `haystack` and positions `haystack`
  * right after the first occurrence of `needle`.
  *
+ * If no needle is provided, the `haystack` is advanced as long as `pred`
+ * evaluates to `true`.
+ * Similarly, the haystack is positioned so as `pred` evaluates to `false` for
+ * `haystack.front`.
+ *
  * Params:
  *  haystack = The
  *   $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) to search
@@ -2711,7 +2669,10 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
  *
  * Returns: `true` if the needle was found, in which case `haystack` is
  * positioned after the end of the first occurrence of `needle`; otherwise
- * `false`, leaving `haystack` untouched.
+ * `false`, leaving `haystack` untouched. If no needle is provided, it returns
+ *  the number of times `pred(haystack.front)` returned true.
+ *
+ * See_Also: $(LREF find)
  */
 bool findSkip(alias pred = "a == b", R1, R2)(ref R1 haystack, R2 needle)
 if (isForwardRange!R1 && isForwardRange!R2
@@ -2742,18 +2703,7 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(findSkip(s, "def") && s.empty);
 }
 
-/**
-* Advances the `haystack` as long as `pred` evaluates to `true`.
-* The haystack is positioned so as pred evaluates to false for haystack.front.
-*
-* Params:
-*  haystack = The
-*   $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) to search
-*   in.
-*  pred = Custom predicate for comparison of haystack and needle
-*
-* Returns: The number of times `pred(haystack.front)` returned true.
-*/
+/// ditto
 size_t findSkip(alias pred, R1)(ref R1 haystack)
 if (isForwardRange!R1 && ifTestable!(typeof(haystack.front), unaryFun!pred))
 {
@@ -2827,6 +2777,8 @@ A sub-type of `Tuple!()` of the split portions of `haystack` (see above for
 details).  This sub-type of `Tuple!()` has `opCast` defined for `bool`.  This
 `opCast` returns `true` when the separating `needle` was found
 (`!result[1].empty`) and `false` otherwise.
+
+See_Also: $(LREF find)
  */
 auto findSplit(alias pred = "a == b", R1, R2)(R1 haystack, R2 needle)
 if (isForwardRange!R1 && isForwardRange!R2)
@@ -3192,6 +3144,8 @@ Returns: The minimum, respectively maximum element of a range together with the
 number it occurs in the range.
 
 Throws: `Exception` if `range.empty`.
+
+See_Also: $(REF min, std,algorithm,comparison), $(LREF minIndex), $(LREF minElement), $(LREF minPos)
  */
 Tuple!(ElementType!Range, size_t)
 minCount(alias pred = "a < b", Range)(Range range)
@@ -3398,7 +3352,9 @@ Params:
 Returns: The minimal element of the passed-in range.
 
 See_Also:
-    $(REF min, std,algorithm,comparison)
+
+    $(LREF maxElement), $(REF min, std,algorithm,comparison), $(LREF minCount),
+    $(LREF minIndex), $(LREF minPos)
 */
 auto minElement(alias map, Range)(Range r)
 if (isInputRange!Range && !isInfinite!Range)
@@ -3511,8 +3467,11 @@ Params:
 
 Returns: The maximal element of the passed-in range.
 
+
 See_Also:
-    $(REF max, std,algorithm,comparison)
+
+    $(LREF minElement), $(REF max, std,algorithm,comparison), $(LREF maxCount),
+    $(LREF maxIndex), $(LREF maxPos)
 */
 auto maxElement(alias map, Range)(Range r)
 if (isInputRange!Range && !isInfinite!Range)
@@ -3637,6 +3596,8 @@ Returns: The position of the minimum (respectively maximum) element of forward
 range `range`, i.e. a subrange of `range` starting at the position of  its
 smallest (respectively largest) element and with the same ending as `range`.
 
+See_Also:
+    $(REF max, std,algorithm,comparison), $(LREF minCount), $(LREF minIndex), $(LREF minElement)
 */
 Range minPos(alias pred = "a < b", Range)(Range range)
 if (isForwardRange!Range && !isInfinite!Range &&
@@ -3738,15 +3699,15 @@ Params:
     range = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
     to search.
 
-Complexity: O(n)
-    Exactly `n - 1` comparisons are needed.
+Complexity: $(BIGOH range.length)
+    Exactly `range.length - 1` comparisons are needed.
 
 Returns:
     The index of the first encounter of the minimum element in `range`. If the
     `range` is empty, -1 is returned.
 
 See_Also:
-    $(REF min, std,algorithm,comparison), $(LREF minCount), $(LREF minElement), $(LREF minPos)
+    $(LREF maxIndex), $(REF min, std,algorithm,comparison), $(LREF minCount), $(LREF minElement), $(LREF minPos)
  */
 sizediff_t minIndex(alias pred = "a < b", Range)(Range range)
 if (isForwardRange!Range && !isInfinite!Range &&
@@ -3852,8 +3813,8 @@ if (isForwardRange!Range && !isInfinite!Range &&
 /**
 Computes the index of the first occurrence of `range`'s maximum element.
 
-Complexity: O(n)
-    Exactly `n - 1` comparisons are needed.
+Complexity: $(BIGOH range)
+    Exactly `range.length - 1` comparisons are needed.
 
 Params:
     pred = The ordering predicate to use to determine the maximum element.
@@ -3864,7 +3825,7 @@ Returns:
     `range` is empty, -1 is returned.
 
 See_Also:
-    $(REF max, std,algorithm,comparison), $(LREF maxCount), $(LREF maxElement), $(LREF maxPos)
+    $(LREF minIndex), $(REF max, std,algorithm,comparison), $(LREF maxCount), $(LREF maxElement), $(LREF maxPos)
  */
 sizediff_t maxIndex(alias pred = "a < b", Range)(Range range)
 if (isInputRange!Range && !isInfinite!Range &&


### PR DESCRIPTION
From https://forum.dlang.org/post/spytixhkojgrsbdlgtmy@forum.dlang.org

> Note to self: learn to scroll down in the docs to find other definitions. I was convinced that remove only acted on indices :p

I also took the opportunity to improve the docs in std.algorithm.searching slightly.

Documentation of std.algorithm
------------------------------

BTW in general while I think std.algorithm is one of the best modules in Phobos,
I don't like it's churned with so many redundant symbols - a quick list:

- min, minElement, minIndex, minPos
- find, findAdjacent, findAmong, findSkip, findSplit, findSplitBefore, findSplitAfter
- levenshteinDistance, levenshteinDistanceAndPath
- move, moveAll, moveEmplaceAll, moveSome, moveEmplaceSome
- largestPartialIntersection, largestPartialIntersectionWeighted
- isSorted, isStrictlyMonotonic
- ordered, strictlyOrdered
- nextPermutation, nextEvenPermutation
- sort, schwartzSort (`sort` already accepts a `SwapStrategy`), `multiSort`, `completeSort`
- topN, topNCopy, topNIndex
- partition, partition3, pivotPartition
- fill, uninitializedFill
- strip, stripLeft, stripRight
- cache, cacheBidirectional
- filter, filterBidirectional

It took me a long time to learn to navigate in this chaos and I observed newcomers
struggling at this too. It also takes a toll from experienced developers.

Of course, some methods in this list are actually useful, but here's what I suggest
to do on case by case evaluation:

If there's a simple unification e.g. `largestPartialIntersection!Weightes.yes`,
add it to Phobos and undocument the legacy baggage and make it an `alias`.
That way we risk zero breakage and can do a major cleanup of std.algorithm
and people will benefit immediately from it as , after all, the rendered docs
are important - not the exposed symbols. People looking for the old symbols
will still find them on docarchives.dlang.io and we can add a nice changelog
entry that these symbols have been removed from the documentation if really necessary.
Imho, std.algorithm should be one of the flagship modules and have superb documentation.