### PR TITLE
Replace usages of `in` with `const scope`

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1500,8 +1500,8 @@ if (isInputRange!R && !isInfinite!R && isSomeChar!(ElementEncodingType!R) &&
         {
             return CloseHandle(hObject);
         }
-        static auto trustedSetFileTime(HANDLE hFile, in FILETIME *lpCreationTime,
-                                       in ref FILETIME lpLastAccessTime, in ref FILETIME lpLastWriteTime) @trusted
+        static auto trustedSetFileTime(HANDLE hFile, const scope FILETIME *lpCreationTime,
+                                       const scope ref FILETIME lpLastAccessTime, const scope ref FILETIME lpLastWriteTime) @trusted
         {
             return SetFileTime(hFile, lpCreationTime, &lpLastAccessTime, &lpLastWriteTime);
         }


### PR DESCRIPTION
In support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters