### PR TITLE
[trivial] unittest: set pagesize by using sysconf(_SC_PAGESIZE) on po…

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -648,7 +648,7 @@ private:
     else version (Posix)
     {
         import core.sys.posix.unistd;
-        win = cast(size_t)sysconf(_SC_PAGESIZE);
+        win = cast(size_t) sysconf(_SC_PAGESIZE);
     }
     string test_file = std.file.deleteme ~ "-testing.txt";
     MmFile mf = new MmFile(test_file,MmFile.Mode.readWriteNew,

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -645,9 +645,10 @@ private:
          win = sysinfo.dwAllocationGranularity;
          +/
     }
-    else version (linux)
+    else version (Posix)
     {
-        // getpagesize() is not defined in the unix D headers so use the guess
+        import core.sys.posix.unistd;
+        win = cast(size_t)sysconf(_SC_PAGESIZE);
     }
     string test_file = std.file.deleteme ~ "-testing.txt";
     MmFile mf = new MmFile(test_file,MmFile.Mode.readWriteNew,


### PR DESCRIPTION
…six platform

getpagesize is not defined but sysconf(_SC_PAGESIZE) can be used.