### PR TITLE
[trivial] Getter property should not return void

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1847,7 +1847,7 @@ expression.
 }
 
 version(unittest) package
-@property void assertCTFEable(alias dg)()
+void assertCTFEable(alias dg)()
 {
     static assert({ cast(void) dg(); return true; }());
     cast(void) dg();


### PR DESCRIPTION
Needed for https://github.com/dlang/dmd/pull/8320.