### PR TITLE
Fix buildkite build

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -666,6 +666,6 @@ auto-tester-build: all checkwhitespace
 auto-tester-test: unittest
 
 .PHONY: buildkite-test
-buildkite-test: unittest betterC
+buildkite-test: unittest betterc
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
The 'betterC' target was renamed to 'betterc' in 1302dd54c1104aa272b52f1f83193c53ca5837be,
but stable was incorrectly merged into master in #6677.