### PR TITLE
[docs][std.range.primitives] Add links to array range primitives

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1,6 +1,9 @@
 /**
 This module is a submodule of $(MREF std, range).
 
+It defines the bidirectional and forward range primitives for arrays:
+$(LREF empty), $(LREF front), $(LREF back), $(LREF popFront), $(LREF popBack) and $(LREF save).
+
 It provides basic range functionality by defining several templates for testing
 whether a given object is a range, and what kind of range it is:
 


### PR DESCRIPTION
It's important to mention this (first), particularly so the user notices the auto-decoding overloads.