### PR TITLE
Clean up use of scope in std.datetime.systime.

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -419,7 +419,7 @@ public:
                        given $(REF DateTime,std,datetime,date) is assumed to
                        be in the given time zone.
       +/
-    this(scope const DateTime dateTime, immutable TimeZone tz = null) @safe nothrow
+    this(DateTime dateTime, immutable TimeZone tz = null) @safe nothrow
     {
         try
             this(dateTime, Duration.zero, tz);
@@ -446,6 +446,11 @@ public:
         test(DateTime(1, 1, 1, 0, 0, 0), new immutable SimpleTimeZone(dur!"minutes"(-60)), 36_000_000_000L);
         test(DateTime(1, 1, 1, 0, 0, 0), new immutable SimpleTimeZone(Duration.zero), 0);
         test(DateTime(1, 1, 1, 0, 0, 0), new immutable SimpleTimeZone(dur!"minutes"(60)), -36_000_000_000L);
+
+        static void testScope(scope ref DateTime dt) @safe
+        {
+            auto st = SysTime(dt);
+        }
     }
 
     /++
@@ -465,7 +470,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if `fracSecs` is negative or if it's
             greater than or equal to one second.
       +/
-    this(scope const DateTime dateTime, scope const Duration fracSecs, immutable TimeZone tz = null) @safe
+    this(DateTime dateTime, Duration fracSecs, immutable TimeZone tz = null) @safe
     {
         enforce(fracSecs >= Duration.zero, new DateTimeException("A SysTime cannot have negative fractional seconds."));
         enforce(fracSecs < seconds(1), new DateTimeException("Fractional seconds must be less than one second."));
@@ -503,6 +508,11 @@ public:
 
         assertThrown!DateTimeException(SysTime(DateTime.init, hnsecs(-1), UTC()));
         assertThrown!DateTimeException(SysTime(DateTime.init, seconds(1), UTC()));
+
+        static void testScope(scope ref DateTime dt, scope ref Duration d) @safe
+        {
+            auto st = SysTime(dt, d);
+        }
     }
 
     /++
@@ -517,7 +527,7 @@ public:
                    given $(REF Date,std,datetime,date) is assumed to be in the
                    given time zone.
       +/
-    this(scope const Date date, immutable TimeZone tz = null) @safe nothrow
+    this(Date date, immutable TimeZone tz = null) @safe nothrow
     {
         _timezone = tz is null ? LocalTime() : tz;
 
@@ -545,6 +555,11 @@ public:
         test(Date(1, 1, 1), UTC(), 0);
         test(Date(1, 1, 2), UTC(), 864000000000);
         test(Date(0, 12, 31), UTC(), -864000000000);
+
+        static void testScope(scope ref Date d) @safe
+        {
+            auto st = SysTime(d);
+        }
     }
 
     /++
@@ -587,27 +602,36 @@ public:
         }
     }
 
+
     /++
         Params:
             rhs = The $(LREF SysTime) to assign to this one.
+
+        Returns: The `this` of this `SysTime`.
       +/
-    ref SysTime opAssign(const ref SysTime rhs) return @safe pure nothrow
+    ref SysTime opAssign()(auto ref const(SysTime) rhs) return @safe pure nothrow scope
     {
         _stdTime = rhs._stdTime;
         _timezone = rhs._timezone;
         return this;
     }
 
-    /++
-        Params:
-            rhs = The $(LREF SysTime) to assign to this one.
-      +/
-    ref SysTime opAssign(SysTime rhs) scope return @safe pure nothrow
+    @safe unittest
     {
-        _stdTime = rhs._stdTime;
-        _timezone = rhs._timezone;
-        return this;
+        SysTime st;
+        st = SysTime(DateTime(2012, 12, 21, 1, 2, 3), UTC());
+        assert(st == SysTime(DateTime(2012, 12, 21, 1, 2, 3), UTC()));
+
+        const other = SysTime(DateTime(19, 1, 7, 13, 14, 15), LocalTime());
+        st = other;
+        assert(st == other);
+
+        static void testScope(scope ref SysTime left, const scope SysTime right) @safe
+        {
+            left = right;
+        }
     }
+
 
     /++
         Checks for equality between this $(LREF SysTime) and the given
@@ -616,13 +640,7 @@ public:
         Note that the time zone is ignored. Only the internal
         std times (which are in UTC) are compared.
      +/
-    bool opEquals(const SysTime rhs) @safe const pure nothrow
-    {
-        return opEquals(rhs);
-    }
-
-    /// ditto
-    bool opEquals(const ref SysTime rhs) @safe const pure nothrow
+    bool opEquals()(auto ref const(SysTime) rhs) @safe const pure nothrow scope
     {
         return _stdTime == rhs._stdTime;
     }
@@ -658,17 +676,24 @@ public:
 
         auto st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         assert(st == st);
         assert(st == cst);
-        //assert(st == ist);
+        assert(st == ist);
         assert(cst == st);
         assert(cst == cst);
-        //assert(cst == ist);
-        //assert(ist == st);
-        //assert(ist == cst);
-        //assert(ist == ist);
+        assert(cst == ist);
+        assert(ist == st);
+        assert(ist == cst);
+        assert(ist == ist);
+
+        static void testScope(scope ref SysTime left, const scope SysTime right) @safe
+        {
+            assert(left == right);
+            assert(right == left);
+        }
     }
+
 
     /++
         Compares this $(LREF SysTime) with the given $(LREF SysTime).
@@ -682,7 +707,7 @@ public:
             $(TR $(TD this &gt; rhs) $(TD &gt; 0))
             )
      +/
-    int opCmp(scope const SysTime rhs) @safe const pure nothrow
+    int opCmp()(auto ref const(SysTime) rhs) @safe const pure nothrow scope
     {
         if (_stdTime < rhs._stdTime)
             return -1;
@@ -746,22 +771,29 @@ public:
 
         auto st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         assert(st.opCmp(st) == 0);
         assert(st.opCmp(cst) == 0);
-        //assert(st.opCmp(ist) == 0);
+        assert(st.opCmp(ist) == 0);
         assert(cst.opCmp(st) == 0);
         assert(cst.opCmp(cst) == 0);
-        //assert(cst.opCmp(ist) == 0);
-        //assert(ist.opCmp(st) == 0);
-        //assert(ist.opCmp(cst) == 0);
-        //assert(ist.opCmp(ist) == 0);
+        assert(cst.opCmp(ist) == 0);
+        assert(ist.opCmp(st) == 0);
+        assert(ist.opCmp(cst) == 0);
+        assert(ist.opCmp(ist) == 0);
+
+        static void testScope(scope ref SysTime left, const scope SysTime right) @safe
+        {
+            assert(left < right);
+            assert(right > left);
+        }
     }
 
-    /**
-     * Returns: A hash of the $(LREF SysTime)
-     */
-    size_t toHash() const @nogc pure nothrow @safe
+
+    /++
+        Returns: A hash of the $(LREF SysTime).
+     +/
+    size_t toHash() const @nogc pure nothrow @safe scope
     {
         static if (is(size_t == ulong))
             return _stdTime;
@@ -798,13 +830,19 @@ public:
         immutable zone = new SimpleTimeZone(dur!"minutes"(60));
         assert(SysTime(DateTime(2000, 1, 1, 1), zone).toHash == SysTime(DateTime(2000, 1, 1), UTC()).toHash);
         assert(SysTime(DateTime(2000, 1, 1), zone).toHash != SysTime(DateTime(2000, 1, 1), UTC()).toHash);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toHash();
+        }
     }
+
 
     /++
         Year of the Gregorian Calendar. Positive numbers are A.D. Non-positive
         are B.C.
      +/
-    @property short year() @safe const nothrow
+    @property short year() @safe const nothrow scope
     {
         return (cast(Date) this).year;
     }
@@ -838,9 +876,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.year == 1999);
-        //assert(ist.year == 1999);
+        assert(ist.year == 1999);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.year;
+        }
     }
 
     /++
@@ -854,7 +897,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the new year is not
             a leap year and the resulting date would be on February 29th.
      +/
-    @property void year(int year) @safe
+    @property void year(int year) @safe scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -886,7 +929,7 @@ public:
     {
         import std.range : chain;
 
-        static void test(SysTime st, int year, scope const SysTime expected)
+        static void test(SysTime st, int year, SysTime expected)
         {
             st.year = year;
             assert(st == expected);
@@ -926,9 +969,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.year = 7));
-        //static assert(!__traits(compiles, ist.year = 7));
+        static assert(!__traits(compiles, ist.year = 7));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.year = 42;
+        }
     }
 
     /++
@@ -937,7 +985,7 @@ public:
         Throws:
             $(REF DateTimeException,std,datetime,date) if `isAD` is true.
      +/
-    @property ushort yearBC() @safe const
+    @property ushort yearBC() @safe const scope
     {
         return (cast(Date) this).yearBC;
     }
@@ -967,11 +1015,16 @@ public:
 
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.year = 12;
         assert(st.year == 12);
         static assert(!__traits(compiles, cst.year = 12));
-        //static assert(!__traits(compiles, ist.year = 12));
+        static assert(!__traits(compiles, ist.year = 12));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.yearBC;
+        }
     }
 
 
@@ -985,7 +1038,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if a non-positive value
             is given.
      +/
-    @property void yearBC(int year) @safe
+    @property void yearBC(int year) @safe scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1016,7 +1069,7 @@ public:
     @safe unittest
     {
         import std.range : chain;
-        static void test(SysTime st, int year, scope const SysTime expected)
+        static void test(SysTime st, int year, SysTime expected)
         {
             st.yearBC = year;
             assert(st == expected, format("SysTime: %s", st));
@@ -1063,17 +1116,23 @@ public:
 
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.yearBC = 12;
         assert(st.yearBC == 12);
         static assert(!__traits(compiles, cst.yearBC = 12));
-        //static assert(!__traits(compiles, ist.yearBC = 12));
+        static assert(!__traits(compiles, ist.yearBC = 12));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.yearBC = 42;
+        }
     }
+
 
     /++
         Month of a Gregorian Year.
      +/
-    @property Month month() @safe const nothrow
+    @property Month month() @safe const nothrow scope
     {
         return (cast(Date) this).month;
     }
@@ -1118,9 +1177,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.month == 7);
-        //assert(ist.month == 7);
+        assert(ist.month == 7);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.month;
+        }
     }
 
 
@@ -1134,7 +1198,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given month is
             not a valid month.
      +/
-    @property void month(Month month) @safe
+    @property void month(Month month) @safe scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1157,7 +1221,7 @@ public:
         import std.algorithm.iteration : filter;
         import std.range : chain;
 
-        static void test(SysTime st, Month month, scope const SysTime expected)
+        static void test(SysTime st, Month month, SysTime expected)
         {
             st.month = cast(Month) month;
             assert(st == expected);
@@ -1226,15 +1290,20 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(!__traits(compiles, cst.month = 12));
-        //static assert(!__traits(compiles, ist.month = 12));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        static assert(!__traits(compiles, cst.month = Month.dec));
+        static assert(!__traits(compiles, ist.month = Month.dec));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.month = Month.dec;
+        }
     }
 
     /++
         Day of a Gregorian Month.
      +/
-    @property ubyte day() @safe const nothrow
+    @property ubyte day() @safe const nothrow scope
     {
         return (cast(Date) this).day;
     }
@@ -1280,9 +1349,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
          assert(cst.day == 6);
-        //assert(ist.day == 6);
+        assert(ist.day == 6);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.day;
+        }
     }
 
 
@@ -1296,7 +1370,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given day is not
             a valid day of the current month.
      +/
-    @property void day(int day) @safe
+    @property void day(int day) @safe scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1380,16 +1454,21 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.day = 27));
-        //static assert(!__traits(compiles, ist.day = 27));
+        static assert(!__traits(compiles, ist.day = 27));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.day = 12;
+        }
     }
 
 
     /++
         Hours past midnight.
      +/
-    @property ubyte hour() @safe const nothrow
+    @property ubyte hour() @safe const nothrow scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1439,9 +1518,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.hour == 12);
-        //assert(ist.hour == 12);
+        assert(ist.hour == 12);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.hour;
+        }
     }
 
 
@@ -1455,7 +1539,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given hour are
             not a valid hour of the day.
      +/
-    @property void hour(int hour) @safe
+    @property void hour(int hour) @safe scope
     {
         enforceValid!"hours"(hour);
 
@@ -1498,16 +1582,21 @@ public:
         assertThrown!DateTimeException(st.hour = 60);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.hour = 27));
-        //static assert(!__traits(compiles, ist.hour = 27));
+        static assert(!__traits(compiles, ist.hour = 27));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.hour = 12;
+        }
     }
 
 
     /++
         Minutes past the current hour.
      +/
-    @property ubyte minute() @safe const nothrow
+    @property ubyte minute() @safe const nothrow scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1559,9 +1648,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.minute == 30);
-        //assert(ist.minute == 30);
+        assert(ist.minute == 30);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.minute;
+        }
     }
 
 
@@ -1575,7 +1669,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given minute are
             not a valid minute of an hour.
      +/
-    @property void minute(int minute) @safe
+    @property void minute(int minute) @safe scope
     {
         enforceValid!"minutes"(minute);
 
@@ -1621,16 +1715,21 @@ public:
         assertThrown!DateTimeException(st.minute = 60);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.minute = 27));
-        //static assert(!__traits(compiles, ist.minute = 27));
+        static assert(!__traits(compiles, ist.minute = 27));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.minute = 12;
+        }
     }
 
 
     /++
         Seconds past the current minute.
      +/
-    @property ubyte second() @safe const nothrow
+    @property ubyte second() @safe const nothrow scope
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -1683,9 +1782,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.second == 33);
-        //assert(ist.second == 33);
+        assert(ist.second == 33);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.second;
+        }
     }
 
 
@@ -1699,7 +1803,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given second are
             not a valid second of a minute.
      +/
-    @property void second(int second) @safe
+    @property void second(int second) @safe scope
     {
         enforceValid!"seconds"(second);
 
@@ -1747,9 +1851,14 @@ public:
         assertThrown!DateTimeException(st.second = 60);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.seconds = 27));
-        //static assert(!__traits(compiles, ist.seconds = 27));
+        static assert(!__traits(compiles, ist.seconds = 27));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.second = 12;
+        }
     }
 
 
@@ -1757,7 +1866,7 @@ public:
         Fractional seconds past the second (i.e. the portion of a
         $(LREF SysTime) which is less than a second).
      +/
-    @property Duration fracSecs() scope @safe const nothrow
+    @property Duration fracSecs() @safe const nothrow scope
     {
         auto hnsecs = removeUnitsFromHNSecs!"days"(adjTime);
 
@@ -1815,9 +1924,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.fracSecs == Duration.zero);
-        //assert(ist.fracSecs == Duration.zero);
+        assert(ist.fracSecs == Duration.zero);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.fracSecs;
+        }
     }
 
 
@@ -1833,7 +1947,7 @@ public:
             $(REF DateTimeException,std,datetime,date) if the given duration
             is negative or if it's greater than or equal to one second.
      +/
-    @property void fracSecs(Duration fracSecs) @safe
+    @property void fracSecs(Duration fracSecs) @safe scope
     {
         enforce(fracSecs >= Duration.zero, new DateTimeException("A SysTime cannot have negative fractional seconds."));
         enforce(fracSecs < seconds(1), new DateTimeException("Fractional seconds must be less than one second."));
@@ -1898,9 +2012,14 @@ public:
         assertThrown!DateTimeException(st.fracSecs = seconds(1));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.fracSecs = msecs(7)));
-        //static assert(!__traits(compiles, ist.fracSecs = msecs(7)));
+        static assert(!__traits(compiles, ist.fracSecs = msecs(7)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.fracSecs = Duration.zero;
+        }
     }
 
 
@@ -1908,7 +2027,7 @@ public:
         The total hnsecs from midnight, January 1st, 1 A.D. UTC. This is the
         internal representation of $(LREF SysTime).
      +/
-    @property long stdTime() @safe const pure nothrow
+    @property long stdTime() @safe const pure nothrow scope
     {
         return _stdTime;
     }
@@ -1923,9 +2042,14 @@ public:
         assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), UTC()).stdTime == 621_355_968_000_000_000L);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.stdTime > 0);
-        //assert(ist.stdTime > 0);
+        assert(ist.stdTime > 0);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.stdTime;
+        }
     }
 
 
@@ -1936,7 +2060,7 @@ public:
         Params:
             stdTime = The number of hnsecs since January 1st, 1 A.D. UTC.
      +/
-    @property void stdTime(long stdTime) @safe pure nothrow
+    @property void stdTime(long stdTime) @safe pure nothrow scope
     {
         _stdTime = stdTime;
     }
@@ -1944,7 +2068,7 @@ public:
     @safe unittest
     {
         import core.time;
-        static void test(long stdTime, scope const SysTime expected, size_t line = __LINE__)
+        static void test(long stdTime, SysTime expected, size_t line = __LINE__)
         {
             auto st = SysTime(0, UTC());
             st.stdTime = stdTime;
@@ -1958,9 +2082,14 @@ public:
         test(621_355_968_000_000_000L, SysTime(DateTime(1970, 1, 1, 0, 0, 0), UTC()));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.stdTime = 27));
-        //static assert(!__traits(compiles, ist.stdTime = 27));
+        static assert(!__traits(compiles, ist.stdTime = 27));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.stdTime = 42;
+        }
     }
 
 
@@ -1971,9 +2100,20 @@ public:
         hours - adjust the time to this $(LREF SysTime)'s time zone before
         returning.
       +/
-    @property immutable(TimeZone) timezone() @safe const pure nothrow
+    @property immutable(TimeZone) timezone() @safe const pure nothrow scope
     {
         return _timezone;
+    }
+
+    @safe unittest
+    {
+        assert(SysTime.init.timezone is InitTimeZone());
+        assert(SysTime(DateTime.init, UTC()).timezone is UTC());
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.timezone;
+        }
     }
 
 
@@ -1988,7 +2128,7 @@ public:
             timezone = The $(REF _TimeZone,std,datetime,_timezone) to set this
                        $(LREF SysTime)'s time zone to.
       +/
-    @property void timezone(immutable TimeZone timezone) @safe pure nothrow
+    @property void timezone(immutable TimeZone timezone) @safe pure nothrow scope
     {
         if (timezone is null)
             _timezone = LocalTime();
@@ -1996,11 +2136,25 @@ public:
             _timezone = timezone;
     }
 
+    @safe unittest
+    {
+        SysTime st;
+        st.timezone = null;
+        assert(st.timezone is LocalTime());
+        st.timezone = UTC();
+        assert(st.timezone is UTC());
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.timezone = UTC();
+        }
+    }
+
 
     /++
         Returns whether DST is in effect for this $(LREF SysTime).
       +/
-    @property bool dstInEffect() @safe const nothrow
+    @property bool dstInEffect() @safe const nothrow scope
     {
         return _timezone.dstInEffect(_stdTime);
     }
@@ -2011,6 +2165,11 @@ public:
     @safe unittest
     {
         assert(!SysTime.init.dstInEffect);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.dstInEffect;
+        }
     }
 
 
@@ -2018,7 +2177,7 @@ public:
         Returns what the offset from UTC is for this $(LREF SysTime).
         It includes the DST offset in effect at that time (if any).
       +/
-    @property Duration utcOffset() @safe const nothrow
+    @property Duration utcOffset() @safe const nothrow scope
     {
         return _timezone.utcOffsetAt(_stdTime);
     }
@@ -2029,6 +2188,11 @@ public:
     @safe unittest
     {
         assert(SysTime.init.utcOffset == Duration.zero);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.utcOffset;
+        }
     }
 
 
@@ -2036,7 +2200,7 @@ public:
         Returns a $(LREF SysTime) with the same std time as this one, but with
         $(REF LocalTime,std,datetime,timezone) as its time zone.
       +/
-    SysTime toLocalTime() @safe const pure nothrow
+    SysTime toLocalTime() @safe const pure nothrow scope
     {
         return SysTime(_stdTime, LocalTime());
     }
@@ -2062,6 +2226,11 @@ public:
             assert(sysTime.toLocalTime().timezone !is UTC());
             assert(sysTime.toLocalTime().timezone !is stz);
         }
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toLocalTime();
+        }
     }
 
 
@@ -2069,7 +2238,7 @@ public:
         Returns a $(LREF SysTime) with the same std time as this one, but with
         `UTC` as its time zone.
       +/
-    SysTime toUTC() @safe const pure nothrow
+    SysTime toUTC() @safe const pure nothrow scope
     {
         return SysTime(_stdTime, UTC());
     }
@@ -2083,6 +2252,11 @@ public:
         assert(sysTime.toUTC().timezone is UTC());
         assert(sysTime.toUTC().timezone !is LocalTime());
         assert(sysTime.toUTC().timezone !is sysTime.timezone);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toUTC();
+        }
     }
 
 
@@ -2090,7 +2264,7 @@ public:
         Returns a $(LREF SysTime) with the same std time as this one, but with
         given time zone as its time zone.
       +/
-    SysTime toOtherTZ(immutable TimeZone tz) @safe const pure nothrow
+    SysTime toOtherTZ(immutable TimeZone tz) @safe const pure nothrow scope
     {
         if (tz is null)
             return SysTime(_stdTime, LocalTime());
@@ -2108,6 +2282,12 @@ public:
         assert(sysTime.toOtherTZ(stz).timezone is stz);
         assert(sysTime.toOtherTZ(stz).timezone !is LocalTime());
         assert(sysTime.toOtherTZ(stz).timezone !is UTC());
+        assert(sysTime.toOtherTZ(null).timezone is LocalTime());
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toOtherTZ(null);
+        }
     }
 
 
@@ -2140,7 +2320,7 @@ public:
             A signed integer representing the unix time which is equivalent to
             this SysTime.
       +/
-    T toUnixTime(T = time_t)() @safe const pure nothrow
+    T toUnixTime(T = time_t)() @safe const pure nothrow scope
         if (is(T == int) || is(T == long))
     {
         return stdTimeToUnixTime!T(_stdTime);
@@ -2163,6 +2343,11 @@ public:
 
         auto ca = SysTime(DateTime(2007, 12, 22, 8, 14, 45), pst);
         assert(ca.toUnixTime() == 1_198_340_085);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toUnixTime();
+        }
     }
 
     @safe unittest
@@ -2252,7 +2437,7 @@ public:
         `tv_sec`. (so `int.max` if it goes over and `int.min` if it
         goes under).
       +/
-    timeval toTimeVal() @safe const pure nothrow
+    timeval toTimeVal() @safe const pure nothrow scope
     {
         immutable tv_sec = toUnixTime!(typeof(timeval.tv_sec))();
         immutable fracHNSecs = removeUnitsFromHNSecs!"seconds"(_stdTime - 621_355_968_000_000_000L);
@@ -2281,6 +2466,11 @@ public:
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), msecs(999), UTC()).toTimeVal() == timeval(0, -1000));
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), UTC()).toTimeVal() == timeval(-1, 0));
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 58), usecs(17), UTC()).toTimeVal() == timeval(-1, -999_983));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toTimeVal();
+        }
     }
 
 
@@ -2292,11 +2482,11 @@ public:
 
             $(BLUE This function is Posix-Only.)
           +/
-        timespec toTimeSpec() @safe const pure nothrow;
+        timespec toTimeSpec() @safe const pure nothrow scope;
     }
     else version(Posix)
     {
-        timespec toTimeSpec() @safe const pure nothrow
+        timespec toTimeSpec() @safe const pure nothrow scope
         {
             immutable tv_sec = toUnixTime!(typeof(timespec.tv_sec))();
             immutable fracHNSecs = removeUnitsFromHNSecs!"seconds"(_stdTime - 621_355_968_000_000_000L);
@@ -2332,13 +2522,18 @@ public:
                    timespec(-1, 0));
             assert(SysTime(DateTime(1969, 12, 31, 23, 59, 58), usecs(17), UTC()).toTimeSpec() ==
                    timespec(-1, -999_983_000));
+
+            static void testScope(scope ref SysTime st) @safe
+            {
+                auto result = st.toTimeSpec();
+            }
         }
     }
 
     /++
         Returns a `tm` which represents this $(LREF SysTime).
       +/
-    tm toTM() @safe const nothrow
+    tm toTM() @safe const nothrow scope
     {
         auto dateTime = cast(DateTime) this;
         tm timeInfo;
@@ -2446,6 +2641,11 @@ public:
                 assert(to!string(timeInfo.tm_zone) == "SysTime.init's timezone");
             }
         }
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toTM();
+        }
     }
 
 
@@ -2468,7 +2668,7 @@ public:
             allowOverflow = Whether the days should be allowed to overflow,
                             causing the month to increment.
       +/
-    ref SysTime add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow
+    ref SysTime add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow scope
         if (units == "years" || units == "months")
     {
         auto hnsecs = adjTime;
@@ -2714,9 +2914,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.add!"years"(4)));
-        //static assert(!__traits(compiles, ist.add!"years"(4)));
+        static assert(!__traits(compiles, ist.add!"years"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.add!"years"(42);
+        }
     }
 
     // Test add!"years"() with AllowDayOverflow.no
@@ -3267,9 +3472,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.add!"months"(4)));
-        //static assert(!__traits(compiles, ist.add!"months"(4)));
+        static assert(!__traits(compiles, ist.add!"months"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.add!"months"(42);
+        }
     }
 
     // Test add!"months"() with AllowDayOverflow.no
@@ -3634,8 +3844,9 @@ public:
             allowOverflow = Whether the days should be allowed to overflow,
                             causing the month to increment.
       +/
-    ref SysTime roll(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow
-        if (units == "years")
+    ref SysTime roll(string units)
+                    (long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow scope
+    if (units == "years")
     {
         return add!"years"(value, allowOverflow);
     }
@@ -3674,16 +3885,22 @@ public:
     {
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.roll!"years"(4);
         static assert(!__traits(compiles, cst.roll!"years"(4)));
-        //static assert(!__traits(compiles, ist.roll!"years"(4)));
+        static assert(!__traits(compiles, ist.roll!"years"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"years"(42);
+        }
     }
 
 
     // Shares documentation with "years" overload.
-    ref SysTime roll(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow
-        if (units == "months")
+    ref SysTime roll(string units)
+                    (long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow scope
+    if (units == "months")
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -4083,9 +4300,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"months"(4)));
-        //static assert(!__traits(compiles, ist.roll!"months"(4)));
+        static assert(!__traits(compiles, ist.roll!"months"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"months"(42);
+        }
     }
 
     // Test roll!"months"() with AllowDayOverflow.no
@@ -4484,7 +4706,7 @@ public:
             value = The number of $(D_PARAM units) to add to this
                     $(LREF SysTime).
       +/
-    ref SysTime roll(string units)(long value) @safe nothrow
+    ref SysTime roll(string units)(long value) @safe nothrow scope
         if (units == "days")
     {
         auto hnsecs = adjTime;
@@ -4837,14 +5059,19 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"days"(4)));
-        //static assert(!__traits(compiles, ist.roll!"days"(4)));
+        static assert(!__traits(compiles, ist.roll!"days"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"days"(42);
+        }
     }
 
 
     // Shares documentation with "days" version.
-    ref SysTime roll(string units)(long value) @safe nothrow
+    ref SysTime roll(string units)(long value) @safe nothrow scope
         if (units == "hours" || units == "minutes" || units == "seconds")
     {
         try
@@ -4889,14 +5116,11 @@ public:
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, int hours, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, int hours, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"hours"(hours);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5101,23 +5325,25 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"hours"(4)));
-        //static assert(!__traits(compiles, ist.roll!"hours"(4)));
+        static assert(!__traits(compiles, ist.roll!"hours"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"hours"(42);
+        }
     }
 
     // Test roll!"minutes"().
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, int minutes, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, int minutes, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"minutes"(minutes);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5315,23 +5541,25 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"minutes"(4)));
-        //static assert(!__traits(compiles, ist.roll!"minutes"(4)));
+        static assert(!__traits(compiles, ist.roll!"minutes"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"minutes"(42);
+        }
     }
 
     // Test roll!"seconds"().
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, int seconds, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, int seconds, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"seconds"(seconds);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5507,14 +5735,19 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"seconds"(4)));
-        //static assert(!__traits(compiles, ist.roll!"seconds"(4)));
+        static assert(!__traits(compiles, ist.roll!"seconds"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"seconds"(42);
+        }
     }
 
 
     // Shares documentation with "days" version.
-    ref SysTime roll(string units)(long value) @safe nothrow
+    ref SysTime roll(string units)(long value) @safe nothrow scope
         if (units == "msecs" || units == "usecs" || units == "hnsecs")
     {
         auto hnsecs = adjTime;
@@ -5545,14 +5778,11 @@ public:
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, int milliseconds, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, int milliseconds, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"msecs"(milliseconds);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5645,23 +5875,25 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(!__traits(compiles, cst.addMSecs(4)));
-        //static assert(!__traits(compiles, ist.addMSecs(4)));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        static assert(!__traits(compiles, cst.roll!"msecs"(4)));
+        static assert(!__traits(compiles, ist.roll!"msecs"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"msecs"(42);
+        }
     }
 
     // Test roll!"usecs"().
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, long microseconds, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, long microseconds, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"usecs"(microseconds);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5778,23 +6010,25 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"usecs"(4)));
-        //static assert(!__traits(compiles, ist.roll!"usecs"(4)));
+        static assert(!__traits(compiles, ist.roll!"usecs"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"usecs"(42);
+        }
     }
 
     // Test roll!"hnsecs"().
     @safe unittest
     {
         import core.time;
-        static void testST(SysTime orig, long hnsecs, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, long hnsecs, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.roll!"hnsecs"(hnsecs);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -5923,9 +6157,14 @@ public:
         }
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.roll!"hnsecs"(4)));
-        //static assert(!__traits(compiles, ist.roll!"hnsecs"(4)));
+        static assert(!__traits(compiles, ist.roll!"hnsecs"(4)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.roll!"hnsecs"(42);
+        }
     }
 
 
@@ -5945,7 +6184,7 @@ public:
             duration = The $(REF Duration, core,time) to add to or subtract from
                        this $(LREF SysTime).
       +/
-    SysTime opBinary(string op)(Duration duration) @safe const pure nothrow
+    SysTime opBinary(string op)(Duration duration) @safe const pure nothrow scope
         if (op == "+" || op == "-")
     {
         SysTime retval = SysTime(this._stdTime, this._timezone);
@@ -6012,15 +6251,11 @@ public:
         assert(st - dur!"hnsecs"(-7) == SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_685)));
         assert(st - dur!"hnsecs"(7) == SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(2_345_671)));
 
-        static void testST(scope const SysTime orig,
-                           long hnsecs, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, long hnsecs, SysTime expected, size_t line = __LINE__) @safe
         {
             auto result = orig + dur!"hnsecs"(hnsecs);
             if (result != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", result, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", result, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -6140,11 +6375,16 @@ public:
 
         auto duration = dur!"seconds"(12);
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
-        //assert(ist + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
+        assert(ist + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
         assert(cst - duration == SysTime(DateTime(1999, 7, 6, 12, 30, 21)));
-        //assert(ist - duration == SysTime(DateTime(1999, 7, 6, 12, 30, 21)));
+        assert(ist - duration == SysTime(DateTime(1999, 7, 6, 12, 30, 21)));
+
+        static void testScope(scope ref SysTime st, scope ref Duration d) @safe
+        {
+            auto result = st + d;
+        }
     }
 
 
@@ -6164,7 +6404,7 @@ public:
             duration = The $(REF Duration, core,time) to add to or subtract from
                        this $(LREF SysTime).
       +/
-    ref SysTime opOpAssign(string op)(Duration duration) @safe pure nothrow
+    ref SysTime opOpAssign(string op)(Duration duration) @safe pure nothrow scope
         if (op == "+" || op == "-")
     {
         immutable hnsecs = duration.total!"hnsecs";
@@ -6212,19 +6452,13 @@ public:
         assert(before - dur!"hnsecs"(-7) == SysTime(DateTime(1999, 7, 6, 12, 30, 33), hnsecs(7)));
         assert(before - dur!"hnsecs"(7) == SysTime(DateTime(1999, 7, 6, 12, 30, 32), hnsecs(9_999_993)));
 
-        static void testST(SysTime orig, long hnsecs, scope const SysTime expected, size_t line = __LINE__) @safe
+        static void testST(SysTime orig, long hnsecs, SysTime expected, size_t line = __LINE__) @safe
         {
             auto r = orig += dur!"hnsecs"(hnsecs);
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed 1. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed 1. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
             if (r != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed 2. actual [%s] != expected [%s]", r, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed 2. actual [%s] != expected [%s]", r, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -6350,11 +6584,17 @@ public:
 
         auto duration = dur!"seconds"(12);
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst += duration));
-        //static assert(!__traits(compiles, ist += duration));
+        static assert(!__traits(compiles, ist += duration));
         static assert(!__traits(compiles, cst -= duration));
-        //static assert(!__traits(compiles, ist -= duration));
+        static assert(!__traits(compiles, ist -= duration));
+
+        static void testScope(scope ref SysTime st, scope ref Duration d) @safe
+        {
+            auto result1 = st += d;
+            auto result2 = st -= d;
+        }
     }
 
 
@@ -6368,7 +6608,7 @@ public:
         $(TR $(TD SysTime) $(TD -) $(TD SysTime) $(TD -->) $(TD duration))
         )
       +/
-    Duration opBinary(string op)(scope const SysTime rhs) @safe const pure nothrow
+    Duration opBinary(string op)(SysTime rhs) @safe const pure nothrow scope
         if (op == "-")
     {
         return dur!"hnsecs"(_stdTime - rhs._stdTime);
@@ -6450,18 +6690,23 @@ public:
 
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st - st == Duration.zero);
         assert(cst - st == Duration.zero);
-        //assert(ist - st == Duration.zero);
+        assert(ist - st == Duration.zero);
 
         assert(st - cst == Duration.zero);
         assert(cst - cst == Duration.zero);
-        //assert(ist - cst == Duration.zero);
+        assert(ist - cst == Duration.zero);
 
-        //assert(st - ist == Duration.zero);
-        //assert(cst - ist == Duration.zero);
-        //assert(ist - ist == Duration.zero);
+        assert(st - ist == Duration.zero);
+        assert(cst - ist == Duration.zero);
+        assert(ist - ist == Duration.zero);
+
+        static void testScope(scope ref SysTime left, scope ref SysTime right) @safe
+        {
+            auto result = left - right;
+        }
     }
 
 
@@ -6486,7 +6731,7 @@ public:
         Params:
             rhs = The $(LREF SysTime) to subtract from this one.
       +/
-    int diffMonths(scope const SysTime rhs) @safe const nothrow
+    int diffMonths(scope SysTime rhs) @safe const nothrow scope
     {
         return (cast(Date) this).diffMonths(cast(Date) rhs);
     }
@@ -6515,25 +6760,30 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.diffMonths(st) == 0);
         assert(cst.diffMonths(st) == 0);
-        //assert(ist.diffMonths(st) == 0);
+        assert(ist.diffMonths(st) == 0);
 
         assert(st.diffMonths(cst) == 0);
         assert(cst.diffMonths(cst) == 0);
-        //assert(ist.diffMonths(cst) == 0);
+        assert(ist.diffMonths(cst) == 0);
 
-        //assert(st.diffMonths(ist) == 0);
-        //assert(cst.diffMonths(ist) == 0);
-        //assert(ist.diffMonths(ist) == 0);
+        assert(st.diffMonths(ist) == 0);
+        assert(cst.diffMonths(ist) == 0);
+        assert(ist.diffMonths(ist) == 0);
+
+        static void testScope(scope ref SysTime left, scope ref SysTime right) @safe
+        {
+            auto result = left.diffMonths(right);
+        }
     }
 
 
     /++
         Whether this $(LREF SysTime) is in a leap year.
      +/
-    @property bool isLeapYear() @safe const nothrow
+    @property bool isLeapYear() @safe const nothrow scope
     {
         return (cast(Date) this).isLeapYear;
     }
@@ -6543,17 +6793,22 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(!st.isLeapYear);
         assert(!cst.isLeapYear);
-        //assert(!ist.isLeapYear);
+        assert(!ist.isLeapYear);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.isLeapYear;
+        }
     }
 
 
     /++
         Day of the week this $(LREF SysTime) is on.
       +/
-    @property DayOfWeek dayOfWeek() @safe const nothrow
+    @property DayOfWeek dayOfWeek() @safe const nothrow scope
     {
         return getDayOfWeek(dayOfGregorianCal);
     }
@@ -6563,17 +6818,22 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.dayOfWeek == DayOfWeek.tue);
         assert(cst.dayOfWeek == DayOfWeek.tue);
-        //assert(ist.dayOfWeek == DayOfWeek.tue);
+        assert(ist.dayOfWeek == DayOfWeek.tue);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.dayOfWeek;
+        }
     }
 
 
     /++
         Day of the year this $(LREF SysTime) is on.
       +/
-    @property ushort dayOfYear() @safe const nothrow
+    @property ushort dayOfYear() @safe const nothrow scope
     {
         return (cast(Date) this).dayOfYear;
     }
@@ -6594,10 +6854,15 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(st.dayOfYear == 187);
         assert(cst.dayOfYear == 187);
-        //assert(ist.dayOfYear == 187);
+        assert(ist.dayOfYear == 187);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.dayOfYear;
+        }
     }
 
 
@@ -6608,7 +6873,7 @@ public:
             day = The day of the year to set which day of the year this
                   $(LREF SysTime) is on.
       +/
-    @property void dayOfYear(int day) @safe
+    @property void dayOfYear(int day) @safe scope
     {
         immutable hnsecs = adjTime;
         immutable days = convert!("hnsecs", "days")(hnsecs);
@@ -6627,18 +6892,23 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.dayOfYear = 12;
         assert(st.dayOfYear == 12);
         static assert(!__traits(compiles, cst.dayOfYear = 12));
-        //static assert(!__traits(compiles, ist.dayOfYear = 12));
+        static assert(!__traits(compiles, ist.dayOfYear = 12));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.dayOfYear = 42;
+        }
     }
 
 
     /++
         The Xth day of the Gregorian Calendar that this $(LREF SysTime) is on.
      +/
-    @property int dayOfGregorianCal() @safe const nothrow
+    @property int dayOfGregorianCal() @safe const nothrow scope
     {
         immutable adjustedTime = adjTime;
 
@@ -6836,9 +7106,14 @@ public:
         assert(SysTime(DateTime(-3760, 9, 7, 0, 0, 0)).dayOfGregorianCal == -1_373_427);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.dayOfGregorianCal == 729_941);
-        //assert(ist.dayOfGregorianCal == 729_941);
+        assert(ist.dayOfGregorianCal == 729_941);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.dayOfGregorianCal;
+        }
     }
 
 
@@ -7012,7 +7287,7 @@ public:
             days = The day of the Gregorian Calendar to set this $(LREF SysTime)
                    to.
      +/
-    @property void dayOfGregorianCal(int days) @safe nothrow
+    @property void dayOfGregorianCal(int days) @safe nothrow scope
     {
         auto hnsecs = adjTime;
         hnsecs = removeUnitsFromHNSecs!"days"(hnsecs);
@@ -7066,14 +7341,11 @@ public:
     @safe unittest
     {
         import core.time;
-        void testST(SysTime orig, int day, scope const SysTime expected, size_t line = __LINE__) @safe
+        void testST(SysTime orig, int day, SysTime expected, size_t line = __LINE__) @safe
         {
             orig.dayOfGregorianCal = day;
             if (orig != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", orig, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -7106,14 +7378,11 @@ public:
 
         auto st = SysTime(DateTime(1, 1, 1, 12, 2, 9), msecs(212));
 
-        void testST2(int day, scope const SysTime expected, size_t line = __LINE__) @safe
+        void testST2(int day, SysTime expected, size_t line = __LINE__) @safe
         {
             st.dayOfGregorianCal = day;
             if (st != expected)
-            {
-                string s = expected.toSimpleString();
-                throw new AssertError(format("Failed. actual [%s] != expected [%s]", st, s), __FILE__, line);
-            }
+                throw new AssertError(format("Failed. actual [%s] != expected [%s]", st, expected), __FILE__, line);
         }
 
         // Test A.D.
@@ -7264,9 +7533,14 @@ public:
         testST2(-735_173, SysTime(DateTime(-2012, 3, 1, 12, 2, 9), msecs(212)));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         static assert(!__traits(compiles, cst.dayOfGregorianCal = 7));
-        //static assert(!__traits(compiles, ist.dayOfGregorianCal = 7));
+        static assert(!__traits(compiles, ist.dayOfGregorianCal = 7));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            st.dayOfGregorianCal = 42;
+        }
     }
 
 
@@ -7276,7 +7550,7 @@ public:
         See_Also:
             $(HTTP en.wikipedia.org/wiki/ISO_week_date, ISO Week Date).
       +/
-    @property ubyte isoWeek() @safe const nothrow
+    @property ubyte isoWeek() @safe const nothrow scope
     {
         return (cast(Date) this).isoWeek;
     }
@@ -7296,12 +7570,20 @@ public:
         assert(ist.isoWeek == 41);
     }
 
+    @safe unittest
+    {
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.isoWeek;
+        }
+    }
+
 
     /++
         $(LREF SysTime) for the last day in the month that this Date is in.
         The time portion of endOfMonth is always 23:59:59.9999999.
       +/
-    @property SysTime endOfMonth() @safe const nothrow
+    @property SysTime endOfMonth() @safe const nothrow scope
     {
         immutable hnsecs = adjTime;
         immutable days = getUnitsFromHNSecs!"days"(hnsecs);
@@ -7382,16 +7664,21 @@ public:
                SysTime(DateTime(-1999, 12, 31, 23, 59, 59), hnsecs(9_999_999)));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.endOfMonth == SysTime(DateTime(1999, 7, 31, 23, 59, 59), hnsecs(9_999_999)));
-        //assert(ist.endOfMonth == SysTime(DateTime(1999, 7, 31, 23, 59, 59), hnsecs(9_999_999)));
+        assert(ist.endOfMonth == SysTime(DateTime(1999, 7, 31, 23, 59, 59), hnsecs(9_999_999)));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.endOfMonth;
+        }
     }
 
 
     /++
         The last day in the month that this $(LREF SysTime) is in.
       +/
-    @property ubyte daysInMonth() @safe const nothrow
+    @property ubyte daysInMonth() @safe const nothrow scope
     {
         return Date(dayOfGregorianCal).daysInMonth;
     }
@@ -7442,16 +7729,21 @@ public:
         assert(SysTime(DateTime(-1999, 12, 1, 12, 52, 13)).daysInMonth == 31);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.daysInMonth == 31);
-        //assert(ist.daysInMonth == 31);
+        assert(ist.daysInMonth == 31);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.daysInMonth;
+        }
     }
 
 
     /++
         Whether the current year is a date in A.D.
       +/
-    @property bool isAD() @safe const nothrow
+    @property bool isAD() @safe const nothrow scope
     {
         return adjTime >= 0;
     }
@@ -7479,9 +7771,14 @@ public:
         assert(!SysTime(DateTime(-2010, 7, 4, 12, 2, 2)).isAD);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.isAD);
-        //assert(ist.isAD);
+        assert(ist.isAD);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.isAD;
+        }
     }
 
 
@@ -7492,7 +7789,7 @@ public:
         this function returns 2_450_173, while from noon onward, the Julian
         day number would be 2_450_174, so this function returns 2_450_174.
       +/
-    @property long julianDay() @safe const nothrow
+    @property long julianDay() @safe const nothrow scope
     {
         immutable jd = dayOfGregorianCal + 1_721_425;
         return hour < 12 ? jd - 1 : jd;
@@ -7526,9 +7823,14 @@ public:
         assert(SysTime(DateTime(2010, 8, 24, 12, 0, 0)).julianDay == 2_455_433);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.julianDay == 2_451_366);
-        //assert(ist.julianDay == 2_451_366);
+        assert(ist.julianDay == 2_451_366);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.julianDay;
+        }
     }
 
 
@@ -7537,7 +7839,7 @@ public:
         any time on this date (since, the modified Julian day changes at
         midnight).
       +/
-    @property long modJulianDay() @safe const nothrow
+    @property long modJulianDay() @safe const nothrow scope
     {
         return dayOfGregorianCal + 1_721_425 - 2_400_001;
     }
@@ -7552,16 +7854,21 @@ public:
         assert(SysTime(DateTime(2010, 8, 24, 12, 0, 0)).modJulianDay == 55_432);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cst.modJulianDay == 51_365);
-        //assert(ist.modJulianDay == 51_365);
+        assert(ist.modJulianDay == 51_365);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.modJulianDay;
+        }
     }
 
 
     /++
         Returns a $(REF Date,std,datetime,date) equivalent to this $(LREF SysTime).
       +/
-    Date opCast(T)() scope @trusted const nothrow
+    Date opCast(T)() @safe const nothrow scope
         if (is(Unqual!T == Date))
     {
         return Date(dayOfGregorianCal);
@@ -7587,9 +7894,14 @@ public:
         assert(cast(Date) SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == Date(-2001, 1, 1));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cast(Date) cst != Date.init);
-        //assert(cast(Date) ist != Date.init);
+        assert(cast(Date) ist != Date.init);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = cast(Date) st;
+        }
     }
 
 
@@ -7597,7 +7909,7 @@ public:
         Returns a $(REF DateTime,std,datetime,date) equivalent to this
         $(LREF SysTime).
       +/
-    DateTime opCast(T)() @safe const nothrow
+    DateTime opCast(T)() @safe const nothrow scope
         if (is(Unqual!T == DateTime))
     {
         try
@@ -7648,9 +7960,14 @@ public:
                DateTime(2011, 1, 13, 8, 17, 2));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cast(DateTime) cst != DateTime.init);
-        //assert(cast(DateTime) ist != DateTime.init);
+        assert(cast(DateTime) ist != DateTime.init);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = cast(DateTime) st;
+        }
     }
 
 
@@ -7658,7 +7975,7 @@ public:
         Returns a $(REF TimeOfDay,std,datetime,date) equivalent to this
         $(LREF SysTime).
       +/
-    TimeOfDay opCast(T)() @safe const nothrow
+    TimeOfDay opCast(T)() @safe const nothrow scope
         if (is(Unqual!T == TimeOfDay))
     {
         try
@@ -7699,9 +8016,14 @@ public:
         assert(cast(TimeOfDay) SysTime(DateTime(-2001, 1, 1, 14, 12, 11)) == TimeOfDay(14, 12, 11));
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         assert(cast(TimeOfDay) cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
+        assert(cast(TimeOfDay) ist != TimeOfDay.init);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = cast(TimeOfDay) st;
+        }
     }
 
 
@@ -7710,10 +8032,18 @@ public:
     // It may be a good idea to keep it though, since casting from a type to itself
     // should be allowed, and it doesn't work without this opCast() since opCast()
     // has already been defined for other types.
-    SysTime opCast(T)() @safe const pure nothrow
+    SysTime opCast(T)() @safe const pure nothrow scope
         if (is(Unqual!T == SysTime))
     {
         return SysTime(_stdTime, _timezone);
+    }
+
+    @safe unittest
+    {
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = cast(SysTime) st;
+        }
     }
 
 
@@ -7754,7 +8084,7 @@ public:
         Returns:
             A `string` when not using an output range; `void` otherwise.
       +/
-    string toISOString() @safe const nothrow
+    string toISOString() @safe const nothrow scope
     {
         import std.array : appender;
         auto app = appender!string();
@@ -7767,7 +8097,7 @@ public:
     }
 
     /// ditto
-    void toISOString(W)(ref W writer) const
+    void toISOString(W)(ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -7877,9 +8207,14 @@ public:
         assert(SysTime(DateTime(-10000, 10, 20, 1, 1, 1), hnsecs(507890)).toISOString() == "-100001020T010101.050789");
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay) cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        assert(cst.toISOString() == "19990706T123033");
+        assert(ist.toISOString() == "19990706T123033");
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toISOString();
+        }
     }
 
 
@@ -7909,7 +8244,7 @@ public:
         Returns:
             A `string` when not using an output range; `void` otherwise.
       +/
-    string toISOExtString() @safe const nothrow
+    string toISOExtString() @safe const nothrow scope
     {
         import std.array : appender;
         auto app = appender!string();
@@ -7922,7 +8257,7 @@ public:
     }
 
     /// ditto
-    void toISOExtString(W)(ref W writer) const
+    void toISOExtString(W)(ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -8038,9 +8373,14 @@ public:
                "-10000-10-20T01:01:01.050789");
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay) cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        assert(cst.toISOExtString() == "1999-07-06T12:30:33");
+        assert(ist.toISOExtString() == "1999-07-06T12:30:33");
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toISOExtString();
+        }
     }
 
     /++
@@ -8068,7 +8408,7 @@ public:
         Returns:
             A `string` when not using an output range; `void` otherwise.
       +/
-    string toSimpleString() scope @trusted const nothrow
+    string toSimpleString() @safe const nothrow scope
     {
         import std.array : appender;
         auto app = appender!string();
@@ -8081,7 +8421,7 @@ public:
     }
 
     /// ditto
-    void toSimpleString(W)(ref W writer) const
+    void toSimpleString(W)(ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -8198,9 +8538,14 @@ public:
                "-10000-Oct-20 01:01:01.050789");
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cast(TimeOfDay) cst != TimeOfDay.init);
-        //assert(cast(TimeOfDay) ist != TimeOfDay.init);
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        assert(cst.toSimpleString() == "1999-Jul-06 12:30:33");
+        assert(ist.toSimpleString() == "1999-Jul-06 12:30:33");
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toSimpleString();
+        }
     }
 
 
@@ -8233,13 +8578,13 @@ public:
         Returns:
             A `string` when not using an output range; `void` otherwise.
       +/
-    string toString() @safe const nothrow
+    string toString() @safe const nothrow scope
     {
         return toSimpleString();
     }
 
     /// ditto
-    void toString(W)(ref W writer) const
+    void toString(W)(ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         toSimpleString(writer);
@@ -8250,10 +8595,15 @@ public:
         import core.time;
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(st.toString());
-        assert(cst.toString());
-        //assert(ist.toString());
+        immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
+        static assert(__traits(compiles, st.toString()));
+        static assert(__traits(compiles, cst.toString()));
+        static assert(__traits(compiles, ist.toString()));
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = st.toString();
+        }
     }
 
 
@@ -8544,6 +8894,11 @@ public:
         test("20101222T172201.1234567+01:00", SysTime(DateTime(2010, 12, 22, 17, 22, 01), hnsecs(1_234_567), east60));
         test("20101222T172201.0000000+01:30", SysTime(DateTime(2010, 12, 22, 17, 22, 01), east90));
         test("20101222T172201.45+08:00", SysTime(DateTime(2010, 12, 22, 17, 22, 01), hnsecs(4_500_000), east480));
+
+        static void testScope(scope ref string str) @safe
+        {
+            auto result = SysTime.fromISOString(str);
+        }
     }
 
     // bug# 17801
@@ -8786,6 +9141,11 @@ public:
         test("2010-12-22T17:22:01.0+01", SysTime(DateTime(2010, 12, 22, 17, 22, 01), east60));
         test("2010-12-22T17:22:01.0000000+01:30", SysTime(DateTime(2010, 12, 22, 17, 22, 01), east90));
         test("2010-12-22T17:22:01.45+08:00", SysTime(DateTime(2010, 12, 22, 17, 22, 01), hnsecs(4_500_000), east480));
+
+        static void testScope(scope ref string str) @safe
+        {
+            auto result = SysTime.fromISOExtString(str);
+        }
     }
 
     // bug# 17801
@@ -9032,6 +9392,11 @@ public:
         test("2010-Dec-22 17:22:01.0+01", SysTime(DateTime(2010, 12, 22, 17, 22, 01), east60));
         test("2010-Dec-22 17:22:01.0000000+01:30", SysTime(DateTime(2010, 12, 22, 17, 22, 01), east90));
         test("2010-Dec-22 17:22:01.45+08:00", SysTime(DateTime(2010, 12, 22, 17, 22, 01), hnsecs(4_500_000), east480));
+
+        static void testScope(scope ref string str) @safe
+        {
+            auto result = SysTime.fromSimpleString(str);
+        }
     }
 
     // bug# 17801
@@ -9398,7 +9763,7 @@ version(StdDdoc)
             unlikely to happen given that `SysTime.max` is in 29,228 A.D. and
             the maximum `SYSTEMTIME` is in 30,827 A.D.
       +/
-    SysTime SYSTEMTIMEToSysTime(const SYSTEMTIME* st, immutable TimeZone tz = LocalTime()) @safe;
+    SysTime SYSTEMTIMEToSysTime(const scope SYSTEMTIME* st, immutable TimeZone tz = LocalTime()) @safe;
 
 
     /++
@@ -9418,7 +9783,7 @@ version(StdDdoc)
             $(LREF SysTime) will not fit in a `SYSTEMTIME`. This will only
             happen if the $(LREF SysTime)'s date is prior to 1601 A.D.
       +/
-    SYSTEMTIME SysTimeToSYSTEMTIME(scope const SysTime sysTime) @safe;
+    SYSTEMTIME SysTimeToSYSTEMTIME(scope SysTime sysTime) @safe;
 
 
     /++
@@ -9485,11 +9850,11 @@ version(StdDdoc)
             $(REF DateTimeException,std,datetime,date) if the given
             $(LREF SysTime) will not fit in a `FILETIME`.
       +/
-    FILETIME SysTimeToFILETIME(SysTime sysTime) @safe;
+    FILETIME SysTimeToFILETIME(scope SysTime sysTime) @safe;
 }
 else version(Windows)
 {
-    SysTime SYSTEMTIMEToSysTime(const SYSTEMTIME* st, immutable TimeZone tz = LocalTime()) @safe
+    SysTime SYSTEMTIMEToSysTime(const scope SYSTEMTIME* st, immutable TimeZone tz = LocalTime()) @safe
     {
         const max = SysTime.max;
 
@@ -9545,10 +9910,15 @@ else version(Windows)
         auto converted = SYSTEMTIMEToSysTime(&st, UTC());
         import core.time : abs;
         assert(abs((converted - sysTime)) <= dur!"seconds"(2));
+
+        static void testScope(scope SYSTEMTIME* st) @safe
+        {
+            auto result = SYSTEMTIMEToSysTime(st);
+        }
     }
 
 
-    SYSTEMTIME SysTimeToSYSTEMTIME(scope const SysTime sysTime) @safe
+    SYSTEMTIME SysTimeToSYSTEMTIME(scope SysTime sysTime) @safe
     {
         immutable dt = cast(DateTime) sysTime;
 
@@ -9585,6 +9955,11 @@ else version(Windows)
         assert(st.wMinute == result.wMinute);
         assert(st.wSecond == result.wSecond);
         assert(st.wMilliseconds == result.wMilliseconds);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = SysTimeToSYSTEMTIME(st);
+        }
     }
 
     private enum hnsecsFrom1601 = 504_911_232_000_000_000L;
@@ -9622,6 +9997,11 @@ else version(Windows)
 
         import core.time : abs;
         assert(abs((converted - sysTime)) <= dur!"seconds"(2));
+
+        static void testScope(scope FILETIME* ft) @safe
+        {
+            auto result = FILETIMEToSysTime(ft);
+        }
     }
 
 
@@ -9640,7 +10020,7 @@ else version(Windows)
         return ft;
     }
 
-    FILETIME SysTimeToFILETIME(SysTime sysTime) @safe
+    FILETIME SysTimeToFILETIME(scope SysTime sysTime) @safe
     {
         return stdTimeToFILETIME(sysTime.stdTime);
     }
@@ -9658,6 +10038,11 @@ else version(Windows)
 
         assert(ft.dwLowDateTime == result.dwLowDateTime);
         assert(ft.dwHighDateTime == result.dwHighDateTime);
+
+        static void testScope(scope ref SysTime st) @safe
+        {
+            auto result = SysTimeToFILETIME(st);
+        }
     }
 }
 
@@ -9708,6 +10093,14 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
     assert(DosFileTimeToSysTime(0x3E3F8456) == SysTime(DateTime(2011, 1, 31, 16, 34, 44)));
 }
 
+@safe unittest
+{
+    static void testScope(scope ref DosFileTime dft) @safe
+    {
+        auto result = DosFileTimeToSysTime(dft);
+    }
+}
+
 
 /++
     Converts from $(LREF SysTime) to DOS file date/time.
@@ -9719,7 +10112,7 @@ SysTime DosFileTimeToSysTime(DosFileTime dft, immutable TimeZone tz = LocalTime(
         $(REF DateTimeException,std,datetime,date) if the given
         $(LREF SysTime) cannot be converted to a `DosFileTime`.
   +/
-DosFileTime SysTimeToDosFileTime(SysTime sysTime) @safe
+DosFileTime SysTimeToDosFileTime(scope SysTime sysTime) @safe
 {
     auto dateTime = cast(DateTime) sysTime;
 
@@ -9748,6 +10141,14 @@ DosFileTime SysTimeToDosFileTime(SysTime sysTime) @safe
     assert(SysTimeToDosFileTime(SysTime(DateTime(1980, 1, 1, 0, 0, 0))) == 0b00000000001000010000000000000000);
     assert(SysTimeToDosFileTime(SysTime(DateTime(2107, 12, 31, 23, 59, 58))) == 0b11111111100111111011111101111101);
     assert(SysTimeToDosFileTime(SysTime(DateTime(2011, 1, 31, 16, 34, 44))) == 0x3E3F8456);
+}
+
+@safe unittest
+{
+    static void testScope(scope ref SysTime st) @safe
+    {
+        auto result = SysTimeToDosFileTime(st);
+    }
 }
 
 
@@ -9794,7 +10195,7 @@ SysTime parseRFC822DateTime()(scope const char[] value) @safe
 }
 
 /++ Ditto +/
-SysTime parseRFC822DateTime(R)(scope R value) @trusted
+SysTime parseRFC822DateTime(R)(scope R value)
 if (isRandomAccessRange!R && hasSlicing!R && hasLength!R &&
     (is(Unqual!(ElementType!R) == char) || is(Unqual!(ElementType!R) == ubyte)))
 {
@@ -10304,6 +10705,11 @@ version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LIN
             testBad((cast(string) currStr) ~ "                                    ");
         }
     }}
+
+    static void testScope(scope ref string str) @safe
+    {
+        auto result = parseRFC822DateTime(str);
+    }
 }
 
 // Obsolete Format per section 4.3 of RFC 5322.
@@ -10590,7 +10996,7 @@ void fracSecsToISOString(W)(ref W writer, int hnsecs)
     Returns a Duration corresponding to to the given ISO string of
     fractional seconds.
   +/
-static Duration fracSecsFromISOString(S)(scope const S isoString) @trusted pure
+static Duration fracSecsFromISOString(S)(scope const S isoString) @safe pure
 if (isSomeString!S)
 {
     import std.algorithm.searching : all;


### PR DESCRIPTION
This removes unnecessary uses of scope, adds a lot of necessary uses of
scope, and adds basic tests that ensure that each of the functions in
std.datetime.systime compile when given scope arguments. It also enables
some previously commented out tests involving immutable SysTimes (IIRC,
they didn't use to compile due to compiler bugs related to
Rebindable!(immutable TimeZone), but they now compiler, so they should
be enabled).