### PR TITLE
std.math: Change fmin/fmax semantics wrt. NaNs

### DIFF
--- a/changelog/std-math-fminmax.dd
+++ b/changelog/std-math-fminmax.dd
@@ -1,0 +1,19 @@
+Changed semantics of std.math.{fmin,fmax} wrt. NaNs.
+
+The semantics of $(REF fmin, std, math) and $(REF fmax, std, math) have been
+streamlined with the C functions: if one of the arguments is a NaN, return the
+other. This involves an additional $(REF isNaN, std, math) check. Use
+$(REF min, std, algorithm, comparison) and $(REF max, std, algorithm, comparison)
+for the previous semantics performing a single comparison.
+
+---
+import std.math;
+assert(fmin(real.nan, 2.0L) == 2.0L);
+assert(fmin(2.0L, real.nan) == 2.0L); // previously: NaN
+assert(isNaN(fmin(real.nan, real.nan)));
+
+import std.algorithm.comparison;
+assert(min(real.nan, 2.0L) == 2.0L);
+assert(isNaN(min(2.0L, real.nan)));
+assert(isNaN(min(real.nan, real.nan)));
+---

--- a/std/math.d
+++ b/std/math.d
@@ -6922,8 +6922,13 @@ real fdim(real x, real y) @safe pure nothrow @nogc { return (x > y) ? x - y : +0
 
 /**
  * Returns the larger of x and y.
+ *
+ * If one of the arguments is a NaN, the other is returned.
  */
-real fmax(real x, real y) @safe pure nothrow @nogc { return x > y ? x : y; }
+real fmax(real x, real y) @safe pure nothrow @nogc
+{
+    return (y > x || isNaN(x)) ? y : x;
+}
 
 ///
 @safe pure nothrow @nogc unittest
@@ -6932,13 +6937,18 @@ real fmax(real x, real y) @safe pure nothrow @nogc { return x > y ? x : y; }
     assert(fmax(-2.0, 0.0) == 0.0);
     assert(fmax(real.infinity, 2.0) == real.infinity);
     assert(fmax(real.nan, 2.0) == 2.0);
-    assert(fmax(2.0, real.nan) is real.nan);
+    assert(fmax(2.0, real.nan) == 2.0);
 }
 
 /**
  * Returns the smaller of x and y.
+ *
+ * If one of the arguments is a NaN, the other is returned.
  */
-real fmin(real x, real y) @safe pure nothrow @nogc { return x < y ? x : y; }
+real fmin(real x, real y) @safe pure nothrow @nogc
+{
+    return (y < x || isNaN(x)) ? y : x;
+}
 
 ///
 @safe pure nothrow @nogc unittest
@@ -6947,7 +6957,7 @@ real fmin(real x, real y) @safe pure nothrow @nogc { return x < y ? x : y; }
     assert(fmin(-2.0, 0.0) == -2.0);
     assert(fmin(real.infinity, 2.0) == 2.0);
     assert(fmin(real.nan, 2.0) == 2.0);
-    assert(fmin(2.0, real.nan) is real.nan);
+    assert(fmin(2.0, real.nan) == 2.0);
 }
 
 /**************************************


### PR DESCRIPTION
If one of the arguments is a NaN, return the other. These are the C99 semantics; the previous simple ternary expression is covered by `std.algorithm.min/max`.