### PR TITLE
Remove superfluous _range used to avoid auto-highlighting

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -119,36 +119,36 @@ if (fun.length >= 1)
 }
 
 /++
-`cache` eagerly evaluates $(REF_ALTTEXT front, front, std,_range,primitives) of `range`
-on each construction or call to $(REF_ALTTEXT popFront, popFront, std,_range,primitives),
+`cache` eagerly evaluates $(REF_ALTTEXT front, front, std,range,primitives) of `range`
+on each construction or call to $(REF_ALTTEXT popFront, popFront, std,range,primitives),
 to store the result in a _cache.
-The result is then directly returned when $(REF_ALTTEXT front, front, std,_range,primitives) is called,
+The result is then directly returned when $(REF_ALTTEXT front, front, std,range,primitives) is called,
 rather than re-evaluated.
 
 This can be a useful function to place in a chain, after functions
 that have expensive evaluation, as a lazy alternative to $(REF array, std,array).
 In particular, it can be placed after a call to $(LREF map), or before a call
-$(REF filter, std,_range) or $(REF tee, std,_range)
+$(REF filter, std,range) or $(REF tee, std,range)
 
 `cache` may provide
-$(REF_ALTTEXT bidirectional _range, isBidirectionalRange, std,_range,primitives)
+$(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives)
 iteration if needed, but since this comes at an increased cost, it must be explicitly requested via the
 call to `cacheBidirectional`. Furthermore, a bidirectional _cache will
 evaluate the "center" element twice, when there is only one element left in
-the _range.
+the range.
 
 `cache` does not provide random access primitives,
 as `cache` would be unable to _cache the random accesses.
 If `Range` provides slicing primitives,
 then `cache` will provide the same slicing primitives,
-but `hasSlicing!Cache` will not yield true (as the $(REF hasSlicing, std,_range,primitives)
+but `hasSlicing!Cache` will not yield true (as the $(REF hasSlicing, std,range,primitives)
 trait also checks for random access).
 
 Params:
-    range = an $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+    range = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
 
 Returns:
-    An $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives) with the cached values of _range
+    An $(REF_ALTTEXT input range, isInputRange, std,range,primitives) with the cached values of range
 +/
 auto cache(Range)(Range range)
 if (isInputRange!Range)
@@ -207,14 +207,14 @@ if (isBidirectionalRange!Range)
 
 /++
 Tip: `cache` is eager when evaluating elements. If calling front on the
-underlying _range has a side effect, it will be observable before calling
-front on the actual cached _range.
+underlying range has a side effect, it will be observable before calling
+front on the actual cached range.
 
-Furthermore, care should be taken composing `cache` with $(REF take, std,_range).
+Furthermore, care should be taken composing `cache` with $(REF take, std,range).
 By placing `take` before `cache`, then `cache` will be "aware"
-of when the _range ends, and correctly stop caching elements when needed.
+of when the range ends, and correctly stop caching elements when needed.
 If calling front has no side effect though, placing `take` after `cache`
-may yield a faster _range.
+may yield a faster range.
 
 Either way, the resulting ranges will be equivalent, but maybe not at the
 same cost or side effects.
@@ -1890,7 +1890,7 @@ if (isForwardRange!Range)
  *
  * Equivalence is defined by the predicate `pred`, which can be either
  * binary, which is passed to $(REF binaryFun, std,functional), or unary, which is
- * passed to $(REF unaryFun, std,functional). In the binary form, two _range elements
+ * passed to $(REF unaryFun, std,functional). In the binary form, two range elements
  * `a` and `b` are considered equivalent if `pred(a,b)` is true. In
  * unary form, two elements are considered equivalent if `pred(a) == pred(b)`
  * is true.

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -535,21 +535,21 @@ $(LINK2 http://en.cppreference.com/w/cpp/algorithm/copy_backward, STL's `copy_ba
 }
 
 /**
-Assigns `value` to each element of input _range `range`.
+Assigns `value` to each element of input range `range`.
 
 Alternatively, instead of using a single `value` to fill the `range`,
-a `filter` $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives)
+a `filter` $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
 can be provided. The length of `filler` and `range` do not need to match, but
 `filler` must not be empty.
 
 Params:
         range = An
-                $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+                $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
                 that exposes references to its elements and has assignable
                 elements
         value = Assigned to each element of range
         filler = A
-                $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives)
+                $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
                 representing the _fill pattern.
 
 Throws: If `filler` is empty.
@@ -832,7 +832,7 @@ Assumes that the elements of the range are uninitialized.
 
 Params:
         range = An
-                $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+                $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
                 that exposes references to its elements and has assignable
                 elements
 
@@ -1704,9 +1704,9 @@ a = a.remove(1); // remove element at offset 1
 assert(a == [ "a", "c", "d"]);
 ----
 
-Note that `remove` does not change the length of the original _range directly;
-instead, it returns the shortened _range. If its return value is not assigned to
-the original _range, the original _range will retain its original length, though
+Note that `remove` does not change the length of the original range directly;
+instead, it returns the shortened range. If its return value is not assigned to
+the original range, the original range will retain its original length, though
 its contents will have changed:
 
 ----
@@ -1779,7 +1779,7 @@ cases.))
 
 Params:
     s = a SwapStrategy to determine if the original order needs to be preserved
-    range = a $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,_range,primitives)
+    range = a $(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives)
     with a length member
     offset = which element(s) to remove
 
@@ -2014,7 +2014,7 @@ if (s == SwapStrategy.stable
 
 /**
 Reduces the length of the
-$(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,_range,primitives) `range` by removing
+$(REF_ALTTEXT bidirectional range, isBidirectionalRange, std,range,primitives) `range` by removing
 elements that satisfy `pred`. If `s = SwapStrategy.unstable`,
 elements are moved from the right end of the range over the elements
 to eliminate. If `s = SwapStrategy.stable` (the default),
@@ -2815,9 +2815,9 @@ be of different types but must have the same element type and support
 swapping.
 
 Params:
-    r1 = an $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+    r1 = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
          with swappable elements
-    r2 = an $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+    r2 = an $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
          with swappable elements
 
 Returns:
@@ -2856,7 +2856,7 @@ uninitializedFill are equivalent).
 
 Params:
         range = An
-                $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+                $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
                 that exposes references to its elements and has assignable
                 elements
         value = Assigned to each element of range

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -116,7 +116,7 @@ template all(alias pred = "a")
 {
     /++
     Returns `true` if and only if $(I _all) values `v` found in the
-    input _range `range` satisfy the predicate `pred`.
+    input range `range` satisfy the predicate `pred`.
     Performs (at most) $(BIGOH range.length) evaluations of `pred`.
      +/
     bool all(Range)(Range range)
@@ -163,7 +163,7 @@ template any(alias pred = "a")
 {
     /++
     Returns `true` if and only if $(I _any) value `v` found in the
-    input _range `range` satisfies the predicate `pred`.
+    input range `range` satisfies the predicate `pred`.
     Performs (at most) $(BIGOH range.length) evaluations of `pred`.
      +/
     bool any(Range)(Range range)
@@ -4525,7 +4525,7 @@ This is similar to `takeWhile` in other languages.
 
 Params:
     pred = Predicate to determine when to stop.
-    range = The $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives)
+    range = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
     to iterate over.
     sentinel = The element to stop at.
     openRight = Determines whether the element for which the given predicate is
@@ -4533,10 +4533,10 @@ Params:
         not (`Yes.openRight`).
 
 Returns:
-    An $(REF_ALTTEXT input _range, isInputRange, std,_range,primitives) that
+    An $(REF_ALTTEXT input range, isInputRange, std,range,primitives) that
     iterates over the original range's elements, but ends when the specified
     predicate becomes true. If the original range is a
-    $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives) or
+    $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) or
     higher, this range will be a forward range.
  */
 Until!(pred, Range, Sentinel)

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -61,7 +61,7 @@ import std.typecons : No;
 // cartesianProduct
 /**
 Lazily computes the Cartesian product of two or more ranges. The product is a
-_range of tuples of elements from each respective range.
+range of tuples of elements from each respective range.
 
 The conditions for the two-range case are as follows:
 
@@ -69,8 +69,8 @@ If both ranges are finite, then one must be (at least) a
 $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) and the
 other an $(REF_ALTTEXT input range, isInputRange, std,range,primitives).
 
-If one _range is infinite and the other finite, then the finite _range must
-be a forward _range, and the infinite range can be an input _range.
+If one range is infinite and the other finite, then the finite range must
+be a forward range, and the infinite range can be an input range.
 
 If both ranges are infinite, then both must be forward ranges.
 

--- a/std/array.d
+++ b/std/array.d
@@ -454,7 +454,7 @@ Construct a range iterating over an associative array by key/value tuples.
 Params:
     aa = The associative array to iterate over.
 
-Returns: A $(REF_ALTTEXT forward range, isForwardRange, std,_range,primitives)
+Returns: A $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
 of Tuple's of key and value pairs from the given associative array. The members
 of each pair can be accessed by name (`.key` and `.value`). or by integer
 index (0 and 1 respectively).
@@ -1482,7 +1482,7 @@ When no delimiter is provided, strings are split into an array of words,
 using whitespace as delimiter.
 Runs of whitespace are merged together (no empty words are produced).
 
-The `range` must be a $(REF_ALTTEXT forward _range, isForwardRange, std,_range,primitives).
+The `range` must be a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives).
 The separator can be a value of the same type as the elements in `range`
 or it can be another forward `range`.
 

--- a/std/format.d
+++ b/std/format.d
@@ -1836,7 +1836,7 @@ FormatSpec!Char singleSpec(Char)(Char[] fmt)
  * Otherwise, are formatted just as their type name.
  *
  * Params:
- *     w = The $(REF_ALTTEXT output range, isOutputRange, std,_range,primitives) to write to.
+ *     w = The $(REF_ALTTEXT output range, isOutputRange, std,range,primitives) to write to.
  *     val = The value to write.
  *     f = The $(REF FormatSpec, std, format) defining how to write the value.
  */

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -5,7 +5,7 @@ The main $(MREF std, range) module provides template-based tools for working wit
 ranges, but sometimes an object-based interface for ranges is needed, such as
 when runtime polymorphism is required. For this purpose, this submodule
 provides a number of object and `interface` definitions that can be used to
-wrap around _range objects created by the $(MREF std, range) templates.
+wrap around range objects created by the $(MREF std, range) templates.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
@@ -49,7 +49,7 @@ $(BOOKTABLE ,
     ))
     $(TR $(TD $(LREF InputRangeObject))
         $(TD Class that implements the `InputRange` interface and wraps the
-        input _range methods in virtual functions.
+        input range methods in virtual functions.
     ))
     $(TR $(TD $(LREF inputRangeObject))
         $(TD Convenience function for creating an `InputRangeObject`

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -14,7 +14,7 @@ Guides:
 There are many articles available that can bolster understanding ranges:
 
 $(UL
-    $(LI Ali Çehreli's $(HTTP ddili.org/ders/d.en/ranges.html, tutorial on _ranges)
+    $(LI Ali Çehreli's $(HTTP ddili.org/ders/d.en/ranges.html, tutorial on ranges)
         for the basics of working with and creating range-based code.)
     $(LI Jonathan M. Davis $(LINK2 http://dconf.org/2015/talks/davis.html, $(I Introduction to Ranges))
         talk at DConf 2015 a vivid introduction from its core constructs to practical advice.)
@@ -22,7 +22,7 @@ $(UL
         for an interactive introduction.)
     $(LI H. S. Teoh's $(LINK2 http://wiki.dlang.org/Component_programming_with_ranges, tutorial on
         component programming with ranges) for a real-world showcase of the influence
-        of _range-based programming on complex algorithms.)
+        of range-based programming on complex algorithms.)
     $(LI Andrei Alexandrescu's article
         $(LINK2 http://www.informit.com/articles/printerfriendly.aspx?p=1407357$(AMP)rll=1,
         $(I On Iteration)) for conceptual aspect of ranges and the motivation
@@ -33,23 +33,23 @@ Submodules:
 
 This module has two submodules:
 
-The $(MREF std, _range, primitives) submodule
-provides basic _range functionality. It defines several templates for testing
-whether a given object is a _range, what kind of _range it is, and provides
-some common _range operations.
+The $(MREF std, range, primitives) submodule
+provides basic range functionality. It defines several templates for testing
+whether a given object is a range, what kind of range it is, and provides
+some common range operations.
 
-The $(MREF std, _range, interfaces) submodule
+The $(MREF std, range, interfaces) submodule
 provides object-based interfaces for working with ranges via runtime
 polymorphism.
 
-The remainder of this module provides a rich set of _range creation and
+The remainder of this module provides a rich set of range creation and
 composition templates that let you construct new ranges out of existing ranges:
 
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
     $(TR $(TD $(LREF chain))
-        $(TD Concatenates several ranges into a single _range.
+        $(TD Concatenates several ranges into a single range.
     ))
     $(TR $(TD $(LREF choose))
         $(TD Chooses one of two ranges at runtime based on a boolean condition.
@@ -58,151 +58,151 @@ $(BOOKTABLE ,
         $(TD Chooses one of several ranges at runtime based on an index.
     ))
     $(TR $(TD $(LREF chunks))
-        $(TD Creates a _range that returns fixed-size chunks of the original
-        _range.
+        $(TD Creates a range that returns fixed-size chunks of the original
+        range.
     ))
     $(TR $(TD $(LREF cycle))
-        $(TD Creates an infinite _range that repeats the given forward _range
+        $(TD Creates an infinite range that repeats the given forward range
         indefinitely. Good for implementing circular buffers.
     ))
     $(TR $(TD $(LREF drop))
-        $(TD Creates the _range that results from discarding the first $(I n)
-        elements from the given _range.
+        $(TD Creates the range that results from discarding the first $(I n)
+        elements from the given range.
     ))
     $(TR $(TD $(LREF dropBack))
-        $(TD Creates the _range that results from discarding the last $(I n)
-        elements from the given _range.
+        $(TD Creates the range that results from discarding the last $(I n)
+        elements from the given range.
     ))
     $(TR $(TD $(LREF dropExactly))
-        $(TD Creates the _range that results from discarding exactly $(I n)
-        of the first elements from the given _range.
+        $(TD Creates the range that results from discarding exactly $(I n)
+        of the first elements from the given range.
     ))
     $(TR $(TD $(LREF dropBackExactly))
-        $(TD Creates the _range that results from discarding exactly $(I n)
-        of the last elements from the given _range.
+        $(TD Creates the range that results from discarding exactly $(I n)
+        of the last elements from the given range.
     ))
     $(TR $(TD $(LREF dropOne))
-        $(TD Creates the _range that results from discarding
-        the first element from the given _range.
+        $(TD Creates the range that results from discarding
+        the first element from the given range.
     ))
     $(TR $(TD $(D $(LREF dropBackOne)))
-        $(TD Creates the _range that results from discarding
-        the last element from the given _range.
+        $(TD Creates the range that results from discarding
+        the last element from the given range.
     ))
     $(TR $(TD $(LREF enumerate))
-        $(TD Iterates a _range with an attached index variable.
+        $(TD Iterates a range with an attached index variable.
     ))
     $(TR $(TD $(LREF evenChunks))
-        $(TD Creates a _range that returns a number of chunks of
-        approximately equal length from the original _range.
+        $(TD Creates a range that returns a number of chunks of
+        approximately equal length from the original range.
     ))
     $(TR $(TD $(LREF frontTransversal))
-        $(TD Creates a _range that iterates over the first elements of the
+        $(TD Creates a range that iterates over the first elements of the
         given ranges.
     ))
     $(TR $(TD $(LREF generate))
-        $(TD Creates a _range by successive calls to a given function. This
+        $(TD Creates a range by successive calls to a given function. This
         allows to create ranges as a single delegate.
     ))
     $(TR $(TD $(LREF indexed))
-        $(TD Creates a _range that offers a view of a given _range as though
-        its elements were reordered according to a given _range of indices.
+        $(TD Creates a range that offers a view of a given range as though
+        its elements were reordered according to a given range of indices.
     ))
     $(TR $(TD $(LREF iota))
-        $(TD Creates a _range consisting of numbers between a starting point
+        $(TD Creates a range consisting of numbers between a starting point
         and ending point, spaced apart by a given interval.
     ))
     $(TR $(TD $(LREF lockstep))
-        $(TD Iterates $(I n) _ranges in lockstep, for use in a `foreach`
+        $(TD Iterates $(I n) ranges in lockstep, for use in a `foreach`
         loop. Similar to `zip`, except that `lockstep` is designed
         especially for `foreach` loops.
     ))
     $(TR $(TD $(LREF nullSink))
-        $(TD An output _range that discards the data it receives.
+        $(TD An output range that discards the data it receives.
     ))
     $(TR $(TD $(LREF only))
-        $(TD Creates a _range that iterates over the given arguments.
+        $(TD Creates a range that iterates over the given arguments.
     ))
     $(TR $(TD $(LREF padLeft))
-        $(TD Pads a _range to a specified length by adding a given element to
-        the front of the _range. Is lazy if the _range has a known length.
+        $(TD Pads a range to a specified length by adding a given element to
+        the front of the range. Is lazy if the range has a known length.
     ))
     $(TR $(TD $(LREF padRight))
-        $(TD Lazily pads a _range to a specified length by adding a given element to
-        the back of the _range.
+        $(TD Lazily pads a range to a specified length by adding a given element to
+        the back of the range.
     ))
     $(TR $(TD $(LREF radial))
-        $(TD Given a random-access _range and a starting point, creates a
-        _range that alternately returns the next left and next right element to
+        $(TD Given a random-access range and a starting point, creates a
+        range that alternately returns the next left and next right element to
         the starting point.
     ))
     $(TR $(TD $(LREF recurrence))
-        $(TD Creates a forward _range whose values are defined by a
+        $(TD Creates a forward range whose values are defined by a
         mathematical recurrence relation.
     ))
     $(TR $(TD $(LREF refRange))
-        $(TD Pass a _range by reference. Both the original _range and the RefRange
+        $(TD Pass a range by reference. Both the original range and the RefRange
         will always have the exact same elements.
         Any operation done on one will affect the other.
     ))
     $(TR $(TD $(LREF repeat))
-        $(TD Creates a _range that consists of a single element repeated $(I n)
-        times, or an infinite _range repeating that element indefinitely.
+        $(TD Creates a range that consists of a single element repeated $(I n)
+        times, or an infinite range repeating that element indefinitely.
     ))
     $(TR $(TD $(LREF retro))
-        $(TD Iterates a bidirectional _range backwards.
+        $(TD Iterates a bidirectional range backwards.
     ))
     $(TR $(TD $(LREF roundRobin))
-        $(TD Given $(I n) ranges, creates a new _range that return the $(I n)
-        first elements of each _range, in turn, then the second element of each
-        _range, and so on, in a round-robin fashion.
+        $(TD Given $(I n) ranges, creates a new range that return the $(I n)
+        first elements of each range, in turn, then the second element of each
+        range, and so on, in a round-robin fashion.
     ))
     $(TR $(TD $(LREF sequence))
-        $(TD Similar to `recurrence`, except that a random-access _range is
+        $(TD Similar to `recurrence`, except that a random-access range is
         created.
     ))
     $(TR $(TD $(D $(LREF slide)))
-        $(TD Creates a _range that returns a fixed-size sliding window
-        over the original _range. Unlike chunks,
+        $(TD Creates a range that returns a fixed-size sliding window
+        over the original range. Unlike chunks,
         it advances a configurable number of items at a time,
         not one chunk at a time.
     ))
     $(TR $(TD $(LREF stride))
-        $(TD Iterates a _range with stride $(I n).
+        $(TD Iterates a range with stride $(I n).
     ))
     $(TR $(TD $(LREF tail))
-        $(TD Return a _range advanced to within `n` elements of the end of
-        the given _range.
+        $(TD Return a range advanced to within `n` elements of the end of
+        the given range.
     ))
     $(TR $(TD $(LREF take))
-        $(TD Creates a sub-_range consisting of only up to the first $(I n)
-        elements of the given _range.
+        $(TD Creates a sub-range consisting of only up to the first $(I n)
+        elements of the given range.
     ))
     $(TR $(TD $(LREF takeExactly))
-        $(TD Like `take`, but assumes the given _range actually has $(I n)
+        $(TD Like `take`, but assumes the given range actually has $(I n)
         elements, and therefore also defines the `length` property.
     ))
     $(TR $(TD $(LREF takeNone))
-        $(TD Creates a random-access _range consisting of zero elements of the
-        given _range.
+        $(TD Creates a random-access range consisting of zero elements of the
+        given range.
     ))
     $(TR $(TD $(LREF takeOne))
-        $(TD Creates a random-access _range consisting of exactly the first
-        element of the given _range.
+        $(TD Creates a random-access range consisting of exactly the first
+        element of the given range.
     ))
     $(TR $(TD $(LREF tee))
-        $(TD Creates a _range that wraps a given _range, forwarding along
+        $(TD Creates a range that wraps a given range, forwarding along
         its elements while also calling a provided function with each element.
     ))
     $(TR $(TD $(LREF transposed))
-        $(TD Transposes a _range of ranges.
+        $(TD Transposes a range of ranges.
     ))
     $(TR $(TD $(LREF transversal))
-        $(TD Creates a _range that iterates over the $(I n)'th elements of the
+        $(TD Creates a range that iterates over the $(I n)'th elements of the
         given random-access ranges.
     ))
     $(TR $(TD $(LREF zip))
-        $(TD Given $(I n) _ranges, creates a _range that successively returns a
+        $(TD Given $(I n) ranges, creates a range that successively returns a
         tuple of all the first elements, a tuple of all the second elements,
         etc.
     ))
@@ -212,12 +212,12 @@ Sortedness:
 
 Ranges whose elements are sorted afford better efficiency with certain
 operations. For this, the $(LREF assumeSorted) function can be used to
-construct a $(LREF SortedRange) from a pre-sorted _range. The $(REF
+construct a $(LREF SortedRange) from a pre-sorted range. The $(REF
 sort, std, algorithm, sorting) function also conveniently
 returns a $(LREF SortedRange). $(LREF SortedRange) objects provide some additional
-_range operations that take advantage of the fact that the _range is sorted.
+range operations that take advantage of the fact that the range is sorted.
 
-Source: $(PHOBOSSRC std/_range/_package.d)
+Source: $(PHOBOSSRC std/range/_package.d)
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
@@ -2906,23 +2906,23 @@ pure @safe nothrow unittest
 }
 
 /++
- + Return a _range advanced to within `_n` elements of the end of
- + `_range`.
+ + Return a range advanced to within `_n` elements of the end of
+ + `range`.
  +
- + Intended as the _range equivalent of the Unix
+ + Intended as the range equivalent of the Unix
  + $(HTTP en.wikipedia.org/wiki/Tail_%28Unix%29, _tail) utility. When the length
- + of `_range` is less than or equal to `_n`, `_range` is returned
+ + of `range` is less than or equal to `_n`, `range` is returned
  + as-is.
  +
  + Completes in $(BIGOH 1) steps for ranges that support slicing and have
- + length. Completes in $(BIGOH _range.length) time for all other ranges.
+ + length. Completes in $(BIGOH range.length) time for all other ranges.
  +
  + Params:
- +    range = _range to get _tail of
+ +    range = range to get _tail of
  +    n = maximum number of elements to include in _tail
  +
  + Returns:
- +    Returns the _tail of `_range` augmented with length information
+ +    Returns the _tail of `range` augmented with length information
  +/
 auto tail(Range)(Range range, size_t n)
 if (isInputRange!Range && !isInfinite!Range &&
@@ -3021,13 +3021,13 @@ pure @safe nothrow @nogc unittest
 
 /++
     Convenience function which calls
-    $(REF popFrontN, std, _range, primitives)`(range, n)` and returns `range`.
+    $(REF popFrontN, std, range, primitives)`(range, n)` and returns `range`.
     `drop` makes it easier to pop elements from a range
     and then pass it to another function within a single expression,
     whereas `popFrontN` would require multiple statements.
 
     `dropBack` provides the same functionality but instead calls
-    $(REF popBackN, std, _range, primitives)`(range, n)`
+    $(REF popBackN, std, range, primitives)`(range, n)`
 
     Note: `drop` and `dropBack` will only pop $(I up to)
     `n` elements but will stop if the range is empty first.
@@ -3041,7 +3041,7 @@ pure @safe nothrow @nogc unittest
         `range` with up to `n` elements dropped
 
     See_Also:
-        $(REF popFront, std, _range, primitives), $(REF popBackN, std, _range, primitives)
+        $(REF popFront, std, range, primitives), $(REF popBackN, std, range, primitives)
   +/
 R drop(R)(R range, size_t n)
 if (isInputRange!R)
@@ -3130,8 +3130,8 @@ if (isBidirectionalRange!R)
         `range` with `n` elements dropped
 
     See_Also:
-        $(REF popFrontExcatly, std, _range, primitives),
-        $(REF popBackExcatly, std, _range, primitives)
+        $(REF popFrontExcatly, std, range, primitives),
+        $(REF popBackExcatly, std, range, primitives)
 +/
 R dropExactly(R)(R range, size_t n)
 if (isInputRange!R)
@@ -4027,7 +4027,7 @@ private alias lengthType(R) = typeof(R.init.length.init);
    `foreach` iterations.
 
     Params:
-        sp = controls what `zip` will do if the _ranges are different lengths
+        sp = controls what `zip` will do if the ranges are different lengths
         ranges = the ranges to zip together
     Returns:
         At minimum, an input range. `Zip` offers the lowest range facilities
@@ -4036,7 +4036,7 @@ private alias lengthType(R) = typeof(R.init.length.init);
         it. Due to this, `Zip` is extremely powerful because it allows manipulating
         several ranges in lockstep.
     Throws:
-        An `Exception` if all of the _ranges are not the same length and
+        An `Exception` if all of the ranges are not the same length and
         `sp` is set to `StoppingPolicy.requireSameLength`.
 
     Limitations: The `@nogc` and `nothrow` attributes cannot be inferred for

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2,69 +2,69 @@
 This module is a submodule of $(MREF std, range).
 
 It provides basic range functionality by defining several templates for testing
-whether a given object is a _range, and what kind of _range it is:
+whether a given object is a range, and what kind of range it is:
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
     $(TR $(TD $(LREF isInputRange))
-        $(TD Tests if something is an $(I input _range), defined to be
+        $(TD Tests if something is an $(I input range), defined to be
         something from which one can sequentially read data using the
         primitives `front`, `popFront`, and `empty`.
     ))
     $(TR $(TD $(LREF isOutputRange))
-        $(TD Tests if something is an $(I output _range), defined to be
+        $(TD Tests if something is an $(I output range), defined to be
         something to which one can sequentially write data using the
         $(LREF put) primitive.
     ))
     $(TR $(TD $(LREF isForwardRange))
-        $(TD Tests if something is a $(I forward _range), defined to be an
-        input _range with the additional capability that one can save one's
+        $(TD Tests if something is a $(I forward range), defined to be an
+        input range with the additional capability that one can save one's
         current position with the `save` primitive, thus allowing one to
-        iterate over the same _range multiple times.
+        iterate over the same range multiple times.
     ))
     $(TR $(TD $(LREF isBidirectionalRange))
-        $(TD Tests if something is a $(I bidirectional _range), that is, a
-        forward _range that allows reverse traversal using the primitives $(D
+        $(TD Tests if something is a $(I bidirectional range), that is, a
+        forward range that allows reverse traversal using the primitives $(D
         back) and `popBack`.
     ))
     $(TR $(TD $(LREF isRandomAccessRange))
-        $(TD Tests if something is a $(I random access _range), which is a
-        bidirectional _range that also supports the array subscripting
+        $(TD Tests if something is a $(I random access range), which is a
+        bidirectional range that also supports the array subscripting
         operation via the primitive `opIndex`.
     ))
 )
 
-It also provides number of templates that test for various _range capabilities:
+It also provides number of templates that test for various range capabilities:
 
 $(BOOKTABLE ,
     $(TR $(TD $(LREF hasMobileElements))
-        $(TD Tests if a given _range's elements can be moved around using the
+        $(TD Tests if a given range's elements can be moved around using the
         primitives `moveFront`, `moveBack`, or `moveAt`.
     ))
     $(TR $(TD $(LREF ElementType))
-        $(TD Returns the element type of a given _range.
+        $(TD Returns the element type of a given range.
     ))
     $(TR $(TD $(LREF ElementEncodingType))
-        $(TD Returns the encoding element type of a given _range.
+        $(TD Returns the encoding element type of a given range.
     ))
     $(TR $(TD $(LREF hasSwappableElements))
-        $(TD Tests if a _range is a forward _range with swappable elements.
+        $(TD Tests if a range is a forward range with swappable elements.
     ))
     $(TR $(TD $(LREF hasAssignableElements))
-        $(TD Tests if a _range is a forward _range with mutable elements.
+        $(TD Tests if a range is a forward range with mutable elements.
     ))
     $(TR $(TD $(LREF hasLvalueElements))
-        $(TD Tests if a _range is a forward _range with elements that can be
+        $(TD Tests if a range is a forward range with elements that can be
         passed by reference and have their address taken.
     ))
     $(TR $(TD $(LREF hasLength))
-        $(TD Tests if a given _range has the `length` attribute.
+        $(TD Tests if a given range has the `length` attribute.
     ))
     $(TR $(TD $(LREF isInfinite))
-        $(TD Tests if a given _range is an $(I infinite _range).
+        $(TD Tests if a given range is an $(I infinite range).
     ))
     $(TR $(TD $(LREF hasSlicing))
-        $(TD Tests if a given _range supports the array slicing operation $(D
+        $(TD Tests if a given range supports the array slicing operation $(D
         R[x .. y]).
     ))
 )
@@ -73,33 +73,33 @@ Finally, it includes some convenience functions for manipulating ranges:
 
 $(BOOKTABLE ,
     $(TR $(TD $(LREF popFrontN))
-        $(TD Advances a given _range by up to $(I n) elements.
+        $(TD Advances a given range by up to $(I n) elements.
     ))
     $(TR $(TD $(LREF popBackN))
-        $(TD Advances a given bidirectional _range from the right by up to
+        $(TD Advances a given bidirectional range from the right by up to
         $(I n) elements.
     ))
     $(TR $(TD $(LREF popFrontExactly))
-        $(TD Advances a given _range by up exactly $(I n) elements.
+        $(TD Advances a given range by up exactly $(I n) elements.
     ))
     $(TR $(TD $(LREF popBackExactly))
-        $(TD Advances a given bidirectional _range from the right by exactly
+        $(TD Advances a given bidirectional range from the right by exactly
         $(I n) elements.
     ))
     $(TR $(TD $(LREF moveFront))
-        $(TD Removes the front element of a _range.
+        $(TD Removes the front element of a range.
     ))
     $(TR $(TD $(LREF moveBack))
-        $(TD Removes the back element of a bidirectional _range.
+        $(TD Removes the back element of a bidirectional range.
     ))
     $(TR $(TD $(LREF moveAt))
-        $(TD Removes the $(I i)'th element of a random-access _range.
+        $(TD Removes the $(I i)'th element of a random-access range.
     ))
     $(TR $(TD $(LREF walkLength))
-        $(TD Computes the length of any _range in O(n) time.
+        $(TD Computes the length of any range in O(n) time.
     ))
     $(TR $(TD $(LREF put))
-        $(TD Outputs element `e` to a _range.
+        $(TD Outputs element `e` to a range.
     ))
 )
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -4475,7 +4475,7 @@ if (isValidArgsForTrie!(Key, Args))
         monotonically increasing function that maps `Key` to an integer.
 
         See_Also: $(REF sort, std,_algorithm),
-        $(REF SortedRange, std,_range),
+        $(REF SortedRange, std,range),
         $(REF setUnion, std,_algorithm).
     */
     auto buildTrie(Range)(Range range, Value filler=Value.init)


### PR DESCRIPTION
A first start as finding all `_range` matches and going over the hits was easy.