### PR TITLE
toUTF16z cannot be used for LPWSTR.

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -3279,7 +3279,7 @@ if (isSomeString!S && isPointer!P && isSomeChar!(typeof(*P.init)) &&
 
     Encodes string `s` into UTF-16 and returns the encoded string.
     `toUTF16z` is suitable for calling the 'W' functions in the Win32 API
-    that take an `LPWSTR` or `LPCWSTR` argument.
+    that take an `LPCWSTR` argument.
   +/
 const(wchar)* toUTF16z(C)(const(C)[] str) @safe pure
 if (isSomeChar!C)


### PR DESCRIPTION
Remove false statement from the documentation. Fixes issue 19151.

Probably a note on what to do for LPWSTR is in place, but what that is, is not easy to say. Both suggestions from https://issues.dlang.org/show_bug.cgi?id=19151 (`cast(LPWSTR)` and `.toUTFz!(wchar*)`) are wrong. Note also that `toStringz` is fundamentally broken https://issues.dlang.org/show_bug.cgi?id=12417. The right thing is probably something like
```d
wchar[sufficient_length] str = "\0";
// or
wchar[] str = new wchar[sufficient_length];
str[] = '\0';

Win_API_func(str.ptr); // taking LPWSTR.
// Hope that Win_API_func does not store a reference.
```

