### PR TITLE
Faster isNaN test

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6360,41 +6360,55 @@ version (D_HardFloat) @safe unittest // rounding
 bool isNaN(X)(X x) @nogc @trusted pure nothrow
 if (isFloatingPoint!(X))
 {
-    alias F = floatTraits!(X);
-    static if (F.realFormat == RealFormat.ieeeSingle)
+    version (all)
     {
-        const uint p = *cast(uint *)&x;
-        // Sign bit (MSB) is irrelevant so mask it out.
-        // Next 8 bits should be all set.
-        // At least one bit among the least significant 23 bits should be set.
-        return (p & 0x7FFF_FFFF) > 0x7F80_0000;
-    }
-    else static if (F.realFormat == RealFormat.ieeeDouble)
-    {
-        const ulong  p = *cast(ulong *)&x;
-        // Sign bit (MSB) is irrelevant so mask it out.
-        // Next 11 bits should be all set.
-        // At least one bit among the least significant 52 bits should be set.
-        return (p & 0x7FFF_FFFF_FFFF_FFFF) > 0x7FF0_0000_0000_0000;
-    }
-    else static if (F.realFormat == RealFormat.ieeeExtended)
-    {
-        const ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
-        const ulong ps = *cast(ulong *)&x;
-        return e == F.EXPMASK &&
-            ps & 0x7FFF_FFFF_FFFF_FFFF; // not infinity
-    }
-    else static if (F.realFormat == RealFormat.ieeeQuadruple)
-    {
-        const ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
-        const ulong psLsb = (cast(ulong *)&x)[MANTISSA_LSB];
-        const ulong psMsb = (cast(ulong *)&x)[MANTISSA_MSB];
-        return e == F.EXPMASK &&
-            (psLsb | (psMsb& 0x0000_FFFF_FFFF_FFFF)) != 0;
+        return x != x;
     }
     else
     {
-        return x != x;
+        /*
+        Code kept for historical context. At least on Intel, the simple test
+        x != x uses one dedicated instruction (ucomiss/ucomisd) that runs in one
+        cycle. Code for 80- and 128-bits is larger but still smaller than the
+        integrals-based solutions below. Future revisions may enable the code
+        below conditionally depending on hardware.
+        */
+        alias F = floatTraits!(X);
+        static if (F.realFormat == RealFormat.ieeeSingle)
+        {
+            const uint p = *cast(uint *)&x;
+            // Sign bit (MSB) is irrelevant so mask it out.
+            // Next 8 bits should be all set.
+            // At least one bit among the least significant 23 bits should be set.
+            return (p & 0x7FFF_FFFF) > 0x7F80_0000;
+        }
+        else static if (F.realFormat == RealFormat.ieeeDouble)
+        {
+            const ulong  p = *cast(ulong *)&x;
+            // Sign bit (MSB) is irrelevant so mask it out.
+            // Next 11 bits should be all set.
+            // At least one bit among the least significant 52 bits should be set.
+            return (p & 0x7FFF_FFFF_FFFF_FFFF) > 0x7FF0_0000_0000_0000;
+        }
+        else static if (F.realFormat == RealFormat.ieeeExtended)
+        {
+            const ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
+            const ulong ps = *cast(ulong *)&x;
+            return e == F.EXPMASK &&
+                ps & 0x7FFF_FFFF_FFFF_FFFF; // not infinity
+        }
+        else static if (F.realFormat == RealFormat.ieeeQuadruple)
+        {
+            const ushort e = F.EXPMASK & (cast(ushort *)&x)[F.EXPPOS_SHORT];
+            const ulong psLsb = (cast(ulong *)&x)[MANTISSA_LSB];
+            const ulong psMsb = (cast(ulong *)&x)[MANTISSA_MSB];
+            return e == F.EXPMASK &&
+                (psLsb | (psMsb& 0x0000_FFFF_FFFF_FFFF)) != 0;
+        }
+        else
+        {
+            return x != x;
+        }
     }
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -6364,14 +6364,18 @@ if (isFloatingPoint!(X))
     static if (F.realFormat == RealFormat.ieeeSingle)
     {
         const uint p = *cast(uint *)&x;
-        return ((p & 0x7F80_0000) == 0x7F80_0000)
-            && p & 0x007F_FFFF; // not infinity
+        // Sign bit (MSB) is irrelevant so mask it out.
+        // Next 8 bits should be all set.
+        // At least one bit among the least significant 23 bits should be set.
+        return (p & 0x7FFF_FFFF) > 0x7F80_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeDouble)
     {
         const ulong  p = *cast(ulong *)&x;
-        return ((p & 0x7FF0_0000_0000_0000) == 0x7FF0_0000_0000_0000)
-            && p & 0x000F_FFFF_FFFF_FFFF; // not infinity
+        // Sign bit (MSB) is irrelevant so mask it out.
+        // Next 11 bits should be all set.
+        // At least one bit among the least significant 52 bits should be set.
+        return (p & 0x7FFF_FFFF_FFFF_FFFF) > 0x7FF0_0000_0000_0000;
     }
     else static if (F.realFormat == RealFormat.ieeeExtended)
     {


### PR DESCRIPTION
To test that at least one bit in the mantissa is set, it's faster to just test for inequality instead of one more masking and an AND.