### PR TITLE
add opDispatch-based test to BitFlags enum

### DIFF
--- a/changelog/bitflags-property-opdispatch.dd
+++ b/changelog/bitflags-property-opdispatch.dd
@@ -1,0 +1,48 @@
+`std.typecons.BitFlags` now supports opDispatch-based property access
+
+BitFlags was extended so that enum members can be set and tested directly on the
+BitFlags instead of having to `&` with the underlying enum.
+
+-------
+enum Features
+{
+    fast = 1 << 0,
+    size = 1 << 1,
+}
+
+void run(BitFlags!Features features)
+{
+    // get
+    if (features.fast && !features.size) {} // new new new
+    if ((features & Features.fast) && !(features & Features.size)) {} // old old old
+    // set
+    features.fast = true; // new new new
+    features.fast = false; // new new new
+    features.fast |= Features.fast; // old old old
+    features.fast &= ~Features.fast; // old old old
+}
+-------
+
+This also works for unsafe BitFlags where the property get tests for an exact
+match of all bits and property set clears or sets all bits.
+
+-------
+enum Features
+{
+    fast = 1 << 0,
+    size = 1 << 1,
+    combined = fast | size,
+}
+
+void run(BitFlags!(Features, Yes.unsafe) features)
+{
+    // get
+    if (features.combined) {} // new new new
+    if ((features & Features.combined) == BitFlags!(Features, Yes.unsafe)(Features.combined)) {} // old old old
+    // set
+    features.combined = true; // new new new
+    features.combined = false; // new new new
+    features.combined |= Features.combined; // old old old
+    features.combined &= ~Features.combined; // old old old
+}
+-------

--- a/changelog/bitflags-property-opdispatch.dd
+++ b/changelog/bitflags-property-opdispatch.dd
@@ -1,6 +1,6 @@
 `std.typecons.BitFlags` now supports opDispatch-based property access
 
-BitFlags was extended so that enum members can be set and tested directly on the
+$(REF BitFlags, std.typecons) was extended so that enum members can be set and tested directly on the
 BitFlags instead of having to `&` with the underlying enum.
 
 -------

--- a/changelog/bitflags-property-opdispatch.dd
+++ b/changelog/bitflags-property-opdispatch.dd
@@ -1,7 +1,7 @@
 `std.typecons.BitFlags` now supports opDispatch-based property access
 
 $(REF BitFlags, std.typecons) was extended so that enum members can be set and tested directly on the
-BitFlags instead of having to `&` with the underlying enum.
+`BitFlags` instead of having to `&` with the underlying enum.
 
 -------
 enum Features
@@ -23,8 +23,9 @@ void run(BitFlags!Features features)
 }
 -------
 
-This also works for unsafe BitFlags where the property get tests for an exact
-match of all bits and property set clears or sets all bits.
+This also works for unsafe `BitFlags` where the property get access tests for an exact
+match of all bits of the unsafe `BitFlags` combination.
+Analogously, the property set access clears or sets all bits of the unsafe `BitFlags` combination.
 
 -------
 enum Features

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7691,13 +7691,15 @@ public:
         return opBinary!op(flag);
     }
 
-    bool opDispatch(string name)() const if (__traits(hasMember, E, name))
+    bool opDispatch(string name)() const
+    if (__traits(hasMember, E, name))
     {
         enum e = __traits(getMember, E, name);
         return (mValue & e) == e;
     }
 
-    void opDispatch(string name)(bool set) if (__traits(hasMember, E, name))
+    void opDispatch(string name)(bool set)
+    if (__traits(hasMember, E, name))
     {
         enum e = __traits(getMember, E, name);
         if (set)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7858,9 +7858,9 @@ public:
 {
     enum UnsafeEnum
     {
-        A,
-        B,
-        C,
+        A = 1,
+        B = 2,
+        C = 4,
         BC = B|C
     }
     static assert(!__traits(compiles, { BitFlags!UnsafeEnum flags; }));
@@ -7874,12 +7874,13 @@ public:
     flags.B = false;
     assert(!flags.BC); // only C
 
-    // property access sets all bits of unsafe enums
+    // property access sets all bits of unsafe enum group
     flags = flags.init;
     flags.BC = true;
-    assert(flags.B && flags.C);
+    assert(!flags.A && flags.B && flags.C);
+    flags.A = true;
     flags.BC = false;
-    assert(!flags.B && !flags.C);
+    assert(flags.A && !flags.B && !flags.C);
 }
 
 // ReplaceType

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7690,6 +7690,21 @@ public:
     {
         return opBinary!op(flag);
     }
+
+    bool opDispatch(string name)() const if (__traits(hasMember, E, name))
+    {
+        enum e = __traits(getMember, E, name);
+        return (mValue & e) == e;
+    }
+
+    void opDispatch(string name)(bool set) if (__traits(hasMember, E, name))
+    {
+        enum e = __traits(getMember, E, name);
+        if (set)
+            mValue |= e;
+        else
+            mValue &= ~e;
+    }
 }
 
 /// Set values with the | operator and test with &
@@ -7702,13 +7717,17 @@ public:
 
     // A default constructed BitFlags has no value set
     immutable BitFlags!Enum flags_empty;
+    assert(!flags_empty.A);
 
     // Value can be set with the | operator
     immutable flags_A = flags_empty | Enum.A;
 
-    // And tested with the & operator
+    // and tested using property access
+    assert(flags_A.A);
+
+    // or the & operator
     assert(flags_A & Enum.A);
-    // Which commutes
+    // which commutes.
     assert(Enum.A & flags_A);
 }
 
@@ -7740,12 +7759,20 @@ public:
         C = 1 << 2
     }
 
+    // Values can also be set using property access
+    BitFlags!Enum flags;
+    flags.A = true;
+    assert(flags & Enum.A);
+    flags.A = false;
+    assert(!(flags & Enum.A));
+
     // BitFlags can be variadically initialized
     immutable BitFlags!Enum flags_AB = BitFlags!Enum(Enum.A, Enum.B);
-    assert((flags_AB & Enum.A) && (flags_AB & Enum.B) && !(flags_AB & Enum.C));
+    assert(flags_AB.A && flags_AB.B && !flags_AB.C);
 
     // You can use the EnumMembers template to set all flags
     immutable BitFlags!Enum flags_all = EnumMembers!Enum;
+    assert(flags_all.A && flags_all.B && flags_all.C);
 }
 
 /// Binary operations: subtracting and intersecting flags
@@ -7762,7 +7789,7 @@ public:
 
     // Use the ~ operator for subtracting flags
     immutable BitFlags!Enum flags_B = flags_AB & ~BitFlags!Enum(Enum.A);
-    assert(!(flags_B & Enum.A) && (flags_B & Enum.B) && !(flags_B & Enum.C));
+    assert(!flags_B.A && flags_B.B && !flags_B.C);
 
     // use & between BitFlags for intersection
     assert(flags_B == (flags_BC & flags_AB));
@@ -7819,7 +7846,7 @@ public:
     assert(flags & flags_AB);
     assert(flags & Enum.A);
 
-    // Finally, you can of course get you raw value out of flags
+    // You can of course get you raw value out of flags
     auto value = cast(int) flags;
     assert(value == Enum.A);
 }
@@ -7832,10 +7859,25 @@ public:
         A,
         B,
         C,
-        D = B|C
+        BC = B|C
     }
-    static assert(!__traits(compiles, { BitFlags!UnsafeEnum flags2; }));
-    BitFlags!(UnsafeEnum, Yes.unsafe) flags3;
+    static assert(!__traits(compiles, { BitFlags!UnsafeEnum flags; }));
+    BitFlags!(UnsafeEnum, Yes.unsafe) flags;
+
+    // property access tests for exact match of unsafe enums
+    flags.B = true;
+    assert(!flags.BC); // only B
+    flags.C = true;
+    assert(flags.BC); // both B and C
+    flags.B = false;
+    assert(!flags.BC); // only C
+
+    // property access sets all bits of unsafe enums
+    flags = flags.init;
+    flags.BC = true;
+    assert(flags.B && flags.C);
+    flags.BC = false;
+    assert(!flags.B && !flags.C);
 }
 
 // ReplaceType


### PR DESCRIPTION
- allows for less brittle flag test
  (`flags.featureX` vs. `(flags & FlagsEnum.featureX)`)
- allows for simpler testing of combined (unsafe) flags
  (`flags.combined` vs.
   `(flags & FlagsEnum.combined) == BitFlags!(FlagsEnum, Yes.unsafe)(FlagsEnum.combined)`)