### PR TITLE
add a DUB description

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,0 +1,6 @@
+name "phobos"
+license "BSL-1.0"
+copyright "Copyright © 1999-2018, The D Language Foundation"
+targetType "library"
+sourcePaths "std" "etc"
+targetPath "generated"


### PR DESCRIPTION
This addition is a convenience for the IDE users, so that we have phobos in the project explorer (or whatever it is called...) rather than a way to build and test (even if this works).