### PR TITLE
std_json allow trailing comma

### DIFF
--- a/changelog/std_json_trailing_comma.dd
+++ b/changelog/std_json_trailing_comma.dd
@@ -1,0 +1,15 @@
+Allow std.json to overlook trailing comma
+
+The JSON grammar does not allow trailing commas, however they are accepted by many JSON parsers.
+$(MREF std,json) now ignores trailing commas as well. Use $(REF_SHORT JSONOptions.strictParsing, std,json) to disable this behavior.
+
+-------
+import std.json;
+import std.exception : assertThrown, assertNotThrown;
+
+// before
+assertThrown(parseJSON(`{ "a" : { } , }`));
+
+// after
+assertNotThrown(parseJSON(`{ "a" : { } , }`));
+-------


### PR DESCRIPTION
I recently encountered a lot of json files with trailing comma's.

std.json rightfully rejected them, but then I kind of really needs to accept them anyway.
This PR allows std.json to ignore trailing comma's.  