### PR TITLE
fix Issue 19777 - SortedRange.opSlice should infer safety

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1170,7 +1170,7 @@ if (Ranges.length > 0 &&
             }
 
             static if (allSatisfy!(hasLength, R) && allSatisfy!(hasSlicing, R))
-                auto opSlice(size_t begin, size_t end)
+                auto opSlice(size_t begin, size_t end) return scope
                 {
                     auto result = this;
                     foreach (i, Unused; R)
@@ -10661,7 +10661,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
 
     /// Ditto
     static if (hasSlicing!Range)
-        auto opSlice(size_t a, size_t b) return scope @trusted
+        auto opSlice(size_t a, size_t b) return scope
         {
             assert(
                 a <= b,


### PR DESCRIPTION
- unittests did fail with DIP1000 due to missing return scope
  inference in chained range, thus leading to a scope violation
  which prevented `@safe` inference
- fixed unittests by adding return scope to chain.Result
- would still fail under dip1000 with other ranges that
  miss return scope on their opSlice
- should not have any effect on non-DIP1000 usage