### PR TITLE
Revert "In std.conv.emplaceInitializer use memset instead of memcpy when setting all 0s"

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -4360,23 +4360,15 @@ if (is(UT == Unqual!UT))
 }
 
 //emplace helper functions
-private void emplaceInitializer(T)(scope ref T chunk) @trusted pure nothrow
+private void emplaceInitializer(T)(ref T chunk) @trusted pure nothrow
 {
     static if (!hasElaborateAssign!T && isAssignable!T)
         chunk = T.init;
     else
     {
-        static if (__traits(isZeroInit, T))
-        {
-            import core.stdc.string : memset;
-            memset(&chunk, 0, T.sizeof);
-        }
-        else
-        {
-            import core.stdc.string : memcpy;
-            static immutable T init = T.init;
-            memcpy(&chunk, &init, T.sizeof);
-        }
+        import core.stdc.string : memcpy;
+        static immutable T init = T.init;
+        memcpy(&chunk, &init, T.sizeof);
     }
 }
 


### PR DESCRIPTION
Reverts dlang/phobos#6461

This was merged too eagerly, and the compiler implementation was not tested against other back-ends.