### PR TITLE
Reduce std/complex compilation time by 10x

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -871,7 +871,7 @@ deprecated
     x87 $(I fsincos) instruction when possible, this function is no faster
     than calculating cos(y) and sin(y) separately.
 */
-Complex!real expi(real y)  @trusted pure nothrow @nogc
+Complex!real expi()(real y)  @trusted pure nothrow @nogc
 {
     import std.math : cos, sin;
     return Complex!real(cos(y), sin(y));
@@ -904,7 +904,7 @@ deprecated
     `coshisinh` is included here for convenience and for easy migration of code
     that uses $(REF _coshisinh, std,math).
 */
-Complex!real coshisinh(real y) @safe pure nothrow @nogc
+Complex!real coshisinh()(real y) @safe pure nothrow @nogc
 {
     static import std.math;
     if (std.math.fabs(y) <= 0.5)


### PR DESCRIPTION
Time dropped from
```
time dmd -c std/complex.d
dmd  -c std/complex.d  0,31s user 0,04s system 99% cpu 0,352 total
```
to
```
time dmd -c std/complex.d
dmd  -c std/complex.d  0,02s user 0,00s system 98% cpu 0,020 total
```