### PR TITLE
Revert "make `cycle`, `splitter`, `roundRobin`, and `until` compatible with `RefRange`"

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -5225,15 +5225,10 @@ private struct SplitterResult(alias isTerminator, Range)
 
     @property typeof(this) save()
     {
-        import std.algorithm.mutation : move;
         auto ret = this;
-        auto savedInput = _input.save;
-        move(savedInput, ret._input);
+        ret._input = _input.save;
         static if (!fullSlicing)
-        {
-            auto savedNext = _next.save;
-            move(savedNext, ret._next);
-        }
+            ret._next = _next.save;
         return ret;
     }
 }
@@ -5329,15 +5324,6 @@ private struct SplitterResult(alias isTerminator, Range)
         ["là", "dove", "terminava", "quella", "valle"]
     ));
     assert(equal(splitter!"a=='本'"("日本語"), ["日", "語"]));
-}
-
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    import std.range : refRange;
-    auto r = refRange(&["foobar"][0]).splitter!(c => c == 'b');
-    assert(equal!equal(r.save, ["foo", "ar"]));
-    assert(equal!equal(r.save, ["foo", "ar"]));
 }
 
 /++

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4983,10 +4983,8 @@ if (isInputRange!Range)
             ///
             @property Until save()
             {
-                import std.algorithm.mutation : move;
                 Until result = this;
-                auto saved = _input.save;
-                move(saved, result._input);
+                result._input     = _input.save;
                 result._sentinel  = _sentinel;
                 result._openRight = _openRight;
                 result._done      = _done;
@@ -4996,10 +4994,8 @@ if (isInputRange!Range)
             ///
             @property Until save()
             {
-                import std.algorithm.mutation : move;
                 Until result = this;
-                auto saved = _input.save;
-                move(saved, result._input);
+                result._input     = _input.save;
                 result._openRight = _openRight;
                 result._done      = _done;
                 return result;
@@ -5054,20 +5050,4 @@ if (isInputRange!Range)
     import std.algorithm.comparison : among, equal;
     auto s = "hello how\nare you";
     assert(equal(s.until!(c => c.among!('\n', '\r')), "hello how"));
-}
-
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    import std.range : refRange;
-    {
-        auto r = refRange(&["foobar"][0]).until("bar");
-        assert(equal(r.save, "foo"));
-        assert(equal(r.save, "foo"));
-    }
-    {
-        auto r = refRange(&["foobar"][0]).until!(e => e == 'b');
-        assert(equal(r.save, "foo"));
-        assert(equal(r.save, "foo"));
-    }
 }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1844,12 +1844,10 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
         static if (allSatisfy!(isForwardRange, staticMap!(Unqual, Rs)))
             @property auto save()
             {
-                import std.algorithm.mutation : move;
                 Result result = this;
                 foreach (i, Unused; Rs)
                 {
-                    auto saved = result.source[i].save;
-                    move(saved, result.source[i]);
+                    result.source[i] = result.source[i].save;
                 }
                 return result;
             }
@@ -1907,14 +1905,6 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
     }
 
     assert(interleave([1, 2, 3], 0).equal([1, 0, 2, 0, 3]));
-}
-
-pure @safe unittest
-{
-    import std.algorithm.comparison : equal;
-    auto r = roundRobin(refRange(&["foo"][0]), refRange(&["bar"][0]));
-    assert(equal(r.save, "fboaor"));
-    assert(equal(r.save, "fboaor"));
 }
 
 /**
@@ -3820,12 +3810,10 @@ if (isForwardRange!R && !isInfinite!R)
         /// ditto
         @property Cycle save()
         {
-            import std.algorithm.mutation : move;
             //No need to call _original.save, because Cycle never actually modifies _original
             Cycle ret = this;
             ret._original = _original;
-            auto saved =  _current.save;
-            move(saved, _current);
+            ret._current =  _current.save;
             return ret;
         }
     }
@@ -4136,14 +4124,6 @@ if (isStaticArray!R)
     import core.exception : AssertError;
     import std.exception : assertThrown;
     assertThrown!AssertError(cycle([0, 1, 2][0 .. 0]));
-}
-
-pure @safe unittest // issue 18657
-{
-    import std.algorithm.comparison : equal;
-    auto r = refRange(&["foo"][0]).cycle.take(4);
-    assert(equal(r.save, "foof"));
-    assert(equal(r.save, "foof"));
 }
 
 private alias lengthType(R) = typeof(R.init.length.init);


### PR DESCRIPTION
Reverts dlang/phobos#6935

RefRange is the problem, not everything else.