### PR TITLE
Fixed Issue 13965 - More handy schwartzSort

### DIFF
--- a/changelog/new_schwartzSort_overload.dd
+++ b/changelog/new_schwartzSort_overload.dd
@@ -1,0 +1,12 @@
+Add overload `std.algorithm.sorting.schwartzSort!(alias transform, SwapStrategy ss, R)`
+
+$(REF schwartzSort, std,algorithm,sorting) now has an overloaded version that can be
+used to provide a `SwapStrategy` without also explicitly specifying the predicate to
+sort by.
+
+-------
+auto s1 = a.schwartzSort!(abs, SwapStrategy.stable);
+
+// The old syntax still works.
+auto s2 = a.schwartzSort!(abs, "a < b", SwapStrategy.stable);
+-------

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -3035,6 +3035,28 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
     schwartzSort!("a[0]", SwapStrategy.stable)(chars);
 }
 
+@safe unittest
+{
+    // issue 13965
+    import std.algorithm.iteration : map;
+    import std.numeric : entropy;
+
+    auto lowEnt = [ 1.0, 0, 0 ],
+        midEnt = [ 0.1, 0.1, 0.8 ],
+        highEnt = [ 0.31, 0.29, 0.4 ];
+    auto arr = new double[][3];
+    arr[0] = midEnt;
+    arr[1] = lowEnt;
+    arr[2] = highEnt;
+
+    schwartzSort!(entropy, SwapStrategy.stable)(arr);
+
+    assert(arr[0] == lowEnt);
+    assert(arr[1] == midEnt);
+    assert(arr[2] == highEnt);
+    assert(isSorted!("a < b")(map!(entropy)(arr)));
+}
+
 // partialSort
 /**
 Reorders the random-access range `r` such that the range `r[0 .. mid]`

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2910,7 +2910,8 @@ SortedRange!(R, ((a, b) => binaryFun!less(unaryFun!transform(a),
                                           unaryFun!transform(b))))
 schwartzSort(alias transform, alias less = "a < b",
         SwapStrategy ss = SwapStrategy.unstable, R)(R r)
-if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
+if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R &&
+    !is(typeof(binaryFun!less) == SwapStrategy))
 {
     import std.conv : emplace;
     import std.range : zip, SortedRange;
@@ -2958,6 +2959,13 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
     }
     zip(xform, r).sort!((a, b) => binaryFun!less(a[0], b[0]), ss)();
     return typeof(return)(r);
+}
+
+/// ditto
+auto schwartzSort(alias transform, SwapStrategy ss, R)(R r)
+if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
+{
+    return schwartzSort!(transform, "a < b", ss, R)(r);
 }
 
 ///
@@ -3017,6 +3025,14 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
     import std.typecons : Tuple;
     Tuple!(char)[] chars;
     schwartzSort!((Tuple!(char) c){ return c[0]; })(chars);
+}
+
+@safe unittest
+{
+    // issue 13965
+    import std.typecons : Tuple;
+    Tuple!(char)[] chars;
+    schwartzSort!("a[0]", SwapStrategy.stable)(chars);
 }
 
 // partialSort


### PR DESCRIPTION
The goal is to be able to specify a `SwapStrategy` without also explicitly specifying the predicate to sort by (see example in the ticket, changelog, or the test I added).