### PR TITLE
std.math: Use SPARC_Any instead of SPARC64

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -150,6 +150,8 @@ version (MIPS32)    version = MIPS_Any;
 version (MIPS64)    version = MIPS_Any;
 version (AArch64)   version = ARM_Any;
 version (ARM)       version = ARM_Any;
+version (SPARC)     version = SPARC_Any;
+version (SPARC64)   version = SPARC_Any;
 
 version (D_InlineAsm_X86)
 {
@@ -5964,7 +5966,7 @@ nothrow @nogc:
                                  | inexactException,
         }
     }
-    else version (SPARC64)
+    else version (SPARC_Any)
     {
         enum : ExceptionMask
         {
@@ -6106,7 +6108,7 @@ private:
     {
         alias ControlState = uint;
     }
-    else version (SPARC64)
+    else version (SPARC_Any)
     {
         alias ControlState = ulong;
     }


### PR DESCRIPTION
Posted and reviewed on gcc-patches, enables building with SPARC32 targets.