### PR TITLE
std.complex: Minimally relax unittest for 64-bit reals

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -929,7 +929,15 @@ deprecated
     assert(coshisinh(3.0L) == complex(std.math.cosh(3.0L), std.math.sinh(3.0L)));
     auto z1 = coshisinh(1.234);
     auto z2 = std.math.coshisinh(1.234);
-    assert(z1.re == z2.re && z1.im == z2.im);
+    static if (real.mant_dig == 53)
+    {
+        assert(std.math.feqrel(z1.re, z2.re) >= real.mant_dig - 1 &&
+               std.math.feqrel(z1.im, z2.im) >= real.mant_dig - 1);
+    }
+    else
+    {
+        assert(z1.re == z2.re && z1.im == z2.im);
+    }
 }
 
 /**


### PR DESCRIPTION
I'm seeing a diff in the last mantissa bit for the imaginary parts with LDC on Win64 and its 64-bit reals.