### PR TITLE
Implement allocateZeroed for building-block allocators

### DIFF
--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -190,6 +190,33 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         return null;
     }
 
+    static if (hasMember!(Allocator, "allocateZeroed"))
+    package(std) void[] allocateZeroed()(size_t s)
+    {
+        for (auto p = &root, n = *p; n; p = &n.next, n = *p)
+        {
+            auto result = n.allocateZeroed(s);
+            if (result.length != s) continue;
+            // Bring to front if not already
+            if (root != n)
+            {
+                *p = n.next;
+                n.next = root;
+                root = n;
+            }
+            return result;
+        }
+
+        // Add a new allocator
+        if (auto a = addAllocator(s))
+        {
+            auto result = a.allocateZeroed(s);
+            assert(owns(result) == Ternary.yes || !result.ptr);
+            return result;
+        }
+        return null;
+    }
+
     /**
     Allocate a block of size `s` with alignment `a`. First tries to allocate
     from the existing list of already-created allocators. If neither can

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -74,6 +74,19 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
         return null;
     }
 
+    static if (hasMember!(Allocator, "allocateZeroed"))
+    package(std) void[] allocateZeroed()(size_t bytes)
+    {
+        if (!bytes) return null;
+        if (auto a = allocatorFor(bytes))
+        {
+            const actual = goodAllocSize(bytes);
+            auto result = a.allocateZeroed(actual);
+            return result.ptr ? result.ptr[0 .. bytes] : null;
+        }
+        return null;
+    }
+
     /**
     Allocates the requested `bytes` of memory with specified `alignment`.
     Directs the call to either one of the `buckets` allocators. Defined only

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -82,6 +82,13 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
         return result.ptr ? result.ptr[0 .. n] : null;
     }
 
+    static if (hasMember!(ParentAllocator, "allocateZeroed"))
+    package(std) void[] allocateZeroed()(size_t n)
+    {
+        auto result = parent.allocateZeroed(goodAllocSize(n));
+        return result.ptr ? result.ptr[0 .. n] : null;
+    }
+
     /**
     Defined only if `parent.alignedAllocate` exists and works similarly to
     `allocate` by forwarding to

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -111,7 +111,7 @@ struct GCAllocator
         return ((n + 4095) / 4096) * 4096;
     }
 
-    package pure nothrow @trusted void[] allocateZeroed(size_t bytes) shared const
+    package pure nothrow @trusted void[] allocateZeroed()(size_t bytes) shared const
     {
         if (!bytes) return null;
         auto p = GC.calloc(bytes);

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -65,7 +65,7 @@ struct Mallocator
     }
 
     @trusted @nogc nothrow pure
-    package void[] allocateZeroed(size_t bytes) shared
+    package void[] allocateZeroed()(size_t bytes) shared
     {
         import core.memory : pureCalloc;
         if (!bytes) return null;


### PR DESCRIPTION
Followup to https://github.com/dlang/phobos/pull/6411

>Some allocators can allocate zeroed memory more efficiently than allocate + memset.
>[...]
>This PR adds non-public `allocateZeroed` methods to `Mallocator` and `MmapAllocator` and `GCAllocator`. Various derived allocators could also implement such methods when their parent allocators support them, but that work is left to a future PR