### PR TITLE
Don't run DScanner in GDB anymore

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -566,7 +566,7 @@ dscanner:
 	@# However, we still need to ensure that the DScanner binary is built once
 	@[ -f $(DSCANNER_DIR)/dsc ] || ${MAKE} -f posix.mak $(DSCANNER_DIR)/dsc
 	@echo "Running DScanner"
-	$(DEBUGGER) -return-child-result -q -ex run -ex bt -batch --args $(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
+	$(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck etc std -I.
 
 style_lint: dscanner $(LIB)
 	@echo "Check for trailing whitespace"


### PR DESCRIPTION
The memory segmentations issues have been solved and actually as we try to retire CircleCi and move the workload to Buildkite this is becoming a problem as `gdb` on older Debian machines doesn't support the full argument syntax.

Moreover, running things in `gdb` is slow, so this will speed-up the CircleCi time (and local `style` builds.)