### PR TITLE
fix Issue 18318 - std.net.curl.download silently ignores non-2xx...

### DIFF
--- a/changelog/curl-http-status-exception.dd
+++ b/changelog/curl-http-status-exception.dd
@@ -1,0 +1,6 @@
+std.net.curl methods now throw on non-2xx status codes
+
+The methods $(REF get,std,net,curl), $(REF post,std,net,curl), $(REF put,std,net,curl), $(REF del,std,net,curl), $(REF trace,std,net,curl), $(REF connect,std,net,curl), $(REF patch,std,net,curl), $(REF byLine,std,net,curl), $(REF byChunk,std,net,curl), $(REF byLineAsync,std,net,curl), and $(REF byChunkAsync,std,net,curl) were changed to throw an $(REF HTTPStatusException,std,net,curl) when the server responds with a non-success status code.
+
+For download, byLineAsync, and byChunkAsync the exception is thrown
+after receiving any error response body.

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1593,7 +1593,7 @@ private mixin template WorkerThreadProtocol(Unit, alias units)
         import std.format : format;
         tryEnsureUnits();
         assert(state == State.gotUnits,
-               format("Expected %s but got $s",
+               format("Expected %s but got %s",
                       State.gotUnits, state));
         return units;
     }
@@ -1605,7 +1605,7 @@ private mixin template WorkerThreadProtocol(Unit, alias units)
 
         tryEnsureUnits();
         assert(state == State.gotUnits,
-               format("Expected %s but got $s",
+               format("Expected %s but got %s",
                       State.gotUnits, state));
         state = State.needUnits;
         // Send to worker thread for buffer reuse

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -618,6 +618,7 @@ if (isCurlConn!Conn)
  * Throws:
  *
  * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  *
  * See_Also: $(LREF HTTP.Method)
  */
@@ -686,6 +687,11 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
  *
  * Returns:
  * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  *
  * See_Also: $(LREF HTTP.Method)
  */
@@ -787,6 +793,11 @@ if (is(T == char) || is(T == ubyte))
  * Returns:
  * A T[] range containing the content of the resource pointed to by the URL.
  *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
+ *
  * See_Also: $(LREF HTTP.Method)
  */
 T[] put(Conn = AutoProtocol, T = char, PutUnit)(const(char)[] url, const(PutUnit)[] putData,
@@ -841,6 +852,11 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
  * import std.net.curl;
  * del("https://httpbin.org/delete");
  * ----
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  *
  * See_Also: $(LREF HTTP.Method)
  */
@@ -958,6 +974,11 @@ if (is(T == char) || is(T == ubyte))
  * Returns:
  * A T[] range containing the trace info of the resource pointed to by the URL.
  *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
+ *
  * See_Also: $(LREF HTTP.Method)
  */
 T[] trace(T = char)(const(char)[] url, HTTP conn = HTTP())
@@ -998,6 +1019,11 @@ if (is(T == char) || is(T == ubyte))
  *
  * Returns:
  * A T[] range containing the connect info of the resource pointed to by the URL.
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  *
  * See_Also: $(LREF HTTP.Method)
  */
@@ -1043,6 +1069,11 @@ if (is(T == char) || is(T == ubyte))
  *
  * Returns:
  * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  *
  * See_Also: $(LREF HTTP.Method)
  */
@@ -1353,6 +1384,11 @@ struct ByLineBuffer(Char)
  *
  * Returns:
  * A range of Char[] with the content of the resource pointer to by the URL
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  */
 auto byLine(Conn = AutoProtocol, Terminator = char, Char = char)
            (const(char)[] url, KeepTerminator keepTerminator = No.keepTerminator,
@@ -1462,6 +1498,11 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
  *
  * Returns:
  * A range of ubyte[chunkSize] with the content of the resource pointer to by the URL
+ *
+ * Throws:
+ *
+ * `CurlException` on error.
+ * `HTTPStatusException` when the response has a non-2xx status
  */
 auto byChunk(Conn = AutoProtocol)
             (const(char)[] url, size_t chunkSize = 1024, Conn conn = Conn())


### PR DESCRIPTION
- document, handle, and throw HTTPStatusException on non-2xx responses in other high-level API functions (download, upload, byLineAsync, byChunkAsync)
- similar to how get, post, et.al. work
- still downloads/fetches the error content (e.g. 404 page)

Not fun to work on this at all, as both std.net.curl and std.concurrency are full of issues and pitfalls.
Maybe we should deprecate the async functions, and point people to use std.parallelism instead, e.g. with a document example in std.net.curl.