### PR TITLE
[trivial] Add mean to the doc index of std.algorithm and std.algorithm.iteration

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -40,6 +40,8 @@ $(T2 joiner,
 $(T2 map,
         `map!(a => a * 2)([1, 2, 3])` lazily returns a range with the numbers
         `2`, `4`, `6`.)
+$(T2 mean,
+        Colloquially known as the average, `mean([1, 2, 3])` returns `2`.)
 $(T2 permutations,
         Lazily computes all permutations using Heap's algorithm.)
 $(T2 reduce,

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -79,6 +79,7 @@ $(TR
         $(SUBREF iteration, group)
         $(SUBREF iteration, joiner)
         $(SUBREF iteration, map)
+        $(SUBREF iteration, mean)
         $(SUBREF iteration, permutations)
         $(SUBREF iteration, reduce)
         $(SUBREF iteration, splitter)


### PR DESCRIPTION
Add missing links to `std.algorithm.iteration : mean` from the indexs of both `std.algorithm` package and the `std.algorithm.iteration`.