### PR TITLE
Add `powmod()` for BigInt operands.

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1949,7 +1949,7 @@ BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow
 }
 
 /// for powmod
-@system unittest
+@system pure nothrow unittest
 {
     BigInt base = BigInt("123456789012345678901234567890");
     BigInt exponent = BigInt("1234567890123456789012345678901234567");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1920,3 +1920,41 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
         "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" ~
         "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
 }
+
+/**
+Fast power modulus calculation for $(LREF BigInt) operands.
+Params:
+     base = the $(LREF BigInt) is basic operands.
+     exponent = the $(LREF BigInt) is power exponent of base.
+     modulus = the $(LREF BigInt) is modules to be modular of base ^ exponent.
+Returns:
+     The power modulus value of (base ^ exponent) % modulus.
+*/
+BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow
+{
+    BigInt result = 1;
+
+    while (exponent)
+    {
+        if (exponent & 1)
+        {
+            result = (result * base) % modulus;
+        }
+
+        base = ((base % modulus) * (base % modulus)) % modulus;
+        exponent >>= 1;
+    }
+
+    return result;
+}
+
+/// for powmod
+@system unittest
+{
+    BigInt base = BigInt("123456789012345678901234567890");
+    BigInt exponent = BigInt("1234567890123456789012345678901234567");
+    BigInt modulus = BigInt("1234567");
+
+    BigInt result = powmod(base, exponent, modulus);
+    assert(result == 359079);
+}

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1949,7 +1949,7 @@ BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow
 }
 
 /// for powmod
-@system pure nothrow unittest
+@system pure unittest
 {
     BigInt base = BigInt("123456789012345678901234567890");
     BigInt exponent = BigInt("1234567890123456789012345678901234567");


### PR DESCRIPTION
Add fast power modulus `powmod()` for BigInt operands.