### PR TITLE
Revert "SortedRange.opSlice() should be return scope"

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10493,7 +10493,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
 
     /// Ditto
     static if (hasSlicing!Range)
-        auto opSlice(size_t a, size_t b) return scope @trusted
+        auto opSlice(size_t a, size_t b)
         {
             assert(
                 a <= b,


### PR DESCRIPTION
Reverts dlang/phobos#6866

Range.opSlice might be unsafe. `_input[a .. b]` can't be `@trusted`.

I tried reverting just the `@trusted` attribute in #6869, but that doesn't seem to work (auto-tester fails).