### PR TITLE
Removed an unittest of minimallyInitializedArray that can fail randomly

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -708,8 +708,12 @@ if (isDynamicArray!T && allSatisfy!(isIntegral, I))
 
     auto arr = minimallyInitializedArray!(int[])(42);
     assert(arr.length == 42);
-    // Elements aren't necessarily initialized to 0
-    assert(!arr.equal(0.repeat(42)));
+
+    // Elements aren't necessarily initialized to 0, so don't do this:
+    // assert(arr.equal(0.repeat(42)));
+    // If that is needed, initialize the array normally instead:
+    auto arr2 = new int[42];
+    assert(arr2.equal(0.repeat(42)));
 }
 
 @safe pure nothrow unittest


### PR DESCRIPTION
This test assumed that there would happen to be other bytes than zeroes in the area that was allocated. Since random pieces of memory often are just zeroes, this one probably was responsible of some of the random autotester failures.