### PR TITLE
Ternary operator no longer promotes characters to integers [Part 2]

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1274,8 +1274,8 @@ pure @safe nothrow unittest
     auto s3 = "string three".byCodeUnit;
     static assert(is(typeof(s3.front) == immutable char));
     auto r2 = s1.chain(s3);
-    //// chaining ranges of mixed character types gives `dchar`
-    //static assert(is(typeof(r2.front) == dchar));
+    // chaining ranges of mixed character types gives `dchar`
+    static assert(is(typeof(r2.front) == dchar));
 
     // use byChar on character ranges to correctly convert them to UTF-8
     auto r3 = s1.byChar.chain(s3);


### PR DESCRIPTION
Re-enable test from #7041.