### PR TITLE
Remove separate @betterC tests

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -635,7 +635,7 @@ publictests: $(addsuffix .publictests,$(D_MODULES))
 ################################################################################
 
 betterc-phobos-tests: $(addsuffix .betterc,$(D_MODULES))
-betterc: betterc-phobos-tests betterc-run-tests
+betterc: betterc-phobos-tests
 
 %.betterc: %.d | $(BETTERCTESTS_DIR)/.directory
 	@# Due to the FORCE rule on druntime, make will always try to rebuild Phobos (even as an order-only dependency)
@@ -644,18 +644,6 @@ betterc: betterc-phobos-tests betterc-run-tests
 	@$(TESTS_EXTRACTOR) --betterC --attributes betterC \
 		--inputdir  $< --outputdir $(BETTERCTESTS_DIR)
 	@$(DMD) $(DFLAGS) $(NODEFAULTLIB) -betterC $(UDFLAGS) -run $(BETTERCTESTS_DIR)/$(subst /,_,$<)
-
-################################################################################
-# Run separate -betterC tests
-################################################################################
-
-test/betterC/%.run: test/betterC/%.d $(DRUNTIME)
-	mkdir -p $(ROOT)/unittest/betterC
-	$(DMD) $(DFLAGS) -of$(ROOT)/unittest/betterC/$(notdir $(basename $<)) -betterC $(UDFLAGS) \
-		$(NODEFAULTLIB) $(LINKDL) $<
-	./$(ROOT)/unittest/betterC/$(notdir $(basename $<))
-
-betterc-run-tests: $(subst .d,.run,$(wildcard test/betterC/*.d))
 
 ################################################################################
 

--- a/test/betterC/algorithm.d
+++ b/test/betterC/algorithm.d
@@ -1,4 +1,0 @@
-extern(C) void main() {
-    import std.algorithm, std.range;
-    assert(100.iota.stride(2).take(10).sum == 90);
-}


### PR DESCRIPTION
Now that we have `@betterC` (see https://github.com/dlang/phobos/pull/6645) it's a lot easier to annotate existing unittests and avoid the overhead of keeping a separate test folder around.