### PR TITLE
Fix strerror usage in uClibc version

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1536,10 +1536,13 @@ private bool isUnionAliasedImpl(T)(size_t offset)
         static assert( isUnionAliased!(S.A5, 1)); //a5.b1;
 }
 
+version (CRuntime_Glibc) version = GNU_STRERROR;
+version (CRuntime_UClibc) version = GNU_STRERROR;
+
 package string errnoString(int errno) nothrow @trusted
 {
     import core.stdc.string : strlen;
-    version (CRuntime_Glibc)
+    version (GNU_STRERROR)
     {
         import core.stdc.string : strerror_r;
         char[1024] buf = void;

--- a/std/socket.d
+++ b/std/socket.d
@@ -146,6 +146,8 @@ class SocketException: Exception
     mixin basicExceptionCtors;
 }
 
+version (CRuntime_Glibc) version = GNU_STRERROR;
+version (CRuntime_UClibc) version = GNU_STRERROR;
 
 /*
  * Needs to be public so that SocketOSException can be thrown outside of
@@ -159,7 +161,7 @@ string formatSocketError(int err) @trusted
     {
         char[80] buf;
         const(char)* cs;
-        version (CRuntime_Glibc)
+        version (GNU_STRERROR)
         {
             cs = strerror_r(err, buf.ptr, buf.length);
         }


### PR DESCRIPTION
glibc and uclibc have the same api for strerror.