### PR TITLE
Comment broken test in std/traits.d

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8408,7 +8408,10 @@ template getSymbolsByUDA(alias symbol, alias attribute)
     import std.internal.test.uda : Attr, HasPrivateMembers;
     // Trying access to private member from another file therefore we do not have access
     // for this otherwise we get deprecation warning - not visible from module
-    static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
+    // This line is commented because `__traits(getMember)` should also consider
+    // private members; this is not currently the case, but the PR that
+    // fixes `__traits(getMember)` is blocked by this specific test.
+    //static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
     static assert(hasUDA!(getSymbolsByUDA!(HasPrivateMembers, Attr)[0], Attr));
 }
 


### PR DESCRIPTION
This currently blocks: https://github.com/dlang/dmd/pull/9585 . The test can be uncommented and fixed after the dmd PR is pulled