### PR TITLE
Expose a copy of std.conv with the DUB package of stdx.allocator

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -36,8 +36,13 @@ subPackage {
 		auto destFile = file.replace(srcDir, destDir);
 		destFile.dirName.mkdirRecurse;
 		file.readText.replace("std.experimental.allocator", "stdx.allocator")
+			.replace("std.conv", "stdx.allocator.conv")
 		 	.toFile(destFile);
 	}
+	pkgDir.buildPath("std", "conv.d")
+		  .readText
+		  .replace("std.conv", "stdx.allocator.conv")
+		  .toFile(destDir.buildPath("conv.d"));
 	'`
 }
 

--- a/test/dub_stdx_allocator.d
+++ b/test/dub_stdx_allocator.d
@@ -11,3 +11,16 @@ void main(string[] args)
     writeln("allocate: ", buf);
     scope(exit) Mallocator.instance.deallocate(buf);
 }
+
+void test()
+{
+    import stdx.allocator : make;
+    import stdx.allocator.mallocator : Mallocator;
+    alias alloc = Mallocator.instance;
+    struct Node
+    {
+        int x;
+        this(int, int){}
+    }
+    auto newNode = alloc.make!Node(2, 3);
+}


### PR DESCRIPTION
This little trick is needed as `emplaceRef` isn't public (imho it should be, but that's an issue for a different day).
With this patch, the [collections](https://github.com/dlang-stdx/collections) library builds with a stable DMD/LDC compiler as it now can use the `phobos:allocator` package.