### PR TITLE
std.mmfile: MAP_ANON is only defined in core.sys.posix.sys.mman

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -335,7 +335,6 @@ class MmFile
             else
             {
                 fd = -1;
-                version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
                 flags |= MAP_ANON;
             }
             this.size = size;


### PR DESCRIPTION
Not to mention that CRuntime_Glibc wrongly assumes that it is synonymous with linux.