### PR TITLE
Temporarily disable dscanner if_else_same_check for std.typecons

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -19,7 +19,8 @@ object_const_check="enabled"
 ; Checks for .. expressions where the left side is larger than the right.
 backwards_range_check="enabled"
 ; Checks for if statements whose 'then' block is the same as the 'else' block
-if_else_same_check="enabled"
+; Temporarily disable until https://github.com/dlang-community/D-Scanner/issues/593 is fixed
+if_else_same_check="-std.typecons"
 ; Checks for some problems with constructors
 constructor_check="enabled"
 ; Checks for unused variables and function parameters


### PR DESCRIPTION
This check appears to be preventing Circle CI from passing at https://github.com/dlang/phobos/pull/6515

The failure is due to a dscanner bug documented at https://github.com/dlang-community/D-Scanner/issues/593

Unfortunately, like others, I am not able to reproduce the problem locally.   I tried to simply re-initiate Circle CI, but it still failed.