### PR TITLE
Add moveFile

### DIFF
--- a/changelog/std-file-move-file.dd
+++ b/changelog/std-file-move-file.dd
@@ -1,0 +1,7 @@
+Added the moveFile function
+
+Example:
+---
+moveFile(from, to);
+---
+$(REF moveFile, std,file) will attempt to rename the file and fallback to copy/remove if it fails.  This can occur when renaming a file from one filesystem/drive to another.


### PR DESCRIPTION
Added the `moveFile` function to move a single file that can work across drives and filesystems.

For windows this means adding a flag to the `MoveFile` function, for posix it means calling rename and falling back to copy on failure.