### PR TITLE
Fix warning in std.range.package - calling without side effects discards return value

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10177,8 +10177,8 @@ template isTwoWayCompatible(alias fn, T1, T2)
             T1 foo();
             T2 bar();
 
-            fn(foo(), bar());
-            fn(bar(), foo());
+            cast(void) fn(foo(), bar());
+            cast(void) fn(bar(), foo());
         }
     ));
 }


### PR DESCRIPTION
DMD currently has a bug that is gagging warnings and deprecations.  That bug is in the process of being fixed at https://github.com/dlang/dmd/pull/8519, but it has revealed some warnings that need to be resolved in Phobos.  This is one.