### PR TITLE
Fix std.variant unittest

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1218,7 +1218,7 @@ public:
 ///
 @system unittest
 {
-    alias Var = VariantN!(maxSize!(int, real, double));
+    alias Var = VariantN!(maxSize!(int, double, string));
 
     Var a; // Must assign before use, otherwise exception ensues
     // Initialize with an integer; make the type int


### PR DESCRIPTION
For all 64-bit targets with `real.sizeof` < 16, e.g., Win64 MSVC for LDC.