### PR TITLE
add std.array.pointer as @safe alternative to .ptr

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3852,3 +3852,28 @@ unittest
     assert(appS.data == "hellow");
     assert(appA.data == "hellow");
 }
+
+/++
+Return `.ptr` or `null` for an array `a`, mitigating the fact we can't use `.ptr` in @safe code.
+`a.ptr` could be an invalid but non-null address if `a` was produced as an empty
+slice of another array, eg b[$ .. $]; returning `null` here prevents memory corruption.
+
+Params:
+    a = array
+Returns:
+    `a.ptr` or null
++/
+T* pointer(T)(T[] a) @trusted @nogc pure nothrow
+{
+    return a.length > 0 ? a.ptr : null;
+}
+
+///
+@safe unittest
+{
+    auto a = [0, 1];
+    auto b = a.pointer;
+    assert(b && b[0] == 0);
+    auto c = a[$ .. $].pointer;
+    assert(c is null);
+}


### PR DESCRIPTION
* addresses https://issues.dlang.org/show_bug.cgi?id=18529
* proposed here https://forum.dlang.org/thread/mailman.301.1519721047.3374.digitalmars-d@puremagic.com?page=2
* eg use case: https://forum.dlang.org/post/lqvihadaufwivbiigtqv@forum.dlang.org or anywhere where we want `.ptr` for a potentially empty slice in @safe code
