### PR TITLE
std.bitmanip.d - fix a -dip1000 compilable issue; trivial

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2429,7 +2429,7 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
     import std.meta;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
     {{
-        scope(failure) writefln("Failed type: %s", T.stringof);
+        scope(failure) writeln("Failed type: ", T.stringof);
         T val;
         const T cval;
         immutable T ival;
@@ -2556,7 +2556,7 @@ if (isFloatOrDouble!T)
          */
                           /*,float, double*/))
     {{
-        scope(failure) writefln("Failed type: %s", T.stringof);
+        scope(failure) writeln("Failed type: ", T.stringof);
         T val;
         const T cval;
         immutable T ival;
@@ -2721,7 +2721,7 @@ if (isFloatOrDouble!T)
                          char, wchar, dchar/*,
                          float, double*/))
     {{
-        scope(failure) writefln("Failed type: %s", T.stringof);
+        scope(failure) writeln("Failed type: ", T.stringof);
         T val;
         const T cval;
         immutable T ival;


### PR DESCRIPTION
Calls to std.stdio.writefln!(char, string) in std/bitmanip.d within @safe unittest{...}, when compiled with -dip1000 via make -f posix.mak std/bitmanip.test,
raise following error (for some yet unknown reason not with switch -dip25):
Error: @safe function std.bitmanip.__unittest_L2427_C7 cannot call @system function std.stdio.writefln!(char, string).writefln

Thus the fix trivially replaces writefln by writeln.