### PR TITLE
std.math: change tests for rounding

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1501,7 +1501,8 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) &&
             return CloseHandle(hObject);
         }
         static auto trustedSetFileTime(HANDLE hFile, const scope FILETIME *lpCreationTime,
-                                       const scope ref FILETIME lpLastAccessTime, const scope ref FILETIME lpLastWriteTime) @trusted
+                                       const scope ref FILETIME lpLastAccessTime,
+                                       const scope ref FILETIME lpLastWriteTime) @trusted
         {
             return SetFileTime(hFile, lpCreationTime, &lpLastAccessTime, &lpLastWriteTime);
         }


### PR DESCRIPTION
Changing floating point rounding modes, because it happens off to the side, interferes with optimizing. In particular, common subexpressions may not be common if the rounding mode is changed.

Solutions are:

1. disable CSEs for floating point (what dmd used to do). Not doing CSEs for floating point is kinda sad.
2. make a compiler intrinsic for changing the rounding mode, so the optimizer knows about it, this would be a fair amount of rewrite both for the optimizer and std.math.
3. change the code that mucks with the rounding mode so it won't interfere with optimization

This does option (3).