### PR TITLE
Fix Issue 18341 - Documentation for std.array.split is confusing/incorrect

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3660,31 +3660,31 @@ The number of seeds must be correspondingly increased.
 
 // splitter
 /**
-Lazily splits a range using an element as a separator. This can be used with
-any narrow string type or sliceable range type, but is most popular with string
-types.
+Lazily splits a range using an element or range as a separator.
+Separator ranges can be any narrow string type or sliceable range type.
 
 Two adjacent separators are considered to surround an empty element in
 the split range. Use `filter!(a => !a.empty)` on the result to compress
 empty elements.
 
-The predicate is passed to $(REF binaryFun, std,functional), and can either accept
-a string, or any callable that can be executed via `pred(element, s)`.
+The predicate is passed to $(REF binaryFun, std,functional) and accepts
+any callable function that can be executed via `pred(element, s)`.
 
-If the empty range is given, the result is an empty range. If a range with
-one separator is given, the result is a range with two empty elements.
+Notes:
+    If splitting a string on whitespace and token compression is desired,
+    consider using `splitter` without specifying a separator.
 
-If splitting a string on whitespace and token compression is desired,
-consider using `splitter` without specifying a separator (see fourth overload
-below).
+    If no separator is passed, the $(REF_ALTTEXT, unary, unaryFun, std,functional)
+    predicate `isTerminator` decides whether to accept an element of `r`.
 
 Params:
     pred = The predicate for comparing each element with the separator,
         defaulting to `"a == b"`.
     r = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to be
-        split. Must support slicing and `.length`.
-    s = The element to be treated as the separator between range segments to be
-        split.
+        split. Must support slicing and `.length` or be a narrow string type.
+    s = The element (or range) to be treated as the separator
+        between range segments to be split.
+    isTerminator = The predicate for deciding where to split the range when no separator is passed
 
 Constraints:
     The predicate `pred` needs to accept an element of `r` and the
@@ -3695,10 +3695,15 @@ Returns:
     is a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
     or $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives),
     the returned range will be likewise.
+    When a range is used a separator, bidirectionality isn't possible.
+
+    If an empty range is given, the result is an empty range. If a range with
+    one separator is given, the result is a range with two empty elements.
 
 See_Also:
  $(REF _splitter, std,regex) for a version that splits using a regular
-expression defined separator.
+expression defined separator and
+ $(REF _splitter, std,array) for a version that splits eagerly.
 */
 auto splitter(alias pred = "a == b", Range, Separator)(Range r, Separator s)
 if (is(typeof(binaryFun!pred(r.front, s)) : bool)
@@ -3855,46 +3860,127 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     return Result(r, s);
 }
 
-///
+/// Basic splitting with characters and numbers.
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    assert("a|bc|def".splitter('|').equal([ "a", "bc", "def" ]));
+
+    int[] a = [1, 0, 2, 3, 0, 4, 5, 6];
+    int[][] w = [ [1], [2, 3], [4, 5, 6] ];
+    assert(a.splitter(0).equal(w));
+}
+
+/// Adjacent separators.
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    assert("|ab|".splitter('|').equal([ "", "ab", "" ]));
+    assert("ab".splitter('|').equal([ "ab" ]));
+
+    assert("a|b||c".splitter('|').equal([ "a", "b", "", "c" ]));
+    assert("hello  world".splitter(' ').equal([ "hello", "", "world" ]));
+
+    auto a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
+    auto w = [ [1, 2], [], [3], [4, 5], [] ];
+    assert(a.splitter(0).equal(w));
+}
+
+/// Empty and separator-only ranges.
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range : empty;
+
+    assert("".splitter('|').empty);
+    assert("|".splitter('|').equal([ "", "" ]));
+    assert("||".splitter('|').equal([ "", "", "" ]));
+}
+
+/// Use a range for splitting
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    assert("a=>bc=>def".splitter("=>").equal([ "a", "bc", "def" ]));
+    assert("a|b||c".splitter("||").equal([ "a|b", "c" ]));
+    assert("hello  world".splitter("  ").equal([ "hello", "world" ]));
+
+    int[] a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
+    int[][] w = [ [1, 2], [3, 0, 4, 5, 0] ];
+    assert(a.splitter([0, 0]).equal(w));
+
+    a = [ 0, 0 ];
+    assert(a.splitter([0, 0]).equal([ (int[]).init, (int[]).init ]));
+
+    a = [ 0, 0, 1 ];
+    assert(a.splitter([0, 0]).equal([ [], [1] ]));
+}
+
+/// Custom predicate functions.
 @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.ascii : toLower;
-    import std.range : empty, retro;
 
-    // Basic splitting with characters and numbers.
-    assert(equal(splitter("a|bc|def", '|'), [ "a", "bc", "def" ]));
-
-    int[] a = [1, 0, 2, 3, 0, 4, 5, 6];
-    int[][] w = [ [1], [2, 3], [4, 5, 6] ];
-    assert(equal(splitter(a, 0), w));
-
-    // Adjacent separators.
-    assert(equal(splitter("a|b||c", '|'), [ "a", "b", "", "c" ]));
-    assert(equal(splitter("hello  world", ' '), [ "hello", "", "world" ]));
-
-    a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
-    w = [ [1, 2], [], [3], [4, 5], [] ];
-    assert(equal(splitter(a, 0), w));
-
-    // Empty and separator-only ranges.
-    assert(splitter("", '|').empty);
-    assert(equal(splitter("|", '|'), [ "", "" ]));
-    assert(equal(splitter("||", '|'), [ "", "", "" ]));
-
-    // Leading separators, trailing separators, or no separators.
-    assert(equal(splitter("|ab|", '|'), [ "", "ab", "" ]));
-    assert(equal(splitter("ab", '|'), [ "ab" ]));
-
-    // Predicate functions.
-    assert(equal(splitter!"a.toLower == b"("abXcdxef", 'x'),
+    assert("abXcdxef".splitter!"a.toLower == b"('x').equal(
                  [ "ab", "cd", "ef" ]));
 
-    w = [ [0], [1], [2] ];
-    assert(equal(splitter!"a.front == b"(w, 1), [ [[0]], [[2]] ]));
+    auto w = [ [0], [1], [2] ];
+    assert(w.splitter!"a.front == b"(1).equal([ [[0]], [[2]] ]));
+}
 
-    // Bidirectional ranges.
-    assert(equal(splitter("a|bc|def", '|').retro, [ "def", "bc", "a" ]));
+/// Use splitter without a separator
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range.primitives : front;
+
+    assert(equal(splitter!(a => a == '|')("a|bc|def"), [ "a", "bc", "def" ]));
+    assert(equal(splitter!(a => a == ' ')("hello  world"), [ "hello", "", "world" ]));
+
+    int[] a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
+    int[][] w = [ [1, 2], [], [3], [4, 5], [] ];
+    assert(equal(splitter!(a => a == 0)(a), w));
+
+    a = [ 0 ];
+    assert(equal(splitter!(a => a == 0)(a), [ (int[]).init, (int[]).init ]));
+
+    a = [ 0, 1 ];
+    assert(equal(splitter!(a => a == 0)(a), [ [], [1] ]));
+
+    w = [ [0], [1], [2] ];
+    assert(equal(splitter!(a => a.front == 1)(w), [ [[0]], [[2]] ]));
+}
+
+/// Leading separators, trailing separators, or no separators.
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    assert("|ab|".splitter('|').equal([ "", "ab", "" ]));
+    assert("ab".splitter('|').equal([ "ab" ]));
+}
+
+/// Splitter returns bidirectional ranges if the delimiter is a single element
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range : retro;
+    assert("a|bc|def".splitter('|').retro.equal([ "def", "bc", "a" ]));
+}
+
+/// Splitting by word lazily
+@safe unittest
+{
+    import std.ascii : isWhite;
+    import std.algorithm.comparison : equal;
+    import std.algorithm.iteration : splitter;
+
+    string str = "Hello World!";
+    assert(str.splitter!(isWhite).equal(["Hello", "World!"]));
 }
 
 @safe unittest
@@ -3972,39 +4058,7 @@ if (is(typeof(binaryFun!pred(r.front, s)) : bool)
     assert(s.empty);
 }
 
-/**
-Similar to the previous overload of `splitter`, except this one uses another
-range as a separator. This can be used with any narrow string type or sliceable
-range type, but is most popular with string types. The predicate is passed to
-$(REF binaryFun, std,functional), and can either accept a string, or any callable
-that can be executed via `pred(r.front, s.front)`.
-
-Two adjacent separators are considered to surround an empty element in
-the split range. Use `filter!(a => !a.empty)` on the result to compress
-empty elements.
-
-Unlike the previous overload of `splitter`, this one will not return a
-bidirectional range.
-
-Params:
-    pred = The predicate for comparing each element with the separator,
-        defaulting to `"a == b"`.
-    r = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to be
-        split.
-    s = The $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) to
-        be treated as the separator between segments of `r` to be split.
-
-Constraints:
-    The predicate `pred` needs to accept an element of `r` and an
-    element of `s`.
-
-Returns:
-    An input range of the subranges of elements between separators. If `r`
-    is a forward range, the returned range will be a forward range.
-
-See_Also: $(REF _splitter, std,regex) for a version that splits using a regular
-expression defined separator.
- */
+/// ditto
 auto splitter(alias pred = "a == b", Range, Separator)(Range r, Separator s)
 if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
         && (hasSlicing!Range || isNarrowString!Range)
@@ -4099,26 +4153,6 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     return Result(r, s);
 }
 
-///
-@safe unittest
-{
-    import std.algorithm.comparison : equal;
-
-    assert(equal(splitter("a=>bc=>def", "=>"), [ "a", "bc", "def" ]));
-    assert(equal(splitter("a|b||c", "||"), [ "a|b", "c" ]));
-    assert(equal(splitter("hello  world", "  "), [ "hello", "world" ]));
-
-    int[] a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
-    int[][] w = [ [1, 2], [3, 0, 4, 5, 0] ];
-    assert(equal(splitter(a, [0, 0]), w));
-
-    a = [ 0, 0 ];
-    assert(equal(splitter(a, [0, 0]), [ (int[]).init, (int[]).init ]));
-
-    a = [ 0, 0, 1 ];
-    assert(equal(splitter(a, [0, 0]), [ [], [1] ]));
-}
-
 @safe unittest
 {
     import std.algorithm.comparison : equal;
@@ -4211,60 +4245,11 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     assert(words.equal([ "i", "am", "pointing" ]));
 }
 
-/**
-
-Similar to the previous overload of `splitter`, except this one does not use a separator.
-Instead, the predicate is an unary function on the input range's element type.
-The `isTerminator` predicate is passed to $(REF unaryFun, std,functional) and can
-either accept a string, or any callable that can be executed via `pred(element, s)`.
-
-Two adjacent separators are considered to surround an empty element in
-the split range. Use `filter!(a => !a.empty)` on the result to compress
-empty elements.
-
-Params:
-    isTerminator = The predicate for deciding where to split the range.
-    input = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to
-        be split.
-
-Constraints:
-    The predicate `isTerminator` needs to accept an element of `input`.
-
-Returns:
-    An input range of the subranges of elements between separators. If `input`
-    is a forward range or $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives),
-    the returned range will be likewise.
-
-See_Also: $(REF _splitter, std,regex) for a version that splits using a regular
-expression defined separator.
- */
-auto splitter(alias isTerminator, Range)(Range input)
-if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(input.front))))
+/// ditto
+auto splitter(alias isTerminator, Range)(Range r)
+if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(r.front))))
 {
-    return SplitterResult!(unaryFun!isTerminator, Range)(input);
-}
-
-///
-@safe unittest
-{
-    import std.algorithm.comparison : equal;
-    import std.range.primitives : front;
-
-    assert(equal(splitter!(a => a == '|')("a|bc|def"), [ "a", "bc", "def" ]));
-    assert(equal(splitter!(a => a == ' ')("hello  world"), [ "hello", "", "world" ]));
-
-    int[] a = [ 1, 2, 0, 0, 3, 0, 4, 5, 0 ];
-    int[][] w = [ [1, 2], [], [3], [4, 5], [] ];
-    assert(equal(splitter!(a => a == 0)(a), w));
-
-    a = [ 0 ];
-    assert(equal(splitter!(a => a == 0)(a), [ (int[]).init, (int[]).init ]));
-
-    a = [ 0, 1 ];
-    assert(equal(splitter!(a => a == 0)(a), [ [], [1] ]));
-
-    w = [ [0], [1], [2] ];
-    assert(equal(splitter!(a => a.front == 1)(w), [ [[0]], [[2]] ]));
+    return SplitterResult!(unaryFun!isTerminator, Range)(r);
 }
 
 private struct SplitterResult(alias isTerminator, Range)

--- a/std/array.d
+++ b/std/array.d
@@ -1443,20 +1443,26 @@ if (isInputRange!S && !isDynamicArray!S)
 }
 
 /++
-Eagerly split the string $(D s) into an array of words, using whitespace as
-delimiter. Runs of whitespace are merged together (no empty words are produced).
+Eagerly splits `range` into an array, using `sep` as the delimiter.
 
-$(D @safe), $(D pure) and $(D CTFE)-able.
+When no delimiter is provided, strings are split into an array of words,
+using whitespace as delimiter.
+Runs of whitespace are merged together (no empty words are produced).
+
+The `range` must be a $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives).
+The separator can be a value of the same type as the elements in `range`
+or it can be another forward `range`.
 
 Params:
-    s = the string to split
+    s = the string to split by word if no separator is given
+    range = the range to split
+    sep = a value of the same type as the elements of $(D range) or another
 
 Returns:
-    An array of each word in `s`
+    An array containing the divided parts of `range` (or the words of `s`).
 
 See_Also:
-$(REF splitter, std,algorithm,iteration) for a version that splits using any
-separator.
+$(REF splitter, std,algorithm,iteration) for a lazy version without allocating memory.
 
 $(REF splitter, std,regex) for a version that splits using a regular
 expression defined separator.
@@ -1496,25 +1502,20 @@ if (isSomeString!S)
 ///
 @safe unittest
 {
+    import std.uni : isWhite;
+    assert("Learning,D,is,fun".split(",") == ["Learning", "D", "is", "fun"]);
+    assert("Learning D is fun".split!isWhite == ["Learning", "D", "is", "fun"]);
+    assert("Learning D is fun".split(" D ") == ["Learning", "is fun"]);
+}
+
+///
+@safe unittest
+{
     string str = "Hello World!";
     assert(str.split == ["Hello", "World!"]);
 
     string str2 = "Hello\t\tWorld\t!";
     assert(str2.split == ["Hello", "World", "!"]);
-}
-
-/**
- * `split` allocates memory, so the same effect can be achieved lazily
- * using $(REF splitter, std,algorithm,iteration).
- */
-@safe unittest
-{
-    import std.ascii : isWhite;
-    import std.algorithm.comparison : equal;
-    import std.algorithm.iteration : splitter;
-
-    string str = "Hello World!";
-    assert(str.splitter!(isWhite).equal(["Hello", "World!"]));
 }
 
 @safe unittest
@@ -1571,43 +1572,12 @@ if (isSomeString!S)
     assert(a == [[1], [4, 5, 1], [4, 5]]);
 }
 
-/++
-    Eagerly splits $(D range) into an array, using $(D sep) as the delimiter.
-
-    The _range must be a
-    $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives).
-    The separator can be a value of the same type as the elements in $(D range)
-    or it can be another forward _range.
-
-    Example:
-        If $(D range) is a $(D string), $(D sep) can be a $(D char) or another
-        $(D string). The return type will be an array of strings. If $(D range) is
-        an $(D int) array, $(D sep) can be an $(D int) or another $(D int) array.
-        The return type will be an array of $(D int) arrays.
-
-    Params:
-        range = a forward _range.
-        sep = a value of the same type as the elements of $(D range) or another
-        forward range.
-
-    Returns:
-        An array containing the divided parts of $(D range).
-
-    See_Also:
-        $(REF splitter, std,algorithm,iteration) for the lazy version of this
-        function.
- +/
-auto split(Range, Separator)(Range range, Separator sep)
-if (isForwardRange!Range && is(typeof(ElementType!Range.init == Separator.init)))
-{
-    import std.algorithm.iteration : splitter;
-    return range.splitter(sep).array;
-}
 ///ditto
 auto split(Range, Separator)(Range range, Separator sep)
-if (
-    isForwardRange!Range && isForwardRange!Separator
-    && is(typeof(ElementType!Range.init == ElementType!Separator.init)))
+if (isForwardRange!Range && (
+    is(typeof(ElementType!Range.init == Separator.init)) ||
+    is(typeof(ElementType!Range.init == ElementType!Separator.init)) && isForwardRange!Separator
+    ))
 {
     import std.algorithm.iteration : splitter;
     return range.splitter(sep).array;
@@ -1618,15 +1588,6 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
 {
     import std.algorithm.iteration : splitter;
     return range.splitter!isTerminator.array;
-}
-
-///
-@safe unittest
-{
-    import std.uni : isWhite;
-    assert("Learning,D,is,fun".split(",") == ["Learning", "D", "is", "fun"]);
-    assert("Learning D is fun".split!isWhite == ["Learning", "D", "is", "fun"]);
-    assert("Learning D is fun".split(" D ") == ["Learning", "is fun"]);
 }
 
 @safe unittest

--- a/std/array.d
+++ b/std/array.d
@@ -1682,7 +1682,7 @@ if (isForwardRange!Range && is(typeof(unaryFun!isTerminator(range.front))))
     }}
 }
 
-/++
+/+
    Conservative heuristic to determine if a range can be iterated cheaply.
    Used by $(D join) in decision to do an extra iteration of the range to
    compute the resultant length. If iteration is not cheap then precomputing


### PR DESCRIPTION
I used the opportunity to reorder the examples of `splitter` too and as they are public examples I converted them to DStyle (UFCS, ~~~no string lambdas~~~).

edit: seems like `splitter` has frame access problems with normal lambdas, so I reverted the string lambda -> lambda for now and opened [18470](https://issues.dlang.org/show_bug.cgi?id=18470) for now.