### PR TITLE
Fix Issue 12507 - SysTime.init.toString should not segfault

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -2342,7 +2342,8 @@ public:
         {
             import std.utf : toUTFz;
             timeInfo.tm_gmtoff = cast(int) convert!("hnsecs", "seconds")(adjTime - _stdTime);
-            auto zone = _timezone is null ? "" : (timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName);
+            auto zone = _timezone is null ? "" :
+                (timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName);
             timeInfo.tm_zone = zone.toUTFz!(char*)();
         }
 


### PR DESCRIPTION
Unbelievably, [this bug was reported on April 2, 2014](https://issues.dlang.org/show_bug.cgi?id=12507). I doubt it is of great interest to anyone precisely what is displayed by `SysTime.init.toString`, but it shouldn't cause a segfault.