### PR TITLE
Remove duplicate of hasElaborateDestructor implementation

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3749,20 +3749,8 @@ template hasElaborateAssign(S)
  */
 template hasElaborateDestructor(S)
 {
-    import std.meta : anySatisfy;
-    static if (isStaticArray!S && S.length)
-    {
-        enum bool hasElaborateDestructor = hasElaborateDestructor!(typeof(S.init[0]));
-    }
-    else static if (is(S == struct))
-    {
-        enum hasElaborateDestructor = hasMember!(S, "__dtor")
-            || anySatisfy!(.hasElaborateDestructor, FieldTypeTuple!S);
-    }
-    else
-    {
-        enum bool hasElaborateDestructor = false;
-    }
+    import core.internal.traits : hasElabDest = hasElaborateDestructor;
+    alias hasElaborateDestructor = hasElabDest!(S);
 }
 
 ///


### PR DESCRIPTION
druntime's `core.internal.traits.hasElaborateDestructor` is an **almost** copy of the same code, as you can [see](https://github.com/dlang/druntime/blob/master/src/core/internal/traits.d#L167).

The druntime implementation accepts a list of `T`. I think that the Phobos alias should do the same. What do you think?

This PR removes the code duplication and the required double maintenance of `hasElaborateDestructor`.