### PR TITLE
Remove redundant 'static' storage classes on __gshared variables

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2522,7 +2522,7 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
     {
         static MySingleton instance()
         {
-            static __gshared MySingleton inst;
+            __gshared MySingleton inst;
             return initOnce!inst(new MySingleton);
         }
     }
@@ -2536,14 +2536,14 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
     {
         static MySingleton instance()
         {
-            static __gshared MySingleton inst;
+            __gshared MySingleton inst;
             return initOnce!inst(new MySingleton);
         }
 
     private:
         this() { val = ++cnt; }
         size_t val;
-        static __gshared size_t cnt;
+        __gshared size_t cnt;
     }
 
     foreach (_; 0 .. 10)

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2817,7 +2817,7 @@ private:
         {
             import std.concurrency : initOnce;
 
-            static __gshared uint[string] _tzIndex;
+            __gshared uint[string] _tzIndex;
 
             // _tzIndex is initialized once and then shared across all threads.
             initOnce!_tzIndex(

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -362,7 +362,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     {
         mixin Impl!();
         static if (stateSize!Allocator == 0)
-            static __gshared AffixAllocator instance;
+            __gshared AffixAllocator instance;
     }
 }
 

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -53,7 +53,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     else
     {
         alias parent = ParentAllocator.instance;
-        static __gshared Quantizer instance;
+        __gshared Quantizer instance;
     }
 
     /**

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -271,7 +271,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
     else
     {
         static if (!stateSize!SmallAllocator && !stateSize!LargeAllocator)
-            static __gshared Segregator instance;
+            __gshared Segregator instance;
         mixin Impl!();
     }
 }

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -2532,8 +2532,8 @@ if (!isPointer!A)
     static if (stateSize!A == 0)
     {
         enum s = stateSize!(CAllocatorImpl!A).divideRoundUp(ulong.sizeof);
-        static __gshared ulong[s] state;
-        static __gshared RCIAllocator result;
+        __gshared ulong[s] state;
+        __gshared RCIAllocator result;
         if (result.isNull)
         {
             // Don't care about a few races

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1628,7 +1628,7 @@ private @property Logger defaultSharedLoggerImpl() @trusted
     import std.conv : emplace;
     import std.stdio : stderr;
 
-    static __gshared align(FileLogger.alignof) void[__traits(classInstanceSize, FileLogger)] _buffer;
+    __gshared align(FileLogger.alignof) void[__traits(classInstanceSize, FileLogger)] _buffer;
 
     import std.concurrency : initOnce;
     initOnce!stdSharedDefaultLogger({

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1082,7 +1082,7 @@ private:
     Mutex waiterMutex;  // For waiterCondition
 
     // The instanceStartIndex of the next instance that will be created.
-    __gshared static size_t nextInstanceIndex = 1;
+    __gshared size_t nextInstanceIndex = 1;
 
     // The index of the current thread.
     static size_t threadIndex;


### PR DESCRIPTION
In preparation for the upcoming DScanner check (https://github.com/dlang-community/D-Scanner/pull/584).

> __gshared may also be applied to member variables and local variables. In these cases, __gshared is equivalent to static, except that the variable is shared by all threads rather than being thread local.

Imho the compiler should error on `__gshared static`, but looks like this is the best we can get for now.