### PR TITLE
make buildNormalizedPath() @safe

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -1725,21 +1725,23 @@ if (Ranges.length >= 2 &&
     Returns: The assembled path.
 */
 immutable(C)[] buildNormalizedPath(C)(const(C[])[] paths...)
-    @trusted pure nothrow
+    @safe pure nothrow
 if (isSomeChar!C)
 {
     import std.array : array;
+    import std.exception : assumeUnique;
 
-    const(C)[] result;
+    const(C)[] chained;
     foreach (path; paths)
     {
-        if (result)
-            result = chainPath(result, path).array;
+        if (chained)
+            chained = chainPath(chained, path).array;
         else
-            result = path;
+            chained = path;
     }
-    result = asNormalizedPath(result).array;
-    return cast(typeof(return)) result;
+    auto result = asNormalizedPath(chained);
+    // .array returns a copy, so it is unique
+    return () @trusted { return assumeUnique(result.array); } ();
 }
 
 ///


### PR DESCRIPTION
Shrink the @trusted to the smallest bit of the function that needs it. The rest is to follow the convention that `result` is for the return value.