### PR TITLE
Use REF1 macro instead of OBJECTREF

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -80,8 +80,7 @@ License:
 Source:
     $(PHOBOSSRC std/_process.d)
 Macros:
-    OBJECTREF=$(D $(LINK2 object.html#$0,$0))
-    LREF=$(D $(LINK2 #.$0,$0))
+    OBJECTREF=$(REF1 $0, object)
 */
 module std.process;
 


### PR DESCRIPTION
The REF1 macro should have been used here instead.

See also: https://github.com/dlang/dlang.org/pull/2191

edit: also fixed a few typos while I was at it.