### PR TITLE
Musl: last remaining tweaks

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -781,7 +781,11 @@ public:
 
     @safe unittest
     {
-        assert(LocalTime().dstName !is null);
+        // tzname, called from dstName, isn't set by default for Musl.
+        version(CRuntime_Musl)
+            assert(LocalTime().dstName is null);
+        else
+            assert(LocalTime().dstName !is null);
 
         version(Posix)
         {

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -704,9 +704,12 @@ version(CRuntime_Musl)
     // sbrk and brk are disabled in Musl:
     // https://git.musl-libc.org/cgit/musl/commit/?id=7a995fe706e519a4f55399776ef0df9596101f93
     // https://git.musl-libc.org/cgit/musl/commit/?id=863d628d93ea341b6a32661a1654320ce69f6a07
-} else:
-private extern(C) void* sbrk(long) nothrow @nogc;
-private extern(C) int brk(shared void*) nothrow @nogc;
+}
+else
+{
+    private extern(C) void* sbrk(long) nothrow @nogc;
+    private extern(C) int brk(shared void*) nothrow @nogc;
+}
 
 /**
 
@@ -718,6 +721,7 @@ that uncontrolled calls to `brk` and `sbrk` may affect the workings of $(D
 SbrkRegion) adversely.
 
 */
+version(CRuntime_Musl) {} else
 version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
 {
     import core.sys.posix.pthread : pthread_mutex_init, pthread_mutex_destroy,
@@ -898,6 +902,7 @@ version(Posix) struct SbrkRegion(uint minAlign = platformAlignment)
     }
 }
 
+version(CRuntime_Musl) {} else
 version(Posix) @system nothrow @nogc unittest
 {
     // Let's test the assumption that sbrk(n) returns the old address
@@ -910,6 +915,7 @@ version(Posix) @system nothrow @nogc unittest
     sbrk(-4096);
 }
 
+version(CRuntime_Musl) {} else
 version(Posix) @system nothrow @nogc unittest
 {
     import std.typecons : Ternary;


### PR DESCRIPTION
`tzname` is unset by default on Musl, and @jercaianu added more code below `SbrkRegion`, so need to version out that part alone for Musl now. With this pull, all Phobos tests pass with Musl on Alpine.