### PR TITLE
Add -betterC testsuite for Phobos

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -424,6 +424,18 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 	 BUILD=debug $(MAKE) -f $(MAKEFILE) $(basename $<).debug_with_debugger
 
 ################################################################################
+# Run separate -betterC tests
+################################################################################
+
+test/betterC/%.run: test/betterC/%.d $(DMD) $(LIB)
+	mkdir -p $(ROOT)/unittest/betterC
+	$(DMD) $(DFLAGS) -of$(ROOT)/unittest/betterC/$(notdir $(basename $<)) -betterC $(UDFLAGS) \
+		-defaultlib= -debuglib= $(LINKDL) $<
+	./$(ROOT)/unittest/betterC/$(notdir $(basename $<))
+
+betterC: $(subst .d,.run,$(wildcard test/betterC/*.d))
+
+################################################################################
 # More stuff
 ################################################################################
 
@@ -622,6 +634,6 @@ $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 auto-tester-build: all checkwhitespace
 
 .PHONY : auto-tester-test
-auto-tester-test: unittest
+auto-tester-test: unittest betterC
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/test/betterC/algorithm.d
+++ b/test/betterC/algorithm.d
@@ -1,0 +1,4 @@
+extern(C) void main() {
+    import std.algorithm, std.range;
+    assert(100.iota.stride(2).take(10).sum == 90);
+}


### PR DESCRIPTION
Split of https://github.com/dlang/phobos/pull/5952 that only contains the testsuite (and a first minimal test) as #5952 is currently blocked (it tries to fix `Tuple` for betterC and there are still some unresolved issues with `toHash`).

This PR should be non-controversial and thus us allow to finally get started with a betterC testsuite.

```
make -f posix.mak betterC
```