### PR TITLE
Fix Issue 19751 - std.stdio.File should not retry fclose after error

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -557,9 +557,11 @@ Throws: `ErrnoException` in case of error.
         }
         if (_p.handle)
         {
-            errnoEnforce(.fclose(_p.handle) == 0,
-                    "Could not close file `"~_name~"'");
+            auto handle = _p.handle;
             _p.handle = null;
+            // fclose disassociates the FILE* even in case of error (issue 19751)
+            errnoEnforce(.fclose(handle) == 0,
+                    "Could not close file `"~_name~"'");
         }
     }
 


### PR DESCRIPTION
C fclose is allowed to fail, and some libc implementations do cause it to fail. 

For example, reading on a file opened only for writing, or (in Wine's MSVCRT implementation) writing on a file opened only for reading sets an error flag, which then causes fclose to return EOF to signal an error.

However, all descriptions of the function specify that "whether or not the call succeeds, the stream shall be disassociated from the file" and "after the call to fclose(), any use of stream results in undefined behavior" (POSIX) or similar.

Currently, if File.close throws and is called again (e.g. in a destructor), it will retry the fclose call. This is undefined behavior as described above, and may potentially affect an unrelated file.

It also makes it overly difficult to "get rid" of a File instance associated with a FILE with its error flag set - all attempts at destroying it will fail and only be eventually retried.