### PR TITLE
make/makeArray: take advantage of allocators with smth. faster than allocate+memset zero

### DIFF
--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -511,6 +511,18 @@ version(unittest)
         assert(b2.length == 2);
         assert(b2.ptr + b2.length <= b1.ptr || b1.ptr + b1.length <= b2.ptr);
 
+        // Test allocateZeroed
+        static if (hasMember!(A, "allocateZeroed"))
+        {{
+            auto b3 = a.allocateZeroed(8);
+            if (b3 !is null)
+            {
+                assert(b3.length == 8);
+                foreach (e; cast(ubyte[]) b3)
+                    assert(e == 0);
+            }
+        }}
+
         // Test alignedAllocate
         static if (hasMember!(A, "alignedAllocate"))
         {{

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -111,6 +111,13 @@ struct GCAllocator
         return ((n + 4095) / 4096) * 4096;
     }
 
+    package pure nothrow @trusted void[] allocateZeroed(size_t bytes) shared const
+    {
+        if (!bytes) return null;
+        auto p = GC.calloc(bytes);
+        return p ? p[0 .. bytes] : null;
+    }
+
     /**
     Returns the global instance of this allocator type. The garbage collected
     allocator is thread-safe, therefore all of its methods and `instance` itself

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -64,6 +64,15 @@ struct Mallocator
         return true;
     }
 
+    @trusted @nogc nothrow pure
+    package void[] allocateZeroed(size_t bytes) shared
+    {
+        import core.memory : pureCalloc;
+        if (!bytes) return null;
+        auto p = pureCalloc(1, bytes);
+        return p ? p[0 .. bytes] : null;
+    }
+
     /**
     Returns the global instance of this allocator type. The C heap allocator is
     thread-safe, therefore all of its methods and `it` itself are

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -48,6 +48,21 @@ struct MmapAllocator
             if (b.ptr) munmap(b.ptr, b.length) == 0 || assert(0);
             return true;
         }
+
+        // Anonymous mmap might be zero-filled on all Posix systems but
+        // not all commit to this in the documentation.
+        version(linux)
+            // http://man7.org/linux/man-pages/man2/mmap.2.html
+            package alias allocateZeroed = allocate;
+        else version(NetBSD)
+            // http://netbsd.gw.com/cgi-bin/man-cgi?mmap+2+NetBSD-current
+            package alias allocateZeroed = allocate;
+        else version(Solaris)
+            // https://docs.oracle.com/cd/E88353_01/html/E37841/mmap-2.html
+            package alias allocateZeroed = allocate;
+        else version(AIX)
+            // https://www.ibm.com/support/knowledgecenter/en/ssw_aix_71/com.ibm.aix.basetrf1/mmap.htm
+            package alias allocateZeroed = allocate;
     }
     else version(Windows)
     {
@@ -71,6 +86,8 @@ struct MmapAllocator
         {
             return b.ptr is null || VirtualFree(b.ptr, 0, MEM_RELEASE) != 0;
         }
+
+        package alias allocateZeroed = allocate;
     }
 }
 


### PR DESCRIPTION
Some allocators can allocate zeroed memory more efficiently than allocate + memset.  This pull request takes advantage of this in `std.experimental.allocator : make` and `makeArray`.

This PR adds non-public `allocateZeroed` methods to `Mallocator` and `MmapAllocator` and `GCAllocator`. Various derived allocators could also implement such methods when their parent allocators support them, but that work is left to a future PR (if this PR is merged).

Ignoring whitespace changes when reviewing this PR should make `make` clearer.