### PR TITLE
std.typecons: Fix a -dip1000 compilable issue

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -46,7 +46,7 @@ aa[std.stdio]=-dip25 #    TODO
 aa[std.string]=-dip1000
 aa[std.system]=-dip1000
 aa[std.traits]=-dip1000
-aa[std.typecons]=-dip25 # cannot call @system function std.format.formattedWrite!(Appender!string, char, Nullable!int)
+aa[std.typecons]=-dip1000 -version=DIP1000 # merged https://github.com/dlang/phobos/pull/6338; COMPROMISE: check the reason for non-dip1000: static struct S. mixin Proxy!foo;
 aa[std.typetuple]=-dip1000
 aa[std.uni]=-dip1000 # merged https://github.com/dlang/phobos/pull/6294, https://github.com/dlang/phobos/pull/6041 (see also TODO-list there); supersedes/includes https://github.com/dlang/phobos/pull/5045; see also https://github.com/dlang/phobos/pull/6104 for improvements proposed by Seb
 aa[std.uri]=-dip1000

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6829,6 +6829,8 @@ mixin template Proxy(alias a)
     bool* b = Name("a") in names;
 }
 
+// excludes struct S; it's 'mixin Proxy!foo' doesn't compile with -dip1000
+version(DIP1000) {} else
 @system unittest
 {
     // bug14213, using function for the payload
@@ -6837,15 +6839,19 @@ mixin template Proxy(alias a)
         int foo() { return 12; }
         mixin Proxy!foo;
     }
+    S s;
+    assert(s + 1 == 13);
+    assert(s * 2 == 24);
+}
+
+@system unittest
+{
     static class C
     {
         int foo() { return 12; }
         mixin Proxy!foo;
     }
-    S s;
-    assert(s + 1 == 13);
     C c = new C();
-    assert(s * 2 == 24);
 }
 
 // Check all floating point comparisons for both Proxy and Typedef,


### PR DESCRIPTION
https://dlang.org/phobos/std_typecons.html#Proxy
"template Proxy(alias a)
Creates a proxy for the value a that will forward all operations while disabling implicit conversions. The aliased item a must be an lvalue."

There is this unittest in std/typecons.d:
```
@system unittest                  <== line 6579
{
    // bug14213, using function for the payload
    static struct S
    {
        int foo() { return 12; }
        mixin Proxy!foo;          <== line 6585
    }
    static class C
    {
        int foo() { return 12; }
        mixin Proxy!foo;
    }
    S s;
    assert(s + 1 == 13);
    C c = new C();
    assert(s * 2 == 24);
}
```

I don't understanf, why a non-lvalue returning function is used/(usable at all) here as template argument, but it compiles for S and C with -dip25.
With -dip1000 it compiles for C only.
Strange.
This quasi-fix just comments-out the offending lines to be -dip1000 compilable, but as said, without understanding much of what the implications are.

https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.typecons]=-dip1000
Errors when running: make -f posix.mak std/typecons.test
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/typecons.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/typecons.d(5953): Error: circular typeof definition
std/typecons.d(5953): Error: alias `std.typecons.__unittest_L6579_C9.S.Proxy!(foo).ValueType` recursive alias declaration
std/typecons.d(6585): Error: mixin `std.typecons.__unittest_L6579_C9.S.Proxy!(foo)` error instantiating
```
