### PR TITLE
[RFC] Add a minimal baremetal testsuite to Phobos

### DIFF
--- a/test/baremetal/hello.d
+++ b/test/baremetal/hello.d
@@ -1,0 +1,6 @@
+extern(C) int main()
+{
+    import std.algorithm, std.range;
+    assert(100.iota.stride(2).take(10).sum == 90);
+    return 0;
+}

--- a/test/baremetal/runtime/runtime.d
+++ b/test/baremetal/runtime/runtime.d
@@ -1,0 +1,83 @@
+extern(C) void __d_sys_exit(size_t arg1)
+{
+    version(linux)
+    {
+        version(X86_64)
+        {
+            asm
+            {
+                mov RAX, 60;
+                mov RDI, arg1;
+                syscall;
+            }
+        }
+        else version(X86)
+        {
+            asm
+            {
+                mov EAX, 2;
+                mov EDI, arg1;
+                syscall;
+            }
+        }
+    }
+}
+
+extern(C) void __assert(const(char)* exp, const(char)* file, uint line)
+{
+    version(linux)
+        print("ASSERT ERROR\n");
+    assert(0);
+}
+
+extern extern(C) int main();
+private extern(C) void _start()
+{
+    __d_sys_exit(main());
+}
+
+void print(const char* c)
+{
+    print(c, c.strlen);
+}
+
+void print(const char* c, size_t len)
+{
+    version(linux)
+    {
+        version(X86_64)
+        {
+            asm
+            {
+                mov RDX, len;
+                mov RSI, c;
+                mov RAX, 1; // write
+                mov RDI, RAX;
+                syscall;
+            }
+        }
+        else version(X86)
+        {
+            asm
+            {
+                mov EDX, len;
+                mov ESI, c;
+                mov EAX, 1; // write
+                mov EDI, EAX;
+                syscall;
+            }
+        }
+    }
+}
+
+size_t strlen(const char* c)
+{
+    auto cptr = cast(char*) c;
+    size_t i;
+    while (*cptr != 0)
+    {
+        cptr++;
+        i++;
+    }
+    return i;
+}


### PR DESCRIPTION
Similarly to https://github.com/dlang/phobos/pull/6640, this will allow to add tests to Phobos for functionality that doesn't depend on libc.
It currently contains a minimal Linux x86 runtime.

Future
------

We probably want to add a special UDA (e.g. `@test-baremetal` and `@test-betterc`) to Phobos and thus extract such tests automatically (instead of keeping them separate).

Another possible route is to combine this with the testsuite runner of DMD or at least have support for minimal things like `TEST_OUTPUT`.

CC @ZombineDev 