### PR TITLE
std.regex: Alignment hotfix

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -445,7 +445,8 @@ abstract class GenericFactory(alias EngineType, Char) : MatcherFactory!Char
 {
     import core.stdc.stdlib : malloc, free;
     import core.memory : GC;
-    enum classSize = __traits(classInstanceSize, EngineType!Char);
+    // round up to next multiple of size_t for alignment purposes
+    enum classSize = (__traits(classInstanceSize, EngineType!Char) + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
 
     Matcher!Char construct(const Regex!Char re, in Char[] input, void[] memory) const;
 


### PR DESCRIPTION
This fixes the unittests for LDC on ARM (with enabled optimizations).

The code used to store a class instance (whose size isn't padded) right before some buffer, without any padding inbetween. The buffer is thus susceptible to misalignment; e.g., `BacktrackingMatcher.dupTo()` casts the buffer from `void[]` to `size_t[]` (in `initExternalMemory()`), simply assuming an alignment >= `size_t.alignof`, which only holds if the prepended class instance size is a multiple of that (as `malloc()` returns a sufficiently aligned block already in this case).