### PR TITLE
fix issue 18349 - std/math.d(543,33): Deprecation: integral promotion not done for -x

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -553,13 +553,13 @@ auto abs(Num)(Num x)
 // workaround for https://issues.dlang.org/show_bug.cgi?id=18251
 //if (!isDeprecatedComplex!Num &&
     //(is(typeof(Num.init >= 0)) && is(typeof(-Num.init)) ||
-    //(is(Num : const(short)) || is(Num : const(byte)))))
+    //(is(Unqual!Num == short) || is(Unqual!Num == byte))))
 {
     static if (isFloatingPoint!(Num))
         return fabs(x);
     else
     {
-        static if (is(Num : const(short)) || is(Num : const(byte)))
+        static if (is(Unqual!Num == short) || is(Unqual!Num == byte))
             return x >= 0 ? x : cast(Num) -int(x);
         else
             return x >= 0 ? x : -x;

--- a/std/math.d
+++ b/std/math.d
@@ -553,13 +553,13 @@ auto abs(Num)(Num x)
 // workaround for https://issues.dlang.org/show_bug.cgi?id=18251
 //if (!isDeprecatedComplex!Num &&
     //(is(typeof(Num.init >= 0)) && is(typeof(-Num.init)) ||
-    //(is(Num == short) || is(Num == byte))))
+    //(is(Num : const(short)) || is(Num : const(byte)))))
 {
     static if (isFloatingPoint!(Num))
         return fabs(x);
     else
     {
-        static if (is(Num == short) || is(Num == byte))
+        static if (is(Num : const(short)) || is(Num : const(byte)))
             return x >= 0 ? x : cast(Num) -int(x);
         else
             return x >= 0 ? x : -x;
@@ -608,6 +608,8 @@ deprecated
     byte b = -8;
     assert(abs(s) == 8);
     assert(abs(b) == 8);
+    immutable(byte) c = -8;
+    assert(abs(c) == 8);
 }
 
 @safe pure nothrow @nogc unittest


### PR DESCRIPTION
last fix was incomplete. abs didn't handle type constructors yet.