### PR TITLE
Posix x86_64 calling conventions fix

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -3230,6 +3230,10 @@ creal expi(real y) @trusted pure nothrow @nogc
             {
                 fld y;
                 fsincos;
+            }
+            version (X86_64) {}
+            else asm pure nothrow @nogc
+            {
                 fxch ST(1), ST(0);
             }
         }


### PR DESCRIPTION
Depends on https://github.com/dlang/dmd/pull/9013
Without this, phobos unittests fail on https://github.com/dlang/dmd/pull/9013