### PR TITLE
Pass writer as `auto ref` to string formatting functions in datetime

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -2874,7 +2874,7 @@ public:
     }
 
     /// ditto
-    void toISOString(W)(ref W writer) const
+    void toISOString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -2951,7 +2951,7 @@ public:
     }
 
     /// ditto
-    void toISOExtString(W)(ref W writer) const
+    void toISOExtString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -3027,7 +3027,7 @@ public:
     }
 
     /// ditto
-    void toSimpleString(W)(ref W writer) const
+    void toSimpleString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -3119,7 +3119,7 @@ public:
     }
 
     /// ditto
-    void toString(W)(ref W writer) const
+    void toString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         toSimpleString(writer);
@@ -7233,7 +7233,7 @@ public:
     }
 
     /// ditto
-    void toISOString(W)(ref W writer) const
+    void toISOString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -7317,7 +7317,7 @@ public:
     }
 
     /// ditto
-    void toISOExtString(W)(ref W writer) const
+    void toISOExtString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -7401,7 +7401,7 @@ public:
     }
 
     /// ditto
-    void toSimpleString(W)(ref W writer) const
+    void toSimpleString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -7469,7 +7469,7 @@ public:
     }
 
     /// ditto
-    void toString(W)(ref W writer) const
+    void toString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         toSimpleString(writer);
@@ -8932,7 +8932,7 @@ public:
     }
 
     /// ditto
-    void toISOString(W)(ref W writer) const
+    void toISOString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -8979,7 +8979,7 @@ public:
     }
 
     /// ditto
-    void toISOExtString(W)(ref W writer) const
+    void toISOExtString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         import std.format : formattedWrite;
@@ -9038,7 +9038,7 @@ public:
     }
 
     /// ditto
-    void toString(W)(ref W writer) const
+    void toString(W)(auto ref W writer) const
     if (isOutputRange!(W, char))
     {
         toISOExtString(writer);

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -1557,7 +1557,7 @@ public:
     }
 
     /// ditto
-    void toString(Writer)(ref Writer w) const
+    void toString(Writer)(auto ref Writer w) const
     if (isOutputRange!(Writer, char))
     {
         import std.range.primitives : put;

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -8134,7 +8134,7 @@ public:
     }
 
     /// ditto
-    void toISOString(W)(ref W writer) const scope
+    void toISOString(W)(auto ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -8294,7 +8294,7 @@ public:
     }
 
     /// ditto
-    void toISOExtString(W)(ref W writer) const scope
+    void toISOExtString(W)(auto ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -8458,7 +8458,7 @@ public:
     }
 
     /// ditto
-    void toSimpleString(W)(ref W writer) const scope
+    void toSimpleString(W)(auto ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         immutable adjustedTime = adjTime;
@@ -8621,7 +8621,7 @@ public:
     }
 
     /// ditto
-    void toString(W)(ref W writer) const scope
+    void toString(W)(auto ref W writer) const scope
     if (isOutputRange!(W, char))
     {
         toSimpleString(writer);

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -1405,7 +1405,7 @@ package:
     }
 
     // ditto
-    static void toISOString(W)(ref W writer, Duration utcOffset)
+    static void toISOString(W)(auto ref W writer, Duration utcOffset)
     if (isOutputRange!(W, char))
     {
         import std.datetime.date : DateTimeException;


### PR DESCRIPTION
Currently this raises a compile error:
```d
import std.stdio;
import std.datetime.systime;
Clock.currTime().toISOExtString(stdout.lockingTextWriter());
```
while this works:
```d
import std.stdio;
import std.datetime.systime;
auto w = stdout.lockingTextWriter();
Clock.currTime().toISOExtString(w);
```
The cause is that the argument for `toISOExtString` is `ref` so it accepts only lvalues.  This PR changes all output stream `ref` arguments for string formatting functions in `datetime` to `auto ref` so that rvalues are accepted, too.