### PR TITLE
std.socket: Fix some -dip1000 compilable issues

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2517,13 +2517,13 @@ public:
             assert(!errorSet.isSet(testPair[1]));
 
             ubyte[1] b;
-            testPair[0].send(b[]);
+            () @safe { testPair[0].send(b[]); }();
             fillSets();
             n = Socket.select(readSet, null, null);
             assert(n == 1); // testPair[1]
             assert(readSet.isSet(testPair[1]));
             assert(!readSet.isSet(testPair[0]));
-            testPair[1].receive(b[]);
+            () @safe { testPair[1].receive(b[]); }();
         }
     });
 }
@@ -2929,7 +2929,7 @@ public:
      * Calling shutdown() before this is recommended
      * for connection-oriented sockets.
      */
-    void close() @trusted nothrow @nogc
+    void close() @trusted nothrow @nogc scope
     {
         _close(sock);
         sock = socket_t.init;
@@ -2993,7 +2993,7 @@ public:
      * Returns: The number of bytes actually sent, or $(D Socket.ERROR) on
      * failure.
      */
-    ptrdiff_t send(const(void)[] buf, SocketFlags flags) @trusted
+    ptrdiff_t send(const(void)[] buf, SocketFlags flags) scope @trusted
     {
         static if (is(typeof(MSG_NOSIGNAL)))
         {
@@ -3007,7 +3007,7 @@ public:
     }
 
     /// ditto
-    ptrdiff_t send(const(void)[] buf)
+    ptrdiff_t send(const(void)[] buf) scope
     {
         return send(buf, SocketFlags.NONE);
     }
@@ -3070,7 +3070,7 @@ public:
      * Returns: The number of bytes actually received, $(D 0) if the remote side
      * has closed the connection, or $(D Socket.ERROR) on failure.
      */
-    ptrdiff_t receive(void[] buf, SocketFlags flags) @trusted
+    ptrdiff_t receive(void[] buf, SocketFlags flags) scope @trusted
     {
         version(Windows)         // Does not use size_t
         {
@@ -3087,7 +3087,7 @@ public:
     }
 
     /// ditto
-    ptrdiff_t receive(void[] buf)
+    ptrdiff_t receive(void[] buf) scope
     {
         return receive(buf, SocketFlags.NONE);
     }
@@ -3582,17 +3582,17 @@ class UdpSocket: Socket
             protected pure nothrow @safe Socket accepting() { assert(0); }
             @trusted Socket accept() { assert(0); }
             nothrow @nogc @trusted void shutdown(SocketShutdown how) { assert(0); }
-            nothrow @nogc @trusted void close() { assert(0); }
+            nothrow @nogc @trusted void close() scope { assert(0); }
             @property @trusted Address remoteAddress() { assert(0); }
             @property @trusted Address localAddress() { assert(0); }
-            @trusted ptrdiff_t send(const(void)[] buf, SocketFlags flags) { assert(0); }
-            @safe ptrdiff_t send(const(void)[] buf) { assert(0); }
+            @trusted ptrdiff_t send(const(void)[] buf, SocketFlags flags) scope { assert(0); }
+            @safe ptrdiff_t send(const(void)[] buf) scope { assert(0); }
             @trusted ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags, Address to) { assert(0); }
             @safe ptrdiff_t sendTo(const(void)[] buf, Address to) { assert(0); }
             @trusted ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags) { assert(0); }
             @safe ptrdiff_t sendTo(const(void)[] buf) { assert(0); }
-            @trusted ptrdiff_t receive(void[] buf, SocketFlags flags) { assert(0); }
-            @safe ptrdiff_t receive(void[] buf) { assert(0); }
+            @trusted ptrdiff_t receive(void[] buf, SocketFlags flags) scope { assert(0); }
+            @safe ptrdiff_t receive(void[] buf) scope { assert(0); }
             @trusted ptrdiff_t receiveFrom(void[] buf, SocketFlags flags, ref Address from) { assert(0); }
             @safe ptrdiff_t receiveFrom(void[] buf, ref Address from) { assert(0); }
             @trusted ptrdiff_t receiveFrom(void[] buf, SocketFlags flags) { assert(0); }


### PR DESCRIPTION
Fixes these errors:
```
std/socket.d(2458): Error: function std.socket.softUnittest(void delegate() @safe test, int line = __LINE__) is not callable using argument types (void function() @system)
std/socket.d(2458):        cannot pass argument __lambda1 of type void function() @system to parameter void delegate() @safe test
std/socket.d(3667): Error: scope variable s assigned to non-scope parameter this calling std.socket.Socket.close
```
https://github.com/dlang/DIPs/blob/master/DIPs/DIP1000.md#scope-function-returns
In that section, the examples that have comment "applies to 'this' reference".