### PR TITLE
Make examples of BitFields more digestable for a reader

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7446,12 +7446,12 @@ template isBitFlagEnum(E)
     {
         enum isBitFlagEnum = (E.min >= 0) &&
         {
-            foreach (immutable flag; EnumMembers!E)
-            {
+            static foreach (immutable flag; EnumMembers!E)
+            {{
                 Base value = flag;
                 value &= value - 1;
                 if (value != 0) return false;
-            }
+            }}
             return true;
         }();
     }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7787,7 +7787,7 @@ public:
     assert(value == Enum.A);
 }
 
-/// You need to specify the `unsafe` parameter for enum with custom values
+/// You need to specify the `unsafe` parameter for enums with custom values
 @safe @nogc pure nothrow unittest
 {
     enum UnsafeEnum

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7474,7 +7474,11 @@ template isBitFlagEnum(E)
     }
 
     static assert(isBitFlagEnum!A);
+}
 
+/// Test an enum with default (consecutive) values
+@safe pure nothrow unittest
+{
     enum B
     {
         A,
@@ -7484,7 +7488,11 @@ template isBitFlagEnum(E)
     }
 
     static assert(!isBitFlagEnum!B);
+}
 
+/// Test an enum with non-integral values
+@safe pure nothrow unittest
+{
     enum C: double
     {
         A = 1 << 0,


### PR DESCRIPTION
Motivation: https://dlang.org/phobos/std_typecons.html#BitFlags

The idea:
- present examples in small chunks, s.t. a reader doesn't need to study 79 lines (!) to grasp the context
- explain _one_ feature per example
- order examples in chronical order (e.g. first introduce `&`, then use it)

This doesn't aim to be perfect, but better than the existing documentation.

Other remarks: Most variable names here use the non DStyle snake_case, e.g. `flags_empty` or `flags_AB`.
I left renaming them to another PR as this PR is purely focussed on reorganizing the content to be better digestable.