### PR TITLE
Fix std.math.log1p() unittest

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3813,7 +3813,7 @@ real log1p(real x) @safe pure nothrow @nogc
     assert(log1p(1.0).feqrel(0.69314) > 16);
 
     assert(log1p(-1.0) == -real.infinity);
-    assert(log1p(-2.0) is -real.nan);
+    assert(isNaN(log1p(-2.0)));
     assert(log1p(real.nan) is real.nan);
     assert(log1p(-real.nan) is -real.nan);
     assert(log1p(real.infinity) == real.infinity);


### PR DESCRIPTION
`log1p(-2.0)` returns +NaN for the non-x87 software implementation, and so does the MSVC runtime function. The x87 asm implementation and libm on Linux return -NaN. So just ignore the sign.