### PR TITLE
Fix issue with benchmark unit test when compiling with optimizations.

### DIFF
--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -447,7 +447,7 @@ Duration[fun.length] benchmark(fun...)(uint n)
     void f0() nothrow {}
     void f1() nothrow { auto b = to!string(a); }
     auto r = benchmark!(f0, f1)(1000);
-    assert(r[0] > Duration.zero);
+    assert(r[0] >= Duration.zero);
     assert(r[1] > Duration.zero);
     assert(r[1] > r[0]);
     assert(r[0] < seconds(1));


### PR DESCRIPTION
Apparently, with gdc and optimizations turned on, the test in question
is optimized enough that the first function being benchmarked sometimes
takes no time at all (since the function being benchmarked does
nothing), causing the test to fail. This fixes that.