### PR TITLE
Implement std.math.{atan[2],tan,exp[2],expm1} for single- and double-precision

### DIFF
--- a/changelog/math_float_double_implementations.dd
+++ b/changelog/math_float_double_implementations.dd
@@ -1,0 +1,15 @@
+Single- and double-precision implementations for (a)tan and exp function families
+
+The `float` and `double` overloads of
+$(REF atan, std, math), $(REF atan2, std, math), $(REF tan, std, math),
+$(REF exp, std, math), $(REF expm1, std, math) and $(REF exp2, std, math)
+previously forwarded to the `real` implementation (inline assembly) and
+now got proper 'software' implementations in the corresponding precision.
+
+While this may result in a slowdown in some cases for DMD (especially for
+`exp()` and `exp2()`), the overall speed-up factor for LDC is > 3, for
+both `double` and `float`.
+
+This also implies less precise results, especially in single-precision,
+so if your code depended on more accurate results via 80-bit intermediate
+precision, you'll have to cast the argument(s) explicitly now.

--- a/std/math.d
+++ b/std/math.d
@@ -1123,10 +1123,11 @@ private T tanImpl(T)(T x) @safe pure nothrow @nogc
     {
         T y = floor(x / cast(T) PI_4);
         // Strip high bits of integer part.
-        enum numHighBits = (realFormat == RealFormat.ieeeDouble ? 3 : 4);
-        T z = ldexp(y, -numHighBits);
+        enum T highBitsFactor = (realFormat == RealFormat.ieeeDouble ? 0x1p3 : 0x1p4);
+        enum T highBitsInv = 1.0 / highBitsFactor;
+        T z = y * highBitsInv;
         // Compute y - 2^numHighBits * (y / 2^numHighBits).
-        z = y - ldexp(floor(z), numHighBits);
+        z = y - highBitsFactor * floor(z);
 
         // Integer and fraction part modulo one octant.
         int j = cast(int)(z);
@@ -2344,7 +2345,7 @@ private T expImpl(T)(T x) @safe pure nothrow @nogc
         xx = x * x;
         const T px = x * poly(xx, P);
         x = px / (poly(xx, Q) - px);
-        x = (cast(T) 1.0) + ldexp(x, 1);
+        x = (cast(T) 1.0) + (cast(T) 2.0) * x;
     }
 
     // Scale by power of 2.
@@ -3173,7 +3174,7 @@ private T exp2Impl(T)(T x) @nogc @safe pure nothrow
         const T xx = x * x;
         const T px = x * poly(xx, P);
         x = px / (poly(xx, Q) - px);
-        x = (cast(T) 1.0) + ldexp(x, 1);
+        x = (cast(T) 1.0) + (cast(T) 2.0) * x;
     }
 
     // Scale by power of 2.

--- a/std/math.d
+++ b/std/math.d
@@ -2195,7 +2195,7 @@ real exp(real x) @trusted pure nothrow @nogc // TODO: @safe
         // (This is valid because the overflow & underflow limits for exp
         // and exp2 are so similar).
         if (!__ctfe)
-            return exp2(LOG2E*x);
+            return exp2Asm(LOG2E*x);
     }
     else version(D_InlineAsm_X86_64)
     {
@@ -2203,7 +2203,7 @@ real exp(real x) @trusted pure nothrow @nogc // TODO: @safe
         // (This is valid because the overflow & underflow limits for exp
         // and exp2 are so similar).
         if (!__ctfe)
-            return exp2(LOG2E*x);
+            return exp2Asm(LOG2E*x);
     }
     return expImpl(x);
 }
@@ -2837,21 +2837,21 @@ private T expm1Impl(T)(T x) @safe pure nothrow @nogc
  *    $(TR $(TD $(NAN))        $(TD $(NAN))    )
  *  )
  */
-pragma(inline, true)
-real exp2(real x) @nogc @trusted pure nothrow
+real exp2(real x) @nogc @trusted pure nothrow // TODO: @safe
 {
     version(InlineAsm_X86_Any)
     {
         if (!__ctfe)
             return exp2Asm(x);
-        else
-            return exp2Impl(x);
     }
-    else
-    {
-        return exp2Impl(x);
-    }
+    return exp2Impl(x);
 }
+
+/// ditto
+double exp2(double x) @nogc @safe pure nothrow { return exp2Impl(x); }
+
+/// ditto
+float exp2(float x) @nogc @safe pure nothrow { return exp2Impl(x); }
 
 ///
 @safe unittest
@@ -2859,6 +2859,16 @@ real exp2(real x) @nogc @trusted pure nothrow
     assert(isIdentical(exp2(0.0), 1.0));
     assert(exp2(2.0).feqrel(4.0) > 16);
     assert(exp2(8.0).feqrel(256.0) > 16);
+}
+
+@safe unittest
+{
+    version(CRuntime_Microsoft) {} else // aexp2/exp2f/exp2l not implemented
+    {
+        assert( core.stdc.math.exp2f(0.0f) == 1 );
+        assert( core.stdc.math.exp2 (0.0)  == 1 );
+        assert( core.stdc.math.exp2l(0.0L) == 1 );
+    }
 }
 
 version(InlineAsm_X86_Any)
@@ -3055,12 +3065,13 @@ L_was_nan:
         static assert(0);
 }
 
-private real exp2Impl(real x) @nogc @trusted pure nothrow
+private T exp2Impl(T)(T x) @nogc @safe pure nothrow
 {
     // Coefficients for exp2(x)
-    static if (floatTraits!real.realFormat == RealFormat.ieeeQuadruple)
+    enum realFormat = floatTraits!T.realFormat;
+    static if (realFormat == RealFormat.ieeeQuadruple)
     {
-        static immutable real[5] P = [
+        static immutable T[5] P = [
             9.079594442980146270952372234833529694788E12L,
             1.530625323728429161131811299626419117557E11L,
             5.677513871931844661829755443994214173883E8L,
@@ -3068,7 +3079,7 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
             1.587171580015525194694938306936721666031E2L
         ];
 
-        static immutable real[6] Q = [
+        static immutable T[6] Q = [
             2.619817175234089411411070339065679229869E13L,
             1.490560994263653042761789432690793026977E12L,
             1.092141473886177435056423606755843616331E10L,
@@ -3077,24 +3088,50 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
             1.0
         ];
     }
-    else
+    else static if (realFormat == RealFormat.ieeeExtended)
     {
-        static immutable real[3] P = [
+        static immutable T[3] P = [
             2.0803843631901852422887E6L,
             3.0286971917562792508623E4L,
             6.0614853552242266094567E1L,
         ];
-        static immutable real[4] Q = [
+        static immutable T[4] Q = [
             6.0027204078348487957118E6L,
             3.2772515434906797273099E5L,
             1.7492876999891839021063E3L,
             1.0000000000000000000000E0L,
         ];
     }
+    else static if (realFormat == RealFormat.ieeeDouble)
+    {
+        static immutable T[3] P = [
+            1.51390680115615096133E3L,
+            2.02020656693165307700E1L,
+            2.30933477057345225087E-2L,
+        ];
+        static immutable T[3] Q = [
+            4.36821166879210612817E3L,
+            2.33184211722314911771E2L,
+            1.00000000000000000000E0L,
+        ];
+    }
+    else static if (realFormat == RealFormat.ieeeSingle)
+    {
+        static immutable T[6] P = [
+            6.931472028550421E-001L,
+            2.402264791363012E-001L,
+            5.550332471162809E-002L,
+            9.618437357674640E-003L,
+            1.339887440266574E-003L,
+            1.535336188319500E-004L,
+        ];
+    }
+    else
+        static assert(0, "no coefficients for exp2()");
 
     // Overflow and Underflow limits.
-    enum real OF =  16_384.0L;
-    enum real UF = -16_382.0L;
+    enum T OF = T.max_exp;
+    enum T UF = T.min_exp - 1;
 
     // Special cases.
     if (isNaN(x))
@@ -3104,16 +3141,40 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
     if (x < UF)
         return 0.0;
 
-    // Separate into integer and fractional parts.
-    int n = cast(int) floor(x + 0.5);
-    x -= n;
+    static if (realFormat == RealFormat.ieeeSingle) // special case for single precision
+    {
+        // The following is necessary because range reduction blows up.
+        if (x == 0.0f)
+            return 1.0f;
 
-    // Rational approximation:
-    //  exp2(x) = 1.0 + 2x P(x^^2) / (Q(x^^2) - P(x^^2))
-    const real xx = x * x;
-    const real px = x * poly(xx, P);
-    x = px / (poly(xx, Q) - px);
-    x = 1.0 + ldexp(x, 1);
+        // Separate into integer and fractional parts.
+        const T i = floor(x);
+        int n = cast(int) i;
+        x -= i;
+        if (x > 0.5f)
+        {
+            n += 1;
+            x -= 1.0f;
+        }
+
+        // Rational approximation:
+        //  exp2(x) = 1.0 + x P(x)
+        x = 1.0f + x * poly(x, P);
+    }
+    else
+    {
+        // Separate into integer and fractional parts.
+        const T i = floor(x + cast(T) 0.5);
+        int n = cast(int) i;
+        x -= i;
+
+        // Rational approximation:
+        //  exp2(x) = 1.0 + 2x P(x^^2) / (Q(x^^2) - P(x^^2))
+        const T xx = x * x;
+        const T px = x * poly(xx, P);
+        x = px / (poly(xx, Q) - px);
+        x = (cast(T) 1.0) + ldexp(x, 1);
+    }
 
     // Scale by power of 2.
     x = ldexp(x, n);
@@ -3121,22 +3182,48 @@ private real exp2Impl(real x) @nogc @trusted pure nothrow
     return x;
 }
 
-///
-@safe unittest
+@safe @nogc nothrow unittest
 {
     assert(feqrel(exp2(0.5L), SQRT2) >= real.mant_dig -1);
     assert(exp2(8.0L) == 256.0);
     assert(exp2(-9.0L)== 1.0L/512.0);
-}
 
-@safe unittest
-{
-    version(CRuntime_Microsoft) {} else // aexp2/exp2f/exp2l not implemented
+    static void testExp2(T)()
     {
-        assert( core.stdc.math.exp2f(0.0f) == 1 );
-        assert( core.stdc.math.exp2 (0.0)  == 1 );
-        assert( core.stdc.math.exp2l(0.0L) == 1 );
+        // NaN
+        const T specialNaN = NaN(0x0123L);
+        assert(isIdentical(exp2(specialNaN), specialNaN));
+
+        // over-/underflow
+        enum T OF = T.max_exp;
+        enum T UF = T.min_exp - T.mant_dig;
+        assert(isIdentical(exp2(OF + 1), cast(T) T.infinity));
+        assert(isIdentical(exp2(UF - 1), cast(T) 0.0));
+
+        static immutable T[2][] vals =
+        [
+            // x, exp2(x)
+            [  0.0, 1.0 ],
+            [ -0.0, 1.0 ],
+            [  0.5, SQRT2 ],
+            [  8.0, 256.0 ],
+            [ -9.0, 1.0 / 512 ],
+        ];
+
+        foreach (ref val; vals)
+        {
+            const T x = val[0];
+            const T r = val[1];
+            const T e = exp2(x);
+
+            //printf("exp2(%Lg) = %Lg, should be %Lg\n", cast(real) x, cast(real) e, cast(real) r);
+            assert(approxEqual(r, e));
+        }
     }
+
+    import std.meta : AliasSeq;
+    foreach (T; AliasSeq!(real, double, float))
+        testExp2!T();
 }
 
 /*

--- a/std/math.d
+++ b/std/math.d
@@ -1090,9 +1090,18 @@ private T tanImpl(T)(T x) @safe pure nothrow @nogc
     }
     else static if (realFormat == RealFormat.ieeeSingle)
     {
+        static immutable T[6] P = [
+            3.33331568548E-1,
+            1.33387994085E-1,
+            5.34112807005E-2,
+            2.44301354525E-2,
+            3.11992232697E-3,
+            9.38540185543E-3,
+        ];
+
         enum T P1 = 0.78515625;
-        enum T P2 = 2.4187564849853515625e-4;
-        enum T P3 = 3.77489497744594108e-8;
+        enum T P2 = 2.4187564849853515625E-4;
+        enum T P3 = 3.77489497744594108E-8;
     }
     else
         static assert(0, "no coefficients for tan()");
@@ -1148,19 +1157,9 @@ private T tanImpl(T)(T x) @safe pure nothrow @nogc
     if (zz > zzThreshold)
     {
         static if (realFormat == RealFormat.ieeeSingle)
-        {
-            y = ((((( 9.38540185543E-3f  * zz
-                    + 3.11992232697E-3f) * zz
-                    + 2.44301354525E-2f) * zz
-                    + 5.34112807005E-2f) * zz
-                    + 1.33387994085E-1f) * zz
-                    + 3.33331568548E-1f) * zz * z
-                + z;
-        }
+            y = z + z * (zz * poly(zz, P));
         else
-        {
             y = z + z * (zz * poly(zz, P) / poly(zz, Q));
-        }
     }
     else
         y = z;
@@ -1393,26 +1392,31 @@ private T atanImpl(T)(T x) @safe pure nothrow @nogc
     else static if (realFormat == RealFormat.ieeeDouble)
     {
         static immutable T[5] P = [
-            -6.485021904942025371773E1L,
-            -1.228866684490136173410E2L,
-            -7.500855792314704667340E1L,
-            -1.615753718733365076637E1L,
-            -8.750608600031904122785E-1L,
+           -6.485021904942025371773E1L,
+           -1.228866684490136173410E2L,
+           -7.500855792314704667340E1L,
+           -1.615753718733365076637E1L,
+           -8.750608600031904122785E-1L,
         ];
         static immutable T[6] Q = [
-             1.945506571482613964425E2L,
-             4.853903996359136964868E2L,
-             4.328810604912902668951E2L,
-             1.650270098316988542046E2L,
-             2.485846490142306297962E1L,
-             1.000000000000000000000E0L,
+            1.945506571482613964425E2L,
+            4.853903996359136964868E2L,
+            4.328810604912902668951E2L,
+            1.650270098316988542046E2L,
+            2.485846490142306297962E1L,
+            1.000000000000000000000E0L,
         ];
 
         enum T MOREBITS = 6.123233995736765886130E-17L;
     }
     else static if (realFormat == RealFormat.ieeeSingle)
     {
-        // inlined below
+        static immutable T[4] P = [
+           -3.33329491539E-1,
+            1.99777106478E-1,
+           -1.38776856032E-1,
+            8.05374449538E-2,
+        ];
     }
     else
         static assert(0, "no coefficients for atan()");
@@ -1486,17 +1490,9 @@ private T atanImpl(T)(T x) @safe pure nothrow @nogc
         // Rational form in x^^2.
         const T z = x * x;
         static if (realFormat == RealFormat.ieeeSingle)
-        {
-            y += ((( 8.05374449538e-2f * z
-                   - 1.38776856032E-1f) * z
-                   + 1.99777106478E-1f) * z
-                   - 3.33329491539E-1f) * z * x
-                 + x;
-        }
+            y += poly(z, P) * z * x + x;
         else
-        {
             y = y + (poly(z, P) / poly(z, Q)) * z * x + x;
-        }
     }
 
     return (sign) ? -y : y;
@@ -2227,6 +2223,15 @@ private T expImpl(T)(T x) @safe pure nothrow @nogc
     alias F = floatTraits!T;
     static if (F.realFormat == RealFormat.ieeeSingle)
     {
+        static immutable T[6] P = [
+            5.0000001201E-1,
+            1.6666665459E-1,
+            4.1665795894E-2,
+            8.3334519073E-3,
+            1.3981999507E-3,
+            1.9875691500E-4,
+        ];
+
         enum T C1 = 0.693359375;
         enum T C2 = -2.12194440e-4;
 
@@ -2329,14 +2334,7 @@ private T expImpl(T)(T x) @safe pure nothrow @nogc
     static if (F.realFormat == RealFormat.ieeeSingle)
     {
         xx = x * x;
-        x = ((((( 1.9875691500E-4f  * x
-                + 1.3981999507E-3f) * x
-                + 8.3334519073E-3f) * x
-                + 4.1665795894E-2f) * x
-                + 1.6666665459E-1f) * x
-                + 5.0000001201E-1f) * xx
-                + x
-                + 1.0f;
+        x = poly(x, P) * xx + x + 1.0f;
     }
     else
     {

--- a/std/math.d
+++ b/std/math.d
@@ -2508,7 +2508,17 @@ real expm1(real x) @trusted pure nothrow @nogc // TODO: @safe
 }
 
 /// ditto
-double expm1(double x) @safe pure nothrow @nogc { return __ctfe ? cast(double) expm1(cast(real) x) : expm1Impl(x); }
+double expm1(double x) @safe pure nothrow @nogc
+{
+    return __ctfe ? cast(double) expm1(cast(real) x) : expm1Impl(x);
+}
+
+/// ditto
+float expm1(float x) @safe pure nothrow @nogc
+{
+    // no single-precision version in Cephes => use double precision
+    return __ctfe ? cast(float) expm1(cast(real) x) : cast(float) expm1Impl(cast(double) x);
+}
 
 ///
 @safe unittest

--- a/std/math.d
+++ b/std/math.d
@@ -8438,6 +8438,20 @@ do
     }
 }
 
+/// ditto
+Unqual!(CommonType!(T1, T2)) poly(T1, T2, int N)(T1 x, ref const T2[N] A) @safe pure nothrow @nogc
+if (isFloatingPoint!T1 && isFloatingPoint!T2 && N > 0 && N <= 10)
+{
+    // statically unrolled version for up to 10 coefficients
+    typeof(return) r = A[N - 1];
+    static foreach (i; 1 .. N)
+    {
+        r *= x;
+        r += A[N - 1 - i];
+    }
+    return r;
+}
+
 ///
 @safe nothrow @nogc unittest
 {

--- a/std/math.d
+++ b/std/math.d
@@ -929,10 +929,10 @@ real tan(real x) @trusted pure nothrow @nogc // TODO: @safe
 }
 
 /// ditto
-double tan(double x) @safe pure nothrow @nogc { return tanImpl(x); }
+double tan(double x) @safe pure nothrow @nogc { return __ctfe ? cast(double) tan(cast(real) x) : tanImpl(x); }
 
 /// ditto
-float tan(float x) @safe pure nothrow @nogc { return tanImpl(x); }
+float tan(float x) @safe pure nothrow @nogc { return __ctfe ? cast(float) tan(cast(real) x) : tanImpl(x); }
 
 ///
 @safe unittest
@@ -1330,10 +1330,10 @@ real atan(real x) @safe pure nothrow @nogc
 }
 
 /// ditto
-double atan(double x) @safe pure nothrow @nogc { return atanImpl(x); }
+double atan(double x) @safe pure nothrow @nogc { return __ctfe ? cast(double) atan(cast(real) x) : atanImpl(x); }
 
 /// ditto
-float atan(float x) @safe pure nothrow @nogc { return atanImpl(x); }
+float atan(float x) @safe pure nothrow @nogc { return __ctfe ? cast(float) atan(cast(real) x) : atanImpl(x); }
 
 ///
 @safe unittest
@@ -1582,13 +1582,13 @@ real atan2(real y, real x) @trusted pure nothrow @nogc // TODO: @safe
 /// ditto
 double atan2(double y, double x) @safe pure nothrow @nogc
 {
-    return atan2Impl(y, x);
+    return __ctfe ? cast(double) atan2(cast(real) y, cast(real) x) : atan2Impl(y, x);
 }
 
 /// ditto
 float atan2(float y, float x) @safe pure nothrow @nogc
 {
-    return atan2Impl(y, x);
+    return __ctfe ? cast(float) atan2(cast(real) y, cast(real) x) : atan2Impl(y, x);
 }
 
 ///
@@ -2206,10 +2206,10 @@ real exp(real x) @trusted pure nothrow @nogc // TODO: @safe
 }
 
 /// ditto
-double exp(double x) @safe pure nothrow @nogc { return expImpl(x); }
+double exp(double x) @safe pure nothrow @nogc { return __ctfe ? cast(double) exp(cast(real) x) : expImpl(x); }
 
 /// ditto
-float exp(float x) @safe pure nothrow @nogc { return expImpl(x); }
+float exp(float x) @safe pure nothrow @nogc { return __ctfe ? cast(float) exp(cast(real) x) : expImpl(x); }
 
 ///
 @safe unittest
@@ -2508,7 +2508,7 @@ real expm1(real x) @trusted pure nothrow @nogc // TODO: @safe
 }
 
 /// ditto
-double expm1(double x) @safe pure nothrow @nogc { return expm1Impl(x); }
+double expm1(double x) @safe pure nothrow @nogc { return __ctfe ? cast(double) expm1(cast(real) x) : expm1Impl(x); }
 
 ///
 @safe unittest
@@ -2847,10 +2847,10 @@ real exp2(real x) @nogc @trusted pure nothrow // TODO: @safe
 }
 
 /// ditto
-double exp2(double x) @nogc @safe pure nothrow { return exp2Impl(x); }
+double exp2(double x) @nogc @safe pure nothrow { return __ctfe ? cast(double) exp2(cast(real) x) : exp2Impl(x); }
 
 /// ditto
-float exp2(float x) @nogc @safe pure nothrow { return exp2Impl(x); }
+float exp2(float x) @nogc @safe pure nothrow { return __ctfe ? cast(float) exp2(cast(real) x) : exp2Impl(x); }
 
 ///
 @safe unittest


### PR DESCRIPTION
And make the x87 `real` version CTFE-able.

Based on Cephes like the existing quadruple and x87 implementations,
https://github.com/jeremybarnes/cephes/blob/master/cmath/atan.c &
https://github.com/jeremybarnes/cephes/blob/master/single/atanf.c