### PR TITLE
Add multiblock support for shared and non-shared BitmappedBlock

### DIFF
--- a/changelog/shared-bitmapped-block.dd
+++ b/changelog/shared-bitmapped-block.dd
@@ -1,0 +1,26 @@
+Added the SharedBitmappedBlock, as the thread-safe version of the regular BitmappedBlock.
+
+The new $(REF SharedBitmappedBlock, std,experimental,allocator,building_blocks,bitmapped_block) and its single-threaded version can now be instantiated with `Yes.multiblock` or `No.multiblock`.
+If instantiated with `Yes.multiblock` (the default behavior), each allocation can return an arbitrary number of blocks.
+With `No.multiblock` however, any allocation request can't exceed the block size. This allows for greater performance on both single and multithreaded environments.
+
+---
+// The 'BitmappedBlock' is implicitly instantiated with Yes.multiblock
+auto a = BitmappedBlock!(blockSize, 8, Mallocator, Yes.multiblock)(numBlocks * blockSize);
+
+// Instantiated with Yes.multiblock, can allocate more than one block at a time
+void[] buf = a.allocate(2 * blockSize);
+assert(buf.length == 2 * blockSize);
+assert(a.deallocate(buf));
+---
+
+---
+// Instantate the 'BitmappedBlock' with No.multiblock
+auto a = BitmappedBlock!(blockSize, 8, Mallocator, No.multiblock)(1024 * blockSize);
+
+// Since instantiated with No.multiblock, can only allocate at most the block size
+void[] buf = a.allocate(blockSize + 1);
+assert(buf is null);
+---
+
+For shared the same rules apply, we only need to replace `BitmappedBlock` with `SharedBitmappedBlock`.

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -6,9 +6,1131 @@ module std.experimental.allocator.building_blocks.bitmapped_block;
 
 import std.experimental.allocator.building_blocks.null_allocator;
 import std.experimental.allocator.common;
+import std.typecons : Flag, Yes, No;
+
+
+// Common implementation for shared and non-shared versions of the BitmappedBlock
+private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
+{
+    import std.conv : text;
+    import std.traits : hasMember;
+    import std.typecons : Ternary;
+    import std.typecons : tuple, Tuple;
+
+    static if (isShared && multiBlock)
+    import core.internal.spinlock : SpinLock;
+
+    static assert(theBlockSize > 0 && theAlignment.isGoodStaticAlignment);
+    static assert(theBlockSize == chooseAtRuntime ||
+        theBlockSize % theAlignment == 0, "Block size must be a multiple of the alignment");
+
+    static if (theBlockSize != chooseAtRuntime)
+    {
+        alias blockSize = theBlockSize;
+    }
+    else
+    {
+        // It is the caller's responsibilty to synchronize this with
+        // allocate/deallocate in shared environments
+        @property uint blockSize() { return _blockSize; }
+        @property void blockSize(uint s)
+        {
+            static if (multiBlock)
+            {
+                assert((cast(BitVector) _control).length == 0 && s % alignment == 0);
+            }
+            else
+            {
+                assert(_control.length == 0 && s % alignment == 0);
+            }
+            _blockSize = s;
+        }
+        private uint _blockSize;
+    }
+
+    static if (is(ParentAllocator == NullAllocator))
+    {
+        private enum parentAlignment = platformAlignment;
+    }
+    else
+    {
+        private alias parentAlignment = ParentAllocator.alignment;
+        static assert(parentAlignment >= ulong.alignof);
+    }
+
+    alias alignment = theAlignment;
+
+    static if (stateSize!ParentAllocator)
+    {
+        ParentAllocator parent;
+    }
+    else
+    {
+        alias parent = ParentAllocator.instance;
+    }
+
+    private size_t _blocks;
+    private void[] _payload;
+    private size_t _startIdx;
+
+    // For multiblock, '_control' is a BitVector, otherwise just a regular ulong[]
+    static if (multiBlock)
+    {
+        // Keeps track of first block which has never been used in an allocation.
+        // All blocks which are located right to the '_freshBit', should have never been
+        // allocated
+        private ulong _freshBit;
+        private BitVector _control;
+    }
+    else
+    {
+        private ulong[] _control;
+    }
+
+    static if (multiBlock && isShared)
+    {
+        SpinLock lock = SpinLock(SpinLock.Contention.brief);
+    }
+
+    pure nothrow @safe @nogc
+    private size_t totalAllocation(size_t capacity)
+    {
+        auto blocks = capacity.divideRoundUp(blockSize);
+        auto leadingUlongs = blocks.divideRoundUp(64);
+        import std.algorithm.comparison : min;
+        immutable initialAlignment = min(parentAlignment,
+            1U << trailingZeros(leadingUlongs * 8));
+        auto maxSlack = alignment <= initialAlignment
+            ? 0
+            : alignment - initialAlignment;
+        return leadingUlongs * 8 + maxSlack + blockSize * blocks;
+    }
+
+    this(ubyte[] data)
+    {
+        immutable a = data.ptr.effectiveAlignment;
+        assert(a >= size_t.alignof || !data.ptr,
+            "Data must be aligned properly");
+
+        immutable ulong totalBits = data.length * 8;
+        immutable ulong bitsPerBlock = blockSize * 8 + 1;
+        _blocks = totalBits / bitsPerBlock;
+
+        // Reality is a bit more complicated, iterate until a good number of
+        // blocks found.
+        size_t localBlocks;
+        for (localBlocks = _blocks; localBlocks; --localBlocks)
+        {
+            immutable controlWords = localBlocks.divideRoundUp(64);
+            auto payload = data[controlWords * 8 .. $].roundStartToMultipleOf(
+                alignment);
+            if (payload.length < localBlocks * blockSize)
+            {
+                // Overestimated
+                continue;
+            }
+
+            // Need the casts for shared versions
+            static if (multiBlock)
+            {
+                _control = cast(typeof(_control)) BitVector((cast(ulong*) data.ptr)[0 .. controlWords]);
+                (cast(BitVector) _control)[] = 0;
+            }
+            else
+            {
+                _control = (cast(typeof(_control.ptr)) data.ptr)[0 .. controlWords];
+                _control[] = 0;
+            }
+
+            _payload = cast(typeof(_payload)) payload;
+            break;
+        }
+
+        _blocks = cast(typeof(_blocks)) localBlocks;
+    }
+
+    static if (chooseAtRuntime == theBlockSize)
+    this(ubyte[] data, uint blockSize)
+    {
+        this._blockSize = blockSize;
+        this(data);
+    }
+
+    static if (!is(ParentAllocator == NullAllocator))
+    this(size_t capacity)
+    {
+        size_t toAllocate = totalAllocation(capacity);
+        auto data = cast(ubyte[])(parent.allocate(toAllocate));
+        this(data);
+        assert(_blocks * blockSize >= capacity);
+    }
+
+    static if (!is(ParentAllocator == NullAllocator) &&
+        chooseAtRuntime == theBlockSize)
+    this(size_t capacity, uint blockSize)
+    {
+        this._blockSize = blockSize;
+        this(capacity);
+    }
+
+    static if (!is(ParentAllocator == NullAllocator)
+        && hasMember!(ParentAllocator, "deallocate"))
+    ~this()
+    {
+        // multiblock bitmapped blocks use a BitVector
+        static if (multiBlock)
+        {
+            void* start = cast(void*) _control.rep.ptr;
+        }
+        else
+        {
+            void* start = cast(void*) _control.ptr;
+        }
+        void* end = cast(void*) (_payload.ptr + _payload.length);
+        parent.deallocate(start[0 .. end - start]);
+    }
+
+    pure nothrow @safe @nogc
+    size_t goodAllocSize(size_t n)
+    {
+        return n.roundUpToMultipleOf(blockSize);
+    }
+
+    // Implementation of the 'multiBlock' BitmappedBlock
+    // For the shared version, the methods are protected by a common lock
+    static if (multiBlock)
+    {
+        /*
+        Adjusts the memoized _startIdx to the leftmost control word that has at
+        least one zero bit. Assumes all control words to the left of $(D
+        _control[_startIdx]) are already occupied.
+        */
+        private void adjustStartIdx()
+        {
+            while (_startIdx < _control.rep.length && _control.rep[_startIdx] == ulong.max)
+            {
+                static if (isShared)
+                {
+                    // Shared demands atomic increment, however this is protected
+                    // by a lock. Regular increment is fine
+                    auto localStart = _startIdx + 1;
+                    _startIdx = localStart;
+                }
+                else
+                {
+                    ++_startIdx;
+                }
+            }
+        }
+
+        /*
+        Based on the latest allocated bit, 'newBit', it adjusts '_freshBit'
+        */
+        pure nothrow @safe @nogc
+        private void adjustFreshBit(const ulong newBit)
+        {
+            import std.algorithm.comparison : max;
+            static if (isShared)
+            {
+                auto localFreshBit = max(newBit, _freshBit);
+                _freshBit = localFreshBit;
+            }
+            else
+            {
+                _freshBit = max(newBit, _freshBit);
+            }
+        }
+
+        /*
+        Returns the blocks corresponding to the control bits starting at word index
+        wordIdx and bit index msbIdx (MSB=0) for a total of howManyBlocks.
+        */
+        @trusted
+        private void[] blocksFor(this _)(size_t wordIdx, uint msbIdx, size_t howManyBlocks)
+        {
+            assert(msbIdx <= 63);
+            const start = (wordIdx * 64 + msbIdx) * blockSize;
+            const end = start + blockSize * howManyBlocks;
+            if (start == end) return null;
+            if (end <= _payload.length) return cast(void[]) _payload[start .. end];
+            // This could happen if we have more control bits than available memory.
+            // That's possible because the control bits are rounded up to fit in
+            // 64-bit words.
+            return null;
+        }
+
+        static if (isShared)
+        nothrow @safe @nogc
+        void[] allocate(const size_t s)
+        {
+            lock.lock();
+            scope(exit) lock.unlock();
+
+            return allocateImpl(s);
+        }
+
+        static if (!isShared)
+        pure nothrow @safe @nogc
+        void[] allocate(const size_t s)
+        {
+            return allocateImpl(s);
+        }
+
+
+        // If shared, this is protected by a lock inside 'allocate'
+        pure nothrow @trusted @nogc
+        private void[] allocateImpl(const size_t s)
+        {
+            const blocks = s.divideRoundUp(blockSize);
+            void[] result;
+
+        Lswitch:
+            switch (blocks)
+            {
+            case 1:
+                // inline code here for speed
+                // find the next available block
+                foreach (i; _startIdx .. _control.rep.length)
+                {
+                    const w = _control.rep[i];
+                    if (w == ulong.max) continue;
+                    uint j = leadingOnes(w);
+                    assert(j < 64, "Invalid number of blocks");
+                    assert((_control.rep[i] & ((1UL << 63) >> j)) == 0, "Corrupted bitmap");
+                    static if (isShared)
+                    {
+                        // Need the cast because shared does not recognize the lock
+                        *(cast(ulong*) &_control._rep[i]) |= (1UL << 63) >> j;
+                    }
+                    else
+                    {
+                        _control.rep[i] |= (1UL << 63) >> j;
+                    }
+                    if (i == _startIdx)
+                    {
+                        adjustStartIdx();
+                    }
+                    result = blocksFor(i, j, 1);
+                    break Lswitch;
+                }
+                goto case 0; // fall through
+            case 0:
+                return null;
+            case 2: .. case 64:
+                result = smallAlloc(cast(uint) blocks);
+                break;
+            default:
+                result = hugeAlloc(blocks);
+                break;
+            }
+            if (result)
+            {
+                adjustFreshBit((result.ptr - _payload.ptr) / blockSize + blocks);
+            }
+            return result.ptr ? result.ptr[0 .. s] : null;
+        }
+
+        @trusted void[] allocateFresh(const size_t s)
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            const blocks = s.divideRoundUp(blockSize);
+
+            void[] result = blocksFor(cast(size_t) (_freshBit / 64),
+                cast(uint) (_freshBit % 64), blocks);
+            if (result)
+            {
+                (cast(BitVector) _control)[_freshBit .. _freshBit + blocks] = 1;
+                static if (isShared)
+                {
+                    ulong localFreshBit = _freshBit;
+                    localFreshBit += blocks;
+                    _freshBit = localFreshBit;
+                }
+                else
+                {
+                    _freshBit += blocks;
+                }
+            }
+            return result;
+        }
+
+        void[] alignedAllocate(size_t n, uint a)
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            return alignedAllocateImpl(n, a);
+        }
+
+        // If shared, this is protected by a lock inside 'alignedAllocate'
+        private void[] alignedAllocateImpl(size_t n, uint a)
+        {
+            import std.math : isPowerOf2;
+            assert(a.isPowerOf2);
+            if (a <= alignment) return allocate(n);
+
+            // Overallocate to make sure we can get an aligned block
+            auto b = allocateImpl((n + a - alignment).roundUpToMultipleOf(blockSize));
+            if (!b.ptr) return null;
+            auto result = b.roundStartToMultipleOf(a);
+            assert(result.length >= n);
+            result = result.ptr[0 .. n]; // final result
+
+            // Free any blocks that might be slack at the beginning
+            auto slackHeadingBlocks = (result.ptr - b.ptr) / blockSize;
+            if (slackHeadingBlocks)
+            {
+                deallocateImpl(b[0 .. slackHeadingBlocks * blockSize]);
+            }
+
+            // Free any blocks that might be slack at the end
+            auto slackTrailingBlocks = ((b.ptr + b.length)
+                - (result.ptr + result.length)) / blockSize;
+            if (slackTrailingBlocks)
+            {
+                deallocateImpl(b[$ - slackTrailingBlocks * blockSize .. $]);
+            }
+
+            return result;
+        }
+
+        /*
+        Tries to allocate "blocks" blocks at the exact position indicated by the
+        position wordIdx/msbIdx (msbIdx counts from MSB, i.e. MSB has index 0). If
+        it succeeds, fills "result" with the result and returns tuple(size_t.max,
+        0). Otherwise, returns a tuple with the next position to search.
+        */
+        private Tuple!(size_t, uint) allocateAt(size_t wordIdx, uint msbIdx,
+                size_t blocks, ref void[] result)
+        {
+            assert(blocks > 0);
+            assert(wordIdx < _control.rep.length);
+            assert(msbIdx <= 63);
+            void[] tmpResult;
+            result = null;
+            if (msbIdx + blocks <= 64)
+            {
+                // Allocation should fit this control word
+                static if (isShared)
+                {
+                    ulong localControl = _control.rep[wordIdx];
+                    bool didSetBit = setBitsIfZero(localControl,
+                        cast(uint) (64 - msbIdx - blocks), 63 - msbIdx);
+                    _control.rep[wordIdx] = localControl;
+                }
+                else
+                {
+                    bool didSetBit = setBitsIfZero(_control.rep[wordIdx],
+                        cast(uint) (64 - msbIdx - blocks), 63 - msbIdx);
+                }
+                if (didSetBit)
+                {
+                    tmpResult = blocksFor(wordIdx, msbIdx, blocks);
+                    if (!tmpResult)
+                    {
+                        static if (isShared)
+                        {
+                            localControl = _control.rep[wordIdx];
+                            resetBits(localControl,
+                                cast(uint) (64 - msbIdx - blocks), 63 - msbIdx);
+                            _control.rep[wordIdx] = localControl;
+                        }
+                        else
+                        {
+                            resetBits(_control.rep[wordIdx],
+                                cast(uint) (64 - msbIdx - blocks), 63 - msbIdx);
+                        }
+                        return tuple(size_t.max - 1, 0u);
+                    }
+                    result = tmpResult;
+                    tmpResult = null;
+                    return tuple(size_t.max, 0u);
+                }
+                // Can't allocate, make a suggestion
+                return msbIdx + blocks == 64
+                    ? tuple(wordIdx + 1, 0u)
+                    : tuple(wordIdx, cast(uint) (msbIdx + blocks));
+            }
+            // Allocation spans two control words or more
+            immutable mask = ulong.max >> msbIdx;
+            if (_control.rep[wordIdx] & mask)
+            {
+                // We can't allocate the rest of this control word,
+                // return a suggestion.
+                return tuple(wordIdx + 1, 0u);
+            }
+            // We can allocate the rest of this control word, but we first need to
+            // make sure we can allocate the tail.
+            if (wordIdx + 1 == _control.rep.length)
+            {
+                // No more memory
+                return tuple(_control.rep.length, 0u);
+            }
+            auto hint = allocateAt(wordIdx + 1, 0, blocks - 64 + msbIdx, result);
+            if (hint[0] == size_t.max)
+            {
+                tmpResult = blocksFor(wordIdx, msbIdx, blocks);
+                if (!tmpResult)
+                {
+                    return tuple(size_t.max - 1, 0u);
+                }
+                static if (isShared)
+                {
+                    // Dont want atomics, because this is protected by 'lock'
+                    ulong localControl = _control.rep[wordIdx];
+                    localControl |= mask;
+                    _control.rep[wordIdx] = localControl;
+                }
+                else
+                {
+                    _control.rep[wordIdx] |= mask;
+                }
+                result = tmpResult;
+                tmpResult = null;
+                return tuple(size_t.max, 0u);
+            }
+            // Failed, return a suggestion that skips this whole run.
+            return hint;
+        }
+
+        /* Allocates as many blocks as possible at the end of the blocks indicated
+        by wordIdx. Returns the number of blocks allocated. */
+        private uint allocateAtTail(size_t wordIdx)
+        {
+            assert(wordIdx < _control.rep.length);
+            const available = trailingZeros(_control.rep[wordIdx]);
+            static if (isShared)
+            {
+                ulong localControl = _control.rep[wordIdx];
+                localControl |= ulong.max >> available;
+                _control.rep[wordIdx] = localControl;
+            }
+            else
+            {
+                _control.rep[wordIdx] |= ulong.max >> available;
+            }
+            return available;
+        }
+
+        pure nothrow @safe @nogc
+        private void[] smallAlloc(uint blocks)
+        {
+            assert(blocks >= 2 && blocks <= 64);
+            void[] result;
+            foreach (i; _startIdx .. _control.rep.length)
+            {
+                // Test within the current 64-bit word
+                const v = _control.rep[i];
+                if (v == ulong.max) continue;
+                auto j = findContigOnes(~v, blocks);
+                if (j < 64)
+                {
+                    // yay, found stuff
+                    result = blocksFor(i, j, blocks);
+                    if (result)
+                    {
+                        static if (isShared)
+                        {
+                            ulong localControl = _control.rep[i];
+                            setBits(localControl, 64 - j - blocks, 63 - j);
+                            _control.rep[i] = localControl;
+                        }
+                        else
+                        {
+                            setBits(_control.rep[i], 64 - j - blocks, 63 - j);
+                        }
+                    }
+                    return result;
+                }
+                // Next, try allocations that cross a word
+                auto available = trailingZeros(v);
+                if (available == 0) continue;
+                if (i + 1 >= _control.rep.length) break;
+                assert(available < blocks); // otherwise we should have found it
+                auto needed = blocks - available;
+                assert(needed > 0 && needed < 64);
+                result = blocksFor(i, 64 - available, blocks);
+                if (result && allocateAtFront(i + 1, needed))
+                {
+                    static if (isShared)
+                    {
+                        ulong localControl = _control.rep[i];
+                        localControl |= (1UL << available) - 1;
+                        _control.rep[i] = localControl;
+                    }
+                    else
+                    {
+                        _control.rep[i] |= (1UL << available) - 1;
+                    }
+                    return result;
+                }
+            }
+            return null;
+        }
+
+        pure nothrow @trusted @nogc
+        private void[] hugeAlloc(size_t blocks)
+        {
+            assert(blocks > 64);
+            if (_startIdx == _control._rep.length)
+            {
+                assert((cast(BitVector) _control).allAre1);
+                return null;
+            }
+
+            auto i = (cast(BitVector)_control).findZeros(blocks, _startIdx * 64);
+            if (i == i.max || i + blocks > _blocks) return null;
+            // Allocate those bits
+            (cast(BitVector) _control)[i .. i + blocks] = 1;
+            return cast(void[]) _payload[cast(size_t) (i * blockSize)
+                .. cast(size_t) ((i + blocks) * blockSize)];
+        }
+
+        // Rounds sizeInBytes to a multiple of blockSize.
+        private size_t bytes2blocks(size_t sizeInBytes)
+        {
+            return (sizeInBytes + blockSize - 1) / blockSize;
+        }
+
+        /* Allocates given blocks at the beginning blocks indicated by wordIdx.
+        Returns true if allocation was possible, false otherwise. */
+        private bool allocateAtFront(size_t wordIdx, uint blocks)
+        {
+            assert(wordIdx < _control.rep.length && blocks >= 1 && blocks <= 64);
+            const mask = (1UL << (64 - blocks)) - 1;
+            if (_control.rep[wordIdx] > mask) return false;
+            static if (isShared)
+            {
+                ulong localControl = _control.rep[wordIdx];
+                localControl |= ~mask;
+                _control.rep[wordIdx] = localControl;
+            }
+            else
+            {
+                _control.rep[wordIdx] |= ~mask;
+            }
+            return true;
+        }
+
+        // Since the lock is not pure, only the single threaded 'expand' is pure
+        static if (isShared)
+        {
+            nothrow @trusted @nogc
+            bool expand(ref void[] b, immutable size_t delta)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+
+                return expandImpl(b, delta);
+            }
+        }
+        else
+        {
+            pure nothrow @trusted @nogc
+            bool expand(ref void[] b, immutable size_t delta)
+            {
+                return expandImpl(b, delta);
+            }
+        }
+
+        // If shared, this is protected by a lock inside 'expand'
+        pure nothrow @trusted @nogc
+        private bool expandImpl(ref void[] b, immutable size_t delta)
+        {
+            // Dispose with trivial corner cases
+            if (b is null || delta == 0) return delta == 0;
+
+            /* To simplify matters, refuse to expand buffers that don't start at a block start (this may be the case for blocks allocated with alignedAllocate).
+            */
+            if ((b.ptr - _payload.ptr) % blockSize) return false;
+
+            const blocksOld = bytes2blocks(b.length);
+            const blocksNew = bytes2blocks(b.length + delta);
+            assert(blocksOld <= blocksNew);
+
+            // Possibly we have enough slack at the end of the block!
+            if (blocksOld == blocksNew)
+            {
+                b = b.ptr[0 .. b.length + delta];
+                return true;
+            }
+
+            assert((b.ptr - _payload.ptr) % blockSize == 0);
+            const blockIdx = (b.ptr - _payload.ptr) / blockSize;
+            const blockIdxAfter = blockIdx + blocksOld;
+
+            // Try the maximum
+            const wordIdx = blockIdxAfter / 64,
+                msbIdx = cast(uint) (blockIdxAfter % 64);
+            void[] p;
+            auto hint = allocateAt(wordIdx, msbIdx,  blocksNew - blocksOld, p);
+            if (hint[0] != size_t.max)
+            {
+                return false;
+            }
+            // Expansion successful
+            assert(p.ptr == b.ptr + blocksOld * blockSize);
+            b = b.ptr[0 .. b.length + delta];
+            adjustFreshBit(blockIdx + blocksNew);
+            return true;
+        }
+
+        @system bool reallocate(ref void[] b, size_t newSize)
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            return reallocateImpl(b, newSize);
+        }
+
+        // If shared, this is protected by a lock inside 'reallocate'
+        private @system bool reallocateImpl(ref void[] b, size_t newSize)
+        {
+            static bool slowReallocate(Allocator)(ref Allocator a, ref void[] b, size_t s)
+            {
+                if (b.length == s) return true;
+                if (b.length <= s && a.expandImpl(b, s - b.length)) return true;
+                auto newB = a.allocateImpl(s);
+                if (newB.length != s) return false;
+                if (newB.length <= b.length) newB[] = b[0 .. newB.length];
+                else newB[0 .. b.length] = b[];
+                a.deallocateImpl(b);
+                b = newB;
+                return true;
+            }
+
+            if (!b.ptr)
+            {
+                b = allocateImpl(newSize);
+                return b.length == newSize;
+            }
+            if (newSize == 0)
+            {
+                deallocateImpl(b);
+                b = null;
+                return true;
+            }
+            if (newSize < b.length)
+            {
+                // Shrink. Will shrink in place by deallocating the trailing part.
+                auto newCapacity = bytes2blocks(newSize) * blockSize;
+                deallocateImpl(b[newCapacity .. $]);
+                b = b[0 .. newSize];
+                return true;
+            }
+            // Go the slow route
+            return slowReallocate(this, b, newSize);
+        }
+
+        @system bool alignedReallocate(ref void[] b, size_t newSize, uint a)
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            return alignedReallocateImpl(b, newSize, a);
+        }
+
+        // If shared, this is protected by a lock inside 'alignedReallocate'
+        private @system bool alignedReallocateImpl(ref void[] b, size_t newSize, uint a)
+        {
+            static bool slowAlignedReallocate(Allocator)(ref Allocator alloc,
+                    ref void[] b, size_t s, uint a)
+            {
+                if (b.length <= s && b.ptr.alignedAt(a)
+                    && alloc.expandImpl(b, s - b.length)) return true;
+
+                auto newB = alloc.alignedAllocateImpl(s, a);
+                if (newB.length != s) return false;
+                if (newB.length <= b.length) newB[] = b[0 .. newB.length];
+                else newB[0 .. b.length] = b[];
+                alloc.deallocateImpl(b);
+                b = newB;
+                return true;
+            }
+
+            if (newSize == 0)
+            {
+                deallocateImpl(b);
+                b = null;
+                return true;
+            }
+            // Go the slow route
+            return slowAlignedReallocate(this, b, newSize, a);
+        }
+
+        nothrow @nogc
+        bool deallocate(void[] b)
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            return deallocateImpl(b);
+        }
+
+        // If shared, this is protected by a lock inside 'deallocate'
+        nothrow @nogc
+        private bool deallocateImpl(void[] b)
+        {
+            if (b is null) return true;
+
+            // Locate position
+            immutable pos = b.ptr - _payload.ptr;
+            immutable blockIdx = pos / blockSize;
+
+            // Adjust pointer, might be inside a block due to alignedAllocate
+            void* begin = cast(void*) (_payload.ptr + blockIdx * blockSize),
+                end = cast(void*) (b.ptr + b.length);
+            b = begin[0 .. end - begin];
+            // Round up size to multiple of block size
+            auto blocks = b.length.divideRoundUp(blockSize);
+
+            // Get into details
+            auto wordIdx = blockIdx / 64, msbIdx = cast(uint) (blockIdx % 64);
+            if (_startIdx > wordIdx) _startIdx = wordIdx;
+
+            // Three stages: heading bits, full words, leftover bits
+            if (msbIdx)
+            {
+                if (blocks + msbIdx <= 64)
+                {
+                    static if (isShared)
+                    {
+                        ulong localControl = _control.rep[wordIdx];
+                        resetBits(localControl,
+                            cast(uint) (64 - msbIdx - blocks),
+                            63 - msbIdx);
+                        _control.rep[wordIdx] = localControl;
+                    }
+                    else
+                    {
+                        resetBits(_control.rep[wordIdx],
+                            cast(uint) (64 - msbIdx - blocks),
+                            63 - msbIdx);
+                    }
+                    return true;
+                }
+                else
+                {
+                    static if (isShared)
+                    {
+                        ulong localControl = _control.rep[wordIdx];
+                        localControl &= ulong.max << (64 - msbIdx);
+                        _control.rep[wordIdx] = localControl;
+                    }
+                    else
+                    {
+                        _control.rep[wordIdx] &= ulong.max << (64 - msbIdx);
+                    }
+                    blocks -= 64 - msbIdx;
+                    ++wordIdx;
+                    msbIdx = 0;
+                }
+            }
+
+            // Stage 2: reset one word at a time
+            for (; blocks >= 64; blocks -= 64)
+            {
+                _control.rep[wordIdx++] = 0;
+            }
+
+            // Stage 3: deal with leftover bits, if any
+            assert(wordIdx <= _control.rep.length);
+            if (blocks)
+            {
+                static if (isShared)
+                {
+                    ulong localControl = _control.rep[wordIdx];
+                    localControl &= ulong.max >> blocks;
+                    _control.rep[wordIdx] = localControl;
+                }
+                else
+                {
+                    _control.rep[wordIdx] &= ulong.max >> blocks;
+                }
+            }
+            return true;
+        }
+
+        // Since the lock is not pure, only the single threaded version is pure
+        static if (isShared)
+        {
+            nothrow @nogc
+            bool deallocateAll()
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+
+                (cast(BitVector) _control)[] = 0;
+                _startIdx = 0;
+                return true;
+            }
+        }
+        else
+        {
+            pure nothrow @nogc
+            bool deallocateAll()
+            {
+                _control[] = 0;
+                _startIdx = 0;
+                return true;
+            }
+        }
+
+        // Since the lock is not pure, only the single threaded version is pure
+        static if (isShared)
+        {
+            nothrow @safe @nogc
+            Ternary empty()
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+
+                return emptyImpl();
+            }
+        }
+        else
+        {
+            pure nothrow @safe @nogc
+            Ternary empty()
+            {
+                return Ternary(_control.allAre0());
+            }
+        }
+
+        pure nothrow @trusted @nogc
+        private Ternary emptyImpl()
+        {
+            return Ternary((cast(BitVector) _control).allAre0());
+        }
+
+        // Debug helper
+        debug(StdBitmapped)
+        private void dump()
+        {
+            import std.stdio : writefln, writeln;
+
+            ulong controlLen = (cast(BitVector) _control).length;
+            writefln("%s @ %s {", typeid(this), cast(void*) (cast(BitVector) _control)._rep.ptr);
+            scope(exit) writeln("}");
+            assert(_payload.length >= blockSize * _blocks);
+            assert(controlLen >= _blocks);
+            writefln("  _startIdx=%s; blockSize=%s; blocks=%s",
+                _startIdx, blockSize, _blocks);
+            if (!controlLen) return;
+            uint blockCount = 1;
+            bool inAllocatedStore = (cast(BitVector) _control)[0];
+            void* start = cast(void*) _payload.ptr;
+            for (size_t i = 1;; ++i)
+            {
+                if (i >= _blocks || (cast(BitVector) _control)[i] != inAllocatedStore)
+                {
+                    writefln("  %s block at 0x%s, length: %s (%s*%s)",
+                        inAllocatedStore ? "Busy" : "Free",
+                        cast(void*) start,
+                        blockCount * blockSize,
+                        blockCount, blockSize);
+                    if (i >= _blocks) break;
+                    assert(i < controlLen);
+                    inAllocatedStore = (cast(BitVector) _control)[i];
+                    start = cast(void*) (_payload.ptr + blockCount * blockSize);
+                    blockCount = 1;
+                }
+                else
+                {
+                    ++blockCount;
+                }
+            }
+        }
+
+        void[] allocateAll()
+        {
+            static if (isShared)
+            {
+                lock.lock();
+                scope(exit) lock.unlock();
+            }
+
+            if (emptyImpl != Ternary.yes) return null;
+            (cast(BitVector) _control)[] = 1;
+            return cast(void[]) _payload;
+        }
+    } // Finish Yes.multiblock implementation specifics
+    else
+    {
+        static if (isShared)
+        pure nothrow @trusted @nogc
+        void[] allocate(const size_t s)
+        {
+            import core.atomic : cas, atomicLoad, atomicOp;
+            import core.bitop : bsr;
+            import std.range : iota;
+            import std.algorithm.iteration : map;
+            import std.array : array;
+
+            if (s.divideRoundUp(blockSize) != 1)
+                return null;
+
+            // First zero bit position for all values in the 0 - 255 range
+            // for fast lookup
+            static immutable ubyte[255] firstZero = iota(255U).map!
+                (x => (7 - (bsr((~x) & 0x000000ff)))).array;
+
+            foreach (size_t i; 0 .. _control.length)
+            {
+                ulong controlVal, newControlVal, bitIndex;
+                do
+                {
+                    bitIndex = 0;
+                    newControlVal = 0;
+                    controlVal = atomicLoad(_control[i]);
+
+                    // skip all control words which have all bits set
+                    if (controlVal == ulong.max)
+                        break;
+
+                    // fast lookup of first byte which has at least one zero bit
+                    foreach (byteIndex; 0 .. 8)
+                    {
+                        ulong mask = (0xFFUL << (8 * (7 - byteIndex)));
+                        if ((mask & controlVal) != mask)
+                        {
+                            ubyte byteVal = cast(ubyte) ((mask & controlVal) >> (8 * (7 - byteIndex)));
+                            bitIndex += firstZero[byteVal];
+                            newControlVal = controlVal | (1UL << (63 - bitIndex));
+                            break;
+                        }
+                        bitIndex += 8;
+                    }
+                } while (!cas(&_control[i], controlVal, newControlVal));
+
+                auto blockIndex = bitIndex + 64 * i;
+                if (controlVal != ulong.max && blockIndex < _blocks)
+                {
+                    size_t payloadBlockStart = cast(size_t) blockIndex * blockSize;
+                    return cast(void[]) _payload[payloadBlockStart .. payloadBlockStart + s];
+                }
+            }
+
+            return null;
+        }
+
+        static if (!isShared)
+        pure nothrow @trusted @nogc
+        void[] allocate(const size_t s)
+        {
+            import core.bitop : bsr;
+            import std.range : iota;
+            import std.algorithm.iteration : map;
+            import std.array : array;
+
+            if (s.divideRoundUp(blockSize) != 1)
+                return null;
+
+            // First zero bit position for all values in the 0 - 255 range
+            // for fast lookup
+            static immutable ubyte[255] firstZero = iota(255U).map!
+                (x => (7 - (bsr((~x) & 0x000000ff)))).array;
+
+            _startIdx = (_startIdx + 1) % _control.length;
+            foreach (size_t idx; 0 .. _control.length)
+            {
+                size_t i = (idx + _startIdx) % _control.length;
+                size_t bitIndex = 0;
+                // skip all control words which have all bits set
+                if (_control[i] == ulong.max)
+                    continue;
+
+                // fast lookup of first byte which has at least one zero bit
+                foreach (byteIndex; 0 .. 8)
+                {
+                    ulong mask = (0xFFUL << (8 * (7 - byteIndex)));
+                    if ((mask & _control[i]) != mask)
+                    {
+                        ubyte byteVal = cast(ubyte) ((mask & _control[i]) >> (8 * (7 - byteIndex)));
+                        bitIndex += firstZero[byteVal];
+                        _control[i] |= (1UL << (63 - bitIndex));
+                        break;
+                    }
+                    bitIndex += 8;
+                }
+
+                auto blockIndex = bitIndex + 64 * i;
+                if (blockIndex < _blocks)
+                {
+                    size_t payloadBlockStart = cast(size_t) blockIndex * blockSize;
+                    return cast(void[]) _payload[payloadBlockStart .. payloadBlockStart + s];
+                }
+            }
+
+            return null;
+        }
+
+        nothrow @nogc
+        bool deallocate(void[] b)
+        {
+            static if (isShared)
+            import core.atomic : atomicOp;
+
+            if (b is null)
+                return true;
+
+            auto blockIndex = (b.ptr - _payload.ptr) / blockSize;
+            auto controlIndex = blockIndex / 64;
+            auto bitIndex = blockIndex % 64;
+            static if (isShared)
+            {
+                atomicOp!"&="(_control[controlIndex], ~(1UL << (63 - bitIndex)));
+            }
+            else
+            {
+                _control[controlIndex] &= ~(1UL << (63 - bitIndex));
+            }
+
+            return true;
+        }
+
+        pure nothrow @trusted @nogc
+        bool expand(ref void[] b, immutable size_t delta)
+        {
+            if (delta == 0)
+                return true;
+
+            immutable newLength = delta + b.length;
+            if (b is null || newLength > blockSize)
+                return false;
+
+            b = b.ptr[0 .. newLength];
+            return true;
+        }
+    } // Finish No.multiblock implementation specifics
+
+    pure nothrow @trusted @nogc
+    Ternary owns(const void[] b) const
+    {
+        assert(b || b.length == 0, "Corrupt block.");
+        return Ternary(b && _payload && (&b[0] >= &_payload[0])
+               && (&b[0] + b.length) <= (&_payload[0] + _payload.length));
+    }
+}
 
 /**
-
 `BitmappedBlock` implements a simple heap consisting of one contiguous area
 of memory organized in blocks, each of size `theBlockSize`. A block is a unit
 of allocation. A bitmap serves as bookkeeping data, more precisely one bit per
@@ -16,10 +1138,12 @@ block indicating whether that block is currently allocated or not.
 
 Passing `NullAllocator` as `ParentAllocator` (the default) means user code
 manages allocation of the memory block from the outside; in that case
-`BitmappedBlock` must be constructed with a `void[]` preallocated block and
+`BitmappedBlock` must be constructed with a `ubyte[]` preallocated block and
 has no responsibility regarding the lifetime of its support underlying storage.
 If another allocator type is passed, `BitmappedBlock` defines a destructor that
-uses the parent allocator to release the memory block. That makes the combination of `AllocatorList`, `BitmappedBlock`, and a back-end allocator such as `MmapAllocator` a simple and scalable solution for memory allocation.
+uses the parent allocator to release the memory block. That makes the combination of `AllocatorList`,
+`BitmappedBlock`, and a back-end allocator such as `MmapAllocator`
+a simple and scalable solution for memory allocation.
 
 There are advantages to storing bookkeeping data separated from the payload
 (as opposed to e.g. using `AffixAllocator` to store metadata together with
@@ -37,751 +1161,203 @@ not need to maintain the allocated size, freeing memory implicitly coalesces
 free blocks together. Also, tuning `blockSize` has a considerable impact on
 both internal and external fragmentation.
 
+If the last template parameter is set to `No.multiblock`, the allocator will only serve
+allocations which require at most `theBlockSize`. The `BitmappedBlock` has a specialized
+implementation for single-block allocations which allows for greater performance,
+at the cost of not being able to allocate more than one block at a time.
+
 The size of each block can be selected either during compilation or at run
 time. Statically-known block sizes are frequent in practice and yield slightly
-better performance. To choose a block size statically, pass it as the $(D
-blockSize) parameter as in `BitmappedBlock!(4096)`. To choose a block
+better performance. To choose a block size statically, pass it as the `blockSize`
+parameter as in `BitmappedBlock!(4096)`. To choose a block
 size parameter, use `BitmappedBlock!(chooseAtRuntime)` and pass the
 block size to the constructor.
 
+Params:
+    theBlockSize = the length of a block, which must be a multiple of `theAlignment`
+
+    theAlignment = alignment of each block
+
+    ParentAllocator = allocator from which the `BitmappedBlock` will draw memory.
+        If set to `NullAllocator`, the storage must be passed via the constructor
+
+    f = `Yes.multiblock` to support allocations spanning across multiple blocks and
+        `No.multiblock` to support single block allocations.
+        Although limited by single block allocations, `No.multiblock` will generally
+        provide higher performance.
 */
 struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment,
-    ParentAllocator = NullAllocator)
+   ParentAllocator = NullAllocator, Flag!"multiblock" f = Yes.multiblock)
 {
-    import std.conv : text;
-    import std.traits : hasMember;
-    import std.typecons : Ternary;
-    import std.typecons : tuple, Tuple;
-
-    @system unittest
+    version(StdDdoc)
     {
-        import std.algorithm.comparison : max;
-        import std.experimental.allocator.mallocator : AlignedMallocator;
-        auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
-                                max(theAlignment, cast(uint) size_t.sizeof)));
-        scope(exit) () nothrow @nogc { AlignedMallocator.instance.deallocate(m); }();
-        static if (theBlockSize == chooseAtRuntime)
-        {
-            testAllocator!(() => BitmappedBlock(m, 64));
-        }
-        else
-        {
-            testAllocator!(() => BitmappedBlock(m));
-        }
-    }
-    static assert(theBlockSize > 0 && theAlignment.isGoodStaticAlignment);
-    static assert(theBlockSize == chooseAtRuntime
-        || theBlockSize % theAlignment == 0,
-        "Block size must be a multiple of the alignment");
-
-    /**
-    If $(D blockSize == chooseAtRuntime), `BitmappedBlock` offers a read/write
-    property `blockSize`. It must be set before any use of the allocator.
-    Otherwise (i.e. `theBlockSize` is a legit constant), `blockSize` is
-    an alias for `theBlockSize`. Whether constant or variable, must also be
-    a multiple of `alignment`. This constraint is `assert`ed statically
-    and dynamically.
-    */
-    static if (theBlockSize != chooseAtRuntime)
-    {
-        alias blockSize = theBlockSize;
-    }
-    else
-    {
-        @property uint blockSize() { return _blockSize; }
-        @property void blockSize(uint s)
-        {
-            assert(_control.length == 0 && s % alignment == 0);
-            _blockSize = s;
-        }
-        private uint _blockSize;
-    }
-
-    static if (is(ParentAllocator == NullAllocator))
-    {
-        private enum parentAlignment = platformAlignment;
-    }
-    else
-    {
-        private alias parentAlignment = ParentAllocator.alignment;
-        static assert(parentAlignment >= ulong.alignof);
-    }
-
-    /**
-    The _alignment offered is user-configurable statically through parameter
-    `theAlignment`, defaulted to `platformAlignment`.
-    */
-    alias alignment = theAlignment;
-
-    // state {
-    /**
-    The _parent allocator. Depending on whether `ParentAllocator` holds state
-    or not, this is a member variable or an alias for
-    `ParentAllocator.instance`.
-    */
-    static if (stateSize!ParentAllocator)
-    {
-        ParentAllocator parent;
-    }
-    else
-    {
-        alias parent = ParentAllocator.instance;
-    }
-
-    private uint _blocks;
-    private BitVector _control;
-    private void[] _payload;
-    private size_t _startIdx;
-
-    // Keeps track of first block which has never been used in an allocation.
-    // All blocks which are located right to the '_freshBit', should have never been
-    // allocated
-    private ulong _freshBit;
-    // }
-
-    pure nothrow @safe @nogc
-    private size_t totalAllocation(size_t capacity)
-    {
-        auto blocks = capacity.divideRoundUp(blockSize);
-        auto leadingUlongs = blocks.divideRoundUp(64);
-        import std.algorithm.comparison : min;
-        immutable initialAlignment = min(parentAlignment,
-            1U << trailingZeros(leadingUlongs * 8));
-        auto maxSlack = alignment <= initialAlignment
-            ? 0
-            : alignment - initialAlignment;
-        //writeln(maxSlack);
-        return leadingUlongs * 8 + maxSlack + blockSize * blocks;
-    }
-
-    /**
-    Constructs a block allocator given a hunk of memory, or a desired capacity
-    in bytes.
-
-    $(UL
-    $(LI If `ParentAllocator` is `NullAllocator`, only the constructor
-    taking `data` is defined and the user is responsible for freeing $(D
-    data) if desired.)
-    $(LI Otherwise, both constructors are defined. The `data`-based
-    constructor assumes memory has been allocated with the parent allocator.
-    The `capacity`-based constructor uses `ParentAllocator` to allocate
-    an appropriate contiguous hunk of memory. Regardless of the constructor
-    used, the destructor releases the memory by using $(D
-    ParentAllocator.deallocate).)
-    )
-    */
-    this(ubyte[] data)
-    {
-        immutable a = data.ptr.effectiveAlignment;
-        assert(a >= size_t.alignof || !data.ptr,
-            "Data must be aligned properly");
-
-        immutable ulong totalBits = data.length * 8;
-        immutable ulong bitsPerBlock = blockSize * 8 + 1;
-        // Get a first estimate
-        import std.conv : to;
-        _blocks = to!uint(totalBits / bitsPerBlock);
-
-        // Reality is a bit more complicated, iterate until a good number of
-        // blocks found.
-        for (; _blocks; --_blocks)
-        {
-            immutable controlWords = _blocks.divideRoundUp(64);
-            auto payload = data[controlWords * 8 .. $].roundStartToMultipleOf(
-                alignment);
-            if (payload.length < _blocks * blockSize)
-            {
-                // Overestimated
-                continue;
-            }
-            _control = BitVector((cast(ulong*) data.ptr)[0 .. controlWords]);
-            _control[] = 0;
-            _payload = payload;
-            break;
-        }
-    }
-
-    /// Ditto
-    static if (chooseAtRuntime == theBlockSize)
-    this(ubyte[] data, uint blockSize)
-    {
-        this._blockSize = blockSize;
-        this(data);
-    }
-
-    /// Ditto
-    static if (!is(ParentAllocator == NullAllocator))
-    this(size_t capacity)
-    {
-        size_t toAllocate = totalAllocation(capacity);
-        auto data = cast(ubyte[])(parent.allocate(toAllocate));
-        this(data);
-        assert(_blocks * blockSize >= capacity);
-    }
-
-    /// Ditto
-    static if (!is(ParentAllocator == NullAllocator) &&
-        chooseAtRuntime == theBlockSize)
-    this(size_t capacity, uint blockSize)
-    {
-        this._blockSize = blockSize;
-        this(capacity);
-    }
-
-    /**
-    If `ParentAllocator` is not `NullAllocator` and defines $(D
-    deallocate), the destructor is defined to deallocate the block held.
-    */
-    static if (!is(ParentAllocator == NullAllocator)
-        && hasMember!(ParentAllocator, "deallocate"))
-    ~this()
-    {
-        void* start = _control.rep.ptr, end = _payload.ptr + _payload.length;
-        parent.deallocate(start[0 .. end - start]);
-    }
-
-    /*
-    Adjusts the memoized _startIdx to the leftmost control word that has at
-    least one zero bit. Assumes all control words to the left of $(D
-    _control[_startIdx]) are already occupied.
-    */
-    private void adjustStartIdx()
-    {
-        while (_startIdx < _control.rep.length
-            && _control.rep[_startIdx] == ulong.max)
-        {
-            ++_startIdx;
-        }
-    }
-
-    /*
-    Based on the latest allocated bit, 'newBit', it adjusts '_freshBit'
-    */
-    void adjustFreshBit(const ulong newBit)
-    {
-        import std.algorithm.comparison : max;
-        _freshBit = max(newBit, _freshBit);
-    }
-
-    /*
-    Returns the blocks corresponding to the control bits starting at word index
-    wordIdx and bit index msbIdx (MSB=0) for a total of howManyBlocks.
-    */
-    private void[] blocksFor(size_t wordIdx, uint msbIdx, size_t howManyBlocks)
-    {
-        assert(msbIdx <= 63);
-        const start = (wordIdx * 64 + msbIdx) * blockSize;
-        const end = start + blockSize * howManyBlocks;
-        if (start == end) return null;
-        if (end <= _payload.length) return _payload[start .. end];
-        // This could happen if we have more control bits than available memory.
-        // That's possible because the control bits are rounded up to fit in
-        // 64-bit words.
-        return null;
-    }
-
-    /**
-    Returns the actual bytes allocated when `n` bytes are requested, i.e.
-    `n.roundUpToMultipleOf(blockSize)`.
-    */
-    pure nothrow @safe @nogc
-    size_t goodAllocSize(size_t n)
-    {
-        return n.roundUpToMultipleOf(blockSize);
-    }
-
-    /**
-    Allocates `s` bytes of memory and returns it, or `null` if memory
-    could not be allocated.
-
-    The following information might be of help with choosing the appropriate
-    block size. Actual allocation occurs in sizes multiple of the block size.
-    Allocating one block is the fastest because only one 0 bit needs to be
-    found in the metadata. Allocating 2 through 64 blocks is the next cheapest
-    because it affects a maximum of two `ulong`s in the metadata.
-    Allocations greater than 64 blocks require a multiword search through the
-    metadata.
-    */
-    pure nothrow @trusted @nogc
-    void[] allocate(const size_t s)
-    {
-        const blocks = s.divideRoundUp(blockSize);
-        void[] result = void;
-
-    switcharoo:
-        switch (blocks)
-        {
-        case 1:
-            // inline code here for speed
-            // find the next available block
-            foreach (i; _startIdx .. _control.rep.length)
-            {
-                const w = _control.rep[i];
-                if (w == ulong.max) continue;
-                uint j = leadingOnes(w);
-                assert(j < 64);
-                assert((_control.rep[i] & ((1UL << 63) >> j)) == 0);
-                _control.rep[i] |= (1UL << 63) >> j;
-                if (i == _startIdx)
-                {
-                    adjustStartIdx();
-                }
-                result = blocksFor(i, j, 1);
-                break switcharoo;
-            }
-            goto case 0; // fall through
-        case 0:
-            return null;
-        case 2: .. case 64:
-            result = smallAlloc(cast(uint) blocks);
-            break;
-        default:
-            result = hugeAlloc(blocks);
-            break;
-        }
-        if (result)
-        {
-            adjustFreshBit((result.ptr - _payload.ptr) / blockSize + blocks);
-        }
-        return result.ptr ? result.ptr[0 .. s] : null;
-    }
-
-    /**
-    Allocates `s` bytes of memory and returns it, or `null` if memory
-    could not be allocated.
-
-    `allocateFresh` behaves just like `allocate`, the only difference being that
-    this always returns unused(fresh) memory. Although there may still be available
-    space in the `BitmappedBlock`, `allocateFresh` could still return `null`,
-    because all the available blocks have been previously deallocated.
-    */
-    @safe void[] allocateFresh(const size_t s)
-    {
-        const blocks = s.divideRoundUp(blockSize);
-
-        void[] result = blocksFor(cast(size_t) (_freshBit / 64),
-            cast(uint) (_freshBit % 64), blocks);
-        if (result)
-        {
-            _control[_freshBit .. _freshBit + blocks] = 1;
-            _freshBit += blocks;
-        }
-        return result;
-    }
-
-    /**
-    Allocates a block with specified alignment `a`. The alignment must be a
-    power of 2. If $(D a <= alignment), function forwards to `allocate`.
-    Otherwise, it attempts to overallocate and then adjust the result for
-    proper alignment. In the worst case the slack memory is around two blocks.
-    */
-    void[] alignedAllocate(size_t n, uint a)
-    {
-        import std.math : isPowerOf2;
-        assert(a.isPowerOf2);
-        if (a <= alignment) return allocate(n);
-
-        // Overallocate to make sure we can get an aligned block
-        auto b = allocate((n + a - alignment).roundUpToMultipleOf(blockSize));
-        if (!b.ptr) return null;
-        auto result = b.roundStartToMultipleOf(a);
-        assert(result.length >= n);
-        result = result.ptr[0 .. n]; // final result
-
-        // Free any blocks that might be slack at the beginning
-        auto slackHeadingBlocks = (result.ptr - b.ptr) / blockSize;
-        if (slackHeadingBlocks)
-        {
-            deallocate(b[0 .. slackHeadingBlocks * blockSize]);
-        }
-
-        // Free any blocks that might be slack at the end
-        auto slackTrailingBlocks = ((b.ptr + b.length)
-            - (result.ptr + result.length)) / blockSize;
-        if (slackTrailingBlocks)
-        {
-            deallocate(b[$ - slackTrailingBlocks * blockSize .. $]);
-        }
-
-        return result;
-    }
-
-    /**
-    If the `BitmappedBlock` object is empty (has no active allocation), allocates
-    all memory within and returns a slice to it. Otherwise, returns `null`
-    (i.e. no attempt is made to allocate the largest available block).
-    */
-    void[] allocateAll()
-    {
-        if (empty != Ternary.yes) return null;
-        _control[] = 1;
-        return _payload;
-    }
-
-    /**
-    Returns `Ternary.yes` if `b` belongs to the `BitmappedBlock` object,
-    `Ternary.no` otherwise. Never returns `Ternary.unkown`. (This
-    method is somewhat tolerant in that accepts an interior slice.)
-    */
-    pure nothrow @trusted @nogc
-    Ternary owns(const void[] b) const
-    {
-        assert(b || b.length == 0, "Corrupt block.");
-        return Ternary(b && _payload && (&b[0] >= &_payload[0])
-               && (&b[0] + b.length) <= (&_payload[0] + _payload.length));
-    }
-
-    /*
-    Tries to allocate "blocks" blocks at the exact position indicated by the
-    position wordIdx/msbIdx (msbIdx counts from MSB, i.e. MSB has index 0). If
-    it succeeds, fills "result" with the result and returns tuple(size_t.max,
-    0). Otherwise, returns a tuple with the next position to search.
-    */
-    private Tuple!(size_t, uint) allocateAt(size_t wordIdx, uint msbIdx,
-            size_t blocks, ref void[] result)
-    {
-        assert(blocks > 0);
-        assert(wordIdx < _control.rep.length);
-        assert(msbIdx <= 63);
-        void[] tmpResult;
-        result = null;
-        if (msbIdx + blocks <= 64)
-        {
-            // Allocation should fit this control word
-            if (setBitsIfZero(_control.rep[wordIdx],
-                    cast(uint) (64 - msbIdx - blocks), 63 - msbIdx))
-            {
-                tmpResult = blocksFor(wordIdx, msbIdx, blocks);
-                if (!tmpResult)
-                {
-                    resetBits(_control.rep[wordIdx],
-                        cast(uint) (64 - msbIdx - blocks), 63 - msbIdx);
-                    return tuple(size_t.max - 1, 0u);
-                }
-                result = tmpResult;
-                tmpResult = null;
-                return tuple(size_t.max, 0u);
-            }
-            // Can't allocate, make a suggestion
-            return msbIdx + blocks == 64
-                ? tuple(wordIdx + 1, 0u)
-                : tuple(wordIdx, cast(uint) (msbIdx + blocks));
-        }
-        // Allocation spans two control words or more
-        immutable mask = ulong.max >> msbIdx;
-        if (_control.rep[wordIdx] & mask)
-        {
-            // We can't allocate the rest of this control word,
-            // return a suggestion.
-            return tuple(wordIdx + 1, 0u);
-        }
-        // We can allocate the rest of this control word, but we first need to
-        // make sure we can allocate the tail.
-        if (wordIdx + 1 == _control.rep.length)
-        {
-            // No more memory
-            return tuple(_control.rep.length, 0u);
-        }
-        auto hint = allocateAt(wordIdx + 1, 0, blocks - 64 + msbIdx, result);
-        if (hint[0] == size_t.max)
-        {
-            tmpResult = blocksFor(wordIdx, msbIdx, blocks);
-            if (!tmpResult)
-            {
-                return tuple(size_t.max - 1, 0u);
-            }
-            _control.rep[wordIdx] |= mask;
-            result = tmpResult;
-            tmpResult = null;
-            return tuple(size_t.max, 0u);
-        }
-        // Failed, return a suggestion that skips this whole run.
-        return hint;
-    }
-
-    /* Allocates as many blocks as possible at the end of the blocks indicated
-    by wordIdx. Returns the number of blocks allocated. */
-    private uint allocateAtTail(size_t wordIdx)
-    {
-        assert(wordIdx < _control.rep.length);
-        const available = trailingZeros(_control.rep[wordIdx]);
-        _control.rep[wordIdx] |= ulong.max >> available;
-        return available;
-    }
-
-    pure nothrow @safe @nogc
-    private void[] smallAlloc(uint blocks)
-    {
-        assert(blocks >= 2 && blocks <= 64);
-        void[] result;
-        foreach (i; _startIdx .. _control.rep.length)
-        {
-            // Test within the current 64-bit word
-            const v = _control.rep[i];
-            if (v == ulong.max) continue;
-            auto j = findContigOnes(~v, blocks);
-            if (j < 64)
-            {
-                // yay, found stuff
-                result = blocksFor(i, j, blocks);
-                if (result)
-                    setBits(_control.rep[i], 64 - j - blocks, 63 - j);
-                return result;
-            }
-            // Next, try allocations that cross a word
-            auto available = trailingZeros(v);
-            if (available == 0) continue;
-            if (i + 1 >= _control.rep.length) break;
-            assert(available < blocks); // otherwise we should have found it
-            auto needed = blocks - available;
-            assert(needed > 0 && needed < 64);
-            result = blocksFor(i, 64 - available, blocks);
-            if (result && allocateAtFront(i + 1, needed))
-            {
-                _control.rep[i] |= (1UL << available) - 1;
-                return result;
-            }
-        }
-        return null;
-    }
-
-    pure nothrow @safe @nogc
-    private void[] hugeAlloc(size_t blocks)
-    {
-        assert(blocks > 64);
-        if (_startIdx == _control._rep.length)
-        {
-            assert(_control.allAre1);
-            return null;
-        }
-
-        auto i = _control.findZeros(blocks, _startIdx * 64);
-        if (i == i.max) return null;
-        // Allocate those bits
-        _control[i .. i + blocks] = 1;
-        return _payload[cast(size_t) (i * blockSize)
-            .. cast(size_t) ((i + blocks) * blockSize)];
-    }
-
-    // Rounds sizeInBytes to a multiple of blockSize.
-    private size_t bytes2blocks(size_t sizeInBytes)
-    {
-        return (sizeInBytes + blockSize - 1) / blockSize;
-    }
-
-    /* Allocates given blocks at the beginning blocks indicated by wordIdx.
-    Returns true if allocation was possible, false otherwise. */
-    private bool allocateAtFront(size_t wordIdx, uint blocks)
-    {
-        assert(wordIdx < _control.rep.length && blocks >= 1 && blocks <= 64);
-        const mask = (1UL << (64 - blocks)) - 1;
-        if (_control.rep[wordIdx] > mask) return false;
-        // yay, works
-        _control.rep[wordIdx] |= ~mask;
-        return true;
-    }
-
-    /**
-    Expands an allocated block in place.
-    */
-    pure nothrow @trusted @nogc
-    bool expand(ref void[] b, immutable size_t delta)
-    {
-        // Dispose with trivial corner cases
-        if (b is null || delta == 0) return delta == 0;
-
-        /* To simplify matters, refuse to expand buffers that don't start at a block start (this may be the case for blocks allocated with alignedAllocate).
+        /**
+        Constructs a block allocator given a hunk of memory, or a desired capacity
+        in bytes.
+        $(UL
+        $(LI If `ParentAllocator` is $(REF_ALTTEXT `NullAllocator`, NullAllocator, std,experimental,allocator,building_blocks,null_allocator),
+        only the constructor taking `data` is defined and the user is responsible for freeing `data` if desired.)
+        $(LI Otherwise, both constructors are defined. The `data`-based
+        constructor assumes memory has been allocated with the parent allocator.
+        The `capacity`-based constructor uses `ParentAllocator` to allocate
+        an appropriate contiguous hunk of memory. Regardless of the constructor
+        used, the destructor releases the memory by using `ParentAllocator.deallocate`.)
+        )
         */
-        if ((b.ptr - _payload.ptr) % blockSize) return false;
+        this(ubyte[] data);
 
-        const blocksOld = bytes2blocks(b.length);
-        const blocksNew = bytes2blocks(b.length + delta);
-        assert(blocksOld <= blocksNew);
+        /// Ditto
+        this(ubyte[] data, uint blockSize);
 
-        // Possibly we have enough slack at the end of the block!
-        if (blocksOld == blocksNew)
-        {
-            b = b.ptr[0 .. b.length + delta];
-            return true;
-        }
+        /// Ditto
+        this(size_t capacity);
 
-        assert((b.ptr - _payload.ptr) % blockSize == 0);
-        const blockIdx = (b.ptr - _payload.ptr) / blockSize;
-        const blockIdxAfter = blockIdx + blocksOld;
+        /// Ditto
+        this(size_t capacity, uint blockSize);
 
-        // Try the maximum
-        const wordIdx = blockIdxAfter / 64,
-            msbIdx = cast(uint) (blockIdxAfter % 64);
-        void[] p;
-        auto hint = allocateAt(wordIdx, msbIdx,  blocksNew - blocksOld, p);
-        if (hint[0] != size_t.max)
-        {
-            return false;
-        }
-        // Expansion successful
-        assert(p.ptr == b.ptr + blocksOld * blockSize);
-        b = b.ptr[0 .. b.length + delta];
-        adjustFreshBit(blockIdx + blocksNew);
-        return true;
+        /**
+        If `blockSize == chooseAtRuntime`, `BitmappedBlock` offers a read/write
+        property `blockSize`. It must be set before any use of the allocator.
+        Otherwise (i.e. `theBlockSize` is a legit constant), `blockSize` is
+        an alias for `theBlockSize`. Whether constant or variable, must also be
+        a multiple of `alignment`. This constraint is `assert`ed statically
+        and dynamically.
+        */
+        alias blockSize = theBlockSize;
+
+        /**
+        The _alignment offered is user-configurable statically through parameter
+        `theAlignment`, defaulted to `platformAlignment`.
+        */
+        alias alignment = theAlignment;
+
+        /**
+        The _parent allocator. Depending on whether `ParentAllocator` holds state
+        or not, this is a member variable or an alias for
+        `ParentAllocator.instance`.
+        */
+        ParentAllocator parent;
+
+        /**
+        Returns the actual bytes allocated when `n` bytes are requested, i.e.
+        `n.roundUpToMultipleOf(blockSize)`.
+        */
+        pure nothrow @safe @nogc
+        size_t goodAllocSize(size_t n);
+
+        /**
+        Returns `Ternary.yes` if `b` belongs to the `BitmappedBlock` object,
+        `Ternary.no` otherwise. Never returns `Ternary.unkown`. (This
+        method is somewhat tolerant in that accepts an interior slice.)
+        */
+        pure nothrow @trusted @nogc
+        Ternary owns(const void[] b) const;
+
+        /**
+        Expands in place a buffer previously allocated by `BitmappedBlock`.
+        If instantiated with `No.multiblock`, the expansion fails if the new length
+        exceeds `theBlockSize`.
+        */
+        pure nothrow @trusted @nogc
+        bool expand(ref void[] b, immutable size_t delta);
+
+        /**
+        Deallocates a block previously allocated with this allocator.
+        */
+        nothrow @nogc
+        bool deallocate(void[] b);
+
+        /**
+        Allocates `s` bytes of memory and returns it, or `null` if memory
+        could not be allocated.
+
+        The following information might be of help with choosing the appropriate
+        block size. Actual allocation occurs in sizes multiple of the block size.
+        Allocating one block is the fastest because only one 0 bit needs to be
+        found in the metadata. Allocating 2 through 64 blocks is the next cheapest
+        because it affects a maximum of two `ulong` in the metadata.
+        Allocations greater than 64 blocks require a multiword search through the
+        metadata.
+
+        If instantiated with `No.multiblock`, it performs a search for the first zero
+        bit in the bitmap and sets it.
+        */
+        pure nothrow @trusted @nogc
+        void[] allocate(const size_t s);
+
+        /**
+        Allocates s bytes of memory and returns it, or `null` if memory could not be allocated.
+        `allocateFresh` behaves just like allocate, the only difference being that this always
+        returns unused(fresh) memory. Although there may still be available space in the `BitmappedBlock`,
+        `allocateFresh` could still return null, because all the available blocks have been previously deallocated.
+        */
+        @trusted void[] allocateFresh(const size_t s);
+
+        /**
+        If the `BitmappedBlock` object is empty (has no active allocation), allocates
+        all memory within and returns a slice to it. Otherwise, returns `null`
+        (i.e. no attempt is made to allocate the largest available block).
+        */
+        void[] allocateAll();
+
+        /**
+        Returns `Ternary.yes` if no memory is currently allocated with this
+        allocator, otherwise `Ternary.no`. This method never returns
+        `Ternary.unknown`.
+        */
+        pure nothrow @safe @nogc
+        Ternary empty();
+
+        /**
+        Forcibly deallocates all memory allocated by this allocator, making it
+        available for further allocations. Does not return memory to `ParentAllocator`.
+        */
+        pure nothrow @nogc
+        bool deallocateAll();
+
+        /**
+        Reallocates a block previously allocated with `alignedAllocate`. Contractions do not occur in place.
+        */
+        @system bool alignedReallocate(ref void[] b, size_t newSize, uint a);
+
+        /**
+        Reallocates a previously-allocated block. Contractions occur in place.
+        */
+        @system bool reallocate(ref void[] b, size_t newSize);
+
+        /**
+        Allocates a block with specified alignment `a`. The alignment must be a
+        power of 2. If `a <= alignment`, function forwards to `allocate`.
+        Otherwise, it attempts to overallocate and then adjust the result for
+        proper alignment. In the worst case the slack memory is around two blocks.
+        */
+        void[] alignedAllocate(size_t n, uint a);
+
+        /**
+        If `ParentAllocator` is not `NullAllocator` and defines `deallocate`,
+        the destructor is defined to deallocate the block held.
+        */
+        ~this();
     }
-
-    /**
-    Reallocates a previously-allocated block. Contractions occur in place.
-    */
-    @system bool reallocate(ref void[] b, size_t newSize)
+    else
     {
-        if (!b.ptr)
+        @system unittest
         {
-            b = allocate(newSize);
-            return b.length == newSize;
-        }
-        if (newSize == 0)
-        {
-            deallocate(b);
-            b = null;
-            return true;
-        }
-        if (newSize < b.length)
-        {
-            // Shrink. Will shrink in place by deallocating the trailing part.
-            auto newCapacity = bytes2blocks(newSize) * blockSize;
-            deallocate(b[newCapacity .. $]);
-            b = b[0 .. newSize];
-            return true;
-        }
-        // Go the slow route
-        return .reallocate(this, b, newSize);
-    }
-
-    /**
-    Reallocates a block previously allocated with `alignedAllocate`. Contractions do not occur in place.
-    */
-    @system bool alignedReallocate(ref void[] b, size_t newSize, uint a)
-    {
-        if (newSize == 0)
-        {
-            deallocate(b);
-            b = null;
-            return true;
-        }
-        // Go the slow route
-        return .alignedReallocate(this, b, newSize, a);
-    }
-
-    /**
-    Deallocates a block previously allocated with this allocator.
-    */
-    nothrow @nogc
-    bool deallocate(void[] b)
-    {
-        if (b is null) return true;
-
-        // Locate position
-        immutable pos = b.ptr - _payload.ptr;
-        immutable blockIdx = pos / blockSize;
-
-        // Adjust pointer, might be inside a block due to alignedAllocate
-        auto begin = _payload.ptr + blockIdx * blockSize,
-            end = b.ptr + b.length;
-        b = begin[0 .. end - begin];
-        // Round up size to multiple of block size
-        auto blocks = b.length.divideRoundUp(blockSize);
-
-        // Get into details
-        auto wordIdx = blockIdx / 64, msbIdx = cast(uint) (blockIdx % 64);
-        if (_startIdx > wordIdx) _startIdx = wordIdx;
-
-        // Three stages: heading bits, full words, leftover bits
-        if (msbIdx)
-        {
-            if (blocks + msbIdx <= 64)
+            import std.algorithm.comparison : max;
+            import std.experimental.allocator.mallocator : AlignedMallocator;
+            auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
+                                    max(theAlignment, cast(uint) size_t.sizeof)));
+            scope(exit) () nothrow @nogc { AlignedMallocator.instance.deallocate(m); }();
+            static if (theBlockSize == chooseAtRuntime)
             {
-                resetBits(_control.rep[wordIdx],
-                    cast(uint) (64 - msbIdx - blocks),
-                    63 - msbIdx);
-                return true;
+                testAllocator!(() => BitmappedBlock!(theBlockSize, theAlignment, NullAllocator)(m, 64));
             }
             else
             {
-                _control.rep[wordIdx] &= ulong.max << 64 - msbIdx;
-                blocks -= 64 - msbIdx;
-                ++wordIdx;
-                msbIdx = 0;
+                testAllocator!(() => BitmappedBlock!(theBlockSize, theAlignment, NullAllocator)(m));
             }
         }
-
-        // Stage 2: reset one word at a time
-        for (; blocks >= 64; blocks -= 64)
-        {
-            _control.rep[wordIdx++] = 0;
-        }
-
-        // Stage 3: deal with leftover bits, if any
-        assert(wordIdx <= _control.rep.length);
-        if (blocks)
-        {
-            _control.rep[wordIdx] &= ulong.max >> blocks;
-        }
-        return true;
-    }
-
-    /**
-    Forcibly deallocates all memory allocated by this allocator, making it
-    available for further allocations. Does not return memory to $(D
-    ParentAllocator).
-    */
-    pure nothrow @nogc
-    bool deallocateAll()
-    {
-        _control[] = 0;
-        _startIdx = 0;
-        return true;
-    }
-
-    /**
-    Returns `Ternary.yes` if no memory is currently allocated with this
-    allocator, otherwise `Ternary.no`. This method never returns
-    `Ternary.unknown`.
-    */
-    pure nothrow @safe @nogc
-    Ternary empty()
-    {
-        return Ternary(_control.allAre0());
-    }
-
-    void dump()
-    {
-        import std.stdio : writefln, writeln;
-        writefln("%s @ %s {", typeid(this), cast(void*) _control._rep.ptr);
-        scope(exit) writeln("}");
-        assert(_payload.length >= blockSize * _blocks);
-        assert(_control.length >= _blocks);
-        writefln("  _startIdx=%s; blockSize=%s; blocks=%s",
-            _startIdx, blockSize, _blocks);
-        if (!_control.length) return;
-        uint blockCount = 1;
-        bool inAllocatedStore = _control[0];
-        void* start = _payload.ptr;
-        for (size_t i = 1;; ++i)
-        {
-            if (i >= _blocks || _control[i] != inAllocatedStore)
-            {
-                writefln("  %s block at 0x%s, length: %s (%s*%s)",
-                    inAllocatedStore ? "Busy" : "Free",
-                    cast(void*) start,
-                    blockCount * blockSize,
-                    blockCount, blockSize);
-                if (i >= _blocks) break;
-                assert(i < _control.length);
-                inAllocatedStore = _control[i];
-                start = _payload.ptr + blockCount * blockSize;
-                blockCount = 1;
-            }
-            else
-            {
-                ++blockCount;
-            }
-        }
+        mixin BitmappedBlockImpl!(false, f == Yes.multiblock);
     }
 }
 
@@ -796,6 +1372,314 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     static assert(hasMember!(InSituRegion!(10_240, 64), "allocateAll"));
     const b = a.allocate(100);
     assert(b.length == 100);
+}
+
+///
+@system unittest
+{
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Flag, Yes;
+
+    enum blockSize = 64;
+    enum numBlocks = 10;
+
+    // The 'BitmappedBlock' is implicitly instantiated with Yes.multiblock
+    auto a = BitmappedBlock!(blockSize, 8, Mallocator, Yes.multiblock)(numBlocks * blockSize);
+
+    // Instantiated with Yes.multiblock, can allocate more than one block at a time
+    void[] buf = a.allocate(2 * blockSize);
+    assert(buf.length == 2 * blockSize);
+    assert(a.deallocate(buf));
+
+    // Can also allocate less than one block
+    buf = a.allocate(blockSize / 2);
+    assert(buf.length == blockSize / 2);
+
+    // Expands inside the same block
+    assert(a.expand(buf, blockSize / 2));
+    assert(buf.length == blockSize);
+
+    // If Yes.multiblock, can expand past the size of a single block
+    assert(a.expand(buf, 3 * blockSize));
+    assert(buf.length == 4 * blockSize);
+    assert(a.deallocate(buf));
+}
+
+///
+@system unittest
+{
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.typecons : Flag, No;
+
+    enum blockSize = 64;
+    auto a = BitmappedBlock!(blockSize, 8, Mallocator, No.multiblock)(1024 * blockSize);
+
+    // Since instantiated with No.multiblock, can only allocate at most the block size
+    void[] buf = a.allocate(blockSize + 1);
+    assert(buf is null);
+
+    buf = a.allocate(blockSize);
+    assert(buf.length == blockSize);
+    assert(a.deallocate(buf));
+
+    // This is also fine, because it's less than the block size
+    buf = a.allocate(blockSize / 2);
+    assert(buf.length == blockSize / 2);
+
+    // Can expand the buffer until its length is at most 64
+    assert(a.expand(buf, blockSize / 2));
+    assert(buf.length == blockSize);
+
+    // Cannot expand anymore
+    assert(!a.expand(buf, 1));
+    assert(a.deallocate(buf));
+}
+
+/**
+The threadsafe version of the $(LREF BitmappedBlock).
+The semantics of the `SharedBitmappedBlock` are identical to the regular $(LREF BitmappedBlock).
+
+Params:
+    theBlockSize = the length of a block, which must be a multiple of `theAlignment`
+
+    theAlignment = alignment of each block
+
+    ParentAllocator = allocator from which the `BitmappedBlock` will draw memory.
+        If set to `NullAllocator`, the storage must be passed via the constructor
+
+    f = `Yes.multiblock` to support allocations spanning across multiple blocks and
+        `No.multiblock` to support single block allocations.
+        Although limited by single block allocations, `No.multiblock` will generally
+        provide higher performance.
+*/
+shared struct SharedBitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment,
+   ParentAllocator = NullAllocator, Flag!"multiblock" f = Yes.multiblock)
+{
+    version(StdDdoc)
+    {
+        /**
+        Constructs a block allocator given a hunk of memory, or a desired capacity
+        in bytes.
+        $(UL
+        $(LI If `ParentAllocator` is $(REF_ALTTEXT `NullAllocator`, NullAllocator, std,experimental,allocator,building_blocks,null_allocator),
+        only the constructor taking `data` is defined and the user is responsible for freeing `data` if desired.)
+        $(LI Otherwise, both constructors are defined. The `data`-based
+        constructor assumes memory has been allocated with the parent allocator.
+        The `capacity`-based constructor uses `ParentAllocator` to allocate
+        an appropriate contiguous hunk of memory. Regardless of the constructor
+        used, the destructor releases the memory by using `ParentAllocator.deallocate`.)
+        )
+        */
+        this(ubyte[] data);
+
+        /// Ditto
+        this(ubyte[] data, uint blockSize);
+
+        /// Ditto
+        this(size_t capacity);
+
+        /// Ditto
+        this(size_t capacity, uint blockSize);
+
+        /**
+        If `blockSize == chooseAtRuntime`, `SharedBitmappedBlock` offers a read/write
+        property `blockSize`. It must be set before any use of the allocator.
+        Otherwise (i.e. `theBlockSize` is a legit constant), `blockSize` is
+        an alias for `theBlockSize`. Whether constant or variable, must also be
+        a multiple of `alignment`. This constraint is `assert`ed statically
+        and dynamically.
+        */
+        alias blockSize = theBlockSize;
+
+        /**
+        The _alignment offered is user-configurable statically through parameter
+        `theAlignment`, defaulted to `platformAlignment`.
+        */
+        alias alignment = theAlignment;
+
+        /**
+        The _parent allocator. Depending on whether `ParentAllocator` holds state
+        or not, this is a member variable or an alias for
+        `ParentAllocator.instance`.
+        */
+        ParentAllocator parent;
+
+        /**
+        Returns the actual bytes allocated when `n` bytes are requested, i.e.
+        `n.roundUpToMultipleOf(blockSize)`.
+        */
+        pure nothrow @safe @nogc
+        size_t goodAllocSize(size_t n);
+
+        /**
+        Returns `Ternary.yes` if `b` belongs to the `SharedBitmappedBlock` object,
+        `Ternary.no` otherwise. Never returns `Ternary.unkown`. (This
+        method is somewhat tolerant in that accepts an interior slice.)
+        */
+        pure nothrow @trusted @nogc
+        Ternary owns(const void[] b) const;
+
+        /**
+        Expands in place a buffer previously allocated by `SharedBitmappedBlock`.
+        Expansion fails if the new length exceeds the block size.
+        */
+        bool expand(ref void[] b, immutable size_t delta);
+
+        /**
+        Deallocates the given buffer `b`, by atomically setting the corresponding
+        bit to `0`. `b` must be valid, and cannot contain multiple adjacent `blocks`.
+        */
+        nothrow @nogc
+        bool deallocate(void[] b);
+
+        /**
+        Allocates `s` bytes of memory and returns it, or `null` if memory
+        could not be allocated.
+
+        The `SharedBitmappedBlock` cannot allocate more than the given block size.
+        Allocations are satisfied by searching the first unset bit in the bitmap,
+        and atomically setting it.
+        In rare memory pressure scenarios, the allocation could fail.
+        */
+        nothrow @trusted @nogc
+        void[] allocate(const size_t s);
+
+        /**
+        Allocates s bytes of memory and returns it, or `null` if memory could not be allocated.
+        `allocateFresh` behaves just like allocate, the only difference being that this always
+        returns unused(fresh) memory. Although there may still be available space in the `SharedBitmappedBlock`,
+        `allocateFresh` could still return null, because all the available blocks have been previously deallocated.
+        */
+        @trusted void[] allocateFresh(const size_t s);
+
+        /**
+        If the `SharedBitmappedBlock` object is empty (has no active allocation), allocates
+        all memory within and returns a slice to it. Otherwise, returns `null`
+        (i.e. no attempt is made to allocate the largest available block).
+        */
+        void[] allocateAll();
+
+        /**
+        Returns `Ternary.yes` if no memory is currently allocated with this
+        allocator, otherwise `Ternary.no`. This method never returns
+        `Ternary.unknown`.
+        */
+        nothrow @safe @nogc
+        Ternary empty();
+
+        /**
+        Forcibly deallocates all memory allocated by this allocator, making it
+        available for further allocations. Does not return memory to `ParentAllocator`.
+        */
+        nothrow @nogc
+        bool deallocateAll();
+
+        /**
+        Reallocates a block previously allocated with `alignedAllocate`. Contractions do not occur in place.
+        */
+        @system bool alignedReallocate(ref void[] b, size_t newSize, uint a);
+
+        /**
+        Reallocates a previously-allocated block. Contractions occur in place.
+        */
+        @system bool reallocate(ref void[] b, size_t newSize);
+
+        /**
+        Allocates a block with specified alignment `a`. The alignment must be a
+        power of 2. If `a <= alignment`, function forwards to `allocate`.
+        Otherwise, it attempts to overallocate and then adjust the result for
+        proper alignment. In the worst case the slack memory is around two blocks.
+        */
+        void[] alignedAllocate(size_t n, uint a);
+
+        /**
+        If `ParentAllocator` is not `NullAllocator` and defines `deallocate`,
+        the destructor is defined to deallocate the block held.
+        */
+        ~this();
+    }
+    else
+    {
+        version(unittest)
+        @system unittest
+        {
+            import std.algorithm.comparison : max;
+            import std.experimental.allocator.mallocator : AlignedMallocator;
+            auto m = cast(ubyte[])(AlignedMallocator.instance.alignedAllocate(1024 * 64,
+                                    max(theAlignment, cast(uint) size_t.sizeof)));
+            scope(exit) () nothrow @nogc { AlignedMallocator.instance.deallocate(m); }();
+            static if (theBlockSize == chooseAtRuntime)
+            {
+                testAllocator!(() => SharedBitmappedBlock!(theBlockSize, theAlignment, NullAllocator)(m, 64));
+            }
+            else
+            {
+                testAllocator!(() => SharedBitmappedBlock!(theBlockSize, theAlignment, NullAllocator)(m));
+            }
+        }
+        mixin BitmappedBlockImpl!(true, f == Yes.multiblock);
+    }
+}
+
+///
+@system unittest
+{
+    import std.experimental.allocator.mallocator : Mallocator;
+    import std.experimental.allocator.common : platformAlignment;
+    import std.typecons : Flag, Yes, No;
+
+    // Create 'numThreads' threads, each allocating in parallel a chunk of memory
+    static void testAlloc(Allocator)(ref Allocator a, size_t allocSize)
+    {
+        import core.thread : ThreadGroup;
+        import std.algorithm.sorting : sort;
+        import core.internal.spinlock : SpinLock;
+
+        SpinLock lock = SpinLock(SpinLock.Contention.brief);
+        enum numThreads = 10;
+        void[][numThreads] buf;
+        size_t count = 0;
+
+        // Each threads allocates 'allocSize'
+        void fun()
+        {
+            void[] b = a.allocate(allocSize);
+            assert(b.length == allocSize);
+
+            lock.lock();
+            scope(exit) lock.unlock();
+
+            buf[count] = b;
+            count++;
+        }
+
+        auto tg = new ThreadGroup;
+        foreach (i; 0 .. numThreads)
+        {
+            tg.create(&fun);
+        }
+        tg.joinAll();
+
+        // Sorting the allocations made by each thread, we expect the buffers to be
+        // adjacent inside the SharedBitmappedBlock
+        sort!((a, b) => a.ptr < b.ptr)(buf[0 .. numThreads]);
+        foreach (i; 0 .. numThreads - 1)
+        {
+            assert(buf[i].ptr + a.goodAllocSize(buf[i].length) <= buf[i + 1].ptr);
+        }
+
+        // Deallocate everything
+        foreach (i; 0 .. numThreads)
+        {
+            assert(a.deallocate(buf[i]));
+        }
+    }
+
+    enum blockSize = 64;
+    auto alloc1 = SharedBitmappedBlock!(blockSize, platformAlignment, Mallocator, Yes.multiblock)(1024 * 1024);
+    auto alloc2 = SharedBitmappedBlock!(blockSize, platformAlignment, Mallocator, No.multiblock)(1024 * 1024);
+    testAlloc(alloc1, 2 * blockSize);
+    testAlloc(alloc2, blockSize);
 }
 
 @system unittest
@@ -816,13 +1700,23 @@ pure @safe unittest
 {
     import std.typecons : Ternary;
 
-    auto a = (() @trusted => BitmappedBlock!(64, 64)(new ubyte[10_240]))();
+    auto a = (() @trusted => BitmappedBlock!(64, 64, NullAllocator, Yes.multiblock)(new ubyte[10_240]))();
     () nothrow @nogc {
         assert(a.empty == Ternary.yes);
         const b = a.allocate(100);
         assert(b.length == 100);
         assert(a.empty == Ternary.no);
     }();
+}
+
+@safe unittest
+{
+    import std.typecons : Ternary;
+
+    auto a = (() @trusted => SharedBitmappedBlock!(64, 64, NullAllocator, Yes.multiblock)(new ubyte[10_240]))();
+    assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
+    const b = a.allocate(100);
+    assert(b.length == 100);
 }
 
 @system unittest
@@ -836,45 +1730,83 @@ pure @safe unittest
     // Test chooseAtRuntime
     import std.experimental.allocator.gc_allocator : GCAllocator;
     uint blockSize = 64;
-    testAllocator!(() => BitmappedBlock!(chooseAtRuntime, 8, GCAllocator)(1024 * 64, blockSize));
+    testAllocator!(() => BitmappedBlock!(chooseAtRuntime, 8, GCAllocator, Yes.multiblock)(1024 * 64, blockSize));
+    testAllocator!(() => BitmappedBlock!(chooseAtRuntime, 8, GCAllocator, No.multiblock)(1024 * 64, blockSize));
 }
 
 @system unittest
 {
-    static void testAllocateAll(size_t bs)(uint blocks, uint blocksAtATime)
+    import std.experimental.allocator.mallocator : Mallocator;
+    testAllocator!(() => SharedBitmappedBlock!(64, 8, Mallocator, Yes.multiblock)(1024 * 64));
+    testAllocator!(() => SharedBitmappedBlock!(64, 8, Mallocator, No.multiblock)(1024 * 64));
+}
+
+@system unittest
+{
+    // Test chooseAtRuntime
+    import std.experimental.allocator.mallocator : Mallocator;
+    uint blockSize = 64;
+    testAllocator!(() => SharedBitmappedBlock!(chooseAtRuntime, 8, Mallocator, Yes.multiblock)(1024 * 64, blockSize));
+    testAllocator!(() => SharedBitmappedBlock!(chooseAtRuntime, 8, Mallocator, No.multiblock)(1024 * 64, blockSize));
+}
+
+@system unittest
+{
+    static void testAllocateAll(size_t bs, bool isShared = true)(size_t blocks, uint blocksAtATime)
     {
-        import std.algorithm.comparison : min;
+        template attribAllocate(string size)
+        {
+            static if (isShared)
+            {
+                const char[] attribAllocate = "(() nothrow @safe @nogc => a.allocate(" ~ size ~ "))()";
+            }
+            else
+            {
+                const char[] attribAllocate = "(() pure nothrow @safe @nogc => a.allocate(" ~ size ~ "))()";
+            }
+        }
+
         assert(bs);
+        import std.typecons : Ternary;
+        import std.algorithm.comparison : min;
         import std.experimental.allocator.gc_allocator : GCAllocator;
-        auto a = BitmappedBlock!(bs, min(bs, platformAlignment))(
-            cast(ubyte[])(GCAllocator.instance.allocate((blocks * bs * 8 +
-                        blocks) / 8))
-        );
+
+        static if (isShared)
+        {
+            auto a = SharedBitmappedBlock!(bs, min(bs, platformAlignment), NullAllocator)(
+                cast(ubyte[])(GCAllocator.instance.allocate((blocks * bs * 8 + blocks) / 8)));
+        }
+        else
+        {
+            auto a = BitmappedBlock!(bs, min(bs, platformAlignment), NullAllocator)(
+                cast(ubyte[])(GCAllocator.instance.allocate((blocks * bs * 8 + blocks) / 8)));
+        }
+
         import std.conv : text;
         assert(blocks >= a._blocks, text(blocks, " < ", a._blocks));
         blocks = a._blocks;
 
         // test allocation of 0 bytes
-        auto x = (() pure nothrow @safe @nogc => a.allocate(0))();
+        auto x = mixin(attribAllocate!("0"));
         assert(x is null);
         // test allocation of 1 byte
-        x = (() pure nothrow @safe @nogc => a.allocate(1))();
-        assert(x.length == 1 || blocks == 0,
-            text(x.ptr, " ", x.length, " ", a));
+        x = mixin(attribAllocate!("1"));
+        assert(x.length == 1 || blocks == 0);
         assert((() nothrow @nogc => a.deallocateAll())());
-
+        assert(a.empty() == Ternary.yes);
         bool twice = true;
 
     begin:
         foreach (i; 0 .. blocks / blocksAtATime)
         {
-            auto b = (() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))();
+            auto b = mixin(attribAllocate!("bs * blocksAtATime"));
             assert(b.length == bs * blocksAtATime, text(i, ": ", b.length));
         }
-        assert((() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))() is null);
+
+        assert(mixin(attribAllocate!("bs * blocksAtATime")) is null);
         if (a._blocks % blocksAtATime == 0)
         {
-            assert((() pure nothrow @safe @nogc => a.allocate(1))() is null);
+            assert(mixin(attribAllocate!("1")) is null);
         }
 
         // Now deallocate all and do it again!
@@ -885,14 +1817,14 @@ pure @safe unittest
         auto v = new void[][blocks / blocksAtATime];
         foreach (i; 0 .. blocks / blocksAtATime)
         {
-            auto b = (() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))();
+            auto b = mixin(attribAllocate!("bs * blocksAtATime"));
             assert(b.length == bs * blocksAtATime, text(i, ": ", b.length));
             v[i] = b;
         }
-        assert((() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))() is null);
+        assert(mixin(attribAllocate!("bs * blocksAtATime")) is null);
         if (a._blocks % blocksAtATime == 0)
         {
-            assert((() pure nothrow @safe @nogc => a.allocate(1))() is null);
+            assert(mixin(attribAllocate!("1")) is null);
         }
 
         foreach (i; 0 .. blocks / blocksAtATime)
@@ -902,7 +1834,7 @@ pure @safe unittest
 
         foreach (i; 0 .. blocks / blocksAtATime)
         {
-            auto b = (() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))();
+            auto b = mixin(attribAllocate!("bs * blocksAtATime"));
             assert(b.length == bs * blocksAtATime, text(i, ": ", b.length));
             v[i] = b;
         }
@@ -925,11 +1857,19 @@ pure @safe unittest
         {
             foreach (i; 0 .. blocks / blocksAtATime - 1)
             {
-                auto b = (() pure nothrow @safe @nogc => a.allocate(bs * blocksAtATime))();
+                auto b = mixin(attribAllocate!("bs * blocksAtATime"));
                 assert(b.length == bs * blocksAtATime, text(i, ": ", b.length));
                 (cast(ubyte[]) b)[] = 0xff;
-                assert((() pure nothrow @safe @nogc => a.expand(b, blocksAtATime * bs))()
-                        , text(i));
+                static if (isShared)
+                {
+                    assert((() nothrow @safe @nogc => a.expand(b, blocksAtATime * bs))()
+                            , text(i));
+                }
+                else
+                {
+                    assert((() pure nothrow @safe @nogc => a.expand(b, blocksAtATime * bs))()
+                            , text(i));
+                }
                 (cast(ubyte[]) b)[] = 0xfe;
                 assert(b.length == bs * blocksAtATime * 2, text(i, ": ", b.length));
                 a.reallocate(b, blocksAtATime * bs) || assert(0);
@@ -939,25 +1879,46 @@ pure @safe unittest
     }
 
     testAllocateAll!(1)(0, 1);
+    testAllocateAll!(1, false)(0, 1);
     testAllocateAll!(1)(8, 1);
+    testAllocateAll!(1, false)(8, 1);
+
     testAllocateAll!(4096)(128, 1);
+    testAllocateAll!(4096, false)(128, 1);
 
     testAllocateAll!(1)(0, 2);
     testAllocateAll!(1)(128, 2);
     testAllocateAll!(4096)(128, 2);
 
+    testAllocateAll!(1, false)(0, 2);
+    testAllocateAll!(1, false)(128, 2);
+    testAllocateAll!(4096, false)(128, 2);
+
     testAllocateAll!(1)(0, 4);
     testAllocateAll!(1)(128, 4);
     testAllocateAll!(4096)(128, 4);
+
+    testAllocateAll!(1, false)(0, 4);
+    testAllocateAll!(1, false)(128, 4);
+    testAllocateAll!(4096, false)(128, 4);
 
     testAllocateAll!(1)(0, 3);
     testAllocateAll!(1)(24, 3);
     testAllocateAll!(3008)(100, 1);
     testAllocateAll!(3008)(100, 3);
 
+    testAllocateAll!(1, false)(0, 3);
+    testAllocateAll!(1, false)(24, 3);
+    testAllocateAll!(3008, false)(100, 1);
+    testAllocateAll!(3008, false)(100, 3);
+
     testAllocateAll!(1)(0, 128);
     testAllocateAll!(1)(128 * 1, 128);
     testAllocateAll!(128 * 20)(13 * 128, 128);
+
+    testAllocateAll!(1, false)(0, 128);
+    testAllocateAll!(1, false)(128 * 1, 128);
+    testAllocateAll!(128 * 20, false)(13 * 128, 128);
 }
 
 @system unittest
@@ -1045,63 +2006,69 @@ pure @safe unittest
     import std.experimental.allocator.mallocator : Mallocator;
     import std.random;
 
-    auto numBlocks = [1, 64, 256];
-    enum blocks = 10000;
-    int iter = 0;
-
-    ubyte[] payload = cast(ubyte[]) Mallocator.instance.allocate(blocks * 16);
-    auto a = BitmappedBlock!(16, 16)(payload);
-    void[][] buf = cast(void[][]) Mallocator.instance.allocate((void[]).sizeof * blocks);
-
-    auto rnd = Random();
-    while (iter < blocks)
+    static void testAlloc(Allocator)()
     {
-        int event = uniform(0, 2, rnd);
-        int doExpand = uniform(0, 2, rnd);
-        int allocSize = numBlocks[uniform(0, 3, rnd)] * 16;
-        int expandSize = numBlocks[uniform(0, 3, rnd)] * 16;
-        int doDeallocate = uniform(0, 2, rnd);
+        auto numBlocks = [1, 64, 256];
+        enum blocks = 10000;
+        int iter = 0;
 
-        if (event) buf[iter] = a.allocate(allocSize);
-        else buf[iter] = a.allocateFresh(allocSize);
+        ubyte[] payload = cast(ubyte[]) Mallocator.instance.allocate(blocks * 16);
+        auto a = Allocator(payload);
+        void[][] buf = cast(void[][]) Mallocator.instance.allocate((void[]).sizeof * blocks);
 
-        if (!buf[iter])
-            break;
-        assert(buf[iter].length == allocSize);
-
-        auto oldSize = buf[iter].length;
-        if (doExpand && a.expand(buf[iter], expandSize))
-            assert(buf[iter].length == expandSize + oldSize);
-
-        if (doDeallocate)
+        auto rnd = Random();
+        while (iter < blocks)
         {
-            assert(a.deallocate(buf[iter]));
-            buf[iter] = null;
+            int event = uniform(0, 2, rnd);
+            int doExpand = uniform(0, 2, rnd);
+            int allocSize = numBlocks[uniform(0, 3, rnd)] * 16;
+            int expandSize = numBlocks[uniform(0, 3, rnd)] * 16;
+            int doDeallocate = uniform(0, 2, rnd);
+
+            if (event) buf[iter] = a.allocate(allocSize);
+            else buf[iter] = a.allocateFresh(allocSize);
+
+            if (!buf[iter])
+                break;
+            assert(buf[iter].length == allocSize);
+
+            auto oldSize = buf[iter].length;
+            if (doExpand && a.expand(buf[iter], expandSize))
+                assert(buf[iter].length == expandSize + oldSize);
+
+            if (doDeallocate)
+            {
+                assert(a.deallocate(buf[iter]));
+                buf[iter] = null;
+            }
+
+            iter++;
         }
 
-        iter++;
+        while (iter < blocks)
+        {
+            buf[iter++] = a.allocate(16);
+            if (!buf[iter - 1])
+                break;
+            assert(buf[iter - 1].length == 16);
+        }
+
+        for (size_t i = 0; i < a._blocks; i++)
+            assert((cast(BitVector) a._control)[i]);
+
+        assert(!a.allocate(16));
+        for (size_t i = 0; i < iter; i++)
+        {
+            if (buf[i])
+                assert(a.deallocate(buf[i]));
+        }
+
+        for (size_t i = 0; i < a._blocks; i++)
+            assert(!(cast(BitVector) a._control)[i]);
     }
 
-    while (iter < blocks)
-    {
-        buf[iter++] = a.allocate(16);
-        if (!buf[iter - 1])
-            break;
-        assert(buf[iter - 1].length == 16);
-    }
-
-    for (size_t i = 0; i < a._blocks; i++)
-        assert(a._control[i]);
-
-    assert(!a.allocate(16));
-    for (size_t i = 0; i < iter; i++)
-    {
-        if (buf[i])
-            assert(a.deallocate(buf[i]));
-    }
-
-    for (size_t i = 0; i < a._blocks; i++)
-        assert(!a._control[i]);
+    testAlloc!(BitmappedBlock!(16, 16))();
+    testAlloc!(SharedBitmappedBlock!(16, 16))();
 }
 
 // Test totalAllocation and goodAllocSize
@@ -1143,8 +2110,8 @@ nothrow @safe @nogc unittest
 // BitmappedBlockWithInternalPointers
 /**
 
-A `BitmappedBlock` with additional structure for supporting $(D
-resolveInternalPointer). To that end, `BitmappedBlockWithInternalPointers` adds a
+A `BitmappedBlock` with additional structure for supporting `resolveInternalPointer`.
+To that end, `BitmappedBlockWithInternalPointers` adds a
 bitmap (one bit per block) that marks object starts. The bitmap itself has
 variable size and is allocated together with regular allocations.
 
@@ -1392,7 +2359,7 @@ struct BitmappedBlockWithInternalPointers(
     assert((() nothrow @safe @nogc => h.resolveInternalPointer(offset, p))() == Ternary.no);
     assert(p is unchanged);
 
-    assert((() nothrow @safe => h.expand(b, 1))());
+    assert((() @safe => h.expand(b, 1))());
     assert(b.length == 4097);
     offset = &b[0] + 4096;
     assert((() nothrow @safe @nogc => h.resolveInternalPointer(offset, p))() == Ternary.yes);
@@ -1409,8 +2376,8 @@ struct BitmappedBlockWithInternalPointers(
 }
 
 /**
-Returns the number of most significant ones before a zero can be found in $(D
-x). If `x` contains no zeros (i.e. is equal to `ulong.max`), returns 64.
+Returns the number of most significant ones before a zero can be found in `x`.
+If `x` contains no zeros (i.e. is equal to `ulong.max`), returns 64.
 */
 pure nothrow @safe @nogc
 private uint leadingOnes(ulong x)
@@ -1513,7 +2480,7 @@ private struct BitVector
 {
     ulong[] _rep;
 
-    auto rep() { return _rep; }
+    auto rep(this _)() { return _rep; }
 
     pure nothrow @safe @nogc
     this(ulong[] data) { _rep = data; }


### PR DESCRIPTION
Both the shared and non-shared versions of the BitmappedBlock now support two modes of allocation: Yes.multiblock and No.multiblock.
Yes.multiblock means that allocation requests can exceed the block size.
No.multiblock means that allocation requests can be at most a single block.

The motivation here is that the SharedBitmappedBlock only supported the No.multiblock which was inconsistent with the regular BitmappedBlock which allowed for allocation requests larger than a single block.

For the SharedBitmappedBlock with Yes.multiblock, I just put a lock around the old implementation.
The SharedBitmappedBlock with No.multiblock has a separate implementation which is faster, with the tradeoff that we can't allocate more than 1 block at a time.

I updated the docs and added a lot of tests and examples for the new functionality.