### PR TITLE
posix.mak: Don't rebuild Phobos when running dscanner

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -536,7 +536,10 @@ $(DSCANNER_DIR)/dsc: | $(DSCANNER_DIR) $(DMD) $(LIB)
 style: publictests style_lint
 
 # runs static code analysis with Dscanner
-dscanner: | $(DSCANNER_DIR)/dsc
+dscanner:
+	@# The dscanner target is without dependencies to avoid constant rebuilds of Phobos (`make` always rebuilds order-only dependencies)
+	@# However, we still need to ensure that the DScanner binary is built once
+	@[ -f $(DSCANNER_DIR)/dsc ] || ${MAKE} -f posix.mak $(DSCANNER_DIR)/dsc
 	@echo "Running DScanner"
 	$(DEBUGGER) -return-child-result -q -ex run -ex bt -batch --args $(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
 


### PR DESCRIPTION
At the moment every execution `make -f posix.mak dscanner` will rebuild Phobos first which is absolutely unnecessary and super annoying.
After all, the dscanner binary only needs to be built once and doesn't need to be rebuilt if a line in Phobos has been changed.

There seems to be no clean way to tell Make to avoid building its order-only dependencies if the final target doesn't need a rebuild anyhow.
So I went with a quick one-line workaround.