### PR TITLE
Revert "make `group`, `chain`, and `choose` compatible with `RefRange`"

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1684,12 +1684,9 @@ if (isInputRange!R)
     static if (isForwardRange!R)
     {
         ///
-        @property typeof(this) save()
-        {
-            import std.algorithm.mutation : move;
+        @property typeof(this) save() {
             typeof(this) ret = this;
-            auto saved = this._input.save;
-            move(saved, ret._input);
+            ret._input = this._input.save;
             ret._current = this._current;
             return ret;
         }
@@ -1808,15 +1805,6 @@ if (isInputRange!R)
     assert(r.equal([ tuple(5, 1u) ]));
     assert(s.equal([ tuple(4, 3u), tuple(5, 1u) ]));
     assert(t.equal([ tuple(3, 1u), tuple(4, 3u), tuple(5, 1u) ]));
-}
-
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    import std.range : refRange;
-    auto r = refRange(&["foo"][0]).group;
-    assert(equal(r.save, "foo".group));
-    assert(equal(r, "foo".group));
 }
 
 // Used by implementation of chunkBy for non-forward input ranges.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -972,12 +972,10 @@ if (Ranges.length > 0 &&
             static if (allSatisfy!(isForwardRange, R))
                 @property auto save()
                 {
-                    import std.algorithm.mutation : move;
                     typeof(this) result = this;
                     foreach (i, Unused; R)
                     {
-                        auto saved = result.source[i].save;
-                        move(saved, result.source[i]);
+                        result.source[i] = result.source[i].save;
                     }
                     return result;
                 }
@@ -1382,14 +1380,6 @@ pure @safe nothrow @nogc unittest
     assert(chain(a, b).empty);
 }
 
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    auto r = refRange(&["foo"][0]).chain("bar");
-    assert(equal(r.save, "foobar"));
-    assert(equal(r, "foobar"));
-}
-
 /**
 Choose one of two ranges at runtime depending on a Boolean condition.
 
@@ -1524,11 +1514,7 @@ private struct ChooseResult(R1, R2)
         @property auto save()
         {
             auto result = this;
-            actOnChosen!((ref r) {
-                import std.algorithm.mutation : move;
-                auto saved = r.save;
-                move(saved, r);
-            })(result);
+            actOnChosen!((ref r) { r = r.save; })(result);
             return result;
         }
 
@@ -1614,14 +1600,6 @@ private struct ChooseResult(R1, R2)
                         return choose(false, Slice1.init, r[begin .. end]);
                 })(this, begin, end);
         }
-}
-
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    auto r = choose(true, refRange(&["foo"][0]), "bar");
-    assert(equal(r.save, "foo"));
-    assert(equal(r, "foo"));
 }
 
 /**


### PR DESCRIPTION
Reverts dlang/phobos#6346

The problem lies with RefRange, not with everything else.