### PR TITLE
Use baseName to also skip leapseconds file in subfolders

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2391,6 +2391,7 @@ public:
         }
         else
         {
+            import std.path : baseName;
             foreach (DirEntry de; dirEntries(tzDatabaseDir, SpanMode.depth))
             {
                 if (de.isFile)
@@ -2399,7 +2400,7 @@ public:
 
                     if (!tzName.extension().empty ||
                         !tzName.startsWith(subName) ||
-                        tzName == "leapseconds" ||
+                        baseName(tzName) == "leapseconds" ||
                         tzName == "+VERSION")
                     {
                         continue;


### PR DESCRIPTION
Like on NixOS in the posix subfolder.

Without this the timezone unittest fails on NixOS.