### PR TITLE
std.datetime: make -dip1000 compatible

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -98,11 +98,11 @@ aa[std.container.rbtree]=-dip25 # DROP
 aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on https://github.com/dlang/phobos/pull/6295 merged
 aa[std.container.util]=-dip25 #    TODO
 
-aa[std.datetime.date]=-dip25 # depends on a fix for writefln
+aa[std.datetime.date]=-dip1000
 aa[std.datetime.interval]=-dip1000
 aa[std.datetime.package]=-dip1000
 aa[std.datetime.stopwatch]=-dip1000
-aa[std.datetime.systime]=-dip25 # merged https://github.com/dlang/phobos/pull/6181 ; depends on a fix for writefln
+aa[std.datetime.systime]=-dip1000 # merged https://github.com/dlang/phobos/pull/6181
 aa[std.datetime.timezone]=-dip1000 # merged https://github.com/dlang/phobos/pull/6183
 
 aa[std.digest.crc]=-dip1000

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -10401,19 +10401,17 @@ if (isSomeString!T)
 
 @safe unittest
 {
-    import std.stdio : writeln;
+    import std.conv : to;
     import std.traits : EnumMembers;
     foreach (badStr; ["Ja", "Janu", "Januar", "Januarys", "JJanuary", "JANUARY",
                       "JAN", "january", "jaNuary", "jaN", "jaNuaRy", "jAn"])
     {
-        scope(failure) writeln(badStr);
-        assertThrown!DateTimeException(monthFromString(badStr));
+        assertThrown!DateTimeException(monthFromString(badStr), badStr);
     }
 
     foreach (month; EnumMembers!Month)
     {
-        scope(failure) writeln(month);
-        assert(monthFromString(monthToString(month)) == month);
+        assert(monthFromString(monthToString(month)) == month, month.to!string);
     }
 }
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -97,7 +97,6 @@ public:
     @safe unittest
     {
         import std.format : format;
-        import std.stdio : writefln;
         import core.time;
         assert(currTime().timezone is LocalTime());
         assert(currTime(UTC()).timezone is UTC());
@@ -123,11 +122,10 @@ public:
         import std.meta : AliasSeq;
         static foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
         {{
-            scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currTime!ct;
             auto value2 = Clock.currTime!ct(UTC());
-            assert(value1 <= value2, format("%s %s", value1, value2));
-            assert(abs(value1 - value2) <= seconds(2));
+            assert(value1 <= value2, format("%s %s (ClockType: %s)", value1, value2, ct));
+            assert(abs(value1 - value2) <= seconds(2), format("ClockType.%s", ct));
         }}
     }
 
@@ -288,7 +286,6 @@ public:
         import std.format : format;
         import std.math : abs;
         import std.meta : AliasSeq;
-        import std.stdio : writefln;
         enum limit = convert!("seconds", "hnsecs")(2);
 
         auto norm1 = Clock.currStdTime;
@@ -298,10 +295,9 @@ public:
 
         static foreach (ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
         {{
-            scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currStdTime!ct;
             auto value2 = Clock.currStdTime!ct;
-            assert(value1 <= value2, format("%s %s", value1, value2));
+            assert(value1 <= value2, format("%s %s (ClockType: %s)", value1, value2, ct));
             assert(abs(value1 - value2) <= limit);
         }}
     }
@@ -10758,16 +10754,13 @@ if (isIntegral!T && isSigned!T) // The constraints on R were already covered by 
 {
     import std.conv : to;
     import std.range : chain, iota;
-    import std.stdio : writeln;
     foreach (i; chain(iota(0, 101), [250, 999, 1000, 1001, 2345, 9999]))
     {
-        scope(failure) writeln(i);
-        assert(_convDigits!int(to!string(i)) == i);
+        assert(_convDigits!int(to!string(i)) == i, i.to!string);
     }
     foreach (str; ["-42", "+42", "1a", "1 ", " ", " 42 "])
     {
-        scope(failure) writeln(str);
-        assert(_convDigits!int(str) == -1);
+        assert(_convDigits!int(str) == -1, str);
     }
 }
 


### PR DESCRIPTION
Weeds out the last violations of `-dip1000` in std.datetime.
`writefln` should be fixed, but we want to crack down `-dip1000` module by module.