### PR TITLE
fix Issue 18397 - Poor implementation of std.conv.hexString results i…

### DIFF
--- a/changelog/fix18397.dd
+++ b/changelog/fix18397.dd
@@ -1,18 +1,18 @@
-Changed std.conv.hexString() to return an immutable string literal
-rather than an array of ubytes. This is more in keeping with
-the documentation that says it is a replacement for the deprecated
-x"deadbeef" string literal syntax.
+Changed `std.conv.hexString` to return an immutable string literal
 
-https://dlang.org/phobos/std_conv.html#hexString
+$(REF hexString, std,conv) now returns an immutable string literal rather than an array of ubytes.
+This is more in keeping with
+the documentation that says it is a replacement for the deprecated
+`x"deadbeef"` string literal syntax.
 
 The benefits of this change are:
 
-* behavior consistency with the documentation
-* the hexString template instantiations no longer appear in the
-generated object file
-* the generated object file no longer contains references to TypeInfo
-and various druntime functions
-* it is now compatible with -betterC mode
+$(UL
+  $(LI behavior consistency with the documentation)
+  $(LI the `hexString` template instantiations no longer appear in the generated object file)
+  $(LI the generated object file no longer contains references to `TypeInfo` and various druntime functions)
+  $(LI it is now compatible with `-betterC` mode)
+)
 
 In some cases, code did rely on it being an array, and a cast will
 fix the issue:
@@ -26,4 +26,3 @@ enum ubyte[8] input = hexString!"c3 fc 3d 7e fb ea dd aa";
 // add cast to fix:
 enum ubyte[8] input = cast(ubyte[8]) hexString!"c3 fc 3d 7e fb ea dd aa";
 ---
-

--- a/changelog/fix18397.dd
+++ b/changelog/fix18397.dd
@@ -1,0 +1,29 @@
+Changed std.conv.hexString() to return an immutable string literal
+rather than an array of ubytes. This is more in keeping with
+the documentation that says it is a replacement for the deprecated
+x"deadbeef" string literal syntax.
+
+https://dlang.org/phobos/std_conv.html#hexString
+
+The benefits of this change are:
+
+* behavior consistency with the documentation
+* the hexString template instantiations no longer appear in the
+generated object file
+* the generated object file no longer contains references to TypeInfo
+and various druntime functions
+* it is now compatible with -betterC mode
+
+In some cases, code did rely on it being an array, and a cast will
+fix the issue:
+
+---
+// now an error:
+enum ubyte[8] input = hexString!"c3 fc 3d 7e fb ea dd aa";
+---
+
+---
+// add cast to fix:
+enum ubyte[8] input = cast(ubyte[8]) hexString!"c3 fc 3d 7e fb ea dd aa";
+---
+

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -381,7 +381,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
                     "1234567890123456789012345678901234567890");
     assert(digest == cast(ubyte[]) hexString!"724aa97c");
 
-    enum ubyte[4] input = hexString!"c3fcd3d7";
+    enum ubyte[4] input = cast(ubyte[4]) hexString!"c3fcd3d7";
     assert(crcHexString(input) == "D7D3FCC3");
 }
 
@@ -421,7 +421,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
                          "1234567890123456789012345678901234567890");
     assert(digest == cast(ubyte[]) hexString!"bd3eb7765d0a22ae");
 
-    enum ubyte[8] input = hexString!"c3fcd3d7efbeadde";
+    enum ubyte[8] input = cast(ubyte[8]) hexString!"c3fcd3d7efbeadde";
     assert(crcHexString(input) == "DEADBEEFD7D3FCC3");
 }
 
@@ -461,7 +461,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
                         "1234567890123456789012345678901234567890");
     assert(digest == cast(ubyte[]) hexString!"760cd2d3588bf809");
 
-    enum ubyte[8] input = hexString!"c3fcd3d7efbeadde";
+    enum ubyte[8] input = cast(ubyte[8]) hexString!"c3fcd3d7efbeadde";
     assert(crcHexString(input) == "DEADBEEFD7D3FCC3");
 }
 

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -480,7 +480,7 @@ struct MD5
                     "1234567890123456789012345678901234567890");
     assert(digest == cast(ubyte[]) hexString!"57edf4a22be3c955ac49da2e2107b67a");
 
-    enum ubyte[16] input = hexString!"c3fcd3d76192e4007dfb496cca67e13b";
+    enum ubyte[16] input = cast(ubyte[16]) hexString!"c3fcd3d76192e4007dfb496cca67e13b";
     assert(toHexString(input)
         == "C3FCD3D76192E4007DFB496CCA67E13B");
 

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -649,7 +649,7 @@ struct RIPEMD160
                     "1234567890123456789012345678901234567890");
     assert(digest == cast(ubyte[]) hexString!"9b752e45573d4b39f4dbd3323cab82bf63326bfb");
 
-    enum ubyte[20] input = hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc";
+    enum ubyte[20] input = cast(ubyte[20]) hexString!"f71c27109c692c1b56bbdceb5b9d2865b3708dbc";
     assert(toHexString(input)
         == "F71C27109C692C1B56BBDCEB5B9D2865B3708DBC");
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -1117,7 +1117,7 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     assert(digest512_224 == cast(ubyte[]) hexString!"37ab331d76f0d36de422bd0edeb22a28accd487b7a8453ae965dd287");
     assert(digest512_256 == cast(ubyte[]) hexString!"9a59a052930187a97038cae692f30708aa6491923ef5194394dc68d56c74fb21");
 
-    enum ubyte[20] input = hexString!"a9993e364706816aba3e25717850c26c9cd0d89d";
+    enum ubyte[20] input = cast(ubyte[20]) hexString!"a9993e364706816aba3e25717850c26c9cd0d89d";
     assert(toHexString(input)
         == "A9993E364706816ABA3E25717850C26C9CD0D89D");
 }


### PR DESCRIPTION
…n unintended bloat

The trick is to make it an enum, use a mixin string literal rather than an array, and instantiate the template in std.conv rather than in user code.

For:
```
import std.conv;
void test() {
    auto data = cast(ubyte[]) hexString!"deadbeef";
}
```
now compiles to:
```
___a4_deadbeef	comdat
	db	0deh,0adh,0beh,0efh,000h	;.....
___a4_deadbeef	ends
_D5test24testFZv	comdat
	assume	CS:_D5test24testFZv
		mov	ECX,offset FLAT:___a4_deadbeef
		mov	EAX,4
		ret
_D5test24testFZv	ends
```
instead of the hundreds of bytes of code it used to.