### PR TITLE
Mark etc.c.sqlite3 as deprecated

### DIFF
--- a/etc/c/sqlite3.d
+++ b/etc/c/sqlite3.d
@@ -34,6 +34,9 @@ module etc.c.sqlite3;
 
 import core.stdc.stdarg : va_list;
 
+// @@@DEPRECATED_2.090@@@
+deprecated("etc.c.sqlite3 is unmaintained, and will be removed in 2.090"):
+
 extern (C) __gshared nothrow:
 
 /**


### PR DESCRIPTION
(I'm going to start this debate by opening a pull request).

Bindings are for 3.10 which is outdated for some years now, the current upstream version of sqlite3 is 3.28.

For up-to-date bindings, there are many external repositories in code.dlang.org that provide them, such as d2sqlite or derelict.

If no one comes forward to maintain it, they will be removed.