### PR TITLE
Remove the empty std.digest.digest site

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -200,7 +200,7 @@ PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util
 PACKAGE_std_datetime = date interval package stopwatch systime timezone
-PACKAGE_std_digest = crc digest hmac md murmurhash package ripemd sha
+PACKAGE_std_digest = crc hmac md murmurhash package ripemd sha
 PACKAGE_std_experimental_logger = core filelogger \
   nulllogger multilogger package
 PACKAGE_std_experimental_allocator = \
@@ -234,6 +234,7 @@ EXTRA_DOCUMENTABLES := $(EXTRA_MODULES_LINUX) $(EXTRA_MODULES_WIN32) $(EXTRA_MOD
 
 EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 	algorithm/internal \
+	digest/digest \
 	$(addprefix internal/, \
 		cstring digest/sha_SSSE3 \
 		$(addprefix math/, biguintcore biguintnoasm biguintx86	\

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -101,7 +101,7 @@ enum LetterCase : bool
 @safe unittest
 {
     import std.digest.hmac : hmac;
-    import std.digest.digest : toHexString;
+    import std.digest : toHexString;
     import std.digest.sha : SHA1;
     import std.string : representation;
 

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -2,20 +2,34 @@ module std.digest.digest;
 
 import _newDigest = std.digest;
 
-// scheduled for deprecation in 2.077
-// See also: https://github.com/dlang/phobos/pull/5013#issuecomment-313987845
+// @@@DEPRECATED_2.084@@@
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias isDigest = _newDigest.isDigest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias DigestType = _newDigest.DigestType;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias hasPeek = _newDigest.hasPeek;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias hasBlockSize = _newDigest.hasBlockSize;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias digest = _newDigest.digest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias hexDigest = _newDigest.hexDigest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias makeDigest = _newDigest.makeDigest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias Digest = _newDigest.Digest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias Order = _newDigest.Order;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias toHexString = _newDigest.toHexString;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias asArray = _newDigest.asArray;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias digestLength = _newDigest.digestLength;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias WrapperDigest = _newDigest.WrapperDigest;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias secureEqual = _newDigest.secureEqual;
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
 alias LetterCase = _newDigest.LetterCase;


### PR DESCRIPTION
https://dlang.org/phobos/std_digest_digest.html

std.digest.digest was moved to std.digest in https://github.com/dlang/phobos/pull/5013