### PR TITLE
[Trivial]std.uni: Fix a -dip1000 compilable issue; appeared since #6041

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -7537,7 +7537,7 @@ public:
     }
 
     /// Append all $(CHARACTERS) from the input range $(D inp) to this Grapheme.
-    ref opOpAssign(string op, Input)(Input inp)
+    ref opOpAssign(string op, Input)(scope Input inp)
         if (isInputRange!Input && is(ElementType!Input : dchar))
     {
         static if (op == "~")


### PR DESCRIPTION
Using posix.mak from https://github.com/dlang/phobos/pull/6278
make -f posix.mak std/uni.test
results in:
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/uni.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/uni.d(7414): Error: scope variable chars assigned to non-scope parameter inp calling std.uni.Grapheme.opOpAssign!("~", const(dchar)[]).opOpAssign
std/uni.d(8363): Error: template instance `std.uni.Grapheme.__ctor!dchar` error instantiating
std/uni.d(7414): Error: scope variable chars assigned to non-scope parameter inp calling std.uni.Grapheme.opOpAssign!("~", const(int)[]).opOpAssign
std/uni.d(8371): Error: template instance `std.uni.Grapheme.__ctor!int` error instantiating
```
sources used (on Linux x86_64):
dmd     : Latest commit 17bc56c
druntime: Latest commit f2711a3
phobos  : Latest commit 6947d80