### PR TITLE
[dmd-cxx] Disable auto-tester-test from running

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -300,13 +300,9 @@ install :
 		DMD=$(DMD) install2
 
 .PHONY : unittest
-ifeq (1,$(BUILD_WAS_SPECIFIED))
-unittest : $(addsuffix .run,$(addprefix unittest/,$(D_MODULES)))
-else
-unittest : unittest-debug unittest-release
-unittest-%:
-	$(MAKE) -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
-endif
+# Disable unittests for Phobos.
+unittest :
+	@echo "Phobos unittests disabled"
 
 ################################################################################
 # Patterns begin here
@@ -622,6 +618,8 @@ $(TESTS_EXTRACTOR): $(TOOLS_DIR)/tests_extractor.d | $(LIB)
 auto-tester-build: all checkwhitespace
 
 .PHONY : auto-tester-test
-auto-tester-test: unittest
+# Disable unittests for Phobos.
+auto-tester-test:
+	@echo "Phobos unittests disabled"
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/win32.mak
+++ b/win32.mak
@@ -1181,4 +1181,5 @@ install: phobos.zip
 
 auto-tester-build: targets
 
-auto-tester-test: unittest
+# Disable unittests for Phobos.
+auto-tester-test:

--- a/win64.mak
+++ b/win64.mak
@@ -1154,4 +1154,5 @@ install: phobos.zip
 
 auto-tester-build: targets
 
-auto-tester-test: unittest
+# Disable unittests for Phobos.
+auto-tester-test:


### PR DESCRIPTION
All unittests pass when compiled with gdc. Don't need to bother wasting auto-tester time here.