### PR TITLE
Fix Issue 19275 - std.process: redirecting output in a non-console application fails

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -706,12 +706,13 @@ private Pid spawnProcessImpl(scope const(char)[] commandLine,
     static void prepareStream(ref File file, DWORD stdHandle, string which,
                               out int fileDescriptor, out HANDLE handle)
     {
+        enum _NO_CONSOLE_FILENO = cast(HANDLE)-2;
         fileDescriptor = getFD(file);
         handle = null;
         if (fileDescriptor >= 0)
             handle = file.windowsHandle;
         // Windows GUI applications have a fd but not a valid Windows HANDLE.
-        if (handle is null || handle == INVALID_HANDLE_VALUE)
+        if (handle is null || handle == INVALID_HANDLE_VALUE || handle == _NO_CONSOLE_FILENO)
             handle = GetStdHandle(stdHandle);
 
         DWORD dwFlags;


### PR DESCRIPTION
MS runtime up to VS2013 used pseudo handle _NO_CONSOLE_FILENO in that case, see https://github.com/shihyu/learn_c/blob/master/vc_lib_src/src/ioinit.c#L285.

No idea how to test a non-console application in phobos.