### PR TITLE
Fix stdio File.open / resetFile / detach / refcount

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -510,17 +510,12 @@ Throws: `ErrnoException` in case of error.
         import std.conv : text;
         import std.exception : errnoEnforce;
 
-        if (_p is null)
+        if (_p !is null)
         {
-            _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
-        }
-        {
-            if (atomicOp!"-="(_p.refs, 1) == 0)
-                closeHandles();
-            else
-                _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
+            detach();
         }
 
+        _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
         FILE* handle;
         version (Posix)
         {


### PR DESCRIPTION
Since https://github.com/dlang/phobos/pull/6382 was merged running phobos unittests will cause this (on DFly):
```
generated/dragonflybsd/debug/64/unittest/test_runner std.experimental.logger.core
****** FAIL debug64 std.experimental.logger.core
std.exception.ErrnoException@std/stdio.d(566): Could not close pipe `' (File exists)
----------------
std/exception.d:515 _init [0x5fe7c9]
std/exception.d:436 _init [0xb32e0e]
std/stdio.d:566 _init [0xd46333]
std/stdio.d:519 _init [0xd46099]
std/stdio.d:503 _init [0xd4600f]
std/experimental/logger/filelogger.d:83 _init [0x1ffe180]
std/experimental/logger/filelogger.d:42 _init [0x1ffe023]
std/experimental/logger/core.d:1808 _init [0x1fba600]
gmake[1]: *** [posix.mak:381: unittest/std/experimental/logger/core.run] Error 1
```
Looking at the sources the resetFile function looks suspect:
Orig source:
```
        ....
        if (_p is null)
        {
           _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
            detach();
        }
        {
            if (atomicOp!"-="(_p.refs, 1) == 0)
                closeHandles();
            else
                _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
        }
        ....
```
Notice, there is no else between these two blocks, so we always decrement _p.refs after the initial allocation of _p, which does not make sense. Just adding 'else' inbetween these blocks is not going to help.

If this decrement does not make the refs go to zero, we malloc _p again (memory leak ?). In short, if we are not (re-)opening a previously opened file, this results in malloc/free/malloc. If there was a previously open file (ie: _p ! is null) and only a single reference (refs==1) then we close the previous file, but do not malloc _p again before using it (null dereference down the line ?). If there were more references, we decrement the refcount by one and then malloc _p a second time. None of this really makes a lot of sense (to me, but maybe i am just missing something). 

Reusing the detach function instead of trying to re-implement seems like the right choice in this situation.

BTW: Would it have been possible to use [std/typecons RefCounted](https://dlang.org/phobos/std_typecons.html#RefCounted) instead of reimplementing it locally/partially ?