### PR TITLE
Fix documentation link.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4809,7 +4809,7 @@ public:
 
     Returns:
         An $(REF_ALTTEXT input range, isInputRange,std,range,primitives) of
-        $(LREF DirEntries).
+        $(LREF DirEntry).
 
     Throws:
         $(LREF FileException) if the directory does not exist.


### PR DESCRIPTION
In absence of LREF_ALTTEXT, sacrifice grammatical correctness to get a working link. There is precedence on line 4784.

Or is REF_ALTTEXT prefered, yielding a different link style?