### PR TITLE
Fix Issue 19135: Rename std.json.JSON_TYPE to JsonType with lowercase attributes

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -39,7 +39,7 @@ import std.traits;
     long x;
     if (const(JSONValue)* code = "code" in j)
     {
-        if (code.type() == JSON_TYPE.INTEGER)
+        if (code.type() == JSONType.integer)
             x = code.integer;
         else
             x = to!int(code.str);
@@ -83,19 +83,32 @@ enum JSONOptions
 /**
 JSON type enumeration
 */
-enum JSON_TYPE : byte
+enum JSONType : byte
 {
     /// Indicates the type of a `JSONValue`.
-    NULL,
-    STRING,  /// ditto
-    INTEGER, /// ditto
-    UINTEGER,/// ditto
-    FLOAT,   /// ditto
-    OBJECT,  /// ditto
-    ARRAY,   /// ditto
-    TRUE,    /// ditto
-    FALSE    /// ditto
+    null_,
+    string,   /// ditto
+    integer,  /// ditto
+    uinteger, /// ditto
+    float_,   /// ditto
+    array,    /// ditto
+    object,   /// ditto
+    true_,    /// ditto
+    false_,   /// ditto
+    /// These symbols will be deprecated after 2.082.
+    NULL = null_,
+    STRING = string,
+    INTEGER = integer,
+    UINTEGER = uinteger,
+    FLOAT = float_,
+    ARRAY = array,
+    OBJECT = object,
+    TRUE = true_,
+    FALSE = false_,
 }
+
+/// This alias will be deprecated after 2.082.
+alias JSON_TYPE = JSONType;
 
 /**
 JSON value node
@@ -114,12 +127,12 @@ struct JSONValue
         JSONValue[]                     array;
     }
     private Store store;
-    private JSON_TYPE type_tag;
+    private JSONType type_tag;
 
     /**
-      Returns the JSON_TYPE of the value stored in this structure.
+      Returns the JSONType of the value stored in this structure.
     */
-    @property JSON_TYPE type() const pure nothrow @safe @nogc
+    @property JSONType type() const pure nothrow @safe @nogc
     {
         return type_tag;
     }
@@ -128,18 +141,18 @@ struct JSONValue
     {
           string s = "{ \"language\": \"D\" }";
           JSONValue j = parseJSON(s);
-          assert(j.type == JSON_TYPE.OBJECT);
-          assert(j["language"].type == JSON_TYPE.STRING);
+          assert(j.type == JSONType.object);
+          assert(j["language"].type == JSONType.string);
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.STRING`.
+     * Value getter/setter for `JSONType.string`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.STRING`.
+     * `JSONType.string`.
      */
     @property string str() const pure @trusted
     {
-        enforce!JSONException(type == JSON_TYPE.STRING,
+        enforce!JSONException(type == JSONType.string,
                                 "JSONValue is not a string");
         return store.str;
     }
@@ -163,13 +176,13 @@ struct JSONValue
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.INTEGER`.
+     * Value getter/setter for `JSONType.integer`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.INTEGER`.
+     * `JSONType.integer`.
      */
     @property inout(long) integer() inout pure @safe
     {
-        enforce!JSONException(type == JSON_TYPE.INTEGER,
+        enforce!JSONException(type == JSONType.integer,
                                 "JSONValue is not an integer");
         return store.integer;
     }
@@ -181,13 +194,13 @@ struct JSONValue
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.UINTEGER`.
+     * Value getter/setter for `JSONType.uinteger`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.UINTEGER`.
+     * `JSONType.uinteger`.
      */
     @property inout(ulong) uinteger() inout pure @safe
     {
-        enforce!JSONException(type == JSON_TYPE.UINTEGER,
+        enforce!JSONException(type == JSONType.uinteger,
                                 "JSONValue is not an unsigned integer");
         return store.uinteger;
     }
@@ -199,14 +212,14 @@ struct JSONValue
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.FLOAT`. Note that despite
+     * Value getter/setter for `JSONType.float_`. Note that despite
      * the name, this is a $(B 64)-bit `double`, not a 32-bit `float`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.FLOAT`.
+     * `JSONType.float_`.
      */
     @property inout(double) floating() inout pure @safe
     {
-        enforce!JSONException(type == JSON_TYPE.FLOAT,
+        enforce!JSONException(type == JSONType.float_,
                                 "JSONValue is not a floating type");
         return store.floating;
     }
@@ -218,9 +231,9 @@ struct JSONValue
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.OBJECT`.
+     * Value getter/setter for `JSONType.object`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.OBJECT`.
+     * `JSONType.object`.
      * Note: this is @system because of the following pattern:
        ---
        auto a = &(json.object());
@@ -230,7 +243,7 @@ struct JSONValue
      */
     @property ref inout(JSONValue[string]) object() inout pure @system
     {
-        enforce!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSONType.object,
                                 "JSONValue is not an object");
         return store.object;
     }
@@ -242,7 +255,7 @@ struct JSONValue
     }
 
     /***
-     * Value getter for `JSON_TYPE.OBJECT`.
+     * Value getter for `JSONType.object`.
      * Unlike `object`, this retrieves the object by value and can be used in @safe code.
      *
      * A caveat is that, if the returned value is null, modifications will not be visible:
@@ -254,19 +267,19 @@ struct JSONValue
      * ---
      *
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.OBJECT`.
+     * `JSONType.object`.
      */
     @property inout(JSONValue[string]) objectNoRef() inout pure @trusted
     {
-        enforce!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSONType.object,
                                 "JSONValue is not an object");
         return store.object;
     }
 
     /***
-     * Value getter/setter for `JSON_TYPE.ARRAY`.
+     * Value getter/setter for `JSONType.array`.
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.ARRAY`.
+     * `JSONType.array`.
      * Note: this is @system because of the following pattern:
        ---
        auto a = &(json.array());
@@ -276,7 +289,7 @@ struct JSONValue
      */
     @property ref inout(JSONValue[]) array() inout pure @system
     {
-        enforce!JSONException(type == JSON_TYPE.ARRAY,
+        enforce!JSONException(type == JSONType.array,
                                 "JSONValue is not an array");
         return store.array;
     }
@@ -288,7 +301,7 @@ struct JSONValue
     }
 
     /***
-     * Value getter for `JSON_TYPE.ARRAY`.
+     * Value getter for `JSONType.array`.
      * Unlike `array`, this retrieves the array by value and can be used in @safe code.
      *
      * A caveat is that, if you append to the returned array, the new values aren't visible in the
@@ -301,37 +314,37 @@ struct JSONValue
      * ---
      *
      * Throws: `JSONException` for read access if `type` is not
-     * `JSON_TYPE.ARRAY`.
+     * `JSONType.array`.
      */
     @property inout(JSONValue[]) arrayNoRef() inout pure @trusted
     {
-        enforce!JSONException(type == JSON_TYPE.ARRAY,
+        enforce!JSONException(type == JSONType.array,
                                 "JSONValue is not an array");
         return store.array;
     }
 
-    /// Test whether the type is `JSON_TYPE.NULL`
+    /// Test whether the type is `JSONType.null_`
     @property bool isNull() const pure nothrow @safe @nogc
     {
-        return type == JSON_TYPE.NULL;
+        return type == JSONType.null_;
     }
 
     private void assign(T)(T arg) @safe
     {
         static if (is(T : typeof(null)))
         {
-            type_tag = JSON_TYPE.NULL;
+            type_tag = JSONType.null_;
         }
         else static if (is(T : string))
         {
-            type_tag = JSON_TYPE.STRING;
+            type_tag = JSONType.string;
             string t = arg;
             () @trusted { store.str = t; }();
         }
         else static if (isSomeString!T) // issue 15884
         {
-            type_tag = JSON_TYPE.STRING;
-            // FIXME: std.array.array(Range) is not deduced as 'pure'
+            type_tag = JSONType.string;
+            // FIXME: std.Array.Array(Range) is not deduced as 'pure'
             () @trusted {
                 import std.utf : byUTF;
                 store.str = cast(immutable)(arg.byUTF!char.array);
@@ -339,27 +352,27 @@ struct JSONValue
         }
         else static if (is(T : bool))
         {
-            type_tag = arg ? JSON_TYPE.TRUE : JSON_TYPE.FALSE;
+            type_tag = arg ? JSONType.true_ : JSONType.false_;
         }
         else static if (is(T : ulong) && isUnsigned!T)
         {
-            type_tag = JSON_TYPE.UINTEGER;
+            type_tag = JSONType.uinteger;
             store.uinteger = arg;
         }
         else static if (is(T : long))
         {
-            type_tag = JSON_TYPE.INTEGER;
+            type_tag = JSONType.integer;
             store.integer = arg;
         }
         else static if (isFloatingPoint!T)
         {
-            type_tag = JSON_TYPE.FLOAT;
+            type_tag = JSONType.float_;
             store.floating = arg;
         }
         else static if (is(T : Value[Key], Key, Value))
         {
             static assert(is(Key : string), "AA key must be string");
-            type_tag = JSON_TYPE.OBJECT;
+            type_tag = JSONType.object;
             static if (is(Value : JSONValue))
             {
                 JSONValue[string] t = arg;
@@ -375,7 +388,7 @@ struct JSONValue
         }
         else static if (isArray!T)
         {
-            type_tag = JSON_TYPE.ARRAY;
+            type_tag = JSONType.array;
             static if (is(ElementEncodingType!T : JSONValue))
             {
                 JSONValue[] t = arg;
@@ -396,13 +409,13 @@ struct JSONValue
         }
         else
         {
-            static assert(false, text(`unable to convert type "`, T.stringof, `" to json`));
+            static assert(false, text(`unable to convert type "`, T.Stringof, `" to json`));
         }
     }
 
     private void assignRef(T)(ref T arg) if (isStaticArray!T)
     {
-        type_tag = JSON_TYPE.ARRAY;
+        type_tag = JSONType.array;
         static if (is(ElementEncodingType!T : JSONValue))
         {
             store.array = arg;
@@ -419,8 +432,8 @@ struct JSONValue
     /**
      * Constructor for `JSONValue`. If `arg` is a `JSONValue`
      * its value and type will be copied to the new `JSONValue`.
-     * Note that this is a shallow copy: if type is `JSON_TYPE.OBJECT`
-     * or `JSON_TYPE.ARRAY` then only the reference to the data will
+     * Note that this is a shallow copy: if type is `JSONType.object`
+     * or `JSONType.array` then only the reference to the data will
      * be copied.
      * Otherwise, `arg` must be implicitly convertible to one of the
      * following types: `typeof(null)`, `string`, `ulong`,
@@ -450,10 +463,10 @@ struct JSONValue
         j = JSONValue(42);
 
         j = JSONValue( [1, 2, 3] );
-        assert(j.type == JSON_TYPE.ARRAY);
+        assert(j.type == JSONType.array);
 
         j = JSONValue( ["language": "D"] );
-        assert(j.type == JSON_TYPE.OBJECT);
+        assert(j.type == JSONType.object);
     }
 
     void opAssign(T)(T arg) if (!isStaticArray!T && !is(T : JSONValue))
@@ -468,7 +481,7 @@ struct JSONValue
 
     /***
      * Array syntax for json arrays.
-     * Throws: `JSONException` if `type` is not `JSON_TYPE.ARRAY`.
+     * Throws: `JSONException` if `type` is not `JSONType.array`.
      */
     ref inout(JSONValue) opIndex(size_t i) inout pure @safe
     {
@@ -487,7 +500,7 @@ struct JSONValue
 
     /***
      * Hash syntax for json objects.
-     * Throws: `JSONException` if `type` is not `JSON_TYPE.OBJECT`.
+     * Throws: `JSONException` if `type` is not `JSONType.object`.
      */
     ref inout(JSONValue) opIndex(string k) inout pure @safe
     {
@@ -508,15 +521,15 @@ struct JSONValue
      * If JSON value is null, then operator initializes it with object and then
      * sets `value` for it.
      *
-     * Throws: `JSONException` if `type` is not `JSON_TYPE.OBJECT`
-     * or `JSON_TYPE.NULL`.
+     * Throws: `JSONException` if `type` is not `JSONType.object`
+     * or `JSONType.null_`.
      */
     void opIndexAssign(T)(auto ref T value, string key) pure
     {
-        enforce!JSONException(type == JSON_TYPE.OBJECT || type == JSON_TYPE.NULL,
+        enforce!JSONException(type == JSONType.object || type == JSONType.null_,
                                 "JSONValue must be object or null");
         JSONValue[string] aa = null;
-        if (type == JSON_TYPE.OBJECT)
+        if (type == JSONType.object)
         {
             aa = this.objectNoRef;
         }
@@ -592,8 +605,8 @@ struct JSONValue
      *      when found, the `const(JSONValue)*` that matches to the key,
      *      otherwise `null`.
      *
-     * Throws: `JSONException` if the right hand side argument `JSON_TYPE`
-     * is not `OBJECT`.
+     * Throws: `JSONException` if the right hand side argument `JSONType`
+     * is not `object`.
      */
     auto opBinaryRight(string op : "in")(string k) const @safe
     {
@@ -620,21 +633,21 @@ struct JSONValue
 
         final switch (type_tag)
         {
-        case JSON_TYPE.STRING:
+        case JSONType.string:
             return store.str == rhs.store.str;
-        case JSON_TYPE.INTEGER:
+        case JSONType.integer:
             return store.integer == rhs.store.integer;
-        case JSON_TYPE.UINTEGER:
+        case JSONType.uinteger:
             return store.uinteger == rhs.store.uinteger;
-        case JSON_TYPE.FLOAT:
+        case JSONType.float_:
             return store.floating == rhs.store.floating;
-        case JSON_TYPE.OBJECT:
+        case JSONType.object:
             return store.object == rhs.store.object;
-        case JSON_TYPE.ARRAY:
+        case JSONType.array:
             return store.array == rhs.store.array;
-        case JSON_TYPE.TRUE:
-        case JSON_TYPE.FALSE:
-        case JSON_TYPE.NULL:
+        case JSONType.true_:
+        case JSONType.false_:
+        case JSONType.null_:
             return true;
         }
     }
@@ -657,7 +670,7 @@ struct JSONValue
     /// Implements the foreach `opApply` interface for json objects.
     int opApply(scope int delegate(string key, ref JSONValue) dg) @system
     {
-        enforce!JSONException(type == JSON_TYPE.OBJECT,
+        enforce!JSONException(type == JSONType.object,
                                 "JSONValue is not an object");
         int result;
 
@@ -708,7 +721,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
     import std.ascii : isDigit, isHexDigit, toUpper, toLower;
     import std.typecons : Nullable, Yes;
     JSONValue root;
-    root.type_tag = JSON_TYPE.NULL;
+    root.type_tag = JSONType.null_;
 
     // Avoid UTF decoding when possible, as it is unnecessary when
     // processing JSON.
@@ -986,7 +999,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
             case '[':
                 if (testChar(']'))
                 {
-                    value.type_tag = JSON_TYPE.ARRAY;
+                    value.type_tag = JSONType.array;
                     break;
                 }
 
@@ -1011,11 +1024,11 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                     tryGetSpecialFloat(str, value.store.floating))
                 {
                     // found a special float, its value was placed in value.store.floating
-                    value.type_tag = JSON_TYPE.FLOAT;
+                    value.type_tag = JSONType.float_;
                     break;
                 }
 
-                value.type_tag = JSON_TYPE.STRING;
+                value.type_tag = JSONType.string;
                 value.store.str = str;
                 break;
 
@@ -1077,7 +1090,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                 string data = number.data;
                 if (isFloat)
                 {
-                    value.type_tag = JSON_TYPE.FLOAT;
+                    value.type_tag = JSONType.float_;
                     value.store.floating = parse!double(data);
                 }
                 else
@@ -1088,7 +1101,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                         value.store.uinteger = parse!ulong(data);
 
                     value.type_tag = !isNegative && value.store.uinteger & (1UL << 63) ?
-                        JSON_TYPE.UINTEGER : JSON_TYPE.INTEGER;
+                        JSONType.uinteger : JSONType.integer;
                 }
                 break;
 
@@ -1096,7 +1109,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                 if (strict) goto default;
                 goto case;
             case 't':
-                value.type_tag = JSON_TYPE.TRUE;
+                value.type_tag = JSONType.true_;
                 checkChar!false('r', strict);
                 checkChar!false('u', strict);
                 checkChar!false('e', strict);
@@ -1106,7 +1119,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                 if (strict) goto default;
                 goto case;
             case 'f':
-                value.type_tag = JSON_TYPE.FALSE;
+                value.type_tag = JSONType.false_;
                 checkChar!false('a', strict);
                 checkChar!false('l', strict);
                 checkChar!false('s', strict);
@@ -1117,7 +1130,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                 if (strict) goto default;
                 goto case;
             case 'n':
-                value.type_tag = JSON_TYPE.NULL;
+                value.type_tag = JSONType.null_;
                 checkChar!false('u', strict);
                 checkChar!false('l', strict);
                 checkChar!false('l', strict);
@@ -1142,10 +1155,10 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
 @safe unittest
 {
     enum issue15742objectOfObject = `{ "key1": { "key2": 1 }}`;
-    static assert(parseJSON(issue15742objectOfObject).type == JSON_TYPE.OBJECT);
+    static assert(parseJSON(issue15742objectOfObject).type == JSONType.object);
 
     enum issue15742arrayOfArray = `[[1]]`;
-    static assert(parseJSON(issue15742arrayOfArray).type == JSON_TYPE.ARRAY);
+    static assert(parseJSON(issue15742arrayOfArray).type == JSONType.array);
 }
 
 @safe unittest
@@ -1293,7 +1306,7 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
 
         final switch (value.type)
         {
-            case JSON_TYPE.OBJECT:
+            case JSONType.object:
                 auto obj = value.objectNoRef;
                 if (!obj.length)
                 {
@@ -1340,7 +1353,7 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                 }
                 break;
 
-            case JSON_TYPE.ARRAY:
+            case JSONType.array:
                 auto arr = value.arrayNoRef;
                 if (arr.empty)
                 {
@@ -1362,19 +1375,19 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                 }
                 break;
 
-            case JSON_TYPE.STRING:
+            case JSONType.string:
                 toString(value.str);
                 break;
 
-            case JSON_TYPE.INTEGER:
+            case JSONType.integer:
                 json.put(to!string(value.store.integer));
                 break;
 
-            case JSON_TYPE.UINTEGER:
+            case JSONType.uinteger:
                 json.put(to!string(value.store.uinteger));
                 break;
 
-            case JSON_TYPE.FLOAT:
+            case JSONType.float_:
                 import std.math : isNaN, isInfinity;
 
                 auto val = value.store.floating;
@@ -1414,15 +1427,15 @@ string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions o
                 }
                 break;
 
-            case JSON_TYPE.TRUE:
+            case JSONType.true_:
                 json.put("true");
                 break;
 
-            case JSON_TYPE.FALSE:
+            case JSONType.false_:
                 json.put("false");
                 break;
 
-            case JSON_TYPE.NULL:
+            case JSONType.null_:
                 json.put("null");
                 break;
         }
@@ -1470,7 +1483,7 @@ class JSONException : Exception
 {
     import std.exception;
     JSONValue jv = "123";
-    assert(jv.type == JSON_TYPE.STRING);
+    assert(jv.type == JSONType.string);
     assertNotThrown(jv.str);
     assertThrown!JSONException(jv.integer);
     assertThrown!JSONException(jv.uinteger);
@@ -1481,19 +1494,19 @@ class JSONException : Exception
     assertThrown!JSONException(jv[2]);
 
     jv = -3;
-    assert(jv.type == JSON_TYPE.INTEGER);
+    assert(jv.type == JSONType.integer);
     assertNotThrown(jv.integer);
 
     jv = cast(uint) 3;
-    assert(jv.type == JSON_TYPE.UINTEGER);
+    assert(jv.type == JSONType.uinteger);
     assertNotThrown(jv.uinteger);
 
     jv = 3.0;
-    assert(jv.type == JSON_TYPE.FLOAT);
+    assert(jv.type == JSONType.float_);
     assertNotThrown(jv.floating);
 
     jv = ["key" : "value"];
-    assert(jv.type == JSON_TYPE.OBJECT);
+    assert(jv.type == JSONType.object);
     assertNotThrown(jv.object);
     assertNotThrown(jv["key"]);
     assert("key" in jv);
@@ -1507,39 +1520,39 @@ class JSONException : Exception
     {
         static assert(is(typeof(value) == JSONValue));
         assert(key == "key");
-        assert(value.type == JSON_TYPE.STRING);
+        assert(value.type == JSONType.string);
         assertNotThrown(value.str);
         assert(value.str == "value");
     }
 
     jv = [3, 4, 5];
-    assert(jv.type == JSON_TYPE.ARRAY);
+    assert(jv.type == JSONType.array);
     assertNotThrown(jv.array);
     assertNotThrown(jv[2]);
     foreach (size_t index, value; jv)
     {
         static assert(is(typeof(value) == JSONValue));
-        assert(value.type == JSON_TYPE.INTEGER);
+        assert(value.type == JSONType.integer);
         assertNotThrown(value.integer);
         assert(index == (value.integer-3));
     }
 
     jv = null;
-    assert(jv.type == JSON_TYPE.NULL);
+    assert(jv.type == JSONType.null_);
     assert(jv.isNull);
     jv = "foo";
     assert(!jv.isNull);
 
     jv = JSONValue("value");
-    assert(jv.type == JSON_TYPE.STRING);
+    assert(jv.type == JSONType.string);
     assert(jv.str == "value");
 
     JSONValue jv2 = JSONValue("value");
-    assert(jv2.type == JSON_TYPE.STRING);
+    assert(jv2.type == JSONType.string);
     assert(jv2.str == "value");
 
     JSONValue jv3 = JSONValue("\u001c");
-    assert(jv3.type == JSON_TYPE.STRING);
+    assert(jv3.type == JSONType.string);
     assert(jv3.str == "\u001C");
 }
 
@@ -1548,41 +1561,41 @@ class JSONException : Exception
     // Bugzilla 11504
 
     JSONValue jv = 1;
-    assert(jv.type == JSON_TYPE.INTEGER);
+    assert(jv.type == JSONType.integer);
 
     jv.str = "123";
-    assert(jv.type == JSON_TYPE.STRING);
+    assert(jv.type == JSONType.string);
     assert(jv.str == "123");
 
     jv.integer = 1;
-    assert(jv.type == JSON_TYPE.INTEGER);
+    assert(jv.type == JSONType.integer);
     assert(jv.integer == 1);
 
     jv.uinteger = 2u;
-    assert(jv.type == JSON_TYPE.UINTEGER);
+    assert(jv.type == JSONType.uinteger);
     assert(jv.uinteger == 2u);
 
     jv.floating = 1.5;
-    assert(jv.type == JSON_TYPE.FLOAT);
+    assert(jv.type == JSONType.float_);
     assert(jv.floating == 1.5);
 
     jv.object = ["key" : JSONValue("value")];
-    assert(jv.type == JSON_TYPE.OBJECT);
+    assert(jv.type == JSONType.object);
     assert(jv.object == ["key" : JSONValue("value")]);
 
     jv.array = [JSONValue(1), JSONValue(2), JSONValue(3)];
-    assert(jv.type == JSON_TYPE.ARRAY);
+    assert(jv.type == JSONType.array);
     assert(jv.array == [JSONValue(1), JSONValue(2), JSONValue(3)]);
 
     jv = true;
-    assert(jv.type == JSON_TYPE.TRUE);
+    assert(jv.type == JSONType.true_);
 
     jv = false;
-    assert(jv.type == JSON_TYPE.FALSE);
+    assert(jv.type == JSONType.false_);
 
     enum E{True = true}
     jv = E.True;
-    assert(jv.type == JSON_TYPE.TRUE);
+    assert(jv.type == JSONType.true_);
 }
 
 @system pure unittest
@@ -1723,27 +1736,27 @@ class JSONException : Exception
     JSONValue jv;
     jv["int"] = 123;
 
-    assert(jv.type == JSON_TYPE.OBJECT);
+    assert(jv.type == JSONType.object);
     assert("int" in jv);
     assert(jv["int"].integer == 123);
 
     jv["array"] = [1, 2, 3, 4, 5];
 
-    assert(jv["array"].type == JSON_TYPE.ARRAY);
+    assert(jv["array"].type == JSONType.array);
     assert(jv["array"][2].integer == 3);
 
     jv["str"] = "D language";
-    assert(jv["str"].type == JSON_TYPE.STRING);
+    assert(jv["str"].type == JSONType.string);
     assert(jv["str"].str == "D language");
 
     jv["bool"] = false;
-    assert(jv["bool"].type == JSON_TYPE.FALSE);
+    assert(jv["bool"].type == JSONType.false_);
 
     assert(jv.object.length == 4);
 
     jv = [5, 4, 3, 2, 1];
-    assert( jv.type == JSON_TYPE.ARRAY );
-    assert( jv[3].integer == 2 );
+    assert(jv.type == JSONType.array);
+    assert(jv[3].integer == 2);
 }
 
 @safe unittest
@@ -1824,9 +1837,9 @@ pure nothrow @safe unittest // issue 15884
     void Test(C)() {
         C[] a = ['x'];
         JSONValue testVal = a;
-        assert(testVal.type == JSON_TYPE.STRING);
+        assert(testVal.type == JSONType.string);
         testVal = a.idup;
-        assert(testVal.type == JSON_TYPE.STRING);
+        assert(testVal.type == JSONType.string);
     }
     Test!char();
     Test!wchar();
@@ -1920,7 +1933,7 @@ pure nothrow @safe unittest // issue 15884
     import std.exception : assertThrown;
 
     // Unescaped ASCII NULs
-    assert(parseJSON("[\0]").type == JSON_TYPE.ARRAY);
+    assert(parseJSON("[\0]").type == JSONType.array);
     assertThrown!JSONException(parseJSON("[\0]", JSONOptions.strictParsing));
     assert(parseJSON("\"\0\"").str == "\0");
     assertThrown!JSONException(parseJSON("\"\0\"", JSONOptions.strictParsing));
@@ -1930,35 +1943,35 @@ pure nothrow @safe unittest // issue 15884
     assert(parseJSON("\"\x7f\"", JSONOptions.strictParsing).str == "\x7f");
 
     // "true", "false", "null" case sensitivity
-    assert(parseJSON("true").type == JSON_TYPE.TRUE);
-    assert(parseJSON("true", JSONOptions.strictParsing).type == JSON_TYPE.TRUE);
-    assert(parseJSON("True").type == JSON_TYPE.TRUE);
+    assert(parseJSON("true").type == JSONType.true_);
+    assert(parseJSON("true", JSONOptions.strictParsing).type == JSONType.true_);
+    assert(parseJSON("True").type == JSONType.true_);
     assertThrown!JSONException(parseJSON("True", JSONOptions.strictParsing));
-    assert(parseJSON("tRUE").type == JSON_TYPE.TRUE);
+    assert(parseJSON("tRUE").type == JSONType.true_);
     assertThrown!JSONException(parseJSON("tRUE", JSONOptions.strictParsing));
 
-    assert(parseJSON("false").type == JSON_TYPE.FALSE);
-    assert(parseJSON("false", JSONOptions.strictParsing).type == JSON_TYPE.FALSE);
-    assert(parseJSON("False").type == JSON_TYPE.FALSE);
+    assert(parseJSON("false").type == JSONType.false_);
+    assert(parseJSON("false", JSONOptions.strictParsing).type == JSONType.false_);
+    assert(parseJSON("False").type == JSONType.false_);
     assertThrown!JSONException(parseJSON("False", JSONOptions.strictParsing));
-    assert(parseJSON("fALSE").type == JSON_TYPE.FALSE);
+    assert(parseJSON("fALSE").type == JSONType.false_);
     assertThrown!JSONException(parseJSON("fALSE", JSONOptions.strictParsing));
 
-    assert(parseJSON("null").type == JSON_TYPE.NULL);
-    assert(parseJSON("null", JSONOptions.strictParsing).type == JSON_TYPE.NULL);
-    assert(parseJSON("Null").type == JSON_TYPE.NULL);
+    assert(parseJSON("null").type == JSONType.null_);
+    assert(parseJSON("null", JSONOptions.strictParsing).type == JSONType.null_);
+    assert(parseJSON("Null").type == JSONType.null_);
     assertThrown!JSONException(parseJSON("Null", JSONOptions.strictParsing));
-    assert(parseJSON("nULL").type == JSON_TYPE.NULL);
+    assert(parseJSON("nULL").type == JSONType.null_);
     assertThrown!JSONException(parseJSON("nULL", JSONOptions.strictParsing));
 
     // Whitespace characters
-    assert(parseJSON("[\f\v]").type == JSON_TYPE.ARRAY);
+    assert(parseJSON("[\f\v]").type == JSONType.array);
     assertThrown!JSONException(parseJSON("[\f\v]", JSONOptions.strictParsing));
-    assert(parseJSON("[ \t\r\n]").type == JSON_TYPE.ARRAY);
-    assert(parseJSON("[ \t\r\n]", JSONOptions.strictParsing).type == JSON_TYPE.ARRAY);
+    assert(parseJSON("[ \t\r\n]").type == JSONType.array);
+    assert(parseJSON("[ \t\r\n]", JSONOptions.strictParsing).type == JSONType.array);
 
     // Empty input
-    assert(parseJSON("").type == JSON_TYPE.NULL);
+    assert(parseJSON("").type == JSONType.null_);
     assertThrown!JSONException(parseJSON("", JSONOptions.strictParsing));
 
     // Numbers with leading '0's
@@ -1978,7 +1991,7 @@ pure nothrow @safe unittest // issue 15884
     assertThrown!JSONException(parseJSON("987\0", JSONOptions.strictParsing));
     assert(parseJSON("987\0\0").integer == 987);
     assertThrown!JSONException(parseJSON("987\0\0", JSONOptions.strictParsing));
-    assert(parseJSON("[]]").type == JSON_TYPE.ARRAY);
+    assert(parseJSON("[]]").type == JSONType.array);
     assertThrown!JSONException(parseJSON("[]]", JSONOptions.strictParsing));
     assert(parseJSON("123 \t\r\n").integer == 123); // Trailing whitespace is OK
     assert(parseJSON("123 \t\r\n", JSONOptions.strictParsing).integer == 123);


### PR DESCRIPTION
JSON_TYPE is an egregious violation of the [D Style Guide](https://dlang.org/dstyle.html).
Rewrite std.json.JSON_TYPE to be CamelCase with lowercase members, with underscore attached to avoid keyword collision.
Deprecate the old type via alias.