### PR TITLE
fix quoting in win64.mak: add them only when invoking command

### DIFF
--- a/etc/c/zlib/win64.mak
+++ b/etc/c/zlib/win64.mak
@@ -3,9 +3,9 @@
 MODEL=64
 VCDIR=\Program Files (x86)\Microsoft Visual Studio 10.0\VC
 
-CC="$(VCDIR)\bin\amd64\cl"
-LD="$(VCDIR)\bin\amd64\link"
-LIB="$(VCDIR)\bin\amd64\lib"
+CC=$(VCDIR)\bin\amd64\cl
+LD=$(VCDIR)\bin\amd64\link
+LIB=$(VCDIR)\bin\amd64\lib
 
 CFLAGS=/O2 /nologo /I"$(VCDIR)\INCLUDE"
 LIBFLAGS=/nologo
@@ -24,72 +24,72 @@ OBJS = adler32$(O) compress$(O) crc32$(O) deflate$(O) gzclose$(O) gzlib$(O) gzre
 all:  zlib64.lib example.exe minigzip.exe
 
 adler32.obj: zutil.h zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 zutil.obj: zutil.h zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 gzclose.obj: zlib.h zconf.h gzguts.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 gzlib.obj: zlib.h zconf.h gzguts.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 gzread.obj: zlib.h zconf.h gzguts.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 gzwrite.obj: zlib.h zconf.h gzguts.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 compress.obj: zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 example.obj: zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 minigzip.obj: zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 uncompr.obj: zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 crc32.obj: zutil.h zlib.h zconf.h crc32.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 deflate.obj: deflate.h zutil.h zlib.h zconf.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 infback.obj: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h inffixed.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 inflate.obj: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h inffixed.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 inffast.obj: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 inftrees.obj: zutil.h zlib.h zconf.h inftrees.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 trees.obj: deflate.h zutil.h zlib.h zconf.h trees.h
-	$(CC) /c $(CFLAGS) $*.c
+	"$(CC)" /c $(CFLAGS) $*.c
 
 
 
 example.obj: example.c zlib.h zconf.h
-	$(CC) /c $(cvarsdll) $(CFLAGS) $*.c
+	"$(CC)" /c $(cvarsdll) $(CFLAGS) $*.c
 
 minigzip.obj: minigzip.c zlib.h zconf.h
-	$(CC) /c $(cvarsdll) $(CFLAGS) $*.c
+	"$(CC)" /c $(cvarsdll) $(CFLAGS) $*.c
 
 zlib$(MODEL).lib: $(OBJS)
-	$(LIB) $(LIBFLAGS) /OUT:zlib$(MODEL).lib $(OBJS)
+	"$(LIB)" $(LIBFLAGS) /OUT:zlib$(MODEL).lib $(OBJS)
 
 example.exe: example.obj zlib$(MODEL).lib
-	$(LD) $(LDFLAGS) example.obj zlib$(MODEL).lib
+	"$(LD)" $(LDFLAGS) example.obj zlib$(MODEL).lib
 
 minigzip.exe: minigzip.obj zlib$(MODEL).lib
-	$(LD) $(LDFLAGS) minigzip.obj zlib$(MODEL).lib
+	"$(LD)" $(LDFLAGS) minigzip.obj zlib$(MODEL).lib
 
 test: example.exe minigzip.exe
 	example

--- a/win64.mak
+++ b/win64.mak
@@ -54,9 +54,9 @@ UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import -unittest
 
 ## C compiler, linker, librarian
 
-CC="$(VCDIR)\bin\amd64\cl"
-LD="$(VCDIR)\bin\amd64\link"
-AR="$(VCDIR)\bin\amd64\lib"
+CC=$(VCDIR)\bin\amd64\cl
+LD=$(VCDIR)\bin\amd64\link
+AR=$(VCDIR)\bin\amd64\lib
 MAKE=make
 
 ## D compiler
@@ -64,23 +64,23 @@ MAKE=make
 DMD_DIR=../dmd
 BUILD=release
 OS=windows
-DMD="$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd"
+DMD=$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd
 
 ## Zlib library
 
 ZLIB=etc\c\zlib\zlib$(MODEL).lib
 
 .c.obj:
-	$(CC) -c $(CFLAGS) $*.c
+	"$(CC)" -c $(CFLAGS) $*.c
 
 .cpp.obj:
-	$(CC) -c $(CFLAGS) $*.cpp
+	"$(CC)" -c $(CFLAGS) $*.cpp
 
 .d.obj:
-	$(DMD) -c $(DFLAGS) $*
+	"$(DMD)" -c $(DFLAGS) $*
 
 .asm.obj:
-	$(CC) -c $*
+	"$(CC)" -c $*
 
 LIB=phobos$(MODEL).lib
 
@@ -89,10 +89,10 @@ targets : $(LIB)
 test : test.exe
 
 test.obj : test.d
-	$(DMD) -conf= -c -m$(MODEL) test -g $(UDFLAGS)
+	"$(DMD)" -conf= -c -m$(MODEL) test -g $(UDFLAGS)
 
 test.exe : test.obj $(LIB)
-	$(DMD) -conf= test.obj -m$(MODEL) -g -L/map
+	"$(DMD)" -conf= test.obj -m$(MODEL) -g -L/map
 
 #	ti_bit.obj ti_Abit.obj
 
@@ -388,7 +388,7 @@ SRC_ZLIB= \
 
 $(LIB) : $(SRC_TO_COMPILE) \
 	$(ZLIB) $(DRUNTIMELIB) win32.mak win64.mak
-	$(DMD) -lib -of$(LIB) -Xfphobos.json $(DFLAGS) $(SRC_TO_COMPILE) \
+	"$(DMD)" -lib -of$(LIB) -Xfphobos.json $(DFLAGS) $(SRC_TO_COMPILE) \
 		$(ZLIB) $(DRUNTIMELIB)
 
 UNITTEST_OBJS= \
@@ -420,33 +420,33 @@ UNITTEST_OBJS= \
 		unittest9.obj
 
 unittest : $(LIB)
-	$(DMD) $(UDFLAGS) -c  -ofunittest1.obj $(SRC_STD_1)
-	$(DMD) $(UDFLAGS) -c  -ofunittest2.obj $(SRC_STD_RANGE)
-	$(DMD) $(UDFLAGS) -c  -ofunittest2a.obj $(SRC_STD_2a)
-	$(DMD) $(UDFLAGS) -c  -ofunittest3.obj $(SRC_STD_3)
-	$(DMD) $(UDFLAGS) -c  -ofunittest3a.obj $(SRC_STD_3a)
-	$(DMD) $(UDFLAGS) -c  -ofunittest3b.obj $(SRC_STD_3b)
-	$(DMD) $(UDFLAGS) -c  -ofunittest3c.obj $(SRC_STD_3c)
-	$(DMD) $(UDFLAGS) -c  -ofunittest3d.obj $(SRC_STD_3d) $(SRC_STD_DATETIME)
-	$(DMD) $(UDFLAGS) -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
-	$(DMD) $(UDFLAGS) -c  -ofunittest5a.obj $(SRC_STD_ALGO_1)
-	$(DMD) $(UDFLAGS) -c  -ofunittest5b.obj $(SRC_STD_ALGO_2)
-	$(DMD) $(UDFLAGS) -c  -ofunittest5c.obj $(SRC_STD_ALGO_3)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6a.obj $(SRC_STD_6a)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6c.obj $(SRC_STD_6c)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6e.obj $(SRC_STD_6e)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6g.obj $(SRC_STD_CONTAINER)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6h.obj $(SRC_STD_6h)
-	$(DMD) $(UDFLAGS) -c  -ofunittest6i.obj $(SRC_STD_6i)
-	$(DMD) $(UDFLAGS) -c  -ofunittest7.obj $(SRC_STD_7) $(SRC_STD_EXP_LOGGER)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8a.obj $(SRC_STD_REGEX)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8b.obj $(SRC_STD_NET)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
-	$(DMD) $(UDFLAGS) -c  -ofunittest8f.obj $(SRC_STD_EXP)
-	$(DMD) $(UDFLAGS) -c  -ofunittest9.obj $(SRC_STD_EXP_ALLOC)
-	$(DMD) $(UDFLAGS) -L/OPT:NOICF  unittest.d $(UNITTEST_OBJS) \
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest1.obj $(SRC_STD_1)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest2.obj $(SRC_STD_RANGE)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest2a.obj $(SRC_STD_2a)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest3.obj $(SRC_STD_3)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest3a.obj $(SRC_STD_3a)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest3b.obj $(SRC_STD_3b)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest3c.obj $(SRC_STD_3c)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest3d.obj $(SRC_STD_3d) $(SRC_STD_DATETIME)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest5a.obj $(SRC_STD_ALGO_1)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest5b.obj $(SRC_STD_ALGO_2)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest5c.obj $(SRC_STD_ALGO_3)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6a.obj $(SRC_STD_6a)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6c.obj $(SRC_STD_6c)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6e.obj $(SRC_STD_6e)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6g.obj $(SRC_STD_CONTAINER)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6h.obj $(SRC_STD_6h)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest6i.obj $(SRC_STD_6i)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest7.obj $(SRC_STD_7) $(SRC_STD_EXP_LOGGER)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8a.obj $(SRC_STD_REGEX)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8b.obj $(SRC_STD_NET)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8c.obj $(SRC_STD_C) $(SRC_STD_WIN) $(SRC_STD_C_WIN)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8d.obj $(SRC_STD_INTERNAL) $(SRC_STD_INTERNAL_DIGEST) $(SRC_STD_INTERNAL_MATH) $(SRC_STD_INTERNAL_WINDOWS)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8e.obj $(SRC_ETC) $(SRC_ETC_C)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest8f.obj $(SRC_STD_EXP)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest9.obj $(SRC_STD_EXP_ALLOC)
+	"$(DMD)" $(UDFLAGS) -L/OPT:NOICF  unittest.d $(UNITTEST_OBJS) \
 	    $(ZLIB) $(DRUNTIMELIB)
 	.\unittest.exe
 
@@ -458,7 +458,7 @@ unittest : $(LIB)
 #	dmc unittest.obj -g
 
 cov : $(SRC_TO_COMPILE) $(LIB)
-	$(DMD) -conf= -m$(MODEL) -cov $(UDFLAGS) -ofcov.exe unittest.d $(SRC_TO_COMPILE) $(LIB)
+	"$(DMD)" -conf= -m$(MODEL) -cov $(UDFLAGS) -ofcov.exe unittest.d $(SRC_TO_COMPILE) $(LIB)
 	cov
 
 ################### Win32 COFF support #########################
@@ -469,17 +469,17 @@ CC32=$(CC)\..\..\cl
 
 # build phobos32mscoff.lib
 phobos32mscoff:
-	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)"
+	"$(MAKE)" -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=$(CC32)" "AR=$(AR)" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)"
 
 # run unittests for 32-bit COFF version
 unittest32mscoff:
-	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)" unittest
+	"$(MAKE)" -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=$(CC32)" "AR=$(AR)" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)" unittest
 
 ######################################################
 
 $(ZLIB): $(SRC_ZLIB)
 	cd etc\c\zlib
-	$(MAKE) -f win64.mak MODEL=$(MODEL) zlib$(MODEL).lib "CC=\$(CC)"\"" "LIB=\$(AR)"\"" "VCDIR=$(VCDIR)"
+	"$(MAKE)" -f win64.mak MODEL=$(MODEL) zlib$(MODEL).lib "CC=$(CC)" "LIB=$(AR)" "VCDIR=$(VCDIR)"
 	cd ..\..\..
 
 ######################################################
@@ -492,7 +492,7 @@ phobos.zip : zip
 
 clean:
 	cd etc\c\zlib
-	$(MAKE) -f win64.mak MODEL=$(MODEL) clean
+	"$(MAKE)" -f win64.mak MODEL=$(MODEL) clean
 	cd ..\..\..
 	del $(DOCS)
 	del $(UNITTEST_OBJS) unittest.obj unittest.exe
@@ -510,5 +510,5 @@ JOBS=$(NUMBER_OF_PROCESSORS)
 GMAKE=gmake
 
 auto-tester-test:
-	$(GMAKE) -j$(JOBS) -f posix.mak unittest BUILD=release DMD="$(DMD)" OS=win$(MODEL) \
+	"$(GMAKE)" -j$(JOBS) -f posix.mak unittest BUILD=release DMD="$(DMD)" OS=win$(MODEL) \
 	CUSTOM_DRUNTIME=1 PIC=0 MODEL=$(MODEL) DRUNTIME=$(DRUNTIMELIB) CC=$(CC)


### PR DESCRIPTION
not when setting variable. This avoids having to skillfully quote variables with spaces in them: use `"CC=%cl64%"` instead of `"CC=\"%cl64%\""`

Not sure how the existing misquoting was supposed to work. Using quotes with the command is agnostic to using `/` instead of `\` as a path separator, too.

See also https://github.com/dlang/druntime/pull/2438