### PR TITLE
fix conversion from wchar to char in LockingTextWriter.put

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2926,8 +2926,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
             }
             else static if (c.sizeof == 2)
             {
-                import std.utf : encode;
-                import std.utf : decodeFront;
+                import std.utf : decodeFront, encode;
 
                 if (orientation_ <= 0)
                 {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2861,6 +2861,9 @@ is empty, throws an `Exception`. In case of an I/O error throws
             {
                 if (p.handle) FUNLOCK(p.handle);
             }
+            file_ = File.init;
+                /* Destroy file_ before possibly throwing. Else it wouldn't be
+                destroyed, and its reference count would be wrong. */
             rbuf16ShouldBeEmpty();
         }
 
@@ -3473,7 +3476,6 @@ void main()
             assertThrown!UTFException(writer.put(dchar('y')));
             assertThrown!UTFException(writer.put(surr));
         } ());
-        f.close(); // No idea why this is needed.
     }
     assert(std.file.readText!string(deleteme) == "x");
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2926,7 +2926,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
             }
             else static if (c.sizeof == 2)
             {
-                import std.utf : decodeFront, encode;
+                import std.utf : encode;
 
                 if (orientation_ <= 0)
                 {
@@ -2942,11 +2942,13 @@ is empty, throws an `Exception`. In case of an I/O error throws
                     }
                     else // standalone or low surrogate
                     {
-                        immutable wchar[2] rbuf = [highSurrogate, c];
-                        wstring str = rbuf[highSurrogate == '\0' ? 1 : 0 .. $];
-                            // Skipping the high surrogate when there's none.
-                        highSurrogate = '\0';
-                        immutable dchar d = decodeFront(str);
+                        dchar d = c;
+                        if (highSurrogate != '\0')
+                        {
+                            immutable wchar[2] rbuf = [highSurrogate, c];
+                            d = rbuf[].front;
+                            highSurrogate = 0;
+                        }
                         char[4] wbuf;
                         immutable size = encode(wbuf, d);
                         foreach (i; 0 .. size)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3475,6 +3475,9 @@ void main()
             assertThrown!UTFException(writer.put(wchar('y')));
             assertThrown!UTFException(writer.put(dchar('y')));
             assertThrown!UTFException(writer.put(surr));
+            // First `surr` is still unpaired at this point. `writer` gets
+            // destroyed now, and the destructor throws a UTFException for
+            // the unpaired surrogate.
         } ());
     }
     assert(std.file.readText!string(deleteme) == "x");


### PR DESCRIPTION
Spin-off from #6469. I'm hoping that this will be relatively easy to get to work on the different platforms.

Instead of throwing a UTFException on unpaired high surrogates, a replacement character could be written. But throwing is what happens currently for unpaired low surrogates, so I went with that.