### PR TITLE
Fix issue 19252: avoid ludicrous format length overestimate

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -6321,8 +6321,11 @@ private size_t guessLength(Char, S)(S fmtString)
 
         if (spec.width == spec.precision)
             len += spec.width;
-        else if (spec.width > 0 && (spec.precision == spec.UNSPECIFIED || spec.width > spec.precision))
+        else if (spec.width > 0 && spec.width != spec.DYNAMIC &&
+                 (spec.precision == spec.UNSPECIFIED || spec.width > spec.precision))
+        {
             len += spec.width;
+        }
         else if (spec.precision != spec.UNSPECIFIED && spec.precision > spec.width)
             len += spec.precision;
     }
@@ -6345,6 +6348,7 @@ unittest
     assert(guessLength!char("%2.4f") == 4);
     assert(guessLength!char("%02d:%02d:%02d") == 8);
     assert(guessLength!char("%0.2f") == 7);
+    assert(guessLength!char("%0*d") == 0);
 }
 
 /// ditto


### PR DESCRIPTION
Dynamic-width strings should estimate as width 0, not `int.max`.

Since dynamic format size (`spec.DYNAMIC`) is encoded as `int.max`, which `guessLength` does not understand, it takes it as int.max, leading `format!"%0*d"` to preallocate 3GB per call. Luckily, Linux can tolerate this, and it's not a common format specifier, but it's still silly.