### PR TITLE
Allow @betterC tests in Phobos

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -73,7 +73,7 @@ setup_repos()
         git checkout -f FETCH_HEAD
     fi
 
-    for proj in dmd druntime ; do
+    for proj in dmd druntime tools ; do
         if [ $base_branch != master ] && [ $base_branch != stable ] &&
             ! git ls-remote --exit-code --heads https://github.com/dlang/$proj.git $base_branch > /dev/null; then
             # use master as fallback for other repos to test feature branches
@@ -124,12 +124,6 @@ coverage()
 publictests()
 {
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
-
-    # checkout a specific version of https://github.com/dlang/tools
-    if [ ! -d ../tools ] ; then
-        clone https://github.com/dlang/tools.git ../tools master
-    fi
-    git -C ../tools checkout 6ad91215253b52e6ecfc39fe1854815867c66f23
 
     make -f posix.mak -j$N publictests DUB=$DUB BUILD=$BUILD
 }

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -126,6 +126,10 @@ publictests()
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
     make -f posix.mak -j$N publictests DUB=$DUB BUILD=$BUILD
+
+    # run -betterC tests
+    make -f posix.mak test_extractor # build in single-threaded mode
+    make -f posix.mak -j$N betterc
 }
 
 # test stdx dub package

--- a/posix.mak
+++ b/posix.mak
@@ -611,6 +611,8 @@ $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 	DFLAGS="$(DFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL)" $(DUB) build --force --compiler=$${PWD}/$(DMD) --single $<
 	mv $(TOOLS_DIR)/tests_extractor $@
 
+test_extractor: $(TESTS_EXTRACTOR)
+
 ################################################################################
 # Extract public tests of a module and test them in an separate file (i.e. without its module)
 # This is done to check for potentially missing imports in the examples, e.g.
@@ -647,7 +649,7 @@ betterc: betterc-phobos-tests betterc-run-tests
 # Run separate -betterC tests
 ################################################################################
 
-test/betterC/%.run: test/betterC/%.d $(DMD) $(LIB)
+test/betterC/%.run: test/betterC/%.d $(DRUNTIME)
 	mkdir -p $(ROOT)/unittest/betterC
 	$(DMD) $(DFLAGS) -of$(ROOT)/unittest/betterC/$(notdir $(basename $<)) -betterC $(UDFLAGS) \
 		$(NODEFAULTLIB) $(LINKDL) $<
@@ -661,9 +663,9 @@ betterc-run-tests: $(subst .d,.run,$(wildcard test/betterC/*.d))
 auto-tester-build: all checkwhitespace
 
 .PHONY : auto-tester-test
-auto-tester-test: unittest betterc
+auto-tester-test: unittest
 
 .PHONY: buildkite-test
-buildkite-test: unittest betterC
+buildkite-test: unittest betterc
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -66,6 +66,8 @@ import std.traits;
 import std.meta : allSatisfy;
 import std.typecons; // : tuple, Tuple, Flag, Yes;
 
+import std.internal.attributes : betterC;
+
 /**
 Find `value` _among `values`, returning the 1-based index
 of the first matching value in `values`, or `0` if `value`
@@ -116,7 +118,7 @@ if (isExpressionTuple!values)
 }
 
 ///
-@safe unittest
+@safe @betterC unittest
 {
     assert(3.among(1, 42, 24, 3, 2));
 
@@ -133,7 +135,7 @@ if (isExpressionTuple!values)
 Alternatively, `values` can be passed at compile-time, allowing for a more
 efficient search, but one that only supports matching on equality:
 */
-@safe unittest
+@safe @betterC unittest
 {
     assert(3.among!(2, 3, 4));
     assert("bar".among!("foo", "bar", "baz") == 2);
@@ -541,7 +543,7 @@ do
 }
 
 ///
-@safe unittest
+@safe @betterC unittest
 {
     assert(clamp(2, 1, 3) == 2);
     assert(clamp(0, 1, 3) == 1);
@@ -1575,7 +1577,7 @@ if (T.length >= 2)
 }
 
 ///
-@safe unittest
+@safe @betterC unittest
 {
     int a = 5;
     short b = 6;
@@ -1687,7 +1689,7 @@ if (T.length >= 2)
 }
 
 ///
-@safe unittest
+@safe @betterC unittest
 {
     int a = 5;
     short b = 6;
@@ -1698,15 +1700,23 @@ if (T.length >= 2)
     auto e = min(a, b, c);
     static assert(is(typeof(e) == double));
     assert(e == 2);
+}
 
-    // With arguments of mixed signedness, the return type is the one that can
-    // store the lowest values.
-    a = -10;
+/**
+With arguments of mixed signedness, the return type is the one that can
+store the lowest values.
+*/
+@safe @betterC unittest
+{
+    int a = -10;
     uint f = 10;
     static assert(is(typeof(min(a, f)) == int));
     assert(min(a, f) == -10);
+}
 
-    // User-defined types that support comparison with < are supported.
+/// User-defined types that support comparison with < are supported.
+@safe unittest
+{
     import std.datetime;
     assert(min(Date(2012, 12, 21), Date(1982, 1, 4)) == Date(1982, 1, 4));
     assert(min(Date(1982, 1, 4), Date(2012, 12, 21)) == Date(1982, 1, 4));
@@ -1985,7 +1995,7 @@ if (isInputRange!Range1 &&
 }
 
 // Test CTFE
-@safe pure unittest
+@safe pure @betterC unittest
 {
     enum result1 = isSameLength([1, 2, 3], [4, 5, 6]);
     static assert(result1);
@@ -2273,7 +2283,7 @@ if (alternatives.length >= 1 &&
 }
 
 ///
-@safe pure unittest
+@safe pure @betterC unittest
 {
     const a = 1;
     const b = 2;
@@ -2292,7 +2302,11 @@ if (alternatives.length >= 1 &&
     auto ef = either(e, f);
     static assert(is(typeof(ef) == int));
     assert(ef == f);
+}
 
+///
+@safe pure unittest
+{
     immutable p = 1;
     immutable q = 2;
     auto pq = either(p, q);
@@ -2303,7 +2317,11 @@ if (alternatives.length >= 1 &&
     assert(either(0, 4) == 4);
     assert(either(0, 0) == 0);
     assert(either("", "a") == "");
+}
 
+///
+@safe pure unittest
+{
     string r = null;
     assert(either(r, "a") == "a");
     assert(either("a", "") == "a");

--- a/std/internal/attributes.d
+++ b/std/internal/attributes.d
@@ -1,0 +1,11 @@
+module std.internal.attributes;
+
+/**
+Used to annotate `unittest`s which need to be tested in a `-betterC` environment.
+
+Such `unittest`s will be compiled and executed without linking druntime in, with
+a `__traits(getUnitTests, mixin(__MODULE__))` style test runner.
+Note that just like any other `unittest` in phobos, they will also be compiled
+and executed without `-betterC`.
+*/
+package(std) enum betterC = 1;


### PR DESCRIPTION
Open questions:
- Should we remove the `test/betterC` folder? (the @betterC test extraction is imho a better replacement)

Requires: https://github.com/dlang/tools/pull/357