### PR TITLE
Make the symlink for phobos soname

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -451,7 +451,8 @@ install2 : all
 	cp $(LIB) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 ifeq (1,$(SHARED))
 	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
-	ln -sf $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
+	cp -P $(ROOT)/$(SONAME) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
+	cp -P $(ROOT)/libphobos2.so $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 endif
 	mkdir -p $(INSTALL_DIR)/src/phobos/etc
 	mkdir -p $(INSTALL_DIR)/src/phobos/std


### PR DESCRIPTION
We must have a symlink to the soname because
otherwise it is problematic to link the shared
library.

Before this patch to distribute phobos it was
necessary to manually create the symlink
(e.g. https://github.com/dlang/installer/blob/482840bf5bd8e94ebb12aabaa7ddb0dac319be90/linux/dmd_phobos.sh#L169),
this was a really uncomfortable and confusing solution
for external package maintainers.

This symlink was actually already created in the
phobos build phase but for some reason unknown to
me was not copied into the installation target.

I also noticed that the libphobos2.so symlink is
already created, so I simply removed the redundant
symlink creation with a simple copy from generated/$(OS)/$(BUILD)/$(MODEL)

Signed-off-by: Ernesto Castellotti <erny.castell@gmail.com>