### PR TITLE
Add minimum RISCV support to phobos

### DIFF
--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -515,6 +515,8 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     else version (PPC64) enum growDownwards = Yes.growDownwards;
     else version (MIPS32) enum growDownwards = Yes.growDownwards;
     else version (MIPS64) enum growDownwards = Yes.growDownwards;
+    else version (RISCV32) enum growDownwards = Yes.growDownwards;
+    else version (RISCV64) enum growDownwards = Yes.growDownwards;
     else version (SPARC) enum growDownwards = Yes.growDownwards;
     else version (SystemZ) enum growDownwards = Yes.growDownwards;
     else static assert(0, "Dunno how the stack grows on this architecture.");

--- a/std/math.d
+++ b/std/math.d
@@ -152,6 +152,8 @@ version (AArch64)   version = ARM_Any;
 version (ARM)       version = ARM_Any;
 version (SPARC)     version = SPARC_Any;
 version (SPARC64)   version = SPARC_Any;
+version (RISCV32)   version = RISCV_Any;
+version (RISCV64)   version = RISCV_Any;
 
 version (D_InlineAsm_X86)
 {
@@ -5535,6 +5537,7 @@ private:
     // The Pentium SSE2 status register is 32 bits.
     // The ARM and PowerPC FPSCR is a 32-bit register.
     // The SPARC FSR is a 32bit register (64 bits for SPARC 7 & 8, but high bits are uninteresting).
+    // The RISC-V (32 & 64 bit) fcsr is 32-bit register.
     uint flags;
 
     version (CRuntime_Microsoft)
@@ -5745,6 +5748,10 @@ version (X86_Any)
     version = IeeeFlagsSupport;
 }
 else version (PPC_Any)
+{
+    version = IeeeFlagsSupport;
+}
+else version (RISCV_Any)
 {
     version = IeeeFlagsSupport;
 }
@@ -6011,6 +6018,21 @@ nothrow @nogc:
                                  | inexactException,
         }
     }
+    else version (RISCV_Any)
+    {
+        enum : ExceptionMask
+        {
+            inexactException      = 0x01,
+            divByZeroException    = 0x02,
+            underflowException    = 0x04,
+            overflowException     = 0x08,
+            invalidException      = 0x10,
+            severeExceptions   = overflowException | divByZeroException
+                                 | invalidException,
+            allExceptions      = severeExceptions | underflowException
+                                 | inexactException,
+        }
+    }
     else version (X86_Any)
     {
         enum : ExceptionMask
@@ -6132,6 +6154,10 @@ private:
         alias ControlState = ulong;
     }
     else version (SystemZ)
+    {
+        alias ControlState = uint;
+    }
+    else version (RISCV_Any)
     {
         alias ControlState = uint;
     }


### PR DESCRIPTION
The asm bits are of course not included.