### PR TITLE
logger: print log level string.

### DIFF
--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -131,8 +131,9 @@ class FileLogger : Logger
 
         auto lt = this.file_.lockingTextWriter();
         systimeToISOString(lt, timestamp);
-        formattedWrite(lt, ":%s:%s:%u ", file[fnIdx .. $],
-            funcName[funIdx .. $], line);
+        import std.conv : to;
+        formattedWrite(lt, " [%s] %s:%u:%s ", logLevel.to!string,
+                file[fnIdx .. $], line, funcName[funIdx .. $]);
     }
 
     /* This methods overrides the base class method and writes the parts of


### PR DESCRIPTION
Log message currently doesn't have log level, thread ID, etc. Log messages without this information is mostly useless.

However, printing the thread ID requires `std.concurrency` to be `@safe` which is not possible at the moment. So I've added only the log level to the message string.