### PR TITLE
bugzilla issue 4391 add curry to std.functional 

### DIFF
--- a/changelog/std-functional-curry.dd
+++ b/changelog/std-functional-curry.dd
@@ -1,0 +1,5 @@
+Added curry to std.functional
+
+Converts a function of multiple parameters to a function of 1 parameter that
+returns a function of 1 parameter... until it runs out of parameters and
+evaluates the function.  Essentially:  f(x, y, z) == curry(f)(x)(y)(z)

--- a/std/functional.d
+++ b/std/functional.d
@@ -871,7 +871,8 @@ Params:
 Returns:
     A single parameter callable object
 */
-template curry(alias F) if (isCallable!F && Parameters!F.length)
+template curry(alias F)
+if (isCallable!F && Parameters!F.length)
 {
     //inspired from the implementation from Artur Skawina here:
     //https://forum.dlang.org/post/mailman.1626.1340110492.24740.digitalmars-d@puremagic.com
@@ -927,7 +928,8 @@ pure @safe @nogc nothrow unittest
 }
 
 ///ditto
-auto curry(T)(T t) if (isCallable!T && Parameters!T.length)
+auto curry(T)(T t)
+if (isCallable!T && Parameters!T.length)
 {
     static auto fun(ref T inst, ref Parameters!T args)
     {


### PR DESCRIPTION

I wasn't sure the best way to add template constraints to make sure that things without state (e.g. functions) use the alias template version and things with state (callable objects) use the type template version.  LMK how best to go about that.

This addresses bugzilla issue 4391