### PR TITLE
Automatically clone dmd+druntime if missing

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -37,6 +37,11 @@ QUIET:=@
 DEBUGGER=gdb
 GIT_HOME=https://github.com/dlang
 DMD_DIR=../dmd
+DRUNTIME_PATH = ../druntime
+
+# Auto-cloning missing directories
+$(shell [ ! -d $(DMD_DIR) ] && git clone ${GIT_HOME}/dmd $(DMD_DIR))
+$(shell [ ! -d $(DRUNTIME_PATH) ] && git clone ${GIT_HOME}/druntime $(DRUNTIME_PATH))
 
 include $(DMD_DIR)/src/osmodel.mak
 
@@ -75,7 +80,6 @@ endif
 
 # Configurable stuff that's rarely edited
 INSTALL_DIR = ../install
-DRUNTIME_PATH = ../druntime
 DLANG_ORG_DIR = ../dlang.org
 ZIPFILE = phobos.zip
 ROOT_OF_THEM_ALL = generated


### PR DESCRIPTION
This shrinks the setup of a D development environment down to:

```sh
git clone https://github.com/dlang/phobos
make -f posix.mak AUTO_BOOTSTRAP=1
```

We use the same logic at dlang.org for quite a while now:
https://github.com/dlang/dlang.org/blob/c88c08ab28c145c912cd04e9298c63740e492b18/posix.mak#L159

CC @CyberShadow 