### PR TITLE
Remove references to STL

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -913,9 +913,6 @@ template equal(alias pred = "a == b")
     Returns:
         `true` if and only if the two ranges compare _equal element
         for element, according to binary predicate `pred`.
-
-    See_Also:
-        $(HTTP sgi.com/tech/stl/_equal.html, STL's _equal)
     +/
     bool equal(Range1, Range2)(Range1 r1, Range2 r2)
     if (isInputRange!Range1 && isInputRange!Range2 &&
@@ -1724,9 +1721,6 @@ stops at the first mismatch (according to `pred`, by default
 equality). Returns a tuple with the reduced ranges that start with the
 two mismatched values. Performs $(BIGOH min(r1.length, r2.length))
 evaluations of `pred`.
-
-See_Also:
-    $(HTTP sgi.com/tech/stl/_mismatch.html, STL's _mismatch)
 */
 Tuple!(Range1, Range2)
 mismatch(alias pred = "a == b", Range1, Range2)(Range1 r1, Range2 r2)

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -363,9 +363,6 @@ Params:
 
 Returns:
     The unfilled part of target
-
-See_Also:
-    $(HTTP sgi.com/tech/stl/_copy.html, STL's _copy)
  */
 TargetRange copy(SourceRange, TargetRange)(SourceRange source, TargetRange target)
 if (areCopyCompatibleArrays!(SourceRange, TargetRange))

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -391,10 +391,6 @@ ordering of all elements `a`, `b` in `r` for which `predicate(a) =$D(
 predicate(b)). If `ss == SwapStrategy.semistable`, `partition` preserves
 the relative ordering of all elements `a`, `b` in the left part of `r`
 for which `predicate(a) == predicate(b)`.
-
-See_Also:
-    STL's $(HTTP sgi.com/tech/stl/_partition.html, _partition)$(BR)
-    STL's $(HTTP sgi.com/tech/stl/stable_partition.html, stable_partition)
 */
 Range partition(alias predicate, SwapStrategy ss, Range)(Range r)
 if (ss == SwapStrategy.stable && isRandomAccessRange!(Range) && hasLength!Range && hasSlicing!Range)
@@ -3096,7 +3092,6 @@ Params:
 
 See_Also:
     $(LREF topNIndex),
-    $(HTTP sgi.com/tech/stl/nth_element.html, STL's nth_element)
 
 BUGS:
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -9922,8 +9922,7 @@ if (isInputRange!Range)
    all $(D x) (e.g., if $(D pred) is "less than", returns the portion of
    the range with elements strictly smaller than $(D value)). The search
    schedule and its complexity are documented in
-   $(LREF SearchPolicy).  See also STL's
-   $(HTTP sgi.com/tech/stl/lower_bound.html, lower_bound).
+   $(LREF SearchPolicy).
 */
     auto lowerBound(SearchPolicy sp = SearchPolicy.binarySearch, V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V)
@@ -9953,8 +9952,6 @@ For ranges that do not offer random access, $(D SearchPolicy.linear)
 is the only policy allowed (and it must be specified explicitly lest it exposes
 user code to unexpected inefficiencies). For random-access searches, all
 policies are allowed, and $(D SearchPolicy.binarySearch) is the default.
-
-See_Also: STL's $(HTTP sgi.com/tech/stl/lower_bound.html,upper_bound).
 */
     auto upperBound(SearchPolicy sp = SearchPolicy.binarySearch, V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V))
@@ -9997,8 +9994,7 @@ See_Also: STL's $(HTTP sgi.com/tech/stl/lower_bound.html,upper_bound).
    and $(D SearchPolicy.gallop) to find the right boundary. These
    policies are justified by the fact that the two boundaries are likely
    to be near the first found value (i.e., equal ranges are relatively
-   small). Completes the entire search in $(BIGOH log(n)) time. See also
-   STL's $(HTTP sgi.com/tech/stl/equal_range.html, equal_range).
+   small). Completes the entire search in $(BIGOH log(n)) time.
 */
     auto equalRange(V)(V value)
     if (isTwoWayCompatible!(predFun, ElementType!Range, V)
@@ -10114,8 +10110,7 @@ equalRange). Completes the entire search in $(BIGOH log(n)) time.
 /**
 Returns $(D true) if and only if $(D value) can be found in $(D
 range), which is assumed to be sorted. Performs $(BIGOH log(r.length))
-evaluations of $(D pred). See also STL's $(HTTP
-sgi.com/tech/stl/binary_search.html, binary_search).
+evaluations of $(D pred).
  */
 
     bool contains(V)(V value)


### PR DESCRIPTION
There's no reason and benefit to link to C++ in our standard library exception for a few
special cases (e.g. saying that this function behaves like XYZ in another language
for better searchability).

See also: dlang/dlang.org#2103