### PR TITLE
Minor optimization for byDchar for wchar[] / byWchar for dchar[]

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -4008,7 +4008,11 @@ if (isSomeChar!C)
                     }
                     else
                     {
-                        if (r.front < 0x80)
+                        static if (is(RC == wchar))
+                            enum firstMulti = 0xD800; // First high surrogate.
+                        else
+                            enum firstMulti = 0x80; // First non-ASCII.
+                        if (r.front < firstMulti)
                         {
                             buff = r.front;
                             r.popFront;
@@ -4052,7 +4056,11 @@ if (isSomeChar!C)
                         pos = 0;
                         auto c = r.front;
 
-                        if (c <= 0x7F)
+                        static if (C.sizeof >= 2 && RC.sizeof >= 2)
+                            enum firstMulti = 0xD800; // First high surrogate.
+                        else
+                            enum firstMulti = 0x80; // First non-ASCII.
+                        if (c < firstMulti)
                         {
                             fill = 1;
                             r.popFront;


### PR DESCRIPTION
Minor enhancement to recent https://github.com/dlang/phobos/pull/6229

When converting from wchar to dchar, the optimization for ASCII characters can be applied to most of the basic multilingual plane.

EDIT: This also applies in reverse when converting from dchar to wchar, so I've added it to that case too.