### PR TITLE
Disable OSX-32 on the auto-tester (build)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -653,7 +653,12 @@ betterc: betterc-phobos-tests
 ################################################################################
 
 .PHONY : auto-tester-build
+ifneq (,$(findstring Darwin_64_32, $(PWD)))
+auto-tester-build:
+	echo "Darwin_64_32_disabled"
+else
 auto-tester-build: all checkwhitespace
+endif
 
 .PHONY : auto-tester-test
 ifneq (,$(findstring Darwin_64_32, $(PWD)))


### PR DESCRIPTION
Disable the build steps For OSX 32 too.
This needs to happen in the order: Phobos, Druntime, DMD.