### PR TITLE
Tid.hasMessages

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -334,6 +334,14 @@ public:
         formattedWrite(sink, "Tid(%x)", cast(void*) mbox);
     }
 
+    /**
+     * Returns whether or not this Tid has concurrency messages waiting to be
+     * received.
+     */
+    bool hasMessages() @safe pure nothrow @nogc
+    {
+        return (mbox.m_localMsgs + mbox.m_sharedBox.length) > 0;
+    }
 }
 
 @system unittest
@@ -346,6 +354,12 @@ public:
     assert(text(tid2) != "Tid(0)");
     auto tid3 = tid2;
     assert(text(tid2) == text(tid3));
+
+    assert(!thisTid.hasMessages);
+    thisTid.send(123);
+    assert(thisTid.hasMessages);
+    int i = receiveOnly!int();
+    assert(!thisTid.hasMessages);
 }
 
 /**


### PR DESCRIPTION
I want to make the case for adding Tid.hasMessages. Naming is hard.

NG thread: https://forum.dlang.org/post/iuvdrthsugkwhxqjgetl@forum.dlang.org

TL;DR: There is no way to tell if there are concurrency messages waiting in a thread (essentially no way to check for threads' message box .empty) without actually attempting to receive, thereby consuming any message and committing to handling it.

Going by the range analogy, currently it's as if Tid's message box only has `popFront` that also returns a `front` (no separate `front`, no `empty`). The only way to know if the message queue is empty is to try to pop and see if it failed.

Knowing whether it's empty allows you to only receive when there's actually something there. Drawbacks to 0-second timeouts mentioned in the NG thread; I'll be happy to argue it in more detail if requested.

What this is:
* The equivalence of .empty for the concurrency message queue
* Literally a oneliner, plus tests

What this is not:
* Breaking
* An attempt to make concurrency message boxes ranges
* Exposing the private MessageBox member of Tid, subverting send and receive
* Mere syntactic sugar for something already possible with existing library functions

You could make the argument that this should only be possible with `thisTid`. I don't mind such a limitation but I also don't really see the need for it.

I'm not sure what a good name is. Tid.empty rings nice but isn't quite true, since it's (the private) Tid.mbox that's empty. Tid.messagesWaiting. Tid.messageBoxEmpty. Tid.canReceive.
