### PR TITLE
Temporarily disable curl tests for FreeBSD 32-bit

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -164,6 +164,16 @@ import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
 
+// Curl tests for FreeBSD 32-bit are temporarily disabled.
+// https://github.com/braddr/d-tester/issues/70
+// https://issues.dlang.org/show_bug.cgi?id=18519
+version(unittest)
+version(FreeBSD)
+version(X86)
+    version = DisableCurlTests;
+
+version(DisableCurlTests) {} else:
+
 version(unittest)
 {
     import std.socket : Socket;


### PR DESCRIPTION
See also: https://github.com/braddr/d-tester/issues/70#issuecomment-368670639

I'm aware that this isn't ideal and `StdUnittest` would be better suited for this, but it keeps the diff small and `std.net.curl` is broken on FreeBSD 32-bit anyhow.
Moreover, I have the opinion that we should just drop the support for legacy platforms that almost no one actively uses, but well that's a different story.