### PR TITLE
add workaround for slow compilation of large unittest functions

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1194,7 +1194,7 @@ if (isInputRange!R &&
     import std.meta : AliasSeq;
 
     static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    (){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         assert(!endsWith(to!S("abc"), 'a'));
         assert(endsWith(to!S("abc"), 'a', 'c') == 2);
         assert(!endsWith(to!S("abc"), 'x', 'n', 'b'));
@@ -1233,7 +1233,7 @@ if (isInputRange!R &&
             assert(endsWith(to!S("a"), T.init, 'a') == 1);
             assert(endsWith(to!S("a"), 'a', T.init) == 2);
         }
-    }
+    }();
 
     static foreach (T; AliasSeq!(int, short))
     {{
@@ -4775,7 +4775,7 @@ if (isInputRange!R &&
     import std.range;
 
     static foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
-    {
+    (){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         assert(!startsWith(to!S("abc"), 'c'));
         assert(startsWith(to!S("abc"), 'a', 'c') == 1);
         assert(!startsWith(to!S("abc"), 'x', 'n', 'b'));
@@ -4817,7 +4817,7 @@ if (isInputRange!R &&
             assert(startsWith(to!S("a"), T.init, 'a') == 1);
             assert(startsWith(to!S("a"), 'a', T.init) == 2);
         }
-    }
+    }();
 
     //Length but no RA
     assert(!startsWith("abc".takeExactly(3), "abcd".takeExactly(4)));

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10503,7 +10503,7 @@ version (unittest) private void testBadParse822(alias cr)(string str, size_t lin
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    {{
+    {(){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         alias testBad = testBadParse822!cr;
@@ -10741,7 +10741,7 @@ version (unittest) private void testBadParse822(alias cr)(string str, size_t lin
             testBad(cast(string) currStr);
             testBad((cast(string) currStr) ~ "                                    ");
         }
-    }}
+    }();}
 
     static void testScope(scope ref string str) @safe
     {
@@ -10774,7 +10774,7 @@ version (unittest) private void testBadParse822(alias cr)(string str, size_t lin
                            function(string a){return cast(ubyte[]) a;},
                            function(string a){return a;},
                            function(string a){return map!(b => cast(char) b)(a.representation);}))
-    {{
+    {(){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
         {
@@ -10964,7 +10964,7 @@ version (unittest) private void testBadParse822(alias cr)(string str, size_t lin
                 assert(collectExceptionMsg!DateTimeException(parseRFC822DateTime(value)) == tooShortMsg);
             }
         }
-    }}
+    }();}
 }
 
 

--- a/std/random.d
+++ b/std/random.d
@@ -3738,7 +3738,7 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
     const(int)[] a = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ];
 
     foreach (UniformRNG; PseudoRngTypes)
-    {
+    (){ // avoid workaround optimizations for large functions @@@BUG@@@ 2396
         auto rng = UniformRNG(1234);
         /* First test the most general case: randomSample of input range, with and
          * without a specified random number generator.
@@ -4044,5 +4044,5 @@ if (isInputRange!Range && hasLength!Range && isUniformRNG!UniformRNG)
             while (sample!UniformRNG(++n) == fst && n < n.max) {}
             assert(n < n.max);
         }
-    }
+    }();
 }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1332,7 +1332,7 @@ pure @safe nothrow unittest
     // pair of DummyRange types, in either order.
 
     foreach (DummyType1; AllDummyRanges)
-    {
+    (){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         DummyType1 dummy1;
         foreach (DummyType2; AllDummyRanges)
         {
@@ -1369,7 +1369,7 @@ pure @safe nothrow unittest
                 static assert(!hasLvalueElements!(typeof(myChain)));
             }
         }
-    }
+    }();
 }
 
 pure @safe nothrow @nogc unittest

--- a/std/string.d
+++ b/std/string.d
@@ -5249,7 +5249,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
     static foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
                           wchar[], const(wchar)[], immutable(wchar)[],
                           dchar[], const(dchar)[], immutable(dchar)[]))
-    {{
+    {(){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         assert(translate(to!S("hello world"), cast(dchar[dchar])['h' : 'q', 'l' : '5']) ==
                to!S("qe55o wor5d"));
         assert(translate(to!S("hello world"), cast(dchar[dchar])['o' : 'l', 'l' : '\U00010143']) ==
@@ -5263,7 +5263,7 @@ if (isSomeChar!C1 && isSomeChar!C2)
         static foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        {
+        (){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
             static foreach (R; AliasSeq!(dchar[dchar], const dchar[dchar],
                         immutable dchar[dchar]))
             {{
@@ -5275,13 +5275,13 @@ if (isSomeChar!C1 && isSomeChar!C2)
                 assert(translate(to!S("hello world"), tt, to!T("q5"))
                     == to!S("qe55o wor5d"));
             }}
-        }
+        }();
 
         auto s = to!S("hello world");
         dchar[dchar] transTable = ['h' : 'q', 'l' : '5'];
         static assert(is(typeof(s) == typeof(translate(s, transTable))));
         assert(translate(s, transTable) == "qe55o wor5d");
-    }}
+    }();}
     });
 }
 
@@ -5307,7 +5307,7 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
     static foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
                           wchar[], const(wchar)[], immutable(wchar)[],
                           dchar[], const(dchar)[], immutable(dchar)[]))
-    {{
+    {(){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
         assert(translate(to!S("hello world"), ['h' : "yellow", 'l' : "42"]) ==
                to!S("yellowe4242o wor42d"));
         assert(translate(to!S("hello world"), ['o' : "owl", 'l' : "\U00010143\U00010143"]) ==
@@ -5325,7 +5325,7 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
         static foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
                               wchar[], const(wchar)[], immutable(wchar)[],
                               dchar[], const(dchar)[], immutable(dchar)[]))
-        {
+        (){ // workaround slow optimizations for large functions @@@BUG@@@ 2396
 
             static foreach (R; AliasSeq!(string[dchar], const string[dchar],
                         immutable string[dchar]))
@@ -5342,13 +5342,13 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2)
                 assert(translate(to!S("hello world"), tt, to!T("42")) ==
                        to!S("yellowe4242o wor42d"));
             }}
-        }
+        }();
 
         auto s = to!S("hello world");
         string[dchar] transTable = ['h' : "silly", 'l' : "putty"];
         static assert(is(typeof(s) == typeof(translate(s, transTable))));
         assert(translate(s, transTable) == "sillyeputtyputtyo worputtyd");
-    }}
+    }();}
     });
 }
 


### PR DESCRIPTION
This got removed when converting `foreach` over tuple to `static foreach`, but that doesn't make a difference to the slow optimizer.

These changes reduce (single threaded) compile and run time of the phobos unittests from 8min50 to 5min51 for my mobile computer.