### PR TITLE
Add warning about the old std.json module from D1

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -3,6 +3,12 @@
 /**
 JavaScript Object Notation
 
+$(MESSAGE_BOX red, This module is considered out-dated and not up to Phobos'
+      current standards. It will remain until we have a suitable replacement,
+      but be aware that it will not remain long term.
+      A potential replacement is $(LINK2 https://github.com/s-ludwig/std_data_json, `std.experimnetal.json`).
+)
+
 Copyright: Copyright Jeremie Pelletier 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth

--- a/std/xml.d
+++ b/std/xml.d
@@ -1,9 +1,11 @@
 // Written in the D programming language.
 
 /**
-$(RED Warning: This module is considered out-dated and not up to Phobos'
+$(MESSAGE_BOX red, This module is considered out-dated and not up to Phobos'
       current standards. It will remain until we have a suitable replacement,
-      but be aware that it will not remain long term.)
+      but be aware that it will not remain long term.
+      A potential replacement is $(LINK2 https://github.com/dlang-community/experimental.xml, `std.experimental.xml`).
+)
 
 Classes and functions for creating and parsing XML
 


### PR DESCRIPTION
We shouldn't advertise code like this:

```
JSONValue json = parseJSON(`{"foo": 1}`);
auto a = &(json.object());
json.uinteger = 0;
(*a)["hello"] = 1;
```
https://run.dlang.io/is/KW86zH

https://dlang.org/phobos/std_json.html