### PR TITLE
Eliminate unreachable statement

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -842,7 +842,6 @@ if (isForwardRange!R && is(ElementType!R : dchar))
         {
         case '*', '?', '+', '|', '{', '}':
             error("'*', '+', '?', '{', '}' not allowed in atom");
-            break;
         case '.':
             if (re_flags & RegexOption.singleline)
                 g.put(Bytecode(IR.Any, 0));


### PR DESCRIPTION
The statement is unreachable which will be detected by `dmd` when compiling with `dub build --build=profile`.