### PR TITLE
Fix issue 19466 - functionLinkage documentation omits some values

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2124,7 +2124,7 @@ Determine the linkage attribute of the function.
 Params:
     func = the function symbol, or the type of a function, delegate, or pointer to function
 Returns:
-    one of the strings "D", "C", "Windows", or "Objective-C"
+    one of the strings "D", "C", "C++", "Windows", "Objective-C", or "System".
 */
 template functionLinkage(func...)
 if (func.length == 1 && isCallable!func)


### PR DESCRIPTION
std.traits.functionLinkage documentation doesn't show the complete list of possible linkage attributes. See https://issues.dlang.org/show_bug.cgi?id=19466