### PR TITLE
 Make ErrnoException.errno nothrow pure @nogc @safe 

### DIFF
--- a/changelog/errnoexception-errno-attributes.dd
+++ b/changelog/errnoexception-errno-attributes.dd
@@ -1,0 +1,4 @@
+ErrnoException.errno is now nothrow pure @nogc @safe
+
+Before, it was just @system. As it turns out, all it does is return the value
+of an integer field, so it can have all these attributes.

--- a/std/exception.d
+++ b/std/exception.d
@@ -1610,16 +1610,17 @@ package string errnoString(int errno) nothrow @trusted
  */
 class ErrnoException : Exception
 {
-    final @property uint errno() { return _errno; } /// Operating system error code.
+    /// Operating system error code.
+    final @property uint errno() nothrow pure @nogc @safe { return _errno; }
     private uint _errno;
     /// Constructor which takes an error message. The current global $(REF errno, core,stdc,errno) value is used as error code.
-    this(string msg, string file = null, size_t line = 0) @trusted
+    this(string msg, string file = null, size_t line = 0) @safe
     {
         import core.stdc.errno : errno;
         this(msg, errno, file, line);
     }
     /// Constructor which takes an error message and error code.
-    this(string msg, int errno, string file = null, size_t line = 0) @trusted
+    this(string msg, int errno, string file = null, size_t line = 0) @safe
     {
         _errno = errno;
         super(msg ~ " (" ~ errnoString(errno) ~ ")", file, line);
@@ -1627,7 +1628,7 @@ class ErrnoException : Exception
 }
 
 ///
-@system unittest
+@safe unittest
 {
     import core.stdc.errno : EAGAIN;
     auto ex = new ErrnoException("oh no", EAGAIN);
@@ -1635,7 +1636,7 @@ class ErrnoException : Exception
 }
 
 /// errno is used by default if no explicit error code is provided
-@system unittest
+@safe unittest
 {
     import core.stdc.errno : errno, EAGAIN;
 


### PR DESCRIPTION
I think the field could be a public const(uint) instead; without a property accessor. However, doing so would be a breaking change.