### PR TITLE
fix issue 19475 - add a staticIndexOf overload taking a pred

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -272,16 +272,10 @@ if (!isAggregateType!T || is(Unqual!T == T))
     static assert(OldAlias!abc == 123);
 }
 
-import std.typecons : Flag;
+public import std.typecons : Flag, Yes, No;
 
 /**
- * Used to indicate the direction of the $(LREF staticIndexOf) overload
- * that takes a predicate.
- */
-alias FromEnd = Flag!"reverse";
-
-/**
- * Retrieve the index of the first or last occurrence of the element that
+ * Retrieves the index of the first or last occurrence of the element that
  * verifies a predicate.
  *
  * Params:
@@ -296,7 +290,7 @@ alias FromEnd = Flag!"reverse";
  *      The specializations $(LREF firstStaticIndexOf) and $(LREF lastStaticIndexOf)
  *      of this template.
  */
-template staticIndexOf(alias pred, FromEnd fromEnd, T...)
+template staticIndexOf(alias pred, Flag!"Reverse" fromEnd, T...)
 {
     enum callPredOnElem = q{
         static if (!is(typeof(_local_idx)) && pred!(T[i]))
@@ -319,11 +313,11 @@ template staticIndexOf(alias pred, FromEnd fromEnd, T...)
     static struct Element{int i, j;}
     alias Elements = AliasSeq!(Element(0,1), Element(1,1), Element(1,0));
     enum cmp(Element e) = e.i == 1;
-    static assert(staticIndexOf!(cmp, FromEnd.no , Elements) == 1);
+    static assert(staticIndexOf!(cmp, No.Reverse , Elements) == 1);
 }
 
 /// Alias of `staticIndexOf` taking a predicate and starting from the beginning of the haystack.
-alias firstStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, FromEnd.no, T);
+alias firstStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, No.Reverse, T);
 ///
 @safe unittest
 {
@@ -334,7 +328,7 @@ alias firstStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, FromEnd.no, T)
 }
 
 /// Alias of `staticIndexOf` taking a predicate and starting at the end of the haystack.
-alias lastStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, FromEnd.yes, T);
+alias lastStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, Yes.Reverse, T);
 ///
 @safe unittest
 {

--- a/std/meta.d
+++ b/std/meta.d
@@ -275,7 +275,7 @@ if (!isAggregateType!T || is(Unqual!T == T))
  * Used to indicate the direction of the $(LREF staticIndexOf) overload
  * that takes a predicate.
  */
-enum IndexOfDirection
+enum IndexOf_Direction
 {
     first,
     last
@@ -291,19 +291,19 @@ enum IndexOfDirection
  *      T    = A list of compile-time stuff.
  *
  * Returns:
- *      `-1` if no element verifies the predicates and its index otherwise.
+ *      `-1` if no element verifies the predicate and its index otherwise.
  *
  * See_Also:
  *      The specialization $(LREF firstStaticIndexOf) and $(LREF lastStaticIndexOf)
  *      of this template.
  */
-template staticIndexOf(alias pred, alias IndexOfDirection dir, T...)
+template staticIndexOf(alias pred, alias IndexOf_Direction dir, T...)
 {
     enum callPredOnElem = q{
         static if (!is(typeof(_local_idx)) && pred!(T[i]))
             enum ptrdiff_t _local_idx = i;
     };
-    static if (dir == IndexOfDirection.first)
+    static if (dir == IndexOf_Direction.first)
         static foreach (i; 0 .. T.length)
             mixin(callPredOnElem);
     else
@@ -311,11 +311,19 @@ template staticIndexOf(alias pred, alias IndexOfDirection dir, T...)
             mixin(callPredOnElem);
     enum ptrdiff_t staticIndexOf = is(typeof(_local_idx)) ? _local_idx : -1;
 }
+///
+@safe unittest
+{
+    static struct Element{int i, j;}
+    alias Elements = AliasSeq!(Element(0,1), Element(1,1), Element(1,0));
+    enum cmp(Element e) = e.i == 1;
+    static assert(staticIndexOf!(cmp, IndexOf_Direction.first, Elements) == 1);
+}
 
 /// Alias of `staticIndexOf` taking a predicate and starting from the beginning of the haystack.
-alias firstStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, IndexOfDirection.first, T);
+alias firstStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, IndexOf_Direction.first, T);
 ///
-unittest
+@safe unittest
 {
     static struct Element{int i, j;}
     alias Elements = AliasSeq!(Element(0,1), Element(1,1), Element(1,0));
@@ -324,9 +332,9 @@ unittest
 }
 
 /// Alias of `staticIndexOf` taking a predicate and starting at the end of the haystack.
-alias lastStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, IndexOfDirection.last, T);
+alias lastStaticIndexOf(alias pred, T...) = staticIndexOf!(pred, IndexOf_Direction.last, T);
 ///
-unittest
+@safe unittest
 {
     static struct Element{int i, j;}
     alias Elements = AliasSeq!(Element(0,1), Element(1,1), Element(1,0));

--- a/std/meta.d
+++ b/std/meta.d
@@ -306,7 +306,10 @@ template staticIndexOf(alias pred, FromEnd fromEnd, T...)
     else
         static foreach_reverse (i; 0 .. T.length)
             mixin(callPredOnElem);
-    enum ptrdiff_t staticIndexOf = is(typeof(_local_idx)) ? _local_idx : -1;
+    static if (is(typeof(_local_idx)))
+        enum ptrdiff_t staticIndexOf = _local_idx;
+    else
+        enum ptrdiff_t staticIndexOf = -1;
 }
 ///
 @safe unittest

--- a/std/meta.d
+++ b/std/meta.d
@@ -48,6 +48,8 @@
  *           $(LREF allSatisfy)
  *           $(LREF anySatisfy)
  *           $(LREF staticIndexOf)
+ *           $(LREF firstStaticIndexOf)
+ *           $(LREF lastStaticIndexOf)
  * ))
  * $(TR $(TD Template predicates) $(TD
  *           $(LREF templateAnd)
@@ -288,10 +290,10 @@ alias FromEnd = Flag!"reverse";
  *      T       = A list of compile-time stuff.
  *
  * Returns:
- *      `-1` if no element verifies the predicate and its index otherwise.
+ *      `-1` if no element verifies the predicate and the element index otherwise.
  *
  * See_Also:
- *      The specialization $(LREF firstStaticIndexOf) and $(LREF lastStaticIndexOf)
+ *      The specializations $(LREF firstStaticIndexOf) and $(LREF lastStaticIndexOf)
  *      of this template.
  */
 template staticIndexOf(alias pred, FromEnd fromEnd, T...)


### PR DESCRIPTION
This overload allows to find the first index or the last index of an element of a alias sequence that verifies a predicate. Current `staticIndexOf` are principally specialized for types and are not adapted, let's say, to work on structures used as UDA.