### PR TITLE
Fix issue 11959 - Set private symbols declared in version(unittest) blocks

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5125,7 +5125,7 @@ version(unittest) private class __conv_EmplaceTestClass
 version(unittest)
 {
     //Ambiguity
-    struct __std_conv_S
+    private struct __std_conv_S
     {
         int i;
         this(__std_conv_SS ss)         {assert(0);}
@@ -5135,7 +5135,7 @@ version(unittest)
             return s;
         }
     }
-    struct __std_conv_SS
+    private struct __std_conv_SS
     {
         int j;
         __std_conv_S s;

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -10418,6 +10418,7 @@ if (isSomeString!T)
 
 version(unittest)
 {
+private:
     // All of these helper arrays are sorted in ascending order.
     auto testYearsBC = [-1999, -1200, -600, -4, -1, 0];
     auto testYearsAD = [1, 4, 1000, 1999, 2000, 2012];

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10417,7 +10417,7 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
     assertThrown!DateTimeException(parseRFC822DateTime(badStr));
 }
 
-version(unittest) void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
+version(unittest) private void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
 {
     import std.format : format;
     auto value = cr(str);
@@ -10426,7 +10426,7 @@ version(unittest) void testParse822(alias cr)(string str, SysTime expected, size
         throw new AssertError(format("wrong result. expected [%s], actual[%s]", expected, result), __FILE__, line);
 }
 
-version(unittest) void testBadParse822(alias cr)(string str, size_t line = __LINE__)
+version(unittest) private void testBadParse822(alias cr)(string str, size_t line = __LINE__)
 {
     try
         parseRFC822DateTime(cr(str));
@@ -11365,6 +11365,7 @@ if (isIntegral!T && isSigned!T) // The constraints on R were already covered by 
 
 version(unittest)
 {
+private:
     // Variables to help in testing.
     Duration currLocalDiffFromUTC;
     immutable (TimeZone)[] testTZs;

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -662,7 +662,7 @@ public:
 
 version(unittest)
 {
-    static void testrw(void[] b) @nogc nothrow
+    private static void testrw(void[] b) @nogc nothrow
     {
         ubyte* buf = cast(ubyte*) b.ptr;
         buf[0] = 100;
@@ -671,7 +671,7 @@ version(unittest)
         assert(buf[b.length - 1] == 101);
     }
 
-    static size_t getPageSize() @nogc nothrow
+    private static size_t getPageSize() @nogc nothrow
     {
         size_t pageSize;
         version(Posix)

--- a/std/format.d
+++ b/std/format.d
@@ -4582,7 +4582,7 @@ private T getNth(string kind, alias Condition, T, A...)(uint index, A args)
 /* ======================== Unit Tests ====================================== */
 
 version(unittest)
-void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __FILE__)
+private void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
     import std.array : appender;
@@ -4596,7 +4596,7 @@ void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __F
 }
 
 version(unittest)
-void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, string fn = __FILE__) @safe
+private void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
     import std.array : appender;
@@ -4609,7 +4609,7 @@ void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, str
 }
 
 version(unittest)
-void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__)
+private void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
     import std.array : appender;
@@ -4627,7 +4627,7 @@ void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = _
 }
 
 version(unittest)
-void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__) @safe
+private void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
     import std.array : appender;
@@ -5109,7 +5109,7 @@ here:
 }
 
 version(unittest)
-void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = __FILE__, size_t ln = __LINE__)
+private void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;
     import std.array : appender;
@@ -5151,7 +5151,7 @@ void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = _
 }
 
 version(unittest)
-void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn = __FILE__, size_t ln = __LINE__)
+private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;
     import std.array : appender;

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1340,7 +1340,7 @@ int highestPowerBelowUlongMax(uint x) pure nothrow @safe
 version(unittest)
 {
 
-int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
+private int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
 {
      int pwr = 1;
      for (ulong q = x;x*q < cast(ulong) uint.max; )

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4123,7 +4123,7 @@ private struct RoundRobinBuffer(C1, C2)
 version(unittest)
 {
     // This was the only way I could get nested maps to work.
-    __gshared TaskPool poolInstance;
+    private __gshared TaskPool poolInstance;
 }
 
 // These test basic functionality but don't stress test for threading bugs.

--- a/std/path.d
+++ b/std/path.d
@@ -4154,6 +4154,7 @@ string expandTilde(string inputPath) @safe nothrow
 
 version(unittest)
 {
+private:
     /* Define a mock RandomAccessRange to use for unittesting.
      */
 

--- a/std/process.d
+++ b/std/process.d
@@ -3078,6 +3078,7 @@ if (is(typeof(allocator(size_t.init)[0] = char.init)))
 
 version(Windows) version(unittest)
 {
+private:
     import core.stdc.stddef;
     import core.stdc.wchar_ : wcslen;
     import core.sys.windows.shellapi : CommandLineToArgvW;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5451,7 +5451,7 @@ version(linux)
     }
 }
 
-version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
+version(unittest) private string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
 {
     import std.conv : text;
     import std.file : deleteme;

--- a/std/traits.d
+++ b/std/traits.d
@@ -2438,6 +2438,7 @@ if (is(T == function))
 
 version(unittest)
 {
+private:
     // Some function types to test.
     int sc(scope int, ref int, out int, lazy int, int);
     extern(System) int novar();
@@ -7873,7 +7874,7 @@ if (sth.length == 1)
     static assert(TL == AliasSeq!("i", "xi", "yi"));
 }
 
-version(unittest) void freeFunc(string);
+version(unittest) private void freeFunc(string);
 
 @safe unittest
 {

--- a/std/utf.d
+++ b/std/utf.d
@@ -3368,6 +3368,7 @@ if (isSomeChar!C)
 // Ranges of code units for testing.
 version(unittest)
 {
+private:
     struct InputCU(C)
     {
         import std.conv : to;
@@ -4122,7 +4123,7 @@ pure @safe nothrow @nogc unittest
 }
 
 version(unittest)
-int impureVariable;
+private int impureVariable;
 
 @system unittest
 {


### PR DESCRIPTION
A check in D-Scanner is planned for this.