### PR TITLE
std.exception: Fix a -dip1000 compilable issue

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -23,7 +23,7 @@ aa[std.conv]=-dip25 # errors from std.typecons
 aa[std.csv]=-dip1000
 aa[std.demangle]=-dip1000
 aa[std.encoding]=-dip1000
-aa[std.exception]=-dip25 # DROP: depends on a workaround or https://issues.dlang.org/show_bug.cgi?id=18637 fixed
+aa[std.exception]=-dip1000 # merged https://github.com/dlang/phobos/pull/6323; a workaround for https://issues.dlang.org/show_bug.cgi?id=18637
 aa[std.file]=-dip25 # probably already fixed (std.uni); currently: undefined symbol  pure nothrow @nogc return @safe std.uni.SliceOverIndexed!(std.uni.Grapheme).SliceOverIndexed std.uni.SliceOverIndexed!(std.uni.Grapheme).SliceOverIndexed.opSlice()
 aa[std.format]=-dip25 # @system function std.range.primitives.put
 aa[std.functional]=-dip25 # DROP: cannot call @system function std.functional.__unittest_L1216_C7.memoize!(pickFirst).memoize

--- a/std/exception.d
+++ b/std/exception.d
@@ -1231,9 +1231,10 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 @system unittest
 {
     int i;
+    int* p = &i; // trick the compiler when initializing slicep; https://issues.dlang.org/show_bug.cgi?id=18637
     int[]  slice = [0, 1, 2, 3, 4];
     int[5] arr   = [0, 1, 2, 3, 4];
-    int*[]  slicep = [&i];
+    int*[]  slicep = [p];
     int*[1] arrp   = [&i];
 
     // A slice points to all of its members:


### PR DESCRIPTION
See also https://issues.dlang.org/show_bug.cgi?id=18637

https://github.com/dlang/phobos/blob/master/dip1000.mak  with
aa[std.exception]=-dip1000
Error when running: make -f posix.mak std/exception.test
```
std/exception.d(1236): Error: copying & i into allocated memory escapes a reference to local variable i
```
