### PR TITLE
std/net/curl.d: Don't call exit in non-main thread

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -203,9 +203,7 @@ version (unittest)
             }
             catch (Throwable e)
             {
-                import core.stdc.stdlib : exit, EXIT_FAILURE;
-                stderr.writeln(e);
-                exit(EXIT_FAILURE); // Bugzilla 7018
+                stderr.writeln(e);  // Bugzilla 7018
             }
         }
     }


### PR DESCRIPTION
Handling bugzilla 7018 is still valid here, however exiting immediately will cause _d_dso_registry to unregister in the wrong thread.

Just returning gracefully from the loop won't cause the testsuite to hang, checked on host without libcurl installed for both native and multilib (-m32 and -mx32).