### PR TITLE
Make `rndGen` nothrow

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1602,7 +1602,7 @@ and initialized to an unpredictable value for each thread.
 Returns:
 A singleton instance of the default random number generator
  */
-@property ref Random rndGen() @safe @nogc
+@property ref Random rndGen() @safe nothrow @nogc
 {
     import std.algorithm.iteration : map;
     import std.range : repeat;


### PR DESCRIPTION
This passes all Phobos tests and would be really nice for no-exceptions situations, instead of appending `assumeWontThrow` to everything. Should be quick.