### PR TITLE
alias std.array.Appender.opOpAssign to put

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3467,10 +3467,11 @@ if (isDynamicArray!A)
     }
 
     /**
-     * Appends `rhs` to the managed array.
+     * Appends to the managed array.
      * Params:
      *     op = the assignment operator `~`
-     *     rhs = Element or range.
+     *
+     * See_Also: $(LREF Appender.put)
      */
     alias opOpAssign(string op : "~") = put;
 

--- a/std/array.d
+++ b/std/array.d
@@ -3472,11 +3472,7 @@ if (isDynamicArray!A)
      *     op = the assignment operator `~`
      *     rhs = Element or range.
      */
-    void opOpAssign(string op : "~", U)(U rhs)
-    if (__traits(compiles, put(rhs)))
-    {
-        put(rhs);
-    }
+    alias opOpAssign(string op : "~") = put;
 
     // only allow overwriting data on non-immutable and non-const data
     static if (isMutable!T)

--- a/std/array.d
+++ b/std/array.d
@@ -3468,8 +3468,6 @@ if (isDynamicArray!A)
 
     /**
      * Appends to the managed array.
-     * Params:
-     *     op = the assignment operator `~`
      *
      * See_Also: $(LREF Appender.put)
      */


### PR DESCRIPTION
We can eliminate an unnecessary `__traits(compiles, ...)` by doing this and it simplifies things for us. It doesn't look like this change is feasible for RefAppender though.