### PR TITLE
logger update

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -203,7 +203,7 @@ PACKAGE_std_container = array binaryheap dlist package rbtree slist util
 PACKAGE_std_datetime = date interval package stopwatch systime timezone
 PACKAGE_std_digest = crc hmac md murmurhash package ripemd sha
 PACKAGE_std_experimental_logger = core filelogger \
-  nulllogger multilogger package
+  nulllogger multilogger package alloclogger
 PACKAGE_std_experimental_allocator = \
   common gc_allocator mallocator mmap_allocator package showcase typed
 PACKAGE_std_experimental_allocator_building_blocks = \

--- a/std/experimental/logger/alloclogger.d
+++ b/std/experimental/logger/alloclogger.d
@@ -1,0 +1,152 @@
+// Written in the D programming language.
+/**
+Source: $(PHOBOSSRC std/experimental/logger/_nulllogger.d)
+*/
+module std.experimental.logger.alloclogger;
+
+import std.experimental.logger.core;
+
+private struct AllocOutRange(Alloc)
+{
+    Alloc* alloc;
+    char[]* str;
+    static AllocOutRange!(Alloc) opCall(Alloc* alloc, char[]* str)
+    {
+        typeof(return) ret;
+        ret.alloc = alloc;
+        ret.str = str;
+        return ret;
+    }
+
+    void put(const(char)[] msg)
+    {
+        import std.experimental.allocator : expandArray;
+        import std.exception : enforce;
+        import std.stdio;
+        size_t oldLen = str.length;
+        enforce(expandArray(*(this.alloc), *(this.str), msg.length));
+        (*this.str)[oldLen - 1 .. $ - 1] = msg;
+    }
+}
+
+unittest
+{
+    import std.experimental.allocator : theAllocator;
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.range : isOutputRange;
+    static assert(isOutputRange!(
+                AllocOutRange!(typeof(GCAllocator.instance)), string)
+            );
+    static assert(isOutputRange!(
+                AllocOutRange!(typeof(theAllocator)), string)
+            );
+}
+
+/** The `AllocLogger` will save the log messages to the array `output`.
+This array is allocated by the passed Allocator `alloc`.
+*/
+class AllocLogger(Alloc) : Logger
+{
+    import std.concurrency : Tid;
+    import std.format : formattedWrite;
+    import std.datetime.systime : SysTime;
+
+    /// The allocator used to alloc memory for log messages
+    Alloc alloc;
+
+    AllocOutRange!(Alloc) oRange;
+
+    char[] output;
+
+    /** The default constructor for the `AllocLogger`.
+
+    Independent of the parameter this Logger will never log a message.
+
+    Params:
+      alloc = The Allocator to use.
+      lv = The `LogLevel` for the `AllocLogger`. By default the `LogLevel`
+      for `AllocLogger` is `LogLevel.all`.
+    */
+    this(Alloc alloc, const LogLevel lv = LogLevel.all)
+    {
+        import std.experimental.allocator : makeArray;
+        super(lv);
+        this.alloc = alloc;
+        this.output = this.alloc.makeArray!char(1);
+        this.oRange = AllocOutRange!(Alloc)(&this.alloc, &this.output);
+        this.fatalHandler = delegate() {};
+    }
+
+    override void beginLogMsg(string file, int line, string funcName,
+        string prettyFuncName, string moduleName, LogLevel logLevel,
+        Tid threadId, SysTime timestamp, Logger logger) @safe
+    {
+        this.curMsgLogLevel = logLevel;
+        if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel))
+        {
+            import std.string : lastIndexOf;
+            ptrdiff_t fnIdx = file.lastIndexOf('/') + 1;
+            ptrdiff_t funIdx = funcName.lastIndexOf('.') + 1;
+
+            ()@trusted
+            {
+                systimeToISOString(this.oRange, timestamp);
+                formattedWrite(this.oRange, ":%s:%s:%u ", file[fnIdx .. $],
+                    funcName[funIdx .. $], line);
+            }();
+        }
+    }
+
+    /** Logs a part of the log message. */
+    override void logMsgPart(scope const(char)[] msg) @safe
+    {
+        if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel))
+        {
+            () @trusted
+            {
+                formattedWrite(this.oRange, msg);
+            }();
+        }
+    }
+
+    /** Signals that the message has been written and no more calls to
+    $(D logMsgPart) follow. */
+    override void finishLogMsg() @safe
+    {
+        if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel))
+        {
+            () @trusted
+            {
+                formattedWrite(this.oRange, "\n");
+            }();
+        }
+    }
+}
+
+///
+unittest
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    import std.experimental.allocator : theAllocator;
+    import std.experimental.logger.core : LogLevel;
+    import std.algorithm.searching : canFind;
+
+    void test(Alloc)(auto ref Alloc alloc)
+    {
+        auto nl1 = new AllocLogger!(Alloc)(alloc, LogLevel.all);
+        auto msgs = ["You will never read this.",
+             "You will never read this, and it will not throw"
+            ];
+        foreach (msg; msgs)
+        {
+            nl1.info(msg);
+        }
+        foreach (msg; msgs)
+        {
+            assert(canFind(nl1.output, msg));
+        }
+    }
+
+    test(GCAllocator.instance);
+    test(theAllocator);
+}

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -641,7 +641,7 @@ private struct MsgRange
         this.log = log;
     }
 
-    void put(T)(T msg) @safe
+    void put(T)(T msg)
         if (isSomeString!T)
     {
         log.logMsgPart(msg);
@@ -796,8 +796,7 @@ abstract class Logger
     */
     abstract void beginLogMsg(string file, int line, string funcName,
         string prettyFuncName, string moduleName, LogLevel logLevel,
-        Tid threadId, SysTime timestamp, Logger logger)
-        @safe;
+        Tid threadId, SysTime timestamp, Logger logger) @safe;
 
     /** Logs a part of the log message. */
     abstract void logMsgPart(scope const(char)[] msg) @safe;
@@ -1632,7 +1631,6 @@ class StdForwardLogger : Logger
     protected override void beginLogMsg(string file, int line, string funcName,
         string prettyFuncName, string moduleName, LogLevel ll,
         Tid threadId, SysTime timestamp, Logger logger)
-        @safe
     {
 
         sharedLog.beginLogMsg(file, line, funcName, prettyFuncName,
@@ -1748,7 +1746,6 @@ package class TestLogger : Logger
     protected override void beginLogMsg(string file, int line, string funcName,
         string prettyFuncName, string moduleName, LogLevel ll,
         Tid threadId, SysTime timestamp, Logger logger)
-        @safe
     {
         super.curMsgLogLevel = ll;
         if (isLoggingEnabled(super.curMsgLogLevel, this.logLevel, globalLogLevel))
@@ -1770,7 +1767,7 @@ package class TestLogger : Logger
         }
     }
 
-    override void finishLogMsg() @safe
+    override void finishLogMsg()
     {
         if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel)
             && super.curMsgLogLevel == LogLevel.fatal)
@@ -2579,7 +2576,6 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
         override void beginLogMsg(string file, int line, string funcName,
             string prettyFuncName, string moduleName, LogLevel ll,
             Tid threadId, SysTime timestamp, Logger logger)
-            @safe
         {
             this.curMsgLogLevel = ll;
             () @trusted { assert(thisTid == this.tid); }();
@@ -2587,13 +2583,13 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
         }
 
         /** Logs a part of the log message. */
-        override void logMsgPart(scope const(char)[] msg) @safe
+        override void logMsgPart(scope const(char)[] msg)
         {
         }
 
         /** Signals that the message has been written and no more calls to
         $(D logMsgPart) follow. */
-        override void finishLogMsg() @safe
+        override void finishLogMsg()
         {
         }
     }
@@ -2608,20 +2604,19 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
         override void beginLogMsg(string file, int line, string funcName,
             string prettyFuncName, string moduleName, LogLevel ll,
             Tid threadId, SysTime timestamp, Logger logger)
-            @safe
         {
             assert(false);
         }
 
         /** Logs a part of the log message. */
-        override void logMsgPart(scope const(char)[] msg) @safe
+        override void logMsgPart(scope const(char)[] msg)
         {
             assert(false);
         }
 
         /** Signals that the message has been written and no more calls to
         $(D logMsgPart) follow. */
-        override void finishLogMsg() @safe
+        override void finishLogMsg()
         {
             assert(false);
         }

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1635,7 +1635,6 @@ class StdForwardLogger : Logger
         @safe
     {
 
-        import std.stdio;
         sharedLog.beginLogMsg(file, line, funcName, prettyFuncName,
                 moduleName, ll, threadId, timestamp, logger);
     }
@@ -1751,7 +1750,6 @@ package class TestLogger : Logger
         Tid threadId, SysTime timestamp, Logger logger)
         @safe
     {
-        import std.stdio;
         super.curMsgLogLevel = ll;
         if (isLoggingEnabled(super.curMsgLogLevel, this.logLevel, globalLogLevel))
         {
@@ -2111,7 +2109,7 @@ version(unittest) private void testFuncNames(Logger logger) @safe
     assert(tl.line == l+1, to!string(tl.line));
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown;
     globalLogLevel = LogLevel.fatal;
@@ -2120,7 +2118,7 @@ unittest
     assertThrown!Throwable(mem.fatal("This should throw"));
 }
 
-unittest
+@system unittest
 {
     import std.exception : assertThrown, assertNotThrown;
     import std.conv : to;
@@ -2180,22 +2178,29 @@ unittest
                                 //    gll, ll, cond, condValue, memOrG, prntf,
                                 //    ll2, shouldLog
                                 //);
-                                if(ll2 == LogLevel.fatal) {
-                                    if(shouldLog) {
+                                if (ll2 == LogLevel.fatal)
+                                {
+                                    if (shouldLog)
+                                    {
                                         assertThrown!Throwable(
                                         testLogger(mem, cond, condValue, memOrG,
                                                prntf, ll2, value)
                                         );
-                                    } else {
+                                    }
+                                    else
+                                    {
                                         assertNotThrown(
                                         testLogger(mem, cond, condValue, memOrG,
                                                prntf, ll2, value)
                                         );
                                     }
-                                } else {
+                                }
+                                else
+                                {
                                     int line = testLogger(mem, cond,
                                         condValue, memOrG, prntf, ll2, value);
-                                    if(shouldLog) {
+                                    if (shouldLog)
+                                    {
                                         assert(mem.msg == to!string(value));
                                         assert(mem.lvl == ll2);
                                         ++value;
@@ -2215,45 +2220,68 @@ private int testLogger(Logger mem, bool cond, bool condValue, bool memOrG,
         bool prntf, LogLevel ll2, int value) @safe
 {
     import std.conv : to;
-    import std.stdio;
-    if(prntf) {
-        if(cond) {
-            if(memOrG) {
+    import std.format : format;
+    if (prntf)
+    {
+        if (cond)
+        {
+            if (memOrG)
+            {
                 mem.logf(ll2, condValue, "%s", to!string(value));
                 return __LINE__ - 1;
-            } else {
+            }
+            else
+            {
                 logf(ll2, condValue, "%s", to!string(value));
                 return __LINE__ - 1;
             }
-        } else {
-            if(memOrG) {
+        }
+        else
+        {
+            if (memOrG)
+            {
                 mem.logf(ll2, "%s", to!string(value));
                 return __LINE__ - 1;
-            } else {
+            }
+            else
+            {
                 logf(ll2, "%s", to!string(value));
                 return __LINE__ - 1;
             }
         }
-    } else {
-        if(cond) {
-            if(memOrG) {
+    }
+    else
+    {
+        if (cond)
+        {
+            if (memOrG)
+            {
                 mem.log(ll2, condValue, to!string(value));
                 return __LINE__ - 1;
-            } else {
+            }
+            else
+            {
                 log(ll2, condValue, to!string(value));
                 return __LINE__ - 1;
             }
-        } else {
-            if(memOrG) {
+        }
+        else
+        {
+            if (memOrG)
+            {
                 mem.log(ll2, to!string(value));
                 return __LINE__ - 1;
-            } else {
+            }
+            else
+            {
                 log(ll2, to!string(value));
                 return __LINE__ - 1;
             }
         }
     }
-    assert(false);
+    assert(false, format("cond %s, condValue %s, memOrG %s, prntf %s,"
+            ~ " ll2 %s, value %s", cond, condValue, memOrG, prntf, ll2, value
+            ));
 }
 
 // testing more possible log conditions

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -108,7 +108,6 @@ class MultiLogger : Logger
         }
     }
 
-    /** Logs a part of the log message. */
     override void logMsgPart(scope const(char)[] msg) @safe
     {
         if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel))
@@ -120,8 +119,6 @@ class MultiLogger : Logger
         }
     }
 
-    /** Signals that the message has been written and no more calls to
-    $(D logMsgPart) follow. */
     override void finishLogMsg() @safe
     {
         if (isLoggingEnabled(this.curMsgLogLevel, this.logLevel, globalLogLevel))

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -35,13 +35,10 @@ class NullLogger : Logger
     {
     }
 
-    /** Logs a part of the log message. */
     override void logMsgPart(scope const(char)[] msg) @safe
     {
     }
 
-    /** Signals that the message has been written and no more calls to
-    $(D logMsgPart) follow. */
     override void finishLogMsg() @safe
     {
     }

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -12,6 +12,8 @@ In case of a log message with `LogLevel.fatal` nothing will happen.
 */
 class NullLogger : Logger
 {
+    import std.concurrency : Tid;
+    import std.datetime.systime : SysTime;
     /** The default constructor for the `NullLogger`.
 
     Independent of the parameter this Logger will never log a message.
@@ -26,7 +28,21 @@ class NullLogger : Logger
         this.fatalHandler = delegate() {};
     }
 
-    override protected void writeLogMsg(ref LogEntry payload) @safe @nogc
+    override void beginLogMsg(string file, int line, string funcName,
+        string prettyFuncName, string moduleName, LogLevel logLevel,
+        Tid threadId, SysTime timestamp, Logger logger)
+        @safe
+    {
+    }
+
+    /** Logs a part of the log message. */
+    override void logMsgPart(scope const(char)[] msg) @safe
+    {
+    }
+
+    /** Signals that the message has been written and no more calls to
+    $(D logMsgPart) follow. */
+    override void finishLogMsg() @safe
     {
     }
 }
@@ -35,7 +51,8 @@ class NullLogger : Logger
 @safe unittest
 {
     import std.experimental.logger.core : LogLevel;
+
     auto nl1 = new NullLogger(LogLevel.all);
     nl1.info("You will never read this.");
-    nl1.fatal("You will never read this, either and it will not throw");
+    nl1.fatal("You will never read this, and it will not throw");
 }

--- a/std/experimental/logger/package.d
+++ b/std/experimental/logger/package.d
@@ -122,8 +122,8 @@ calls before they reach the `sharedLog` `Logger`.
 
 $(H3 User Defined Logger)
 To customize the `Logger` behavior, create a new `class` that inherits from
-the abstract `Logger` `class`, and implements the `writeLogMsg`
-method.
+the abstract `Logger` `class`, and implements the methods
+`beginLogMsg`, `logMsgPart`, and `finishLogMsg`.
 -------------
 class MyCustomLogger : Logger
 {
@@ -132,19 +132,28 @@ class MyCustomLogger : Logger
         super(lv);
     }
 
-    override void writeLogMsg(ref LogEntry payload)
+    // Signals the begin of log call.
+    override void beginLogMsg(string file, int line, string funcName,
+        string prettyFuncName, string moduleName, LogLevel logLevel,
+        Tid threadId, SysTime timestamp, Logger logger)
+        @safe
     {
-        // log message in my custom way
+    }
+
+    // Logs a part of the log message.
+    override void logMsgPart(scope const(char)[] msg) @safe
+    {
+    }
+
+    // Signals that the log call has finished
+    override void finishLogMsg() @safe
+    {
     }
 }
 
 auto logger = new MyCustomLogger(LogLevel.info);
 logger.log("Awesome log message with LogLevel.info");
 -------------
-
-To gain more precise control over the logging process, additionally to
-overriding the `writeLogMsg` method the methods `beginLogMsg`,
-`logMsgPart` and `finishLogMsg` can be overridden.
 
 $(H3 Compile Time Disabling of `Logger`)
 In order to disable logging at compile time, pass `StdLoggerDisableLogging` as a

--- a/win32.mak
+++ b/win32.mak
@@ -320,6 +320,7 @@ SRC_STD_EXP_LOGGER= \
 	std\experimental\logger\filelogger.d \
 	std\experimental\logger\multilogger.d \
 	std\experimental\logger\nulllogger.d \
+	std\experimental\logger\alloclogger.d \
 	std\experimental\logger\package.d
 
 SRC_ETC=

--- a/win64.mak
+++ b/win64.mak
@@ -345,6 +345,7 @@ SRC_STD_EXP_LOGGER= \
 	std\experimental\logger\filelogger.d \
 	std\experimental\logger\multilogger.d \
 	std\experimental\logger\nulllogger.d \
+	std\experimental\logger\alloclogger.d \
 	std\experimental\logger\package.d
 
 SRC_ETC=


### PR DESCRIPTION
this is a breaking change.
In order to make the logger work with allocator and the forward messages
without the need to gc allocation writeLogMsg had to go.
To test the design a new logger was added.
This logger is called AllocLogger and has an additional ctor argument,
an Allocator.

Additionally, the unit tests were simplified.