### PR TITLE
Escape backslashes in documentation, supporting Markdown escapes

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -472,7 +472,7 @@ $(JSON) : $(ALL_D_FILES)
 ###########################################################
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(EXTRA_DOCUMENTABLES))
 # Set DDOC, the documentation generator
-DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -version=StdDdoc \
+DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -version=StdDdoc -transition=markdown \
 	-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS)
 
 # D file to html, e.g. std/conv.d -> std_conv.html

--- a/std/path.d
+++ b/std/path.d
@@ -3564,7 +3564,7 @@ if (isConvertibleToString!Range)
         $(LI $(D filename) must not contain any characters whose integer
             representation is in the range 0-31.)
         $(LI $(D filename) must not contain any of the following $(I reserved
-            characters): <>:"/\|?*)
+            characters): <>:"/\\|?*)
         $(LI $(D filename) may not end with a space ($(D ' ')) or a period
             ($(D '.')).)
     )

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -136,7 +136,7 @@ $(TR $(TD Objects) $(TD
     $(REG_ROW \W, Matches any non-word character.)
     $(REG_ROW \s, Matches whitespace, same as \p{White_Space}.)
     $(REG_ROW \S, Matches any character except those recognized as $(I \s ). )
-    $(REG_ROW \\, Matches \ character. )
+    $(REG_ROW \\\\, Matches \\ character. )
     $(REG_ROW \c where c is one of [|*+?(), Matches the character c itself. )
     $(REG_ROW \p{PropertyName}, Matches a character that belongs
         to the Unicode PropertyName set.
@@ -261,7 +261,7 @@ $(TR $(TD Objects) $(TD
         $(REG_ROW $', part of input $(I following) the match. )
         $(REG_ROW $$, '$' character. )
         $(REG_ROW \c $(COMMA) where c is any character, the character c itself. )
-        $(REG_ROW \\, '\' character. )
+        $(REG_ROW \\\\, '\\' character. )
         $(REG_ROW $(DOLLAR)1 .. $(DOLLAR)99, submatch number 1 to 99 respectively. )
     )
 


### PR DESCRIPTION
This is in support of the corresponding [dmd PR](https://github.com/dlang/dmd/pull/8043). It should *not* be merged until that PR is accepted and merged.