### PR TITLE
std.typecons: Unittest isn't safe

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3390,7 +3390,7 @@ auto nullable(T)(T t)
 }
 
 // check that toHash on Nullable is forwarded to the contained type
-@safe unittest
+@system unittest
 {
     struct S
     {


### PR DESCRIPTION
It takes the address of local variables.