### PR TITLE
Add `inout` to range.front to reduce template proliferation

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2419,15 +2419,8 @@ equivalent to `front(array)`. For $(GLOSSARY narrow strings), $(D
 front) automatically returns the first $(GLOSSARY code point) as _a $(D
 dchar).
 */
-@property ref T front(T)(return scope T[] a) @safe pure nothrow @nogc
+@property ref inout(T) front(T)(return scope inout(T)[] a) @safe pure nothrow @nogc
 if (!(autodecodeStrings && isNarrowString!(T[])) && !is(T[] == void[]))
-// We would have preferred to write the function template
-// ---
-//     @property ref inout(T) front(T)(return scope inout(T)[] a)
-//        if (/* same constraint */)
-// ---
-// as that would cause fewer distinct functions to be generated with
-// IFTI, but that caused a linker error in the test suite on Win32_64.
 {
     assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
     return a[0];


### PR DESCRIPTION
The Win32_64 linker error that prevented this from being included in PR #6743 no longer occurs in CI.