### PR TITLE
[stable] Temporarily disable curl tests for FreeBSD 32-bit

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -164,6 +164,16 @@ import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
 
+// Curl tests for FreeBSD 32-bit are temporarily disabled.
+// https://github.com/braddr/d-tester/issues/70
+// https://issues.dlang.org/show_bug.cgi?id=18519
+version(unittest)
+version(FreeBSD)
+version(X86)
+    version = DisableCurlTests;
+
+version(DisableCurlTests) {} else:
+
 version(unittest)
 {
     import std.socket : Socket;


### PR DESCRIPTION
Cherry-pick https://github.com/dlang/phobos/pull/6232 to `stable`, s.t. auto-tester will pass on stable too.
Note this will fail on auto-tester as it requires https://github.com/dlang/dmd/pull/7970 first.

See also: https://github.com/braddr/d-tester/issues/70