### PR TITLE
std.container.rbtree: Fix -dip1000 compilable issues

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -94,7 +94,7 @@ aa[std.container.array]=-dip1000
 aa[std.container.binaryheap]=-dip1000
 aa[std.container.dlist]=-dip1000
 aa[std.container.package]=-dip1000
-aa[std.container.rbtree]=-dip25 # DROP
+aa[std.container.rbtree]=-dip1000 # merged https://github.com/dlang/phobos/pull/6332
 aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on https://github.com/dlang/phobos/pull/6295 merged
 aa[std.container.util]=-dip25 #    TODO
 

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -2121,7 +2121,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 @safe pure unittest
 {
     class C {}
-    RedBlackTree!(C, (a,b) @trusted  => cast(void*)a < cast(void*)b) tree;
+    RedBlackTree!(C, (a,b) @trusted  => cast(void*) a < cast(void*) b) tree;
 }
 
 @safe pure unittest // const/immutable elements (issue 17519)


### PR DESCRIPTION
https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.container.rbtree]=-dip1000
Errors when running: make -f posix.mak std/container/rbtree.test
```
std/container/rbtree.d(817): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L813_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(991): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L988_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1056): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1054_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1111): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1109_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1173): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1171_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1222): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1220_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1266): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1264_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1308): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1305_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1355): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1351_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1447): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1443_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1472): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1443_C39 cannot call @system function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.removeKey!int.removeKey
std/container/rbtree.d(1475): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1443_C39 cannot call @system function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.removeKey!(int, int, int).removeKey
std/container/rbtree.d(1478): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1443_C39 cannot call @system function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.removeKey!int.removeKey
std/container/rbtree.d(1601): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.__unittest_L1598_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a < b", false).RedBlackTree.this
std/container/rbtree.d(1833): Error: template instance `std.container.rbtree.RedBlackTree!(int, "a < b", false)` error instantiating
std/container/rbtree.d(25):        instantiated from here: redBlackTree!int
std/container/rbtree.d(25): Error: @safe function std.container.rbtree.__unittest_L20_C12 cannot call @system function std.container.rbtree.redBlackTree!int.redBlackTree
std/container/rbtree.d(817): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.__unittest_L813_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.this
std/container/rbtree.d(991): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.__unittest_L988_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.this
std/container/rbtree.d(1056): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.__unittest_L1054_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.this
std/container/rbtree.d(1111): Error: @safe function std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.__unittest_L1109_C39 cannot call @system constructor std.container.rbtree.RedBlackTree!(int, "a > b", false).RedBlackTree.this
```
The fix basically applies @n8sh 's idea (https://github.com/dlang/phobos/pull/6295 from slist) to rbtree as well, manually inlining within the constructor as much as required for inferred @safe with scope (changing inlined _add 's return type to void)
