### PR TITLE
In std.conv.emplaceInitializer use memset instead of memcpy when setting all 0s

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -4360,15 +4360,23 @@ if (is(UT == Unqual!UT))
 }
 
 //emplace helper functions
-private void emplaceInitializer(T)(ref T chunk) @trusted pure nothrow
+private void emplaceInitializer(T)(scope ref T chunk) @trusted pure nothrow
 {
     static if (!hasElaborateAssign!T && isAssignable!T)
         chunk = T.init;
     else
     {
-        import core.stdc.string : memcpy;
-        static immutable T init = T.init;
-        memcpy(&chunk, &init, T.sizeof);
+        static if (__traits(isZeroInit, T))
+        {
+            import core.stdc.string : memset;
+            memset(&chunk, 0, T.sizeof);
+        }
+        else
+        {
+            import core.stdc.string : memcpy;
+            static immutable T init = T.init;
+            memcpy(&chunk, &init, T.sizeof);
+        }
     }
 }
 


### PR DESCRIPTION
In std.conv.emplaceInitializer use memset instead of memcpy when setting all 0s.

~~This PR also moves `isInitAllZeroBits` from std.experimental.allocator.common to ~~std.conv~~ **EDIT: `std.traits`** to avoid making everything that uses `std.conv` also depend on `std.experimental.allocator.common`. The visibility remains `package`.~~

EDIT2: The above remark is obsolete. This PR uses the new `__traits(isZeroInit)`.