### PR TITLE
Add `TailShared` to `std.traits`

### DIFF
--- a/changelog/std-traits-tailshared.dd
+++ b/changelog/std-traits-tailshared.dd
@@ -1,0 +1,11 @@
+`TailShared` was added to `std.traits`
+
+$(REF TailShared, std, traits) changes a type's qualifiers such that its tail is shared, but its head isn't.
+
+---
+import std.traits;
+
+static assert(is(TailShared!int == int));
+static assert(is(TailShared!(int*) == shared(int)*));
+static assert(is(TailShared!(shared int**) == shared(int*)*));
+---


### PR DESCRIPTION
While working on some thread-safe code, I felt an easy way to unshare just the head of a type was missing. But when looking at the docs of `core.atomic` I saw references to TailShared, which happens to do just that, but is private to that module.

Now I could propose to make it public there... but it actually it hasn't much to do with atomicity, so `core.atomic` did not feel like the right place to me. I'd look in `std.traits` first for a thing like that. But moving it there is also wrong, because druntime should not depend on phobos.

So I decided to let `std.traits` steal it from `core.atomic`. A bit ugly in implementation, but I think it results in the best API.