### PR TITLE
Remove duplicate of hasElaborateCopyConstructor implementation

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3606,19 +3606,8 @@ template hasUnsharedAliasing(T...)
  */
 template hasElaborateCopyConstructor(S)
 {
-    import std.meta : anySatisfy;
-    static if (isStaticArray!S && S.length)
-    {
-        enum bool hasElaborateCopyConstructor = hasElaborateCopyConstructor!(typeof(S.init[0]));
-    }
-    else static if (is(S == struct))
-    {
-        enum hasElaborateCopyConstructor = hasMember!(S, "__xpostblit");
-    }
-    else
-    {
-        enum bool hasElaborateCopyConstructor = false;
-    }
+    import core.internal.traits : hasElabCCtor = hasElaborateCopyConstructor;
+    alias hasElaborateCopyConstructor = hasElabCCtor!(S);
 }
 
 ///


### PR DESCRIPTION
druntime's core.internal.traits.hasElaborateCopyConstructor` is a copy of the same code. This PR removes the code duplication and the required double maintenance of `hasElaborateCopyConstructor`.