### PR TITLE
Issue 19836 followup - also fix on 32 bit machines

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1813,8 +1813,8 @@ A singleton instance of the default random number generator
     {
         static if (isSeedable!(Random, ulong))
             result.seed(unpredictableSeed!ulong); // Avoid unnecessary copy.
-        else static if (size_t.sizeof >= ulong.sizeof && is(Random : MersenneTwisterEngine!Params, Params...))
-            initMTEngine(result); // 64-bit multiplication is fast, so use a 64-bit seed.
+        else static if (is(Random : MersenneTwisterEngine!Params, Params...))
+            initMTEngine(result);
         else static if (isSeedable!(Random, uint))
             result.seed(unpredictableSeed!uint); // Avoid unnecessary copy.
         else
@@ -1842,23 +1842,36 @@ private void initMTEngine(MTEngine)(scope ref MTEngine mt)
 if (is(MTEngine : MersenneTwisterEngine!Params, Params...))
 {
     pragma(inline, false); // Called no more than once per thread by rndGen.
-    ulong x = unpredictableSeed!ulong;
-    alias UIntType = typeof(mt.front());
-    foreach (size_t i, ref e; mt.state.data)
+    ulong seed = unpredictableSeed!ulong;
+    static if (is(typeof(mt.seed(seed))))
     {
-        x = (x ^ (x >> 62)) * 6_364_136_223_846_793_005UL + i;
-        e = cast(UIntType) x;
-        static if (MTEngine.max != UIntType.max)
-        {
-            e &= MTEngine.max;
-        }
+        mt.seed(seed);
     }
-    mt.state.index = mt.state.data.length - 1;
-    // double popFront() to guarantee both `mt.state.z`
-    // and `mt.state.front` are derived from the newly
-    // set values in `mt.state.data`.
-    mt.popFront();
-    mt.popFront();
+    else
+    {
+        alias UIntType = typeof(mt.front());
+        if (seed == 0) seed = -1; // Any number but 0 is fine.
+        uint s0 = cast(uint) seed;
+        uint s1 = cast(uint) (seed >> 32);
+        foreach (ref e; mt.state.data)
+        {
+            //http://xoshiro.di.unimi.it/xoroshiro64starstar.c
+            const tmp = s0 * 0x9E3779BB;
+            e = ((tmp << 5) | (tmp >> (32 - 5))) * 5;
+            static if (MTEngine.max != UIntType.max) { e &= MTEngine.max; }
+
+            const tmp1 = s0 ^ s1;
+            s0 = ((s0 << 26) | (s0 >> (32 - 26))) ^ tmp1 ^ (tmp1 << 9);
+            s1 = (tmp1 << 13) | (tmp1 >> (32 - 13));
+        }
+
+        mt.state.index = mt.state.data.length - 1;
+        // double popFront() to guarantee both `mt.state.z`
+        // and `mt.state.front` are derived from the newly
+        // set values in `mt.state.data`.
+        mt.popFront();
+        mt.popFront();
+    }
 }
 
 /**


### PR DESCRIPTION
Changed the private enhanced seeding method for `rndGen` to something that is fast on both 64 bit and 32 bit machines so can be enabled regardless of architecture. When compiled with LDC it is about 1.35x the speed of public `Mt19937.seed(uint)`.