### PR TITLE
Fix spurious build failures in std.file by using more unique test directories

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4398,7 +4398,7 @@ enum SpanMode
     import std.algorithm.iteration : map;
     import std.path : buildPath, relativePath;
 
-    auto root = tempDir.buildPath("root");
+    auto root = deleteme ~ "root";
     scope(exit) root.rmdirRecurse;
     root.mkdir;
 
@@ -5105,8 +5105,15 @@ string tempDir() @trusted
 ///
 @safe unittest
 {
+    import std.ascii : letters;
+    import std.conv : to;
     import std.path : buildPath;
-    auto myFile = tempDir.buildPath("my_tmp_file");
+    import std.random : randomSample;
+    import std.utf : byCodeUnit;
+
+    // random id with 20 letters
+    auto id = letters.byCodeUnit.randomSample(20).to!string;
+    auto myFile = tempDir.buildPath(id ~ "my_tmp_file");
     scope(exit) myFile.remove;
 
     myFile.write("hello");


### PR DESCRIPTION
Since we added a whole bunch of new test to std.file, auto-tester sometimes fails:

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3092231&isPull=true

So it's probably a good idea to use unique directories like `deleteme` or
in the case of the `tempDir` examples, generating a unique file.