### PR TITLE
std.container.slist: Fix -dip1000 compilable issues

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -59,8 +59,8 @@ aa[std.zlib]=-dip1000
 
 aa[std.algorithm.comparison]=-dip1000
 aa[std.algorithm.internal]=-dip1000
-aa[std.algorithm.iteration]=-dip25 # depends on std.container.slist (to be updated https://github.com/dlang/phobos/pull/6295)
-aa[std.algorithm.mutation]=-dip25 #  depends on std.container.slist (to be updated https://github.com/dlang/phobos/pull/6295)
+aa[std.algorithm.iteration]=-dip25 # depends on SList!string fixed
+aa[std.algorithm.mutation]=-dip1000
 aa[std.algorithm.package]=-dip1000
 aa[std.algorithm.searching]=-dip25 # depends on https://github.com/dlang/phobos/pull/6246 merged and std.algorithm.comparison fixed
 aa[std.algorithm.setops]=-dip1000
@@ -95,7 +95,7 @@ aa[std.container.binaryheap]=-dip1000
 aa[std.container.dlist]=-dip1000
 aa[std.container.package]=-dip1000
 aa[std.container.rbtree]=-dip25 # DROP
-aa[std.container.slist]=-dip25 # -dip1000 -version=DIP1000   depends on an update (no insertFront's code duplication in constructor) and merge of https://github.com/dlang/phobos/pull/6295
+aa[std.container.slist]=-dip1000 # -dip1000 -version=DIP1000   depends on an update (no insertFront's code duplication in constructor) and merge of https://github.com/dlang/phobos/pull/6295
 aa[std.container.util]=-dip25 # depends on rbtree and slist = -dip1000
 
 aa[std.datetime.date]=-dip1000

--- a/dip1000.mak
+++ b/dip1000.mak
@@ -59,10 +59,10 @@ aa[std.zlib]=-dip1000
 
 aa[std.algorithm.comparison]=-dip1000
 aa[std.algorithm.internal]=-dip1000
-aa[std.algorithm.iteration]=-dip25 # depends on SList!string fixed
+aa[std.algorithm.iteration]=-dip1000
 aa[std.algorithm.mutation]=-dip1000
 aa[std.algorithm.package]=-dip1000
-aa[std.algorithm.searching]=-dip25 # depends on https://github.com/dlang/phobos/pull/6246 merged and std.algorithm.comparison fixed
+aa[std.algorithm.searching]=-dip25 # depends on std.algorithm.comparison fixed
 aa[std.algorithm.setops]=-dip1000
 aa[std.algorithm.sorting]=-dip25 # i.a. depends on std.algorithm.searching? and a fix for writefln
 
@@ -95,7 +95,7 @@ aa[std.container.binaryheap]=-dip1000
 aa[std.container.dlist]=-dip1000
 aa[std.container.package]=-dip1000
 aa[std.container.rbtree]=-dip25 # DROP
-aa[std.container.slist]=-dip1000 # -dip1000 -version=DIP1000   depends on an update (no insertFront's code duplication in constructor) and merge of https://github.com/dlang/phobos/pull/6295
+aa[std.container.slist]=-dip1000
 aa[std.container.util]=-dip25 # depends on rbtree and slist = -dip1000
 
 aa[std.datetime.date]=-dip1000

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -354,7 +354,7 @@ Returns: The number of elements inserted
 
 Complexity: $(BIGOH m), where $(D m) is the length of $(D stuff)
      */
-    size_t insertFront(Stuff)(Stuff stuff)
+    size_t insertFront(Stuff)(scope Stuff stuff)
     if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))
     {
         initialize();
@@ -791,7 +791,7 @@ Complexity: $(BIGOH n)
     assert(s.insertAfter(r, 5) == 1);
     assert(s == SList!int(1, 2, 5, 3, 4));
 }
-
+/+
 @safe unittest
 {
     import std.algorithm.comparison : equal;
@@ -804,7 +804,7 @@ Complexity: $(BIGOH n)
     sl.insertAfter(take(sl[], 2), "c"); // insert after "b"
     assert(equal(sl[], ["a", "b", "c", "d", "e"]));
 }
-
++/
 @safe unittest
 {
     import std.range.primitives;

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -58,7 +58,7 @@ struct SList(T)
     import std.exception : enforce;
     import std.range : Take;
     import std.range.primitives : isInputRange, isForwardRange, ElementType;
-    import std.traits : isImplicitlyConvertible;
+    import std.traits : isImplicitlyConvertible, isSomeString;
 
     private struct Node
     {
@@ -362,7 +362,10 @@ Complexity: $(BIGOH m), where $(D m) is the length of $(D stuff)
         Node * n, newRoot;
         foreach (item; stuff)
         {
-            auto newNode = new Node(null, item);
+            static if (isSomeString!T)
+                auto newNode = new Node(null, item.dup);
+            else
+                auto newNode = new Node(null, item);
             (newRoot ? n._next : newRoot) = newNode;
             n = newNode;
             ++result;
@@ -791,7 +794,7 @@ Complexity: $(BIGOH n)
     assert(s.insertAfter(r, 5) == 1);
     assert(s == SList!int(1, 2, 5, 3, 4));
 }
-/+
+
 @safe unittest
 {
     import std.algorithm.comparison : equal;
@@ -804,7 +807,7 @@ Complexity: $(BIGOH n)
     sl.insertAfter(take(sl[], 2), "c"); // insert after "b"
     assert(equal(sl[], ["a", "b", "c", "d", "e"]));
 }
-+/
+
 @safe unittest
 {
     import std.range.primitives;


### PR DESCRIPTION
A new attempt since https://github.com/dlang/phobos/pull/6295

https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.container.slist]=-dip1000
Errors when running: make -f posix.mak std/container/slist.test
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000 -version=DIP1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/container/slist.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/container/slist.d(280): Error: @safe function std.container.slist.SList!int.SList.__unittest_L278_C11 cannot call @system constructor std.container.slist.SList!int.SList.__ctor!int.this
std/container/slist.d(282): Error: @safe function std.container.slist.SList!int.SList.__unittest_L278_C11 cannot call @system constructor std.container.slist.SList!int.SList.__ctor!int.this
std/container/slist.d(27): Error: template instance `std.container.slist.SList!int` error instantiating
std/container/slist.d(801): Error: template instance `std.container.slist.SList!string` error instantiating
```
Changing to:
size_t insertFront(Stuff)(scope Stuff stuff)
if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))

compiles everything except:  auto sl = SList!string(["a", "b", "d"]);
```
std/container/slist.d(365): Error: scope variable item may not be copied into allocated memory
std/container/slist.d(154): Error: template instance `std.container.slist.SList!string.SList.insertFront!(Range)` error instantiating
std/container/slist.d(250):        instantiated from here: __ctor!(Range)
std/container/slist.d(801):        instantiated from here: SList!string
```
Thus I'm going to try with a dedicated constructor (or ?) for the string types, probably including dup-ing consructor arguments. We'll see.
