### PR TITLE
Disable the style_lint target on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y gdb
           name: Install gdb
       - run:
-          command: ./.circleci/run.sh style_lint
-          name: Run code style & linter
-      - run:
           command: ./.circleci/run.sh publictests
           name: Run all public unittests
       - run:

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -91,15 +91,6 @@ setup_repos()
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD=$BUILD
 }
 
-# verify style guide
-style_lint()
-{
-    # dscanner needs a more up-to-date DMD version
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
-
-    make -f posix.mak style_lint DUB=$DUB BUILD=$BUILD
-}
-
 # run unittest with coverage
 coverage()
 {
@@ -146,7 +137,7 @@ case $1 in
     setup-repos) setup_repos ;;
     coverage) coverage ;;
     publictests) publictests ;;
-    style_lint) style_lint ;;
+    style_lint) echo "style_lint is now run at Buildkite";;
     # has_public_example has been removed and is kept for compatibility with older PRs
     has_public_example) echo "OK" ;;
     *) echo "Unknown command"; exit 1;;

--- a/dip1000.mak
+++ b/dip1000.mak
@@ -18,7 +18,7 @@ aa[std.bigint]=-dip1000
 aa[std.bitmanip]=-dip1000 # merged https://github.com/dlang/phobos/pull/6174
 aa[std.compiler]=-dip1000
 aa[std.complex]=-dip1000
-aa[std.concurrency]=-dip1000
+aa[std.concurrency]=-dip25
 aa[std.conv]=-dip1000
 aa[std.csv]=-dip1000
 aa[std.demangle]=-dip1000
@@ -168,7 +168,7 @@ aa[std.internal.test.range]=-dip1000
 aa[std.internal.test.uda]=-dip1000
 aa[std.internal.windows.advapi32]=-dip1000
 
-aa[std.net.curl]=-dip1000 # TODO have a look into open https://github.com/dlang/phobos/pull/5052: std.net.curl: fix for -dip1000
+aa[std.net.curl]=-dip25 # TODO have a look into open https://github.com/dlang/phobos/pull/5052: std.net.curl: fix for -dip1000
 aa[std.net.isemail]=-dip1000
 
 aa[std.range.interfaces]=-dip1000


### PR DESCRIPTION
It has been running there for a while.

See also: https://github.com/dlang/ci/pull/259

(CircleCi is intended to be fully retired soon, see e.g. https://github.com/dlang/phobos/pull/6663)