### PR TITLE
Fix Issue 19513 - Use sched_getaffinity(2) to get the number of CPU cores if abailable

### DIFF
--- a/changelog/count_processors_via_sched_affinity_on_linux.dd
+++ b/changelog/count_processors_via_sched_affinity_on_linux.dd
@@ -1,0 +1,10 @@
+Count processors via sched_getaffinity on Linux
+
+On GNU/Linux usable number of processors may be restricted if a process runs in containers.
+In case it's better to use sched_getaffinity(2).
+-------
+import std.parallelism;
+
+writeln(totalCPUs); // 4
+writeln(totalCPUs); // 1: runs on `taskset -c 0`
+-------

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -967,7 +967,16 @@ uint totalCPUsImpl() @nogc nothrow @trusted
     }
     else version (linux)
     {
+        import core.sys.linux.sched : CPU_COUNT, cpu_set_t, sched_getaffinity;
         import core.sys.posix.unistd : _SC_NPROCESSORS_ONLN, sysconf;
+
+        cpu_set_t set = void;
+        if (sched_getaffinity(0, cpu_set_t.sizeof, &set) == 0)
+        {
+            int count = CPU_COUNT(&set);
+            if (count > 0)
+                return cast(uint) count;
+        }
         return cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
     }
     else version (Solaris)


### PR DESCRIPTION
Currently std.parallelism.totalCPUs is implemented by
sysconf(_SC_NPROCESSORS_ONLN) on Posix platoform. However, on GNU/Linux,
usable number of processors may be restricted if a process runs in
container. In case it's better to use sched_getaffinity(2).

ref: http://man7.org/linux/man-pages/man1/nproc.1.html