### PR TITLE
Fix Issue 19453 - Remove unnecessary error checks in std.datetime.systime.currStdTime()

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -217,11 +217,12 @@ public:
                 else
                 {
                     import core.sys.posix.sys.time : gettimeofday, timeval;
-                    timeval tv;
-                    if (gettimeofday(&tv, null) != 0)
-                        throw new TimeException("Call to gettimeofday() failed");
+                    timeval tv = void;
+                    // Posix gettimeofday called with a valid timeval address
+                    // and a null second parameter doesn't fail.
+                    gettimeofday(&tv, null);
                     return convert!("seconds", "hnsecs")(tv.tv_sec) +
-                           convert!("usecs", "hnsecs")(tv.tv_usec) +
+                           tv.tv_usec * 10 +
                            hnsecsToUnixEpoch;
                 }
             }
@@ -237,9 +238,16 @@ public:
                     else static if (clockType == ClockType.normal)  alias clockArg = CLOCK_REALTIME;
                     else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME;
                     else static assert(0, "Previous static if is wrong.");
-                    timespec ts;
-                    if (clock_gettime(clockArg, &ts) != 0)
-                        throw new TimeException("Call to clock_gettime() failed");
+                    timespec ts = void;
+                    immutable error = clock_gettime(clockArg, &ts);
+                    // Posix clock_gettime called with a valid address and valid clock_id is only
+                    // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                    // is long or larger overflow won't happen before 292 billion years A.D.
+                    static if (ts.tv_sec.max < long.max)
+                    {
+                        if (error)
+                            throw new TimeException("Call to clock_gettime() failed");
+                    }
                     return convert!("seconds", "hnsecs")(ts.tv_sec) +
                            ts.tv_nsec / 100 +
                            hnsecsToUnixEpoch;
@@ -254,9 +262,16 @@ public:
                 else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME_PRECISE;
                 else static if (clockType == ClockType.second)  alias clockArg = CLOCK_SECOND;
                 else static assert(0, "Previous static if is wrong.");
-                timespec ts;
-                if (clock_gettime(clockArg, &ts) != 0)
-                    throw new TimeException("Call to clock_gettime() failed");
+                timespec ts = void;
+                immutable error = clock_gettime(clockArg, &ts);
+                // Posix clock_gettime called with a valid address and valid clock_id is only
+                // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                // is long or larger overflow won't happen before 292 billion years A.D.
+                static if (ts.tv_sec.max < long.max)
+                {
+                    if (error)
+                        throw new TimeException("Call to clock_gettime() failed");
+                }
                 return convert!("seconds", "hnsecs")(ts.tv_sec) +
                        ts.tv_nsec / 100 +
                        hnsecsToUnixEpoch;
@@ -267,12 +282,18 @@ public:
                     return unixTimeToStdTime(core.stdc.time.time(null));
                 else
                 {
-                    import core.sys.posix.sys.time : gettimeofday, timeval;
-                    timeval tv;
-                    if (gettimeofday(&tv, null) != 0)
-                        throw new TimeException("Call to gettimeofday() failed");
-                    return convert!("seconds", "hnsecs")(tv.tv_sec) +
-                           convert!("usecs", "hnsecs")(tv.tv_usec) +
+                    import core.sys.netbsd.time : clock_gettime, CLOCK_REALTIME;
+                    timespec ts = void;
+                    // Posix clock_gettime called with a valid address and valid clock_id is only
+                    // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                    // is long or larger overflow won't happen before 292 billion years A.D.
+                    static if (ts.tv_sec.max < long.max)
+                    {
+                        if (error)
+                            throw new TimeException("Call to clock_gettime() failed");
+                    }
+                    return convert!("seconds", "hnsecs")(ts.tv_sec) +
+                           ts.tv_nsec / 100 +
                            hnsecsToUnixEpoch;
                 }
             }
@@ -285,9 +306,16 @@ public:
                 else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME_PRECISE;
                 else static if (clockType == ClockType.second)  alias clockArg = CLOCK_SECOND;
                 else static assert(0, "Previous static if is wrong.");
-                timespec ts;
-                if (clock_gettime(clockArg, &ts) != 0)
-                    throw new TimeException("Call to clock_gettime() failed");
+                timespec ts = void;
+                immutable error = clock_gettime(clockArg, &ts);
+                // Posix clock_gettime called with a valid address and valid clock_id is only
+                // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                // is long or larger overflow won't happen before 292 billion years A.D.
+                static if (ts.tv_sec.max < long.max)
+                {
+                    if (error)
+                        throw new TimeException("Call to clock_gettime() failed");
+                }
                 return convert!("seconds", "hnsecs")(ts.tv_sec) +
                        ts.tv_nsec / 100 +
                        hnsecsToUnixEpoch;
@@ -303,9 +331,16 @@ public:
                     else static if (clockType == ClockType.normal)  alias clockArg = CLOCK_REALTIME;
                     else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME;
                     else static assert(0, "Previous static if is wrong.");
-                    timespec ts;
-                    if (clock_gettime(clockArg, &ts) != 0)
-                        throw new TimeException("Call to clock_gettime() failed");
+                    timespec ts = void;
+                    immutable error = clock_gettime(clockArg, &ts);
+                    // Posix clock_gettime called with a valid address and valid clock_id is only
+                    // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                    // is long or larger overflow won't happen before 292 billion years A.D.
+                    static if (ts.tv_sec.max < long.max)
+                    {
+                        if (error)
+                            throw new TimeException("Call to clock_gettime() failed");
+                    }
                     return convert!("seconds", "hnsecs")(ts.tv_sec) +
                            ts.tv_nsec / 100 +
                            hnsecsToUnixEpoch;


### PR DESCRIPTION
Explanation is the same as for https://github.com/dlang/druntime/pull/2315 and https://github.com/dlang/druntime/pull/2317 for `core.time`.