### PR TITLE
add isLvalue() to prepare for rvalue ref

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -443,7 +443,7 @@ struct Task(alias fun, Args...)
         {
             fun(myCastedTask._args);
         }
-        else static if (is(typeof(addressOf(fun(myCastedTask._args)))))
+        else static if (is(typeof(&(fun(myCastedTask._args)))))
         {
             myCastedTask.returnVal = addressOf(fun(myCastedTask._args));
         }


### PR DESCRIPTION
Necessary because with the change an rvalue can be an argument to a ref parameter.