### PR TITLE
std.stdio: Remove redundant enum declarations

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -140,7 +140,6 @@ version (DIGITAL_MARS_STDIO)
     alias FUNLOCK = __fp_unlock;
 
     alias _setmode = setmode;
-    enum _O_BINARY = 0x8000;
     int _fileno(FILE* f) { return f._file; }
     alias fileno = _fileno;
 }
@@ -175,14 +174,6 @@ else version (MICROSOFT_STDIO)
 
     alias setmode = _setmode;
     alias fileno = _fileno;
-
-    enum
-    {
-        _O_RDONLY = 0x0000,
-        _O_APPEND = 0x0004,
-        _O_TEXT   = 0x4000,
-        _O_BINARY = 0x8000,
-    }
 }
 else version (GCC_IO)
 {


### PR DESCRIPTION
These are already present in `core.stdc.stdio`, no need to declare them again.