### PR TITLE
 fix Issue 18519: missing curl + phobos = std.net.curl unittest timing out

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -344,7 +344,17 @@ endif
 # Unittests
 ################################################################################
 
-$(addprefix $(ROOT)/unittest/,$(DISABLED_TESTS)) :
+DISABLED_TESTS =
+ifeq ($(OS),freebsd)
+    ifeq ($(MODEL),32)
+    # Curl tests for FreeBSD 32-bit are temporarily disabled.
+    # https://github.com/braddr/d-tester/issues/70
+    # https://issues.dlang.org/show_bug.cgi?id=18519
+    DISABLED_TESTS += std/net/curl
+    endif
+endif
+
+$(addsuffix .run,$(addprefix unittest/,$(DISABLED_TESTS))) :
 	@echo Testing $@ - disabled
 
 include dip1000.mak

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -176,7 +176,7 @@ version (DisableCurlTests) {} else:
 
 version (unittest)
 {
-    import std.socket : Socket;
+    import std.socket : Socket, SocketShutdown;
 
     private struct TestServer
     {
@@ -248,7 +248,10 @@ version (unittest)
         // terminate server from a thread local dtor of the thread that started it,
         //  because thread_joinall is called before shared module dtors
         if (tlsInit && server.sock)
+        {
+            server.sock.shutdown(SocketShutdown.RECEIVE);
             server.sock.close();
+        }
     }
 
     private struct Request(T)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -451,7 +451,11 @@ if (isCurlConn!Conn)
             s.send(httpOK("Hello world"));
         });
         auto fn = std.file.deleteme;
-        scope (exit) std.file.remove(fn);
+        scope (exit)
+        {
+            if (std.file.exists(fn))
+                std.file.remove(fn);
+        }
         download(host, fn);
         assert(std.file.readText(fn) == "Hello world");
     }
@@ -513,7 +517,11 @@ if (isCurlConn!Conn)
     foreach (host; [testServer.addr, "http://"~testServer.addr])
     {
         auto fn = std.file.deleteme;
-        scope (exit) std.file.remove(fn);
+        scope (exit)
+        {
+            if (std.file.exists(fn))
+                std.file.remove(fn);
+        }
         std.file.write(fn, "upload data\n");
         testServer.handle((s) {
             auto req = s.recvReq;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -164,16 +164,6 @@ import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
 
-// Curl tests for FreeBSD 32-bit are temporarily disabled.
-// https://github.com/braddr/d-tester/issues/70
-// https://issues.dlang.org/show_bug.cgi?id=18519
-version (unittest)
-version (FreeBSD)
-version (X86)
-    version = DisableCurlTests;
-
-version (DisableCurlTests) {} else:
-
 version (unittest)
 {
     import std.socket : Socket, SocketShutdown;


### PR DESCRIPTION
Second attempt at fixing the issue.

Only a little sceptical that this is more correct here - calling shutdown is recommended however in the docs.  In any case, I can no longer reproduce this on Linux after applying patch.