### PR TITLE
Issue 18471

### DIFF
--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -293,26 +293,22 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     {
         static if (isIntegral!U)
         {
-            auto val = rhs;
+            payload = rhs;
         }
         else
         {
-            auto val = rhs.payload;
+            payload = rhs.payload;
         }
 
         static if (hasMember!(Hook, "min") && hasMember!(Hook, "onLowerBound") &&
-            (ProperCompare.hookOpCmp(val, hook.min!T) < 0))
+            (ProperCompare.hookOpCmp(payload, hook.min!T) < 0))
         {
-            payload = hook.onLowerBound(val, hook.min!T);
+            payload = hook.onLowerBound(payload, hook.min!T);
         }
         static if (hasMember!(Hook, "max") && hasMember!(Hook, "onUpperBound") &&
-            (ProperCompare.hookOpCmp(val, hook.max!T) > 0))
+            (ProperCompare.hookOpCmp(payload, hook.max!T) > 0))
         {
-            payload = hook.onUpperBound(val, hook.max!T);
-        }
-        else
-        {
-            payload = val;
+            payload = hook.onUpperBound(payload, hook.max!T);
         }
     }
     ///
@@ -331,26 +327,22 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     {
         static if (isIntegral!U)
         {
-            auto val = rhs;
+            payload = rhs;
         }
         else
         {
-            auto val = rhs.payload;
+            payload = rhs.payload;
         }
 
         static if (hasMember!(Hook, "min") && hasMember!(Hook, "onLowerBound") &&
-            (ProperCompare.hookOpCmp(val, hook.min!T) < 0))
+            (ProperCompare.hookOpCmp(payload, hook.min!T) < 0))
         {
-            payload = hook.onLowerBound(val, hook.min!T);
+            payload = hook.onLowerBound(payload, hook.min!T);
         }
         static if (hasMember!(Hook, "max") && hasMember!(Hook, "onUpperBound") &&
-            (ProperCompare.hookOpCmp(val, hook.max!T) > 0))
+            (ProperCompare.hookOpCmp(payload, hook.max!T) > 0))
         {
-            payload = hook.onUpperBound(val, hook.max!T);
-        }
-        else
-        {
-            payload = val;
+            payload = hook.onUpperBound(payload, hook.max!T);
         }
     }
     ///

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -1030,7 +1030,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             assert(0);
         }
     }
-    assertThrown!AssertError(Checked!(int, MyHook)(0));
+    assertThrown!AssertError({ auto a = Checked!(int, MyHook)(0); }());
     assertThrown!AssertError({ auto a = Checked!(int, MyHook)(101); }());
     Checked!(int, MyHook) a = 10;
     assertThrown!AssertError(a = 101);


### PR DESCRIPTION
Added std.experimental.checkedint support for constructing or assigning a Checked!int with a custom hook that defines min and max. These defined min and max values are no longer ignored. The constructor and the assignment value are compared to these values and if defined, the `onLowerBound` and `onUpperBound` methods are triggered when `value < min` or `value > max` . 