### PR TITLE
Issue 18715 - Non-documented unittests should not use unpredictableSeed or default Random alias

### DIFF
--- a/std/algorithm/internal.d
+++ b/std/algorithm/internal.d
@@ -21,13 +21,13 @@ version(unittest)
 
     package string[] rndstuff(T : string)()
     {
-        import std.random : Random, unpredictableSeed, uniform;
+        import std.random : Random = Xorshift, uniform;
 
         static Random rnd;
         static bool first = true;
         if (first)
         {
-            rnd = Random(unpredictableSeed);
+            rnd.seed(234_567_891);
             first = false;
         }
         string[] result =
@@ -46,13 +46,13 @@ version(unittest)
 
     package int[] rndstuff(T : int)()
     {
-        import std.random : Random, unpredictableSeed, uniform;
+        import std.random : Random = Xorshift, uniform;
 
         static Random rnd;
         static bool first = true;
         if (first)
         {
-            rnd = Random(unpredictableSeed);
+            rnd = Random(345_678_912);
             first = false;
         }
         int[] result = new int[uniform(minArraySize, maxArraySize, rnd)];

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -691,7 +691,7 @@ private struct MapResult(alias fun, Range)
     import std.internal.test.dummyrange;
     import std.range;
     import std.typecons : tuple;
-    import std.random : unpredictableSeed, uniform, Random;
+    import std.random : uniform, Random = Xorshift;
 
     int[] arr1 = [ 1, 2, 3, 4 ];
     const int[] arr1Const = arr1;
@@ -749,7 +749,7 @@ private struct MapResult(alias fun, Range)
     assert(fibsSquares.front == 9);
 
     auto repeatMap = map!"a"(repeat(1));
-    auto gen = Random(unpredictableSeed);
+    auto gen = Random(123_456_789);
     auto index = uniform(0, 1024, gen);
     static assert(isInfinite!(typeof(repeatMap)));
     assert(repeatMap[index] == 1);

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -278,11 +278,11 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
 {
     import std.algorithm.comparison : equal;
     import std.conv : text;
-    import std.random : Random, unpredictableSeed, uniform;
+    import std.random : Random = Xorshift, uniform;
 
     // a more elaborate test
     {
-        auto rnd = Random(unpredictableSeed);
+        auto rnd = Random(123_456_789);
         int[] a = new int[uniform(100, 200, rnd)];
         int[] b = new int[uniform(100, 200, rnd)];
         foreach (ref e; a) e = uniform(-100, 100, rnd);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -746,8 +746,8 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && hasAssig
         import std.algorithm.iteration : map;
         import std.random;
         import std.stdio;
-        auto s = unpredictableSeed;
-        auto g = Random(s);
+        auto s = 123_456_789;
+        auto g = Xorshift(s);
         a = iota(0, uniform(1, 1000, g))
             .map!(_ => uniform(-1000, 1000, g))
             .array;
@@ -883,9 +883,9 @@ if (ss == SwapStrategy.unstable && isRandomAccessRange!Range
 
 @safe unittest
 {
-    import std.random : Random, uniform, unpredictableSeed;
+    import std.random : Random = Xorshift, uniform;
 
-    immutable uint[] seeds = [3923355730, 1927035882, unpredictableSeed];
+    immutable uint[] seeds = [3923355730, 1927035882];
     foreach (s; seeds)
     {
         auto r = Random(s);
@@ -1710,7 +1710,7 @@ private void shortSort(alias less, Range)(Range r)
 
 @safe unittest
 {
-    import std.random : Random, uniform;
+    import std.random : Random = Xorshift, uniform;
 
     auto rnd = Random(1);
     auto a = new int[uniform(100, 200, rnd)];
@@ -1949,12 +1949,12 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 {
     import std.algorithm.internal : rndstuff;
     import std.algorithm.mutation : swapRanges;
-    import std.random : Random, unpredictableSeed, uniform;
+    import std.random : Random = Xorshift, uniform;
     import std.uni : toUpper;
 
     // sort using delegate
     auto a = new int[100];
-    auto rnd = Random(unpredictableSeed);
+    auto rnd = Random(123_456_789);
     foreach (ref e; a)
     {
         e = uniform(-100, 100, rnd);
@@ -3457,7 +3457,7 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
     T minValue = 0, T maxValue = 255)
 {
     import std.algorithm.iteration : map;
-    import std.random : unpredictableSeed, Random, uniform;
+    import std.random : uniform;
     auto size = flag == Yes.exactSize ? maxSize : uniform(1, maxSize);
     return iota(0, size).map!(_ => uniform(minValue, maxValue)).array;
 }
@@ -3513,9 +3513,9 @@ private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
 {
     import std.algorithm.comparison : max, min;
     import std.algorithm.iteration : reduce;
-    import std.random : Random, uniform, unpredictableSeed;
+    import std.random : Random = Xorshift, uniform;
 
-    immutable uint[] seeds = [90027751, 2709791795, 1374631933, 995751648, 3541495258, 984840953, unpredictableSeed];
+    immutable uint[] seeds = [90027751, 2709791795, 1374631933, 995751648, 3541495258, 984840953];
     foreach (s; seeds)
     {
         auto r = Random(s);
@@ -3718,10 +3718,10 @@ if (isInputRange!(SRange) && isRandomAccessRange!(TRange)
 
 @system unittest
 {
-    import std.random : Random, unpredictableSeed, uniform, randomShuffle;
+    import std.random : Random = Xorshift, uniform, randomShuffle;
     import std.typecons : Yes;
 
-    auto r = Random(unpredictableSeed);
+    auto r = Random(123_456_789);
     ptrdiff_t[] a = new ptrdiff_t[uniform(1, 1000, r)];
     foreach (i, ref e; a) e = i;
     randomShuffle(a, r);

--- a/std/random.d
+++ b/std/random.d
@@ -583,7 +583,8 @@ alias MinstdRand = LinearCongruentialEngine!(uint, 48_271, 0, 2_147_483_647);
     // Check .save works
     static foreach (Type; std.meta.AliasSeq!(MinstdRand0, MinstdRand))
     {{
-        auto rnd1 = Type(unpredictableSeed);
+        auto rnd1 = Type(123_456_789);
+        rnd1.popFront();
         auto rnd2 = rnd1.save;
         assert(rnd1 == rnd2);
         // Enable next test when RNGs are reference types
@@ -991,11 +992,11 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
 
     Mt19937 gen;
 
-    assertThrown(gen.seed(map!((a) => unpredictableSeed)(repeat(0, 623))));
+    assertThrown(gen.seed(map!((a) => 123_456_789U)(repeat(0, 623))));
 
-    gen.seed(map!((a) => unpredictableSeed)(repeat(0, 624)));
+    gen.seed(123_456_789U.repeat(624));
     //infinite Range
-    gen.seed(map!((a) => unpredictableSeed)(repeat(0)));
+    gen.seed(123_456_789U.repeat);
 }
 
 @safe pure nothrow unittest
@@ -1020,7 +1021,8 @@ alias Mt19937_64 = MersenneTwisterEngine!(ulong, 64, 312, 156, 31,
     // Check .save works
     static foreach (Type; std.meta.AliasSeq!(Mt19937, Mt19937_64))
     {{
-        auto gen1 = Type(unpredictableSeed);
+        auto gen1 = Type(123_456_789);
+        gen1.popFront();
         auto gen2 = gen1.save;
         assert(gen1 == gen2);  // Danger, Will Robinson -- no opEquals for MT
         // Enable next test when RNGs are reference types
@@ -1323,7 +1325,8 @@ alias Xorshift    = Xorshift128;                            /// ditto
     // Check .save works
     foreach (Type; XorshiftTypes)
     {
-        auto rnd1 = Type(unpredictableSeed);
+        auto rnd1 = Type(123_456_789);
+        rnd1.popFront();
         auto rnd2 = rnd1.save;
         assert(rnd1 == rnd2);
         // Enable next test when RNGs are reference types
@@ -1343,7 +1346,7 @@ alias Xorshift    = Xorshift128;                            /// ditto
     foreach (Rng; PseudoRngTypes)
     {
         static assert(isUniformRNG!Rng);
-        auto rng = Rng(unpredictableSeed);
+        auto rng = Rng(123_456_789);
     }
 }
 
@@ -1720,7 +1723,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
 @safe unittest
 {
     import std.conv : to;
-    auto gen = Mt19937(unpredictableSeed);
+    auto gen = Mt19937(123_456_789);
     static assert(isForwardRange!(typeof(gen)));
 
     auto a = uniform(0, 1024, gen);
@@ -2056,7 +2059,7 @@ do
 
         static foreach (T; std.meta.AliasSeq!(float, double, real))
         {{
-            UniformRNG rng = UniformRNG(unpredictableSeed);
+            UniformRNG rng = UniformRNG(123_456_789);
 
             auto a = uniform01();
             assert(is(typeof(a) == double));
@@ -2240,7 +2243,7 @@ if (isRandomAccessRange!Range)
         // Also tests partialShuffle indirectly.
         auto a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         auto b = a.dup;
-        auto gen = RandomGen(unpredictableSeed);
+        auto gen = RandomGen(123_456_789);
         randomShuffle(a, gen);
         sort(a);
         assert(a == b);
@@ -2421,7 +2424,7 @@ do
 
 @safe unittest
 {
-    auto rnd = Random(unpredictableSeed);
+    auto rnd = Xorshift(123_456_789);
     auto i = dice(rnd, 0.0, 100.0);
     assert(i == 1);
     i = dice(rnd, 100.0, 0.0);
@@ -2628,11 +2631,11 @@ if (isRandomAccessRange!Range)
         }
         else
         {
-            auto rng = UniformRNG(unpredictableSeed);
+            auto rng = UniformRNG(123_456_789);
             auto rc = randomCover(a, rng);
             static assert(isForwardRange!(typeof(rc)));
             // check for constructor passed a value-type RNG
-            auto rc2 = RandomCover!(int[], UniformRNG)(a, UniformRNG(unpredictableSeed));
+            auto rc2 = RandomCover!(int[], UniformRNG)(a, UniformRNG(987_654_321));
             static assert(isForwardRange!(typeof(rc2)));
             auto rcEmpty = randomCover(c, rng);
             assert(rcEmpty.length == 0);
@@ -3199,7 +3202,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
         {
             auto sample =
                 RandomSample!(TestInputRange, UniformRNG)
-                             (TestInputRange(), 5, 10, UniformRNG(unpredictableSeed));
+                             (TestInputRange(), 5, 10, UniformRNG(987_654_321));
             static assert(isInputRange!(typeof(sample)));
             static assert(!isForwardRange!(typeof(sample)));
         }
@@ -3215,7 +3218,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
         {
             auto sample =
                 RandomSample!(typeof(TestInputRange().takeExactly(10)), UniformRNG)
-                             (TestInputRange().takeExactly(10), 5, 10, UniformRNG(unpredictableSeed));
+                             (TestInputRange().takeExactly(10), 5, 10, UniformRNG(654_321_987));
             static assert(isInputRange!(typeof(sample)));
             static assert(!isForwardRange!(typeof(sample)));
         }
@@ -3229,7 +3232,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
             {
                 auto sample =
                     RandomSample!(int[], UniformRNG)
-                                 (a, 5, UniformRNG(unpredictableSeed));
+                                 (a, 5, UniformRNG(321_987_654));
                 static assert(isForwardRange!(typeof(sample)));
             }
         }
@@ -3241,7 +3244,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
             {
                 auto sample =
                     RandomSample!(int[], UniformRNG)
-                                 (a, 5, UniformRNG(unpredictableSeed));
+                                 (a, 5, UniformRNG(789_123_456));
                 static assert(isInputRange!(typeof(sample)));
                 static assert(!isForwardRange!(typeof(sample)));
             }


### PR DESCRIPTION
Rationale in review comment by @wilzbach  https://github.com/dlang/phobos/pull/6410#discussion_r178660995:
>Use a fixed seed and a fixed engine, everything else might lead to random coverage changes.

This PR applies this across Phobos. Exceptions are made for public unittests that may be meant to demonstrate use of unpredictableSeed and/or the default Random.