### PR TITLE
Replace D1 operator overloads with D2 operator overloads - Part 2

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1816,7 +1816,8 @@ public:
     /***************************************
      * Support for unary operator ~ for `BitArray`.
      */
-    BitArray opCom() const pure nothrow
+    BitArray opUnary(string op)() const pure nothrow
+        if (op == "~")
     {
         auto dim = this.dim;
 


### PR DESCRIPTION
Follow up to https://github.com/dlang/phobos/pull/7098  (I missed one)

In support of https://github.com/dlang/dmd/pull/10130