### PR TITLE
Use informational:true for CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -37,7 +37,7 @@ coverage:
     project: off
     patch:
       default:
-        threshold: 5
+        informational: true
     changes: off
 
 comment: false


### PR DESCRIPTION
There are still many parts of Phobos which have a low coverage. Touching them shouldn't make a PR fail.

Example from: https://github.com/dlang/phobos/pull/6041#issuecomment-362899073

> 50% of diff hit (target 90.369%)