### PR TITLE
Add a special buildkite Makefile target that can be used to run Phobos testsuite on Buildkite

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -636,4 +636,7 @@ auto-tester-build: all checkwhitespace
 .PHONY : auto-tester-test
 auto-tester-test: unittest betterC
 
+.PHONY: buildkite-test
+buildkite-test: unittest betterC
+
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
It's equivalent to the `auto-tester-test` target for now, but it will change in the future.

See also: https://github.com/dlang/phobos/pull/6645#issuecomment-413491253 for a motivation.