### PR TITLE
Fix Misplaced Table

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1204,65 +1204,23 @@ if (distinctFieldNames!(Specs))
         /**
          * Formats `Tuple` with either `%s`, `%(inner%)` or `%(inner%|sep%)`.
          *
-         * Params:
-         *     sink = A `char` accepting delegate
-         *     fmt = A $(REF FormatSpec, std,format)
-         *
          * $(TABLE2 Formats supported by Tuple,
          * $(THEAD Format, Description)
          * $(TROW $(P `%s`), $(P Format like `Tuple!(types)(elements formatted with %s each)`.))
-         * $(TROW $(P `%(inner%)`), $(P The format `inner` is applied the expanded `Tuple`, so
+         * $(TROW $(P `%(inner%)`), $(P The format `inner` is applied the expanded `Tuple`$(COMMA) so
          *      it may contain as many formats as the `Tuple` has fields.))
-         * $(TROW $(P `%(inner%|sep%)`), $(P The format `inner` is one format, that is applied
+         * $(TROW $(P `%(inner%|sep%)`), $(P The format `inner` is one format$(COMMA) that is applied
          *      on all fields of the `Tuple`. The inner format must be compatible to all
          *      of them.)))
+         *
+         * Params:
+         *     sink = A `char` accepting delegate
+         *     fmt = A $(REF FormatSpec, std,format)
          */
         void toString(DG)(scope DG sink) const
         {
             auto f = FormatSpec!char();
             toString(sink, f);
-        }
-
-        ///
-        static if (Types.length == 0)
-        @safe unittest
-        {
-            import std.format : format, FormatException;
-            import std.exception : assertThrown;
-
-            // enum tupStr = tuple(1, 1.0).toString; // toString is *impure* for double (issue 17628)
-            // static assert(tupStr == `Tuple!(int, double)(1, 1)`);
-
-            Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
-
-            // Default format
-            assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
-
-            // One Format for each individual component
-            assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
-            assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
-
-            // One Format for all components
-            assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
-
-            // Array of Tuples
-            assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
-
-
-            // Error: %( %) missing.
-            assertThrown!FormatException(
-                format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
-            );
-
-            // Error: %( %| %) missing.
-            assertThrown!FormatException(
-                format("%d", tuple(1, 2)) == `1, 2`
-            );
-
-            // Error: %d inadequate for double
-            assertThrown!FormatException(
-                format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
-            );
         }
 
         /// ditto
@@ -1326,6 +1284,51 @@ if (distinctFieldNames!(Specs))
                     "Expected '%s' or '%(...%)' or '%(...%|...%)' format specifier for type '" ~
                         Unqual!(typeof(this)).stringof ~ "', not '%" ~ fmt.spec ~ "'.");
             }
+        }
+
+        ///
+        static if (Types.length == 0)
+        @safe unittest
+        {
+            import std.format : format;
+
+            Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
+
+            // Default format
+            assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
+
+            // One Format for each individual component
+            assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
+            assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
+
+            // One Format for all components
+            assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
+
+            // Array of Tuples
+            assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
+        }
+
+        ///
+        static if (Types.length == 0)
+        @safe unittest
+        {
+            import std.exception : assertThrown;
+            import std.format : format, FormatException;
+
+            // Error: %( %) missing.
+            assertThrown!FormatException(
+                format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
+            );
+
+            // Error: %( %| %) missing.
+            assertThrown!FormatException(
+                format("%d", tuple(1, 2)) == `1, 2`
+            );
+
+            // Error: %d inadequate for double
+            assertThrown!FormatException(
+                format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
+            );
         }
     }
 }


### PR DESCRIPTION
The table explaining format specifiers for `Tuple` has been placed in the parameter explanation.
I moved the table so this is not the case.
The table contained unescaped commas, which are escaped now.

This is also an addition to #6502.