### PR TITLE
Add a getter and setter for booleans in JSON

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -231,6 +231,38 @@ struct JSONValue
     }
 
     /***
+     * Value getter/setter for boolean stored in JSON.
+     * Throws: `JSONException` for read access if `this.type` is not
+     * `JSONType.true_` or `JSONType.false_`.
+     */
+    @property bool boolean() const pure @safe
+    {
+        if (type == JSONType.true_) return true;
+        if (type == JSONType.false_) return false;
+
+        throw new JSONException("JSONValue is not a boolean type");
+    }
+    /// ditto
+    @property bool boolean(bool v) pure nothrow @safe @nogc
+    {
+        assign(v);
+        return v;
+    }
+    ///
+    @safe unittest
+    {
+        JSONValue j = true;
+        assert(j.boolean == true);
+
+        j.boolean = false;
+        assert(j.boolean == false);
+
+        j.integer = 12;
+        import std.exception : assertThrown;
+        assertThrown!JSONException(j.boolean);
+    }
+
+    /***
      * Value getter/setter for `JSONType.object`.
      * Throws: `JSONException` for read access if `type` is not
      * `JSONType.object`.


### PR DESCRIPTION
Works the same as `integer`, `floating` etc. 

Seems obvious you need this to use the module in any real-world usage.