### PR TITLE
Fix Issue 19085 - std.experimental.allocator.makeArray should work with void

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1629,6 +1629,16 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
     assert(c.equal([0, 0, 0, 0, 0]));
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=19085 - makeArray with void
+@system unittest
+{
+    auto b = theAllocator.makeArray!void(5);
+    scope(exit) theAllocator.dispose(b);
+    auto c = cast(ubyte[]) b;
+    assert(c.length == 5);
+    assert(c == [0, 0, 0, 0, 0]); // default initialization
+}
+
 private enum hasPurePostblit(T) = !hasElaborateCopyConstructor!T ||
     is(typeof(() pure { T.init.__xpostblit(); }));
 


### PR DESCRIPTION
Not really convinced that we should encourage people to use `void`, but it's not too hard to support `void` here as this implies uninitialized memory.