### PR TITLE
Trim as much version(unittest) as possible from allocator

### DIFF
--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -7,7 +7,6 @@ module std.experimental.allocator.building_blocks.allocator_list;
 import std.experimental.allocator.building_blocks.null_allocator;
 import std.experimental.allocator.common;
 import std.experimental.allocator.gc_allocator;
-version(unittest) import std.stdio;
 
 // Turn this on for debugging
 // debug = allocator_list;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -53,7 +53,6 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     import std.typecons : Ternary;
     import std.typecons : tuple, Tuple;
 
-    version(unittest)
     @system unittest
     {
         import std.algorithm.comparison : max;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -29,7 +29,6 @@ struct FallbackAllocator(Primary, Fallback)
 
     // Need both allocators to be stateless
     // This is to avoid using default initialized stateful allocators
-    version(unittest)
     static if (!stateSize!Primary && !stateSize!Fallback)
     @system unittest
     {

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -120,7 +120,6 @@ struct FreeList(ParentAllocator,
             _max = high;
         }
 
-        version(unittest)
         @system unittest
         {
             import std.experimental.allocator.common : chooseAtRuntime;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -335,7 +335,6 @@ struct FreeTree(ParentAllocator)
         return true;
     }
 
-    version(unittest)
     @system unittest // test a few simple configurations
     {
         import std.experimental.allocator.gc_allocator;
@@ -357,7 +356,6 @@ struct FreeTree(ParentAllocator)
         assert(a.formatSizes == "(_)", a.formatSizes);
     }
 
-    version(unittest)
     @system unittest // build a complex free tree
     {
         import std.experimental.allocator.gc_allocator, std.range;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -6,7 +6,6 @@ module std.experimental.allocator.building_blocks.kernighan_ritchie;
 import std.experimental.allocator.building_blocks.null_allocator;
 
 //debug = KRRegion;
-version(unittest) import std.conv : text;
 debug(KRRegion) import std.stdio;
 
 // KRRegion
@@ -554,7 +553,6 @@ struct KRRegion(ParentAllocator = NullAllocator)
     }
 
     ///
-    version(unittest)
     @system unittest
     {
         import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -776,7 +774,7 @@ it actually returns memory to the operating system when possible.
     auto p = cast(KRRegion!()* ) store.ptr;
     import core.stdc.string : memcpy;
     import std.algorithm.mutation : move;
-    import std.conv : emplace;
+    import std.conv : text, emplace;
 
     memcpy(p, &alloc, alloc.sizeof);
     emplace(&alloc);

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -23,7 +23,6 @@ struct ScopedAllocator(ParentAllocator)
     static if (!stateSize!ParentAllocator)
     {
         // This test is available only for stateless allocators
-        version(unittest)
         @system unittest
         {
             testAllocator!(() => ScopedAllocator());

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -612,7 +612,7 @@ version(unittest)
         // unnecessary import of std.experimental.allocator
         import std.experimental.allocator : RCIAllocator, RCISharedAllocator;
         static assert(is(RCAllocInterface == RCIAllocator)
-            || is (RCAllocInterface == shared RCISharedAllocator));
+            || is (RCAllocInterface == RCISharedAllocator));
 
         import std.conv : text;
         import std.math : isPowerOf2;

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -481,7 +481,6 @@ Forwards each of the methods in `funs` (if defined) to `member`.
 
 version(unittest)
 {
-    import std.experimental.allocator : RCIAllocator, RCISharedAllocator;
 
     package void testAllocator(alias make)()
     {
@@ -608,9 +607,13 @@ version(unittest)
     }
 
     package void testAllocatorObject(RCAllocInterface)(RCAllocInterface a)
-    if (is(RCAllocInterface == RCIAllocator)
-        || is (RCAllocInterface == shared RCISharedAllocator))
     {
+        // this used to be a template constraint, but moving it inside prevents
+        // unnecessary import of std.experimental.allocator
+        import std.experimental.allocator : RCIAllocator, RCISharedAllocator;
+        static assert(is(RCAllocInterface == RCIAllocator)
+            || is (RCAllocInterface == shared RCISharedAllocator));
+
         import std.conv : text;
         import std.math : isPowerOf2;
         import std.stdio : writeln, stderr;

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -394,7 +394,7 @@ version(CRuntime_DigitalMars)
 {
     void* m;
 
-    alias m_addr = () => cast(size_t) m;
+    size_t m_addr() { return cast(size_t) m; }
 
     m = _aligned_malloc(16, 0x10);
     if (m)

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -12,7 +12,6 @@ import std.experimental.allocator.common;
  */
 struct Mallocator
 {
-    version(unittest)
     @system unittest { testAllocator!(() => Mallocator.instance); }
 
     /**
@@ -363,10 +362,6 @@ version(LDC_AddressSanitizer)
     //...
 }
 
-version(unittest) version(CRuntime_DigitalMars)
-@nogc nothrow
-size_t addr(ref void* ptr) { return cast(size_t) ptr; }
-
 version(Posix)
 @nogc @system nothrow unittest
 {
@@ -399,24 +394,27 @@ version(CRuntime_DigitalMars)
 {
     void* m;
 
+    @nogc nothrow
+        size_t addr() { return cast(size_t) m; }
+
     m = _aligned_malloc(16, 0x10);
     if (m)
     {
-        assert((m.addr & 0xF) == 0);
+        assert((addr & 0xF) == 0);
         _aligned_free(m);
     }
 
     m = _aligned_malloc(16, 0x100);
     if (m)
     {
-        assert((m.addr & 0xFF) == 0);
+        assert((addr & 0xFF) == 0);
         _aligned_free(m);
     }
 
     m = _aligned_malloc(16, 0x1000);
     if (m)
     {
-        assert((m.addr & 0xFFF) == 0);
+        assert((addr & 0xFFF) == 0);
         _aligned_free(m);
     }
 
@@ -425,7 +423,7 @@ version(CRuntime_DigitalMars)
     {
         assert((cast(size_t) m & 0xF) == 0);
         m = _aligned_realloc(m, 32, 0x10000);
-        if (m) assert((m.addr & 0xFFFF) == 0);
+        if (m) assert((addr & 0xFFFF) == 0);
         _aligned_free(m);
     }
 

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -394,27 +394,26 @@ version(CRuntime_DigitalMars)
 {
     void* m;
 
-    @nogc nothrow
-        size_t addr() { return cast(size_t) m; }
+    alias m_addr = () => cast(size_t) m;
 
     m = _aligned_malloc(16, 0x10);
     if (m)
     {
-        assert((addr & 0xF) == 0);
+        assert((m_addr & 0xF) == 0);
         _aligned_free(m);
     }
 
     m = _aligned_malloc(16, 0x100);
     if (m)
     {
-        assert((addr & 0xFF) == 0);
+        assert((m_addr & 0xFF) == 0);
         _aligned_free(m);
     }
 
     m = _aligned_malloc(16, 0x1000);
     if (m)
     {
-        assert((addr & 0xFFF) == 0);
+        assert((m_addr & 0xFFF) == 0);
         _aligned_free(m);
     }
 
@@ -423,7 +422,7 @@ version(CRuntime_DigitalMars)
     {
         assert((cast(size_t) m & 0xF) == 0);
         m = _aligned_realloc(m, 32, 0x10000);
-        if (m) assert((addr & 0xFFFF) == 0);
+        if (m) assert((m_addr & 0xFFFF) == 0);
         _aligned_free(m);
     }
 


### PR DESCRIPTION
Most of the `version(unittest)` stuff here is not needed at all (there's no reason to guard unittests with `version(unittest)`).

A couple of the changes are not trivial, however.

See #6450 for more details.