### PR TITLE
Simplify isImplicitlyConvertible trait

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4972,16 +4972,7 @@ template ImplicitConversionTargets(T)
 /**
 Is `From` implicitly convertible to `To`?
  */
-template isImplicitlyConvertible(From, To)
-{
-    enum bool isImplicitlyConvertible = is(typeof({
-        void fun(ref From v)
-        {
-            void gun(To) {}
-            gun(v);
-        }
-    }));
-}
+enum bool isImplicitlyConvertible(From, To) = is(From : To);
 
 ///
 @safe unittest


### PR DESCRIPTION
`std.traits.isImplicitlyConvertible` should just use the `is` expression syntax [0].
This PR reduces and simplifies the implementation.

[0] - https://dlang.org/spec/expression.html#is_expression