### PR TITLE
[GDC] GCC9 last-minute fix: MinGW changes to get phobos to build

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -164,6 +164,12 @@ else version (D_InlineAsm_X86_64)
     version = InlineAsm_X86_Any;
 }
 
+version (CRuntime_Microsoft)
+{
+    version (InlineAsm_X86_Any)
+        version = MSVC_InlineAsm;
+}
+
 version (X86_64) version = StaticallyHaveSSE;
 version (X86) version (OSX) version = StaticallyHaveSSE;
 
@@ -4387,7 +4393,7 @@ real logb(real x) @trusted nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         asm pure nothrow @nogc
         {
@@ -4728,7 +4734,7 @@ real ceil(real x) @trusted pure nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc
@@ -4856,7 +4862,7 @@ real floor(real x) @trusted pure nothrow @nogc
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc
@@ -5420,7 +5426,7 @@ real trunc(real x) @trusted nothrow @nogc pure
             ret                         ;
         }
     }
-    else version (CRuntime_Microsoft)
+    else version (MSVC_InlineAsm)
     {
         short cw;
         asm pure nothrow @nogc


### PR DESCRIPTION
This should hopefully contain only uncontroversial changes required to build phobos for MinGW. We have to hurry a bit to get this still into GCC-9, as that will likely be released next friday.

Related druntime PR: https://github.com/dlang/druntime/pull/2586
Related GDC PR: https://github.com/D-Programming-GDC/gcc/pull/14

ping @ibuclaw @redstar 