### PR TITLE
Fix Issue 18419 - make all Phobos unittests version(StdUnittest)

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -116,7 +116,7 @@ if (isExpressionTuple!values)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(3.among(1, 42, 24, 3, 2));
 
@@ -133,13 +133,13 @@ if (isExpressionTuple!values)
 Alternatively, `values` can be passed at compile-time, allowing for a more
 efficient search, but one that only supports matching on equality:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(3.among!(2, 3, 4));
     assert("bar".among!("foo", "bar", "baz") == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -373,7 +373,7 @@ auto castSwitch(choices...)(Object switchObject)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : map;
     import std.format : format;
@@ -404,7 +404,7 @@ auto castSwitch(choices...)(Object switchObject)
 }
 
 /// Using with void handlers:
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -425,7 +425,7 @@ auto castSwitch(choices...)(Object switchObject)
     )();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : SwitchError;
     import std.exception : assertThrown;
@@ -498,7 +498,7 @@ auto castSwitch(choices...)(Object switchObject)
                            )());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface I { }
     class B : I { }
@@ -541,7 +541,7 @@ do
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(clamp(2, 1, 3) == 2);
     assert(clamp(0, 1, 3) == 1);
@@ -552,7 +552,7 @@ do
     assert(clamp(5, -1, 2u) == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a = 1;
     short b = 6;
@@ -752,7 +752,7 @@ if (isInputRange!R1 && isInputRange!R2)
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     int result;
 
@@ -789,7 +789,7 @@ pure @safe unittest
 }
 
 /// Example predicate that compares individual elements in reverse lexical order
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     int result;
 
@@ -825,7 +825,7 @@ pure @safe unittest
     assert(result > 0);
 }
 
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     // Issue 18286: cmp for string with custom predicate fails if distinct chars can compare equal
     static bool ltCi(dchar a, dchar b)// less than, case insensitive
@@ -840,7 +840,7 @@ pure @safe unittest
     static assert(cmp!ltCi("apple", "APPLE") == 0);
 }
 
-@nogc nothrow @safe unittest
+version(StdUnittest) @nogc nothrow @safe unittest
 {
     // Issue 18280: for non-string ranges check that opCmp is evaluated only once per pair.
     static int ctr = 0;
@@ -859,7 +859,7 @@ pure @safe unittest
     assert(ctr == a.length, "opCmp should be called exactly once per pair of items!");
 }
 
-nothrow pure @safe unittest
+version(StdUnittest) nothrow pure @safe unittest
 {
     // Test cmp when opCmp returns float.
     struct F
@@ -881,7 +881,7 @@ nothrow pure @safe unittest
     assert(result > 0);
 }
 
-nothrow pure @safe unittest
+version(StdUnittest) nothrow pure @safe unittest
 {
     // Parallelism (was broken by inferred return type "immutable int")
     import std.parallelism : task;
@@ -984,7 +984,7 @@ template equal(alias pred = "a == b")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.math : approxEqual;
@@ -1010,7 +1010,7 @@ This can be very useful when the element type of a range is itself a
 range. In particular, `equal` can be its own predicate, allowing
 range of range (of range...) comparisons.
  +/
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota, chunks;
@@ -1020,7 +1020,7 @@ range of range (of range...) comparisons.
     ));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.internal.test.dummyrange : ReferenceForwardRange,
@@ -1084,7 +1084,7 @@ range of range (of range...) comparisons.
     assert(!equal(cir, ifr));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.utf : byChar, byWchar, byDchar;
 
@@ -1096,7 +1096,7 @@ range of range (of range...) comparisons.
     assert(equal("æøå"d, "æøå".byDchar));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     struct R(bool _empty) {
         enum empty = _empty;
@@ -1169,7 +1169,7 @@ enum EditOp : char
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     with(EditOp)
     {
@@ -1418,7 +1418,7 @@ if (isForwardRange!(Range1) && isForwardRange!(Range2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.uni : toUpper;
@@ -1434,7 +1434,7 @@ if (isForwardRange!(Range1) && isForwardRange!(Range2))
     assert(levenshteinDistance("ID", "I♥D") == 1);
 }
 
-@safe @nogc nothrow unittest
+version(StdUnittest) @safe @nogc nothrow unittest
 {
     assert(levenshteinDistance("cat"d, "rat"d) == 1);
 }
@@ -1449,7 +1449,7 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
     return levenshteinDistance!(equals, Types)(s, t);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S { string s; alias s this; }
     assert(levenshteinDistance(S("cat"), S("rat")) == 1);
@@ -1457,7 +1457,7 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
     assert(levenshteinDistance(S("cat"), "rat") == 1);
 }
 
-@safe @nogc nothrow unittest
+version(StdUnittest) @safe @nogc nothrow unittest
 {
     static struct S { dstring s; alias s this; }
     assert(levenshteinDistance(S("cat"d), S("rat"d)) == 1);
@@ -1491,7 +1491,7 @@ if (isForwardRange!(Range1) && isForwardRange!(Range2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string a = "Saturday", b = "Sundays";
     auto p = levenshteinDistanceAndPath(a, b);
@@ -1499,7 +1499,7 @@ if (isForwardRange!(Range1) && isForwardRange!(Range2))
     assert(equal(p[1], "nrrnsnnni"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(levenshteinDistance("a", "a") == 0);
     assert(levenshteinDistance("a", "b") == 1);
@@ -1520,7 +1520,7 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
     return levenshteinDistanceAndPath!(equals, Types)(s, t);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S { string s; alias s this; }
     assert(levenshteinDistanceAndPath(S("cat"), S("rat"))[0] == 1);
@@ -1571,7 +1571,7 @@ if (T.length >= 2)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a = 5;
     short b = 6;
@@ -1584,7 +1584,7 @@ if (T.length >= 2)
     assert(e == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a = 5;
     short b = 6;
@@ -1683,7 +1683,7 @@ if (T.length >= 2)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a = 5;
     short b = 6;
@@ -1734,7 +1734,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[]    x = [ 1,  5, 2, 7,   4, 3 ];
     double[] y = [ 1.0, 5, 2, 7.3, 4, 8 ];
@@ -1743,7 +1743,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
     assert(m[1] == y[3 .. $]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3 ];
     int[] b = [ 1, 2, 4, 5 ];
@@ -1829,7 +1829,7 @@ auto predSwitch(alias pred = "a == b", T, R ...)(T switchExpression, lazy R choi
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string res = 2.predSwitch!"a < b"(
         1, "less than 1",
@@ -1856,7 +1856,7 @@ auto predSwitch(alias pred = "a == b", T, R ...)(T switchExpression, lazy R choi
     assertThrown!Exception(factorial(-9));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : SwitchError;
     import std.exception : assertThrown;
@@ -1965,7 +1965,7 @@ if (isInputRange!Range1 &&
 }
 
 ///
-@safe nothrow pure unittest
+version(StdUnittest) @safe nothrow pure unittest
 {
     assert(isSameLength([1, 2, 3], [4, 5, 6]));
     assert(isSameLength([0.3, 90.4, 23.7, 119.2], [42.6, 23.6, 95.5, 6.3]));
@@ -1981,7 +1981,7 @@ if (isInputRange!Range1 &&
 }
 
 // Test CTFE
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     enum result1 = isSameLength([1, 2, 3], [4, 5, 6]);
     static assert(result1);
@@ -1990,7 +1990,7 @@ if (isInputRange!Range1 &&
     static assert(!result2);
 }
 
-@safe nothrow pure unittest
+version(StdUnittest) @safe nothrow pure unittest
 {
     import std.internal.test.dummyrange;
 
@@ -2168,7 +2168,7 @@ if (is(typeof(binaryFun!(pred))) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : Yes;
 
@@ -2186,7 +2186,7 @@ if (is(typeof(binaryFun!(pred))) &&
 }
 
 // Test @nogc inference
-@safe @nogc pure unittest
+version(StdUnittest) @safe @nogc pure unittest
 {
     static immutable arr1 = [1, 2, 3];
     static immutable arr2 = [3, 2, 1];
@@ -2197,7 +2197,7 @@ if (is(typeof(binaryFun!(pred))) &&
     assert(!isPermutation(arr3, arr4));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.internal.test.dummyrange;
 
@@ -2269,7 +2269,7 @@ if (alternatives.length >= 1 &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     const a = 1;
     const b = 2;

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -97,7 +97,7 @@ if (fun.length >= 1)
         return ror.map!(reduce!fun);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal, max, min;
 
@@ -164,7 +164,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range, std.stdio;
@@ -219,7 +219,7 @@ may yield a faster _range.
 Either way, the resulting ranges will be equivalent, but maybe not at the
 same cost or side effects.
 +/
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -236,7 +236,7 @@ same cost or side effects.
     assert(i == 3); //cache has accessed 3. It is still stored internally by cache.
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -249,7 +249,7 @@ same cost or side effects.
     assert(equal(r2, [2, 3, 4]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -267,7 +267,7 @@ same cost or side effects.
     assert(equal(s.cacheBidirectional(), s));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -277,14 +277,14 @@ same cost or side effects.
     assert(equal(a.cacheBidirectional(), a));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[][] stringbufs = ["hello".dup, "world".dup];
     auto strings = stringbufs.map!((a)=>a.idup)().cache();
     assert(strings.front is strings.front);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : cycle;
     import std.algorithm.comparison : equal;
@@ -295,7 +295,7 @@ same cost or side effects.
     assert(d.equal([2]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct Range
     {
@@ -499,7 +499,7 @@ if (fun.length >= 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : chain;
@@ -514,7 +514,7 @@ Multiple functions can be passed to `map`. In that case, the
 element type of `map` is a tuple containing one element for each
 function.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto sums = [2, 4, 6, 8];
     auto products = [1, 4, 9, 16];
@@ -532,7 +532,7 @@ function.
 You may alias `map` with some function(s) to a symbol and use
 it separately:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -540,8 +540,7 @@ it separately:
     alias stringize = map!(to!string);
     assert(equal(stringize([ 1, 2, 3, 4 ]), [ "1", "2", "3", "4" ]));
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Verify workaround for DMD #15777
 
@@ -664,8 +663,7 @@ private struct MapResult(alias fun, Range)
         }
     }
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -684,7 +682,7 @@ private struct MapResult(alias fun, Range)
     //assert(equal(countAndSquare([ 10, 2 ]), [ tuple(0u, 100), tuple(1u, 4) ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.ascii : toUpper;
@@ -799,7 +797,7 @@ private struct MapResult(alias fun, Range)
     assert(dd.length == 4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -808,7 +806,7 @@ private struct MapResult(alias fun, Range)
     assert(equal(m, [1L, 4L, 9L]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota;
 
@@ -824,7 +822,7 @@ private struct MapResult(alias fun, Range)
     assert(map!(i => i)(iota(floatBegin, floatEnd, floatStep)).walkLength == 50);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -836,7 +834,7 @@ private struct MapResult(alias fun, Range)
     assert(equal(rr[0 .. 5], [1, 4, 9, 16, 0]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     struct S {int* p;}
@@ -965,7 +963,7 @@ public:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range : iota;
 
@@ -1006,7 +1004,7 @@ public:
 }
 
 // binary foreach with two ref args
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range : lockstep;
 
@@ -1020,7 +1018,7 @@ public:
 }
 
 // #15358: application of `each` with >2 args (opApply)
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range : lockstep;
     auto a = [0,1,2];
@@ -1035,7 +1033,7 @@ public:
 }
 
 // #15358: application of `each` with >2 args (range interface)
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : zip;
     auto a = [0,1,2];
@@ -1050,7 +1048,7 @@ public:
 }
 
 // #16255: `each` on opApply doesn't support ref
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] dynamicArray = [1, 2, 3, 4, 5];
     int[5] staticArray = [1, 2, 3, 4, 5];
@@ -1066,7 +1064,7 @@ public:
 }
 
 // #16255: `each` on opApply doesn't support ref
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -1110,7 +1108,7 @@ if (is(typeof(unaryFun!predicate)))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.math : approxEqual;
@@ -1200,8 +1198,7 @@ private struct FilterResult(alias pred, Range)
         }
     }
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -1262,8 +1259,7 @@ private struct FilterResult(alias pred, Range)
     auto m = map!"a + 1"(filter!"a < 4"(arr));
     assert(equal(m, [2, 3, 4]));
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1279,7 +1275,7 @@ private struct FilterResult(alias pred, Range)
     assert(equal(under10.save, under10));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.functional : compose, pipe;
@@ -1290,7 +1286,7 @@ private struct FilterResult(alias pred, Range)
             [2,6,10]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1330,7 +1326,7 @@ template filterBidirectional(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -1512,7 +1508,7 @@ if (isInputRange!R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple, Tuple;
@@ -1526,7 +1522,7 @@ if (isInputRange!R)
  * Using group, an associative array can be easily generated with the count of each
  * unique element in the range.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : sort;
     import std.array : assocArray;
@@ -1540,7 +1536,7 @@ if (isInputRange!R)
     assert(result == ["a": 2U, "b": 2U, "c": 3U, "d": 1U, "e": 1U]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -1564,7 +1560,7 @@ if (isInputRange!R)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -1828,7 +1824,7 @@ if (isForwardRange!Range)
     static assert(isForwardRange!(typeof(this)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1929,7 +1925,7 @@ if (isInputRange!Range)
 }
 
 /// Showing usage with binary predicate:
-/*FIXME: @safe*/ @system unittest
+version(StdUnittest) /*FIXME: @safe*/ @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1956,7 +1952,7 @@ if (isInputRange!Range)
 }
 
 version(none) // this example requires support for non-equivalence relations
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Grouping by maximum adjacent difference:
     import std.math : abs;
@@ -1970,7 +1966,7 @@ version(none) // this example requires support for non-equivalence relations
 }
 
 /// Showing usage with unary predicate:
-/* FIXME: pure @safe nothrow*/ @system unittest
+version(StdUnittest) /* FIXME: pure @safe nothrow*/ @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives;
@@ -2019,7 +2015,7 @@ version(none) // this example requires support for non-equivalence relations
     }
 }
 
-/*FIXME: pure @safe nothrow*/ @system unittest
+version(StdUnittest) /*FIXME: pure @safe nothrow*/ @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -2097,7 +2093,7 @@ version(none) // this example requires support for non-equivalence relations
 
 // Issue 13595
 version(none) // This requires support for non-equivalence relations
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto r = [1, 2, 3, 4, 5, 6, 7, 8, 9].chunkBy!((x, y) => ((x*y) % 3) == 0);
@@ -2110,7 +2106,7 @@ version(none) // This requires support for non-equivalence relations
 }
 
 // Issue 13805
-@system unittest
+version(StdUnittest) @system unittest
 {
     [""].map!((s) => s).chunkBy!((x, y) => true);
 }
@@ -2293,7 +2289,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -2306,8 +2302,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     assert([""].joiner("xyz").equal(""));
     assert(["", ""].joiner("xyz").equal("xyz"));
 }
-
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.interfaces;
@@ -2317,7 +2312,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     assert(equal(joiner(r, "xyz"), "abcxyzdef"));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -2366,7 +2361,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
         .array();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2413,7 +2408,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     assert(equal(joiner(tr5, [0,1]), [1,2,0,1,3,4,0,1,0,1]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isInputRange!(typeof(joiner([""], ""))));
     static assert(isForwardRange!(typeof(joiner([""], ""))));
@@ -2525,8 +2520,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     }
     return Result(r);
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.interfaces : inputRangeObject;
@@ -2552,7 +2546,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.interfaces : inputRangeObject;
@@ -2575,7 +2569,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     assert(!equal(js2, js));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2620,7 +2614,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     assert(equal(result, [1,2,3,4,5,6,7]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.internal : algoFormat;
@@ -2670,7 +2664,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
 }
 
 // Issue 8061
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.range.interfaces;
@@ -2682,7 +2676,7 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR))
     assert(str == "abcd");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : repeat;
 
@@ -2897,7 +2891,7 @@ Many aggregate range operations turn out to be solved with `reduce`
 quickly and easily. The example below illustrates `reduce`'s
 remarkable power and flexibility.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.math : approxEqual;
@@ -2952,7 +2946,7 @@ If two or more functions are passed, `reduce` returns a
 $(REF Tuple, std,typecons) object with one member per passed-in function.
 The number of seeds must be correspondingly increased.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.math : approxEqual, sqrt;
@@ -2976,7 +2970,7 @@ The number of seeds must be correspondingly increased.
     assert(cast(int) stdev == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.range : chain;
@@ -3005,7 +2999,7 @@ The number of seeds must be correspondingly increased.
     assert(rep[2 .. $] == "1, 2, 3, 4, 5", "["~rep[2 .. $]~"]");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.exception : assertThrown;
@@ -3045,7 +3039,7 @@ The number of seeds must be correspondingly increased.
     assertThrown(reduce!"a + b"(oa));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     const float a = 0.0;
     const float[] b = [ 1.2, 3, 3.3 ];
@@ -3055,7 +3049,7 @@ The number of seeds must be correspondingly increased.
     assert(r == 7.5);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue #10408 - Two-function reduce of a const array.
     import std.algorithm.comparison : max, min;
@@ -3068,7 +3062,7 @@ The number of seeds must be correspondingly increased.
     assert(minmax == tuple(10, 30));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //10709
     import std.typecons : tuple, Tuple;
@@ -3081,7 +3075,7 @@ The number of seeds must be correspondingly increased.
     assert(r2 == tuple(3, 3));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct OpApply
     {
@@ -3120,7 +3114,7 @@ The number of seeds must be correspondingly increased.
     assert(b == 9);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.typecons : tuple, Tuple;
@@ -3137,7 +3131,7 @@ The number of seeds must be correspondingly increased.
     assert(minmaxElement([1, 2, 3]) == tuple(1, 3));
 }
 
-@safe unittest //12569
+version(StdUnittest) @safe unittest //12569
 {
     import std.algorithm.comparison : max, min;
     import std.typecons : tuple;
@@ -3158,7 +3152,7 @@ The number of seeds must be correspondingly increased.
     static assert(!is(typeof(reduce!(all, all)(tuple(1, 1), "hello"))));
 }
 
-@safe unittest //13304
+version(StdUnittest) @safe unittest //13304
 {
     int[] data;
     static assert(is(typeof(reduce!((a, b) => a + b)(data))));
@@ -3230,7 +3224,7 @@ if (fun.length >= 1)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     immutable arr = [1, 2, 3, 4, 5];
 
@@ -3256,7 +3250,7 @@ if (fun.length >= 1)
     assert(arr.fold!((a, b) => b) == 5);
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     int[1] arr;
     static assert(!is(typeof(arr.fold!())));
@@ -3444,7 +3438,7 @@ if (fun.length >= 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.array : array;
@@ -3500,7 +3494,7 @@ If two or more functions are passed, `cumulativeFold` returns a $(REF Tuple,
 std,typecons) object with one member per passed-in function.
 The number of seeds must be correspondingly increased.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.algorithm.iteration : map;
@@ -3520,7 +3514,7 @@ The number of seeds must be correspondingly increased.
     assert(approxEqual(r2.map!"a[1]", [9, 25, 74, 195, 204, 208, 233])); // sum of squares
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal, max, min;
     import std.conv : to;
@@ -3555,7 +3549,7 @@ The number of seeds must be correspondingly increased.
     assert(a.cumulativeFold!"a + b"(2.0).empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.array : array;
@@ -3578,8 +3572,7 @@ The number of seeds must be correspondingly increased.
     enum minmax = numbers.cumulativeFold!(min, max).array;
     assert(minmax == [tuple(10, 10), tuple(10, 30), tuple(10, 30)]);
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
     import std.typecons : tuple;
@@ -3592,8 +3585,7 @@ The number of seeds must be correspondingly increased.
     assert(approxEqual(r2.map!"a[0]", [0, 0.5, 1.5, 3]));
     assert(approxEqual(r2.map!"a[1]", [0, 0.5, 1.5, 3]));
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal, max, min;
     import std.array : array;
@@ -3610,7 +3602,7 @@ The number of seeds must be correspondingly increased.
     assert(minmaxElement([1, 2, 3]).equal([tuple(1, 1), tuple(1, 2), tuple(1, 3)]));
 }
 
-@safe unittest //12569
+version(StdUnittest) @safe unittest //12569
 {
     import std.algorithm.comparison : equal, max, min;
     import std.typecons : tuple;
@@ -3633,13 +3625,12 @@ The number of seeds must be correspondingly increased.
     static assert(!__traits(compiles, cumulativeFold!(all, all)("hello", tuple(1, 1))));
 }
 
-@safe unittest //13304
+version(StdUnittest) @safe unittest //13304
 {
     int[] data;
     assert(data.cumulativeFold!((a, b) => a + b).empty);
 }
-
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, propagatesLength,
@@ -3856,7 +3847,7 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.ascii : toLower;
@@ -3897,7 +3888,7 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     assert(equal(splitter("a|bc|def", '|').retro, [ "def", "bc", "a" ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.array : array;
@@ -3959,7 +3950,7 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
         }
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.range;
@@ -4100,7 +4091,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4119,7 +4110,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(equal(splitter(a, [0, 0]), [ [], [1] ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : Tuple;
@@ -4129,7 +4120,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(equal(splitter!"a.x == b"(a, [2, 3]), [ [C(1,0)], [C(4,0)] ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.array : split;
@@ -4159,7 +4150,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(walkLength(words) == 5, text(walkLength(words)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][] a = [ [1], [2], [0], [3], [0], [4], [5], [0] ];
     int[][][] w = [ [[1], [2]], [[3]], [[4], [5]], [] ];
@@ -4172,7 +4163,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(i == w.length);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto s6 = ",";
@@ -4181,7 +4172,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(equal(sp6, ["", ""][]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4190,7 +4181,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(s.equal(["a", "b", "c"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4245,7 +4236,7 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(input.front))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : front;
@@ -4377,7 +4368,7 @@ private struct SplitterResult(alias isTerminator, Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -4391,7 +4382,7 @@ private struct SplitterResult(alias isTerminator, Range)
     assert(s.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.internal : algoFormat;
@@ -4426,7 +4417,7 @@ private struct SplitterResult(alias isTerminator, Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.internal : algoFormat;
@@ -4453,7 +4444,7 @@ private struct SplitterResult(alias isTerminator, Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.uni : isWhite;
@@ -4539,14 +4530,14 @@ if (isSomeChar!C)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     auto a = " a     bcd   ef gh ";
     assert(equal(splitter(a), ["a", "bcd", "ef", "gh"][]));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.meta : AliasSeq;
@@ -4563,7 +4554,7 @@ if (isSomeChar!C)
     assert(equal(splitter(s), ["a", "bcd", "ef", "gh"][]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.string : strip;
@@ -4591,7 +4582,7 @@ if (isSomeChar!C)
     assert(dictionary["last"]== 4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.internal : algoFormat;
@@ -4746,7 +4737,7 @@ private template hasDifferentAutodecoding(Range, Needles...)
                                     is(CommonType!(Range, Needles) == void));
 }
 
-@safe nothrow @nogc pure unittest
+version(StdUnittest) @safe nothrow @nogc pure unittest
 {
     import std.meta : AliasSeq; // used for better clarity
 
@@ -5003,7 +4994,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5033,7 +5024,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 /// Use the faster compile-time overload
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5050,7 +5041,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 /// Multiple substitutes
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : ElementType;
@@ -5068,7 +5059,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // Test the first example with compile-time overloads
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5098,7 +5089,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test infinite ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : cycle, take;
@@ -5109,7 +5100,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test infinite ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -5127,7 +5118,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test multiple replacements
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5153,7 +5144,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test combination of subrange + element replacement
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5166,7 +5157,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test const + immutable storage groups
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5186,7 +5177,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test with narrow strings (auto-decoding) and subranges
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5202,7 +5193,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test with narrow strings (auto-decoding) and single elements
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5217,7 +5208,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test auto-decoding {n,w,d} strings X {n,w,d} strings
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5240,7 +5231,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test repeated replacement
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5250,7 +5241,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test @nogc for single element replacements
-@safe @nogc unittest
+version(StdUnittest) @safe @nogc unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5262,7 +5253,7 @@ if (isInputRange!R && Substs.length >= 2 && !is(CommonType!(Substs) == void))
 }
 
 // test different range types
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -5360,7 +5351,7 @@ if (isInputRange!R && !isInfinite!R && is(typeof(seed = seed + r.front)))
 }
 
 /// Ditto
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.range;
 
@@ -5499,7 +5490,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     return result;
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static assert(is(typeof(sum([cast( byte) 1])) ==  int));
     static assert(is(typeof(sum([cast(ubyte) 1])) ==  int));
@@ -5516,7 +5507,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     assert(sum([42, 43, 44, 45]) == 42 + 43 + 44 + 45);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static assert(is(typeof(sum([1.0, 2.0, 3.0, 4.0])) == double));
     static assert(is(typeof(sum([ 1F,  2F,  3F,  4F])) == double));
@@ -5532,7 +5523,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     assert(sum([42., 43., 44., 45.5]) == 42 + 43 + 44 + 45.5);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.container;
     static assert(is(typeof(sum(SList!float()[])) == double));
@@ -5546,7 +5537,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     assert(sum(SList!double(1, 2, 3, 4)[]) == 10);
 }
 
-@safe pure nothrow unittest // 12434
+version(StdUnittest) @safe pure nothrow unittest // 12434
 {
     immutable a = [10, 20];
     auto s1 = sum(a);
@@ -5555,7 +5546,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     assert(s2 == 30);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.bigint;
     import std.range;
@@ -5568,7 +5559,7 @@ private auto sumKahan(Result, R)(Result result, R r)
     assert(sb == (BigInt(ulong.max/2) * 10));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.range;
     foreach (n; iota(50))
@@ -5651,7 +5642,7 @@ if (isInputRange!R &&
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     import std.math : approxEqual, isNaN;
 
@@ -5664,7 +5655,7 @@ if (isInputRange!R &&
     assert(arr1[0 .. 0].mean.isNaN);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.internal.test.dummyrange : ReferenceInputRange;
     import std.math : approxEqual;
@@ -5677,7 +5668,7 @@ if (isInputRange!R &&
 }
 
 // Test user defined types
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.bigint : BigInt;
     import std.internal.test.dummyrange : ReferenceInputRange;
@@ -5733,7 +5724,7 @@ if (isInputRange!Range && is(typeof(binaryFun!pred(r.front, r.front)) == bool))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.mutation : copy;
@@ -5819,7 +5810,7 @@ private struct UniqResult(alias pred, Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -5847,7 +5838,7 @@ private struct UniqResult(alias pred, Range)
     }
 }
 
-@safe unittest // https://issues.dlang.org/show_bug.cgi?id=17264
+version(StdUnittest) @safe unittest // https://issues.dlang.org/show_bug.cgi?id=17264
 {
     import std.algorithm.comparison : equal;
 
@@ -5935,7 +5926,7 @@ if (isRandomAccessRange!Range && hasLength!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -149,7 +149,7 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
 The simplest use of `bringToFront` is for rotating elements in a
 buffer. For example:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto arr = [4, 5, 6, 7, 1, 2, 3];
     auto p = bringToFront(arr[0 .. 4], arr[4 .. $]);
@@ -163,7 +163,7 @@ range. This is very useful with forward ranges that cannot compute
 comfortably right-bounded subranges like `arr[0 .. 4]` above. In
 the example below, `r2` is a right subrange of `r1`.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
@@ -180,7 +180,7 @@ the example below, `r2` is a right subrange of `r1`.
 /**
 Elements can be swapped across ranges of different types:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
@@ -195,7 +195,7 @@ Elements can be swapped across ranges of different types:
 /**
 Unicode integrity is not preserved:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string : representation;
     auto ar = representation("a".dup);
@@ -275,7 +275,7 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
     return result;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -420,7 +420,7 @@ if (!areCopyCompatibleArrays!(SourceRange, TargetRange) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 5 ];
     int[] b = [ 9, 8 ];
@@ -435,7 +435,7 @@ if (!areCopyCompatibleArrays!(SourceRange, TargetRange) &&
 As long as the target range elements support assignment from source
 range elements, different types of ranges are accepted:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     float[] src = [ 1.0f, 5 ];
     double[] dest = new double[src.length];
@@ -446,7 +446,7 @@ range elements, different types of ranges are accepted:
 To _copy at most `n` elements from a range, you may want to use
 $(REF take, std,range):
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     int[] src = [ 1, 5, 8, 9, 10 ];
@@ -459,7 +459,7 @@ $(REF take, std,range):
 To _copy just those elements from a range that satisfy a predicate,
 use $(LREF filter):
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     int[] src = [ 1, 5, 8, 9, 10, 1, 2, 0 ];
@@ -474,7 +474,7 @@ use $(LREF filter):
 $(REF retro, std,range) can be used to achieve behavior similar to
 $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm, std.range;
     int[] src = [1, 2, 4];
@@ -484,14 +484,14 @@ $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 }
 
 // Test CTFE copy.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum c = copy([1,2,3], [4,5,6,7]);
     assert(c == [7]);
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
 
@@ -521,7 +521,7 @@ $(HTTP sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 13650
     import std.meta : AliasSeq;
@@ -583,7 +583,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 4 ];
     fill(a, 5);
@@ -591,7 +591,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
 }
 
 // issue 16342, test fallback on mutable narrow strings
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] chars = ['a', 'b'];
     fill(chars, 'c');
@@ -610,7 +610,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
     assert(dchars == "cc"d);
 }
 
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     const(char)[] chars;
     assert(chars.length == 0);
@@ -620,21 +620,21 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
     static assert(!__traits(compiles, fill(wchars, wchar('c'))));
 }
 
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     char[] chars;
     fill(chars, 'c');
     assert(chars == ""c);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     shared(char)[] chrs = ['r'];
     fill(chrs, 'c');
     assert(chrs == [shared(char)('c')]);
 }
 
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     struct Str(size_t len)
     {
@@ -647,7 +647,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
     assert(str._data == "::");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] chars = ['a','b','c','d'];
     chars[1 .. 3].fill(':');
@@ -655,7 +655,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
 }
 // end issue 16342
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : text;
     import std.internal.test.dummyrange;
@@ -682,7 +682,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
         assert(value == filler);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //ER8638_1 IS_NOT self assignable
     static struct ER8638_1
@@ -703,7 +703,7 @@ if ((isInputRange!Range && is(typeof(range.front = value)) ||
     er8638_2.fill(5); //opSlice(T.init) case
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     {
         int[] a = [1, 2, 3];
@@ -790,7 +790,7 @@ if (isInputRange!InputRange
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 4, 5 ];
     int[] b = [ 8, 9 ];
@@ -798,7 +798,7 @@ if (isInputRange!InputRange
     assert(a == [ 8, 9, 8, 9, 8 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     import std.internal.test.dummyrange;
@@ -898,7 +898,7 @@ if (is(Range == char[]) || is(Range == wchar[]))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.stdc.stdlib : malloc, free;
 
@@ -914,7 +914,7 @@ if (is(Range == char[]) || is(Range == wchar[]))
     scope(exit) free(s.ptr);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : filter;
     import std.meta : AliasSeq;
@@ -1002,7 +1002,7 @@ if (is(Range == char[]) || is(Range == wchar[]))
 
 // test that initializeAll works for arrays of static arrays of structs with
 // elaborate assigns.
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Int {
         ~this() {}
@@ -1047,7 +1047,7 @@ void move(T)(ref T source, ref T target)
 }
 
 /// For non-struct types, `move` just performs `target = source`:
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Object obj1 = new Object;
     Object obj2 = obj1;
@@ -1060,7 +1060,7 @@ void move(T)(ref T source, ref T target)
 }
 
 ///
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     // Structs without destructors are simply copied
     struct S1
@@ -1094,7 +1094,7 @@ pure nothrow @safe @nogc unittest
     assert(s22 == S2(3, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertCTFEable;
     import std.traits;
@@ -1166,7 +1166,7 @@ T move(T)(return scope ref T source)
 }
 
 /// Non-copyable structs can still be moved:
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     struct S
     {
@@ -1212,7 +1212,7 @@ private T moveImpl(T)(ref T source)
     return result;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertCTFEable;
     import std.traits;
@@ -1271,7 +1271,7 @@ private T moveImpl(T)(ref T source)
     assert(s53 is s51);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S { int n = 0; ~this() @system { n = 0; } }
     S a, b;
@@ -1285,14 +1285,14 @@ private T moveImpl(T)(ref T source)
     assert(a.n == 0);
 }
 
-@safe unittest//Issue 6217
+version(StdUnittest) @safe unittest//Issue 6217
 {
     import std.algorithm.iteration : map;
     auto x = map!"a"([1,2,3]);
     x = move(x);
 }
 
-@safe unittest// Issue 8055
+version(StdUnittest) @safe unittest// Issue 8055
 {
     static struct S
     {
@@ -1312,7 +1312,7 @@ private T moveImpl(T)(ref T source)
     assert(b.x == 0);
 }
 
-@system unittest// Issue 8057
+version(StdUnittest) @system unittest// Issue 8057
 {
     int n = 10;
     struct S
@@ -1405,7 +1405,7 @@ void moveEmplace(T)(ref T source, ref T target) @system
 }
 
 ///
-pure nothrow @nogc @system unittest
+version(StdUnittest) pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -1456,7 +1456,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     int[3] a = [ 1, 2, 3 ];
     int[5] b;
@@ -1479,7 +1479,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @nogc @system unittest
+version(StdUnittest) pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -1499,7 +1499,7 @@ pure nothrow @nogc @system unittest
     assert(dst[0 .. 3].all!(e => e._ptr !is null));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct InputRange
     {
@@ -1563,7 +1563,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     int[5] a = [ 1, 2, 3, 4, 5 ];
     int[3] b;
@@ -1585,7 +1585,7 @@ if (isInputRange!InputRange1 && isInputRange!InputRange2
 }
 
 ///
-pure nothrow @nogc @system unittest
+version(StdUnittest) pure nothrow @nogc @system unittest
 {
     static struct Foo
     {
@@ -1666,7 +1666,7 @@ enum SwapStrategy
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.stdio;
     import std.algorithm.sorting : partition;
@@ -1677,7 +1677,7 @@ enum SwapStrategy
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : partition;
 
@@ -1927,7 +1927,7 @@ if (s == SwapStrategy.stable
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : tuple;
 
@@ -1944,7 +1944,7 @@ if (s == SwapStrategy.stable
     assert(remove!(SwapStrategy.unstable)(a, tuple(1, 4)) == [0, 5, 4]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     import std.range;
@@ -1957,7 +1957,7 @@ if (s == SwapStrategy.stable
     assertThrown(remove!(SwapStrategy.unstable)(test, 2, 4, 1, 3));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     int[] a = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
@@ -1993,7 +1993,7 @@ if (s == SwapStrategy.stable
             == [0, 9, 8, 7, 4, 5]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 11576
     auto arr = [1,2,3];
@@ -2002,7 +2002,7 @@ if (s == SwapStrategy.stable
 
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     // Bug# 12889
@@ -2072,7 +2072,7 @@ if (isBidirectionalRange!Range
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static immutable base = [1, 2, 3, 2, 4, 2, 5, 2];
 
@@ -2090,7 +2090,7 @@ if (isBidirectionalRange!Range
     assert(remove!(a => a == 2)(arr) == [ 1, 3, 4, 5 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 2, 3, 4, 5, 2, 5, 6 ];
     assert(remove!("a == 2", SwapStrategy.unstable)(a) ==
@@ -2100,7 +2100,7 @@ if (isBidirectionalRange!Range
             [ 1, 3, 3, 4, 5, 5, 6 ]);
 }
 
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     // @nogc test
     int[10] arr = [0,1,2,3,4,5,6,7,8,9];
@@ -2112,7 +2112,7 @@ if (isBidirectionalRange!Range
     r = r.remove!(pred, SwapStrategy.stable);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : min;
     import std.algorithm.searching : all, any;
@@ -2205,7 +2205,7 @@ if (isBidirectionalRange!Range && !isRandomAccessRange!Range
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] arr = [ 1, 2, 3 ];
     reverse(arr);
@@ -2225,7 +2225,7 @@ if (isRandomAccessRange!Range && hasLength!Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] range = null;
     reverse(range);
@@ -2265,14 +2265,14 @@ if (isNarrowString!(Char[]) && !is(Char == const) && !is(Char == immutable))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] arr = "hello\U00010143\u0100\U00010143".dup;
     reverse(arr);
     assert(arr == "\U00010143\u0100\U00010143olleh");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test(string a, string b)
     {
@@ -2372,7 +2372,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip leading and trailing elements equal to the target element.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".strip(' ') == "foobar");
     assert("00223.444500".strip('0') == "223.4445");
@@ -2382,7 +2382,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip leading and trailing elements while the predicate returns true.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".strip!(a => a == ' ')() == "foobar");
     assert("00223.444500".strip!(a => a == '0')() == "223.4445");
@@ -2392,7 +2392,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip leading elements equal to the target element.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".stripLeft(' ') == "foobar  ");
     assert("00223.444500".stripLeft('0') == "223.444500");
@@ -2402,7 +2402,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip leading elements while the predicate returns true.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".stripLeft!(a => a == ' ')() == "foobar  ");
     assert("00223.444500".stripLeft!(a => a == '0')() == "223.444500");
@@ -2412,7 +2412,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip trailing elements equal to the target element.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".stripRight(' ') == "  foobar");
     assert("00223.444500".stripRight('0') == "00223.4445");
@@ -2422,7 +2422,7 @@ if (isBidirectionalRange!Range && is(typeof(pred(range.back)) : bool))
 }
 
 /// Strip trailing elements while the predicate returns true.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert("  foobar  ".stripRight!(a => a == ' ')() == "  foobar");
     assert("00223.444500".stripRight!(a => a == '0')() == "00223.4445");
@@ -2495,7 +2495,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Swapping POD (plain old data) types:
     int a = 42, b = 34;
@@ -2527,7 +2527,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Non-copyable types can still be swapped.
     static struct NoCopy
@@ -2573,7 +2573,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     static assert(!__traits(compiles, swap(const1, const2)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Bug# 4789
     int[1] s = [1];
@@ -2584,7 +2584,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     assert(a == [1, 3, 2]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct NoAssign
     {
@@ -2598,7 +2598,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     assert(s2.i == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S
     {
@@ -2613,7 +2613,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     assert(s.i3 == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //11853
     import std.traits : isAssignable;
@@ -2621,7 +2621,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     static assert(isAssignable!T);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 12024
     import std.datetime;
@@ -2629,7 +2629,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     swap(a, b);
 }
 
-@system unittest // 9975
+version(StdUnittest) @system unittest // 9975
 {
     import std.exception : doesPointTo, mayPointTo;
     static struct S2
@@ -2655,7 +2655,7 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
     assertThrown!Error(swap(p, pp));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct A
     {
@@ -2711,7 +2711,7 @@ void swapAt(R)(auto ref R r, size_t i1, size_t i2)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     auto a = [1, 2, 3];
@@ -2719,7 +2719,7 @@ pure @safe nothrow unittest
     assert(a.equal([1, 3, 2]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     auto a = [4, 5, 6];
@@ -2727,7 +2727,7 @@ pure @safe nothrow unittest
     assert(a.equal([4, 5, 6]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     // test non random access ranges
     import std.algorithm.comparison : equal;
@@ -2836,7 +2836,7 @@ if (hasSwappableElements!InputRange1 && hasSwappableElements!InputRange2
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : empty;
     int[] a = [ 100, 101, 102, 103 ];
@@ -2885,7 +2885,7 @@ if (isInputRange!Range && hasLvalueElements!Range && is(typeof(range.front = val
 }
 
 ///
-nothrow @system unittest
+version(StdUnittest) nothrow @system unittest
 {
     import core.stdc.stdlib : malloc, free;
 

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -132,7 +132,7 @@ template all(alias pred = "a")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert( all!"a & 1"([1, 3, 5, 7, 9]));
     assert(!all!"a & 1"([1, 2, 3, 5, 7, 9]));
@@ -144,13 +144,13 @@ evaluated to true or false in a conditional statement. This can be a
 convenient way to quickly evaluate that $(I _all) of the elements of a range
 are true.
  +/
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[3] vals = [5, 3, 18];
     assert( all(vals[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int x = 1;
     assert(all!(a => a > x)([2, 3]));
@@ -177,7 +177,7 @@ template any(alias pred = "a")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isWhite;
     assert( all!(any!isWhite)(["a a", "b b"]));
@@ -190,7 +190,7 @@ evaluated to true or false in a conditional statement. `!any` can be a
 convenient way to quickly test that $(I none) of the elements of a range
 evaluate to true.
  +/
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[3] vals1 = [0, 0, 0];
     assert(!any(vals1[])); //none of vals1 evaluate to true
@@ -204,7 +204,7 @@ evaluate to true.
     assert( all(vals3[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 1, 2, 0, 4 ];
     assert(any!"a == 2"(a));
@@ -261,7 +261,7 @@ if (isInputRange!(Range) && is(typeof(r.front == lPar)))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s = "1 + (2 * (3 + 1 / 2)";
     assert(!balancedParens(s, '(', ')'));
@@ -401,7 +401,7 @@ if ((isRandomAccessRange!(Range) && hasSlicing!Range) || isSomeString!Range)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto bmFinder = boyerMooreFinder("TG");
 
@@ -471,7 +471,7 @@ if (isForwardRange!R1 && isInputRange!R2 &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(commonPrefix("hello, world", "hello, there") == "hello, ");
 }
@@ -536,7 +536,7 @@ if (isNarrowString!R1 && isNarrowString!R2)
         return commonPrefix!"a == b"(r1, r2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -642,7 +642,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.uni : toLower;
 
@@ -661,7 +661,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(count!("a > 1")(a) == 8);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : text;
 
@@ -679,7 +679,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(count!("a == '語'")("日本語"d) == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string s = "This is a fofofof list";
     string sub = "fof";
@@ -729,7 +729,7 @@ if (isInputRange!R && !isInfinite!R)
     return walkLength(haystack);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 4, 3, 2, 5, 3, 2, 4 ];
     assert(count!("a == 3")(a) == 2);
@@ -737,7 +737,7 @@ if (isInputRange!R && !isInfinite!R)
 }
 
 // Issue 11253
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     assert([1, 2, 3].count([2, 3]) == 1);
 }
@@ -863,7 +863,7 @@ if (isInputRange!R &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(countUntil("hello world", "world") == 6);
     assert(countUntil("hello world", 'r') == 8);
@@ -877,7 +877,7 @@ if (isInputRange!R &&
     assert(countUntil!"a > b"([0, 7, 12, 22, 9], 20) == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.internal.test.dummyrange;
@@ -904,7 +904,7 @@ if (isInputRange!R &&
     assert(r.save.countUntil(r3) == -1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(countUntil("hello world", "world", "asd") == 6);
     assert(countUntil("hello world", "world", "ello") == 1);
@@ -957,7 +957,7 @@ if (isInputRange!R &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isDigit;
     import std.uni : isWhite;
@@ -967,7 +967,7 @@ if (isInputRange!R &&
     assert(countUntil!"a > 20"([0, 7, 12, 22, 9]) == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.internal.test.dummyrange;
 
@@ -1158,7 +1158,7 @@ if (isInputRange!R &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isAlpha;
     assert("abc".endsWith!(a => a.isAlpha));
@@ -1185,7 +1185,7 @@ if (isInputRange!R &&
     assert(endsWith("abc", "x", "aaa", 'c', "sab") == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filterBidirectional;
     import std.conv : to;
@@ -1391,7 +1391,7 @@ private auto extremum(alias selector = "a < b", Range,
     return extremeElement;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // allows a custom map to select the extremum
     assert([[0, 4], [1, 2]].extremum!"a[0]" == [0, 4]);
@@ -1416,7 +1416,7 @@ private auto extremum(alias selector = "a < b", Range,
     assert(arr.extremum(1) == 1);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // 2d seeds
     int[][] arr2d;
@@ -1426,7 +1426,7 @@ private auto extremum(alias selector = "a < b", Range,
     assert(extremum([2, 3, 4], 1.5) == 1.5);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : enumerate, iota;
 
@@ -1457,7 +1457,7 @@ private auto extremum(alias selector = "a < b", Range,
     }
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable arr = [7, 3, 4, 2, 1, 8];
     assert(arr.extremum == 1);
@@ -1665,7 +1665,7 @@ if (isInputRange!InputRange &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
 
@@ -1683,7 +1683,7 @@ if (isInputRange!InputRange &&
 }
 
 /// Case-insensitive find of a string
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
     import std.uni : toLower;
@@ -1692,7 +1692,7 @@ if (isInputRange!InputRange &&
     assert(s.find!((a, b) => toLower(a) == b)("hello") == s);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
@@ -1705,7 +1705,7 @@ if (isInputRange!InputRange &&
     assert(equal(find!"a > b"("hello", 'k'), "llo"));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     assert(!find              ([1, 2, 3], 2).empty);
     assert(!find!((a,b)=>a == b)([1, 2, 3], 2).empty);
@@ -1713,7 +1713,7 @@ if (isInputRange!InputRange &&
     assert(!find!((a,b)=>a == b)([1, 2, 3], 2).empty);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.meta : AliasSeq;
     static foreach (R; AliasSeq!(string, wstring, dstring))
@@ -1734,7 +1734,7 @@ if (isInputRange!InputRange &&
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //CTFE
     static assert(find("abc", 'b') == "bc");
@@ -1748,7 +1748,7 @@ if (isInputRange!InputRange &&
     static assert(find!((a,b)=>a == b)([1, 2, 3], 2));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertCTFEable;
     import std.meta : AliasSeq;
@@ -1771,7 +1771,7 @@ if (isInputRange!InputRange &&
     assertCTFEable!dg;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 11603
     enum Foo : ubyte { A }
@@ -1814,7 +1814,7 @@ if (isInputRange!InputRange)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto arr = [ 1, 2, 3, 4, 1 ];
     assert(find!("a > 2")(arr) == [ 3, 4, 1 ]);
@@ -1824,7 +1824,7 @@ if (isInputRange!InputRange)
     assert(find!(pred)(arr) == arr);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     int[] r = [ 1, 2, 3 ];
     assert(find!(a=>a > 2)(r) == [3]);
@@ -2038,7 +2038,7 @@ if (isForwardRange!R1 && isForwardRange!R2
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.container : SList;
     import std.range.primitives : empty;
@@ -2053,14 +2053,14 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(a[1 .. $].find!"a.x == b"([2, 3]) == [C(2,0), C(3,1), C(4,0)]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.container : SList;
     alias C = Tuple!(int, "x", int, "y");
     assert([C(1,0), C(2,0), C(3,1), C(4,0)].find!"a.x == b"(SList!int(2, 3)[]) == [C(2,0), C(3,1), C(4,0)]);
 }
 
-@safe unittest // issue 12470
+version(StdUnittest) @safe unittest // issue 12470
 {
     import std.array : replace;
     inout(char)[] sanitize(inout(char)[] p)
@@ -2070,7 +2070,7 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(sanitize("O\x00o") == "O o");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
@@ -2082,7 +2082,7 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(equal(r, SList!int(2, 5, 7, 3)[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     import std.stdio;
@@ -2103,7 +2103,7 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(find(r1, r7).empty());
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     // @@@BUG@@@ removing static below makes unittest fail
@@ -2121,7 +2121,7 @@ if (isForwardRange!R1 && isForwardRange!R2
     assert(equal(find(r, [10, 11]), [10, 11, 4]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.container : SList;
 
@@ -2130,7 +2130,7 @@ if (isForwardRange!R1 && isForwardRange!R2
 }
 
 //Bug# 8334
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.range;
@@ -2214,7 +2214,7 @@ private R1 simpleMindedFind(alias pred, R1, R2)(R1 haystack, scope R2 needle)
     return haystack;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test simpleMindedFind for the case where both haystack and needle have
     // length.
@@ -2304,7 +2304,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : tuple;
     int[] a = [ 1, 4, 2, 3 ];
@@ -2315,7 +2315,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find(a, 5, [ 1.2, 3.5 ], 2.0) == tuple([ 2, 3 ], 3));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s1 = "Mary has a little lamb";
     assert(find(s1, "has a", "has an") == tuple("has a little lamb", 1));
@@ -2324,7 +2324,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find("abc", "bc").length == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.internal : rndstuff;
     import std.meta : AliasSeq;
@@ -2351,7 +2351,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find!(f)(s, "hello").length == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.internal : rndstuff;
@@ -2373,7 +2373,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -2410,7 +2410,7 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
     return needle.beFound(haystack);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string h = "/homes/aalexand/d/dmd/bin/../lib/libphobos.a(dmain2.o)"~
         "(.gnu.linkonce.tmain+0x74): In function `main' undefined reference"~
@@ -2424,7 +2424,7 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives : empty;
     int[] a = [ -1, 0, 1, 2, 3, 4, 5 ];
@@ -2434,7 +2434,7 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
     assert(find(b, boyerMooreFinder(a)).empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto bm = boyerMooreFinder("for");
     auto match = find("Moor", bm);
@@ -2495,7 +2495,7 @@ template canFind(alias pred="a == b")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(canFind([0, 1, 2, 3], 2) == true);
     assert(canFind([0, 1, 2, 3], [1, 2], [2, 3]));
@@ -2512,7 +2512,7 @@ template canFind(alias pred="a == b")
  * Example using a custom predicate.
  * Note that the needle appears as the second argument of the predicate.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto words = [
         "apple",
@@ -2523,7 +2523,7 @@ template canFind(alias pred="a == b")
     assert( canFind!((string a, string b) => a.startsWith(b))(words, "bees"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.internal : rndstuff;
 
@@ -2535,7 +2535,7 @@ template canFind(alias pred="a == b")
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     assert(equal!(canFind!"a < b")([[1, 2, 3], [7, 8, 9]], [2, 8]));
@@ -2576,7 +2576,7 @@ if (isForwardRange!(Range))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 11, 10, 10, 9, 8, 8, 7, 8, 9 ];
     auto r = findAdjacent(a);
@@ -2586,7 +2586,7 @@ if (isForwardRange!(Range))
 
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -2646,14 +2646,14 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ -1, 0, 1, 2, 3, 4, 5 ];
     int[] b = [ 3, 1, 2 ];
     assert(findAmong(a, b) == a[2 .. $]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ -1, 0, 2, 1, 2, 3, 4, 5 ];
     int[] b = [ 1, 2, 3 ];
@@ -2701,7 +2701,7 @@ if (isForwardRange!R1 && isForwardRange!R2
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives : empty;
     // Needle is found; s is replaced by the substring following the first
@@ -2732,7 +2732,7 @@ if (isForwardRange!R1 && ifTestable!(typeof(haystack.front), unaryFun!pred))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isWhite;
     string s = "    abc";
@@ -2743,7 +2743,7 @@ if (isForwardRange!R1 && ifTestable!(typeof(haystack.front), unaryFun!pred))
     assert(findSkip!isWhite(s) == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isWhite;
 
@@ -2988,7 +2988,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
 
 /// Returning a subtype of $(REF Tuple, std,typecons) enables
 /// the following convenient idiom:
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // findSplit returns a triplet
     if (auto split = "dlang-rocks".findSplit("-"))
@@ -2996,7 +2996,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.range.primitives : empty;
 
@@ -3024,13 +3024,13 @@ if (isForwardRange!R1 && isForwardRange!R2)
 }
 
 /// Use $(REF only, std,range) to find single elements:
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.range : only;
     assert([1, 2, 3, 4].findSplitBefore(only(3))[0] == [1, 2]);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.range.primitives : empty;
 
@@ -3065,7 +3065,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
     assert(r2[1] == a[4 .. $]);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -3102,7 +3102,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
     assert(equal(r2[1], a[4 .. $]));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     auto str = "sep,one,sep,two";
 
@@ -3116,7 +3116,7 @@ if (isForwardRange!R1 && isForwardRange!R2)
     assert(split[0] == "sep");
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     auto str = "sep,one,sep,two";
 
@@ -3258,7 +3258,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : text;
     import std.typecons : tuple;
@@ -3270,7 +3270,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(a.maxCount == tuple(4, 2));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.exception : assertThrown;
@@ -3288,7 +3288,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(minCount(new ReferenceForwardRange!int([1, 2, 1, 0, 2, 0])) == tuple(0, 2));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.meta : AliasSeq;
@@ -3403,7 +3403,7 @@ auto minElement(Range, RangeElementType = ElementType!Range)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : enumerate;
     import std.typecons : tuple;
@@ -3421,7 +3421,7 @@ auto minElement(Range, RangeElementType = ElementType!Range)
     assert(arr.minElement(1) == 1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : enumerate, iota;
     // supports mapping
@@ -3458,7 +3458,7 @@ auto minElement(Range, RangeElementType = ElementType!Range)
     assert(arr.minElement!(a => a)(42) == 42);
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable arr = [7, 3, 4, 2, 1, 8];
     assert(arr.minElement == 1);
@@ -3520,7 +3520,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : enumerate;
     import std.typecons : tuple;
@@ -3537,7 +3537,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(arr.minElement(1) == 1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : enumerate, iota;
 
@@ -3577,7 +3577,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable arr = [7, 3, 8, 2, 1, 4];
     assert(arr.maxElement == 8);
@@ -3658,7 +3658,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 2, 3, 4, 1, 2, 4, 1, 1, 2 ];
     // Minimum is 1 and first occurs in position 3
@@ -3667,7 +3667,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
     assert(a.maxPos == [ 4, 1, 2, 4, 1, 1, 2 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -3681,7 +3681,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
     assert( equal( minPos(new ReferenceForwardRange!int([1, 2, 1, 0, 2, 0])), [0, 2, 0] ) );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Rvalue range
     import std.algorithm.comparison : equal;
@@ -3693,7 +3693,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
                .equal([ 1, 2, 4, 1, 1, 2 ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //BUG 9299
     immutable a = [ 2, 3, 4, 1, 2, 4, 1, 1, 2 ];
@@ -3760,7 +3760,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] a = [2, 3, 4, 1, 2, 4, 1, 1, 2];
 
@@ -3779,7 +3779,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
     assert(dogs.minIndex!"a.age < b.age" == 1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // should work with const
     const(int)[] immArr = [2, 1, 3];
@@ -3816,7 +3816,7 @@ if (isForwardRange!Range && !isInfinite!Range &&
     }
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable arr = [7, 3, 8, 2, 1, 4];
     assert(arr.minIndex == 4);
@@ -3850,7 +3850,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // Maximum is 4 and first occurs in position 2
     int[] a = [2, 3, 4, 1, 2, 4, 1, 1, 2];
@@ -3866,7 +3866,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert(dogs.maxIndex!"a.age < b.age" == 1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // should work with const
     const(int)[] immArr = [5, 1, 3];
@@ -3905,7 +3905,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     }
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable arr = [7, 3, 8, 2, 1, 4];
     assert(arr.maxIndex == 2);
@@ -4000,7 +4000,7 @@ template skipOver(alias pred = "a == b")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4028,7 +4028,7 @@ template skipOver(alias pred = "a == b")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4049,7 +4049,7 @@ template skipOver(alias pred = "a == b")
 }
 
 /// Partial instantiation
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isWhite;
     import std.range.primitives : empty;
@@ -4283,7 +4283,7 @@ if (isInputRange!R &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isAlpha;
 
@@ -4314,7 +4314,7 @@ if (isInputRange!R &&
     assert(startsWith!"a.x == b"([ C(1,1), C(2,1), C(2,2) ], [1, 1], [1, 2], [1, 3]) == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.conv : to;
@@ -4427,7 +4427,7 @@ private void skipAll(alias pred = "a == b", R, Es...)(ref R r, Es es)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s1 = "Hello world";
     skipAll(s1, 'H', 'e');
@@ -4577,7 +4577,7 @@ if (isInputRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : No;
@@ -4586,7 +4586,7 @@ if (isInputRange!Range)
     assert(equal(a.until(7, No.openRight), [1, 2, 4, 7]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [ 1, 2, 4, 7, 7, 2, 4, 7, 3, 5];
@@ -4600,7 +4600,7 @@ if (isInputRange!Range)
     assert(equal(until!"a == 2"(a, No.openRight), [1, 2]));
 }
 
-@system unittest // bugzilla 13171
+version(StdUnittest) @system unittest // bugzilla 13171
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -4609,7 +4609,7 @@ if (isInputRange!Range)
     assert(a == [4]);
 }
 
-@safe unittest // Issue 10460
+version(StdUnittest) @safe unittest // Issue 10460
 {
     import std.algorithm.comparison : equal;
     auto a = [1, 2, 3, 4];
@@ -4618,7 +4618,7 @@ if (isInputRange!Range)
     assert(equal(a, [0, 0, 3, 4]));
 }
 
-@safe unittest // Issue 13124
+version(StdUnittest) @safe unittest // Issue 13124
 {
     import std.algorithm.comparison : among, equal;
     auto s = "hello how\nare you";

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -131,7 +131,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.range;
@@ -148,7 +148,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.typecons : tuple;
@@ -164,7 +164,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test cartesian product of two infinite ranges
     import std.algorithm.searching : canFind;
@@ -187,7 +187,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
     assert(canFind(EvenOdd, tuple(42, 1)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test cartesian product of an infinite input range and a finite forward
     // range.
@@ -227,7 +227,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
     assert(!canFind(MN.take(100), tuple(100, 200)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.typecons : tuple;
@@ -254,7 +254,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
     // And therefore, by set comprehension, XY == Expected
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -349,7 +349,7 @@ if (!allSatisfy!(isForwardRange, R1, R2) ||
 }
 
 // Issue 13091
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     int[1] a = [1];
     foreach (t; cartesianProduct(a[], a[])) {}
@@ -422,7 +422,7 @@ if (ranges.length >= 2 &&
     return Result(ranges);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 10693: cartesian product of empty ranges should be empty.
     int[] a, b, c, d, e;
@@ -438,7 +438,7 @@ if (ranges.length >= 2 &&
     foreach (_; cprod2) {} // should not crash
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // .init value of cartesianProduct should be empty
     auto cprod = cartesianProduct([0,0], [1,1], [2,2]);
@@ -446,7 +446,7 @@ if (ranges.length >= 2 &&
     assert(cprod.init.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 13393
     assert(!cartesianProduct([0],[0],[0]).save.empty);
@@ -473,7 +473,7 @@ if (!allSatisfy!(isForwardRange, R1, R2, RR) ||
     );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.range;
@@ -490,7 +490,7 @@ if (!allSatisfy!(isForwardRange, R1, R2, RR) ||
     assert(canFind(N3, tuple(9, 3, 0)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.range;
@@ -509,7 +509,7 @@ if (!allSatisfy!(isForwardRange, R1, R2, RR) ||
 
 // Issue 9878
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -532,7 +532,7 @@ if (!allSatisfy!(isForwardRange, R1, R2, RR) ||
     ]));
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.range.primitives : isForwardRange;
     int[2] A = [1,2];
@@ -547,7 +547,7 @@ pure @safe nothrow @nogc unittest
 }
 
 // Issue 13935
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     auto seq = [1, 2].map!(x => x);
@@ -603,7 +603,7 @@ void largestPartialIntersection
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -686,7 +686,7 @@ void largestPartialIntersectionWeighted
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -723,7 +723,7 @@ void largestPartialIntersectionWeighted
     // 1.0 occurs 5 times -> 1.2 * 5 = 6
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.typecons : tuple, Tuple, Yes;
@@ -742,7 +742,7 @@ void largestPartialIntersectionWeighted
     assert(a[0].empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.typecons : tuple, Tuple, Yes;
@@ -760,7 +760,7 @@ void largestPartialIntersectionWeighted
     assert(b == [ tuple("7", 4u), tuple("1", 3u) ][], text(b));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -781,7 +781,7 @@ void largestPartialIntersectionWeighted
     assert(b[0] == tuple(4.0, 2u));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.container : Array;
     import std.typecons : Tuple;
@@ -896,7 +896,7 @@ MultiwayMerge!(less, RangeOfRanges) multiwayMerge
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -954,7 +954,7 @@ auto multiwayUnion(alias less = "a < b", RangeOfRanges)(RangeOfRanges ror)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1086,7 +1086,7 @@ SetDifference!(less, R1, R2) setDifference(alias less = "a < b", R1, R2)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : isForwardRange;
@@ -1105,7 +1105,7 @@ SetDifference!(less, R1, R2) setDifference(alias less = "a < b", R1, R2)
     assert(setDifference(r, x).empty);
 }
 
-@safe unittest // Issue 10460
+version(StdUnittest) @safe unittest // Issue 10460
 {
     import std.algorithm.comparison : equal;
 
@@ -1234,7 +1234,7 @@ if (Rs.length >= 2 && allSatisfy!(isInputRange, Rs) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1253,7 +1253,7 @@ if (Rs.length >= 2 && allSatisfy!(isInputRange, Rs) &&
     assert(equal(setIntersection(d, e), [1, 1, 7]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -1402,7 +1402,7 @@ setSymmetricDifference(alias less = "a < b", R1, R2)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : isForwardRange;
@@ -1420,7 +1420,7 @@ setSymmetricDifference(alias less = "a < b", R1, R2)
     assert(equal(setSymmetricDifference(c, d), [1, 1, 2, 5, 6, 7, 9]));
 }
 
-@safe unittest // Issue 10460
+version(StdUnittest) @safe unittest // Issue 10460
 {
     import std.algorithm.comparison : equal;
 
@@ -1468,7 +1468,7 @@ auto setUnion(alias less = "a < b", Rs...)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
     ///
 {
     import std.algorithm.comparison : equal;
@@ -1478,7 +1478,7 @@ auto setUnion(alias less = "a < b", Rs...)
     assert(a.setUnion(b).equal([1, 2, 3, 4, 5]));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1491,7 +1491,7 @@ auto setUnion(alias less = "a < b", Rs...)
                     [0, 1, 2, 4, 5, 7, 8, 9, 10.5][]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // save
     import std.range : dropOne;
@@ -1503,7 +1503,7 @@ auto setUnion(alias less = "a < b", Rs...)
     assert(arr.front == 0);
 }
 
-@nogc @safe pure nothrow unittest
+version(StdUnittest) @nogc @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1513,7 +1513,7 @@ auto setUnion(alias less = "a < b", Rs...)
     assert(a.setUnion(b).equal(r));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -130,7 +130,7 @@ if (hasLength!(RandomAccessRange2) && hasSlicing!(RandomAccessRange2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : assumeSorted;
     int[] a = [ 1, 2, 3 ];
@@ -200,7 +200,7 @@ if (isForwardRange!(Range))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert([1, 1, 2].isSorted);
     // strictly monotonic doesn't allow duplicates
@@ -218,7 +218,7 @@ if (isForwardRange!(Range))
     assert(isStrictlyMonotonic(arr));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -244,7 +244,7 @@ if (isForwardRange!(Range))
     assert(isSorted(s));   // bidirectional
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable a = [1, 2, 3];
     assert(a.isSorted);
@@ -258,7 +258,7 @@ if (isForwardRange!Range)
     return findAdjacent!((a,b) => !binaryFun!less(a,b))(r).empty;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -284,7 +284,7 @@ if (isForwardRange!Range)
     assert(isStrictlyMonotonic(s2));   // bidirectional
 }
 
-@nogc @safe nothrow pure unittest
+version(StdUnittest) @nogc @safe nothrow pure unittest
 {
     static immutable a = [1, 2, 3];
     assert(a.isStrictlyMonotonic);
@@ -348,7 +348,7 @@ if (is(typeof(ordered!less(values))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(ordered(42, 42, 43));
     assert(!strictlyOrdered(43, 42, 45));
@@ -512,7 +512,7 @@ if (ss != SwapStrategy.stable && isInputRange!Range && hasSwappableElements!Rang
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.mutation : SwapStrategy;
     import std.algorithm.searching : count, find;
@@ -552,7 +552,7 @@ if (ss != SwapStrategy.stable && isInputRange!Range && hasSwappableElements!Rang
     assert(arr == [4, 5, 6, 7, 8, 9, 10, 2, 3, 1] && r == arr[7 .. $]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.internal : rndstuff;
     static bool even(int a) { return (a & 1) == 0; }
@@ -692,7 +692,7 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range)
 }
 
 ///
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     int[] a = [5, 3, 2, 6, 4, 1, 3, 7];
     size_t pivot = pivotPartition(a, a.length / 2);
@@ -701,7 +701,7 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range)
     assert(a[pivot .. $].all!(x => x >= a[pivot]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test(alias less)()
     {
@@ -787,7 +787,7 @@ if (isForwardRange!(Range))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] r = [ 1, 3, 5, 7, 8, 2, 4, ];
     assert(isPartitioned!"a & 1"(r));
@@ -871,7 +871,7 @@ if (ss == SwapStrategy.unstable && isRandomAccessRange!Range
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 8, 3, 4, 1, 4, 7, 4 ];
     auto pieces = partition3(a, 4);
@@ -880,7 +880,7 @@ if (ss == SwapStrategy.unstable && isRandomAccessRange!Range
     assert(pieces[2] == [ 8, 7 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : Random, uniform, unpredictableSeed;
 
@@ -1006,7 +1006,7 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     immutable(int[]) arr = [ 2, 3, 1, 5, 0 ];
     // index using pointers
@@ -1021,7 +1021,7 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
         (index2));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     immutable(int)[] arr = [ 2, 3, 1, 5, 0 ];
     // index using pointers
@@ -1052,7 +1052,7 @@ if (isRandomAccessRange!Range && !isInfinite!Range &&
             (index3));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1314,7 +1314,7 @@ if (Rs.length >= 2 &&
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : retro;
@@ -1326,7 +1326,7 @@ if (Rs.length >= 2 &&
     assert(a.merge(b).retro.equal([5, 4, 3, 3, 2, 1]));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1343,7 +1343,7 @@ if (Rs.length >= 2 &&
     assert(equal(u, [-1, 1, 1, 2, 2, 4, 4, 5, 7, 7, 8, 9][]));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // save
     import std.range : dropOne;
@@ -1355,7 +1355,7 @@ if (Rs.length >= 2 &&
     assert(arr.front == 0);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -1371,7 +1371,7 @@ if (Rs.length >= 2 &&
     }
 }
 
-@nogc @safe pure nothrow unittest
+version(StdUnittest) @nogc @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1382,7 +1382,7 @@ if (Rs.length >= 2 &&
 }
 
 /// test bi-directional access and common type
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : retro;
@@ -1479,7 +1479,7 @@ template multiSort(less...) //if (less.length > 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.mutation : SwapStrategy;
     static struct Point { int x, y; }
@@ -1530,7 +1530,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -1549,7 +1549,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     assert(pts4.multiSort!("a > b").release.equal(iota(10).retro));
 }
 
-@safe unittest //issue 9160 (L-value only comparators)
+version(StdUnittest) @safe unittest //issue 9160 (L-value only comparators)
 {
     static struct A
     {
@@ -1573,7 +1573,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     assert(points[1] == A(4, 1));
 }
 
-@safe unittest // issue 16179 (cannot access frame of function)
+version(StdUnittest) @safe unittest // issue 16179 (cannot access frame of function)
 {
     auto arr = [[1, 2], [2, 0], [1, 0], [1, 1]];
     int c = 3;
@@ -1585,7 +1585,7 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
     assert(arr == [[1, 0], [1, 1], [1, 2], [2, 0]]);
 }
 
-@safe unittest //Issue 16413 - @system comparison function
+version(StdUnittest) @safe unittest //Issue 16413 - @system comparison function
 {
     bool lt(int a, int b) { return a < b; } static @system
     auto a = [2, 1];
@@ -1707,7 +1707,7 @@ private void shortSort(alias less, Range)(Range r)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : Random, uniform;
 
@@ -1776,7 +1776,7 @@ private void sort5(alias lt, Range)(Range r)
     // 7 comparisons, 0-9 swaps
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : permutations;
     import std.algorithm.mutation : copy;
@@ -1875,7 +1875,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] array = [ 1, 2, 3, 4 ];
 
@@ -1893,7 +1893,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Showcase stable sorting
     import std.algorithm.mutation : SwapStrategy;
@@ -1903,7 +1903,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Sorting floating-point numbers in presence of NaN
     double[] numbers = [-0.0, 3.0, -2.0, double.nan, 0.0, -double.nan];
@@ -1917,7 +1917,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
     assert(numbers.equal!isIdentical(sorted));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Simple regression benchmark
     import std.algorithm.iteration, std.algorithm.mutation, std.random;
@@ -1944,7 +1944,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
         " Please update watermark from ", watermark, " to ", comps));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.internal : rndstuff;
     import std.algorithm.mutation : swapRanges;
@@ -2743,7 +2743,7 @@ private template TimSortImpl(alias pred, R)
     alias gallopReverseUpper = gallopSearch!( true,  true);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : Random, uniform, randomShuffle;
 
@@ -2819,7 +2819,7 @@ private template TimSortImpl(alias pred, R)
     assert(result == true);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {//bugzilla 4584
     assert(isSorted!"a < b"(sort!("a < b", SwapStrategy.stable)(
        [83, 42, 85, 86, 87, 22, 89, 30, 91, 46, 93, 94, 95, 6,
@@ -2828,7 +2828,7 @@ private template TimSortImpl(alias pred, R)
 
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //test stable sort + zip
     import std.range;
@@ -2840,7 +2840,7 @@ private template TimSortImpl(alias pred, R)
     assert(y == "aebcd"d);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 14223
     import std.array, std.range;
@@ -2951,7 +2951,7 @@ if (isRandomAccessRange!R && hasLength!R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.numeric : entropy;
@@ -2972,7 +2972,7 @@ if (isRandomAccessRange!R && hasLength!R)
     assert(isSorted!("a > b")(map!(entropy)(arr)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.numeric : entropy;
@@ -2993,7 +2993,7 @@ if (isRandomAccessRange!R && hasLength!R)
     assert(isSorted!("a < b")(map!(entropy)(arr)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 4909
     import std.typecons : Tuple;
@@ -3001,7 +3001,7 @@ if (isRandomAccessRange!R && hasLength!R)
     schwartzSort!"a[0]"(chars);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 5924
     import std.typecons : Tuple;
@@ -3032,7 +3032,7 @@ if (isRandomAccessRange!(Range) && hasLength!(Range) && hasSlicing!(Range))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 ];
     partialSort(a, 5);
@@ -3059,7 +3059,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
     sort!(less, ss)(r1);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [5, 7, 2, 6, 7];
     int[] b = [2, 1, 5, 6, 7, 3, 0];
@@ -3123,7 +3123,7 @@ if (isRandomAccessRange!(Range) && hasLength!Range && hasSlicing!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] v = [ 25, 7, 9, 2, 0, 5, 21 ];
     topN!"a < b"(v, 100);
@@ -3429,7 +3429,7 @@ done:
     return pivot;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 10, 5, 3, 4, 8,  11,  13, 3, 9, 4, 10 ];
     assert(expandPartition!((a, b) => a < b)(a, 4, 5, 6) == 9);
@@ -3450,7 +3450,7 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     return iota(0, size).map!(_ => uniform(minValue, maxValue)).array;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.algorithm.iteration : reduce;
@@ -3497,7 +3497,7 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     foreach (e; idx[mid .. $]) assert((*e)[1] >= (*idx[mid])[1]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : max, min;
     import std.algorithm.iteration : reduce;
@@ -3527,7 +3527,7 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
 }
 
 // bug 12987
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 25, 7, 9, 2, 0, 5, 21 ];
     auto n = 4;
@@ -3567,7 +3567,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3577,7 +3577,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 // bug 15421
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -3621,7 +3621,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 // bug 15421
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = [ 9, 8, 0, 3, 5, 25, 43, 4, 2, 0, 7 ];
     auto b = [ 9, 8, 0, 3, 5, 25, 43, 4, 2, 0, 7 ];
@@ -3640,7 +3640,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 // bug 12987
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3650,7 +3650,7 @@ if (isRandomAccessRange!(Range1) && hasLength!Range1 &&
 }
 
 // bug 15420
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [ 5, 7, 2, 6, 7 ];
     int[] b = [ 2, 1, 5, 6, 7, 3, 0 ];
@@ -3694,7 +3694,7 @@ if (isInputRange!(SRange) && isRandomAccessRange!(TRange)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Yes;
 
@@ -3704,7 +3704,7 @@ if (isInputRange!(SRange) && isRandomAccessRange!(TRange)
     assert(b == [ 0, 1, 2 ]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.random : Random, unpredictableSeed, uniform, randomShuffle;
     import std.typecons : Yes;
@@ -3803,7 +3803,7 @@ if (isRandomAccessRange!Range &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Yes;
 
@@ -3819,7 +3819,7 @@ if (isRandomAccessRange!Range &&
     assert(ptrIndex == [ &a[5], &a[1], &a[3] ]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
 
@@ -3985,7 +3985,7 @@ if (isRandomAccessRange!Range && hasLength!Range &&
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Verify medianOf for all permutations of [1, 2, 2, 3, 4].
     int[5] data = [1, 2, 2, 3, 4];
@@ -4094,7 +4094,7 @@ if (isBidirectionalRange!BidirectionalRange &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Step through all permutations of a sorted array in lexicographic order
     int[] a = [1,2,3];
@@ -4113,7 +4113,7 @@ if (isBidirectionalRange!BidirectionalRange &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Step through permutations of an array containing duplicate elements:
     int[] a = [1,1,2];
@@ -4125,7 +4125,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(a == [1,1,2]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Boundary cases: arrays of 0 or 1 element.
     int[] a1 = [];
@@ -4137,7 +4137,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(a2 == [1]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -4216,7 +4216,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(equal(a1, [1, 2, 3, 4]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test with non-default sorting order
     int[] a = [3,2,1];
@@ -4235,7 +4235,7 @@ if (isBidirectionalRange!BidirectionalRange &&
 }
 
 // Issue 13594
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[3] a = [1,2,3];
     assert(nextPermutation(a[]));
@@ -4364,7 +4364,7 @@ if (isBidirectionalRange!BidirectionalRange &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Step through even permutations of a sorted array in lexicographic order
     int[] a = [1,2,3];
@@ -4376,7 +4376,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(a == [1,2,3]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a3 = [ 1, 2, 3, 4 ];
     int count = 1;
@@ -4384,7 +4384,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(count == 12);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test with non-default sorting order
     auto a = [ 3, 2, 1 ];
@@ -4397,7 +4397,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(a == [ 3, 2, 1 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test various cases of rollover
     auto a = [ 3, 1, 2 ];
@@ -4409,7 +4409,7 @@ if (isBidirectionalRange!BidirectionalRange &&
     assert(b == [ 1, 3, 2 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 13594
     int[3] a = [1,2,3];
@@ -4421,7 +4421,7 @@ if (isBidirectionalRange!BidirectionalRange &&
 Even permutations are useful for generating coordinates of certain geometric
 shapes. Here's a non-trivial example:
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : sqrt;
 

--- a/std/array.d
+++ b/std/array.d
@@ -146,13 +146,13 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = array([1, 2, 3, 4, 5][]);
     assert(a == [ 1, 2, 3, 4, 5 ]);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     struct Foo
@@ -163,7 +163,7 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
     assert(equal(a, [Foo(1), Foo(2), Foo(3), Foo(4), Foo(5)]));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     struct MyRange
     {
@@ -176,14 +176,14 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
     assert(arr.empty);
 }
 
-@system pure nothrow unittest
+version(StdUnittest) @system pure nothrow unittest
 {
     immutable int[] a = [1, 2, 3, 4];
     auto b = (&a).array;
     assert(b == a);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     struct Foo
@@ -202,7 +202,7 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
     assert(equal(a, [Foo(1), Foo(2), Foo(3), Foo(4), Foo(5)]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 12315
     static struct Bug12315 { immutable int i; }
@@ -210,7 +210,7 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
     static assert(bug12315[0].i == 123456789);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     static struct S{int* p;}
@@ -240,7 +240,7 @@ if (isNarrowString!String)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives : isRandomAccessRange;
 
@@ -251,7 +251,7 @@ if (isNarrowString!String)
     static assert(isRandomAccessRange!dstring == true);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -312,7 +312,7 @@ if (isNarrowString!String)
 }
 
 //Bug# 8233
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(array("hello world"d) == "hello world"d);
     immutable a = [1, 2, 3, 4, 5];
@@ -339,7 +339,7 @@ if (isNarrowString!String)
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //9824
     static struct S
@@ -352,7 +352,7 @@ if (isNarrowString!String)
 }
 
 // Bugzilla 10220
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.exception;
@@ -372,7 +372,7 @@ if (isNarrowString!String)
     });
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Turn down infinity:
     static assert(!is(typeof(
@@ -414,7 +414,7 @@ if (isInputRange!Range)
 }
 
 ///
-@safe pure /*nothrow*/ unittest
+version(StdUnittest) @safe pure /*nothrow*/ unittest
 {
     import std.range;
     import std.typecons;
@@ -428,7 +428,7 @@ if (isInputRange!Range)
 }
 
 // @@@11053@@@ - Cannot be version(unittest) - recursive instantiation error
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons;
     static assert(!__traits(compiles, [ tuple("foo", "bar", "baz") ].assocArray()));
@@ -437,7 +437,7 @@ if (isInputRange!Range)
 }
 
 // Issue 13909
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons;
     auto a = [tuple!(const string, string)("foo", "bar")];
@@ -467,7 +467,7 @@ auto byPair(AA : Value[Key], Value, Key)(AA aa)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : sort;
     import std.typecons : tuple, Tuple;
@@ -494,7 +494,7 @@ auto byPair(AA : Value[Key], Value, Key)(AA aa)
     ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : tuple, Tuple;
     import std.meta : AliasSeq;
@@ -519,7 +519,7 @@ auto byPair(AA : Value[Key], Value, Key)(AA aa)
 }
 
 // Issue 17711
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     const(int[string]) aa = [ "abc": 123 ];
 
@@ -619,7 +619,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I) && !hasIndirections!(ElementE
     return arrayAllocImpl!(false, T, ST)(sizes);
 }
 ///
-@system nothrow pure unittest
+version(StdUnittest) @system nothrow pure unittest
 {
     double[] arr = uninitializedArray!(double[])(100);
     assert(arr.length == 100);
@@ -657,7 +657,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : repeat;
@@ -668,7 +668,7 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
     assert(!arr.equal(0.repeat(42)));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     cast(void) minimallyInitializedArray!(int[][][][][])();
     double[] arr = minimallyInitializedArray!(double[])(100);
@@ -745,7 +745,7 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
     return ret;
 }
 
-@safe nothrow pure unittest
+version(StdUnittest) @safe nothrow pure unittest
 {
     auto s1 = uninitializedArray!(int[])();
     auto s2 = minimallyInitializedArray!(int[])();
@@ -753,7 +753,7 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
     assert(s2.length == 0);
 }
 
-@safe nothrow pure unittest //@@@9803@@@
+version(StdUnittest) @safe nothrow pure unittest //@@@9803@@@
 {
     auto a = minimallyInitializedArray!(int*[])(1);
     assert(a[0] == null);
@@ -763,7 +763,7 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
     assert(c[0][0] == null);
 }
 
-@safe unittest //@@@10637@@@
+version(StdUnittest) @safe unittest //@@@10637@@@
 {
     static struct S
     {
@@ -789,7 +789,7 @@ private auto arrayAllocImpl(bool minimallyInitialized, T, I...)(I sizes) nothrow
     assert(b[0].p == null);
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     static struct S1
     {
@@ -848,7 +848,7 @@ if (is(typeof(a.ptr < b.ptr) == bool))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] a = [ 10, 11, 12, 13, 14 ];
     int[] b = a[1 .. 3];
@@ -868,7 +868,7 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     static assert(test == "three"d);
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     static void test(L, R)(L l, R r)
     {
@@ -893,7 +893,7 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     assert(overlap(c, d.idup).empty);
 }
 
-@safe pure nothrow unittest // bugzilla 9836
+version(StdUnittest) @safe pure nothrow unittest // bugzilla 9836
 {
     // range primitives for array should work with alias this types
     struct Wrapper
@@ -1094,7 +1094,7 @@ if (isSomeString!(T[]) && allSatisfy!(isCharOrStringOrDcharRange, U))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     int[] a = [ 1, 2, 3, 4 ];
     a.insertInPlace(2, [ 1, 2 ]);
@@ -1132,7 +1132,7 @@ private template isInputRangeOrConvertible(E)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to insertInPlace
     import core.exception;
@@ -1227,7 +1227,7 @@ private template isInputRangeOrConvertible(E)
                     "flip_xyz\U00010143_abc__flop"));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     // insertInPlace interop with postblit
@@ -1260,7 +1260,7 @@ private template isInputRangeOrConvertible(E)
     assert(equal(arr, [1, 2, 3, 4, 5]));  //check it works with postblit
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -1272,7 +1272,7 @@ private template isInputRangeOrConvertible(E)
     });
 }
 
-@system unittest // bugzilla 6874
+version(StdUnittest) @system unittest // bugzilla 6874
 {
     import core.memory;
     // allocate some space
@@ -1303,7 +1303,7 @@ pure nothrow bool sameHead(T)(in T[] lhs, in T[] rhs)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [1, 2, 3, 4, 5];
     auto b = a[0 .. 2];
@@ -1324,7 +1324,7 @@ pure nothrow bool sameTail(T)(in T[] lhs, in T[] rhs)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [1, 2, 3, 4, 5];
     auto b = a[3..$];
@@ -1332,7 +1332,7 @@ pure nothrow bool sameTail(T)(in T[] lhs, in T[] rhs)
     assert(a.sameTail(b));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static foreach (T; AliasSeq!(int[], const(int)[], immutable(int)[], const int[], immutable int[]))
     {{
@@ -1407,7 +1407,7 @@ if (isInputRange!S && !isDynamicArray!S)
 
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = "abc";
     auto s = replicate(a, 3);
@@ -1424,7 +1424,7 @@ if (isInputRange!S && !isDynamicArray!S)
     assert(d == []);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -1494,7 +1494,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string str = "Hello World!";
     assert(str.split == ["Hello", "World!"]);
@@ -1507,7 +1507,7 @@ if (isSomeString!S)
  * `split` allocates memory, so the same effect can be achieved lazily
  * using $(REF splitter, std,algorithm,iteration).
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isWhite;
     import std.algorithm.comparison : equal;
@@ -1517,7 +1517,7 @@ if (isSomeString!S)
     assert(str.splitter!(isWhite).equal(["Hello", "World!"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.format;
@@ -1549,7 +1549,7 @@ if (isSomeString!S)
     assert(split(s) == ["peter", "paul", "jerry"]);
 }
 
-@safe unittest //purity, ctfe ...
+version(StdUnittest) @safe unittest //purity, ctfe ...
 {
     import std.exception;
     void dg() @safe pure {
@@ -1562,7 +1562,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(split("hello world") == ["hello","world"]);
     assert(split("192.168.0.1", ".") == ["192", "168", "0", "1"]);
@@ -1621,7 +1621,7 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.uni : isWhite;
     assert("Learning,D,is,fun".split(",") == ["Learning", "D", "is", "fun"]);
@@ -1629,7 +1629,7 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
     assert("Learning D is fun".split(" D ") == ["Learning", "is fun"]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv;
@@ -1777,7 +1777,7 @@ if (isInputRange!RoR &&
     }
 }
 
-@safe unittest // Issue 14230
+version(StdUnittest) @safe unittest // Issue 14230
 {
    string[] ary = ["","aa","bb","cc"]; // leaded by _empty_ element
    assert(ary.join(" @") == " @aa @bb @cc"); // OK in 2.067b1 and olders
@@ -1849,7 +1849,7 @@ if (isInputRange!RoR &&
     }
 }
 
-@safe unittest // Issue 10895
+version(StdUnittest) @safe unittest // Issue 10895
 {
     class A
     {
@@ -1864,7 +1864,7 @@ if (isInputRange!RoR &&
     assert(temp.length == 3);
 }
 
-@safe unittest // Issue 14230
+version(StdUnittest) @safe unittest // Issue 14230
 {
    string[] ary = ["","aa","bb","cc"];
    assert(ary.join('@') == "@aa@bb@cc");
@@ -1907,7 +1907,7 @@ if (isInputRange!RoR &&
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     assert(join(["hello", "silly", "world"], " ") == "hello silly world");
     assert(join(["hello", "silly", "world"]) == "hellosillyworld");
@@ -1920,7 +1920,7 @@ if (isInputRange!RoR &&
     assert(arr.join() == "applebanana");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1959,7 +1959,7 @@ if (isInputRange!RoR &&
     assert(arr.join(',') == "apple,banana");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.conv : to;
@@ -2065,7 +2065,7 @@ if (isInputRange!RoR &&
 }
 
 // Issue 10683
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : join;
     import std.typecons : tuple;
@@ -2074,7 +2074,7 @@ if (isInputRange!RoR &&
 }
 
 // Issue 13877
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test that the range is iterated only once.
     import std.algorithm.iteration : map;
@@ -2140,13 +2140,13 @@ if (isDynamicArray!(E[]) && isForwardRange!R1 && isForwardRange!R2
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert("Hello Wörld".replace("o Wö", "o Wo") == "Hello World");
     assert("Hello Wörld".replace("l", "h") == "Hehho Wörhd");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert([1, 2, 3, 4, 2].replace([2], [5]) == [1, 5, 3, 4, 5]);
     assert([3, 3, 3].replace([3], [0]) == [0, 0, 0]);
@@ -2154,7 +2154,7 @@ if (isDynamicArray!(E[]) && isForwardRange!R1 && isForwardRange!R2
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18215
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto arr = ["aaa.dd", "b"];
     arr = arr.replace("aaa.dd", ".");
@@ -2166,7 +2166,7 @@ if (isDynamicArray!(E[]) && isForwardRange!R1 && isForwardRange!R2
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18215
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert([[0], [1, 2], [0], [3]].replace([0], [4]) == [[4], [1, 2], [4], [3]]);
     assert([[0], [1, 2], [0], [3], [1, 2]]
@@ -2208,7 +2208,7 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto arr = [1, 2, 3, 4, 5];
     auto from = [2, 3];
@@ -2220,7 +2220,7 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
     assert(sink.data == [1, 4, 6, 4, 5]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv : to;
@@ -2251,7 +2251,7 @@ if (isOutputRange!(Sink, E) && isDynamicArray!(E[])
     assert(replace(s, "foo", "silly") == "This is a silly silly list");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : skipOver;
     import std.conv : to;
@@ -2319,7 +2319,7 @@ if (isInputRange!Range &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 1, 2, 3, 4 ];
     auto b = a.replace(1, 3, [ 9, 9, 9 ]);
@@ -2327,7 +2327,7 @@ if (isInputRange!Range &&
     assert(b == [ 1, 9, 9, 9, 4 ]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
     import std.algorithm.iteration : filter;
@@ -2452,7 +2452,7 @@ if (is(typeof(replace(array, from, to, stuff))))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [1, 4, 5];
     replaceInPlace(a, 1u, 2u, [2, 3, 4]);
@@ -2463,7 +2463,7 @@ if (is(typeof(replace(array, from, to, stuff))))
     assert(a == [1, 4, 5, 5]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bug# 12889
     int[1][] arr = [[0], [1], [2], [3], [4], [5], [6]];
@@ -2472,7 +2472,7 @@ if (is(typeof(replace(array, from, to, stuff))))
     assert(arr == [[0], [1], [2], [3], [0], [1], [6]]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bug# 14925
     char[] a = "mon texte 1".dup;
@@ -2522,7 +2522,7 @@ if (is(typeof(replace(array, from, to, stuff))))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // the constraint for the first overload used to match this, which wouldn't compile.
     import std.algorithm.comparison : equal;
@@ -2532,7 +2532,7 @@ if (is(typeof(replace(array, from, to, stuff))))
     assert(equal(a, [1L, 4, 5, 6, 3]));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
     import std.algorithm.comparison : equal;
@@ -2653,7 +2653,7 @@ if (isDynamicArray!(E[]) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [1, 2, 2, 3, 4, 5];
     auto b = a.replaceFirst([2], [1337]);
@@ -2664,7 +2664,7 @@ if (isDynamicArray!(E[]) &&
     assert(r == "This is a silly foo list");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv : to;
@@ -2701,7 +2701,7 @@ if (isDynamicArray!(E[]) &&
 }
 
 //Bug# 8187
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto res = ["a", "a"];
     assert(replace(res, "a", "b") == ["b", "b"]);
@@ -2766,7 +2766,7 @@ if (isDynamicArray!(E[]) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [1, 2, 2, 3, 4, 5];
     auto b = a.replaceLast([2], [1337]);
@@ -2777,7 +2777,7 @@ if (isDynamicArray!(E[]) &&
     assert(r == "This is a foo silly list", r);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv : to;
@@ -2851,7 +2851,7 @@ do
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [1, 2, 3, 4, 5];
     auto b = replaceSlice(a, a[1 .. 4], [0, 0, 0]);
@@ -2859,7 +2859,7 @@ do
     assert(b == [1, 0, 0, 0, 5]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
 
@@ -3205,7 +3205,7 @@ if (isDynamicArray!A)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto app = appender!string();
     string b = "abcdefg";
@@ -3220,7 +3220,7 @@ if (isDynamicArray!A)
     assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
     auto app = appender!(int[])();
@@ -3230,7 +3230,7 @@ if (isDynamicArray!A)
     assert("%s".format(app) == "Appender!(int[])(%s)".format([1,2,3]));
 }
 
-@safe unittest // issue 17251
+version(StdUnittest) @safe unittest // issue 17251
 {
     static struct R
     {
@@ -3345,7 +3345,7 @@ if (isDynamicArray!A)
 
 ///
 @system pure nothrow
-unittest
+version(StdUnittest) unittest
 {
     int[] a = [1, 2];
     auto app2 = appender(&a);
@@ -3378,7 +3378,7 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     return Appender!(E[])(array);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.exception;
     {
@@ -3484,7 +3484,7 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
 
 ///
 @safe pure nothrow
-unittest
+version(StdUnittest) unittest
 {
     auto w = appender!string;
     // pre-allocate space for at least 10 elements (this avoids costly reallocations)
@@ -3501,7 +3501,7 @@ unittest
     assert(w.data == "abcdef");
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     {
         auto w = appender!string();
@@ -3550,7 +3550,7 @@ unittest
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.typecons;
@@ -3559,7 +3559,7 @@ unittest
     [tuple("A")].filter!(t => true).array; // error
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     //Coverage for put(Range)
@@ -3579,7 +3579,7 @@ unittest
     au1.put(sc1.repeat().take(10));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range;
     struct S2
@@ -3591,7 +3591,7 @@ unittest
     au2.put(sc2.repeat().take(10));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -3624,7 +3624,7 @@ unittest
     a2.put([s2]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //9528
     const(E)[] fastCopy(E)(E[] src) {
@@ -3642,7 +3642,7 @@ unittest
     assert(t.length == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     //10753
@@ -3656,7 +3656,7 @@ unittest
     [1, 2].map!Bar.array;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3705,7 +3705,7 @@ unittest
     assert(app8.data == null);
 }
 
-@safe unittest //Test large allocations (for GC.extend)
+version(StdUnittest) @safe unittest //Test large allocations (for GC.extend)
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -3716,7 +3716,7 @@ unittest
     assert(equal(app.data, 'a'.repeat(100_000)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto reference = new ubyte[](2048 + 1); //a number big enough to have a full page (EG: the GC extends)
     auto arr = reference.dup;
@@ -3726,7 +3726,7 @@ unittest
     assert(reference[] == arr[]);
 }
 
-@safe unittest // clear method is supported only for mutable element types
+version(StdUnittest) @safe unittest // clear method is supported only for mutable element types
 {
     Appender!string app;
     app.put("foo");
@@ -3734,7 +3734,7 @@ unittest
     assert(app.data == "foo");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct D//dynamic
     {
@@ -3763,7 +3763,7 @@ unittest
     static assert(!is(typeof(appender(foo()))));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Issue 13077
     static class A {}
@@ -3794,7 +3794,7 @@ RefAppender!(E[]) appender(P : E[]*, E)(P arrayPtr)
 
 ///
 @system pure nothrow
-unittest
+version(StdUnittest) unittest
 {
     int[] a = [1, 2];
     auto app2 = appender(&a);
@@ -3809,7 +3809,7 @@ unittest
     assert(app2.capacity >= 5);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception;
     {
@@ -3864,13 +3864,13 @@ unittest
     assert(app3.data == [1, 2, 3]);
 }
 
-@safe unittest // issue 14605
+version(StdUnittest) @safe unittest // issue 14605
 {
     static assert(isOutputRange!(Appender!(int[]), int));
     static assert(isOutputRange!(RefAppender!(int[]), int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Appender!(int[]) app;
     short[] range = [1, 2, 3];
@@ -3878,7 +3878,7 @@ unittest
     assert(app.data == [1, 2, 3]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string s = "hello".idup;
     char[] a = "hello".dup;

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -88,7 +88,7 @@ enum LetterCase : bool
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -97,7 +97,7 @@ enum LetterCase : bool
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.digest.hmac : hmac;
     import std.digest.digest : toHexString;
@@ -129,7 +129,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isAlphaNum('A'));
     assert( isAlphaNum('1'));
@@ -139,7 +139,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
     assert(!isAlphaNum('á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; chain(digits, octalDigits, fullHexDigits, letters, lowercase, uppercase))
         assert(isAlphaNum(c));
@@ -160,7 +160,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isAlpha('A'));
     assert(!isAlpha('1'));
@@ -170,7 +170,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
     assert(!isAlpha('á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; chain(letters, lowercase, uppercase))
         assert(isAlpha(c));
@@ -190,7 +190,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isLower('a'));
     assert(!isLower('A'));
@@ -201,7 +201,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
     assert(!isLower('Á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; lowercase)
         assert(isLower(c));
@@ -221,7 +221,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isUpper('A'));
     assert(!isUpper('a'));
@@ -232,7 +232,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
     assert(!isUpper('Á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; uppercase)
         assert(isUpper(c));
@@ -252,7 +252,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isDigit('3'));
     assert( isDigit('8'));
@@ -264,7 +264,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
     assert(!isDigit('４')); // full-width digit four (U+FF14)
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; digits)
         assert(isDigit(c));
@@ -284,7 +284,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isOctalDigit('0'));
     assert( isOctalDigit('7'));
@@ -293,7 +293,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
     assert(!isOctalDigit('#'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; octalDigits)
         assert(isOctalDigit(c));
@@ -313,7 +313,7 @@ bool isHexDigit(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isHexDigit('0'));
     assert( isHexDigit('A'));
@@ -323,7 +323,7 @@ bool isHexDigit(dchar c) @safe pure nothrow @nogc
     assert(!isHexDigit('#'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; fullHexDigits)
         assert(isHexDigit(c));
@@ -345,7 +345,7 @@ bool isWhite(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isWhite(' '));
     assert( isWhite('\t'));
@@ -360,7 +360,7 @@ bool isWhite(dchar c) @safe pure nothrow @nogc
     assert(!isWhite('\u00A0')); // std.ascii.isWhite
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (c; whitespace)
         assert(isWhite(c));
@@ -380,7 +380,7 @@ bool isControl(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isControl('\0'));
     assert( isControl('\022'));
@@ -396,7 +396,7 @@ bool isControl(dchar c) @safe pure nothrow @nogc
     assert(!isControl('\u2029'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (dchar c; 0 .. 32)
         assert(isControl(c));
@@ -419,7 +419,7 @@ bool isPunctuation(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isPunctuation('.'));
     assert( isPunctuation(','));
@@ -440,7 +440,7 @@ bool isPunctuation(dchar c) @safe pure nothrow @nogc
     assert(!isPunctuation('\u2012')); // (U+2012 = en-dash)
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (dchar c; 0 .. 128)
     {
@@ -463,7 +463,7 @@ bool isGraphical(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isGraphical('1'));
     assert( isGraphical('a'));
@@ -476,7 +476,7 @@ bool isGraphical(dchar c) @safe pure nothrow @nogc
     assert(!isGraphical('á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (dchar c; 0 .. 128)
     {
@@ -499,7 +499,7 @@ bool isPrintable(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isPrintable(' '));  // whitespace is printable
     assert( isPrintable('1'));
@@ -511,7 +511,7 @@ bool isPrintable(dchar c) @safe pure nothrow @nogc
     assert(!isPrintable('á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (dchar c; 0 .. 128)
     {
@@ -535,13 +535,13 @@ bool isASCII(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isASCII('a'));
     assert(!isASCII('á'));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (dchar c; 0 .. 128)
         assert(isASCII(c));
@@ -576,7 +576,7 @@ if (is(C : dchar))
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(toLower('a') == 'a');
     assert(toLower('A') == 'a');
@@ -586,7 +586,7 @@ if (is(C : dchar))
     assert(toLower('Á') == 'Á');
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
 
     static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
@@ -638,7 +638,7 @@ if (is(C : dchar))
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(toUpper('a') == 'A');
     assert(toUpper('A') == 'A');
@@ -648,7 +648,7 @@ if (is(C : dchar))
     assert(toUpper('á') == 'á');
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
@@ -673,7 +673,7 @@ if (is(C : dchar))
 }
 
 
-@safe unittest //Test both toUpper and toLower with non-builtin
+version(StdUnittest) @safe unittest //Test both toUpper and toLower with non-builtin
 {
     //User Defined [Char|Wchar|Dchar]
     static struct UDC {  char c; alias c this; }

--- a/std/base64.d
+++ b/std/base64.d
@@ -62,7 +62,7 @@ import std.range.primitives;      // isInputRange, isOutputRange, isForwardRange
 import std.traits;     // isArray
 
 // Make sure module header code examples work correctly.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[] data = [0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e];
 
@@ -81,7 +81,7 @@ import std.traits;     // isArray
 alias Base64 = Base64Impl!('+', '/');
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[] data = [0x83, 0xd7, 0x30, 0x7a, 0x01, 0x3f];
     assert(Base64.encode(data) == "g9cwegE/");
@@ -97,7 +97,7 @@ alias Base64 = Base64Impl!('+', '/');
 alias Base64URL = Base64Impl!('-', '_');
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[] data = [0x83, 0xd7, 0x30, 0x7a, 0x01, 0x3f];
     assert(Base64URL.encode(data) == "g9cwegE_");
@@ -113,7 +113,7 @@ alias Base64URL = Base64Impl!('-', '_');
 alias Base64URLNoPadding = Base64Impl!('-', '_', Base64.NoPadding);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[] data = [0x83, 0xd7, 0x30, 0x7b, 0xef];
     assert(Base64URLNoPadding.encode(data) == "g9cwe-8");
@@ -189,7 +189,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         ubyte[] data = [0x1a, 0x2b, 0x3c, 0x4d, 0x5d, 0x6e];
 
@@ -276,7 +276,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         ubyte[] data = [0x83, 0xd7, 0x30, 0x7a, 0x01, 0x3f];
         char[32] buffer;    // much bigger than necessary
@@ -453,7 +453,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system because encode for OutputRange is @system
         struct OutputRange
@@ -576,7 +576,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         ubyte[] data = [0x1a, 0x2b, 0x3c, 0x4d, 0x5d, 0x6e];
         assert(Base64.encode(data) == "Gis8TV1u");
@@ -941,7 +941,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto encoded = "Gis8TV1u";
 
@@ -1054,7 +1054,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto encoded = "Gis8TV1u";
         ubyte[32] buffer;   // much bigger than necessary
@@ -1238,7 +1238,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         struct OutputRange
         {
@@ -1356,7 +1356,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto data = "Gis8TV1u";
         assert(Base64.decode(data) == [0x1a, 0x2b, 0x3c, 0x4d, 0x5d, 0x6e]);
@@ -1731,7 +1731,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string : representation;
 
@@ -1759,13 +1759,13 @@ class Base64Exception : Exception
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     assertThrown!Base64Exception(Base64.decode("ab|c"));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.sorting : sort;
@@ -2031,7 +2031,7 @@ class Base64Exception : Exception
 }
 
 // Regression control for the output range ref bug in encode.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct InputRange
     {
@@ -2063,7 +2063,7 @@ class Base64Exception : Exception
 }
 
 // Regression control for the output range ref bug in decode.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct InputRange
     {

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -122,7 +122,7 @@ public:
         this(s.byCodeUnit);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // system because of the dummy ranges eventually call std.array!string
         import std.exception : assertThrown;
@@ -152,7 +152,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system due to failure in FreeBSD32
         ulong data = 1_000_000_000_000;
@@ -167,7 +167,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         const(BigInt) b1 = BigInt("1_234_567_890");
         BigInt b2 = BigInt(b1);
@@ -183,7 +183,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto b = BigInt("123");
         b = 456;
@@ -199,7 +199,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto b1 = BigInt("123");
         auto b2 = BigInt("456");
@@ -299,7 +299,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         //@system because opOpAssign is @system
         auto b = BigInt("1_000_000_000");
@@ -312,7 +312,7 @@ public:
     }
 
     // Issue 16264
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto a = BigInt(
     `335690982744637013564796917901053301979460129353374296317539383938630086938` ~
@@ -410,7 +410,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system because opOpAssign is @system
         auto x = BigInt("123");
@@ -432,7 +432,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("123");
         auto y = BigInt("456");
@@ -453,7 +453,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("123");
         x *= 300;
@@ -511,7 +511,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto  x  = BigInt("1_000_000_500");
         long  l  = 1_000_000L;
@@ -536,7 +536,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("100");
         BigInt y = 123 + x;
@@ -630,7 +630,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("1234");
         assert(-x == BigInt("-1234"));
@@ -657,7 +657,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("12345");
         auto y = BigInt("12340");
@@ -680,7 +680,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // Non-zero values are regarded as true
         auto x = BigInt("1");
@@ -727,7 +727,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.conv : to, ConvOverflowException;
         import std.exception : assertThrown;
@@ -740,7 +740,7 @@ public:
         assertThrown!ConvOverflowException(BigInt("-1").to!ubyte);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.conv : to, ConvOverflowException;
         import std.exception : assertThrown;
@@ -787,7 +787,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         const(BigInt) x = BigInt("123");
         BigInt y = cast() x;    // cast away const
@@ -825,7 +825,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = BigInt("100");
         auto y = BigInt("10");
@@ -851,7 +851,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto b = BigInt("12345");
         long l = b.toLong();
@@ -871,7 +871,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto big = BigInt("5_000_000");
         auto i = big.toInt();
@@ -988,7 +988,7 @@ public:
         `toString` is rarely directly invoked; the usual way of using it is via
         $(REF format, std, format):
      */
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.format : format;
 
@@ -1015,7 +1015,7 @@ public:
         `toHash` is rarely directly invoked; it is implicitly used when
         BigInt is used as the key of an associative array.
      */
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         string[BigInt] aa;
         aa[BigInt(123)] = "abc";
@@ -1052,7 +1052,7 @@ public:
     }
 
     ///
-    @system pure unittest
+    version(StdUnittest) @system pure unittest
     {
         auto a = BigInt("1000");
         assert(a.ulongLength() == 1);
@@ -1096,7 +1096,7 @@ private:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     BigInt a = "9588669891916142";
     BigInt b = "7452469135154800";
@@ -1144,7 +1144,7 @@ string toDecimalString(const(BigInt) x) pure nothrow
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     auto x = BigInt("123");
     x *= 1000;
@@ -1172,7 +1172,7 @@ string toHex(const(BigInt) x)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto x = BigInt("123");
     x *= 1000;
@@ -1212,14 +1212,14 @@ if (isIntegral!T)
 
 ///
 nothrow pure @system
-unittest
+version(StdUnittest) unittest
 {
     assert((-1).absUnsign == 1);
     assert(1.absUnsign == 1);
 }
 
 nothrow pure @system
-unittest
+version(StdUnittest) unittest
 {
     BigInt a, b;
     a = 1;
@@ -1229,7 +1229,7 @@ unittest
 }
 
 nothrow pure @system
-unittest
+version(StdUnittest) unittest
 {
     long a;
     BigInt b;
@@ -1240,7 +1240,7 @@ unittest
 }
 
 nothrow pure @system
-unittest
+version(StdUnittest) unittest
 {
     BigInt x = 1, y = 2;
     assert(x <  y);
@@ -1264,7 +1264,7 @@ unittest
     assert(incr == BigInt(1));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Radix conversion
     assert( toDecimalString(BigInt("-1_234_567_890_123_456_789"))
@@ -1302,7 +1302,7 @@ unittest
         == "1234567");
 }
 
-@system unittest // Minimum signed value bug tests.
+version(StdUnittest) @system unittest // Minimum signed value bug tests.
 {
     assert(BigInt("-0x8000000000000000") == BigInt(long.min));
     assert(BigInt("-0x8000000000000000")+1 > BigInt(long.min));
@@ -1323,7 +1323,7 @@ unittest
     assert((BigInt(int.min)-1)%int.min == -1);
 }
 
-@system unittest // Recursive division, bug 5568
+version(StdUnittest) @system unittest // Recursive division, bug 5568
 {
     enum Z = 4843;
     BigInt m = (BigInt(1) << (Z*8) ) - 1;
@@ -1369,7 +1369,7 @@ unittest
     a8165[0] = a8165[1] = 1;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     import std.format;
@@ -1420,7 +1420,7 @@ unittest
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     import std.format;
@@ -1471,7 +1471,7 @@ unittest
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     import std.format;
@@ -1523,7 +1523,7 @@ unittest
 }
 
 // 6448
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     import std.format;
@@ -1549,7 +1549,7 @@ unittest
     assert(y.toLong() == -2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : abs;
     auto r = abs(BigInt(-1000)); // 6486
@@ -1565,7 +1565,7 @@ unittest
     assert(one && !zero);
 }
 
-@system unittest // 6850
+version(StdUnittest) @system unittest // 6850
 {
     pure long pureTest() {
         BigInt a = 1;
@@ -1577,7 +1577,7 @@ unittest
     assert(pureTest() == 1337);
 }
 
-@system unittest // 8435 & 10118
+version(StdUnittest) @system unittest // 8435 & 10118
 {
     auto i = BigInt(100);
     auto j = BigInt(100);
@@ -1601,7 +1601,7 @@ unittest
     assert(keys.empty);
 }
 
-@system unittest // 11148
+version(StdUnittest) @system unittest // 11148
 {
     void foo(BigInt) {}
     const BigInt cbi = 3;
@@ -1639,14 +1639,14 @@ unittest
     assert(n == 4);
 }
 
-@safe unittest // 8167
+version(StdUnittest) @safe unittest // 8167
 {
     BigInt a = BigInt(3);
     BigInt b = BigInt(a);
     assert(b == 3);
 }
 
-@safe unittest // 9061
+version(StdUnittest) @safe unittest // 9061
 {
     long l1 = 0x12345678_90ABCDEF;
     long l2 = 0xFEDCBA09_87654321;
@@ -1665,7 +1665,7 @@ unittest
     assert(l5 == b5);
 }
 
-@system unittest // 11600
+version(StdUnittest) @system unittest // 11600
 {
     import std.conv;
     import std.exception : assertThrown;
@@ -1680,13 +1680,13 @@ unittest
     assertThrown!ConvException(to!BigInt("-123four"));
 }
 
-@safe unittest // 11583
+version(StdUnittest) @safe unittest // 11583
 {
     BigInt x = 0;
     assert((x > 0) == false);
 }
 
-@system unittest // 13391
+version(StdUnittest) @system unittest // 13391
 {
     BigInt x1 = "123456789";
     BigInt x2 = "123456789123456789";
@@ -1717,7 +1717,7 @@ unittest
     assert(x2 == 1);
 }
 
-@system unittest // 13963
+version(StdUnittest) @system unittest // 13963
 {
     BigInt x = 1;
     import std.meta : AliasSeq;
@@ -1768,7 +1768,7 @@ unittest
     assert(-x2 % ulong.max == -x2);
 }
 
-@system unittest // 14124
+version(StdUnittest) @system unittest // 14124
 {
     auto x = BigInt(-3);
     x %= 3;
@@ -1792,7 +1792,7 @@ unittest
 }
 
 // issue 15678
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     assertThrown!ConvException(BigInt(""));
@@ -1801,7 +1801,7 @@ unittest
 }
 
 // Issue 6447
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1817,13 +1817,13 @@ unittest
 }
 
 // Issue 17330
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto b = immutable BigInt("123");
     assert(b == 123);
 }
 
-@system pure unittest // issue 14767
+version(StdUnittest) @system pure unittest // issue 14767
 {
     static immutable a = BigInt("340282366920938463463374607431768211455");
     assert(a == BigInt("340282366920938463463374607431768211455"));
@@ -1857,7 +1857,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
 }
 
 ///
-@system pure nothrow unittest
+version(StdUnittest) @system pure nothrow unittest
 {
     auto a = BigInt(123);
     auto b = BigInt(25);
@@ -1871,7 +1871,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
 }
 
 // Issue 18086
-@system pure nothrow unittest
+version(StdUnittest) @system pure nothrow unittest
 {
     BigInt q = 1;
     BigInt r = 1;

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -315,7 +315,7 @@ template taggedPointer(T : T*, string name, Ts...) {
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A
     {
@@ -349,7 +349,7 @@ if (is(T == class))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A
     {
@@ -364,7 +364,7 @@ if (is(T == class))
 }
 
 @safe pure nothrow @nogc
-unittest
+version(StdUnittest) unittest
 {
     // Degenerate bitfields (#8474 / #11160) tests mixed with range tests
     struct Test1
@@ -430,7 +430,7 @@ unittest
     t4b.a = -5; assert(t4b.a == -5L);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Test5
     {
@@ -470,7 +470,7 @@ unittest
     assert(t6.b == true);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!__traits(compiles,
         taggedPointer!(
@@ -494,7 +494,7 @@ unittest
     static assert(!__traits(compiles, bar(s)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bug #6686
     union  S {
@@ -511,7 +511,7 @@ unittest
     assert(num.bits == 0xFFFF_FFFF_8000_0001uL);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bug #5942
     struct S
@@ -528,7 +528,7 @@ unittest
     assert(data.b == 42);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Test
     {
@@ -553,7 +553,7 @@ unittest
     test();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     {
         static struct Integrals {
@@ -630,7 +630,7 @@ unittest
 }
 
 // Issue 12477
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.algorithm.searching : canFind;
@@ -720,7 +720,7 @@ struct DoubleRep
     enum uint bias = 1023, signBits = 1, fractionBits = 52, exponentBits = 11;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // test reading
     DoubleRep x;
@@ -748,7 +748,7 @@ struct DoubleRep
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue #15305
     struct S {
@@ -854,7 +854,7 @@ public:
         return cast(bool) bt(_ptr, i);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opIndex.unittest\n");
 
@@ -903,7 +903,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
 
@@ -969,7 +969,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -1010,7 +1010,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -1035,7 +1035,7 @@ public:
         bt(_ptr, i) ? btr(_ptr, i) : bts(_ptr, i);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto ax = BitArray([1, 0, 0, 1]);
         ax.flip(0);
@@ -1060,7 +1060,7 @@ public:
         return bitCount;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto a = BitArray([0, 1, 1, 0, 0, 1, 1]);
         assert(a.count == 4);
@@ -1084,7 +1084,7 @@ public:
         return ba;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         BitArray a;
         BitArray b;
@@ -1166,7 +1166,7 @@ public:
         return result;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opApply unittest\n");
 
@@ -1227,7 +1227,7 @@ public:
         return this;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.reverse.unittest\n");
 
@@ -1291,7 +1291,7 @@ public:
         return this;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.sort.unittest\n");
 
@@ -1325,7 +1325,7 @@ public:
         return (p1[i] & endMask) == (p2[i] & endMask);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opEquals unittest\n");
 
@@ -1391,7 +1391,7 @@ public:
         return (this.length > a2.length) - (this.length < a2.length);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCmp unittest\n");
 
@@ -1517,7 +1517,7 @@ public:
         }
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.init unittest\n");
 
@@ -1557,7 +1557,7 @@ public:
         return _ptr[0 .. dim];
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCast unittest\n");
 
@@ -1589,7 +1589,7 @@ public:
         return result;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCom unittest\n");
 
@@ -1635,7 +1635,7 @@ public:
         return result;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opAnd unittest\n");
 
@@ -1654,7 +1654,7 @@ public:
         assert(c[4] == 0);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opOr unittest\n");
 
@@ -1673,7 +1673,7 @@ public:
         assert(c[4] == 1);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opXor unittest\n");
 
@@ -1692,7 +1692,7 @@ public:
         assert(c[4] == 1);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opSub unittest\n");
 
@@ -1744,7 +1744,7 @@ public:
         return this;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static bool[] ba = [1,0,1,0,1,1,0,1,0,1];
         static bool[] bb = [1,0,1,1,0];
@@ -1760,7 +1760,7 @@ public:
         assert(a[9] == 1);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opAndAssign unittest\n");
 
@@ -1778,7 +1778,7 @@ public:
         assert(a[4] == 0);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opOrAssign unittest\n");
 
@@ -1796,7 +1796,7 @@ public:
         assert(a[4] == 1);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opXorAssign unittest\n");
 
@@ -1814,7 +1814,7 @@ public:
         assert(a[4] == 1);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opSubAssign unittest\n");
 
@@ -1847,7 +1847,7 @@ public:
         return this;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCatAssign unittest\n");
 
@@ -1880,7 +1880,7 @@ public:
         return this;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCatAssign unittest\n");
 
@@ -1937,7 +1937,7 @@ public:
         return r;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         debug(bitarray) printf("BitArray.opCat unittest\n");
 
@@ -1984,7 +1984,7 @@ public:
         return (upper << (bitsPerSizeT - nbits)) | (lower >> nbits);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static if (size_t.sizeof == 8)
         {
@@ -2021,7 +2021,7 @@ public:
         return (upper << nbits) | (lower >> (bitsPerSizeT - nbits));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static if (size_t.sizeof == 8)
         {
@@ -2120,7 +2120,7 @@ public:
     }
 
     // Issue 17467
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -2140,7 +2140,7 @@ public:
         assert(equal(b.bitsSet, iota(64, 128)));
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.format : format;
 
@@ -2168,7 +2168,7 @@ public:
     }
 
     // Test multi-word case
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.format : format;
 
@@ -2245,7 +2245,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.format : format;
 
@@ -2274,7 +2274,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
 
@@ -2289,7 +2289,7 @@ public:
         assert(b2.bitsSet.equal([333, 666, 999]));
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -2353,7 +2353,7 @@ public:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.format : format;
 
@@ -2424,7 +2424,7 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
     return res << 32 | bswap(cast(uint)(val >> 32));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
@@ -2507,7 +2507,7 @@ if (canSwapEndianness!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int i = 12345;
     ubyte[4] swappedI = nativeToBigEndian(i);
@@ -2540,7 +2540,7 @@ if (isFloatOrDouble!T)
         return floatEndianImpl!(T, false)(val);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
@@ -2629,7 +2629,7 @@ if (canSwapEndianness!T && n == T.sizeof)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ushort i = 12345;
     ubyte[2] swappedI = nativeToBigEndian(i);
@@ -2681,7 +2681,7 @@ if (canSwapEndianness!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int i = 12345;
     ubyte[4] swappedI = nativeToLittleEndian(i);
@@ -2714,7 +2714,7 @@ if (isFloatOrDouble!T)
         return floatEndianImpl!(T, false)(val);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
@@ -2776,7 +2776,7 @@ if (canSwapEndianness!T && n == T.sizeof)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ushort i = 12345;
     ubyte[2] swappedI = nativeToLittleEndian(i);
@@ -2844,7 +2844,7 @@ private template isFloatOrDouble(T)
                            !is(Unqual!(FloatingPointTypeOf!T) == real);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(float, double))
@@ -2873,7 +2873,7 @@ private template canSwapEndianness(T)
                              isFloatOrDouble!T;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(bool, ubyte, byte, ushort, short, uint, int, ulong,
@@ -2971,7 +2971,7 @@ if (canSwapEndianness!T &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
     assert(buffer.peek!uint() == 17110537);
@@ -2993,7 +2993,7 @@ if (canSwapEndianness!T &&
     assert(index == 7);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     {
         //bool
@@ -3194,7 +3194,7 @@ if (canSwapEndianness!T &&
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     ubyte[] buffer = [1, 5, 22, 9, 44, 255, 7];
@@ -3242,7 +3242,7 @@ if (canSwapEndianness!T && isInputRange!R && is(ElementType!R : const ubyte))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives : empty;
     ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
@@ -3258,7 +3258,7 @@ if (canSwapEndianness!T && isInputRange!R && is(ElementType!R : const ubyte))
     assert(buffer.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     {
         //bool
@@ -3431,7 +3431,7 @@ if (canSwapEndianness!T && isInputRange!R && is(ElementType!R : const ubyte))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     ubyte[] buffer = [1, 5, 22, 9, 44, 255, 8];
@@ -3449,7 +3449,7 @@ if (canSwapEndianness!T && isInputRange!R && is(ElementType!R : const ubyte))
 }
 
 // issue 17247
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct UbyteRange
     {
@@ -3518,7 +3518,7 @@ if (canSwapEndianness!T &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     {
         ubyte[] buffer = [0, 0, 0, 0, 0, 0, 0, 0];
@@ -3561,7 +3561,7 @@ if (canSwapEndianness!T &&
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     {
         //bool
@@ -3844,7 +3844,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     auto buffer = appender!(const ubyte[])();
@@ -3858,7 +3858,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
     assert(buffer.data == [1, 5, 22, 9, 44, 255, 8]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     {
@@ -3989,7 +3989,7 @@ if (canSwapEndianness!T && isOutputRange!(R, ubyte))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     import std.format : format;
@@ -4074,7 +4074,7 @@ if (isIntegral!T)
     return cast(uint) c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(countBitsSet(1) == 1);
     assert(countBitsSet(0) == 0);
@@ -4082,7 +4082,7 @@ if (isIntegral!T)
     assert(countBitsSet(uint.max) == 32);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
@@ -4179,7 +4179,7 @@ if (isIntegral!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -4190,7 +4190,7 @@ if (isIntegral!T)
     assert(bitsSet(int.min).equal([31]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;

--- a/std/complex.d
+++ b/std/complex.d
@@ -54,7 +54,7 @@ if (is(R : double) && is(I : double))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = complex(1.0);
     static assert(is(typeof(a) == Complex!double));
@@ -130,7 +130,7 @@ if (isFloatingPoint!T)
 
     static if (is(T == double))
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto c = complex(1.2, 3.4);
 
@@ -437,7 +437,7 @@ if (isFloatingPoint!T)
     }
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.complex;
     import std.math;
@@ -613,7 +613,7 @@ if (isFloatingPoint!T)
     assert(approxEqual(c2c.im, 0.0, EPS));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // Initialization
     Complex!double a = 1;
@@ -624,7 +624,7 @@ if (isFloatingPoint!T)
     assert(c.re == 1.0 && c.im == 2);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // Assignments and comparisons
     Complex!double z;
@@ -672,7 +672,7 @@ if (is(T R == Complex!R))
     alias Complex = T;
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static assert(is(Complex!(Complex!real) == Complex!real));
 
@@ -701,7 +701,7 @@ T abs(T)(Complex!T z) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static import std.math;
     assert(abs(complex(1.0)) == 1.0);
@@ -723,7 +723,7 @@ T sqAbs(T)(Complex!T z) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math;
     assert(sqAbs(complex(0.0)) == 0.0);
@@ -741,7 +741,7 @@ if (isFloatingPoint!T)
     return x*x;
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math;
     assert(sqAbs(0.0) == 0.0);
@@ -762,7 +762,7 @@ T arg(T)(Complex!T z) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math;
     assert(arg(complex(1.0)) == 0.0);
@@ -781,7 +781,7 @@ Complex!T conj(T)(Complex!T z) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     assert(conj(complex(1.0)) == complex(1.0));
     assert(conj(complex(1.0, 2.0)) == complex(1.0, -2.0));
@@ -804,7 +804,7 @@ Complex!(CommonType!(T, U)) fromPolar(T, U)(T modulus, U argument)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math;
     auto z = fromPolar(std.math.sqrt(2.0), PI_4);
@@ -827,7 +827,7 @@ Complex!T sin(T)(Complex!T z)  @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static import std.math;
     assert(sin(complex(0.0)) == 0.0);
@@ -844,14 +844,14 @@ Complex!T cos(T)(Complex!T z)  @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.complex;
     assert(cos(complex(0.0)) == 1.0);
 }
 
 deprecated
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math;
     assert(cos(complex(0, 5.2L)) == cosh(5.2L));
@@ -875,7 +875,7 @@ Complex!real expi(real y)  @trusted pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math : cos, sin;
     assert(expi(0.0L) == 1.0L);
@@ -883,7 +883,7 @@ Complex!real expi(real y)  @trusted pure nothrow @nogc
 }
 
 deprecated
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static import std.math;
 
@@ -916,14 +916,14 @@ Complex!real coshisinh(real y) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.math : cosh, sinh;
     assert(coshisinh(3.0L) == complex(cosh(3.0L), sinh(3.0L)));
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     static import std.math;
     assert(coshisinh(3.0L) == complex(std.math.cosh(3.0L), std.math.sinh(3.0L)));
@@ -981,7 +981,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static import std.math;
     assert(sqrt(complex(0.0)) == 0.0);
@@ -989,7 +989,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
     assert(sqrt(complex(-1.0L, 0)) == complex(0, 1.0L));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.math : approxEqual;
 
@@ -1006,7 +1006,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
 }
 
 // Issue 10881: support %f formatting of complex numbers
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
 
@@ -1017,7 +1017,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
     assert(format("%.2f", y) == "1.20-3.40i");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test wide string formatting
     import std.format;
@@ -1033,7 +1033,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
     assert(wformat("%.2f", x) == "1.20+3.40i"w);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test ease of use (vanilla toString() should be supported)
     assert(complex(1.2, 3.4).toString() == "1.2+3.4i");

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -42,7 +42,7 @@ import std.range.interfaces : InputRange;
 import std.traits;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     __gshared string received;
     static void spawnedFunc(Tid ownerTid)
@@ -323,7 +323,7 @@ public:
 
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // text!Tid is @system
     import std.conv : text;
@@ -366,7 +366,7 @@ public:
     return thisInfo.owner;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -437,7 +437,7 @@ Tid spawn(F, T...)(F fn, T args) if (isSpawnable!(F, T))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void f(string msg)
     {
@@ -448,7 +448,7 @@ Tid spawn(F, T...)(F fn, T args) if (isSpawnable!(F, T))
 }
 
 /// Fails: char[] has mutable aliasing.
-@system unittest
+version(StdUnittest) @system unittest
 {
     string msg = "Hello, World!";
 
@@ -462,7 +462,7 @@ Tid spawn(F, T...)(F fn, T args) if (isSpawnable!(F, T))
 }
 
 /// New thread with anonymous function
-@system unittest
+version(StdUnittest) @system unittest
 {
     spawn({
         ownerTid.send("This is so great!");
@@ -470,7 +470,7 @@ Tid spawn(F, T...)(F fn, T args) if (isSpawnable!(F, T))
     assert(receiveOnly!string == "This is so great!");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.thread : thread_joinAll;
 
@@ -538,7 +538,7 @@ private Tid _spawn(F, T...)(bool linked, F fn, T args) if (isSpawnable!(F, T))
     return spawnTid;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void function() fn1;
     void function(int) fn2;
@@ -655,7 +655,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.variant : Variant;
 
@@ -687,7 +687,7 @@ do
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( __traits( compiles,
                       {
@@ -711,7 +711,7 @@ version(StdUnittest)
 {
     private void receiveFunction(int x) {}
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( __traits( compiles,
                       {
@@ -778,7 +778,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto tid = spawn(
     {
@@ -788,7 +788,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto tid = spawn(
     {
@@ -798,7 +798,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Record { string name; int age; }
 
@@ -813,7 +813,7 @@ do
     send(tid, 0.5, Record("Alice", 31));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void t1(Tid mainTid)
     {
@@ -856,7 +856,7 @@ do
     return thisInfo.ident.mbox.get(duration, ops);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, {
         receiveTimeout(msecs(0), (Variant x) {});
@@ -1432,7 +1432,7 @@ private:
     size_t m_pos;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void receive(Condition cond, ref size_t received)
     {
@@ -1748,7 +1748,7 @@ void yield(T)(T value)
     yield(value);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
     import std.exception;
@@ -1797,7 +1797,7 @@ void yield(T)(T value)
     testScheduler(new FiberScheduler);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range;
 
@@ -2467,12 +2467,12 @@ version(StdUnittest)
         runTest(tid);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         simpleTest();
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         scheduler = new ThreadScheduler;
         simpleTest();
@@ -2513,7 +2513,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
 }
 
 /// A typical use-case is to perform lazy but thread-safe initialization.
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class MySingleton
     {
@@ -2527,7 +2527,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
     assert(MySingleton.instance !is null);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class MySingleton
     {
@@ -2595,7 +2595,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 /// Use a separate mutex when init blocks on another thread that might also call initOnce.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.sync.mutex : Mutex;
 
@@ -2614,7 +2614,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
     assert(varB == true);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static shared bool a;
     __gshared bool b;
@@ -2627,7 +2627,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 // test ability to send shared arrays
-@system unittest
+version(StdUnittest) @system unittest
 {
     static shared int[] x = new shared(int)[1];
     auto tid = spawn({

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -25,7 +25,7 @@ import std.traits;
 public import std.container.util;
 
 ///
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     auto arr = Array!int(0, 2, 3);
     assert(arr[0] == 0);
@@ -52,7 +52,7 @@ pure @system unittest
 }
 
 ///
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     import std.algorithm.comparison : equal;
     auto arr = Array!int(1, 2, 3);
@@ -71,7 +71,7 @@ pure @system unittest
 }
 
 /// `Array!bool` packs together values efficiently by allocating one bit per element
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     Array!bool arr;
     arr.insert([true, true, false, true, false]);
@@ -1020,13 +1020,13 @@ if (!is(Unqual!T == bool))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!int a;
     assert(a.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!int a;
     a.length = 10;
@@ -1034,7 +1034,7 @@ if (!is(Unqual!T == bool))
     assert(a.capacity >= a.length);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Dumb { int x = 5; }
     Array!Dumb a;
@@ -1078,7 +1078,7 @@ if (!is(Unqual!T == bool))
         assert(e.x == Dumb.init.x);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!int a = Array!int(1, 2, 3);
     //a._data._refCountedDebug = true;
@@ -1089,13 +1089,13 @@ if (!is(Unqual!T == bool))
     assert(a == Array!int(1, 2, 3));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3);
     assert(a.length == 3);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     const Array!int a = [1, 2];
 
@@ -1116,14 +1116,14 @@ if (!is(Unqual!T == bool))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // REG https://issues.dlang.org/show_bug.cgi?id=13621
     import std.container : Array, BinaryHeap;
     alias Heap = BinaryHeap!(Array!int);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!int a;
     a.reserve(1000);
@@ -1138,14 +1138,14 @@ if (!is(Unqual!T == bool))
     assert(p == a._data._payload.ptr);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3);
     a[1] *= 42;
     assert(a[1] == 84);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3);
     auto b = Array!int(11, 12, 13);
@@ -1155,7 +1155,7 @@ if (!is(Unqual!T == bool))
     assert(a ~ [4,5] == Array!int(1,2,3,4,5));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3);
     auto b = Array!int(11, 12, 13);
@@ -1163,14 +1163,14 @@ if (!is(Unqual!T == bool))
     assert(a == Array!int(1, 2, 3, 11, 12, 13));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3, 4);
     assert(a.removeAny() == 4);
     assert(a == Array!int(1, 2, 3));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(1, 2, 3, 4, 5);
     auto r = a[2 .. a.length];
@@ -1181,7 +1181,7 @@ if (!is(Unqual!T == bool))
     assert(a == Array!int(1, 2, 8, 9, 42, 3, 4, 5));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int(0, 1, 2, 3, 4, 5, 6, 7, 8);
     a.linearRemove(a[4 .. 6]);
@@ -1189,7 +1189,7 @@ if (!is(Unqual!T == bool))
 }
 
 // Give the Range object some testing.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : retro;
@@ -1207,7 +1207,7 @@ if (!is(Unqual!T == bool))
     assert(equal(a[1 .. 4], [1, 2, 3]));
 }
 // Test issue 5920
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct structBug5920
     {
@@ -1246,7 +1246,7 @@ if (!is(Unqual!T == bool))
     assert(dMask == 0b1111_1111);   // make sure the d'tor is called once only.
 }
 // Test issue 5792 (mainly just to check if this piece of code is compilable)
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!(int[])([[1,2],[3,4]]);
     a.reserve(4);
@@ -1262,7 +1262,7 @@ if (!is(Unqual!T == bool))
 }
 
 // test replace!Stuff with range Stuff
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int([1, 42, 5]);
@@ -1271,28 +1271,28 @@ if (!is(Unqual!T == bool))
 }
 
 // test insertBefore and replace with empty Arrays
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.insertBefore(a[], 1);
     assert(equal(a[], [1]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.insertBefore(a[], [1, 2]);
     assert(equal(a[], [1, 2]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
     a.replace(a[], [1, 2]);
     assert(equal(a[], [1, 2]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = Array!int();
@@ -1300,7 +1300,7 @@ if (!is(Unqual!T == bool))
     assert(equal(a[], [1]));
 }
 // make sure that Array instances refuse ranges that don't belong to them
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -1313,7 +1313,7 @@ if (!is(Unqual!T == bool))
     assertThrown(a.replace(r, [42]));
     assertThrown(a.linearRemove(r));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = Array!int([1, 1]);
     a[1]  = 0; //Check Array.opIndexAssign
@@ -1344,7 +1344,7 @@ if (!is(Unqual!T == bool))
     assert(~r[0] == ~3);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1390,7 +1390,7 @@ if (!is(Unqual!T == bool))
 }
 
 // Test issue 11194
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S {
         int i = 1337;
@@ -1404,7 +1404,7 @@ if (!is(Unqual!T == bool))
     arr ~= s;
 }
 
-@safe unittest //11459
+version(StdUnittest) @safe unittest //11459
 {
     static struct S
     {
@@ -1415,18 +1415,18 @@ if (!is(Unqual!T == bool))
     alias B = Array!(shared bool);
 }
 
-@system unittest //11884
+version(StdUnittest) @system unittest //11884
 {
     import std.algorithm.iteration : filter;
     auto a = Array!int([1, 2, 2].filter!"true"());
 }
 
-@safe unittest //8282
+version(StdUnittest) @safe unittest //8282
 {
     auto arr = new Array!int;
 }
 
-@system unittest //6998
+version(StdUnittest) @system unittest //6998
 {
     static int i = 0;
     class C
@@ -1451,7 +1451,7 @@ if (!is(Unqual!T == bool))
     //Just to make sure the GC doesn't collect before the above test.
     assert(c.dummy == 1);
 }
-@system unittest //6998-2
+version(StdUnittest) @system unittest //6998-2
 {
     static class C {int i;}
     auto c = new C;
@@ -1462,13 +1462,13 @@ if (!is(Unqual!T == bool))
     assert(c.i == 42); //fails
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Array!int.Range));
     static assert(is(Array!int.ConstRange));
 }
 
-@system unittest // const/immutable Array and Ranges
+version(StdUnittest) @system unittest // const/immutable Array and Ranges
 {
     static void test(A, R, E, S)()
     {
@@ -1498,7 +1498,7 @@ if (!is(Unqual!T == bool))
 }
 
 // ensure @nogc
-@nogc @system unittest
+version(StdUnittest) @nogc @system unittest
 {
     Array!int ai;
     ai ~= 1;
@@ -2133,13 +2133,13 @@ if (is(Unqual!T == bool))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     assert(a.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool arr;
     arr.insert([false, false, false, false]);
@@ -2161,13 +2161,13 @@ if (is(Unqual!T == bool))
 }
 
 // issue 16331 - uncomparable values are valid values for an array
-@system unittest
+version(StdUnittest) @system unittest
 {
     double[] values = [double.nan, double.nan];
     auto arr = Array!double(values);
 }
 
-@nogc @system unittest
+version(StdUnittest) @nogc @system unittest
 {
     auto a = Array!int(0, 1, 2);
     int[3] b = [3, 4, 5];
@@ -2179,7 +2179,7 @@ if (is(Unqual!T == bool))
     assert(Array!int(0, 1, 2, 0, 1, 0) == a ~ c);
 }
 
-@nogc @system unittest
+version(StdUnittest) @nogc @system unittest
 {
     auto a = Array!char('a', 'b');
     assert(Array!char("abc") == a ~ 'c');
@@ -2187,7 +2187,7 @@ if (is(Unqual!T == bool))
     assert(Array!char("abcd") == a ~ "cd".byCodeUnit);
 }
 
-@nogc @system unittest
+version(StdUnittest) @nogc @system unittest
 {
     auto a = Array!dchar("ąćę"d);
     assert(Array!dchar("ąćęϢϖ"d) == a ~ "Ϣϖ"d);
@@ -2195,7 +2195,7 @@ if (is(Unqual!T == bool))
     assert(Array!dchar("ąćęϢz"d) == a ~ x ~ 'z');
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     assert(a.empty);
@@ -2203,7 +2203,7 @@ if (is(Unqual!T == bool))
     assert(!a.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     assert(a.empty);
@@ -2213,7 +2213,7 @@ if (is(Unqual!T == bool))
     assert(b.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     Array!bool a;
@@ -2222,7 +2222,7 @@ if (is(Unqual!T == bool))
     assert(a.length == 1, to!string(a.length));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     Array!bool a;
@@ -2234,7 +2234,7 @@ if (is(Unqual!T == bool))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     assert(a.capacity == 0);
@@ -2244,21 +2244,21 @@ if (is(Unqual!T == bool))
     assert(a.capacity >= 15657);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
     assert(a[0 .. 2].length == 2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
     assert(a[].length == 4);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
@@ -2267,14 +2267,14 @@ if (is(Unqual!T == bool))
     assert(!a.front);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
     assert(a[].length == 4);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
@@ -2283,7 +2283,7 @@ if (is(Unqual!T == bool))
     assert(!a.back);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
@@ -2292,7 +2292,7 @@ if (is(Unqual!T == bool))
     assert(!a[0]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     Array!bool a;
@@ -2306,7 +2306,7 @@ if (is(Unqual!T == bool))
     c.insertBack(true);
     assert((c ~ false)[].equal([true, false]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     Array!bool a;
@@ -2319,7 +2319,7 @@ if (is(Unqual!T == bool))
                 [true, false, true, true, false, true, false, true, true]));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.insertBack([true, false, true, true]);
@@ -2327,7 +2327,7 @@ if (is(Unqual!T == bool))
     assert(a.capacity == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.length = 1057;
@@ -2344,7 +2344,7 @@ if (is(Unqual!T == bool))
     assert(a.capacity == cap);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.length = 1057;
@@ -2356,7 +2356,7 @@ if (is(Unqual!T == bool))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     for (int i = 0; i < 100; ++i)
@@ -2365,7 +2365,7 @@ if (is(Unqual!T == bool))
         assert(e);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Array!bool a;
     a.length = 1057;
@@ -2377,7 +2377,7 @@ if (is(Unqual!T == bool))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     Array!bool a;
@@ -2394,7 +2394,7 @@ if (is(Unqual!T == bool))
     assert(a[].equal([false, true, true]));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     Array!bool a;
@@ -2403,7 +2403,7 @@ if (is(Unqual!T == bool))
     assert(a.length == 11, to!string(a.length));
     assert(a[5]);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias V3 = int[3];
     V3 v = [1, 2, 3];
@@ -2411,7 +2411,7 @@ if (is(Unqual!T == bool))
     arr ~= v;
     assert(arr[0] == [1, 2, 3]);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias V3 = int[3];
     V3[2] v = [[1, 2, 3], [4, 5, 6]];

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -22,7 +22,7 @@ import std.traits;
 public import std.container.util;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -402,7 +402,7 @@ leaves the heap unaffected and returns $(D false).
 }
 
 /// Example from "Introduction to Algorithms" Cormen et al, p 146
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
@@ -415,7 +415,7 @@ leaves the heap unaffected and returns $(D false).
 
 /// $(D BinaryHeap) implements the standard input range interface, allowing
 /// lazy iteration of the underlying range in descending order.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -436,7 +436,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.range.primitives;
@@ -467,7 +467,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test range interface.
     import std.algorithm.comparison : equal;
@@ -477,7 +477,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     assert(h.equal([16, 14, 10, 9, 8, 7, 4, 3, 2, 1]));
 }
 
-@system unittest // 15675
+version(StdUnittest) @system unittest // 15675
 {
     import std.container.array : Array;
 
@@ -486,7 +486,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     assert(heap.front == 12);
 }
 
-@system unittest // 16072
+version(StdUnittest) @system unittest // 16072
 {
     auto q = heapify!"a > b"([2, 4, 5]);
     q.insert(1);
@@ -502,7 +502,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     assert(r.front == 99);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7];
@@ -511,7 +511,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     assert(dup.equal([16, 14, 10, 9, 8, 7, 4, 3, 2, 1]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct StructWithoutDup
     {
@@ -541,7 +541,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
         }));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct StructWithDup
     {
@@ -563,7 +563,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
         }));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange;
@@ -585,7 +585,7 @@ BinaryHeap!(Store, less) heapify(alias less = "a < b", Store)(Store s,
     assert(equal(b, [10, 9, 8, 7, 6, 6, 7, 8, 9, 10]));
 }
 
-@system unittest // Issue 17314
+version(StdUnittest) @system unittest // Issue 17314
 {
     import std.algorithm.comparison : equal;
     int[] a = [5];

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -19,7 +19,7 @@ $(SCRIPT inhibitQuickIndex = 1;)
 module std.container.dlist;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : DList;
@@ -105,7 +105,7 @@ The base DList Range. Contains Range primitives that don't depend on payload typ
  +/
 private struct DRange
 {
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static assert(isBidirectionalRange!DRange);
         static assert(is(ElementType!DRange == BaseNode*));
@@ -799,7 +799,7 @@ private:
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -831,7 +831,7 @@ private:
     a.linearRemoveElement(3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -850,7 +850,7 @@ private:
     assert(equal(a4[], [0, 1]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -867,7 +867,7 @@ private:
     assert(equal(list[],[4,5,6,7,0,1,2,3]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -926,7 +926,7 @@ private:
     assert(equal(list[],[0,3]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -950,7 +950,7 @@ private:
     assert(dl.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -963,7 +963,7 @@ private:
     assert(equal(dl[], ["a", "b", "c", "d", "e"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -976,7 +976,7 @@ private:
     assert(equal(dl[], ["e", "a", "c", "b", "d"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto d = DList!int([1, 2, 3]);
     d.front = 5; //test frontAssign
@@ -987,7 +987,7 @@ private:
 }
 
 // Issue 8895
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = make!(DList!int)(1,2,3,4);
     auto b = make!(DList!int)(1,2,3,4);
@@ -998,7 +998,7 @@ private:
     assert(!(a == d));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto d = DList!int([1, 2, 3]);
     d.front = 5; //test frontAssign
@@ -1008,7 +1008,7 @@ private:
     assert(r.back == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = DList!int();
     assert(a.removeFront(10) == 0);
@@ -1017,7 +1017,7 @@ private:
     assert(a[].empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1053,7 +1053,7 @@ private:
     c.removeBack();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1065,7 +1065,7 @@ private:
     assert(a[].equal([1, 2, 3, 7]));
 }
 
-@safe unittest //12566
+version(StdUnittest) @safe unittest //12566
 {
     auto dl2 = DList!int([2,7]);
     dl2.removeFront();
@@ -1074,14 +1074,14 @@ private:
     assert(dl2.empty, "not empty?!");
 }
 
-@safe unittest //13076
+version(StdUnittest) @safe unittest //13076
 {
     DList!int list;
     assert(list.empty);
     list.clear();
 }
 
-@safe unittest //13425
+version(StdUnittest) @safe unittest //13425
 {
     import std.range : drop, take;
     auto list = DList!int([1,2,3,4,5]);
@@ -1091,7 +1091,7 @@ private:
     assert(r.empty); // fails
 }
 
-@safe unittest //14300
+version(StdUnittest) @safe unittest //14300
 {
     interface ITest {}
     static class Test : ITest {}
@@ -1099,7 +1099,7 @@ private:
     DList!ITest().insertBack(new Test());
 }
 
-@safe unittest //15263
+version(StdUnittest) @safe unittest //15263
 {
     import std.range : iota;
     auto a = DList!int();

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -1150,7 +1150,7 @@ Complexity: $(BIGOH n)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     TotalContainer!int test;
 }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -17,7 +17,7 @@ Authors: Steven Schveighoffer, $(HTTP erdani.com, Andrei Alexandrescu)
 module std.container.rbtree;
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.container.rbtree;
@@ -638,7 +638,7 @@ struct RBNode(V)
 }
 
 //constness checks
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     const RBNode!int n;
     static assert(is(typeof(n.leftmost)));
@@ -1754,7 +1754,7 @@ assert(equal(rbt[], [5]));
 }
 
 //Verify Example for removeKey.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     auto rbt = redBlackTree!true(0, 1, 1, 1, 4, 5, 7);
@@ -1765,7 +1765,7 @@ assert(equal(rbt[], [5]));
 }
 
 //Tests for removeKey
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     {
@@ -1795,7 +1795,7 @@ assert(equal(rbt[], [5]));
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     void test(T)()
     {
@@ -1890,7 +1890,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.range : iota;
 
@@ -1908,7 +1908,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 //Combinations not in examples.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto rbt1 = redBlackTree!(true, string)("hello", "hello");
     auto rbt2 = redBlackTree!((a, b){return a < b;}, double)(5.1, 2.3);
@@ -1916,7 +1916,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 //Range construction.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1926,7 +1926,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 
 
 // construction with arrays
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1956,7 +1956,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 // convenience wrapper range construction
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : chain, iota;
@@ -1980,7 +1980,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
     assert(equal(rbt6[], [7.2, 5.9, 5.9, 1.3, 0.1]));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
 
@@ -2001,7 +2001,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
     assert(array(rt4[]) == ["hello"]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
 
@@ -2020,7 +2020,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 //constness checks
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     const rt1 = redBlackTree(5,4,3,2,1);
     static assert(is(typeof(rt1.length)));
@@ -2035,7 +2035,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 //immutable checks
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     immutable rt1 = redBlackTree(5,4,3,2,1);
     static assert(is(typeof(rt1.length)));
@@ -2046,13 +2046,13 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 // issue 15941
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     class C {}
     RedBlackTree!(C, "cast(void*)a < cast(void*) b") tree;
 }
 
-@safe pure unittest // const/immutable elements (issue 17519)
+version(StdUnittest) @safe pure unittest // const/immutable elements (issue 17519)
 {
     RedBlackTree!(immutable int) t1;
     RedBlackTree!(const int) t2;

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -19,7 +19,7 @@ $(SCRIPT inhibitQuickIndex = 1;)
 module std.container.slist;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container : SList;
@@ -223,7 +223,7 @@ Defines the container's primary range, which embodies a forward range.
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static assert(isForwardRange!Range);
     }
@@ -275,7 +275,7 @@ Complexity: $(BIGOH 1)
         return _first._payload;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto s = SList!int(1, 2, 3);
         s.front = 42;
@@ -626,7 +626,7 @@ Complexity: $(BIGOH n)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -658,7 +658,7 @@ Complexity: $(BIGOH n)
     a.linearRemoveElement(3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -674,21 +674,21 @@ Complexity: $(BIGOH n)
     assert(equal(b[], [2, 1, 9]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int(1, 2, 3);
     auto n = s.findLastNode(s._root);
     assert(n && n._payload == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
     auto s = SList!int(1, 2, 5, 10);
     assert(walkLength(s[]) == 4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : take;
     auto src = take([0, 1, 2, 3], 3);
@@ -696,7 +696,7 @@ Complexity: $(BIGOH n)
     assert(s == SList!int(0, 1, 2));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int();
     auto b = SList!int();
@@ -704,7 +704,7 @@ Complexity: $(BIGOH n)
     assert(c.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = SList!int(4, 5, 6);
@@ -712,7 +712,7 @@ Complexity: $(BIGOH n)
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = [4, 5, 6];
@@ -720,21 +720,21 @@ Complexity: $(BIGOH n)
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto c = a ~ 4;
     assert(c == SList!int(1, 2, 3, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int(2, 3, 4);
     auto b = 1 ~ a;
     assert(b == SList!int(1, 2, 3, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [1, 2, 3];
     auto b = SList!int(4, 5, 6);
@@ -742,14 +742,14 @@ Complexity: $(BIGOH n)
     assert(c == SList!int(1, 2, 3, 4, 5, 6));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int(1, 2, 3, 4);
     s.insertFront([ 42, 43 ]);
     assert(s == SList!int(42, 43, 1, 2, 3, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int(1, 2, 3);
     assert(s.removeAny() == 1);
@@ -758,7 +758,7 @@ Complexity: $(BIGOH n)
     assert(s == SList!int(3));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -769,21 +769,21 @@ Complexity: $(BIGOH n)
     assert(equal(s[], [3]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int(1, 2, 3, 4, 5, 6, 7);
     assert(s.removeFront(3) == 3);
     assert(s == SList!int(4, 5, 6, 7));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = SList!int(1, 2, 3);
     auto b = SList!int(1, 2, 3);
     assert(a.insertAfter(a[], b[]) == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : take;
     auto s = SList!int(1, 2, 3, 4);
@@ -792,7 +792,7 @@ Complexity: $(BIGOH n)
     assert(s == SList!int(1, 2, 5, 3, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : take;
@@ -805,7 +805,7 @@ Complexity: $(BIGOH n)
     assert(equal(sl[], ["a", "b", "c", "d", "e"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
     auto s = SList!int(1, 2, 3, 4, 5);
@@ -816,7 +816,7 @@ Complexity: $(BIGOH n)
     assert(r1.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int(1, 2, 3, 4, 5);
     auto r = s[];
@@ -825,7 +825,7 @@ Complexity: $(BIGOH n)
     assert(r1.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range;
@@ -840,7 +840,7 @@ Complexity: $(BIGOH n)
     assert(equal(r2, [8, 9, 10]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
     auto lst = SList!int(1, 5, 42, 9);
@@ -855,12 +855,12 @@ Complexity: $(BIGOH n)
     assert(walkLength(lst3[]) == 5);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = make!(SList!int)(1, 2, 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 5193
     static struct Data
@@ -870,7 +870,7 @@ Complexity: $(BIGOH n)
     SList!Data list;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = SList!int([1, 2, 3]);
     s.front = 5; //test frontAssign
@@ -880,7 +880,7 @@ Complexity: $(BIGOH n)
     assert(r.front == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 14920
     SList!int s;
@@ -888,20 +888,20 @@ Complexity: $(BIGOH n)
     assert(s.front == 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 15659
     SList!int s;
     s.clear();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     SList!int s;
     s.reverse();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -52,7 +52,7 @@ if (is(T == struct) || is(T == class))
 
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.container;
@@ -68,7 +68,7 @@ if (is(T == struct) || is(T == class))
     assert(equal(slist[], [1, 2, 3]));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.container;
@@ -85,7 +85,7 @@ if (is(T == struct) || is(T == class))
 }
 
 // Issue 8895
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container;
@@ -123,7 +123,7 @@ if (!is(Container))
 }
 
 /// forbid construction from infinite range
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.container.array : Array;
     import std.range : only, repeat;
@@ -133,7 +133,7 @@ if (!is(Container))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.container.array, std.container.rbtree, std.container.slist;
@@ -153,7 +153,7 @@ if (!is(Container))
     assert(equal(list[], [1, 7, 42]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container.rbtree;
@@ -163,7 +163,7 @@ if (!is(Container))
 }
 
 // Issue 13872
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.container;
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -227,7 +227,7 @@ template to(T)
  * Converting a value _to its own type (useful mostly for generic code)
  * simply returns its argument.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     int a = 42;
     int b = to!int(a);
@@ -243,7 +243,7 @@ template to(T)
  * truncate. (_To round a floating point value when casting _to an
  * integral, use `roundTo`.)
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -266,7 +266,7 @@ template to(T)
  *
  * _To work around this, you can specify a radix for conversions involving numbers.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = to!string(42, 16);
     assert(str == "2A");
@@ -281,7 +281,7 @@ template to(T)
  * `float`, `2^53-1` for `double`, and `2^64-1` for `real` (when
  * `real` is 80-bit, e.g. on Intel machines).
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // 2^24 - 1, largest proper integer representable as float
     int a = 16_777_215;
@@ -294,7 +294,7 @@ template to(T)
    to consist of a single code point, and said code point must
    fit in the target type. Otherwise, $(LREF ConvException) is thrown.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -317,7 +317,7 @@ template to(T)
  * element in turn. Associative arrays can be converted _to associative
  * arrays as long as keys and values can in turn be converted.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.string : split;
 
@@ -343,7 +343,7 @@ template to(T)
  * `to!(double[])` applies _to an `int[]`. The conversion might throw an
  * exception because `to!short` might fail the range check.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[string][double[int[]]] a;
     auto b = to!(short[wstring][string[double[]]])(a);
@@ -353,7 +353,7 @@ template to(T)
  * Object-to-object conversions by dynamic casting throw exception when
  * the source is non-null and the target is null.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
     // Testing object conversions
@@ -397,7 +397,7 @@ template to(T)
  *        If pointer is $(D char*), treat it as C-style strings.
  *        In that case, this function is $(D @system).))
  */
-@system pure unittest // @system due to cast and ptr
+version(StdUnittest) @system pure unittest // @system due to cast and ptr
 {
     // Conversion representing dynamic/static array with string
     long[] a = [ 1, 3, 5 ];
@@ -422,7 +422,7 @@ template to(T)
 }
 
 // Tests for issue 6175
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     char[9] sarr = "blablabla";
     auto darr = to!(char[])(sarr);
@@ -431,14 +431,14 @@ template to(T)
 }
 
 // Tests for issue 7348
-@safe pure /+nothrow+/ unittest
+version(StdUnittest) @safe pure /+nothrow+/ unittest
 {
     assert(to!string(null) == "null");
     assert(text(null) == "null");
 }
 
 // Tests for issue 11390
-@safe pure /+nothrow+/ unittest
+version(StdUnittest) @safe pure /+nothrow+/ unittest
 {
     const(typeof(null)) ctn;
     immutable(typeof(null)) itn;
@@ -447,7 +447,7 @@ template to(T)
 }
 
 // Tests for issue 8729: do NOT skip leading WS
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
     static foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
@@ -503,14 +503,14 @@ if (isImplicitlyConvertible!(S, T) &&
     return value;
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     enum E { a }  // Issue 9523 - Allow identity enum conversion
     auto e = to!E(E.a);
     assert(e == E.a);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int a = 42;
     auto b = to!long(a);
@@ -518,7 +518,7 @@ if (isImplicitlyConvertible!(S, T) &&
 }
 
 // Tests for issue 6377
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
     // Conversion between same size
@@ -596,7 +596,7 @@ if (isStaticArray!S)
     return toImpl!(T, typeof(s[0])[])(s);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     char[4] test = ['a', 'b', 'c', 'd'];
     static assert(!isInputRange!(Unqual!(char[4])));
@@ -615,7 +615,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     return value.opCast!T();
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static struct Test
     {
@@ -635,7 +635,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     Test.T t = s;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     class B
     {
@@ -665,7 +665,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 }
 
 // Bugzilla 3961
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     struct Int
     {
@@ -694,7 +694,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 }
 
 // Bugzilla 6808
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static struct FakeBigInt
     {
@@ -713,7 +713,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     return new T(value);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static struct S
     {
@@ -744,7 +744,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     assert(c2.x == 3);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     struct S
     {
@@ -831,7 +831,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 }
 
 // Unittest for 6288
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -1006,13 +1006,13 @@ if (!(isImplicitlyConvertible!(S, T) &&
 }
 
 // Bugzilla 14042
-@system unittest
+version(StdUnittest) @system unittest
 {
     immutable(char)* ptr = "hello".ptr;
     auto result = ptr.to!(char[]);
 }
 // Bugzilla 8384
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test1(T)(T lp, string cmp)
     {
@@ -1059,7 +1059,7 @@ if (!(isImplicitlyConvertible!(S, T) &&
 }
 
 // Bugzilla 16108
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct A
     {
@@ -1098,7 +1098,7 @@ private template isSwitchable(E)
 }
 
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isSwitchable!int);
     static assert(!isSwitchable!double);
@@ -1114,7 +1114,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     static T enumRep = toStr!T(value);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
     void dg()
@@ -1158,7 +1158,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assertCTFEable!dg;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // Conversion representing bool value with string
     bool b;
@@ -1167,7 +1167,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(to!string(b) == "true");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // Conversion representing character value with string
     alias AllChars =
@@ -1194,7 +1194,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(s2 == "foo");
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.exception;
     // Conversion representing integer values with string
@@ -1229,13 +1229,13 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     });
 }
 
-@safe unittest // sprintf issue
+version(StdUnittest) @safe unittest // sprintf issue
 {
     double[2] a = [ 1.5, 2.5 ];
     assert(to!string(a) == "[1.5, 2.5]");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Conversion representing class object with string
     class A
@@ -1254,7 +1254,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(to!string(s) == "C");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Conversion representing struct object with string
     struct S1
@@ -1282,7 +1282,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(to!string(s8080) == "<S>");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Conversion representing enum value with string
     enum EB : bool { a = true }
@@ -1306,7 +1306,7 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     assert(to!dstring(o) == "cast(EU)5"d);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum E
     {
@@ -1394,7 +1394,7 @@ do
     }
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     static foreach (Int; AliasSeq!(uint, ulong))
     {
@@ -1451,7 +1451,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     return (ref value)@trusted{ return cast(T) value; }(value);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -1476,7 +1476,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     dchar to4 = to!dchar(from4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
 
@@ -1541,7 +1541,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -1583,7 +1583,7 @@ if (!isImplicitlyConvertible!(S, T) &&
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto b = [ 1.0f, 2, 3 ];
 
@@ -1616,7 +1616,7 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
     return cast(T) result;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // hash to hash conversions
     int[string] a;
@@ -1625,7 +1625,7 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
     auto b = to!(double[dstring])(a);
     assert(b["0"d] == 1 && b["1"d] == 2);
 }
-@safe unittest // Bugzilla 8705, from doc
+version(StdUnittest) @safe unittest // Bugzilla 8705, from doc
 {
     import std.exception;
     int[string][double[int[]]] a;
@@ -1633,7 +1633,7 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
     a = [null:["hello":int.max]];
     assertThrown!ConvOverflowException(to!(short[wstring][string[double[]]])(a));
 }
-@system unittest // Extra cases for AA with qualifiers conversion
+version(StdUnittest) @system unittest // Extra cases for AA with qualifiers conversion
 {
     int[][int[]] a;// = [[], []];
     auto b = to!(immutable(short[])[immutable short[]])(a);
@@ -1642,7 +1642,7 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
     auto d = to!(immutable(short[immutable wstring])[immutable string[double[]]])(c);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.array : byPair;
@@ -1719,7 +1719,7 @@ private void testFloatingToIntegral(Floating, Integral)()
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     alias AllInts = AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong);
     alias AllFloats = AliasSeq!(float, double, real);
@@ -1797,7 +1797,7 @@ private void testFloatingToIntegral(Floating, Integral)()
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias AllInts = AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong);
     alias AllFloats = AliasSeq!(float, double, real);
@@ -1867,14 +1867,14 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S) &&
     return parse!T(value, radix);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // Issue 6668 - ensure no collaterals thrown
     try { to!uint("-1"); }
     catch (ConvException e) { assert(e.next is null); }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static foreach (Str; AliasSeq!(string, wstring, dstring))
     {{
@@ -1889,7 +1889,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S) &&
 }
 
 // bugzilla 15800
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.utf : byCodeUnit, byChar, byWchar, byDchar;
 
@@ -1935,7 +1935,7 @@ if (isSomeChar!T && !is(typeof(parse!T(value))) &&
     return decodedCodepoint[0];
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -1968,7 +1968,7 @@ if (is(T == enum) && !is(S == enum)
     throw new ConvException(convFormat("Value (%s) does not match any member value of enum '%s'", value, T.stringof));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
     enum En8143 : int { A = 10, B = 20, C = 30, D = 20 }
@@ -2001,7 +2001,7 @@ template roundTo(Target)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(roundTo!int(3.14) == 3);
     assert(roundTo!int(3.49) == 3);
@@ -2014,7 +2014,7 @@ template roundTo(Target)
     assert(roundTo!(const int)(to!(const double)(-3.999)) == -4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     // boundary values
@@ -2095,14 +2095,14 @@ Lerr:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = "true";
     bool b = parse!bool(s);
     assert(b);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.exception;
@@ -2255,7 +2255,7 @@ Lerr:
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string s = "123";
     auto a = parse!int(s);
@@ -2266,7 +2266,7 @@ Lerr:
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.string : tr;
     string test = "123 \t  76.14";
@@ -2280,7 +2280,7 @@ Lerr:
     assert(test == "");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
@@ -2374,7 +2374,7 @@ Lerr:
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -2450,7 +2450,7 @@ Lerr:
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     void checkErrMsg(string input, dchar charInMsg, dchar charNotInMsg)
     {
@@ -2480,7 +2480,7 @@ Lerr:
     checkErrMsg("12@$", '@', '$');
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
     assertCTFEable!({ string s =  "1234abc"; assert(parse! int(s) ==  1234 && s == "abc"); });
@@ -2489,7 +2489,7 @@ Lerr:
 }
 
 // Issue 13931
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -2498,7 +2498,7 @@ Lerr:
 }
 
 // Issue 14396
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     struct StrInputRange
     {
@@ -2578,7 +2578,7 @@ do
     return v;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string s; // parse doesn't accept rvalues
     foreach (i; 2 .. 37)
@@ -2598,7 +2598,7 @@ do
     assert(parse!ubyte(s = "ff", 16) == 0xFF);
 }
 
-@safe pure unittest // bugzilla 7302
+version(StdUnittest) @safe pure unittest // bugzilla 7302
 {
     import std.range : cycle;
     auto r = cycle("2A!");
@@ -2607,14 +2607,14 @@ do
     assert(r.front == '!');
 }
 
-@safe pure unittest // bugzilla 13163
+version(StdUnittest) @safe pure unittest // bugzilla 13163
 {
     import std.exception;
     foreach (s; ["fff", "123"])
         assertThrown!ConvOverflowException(s.parse!ubyte(16));
 }
 
-@safe pure unittest // bugzilla 17282
+version(StdUnittest) @safe pure unittest // bugzilla 17282
 {
     auto str = "0=\x00\x02\x55\x40&\xff\xf0\n\x00\x04\x55\x40\xff\xf0~4+10\n";
     assert(parse!uint(str) == 0);
@@ -2664,7 +2664,7 @@ if (isSomeString!Source && !is(Source == enum) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum EnumType : bool { a = true, b = false, c = a }
 
@@ -2672,7 +2672,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     assert(parse!EnumType(str) == EnumType.a);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
 
@@ -2693,7 +2693,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     }
 }
 
-@safe pure unittest // bugzilla 4744
+version(StdUnittest) @safe pure unittest // bugzilla 4744
 {
     enum A { member1, member11, member111 }
     assert(to!A("member1"  ) == A.member1  );
@@ -3233,7 +3233,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
     auto str = "123.456";
@@ -3241,7 +3241,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     assert(parse!double(str).approxEqual(123.456));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     import std.math : isNaN, fabs;
@@ -3327,7 +3327,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 }
 
 // Tests for the double implementation
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system because strtod is not @safe.
     static if (real.mant_dig == 53)
@@ -3400,7 +3400,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.stdc.errno;
     import core.stdc.stdlib;
@@ -3471,7 +3471,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     x1 = *cast(longdouble *)&ld1;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -3542,7 +3542,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static foreach (Str; AliasSeq!(string, wstring, dstring))
     {
@@ -3572,7 +3572,7 @@ if (!isSomeString!Source && isInputRange!Source && isSomeChar!(ElementType!Sourc
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s = "Hello, World!";
     char first = parse!char(s);
@@ -3584,7 +3584,7 @@ if (!isSomeString!Source && isInputRange!Source && isSomeChar!(ElementType!Sourc
 /*
     Tests for to!bool and parse!bool
 */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -3639,7 +3639,7 @@ if (isInputRange!Source &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -3733,7 +3733,7 @@ if (isSomeString!Source && !is(Source == enum) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s1 = `[['h', 'e', 'l', 'l', 'o'], "world"]`;
     auto a1 = parse!(string[])(s1);
@@ -3744,7 +3744,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     assert(a2 == ["aaa", "bbb", "ccc"]);
 }
 
-@safe unittest // Bugzilla 9615
+version(StdUnittest) @safe unittest // Bugzilla 9615
 {
     string s0 = "[1,2, ]";
     string s1 = "[1,2, \t\v\r\n]";
@@ -3765,21 +3765,21 @@ if (isSomeString!Source && !is(Source == enum) &&
     assertThrown!ConvException(parse!(int[])(s6));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [1, 2, 3, 4, 5];
     auto s = to!string(a);
     assert(to!(int[])(s) == a);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][] a = [ [1, 2] , [3], [4, 5] ];
     auto s = to!string(a);
     assert(to!(int[][])(s) == a);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][][] ia = [ [[1,2],[3,4],[5]] , [[6],[],[7,8,9]] , [[]] ];
 
@@ -3790,7 +3790,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     assert( ia == ia2);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -3804,7 +3804,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     int[] arr = parse!(int[])(s);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     //Checks parsing of strings with escaped characters
     string s1 = `[
@@ -3882,7 +3882,7 @@ Lfewerr:
     throw parseError(text("Too few elements in input, ", result.length, " elements expected."));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -3955,7 +3955,7 @@ if (isSomeString!Source && !is(Source == enum) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s1 = "[1:10, 2:20, 3:30]";
     auto aa1 = parse!(int[int])(s1);
@@ -3970,7 +3970,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     assert(aa3 == ["aaa":[1], "bbb":[2,3], "ccc":[4,5,6]]);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -4052,7 +4052,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
     return result;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string[] s1 = [
         `\"`, `\'`, `\?`, `\\`, `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, //Normal escapes
@@ -4077,7 +4077,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -4198,7 +4198,7 @@ dstring dtext(T...)(T args)
 if (T.length > 0) { return textImpl!dstring(args); }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert( text(42, ' ', 1.5, ": xyz") == "42 1.5: xyz"c);
     assert(wtext(42, ' ', 1.5, ": xyz") == "42 1.5: xyz"w);
@@ -4284,7 +4284,7 @@ if (isIntegral!(typeof(decimalInteger)))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // same as 0177
     auto x = octal!177;
@@ -4318,7 +4318,7 @@ private T octal(T)(const string num)
     return value;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a = octal!int("10");
     assert(a == 8);
@@ -4413,7 +4413,7 @@ private bool isOctalLiteral(const string num)
     return true;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // ensure that you get the right types, even with embedded underscores
     auto w = octal!"100_000_000_000";
@@ -4589,7 +4589,7 @@ T* emplace(T)(T* chunk) @safe pure nothrow
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -4601,7 +4601,7 @@ T* emplace(T)(T* chunk) @safe pure nothrow
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface I {}
     class K : I {}
@@ -4635,14 +4635,14 @@ if (is(T == struct) || Args.length == 1)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int a;
     int b = 42;
     assert(*emplace!int(&a, b) == 42);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     shared int i;
     emplace(&i, 42);
@@ -4710,7 +4710,7 @@ if (is(T == class))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     () @safe {
         class SafeClass
@@ -4737,7 +4737,7 @@ if (is(T == class))
     }();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class Outer
     {
@@ -4785,7 +4785,7 @@ if (is(T == class))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class C
     {
@@ -4797,7 +4797,7 @@ if (is(T == class))
     assert(c.i == 5);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Outer
     {
@@ -4813,7 +4813,7 @@ if (is(T == class))
     assert(inner.getI == 3);
 }
 
-@nogc pure nothrow @safe unittest
+version(StdUnittest) @nogc pure nothrow @safe unittest
 {
     int var = 6;
     align(__conv_EmplaceTestClass.alignof) ubyte[__traits(classInstanceSize, __conv_EmplaceTestClass)] buf;
@@ -4848,7 +4848,7 @@ if (!is(T == class))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -4864,7 +4864,7 @@ if (!is(T == class))
 
 // Bulk of emplace unittests starts here
 
-@system unittest /* unions */
+version(StdUnittest) @system unittest /* unions */
 {
     static union U
     {
@@ -4919,7 +4919,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     }
 }
 
-@system unittest // bugzilla 15772
+version(StdUnittest) @system unittest // bugzilla 15772
 {
     abstract class Foo {}
     class Bar: Foo {}
@@ -4932,7 +4932,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     static assert( is(typeof(emplace!Bar(memory))));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S { @disable this(); }
     S s = void;
@@ -4940,7 +4940,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     emplace(&s, S.init);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S1
     {}
@@ -4960,7 +4960,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     emplace(&as2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S1
     {
@@ -4980,7 +4980,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     emplace(&ss2, s2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -4999,7 +4999,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 
 //Start testing emplace-args here
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface I {}
     class K : I {}
@@ -5015,7 +5015,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     assert(i is k);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5031,7 +5031,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 //Start testing emplace-struct here
 
 // Test constructor branch
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -5050,14 +5050,14 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     assert(*emplace!S(cast(S*) s1, 44, 45) == S(44, 45));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     __conv_EmplaceTest k = void;
     emplace(&k, 5);
     assert(k.i == 5);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int var = 6;
     __conv_EmplaceTest k = void;
@@ -5067,7 +5067,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 // Test matching fields branch
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S { uint n; }
     S s;
@@ -5075,14 +5075,14 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     assert(s.n == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S { int a, b; this(int){} }
     S s;
     static assert(!__traits(compiles, emplace!S(&s, 2, 3)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S { int a, b = 7; }
     S s1 = void, s2 = void;
@@ -5095,7 +5095,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //opAssign
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5113,7 +5113,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //postblit precedence
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Works, but breaks in "-w -O" because of @@@9332@@@.
     //Uncomment test when 9332 is fixed.
@@ -5144,7 +5144,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //nested structs and postblit
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5172,7 +5172,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //disabled postblit
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S1
     {
@@ -5219,7 +5219,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //Imutability
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Castable immutability
     {
@@ -5246,7 +5246,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5260,7 +5260,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //Context pointer
-@system unittest
+version(StdUnittest) @system unittest
 {
     int i = 0;
     {
@@ -5289,7 +5289,7 @@ version(StdUnittest) private class __conv_EmplaceTestClass
 }
 
 //Alias this
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5344,7 +5344,7 @@ version(StdUnittest)
         alias foo this;
     }
     static assert(is(__std_conv_SS : __std_conv_S));
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         __std_conv_S s = void;
         __std_conv_SS ss = __std_conv_SS(1);
@@ -5356,7 +5356,7 @@ version(StdUnittest)
 }
 
 //Nested classes
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A{}
     static struct S
@@ -5370,7 +5370,7 @@ version(StdUnittest)
 }
 
 //safety & nothrow & CTFE
-@system unittest
+version(StdUnittest) @system unittest
 {
     //emplace should be safe for anything with no elaborate opassign
     static struct S1
@@ -5427,7 +5427,7 @@ version(StdUnittest)
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -5452,7 +5452,7 @@ version(StdUnittest)
 }
 
 //disable opAssign
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5463,7 +5463,7 @@ version(StdUnittest)
 }
 
 //opCall
-@system unittest
+version(StdUnittest) @system unittest
 {
     int i;
     //Without constructor
@@ -5501,7 +5501,7 @@ version(StdUnittest)
     }
 }
 
-@safe unittest //@@@9559@@@
+version(StdUnittest) @safe unittest //@@@9559@@@
 {
     import std.algorithm.iteration : map;
     import std.array : array;
@@ -5511,7 +5511,7 @@ version(StdUnittest)
     auto asArray = array(ints);
 }
 
-@system unittest //http://forum.dlang.org/post/nxbdgtdlmwscocbiypjs@forum.dlang.org
+version(StdUnittest) @system unittest //http://forum.dlang.org/post/nxbdgtdlmwscocbiypjs@forum.dlang.org
 {
     import std.array : array;
     import std.datetime : SysTime, UTC;
@@ -5552,7 +5552,7 @@ version(StdUnittest)
 }
 
 //static arrays
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -5575,7 +5575,7 @@ version(StdUnittest)
     static assert(!__traits(compiles, emplace(&s, uu)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[2]  sii;
     int[2]  sii2;
@@ -5595,7 +5595,7 @@ version(StdUnittest)
     emplace(&uii, uii2[]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool allowDestruction = false;
     struct S
@@ -5617,7 +5617,7 @@ version(StdUnittest)
     allowDestruction = true;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Checks postblit, construction, and context pointer
     int count = 0;
@@ -5642,7 +5642,7 @@ version(StdUnittest)
     assert(count == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -5653,7 +5653,7 @@ version(StdUnittest)
     emplace(&sss, s);
 }
 
-@system unittest //Constness
+version(StdUnittest) @system unittest //Constness
 {
     import std.stdio;
 
@@ -5679,7 +5679,7 @@ version(StdUnittest)
     emplaceRef!(IS[2])(ss, iss[]);
 }
 
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     int i;
     emplaceRef(i);
@@ -5689,7 +5689,7 @@ pure nothrow @safe @nogc unittest
 }
 
 // Test attribute propagation for UDTs
-pure nothrow @safe /* @nogc */ unittest
+version(StdUnittest) pure nothrow @safe /* @nogc */ unittest
 {
     static struct Safe
     {
@@ -5718,7 +5718,7 @@ pure nothrow @safe /* @nogc */ unittest
     static assert(!__traits(compiles, emplaceRef(uninitializedUnsafeArr, unsafeArr)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Issue 15313
     static struct Node
@@ -5738,7 +5738,7 @@ pure nothrow @safe /* @nogc */ unittest
     assert(n.refs == 10);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int var = 6;
     auto k = emplace!__conv_EmplaceTest(new void[__conv_EmplaceTest.sizeof], 5, var);
@@ -5746,7 +5746,7 @@ pure nothrow @safe /* @nogc */ unittest
     assert(var == 7);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A
     {
@@ -5775,7 +5775,7 @@ pure nothrow @safe /* @nogc */ unittest
 }
 // Bulk of emplace unittests ends here
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -5802,7 +5802,7 @@ if (isIntegral!T && isOutputRange!(W, char))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     auto result = appender!(char[])();
@@ -5827,7 +5827,7 @@ if (isIntegral!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : Unsigned;
     immutable int s = 42;
@@ -5838,7 +5838,7 @@ if (isIntegral!T)
     immutable u3 = unsigned(s); //explicitly qualified
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(byte, ubyte))
     {
@@ -5877,7 +5877,7 @@ if (isSomeChar!T)
     return cast(Unqual!T) x;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(char, wchar, dchar))
     {
@@ -5904,7 +5904,7 @@ if (isIntegral!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : Signed;
 
@@ -5916,7 +5916,7 @@ if (isIntegral!T)
     immutable s3 = signed(u); //explicitly qualified
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static foreach (T; AliasSeq!(byte, ubyte))
     {
@@ -5947,7 +5947,7 @@ if (isIntegral!T)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 10874
     enum Test { a = 0 }
@@ -5966,7 +5966,7 @@ OriginalType!E asOriginalType(E)(E value) if (is(E == enum))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum A { a = 42 }
     static assert(is(typeof(A.a.asOriginalType) == int));
@@ -6017,7 +6017,7 @@ template castFrom(From)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Regular cast, which has been verified to be legal by the programmer:
     {
@@ -6051,7 +6051,7 @@ template castFrom(From)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16667
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] a = ['a', 'b', 'c'];
     assert(castFrom!(ubyte[]).to!(string)(a) == "abc");
@@ -6095,7 +6095,7 @@ private bool isHexLiteral(String)(scope const String hexData)
     return !(i & 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // test all the hex digits
     static assert( ("0123456789abcdefABCDEF").isHexLiteral);
@@ -6105,7 +6105,7 @@ private bool isHexLiteral(String)(scope const String hexData)
     static assert( "A\r\n\tB".isHexLiteral);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii;
     // empty/whites
@@ -6191,7 +6191,7 @@ if (hexData.isHexLiteral)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // conversion at compile time
     auto string1 = hexString!"304A314B";
@@ -6267,7 +6267,7 @@ private auto hexStrLiteral(String)(scope String hexData)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // compile time
     assert(hexString!"46 47 48 49 4A 4B" == "FGHIJK");
@@ -6441,7 +6441,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.range;
@@ -6526,7 +6526,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
     }
 }
 
-@safe unittest // opSlice (issue 16192)
+version(StdUnittest) @safe unittest // opSlice (issue 16192)
 {
     import std.meta : AliasSeq;
 

--- a/std/csv.d
+++ b/std/csv.d
@@ -141,7 +141,7 @@ class CSVException : Exception
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.string;
     auto e1 = new Exception("Foobar");
@@ -179,7 +179,7 @@ class IncompleteCellException : CSVException
     mixin basicExceptionCtors;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto e1 = new Exception("Foobar");
     auto e2 = new IncompleteCellException("args", e1);
@@ -211,7 +211,7 @@ class HeaderMismatchException : CSVException
     mixin basicExceptionCtors;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto e1 = new Exception("Foobar");
     auto e2 = new HeaderMismatchException("args", e1);
@@ -425,7 +425,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test standard iteration over input.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = `one,"two ""quoted"""` ~ "\n\"three\nnew line\",\nfive,six";
     auto records = csvReader(str);
@@ -442,7 +442,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test newline on last record
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = "one,two\nthree,four\n";
     auto records = csvReader(str);
@@ -452,7 +452,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test shorter row length
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     wstring str = "one,1\ntwo\nthree"w;
     struct Layout
@@ -481,7 +481,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test shorter row length exception
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -504,7 +504,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 
 
 // Test structure conversion interface with unicode.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.math : abs;
 
@@ -538,7 +538,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test input conversion interface
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm;
     string str = `76,26,22`;
@@ -552,7 +552,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test struct & header interface and same unicode
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : abs;
 
@@ -587,7 +587,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test header interface
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
 
@@ -633,7 +633,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test null header interface
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string str = "a,b,c\nHello,65,63.63\nWorld,123,3673.562";
     auto records = csvReader(str, ["a"]);
@@ -642,7 +642,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test unchecked read
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = "one \"quoted\"";
     foreach (record; csvReader!(string,Malformed.ignore)(str))
@@ -666,7 +666,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test partial data returned
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = "\"one\nnew line";
 
@@ -683,7 +683,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test Windows line break
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = "one,two\r\nthree";
 
@@ -699,7 +699,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 
 
 // Test associative array support with unicode separator
-@safe unittest
+version(StdUnittest) @safe unittest
 {
   string str = "1❁2❁3\n34❁65❁63\n34❁65❁63";
 
@@ -715,7 +715,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
 }
 
 // Test restricted range
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons;
     struct InputRange
@@ -753,7 +753,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar)
             (ir,cast(string[]) null)) {}
 }
 
-@safe unittest // const/immutable dchars
+version(StdUnittest) @safe unittest // const/immutable dchars
 {
     import std.algorithm.iteration : map;
     import std.array : array;
@@ -1099,7 +1099,7 @@ public:
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1116,7 +1116,7 @@ public:
 
 // Bugzilla 15545
 // @system due to the catch for Throwable
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.exception : assertNotThrown;
     enum failData =
@@ -1464,7 +1464,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     import std.range.primitives : popFront;
@@ -1491,7 +1491,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Test csvNextToken on simplest form and correct format.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
 
@@ -1534,7 +1534,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Test quoted tokens
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
 
@@ -1577,7 +1577,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Test empty data is pulled at end of record.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
 
@@ -1593,7 +1593,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Test exceptions
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
 
@@ -1638,7 +1638,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Test modifying token delimiter
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
 
@@ -1668,7 +1668,7 @@ if (isSomeChar!Separator && isInputRange!Range
 }
 
 // Bugzilla 8908
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string csv = `  1.0, 2.0, 3.0
                     4.0, 5.0, 6.0`;

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -49,7 +49,7 @@ import std.range.primitives : isOutputRange;
 
 version(StdUnittest) import std.exception : assertThrown;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     initializeTests();
 }
@@ -157,7 +157,7 @@ public:
         _tod = tod;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         {
             auto dt = DateTime.init;
@@ -194,7 +194,7 @@ public:
         _tod = TimeOfDay(hour, minute, second);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         {
             auto dt = DateTime(1999, 7 ,6);
@@ -230,7 +230,7 @@ public:
         return _tod.opCmp(rhs._tod);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(DateTime(Date.init, TimeOfDay.init).opCmp(DateTime.init) == 0);
@@ -435,7 +435,7 @@ public:
         return _date;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         {
             auto dt = DateTime.init;
@@ -465,7 +465,7 @@ public:
         _date = date;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime.init;
         dt.date = Date(1999, 7, 6);
@@ -487,7 +487,7 @@ public:
         return _tod;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         {
             auto dt = DateTime.init;
@@ -518,7 +518,7 @@ public:
         _tod = tod;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime.init;
         dt.timeOfDay = TimeOfDay(12, 30, 33);
@@ -541,7 +541,7 @@ public:
         return _date.year;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.init.year == 1);
         assert(Date(1999, 7, 6).year == 1999);
@@ -571,14 +571,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(9, 7, 5)).year == 1999);
         assert(DateTime(Date(2010, 10, 4), TimeOfDay(0, 0, 30)).year == 2010);
         assert(DateTime(Date(-7, 4, 5), TimeOfDay(7, 45, 2)).year == -7);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime dt, int year, in DateTime expected, size_t line = __LINE__)
         {
@@ -615,14 +615,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(0, 1, 1), TimeOfDay(12, 30, 33)).yearBC == 1);
         assert(DateTime(Date(-1, 1, 1), TimeOfDay(10, 7, 2)).yearBC == 2);
         assert(DateTime(Date(-100, 1, 1), TimeOfDay(4, 59, 0)).yearBC == 101);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((in DateTime dt){dt.yearBC;}(DateTime(Date(1, 1, 1))));
 
@@ -652,7 +652,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(2010, 1, 1), TimeOfDay(7, 30, 0));
         dt.yearBC = 1;
@@ -662,7 +662,7 @@ public:
         assert(dt == DateTime(Date(-9, 1, 1), TimeOfDay(7, 30, 0)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((DateTime dt){dt.yearBC = -1;}(DateTime(Date(1, 1, 1))));
 
@@ -685,14 +685,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(9, 7, 5)).month == 7);
         assert(DateTime(Date(2010, 10, 4), TimeOfDay(0, 0, 30)).month == 10);
         assert(DateTime(Date(-7, 4, 5), TimeOfDay(7, 45, 2)).month == 4);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.init.month == 1);
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33)).month == 7);
@@ -720,7 +720,7 @@ public:
         _date.month = month;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime dt, Month month, in DateTime expected = DateTime.init, size_t line = __LINE__)
         {
@@ -755,14 +755,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(9, 7, 5)).day == 6);
         assert(DateTime(Date(2010, 10, 4), TimeOfDay(0, 0, 30)).day == 4);
         assert(DateTime(Date(-7, 4, 5), TimeOfDay(7, 45, 2)).day == 5);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.format : format;
         import std.range : chain;
@@ -803,7 +803,7 @@ public:
         _date.day = day;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : assertNotThrown;
 
@@ -897,7 +897,7 @@ public:
         return _tod.hour;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.init.hour == 0);
         assert(DateTime(Date.init, TimeOfDay(12, 0, 0)).hour == 12);
@@ -924,7 +924,7 @@ public:
         _tod.hour = hour;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){DateTime(Date(1999, 7, 6), TimeOfDay(0, 0, 0)).hour = 24;}());
 
@@ -947,7 +947,7 @@ public:
         return _tod.minute;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.init.minute == 0);
         assert(DateTime(1, 1, 1, 0, 30, 0).minute == 30);
@@ -974,7 +974,7 @@ public:
         _tod.minute = minute;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){DateTime.init.minute = 60;}());
 
@@ -997,7 +997,7 @@ public:
         return _tod.second;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.init.second == 0);
         assert(DateTime(1, 1, 1, 0, 0, 33).second == 33);
@@ -1024,7 +1024,7 @@ public:
         _tod.second = second;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){DateTime.init.second = 60;}());
 
@@ -1067,7 +1067,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt1 = DateTime(2010, 1, 1, 12, 30, 33);
         dt1.add!"months"(11);
@@ -1086,7 +1086,7 @@ public:
         assert(dt4 == DateTime(2001, 2, 28, 12, 30, 33));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(2000, 1, 31);
         dt.add!"years"(7).add!"months"(-4);
@@ -1129,7 +1129,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt1 = DateTime(2010, 1, 1, 12, 33, 33);
         dt1.roll!"months"(1);
@@ -1156,7 +1156,7 @@ public:
         assert(dt6 == DateTime(2001, 2, 28, 12, 30, 33));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(2000, 1, 31);
         dt.roll!"years"(7).roll!"months"(-4);
@@ -1195,7 +1195,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt1 = DateTime(2010, 1, 1, 11, 23, 12);
         dt1.roll!"days"(1);
@@ -1214,7 +1214,7 @@ public:
         assert(dt3 == DateTime(2010, 1, 1, 0, 0, 59));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(2000, 1, 31);
         dt.roll!"days"(7).roll!"days"(-4);
@@ -1238,7 +1238,7 @@ public:
     }
 
     // Test roll!"hours"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime orig, int hours, in DateTime expected, size_t line = __LINE__)
         {
@@ -1541,7 +1541,7 @@ public:
     }
 
     // Test roll!"minutes"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime orig, int minutes, in DateTime expected, size_t line = __LINE__)
         {
@@ -1841,7 +1841,7 @@ public:
     }
 
     // Test roll!"seconds"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime orig, int seconds, in DateTime expected, size_t line = __LINE__)
         {
@@ -2125,7 +2125,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, seconds;
 
@@ -2142,7 +2142,7 @@ public:
                DateTime(2015, 12, 31, 23, 59, 59));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : dur;
 
@@ -2223,7 +2223,7 @@ public:
         mixin(format(`return _addSeconds(convert!("hnsecs", "seconds")(%shnsecs));`, op));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : dur;
         assert(DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33)) + dur!"weeks"(7) ==
@@ -2327,7 +2327,7 @@ public:
         return dur!"hnsecs"(dateResult.total!"hnsecs" + todResult.total!"hnsecs");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(1999, 7, 6, 12, 30, 33);
 
@@ -2410,7 +2410,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(1999, 2, 1, 12, 2, 3).diffMonths(
                    DateTime(1999, 1, 31, 23, 59, 59)) == 1);
@@ -2425,7 +2425,7 @@ public:
                    DateTime(1999, 3, 31, 0, 30, 58)) == -2);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2452,7 +2452,7 @@ public:
         return _date.isLeapYear;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2471,7 +2471,7 @@ public:
         return _date.dayOfWeek;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2491,14 +2491,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 1, 1), TimeOfDay(12, 22, 7)).dayOfYear == 1);
         assert(DateTime(Date(1999, 12, 31), TimeOfDay(7, 2, 59)).dayOfYear == 365);
         assert(DateTime(Date(2000, 12, 31), TimeOfDay(21, 20, 0)).dayOfYear == 366);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2521,7 +2521,7 @@ public:
         _date.dayOfYear = day;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2542,7 +2542,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1, 1, 1), TimeOfDay(0, 0, 0)).dayOfGregorianCal == 1);
         assert(DateTime(Date(1, 12, 31), TimeOfDay(23, 59, 59)).dayOfGregorianCal == 365);
@@ -2556,7 +2556,7 @@ public:
         assert(DateTime(Date(2010, 12, 31), TimeOfDay(15, 45, 50)).dayOfGregorianCal == 734_137);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2580,7 +2580,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date.init, TimeOfDay(12, 0, 0));
         dt.dayOfGregorianCal = 1;
@@ -2608,7 +2608,7 @@ public:
         assert(dt == DateTime(Date(2010, 12, 31), TimeOfDay(12, 0, 0)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2628,7 +2628,7 @@ public:
         return _date.isoWeek;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2653,7 +2653,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 1, 6), TimeOfDay(0, 0, 0)).endOfMonth ==
                DateTime(Date(1999, 1, 31), TimeOfDay(23, 59, 59)));
@@ -2668,7 +2668,7 @@ public:
                DateTime(Date(2000, 6, 30), TimeOfDay(23, 59, 59)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(DateTime(1999, 1, 1, 0, 13, 26).endOfMonth == DateTime(1999, 1, 31, 23, 59, 59));
@@ -2716,7 +2716,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1999, 1, 6), TimeOfDay(0, 0, 0)).daysInMonth == 31);
         assert(DateTime(Date(1999, 2, 7), TimeOfDay(19, 30, 0)).daysInMonth == 28);
@@ -2724,7 +2724,7 @@ public:
         assert(DateTime(Date(2000, 6, 4), TimeOfDay(12, 22, 9)).daysInMonth == 30);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2742,7 +2742,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1, 1, 1), TimeOfDay(12, 7, 0)).isAD);
         assert(DateTime(Date(2010, 12, 31), TimeOfDay(0, 0, 0)).isAD);
@@ -2750,7 +2750,7 @@ public:
         assert(!DateTime(Date(-2010, 1, 1), TimeOfDay(2, 2, 2)).isAD);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -2774,7 +2774,7 @@ public:
             return _date.julianDay;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(-4713, 11, 24), TimeOfDay(0, 0, 0)).julianDay == -1);
         assert(DateTime(Date(-4713, 11, 24), TimeOfDay(12, 0, 0)).julianDay == 0);
@@ -2816,7 +2816,7 @@ public:
         return _date.modJulianDay;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(1858, 11, 17), TimeOfDay(0, 0, 0)).modJulianDay == 0);
         assert(DateTime(Date(1858, 11, 17), TimeOfDay(12, 0, 0)).modJulianDay == 0);
@@ -2868,7 +2868,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)).toISOString() ==
                "20100704T070612");
@@ -2883,7 +2883,7 @@ public:
                "-00040105T000002");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(DateTime(Date(9, 12, 4), TimeOfDay(0, 0, 0)).toISOString() == "00091204T000000");
@@ -2945,7 +2945,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)).toISOExtString() ==
                "2010-07-04T07:06:12");
@@ -2960,7 +2960,7 @@ public:
                "-0004-01-05T00:00:02");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(DateTime(Date(9, 12, 4), TimeOfDay(0, 0, 0)).toISOExtString() == "0009-12-04T00:00:00");
@@ -3021,7 +3021,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)).toSimpleString() ==
                "2010-Jul-04 07:06:12");
@@ -3036,7 +3036,7 @@ public:
                "-0004-Jan-05 00:00:02");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(DateTime(Date(9, 12, 4), TimeOfDay(0, 0, 0)).toSimpleString() == "0009-Dec-04 00:00:00");
@@ -3088,7 +3088,7 @@ public:
         return toSimpleString();
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
@@ -3140,7 +3140,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.fromISOString("20100704T070612") ==
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
@@ -3158,7 +3158,7 @@ public:
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(DateTime.fromISOString(""));
         assertThrown!DateTimeException(DateTime.fromISOString("20100704000000"));
@@ -3193,7 +3193,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -3241,7 +3241,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.fromISOExtString("2010-07-04T07:06:12") ==
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
@@ -3259,7 +3259,7 @@ public:
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(DateTime.fromISOExtString(""));
         assertThrown!DateTimeException(DateTime.fromISOExtString("20100704000000"));
@@ -3293,7 +3293,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -3341,7 +3341,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.fromSimpleString("2010-Jul-04 07:06:12") ==
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
@@ -3355,7 +3355,7 @@ public:
                DateTime(Date(2010, 7, 4), TimeOfDay(7, 6, 12)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(DateTime.fromISOString(""));
         assertThrown!DateTimeException(DateTime.fromISOString("20100704000000"));
@@ -3397,7 +3397,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -3429,7 +3429,7 @@ public:
         return dt;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.min.year < 0);
         assert(DateTime.min < DateTime.max);
@@ -3459,7 +3459,7 @@ public:
         return dt;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(DateTime.max.year > 0);
         assert(DateTime.max > DateTime.min);
@@ -3506,7 +3506,7 @@ private:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDT(DateTime orig, int seconds, in DateTime expected, size_t line = __LINE__)
         {
@@ -3725,7 +3725,7 @@ public:
         _day   = cast(ubyte) day;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : assertNotThrown;
         assert(Date(1, 1, 1) == Date.init);
@@ -3905,7 +3905,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -3945,7 +3945,7 @@ public:
         return 0;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(1, 1, 1).opCmp(Date.init) == 0);
@@ -4039,14 +4039,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 7, 6).year == 1999);
         assert(Date(2010, 10, 4).year == 2010);
         assert(Date(-7, 4, 5).year == -7);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.init.year == 1);
         assert(Date(1999, 7, 6).year == 1999);
@@ -4076,14 +4076,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 7, 6).year == 1999);
         assert(Date(2010, 10, 4).year == 2010);
         assert(Date(-7, 4, 5).year == -7);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDateInvalid(Date date, int year)
         {
@@ -4125,14 +4125,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(0, 1, 1).yearBC == 1);
         assert(Date(-1, 1, 1).yearBC == 2);
         assert(Date(-100, 1, 1).yearBC == 101);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((in Date date){date.yearBC;}(Date(1, 1, 1)));
 
@@ -4163,7 +4163,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(2010, 1, 1);
         date.yearBC = 1;
@@ -4173,7 +4173,7 @@ public:
         assert(date == Date(-9, 1, 1));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((Date date){date.yearBC = -1;}(Date(1, 1, 1)));
 
@@ -4196,14 +4196,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 7, 6).month == 7);
         assert(Date(2010, 10, 4).month == 10);
         assert(Date(-7, 4, 5).month == 4);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.init.month == 1);
         assert(Date(1999, 7, 6).month == 7);
@@ -4233,7 +4233,7 @@ public:
         _month = cast(Month) month;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testDate(Date date, Month month, in Date expected = Date.init)
         {
@@ -4266,14 +4266,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 7, 6).day == 6);
         assert(Date(2010, 10, 4).day == 4);
         assert(Date(-7, 4, 5).day == 5);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.format : format;
         import std.range : chain;
@@ -4311,7 +4311,7 @@ public:
         _day = cast(ubyte) day;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : assertNotThrown;
 
@@ -4439,7 +4439,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto d1 = Date(2010, 1, 1);
         d1.add!"months"(11);
@@ -4459,7 +4459,7 @@ public:
     }
 
     // Test add!"years"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -4561,7 +4561,7 @@ public:
     }
 
     // Test add!"years"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -4702,7 +4702,7 @@ public:
     }
 
     // Test add!"months"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -4944,7 +4944,7 @@ public:
     }
 
     // Test add!"months"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -5208,7 +5208,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto d1 = Date(2010, 1, 1);
         d1.roll!"months"(1);
@@ -5235,7 +5235,7 @@ public:
         assert(d6 == Date(2001, 2, 28));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
@@ -5283,7 +5283,7 @@ public:
     }
 
     // Test roll!"months"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -5557,7 +5557,7 @@ public:
     }
 
     // Test roll!"months"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -5860,7 +5860,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto d = Date(2010, 1, 1);
         d.roll!"days"(1);
@@ -5871,7 +5871,7 @@ public:
         assert(d == Date(2010, 1, 25));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -6087,7 +6087,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : days;
 
@@ -6098,7 +6098,7 @@ public:
         assert(Date(2004, 3, 1) - days(4) == Date(2004, 2, 26));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
 
@@ -6175,7 +6175,7 @@ public:
         mixin("return _addDays(" ~ op ~ "days);");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : dur;
         assert(Date(1999, 7, 6) + dur!"weeks"(7) == Date(1999, 8, 24));
@@ -6250,7 +6250,7 @@ public:
         return dur!"days"(this.dayOfGregorianCal - rhs.dayOfGregorianCal);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
 
@@ -6308,7 +6308,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 2, 1).diffMonths(Date(1999, 1, 31)) == 1);
         assert(Date(1999, 1, 31).diffMonths(Date(1999, 2, 1)) == -1);
@@ -6316,7 +6316,7 @@ public:
         assert(Date(1999, 1, 1).diffMonths(Date(1999, 3, 31)) == -2);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
 
@@ -6542,7 +6542,7 @@ public:
         return yearIsLeapYear(_year);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
@@ -6561,7 +6561,7 @@ public:
         return getDayOfWeek(dayOfGregorianCal);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
@@ -6588,14 +6588,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 1, 1).dayOfYear == 1);
         assert(Date(1999, 12, 31).dayOfYear == 365);
         assert(Date(2000, 12, 31).dayOfYear == 366);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.iteration : filter;
         import std.range : chain;
@@ -6662,7 +6662,7 @@ public:
         assert(0, "Invalid day of the year.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void test(Date date, int day, MonthDay expected, size_t line = __LINE__)
         {
@@ -6747,7 +6747,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1, 1, 1).dayOfGregorianCal == 1);
         assert(Date(1, 12, 31).dayOfGregorianCal == 365);
@@ -6761,7 +6761,7 @@ public:
         assert(Date(2010, 12, 31).dayOfGregorianCal == 734_137);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -6788,7 +6788,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date.init;
         date.dayOfGregorianCal = 1;
@@ -6816,7 +6816,7 @@ public:
         assert(date == Date(2010, 12, 31));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
@@ -6868,7 +6868,7 @@ public:
             assert(0, "Date's constructor threw.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(2009, 12, 28).isoWeek == 53);
@@ -6942,7 +6942,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 1, 6).endOfMonth == Date(1999, 1, 31));
         assert(Date(1999, 2, 7).endOfMonth == Date(1999, 2, 28));
@@ -6950,7 +6950,7 @@ public:
         assert(Date(2000, 6, 4).endOfMonth == Date(2000, 6, 30));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(1999, 1, 1).endOfMonth == Date(1999, 1, 31));
@@ -6998,7 +6998,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1999, 1, 6).daysInMonth == 31);
         assert(Date(1999, 2, 7).daysInMonth == 28);
@@ -7006,7 +7006,7 @@ public:
         assert(Date(2000, 6, 4).daysInMonth == 30);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(1999, 1, 1).daysInMonth == 31);
@@ -7054,7 +7054,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1, 1, 1).isAD);
         assert(Date(2010, 12, 31).isAD);
@@ -7062,7 +7062,7 @@ public:
         assert(!Date(-2010, 1, 1).isAD);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(2010, 7, 4).isAD);
         assert(Date(1, 1, 1).isAD);
@@ -7086,7 +7086,7 @@ public:
         return dayOfGregorianCal + 1_721_425;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(-4713, 11, 24).julianDay == 0);
         assert(Date(0, 12, 31).julianDay == 1_721_425);
@@ -7114,7 +7114,7 @@ public:
         return julianDay - 2_400_001;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(1858, 11, 17).modJulianDay == 0);
         assert(Date(2010, 8, 24).modJulianDay == 55_432);
@@ -7149,7 +7149,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(2010, 7, 4).toISOString() == "20100704");
         assert(Date(1998, 12, 25).toISOString() == "19981225");
@@ -7157,7 +7157,7 @@ public:
         assert(Date(-4, 1, 5).toISOString() == "-00040105");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(9, 12, 4).toISOString() == "00091204");
@@ -7198,7 +7198,7 @@ public:
             formattedWrite(writer, "%06d%02d%02d", _year, _month, _day);
     }
 
-    @safe pure unittest
+    version(StdUnittest) @safe pure unittest
     {
         import std.array : appender;
 
@@ -7233,7 +7233,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(2010, 7, 4).toISOExtString() == "2010-07-04");
         assert(Date(1998, 12, 25).toISOExtString() == "1998-12-25");
@@ -7241,7 +7241,7 @@ public:
         assert(Date(-4, 1, 5).toISOExtString() == "-0004-01-05");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(9, 12, 4).toISOExtString() == "0009-12-04");
@@ -7282,7 +7282,7 @@ public:
             formattedWrite(writer, "%06d-%02d-%02d", _year, _month, _day);
     }
 
-    @safe pure unittest
+    version(StdUnittest) @safe pure unittest
     {
         import std.array : appender;
 
@@ -7317,7 +7317,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date(2010, 7, 4).toSimpleString() == "2010-Jul-04");
         assert(Date(1998, 12, 25).toSimpleString() == "1998-Dec-25");
@@ -7325,7 +7325,7 @@ public:
         assert(Date(-4, 1, 5).toSimpleString() == "-0004-Jan-05");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         assert(Date(9, 12, 4).toSimpleString() == "0009-Dec-04");
@@ -7366,7 +7366,7 @@ public:
             formattedWrite(writer, "%06d-%s-%02d", _year, monthToString(_month), _day);
     }
 
-    @safe pure unittest
+    version(StdUnittest) @safe pure unittest
     {
         import std.array : appender;
 
@@ -7406,7 +7406,7 @@ public:
         return toSimpleString();
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
@@ -7477,7 +7477,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.fromISOString("20100704") == Date(2010, 7, 4));
         assert(Date.fromISOString("19981225") == Date(1998, 12, 25));
@@ -7486,7 +7486,7 @@ public:
         assert(Date.fromISOString(" 20100704 ") == Date(2010, 7, 4));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(Date.fromISOString(""));
         assertThrown!DateTimeException(Date.fromISOString("990704"));
@@ -7553,7 +7553,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -7615,7 +7615,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.fromISOExtString("2010-07-04") == Date(2010, 7, 4));
         assert(Date.fromISOExtString("1998-12-25") == Date(1998, 12, 25));
@@ -7624,7 +7624,7 @@ public:
         assert(Date.fromISOExtString(" 2010-07-04 ") == Date(2010, 7, 4));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(Date.fromISOExtString(""));
         assertThrown!DateTimeException(Date.fromISOExtString("990704"));
@@ -7691,7 +7691,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -7753,7 +7753,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.fromSimpleString("2010-Jul-04") == Date(2010, 7, 4));
         assert(Date.fromSimpleString("1998-Dec-25") == Date(1998, 12, 25));
@@ -7762,7 +7762,7 @@ public:
         assert(Date.fromSimpleString(" 2010-Jul-04 ") == Date(2010, 7, 4));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(Date.fromSimpleString(""));
         assertThrown!DateTimeException(Date.fromSimpleString("990704"));
@@ -7829,7 +7829,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -7855,7 +7855,7 @@ public:
         return date;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.min.year < 0);
         assert(Date.min < Date.max);
@@ -7876,7 +7876,7 @@ public:
         return date;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(Date.max.year > 0);
         assert(Date.max > Date.min);
@@ -7925,7 +7925,7 @@ package:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test A.D.
         {
@@ -8128,7 +8128,7 @@ public:
         _second = cast(ubyte) second;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay(0, 0) == TimeOfDay.init);
 
@@ -8189,7 +8189,7 @@ public:
         return 0;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay(0, 0, 0).opCmp(TimeOfDay.init) == 0);
 
@@ -8234,7 +8234,7 @@ public:
         return _hour;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.init.hour == 0);
         assert(TimeOfDay(12, 0, 0).hour == 12);
@@ -8262,7 +8262,7 @@ public:
         _hour = cast(ubyte) hour;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){TimeOfDay(0, 0, 0).hour = 24;}());
 
@@ -8285,7 +8285,7 @@ public:
         return _minute;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.init.minute == 0);
         assert(TimeOfDay(0, 30, 0).minute == 30);
@@ -8313,7 +8313,7 @@ public:
         _minute = cast(ubyte) minute;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){TimeOfDay(0, 0, 0).minute = 60;}());
 
@@ -8336,7 +8336,7 @@ public:
         return _second;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.init.second == 0);
         assert(TimeOfDay(0, 0, 33).second == 33);
@@ -8364,7 +8364,7 @@ public:
         _second = cast(ubyte) second;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException((){TimeOfDay(0, 0, 0).second = 60;}());
 
@@ -8403,7 +8403,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod1 = TimeOfDay(7, 12, 0);
         tod1.roll!"hours"(1);
@@ -8430,7 +8430,7 @@ public:
         assert(tod6 == TimeOfDay(0, 0, 59));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 27, 2);
         tod.roll!"hours"(22).roll!"hours"(-7);
@@ -8466,7 +8466,7 @@ public:
     }
 
     // Test roll!"minutes"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testTOD(TimeOfDay orig, int minutes, in TimeOfDay expected, size_t line = __LINE__)
         {
@@ -8550,7 +8550,7 @@ public:
     }
 
     // Test roll!"seconds"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testTOD(TimeOfDay orig, int seconds, in TimeOfDay expected, size_t line = __LINE__)
         {
@@ -8649,7 +8649,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, minutes, seconds;
 
@@ -8664,7 +8664,7 @@ public:
         assert(TimeOfDay(0, 0, 0) - seconds(1) == TimeOfDay(23, 59, 59));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 30, 33);
 
@@ -8734,7 +8734,7 @@ public:
         mixin("return _addSeconds(" ~ op ~ "seconds);");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : dur;
         auto duration = dur!"hours"(12);
@@ -8803,7 +8803,7 @@ public:
         return dur!"seconds"(lhsSec - rhsSec);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 30, 33);
 
@@ -8863,13 +8863,13 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay(0, 0, 0).toISOString() == "000000");
         assert(TimeOfDay(12, 30, 33).toISOString() == "123033");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
@@ -8910,13 +8910,13 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay(0, 0, 0).toISOExtString() == "00:00:00");
         assert(TimeOfDay(12, 30, 33).toISOExtString() == "12:30:33");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
@@ -8967,7 +8967,7 @@ public:
         toISOExtString(writer);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
@@ -9019,14 +9019,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.fromISOString("000000") == TimeOfDay(0, 0, 0));
         assert(TimeOfDay.fromISOString("123033") == TimeOfDay(12, 30, 33));
         assert(TimeOfDay.fromISOString(" 123033 ") == TimeOfDay(12, 30, 33));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(TimeOfDay.fromISOString(""));
         assertThrown!DateTimeException(TimeOfDay.fromISOString("0"));
@@ -9090,7 +9090,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -9144,14 +9144,14 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.fromISOExtString("00:00:00") == TimeOfDay(0, 0, 0));
         assert(TimeOfDay.fromISOExtString("12:30:33") == TimeOfDay(12, 30, 33));
         assert(TimeOfDay.fromISOExtString(" 12:30:33 ") == TimeOfDay(12, 30, 33));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assertThrown!DateTimeException(TimeOfDay.fromISOExtString(""));
         assertThrown!DateTimeException(TimeOfDay.fromISOExtString("0"));
@@ -9215,7 +9215,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -9235,7 +9235,7 @@ public:
         return TimeOfDay.init;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.min.hour == 0);
         assert(TimeOfDay.min.minute == 0);
@@ -9257,7 +9257,7 @@ public:
         return tod;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(TimeOfDay.max.hour == 23);
         assert(TimeOfDay.max.minute == 59);
@@ -9303,7 +9303,7 @@ private:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void testTOD(TimeOfDay orig, int seconds, in TimeOfDay expected, size_t line = __LINE__)
         {
@@ -9435,7 +9435,7 @@ if (units == "months" ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(valid!"hours"(12));
     assert(!valid!"hours"(32));
@@ -9459,7 +9459,7 @@ if (units == "days")
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(valid!"days"(2016, 2, 29));
     assert(!valid!"days"(2016, 2, 30));
@@ -9551,14 +9551,14 @@ int daysToDayOfWeek(DayOfWeek currDoW, DayOfWeek dow) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(daysToDayOfWeek(DayOfWeek.mon, DayOfWeek.mon) == 0);
     assert(daysToDayOfWeek(DayOfWeek.mon, DayOfWeek.sun) == 6);
     assert(daysToDayOfWeek(DayOfWeek.mon, DayOfWeek.wed) == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(daysToDayOfWeek(DayOfWeek.sun, DayOfWeek.sun) == 0);
     assert(daysToDayOfWeek(DayOfWeek.sun, DayOfWeek.mon) == 1);
@@ -9639,14 +9639,14 @@ int monthsToMonth(int currMonth, int month) @safe pure
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(monthsToMonth(Month.jan, Month.jan) == 0);
     assert(monthsToMonth(Month.jan, Month.dec) == 11);
     assert(monthsToMonth(Month.jul, Month.oct) == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(monthsToMonth(Month.jan, Month.jan) == 0);
     assert(monthsToMonth(Month.jan, Month.feb) == 1);
@@ -9718,7 +9718,7 @@ bool yearIsLeapYear(int year) @safe pure nothrow @nogc
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (year; [1, 2, 100, 2001, 2002, 2003, 2005, 2006, 2007, 2009, 2010])
     {
@@ -9733,7 +9733,7 @@ bool yearIsLeapYear(int year) @safe pure nothrow @nogc
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
     foreach (year; [1, 2, 3, 5, 6, 7, 100, 200, 300, 500, 600, 700, 1998, 1999,
@@ -9812,7 +9812,7 @@ private:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.time : Duration;
     import std.datetime.interval : Interval;
@@ -9828,7 +9828,7 @@ private:
     static assert(!isTimePoint!(Interval!SysTime));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.time;
     import std.datetime.interval;
@@ -9865,7 +9865,7 @@ bool validTimeUnits(string[] units...) @safe pure nothrow @nogc
 }
 
 ///
-@safe @nogc nothrow unittest
+version(StdUnittest) @safe @nogc nothrow unittest
 {
     assert(validTimeUnits("msecs", "seconds", "minutes"));
     assert(validTimeUnits("days", "weeks", "months"));
@@ -9909,7 +9909,7 @@ int cmpTimeUnits(string lhs, string rhs) @safe pure
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -9920,7 +9920,7 @@ int cmpTimeUnits(string lhs, string rhs) @safe pure
     assertThrown!DateTimeException(cmpTimeUnits("month", "second"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (i, outerUnits; timeStrings)
     {
@@ -9978,7 +9978,7 @@ private int cmpTimeUnitsCTFE(string lhs, string rhs) @safe pure nothrow @nogc
     return 0;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (i; 0 .. timeStrings.length)
     {
@@ -10039,7 +10039,7 @@ do
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test A.D.
     assert(maxDay(1999, 1) == 31);
@@ -10118,7 +10118,7 @@ if (validTimeUnits(units) && CmpTimeUnits!(units, "months") < 0)
     return value;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto hnsecs = 2595000000007L;
     immutable days = splitUnitsFromHNSecs!"days"(hnsecs);
@@ -10154,7 +10154,7 @@ DayOfWeek getDayOfWeek(int day) @safe pure nothrow @nogc
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.systime : SysTime;
 
@@ -10224,7 +10224,7 @@ string monthToString(Month month) @safe pure
     return _monthNames[month - Month.jan];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(monthToString(Month.jan) == "Jan");
     assert(monthToString(Month.feb) == "Feb");
@@ -10286,7 +10286,7 @@ if (isSomeString!T)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.stdio : writeln;
     import std.traits : EnumMembers;

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -1613,7 +1613,7 @@ private:
 }
 
 // Test Interval's constructors.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -1642,7 +1642,7 @@ private:
 }
 
 // Test Interval's begin.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1660,7 +1660,7 @@ private:
 }
 
 // Test Interval's end.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1678,7 +1678,7 @@ private:
 }
 
 // Test Interval's length.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -1701,7 +1701,7 @@ private:
 }
 
 // Test Interval's empty.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -1723,7 +1723,7 @@ private:
 }
 
 // Test Interval's contains(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1755,7 +1755,7 @@ private:
 }
 
 // Test Interval's contains(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1857,7 +1857,7 @@ private:
 }
 
 // Test Interval's isBefore(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1889,7 +1889,7 @@ private:
 }
 
 // Test Interval's isBefore(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -1992,7 +1992,7 @@ private:
 }
 
 // Test Interval's isAfter(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2024,7 +2024,7 @@ private:
 }
 
 // Test Interval's isAfter(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2126,7 +2126,7 @@ private:
 }
 
 // Test Interval's intersects().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2230,7 +2230,7 @@ private:
 }
 
 // Test Interval's intersection().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2370,7 +2370,7 @@ private:
 }
 
 // Test Interval's isAdjacent().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2479,7 +2479,7 @@ private:
 }
 
 // Test Interval's merge().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2624,7 +2624,7 @@ private:
 }
 
 // Test Interval's span().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2759,7 +2759,7 @@ private:
 }
 
 // Test Interval's shift(duration).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2798,7 +2798,7 @@ private:
 }
 
 // Test Interval's shift(int, int, AllowDayOverflow).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2852,7 +2852,7 @@ private:
 }
 
 // Test Interval's expand(Duration).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -2892,7 +2892,7 @@ private:
 }
 
 // Test Interval's expand(int, int, AllowDayOverflow, Direction)
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -3003,7 +3003,7 @@ private:
 }
 
 // Test Interval's fwdRange.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -3071,7 +3071,7 @@ private:
 }
 
 // Test Interval's bwdRange.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -3139,7 +3139,7 @@ private:
 }
 
 // Test Interval's toString().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4178,7 +4178,7 @@ private:
 }
 
 //Test PosInfInterval's constructor.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -4193,7 +4193,7 @@ private:
 }
 
 //Test PosInfInterval's begin.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4211,7 +4211,7 @@ private:
 }
 
 //Test PosInfInterval's empty.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -4231,7 +4231,7 @@ private:
 }
 
 //Test PosInfInterval's contains(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4260,7 +4260,7 @@ private:
 }
 
 //Test PosInfInterval's contains(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4356,7 +4356,7 @@ private:
 }
 
 //Test PosInfInterval's isBefore(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4385,7 +4385,7 @@ private:
 }
 
 //Test PosInfInterval's isBefore(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4480,7 +4480,7 @@ private:
 }
 
 //Test PosInfInterval's isAfter(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4509,7 +4509,7 @@ private:
 }
 
 //Test PosInfInterval's isAfter(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4606,7 +4606,7 @@ private:
 }
 
 //Test PosInfInterval's intersects().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4703,7 +4703,7 @@ private:
 }
 
 //Test PosInfInterval's intersection().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4821,7 +4821,7 @@ private:
 }
 
 //Test PosInfInterval's isAdjacent().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -4917,7 +4917,7 @@ private:
 }
 
 //Test PosInfInterval's merge().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5026,7 +5026,7 @@ private:
 }
 
 //Test PosInfInterval's span().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5137,7 +5137,7 @@ private:
 }
 
 //Test PosInfInterval's shift().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5169,7 +5169,7 @@ private:
 }
 
 //Test PosInfInterval's shift(int, int, AllowDayOverflow).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5216,7 +5216,7 @@ private:
 }
 
 //Test PosInfInterval's expand().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5248,7 +5248,7 @@ private:
 }
 
 //Test PosInfInterval's expand(int, int, AllowDayOverflow).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -5295,7 +5295,7 @@ private:
 }
 
 //Test PosInfInterval's fwdRange().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -5348,7 +5348,7 @@ private:
 }
 
 //Test PosInfInterval's toString().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     assert(PosInfInterval!Date(Date(2010, 7, 4)).toString() == "[2010-Jul-04 - ∞)");
@@ -6400,7 +6400,7 @@ private:
 }
 
 //Test NegInfInterval's constructor.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -6412,7 +6412,7 @@ private:
 }
 
 //Test NegInfInterval's end.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6430,7 +6430,7 @@ private:
 }
 
 //Test NegInfInterval's empty.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -6450,7 +6450,7 @@ private:
 }
 
 //Test NegInfInterval's contains(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6480,7 +6480,7 @@ private:
 }
 
 //Test NegInfInterval's contains(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6576,7 +6576,7 @@ private:
 }
 
 //Test NegInfInterval's isBefore(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6606,7 +6606,7 @@ private:
 }
 
 //Test NegInfInterval's isBefore(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6703,7 +6703,7 @@ private:
 }
 
 //Test NegInfInterval's isAfter(time point).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6728,7 +6728,7 @@ private:
 }
 
 //Test NegInfInterval's isAfter(Interval).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6829,7 +6829,7 @@ private:
 }
 
 //Test NegInfInterval's intersects().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -6926,7 +6926,7 @@ private:
 }
 
 //Test NegInfInterval's intersection().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7044,7 +7044,7 @@ private:
 }
 
 //Test NegInfInterval's isAdjacent().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7142,7 +7142,7 @@ private:
 }
 
 //Test NegInfInterval's merge().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7251,7 +7251,7 @@ private:
 }
 
 //Test NegInfInterval's span().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7362,7 +7362,7 @@ private:
 }
 
 //Test NegInfInterval's shift().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7394,7 +7394,7 @@ private:
 }
 
 //Test NegInfInterval's shift(int, int, AllowDayOverflow).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7446,7 +7446,7 @@ private:
 }
 
 //Test NegInfInterval's expand().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7478,7 +7478,7 @@ private:
 }
 
 //Test NegInfInterval's expand(int, int, AllowDayOverflow).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7525,7 +7525,7 @@ private:
 }
 
 //Test NegInfInterval's bwdRange().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -7579,7 +7579,7 @@ private:
 }
 
 //Test NegInfInterval's toString().
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
 
@@ -7633,7 +7633,7 @@ if (isTimePoint!TP &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date : Date, DayOfWeek;
 
@@ -7657,7 +7657,7 @@ if (isTimePoint!TP &&
     assert(range.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -7755,7 +7755,7 @@ if (isTimePoint!TP &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date : Date, Month;
 
@@ -7785,7 +7785,7 @@ if (isTimePoint!TP &&
     assert(range.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -7866,7 +7866,7 @@ if (isTimePoint!TP &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.time : dur;
     import std.datetime.date : Date;
@@ -7891,7 +7891,7 @@ if (isTimePoint!TP &&
     assert(range.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -7991,7 +7991,7 @@ if (isTimePoint!TP &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.time : dur;
     import std.datetime.date : AllowDayOverflow, Date;
@@ -8016,7 +8016,7 @@ if (isTimePoint!TP &&
     assert(range.empty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -8299,7 +8299,7 @@ private:
 }
 
 //Test that IntervalRange satisfies the range predicates that it's supposed to satisfy.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -8326,7 +8326,7 @@ private:
 }
 
 //Test construction of IntervalRange.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -8358,7 +8358,7 @@ private:
 }
 
 //Test IntervalRange's empty().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8396,7 +8396,7 @@ private:
 }
 
 //Test IntervalRange's front.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8438,7 +8438,7 @@ private:
 }
 
 //Test IntervalRange's popFront().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.range.primitives : walkLength;
@@ -8490,7 +8490,7 @@ private:
 }
 
 //Test IntervalRange's save.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8514,7 +8514,7 @@ private:
 }
 
 //Test IntervalRange's interval.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8544,7 +8544,7 @@ private:
 }
 
 //Test IntervalRange's func.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8568,7 +8568,7 @@ private:
 }
 
 //Test IntervalRange's direction.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8743,7 +8743,7 @@ private:
 }
 
 //Test that PosInfIntervalRange satisfies the range predicates that it's supposed to satisfy.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -8769,7 +8769,7 @@ private:
 }
 
 //Test construction of PosInfIntervalRange.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -8800,7 +8800,7 @@ private:
 }
 
 //Test PosInfIntervalRange's front.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8815,7 +8815,7 @@ private:
 }
 
 //Test PosInfIntervalRange's popFront().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.range : take;
@@ -8834,7 +8834,7 @@ private:
 }
 
 //Test PosInfIntervalRange's save.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8846,7 +8846,7 @@ private:
 }
 
 //Test PosInfIntervalRange's interval.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -8861,7 +8861,7 @@ private:
 }
 
 //Test PosInfIntervalRange's func.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -9027,7 +9027,7 @@ private:
 }
 
 //Test that NegInfIntervalRange satisfies the range predicates that it's supposed to satisfy.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.range.primitives;
@@ -9051,7 +9051,7 @@ private:
 }
 
 //Test construction of NegInfIntervalRange.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date;
     import std.datetime.systime;
@@ -9082,7 +9082,7 @@ private:
 }
 
 //Test NegInfIntervalRange's front.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -9098,7 +9098,7 @@ private:
 }
 
 //Test NegInfIntervalRange's popFront().
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
     import std.range : take;
@@ -9118,7 +9118,7 @@ private:
 }
 
 //Test NegInfIntervalRange's save.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -9130,7 +9130,7 @@ private:
 }
 
 //Test NegInfIntervalRange's interval.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 
@@ -9145,7 +9145,7 @@ private:
 }
 
 //Test NegInfIntervalRange's func.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.datetime.date;
 

--- a/std/datetime/package.d
+++ b/std/datetime/package.d
@@ -122,7 +122,7 @@ import std.typecons : Flag, Yes, No;
 
 
 // Verify module example.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto currentTime = Clock.currTime();
     auto timeString = currentTime.toISOExtString();
@@ -130,7 +130,7 @@ import std.typecons : Flag, Yes, No;
 }
 
 // Verify Examples for core.time.Duration which couldn't be in core.time.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(std.datetime.Date(2010, 9, 7) + dur!"days"(5) ==
            std.datetime.Date(2010, 9, 12));
@@ -139,7 +139,7 @@ import std.typecons : Flag, Yes, No;
            dur!"days"(-26));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : hasUnsharedAliasing;
     /* Issue 6642 */
@@ -207,7 +207,7 @@ public:
             start();
     }
 
-    @nogc @safe unittest
+    version(StdUnittest) @nogc @safe unittest
     {
         auto sw = StopWatch(Yes.autoStart);
         sw.stop();
@@ -247,7 +247,7 @@ public:
         _timeMeasured.length = 0;
     }
 
-    @nogc @safe unittest
+    version(StdUnittest) @nogc @safe unittest
     {
         StopWatch sw;
         sw.start();
@@ -267,7 +267,7 @@ public:
         _timeStart = TickDuration.currSystemTick;
     }
 
-    @nogc @system unittest
+    version(StdUnittest) @nogc @system unittest
     {
         StopWatch sw;
         sw.start();
@@ -293,7 +293,7 @@ public:
         _timeMeasured += TickDuration.currSystemTick - _timeStart;
     }
 
-    @nogc @system unittest
+    version(StdUnittest) @nogc @system unittest
     {
         StopWatch sw;
         sw.start();
@@ -321,7 +321,7 @@ public:
         return _timeMeasured;
     }
 
-    @nogc @safe unittest
+    version(StdUnittest) @nogc @safe unittest
     {
         StopWatch sw;
         sw.start();
@@ -344,7 +344,7 @@ public:
         _timeMeasured = d;
     }
 
-    @nogc @safe unittest
+    version(StdUnittest) @nogc @safe unittest
     {
         StopWatch sw;
         TickDuration t0;
@@ -363,7 +363,7 @@ public:
         return _flagStarted;
     }
 
-    @nogc @safe unittest
+    version(StdUnittest) @nogc @safe unittest
     {
         StopWatch sw1;
         assert(!sw1.running);
@@ -395,7 +395,7 @@ private:
 }
 
 ///
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     void writeln(S...)(S args){}
     static void bar() {}
@@ -475,7 +475,7 @@ TickDuration[fun.length] benchmark(fun...)(uint n)
 }
 
 ///
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     import std.conv : to;
     int a;
@@ -488,7 +488,7 @@ deprecated @safe unittest
     auto f2Result = to!Duration(r[2]); // time f2 took to run 10,000 times
 }
 
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     int a;
     void f0() {}
@@ -584,7 +584,7 @@ ComparingBenchmarkResult comparingBenchmark(alias baseFunc,
 }
 
 ///
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     void f1x() {}
     void f2x() {}
@@ -595,7 +595,7 @@ deprecated @safe unittest
 }
 
 //Bug# 8450
-deprecated @system unittest
+version(StdUnittest) deprecated @system unittest
 {
     @safe    void safeFunc() {}
     @trusted void trustFunc() {}
@@ -691,7 +691,7 @@ if (!isSafe!((){StopWatch sw; unaryFun!func(sw.peek());}))
 }
 
 // Verify Example.
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     {
         auto mt = measureTime!((TickDuration a)
@@ -710,7 +710,7 @@ deprecated @safe unittest
     }
 }
 
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     import std.math : isNaN;
 
@@ -730,7 +730,7 @@ deprecated @safe unittest
     +/
 }
 
-deprecated @safe unittest
+version(StdUnittest) deprecated @safe unittest
 {
     import std.math : isNaN;
 
@@ -751,7 +751,7 @@ deprecated @safe unittest
 }
 
 //Bug# 8450
-deprecated @system unittest
+version(StdUnittest) deprecated @system unittest
 {
     @safe    void safeFunc() {}
     @trusted void trustFunc() {}

--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -96,7 +96,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -138,7 +138,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -150,7 +150,7 @@ public:
         assert(sw.peek() == Duration.zero);
     }
 
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -185,7 +185,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -213,7 +213,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -250,7 +250,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -274,7 +274,7 @@ public:
         assert(sw.peek() > stopped);
     }
 
-    @safe nothrow @nogc unittest
+    version(StdUnittest) @safe nothrow @nogc unittest
     {
         assert(StopWatch.init.peek() == Duration.zero);
     }
@@ -295,7 +295,7 @@ public:
     }
 
     ///
-    @system nothrow @nogc unittest
+    version(StdUnittest) @system nothrow @nogc unittest
     {
         import core.thread : Thread;
 
@@ -323,7 +323,7 @@ public:
     }
 
     ///
-    @safe nothrow @nogc unittest
+    version(StdUnittest) @safe nothrow @nogc unittest
     {
         StopWatch sw;
         assert(!sw.running);
@@ -345,7 +345,7 @@ private:
 }
 
 /// Measure a time in milliseconds, microseconds, or nanoseconds
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     auto sw = StopWatch(AutoStart.no);
     sw.start();
@@ -361,7 +361,7 @@ private:
 }
 
 ///
-@system nothrow @nogc unittest
+version(StdUnittest) @system nothrow @nogc unittest
 {
     import core.thread : Thread;
 
@@ -425,7 +425,7 @@ Duration[fun.length] benchmark(fun...)(uint n)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -439,7 +439,7 @@ Duration[fun.length] benchmark(fun...)(uint n)
     Duration f2Result = r[2]; // time f2 took to run 10,000 times
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.conv : to;
 
@@ -454,7 +454,7 @@ Duration[fun.length] benchmark(fun...)(uint n)
     assert(r[1] < seconds(1));
 }
 
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     int f0Count;
     int f1Count;

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -62,7 +62,7 @@ version(StdUnittest)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     initializeTests();
 }
@@ -94,7 +94,7 @@ public:
         return SysTime(currStdTime!clockType, tz);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.format : format;
         import std.stdio : writefln;
@@ -283,7 +283,7 @@ public:
         else static assert(0, "Unsupported OS");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.format : format;
         import std.math : abs;
@@ -388,7 +388,7 @@ public:
             assert(0, "SysTime's constructor threw when it shouldn't have.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void test(DateTime dt, immutable TimeZone tz, long expected)
         {
@@ -441,7 +441,7 @@ public:
         this(standardTime, nonNullTZ);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void test(DateTime dt, Duration fracSecs, immutable TimeZone tz, long expected)
@@ -493,7 +493,7 @@ public:
             assert(0, "Date's constructor through when it shouldn't have.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void test(Date d, immutable TimeZone tz, long expected)
         {
@@ -532,7 +532,7 @@ public:
         _timezone = tz is null ? LocalTime() : tz;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static void test(long stdTime, immutable TimeZone tz)
         {
@@ -588,7 +588,7 @@ public:
         return _stdTime == rhs._stdTime;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -652,7 +652,7 @@ public:
         return 0;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.iteration : map;
         import std.array : array;
@@ -746,7 +746,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(SysTime(0).toHash == SysTime(0).toHash);
         assert(SysTime(DateTime(2000, 1, 1)).toHash == SysTime(DateTime(2000, 1, 1)).toHash);
@@ -770,7 +770,7 @@ public:
         return (cast(Date) this).year;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
         static void test(SysTime sysTime, long expected)
@@ -834,7 +834,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.datetime.date : DateTime;
 
@@ -843,7 +843,7 @@ public:
         assert(SysTime(DateTime(-7, 4, 5, 7, 45, 2)).year == -7);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -904,7 +904,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.datetime.date : DateTime;
 
@@ -913,7 +913,7 @@ public:
         assert(SysTime(DateTime(-100, 1, 1, 4, 59, 0)).yearBC == 101);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : assertNotThrown;
         foreach (st; testSysTimesBC)
@@ -964,7 +964,7 @@ public:
         adjTime = newDaysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto st = SysTime(DateTime(2010, 1, 1, 7, 30, 0));
         st.yearBC = 1;
@@ -974,7 +974,7 @@ public:
         assert(st == SysTime(DateTime(-9, 1, 1, 7, 30, 0)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
         static void test(SysTime st, int year, in SysTime expected)
@@ -1040,7 +1040,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.datetime.date : DateTime;
 
@@ -1049,7 +1049,7 @@ public:
         assert(SysTime(DateTime(-7, 4, 5, 7, 45, 2)).month == 4);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1113,7 +1113,7 @@ public:
         adjTime = newDaysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.iteration : filter;
         import std.range : chain;
@@ -1201,7 +1201,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.datetime.date : DateTime;
 
@@ -1210,7 +1210,7 @@ public:
         assert(SysTime(DateTime(-7, 4, 5, 7, 45, 2)).day == 5);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1275,7 +1275,7 @@ public:
         adjTime = newDaysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
         import std.traits : EnumMembers;
@@ -1364,7 +1364,7 @@ public:
         return cast(ubyte) getUnitsFromHNSecs!"hours"(hnsecs);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1437,7 +1437,7 @@ public:
         adjTime = daysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1484,7 +1484,7 @@ public:
         return cast(ubyte) getUnitsFromHNSecs!"minutes"(hnsecs);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1560,7 +1560,7 @@ public:
         adjTime = daysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1608,7 +1608,7 @@ public:
         return cast(ubyte) getUnitsFromHNSecs!"seconds"(hnsecs);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1686,7 +1686,7 @@ public:
         adjTime = daysHNSecs + hnsecs;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
 
@@ -1729,7 +1729,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, usecs, hnsecs, nsecs;
         import std.datetime.date : DateTime;
@@ -1744,7 +1744,7 @@ public:
         assert(SysTime(dt, nsecs(123456789)).fracSecs == nsecs(123456700));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
         import core.time;
@@ -1818,7 +1818,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : Duration, msecs, hnsecs, nsecs;
         import std.datetime.date : DateTime;
@@ -1838,7 +1838,7 @@ public:
         assert(st.fracSecs == hnsecs(1234567));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.range : chain;
         import core.time;
@@ -1874,7 +1874,7 @@ public:
         return _stdTime;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(0).stdTime == 0);
@@ -1902,7 +1902,7 @@ public:
         _stdTime = stdTime;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void test(long stdTime, in SysTime expected, size_t line = __LINE__)
@@ -1987,7 +1987,7 @@ public:
         return SysTime(_stdTime, LocalTime());
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         {
@@ -2020,7 +2020,7 @@ public:
         return SysTime(_stdTime, UTC());
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto sysTime = SysTime(DateTime(1982, 1, 4, 8, 59, 7), hnsecs(27));
@@ -2044,7 +2044,7 @@ public:
             return SysTime(_stdTime, tz);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto stz = new immutable SimpleTimeZone(dur!"minutes"(11 * 60));
@@ -2093,7 +2093,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours;
         import std.datetime.date : DateTime;
@@ -2111,7 +2111,7 @@ public:
         assert(ca.toUnixTime() == 1_198_340_085);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.meta : AliasSeq;
         import core.time;
@@ -2146,7 +2146,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours;
         import std.datetime.date : DateTime;
@@ -2170,7 +2170,7 @@ public:
         assert(st2 == SysTime(DateTime(2007, 12, 22, 0, 14, 45), pst));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime.fromUnixTime(0) == SysTime(DateTime(1970, 1, 1), UTC()));
@@ -2206,7 +2206,7 @@ public:
         return timeval(tv_sec, tv_usec);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(DateTime(1970, 1, 1), UTC()).toTimeVal() == timeval(0, 0));
@@ -2250,7 +2250,7 @@ public:
             return timespec(tv_sec, tv_nsec);
         }
 
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             import core.time;
             assert(SysTime(DateTime(1970, 1, 1), UTC()).toTimeSpec() == timespec(0, 0));
@@ -2310,7 +2310,7 @@ public:
         return timeInfo;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.conv : to;
         import core.time;
@@ -2420,7 +2420,7 @@ public:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto st1 = SysTime(DateTime(2010, 1, 1, 12, 30, 33));
         st1.add!"months"(11);
@@ -2440,7 +2440,7 @@ public:
     }
 
     // Test add!"years"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -2643,7 +2643,7 @@ public:
     }
 
     // Test add!"years"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -2849,7 +2849,7 @@ public:
     }
 
     // Test add!"months"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -3196,7 +3196,7 @@ public:
     }
 
     // Test add!"months"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -3564,7 +3564,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.datetime.date : AllowDayOverflow, DateTime;
 
@@ -3593,7 +3593,7 @@ public:
         assert(st6 == SysTime(DateTime(2001, 2, 28, 12, 30, 33)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -3633,7 +3633,7 @@ public:
     }
 
     // Test roll!"months"() with AllowDayOverflow.yes
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -4012,7 +4012,7 @@ public:
     }
 
     // Test roll!"months"() with AllowDayOverflow.no
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -4435,7 +4435,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -4490,7 +4490,7 @@ public:
         assert(st11 == SysTime(dt, hnsecs(9_999_999)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -4809,7 +4809,7 @@ public:
     }
 
     // Test roll!"hours"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, int hours, in SysTime expected, size_t line = __LINE__)
@@ -5027,7 +5027,7 @@ public:
     }
 
     // Test roll!"minutes"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, int minutes, in SysTime expected, size_t line = __LINE__)
@@ -5238,7 +5238,7 @@ public:
     }
 
     // Test roll!"seconds"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, int seconds, in SysTime expected, size_t line = __LINE__)
@@ -5456,7 +5456,7 @@ public:
 
 
     // Test roll!"msecs"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, int milliseconds, in SysTime expected, size_t line = __LINE__)
@@ -5562,7 +5562,7 @@ public:
     }
 
     // Test roll!"usecs"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, long microseconds, in SysTime expected, size_t line = __LINE__)
@@ -5692,7 +5692,7 @@ public:
     }
 
     // Test roll!"hnsecs"().
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         static void testST(SysTime orig, long hnsecs, in SysTime expected, size_t line = __LINE__)
@@ -5860,7 +5860,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, seconds;
         import std.datetime.date : DateTime;
@@ -5878,7 +5878,7 @@ public:
                SysTime(DateTime(2015, 12, 31, 23, 59, 59)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_678));
@@ -6073,7 +6073,7 @@ public:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto before = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6269,7 +6269,7 @@ public:
         return dur!"hnsecs"(_stdTime - rhs._stdTime);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(DateTime(1999, 7, 6, 12, 30, 33)) - SysTime(DateTime(1998, 7, 6, 12, 30, 33)) ==
@@ -6387,7 +6387,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : Date;
@@ -6405,7 +6405,7 @@ public:
                    SysTime(Date(1999, 3, 31))) == -2);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6433,7 +6433,7 @@ public:
         return (cast(Date) this).isLeapYear;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6453,7 +6453,7 @@ public:
         return getDayOfWeek(dayOfGregorianCal);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6474,7 +6474,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : DateTime;
@@ -6484,7 +6484,7 @@ public:
         assert(SysTime(DateTime(2000, 12, 31, 21, 20, 0)).dayOfYear == 366);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6517,7 +6517,7 @@ public:
         adjTime = newDaysHNSecs + theRest;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -6550,7 +6550,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : DateTime;
@@ -6567,7 +6567,7 @@ public:
         assert(SysTime(DateTime(2010, 12, 31, 15, 45, 50)).dayOfGregorianCal == 734_137);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -6739,7 +6739,7 @@ public:
 
     // Test that the logic for the day of the Gregorian Calendar is consistent
     // between Date and SysTime.
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         void test(Date date, SysTime st, size_t line = __LINE__)
@@ -6927,7 +6927,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : DateTime;
@@ -6958,7 +6958,7 @@ public:
         assert(st == SysTime(DateTime(2010, 12, 31, 12, 0, 0)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         void testST(SysTime orig, int day, in SysTime expected, size_t line = __LINE__)
@@ -7171,7 +7171,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : Date;
@@ -7216,7 +7216,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -7234,7 +7234,7 @@ public:
                SysTime(DateTime(2000, 6, 30, 23, 59, 59), hnsecs(9_999_999)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -7286,7 +7286,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : DateTime;
@@ -7297,7 +7297,7 @@ public:
         assert(SysTime(DateTime(2000, 6, 4, 12, 22, 9)).daysInMonth == 30);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -7346,7 +7346,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.datetime.date : DateTime;
@@ -7357,7 +7357,7 @@ public:
         assert(!SysTime(DateTime(-2010, 1, 1, 2, 2, 2)).isAD);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(DateTime(2010, 7, 4, 12, 0, 9)).isAD);
@@ -7387,7 +7387,7 @@ public:
         return hour < 12 ? jd - 1 : jd;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(DateTime(-4713, 11, 24, 0, 0, 0)).julianDay == -1);
@@ -7431,7 +7431,7 @@ public:
         return dayOfGregorianCal + 1_721_425 - 2_400_001;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(SysTime(DateTime(1858, 11, 17, 0, 0, 0)).modJulianDay == 0);
@@ -7456,7 +7456,7 @@ public:
         return Date(dayOfGregorianCal);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(cast(Date) SysTime(Date(1999, 7, 6)) == Date(1999, 7, 6));
@@ -7510,7 +7510,7 @@ public:
             assert(0, "Either DateTime's constructor or TimeOfDay's constructor threw.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(cast(DateTime) SysTime(DateTime(1, 1, 6, 7, 12, 22)) == DateTime(1, 1, 6, 7, 12, 22));
@@ -7568,7 +7568,7 @@ public:
             assert(0, "TimeOfDay's constructor threw.");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         assert(cast(TimeOfDay) SysTime(Date(1999, 7, 6)) == TimeOfDay(0, 0, 0));
@@ -7678,7 +7678,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -7696,7 +7696,7 @@ public:
                "-00040105T000002.052092");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -7811,7 +7811,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -7829,7 +7829,7 @@ public:
                "-0004-01-05T00:00:02.052092");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -7948,7 +7948,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : msecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -7966,7 +7966,7 @@ public:
                 "-0004-Jan-05 00:00:02.052092");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         // Test A.D.
@@ -8055,7 +8055,7 @@ public:
         return toSimpleString();
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
@@ -8199,7 +8199,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -8235,7 +8235,7 @@ public:
                        new immutable SimpleTimeZone(hours(8))));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000", "20100704t000000",
@@ -8357,7 +8357,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.meta : AliasSeq;
@@ -8470,7 +8470,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -8505,7 +8505,7 @@ public:
                        new immutable SimpleTimeZone(hours(8))));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000",
@@ -8599,7 +8599,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.conv : to;
@@ -8713,7 +8713,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time : hours, msecs, usecs, hnsecs;
         import std.datetime.date : DateTime;
@@ -8749,7 +8749,7 @@ public:
                        new immutable SimpleTimeZone(hours(8))));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         foreach (str; ["", "20100704000000", "20100704 000000",
@@ -8845,7 +8845,7 @@ public:
     }
 
     // bug# 17801
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.time;
         import std.conv : to;
@@ -8872,7 +8872,7 @@ public:
         return SysTime(long.min, UTC());
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(SysTime.min.year < 0);
         assert(SysTime.min < SysTime.max);
@@ -8890,7 +8890,7 @@ public:
         return SysTime(long.max, UTC());
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(SysTime.max.year > 0);
         assert(SysTime.max > SysTime.min);
@@ -8965,7 +8965,7 @@ long unixTimeToStdTime(long unixTime) @safe pure nothrow
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.date : DateTime;
     import std.datetime.timezone : UTC;
@@ -8984,7 +8984,7 @@ long unixTimeToStdTime(long unixTime) @safe pure nothrow
            SysTime(DateTime(1969, 12, 30, 12, 41, 13), UTC()));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Midnight, January 2nd, 1970
     assert(unixTimeToStdTime(86_400) == 621_355_968_000_000_000L + 864_000_000_000L);
@@ -9064,7 +9064,7 @@ if (is(T == int) || is(T == long))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Midnight, January 1st, 1970 UTC
     assert(stdTimeToUnixTime(621_355_968_000_000_000L) == 0);
@@ -9073,7 +9073,7 @@ if (is(T == int) || is(T == long))
     assert(stdTimeToUnixTime(642_830_804_470_000_000L) == int.max);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum unixEpochAsStdTime = (Date(1970, 1, 1) - Date.init).total!"hnsecs";
 
@@ -9276,7 +9276,7 @@ else version(Windows)
         return SysTime(dt, msecs(st.wMilliseconds), tz);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto sysTime = Clock.currTime(UTC());
         SYSTEMTIME st = void;
@@ -9308,7 +9308,7 @@ else version(Windows)
         return st;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         SYSTEMTIME st = void;
         GetSystemTime(&st);
@@ -9348,7 +9348,7 @@ else version(Windows)
         return sysTime;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto sysTime = Clock.currTime(UTC());
         SYSTEMTIME st = void;
@@ -9384,7 +9384,7 @@ else version(Windows)
         return stdTimeToFILETIME(sysTime.stdTime);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         SYSTEMTIME st = void;
         GetSystemTime(&st);
@@ -9437,7 +9437,7 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
         throw new DateTimeException("Invalid DosFileTime", __FILE__, __LINE__, dte);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(DosFileTimeToSysTime(0b00000000001000010000000000000000) == SysTime(DateTime(1980, 1, 1, 0, 0, 0)));
     assert(DosFileTimeToSysTime(0b11111111100111111011111101111101) == SysTime(DateTime(2107, 12, 31, 23, 59, 58)));
@@ -9476,7 +9476,7 @@ DosFileTime SysTimeToDosFileTime(SysTime sysTime) @safe
     return cast(DosFileTime) retval;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(SysTimeToDosFileTime(SysTime(DateTime(1980, 1, 1, 0, 0, 0))) == 0b00000000001000010000000000000000);
     assert(SysTimeToDosFileTime(SysTime(DateTime(2107, 12, 31, 23, 59, 58))) == 0b11111111100111111011111101111101);
@@ -9731,7 +9731,7 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.time : hours;
     import std.datetime.date : DateTime, DateTimeException;
@@ -9767,7 +9767,7 @@ version(StdUnittest) void testBadParse822(alias cr)(string str, size_t line = __
     throw new AssertError("No DateTimeException was thrown", __FILE__, line);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.time;
     import std.algorithm.iteration : filter, map;
@@ -10040,7 +10040,7 @@ version(StdUnittest) void testBadParse822(alias cr)(string str, size_t line = __
 }
 
 // Obsolete Format per section 4.3 of RFC 5322.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : filter, map;
     import std.ascii : letters;
@@ -10283,7 +10283,7 @@ static string fracSecsToISOString(int hnsecs) @safe pure nothrow
         assert(0, "format() threw.");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(fracSecsToISOString(0) == "");
     assert(fracSecsToISOString(1) == ".0000001");
@@ -10346,7 +10346,7 @@ if (isSomeString!S)
     return hnsecs(to!int(fullISOString[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.time;
     static void testFSInvalid(string isoString)
@@ -10425,7 +10425,7 @@ if (validTimeUnits(units) &&
     return convert!("hnsecs", units)(hnsecs);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto hnsecs = 2595000000007L;
     immutable days = getUnitsFromHNSecs!"days"(hnsecs);
@@ -10453,7 +10453,7 @@ if (validTimeUnits(units) &&
     return hnsecs - convert!(units, "hnsecs")(value);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto hnsecs = 2595000000007L;
     auto returned = removeUnitsFromHNSecs!"days"(hnsecs);
@@ -10546,7 +10546,7 @@ if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
     return range[e .. e];
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -10668,7 +10668,7 @@ if (isIntegral!T && isSigned!T) // The constraints on R were already covered by 
     return num;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.range : chain, iota;

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -191,7 +191,7 @@ public:
     }
 
     ///
-    deprecated @safe unittest
+    version(StdUnittest) deprecated @safe unittest
     {
         auto tz = TimeZone.getTimeZone("America/Los_Angeles");
     }
@@ -217,7 +217,7 @@ public:
     // Since reading in the time zone files could be expensive, most unit tests
     // are consolidated into this one unittest block which minimizes how often
     // it reads a time zone file.
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import core.exception : AssertError;
         import std.conv : to;
@@ -543,7 +543,7 @@ public:
         }
     }
 
-    deprecated @safe unittest
+   version(StdUnittest) deprecated @safe unittest
     {
         import std.exception : assertNotThrown;
         import std.stdio : writefln;
@@ -691,7 +691,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         version(FreeBSD)
         {
@@ -776,7 +776,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(LocalTime().dstName !is null);
 
@@ -843,7 +843,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         LocalTime().hasDST;
 
@@ -901,7 +901,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto currTime = Clock.currStdTime;
         LocalTime().dstInEffect(currTime);
@@ -941,7 +941,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         LocalTime().utcToTZ(0);
     }
@@ -994,7 +994,7 @@ public:
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.exception : AssertError;
         import std.format : format;
@@ -1232,7 +1232,7 @@ public:
         return stdTime;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(UTC().utcToTZ(0) == 0);
 
@@ -1265,7 +1265,7 @@ public:
         return adjTime;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(UTC().tzToUTC(0) == 0);
 
@@ -1356,7 +1356,7 @@ public:
         return stdTime + _utcOffset.total!"hnsecs";
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto west = new immutable SimpleTimeZone(dur!"hours"(-8));
         auto east = new immutable SimpleTimeZone(dur!"hours"(8));
@@ -1383,7 +1383,7 @@ public:
         return adjTime - _utcOffset.total!"hnsecs";
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto west = new immutable SimpleTimeZone(dur!"hours"(-8));
         auto east = new immutable SimpleTimeZone(dur!"hours"(8));
@@ -1427,7 +1427,7 @@ public:
         this._utcOffset = utcOffset;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto stz = new immutable SimpleTimeZone(dur!"hours"(-8), "PST");
         assert(stz.name == "");
@@ -1472,7 +1472,7 @@ package:
         return format(utcOffset < Duration.zero ? "-%02d%02d" : "+%02d%02d", hours, minutes);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static string testSTZInvalid(Duration offset)
         {
@@ -1528,7 +1528,7 @@ package:
         return format(utcOffset < Duration.zero ? "-%02d:%02d" : "+%02d:%02d", hours, minutes);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static string testSTZInvalid(Duration offset)
         {
@@ -1614,7 +1614,7 @@ package:
         return new immutable SimpleTimeZone(sign * (dur!"hours"(hours) + dur!"minutes"(minutes)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.exception : AssertError;
         import std.format : format;
@@ -1675,7 +1675,7 @@ package:
         test("-23", hours(-23));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.exception : AssertError;
         import std.format : format;
@@ -1776,7 +1776,7 @@ package:
         return new immutable SimpleTimeZone(sign * (dur!"hours"(hours) + dur!"minutes"(minutes)));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.exception : AssertError;
         import std.format : format;
@@ -1837,7 +1837,7 @@ package:
         test("-23", hours(-23));
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import core.exception : AssertError;
         import std.format : format;
@@ -2413,7 +2413,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         version(Posix)
         {
@@ -2495,7 +2495,7 @@ public:
         return timezones.data;
     }
 
-    version(Posix) @system unittest
+    version(Posix) version(StdUnittest) @system unittest
     {
         import std.exception : assertNotThrown;
         import std.stdio : writefln;
@@ -3066,7 +3066,7 @@ else version(Windows)
             return timezones.data;
         }
 
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             import std.exception : assertNotThrown;
             import std.stdio : writefln;
@@ -3160,7 +3160,7 @@ else version(Windows)
                 assert(0, "DateTime's constructor threw.");
         }
 
-        @system unittest
+        version(StdUnittest) @system unittest
         {
             TIME_ZONE_INFORMATION tzInfo;
             GetTimeZoneInformation(&tzInfo);
@@ -3467,7 +3467,7 @@ TZConversions parseTZConversions(string windowsZonesXMLText) @safe pure
     return TZConversions(nix2Win, win2Nix);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : uniq;
@@ -4007,7 +4007,7 @@ string tzDatabaseNameToWindowsTZName(string tzName) @safe pure nothrow @nogc
     }
 }
 
-version(Windows) version(UpdateWindowsTZTranslations) deprecated @system unittest
+version(Windows) version(StdUnittest) version(UpdateWindowsTZTranslations) deprecated @system unittest
 {
     import std.stdio : stderr;
 

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -64,7 +64,7 @@ version(StdUnittest) import std.exception;
 
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Template API
     import std.digest.crc;
@@ -82,7 +82,7 @@ version(StdUnittest) import std.exception;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //OOP API
     import std.digest.crc;
@@ -124,7 +124,7 @@ private T[256][8] genTables(T)(T polynomial)
     return res;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto tables = genTables(0xEDB88320);
     assert(tables[0][0] == 0x00000000 && tables[0][$ - 1] == 0x2d02ef8d && tables[7][$ - 1] == 0x264b06e6);
@@ -282,7 +282,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using crc32Of helper function
     ubyte[4] hash32 = crc32Of("abc");
@@ -296,7 +296,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[1024] data;
     //Using the basic API
@@ -313,7 +313,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Let's use the template features:
     //Note: When passing a CRC32 to a function, it must be passed by reference!
@@ -337,14 +337,14 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
     assert(crcHexString(crc64iso.finish()) == "6F90000000000000");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isDigest!CRC32);
     assert(isDigest!CRC64ECMA);
     assert(isDigest!CRC64ISO);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     ubyte[4] digest;
@@ -385,7 +385,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
     assert(crcHexString(input) == "D7D3FCC3");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     ubyte[8] digest;
@@ -425,7 +425,7 @@ struct CRC(uint N, ulong P) if (N == 32 || N == 64)
     assert(crcHexString(input) == "DEADBEEFD7D3FCC3");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     ubyte[8] digest;
@@ -484,7 +484,7 @@ ubyte[4] crc32Of(T...)(T data)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] data = [4,5,7,25];
     assert(data.crc32Of == [167, 180, 199, 131]);
@@ -519,7 +519,7 @@ ubyte[8] crc64ECMAOf(T...)(T data)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] data = [4,5,7,25];
     assert(data.crc64ECMAOf == [58, 142, 220, 214, 118, 98, 105, 69]);
@@ -555,7 +555,7 @@ ubyte[8] crc64ISOOf(T...)(T data)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] data = [4,5,7,25];
     assert(data.crc64ISOOf == [0, 0, 0, 80, 137, 232, 203, 120]);
@@ -608,7 +608,7 @@ alias CRC64ECMADigest = WrapperDigest!CRC64ECMA;
 alias CRC64ISODigest = WrapperDigest!CRC64ISO;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto crc = new CRC32Digest();
@@ -618,7 +618,7 @@ alias CRC64ISODigest = WrapperDigest!CRC64ISO;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
      //Let's use the OOP features:
     void test(Digest dig)
@@ -635,7 +635,7 @@ alias CRC64ISODigest = WrapperDigest!CRC64ISO;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example
     auto hash = new CRC32Digest();
@@ -644,7 +644,7 @@ alias CRC64ISODigest = WrapperDigest!CRC64ISO;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //using a supplied buffer
     ubyte[4] buf;
@@ -656,7 +656,7 @@ alias CRC64ISODigest = WrapperDigest!CRC64ISO;
     //length)
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     import std.range;

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -32,7 +32,7 @@ import std.meta : allSatisfy;
  */
 
 /// Compute HMAC over an input string
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : LetterCase;
     import std.digest : toHexString;
@@ -90,7 +90,7 @@ if (hashBlockSize % 8 == 0)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.digest.hmac, std.digest.sha;
         import std.string : representation;
@@ -127,7 +127,7 @@ if (hashBlockSize % 8 == 0)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.digest.hmac, std.digest.sha;
         import std.string : representation;
@@ -158,7 +158,7 @@ if (hashBlockSize % 8 == 0)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.digest.hmac, std.digest.sha;
         import std.string : representation;
@@ -194,7 +194,7 @@ if (hashBlockSize % 8 == 0)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.digest.hmac, std.digest.sha;
         import std.string : representation;
@@ -235,7 +235,7 @@ if (isDigest!H)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.digest.hmac, std.digest.sha;
         import std.string : representation;
@@ -269,7 +269,7 @@ if (isDigest!H)
     }
 
     ///
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         import std.algorithm.iteration : map;
         import std.digest.hmac, std.digest.sha;
@@ -294,7 +294,7 @@ version(StdUnittest)
 }
 
 @safe pure nothrow @nogc
-unittest
+version(StdUnittest) unittest
 {
     import std.digest.md : MD5;
     import std.range : isOutputRange;
@@ -304,7 +304,7 @@ unittest
 }
 
 @safe pure nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.digest.md : MD5;
     import std.digest.sha : SHA1, SHA256;

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -48,7 +48,7 @@ module std.digest.md;
 public import std.digest;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Template API
     import std.digest.md;
@@ -64,7 +64,7 @@ public import std.digest;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //OOP API
     import std.digest.md;
@@ -391,7 +391,7 @@ struct MD5
             return data;
         }
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             //Simple example
             MD5 hash;
@@ -402,7 +402,7 @@ struct MD5
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using md5Of helper function
     ubyte[16] hash = md5Of("abc");
@@ -411,7 +411,7 @@ struct MD5
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Using the basic API
     MD5 hash;
@@ -423,7 +423,7 @@ struct MD5
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Let's use the template features:
     void doSomething(T)(ref T hash)
@@ -437,12 +437,12 @@ struct MD5
     assert(toHexString(md5.finish()) == "93B885ADFE0DA089CDF634904FD59F71");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isDigest!MD5);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range;
     import std.conv : hexString;
@@ -505,7 +505,7 @@ auto md5Of(T...)(T data)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[16] hash = md5Of("abc");
     assert(hash == digest!MD5("abc"));
@@ -521,7 +521,7 @@ auto md5Of(T...)(T data)
 alias MD5Digest = WrapperDigest!MD5;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto md5 = new MD5Digest();
@@ -531,7 +531,7 @@ alias MD5Digest = WrapperDigest!MD5;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
      //Let's use the OOP features:
     void test(Digest dig)
@@ -547,7 +547,7 @@ alias MD5Digest = WrapperDigest!MD5;
     assert(toHexString(result) == "93B885ADFE0DA089CDF634904FD59F71");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     auto md5 = new MD5Digest();

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -44,7 +44,7 @@ else version (X86_64)
     version = HaveUnalignedLoads;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // MurmurHash3!32, MurmurHash3!(128, 32) and MurmurHash3!(128, 64) implement
     // the std.digest Template API.
@@ -55,7 +55,7 @@ else version (X86_64)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // One can also hash ubyte data piecewise by instanciating a hasher and call
     // the 'put' method.
@@ -73,7 +73,7 @@ else version (X86_64)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Using `putElements`, `putRemainder` and `finalize` you gain full
     // control over which part of the algorithm to run.
@@ -688,7 +688,7 @@ version(StdUnittest)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!32)([
@@ -722,7 +722,7 @@ version(StdUnittest)
     // dfmt on
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!(128,32))([
@@ -756,7 +756,7 @@ version(StdUnittest)
     // dfmt on
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // dfmt off
     checkResult!(MurmurHash3!(128,64))([
@@ -790,7 +790,7 @@ version(StdUnittest)
     // dfmt on
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Pushing unaligned data and making sure the result is still coherent.
     void testUnalignedHash(H)()

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -70,7 +70,7 @@ import std.traits;
 
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
 
@@ -86,7 +86,7 @@ import std.traits;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Generating the hashes of a file, idiomatic D way
     import std.digest.crc, std.digest.md, std.digest.sha;
@@ -112,7 +112,7 @@ import std.traits;
     }
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Generating the hashes of a file using the template API
     import std.digest.crc, std.digest.md, std.digest.sha;
@@ -152,7 +152,7 @@ import std.traits;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc, std.digest.md, std.digest.sha;
     import std.stdio;
@@ -256,7 +256,7 @@ version(ExampleDigest)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Using the OutputRange feature
     import std.algorithm.mutation : copy;
@@ -297,13 +297,13 @@ template isDigest(T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     static assert(isDigest!CRC32);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     void myFunction(T)()
@@ -335,13 +335,13 @@ template DigestType(T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     assert(is(DigestType!(CRC32) == ubyte[4]));
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     CRC32 dig;
@@ -371,14 +371,14 @@ template hasPeek(T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc, std.digest.md;
     assert(!hasPeek!(MD5));
     assert(hasPeek!CRC32);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     void myFunction(T)()
@@ -403,7 +403,7 @@ if (isDigest!T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.hmac, std.digest.md;
     static assert(hasBlockSize!MD5        && MD5.blockSize      == 512);
@@ -441,7 +441,7 @@ if (!isArray!Range
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.md;
     import std.range : repeat;
@@ -466,7 +466,7 @@ if (allSatisfy!(isArray, typeof(data)))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc, std.digest.md, std.digest.sha;
     auto md5   = digest!MD5(  "The quick brown fox jumps over the lazy dog");
@@ -476,7 +476,7 @@ if (allSatisfy!(isArray, typeof(data)))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     auto crc32 = digest!CRC32("The quick ", "brown ", "fox jumps over the lazy dog");
@@ -499,7 +499,7 @@ if (!isArray!Range && isDigestibleRange!Range)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.md;
     import std.range : repeat;
@@ -521,13 +521,13 @@ if (allSatisfy!(isArray, typeof(data)))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     assert(hexDigest!(CRC32, Order.decreasing)("The quick brown fox jumps over the lazy dog") == "414FA339");
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     assert(hexDigest!(CRC32, Order.decreasing)("The quick ", "brown ", "fox jumps over the lazy dog") == "414FA339");
@@ -545,7 +545,7 @@ Hash makeDigest(Hash)()
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.md;
     auto md5 = makeDigest!MD5();
@@ -625,7 +625,7 @@ interface Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Using the OutputRange feature
     import std.algorithm.mutation : copy;
@@ -639,7 +639,7 @@ interface Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc, std.digest.md, std.digest.sha;
     ubyte[] md5   = (new MD5Digest()).digest("The quick brown fox jumps over the lazy dog");
@@ -649,14 +649,14 @@ interface Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.crc;
     ubyte[] crc32 = (new CRC32Digest()).digest("The quick ", "brown ", "fox jumps over the lazy dog");
     assert(crcHexString(crc32) == "414FA339");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range : isOutputRange;
     assert(!isDigest!(Digest));
@@ -664,7 +664,7 @@ interface Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(Digest dig)
     {
@@ -794,7 +794,7 @@ string toHexString(LetterCase letterCase, Order order = Order.increasing)(in uby
 //For more example unittests, see Digest.digest, digest
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.digest.crc;
     //Test with template API:
@@ -807,7 +807,7 @@ string toHexString(LetterCase letterCase, Order order = Order.increasing)(in uby
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.digest.crc;
     // With OOP API
@@ -816,7 +816,7 @@ string toHexString(LetterCase letterCase, Order order = Order.increasing)(in uby
     assert(toHexString!(Order.decreasing)(crc32) == "414FA339");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[16] data;
     assert(toHexString(data) == "00000000000000000000000000000000");
@@ -851,7 +851,7 @@ if (isDigest!T)
 }
 
 @safe pure nothrow @nogc
-unittest
+version(StdUnittest) unittest
 {
     import std.digest.md : MD5;
     import std.digest.sha : SHA1, SHA256, SHA512;
@@ -988,7 +988,7 @@ if (isDigest!T) : Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.digest.md;
     //Simple example
@@ -998,7 +998,7 @@ if (isDigest!T) : Digest
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //using a supplied buffer
     import std.digest.md;
@@ -1011,7 +1011,7 @@ if (isDigest!T) : Digest
     //length
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test peek & length
     import std.digest.crc;
@@ -1113,7 +1113,7 @@ if (isInputRange!R1 && isInputRange!R2 && !isInfinite!R1 && !isInfinite!R2 &&
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.digest.hmac : hmac;
     import std.digest.sha : SHA1;
@@ -1131,7 +1131,7 @@ if (isInputRange!R1 && isInputRange!R2 && !isInfinite!R1 && !isInfinite!R2 &&
     assert(!secureEqual(hex1[], hex3[]));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.internal.test.dummyrange : ReferenceInputRange;
     import std.range : takeExactly;

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -49,7 +49,7 @@ module std.digest.ripemd;
 public import std.digest;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Template API
     import std.digest.md;
@@ -68,7 +68,7 @@ public import std.digest;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //OOP API
     import std.digest.md;
@@ -560,7 +560,7 @@ struct RIPEMD160
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using ripemd160Of helper function
     ubyte[20] hash = ripemd160Of("abc");
@@ -569,7 +569,7 @@ struct RIPEMD160
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Using the basic API
     RIPEMD160 hash;
@@ -581,7 +581,7 @@ struct RIPEMD160
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Let's use the template features:
     void doSomething(T)(ref T hash)
@@ -596,7 +596,7 @@ struct RIPEMD160
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example
     RIPEMD160 hash;
@@ -606,12 +606,12 @@ struct RIPEMD160
     assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isDigest!RIPEMD160);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     import std.range;
@@ -674,7 +674,7 @@ auto ripemd160Of(T...)(T data)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[20] hash = ripemd160Of("abc");
     assert(hash == digest!RIPEMD160("abc"));
@@ -690,7 +690,7 @@ auto ripemd160Of(T...)(T data)
 alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto md = new RIPEMD160Digest();
@@ -700,7 +700,7 @@ alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Let's use the OOP features:
     void test(Digest dig)
@@ -716,7 +716,7 @@ alias RIPEMD160Digest = WrapperDigest!RIPEMD160;
     assert(toHexString(result) == "C81B94933420221A7AC004A90242D8B1D3E5070D");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     auto md = new RIPEMD160Digest();

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -58,7 +58,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
 module std.digest.sha;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Template API
     import std.digest.sha;
@@ -80,7 +80,7 @@ module std.digest.sha;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //OOP API
     import std.digest.sha;
@@ -740,7 +740,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 (&buffer[index])[0 .. inputLen-i] = (&input[i])[0 .. inputLen-i];
         }
 
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             typeof(this) dig;
             dig.put(cast(ubyte) 0); //single ubyte
@@ -810,7 +810,7 @@ struct SHA(uint hashBlockSize, uint digestSize)
                 static assert(0);
         }
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             //Simple example
             SHA1 hash;
@@ -829,7 +829,7 @@ alias SHA512_224 = SHA!(1024, 224); /// SHA alias for SHA-512/224, hash is ubyte
 alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte[32]
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using sha1Of helper function
     ubyte[20] hash = sha1Of("abc");
@@ -842,7 +842,7 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Using the basic API
     SHA1 hash;
@@ -854,7 +854,7 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Let's use the template features:
     //Note: When passing a SHA1 to a function, it must be passed by reference!
@@ -869,7 +869,7 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     assert(toHexString(sha.finish()) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isDigest!SHA1);
     assert(isDigest!SHA224);
@@ -880,7 +880,7 @@ alias SHA512_256 = SHA!(1024, 256); /// SHA alias for SHA-512/256, hash is ubyte
     assert(isDigest!SHA512_256);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     import std.range;
@@ -1163,7 +1163,7 @@ auto sha512_256Of(T...)(T data)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte[20] hash = sha1Of("abc");
     assert(hash == digest!SHA1("abc"));
@@ -1187,7 +1187,7 @@ auto sha512_256Of(T...)(T data)
     assert(hash512_256 == digest!SHA512_256("abc"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string a = "Mary has ", b = "a little lamb";
     int[] c = [ 1, 2, 3, 4, 5 ];
@@ -1214,7 +1214,7 @@ alias SHA512_224Digest = WrapperDigest!SHA512_224; ///ditto
 alias SHA512_256Digest = WrapperDigest!SHA512_256; ///ditto
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
     auto sha = new SHA1Digest();
@@ -1230,7 +1230,7 @@ alias SHA512_256Digest = WrapperDigest!SHA512_256; ///ditto
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Let's use the OOP features:
     void test(Digest dig)
@@ -1246,7 +1246,7 @@ alias SHA512_256Digest = WrapperDigest!SHA512_256; ///ditto
     assert(toHexString(result) == "5BA93C9DB0CFF93F52B521D7420E43F6EDA2784F");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : hexString;
     auto sha = new SHA1Digest();

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -111,7 +111,7 @@ import std.range.primitives;
 import std.traits;
 import std.typecons;
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static ubyte[][] validStrings =
     [
@@ -1636,7 +1636,7 @@ bool isValidCodePoint(dchar c) @safe pure nothrow @nogc
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(encodingName!(char) == "UTF-8");
     assert(encodingName!(wchar) == "UTF-16");
@@ -1665,7 +1665,7 @@ bool canEncode(E)(dchar c)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert( canEncode!(Latin1Char)('A'));
     assert( canEncode!(Latin2Char)('A'));
@@ -1685,7 +1685,7 @@ bool canEncode(E)(dchar c)
 }
 
 /// How to check an entire string
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.searching : find;
     import std.utf : byDchar;
@@ -1713,7 +1713,7 @@ bool isValidCodeUnit(E)(E c)
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(!isValidCodeUnit(cast(char) 0xC0));
     assert(!isValidCodeUnit(cast(char) 0xFF));
@@ -1748,7 +1748,7 @@ bool isValid(E)(const(E)[] s)
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert( isValid("\u20AC100"));
     assert(!isValid(cast(char[3])[167, 133, 175]));
@@ -1833,7 +1833,7 @@ immutable(E)[] sanitize(E)(immutable(E)[] s)
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(sanitize("hello \xF0\x80world") == "hello \xEF\xBF\xBDworld");
 }
@@ -1865,7 +1865,7 @@ do
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(firstSequence("\u20AC1000") == "\u20AC".length);
     assert(firstSequence("hel") == "h".length);
@@ -1897,7 +1897,7 @@ do
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(lastSequence("1000\u20AC") == "\u20AC".length);
     assert(lastSequence("hellö") == "ö".length);
@@ -1933,7 +1933,7 @@ do
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(index("\u20AC100",1) == 3);
     assert(index("hällo",2) == 3);
@@ -2180,7 +2180,7 @@ if (isNativeOutputRange!(R, E))
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
     Appender!(char[]) r;
@@ -2286,7 +2286,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     string s = "hello";
     string t;
@@ -2327,7 +2327,7 @@ do
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     char[] a;
     foreach (c;codeUnits!(char)(cast(dchar)'\u20AC'))
@@ -2408,7 +2408,7 @@ do
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     wstring ws;
     // transcode from UTF-8 to UTF-16
@@ -2421,7 +2421,7 @@ do
     assert(ws == "hello world");
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.meta;
     import std.range;
@@ -2461,7 +2461,7 @@ do
     }
 }
 
-@system unittest // mutable/const input/output
+version(StdUnittest) @system unittest // mutable/const input/output
 {
     import std.meta : AliasSeq;
 
@@ -3301,7 +3301,7 @@ class EncodingSchemeWindows1252 : EncodingScheme
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static string[] schemeNames =
     [
@@ -3516,7 +3516,7 @@ class EncodingSchemeUtf16Native : EncodingScheme
         }
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     version(LittleEndian)
     {
@@ -3612,7 +3612,7 @@ class EncodingSchemeUtf32Native : EncodingScheme
         }
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     version(LittleEndian)
     {
@@ -3815,7 +3815,7 @@ if (isForwardRange!Range && is(Unqual!(ElementType!Range) == ubyte))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.format : format;
 
@@ -3832,7 +3832,7 @@ if (isForwardRange!Range && is(Unqual!(ElementType!Range) == ubyte))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.format : format;
 
@@ -3850,7 +3850,7 @@ if (isForwardRange!Range && is(Unqual!(ElementType!Range) == ubyte))
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     struct BOMInputRange
     {

--- a/std/exception.d
+++ b/std/exception.d
@@ -116,7 +116,7 @@ auto assertNotThrown(T : Throwable = Exception, E)
     }
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
 
@@ -130,7 +130,7 @@ auto assertNotThrown(T : Throwable = Exception, E)
                enforce!StringException(false, "Error!"))) ==
            `assertNotThrown failed: StringException was thrown: Error!`);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.string;
@@ -147,7 +147,7 @@ auto assertNotThrown(T : Throwable = Exception, E)
            `assertNotThrown failed: StringException was thrown.`);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
 
@@ -259,7 +259,7 @@ void assertThrown(T : Throwable = Exception, E)
                           file, line);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.string;
@@ -274,7 +274,7 @@ void assertThrown(T : Throwable = Exception, E)
            `assertThrown failed: No StringException was thrown.`);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
 
@@ -416,7 +416,7 @@ T enforce(T)(T value, lazy Throwable ex)
 }
 
 ///
-unittest
+version(StdUnittest) unittest
 {
     import core.stdc.stdlib : malloc, free;
     import std.conv : ConvException, to;
@@ -435,14 +435,14 @@ unittest
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assertNotThrown(enforce(true, new Exception("this should not be thrown")));
     assertThrown(enforce(false, new Exception("this should be thrown")));
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(enforce(123) == 123);
 
@@ -460,7 +460,7 @@ unittest
 }
 
 /// Alias your own enforce function
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : ConvException;
     alias convEnforce = enforce!ConvException;
@@ -485,7 +485,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 10510
     extern(C) void cFoo() { }
@@ -493,7 +493,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
 }
 
 // purity and safety inference test
-@system unittest
+version(StdUnittest) @system unittest
 {
     static foreach (EncloseSafe; [false, true])
     static foreach (EnclosePure; [false, true])
@@ -526,7 +526,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
 }
 
 // Test for bugzilla 8637
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -559,7 +559,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
     enforce!E2(s);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 14685
 
@@ -641,7 +641,7 @@ if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.i
 }
 
 //deprecated
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : OutOfMemoryError;
     import std.array : empty;
@@ -685,7 +685,7 @@ if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.i
 }
 
 //deprecated
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias enf = enforceEx!Exception;
     assertNotThrown(enf(true));
@@ -723,7 +723,7 @@ T collectException(T = Exception, E)(lazy E expression, ref E result)
     return null;
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int b;
     int foo() { throw new Exception("blah"); }
@@ -763,7 +763,7 @@ T collectException(T : Throwable = Exception, E)(lazy E expression)
     return null;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo() { throw new Exception("blah"); }
     assert(collectException(foo()));
@@ -801,7 +801,7 @@ string collectExceptionMsg(T = Exception, E)(lazy E expression)
         return e.msg.empty ? emptyExceptionMsg : e.msg;
 }
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void throwFunc() { throw new Exception("My Message."); }
     assert(collectExceptionMsg(throwFunc()) == "My Message.");
@@ -942,7 +942,7 @@ immutable(T[U]) assumeUnique(T, U)(ref T[U] array) pure nothrow
     return result;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to assumeUnique
     int[] arr = new int[1];
@@ -950,7 +950,7 @@ immutable(T[U]) assumeUnique(T, U)(ref T[U] array) pure nothrow
     assert(is(typeof(arr1) == immutable(int)[]) && arr == null);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[string] arr = ["a":1];
     auto arr1 = assumeUnique(arr);
@@ -1002,7 +1002,7 @@ T assumeWontThrow(T)(lazy T expr,
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : sqrt;
 
@@ -1027,7 +1027,7 @@ T assumeWontThrow(T)(lazy T expr,
     assert(computeLength(3, 4) == 5);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
 
@@ -1165,7 +1165,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 /// Pointers
-@system unittest
+version(StdUnittest) @system unittest
 {
     int  i = 0;
     int* p = null;
@@ -1175,7 +1175,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 /// Structs and Unions
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -1196,7 +1196,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 /// Arrays (dynamic and static)
-@system unittest
+version(StdUnittest) @system unittest
 {
     int i;
     int[]  slice = [0, 1, 2, 3, 4];
@@ -1228,7 +1228,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 /// Classes
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C
     {
@@ -1261,7 +1261,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     assert(b.doesPointTo(*aLoc)); // b points to where a is pointing
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S1 { int a; S1 * b; }
     S1 a1;
@@ -1311,7 +1311,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     assert(!doesPointTo(darr[0 .. 3], darr[3]));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //tests with static arrays
     //Static arrays themselves are just objects, and don't really *point* to anything.
@@ -1360,7 +1360,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 
-@system unittest //Unions
+version(StdUnittest) @system unittest //Unions
 {
     int i;
     union U //Named union
@@ -1399,7 +1399,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     assert( mayPointTo(s, i));
 }
 
-@system unittest //Classes
+version(StdUnittest) @system unittest //Classes
 {
     int i;
     static class A
@@ -1411,7 +1411,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     a.p = &i;
     assert(!doesPointTo(a, i)); //a does not point to i
 }
-@safe unittest //alias this test
+version(StdUnittest) @safe unittest //alias this test
 {
     static int i;
     static int j;
@@ -1428,7 +1428,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     assert( doesPointTo(cast(int*) s, i));
     assert(!doesPointTo(cast(int*) s, j));
 }
-@safe unittest //more alias this opCast
+version(StdUnittest) @safe unittest //more alias this opCast
 {
     void* p;
     class A
@@ -1460,7 +1460,7 @@ private bool isUnionAliasedImpl(T)(size_t offset)
     return count >= 2;
 }
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S
     {
@@ -1546,7 +1546,7 @@ class ErrnoException : Exception
         super(msg ~ " (" ~ errnoString(errno) ~ ")", file, line);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import core.stdc.errno : errno, EAGAIN;
 
@@ -1558,7 +1558,7 @@ class ErrnoException : Exception
         assert(ex.errno == EAGAIN);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import core.stdc.errno : EAGAIN;
         auto ex = new ErrnoException("oh no", EAGAIN);
@@ -1702,7 +1702,7 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
 }
 
 //Verify Examples
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
     import std.string;
@@ -1734,7 +1734,7 @@ CommonType!(T1, T2) ifThrown(T1, T2)(lazy scope T1 expression, scope T2 delegate
     assert("%s".format().ifThrown(e => e.classinfo.name) == "std.format.FormatException");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
     import std.conv;
@@ -2082,7 +2082,7 @@ pure @safe unittest
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : retro;
@@ -2097,7 +2097,7 @@ pure @safe unittest
     assert(handled.retro.equal("dlrow olleh")); // as well as `back`
 }
 
-pure nothrow @safe unittest
+version(StdUnittest) pure nothrow @safe unittest
 {
     static struct ThrowingRange
     {
@@ -2288,7 +2288,7 @@ mixin template basicExceptionCtors()
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class MeaCulpa: Exception
     {
@@ -2306,7 +2306,7 @@ mixin template basicExceptionCtors()
     }
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     class TestException : Exception { mixin basicExceptionCtors; }
     auto e = new Exception("msg");
@@ -2314,7 +2314,7 @@ mixin template basicExceptionCtors()
     auto te2 = new TestException("foo", e);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class TestException : Exception { mixin basicExceptionCtors; }
     auto e = new Exception("!!!");

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -361,7 +361,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     // One word before and after each allocation.
@@ -373,7 +373,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         && A.instance.suffix(b) == 0xDEAD_BEEF);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator : theAllocator, RCIAllocator;
@@ -395,7 +395,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         && B.suffix(b) == 0xDEAD_BEEF);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block
         : BitmappedBlock;
@@ -408,7 +408,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
 }
 
 // Test empty
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;
     import std.typecons : Ternary;
@@ -421,7 +421,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     alias A = AffixAllocator!(Mallocator, size_t);
@@ -436,7 +436,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     assert(b is null);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator;
     import std.experimental.allocator.gc_allocator;
@@ -459,7 +459,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     assert(p.ptr is d.ptr && p.length >= d.length);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator;
     alias a = AffixAllocator!(GCAllocator, uint).instance;
@@ -473,7 +473,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     () nothrow @nogc { a.deallocate(b); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
 
@@ -488,7 +488,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
 }
 
 // Test that reallocate infers from parent
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -549,7 +549,7 @@ template AllocatorList(alias factoryFunction,
 }
 
 ///
-version(Posix) @system unittest
+version(StdUnittest) version(Posix) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.free_list : ContiguousFreeList;
@@ -592,7 +592,7 @@ version(Posix) @system unittest
     assert(b1.length == 1024 * 10);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
@@ -606,7 +606,7 @@ version(Posix) @system unittest
     a.deallocateAll();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
@@ -621,7 +621,7 @@ version(Posix) @system unittest
     a.deallocateAll();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.region : Region;
@@ -641,7 +641,7 @@ version(Posix) @system unittest
     assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     enum bs = GCAllocator.alignment;
@@ -663,7 +663,7 @@ version(Posix) @system unittest
     a.deallocateAll();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -723,7 +723,7 @@ version(Posix) @system unittest
     assert(a.deallocateAll());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -689,7 +689,7 @@ version(StdUnittest)
     }
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     static void testAlloc(Allocator)(ref Allocator a) @nogc nothrow
     {
@@ -728,7 +728,7 @@ version(StdUnittest)
     testAlloc(aa);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     size_t numPages = 26214;
@@ -745,7 +745,7 @@ version(StdUnittest)
     assert(a.getAvailableSize() == 0);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     size_t numPages = 26214;
@@ -764,7 +764,7 @@ version(StdUnittest)
     assert(a.getAvailableSize() == 0);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     static void testAlloc(Allocator)(ref Allocator a) @nogc nothrow
     {
@@ -837,7 +837,7 @@ version(StdUnittest)
     testAlloc(aa);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     size_t numPages = 21000;
@@ -861,7 +861,7 @@ version(StdUnittest)
     }
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     size_t numPages = 21000;
@@ -885,7 +885,7 @@ version(StdUnittest)
     }
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     enum numPages = 2;
@@ -899,7 +899,7 @@ version(StdUnittest)
     assert(!a.data && !a.offset);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     enum numPages = 26;
@@ -913,7 +913,7 @@ version(StdUnittest)
     assert(!a.data && !a.offset);
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     size_t pageSize = getPageSize();
     enum numPages = 10;
@@ -948,7 +948,7 @@ version(StdUnittest)
     assert(!a.data && !a.offset);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.thread : ThreadGroup;
     import std.algorithm.sorting : sort;
@@ -988,7 +988,7 @@ version(StdUnittest)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.thread : ThreadGroup;
     import std.algorithm.sorting : sort;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -784,7 +784,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Create a block allocator on top of a 10KB stack region.
     import std.experimental.allocator.building_blocks.region : InSituRegion;
@@ -796,7 +796,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     assert(b.length == 100);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test chooseAtRuntime
     // Create a block allocator on top of a 10KB stack region.
@@ -810,7 +810,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     assert(b.length == 100);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Ternary;
 
@@ -821,13 +821,13 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     testAllocator!(() => BitmappedBlock!(64, 8, GCAllocator)(1024 * 64));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test chooseAtRuntime
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -835,7 +835,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     testAllocator!(() => BitmappedBlock!(chooseAtRuntime, 8, GCAllocator)(1024 * 64, blockSize));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void testAllocateAll(size_t bs)(uint blocks, uint blocksAtATime)
     {
@@ -952,7 +952,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     testAllocateAll!(128 * 20)(13 * 128, 128);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -1032,7 +1032,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.random;
@@ -1097,7 +1097,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
 }
 
 // Test totalAllocation and goodAllocSize
-nothrow @safe @nogc unittest
+version(StdUnittest) nothrow @safe @nogc unittest
 {
     BitmappedBlock!(8, 8, NullAllocator) h1;
     assert(h1.goodAllocSize(1) == 8);
@@ -1120,7 +1120,7 @@ nothrow @safe @nogc unittest
 }
 
 // Test owns
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
@@ -1150,7 +1150,7 @@ struct BitmappedBlockWithInternalPointers(
 {
     import std.conv : text;
     import std.typecons : Ternary;
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;
         auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
@@ -1354,7 +1354,7 @@ struct BitmappedBlockWithInternalPointers(
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Ternary;
 
@@ -1394,7 +1394,7 @@ struct BitmappedBlockWithInternalPointers(
     () nothrow @nogc { h.deallocate(b); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto h = BitmappedBlockWithInternalPointers!(4096)(new ubyte[4096 * 1024]);
     assert((() pure nothrow @safe @nogc => h.goodAllocSize(1))() == 4096);
@@ -1416,7 +1416,7 @@ private uint leadingOnes(ulong x)
     return result;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(leadingOnes(0) == 0);
     assert(leadingOnes(~0UL) == 64);
@@ -1442,7 +1442,7 @@ private uint findContigOnes(ulong x, uint n)
     return leadingOnes(~x);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(findContigOnes(0x0000_0000_0000_0300, 2) == 54);
 
@@ -1467,7 +1467,7 @@ private void setBits(ref ulong w, uint lsb, uint msb)
     w |= mask;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ulong w;
     w = 0; setBits(w, 0, 63); assert(w == ulong.max);
@@ -1678,7 +1678,7 @@ private struct BitVector
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto v = BitVector(new ulong[10]);
     assert(v.length == 640);

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -225,7 +225,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
@@ -246,7 +246,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     a.deallocate(b);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
@@ -282,7 +282,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
 }
 
 // Test alignedAllocate
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -304,7 +304,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     assert((() pure nothrow @safe @nogc => !a.expand(b, 1))());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;
     import std.experimental.allocator.gc_allocator : GCAllocator;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -29,8 +29,7 @@ struct FallbackAllocator(Primary, Fallback)
 
     // Need both allocators to be stateless
     // This is to avoid using default initialized stateful allocators
-    version(StdUnittest)
-    static if (!stateSize!Primary && !stateSize!Fallback)
+    version(StdUnittest) static if (!stateSize!Primary && !stateSize!Fallback)
     @system unittest
     {
         testAllocator!(() => FallbackAllocator());
@@ -262,7 +261,7 @@ struct FallbackAllocator(Primary, Fallback)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.experimental.allocator.building_blocks.region : InSituRegion;
@@ -284,7 +283,7 @@ struct FallbackAllocator(Primary, Fallback)
     () nothrow @nogc { a.deallocate(b2); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlockWithInternalPointers;
     import std.typecons : Ternary;
@@ -308,7 +307,7 @@ struct FallbackAllocator(Primary, Fallback)
     assert((() nothrow @safe @nogc => a.empty)() == Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;
@@ -323,7 +322,7 @@ struct FallbackAllocator(Primary, Fallback)
     assert(b.length == 100);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlockWithInternalPointers;
     import std.typecons : Ternary;
@@ -343,7 +342,7 @@ struct FallbackAllocator(Primary, Fallback)
     );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;
@@ -372,7 +371,7 @@ private auto ref forward(alias arg)()
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void fun(T)(auto ref T, string) { /* ... */ }
     void gun(T...)(auto ref T args)
@@ -384,7 +383,7 @@ private auto ref forward(alias arg)()
     gun(x, "hello");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void checkByRef(T)(auto ref T value)
     {
@@ -424,7 +423,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -438,7 +437,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     assert(a.primary.owns(b2) == Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -446,7 +445,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
 }
 
 // Ensure `owns` inherits function attributes
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : InSituRegion;
     import std.typecons : Ternary;
@@ -456,7 +455,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     assert((() pure nothrow @safe @nogc => a.owns(buff))() == Ternary.yes);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
@@ -470,7 +469,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     assert((() nothrow @safe @nogc => a.resolveInternalPointer(&b[0], p))() == Ternary.yes);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -407,7 +407,7 @@ struct FreeList(ParentAllocator,
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.experimental.allocator.building_blocks.stats_collector
@@ -437,7 +437,7 @@ struct FreeList(ParentAllocator,
     destroy(fl);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     FreeList!(GCAllocator, 0, 8) fl;
@@ -452,7 +452,7 @@ struct FreeList(ParentAllocator,
     assert(fl.root is null);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     FreeList!(GCAllocator, 0, 16) fl;
@@ -461,7 +461,7 @@ struct FreeList(ParentAllocator,
 }
 
 // Test that deallocateAll infers from parent
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
 
@@ -746,7 +746,7 @@ struct ContiguousFreeList(ParentAllocator,
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.allocator.building_blocks.allocator_list
         : AllocatorList;
@@ -759,7 +759,7 @@ struct ContiguousFreeList(ParentAllocator,
     );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.null_allocator
         : NullAllocator;
@@ -786,7 +786,7 @@ struct ContiguousFreeList(ParentAllocator,
     () nothrow @nogc { a.deallocate(b); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -819,7 +819,7 @@ struct ContiguousFreeList(ParentAllocator,
     assert((() nothrow @nogc => a.deallocateAll())());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     alias A = ContiguousFreeList!(GCAllocator, 64, 64);
@@ -1131,7 +1131,7 @@ struct SharedFreeList(ParentAllocator,
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.allocator.common : chooseAtRuntime;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1143,7 +1143,7 @@ struct SharedFreeList(ParentAllocator,
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.allocator.common : chooseAtRuntime;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1158,7 +1158,7 @@ struct SharedFreeList(ParentAllocator,
     assert(a.approxMaxLength  == 1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.thread : ThreadGroup;
     import std.algorithm.comparison : equal;
@@ -1191,7 +1191,7 @@ struct SharedFreeList(ParentAllocator,
     tg.joinAll();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
@@ -1204,7 +1204,7 @@ struct SharedFreeList(ParentAllocator,
     assert(a.nodes == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
@@ -1223,7 +1223,7 @@ struct SharedFreeList(ParentAllocator,
     assert(a.nodes == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static shared SharedFreeList!(Mallocator, 64, 128, 10) a;
@@ -1240,7 +1240,7 @@ struct SharedFreeList(ParentAllocator,
     assert(a.nodes == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime) a;
@@ -1252,7 +1252,7 @@ struct SharedFreeList(ParentAllocator,
     () nothrow @nogc { a.deallocate(c); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, chooseAtRuntime, chooseAtRuntime, chooseAtRuntime) a;
@@ -1260,7 +1260,7 @@ struct SharedFreeList(ParentAllocator,
     a.allocate(64);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40) a;
@@ -1268,7 +1268,7 @@ struct SharedFreeList(ParentAllocator,
     a.allocate(64);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     shared SharedFreeList!(Mallocator, 30, 40, chooseAtRuntime) a;
@@ -1276,7 +1276,7 @@ struct SharedFreeList(ParentAllocator,
     a.allocate(64);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Pull request #5556
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1286,7 +1286,7 @@ struct SharedFreeList(ParentAllocator,
     a.allocate(64);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Pull request #5556
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -413,13 +413,13 @@ struct FreeTree(ParentAllocator)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator;
     testAllocator!(() => FreeTree!GCAllocator());
 }
 
-@system unittest // issue 16506
+version(StdUnittest) @system unittest // issue 16506
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -438,7 +438,7 @@ struct FreeTree(ParentAllocator)
     f!GCAllocator(1);
 }
 
-@system unittest // issue 16507
+version(StdUnittest) @system unittest // issue 16507
 {
     static struct MyAllocator
     {
@@ -456,7 +456,7 @@ struct FreeTree(ParentAllocator)
     MyAllocator.alive = false;
 }
 
-@system unittest // "desperation mode"
+version(StdUnittest) @system unittest // "desperation mode"
 {
     uint myDeallocCounter = 0;
 
@@ -491,7 +491,7 @@ struct FreeTree(ParentAllocator)
     assert(y.ptr is null);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator;
     FreeTree!GCAllocator a;
@@ -501,7 +501,7 @@ struct FreeTree(ParentAllocator)
     assert(!__traits(compiles, (() pure nothrow @safe @nogc => a.goodAllocSize(0))()));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
 

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -632,7 +632,7 @@ allocator if $(D deallocate) is needed, yet the actual deallocation traffic is
 relatively low. The example below shows a $(D KRRegion) using stack storage
 fronting the GC allocator.
 */
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.fallback_allocator
         : fallbackAllocator;
@@ -656,7 +656,7 @@ It should perform slightly better because instead of searching through one
 large free list, it searches through several shorter lists in LRU order. Also,
 it actually returns memory to the operating system when possible.
 */
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -666,7 +666,7 @@ it actually returns memory to the operating system when possible.
     AllocatorList!(n => KRRegion!MmapAllocator(max(n * 16, 1024 * 1024))) alloc;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -699,7 +699,7 @@ it actually returns memory to the operating system when possible.
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -737,7 +737,7 @@ it actually returns memory to the operating system when possible.
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -748,7 +748,7 @@ it actually returns memory to the operating system when possible.
         n => KRRegion!GCAllocator(max(n * 16, 1024 * 1024)))());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
@@ -766,7 +766,7 @@ it actually returns memory to the operating system when possible.
     assert(alloc.allocateAll().length == 1024 * 1024);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
@@ -800,7 +800,7 @@ it actually returns memory to the operating system when possible.
     assert(b.length == 1024 * 1024 - KRRegion!().sizeof, text(b.length));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Ternary;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -814,7 +814,7 @@ it actually returns memory to the operating system when possible.
     assert(p.length == 1024 * 1024);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks;
     import std.random;
@@ -856,7 +856,7 @@ it actually returns memory to the operating system when possible.
     test(sizes32);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks;
     import std.random;
@@ -902,7 +902,7 @@ it actually returns memory to the operating system when possible.
     test(sizes32, word32);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
@@ -910,7 +910,7 @@ it actually returns memory to the operating system when possible.
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(1))() == typeof(*a.root).sizeof);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {   import std.typecons : Ternary;
 
     ubyte[1024] b;

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -75,7 +75,7 @@ struct NullAllocator
     static shared NullAllocator instance;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(NullAllocator.instance.alignedAllocate(100, 0) is null);
     assert(NullAllocator.instance.allocateAll() is null);

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -212,7 +212,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.free_tree : FreeTree;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -233,7 +233,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(buf.ptr);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     alias MyAlloc = Quantizer!(GCAllocator,
@@ -258,7 +258,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     () nothrow @nogc { a.deallocate(b); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -287,7 +287,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(c.length == 100);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -303,7 +303,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(alignedAt(&b[0], 16));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -341,7 +341,7 @@ struct Region(ParentAllocator = NullAllocator,
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -363,7 +363,7 @@ struct Region(ParentAllocator = NullAllocator,
     // Destructor will free the memory
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;
@@ -384,7 +384,7 @@ struct Region(ParentAllocator = NullAllocator,
     assert((() pure nothrow @safe @nogc => reg.empty)() ==  Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -392,7 +392,7 @@ struct Region(ParentAllocator = NullAllocator,
     testAllocator!(() => Region!(Mallocator, Mallocator.alignment, Yes.growDownwards)(1024 * 64));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -577,7 +577,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // 128KB region, allocated to x86's cache line
     InSituRegion!(128 * 1024, 16) r1;
@@ -611,7 +611,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     assert(a4.length == 104);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Ternary;
 
@@ -830,7 +830,7 @@ version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
     }
 }
 
-version(Posix) @system unittest
+version(StdUnittest) version(Posix) @system unittest
 {
     // Let's test the assumption that sbrk(n) returns the old address
     const p1 = sbrk(0);
@@ -842,7 +842,7 @@ version(Posix) @system unittest
     sbrk(-4096);
 }
 
-version(Posix) @system unittest
+version(StdUnittest) version(Posix) @system unittest
 {
     import std.typecons : Ternary;
     import std.algorithm.comparison : min;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -24,7 +24,7 @@ struct ScopedAllocator(ParentAllocator)
     {
         // This test is available only for stateless allocators
         version(StdUnittest)
-        @system unittest
+        version(StdUnittest) @system unittest
         {
             testAllocator!(() => ScopedAllocator());
         }
@@ -200,7 +200,7 @@ struct ScopedAllocator(ParentAllocator)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;
@@ -211,13 +211,13 @@ struct ScopedAllocator(ParentAllocator)
     assert(alloc.empty == Ternary.no);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     testAllocator!(() => ScopedAllocator!GCAllocator());
 }
 
-@system unittest // https://issues.dlang.org/show_bug.cgi?id=16046
+version(StdUnittest) @system unittest // https://issues.dlang.org/show_bug.cgi?id=16046
 {
     import std.exception;
     import std.experimental.allocator;
@@ -229,7 +229,7 @@ struct ScopedAllocator(ParentAllocator)
     alloc.dispose(bar); // segfault here
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     ScopedAllocator!GCAllocator a;
@@ -245,7 +245,7 @@ struct ScopedAllocator(ParentAllocator)
 }
 
 // Test that deallocateAll infers from parent
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
 
@@ -260,7 +260,7 @@ struct ScopedAllocator(ParentAllocator)
     assert((() nothrow @nogc => a.deallocateAll())());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -279,7 +279,7 @@ struct ScopedAllocator(ParentAllocator)
 }
 
 // Test empty
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -277,7 +277,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -345,7 +345,7 @@ if (Args.length > 3)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -363,7 +363,7 @@ if (Args.length > 3)
     a.deallocate(b);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.kernighan_ritchie : KRRegion;
@@ -378,7 +378,7 @@ if (Args.length > 3)
             == GCAllocator.instance.goodAllocSize(1));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;
     import std.typecons : Ternary;
@@ -418,7 +418,7 @@ if (Args.length > 3)
     assert(a.empty == Ternary.yes);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.typecons : Ternary;
@@ -436,7 +436,7 @@ if (Args.length > 3)
     assert((() nothrow @nogc => a.deallocate(b))());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlockWithInternalPointers;
     import std.typecons : Ternary;
@@ -460,7 +460,7 @@ if (Args.length > 3)
 }
 
 // Test that reallocate infers from parent
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -473,7 +473,7 @@ if (Args.length > 3)
     assert((() nothrow @nogc => a.deallocate(b))());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.typecons : Ternary;

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -9,7 +9,7 @@ Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_stats_collector.
 module std.experimental.allocator.building_blocks.stats_collector;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.building_blocks.free_list : FreeList;
@@ -658,7 +658,7 @@ public:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -680,7 +680,7 @@ public:
     assert(File(f).byLine.walkLength == 22);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(Allocator)()
     {
@@ -719,7 +719,7 @@ public:
         Options.all));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(Allocator)()
     {
@@ -740,7 +740,7 @@ public:
     test!(StatsCollector!(GCAllocator, 0, 0));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     StatsCollector!(GCAllocator, 0, 0) a;
@@ -749,7 +749,7 @@ public:
     assert((() pure nothrow @safe @nogc => a.goodAllocSize(1))());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
 

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -29,7 +29,7 @@ template stateSize(T)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     static assert(stateSize!void == 0);
     struct A {}
@@ -103,7 +103,7 @@ package size_t roundUpToMultipleOf(size_t s, uint base)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     assert(10.roundUpToMultipleOf(11) == 11);
     assert(11.roundUpToMultipleOf(11) == 11);
@@ -128,7 +128,7 @@ package size_t roundUpToAlignment(size_t n, uint alignment)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     assert(10.roundUpToAlignment(4) == 12);
     assert(11.roundUpToAlignment(2) == 12);
@@ -148,7 +148,7 @@ package size_t roundDownToAlignment(size_t n, uint alignment)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     assert(10.roundDownToAlignment(4) == 8);
     assert(11.roundDownToAlignment(2) == 10);
@@ -171,7 +171,7 @@ package void[] roundUpToAlignment(void[] b, uint a)
 }
 
 @nogc nothrow pure
-@system unittest
+version(StdUnittest) @system unittest
 {
     void[] empty;
     assert(roundUpToAlignment(empty, 4) == null);
@@ -204,7 +204,7 @@ package void[] roundStartToMultipleOf(void[] s, uint base)
 }
 
 nothrow pure
-@system unittest
+version(StdUnittest) @system unittest
 {
     void[] p;
     assert(roundStartToMultipleOf(p, 16) is null);
@@ -233,7 +233,7 @@ package size_t roundUpToPowerOf2(size_t s)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     assert(0.roundUpToPowerOf2 == 0);
     assert(1.roundUpToPowerOf2 == 1);
@@ -264,7 +264,7 @@ package uint trailingZeros(ulong x)
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     assert(trailingZeros(0) == 64);
     assert(trailingZeros(1) == 0);
@@ -293,7 +293,7 @@ package uint effectiveAlignment(void* ptr)
 }
 
 @nogc nothrow pure
-@system unittest
+version(StdUnittest) @system unittest
 {
     int x;
     assert(effectiveAlignment(&x) >= int.alignof);
@@ -404,7 +404,7 @@ if (hasMember!(Allocator, "alignedAllocate"))
     return true;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool called = false;
     struct DummyAllocator

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -14,7 +14,7 @@ struct GCAllocator
 {
     import core.memory : GC;
     import std.typecons : Ternary;
-    @system unittest { testAllocator!(() => GCAllocator.instance); }
+    version(StdUnittest) @system unittest { testAllocator!(() => GCAllocator.instance); }
 
     /**
     The alignment is a static constant equal to $(D platformAlignment), which
@@ -127,7 +127,7 @@ struct GCAllocator
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto buffer = GCAllocator.instance.allocate(1024 * 1024 * 4);
     // deallocate upon scope's end (alternatively: leave it to collection)
@@ -135,13 +135,13 @@ struct GCAllocator
     //...
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto b = GCAllocator.instance.allocate(10_000);
     assert(GCAllocator.instance.expand(b, 1));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.memory : GC;
     import std.typecons : Ternary;
@@ -173,7 +173,7 @@ struct GCAllocator
     assert((() nothrow @safe @nogc => GCAllocator.instance.goodAllocSize(4096 * 4 + 1))() == 4096 * 5);
 }
 
-nothrow @safe unittest
+version(StdUnittest) nothrow @safe unittest
 {
     import std.typecons : Ternary;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -74,14 +74,14 @@ struct Mallocator
 }
 
 ///
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     auto buffer = Mallocator.instance.allocate(1024 * 1024 * 4);
     scope(exit) Mallocator.instance.deallocate(buffer);
     //...
 }
 
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     @nogc nothrow
     static void test(A)()
@@ -95,7 +95,7 @@ struct Mallocator
     test!Mallocator();
 }
 
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     static void test(A)()
     {
@@ -202,7 +202,7 @@ version (Windows)
  */
 struct AlignedMallocator
 {
-    @system unittest { testAllocator!(() => typeof(this).instance); }
+    version(StdUnittest) @system unittest { testAllocator!(() => typeof(this).instance); }
 
     /**
     The default alignment is $(D platformAlignment).
@@ -346,7 +346,7 @@ struct AlignedMallocator
 }
 
 ///
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     auto buffer = AlignedMallocator.instance.alignedAllocate(1024 * 1024 * 4,
         128);
@@ -359,7 +359,7 @@ version(StdUnittest) version(CRuntime_DigitalMars)
 size_t addr(ref void* ptr) { return cast(size_t) ptr; }
 
 version(Posix)
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     // 16398 : test the "pseudo" alignedReallocate for Posix
     void[] s = AlignedMallocator.instance.alignedAllocate(16, 32);
@@ -386,7 +386,7 @@ version(Posix)
 }
 
 version(CRuntime_DigitalMars)
-@nogc @system nothrow unittest
+version(StdUnittest) @nogc @system nothrow unittest
 {
     void* m;
 

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -72,7 +72,7 @@ struct MmapAllocator
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias alloc = MmapAllocator.instance;
     auto p = alloc.allocate(100);

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -227,7 +227,7 @@ public import std.experimental.allocator.common,
     std.experimental.allocator.typed;
 
 // Example in the synopsis above
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : min, max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -531,7 +531,7 @@ nothrow:
     }
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
     import std.conv : emplace;
@@ -553,7 +553,7 @@ unittest
     assert((cast(CAllocatorImpl!(Region!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;
@@ -576,7 +576,7 @@ unittest
             ~ to!string(bytesUsed) ~ " bytes");
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;
@@ -1000,7 +1000,7 @@ nothrow @system @nogc
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Install a new allocator that is faster for 128-byte allocations.
     import std.experimental.allocator.building_blocks.free_list : FreeList;
@@ -1042,7 +1042,7 @@ nothrow @system @nogc
     _processAllocator = a;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -1156,7 +1156,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Dynamically allocate one integer
     const int* p1 = theAllocator.make!int;
@@ -1202,7 +1202,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
     assert(outer.x == inner.getX);
 }
 
-@system unittest // bugzilla 15639 & 15772
+version(StdUnittest) @system unittest // bugzilla 15639 & 15772
 {
     abstract class Foo {}
     class Bar: Foo {}
@@ -1210,7 +1210,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
     static assert( is(typeof(theAllocator.make!Bar)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(Allocator)(auto ref Allocator alloc)
     {
@@ -1268,7 +1268,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
 }
 
 // Attribute propagation
-nothrow @safe @nogc unittest
+version(StdUnittest) nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     alias alloc = Mallocator.instance;
@@ -1286,7 +1286,7 @@ nothrow @safe @nogc unittest
 }
 
 // should be pure with the GCAllocator
-/*pure nothrow*/ @safe unittest
+version(StdUnittest) /*pure nothrow*/ @safe unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
@@ -1305,7 +1305,7 @@ nothrow @safe @nogc unittest
 }
 
 // Verify that making an object by calling an impure constructor is not @safe
-nothrow @safe @nogc unittest
+version(StdUnittest) nothrow @safe @nogc unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     static struct Pure { this(int) pure nothrow @nogc @safe {} }
@@ -1320,7 +1320,7 @@ nothrow @safe @nogc unittest
 }
 
 // test failure with a pure, failing struct
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown, enforce;
 
@@ -1337,7 +1337,7 @@ nothrow @safe @nogc unittest
 }
 
 // test failure with an impure, failing struct
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown, enforce;
     static int g;
@@ -1378,7 +1378,7 @@ if (T.sizeof != 1)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test T.sizeof == 1 path of fillWithMemcpy.
     ubyte[] a;
@@ -1389,7 +1389,7 @@ if (T.sizeof != 1)
     assert(a == [ 42, 42, 42, 42, 42]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a;
     fillWithMemcpy(a, 42);
@@ -1407,7 +1407,7 @@ private T[] uninitializedFillDefault(T)(T[] array) nothrow
 }
 
 pure nothrow @nogc
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S { int x = 42; @disable this(this); }
 
@@ -1417,7 +1417,7 @@ pure nothrow @nogc
     assert((cast(int*) arr.ptr)[0 .. arr.length] == expected);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = [1, 2, 4];
     uninitializedFillDefault(a);
@@ -1452,7 +1452,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
     return () @trusted { return cast(T[]) uninitializedFillDefault(cast(U[]) m); }();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test1(A)(auto ref A alloc)
     {
@@ -1481,7 +1481,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
     test2(theAllocator);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto a = theAllocator.makeArray!(shared int)(5);
@@ -1553,7 +1553,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length, T init)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     static void test(T)()
@@ -1572,7 +1572,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length, T init)
     test!(immutable int)();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(T)(in T initialValue)
     {
@@ -1584,7 +1584,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length, T init)
     test(init);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1600,7 +1600,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length, T init)
 }
 
 // test failure with a pure, failing struct
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown, enforce;
 
@@ -1621,7 +1621,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length, T init)
 }
 
 // test failure with an impure, failing struct
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown, enforce;
 
@@ -1762,7 +1762,7 @@ if (isInputRange!R && !isInfinite!R)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1783,7 +1783,7 @@ if (isInputRange!R && !isInfinite!R)
 }
 
 // infer types for strings
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -1805,7 +1805,7 @@ if (isInputRange!R && !isInfinite!R)
     test(theAllocator);
 }
 
-/*pure*/ nothrow @safe unittest
+version(StdUnittest) /*pure*/ nothrow @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -1824,7 +1824,7 @@ if (isInputRange!R && !isInfinite!R)
 }
 
 // test failure with a pure, failing struct
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown, enforce;
 
@@ -1871,7 +1871,7 @@ if (isInputRange!R && !isInfinite!R)
 }
 
 // test failure with an impure, failing struct
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown, enforce;
 
@@ -1942,7 +1942,7 @@ version(StdUnittest)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array : array;
     import std.range : iota;
@@ -2001,7 +2001,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
     return true;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -2030,7 +2030,7 @@ bool expandArray(T, Allocator)(auto ref Allocator alloc, ref T[] array,
     return true;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -2104,7 +2104,7 @@ if (isInputRange!R)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto arr = theAllocator.makeArray!int([1, 2, 3]);
     assert(theAllocator.expandArray(arr, 2));
@@ -2114,7 +2114,7 @@ if (isInputRange!R)
     assert(arr == [1, 2, 3, 0, 0, 4, 5]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto arr = theAllocator.makeArray!int([1, 2, 3]);
     ForcedInputRange r;
@@ -2188,7 +2188,7 @@ bool shrinkArray(T, Allocator)(auto ref Allocator alloc,
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] a = theAllocator.makeArray!int(100, 42);
     assert(a.length == 100);
@@ -2197,7 +2197,7 @@ bool shrinkArray(T, Allocator)(auto ref Allocator alloc,
     assert(a == [42, 42]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(A)(auto ref A alloc)
     {
@@ -2271,7 +2271,7 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
         array = null;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static int x;
     static interface I
@@ -2309,7 +2309,7 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
     theAllocator.dispose(arr);
 }
 
-@system unittest //bugzilla 16512
+version(StdUnittest) @system unittest //bugzilla 16512
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -2330,7 +2330,7 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
     assert(ua is null);
 }
 
-@system unittest //bugzilla 15721
+version(StdUnittest) @system unittest //bugzilla 15721
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -2373,7 +2373,7 @@ auto makeMultidimensionalArray(T, Allocator, size_t N)(auto ref Allocator alloc,
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -2417,7 +2417,7 @@ void disposeMultidimensionalArray(T, Allocator)(auto ref Allocator alloc, auto r
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct TestAllocator
     {
@@ -2535,7 +2535,7 @@ RCIAllocator allocatorObject(A)(A* pa)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -2554,7 +2554,7 @@ RCIAllocator allocatorObject(A)(A* pa)
     assert(a.deallocate(b));
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.conv;
     import std.experimental.allocator.mallocator;
@@ -3111,7 +3111,7 @@ nothrow:
 
 
 // Example in intro above
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Allocate an int, initialize it with 42
     int* p = theAllocator.make!int(42);
@@ -3185,7 +3185,7 @@ struct ThreadLocal(A)
 }
 
 ///
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -3389,7 +3389,7 @@ private struct EmbeddedTree(T, alias less)
     }
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
 
@@ -3534,7 +3534,7 @@ private struct InternalPointersTree(Allocator)
     }
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.random : randomCover;
@@ -3572,7 +3572,7 @@ unittest
 }
 
 //version (std_allocator_benchmark)
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
     import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
@@ -3641,7 +3641,7 @@ unittest
     )(20)[].map!(t => t.to!Duration));
 }
 
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.building_blocks.free_list : FreeList;
     import std.experimental.allocator.building_blocks.region : InSituRegion;
@@ -3666,7 +3666,7 @@ unittest
 }
 
 ///
-unittest
+version(StdUnittest) unittest
 {
     import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlock;

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -40,7 +40,7 @@ alias StackFront(size_t stackSize, Allocator = GCAllocator) =
         Allocator);
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     StackFront!4096 a;
     auto b = a.allocate(4000);
@@ -85,7 +85,7 @@ auto mmapRegionList(size_t bytesPerRegion)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto alloc = mmapRegionList(1024 * 1024);
     const b = alloc.allocate(100);

--- a/std/experimental/allocator/typed.d
+++ b/std/experimental/allocator/typed.d
@@ -394,7 +394,7 @@ struct TypedAllocator(PrimaryAllocator, Policies...)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -194,7 +194,7 @@ module std.experimental.checkedint;
 import std.traits : isFloatingPoint, isIntegral, isNumeric, isUnsigned, Unqual;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] concatAndAdd(int[] a, int[] b, int offset)
     {
@@ -246,7 +246,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     */
     auto get() inout { return payload; }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto x = checked(ubyte(42));
         static assert(is(typeof(x.get()) == ubyte));
@@ -264,7 +264,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     {
         enum Checked!(T, Hook) min = Checked!(T, Hook)(Hook.min!T);
         ///
-        @system unittest
+        version(StdUnittest) @system unittest
         {
             assert(Checked!short.min == -32768);
             assert(Checked!(short, WithNaN).min == -32767);
@@ -297,7 +297,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             payload = rhs.payload;
     }
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto a = checked(42L);
         assert(a == 42);
@@ -316,7 +316,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             payload = rhs.payload;
     }
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         Checked!long a;
         a = 42L;
@@ -381,7 +381,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         }
     }
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         assert(cast(uint) checked(42) == 42);
         assert(cast(uint) checked!WithNaN(-42) == uint.max);
@@ -435,7 +435,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     }
 
     ///
-    static if (is(T == int) && is(Hook == void)) @safe unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @safe unittest
     {
         static struct MyHook
         {
@@ -536,7 +536,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     }
 
     ///
-    static if (is(T == int) && is(Hook == void)) @safe unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @safe unittest
     {
         static struct MyHook
         {
@@ -578,7 +578,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     }
 
     // For coverage
-    static if (is(T == int) && is(Hook == void)) @system unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @system unittest
     {
         assert(checked(42) <= checked!void(42));
         assert(checked!void(42) <= checked(42u));
@@ -657,7 +657,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     }
 
     ///
-    static if (is(T == int) && is(Hook == void)) @safe unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @safe unittest
     {
         static struct MyHook
         {
@@ -789,7 +789,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         }
     }
 
-    static if (is(T == int) && is(Hook == void)) @system unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @system unittest
     {
         const a = checked(42);
         assert(a + 1 == 43);
@@ -867,7 +867,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         }
     }
 
-    static if (is(T == int) && is(Hook == void)) @system unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @system unittest
     {
         assert(1 + checked(1) == 2);
         static uint tally;
@@ -956,7 +956,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     }
 
     ///
-    static if (is(T == int) && is(Hook == void)) @safe unittest
+    version(StdUnittest) static if (is(T == int) && is(Hook == void)) @safe unittest
     {
         static struct MyHook
         {
@@ -996,7 +996,7 @@ if (is(typeof(Checked!(T, Hook)(value))))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static assert(is(typeof(checked(42)) == Checked!int));
     assert(checked(42) == Checked!int(42));
@@ -1005,7 +1005,7 @@ if (is(typeof(Checked!(T, Hook)(value))))
 }
 
 // get
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test(T)()
     {
@@ -1159,7 +1159,7 @@ static:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void test(T)()
     {
@@ -1332,7 +1332,7 @@ struct Throw
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test(T)()
     {
@@ -1446,7 +1446,7 @@ static:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = checked!Warn(-42);
         // Passes
@@ -1485,7 +1485,7 @@ static:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto x = checked!Warn(-42);
         // Passes
@@ -1524,7 +1524,7 @@ static:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto x = checked!Warn(42);
     short x1 = cast(short) x;
@@ -1648,7 +1648,7 @@ struct ProperCompare
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias opEqualsProper = ProperCompare.hookOpEquals;
     assert(opEqualsProper(42, 42));
@@ -1663,7 +1663,7 @@ struct ProperCompare
     assert(!opEqualsProper(3_000_000_000U, -1_294_967_296));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias opCmpProper = ProperCompare.hookOpCmp;
     assert(opCmpProper(42, 42) == 0);
@@ -1679,7 +1679,7 @@ struct ProperCompare
     assert(opCmpProper(-1.0, -1) == 0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x1 = Checked!(uint, ProperCompare)(42u);
     assert(x1.get < -1);
@@ -1758,7 +1758,7 @@ static:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto x = checked!WithNaN(422);
         assert((cast(ubyte) x) == 255);
@@ -1811,7 +1811,7 @@ static:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Checked!(int, WithNaN) x;
         assert(!(x < 0) && !(x > 0) && !(x == 0));
@@ -1870,7 +1870,7 @@ static:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Checked!(int, WithNaN) x;
         ++x;
@@ -1882,7 +1882,7 @@ static:
         assert(!x.isNaN);
     }
 
-    @safe unittest // for coverage
+    version(StdUnittest) @safe unittest // for coverage
     {
         Checked!(uint, WithNaN) y;
         ++y;
@@ -1920,7 +1920,7 @@ static:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Checked!(int, WithNaN) x;
         assert((x + 1).isNaN);
@@ -1958,7 +1958,7 @@ static:
         return defaultValue!Result;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Checked!(int, WithNaN) x;
         assert((1 + x).isNaN);
@@ -1995,7 +1995,7 @@ static:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Checked!(int, WithNaN) x;
         x += 4;
@@ -2009,7 +2009,7 @@ static:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x1 = Checked!(int, WithNaN)();
     assert(x1.isNaN);
@@ -2046,7 +2046,7 @@ bool isNaN(T)(const Checked!(T, WithNaN) x)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x1 = Checked!(int, WithNaN)();
     assert(x1.isNaN);
@@ -2056,7 +2056,7 @@ bool isNaN(T)(const Checked!(T, WithNaN) x)
     assert(x1.isNaN);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test1(T)()
     {
@@ -2101,7 +2101,7 @@ bool isNaN(T)(const Checked!(T, WithNaN) x)
     test2!int;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Smart(T) = Checked!(Checked!(T, ProperCompare), WithNaN);
     Smart!int x1;
@@ -2149,7 +2149,7 @@ static:
         return bound;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto x = checked!Saturate(short(100));
         x += 33000;
@@ -2207,7 +2207,7 @@ static:
             static assert(false);
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(checked!Saturate(int.max) + 1 == int.max);
         assert(checked!Saturate(100) ^^ 10 == int.max);
@@ -2221,7 +2221,7 @@ static:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x = checked!Saturate(int.max);
     ++x;
@@ -2459,7 +2459,7 @@ fail:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool overflow;
     assert(opChecked!"+"(const short(1), short(1), overflow) == 2 && !overflow);
@@ -2470,7 +2470,7 @@ fail:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool overflow;
     assert(opChecked!"-"(1, 1, overflow) == 0 && !overflow);
@@ -2479,7 +2479,7 @@ fail:
     assert(opChecked!"-"(-1, 1u, overflow) == 0 && overflow);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool overflow;
     assert(opChecked!"*"(2, 3, overflow) == 6 && !overflow);
@@ -2488,7 +2488,7 @@ fail:
     //assert(mul(-1, 1u, overflow) == uint.max - 1 && overflow);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool overflow;
     assert(opChecked!"/"(6, 3, overflow) == 2 && !overflow);
@@ -2586,7 +2586,7 @@ if (isIntegral!T && T.sizeof >= 4)
     return r;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void testPow(T)(T x, uint e)
     {
@@ -2656,7 +2656,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opBinary
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     auto x = Checked!(const int, void)(42), y = Checked!(immutable int, void)(142);
     assert(x + y == 184);
@@ -2739,7 +2739,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opBinaryRight
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     auto x1 = Checked!(int, CountOverflows)(42);
     assert(1 + x1 == 43);
@@ -2751,7 +2751,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opOpAssign
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x1 = Checked!(int, CountOverflows)(3);
     assert((x1 += 2) == 5);
@@ -2772,7 +2772,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opAssign
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Checked!(int, void) x;
     x = 42;
@@ -2785,7 +2785,7 @@ version(StdUnittest) private struct CountOpBinary
     assert(x.get == 44);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!is(typeof(Checked!(short, void)(ushort(42)))));
     static assert(!is(typeof(Checked!(int, void)(long(42)))));
@@ -2795,7 +2795,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opCast
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     static assert(is(typeof(cast(float) Checked!(int, void)(42)) == float));
     assert(cast(float) Checked!(int, void)(42) == 42);
@@ -2855,7 +2855,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opEquals
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     assert(Checked!(int, void)(42) == 42L);
     assert(42UL == Checked!(int, void)(42));
@@ -2909,7 +2909,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opCmp
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     Checked!(int, void) x;
     assert(x <= x);
@@ -2959,7 +2959,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 // opUnary
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     auto x = Checked!(int, void)(42);
     assert(x == +x);
@@ -3027,7 +3027,7 @@ version(StdUnittest) private struct CountOpBinary
 }
 
 //
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     Checked!(int, void) x;
     assert(x == x);

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -121,7 +121,7 @@ if (!moduleName.length)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static assert(moduleLogLevel!"" == LogLevel.all);
 }
@@ -147,7 +147,7 @@ if (moduleName.length)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static assert(moduleLogLevel!"not.amodule.path" == LogLevel.all);
 }
@@ -665,7 +665,7 @@ private void formatString(A...)(MsgRange oRange, A args)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void dummy() @safe
     {
@@ -1741,7 +1741,7 @@ class StdForwardLogger : Logger
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto nl1 = new StdForwardLogger(LogLevel.all);
 }
@@ -1800,7 +1800,7 @@ functions.
 }
 
 /// Ditto
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.experimental.logger.filelogger : FileLogger;
     import std.file : deleteme, remove;
@@ -1813,7 +1813,7 @@ functions.
     destroy(tempLog);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     LogLevel ll = globalLogLevel;
     globalLogLevel = LogLevel.fatal;
@@ -1852,7 +1852,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     logger.log(s);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto tl1 = new TestLogger();
     testFuncNames(tl1);
@@ -1863,7 +1863,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(tl1.msg == "I'm here", tl1.msg);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto tl1 = new TestLogger(LogLevel.all);
     tl1.log();
@@ -1904,7 +1904,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(tl1.line == __LINE__ - 1);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.logger.multilogger : MultiLogger;
 
@@ -1929,7 +1929,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(n is null);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool errorThrown = false;
     auto tl = new TestLogger;
@@ -1941,7 +1941,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(errorThrown);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.exception : assertThrown, assertNotThrown;
@@ -2083,7 +2083,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(l.logLevel == LogLevel.all);
 }
 
-@system unittest // default logger
+version(StdUnittest) @system unittest // default logger
 {
     import std.file : deleteme, exists, remove;
     import std.stdio : File;
@@ -2123,7 +2123,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     file.close();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.file : deleteme, remove;
     import std.stdio : File;
@@ -2158,7 +2158,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     file.close();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -2176,7 +2176,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // testing possible log conditions
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.format : format;
@@ -2423,7 +2423,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // more testing
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     import std.format : format;
@@ -2680,7 +2680,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // testing more possible log conditions
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     bool fatalLog;
     auto mem = new TestLogger;
@@ -2911,7 +2911,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // Issue #5
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string : indexOf;
 
@@ -2931,7 +2931,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // Issue #5
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.logger.multilogger : MultiLogger;
     import std.string : indexOf;
@@ -2960,7 +2960,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
     assert(tl.msg.indexOf("error") == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     auto tl = new TestLogger();
@@ -2968,7 +2968,7 @@ version(StdUnittest) private void testFuncNames(Logger logger) @safe
 }
 
 // log objects with non-safe toString
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Test
     {
@@ -2999,7 +2999,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 
 // check that thread-local logging does not propagate
 // to shared logger
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.atomic, core.thread, std.concurrency;
 
@@ -3059,7 +3059,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
     assert(atomicOp!"=="(logged_count, 4));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);
@@ -3072,7 +3072,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Issue 14940
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : Nullable;
 
@@ -3083,7 +3083,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Ensure @system toString methods work
-@system unittest
+version(StdUnittest) @system unittest
 {
     enum SystemToStringMsg = "SystemToString";
     static struct SystemToString
@@ -3102,7 +3102,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Issue 17328
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
 
@@ -3124,7 +3124,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Issue 15954
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     auto tl = new TestLogger();
@@ -3133,7 +3133,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Issue 16256
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     auto tl = new TestLogger();
@@ -3142,7 +3142,7 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 }
 
 // Issue 15517
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.file : exists, remove;
     import std.stdio : File;

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -180,7 +180,7 @@ class FileLogger : Logger
     protected string filename;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array : empty;
     import std.file : deleteme, remove;
@@ -209,7 +209,7 @@ class FileLogger : Logger
     assert(readLine.indexOf(notWritten) == -1, readLine);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.file : rmdirRecurse, exists, deleteme;
     import std.path : dirName;
@@ -227,7 +227,7 @@ class FileLogger : Logger
     f.file.close();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array : empty;
     import std.file : deleteme, remove;
@@ -258,7 +258,7 @@ class FileLogger : Logger
     file.close();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -106,7 +106,7 @@ class MultiLogger : Logger
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     import std.experimental.logger.nulllogger;
@@ -127,7 +127,7 @@ class MultiLogger : Logger
     assert(n is null);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = new MultiLogger;
     auto n0 = new TestLogger;
@@ -143,7 +143,7 @@ class MultiLogger : Logger
 }
 
 // Issue #16
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.file : deleteme;
     import std.stdio : File;
@@ -187,7 +187,7 @@ class MultiLogger : Logger
     assert(line.indexOf(iMsg) != -1, line ~ ":" ~ tMsg);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto dl = cast(FileLogger) sharedLog;
     assert(dl !is null);

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -32,7 +32,7 @@ class NullLogger : Logger
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.logger.core : LogLevel;
     auto nl1 = new NullLogger(LogLevel.all);

--- a/std/experimental/scripting.d
+++ b/std/experimental/scripting.d
@@ -4,7 +4,7 @@ Convenience file that allows to import entire Phobos in one command.
 module std.experimental.scripting;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.scripting;
 
@@ -21,7 +21,7 @@ module std.experimental.scripting;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.experimental.scripting;
     assert(10.iota.map!(partial!(pow, 2)).sum == 1023);

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -56,7 +56,7 @@ if (is(T == class) || is(T == interface))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C { @disable opCast(T)() {} }
     auto c = new C;
@@ -129,7 +129,7 @@ if (Targets.length >= 1 && !allSatisfy!(isMutable, Targets))
     alias implementsInterface = .implementsInterface!(Source, staticMap!(Unqual, Targets));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface Foo {
         void foo();
@@ -375,7 +375,7 @@ private template wrapperSignature(alias fun)
         ~ name~"("~wrapperParameters~")"~mod;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface M
     {
@@ -427,7 +427,7 @@ version(StdDdoc)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface Quack
     {
@@ -508,7 +508,7 @@ version(StdDdoc)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.traits : functionAttributes, FunctionAttribute;
     interface A { int run(); }
@@ -609,7 +609,7 @@ template unwrap(Target)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Validate const/immutable
     class A
@@ -656,7 +656,7 @@ template unwrap(Target)
         assert(d.draw(10) == 10);
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 10377
     import std.algorithm, std.range;
@@ -673,7 +673,7 @@ template unwrap(Target)
     auto r = iota(0,10,1).inputRangeObject().wrap!(MyInputRange!int)();
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 10536
     interface Interface
@@ -689,7 +689,7 @@ template unwrap(Target)
     Interface i = new Pluggable().wrap!Interface;
     assert(i.foo() == 1);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Enhancement 10538
     interface Interface
@@ -911,7 +911,7 @@ Final!T makeFinal(T)(T t)
 }
 
 /// `Final` can be used to create class references which cannot be rebound:
-pure nothrow @safe unittest
+version(StdUnittest) pure nothrow @safe unittest
 {
     static class A
     {
@@ -933,7 +933,7 @@ pure nothrow @safe unittest
 }
 
 /// `Final` can also be used to create read-only data fields without using transitive immutability:
-pure nothrow @safe unittest
+version(StdUnittest) pure nothrow @safe unittest
 {
     static class A
     {
@@ -964,7 +964,7 @@ pure nothrow @safe unittest
     assert(b.a.i == 24);
 }
 
-pure nothrow @safe unittest
+version(StdUnittest) pure nothrow @safe unittest
 {
     static class A { int i; }
     static assert(!is(Final!A == A));
@@ -1037,7 +1037,7 @@ pure nothrow @safe unittest
     assert(c.get == 30);
 }
 
-pure nothrow @safe unittest
+version(StdUnittest) pure nothrow @safe unittest
 {
     auto arr = makeFinal([1, 2, 3]);
     static assert(!__traits(compiles, arr = null));
@@ -1046,7 +1046,7 @@ pure nothrow @safe unittest
 }
 
 // issue 17270
-pure nothrow @nogc @system unittest
+version(StdUnittest) pure nothrow @nogc @system unittest
 {
     int i = 1;
     Final!(int*) fp = &i;
@@ -1061,7 +1061,7 @@ pure nothrow @nogc @system unittest
     assert(*p == 2);
 }
 
-pure nothrow @system unittest
+version(StdUnittest) pure nothrow @system unittest
 {
     Final!(int[]) arr;
     // static assert(!__traits(compiles,

--- a/std/file.d
+++ b/std/file.d
@@ -263,7 +263,7 @@ private T cenforce(T)(T condition, const(char)[] name, const(FSChar)* namez,
     throw new FileException(name, .errno, file, line);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 17102
     try
@@ -303,7 +303,7 @@ if (isInputRange!R && isSomeChar!(ElementEncodingType!R) && !isInfinite!R &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.utf : byChar;
     scope(exit)
@@ -325,7 +325,7 @@ if (isConvertibleToString!R)
     return read!(StringTypeOf!R)(name, upTo);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, read(TestAliasedString(null))));
 }
@@ -456,7 +456,7 @@ version (linux) @safe unittest
     //writefln("'%s'", s);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     scope(exit) if (exists(deleteme)) remove(deleteme);
     import std.stdio;
@@ -494,7 +494,7 @@ if (isSomeString!S &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : enforce;
     write(deleteme, "abc"); // deleteme is the name of a temporary file
@@ -510,7 +510,7 @@ if (isConvertibleToString!R)
     return readText!(S, StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, readText(TestAliasedString(null))));
 }
@@ -539,7 +539,7 @@ if ((isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) || is
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
    scope(exit)
    {
@@ -559,7 +559,7 @@ if (isConvertibleToString!R)
     write!(StringTypeOf!R)(name, buffer);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, write(TestAliasedString(null), null)));
 }
@@ -586,7 +586,7 @@ if ((isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) || is
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
    scope(exit)
    {
@@ -608,7 +608,7 @@ if (isConvertibleToString!R)
     append!(StringTypeOf!R)(name, buffer);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, append(TestAliasedString("foo"), [0, 1, 2, 3])));
 }
@@ -726,7 +726,7 @@ if (isConvertibleToString!RF || isConvertibleToString!RT)
     rename!Types(from, to);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, rename(TestAliasedString(null), TestAliasedString(null))));
     static assert(__traits(compiles, rename("", TestAliasedString(null))));
@@ -766,7 +766,7 @@ private void renameImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, 
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.utf : byWchar;
 
@@ -806,7 +806,7 @@ if (isConvertibleToString!R)
     remove!(StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, remove(TestAliasedString("foo"))));
 }
@@ -915,12 +915,12 @@ if (isConvertibleToString!R)
     return getSize!(StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, getSize(TestAliasedString("foo"))));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // create a file of size 1
     write(deleteme, "a");
@@ -1012,13 +1012,13 @@ if (isConvertibleToString!R)
     return getTimes!(StringTypeOf!R)(name, accessTime, modificationTime);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     SysTime atime, mtime;
     static assert(__traits(compiles, getTimes(TestAliasedString("foo"), atime, mtime)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.stdio : writefln;
 
@@ -1313,13 +1313,13 @@ if (isConvertibleToString!R)
     setTimes!(StringTypeOf!R)(name, accessTime, modificationTime);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     if (false) // Test instatiation
         setTimes(TestAliasedString("foo"), SysTime.init, SysTime.init);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.stdio : File;
     string newdir = deleteme ~ r".dir";
@@ -1397,7 +1397,7 @@ if (isConvertibleToString!R)
     return timeLastModified!(StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, timeLastModified(TestAliasedString("foo"))));
 }
@@ -1462,7 +1462,7 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //std.process.system("echo a > deleteme") == 0 || assert(false);
     if (exists(deleteme))
@@ -1492,7 +1492,7 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R))
 version (FreeBSD) {} else
 version (DragonFlyBSD) {} else
 version (OSX) {} else
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.thread;
 
@@ -1570,7 +1570,7 @@ private bool existsImpl(const(FSChar)* namez) @trusted nothrow @nogc
         static assert(0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(exists("."));
     assert(!exists("this file does not exist"));
@@ -1579,7 +1579,7 @@ private bool existsImpl(const(FSChar)* namez) @trusted nothrow @nogc
     assert(exists(deleteme));
 }
 
-@safe unittest // Bugzilla 16573
+version(StdUnittest) @safe unittest // Bugzilla 16573
 {
     enum S : string { foo = "foo" }
     assert(__traits(compiles, S.foo.exists));
@@ -1652,7 +1652,7 @@ if (isConvertibleToString!R)
     return getAttributes!(StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, getAttributes(TestAliasedString(null))));
 }
@@ -1708,7 +1708,7 @@ if (isConvertibleToString!R)
     return getLinkAttributes!(StringTypeOf!R)(name);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, getLinkAttributes(TestAliasedString(null))));
 }
@@ -1763,7 +1763,7 @@ if (isConvertibleToString!R)
     return setAttributes!(StringTypeOf!R)(name, attributes);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, setAttributes(TestAliasedString(null), 0)));
 }
@@ -1807,12 +1807,12 @@ if (isConvertibleToString!R)
     return name.isDir!(StringTypeOf!R);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, TestAliasedString(null).isDir));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Windows)
     {
@@ -1832,7 +1832,7 @@ if (isConvertibleToString!R)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     version(Windows)
         enum dir = "C:\\Program Files\\";
@@ -1874,7 +1874,7 @@ bool attrIsDir(uint attributes) @safe pure nothrow @nogc
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Windows)
     {
@@ -1954,18 +1954,18 @@ if (isConvertibleToString!R)
     return isFile!(StringTypeOf!R)(name);
 }
 
-@system unittest // bugzilla 15658
+version(StdUnittest) @system unittest // bugzilla 15658
 {
     DirEntry e = DirEntry(".");
     static assert(is(typeof(isFile(e))));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, TestAliasedString(null).isFile));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Windows)
     {
@@ -2024,7 +2024,7 @@ bool attrIsFile(uint attributes) @safe pure nothrow @nogc
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Windows)
     {
@@ -2089,12 +2089,12 @@ if (isConvertibleToString!R)
     return name.isSymlink!(StringTypeOf!R);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, TestAliasedString(null).isSymlink));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     version(Windows)
     {
@@ -2236,7 +2236,7 @@ if (isConvertibleToString!R)
     return chdir!(StringTypeOf!R)(pathname);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, chdir(TestAliasedString(null))));
 }
@@ -2289,7 +2289,7 @@ if (isConvertibleToString!R)
     return mkdir!(StringTypeOf!R)(pathname);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.file : mkdir;
     static assert(__traits(compiles, mkdir(TestAliasedString(null))));
@@ -2345,7 +2345,7 @@ void mkdirRecurse(in char[] pathname) @safe
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     {
@@ -2435,7 +2435,7 @@ if (isConvertibleToString!R)
     rmdir!(StringTypeOf!R)(pathname);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(__traits(compiles, rmdir(TestAliasedString(null))));
 }
@@ -2484,7 +2484,7 @@ if ((isInputRange!RO && !isInfinite!RO && isSomeChar!(ElementEncodingType!RO) ||
     }
 }
 
-version(Posix) @safe unittest
+version(StdUnittest) version(Posix) @safe unittest
 {
     if (system_directory.exists)
     {
@@ -2527,7 +2527,7 @@ version(Posix) @safe unittest
     }
 }
 
-version(Posix) @safe unittest
+version(StdUnittest) version(Posix) @safe unittest
 {
     static assert(__traits(compiles,
         symlink(TestAliasedString(null), TestAliasedString(null))));
@@ -2598,7 +2598,7 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) ||
     }
 }
 
-version(Posix) @safe unittest
+version(StdUnittest) version(Posix) @safe unittest
 {
     import std.exception : assertThrown;
     import std.string;
@@ -2618,12 +2618,12 @@ version(Posix) @safe unittest
     assertThrown!FileException(readLink("/doesnotexist"));
 }
 
-version(Posix) @safe unittest
+version(StdUnittest) version(Posix) @safe unittest
 {
     static assert(__traits(compiles, readLink(TestAliasedString("foo"))));
 }
 
-version(Posix) @system unittest // input range of dchars
+version(StdUnittest) version(Posix) @system unittest // input range of dchars
 {
     mkdirRecurse(deleteme);
     scope(exit) if (deleteme.exists) rmdirRecurse(deleteme);
@@ -2695,7 +2695,7 @@ else version (Posix) string getcwd()
     return p[0 .. core.stdc.string.strlen(p)].idup;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto s = getcwd();
     assert(s.length);
@@ -2804,7 +2804,7 @@ else version (NetBSD)
         static assert(0, "thisExePath is not supported on this platform");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.path : isAbsolute;
     auto path = thisExePath();
@@ -3293,7 +3293,7 @@ else version(Posix)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     version(Windows)
     {
@@ -3434,7 +3434,7 @@ if (isConvertibleToString!RF || isConvertibleToString!RT)
     copy!Types(from, to, preserve);
 }
 
-@safe unittest // issue 15319
+version(StdUnittest) @safe unittest // issue 15319
 {
     assert(__traits(compiles, copy("from.txt", "to.txt")));
 }
@@ -3525,7 +3525,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
     }
 }
 
-@safe unittest
+version(StdUnittest) version(StdUnittest) @safe unittest
 {
     import std.algorithm, std.file; // issue 14817
     auto t1 = deleteme, t2 = deleteme~"2";
@@ -3542,7 +3542,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
     assert(readText(t2.byChar) == "2");
 }
 
-@safe version(Posix) @safe unittest //issue 11434
+version(StdUnittest) @safe version(Posix) @safe unittest //issue 11434
 {
     import std.conv : octal;
     auto t1 = deleteme, t2 = deleteme~"2";
@@ -3554,7 +3554,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
     assert(getAttributes(t2) == octal!100767);
 }
 
-@safe unittest // issue 15865
+version(StdUnittest) @safe unittest // issue 15865
 {
     import std.exception : assertThrown;
     auto t = deleteme;
@@ -3622,7 +3622,7 @@ void rmdirRecurse(DirEntry de)
     rmdirRecurse(de);
 }
 
-version(Windows) @system unittest
+version(StdUnittest) version(Windows) @system unittest
 {
     import std.exception : enforce;
     auto d = deleteme ~ r".dir\a\b\c\d\e\f\g";
@@ -3631,7 +3631,7 @@ version(Windows) @system unittest
     enforce(!exists(deleteme ~ ".dir"));
 }
 
-version(Posix) @system unittest
+version(StdUnittest) version(Posix) @system unittest
 {
     import std.exception : enforce, collectException;
     import std.process : executeShell;
@@ -3655,7 +3655,7 @@ version(Posix) @system unittest
     enforce(!exists(deleteme));
 }
 
-@system unittest
+version(StdUnittest) version(StdUnittest) @system unittest
 {
     void[] buf;
 
@@ -4042,7 +4042,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 }
 
 /// Duplicate functionality of D1's $(D std.file.listdir()):
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string[] listdir(string pathname)
     {
@@ -4066,7 +4066,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
      }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -4148,7 +4148,7 @@ auto dirEntries(string path, string pattern, SpanMode mode,
     return filter!f(DirIterator(path, mode, followSymlink));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.stdio : writefln;
     immutable dpath = deleteme ~ "_dir";
@@ -4225,7 +4225,7 @@ auto dirEntries(string path, string pattern, SpanMode mode,
 }
 
 // Bugzilla 17962 - Make sure that dirEntries does not butcher Unicode file names.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -4299,7 +4299,7 @@ slurp(Types...)(string filename, in char[] format)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : tuple;
 

--- a/std/format.d
+++ b/std/format.d
@@ -447,7 +447,7 @@ if (isSomeString!(typeof(fmt)))
 }
 
 /// The format string can be checked at compile-time (see $(LREF format) for details):
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
 
@@ -592,7 +592,7 @@ uint formattedWrite(Writer, Char, A...)(auto ref Writer w, in Char[] fmt, A args
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(format("%,d", 1000) == "1,000");
     assert(format("%,f", 1234567.891011) == "1,234,567.891,011");
@@ -605,7 +605,7 @@ uint formattedWrite(Writer, Char, A...)(auto ref Writer w, in Char[] fmt, A args
             format("%12,3.3f", 1234.5678) ~ "'");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
     auto w = appender!string();
@@ -702,7 +702,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
 }
 
 /// The format string can be checked at compile-time (see $(LREF format) for details):
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string s = "hello!124:34.5";
     string a;
@@ -712,7 +712,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(a == "hello" && b == 124 && c == 34.5);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math;
     string s = " 1.2 3.4 ";
@@ -725,7 +725,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
 }
 
 // for backwards compatibility
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string s = "hello!124:34.5";
     string a;
@@ -749,7 +749,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
 }
 
 // for backwards compatibility
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.math;
     string s = " 1.2 3.4 ";
@@ -761,7 +761,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(isNaN(z));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -800,7 +800,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(!f1);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
      union B
      {
@@ -815,7 +815,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
      assert(witness == b.typed);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     union A
     {
@@ -830,7 +830,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(witness == a.typed);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.typecons;
     char[] line = "1 2".dup;
@@ -853,7 +853,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(t[0] == 1 && t[1] == 2.125);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -865,7 +865,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(line == "c");
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -875,7 +875,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(s1 == [1,2,3]);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -900,7 +900,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(s4 == ["hello", "world"]);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -918,7 +918,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assertThrown(formattedRead(line, "%s", &sa3));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string input;
 
@@ -932,7 +932,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assertThrown(formattedRead(input, "[%(%s,%)]", &sa2));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -958,7 +958,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
     assert(s4 == "hello");
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string line;
 
@@ -979,7 +979,7 @@ uint formattedRead(R, Char, S...)(auto ref R r, const(Char)[] fmt, auto ref S ar
 }
 
 // test rvalue using
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     string[int] aa1;
     formattedRead!("%s")(`[1:"hello", 2:"world"]`, aa1);
@@ -1201,7 +1201,7 @@ if (is(Unqual!Char == Char))
         return false;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.array;
         auto w = appender!(char[])();
@@ -1557,7 +1557,7 @@ if (is(Unqual!Char == Char))
         return w.data;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // issue 5237
         import std.array;
@@ -1616,7 +1616,7 @@ if (is(Unqual!Char == Char))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
     auto a = appender!(string)();
@@ -1639,7 +1639,7 @@ if (is(Unqual!Char == Char))
 }
 
 // Issue 14059
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     auto a = appender!(string)();
@@ -1651,7 +1651,7 @@ if (is(Unqual!Char == Char))
     assertThrown(f.writeUpToNextSpec(a));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     auto a = appender!(string)();
@@ -1711,7 +1711,7 @@ FormatSpec!Char singleSpec(Char)(Char[] fmt)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
     auto spec = singleSpec("%2.3e");
@@ -1780,7 +1780,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 /++
    The following code compares the use of $(D formatValue) and $(D formattedWrite).
  +/
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
    import std.array : appender;
 
@@ -1798,7 +1798,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  * `bool`s are formatted as `"true"` or `"false"` with `%s` and as `1` or
  * `0` with integral-specific format specs.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1809,7 +1809,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// `null` literal is formatted as `"null"`.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1820,7 +1820,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Integrals are formatted like $(REF printf, core, stdc, stdio).
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1831,7 +1831,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Floating-point values are formatted like $(REF printf, core, stdc, stdio)
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1846,7 +1846,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  * Unicode characters with `%s` and as integers with integral-specific format
  * specs.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1857,7 +1857,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Strings are formatted like $(REF printf, core, stdc, stdio)
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1868,7 +1868,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Static-size arrays are formatted as dynamic arrays.
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1888,7 +1888,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  *      $(LI Const array is converted to input range by removing its qualifier.)
  *   )
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1903,7 +1903,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  * Associative arrays are formatted by using `':'` and `", "` as
  * separators, and enclosed by `'['` and `']'`.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1915,7 +1915,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// `enum`s are formatted like their base value
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -1936,7 +1936,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  * use $(REF put, std,range,primitives) rather than use the `put` method of the range
  * directly.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     import std.range.primitives;
@@ -1972,7 +1972,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
  * $(RED This method is now discouraged for non-virtual functions).
  * If possible, please use the output range method instead.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
    static struct Point
    {
@@ -1995,7 +1995,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Pointers are formatted as hex integers.
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -2008,7 +2008,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// SIMD vectors are formatted as arrays.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.simd;
     import std.array : appender;
@@ -2033,7 +2033,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, const ref F
 }
 
 /// Delegates are formatted by `ReturnType delegate(Parameters) FunctionAttributes`
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -2086,7 +2086,7 @@ if (is(BooleanTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         formatValueImpl(w, cast(int) val, f);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assertCTFEable!(
     {
@@ -2094,7 +2094,7 @@ if (is(BooleanTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         formatTest( true,  "true"  );
     });
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C1 { bool val; alias val this; this(bool v){ val = v; } }
     class C2 { bool val; alias val this; this(bool v){ val = v; }
@@ -2113,7 +2113,7 @@ if (is(BooleanTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     formatTest( S2(true),  "S" );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string t1 = format("[%6s] [%6s] [%-6s]", true, false, true);
     assert(t1 == "[  true] [ false] [true  ]");
@@ -2134,7 +2134,7 @@ if (is(Unqual!T == typeof(null)) && !is(T == enum) && !hasToString!(T, Char))
     put(w, "null");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(collectExceptionMsg!FormatException(format("%p", null)).back == 'p');
 
@@ -2353,7 +2353,7 @@ private void formatUnsigned(Writer, T, Char)
         put(w, ' ');
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(collectExceptionMsg!FormatException(format("%c", 5)).back == 'c');
 
@@ -2364,7 +2364,7 @@ private void formatUnsigned(Writer, T, Char)
     });
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C1 { long val; alias val this; this(long v){ val = v; } }
     class C2 { long val; alias val this; this(long v){ val = v; }
@@ -2380,7 +2380,7 @@ private void formatUnsigned(Writer, T, Char)
 }
 
 // bugzilla 9117
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct Frop {}
 
@@ -2605,7 +2605,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
 }
 
-@safe /*pure*/ unittest     // formatting floating point values is now impure
+version(StdUnittest) @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
 
@@ -2621,7 +2621,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     formatTest( 2.25, "2.25" );
 
@@ -2658,7 +2658,7 @@ if (is(Unqual!T : creal) && !is(T == enum) && !hasToString!(T, Char))
 
 version(TestComplex)
 deprecated
-@safe /*pure*/ unittest     // formatting floating point values is now impure
+version(StdUnittest) @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
     static foreach (T; AliasSeq!(cfloat, cdouble, creal))
@@ -2677,7 +2677,7 @@ deprecated
 
 version(TestComplex)
 deprecated
-@system unittest
+version(StdUnittest) @system unittest
 {
     formatTest( 3+2.25i, "3+2.25i" );
 
@@ -2709,7 +2709,7 @@ if (is(Unqual!T : ireal) && !is(T == enum) && !hasToString!(T, Char))
 
 version(TestComplex)
 deprecated
-@safe /*pure*/ unittest     // formatting floating point values is now impure
+version(StdUnittest) @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
     static foreach (T; AliasSeq!(ifloat, idouble, ireal))
@@ -2722,7 +2722,7 @@ deprecated
 
 version(TestComplex)
 deprecated
-@system unittest
+version(StdUnittest) @system unittest
 {
     formatTest( 2.25i, "2.25i" );
 
@@ -2759,7 +2759,7 @@ if (is(CharTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assertCTFEable!(
     {
@@ -2767,7 +2767,7 @@ if (is(CharTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     });
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C1 { char val; alias val this; this(char v){ val = v; } }
     class C2 { char val; alias val this; this(char v){ val = v; }
@@ -2782,7 +2782,7 @@ if (is(CharTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     formatTest( S2('c'), "S" );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Little Endian
     formatTest( "%-r", cast( char)'c', ['c'         ] );
@@ -2807,12 +2807,12 @@ if (is(StringTypeOf!T) && !is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToSt
     formatRange(w, val, f);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     formatTest( "abc", "abc" );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test for bug 5371 for classes
     class C1 { const string var; alias var this; this(string s){ var = s; } }
@@ -2827,7 +2827,7 @@ if (is(StringTypeOf!T) && !is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToSt
     formatTest( S2("s2"), "s2" );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class  C3 { string val; alias val this; this(string s){ val = s; }
                 override string toString() const { return "C"; } }
@@ -2838,7 +2838,7 @@ if (is(StringTypeOf!T) && !is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToSt
     formatTest( S3("s3"), "S" );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     //Little Endian
     formatTest( "%-r", "ab"c, ['a'         , 'b'         ] );
@@ -2868,7 +2868,7 @@ if (is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     formatValueImpl(w, obj[], f);
 }
 
-@safe unittest    // Test for issue 8310
+version(StdUnittest) @safe unittest    // Test for issue 8310
 {
     import std.array : appender;
     FormatSpec!char f;
@@ -2905,7 +2905,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
 }
 
 // alias this, input range I/F, and toString()
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S(int flags)
     {
@@ -2960,7 +2960,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     formatTest(new C!0b111([0, 1, 2]), "C");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // void[]
     void[] val0;
@@ -2976,7 +2976,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     formatTest( sval, "[1, 2, 3]" );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // const(T[]) -> const(T)[]
     const short[] a = [1, 2, 3];
@@ -2987,7 +2987,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     formatTest( s, "[1, 2, 3]" );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 6640
     struct Range
@@ -3015,7 +3015,7 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // string literal from valid UTF sequence is encoding free.
     static foreach (StrType; AliasSeq!(string, wstring, dstring))
@@ -3061,14 +3061,14 @@ if (is(DynamicArrayTypeOf!T) && !is(StringTypeOf!T) && !is(T == enum) && !hasToS
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // nested range formatting with array of string
     formatTest( "%({%(%02x %)}%| %)", ["test", "msg"],
                 `{74 65 73 74} {6d 73 67}` );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // stop auto escaping inside range formatting
     auto arr = ["hello", "world"];
@@ -3275,7 +3275,7 @@ if (isInputRange!T)
         throw new Exception(text("Incorrect format specifier for range: %", f.spec));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(collectExceptionMsg(format("%d", "hi")).back == 'd');
 }
@@ -3376,7 +3376,7 @@ if (is(StringTypeOf!T) && !is(T == enum))
         formatValue(w, str, f);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -3386,7 +3386,7 @@ if (is(StringTypeOf!T) && !is(T == enum))
     assert(w.data == "\"Hello World\"");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test for bug 8015
     import std.typecons;
@@ -3418,7 +3418,7 @@ if (is(CharTypeOf!T) && !is(T == enum))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     auto w = appender!string();
@@ -3488,7 +3488,7 @@ if (is(AssocArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         put(w, f.seqAfter);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(collectExceptionMsg!FormatException(format("%d", [0:1])).back == 'd');
 
@@ -3517,7 +3517,7 @@ if (is(AssocArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     formatTest("%(%s:<%s>%|%)" , [1:2], "1:<2>");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C1 { int[char] val; alias val this; this(int[char] v){ val = v; } }
     class C2 { int[char] val; alias val this; this(int[char] v){ val = v; }
@@ -3532,7 +3532,7 @@ if (is(AssocArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     formatTest( S2(['c':1, 'd':2]), "S" );
 }
 
-@safe unittest  // Issue 8921
+version(StdUnittest) @safe unittest  // Issue 8921
 {
     enum E : char { A = 'a', B = 'b', C = 'c' }
     E[3] e = [E.A, E.B, E.C];
@@ -3590,7 +3590,7 @@ private template hasToString(T, Char)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct A
     {
@@ -3673,7 +3673,7 @@ void enforceValidFormatSpec(T, Char)(const ref FormatSpec!Char f)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static interface IF1 { }
     class CIF1 : IF1 { }
@@ -3768,7 +3768,7 @@ if (is(T == class) && !is(T == enum))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array : appender;
     import std.range.interfaces;
@@ -3780,7 +3780,7 @@ if (is(T == class) && !is(T == enum))
     formatTest( c, "null" );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // 5354
     // If the class has both range I/F and custom toString, the use of custom
@@ -3873,7 +3873,7 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // interface
     import std.range.interfaces;
@@ -3968,7 +3968,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bug 4638
     struct U8  {  string toString() const { return "blah"; } }
@@ -3979,7 +3979,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     formatTest( U32(), "blah" );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 3890
     struct Int{ int n; }
@@ -3988,7 +3988,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
                 `Pair("hello", Int(5))` );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // union formatting without toString
     union U1
@@ -4011,7 +4011,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     formatTest( u2, "hello" );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     // 7230
@@ -4035,7 +4035,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     assert(w.data == `Bug7230("hello", #{overlap a, b, c}, 10)`);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     static struct S{ @disable this(this); }
@@ -4047,7 +4047,7 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     assert(w.data == "S()");
 }
 
-unittest
+version(StdUnittest) @safe unittest
 {
     //struct Foo { @disable string toString(); }
     //Foo foo;
@@ -4089,25 +4089,25 @@ if (is(T == enum))
     formatValueImpl(w, cast(OriginalType!T) val, f);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum A { first, second, third }
     formatTest( A.second, "second" );
     formatTest( cast(A) 72, "cast(A)72" );
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum A : string { one = "uno", two = "dos", three = "tres" }
     formatTest( A.three, "three" );
     formatTest( cast(A)"mill\&oacute;n", "cast(A)mill\&oacute;n" );
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum A : bool { no, yes }
     formatTest( A.yes, "yes" );
     formatTest( A.no, "no" );
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test for bug 6892
     enum Foo { A = 10 }
@@ -4171,7 +4171,7 @@ if (isSIMDVector!V)
     formatValueImpl(w, val.array, f);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.simd;
     static if (is(float4))
@@ -4192,7 +4192,7 @@ if (isSIMDVector!V)
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // pointer
     import std.range;
@@ -4207,7 +4207,7 @@ if (isSIMDVector!V)
     formatTest( q, "FFEECCAA" );
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Test for issue 7869
     struct S
@@ -4221,7 +4221,7 @@ if (isSIMDVector!V)
     formatTest( q, "FFEECCAA" );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Test for issue 8186
     class B
@@ -4233,14 +4233,14 @@ if (isSIMDVector!V)
     formatTest( B.init, "null" );
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Test for issue 9336
     shared int i;
     format("%s", &i);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Test for issue 11778
     int* p = null;
@@ -4248,7 +4248,7 @@ if (isSIMDVector!V)
     assertThrown(format("%04d", p + 2));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // Test for issue 12505
     void* p = null;
@@ -4264,13 +4264,13 @@ if (isDelegate!T)
     formatValueImpl(w, T.stringof, f);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void func() @system { __gshared int x; ++x; throw new Exception("msg"); }
     version (linux) formatTest( &func, "void delegate() @system" );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     int[] a = [ 1, 3, 2 ];
     formatTest( "testing %(%s & %) embedded", a,
@@ -4316,7 +4316,7 @@ private T getNth(string kind, alias Condition, T, A...)(uint index, A args)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // width/precision
     assert(collectExceptionMsg!FormatException(format("%*.d", 5.1, 2))
@@ -4406,7 +4406,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
             text("expected one of `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-@safe /*pure*/ unittest     // formatting floating point values is now impure
+version(StdUnittest) @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.array;
 
@@ -4415,7 +4415,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     assert(stream.data == "1.1", stream.data);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm;
     import std.array;
@@ -4431,7 +4431,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     assert(stream.data == "6");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array;
     auto stream = appender!string();
@@ -4439,7 +4439,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     assert(stream.data == "42", stream.data);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // testing raw writes
     import std.array;
@@ -4454,7 +4454,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
         && w.data[2] == 3 && w.data[3] == 2);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // testing positional parameters
     import std.array;
@@ -4475,7 +4475,7 @@ void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, s
     assert(w.data == "2345", w.data);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.stdc.string : strlen;
     import std.array : appender;
@@ -4836,7 +4836,7 @@ here:
     assert(stream.data == "7", ">" ~ stream.data ~ "<");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.stdio;
@@ -4861,7 +4861,7 @@ here:
     formattedWrite(stream, "%s", aa);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string s = "hello!124:34.5";
     string a;
@@ -4962,7 +4962,7 @@ void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn =
             input, fn, ln);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void booleanTest()
     {
@@ -5108,7 +5108,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Booleans
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = "false";
     auto spec = singleSpec("%s");
@@ -5120,7 +5120,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Null values
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = "null";
     auto spec = singleSpec("%s");
@@ -5128,7 +5128,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Integrals
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = "123";
     auto spec = singleSpec("%s");
@@ -5144,7 +5144,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Floating point numbers
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.math : approxEqual;
 
@@ -5154,7 +5154,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Character input ranges
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = "aaa";
     auto spec = singleSpec("%s");
@@ -5175,7 +5175,7 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Arrays and static arrays
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string str = "aaa";
     auto spec = singleSpec("%s");
@@ -5197,14 +5197,14 @@ T unformatValue(T, Range, Char)(ref Range input, const ref FormatSpec!Char spec)
 }
 
 /// Associative arrays
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto str = `["one": 1, "two": 2]`;
     auto spec = singleSpec("%s");
     assert(str.unformatValue!(int[string])(spec) == ["one": 1, "two": 2]);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     // 7241
     string input = "a";
@@ -5618,7 +5618,7 @@ private bool needToSwapEndianess(Char)(const ref FormatSpec!Char f)
 
 /* ======================== Unit Tests ====================================== */
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : octal;
 
@@ -5660,13 +5660,13 @@ private bool needToSwapEndianess(Char)(const ref FormatSpec!Char f)
 
 version(TestComplex)
 deprecated
-@system unittest
+version(StdUnittest) @system unittest
 {
         string s = format("%s", 1.2 + 3.4i);
         assert(s == "1.2+3.4i", s);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : octal;
 
@@ -5932,7 +5932,7 @@ deprecated
     assert(format("%8s", "b\u00e9ll\u00f4") == "   b\u00e9ll\u00f4");
 }
 
-@safe pure unittest // bugzilla 18205
+version(StdUnittest) @safe pure unittest // bugzilla 18205
 {
     assert("|%8s|".format("abc")        == "|     abc|");
     assert("|%8s|".format("αβγ")        == "|     αβγ|");
@@ -5944,7 +5944,7 @@ deprecated
     assert("%2s".format("a\u0310\u0337"d) == " a\u0310\u0337");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bugzilla 3479
     import std.array;
@@ -5953,7 +5953,7 @@ deprecated
     assert(stream.data == "000000000010", stream.data);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bug 6893
     import std.array;
@@ -6014,7 +6014,7 @@ if (isSomeString!(typeof(fmt)))
 }
 
 /// Type checking can be done when fmt is known at compile-time:
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = format!"%s is %s"("Pi", 3.14);
     assert(s == "Pi is 3.14");
@@ -6090,7 +6090,7 @@ private size_t guessLength(Char, S)(S fmtString)
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     assert(guessLength!char("%c") == 1);
     assert(guessLength!char("%d") == 3);
@@ -6125,7 +6125,7 @@ if (isSomeChar!Char)
     return w.data;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import core.exception;
     import std.exception;
@@ -6153,7 +6153,7 @@ if (isSomeChar!Char)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16661
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(format("%.2f"d, 0.4) == "0.40");
     assert("%02d"d.format(1) == "01"d);
@@ -6237,7 +6237,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 }
 
 /// The format string can be checked at compile-time (see $(LREF format) for details):
-@system unittest
+version(StdUnittest) @system unittest
 {
     char[10] buf;
 
@@ -6245,7 +6245,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
     assert(sformat(buf[], "%s foo", "bar") == "bar foo");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
 
@@ -6282,7 +6282,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
     return array1.ptr - array2.ptr;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assertCTFEable!({
     auto tmp = format("%,d", 1000);
@@ -6308,7 +6308,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
     });
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto tmp = format("%,f", 1000.0);
     assert(tmp == "1,000.000,000", "'" ~ tmp ~ "'");
@@ -6366,14 +6366,14 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 }
 
 // Test for multiple indexes
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto tmp = format("%2:5$s", 1, 2, 3, 4, 5);
     assert(tmp == "2345", tmp);
 }
 
 // Issue 18047
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cmp = "     123,456";
     assert(cmp.length == 12, format("%d", cmp.length));
@@ -6384,7 +6384,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 }
 
 // Issue 17459
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cmp = "100";
     auto tmp  = format("%0d", 100);
@@ -6416,7 +6416,7 @@ char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 }
 
 // Issue 17459
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cmp = "100,000";
     auto tmp  = format("%06,d", 100_000);

--- a/std/functional.d
+++ b/std/functional.d
@@ -126,14 +126,14 @@ template unaryFun(alias fun, string parmName = "a")
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Strings are compiled into functions:
     alias isEven = unaryFun!("(a & 1) == 0");
     assert(isEven(2) && !isEven(1));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static int f1(int a) { return a + 1; }
     static assert(is(typeof(unaryFun!(f1)(1)) == int));
@@ -213,7 +213,7 @@ template binaryFun(alias fun, string parm1Name = "a",
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias less = binaryFun!("a < b");
     assert(less(1, 2) && !less(2, 1));
@@ -221,7 +221,7 @@ template binaryFun(alias fun, string parm1Name = "a",
     assert(!greater("1", "2") && greater("2", "1"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static int f1(int a, string b) { return a + 1; }
     static assert(is(typeof(binaryFun!(f1)(1, "2")) == int));
@@ -325,7 +325,7 @@ private uint _ctfeMatchUnary(string fun, string name)
     return fun.length == 0;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!_ctfeMatchUnary("sqrt(ё)", "ё"));
     static assert(!_ctfeMatchUnary("ё.sqrt", "ё"));
@@ -372,7 +372,7 @@ private uint _ctfeMatchBinary(string fun, string name1, string name2)
     return fun.length == 0;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
 
     static assert(!_ctfeMatchBinary("sqrt(ё)", "ё", "b"));
@@ -461,7 +461,7 @@ if (S=="<"||S==">"||S=="<="||S==">="||S=="=="||S=="!=")
     }
 }
 
-@safe unittest //check user defined types
+version(StdUnittest) @safe unittest //check user defined types
 {
     import std.algorithm.comparison : equal;
     struct Foo
@@ -482,7 +482,7 @@ if (S=="<"||S==">"||S=="<="||S==">="||S=="=="||S=="!=")
 alias lessThan = safeOp!"<";
 
 ///
-pure @safe @nogc nothrow unittest
+version(StdUnittest) pure @safe @nogc nothrow unittest
 {
     assert(lessThan(2, 3));
     assert(lessThan(2U, 3U));
@@ -503,7 +503,7 @@ pure @safe @nogc nothrow unittest
 alias greaterThan = safeOp!">";
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(!greaterThan(2, 3));
     assert(!greaterThan(2U, 3U));
@@ -524,7 +524,7 @@ alias greaterThan = safeOp!">";
 alias equalTo = safeOp!"==";
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(equalTo(0U, 0));
     assert(equalTo(0, 0U));
@@ -544,7 +544,7 @@ template reverseArgs(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias gt = reverseArgs!(binaryFun!("a < b"));
     assert(gt(2, 1) && !gt(1, 1));
@@ -557,7 +557,7 @@ template reverseArgs(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int abc(int a, int b, int c) { return a * b + c; }
     alias cba = reverseArgs!abc;
@@ -565,7 +565,7 @@ template reverseArgs(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int a(int a) { return a * 2; }
     alias _a = reverseArgs!a;
@@ -573,7 +573,7 @@ template reverseArgs(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int b() { return 4; }
     alias _b = reverseArgs!b;
@@ -594,14 +594,14 @@ template binaryReverseArgs(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias gt = binaryReverseArgs!(binaryFun!("a < b"));
     assert(gt(2, 1) && !gt(1, 1));
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int x = 42;
     bool xyz(int a, int b) { return a * x < b / x; }
@@ -630,7 +630,7 @@ template not(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : find;
     import std.functional;
@@ -639,7 +639,7 @@ template not(alias pred)
     assert(find!(not!isWhite)(a) == "Hello, world!");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(not!"a != 5"(5));
     assert(not!"a != b"(5, 5));
@@ -690,7 +690,7 @@ template partial(alias fun, alias arg)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int fun(int a, int b) { return a + b; }
     alias fun5 = partial!(fun, 5);
@@ -701,7 +701,7 @@ template partial(alias fun, alias arg)
 }
 
 // tests for partially evaluating callables
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static int f1(int a, int b) { return a + b; }
     assert(partial!(f1, 5)(6) == 11);
@@ -731,7 +731,7 @@ template partial(alias fun, alias arg)
 }
 
 // tests for partially evaluating templated/overloaded callables
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static auto add(A, B)(A x, B y)
     {
@@ -826,7 +826,7 @@ if (F.length > 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.functional, std.typecons : Tuple;
     static bool f1(int a) { return a != 0; }
@@ -836,7 +836,7 @@ if (F.length > 1)
     assert(x[0] == true && x[1] == 2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : Tuple;
     static bool F1(int a) { return a != 0; }
@@ -862,7 +862,7 @@ if (F.length > 1)
     assert(x4 == 43);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : staticMap;
     import std.typecons : Tuple, tuple;
@@ -915,7 +915,7 @@ template compose(fun...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -946,7 +946,7 @@ int[] a = pipe!(readText, split, map!(to!(int)))("file.txt");
  */
 alias pipe(fun...) = compose!(Reverse!(fun));
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     string foo(int a) { return to!(string)(a); }
@@ -1072,7 +1072,7 @@ template memoize(alias fun, uint maxSize)
  * To _memoize a recursive function, simply insert the memoized call in lieu of the plain recursive call.
  * For example, to transform the exponential-time Fibonacci implementation into a linear-time computation:
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ulong fib(ulong n) @safe
     {
@@ -1084,7 +1084,7 @@ template memoize(alias fun, uint maxSize)
 /**
  * To improve the speed of the factorial function,
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ulong fact(ulong n) @safe
     {
@@ -1097,7 +1097,7 @@ template memoize(alias fun, uint maxSize)
  * This memoizes all values of $(D fact) up to the largest argument. To only cache the final
  * result, move $(D memoize) outside the function as shown below.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ulong factImpl(ulong n) @safe
     {
@@ -1111,7 +1111,7 @@ template memoize(alias fun, uint maxSize)
  * When the $(D maxSize) parameter is specified, memoize will used
  * a fixed size hash table to limit the number of cached entries.
  */
-@system unittest // not @safe due to memoize
+version(StdUnittest) @system unittest // not @safe due to memoize
 {
     ulong fact(ulong n)
     {
@@ -1123,7 +1123,7 @@ template memoize(alias fun, uint maxSize)
     assert(fact(10) == 3628800);
 }
 
-@system unittest // not @safe due to memoize
+version(StdUnittest) @system unittest // not @safe due to memoize
 {
     import core.math : sqrt;
     alias msqrt = memoize!(function double(double x) { return sqrt(x); });
@@ -1170,7 +1170,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with arrays
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int executed = 0;
     T median(T)(const T[] nums) {
@@ -1194,7 +1194,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with structs
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int executed = 0;
     T pickFirst(T)(T first)
@@ -1213,7 +1213,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with classes
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int executed = 0;
     T pickFirst(T)(T first)
@@ -1369,7 +1369,7 @@ if (isCallable!(F))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static int inc(ref uint num) {
         num++;
@@ -1382,7 +1382,7 @@ if (isCallable!(F))
     assert(myNum == 1);
 }
 
-@system unittest // not @safe due to toDelegate
+version(StdUnittest) @system unittest // not @safe due to toDelegate
 {
     static int inc(ref uint num) {
         num++;
@@ -1497,7 +1497,7 @@ template forward(args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C
     {
@@ -1512,7 +1512,7 @@ template forward(args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void foo(int n, ref string s) { s = null; foreach (i; 0 .. n) s ~= "Hello"; }
 
@@ -1529,7 +1529,7 @@ template forward(args...)
     assert(s == "HelloHello");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto foo(TL...)(auto ref TL args)
     {
@@ -1560,7 +1560,7 @@ template forward(args...)
     assert(baz(S(), makeS(), n, s) == "LLRRRL");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ref int foo(return ref int a) { return a; }
     ref int bar(Args)(auto ref Args args)
@@ -1573,7 +1573,7 @@ template forward(args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct X {
         int i;
@@ -1640,7 +1640,7 @@ template forward(args...)
 }
 
 // lazy -> lazy
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo1(lazy int i) { return i; }
     int foo2(A)(auto ref A i) { return foo1(forward!i); }
@@ -1652,7 +1652,7 @@ template forward(args...)
 }
 
 // lazy -> non-lazy
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo1(int a, int b) { return a + b; }
     int foo2(A...)(auto ref A args) { return foo1(forward!args); }
@@ -1664,7 +1664,7 @@ template forward(args...)
 }
 
 // non-lazy -> lazy
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo1(int a, lazy int b) { return a + b; }
     int foo2(A...)(auto ref A args) { return foo1(forward!args); }
@@ -1674,7 +1674,7 @@ template forward(args...)
 }
 
 // out
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void foo1(int a, out int b) { b = a; }
     void foo2(A...)(auto ref A args) { foo1(forward!args); }

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -443,7 +443,7 @@ GetoptResult getopt(T...)(ref string[] args, T opts)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto args = ["prog", "--foo", "-b"];
 
@@ -528,7 +528,7 @@ private pure Option splitAndGet(string opt) @trusted nothrow
     return ret;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto oshort = splitAndGet("f");
     assert(oshort.optShort == "-f");
@@ -615,7 +615,7 @@ private template optionValidator(A...)
     alias optionValidator = message;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     alias P = void*;
     alias S = string;
@@ -657,7 +657,7 @@ private template optionValidator(A...)
     static assert(optionValidator!(C,A,P,C,A,S,F) == "");
 }
 
-@system unittest // bugzilla 15914
+version(StdUnittest) @system unittest // bugzilla 15914
 {
     bool opt;
     string[] args = ["program", "-a"];
@@ -977,7 +977,7 @@ private bool handleOption(R)(string option, R receiver, ref string[] args,
 }
 
 // 17574
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : startsWith;
 
@@ -997,7 +997,7 @@ private bool handleOption(R)(string option, R receiver, ref string[] args,
 }
 
 // 5316 - arrays with arraySep
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
 
@@ -1026,7 +1026,7 @@ private bool handleOption(R)(string option, R receiver, ref string[] args,
 }
 
 // 5316 - associative arrays with arraySep
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
 
@@ -1179,7 +1179,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
     import std.math;
@@ -1361,7 +1361,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     catch (MyEx ex) { assert(ex.option == "verbose" && ex.value == "2"); }
 }
 
-@safe unittest // @safe std.getopt.config option use
+version(StdUnittest) @safe unittest // @safe std.getopt.config option use
 {
     long x = 0;
     string[] args = ["program", "--inc-x", "--inc-x"];
@@ -1371,7 +1371,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(x == 2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // From bugzilla 2142
     bool f_linenum, f_filename;
@@ -1388,7 +1388,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(f_filename);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // From bugzilla 6887
     string[] p;
@@ -1398,7 +1398,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(p[0] == "a");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // From bugzilla 6888
     int[string] foo;
@@ -1407,7 +1407,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(foo == ["a":1]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // From bugzilla 9583
     int opt;
@@ -1416,7 +1416,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(args == ["prog", "--a", "--b", "--c"]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string foo, bar;
     auto args = ["prog", "-thello", "-dbar=baz"];
@@ -1451,7 +1451,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(o == "str");
 }
 
-@system unittest // 5228
+version(StdUnittest) @system unittest // 5228
 {
     import std.conv;
     import std.exception;
@@ -1464,7 +1464,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assertThrown!ConvException(getopt(args, "abc", &abc));
 }
 
-@system unittest // From bugzilla 7693
+version(StdUnittest) @system unittest // From bugzilla 7693
 {
     import std.exception;
 
@@ -1484,7 +1484,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assertNotThrown(getopt(args, "foo", &foo));
 }
 
-@system unittest // same bug as 7693 only for bool
+version(StdUnittest) @system unittest // same bug as 7693 only for bool
 {
     import std.exception;
 
@@ -1496,7 +1496,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(foo);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool foo;
     auto args = ["prog", "--foo"];
@@ -1504,7 +1504,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(foo);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool foo;
     bool bar;
@@ -1515,7 +1515,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(bar);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool foo;
     bool bar;
@@ -1527,7 +1527,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(bar);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception;
 
@@ -1539,7 +1539,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
         config.passThrough));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception;
 
@@ -1553,7 +1553,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(!bar);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool foo;
     auto args = ["prog", "-f"];
@@ -1562,7 +1562,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
     assert(!r.helpWanted);
 }
 
-@safe unittest // implicit help option without config.passThrough
+version(StdUnittest) @safe unittest // implicit help option without config.passThrough
 {
     string[] args = ["program", "--help"];
     auto r = getopt(args);
@@ -1570,7 +1570,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
 }
 
 // Issue 13316 - std.getopt: implicit help option breaks the next argument
-@system unittest
+version(StdUnittest) @system unittest
 {
     string[] args = ["program", "--help", "--", "something"];
     getopt(args);
@@ -1587,7 +1587,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
 }
 
 // Issue 13317 - std.getopt: endOfOptions broken when it doesn't look like an option
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto endOfOptionsBackup = endOfOptions;
     scope(exit) endOfOptions = endOfOptionsBackup;
@@ -1663,7 +1663,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
 
@@ -1692,7 +1692,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     assert(wanted == helpMsg);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array ;
     import std.conv;
@@ -1721,7 +1721,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     assert(wanted == helpMsg, helpMsg ~ wanted);
 }
 
-@system unittest // Issue 14724
+version(StdUnittest) @system unittest // Issue 14724
 {
     bool a;
     auto args = ["prog", "--help"];
@@ -1741,7 +1741,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 }
 
 // throw on duplicate options
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception;
     auto args = ["prog", "--abc", "1"];
@@ -1751,7 +1751,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     assertNotThrown!AssertError(getopt(args, "abc", &abc, "def", &def));
 }
 
-@system unittest // Issue 17327 repeated option use
+version(StdUnittest) @system unittest // Issue 17327 repeated option use
 {
     long num = 0;
 
@@ -1804,7 +1804,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     assert(flag);
 }
 
-@safe unittest  // Delegates as callbacks
+version(StdUnittest) @safe unittest  // Delegates as callbacks
 {
     alias TwoArgOptionHandler = void delegate(string option, string value) @safe;
 
@@ -1838,7 +1838,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
     assert(y == 50);
 }
 
-@system unittest // Hyphens at the start of option values; Issue 17650
+version(StdUnittest) @system unittest // Hyphens at the start of option values; Issue 17650
 {
     auto args = ["program", "-m", "-5", "-n", "-50", "-c", "-", "-f", "-"];
 

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -16,7 +16,7 @@ COREREF = $(HTTP dlang.org/phobos/core_$1.html#$2, $(D core.$1.$2))
 module std.internal.cstring;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Posix)
     {
@@ -41,7 +41,7 @@ module std.internal.cstring;
 import std.range;
 import std.traits;
 
-version(unittest)
+version(StdUnittest) version(unittest)
 @property inout(C)[] asArray(C)(inout C* cstr) pure nothrow @nogc @trusted
 if (isSomeChar!C)
 in { assert(cstr); }
@@ -134,7 +134,7 @@ if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
 }
 
 ///
-nothrow @nogc @system unittest
+version(StdUnittest) nothrow @nogc @system unittest
 {
     import core.stdc.string;
 
@@ -155,7 +155,7 @@ nothrow @nogc @system unittest
     // both primary expressions are ended.
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert("abc".tempCString().asArray == "abc");
     assert("abc"d.tempCString().ptr.asArray == "abc");
@@ -169,7 +169,7 @@ nothrow @nogc @system unittest
 }
 
 // Bugzilla 14980
-pure nothrow @nogc @safe unittest
+version(StdUnittest) pure nothrow @nogc @safe unittest
 {
     const(char[]) str = null;
     auto res = tempCString(str);

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1113,7 +1113,7 @@ public:
 
 } // end BigUint
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // ulong comparison test
     BigUint a = [1];
@@ -1135,7 +1135,7 @@ inout(BigDigit) [] removeLeadingZeros(inout(BigDigit) [] x) pure nothrow @safe
     return x[0 .. k];
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
    BigUint r = BigUint([5]);
    BigUint t = BigUint([7]);
@@ -1144,7 +1144,7 @@ pure @system unittest
 }
 
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     BigUint r;
     r = 5UL;
@@ -1157,7 +1157,7 @@ pure @system unittest
 
 
 // Pow tests
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     BigUint r, s;
     r.fromHexString("80000000_00000001");
@@ -1181,7 +1181,7 @@ pure @system unittest
 }
 
 // Radix conversion tests
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     BigUint r;
     r.fromHexString("1_E1178E81_00000000");
@@ -1202,7 +1202,7 @@ pure @system unittest
 }
 
 //
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     BigUint r;
     r.fromHexString("1_E1178E81_00000000");
@@ -1337,7 +1337,7 @@ int highestPowerBelowUlongMax(uint x) pure nothrow @safe
      return 2;
 }
 
-version(unittest)
+version(StdUnittest) version(unittest)
 {
 
 int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
@@ -1350,7 +1350,7 @@ int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
      return pwr;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(highestPowerBelowUintMax(10)==9);
     for (int k=82; k<88; ++k)
@@ -1724,7 +1724,7 @@ void divModInternal(BigDigit [] quotient, BigDigit[] remainder, const BigDigit [
     () @trusted { GC.free(un.ptr); GC.free(vn.ptr); } ();
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     immutable(uint) [] u = [0, 0xFFFF_FFFE, 0x8000_0000];
     immutable(uint) [] v = [0xFFFF_FFFF, 0x8000_0000];
@@ -2679,7 +2679,7 @@ pure nothrow
     () @trusted { GC.free(scratch.ptr); } ();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.stdc.stdio;
 
@@ -2716,7 +2716,7 @@ pure nothrow
 }
 
 // biguintToOctal
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum bufSize = 5 * BigDigitBits / 3 + 1;
     auto buf = new char[bufSize];

--- a/std/internal/math/biguintnoasm.d
+++ b/std/internal/math/biguintnoasm.d
@@ -48,7 +48,7 @@ uint multibyteAddSub(char op)(uint[] dest, const(uint) [] src1,
     return cast(uint) c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     uint [] a = new uint[40];
     uint [] b = new uint[40];
@@ -167,7 +167,7 @@ void multibyteShr(uint [] dest, const(uint) [] src, uint numbits)
    }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
 
     uint [] aa = [0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -204,7 +204,7 @@ uint multibyteMul(uint[] dest, const(uint)[] src, uint multiplier, uint carry)
     return cast(uint) c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A,
         0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -241,7 +241,7 @@ uint multibyteMulAdd(char op)(uint [] dest, const(uint)[] src,
     return cast(uint) c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
 
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A,
@@ -296,7 +296,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow)
     return cast(uint) c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     uint [] aa = new uint[101];
     for (uint i = 0; i < aa.length; ++i)

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -91,7 +91,7 @@ string indexedLoopUnroll(int n, string s) pure @safe
     }
     return u;
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(indexedLoopUnroll(3, "@*23;")=="0*23;1*23;2*23;");
 }
@@ -177,7 +177,7 @@ done:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     uint [] a = new uint[40];
     uint [] b = new uint[40];
@@ -522,7 +522,7 @@ L_last:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
 
     uint [] aa = [0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -624,7 +624,7 @@ L_odd:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
     multibyteMul(aa[1 .. 4], aa[1 .. 4], 16, 0);
@@ -795,7 +795,7 @@ L_enter_odd:
     mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd(OP, "ESP+LASTPARAM") ~ "}");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
 
     uint [] aa = [0xF0FF_FFFF, 0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];
@@ -1015,7 +1015,7 @@ Lc:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     uint [] aa = new uint[101];
     for (int i=0; i<aa.length; ++i) aa[i] = 0x8765_4321 * (i+3);
@@ -1068,7 +1068,7 @@ L1:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     uint [] aa = new uint[13];
         uint [] bb = new uint[6];
@@ -1212,7 +1212,7 @@ L_enter_odd:
     mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
    uint [] aa = new uint[200];
    uint [] a  = aa[0 .. 100];

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -864,7 +864,7 @@ real erf(real x)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // High resolution test points.
     enum real erfc0_250 = 0.723663330078125 + 1.0279753638067014931732235184287934646022E-5;
@@ -1000,7 +1000,7 @@ real normalDistributionImpl(real a)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
 assert(fabs(normalDistributionImpl(1L) - (0.841344746068543))< 0.0000000000000005);
 assert(isIdentical(normalDistributionImpl(NaN(0x325)), NaN(0x325)));
@@ -1126,7 +1126,7 @@ static immutable real[8] Q3 =
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // TODO: Use verified test points.
     // The values below are from Excel 2003.

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -382,7 +382,7 @@ real gamma(real x)
     return z * poly( x, GammaNumeratorCoeffs ) / poly( x, GammaDenominatorCoeffs );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // gamma(n) = factorial(n-1) if n is an integer.
     real fact = 1.0L;
@@ -526,7 +526,7 @@ real logGamma(real x)
     return q ;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isIdentical(logGamma(NaN(0xDEF)), NaN(0xDEF)));
     assert(logGamma(real.infinity) == real.infinity);
@@ -1013,7 +1013,7 @@ done:
     return x;
 }
 
-@safe unittest { // also tested by the normal distribution
+version(StdUnittest) @safe unittest { // also tested by the normal distribution
     // check NaN propagation
     assert(isIdentical(betaIncomplete(NaN(0xABC),2,3), NaN(0xABC)));
     assert(isIdentical(betaIncomplete(7,NaN(0xABC),3), NaN(0xABC)));
@@ -1581,7 +1581,7 @@ ihalve:
     return x;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
 //Values from Excel's GammaInv(1-p, x, 1)
 assert(fabs(gammaIncompleteComplInv(1, 0.5) - 0.693147188044814) < 0.00000005);
@@ -1704,7 +1704,7 @@ done:
     return y;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Exact values
     assert(digamma(1.0)== -EULERGAMMA);
@@ -1764,7 +1764,7 @@ real logmdigamma(real x)
     return x == s ? y + 0.5L/s : (log(x/s) + 0.5L/s + y + w);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(logmdigamma(-5.0).isNaN());
     assert(isIdentical(logmdigamma(NaN(0xABC)), NaN(0xABC)));
@@ -1817,7 +1817,7 @@ real logmdigammaInverse(real y)
     return y; //NaN
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons;
     //WolframAlpha, 22.02.2015

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -128,7 +128,7 @@ if (isAssignable!T &&
         this.bufLen = cast(uint) buf.length;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         ubyte[10] tmpbuf = void;
         auto sbuf = ScopeBuffer!ubyte(tmpbuf);
@@ -289,7 +289,7 @@ if (isAssignable!T &&
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.stdc.stdio;
     import std.range;
@@ -332,7 +332,7 @@ if (isAssignable!T &&
 
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string cat(string s1, string s2)
     {
@@ -350,7 +350,7 @@ if (isAssignable!T &&
 }
 
 // const
-@system unittest
+version(StdUnittest) @system unittest
 {
     char[10] tmpbuf = void;
     auto textbuf = ScopeBuffer!char(tmpbuf);
@@ -377,14 +377,14 @@ auto scopeBuffer(T)(T[] tmpbuf)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[10] tmpbuf = void;
     auto sb = scopeBuffer(tmpbuf);
     scope(exit) sb.free();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     ScopeBuffer!(int*) b;
     int*[] s;

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -303,7 +303,7 @@ class ReferenceBidirectionalRange(T) : ReferenceForwardRange!T
     final void popBack(){_payload.popBack();}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isInputRange!(ReferenceInputRange!int));
     static assert(isInputRange!(ReferenceInfiniteInputRange!int));
@@ -417,7 +417,7 @@ if (is(T == TestFoo))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota, retro, repeat;

--- a/std/internal/test/range.d
+++ b/std/internal/test/range.d
@@ -7,7 +7,7 @@ module std.internal.test.range;
 
 // Note: currently can't be @safe because RefCounted, which is used by chunks,
 // isn't.
-@system /*@safe*/ unittest
+version(StdUnittest) @system /*@safe*/ unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : chunks;

--- a/std/json.d
+++ b/std/json.d
@@ -23,7 +23,7 @@ import std.range.primitives;
 import std.traits;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
 
@@ -123,7 +123,7 @@ struct JSONValue
         return type_tag;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
           string s = "{ \"language\": \"D\" }";
           JSONValue j = parseJSON(s);
@@ -149,7 +149,7 @@ struct JSONValue
         return v;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         JSONValue j = [ "language": "D" ];
 
@@ -443,7 +443,7 @@ struct JSONValue
         type_tag = arg.type;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         JSONValue j = JSONValue( "a string" );
         j = JSONValue(42);
@@ -477,7 +477,7 @@ struct JSONValue
         return a[i];
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         JSONValue j = JSONValue( [42, 43, 44] );
         assert( j[0].integer == 42 );
@@ -495,7 +495,7 @@ struct JSONValue
                                         "Key not found: " ~ k);
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         JSONValue j = JSONValue( ["language": "D"] );
         assert( j["language"].str == "D" );
@@ -524,7 +524,7 @@ struct JSONValue
         this.object = aa;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
             JSONValue j = JSONValue( ["language": "D"] );
             j["language"].str = "Perl";
@@ -540,7 +540,7 @@ struct JSONValue
         this.array = a;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
             JSONValue j = JSONValue( ["Perl", "C"] );
             j[1].str = "D";
@@ -599,7 +599,7 @@ struct JSONValue
         return k in this.objectNoRef;
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         JSONValue j = [ "language": "D", "author": "walter" ];
         string a = ("author" in j).str;
@@ -1074,7 +1074,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
     return root;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum issue15742objectOfObject = `{ "key1": { "key2": 1 }}`;
     static assert(parseJSON(issue15742objectOfObject).type == JSON_TYPE.OBJECT);
@@ -1083,7 +1083,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
     static assert(parseJSON(issue15742arrayOfArray).type == JSON_TYPE.ARRAY);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Ensure we can parse and use JSON from @safe code
     auto a = `{ "key1": { "key2": 1 }}`.parseJSON;
@@ -1091,7 +1091,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
     assert(a.toString == `{"key1":{"key2":1}}`);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Ensure we can parse JSON from a @system range.
     struct Range
@@ -1367,7 +1367,7 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
     return json.data;
 }
 
-@safe unittest // bugzilla 12897
+version(StdUnittest) @safe unittest // bugzilla 12897
 {
     JSONValue jv0 = JSONValue("test测试");
     assert(toJSON(jv0, false, JSONOptions.escapeNonAsciiChars) == `"test\u6D4B\u8BD5"`);
@@ -1401,7 +1401,7 @@ class JSONException : Exception
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception;
     JSONValue jv = "123";
@@ -1478,7 +1478,7 @@ class JSONException : Exception
     assert(jv3.str == "\u001C");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 11504
 
@@ -1520,7 +1520,7 @@ class JSONException : Exception
     assert(jv.type == JSON_TYPE.TRUE);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Adding new json element via array() / object() directly
 
@@ -1535,7 +1535,7 @@ class JSONException : Exception
     assert(jobj.object.length == 10);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Adding new json element without array() / object() access
 
@@ -1555,7 +1555,7 @@ class JSONException : Exception
     assert(jarr[0] == JSONValue(10));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system because JSONValue.array is @system
     import std.exception;
@@ -1643,7 +1643,7 @@ class JSONException : Exception
 }`);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
   auto json = `"hello\nworld"`;
   const jv = parseJSON(json);
@@ -1651,7 +1651,7 @@ class JSONException : Exception
   assert(jv.toPrettyString == json);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     // Bugzilla 12969
 
@@ -1681,7 +1681,7 @@ class JSONException : Exception
     assert( jv[3].integer == 2 );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto s = q"EOF
 [
@@ -1699,7 +1699,7 @@ EOF";
 }
 
 // handling of special float values (NaN, Inf, -Inf)
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     import std.math : isNaN, isInfinity;
@@ -1740,7 +1740,7 @@ EOF";
     assert(jvNegInf.str == JSONFloatLiteral.negativeInf);
 }
 
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     JSONValue testVal;
     testVal = "test";
@@ -1753,7 +1753,7 @@ pure nothrow @safe @nogc unittest
     assert(testVal.isNull);
 }
 
-pure nothrow @safe unittest // issue 15884
+version(StdUnittest) pure nothrow @safe unittest // issue 15884
 {
     import std.typecons;
     void Test(C)() {
@@ -1768,7 +1768,7 @@ pure nothrow @safe unittest // issue 15884
     Test!dchar();
 }
 
-@safe unittest // issue 15885
+version(StdUnittest) @safe unittest // issue 15885
 {
     enum bool realInDoublePrecision = real.mant_dig == double.mant_dig;
 
@@ -1802,47 +1802,47 @@ pure nothrow @safe unittest // issue 15884
     assert(test(3*minSub));
 }
 
-@safe unittest // issue 17555
+version(StdUnittest) @safe unittest // issue 17555
 {
     import std.exception : assertThrown;
 
     assertThrown!JSONException(parseJSON("\"a\nb\""));
 }
 
-@safe unittest // issue 17556
+version(StdUnittest) @safe unittest // issue 17556
 {
     auto v = JSONValue("\U0001D11E");
     auto j = toJSON(v, false, JSONOptions.escapeNonAsciiChars);
     assert(j == `"\uD834\uDD1E"`);
 }
 
-@safe unittest // issue 5904
+version(StdUnittest) @safe unittest // issue 5904
 {
     string s = `"\uD834\uDD1E"`;
     auto j = parseJSON(s);
     assert(j.str == "\U0001D11E");
 }
 
-@safe unittest // issue 17557
+version(StdUnittest) @safe unittest // issue 17557
 {
     assert(parseJSON("\"\xFF\"").str == "\xFF");
     assert(parseJSON("\"\U0001D11E\"").str == "\U0001D11E");
 }
 
-@safe unittest // issue 17553
+version(StdUnittest) @safe unittest // issue 17553
 {
     auto v = JSONValue("\xFF");
     assert(toJSON(v) == "\"\xFF\"");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.utf;
     assert(parseJSON("\"\xFF\"".byChar).str == "\xFF");
     assert(parseJSON("\"\U0001D11E\"".byChar).str == "\U0001D11E");
 }
 
-@safe unittest // JSONOptions.doNotEscapeSlashes (issue 17587)
+version(StdUnittest) @safe unittest // JSONOptions.doNotEscapeSlashes (issue 17587)
 {
     assert(parseJSON(`"/"`).toString == `"\/"`);
     assert(parseJSON(`"\/"`).toString == `"\/"`);

--- a/std/math.d
+++ b/std/math.d
@@ -524,7 +524,7 @@ template isDeprecatedComplex(T)
     }
 }
 
-deprecated unittest
+version(StdUnittest) deprecated unittest
 {
     static assert(isDeprecatedComplex!cfloat);
     static assert(isDeprecatedComplex!cdouble);
@@ -585,7 +585,7 @@ static foreach (Num; AliasSeq!(cfloat, cdouble, creal, ifloat, idouble, ireal))
 }
 
 /// ditto
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(isIdentical(abs(-0.0L), 0.0L));
     assert(isNaN(abs(real.nan)));
@@ -595,14 +595,14 @@ static foreach (Num; AliasSeq!(cfloat, cdouble, creal, ifloat, idouble, ireal))
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(abs(-3.2Li) == 3.2L);
     assert(abs(71.6Li) == 71.6L);
     assert(abs(-1L+1i) == sqrt(2.0L));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     short s = -8;
     byte b = -8;
@@ -612,7 +612,7 @@ deprecated
     assert(abs(c) == 8);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(float, double, real))
@@ -624,7 +624,7 @@ deprecated
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(cfloat, cdouble, creal))
@@ -665,7 +665,7 @@ if (is(Num* : const(ifloat*)) || is(Num* : const(idouble*))
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     creal c = 7 + 3Li;
     assert(conj(c) == 7-3Li);
@@ -674,7 +674,7 @@ deprecated
 }
 //Issue 14206
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     cdouble c = 7 + 3i;
     assert(conj(c) == 7-3i);
@@ -683,7 +683,7 @@ deprecated
 }
 //Issue 14206
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     cfloat c = 7f + 3fi;
     assert(conj(c) == 7f-3fi);
@@ -711,7 +711,7 @@ double cos(double x) @safe pure nothrow @nogc { return cos(cast(real) x); }
 ///ditto
 float cos(float x) @safe pure nothrow @nogc { return cos(cast(real) x); }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real function(real) pcos = &cos;
     assert(pcos != null);
@@ -746,7 +746,7 @@ double sin(double x) @safe pure nothrow @nogc { return sin(cast(real) x); }
 float sin(float x) @safe pure nothrow @nogc { return sin(cast(real) x); }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : sin, PI;
     import std.stdio : writefln;
@@ -759,7 +759,7 @@ float sin(float x) @safe pure nothrow @nogc { return sin(cast(real) x); }
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real function(real) psin = &sin;
     assert(psin != null);
@@ -789,7 +789,7 @@ auto sin(ireal y) @safe pure nothrow @nogc
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
   assert(sin(0.0+0.0i) == 0.0);
   assert(sin(2.0+0.0i) == sin(2.0L) );
@@ -816,7 +816,7 @@ real cos(ireal y) @safe pure nothrow @nogc
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(cos(0.0+0.0i)==1.0);
     assert(cos(1.3L+0.0i)==cos(1.3L));
@@ -1024,7 +1024,7 @@ Lret: {}
     }
 }
 
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     static real[2][] vals =     // angle,tan
         [
@@ -1078,7 +1078,7 @@ Lret: {}
     assert(isIdentical( tan(NaN(0x0123L)), NaN(0x0123L) ));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(tan(PI / 3), std.math.sqrt(3.0), useDigits));
 }
@@ -1105,7 +1105,7 @@ double acos(double x) @safe pure nothrow @nogc { return acos(cast(real) x); }
 /// ditto
 float acos(float x) @safe pure nothrow @nogc  { return acos(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(acos(0.5), std.math.PI / 3, useDigits));
 }
@@ -1132,7 +1132,7 @@ double asin(double x) @safe pure nothrow @nogc { return asin(cast(real) x); }
 /// ditto
 float asin(float x) @safe pure nothrow @nogc  { return asin(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(asin(0.5), PI / 6, useDigits));
 }
@@ -1248,7 +1248,7 @@ double atan(double x) @safe pure nothrow @nogc { return atan(cast(real) x); }
 /// ditto
 float atan(float x)  @safe pure nothrow @nogc { return atan(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(atan(std.math.sqrt(3.0)), PI / 3, useDigits));
 }
@@ -1361,7 +1361,7 @@ float atan2(float y, float x) @safe pure nothrow @nogc
     return atan2(cast(real) y, cast(real) x);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(atan2(1.0L, std.math.sqrt(3.0L)), PI / 6, useDigits));
 }
@@ -1388,7 +1388,7 @@ double cosh(double x) @safe pure nothrow @nogc { return cosh(cast(real) x); }
 /// ditto
 float cosh(float x) @safe pure nothrow @nogc  { return cosh(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(cosh(1.0), (E + 1.0 / E) / 2, useDigits));
 }
@@ -1423,7 +1423,7 @@ double sinh(double x) @safe pure nothrow @nogc { return sinh(cast(real) x); }
 /// ditto
 float sinh(float x) @safe pure nothrow @nogc  { return sinh(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(sinh(1.0), (E - 1.0 / E) / 2, useDigits));
 }
@@ -1455,7 +1455,7 @@ double tanh(double x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
 /// ditto
 float tanh(float x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(tanh(1.0), sinh(1.0) / cosh(1.0), 15));
 }
@@ -1482,7 +1482,7 @@ auto coshisinh(real x) @safe pure nothrow @nogc
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     creal c = coshisinh(3.0L);
     assert(c.re == cosh(3.0L));
@@ -1524,7 +1524,7 @@ double acosh(double x) @safe pure nothrow @nogc { return acosh(cast(real) x); }
 float acosh(float x) @safe pure nothrow @nogc  { return acosh(cast(real) x); }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(isNaN(acosh(0.9)));
     assert(isNaN(acosh(real.nan)));
@@ -1565,7 +1565,7 @@ double asinh(double x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
 /// ditto
 float asinh(float x) @safe pure nothrow @nogc { return asinh(cast(real) x); }
 
-@system  unittest
+version(StdUnittest) @system  unittest
 {
     assert(isIdentical(asinh(0.0), 0.0));
     assert(isIdentical(asinh(-0.0), -0.0));
@@ -1606,7 +1606,7 @@ double atanh(double x) @safe pure nothrow @nogc { return atanh(cast(real) x); }
 float atanh(float x) @safe pure nothrow @nogc { return atanh(cast(real) x); }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(isIdentical(atanh(0.0), 0.0));
     assert(isIdentical(atanh(-0.0),-0.0));
@@ -1630,7 +1630,7 @@ long rndtol(double x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
 ///ditto
 long rndtol(float x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     long function(real) prndtol = &rndtol;
     assert(prndtol != null);
@@ -1662,7 +1662,7 @@ double sqrt(double x) @nogc @safe pure nothrow { pragma(inline, true); return co
 /// ditto
 real sqrt(real x) @nogc @safe pure nothrow { pragma(inline, true); return core.math.sqrt(x); }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     //ctfe
     enum ZX80 = sqrt(7.0f);
@@ -1674,7 +1674,7 @@ real sqrt(real x) @nogc @safe pure nothrow { pragma(inline, true); return core.m
     assert(isNaN(sqrt(-1.0L)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     float function(float) psqrtf = &sqrt;
     assert(psqrtf != null);
@@ -1877,7 +1877,7 @@ double exp(double x) @safe pure nothrow @nogc  { return exp(cast(real) x); }
 /// ditto
 float exp(float x)  @safe pure nothrow @nogc   { return exp(cast(real) x); }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(exp(3.0L), E * E * E, useDigits));
 }
@@ -2453,14 +2453,14 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(feqrel(exp2(0.5L), SQRT2) >= real.mant_dig -1);
     assert(exp2(8.0L) == 256.0);
     assert(exp2(-9.0L)== 1.0L/512.0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(CRuntime_Microsoft) {} else // aexp2/exp2f/exp2l not implemented
     {
@@ -2470,7 +2470,7 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     FloatingPointControl ctrl;
     if (FloatingPointControl.hasExceptionTraps)
@@ -2630,7 +2630,7 @@ creal expi(real y) @trusted pure nothrow @nogc
 }
 
 deprecated
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(expi(1.3e5L) == cos(1.3e5L) + sin(1.3e5L) * 1i);
     assert(expi(0.0L) == 1L + 0.0Li);
@@ -2834,7 +2834,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int exp;
     real mantissa = frexp(123.456L, exp);
@@ -2849,7 +2849,7 @@ if (isFloatingPoint!T)
     assert(frexp(0.0, exp) == 0.0 && exp == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int exp;
     real mantissa = frexp(123.456L, exp);
@@ -2858,7 +2858,7 @@ if (isFloatingPoint!T)
     assert(equalsDigit(mantissa * pow(2.0L, cast(real) exp), 123.456L, 19));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     import std.typecons : tuple, Tuple;
@@ -2917,7 +2917,7 @@ if (isFloatingPoint!T)
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     void foo() {
@@ -3112,7 +3112,7 @@ if (isIntegral!T && isSigned!T)
 alias FP_ILOGB0   = core.stdc.math.FP_ILOGB0;
 alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
 
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
     import std.typecons : Tuple;
@@ -3186,7 +3186,7 @@ double ldexp(double n, int exp) @safe pure nothrow @nogc { return ldexp(cast(rea
 float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real) n, exp); }
 
 ///
-@nogc @safe pure nothrow unittest
+version(StdUnittest) @nogc @safe pure nothrow unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(float, double, real))
@@ -3206,7 +3206,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
     }}
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
     {
@@ -3232,7 +3232,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
 }
 
 /* workaround Issue 14718, float parsing depends on platform strtold
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ldexp(1.0, -1024) == 0x1p-1024);
     assert(ldexp(1.0, -1022) == 0x1p-1022);
@@ -3243,7 +3243,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
     assert(ldexp(n, x)==0x1p-1024);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ldexp(1.0f, -128) == 0x1p-128f);
     assert(ldexp(1.0f, -126) == 0x1p-126f);
@@ -3255,7 +3255,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
 }
 */
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static real[3][] vals =    // value,exp,ldexp
     [
@@ -3470,7 +3470,7 @@ real log(real x) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(log(E) == 1);
 }
@@ -3567,7 +3567,7 @@ real log10(real x) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(fabs(log10(1000) - 3) < .000001);
 }
@@ -3694,12 +3694,12 @@ real log2(real x) @safe pure nothrow @nogc
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(approxEqual(log2(1024.0L), 10));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // check if values are equal to 19 decimal digits of precision
     assert(equalsDigit(log2(1024.0L), 10, 19));
@@ -3837,7 +3837,7 @@ real scalbn(real x, int n) @trusted nothrow @nogc
 }
 
 ///
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     assert(scalbn(-real.infinity, 5) == -real.infinity);
 }
@@ -3883,7 +3883,7 @@ double fabs(double x) @safe pure nothrow @nogc { return fabs(cast(real) x); }
 ///ditto
 float fabs(float x) @safe pure nothrow @nogc { return fabs(cast(real) x); }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real function(real) pfabs = &fabs;
     assert(pfabs != null);
@@ -3962,7 +3962,7 @@ real hypot(real x, real y) @safe pure nothrow @nogc
     return sqrt(u*u + v*v);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static real[3][] vals =     // x,y,hypot
         [
@@ -4052,7 +4052,7 @@ real ceil(real x) @trusted pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ceil(+123.456L) == +124);
     assert(ceil(-123.456L) == -123);
@@ -4080,7 +4080,7 @@ double ceil(double x) @trusted pure nothrow @nogc
     return y;
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ceil(+123.456) == +124);
     assert(ceil(-123.456) == -123);
@@ -4108,7 +4108,7 @@ float ceil(float x) @trusted pure nothrow @nogc
     return y;
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ceil(+123.456f) == +124);
     assert(ceil(-123.456f) == -123);
@@ -4176,7 +4176,7 @@ real floor(real x) @trusted pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(floor(+123.456L) == +123);
     assert(floor(-123.456L) == -124);
@@ -4200,7 +4200,7 @@ double floor(double x) @trusted pure nothrow @nogc
     return floorImpl(x);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(floor(+123.456) == +123);
     assert(floor(-123.456) == -124);
@@ -4224,7 +4224,7 @@ float floor(float x) @trusted pure nothrow @nogc
     return floorImpl(x);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(floor(+123.456f) == +123);
     assert(floor(-123.456f) == -124);
@@ -4257,7 +4257,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(12345.6789L.quantize(0.01L) == 12345.68L);
     assert(12345.6789L.quantize!floor(0.01L) == 12345.67L);
@@ -4265,7 +4265,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(12345.6789L.quantize(0) == 12345.6789L);
     assert(12345.6789L.quantize(real.infinity).isNaN);
@@ -4298,7 +4298,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(12345.6789L.quantize!10(-2) == 12345.68L);
     assert(12345.6789L.quantize!(10, -2) == 12345.68L);
@@ -4309,7 +4309,7 @@ if (is(typeof(rfunc(F.init)) : F) && isFloatingPoint!F)
     assert(12345.6789L.quantize!22 == 12342.0L);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
 
@@ -4362,7 +4362,7 @@ double rint(double x) @safe pure nothrow @nogc { return rint(cast(real) x); }
 ///ditto
 float rint(float x) @safe pure nothrow @nogc { return rint(cast(real) x); }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real function(real) print = &rint;
     assert(print != null);
@@ -4550,7 +4550,7 @@ long lrint(real x) @trusted pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(lrint(4.5) == 4);
     assert(lrint(5.5) == 6);
@@ -4565,7 +4565,7 @@ long lrint(real x) @trusted pure nothrow @nogc
 
 static if (real.mant_dig >= long.sizeof * 8)
 {
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         assert(lrint(long.max - 1.5L) == long.max - 1);
         assert(lrint(long.max - 0.5L) == long.max - 1);
@@ -4613,7 +4613,7 @@ long lround(real x) @trusted nothrow @nogc
 
 version(Posix)
 {
-    @safe nothrow @nogc unittest
+    version(StdUnittest) @safe nothrow @nogc unittest
     {
         assert(lround(0.49) == 0);
         assert(lround(0.5) == 1);
@@ -4857,7 +4857,7 @@ public:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void func() {
         int a = 10 * 10;
@@ -4883,7 +4883,7 @@ public:
     assert(ieeeFlags == f);
 }
 
-version(D_HardFloat) @system unittest
+version(StdUnittest) version(D_HardFloat) @system unittest
 {
     import std.meta : AliasSeq;
 
@@ -5349,7 +5349,7 @@ private:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void ensureDefaults()
     {
@@ -5389,7 +5389,7 @@ private:
     ensureDefaults();
 }
 
-version(D_HardFloat) @system unittest // rounding
+version(StdUnittest) version(D_HardFloat) @system unittest // rounding
 {
     import std.meta : AliasSeq;
 
@@ -5475,7 +5475,7 @@ if (isFloatingPoint!(X))
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isNaN(float.init));
     assert( isNaN(-double.init));
@@ -5485,7 +5485,7 @@ if (isFloatingPoint!(X))
     assert(!isNaN(cast(real)-53.6));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
 
@@ -5534,7 +5534,7 @@ if (isFloatingPoint!X)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( isFinite(1.23f));
     assert( isFinite(float.max));
@@ -5543,7 +5543,7 @@ if (isFloatingPoint!X)
     assert(!isFinite(float.infinity));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(isFinite(1.23));
     assert(isFinite(double.max));
@@ -5590,7 +5590,7 @@ if (isFloatingPoint!X)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = 3;
     double d = 500;
@@ -5664,7 +5664,7 @@ if (isFloatingPoint!X)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
 
@@ -5723,7 +5723,7 @@ if (isFloatingPoint!(X))
 }
 
 ///
-@nogc @safe pure nothrow unittest
+version(StdUnittest) @nogc @safe pure nothrow unittest
 {
     assert(!isInfinity(float.init));
     assert(!isInfinity(-float.init));
@@ -5734,7 +5734,7 @@ if (isFloatingPoint!(X))
     assert(isInfinity(-1.0f / 0.0f));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     // CTFE-able tests
     assert(!isInfinity(double.init));
@@ -5834,7 +5834,7 @@ if (isFloatingPoint!X)
 }
 
 ///
-@nogc @safe pure nothrow unittest
+version(StdUnittest) @nogc @safe pure nothrow unittest
 {
     assert(!signbit(float.nan));
     assert(signbit(-float.nan));
@@ -5888,7 +5888,7 @@ if (isIntegral!(X) && isFloatingPoint!(R))
     return copysign(cast(R) to, from);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.meta : AliasSeq;
 
@@ -5936,7 +5936,7 @@ if (isNumeric!F)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(sgn(168.1234) == 1);
     assert(sgn(-168.1234) == -1);
@@ -6025,7 +6025,7 @@ real NaN(ulong payload) @trusted pure nothrow @nogc
     }
 }
 
-@system pure nothrow @nogc unittest // not @safe because taking address of local.
+version(StdUnittest) @system pure nothrow @nogc unittest // not @safe because taking address of local.
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     {
@@ -6088,7 +6088,7 @@ ulong getNaNPayload(real x) @trusted pure nothrow @nogc
 
 debug(UnitTest)
 {
-    @safe pure nothrow @nogc unittest
+    version(StdUnittest) @safe pure nothrow @nogc unittest
     {
         real nan4 = NaN(0x789_ABCD_EF12_3456);
         static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended
@@ -6313,12 +6313,12 @@ float nextDown(float x) @safe pure nothrow @nogc
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert( nextDown(1.0 + real.epsilon) == 1.0);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
     {
@@ -6409,7 +6409,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float a = 1;
     assert(is(typeof(nextafter(a, a)) == float));
@@ -6506,7 +6506,7 @@ if (isFloatingPoint!(F) && isIntegral!(G))
     return p;
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     // Make sure it instantiates and works properly on immutable values and
     // with various integer and float types.
@@ -6549,7 +6549,7 @@ if (isFloatingPoint!(F) && isIntegral!(G))
     assert(feqrel(pow(x, neg3),  1 / (x * x * x)) >= real.mant_dig - 1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(equalsDigit(pow(2.0L, 10.0L), 1024, 19));
 }
@@ -6600,7 +6600,7 @@ if (isIntegral!(F) && isIntegral!(G))
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     immutable int one = 1;
     immutable byte two = 2;
@@ -6867,7 +6867,7 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
     return impl(x, y);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     // Test all the special values.  These unittests can be run on Windows
     // by temporarily changing the version(linux) to version(all).
@@ -7007,7 +7007,7 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
     return result;
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     ulong a = 18446744073709551615u, b = 20u, c = 18446744073709551610u;
     assert(powmod(a, b, c) == 95367431640625u);
@@ -7164,7 +7164,7 @@ if (isFloatingPoint!(X))
     }
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     void testFeqrel(F)()
     {
@@ -7336,7 +7336,7 @@ do
     return u;
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(ieeeMean(-0.0,-1e-20)<0);
     assert(ieeeMean(0.0,1e-20)>0);
@@ -7392,7 +7392,7 @@ do
 }
 
 ///
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     real x = 3.1;
     static real[] pp = [56.1, 32.7, 6];
@@ -7400,7 +7400,7 @@ do
     assert(poly(x, pp) == (56.1L + (32.7L + 6.0L * x) * x));
 }
 
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     double x = 3.1;
     static double[] pp = [56.1, 32.7, 6];
@@ -7412,7 +7412,7 @@ do
     assert(poly(x, pp) == y);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(poly(3.0, [1.0, 2.0, 3.0]) == 34);
 }
@@ -7718,7 +7718,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     assert(approxEqual(1.0, 1.0099));
     assert(!approxEqual(1.0, 1.011));
@@ -7742,7 +7742,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
     assert(approxEqual(10, a));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     real num = real.infinity;
     assert(num == real.infinity);  // Passes.
@@ -7750,7 +7750,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
 }
 
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = sqrt(2.0f);
     assert(fabs(f * f - 2.0f) < .00001);
@@ -7762,7 +7762,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
     assert(fabs(r * r - 2.0) < .00001);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = fabs(-2.0f);
     assert(f == 2);
@@ -7774,7 +7774,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
     assert(r == 2);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = sin(-2.0f);
     assert(fabs(f - -0.909297f) < .00001);
@@ -7786,7 +7786,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
     assert(fabs(r - -0.909297f) < .00001);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = cos(-2.0f);
     assert(fabs(f - -0.416147f) < .00001);
@@ -7798,7 +7798,7 @@ bool approxEqual(T, U)(T lhs, U rhs)
     assert(fabs(r - -0.416147f) < .00001);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     float f = tan(-2.0f);
     assert(fabs(f - 2.18504f) < .00001);
@@ -7819,14 +7819,14 @@ bool approxEqual(T, U)(T lhs, U rhs)
     }
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // issue 6381: floor/ceil should be usable in pure function.
     auto x = floor(1.2);
     auto y = ceil(1.2);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // relative comparison depends on rhs, make sure proper side is used when
     // comparing range to single value. Based on bugzilla issue 15763
@@ -7999,7 +7999,7 @@ if (isFloatingPoint!T)
 }
 
 /// Most numbers are ordered naturally.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(cmp(-double.infinity, -double.max) < 0);
     assert(cmp(-double.max, -100.0) < 0);
@@ -8014,14 +8014,14 @@ if (isFloatingPoint!T)
 }
 
 /// Positive and negative zeroes are distinct.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(cmp(-0.0, +0.0) < 0);
     assert(cmp(+0.0, -0.0) > 0);
 }
 
 /// Depending on the sign, $(NAN)s go to either end of the spectrum.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(cmp(-double.nan, -double.infinity) < 0);
     assert(cmp(double.infinity, double.nan) < 0);
@@ -8029,13 +8029,13 @@ if (isFloatingPoint!T)
 }
 
 /// $(NAN)s of the same sign are ordered by the payload.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(cmp(NaN(10), NaN(20)) < 0);
     assert(cmp(-NaN(20), -NaN(10)) < 0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(float, double, real))
@@ -8139,7 +8139,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(nextPow2(2) == 4);
     assert(nextPow2(10) == 16);
@@ -8160,7 +8160,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(nextPow2(2.1) == 4.0);
     assert(nextPow2(-2.0) == -4.0);
@@ -8171,7 +8171,7 @@ if (isFloatingPoint!T)
     assert(nextPow2(double.infinity) == double.infinity);
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(nextPow2(ubyte(2)) == 4);
     assert(nextPow2(ubyte(10)) == 16);
@@ -8188,7 +8188,7 @@ if (isFloatingPoint!T)
     assert(nextPow2(ushort(4000)) == 4096);
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     foreach (ulong i; 1 .. 62)
     {
@@ -8199,7 +8199,7 @@ if (isFloatingPoint!T)
     }
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     import std.meta : AliasSeq;
 
@@ -8231,7 +8231,7 @@ if (isFloatingPoint!T)
     }}
 }
 
-@safe @nogc pure nothrow unittest // Issue 15973
+version(StdUnittest) @safe @nogc pure nothrow unittest // Issue 15973
 {
     assert(nextPow2(uint.max / 2) == uint.max / 2 + 1);
     assert(nextPow2(uint.max / 2 + 2) == 0);
@@ -8264,7 +8264,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(truncPow2(3) == 2);
     assert(truncPow2(4) == 4);
@@ -8286,7 +8286,7 @@ if (isFloatingPoint!T)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(truncPow2(2.1) == 2.0);
     assert(truncPow2(7.0) == 4.0);
@@ -8297,7 +8297,7 @@ if (isFloatingPoint!T)
     assert(truncPow2(double.infinity) == double.infinity);
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(truncPow2(ubyte(3)) == 2);
     assert(truncPow2(ubyte(4)) == 4);
@@ -8318,7 +8318,7 @@ if (isFloatingPoint!T)
     assert(truncPow2(short(4000)) == 2048);
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     foreach (ulong i; 1 .. 62)
     {
@@ -8329,7 +8329,7 @@ if (isFloatingPoint!T)
     }
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     import std.meta : AliasSeq;
 
@@ -8391,7 +8391,7 @@ if (isNumeric!X)
     }
 }
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert( isPowerOf2(1.0L));
     assert( isPowerOf2(2.0L));
@@ -8409,7 +8409,7 @@ if (isNumeric!X)
     assert(!isPowerOf2(real.infinity));
 }
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert( isPowerOf2(1));
     assert( isPowerOf2(2));
@@ -8420,7 +8420,7 @@ if (isNumeric!X)
     assert(!isPowerOf2(1337u));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -135,7 +135,7 @@ real sgnGamma(real x)
     return n & 1 ? 1.0 : -1.0;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(sgnGamma(5.0) == 1.0);
     assert(isNaN(sgnGamma(-3.0)));
@@ -159,7 +159,7 @@ real beta(real x, real y)
     } else return gamma(x) * gamma(y) / gamma(x+y);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isIdentical(beta(NaN(0xABC), 4), NaN(0xABC)));
     assert(isIdentical(beta(2, NaN(0xABC)), NaN(0xABC)));

--- a/std/meta.d
+++ b/std/meta.d
@@ -85,7 +85,7 @@ template AliasSeq(TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     alias TL = AliasSeq!(int, double);
@@ -97,7 +97,7 @@ template AliasSeq(TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias TL = AliasSeq!(int, double);
 
@@ -112,7 +112,7 @@ template AliasSeq(TList...)
  */
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto ref ArgCall(alias Func, alias arg)()
     {
@@ -195,7 +195,7 @@ alias Alias(alias a) = a;
 alias Alias(T) = T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Without Alias this would fail if Args[0] was e.g. a value and
     // some logic would be needed to detect when to use enum instead
@@ -209,7 +209,7 @@ alias Alias(T) = T;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias a = Alias!(123);
     static assert(a == 123);
@@ -256,7 +256,7 @@ if (!isAggregateType!T || is(Unqual!T == T))
     alias OldAlias = T;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct Foo {}
     static assert(is(OldAlias!(const(Foo)) == Foo));
@@ -283,7 +283,7 @@ template staticIndexOf(alias T, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.stdio;
 
@@ -323,7 +323,7 @@ if (args.length >= 1)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(staticIndexOf!( byte, byte, short, int, long) ==  0);
     static assert(staticIndexOf!(short, byte, short, int, long) ==  1);
@@ -361,7 +361,7 @@ template Erase(alias T, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, double, char);
     alias TL = Erase!(long, Types);
@@ -391,7 +391,7 @@ if (args.length >= 1)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(Pack!(Erase!(int,
                 short, int, int, 4)).
@@ -419,7 +419,7 @@ template EraseAll(alias T, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, long, int);
 
@@ -454,7 +454,7 @@ if (args.length >= 1)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(Pack!(EraseAll!(int,
                 short, int, int, 4)).
@@ -510,7 +510,7 @@ template NoDuplicates(TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, long, int, float);
 
@@ -518,7 +518,7 @@ template NoDuplicates(TList...)
     static assert(is(TL == AliasSeq!(int, long, float)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota;
 
@@ -535,7 +535,7 @@ template NoDuplicates(TList...)
     static assert(NoDuplicates!(aliasSeqOf!(iota(8)), aliasSeqOf!(iota(8))) == aliasSeqOf!(iota(8)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         Pack!(
@@ -572,7 +572,7 @@ template Replace(alias T, alias U, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, long, int, float);
 
@@ -605,7 +605,7 @@ if (args.length >= 2)
     }
  }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(Pack!(Replace!(byte, ubyte,
                 short,  byte, byte, byte)).
@@ -652,7 +652,7 @@ template ReplaceAll(alias T, alias U, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, long, int, float);
 
@@ -685,7 +685,7 @@ if (args.length >= 2)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(Pack!(ReplaceAll!(byte, ubyte,
                  byte, short,  byte,  byte)).
@@ -723,7 +723,7 @@ template Reverse(TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(int, long, long, int, float);
 
@@ -746,7 +746,7 @@ template MostDerived(T, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class A { }
     class B : A { }
@@ -774,7 +774,7 @@ template DerivedToFront(TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class A { }
     class B : A { }
@@ -808,14 +808,14 @@ template staticMap(alias F, T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : Unqual;
     alias TL = staticMap!(Unqual, int, const int, immutable int);
     static assert(is(TL == AliasSeq!(int, int, int)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : Unqual;
 
@@ -857,7 +857,7 @@ template allSatisfy(alias F, T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isIntegral;
 
@@ -891,7 +891,7 @@ template anySatisfy(alias F, T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isIntegral;
 
@@ -927,7 +927,7 @@ template Filter(alias pred, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isNarrowString, isUnsigned;
 
@@ -940,7 +940,7 @@ template Filter(alias pred, TList...)
     static assert(is(TL2 == AliasSeq!(ubyte, uint, ulong)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isPointer;
 
@@ -978,7 +978,7 @@ template templateNot(alias pred)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isPointer;
 
@@ -987,7 +987,7 @@ template templateNot(alias pred)
     static assert(allSatisfy!(isNoPointer, string, char, float));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))
     {
@@ -1025,7 +1025,7 @@ template templateAnd(Preds...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isNumeric, isUnsigned;
 
@@ -1038,7 +1038,7 @@ template templateAnd(Preds...)
     static assert(alwaysTrue!int);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))
     {
@@ -1083,7 +1083,7 @@ template templateOr(Preds...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isPointer, isUnsigned;
 
@@ -1096,7 +1096,7 @@ template templateOr(Preds...)
     static assert(!alwaysFalse!int);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))
     {
@@ -1155,7 +1155,7 @@ template aliasSeqOf(alias range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.sorting : sort;
@@ -1175,7 +1175,7 @@ template aliasSeqOf(alias range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static immutable REF = [0, 1, 2, 3];
     foreach (I, V; aliasSeqOf!([0, 1, 2, 3]))
@@ -1185,7 +1185,7 @@ template aliasSeqOf(alias range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to, octal;
     import std.range : iota;
@@ -1201,7 +1201,7 @@ template aliasSeqOf(alias range)
         }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum REF = "日本語"d;
     foreach (I, V; aliasSeqOf!"日本語"c)
@@ -1234,7 +1234,7 @@ template ApplyRight(alias Template, args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // enum bool isImplicitlyConvertible(From, To)
     import std.traits : isImplicitlyConvertible;
@@ -1248,7 +1248,7 @@ template ApplyRight(alias Template, args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : hasMember, ifTestable;
 
@@ -1272,7 +1272,7 @@ template ApplyRight(alias Template, args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : Largest;
 
@@ -1285,7 +1285,7 @@ template ApplyRight(alias Template, args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : FunctionAttribute, SetFunctionAttributes;
 
@@ -1313,7 +1313,7 @@ private template SmartAlias(T...)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(typeof({
         alias T(T0, int a, double b, alias T1, string c) = AliasSeq!(T0, a, b, T1, c);
@@ -1364,7 +1364,7 @@ template Repeat(size_t n, TList...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias ImInt0 = Repeat!(0, int);
     static assert(is(ImInt0 == AliasSeq!()));
@@ -1386,7 +1386,7 @@ template Repeat(size_t n, TList...)
 
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto staticArray(T, size_t n)(Repeat!(n, T) elems)
     {
@@ -1431,7 +1431,7 @@ template staticSort(alias cmp, Seq...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Nums = AliasSeq!(7, 2, 3, 23);
     enum Comp(int N1, int N2) = N1 < N2;
@@ -1439,7 +1439,7 @@ template staticSort(alias cmp, Seq...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Types = AliasSeq!(uint, short, ubyte, long, ulong);
     enum Comp(T1, T2) = __traits(isUnsigned, T2) - __traits(isUnsigned, T1);
@@ -1507,7 +1507,7 @@ template staticIsSorted(alias cmp, Seq...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Comp(int N1, int N2) = N1 < N2;
     static assert( staticIsSorted!(Comp, 2, 2));
@@ -1516,7 +1516,7 @@ template staticIsSorted(alias cmp, Seq...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Comp(T1, T2) = __traits(isUnsigned, T2) - __traits(isUnsigned, T1);
     static assert( staticIsSorted!(Comp, uint, ubyte, ulong, short, long));
@@ -1557,7 +1557,7 @@ if (stepSize != 0)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Stride!(1, short, int, long) == AliasSeq!(short, int, long)));
     static assert(is(Stride!(2, short, int, long) == AliasSeq!(short, long)));
@@ -1570,7 +1570,7 @@ if (stepSize != 0)
     static assert(is(Stride!(-3, attribs) == AliasSeq!(ulong, long)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(Pack!(Stride!(5, int)).equals!(int));
     static assert(Pack!(Stride!(-5, int)).equals!(int));
@@ -1593,7 +1593,7 @@ if (stepSize != 0)
 alias Instantiate(alias Template, Params...) = Template!Params;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // ApplyRight combined with Instantiate can be used to apply various
     // templates to the same parameters.
@@ -1652,7 +1652,7 @@ if (ab.length == 2)
 private template expectType(T) {}
 private template expectBool(bool b) {}
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isSame!(int, int));
     static assert(!isSame!(int, short));
@@ -1723,7 +1723,7 @@ private template Pack(T...)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( Pack!(1, int, "abc").equals!(1, int, "abc"));
     static assert(!Pack!(1, int, "abc").equals!(1, int, "cba"));

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -624,7 +624,7 @@ private:
     // }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.memory : GC;
     import std.file : deleteme;
@@ -670,7 +670,7 @@ private:
 }
 
 version(linux)
-@system unittest // Issue 14868
+version(StdUnittest) @system unittest // Issue 14868
 {
     import std.file : deleteme;
     import std.typecons : scoped;
@@ -693,7 +693,7 @@ version(linux)
     assert(.close(fd) == -1);
 }
 
-@system unittest // Issue 14994, 14995
+version(StdUnittest) @system unittest // Issue 14994, 14995
 {
     import std.file : deleteme;
     import std.typecons : scoped;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -417,7 +417,7 @@ if (isCurlConn!Conn)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
     static import std.file;
@@ -483,7 +483,7 @@ if (isCurlConn!Conn)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
     static import std.file;
@@ -553,7 +553,7 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -606,7 +606,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, postData, conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -623,7 +623,7 @@ if (is(T == char) || is(T == ubyte))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -650,7 +650,7 @@ if (is(T == char) || is(T == ubyte))
     return post(url, urlEncode(postDict), conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     foreach (host; [testServer.addr, "http://" ~ testServer.addr])
     {
@@ -713,7 +713,7 @@ if ( isCurlConn!Conn && (is(T == char) || is(T == ubyte)) )
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -781,7 +781,7 @@ if (isCurlConn!Conn)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -827,7 +827,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, null, conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -869,7 +869,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, cast(void[]) null, conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -910,7 +910,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, cast(void[]) null, conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -956,7 +956,7 @@ if (is(T == char) || is(T == ubyte))
     return _basicHTTP!(T)(url, patchData, conn);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -1056,7 +1056,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     return _decodeContent!T(content.data, client.p.charset);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
     import std.exception : collectException;
@@ -1072,7 +1072,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
 }
 
 // Bugzilla 14760 - content length must be reset after post
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -1097,7 +1097,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     assert(res == "TRACERESPONSE");
 }
 
-@system unittest // charset detection and transcoding to T
+version(StdUnittest) @system unittest // charset detection and transcoding to T
 {
     testServer.handle((s) {
         s.send("HTTP/1.1 200 OK\r\n"~
@@ -1330,7 +1330,7 @@ if (isCurlConn!Conn && isSomeChar!Char && isSomeChar!Terminator)
     return SyncLineInputRange(result, keepTerminator == Yes.keepTerminator, terminator);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1404,7 +1404,7 @@ if (isCurlConn!(Conn))
     return SyncChunkInputRange(result, chunkSize);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1680,7 +1680,7 @@ auto byLineAsync(Conn = AutoProtocol, Terminator = char, Char = char)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1802,7 +1802,7 @@ if (isCurlConn!(Conn))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2038,7 +2038,7 @@ private mixin template Protocol()
         p.curl.set(CurlOption.userpwd, format("%s:%s", username, password));
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.searching : canFind;
 
@@ -3025,7 +3025,7 @@ struct HTTP
             method = Method.post;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.searching : canFind;
 
@@ -3194,7 +3194,7 @@ struct HTTP
 
 } // HTTP
 
-@system unittest // charset/Charset/CHARSET/...
+version(StdUnittest) @system unittest // charset/Charset/CHARSET/...
 {
     import etc.c.curl;
 
@@ -3600,7 +3600,7 @@ struct FTP
         return p.curl.getTiming(timing, val);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         auto client = FTP();
 
@@ -3963,7 +3963,7 @@ struct SMTP
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.net.curl;
 

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -778,7 +778,7 @@ if (isSomeChar!(Char))
     return EmailStatus(valid, to!(string)(localPart), to!(string)(domainPart), finalStatus);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(`test.test@iana.org`.isEmail(No.checkDns).statusCode == EmailStatusCode.valid);
     assert(`test.test@iana.org`.isEmail(No.checkDns, EmailStatusCode.none).statusCode == EmailStatusCode.valid);
@@ -1258,7 +1258,7 @@ if (isSomeChar!(Char))
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17217
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     wstring a = `test.test@iana.org`w;
     dstring b = `test.test@iana.org`d;
@@ -1802,7 +1802,7 @@ if (is(Unqual!(ElementType!(S1)) == dchar) && is(Unqual!(ElementType!(S2)) == dc
     return slice1.icmp(slice2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert("abc".compareFirstN("abcdef", 3) == 0);
     assert("abc".compareFirstN("Abc", 3) == 0);
@@ -1826,7 +1826,7 @@ if (isDynamicArray!(A) && !isNarrowString!(A) && isMutable!(A) && !is(A == void[
     return e;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto array = [0, 1, 2, 3];
     auto result = array.pop();
@@ -1852,13 +1852,13 @@ const(T)[] get (T) (const(T)[] str, size_t index, dchar c)
     return str[index .. index + codeLength!(T)(c)];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert("abc".get(1, 'b') == "b");
     assert("löv".get(1, 'ö') == "ö");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert("abc".get(1, 'b') == "b");
     assert("löv".get(1, 'ö') == "ö");

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -126,7 +126,7 @@ if (((flags & flags.signed) + precision + exponentWidth) % 8 == 0 && precision +
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : sin, cos;
 
@@ -614,7 +614,7 @@ public:
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     alias FPTypes =
@@ -650,7 +650,7 @@ public:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to to!string(CustomFloat)
     import std.conv;
@@ -691,7 +691,7 @@ if (isFloatingPoint!F)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
 
@@ -736,7 +736,7 @@ template secantMethod(alias fun)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual, cos;
 
@@ -748,7 +748,7 @@ template secantMethod(alias fun)
     assert(approxEqual(x, 0.865474));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system because of __gshared stderr
     scope(failure) stderr.writeln("Failure testing secantMethod");
@@ -1176,7 +1176,7 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
     return findRoot!(T, R delegate(T), bool delegate(T lo, T hi))(f, a, b, tolerance);
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     int numProblems = 0;
     int numCalls;
@@ -1387,7 +1387,7 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
 }
 
 //regression control
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to the case in the 2nd line
     static assert(__traits(compiles, findRoot((float x)=>cast(real) x, float.init, float.init)));
@@ -1576,7 +1576,7 @@ do
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
 
@@ -1585,7 +1585,7 @@ do
     assert(ret.y.approxEqual(0.0));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(double, float, real))
@@ -1674,7 +1674,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
     return sqrt(result);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(double, const double, immutable double))
@@ -1765,7 +1765,7 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
     return sum0;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to dotProduct and assertCTFEable
     import std.exception : assertCTFEable;
@@ -1812,7 +1812,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
     return dotprod / sqrt(norma * normb);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(double, const double, immutable double))
@@ -1876,7 +1876,7 @@ if (isForwardRange!(R))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     double[] a = [];
     assert(!normalize(a));
@@ -1914,7 +1914,7 @@ if (isInputRange!Range && isFloatingPoint!(ElementType!Range))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : isNaN;
 
@@ -1966,7 +1966,7 @@ if (isInputRange!Range &&
     return result;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(double, const double, immutable double))
@@ -2013,7 +2013,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
 
@@ -2097,7 +2097,7 @@ if (isInputRange!Range1 && isInputRange!Range2 &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math : approxEqual;
 
@@ -2232,7 +2232,7 @@ if (isRandomAccessRange!(R1) && hasLength!(R1) &&
     return result;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string[] s = ["Hello", "brave", "new", "world"];
     string[] t = ["Hello", "new", "world"];
@@ -2287,7 +2287,7 @@ if (isRandomAccessRange!(R1) && hasLength!(R1) &&
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.math : approxEqual, sqrt;
 
@@ -2513,7 +2513,7 @@ GapWeightedSimilarityIncremental!(R, F) gapWeightedSimilarityIncremental(R, F)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     string[] s = ["Hello", "brave", "new", "world"];
     string[] t = ["Hello", "new", "world"];
@@ -2527,7 +2527,7 @@ GapWeightedSimilarityIncremental!(R, F) gapWeightedSimilarityIncremental(R, F)
     assert(simIter.empty);     // no more match
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     string[] s = ["Hello", "brave", "new", "world"];
@@ -2569,7 +2569,7 @@ GapWeightedSimilarityIncremental!(R, F) gapWeightedSimilarityIncremental(R, F)
     assert(simIter.front == 0.5, text(simIter.front)); // one 2-gram match, 1 gap
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     GapWeightedSimilarityIncremental!(string[]) sim =
         GapWeightedSimilarityIncremental!(string[])(
@@ -2656,7 +2656,7 @@ T gcd(T)(T a, T b)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(gcd(2 * 5 * 7 * 7, 5 * 7 * 11) == 5 * 7);
     const int a = 5 * 13 * 23 * 23, b = 13 * 59;
@@ -2720,7 +2720,7 @@ T gcd(T)(T a, T b)
 }
 
 // Issue 7102
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.bigint : BigInt;
     assert(gcd(BigInt("71_000_000_000_000_000_000"),
@@ -2728,7 +2728,7 @@ T gcd(T)(T a, T b)
            BigInt("1_000_000_000_000_000_000"));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // A numerical type that only supports % and - (to force gcd implementation
     // to use Euclidean algorithm).
@@ -3252,7 +3252,7 @@ void inverseFft(Ret, R)(R range, Ret buf)
     return fftObj.inverseFft!(Ret, R)(range, buf);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm;
     import std.conv;
@@ -3448,7 +3448,7 @@ if (isScalarType!N && !isFloatingPoint!N)
     return num & (cast(N) 1 << bsr(num));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(roundDownToPowerOf2(7) == 4);
     assert(roundDownToPowerOf2(4) == 4);
@@ -3460,7 +3460,7 @@ template isComplexLike(T)
         is(typeof(T.init.im));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isComplexLike!(Complex!double));
     static assert(!isComplexLike!(uint));

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -251,7 +251,19 @@ class OutBuffer
         import core.stdc.stdlib : alloca;
         import std.string : toStringz;
 
-        version (unittest)
+        version(unittest)
+        {
+            version(StdUnittest)
+                enum triggerReallocationForTest = true;
+            else
+                enum triggerReallocationForTest = false;
+        }
+        else
+        {
+            enum triggerReallocationForTest = false;
+        }
+
+        static if (triggerReallocationForTest)
             char[3] buffer = void;      // trigger reallocation
         else
             char[128] buffer = void;
@@ -316,7 +328,7 @@ class OutBuffer
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         OutBuffer b = new OutBuffer();
         b.writef("a%sb", 16);
@@ -343,7 +355,7 @@ class OutBuffer
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         OutBuffer b = new OutBuffer();
         b.writefln("a%sb", 16);
@@ -375,7 +387,7 @@ class OutBuffer
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string : cmp;
 
@@ -394,7 +406,7 @@ class OutBuffer
     assert(cmp(buf.toString(),"New data") == 0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     static assert(isOutputRange!(OutBuffer, char));

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -41,7 +41,7 @@ License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
 module std.parallelism;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : map;
     import std.math : approxEqual;
@@ -175,7 +175,7 @@ private size_t cacheLineSizeImpl() @nogc nothrow @trusted
     return result;
 }
 
-@nogc @safe nothrow unittest
+version(StdUnittest) @nogc @safe nothrow unittest
 {
     assert(cacheLineSize == cacheLineSizeImpl);
 }
@@ -243,7 +243,7 @@ private template isSafeTask(F)
         allSatisfy!(noUnsharedAliasing, Parameters!F);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias F1 = void function() @safe;
     alias F2 = void function();
@@ -356,7 +356,7 @@ private template isRoundRobin(T)
     enum isRoundRobin = false;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isRoundRobin!(RoundRobinBuffer!(void delegate(char[]), bool delegate())));
     static assert(!isRoundRobin!(uint));
@@ -2920,7 +2920,7 @@ public:
     // they would appear under the outer one. (We can't move this inside the
     // outer fold() template because then dmd runs out of memory possibly due to
     // recursive template instantiation, which is surprisingly not caught.)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // Just the range
         auto x = taskPool.fold!"a + b"([1, 2, 3, 4]);
@@ -3469,7 +3469,7 @@ public:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : sum;
     import std.range : iota;
@@ -4113,7 +4113,7 @@ version(StdUnittest)
 
 // These test basic functionality but don't stress test for threading bugs.
 // These are the tests that should be run every time Phobos is compiled.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal, min, max;
     import std.algorithm.iteration : filter, map, reduce;
@@ -4525,7 +4525,7 @@ version(StdUnittest)
 // tons of stuff and should not be run every time make unittest is run.
 version(parallelismStressTest)
 {
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         size_t attempt;
         for (; attempt < 10; attempt++)
@@ -4608,7 +4608,7 @@ version(parallelismStressTest)
 
     // These unittests are intended more for actual testing and not so much
     // as examples.
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         foreach (attempt; 0 .. 10)
         foreach (poolSize; [0, 4])
@@ -4784,14 +4784,14 @@ version(StdUnittest)
     static auto __genPair_12733(ulong n) { return __S_12733(n); }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     immutable ulong[] data = [ 2UL^^59-1, 2UL^^59-1, 2UL^^59-1, 112_272_537_195_293UL ];
 
     auto result = taskPool.amap!__genPair_12733(data);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota;
 
@@ -4799,7 +4799,7 @@ version(StdUnittest)
     assert(__traits(compiles, { foreach (i; iota(0, 100UL).parallel) {} }));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : each;
 
@@ -4810,7 +4810,7 @@ version(StdUnittest)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17539
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.random : rndGen;
     // ensure compilation

--- a/std/path.d
+++ b/std/path.d
@@ -257,7 +257,7 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementType!R) ||
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byDchar;
@@ -286,7 +286,7 @@ if (isBidirectionalRange!R && isSomeChar!(ElementType!R) ||
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byDchar;
@@ -304,7 +304,7 @@ if (isBidirectionalRange!R && isSomeChar!(ElementType!R) ||
     return ltrimDirSeparators(rtrimDirSeparators(path));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byDchar;
@@ -436,7 +436,7 @@ if (isSomeChar!C && isSomeChar!C1)
     else return p;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(baseName("").empty);
     assert(baseName("file.ext"w) == "file.ext");
@@ -497,7 +497,7 @@ if (isSomeChar!C && isSomeChar!C1)
     assert(baseName(DirEntry("dir/file.ext")) == "file.ext");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!baseName("file"));
 
@@ -583,7 +583,7 @@ private auto _dirName(R)(R path)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(dirName("") == ".");
     assert(dirName("file"w) == ".");
@@ -620,7 +620,7 @@ private auto _dirName(R)(R path)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!dirName("file"));
 
@@ -631,7 +631,7 @@ private auto _dirName(R)(R path)
     assert(sa.dirName == "file/path/to");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(dirName("dir/file") == "dir");
 
@@ -731,7 +731,7 @@ Lnull:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(rootName("") is null);
     assert(rootName("foo") is null);
@@ -747,7 +747,7 @@ Lnull:
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!rootName("/foo/bar"));
 
@@ -758,7 +758,7 @@ Lnull:
     assert(sa.rootName == "/");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byChar;
@@ -820,7 +820,7 @@ private auto _driveName(R)(R path)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : empty;
     version (Posix)  assert(driveName("c:/foo").empty);
@@ -838,7 +838,7 @@ private auto _driveName(R)(R path)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!driveName("d:/file"));
 
@@ -854,7 +854,7 @@ private auto _driveName(R)(R path)
     assert(sa.driveName == result);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byChar;
@@ -907,7 +907,7 @@ private auto _stripDrive(R)(R path)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version (Windows)
     {
@@ -916,7 +916,7 @@ private auto _stripDrive(R)(R path)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!stripDrive("d:/dir/file"));
 
@@ -932,7 +932,7 @@ private auto _stripDrive(R)(R path)
     assert(sa.stripDrive == result);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version(Windows)
     {
@@ -977,7 +977,7 @@ if (isRandomAccessRange!R && hasLength!R && isSomeChar!(ElementType!R) ||
     return -1;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(extSeparatorPos("file") == -1);
     assert(extSeparatorPos("file.ext"w) == 4);
@@ -986,7 +986,7 @@ if (isRandomAccessRange!R && hasLength!R && isSomeChar!(ElementType!R) ||
     assert(extSeparatorPos(".foo.ext"w.dup) == 4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(extSeparatorPos("dir/file"d.dup) == -1);
     assert(extSeparatorPos("dir/file.ext") == 8);
@@ -1036,7 +1036,7 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : empty;
     assert(extension("file").empty);
@@ -1050,7 +1050,7 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) ||
     static assert(extension("file.ext") == ".ext");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     {
         auto r = MockRange!(immutable(char))(`file.ext1.ext2`);
@@ -1092,7 +1092,7 @@ private auto _stripExtension(R)(R path)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(stripExtension("file")           == "file");
     assert(stripExtension("file.ext")       == "file");
@@ -1103,7 +1103,7 @@ private auto _stripExtension(R)(R path)
     assert(stripExtension("dir/file.ext")   == "dir/file");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!stripExtension("file"));
 
@@ -1114,7 +1114,7 @@ private auto _stripExtension(R)(R path)
     assert(sa.stripExtension == "foo");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(stripExtension("file.ext"w) == "file");
     assert(stripExtension("file.ext1.ext2"d) == "file.ext1");
@@ -1184,7 +1184,7 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(setExtension("file", "ext") == "file.ext");
     assert(setExtension("file"w, ".ext"w) == "file.ext");
@@ -1194,7 +1194,7 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
     assert(setExtension("file.old"d, ".new"d) == "file.new");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(setExtension("file"w.dup, "ext"w) == "file.ext");
     assert(setExtension("file"w.dup, ".ext"w) == "file.ext");
@@ -1253,7 +1253,7 @@ private auto _withExtension(R, C)(R path, C[] ext)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     assert(withExtension("file", "ext").array == "file.ext");
@@ -1266,7 +1266,7 @@ private auto _withExtension(R, C)(R path, C[] ext)
     assert(withExtension("file.ext"w.byWchar, ".").array == "file."w);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1299,7 +1299,7 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(defaultExtension("file", "ext") == "file.ext");
     assert(defaultExtension("file", ".ext") == "file.ext");
@@ -1308,7 +1308,7 @@ if (isSomeChar!C1 && is(Unqual!C1 == Unqual!C2))
     assert(defaultExtension("file.old", ".new") == "file.old");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(defaultExtension("file"w.dup, "ext"w) == "file.ext");
     assert(defaultExtension("file.old"d.dup, "new"d) == "file.old");
@@ -1367,7 +1367,7 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     assert(withDefaultExtension("file", "ext").array == "file.ext");
@@ -1382,7 +1382,7 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
     assert(withDefaultExtension("file".byChar, "").array == "file.");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1466,7 +1466,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version (Posix)
     {
@@ -1485,7 +1485,7 @@ if (isSomeChar!C)
     }
 }
 
-@system unittest // non-documented
+version(StdUnittest) @system unittest // non-documented
 {
     import std.range;
     // ir() wraps an array in a plain (i.e. non-forward) input range, so that
@@ -1564,7 +1564,7 @@ if (isSomeChar!C)
     assert(buildPath(ir(fewLong)) == fewLongCombined);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test for issue 7397
     string[] ary = ["a", "b"];
@@ -1650,7 +1650,7 @@ if ((isRandomAccessRange!R1 && hasSlicing!R1 && hasLength!R1 && isSomeChar!(Elem
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     version (Posix)
@@ -1696,7 +1696,7 @@ if (Ranges.length >= 2 &&
     return chainPath!Types(ranges);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(chainPath(TestAliasedString(null), TestAliasedString(null), TestAliasedString(null)).empty);
     assert(chainPath(TestAliasedString(null), TestAliasedString(null), "").empty);
@@ -1743,7 +1743,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(buildNormalizedPath("foo", "..") == ".");
 
@@ -1768,7 +1768,7 @@ if (isSomeChar!C)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(buildNormalizedPath(".", ".") == ".");
     assert(buildNormalizedPath("foo", "..") == ".");
@@ -1843,7 +1843,7 @@ if (isSomeChar!C)
     else static assert(0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test for issue 7397
     string[] ary = ["a", "b"];
@@ -2021,7 +2021,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     assert(asNormalizedPath("foo/..").array == ".");
@@ -2051,12 +2051,12 @@ if (isConvertibleToString!R)
     return asNormalizedPath!(StringTypeOf!R)(path);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!asNormalizedPath(null));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.utf : byChar;
@@ -2144,7 +2144,7 @@ if (isConvertibleToString!R)
     else static assert(0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
 
@@ -2425,7 +2425,7 @@ if ((isRandomAccessRange!R && hasSlicing!R ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -2454,13 +2454,13 @@ if (isConvertibleToString!R)
     return pathSplitter!(StringTypeOf!R)(path);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     assert(testAliasedString!pathSplitter("/"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // equal2 verifies that the range is the same both ways, i.e.
     // through front/popFront and back/popBack.
@@ -2569,7 +2569,7 @@ if (isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isRooted("/"));
     assert(isRooted("/foo"));
@@ -2652,7 +2652,7 @@ else version (Posix)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(!isAbsolute("foo"));
     assert(!isAbsolute("../foo"w));
@@ -2727,7 +2727,7 @@ string absolutePath(string path, lazy string base = getcwd())
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version (Posix)
     {
@@ -2746,7 +2746,7 @@ string absolutePath(string path, lazy string base = getcwd())
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     version (Posix)
     {
@@ -2794,7 +2794,7 @@ if ((isRandomAccessRange!R && isSomeChar!(ElementType!R) ||
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     assert(asAbsolutePath(cast(string) null).array == "");
@@ -2815,7 +2815,7 @@ if (isConvertibleToString!R)
     return asAbsolutePath!(StringTypeOf!R)(path);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(testAliasedString!asAbsolutePath(null));
 }
@@ -2874,7 +2874,7 @@ string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(relativePath("foo") == "foo");
 
@@ -2897,7 +2897,7 @@ string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assert(relativePath("foo") == "foo");
@@ -3005,7 +3005,7 @@ if ((isNarrowString!R1 ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     version (Posix)
@@ -3040,7 +3040,7 @@ if (isConvertibleToString!R1 || isConvertibleToString!R2)
     return asRelativePath!(cs, Types)(path, base);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     version (Posix)
@@ -3054,7 +3054,7 @@ if (isConvertibleToString!R1 || isConvertibleToString!R2)
     assert(asRelativePath("foo"d.byDchar, TestAliasedString("bar")).array == "foo");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array, std.utf : bCU=byCodeUnit;
     version (Posix)
@@ -3104,7 +3104,7 @@ int filenameCharCmp(CaseSensitive cs = CaseSensitive.osDefault)(dchar a, dchar b
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(filenameCharCmp('a', 'a') == 0);
     assert(filenameCharCmp('a', 'b') < 0);
@@ -3125,7 +3125,7 @@ int filenameCharCmp(CaseSensitive cs = CaseSensitive.osDefault)(dchar a, dchar b
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(filenameCharCmp!(CaseSensitive.yes)('A', 'a') < 0);
     assert(filenameCharCmp!(CaseSensitive.yes)('a', 'A') > 0);
@@ -3208,7 +3208,7 @@ if (isInputRange!Range1 && !isInfinite!Range1 &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(filenameCmp("abc", "abc") == 0);
     assert(filenameCmp("abc", "abd") < 0);
@@ -3241,14 +3241,14 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
     return filenameCmp!(cs, Types)(filename1, filename2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), "abc") < 0);
     assert(filenameCmp!(CaseSensitive.yes)("Abc", TestAliasedString("abc")) < 0);
     assert(filenameCmp!(CaseSensitive.yes)(TestAliasedString("Abc"), TestAliasedString("abc")) < 0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(filenameCmp!(CaseSensitive.yes)("Abc", "abc") < 0);
     assert(filenameCmp!(CaseSensitive.yes)("abc", "Abc") > 0);
@@ -3458,7 +3458,7 @@ do
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(globMatch("foo.bar", "*"));
     assert(globMatch("foo.bar", "*.*"));
@@ -3491,12 +3491,12 @@ if (isConvertibleToString!Range)
     return globMatch!(cs, C, StringTypeOf!Range)(path, pattern);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!globMatch("foo.bar", "*"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(globMatch!(CaseSensitive.no)("foo", "Foo"));
     assert(!globMatch!(CaseSensitive.yes)("foo", "Foo"));
@@ -3629,7 +3629,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
 
 ///
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.utf : byCodeUnit;
 
@@ -3642,13 +3642,13 @@ if (isConvertibleToString!Range)
     return isValidFilename!(StringTypeOf!Range)(filename);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!isValidFilename("hello.exe"));
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.conv;
     auto valid = ["foo"];
@@ -3822,7 +3822,7 @@ if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeC
 
 ///
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     assert(isValidPath("/foo/bar"));
     assert(!isValidPath("/foo\0/bar"));
@@ -3865,7 +3865,7 @@ if (isConvertibleToString!Range)
     return isValidPath!(StringTypeOf!Range)(path);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!isValidPath("/foo/bar"));
 }
@@ -4010,8 +4010,20 @@ string expandTilde(string inputPath) nothrow
 
                 assert(last_char > 1);
 
+                version(unittest)
+                {
+                    version(StdUnittest)
+                        enum inStdUnittest = true;
+                    else
+                        enum inStdUnittest = false;
+                }
+                else
+                {
+                    enum inStdUnittest = false;
+                }
+
                 // Reserve C memory for the getpwnam_r() function.
-                version (unittest)
+                static if (inStdUnittest)
                     uint extra_memory_size = 2;
                 else
                     uint extra_memory_size = 5 * 1024;
@@ -4074,7 +4086,7 @@ string expandTilde(string inputPath) nothrow
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     version (Posix)
     {

--- a/std/process.d
+++ b/std/process.d
@@ -146,7 +146,7 @@ private
             }
         }
 
-        @system unittest
+        version(StdUnittest) @system unittest
         {
             new Thread({assert(getEnvironPtr !is null);}).start();
         }
@@ -810,7 +810,7 @@ private const(char*)* createEnv(const string[string] childEnv,
     return envz.ptr;
 }
 
-version (Posix) @system unittest
+version(StdUnittest) version (Posix) @system unittest
 {
     auto e1 = createEnv(null, false);
     assert(e1 != null && *e1 == null);
@@ -875,7 +875,7 @@ private LPVOID createEnv(const string[string] childEnv,
     return envz.data.ptr;
 }
 
-version (Windows) @system unittest
+version(StdUnittest) version (Windows) @system unittest
 {
     assert(createEnv(null, true) == null);
     assert((cast(wchar*) createEnv(null, false))[0 .. 2] == "\0\0"w);
@@ -913,7 +913,7 @@ private bool isExecutable(in char[] path) @trusted nothrow @nogc //TODO: @safe
     return (access(path.tempCString(), X_OK) == 0);
 }
 
-version (Posix) @safe unittest
+version(StdUnittest) version (Posix) @safe unittest
 {
     import std.algorithm;
     auto lsPath = searchPathFor("ls");
@@ -939,7 +939,7 @@ private void setCLOEXEC(int fd, bool on) nothrow @nogc
     assert(flags != -1 || .errno == EBADF);
 }
 
-@system unittest // Command line arguments in spawnProcess().
+version(StdUnittest) @system unittest // Command line arguments in spawnProcess().
 {
     version (Windows) TestScript prog =
        "if not [%~1]==[foo] ( exit 1 )
@@ -959,7 +959,7 @@ private void setCLOEXEC(int fd, bool on) nothrow @nogc
 // test that file descriptors are correctly closed / left open.
 // ideally this would be done by the child process making libc
 // calls, but we make do...
-version (Posix) @system unittest
+version(StdUnittest) version (Posix) @system unittest
 {
     import core.sys.posix.fcntl : open, O_RDONLY;
     import core.sys.posix.unistd : close;
@@ -1033,7 +1033,7 @@ version (Posix) @system unittest
     testFDs();
 }
 
-@system unittest // Environment variables in spawnProcess().
+version(StdUnittest) @system unittest // Environment variables in spawnProcess().
 {
     // We really should use set /a on Windows, but Wine doesn't support it.
     version (Windows) TestScript envProg =
@@ -1078,7 +1078,7 @@ version (Posix) @system unittest
     assert(wait(spawnProcess(envProg.path, env, Config.newEnv)) == 6);
 }
 
-@system unittest // Stream redirection in spawnProcess().
+version(StdUnittest) @system unittest // Stream redirection in spawnProcess().
 {
     import std.path : buildPath;
     import std.string;
@@ -1137,7 +1137,7 @@ version (Posix) @system unittest
     testFiles(Config.detached);
 }
 
-@system unittest // Error handling in spawnProcess()
+version(StdUnittest) @system unittest // Error handling in spawnProcess()
 {
     import std.exception : assertThrown;
     assertThrown!ProcessException(spawnProcess("ewrgiuhrifuheiohnmnvqweoijwf"));
@@ -1160,7 +1160,7 @@ version (Posix) @system unittest
     }
 }
 
-@system unittest // Specifying a working directory.
+version(StdUnittest) @system unittest // Specifying a working directory.
 {
     import std.path;
     TestScript prog = "echo foo>bar";
@@ -1174,7 +1174,7 @@ version (Posix) @system unittest
     assert(exists(buildPath(directory, "bar")));
 }
 
-@system unittest // Specifying a bad working directory.
+version(StdUnittest) @system unittest // Specifying a bad working directory.
 {
     import std.exception : assertThrown;
     TestScript prog = "echo";
@@ -1204,7 +1204,7 @@ version (Posix) @system unittest
     }
 }
 
-@system unittest // Specifying empty working directory.
+version(StdUnittest) @system unittest // Specifying empty working directory.
 {
     TestScript prog = "";
 
@@ -1213,7 +1213,7 @@ version (Posix) @system unittest
     spawnProcess([prog.path], null, Config.none, directory).wait();
 }
 
-@system unittest // Reopening the standard streams (issue 13258)
+version(StdUnittest) @system unittest // Reopening the standard streams (issue 13258)
 {
     import std.string;
     void fun()
@@ -1239,7 +1239,7 @@ version (Posix) @system unittest
 }
 
 version (Windows)
-@system unittest // MSVCRT workaround (issue 14422)
+version(StdUnittest) @system unittest // MSVCRT workaround (issue 14422)
 {
     auto fn = uniqueTempPath();
     std.file.write(fn, "AAAAAAAAAA");
@@ -1322,7 +1322,7 @@ Pid spawnShell(in char[] command,
                       shellPath);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     version (Windows)
         auto cmd = "echo %FOO%";
@@ -1343,7 +1343,7 @@ Pid spawnShell(in char[] command,
 }
 
 version (Windows)
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.string;
     TestScript prog = "echo %0 %*";
@@ -1671,7 +1671,7 @@ int wait(Pid pid) @safe
 }
 
 
-@system unittest // Pid and wait()
+version(StdUnittest) @system unittest // Pid and wait()
 {
     version (Windows)    TestScript prog = "exit %~1";
     else version (Posix) TestScript prog = "exit $1";
@@ -1826,7 +1826,7 @@ void kill(Pid pid, int codeOrSignal)
     }
 }
 
-@system unittest // tryWait() and kill()
+version(StdUnittest) @system unittest // tryWait() and kill()
 {
     import core.thread;
     import std.exception : assertThrown;
@@ -1865,7 +1865,7 @@ void kill(Pid pid, int codeOrSignal)
     assertThrown!ProcessException(kill(pid));
 }
 
-@system unittest // wait() and kill() detached process
+version(StdUnittest) @system unittest // wait() and kill() detached process
 {
     import core.thread;
     import std.exception : assertThrown;
@@ -2007,7 +2007,7 @@ private:
     File _read, _write;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.string;
     auto p = pipe();
@@ -2254,7 +2254,7 @@ enum Redirect
     stdoutToStderr = 16,
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.string;
     version (Windows) TestScript prog =
@@ -2311,7 +2311,7 @@ enum Redirect
     assert(wait(pp.pid) == 1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     TestScript prog = "exit 0";
@@ -2535,7 +2535,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     return Tuple!(int, "status", string, "output")(wait(p.pid), cast(string) a.data);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.string;
     // To avoid printing the newline characters, we use the echo|set trick on
@@ -2560,7 +2560,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     assert(s.output.stripRight() == "HelloWorld");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string;
     auto r1 = executeShell("echo foo");
@@ -2578,7 +2578,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     assert(r4.output.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : Tuple;
     void foo() //Just test the compilation
@@ -2709,7 +2709,7 @@ version (Windows) private immutable string shellSwitch = "/C";
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int pidA, pidB;
     ThreadID tidA, tidB;
@@ -2859,7 +2859,7 @@ string escapeShellCommand(in char[][] args...) @safe pure
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // This is a simple unit test without any special requirements,
     // in addition to the unittest_burnin one below which requires
@@ -3097,7 +3097,7 @@ version(Windows) version(StdUnittest)
             .array();
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         string[] testStrings = [
             `Hello`,
@@ -3195,7 +3195,7 @@ string escapeShellFileName(in char[] fileName) @trusted pure nothrow
 //version = unittest_burnin;
 
 version(unittest_burnin)
-@system unittest
+version(StdUnittest) @system unittest
 {
     // There are no readily-available commands on all platforms suitable
     // for properly testing command escaping. The behavior of CMD's "echo"
@@ -3656,7 +3656,7 @@ private:
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertThrown;
     // New variable

--- a/std/random.d
+++ b/std/random.d
@@ -56,7 +56,7 @@ import std.range.primitives;
 import std.traits;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // seed a random generator with a constant
     auto rnd = Random(42);
@@ -193,7 +193,7 @@ template isSeedable(Rng)
         }));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     struct NoRng
     {
@@ -316,7 +316,7 @@ The parameters of this distribution. The random number is $(D_PARAM x
         return result * n;
     }
 
-    @safe pure nothrow unittest
+    version(StdUnittest) @safe pure nothrow unittest
     {
         static assert(primeFactorsOnly(100) == 10);
         //writeln(primeFactorsOnly(11));
@@ -462,7 +462,7 @@ alias MinstdRand0 = LinearCongruentialEngine!(uint, 16_807, 0, 2_147_483_647);
 alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // seed with a constant
     auto rnd0 = MinstdRand0(1);
@@ -472,7 +472,7 @@ alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
     n = rnd0.front; // different across runs
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     static assert(isForwardRange!MinstdRand);
@@ -537,7 +537,7 @@ alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto rnd0 = MinstdRand0(MinstdRand0.modulus);
     auto n = rnd0.front;
@@ -852,7 +852,7 @@ alias Mt19937 = MersenneTwisterEngine!(uint, 32, 624, 397, 31,
                                        0xefc60000, 18, 1_812_433_253);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // seed with a constant
     Mt19937 gen;
@@ -862,7 +862,7 @@ alias Mt19937 = MersenneTwisterEngine!(uint, 32, 624, 397, 31,
     n = gen.front; // different across runs
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.algorithm;
     import std.range;
@@ -893,7 +893,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
                                           0xfff7eee000000000, 43, 6_364_136_223_846_793_005);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Seed with a constant
     auto gen = Mt19937_64(12345);
@@ -903,7 +903,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     n = gen.front; // different across runs
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.algorithm;
     import std.range;
@@ -928,7 +928,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     assert(gen.front == 15956361063660440239uL);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.exception;
@@ -943,7 +943,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     gen.seed(map!((a) => unpredictableSeed)(repeat(0)));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     uint a, b;
     {
@@ -959,7 +959,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     assert(a != b);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     // Check .save works
@@ -974,7 +974,7 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     }}
 }
 
-@safe pure nothrow unittest //11690
+version(StdUnittest) @safe pure nothrow unittest //11690
 {
     alias MT(UIntType, uint w) = MersenneTwisterEngine!(UIntType, w, 624, 397, 31,
                                                         0x9908b0df, 11, 0xffffffff, 7,
@@ -1187,7 +1187,7 @@ if (isUnsigned!UIntType)
     }
 
 
-    @safe pure nothrow unittest
+    version(StdUnittest) @safe pure nothrow unittest
     {
         static if (size  ==  4)  // Other bits too
         {
@@ -1214,7 +1214,7 @@ alias Xorshift192 = XorshiftEngine!(uint, 192, 2,  1,  4);  /// ditto
 alias Xorshift    = Xorshift128;                            /// ditto
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Seed with a constant
     auto rnd = Xorshift(1);
@@ -1225,7 +1225,7 @@ alias Xorshift    = Xorshift128;                            /// ditto
     num = rnd.front; // different across rnd
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range;
     static assert(isForwardRange!Xorshift);
@@ -1281,7 +1281,7 @@ alias Xorshift    = Xorshift128;                            /// ditto
  * object is compatible with all the pseudo-random number generators
  * available.  It is enabled only in unittest mode.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     foreach (Rng; PseudoRngTypes)
     {
@@ -1315,7 +1315,7 @@ A single unsigned integer seed value, different on each successive call
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto rnd = Random(unpredictableSeed);
     auto n = rnd.front;
@@ -1332,7 +1332,7 @@ method being used.
 
 alias Random = Mt19937;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isUniformRNG!Random);
     static assert(isUniformRNG!(Random, uint));
@@ -1393,7 +1393,7 @@ if (!is(CommonType!(T1, T2) == void))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto gen = Random(unpredictableSeed);
     // Generate an integer in [0, 1023]
@@ -1403,7 +1403,7 @@ if (!is(CommonType!(T1, T2) == void))
 }
 
 /// Create an array of random numbers using range functions and UFCS
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : array;
     import std.range : generate, takeExactly;
@@ -1413,7 +1413,7 @@ if (!is(CommonType!(T1, T2) == void))
     assert(arr[0] >= 0 && arr[0] < 100);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     MinstdRand0 gen;
     foreach (i; 0 .. 20)
@@ -1605,7 +1605,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
     return cast(ResultType)(lower + offset);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     auto gen = Mt19937(unpredictableSeed);
@@ -1789,7 +1789,7 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
     return uniform!T(rndGen);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong))
@@ -1837,13 +1837,13 @@ if (is(E == enum))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Fruit { apple, mango, pear }
     auto randFruit = uniform!Fruit();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Fruit { Apple = 12, Mango = 29, Pear = 72 }
     foreach (_; 0 .. 100)
@@ -1936,7 +1936,7 @@ do
     assert(false);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta;
     static foreach (UniformRNG; PseudoRngTypes)
@@ -1989,7 +1989,7 @@ if (isFloatingPoint!F)
     return useThis;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.math;
@@ -2034,7 +2034,7 @@ auto ref choice(Range)(auto ref Range range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -2055,7 +2055,7 @@ auto ref choice(Range)(auto ref Range range)
            "Choice did not return a valid element from the given Range");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
 
@@ -2081,7 +2081,7 @@ auto ref choice(Range)(auto ref Range range)
            "Choice did not return a valid element from the given Range");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.searching : canFind;
@@ -2119,7 +2119,7 @@ if (isRandomAccessRange!Range)
     return randomShuffle(r, rndGen);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : sort;
     foreach (RandomGen; PseudoRngTypes)
@@ -2174,7 +2174,7 @@ if (isRandomAccessRange!Range)
     return partialShuffle(r, n, rndGen);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     foreach (RandomGen; PseudoRngTypes)
@@ -2260,7 +2260,7 @@ if (isNumeric!Num)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto x = dice(0.5, 0.5);   // x is 0 or 1 in equal proportions
     auto y = dice(50, 50);     // y is 0 or 1 in equal proportions
@@ -2296,7 +2296,7 @@ do
     assert(false);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto rnd = Random(unpredictableSeed);
     auto i = dice(rnd, 0.0, 100.0);
@@ -2489,7 +2489,7 @@ if (isRandomAccessRange!Range)
     return RandomCover!(Range, void)(r);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.conv;
@@ -2527,7 +2527,7 @@ if (isRandomAccessRange!Range)
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 12589
     int[] r = [];
@@ -3043,7 +3043,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
     return RandomSample!(Range, UniformRNG)(r, n, r.length, rng);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system because it takes the address of a local
     import std.conv : text;

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -127,7 +127,7 @@ interface InputRange(E) {
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.range : iota;
@@ -213,7 +213,7 @@ interface InputAssignable(E) : InputRange!E {
     alias front = InputRange!E.front; // overload base interface method
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isInputRange!(InputAssignable!int));
 }
@@ -249,7 +249,7 @@ interface OutputRange(E) {
     void put(E);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 6973
     static assert(isOutputRange!(OutputRange!int, int));
@@ -509,7 +509,7 @@ template outputRangeObject(E...) {
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
      import std.array;
      auto app = appender!(uint[])();
@@ -518,7 +518,7 @@ template outputRangeObject(E...) {
      static assert(is(typeof(appWrapped) : OutputRange!(uint)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.array;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -363,7 +363,7 @@ if (isBidirectionalRange!(Unqual!Range))
 
 
 ///
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
     int[5] a = [ 1, 2, 3, 4, 5 ];
@@ -373,7 +373,7 @@ pure @safe nothrow @nogc unittest
     assert(retro(retro(a[])) is a[]);
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     static assert(isBidirectionalRange!(typeof(retro("hello"))));
@@ -400,7 +400,7 @@ pure @safe nothrow unittest
     assert(equal(r, [3, 2, 1]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.internal.test.dummyrange : AllDummyRanges, propagatesRangeType,
         ReturnBy;
@@ -461,7 +461,7 @@ pure @safe nothrow unittest
     }
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
     auto LL = iota(1L, 4L);
@@ -471,7 +471,7 @@ pure @safe nothrow @nogc unittest
 }
 
 // Issue 12662
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     int[3] src = [1,2,3];
     int[] data = src[];
@@ -686,7 +686,7 @@ do
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -695,7 +695,7 @@ pure @safe nothrow unittest
     assert(stride(stride(a, 2), 3) == stride(a, 6));
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -704,7 +704,7 @@ pure @safe nothrow @nogc unittest
     assert(equal(testArr[].stride(2), result));
 }
 
-debug pure nothrow @system unittest
+version(StdUnittest) debug pure nothrow @system unittest
 {//check the contract
     int[4] testArr = [1,2,3,4];
     bool passed = false;
@@ -722,7 +722,7 @@ debug pure nothrow @system unittest
     }
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, propagatesRangeType,
@@ -858,7 +858,7 @@ pure @safe nothrow unittest
     }
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1205,7 +1205,7 @@ if (Ranges.length > 0 &&
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1222,7 +1222,7 @@ pure @safe nothrow unittest
  * Range primitives are carried over to the returned range if
  * all of the ranges provide them
  */
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.sorting : sort;
@@ -1240,7 +1240,7 @@ pure @safe nothrow unittest
     assert(arr3.equal([7, 8, 9]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, dummyLength,
@@ -1339,7 +1339,7 @@ pure @safe nothrow unittest
     }
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     class Foo{}
     immutable(Foo)[] a;
@@ -1538,7 +1538,7 @@ private struct ChooseResult(R1, R2)
 }
 
 ///
-@safe nothrow pure @nogc unittest
+version(StdUnittest) @safe nothrow pure @nogc unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -1594,7 +1594,7 @@ if (Ranges.length >= 2
 }
 
 ///
-@safe nothrow pure @nogc unittest
+version(StdUnittest) @safe nothrow pure @nogc unittest
 {
     auto test()
     {
@@ -1670,7 +1670,7 @@ if (Ranges.length >= 2
     static b = test();
 }
 
-@safe nothrow pure @nogc unittest
+version(StdUnittest) @safe nothrow pure @nogc unittest
 {
     int[3] a = [1, 2, 3];
     long[3] b = [4, 5, 6];
@@ -1679,7 +1679,7 @@ if (Ranges.length >= 2
     assert(c[0] == 42);
 }
 
-@safe nothrow pure @nogc unittest
+version(StdUnittest) @safe nothrow pure @nogc unittest
 {
     static struct RefAccessRange
     {
@@ -1816,7 +1816,7 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1830,7 +1830,7 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
  * roundRobin can be used to create "interleave" functionality which inserts
  * an element between each element in a range.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -1882,7 +1882,7 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R) && hasSlicing!(Unqual
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [ 1, 2, 3, 4, 5 ];
@@ -1900,7 +1900,7 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R) && hasSlicing!(Unqual
     assert(equal(radial(a, 4), [ 4, 5, 3, 2, 1, 0 ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -1942,7 +1942,7 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R) && hasSlicing!(Unqual
     // static assert(is(typeof(radial(immi))));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2190,7 +2190,7 @@ if (isInputRange!(Unqual!R) &&
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2206,7 +2206,7 @@ pure @safe nothrow unittest
  * range (unlike $(LREF takeExactly), which will cause an assertion failure if
  * the range ends prematurely):
  */
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2216,7 +2216,7 @@ pure @safe nothrow unittest
     assert(equal(t, [ 1, 2, 3 ]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -2282,7 +2282,7 @@ pure @safe nothrow unittest
     static assert(is(Take!(typeof(myRepeat))));
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     //check for correct slicing of Take on an infinite range
     import std.algorithm.comparison : equal;
@@ -2292,7 +2292,7 @@ pure @safe nothrow @nogc unittest
                 .equal(iota(start, stop)));
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     // Check that one can declare variables of all Take types,
     // and that they match the return type of the corresponding
@@ -2312,7 +2312,7 @@ pure @safe nothrow @nogc unittest
     assert(t3.empty);
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     alias R1 = typeof(repeat(1));
     alias R2 = typeof(cycle([1]));
@@ -2322,7 +2322,7 @@ pure @safe nothrow @nogc unittest
     static assert(isBidirectionalRange!TR2);
 }
 
-pure @safe nothrow @nogc unittest //12731
+version(StdUnittest) pure @safe nothrow @nogc unittest //12731
 {
     auto a = repeat(1);
     auto s = a[1 .. 5];
@@ -2332,7 +2332,7 @@ pure @safe nothrow @nogc unittest //12731
     assert(s[1] == 1);
 }
 
-pure @safe nothrow @nogc unittest //13151
+version(StdUnittest) pure @safe nothrow @nogc unittest //13151
 {
     import std.algorithm.comparison : equal;
 
@@ -2432,7 +2432,7 @@ if (isInputRange!R)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2446,7 +2446,7 @@ pure @safe nothrow unittest
     assert(b.back == 3);
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -2469,7 +2469,7 @@ pure @safe nothrow unittest
     assert(equal(takeExactly(e, 3), [3, 4, 5]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -2531,7 +2531,7 @@ pure @safe nothrow unittest
     }
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : DummyRange, Length, RangeType, ReturnBy;
@@ -2545,7 +2545,7 @@ pure @safe nothrow unittest
 
 // https://issues.dlang.org/show_bug.cgi?id=18092
 // can't combine take and takeExactly
-unittest
+version(StdUnittest) unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -2635,7 +2635,7 @@ if (isInputRange!R)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     auto s = takeOne([42, 43, 44]);
     static assert(isRandomAccessRange!(typeof(s)));
@@ -2651,7 +2651,7 @@ pure @safe nothrow unittest
     assert(s.empty);
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     struct NonForwardRange
     {
@@ -2667,7 +2667,7 @@ pure @safe nothrow @nogc unittest
 }
 
 //guards against issue 16999
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     auto myIota = new class
     {
@@ -2697,14 +2697,14 @@ if (isInputRange!R)
 }
 
 ///
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     auto range = takeNone!(int[])();
     assert(range.length == 0);
     assert(range.empty);
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     enum ctfe = takeNone!(int[])();
     static assert(ctfe.length == 0);
@@ -2743,7 +2743,7 @@ if (isInputRange!R)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.iteration : filter;
     assert(takeNone([42, 27, 19]).empty);
@@ -2751,7 +2751,7 @@ pure @safe nothrow unittest
     assert(takeNone(filter!"true"([42, 27, 19])).empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.meta : AliasSeq;
@@ -2928,7 +2928,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     // tail -c n
     assert([1, 2, 3].tail(1) == [3]);
@@ -2951,7 +2951,7 @@ pure @safe nothrow unittest
 }
 
 // @nogc prevented by @@@BUG@@@ 15408
-pure nothrow @safe /+@nogc+/ unittest
+version(StdUnittest) pure nothrow @safe /+@nogc+/ unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, DummyRange, Length,
@@ -2981,7 +2981,7 @@ pure nothrow @safe /+@nogc+/ unittest
         RangeType.Input).init.tail(5)));
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     static immutable input = [1, 2, 3];
     static immutable expectedOutput = [2, 3];
@@ -3027,7 +3027,7 @@ if (isBidirectionalRange!R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3037,7 +3037,7 @@ if (isBidirectionalRange!R)
     assert("hello world".take(6).drop(3).equal("lo "));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3047,7 +3047,7 @@ if (isBidirectionalRange!R)
     assert("hello world".drop(4).dropBack(4).equal("o w"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container.dlist : DList;
@@ -3058,7 +3058,7 @@ if (isBidirectionalRange!R)
     assert(a[].equal(a[].take(2)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -3067,7 +3067,7 @@ if (isBidirectionalRange!R)
     assert(equal(drop(filter!"true"([0, 2, 1, 5, 0, 3]), 3), [5, 0, 3]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.container.dlist : DList;
@@ -3117,7 +3117,7 @@ if (isBidirectionalRange!R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filterBidirectional;
@@ -3160,7 +3160,7 @@ if (isBidirectionalRange!R)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filterBidirectional;
@@ -3255,14 +3255,14 @@ public:
 Repeat!T repeat(T)(T value) { return Repeat!T(value); }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
     assert(equal(5.repeat().take(4), [ 5, 5, 5, 5 ]));
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3293,14 +3293,14 @@ Take!(Repeat!T) repeat(T)(T value, size_t n)
 }
 
 ///
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
 
     assert(equal(5.repeat(4), 5.repeat().take(4)));
 }
 
-pure @safe nothrow unittest //12007
+version(StdUnittest) pure @safe nothrow unittest //12007
 {
     static class C{}
     Repeat!(immutable int) ri;
@@ -3356,7 +3356,7 @@ if (isCallable!fun)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -3367,7 +3367,7 @@ if (isCallable!fun)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3382,7 +3382,7 @@ if (isCallable!fun)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
     import std.random : uniform;
@@ -3439,7 +3439,7 @@ public:
     }
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3451,7 +3451,7 @@ public:
     assert(equal(generate!StaticOpCall().take(10), repeat(5).take(10)));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3465,7 +3465,7 @@ public:
 }
 
 // verify ref mechanism works
-@system nothrow unittest
+version(StdUnittest) @system nothrow unittest
 {
     int[10] arr;
     int idx;
@@ -3485,7 +3485,7 @@ public:
 }
 
 // assure front isn't the mechanism to make generate go to the next element.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int i;
     auto g = generate!(() => ++i);
@@ -3778,7 +3778,7 @@ if (isInputRange!R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : cycle, take;
@@ -3805,7 +3805,7 @@ if (isStaticArray!R)
     return Cycle!R(input, index);
 }
 
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -3867,7 +3867,7 @@ if (isStaticArray!R)
     }
 }
 
-@system nothrow unittest // For static arrays.
+version(StdUnittest) @system nothrow unittest // For static arrays.
 {
     import std.algorithm.comparison : equal;
 
@@ -3885,7 +3885,7 @@ if (isStaticArray!R)
     static assert(is(typeof(cConst[1 .. $]) == const(C)));
 }
 
-@safe nothrow unittest // For infinite ranges
+version(StdUnittest) @safe nothrow unittest // For infinite ranges
 {
     struct InfRange
     {
@@ -3909,7 +3909,7 @@ if (isStaticArray!R)
     static assert(is(typeof(j.cycle) == typeof(j)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3929,7 +3929,7 @@ if (isStaticArray!R)
     }
 }
 
-@system @nogc nothrow unittest
+version(StdUnittest) @system @nogc nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3949,7 +3949,7 @@ if (isStaticArray!R)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -3960,7 +3960,7 @@ if (isStaticArray!R)
     assert(cleS.front == 0);
 }
 
-@system unittest //10845
+version(StdUnittest) @system unittest //10845
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -3969,13 +3969,13 @@ if (isStaticArray!R)
     assert(equal(cycle(a).take(10), [0, 1, 2, 0, 1, 2, 0, 1, 2, 0]));
 }
 
-@safe unittest // 12177
+version(StdUnittest) @safe unittest // 12177
 {
     static assert(__traits(compiles, recurrence!q{a[n - 1] ~ a[n - 2]}("1", "0")));
 }
 
 // Issue 13390
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -4362,7 +4362,7 @@ if (Ranges.length && allSatisfy!(isInputRange, Ranges))
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -4374,7 +4374,7 @@ pure @safe unittest
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.conv : to;
 
@@ -4400,7 +4400,7 @@ pure @safe unittest
 }
 
 /// $(D zip) is powerful - the following code sorts two arrays in parallel:
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.sorting : sort;
 
@@ -4434,7 +4434,7 @@ enum StoppingPolicy
     requireSameLength,
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -4556,7 +4556,7 @@ pure @system unittest
     +/
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.sorting : sort;
 
@@ -4570,7 +4570,7 @@ pure @safe unittest
     assert(b == [6, 5, 2, 1, 3]);
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -4586,7 +4586,7 @@ pure @safe unittest
 }
 
 // Text for Issue 11196
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
 
@@ -4596,7 +4596,7 @@ pure @safe unittest
     assertThrown(zip(StoppingPolicy.longest, cast(S[]) null, new int[1]).front);
 }
 
-@safe pure unittest //12007
+version(StdUnittest) @safe pure unittest //12007
 {
     static struct R
     {
@@ -4611,7 +4611,7 @@ pure @safe unittest
     assert(z.save == z);
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     import std.typecons : tuple;
 
@@ -4838,7 +4838,7 @@ if (allSatisfy!(isInputRange, Ranges))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
    auto arr1 = [1,2,3,4,5,100];
    auto arr2 = [6,7,8,9,10];
@@ -4858,7 +4858,7 @@ if (allSatisfy!(isInputRange, Ranges))
    }
 }
 
-@system unittest // Bugzilla 15860: foreach_reverse on lockstep
+version(StdUnittest) @system unittest // Bugzilla 15860: foreach_reverse on lockstep
 {
     auto arr1 = [0, 1, 2, 3];
     auto arr2 = [4, 5, 6, 7];
@@ -4882,7 +4882,7 @@ if (allSatisfy!(isInputRange, Ranges))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : filter;
     import std.conv : to;
@@ -4978,7 +4978,7 @@ if (allSatisfy!(isInputRange, Ranges))
     foreach (x, y; lockstep(iota(0, 10), iota(0, 10))) { }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct RvalueRange
     {
@@ -5075,7 +5075,7 @@ struct Recurrence(alias fun, StateType, size_t stateSize)
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5111,7 +5111,7 @@ recurrence(alias fun, State...)(State initial)
     return typeof(return)(state);
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5212,7 +5212,7 @@ auto sequence(alias fun, State...)(State args)
 }
 
 /// Odd numbers, using function in string form:
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     auto odds = sequence!("a[0] + n * a[1]")(1, 2);
     assert(odds.front == 1);
@@ -5223,7 +5223,7 @@ pure @safe nothrow @nogc unittest
 }
 
 /// Triangular numbers, using function in lambda form:
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     auto tri = sequence!((a,n) => n*(n+1)/2)();
 
@@ -5236,7 +5236,7 @@ pure @safe nothrow @nogc unittest
 }
 
 /// Fibonacci numbers, using function in explicit form:
-@safe nothrow @nogc unittest
+version(StdUnittest) @safe nothrow @nogc unittest
 {
     import std.math : pow, round, sqrt;
     static ulong computeFib(S)(S state, size_t n)
@@ -5258,7 +5258,7 @@ pure @safe nothrow @nogc unittest
     assert(fib[9] == 55);
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.typecons : Tuple, tuple;
     auto y = Sequence!("a[0] + n * a[1]", Tuple!(int, int))(tuple(0, 4));
@@ -5279,7 +5279,7 @@ pure @safe nothrow @nogc unittest
     }
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -5304,7 +5304,7 @@ pure @safe nothrow @nogc unittest
 }
 
 // Issue 5036
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     auto s = sequence!((a, n) => new int)(0);
     assert(s.front != s.front);  // no caching
@@ -5648,7 +5648,7 @@ do
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.math : approxEqual;
@@ -5668,7 +5668,7 @@ pure @safe unittest
     assert(approxEqual(rf, [0.0, 0.1, 0.2, 0.3, 0.4]));
 }
 
-pure nothrow @nogc @safe unittest
+version(StdUnittest) pure nothrow @nogc @safe unittest
 {
    //float overloads use std.conv.to so can't be @nogc or nothrow
     alias ssize_t = Signed!size_t;
@@ -5679,7 +5679,7 @@ pure nothrow @nogc @safe unittest
     assert(iota(ssize_t.max, ssize_t.min, -3).length == size_t.max / 3);
 }
 
-debug @system unittest
+version(StdUnittest) debug @system unittest
 {//check the contracts
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -5689,7 +5689,7 @@ debug @system unittest
     assertThrown!AssertError(iota(0f,1f,-0.1f));
 }
 
-pure @system nothrow unittest
+version(StdUnittest) pure @system nothrow unittest
 {
     int[] a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     auto r1 = iota(a.ptr, a.ptr + a.length, 1);
@@ -5698,7 +5698,7 @@ pure @system nothrow unittest
     assert(&a[4] in r1);
 }
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     assert(iota(1UL, 0UL).length == 0);
     assert(iota(1UL, 0UL, 1).length == 0);
@@ -5708,7 +5708,7 @@ pure @safe nothrow @nogc unittest
     assert(iota(ulong.max, 0).length == 0);
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.searching : count;
@@ -5854,14 +5854,14 @@ pure @safe unittest
     }}
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.mutation : copy;
     auto idx = new size_t[100];
     copy(iota(0, idx.length), idx);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (range; AliasSeq!(iota(2, 27, 4),
@@ -5880,7 +5880,7 @@ pure @safe nothrow unittest
     }}
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //The ptr stuff can't be done at compile time, so we unfortunately end
     //up with some code duplication here.
@@ -5909,7 +5909,7 @@ pure @safe nothrow unittest
     }
 }
 
-@nogc nothrow pure @safe unittest
+version(StdUnittest) @nogc nothrow pure @safe unittest
 {
     {
         ushort start = 0, end = 10, step = 2;
@@ -5966,7 +5966,7 @@ if (!isIntegral!(CommonType!(B, E)) &&
     return Result(begin, end);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -6247,7 +6247,7 @@ FrontTransversal!(RangeOfRanges, opt) frontTransversal(
 }
 
 ///
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
     int[][] x = new int[][2];
@@ -6257,7 +6257,7 @@ pure @safe nothrow unittest
     assert(equal(ror, [ 1, 3 ][]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, DummyRange, ReturnBy;
@@ -6325,7 +6325,7 @@ pure @safe nothrow unittest
 }
 
 // Issue 16363
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -6337,7 +6337,7 @@ pure @safe nothrow unittest
 }
 
 // Bugzilla 16442
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     int[][] arr = [[], []];
 
@@ -6346,7 +6346,7 @@ pure @safe nothrow unittest
 }
 
 // ditto
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     int[][] arr = [[], []];
 
@@ -6586,7 +6586,7 @@ Transversal!(RangeOfRanges, opt) transversal
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     int[][] x = new int[][2];
@@ -6597,7 +6597,7 @@ Transversal!(RangeOfRanges, opt) transversal
 }
 
 /// The following code does a full unzip
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -6606,7 +6606,7 @@ Transversal!(RangeOfRanges, opt) transversal
     assert(equal!equal(z, [[1, 4], [2, 5], [3, 6]]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.internal.test.dummyrange : DummyRange, Length, RangeType, ReturnBy;
 
@@ -6732,7 +6732,7 @@ private:
     RangeOfRanges _input;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Boundary case: transpose of empty range should be empty
     int[][] ror = [];
@@ -6740,7 +6740,7 @@ private:
 }
 
 // Issue 9507
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -6752,7 +6752,7 @@ private:
 }
 
 // Issue 17742
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.comparison : equal;
@@ -6805,7 +6805,7 @@ if (isForwardRange!RangeOfRanges &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     int[][] ror = [
@@ -6821,7 +6821,7 @@ if (isForwardRange!RangeOfRanges &&
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][] x = new int[][2];
     x[0] = [1, 2];
@@ -6837,7 +6837,7 @@ if (isForwardRange!RangeOfRanges &&
 }
 
 // Issue 8764
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     ulong[1] t0 = [ 123 ];
@@ -7047,7 +7047,7 @@ if (isRandomAccessRange!Source && isInputRange!Indices &&
         }
 
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             auto ind = indexed([1, 2, 3, 4, 5], [1, 3, 4]);
             assert(ind.physicalIndex(0) == 1);
@@ -7067,7 +7067,7 @@ Indexed!(Source, Indices) indexed(Source, Indices)(Source source, Indices indice
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto source = [1, 2, 3, 4, 5];
@@ -7077,7 +7077,7 @@ Indexed!(Source, Indices) indexed(Source, Indices)(Source source, Indices indice
     assert(equal(retro(ind), [5, 1, 3, 2, 4, 5]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     {
         auto ind = indexed([1, 2, 3, 4, 5], [1, 3, 4]);
@@ -7095,7 +7095,7 @@ Indexed!(Source, Indices) indexed(Source, Indices)(Source source, Indices indice
     assert(ind[5] == 6);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.internal.test.dummyrange : AllDummyRanges, propagatesLength,
         propagatesRangeType, RangeType;
@@ -7388,7 +7388,7 @@ if (isInputRange!Source)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -7403,7 +7403,7 @@ if (isInputRange!Source)
 }
 
 /// Non-forward input ranges are supported, but with limited semantics.
-@system /*@safe*/ unittest // FIXME: can't be @safe because RefCounted isn't.
+version(StdUnittest) @system /*@safe*/ unittest // FIXME: can't be @safe because RefCounted isn't.
 {
     import std.algorithm.comparison : equal;
 
@@ -7421,7 +7421,7 @@ if (isInputRange!Source)
     assert(chunked.front.equal([3, 4]));
 }
 
-@system /*@safe*/ unittest
+version(StdUnittest) @system /*@safe*/ unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : ReferenceInputRange;
@@ -7451,7 +7451,7 @@ if (isInputRange!Source)
     assert(r3.front.equal([5]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     auto chunks = chunks(source, 4);
@@ -7466,7 +7466,7 @@ if (isInputRange!Source)
     static assert(isRandomAccessRange!(typeof(chunks)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7501,7 +7501,7 @@ if (isInputRange!Source)
     assert(chunks1[$ / 2 .. $ - 1].equal([[2, 2], [3, 3]])); //Slow
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -7674,7 +7674,7 @@ if (isForwardRange!Source && hasLength!Source)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -7684,7 +7684,7 @@ if (isForwardRange!Source && hasLength!Source)
     assert(chunks[2] == [8, 9, 10]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7706,7 +7706,7 @@ if (isForwardRange!Source && hasLength!Source)
     static assert(isRandomAccessRange!(typeof(chunks)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7753,7 +7753,7 @@ auto slide(Flag!"withPartial" f = Yes.withPartial,
 }
 
 /// Iterate over ranges with windows
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7767,7 +7767,7 @@ auto slide(Flag!"withPartial" f = Yes.withPartial,
 }
 
 /// set a custom stepsize (default 1)
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7789,7 +7789,7 @@ auto slide(Flag!"withPartial" f = Yes.withPartial,
 }
 
 /// Allow the last slide to have fewer elements than windowSize
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7800,7 +7800,7 @@ auto slide(Flag!"withPartial" f = Yes.withPartial,
 }
 
 /// Count all the possible substrings of length 2
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.iteration : each;
 
@@ -8337,7 +8337,7 @@ public:
 }
 
 // test @nogc
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -8349,7 +8349,7 @@ public:
 }
 
 // test different window sizes
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.array : array;
     import std.algorithm.comparison : equal;
@@ -8371,7 +8371,7 @@ public:
 }
 
 // test combinations
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -8414,7 +8414,7 @@ public:
 }
 
 // test emptiness and copyability
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -8433,7 +8433,7 @@ public:
 }
 
 // test with strings
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.iteration : each;
 
@@ -8450,7 +8450,7 @@ public:
 }
 
 // test with utf8 strings
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.stdio;
     import std.algorithm.comparison : equal;
@@ -8465,7 +8465,7 @@ public:
 }
 
 // test length
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     // Slides with fewer elements are empty or 1 for Yes.withPartial
     static foreach (expectedLength, Partial; [No.withPartial, Yes.withPartial])
@@ -8498,7 +8498,7 @@ public:
 }
 
 // test index and slicing
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.array : array;
@@ -8540,7 +8540,7 @@ public:
 }
 
 // test with infinite ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -8571,7 +8571,7 @@ public:
 }
 
 // test reverse
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -8592,7 +8592,7 @@ public:
 }
 
 // test with dummy ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -8629,7 +8629,7 @@ public:
 }
 
 // test with dummy ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -8678,7 +8678,7 @@ public:
 }
 
 // test reverse with dummy ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -8721,7 +8721,7 @@ public:
 }
 
 // test different sliceable ranges
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges;
@@ -9041,7 +9041,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, joiner, map;
@@ -9061,7 +9061,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
         .equal("T.D.P.L"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Verify that the same common type and same arity
     // results in the same template instantiation
@@ -9073,7 +9073,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
 }
 
 // Tests the zero-element result
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -9095,7 +9095,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
 }
 
 // Tests the single-element result
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -9144,7 +9144,7 @@ if (!is(CommonType!Values == void) || Values.length == 0)
 }
 
 // Tests multiple-element results
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : joiner;
@@ -9416,7 +9416,7 @@ do
 }
 
 /// Can start enumeration from a negative position:
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.array : assocArray;
     import std.range : enumerate;
@@ -9427,7 +9427,7 @@ pure @safe nothrow unittest
     assert(aa[1]);
 }
 
-pure @safe nothrow unittest
+version(StdUnittest) pure @safe nothrow unittest
 {
     import std.internal.test.dummyrange : AllDummyRanges;
     import std.meta : AliasSeq;
@@ -9534,7 +9534,7 @@ pure @safe nothrow unittest
     }}
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.meta : AliasSeq;
@@ -9558,7 +9558,7 @@ pure @safe unittest
 version(none) // @@@BUG@@@ 10939
 {
     // Re-enable (or remove) if 10939 is resolved.
-    /+pure+/ @safe unittest // Impure because of std.conv.to
+    version(StdUnittest) /+pure+/ @safe unittest // Impure because of std.conv.to
     {
         import core.exception : RangeError;
         import std.exception : assertNotThrown, assertThrown;
@@ -9932,7 +9932,7 @@ if (isInputRange!Range)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = assumeSorted([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
@@ -9974,7 +9974,7 @@ policies are allowed, and $(D SearchPolicy.binarySearch) is the default.
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = assumeSorted([ 1, 2, 3, 3, 3, 4, 4, 5, 6 ]);
@@ -10036,7 +10036,7 @@ policies are allowed, and $(D SearchPolicy.binarySearch) is the default.
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
@@ -10096,7 +10096,7 @@ equalRange). Completes the entire search in $(BIGOH log(n)) time.
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         auto a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
@@ -10144,7 +10144,7 @@ sorting relation.
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : sort;
     auto a = [ 1, 2, 3, 42, 52, 64 ];
@@ -10166,7 +10166,7 @@ No copy of the original range is ever made. If the underlying range is
 changed concurrently with its corresponding $(D SortedRange) in ways
 that break its sorted-ness, $(D SortedRange) will work erratically.
 */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.mutation : swap;
     auto a = [ 1, 2, 3, 42, 52, 64 ];
@@ -10176,7 +10176,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     assert(!r.contains(42));  // passes although it shouldn't
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -10192,7 +10192,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     assert(equal(r[2], [ 40, 40, 50, 60 ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto a = [ "A", "AG", "B", "E", "F" ];
@@ -10206,7 +10206,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     assert(equal(r[2], [ "AG", "B", "E", "F" ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     static void test(SearchPolicy pol)()
@@ -10241,7 +10241,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     test!(SearchPolicy.binarySearch)();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Check for small arrays
     int[] a;
@@ -10254,7 +10254,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     r = assumeSorted(a);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.mutation : swap;
     auto a = [ 1, 2, 3, 42, 52, 64 ];
@@ -10264,13 +10264,13 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
     assert(!r.contains(42));            // passes although it shouldn't
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     immutable(int)[] arr = [ 1, 2, 3 ];
     auto s = assumeSorted(arr);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     int[] arr = [100, 101, 102, 200, 201, 300];
@@ -10279,7 +10279,7 @@ that break its sorted-ness, $(D SortedRange) will work erratically.
 }
 
 // Test on an input range
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     import std.file : exists, remove, tempDir;
@@ -10319,7 +10319,7 @@ if (isInputRange!(Unqual!R))
     return SortedRange!(Unqual!R, pred)(r);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     static assert(isRandomAccessRange!(SortedRange!(int[])));
@@ -10334,7 +10334,7 @@ if (isInputRange!(Unqual!R))
     assert(equal(p, [ 0, 1, 2, 3, 4, 5, 6]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     int[] a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
@@ -10344,7 +10344,7 @@ if (isInputRange!(Unqual!R))
     assert(equal(p, [ 5, 6 ]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -10364,7 +10364,7 @@ if (isInputRange!(Unqual!R))
     assert(equal(p, [ 3, 3, 3]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 3, 3, 4, 4, 5, 6 ];
     if (a.length)
@@ -10375,7 +10375,7 @@ if (isInputRange!(Unqual!R))
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 5, 7, 34, 345, 677 ];
     auto r = assumeSorted(a);
@@ -10385,7 +10385,7 @@ if (isInputRange!(Unqual!R))
     r = assumeSorted(a);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     bool ok = true;
     try
@@ -10400,7 +10400,7 @@ if (isInputRange!(Unqual!R))
 }
 
 // issue 15003
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     static immutable a = [1, 2, 3, 4];
     auto r = a.assumeSorted;
@@ -10774,7 +10774,7 @@ private:
 }
 
 /// Basic Example
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : find;
     ubyte[] buffer = [1, 9, 45, 12, 22];
@@ -10801,7 +10801,7 @@ private:
 }
 
 /// opAssign Example.
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] buffer1 = [1, 2, 3, 4, 5];
     ubyte[] buffer2 = [6, 7, 8, 9, 10];
@@ -10846,7 +10846,7 @@ private:
     assert(buffer2 == [11, 12, 13, 14, 15]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : filter;
     {
@@ -10933,7 +10933,7 @@ private:
 }
 
 //Test assignment.
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] buffer1 = [1, 2, 3, 4, 5];
     ubyte[] buffer2 = [6, 7, 8, 9, 10];
@@ -10960,7 +10960,7 @@ private:
     assert(buffer2 == [6, 7, 8, 9, 10]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.mutation : bringToFront;
@@ -11080,7 +11080,7 @@ private:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -11095,7 +11095,7 @@ private:
     static assert(isInfinite!(typeof(wrapper)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C
     {
@@ -11112,7 +11112,7 @@ private:
     assert(cWrapper is c);
 }
 
-@system unittest // issue 14373
+version(StdUnittest) @system unittest // issue 14373
 {
     static struct R
     {
@@ -11125,7 +11125,7 @@ private:
     assert(r.empty);
 }
 
-@system unittest // issue 14575
+version(StdUnittest) @system unittest // issue 14575
 {
     struct R
     {
@@ -11167,7 +11167,7 @@ if (isInputRange!R)
 
 /*****************************************************************************/
 
-@safe unittest    // bug 9060
+version(StdUnittest) @safe unittest    // bug 9060
 {
     import std.algorithm.iteration : map, joiner, group;
     import std.algorithm.searching : until;
@@ -11475,7 +11475,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.format : format;
@@ -11496,7 +11496,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 }
 
 /// You can use bitwise to implement an uniform bool generator
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.random : rndGen;
@@ -11510,7 +11510,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 }
 
 // Test nogc inference
-@safe @nogc unittest
+version(StdUnittest) @safe @nogc unittest
 {
     static ubyte[] arr = [3, 9];
     auto bw = arr.bitwise;
@@ -11525,7 +11525,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 }
 
 // Test all range types over all integral types
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.internal.test.dummyrange;
 
@@ -11621,7 +11621,7 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 }
 
 // Test opIndex and opSlice
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias IntegralTypes = AliasSeq!(byte, ubyte, short, ushort, int, uint,
             long, ulong);
@@ -11680,7 +11680,7 @@ auto ref nullSink()
 }
 
 ///
-@safe nothrow unittest
+version(StdUnittest) @safe nothrow unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.mutation : copy;
@@ -11688,7 +11688,7 @@ auto ref nullSink()
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.csv : csvNextToken;
 
@@ -11704,7 +11704,7 @@ auto ref nullSink()
     assert(app.data == "b");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = 10.iota
                 .tee(nullSink)
@@ -11837,7 +11837,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -11863,7 +11863,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
 }
 
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -11901,7 +11901,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
 }
 
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter, map;
@@ -11925,7 +11925,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     assert(shiftedCount == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Manually stride to test different pipe behavior.
     void testRange(Range)(Range r)
@@ -11962,7 +11962,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     assert(frontCount == 9);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.meta : AliasSeq;
@@ -12003,7 +12003,7 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Issue 13483
     static void func1(T)(T x) {}
@@ -12052,7 +12052,7 @@ if (
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -12062,7 +12062,7 @@ if (
     assert("abc".padLeft('_', 6).equal("___abc"));
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : DummyRange, Length, RangeType, ReturnBy;
@@ -12092,7 +12092,7 @@ if (
 }
 
 // Test nogc inference
-@safe @nogc pure unittest
+version(StdUnittest) @safe @nogc pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -12248,7 +12248,7 @@ if (
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -12258,7 +12258,7 @@ if (
     assert("abc".padRight('_', 6).equal("abc___"));
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : AllDummyRanges, ReferenceInputRange;
@@ -12306,7 +12306,7 @@ pure @safe unittest
 }
 
 // Test nogc inference
-@safe @nogc pure unittest
+version(StdUnittest) @safe @nogc pure unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -169,7 +169,7 @@ enum bool isInputRange(R) =
     && is(typeof((R r) => r.popFront));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A {}
     struct B
@@ -220,7 +220,7 @@ enum bool isInputRange(R) =
     static assert(!isInputRange!VoidFront);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -286,7 +286,7 @@ private void doPut(R, E)(ref R r, auto ref E e)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!isNativeOutputRange!(int,     int));
     static assert( isNativeOutputRange!(int[],   int));
@@ -411,7 +411,7 @@ void put(R, E)(ref R r, E e)
  * `T`, use the global `put` to handle outputting a `T[]` to the range
  * or vice-versa.
  */
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.traits : isSomeChar;
 
@@ -437,7 +437,7 @@ void put(R, E)(ref R r, E e)
  *
  * Be sure to save the position of the array before calling `put`.
  */
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] a = [1, 2, 3], b = [10, 20];
     auto c = a;
@@ -453,7 +453,7 @@ void put(R, E)(ref R r, E e)
  * so using `put` with `char` arrays is disallowed. In order to fill
  * any `char` type array, use $(REF byCodeUnit, std, utf).
  */
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.utf : byCodeUnit;
 
@@ -465,7 +465,7 @@ void put(R, E)(ref R r, E e)
     assert(s1 == "Hello, World!");
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     static struct R() { void put(in char[]) {} }
     R!() r;
@@ -519,21 +519,21 @@ if (isSomeChar!E)
     }
 }
 
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     auto f = delegate (const(char)[]) {};
     putChar(f, cast(dchar)'a');
 }
 
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static struct R() { void put(in char[]) {} }
     R!() r;
     putChar(r, 'a');
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A {}
     static assert(!isInputRange!(A));
@@ -545,7 +545,7 @@ pure @safe unittest
     put(b, 5);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = new int[10];
     int b;
@@ -553,14 +553,14 @@ pure @safe unittest
     put(a, b);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void myprint(in char[] s) { }
     auto r = &myprint;
     put(r, 'a');
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = new int[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
@@ -576,7 +576,7 @@ pure @safe unittest
     assert(a.length == 6);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] a = new char[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
@@ -586,7 +586,7 @@ pure @safe unittest
     static assert(!__traits(compiles, put(a, "ABC")));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][] a = new int[][10];
     int[]   b = new int[10];
@@ -598,7 +598,7 @@ pure @safe unittest
     static assert(!__traits(compiles, put(a, c)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[][] a = new int[][](3);
     int[]   b = [1];
@@ -613,7 +613,7 @@ pure @safe unittest
     assert(a == [[2], [2], [2]]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test fix for bug 7476.
     struct LockingTextWriter
@@ -632,7 +632,7 @@ pure @safe unittest
     put(w, r);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.meta : AliasSeq;
@@ -695,7 +695,7 @@ pure @safe unittest
     }}
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct CharRange
     {
@@ -712,7 +712,7 @@ pure @safe unittest
     put(c, "hello"d);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // issue 9823
     const(char)[] r;
@@ -721,7 +721,7 @@ pure @safe unittest
     assert(r == "ABC");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // issue 10571
     import std.format;
@@ -730,7 +730,7 @@ pure @safe unittest
     assert(buf == "hello");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format;
     import std.meta : AliasSeq;
@@ -798,7 +798,7 @@ guaranteed to not overflow the range.
 package(std) enum bool isNativeOutputRange(R, E) =
     is(typeof(doPut(lvalueOf!R, lvalueOf!E)));
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] r = new int[](4);
     static assert(isInputRange!(int[]));
@@ -821,7 +821,7 @@ enum bool isOutputRange(R, E) =
     is(typeof(put(lvalueOf!R, lvalueOf!E)));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void myprint(in char[] s) { }
     static assert(isOutputRange!(typeof(&myprint), char));
@@ -831,7 +831,7 @@ enum bool isOutputRange(R, E) =
     static assert( isOutputRange!(dchar[], dchar));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
     import std.stdio : writeln;
@@ -884,14 +884,14 @@ enum bool isForwardRange(R) = isInputRange!R
     && is(ReturnType!((R r) => r.save) == R);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!isForwardRange!(int));
     static assert( isForwardRange!(int[]));
     static assert( isForwardRange!(inout(int)[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // BUG 14544
     struct R14544
@@ -924,7 +924,7 @@ enum bool isBidirectionalRange(R) = isForwardRange!R
     && is(ReturnType!((R r) => r.back) == ElementType!R);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias R = int[];
     R r = [0,1];
@@ -935,7 +935,7 @@ enum bool isBidirectionalRange(R) = isForwardRange!R
     static assert(is(typeof(t) == typeof(w))); // same type for front and back
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A {}
     struct B
@@ -990,7 +990,7 @@ enum bool isRandomAccessRange(R) =
         || is(typeof(lvalueOf!R[$ - 1]) == ElementType!R));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.traits : isNarrowString;
 
@@ -1019,7 +1019,7 @@ enum bool isRandomAccessRange(R) =
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A {}
     struct B
@@ -1071,7 +1071,7 @@ enum bool isRandomAccessRange(R) =
     static assert( isRandomAccessRange!(inout(int)[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test fix for bug 6935.
     struct R
@@ -1128,7 +1128,7 @@ enum bool hasMobileElements(R) =
         || is(typeof(moveAt(lvalueOf!R, 0)) == ElementType!R));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.range : iota, repeat;
@@ -1167,7 +1167,7 @@ template ElementType(R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota;
 
@@ -1187,14 +1187,14 @@ template ElementType(R)
     static assert(is(ElementType!(typeof(range)) == int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ElementType!(byte[]) == byte));
     static assert(is(ElementType!(wchar[]) == dchar)); // rvalue
     static assert(is(ElementType!(wstring) == dchar));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum XYZ : string { a = "foo" }
     auto x = XYZ.a.front;
@@ -1209,7 +1209,7 @@ template ElementType(R)
     static assert(is(ElementType!(inout(int[])) == inout(int)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ElementType!(int[5]) == int));
     static assert(is(ElementType!(int[0]) == int));
@@ -1217,7 +1217,7 @@ template ElementType(R)
     static assert(is(ElementType!(char[0]) == dchar));
 }
 
-@safe unittest //11336
+version(StdUnittest) @safe unittest //11336
 {
     static struct S
     {
@@ -1226,7 +1226,7 @@ template ElementType(R)
     static assert(is(ElementType!(S[]) == S));
 }
 
-@safe unittest // 11401
+version(StdUnittest) @safe unittest // 11401
 {
     // ElementType should also work for non-@propety 'front'
     struct E { ushort id; }
@@ -1253,7 +1253,7 @@ template ElementEncodingType(R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota;
     // internally the range stores the encoded type
@@ -1267,7 +1267,7 @@ template ElementEncodingType(R)
     static assert(is(ElementEncodingType!(typeof(range)) == int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ElementEncodingType!(wchar[]) == wchar));
     static assert(is(ElementEncodingType!(dchar[]) == dchar));
@@ -1276,7 +1276,7 @@ template ElementEncodingType(R)
     static assert(is(ElementEncodingType!(int[])  == int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum XYZ : string { a = "foo" }
     auto x = XYZ.a.front;
@@ -1294,7 +1294,7 @@ template ElementEncodingType(R)
     static assert(is(ElementEncodingType!(inout char[]) : inout(char)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ElementEncodingType!(int[5]) == int));
     static assert(is(ElementEncodingType!(int[0]) == int));
@@ -1327,7 +1327,7 @@ template hasSwappableElements(R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasSwappableElements!(const int[]));
     static assert(!hasSwappableElements!(const(int)[]));
@@ -1361,7 +1361,7 @@ enum bool hasAssignableElements(R) = isInputRange!R
         || is(typeof(lvalueOf!R[0] = lvalueOf!R.front)));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasAssignableElements!(const int[]));
     static assert(!hasAssignableElements!(const(int)[]));
@@ -1395,7 +1395,7 @@ enum bool hasLvalueElements(R) = isInputRange!R
         || is(typeof(((ref x) => x)(lvalueOf!R[0]))));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : iota, chain;
 
@@ -1414,7 +1414,7 @@ enum bool hasLvalueElements(R) = isInputRange!R
     static assert( hasLvalueElements!(typeof(c)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bugfix 6336
     struct S { immutable int value; }
@@ -1448,7 +1448,7 @@ template hasLength(R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasLength!(char[]));
     static assert( hasLength!(int[]));
@@ -1461,7 +1461,7 @@ template hasLength(R)
 }
 
 // test combinations which are invalid on some platforms
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A { ulong length; }
     struct B { @property uint length() { return 0; } }
@@ -1479,7 +1479,7 @@ template hasLength(R)
 }
 
 // test combinations which are invalid on all platforms
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct A { long length; }
     struct B { int length; }
@@ -1515,7 +1515,7 @@ template isInfinite(R)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : Repeat;
     static assert(!isInfinite!(int[]));
@@ -1565,7 +1565,7 @@ enum bool hasSlicing(R) = isForwardRange!R
     }));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : takeExactly;
     static assert( hasSlicing!(int[]));
@@ -1659,7 +1659,7 @@ if (isInputRange!Range)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.range : recurrence, take;
@@ -1774,7 +1774,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 4, 5 ];
     a.popFrontN(2);
@@ -1784,7 +1784,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1795,7 +1795,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int[] a = [ 1, 2, 3, 4, 5 ];
     a.popBackN(2);
@@ -1805,7 +1805,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -1867,7 +1867,7 @@ if (isBidirectionalRange!Range)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filterBidirectional;
@@ -1919,7 +1919,7 @@ ElementType!R moveFront(R)(R r)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [ 1, 2, 3 ];
     assert(moveFront(a) == 1);
@@ -1938,7 +1938,7 @@ ElementType!R moveFront(R)(R r)
     assert(moveFront(r) == 43);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct R
     {
@@ -1977,7 +1977,7 @@ ElementType!R moveBack(R)(R r)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct TestRange
     {
@@ -2023,7 +2023,7 @@ ElementType!R moveAt(R)(R r, size_t i)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = [1,2,3,4];
     foreach (idx, it; a)
@@ -2032,7 +2032,7 @@ ElementType!R moveAt(R)(R r, size_t i)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.internal.test.dummyrange;
 
@@ -2066,7 +2066,7 @@ if (is(typeof(a.length) : size_t) || isNarrowString!T)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     assert(!a.empty);
@@ -2091,7 +2091,7 @@ content of the array, it simply returns its argument.
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     auto b = a.save;
@@ -2114,7 +2114,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     a.popFront();
@@ -2165,7 +2165,7 @@ if (isNarrowString!(C[]))
     else static assert(0, "Bad template constraint.");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.meta : AliasSeq;
 
@@ -2200,7 +2200,7 @@ if (isNarrowString!(C[]))
     static assert(checkCTFEW.empty);
 }
 
-@safe unittest // issue 16090
+version(StdUnittest) @safe unittest // issue 16090
 {
     string s = "\u00E4";
     assert(s.length == 2);
@@ -2210,7 +2210,7 @@ if (isNarrowString!(C[]))
     assert(s.empty);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     wstring s = "\U00010000";
     assert(s.length == 2);
@@ -2235,7 +2235,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [ 1, 2, 3 ];
     a.popBack();
@@ -2258,7 +2258,7 @@ if (isNarrowString!(T[]))
     a = a[0 .. $ - strideBack(a, $)];
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.meta : AliasSeq;
 
@@ -2302,13 +2302,13 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] a = [ 1, 2, 3 ];
     assert(a.front == 1);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto a = [ 1, 2 ];
     a.front = 4;
@@ -2348,7 +2348,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int[] a = [ 1, 2, 3 ];
     assert(a.back == 3);
@@ -2356,7 +2356,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
     assert(a.back == 7);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     immutable b = [ 1, 2, 3 ];
     assert(b.back == 3);

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -175,7 +175,7 @@ module std.regex.internal.generator;
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range, std.regex;
     auto re = regex(`P[a-z]{3,}q`);

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -512,7 +512,7 @@ public:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv, std.regex;
     @trusted void test_fixed(alias Kick)()

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -53,7 +53,7 @@ if (isSomeString!S)
     return makeRegex(Parser!(S, CodeGen)(arg, ""));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto re = makeRegex(`(?P<name>\w+) = (?P<var>\d+)`);

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -10,7 +10,7 @@ import std.conv, std.exception, std.meta, std.range,
 
 import std.uni : Escapables; // characters that need escaping
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {//sanity checks
     regex("(a|b)*");
     regex(`(?:([0-9A-F]+)\.\.([0-9A-F]+)|([0-9A-F]+))\s*;\s*(.*)\s*#`);
@@ -52,7 +52,7 @@ import std.uni : Escapables; // characters that need escaping
 
  */
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct TestVectors
     {

--- a/std/regex/internal/tests2.d
+++ b/std/regex/internal/tests2.d
@@ -9,14 +9,14 @@ import std.conv, std.exception, std.meta, std.range,
 
 import std.uni : Escapables; // characters that need escaping
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cr = ctRegex!("abc");
     assert(bmatch("abc",cr).hit == "abc");
     auto cr2 = ctRegex!("ab*c");
     assert(bmatch("abbbbc",cr2).hit == "abbbbc");
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cr3 = ctRegex!("^abc$");
     assert(bmatch("abc",cr3).hit == "abc");
@@ -24,7 +24,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(array(match("azb",cr4).captures) == ["azb", "azb"]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cr5 = ctRegex!("(?:a{2,4}b{1,3}){1,2}");
     assert(bmatch("aaabaaaabbb", cr5).hit == "aaabaaaabbb");
@@ -32,7 +32,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(bmatch("aaabaaaabbb"w,  cr6).hit == "aaab"w);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cr7 = ctRegex!(`\r.*?$`,"sm");
     assert(bmatch("abc\r\nxy",  cr7).hit == "\r\nxy");
@@ -41,7 +41,7 @@ import std.uni : Escapables; // characters that need escaping
             == "<packet>text</packet>");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto cr8 = ctRegex!("^(a)(b)?(c*)");
@@ -56,7 +56,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(equal(bmatch("xxqababqyy",cr9).captures, ["qababq", "b"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto rtr = regex("a|b|c");
@@ -69,7 +69,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(equal(testCT.ir,testRT.ir));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -100,7 +100,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(equal(map!"a.hit"(m9), ["First", "", "Second"]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -143,7 +143,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 //tests for accumulated std.regex issues and other regressions
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -225,7 +225,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // tests for replace
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void test(alias matchFn)()
     {
@@ -259,7 +259,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // tests for splitter
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,     fg, hi, ";
@@ -279,13 +279,13 @@ import std.uni : Escapables; // characters that need escaping
     assert(equal(sp2, w2));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] s1 = ", abc, de,  fg, hi, ".dup;
     auto sp2 = splitter(s1, regex(", *"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,  fg, hi, ";
@@ -293,7 +293,7 @@ import std.uni : Escapables; // characters that need escaping
     assert(equal(split(s1, regex(", *")), w1[]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 { // bugzilla 7141
     string pattern = `[a\--b]`;
     assert(match("-", pattern));
@@ -301,17 +301,17 @@ import std.uni : Escapables; // characters that need escaping
     string pattern2 = `[&-z]`;
     assert(match("b", pattern2));
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {//bugzilla 7111
     assert(match("", regex("^")));
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {//bugzilla 7300
     assert(!match("a"d, "aa"d));
 }
 
 // bugzilla 7551
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = regex("[]abc]*");
     assert("]ab".matchFirst(r).hit == "]ab");
@@ -320,13 +320,13 @@ import std.uni : Escapables; // characters that need escaping
     assert("]ac".matchFirst(r2).hit == "]");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {//bugzilla 7674
     assert("1234".replace(regex("^"), "$$") == "$1234");
     assert("hello?".replace(regex(r"\?", "g"), r"\?") == r"hello\?");
     assert("hello?".replace(regex(r"\?", "g"), r"\\?") != r"hello\?");
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {// bugzilla 7679
     import std.algorithm.comparison : equal;
     static foreach (S; AliasSeq!(string, wstring, dstring))
@@ -337,7 +337,7 @@ import std.uni : Escapables; // characters that need escaping
         assert(split(str, re) == [to!S("a"), to!S("b")]);
     }}
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {//bugzilla 8203
     string data = "
     NAME   = XPAW01_STA:STATION
@@ -353,14 +353,14 @@ import std.uni : Escapables; // characters that need escaping
     auto r2 = regex(`([а-яА-Я\-_]+\s*)+(?<=[\s\.,\^])`);
     match("аллея Театральная", r2);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {// bugzilla 8637 purity of enforce
     auto m = match("hello world", regex("world"));
     enforce(m);
 }
 
 // bugzilla 8725
-@safe unittest
+version(StdUnittest) @safe unittest
 {
   static italic = regex( r"\*
                 (?!\s+)
@@ -373,7 +373,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 8349
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum peakRegexStr = r"\>(wgEncode.*Tfbs.*\.(?:narrow)|(?:broad)Peak.gz)</a>";
     enum peakRegex = ctRegex!(peakRegexStr);
@@ -382,7 +382,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 9211
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto rx_1 =  regex(r"^(\w)*(\d)");
@@ -394,7 +394,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 9280
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string tomatch = "a!b@c";
     static r = regex(r"^(?P<nick>.*?)!(?P<ident>.*?)@(?P<host>.*?)$");
@@ -407,7 +407,7 @@ import std.uni : Escapables; // characters that need escaping
 
 
 // bugzilla 9579
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] input = ['a', 'b', 'c'];
     string format = "($1)";
@@ -418,14 +418,14 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 9634
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto re = ctRegex!"(?:a+)";
     assert(match("aaaa", re).hit == "aaaa");
 }
 
 //bugzilla 10798
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto cr = ctRegex!("[abcd--c]*");
     auto m  = "abc".match(cr);
@@ -434,7 +434,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 10913
-@system unittest
+version(StdUnittest) @system unittest
 {
     @system static string foo(const(char)[] s)
     {
@@ -453,7 +453,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 11262
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum reg = ctRegex!(r",", "g");
     auto str = "This,List";
@@ -462,13 +462,13 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 11775
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(collectException(regex("a{1,0}")));
 }
 
 // bugzilla 11839
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     assert(regex(`(?P<var1>\w+)`).namedCaptures.equal(["var1"]));
@@ -479,7 +479,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 12076
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto RE = ctRegex!(r"(?<!x[a-z]+)\s([a-z]+)");
     string s = "one two";
@@ -487,7 +487,7 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 12105
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = ctRegex!`.*?(?!a)`;
     assert("aaab".matchFirst(r).hit == "aaa");
@@ -496,14 +496,14 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 //bugzilla 11784
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert("abcdefghijklmnopqrstuvwxyz"
         .matchFirst("[a-z&&[^aeiuo]]").hit == "b");
 }
 
 //bugzilla 12366
-@safe unittest
+version(StdUnittest) @safe unittest
 {
      auto re = ctRegex!(`^((?=(xx+?)\2+$)((?=\2+$)(?=(x+)(\4+$))\5){2})*x?$`);
      assert("xxxxxxxx".match(re).empty);
@@ -511,27 +511,27 @@ import std.uni : Escapables; // characters that need escaping
 }
 
 // bugzilla 12582
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = regex(`(?P<a>abc)`);
     assert(collectException("abc".matchFirst(r)["b"]));
 }
 
 // bugzilla 12691
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(bmatch("e@", "^([a-z]|)*$").empty);
     assert(bmatch("e@", ctRegex!`^([a-z]|)*$`).empty);
 }
 
 //bugzilla  12713
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assertThrown(regex("[[a-z]([a-z]|(([[a-z])))"));
 }
 
 //bugzilla 12747
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assertThrown(regex(`^x(\1)`));
     assertThrown(regex(`^(x(\1))`));
@@ -540,7 +540,7 @@ import std.uni : Escapables; // characters that need escaping
 
 // bugzilla 13532
 version(none) // TODO: revist once we have proper benchmark framework
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.datetime.stopwatch : StopWatch, AutoStart;
     import std.math : abs;
@@ -569,14 +569,14 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 14504
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto p = ctRegex!("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?" ~
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 }
 
 // bugzilla 14529
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto ctPat2 = regex(r"^[CDF]$", "i");
     foreach (v; ["C", "c", "D", "d", "F", "f"])
@@ -584,7 +584,7 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 14615
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     import std.regex : replaceFirst, replaceFirstInto, regex;
@@ -603,19 +603,19 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 15573
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto rx = regex("[c d]", "x");
     assert("a b".matchFirst(rx));
 }
 
 // bugzilla 15864
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     regex(`(<a (?:(?:\w+=\"[^"]*\")?\s*)*href="\.\.?)"`);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = regex("(?# comment)abc(?# comment2)");
     assert("abc".matchFirst(r));
@@ -623,7 +623,7 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 17075
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum titlePattern = `<title>(.+)</title>`;
     static titleRegex = ctRegex!titlePattern;
@@ -632,14 +632,14 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 17212
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto r = regex(" [a] ", "x");
     assert("a".matchFirst(r));
 }
 
 // bugzilla 17157
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     auto ctr = ctRegex!"(a)|(b)|(c)|(d)";
@@ -656,7 +656,7 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 17667
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     void willThrow(T, size_t line = __LINE__)(T arg, string msg)
@@ -672,7 +672,7 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 17668
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching;
     auto e = collectException!RegexException(regex(q"<[^]>"));
@@ -680,7 +680,7 @@ version(none) // TODO: revist once we have proper benchmark framework
 }
 
 // bugzilla 17673
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string str = `<">`;
     string[] regexps = ["abc", "\"|x"];

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -400,7 +400,7 @@ if (isSomeString!(S))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // multi-pattern regex example
     auto multi = regex([`([a-z]+):(\d+)`, `(\d+),\d+`]); // multi regex
@@ -637,7 +637,7 @@ public:
     @safe @property int whichPattern() const nothrow { return _nMatch; }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.regex;
         assert(matchFirst("abc", "[0-9]+", "[a-z]+").whichPattern == 2);
@@ -674,7 +674,7 @@ public:
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.range.primitives : popFrontN;
 
@@ -818,7 +818,7 @@ private auto matchMany(RegEx, R)(R input, RegEx re) @safe
     return RegexMatch!R(input, re.withFlags(re.flags | RegexOption.global));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //sanity checks for new API
     auto re = regex("abc");
@@ -827,7 +827,7 @@ private auto matchMany(RegEx, R)(R input, RegEx re) @safe
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18135
-unittest
+version(StdUnittest) unittest
 {
     static struct MapResult { RegexMatch!string m; }
     MapResult m;
@@ -1014,7 +1014,7 @@ if (isSomeString!R && isSomeString!String)
 }
 
 // another set of tests just to cover the new API
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -1183,7 +1183,7 @@ if (isSomeString!R && is(C : dchar) && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     assert(replaceFirst("noon", regex("n"), "[$&]") == "[n]oon");
 }
@@ -1210,7 +1210,7 @@ if (isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     string list = "#21 out of 46";
@@ -1246,7 +1246,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array;
     string m1 = "first message\n";
@@ -1259,7 +1259,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 //examples for replaceFirst
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv;
     string list = "#21 out of 46";
@@ -1301,7 +1301,7 @@ if (isSomeString!R && is(C : dchar) && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // insert comma as thousands delimiter
     auto re = regex(r"(?<=\d)(?=(\d\d\d)+\b)","g");
@@ -1335,7 +1335,7 @@ if (isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     string baz(Captures!(string) m)
     {
@@ -1374,7 +1374,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     // insert comma as thousands delimiter in fifty randomly produced big numbers
     import std.array, std.conv, std.random, std.range;
@@ -1391,7 +1391,7 @@ if (isOutputRange!(Sink, dchar) && isSomeString!R && isRegexFor!(RegEx, R))
 }
 
 // exercise all of the replace APIs
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.array : appender;
     import std.conv;
@@ -1580,7 +1580,7 @@ if (
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     auto s1 = ", abc, de,  fg, hi, ";
@@ -1589,7 +1589,7 @@ if (
 }
 
 /// Split on a pattern, but keep the matches in the resulting range
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : Yes;
@@ -1659,7 +1659,7 @@ auto escaper(Range)(Range r)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison;
     import std.regex;
@@ -1667,7 +1667,7 @@ auto escaper(Range)(Range r)
     assert(s.escaper.equal(`This is \{unfriendly\} to \*regex\*`));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison;
     import std.conv;

--- a/std/signals.d
+++ b/std/signals.d
@@ -287,7 +287,7 @@ mixin template Signal(T1...)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.signals;
 
@@ -372,9 +372,9 @@ mixin template Signal(T1...)
 
 // A function whose sole purpose is to get this module linked in
 // so the unittest will run.
-void linkin() { }
+version(StdUnittest) void linkin() { }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Observer
     {
@@ -444,7 +444,7 @@ void linkin() { }
     a.value = 7;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Observer
     {
@@ -624,7 +624,7 @@ void linkin() { }
 }
 
 // Triggers bug from issue 15341
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Observer
     {
@@ -652,7 +652,7 @@ void linkin() { }
 }
 
 version(none) // Disabled because of dmd @@@BUG5028@@@
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A
     {
@@ -666,7 +666,7 @@ version(none) // Disabled because of dmd @@@BUG5028@@@
 }
 
 // Triggers bug from issue 16249
-@system unittest
+version(StdUnittest) @system unittest
 {
     class myLINE
     {
@@ -718,7 +718,7 @@ version(none) // Disabled because of dmd @@@BUG5028@@@
     assert( dot2.value == -22 );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.signals;
 

--- a/std/socket.d
+++ b/std/socket.d
@@ -492,7 +492,7 @@ class Protocol
 // Skip this test on Android because getprotobyname/number are
 // unimplemented in bionic.
 version(CRuntime_Bionic) {} else
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         Protocol proto = new Protocol;
@@ -593,7 +593,7 @@ class Service
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         Service serv = new Service;
@@ -812,7 +812,7 @@ class InternetHost
 }
 
 ///
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     InternetHost ih = new InternetHost;
 
@@ -967,7 +967,7 @@ AddressInfo[] getAddressInfo(T...)(in char[] node, T options)
     return () @trusted { return getAddressInfoImpl(node, service, &hints); }();
 }
 
-@system unittest
+version (StdUnittest) @system unittest
 {
     struct Oops
     {
@@ -1018,7 +1018,7 @@ private AddressInfo[] getAddressInfoImpl(in char[] node, in char[] service, addr
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         if (getaddrinfoPointer)
@@ -1133,7 +1133,7 @@ Address[] getAddress(in char[] hostname, ushort port)
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         auto addresses = getAddress("63.105.9.61");
@@ -1213,7 +1213,7 @@ Address parseAddress(in char[] hostaddr, ushort port)
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         auto address = parseAddress("63.105.9.61");
@@ -1661,7 +1661,7 @@ public:
     }
 
     ///
-    @system unittest
+version (StdUnittest)     @system unittest
     {
         auto addr1 = new InternetAddress("127.0.0.1", 80);
         auto addr2 = new InternetAddress("127.0.0.2", 80);
@@ -1694,7 +1694,7 @@ public:
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         const InternetAddress ia = new InternetAddress("63.105.9.61", 80);
@@ -1901,7 +1901,7 @@ public:
 }
 
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         const Internet6Address ia = new Internet6Address("::1", 80);
@@ -2063,7 +2063,7 @@ static if (is(sockaddr_un))
         }
     }
 
-    @safe unittest
+version (StdUnittest)     @safe unittest
     {
         import core.stdc.stdio : remove;
         import std.file : deleteme;
@@ -2431,7 +2431,7 @@ public:
     }
 }
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     auto fds = cast(socket_t[])
         [cast(socket_t) 1, 2, 0, 1024, 17, 42, 1234, 77, 77+32, 77+64];
@@ -2453,7 +2453,7 @@ public:
     }
 }
 
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     softUnittest({
         enum PAIRS = 768;
@@ -2528,7 +2528,7 @@ public:
     });
 }
 
-@safe unittest // Issue 14012, 14013
+version (StdUnittest) @safe unittest // Issue 14012, 14013
 {
     auto set = new SocketSet(1);
     assert(set.max >= 0);
@@ -2629,7 +2629,7 @@ private:
     // behavior.
     enum WINSOCK_TIMEOUT_SKEW = 500;
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         version(SlowTests)
         softUnittest({
@@ -3565,7 +3565,7 @@ class UdpSocket: Socket
 }
 
 // Issue 16514
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     class TestSocket : Socket
     {
@@ -3660,7 +3660,7 @@ Socket[2] socketPair() @trusted
 }
 
 ///
-@safe unittest
+version (StdUnittest) @safe unittest
 {
     immutable ubyte[] data = [1, 2, 3, 4];
     auto pair = socketPair();

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -449,7 +449,7 @@ Throws: $(D ErrnoException) if the file could not be opened.
         this(name.to!string, mode.to!string);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static import std.file;
         import std.utf : byChar;
@@ -627,7 +627,7 @@ Throws: $(D ErrnoException) in case of error.
             _name = name;
     }
 
-    @system unittest // Test changing filename
+    version(StdUnittest) @system unittest // Test changing filename
     {
         import std.exception : assertThrown, assertNotThrown;
         static import std.file;
@@ -649,7 +649,7 @@ Throws: $(D ErrnoException) in case of error.
 
     version (CRuntime_DigitalMars) {} else // Not implemented
     version (CRuntime_Microsoft) {} else // Not implemented
-    @system unittest // Test changing mode
+    version(StdUnittest) @system unittest // Test changing mode
     {
         import std.exception : assertThrown, assertNotThrown;
         static import std.file;
@@ -817,7 +817,7 @@ the file handle.
         return !isOpen || .ferror(cast(FILE*) _p.handle);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Issue 12349
         static import std.file;
@@ -847,7 +847,7 @@ Throws: $(D ErrnoException) on failure if closing the file.
         }
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static import std.file;
 
@@ -919,7 +919,7 @@ Throws: $(D Exception) if the file is not opened or if the call to $(D fflush) f
         errnoEnforce(.fflush(_p.handle) == 0);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Issue 12349
         import std.exception : assertThrown;
@@ -1010,7 +1010,7 @@ $(D rawRead) always reads in binary mode on Windows.
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -1065,7 +1065,7 @@ Throws: $(D ErrnoException) if the file is not opened or if the call to $(D fwri
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -1113,7 +1113,7 @@ Throws: $(D Exception) if the file is not opened.
                 "Could not seek in file `"~_name~"'");
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.conv : text;
         static import std.file;
@@ -1171,7 +1171,7 @@ Throws: $(D Exception) if the file is not opened.
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.conv : text;
         static import std.file;
@@ -1395,7 +1395,7 @@ Removes the lock over the specified file segment.
     }
 
     version(Windows)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         auto deleteme = testFilename();
@@ -1414,7 +1414,7 @@ Removes the lock over the specified file segment.
     }
 
     version(Posix)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         auto deleteme = testFilename();
@@ -1622,7 +1622,7 @@ void main()
         return cast(S) buf;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         static import std.file;
@@ -1646,7 +1646,7 @@ void main()
         }}
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         import std.typecons : Tuple;
@@ -1773,7 +1773,7 @@ is recommended if you want to process a complete file.
         }
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system due to readln
         static import std.file;
@@ -1791,7 +1791,7 @@ is recommended if you want to process a complete file.
         assert(buffer[beyond] == 'a');
     }
 
-    @system unittest // bugzilla 15293
+    version(StdUnittest) @system unittest // bugzilla 15293
     {
         // @system due to readln
         static import std.file;
@@ -1845,7 +1845,7 @@ is recommended if you want to process a complete file.
         return buf.length;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         import std.typecons : Tuple;
@@ -1919,7 +1919,7 @@ $(CONSOLE
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -1939,7 +1939,7 @@ $(CONSOLE
     }
 
     // backwards compatibility with pointers
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system due to readf
         static import std.file;
@@ -1961,7 +1961,7 @@ $(CONSOLE
     }
 
     // backwards compatibility (mixed)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // @system due to readf
         static import std.file;
@@ -1982,7 +1982,7 @@ $(CONSOLE
     }
 
     // Issue 12260 - Nice error of std.stdio.readf with newlines
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -2036,7 +2036,7 @@ Returns the $(D FILE*) corresponding to this object.
         return _p.handle;
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import core.stdc.stdio;
         assert(stdout.getFP() == core.stdc.stdio.stdout);
@@ -2262,7 +2262,7 @@ the contents may well have changed).
         return ByLineImpl!(Char, Terminator)(this, keepTerminator, terminator);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         auto deleteme = testFilename();
@@ -2400,7 +2400,7 @@ $(REF readText, std,file)
         return ByLineCopy!(Char, Terminator)(this, keepTerminator, terminator);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         static assert(is(typeof(File("").byLine.front) == char[]));
         static assert(is(typeof(File("").byLineCopy.front) == string));
@@ -2408,7 +2408,7 @@ $(REF readText, std,file)
             is(typeof(File("").byLineCopy!(char, char).front) == char[]));
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         static import std.file;
@@ -2487,7 +2487,7 @@ $(REF readText, std,file)
         test("sue\r", ["sue\r"], kt, '\r');
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : drop, take;
@@ -2538,7 +2538,7 @@ $(REF readText, std,file)
         assert(!file.isOpen);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
         auto deleteme = testFilename();
@@ -2577,7 +2577,7 @@ $(REF readText, std,file)
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
          static import std.file;
          import std.typecons : tuple;
@@ -2759,7 +2759,7 @@ $(D StdioException).
         return ByChunkImpl(this, buffer);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -2784,7 +2784,7 @@ $(D StdioException).
         assert(i == witness.length);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         static import std.file;
 
@@ -3145,7 +3145,7 @@ void main()
         return LockingBinaryWriter(this);
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.mutation : reverse;
         import std.exception : collectException;
@@ -3230,7 +3230,7 @@ void main()
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     @system struct SystemToString
     {
@@ -3368,7 +3368,7 @@ void main()
     safeTests();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : collectException;
     static import std.file;
@@ -3381,7 +3381,7 @@ void main()
     assert(f.tell == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to readln
     static import std.file;
@@ -3405,7 +3405,7 @@ void main()
     assert(File(deleteme).readln() == "日本語日本語日本語日本語############日本語");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : collectException;
     auto e = collectException({ File f; f.writeln("Hello!"); }());
@@ -3511,7 +3511,7 @@ struct LockingTextReader
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to readf
     static import std.file;
@@ -3531,7 +3531,7 @@ struct LockingTextReader
     assert(x == 3);
 }
 
-@system unittest // bugzilla 13686
+version(StdUnittest) @system unittest // bugzilla 13686
 {
     import std.algorithm.comparison : equal;
     static import std.file;
@@ -3549,7 +3549,7 @@ struct LockingTextReader
     assert(equal(ltr, "Тест".byDchar));
 }
 
-@system unittest // bugzilla 12320
+version(StdUnittest) @system unittest // bugzilla 12320
 {
     static import std.file;
     auto deleteme = testFilename();
@@ -3563,7 +3563,7 @@ struct LockingTextReader
     assert(ltr.empty);
 }
 
-@system unittest // bugzilla 14861
+version(StdUnittest) @system unittest // bugzilla 14861
 {
     // @system due to readf
     static import std.file;
@@ -3597,7 +3597,7 @@ template isFileHandle(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isFileHandle!(FILE*));
     static assert(isFileHandle!(File));
@@ -3645,7 +3645,7 @@ if (!is(T[0] : File))
     trustedStdout.write(args);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -3725,7 +3725,7 @@ void writeln(T...)(T args)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Just make sure the call compiles
     if (false) writeln();
@@ -3744,7 +3744,7 @@ void writeln(T...)(T args)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -3790,7 +3790,7 @@ void writeln(T...)(T args)
             "Hello!\nHello!\nHello!\nembedded\0null\n");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -3824,7 +3824,7 @@ void writeln(T...)(T args)
                 "A\nB\nA\nB\nA\nB\nA\nB\n");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static auto useInit(T)(T ltw)
     {
@@ -3876,7 +3876,7 @@ void writef(Char, A...)(in Char[] fmt, A args)
     trustedStdout.writef(fmt, args);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -3917,7 +3917,7 @@ void writefln(Char, A...)(in Char[] fmt, A args)
     trustedStdout.writefln(fmt, args);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -3995,7 +3995,7 @@ uint readf(A...)(in char[] format, auto ref A args)
     return stdin.readf(format, args);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     float f;
     if (false) readf("%s", &f);
@@ -4086,7 +4086,7 @@ if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum) &&
     return stdin.readln(buf, terminator);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -4346,7 +4346,7 @@ struct lines
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
     import std.meta : AliasSeq;
@@ -4540,7 +4540,7 @@ private struct ChunksImpl
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -4588,7 +4588,7 @@ if (is(typeof(copy(data, stdout.lockingBinaryWriter))))
     copy(data, File(fileName, "wb").lockingBinaryWriter);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
 
@@ -4684,7 +4684,7 @@ enum StdFileHandle: string
 alias stdin = makeGlobal!(StdFileHandle.stdin);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Read stdin, sort lines, write to stdout
     import std.algorithm.mutation : copy;
@@ -4720,7 +4720,7 @@ alias stdout = makeGlobal!(StdFileHandle.stdout);
 */
 alias stderr = makeGlobal!(StdFileHandle.stderr);
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
     import std.typecons : tuple;
@@ -4744,7 +4744,7 @@ alias stderr = makeGlobal!(StdFileHandle.stderr);
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Retain backwards compatibility
     // https://issues.dlang.org/show_bug.cgi?id=17472
@@ -5188,7 +5188,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
     return buf.length;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static import std.file;
     auto deleteme = testFilename();

--- a/std/string.d
+++ b/std/string.d
@@ -219,7 +219,7 @@ inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
 }
 
 ///
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     assert(fromStringz(null) == null);
     assert(fromStringz("foo") == "foo");
@@ -299,7 +299,7 @@ immutable(char)* toStringz(in string s) @trusted pure nothrow
 }
 
 ///
-pure nothrow @system unittest
+version(StdUnittest) pure nothrow @system unittest
 {
     import core.stdc.string : strlen;
     import std.conv : to;
@@ -542,7 +542,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -553,7 +553,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -563,7 +563,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
     assert(indexOf(s, 'w', 3, No.caseSensitive) == 6);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!indexOf("std/string.d", '/'));
 
@@ -574,7 +574,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
     assert(sa.indexOf('/') == 3);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -625,7 +625,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!indexOf("std/string.d", '/', 0));
     assert(testAliasedString!indexOf("std/string.d", '/', 1));
@@ -642,7 +642,7 @@ if (isInputRange!Range && isSomeChar!(ElementType!Range))
     assert(sa.indexOf('/', 4) == -1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.traits : EnumMembers;
@@ -805,7 +805,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -816,7 +816,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -835,12 +835,12 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
     return indexOf!(StringTypeOf!Range)(s, sub, cs);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!indexOf("std/string.d", "string"));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -894,7 +894,7 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 }
 
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.traits : EnumMembers;
     import std.utf : byWchar;
@@ -911,7 +911,7 @@ unittest
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.traits : EnumMembers;
@@ -1065,7 +1065,7 @@ if (isSomeChar!Char)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -1076,7 +1076,7 @@ if (isSomeChar!Char)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -1086,7 +1086,7 @@ if (isSomeChar!Char)
     assert(lastIndexOf(s, 'L', 7, No.caseSensitive) == 3);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -1126,7 +1126,7 @@ if (isSomeChar!Char)
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.traits : EnumMembers;
@@ -1271,7 +1271,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -1282,7 +1282,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.typecons : No;
 
@@ -1292,7 +1292,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     assert(lastIndexOf(s, "lL", 3, No.caseSensitive) == -1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1309,7 +1309,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     }}
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -1369,7 +1369,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     });
 }
 
-@safe pure unittest // issue13529
+version(StdUnittest) @safe pure unittest // issue13529
 {
     import std.conv : to;
     static foreach (S; AliasSeq!(string, wstring, dstring))
@@ -1386,7 +1386,7 @@ if (isSomeChar!Char1 && isSomeChar!Char2)
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.traits : EnumMembers;
@@ -1593,7 +1593,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1604,7 +1604,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1615,7 +1615,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     assert(i == 8, to!string(i));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1632,7 +1632,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     }}
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -1671,7 +1671,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.traits : EnumMembers;
@@ -1758,7 +1758,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     ptrdiff_t i = "helloWorld".lastIndexOfAny("Wlo");
     assert(i == 8);
@@ -1768,7 +1768,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1779,7 +1779,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     assert(i == 0);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1796,7 +1796,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     }}
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -1849,7 +1849,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -1942,7 +1942,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(indexOfNeither("abba", "a", 2) == 2);
     assert(indexOfNeither("def", "de", 1) == 2);
@@ -1950,14 +1950,14 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(indexOfNeither("def", "a") == 0);
     assert(indexOfNeither("def", "de") == 2);
     assert(indexOfNeither("dfefffg", "dfe") == 6);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -1974,7 +1974,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     }}
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -2018,7 +2018,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -2098,20 +2098,20 @@ if (isSomeChar!Char && isSomeChar!Char2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(lastIndexOfNeither("abba", "a") == 2);
     assert(lastIndexOfNeither("def", "f") == 1);
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(lastIndexOfNeither("def", "rsa", 3) == -1);
     assert(lastIndexOfNeither("abba", "a", 2) == 1);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
 
@@ -2128,7 +2128,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     }}
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -2173,7 +2173,7 @@ if (isSomeChar!Char && isSomeChar!Char2)
     );
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -2237,7 +2237,7 @@ if (isSomeChar!Char)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string s = "hello";
     static assert(is(typeof(representation(s)) == immutable(ubyte)[]));
@@ -2245,7 +2245,7 @@ if (isSomeChar!Char)
     assert(representation(s) == [0x68, 0x65, 0x6c, 0x6c, 0x6f]);
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.exception : assertCTFEable;
     import std.traits : Fields;
@@ -2301,7 +2301,7 @@ if (isSomeString!S)
 }
 
 ///
-pure @safe unittest
+version(StdUnittest) pure @safe unittest
 {
     assert(capitalize("hello") == "Hello");
     assert(capitalize("World") == "World");
@@ -2313,12 +2313,12 @@ if (!isSomeString!S && is(StringTypeOf!S))
     return capitalize!(StringTypeOf!S)(s);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!capitalize("hello"));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv : to;
@@ -2468,19 +2468,19 @@ if (isSomeChar!C)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     string s = "Hello\nmy\rname\nis";
     assert(splitLines(s) == ["Hello", "my", "name", "is"]);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     string s = "a\xC2\x86b";
     assert(splitLines(s) == [s]);
 }
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     assert(testAliasedString!splitLines("hello\nworld"));
 
@@ -2491,7 +2491,7 @@ if (isSomeChar!C)
     assert(sa.splitLines() == ["hello", "world"]);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -2726,7 +2726,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
 
@@ -2738,7 +2738,7 @@ if (isSomeChar!C)
     assert(lineSplitter(s).array == splitLines(s));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.conv : to;
@@ -2805,7 +2805,7 @@ if (isSomeChar!C)
 }
 
 ///
-@nogc @safe pure unittest
+version(StdUnittest) @nogc @safe pure unittest
 {
     auto s = "\rpeter\n\rpaul\r\njerry\u2028ice\u2029cream\n\nsunday\nmon\u2030day\n";
     auto lines = s.lineSplitter();
@@ -2818,7 +2818,7 @@ if (isSomeChar!C)
     assert(i == witness.length);
 }
 
-@nogc @safe pure unittest
+version(StdUnittest) @nogc @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : only;
@@ -2834,7 +2834,7 @@ if (isSomeChar!C)
     assert(equal(sa.lineSplitter(), only("hello", "world")));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s = "line1\nline2";
     auto spl0 = s.lineSplitter!(Yes.keepTerminator);
@@ -2892,7 +2892,7 @@ if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.uni : lineSep, paraSep;
     assert(stripLeft("     hello world     ") ==
@@ -2918,7 +2918,7 @@ if (isConvertibleToString!Range)
     return stripLeft!(StringTypeOf!Range)(str);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!stripLeft("  hello"));
 }
@@ -2942,7 +2942,7 @@ if (((isForwardRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(stripLeft("     hello world     ", " ") ==
            "hello world     ");
@@ -2953,7 +2953,7 @@ if (((isForwardRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.utf : byChar, byWchar, byDchar;
@@ -2973,7 +2973,7 @@ if (((isForwardRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
     assert(stripLeft(" hello ", "") == " hello ");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!stripLeft(" xyz  hello", "xyz "));
 }
@@ -3091,7 +3091,7 @@ if (isSomeString!Range ||
 
 ///
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.uni : lineSep, paraSep;
     assert(stripRight("     hello world     ") ==
@@ -3112,12 +3112,12 @@ if (isConvertibleToString!Range)
     return stripRight!(StringTypeOf!Range)(str);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!stripRight("hello   "));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.uni : lineSep, paraSep;
@@ -3161,7 +3161,7 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
 
 ///
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     assert(stripRight("     hello world     ", "x") ==
            "     hello world     ");
@@ -3171,12 +3171,12 @@ unittest
            "     hello world");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!stripRight("hello xyz  ", "xyz "));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.utf : byChar, byDchar, byUTF, byWchar;
@@ -3222,7 +3222,7 @@ if (isSomeString!Range ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.uni : lineSep, paraSep;
     assert(strip("     hello world     ") ==
@@ -3243,12 +3243,12 @@ if (isConvertibleToString!Range)
     return strip!(StringTypeOf!Range)(str);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!strip("     hello world     "));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -3283,7 +3283,7 @@ if (isConvertibleToString!Range)
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : sameHead, sameTail;
     import std.exception : assertCTFEable;
@@ -3307,7 +3307,7 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(strip("     hello world     ", "x") ==
            "     hello world     ");
@@ -3320,7 +3320,7 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
     assert(strip(" hello ", "") == " hello ");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!strip("  xyz   hello world  xyz   ", "xyz "));
 }
@@ -3337,7 +3337,7 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(strip("xxhelloyy", "x", "y") == "hello");
     assert(strip("   xyxyhello worldxyxyzz    ", "xy ", "xyz ") ==
@@ -3348,12 +3348,12 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
     assert(strip(" hello ", "", "") == " hello ");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!strip("  xy   hello world  pq   ", "xy ", "pq "));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -3402,7 +3402,7 @@ if (((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range)) ||
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : sameHead, sameTail;
     import std.exception : assertCTFEable;
@@ -3529,7 +3529,7 @@ if ((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range) ||
 
 ///
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.uni : lineSep, paraSep, nelSep;
     import std.utf : decode;
@@ -3565,13 +3565,13 @@ if (isConvertibleToString!Range)
     return chomp!(StringTypeOf!Range, C2)(str, delimiter);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!chomp(" hello world  \n\r"));
     assert(testAliasedString!chomp(" hello world", "orld"));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -3679,7 +3679,7 @@ if ((isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(chompPrefix("hello world", "he") == "llo world");
     assert(chompPrefix("hello world", "hello w") == "orld");
@@ -3694,7 +3694,7 @@ if (isConvertibleToString!Range)
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -3729,7 +3729,7 @@ unittest
     assert(chompPrefix("\u2020world"d.byDchar, "\u2020"d).array == "world"d);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!chompPrefix("hello world", "hello"));
 }
@@ -3803,7 +3803,7 @@ if ((isBidirectionalRange!Range && isSomeChar!(ElementEncodingType!Range) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(chop("hello world") == "hello worl");
     assert(chop("hello world\n") == "hello world");
@@ -3820,12 +3820,12 @@ if (isConvertibleToString!Range)
     return chop!(StringTypeOf!Range)(str);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!chop("hello world"));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.utf : byChar, byWchar, byDchar, byCodeUnit, invalidUTFstrings;
@@ -3859,7 +3859,7 @@ if (isConvertibleToString!Range)
     }
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -3905,7 +3905,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(leftJustify("hello", 7, 'X') == "helloXX");
     assert(leftJustify("hello", 2, 'X') == "hello");
@@ -3993,7 +3993,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 
 ///
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.algorithm.comparison : equal;
     import std.utf : byChar;
@@ -4008,7 +4008,7 @@ if (isConvertibleToString!Range)
     return leftJustifier!(StringTypeOf!Range)(r, width, fillChar);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto r = "hello".leftJustifier(8);
     r.popFront();
@@ -4018,7 +4018,7 @@ if (isConvertibleToString!Range)
     assert(save.front == 'e');
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!leftJustifier("hello", 2));
 }
@@ -4047,7 +4047,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(rightJustify("hello", 7, 'X') == "XXhello");
     assert(rightJustify("hello", 2, 'X') == "hello");
@@ -4173,7 +4173,7 @@ if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 
 ///
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.algorithm.comparison : equal;
     import std.utf : byChar;
@@ -4188,12 +4188,12 @@ if (isConvertibleToString!Range)
     return rightJustifier!(StringTypeOf!Range)(r, width, fillChar);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!rightJustifier("hello", 2));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto r = "hello"d.rightJustifier(6);
     r.popFront();
@@ -4237,7 +4237,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(center("hello", 7, 'X') == "XhelloX");
     assert(center("hello", 2, 'X') == "hello");
@@ -4245,7 +4245,7 @@ if (isSomeString!S)
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -4332,7 +4332,7 @@ if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 
 ///
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     import std.algorithm.comparison : equal;
     import std.utf : byChar;
@@ -4347,12 +4347,12 @@ if (isConvertibleToString!Range)
     return centerJustifier!(StringTypeOf!Range)(r, width, fillChar);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!centerJustifier("hello", 8));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static auto byFwdRange(dstring s)
     {
@@ -4412,12 +4412,12 @@ if ((isForwardRange!Range && isSomeChar!(ElementEncodingType!Range))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(detab(" \n\tx", 9) == " \n         x");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     static struct TestStruct
     {
@@ -4565,7 +4565,7 @@ if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
 
@@ -4578,12 +4578,12 @@ if (isConvertibleToString!Range)
     return detabber!(StringTypeOf!Range)(r, tabSize);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!detabber(  "  ab\t asdf ", 8));
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : cmp;
     import std.conv : to;
@@ -4614,7 +4614,7 @@ if (isConvertibleToString!Range)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     import std.utf : byChar, byWchar;
@@ -4652,7 +4652,7 @@ if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(entab("        x \n") == "\tx\n");
 }
@@ -4664,7 +4664,7 @@ if (!(isForwardRange!Range && isSomeChar!(ElementEncodingType!Range)) &&
     return entab!(StringTypeOf!Range)(s, tabSize);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!entab("        x \n"));
 }
@@ -4903,7 +4903,7 @@ if (isForwardRange!Range && !isConvertibleToString!Range)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : array;
     assert(entabber("        x \n").array == "\tx\n");
@@ -4915,13 +4915,13 @@ if (isConvertibleToString!Range)
     return entabber!(StringTypeOf!Range)(r, tabSize);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!entabber("  ab    asdf ", 8));
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -4968,7 +4968,7 @@ unittest
 }
 
 @safe pure
-unittest
+version(StdUnittest) unittest
 {
     import std.array : array;
     import std.utf : byChar;
@@ -5015,7 +5015,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     dchar[dchar] transTable1 = ['e' : '5', 'o' : '7', '5': 'q'];
     assert(translate("hello world", transTable1) == "h5ll7 w7rld");
@@ -5026,7 +5026,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
     assert(translate("hello world", transTable2) == "h5llorange worangerld");
 }
 
-@safe pure unittest // issue 13018
+version(StdUnittest) @safe pure unittest // issue 13018
 {
     immutable dchar[dchar] transTable1 = ['e' : '5', 'o' : '7', '5': 'q'];
     assert(translate("hello world", transTable1) == "h5ll7 w7rld");
@@ -5037,7 +5037,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
     assert(translate("hello world", transTable2) == "h5llorange worangerld");
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5095,7 +5095,7 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
     return buffer.data;
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5170,7 +5170,7 @@ if (isSomeChar!C1 && isSomeChar!C2 && isOutputRange!(Buffer, C1))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     dchar[dchar] transTable1 = ['e' : '5', 'o' : '7', '5': 'q'];
@@ -5188,7 +5188,7 @@ if (isSomeChar!C1 && isSomeChar!C2 && isOutputRange!(Buffer, C1))
     assert(buffer.data == "h5llorange worangerld");
 }
 
-@safe pure unittest // issue 13018
+version(StdUnittest) @safe pure unittest // issue 13018
 {
     import std.array : appender;
     immutable dchar[dchar] transTable1 = ['e' : '5', 'o' : '7', '5': 'q'];
@@ -5319,7 +5319,7 @@ string makeTrans(in char[] from, in char[] to) @trusted pure nothrow
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     auto transTable1 = makeTrans("eo5", "57q");
     assert(translate("hello world", transTable1) == "h5ll7 w7rld");
@@ -5360,7 +5360,7 @@ do
     return result;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5435,7 +5435,7 @@ do
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.array : appender;
     auto buffer = appender!(char[])();
@@ -5507,7 +5507,7 @@ if (isSomeString!S)
 
 
 deprecated
-@safe pure @nogc unittest
+version(StdUnittest) @safe pure @nogc unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5581,7 +5581,7 @@ if (isSomeString!S && isSomeString!S1)
 }
 
 deprecated
-@safe pure @nogc unittest
+version(StdUnittest) @safe pure @nogc unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5634,7 +5634,7 @@ if (isSomeString!S)
 }
 
 deprecated
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5649,7 +5649,7 @@ deprecated
 }
 
 deprecated
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(removechars("abc", "x") == "abc");
 }
@@ -5710,7 +5710,7 @@ S squeeze(S)(S s, in S pattern = null)
 }
 
 deprecated
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -5765,7 +5765,7 @@ S1 munch(S1, S2)(ref S1 s, S2 pattern) @safe pure @nogc
 
 ///
 deprecated
-@safe pure @nogc unittest
+version(StdUnittest) @safe pure @nogc unittest
 {
     string s = "123abc";
     string t = munch(s, "0123456789");
@@ -5775,7 +5775,7 @@ deprecated
 }
 
 deprecated
-@safe pure @nogc unittest
+version(StdUnittest) @safe pure @nogc unittest
 {
     string s = "123€abc";
     string t = munch(s, "0123456789");
@@ -5842,7 +5842,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(succ("1") == "2");
     assert(succ("9") == "10");
@@ -5850,7 +5850,7 @@ if (isSomeString!S)
     assert(succ("zz99") == "aaa00");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -6026,7 +6026,7 @@ C1[] tr(C1, C2, C3, C4 = immutable char)
     return result.data;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : to;
@@ -6070,7 +6070,7 @@ C1[] tr(C1, C2, C3, C4 = immutable char)
     });
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -6243,7 +6243,7 @@ if (isSomeString!S ||
  * Integer Whole Number: (byte, ubyte, short, ushort, int, uint, long, and ulong)
  * ['+'|'-']digit(s)[U|L|UL]
  */
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(isNumeric("123"));
     assert(isNumeric("123UL"));
@@ -6257,7 +6257,7 @@ if (isSomeString!S ||
  * ['+'|'-']digit(s)[.][digit(s)][[e-|e+]digit(s)][i|f|L|Li|fi]]
  *      or [nan|nani|inf|-inf]
  */
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(isNumeric("+123"));
     assert(isNumeric("-123.01"));
@@ -6276,14 +6276,14 @@ if (isSomeString!S ||
  *         [digit(s)[.][digit(s)][[e-|e+]digit(s)][i|f|L|Li|fi]]
  *      or [nan|nani|nan+nani|inf|-inf]
  */
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(isNumeric("-123e-1+456.9e-10Li"));
     assert(isNumeric("+123e+10+456i"));
     assert(isNumeric("123+456"));
 }
 
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(!isNumeric("F"));
     assert(!isNumeric("L"));
@@ -6307,7 +6307,7 @@ if (isSomeString!S ||
 }
 
 // Test string types
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
 
@@ -6322,7 +6322,7 @@ if (isSomeString!S ||
 }
 
 // test ranges
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.range : refRange;
     import std.utf : byCodeUnit;
@@ -6341,7 +6341,7 @@ if (isSomeString!S ||
 }
 
 /// isNumeric works with CTFE
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     enum a = isNumeric("123.00E-5+1234.45E-12Li");
     enum b = isNumeric("12345xxxx890");
@@ -6350,7 +6350,7 @@ if (isSomeString!S ||
     static assert(!b);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -6402,7 +6402,7 @@ if (isSomeString!S ||
 
 version(TestComplex)
 deprecated
-unittest
+version(StdUnittest) unittest
 {
     import std.conv : to;
     assert(isNumeric(to!string(123e+2+1234.78Li)) == true);
@@ -6539,7 +6539,7 @@ do
 }
 
 
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.exception : assertCTFEable;
     assertCTFEable!(
@@ -6592,7 +6592,7 @@ do
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!soundexer("Martinez"));
 }
@@ -6658,7 +6658,7 @@ string[string] abbrev(string[] values) @safe pure
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.string;
 
@@ -6669,7 +6669,7 @@ string[string] abbrev(string[] values) @safe pure
 }
 
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.algorithm.sorting : sort;
     import std.conv : to;
@@ -6765,7 +6765,7 @@ if ((isInputRange!Range && isSomeChar!(Unqual!(ElementEncodingType!Range)) ||
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.utf : byChar, byWchar, byDchar;
 
@@ -6806,12 +6806,12 @@ if (isConvertibleToString!Range)
     return column!(StringTypeOf!Range)(str, tabsize);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(testAliasedString!column("abc\u00861"));
 }
 
-@safe @nogc unittest
+version(StdUnittest) @safe @nogc unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -6913,7 +6913,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(wrap("a short string", 7) == "a short\nstring\n");
 
@@ -6924,7 +6924,7 @@ if (isSomeString!S)
     assert(wrap("a short string", 7, "\t", "    ") == "\ta\n    short\n    string\n");
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -6968,7 +6968,7 @@ if (isSomeString!S)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     enum pretty = q{
        import std.stdio;
@@ -7064,7 +7064,7 @@ if (isSomeString!S)
     return lines;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception : assertCTFEable;
@@ -7157,7 +7157,7 @@ if (isSomeString!S)
     });
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception : assertThrown;
     auto bad = "      a\n\tb\n   c";
@@ -7193,7 +7193,7 @@ if (staticIndexOf!(Unqual!T, ubyte, ushort, uint) != -1)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     string a = "Hölo World";
     immutable(ubyte)[] b = a.representation;
@@ -7202,7 +7202,7 @@ if (staticIndexOf!(Unqual!T, ubyte, ushort, uint) != -1)
     assert(a == c);
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     import std.algorithm.comparison : equal;
     static foreach (T; AliasSeq!(char[], wchar[], dchar[]))

--- a/std/traits.d
+++ b/std/traits.d
@@ -300,7 +300,7 @@ template SharedConstOf(T) { alias SharedConstOf = shared(const(T)); }
 /// Add the immutable qualifier to the given type T.
 template ImmutableOf(T)   { alias ImmutableOf   =    immutable(T) ; }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(    MutableOf!int ==              int));
     static assert(is(      InoutOf!int ==        inout int));
@@ -323,7 +323,7 @@ template QualifierOf(T)
     else                                         alias QualifierOf = MutableOf;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Qual1 = QualifierOf!(             int);   static assert(is(Qual1!long ==              long));
     alias Qual2 = QualifierOf!(       inout int);   static assert(is(Qual2!long ==        inout long));
@@ -369,12 +369,12 @@ template packageName(alias T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(packageName!packageName == "std");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
 
@@ -424,12 +424,12 @@ template moduleName(alias T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(moduleName!moduleName == "std.traits");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array;
 
@@ -477,7 +477,7 @@ template fullyQualifiedName(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(fullyQualifiedName!fullyQualifiedName == "std.traits.fullyQualifiedName");
 }
@@ -566,7 +566,7 @@ private template fqnSym(alias T)
     enum fqnSym = parentPrefix ~ adjustIdent(__traits(identifier, T));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias fqn = fullyQualifiedName;
 
@@ -592,7 +592,7 @@ private template fqnSym(alias T)
     static assert(fqn!Barrier == "core.sync.barrier.Barrier");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct TemplatedStruct()
     {
@@ -812,7 +812,7 @@ private template fqnType(T,
         static assert(0, "Unrecognized type " ~ T.stringof ~ ", can't convert to fully qualified string");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
     alias fqn = fullyQualifiedName;
@@ -901,13 +901,13 @@ template ReturnType(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo();
     ReturnType!foo x;   // x is declared as int
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct G
     {
@@ -960,7 +960,7 @@ template Parameters(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo(int, long);
     void bar(Parameters!foo);      // declares void bar(int, long);
@@ -972,7 +972,7 @@ template Parameters(func...)
  */
 alias ParameterTypeTuple = Parameters;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo(int i, bool b) { return 0; }
     static assert(is(ParameterTypeTuple!foo == AliasSeq!(int, bool)));
@@ -1008,7 +1008,7 @@ template arity(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void foo(){}
     static assert(arity!foo == 0);
@@ -1018,7 +1018,7 @@ template arity(func...)
     static assert(!__traits(compiles, arity!variadicFoo));
 }
 
-@safe unittest // issue 11389
+version(StdUnittest) @safe unittest // issue 11389
 {
     alias TheType = size_t function( string[] );
     static assert(arity!TheType == 1);
@@ -1074,7 +1074,7 @@ template ParameterStorageClassTuple(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias STC = ParameterStorageClass; // shorten the enum name
 
@@ -1123,7 +1123,7 @@ template extractParameterStorageClassFlags(Attribs...)
     }();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias STC = ParameterStorageClass;
 
@@ -1164,7 +1164,7 @@ template extractParameterStorageClassFlags(Attribs...)
     static assert(ParameterStorageClassTuple!(typeof(func))[0] == STC.none);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 14253
     static struct Foo {
@@ -1218,13 +1218,13 @@ template ParameterIdentifierTuple(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo(int num, string name, int);
     static assert([ParameterIdentifierTuple!foo] == ["num", "name", ""]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias PIT = ParameterIdentifierTuple;
 
@@ -1322,7 +1322,7 @@ template ParameterDefaults(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     int foo(int num, string name = "hello", int[] = [1,2,3], lazy int x = 0);
     static assert(is(ParameterDefaults!foo[0] == void));
@@ -1331,7 +1331,7 @@ template ParameterDefaults(func...)
     static assert(   ParameterDefaults!foo[3] == 0);
 }
 
-@safe unittest // issue 17192
+version(StdUnittest) @safe unittest // issue 17192
 {
     static void func(int i, int PT, int __pd_value, int __pd_val, int __args,
         int name, int args, int val, int ptr, int args_, int val_, int ptr_)
@@ -1347,7 +1347,7 @@ template ParameterDefaults(func...)
  */
 alias ParameterDefaultValueTuple = ParameterDefaults;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias PDVT = ParameterDefaultValueTuple;
 
@@ -1425,7 +1425,7 @@ template functionAttributes(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias FA = FunctionAttribute; // shorten the enum name
 
@@ -1438,7 +1438,7 @@ template functionAttributes(func...)
     static assert(!(functionAttributes!func & FA.trusted)); // not @trusted
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias FA = FunctionAttribute;
 
@@ -1607,7 +1607,7 @@ template hasFunctionAttributes(args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real func(real x) pure nothrow @safe;
     static assert(hasFunctionAttributes!(func, "@safe", "pure"));
@@ -1622,7 +1622,7 @@ template hasFunctionAttributes(args...)
     static assert(!hasFunctionAttributes!(myFunc!bool, "shared"));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -1781,7 +1781,7 @@ template isSafe(alias func)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     @safe    int add(int a, int b) {return a+b;}
     @trusted int sub(int a, int b) {return a-b;}
@@ -1793,7 +1793,7 @@ template isSafe(alias func)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Member functions
     interface Set
@@ -1858,7 +1858,7 @@ template isUnsafe(alias func)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     @safe    int add(int a, int b) {return a+b;}
     @trusted int sub(int a, int b) {return a-b;}
@@ -1869,7 +1869,7 @@ template isUnsafe(alias func)
     static assert( isUnsafe!mul);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Member functions
     interface Set
@@ -1939,7 +1939,7 @@ template functionLinkage(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     extern(D) void Dfunc() {}
     extern(C) void Cfunc() {}
@@ -1954,7 +1954,7 @@ template functionLinkage(func...)
     assert(b == "C");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface Test
     {
@@ -1998,7 +1998,7 @@ template variadicFunctionStyle(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void func() {}
     static assert(variadicFunctionStyle!func == Variadic.no);
@@ -2007,7 +2007,7 @@ template variadicFunctionStyle(func...)
     static assert(variadicFunctionStyle!printf == Variadic.c);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import core.vararg;
 
@@ -2067,7 +2067,7 @@ template FunctionTypeOf(func...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C
     {
@@ -2077,7 +2077,7 @@ template FunctionTypeOf(func...)
     static assert(is( FunctionTypeOf!(C.value) == function ));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int test(int a);
     int propGet() @property;
@@ -2226,7 +2226,7 @@ template SetFunctionAttributes(T, string linkage, uint attrs)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias ExternC(T) = SetFunctionAttributes!(T, "C", functionAttributes!T);
 
@@ -2247,7 +2247,7 @@ version(StdUnittest)
     extern(D) int dstyle(...);
     extern(D) int typesafe(int[]...);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : reduce;
 
@@ -2324,7 +2324,7 @@ template isInnerClass(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C
     {
@@ -2364,7 +2364,7 @@ template isNested(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S { }
     static assert(!isNested!S);
@@ -2396,7 +2396,7 @@ template hasNested(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S { }
 
@@ -2407,7 +2407,7 @@ template hasNested(T)
     static assert(hasNested!(NS[2]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!__traits(compiles, isNested!int));
     static assert(!hasNested!int);
@@ -2484,7 +2484,7 @@ template Fields(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     struct S { int x; float y; }
@@ -2496,7 +2496,7 @@ template Fields(T)
  */
 alias FieldTypeTuple = Fields;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(FieldTypeTuple!int == AliasSeq!int));
 
@@ -2541,7 +2541,7 @@ template FieldNameTuple(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     struct S { int x; float y; }
@@ -2549,7 +2549,7 @@ template FieldNameTuple(T)
     static assert(FieldNameTuple!int == AliasSeq!"");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(FieldNameTuple!int == AliasSeq!"");
 
@@ -2617,7 +2617,7 @@ template RepresentationTypeTuple(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S1 { int a; float b; }
     struct S2 { char[] a; union { S1 b; S1 * c; } }
@@ -2627,7 +2627,7 @@ template RepresentationTypeTuple(T)
         && is(R[2] == float) && is(R[3] == S1*));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias S1 = RepresentationTypeTuple!int;
     static assert(is(S1 == AliasSeq!int));
@@ -2691,7 +2691,7 @@ private template hasRawAliasing(T...)
 }
 
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // simple types
     static assert(!hasRawAliasing!int);
@@ -2708,7 +2708,7 @@ private template hasRawAliasing(T...)
     static assert(!hasRawAliasing!S2);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // struct with a pointer member
     struct S3 { int a; double * b; }
@@ -2787,7 +2787,7 @@ private template hasRawUnsharedAliasing(T...)
 }
 
 //
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // simple types
     static assert(!hasRawUnsharedAliasing!int);
@@ -2811,7 +2811,7 @@ private template hasRawUnsharedAliasing(T...)
     static assert(!hasRawUnsharedAliasing!S4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // struct with a pointer member
     struct S3 { int a; double * b; }
@@ -3014,7 +3014,7 @@ template hasAliasing(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S1 { int a; Object b; }
     struct S2 { string a; }
@@ -3026,7 +3026,7 @@ template hasAliasing(T...)
     static assert(!hasAliasing!S4);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( hasAliasing!(uint[uint]));
     static assert(!hasAliasing!(immutable(uint[uint])));
@@ -3110,7 +3110,7 @@ template hasIndirections(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( hasIndirections!(int[string]));
     static assert( hasIndirections!(void delegate()));
@@ -3123,7 +3123,7 @@ template hasIndirections(T)
     static assert(!hasIndirections!(byte[1]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // void static array hides actual type of bits, so "may have indirections".
     static assert( hasIndirections!(void[1]));
@@ -3182,7 +3182,7 @@ template hasIndirections(T)
     static assert( hasIndirections!S26);
 }
 
-@safe unittest //12000
+version(StdUnittest) @safe unittest //12000
 {
     static struct S(T)
     {
@@ -3240,7 +3240,7 @@ template hasUnsharedAliasing(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S1 { int a; Object b; }
     struct S2 { string a; }
@@ -3259,7 +3259,7 @@ template hasUnsharedAliasing(T...)
     static assert(!hasUnsharedAliasing!S7);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     /* Issue 6642 */
     import std.typecons : Rebindable;
@@ -3275,7 +3275,7 @@ template hasUnsharedAliasing(T...)
     static assert(!hasUnsharedAliasing!(void delegate() shared const));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : Rebindable;
     static assert( hasUnsharedAliasing!(const(void delegate())));
@@ -3400,7 +3400,7 @@ template hasElaborateCopyConstructor(S)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasElaborateCopyConstructor!int);
 
@@ -3458,7 +3458,7 @@ template hasElaborateAssign(S)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasElaborateAssign!int);
 
@@ -3476,7 +3476,7 @@ template hasElaborateAssign(S)
     static assert(!hasElaborateAssign!(S3[0]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S  { void opAssign(S) {} }
     static struct S4
@@ -3544,7 +3544,7 @@ template hasElaborateDestructor(S)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasElaborateDestructor!int);
 
@@ -3576,7 +3576,7 @@ package alias Identity(alias A) = A;
 enum hasMember(T, string name) = __traits(hasMember, T, name);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!hasMember!(int, "blah"));
     struct S1 { int blah; }
@@ -3589,7 +3589,7 @@ enum hasMember(T, string name) = __traits(hasMember, T, name);
     static assert(hasMember!(C2, "blah"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // 8321
     struct S {
@@ -3621,7 +3621,7 @@ enum hasMember(T, string name) = __traits(hasMember, T, name);
     static assert(hasMember!(R2!S, "T"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S
     {
@@ -3659,7 +3659,7 @@ template hasStaticMember(T, string member)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S
     {
@@ -3679,7 +3679,7 @@ template hasStaticMember(T, string member)
     static assert(!hasStaticMember!(S, "hello"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S
     {
@@ -3920,7 +3920,7 @@ template EnumMembers(E)
     alias EnumMembers = EnumSpecificMembers!(__traits(allMembers, E));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum A { a }
     static assert([ EnumMembers!A ] == [ A.a ]);
@@ -3928,7 +3928,7 @@ template EnumMembers(E)
     static assert([ EnumMembers!B ] == [ B.a, B.b, B.c, B.d, B.e ]);
 }
 
-@safe unittest    // typed enums
+version(StdUnittest) @safe unittest    // typed enums
 {
     enum A : string { a = "alpha", b = "beta" }
     static assert([ EnumMembers!A ] == [ A.a, A.b ]);
@@ -3942,7 +3942,7 @@ template EnumMembers(E)
     static assert([ EnumMembers!B ] == [ B.a, B.b, B.c ]);
 }
 
-@safe unittest    // duplicated values
+version(StdUnittest) @safe unittest    // duplicated values
 {
     enum A
     {
@@ -3952,7 +3952,7 @@ template EnumMembers(E)
     static assert([ EnumMembers!A ] == [ A.a, A.b, A.c, A.d, A.e ]);
 }
 
-@safe unittest // Bugzilla 14561: huge enums
+version(StdUnittest) @safe unittest // Bugzilla 14561: huge enums
 {
     string genEnum()
     {
@@ -3977,7 +3977,7 @@ template EnumMembers(E)
     static assert(EnumMembers!TLAs[$-1] == TLAs._2999);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum E { member, a = 0, b = 0 }
     static assert(__traits(identifier, EnumMembers!E[0]) == "member");
@@ -4004,7 +4004,7 @@ template BaseTypeTuple(A)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -4018,7 +4018,7 @@ template BaseTypeTuple(A)
     static assert(is(BaseTypeTuple!I123 == AliasSeq!(I1, I2, I3)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface I1 { }
     interface I2 { }
@@ -4059,7 +4059,7 @@ template BaseClassesTuple(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -4072,7 +4072,7 @@ template BaseClassesTuple(T)
     static assert(is(BaseClassesTuple!C3 == AliasSeq!(C2, C1, Object)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S { }
     static assert(!__traits(compiles, BaseClassesTuple!S));
@@ -4113,7 +4113,7 @@ template InterfacesTuple(T)
         alias InterfacesTuple = AliasSeq!();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // doc example
     interface I1 {}
@@ -4125,7 +4125,7 @@ template InterfacesTuple(T)
     static assert(is(TL[0] == I1) && is(TL[1] == I2));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface Iaa {}
     interface Iab {}
@@ -4160,7 +4160,7 @@ template TransitiveBaseTypeTuple(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface J1 {}
     interface J2 {}
@@ -4284,7 +4284,7 @@ template MemberFunctionsTuple(C, string name)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface I { I foo(); }
     class B
@@ -4301,7 +4301,7 @@ template MemberFunctionsTuple(C, string name)
     static assert(__traits(isSame, foos[1], B.foo));
 }
 
-@safe unittest // Issue 15920
+version(StdUnittest) @safe unittest // Issue 15920
 {
     import std.meta : AliasSeq;
     class A
@@ -4320,7 +4320,7 @@ template MemberFunctionsTuple(C, string name)
     assert(__traits(isSame, fs[1], bfs[0]) || __traits(isSame, fs[1], bfs[1]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface I     { I test(); }
     interface J : I { J test(); }
@@ -4383,13 +4383,13 @@ template TemplateOf(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Foo(T, U) {}
     static assert(__traits(isSame, TemplateOf!(Foo!(int, real)), Foo));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     template Foo1(A) {}
     template Foo2(A, B) {}
@@ -4413,7 +4413,7 @@ template TemplateOf(T)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18214
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(TemplateOf!(int[]) == void));
     static assert(is(TemplateOf!bool == void));
@@ -4434,7 +4434,7 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -4442,7 +4442,7 @@ template TemplateArgsOf(T : Base!Args, alias Base, Args...)
     static assert(is(TemplateArgsOf!(Foo!(int, real)) == AliasSeq!(int, real)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     template Foo1(A) {}
     template Foo2(A, B) {}
@@ -4492,7 +4492,7 @@ template classInstanceAlignment(T) if (is(T == class))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class A { byte b; }
     class B { long l; }
@@ -4539,14 +4539,14 @@ template CommonType(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias X = CommonType!(int, long, short);
     assert(is(X == long));
     alias Y = CommonType!(int, char[], short);
     assert(is(Y == void));
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(CommonType!(3) == int));
     static assert(is(CommonType!(double, 4, float) == double));
@@ -4634,7 +4634,7 @@ template ImplicitConversionTargets(T)
         alias ImplicitConversionTargets = AliasSeq!();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ImplicitConversionTargets!(double)[0] == real));
     static assert(is(ImplicitConversionTargets!(string)[0] == const(char)[]));
@@ -4655,7 +4655,7 @@ template isImplicitlyConvertible(From, To)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isImplicitlyConvertible!(immutable(char), char));
     static assert( isImplicitlyConvertible!(const(char), char));
@@ -4681,7 +4681,7 @@ If you omit $(D Rhs), $(D isAssignable) will check identity assignable of $(D Lh
 enum isAssignable(Lhs, Rhs = Lhs) = isRvalueAssignable!(Lhs, Rhs) && isLvalueAssignable!(Lhs, Rhs);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isAssignable!(long, int));
     static assert(!isAssignable!(int, long));
@@ -4701,7 +4701,7 @@ private enum isRvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, lvalueOf!Lh
 // ditto
 private enum isLvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, lvalueOf!Lhs = lvalueOf!Rhs);
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!isAssignable!(immutable int, int));
     static assert( isAssignable!(int, immutable int));
@@ -4789,7 +4789,7 @@ package template isBlitAssignable(T)
         enum isBlitAssignable = isMutable!T;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isBlitAssignable!int);
     static assert(!isBlitAssignable!(const int));
@@ -4876,7 +4876,7 @@ private template isStorageClassImplicitlyConvertible(From, To)
             ModifyTypePreservingTQ!(Pointify,   To) );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isStorageClassImplicitlyConvertible!(          int, const int));
     static assert( isStorageClassImplicitlyConvertible!(immutable int, const int));
@@ -5003,7 +5003,7 @@ template isCovariantWith(F, G)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface I { I clone(); }
     interface J { J clone(); }
@@ -5023,7 +5023,7 @@ template isCovariantWith(F, G)
     static assert(!isCovariantWith!(typeof(C.clone), typeof(J.clone)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum bool isCovariantWith(alias f, alias g) = .isCovariantWith!(typeof(f), typeof(g));
 
@@ -5124,7 +5124,7 @@ int i = rvalueOf!int; // error, no actual value is returned
 // Note: unittest can't be used as an example here as function overloads
 // aren't allowed inside functions.
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     void needLvalue(T)(ref T);
     static struct S { }
@@ -5177,7 +5177,7 @@ template BooleanTypeOf(T)
         static assert(0, T.stringof~" is not boolean type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // unexpected failure, maybe dmd type-merging bug
     static foreach (T; AliasSeq!bool)
@@ -5195,7 +5195,7 @@ template BooleanTypeOf(T)
         }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct B
     {
@@ -5229,7 +5229,7 @@ template IntegralTypeOf(T)
         static assert(0, T.stringof~" is not an integral type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; IntegralTypeList)
         static foreach (Q; TypeQualifierList)
@@ -5264,7 +5264,7 @@ template FloatingPointTypeOf(T)
         static assert(0, T.stringof~" is not a floating point type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; FloatingPointTypeList)
         static foreach (Q; TypeQualifierList)
@@ -5293,7 +5293,7 @@ template NumericTypeOf(T)
         static assert(0, T.stringof~" is not a numeric type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; NumericTypeList)
         static foreach (Q; TypeQualifierList)
@@ -5354,7 +5354,7 @@ template CharTypeOf(T)
         static assert(0, T.stringof~" is not a character type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; CharTypeList)
         static foreach (Q; TypeQualifierList)
@@ -5393,7 +5393,7 @@ template StaticArrayTypeOf(T)
         static assert(0, T.stringof~" is not a static array type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(bool, NumericTypeList, /*ImaginaryTypeList, ComplexTypeList*/))
         static foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
@@ -5430,7 +5430,7 @@ template DynamicArrayTypeOf(T)
         static assert(0, T.stringof~" is not a dynamic array");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(/*void, */bool, NumericTypeList, /*ImaginaryTypeList, ComplexTypeList*/))
         static foreach (Q; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
@@ -5485,7 +5485,7 @@ template StringTypeOf(T)
         static assert(0, T.stringof~" is not a string type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; CharTypeList)
         static foreach (Q; AliasSeq!(MutableOf, ConstOf, ImmutableOf, InoutOf))
@@ -5509,7 +5509,7 @@ template StringTypeOf(T)
         }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(StringTypeOf!(char[4]) == char[]));
 }
@@ -5531,7 +5531,7 @@ template AssocArrayTypeOf(T)
         static assert(0, T.stringof~" is not an associative array type");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int/*bool, CharTypeList, NumericTypeList, ImaginaryTypeList, ComplexTypeList*/))
         static foreach (P; AliasSeq!(TypeQualifierList, InoutOf, SharedInoutOf))
@@ -5577,7 +5577,7 @@ template BuiltinTypeOf(T)
 enum bool isBoolean(T) = is(BooleanTypeOf!T) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isBoolean!bool);
     enum EB : bool { a = true }
@@ -5585,7 +5585,7 @@ enum bool isBoolean(T) = is(BooleanTypeOf!T) && !isAggregateType!T;
     static assert(!isBoolean!(SubTypeOf!bool));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S(T)
     {
@@ -5602,7 +5602,7 @@ enum bool isBoolean(T) = is(BooleanTypeOf!T) && !isAggregateType!T;
 enum bool isIntegral(T) = is(IntegralTypeOf!T) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         isIntegral!byte &&
@@ -5629,7 +5629,7 @@ enum bool isIntegral(T) = is(IntegralTypeOf!T) && !isAggregateType!T;
     static assert(!isIntegral!S);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; IntegralTypeList)
     {
@@ -5659,7 +5659,7 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !(is(Unqual!T == cfloa
                                                             is(Unqual!T == ireal));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         isFloatingPoint!float &&
@@ -5687,7 +5687,7 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !(is(Unqual!T == cfloa
     static assert(!isFloatingPoint!S);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum EF : real { a = 1.414, b = 1.732, c = 2.236 }
 
@@ -5709,7 +5709,7 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !(is(Unqual!T == cfloa
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17195
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!isFloatingPoint!cfloat);
     static assert(!isFloatingPoint!cdouble);
@@ -5730,7 +5730,7 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == bool) ||
                                                         is(Unqual!T == dchar));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         isNumeric!byte &&
@@ -5762,7 +5762,7 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == bool) ||
     static assert(!isIntegral!S);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(NumericTypeList))
     {
@@ -5788,7 +5788,7 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(Unqual!T == bool) ||
 enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!isScalarType!void);
     static assert( isScalarType!(immutable(byte)));
@@ -5804,7 +5804,7 @@ enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
     static assert( isScalarType!(const(real)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S(T)
     {
@@ -5820,7 +5820,7 @@ enum bool isScalarType(T) = is(T : real) && !isAggregateType!T;
 enum bool isBasicType(T) = isScalarType!T || is(Unqual!T == void);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isBasicType!void);
     static assert(isBasicType!(const(void)));
@@ -5846,7 +5846,7 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
                                                        is(Unqual!T == bool));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         isUnsigned!uint &&
@@ -5863,7 +5863,7 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
     );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(UnsignedIntTypeList))
     {
@@ -5888,7 +5888,7 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(Unqual!T == char) ||
 enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         isSigned!int &&
@@ -5901,7 +5901,7 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
     );
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum E { e1 = 0 }
     static assert(isSigned!E);
@@ -5927,7 +5927,7 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17196
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isUnsigned!bool == false);
     static assert(isSigned!bool == false);
@@ -5942,7 +5942,7 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
 enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Char types
     static assert( isSomeChar!char);
@@ -5961,7 +5961,7 @@ enum bool isSomeChar(T) = is(CharTypeOf!T) && !isAggregateType!T;
     static assert(!isSomeChar!(char[4]));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum EC : char { a = 'x', b = 'y' }
 
@@ -5995,7 +5995,7 @@ built-in string types.
 enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStaticArray!T && !is(T == enum);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //String types
     static assert( isSomeString!string);
@@ -6022,7 +6022,7 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
     static assert(!isSomeString!Stringish);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(char[], dchar[], string, wstring, dstring))
     {
@@ -6040,7 +6040,7 @@ enum bool isSomeString(T) = is(StringTypeOf!T) && !isAggregateType!T && !isStati
 enum bool isNarrowString(T) = isSomeString!T && !is(T : const dchar[]);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isNarrowString!string);
     static assert(isNarrowString!wstring);
@@ -6064,7 +6064,7 @@ enum bool isNarrowString(T) = isSomeString!T && !is(T : const dchar[]);
     static assert(!isNarrowString!Stringish);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(char[], string, wstring))
     {
@@ -6092,7 +6092,7 @@ enum bool isNarrowString(T) = isSomeString!T && !is(T : const dchar[]);
 enum bool isOrderingComparable(T) = ifTestable!(T, unaryFun!"a < a");
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isOrderingComparable!int);
     static assert(isOrderingComparable!string);
@@ -6115,7 +6115,7 @@ enum bool isOrderingComparable(T) = ifTestable!(T, unaryFun!"a < a");
 /// ditto
 enum bool isEqualityComparable(T) = ifTestable!(T, unaryFun!"a == a");
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isEqualityComparable!int);
     static assert(isEqualityComparable!string);
@@ -6140,7 +6140,7 @@ enum bool isEqualityComparable(T) = ifTestable!(T, unaryFun!"a == a");
 
 version(TestComplex)
 deprecated
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isEqualityComparable!creal);
 }
@@ -6176,7 +6176,7 @@ template isConvertibleToString(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct AliasedString
     {
@@ -6193,7 +6193,7 @@ template isConvertibleToString(T)
     assert(!isConvertibleToString!(char[]));
 }
 
-@safe unittest // Bugzilla 16573
+version(StdUnittest) @safe unittest // Bugzilla 16573
 {
     enum I : int { foo = 1 }
     enum S : string { foo = "foo" }
@@ -6228,7 +6228,7 @@ package template convertToString(T)
 enum bool isAutodecodableString(T) = (is(T : const char[]) || is(T : const wchar[])) && !isStaticArray!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct Stringish
     {
@@ -6246,7 +6246,7 @@ enum bool isAutodecodableString(T) = (is(T : const char[]) || is(T : const wchar
 enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isStaticArray!(int[3]));
     static assert( isStaticArray!(const(int)[5]));
@@ -6262,7 +6262,7 @@ enum bool isStaticArray(T) = __traits(isStaticArray, T);
     static assert(!isStaticArray!int);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int[51], int[][2],
                            char[][int][11], immutable char[13u],
@@ -6285,7 +6285,7 @@ enum bool isStaticArray(T) = __traits(isStaticArray, T);
 enum bool isDynamicArray(T) = is(DynamicArrayTypeOf!T) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isDynamicArray!(int[]));
     static assert( isDynamicArray!(string));
@@ -6295,7 +6295,7 @@ enum bool isDynamicArray(T) = is(DynamicArrayTypeOf!T) && !isAggregateType!T;
     static assert(!isDynamicArray!(typeof(null)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(int[], char[], string, long[3][], double[string][]))
@@ -6315,7 +6315,7 @@ enum bool isDynamicArray(T) = is(DynamicArrayTypeOf!T) && !isAggregateType!T;
 enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isArray!(int[]));
     static assert( isArray!(int[5]));
@@ -6326,7 +6326,7 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
     static assert(!isArray!(typeof(null)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     static foreach (T; AliasSeq!(int[], int[5], void[]))
@@ -6344,7 +6344,7 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
  */
 enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Foo
     {
@@ -6376,7 +6376,7 @@ enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 enum bool isBuiltinType(T) = is(BuiltinTypeOf!T) && !isAggregateType!T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C;
     union U;
@@ -6399,7 +6399,7 @@ enum bool isBuiltinType(T) = is(BuiltinTypeOf!T) && !isAggregateType!T;
  */
 enum bool isSIMDVector(T) = is(T : __vector(V[N]), V, size_t N);
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static if (is(__vector(float[4])))
     {
@@ -6416,7 +6416,7 @@ enum bool isSIMDVector(T) = is(T : __vector(V[N]), V, size_t N);
  */
 enum bool isPointer(T) = is(T == U*, U) && !isAggregateType!T;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static foreach (T; AliasSeq!(int*, void*, char[]*))
     {
@@ -6439,7 +6439,7 @@ Returns the target type of a pointer.
 alias PointerTarget(T : T*) = T;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(PointerTarget!(int*) == int));
     static assert(is(PointerTarget!(void*) == void));
@@ -6452,7 +6452,7 @@ enum bool isAggregateType(T) = is(T == struct) || is(T == union) ||
                                is(T == class) || is(T == interface);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C;
     union U;
@@ -6480,7 +6480,7 @@ enum bool isAggregateType(T) = is(T == struct) || is(T == union) ||
 enum bool isIterable(T) = is(typeof({ foreach (elem; T.init) {} }));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct OpApply
     {
@@ -6509,7 +6509,7 @@ enum bool isIterable(T) = is(typeof({ foreach (elem; T.init) {} }));
 enum bool isMutable(T) = !is(T == const) && !is(T == immutable) && !is(T == inout);
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert( isMutable!int);
     static assert( isMutable!string);
@@ -6536,7 +6536,7 @@ template isInstanceOf(alias S, alias T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct Foo(T...) { }
     static struct Bar(T...) { }
@@ -6559,7 +6559,7 @@ template isInstanceOf(alias S, alias T)
  * To use `isInstanceOf` to check the identity of a template while inside of said
  * template, use $(LREF TemplateOf).
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct A(T = void)
     {
@@ -6579,7 +6579,7 @@ template isInstanceOf(alias S, alias T)
     static assert( __traits(compiles, a1.method(a3)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void fun1(T)() { }
     static void fun2(T)() { }
@@ -6610,7 +6610,7 @@ template isExpressions(T ...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isExpressions!(1, 2.0, "a"));
     static assert(!isExpressions!(int, double, string));
@@ -6623,7 +6623,7 @@ template isExpressions(T ...)
 
 alias isExpressionTuple = isExpressions;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     void foo();
     static int bar() { return 42; }
@@ -6660,14 +6660,14 @@ template isTypeTuple(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isTypeTuple!(int, float, string));
     static assert(!isTypeTuple!(1, 2.0, "a"));
     static assert(!isTypeTuple!(1, double, string));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C {}
     void func(int) {}
@@ -6704,7 +6704,7 @@ template isFunctionPointer(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void foo() {}
     void bar() {}
@@ -6743,7 +6743,7 @@ template isDelegate(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void sfunc() { }
     int x;
@@ -6783,7 +6783,7 @@ template isSomeFunction(T...)
         enum bool isSomeFunction = false;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static real func(ref int) { return 0; }
     static void prop() @property { }
@@ -6838,7 +6838,7 @@ template isCallable(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     interface I { real value() @property; }
     struct S { static int opCall(int) { return 0; } }
@@ -6864,7 +6864,7 @@ template isAbstractFunction(T...)
     enum bool isAbstractFunction = __traits(isAbstractFunction, T[0]);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S { void foo() { } }
     class C { void foo() { } }
@@ -6885,7 +6885,7 @@ template isFinalFunction(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S { void bar() { } }
     final class FC { void foo(); }
@@ -6909,7 +6909,7 @@ template isNestedFunction(alias f)
     enum isNestedFunction = __traits(isNested, f);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void f() { }
     void g() { }
@@ -6927,7 +6927,7 @@ template isAbstractClass(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S { }
     class C { }
@@ -6951,7 +6951,7 @@ template isFinalClass(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C { }
     abstract class AC { }
@@ -6999,7 +6999,7 @@ template Unqual(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Unqual!int == int));
     static assert(is(Unqual!(const int) == int));
@@ -7008,7 +7008,7 @@ template Unqual(T)
     static assert(is(Unqual!(shared(const int)) == int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Unqual!(                   int) == int));
     static assert(is(Unqual!(             const int) == int));
@@ -7038,7 +7038,7 @@ package template ModifyTypePreservingTQ(alias Modifier, T)
     else                                             alias ModifyTypePreservingTQ =                    Modifier!T;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Intify(T) = int;
     static assert(is(ModifyTypePreservingTQ!(Intify,                    real) ==                    int));
@@ -7070,12 +7070,12 @@ template CopyTypeQualifiers(FromType, ToType)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(CopyTypeQualifiers!(inout const real, int) == inout const int));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(CopyTypeQualifiers!(                   real, int) ==                    int));
     static assert(is(CopyTypeQualifiers!(             const real, int) ==              const int));
@@ -7102,7 +7102,7 @@ template CopyConstness(FromType, ToType)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     const(int) i;
     CopyConstness!(typeof(i), float) f;
@@ -7126,7 +7126,7 @@ template CopyConstness(FromType, ToType)
     assert( is(CstT == const(int)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Test
     {
@@ -7142,13 +7142,13 @@ template CopyConstness(FromType, ToType)
     assert(is(CopyConstness!(typeof(Test.method3), string) == immutable(string)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(is(CopyConstness!(inout(int)[], int[]) == int[]));
     assert(is(CopyConstness!(inout(int[]), int[]) == inout(int[])));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(CopyConstness!(                   int, real) ==             real));
     static assert(is(CopyConstness!(const              int, real) ==       const real));
@@ -7182,7 +7182,7 @@ template ForeachType(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(ForeachType!(uint[]) == uint));
     static assert(is(ForeachType!string == immutable(char)));
@@ -7206,7 +7206,7 @@ template OriginalType(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum E : real { a }
     enum F : E    { a = E.a }
@@ -7222,7 +7222,7 @@ template OriginalType(T)
 alias KeyType(V : V[K], K) = K;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Hash = int[string];
     static assert(is(KeyType!Hash == string));
@@ -7237,7 +7237,7 @@ alias KeyType(V : V[K], K) = K;
 alias ValueType(V : V[K], K) = V;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Hash = int[string];
     static assert(is(KeyType!Hash == string));
@@ -7274,7 +7274,7 @@ template Unsigned(T)
     alias Unsigned = ModifyTypePreservingTQ!(Impl, OriginalType!T);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias U1 = Unsigned!int;
     alias U2 = Unsigned!(const(int));
@@ -7332,7 +7332,7 @@ template Largest(T...) if (T.length >= 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Largest!(uint, ubyte, ushort, real) == real));
     static assert(is(Largest!(ulong, double) == ulong));
@@ -7371,7 +7371,7 @@ template Signed(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias S1 = Signed!uint;
     static assert(is(S1 == int));
@@ -7386,7 +7386,7 @@ template Signed(T)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(is(Signed!float == float));
     static if (is(__vector(int[4])) && is(__vector(uint[4])))
@@ -7414,7 +7414,7 @@ template mostNegative(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(mostNegative!float == -float.max);
     static assert(mostNegative!double == -double.max);
@@ -7423,7 +7423,7 @@ template mostNegative(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -7445,7 +7445,7 @@ template Promoted(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     ubyte a = 3, b = 5;
     static assert(is(typeof(a * b) == Promoted!ubyte));
@@ -7456,7 +7456,7 @@ template Promoted(T)
     static assert(is(Promoted!double == double));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // promote to int:
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, char, wchar))
@@ -7491,7 +7491,7 @@ template mangledName(sth...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq;
     alias TL = staticMap!(mangledName, int, const int, immutable int);
@@ -7500,7 +7500,7 @@ template mangledName(sth...)
 
 version(StdUnittest) void freeFunc(string);
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C { int value() @property { return 0; } }
     static assert(mangledName!int == int.mangleof);
@@ -7516,7 +7516,7 @@ version(StdUnittest) void freeFunc(string);
     static assert(mangledName!((int a) { return a+x; }) == "DFNbNiNfiZi");  // nothrow @safe @nnogc
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to demangle
     // Test for bug 5718
@@ -7546,7 +7546,7 @@ template Select(bool condition, T...) if (T.length == 2)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // can select types
     static assert(is(Select!(true, int, long) == int));
@@ -7575,7 +7575,7 @@ A select(bool cond : true, A, B)(A a, lazy B b) { return a; }
 /// Ditto
 B select(bool cond : false, A, B)(lazy A a, B b) { return b; }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     real pleasecallme() { return 0; }
     int dontcallme() { assert(0); }
@@ -7598,7 +7598,7 @@ template hasUDA(alias symbol, alias attribute)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum E;
     struct S {}
@@ -7705,7 +7705,7 @@ template getUDAs(alias symbol, alias attribute)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Attr
     {
@@ -7891,7 +7891,7 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Attr;
 
@@ -7956,7 +7956,7 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 // Issue 18314
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum attr1;
     enum attr2;
@@ -7979,7 +7979,7 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 // #15335: getSymbolsByUDA fails if type has private members
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // HasPrivateMembers has, well, private members, one of which has a UDA.
     import std.internal.test.uda : Attr, HasPrivateMembers;
@@ -7990,7 +7990,7 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Attr;
     struct A
@@ -8006,7 +8006,7 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 // #16387: getSymbolsByUDA works with structs but fails with classes
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum Attr;
     class A
@@ -8035,7 +8035,7 @@ template allSameType(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(allSameType!(int, int));
     static assert(allSameType!(int, int, int));
@@ -8052,7 +8052,7 @@ template allSameType(T...)
 */
 enum ifTestable(T, alias pred = a => a) = __traits(compiles, { if (pred(T.init)) {} });
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.meta : AliasSeq, allSatisfy;
     static assert(allSatisfy!(ifTestable, AliasSeq!(bool, int, float, double, string)));
@@ -8073,7 +8073,7 @@ template isType(X...) if (X.length == 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S {
         template Test() {}
@@ -8128,7 +8128,7 @@ template isFunction(X...) if (X.length == 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static void func(){}
     static assert(isFunction!func);
@@ -8157,7 +8157,7 @@ template isFinal(X...) if (X.length == 1)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C
     {
@@ -8191,7 +8191,7 @@ enum isCopyable(S) = is(typeof(
 ));
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct S1 {}                        // Fine. Can be copied
     struct S2 {         this(this) {}}  // Fine. Can be copied

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -73,7 +73,7 @@ import std.meta; // : AliasSeq, allSatisfy;
 import std.traits;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // value tuples
     alias Coord = Tuple!(int, "x", int, "y", int, "z");
@@ -247,7 +247,7 @@ private:
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct S
     {
@@ -282,7 +282,7 @@ private:
     assert(u1.isEmpty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // test conversion to base ref
     int deleted = 0;
@@ -307,7 +307,7 @@ private:
     assert(deleted == 2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Bar
     {
@@ -329,7 +329,7 @@ private:
     assert(!ub2.isEmpty);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface Bar
     {
@@ -371,7 +371,7 @@ private:
     assert(BarImpl.count == 0);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Foo
     {
@@ -396,7 +396,7 @@ private:
 }
 
 // ensure Unique behaves correctly through const access paths
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Bar {int val;}
     struct Foo
@@ -435,7 +435,7 @@ private enum bool distinctFieldNames(names...) = __traits(compiles,
             mixin("enum int" ~ name ~ " = 0;");
 });
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(!distinctFieldNames!(string, "abc", string, "abc"));
     static assert(distinctFieldNames!(string, "abc", int, "abd"));
@@ -587,7 +587,7 @@ if (distinctFieldNames!(Specs))
         alias Types = staticMap!(extractType, fieldSpecs);
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             alias Fields = Tuple!(int, "id", string, float);
             static assert(is(Fields.Types == AliasSeq!(int, string, float)));
@@ -599,7 +599,7 @@ if (distinctFieldNames!(Specs))
         alias fieldNames = staticMap!(extractName, fieldSpecs);
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             alias Fields = Tuple!(int, "id", string, float);
             static assert(Fields.fieldNames == AliasSeq!("id", "", ""));
@@ -615,7 +615,7 @@ if (distinctFieldNames!(Specs))
         mixin(injectNamedFields());
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             auto t1 = tuple(1, " hello ", 'a');
             assert(t1.toString() == `Tuple!(int, string, char)(1, " hello ", 'a')`);
@@ -673,7 +673,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             alias ISD = Tuple!(int, string, double);
             auto tup = ISD(1, "test", 3.2);
@@ -697,7 +697,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             int[2] ints;
             Tuple!(int, int) t = ints;
@@ -720,7 +720,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             alias IntVec = Tuple!(int, int, int);
             alias DubVec = Tuple!(double, double, double);
@@ -767,7 +767,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             Tuple!(int, string) t1 = tuple(1, "test");
             Tuple!(double, string) t2 =  tuple(1.0, "test");
@@ -823,7 +823,7 @@ if (distinctFieldNames!(Specs))
             The first `v1` for which `v1 > v2` is true determines
             the result. This could lead to unexpected behaviour.
          */
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             auto tup1 = tuple(1, 1, 1);
             auto tup2 = tuple(1, 100, 100);
@@ -913,7 +913,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             auto t0 = tuple(4, "hello");
 
@@ -1012,7 +1012,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             //replacing names by their current name
 
@@ -1032,7 +1032,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             //replace names by their position
 
@@ -1052,7 +1052,7 @@ if (distinctFieldNames!(Specs))
             assert(t2Named.c == 3);
         }
 
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             //check that empty translations work fine
             enum string[string] a0 = null;
@@ -1096,7 +1096,7 @@ if (distinctFieldNames!(Specs))
         }
 
         ///
-        static if (Specs.length == 0) @safe unittest
+        version(StdUnittest) static if (Specs.length == 0) @safe unittest
         {
             Tuple!(int, string, float, double) a;
             a[1] = "abc";
@@ -1260,7 +1260,7 @@ if (distinctFieldNames!(Specs))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Tuple!(int, int) point;
     // assign coordinates
@@ -1275,7 +1275,7 @@ if (distinctFieldNames!(Specs))
     `Tuple` members can be named. It is legal to mix named and unnamed
     members. The method above is still applicable to all fields.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias Entry = Tuple!(int, "index", string, "value");
     Entry e;
@@ -1291,7 +1291,7 @@ if (distinctFieldNames!(Specs))
     `Tuple`s differing in naming only are still distinct, even though they
     might have the same structure.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Tuple!(int, "x", int, "y") point1;
     Tuple!(int, int) point2;
@@ -1299,7 +1299,7 @@ if (distinctFieldNames!(Specs))
 }
 
 /// Use tuples as ranges
-unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : sum;
     import std.range : only;
@@ -1307,7 +1307,7 @@ unittest
     assert(t.expand.only.sum == 3);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 4582
     static assert(!__traits(compiles, Tuple!(string, "id", int, "id")));
@@ -1339,7 +1339,7 @@ auto reverse(T)(T t)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto tup = tuple(1, "2");
     assert(tup.reverse == tuple("2", 1));
@@ -1374,12 +1374,12 @@ private template ReverseTupleSpecs(T...)
 }
 
 // ensure that internal Tuple unittests are compiled
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Tuple!() t;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv;
     {
@@ -1558,7 +1558,7 @@ private template ReverseTupleSpecs(T...)
         assert(rev.x == 3 && rev.y == "4");
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // opEquals
     {
@@ -1653,7 +1653,7 @@ private template ReverseTupleSpecs(T...)
         assert(t2[0] == 1 && t2[1] == 2);
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto t1 = Tuple!(int, "x", string, "y")(1, "a");
     assert(t1.x == 1);
@@ -1668,7 +1668,7 @@ private template ReverseTupleSpecs(T...)
     static assert(is(typeof(Tuple!(int, "x", string, "y").tupleof) ==
                      typeof(Tuple!(int,      string     ).tupleof)));
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 10686
     immutable Tuple!(int) t1;
@@ -1676,7 +1676,7 @@ private template ReverseTupleSpecs(T...)
     immutable Tuple!(int, "x") t2;
     auto r2 = t2[0]; // error
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : assertCTFEable;
 
@@ -1687,13 +1687,13 @@ private template ReverseTupleSpecs(T...)
         t = tuple(2);   // assignment
     });
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class Foo{}
     Tuple!(immutable(Foo)[]) a;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Test non-assignable
     static struct S
@@ -1716,7 +1716,7 @@ private template ReverseTupleSpecs(T...)
 }
 
 // Bugzilla #9819
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias T = Tuple!(int, "x", double, "foo");
     static assert(T.fieldNames[0] == "x");
@@ -1727,7 +1727,7 @@ private template ReverseTupleSpecs(T...)
 }
 
 // Bugzilla 13837
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // New behaviour, named arguments.
     static assert(is(
@@ -1760,7 +1760,7 @@ private template ReverseTupleSpecs(T...)
     static assert(!__traits(compiles, tuple!("x", int)(2)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C {}
     Tuple!(Rebindable!(const C)) a;
@@ -1768,14 +1768,14 @@ private template ReverseTupleSpecs(T...)
     a = b;
 }
 
-@nogc @safe unittest
+version(StdUnittest) @nogc @safe unittest
 {
     alias T = Tuple!(string, "s");
     T x;
     x = T.init;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format, FormatException;
     import std.exception : assertThrown;
@@ -1816,13 +1816,13 @@ private template ReverseTupleSpecs(T...)
 }
 
 // Issue 17803, parte uno
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = tuple(3, "foo");
     assert(__traits(compiles, { a = (a = a); }));
 }
 // Ditto
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Tuple!(int[]) a, b, c;
     a = tuple([0, 1, 2]);
@@ -1892,7 +1892,7 @@ template tuple(Names...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto value = tuple(5, 6.7, "hello");
     assert(value[0] == 5);
@@ -1921,7 +1921,7 @@ enum isTuple(T) = __traits(compiles,
                            } );
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isTuple!(Tuple!()));
     static assert(isTuple!(Tuple!(int)));
@@ -1930,7 +1930,7 @@ enum isTuple(T) = __traits(compiles,
     static assert(isTuple!(Tuple!(int, Tuple!(real), string)));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(isTuple!(const Tuple!(int)));
     static assert(isTuple!(immutable Tuple!(int)));
@@ -2027,7 +2027,7 @@ template Rebindable(T)
 }
 
 ///Regular $(D const) object references cannot be reassigned.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class Widget { int x; int y() @safe const { return x; } }
     const a = new Widget;
@@ -2043,7 +2043,7 @@ template Rebindable(T)
     However, $(D Rebindable!(Widget)) does allow reassignment,
     while otherwise behaving exactly like a $(D const Widget).
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class Widget { int x; int y() const @safe { return x; } }
     auto a = Rebindable!(const Widget)(new Widget);
@@ -2055,7 +2055,7 @@ template Rebindable(T)
     a = new Widget;
 }
 
-@safe unittest // issue 16054
+version(StdUnittest) @safe unittest // issue 16054
 {
     Rebindable!(immutable Object) r;
     static assert(__traits(compiles, r.get()));
@@ -2097,7 +2097,7 @@ Rebindable!T rebindable(T)(Rebindable!T obj)
     return obj;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface CI { int foo() const; }
     class C : CI {
@@ -2216,7 +2216,7 @@ template UnqualRef(T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Data {}
 
@@ -2237,7 +2237,7 @@ template UnqualRef(T)
     assert(b is null);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     class C { }
     alias T = UnqualRef!(const shared C);
@@ -2289,14 +2289,14 @@ string alignForSize(E...)(const char[][] names...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct Banner {
         mixin(alignForSize!(byte[6], double)(["name", "height"]));
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     enum x = alignForSize!(int[], char[3], short, double[5])("x", "y","z", "w");
     struct Foo { int x; }
@@ -2314,7 +2314,7 @@ string alignForSize(E...)(const char[][] names...)
 }
 
 // Issue 12914
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     immutable string[] fieldNames = ["x", "y"];
     struct S
@@ -2388,7 +2388,7 @@ Params:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         Nullable!int empty;
         Nullable!int a = 42;
@@ -2409,7 +2409,7 @@ Params:
         assert(c != 42);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // Test constness
         immutable Nullable!int a = 42;
@@ -2431,7 +2431,7 @@ Params:
     }
 
     // Issue 17482
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.variant : Variant;
         Nullable!Variant a = Variant(12);
@@ -2482,7 +2482,7 @@ Returns:
     }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Nullable!int ni;
     assert(ni.isNull);
@@ -2492,7 +2492,7 @@ Returns:
 }
 
 // Issue 14940
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : appender;
     import std.format : formattedWrite;
@@ -2516,7 +2516,7 @@ Forces $(D this) to the null state.
     }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Nullable!int ni = 0;
     assert(!ni.isNull);
@@ -2547,7 +2547,7 @@ Params:
     the version of `Nullable` that takes an additional `nullValue`
     template argument.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Passes
     Nullable!(int*) npi;
@@ -2584,7 +2584,7 @@ Returns:
     }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.exception : assertThrown, assertNotThrown;
@@ -2602,7 +2602,7 @@ Returns:
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     int i = 42;
     Nullable!int ni2;
@@ -2628,7 +2628,7 @@ auto nullable(T)(T t)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct CustomerRecord
     {
@@ -2660,7 +2660,7 @@ auto nullable(T)(T t)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -2673,7 +2673,7 @@ auto nullable(T)(T t)
     assertThrown!Throwable(a.get);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -2696,14 +2696,14 @@ auto nullable(T)(T t)
     a.nullify();
     assertThrown!Throwable(a += 2);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto k = Nullable!int(74);
     assert(k == 74);
     k.nullify();
     assert(k.isNull);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static int f(in Nullable!int x) {
         return x.isNull ? 42 : x.get;
@@ -2715,7 +2715,7 @@ auto nullable(T)(T t)
     a.nullify();
     assert(f(a) == 42);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -2731,7 +2731,7 @@ auto nullable(T)(T t)
     s.nullify();
     assertThrown!Throwable(s.x = 9441);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Ensure Nullable can be used in pure/nothrow/@safe environment.
     function() @safe pure nothrow
@@ -2745,7 +2745,7 @@ auto nullable(T)(T t)
         assert(n.isNull);
     }();
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Ensure Nullable can be used when the value is not pure/nothrow/@safe
     static struct S
@@ -2762,7 +2762,7 @@ auto nullable(T)(T t)
     s.nullify();
     assert(s.isNull);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzilla 9404
     alias N = Nullable!int;
@@ -2775,7 +2775,7 @@ auto nullable(T)(T t)
     N n;
     foo(n);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Check nullable immutable is constructable
     {
@@ -2790,7 +2790,7 @@ auto nullable(T)(T t)
         auto i = a2.get;
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias NInt   = Nullable!int;
 
@@ -2833,7 +2833,7 @@ auto nullable(T)(T t)
         assert(b3.isNull);
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Check nullable is nicelly embedable in a struct
     static struct S1
@@ -2860,7 +2860,7 @@ auto nullable(T)(T t)
         c = a;
     }}
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 10268
     import std.json;
@@ -2911,13 +2911,13 @@ auto nullable(T)(T t)
         assert(*x4.val == 10);
     }
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Bugzila 10357
     import std.datetime;
     Nullable!SysTime time = SysTime(0);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.array;
@@ -2956,7 +2956,7 @@ auto nullable(T)(T t)
 }
 
 // Bugzilla 14477
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct DisabledDefaultConstructor
     {
@@ -2969,7 +2969,7 @@ auto nullable(T)(T t)
 }
 
 // Issue 17440
-@system unittest
+version(StdUnittest) @system unittest
 {
     static interface I { }
 
@@ -3065,7 +3065,7 @@ Returns:
     }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Nullable!(int, -1) ni;
     //Initialized to "null" state
@@ -3077,7 +3077,7 @@ Returns:
 
 // https://issues.dlang.org/show_bug.cgi?id=11135
 // disable test until https://issues.dlang.org/show_bug.cgi?id=15316 gets fixed
-version (none) @system unittest
+version(StdUnittest) version (none) @system unittest
 {
     static foreach (T; AliasSeq!(float, double, real))
     {{
@@ -3103,7 +3103,7 @@ Forces $(D this) to the null state.
     }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Nullable!(int, -1) ni = 0;
     assert(!ni.isNull);
@@ -3136,7 +3136,7 @@ Params:
     recommended that this be avoided by using `T`'s "built in"
     null value for `nullValue`.
  */
-@system unittest
+version(StdUnittest) @system unittest
 {
     //Passes
     enum nullVal = cast(int*) 0xCAFEBABE;
@@ -3165,7 +3165,7 @@ Returns:
     }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown, assertNotThrown;
 
@@ -3193,7 +3193,7 @@ auto nullable(alias nullValue, T)(T t)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Nullable!(size_t, size_t.max) indexOf(string[] haystack, string needle)
     {
@@ -3224,7 +3224,7 @@ auto nullable(alias nullValue, T)(T t)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -3238,7 +3238,7 @@ auto nullable(alias nullValue, T)(T t)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto a = nullable!(int.min)(8);
     assert(a == 8);
@@ -3246,7 +3246,7 @@ auto nullable(alias nullValue, T)(T t)
     assert(a.isNull);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static int f(in Nullable!(int, int.min) x) {
         return x.isNull ? 42 : x.get;
@@ -3258,7 +3258,7 @@ auto nullable(alias nullValue, T)(T t)
     a.nullify();
     assert(f(a) == 42);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Ensure Nullable can be used in pure/nothrow/@safe environment.
     function() @safe pure nothrow
@@ -3272,7 +3272,7 @@ auto nullable(alias nullValue, T)(T t)
         assert(n.isNull);
     }();
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Ensure Nullable can be used when the value is not pure/nothrow/@system
     static struct S
@@ -3289,7 +3289,7 @@ auto nullable(alias nullValue, T)(T t)
     s.nullify();
     assert(s.isNull);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Check nullable is nicelly embedable in a struct
     static struct S1
@@ -3316,7 +3316,7 @@ auto nullable(alias nullValue, T)(T t)
         c = a;
     }}
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
 
@@ -3404,7 +3404,7 @@ Params:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         NullableRef!int nr = new int(42);
         assert(nr == 42);
@@ -3426,7 +3426,7 @@ Returns:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         NullableRef!int nr;
         assert(nr.isNull);
@@ -3445,7 +3445,7 @@ Forces $(D this) to the null state.
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         NullableRef!int nr = new int(42);
         assert(!nr.isNull);
@@ -3472,7 +3472,7 @@ Params:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.exception : assertThrown, assertNotThrown;
 
@@ -3498,7 +3498,7 @@ This function is also called for the implicit conversion to $(D T).
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.exception : assertThrown, assertNotThrown;
 
@@ -3525,7 +3525,7 @@ auto nullableRef(T)(T* t)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -3548,7 +3548,7 @@ auto nullableRef(T)(T* t)
     y = 135;
     assert(a == 135);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     static int f(in NullableRef!int x) {
         return x.isNull ? 42 : x.get;
@@ -3559,7 +3559,7 @@ auto nullableRef(T)(T* t)
     a.nullify();
     assert(f(a) == 42);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Ensure NullableRef can be used in pure/nothrow/@safe environment.
     function() @safe pure nothrow
@@ -3578,7 +3578,7 @@ auto nullableRef(T)(T* t)
         assert(n.isNull);
     }();
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Ensure NullableRef can be used when the value is not pure/nothrow/@safe
     static struct S
@@ -3598,7 +3598,7 @@ auto nullableRef(T)(T* t)
     s.nullify();
     assert(s.isNull);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Check nullable is nicelly embedable in a struct
     static struct S1
@@ -3625,7 +3625,7 @@ auto nullableRef(T)(T* t)
         c = a;
     }}
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
 
@@ -3679,7 +3679,7 @@ See_Also:
 alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFunction);
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.math : isNaN;
 
@@ -3702,7 +3702,7 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
     c.doSomething();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.math : isNaN;
 
@@ -3759,7 +3759,7 @@ See_Also:
 alias WhiteHole(Base) = AutoImplement!(Base, generateAssertTrap, isAbstractFunction);
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
 
@@ -3781,7 +3781,7 @@ class NotImplementedError : Error
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     // nothrow
@@ -4109,7 +4109,7 @@ private static:
 }
 
 //debug = SHOW_GENERATED_CODE;
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.vararg;
     // no function to implement
@@ -4224,7 +4224,7 @@ private static:
 }
 
 // Issue 17177 - AutoImplement fails on function overload sets with "cannot infer type from overloaded function symbol"
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class Issue17177
     {
@@ -4298,7 +4298,7 @@ version(StdUnittest)
         void bar(int a) { }
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto foo = new issue10647_DoNothing!issue10647_Foo();
     foo.bar(13);
@@ -4676,7 +4676,7 @@ if (is(T == class) || is(T == interface))
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C { @disable opCast(T)() {} }
     auto c = new C;
@@ -4937,7 +4937,7 @@ if (!isMutable!Target)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface Quack
     {
@@ -4998,7 +4998,7 @@ if (!isMutable!Target)
     assert(hz is h1);
 }
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.traits : FunctionAttribute, functionAttributes;
     interface A { int run(); }
@@ -5019,7 +5019,7 @@ if (!isMutable!Target)
     assert(b.status == 3);
     static assert(functionAttributes!(typeof(ab).status) & FunctionAttribute.property);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A
     {
@@ -5065,7 +5065,7 @@ if (!isMutable!Target)
         assert(d.draw(10) == 10);
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 10377
     import std.range, std.algorithm;
@@ -5082,7 +5082,7 @@ if (!isMutable!Target)
     auto r = iota(0,10,1).inputRangeObject().wrap!(MyInputRange!int)();
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 10536
     interface Interface
@@ -5098,7 +5098,7 @@ if (!isMutable!Target)
     Interface i = new Pluggable().wrap!Interface;
     assert(i.foo() == 1);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Enhancement 10538
     interface Interface
@@ -5116,7 +5116,7 @@ if (!isMutable!Target)
     assert(i.bar(10) == 100);
 }
 
-@system unittest // issue 12064
+version(StdUnittest) @system unittest // issue 12064
 {
     interface I
     {
@@ -5243,7 +5243,7 @@ version(StdUnittest)
         alias type = FunctionTypeOf!f;
     }
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A
     {
@@ -5339,7 +5339,7 @@ package template DerivedFunctionType(T...)
     else
         alias DerivedFunctionType = void;
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // attribute covariance
     alias int F1();
@@ -5733,7 +5733,7 @@ assert(refCountedStore.isInitialized)).
 }
 
 ///
-pure @system nothrow @nogc unittest
+version(StdUnittest) pure @system nothrow @nogc unittest
 {
     // A pair of an `int` and a `size_t` - the latter being the
     // reference count - will be dynamically allocated
@@ -5747,7 +5747,7 @@ pure @system nothrow @nogc unittest
     // the pair will be freed when rc1 and rc2 go out of scope
 }
 
-pure @system unittest
+version(StdUnittest) pure @system unittest
 {
     RefCounted!int* p;
     {
@@ -5786,7 +5786,7 @@ pure @system unittest
     assert(a.x._refCounted._store._count == 2, "BUG 4356 still unfixed");
 }
 
-pure @system nothrow @nogc unittest
+version(StdUnittest) pure @system nothrow @nogc unittest
 {
     import std.algorithm.mutation : swap;
 
@@ -5795,7 +5795,7 @@ pure @system nothrow @nogc unittest
 }
 
 // 6606
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     union U {
        size_t i;
@@ -5810,7 +5810,7 @@ pure @system nothrow @nogc unittest
 }
 
 // 6436
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     struct S { this(ref int val) { assert(val == 3); ++val; } }
 
@@ -5820,14 +5820,14 @@ pure @system nothrow @nogc unittest
 }
 
 // gc_addRange coverage
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     struct S { int* p; }
 
     auto s = RefCounted!S(null);
 }
 
-@system pure nothrow @nogc unittest
+version(StdUnittest) @system pure nothrow @nogc unittest
 {
     RefCounted!int a;
     a = 5; //This should not assert
@@ -5861,7 +5861,7 @@ RefCounted!(T, RefCountedAutoInitialize.no) refCounted(T)(T val)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct File
     {
@@ -6117,7 +6117,7 @@ mixin template Proxy(alias a)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct MyInt
     {
@@ -6142,7 +6142,7 @@ mixin template Proxy(alias a)
 }
 
 ///The proxied value must be an $(B lvalue).
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct NewIntType
     {
@@ -6181,7 +6181,7 @@ mixin template Proxy(alias a)
     functions are usable with the new type; they will be forwarded on to the
     proxied value.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.math;
 
@@ -6200,7 +6200,7 @@ mixin template Proxy(alias a)
     assert(!nf.isInfinity);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct MyInt
     {
@@ -6247,7 +6247,7 @@ mixin template Proxy(alias a)
         static assert(T.arr == [1,2,3]);
     }}
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct MyArray
     {
@@ -6287,7 +6287,7 @@ mixin template Proxy(alias a)
         }
     }}
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Foo
     {
@@ -6363,7 +6363,7 @@ mixin template Proxy(alias a)
     assert(h.tempfunc!int() == 0);
 }
 
-@system unittest // about Proxy inside a class
+version(StdUnittest) @system unittest // about Proxy inside a class
 {
     class MyClass
     {
@@ -6476,7 +6476,7 @@ mixin template Proxy(alias a)
     assert(hash[c] == 21);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     struct MyInt
     {
@@ -6513,7 +6513,7 @@ mixin template Proxy(alias a)
     MyFoo2 f2;
     f2 = f2;
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bug8613
     static struct Name
@@ -6528,7 +6528,7 @@ mixin template Proxy(alias a)
     bool* b = Name("a") in names;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // bug14213, using function for the payload
     static struct S
@@ -6550,7 +6550,7 @@ mixin template Proxy(alias a)
 // Check all floating point comparisons for both Proxy and Typedef,
 // also against int and a Typedef!int, to be as regression-proof
 // as possible. bug 15561
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static struct MyFloatImpl
     {
@@ -6714,7 +6714,7 @@ template TypedefType(T)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typecons : Typedef, TypedefType;
     import std.conv : to;
@@ -6739,7 +6739,7 @@ template TypedefType(T)
     static assert(MyIntInit() == 42);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Typedef!int x = 10;
     static assert(!__traits(compiles, { int y = x; }));
@@ -6801,7 +6801,7 @@ template TypedefType(T)
     assert(drange3[$] == 123);
 }
 
-@safe @nogc pure nothrow unittest // Bugzilla 11703
+version(StdUnittest) @safe @nogc pure nothrow unittest // Bugzilla 11703
 {
     alias I = Typedef!int;
     static assert(is(typeof(I.min) == I));
@@ -6816,7 +6816,7 @@ template TypedefType(T)
     assert(!is(typeof(F.im).stringof == double));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // bug8655
     import std.typecons;
@@ -6834,7 +6834,7 @@ template TypedefType(T)
     }
 }
 
-@safe unittest // Issue 12596
+version(StdUnittest) @safe unittest // Issue 12596
 {
     import std.typecons;
     alias TD = Typedef!int;
@@ -6843,7 +6843,7 @@ template TypedefType(T)
     assert(x == y);
 }
 
-@safe unittest // about toHash
+version(StdUnittest) @safe unittest // about toHash
 {
     import std.typecons;
     {
@@ -6901,7 +6901,7 @@ template TypedefType(T)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias String = Typedef!(char[]);
     alias CString = Typedef!(const(char)[]);
@@ -6988,7 +6988,7 @@ template scoped(T)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A
     {
@@ -7076,7 +7076,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     return (n + badEnd) & ~badEnd;
 }
 
-@system unittest // Issue 6580 testcase
+version(StdUnittest) @system unittest // Issue 6580 testcase
 {
     enum alignment = (void*).alignof;
 
@@ -7139,7 +7139,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     }
 }
 
-@system unittest // Original Issue 6580 testcase
+version(StdUnittest) @system unittest // Original Issue 6580 testcase
 {
     class C { int i; byte b; }
 
@@ -7148,7 +7148,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(cast(uint)&sa[1].i % int.alignof == 0); // fails
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A { int x = 1; }
     auto a1 = scoped!A();
@@ -7159,7 +7159,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(a1.x == 42);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A { int x = 1; this() { x = 2; } }
     auto a1 = scoped!A();
@@ -7170,7 +7170,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(a1.x == 42);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A { int x = 1; this(int y) { x = y; } ~this() {} }
     auto a1 = scoped!A(5);
@@ -7181,7 +7181,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(a1.x == 42);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class A { static bool dead; ~this() { dead = true; } }
     class B : A { static bool dead; ~this() { dead = true; } }
@@ -7192,7 +7192,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(A.dead, "asdasd");
 }
 
-@system unittest // Issue 8039 testcase
+version(StdUnittest) @system unittest // Issue 8039 testcase
 {
     static int dels;
     static struct S { ~this(){ ++dels; } }
@@ -7215,7 +7215,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(dels == 1+6);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // bug4500
     class A
@@ -7236,7 +7236,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(a1.check());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class A
     {
@@ -7259,13 +7259,13 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     auto abob = scoped!ABob();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static class A { this(int) {} }
     static assert(!__traits(compiles, scoped!A()));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static class A { @property inout(int) foo() inout { return 1; } }
 
@@ -7294,7 +7294,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     static assert(is(typeof(c3.foo) == immutable(int)));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C { this(ref int val) { assert(val == 3); ++val; } }
 
@@ -7303,7 +7303,7 @@ private uintptr_t _alignUp(uintptr_t alignment)(uintptr_t n)
     assert(val == 4);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     class C
     {
@@ -7420,7 +7420,7 @@ struct No
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     Flag!"abc" flag1;
     assert(flag1 == Flag!"abc".no);
@@ -7462,7 +7462,7 @@ template isBitFlagEnum(E)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     enum A
     {
@@ -7648,7 +7648,7 @@ public:
 }
 
 /// BitFlags can be manipulated with the usual operators
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     import std.traits : EnumMembers;
 
@@ -7812,7 +7812,7 @@ template ReplaceType(From, To, T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(
         is(ReplaceType!(int, string, int[]) == string[]) &&
@@ -7907,7 +7907,7 @@ private template replaceTypeInFunctionType(From, To, fun)
     mixin("alias replaceTypeInFunctionType = " ~ gen() ~ ";");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     template Test(Ts...)
     {
@@ -7995,7 +7995,7 @@ private template replaceTypeInFunctionType(From, To, fun)
     );
 }
 
-@safe unittest // Bugzilla 17116
+version(StdUnittest) @safe unittest // Bugzilla 17116
 {
     alias ConstDg = void delegate(float) const;
     alias B = void delegate(int) const;
@@ -8100,7 +8100,7 @@ struct Ternary
 
 ///
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     Ternary a;
     assert(a == Ternary.unknown);
@@ -8111,7 +8111,7 @@ unittest
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     alias f = Ternary.no, t = Ternary.yes, u = Ternary.unknown;
     Ternary[27] truthTableAnd =
@@ -8182,7 +8182,7 @@ unittest
 }
 
 @safe @nogc nothrow pure
-unittest
+version(StdUnittest) unittest
 {
     Ternary a = Ternary(true);
     assert(a == Ternary.yes);

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -19,7 +19,7 @@ public import std.meta;
 alias TypeTuple = AliasSeq;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.typetuple;
     alias TL = TypeTuple!(int, double);
@@ -31,7 +31,7 @@ alias TypeTuple = AliasSeq;
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias TL = TypeTuple!(int, double);
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -774,7 +774,7 @@ public enum dchar paraSep = '\u2029'; /// Constant $(CODEPOINT) (0x2029) - parag
 public enum dchar nelSep  = '\u0085'; /// Constant $(CODEPOINT) (0x0085) - next line.
 
 // test the intro example
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : find;
     // initialize code point sets using script/block or property name
@@ -872,7 +872,7 @@ size_t replicateBits(size_t times, size_t bits)(size_t val) @safe pure nothrow @
         return replicateBits!(times/2, bits*2)((val << bits) | val);
 }
 
-@safe pure nothrow @nogc unittest // for replicate
+version(StdUnittest) @safe pure nothrow @nogc unittest // for replicate
 {
     import std.algorithm.iteration : sum, map;
     import std.range : iota;
@@ -1012,7 +1012,7 @@ private:
     size_t[] storage;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : text;
     enum dg = (){
@@ -1085,7 +1085,7 @@ private:
     auto rt = dg();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {// more bitpacking tests
     import std.conv : text;
 
@@ -1542,7 +1542,7 @@ if (is(Unqual!T == T))
     return SliceOverIndexed!T(a, b, x);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[] idxArray = [2, 3, 5, 8, 13];
     auto sliced = sliceOverIndexed(0, idxArray.length, &idxArray);
@@ -1687,7 +1687,7 @@ template sharMethod(alias uniLowerBound)
 alias sharLowerBound = sharMethod!uniformLowerBound;
 alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : array;
     import std.range : assumeSorted, iota;
@@ -1866,7 +1866,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         arr[$-1] = force!T(value);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         int[] arr;
         ReallocPolicy.append(arr, 3);
@@ -1889,7 +1889,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
         copy(value, arr[$-value.length..$]);
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         int[] arr;
         ReallocPolicy.append(arr, [1,2,3]);
@@ -1910,7 +1910,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
 //build hack
 alias _RealArray = CowArray!ReallocPolicy;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2150,7 +2150,7 @@ pure:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
 
@@ -2201,7 +2201,7 @@ pure:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto gothic = unicode.Gothic;
         // Gothic letter ahsa
@@ -2287,7 +2287,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -2353,7 +2353,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert('я' in unicode.Cyrillic);
         assert(!('z' in unicode.Cyrillic));
@@ -2415,7 +2415,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.algorithm.comparison : equal;
         import std.range : iota;
@@ -2473,7 +2473,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.conv : to;
         import std.format : format;
@@ -2494,7 +2494,7 @@ public:
             ~"[0XA640..0XA698) [0XA69F..0XA6A0)");
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : assertThrown;
         import std.format : format, FormatException;
@@ -2512,7 +2512,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         CodepointSet someSet;
         someSet.add('0', '5').add('A','Z'+1);
@@ -2548,7 +2548,7 @@ private:
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         assert(unicode.Cyrillic.intersect('-').byInterval.empty);
     }
@@ -2615,7 +2615,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto set = unicode.ASCII;
         // union with the inverse gets all of the code points in the Unicode
@@ -2775,7 +2775,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         CodepointSet emptySet;
         assert(emptySet.length == 0);
@@ -3120,7 +3120,7 @@ private:
     CowArray!SP data;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     assert(unicode.ASCII.to!string() == "[0..128)");
@@ -3405,7 +3405,7 @@ private:
     uint[] data;
 }
 
-@safe unittest// Uint24 tests
+version(StdUnittest) @safe unittest// Uint24 tests
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.mutation : copy;
@@ -3497,7 +3497,7 @@ version(StdUnittest)
     private alias AllSets = AliasSeq!(InversionList!GcPolicy, InversionList!ReallocPolicy);
 }
 
-@safe unittest// core set primitives test
+version(StdUnittest) @safe unittest// core set primitives test
 {
     import std.conv : text;
     foreach (CodeList; AllSets)
@@ -3574,7 +3574,7 @@ version(StdUnittest)
 
 
 //test constructor to work with any order of intervals
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text, to;
@@ -3618,7 +3618,7 @@ version(StdUnittest)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {   // full set operations
     import std.conv : text;
     foreach (CodeList; AllSets)
@@ -3723,7 +3723,7 @@ version(StdUnittest)
 
 }
 
-@safe unittest// vs single dchar
+version(StdUnittest) @safe unittest// vs single dchar
 {
     import std.conv : text;
     CodepointSet a = CodepointSet(10, 100, 120, 200);
@@ -3731,7 +3731,7 @@ version(StdUnittest)
     assert((a & 'B') == CodepointSet(66, 67));
 }
 
-@safe unittest// iteration & opIndex
+version(StdUnittest) @safe unittest// iteration & opIndex
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -4353,7 +4353,7 @@ if (sumOfIntegerTuple!sizes == 21)
     }
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.algorithm.comparison : max;
     import std.algorithm.searching : count;
@@ -4620,7 +4620,7 @@ public struct MatcherConcept
         assert(false);
     }
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         string truth = "2² = 4";
         auto m = utfMatcher!char(unicode.Number);
@@ -4656,7 +4656,7 @@ public struct MatcherConcept
         return this;
     }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto m = utfMatcher!char(unicode.Number);
         string square = "2²";
@@ -4693,7 +4693,7 @@ public enum isUtfMatcher(M, C) = __traits(compiles, (){
     assert(is(typeof(m.test(s)) == bool));
 });
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias CharMatcher = typeof(utfMatcher!char(CodepointSet.init));
     alias WcharMatcher = typeof(utfMatcher!wchar(CodepointSet.init));
@@ -5305,7 +5305,7 @@ if (is(C : wchar) || is(C : char))
     return Decoder(s, offset);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string rs = "hi! ﾈемног砀 текста";
     auto codec = rs.decoder;
@@ -5360,7 +5360,7 @@ if (is(C : wchar) || is(C : char))
     assert(codec.idx == i);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range : stride;
     static bool testAll(Matcher, Range)(ref Matcher m, ref Range r)
@@ -5410,7 +5410,7 @@ if (is(C : wchar) || is(C : char))
 }
 
 // cover decode fail cases of Matcher
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : map;
     import std.exception : collectException;
@@ -5620,7 +5620,7 @@ template Sequence(size_t start, size_t end)
 }
 
 //---- TRIE TESTS ----
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.sorting : sort;
@@ -5780,7 +5780,7 @@ if (is(Char1 : dchar) && is(Char2 : dchar))
         b.map!toLower.filter!pred);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     assert(!comparePropertyName("foo-bar", "fooBar"));
 }
@@ -5849,7 +5849,7 @@ if (isInputRange!Range && isIntegralPair!(ElementType!Range))
     return storage;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.typecons : tuple;
@@ -6189,7 +6189,7 @@ package dchar parseUniHex(Range)(ref Range str, size_t maxDigit)
     return val;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.searching : canFind;
     import std.exception : collectException;
@@ -6714,7 +6714,7 @@ auto caseEnclose(CodepointSet set)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.exception : collectException;
         auto ascii = unicode.ASCII;
@@ -6767,7 +6767,7 @@ auto caseEnclose(CodepointSet set)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // use .block for explicitness
         assert(unicode.block.Greek_and_Coptic == unicode.InGreek_and_Coptic);
@@ -6786,7 +6786,7 @@ auto caseEnclose(CodepointSet set)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto arabicScript = unicode.script.arabic;
         auto arabicBlock = unicode.block.arabic;
@@ -6817,7 +6817,7 @@ auto caseEnclose(CodepointSet set)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // L here is syllable type not Letter as in unicode.L short-cut
         auto leadingVowel = unicode.hangulSyllableType("L");
@@ -6895,7 +6895,7 @@ auto caseEnclose(CodepointSet set)
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         import std.uni : unicode;
         string pat = "[a-zA-Z0-9]hello";
@@ -6934,7 +6934,7 @@ private:
     //@disable ~this();
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.internal.unicode_tables : blocks, uniProps; // generated file
     assert(unicode("InHebrew") == asSet(blocks.Hebrew));
@@ -7106,7 +7106,7 @@ if (is(C : dchar))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(graphemeStride("  ", 1) == 1);
     // A + combing ring above
@@ -7117,7 +7117,7 @@ if (is(C : dchar))
     assert(city[first..$] == "rhus");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Ensure that graphemeStride is usable from CTFE.
     enum c1 = graphemeStride("A", 0);
@@ -7142,7 +7142,7 @@ if (isInputRange!Input && is(Unqual!(ElementType!Input) == dchar))
     return genericDecodeGrapheme!true(inp);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -7208,7 +7208,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : walkLength;
@@ -7234,7 +7234,7 @@ private static struct InputRangeString
     void popFront() { s.popFront(); }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.array : array;
@@ -7338,7 +7338,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : array;
     import std.conv : text;
@@ -7356,7 +7356,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
     assert(reverse == "le\u0308on"); // lëon
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.range.primitives : walkLength;
@@ -7437,7 +7437,7 @@ public:
     }
 
     ///
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         auto g = Grapheme("A\u0302");
         assert(g[0] == 'A');
@@ -7515,7 +7515,7 @@ public:
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison : equal;
         auto g = Grapheme("A");
@@ -7646,7 +7646,7 @@ private:
 static assert(Grapheme.sizeof == size_t.sizeof*4);
 
 
-@system pure /*nothrow @nogc*/ unittest // TODO: string .front is GC and throw
+version(StdUnittest) @system pure /*nothrow @nogc*/ unittest // TODO: string .front is GC and throw
 {
     import std.algorithm.comparison : equal;
     Grapheme[3] data = [Grapheme("Ю"), Grapheme("У"), Grapheme("З")];
@@ -7654,7 +7654,7 @@ static assert(Grapheme.sizeof == size_t.sizeof*4);
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : filter;
@@ -7690,7 +7690,7 @@ static assert(Grapheme.sizeof == size_t.sizeof*4);
     assert(g[].equal("A\u0301B"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto g = Grapheme("A\u0302");
     assert(g[0] == 'A');
@@ -7700,7 +7700,7 @@ static assert(Grapheme.sizeof == size_t.sizeof*4);
     assert(!g.valid);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.iteration : map;
@@ -7820,7 +7820,7 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(sicmp("Август", "авгусТ") == 0);
     // Greek also works as long as there is no 1:M mapping in sight
@@ -7939,7 +7939,7 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
 }
 
 ///
-@safe @nogc pure nothrow unittest
+version(StdUnittest) @safe @nogc pure nothrow unittest
 {
     assert(icmp("Rußland", "Russland") == 0);
     assert(icmp("ᾩ -> \u1F70\u03B9", "\u1F61\u03B9 -> ᾲ") == 0);
@@ -7949,7 +7949,7 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
  * By using $(REF byUTF, std,utf) and its aliases, GC allocations via auto-decoding
  * and thrown exceptions can be avoided, making `icmp` `@safe @nogc nothrow pure`.
  */
-@safe @nogc nothrow pure unittest
+version(StdUnittest) @safe @nogc nothrow pure unittest
 {
     import std.utf : byDchar;
 
@@ -7958,7 +7958,7 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
 }
 
 // test different character types
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(icmp("Rußland", "Russland") == 0);
     assert(icmp("Rußland"w, "Russland") == 0);
@@ -7979,7 +7979,7 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
     { return icmp!(const(dchar)[], const(dchar)[])(str1, str2); }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.sorting : sort;
     import std.conv : to;
@@ -8020,7 +8020,7 @@ if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
 }
 
 // issue 17372
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.iteration : joiner, map;
     import std.algorithm.sorting : sort;
@@ -8109,7 +8109,7 @@ package auto simpleCaseFoldings(dchar ch) @safe
     return Range(start, entry.size);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.searching : canFind;
@@ -8137,7 +8137,7 @@ ubyte combiningClass(dchar ch) @safe pure nothrow @nogc
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // shorten the code
     alias CC = combiningClass;
@@ -8150,7 +8150,7 @@ ubyte combiningClass(dchar ch) @safe pure nothrow @nogc
     // placed after a "ring below" in a sequence
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     foreach (ch; 0 .. 0x80)
         assert(combiningClass(ch) == 0);
@@ -8213,7 +8213,7 @@ public dchar compose(dchar first, dchar second) pure nothrow @safe
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(compose('A','\u0308') == '\u00C4');
     assert(compose('A', 'B') == dchar.init);
@@ -8260,7 +8260,7 @@ public Grapheme decompose(UnicodeDecomposition decompType=Canonical)(dchar ch) @
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -8368,7 +8368,7 @@ Grapheme decomposeHangul(dchar ch) @safe
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     assert(decomposeHangul('\uD4DB')[].equal("\u1111\u1171\u11B6"));
@@ -8397,7 +8397,7 @@ dchar composeJamo(dchar lead, dchar vowel, dchar trailing=dchar.init) pure nothr
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(composeJamo('\u1111', '\u1171', '\u11B6') == '\uD4DB');
     // leaving out T-vowel, or passing any codepoint
@@ -8408,7 +8408,7 @@ dchar composeJamo(dchar lead, dchar vowel, dchar trailing=dchar.init) pure nothr
     assert(composeJamo('A', '\u1171') == dchar.init);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
@@ -8562,7 +8562,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // any encoding works
     wstring greet = "Hello world";
@@ -8576,7 +8576,7 @@ inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
     assert(normalize!NFKD("ϓ") == "\u03A5\u0301");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : text;
 
@@ -8726,7 +8726,7 @@ public bool allowedIn(NormalizationForm norm)(dchar ch)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // e.g. Cyrillic is always allowed, so is ASCII
     assert(allowedIn!NFC('я'));
@@ -8752,7 +8752,7 @@ private bool notAllowedIn(NormalizationForm norm)(dchar ch)
     return qcTrie[ch];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(allowedIn!NFC('я'));
     assert(allowedIn!NFD('я'));
@@ -8825,7 +8825,7 @@ bool isLower(dchar c)
     return lowerCaseTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isLower;
     foreach (v; 0 .. 0x80)
@@ -8858,7 +8858,7 @@ bool isUpper(dchar c)
     return upperCaseTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.ascii : isLower;
     foreach (v; 0 .. 0x80)
@@ -8949,7 +8949,7 @@ if (isSomeString!S)
     return s;
 }
 
-@safe unittest //12428
+version(StdUnittest) @safe unittest //12428
 {
     import std.array : replicate;
     auto s = "abcdefghij".replicate(300);
@@ -9101,7 +9101,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -9124,13 +9124,13 @@ if (isConvertibleToString!Range)
     return asUpperCase!(StringTypeOf!Range)(str);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!asLowerCase("hEllo"));
     assert(testAliasedString!asUpperCase("hEllo"));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : array;
 
@@ -9298,7 +9298,7 @@ if (isInputRange!Range && isSomeChar!(ElementEncodingType!Range) &&
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -9312,18 +9312,18 @@ if (isConvertibleToString!Range)
     return asCapitalized!(StringTypeOf!Range)(str);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(testAliasedString!asCapitalized("hEllo"));
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     auto r = "hEllo".asCapitalized();
     assert(r.front == 'H');
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.array : array;
 
@@ -9405,7 +9405,7 @@ private size_t encodeTo(scope char[] buf, size_t idx, dchar c) @trusted pure not
     return idx;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     char[] s = "abcd".dup;
     size_t i = 0;
@@ -9552,7 +9552,7 @@ private template toCaseLength(alias indexFn, uint maxIdx, alias tableFn)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     alias toLowerLength = toCaseLength!(LowerTriple);
     assert(toLowerLength("abcd") == 4);
@@ -9708,7 +9708,7 @@ if (isSomeString!S)
     dstring toLower(dstring s)
     { return toLower!dstring(s); }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // https://issues.dlang.org/show_bug.cgi?id=16663
 
@@ -9726,7 +9726,7 @@ if (isSomeString!S)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static import std.ascii;
     import std.format : format;
@@ -9746,7 +9746,7 @@ if (isSomeString!S)
 }
 
 //bugzilla 9629
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     wchar[] test = "hello þ world"w.dup;
     auto piece = test[6 .. 7];
@@ -9755,7 +9755,7 @@ if (isSomeString!S)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
     string s1 = "FoL";
@@ -9841,7 +9841,7 @@ dchar toUpper(dchar c)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : map;
     import std.algorithm.mutation : copy;
@@ -9852,7 +9852,7 @@ dchar toUpper(dchar c)
     assert(abuf.data == "HELLO");
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static import std.ascii;
     import std.format : format;
@@ -9890,7 +9890,7 @@ if (isSomeString!S)
     dstring toUpper(dstring s)
     { return toUpper!dstring(s); }
 
-    @safe unittest
+    version(StdUnittest) @safe unittest
     {
         // https://issues.dlang.org/show_bug.cgi?id=16663
 
@@ -9907,7 +9907,7 @@ if (isSomeString!S)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : cmp;
 
@@ -9936,7 +9936,7 @@ if (isSomeString!S)
     assert(s2 !is s1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void doTest(C)(const(C)[] s, const(C)[] trueUp, const(C)[] trueLow)
     {
@@ -10019,7 +10019,7 @@ bool isAlpha(dchar c)
     return alphaTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto alpha = unicode("Alphabetic");
     foreach (ch; alpha.byCodepoint)
@@ -10039,7 +10039,7 @@ bool isMark(dchar c)
     return markTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto mark = unicode("Mark");
     foreach (ch; mark.byCodepoint)
@@ -10066,7 +10066,7 @@ bool isNumber(dchar c)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto n = unicode("N");
     foreach (ch; n.byCodepoint)
@@ -10101,7 +10101,7 @@ bool isAlphaNum(dchar c)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto n = unicode("N");
     auto alpha = unicode("Alphabetic");
@@ -10138,7 +10138,7 @@ bool isPunctuation(dchar c)
     }
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isPunctuation('\u0021'));
     assert(isPunctuation('\u0028'));
@@ -10161,7 +10161,7 @@ bool isSymbol(dchar c)
    return symbolTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.format : format;
     assert(isSymbol('\u0024'));
@@ -10185,7 +10185,7 @@ bool isSpace(dchar c)
     return isSpaceGen(c);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isSpace('\u0020'));
     auto space = unicode.Zs;
@@ -10208,7 +10208,7 @@ bool isGraphical(dchar c)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto set = unicode("Graphical");
     import std.format : format;
@@ -10230,7 +10230,7 @@ bool isControl(dchar c)
     return isControlGen(c);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isControl('\u0000'));
     assert(isControl('\u0081'));
@@ -10255,7 +10255,7 @@ bool isFormat(dchar c)
 }
 
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(isFormat('\u00AD'));
     foreach (ch; unicode("Format").byCodepoint)
@@ -10316,7 +10316,7 @@ bool isNonCharacter(dchar c)
     return nonCharacterTrie[c];
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto set = unicode("Cn");
     foreach (ch; set.byCodepoint)

--- a/std/uri.d
+++ b/std/uri.d
@@ -396,7 +396,7 @@ package string urlEncode(in string[string] values)
     return enc.data;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system because urlEncode -> encodeComponent -> URI_Encode
     // URI_Encode uses alloca and pointer slicing
@@ -466,7 +466,7 @@ if (isSomeChar!Char)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string s1 = "http://www.digitalmars.com/~fred/fredsRX.html#foo end!";
     assert(uriLength(s1) == 49);
@@ -533,7 +533,7 @@ if (isSomeChar!Char)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string s1 = "my.e-mail@www.example-domain.com with garbage added";
     assert(emailLength(s1) == 32);
@@ -543,7 +543,7 @@ if (isSomeChar!Char)
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     //@system because of encode -> URI_Encode
     debug(uri) writeln("uri.encodeURI.unittest");

--- a/std/utf.d
+++ b/std/utf.d
@@ -252,7 +252,7 @@ bool isValidDchar(dchar c) pure nothrow @safe @nogc
     return c < 0xD800 || (c > 0xDFFF && c <= 0x10FFFF);
 }
 
-pure nothrow @safe @nogc unittest
+version(StdUnittest) pure nothrow @safe @nogc unittest
 {
     import std.exception;
 
@@ -339,7 +339,7 @@ do
     return msbs;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -406,7 +406,7 @@ do
     });
 }
 
-@safe unittest // invalid start bytes
+version(StdUnittest) @safe unittest // invalid start bytes
 {
     import std.exception : assertThrown;
     immutable char[] invalidStartBytes = [
@@ -447,7 +447,7 @@ if (isInputRange!S && is(Unqual!(ElementType!S) == wchar))
     return 1 + (u >= 0xD800 && u <= 0xDBFF);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -526,7 +526,7 @@ if (is(S : const dchar[]) ||
     return 1;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -672,7 +672,7 @@ if (isBidirectionalRange!S && is(Unqual!(ElementType!S) == char) && !isRandomAcc
     throw new UTFException("The last code unit is not the end of the UTF-8 sequence");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -769,7 +769,7 @@ if (is(S : const wchar[]) ||
     return 1 + (0xDC00 <= c2 && c2 <= 0xE000);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -854,7 +854,7 @@ if (isBidirectionalRange!S && is(Unqual!(ElementEncodingType!S) == dchar))
     return 1;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import core.exception : AssertError;
     import std.conv : to;
@@ -955,7 +955,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(toUCSindex(`hello world`, 7) == 7);
     assert(toUCSindex(`hello world`w, 7) == 7);
@@ -995,7 +995,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert(toUTFindex(`hello world`, 7) == 7);
     assert(toUTFindex(`hello world`w, 7) == 7);
@@ -1529,7 +1529,7 @@ if (
 }
 
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     // Add tests for useReplacemendDchar == yes path
 
@@ -1646,7 +1646,7 @@ if (is(S : const wchar[]) || (isInputRange!S && is(Unqual!(ElementEncodingType!S
 }
 
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     // Add tests for useReplacemendDchar == true path
 
@@ -1710,7 +1710,7 @@ if (is(S : const dchar[]) || (isInputRange!S && is(Unqual!(ElementEncodingType!S
 }
 
 @safe pure @nogc nothrow
-unittest
+version(StdUnittest) unittest
 {
     // Add tests for useReplacemendDchar == true path
 
@@ -1886,7 +1886,7 @@ version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.exception;
@@ -1970,7 +1970,7 @@ version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __
     });
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.exception;
@@ -2026,7 +2026,7 @@ version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __
     });
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.exception;
@@ -2082,7 +2082,7 @@ version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __
     });
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2107,7 +2107,7 @@ version(StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __
     });
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     char[4] val;
@@ -2180,7 +2180,7 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     goto L3;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2237,7 +2237,7 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     goto L1;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2276,7 +2276,7 @@ size_t encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     return 1;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2362,7 +2362,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     str = r;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
 
@@ -2384,7 +2384,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     });
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2449,7 +2449,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     str = r;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2487,7 +2487,7 @@ void encode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar)(
     str ~= c;
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -2541,7 +2541,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     assert(codeLength!char('a') == 1);
     assert(codeLength!wchar('a') == 1);
@@ -2583,7 +2583,7 @@ if (isInputRange!InputRange && !isInfinite!InputRange && is(ElementType!InputRan
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.conv : to;
     assert(codeLength!char("hello world") ==
@@ -2606,7 +2606,7 @@ if (isInputRange!InputRange && !isInfinite!InputRange && is(ElementType!InputRan
            `, ça, ce ne serait pas bien.`);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.iteration : filter;
     import std.conv : to;
@@ -2652,7 +2652,7 @@ if (isSomeChar!C)
     else
         static assert(0);
 }
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     assert( canSearchInCodeUnits! char('a'));
     assert( canSearchInCodeUnits!wchar('a'));
@@ -2690,7 +2690,7 @@ if (isSomeString!S)
 }
 
 
-@safe unittest // bugzilla 12923
+version(StdUnittest) @safe unittest // bugzilla 12923
 {
     import std.exception;
     assertThrown((){
@@ -2717,7 +2717,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2728,7 +2728,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S))
     assert("𐐷"d.toUTF8.equal([0xF0, 0x90, 0x90, 0xB7]));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : ReferenceInputRange;
@@ -2758,7 +2758,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S))
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.algorithm.comparison : equal;
 
@@ -2770,7 +2770,7 @@ if (isInputRange!S && !isInfinite!S && isSomeChar!(ElementEncodingType!S))
     assert("𐐷"d.toUTF16.equal([0xD801, 0xDC37]));
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.algorithm.comparison : equal;
     import std.internal.test.dummyrange : ReferenceInputRange;
@@ -2869,7 +2869,7 @@ template toUTFz(P)
 }
 
 ///
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto p1 = toUTFz!(char*)("hello world");
     auto p2 = toUTFz!(const(char)*)("hello world");
@@ -2979,7 +2979,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
     return () @trusted { return cast(P) retval.data.ptr; } ();
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import core.exception : AssertError;
     import std.algorithm;
@@ -3080,7 +3080,7 @@ if (isSomeChar!C)
     return toUTFz!(const(wchar)*)(str);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     //toUTFz is already thoroughly tested, so this will just verify that
@@ -3092,7 +3092,7 @@ if (isSomeChar!C)
 
 /* ================================ tests ================================== */
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.exception;
 
@@ -3138,7 +3138,7 @@ if (isSomeChar!C)
     return walkLength(str);
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.exception;
     assertCTFEable!(
@@ -3355,7 +3355,7 @@ if (isAutodecodableString!R ||
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.range.primitives;
 
@@ -3376,7 +3376,7 @@ if (isAutodecodableString!R ||
 }
 
 /// `byCodeUnit` does no Unicode decoding
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     string noel1 = "noe\u0308l"; // noël using e + combining diaeresis
     assert(noel1.byCodeUnit[2] != 'ë');
@@ -3389,7 +3389,7 @@ if (isAutodecodableString!R ||
 }
 
 /// `byCodeUnit` exposes a `source` property when wrapping narrow strings.
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : popFrontN;
@@ -3407,7 +3407,7 @@ if (isAutodecodableString!R ||
     }
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
     import std.range;
     {
@@ -3712,7 +3712,7 @@ alias byWchar = byUTF!wchar;
 /// Ditto
 alias byDchar = byUTF!dchar;
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
   {
     char[5] s;
@@ -3759,7 +3759,7 @@ alias byDchar = byUTF!dchar;
   }
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
   {
     wchar[11] s;
@@ -3801,7 +3801,7 @@ alias byDchar = byUTF!dchar;
   }
 }
 
-@safe pure nothrow @nogc unittest
+version(StdUnittest) @safe pure nothrow @nogc unittest
 {
   {
     dchar[9] s;
@@ -3898,7 +3898,7 @@ alias byDchar = byUTF!dchar;
 // test pure, @safe, nothrow, @nogc correctness of byChar/byWchar/byDchar,
 // which needs to support ranges with and without those attributes
 
-pure @safe nothrow @nogc unittest
+version(StdUnittest) pure @safe nothrow @nogc unittest
 {
     dchar[5] s = "hello"d;
     foreach (c; s[].byChar())  { }
@@ -3909,7 +3909,7 @@ pure @safe nothrow @nogc unittest
 version(StdUnittest)
 int impureVariable;
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct ImpureThrowingSystemRange(Char)
     {
@@ -4048,7 +4048,7 @@ if (isSomeChar!C)
 }
 
 ///
-@safe pure nothrow unittest
+version(StdUnittest) @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
 

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -98,7 +98,7 @@ $(TR $(TDNW UUID namespaces)
 module std.uuid;
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.uuid;
 
@@ -141,7 +141,7 @@ public struct UUID
                 return cast(Char)('a' + (i-10));
         }
 
-        @safe pure nothrow unittest
+        version(StdUnittest) @safe pure nothrow unittest
         {
             assert(UUID(cast(ubyte[16])[138, 179, 6, 14, 44, 186, 79, 35, 183, 76, 181, 45,
                 179, 189, 251, 70]).toString() == "8ab3060e-2cba-4f23-b74c-b52db3bdfb46");
@@ -229,7 +229,7 @@ public struct UUID
          * that is not needed right now.
          */
 
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             UUID tmp;
             tmp.data = cast(ubyte[16])[0,1,2,3,4,5,6,7,8,9,10,11,12,
@@ -260,7 +260,7 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             enum ubyte[16] data = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
             auto uuid = UUID(data);
@@ -286,14 +286,14 @@ public struct UUID
         }
 
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             auto tmp = UUID(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
             assert(tmp.data == cast(ubyte[16])[0,1,2,3,4,5,6,7,8,9,10,11,
                 12,13,14,15]);
         }
 
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             UUID tmp = UUID(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
             assert(tmp.data == cast(ubyte[16])[0,1,2,3,4,5,6,7,8,9,10,11,
@@ -388,7 +388,7 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             auto id = UUID("8AB3060E-2cba-4f23-b74c-b52db3bdfb46");
             assert(id.data == [138, 179, 6, 14, 44, 186, 79, 35, 183, 76,
@@ -400,7 +400,7 @@ public struct UUID
             //here parsing is done at compile time, no runtime overhead!
         }
 
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             import std.conv : to;
             import std.exception;
@@ -477,7 +477,7 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             UUID id;
             assert(id.empty);
@@ -485,7 +485,7 @@ public struct UUID
             assert(!id.empty);
         }
 
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             ubyte[16] getData(size_t i)
             {
@@ -544,12 +544,12 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             assert(UUID("8ab3060e-2cba-4f23-b74c-b52db3bdfb46").variant
                == UUID.Variant.rfc4122);
         }
-        @system pure unittest
+        version(StdUnittest) @system pure unittest
         {
             // @system due to Variant
             Variant[ubyte] tests = cast(Variant[ubyte])[0x00 : Variant.ncs,
@@ -605,12 +605,12 @@ public struct UUID
         }
 
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             assert(UUID("8ab3060e-2cba-4f23-b74c-b52db3bdfb46").uuidVersion
                 == UUID.Version.randomNumberBased);
         }
-        @system unittest
+        version(StdUnittest) @system unittest
         {
             // @system due to cast
             Version[ubyte] tests = cast(Version[ubyte]) [
@@ -649,7 +649,7 @@ public struct UUID
         }
 
         ///
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             immutable ubyte[16] data = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
             UUID u1;
@@ -670,7 +670,7 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             //compare UUIDs
             assert(UUID("00000000-0000-0000-0000-000000000000") == UUID.init);
@@ -808,7 +808,7 @@ public struct UUID
             }
             return h;
         }
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             assert(UUID("00000000-0000-0000-0000-000000000000") == UUID.init);
             int[UUID] test = [UUID("8a94f585-d180-44f7-8929-6fca0189c7d0") : 1,
@@ -901,14 +901,14 @@ public struct UUID
         }
 
         ///
-        @safe pure unittest
+        version(StdUnittest) @safe pure unittest
         {
             immutable str = "8ab3060e-2cba-4f23-b74c-b52db3bdfb46";
             auto id = UUID(str);
             assert(id.toString() == str);
         }
 
-        @safe pure nothrow @nogc unittest
+        version(StdUnittest) @safe pure nothrow @nogc unittest
         {
             import std.meta : AliasSeq;
             static foreach (Char; AliasSeq!(char, wchar, dchar))
@@ -929,7 +929,7 @@ public struct UUID
             }}
         }
 
-        @system pure nothrow @nogc unittest
+        version(StdUnittest) @system pure nothrow @nogc unittest
         {
             // @system due to cast
             import std.encoding : Char = AsciiChar;
@@ -943,7 +943,7 @@ public struct UUID
             assert(str == s);
         }
 
-        @safe unittest
+        version(StdUnittest) @safe unittest
         {
             auto u1 = UUID(cast(ubyte[16])[138, 179, 6, 14, 44, 186, 79,
                 35, 183, 76, 181, 45, 179, 189, 251, 70]);
@@ -1031,7 +1031,7 @@ public struct UUID
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Use default UUID.init namespace
     auto simpleID = md5UUID("test.uuid.any.string");
@@ -1041,7 +1041,7 @@ public struct UUID
     auto id = md5UUID("some-description", namespace);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto simpleID = md5UUID("test.uuid.any.string");
     assert(simpleID.data == cast(ubyte[16])[126, 206, 86, 72, 29, 233, 62, 213, 178, 139, 198, 136,
@@ -1143,7 +1143,7 @@ public struct UUID
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     //Use default UUID.init namespace
     auto simpleID = sha1UUID("test.uuid.any.string");
@@ -1153,7 +1153,7 @@ public struct UUID
     auto id = sha1UUID("some-description", namespace);
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto simpleID = sha1UUID("test.uuid.any.string");
     assert(simpleID.data == cast(ubyte[16])[16, 209, 239, 61, 99, 12, 94, 70, 159, 79, 255, 250,
@@ -1231,7 +1231,7 @@ if (isInputRange!RNG && isIntegral!(ElementType!RNG))
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : Xorshift192, unpredictableSeed;
 
@@ -1251,13 +1251,13 @@ if (isInputRange!RNG && isIntegral!(ElementType!RNG))
  * to something else, this assert and the randomUUID function
  * have to be updated.
  */
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : rndGen, Mt19937;
     static assert(is(typeof(rndGen) == Mt19937));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.random : Xorshift192, unpredictableSeed;
     //simple call
@@ -1454,7 +1454,7 @@ if (isInputRange!Range
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto id = parseUUID("8AB3060E-2CBA-4F23-b74c-B52Db3BDFB46");
     //no dashes
@@ -1473,7 +1473,7 @@ if (isInputRange!Range
     //here parsing is done at compile time, no runtime overhead!
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     import std.conv : to;
     import std.exception;
@@ -1646,7 +1646,7 @@ enum uuidRegex = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}"~
     "-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.algorithm;
     import std.regex;
@@ -1710,7 +1710,7 @@ public class UUIDParsingException : Exception
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     import std.exception : collectException;
 
@@ -1722,7 +1722,7 @@ public class UUIDParsingException : Exception
     assert(ex.reason == UUIDParsingException.Reason.tooLittle);
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     auto ex = new UUIDParsingException("foo", 10, UUIDParsingException.Reason.tooMuch);
     assert(ex.input == "foo");

--- a/std/variant.d
+++ b/std/variant.d
@@ -36,7 +36,7 @@ module std.variant;
 import std.meta, std.traits, std.typecons;
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     Variant a; // Must assign before use, otherwise exception ensues
     // Initialize with an integer; make the type int
@@ -89,7 +89,7 @@ template maxSize(T...)
 }
 
 ///
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     static assert(maxSize!(int, long) == 8);
     static assert(maxSize!(bool, byte) == 1);
@@ -698,7 +698,7 @@ public:
 
     ///
     version(StdUnittest)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         Variant a;
         assert(!a.hasValue);
@@ -731,7 +731,7 @@ public:
 
     ///
     version(StdUnittest)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         Variant a = 5;
         auto b = a.peek!(int);
@@ -1123,7 +1123,7 @@ public:
 
     ///
     version(StdUnittest)
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         Variant a = new int[10];
         a[5] = 42;
@@ -1208,7 +1208,7 @@ public:
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     Variant v;
@@ -1221,7 +1221,7 @@ public:
     assert(v("43") == 43);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[int] hash = [ 42:24 ];
     Variant v = hash;
@@ -1231,7 +1231,7 @@ public:
 }
 
 // opIndex with static arrays, issue 12771
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[4] elements = [0, 1, 2, 3];
     Variant v = elements;
@@ -1243,7 +1243,7 @@ public:
     assert(v != elements);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     Algebraic!(int[]) v = [2, 2];
@@ -1262,7 +1262,7 @@ public:
 }
 
 //Issue# 10879
-@system unittest
+version(StdUnittest) @system unittest
 {
     int[10] arr = [1,2,3,4,5,6,7,8,9,10];
     Variant v1 = arr;
@@ -1288,7 +1288,7 @@ public:
 }
 
 //Issue# 8195
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct S
     {
@@ -1308,7 +1308,7 @@ public:
 }
 
 // Issue #10961
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Primarily test that we can assign a void[] to a Variant.
     void[] elements = cast(void[])[1, 2, 3];
@@ -1318,7 +1318,7 @@ public:
 }
 
 // Issue #13352
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias TP = Algebraic!(long);
     auto a = TP(1L);
@@ -1334,7 +1334,7 @@ public:
 }
 
 // Issue #13354
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias A = Algebraic!(string[]);
     A a = ["a", "b"];
@@ -1352,14 +1352,14 @@ public:
 }
 
 // Issue #14198
-@system unittest
+version(StdUnittest) @system unittest
 {
     Variant a = true;
     assert(a.type == typeid(bool));
 }
 
 // Issue #14233
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias Atom = Algebraic!(string, This[]);
 
@@ -1368,7 +1368,7 @@ public:
 }
 
 pure nothrow @nogc
-@system unittest
+version(StdUnittest) @system unittest
 {
     Algebraic!(int, double) a;
     a = 100;
@@ -1376,7 +1376,7 @@ pure nothrow @nogc
 }
 
 // Issue 14457
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias A = Algebraic!(int, float, double);
     alias B = Algebraic!(int, float);
@@ -1390,7 +1390,7 @@ pure nothrow @nogc
 }
 
 // Issue 14585
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -1401,13 +1401,13 @@ pure nothrow @nogc
 }
 
 // Issue 14586
-@system unittest
+version(StdUnittest) @system unittest
 {
     const Variant v = new immutable Object;
     v.get!(immutable Object);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct S
     {
@@ -1418,7 +1418,7 @@ pure nothrow @nogc
 }
 
 // issue 13262
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void fun(T)(Variant v){
         T x;
@@ -1482,7 +1482,7 @@ template Algebraic(T...)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto v = Algebraic!(int, double, string)(5);
     assert(v.peek!(int));
@@ -1506,7 +1506,7 @@ alpha renaming) on its constituent types, replacing `This`
 with the self-referenced type. The structure of the type involving `This` may
 be arbitrarily complex.
 */
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.typecons : Tuple, tuple;
 
@@ -1559,7 +1559,7 @@ Variant[] variantArray(T...)(T args)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto a = variantArray(1, 3.14, "Hi!");
     assert(a[1] == 3.14);
@@ -1599,7 +1599,7 @@ static class VariantException : Exception
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     alias W1 = This2Variant!(char, int, This[int]);
     alias W2 = AliasSeq!(int, char[int]);
@@ -1609,7 +1609,7 @@ static class VariantException : Exception
     var_t foo = "quux";
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
      alias A = Algebraic!(real, This[], This[int], This[This]);
      A v1, v2, v3;
@@ -1624,7 +1624,7 @@ static class VariantException : Exception
      //writeln(v1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : ConvException;
     import std.exception : assertThrown, collectException;
@@ -1721,7 +1721,7 @@ static class VariantException : Exception
 
 // tests adapted from
 // http://www.dsource.org/projects/tango/browser/trunk/tango/core/Variant.d?rev=2601
-@system unittest
+version(StdUnittest) @system unittest
 {
     Variant v;
 
@@ -1841,14 +1841,14 @@ static class VariantException : Exception
 
 version(TestComplex)
 deprecated
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto v3 = Variant(1+2.0i);
     hash[v3] = 2;
     assert( hash[v3] == 2 );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // check comparisons incompatible with AllowedTypes
     Algebraic!int v = 2;
@@ -1861,7 +1861,7 @@ deprecated
     static assert(!__traits(compiles, {v > null;}));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // bug 1558
     Variant va=1;
@@ -1870,7 +1870,7 @@ deprecated
     assert((va-vb).get!(int) == 3);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Variant a;
     a=5;
@@ -1881,14 +1881,14 @@ deprecated
     assert(c[3] == "hello");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Variant v = 5;
     assert(!__traits(compiles, v.coerce!(bool delegate())));
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct Huge {
         real a, b, c, d, e, f, g;
@@ -1901,7 +1901,7 @@ deprecated
     assert(v.get!(Huge).e == 42);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     const x = Variant(42);
     auto y1 = x.get!(const int);
@@ -1910,7 +1910,7 @@ deprecated
 }
 
 // test iteration
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto v = Variant([ 1, 2, 3, 4 ][]);
     auto j = 0;
@@ -1922,14 +1922,14 @@ deprecated
 }
 
 // test convertibility
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto v = Variant("abc".dup);
     assert(v.convertsTo!(char[]));
 }
 
 // http://d.puremagic.com/issues/show_bug.cgi?id=5424
-@system unittest
+version(StdUnittest) @system unittest
 {
     interface A {
         void func1();
@@ -1944,7 +1944,7 @@ deprecated
     Variant b = Variant(a);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // bug 7070
     Variant v;
@@ -1952,7 +1952,7 @@ deprecated
 }
 
 // Class and interface opEquals, issue 12157
-@system unittest
+version(StdUnittest) @system unittest
 {
     class Foo { }
 
@@ -1970,7 +1970,7 @@ deprecated
 }
 
 // Const parameters with opCall, issue 11361.
-@system unittest
+version(StdUnittest) @system unittest
 {
     static string t1(string c) {
         return c ~ "a";
@@ -2001,7 +2001,7 @@ deprecated
 }
 
 // issue 12071
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct Structure { int data; }
     alias VariantTest = Algebraic!(Structure delegate() pure nothrow @nogc @safe);
@@ -2018,7 +2018,7 @@ deprecated
 }
 
 // Ordering comparisons of incompatible types, e.g. issue 7990.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     assertThrown!VariantException(Variant(3) < "a");
@@ -2030,7 +2030,7 @@ deprecated
 }
 
 // Handling of unordered types, e.g. issue 9043.
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     static struct A { int a; }
@@ -2043,7 +2043,7 @@ deprecated
 }
 
 // Handling of empty types and arrays, e.g. issue 10958
-@system unittest
+version(StdUnittest) @system unittest
 {
     class EmptyClass { }
     struct EmptyStruct { }
@@ -2074,7 +2074,7 @@ deprecated
 }
 
 // Handling of void function pointers / delegates, e.g. issue 11360
-@system unittest
+version(StdUnittest) @system unittest
 {
     static void t1() { }
     Variant v = &t1;
@@ -2086,7 +2086,7 @@ deprecated
 }
 
 // Using peek for large structs, issue 8580
-@system unittest
+version(StdUnittest) @system unittest
 {
     struct TestStruct(bool pad)
     {
@@ -2156,7 +2156,7 @@ if (Handlers.length > 0)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     Algebraic!(int, string) variant;
 
@@ -2191,7 +2191,7 @@ if (Handlers.length > 0)
     assert(empty2.visit!(x => x + 1, () => -1) == -1);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Algebraic!(size_t, string) variant;
 
@@ -2252,7 +2252,7 @@ if (Handlers.length > 0)
 
 // disallow providing multiple generic handlers to visit
 // disallow a generic handler that does not apply to all types
-@system unittest
+version(StdUnittest) @system unittest
 {
     Algebraic!(int, float) number = 2;
     // ok, x + 1 valid for int and float
@@ -2299,7 +2299,7 @@ if (Handlers.length > 0)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     Algebraic!(int, string) variant;
 
@@ -2315,7 +2315,7 @@ if (Handlers.length > 0)
     assert(which == -100);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     Algebraic!(int, string) variant;
@@ -2348,7 +2348,7 @@ private template isAlgebraic(Type)
         enum isAlgebraic = false;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static assert(!isAlgebraic!(Variant));
     static assert( isAlgebraic!(Algebraic!(string)));
@@ -2475,7 +2475,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(false);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // validate that visit can be called with a const type
     struct Foo { int depth; }
@@ -2491,7 +2491,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(depth(fb) == 3);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=16383
     class Foo {this() immutable {}}
@@ -2503,7 +2503,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(x == 3);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // http://d.puremagic.com/issues/show_bug.cgi?id=5310
     const Variant a;
@@ -2513,13 +2513,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(b == a);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     const Variant a = [2];
     assert(a[0] == 2);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // http://d.puremagic.com/issues/show_bug.cgi?id=10017
     static struct S
@@ -2532,7 +2532,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     v2 = v1;  // AssertError: target must be non-null
     assert(v1 == v2);
 }
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown;
     // http://d.puremagic.com/issues/show_bug.cgi?id=7069
@@ -2694,7 +2694,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static struct DummyScope
     {
@@ -2708,7 +2708,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=10194
     // Also test for elaborate copying
@@ -2754,7 +2754,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(S.cnt == 0);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 13300
     static struct S
@@ -2784,7 +2784,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     auto a = appender!(T[]);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 13871
     alias A = Algebraic!(int, typeof(null));
@@ -2795,7 +2795,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     var = C(B());
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.exception : assertThrown, assertNotThrown;
     // Make sure Variant can handle types with opDispatch but no length field.
@@ -2823,7 +2823,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assertThrown!VariantException(v.length);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 13534
     static assert(!__traits(compiles, () @safe {
@@ -2833,7 +2833,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     }));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 15039
     import std.typecons;
@@ -2851,7 +2851,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 15791
     int n = 3;
@@ -2865,7 +2865,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     assert(v.get!NS2.foo() == 30);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // Bugzilla 15827
     static struct Foo15827 { Variant v; this(Foo15827 v) {} }

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -83,7 +83,7 @@ class Win32Exception : WindowsException
 
 version(StdUnittest) import std.string : startsWith, endsWith;
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // Test that we can throw and catch one by its own type
     string message = "Test W1";
@@ -93,7 +93,7 @@ version(StdUnittest) import std.string : startsWith, endsWith;
     assert(e.msg.startsWith(message));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // ditto
     string message = "Test W2";
@@ -138,7 +138,7 @@ public:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // (i) Test that we can throw and catch one by its own type
     string message = "Test 1";
@@ -150,7 +150,7 @@ public:
     assert(e.msg.startsWith(message));
 }
 
-@safe unittest
+version(StdUnittest) @safe unittest
 {
     // ditto
     string message = "Test 2";
@@ -1739,7 +1739,7 @@ private:
 }
 
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     debug(winreg) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
     debug(winreg) writefln("std.windows.registry.unittest read");
@@ -1772,7 +1772,7 @@ private:
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     debug(winreg) scope(success) writeln("unittest @", __FILE__, ":", __LINE__, " succeeded.");
     debug(winreg) writefln("std.windows.registry.unittest write");
@@ -1843,7 +1843,7 @@ private:
     assert(e.msg.endsWith(" (error 2)"));
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     Key HKCU = Registry.currentUser;
     assert(HKCU);

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -178,7 +178,7 @@ T wenforce(T)(T condition, const(char)[] name, const(wchar)* namez, string file 
 }
 
 version(Windows)
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.algorithm.searching : startsWith, endsWith;
     import std.exception;

--- a/std/xml.d
+++ b/std/xml.d
@@ -159,7 +159,7 @@ bool isChar(dchar c) @safe @nogc pure nothrow // rule 2
     return false;
 }
 
-@safe @nogc nothrow pure unittest
+version(StdUnittest) @safe @nogc nothrow pure unittest
 {
     assert(!isChar(cast(dchar) 0x8));
     assert( isChar(cast(dchar) 0x9));
@@ -221,7 +221,7 @@ bool isDigit(dchar c) @safe @nogc pure nothrow
         return lookup(DigitTable,c);
 }
 
-@safe @nogc nothrow pure unittest
+version(StdUnittest) @safe @nogc nothrow pure unittest
 {
     debug (stdxml_TestHardcodedChecks)
     {
@@ -263,7 +263,7 @@ bool isIdeographic(dchar c) @safe @nogc nothrow pure
     return false;
 }
 
-@safe @nogc nothrow pure unittest
+version(StdUnittest) @safe @nogc nothrow pure unittest
 {
     assert(isIdeographic('\u4E00'));
     assert(isIdeographic('\u9FA5'));
@@ -373,7 +373,7 @@ S encode(S)(S s)
     return result.data;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     auto s = "hello";
     assert(encode(s) is s);
@@ -485,7 +485,7 @@ string decode(string s, DecodeMode mode=DecodeMode.LOOSE) @safe pure
     return (buffer.length == 0) ? s : buffer;
 }
 
-@safe pure unittest
+version(StdUnittest) @safe pure unittest
 {
     void assertNot(string s) pure
     {
@@ -643,7 +643,7 @@ class Document : Element
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // https://issues.dlang.org/show_bug.cgi?id=14966
     auto xml = `<?xml version="1.0" encoding="UTF-8"?><foo></foo>`;
@@ -1313,7 +1313,7 @@ class Comment : Item
     override @property @safe @nogc pure nothrow scope bool isEmptyXML() const { return false; } /// Returns false always
 }
 
-@safe unittest // issue 16241
+version(StdUnittest) @safe unittest // issue 16241
 {
     import std.exception : assertThrown;
     auto c = new Comment("==");
@@ -1727,7 +1727,7 @@ class DocumentParser : ElementParser
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto doc = new Document("<root><child><grandchild/></child></root>");
     assert(doc.elements.length == 1);
@@ -2739,7 +2739,7 @@ void check(string s) @safe pure
     }
 }
 
-@system pure unittest
+version(StdUnittest) @system pure unittest
 {
     import std.string : indexOf;
 
@@ -2788,7 +2788,7 @@ void check(string s) @safe pure
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string s = q"EOS
 <?xml version="1.0"?>
@@ -2808,7 +2808,7 @@ EOS";
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string test_xml = `<?xml version="1.0" encoding='UTF-8'?><r><stream:stream
                         xmlns:stream="http://etherx.'jabber'.org/streams"
@@ -2828,7 +2828,7 @@ EOS";
     assert(tested);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string s = q"EOS
 <?xml version="1.0" encoding="utf-8"?> <Tests>
@@ -2847,7 +2847,7 @@ EOS";
     xml.parse();
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     string s = `<tag attr="&quot;value&gt;" />`;
     auto doc = new Document(s);

--- a/std/zip.d
+++ b/std/zip.d
@@ -178,7 +178,7 @@ final class ArchiveMember
         }
     }
 
-    version (Posix) @safe unittest
+    version(StdUnittest) version (Posix) @safe unittest
     {
         auto am = new ArchiveMember();
         am.fileAttributes = octal!100644;
@@ -834,7 +834,7 @@ debug(print)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to (at least) ZipArchive.build
     auto zip1 = new ZipArchive();
@@ -887,7 +887,7 @@ debug(print)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.conv : to;
     import std.random : Mt19937, randomShuffle;
@@ -926,7 +926,7 @@ debug(print)
     }
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     import std.zlib;
 
@@ -939,7 +939,7 @@ the quick brown fox jumps over the lazy dog\r
     assert(src == after);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     // @system due to ZipArchive.build
     import std.datetime;
@@ -966,7 +966,7 @@ the quick brown fox jumps over the lazy dog\r
 // Non-Android Posix-only, because we can't rely on the unzip command being
 // available on Android or Windows
 version(Android) {} else
-version(Posix) @system unittest
+version(StdUnittest) version(Posix) @system unittest
 {
     import std.datetime, std.file, std.format, std.path, std.process, std.stdio;
 

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -121,7 +121,7 @@ uint adler32(uint adler, const(void)[] buf)
 }
 
 ///
-@system unittest
+version(StdUnittest) @system unittest
 {
     static ubyte[] data = [1,2,3,4,5,6,7,8,9,10];
 
@@ -129,7 +129,7 @@ uint adler32(uint adler, const(void)[] buf)
     assert(adler == 0xdc0037);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static string data = "test";
 
@@ -163,7 +163,7 @@ uint crc32(uint crc, const(void)[] buf)
     return crc;
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static ubyte[] data = [1,2,3,4,5,6,7,8,9,10];
 
@@ -279,7 +279,7 @@ void[] uncompress(const(void)[] srcbuf, size_t destlen = 0u, int winbits = 15)
     assert(0, "Unreachable code");
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     auto src =
 "the quick brown fox jumps over the lazy dog\r
@@ -296,7 +296,7 @@ the quick brown fox jumps over the lazy dog\r
     assert(result == src);
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     ubyte[] src = new ubyte[1000000];
     ubyte[] dst;
@@ -657,7 +657,7 @@ class UnCompress
     }
 
     // Test for issues 3191 and 9505
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         import std.algorithm.comparison;
         import std.array;
@@ -711,7 +711,7 @@ class UnCompress
                 "The uncompressed and the original data differ");
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         ubyte[1024] invalidData;
         auto decompressor = new UnCompress();
@@ -729,7 +729,7 @@ class UnCompress
         assert(false, "Corrupted data didn't result in an error");
     }
 
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         ubyte[2014] originalData = void;
         auto compressedData = compress(originalData, 9);
@@ -773,7 +773,7 @@ class UnCompress
     }
 
     ///
-    @system unittest
+    version(StdUnittest) @system unittest
     {
         // some random data
         ubyte[1024] originalData = void;
@@ -795,7 +795,7 @@ class UnCompress
 import std.random;
 import std.stdio;
 
-@system unittest // by Dave
+version(StdUnittest) @system unittest // by Dave
 {
     debug(zlib) writeln("std.zlib.unittest");
 
@@ -855,7 +855,7 @@ import std.stdio;
 }
 
 
-@system unittest // by Artem Rebrov
+version(StdUnittest) @system unittest // by Artem Rebrov
 {
     Compress cmp = new Compress;
     UnCompress decmp = new UnCompress;
@@ -872,7 +872,7 @@ import std.stdio;
     assert( output[] == input[] );
 }
 
-@system unittest
+version(StdUnittest) @system unittest
 {
     static assert(__traits(compiles, etc.c.zlib.gzclose(null)));        // bugzilla 15457
 }


### PR DESCRIPTION
This is the purpose for which `version(StdUnittest)` was added. The pain is one-time, the benefit is forever. It is also a good practice for other library authors to copy.