### PR TITLE
rbtree _add need only return a bool

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -874,9 +874,12 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         }
     }
 
-    // add an element to the tree, returns the node added, or the existing node
-    // if it has already been added and allowDuplicates is false
-    private auto _add(Elem n)
+    /* add an element to the tree, returns the node added, or the existing node
+     * if it has already been added and allowDuplicates is false
+     * Returns:
+     *   true if node was added
+     */
+    private bool _add(Elem n)
     {
         Node result;
         static if (!allowDuplicates)
@@ -937,7 +940,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
             debug(RBDoChecks)
                 check();
             ++_length;
-            return result;
+            return true;
         }
         else
         {
@@ -950,7 +953,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
             }
             debug(RBDoChecks)
                 check();
-            return Tuple!(bool, "added", Node, "n")(added, result);
+            return added;
         }
     }
 
@@ -1257,7 +1260,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         }
         else
         {
-            return(_add(stuff).added ? 1 : 0);
+            return _add(stuff);
         }
     }
 
@@ -1284,8 +1287,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
         {
             foreach (e; stuff)
             {
-                if (_add(e).added)
-                    ++result;
+                result += _add(e);
             }
         }
         return result;


### PR DESCRIPTION
Returning a Node unnecessarily complicates getting it to work with dip1000.