### PR TITLE
Fix issues arising from the DMD 9029 fix (types match to alias)

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -4076,7 +4076,7 @@ if (isOctalLiteral(num))
 
 /// Ditto
 template octal(alias decimalInteger)
-if (isIntegral!(typeof(decimalInteger)))
+if (is(typeof(decimalInteger)) && isIntegral!(typeof(decimalInteger)))
 {
     enum octal = octal!(typeof(decimalInteger))(to!string(decimalInteger));
 }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5022,10 +5022,11 @@ package template OverloadSet(string nam, T...)
 /*
 Used by MemberFunctionGenerator.
  */
-package template FuncInfo(alias func, /+[BUG 4217 ?]+/ T = typeof(&func))
+package template FuncInfo(alias func)
+if (is(typeof(&func)))
 {
-    alias RT = ReturnType!T;
-    alias PT = Parameters!T;
+    alias RT = ReturnType!(typeof(&func));
+    alias PT = Parameters!(typeof(&func));
 }
 package template FuncInfo(Func)
 {


### PR DESCRIPTION
This PR represents two minor upfront fixes to make the DMD 9029 fix pass. (With 9029, primitive types can be passed to alias parameters same as named types.)