### PR TITLE
Fix Issue 19226 - std.typecons.Nullable(T, T nullValue) doesn't fully handle non-self-equal nullValue

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3542,7 +3542,7 @@ Returns:
         }
         //Need to use 'is' if T is a float type
         //because NaN != NaN
-        else static if (isFloatingPoint!T)
+        else static if (__traits(isFloating, T) || __traits(compiles, { static assert(!(nullValue == nullValue)); }))
         {
             return _value is nullValue;
         }
@@ -3561,6 +3561,14 @@ Returns:
 
     ni = 0;
     assert(!ni.isNull);
+}
+
+@system unittest
+{
+    assert(typeof(this).init.isNull, typeof(this).stringof ~
+        ".isNull does not work correctly because " ~ T.stringof ~
+        " has an == operator that is non-reflexive and could not be" ~
+        " determined before runtime to be non-reflexive!");
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=11135
@@ -3735,6 +3743,25 @@ if (is (typeof(nullValue) == T))
     assert(a == 8);
     a.nullify();
     assert(a.isNull);
+}
+
+@nogc nothrow pure @safe unittest
+{
+    // issue 19226 - fully handle non-self-equal nullValue
+    static struct Fraction
+    {
+        int denominator;
+        bool isNaN() const
+        {
+            return denominator == 0;
+        }
+        bool opEquals(const Fraction rhs) const
+        {
+            return !isNaN && denominator == rhs.denominator;
+        }
+    }
+    alias N = Nullable!(Fraction, Fraction.init);
+    assert(N.init.isNull);
 }
 
 @safe unittest


### PR DESCRIPTION
`Nullable(T, T nullValue)` special-cases floating point numbers but this doesn't account for all types where `nullValue != nullValue`. For instance:

https://run.dlang.io/is/hiLncI

```d
struct S
{
    float f;
}

void main()
{
    import std.typecons : Nullable;

    alias N = Nullable!(S, S.init);
    assert(N(S.init).isNull); // Fails!
}
```