### PR TITLE
std.datetime.timezone - fix a -dip1000 compilable issue; trivial

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -546,10 +546,10 @@ public:
     deprecated @safe unittest
     {
         import std.exception : assertNotThrown;
-        import std.stdio : writefln;
+        import std.stdio : writeln;
         static void testPZSuccess(string tzName)
         {
-            scope(failure) writefln("TZName which threw: %s", tzName);
+            scope(failure) writeln("TZName which threw: ", tzName);
             TimeZone.getTimeZone(tzName);
         }
 


### PR DESCRIPTION
A call to std.stdio.writefln!(char, string) in std/datetime/timezone.d within @safe unittest{...}, when compiled with -dip1000 via make -f posix.mak std/datetime/timezone.test,
raises following error (for some yet unknown reason not with switch -dip25):
std/datetime/timezone.d(552): Error: [manually/temporarily attributed @safe] function std.datetime.timezone.TimeZone.__unittest_L546_C22.testPZSuccess cannot call @system function std.stdio.writefln!(char, string).writefln

Thus the fix trivially replaces writefln by writeln.