### PR TITLE
[stable] Remove superfluous core.stdc.* dependencies in std.{conv,random}

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2737,7 +2737,6 @@ Target parse(Target, Source)(ref Source source)
 if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
     isFloatingPoint!Target && !is(Target == enum))
 {
-    import core.stdc.math : HUGE_VAL;
     import std.ascii : isDigit, isAlpha, toLower, toUpper, isHexDigit;
     import std.exception : enforce;
 
@@ -3240,7 +3239,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         }
     }
   L6: // if overflow occurred
-    enforce(ldval != HUGE_VAL, new ConvException("Range error"));
+    enforce(ldval != real.infinity, new ConvException("Range error"));
 
   L1:
     static if (isNarrowString!Source)

--- a/std/random.d
+++ b/std/random.d
@@ -2182,8 +2182,7 @@ do
         immutable T u = (rng.front - rng.min) * factor;
         rng.popFront();
 
-        import core.stdc.limits : CHAR_BIT;  // CHAR_BIT is always 8
-        static if (isIntegral!R && T.mant_dig >= (CHAR_BIT * R.sizeof))
+        static if (isIntegral!R && T.mant_dig >= (8 * R.sizeof))
         {
             /* If RNG variates are integral and T has enough precision to hold
              * R without loss, we're guaranteed by the definition of factor


### PR DESCRIPTION
For WebAssembly etc.