### PR TITLE
Fix all DScanner warnings + use -return-exit-code re-enable it

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -535,7 +535,7 @@ style: publictests style_lint
 # runs static code analysis with Dscanner
 dscanner: | $(DSCANNER_DIR)/dsc
 	@echo "Running DScanner"
-	$(DEBUGGER) -q -ex run -ex bt -batch --args $(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
+	$(DEBUGGER) -return-child-result -q -ex run -ex bt -batch --args $(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
 
 style_lint: dscanner $(LIB)
 	@echo "Check for trailing whitespace"

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -851,6 +851,8 @@ pure @safe unittest
             ++ctr;
             return 0;
         }
+        bool opEquals(T)(T o) const { return false; }
+        size_t toHash() const { return 0; }
     }
     immutable S[4] a;
     immutable S[4] b;
@@ -869,6 +871,8 @@ nothrow pure @safe unittest
         {
             return value - rhs.value;
         }
+        bool opEquals(T)(T o) const { return false; }
+        size_t toHash() const { return 0; }
     }
     auto result = cmp([F(1), F(2), F(3)], [F(1), F(2), F(3)]);
     assert(result == 0);

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1138,10 +1138,13 @@ if (isBidirectionalRange!R &&
         static if (isDefaultPred && isSomeChar!E && E.sizeof <= ElementEncodingType!R.sizeof)
             return doesThisEnd[$ - 1] == withThis;
         // specialize for ASCII as to not change previous behavior
-        else if (withThis <= 0x7F)
-            return predFunc(doesThisEnd[$ - 1], withThis);
         else
-            return predFunc(doesThisEnd.back, withThis);
+        {
+            if (withThis <= 0x7F)
+                return predFunc(doesThisEnd[$ - 1], withThis);
+            else
+                return predFunc(doesThisEnd.back, withThis);
+        }
     }
     else
     {
@@ -4263,10 +4266,13 @@ if (isInputRange!R &&
         static if (isDefaultPred && isSomeChar!E && E.sizeof <= ElementEncodingType!R.sizeof)
             return doesThisStart[0] == withThis;
         // specialize for ASCII as to not change previous behavior
-        else if (withThis <= 0x7F)
-            return predFunc(doesThisStart[0], withThis);
         else
-            return predFunc(doesThisStart.front, withThis);
+        {
+            if (withThis <= 0x7F)
+                return predFunc(doesThisStart[0], withThis);
+            else
+                return predFunc(doesThisStart.front, withThis);
+        }
     }
     else
     {

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1835,6 +1835,7 @@ unittest
 
     enum BigInt test1 = BigInt(123);
     enum BigInt test2 = plusTwo(test1);
+    assert(test2 == 125);
 }
 
 /**

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10322,7 +10322,6 @@ if (isSomeString!S)
     import std.ascii : isDigit;
     import std.conv : to;
     import std.string : representation;
-    import core.time;
 
     if (isoString.empty)
         return Duration.zero;
@@ -10963,7 +10962,6 @@ version(StdUnittest)
 
     void initializeTests() @safe
     {
-        import core.time;
         import std.algorithm.sorting : sort;
         import std.typecons : Rebindable;
         immutable lt = LocalTime().utcToTZ(0);

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -909,7 +909,8 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     sha256.put(cast(ubyte[])"abcdef");
     sha256.start();
     sha256.put(cast(ubyte[])"");
-    assert(sha256.finish() == cast(ubyte[]) hexString!"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert(sha256.finish() == cast(ubyte[])
+            hexString!"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     SHA384 sha384;
     sha384.put(cast(ubyte[])"abcdef");
@@ -922,7 +923,8 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     sha512.put(cast(ubyte[])"abcdef");
     sha512.start();
     sha512.put(cast(ubyte[])"");
-    assert(sha512.finish() == cast(ubyte[]) hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
+    assert(sha512.finish() == cast(ubyte[])
+            hexString!("cf83e1357eefb8bdf1542850d66d8007d620e4050b571"
         ~"5dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
 
     SHA512_224 sha512_224;
@@ -935,7 +937,8 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     sha512_256.put(cast(ubyte[])"abcdef");
     sha512_256.start();
     sha512_256.put(cast(ubyte[])"");
-    assert(sha512_256.finish() == cast(ubyte[]) hexString!"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
+    assert(sha512_256.finish() == cast(ubyte[])
+            hexString!"c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a");
 
     digest        = sha1Of      ("");
     digest224     = sha224Of    ("");

--- a/std/exception.d
+++ b/std/exception.d
@@ -416,7 +416,7 @@ T enforce(T)(T value, lazy Throwable ex)
 }
 
 ///
-unittest
+@system unittest
 {
     import core.stdc.stdlib : malloc, free;
     import std.conv : ConvException, to;

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -576,7 +576,7 @@ nothrow:
             ~ to!string(bytesUsed) ~ " bytes");
 }
 
-@safe unittest
+@system unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -531,7 +531,7 @@ nothrow:
     }
 }
 
-unittest
+@system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.conv : emplace;
@@ -553,7 +553,7 @@ unittest
     assert((cast(CAllocatorImpl!(Region!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
 }
 
-unittest
+@system unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;
@@ -576,7 +576,7 @@ unittest
             ~ to!string(bytesUsed) ~ " bytes");
 }
 
-unittest
+@safe unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;
@@ -2554,7 +2554,7 @@ RCIAllocator allocatorObject(A)(A* pa)
     assert(a.deallocate(b));
 }
 
-unittest
+@system unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;

--- a/std/experimental/scripting.d
+++ b/std/experimental/scripting.d
@@ -9,7 +9,7 @@ module std.experimental.scripting;
     import std.experimental.scripting;
 
     int len;
-    auto r = 6.iota
+    const r = 6.iota
               .filter!(a => a % 2) // 0 2 4
               .map!(a => a * 2) // 0 4 8
               .tee!(_ => len++)

--- a/std/format.d
+++ b/std/format.d
@@ -4047,7 +4047,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     assert(w.data == "S()");
 }
 
-unittest
+@safe unittest
 {
     //struct Foo { @disable string toString(); }
     //Foo foo;

--- a/std/math.d
+++ b/std/math.d
@@ -524,7 +524,7 @@ template isDeprecatedComplex(T)
     }
 }
 
-deprecated unittest
+@safe deprecated unittest
 {
     static assert(isDeprecatedComplex!cfloat);
     static assert(isDeprecatedComplex!cdouble);

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -313,7 +313,7 @@ version(StdUnittest)
 version(StdDdoc) import std.stdio;
 
 // Default data timeout for Protocols
-enum _defaultDataTimeout = dur!"minutes"(2);
+private enum _defaultDataTimeout = dur!"minutes"(2);
 
 /**
 Macros:
@@ -1643,7 +1643,7 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
     }
     else
     {
-        import std.concurrency;
+        import std.concurrency : OnCrowding, send, setMaxMailboxSize, spawn, thisTid, Tid;
         // 50 is just an arbitrary number for now
         setMaxMailboxSize(thisTid, 50, OnCrowding.block);
         auto tid = spawn(&_async!().spawn!(Conn, Char, Terminator));
@@ -1767,7 +1767,7 @@ if (isCurlConn!(Conn))
     }
     else
     {
-        import std.concurrency;
+        import std.concurrency : OnCrowding, send, setMaxMailboxSize, spawn, thisTid, Tid;
         // 50 is just an arbitrary number for now
         setMaxMailboxSize(thisTid, 50, OnCrowding.block);
         auto tid = spawn(&_async!().spawn!(Conn, ubyte));
@@ -1826,7 +1826,7 @@ if (isCurlConn!(Conn))
 */
 private mixin template Protocol()
 {
-    import etc.c.curl : CurlReadFunc;
+    import etc.c.curl : CurlReadFunc, RawCurlProxy = CurlProxy;
     import core.time : Duration;
     import std.socket : InternetAddress;
 
@@ -1911,7 +1911,7 @@ private mixin template Protocol()
     }
 
     /// Type of proxy
-    alias CurlProxy = etc.c.curl.CurlProxy;
+    alias CurlProxy = RawCurlProxy;
 
     /** Proxy type
      *  See: $(HTTP curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY, _proxy_type)
@@ -2323,7 +2323,7 @@ struct HTTP
 
     import std.datetime.systime : SysTime;
     import std.typecons : RefCounted;
-    import etc.c.curl;
+    import etc.c.curl : CurlAuth, CurlInfo, curl_slist, CURLVERSION_NOW, curl_off_t;
 
     /// Authentication method equal to $(REF CurlAuth, etc,c,curl)
     alias AuthMethod = CurlAuth;
@@ -3244,7 +3244,7 @@ struct FTP
     mixin Protocol;
 
     import std.typecons : RefCounted;
-    import etc.c.curl;
+    import etc.c.curl : CurlError, CurlInfo, curl_off_t, curl_slist;
 
     private struct Impl
     {
@@ -3646,7 +3646,7 @@ struct SMTP
 {
     mixin Protocol;
     import std.typecons : RefCounted;
-    import etc.c.curl;
+    import etc.c.curl : CurlUseSSL, curl_slist;
 
     private struct Impl
     {
@@ -4056,9 +4056,11 @@ alias ThrowOnError = Flag!"throwOnError";
 
 private struct CurlAPI
 {
-    import etc.c.curl;
+    import etc.c.curl : CurlGlobal;
     static struct API
     {
+    import etc.c.curl : curl_version_info, curl_version_info_data,
+                        CURL, CURLcode, CURLINFO, CURLoption, CURLversion, curl_slist;
     extern(C):
         import core.stdc.config : c_long;
         CURLcode function(c_long flags) global_init;
@@ -4189,7 +4191,10 @@ private struct CurlAPI
 */
 struct Curl
 {
-    import etc.c.curl;
+    import etc.c.curl : CURL, CurlError, CurlPause, CurlSeek, CurlSeekPos,
+                        curl_socket_t, CurlSockType,
+                        CurlReadFunc, CurlInfo, curlsocktype, curl_off_t,
+                        LIBCURL_VERSION_MAJOR, LIBCURL_VERSION_MINOR, LIBCURL_VERSION_PATCH;
 
     alias OutData = void[];
     alias InData = ubyte[];

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2561,6 +2561,8 @@ struct HTTP
     // docs mixed in.
     version (StdDdoc)
     {
+        static import etc.c.curl;
+
         /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
         /// pause a request
         alias requestPause = CurlReadFunc.pause;
@@ -3338,6 +3340,8 @@ struct FTP
     // docs mixed in.
     version (StdDdoc)
     {
+        static import etc.c.curl;
+
         /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
         /// pause a request
         alias requestPause = CurlReadFunc.pause;
@@ -3762,6 +3766,8 @@ struct SMTP
     // docs mixed in.
     version (StdDdoc)
     {
+        static import etc.c.curl;
+
         /// Value to return from $(D onSend)/$(D onReceive) delegates in order to
         /// pause a request
         alias requestPause = CurlReadFunc.pause;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2545,7 +2545,7 @@ pure @safe nothrow unittest
 
 // https://issues.dlang.org/show_bug.cgi?id=18092
 // can't combine take and takeExactly
-unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -8475,7 +8475,7 @@ public:
         assert(3.iota.slide!(Partial)(4, 3).walkLength == expectedLength);
     }}
 
-    enum list = [
+    static immutable list = [
     //  iota   slide    expected
         [4,    2, 1,     3, 3],
         [5,    3, 1,     3, 3],
@@ -8637,7 +8637,7 @@ public:
     import std.typecons : tuple;
 
     alias t = tuple;
-    enum list = [
+    static immutable list = [
     // iota   slide    expected
         t(6,  t(4, 2), [[1, 2, 3, 4], [3, 4, 5, 6]]),
         t(6,  t(4, 6), [[1, 2, 3, 4]]),
@@ -8655,7 +8655,7 @@ public:
     foreach (e; list)
         assert(Range().take(e[0]).slide!Partial(e[1].expand).equal!equal(e[2]));
 
-    enum listSpecial = [
+    static immutable listSpecial = [
     // iota   slide    expected
         t(6,  t(4, 3), [[1, 2, 3, 4], [4, 5, 6]]),
         t(7,  t(4, 5), [[1, 2, 3, 4], [6, 7]]),
@@ -8686,11 +8686,12 @@ public:
     import std.typecons : tuple;
     alias t = tuple;
 
-    enum list = [
+    static immutable list = [
     //   slide   expected
         t(1, 1, [[10], [9], [8], [7], [6], [5], [4], [3], [2], [1]]),
         t(2, 1, [[9, 10], [8, 9], [7, 8], [6, 7], [5, 6], [4, 5], [3, 4], [2, 3], [1, 2]]),
-        t(5, 1, [[6, 7, 8, 9, 10], [5, 6, 7, 8, 9], [4, 5, 6, 7, 8], [3, 4, 5, 6, 7], [2, 3, 4, 5, 6], [1, 2, 3, 4, 5]]),
+        t(5, 1, [[6, 7, 8, 9, 10], [5, 6, 7, 8, 9], [4, 5, 6, 7, 8],
+                 [3, 4, 5, 6, 7], [2, 3, 4, 5, 6], [1, 2, 3, 4, 5]]),
         t(2, 2, [[9, 10], [7, 8], [5, 6], [3, 4], [1, 2]]),
         t(2, 4, [[9, 10], [5, 6], [1, 2]]),
     ];

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -827,11 +827,12 @@ private auto matchMany(RegEx, R)(R input, RegEx re) @safe
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18135
-unittest
+@system unittest
 {
     static struct MapResult { RegexMatch!string m; }
     MapResult m;
     m = MapResult();
+    assert(m == m);
 }
 
 private enum isReplaceFunctor(alias fun, R) =

--- a/std/string.d
+++ b/std/string.d
@@ -6402,7 +6402,7 @@ if (isSomeString!S ||
 
 version(TestComplex)
 deprecated
-unittest
+@safe unittest
 {
     import std.conv : to;
     assert(isNumeric(to!string(123e+2+1234.78Li)) == true);

--- a/std/traits.d
+++ b/std/traits.d
@@ -5238,7 +5238,8 @@ template IntegralTypeOf(T)
             static assert( is(Q!T == IntegralTypeOf!( SubTypeOf!(Q!T) )));
         }
 
-    static foreach (T; AliasSeq!(void, bool, FloatingPointTypeList, /*ImaginaryTypeList, ComplexTypeList,*/ CharTypeList))
+    static foreach (T; AliasSeq!(void, bool, FloatingPointTypeList,
+                /*ImaginaryTypeList, ComplexTypeList,*/ CharTypeList))
         static foreach (Q; TypeQualifierList)
         {
             static assert(!is(IntegralTypeOf!(            Q!T  )));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1299,7 +1299,7 @@ if (distinctFieldNames!(Specs))
 }
 
 /// Use tuples as ranges
-unittest
+@safe unittest
 {
     import std.algorithm.iteration : sum;
     import std.range : only;


### PR DESCRIPTION
tl;dr: DScanner started to segfaulted in December due to the introduction of the AscendingPageAllocator, which used `~this(){}`. The DScanner bug has been fixed and now we can fix the DScanner warnings that sneaked in and re-enable in.

See also: https://github.com/dlang/phobos/pull/6148