### PR TITLE
[stable] std.exception: Make unittest less brittle

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -629,7 +629,7 @@ alias errnoEnforce = enforce!ErrnoException;
 @system unittest
 {
     import core.stdc.stdio : fclose, fgets, fopen;
-    auto f = fopen(__FILE__, "r").errnoEnforce;
+    auto f = fopen(__FILE_FULL_PATH__, "r").errnoEnforce;
     scope(exit) fclose(f);
     char[100] buf;
     auto line = fgets(buf.ptr, buf.length, f);


### PR DESCRIPTION
It makes sure the source file can be read from when running the tests.

If the path to `std/exception.d` in the compile-Phobos command line was relative, this required the testrunner to be run in the same working directory as when compiling Phobos.