### PR TITLE
Fix issue 19797 - Ungraceful termination in File.seek() on Windows

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1071,7 +1071,17 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
 
 /**
 Calls $(HTTP cplusplus.com/reference/clibrary/cstdio/fseek.html, fseek)
-for the file handle.
+for the file handle to move its position indicator.
+
+Params:
+    offset = Binary files: Number of bytes to offset from origin.$(BR)
+             Text files: Either zero, or a value returned by $(LREF tell).
+    origin = Binary files: Position used as reference for the offset, must be
+             one of $(REF_ALTTEXT SEEK_SET, SEEK_SET, core,stdc,stdio),
+             $(REF_ALTTEXT SEEK_CUR, SEEK_CUR, core,stdc,stdio) or
+             $(REF_ALTTEXT SEEK_END, SEEK_END, core,stdc,stdio).$(BR)
+             Text files: Shall necessarily be
+             $(REF_ALTTEXT SEEK_SET, SEEK_SET, core,stdc,stdio).
 
 Throws: `Exception` if the file is not opened.
         `ErrnoException` if the call to `fseek` fails.
@@ -1088,6 +1098,9 @@ Throws: `Exception` if the file is not opened.
             {
                 alias fseekFun = _fseeki64;
                 alias off_t = long;
+                // Issue 19797
+                enforce(origin >= SEEK_SET && origin <= SEEK_END,
+                        "Could not seek in file `"~_name~"' (Invalid argument)");
             }
             else
             {
@@ -1108,6 +1121,7 @@ Throws: `Exception` if the file is not opened.
     {
         import std.conv : text;
         static import std.file;
+        import std.exception;
 
         auto deleteme = testFilename();
         auto f = File(deleteme, "w+");
@@ -1130,6 +1144,7 @@ Throws: `Exception` if the file is not opened.
         // f.rawWrite("abcdefghijklmnopqrstuvwxyz");
         // f.seek(-3, SEEK_END);
         // assert(f.readln() == "xyz");
+        assertThrown(f.seek(0, 3));
     }
 
 /**


### PR DESCRIPTION
Context: https://forum.dlang.org/post/mqzblhbrweydjlcjdppj@forum.dlang.org 

1. Extra parameter validation when compiling for `CRuntime_Microsoft` to prevent ungraceful process termination. Fixes issue 19797. This is a workaround for what looks like a bug in Microsoft's `_fseeki64`.
2. Improved documentation.
