### PR TITLE
Fix Issue 11084 - Mention scan in cumulativeFold

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3292,6 +3292,11 @@ Returns:
 
 See_Also:
     $(HTTP en.wikipedia.org/wiki/Prefix_sum, Prefix Sum)
+
+Note:
+
+    In functional programming languages this is typically called `scan`, `scanl`,
+    `scanLeft` or `reductions`.
 +/
 template cumulativeFold(fun...)
 if (fun.length >= 1)


### PR DESCRIPTION
`cumulativeFold` has been added in 2.072. Let's close the issue by mentioning alternative names, s.t. people can find it easily via Google.