### PR TITLE
Add LibcurlPath version option

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -22,10 +22,6 @@
 #
 # make std/somemodule.test => only builds and unittests std.somemodule
 #
-# make TZ_DATABASE_DIR=path to the TZDatabase directory => This is useful to
-# overwrite the hardcoded path to the TZDatabase directory needed
-# for std/datetime/timezone.d
-
 ################################################################################
 # Configurable stuff, usually from the command line
 #
@@ -151,10 +147,6 @@ endif
 
 ifdef ENABLE_COVERAGE
 override DFLAGS  += -cov
-endif
-ifneq (,$(TZ_DATABASE_DIR))
-$(file > /tmp/TZDatabaseDirFile, ${TZ_DATABASE_DIR})
-override DFLAGS += -version=TZDatabaseDir -J/tmp/
 endif
 
 UDFLAGS=-unittest

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -4175,7 +4175,12 @@ private struct CurlAPI
             version (Posix)
                 dlclose(handle);
 
-            version (OSX)
+            version (LibcurlPath)
+            {
+                import std.string : strip;
+                static immutable names = [strip(import("LibcurlPathFile"))];
+            }
+            else version (OSX)
                 static immutable names = ["libcurl.4.dylib"];
             else version (Posix)
             {


### PR DESCRIPTION
Adds possibility to specify absolute path to libcurl.
The TZDatabaseDir version option already does the same for the tzdata directory.
This commit enables the same fix for the path to libcurl. It's needed for Operating systems like NixOS without a search path for dynamic libs.
See https://issues.dlang.org/show_bug.cgi?id=15391 for more information.
Additionally I removed the Makefile part of the TZDatabaseDir solution
because the necessary compiler arguments can be easily given via DFLAGS, which is also compiler independent and doesn't use the /tmp dir which leads to problems on NixOS.