### PR TITLE
Fix Issue 18752 - std.file.read runnable example fails

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -323,7 +323,7 @@ if (isInputRange!R && isSomeChar!(ElementEncodingType!R) && !isInfinite!R &&
         remove(deleteme);
     }
 
-    write(deleteme, "1234"); // deleteme is the name of a temporary file
+    std.file.write(deleteme, "1234"); // deleteme is the name of a temporary file
     assert(read(deleteme, 2) == "12");
     assert(read(deleteme.byChar) == "1234");
     assert((cast(const(ubyte)[])read(deleteme)).length == 4);


### PR DESCRIPTION
The problem is that run.dlang.io automatically adds `import std.stdio` and thus
we silently print to stdio instead of writing to a file (we should really deprecated
std.file.write because of this!).

Anyhow, I think the easiest solution here is to use the fully qualified symbol.