### PR TITLE
Typo in REF macro parameter list in each doc.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -860,7 +860,7 @@ parallel, std,parallelism).
 
 Normally the entire range is iterated. If partial iteration (early stopping) is
 desired, `fun` needs to return a value of type $(REF Flag,
-std.typecons)`!"each"` (`Yes.each` to continue iteration, or `No.each` to stop
+std,typecons)`!"each"` (`Yes.each` to continue iteration, or `No.each` to stop
 iteration).
 
 Params:


### PR DESCRIPTION
`$(REF Flag, std.typecons)`!"each"` should have a comma between the package names, not a dot. It was causing the text to render as `std.typecons..Flag!"each"`.