### PR TITLE
Revert fix for 18631.

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -2072,8 +2072,7 @@ Returns:
     return a `ref` to the $(D range element), otherwise it will return
     a copy.
  */
-auto ref inout(ElementType!Range) choice(Range, RandomGen = Random)(inout auto ref Range range,
-                                           ref RandomGen urng)
+auto ref choice(Range, RandomGen = Random)(auto ref Range range, ref RandomGen urng)
 if (isRandomAccessRange!Range && hasLength!Range && isUniformRNG!RandomGen)
 {
     assert(range.length > 0,
@@ -2108,13 +2107,6 @@ auto ref choice(Range)(auto ref Range range)
     elem = choice(array, rng2);
     assert(canFind(array, elem),
            "Choice did not return a valid element from the given Range");
-}
-
-@safe unittest // issue 18631
-{
-    const a = [0,1,2];
-    auto r = choice(a);
-    auto s = choice(cast(const)[0,1,2]);
 }
 
 @safe unittest


### PR DESCRIPTION
The fix for 18631 broke code. Ranges cannot be marked with const or
inout in generic code. The range API does not require that any functions
be const or inout. In this case, with the changes, choice requires that
length and opSlice be const, breaking any code that uses a range with
choice that does not have a const length or opSlice (which is going to
be a large percentage of ranges with those functions which aren't
arrays).