### PR TITLE
[dmd-cxx] Backport non-math related patches from #5358

### DIFF
--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -105,10 +105,6 @@ struct Mallocator
     test!Mallocator();
 }
 
-version (Posix)
-@nogc nothrow
-private extern(C) int posix_memalign(void**, size_t, size_t);
-
 version (Windows)
 {
     // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
@@ -231,6 +227,7 @@ struct AlignedMallocator
     void[] alignedAllocate(size_t bytes, uint a) shared
     {
         import core.stdc.errno : ENOMEM, EINVAL;
+        import core.sys.posix.stdlib : posix_memalign;
         assert(a.isGoodDynamicAlignment);
         void* result;
         auto code = posix_memalign(&result, a, bytes);

--- a/std/file.d
+++ b/std/file.d
@@ -4293,11 +4293,6 @@ string tempDir() @trusted
             DWORD len = GetTempPathW(buf.length, buf.ptr);
             if (len) cache = buf[0 .. len].to!string;
         }
-        else version (Android)
-        {
-            // Don't check for a global temporary directory as
-            // Android doesn't have one.
-        }
         else version (Posix)
         {
             import std.process : environment;

--- a/std/math.d
+++ b/std/math.d
@@ -5055,6 +5055,21 @@ struct FloatingPointControl
                                  | inexactException | subnormalException,
         }
     }
+    else version (PPC_Any)
+    {
+        enum : ExceptionMask
+        {
+            inexactException      = 0x0008,
+            divByZeroException    = 0x0010,
+            underflowException    = 0x0020,
+            overflowException     = 0x0040,
+            invalidException      = 0x0080,
+            severeExceptions   = overflowException | divByZeroException
+                                 | invalidException,
+            allExceptions      = severeExceptions | underflowException
+                                 | inexactException,
+        }
+    }
     else version (HPPA)
     {
         enum : ExceptionMask
@@ -5075,25 +5090,10 @@ struct FloatingPointControl
         enum : ExceptionMask
         {
             inexactException      = 0x0080,
-            underflowException    = 0x0100,
-            overflowException     = 0x0200,
             divByZeroException    = 0x0400,
+            overflowException     = 0x0200,
+            underflowException    = 0x0100,
             invalidException      = 0x0800,
-            severeExceptions   = overflowException | divByZeroException
-                                 | invalidException,
-            allExceptions      = severeExceptions | underflowException
-                                 | inexactException,
-        }
-    }
-    else version (PPC_Any)
-    {
-        enum : ExceptionMask
-        {
-            inexactException      = 0x08,
-            divByZeroException    = 0x10,
-            underflowException    = 0x20,
-            overflowException     = 0x40,
-            invalidException      = 0x80,
             severeExceptions   = overflowException | divByZeroException
                                  | invalidException,
             allExceptions      = severeExceptions | underflowException

--- a/std/system.d
+++ b/std/system.d
@@ -28,10 +28,11 @@ immutable
     {
         win32 = 1, /// Microsoft 32 bit Windows systems
         win64,     /// Microsoft 64 bit Windows systems
-        linux,     /// All Linux Systems
+        linux,     /// All Linux Systems, except for Android
         osx,       /// Mac OS X
         freeBSD,   /// FreeBSD
         netBSD,    /// NetBSD
+        dragonFlyBSD, /// DragonFlyBSD
         solaris,   /// Solaris
         android,   /// Android
         otherPosix /// Other Posix Systems
@@ -45,6 +46,7 @@ immutable
     else version (OSX)     OS os = OS.osx;
     else version (FreeBSD) OS os = OS.freeBSD;
     else version (NetBSD)  OS os = OS.netBSD;
+    else version (DragonFlyBSD) OS os = OS.dragonFlyBSD;
     else version (Posix)   OS os = OS.otherPosix;
     else static assert(0, "Unknown OS.");
 


### PR DESCRIPTION
Somehow the order got messed up by git cherry-pick.

The other parts were taken from #5358, the std.math bits were cherry-picked to dmd-cxx branch in #6838.