### PR TITLE
Push deprecation of std.exception.enforceEx

### DIFF
--- a/changelog/std-exception-enforceEx.dd
+++ b/changelog/std-exception-enforceEx.dd
@@ -1,0 +1,24 @@
+`std.exception.enforceEx` was deprecated in favor of `std.exception.enforce`
+
+With 2.079 $(REF enforce, std,exception) became a complete super set of
+$(REF enforceEx, std,exception)
+
+$(H3 Corrective action)
+
+Replace:
+
+---
+import std.exception;
+alias enf = enforceEx!Exception;
+assertNotThrown(enf(true));
+assertThrown(enf(false, "blah"));
+---
+
+with:
+
+---
+import std.exception;
+alias enf = enforce!Exception;
+assertNotThrown(enf(true));
+assertThrown(enf(false, "blah"));
+---

--- a/std/exception.d
+++ b/std/exception.d
@@ -636,16 +636,14 @@ T errnoEnforce(T, string file = __FILE__, size_t line = __LINE__)
     return value;
 }
 
-// @@@DEPRECATED_2.084@@@
+// @@@DEPRECATED_2.089@@@
 /++
-    $(RED Deprecated. Please use $(LREF enforce) instead. This function will be removed 2.084.)
+    $(RED Deprecated. Please use $(LREF enforce) instead. This function will be removed 2.089.)
 
     If $(D !value) is $(D false), $(D value) is returned. Otherwise,
     $(D new E(msg, file, line)) is thrown. Or if $(D E) doesn't take a message
     and can be constructed with $(D new E(file, line)), then
     $(D new E(file, line)) will be thrown.
-
-    This is legacy name, it is recommended to use $(D enforce!E) instead.
 
     Example:
     --------------------
@@ -654,7 +652,7 @@ T errnoEnforce(T, string file = __FILE__, size_t line = __LINE__)
     enforceEx!DataCorruptionException(line.length);
     --------------------
  +/
-//deprecated("Please use enforce instead")
+deprecated("Use `enforce`. `enforceEx` will be removed with 2.089.")
 template enforceEx(E : Throwable)
 if (is(typeof(new E("", string.init, size_t.init))))
 {
@@ -667,7 +665,7 @@ if (is(typeof(new E("", string.init, size_t.init))))
 }
 
 /+ Ditto +/
-//deprecated("Please use enforce instead")
+deprecated("Use `enforce`. `enforceEx` will be removed with 2.089.")
 template enforceEx(E : Throwable)
 if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.init, size_t.init))))
 {
@@ -679,7 +677,7 @@ if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.i
     }
 }
 
-//deprecated
+deprecated
 @system unittest
 {
     import core.exception : OutOfMemoryError;
@@ -723,7 +721,7 @@ if (is(typeof(new E(string.init, size_t.init))) && !is(typeof(new E("", string.i
     static assert(!is(typeof(enforceEx!int(true))));
 }
 
-//deprecated
+deprecated
 @safe unittest
 {
     alias enf = enforceEx!Exception;


### PR DESCRIPTION
In https://github.com/dlang/phobos/pull/6086 we prepared `enforce` to be a super set of `enforceEx` and thus allow a deprecation of it.

See also: https://dlang.org/changelog/2.079.0.html#std-exception-enforce

> However, if enforce can't fully replace enforceEx, then it needs to stick around for at least one more release so that we can have a release where enforce can fully replace enforceEx.

This has happened, so we finally can start the deprecation rodeo.

The targetted deprecation version is 2.084 as it's marked as a legacy symbol in the docs for quite a while now.