### PR TITLE
fix issue 18996 - Inserting a struct into an std.container Array causes SIGILL(4)

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -262,6 +262,15 @@ if (!is(Unqual!T == bool))
     import std.exception : enforce;
     import std.typecons : RefCounted, RefCountedAutoInitialize;
 
+    shared static this()
+    {
+        // issue 18996
+        static if (is(T == string) || is(T == wstring) || is(T == dstring))
+        {
+            GC.initialize();
+        }
+    }
+
     // This structure is not copyable.
     private struct Payload
     {


### PR DESCRIPTION
For now blocked by https://github.com/dlang/druntime/pull/2219.