### PR TITLE
Fix enum type in std.socket to match the receiver type

### DIFF
--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -729,7 +729,7 @@ public:
         private void addPerCall(string f, uint n, names...)(ulong[] values...)
         {
             import std.array : join;
-            enum uint mask = mixin("Options."~[names].join("|Options."));
+            enum ulong mask = mixin("Options."~[names].join("|Options."));
             static if (perCallFlags & mask)
             {
                 // Per allocation info

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -480,7 +480,7 @@ struct Task(alias fun, Args...)
         static if (isFunctionPointer!(_args[0]))
         {
             private enum bool isPure =
-            functionAttributes!(Args[0]) & FunctionAttribute.pure_;
+            (functionAttributes!(Args[0]) & FunctionAttribute.pure_) != 0;
         }
         else
         {

--- a/std/socket.d
+++ b/std/socket.d
@@ -325,7 +325,7 @@ shared static ~this() @system nothrow @nogc
 /**
  * The communication domain used to resolve an address.
  */
-enum AddressFamily: int
+enum AddressFamily: ushort
 {
     UNSPEC =     AF_UNSPEC,     /// Unspecified address family
     UNIX =       AF_UNIX,       /// Local communication


### PR DESCRIPTION
This currently blocks [1]. The enum is declared as an integer, but it is assigned to ushort variables. This worked due to a bug in dmd which is now being fixed.

[1] https://github.com/dlang/dmd/pull/10099