### PR TITLE
[Trivial]std.functional: -dip1000 compilable by @safe => @system unit…

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -26,7 +26,7 @@ aa[std.encoding]=-dip1000
 aa[std.exception]=-dip1000 # merged https://github.com/dlang/phobos/pull/6323; a workaround for https://issues.dlang.org/show_bug.cgi?id=18637
 aa[std.file]=-dip25 # probably already fixed (std.uni); currently: undefined symbol  pure nothrow @nogc return @safe std.uni.SliceOverIndexed!(std.uni.Grapheme).SliceOverIndexed std.uni.SliceOverIndexed!(std.uni.Grapheme).SliceOverIndexed.opSlice()
 aa[std.format]=-dip25 # @system function std.range.primitives.put
-aa[std.functional]=-dip25 # DROP: cannot call @system function std.functional.__unittest_L1216_C7.memoize!(pickFirst).memoize
+aa[std.functional]=-dip1000 # merged https://github.com/dlang/phobos/pull/6351
 aa[std.getopt]=-dip1000
 aa[std.json]=-dip1000
 aa[std.math]=-dip1000

--- a/std/functional.d
+++ b/std/functional.d
@@ -1194,7 +1194,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with arrays
-@safe unittest
+@system unittest // not @safe with -dip1000 due to memoize
 {
     int executed = 0;
     T median(T)(const T[] nums) {
@@ -1237,7 +1237,7 @@ template memoize(alias fun, uint maxSize)
 }
 
 // 16079: memoize should work with classes
-@safe unittest
+@system unittest // not @safe with -dip1000 due to memoize
 {
     int executed = 0;
     T pickFirst(T)(T first)


### PR DESCRIPTION
…test

https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.functional]=-dip1000
Errors when running: make -f posix.mak std/functional.test
...
```
std/functional.d(1214): Error: @safe function std.functional.__unittest_L1197_C7 cannot call @system function std.functional.__unittest_L1197_C7.memoize!(median).memoize
std/functional.d(1215): Error: @safe function std.functional.__unittest_L1197_C7 cannot call @system function std.functional.__unittest_L1197_C7.memoize!(median).memoize
std/functional.d(1268): Error: @safe function std.functional.__unittest_L1240_C7 cannot call @system function std.functional.__unittest_L1240_C7.memoize!(pickFirst).memoize
std/functional.d(1269): Error: @safe function std.functional.__unittest_L1240_C7 cannot call @system function std.functional.__unittest_L1240_C7.memoize!(pickFirst).memoize
```

Fixing memoize to be @safe requires a lot of @trusted usage, thus I abstain from that