### PR TITLE
fix issue 18937 - [REG 2.080.0] std.experimental.allocator: compiling…

### DIFF
--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -829,7 +829,7 @@ private template isAllZeroBits(T, T value)
 
 @nogc nothrow pure @safe unittest // large static arrays
 {
-    import std.meta: Repeat;
+    import std.meta : Repeat;
     enum n = 16 * 1024;
 
     static assert(isAllZeroBits!(ubyte[n], (ubyte[n]).init));

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -781,13 +781,13 @@ private bool bitwiseIdentical(T)(T a, T b)
     static struct NeverEq
     {
         int x;
-        bool opEquals(NeverEq other) { return false; }
+        bool opEquals(NeverEq other) const { return false; }
     }
 
     static struct AlwaysEq
     {
         int x;
-        bool opEquals(AlwaysEq other) { return true; }
+        bool opEquals(AlwaysEq other) const { return true; }
     }
 
     static foreach (x; AliasSeq!(-1, 0, 1, 2, "foo", NeverEq(0)))
@@ -906,7 +906,7 @@ private template isAllZeroBits(T, T value)
     static struct AlwaysEq
     {
         int x;
-        bool opEquals(AlwaysEq other) { return true; }
+        bool opEquals(AlwaysEq other) const { return true; }
     }
     static assert(AlwaysEq(0) == AlwaysEq(0));
     static assert(AlwaysEq(0) == AlwaysEq(1));
@@ -918,7 +918,7 @@ private template isAllZeroBits(T, T value)
     static struct NeverEq
     {
         int x;
-        bool opEquals(NeverEq other) { return false; }
+        bool opEquals(NeverEq other) const { return false; }
     }
     static assert(NeverEq(0) != NeverEq(1));
     static assert(NeverEq(0) != NeverEq(0));

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1378,6 +1378,22 @@ nothrow @safe @nogc unittest
         "Don't allow zero-ctor-args `make` for structs with `@disable this();`");
 }
 
+@safe unittest // issue 18937
+{
+    static struct S
+    {
+        ubyte[16 * 1024] data;
+    }
+
+    static struct SomeAllocator
+    {
+        ubyte[] allocate(size_t) { return []; }
+        void deallocate(void[]) {}
+    }
+
+    auto x = SomeAllocator().make!S();
+}
+
 private void fillWithMemcpy(T)(scope void[] array, auto ref T filler) nothrow
 if (T.sizeof == 1)
 {


### PR DESCRIPTION
… `make` needs an unreasonable amount of memory for structs that contain static arrays