### PR TITLE
Added micro-optimizations to std.stdio.LockingTextWriter.put

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2880,10 +2880,9 @@ $(D Range) that locks the file and allows fast writing to it.
             }
 
             // put each element in turn.
-            alias Elem = Unqual!(ElementType!A);
-            foreach (Elem c; writeme)
+            for (; !writeme.empty; writeme.popFront)
             {
-                put(c);
+                put(writeme.front);
             }
         }
 


### PR DESCRIPTION
Using the AST viewer on run.dlang.io, I noticed that foreach loops do a lot of extra copying that isn't always necessary. E.g. this

```d
auto m = "test".takeExactly(3);
foreach (c; m)
{
}

immutable size = 5;
foreach (i; 0 .. size)
{
}
```

becomes

```d
Result m = takeExactly("test", 3LU)
{
	Result __r71 = m;
	for (; !__r71.empty(); __r71.popFront())
	{
		dchar c = __r71.front();
	}
}

immutable immutable(int) size = 5;
{
	int __key72 = 0;
	int __limit73 = 5;
	for (; __key72 < __limit73; __key72 += 1)
	{
		int i = __key72;
	}
}
```

This PR changes some loops to be for loops without extra copying.