### PR TITLE
Expose experimental packages on Dub

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -134,6 +134,15 @@ publictests()
     make -f posix.mak -j$N publictests DUB=$DUB BUILD=$BUILD
 }
 
+# test stdx dub package
+dub_package()
+{
+    pushd test
+    dub -v --single dub_stdx_checkedint.d
+    dub -v --single dub_stdx_allocator.d
+    popd
+}
+
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ obj/
 .vscode
 
 *.html
+
+.dub/
+libphobos_*
+source/

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,6 +1,50 @@
 name "phobos"
 license "BSL-1.0"
+description "D Standard Library"
+authors "DLang Community"
 copyright "Copyright © 1999-2018, The D Language Foundation"
+
 targetType "library"
 sourcePaths "std" "etc"
 targetPath "generated"
+
+subPackage {
+  name "checkedint"
+  targetType "library"
+  preGenerateCommands `rdmd --eval='
+	auto pkgDir = environment.get("DUB_PACKAGE_DIR");
+	auto destDir = pkgDir.buildPath("source", "stdx");
+	mkdirRecurse(destDir);
+	pkgDir.buildPath("std", "experimental", "checkedint.d")
+		  .readText
+		  .replace("std.experimental.checkedint", "stdx.checkedint")
+		  .toFile(destDir.buildPath("checkedint.d"));'`
+  sourceFiles "source/stdx/checkedint.d"
+  importPaths "source"
+}
+
+// This meta package is needed because dub searches for the source files _before_ it evaluates preGenerateCommands
+// However, it does run its dependencies _before_ searching through its source paths
+subPackage {
+  name "allocator-generator"
+  targetType "none"
+  preGenerateCommands `rdmd --eval='
+	auto pkgDir = environment.get("DUB_PACKAGE_DIR");
+	auto destDir = pkgDir.buildPath("source", "stdx", "allocator");
+	auto srcDir = pkgDir.buildPath("std", "experimental", "allocator");
+	foreach (file; srcDir.dirEntries("*.d", SpanMode.depth)) {
+		auto destFile = file.replace(srcDir, destDir);
+		destFile.dirName.mkdirRecurse;
+		file.readText.replace("std.experimental.allocator", "stdx.allocator")
+		 	.toFile(destFile);
+	}
+	'`
+}
+
+subPackage {
+  name "allocator"
+  targetType "library"
+  dependency "phobos:allocator-generator" version="*"
+  sourcePaths "source/stdx/allocator"
+  importPaths "source"
+}

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+dub_stdx_allocator
+dub_stdx_checkedint

--- a/test/dub_stdx_allocator.d
+++ b/test/dub_stdx_allocator.d
@@ -1,0 +1,13 @@
+#!/usr/bin/env dub
+/++dub.sdl:
+dependency "phobos:allocator" path=".."
++/
+
+void main(string[] args)
+{
+    import stdx.allocator.mallocator : Mallocator; // From latest Phobos
+    import std.stdio; // current phobos
+    auto buf = Mallocator.instance.allocate(10);
+    writeln("allocate: ", buf);
+    scope(exit) Mallocator.instance.deallocate(buf);
+}

--- a/test/dub_stdx_checkedint.d
+++ b/test/dub_stdx_checkedint.d
@@ -1,0 +1,11 @@
+#!/usr/bin/env dub
+/++dub.sdl:
+dependency "phobos:checkedint" path=".."
++/
+
+void main(string[] args)
+{
+    import stdx.checkedint; // From latest Phobos
+    import std.stdio; // DMD's Phobos
+    writeln("checkedint: ", 2.checked + 3);
+}


### PR DESCRIPTION
I often had the need to use the latest version of a package in Phobos, but without requiring my library users to upgrade their compiler.

This simple `dub.sdl` allows the usage of the checkedint module via DUB.

Example
-------

```d
#!/usr/bin/env dub
/++dub.sdl:
dependency "phobos:checkedint" path=".."
+/

void main(string[] args)
{
    import stdx.checkedint; // From latest Phobos
    import std.stdio; // DMD's Phobos
    writeln("checkedint: ", 2.checked + 3);
}
```

Motivation
----------

Of course, the main motivation is `std.experimental.allocator`, but that's a bit more complicated.

Future
------

Also, like for [dmd's dub package](http://code.dlang.org/packages/dmd) it will only be exposed as `~master` due to D's versioning not matching SemVer and thus the DUB registry rejecting the versions.

I will add a preview for the `std.experimental.allocator` package within the next days, but maybe someone already has an opinion on this?