### PR TITLE
Move the -std.typecons exclude to the filter section of the DScanner Ini

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -19,8 +19,7 @@ object_const_check="enabled"
 ; Checks for .. expressions where the left side is larger than the right.
 backwards_range_check="enabled"
 ; Checks for if statements whose 'then' block is the same as the 'else' block
-; Temporarily disable until https://github.com/dlang-community/D-Scanner/issues/593 is fixed
-if_else_same_check="-std.typecons"
+if_else_same_check="enabled"
 ; Checks for some problems with constructors
 constructor_check="enabled"
 ; Checks for unused variables and function parameters
@@ -479,3 +478,6 @@ unused_variable_check="-std.algorithm.comparison,\
 vcall_in_ctor="-std.socket,-std.xml"
 ; Check for @trusted applied to a bigger scope than a single function
 trust_too_much="-std.regex,-std.stdio,-std.uni,-std.internal.cstring"
+; Checks for if statements whose 'then' block is the same as the 'else' block
+; Temporarily disable until https://github.com/dlang-community/D-Scanner/issues/593 is fixed
+if_else_same_check="-std.typecons"


### PR DESCRIPTION
Sorry the .dscanner.ini doesn't support direct excludes/includes in the main section, but only in the special filter section (that is due to inifiled not supporting variant types).

See also: https://github.com/dlang/phobos/pull/6532

CC @JinShil