### PR TITLE
Cache and reuse std.regex engine to speed repeated matching

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -172,6 +172,15 @@ final:
         backtracking.initExternalMemory(memBlock);
     }
 
+    override Matcher!Char rearm(in Char[] data)
+    {
+        merge[] = Trace.init;
+        exhausted = false;
+        s = Stream(data);
+        next();
+        return this;
+    }
+
     this(ref const RegEx program, Stream stream, void[] memBlock, dchar ch, DataIndex idx)
     {
         _refCount = 1;

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -448,9 +448,9 @@ abstract class GenericFactory(alias EngineType, Char) : MatcherFactory!Char
     // round up to next multiple of size_t for alignment purposes
     enum classSize = (__traits(classInstanceSize, EngineType!Char) + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
 
-    Matcher!Char construct(const ref Regex!Char re, in Char[] input, void[] memory) const;
+    EngineType!Char construct(const ref Regex!Char re, in Char[] input, void[] memory) const;
 
-    override Matcher!Char create(const ref Regex!Char re, in Char[] input) const @trusted
+    override EngineType!Char create(const ref Regex!Char re, in Char[] input) const @trusted
     {
         immutable size = EngineType!Char.initialMemory(re) + classSize;
         auto memory = enforce(malloc(size), "malloc failed")[0 .. size];
@@ -462,7 +462,7 @@ abstract class GenericFactory(alias EngineType, Char) : MatcherFactory!Char
         return engine;
     }
 
-    override Matcher!Char dup(Matcher!Char engine, in Char[] input) const @trusted
+    override EngineType!Char dup(Matcher!Char engine, in Char[] input) const @trusted
     {
         immutable size = EngineType!Char.initialMemory(engine.pattern) + classSize;
         auto memory = enforce(malloc(size), "malloc failed")[0 .. size];
@@ -554,6 +554,8 @@ abstract:
     void dupTo(Matcher!Char m, void[] memory);
     // The pattern loaded
     @property ref const(Regex!Char) pattern() @safe;
+    // Re-arm the engine with new Input
+    Matcher rearm(in Char[] stream);
 }
 
 /++
@@ -629,6 +631,7 @@ package(std.regex):
     uint[] backrefed;                      // bit array of backreferenced submatches
     Kickstart!Char kickstart;
     MatcherFactory!Char factory;           // produces optimal matcher for this pattern
+    immutable(Char)[] pattern;             // copy of pattern to serve as cache key
 
     const(Regex) withFactory(MatcherFactory!Char factory) pure const @trusted
     {
@@ -765,6 +768,11 @@ struct BackLooperImpl(Input)
     {
         _origin = input._origin;
         _index = index;
+    }
+    this(String input)
+    {
+        _origin = input;
+        _index = input.length;
     }
     @trusted bool nextChar(ref dchar res,ref size_t pos)
     {

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -28,6 +28,7 @@ auto makeRegex(S, CG)(Parser!(S, CG) p)
         charsets = g.charsets;
         matchers = g.matchers;
         backrefed = g.backrefed;
+        re.pattern = p.origin.idup;
         re.postprocess();
         // check if we have backreferences, if so - use backtracking
         if (__ctfe) factory = null; // allows us to use the awful enum re = regex(...);

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -847,6 +847,14 @@ final:
         }
     }
 
+    override Matcher!Char rearm(in Char[] data)
+    {
+        exhausted = false;
+        matched = 0;
+        s = Stream(data);
+        return this;
+    }
+
     this()(ref const Regex!Char program, Stream stream, void[] memory)
     {
          // We are emplace'd to malloced memory w/o blitting T.init over it\

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -826,9 +826,28 @@ public:
 private @trusted auto matchOnce(RegEx, R)(R input, const auto ref RegEx prog)
 {
     alias Char = BasicElementOf!R;
+    static struct Key
+    {
+        immutable(Char)[] pattern;
+        uint flags;
+    }
+    static Key cacheKey = Key("", -1);
+    static Matcher!Char cache;
     auto factory = prog.factory is null ? defaultFactory!Char(prog) : prog.factory;
-    auto engine = factory.create(prog, input);
-    scope(exit) factory.decRef(engine); // destroys the engine
+    auto key = Key(prog.pattern, prog.flags);
+    Matcher!Char engine;
+    if (cacheKey == key)
+    {
+        engine = cache;
+        engine.rearm(input);
+    }
+    else
+    {
+        engine = factory.create(prog, input);
+        if (cache) factory.decRef(cache); // destroy cached engine *after* building a new one
+        cache = engine;
+        cacheKey = key;
+    }
     auto captures = Captures!R(input, prog.ngroup, prog.dict);
     captures._nMatch = engine.match(captures.matches);
     return captures;


### PR DESCRIPTION
Prime use case is line by line matching.

Some anecdotal evidence on @jondegenhardt benchmarks shows:

```
# Before
▶ ./find_regex '(aa)+(cc)+g' strings.txt               
106437 matches; 5538.671 milliseconds

# After
▶ ./find_regex '(aa)+(cc)+g' strings.txt
106437 matches; 1880.550 milliseconds
```
For roughly ~3x speedup.

See also:
https://issues.dlang.org/show_bug.cgi?id=18114