### PR TITLE
[Trivial] zip & zlib: don't zero-fill buffers before writing to them

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -414,7 +414,7 @@ final class ZipArchive
      */
     void[] build() @safe pure
     {
-        import std.array : array;
+        import std.array : array, uninitializedArray;
         import std.algorithm.sorting : sort;
         import std.string : representation;
 
@@ -449,7 +449,7 @@ final class ZipArchive
         if (isZip64)
             dataSize += eocd64LocLength + eocd64Length;
 
-        _data = new ubyte[dataSize];
+        _data = uninitializedArray!(ubyte[])(dataSize);
 
         // Populate the data[]
 

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -201,8 +201,9 @@ in
 do
 {
     import core.memory : GC;
+    import std.array : uninitializedArray;
     auto destlen = srcbuf.length + ((srcbuf.length + 1023) / 1024) + 12;
-    auto destbuf = new ubyte[destlen];
+    auto destbuf = uninitializedArray!(ubyte[])(destlen);
     auto err = etc.c.zlib.compress2(destbuf.ptr, &destlen, cast(ubyte *) srcbuf.ptr, srcbuf.length, level);
     if (err)
     {
@@ -411,6 +412,7 @@ class Compress
     const(void)[] compress(const(void)[] buf)
     {
         import core.memory : GC;
+        import std.array : uninitializedArray;
         int err;
         ubyte[] destbuf;
 
@@ -425,7 +427,7 @@ class Compress
             inited = 1;
         }
 
-        destbuf = new ubyte[zs.avail_in + buf.length];
+        destbuf = uninitializedArray!(ubyte[])(zs.avail_in + buf.length);
         zs.next_out = destbuf.ptr;
         zs.avail_out = to!uint(destbuf.length);
 
@@ -586,6 +588,7 @@ class UnCompress
             return null;
 
         import core.memory : GC;
+        import std.array : uninitializedArray;
         int err;
 
         if (!inited)
@@ -604,7 +607,7 @@ class UnCompress
 
         if (!destbufsize)
             destbufsize = to!uint(buf.length) * 2;
-        auto destbuf = new ubyte[destbufsize];
+        auto destbuf = uninitializedArray!(ubyte[])(destbufsize);
         size_t destFill;
 
         zs.next_in = cast(ubyte*) buf.ptr;


### PR DESCRIPTION
The buffers are file-sized so it's worth skipping unneeded initialization.

This PR doesn't make this change for `std.zlib.uncompress`.