### PR TITLE
reenable unittests for Win64

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -50,7 +50,7 @@ DFLAGS=-conf= -m$(MODEL) -O -release -w -de -dip25 -I$(DRUNTIME)\import
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import -unittest
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
They have been disabled by https://github.com/dlang/phobos/pull/5927