### PR TITLE
std.process.forkChild cannot be inlined

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -468,7 +468,6 @@ private Pid spawnProcessImpl(scope const(char[])[] args,
     void forkChild() nothrow @nogc
     {
         static import core.sys.posix.stdio;
-        pragma(inline, true);
 
         // Child process
 


### PR DESCRIPTION
This PR is in support of https://github.com/dlang/dmd/pull/9978

`forkChild` is much too large to be inlined, but noone knew about it until now because `std.process` is not being compiled with the `-inline` flag and because of [Issue 15110](https://issues.dlang.org/show_bug.cgi?id=15110) which https://github.com/dlang/dmd/pull/9978 attempts to fix.

See the output of the CIs in https://github.com/dlang/dmd/pull/9978 for more information.