### PR TITLE
Revert "Temporarily disable curl tests for FreeBSD 32-bit"

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -164,16 +164,6 @@ import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
 
-// Curl tests for FreeBSD 32-bit are temporarily disabled.
-// https://github.com/braddr/d-tester/issues/70
-// https://issues.dlang.org/show_bug.cgi?id=18519
-version(unittest)
-version(FreeBSD)
-version(X86)
-    version = DisableCurlTests;
-
-version(DisableCurlTests) {} else:
-
 version(unittest)
 {
     import std.socket : Socket;


### PR DESCRIPTION
Reverts dlang/phobos#6232

Let's see whether https://github.com/dlang/phobos/pull/6234 fixed the issue for FreeBSD.