### PR TITLE
Optimized fracSecsToISOString and added writer overload

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10263,24 +10263,32 @@ private:
 /+
     Returns the given hnsecs as an ISO string of fractional seconds.
   +/
-static string fracSecsToISOString(int hnsecs) @safe pure nothrow
+string fracSecsToISOString(int hnsecs) @safe pure nothrow
 {
+    import std.array : appender;
+    auto w = appender!string();
+    try
+        fracSecsToISOString(w, hnsecs);
+    catch (Exception e)
+        assert(0, "fracSecsToISOString() threw.");
+    return w.data;
+}
+
+void fracSecsToISOString(W)(ref W writer, int hnsecs)
+{
+    import std.conv : toChars;
+    import std.range : padLeft;
+
     assert(hnsecs >= 0);
 
-    try
-    {
-        if (hnsecs == 0)
-            return "";
+    if (hnsecs == 0)
+        return;
 
-        string isoString = format(".%07d", hnsecs);
-
-        while (isoString[$ - 1] == '0')
-            isoString.popBack();
-
-        return isoString;
-    }
-    catch (Exception e)
-        assert(0, "format() threw.");
+    put(writer, '.');
+    auto chars = hnsecs.toChars.padLeft('0', 7);
+    while (chars.back == '0')
+        chars.popBack();
+    put(writer, chars);
 }
 
 @safe unittest


### PR DESCRIPTION
The writer overload is needed for the future writer overload of systime's tostring overloads.

While I was working on it I realized I could make it faster by not using format.

```
$ ldc2 -O -release test.d && ./test
.0009999
old		1 sec, 305 ms, 137 μs, and 9 hnsecs
new		749 ms, 261 μs, and 8 hnsecs
```

<details>

```d
import std.stdio;
import std.exception;
import std.conv;
import std.ascii;
import std.range;
import std.traits;
import std.typecons;
import std.string;
import std.datetime.systime;
import std.datetime.date;
import std.datetime.timezone;
import std.datetime.stopwatch;
import core.time;
import std.random;

enum testCount = 5_000_000;

auto fracSecsToISOString1(int hnsecs) @safe pure nothrow
{
    assert(hnsecs >= 0);

    try
    {
        if (hnsecs == 0)
            return "";

        string isoString = format(".%07d", hnsecs);

        while (isoString[$ - 1] == '0')
            isoString.popBack();

        return isoString;
    }
    catch (Exception e)
        assert(0, "format() threw.");
}

string fracSecsToISOString2(int hnsecs) @safe pure nothrow
{
    import std.array : appender;
    auto w = appender!string();
    try
        fracSecsToISOString(w, hnsecs);
    catch (Exception e)
        assert(0, "fracSecsToISOString() threw.");
    return w.data;
}

void fracSecsToISOString(W)(ref W writer, int hnsecs)
{
    import std.conv : toChars;
    import std.range : padLeft;

    assert(hnsecs >= 0);

    if (hnsecs == 0)
        return;

    put(writer, '.');
    auto chars = hnsecs.toChars.padLeft('0', 7);
    while (chars.back == '0')
        chars.popBack();
    put(writer, chars);
}

void main()
{
    string res;

    auto result = to!Duration(benchmark!(() => res = fracSecsToISOString1(9_999))(testCount)[0]);
    auto result2 = to!Duration(benchmark!(() => res = fracSecsToISOString2(9_999))(testCount)[0]);

    writeln(res); // force execution

    writeln("old", "\t\t", result);
    writeln("new", "\t\t", result2);
}
```

</details>