### PR TITLE
Expose the enforce overload on the docs

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -388,7 +388,7 @@ void assertThrown(T : Throwable = Exception, E)
 template enforce(E : Throwable = Exception)
 if (is(typeof(new E("", __FILE__, __LINE__)) : Throwable) || is(typeof(new E(__FILE__, __LINE__)) : Throwable))
 {
-
+    ///
     T enforce(T)(T value, lazy const(char)[] msg = null,
     string file = __FILE__, size_t line = __LINE__)
     if (is(typeof({ if (!value) {} })))


### PR DESCRIPTION
Note this isn't ideal yet, because `enforce` will be displayed after the the following two overloads but it already improves the status quo and for now I don't have good ideas that can be easily done.