### PR TITLE
make `cycle`, `splitter`, `roundRobin`, and `until` compatible with `RefRange`

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -5225,10 +5225,15 @@ private struct SplitterResult(alias isTerminator, Range)
 
     @property typeof(this) save()
     {
+        import std.algorithm.mutation : move;
         auto ret = this;
-        ret._input = _input.save;
+        auto savedInput = _input.save;
+        move(savedInput, ret._input);
         static if (!fullSlicing)
-            ret._next = _next.save;
+        {
+            auto savedNext = _next.save;
+            move(savedNext, ret._next);
+        }
         return ret;
     }
 }
@@ -5324,6 +5329,15 @@ private struct SplitterResult(alias isTerminator, Range)
         ["là", "dove", "terminava", "quella", "valle"]
     ));
     assert(equal(splitter!"a=='本'"("日本語"), ["日", "語"]));
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    import std.range : refRange;
+    auto r = refRange(&["foobar"][0]).splitter!(c => c == 'b');
+    assert(equal!equal(r.save, ["foo", "ar"]));
+    assert(equal!equal(r.save, ["foo", "ar"]));
 }
 
 /++

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4975,8 +4975,10 @@ if (isInputRange!Range)
             ///
             @property Until save()
             {
+                import std.algorithm.mutation : move;
                 Until result = this;
-                result._input     = _input.save;
+                auto saved = _input.save;
+                move(saved, result._input);
                 result._sentinel  = _sentinel;
                 result._openRight = _openRight;
                 result._done      = _done;
@@ -4986,8 +4988,10 @@ if (isInputRange!Range)
             ///
             @property Until save()
             {
+                import std.algorithm.mutation : move;
                 Until result = this;
-                result._input     = _input.save;
+                auto saved = _input.save;
+                move(saved, result._input);
                 result._openRight = _openRight;
                 result._done      = _done;
                 return result;
@@ -5042,4 +5046,20 @@ if (isInputRange!Range)
     import std.algorithm.comparison : among, equal;
     auto s = "hello how\nare you";
     assert(equal(s.until!(c => c.among!('\n', '\r')), "hello how"));
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    import std.range : refRange;
+    {
+        auto r = refRange(&["foobar"][0]).until("bar");
+        assert(equal(r.save, "foo"));
+        assert(equal(r.save, "foo"));
+    }
+    {
+        auto r = refRange(&["foobar"][0]).until!(e => e == 'b');
+        assert(equal(r.save, "foo"));
+        assert(equal(r.save, "foo"));
+    }
 }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1844,10 +1844,12 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
         static if (allSatisfy!(isForwardRange, staticMap!(Unqual, Rs)))
             @property auto save()
             {
+                import std.algorithm.mutation : move;
                 Result result = this;
                 foreach (i, Unused; Rs)
                 {
-                    result.source[i] = result.source[i].save;
+                    auto saved = result.source[i].save;
+                    move(saved, result.source[i]);
                 }
                 return result;
             }
@@ -1905,6 +1907,14 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
     }
 
     assert(interleave([1, 2, 3], 0).equal([1, 0, 2, 0, 3]));
+}
+
+pure @safe unittest
+{
+    import std.algorithm.comparison : equal;
+    auto r = roundRobin(refRange(&["foo"][0]), refRange(&["bar"][0]));
+    assert(equal(r.save, "fboaor"));
+    assert(equal(r.save, "fboaor"));
 }
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3810,10 +3810,12 @@ if (isForwardRange!R && !isInfinite!R)
         /// ditto
         @property Cycle save()
         {
+            import std.algorithm.mutation : move;
             //No need to call _original.save, because Cycle never actually modifies _original
             Cycle ret = this;
             ret._original = _original;
-            ret._current =  _current.save;
+            auto saved =  _current.save;
+            move(saved, _current);
             return ret;
         }
     }
@@ -4124,6 +4126,14 @@ if (isStaticArray!R)
     import core.exception : AssertError;
     import std.exception : assertThrown;
     assertThrown!AssertError(cycle([0, 1, 2][0 .. 0]));
+}
+
+pure @safe unittest // issue 18657
+{
+    import std.algorithm.comparison : equal;
+    auto r = refRange(&["foo"][0]).cycle.take(4);
+    assert(equal(r.save, "foof"));
+    assert(equal(r.save, "foof"));
 }
 
 private alias lengthType(R) = typeof(R.init.length.init);


### PR DESCRIPTION
Part of a series on [issue 18657](https://issues.dlang.org/show_bug.cgi?id=18657). Previously: #6346.
This concludes std.range and std.algorithm.searching. Everything else still needs to be checked.