### PR TITLE
[ASan] Handle the (invalid) return value of posix_memalign

### DIFF
--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -243,7 +243,6 @@ version(LDC_AddressSanitizer)
         if (code == -1)
             return null;
 }
-
         if (code == ENOMEM)
             return null;
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -234,6 +234,16 @@ struct AlignedMallocator
         assert(a.isGoodDynamicAlignment);
         void* result;
         auto code = posix_memalign(&result, a, bytes);
+
+version(OSX)
+version(LDC_AddressSanitizer)
+{
+        // The return value with AddressSanitizer may be -1 instead of ENOMEM
+        // or EINVAL. See https://bugs.llvm.org/show_bug.cgi?id=36510
+        if (code == -1)
+            return null;
+}
+
         if (code == ENOMEM)
             return null;
 


### PR DESCRIPTION
See https://github.com/ldc-developers/phobos/pull/58

With ASan enabled, posix_memalign returns -1 upon invalid parameters or when not enough memory is available. This bug is reported with compiler-rt here: https://bugs.llvm.org/show_bug.cgi?id=36510
Still, if we deal with the invalid -1 return value in Phobos, we can continue testing with ASan enabled.
It looks like this workaround is only needed on OSX.

@andralex 