### PR TITLE
Reduce size of slow testcase in std.algorithm.setops

### DIFF
--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -504,7 +504,7 @@ if (!allSatisfy!(isForwardRange, R1, R2, RR) ||
 
     assert(canFind(N4, tuple(1, 2, 3, 4)));
     assert(canFind(N4, tuple(4, 3, 2, 1)));
-    assert(canFind(N4, tuple(10, 31, 7, 12)));
+    assert(canFind(N4, tuple(10, 3, 7, 2)));
 }
 
 // Issue 9878


### PR DESCRIPTION
This test takes an unfeasibly large amount of time to run. (I've never managed to run it to completion.)

The only reason why it appears to pass is that it completes instantly, because canFind never evaluates the Cartesian range at all due to DMD bug #12486. When I fixed it in DMD PR https://github.com/dlang/dmd/pull/8013, the test started timing out.

By the way, how do I get reviewers for that DMD PR?