### PR TITLE
Update win32 libcurl link

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -28,7 +28,7 @@ to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org, DUB).
 
 Windows x86 note:
 A DMD compatible libcurl static library can be downloaded from the dlang.org
-$(LINK2 http://dlang.org/download.html, download page).
+$(LINK2 http://downloads.dlang.org/other/index.html, download archive page).
 
 Compared to using libcurl directly this module allows simpler client code for
 common uses, requires no unsafe operations, and integrates better with the rest


### PR DESCRIPTION
The real download can be found in the directory `other` of the *Release Archive*. It wasn't really straight forward to just link the general download page. A link to the archive can be found on the dl page, though.

(Usually people don't like to play hide and seek while coding 🙈)

> @0xNiklas on Discord:
>> well there is no download ^^
>> or i am blind
