### PR TITLE
windows: build phobos unittests through posix.mak to allow parallel builds

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -112,11 +112,32 @@ else
 endif
 
 # Set CFLAGS
-CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
-ifeq ($(BUILD),debug)
-	CFLAGS += -g
+OUTFILEFLAG = -o
+NODEFAULTLIB=-defaultlib= -debuglib=
+ifeq (,$(findstring win,$(OS)))
+	CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+	ifeq ($(BUILD),debug)
+		CFLAGS += -g
+	else
+		CFLAGS += -O3
+	endif
 else
-	CFLAGS += -O3
+	ifeq ($(OS),win32)
+		CFLAGS=-DNO_snprintf
+		ifeq ($(BUILD),debug)
+			CFLAGS += -g
+		else
+			CFLAGS += -O
+		endif
+	else # win64/win32coff
+		OUTFILEFLAG = /Fo
+		NODEFAULTLIB=-L/NOD:phobos$(MODEL).lib -L/OPT:NOICF
+		ifeq ($(BUILD),debug)
+			CFLAGS += /Z7
+		else
+			CFLAGS += /Ox
+		endif
+	endif
 endif
 
 # Set DFLAGS
@@ -186,7 +207,7 @@ STD_PACKAGES = std $(addprefix std/,\
   algorithm container datetime digest experimental/allocator \
   experimental/allocator/building_blocks experimental/logger \
   net \
-  experimental range regex)
+  experimental range regex windows)
 
 # Modules broken down per package
 
@@ -215,6 +236,7 @@ PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \
   backtracking tests tests2 thompson kickstart)
+PACKAGE_std_windows = charset registry syserror
 
 # Modules in std (including those in packages)
 STD_MODULES=$(call P2MODULES,$(STD_PACKAGES))
@@ -234,6 +256,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 						   errorfunction gammafunction ) \
 		scopebuffer test/dummyrange test/range \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
+		windows/advapi32 \
 	) \
 	typetuple \
 )
@@ -248,9 +271,7 @@ D_FILES = $(addsuffix .d,$(D_MODULES))
 # Aggregate all D modules over all OSs (this is for the zip file)
 ALL_D_FILES = $(addsuffix .d, $(STD_MODULES) $(EXTRA_MODULES_COMMON) \
   $(EXTRA_MODULES_LINUX) $(EXTRA_MODULES_OSX) $(EXTRA_MODULES_FREEBSD) \
-  $(EXTRA_MODULES_WIN32) $(EXTRA_MODULES_INTERNAL)) \
-  std/internal/windows/advapi32.d \
-  std/windows/registry.d
+  $(EXTRA_MODULES_WIN32) $(EXTRA_MODULES_INTERNAL))
 
 # C files to be part of the build
 C_MODULES = $(addprefix etc/c/zlib/, adler32 compress crc32 deflate	\
@@ -300,7 +321,7 @@ dll: $(ROOT)/libphobos2.so
 
 $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
-	$(CC) -c $(CFLAGS) $< -o$@
+	$(CC) -c $(CFLAGS) $< $(OUTFILEFLAG)$@
 
 $(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
@@ -313,7 +334,7 @@ $(ROOT)/$(SONAME): $(LIBSO)
 
 $(LIBSO): override PIC:=-fPIC
 $(LIBSO): $(OBJS) $(ALL_D_FILES) $(DRUNTIMESO)
-	$(DMD) $(DFLAGS) -shared -debuglib= -defaultlib= -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
+	$(DMD) $(DFLAGS) -shared $(NODEFAULTLIB) -of$@ -L-soname=$(SONAME) $(DRUNTIMESO) $(LINKDL) $(D_FILES) $(OBJS)
 
 ifeq (osx,$(OS))
 # Build fat library that combines the 32 bit and the 64 bit libraries
@@ -335,10 +356,10 @@ $(addprefix $(ROOT)/unittest/,$(DISABLED_TESTS)) :
 
 include dip1000.mak
 
-UT_D_OBJS:=$(addprefix $(ROOT)/unittest/,$(addsuffix .o,$(D_MODULES)))
+UT_D_OBJS:=$(addprefix $(ROOT)/unittest/,$(addsuffix $(DOTOBJ),$(D_MODULES)))
 # need to recompile all unittest objects whenever sth. changes
 $(UT_D_OBJS): $(ALL_D_FILES)
-$(UT_D_OBJS): $(ROOT)/unittest/%.o: %.d
+$(UT_D_OBJS): $(ROOT)/unittest/%$(DOTOBJ): %.d
 	@mkdir -p $(dir $@)
 	$(DMD) $(DFLAGS) $(UDFLAGS) -c -of$@ $<
 
@@ -347,7 +368,7 @@ ifneq (1,$(SHARED))
 $(UT_D_OBJS): $(DRUNTIME)
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME)
-	$(DMD) $(DFLAGS) $(UDFLAGS) -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKDL) -defaultlib= -debuglib=
+	$(DMD) $(DFLAGS) $(UDFLAGS) -of$@ $(DRUNTIME_PATH)/src/test_runner.d $(UT_D_OBJS) $(OBJS) $(DRUNTIME) $(LINKDL) $(NODEFAULTLIB)
 
 else
 
@@ -357,10 +378,10 @@ $(UT_D_OBJS): $(DRUNTIMESO)
 
 $(UT_LIBSO): override PIC:=-fPIC
 $(UT_LIBSO): $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO)
-	$(DMD) $(DFLAGS) -shared $(UDFLAGS) -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) -defaultlib= -debuglib=
+	$(DMD) $(DFLAGS) -shared $(UDFLAGS) -of$@ $(UT_D_OBJS) $(OBJS) $(DRUNTIMESO) $(LINKDL) $(NODEFAULTLIB)
 
 $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_LIBSO)
-	$(DMD) $(DFLAGS) -of$@ $< -L$(UT_LIBSO) -defaultlib= -debuglib=
+	$(DMD) $(DFLAGS) -of$@ $< -L$(UT_LIBSO) $(NODEFAULTLIB)
 
 endif
 
@@ -377,7 +398,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) $(aa[$(subst /,.,$(basename $<))]) -main $(UDFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL) -cov -run $< ;     \
+	    $(DMD) -od$$T $(DFLAGS) $(aa[$(subst /,.,$(basename $<))]) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov -run $< ;     \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 
@@ -393,7 +414,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 # This forces all of phobos to have debug symbols, which we need as we don't
 # know where debugging is leading us.
 %.debug_with_debugger : %.d $(LIB)
-	$(DMD) $(DFLAGS) -main $(UDFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL) $<
+	$(DMD) $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) $<
 	$(DEBUGGER) ./$(basename $(notdir $<))
 
 # Target for quickly debugging a single module
@@ -506,7 +527,7 @@ CWS_TOCHECK = posix.mak win32.mak win64.mak
 CWS_TOCHECK += $(ALL_D_FILES) index.d
 
 checkwhitespace: $(LIB) $(TOOLS_DIR)/checkwhitespace.d
-	$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -run $(TOOLS_DIR)/checkwhitespace.d $(CWS_TOCHECK)
+	$(DMD) $(DFLAGS) $(NODEFAULTLIB) $(LIB) -run $(TOOLS_DIR)/checkwhitespace.d $(CWS_TOCHECK)
 
 #############################
 # Submission to Phobos are required to conform to the DStyle
@@ -577,7 +598,7 @@ style_lint: dscanner $(LIB)
 	done
 
 	@echo "Check that Ddoc runs without errors"
-	$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -w -D -Df/dev/null -main -c -o- $$(find etc std -type f -name '*.d') 2>&1
+	$(DMD) $(DFLAGS) $(NODEFAULTLIB) $(LIB) -w -D -Df/dev/null -main -c -o- $$(find etc std -type f -name '*.d') 2>&1
 
 ################################################################################
 # Check for missing imports in public unittest examples.
@@ -585,7 +606,7 @@ style_lint: dscanner $(LIB)
 publictests: $(addsuffix .publictests,$(D_MODULES))
 
 $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
-	DFLAGS="$(DFLAGS) $(LIB) -defaultlib= -debuglib= $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<
+	DFLAGS="$(DFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<
 	mv $(TOOLS_DIR)/tests_extractor $@
 
 ################################################################################
@@ -595,7 +616,7 @@ $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 ################################################################################
 %.publictests: %.d $(LIB) $(TESTS_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
 	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
-	@$(DMD) $(DFLAGS) -defaultlib= -debuglib= $(LIB) -main $(UDFLAGS) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
+	@$(DMD) $(DFLAGS) $(NODEFAULTLIB) $(LIB) -main $(UDFLAGS) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 
 .PHONY : auto-tester-build
 auto-tester-build: all checkwhitespace

--- a/win32.mak
+++ b/win32.mak
@@ -36,8 +36,8 @@ CFLAGS=-mn -6 -r
 
 ## Location of druntime tree
 
-DRUNTIME=..\druntime
-DRUNTIMELIB=$(DRUNTIME)\lib\druntime.lib
+DRUNTIME=../druntime
+DRUNTIMELIB=$(DRUNTIME)/lib/druntime.lib
 
 ## Flags for dmd D compiler
 
@@ -57,10 +57,10 @@ MAKE=make
 
 ## D compiler
 
-DMD_DIR=..\dmd
+DMD_DIR=../dmd
 BUILD=release
 OS=windows
-DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
+DMD=$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd
 
 ## Zlib library
 
@@ -534,4 +534,9 @@ install: phobos.zip
 
 auto-tester-build: targets
 
-auto-tester-test: unittest
+JOBS=$(NUMBER_OF_PROCESSORS)
+GMAKE=gmake
+
+auto-tester-test:
+	$(GMAKE) -j$(JOBS) -f posix.mak unittest BUILD=release DMD="$(DMD)" OS=win$(MODEL) \
+	CUSTOM_DRUNTIME=1 PIC=0 MODEL=$(MODEL) DRUNTIME=$(DRUNTIMELIB) CC=$(CC)

--- a/win64.mak
+++ b/win64.mak
@@ -39,8 +39,8 @@ CFLAGS=/O2 /nologo /I"$(VCDIR)\INCLUDE" /I"$(SDKDIR)\Include"
 
 ## Location of druntime tree
 
-DRUNTIME=..\druntime
-DRUNTIMELIB=$(DRUNTIME)\lib\druntime$(MODEL).lib
+DRUNTIME=../druntime
+DRUNTIMELIB=$(DRUNTIME)/lib/druntime$(MODEL).lib
 
 ## Flags for dmd D compiler
 
@@ -61,10 +61,10 @@ MAKE=make
 
 ## D compiler
 
-DMD_DIR=..\dmd
+DMD_DIR=../dmd
 BUILD=release
 OS=windows
-DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
+DMD="$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd"
 
 ## Zlib library
 
@@ -506,4 +506,9 @@ install: phobos.zip
 
 auto-tester-build: targets
 
-auto-tester-test: unittest
+JOBS=$(NUMBER_OF_PROCESSORS)
+GMAKE=gmake
+
+auto-tester-test:
+	$(GMAKE) -j$(JOBS) -f posix.mak unittest BUILD=release DMD="$(DMD)" OS=win$(MODEL) \
+	CUSTOM_DRUNTIME=1 PIC=0 MODEL=$(MODEL) DRUNTIME=$(DRUNTIMELIB) CC=$(CC)


### PR DESCRIPTION
This builds unittests in about half the time of the sequential build on my mobile i7 quad-core.