### PR TITLE
Turn on -preview=markdown

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -867,7 +867,7 @@ enum CurlOption {
   /** We want the referrer field set automatically when following locations */
   autoreferer = 58,
   /** Port of the proxy, can be set in the proxy string as well with:
-     "[host]:[port]" */
+     `[host]:[port]` */
   proxyport,
   /** size of the POST input data, if strlen() is not good to use */
   postfieldsize,

--- a/etc/c/sqlite3.d
+++ b/etc/c/sqlite3.d
@@ -38,7 +38,7 @@ import core.stdc.config : c_ulong;
 extern (C) __gshared nothrow:
 
 /**
-** CAPI3REF: Compile-Time Library Version Numbers
+* CAPI3REF: Compile-Time Library Version Numbers
 */
 enum SQLITE_VERSION = "3.28.0";
 /// Ditto
@@ -47,7 +47,7 @@ enum SQLITE_VERSION_NUMBER = 3028000;
 enum SQLITE_SOURCE_ID = "2019-04-16 19:49:53 884b4b7e502b4e991677b53971277adfaf0a04a284f8e483e2553d0f83156b50";
 
 /**
-** CAPI3REF: Run-Time Library Version Numbers
+* CAPI3REF: Run-Time Library Version Numbers
 */
 extern immutable(char)* sqlite3_version;
 /// Ditto
@@ -58,19 +58,19 @@ immutable(char)* sqlite3_sourceid();
 int sqlite3_libversion_number();
 
 /**
-** CAPI3REF: Run-Time Library Compilation Options Diagnostics
+* CAPI3REF: Run-Time Library Compilation Options Diagnostics
 */
 int sqlite3_compileoption_used(const char *zOptName);
 /// Ditto
 immutable(char)* sqlite3_compileoption_get(int N);
 
 /**
-** CAPI3REF: Test To See If The Library Is Threadsafe
+* CAPI3REF: Test To See If The Library Is Threadsafe
 */
 int sqlite3_threadsafe();
 
 /**
-** CAPI3REF: Database Connection Handle
+* CAPI3REF: Database Connection Handle
 */
 struct sqlite3;
 
@@ -80,21 +80,21 @@ alias sqlite3_int64 = long;
 alias sqlite3_uint64 = ulong;
 
 /**
-** CAPI3REF: Closing A Database Connection
-**
+* CAPI3REF: Closing A Database Connection
+*
 */
 int sqlite3_close(sqlite3 *);
 int sqlite3_close_v2(sqlite3*);
 
 /**
-** The type for a callback function.
-** This is legacy and deprecated.  It is included for historical
-** compatibility and is not documented.
+* The type for a callback function.
+* This is legacy and deprecated.  It is included for historical
+* compatibility and is not documented.
 */
 alias sqlite3_callback = int function (void*,int,char**, char**);
 
 /**
-** CAPI3REF: One-Step Query Execution Interface
+* CAPI3REF: One-Step Query Execution Interface
 */
 int sqlite3_exec(
     sqlite3*,                                         /** An open database */
@@ -105,7 +105,7 @@ int sqlite3_exec(
 );
 
 /**
-** CAPI3REF: Result Codes
+* CAPI3REF: Result Codes
 */
 enum
 {
@@ -146,7 +146,7 @@ enum
 /* end-of-error-codes */
 
 /**
-** CAPI3REF: Extended Result Codes
+* CAPI3REF: Extended Result Codes
 */
 enum
 {
@@ -220,7 +220,7 @@ enum
 }
 
 /**
-** CAPI3REF: Flags For File Open Operations
+* CAPI3REF: Flags For File Open Operations
 */
 enum
 {
@@ -247,7 +247,7 @@ enum
 }
 
 /**
-** CAPI3REF: Device Characteristics
+* CAPI3REF: Device Characteristics
 */
 enum
 {
@@ -269,7 +269,7 @@ enum
 }
 
 /**
-** CAPI3REF: File Locking Levels
+* CAPI3REF: File Locking Levels
 */
 enum
 {
@@ -281,7 +281,7 @@ enum
 }
 
 /**
-** CAPI3REF: Synchronization Type Flags
+* CAPI3REF: Synchronization Type Flags
 */
 enum
 {
@@ -291,7 +291,7 @@ enum
 }
 
 /**
-** CAPI3REF: OS Interface Open File Handle
+* CAPI3REF: OS Interface Open File Handle
 */
 struct sqlite3_file
 {
@@ -299,7 +299,7 @@ struct sqlite3_file
 }
 
 /**
-** CAPI3REF: OS Interface File Virtual Methods Object
+* CAPI3REF: OS Interface File Virtual Methods Object
 */
 
 struct sqlite3_io_methods
@@ -329,7 +329,7 @@ struct sqlite3_io_methods
 }
 
 /**
-** CAPI3REF: Standard File Control Opcodes
+* CAPI3REF: Standard File Control Opcodes
 */
 enum
 {
@@ -378,17 +378,17 @@ deprecated ("deprecated names")
 }
 
 /**
-** CAPI3REF: Mutex Handle
+* CAPI3REF: Mutex Handle
 */
 struct sqlite3_mutex;
 
 /**
-** CAPI3REF: Loadable Extension Thunk
+* CAPI3REF: Loadable Extension Thunk
 */
 struct sqlite3_api_routines;
 
 /**
-** CAPI3REF: OS Interface Object
+* CAPI3REF: OS Interface Object
 */
 
 alias xDlSymReturn = void * function();
@@ -436,7 +436,7 @@ struct sqlite3_vfs
 }
 
 /**
-** CAPI3REF: Flags for the xAccess VFS method
+* CAPI3REF: Flags for the xAccess VFS method
 */
 enum
 {
@@ -447,7 +447,7 @@ enum
 }
 
 /**
-** CAPI3REF: Flags for the xShmLock VFS method
+* CAPI3REF: Flags for the xShmLock VFS method
 */
 enum
 {
@@ -458,13 +458,13 @@ enum
 }
 
 /**
-** CAPI3REF: Maximum xShmLock index
+* CAPI3REF: Maximum xShmLock index
 */
 enum SQLITE_SHM_NLOCK        = 8;
 
 
 /**
-** CAPI3REF: Initialize The SQLite Library
+* CAPI3REF: Initialize The SQLite Library
 */
 int sqlite3_initialize();
 /// Ditto
@@ -475,17 +475,17 @@ int sqlite3_os_init();
 int sqlite3_os_end();
 
 /**
-** CAPI3REF: Configuring The SQLite Library
+* CAPI3REF: Configuring The SQLite Library
 */
 int sqlite3_config(int, ...);
 
 /**
-** CAPI3REF: Configure database connections
+* CAPI3REF: Configure database connections
 */
 int sqlite3_db_config(sqlite3*, int op, ...);
 
 /**
-** CAPI3REF: Memory Allocation Routines
+* CAPI3REF: Memory Allocation Routines
 */
 struct sqlite3_mem_methods
 {
@@ -500,7 +500,7 @@ struct sqlite3_mem_methods
 }
 
 /**
-** CAPI3REF: Configuration Options
+* CAPI3REF: Configuration Options
 */
 enum
 {
@@ -536,7 +536,7 @@ enum
 }
 
 /**
-** CAPI3REF: Database Connection Configuration Options
+* CAPI3REF: Database Connection Configuration Options
 */
 enum
 {
@@ -557,54 +557,54 @@ enum
 
 
 /**
-** CAPI3REF: Enable Or Disable Extended Result Codes
+* CAPI3REF: Enable Or Disable Extended Result Codes
 */
 int sqlite3_extended_result_codes(sqlite3*, int onoff);
 
 /**
-** CAPI3REF: Last Insert Rowid
+* CAPI3REF: Last Insert Rowid
 */
 sqlite3_int64 sqlite3_last_insert_rowid(sqlite3*);
 
 /**
-** CAPI3REF: Set the Last Insert Rowid value
+* CAPI3REF: Set the Last Insert Rowid value
 */
 void sqlite3_set_last_insert_rowid(sqlite3*,sqlite3_int64);
 
 /**
-** CAPI3REF: Count The Number Of Rows Modified
+* CAPI3REF: Count The Number Of Rows Modified
 */
 int sqlite3_changes(sqlite3*);
 
 /**
-** CAPI3REF: Total Number Of Rows Modified
+* CAPI3REF: Total Number Of Rows Modified
 */
 int sqlite3_total_changes(sqlite3*);
 
 /**
-** CAPI3REF: Interrupt A Long-Running Query
+* CAPI3REF: Interrupt A Long-Running Query
 */
 void sqlite3_interrupt(sqlite3*);
 
 /**
-** CAPI3REF: Determine If An SQL Statement Is Complete
+* CAPI3REF: Determine If An SQL Statement Is Complete
 */
 int sqlite3_complete(const char *sql);
 /// Ditto
 int sqlite3_complete16(const void *sql);
 
 /**
-** CAPI3REF: Register A Callback To Handle SQLITE_BUSY Errors
+* CAPI3REF: Register A Callback To Handle SQLITE_BUSY Errors
 */
 int sqlite3_busy_handler(sqlite3*, int function (void*,int), void*);
 
 /**
-** CAPI3REF: Set A Busy Timeout
+* CAPI3REF: Set A Busy Timeout
 */
 int sqlite3_busy_timeout(sqlite3*, int ms);
 
 /**
-** CAPI3REF: Convenience Routines For Running Queries
+* CAPI3REF: Convenience Routines For Running Queries
 */
 int sqlite3_get_table(
     sqlite3 *db,          /** An open database */
@@ -618,7 +618,7 @@ int sqlite3_get_table(
 void sqlite3_free_table(char **result);
 
 /**
-** CAPI3REF: Formatted String Printing Functions
+* CAPI3REF: Formatted String Printing Functions
 */
 char *sqlite3_mprintf(const char*,...);
 char *sqlite3_vmprintf(const char*, va_list);
@@ -626,7 +626,7 @@ char *sqlite3_snprintf(int,char*,const char*, ...);
 char *sqlite3_vsnprintf(int,char*,const char*, va_list);
 
 /**
-** CAPI3REF: Memory Allocation Subsystem
+* CAPI3REF: Memory Allocation Subsystem
 */
 void *sqlite3_malloc(int);
 /// Ditto
@@ -641,18 +641,18 @@ void sqlite3_free(void*);
 sqlite3_uint64 sqlite3_msize(void*);
 
 /**
-** CAPI3REF: Memory Allocator Statistics
+* CAPI3REF: Memory Allocator Statistics
 */
 sqlite3_int64 sqlite3_memory_used();
 sqlite3_int64 sqlite3_memory_highwater(int resetFlag);
 
 /**
-** CAPI3REF: Pseudo-Random Number Generator
+* CAPI3REF: Pseudo-Random Number Generator
 */
 void sqlite3_randomness(int N, void *P);
 
 /**
-** CAPI3REF: Compile-Time Authorization Callbacks
+* CAPI3REF: Compile-Time Authorization Callbacks
 */
 int sqlite3_set_authorizer(
     sqlite3*,
@@ -661,7 +661,7 @@ int sqlite3_set_authorizer(
 );
 
 /**
-** CAPI3REF: Authorizer Return Codes
+* CAPI3REF: Authorizer Return Codes
 */
 enum
 {
@@ -670,7 +670,7 @@ enum
 }
 
 /**
-** CAPI3REF: Authorizer Action Codes
+* CAPI3REF: Authorizer Action Codes
 */
 /******************************************* 3rd ************ 4th ***********/
 enum
@@ -712,14 +712,14 @@ enum
 }
 
 /**
-** CAPI3REF: Tracing And Profiling Functions
+* CAPI3REF: Tracing And Profiling Functions
 */
 deprecated void *sqlite3_trace(sqlite3*, void function (void*,const char*) xTrace, void*);
 /// Ditto
 deprecated void *sqlite3_profile(sqlite3*, void function (void*,const char*,sqlite3_uint64) xProfile, void*);
 
 /**
-** CAPI3REF: SQL Trace Event Codes
+* CAPI3REF: SQL Trace Event Codes
 */
 enum
 {
@@ -730,7 +730,7 @@ enum
 }
 
 /**
-** CAPI3REF: SQL Trace Hook
+* CAPI3REF: SQL Trace Hook
 */
 int sqlite3_trace_v2(
     sqlite3*,
@@ -740,12 +740,12 @@ int sqlite3_trace_v2(
 );
 
 /**
-** CAPI3REF: Query Progress Callbacks
+* CAPI3REF: Query Progress Callbacks
 */
 void sqlite3_progress_handler(sqlite3*, int, int function (void*), void*);
 
 /**
-** CAPI3REF: Opening A New Database Connection
+* CAPI3REF: Opening A New Database Connection
 */
 int sqlite3_open(
     const(char)*filename,   /** Database filename (UTF-8) */
@@ -765,7 +765,7 @@ int sqlite3_open_v2(
 );
 
 /*
-** CAPI3REF: Obtain Values For URI Parameters
+* CAPI3REF: Obtain Values For URI Parameters
 */
 const(char)* sqlite3_uri_parameter(const(char)* zFilename, const(char)* zParam);
 /// Ditto
@@ -774,7 +774,7 @@ int sqlite3_uri_boolean(const(char)* zFile, const(char)* zParam, int bDefault);
 sqlite3_int64 sqlite3_uri_int64(const char*, const char*, sqlite3_int64);
 
 /**
-** CAPI3REF: Error Codes And Messages
+* CAPI3REF: Error Codes And Messages
 */
 int sqlite3_errcode(sqlite3 *db);
 /// Ditto
@@ -787,17 +787,17 @@ const(void)* sqlite3_errmsg16(sqlite3*);
 const(char)* sqlite3_errstr(int);
 
 /**
-** CAPI3REF: SQL Statement Object
+* CAPI3REF: SQL Statement Object
 */
 struct sqlite3_stmt;
 
 /**
-** CAPI3REF: Run-time Limits
+* CAPI3REF: Run-time Limits
 */
 int sqlite3_limit(sqlite3*, int id, int newVal);
 
 /**
-** CAPI3REF: Run-Time Limit Categories
+* CAPI3REF: Run-Time Limit Categories
 */
 enum
 {
@@ -816,7 +816,7 @@ enum
 }
 
 /**
-** CAPI3REF: Prepare Flags
+* CAPI3REF: Prepare Flags
 */
 enum
 {
@@ -826,7 +826,7 @@ enum
 }
 
 /**
-** CAPI3REF: Compiling An SQL Statement
+* CAPI3REF: Compiling An SQL Statement
 */
 int sqlite3_prepare(
     sqlite3 *db,            /** Database handle */
@@ -879,7 +879,7 @@ int sqlite3_prepare16_v3(
 );
 
 /**
-** CAPI3REF: Retrieving Statement SQL
+* CAPI3REF: Retrieving Statement SQL
 */
 const(char)* sqlite3_sql(sqlite3_stmt *pStmt);
 /// Ditto
@@ -887,33 +887,33 @@ char* sqlite3_expanded_sql(sqlite3_stmt *pStmt);
 const(char)* sqlite3_normalized_sql(sqlite3_stmt *pStmt);
 
 /*
-** CAPI3REF: Determine If An SQL Statement Writes The Database
+* CAPI3REF: Determine If An SQL Statement Writes The Database
 */
 int sqlite3_stmt_readonly(sqlite3_stmt *pStmt);
 
 /*
-** CAPI3REF: Query The EXPLAIN Setting For A Prepared Statement
+* CAPI3REF: Query The EXPLAIN Setting For A Prepared Statement
 */
 int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Determine If A Prepared Statement Has Been Reset
+* CAPI3REF: Determine If A Prepared Statement Has Been Reset
 */
 int sqlite3_stmt_busy(sqlite3_stmt*);
 
 
 /**
-** CAPI3REF: Dynamically Typed Value Object
+* CAPI3REF: Dynamically Typed Value Object
 */
 struct sqlite3_value;
 
 /**
-** CAPI3REF: SQL Function Context Object
+* CAPI3REF: SQL Function Context Object
 */
 struct sqlite3_context;
 
 /**
-** CAPI3REF: Binding Values To Prepared Statements
+* CAPI3REF: Binding Values To Prepared Statements
 */
 int sqlite3_bind_blob(sqlite3_stmt*, int, const void*, int n, void function (void*));
 /// Ditto
@@ -940,39 +940,39 @@ int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
 int sqlite3_bind_zeroblob64(sqlite3_stmt*, int, sqlite3_uint64 n);
 
 /**
-** CAPI3REF: Number Of SQL Parameters
+* CAPI3REF: Number Of SQL Parameters
 */
 int sqlite3_bind_parameter_count(sqlite3_stmt*);
 
 /**
-** CAPI3REF: Name Of A Host Parameter
+* CAPI3REF: Name Of A Host Parameter
 */
 const(char)* sqlite3_bind_parameter_name(sqlite3_stmt*, int);
 
 /**
-** CAPI3REF: Index Of A Parameter With A Given Name
+* CAPI3REF: Index Of A Parameter With A Given Name
 */
 int sqlite3_bind_parameter_index(sqlite3_stmt*, const char *zName);
 
 /**
-** CAPI3REF: Reset All Bindings On A Prepared Statement
+* CAPI3REF: Reset All Bindings On A Prepared Statement
 */
 int sqlite3_clear_bindings(sqlite3_stmt*);
 
 /**
-** CAPI3REF: Number Of Columns In A Result Set
+* CAPI3REF: Number Of Columns In A Result Set
 */
 int sqlite3_column_count(sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Column Names In A Result Set
+* CAPI3REF: Column Names In A Result Set
 */
 const(char)* sqlite3_column_name(sqlite3_stmt*, int N);
 /// Ditto
 const(void)* sqlite3_column_name16(sqlite3_stmt*, int N);
 
 /**
-** CAPI3REF: Source Of Data In A Query Result
+* CAPI3REF: Source Of Data In A Query Result
 */
 const(char)* sqlite3_column_database_name(sqlite3_stmt*,int);
 /// Ditto
@@ -987,24 +987,24 @@ const (char)* sqlite3_column_origin_name(sqlite3_stmt*,int);
 const (void)* sqlite3_column_origin_name16(sqlite3_stmt*,int);
 
 /**
-** CAPI3REF: Declared Datatype Of A Query Result
+* CAPI3REF: Declared Datatype Of A Query Result
 */
 const (char)* sqlite3_column_decltype(sqlite3_stmt*,int);
 /// Ditto
 const (void)* sqlite3_column_decltype16(sqlite3_stmt*,int);
 
 /**
-** CAPI3REF: Evaluate An SQL Statement
+* CAPI3REF: Evaluate An SQL Statement
 */
 int sqlite3_step(sqlite3_stmt*);
 
 /**
-** CAPI3REF: Number of columns in a result set
+* CAPI3REF: Number of columns in a result set
 */
 int sqlite3_data_count(sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Fundamental Datatypes
+* CAPI3REF: Fundamental Datatypes
 */
 enum
 {
@@ -1016,7 +1016,7 @@ enum
 }
 
 /**
-** CAPI3REF: Result Values From A Query
+* CAPI3REF: Result Values From A Query
 */
 const (void)* sqlite3_column_blob(sqlite3_stmt*, int iCol);
 /// Ditto
@@ -1039,17 +1039,17 @@ int sqlite3_column_bytes16(sqlite3_stmt*, int iCol);
 int sqlite3_column_type(sqlite3_stmt*, int iCol);
 
 /**
-** CAPI3REF: Destroy A Prepared Statement Object
+* CAPI3REF: Destroy A Prepared Statement Object
 */
 int sqlite3_finalize(sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Reset A Prepared Statement Object
+* CAPI3REF: Reset A Prepared Statement Object
 */
 int sqlite3_reset(sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Create Or Redefine SQL Functions
+* CAPI3REF: Create Or Redefine SQL Functions
 */
 int sqlite3_create_function(
     sqlite3 *db,
@@ -1099,10 +1099,10 @@ int sqlite3_create_window_function(
 );
 
 /**
-** CAPI3REF: Text Encodings
-**
-** These constant define integer codes that represent the various
-** text encodings supported by SQLite.
+* CAPI3REF: Text Encodings
+*
+* These constant define integer codes that represent the various
+* text encodings supported by SQLite.
 */
 enum
 {
@@ -1115,12 +1115,12 @@ enum
 }
 
 /**
-** CAPI3REF: Function Flags
+* CAPI3REF: Function Flags
 */
 enum SQLITE_DETERMINISTIC = 0x800;
 
 /**
-** CAPI3REF: Deprecated Functions
+* CAPI3REF: Deprecated Functions
 */
 deprecated int sqlite3_aggregate_count(sqlite3_context*);
 deprecated int sqlite3_expired(sqlite3_stmt*);
@@ -1130,7 +1130,7 @@ deprecated void sqlite3_thread_cleanup();
 deprecated int sqlite3_memory_alarm(void function(void*,sqlite3_int64,int),void*,sqlite3_int64);
 
 /**
-** CAPI3REF: Obtaining SQL Function Parameter Values
+* CAPI3REF: Obtaining SQL Function Parameter Values
 */
 const (void)* sqlite3_value_blob(sqlite3_value*);
 /// Ditto
@@ -1161,33 +1161,33 @@ int sqlite3_value_nochange(sqlite3_value*);
 int sqlite3_value_frombind(sqlite3_value*);
 
 /*
-** CAPI3REF: Finding The Subtype Of SQL Values
+* CAPI3REF: Finding The Subtype Of SQL Values
 */
 uint sqlite3_value_subtype(sqlite3_value*);
 
 /*
-** CAPI3REF: Copy And Free SQL Values
+* CAPI3REF: Copy And Free SQL Values
 */
 sqlite3_value* sqlite3_value_dup(const sqlite3_value*);
 void sqlite3_value_free(sqlite3_value*);
 
 /**
-** CAPI3REF: Obtain Aggregate Function Context
+* CAPI3REF: Obtain Aggregate Function Context
 */
 void *sqlite3_aggregate_context(sqlite3_context*, int nBytes);
 
 /**
-** CAPI3REF: User Data For Functions
+* CAPI3REF: User Data For Functions
 */
 void *sqlite3_user_data(sqlite3_context*);
 
 /**
-** CAPI3REF: Database Connection For Functions
+* CAPI3REF: Database Connection For Functions
 */
 sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 
 /**
-** CAPI3REF: Function Auxiliary Data
+* CAPI3REF: Function Auxiliary Data
 */
 void *sqlite3_get_auxdata(sqlite3_context*, int N);
 /// Ditto
@@ -1195,7 +1195,7 @@ void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void function (void*));
 
 
 /**
-** CAPI3REF: Constants Defining Special Destructor Behavior
+* CAPI3REF: Constants Defining Special Destructor Behavior
 */
 alias sqlite3_destructor_type = void function (void*);
 /// Ditto
@@ -1206,7 +1206,7 @@ enum
 }
 
 /**
-** CAPI3REF: Setting The Result Of An SQL Function
+* CAPI3REF: Setting The Result Of An SQL Function
 */
 void sqlite3_result_blob(sqlite3_context*, const void*, int, void function(void*));
 /// Ditto
@@ -1247,12 +1247,12 @@ void sqlite3_result_zeroblob(sqlite3_context*, int n);
 int sqlite3_result_zeroblob64(sqlite3_context*, sqlite3_uint64 n);
 
 /*
-** CAPI3REF: Setting The Subtype Of An SQL Function
+* CAPI3REF: Setting The Subtype Of An SQL Function
 */
 void sqlite3_result_subtype(sqlite3_context*,uint);
 
 /**
-** CAPI3REF: Define New Collating Sequences
+* CAPI3REF: Define New Collating Sequences
 */
 int sqlite3_create_collation(
     sqlite3*,
@@ -1280,7 +1280,7 @@ int sqlite3_create_collation16(
 );
 
 /**
-** CAPI3REF: Collation Needed Callbacks
+* CAPI3REF: Collation Needed Callbacks
 */
 int sqlite3_collation_needed(
     sqlite3*,
@@ -1307,12 +1307,12 @@ int sqlite3_key_v2(
 );
 
 /**
-** Change the key on an open database.  If the current database is not
-** encrypted, this routine will encrypt it.  If pNew == 0 or nNew == 0, the
-** database is decrypted.
-**
-** The code to implement this API is not available in the public release
-** of SQLite.
+* Change the key on an open database.  If the current database is not
+* encrypted, this routine will encrypt it.  If pNew == 0 or nNew == 0, the
+* database is decrypted.
+*
+* The code to implement this API is not available in the public release
+* of SQLite.
 */
 int sqlite3_rekey(
     sqlite3 *db,                   /** Database to be rekeyed */
@@ -1325,38 +1325,38 @@ int sqlite3_rekey_v2(
 );
 
 /**
-** Specify the activation key for a SEE database.  Unless
-** activated, none of the SEE routines will work.
+* Specify the activation key for a SEE database.  Unless
+* activated, none of the SEE routines will work.
 */
 void sqlite3_activate_see(
     const(char)*zPassPhrase        /** Activation phrase */
 );
 
 /**
-** Specify the activation key for a CEROD database.  Unless
-** activated, none of the CEROD routines will work.
+* Specify the activation key for a CEROD database.  Unless
+* activated, none of the CEROD routines will work.
 */
 void sqlite3_activate_cerod(
     const(char)*zPassPhrase        /** Activation phrase */
 );
 
 /**
-** CAPI3REF: Suspend Execution For A Short Time
+* CAPI3REF: Suspend Execution For A Short Time
 */
 int sqlite3_sleep(int);
 
 /**
-** CAPI3REF: Name Of The Folder Holding Temporary Files
+* CAPI3REF: Name Of The Folder Holding Temporary Files
 */
 extern char *sqlite3_temp_directory;
 
 /**
-** CAPI3REF: Name Of The Folder Holding Database Files
+* CAPI3REF: Name Of The Folder Holding Database Files
 */
 extern char *sqlite3_data_directory;
 
 /**
-** CAPI3REF: Win32 Specific Interface
+* CAPI3REF: Win32 Specific Interface
 */
 int sqlite3_win32_set_directory(
     c_ulong type,        /** Identifier for directory being set or reset */
@@ -1374,7 +1374,7 @@ int sqlite3_win32_set_directory16(
 );
 
 /**
-** CAPI3REF: Win32 Directory Types
+* CAPI3REF: Win32 Directory Types
 */
 enum
 {
@@ -1383,39 +1383,39 @@ enum
 }
 
 /**
-** CAPI3REF: Test For Auto-Commit Mode
+* CAPI3REF: Test For Auto-Commit Mode
 */
 int sqlite3_get_autocommit(sqlite3*);
 
 /**
-** CAPI3REF: Find The Database Handle Of A Prepared Statement
+* CAPI3REF: Find The Database Handle Of A Prepared Statement
 */
 sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 
 /**
-** CAPI3REF: Return The Filename For A Database Connection
+* CAPI3REF: Return The Filename For A Database Connection
 */
 const(char)* sqlite3_db_filename(sqlite3 *db, const char* zDbName);
 
 /**
-** CAPI3REF: Determine if a database is read-only
+* CAPI3REF: Determine if a database is read-only
 */
 int sqlite3_db_readonly(sqlite3 *db, const char * zDbName);
 
 /*
-** CAPI3REF: Find the next prepared statement
+* CAPI3REF: Find the next prepared statement
 */
 sqlite3_stmt *sqlite3_next_stmt(sqlite3 *pDb, sqlite3_stmt *pStmt);
 
 /**
-** CAPI3REF: Commit And Rollback Notification Callbacks
+* CAPI3REF: Commit And Rollback Notification Callbacks
 */
 void *sqlite3_commit_hook(sqlite3*, int function (void*), void*);
 /// Ditto
 void *sqlite3_rollback_hook(sqlite3*, void function (void *), void*);
 
 /**
-** CAPI3REF: Data Change Notification Callbacks
+* CAPI3REF: Data Change Notification Callbacks
 */
 void *sqlite3_update_hook(
     sqlite3*,
@@ -1424,32 +1424,32 @@ void *sqlite3_update_hook(
 );
 
 /**
-** CAPI3REF: Enable Or Disable Shared Pager Cache
+* CAPI3REF: Enable Or Disable Shared Pager Cache
 */
 int sqlite3_enable_shared_cache(int);
 
 /**
-** CAPI3REF: Attempt To Free Heap Memory
+* CAPI3REF: Attempt To Free Heap Memory
 */
 int sqlite3_release_memory(int);
 
 /**
-** CAPI3REF: Free Memory Used By A Database Connection
+* CAPI3REF: Free Memory Used By A Database Connection
 */
 int sqlite3_db_release_memory(sqlite3*);
 
 /*
-** CAPI3REF: Impose A Limit On Heap Size
+* CAPI3REF: Impose A Limit On Heap Size
 */
 sqlite3_int64 sqlite3_soft_heap_limit64(sqlite3_int64 N);
 
 /**
-** CAPI3REF: Deprecated Soft Heap Limit Interface
+* CAPI3REF: Deprecated Soft Heap Limit Interface
 */
 deprecated void sqlite3_soft_heap_limit(int N);
 
 /**
-** CAPI3REF: Extract Metadata About A Column Of A Table
+* CAPI3REF: Extract Metadata About A Column Of A Table
 */
 int sqlite3_table_column_metadata(
     sqlite3 *db,                /** Connection handle */
@@ -1464,7 +1464,7 @@ int sqlite3_table_column_metadata(
 );
 
 /**
-** CAPI3REF: Load An Extension
+* CAPI3REF: Load An Extension
 */
 int sqlite3_load_extension(
     sqlite3 *db,          /** Load the extension into this database connection */
@@ -1474,36 +1474,36 @@ int sqlite3_load_extension(
 );
 
 /**
-** CAPI3REF: Enable Or Disable Extension Loading
+* CAPI3REF: Enable Or Disable Extension Loading
 */
 int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
 
 /**
-** CAPI3REF: Automatically Load Statically Linked Extensions
+* CAPI3REF: Automatically Load Statically Linked Extensions
 */
 int sqlite3_auto_extension(void function () xEntryPoint);
 
 /**
-** CAPI3REF: Cancel Automatic Extension Loading
+* CAPI3REF: Cancel Automatic Extension Loading
 */
 int sqlite3_cancel_auto_extension(void function() xEntryPoint);
 
 /**
-** CAPI3REF: Reset Automatic Extension Loading
+* CAPI3REF: Reset Automatic Extension Loading
 */
 void sqlite3_reset_auto_extension();
 
 /**
-** The interface to the virtual-table mechanism is currently considered
-** to be experimental.  The interface might change in incompatible ways.
-** If this is a problem for you, do not use the interface at this time.
-**
-** When the virtual-table mechanism stabilizes, we will declare the
-** interface fixed, support it indefinitely, and remove this comment.
+* The interface to the virtual-table mechanism is currently considered
+* to be experimental.  The interface might change in incompatible ways.
+* If this is a problem for you, do not use the interface at this time.
+*
+* When the virtual-table mechanism stabilizes, we will declare the
+* interface fixed, support it indefinitely, and remove this comment.
 */
 
 /**
-** CAPI3REF: Virtual Table Object
+* CAPI3REF: Virtual Table Object
 */
 
 alias mapFunction = void function (sqlite3_context*,int,sqlite3_value**);
@@ -1545,7 +1545,7 @@ struct sqlite3_module
 }
 
 /**
-** CAPI3REF: Virtual Table Indexing Information
+* CAPI3REF: Virtual Table Indexing Information
 */
 struct sqlite3_index_info
 {
@@ -1584,7 +1584,7 @@ struct sqlite3_index_info
 }
 
 /**
-** CAPI3REF: Virtual Table Scan Flags
+* CAPI3REF: Virtual Table Scan Flags
 */
 enum
 {
@@ -1592,7 +1592,7 @@ enum
 }
 
 /**
-** CAPI3REF: Virtual Table Constraint Operator Codes
+* CAPI3REF: Virtual Table Constraint Operator Codes
 */
 enum
 {
@@ -1614,7 +1614,7 @@ enum
 }
 
 /**
-** CAPI3REF: Register A Virtual Table Implementation
+* CAPI3REF: Register A Virtual Table Implementation
 */
 int sqlite3_create_module(
     sqlite3 *db,                    /* SQLite connection to register module with */
@@ -1632,7 +1632,7 @@ int sqlite3_create_module_v2(
 );
 
 /**
-** CAPI3REF: Virtual Table Instance Object
+* CAPI3REF: Virtual Table Instance Object
 */
 struct sqlite3_vtab
 {
@@ -1643,7 +1643,7 @@ struct sqlite3_vtab
 }
 
 /**
-** CAPI3REF: Virtual Table Cursor Object
+* CAPI3REF: Virtual Table Cursor Object
 */
 struct sqlite3_vtab_cursor
 {
@@ -1652,32 +1652,32 @@ struct sqlite3_vtab_cursor
 }
 
 /**
-** CAPI3REF: Declare The Schema Of A Virtual Table
+* CAPI3REF: Declare The Schema Of A Virtual Table
 */
 int sqlite3_declare_vtab(sqlite3*, const char *zSQL);
 
 /**
-** CAPI3REF: Overload A Function For A Virtual Table
+* CAPI3REF: Overload A Function For A Virtual Table
 */
 int sqlite3_overload_function(sqlite3*, const char *zFuncName, int nArg);
 
 /**
-** The interface to the virtual-table mechanism defined above (back up
-** to a comment remarkably similar to this one) is currently considered
-** to be experimental.  The interface might change in incompatible ways.
-** If this is a problem for you, do not use the interface at this time.
-**
-** When the virtual-table mechanism stabilizes, we will declare the
-** interface fixed, support it indefinitely, and remove this comment.
+* The interface to the virtual-table mechanism defined above (back up
+* to a comment remarkably similar to this one) is currently considered
+* to be experimental.  The interface might change in incompatible ways.
+* If this is a problem for you, do not use the interface at this time.
+*
+* When the virtual-table mechanism stabilizes, we will declare the
+* interface fixed, support it indefinitely, and remove this comment.
 */
 
 /*
-** CAPI3REF: A Handle To An Open BLOB
+* CAPI3REF: A Handle To An Open BLOB
 */
 struct sqlite3_blob;
 
 /**
-** CAPI3REF: Open A BLOB For Incremental I/O
+* CAPI3REF: Open A BLOB For Incremental I/O
 */
 int sqlite3_blob_open(
     sqlite3*,
@@ -1690,32 +1690,32 @@ int sqlite3_blob_open(
 );
 
 /**
-** CAPI3REF: Move a BLOB Handle to a New Row
+* CAPI3REF: Move a BLOB Handle to a New Row
 */
 int sqlite3_blob_reopen(sqlite3_blob *, sqlite3_int64);
 
 /**
-** CAPI3REF: Close A BLOB Handle
+* CAPI3REF: Close A BLOB Handle
 */
 int sqlite3_blob_close(sqlite3_blob *);
 
 /**
-** CAPI3REF: Return The Size Of An Open BLOB
+* CAPI3REF: Return The Size Of An Open BLOB
 */
 int sqlite3_blob_bytes(sqlite3_blob *);
 
 /**
-** CAPI3REF: Read Data From A BLOB Incrementally
+* CAPI3REF: Read Data From A BLOB Incrementally
 */
 int sqlite3_blob_read(sqlite3_blob *, void *Z, int N, int iOffset);
 
 /**
-** CAPI3REF: Write Data Into A BLOB Incrementally
+* CAPI3REF: Write Data Into A BLOB Incrementally
 */
 int sqlite3_blob_write(sqlite3_blob *, const void *z, int n, int iOffset);
 
 /**
-** CAPI3REF: Virtual File System Objects
+* CAPI3REF: Virtual File System Objects
 */
 sqlite3_vfs *sqlite3_vfs_find(const char *zVfsName);
 /// Ditto
@@ -1724,7 +1724,7 @@ int sqlite3_vfs_register(sqlite3_vfs*, int makeDflt);
 int sqlite3_vfs_unregister(sqlite3_vfs*);
 
 /**
-** CAPI3REF: Mutexes
+* CAPI3REF: Mutexes
 */
 sqlite3_mutex *sqlite3_mutex_alloc(int);
 /// Ditto
@@ -1737,7 +1737,7 @@ int sqlite3_mutex_try(sqlite3_mutex*);
 void sqlite3_mutex_leave(sqlite3_mutex*);
 
 /**
-** CAPI3REF: Mutex Methods Object
+* CAPI3REF: Mutex Methods Object
 */
 struct sqlite3_mutex_methods
 {
@@ -1753,7 +1753,7 @@ struct sqlite3_mutex_methods
 }
 
 /**
-** CAPI3REF: Mutex Verification Routines
+* CAPI3REF: Mutex Verification Routines
 */
 
 //#ifndef NDEBUG
@@ -1763,7 +1763,7 @@ int sqlite3_mutex_notheld(sqlite3_mutex*);
 //#endif
 
 /**
-** CAPI3REF: Mutex Types
+* CAPI3REF: Mutex Types
 */
 enum
 {
@@ -1786,22 +1786,22 @@ enum
 }
 
 /**
-** CAPI3REF: Retrieve the mutex for a database connection
+* CAPI3REF: Retrieve the mutex for a database connection
 */
 sqlite3_mutex *sqlite3_db_mutex(sqlite3*);
 
 /**
-** CAPI3REF: Low-Level Control Of Database Files
+* CAPI3REF: Low-Level Control Of Database Files
 */
 int sqlite3_file_control(sqlite3*, const char *zDbName, int op, void*);
 
 /**
-** CAPI3REF: Testing Interface
+* CAPI3REF: Testing Interface
 */
 int sqlite3_test_control(int op, ...);
 
 /**
-** CAPI3REF: Testing Interface Operation Codes
+* CAPI3REF: Testing Interface Operation Codes
 */
 enum
 {
@@ -1834,7 +1834,7 @@ enum
 }
 
 /**
-** CAPI3REF: SQL Keyword Checking
+* CAPI3REF: SQL Keyword Checking
 */
 int sqlite3_keyword_count();
 /// Ditto
@@ -1843,22 +1843,22 @@ int sqlite3_keyword_name(int, const(char*)*, int*);
 int sqlite3_keyword_check(const(char)*, int);
 
 /**
-** CAPI3REF: Dynamic String Object
+* CAPI3REF: Dynamic String Object
 */
 struct sqlite3_str;
 
 /**
-** CAPI3REF: Create A New Dynamic String Object
+* CAPI3REF: Create A New Dynamic String Object
 */
 sqlite3_str* sqlite3_str_new(sqlite3*);
 
 /**
-** CAPI3REF: Finalize A Dynamic String
+* CAPI3REF: Finalize A Dynamic String
 */
 char* sqlite3_str_finish(sqlite3_str*);
 
 /**
-** CAPI3REF: Add Content To A Dynamic String
+* CAPI3REF: Add Content To A Dynamic String
 */
 void sqlite3_str_appendf(sqlite3_str*, const(char)* zFormat, ...);
 /// Ditto
@@ -1873,21 +1873,21 @@ void sqlite3_str_appendchar(sqlite3_str*, int N, char C);
 void sqlite3_str_reset(sqlite3_str*);
 
 /**
-** CAPI3REF: Status Of A Dynamic String
+* CAPI3REF: Status Of A Dynamic String
 */
 int sqlite3_str_errcode(sqlite3_str*);
 int sqlite3_str_length(sqlite3_str*);
 char* sqlite3_str_value(sqlite3_str*);
 
 /**
-** CAPI3REF: SQLite Runtime Status
+* CAPI3REF: SQLite Runtime Status
 */
 int sqlite3_status(int op, int *pCurrent, int *pHighwater, int resetFlag);
 /// Ditto
 int  sqlite3_status64(int op, long *pCurrent, long *pHighwater, int resetFlag);
 
 /**
-** CAPI3REF: Status Parameters
+* CAPI3REF: Status Parameters
 */
 enum
 {
@@ -1904,12 +1904,12 @@ enum
 }
 
 /**
-** CAPI3REF: Database Connection Status
+* CAPI3REF: Database Connection Status
 */
 int sqlite3_db_status(sqlite3*, int op, int *pCur, int *pHiwtr, int resetFlg);
 
 /**
-** CAPI3REF: Status Parameters for database connections
+* CAPI3REF: Status Parameters for database connections
 */
 enum
 {
@@ -1930,12 +1930,12 @@ enum
 }
 
 /**
-** CAPI3REF: Prepared Statement Status
+* CAPI3REF: Prepared Statement Status
 */
 int sqlite3_stmt_status(sqlite3_stmt*, int op,int resetFlg);
 
 /**
-** CAPI3REF: Status Parameters for prepared statements
+* CAPI3REF: Status Parameters for prepared statements
 */
 enum
 {
@@ -1949,12 +1949,12 @@ enum
 }
 
 /**
-** CAPI3REF: Custom Page Cache Object
+* CAPI3REF: Custom Page Cache Object
 */
 struct sqlite3_pcache;
 
 /**
-** CAPI3REF: Custom Page Cache Object
+* CAPI3REF: Custom Page Cache Object
 */
 struct sqlite3_pcache_page
 {
@@ -1963,7 +1963,7 @@ struct sqlite3_pcache_page
 }
 
 /**
-** CAPI3REF: Application Defined Page Cache.
+* CAPI3REF: Application Defined Page Cache.
 */
 struct sqlite3_pcache_methods2
 {
@@ -1999,12 +1999,12 @@ struct sqlite3_pcache_methods
 }
 
 /**
-** CAPI3REF: Online Backup Object
+* CAPI3REF: Online Backup Object
 */
 struct sqlite3_backup;
 
 /**
-** CAPI3REF: Online Backup API.
+* CAPI3REF: Online Backup API.
 */
 sqlite3_backup *sqlite3_backup_init(
     sqlite3 *pDest,                        /** Destination database handle */
@@ -2022,7 +2022,7 @@ int sqlite3_backup_remaining(sqlite3_backup *p);
 int sqlite3_backup_pagecount(sqlite3_backup *p);
 
 /**
-** CAPI3REF: Unlock Notification
+* CAPI3REF: Unlock Notification
 */
 int sqlite3_unlock_notify(
     sqlite3 *pBlocked,                               /** Waiting connection */
@@ -2031,29 +2031,29 @@ int sqlite3_unlock_notify(
 );
 
 /**
-** CAPI3REF: String Comparison
+* CAPI3REF: String Comparison
 */
 int sqlite3_stricmp(const char * , const char * );
 int sqlite3_strnicmp(const char * , const char * , int);
 
 /*
-** CAPI3REF: String Globbing
+* CAPI3REF: String Globbing
 *
 */
 int sqlite3_strglob(const(char)* zGlob, const(char)* zStr);
 
 /*
-** CAPI3REF: String LIKE Matching
+* CAPI3REF: String LIKE Matching
 */
 int sqlite3_strlike(const(char)* zGlob, const(char)* zStr, uint cEsc);
 
 /**
-** CAPI3REF: Error Logging Interface
+* CAPI3REF: Error Logging Interface
 */
 void sqlite3_log(int iErrCode, const char *zFormat, ...);
 
 /**
-** CAPI3REF: Write-Ahead Log Commit Hook
+* CAPI3REF: Write-Ahead Log Commit Hook
 */
 void *sqlite3_wal_hook(
     sqlite3*,
@@ -2062,17 +2062,17 @@ void *sqlite3_wal_hook(
 );
 
 /**
-** CAPI3REF: Configure an auto-checkpoint
+* CAPI3REF: Configure an auto-checkpoint
 */
 int sqlite3_wal_autocheckpoint(sqlite3 *db, int N);
 
 /**
-** CAPI3REF: Checkpoint a database
+* CAPI3REF: Checkpoint a database
 */
 int sqlite3_wal_checkpoint(sqlite3 *db, const char *zDb);
 
 /**
-** CAPI3REF: Checkpoint a database
+* CAPI3REF: Checkpoint a database
 */
 int sqlite3_wal_checkpoint_v2(
     sqlite3 *db,                    /** Database handle */
@@ -2083,7 +2083,7 @@ int sqlite3_wal_checkpoint_v2(
 );
 
 /**
-** CAPI3REF: Checkpoint operation parameters
+* CAPI3REF: Checkpoint operation parameters
 */
 enum
 {
@@ -2094,26 +2094,26 @@ enum
 }
 
 /*
-** CAPI3REF: Virtual Table Interface Configuration
+* CAPI3REF: Virtual Table Interface Configuration
 */
 int sqlite3_vtab_config(sqlite3*, int op, ...);
 
 /**
-** CAPI3REF: Virtual Table Configuration Options
+* CAPI3REF: Virtual Table Configuration Options
 */
 enum SQLITE_VTAB_CONSTRAINT_SUPPORT = 1;
 
 /*
-** 2010 August 30
-**
-** The author disclaims copyright to this source code.  In place of
-** a legal notice, here is a blessing:
-**
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
-**
-*************************************************************************
+* 2010 August 30
+*
+* The author disclaims copyright to this source code.  In place of
+* a legal notice, here is a blessing:
+*
+*    May you do good and not evil.
+*    May you find forgiveness for yourself and forgive others.
+*    May you share freely, never taking more than you give.
+*
+************************************************************************
 */
 
 //#ifndef _SQLITE3RTREE_H_
@@ -2121,22 +2121,22 @@ enum SQLITE_VTAB_CONSTRAINT_SUPPORT = 1;
 
 
 /*
-** CAPI3REF: Determine The Virtual Table Conflict Policy
+* CAPI3REF: Determine The Virtual Table Conflict Policy
 */
 int sqlite3_vtab_on_conflict(sqlite3 *);
 
 /*
-** CAPI3REF: Determine If Virtual Table Column Access Is For UPDATE
+* CAPI3REF: Determine If Virtual Table Column Access Is For UPDATE
 */
 int sqlite3_vtab_nochange(sqlite3_context*);
 
 /*
-** CAPI3REF: Determine The Collation For a Virtual Table Constraint
+* CAPI3REF: Determine The Collation For a Virtual Table Constraint
 */
 const(char)* sqlite3_vtab_collation (sqlite3_index_info*, int);
 
 /*
-** CAPI3REF: Conflict resolution modes
+* CAPI3REF: Conflict resolution modes
 */
 enum
 {
@@ -2146,7 +2146,7 @@ enum
 }
 
 /*
-** CAPI3REF: Prepared Statement Scan Status Opcodes
+* CAPI3REF: Prepared Statement Scan Status Opcodes
 */
 enum
 {
@@ -2159,22 +2159,22 @@ enum
 }
 
 /*
-** CAPI3REF: Prepared Statement Scan Status
+* CAPI3REF: Prepared Statement Scan Status
 */
 int sqlite3_stmt_scanstatus(sqlite3_stmt *pStmt, int idx, int iScanStatusOp, void *pOut);
 
 /*
-** CAPI3REF: Zero Scan-Status Counters
+* CAPI3REF: Zero Scan-Status Counters
 */
 void sqlite3_stmt_scanstatus_reset(sqlite3_stmt *);
 
 /*
-** CAPI3REF: Flush caches to disk mid-transaction
+* CAPI3REF: Flush caches to disk mid-transaction
 */
 int sqlite3_db_cacheflush(sqlite3 *);
 
 /*
-** CAPI3REF: The pre-update hook
+* CAPI3REF: The pre-update hook
 */
 void* sqlite3_preupdate_hook(
     sqlite3* db,
@@ -2199,7 +2199,7 @@ int sqlite3_preupdate_depth(sqlite3*);
 int sqlite3_preupdate_new(sqlite3*, int, sqlite3_value**);
 
 /*
-** CAPI3REF: Database Snapshot
+* CAPI3REF: Database Snapshot
 */
 struct sqlite3_snapshot
 {
@@ -2207,32 +2207,32 @@ struct sqlite3_snapshot
 }
 
 /*
-** CAPI3REF: Record A Database Snapshot
+* CAPI3REF: Record A Database Snapshot
 */
 int sqlite3_snapshot_get(sqlite3 *db, char *zSchema, sqlite3_snapshot **ppSnapshot);
 
 /*
-** CAPI3REF: Start a read transaction on an historical snapshot
+* CAPI3REF: Start a read transaction on an historical snapshot
 */
 int sqlite3_snapshot_open(sqlite3 *db, char *zSchema, sqlite3_snapshot *pSnapshot);
 
 /*
-** CAPI3REF: Destroy a snapshot
+* CAPI3REF: Destroy a snapshot
 */
 void sqlite3_snapshot_free(sqlite3_snapshot *);
 
 /*
-** CAPI3REF: Compare the ages of two snapshot handles
+* CAPI3REF: Compare the ages of two snapshot handles
 */
 int sqlite3_snapshot_cmp(sqlite3_snapshot* p1, sqlite3_snapshot* p2);
 
 /*
-** CAPI3REF: Recover snapshots from a wal file
+* CAPI3REF: Recover snapshots from a wal file
 */
 int sqlite3_snapshot_recover (sqlite3* db, const(char)* zDb);
 
 /*
-** CAPI3REF: Serialize a database
+* CAPI3REF: Serialize a database
 */
 ubyte* sqlite3_serialize(
     sqlite3* db,
@@ -2242,7 +2242,7 @@ ubyte* sqlite3_serialize(
 );
 
 /*
-** CAPI3REF: Serialize a database
+* CAPI3REF: Serialize a database
 */
 enum
 {
@@ -2250,7 +2250,7 @@ enum
 }
 
 /*
-** CAPI3REF: Deserialize a database
+* CAPI3REF: Deserialize a database
 */
 int sqlite3_deserialize (
     sqlite3* db,
@@ -2262,7 +2262,7 @@ int sqlite3_deserialize (
 );
 
 /*
-** CAPI3REF: Flags for sqlite3_deserialize()
+* CAPI3REF: Flags for sqlite3_deserialize()
 */
 enum
 {
@@ -2272,10 +2272,10 @@ enum
 }
 
 /**
-** Register a geometry callback named zGeom that can be used as part of an
-** R-Tree geometry query as follows:
-**
-**   SELECT ... FROM $(LT)rtree$(GT) WHERE $(LT)rtree col$(GT) MATCH $zGeom(... params ...)
+* Register a geometry callback named zGeom that can be used as part of an
+* R-Tree geometry query as follows:
+*
+*   SELECT ... FROM $(LT)rtree$(GT) WHERE $(LT)rtree col$(GT) MATCH $zGeom(... params ...)
 */
 int sqlite3_rtree_geometry_callback(
     sqlite3 *db,
@@ -2285,8 +2285,8 @@ int sqlite3_rtree_geometry_callback(
 );
 
 /**
-** A pointer to a structure of the following type is passed as the first
-** argument to callbacks registered using rtree_geometry_callback().
+* A pointer to a structure of the following type is passed as the first
+* argument to callbacks registered using rtree_geometry_callback().
 */
 struct sqlite3_rtree_geometry
 {
@@ -2333,17 +2333,17 @@ enum
 }
 
 /*
-** CAPI3REF: Session Object Handle
+* CAPI3REF: Session Object Handle
 */
 struct sqlite3_session;
 
 /*
-** CAPI3REF: Session Object Handle
+* CAPI3REF: Session Object Handle
 */
 struct sqlite3_changeset_iter;
 
 /*
-** CAPI3REF: Create A New Session Object
+* CAPI3REF: Create A New Session Object
 */
 int sqlite3session_create (
     sqlite3* db,
@@ -2352,27 +2352,27 @@ int sqlite3session_create (
 );
 
 /*
-** CAPI3REF: Delete A Session Object
+* CAPI3REF: Delete A Session Object
 */
 void sqlite3session_delete(sqlite3_session* pSession);
 
 /*
-** CAPI3REF: Enable Or Disable A Session Object
+* CAPI3REF: Enable Or Disable A Session Object
 */
 int sqlite3session_enable(sqlite3_session* pSession, int bEnable);
 
 /*
-** CAPI3REF: Set Or Clear the Indirect Change Flag
+* CAPI3REF: Set Or Clear the Indirect Change Flag
 */
 int sqlite3session_indirect(sqlite3_session* pSession, int bIndirect);
 
 /*
-** CAPI3REF: Attach A Table To A Session Object
+* CAPI3REF: Attach A Table To A Session Object
 */
 int sqlite3session_attach(sqlite3_session* pSession, const(char)* zTab);
 
 /*
-** CAPI3REF: Set a table filter on a Session Object
+* CAPI3REF: Set a table filter on a Session Object
 */
 void sqlite3session_table_filter(
     sqlite3_session* pSession,
@@ -2381,7 +2381,7 @@ void sqlite3session_table_filter(
 );
 
 /*
-** CAPI3REF: Generate A Changeset From A Session Object
+* CAPI3REF: Generate A Changeset From A Session Object
 */
 int sqlite3session_changeset(
     sqlite3_session* pSession,
@@ -2390,7 +2390,7 @@ int sqlite3session_changeset(
 );
 
 /*
-** CAPI3REF: Load The Difference Between Tables Into A Session
+* CAPI3REF: Load The Difference Between Tables Into A Session
 */
 int sqlite3session_diff(
     sqlite3_session* pSession,
@@ -2400,7 +2400,7 @@ int sqlite3session_diff(
 );
 
 /*
-** CAPI3REF: Generate A Patchset From A Session Object
+* CAPI3REF: Generate A Patchset From A Session Object
 */
 int sqlite3session_patchset(
     sqlite3_session* pSession,
@@ -2409,12 +2409,12 @@ int sqlite3session_patchset(
 );
 
 /*
-** CAPI3REF: Test if a changeset has recorded any changes
+* CAPI3REF: Test if a changeset has recorded any changes
 */
 int sqlite3session_isempty (sqlite3_session* pSession);
 
 /*
-** CAPI3REF: Create An Iterator To Traverse A Changeset
+* CAPI3REF: Create An Iterator To Traverse A Changeset
 */
 int sqlite3changeset_start(
     sqlite3_changeset_iter** pp,
@@ -2430,7 +2430,7 @@ int sqlite3changeset_start_v2(
 );
 
 /*
-** CAPI3REF: Flags for sqlite3changeset_start_v2
+* CAPI3REF: Flags for sqlite3changeset_start_v2
 */
 enum
 {
@@ -2438,12 +2438,12 @@ enum
 }
 
 /*
-** CAPI3REF: Advance A Changeset Iterator
+* CAPI3REF: Advance A Changeset Iterator
 */
 int sqlite3changeset_next(sqlite3_changeset_iter* pIter);
 
 /*
-** CAPI3REF: Obtain The Current Operation From A Changeset Iterator
+* CAPI3REF: Obtain The Current Operation From A Changeset Iterator
 */
 int sqlite3changeset_op(
     sqlite3_changeset_iter* pIter,
@@ -2454,7 +2454,7 @@ int sqlite3changeset_op(
 );
 
 /*
-** CAPI3REF: Obtain The Primary Key Definition Of A Table
+* CAPI3REF: Obtain The Primary Key Definition Of A Table
 */
 int sqlite3changeset_pk(
     sqlite3_changeset_iter* pIter,
@@ -2463,7 +2463,7 @@ int sqlite3changeset_pk(
 );
 
 /*
-** CAPI3REF: Obtain old.* Values From A Changeset Iterator
+* CAPI3REF: Obtain old.* Values From A Changeset Iterator
 */
 int sqlite3changeset_old(
     sqlite3_changeset_iter* pIter,
@@ -2472,7 +2472,7 @@ int sqlite3changeset_old(
 );
 
 /*
-** CAPI3REF: Obtain new.* Values From A Changeset Iterator
+* CAPI3REF: Obtain new.* Values From A Changeset Iterator
 */
 int sqlite3changeset_new(
     sqlite3_changeset_iter* pIter,
@@ -2481,7 +2481,7 @@ int sqlite3changeset_new(
 );
 
 /*
-** CAPI3REF: Obtain Conflicting Row Values From A Changeset Iterator
+* CAPI3REF: Obtain Conflicting Row Values From A Changeset Iterator
 */
 int sqlite3changeset_conflict(
     sqlite3_changeset_iter* pIter,
@@ -2490,17 +2490,17 @@ int sqlite3changeset_conflict(
 );
 
 /*
-** CAPI3REF: Determine The Number Of Foreign Key Constraint Violations
+* CAPI3REF: Determine The Number Of Foreign Key Constraint Violations
 */
 int sqlite3changeset_fk_conflicts(sqlite3_changeset_iter* pIter, int* pnOut);
 
 /*
-** CAPI3REF: Finalize A Changeset Iterator
+* CAPI3REF: Finalize A Changeset Iterator
 */
 int sqlite3changeset_finalize (sqlite3_changeset_iter* pIter);
 
 /*
-** CAPI3REF: Invert A Changeset
+* CAPI3REF: Invert A Changeset
 */
 int sqlite3changeset_invert(
     int nIn,
@@ -2510,7 +2510,7 @@ int sqlite3changeset_invert(
 );
 
 /*
-** CAPI3REF: Concatenate Two Changeset Objects
+* CAPI3REF: Concatenate Two Changeset Objects
 */
 int sqlite3changeset_concat(
     int nA,
@@ -2522,22 +2522,22 @@ int sqlite3changeset_concat(
 );
 
 /*
-** CAPI3REF: Changegroup Handle
+* CAPI3REF: Changegroup Handle
 */
 struct sqlite3_changegroup;
 
 /*
-** CAPI3REF: Create A New Changegroup Object
+* CAPI3REF: Create A New Changegroup Object
 */
 int sqlite3changegroup_new(sqlite3_changegroup** pp);
 
 /*
-** CAPI3REF: Add A Changeset To A Changegroup
+* CAPI3REF: Add A Changeset To A Changegroup
 */
 int sqlite3changegroup_add(sqlite3_changegroup*, int nData, void* pData);
 
 /*
-** CAPI3REF: Obtain A Composite Changeset From A Changegroup
+* CAPI3REF: Obtain A Composite Changeset From A Changegroup
 */
 int sqlite3changegroup_output(
     sqlite3_changegroup*,
@@ -2546,12 +2546,12 @@ int sqlite3changegroup_output(
 );
 
 /*
-** CAPI3REF: Delete A Changegroup Object
+* CAPI3REF: Delete A Changegroup Object
 */
 void sqlite3changegroup_delete (sqlite3_changegroup*);
 
 /*
-** CAPI3REF: Apply A Changeset To A Database
+* CAPI3REF: Apply A Changeset To A Database
 */
 int sqlite3changeset_apply(
     sqlite3* db,
@@ -2575,7 +2575,7 @@ int sqlite3changeset_apply_v2(
 );
 
 /*
-** CAPI3REF: Flags for sqlite3changeset_apply_v2
+* CAPI3REF: Flags for sqlite3changeset_apply_v2
 */
 enum
 {
@@ -2584,7 +2584,7 @@ enum
 }
 
 /*
-** CAPI3REF: Constants Passed To The Conflict Handler
+* CAPI3REF: Constants Passed To The Conflict Handler
 */
 enum
 {
@@ -2596,7 +2596,7 @@ enum
 }
 
 /*
-** CAPI3REF: Constants Returned By The Conflict Handler
+* CAPI3REF: Constants Returned By The Conflict Handler
 */
 enum
 {
@@ -2606,17 +2606,17 @@ enum
 }
 
 /*
-** CAPI3REF: Rebasing changesets
+* CAPI3REF: Rebasing changesets
 */
 struct sqlite3_rebaser;
 
 /*
-** CAPI3REF: Create a changeset rebaser object
+* CAPI3REF: Create a changeset rebaser object
 */
 int sqlite3rebaser_create(sqlite3_rebaser** ppNew);
 
 /*
-** CAPI3REF: Configure a changeset rebaser object
+* CAPI3REF: Configure a changeset rebaser object
 */
 int sqlite3rebaser_configure(
     sqlite3_rebaser*,
@@ -2625,7 +2625,7 @@ int sqlite3rebaser_configure(
 );
 
 /*
-** CAPI3REF: Rebase a changeset
+* CAPI3REF: Rebase a changeset
 */
 int sqlite3rebaser_rebase(
     sqlite3_rebaser*,
@@ -2636,12 +2636,12 @@ int sqlite3rebaser_rebase(
 );
 
 /*
-** CAPI3REF: Delete a changeset rebaser object
+* CAPI3REF: Delete a changeset rebaser object
 */
 void sqlite3rebaser_delete(sqlite3_rebaser* p);
 
 /*
-** CAPI3REF: Streaming Versions of API functions
+* CAPI3REF: Streaming Versions of API functions
 */
 int sqlite3changeset_apply_strm(
     sqlite3* db,
@@ -2726,12 +2726,12 @@ int sqlite3rebaser_rebase_strm(
 );
 
 /*
-** CAPI3REF: Configure global parameters
+* CAPI3REF: Configure global parameters
 */
 int sqlite3session_config(int op, void* pArg);
 
 /*
-** CAPI3REF: Values for sqlite3session_config()
+* CAPI3REF: Values for sqlite3session_config()
 */
 enum
 {
@@ -2739,7 +2739,7 @@ enum
 }
 
 /******************************************************************************
-** Interfaces to extend FTS5.
+* Interfaces to extend FTS5.
 */
 struct Fts5Context;
 /// Ditto

--- a/posix.mak
+++ b/posix.mak
@@ -490,7 +490,7 @@ $(JSON) : $(ALL_D_FILES)
 ###########################################################
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(EXTRA_DOCUMENTABLES))
 # Set DDOC, the documentation generator
-DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -version=StdDdoc \
+DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -preview=markdown -version=StdDdoc \
 	-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS)
 
 # D file to html, e.g. std/conv.d -> std_conv.html

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1751,8 +1751,8 @@ expression.
 
 `choices` needs to be composed of pairs of test expressions and return
 expressions. Each test-expression is compared with `switchExpression` using
-`pred`(`switchExpression` is the first argument) and if that yields true
-- the return expression is returned.
+`pred`(`switchExpression` is the first argument) and if that yields true -
+the return expression is returned.
 
 Both the test and the return expressions are lazily evaluated.
 

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -235,8 +235,8 @@ $(TR $(TDC2 BitmappedBlock, bitmapped_block) $(TD Organizes one contiguous chunk
 equal-size blocks and tracks allocation status at the cost of one bit per
 block.))
 
-$(TR $(TDC2 FallbackAllocator, fallback_allocator) $(TD Allocator that combines two other allocators
- - primary and fallback. Allocation requests are first tried with primary, and
+$(TR $(TDC2 FallbackAllocator, fallback_allocator) $(TD Allocator that combines two other
+ allocators - primary and fallback. Allocation requests are first tried with primary, and
  upon failure are passed to the fallback. Useful for small and fast allocators
  fronting general-purpose ones.))
 

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -1984,8 +1984,8 @@ static:
     left-hand side operand. If $(D lhs == WithNaN.defaultValue!Lhs), returns
     $(D WithNaN.defaultValue!(typeof(lhs + rhs))) without evaluating the
     operand. Otherwise, evaluates the operand. If evaluation does not overflow,
-    returns the result. Otherwise, returns $(D WithNaN.defaultValue!(typeof(lhs
-    + rhs))).
+    returns the result. Otherwise, returns $(D WithNaN.defaultValue!(typeof(lhs +
+    rhs))).
 
     Params:
     x = The operator symbol
@@ -2023,8 +2023,8 @@ static:
     right-hand side operand. If $(D rhs == WithNaN.defaultValue!Rhs), returns
     $(D WithNaN.defaultValue!(typeof(lhs + rhs))) without evaluating the
     operand. Otherwise, evaluates the operand. If evaluation does not overflow,
-    returns the result. Otherwise, returns $(D WithNaN.defaultValue!(typeof(lhs
-    + rhs))).
+    returns the result. Otherwise, returns $(D WithNaN.defaultValue!(typeof(lhs +
+    rhs))).
 
     Params:
     x = The operator symbol

--- a/std/functional.d
+++ b/std/functional.d
@@ -1003,7 +1003,7 @@ if (F.length > 1)
    Params:
         fun = the call-able(s) or `string`(s) to compose into one function
     Returns:
-        A new function `f(x)` that in turn returns $(D fun[0](fun[1](...(x)))...).
+        A new function `f(x)` that in turn returns `fun[0](fun[1](...(x)))...`.
 
    See_Also: $(LREF pipe)
 */
@@ -1054,7 +1054,7 @@ template compose(fun...)
    Params:
         fun = the call-able(s) or `string`(s) to compose into one function
     Returns:
-        A new function `f(x)` that in turn returns $(D fun[0](fun[1](...(x)))...).
+        A new function `f(x)` that in turn returns `fun[0](fun[1](...(x)))...`.
 
    Example:
 

--- a/std/math.d
+++ b/std/math.d
@@ -8461,11 +8461,11 @@ public:
 
 
 /***********************************
- * Evaluate polynomial A(x) = $(SUB a, 0) + $(SUB a, 1)x + $(SUB a, 2)$(POWER x,2)
- *                          + $(SUB a,3)$(POWER x,3); ...
+ * Evaluate polynomial A(x) = $(SUB a, 0) + $(SUB a, 1)x + $(SUB a, 2)$(POWER x,2) +
+ *                          $(SUB a,3)$(POWER x,3); ...
  *
- * Uses Horner's rule A(x) = $(SUB a, 0) + x($(SUB a, 1) + x($(SUB a, 2)
- *                         + x($(SUB a, 3) + ...)))
+ * Uses Horner's rule A(x) = $(SUB a, 0) + x($(SUB a, 1) + x($(SUB a, 2) +
+ *                         x($(SUB a, 3) + ...)))
  * Params:
  *      x =     the value to evaluate.
  *      A =     array of coefficients $(SUB a, 0), $(SUB a, 1), etc.

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3007,9 +3007,9 @@ public:
     The main uses cases for `WorkerLocalStorageStorage` are:
 
     1.  Performing parallel reductions with an imperative, as opposed to
-    functional, programming style.  In this case, it's useful to treat
-    `WorkerLocalStorageStorage` as local to each thread for only the parallel
-    portion of an algorithm.
+        functional, programming style.  In this case, it's useful to treat
+        `WorkerLocalStorageStorage` as local to each thread for only the parallel
+        portion of an algorithm.
 
     2.  Recycling temporary buffers across iterations of a parallel foreach loop.
 

--- a/std/path.d
+++ b/std/path.d
@@ -3586,7 +3586,7 @@ if (isConvertibleToString!Range)
         $(LI `filename` must not contain any characters whose integer
             representation is in the range 0-31.)
         $(LI `filename` must not contain any of the following $(I reserved
-            characters): <>:"/\|?*)
+            characters): `<>:"/\|?*`)
         $(LI `filename` may not end with a space ($(D ' ')) or a period
             (`'.'`).)
     )

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -5813,8 +5813,8 @@ $(D (n - State.length)).
 
 If the function is passed in string form, the state has name `"a"`
 and the zero-based index in the recurrence has name `"n"`. The
-given string must return the desired value for `a[n]` given $(D a[n
-- 1]), $(D a[n - 2]), $(D a[n - 3]),..., $(D a[n - stateSize]). The
+given string must return the desired value for `a[n]` given
+`a[n - 1]`, `a[n - 2]`, `a[n - 3]`,..., `a[n - stateSize]`. The
 state size is dictated by the number of arguments passed to the call
 to `recurrence`. The `Recurrence` struct itself takes care of
 managing the recurrence's state and shifting it appropriately.

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -136,7 +136,7 @@ $(TR $(TD Objects) $(TD
     $(REG_ROW \W, Matches any non-word character.)
     $(REG_ROW \s, Matches whitespace, same as \p{White_Space}.)
     $(REG_ROW \S, Matches any character except those recognized as $(I \s ). )
-    $(REG_ROW \\, Matches \ character. )
+    $(REG_ROW \\\\, Matches \ character. )
     $(REG_ROW \c where c is one of [|*+?(), Matches the character c itself. )
     $(REG_ROW \p{PropertyName}, Matches a character that belongs
         to the Unicode PropertyName set.
@@ -261,7 +261,7 @@ $(TR $(TD Objects) $(TD
         $(REG_ROW $', part of input $(I following) the match. )
         $(REG_ROW $$, '$' character. )
         $(REG_ROW \c $(COMMA) where c is any character, the character c itself. )
-        $(REG_ROW \\, '\' character. )
+        $(REG_ROW \\\\, '\\' character. )
         $(REG_ROW $(DOLLAR)1 .. $(DOLLAR)99, submatch number 1 to 99 respectively. )
     )
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -8714,8 +8714,8 @@ public:
 // ReplaceType
 /**
 Replaces all occurrences of `From` into `To`, in one or more types `T`. For
-example, $(D ReplaceType!(int, uint, Tuple!(int, float)[string])) yields
-$(D Tuple!(uint, float)[string]). The types in which replacement is performed
+example, `ReplaceType!(int, uint, Tuple!(int, float)[string])` yields
+`Tuple!(uint, float)[string]`. The types in which replacement is performed
 may be arbitrarily complex, including qualifiers, built-in type constructors
 (pointers, arrays, associative arrays, functions, and delegates), and template
 instantiations; replacement proceeds transitively through the type definition.

--- a/std/uni.d
+++ b/std/uni.d
@@ -2027,8 +2027,8 @@ pure:
     ---
     $(P
     The way to read this is: start with negative meaning that all numbers
-    smaller then the next one are not present in this set (and positive
-    - the contrary). Then switch positive/negative after each
+    smaller then the next one are not present in this set (and positive -
+    the contrary). Then switch positive/negative after each
     number passed from left to right.
     )
     $(P This way negative spans until 10, then positive until 50,


### PR DESCRIPTION
This PR does two things:

1. Adds the `-preview=markdown` flag to the Phobos Ddoc build.
2. Fixes places in the docs that were unintentionally interpreted as markdown.

The fixes were generally for:

* Lines that start with `-`, `+` or `*`, which in Markdown starts a list item.
* Backslashes that aren't in code blocks, and so are treated as escaping the next character.
* Words in brackets that aren't in code blocks, which Ddoc treats as [reference links](https://dlang.org/spec/ddoc.html#reference_links) to symbols with the same name.