### PR TITLE
Only run -dip1000 checks on CircleCi on not on the auto-tester

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -348,7 +348,7 @@ UT_D_OBJS:=$(addprefix $(ROOT)/unittest/,$(addsuffix .o,$(D_MODULES)))
 $(UT_D_OBJS): $(ALL_D_FILES)
 $(UT_D_OBJS): $(ROOT)/unittest/%.o: %.d
 	@mkdir -p $(dir $@)
-	$(DMD) $(DFLAGS) $(UDFLAGS) $(aa[$(subst /,.,$(basename $<))]) -c -of$@ $<
+	$(DMD) $(DFLAGS) $(UDFLAGS) -c -of$@ $<
 
 ifneq (1,$(SHARED))
 


### PR DESCRIPTION
It seems that there are still many issues with -dip1000 and for the time being it's apparentely better to only test the separate `.test` targets with -dip1000.
This is not ideal as -dip1000 is now only checked on Linux 64-bit, but before it wasn't run on Windows neither and -dip1000 is not very platform dependent.

This should hopefully unblock https://github.com/dlang/dmd/pull/8124

The only downside to this is that now a PR at dmd will no longer run Phobos with -dip1000 checks. We can either
- hope that no one will regress the CircleCi dip1000-enabled `*.test`
- let dmd's CircleCi run the `*.test` targets too
- fix the mangling issues with -dip1000 and re-enable the checking that this PR disables