### PR TITLE
function attributes go on the right of function aliases

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -532,7 +532,7 @@ public:
       +/
     static immutable(LocalTime) opCall() @trusted pure nothrow
     {
-        alias FuncType = @safe pure nothrow immutable(LocalTime) function();
+        alias FuncType = immutable(LocalTime) function() @safe pure nothrow;
         return (cast(FuncType)&singleton)();
     }
 


### PR DESCRIPTION
FuncType is actually `@system` because of this, for some reason it is still `pure` and `nothrow`.