### PR TITLE
Make locally-defined `FiberScheduler` actually usable

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1377,7 +1377,7 @@ private:
                  !notified && !period.isNegative;
                  period = limit - MonoTime.currTime)
             {
-                yield();
+                this.outer.yield();
             }
             return notified;
         }
@@ -1399,7 +1399,7 @@ private:
         {
             mutex_nothrow.unlock_nothrow();
             scope (exit) mutex_nothrow.lock_nothrow();
-            yield();
+            this.outer.yield();
         }
 
         private bool notified;

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1334,6 +1334,15 @@ class FiberScheduler : Scheduler
 
     /**
      * Returns a Condition analog that yields when wait or notify is called.
+     *
+     * Bug:
+     * For the default implementation, `notifyAll`will behave like `notify`.
+     *
+     * Params:
+     *   m = A `Mutex` to use for locking if the condition needs to be waited on
+     *       or notified from multiple `Thread`s.
+     *       If `null`, no `Mutex` will be used and it is assumed that the
+     *       `Condition` is only waited on/notified from one `Thread`.
      */
     Condition newCondition(Mutex m) nothrow
     {
@@ -1397,8 +1406,10 @@ private:
     private:
         void switchContext() nothrow
         {
-            mutex_nothrow.unlock_nothrow();
-            scope (exit) mutex_nothrow.lock_nothrow();
+            if (mutex_nothrow) mutex_nothrow.unlock_nothrow();
+            scope (exit)
+                if (mutex_nothrow)
+                    mutex_nothrow.lock_nothrow();
             this.outer.yield();
         }
 


### PR DESCRIPTION
So... Do people actually use this module ?

I have a test library which spawns `Thread` to simulate Vibe.d servers. Within each node, I need to replicate a simple, re-entrant event loop. I tried to use a local `scheduler` (thread-local) as I don't want to mess with a global instance (why do we even have one to begin with ? The user can define that on their own if they need it...), but it seems this use case hasn't been tested.