### PR TITLE
Removed auto-decoding from std.algorithm.searching.balancedParens

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -233,14 +233,25 @@ bool balancedParens(Range, E)(Range r, E lPar, E rPar,
 if (isInputRange!(Range) && is(typeof(r.front == lPar)))
 {
     size_t count;
-    for (; !r.empty; r.popFront())
+
+    static if (is(Unqual!(ElementEncodingType!Range) == Unqual!E) && isNarrowString!Range)
     {
-        if (r.front == lPar)
+        import std.utf : byCodeUnit;
+        auto rn = r.byCodeUnit;
+    }
+    else
+    {
+        alias rn = r;
+    }
+
+    for (; !rn.empty; rn.popFront())
+    {
+        if (rn.front == lPar)
         {
             if (count > maxNestingLevel) return false;
             ++count;
         }
-        else if (r.front == rPar)
+        else if (rn.front == rPar)
         {
             if (!count) return false;
             --count;
@@ -250,7 +261,7 @@ if (isInputRange!(Range) && is(typeof(r.front == lPar)))
 }
 
 ///
-@safe unittest
+@safe pure unittest
 {
     auto s = "1 + (2 * (3 + 1 / 2)";
     assert(!balancedParens(s, '(', ')'));
@@ -260,6 +271,8 @@ if (isInputRange!(Range) && is(typeof(r.front == lPar)))
     assert(!balancedParens(s, '(', ')', 0));
     s = "1 + (2 * 3 + 1) / (2 - 5)";
     assert(balancedParens(s, '(', ')', 0));
+    s = "f(x) = ⌈x⌉";
+    assert(balancedParens(s, '⌈', '⌉'));
 }
 
 /**


### PR DESCRIPTION
I'm not sold on this function's usefulness, but fixing auto-decoding is simple so we might as well.

```
$ ldc2 -O -release test.d && ./test
0
old		4 secs, 968 ms, 536 μs, and 6 hnsecs
new		1 sec, 988 ms, and 715 μs
$ dmd -O -inline -release test.d && ./test
0
old		16 secs, 874 ms, 710 μs, and 5 hnsecs
new		6 secs, 49 ms, 780 μs, and 8 hnsecs
```

```d
import std.stdio;
import std.algorithm;
import std.conv;
import std.ascii;
import std.range;
import std.traits;
import std.string;
import std.datetime.timezone;
import std.datetime.stopwatch;
import std.utf;
import std.random;

enum testCount = 100_000_000;

__gshared a = "1 + (2 * (3 + 1 / 2)";

bool balancedParens1(Range, E)(Range r, E lPar, E rPar,
        size_t maxNestingLevel = size_t.max)
if (isInputRange!(Range) && is(typeof(r.front == lPar)))
{
    size_t count;

    for (; !r.empty; r.popFront())
    {
        if (r.front == lPar)
        {
            if (count > maxNestingLevel) return false;
            ++count;
        }
        else if (r.front == rPar)
        {
            if (!count) return false;
            --count;
        }
    }
    return count == 0;
}

bool balancedParens2(Range, E)(Range r, E lPar, E rPar,
        size_t maxNestingLevel = size_t.max)
if (isInputRange!(Range) && is(typeof(r.front == lPar)))
{
    size_t count;

    static if (is(Unqual!(ElementEncodingType!Range) == Unqual!E) && isNarrowString!Range)
        auto rn = r.byCodeUnit;
    else
        alias rn = r;

    for (; !rn.empty; rn.popFront())
    {
        if (rn.front == lPar)
        {
            if (count > maxNestingLevel) return false;
            ++count;
        }
        else if (rn.front == rPar)
        {
            if (!count) return false;
            --count;
        }
    }
    return count == 0;
}

void main()
{
    long res;

    auto result = to!Duration(benchmark!(() => res += a.balancedParens1('(', ')'))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => res += a.balancedParens2('(', ')'))(testCount)[0]);

    writeln(res); // force execution

    writeln("old", "\t\t", result);
    writeln("new", "\t\t", result2);
}
```