### PR TITLE
Allow to add additional DFLAGS when building Phobos

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -120,19 +120,20 @@ else
 endif
 
 # Set DFLAGS
-DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC) -transition=complex
+DFLAGS=
+override DFLAGS+=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC) -transition=complex
 ifeq ($(BUILD),debug)
-	DFLAGS += -g -debug
+override DFLAGS += -g -debug
 else
-	DFLAGS += -O -release
+override DFLAGS += -O -release
 endif
 
 ifdef ENABLE_COVERAGE
-DFLAGS  += -cov
+override DFLAGS  += -cov
 endif
 ifneq (,$(TZ_DATABASE_DIR))
 $(file > /tmp/TZDatabaseDirFile, ${TZ_DATABASE_DIR})
-DFLAGS += -version=TZDatabaseDir -J/tmp/
+override DFLAGS += -version=TZDatabaseDir -J/tmp/
 endif
 
 UDFLAGS=-unittest


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/8089 for Phobos, s.t. downstream packers can set their custom flags and don't need to patch `posix.mak` like e.g. https://github.com/dlang/phobos/pull/5966

It's also useful for quickly applying a flag for local testing:

```
make -f posix.mak std/algorithm/iteration.test DFLAGS="-debug=MyDebug"
```

For reference, environment variables aren't read, so global `DFLAGS` won't start to influence this Makefile, e.g.

```
DFLAGS="-debug=MyDebug" make -f posix.mak std/algorithm/iteration.test
```