### PR TITLE
[WIP] Issue 14770 - Use vfork on Linux when available

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -490,8 +490,8 @@ private Pid spawnProcessImpl(scope const(char[])[] args,
             }
             return false;
         }
-        if (!(config & Config.inheritFDs) &&
-            (config & Config.detached) &&
+        if ((config & Config.inheritFDs) &&
+            !(config & Config.detached) &&
             !hasPrivilege())
             id = core.sys.posix.unistd.vfork();
         else

--- a/std/process.d
+++ b/std/process.d
@@ -490,7 +490,9 @@ private Pid spawnProcessImpl(scope const(char[])[] args,
             }
             return false;
         }
-        if (!hasPrivilege())
+        if (!(config & Config.inheritFDs) &&
+            (config & Config.detached) &&
+            !hasPrivilege())
             id = core.sys.posix.unistd.vfork();
         else
             id = core.sys.posix.unistd.fork();

--- a/std/process.d
+++ b/std/process.d
@@ -460,6 +460,11 @@ private Pid spawnProcessImpl(scope const(char[])[] args,
     pid_t id;
     version (linux)
     {
+        /*
+        If vfork() is used and the parent or child changes
+        effective UID or GID, different privileged process
+        shares memory. This causes security issues.
+         */
         bool hasPrivilege()
         {
             import core.sys.posix.unistd : getegid, geteuid, getgid, getuid;


### PR DESCRIPTION
## Purpose

vfork (or posix_spawn) sometimes very useful when we need subprocess (e.g, https://about.gitlab.com/2018/01/23/how-a-fix-in-go-19-sped-up-our-gitaly-service-by-30x/ Go uses clone(CLONE_VFORK, ...) internally.)
~~posix_spawn has some problems (cannnot change working directory, and so on), so I decide to use vfork.~~

posix_spawn seems good, but posix_spawn requires glibc 2.24+ and changes to druntime, so I started to use vfork.

## TODO:

- [ ] Investigte singal handling.
- [ ] Update CHANGELOG. (Since I still investigate)

## Related things

refs: https://github.com/dlang/phobos/pull/3476