### PR TITLE
Use selective top-level module imports in std.{functional,getopt,math,net,outbuffer}

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -61,8 +61,8 @@ Distributed under the Boost Software License, Version 1.0.
 */
 module std.functional;
 
-import std.meta; // AliasSeq, Reverse
-import std.traits; // isCallable, Parameters
+import std.meta : AliasSeq, Reverse;
+import std.traits : isCallable, Parameters;
 
 
 private template needOpCallAlias(alias fun)

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -28,7 +28,7 @@ Distributed under the Boost Software License, Version 1.0.
 */
 module std.getopt;
 
-import std.exception;  // basicExceptionCtors
+import std.exception : basicExceptionCtors;
 import std.traits;
 
 /**
@@ -659,6 +659,7 @@ private template optionValidator(A...)
 
 @system unittest // bugzilla 15914
 {
+    import std.exception : assertThrown;
     bool opt;
     string[] args = ["program", "-a"];
     getopt(args, config.passThrough, 'a', &opt);
@@ -1743,7 +1744,8 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt)
 // throw on duplicate options
 @system unittest
 {
-    import core.exception;
+    import core.exception : AssertError;
+    import std.exception : assertNotThrown, assertThrown;
     auto args = ["prog", "--abc", "1"];
     int abc, def;
     assertThrown!AssertError(getopt(args, "abc", &abc, "abc", &abc));

--- a/std/math.d
+++ b/std/math.d
@@ -130,7 +130,8 @@ version (Win64)
 static import core.math;
 static import core.stdc.math;
 static import core.stdc.fenv;
-import std.traits; // CommonType, isFloatingPoint, isIntegral, isSigned, isUnsigned, Largest, Unqual
+import std.traits :  CommonType, isFloatingPoint, isIntegral, isNumeric,
+    isSigned, isUnsigned, Largest, Unqual;
 
 version (LDC)
 {

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -25,8 +25,7 @@
  */
 module std.net.isemail;
 
-// FIXME
-import std.range.primitives; // : ElementType;
+import std.range.primitives : back, front, ElementType, popFront, popBack;
 import std.traits;
 import std.typecons : Flag, Yes, No;
 

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -12,7 +12,7 @@ Serialize data to `ubyte` arrays.
  */
 module std.outbuffer;
 
-import core.stdc.stdarg; // : va_list;
+import core.stdc.stdarg;
 
 /*********************************************
  * OutBuffer provides a way to build up an array of bytes out


### PR DESCRIPTION
Doing this in multiple parts.

See also: #7024