### PR TITLE
Simplify isInnerClass trait

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2513,11 +2513,8 @@ Returns:
 template isInnerClass(T)
 if (is(T == class))
 {
-    import std.meta : staticIndexOf;
-
     static if (is(typeof(T.outer)))
-        enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T))
-                         && (staticIndexOf!(__traits(allMembers, T), "outer") == -1);
+        enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T));
     else
         enum isInnerClass = false;
 }


### PR DESCRIPTION
This PR reduces and simplifies the implementation of `std.traits.isInnerClass`. This should also improve the compilation time.