### PR TITLE
std.regex.internal.tests: Fix a -dip1000 compilable issue

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -178,7 +178,7 @@ aa[std.regex.internal.ir]=-dip1000
 aa[std.regex.internal.kickstart]=-dip1000
 aa[std.regex.internal.parser]=-dip1000
 aa[std.regex.internal.tests2]=-dip1000
-aa[std.regex.internal.tests]=-dip25 # i.a. depends on https://github.com/dlang/phobos/pull/5915 ? and a fix for writeln
+aa[std.regex.internal.tests]=-dip1000 # merged https://github.com/dlang/phobos/pull/6340; for -debug=std_regex_test (set nowhere in sources) still depends on a fix for writeln
 aa[std.regex.internal.thompson]=-dip1000
 
 aa[std.windows.charset]=-dip1000

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -10,6 +10,8 @@ import std.conv, std.exception, std.meta, std.range,
 
 import std.uni : Escapables; // characters that need escaping
 
+debug(std_regex_test) import std.stdio;
+
 @safe unittest
 {//sanity checks
     regex("(a|b)*");
@@ -449,11 +451,9 @@ import std.uni : Escapables; // characters that need escaping
                     v ,": ", tvd.pattern));
                 if (c == 'y')
                 {
-                    import std.stdio;
                     auto result = produceExpected(m, tvd.format);
-                    if (result != tvd.replace)
-                        writeln("ctRegex mismatch pattern #", v, ": ", tvd.pattern," expected: ",
-                                tvd.replace, " vs ", result);
+                    assert(result == tvd.replace, text("ctRegex mismatch pattern #", v,
+                        ": ", tvd.pattern," expected: ", tvd.replace, " vs ", result));
                 }
             }
         }}


### PR DESCRIPTION
https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.regex.internal.tests]=-dip1000
Error when running: make -f posix.mak std/regex/internal/tests.test
```
std/regex/internal/tests.d(463): Error: @safe function std.regex.internal.tests.__unittest_L55_C7 cannot call @system function std.regex.internal.tests.__unittest_L55_C7.ct_tests
```