### PR TITLE
Fix issue 19003: don't call toString on T.init

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -4012,6 +4012,27 @@ version(unittest)
     assert(s == "shared(std.format.C)");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=19003
+@safe unittest
+{
+    struct S
+    {
+        int i;
+
+        @disable this();
+
+        invariant { assert(this.i); }
+
+        this(int i) @safe in { assert(i); } do { this.i = i; }
+
+        string toString() { return "S"; }
+    }
+
+    S s = S(1);
+
+    format!"%s"(s);
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=7879
 @safe unittest
 {

--- a/std/format.d
+++ b/std/format.d
@@ -6201,8 +6201,14 @@ deprecated
 // Used to check format strings are compatible with argument types
 package static const checkFormatException(alias fmt, Args...) =
 {
+    import std.conv : text;
+
     try
-        .format(fmt, Args.init);
+    {
+        auto n = .formattedWrite(NoOpSink(), fmt, Args.init);
+
+        enforceFmt(n == Args.length, text("Orphan format arguments: args[", n, "..", Args.length, "]"));
+    }
     catch (Exception e)
         return (e.msg == ctfpMessage) ? null : e;
     return null;


### PR DESCRIPTION
Avoid actually calling `toString` when speculatively formatting to check for format exceptions.

`Args.init` is not a constructed value; hence it is not safe to call methods on it.

Two-step solution:

1. avoid actually calling `toString` when writing into `NullSink` (why bother?)

2. call `formattedWrite` to write into `NullSink` in `checkFormatException`.