### PR TITLE
Fix Issue 19105 - Bogus recursive template expansion via getSymbolsByUDA

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8353,6 +8353,7 @@ Note:
     nested structs or unions.
  */
 template getSymbolsByUDA(alias symbol, alias attribute)
+if (isAggregateType!symbol)
 {
     alias membersWithUDA = getSymbolsByUDAImpl!(symbol, attribute, __traits(allMembers, symbol));
 
@@ -8477,6 +8478,15 @@ template getSymbolsByUDA(alias symbol, alias attribute)
 
     static assert(getSymbolsByUDA!(A, attr1).length == 2);
     static assert(getSymbolsByUDA!(A, attr2).length == 1);
+}
+
+// Issue 19105
+@safe unittest
+{
+    struct A(Args...) {}
+    struct B {}
+    // modules cannot be passed as the first argument of getSymbolsByUDA
+    static assert(!__traits(compiles, A!( getSymbolsByUDA!(traits, B))));
 }
 
 // #15335: getSymbolsByUDA fails if type has private members


### PR DESCRIPTION
Issue 19105 was reported as a compiler bug. The reported code is:

```d
module junk;

import std.traits;

struct A(Args...) {}
struct B {}
alias C = A!( getSymbolsByUDA!(junk, B) );
```

But reading the docs of `getSymbolsByUDA`is seems that it was meant to work only with aggregate declarations (not with modules). I added a template constraint that requires that the symbol passed is an aggregated type.

The code fails because while getting the members of `junk`, the innards of `getSymbolsByUDA` uses aliases for the list of symbols and at some point alias C ends up aliasing to something that aliases itself.