### PR TITLE
Fix Issue 19236 - Replace runtime `typeid(T).initializer().ptr is null` checks with compile-time `__traits(isZeroInit, T)`

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -875,9 +875,9 @@ if (isInputRange!Range && hasLvalueElements!Range && hasAssignableElements!Range
         //We avoid calling emplace here, because our goal is to initialize to
         //the static state of T.init,
         //So we want to avoid any un-necassarilly CC'ing of T.init
-        auto p = typeid(T).initializer();
-        if (p.ptr)
+        static if (!__traits(isZeroInit, T))
         {
+            auto p = typeid(T).initializer();
             for ( ; !range.empty ; range.popFront() )
             {
                 static if (__traits(isStaticArray, T))
@@ -1409,11 +1409,13 @@ void moveEmplace(T)(ref T source, ref T target) @system
             else
                 enum sz = T.sizeof;
 
-            auto init = typeid(T).initializer();
-            if (init.ptr is null) // null ptr means initialize to 0s
+            static if (__traits(isZeroInit, T))
                 memset(&source, 0, sz);
             else
+            {
+                auto init = typeid(T).initializer();
                 memcpy(&source, init.ptr, sz);
+            }
         }
     }
     else

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6162,11 +6162,13 @@ if (!is(T == class) && !(is(T == interface)))
                 else
                     enum sz = T.sizeof;
 
-                auto init = typeid(T).initializer();
-                if (init.ptr is null) // null ptr means initialize to 0s
+                static if (__traits(isZeroInit, T))
                     memset(&source, 0, sz);
                 else
+                {
+                    auto init = typeid(T).initializer();
                     memcpy(&source, init.ptr, sz);
+                }
             }
 
             _store._count = 1;


### PR DESCRIPTION
With the new `__traits(isZeroInit)` (https://github.com/dlang/dmd/pull/8583) we can check at compile-time if a type has a zero initializer. Aside from removing a branch and some dead code, removing a use of `TypeInfo` is a step towards -betterC compatibility.