### PR TITLE
fix issue 18436 - broken opCast fails silently when used with std.conv.to

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -608,7 +608,8 @@ When source type supports member template function opCast, it is used.
 */
 private T toImpl(T, S)(S value)
 if (!isImplicitlyConvertible!(S, T) &&
-    hasMember!(S, "opCast") && allSameType!(ReturnType!(S.opCast!T), T) &&
+    is(typeof(S.init.opCast!T())) &&
+    allSameType!(ReturnType!(S.opCast!T), T) &&
     !isExactSomeString!T &&
     !is(typeof(T(value))))
 {

--- a/std/conv.d
+++ b/std/conv.d
@@ -608,7 +608,7 @@ When source type supports member template function opCast, it is used.
 */
 private T toImpl(T, S)(S value)
 if (!isImplicitlyConvertible!(S, T) &&
-    is(typeof(S.init.opCast!T()) : T) &&
+    hasMember!(S, "opCast") && allSameType!(ReturnType!(S.opCast!T), T) &&
     !isExactSomeString!T &&
     !is(typeof(T(value))))
 {


### PR DESCRIPTION
I'm reasonably certain this change won't cause previously-rejected cases to be accepted or vice versa.