### PR TITLE
Replaced version(unittest) blocks with version(StdUnittest)

### DIFF
--- a/std/algorithm/internal.d
+++ b/std/algorithm/internal.d
@@ -14,7 +14,7 @@ package template algoFormat()
 }
 
 // Internal random array generators
-version(unittest)
+version(StdUnittest)
 {
     package enum size_t maxArraySize = 50;
     package enum size_t minArraySize = maxArraySize - 1;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -637,7 +637,7 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range)
         for (;;)
         {
             // Loop invariant
-            version(unittest)
+            version(StdUnittest)
             {
                 import std.algorithm.searching : all;
                 assert(r[0 .. lo].all!(x => !lt(p, x)));
@@ -3439,7 +3439,7 @@ done:
         a.length / 2 + 1);
 }
 
-version(unittest)
+version(StdUnittest)
 private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     size_t maxSize = 1000,
     T minValue = 0, T maxValue = 255)

--- a/std/array.d
+++ b/std/array.d
@@ -550,7 +550,7 @@ private template blockAttribute(T)
         enum blockAttribute = GC.BlkAttr.NO_SCAN;
     }
 }
-version(unittest)
+version(StdUnittest)
 {
     import core.memory : UGC = GC;
     static assert(!(blockAttribute!void & UGC.BlkAttr.NO_SCAN));
@@ -569,7 +569,7 @@ private template nDimensions(T)
     }
 }
 
-version(unittest)
+version(StdUnittest)
 {
     static assert(nDimensions!(uint[]) == 1);
     static assert(nDimensions!(float[][]) == 2);

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -59,7 +59,7 @@ $(TR $(TD Enums) $(TD
   +/
 module std.ascii;
 
-version (unittest)
+version(StdUnittest)
 {
     // FIXME: When dmd bug #314 is fixed, make these selective.
     import std.meta; // : AliasSeq;

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -58,7 +58,7 @@ import std.range.primitives;
 public import std.system : Endian;
 import std.traits;
 
-version(unittest)
+version(StdUnittest)
 {
     import std.stdio;
 }

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2427,7 +2427,7 @@ private
     }
 }
 
-version (unittest)
+version(StdUnittest)
 {
     import std.stdio;
     import std.typecons : tuple, Tuple;

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -61,7 +61,7 @@ import std.functional : binaryFun;
 
 public import std.container.util;
 
-version(unittest) debug = RBDoChecks;
+version(StdUnittest) debug = RBDoChecks;
 
 //debug = RBDoChecks;
 
@@ -745,7 +745,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
     alias _less = binaryFun!less;
 
-    version(unittest)
+    version(StdUnittest)
     {
         static if (is(typeof(less) == string))
         {

--- a/std/conv.d
+++ b/std/conv.d
@@ -4882,7 +4882,7 @@ if (!is(T == class))
     assert(u1.a == "hello");
 }
 
-version(unittest) private struct __conv_EmplaceTest
+version(StdUnittest) private struct __conv_EmplaceTest
 {
     int i = 3;
     this(int i)
@@ -4903,7 +4903,7 @@ version(unittest) private struct __conv_EmplaceTest
     void opAssign();
 }
 
-version(unittest) private class __conv_EmplaceTestClass
+version(StdUnittest) private class __conv_EmplaceTestClass
 {
     int i = 3;
     this(int i) @nogc @safe pure nothrow
@@ -5323,7 +5323,7 @@ version(unittest) private class __conv_EmplaceTestClass
         assert(s.i == 2);
     }
 }
-version(unittest)
+version(StdUnittest)
 {
     //Ambiguity
     struct __std_conv_S

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -14,7 +14,7 @@ import std.traits : isSomeString, Unqual;
 import std.typecons : Flag;
 import std.range.primitives : isOutputRange;
 
-version(unittest) import std.exception : assertThrown;
+version(StdUnittest) import std.exception : assertThrown;
 
 @safe unittest
 {
@@ -10272,7 +10272,7 @@ if (isSomeString!T)
 }
 
 
-version(unittest)
+version(StdUnittest)
 {
     // All of these helper arrays are sorted in ascending order.
     auto testYearsBC = [-1999, -1200, -600, -4, -1, 0];

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -14,7 +14,7 @@ import std.exception : enforce;
 import std.traits : isIntegral, Unqual;
 import std.typecons : Flag;
 
-version(unittest) import std.exception : assertThrown;
+version(StdUnittest) import std.exception : assertThrown;
 
 
 /++

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -31,7 +31,7 @@ else version(Posix)
     import core.sys.posix.sys.types : time_t;
 }
 
-version(unittest)
+version(StdUnittest)
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -9699,7 +9699,7 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
     assertThrown!DateTimeException(parseRFC822DateTime(badStr));
 }
 
-version(unittest) void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
+version(StdUnittest) void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
 {
     import std.format : format;
     auto value = cr(str);
@@ -9708,7 +9708,7 @@ version(unittest) void testParse822(alias cr)(string str, SysTime expected, size
         throw new AssertError(format("wrong result. expected [%s], actual[%s]", expected, result), __FILE__, line);
 }
 
-version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LINE__)
+version(StdUnittest) void testBadParse822(alias cr)(string str, size_t line = __LINE__)
 {
     try
         parseRFC822DateTime(cr(str));
@@ -10636,7 +10636,7 @@ if (isIntegral!T && isSigned!T) // The constraints on R were already covered by 
 }
 
 
-version(unittest)
+version(StdUnittest)
 {
     // Variables to help in testing.
     Duration currLocalDiffFromUTC;

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -33,7 +33,7 @@ else version(Posix)
     import core.sys.posix.sys.types : time_t;
 }
 
-version(unittest) import std.exception : assertThrown;
+version(StdUnittest) import std.exception : assertThrown;
 
 
 /++

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -60,8 +60,7 @@ module std.digest.crc;
 
 public import std.digest;
 
-version(unittest)
-    import std.exception;
+version(StdUnittest) import std.exception;
 
 
 ///

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -287,7 +287,7 @@ if (isDigest!H)
     }
 }
 
-version(unittest)
+version(StdUnittest)
 {
     import std.digest : toHexString, LetterCase;
     alias hex = toHexString!(LetterCase.lower);

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -658,7 +658,7 @@ L_end:
     }
 }
 
-version (unittest)
+version(StdUnittest)
 {
     import std.string : representation;
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -118,7 +118,7 @@ else version(D_InlineAsm_X86_64)
 version(LittleEndian) import core.bitop : bswap;
 
 
-version(unittest)
+version(StdUnittest)
 {
     import std.exception;
 }

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -3634,7 +3634,7 @@ class EncodingSchemeUtf32Native : EncodingScheme
 
 
 // Helper functions
-version(unittest)
+version(StdUnittest)
 {
     void transcodeReverse(Src,Dst)(immutable(Src)[] s, out immutable(Dst)[] r)
     {

--- a/std/exception.d
+++ b/std/exception.d
@@ -1752,7 +1752,7 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
     static assert(!__traits(compiles, (new Object()).ifThrown(e=>1)));
 }
 
-version(unittest) package
+version(StdUnittest) package
 @property void assertCTFEable(alias dg)()
 {
     static assert({ cast(void) dg(); return true; }());

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -7,7 +7,7 @@ module std.experimental.allocator.building_blocks.allocator_list;
 import std.experimental.allocator.building_blocks.null_allocator;
 import std.experimental.allocator.common;
 import std.experimental.allocator.gc_allocator;
-version(unittest) import std.stdio;
+version(StdUnittest) import std.stdio;
 
 // Turn this on for debugging
 // debug = allocator_list;

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -657,7 +657,7 @@ else
     }
 }
 
-version (StdUnittest)
+version(StdUnittest)
 {
     static void testrw(void[] b) @nogc nothrow
     {

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -6,7 +6,7 @@ module std.experimental.allocator.building_blocks.kernighan_ritchie;
 import std.experimental.allocator.building_blocks.null_allocator;
 
 //debug = KRRegion;
-version(unittest) import std.conv : text;
+version(StdUnittest) import std.conv : text;
 debug(KRRegion) import std.stdio;
 
 // KRRegion

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -479,7 +479,7 @@ Forwards each of the methods in `funs` (if defined) to `member`.
     return result;
 }
 
-version(unittest)
+version(StdUnittest)
 {
     import std.experimental.allocator : RCIAllocator, RCISharedAllocator;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -354,7 +354,7 @@ struct AlignedMallocator
     //...
 }
 
-version(unittest) version(CRuntime_DigitalMars)
+version(StdUnittest) version(CRuntime_DigitalMars)
 @nogc nothrow
 size_t addr(ref void* ptr) { return cast(size_t) ptr; }
 

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1930,7 +1930,7 @@ if (isInputRange!R && !isInfinite!R)
     assert(arr2.map!`a.val`.equal(iota(32, 204, 2)));
 }
 
-version(unittest)
+version(StdUnittest)
 {
     private struct ForcedInputRange
     {

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1846,7 +1846,7 @@ package class TestLogger : Logger
     }
 }
 
-version(unittest) private void testFuncNames(Logger logger) @safe
+version(StdUnittest) private void testFuncNames(Logger logger) @safe
 {
     string s = "I'm here";
     logger.log(s);

--- a/std/file.d
+++ b/std/file.d
@@ -132,7 +132,7 @@ else
     return _deleteme;
 }
 
-version (unittest) private struct TestAliasedString
+version(StdUnittest) private struct TestAliasedString
 {
     string get() @safe @nogc pure nothrow { return _s; }
     alias get this;
@@ -2655,7 +2655,7 @@ version(Windows) string getcwd()
         3. the buffer (lpBuffer) is not large enough: the required size of
     the buffer, in characters, including the null-terminating character.
     */
-    version (StdUnittest)
+    version(StdUnittest)
         enum BUF_SIZE = 10;     // trigger reallocation code
     else
         enum BUF_SIZE = 4096;   // enough for most common case

--- a/std/format.d
+++ b/std/format.d
@@ -4344,7 +4344,7 @@ private T getNth(string kind, alias Condition, T, A...)(uint index, A args)
 
 /* ======================== Unit Tests ====================================== */
 
-version(unittest)
+version(StdUnittest)
 void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
@@ -4358,7 +4358,7 @@ void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __F
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version(unittest)
+version(StdUnittest)
 void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
@@ -4371,7 +4371,7 @@ void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, str
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version(unittest)
+version(StdUnittest)
 void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
@@ -4389,7 +4389,7 @@ void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = _
             text("expected one of `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version(unittest)
+version(StdUnittest)
 void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
@@ -4871,7 +4871,7 @@ here:
     assert(a == "hello" && b == 124 && c == 34.5);
 }
 
-version(unittest)
+version(StdUnittest)
 void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;
@@ -4913,7 +4913,7 @@ void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = _
             input, fn, ln);
 }
 
-version(unittest)
+version(StdUnittest)
 void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -217,7 +217,7 @@ private:
 
     To* _ptr;
     size_t _length;        // length of the string
-    version (StdUnittest)
+    version(StdUnittest)
     // the 'small string optimization'
     {
         // smaller size to trigger reallocations. Padding is to account for

--- a/std/math.d
+++ b/std/math.d
@@ -175,7 +175,7 @@ else version (X86)
     private alias haveSSE = core.cpuid.sse;
 }
 
-version(unittest)
+version(StdUnittest)
 {
     import core.stdc.stdio; // : sprintf;
 

--- a/std/meta.d
+++ b/std/meta.d
@@ -950,7 +950,7 @@ template Filter(alias pred, TList...)
 
 
 // Used in template predicate unit tests below.
-private version (unittest)
+private version(StdUnittest)
 {
     template testAlways(T...)
     {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -26,7 +26,7 @@ import std.range.primitives;
 import std.traits;
 import std.typecons;
 
-version(unittest)
+version(StdUnittest)
 {
     import std.stdio;
 }

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4103,7 +4103,7 @@ private struct RoundRobinBuffer(C1, C2)
     }
 }
 
-version(unittest)
+version(StdUnittest)
 {
     // This was the only way I could get nested maps to work.
     __gshared TaskPool poolInstance;
@@ -4770,7 +4770,7 @@ version(parallelismStressTest)
     }
 }
 
-version(unittest)
+version(StdUnittest)
 {
     struct __S_12733
     {

--- a/std/path.d
+++ b/std/path.d
@@ -102,7 +102,7 @@ static import std.meta;
 import std.range.primitives;
 import std.traits;
 
-version (unittest)
+version(StdUnittest)
 {
 private:
     struct TestAliasedString
@@ -4114,7 +4114,7 @@ string expandTilde(string inputPath) nothrow
     }
 }
 
-version (unittest)
+version(StdUnittest)
 {
     /* Define a mock RandomAccessRange to use for unittesting.
      */
@@ -4145,7 +4145,7 @@ version (unittest)
     static assert( isRandomAccessRange!(MockRange!(const(char))) );
 }
 
-version (unittest)
+version(StdUnittest)
 {
     /* Define a mock BidirectionalRange to use for unittesting.
      */

--- a/std/process.d
+++ b/std/process.d
@@ -2731,7 +2731,7 @@ version (Windows) private immutable string shellSwitch = "/C";
 // file. On Windows the file name gets a .cmd extension, while on
 // POSIX its executable permission bit is set.  The file is
 // automatically deleted when the object goes out of scope.
-version (unittest)
+version(StdUnittest)
 private struct TestScript
 {
     this(string code) @system
@@ -2774,7 +2774,7 @@ private struct TestScript
     string path;
 }
 
-version (unittest)
+version(StdUnittest)
 private string uniqueTempPath() @safe
 {
     import std.file : tempDir;
@@ -3073,7 +3073,7 @@ if (is(typeof(allocator(size_t.init)[0] = char.init)))
     return buf;
 }
 
-version(Windows) version(unittest)
+version(Windows) version(StdUnittest)
 {
     import core.stdc.stddef;
     import core.stdc.wchar_ : wcslen;
@@ -3752,7 +3752,7 @@ version (Posix)
 {
     import core.sys.posix.stdlib;
 }
-version (unittest)
+version(StdUnittest)
 {
     import std.conv, std.file, std.random;
 }

--- a/std/random.d
+++ b/std/random.d
@@ -75,7 +75,7 @@ import std.traits;
     static assert(is(typeof(u) == uint));
 }
 
-version(unittest)
+version(StdUnittest)
 {
     static import std.meta;
     package alias PseudoRngTypes = std.meta.AliasSeq!(MinstdRand0, MinstdRand, Mt19937, Xorshift32, Xorshift64,

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2121,7 +2121,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
     assert(a == [ 2, 3 ]);
 }
 
-version(unittest)
+version(StdUnittest)
 {
     static assert(!is(typeof({          int[4] a; popFront(a); })));
     static assert(!is(typeof({ immutable int[] a; popFront(a); })));
@@ -2242,7 +2242,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
     assert(a == [ 1, 2 ]);
 }
 
-version(unittest)
+version(StdUnittest)
 {
     static assert(!is(typeof({ immutable int[] a; popBack(a); })));
     static assert(!is(typeof({          int[4] a; popBack(a); })));

--- a/std/socket.d
+++ b/std/socket.d
@@ -120,7 +120,7 @@ else
     static assert(0);     // No socket support yet.
 }
 
-version(unittest)
+version(StdUnittest)
 {
     static assert(is(uint32_t == uint));
     static assert(is(uint16_t == ushort));

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5273,7 +5273,7 @@ version(linux)
     }
 }
 
-version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
+version(StdUnittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
 {
     import std.conv : text;
     import std.file : deleteme;

--- a/std/string.d
+++ b/std/string.d
@@ -143,7 +143,7 @@ Source:    $(PHOBOSSRC std/_string.d)
 */
 module std.string;
 
-version (unittest)
+version(StdUnittest)
 {
 private:
     struct TestAliasedString

--- a/std/traits.d
+++ b/std/traits.d
@@ -334,7 +334,7 @@ template QualifierOf(T)
     alias Qual7 = QualifierOf!(   immutable int);   static assert(is(Qual7!long ==    immutable long));
 }
 
-version(unittest)
+version(StdUnittest)
 {
     alias TypeQualifierList = AliasSeq!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf);
 
@@ -482,7 +482,7 @@ template fullyQualifiedName(T...)
     static assert(fullyQualifiedName!fullyQualifiedName == "std.traits.fullyQualifiedName");
 }
 
-version(unittest)
+version(StdUnittest)
 {
     // Used for both fqnType and fqnSym unittests
     private struct QualifiedNameTests
@@ -2238,7 +2238,7 @@ template SetFunctionAttributes(T, string linkage, uint attrs)
     }
 }
 
-version (unittest)
+version(StdUnittest)
 {
     // Some function types to test.
     int sc(scope int, ref int, out int, lazy int, int);
@@ -7498,7 +7498,7 @@ template mangledName(sth...)
     static assert(TL == AliasSeq!("i", "xi", "yi"));
 }
 
-version(unittest) void freeFunc(string);
+version(StdUnittest) void freeFunc(string);
 
 @safe unittest
 {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4264,7 +4264,7 @@ private static:
     alias Implementation = AutoImplement!(Issue17177, how, templateNot!isFinalFunction);
 }
 
-version(unittest)
+version(StdUnittest)
 {
     // Issue 10647
     // Add prefix "issue10647_" as a workaround for issue 1238
@@ -5235,7 +5235,7 @@ private template TypeMod(T)
     enum TypeMod = cast(TypeModifier)(mod1 | mod2);
 }
 
-version(unittest)
+version(StdUnittest)
 {
     private template UnittestFuncInfo(alias f)
     {

--- a/std/uni.d
+++ b/std/uni.d
@@ -719,7 +719,7 @@ debug(std_uni) import std.stdio; // writefln, writeln
 
 private:
 
-version (unittest)
+version(StdUnittest)
 {
 private:
     struct TestAliasedString
@@ -3492,7 +3492,7 @@ private:
     }}
 }
 
-version(unittest)
+version(StdUnittest)
 {
     private alias AllSets = AliasSeq!(InversionList!GcPolicy, InversionList!ReallocPolicy);
 }
@@ -7224,7 +7224,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 }
 
 // For testing non-forward-range input ranges
-version(unittest)
+version(StdUnittest)
 private static struct InputRangeString
 {
     private string s;

--- a/std/utf.d
+++ b/std/utf.d
@@ -1736,7 +1736,7 @@ unittest
 }
 
 
-version(unittest) private void testDecode(R)(R range,
+version(StdUnittest) private void testDecode(R)(R range,
                                              size_t index,
                                              dchar expectedChar,
                                              size_t expectedIndex,
@@ -1765,7 +1765,7 @@ version(unittest) private void testDecode(R)(R range,
     }
 }
 
-version(unittest) private void testDecodeFront(R)(ref R range,
+version(StdUnittest) private void testDecodeFront(R)(ref R range,
                                                   dchar expectedChar,
                                                   size_t expectedNumCodeUnits,
                                                   size_t line = __LINE__)
@@ -1790,7 +1790,7 @@ version(unittest) private void testDecodeFront(R)(ref R range,
     }
 }
 
-version(unittest) private void testDecodeBack(R)(ref R range,
+version(StdUnittest) private void testDecodeBack(R)(ref R range,
                                                  dchar expectedChar,
                                                  size_t expectedNumCodeUnits,
                                                  size_t line = __LINE__)
@@ -1821,7 +1821,7 @@ version(unittest) private void testDecodeBack(R)(ref R range,
     }
 }
 
-version(unittest) private void testAllDecode(R)(R range,
+version(StdUnittest) private void testAllDecode(R)(R range,
                                                 dchar expectedChar,
                                                 size_t expectedIndex,
                                                 size_t line = __LINE__)
@@ -1835,7 +1835,7 @@ version(unittest) private void testAllDecode(R)(R range,
     testDecodeFront(range, expectedChar, expectedIndex, line);
 }
 
-version(unittest) private void testBadDecode(R)(R range, size_t index, size_t line = __LINE__)
+version(StdUnittest) private void testBadDecode(R)(R range, size_t index, size_t line = __LINE__)
 {
     import core.exception : AssertError;
     import std.string : format;
@@ -1861,7 +1861,7 @@ version(unittest) private void testBadDecode(R)(R range, size_t index, size_t li
         assertThrown!UTFException(decodeFront(range, index), null, __FILE__, line);
 }
 
-version(unittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
+version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
 {
     // This condition is to allow unit testing all `decode` functions together
     static if (!isBidirectionalRange!R)
@@ -3152,7 +3152,7 @@ if (isSomeChar!C)
 
 
 // Ranges of code units for testing.
-version(unittest)
+version(StdUnittest)
 {
     struct InputCU(C)
     {
@@ -3906,7 +3906,7 @@ pure @safe nothrow @nogc unittest
     foreach (c; s[].byDchar()) { }
 }
 
-version(unittest)
+version(StdUnittest)
 int impureVariable;
 
 @system unittest

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -81,7 +81,7 @@ class Win32Exception : WindowsException
     @property int error() { return super.code; }
 }
 
-version(unittest) import std.string : startsWith, endsWith;
+version(StdUnittest) import std.string : startsWith, endsWith;
 
 @safe unittest
 {


### PR DESCRIPTION
Should result in faster compiles for unittest builds in some cases.