### PR TITLE
std.uni: add scope to addInterval()

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -2939,7 +2939,7 @@ private:
     }
 
     //
-    Marker addInterval(int a, int b, Marker hint=Marker.init)
+    Marker addInterval(int a, int b, Marker hint=Marker.init) scope
     in
     {
         assert(a <= b);


### PR DESCRIPTION
Because the scope inference needs a little help sometimes. Needed for -dip1000 compliance.