### PR TITLE
Fix Issue 18595 & Issue 18596: replace MindstdRand0 w/SplitMix & templatize unpredictableSeed!UIntType

### DIFF
--- a/changelog/pr6580.dd
+++ b/changelog/pr6580.dd
@@ -1,0 +1,23 @@
+Add overload `std.random.unpredictableSeed!UIntType`
+
+$(REF unpredictableSeed, std,random) now has an overloaded version
+`std.random.unpredictableSeed!UIntType` that can be used to produce
+seeds of any unsigned type `UIntType`.
+
+-------
+import std.random : unpredictableSeed;
+
+auto a = unpredictableSeed!uint;
+static assert(is(typeof(a) == uint));
+
+auto b = unpredictableSeed!ulong;
+static assert(is(typeof(b) == ulong));
+
+// The old syntax still works.
+uint c = unpredictableSeed;
+-------
+
+Additionally the implementation quality of `unpredictableSeed` has been
+improved, speeding it up and eliminating an obvious pattern in the high
+bit. (Bear in mind that `unpredictableSeed` is still not
+cryptographically secure.)


### PR DESCRIPTION
Slicing the elephant into smaller pieces. This PR differs from https://github.com/dlang/phobos/pull/6388 in that it omits entirely system entropy.

The PR's visible change is that one may now write `unpredictableSeed!ulong` and get a `ulong`. The PR's under-the-hood change is that instead of thread-local MinstdRand0 `unpredictableSeed` uses a global SplitMix.

**Q: Why prefer global shared (atomic) instance to thread-locals?**
**A:** It gives us an easy guarantee that the same `ulong` seed will not be produced by more than 1 thread except if `unpredictableSeed!ulong` is called 2^^64 times during the life of the application. The question should rather be, what advantage would thread-local storage give us here?

**Q: What about cryptography?**
**A:** This PR changes nothing about the current situation. `unpredictableSeed` is not in any sense unpredictable to an adversary willing to use mathematics.

**Q: What about speed?**
**A:** This shouldn't be a main consideration, but this implementation happens to be faster. The new `unpredictableSeed` takes about 1/3 the time with `ldc2 -O` and about 1/2 the time with `dmd -O -inline`. The story is even better if you compare the new `unpredictableSeed!ulong` to calling the old `unpredictableSeed` twice to produce a 64-bit value.