### PR TITLE
Fix Issue 8341 - topN(zip()) doesn't work

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -84,11 +84,6 @@ import std.typecons; // : tuple, Tuple;
 
 // bringToFront
 /**
-The `bringToFront` function has considerable flexibility and
-usefulness. It can rotate elements in one buffer left or right, swap
-buffers of equal length, and even move elements across disjoint
-buffers of different types and different lengths.
-
 `bringToFront` takes two ranges `front` and `back`, which may
 be of different types. Considering the concatenation of `front` and
 `back` one unified range, `bringToFront` rotates that unified
@@ -103,6 +98,10 @@ in ranges, not as a string function.
 
 Performs $(BIGOH max(front.length, back.length)) evaluations of $(D
 swap).
+
+The `bringToFront` function can rotate elements in one buffer left or right, swap
+buffers of equal length, and even move elements across disjoint
+buffers of different types and different lengths.
 
 Preconditions:
 


### PR DESCRIPTION
`topN` requires an assignable range. While fixing the constraint of `topN`, I found that almost the entire module had missing constraints.
This should improve the error messages slightly, i.e. now they aren't in `std.algorithm` anymore, but the user at least gets "no matching function found" and sees the constraints.