### PR TITLE
std.range.package.d: -dip1000 compilable

### DIFF
--- a/dip1000.mak
+++ b/dip1000.mak
@@ -168,7 +168,7 @@ aa[std.net.curl]=-dip1000 # TODO have a look into open https://github.com/dlang/
 aa[std.net.isemail]=-dip1000
 
 aa[std.range.interfaces]=-dip1000
-aa[std.range.package]=-dip25 # reference to local variable a / b assigned to non-scope parameter _param_1 / _param_2 calling std.range.chooseAmong!(RefAccessRange, RefAccessRange).chooseAmong
+aa[std.range.package]=-dip1000
 aa[std.range.primitives]=-dip1000
 
 aa[std.regex.package]=-dip1000

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1713,25 +1713,25 @@ if (Ranges.length >= 2
     assert(c[0] == 42);
 }
 
-@safe nothrow pure @nogc unittest
+@safe nothrow pure /*@nogc*/ unittest
 {
     static struct RefAccessRange
     {
         int[] r;
-        ref front() @property { return r[0]; }
-        ref back() @property { return r[$ - 1]; }
+        scope ref front() @property { return r[0]; }
+        scope ref back() @property { return r[$ - 1]; }
         void popFront() { r = r[1 .. $]; }
         void popBack() { r = r[0 .. $ - 1]; }
         auto empty() @property { return r.empty; }
-        ref opIndex(size_t i) { return r[i]; }
+        scope ref opIndex(size_t i) { return r[i]; }
         auto length() @property { return r.length; }
         alias opDollar = length;
         auto save() { return this; }
     }
     static assert(isRandomAccessRange!RefAccessRange);
     static assert(isRandomAccessRange!RefAccessRange);
-    int[4] a = [4, 3, 2, 1];
-    int[2] b = [6, 5];
+    int[] a = [4, 3, 2, 1];
+    int[] b = [6, 5];
     auto c = chooseAmong(0, RefAccessRange(a[]), RefAccessRange(b[]));
 
     void refFunc(ref int a, int target) { assert(a == target); }
@@ -5052,21 +5052,21 @@ nothrow pure @system unittest
     assert(z2.front == tuple(0,1));
 }
 
-@nogc nothrow pure @safe unittest
+/*@nogc*/ nothrow pure @safe unittest
 {
     // Test zip's `back` and `length` with non-equal ranges.
     static struct NonSliceableRandomAccess
     {
         private int[] a;
-        @property ref front()
+        @property scope ref front()
         {
             return a.front;
         }
-        @property ref back()
+        @property scope ref back()
         {
             return a.back;
         }
-        ref opIndex(size_t i)
+        scope ref opIndex(size_t i)
         {
             return a[i];
         }
@@ -5107,7 +5107,7 @@ nothrow pure @system unittest
     static assert(!hasSlicing!NonSliceableRandomAccess);
     static foreach (iteration; 0 .. 2)
     {{
-        int[5] data = [101, 102, 103, 201, 202];
+        int[] data = [101, 102, 103, 201, 202];
         static if (iteration == 0)
         {
             auto r1 = NonSliceableRandomAccess(data[0 .. 3]);


### PR DESCRIPTION
https://github.com/dlang/phobos/blob/master/dip1000.mak with
aa[std.range.package]=-dip1000
Errors when running: make -f posix.mak std/range/package.test
...
```
T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
  (                                                                                                     \
    ../dmd/generated/linux/release/64/dmd -od$T -conf= -I../druntime/import  -w -de -dip25 -m64 -fPIC -transition=complex -O -release -dip1000  -main -unittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-ldl -cov -run std/range/package.d ;     \
    RET=$? ; rm -rf $T ; exit $RET                                                                   \
  )
std/range/package.d(1703): Error: reference to local variable a assigned to non-scope parameter _param_1 calling std.range.chooseAmong!(RefAccessRange, RefAccessRange).chooseAmong
std/range/package.d(1703): Error: reference to local variable b assigned to non-scope parameter _param_2 calling std.range.chooseAmong!(RefAccessRange, RefAccessRange).chooseAmong
std/range/package.d(5089): Error: scope variable r1 assigned to non-scope parameter _param_0 calling std.range.zip!(NonSliceableRandomAccess, NonSliceableRandomAccess).zip
std/range/package.d(5089): Error: scope variable r2 assigned to non-scope parameter _param_1 calling std.range.zip!(NonSliceableRandomAccess, NonSliceableRandomAccess).zip
std/range/package.d(5090):        while evaluating: static assert(isRandomAccessRange!(typeof(__error)))
```
Maybe, the changes to the affected unittests are too drastic in that they aren't @nogc and don't operate with static arrays any more.
The PR shows, what's working without changing std.range algorithms.

---
Starting a countdown: The last 5 (6?) phobos modules, that haven't -dip1000 set (apart from those in the PR pipeline):
std.format
std.outbuffer
std.path
(std.algorithm.searching   https://github.com/dlang/phobos/pull/6359 states, it depends on std.container.slist only)
std.algorithm.sorting   see also https://github.com/dlang/phobos/pull/6359
std.experimental.logger.filelogger