### PR TITLE
Fix DScanner - same visibility attribute used as defined on line 1713

### DIFF
--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -1866,7 +1866,7 @@ static fourChars = ctRegex!(`^[0-9A-Fa-f]{0,4}$`.to!(const(Char)[]));
 a => a.matchFirst(fourChars).empty
 ---
 +/
-private bool isUpToFourHexChars(Char)(scope const(Char)[] s)
+bool isUpToFourHexChars(Char)(scope const(Char)[] s)
 {
     import std.ascii : isHexDigit;
     if (s.length > 4) return false;
@@ -1894,7 +1894,7 @@ Note that only the first item of "matchAll" was ever used in practice
 so we can return `const(Char)[]` instead of `const(Char)[][]` using a
 zero-length string to indicate no match.
 +/
-private const(Char)[] matchIPSuffix(Char)(return const(Char)[] s) @nogc nothrow pure @safe
+const(Char)[] matchIPSuffix(Char)(return const(Char)[] s) @nogc nothrow pure @safe
 {
     size_t end = s.length;
     if (end < 7) return null;


### PR DESCRIPTION
Urgh so it looks like due to the fact that DScanner was disabled for two months many PRs are still green, but never actually ran DScanner.
In this case it was https://github.com/dlang/phobos/pull/6129

```
std/net/isemail.d(1869:1)[warn]: same visibility attribute used as defined on line 1713.
std/net/isemail.d(1897:1)[warn]: same visibility attribute used as defined on line 1713.
```