### PR TITLE
Add needed changes to get all tests passing with Musl

### DIFF
--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -647,6 +647,12 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     assert((() nothrow @nogc => r2.deallocateAll())());
 }
 
+version(CRuntime_Musl)
+{
+    // sbrk and brk are disabled in Musl:
+    // https://git.musl-libc.org/cgit/musl/commit/?id=7a995fe706e519a4f55399776ef0df9596101f93
+    // https://git.musl-libc.org/cgit/musl/commit/?id=863d628d93ea341b6a32661a1654320ce69f6a07
+} else:
 private extern(C) void* sbrk(long) nothrow @nogc;
 private extern(C) int brk(shared void*) nothrow @nogc;
 

--- a/std/socket.d
+++ b/std/socket.d
@@ -163,56 +163,14 @@ string formatSocketError(int err) @trusted
         {
             cs = strerror_r(err, buf.ptr, buf.length);
         }
-        else version (OSX)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
-        else version (FreeBSD)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
-        else version (NetBSD)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
-        else version (DragonFlyBSD)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
-        else version (Solaris)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
-        else version (CRuntime_Bionic)
-        {
-            auto errs = strerror_r(err, buf.ptr, buf.length);
-            if (errs == 0)
-                cs = buf.ptr;
-            else
-                return "Socket error " ~ to!string(err);
-        }
         else
-            static assert(0);
+        {
+            auto errs = strerror_r(err, buf.ptr, buf.length);
+            if (errs == 0)
+                cs = buf.ptr;
+            else
+                return "Socket error " ~ to!string(err);
+        }
 
         auto len = strlen(cs);
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -44,38 +44,38 @@ version (CRuntime_Glibc)
     version = GCC_IO;
     version = HAS_GETDELIM;
 }
+else version (CRuntime_Bionic)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
+else version (CRuntime_Musl)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
 
 version (OSX)
 {
     version = GENERIC_IO;
     version = HAS_GETDELIM;
 }
-
-version (FreeBSD)
+else version (FreeBSD)
 {
     version = GENERIC_IO;
     version = HAS_GETDELIM;
 }
-
-version (NetBSD)
+else version (NetBSD)
 {
     version = GENERIC_IO;
     version = HAS_GETDELIM;
 }
-
-version (DragonFlyBSD)
+else version (DragonFlyBSD)
 {
     version = GENERIC_IO;
     version = HAS_GETDELIM;
 }
-
-version (Solaris)
-{
-    version = GENERIC_IO;
-    version = NO_GETDELIM;
-}
-
-version (CRuntime_Bionic)
+else version (Solaris)
 {
     version = GENERIC_IO;
     version = NO_GETDELIM;


### PR DESCRIPTION
Only one assert trips when running the Phobos tests after this patch, [this one in `std.datetime.timezone`](https://github.com/dlang/phobos/blob/master/std/datetime/timezone.d#L781), but I don't know if that's because of the bare minimum install of Alpine I'm testing in or if it needs to be addressed. @yshui, what do you say?