### PR TITLE
Replace imports of core.sys.windows.windows to speed up compilation

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -81,7 +81,8 @@ import std.traits : isIntegral, isSigned, isSomeString, Unqual, isNarrowString;
 version (Windows)
 {
     import core.stdc.time : time_t;
-    import core.sys.windows.windows;
+    import core.sys.windows.winbase;
+    import core.sys.windows.winnt;
     import core.sys.windows.winsock2;
 }
 else version (Posix)

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -37,7 +37,7 @@ import std.traits : isIntegral, isSomeString, Unqual;
 version (Windows)
 {
     import core.stdc.time : time_t;
-    import core.sys.windows.windows;
+    import core.sys.windows.winbase;
     import core.sys.windows.winsock2;
     import std.windows.registry;
 

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -22,7 +22,8 @@ private mixin template AscendingPageAllocatorImpl(bool isShared)
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : VirtualFree, MEM_RELEASE, MEM_DECOMMIT;
+            import core.sys.windows.winbase : VirtualFree;
+            import core.sys.windows.winnt : MEM_DECOMMIT;
 
             auto ret = VirtualFree(buf.ptr, goodSize, MEM_DECOMMIT);
             if (ret == 0)
@@ -59,7 +60,8 @@ private mixin template AscendingPageAllocatorImpl(bool isShared)
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : VirtualFree, MEM_RELEASE;
+            import core.sys.windows.winbase : VirtualFree;
+            import core.sys.windows.winnt : MEM_RELEASE;
             auto ret = VirtualFree(cast(void*) data, 0, MEM_RELEASE);
             if (ret == 0)
                 assert(0, "Failed to unmap memory, VirtualFree failure");
@@ -100,8 +102,8 @@ private mixin template AscendingPageAllocatorImpl(bool isShared)
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : VirtualAlloc, PAGE_NOACCESS,
-                MEM_RESERVE, GetSystemInfo, SYSTEM_INFO;
+            import core.sys.windows.winbase : GetSystemInfo, SYSTEM_INFO, VirtualAlloc;
+            import core.sys.windows.winnt : MEM_RESERVE, PAGE_NOACCESS;
 
             SYSTEM_INFO si;
             GetSystemInfo(&si);
@@ -148,7 +150,8 @@ private mixin template AscendingPageAllocatorImpl(bool isShared)
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : VirtualAlloc, MEM_COMMIT, PAGE_READWRITE;
+            import core.sys.windows.winbase : VirtualAlloc;
+            import core.sys.windows.winnt : MEM_COMMIT, PAGE_READWRITE;
 
             auto ret = VirtualAlloc(start, size, MEM_COMMIT, PAGE_READWRITE);
             return ret != null;
@@ -682,7 +685,7 @@ version (unittest)
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : GetSystemInfo, SYSTEM_INFO;
+            import core.sys.windows.winbase : GetSystemInfo, SYSTEM_INFO;
 
             SYSTEM_INFO si;
             GetSystemInfo(&si);

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -71,7 +71,7 @@ struct MmapAllocator
     }
     else version (Windows)
     {
-        import core.sys.windows.windows : MEM_COMMIT, PAGE_READWRITE, MEM_RELEASE;
+        import core.sys.windows.winnt : MEM_COMMIT, PAGE_READWRITE, MEM_RELEASE;
 
         /// Allocator API.
         pure nothrow @nogc @safe

--- a/std/file.d
+++ b/std/file.d
@@ -93,7 +93,7 @@ import std.typecons;
 
 version (Windows)
 {
-    import core.sys.windows.windows, std.windows.syserror;
+    import core.sys.windows.winbase, core.sys.windows.winnt, std.windows.syserror;
 }
 else version (Posix)
 {

--- a/std/format.d
+++ b/std/format.d
@@ -4152,7 +4152,7 @@ if (is(T == interface) && (hasToString!(T, Char) || !is(BuiltinTypeOf!T)) && !is
     version (Windows)
     {
         import core.sys.windows.com : IUnknown, IID;
-        import core.sys.windows.windows : HRESULT;
+        import core.sys.windows.windef : HRESULT;
 
         interface IUnknown2 : IUnknown { }
 

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -30,7 +30,7 @@ module std.internal.cstring;
 
     version (Windows)
     {
-        import core.sys.windows.windows : SetEnvironmentVariableW;
+        import core.sys.windows.winbase : SetEnvironmentVariableW;
         import std.exception : enforce;
 
         void setEnvironment(scope const(char)[] name, scope const(char)[] value)
@@ -176,7 +176,7 @@ pure nothrow @nogc @safe unittest
 
 version (Windows)
 {
-    import core.sys.windows.windows : WCHAR;
+    import core.sys.windows.winnt : WCHAR;
     alias tempCStringW = tempCString!(WCHAR, const(char)[]);
 }
 

--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -12,7 +12,7 @@ module std.internal.windows.advapi32;
 
 version (Windows):
 
-import core.sys.windows.windows;
+import core.sys.windows.winbase, core.sys.windows.winnt, core.sys.windows.winreg;
 
 pragma(lib, "advapi32.lib");
 

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -31,7 +31,8 @@ import std.internal.cstring;
 
 version (Windows)
 {
-    import core.sys.windows.windows;
+    import core.sys.windows.winbase;
+    import core.sys.windows.winnt;
     import std.utf;
     import std.windows.syserror;
 }

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -4154,7 +4154,7 @@ private struct CurlAPI
         }
         else version (Windows)
         {
-            import core.sys.windows.windows : GetProcAddress, GetModuleHandleA,
+            import core.sys.windows.winbase : GetProcAddress, GetModuleHandleA,
                 LoadLibraryA;
             alias loadSym = GetProcAddress;
         }
@@ -4219,7 +4219,7 @@ private struct CurlAPI
             }
             else version (Windows)
             {
-                import core.sys.windows.windows : FreeLibrary;
+                import core.sys.windows.winbase : FreeLibrary;
                 FreeLibrary(_handle);
             }
             else

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -962,7 +962,7 @@ uint totalCPUsImpl() @nogc nothrow @trusted
     version (Windows)
     {
         // BUGS:  Only works on Windows 2000 and above.
-        import core.sys.windows.windows : SYSTEM_INFO, GetSystemInfo;
+        import core.sys.windows.winbase : SYSTEM_INFO, GetSystemInfo;
         import std.algorithm.comparison : max;
         SYSTEM_INFO si;
         GetSystemInfo(&si);

--- a/std/process.d
+++ b/std/process.d
@@ -92,7 +92,8 @@ version (Posix)
 version (Windows)
 {
     import core.stdc.stdio;
-    import core.sys.windows.windows;
+    import core.sys.windows.winbase;
+    import core.sys.windows.winnt;
     import std.utf;
     import std.windows.syserror;
 }
@@ -3084,7 +3085,8 @@ private:
     import core.stdc.stddef;
     import core.stdc.wchar_ : wcslen;
     import core.sys.windows.shellapi : CommandLineToArgvW;
-    import core.sys.windows.windows;
+    import core.sys.windows.winbase;
+    import core.sys.windows.winnt;
     import std.array;
 
     string[] parseCommandLine(string line)
@@ -4004,7 +4006,7 @@ version (StdDdoc)
 else
 version (Windows)
 {
-    import core.sys.windows.windows;
+    import core.sys.windows.shellapi, core.sys.windows.winuser;
 
     pragma(lib,"shell32.lib");
 

--- a/std/socket.d
+++ b/std/socket.d
@@ -60,7 +60,7 @@ version (Windows)
     pragma (lib, "ws2_32.lib");
     pragma (lib, "wsock32.lib");
 
-    import core.sys.windows.windows, std.windows.syserror;
+    import core.sys.windows.winbase, std.windows.syserror;
     public import core.sys.windows.winsock2;
     private alias _ctimeval = core.sys.windows.winsock2.timeval;
     private alias _clinger = core.sys.windows.winsock2.linger;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -108,7 +108,7 @@ version (Windows)
     extern (C) nothrow @nogc FILE* _wfopen(in wchar* filename, in wchar* mode);
     extern (C) nothrow @nogc FILE* _wfreopen(in wchar* filename, in wchar* mode, FILE* fp);
 
-    import core.sys.windows.windows : HANDLE;
+    import core.sys.windows.basetsd : HANDLE;
 }
 
 version (DIGITAL_MARS_STDIO)
@@ -942,7 +942,7 @@ Throws: `Exception` if the file is not opened or if the OS call fails.
 
         version (Windows)
         {
-            import core.sys.windows.windows : FlushFileBuffers;
+            import core.sys.windows.winbase : FlushFileBuffers;
             wenforce(FlushFileBuffers(windowsHandle), "FlushFileBuffers failed");
         }
         else
@@ -1225,7 +1225,8 @@ Throws: `Exception` if the file is not opened.
 
     version (Windows)
     {
-        import core.sys.windows.windows : ULARGE_INTEGER, OVERLAPPED, BOOL;
+        import core.sys.windows.winbase : OVERLAPPED;
+        import core.sys.windows.winnt : BOOL, ULARGE_INTEGER;
 
         private BOOL lockImpl(alias F, Flags...)(ulong start, ulong length,
             Flags flags)
@@ -1245,7 +1246,7 @@ Throws: `Exception` if the file is not opened.
 
         private static T wenforce(T)(T cond, string str)
         {
-            import core.sys.windows.windows : GetLastError;
+            import core.sys.windows.winbase : GetLastError;
             import std.windows.syserror : sysErrorString;
 
             if (cond) return cond;
@@ -1303,7 +1304,7 @@ $(UL
         else
         version (Windows)
         {
-            import core.sys.windows.windows : LockFileEx, LOCKFILE_EXCLUSIVE_LOCK;
+            import core.sys.windows.winbase : LockFileEx, LOCKFILE_EXCLUSIVE_LOCK;
             immutable type = lockType == LockType.readWrite ?
                 LOCKFILE_EXCLUSIVE_LOCK : 0;
             wenforce(lockImpl!LockFileEx(start, length, type),
@@ -1341,8 +1342,9 @@ specified file segment was already locked.
         else
         version (Windows)
         {
-            import core.sys.windows.windows : GetLastError, LockFileEx, LOCKFILE_EXCLUSIVE_LOCK,
-                ERROR_IO_PENDING, ERROR_LOCK_VIOLATION, LOCKFILE_FAIL_IMMEDIATELY;
+            import core.sys.windows.winbase : GetLastError, LockFileEx, LOCKFILE_EXCLUSIVE_LOCK,
+                LOCKFILE_FAIL_IMMEDIATELY;
+            import core.sys.windows.winerror : ERROR_IO_PENDING, ERROR_LOCK_VIOLATION;
             immutable type = lockType == LockType.readWrite
                 ? LOCKFILE_EXCLUSIVE_LOCK : 0;
             immutable res = lockImpl!LockFileEx(start, length,
@@ -1375,7 +1377,7 @@ Removes the lock over the specified file segment.
         else
         version (Windows)
         {
-            import core.sys.windows.windows : UnlockFileEx;
+            import core.sys.windows.winbase : UnlockFileEx;
             wenforce(lockImpl!UnlockFileEx(start, length),
                 "Could not remove lock for file `"~_name~"'");
         }

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -50,7 +50,7 @@ else:
 
 version (Windows):
 
-import core.sys.windows.windows;
+import core.sys.windows.winbase, core.sys.windows.winnls;
 import std.conv;
 import std.string;
 import std.windows.syserror;

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -38,7 +38,7 @@
 module std.windows.registry;
 version (Windows):
 
-import core.sys.windows.windows;
+import core.sys.windows.winbase, core.sys.windows.windef, core.sys.windows.winreg;
 import std.array;
 import std.conv;
 import std.exception;

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -65,7 +65,7 @@ else:
 
 version (Windows):
 
-import core.sys.windows.windows;
+import core.sys.windows.winbase, core.sys.windows.winnt;
 import std.array : appender;
 import std.conv : to;
 import std.format : formattedWrite;
@@ -117,7 +117,7 @@ bool putSysError(Writer)(DWORD code, Writer w, /*WORD*/int langId = 0)
 
 class WindowsException : Exception
 {
-    import core.sys.windows.windows : DWORD;
+    import core.sys.windows.windef : DWORD;
 
     final @property DWORD code() { return _code; } /// `GetLastError`'s return value.
     private DWORD _code;


### PR DESCRIPTION
Importing `core.sys.windows.windows.d` is slow and replacing it can speed up compilation. See https://github.com/dlang/druntime/pull/2400#issuecomment-447933446