### PR TITLE
Don't shorten the width of the iteration variable

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -5422,7 +5422,7 @@ if (allSatisfy!(isInputRange, Ranges))
     // Just make sure 1-range case instantiates.  This hangs the compiler
     // when no explicit stopping policy is specified due to Bug 4652.
     auto stuff = lockstep([1,2,3,4,5], StoppingPolicy.shortest);
-    foreach (int i, a; stuff)
+    foreach (i, a; stuff)
     {
         assert(stuff[i] == a);
     }


### PR DESCRIPTION
for https://github.com/dlang/dmd/pull/8941