### PR TITLE
[GDC] Cleanup MinGW code

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -4784,11 +4784,6 @@ private void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __L
         assert(stream.data == "1.67 -0X1.47AE147AE147BP+0 nan",
                 stream.data);
     }
-    else version (MinGW)
-    {
-        assert(stream.data == "1.67 -0XA.3D70A3D70A3D8P-3 nan",
-                stream.data);
-    }
     else version (CRuntime_Microsoft)
     {
         assert(stream.data == "1.67 -0X1.47AE14P+0 nan"
@@ -5264,10 +5259,7 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
     {
         auto f = 3.14;
         formatReflectTest(f, "%s",  `3.14`);
-        version (MinGW)
-            formatReflectTest(f, "%e",  `3.140000e+000`);
-        else
-            formatReflectTest(f, "%e",  `3.140000e+00`);
+        formatReflectTest(f, "%e",  `3.140000e+00`);
         formatReflectTest(f, "%f",  `3.140000`);
         formatReflectTest(f, "%g",  `3.14`);
     }
@@ -5918,9 +5910,7 @@ private bool needToSwapEndianess(Char)(const ref FormatSpec!Char f)
     //else version (OSX)
     //    assert(s == "1.67 -0XA.3D70A3D70A3D8P-3 nan", s);
     //else
-    version (MinGW)
-        assert(s == "1.67 -0XA.3D70A3D70A3D8P-3 nan", s);
-    else version (CRuntime_Microsoft)
+    version (CRuntime_Microsoft)
         assert(s == "1.67 -0X1.47AE14P+0 nan"
             || s == "1.67 -0X1.47AE147AE147BP+0 nan", s); // MSVCRT 14+ (VS 2015)
     else

--- a/std/json.d
+++ b/std/json.d
@@ -1732,10 +1732,7 @@ class JSONException : Exception
     ];
 
     enum dbl1_844 = `1.8446744073709568`;
-    version (MinGW)
-        jsons ~= dbl1_844 ~ `e+019`;
-    else
-        jsons ~= dbl1_844 ~ `e+19`;
+    jsons ~= dbl1_844 ~ `e+19`;
 
     JSONValue val;
     string result;

--- a/std/math.d
+++ b/std/math.d
@@ -162,6 +162,12 @@ else version (D_InlineAsm_X86_64)
     version = InlineAsm_X86_Any;
 }
 
+version (CRuntime_Microsoft)
+{
+    version (InlineAsm_X86_Any)
+        version = MSVC_InlineAsm;
+}
+
 version (X86_64) version = StaticallyHaveSSE;
 version (X86) version (OSX) version = StaticallyHaveSSE;
 
@@ -4385,7 +4391,7 @@ real logb(real x) @trusted nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         asm pure nothrow @nogc
         {
@@ -4726,7 +4732,7 @@ real ceil(real x) @trusted pure nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc
@@ -4854,7 +4860,7 @@ real floor(real x) @trusted pure nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc
@@ -5418,7 +5424,7 @@ real trunc(real x) @trusted nothrow @nogc pure
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc


### PR DESCRIPTION
Remove old code: We now simply set `CRuntime_Microsoft`, as MinGW is really MS runtime+ some extra libraries. Because of that, we no longer need MinGW specific code.

Also use generic math implementations as DMD-style IASM isn't available. Part of MinGW support for GDC/GCC9, https://github.com/D-Programming-GDC/gcc/pull/1