### PR TITLE
Fix Issue 18848 - std.allocator: Regions are non-copyable, yet are pa…

### DIFF
--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -96,11 +96,6 @@ struct Region(ParentAllocator = NullAllocator,
         this(cast(ubyte[]) (parent.allocate(n.roundUpToAlignment(alignment))));
     }
 
-    /*
-    TODO: The postblit of `BasicRegion` should be disabled because such objects
-    should not be copied around naively.
-    */
-
     /**
     If `ParentAllocator` is not $(REF_ALTTEXT `NullAllocator`, NullAllocator, std,experimental,allocator,building_blocks,null_allocator) and defines `deallocate`,
     the region defines a destructor that uses `ParentAllocator.deallocate` to free the
@@ -112,6 +107,13 @@ struct Region(ParentAllocator = NullAllocator,
     {
         parent.deallocate(_begin[0 .. _end - _begin]);
     }
+
+    /**
+    `Region` deallocates on destruction (see above), therefore is not copyable.
+    */
+    static if (!is(ParentAllocator == NullAllocator)
+        && hasMember!(ParentAllocator, "deallocate"))
+    @disable this(this);
 
     /**
     Rounds the given size to a multiple of the `alignment`


### PR DESCRIPTION
…ssed around in examples

This doesn't fix that non-copyable regions are still passed around in
examples, so we still rely on NRVO to do its thing and elide the
copy, but at least this will now catch wrong code that mistakenly
copied Regions around.