### PR TITLE
std.algorithm.iteration: Fix a -dip1000 compilable issue

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -59,8 +59,8 @@ aa[std.zlib]=-dip1000
 
 aa[std.algorithm.comparison]=-dip1000
 aa[std.algorithm.internal]=-dip1000
-aa[std.algorithm.iteration]=-dip25 #    WIP_carblue
-aa[std.algorithm.mutation]=-dip25 # depends on std.container.slist (https://github.com/dlang/phobos/pull/6295)
+aa[std.algorithm.iteration]=-dip25 # depends on std.container.slist (to be updated https://github.com/dlang/phobos/pull/6295)
+aa[std.algorithm.mutation]=-dip25 #  depends on std.container.slist (to be updated https://github.com/dlang/phobos/pull/6295)
 aa[std.algorithm.package]=-dip1000
 aa[std.algorithm.searching]=-dip25 # depends on https://github.com/dlang/phobos/pull/6246 merged and std.algorithm.comparison fixed
 aa[std.algorithm.setops]=-dip1000
@@ -95,8 +95,8 @@ aa[std.container.binaryheap]=-dip1000
 aa[std.container.dlist]=-dip1000
 aa[std.container.package]=-dip1000
 aa[std.container.rbtree]=-dip25 # DROP
-aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on https://github.com/dlang/phobos/pull/6295 merged
-aa[std.container.util]=-dip25 #    TODO
+aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on an update (no insertFront's code duplication in constructor) and merge of https://github.com/dlang/phobos/pull/6295
+aa[std.container.util]=-dip25 # depends on rbtree and slist = -dip1000
 
 aa[std.datetime.date]=-dip1000
 aa[std.datetime.interval]=-dip1000

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4236,7 +4236,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
         @property empty() { return _impl.empty; }
         @property auto front() { return _impl.front; }
         void popFront() { _impl = _impl[1..$]; }
-        @property RefSep save() { return new RefSep(_impl); }
+        @property RefSep save() scope { return new RefSep(_impl); }
         @property auto length() { return _impl.length; }
     }
     auto sep = new RefSep("->");


### PR DESCRIPTION
https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.algorithm.iteration]=-dip1000
Errors when running: make -f posix.mak std/algorithm/iteration.test
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/algorithm/iteration.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/algorithm/iteration.d(4245): Error: @safe function std.algorithm.iteration.__unittest_L4227_C7 cannot call @system function std.algorithm.comparison.equal!().equal!(Result, string[]).equal
std/algorithm/iteration.d(5525): Error: static assert:  is(typeof(sum(R)(R r) if (isInputRange!R && !isInfinite!R && is(typeof(r.front + r.front)))((__error)[])) == double) is false
```
The remaining errors are from std/container/slist.d only