### PR TITLE
std.algorithm.searching: Fix a -dip1000 compilable issue

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -297,7 +297,7 @@ private:
     ptrdiff_t[ElementType!(Range)] occ;         // GC allocated
     Range needle;
 
-    ptrdiff_t occurrence(ElementType!(Range) c)
+    ptrdiff_t occurrence(ElementType!(Range) c) scope
     {
         auto p = c in occ;
         return p ? *p : -1;
@@ -360,7 +360,7 @@ public:
     }
 
     ///
-    Range beFound(Range haystack)
+    Range beFound(Range haystack) scope
     {
         import std.algorithm.comparison : max;
 


### PR DESCRIPTION
Eliminates an error from std.algorithm.searching (the remaining errors are from std.algorithm.comparison and std.uni):

make -f posix.mak std/algorithm/searching.test  [-dip1000 for std.algorithm.searching.d (the posix.mak I'm using is master+ https://github.com/dlang/phobos/pull/6195] + -dip1000 for searching.d; master at Latest commit 4820a49)]:

```
std/algorithm/searching.d(2101): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2102): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2103): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2104): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2105): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2106): Error: @safe function std.algorithm.searching.__unittest_L2088_C7 cannot call @system function std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).find
std/algorithm/searching.d(2424): Error: @safe function std.algorithm.searching.__unittest_L2416_C7 cannot call @system function std.algorithm.searching.find!(string, binaryFun, string).find
std/algorithm/searching.d(2436): Error: @safe function std.algorithm.searching.__unittest_L2430_C7 cannot call @system function std.algorithm.searching.find!(int[], binaryFun, int[]).find
std/algorithm/searching.d(2437): Error: @safe function std.algorithm.searching.__unittest_L2430_C7 cannot call @system function std.algorithm.searching.find!(int[], binaryFun, int[]).find
std/algorithm/searching.d(2443): Error: @safe function std.algorithm.searching.__unittest_L2440_C7 cannot call @system function std.algorithm.searching.find!(string, binaryFun, string).find
```

PR applied and function
R1 find(alias pred = "a == b", R1, R2)(R1 haystack, scope R2 needle)
temporarily attributed @safe, results in:
```
std/algorithm/searching.d(1969): Error: scope variable needle assigned to non-scope parameter r2 calling std.algorithm.comparison.mismatch!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b")).mismatch
std/algorithm/searching.d(2101): Error: template instance `std.algorithm.searching.find!("a == b", SortedRange!(int[], "a < b"), SortedRange!(int[], "a < b"))` error instantiating
std/uni.d(2553): Error: reference to local variable __tmpfordtor1666 assigned to non-scope parameter this calling std.uni.InversionList!(GcPolicy).InversionList.byInterval
std/uni.d(1976): Error: template instance `std.uni.InversionList!(GcPolicy)` error instantiating
```
