### PR TITLE
Fix issue 19162 - [REG: 2.079.0] Public Import Overlapping Names Conflict Resolution

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -711,6 +711,22 @@ static foreach (Num; AliasSeq!(cfloat, cdouble, creal, ifloat, idouble, ireal))
     }
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=19162
+@safe unittest
+{
+    struct Vector(T, int size)
+    {
+        T x, y, z;
+    }
+
+    static auto abs(T, int size)(auto ref const Vector!(T, size) v)
+    {
+        return v;
+    }
+    Vector!(float, 3) v;
+    assert(abs(v) == v);
+}
+
 /*
  * Complex conjugate
  *

--- a/std/math.d
+++ b/std/math.d
@@ -628,8 +628,8 @@ template isDeprecatedComplex(T)
  */
 auto abs(Num)(Num x)
 if (!isDeprecatedComplex!Num &&
-    (is(typeof(Num.init >= 0)) && is(typeof(-Num.init)) ||
-    (is(Unqual!Num == short) || is(Unqual!Num == byte))))
+    (is(Unqual!Num == short) || is(Unqual!Num == byte)) ||
+    (is(typeof(Num.init >= 0)) && is(typeof(-Num.init))))
 {
     static if (isFloatingPoint!(Num))
         return fabs(x);
@@ -723,7 +723,7 @@ static foreach (Num; AliasSeq!(cfloat, cdouble, creal, ifloat, idouble, ireal))
     {
         return v;
     }
-    Vector!(float, 3) v;
+    Vector!(int, 3) v;
     assert(abs(v) == v);
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -627,10 +627,9 @@ template isDeprecatedComplex(T)
  *     the return type will be the same as the input;
  */
 auto abs(Num)(Num x)
-// workaround for https://issues.dlang.org/show_bug.cgi?id=18251
-//if (!isDeprecatedComplex!Num &&
-    //(is(typeof(Num.init >= 0)) && is(typeof(-Num.init)) ||
-    //(is(Unqual!Num == short) || is(Unqual!Num == byte))))
+if (!isDeprecatedComplex!Num &&
+    (is(typeof(Num.init >= 0)) && is(typeof(-Num.init)) ||
+    (is(Unqual!Num == short) || is(Unqual!Num == byte))))
 {
     static if (isFloatingPoint!(Num))
         return fabs(x);

--- a/std/math.d
+++ b/std/math.d
@@ -627,8 +627,7 @@ template isDeprecatedComplex(T)
  *     the return type will be the same as the input;
  */
 auto abs(Num)(Num x)
-if (!isDeprecatedComplex!Num &&
-    (is(Unqual!Num == short) || is(Unqual!Num == byte)) ||
+if ((is(Unqual!Num == short) || is(Unqual!Num == byte)) ||
     (is(typeof(Num.init >= 0)) && is(typeof(-Num.init))))
 {
     static if (isFloatingPoint!(Num))
@@ -652,6 +651,7 @@ if (!isDeprecatedComplex!Num &&
     assert(abs(2321312L)  == 2321312L);
 }
 
+version(TestComplex)
 deprecated
 @safe pure nothrow @nogc unittest
 {
@@ -681,6 +681,7 @@ deprecated
     }}
 }
 
+version(TestComplex)
 deprecated
 @safe pure nothrow @nogc unittest
 {


### PR DESCRIPTION
This shouldn't have been committed to begin with until after the actual issue had been fixed. A breaking change which allows abs() to be instigated for all types irregardless if they have comparison and negative operators.

@wilzbach Per your commit.