### PR TITLE
Fix Issue 19164 - malloc may be considered pure when failure results in program exit (no need to reset errno)

### DIFF
--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -235,8 +235,7 @@ private To[] trustedRealloc(To)(scope To[] buf, size_t strLength, bool bufIsOnSt
 {
     pragma(inline, false);  // because it's rarely called
 
-    import core.exception : onOutOfMemoryError;
-    import core.memory : pureMalloc, pureRealloc;
+    import std.internal.memory : enforceMalloc, enforceRealloc;
 
     size_t newlen = buf.length * 3 / 2;
 
@@ -244,19 +243,25 @@ private To[] trustedRealloc(To)(scope To[] buf, size_t strLength, bool bufIsOnSt
     {
         if (newlen <= strLength)
             newlen = strLength + 1; // +1 for terminating 0
-        auto ptr = cast(To*) pureMalloc(newlen * To.sizeof);
-        if (!ptr)
-            onOutOfMemoryError();
+        auto ptr = cast(To*) enforceMalloc(newlen * To.sizeof);
         ptr[0 .. buf.length] = buf[];
         return ptr[0 .. newlen];
     }
     else
     {
         if (buf.length >= size_t.max / (2 * To.sizeof))
-            onOutOfMemoryError();
-        auto ptr = cast(To*) pureRealloc(buf.ptr, newlen * To.sizeof);
-        if (!ptr)
-            onOutOfMemoryError();
+        {
+            version (D_Exceptions)
+            {
+                import core.exception : onOutOfMemoryError;
+                onOutOfMemoryError();
+            }
+            else
+            {
+                assert(0, "Memory allocation failed");
+            }
+        }
+        auto ptr = cast(To*) enforceRealloc(buf.ptr, newlen * To.sizeof);
         return ptr[0 .. newlen];
     }
 }

--- a/std/internal/memory.d
+++ b/std/internal/memory.d
@@ -1,0 +1,58 @@
+module std.internal.memory;
+
+package(std):
+
+version (D_Exceptions)
+{
+    import core.exception : onOutOfMemoryError;
+    private enum allocationFailed = `onOutOfMemoryError();`;
+}
+else
+{
+    private enum allocationFailed = `assert(0, "Memory allocation failed");`;
+}
+
+// (below comments are non-DDOC, but are written in similar style)
+
+/+
+Pure variants of C's memory allocation functions `malloc`, `calloc`, and
+`realloc` that achieve purity by aborting the program on failure so
+they never visibly change errno.
+
+The functions may terminate the program using `onOutOfMemoryError` or
+`assert(0)`. These functions' purity guarantees no longer hold if
+the program continues execution after catching AssertError or
+OutOfMemoryError.
+
+See_Also: $(REF pureMalloc, core,memory)
++/
+void* enforceMalloc()(size_t size) @nogc nothrow pure @safe
+{
+    auto result = fakePureMalloc(size);
+    if (!result) mixin(allocationFailed);
+    return result;
+}
+
+// ditto
+void* enforceCalloc()(size_t nmemb, size_t size) @nogc nothrow pure @safe
+{
+    auto result = fakePureCalloc(nmemb, size);
+    if (!result) mixin(allocationFailed);
+    return result;
+}
+
+// ditto
+void* enforceRealloc()(void* ptr, size_t size) @nogc nothrow pure @system
+{
+    auto result = fakePureRealloc(ptr, size);
+    if (!result) mixin(allocationFailed);
+    return result;
+}
+
+// Purified for local use only.
+extern (C) @nogc nothrow pure private
+{
+    pragma(mangle, "malloc") void* fakePureMalloc(size_t) @safe;
+    pragma(mangle, "calloc") void* fakePureCalloc(size_t nmemb, size_t size) @safe;
+    pragma(mangle, "realloc") void* fakePureRealloc(void* ptr, size_t size) @system;
+}

--- a/std/random.d
+++ b/std/random.d
@@ -2914,31 +2914,25 @@ private struct RandomCoverChoices
 
     this(this) pure nothrow @nogc @trusted
     {
-        import core.memory : pureMalloc;
         import core.stdc.string : memcpy;
-        import core.exception : onOutOfMemoryError;
+        import std.internal.memory : enforceMalloc;
 
         if (!hasPackedBits && buffer !is null)
         {
-            void* nbuffer = pureMalloc(_length);
-            if (nbuffer is null)
-                onOutOfMemoryError();
+            void* nbuffer = enforceMalloc(_length);
             buffer = memcpy(nbuffer, buffer, _length);
         }
     }
 
     this(size_t numChoices) pure nothrow @nogc @trusted
     {
-        import core.memory : pureCalloc;
-        import core.exception : onOutOfMemoryError;
+        import std.internal.memory : enforceCalloc;
 
         _length = numChoices;
         hasPackedBits = _length <= size_t.sizeof * 8;
         if (!hasPackedBits)
         {
-            buffer = pureCalloc(numChoices, 1);
-            if (buffer is null)
-                onOutOfMemoryError();
+            buffer = enforceCalloc(numChoices, 1);
         }
     }
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6098,7 +6098,6 @@ if (!is(T == class) && !(is(T == interface)))
     /// `RefCounted` storage implementation.
     struct RefCountedStore
     {
-        import core.memory : pureMalloc;
         private struct Impl
         {
             T _payload;
@@ -6109,12 +6108,10 @@ if (!is(T == class) && !(is(T == interface)))
 
         private void initialize(A...)(auto ref A args)
         {
-            import core.exception : onOutOfMemoryError;
+            import std.internal.memory : enforceMalloc;
             import std.conv : emplace;
 
-            _store = cast(Impl*) pureMalloc(Impl.sizeof);
-            if (_store is null)
-                onOutOfMemoryError();
+            _store = cast(Impl*) enforceMalloc(Impl.sizeof);
             static if (hasIndirections!T)
                 pureGcAddRange(&_store._payload, T.sizeof);
             emplace(&_store._payload, args);
@@ -6123,12 +6120,10 @@ if (!is(T == class) && !(is(T == interface)))
 
         private void move(ref T source)
         {
-            import core.exception : onOutOfMemoryError;
+            import std.internal.memory : enforceMalloc;
             import core.stdc.string : memcpy, memset;
 
-            _store = cast(Impl*) pureMalloc(Impl.sizeof);
-            if (_store is null)
-                onOutOfMemoryError();
+            _store = cast(Impl*) enforceMalloc(Impl.sizeof);
             static if (hasIndirections!T)
                 pureGcAddRange(&_store._payload, T.sizeof);
 


### PR DESCRIPTION
The `core.memory.pureMalloc` wrapper reads errno, calls malloc, then resets errno. This is unnecessary if when the allocation fails the program terminates with `assert(false)` or `onOutOfMemoryError()`.