### PR TITLE
Fix Issue 18741 - std.math.sqrt doesn't use sqrtl when it's available

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -1840,7 +1840,21 @@ float sqrt(float x) @nogc @safe pure nothrow { pragma(inline, true); return core
 double sqrt(double x) @nogc @safe pure nothrow { pragma(inline, true); return core.math.sqrt(x); }
 
 /// ditto
-real sqrt(real x) @nogc @safe pure nothrow { pragma(inline, true); return core.math.sqrt(x); }
+real sqrt(real x) @nogc @safe pure nothrow
+{
+    pragma(inline, true);
+
+    version(FreeBSD)
+        return core.math.sqrtl(x);
+    else version(OpenBSD)
+        return core.math.sqrtl(x);
+    else version(NetBSD)
+        return core.math.sqrtl(x);
+    else version(DragonFlyBSD)
+        return core.math.sqrtl(x);
+    else
+        return core.math.sqrt(x);
+}
 
 ///
 @safe pure nothrow @nogc unittest


### PR DESCRIPTION
std.math is such a rat's nest. Which functions cast everything to real and back, which functions forward to their respective C versions, and which functions don't even have float or double overloads? It's all done on a function by function basis.