### PR TITLE
Explicitly link to math library

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -112,7 +112,7 @@ OUTFILEFLAG = -o
 NODEFAULTLIB=-defaultlib= -debuglib=
 ifeq (,$(findstring win,$(OS)))
 	CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
-	NODEFAULTLIB += -L-lpthread
+	NODEFAULTLIB += -L-lpthread -L-lm
 	ifeq ($(BUILD),debug)
 		CFLAGS += -g
 	else


### PR DESCRIPTION
Second pass of https://github.com/dlang/phobos/pull/7021

Looks like we also need `-lm`.
