### PR TITLE
Issue 18298 - add note about frozen curl package

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -22,6 +22,10 @@ SMTP) )
 )
 )
 
+$(MESSAGE_BOX gray, The API of `std.net.curl` has been $(B frozen) for stability.
+For a high-level, pure D networking client, see $(LINK2 https://github.com/ikod/dlang-requests, requests).
+)
+
 Note:
 You may need to link to the $(B curl) library, e.g. by adding $(D "libs": ["curl"])
 to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org, DUB).


### PR DESCRIPTION
I think this is the third time I have the __same__ issue on the issue tracker and I don't know how many times people have been having asking for a better http client on the forums.
This PR makes the standard answer: "No one is or will be working on that. However, try requests it's great, written entirely in D, compatible with Vibe.d eventloop for async requests and as fast as curl"

See also:
- https://forum.dlang.org/post/vjfrbipjdtyuesndlvcj@forum.dlang.org

The author of D's requests package shares a similar opinion as the Python requests developer have:

> Essentially, the standard library is where a library goes to die.
It is appropriate for a module to be included when active
development is no longer necessary.

https://github.com/requests/requests/issues/2424
http://docs.python-requests.org/en/latest/dev/philosophy/

With the web consistently moving (HTTP/2, newer SSL releases, etc.),
it's unlikely that the development will stop.

Hence, my proposal is to state the facts and to prevent people from bumping into the same issue over and over again.

Preview:

![image](https://user-images.githubusercontent.com/4370550/35768623-fd73073c-08fe-11e8-89ed-21fe4b02c1d4.png)
