### PR TITLE
Fix issue 19994 - Can't nest self-referential Algebraic types

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -100,7 +100,7 @@ template maxSize(T...)
 
 struct This;
 
-private alias This2Variant(V, T...) = AliasSeq!(ReplaceType!(This, V, T));
+private alias This2Variant(V, T...) = AliasSeq!(ReplaceTypeUnless!(isAlgebraic, This, V, T));
 
 // We can't just use maxAlignment because no types might be specified
 // to VariantN, so handle that here and then pass along the rest.
@@ -3053,4 +3053,13 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     Variant v = createVariant([0, 1]);
     createVariant([2, 3]);
     assert(v == [0,1]);
+}
+
+@safe unittest
+{
+    // Bugzilla 19994
+    alias Inner = Algebraic!(This*);
+    alias Outer = Algebraic!(Inner, This*);
+
+    static assert(is(Outer.AllowedTypes == AliasSeq!(Inner, Outer*)));
 }


### PR DESCRIPTION
Previously, self-referential `Algebraic` types using `This` could not be nested, since the outer `Algebraic` instance would replace the inner `Algebraic`'s `This` argument when computing `AllowedTypes`, leading to a recursive template expansion. With these changes, each occurrence of `This` in `Algebraic`'s argument list is replaced only by the inner-most `Algebraic` instance that contains it. This ensures that no occurrence of `This` is ever replaced more than once.

These changes are based on pbackus/sumtype@5a6136855acd9e7f3ab7c421fc2f531055114240, which fixed an analagous issue in the `sumtype` DUB package.