### PR TITLE
std.datetime.systime - fix a -dip1000 compilable issue; trivial

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -8981,7 +8981,7 @@ private:
     /+
         Returns $(D stdTime) converted to $(LREF SysTime)'s time zone.
       +/
-    @property long adjTime() @safe const nothrow
+    @property long adjTime() @safe const nothrow scope
     {
         return _timezone.utcToTZ(_stdTime);
     }
@@ -8990,7 +8990,7 @@ private:
     /+
         Converts the given hnsecs from $(LREF SysTime)'s time zone to std time.
       +/
-    @property void adjTime(long adjTime) @safe nothrow
+    @property void adjTime(long adjTime) @safe nothrow scope
     {
         _stdTime = _timezone.tzToUTC(adjTime);
     }


### PR DESCRIPTION
This fixes a few
Error: reference to local variable ... assigned to non-scope parameter this
The only remaining issue in this module is with
Error: @safe function std.datetime.systime.....__unittest_... cannot call @system function std.stdio.writefln
