### PR TITLE
[trivial] popFront is not a property

### DIFF
--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -70,7 +70,7 @@ struct ThreadList(DataIndex)
         this(ThreadList tlist){ ct = tlist.tip; }
         @property bool empty(){ return ct is null; }
         @property const(Thread!DataIndex)* front(){ return ct; }
-        @property popFront()
+        void popFront()
         {
             assert(ct);
             ct = ct.next;


### PR DESCRIPTION
This fixes a possible deprecation with https://github.com/dlang/dmd/pull/8320.