### PR TITLE
Renaming the upcoming global import file to std.experimental.all

### DIFF
--- a/changelog/std-experimental-all.dd
+++ b/changelog/std-experimental-all.dd
@@ -1,10 +1,10 @@
-`import std.experimental.scripting` as a global convenience import
+`import std.experimental.all` as a global convenience import
 
-$(MREF std,experimental,scripting) allows convenient use of all Phobos modules
+$(MREF std,experimental,all) allows convenient use of all Phobos modules
 with one import:
 
 ---
-import std.experimental.scripting;
+import std.experimental.all;
 void main()
 {
     10.iota.map!log.sum.writeln;
@@ -13,11 +13,11 @@ void main()
 
 For short scripts a lot of imports are often needed to get all the
 modules from the standard library.
-With this release it's possible to use `import std.experimental.scripting` for importing the entire
+With this release it's possible to use `import std.experimental.all` for importing the entire
 standard library at once. This can be used for fast prototyping or REPLs:
 
 ---
-import std.experimental.scripting;
+import std.experimental.all;
 void main()
 {
     6.iota
@@ -34,6 +34,6 @@ In this case, $(LINK2 $(ROOT)spec/module.html#static_imports, static imports) or
 $(LINK2 $(ROOT)spec/module.html#renamed_imports, renamed imports) can be used
 to uniquely select a specific symbol.
 
-The baseline cost for `import std.experimental.scripting`
+The baseline cost for `import std.experimental.all`
 is less than half a second (varying from system to system) and
 work is in progress to reduce this overhead even further.

--- a/posix.mak
+++ b/posix.mak
@@ -195,7 +195,7 @@ PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   outbuffer parallelism path process random signals socket stdint \
   stdio string system traits typecons uni \
   uri utf uuid variant xml zip zlib
-PACKAGE_std_experimental = checkedint typecons scripting
+PACKAGE_std_experimental = all checkedint typecons
 PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util

--- a/std/experimental/all.d
+++ b/std/experimental/all.d
@@ -1,12 +1,12 @@
 /++
 Convenience file that allows to import entire Phobos in one command.
 +/
-module std.experimental.scripting;
+module std.experimental.all;
 
 ///
 @safe unittest
 {
-    import std.experimental.scripting;
+    import std.experimental.all;
 
     int len;
     const r = 6.iota
@@ -23,7 +23,7 @@ module std.experimental.scripting;
 ///
 @safe unittest
 {
-    import std.experimental.scripting;
+    import std.experimental.all;
     assert(10.iota.map!(partial!(pow, 2)).sum == 1023);
 }
 

--- a/win32.mak
+++ b/win32.mak
@@ -284,7 +284,7 @@ SRC_STD_INTERNAL_WINDOWS= \
 	std\internal\windows\advapi32.d
 
 SRC_STD_EXP= \
-	std\experimental\checkedint.d std\experimental\typecons.d std\experimental\scripting.d
+	std\experimental\all.d std\experimental\checkedint.d std\experimental\typecons.d
 
 SRC_STD_EXP_ALLOC_BB= \
 	std\experimental\allocator\building_blocks\affix_allocator.d \

--- a/win64.mak
+++ b/win64.mak
@@ -309,7 +309,7 @@ SRC_STD_INTERNAL_WINDOWS= \
 	std\internal\windows\advapi32.d
 
 SRC_STD_EXP= \
-	std\experimental\checkedint.d std\experimental\typecons.d std\experimental\scripting.d
+	std\experimental\all.d std\experimental\checkedint.d std\experimental\typecons.d
 
 SRC_STD_EXP_ALLOC_BB= \
 	std\experimental\allocator\building_blocks\affix_allocator.d \


### PR DESCRIPTION
I just tried to explain this to someone as he was confused by `scripting`.

`scripting` was used because it was the first name suggested by @andralex, but while I don't hope that this will stay in `experimental` for too long, it's probably a good idea to use `all` is it will immediately tell every reader what's going on. `scripting` is rather vague.

Credits: this has been suggested by @carun here https://github.com/dlang/phobos/pull/5916#discussion_r167300850

I know the name doesn't matter too much and we ideally can use `import std` soon, but it was a quick five minute change and will hopefully lead to less confusion.

See also: https://github.com/dlang/phobos/pull/5916 (PR that introduced `std.experimental.scripting`)