### PR TITLE
Use selective top-level module imports in std.{typecons,uni,utf}

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -69,7 +69,7 @@ Authors:   $(HTTP erdani.org, Andrei Alexandrescu),
 module std.typecons;
 
 import std.format : singleSpec, FormatSpec, formatValue;
-import std.meta; // : AliasSeq, allSatisfy;
+import std.meta : AliasSeq, allSatisfy;
 import std.range.primitives : isOutputRange;
 import std.traits;
 import std.internal.attributes : betterC;
@@ -949,6 +949,8 @@ if (distinctFieldNames!(Specs))
                 static assert(nN <= nT, "Cannot have more names than tuple members");
                 alias allNames = AliasSeq!(names, fieldNames[nN .. $]);
 
+                import std.meta : Alias, aliasSeqOf;
+
                 template GetItem(size_t idx)
                 {
                     import std.array : empty;
@@ -1021,6 +1023,7 @@ if (distinctFieldNames!(Specs))
         if (is(typeof(translate) : V[K], V, K) && isSomeString!V &&
                 (isSomeString!K || is(K : size_t)))
         {
+            import std.meta : aliasSeqOf;
             import std.range : ElementType;
             static if (isSomeString!(ElementType!(typeof(translate.keys))))
             {
@@ -4967,6 +4970,7 @@ private static:
         }
     }
 
+    import std.meta : templateNot;
     alias Implementation = AutoImplement!(Issue17177, how, templateNot!isFinalFunction);
 }
 
@@ -5482,6 +5486,7 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
         template OnlyVirtual(members...)
         {
             enum notFinal(alias T) = !__traits(isFinalFunction, T);
+            import std.meta : Filter;
             alias OnlyVirtual = Filter!(notFinal, members);
         }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -703,12 +703,12 @@ CLUSTER = $(S_LINK Grapheme cluster, grapheme cluster)
 +/
 module std.uni;
 
-import std.meta; // AliasSeq
-import std.range.primitives; // back, ElementEncodingType, ElementType, empty,
-    // front, isForwardRange, isInputRange, isRandomAccessRange, popFront, put,
-    // save
-import std.traits; // isConvertibleToString, isIntegral, isSomeChar,
-    // isSomeString, Unqual
+import std.meta : AliasSeq;
+import std.range.primitives : back, ElementEncodingType, ElementType, empty,
+    front, hasLength, hasSlicing, isForwardRange, isInputRange,
+    isRandomAccessRange, popFront, put, save;
+import std.traits : isConvertibleToString, isIntegral, isSomeChar,
+    isSomeString, Unqual;
 // debug = std_uni;
 
 debug(std_uni) import std.stdio; // writefln, writeln
@@ -2804,6 +2804,8 @@ private:
     // a random-access range of integral pairs
     static struct Intervals(Range)
     {
+        import std.range.primitives : hasAssignableElements;
+
         this(Range sp) scope
         {
             slice = sp;
@@ -4943,6 +4945,7 @@ template Utf8Matcher()
 
         bool lookup(int size, Mode mode, Range)(ref Range inp) const
         {
+            import std.range : popFrontN;
             if (inp.length < size)
             {
                 badEncoding();
@@ -5208,6 +5211,7 @@ template Utf16Matcher()
             }
             else
             {
+                import std.range : popFrontN;
                 static if (sizeFlags & 2)
                 {
                     if (inp.length < 2)
@@ -7333,6 +7337,8 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == Grapheme))
 auto byCodePoint(Range)(Range range)
 if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 {
+    import std.range.primitives : isBidirectionalRange, popBack;
+    import std.traits : isNarrowString;
     static if (isNarrowString!Range)
     {
         static struct Result
@@ -7786,7 +7792,9 @@ if (isInputRange!S1 && isSomeChar!(ElementEncodingType!S1)
     && isInputRange!S2 && isSomeChar!(ElementEncodingType!S2))
 {
     import std.internal.unicode_tables : sTable = simpleCaseTable; // generated file
+    import std.range.primitives : isInfinite;
     import std.utf : decodeFront;
+    import std.traits : isDynamicArray;
     import std.typecons : Yes;
     static import std.ascii;
 
@@ -7963,6 +7971,8 @@ int icmp(S1, S2)(S1 r1, S2 r2)
 if (isForwardRange!S1 && isSomeChar!(ElementEncodingType!S1)
     && isForwardRange!S2 && isSomeChar!(ElementEncodingType!S2))
 {
+    import std.range.primitives : isInfinite;
+    import std.traits : isDynamicArray;
     import std.utf : byDchar;
     static import std.ascii;
 

--- a/std/utf.d
+++ b/std/utf.d
@@ -60,11 +60,12 @@ $(TR $(TD Miscellaneous) $(TD
    +/
 module std.utf;
 
-import std.exception;  // basicExceptionCtors
-import std.meta;       // AliasSeq
+import std.exception : basicExceptionCtors;
+import std.meta : AliasSeq;
 import std.range.primitives;
-import std.traits;     // isSomeChar, isSomeString
-import std.typecons;   // Flag, Yes, No
+import std.traits : isAutodecodableString, isPointer, isSomeChar,
+    isSomeString, isStaticArray, Unqual;
+import std.typecons : Flag, Yes, No;
 
 
 /++
@@ -363,6 +364,7 @@ if (is(S : const char[]) ||
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(string s, dchar c, size_t i = 0, size_t line = __LINE__)
     {
         enforce(stride(s, i) == codeLength!char(c),
@@ -471,6 +473,7 @@ if (isInputRange!S && is(Unqual!(ElementType!S) == wchar))
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(wstring s, dchar c, size_t i = 0, size_t line = __LINE__)
     {
         enforce(stride(s, i) == codeLength!wchar(c),
@@ -560,6 +563,7 @@ if (is(S : const dchar[]) ||
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(dstring s, dchar c, size_t i = 0, size_t line = __LINE__)
     {
         enforce(stride(s, i) == codeLength!dchar(c),
@@ -717,6 +721,7 @@ if (isBidirectionalRange!S && is(Unqual!(ElementType!S) == char) && !isRandomAcc
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(string s, dchar c, size_t i = size_t.max, size_t line = __LINE__)
     {
         enforce(strideBack(s, i == size_t.max ? s.length : i) == codeLength!char(c),
@@ -814,6 +819,7 @@ if (is(S : const wchar[]) ||
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(wstring s, dchar c, size_t i = size_t.max, size_t line = __LINE__)
     {
         enforce(strideBack(s, i == size_t.max ? s.length : i) == codeLength!wchar(c),
@@ -909,6 +915,7 @@ if (isBidirectionalRange!S && is(Unqual!(ElementEncodingType!S) == dchar))
     import std.conv : to;
     import std.exception;
     import std.string : format;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     static void test(dstring s, dchar c, size_t i = size_t.max, size_t line = __LINE__)
     {
         enforce(strideBack(s, i == size_t.max ? s.length : i) == codeLength!dchar(c),
@@ -1068,6 +1075,7 @@ alias UseReplacementDchar = Flag!"useReplacementDchar";
 // Reduce distinct instantiations of decodeImpl.
 private template TypeForDecode(T)
 {
+    import std.traits : isDynamicArray;
     static if (isDynamicArray!T && is(T : E[], E) && __traits(isArithmetic, E) && !is(E == shared))
         alias TypeForDecode = const(Unqual!E)[];
     else
@@ -1856,6 +1864,7 @@ version (unittest) private void testDecode(R)(R range,
                                              size_t line = __LINE__)
 {
     import core.exception : AssertError;
+    import std.exception : enforce;
     import std.string : format;
 
     static if (hasLength!R)
@@ -1884,6 +1893,7 @@ version (unittest) private void testDecodeFront(R)(ref R range,
                                                   size_t line = __LINE__)
 {
     import core.exception : AssertError;
+    import std.exception : enforce;
     import std.string : format;
 
     static if (hasLength!R)
@@ -1914,6 +1924,7 @@ version (unittest) private void testDecodeBack(R)(ref R range,
     else
     {
         import core.exception : AssertError;
+        import std.exception : enforce;
         import std.string : format;
 
         static if (hasLength!R)
@@ -1951,6 +1962,7 @@ version (unittest) private void testAllDecode(R)(R range,
 version (unittest) private void testBadDecode(R)(R range, size_t index, size_t line = __LINE__)
 {
     import core.exception : AssertError;
+    import std.exception : assertThrown, enforce;
     import std.string : format;
 
     immutable initialIndex = index;
@@ -1982,6 +1994,7 @@ version (unittest) private void testBadDecodeBack(R)(R range, size_t line = __LI
     else
     {
         import core.exception : AssertError;
+        import std.exception : assertThrown, enforce;
         import std.string : format;
 
         static if (hasLength!R)
@@ -2198,6 +2211,7 @@ version (unittest) private void testBadDecodeBack(R)(R range, size_t line = __LI
 @safe unittest
 {
     import std.exception;
+    import std.traits : FunctionAttribute, functionAttributes, isSafe;
     assertCTFEable!(
     {
     foreach (S; AliasSeq!( char[], const( char)[],  string,
@@ -3535,6 +3549,7 @@ if (isAutodecodableString!R ||
     isInputRange!R && isSomeChar!(ElementEncodingType!R) ||
     (is(R : const dchar[]) && !isStaticArray!R))
 {
+    import std.traits : isNarrowString, StringTypeOf;
     static if (isNarrowString!R ||
                // This would be cleaner if we had a way to check whether a type
                // was a range without any implicit conversions.


### PR DESCRIPTION
Doing this in multiple parts.

See also: #7024