### PR TITLE
Make references to input ranges a link to isInputRange

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1091,7 +1091,7 @@ that can be executed via `pred(element)`.
 
 Params:
     predicate = Function to apply to each element of range
-    range = Input range of elements
+    range = An $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of elements
 
 Returns:
     `filter!(predicate)(range)` returns a new range containing only elements `x` in `range` for

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -930,7 +930,8 @@ alias nWayUnion = multiwayMerge;
 alias NWayUnion = MultiwayMerge;
 
 /**
-Computes the union of multiple ranges. The input ranges are passed
+Computes the union of multiple ranges. The
+$(REF_ALTTEXT input ranges, isInputRange, std,range,primitives) are passed
 as a range of ranges and each is assumed to be sorted by $(D
 less). Computation is done lazily, one union element at a time.
 `multiwayUnion(ror)` is functionally equivalent to `multiwayMerge(ror).uniq`.
@@ -1117,8 +1118,9 @@ SetDifference!(less, R1, R2) setDifference(alias less = "a < b", R1, R2)
 }
 
 /**
-Lazily computes the intersection of two or more input ranges $(D
-ranges). The ranges are assumed to be sorted by `less`. The element
+Lazily computes the intersection of two or more
+$(REF_ALTTEXT input ranges, isInputRange, std,range,primitives)
+`ranges`. The ranges are assumed to be sorted by `less`. The element
 types of the ranges must have a common type.
 
 In the case of multisets, the range with the minimum number of

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -460,7 +460,7 @@ if (!is(Unqual!T == bool))
     }
 
     /**
-     * Constructor taking an input range
+     * Constructor taking an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
      */
     this(Range)(Range r)
     if (isInputRange!Range && isImplicitlyConvertible!(ElementType!Range, T) && !is(Range == T[]))

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -241,7 +241,7 @@ Constructor taking a number of nodes
     }
 
 /**
-Constructor taking an input range
+Constructor taking an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
      */
     this(Stuff)(Stuff stuff)
     if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -187,7 +187,7 @@ Constructor taking a number of nodes
     }
 
 /**
-Constructor taking an input range
+Constructor taking an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
      */
     this(Stuff)(Stuff stuff)
     if (isInputRange!Stuff

--- a/std/csv.d
+++ b/std/csv.d
@@ -2,7 +2,7 @@
 
 /**
  * Implements functionality to read Comma Separated Values and its variants
- * from an input range of `dchar`.
+ * from an $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of `dchar`.
  *
  * Comma Separated Values provide a simple means to transfer and store
  * tabular data. It has been common for programs to use their own
@@ -293,8 +293,8 @@ enum Malformed
 }
 
 /**
-Returns an input range for iterating over records found in $(D
-input).
+Returns an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+for iterating over records found in `input`.
 
 An optional `header` can be provided. The first record will be read in
 as the header. If `Contents` is a struct then the header provided is
@@ -1182,7 +1182,7 @@ private:
 public:
     /*
      * Params:
-     *      input = Pointer to a character input range
+     *      input = Pointer to a character $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
      *      delimiter = Separator for each column
      *      quote = Character used for quotation
      *      indices = An array containing which columns will be returned.

--- a/std/file.d
+++ b/std/file.d
@@ -4681,7 +4681,8 @@ public:
     void popFront() { impl.popFront(); }
 }
 /++
-    Returns an input range of `DirEntry` that lazily iterates a given directory,
+    Returns an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+    of `DirEntry` that lazily iterates a given directory,
     also provides two ways of foreach iteration. The iteration variable can be of
     type `string` if only the name is needed, or `DirEntry`
     if additional details are needed. The span _mode dictates how the

--- a/std/format.d
+++ b/std/format.d
@@ -621,8 +621,8 @@ uint formattedWrite(Writer, Char, A...)(auto ref Writer w, in Char[] fmt, A args
 }
 
 /**
-Reads characters from input range `r`, converts them according
-to `fmt`, and writes them to `args`.
+Reads characters from $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+`r`, converts them according to `fmt`, and writes them to `args`.
 
 Params:
     r = The range to read from.

--- a/std/meta.d
+++ b/std/meta.d
@@ -1121,7 +1121,8 @@ template templateOr(Preds...)
 }
 
 /**
- * Converts an input range `range` to an alias sequence.
+ * Converts an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ * `range` to an alias sequence.
  */
 template aliasSeqOf(alias range)
 {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1835,7 +1835,8 @@ public:
 
         Params:
 
-        source = The input range to be mapped.  If `source` is not random
+        source = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+        to be mapped.  If `source` is not random
         access it will be lazily buffered to an array of size `bufSize` before
         the map function is evaluated.  (For an exception to this rule, see Notes.)
 
@@ -2164,8 +2165,8 @@ public:
 
     /**
     Given a `source` range that is expensive to iterate over, returns an
-    input range that asynchronously buffers the contents of
-    `source` into a buffer of `bufSize` elements in a worker thread,
+    $(REF_ALTTEXT input range, isInputRange, std,range,primitives) that
+    asynchronously buffers the contents of `source` into a buffer of `bufSize` elements in a worker thread,
     while making previously buffered elements from a second buffer, also of size
     `bufSize`, available via the range interface of the returned
     object.  The returned range has a length iff `hasLength!S`.

--- a/std/path.d
+++ b/std/path.d
@@ -1414,7 +1414,8 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
     range.
 
     Params:
-        segments = An input range of segments to assemble the path from.
+        segments = An $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+        of segments to assemble the path from.
     Returns: The assembled path.
 */
 immutable(ElementEncodingType!(ElementType!Range))[]

--- a/std/random.d
+++ b/std/random.d
@@ -2648,7 +2648,8 @@ Params:
 Returns:
     Range whose elements consist of the elements of `r`,
     in random order.  Will be a forward range if both `r` and
-    `rng` are forward ranges, an input range otherwise.
+    `rng` are forward ranges, an
+    $(REF_ALTTEXT input range, isInputRange, std,range,primitives) otherwise.
 */
 struct RandomCover(Range, UniformRNG = void)
 if (isRandomAccessRange!Range && (isUniformRNG!UniformRNG || is(UniformRNG == void)))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -489,7 +489,7 @@ the same range results in a stride with a step that is the
 product of the two applications. It is an error for `n` to be 0.
 
 Params:
-    r = the input range to stride over
+    r = the $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to stride over
     n = the number of elements to skip over
 
 Returns:
@@ -881,7 +881,7 @@ Chain) type exits the picture by aliasing itself directly to that
 range's type.
 
 Params:
-    rs = the input ranges to chain together
+    rs = the $(REF_ALTTEXT input ranges, isInputRange, std,range,primitives) to chain together
 
 Returns:
     An input range at minimum. If all of the ranges in `rs` provide
@@ -1995,7 +1995,8 @@ information is not applied to the result unless `input` also has
 length information.
 
 Params:
-    input = an input range to iterate over up to `n` times
+    input = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+    to iterate over up to `n` times
     n = the number of elements to take
 
 Returns:
@@ -3034,7 +3035,7 @@ pure @safe nothrow @nogc unittest
     In other languages this is sometimes called `skip`.
 
     Params:
-        range = the input range to drop from
+        range = the $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to drop from
         n = the number of elements to drop
 
     Returns:
@@ -3123,7 +3124,7 @@ if (isBidirectionalRange!R)
     `n` elements.
 
     Params:
-        range = the input range to drop from
+        range = the $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to drop from
         n = the number of elements to drop
 
     Returns:
@@ -7654,8 +7655,8 @@ Indexed!(Source, Indices) indexed(Source, Indices)(Source source, Indices indice
 
 /**
 This range iterates over fixed-sized chunks of size `chunkSize` of a
-`source` range. `Source` must be an input range. `chunkSize` must be
-greater than zero.
+`source` range. `Source` must be an $(REF_ALTTEXT input range, isInputRange, std,range,primitives).
+`chunkSize` must be greater than zero.
 
 If `!isInfinite!Source` and `source.walkLength` is not evenly
 divisible by `chunkSize`, the back element of this range will contain
@@ -9812,7 +9813,7 @@ Overflow:
     continue from `Enumerator.min`.
 
 Params:
-    range = the input range to attach indexes to
+    range = the $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to attach indexes to
     start = the number to start the index counter from
 
 Returns:
@@ -12043,7 +12044,7 @@ Bitwise adapter over an integral type range. Consumes the range elements bit by
 bit, from the least significant bit to the most significant bit.
 
 Params:
-    R = an integral input range to iterate over
+    R = an integral $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to iterate over
     range = range to consume bit by by
 
 Returns:
@@ -12609,7 +12610,7 @@ $(REF byGrapheme, std, uni) before calling this function.
 If `r` has a length, then this is $(BIGOH 1). Otherwise, it's $(BIGOH r.length).
 
 Params:
-    r = an input range with a length, or a forward range
+    r = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives) with a length, or a forward range
     e = element to pad the range with
     n = the length to pad to
 
@@ -12695,7 +12696,7 @@ provides them. Except the functions `back` and `popBack`, which also require
 the range to have a length as well as `back` and `popBack`
 
 Params:
-    r = an input range with a length
+    r = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives) with a length
     e = element to pad the range with
     n = the length to pad to
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -156,11 +156,14 @@ Also, note that Phobos code assumes that the primitives `r.front` and
 running time. $(BIGOH) statements in the documentation of range functions
 are made with this assumption.
 
+See_Also:
+    The header of $(MREF std,range) for tutorials on ranges.
+
 Params:
     R = type to be tested
 
 Returns:
-    true if R is an InputRange, false if not
+    `true` if R is an input range, `false` if not
  */
 enum bool isInputRange(R) =
     is(typeof(R.init) == R)
@@ -817,6 +820,9 @@ package(std) enum bool isNativeOutputRange(R, E) =
 Returns `true` if `R` is an output range for elements of type
 `E`. An output range is defined functionally as a range that
 supports the operation $(D put(r, e)) as defined above.
+
+See_Also:
+    The header of $(MREF std,range) for tutorials on ranges.
  +/
 enum bool isOutputRange(R, E) =
     is(typeof(put(lvalueOf!R, lvalueOf!E)));
@@ -880,6 +886,9 @@ The semantics of a forward range (not checkable during compilation)
 are the same as for an input range, with the additional requirement
 that backtracking must be possible by saving a copy of the range
 object with `save` and using it later.
+
+See_Also:
+    The header of $(MREF std,range) for tutorials on ranges.
  */
 enum bool isForwardRange(R) = isInputRange!R
     && is(ReturnType!((R r) => r.save) == R);
@@ -919,6 +928,9 @@ type `R`):
 $(UL $(LI `r.back` returns (possibly a reference to) the last
 element in the range. Calling `r.back` is allowed only if calling
 `r.empty` has, or would have, returned `false`.))
+
+See_Also:
+    The header of $(MREF std,range) for tutorials on ranges.
  */
 enum bool isBidirectionalRange(R) = isForwardRange!R
     && is(typeof((R r) => r.popBack))
@@ -980,6 +992,9 @@ versions including `string` and `wstring`) are arrays, $(D
 isRandomAccessRange) yields `false` for them because they use
 variable-length encodings (UTF-8 and UTF-16 respectively). These types
 are bidirectional ranges only.
+
+See_Also:
+    The header of $(MREF std,range) for tutorials on ranges.
  */
 enum bool isRandomAccessRange(R) =
     is(typeof(lvalueOf!R[1]) == ElementType!R)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2191,8 +2191,8 @@ Allows to directly use range operations on lines of a file.
     }
 
 /**
-Returns an input range set up to read from the file handle one line
-at a time.
+Returns an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+set up to read from the file handle one line at a time.
 
 The element type for the range will be `Char[]`. Range primitives
 may throw `StdioException` on I/O error.
@@ -2353,7 +2353,8 @@ the contents may well have changed).
     }
 
 /**
-Returns an input range set up to read from the file handle one line
+Returns an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+set up to read from the file handle one line
 at a time. Each line will be newly allocated. `front` will cache
 its value to allow repeated calls without unnecessary allocations.
 
@@ -2556,8 +2557,8 @@ $(REF readText, std,file)
     }
 
     /**
-    Creates an input range set up to parse one line at a time from the file
-    into a tuple.
+    Creates an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+    set up to parse one line at a time from the file into a tuple.
 
     Range primitives may throw `StdioException` on I/O error.
 
@@ -2677,8 +2678,8 @@ $(REF readText, std,file)
     }
 
 /**
-Returns an input range set up to read from the file handle a chunk at a
-time.
+Returns an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+set up to read from the file handle a chunk at a time.
 
 The element type for the range will be `ubyte[]`. Range primitives
 may throw `StdioException` on I/O error.

--- a/std/uni.d
+++ b/std/uni.d
@@ -7134,7 +7134,8 @@ if (is(C : dchar))
 }
 
 /++
-    Reads one full grapheme cluster from an input range of dchar `inp`.
+    Reads one full grapheme cluster from an
+    $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of dchar `inp`.
 
     For examples see the $(LREF Grapheme) below.
 
@@ -7761,8 +7762,8 @@ static assert(Grapheme.sizeof == size_t.sizeof*4);
     than $(LREF icmp). However keep in mind the warning below.)
 
     Params:
-        r1 = an input range of characters
-        r2 = an input range of characters
+        r1 = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of characters
+        r2 = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives) of characters
 
     Returns:
         An `int` that is 0 if the strings match,
@@ -9139,7 +9140,8 @@ if (isInputRange!Range &&
 }
 
 /*********************
- * Convert input range or string to upper or lower case.
+ * Convert an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ * or a string to upper or lower case.
  *
  * Does not allocate memory.
  * Characters in UTF-8 or UTF-16 format that cannot be decoded
@@ -9149,7 +9151,7 @@ if (isInputRange!Range &&
  *      str = string or range of characters
  *
  * Returns:
- *      an InputRange of dchars
+ *      an input range of `dchar`s
  *
  * See_Also:
  *      $(LREF toUpper), $(LREF toLower)
@@ -9354,7 +9356,8 @@ if (isInputRange!Range &&
 }
 
 /*********************
- * Capitalize input range or string, meaning convert the first
+ * Capitalize an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ * or string, meaning convert the first
  * character to upper case and subsequent characters to lower case.
  *
  * Does not allocate memory.

--- a/std/utf.d
+++ b/std/utf.d
@@ -280,8 +280,8 @@ pure nothrow @safe @nogc unittest
     in `str`.
 
     Params:
-        str = input range of UTF code units. Must be random access if
-        `index` is passed
+        str = $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+        of UTF code units. Must be random access if `index` is passed
         index = starting index of UTF sequence (default: `0`)
 
     Returns:
@@ -1080,7 +1080,8 @@ do
 /++
     `decodeFront` is a variant of $(LREF decode) which specifically decodes
     the first code point. Unlike $(LREF decode), `decodeFront` accepts any
-    input range of code units (rather than just a string or random access
+    $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+    of code units (rather than just a string or random access
     range). It also takes the range by `ref` and pops off the elements as it
     decodes them. If `numCodeUnits` is passed in, it gets set to the number
     of code units which were in the code point which was decoded.
@@ -2562,7 +2563,8 @@ if (isSomeChar!C)
 
     Params:
         C = the character type to get the encoding length for
-        input = the input range to calculate the encoding length from
+        input = the $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+        to calculate the encoding length from
     Returns:
         The number of code units in `input` when encoded to `C`
   +/
@@ -3278,8 +3280,8 @@ enum dchar replacementDchar = '\uFFFD';
  * one while iterating over the resulting range will give nonsensical results.
  *
  * Params:
- *      r = an input range of characters (including strings) or a type that
- *          implicitly converts to a string type.
+ *      r = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ *      of characters (including strings) or a type that implicitly converts to a string type.
  * Returns:
  *      If `r` is not an auto-decodable string (i.e. a narrow string or a
  *      user-defined type that implicits converts to a string type), then `r`
@@ -3698,7 +3700,8 @@ if (isAutodecodableString!R ||
 }
 
 /****************************
- * Iterate an input range of characters by char, wchar, or dchar.
+ * Iterate an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ * of characters by char, wchar, or dchar.
  * These aliases simply forward to $(LREF byUTF) with the
  * corresponding C argument.
  *
@@ -3933,8 +3936,8 @@ int impureVariable;
 }
 
 /****************************
- * Iterate an input range of characters by char type `C` by
- * encoding the elements of the range.
+ * Iterate an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
+ * of characters by char type `C` by encoding the elements of the range.
  *
  * UTF sequences that cannot be converted to the specified encoding are
  * replaced by U+FFFD per "5.22 Best Practice for U+FFFD Substitution"


### PR DESCRIPTION
Unfortunately we can't control when people are introduced to the concept of a range. Ideally they read Ali's chapter on it or go through the tour before they start going through the docs. But, a lot of users will have these terms thrown at them without introduction (from their perspective).

This PR makes mentions of input ranges into links to `isInputRange`. Also, the major range types now have links to the header of std.range which contains lots of range tutorials.