### PR TITLE
[Trivial] std.path: fix a -dip1000 compilable issue

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -1736,7 +1736,7 @@ if (isSomeChar!C)
         if (result)
             result = chainPath(result, path).array;
         else
-            result = path;
+            result = path.idup;
     }
     result = asNormalizedPath(result).array;
     return cast(typeof(return)) result;

--- a/std/path.d
+++ b/std/path.d
@@ -1729,6 +1729,7 @@ immutable(C)[] buildNormalizedPath(C)(const(C[])[] paths...)
 if (isSomeChar!C)
 {
     import std.array : array;
+    import std.exception : assumeUnique;
 
     const(C)[] result;
     foreach (path; paths)
@@ -1736,7 +1737,7 @@ if (isSomeChar!C)
         if (result)
             result = chainPath(result, path).array;
         else
-            result = path.idup;
+            result = assumeUnique(path);
     }
     result = asNormalizedPath(result).array;
     return cast(typeof(return)) result;


### PR DESCRIPTION
Without this fix  and 
string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
(string path, lazy string base = getcwd())    temporarily attributed @safe
the reported errors are:
std/path.d(1742): Error: scope variable result may not be returned
std/path.d(1748): Error: template instance `std.path.buildNormalizedPath!char` error instantiating
std/path.d(1800):        while evaluating: static assert(buildNormalizedPath(["/foo/..", "/bar/./baz"][]) == "/bar/baz")
std/path.d(2873): Error: @safe function std.path.relativePath!cast(CaseSensitive)true.relativePath cannot call @system function std.conv.to!string.to!(ChooseResult!(ByCodeUnitImpl, Result)).to

Thus the remainder will be an error from std.conv.to!string.to only.