### PR TITLE
revert bad @trusted

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10493,7 +10493,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
 
     /// Ditto
     static if (hasSlicing!Range)
-        auto opSlice(size_t a, size_t b) return scope @trusted
+        auto opSlice(size_t a, size_t b) return scope
         {
             assert(
                 a <= b,


### PR DESCRIPTION
Range.opSlice might be unsafe. `_input[a .. b]` can't be @trusted.

Partially reverts #6866. CC @WalterBright @wilzbach