### PR TITLE
fix issue 18519 freebsd 11 + phobos + curl, timing out

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -185,6 +185,7 @@ version(unittest)
     private:
         string _addr;
         Tid tid;
+        TcpSocket sock;
 
         static void loop(shared TcpSocket listener)
         {
@@ -214,19 +215,30 @@ version(unittest)
         import std.concurrency : spawn;
         import std.socket : INADDR_LOOPBACK, InternetAddress, TcpSocket;
 
+        tlsInit = true;
         auto sock = new TcpSocket;
         sock.bind(new InternetAddress(INADDR_LOOPBACK, InternetAddress.PORT_ANY));
         sock.listen(1);
         auto addr = sock.localAddress.toString();
         auto tid = spawn(&TestServer.loop, cast(shared) sock);
-        return TestServer(addr, tid);
+        return TestServer(addr, tid, sock);
     }
+
+    __gshared TestServer server;
+    bool tlsInit;
 
     private ref TestServer testServer()
     {
         import std.concurrency : initOnce;
-        __gshared TestServer server;
         return initOnce!server(startServer());
+    }
+
+    static ~this()
+    {
+        // terminate server from a thread local dtor of the thread that started it,
+        //  because thread_joinall is called before shared module dtors
+        if (tlsInit && server.sock)
+            server.sock.close();
     }
 
     private struct Request(T)


### PR DESCRIPTION
stop the TestServer waiting in accept() before thread_joinall

Windows is also affected if libcurl.dll is missing.