### PR TITLE
Add std.traits.isStronglyPure

### DIFF
--- a/changelog/std-traits-isStronglyPure.dd
+++ b/changelog/std-traits-isStronglyPure.dd
@@ -1,0 +1,15 @@
+Addition: `std.traits.isStronglyPure` 
+
+Strongly `pure` functions are `pure` functions of which parameters and return value cannot
+reach any mutable state. Practically this means the layout of all parameters and that of
+the result contains nonpointer data passed (or returned) by value, in conjunction
+with `immutable` indirectly-accessed data. This is in keeping with the
+$(LINK2 $(ROOT_DIR)spec/function.html#pure-functions, D language spacification of pure functions).
+
+$(REF isStronglyPure, std, traits) yields `true` if a the function passed to it satisfies
+these conditions. Example:
+-------
+static assert(isStronglyPure!((int x) => x));
+static assert(!isStronglyPure((ref int x) => x));
+-------
+

--- a/std/traits.d
+++ b/std/traits.d
@@ -9107,27 +9107,31 @@ if (F.length == 1 && isCallable!F)
 
         //check if the function is a member function
         static if (isType!(__traits(parent, F)) && !hasFunctionAttributes!(F, "immutable"))
-            return false;
-
-        alias STC = ParameterStorageClass;
-
-        static foreach (i, param; Parameters!F)
         {
-            if (!is(param == immutable)
-                    && (isRefType!param || hasAliasing!param
-                    || ParameterStorageClassTuple!F[i] == STC.ref_
-                    || ParameterStorageClassTuple!F[i] == STC.out_))
-                return false;
-        }
-
-        alias rt = ReturnType!F;
-
-        if (is(rt == immutable))
-            return true;
-        else if (isRefType!rt || hasAliasing!rt || hasFunctionAttributes!(F, "ref"))
             return false;
+        }
         else
-            return true;
+        {
+            alias STC = ParameterStorageClass;
+
+            foreach (i, param; Parameters!F)
+            {
+                 if (!is(param == immutable)
+                        && (isRefType!param || hasAliasing!param
+                        || ParameterStorageClassTuple!F[i] == STC.ref_
+                        || ParameterStorageClassTuple!F[i] == STC.out_))
+                    return false;
+            }
+
+            alias rt = ReturnType!F;
+
+            if (is(rt == immutable))
+                return true;
+            else if (isRefType!rt || hasAliasing!rt || hasFunctionAttributes!(F, "ref"))
+                return false;
+            else
+                return true;
+        }
     }
 
     private bool isRefType(T)()


### PR DESCRIPTION
See relevant NG discussion: https://forum.dlang.org/thread/p9m6lb$iud$1@digitalmars.com

D currently allows functions to be pure even though they are not strictly pure.
To be strictly pure, a function must satisfy the following:
* Each parameter:
  - is `immutable`, OR
  - can be converted automatically to `immutable` (i.e. has no mutable indirections) AND is passed by value
* The return type:
  - is `immutable`, OR
  - can be converted automatically to `immutable`

Andrei has said that `const` will not count for now

I'm also unsure on how to unittest the second overload for isStronglyPure,  since overloading of functions within the local scope is not allowed. Please help with this. Thanks!