### PR TITLE
Fix Issue 6657 - dotProduct overload for small fixed size arrays

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1774,6 +1774,24 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
     return sum0;
 }
 
+/// ditto
+F dotProduct(F, uint N)(const ref scope F[N] a, const ref scope F[N] b)
+if (N <= 16)
+{
+    F sum0 = 0;
+    F sum1 = 0;
+    static foreach (i; 0 .. N / 2)
+    {
+        sum0 += a[i*2] * b[i*2];
+        sum1 += a[i*2+1] * b[i*2+1];
+    }
+    static if (N % 2 == 1)
+    {
+        sum0 += a[N-1] * b[N-1];
+    }
+    return sum0 + sum1;
+}
+
 @system unittest
 {
     // @system due to dotProduct and assertCTFEable
@@ -1785,6 +1803,13 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
         T[] b = [ 4.0, 6.0, ];
         assert(dotProduct(a, b) == 16);
         assert(dotProduct([1, 3, -5], [4, -2, -1]) == 3);
+        // Test with fixed-length arrays.
+        T[2] c = [ 1.0, 2.0, ];
+        T[2] d = [ 4.0, 6.0, ];
+        assert(dotProduct(c, d) == 16);
+        T[3] e = [1,  3, -5];
+        T[3] f = [4, -2, -1];
+        assert(dotProduct(e, f) == 3);
     }}
 
     // Make sure the unrolled loop codepath gets tested.


### PR DESCRIPTION
Benchmark using DMD, 10 million trials:

| version | arg type  | compiler | time (ms) |
|---------|-----------|----------|-----------|
| old     | float[3]  | dmd -O   | 118.503   |
| new     | float[3]  | dmd -O   |  64.535   |
| old     | float[4]  | dmd -O   | 120.456   |
| new     | float[4]  | dmd -O   |  74.575   |
| old     | float[5]  | dmd -O   | 141.211   |
| new     | float[5]  | dmd -O   |  99.659   |
| old     | float[6]  | dmd -O   | 151.537   |
| new     | float[6]  | dmd -O   | 107.559   |
| old     | float[7]  | dmd -O   | 192.009   |
| new     | float[7]  | dmd -O   | 137.358   |
| old     | float[8]  | dmd -O   | 176.876   |
| new     | float[8]  | dmd -O   | 147.655   |
| old     | float[9]  | dmd -O   | 200.092   |
| new     | float[9]  | dmd -O   | 167.429   |
| old     | float[16] | dmd -O   | 318.174   |
| new     | float[16] | dmd -O   | 288.255   |

Benchmark using LDC, 10 million trials:

| version | arg type  | compiler | time (ms) |
|---------|-----------|----------|-----------|
| old     | float[3]  | ldc -O2  |  55.215   |
| new     | float[3]  | ldc -O2  |  17.219   |
| old     | float[4]  | ldc -O2  |  35.801   |
| new     | float[4]  | ldc -O2  |  20.170   |
| old     | float[5]  | ldc -O2  |  53.151   |
| new     | float[5]  | ldc -O2  |  20.194   |
| old     | float[6]  | ldc -O2  |  62.134   |
| new     | float[6]  | ldc -O2  |  26.126   |
| old     | float[7]  | ldc -O2  |  67.609   |
| new     | float[7]  | ldc -O2  |  26.335   |
| old     | float[8]  | ldc -O2  |  47.428   |
| new     | float[8]  | ldc -O2  |  25.960   |
| old     | float[9]  | ldc -O2  |  66.051   |
| new     | float[9]  | ldc -O2  |  29.275   |
| old     | float[16] | ldc -O2  |  73.301   |
| new     | float[16] | ldc -O2  |  45.106   |