### PR TITLE
logger: write thread id as part of log message

### DIFF
--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -19,7 +19,7 @@ is already present new log messages will be append at its end.
 */
 class FileLogger : Logger
 {
-    import std.concurrency : Tid;
+    import core.thread : ThreadID;
     import std.datetime.systime : SysTime;
     import std.format : formattedWrite;
 
@@ -122,7 +122,7 @@ class FileLogger : Logger
     */
     override protected void beginLogMsg(string file, int line, string funcName,
         string prettyFuncName, string moduleName, LogLevel logLevel,
-        Tid threadId, SysTime timestamp, Logger logger)
+        ThreadID threadId, SysTime timestamp, Logger logger)
         @safe
     {
         import std.string : lastIndexOf;
@@ -132,7 +132,7 @@ class FileLogger : Logger
         auto lt = this.file_.lockingTextWriter();
         systimeToISOString(lt, timestamp);
         import std.conv : to;
-        formattedWrite(lt, " [%s] %s:%u:%s ", logLevel.to!string,
+        formattedWrite(lt, " %s %s %s:%u:%s ", threadId, logLevel.to!string,
                 file[fnIdx .. $], line, funcName[funIdx .. $]);
     }
 


### PR DESCRIPTION
Previous implementation had `std.concurrency.Tid`, which is simply a
wrapper around MessageBox and is not related to Thread ID in anyway.
It cannot be used in @safe code.

Instead this patch uses `core.thread.ThreadID`. It requires `this` and
it also locks mutex for every call. This patch caches the result in a
TLS to prevent unnecessary synchronization overhead.