### PR TITLE
Fix Issue 12086 - std.algorithm.remove + range of indices produces wrong results

### DIFF
--- a/changelog/std-algorithm-mutation-remove.dd
+++ b/changelog/std-algorithm-mutation-remove.dd
@@ -1,0 +1,27 @@
+`std.algorithm.mutation.remove` now only accepts integral values or pair of integral values as offset
+
+Previously, without being stated in the documentation,
+$(REF remove, std,algorithm) used to accept any values as `offset`.
+This behavior was very error-prone:
+
+---
+import std.algorithm, std.stdio;
+[0, 1, 2, 3, 4].remove(1, 3).writeln; // 0, 2, 4  -- correct
+[0, 1, 2, 3, 4].remove([1, 3]).writeln; // 0, 3, 4  -- incorrect
+---
+
+With this release, using arrays as individual elements is no longer valid.
+$(REF tuple, std,typecons) can be used to explicitly indicate that a range
+from `start` to `stop` (non-enclosing) should be removed:
+
+---
+import std.algorithm, std.stdio, std.typecons;
+[0, 1, 2, 3, 4].remove(tuple(1, 3)).writeln; // 0, 3, 4
+---
+
+However, only 2-tuples are allowed to avoid this un-intuitive scenario:
+
+---
+import std.algorithm, std.stdio, std.typecons;
+[0, 1, 2, 3, 4].remove(tuple(1, 3, 4)).writeln; // 0, 4?
+---


### PR DESCRIPTION
See the Bugzilla message or the changelog entry for a motivation.

----

Previously, `std.algorithm.remove` used to accept any values as `offset`.
This behavior was very error-prone:

```d
import std.algorithm, std.stdio;
[0, 1, 2, 3, 4].remove(1, 3).writeln; // 0, 2, 4  -- correct
[0, 1, 2, 3, 4].remove([1, 3]).writeln; // 0, 3, 4  -- incorrect
```

With this release, using arrays as individual element is deprecated.
`tuple` can be used to explicitly indicate that a range
from `start` to `stop` (non-enclosing) should be removed:

```d
import std.algorithm, std.stdio, std.typecons;
[0, 1, 2, 3, 4].remove(tuple(1, 3)).writeln; // 0, 3, 4
```

However, only 2-tuples are allowed to avoid this un-intuitive scenario:

```d
import std.algorithm, std.stdio, std.typecons;
[0, 1, 2, 3, 4].remove(tuple(1, 3, 4)).writeln; // 0, 3, 4
```