### PR TITLE
Fix awfully slow sicmp

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -7777,20 +7777,26 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
     && isInputRange!S2 && isSomeChar!(ElementEncodingType!S2))
 {
     import std.internal.unicode_tables : sTable = simpleCaseTable; // generated file
-    import std.utf : byDchar;
+    import std.utf : decodeFront;
+    import std.typecons : Yes;
+    static import std.ascii;
 
-    auto str1 = r1.byDchar;
-    auto str2 = r2.byDchar;
-
-    foreach (immutable lhs; str1)
+    while (!r1.empty)
     {
-        if (str2.empty)
+        immutable lhs = decodeFront!(Yes.useReplacementDchar)(r1);
+        if (r2.empty)
             return 1;
-        immutable rhs = str2.front;
-        str2.popFront();
+        immutable rhs = decodeFront!(Yes.useReplacementDchar)(r2);
         int diff = lhs - rhs;
         if (!diff)
             continue;
+        else if ((lhs | rhs) < 0x80)
+        {
+            auto lowL = std.ascii.toLower(lhs);
+            auto lowR = std.ascii.toLower(rhs);
+            if (!(lowL - lowR)) continue;
+            else return lowL - lowR;
+        }
         size_t idx = simpleCaseTrie[lhs];
         size_t idx2 = simpleCaseTrie[rhs];
         // simpleCaseTrie is packed index table
@@ -7816,7 +7822,7 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
         // one of chars is not cased at all
         return diff;
     }
-    return str2.empty ? 0 : -1;
+    return r2.empty ? 0 : -1;
 }
 
 ///

--- a/std/uni.d
+++ b/std/uni.d
@@ -7792,10 +7792,9 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
             continue;
         if ((lhs | rhs) < 0x80)
         {
-            auto lowL = std.ascii.toLower(lhs);
-            auto lowR = std.ascii.toLower(rhs);
-            if (!(lowL - lowR)) continue;
-            else return lowL - lowR;
+            immutable d = std.ascii.toLower(lhs) - std.ascii.toLower(rhs);
+            if (!d) continue;
+            return d;
         }
         size_t idx = simpleCaseTrie[lhs];
         size_t idx2 = simpleCaseTrie[rhs];

--- a/std/uni.d
+++ b/std/uni.d
@@ -7821,7 +7821,7 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
         // one of chars is not cased at all
         return diff;
     }
-    return -int(r2.empty);
+    return int(r2.empty) - 1;
 }
 
 ///

--- a/std/uni.d
+++ b/std/uni.d
@@ -7790,7 +7790,7 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
         int diff = lhs - rhs;
         if (!diff)
             continue;
-        else if ((lhs | rhs) < 0x80)
+        if ((lhs | rhs) < 0x80)
         {
             auto lowL = std.ascii.toLower(lhs);
             auto lowR = std.ascii.toLower(rhs);
@@ -7822,7 +7822,7 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
         // one of chars is not cased at all
         return diff;
     }
-    return r2.empty ? 0 : -1;
+    return -int(r2.empty);
 }
 
 ///


### PR DESCRIPTION
Turns out byDchar is ~2x slower then decodeFront,
time to either deprecate byDchar or make it fast.

<del>
2nd order of magnitude improvement is handling
ascii case w/o lookup tables.</del>

```
//1st module
import core.stdc.string;
import std.datetime.stopwatch;
import std.uni;
import std.stdio;
import bench_data;

extern(C) int strcasecmp(const char *s1, const char *s2);

void main() {
    auto timings = benchmark!(
        () => blackhole = sicmp(ascii1, ascii2),
        () => blackhole = sicmp(uni1, uni2),
        () => blackhole = strcasecmp(ascii1.ptr, ascii2.ptr)
    )(1_000_000);
    writefln("ASCII %s", timings[0]);
    writefln("Unicode %s", timings[1]);
    writefln("strcasecmp %s", timings[2]);
}

// 2nd module to hide data from optimizer
module bench_data;
string ascii1 = "This is some STring";
string ascii2 = "ThiS is some strIng";

string uni1 = "Некая СТроКа";
string uni2 = "некаЯ стРока";

int blackhole;
```