### PR TITLE
Remove duplicate of anySatisfy implementation

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -866,18 +866,8 @@ template predicate must be instantiable with one of the given items.
  */
 template anySatisfy(alias F, T...)
 {
-    static foreach (Ti; T)
-    {
-        static if (!is(typeof(anySatisfy) == bool) && // not yet defined
-                   F!(Ti))
-        {
-            enum anySatisfy = true;
-        }
-    }
-    static if (!is(typeof(anySatisfy) == bool)) // if not yet defined
-    {
-        enum anySatisfy = false;
-    }
+    import core.internal.traits : anySat = anySatisfy;
+    alias anySatisfy = anySat!(F, T);
 }
 
 ///


### PR DESCRIPTION
druntime's `core.internal.traits.anySatisfy` is a copy of the same code. This PR removes the code duplication and the required double maintenance of `anySatisfy`.