### PR TITLE
Fix Ddoc template execution bug

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -601,7 +601,7 @@ T errnoEnforce(T, string file = __FILE__, size_t line = __LINE__)
     --------------------
  +/
 template enforceEx(E : Throwable)
-if (is(typeof(new E("", __FILE__, __LINE__))))
+if (is(typeof(new E("", string.init, size_t.init))))
 {
     /++ Ditto +/
     T enforceEx(T)(T value, lazy string msg = "", string file = __FILE__, size_t line = __LINE__)
@@ -613,7 +613,7 @@ if (is(typeof(new E("", __FILE__, __LINE__))))
 
 /++ Ditto +/
 template enforceEx(E : Throwable)
-if (is(typeof(new E(__FILE__, __LINE__))) && !is(typeof(new E("", __FILE__, __LINE__))))
+if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.init, size_t.init))))
 {
     /++ Ditto +/
     T enforceEx(T)(T value, string file = __FILE__, size_t line = __LINE__)


### PR DESCRIPTION
Ddoc replaces `__FILE__` and `__LINE__` - even in the documentation build.
In think, the best course of action here, is to do the same other functions
in this module do and use `string.init` and `size_of.init`

Current function: https://dlang.org/phobos/std_exception.html#enforceEx

This was discovered while working on the assert/rewrite pipeline:

https://github.com/dlang/dlang.org/pull/2069#issuecomment-363154934

(Ddox doesn't show this, I just filed the issue - https://github.com/rejectedsoftware/ddox/issues/197)