### PR TITLE
SList implementation improvements

### DIFF
--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -929,3 +929,11 @@ Complexity: $(BIGOH n)
     s.reverse();
     assert(s[].equal([3, 2, 1]));
 }
+
+@safe unittest
+{
+    auto s = SList!int([4, 6, 8, 12, 16]);
+    auto d = s.dup;
+    assert(d !is s);
+    assert(d == s);
+}

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -290,24 +290,28 @@ define $(D opBinary).
     SList opBinary(string op, Stuff)(Stuff rhs)
     if (op == "~" && is(typeof(SList(rhs))))
     {
-        auto toAdd = SList(rhs);
-        if (empty) return toAdd;
-        // TODO: optimize
-        auto result = dup;
-        auto n = findLastNode(result._first);
-        n._next = toAdd._first;
-        return result;
+        import std.range : chain, only;
+
+        static if (isInputRange!Stuff)
+            alias r = rhs;
+        else
+            auto r = only(rhs);
+
+        return SList(this[].chain(r));
     }
 
     /// ditto
     SList opBinaryRight(string op, Stuff)(Stuff lhs)
     if (op == "~" && !is(typeof(lhs.opBinary!"~"(this))) && is(typeof(SList(lhs))))
     {
-        auto toAdd = SList(lhs);
-        if (empty) return toAdd;
-        auto result = dup;
-        result.insertFront(toAdd[]);
-        return result;
+        import std.range : chain, only;
+
+        static if (isInputRange!Stuff)
+            alias r = lhs;
+        else
+            auto r = only(lhs);
+
+        return SList(r.chain(this[]));
     }
 
 /**

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -54,6 +54,7 @@ public import std.container.util;
    $(D SList) uses reference semantics.
  */
 struct SList(T)
+if (!is(T == shared))
 {
     import std.exception : enforce;
     import std.range : Take;


### PR DESCRIPTION
- Optimize implementation of opBinary

- ~Allow concatenation of lists with different element types, if both
  element types have a common base type.~ (this change has been removed from the PR)

- Use separate common logic from insertFront and insertAfter, and use it in both of them.

- Explicitly forbid shared element types (did not work anyway, and would be bad usage of `shared` as well).