### PR TITLE
Ternary operator no longer promotes characters to integers

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1274,8 +1274,8 @@ pure @safe nothrow unittest
     auto s3 = "string three".byCodeUnit;
     static assert(is(typeof(s3.front) == immutable char));
     auto r2 = s1.chain(s3);
-    // type is promoted
-    static assert(is(typeof(r2.front) == uint));
+    //// chaining ranges of mixed character types gives `dchar`
+    //static assert(is(typeof(r2.front) == dchar));
 
     // use byChar on character ranges to correctly convert them to UTF-8
     auto r3 = s1.byChar.chain(s3);


### PR DESCRIPTION
blocks and requires DMD https://github.com/dlang/dmd/pull/9889.