### PR TITLE
Work On Issue 18693 - Remove rndtonl from std.math

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -252,7 +252,6 @@ has_public_example="-etc.c.curl,\
 -std.internal.scopebuffer,\
 -std.internal.test.dummyrange,\
 -std.json,\
--std.math,\
 -std.mathspecial,\
 -std.mmfile,\
 -std.net.curl,\

--- a/changelog/rndtonl-deprecated.dd
+++ b/changelog/rndtonl-deprecated.dd
@@ -1,0 +1,6 @@
+std.math.rndtonl has been deprecated
+
+$(REF rndtonl, std, math) is a rounding function only available when using the
+Digital Mars C Runtime on Windows. As this function is not cross-platform, it
+has been deprecated, and will be removed on version 2.089. Please use
+$(REF round, std, math) instead.

--- a/std/math.d
+++ b/std/math.d
@@ -1804,22 +1804,34 @@ long rndtol(float x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
     assert(prndtol != null);
 }
 
-/*****************************************
- * Returns x rounded to a long value using the FE_TONEAREST rounding mode.
- * If the integer value of x is
- * greater than long.max, the result is
- * indeterminate.
+/**
+$(RED Deprecated. Please use $(LREF round) instead.)
+
+Returns `x` rounded to a `long` value using the `FE_TONEAREST` rounding mode.
+If the integer value of `x` is greater than `long.max`, the result is
+indeterminate.
+
+Only works with the Digital Mars C Runtime.
+
+Params:
+    x = the number to round
+Returns:
+    `x` rounded to an integer value
  */
+deprecated("rndtonl is to be removed by 2.089. Please use round instead")
 extern (C) real rndtonl(real x);
 
-// issue 18693
-//@safe unittest
-//{
-//    assert(rndtol(1.0) == 1.0);
-//    assert(rndtol(1.2) == 1.0);
-//    assert(rndtol(1.7) == 2.0);
-//    assert(rndtol(1.0001) == 1.0);
-//}
+///
+deprecated @system unittest
+{
+    version(CRuntime_DigitalMars)
+    {
+        assert(rndtonl(1.0) is -real.nan);
+        assert(rndtonl(1.2) is -real.nan);
+        assert(rndtonl(1.7) is -real.nan);
+        assert(rndtonl(1.0001) is -real.nan);
+    }
+}
 
 /***************************************
  * Compute square root of x.


### PR DESCRIPTION
This function 

1. Results in link errors if you're not using DM's C runtime
2. Is non-standard
3. Is covered by `round` and friends

Side note: all of these platform specific math functions which share the C names feel a lot like PHP.  This is not how these would be designed if std.math was to be written today, so any instance of these that we can remove/redesign, the better. 