### PR TITLE
Explicitly link to pthread

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -112,6 +112,7 @@ OUTFILEFLAG = -o
 NODEFAULTLIB=-defaultlib= -debuglib=
 ifeq (,$(findstring win,$(OS)))
 	CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+	NODEFAULTLIB += -L-lpthread
 	ifeq ($(BUILD),debug)
 		CFLAGS += -g
 	else


### PR DESCRIPTION
Currently, phobos is using `-defaultlib=` to build itself, but is implicitly relying on its library dependencies to be added by dmd.

This change makes the phobos library dependencies explicit rather than relying on its dependencies to be hardcoded into the compiler, which in turn forces all D programs to link to those libraries as well.

This change is required to allow https://github.com/dlang/dmd/pull/9831 to be merged, which removes these implicit libraries from being linked to ALL D programs that use DMD to link.