### PR TITLE
[stable] Fix std.experimental.allocator.common.effectiveAlignment()

### DIFF
--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -99,7 +99,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
         auto leadingUlongs = blocks.divideRoundUp(64);
         import std.algorithm.comparison : min;
         immutable initialAlignment = min(parentAlignment,
-            1U << trailingZeros(leadingUlongs * 8));
+            1U << min(31U, trailingZeros(leadingUlongs * 8)));
         auto maxSlack = alignment <= initialAlignment
             ? 0
             : alignment - initialAlignment;

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -287,9 +287,9 @@ Returns the effective alignment of `ptr`, i.e. the largest power of two that is
 a divisor of `ptr`.
 */
 @nogc nothrow pure
-package uint effectiveAlignment(void* ptr)
+package size_t effectiveAlignment(void* ptr)
 {
-    return 1U << trailingZeros(cast(size_t) ptr);
+    return (cast(size_t) 1) << trailingZeros(cast(size_t) ptr);
 }
 
 @nogc nothrow pure
@@ -297,6 +297,9 @@ package uint effectiveAlignment(void* ptr)
 {
     int x;
     assert(effectiveAlignment(&x) >= int.alignof);
+
+    const max = (cast(size_t) 1) << (size_t.sizeof * 8 - 1);
+    assert(effectiveAlignment(cast(void*) max) == max);
 }
 
 /*


### PR DESCRIPTION
It was unable to handle alignments > 2^31 bytes, e.g., returning 2 for the 64-bit pointer 0x2FA_00000000. Return a `size_t` instead of a `uint`. Note that it's only called in one place, an assertion in a ctor of the
`BitmappedBlockImpl` mixin, which handles `size_t` fine.

This fixes sporadic `std.experimental.allocator.building_blocks.bitmapped_block` unittest failures for LDC CI on Win64 (something like 1 out of 100 runs failing).