### PR TITLE
Implement apply for Nullable, in analogy to Haskell's monad operation

### DIFF
--- a/changelog/std-typecons-nullable-apply.dd
+++ b/changelog/std-typecons-nullable-apply.dd
@@ -1,6 +1,6 @@
-`bind` was added to `std.typecons`.
+`apply` was added to `std.typecons`.
 
-`bind` is an operation for $(REF Nullable, std, typecons) values that "unpacks" the `Nullable`, performs some
+`apply` is an operation for $(REF Nullable, std, typecons) values that "unpacks" the `Nullable`, performs some
 operation (that is passed as a template parameter), then packs the result into another `Nullable` if necessary.
 When the initial `Nullable` is `null`, the resulting `Nullable` is also `null` and the function is not
 called.
@@ -8,8 +8,8 @@ called.
 -----
 Nullable!int n;
 alias square = i => i * i;
-n = n.bind!square; // does nothing if isNull
+n = n.apply!square; // does nothing if isNull
 assert(n.isNull);
 n = 2;
-assert(n.bind!square.get == 4);
+assert(n.apply!square.get == 4);
 -----

--- a/changelog/std-typecons-nullable-bind.dd
+++ b/changelog/std-typecons-nullable-bind.dd
@@ -10,3 +10,4 @@ Nullable!int square(Nullable!int n)
 {
     return n.bind!(i => i * i);
 }
+-----

--- a/changelog/std-typecons-nullable-bind.dd
+++ b/changelog/std-typecons-nullable-bind.dd
@@ -1,13 +1,15 @@
-`bind` was added to std.typecons.
+`bind` was added to `std.typecons`.
 
-$(REF bind, std, typecons) is an operation for $(D Nullable) values that "unpacks" the $(D Nullable), performs some
-operation (that is passed as a template parameter), then packs the result into another $(D Nullable) if necessary.
-When the initial $(D Nullable) is $(D null), the resulting $(D Nullable) is also $(D null) and the function is not
+`bind` is an operation for $(REF Nullable, std, typecons) values that "unpacks" the `Nullable`, performs some
+operation (that is passed as a template parameter), then packs the result into another `Nullable` if necessary.
+When the initial `Nullable` is `null`, the resulting `Nullable` is also `null` and the function is not
 called.
 
 -----
-Nullable!int square(Nullable!int n)
-{
-    return n.bind!(i => i * i);
-}
+Nullable!int n;
+alias square = i => i * i;
+n = n.bind!square; // does nothing if isNull
+assert(n.isNull);
+n = 2;
+assert(n.bind!square.get == 4);
 -----

--- a/changelog/std-typecons-nullable-bind.dd
+++ b/changelog/std-typecons-nullable-bind.dd
@@ -1,0 +1,12 @@
+`bind` was added to std.typecons.
+
+$(REF bind, std, typecons) is an operation for $(D Nullable) values that "unpacks" the $(D Nullable), performs some
+operation (that is passed as a template parameter), then packs the result into another $(D Nullable) if necessary.
+When the initial $(D Nullable) is $(D null), the resulting $(D Nullable) is also $(D null) and the function is not
+called.
+
+-----
+Nullable!int square(Nullable!int n)
+{
+    return n.bind!(i => i * i);
+}

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3416,7 +3416,7 @@ nothrow pure @nogc @safe unittest
     Nullable!int sample;
 
     // apply(null) results in a null $(D Nullable) of the function's return type.
-    auto f = sample.apply!toFloat;
+    Nullable!float f = sample.apply!toFloat;
     assert(sample.isNull && f.isNull);
 
     sample = 3;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3399,6 +3399,8 @@ template bind(alias fun)
 ///
 @safe unittest
 {
+    import std.meta : Alias;
+
     alias toFloat = Alias!(i => cast(float) i);
 
     Nullable!int sample;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3354,16 +3354,27 @@ auto nullable(alias nullValue, T)(T t)
 }
 
 /**
+Unpacks the content of a $(D Nullable), performs an operation and packs it again. Does nothing if isNull.
+
 When called on a $(D Nullable), $(D bind) will unpack the value contained in the $(D Nullable),
 pass it to the function you provide and wrap the result in another $(D Nullable) (if necessary).
 If the Nullable is null, $(D bind) will return null itself.
+
+Params:
+    t = a $(D Nullable)
+    fun = a function operating on the content of the nullable
+
+Returns:
+    `fun(t.get).nullable` if `!t.isNull`, else `Nullable.init`.
+
+See also:
+    $(HTTP en.wikipedia.org/wiki/Monad_(functional_programming)#The_Maybe_monad, The `Maybe` monad)
  */
 template bind(alias fun)
 {
     import std.functional : unaryFun;
 
-    auto bind(T)(T t)
-    if (isInstanceOf!(Nullable, T) && is(typeof(unaryFun!fun(T.init.get))))
+    auto bind(T)(T t) if (isInstanceOf!(Nullable, T) && is(typeof(unaryFun!fun(T.init.get))))
     {
         alias FunType = typeof(unaryFun!fun(T.init.get));
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3356,9 +3356,9 @@ auto nullable(alias nullValue, T)(T t)
 /**
 Unpacks the content of a $(D Nullable), performs an operation and packs it again. Does nothing if isNull.
 
-When called on a $(D Nullable), $(D bind) will unpack the value contained in the $(D Nullable),
+When called on a $(D Nullable), $(D apply) will unpack the value contained in the $(D Nullable),
 pass it to the function you provide and wrap the result in another $(D Nullable) (if necessary).
-If the Nullable is null, $(D bind) will return null itself.
+If the Nullable is null, $(D apply) will return null itself.
 
 Params:
     t = a $(D Nullable)
@@ -3370,11 +3370,11 @@ Returns:
 See also:
     $(HTTP en.wikipedia.org/wiki/Monad_(functional_programming)#The_Maybe_monad, The `Maybe` monad)
  */
-template bind(alias fun)
+template apply(alias fun)
 {
     import std.functional : unaryFun;
 
-    auto bind(T)(T t)
+    auto apply(T)(T t)
     if (isInstanceOf!(Nullable, T) && is(typeof(unaryFun!fun(T.init.get))))
     {
         alias FunType = typeof(unaryFun!fun(T.init.get));
@@ -3415,14 +3415,14 @@ nothrow pure @nogc @safe unittest
 
     Nullable!int sample;
 
-    // bind(null) results in a null $(D Nullable) of the function's return type.
-    auto f = sample.bind!toFloat;
+    // apply(null) results in a null $(D Nullable) of the function's return type.
+    auto f = sample.apply!toFloat;
     assert(sample.isNull && f.isNull);
 
     sample = 3;
 
-    // bind(non-null) calls the function and wraps the result in a $(D Nullable).
-    f = sample.bind!toFloat;
+    // apply(non-null) calls the function and wraps the result in a $(D Nullable).
+    f = sample.apply!toFloat;
     assert(!sample.isNull && !f.isNull);
     assert(f.get == 3.0f);
 }
@@ -3435,17 +3435,17 @@ nothrow pure @nogc @safe unittest
     Nullable!int sample;
 
     // when the function already returns a $(D Nullable), that $(D Nullable) is not wrapped.
-    auto result = sample.bind!greaterThree;
+    auto result = sample.apply!greaterThree;
     assert(sample.isNull && result.isNull);
 
     // The function may decide to return a null $(D Nullable).
     sample = 3;
-    result = sample.bind!greaterThree;
+    result = sample.apply!greaterThree;
     assert(!sample.isNull && result.isNull);
 
     // Or it may return a value already wrapped in a $(D Nullable).
     sample = 4;
-    result = sample.bind!greaterThree;
+    result = sample.apply!greaterThree;
     assert(!sample.isNull && !result.isNull);
     assert(result.get == 4);
 }


### PR DESCRIPTION
`bind` is an operation for Nullables that unpacks the nullable, if it's non-null, and then repacks the result in another appropriately-typed nullable. This replaces a lot of awkward `thingy.isNull ? Nullable!SomeType.init : op(thingy.get)` with `thingy.bind!op`.

"Monads are underrated."