### PR TITLE
[Trivial] std.file: Optimize deleteme a bit

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -118,20 +118,16 @@ else
 // Purposefully not documented. Use at your own risk
 @property string deleteme() @safe
 {
-    import std.conv : to;
+    import std.conv : text;
     import std.path : buildPath;
     import std.process : thisProcessID;
 
-    static _deleteme = "deleteme.dmd.unittest.pid";
-    static _first = true;
+    enum base = "deleteme.dmd.unittest.pid";
+    static string fileName;
 
-    if (_first)
-    {
-        _deleteme = buildPath(tempDir(), _deleteme) ~ to!string(thisProcessID);
-        _first = false;
-    }
-
-    return _deleteme;
+    if (!fileName)
+        fileName = text(buildPath(tempDir(), base), thisProcessID);
+    return fileName;
 }
 
 version (unittest) private struct TestAliasedString


### PR DESCRIPTION
- Remove one unnecessary TLS variable
- Replace std.conv.to + concatenation with std.conv.text to lower the upper bound of allocations