### PR TITLE
Disables Typedef.toString()

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6954,6 +6954,14 @@ template TypedefType(T)
     assert(s2 == cs2);
 }
 
+@safe unittest
+{
+    auto i = Typedef!int(10);
+    auto s = Typedef!string("test");
+    assert(!__traits(compiles, i.toString));
+    assert(!__traits(compiles, s.toString));
+}
+
 /**
 Allocates a $(D class) object right inside the current scope,
 therefore avoiding the overhead of $(D new). This facility is unsafe;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6735,6 +6735,10 @@ struct Typedef(T, T init = T.init, string cookie=null)
             TD re() {return TD(Typedef_payload.re);}
             TD im() {return TD(Typedef_payload.im);}
         }
+
+        // Prevents silent unexpected conversion into string and
+        // leakage of string type payload
+        @disable string toString() { return null; };
     }
 }
 


### PR DESCRIPTION
It is need to avoid silently conversion of Typedef struct to string by std.conv.to and to prohibit string type payload leakage.

Discussion:
https://forum.dlang.org/post/kjzayldqnixehfprgslc@forum.dlang.org