### PR TITLE
Fixed unusual behavior of the template function `filter`: double call method `front()` of the input range

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -179,28 +179,15 @@ if (isBidirectionalRange!Range)
         // http://en.wikipedia.org/wiki/Quartic_function
         return ( (x + 4.0) * (x + 1.0) * (x - 1.0) * (x - 3.0) ) / 14.0 + 0.5;
     }
-    // Without cache, with array (greedy)
-    auto result1 = iota(-4, 5).map!(a =>tuple(a, fun(a)))()
-                             .filter!(a => a[1] < 0)()
-                             .map!(a => a[0])()
-                             .array();
 
-    // the values of x that have a negative y are:
-    assert(equal(result1, [-3, -2, 2]));
-
-    // Check how many times fun was evaluated.
-    // As many times as the number of items in both source and result.
-    assert(counter == iota(-4, 5).length + result1.length);
-
-    counter = 0;
     // Without array, with cache (lazy)
-    auto result2 = iota(-4, 5).map!(a =>tuple(a, fun(a)))()
+    auto result = iota(-4, 5).map!(a =>tuple(a, fun(a)))()
                              .cache()
                              .filter!(a => a[1] < 0)()
                              .map!(a => a[0])();
 
     // the values of x that have a negative y are:
-    assert(equal(result2, [-3, -2, 2]));
+    assert(equal(result, [-3, -2, 2]));
 
     // Check how many times fun was evaluated.
     // Only as many times as the number of items in source.


### PR DESCRIPTION
template function `filter` twice calls method `front()` of its input range

I propose fix `FilterResult` to make behavior more expected.

Here are some examples
https://run.dlang.io/is/wnJFgm
```d
import std.stdio     : writeln;
import std.typecons  : tuple;
import std.algorithm : filter, map, sum;

void main(string[] args)
{
    auto r = [0,1,2,3,4,5]
        .map!( (x) {
            writeln("x.... ", x);
            return (3 == x) ?
                tuple(false, 2*x):
                tuple(true, x*x);
        })
        .filter!(pair => pair[0])
        .map!(pair => pair[1]) ;
    
    r.sum.writeln;
}
```
Otput:
```
x.... 0
x.... 0
x.... 1
x.... 1
x.... 2
x.... 2
x.... 3
x.... 4
x.... 4
x.... 5
x.... 5
46
```
https://run.dlang.io/is/29ciqF
```d
import std.stdio     : writeln;
import std.algorithm : filter, map;

void main()
{
    int i = 0;
    [1, 2, 3]
    	.map!(e => i++)
        .filter!"a < 3"
        .writeln;
}
```
Otput:
```
[1, 3]
```