### PR TITLE
make `group`, `chain`, and `choose` compatible with `RefRange`

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1684,9 +1684,12 @@ if (isInputRange!R)
     static if (isForwardRange!R)
     {
         ///
-        @property typeof(this) save() {
+        @property typeof(this) save()
+        {
+            import std.algorithm.mutation : move;
             typeof(this) ret = this;
-            ret._input = this._input.save;
+            auto saved = this._input.save;
+            move(saved, ret._input);
             ret._current = this._current;
             return ret;
         }
@@ -1805,6 +1808,15 @@ if (isInputRange!R)
     assert(r.equal([ tuple(5, 1u) ]));
     assert(s.equal([ tuple(4, 3u), tuple(5, 1u) ]));
     assert(t.equal([ tuple(3, 1u), tuple(4, 3u), tuple(5, 1u) ]));
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    import std.range : refRange;
+    auto r = refRange(&["foo"][0]).group;
+    assert(equal(r.save, "foo".group));
+    assert(equal(r, "foo".group));
 }
 
 // Used by implementation of chunkBy for non-forward input ranges.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1524,7 +1524,11 @@ private struct ChooseResult(R1, R2)
         @property auto save()
         {
             auto result = this;
-            actOnChosen!((ref r) { r = r.save; })(result);
+            actOnChosen!((ref r) {
+                import std.algorithm.mutation : move;
+                auto saved = r.save;
+                move(saved, r);
+            })(result);
             return result;
         }
 
@@ -1610,6 +1614,14 @@ private struct ChooseResult(R1, R2)
                         return choose(false, Slice1.init, r[begin .. end]);
                 })(this, begin, end);
         }
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    auto r = choose(true, refRange(&["foo"][0]), "bar");
+    assert(equal(r.save, "foo"));
+    assert(equal(r, "foo"));
 }
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -972,10 +972,12 @@ if (Ranges.length > 0 &&
             static if (allSatisfy!(isForwardRange, R))
                 @property auto save()
                 {
+                    import std.algorithm.mutation : move;
                     typeof(this) result = this;
                     foreach (i, Unused; R)
                     {
-                        result.source[i] = result.source[i].save;
+                        auto saved = result.source[i].save;
+                        move(saved, result.source[i]);
                     }
                     return result;
                 }
@@ -1378,6 +1380,14 @@ pure @safe nothrow @nogc unittest
     immutable(Foo)[] a;
     immutable(Foo)[] b;
     assert(chain(a, b).empty);
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    auto r = refRange(&["foo"][0]).chain("bar");
+    assert(equal(r.save, "foobar"));
+    assert(equal(r, "foobar"));
 }
 
 /**


### PR DESCRIPTION
The first three of probably many functions that need to be fixed in order to resolve [issue 18657](https://issues.dlang.org/show_bug.cgi?id=18657).

Related forum discussion: <https://forum.dlang.org/post/p96gs4$22fp$1@digitalmars.com>.

I'm not sure if this is the right direction. The alternative would be to add assignment to the range interface, and remove `opAssign` from `RefRange`. That would be less busywork, and being able to use assignment with ranges might be better for everyone's sanity. But it would also be more of a breaking change.
