### PR TITLE
Fix Issue 18822 - Compiling byGrapheme Fails

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -4086,9 +4086,8 @@ public:
     */
     void putValue(Key key, Value v)
     {
-        import std.conv : text;
         auto idx = getIndex(key);
-        enforce(idx >= curIndex, text(errMsg, " ", idx));
+        enforce(idx >= curIndex, errMsg);
         putAt(idx, v);
     }
 


### PR DESCRIPTION
So, what's happening is that the `toString` of `Appender` now uses `formatValue`, which calls `formatRange`, which calls `graphemeStride`. `Grapheme` uses `TrieBuilder`, which uses `std.conv.text` for an error message which uses `Appender`, and you can see the problem.

If the `Appender.toString` code wasn't already released, I'd suggest removing the format specifier from it, as it would be a much cleaner fix. My guess is that other such return inference issues exist that we can't detect.

The other troubling issue is that the test suite didn't pick this up. The error only appears when compiling a file outside of the Phobos directory. Which strengthens my hypothesis about hidden inference problems.