### PR TITLE
std.container.rbtree: Fix -dip1000 compilable issues (alternative)

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -94,7 +94,7 @@ aa[std.container.array]=-dip1000
 aa[std.container.binaryheap]=-dip1000
 aa[std.container.dlist]=-dip1000
 aa[std.container.package]=-dip1000
-aa[std.container.rbtree]=-dip25 # DROP
+aa[std.container.rbtree]=-dip1000 -version=DIP1000
 aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on an update (no insertFront's code duplication in constructor) and merge of https://github.com/dlang/phobos/pull/6295
 aa[std.container.util]=-dip25 # depends on rbtree and slist = -dip1000
 


### PR DESCRIPTION
Alternative version to: https://github.com/dlang/phobos/pull/6332

Still not perfect and I don't know why this is disallowed:

```
auto rbt4 = redBlackTree(chain(["hello"], ["world"]));
assert(equal(rbt4[], ["hello", "world"]));
```

but this is allowed:

```
auto rbt5 = redBlackTree!true(chain([0, 1], [5, 7, 5]));
assert(equal(rbt5[], [0, 1, 5, 5, 7]));
```