### PR TITLE
Add %-( to format string grammar

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -149,6 +149,7 @@ $(I FormatStringItem):
     $(B '%%')
     $(B '%') $(I Position) $(I Flags) $(I Width) $(I Separator) $(I Precision) $(I FormatChar)
     $(B '%$(LPAREN)') $(I FormatString) $(B '%$(RPAREN)')
+    $(B '%-$(LPAREN)') $(I FormatString) $(B '%$(RPAREN)')
     $(I OtherCharacterExceptPercent)
 $(I Position):
     $(I empty)


### PR DESCRIPTION
This format specification is described later in the documentation, and works as documented, but is not included in the format string grammar.