### PR TITLE
[WIP] Experiment with generating a header file the unicode_tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ obj/
 .vscode
 
 *.html
+
+# Generated header files
+*.di

--- a/posix.mak
+++ b/posix.mak
@@ -297,6 +297,11 @@ unittest-%:
 	$(MAKE) -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
 endif
 
+
+HEADER_FILES=std/internal/unicode_tables.di
+%.di: %.d
+	$(DMD) $(DFLAGS) -c -o- -Hf$@ $<
+
 ################################################################################
 # Patterns begin here
 ################################################################################
@@ -309,7 +314,7 @@ $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
 	$(CC) -c $(CFLAGS) $< -o$@
 
-$(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
+$(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME) $(HEADER_FILES)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
 
 $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
@@ -319,13 +324,13 @@ $(ROOT)/$(SONAME): $(LIBSO)
 	ln -sf $(notdir $(LIBSO)) $@
 
 $(LIBSO): override PIC:=-fPIC
-$(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO)
+$(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO) $(HEADER_FILES)
 	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
 
 ifeq (osx,$(OS))
 # Build fat library that combines the 32 bit and the 64 bit libraries
 libphobos2.a: $(ROOT_OF_THEM_ALL)/osx/release/libphobos2.a
-$(ROOT_OF_THEM_ALL)/osx/release/libphobos2.a:
+$(ROOT_OF_THEM_ALL)/osx/release/libphobos2.a: $(HEADER_FILES)
 	$(MAKE) -f $(MAKEFILE) OS=$(OS) MODEL=32 BUILD=release
 	$(MAKE) -f $(MAKEFILE) OS=$(OS) MODEL=64 BUILD=release
 	lipo $(ROOT_OF_THEM_ALL)/osx/release/32/libphobos2.a \


### PR DESCRIPTION
1) There's a bug in the header generation with `return` - will look into that one shortly
2) It's stil failing with another D header file generation bug :/

```
> echo "import std.net.curl;" | dmddev -c -o- -
std/uni.d(7002): Error: function std.internal.unicode_tables.isHangL is not accessible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(7004): Error: function std.internal.unicode_tables.isHangV is not accessible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(7008): Error: function std.internal.unicode_tables.isHangT is not accessible from module uni
std/uni.d(7032): Error: function std.internal.unicode_tables.isHangL is not accessible from module uni
std/uni.d(7034): Error: function std.internal.unicode_tables.isHangV is not accessible from module uni
std/uni.d(7048): Error: function std.internal.unicode_tables.isHangV is not accessible from module uni
std/uni.d(7050): Error: function std.internal.unicode_tables.isHangT is not accessible from module uni
std/uni.d(7059): Error: function std.internal.unicode_tables.isHangT is not accessible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(10335): Deprecation: std.internal.unicode_tables.TrieEntry(T...) is not visible from module uni
std/uni.d(7104): Error: template instance std.uni.genericDecodeGrapheme!false.genericDecodeGrapheme!(const(char)[]) error instantiating
std/format.d(3123):        instantiated from here: graphemeStride!char
std/format.d(2807):        instantiated from here: formatRange!(Appender!string, string, char)
std/format.d(1777):        instantiated from here: formatValueImpl!(Appender!string, string, char)
std/format.d(567):        ... (1 instantiations, -v to show) ...
std/format.d(6115):        instantiated from here: formattedWrite!(Appender!string, char, const(ushort), string, const(ushort), const(ushort))
std/net/curl.d(3295):        instantiated from here: format!(char, const(ushort), string, const(ushort), const(ushort))
```