### PR TITLE
[TRIVIAL] std.experimental.logger...: Fix -dip1000 compilable issues

### DIFF
--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -825,7 +825,7 @@ abstract class Logger
     }
 
     /** Logs a part of the log message. */
-    protected void logMsgPart(const(char)[] msg) @safe
+    protected void logMsgPart(scope const(char)[] msg) @safe
     {
         static if (isLoggingActive)
         {

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -138,7 +138,7 @@ class FileLogger : Logger
     /* This methods overrides the base class method and writes the parts of
     the log call directly to the file.
     */
-    override protected void logMsgPart(const(char)[] msg)
+    override protected void logMsgPart(scope const(char)[] msg)
     {
         formattedWrite(this.file_.lockingTextWriter(), "%s", msg);
     }


### PR DESCRIPTION
Using posix.mak from https://github.com/dlang/phobos/pull/6195
with aa[std.experimental.logger.core]=-dip1000  and running
make -f posix.mak std/experimental/logger/core.test
results in:
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/experimental/logger/core.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/experimental/logger/core.d(654): Error: reference to local variable buffer assigned to non-scope parameter msg calling std.experimental.logger.core.Logger.logMsgPart
std/experimental/logger/core.d(674): Error: @safe function std.experimental.logger.core.__unittest_L668_C9.dummy cannot call @system function std.experimental.logger.core.formatString!(string, string).formatString
std/experimental/logger/core.d(1852): Error: @safe function std.experimental.logger.core.testFuncNames cannot call @system function std.experimental.logger.core.Logger.log!string.log
std/experimental/logger/core.d(1894): Error: @safe function std.experimental.logger.core.__unittest_L1866_C7 cannot call @system function std.experimental.logger.core.log!(LogLevel).log
std/experimental/logger/core.d(1919): Error: @safe function std.experimental.logger.core.__unittest_L1907_C7 cannot call @system function std.experimental.logger.core.Logger.log!string.log
std/experimental/logger/core.d(1952): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.log!string.log
std/experimental/logger/core.d(1958): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.log!string.log
std/experimental/logger/core.d(1964): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.log!string.log
std/experimental/logger/core.d(1970): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.logf!(1970, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(1976): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.logf!(1976, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(1982): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.logf!(1982, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2003): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.Logger.logf!(2003, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2028): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.log!string.log
std/experimental/logger/core.d(2034): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.log!(string, "std.experimental.logger.core").log
std/experimental/logger/core.d(2040): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.log!(string, "std.experimental.logger.core").log
std/experimental/logger/core.d(2046): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.logf!(2046, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2052): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.logf!(2052, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2058): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.logf!(2058, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2080): Error: @safe function std.experimental.logger.core.__unittest_L1944_C7 cannot call @system function std.experimental.logger.core.logf!(2080, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L1944_C7", "void std.experimental.logger.core.__unittest_L1944_C7() @safe", "std.experimental.logger.core", string).logf
std/experimental/logger/core.d(2167): Error: @safe function std.experimental.logger.core.__unittest_L2161_C7 cannot call @system function std.experimental.logger.core.Logger.memLogFunctions!cast(LogLevel)cast(ubyte)64u.logImpl!(2167, "std/experimental/logger/core.d", "std.experimental.logger.core.__unittest_L2161_C7", "void std.experimental.logger.core.__unittest_L2161_C7() @safe", "std.experimental.logger.core", string).logImpl
posix.mak:570: (the rule for target „std/experimental/logger/core.test“ failed) die Regel für Ziel „std/experimental/logger/core.test“ scheiterte
```

With PR applied (and  std.experimental.logger.core. formatString and systimeToISOString TEMPORARILY ATTRIBUTED @safe), the remaining errors are:
A known one, https://issues.dlang.org/show_bug.cgi?id=17961 / https://github.com/dlang/phobos/pull/6041 from std.uni  and  unsolved ones from std.format.formattedWrite

