### PR TITLE
Fix issue 18691 - memory errors in std.regex.Captures

### DIFF
--- a/std/regex/internal/tests2.d
+++ b/std/regex/internal/tests2.d
@@ -689,3 +689,13 @@ version(none) // TODO: revist once we have proper benchmark framework
     assert(c);
     assert(c.whichPattern == 2);
 }
+
+// bugzilla 18692
+@safe unittest
+{
+    auto rx = regex("()()()");
+    auto ma = "".matchFirst(rx);
+    auto ma2 = ma;
+    ma = ma2;
+    assert(ma[1] == "");
+}

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -484,26 +484,20 @@ if (isSomeString!R)
 {//@trusted because of union inside
     alias DataIndex = size_t;
     alias String = R;
+    alias Store = SmallFixedArray!(Group!DataIndex, 3);
 private:
     import std.conv : text;
-    enum smallString = 3;
-    enum SMALL_MASK = 0x8000_0000, REF_MASK= 0x1FFF_FFFF;
-    union
-    {
-        Group!DataIndex[] big_matches;
-        Group!DataIndex[smallString] small_matches;
-    }
+    Store matches;
     const(NamedGroup)[] _names;
     R _input;
     int _nMatch;
     uint _f, _b;
-    uint _refcount; // ref count or SMALL MASK + num groups
 
     this(R input, uint n, const(NamedGroup)[] named)
     {
         _input = input;
         _names = named;
-        newMatches(n);
+        matches = Store(n);
         _b = n;
         _f = 0;
     }
@@ -513,60 +507,12 @@ private:
         _input = rmatch._input;
         _names = rmatch._engine.pattern.dict;
         immutable n = rmatch._engine.pattern.ngroup;
-        newMatches(n);
+        matches = Store(n);
         _b = n;
         _f = 0;
     }
 
-    @property inout(Group!DataIndex[]) matches() inout
-    {
-       return (_refcount & SMALL_MASK)  ? small_matches[0 .. _refcount & 0xFF] : big_matches;
-    }
-
-    void newMatches(uint n)
-    {
-        import core.stdc.stdlib : calloc;
-        import std.exception : enforce;
-        if (n > smallString)
-        {
-            auto p = cast(Group!DataIndex*) enforce(
-                calloc(Group!DataIndex.sizeof,n),
-                "Failed to allocate Captures struct"
-            );
-            big_matches = p[0 .. n];
-            _refcount = 1;
-        }
-        else
-        {
-            _refcount = SMALL_MASK | n;
-        }
-    }
-
-    bool unique()
-    {
-        return (_refcount & SMALL_MASK) || _refcount == 1;
-    }
-
 public:
-    this(this)
-    {
-        if (!(_refcount & SMALL_MASK))
-        {
-            _refcount++;
-        }
-    }
-    ~this()
-    {
-        import core.stdc.stdlib : free;
-        if (!(_refcount & SMALL_MASK))
-        {
-            if (--_refcount == 0)
-            {
-                free(big_matches.ptr);
-                big_matches = null;
-            }
-        }
-    }
     ///Slice of input prior to the match.
     @property R pre()
     {
@@ -681,18 +627,6 @@ public:
 
     ///A hook for compatibility with original std.regex.
     @property ref captures(){ return this; }
-
-    typeof(this) opAssign()(auto ref Captures rhs)
-    {
-        if (rhs._refcount & SMALL_MASK)
-            small_matches[0 .. rhs._refcount & 0xFF] = rhs.small_matches[0 .. rhs._refcount & 0xFF];
-        else
-            big_matches = rhs.big_matches;
-        assert(&this.tupleof[0] is &big_matches);
-        assert(&this.tupleof[1] is &small_matches);
-        this.tupleof[2 .. $] = rhs.tupleof[2 .. $];
-        return this;
-    }
 }
 
 ///
@@ -750,7 +684,7 @@ private:
         _engine = _factory.create(prog, input);
         assert(_engine.refCount == 1);
         _captures = Captures!R(this);
-        _captures._nMatch = _engine.match(_captures.matches);
+        _captures.matches.mutate((slice) { _captures._nMatch = _engine.match(slice); });
     }
 
 public:
@@ -811,12 +745,7 @@ public:
             _engine = _factory.dup(old, _input);
             _factory.decRef(old);
         }
-        if (!_captures.unique)
-        {
-            // has external references - allocate new space
-            _captures.newMatches(_engine.pattern.ngroup);
-        }
-        _captures._nMatch = _engine.match(_captures.matches);
+        _captures.matches.mutate((slice) { _captures._nMatch = _engine.match(slice); });
     }
 
     ///ditto
@@ -839,7 +768,7 @@ private @trusted auto matchOnce(RegEx, R)(R input, const auto ref RegEx prog)
     auto engine = factory.create(prog, input);
     scope(exit) factory.decRef(engine); // destroys the engine
     auto captures = Captures!R(input, prog.ngroup, prog.dict);
-    captures._nMatch = engine.match(captures.matches);
+    captures.matches.mutate((slice){ captures._nMatch = engine.match(slice); });
     return captures;
 }
 


### PR DESCRIPTION
Instead of a messy code that ended up with refcount at the wrong place
provide a clean sealed fixed-size array with required semantics and
build on top of that.