### PR TITLE
Fix unrelated DAutoTest diff changes

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -424,7 +424,8 @@ void assertThrown(T : Throwable = Exception, E)
         from `Dg`'s safety and purity.
  +/
 template enforce(E : Throwable = Exception)
-if (is(typeof(new E("", __FILE__, __LINE__)) : Throwable) || is(typeof(new E(__FILE__, __LINE__)) : Throwable))
+if (is(typeof(new E("", string.init, size_t.init)) : Throwable) ||
+    is(typeof(new E(string.init, size_t.init)) : Throwable))
 {
     ///
     T enforce(T)(T value, lazy const(char)[] msg = null,


### PR DESCRIPTION
`__FILE__` is expanded to the actual file while Ddoc runs and thus leads to unrelated changes.

At the moment this appears on all PRs:

![image](https://user-images.githubusercontent.com/4370550/37728931-de5919b6-2d3b-11e8-9d72-5aa4b39caa27.png)

http://dtest.dlang.io/diff/website-6692bbe81733e200f12e675ad9736f9ea126ac0f-7104e0cf40688f445578d863618c97f4/website-6692bbe81733e200f12e675ad9736f9ea126ac0f-f5c9edd530f5ccf612df5a6a294089a8/web/phobos/std_exception.html

See also: https://github.com/dlang/dlang.org/pull/2268