### PR TITLE
Use selective top-level module imports in std.{base64,csv,datetime}

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -57,9 +57,10 @@
  */
 module std.base64;
 
-import std.exception;  // enforce
-import std.range.primitives;      // isInputRange, isOutputRange, isForwardRange, ElementType, hasLength
-import std.traits;     // isArray
+import std.exception : enforce;
+import std.range.primitives : empty, front, isInputRange, isOutputRange,
+    isForwardRange, ElementType, hasLength, popFront, put, save;
+import std.traits : isArray;
 
 // Make sure module header code examples work correctly.
 @safe unittest
@@ -1764,6 +1765,7 @@ class Base64Exception : Exception
     import std.algorithm.comparison : equal;
     import std.algorithm.sorting : sort;
     import std.conv;
+    import std.exception : assertThrown;
     import std.file;
     import std.stdio;
 

--- a/std/csv.d
+++ b/std/csv.d
@@ -92,7 +92,7 @@
 module std.csv;
 
 import std.conv;
-import std.exception;  // basicExceptionCtors
+import std.exception : basicExceptionCtors;
 import std.range.primitives;
 import std.traits;
 

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -40,9 +40,7 @@ $(TR $(TD Other) $(TD
 +/
 module std.datetime.date;
 
-// Note: reconsider using specific imports below after
-// https://issues.dlang.org/show_bug.cgi?id=17630 has been fixed
-import core.time;// : TimeException;
+import core.time : TimeException;
 import std.traits : isSomeString, Unqual;
 import std.typecons : Flag;
 import std.range.primitives : isOutputRange;

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -27,11 +27,9 @@ $(TR $(TD Utilities) $(TD
 +/
 module std.datetime.timezone;
 
-// Note: reconsider using specific imports below after
-// https://issues.dlang.org/show_bug.cgi?id=17630 has been fixed
-import core.time;// : abs, convert, dur, Duration, hours, minutes;
-import std.datetime.systime;// : Clock, stdTimeToUnixTime, SysTime;
-import std.range.primitives;// : back, front, empty, popFront;
+import core.time : abs, convert, dur, Duration, hours, minutes;
+import std.datetime.systime : Clock, stdTimeToUnixTime, SysTime;
+import std.range.primitives : back, empty, front, isOutputRange, popFront;
 import std.traits : isIntegral, isSomeString, Unqual;
 
 version (Windows)


### PR DESCRIPTION
Doing this in multiple parts.

See also: https://github.com/dlang/phobos/pull/7024