### PR TITLE
Prefer an appender to a dynamic array

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1472,7 +1472,7 @@ if (isSomeString!S)
 {
     size_t istart;
     bool inword = false;
-    S[] result;
+    auto result = appender!(S[]);
 
     foreach (i, dchar c ; s)
     {
@@ -1481,7 +1481,7 @@ if (isSomeString!S)
         {
             if (inword)
             {
-                result ~= s[istart .. i];
+                put(result, s[istart .. i]);
                 inword = false;
             }
         }
@@ -1495,8 +1495,8 @@ if (isSomeString!S)
         }
     }
     if (inword)
-        result ~= s[istart .. $];
-    return result;
+        put(result, s[istart .. $]);
+    return result.data;
 }
 
 ///


### PR DESCRIPTION
benchmark:
```d
unittest
{
    import std.stdio, std.datetime.stopwatch;

    auto str = "a bb ccc dddd eeee fff gg h i jj kkk llll mmmm nnn oo p q rr sss tttt uuuu vvv ww x y zz";

    void use_an_array() { auto ret = split(str); }
    void use_an_appender() { auto ret = split2(str); }

    auto r = benchmark!(use_an_array, use_an_appender)(1_000_000);

    writefln("use_an_array: %s", r[0]);
    writefln("use_an_appender: %s", r[1]);
}
```

output:
```
use_an_array: 4 secs, 343 ms, 762 μs, and 4 hnsecs
use_an_appender: 2 secs, 882 ms, 757 μs, and 9 hnsecs
```