### PR TITLE
[dmd-cxx] Temporarily disable checkwhitespace to get auto-tester to build DMD's testsuite

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -517,7 +517,8 @@ CWS_TOCHECK = posix.mak win32.mak win64.mak
 CWS_TOCHECK += $(ALL_D_FILES) index.d
 
 checkwhitespace: $(LIB) $(TOOLS_DIR)/checkwhitespace.d
-	$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -run $(TOOLS_DIR)/checkwhitespace.d $(CWS_TOCHECK)
+	# Temporarily disabled - see https://github.com/dlang/dmd/pull/7953
+	#$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -run $(TOOLS_DIR)/checkwhitespace.d $(CWS_TOCHECK)
 
 #############################
 # Submission to Phobos are required to conform to the DStyle


### PR DESCRIPTION
See also:

https://github.com/dlang/dmd/pull/7953#issuecomment-368275298

In short `dmd-cxx` is the C/C++ branch of dmd and interesting for bootstrapping on new OSes (though LDC's cross-compilation works too). This is a small step towards getting the testsuite on the auto-tester working again as running the dmd testsuite itself will hopefully reveal the real issue.