### PR TITLE
Remove version(unittest) imports to avoid extra imports in user code.

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -640,9 +640,12 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && hasAssig
             // Loop invariant
             version(unittest)
             {
-                import std.algorithm.searching : all;
-                assert(r[0 .. lo].all!(x => !lt(p, x)));
-                assert(r[hi + 1 .. r.length].all!(x => !lt(x, p)));
+                // this used to import std.algorithm.all, but we want to save
+                // imports when unittests are enabled if possible.
+                foreach (x; r[0 .. lo])
+                    assert(!lt(p, x));
+                foreach (x; r[hi+1 .. r.length])
+                    assert(!lt(x, p));
             }
             do ++lo; while (lt(r[lo], p));
             r[hi] = r[lo];
@@ -3444,21 +3447,14 @@ done:
 {
     auto a = [ 10, 5, 3, 4, 8,  11,  13, 3, 9, 4, 10 ];
     assert(expandPartition!((a, b) => a < b)(a, 4, 5, 6) == 9);
-    a = randomArray;
+
+    import std.algorithm.iteration : map;
+    import std.random : uniform;
+    auto size = uniform(1, 1000);
+    a = iota(0, size).map!(_ => uniform(0, 1000)).array;
     if (a.length == 0) return;
     expandPartition!((a, b) => a < b)(a, a.length / 2, a.length / 2,
         a.length / 2 + 1);
-}
-
-version(unittest)
-private T[] randomArray(Flag!"exactSize" flag = No.exactSize, T = int)(
-    size_t maxSize = 1000,
-    T minValue = 0, T maxValue = 255)
-{
-    import std.algorithm.iteration : map;
-    import std.random : uniform;
-    auto size = flag == Yes.exactSize ? maxSize : uniform(1, maxSize);
-    return iota(0, size).map!(_ => uniform(minValue, maxValue)).array;
 }
 
 @safe unittest

--- a/std/array.d
+++ b/std/array.d
@@ -553,7 +553,8 @@ private template blockAttribute(T)
         enum blockAttribute = GC.BlkAttr.NO_SCAN;
     }
 }
-version(unittest)
+
+@safe unittest
 {
     import core.memory : UGC = GC;
     static assert(!(blockAttribute!void & UGC.BlkAttr.NO_SCAN));
@@ -572,7 +573,7 @@ private template nDimensions(T)
     }
 }
 
-version(unittest)
+@safe unittest
 {
     static assert(nDimensions!(uint[]) == 1);
     static assert(nDimensions!(float[][]) == 2);

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -60,15 +60,6 @@ $(TR $(TD Enums) $(TD
   +/
 module std.ascii;
 
-version(unittest)
-{
-    // FIXME: When dmd bug #314 is fixed, make these selective.
-    import std.meta; // : AliasSeq;
-    import std.range; // : chain;
-    import std.traits; // : functionAttributes, FunctionAttribute, isSafe;
-}
-
-
 immutable fullHexDigits  = "0123456789ABCDEFabcdef";     /// 0 .. 9A .. Fa .. f
 immutable hexDigits      = fullHexDigits[0 .. 16];         /// 0 .. 9A .. F
 immutable lowerHexDigits = "0123456789abcdef";           /// 0 .. 9a .. f
@@ -142,6 +133,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; chain(digits, octalDigits, fullHexDigits, letters, lowercase, uppercase))
         assert(isAlphaNum(c));
 
@@ -173,6 +165,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; chain(letters, lowercase, uppercase))
         assert(isAlpha(c));
 
@@ -204,6 +197,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; lowercase)
         assert(isLower(c));
 
@@ -235,6 +229,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; uppercase)
         assert(isUpper(c));
 
@@ -267,6 +262,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; digits)
         assert(isDigit(c));
 
@@ -296,6 +292,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; octalDigits)
         assert(isOctalDigit(c));
 
@@ -326,6 +323,7 @@ bool isHexDigit(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; fullHexDigits)
         assert(isHexDigit(c));
 
@@ -363,6 +361,7 @@ bool isWhite(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (c; whitespace)
         assert(isWhite(c));
 
@@ -399,6 +398,7 @@ bool isControl(dchar c) @safe pure nothrow @nogc
 
 @safe unittest
 {
+    import std.range;
     foreach (dchar c; 0 .. 32)
         assert(isControl(c));
     assert(isControl(127));
@@ -590,6 +590,7 @@ if (is(C : dchar))
 @safe pure nothrow unittest
 {
 
+    import std.meta;
     static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; uppercase)
@@ -651,6 +652,7 @@ if (is(C : dchar))
 
 @safe pure nothrow unittest
 {
+    import std.meta;
     static foreach (C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach (i, c; lowercase)
@@ -676,6 +678,9 @@ if (is(C : dchar))
 
 @safe unittest //Test both toUpper and toLower with non-builtin
 {
+    import std.meta;
+    import std.traits;
+
     //User Defined [Char|Wchar|Dchar]
     static struct UDC {  char c; alias c this; }
     static struct UDW { wchar c; alias c this; }

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -56,12 +56,6 @@ import std.range.primitives;
 public import std.system : Endian;
 import std.traits;
 
-version(unittest)
-{
-    import std.stdio;
-}
-
-
 private string myToString(ulong n)
 {
     import core.internal.string : UnsignedStringBuf, unsignedToTempString;
@@ -2770,6 +2764,7 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
 @safe unittest
 {
     import std.meta;
+    import std.stdio;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
     {{
         scope(failure) writeln("Failed type: ", T.stringof);
@@ -2898,6 +2893,7 @@ if (isFloatOrDouble!T)
 @safe unittest
 {
     import std.meta;
+    import std.stdio;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
                          char, wchar, dchar
         /* The trouble here is with floats and doubles being compared against nan
@@ -3072,6 +3068,7 @@ if (isFloatOrDouble!T)
 @safe unittest
 {
     import std.meta;
+    import std.stdio;
     static foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
                          char, wchar, dchar/*,
                          float, double*/))


### PR DESCRIPTION
Having imports in `version(unittest)` blocks means that user code being unit tested will also import these files incurring a compile-time penalty.

Should help with dlang/dmd#8124 a bit, at least for the `version(unittest)` portion.

I will submit more PRs for the rest of Phobos, I wanted to make these PRs small and reviewable.