### PR TITLE
Fix Issue 19138 - std.uuid.randomUUID should not depend on std.random.Random being Mt19937

### DIFF
--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1210,7 +1210,25 @@ public struct UUID
 @safe UUID randomUUID()
 {
     import std.random : rndGen;
-    return randomUUID(rndGen);
+    // A PRNG with fewer than `n` bytes of state cannot produce
+    // every distinct `n` byte sequence.
+    static if (typeof(rndGen).sizeof >= UUID.sizeof)
+    {
+        return randomUUID(rndGen);
+    }
+    else
+    {
+        import std.random : unpredictableSeed, Xorshift192;
+        static assert(Xorshift192.sizeof >= UUID.sizeof);
+        static Xorshift192 rng;
+        static bool initialized;
+        if (!initialized)
+        {
+            rng.seed(unpredictableSeed);
+            initialized = true;
+        }
+        return randomUUID(rng);
+    }
 }
 
 /// ditto
@@ -1258,18 +1276,6 @@ if (isInputRange!RNG && isIntegral!(ElementType!RNG))
 
     gen.seed(unpredictableSeed);
     auto uuid3 = randomUUID(gen);
-}
-
-/*
- * Original boost.uuid used Mt19937, we don't want
- * to use anything worse than that. If Random is changed
- * to something else, this assert and the randomUUID function
- * have to be updated.
- */
-@safe unittest
-{
-    import std.random : rndGen, Mt19937;
-    static assert(is(typeof(rndGen) == Mt19937));
 }
 
 @safe unittest


### PR DESCRIPTION
Right now `std.uuid` has a static assert that `std.random.Random` is `Mt19937`. This is contrary to the public documentation of `std.random.Random`:

```d
/**
The "default", "favorite", "suggested" random number generator type on
the current platform. It is an alias for one of the previously-defined
generators. You may want to use it if (1) you need to generate some
nice random numbers, and (2) you don't care for the minutiae of the
method being used.
 */
```

Depending on implementation details of another module is brittle and risks leading others to believe they can rely on `Random` being `Mt19937` in their code too.