### PR TITLE
Correct documentation for std.stdio.write.

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3712,7 +3712,7 @@ private @property File trustedStdout() @trusted
 }
 
 /***********************************
-Writes its arguments in text format to `stdout`.
+Writes its arguments in text format to standard output (without a trailing newline).
 
 Params:
     args = the items to write to `stdout`

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3712,10 +3712,7 @@ private @property File trustedStdout() @trusted
 }
 
 /***********************************
-For each argument `arg` in `args`, format the argument (using
-$(REF to, std,conv)) and write the resulting
-string to `args[0]`. A call without any arguments will fail to
-compile.
+Writes its arguments in text format to `stdout`.
 
 Params:
     args = the items to write to `stdout`


### PR DESCRIPTION
Remove errors in the description: It writes to stdout not args[0], calling without arguments does compile and it does not use std.conv.to.
Use similar description as std.stdio.writef.