### PR TITLE
Remove a few cases of underscore escaping

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
-It contains generic _comparison algorithms.
+It contains generic comparison algorithms.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE Cheat Sheet,
@@ -29,12 +29,12 @@ $(T2 isSameLength,
 $(T2 levenshteinDistance,
         `levenshteinDistance("kitten", "sitting")` returns `3` by using
         the $(LINK2 https://en.wikipedia.org/wiki/Levenshtein_distance,
-        Levenshtein distance _algorithm).)
+        Levenshtein distance algorithm).)
 $(T2 levenshteinDistanceAndPath,
         `levenshteinDistanceAndPath("kitten", "sitting")` returns
         `tuple(3, "snnnsni")` by using the
         $(LINK2 https://en.wikipedia.org/wiki/Levenshtein_distance,
-        Levenshtein distance _algorithm).)
+        Levenshtein distance algorithm).)
 $(T2 max,
         `max(3, 4, 2)` returns `4`.)
 $(T2 min,
@@ -51,7 +51,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_comparison.d)
+Source: $(PHOBOSSRC std/algorithm/comparison.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
-It contains generic _iteration algorithms.
+It contains generic iteration algorithms.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE Cheat Sheet,
@@ -63,7 +63,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_iteration.d)
+Source: $(PHOBOSSRC std/algorithm/iteration.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
-It contains generic _mutation algorithms.
+It contains generic mutation algorithms.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE Cheat Sheet,
@@ -70,7 +70,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_mutation.d)
+Source: $(PHOBOSSRC std/algorithm/mutation.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -186,7 +186,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/_algorithm/package.d)
+Source: $(PHOBOSSRC std/algorithm/package.d)
  */
 module std.algorithm;
 

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
-It contains generic _searching algorithms.
+It contains generic searching algorithms.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE Cheat Sheet,
@@ -95,7 +95,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_searching.d)
+Source: $(PHOBOSSRC std/algorithm/searching.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -40,7 +40,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_setops.d)
+Source: $(PHOBOSSRC std/algorithm/setops.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 /**
 This is a submodule of $(MREF std, algorithm).
-It contains generic _sorting algorithms.
+It contains generic sorting algorithms.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE Cheat Sheet,
@@ -67,7 +67,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/algorithm/_sorting.d)
+Source: $(PHOBOSSRC std/algorithm/sorting.d)
 
 Macros:
 T2=$(TR $(TDNW $(LREF $1)) $(TD $+))

--- a/std/array.d
+++ b/std/array.d
@@ -8,47 +8,47 @@ $(SCRIPT inhibitQuickIndex = 1;)
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(LREF _array))
-        $(TD Returns a copy of the input in a newly allocated dynamic _array.
+    $(TR $(TD $(LREF array))
+        $(TD Returns a copy of the input in a newly allocated dynamic array.
     ))
     $(TR $(TD $(LREF appender))
-        $(TD Returns a new $(LREF Appender) or $(LREF RefAppender) initialized with a given _array.
+        $(TD Returns a new $(LREF Appender) or $(LREF RefAppender) initialized with a given array.
     ))
     $(TR $(TD $(LREF assocArray))
-        $(TD Returns a newly allocated associative _array from a range of key/value tuples.
+        $(TD Returns a newly allocated associative array from a range of key/value tuples.
     ))
     $(TR $(TD $(LREF byPair))
-        $(TD Construct a range iterating over an associative _array by key/value tuples.
+        $(TD Construct a range iterating over an associative array by key/value tuples.
     ))
     $(TR $(TD $(LREF insertInPlace))
-        $(TD Inserts into an existing _array at a given position.
+        $(TD Inserts into an existing array at a given position.
     ))
     $(TR $(TD $(LREF join))
-        $(TD Concatenates a range of ranges into one _array.
+        $(TD Concatenates a range of ranges into one array.
     ))
     $(TR $(TD $(LREF minimallyInitializedArray))
-        $(TD Returns a new _array of type `T`.
+        $(TD Returns a new array of type `T`.
     ))
     $(TR $(TD $(LREF replace))
-        $(TD Returns a new _array with all occurrences of a certain subrange replaced.
+        $(TD Returns a new array with all occurrences of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceFirst))
-        $(TD Returns a new _array with the first occurrence of a certain subrange replaced.
+        $(TD Returns a new array with the first occurrence of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceInPlace))
-        $(TD Replaces all occurrences of a certain subrange and puts the result into a given _array.
+        $(TD Replaces all occurrences of a certain subrange and puts the result into a given array.
     ))
     $(TR $(TD $(LREF replaceInto))
         $(TD Replaces all occurrences of a certain subrange and puts the result into an output range.
     ))
     $(TR $(TD $(LREF replaceLast))
-        $(TD Returns a new _array with the last occurrence of a certain subrange replaced.
+        $(TD Returns a new array with the last occurrence of a certain subrange replaced.
     ))
     $(TR $(TD $(LREF replaceSlice))
-        $(TD Returns a new _array with a given slice replaced.
+        $(TD Returns a new array with a given slice replaced.
     ))
     $(TR $(TD $(LREF replicate))
-        $(TD Creates a new _array out of several copies of an input _array or range.
+        $(TD Creates a new array out of several copies of an input array or range.
     ))
     $(TR $(TD $(LREF sameHead))
         $(TD Checks if the initial segments of two arrays refer to the same
@@ -59,10 +59,10 @@ $(TR $(TH Function Name) $(TH Description)
         in memory.
     ))
     $(TR $(TD $(LREF split))
-        $(TD Eagerly split a range or string into an _array.
+        $(TD Eagerly split a range or string into an array.
     ))
     $(TR $(TD $(LREF uninitializedArray))
-        $(TD Returns a new _array of type `T` without initializing its elements.
+        $(TD Returns a new array of type `T` without initializing its elements.
     ))
 )
 
@@ -73,7 +73,7 @@ License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu) and
            $(HTTP jmdavisprog.com, Jonathan M Davis)
 
-Source: $(PHOBOSSRC std/_array.d)
+Source: $(PHOBOSSRC std/array.d)
 */
 module std.array;
 
@@ -382,7 +382,7 @@ if (isNarrowString!String)
 }
 
 /**
-Returns a newly allocated associative _array from a range of key/value tuples.
+Returns a newly allocated associative array from a range of key/value tuples.
 
 Params:
     r = An $(REF_ALTTEXT input range, isInputRange, std,range,primitives)
@@ -2424,7 +2424,7 @@ if (isInputRange!Range &&
     shrinks the array as needed.
 
     Params:
-        array = the _array to scan
+        array = the array to scan
         from = the starting index
         to = the ending index
         stuff = the items to replace in-between `from` and `to`

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -3,7 +3,7 @@
 /++
     Functions which operate on ASCII characters.
 
-    All of the functions in std._ascii accept Unicode characters but
+    All of the functions in std.ascii accept Unicode characters but
     effectively ignore them if they're not ASCII. All `isX` functions return
     `false` for non-ASCII characters, and all `toX` functions do nothing
     to non-ASCII characters.
@@ -56,7 +56,7 @@ $(TR $(TD Enums) $(TD
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP digitalmars.com, Walter Bright) and
                $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/_ascii.d)
+    Source:    $(PHOBOSSRC std/ascii.d)
   +/
 module std.ascii;
 

--- a/std/base64.d
+++ b/std/base64.d
@@ -51,7 +51,7 @@
  * Copyright: Masahiro Nakagawa 2010-.
  * License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Masahiro Nakagawa, Daniel Murphy (Single value Encoder and Decoder)
- * Source:    $(PHOBOSSRC std/_base64.d)
+ * Source:    $(PHOBOSSRC std/base64.d)
  * Macros:
  *      LREF2=<a href="#$1">`$2`</a>
  */

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -15,7 +15,7 @@
  *
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Don Clugston
- * Source: $(PHOBOSSRC std/_bigint.d)
+ * Source: $(PHOBOSSRC std/bigint.d)
  */
 /*          Copyright Don Clugston 2008 - 2010.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -42,7 +42,7 @@ Authors:   $(HTTP digitalmars.com, Walter Bright),
            Alex Rønne Petersen,
            Damian Ziemba,
            Amaury SECHET
-Source: $(PHOBOSSRC std/_bitmanip.d)
+Source: $(PHOBOSSRC std/bitmanip.d)
 */
 /*
          Copyright Digital Mars 2007 - 2012.

--- a/std/compiler.d
+++ b/std/compiler.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright), Alex Rønne Petersen
- * Source:    $(PHOBOSSRC std/_compiler.d)
+ * Source:    $(PHOBOSSRC std/compiler.d)
  */
 /*          Copyright Digital Mars 2000 - 2011.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/complex.d
+++ b/std/complex.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /** This module contains the $(LREF Complex) type, which is used to represent
-    _complex numbers, along with related mathematical operations and functions.
+    complex numbers, along with related mathematical operations and functions.
 
     $(LREF Complex) will eventually
     $(DDLINK deprecate, Deprecated Features, replace)
@@ -11,13 +11,13 @@
     Authors:    Lars Tandle Kyllingstad, Don Clugston
     Copyright:  Copyright (c) 2010, Lars T. Kyllingstad.
     License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
-    Source:     $(PHOBOSSRC std/_complex.d)
+    Source:     $(PHOBOSSRC std/complex.d)
 */
 module std.complex;
 
 import std.traits;
 
-/** Helper function that returns a _complex number with the specified
+/** Helper function that returns a complex number with the specified
     real and imaginary parts.
 
     Params:

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -22,7 +22,7 @@
  * Copyright: Copyright Sean Kelly 2009 - 2014.
  * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
  * Authors:   Sean Kelly, Alex Rønne Petersen, Martin Nowak
- * Source:    $(PHOBOSSRC std/_concurrency.d)
+ * Source:    $(PHOBOSSRC std/concurrency.d)
  */
 /*          Copyright Sean Kelly 2009 - 2014.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -4,7 +4,7 @@
  *
  * This module is a submodule of $(MREF std, container).
  *
- * Source: $(PHOBOSSRC std/container/_array.d)
+ * Source: $(PHOBOSSRC std/container/array.d)
  *
  * Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
  *

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -4,7 +4,7 @@ adaptor that makes a binary heap out of any user-provided random-access range.
 
 This module is a submodule of $(MREF std, container).
 
-Source: $(PHOBOSSRC std/container/_binaryheap.d)
+Source: $(PHOBOSSRC std/container/binaryheap.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -4,7 +4,7 @@ It can be used as a queue, dequeue or stack.
 
 This module is a submodule of $(MREF std, container).
 
-Source: $(PHOBOSSRC std/container/_dlist.d)
+Source: $(PHOBOSSRC std/container/dlist.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -6,7 +6,7 @@ This module defines generic containers.
 Construction:
 
 To implement the different containers both struct and class based
-approaches have been used. $(REF make, std,_container,util) allows for
+approaches have been used. $(REF make, std,container,util) allows for
 uniform construction with either approach.
 
 ---
@@ -34,7 +34,7 @@ Reference_semantics:
 All containers have reference semantics, which means that after
 assignment both variables refer to the same underlying data.
 
-To make a copy of a _container, use the `c._dup` _container primitive.
+To make a copy of a container, use the `c._dup` container primitive.
 ---
 import std.container, std.range;
 Array!int originalArray = make!(Array!int)(1, 2, 3);
@@ -52,7 +52,7 @@ secondArray[0] = 1;
 assert(originalArray[0] == 12);
 ---
 
-$(B Attention:) If the _container is implemented as a class, using an
+$(B Attention:) If the container is implemented as a class, using an
 uninitialized instance can cause a null pointer dereference.
 
 ---
@@ -62,8 +62,8 @@ RedBlackTree!int rbTree;
 rbTree.insert(5); // null pointer dereference
 ---
 
-Using an uninitialized struct-based _container will work, because the struct
-intializes itself upon use; however, up to this point the _container will not
+Using an uninitialized struct-based container will work, because the struct
+intializes itself upon use; however, up to this point the container will not
 have an identity and assignment does not create two references to the same
 data.
 
@@ -85,9 +85,9 @@ array1.removeBack();
 assert(array2.empty);
 ---
 It is therefore recommended to always construct containers using
-$(REF make, std,_container,util).
+$(REF make, std,container,util).
 
-This is in fact necessary to put containers into another _container.
+This is in fact necessary to put containers into another container.
 For example, to construct an `Array` of ten empty `Array`s, use
 the following that calls `make` ten times.
 
@@ -103,47 +103,47 @@ This module consists of the following submodules:
 
 $(UL
     $(LI
-        The $(MREF std, _container, array) module provides
+        The $(MREF std, container, array) module provides
         an array type with deterministic control of memory, not reliant on
         the GC unlike built-in arrays.
     )
     $(LI
-        The $(MREF std, _container, binaryheap) module
+        The $(MREF std, container, binaryheap) module
         provides a binary heap implementation that can be applied to any
         user-provided random-access range.
     )
     $(LI
-        The $(MREF std, _container, dlist) module provides
+        The $(MREF std, container, dlist) module provides
         a doubly-linked list implementation.
     )
     $(LI
-        The $(MREF std, _container, rbtree) module
+        The $(MREF std, container, rbtree) module
         implements red-black trees.
     )
     $(LI
-        The $(MREF std, _container, slist) module
+        The $(MREF std, container, slist) module
         implements singly-linked lists.
     )
     $(LI
-        The $(MREF std, _container, util) module contains
-        some generic tools commonly used by _container implementations.
+        The $(MREF std, container, util) module contains
+        some generic tools commonly used by container implementations.
     )
 )
 
 The_primary_range_of_a_container:
 
-While some _containers offer direct access to their elements e.g. via
+While some containers offer direct access to their elements e.g. via
 `opIndex`, `c.front` or `c.back`, access
-and modification of a _container's contents is generally done through
+and modification of a container's contents is generally done through
 its primary $(MREF_ALTTEXT range, std, range) type,
 which is aliased as `C.Range`. For example, the primary range type of
 `Array!int` is `Array!int.Range`.
 
-If the documentation of a member function of a _container takes
+If the documentation of a member function of a container takes
 a parameter of type `Range`, then it refers to the primary range type of
-this _container. Oftentimes `Take!Range` will be used, in which case
-the range refers to a span of the elements in the _container. Arguments to
-these parameters $(B must) be obtained from the same _container instance
+this container. Oftentimes `Take!Range` will be used, in which case
+the range refers to a span of the elements in the container. Arguments to
+these parameters $(B must) be obtained from the same container instance
 as the one being worked with. It is important to note that many generic range
 algorithms return the same range type as their input range.
 
@@ -192,28 +192,28 @@ Container_primitives:
 Containers do not form a class hierarchy, instead they implement a
 common set of primitives (see table below). These primitives each guarantee
 a specific worst case complexity and thus allow generic code to be written
-independently of the _container implementation.
+independently of the container implementation.
 
 For example the primitives `c.remove(r)` and `c.linearRemove(r)` both
-remove the sequence of elements in range `r` from the _container `c`.
+remove the sequence of elements in range `r` from the container `c`.
 The primitive `c.remove(r)` guarantees
 $(BIGOH n$(SUBSCRIPT r) log n$(SUBSCRIPT c)) complexity in the worst case and
 `c.linearRemove(r)` relaxes this guarantee to $(BIGOH n$(SUBSCRIPT c)).
 
-Since a sequence of elements can be removed from a $(MREF_ALTTEXT doubly linked list,std,_container,dlist)
+Since a sequence of elements can be removed from a $(MREF_ALTTEXT doubly linked list,std,container,dlist)
 in constant time, `DList` provides the primitive `c.remove(r)`
 as well as `c.linearRemove(r)`. On the other hand
-$(MREF_ALTTEXT Array, std,_container, array) only offers `c.linearRemove(r)`.
+$(MREF_ALTTEXT Array, std,container, array) only offers `c.linearRemove(r)`.
 
 The following table describes the common set of primitives that containers
-implement.  A _container need not implement all primitives, but if a
+implement.  A container need not implement all primitives, but if a
 primitive is implemented, it must support the syntax described in the $(B
 syntax) column with the semantics described in the $(B description) column, and
 it must not have a worst-case complexity worse than denoted in big-O notation in
-the $(BIGOH &middot;) column.  Below, `C` means a _container type, `c` is
-a value of _container type, $(D n$(SUBSCRIPT x)) represents the effective length of
+the $(BIGOH &middot;) column.  Below, `C` means a container type, `c` is
+a value of container type, $(D n$(SUBSCRIPT x)) represents the effective length of
 value `x`, which could be a single element (in which case $(D n$(SUBSCRIPT x)) is
-`1`), a _container, or a range.
+`1`), a container, or a range.
 
 $(BOOKTABLE Container primitives,
 $(TR
@@ -224,13 +224,13 @@ $(TR
 $(TR
     $(TDNW `C(x)`)
     $(TDNW $(D n$(SUBSCRIPT x)))
-    $(TD Creates a _container of type `C` from either another _container or a range.
-    The created _container must not be a null reference even if x is empty.)
+    $(TD Creates a container of type `C` from either another container or a range.
+    The created container must not be a null reference even if x is empty.)
 )
 $(TR
     $(TDNW `c.dup`)
     $(TDNW $(D n$(SUBSCRIPT c)))
-    $(TD Returns a duplicate of the _container.)
+    $(TD Returns a duplicate of the container.)
 )
 $(TR
     $(TDNW $(D c ~ x))
@@ -249,43 +249,43 @@ $(LEADINGROWN 3, Iteration
 $(TR
     $(TD `c.Range`)
     $(TD)
-    $(TD The primary range type associated with the _container.)
+    $(TD The primary range type associated with the container.)
 )
 $(TR
     $(TD `c[]`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Returns a range
-         iterating over the entire _container, in a _container-defined order.)
+         iterating over the entire container, in a container-defined order.)
 )
 $(TR
     $(TDNW $(D c[a .. b]))
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Fetches a portion of the _container from key `a` to key `b`.)
+    $(TD Fetches a portion of the container from key `a` to key `b`.)
 )
 $(LEADINGROWN 3, Capacity
 )
 $(TR
     $(TD `c.empty`)
     $(TD `1`)
-    $(TD Returns `true` if the _container has no elements, `false` otherwise.)
+    $(TD Returns `true` if the container has no elements, `false` otherwise.)
 )
 $(TR
     $(TD `c.length`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Returns the number of elements in the _container.)
+    $(TD Returns the number of elements in the container.)
 )
 $(TR
     $(TDNW $(D c.length = n))
     $(TDNW $(D n$(SUBSCRIPT c) + n))
-    $(TD Forces the number of elements in the _container to `n`.
-        If the _container ends up growing, the added elements are initialized
-        in a _container-dependent manner (usually with `T.init`).)
+    $(TD Forces the number of elements in the container to `n`.
+        If the container ends up growing, the added elements are initialized
+        in a container-dependent manner (usually with `T.init`).)
 )
 $(TR
     $(TD `c.capacity`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Returns the maximum number of elements that can be stored in the
-    _container without triggering a reallocation.)
+    container without triggering a reallocation.)
 )
 $(TR
     $(TD `c.reserve(x)`)
@@ -297,63 +297,63 @@ $(LEADINGROWN 3, Access
 $(TR
     $(TDNW `c.front`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Returns the first element of the _container, in a _container-defined order.)
+    $(TD Returns the first element of the container, in a container-defined order.)
 )
 $(TR
     $(TDNW `c.moveFront`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Destructively reads and returns the first element of the
-         _container. The slot is not removed from the _container; it is left
+         container. The slot is not removed from the container; it is left
          initialized with `T.init`. This routine need not be defined if $(D
          front) returns a `ref`.)
 )
 $(TR
     $(TDNW $(D c.front = v))
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Assigns `v` to the first element of the _container.)
+    $(TD Assigns `v` to the first element of the container.)
 )
 $(TR
     $(TDNW `c.back`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Returns the last element of the _container, in a _container-defined order.)
+    $(TD Returns the last element of the container, in a container-defined order.)
 )
 $(TR
     $(TDNW `c.moveBack`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Destructively reads and returns the last element of the
-         _container. The slot is not removed from the _container; it is left
+         container. The slot is not removed from the container; it is left
          initialized with `T.init`. This routine need not be defined if $(D
          front) returns a `ref`.)
 )
 $(TR
     $(TDNW $(D c.back = v))
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Assigns `v` to the last element of the _container.)
+    $(TD Assigns `v` to the last element of the container.)
 )
 $(TR
     $(TDNW `c[x]`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Provides indexed access into the _container. The index type is
-         _container-defined. A _container may define several index types (and
+    $(TD Provides indexed access into the container. The index type is
+         container-defined. A container may define several index types (and
          consequently overloaded indexing).)
 )
 $(TR
     $(TDNW `c.moveAt(x)`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Destructively reads and returns the value at position `x`. The slot
-         is not removed from the _container; it is left initialized with $(D
+         is not removed from the container; it is left initialized with $(D
          T.init).)
 )
 $(TR
     $(TDNW $(D c[x] = v))
     $(TDNW $(D log n$(SUBSCRIPT c)))
-    $(TD Sets element at specified index into the _container.)
+    $(TD Sets element at specified index into the container.)
 )
 $(TR
     $(TDNW $(D c[x] $(I op)= v))
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Performs read-modify-write operation at specified index into the
-        _container.)
+        container.)
 )
 $(LEADINGROWN 3, Operations
 )
@@ -490,7 +490,7 @@ $(TR
     $(TDNW `c.removeKey(k)`)
     $(TDNW $(D log n$(SUBSCRIPT c)))
     $(TD Removes an element from `c` by using its key `k`.
-         The key's type is defined by the _container.)
+         The key's type is defined by the container.)
 )
 $(TR
     $(TDNW ``)
@@ -499,7 +499,7 @@ $(TR
 )
 )
 
-Source: $(PHOBOSSRC std/_container/package.d)
+Source: $(PHOBOSSRC std/container/package.d)
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -3,7 +3,7 @@ This module implements a red-black tree container.
 
 This module is a submodule of $(MREF std, container).
 
-Source: $(PHOBOSSRC std/container/_rbtree.d)
+Source: $(PHOBOSSRC std/container/rbtree.d)
 
 Copyright: Red-black tree code copyright (C) 2008- by Steven Schveighoffer. Other code
 copyright 2010- Andrei Alexandrescu. All rights reserved by the respective holders.

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -4,7 +4,7 @@ It can be used as a stack.
 
 This module is a submodule of $(MREF std, container).
 
-Source: $(PHOBOSSRC std/container/_slist.d)
+Source: $(PHOBOSSRC std/container/slist.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -3,7 +3,7 @@ This module contains some common utilities used by containers.
 
 This module is a submodule of $(MREF std, container).
 
-Source: $(PHOBOSSRC std/container/_util.d)
+Source: $(PHOBOSSRC std/container/util.d)
 
 Copyright: 2010- Andrei Alexandrescu. All rights reserved by the respective holders.
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -42,7 +42,7 @@ Authors:   $(HTTP digitalmars.com, Walter Bright),
            Adam D. Ruppe,
            Kenji Hara
 
-Source:    $(PHOBOSSRC std/_conv.d)
+Source:    $(PHOBOSSRC std/conv.d)
 
 */
 module std.conv;

--- a/std/csv.d
+++ b/std/csv.d
@@ -87,7 +87,7 @@
  *   Copyright: Copyright 2011
  *   License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *   Authors:   Jesse Phillips
- *   Source:    $(PHOBOSSRC std/_csv.d)
+ *   Source:    $(PHOBOSSRC std/csv.d)
  */
 module std.csv;
 

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -36,7 +36,7 @@ $(TR $(TD Other) $(TD
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/datetime/_date.d)
+    Source:    $(PHOBOSSRC std/datetime/date.d)
 +/
 module std.datetime.date;
 

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -29,7 +29,7 @@ $(TR $(TD Flags) $(TD
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/datetime/_interval.d)
+    Source:    $(PHOBOSSRC std/datetime/interval.d)
 +/
 module std.datetime.interval;
 

--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -43,7 +43,7 @@ $(TR $(TD Flags) $(TD
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis) and Kato Shoichi
-    Source:    $(PHOBOSSRC std/datetime/_stopwatch.d)
+    Source:    $(PHOBOSSRC std/datetime/stopwatch.d)
 +/
 module std.datetime.stopwatch;
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -27,7 +27,7 @@ $(TR $(TD Conversion) $(TD
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/datetime/_systime.d)
+    Source:    $(PHOBOSSRC std/datetime/systime.d)
 +/
 module std.datetime.systime;
 

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -23,7 +23,7 @@ $(TR $(TD Utilities) $(TD
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/datetime/_timezone.d)
+    Source:    $(PHOBOSSRC std/datetime/timezone.d)
 +/
 module std.datetime.timezone;
 

--- a/std/demangle.d
+++ b/std/demangle.d
@@ -7,7 +7,7 @@
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *                        Thomas K$(UUML)hne, Frits van Bommel
- * Source:    $(PHOBOSSRC std/_demangle.d)
+ * Source:    $(PHOBOSSRC std/demangle.d)
  * $(SCRIPT inhibitQuickIndex = 1;)
  */
 /*

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -38,7 +38,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of) $(MYREF crc64EC
  * References:
  *      $(LINK2 http://en.wikipedia.org/wiki/Cyclic_redundancy_check, Wikipedia on CRC)
  *
- * Source: $(PHOBOSSRC std/digest/_crc.d)
+ * Source: $(PHOBOSSRC std/digest/crc.d)
  *
  * Standards:
  * Implements the 'common' IEEE CRC32 variant

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -11,7 +11,7 @@ Macros:
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
-Source: $(PHOBOSSRC std/digest/_hmac.d)
+Source: $(PHOBOSSRC std/digest/hmac.d)
  */
 
 module std.digest.hmac;

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -36,7 +36,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
  * References:
  *      $(LINK2 http://en.wikipedia.org/wiki/Md5, Wikipedia on MD5)
  *
- * Source: $(PHOBOSSRC std/digest/_md.d)
+ * Source: $(PHOBOSSRC std/digest/md.d)
  *
  */
 

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -26,7 +26,7 @@ This module conforms to the APIs defined in $(MREF std, digest).
 
 This module publicly imports $(MREF std, digest) and can be used as a stand-alone module.
 
-Source: $(PHOBOSSRC std/digest/_murmurhash.d)
+Source: $(PHOBOSSRC std/digest/murmurhash.d)
 License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Guillaume Chatelet
 References: $(LINK2 https://github.com/aappleby/smhasher, Reference implementation)

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1,7 +1,7 @@
 /**
- * This module describes the _digest APIs used in Phobos. All digests follow
+ * This module describes the digest APIs used in Phobos. All digests follow
  * these APIs. Additionally, this module contains useful helper methods which
- * can be used with every _digest type.
+ * can be used with every digest type.
  *
 $(SCRIPT inhibitQuickIndex = 1;)
 
@@ -11,7 +11,7 @@ $(TR $(TH Category) $(TH Functions)
 )
 $(TR $(TDNW Template API) $(TD $(MYREF isDigest) $(MYREF DigestType) $(MYREF hasPeek)
   $(MYREF hasBlockSize)
-  $(MYREF ExampleDigest) $(MYREF _digest) $(MYREF hexDigest) $(MYREF makeDigest)
+  $(MYREF ExampleDigest) $(MYREF digest) $(MYREF hexDigest) $(MYREF makeDigest)
 )
 )
 $(TR $(TDNW OOP API) $(TD $(MYREF Digest)
@@ -36,10 +36,10 @@ $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDi
  * buffer was provided. If you provide a buffer to the OOP APIs finish function, it doesn't allocate,
  * but the $(LREF Digest) classes still have to be created using `new` which allocates them using the GC.
  *
- * The OOP API is useful to change the _digest function and/or _digest backend at 'runtime'. The benefit here
+ * The OOP API is useful to change the digest function and/or digest backend at 'runtime'. The benefit here
  * is that switching e.g. Phobos MD5Digest and an OpenSSLMD5Digest implementation is ABI compatible.
  *
- * If just one specific _digest type and backend is needed, the template API is usually a good fit.
+ * If just one specific digest type and backend is needed, the template API is usually a good fit.
  * In this simplest case, the template API can even be used without templates: Just use the "$(B x)" structs
  * directly.
  *
@@ -47,7 +47,7 @@ $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDi
  * Authors:
  * Johannes Pfau
  *
- * Source:    $(PHOBOSSRC std/_digest/_package.d)
+ * Source:    $(PHOBOSSRC std/digest/package.d)
  *
  * CTFE:
  * Digests do not work in CTFE

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -40,7 +40,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
  * $(LI $(LINK2 http://en.wikipedia.org/wiki/RIPEMD-160, Wikipedia on RIPEMD-160))
  * )
  *
- * Source: $(PHOBOSSRC std/digest/_ripemd.d)
+ * Source: $(PHOBOSSRC std/digest/ripemd.d)
  *
  */
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -46,7 +46,7 @@ $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
  * $(LI $(LINK2 http://en.wikipedia.org/wiki/Secure_Hash_Algorithm, Wikipedia article about SHA))
  * )
  *
- * Source: $(PHOBOSSRC std/digest/_sha.d)
+ * Source: $(PHOBOSSRC std/digest/sha.d)
  *
  */
 

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -3,8 +3,8 @@
 /**
 Classes and functions for handling and transcoding between various encodings.
 
-For cases where the _encoding is known at compile-time, functions are provided
-for arbitrary _encoding and decoding of characters, arbitrary transcoding
+For cases where the encoding is known at compile-time, functions are provided
+for arbitrary encoding and decoding of characters, arbitrary transcoding
 between strings of different type, as well as validation and sanitization.
 
 Encodings currently supported are UTF-8, UTF-16, UTF-32, ASCII, ISO-8859-1
@@ -77,7 +77,7 @@ $(TR $(TD Exceptions) $(TD
 ))
 )
 
-For cases where the _encoding is not known at compile-time, but is
+For cases where the encoding is not known at compile-time, but is
 known at run-time, the abstract class $(LREF EncodingScheme)
 and its subclasses is provided.  To construct a run-time encoder/decoder,
 one does e.g.
@@ -92,12 +92,12 @@ WINDOWS-1251, WINDOWS-1252, UTF-8, and (on little-endian architectures)
 UTF-16LE and UTF-32LE; or (on big-endian architectures) UTF-16BE and UTF-32BE.
 
 This library provides a mechanism whereby other modules may add $(LREF
-EncodingScheme) subclasses for any other _encoding.
+EncodingScheme) subclasses for any other encoding.
 
 Copyright: Copyright Janice Caron 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron
-Source:    $(PHOBOSSRC std/_encoding.d)
+Source:    $(PHOBOSSRC std/encoding.d)
 */
 /*
          Copyright Janice Caron 2008 - 2009.

--- a/std/exception.d
+++ b/std/exception.d
@@ -37,7 +37,7 @@ $(TR $(TD Other) $(TD
     License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Authors:   $(HTTP erdani.org, Andrei Alexandrescu) and
                $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/_exception.d)
+    Source:    $(PHOBOSSRC std/exception.d)
 
  +/
 module std.exception;

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_affix_allocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/affix_allocator.d)
 */
 module std.experimental.allocator.building_blocks.affix_allocator;
 

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_allocator_list.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/allocator_list.d)
 */
 module std.experimental.allocator.building_blocks.allocator_list;
 

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_ascending_page_allocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/ascending_page_allocator.d)
 */
 module std.experimental.allocator.building_blocks.ascending_page_allocator;
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_bitmapped_block.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/bitmapped_block.d)
 */
 module std.experimental.allocator.building_blocks.bitmapped_block;
 

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_bucketizer.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/bucketizer.d)
 */
 module std.experimental.allocator.building_blocks.bucketizer;
 

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_fallback_allocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/fallback_allocator.d)
 */
 module std.experimental.allocator.building_blocks.fallback_allocator;
 

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_free_list.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/free_list.d)
 */
 module std.experimental.allocator.building_blocks.free_list;
 

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_kernighan_ritchie.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/kernighan_ritchie.d)
 */
 module std.experimental.allocator.building_blocks.kernighan_ritchie;
 import std.experimental.allocator.building_blocks.null_allocator;

--- a/std/experimental/allocator/building_blocks/null_allocator.d
+++ b/std/experimental/allocator/building_blocks/null_allocator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_null_allocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/null_allocator.d)
 */
 module std.experimental.allocator.building_blocks.null_allocator;
 

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -287,7 +287,7 @@ $(COMMENT $(TR $(TDC2 InternalPointersTree) $(TD Adds support for resolving inte
 pointers on top of another allocator.)))
 )
 
-Source: $(PHOBOSSRC std/experimental/allocator/_building_blocks/package.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/package.d)
 
 Macros:
 MYREF2 = $(REF_SHORT $1, std,experimental,allocator,building_blocks,$2)

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_quantizer.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/quantizer.d)
 */
 module std.experimental.allocator.building_blocks.quantizer;
 

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_region.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/region.d)
 */
 module std.experimental.allocator.building_blocks.region;
 

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_scoped_allocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/scoped_allocator.d)
 */
 module std.experimental.allocator.building_blocks.scoped_allocator;
 

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_segregator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/segregator.d)
 */
 module std.experimental.allocator.building_blocks.segregator;
 

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -4,7 +4,7 @@ Allocator that collects useful statistics about allocations, both global and per
 calling point. The statistics collected can be configured statically by choosing
 combinations of `Options` appropriately.
 
-Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/_stats_collector.d)
+Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/stats_collector.d)
 */
 module std.experimental.allocator.building_blocks.stats_collector;
 

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -6,7 +6,7 @@ appropriate parts of `std`.
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu), Timon Gehr (`Ternary`)
 
-Source: $(PHOBOSSRC std/experimental/allocator/_common.d)
+Source: $(PHOBOSSRC std/experimental/allocator/common.d)
 */
 module std.experimental.allocator.common;
 import std.algorithm.comparison, std.traits;

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -2,7 +2,7 @@
 /**
 The C heap allocator.
 
-Source: $(PHOBOSSRC std/experimental/allocator/_mallocator.d)
+Source: $(PHOBOSSRC std/experimental/allocator/mallocator.d)
 */
 module std.experimental.allocator.mallocator;
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -69,7 +69,7 @@ to the type of the objects being allocated; they only deal in `void[]`, by
 necessity of the interface being dynamic (as opposed to type-parameterized).
 Each thread has a current allocator it uses by default, which is a thread-local
 variable $(LREF theAllocator) of type $(LREF IAllocator). The process has a
-global _allocator called $(LREF processAllocator), also of type $(LREF
+global allocator called $(LREF processAllocator), also of type $(LREF
 IAllocator). When a new thread is created, $(LREF processAllocator) is copied
 into $(LREF theAllocator). An application can change the objects to which these
 references point. By default, at application startup, $(LREF processAllocator)
@@ -82,7 +82,7 @@ $(LI A mid-level, statically-typed layer for assembling several allocators into
 one. It uses properties of the type of the objects being created to route
 allocation requests to possibly specialized allocators. This layer is relatively
 thin and implemented and documented in the $(MREF
-std,experimental,_allocator,typed) module. It allows an interested user to e.g.
+std,experimental,allocator,typed) module. It allows an interested user to e.g.
 use different allocators for arrays versus fixed-sized objects, to the end of
 better overall performance.)
 
@@ -91,27 +91,27 @@ Lego-like pieces that can be used to assemble application-specific allocators.
 The real allocation smarts are occurring at this level. This layer is of
 interest to advanced applications that want to configure their own allocators.
 A good illustration of typical uses of these building blocks is module $(MREF
-std,experimental,_allocator,showcase) which defines a collection of frequently-
+std,experimental,allocator,showcase) which defines a collection of frequently-
 used preassembled allocator objects. The implementation and documentation entry
-point is $(MREF std,experimental,_allocator,building_blocks). By design, the
+point is $(MREF std,experimental,allocator,building_blocks). By design, the
 primitives of the static interface have the same signatures as the $(LREF
 IAllocator) primitives but are for the most part optional and driven by static
 introspection. The parameterized class $(LREF CAllocatorImpl) offers an
-immediate and useful means to package a static low-level _allocator into an
+immediate and useful means to package a static low-level allocator into an
 implementation of $(LREF IAllocator).)
 
-$(LI Core _allocator objects that interface with D's garbage collected heap
-($(MREF std,experimental,_allocator,gc_allocator)), the C `malloc` family
-($(MREF std,experimental,_allocator,mallocator)), and the OS ($(MREF
-std,experimental,_allocator,mmap_allocator)). Most custom allocators would
+$(LI Core allocator objects that interface with D's garbage collected heap
+($(MREF std,experimental,allocator,gc_allocator)), the C `malloc` family
+($(MREF std,experimental,allocator,mallocator)), and the OS ($(MREF
+std,experimental,allocator,mmap_allocator)). Most custom allocators would
 ultimately obtain memory from one of these core allocators.)
 )
 
-$(H2 Idiomatic Use of `std.experimental._allocator`)
+$(H2 Idiomatic Use of `std.experimental.allocator`)
 
-As of this time, `std.experimental._allocator` is not integrated with D's
+As of this time, `std.experimental.allocator` is not integrated with D's
 built-in operators that allocate memory, such as `new`, array literals, or
-array concatenation operators. That means `std.experimental._allocator` is
+array concatenation operators. That means `std.experimental.allocator` is
 opt-in$(MDASH)applications need to make explicit use of it.
 
 For casual creation and disposal of dynamically-allocated objects, use $(LREF
@@ -133,9 +133,9 @@ void fun(size_t n)
 
 To experiment with alternative allocators, set $(LREF theAllocator) for the
 current thread. For example, consider an application that allocates many 8-byte
-objects. These are not well supported by the default _allocator, so a
-$(MREF_ALTTEXT free list _allocator,
-std,experimental,_allocator,building_blocks,free_list) would be recommended.
+objects. These are not well supported by the default allocator, so a
+$(MREF_ALTTEXT free list allocator,
+std,experimental,allocator,building_blocks,free_list) would be recommended.
 To install one in `main`, the application would use:
 
 ----
@@ -158,27 +158,27 @@ last through the application.
 
 To avoid this, long-lived objects that need to perform allocations,
 reallocations, and deallocations relatively often may want to store a reference
-to the _allocator object they use throughout their lifetime. Then, instead of
+to the allocator object they use throughout their lifetime. Then, instead of
 using `theAllocator` for internal allocation-related tasks, they'd use the
 internally held reference. For example, consider a user-defined hash table:
 
 ----
 struct HashTable
 {
-    private IAllocator _allocator;
+    private IAllocator allocator;
     this(size_t buckets, IAllocator allocator = theAllocator) {
-        this._allocator = allocator;
+        this.allocator = allocator;
         ...
     }
     // Getter and setter
-    IAllocator allocator() { return _allocator; }
-    void allocator(IAllocator a) { assert(empty); _allocator = a; }
+    IAllocator allocator() { return allocator; }
+    void allocator(IAllocator a) { assert(empty); allocator = a; }
 }
 ----
 
 Following initialization, the `HashTable` object would consistently use its
-`_allocator` object for acquiring memory. Furthermore, setting
-`HashTable._allocator` to point to a different _allocator should be legal but
+`allocator` object for acquiring memory. Furthermore, setting
+`HashTable.allocator` to point to a different allocator should be legal but
 only if the object is empty; otherwise, the object wouldn't be able to
 deallocate its existing state.
 
@@ -217,7 +217,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
 Authors: $(HTTP erdani.com, Andrei Alexandrescu)
 
-Source: $(PHOBOSSRC std/experimental/_allocator)
+Source: $(PHOBOSSRC std/experimental/allocator)
 
 */
 

--- a/std/experimental/allocator/typed.d
+++ b/std/experimental/allocator/typed.d
@@ -6,7 +6,7 @@ properties of the types allocated. For example, distinct allocators may be used
 for thread-local vs. thread-shared data, or for fixed-size data (`struct`,
 `class` objects) vs. resizable data (arrays).
 
-Source: $(PHOBOSSRC std/experimental/allocator/_typed.d)
+Source: $(PHOBOSSRC std/experimental/allocator/typed.d)
 
 Macros:
 T2=$(TR <td style="text-align:left">`$1`</td> $(TD $(ARGS $+)))

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -188,7 +188,7 @@ and `>>>=` is larger than the largest value representable by `T`.)
 )
 )
 
-Source: $(PHOBOSSRC std/experimental/_checkedint.d)
+Source: $(PHOBOSSRC std/experimental/checkedint.d)
 */
 module std.experimental.checkedint;
 import std.traits : isFloatingPoint, isIntegral, isNumeric, isUnsigned, Unqual;

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/logger/_core.d)
+Source: $(PHOBOSSRC std/experimental/logger/core.d)
 */
 module std.experimental.logger.core;
 

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/logger/_filelogger.d)
+Source: $(PHOBOSSRC std/experimental/logger/filelogger.d)
 */
 module std.experimental.logger.filelogger;
 

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/logger/_multilogger.d)
+Source: $(PHOBOSSRC std/experimental/logger/multilogger.d)
 */
 module std.experimental.logger.multilogger;
 

--- a/std/experimental/logger/nulllogger.d
+++ b/std/experimental/logger/nulllogger.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Source: $(PHOBOSSRC std/experimental/logger/_nulllogger.d)
+Source: $(PHOBOSSRC std/experimental/logger/nulllogger.d)
 */
 module std.experimental.logger.nulllogger;
 

--- a/std/experimental/logger/package.d
+++ b/std/experimental/logger/package.d
@@ -178,7 +178,7 @@ calls to its stored `Logger`. The `NullLogger` does not do anything. It
 will never log a message and will never throw on a log call with `LogLevel`
 `error`.
 
-Source: $(PHOBOSSRC std/experimental/logger/_package.d)
+Source: $(PHOBOSSRC std/experimental/logger/package.d)
 */
 module std.experimental.logger;
 

--- a/std/experimental/typecons.d
+++ b/std/experimental/typecons.d
@@ -1,14 +1,14 @@
 // Written in the D programming language.
 
 /**
-This module implements experimental additions/modifications to $(MREF std, _typecons).
+This module implements experimental additions/modifications to $(MREF std, typecons).
 
-Use this module to test out new functionality for $(REF wrap, std, _typecons)
+Use this module to test out new functionality for $(REF wrap, std, typecons)
 which allows for a struct to be wrapped against an interface; the
-implementation in $(MREF std, _typecons) only allows for classes to use the wrap
+implementation in $(MREF std, typecons) only allows for classes to use the wrap
 functionality.
 
-Source:    $(PHOBOSSRC std/experimental/_typecons.d)
+Source:    $(PHOBOSSRC std/experimental/typecons.d)
 
 Copyright: Copyright the respective authors, 2008-
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/file.d
+++ b/std/file.d
@@ -2,7 +2,7 @@
 
 /**
 Utilities for manipulating files and scanning directories. Functions
-in this module handle files as a unit, e.g., read or write one _file
+in this module handle files as a unit, e.g., read or write one file
 at a time. For opening files and manipulating them via handles refer
 to module $(MREF std, stdio).
 
@@ -74,7 +74,7 @@ License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP digitalmars.com, Walter Bright),
            $(HTTP erdani.org, Andrei Alexandrescu),
            $(HTTP jmdavisprog.com, Jonathan M Davis)
-Source:    $(PHOBOSSRC std/_file.d)
+Source:    $(PHOBOSSRC std/file.d)
  */
 module std.file;
 
@@ -180,7 +180,7 @@ class FileException : Exception
         Params:
             name = Name of file for which the error occurred.
             msg  = Message describing the error.
-            file = The _file where the error occurred.
+            file = The file where the error occurred.
             line = The _line where the error occurred.
      +/
     this(in char[] name, in char[] msg, string file = __FILE__, size_t line = __LINE__) @safe pure
@@ -195,7 +195,7 @@ class FileException : Exception
         Params:
             name  = Name of file for which the error occurred.
             errno = The error number.
-            file  = The _file where the error occurred.
+            file  = The file where the error occurred.
                     Defaults to `__FILE__`.
             line  = The _line where the error occurred.
                     Defaults to `__LINE__`.

--- a/std/format.d
+++ b/std/format.d
@@ -15,23 +15,23 @@ $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
     $(TR $(TD $(LREF formattedRead))
-        $(TD Reads values according to the _format string from an InputRange.
+        $(TD Reads values according to the format string from an InputRange.
     ))
     $(TR $(TD $(LREF formattedWrite))
-        $(TD Formats its arguments according to the _format string and puts them
+        $(TD Formats its arguments according to the format string and puts them
         to an OutputRange.
     ))
 )
 
    Please see the documentation of function $(LREF formattedWrite) for a
-   description of the _format string.
+   description of the format string.
 
    Two functions have been added for convenience:
 
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
-    $(TR $(TD $(LREF _format))
+    $(TR $(TD $(LREF format))
         $(TD Returns a GC-allocated string with the formatting result.
     ))
     $(TR $(TD $(LREF sformat))
@@ -51,7 +51,7 @@ $(TR $(TH Function Name) $(TH Description)
    Authors: $(HTTP walterbright.com, Walter Bright), $(HTTP erdani.com,
    Andrei Alexandrescu), and Kenji Hara
 
-   Source: $(PHOBOSSRC std/_format.d)
+   Source: $(PHOBOSSRC std/format.d)
  */
 module std.format;
 
@@ -6179,7 +6179,7 @@ package static const checkFormatException(alias fmt, Args...) =
  * better performance.
  *
  * Params: fmt  = Format string. For detailed specification, see $(LREF formattedWrite).
- *         args = Variadic list of arguments to _format into returned string.
+ *         args = Variadic list of arguments to format into returned string.
  *
  * Throws:
  *     $(LREF, FormatException) if the number of arguments doesn't match the number

--- a/std/functional.d
+++ b/std/functional.d
@@ -51,7 +51,7 @@ $(TR $(TH Function Name) $(TH Description)
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
-Source:    $(PHOBOSSRC std/_functional.d)
+Source:    $(PHOBOSSRC std/functional.d)
 */
 /*
          Copyright Andrei Alexandrescu 2008 - 2009.

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -18,7 +18,7 @@ Credits:   This module and its documentation are inspired by Perl's $(HTTP
            D's `getopt` is simpler than its Perl counterpart because $(D
            getopt) infers the expected parameter types from the static types of
            the passed-in pointers.
-Source:    $(PHOBOSSRC std/_getopt.d)
+Source:    $(PHOBOSSRC std/getopt.d)
 */
 /*
          Copyright Andrei Alexandrescu 2008 - 2015.

--- a/std/internal/scopebuffer.d
+++ b/std/internal/scopebuffer.d
@@ -2,7 +2,7 @@
  * Copyright: 2014 by Digital Mars
  * License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors: Walter Bright
- * Source: $(PHOBOSSRC std/internal/_scopebuffer.d)
+ * Source: $(PHOBOSSRC std/internal/scopebuffer.d)
  */
 
 module std.internal.scopebuffer;

--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -6,7 +6,7 @@
  *
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Kenji Hara
- * Source:    $(PHOBOSSRC std/internal/windows/_advapi32.d)
+ * Source:    $(PHOBOSSRC std/internal/windows/advapi32.d)
  */
 module std.internal.windows.advapi32;
 

--- a/std/json.d
+++ b/std/json.d
@@ -7,7 +7,7 @@ Copyright: Copyright Jeremie Pelletier 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth
 References: $(LINK http://json.org/)
-Source:    $(PHOBOSSRC std/_json.d)
+Source:    $(PHOBOSSRC std/json.d)
 */
 /*
          Copyright Jeremie Pelletier 2008 - 2009.

--- a/std/math.d
+++ b/std/math.d
@@ -117,7 +117,7 @@ $(TR $(TDNW Hardware Control) $(TD
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
  *            Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
- * Source: $(PHOBOSSRC std/_math.d)
+ * Source: $(PHOBOSSRC std/math.d)
  */
 module std.math;
 

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -50,7 +50,7 @@
  *            Copyright (C) 1994 Stephen L. Moshier (moshier@world.std.com).
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Stephen L. Moshier (original C code). Conversion to D by Don Clugston
- * Source:    $(PHOBOSSRC std/_mathspecial.d)
+ * Source:    $(PHOBOSSRC std/mathspecial.d)
  */
 module std.mathspecial;
 import std.internal.math.errorfunction;

--- a/std/meta.d
+++ b/std/meta.d
@@ -72,7 +72,7 @@
  * Authors:
  *     $(HTTP digitalmars.com, Walter Bright),
  *     $(HTTP klickverbot.at, David Nadlinger)
- * Source:    $(PHOBOSSRC std/_meta.d)
+ * Source:    $(PHOBOSSRC std/meta.d)
  */
 
 module std.meta;

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -6,7 +6,7 @@
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *            Matthew Wilson
- * Source:    $(PHOBOSSRC std/_mmfile.d)
+ * Source:    $(PHOBOSSRC std/mmfile.d)
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
-Networking client functionality as provided by $(HTTP _curl.haxx.se/libcurl,
+Networking client functionality as provided by $(HTTP curl.haxx.se/libcurl,
 libcurl). The libcurl library must be installed on the system in order to use
 this module.
 
@@ -139,13 +139,13 @@ the onReceive callback. See $(LREF onReceiveHeader)/$(LREF onReceive) for more
 information. Finally the HTTP request is effected by calling perform(), which is
 synchronous.
 
-Source: $(PHOBOSSRC std/net/_curl.d)
+Source: $(PHOBOSSRC std/net/curl.d)
 
 Copyright: Copyright Jonas Drewsen 2011-2012
 License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Jonas Drewsen. Some of the SMTP code contributed by Jimmy Cao.
 
-Credits: The functionally is based on $(HTTP _curl.haxx.se/libcurl, libcurl).
+Credits: The functionally is based on $(HTTP curl.haxx.se/libcurl, libcurl).
          LibCurl is licensed under an MIT/X derivative license.
 */
 /*

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -21,7 +21,7 @@
  *             $(LI $(LINK http://tools.ietf.org/html/rfc5322))
  *          )
  *
- * Source: $(PHOBOSSRC std/net/_isemail.d)
+ * Source: $(PHOBOSSRC std/net/isemail.d)
  */
 module std.net.isemail;
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -10,7 +10,7 @@ Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
                    Don Clugston, Robert Jacques, Ilya Yaroshenko
-Source:    $(PHOBOSSRC std/_numeric.d)
+Source:    $(PHOBOSSRC std/numeric.d)
 */
 /*
          Copyright Andrei Alexandrescu 2008 - 2009.

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -6,7 +6,7 @@ Serialize data to `ubyte` arrays.
  * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_outbuffer.d)
+ * Source:    $(PHOBOSSRC std/outbuffer.d)
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1,17 +1,17 @@
 /**
-`std._parallelism` implements high-level primitives for SMP _parallelism.
+`std.parallelism` implements high-level primitives for SMP parallelism.
 These include parallel foreach, parallel reduce, parallel eager map, pipelining
-and future/promise _parallelism.  `std._parallelism` is recommended when the
+and future/promise parallelism.  `std.parallelism` is recommended when the
 same operation is to be executed in parallel on different data, or when a
 function is to be executed in a background thread and its result returned to a
 well-defined main thread.  For communication between arbitrary threads, see
 `std.concurrency`.
 
-`std._parallelism` is based on the concept of a `Task`.  A `Task` is an
+`std.parallelism` is based on the concept of a `Task`.  A `Task` is an
 object that represents the fundamental unit of work in this library and may be
 executed in parallel with any other `Task`.  Using `Task`
 directly allows programming with a future/promise paradigm.  All other
-supported _parallelism paradigms (parallel foreach, map, reduce, pipelining)
+supported parallelism paradigms (parallel foreach, map, reduce, pipelining)
 represent an additional level of abstraction over `Task`.  They
 automatically create one or more `Task` objects, or closely related types
 that are conceptually identical but not part of the public API.
@@ -33,7 +33,7 @@ Warning:  Unless marked as `@trusted` or `@safe`, artifacts in
           this module allow implicit data sharing between threads and cannot
           guarantee that client code is free from low level data races.
 
-Source:    $(PHOBOSSRC std/_parallelism.d)
+Source:    $(PHOBOSSRC std/parallelism.d)
 Author:  David Simcha
 Copyright:  Copyright (c) 2009-2011, David Simcha.
 License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
@@ -399,7 +399,7 @@ private struct AbstractTask
 /**
 `Task` represents the fundamental unit of work.  A `Task` may be
 executed in parallel with any other `Task`.  Using this struct directly
-allows future/promise _parallelism.  In this paradigm, a function (or delegate
+allows future/promise parallelism.  In this paradigm, a function (or delegate
 or other callable) is executed in a thread other than the one it was called
 from.  The calling thread does not block while the function is being executed.
 A call to `workForce`, `yieldForce`, or `spinForce` is used to

--- a/std/path.d
+++ b/std/path.d
@@ -1,15 +1,15 @@
 // Written in the D programming language.
 
-/** This module is used to manipulate _path strings.
+/** This module is used to manipulate path strings.
 
     All functions, with the exception of $(LREF expandTilde) (and in some
     cases $(LREF absolutePath) and $(LREF relativePath)), are pure
     string manipulation functions; they don't depend on any state outside
     the program, nor do they perform any actual file system actions.
     This has the consequence that the module does not make any distinction
-    between a _path that points to a directory and a _path that points to a
+    between a path that points to a directory and a path that points to a
     file, and it does not know whether or not the object pointed to by the
-    _path actually exists in the file system.
+    path actually exists in the file system.
     To differentiate between these cases, use $(REF isDir, std,file) and
     $(REF exists, std,file).
 
@@ -21,9 +21,9 @@
 
     In general, the functions in this module assume that the input paths
     are well-formed.  (That is, they should not contain invalid characters,
-    they should follow the file system's _path format, etc.)  The result
-    of calling a function on an ill-formed _path is undefined.  When there
-    is a chance that a _path or a file name is invalid (for instance, when it
+    they should follow the file system's path format, etc.)  The result
+    of calling a function on an ill-formed path is undefined.  When there
+    is a chance that a path or a file name is invalid (for instance, when it
     has been input by the user), it may sometimes be desirable to use the
     $(LREF isValidFilename) and $(LREF isValidPath) functions to check
     this.
@@ -91,7 +91,7 @@ $(TR $(TD Other) $(TD
     License:
         $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Source:
-        $(PHOBOSSRC std/_path.d)
+        $(PHOBOSSRC std/path.d)
 */
 module std.path;
 
@@ -807,7 +807,7 @@ Lnull:
         path = string or range of characters
 
     Returns:
-        A slice of `_path` that is the drive, or an empty range if the drive
+        A slice of `path` that is the drive, or an empty range if the drive
         is not specified.  In the case of UNC paths, the network share
         is returned.
 
@@ -1165,7 +1165,7 @@ private auto _stripExtension(R)(R path)
         path = A path name
         ext = The new extension
 
-    Returns: A string containing the _path given by `path`, but where
+    Returns: A string containing the path given by `path`, but where
     the extension has been set to `ext`.
 
     See_Also:
@@ -1303,7 +1303,7 @@ private auto _withExtension(R, C)(R path, C[] ext)
         path = A path name.
         ext = The default extension to use.
 
-    Returns: The _path given by `path`, with the extension given by `ext`
+    Returns: The path given by `path`, with the extension given by `ext`
     appended if the path doesn't already have one.
 
     Including the dot in the extension is optional.
@@ -1895,7 +1895,7 @@ if (isSomeChar!C)
     Use $(LREF buildNormalizedPath) to allocate memory and return a string.
 
     Params:
-        path = string or random access range representing the _path to normalize
+        path = string or random access range representing the path to normalize
 
     Returns:
         normalized path as a forward range
@@ -2712,7 +2712,7 @@ else version (Posix)
 
 
 
-/** Transforms `path` into an absolute _path.
+/** Transforms `path` into an absolute path.
 
     The following algorithm is used:
     $(OL
@@ -2785,7 +2785,7 @@ string absolutePath(string path, lazy string base = getcwd())
     assertThrown(absolutePath("bar", "foo"));
 }
 
-/** Transforms `path` into an absolute _path.
+/** Transforms `path` into an absolute path.
 
     The following algorithm is used:
     $(OL
@@ -2843,11 +2843,11 @@ if (isConvertibleToString!R)
     assert(testAliasedString!asAbsolutePath(null));
 }
 
-/** Translates `path` into a relative _path.
+/** Translates `path` into a relative path.
 
-    The returned _path is relative to `base`, which is by default
+    The returned path is relative to `base`, which is by default
     taken to be the current working directory.  If specified,
-    `base` must be an absolute _path, and it is always assumed
+    `base` must be an absolute path, and it is always assumed
     to refer to a directory.  If `path` and `base` refer to
     the same directory, the function returns ``.``.
 
@@ -2939,11 +2939,11 @@ string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
     else static assert(0);
 }
 
-/** Transforms `path` into a _path relative to `base`.
+/** Transforms `path` into a path relative to `base`.
 
-    The returned _path is relative to `base`, which is usually
+    The returned path is relative to `base`, which is usually
     the current working directory.
-    `base` must be an absolute _path, and it is always assumed
+    `base` must be an absolute path, and it is always assumed
     to refer to a directory.  If `path` and `base` refer to
     the same directory, the function returns `'.'`.
 
@@ -2964,13 +2964,13 @@ string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
     $(LREF filenameCmp) documentation for details.
 
     Params:
-        path = _path to transform
+        path = path to transform
         base = absolute path
         cs = whether filespec comparisons are sensitive or not; defaults to
          `CaseSensitive.osDefault`
 
     Returns:
-        a random access range of the transformed _path
+        a random access range of the transformed path
 
     See_Also:
         $(LREF relativePath)
@@ -3715,13 +3715,13 @@ unittest
 
 
 
-/** Checks whether `path` is a valid _path.
+/** Checks whether `path` is a valid path.
 
     Generally, this function checks that `path` is not empty, and that
     each component of the path either satisfies $(LREF isValidFilename)
     or is equal to `"."` or `".."`.
 
-    $(B It does $(I not) check whether the _path points to an existing file
+    $(B It does $(I not) check whether the path points to an existing file
     or directory; use $(REF exists, std,file) for this purpose.)
 
     On Windows, some special rules apply:
@@ -3744,7 +3744,7 @@ unittest
         path = string or Range of characters to check
 
     Returns:
-        true if `path` is a valid _path.
+        true if `path` is a valid path.
 */
 bool isValidPath(Range)(Range path)
 if ((isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && isSomeChar!(ElementEncodingType!Range) ||

--- a/std/process.d
+++ b/std/process.d
@@ -2,33 +2,33 @@
 
 /**
 Functions for starting and interacting with other processes, and for
-working with the current _process' execution environment.
+working with the current process' execution environment.
 
 Process_handling:
 $(UL $(LI
-    $(LREF spawnProcess) spawns a new _process, optionally assigning it an
+    $(LREF spawnProcess) spawns a new process, optionally assigning it an
     arbitrary set of standard input, output, and error streams.
-    The function returns immediately, leaving the child _process to execute
+    The function returns immediately, leaving the child process to execute
     in parallel with its parent.  All other functions in this module that
     spawn processes are built around `spawnProcess`.)
 $(LI
-    $(LREF wait) makes the parent _process wait for a child _process to
+    $(LREF wait) makes the parent process wait for a child process to
     terminate.  In general one should always do this, to avoid
-    child processes becoming "zombies" when the parent _process exits.
+    child processes becoming "zombies" when the parent process exits.
     Scope guards are perfect for this – see the $(LREF spawnProcess)
     documentation for examples.  $(LREF tryWait) is similar to `wait`,
-    but does not block if the _process has not yet terminated.)
+    but does not block if the process has not yet terminated.)
 $(LI
-    $(LREF pipeProcess) also spawns a child _process which runs
+    $(LREF pipeProcess) also spawns a child process which runs
     in parallel with its parent.  However, instead of taking
     arbitrary streams, it automatically creates a set of
     pipes that allow the parent to communicate with the child
     through the child's standard input, output, and/or error streams.
     This function corresponds roughly to C's `popen` function.)
 $(LI
-    $(LREF execute) starts a new _process and waits for it
+    $(LREF execute) starts a new process and waits for it
     to complete before returning.  Additionally, it captures
-    the _process' standard output and error streams and returns
+    the process' standard output and error streams and returns
     the output of these as a string.)
 $(LI
     $(LREF spawnShell), $(LREF pipeShell) and $(LREF executeShell) work like
@@ -37,16 +37,16 @@ $(LI
     the current user's default command interpreter.
     `executeShell` corresponds roughly to C's `system` function.)
 $(LI
-    $(LREF kill) attempts to terminate a running _process.)
+    $(LREF kill) attempts to terminate a running process.)
 )
 
-The following table compactly summarises the different _process creation
+The following table compactly summarises the different process creation
 functions and how they relate to each other:
 $(BOOKTABLE,
     $(TR $(TH )
          $(TH Runs program directly)
          $(TH Runs shell command))
-    $(TR $(TD Low-level _process creation)
+    $(TR $(TD Low-level process creation)
          $(TD $(LREF spawnProcess))
          $(TD $(LREF spawnShell)))
     $(TR $(TD Automatic input/output redirection using pipes)
@@ -62,7 +62,7 @@ $(UL
 $(LI
     $(LREF pipe) is used to create unidirectional pipes.)
 $(LI
-    $(LREF environment) is an interface through which the current _process'
+    $(LREF environment) is an interface through which the current process'
     environment variables can be read and manipulated.)
 $(LI
     $(LREF escapeShellCommand) and $(LREF escapeShellFileName) are useful
@@ -78,7 +78,7 @@ Copyright:
 License:
    $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Source:
-    $(PHOBOSSRC std/_process.d)
+    $(PHOBOSSRC std/process.d)
 Macros:
     OBJECTREF=$(REF1 $0, object)
 */
@@ -160,10 +160,10 @@ private
 
 
 /**
-Spawns a new _process, optionally assigning it an arbitrary set of standard
+Spawns a new process, optionally assigning it an arbitrary set of standard
 input, output, and error streams.
 
-The function returns immediately, leaving the child _process to execute
+The function returns immediately, leaving the child process to execute
 in parallel with its parent.  It is recommended to always call $(LREF wait)
 on the returned $(LREF Pid) unless the process was spawned with
 `Config.detached` flag, as detailed in the documentation for `wait`.

--- a/std/random.d
+++ b/std/random.d
@@ -54,7 +54,7 @@ $(TR $(TD Traits) $(TD
 ))
 )
 
-$(RED Disclaimer:) The _random number generators and API provided in this
+$(RED Disclaimer:) The random number generators and API provided in this
 module are not designed to be cryptographically secure, and are therefore
 unsuitable for cryptographic or security-related purposes such as generating
 authentication tokens or network sequence numbers. For such needs, please use a
@@ -79,7 +79,7 @@ distributions, which skew a generator's output statistical
 distribution in various ways. So far the uniform distribution for
 integers and real numbers have been implemented.
 
-Source:    $(PHOBOSSRC std/_random.d)
+Source:    $(PHOBOSSRC std/random.d)
 
 Macros:
 
@@ -88,7 +88,7 @@ License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
            Masahiro Nakagawa (Xorshift random generator)
            $(HTTP braingam.es, Joseph Rushton Wakeling) (Algorithm D for random sampling)
-           Ilya Yaroshenko (Mersenne Twister implementation, adapted from $(HTTPS github.com/libmir/mir-_random, mir-_random))
+           Ilya Yaroshenko (Mersenne Twister implementation, adapted from $(HTTPS github.com/libmir/mir-random, mir-random))
 Credits:   The entire random number library architecture is derived from the
            excellent $(HTTP open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2461.pdf, C++0X)
            random number facility proposed by Jens Maurer and contributed to by

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -61,7 +61,7 @@ $(BOOKTABLE ,
 )
 
 
-Source: $(PHOBOSSRC std/range/_interfaces.d)
+Source: $(PHOBOSSRC std/range/interfaces.d)
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -217,7 +217,7 @@ sort, std, algorithm, sorting) function also conveniently
 returns a $(LREF SortedRange). $(LREF SortedRange) objects provide some additional
 range operations that take advantage of the fact that the range is sorted.
 
-Source: $(PHOBOSSRC std/range/_package.d)
+Source: $(PHOBOSSRC std/range/package.d)
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
@@ -10998,15 +10998,15 @@ if (isInputRange!(Unqual!R))
     consumed as if it were a reference type.
 
     Note:
-        `save` works as normal and operates on a new _range, so if
+        `save` works as normal and operates on a new range, so if
         `save` is ever called on the `RefRange`, then no operations on the
-        saved _range will affect the original.
+        saved range will affect the original.
 
     Params:
         range = the range to construct the `RefRange` from
 
     Returns:
-        A `RefRange`. If the given _range is a class type
+        A `RefRange`. If the given range is a class type
         (and thus is already a reference type), then the original
         range is returned rather than a `RefRange`.
   +/

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -103,7 +103,7 @@ $(BOOKTABLE ,
     ))
 )
 
-Source: $(PHOBOSSRC std/range/_primitives.d)
+Source: $(PHOBOSSRC std/range/primitives.d)
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -18,7 +18,7 @@ $(TR $(TD Matching) $(TD
 $(TR $(TD Building) $(TD
         $(LREF ctRegex)
         $(LREF escaper)
-        $(LREF _regex)
+        $(LREF regex)
 ))
 $(TR $(TD Replace) $(TD
         $(LREF replace)
@@ -284,7 +284,7 @@ $(TR $(TD Objects) $(TD
     API and utility constructs are modeled after the original `std.regex`
   by Walter Bright and Andrei Alexandrescu.
 
-  Source: $(PHOBOSSRC std/_regex/_package.d)
+  Source: $(PHOBOSSRC std/regex/package.d)
 
 Macros:
     REG_ROW = $(TR $(TD $(I $1 )) $(TD $+) )

--- a/std/signals.d
+++ b/std/signals.d
@@ -51,7 +51,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_signals.d)
+ * Source:    $(PHOBOSSRC std/signals.d)
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */

--- a/std/socket.d
+++ b/std/socket.d
@@ -39,7 +39,7 @@
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors: Christopher E. Miller, $(HTTP klickverbot.at, David Nadlinger),
  *      $(HTTP thecybershadow.net, Vladimir Panteleev)
- * Source:  $(PHOBOSSRC std/_socket.d)
+ * Source:  $(PHOBOSSRC std/socket.d)
  */
 
 module std.socket;

--- a/std/stdint.d
+++ b/std/stdint.d
@@ -119,7 +119,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_stdint.d)
+ * Source:    $(PHOBOSSRC std/stdint.d)
  */
 /*          Copyright Digital Mars 2000 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4,7 +4,7 @@
 Standard I/O functions that extend $(B core.stdc.stdio).  $(B core.stdc.stdio)
 is $(D_PARAM public)ally imported when importing $(B std.stdio).
 
-Source: $(PHOBOSSRC std/_stdio.d)
+Source: $(PHOBOSSRC std/stdio.d)
 Copyright: Copyright Digital Mars 2007-.
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP digitalmars.com, Walter Bright),

--- a/std/string.d
+++ b/std/string.d
@@ -69,7 +69,7 @@ $(TR $(TDNW Miscellaneous)
     )
 )))
 
-Objects of types `_string`, `wstring`, and `dstring` are value types
+Objects of types `string`, `wstring`, and `dstring` are value types
 and cannot be mutated element-by-element. For using mutation during building
 strings, use `char[]`, `wchar[]`, or `dchar[]`. The `xxxstring`
 types are preferable because they don't exhibit undesired aliasing, thus
@@ -110,7 +110,7 @@ $(LEADINGROW Publicly imported functions)
     ))
 )
 
-There is a rich set of functions for _string handling defined in other modules.
+There is a rich set of functions for string handling defined in other modules.
 Functions related to Unicode and ASCII are found in $(MREF std, uni)
 and $(MREF std, ascii), respectively. Other functions that have a
 wider generality than just strings can be found in $(MREF std, algorithm)
@@ -138,7 +138,7 @@ Authors: $(HTTP digitalmars.com, Walter Bright),
          $(HTTP jmdavisprog.com, Jonathan M Davis),
          and David L. 'SpottedTiger' Davis
 
-Source:    $(PHOBOSSRC std/_string.d)
+Source:    $(PHOBOSSRC std/string.d)
 
 */
 module std.string;

--- a/std/system.d
+++ b/std/system.d
@@ -7,7 +7,7 @@
  *  License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *  Authors:   $(HTTP digitalmars.com, Walter Bright) and
                $(HTTP jmdavisprog.com, Jonathan M Davis)
- *  Source:    $(PHOBOSSRC std/_system.d)
+ *  Source:    $(PHOBOSSRC std/system.d)
  */
 module std.system;
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -8,12 +8,12 @@
  * $(DIVC quickindex,
  * $(BOOKTABLE ,
  * $(TR $(TH Category) $(TH Templates))
- * $(TR $(TD Symbol Name _traits) $(TD
+ * $(TR $(TD Symbol Name traits) $(TD
  *           $(LREF fullyQualifiedName)
  *           $(LREF moduleName)
  *           $(LREF packageName)
  * ))
- * $(TR $(TD Function _traits) $(TD
+ * $(TR $(TD Function traits) $(TD
  *           $(LREF isFunction)
  *           $(LREF arity)
  *           $(LREF functionAttributes)
@@ -31,7 +31,7 @@
  *           $(LREF SetFunctionAttributes)
  *           $(LREF variadicFunctionStyle)
  * ))
- * $(TR $(TD Aggregate Type _traits) $(TD
+ * $(TR $(TD Aggregate Type traits) $(TD
  *           $(LREF BaseClassesTuple)
  *           $(LREF BaseTypeTuple)
  *           $(LREF classInstanceAlignment)
@@ -156,7 +156,7 @@
  *            $(HTTP klickverbot.at, David Nadlinger),
  *            Kenji Hara,
  *            Shoichi Kato
- * Source:    $(PHOBOSSRC std/_traits.d)
+ * Source:    $(PHOBOSSRC std/traits.d)
  */
 /*          Copyright Digital Mars 2005 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -59,7 +59,7 @@ $(TR $(TD Types) $(TD
 
 Copyright: Copyright the respective authors, 2008-
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Source:    $(PHOBOSSRC std/_typecons.d)
+Source:    $(PHOBOSSRC std/typecons.d)
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
            $(HTTP bartoszmilewski.wordpress.com, Bartosz Milewski),
            Don Clugston,

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright Digital Mars 2005 - 2015.
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
- * Source:    $(PHOBOSSRC std/_typetuple.d)
+ * Source:    $(PHOBOSSRC std/typetuple.d)
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */

--- a/std/uni.d
+++ b/std/uni.d
@@ -691,7 +691,7 @@ $(TR $(TD Building blocks) $(TD
     Copyright: Copyright 2013 -
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Dmitry Olshansky
-    Source:    $(PHOBOSSRC std/_uni.d)
+    Source:    $(PHOBOSSRC std/uni.d)
     Standards: $(HTTP www.unicode.org/versions/Unicode6.2.0/, Unicode v6.2)
 
 Macros:
@@ -2435,8 +2435,8 @@ public:
         open-right intervals and feed it to `sink`.
         )
         $(P Used by various standard formatting facilities such as
-         $(REF formattedWrite, std,_format), $(REF write, std,_stdio),
-         $(REF writef, std,_stdio), $(REF to, std,_conv) and others.
+         $(REF formattedWrite, std,format), $(REF write, std,stdio),
+         $(REF writef, std,stdio), $(REF to, std,conv) and others.
         )
         Example:
         ---

--- a/std/uri.d
+++ b/std/uri.d
@@ -14,7 +14,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_uri.d)
+ * Source:    $(PHOBOSSRC std/uri.d)
  */
 /*          Copyright Digital Mars 2000 - 2009.
  * Distributed under the Boost Software License, Version 1.0.

--- a/std/utf.d
+++ b/std/utf.d
@@ -56,7 +56,7 @@ $(TR $(TD Miscellaneous) $(TD
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP digitalmars.com, Walter Bright) and
                $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC std/_utf.d)
+    Source:    $(PHOBOSSRC std/utf.d)
    +/
 module std.utf;
 

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -72,7 +72,7 @@ $(TR $(TDNW UUID namespaces)
  * Use UUID's constructors or the UUID generator functions to get an initialized UUID.
  *
  * This is a port of $(LINK2 http://www.boost.org/doc/libs/1_42_0/libs/uuid/uuid.html,
- * boost._uuid) from the Boost project with some minor additions and API
+ * boost.uuid) from the Boost project with some minor additions and API
  * changes for a more D-like API.
  *
  * Standards:
@@ -84,7 +84,7 @@ $(TR $(TDNW UUID namespaces)
  * Copyright: Copyright Johannes Pfau 2011 - .
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Johannes Pfau
- * Source:    $(PHOBOSSRC std/_uuid.d)
+ * Source:    $(PHOBOSSRC std/uuid.d)
  *
  * Macros:
  * MYREF2 = <a href="#$2">$(TT $1)</a>&nbsp;

--- a/std/variant.d
+++ b/std/variant.d
@@ -29,7 +29,7 @@ for associative arrays; (3) friendlier behavior towards the garbage collector.
 Copyright: Copyright Andrei Alexandrescu 2007 - 2015.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(HTTP erdani.org, Andrei Alexandrescu)
-Source:    $(PHOBOSSRC std/_variant.d)
+Source:    $(PHOBOSSRC std/variant.d)
 */
 module std.variant;
 

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -12,7 +12,7 @@
         Created      15th March 2003,
         Updated      25th April 2004,
 
-    Source:    $(PHOBOSSRC std/windows/_registry.d)
+    Source:    $(PHOBOSSRC std/windows/registry.d)
 */
 /* /////////////////////////////////////////////////////////////////////////////
  *

--- a/std/xml.d
+++ b/std/xml.d
@@ -115,7 +115,7 @@ void main()
 Copyright: Copyright Janice Caron 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Janice Caron
-Source:    $(PHOBOSSRC std/_xml.d)
+Source:    $(PHOBOSSRC std/xml.d)
 */
 /*
          Copyright Janice Caron 2008 - 2009.

--- a/std/zip.d
+++ b/std/zip.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
- * Read/write data in the $(LINK2 http://www.info-zip.org, _zip archive) format.
+ * Read/write data in the $(LINK2 http://www.info-zip.org, zip archive) format.
  * Makes use of the etc.c.zlib compression library.
  *
  * Bugs:
@@ -61,7 +61,7 @@ void main()
  * Copyright: Copyright Digital Mars 2000 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_zip.d)
+ * Source:    $(PHOBOSSRC std/zip.d)
  */
 
 /*          Copyright Digital Mars 2000 - 2009.

--- a/std/zlib.d
+++ b/std/zlib.d
@@ -1,7 +1,7 @@
 // Written in the D programming language.
 
 /**
- * Compress/decompress data using the $(HTTP www._zlib.net, _zlib library).
+ * Compress/decompress data using the $(HTTP www.zlib.net, zlib library).
  *
  * Examples:
  *
@@ -46,7 +46,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
- * Source:    $(PHOBOSSRC std/_zlib.d)
+ * Source:    $(PHOBOSSRC std/zlib.d)
  */
 /*          Copyright Digital Mars 2000 - 2011.
  * Distributed under the Boost Software License, Version 1.0.


### PR DESCRIPTION
A start at removing the no longer needed underscore escaping from Phobos.
This was done partially by a script to get an initial set of replacements:

```d
import std.experimental.all;
void main(string[] args)
{
    foreach (file; dirEntries(".", "*.d", SpanMode.depth))
    {
        auto text = file.readText;
        auto packageName = file.baseName.stripExtension;
        auto moduleName = file.dirName.baseName;
        foreach (rep; [packageName, moduleName])
            text = text.replace("_"~rep, rep);
        text.toFile(file);
    }
}
```

And then manually adding the replacements to the git index.
I might have missed a few instances (or skipped the ones which were a bit more complicated),
but we can easily find them later with the `DDOC_AUTO_PSYMBOL_SUPPRESS` macro).

See also:
- https://github.com/dlang/dlang.org/pull/2307
- https://dlang.org/changelog/2.079.0.html#fix18361