### PR TITLE
add std.range.primitives.Autodecoding

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -376,7 +376,10 @@ void put(R, E)(ref R r, E e)
         doPut(r, e);
     }
     //Optional optimization block for straight up array to array copy.
-    else static if (isDynamicArray!R && !isNarrowString!R && isDynamicArray!E && is(typeof(r[] = e[])))
+    else static if (isDynamicArray!R &&
+                    !(Autodecoding && isNarrowString!R) &&
+                    isDynamicArray!E &&
+                    is(typeof(r[] = e[])))
     {
         immutable len = e.length;
         r[0 .. len] = e[];
@@ -404,7 +407,7 @@ void put(R, E)(ref R r, E e)
     {
         //Special optimization: If E is a narrow string, and r accepts characters no-wider than the string's
         //Then simply feed the characters 1 by 1.
-        static if (isNarrowString!E && (
+        static if (Autodecoding && isNarrowString!E && (
             (is(E : const  char[]) && is(typeof(doPut(r,  char.max))) && !is(typeof(doPut(r, dchar.max))) &&
                 !is(typeof(doPut(r, wchar.max)))) ||
             (is(E : const wchar[]) && is(typeof(doPut(r, wchar.max))) && !is(typeof(doPut(r, dchar.max)))) ) )
@@ -1077,7 +1080,7 @@ See_Also:
  */
 enum bool isRandomAccessRange(R) =
     is(typeof(lvalueOf!R[1]) == ElementType!R)
-    && !isNarrowString!R
+    && !(Autodecoding && isNarrowString!R)
     && isForwardRange!R
     && (isBidirectionalRange!R || isInfinite!R)
     && (hasLength!R || isInfinite!R)
@@ -1099,7 +1102,7 @@ enum bool isRandomAccessRange(R) =
     auto e = r[1]; // can index
     auto f = r.front;
     static assert(is(typeof(e) == typeof(f))); // same type for indexed and front
-    static assert(!isNarrowString!R); // narrow strings cannot be indexed as ranges
+    static assert(!(Autodecoding && isNarrowString!R)); // narrow strings cannot be indexed as ranges
     static assert(hasLength!R || isInfinite!R); // must have length or be infinite
 
     // $ must work as it does with arrays if opIndex works with $
@@ -1537,7 +1540,8 @@ length, use $(REF representation, std, string) or $(REF byCodeUnit, std, utf).
 template hasLength(R)
 {
     static if (is(typeof(((R* r) => r.length)(null)) Length))
-        enum bool hasLength = is(Length == size_t) && !isNarrowString!R;
+        enum bool hasLength = is(Length == size_t) &&
+                              !(Autodecoding && isNarrowString!R);
     else
         enum bool hasLength = false;
 }
@@ -1648,7 +1652,7 @@ The following expression must be true for `hasSlicing` to be `true`:
 ----
  */
 enum bool hasSlicing(R) = isForwardRange!R
-    && !isNarrowString!R
+    && !(Autodecoding && isNarrowString!R)
     && is(ReturnType!((R r) => r[1 .. 1].length) == size_t)
     && (is(typeof(lvalueOf!R[1 .. 1]) == R) || isInfinite!R)
     && (!is(typeof(lvalueOf!R[0 .. $])) || is(typeof(lvalueOf!R[0 .. $]) == R))
@@ -2214,7 +2218,7 @@ equivalent to `popFront(array)`. For $(GLOSSARY narrow strings),
 point).
 */
 void popFront(T)(scope ref inout(T)[] a) @safe pure nothrow @nogc
-if (!isNarrowString!(T[]) && !is(T[] == void[]))
+if (!(Autodecoding && isNarrowString!(T[])) && !is(T[] == void[]))
 {
     assert(a.length, "Attempting to popFront() past the end of an array of " ~ T.stringof);
     a = a[1 .. $];
@@ -2237,7 +2241,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 
 /// ditto
 void popFront(C)(scope ref inout(C)[] str) @trusted pure nothrow
-if (isNarrowString!(C[]))
+if (Autodecoding && isNarrowString!(C[]))
 {
     import std.algorithm.comparison : min;
 
@@ -2335,7 +2339,7 @@ equivalent to `popBack(array)`. For $(GLOSSARY narrow strings), $(D
 popFront) automatically eliminates the last $(GLOSSARY code point).
 */
 void popBack(T)(scope ref inout(T)[] a) @safe pure nothrow @nogc
-if (!isNarrowString!(T[]) && !is(T[] == void[]))
+if (!(Autodecoding && isNarrowString!(T[])) && !is(T[] == void[]))
 {
     assert(a.length);
     a = a[0 .. $ - 1];
@@ -2358,7 +2362,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 
 /// ditto
 void popBack(T)(scope ref inout(T)[] a) @safe pure
-if (isNarrowString!(T[]))
+if (Autodecoding && isNarrowString!(T[]))
 {
     import std.utf : strideBack;
     assert(a.length, "Attempting to popBack() past the front of an array of " ~ T.stringof);
@@ -2394,6 +2398,12 @@ if (isNarrowString!(T[]))
 }
 
 /**
+Autodecoding is enabled if this is set to true.
+*/
+
+enum Autodecoding = true;
+
+/**
 Implements the range interface primitive `front` for built-in
 arrays. Due to the fact that nonmember functions can be called with
 the first argument using the dot notation, `array.front` is
@@ -2402,7 +2412,7 @@ front) automatically returns the first $(GLOSSARY code point) as _a $(D
 dchar).
 */
 @property ref T front(T)(return scope T[] a) @safe pure nothrow @nogc
-if (!isNarrowString!(T[]) && !is(T[] == void[]))
+if (!(Autodecoding && isNarrowString!(T[])) && !is(T[] == void[]))
 // We would have preferred to write the function template
 // ---
 //     @property ref inout(T) front(T)(return scope inout(T)[] a)
@@ -2438,7 +2448,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 
 /// ditto
 @property dchar front(T)(scope const(T)[] a) @safe pure
-if (isNarrowString!(T[]))
+if (Autodecoding && isNarrowString!(T[]))
 {
     import std.utf : decode;
     assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
@@ -2455,7 +2465,7 @@ back) automatically returns the last $(GLOSSARY code point) as _a $(D
 dchar).
 */
 @property ref inout(T) back(T)(return scope inout(T)[] a) @safe pure nothrow @nogc
-if (!isNarrowString!(T[]) && !is(T[] == void[]))
+if (!(Autodecoding && isNarrowString!(T[])) && !is(T[] == void[]))
 {
     assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
     return a[$ - 1];
@@ -2482,7 +2492,7 @@ if (!isNarrowString!(T[]) && !is(T[] == void[]))
 /// ditto
 // Specialization for strings
 @property dchar back(T)(scope const(T)[] a) @safe pure
-if (isNarrowString!(T[]))
+if (Autodecoding && isNarrowString!(T[]))
 {
     import std.utf : decode, strideBack;
     assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);

--- a/std/traits.d
+++ b/std/traits.d
@@ -6583,7 +6583,12 @@ package template convertToString(T)
  * See Also:
  *      $(LREF isNarrowString)
  */
-enum bool isAutodecodableString(T) = (is(T : const char[]) || is(T : const wchar[])) && !isStaticArray!T;
+template isAutodecodableString(T)
+{
+    import std.range.primitives : Autodecoding;
+
+    enum isAutodecodableString = Autodecoding && (is(T : const char[]) || is(T : const wchar[])) && !isStaticArray!T;
+}
 
 ///
 @safe unittest


### PR DESCRIPTION
Regardless of how we decide how to deal with autodecoding, Phobos' dependencies on autodecoding need to be removed. By manually setting `Autodecoding` to `false`, Phobos can be gone through module by module to remove those dependencies.