### PR TITLE
A little bit of safety

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -690,7 +690,7 @@ private struct RBRange(N)
      *
      * Complexity: amortized $(BIGOH 1)
      */
-    void popFront()
+    void popFront() @safe
     {
         _begin = _begin.next;
     }


### PR DESCRIPTION
Can't manage to provide reduced case for compiler error (dmd-fe 2.085) sorta `Error: @safe function [snipped].RedBlackTree.toHash cannot call @system function std.container.rbtree.RBRange[snipped].popFront`. This PR fixes the issue.