### PR TITLE
Simplify implementation of errnoEnforce

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -629,12 +629,7 @@ private void bailOut(E : Throwable = Exception)(string file, size_t line, in cha
     enforce(line.length); // expect a non-empty line
     --------------------
  +/
-T errnoEnforce(T, string file = __FILE__, size_t line = __LINE__)
-    (T value, lazy string msg = null)
-{
-    if (!value) throw new ErrnoException(msg, file, line);
-    return value;
-}
+alias errnoEnforce = enforce!ErrnoException;
 
 // @@@DEPRECATED_2.084@@@
 /++


### PR DESCRIPTION
With `enforce` now being an epoynmous template, `enforce` is a superset of `errnooEnforce`.

While it might be deputable to deeprecate tthe symbol, we can definitely simplify its implementation which also helps the readers browsing the documentation.

See also:

https://github.com/dlang/phobos/pull/6086