### PR TITLE
Accomodate Enum init deprecation

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3814,8 +3814,8 @@ void writeln(T...)(T args)
     scope(exit) { std.file.remove(deleteme); }
 
     enum EI : int    { A, B }
-    enum ED : double { A, B }
-    enum EC : char   { A, B }
+    enum ED : double { A = 0, B } // NOTE: explicit initialization to 0 required during Enum init deprecation cycle
+    enum EC : char   { A = 0, B } // NOTE: explicit initialization to 0 required during Enum init deprecation cycle
     enum ES : string { A = "aaa", B = "bbb" }
 
     f.writeln(EI.A);  // false, but A on 2.058

--- a/std/traits.d
+++ b/std/traits.d
@@ -7480,7 +7480,7 @@ template OriginalType(T)
 ///
 @safe unittest
 {
-    enum E : real { a }
+    enum E : real { a = 0 } // NOTE: explicit initialization to 0 required during Enum init deprecation cycle
     enum F : E    { a = E.a }
     alias G = const(F);
     static assert(is(OriginalType!E == real));


### PR DESCRIPTION
PR https://github.com/dlang/dmd/pull/7996 is modifying the compiler to comply with the language specification:

> The value of an EnumMember is given by its AssignExpression. If there is no AssignExpression and it is the first EnumMember, its value is EnumBaseType.init.

The current behavior is to assign the value `0` to the first enum member when no assign expression is given.  The referenced PR introduces a deprecation message when an enum's base type's `.init` member is not 0.  This applies to the types `double`, `char` and `real`.  This allows applications to maintain the current behavior for a time until the deprecation is over and the behavior will change to match the specification.  Note that this means you cannot currently create an enum with base type `double`, `char` or `real` without a deprecation message unless you give it's first member an explicit assignment.  Since phobos treats deprecations as errors, this PR provides explicit assignments in these cases during this deprecation period.