### PR TITLE
Only incorporate VariantN doc tests in doc builds.

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -705,7 +705,7 @@ public:
     }
 
     ///
-    version(unittest)
+    version(StdDdoc)
     @system unittest
     {
         Variant a;
@@ -738,7 +738,7 @@ public:
     }
 
     ///
-    version(unittest)
+    version(StdDdoc)
     @system unittest
     {
         Variant a = 5;
@@ -1130,7 +1130,7 @@ public:
     }
 
     ///
-    version(unittest)
+    version(StdDdoc)
     @system unittest
     {
         Variant a = new int[10];


### PR DESCRIPTION
The tests are for documentation and are located inside a template. This means they'll run every time you instantiate the VariantN template.

The unfortunate effect of this commit is that the documentation tests will not be executed, allowing them to get out of date. The obvious way to deal with this is to require every documentation test to run and to add `-version=StdDdoc` when compiling for the test target.