### PR TITLE
Appender and RefAppender: use opSlice() instead of data()

### DIFF
--- a/changelog/array-opslice.dd
+++ b/changelog/array-opslice.dd
@@ -1,0 +1,8 @@
+std.array.Appender and RefAppender: use .opSlice() instead of data()
+
+Previonsly, Appender.data() was used to extract a slice of the Appender's array.
+Now use the [] slice operator instead.
+The same goes for RefAppender.
+
+$(REF Appender, std, array)
+$(REF RefAppender, std, array)

--- a/std/array.d
+++ b/std/array.d
@@ -3271,9 +3271,18 @@ if (isDynamicArray!A)
     }
 
     /**
+     * Use opSlice() from now on.
      * Returns: The managed array.
      */
     @property inout(ElementEncodingType!A)[] data() inout @trusted pure nothrow
+    {
+        return this[];
+    }
+
+    /**
+     * Returns: The managed array.
+     */
+    @property inout(ElementEncodingType!A)[] opSlice() inout @trusted pure nothrow
     {
         /* @trusted operation:
          * casting Unqual!T[] to inout(T)[]
@@ -3582,13 +3591,13 @@ if (isDynamicArray!A)
     string b = "abcdefg";
     foreach (char c; b)
         app.put(c);
-    assert(app.data == "abcdefg");
+    assert(app[] == "abcdefg");
 
     int[] a = [ 1, 2 ];
     auto app2 = appender(a);
     app2.put(3);
     app2.put([ 4, 5, 6 ]);
-    assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
+    assert(app2[] == [ 1, 2, 3, 4, 5, 6 ]);
 }
 
 @safe pure unittest
@@ -3604,12 +3613,12 @@ if (isDynamicArray!A)
     auto app2 = appender!string();
     auto spec = singleSpec("%s");
     app.toString(app2, spec);
-    assert(app2.data == "Appender!(int[])([1, 2, 3])");
+    assert(app2[] == "Appender!(int[])([1, 2, 3])");
 
     auto app3 = appender!string();
     spec = singleSpec("%(%04d, %)");
     app.toString(app3, spec);
-    assert(app3.data == "Appender!(int[])(0001, 0002, 0003)");
+    assert(app3[] == "Appender!(int[])(0001, 0002, 0003)");
 }
 
 @safe unittest // issue 17251
@@ -3677,7 +3686,7 @@ if (isDynamicArray!A)
 
     appender.put(const(Struct)(42));
 
-    auto result = appender.data[0];
+    auto result = appender[][0];
 
     assert(result.value != 23);
 }
@@ -3748,7 +3757,7 @@ if (isDynamicArray!A)
     if (__traits(compiles, (Appender!A a) => mixin("a." ~ fn ~ "(args)")))
     {
         // we do it this way because we can't cache a void return
-        scope(exit) *this.arr = impl.data;
+        scope(exit) *this.arr = impl[];
         mixin("return impl." ~ fn ~ "(args);");
     }
 
@@ -3760,7 +3769,7 @@ if (isDynamicArray!A)
     void opOpAssign(string op : "~", U)(U rhs)
     if (__traits(compiles, (Appender!A a){ a.put(rhs); }))
     {
-        scope(exit) *this.arr = impl.data;
+        scope(exit) *this.arr = impl[];
         impl.put(rhs);
     }
 
@@ -3774,12 +3783,20 @@ if (isDynamicArray!A)
         return impl.capacity;
     }
 
-    /**
-     * Returns the managed array.
+    /* Use opSlice() instead.
+     * Returns: the managed array.
      */
     @property inout(ElementEncodingType!A)[] data() inout
     {
-        return impl.data;
+        return impl[];
+    }
+
+    /**
+     * Returns: the managed array.
+     */
+    @property inout(ElementEncodingType!A)[] opSlice() inout
+    {
+        return impl[];
     }
 }
 
@@ -3789,11 +3806,11 @@ unittest
 {
     int[] a = [1, 2];
     auto app2 = appender(&a);
-    assert(app2.data == [1, 2]);
+    assert(app2[] == [1, 2]);
     assert(a == [1, 2]);
     app2 ~= 3;
     app2 ~= [4, 5, 6];
-    assert(app2.data == [1, 2, 3, 4, 5, 6]);
+    assert(app2[] == [1, 2, 3, 4, 5, 6]);
     assert(a == [1, 2, 3, 4, 5, 6]);
 
     app2.reserve(5);
@@ -3825,33 +3842,33 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
         auto app = appender!(char[])();
         string b = "abcdefg";
         foreach (char c; b) app.put(c);
-        assert(app.data == "abcdefg");
+        assert(app[] == "abcdefg");
     }
     {
         auto app = appender!(char[])();
         string b = "abcdefg";
         foreach (char c; b) app ~= c;
-        assert(app.data == "abcdefg");
+        assert(app[] == "abcdefg");
     }
     {
         int[] a = [ 1, 2 ];
         auto app2 = appender(a);
-        assert(app2.data == [ 1, 2 ]);
+        assert(app2[] == [ 1, 2 ]);
         app2.put(3);
         app2.put([ 4, 5, 6 ][]);
-        assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
+        assert(app2[] == [ 1, 2, 3, 4, 5, 6 ]);
         app2.put([ 7 ]);
-        assert(app2.data == [ 1, 2, 3, 4, 5, 6, 7 ]);
+        assert(app2[] == [ 1, 2, 3, 4, 5, 6, 7 ]);
     }
 
     int[] a = [ 1, 2 ];
     auto app2 = appender(a);
-    assert(app2.data == [ 1, 2 ]);
+    assert(app2[] == [ 1, 2 ]);
     app2 ~= 3;
     app2 ~= [ 4, 5, 6 ][];
-    assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
+    assert(app2[] == [ 1, 2, 3, 4, 5, 6 ]);
     app2 ~= [ 7 ];
-    assert(app2.data == [ 1, 2, 3, 4, 5, 6, 7 ]);
+    assert(app2[] == [ 1, 2, 3, 4, 5, 6, 7 ]);
 
     app2.reserve(5);
     assert(app2.capacity >= 5);
@@ -3861,12 +3878,12 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
         app2.shrinkTo(3);
     }
     catch (Exception) assert(0);
-    assert(app2.data == [ 1, 2, 3 ]);
+    assert(app2[] == [ 1, 2, 3 ]);
     assertThrown(app2.shrinkTo(5));
 
     const app3 = app2;
     assert(app3.capacity >= 3);
-    assert(app3.data == [1, 2, 3]);
+    assert(app3[] == [1, 2, 3]);
 
     auto app4 = appender([]);
     try // shrinkTo may throw
@@ -3881,29 +3898,29 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
         {
             Appender!S app5663i;
             assertNotThrown(app5663i.put("\xE3"));
-            assert(app5663i.data == "\xE3");
+            assert(app5663i[] == "\xE3");
 
             Appender!S app5663c;
             assertNotThrown(app5663c.put(cast(const(char)[])"\xE3"));
-            assert(app5663c.data == "\xE3");
+            assert(app5663c[] == "\xE3");
 
             Appender!S app5663m;
             assertNotThrown(app5663m.put("\xE3".dup));
-            assert(app5663m.data == "\xE3");
+            assert(app5663m[] == "\xE3");
         }
         // ditto for ~=
         {
             Appender!S app5663i;
             assertNotThrown(app5663i ~= "\xE3");
-            assert(app5663i.data == "\xE3");
+            assert(app5663i[] == "\xE3");
 
             Appender!S app5663c;
             assertNotThrown(app5663c ~= cast(const(char)[])"\xE3");
-            assert(app5663c.data == "\xE3");
+            assert(app5663c[] == "\xE3");
 
             Appender!S app5663m;
             assertNotThrown(app5663m ~= "\xE3".dup);
-            assert(app5663m.data == "\xE3");
+            assert(app5663m[] == "\xE3");
         }
     }
 
@@ -3918,7 +3935,7 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     {
         auto w = appender!(S10122[])();
         w.put(S10122(1));
-        assert(w.data.length == 1 && w.data[0].val == 1);
+        assert(w[].length == 1 && w[][0].val == 1);
     });
 }
 
@@ -3938,7 +3955,7 @@ unittest
     w ~= 'd';
     w ~= "ef";
 
-    assert(w.data == "abcdef");
+    assert(w[] == "abcdef");
 }
 
 @safe pure nothrow unittest
@@ -3947,7 +3964,7 @@ unittest
         auto w = appender!string();
         w.reserve(4);
         cast(void) w.capacity;
-        cast(void) w.data;
+        cast(void) w[];
         try
         {
             wchar wc = 'a';
@@ -3961,7 +3978,7 @@ unittest
         auto w = appender!(int[])();
         w.reserve(4);
         cast(void) w.capacity;
-        cast(void) w.data;
+        cast(void) w[];
         w.put(10);
         w.put([10]);
         w.clear();
@@ -4071,7 +4088,7 @@ unittest
             auto app = appender!(const(E)[])();
             foreach (i, e; src)
                     app.put(e);
-            return app.data;
+            return app[];
     }
 
     class C {}
@@ -4111,26 +4128,26 @@ unittest
 
     auto app1 = Appender!mutARR(mut);                //Always worked. Should work. Should not create a warning.
     app1.put(7);
-    assert(equal(app1.data, [7]));
+    assert(equal(app1[], [7]));
     static assert(!is(typeof(Appender!mutARR(con)))); //Never worked.  Should not work.
     static assert(!is(typeof(Appender!mutARR(imm)))); //Never worked.  Should not work.
 
     auto app2 = Appender!conARR(mut); //Always worked. Should work. Should not create a warning.
     app2.put(7);
-    assert(equal(app2.data, [7]));
+    assert(equal(app2[], [7]));
     auto app3 = Appender!conARR(con); //Didn't work.   Now works.   Should not create a warning.
     app3.put(7);
-    assert(equal(app3.data, [7]));
+    assert(equal(app3[], [7]));
     auto app4 = Appender!conARR(imm); //Didn't work.   Now works.   Should not create a warning.
     app4.put(7);
-    assert(equal(app4.data, [7]));
+    assert(equal(app4[], [7]));
 
     //{auto app = Appender!immARR(mut);}                //Worked. Will cease to work. Creates warning.
     //static assert(!is(typeof(Appender!immARR(mut)))); //Worked. Will cease to work. Uncomment me after full deprecation.
     static assert(!is(typeof(Appender!immARR(con))));   //Never worked. Should not work.
     auto app5 = Appender!immARR(imm);                  //Didn't work.  Now works. Should not create a warning.
     app5.put(7);
-    assert(equal(app5.data, [7]));
+    assert(equal(app5[], [7]));
 
     //Deprecated. Please uncomment and make sure this doesn't work:
     //char[] cc;
@@ -4138,11 +4155,11 @@ unittest
 
     //This should always work:
     auto app6 = appender!string(null);
-    assert(app6.data == null);
+    assert(app6[] == null);
     auto app7 = appender!(const(char)[])(null);
-    assert(app7.data == null);
+    assert(app7[] == null);
     auto app8 = appender!(char[])(null);
-    assert(app8.data == null);
+    assert(app8[] == null);
 }
 
 @safe unittest //Test large allocations (for GC.extend)
@@ -4153,7 +4170,7 @@ unittest
     app.reserve(1); //cover reserve on non-initialized
     foreach (_; 0 .. 100_000)
         app.put('a');
-    assert(equal(app.data, 'a'.repeat(100_000)));
+    assert(equal(app[], 'a'.repeat(100_000)));
 }
 
 @safe unittest
@@ -4171,7 +4188,7 @@ unittest
     Appender!string app;
     app.put("foo");
     static assert(!__traits(compiles, app.clear()));
-    assert(app.data == "foo");
+    assert(app[] == "foo");
 }
 
 @safe unittest
@@ -4238,11 +4255,11 @@ unittest
 {
     int[] a = [1, 2];
     auto app2 = appender(&a);
-    assert(app2.data == [1, 2]);
+    assert(app2[] == [1, 2]);
     assert(a == [1, 2]);
     app2 ~= 3;
     app2 ~= [4, 5, 6];
-    assert(app2.data == [1, 2, 3, 4, 5, 6]);
+    assert(app2[] == [1, 2, 3, 4, 5, 6]);
     assert(a == [1, 2, 3, 4, 5, 6]);
 
     app2.reserve(5);
@@ -4257,7 +4274,7 @@ unittest
         auto app = appender(&arr);
         string b = "abcdefg";
         foreach (char c; b) app.put(c);
-        assert(app.data == "abcdefg");
+        assert(app[] == "abcdefg");
         assert(arr == "abcdefg");
     }
     {
@@ -4265,27 +4282,27 @@ unittest
         auto app = appender(&arr);
         string b = "abcdefg";
         foreach (char c; b) app ~= c;
-        assert(app.data == "abcdefg");
+        assert(app[] == "abcdefg");
         assert(arr == "abcdefg");
     }
     {
         int[] a = [ 1, 2 ];
         auto app2 = appender(&a);
-        assert(app2.data == [ 1, 2 ]);
+        assert(app2[] == [ 1, 2 ]);
         assert(a == [ 1, 2 ]);
         app2.put(3);
         app2.put([ 4, 5, 6 ][]);
-        assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
+        assert(app2[] == [ 1, 2, 3, 4, 5, 6 ]);
         assert(a == [ 1, 2, 3, 4, 5, 6 ]);
     }
 
     int[] a = [ 1, 2 ];
     auto app2 = appender(&a);
-    assert(app2.data == [ 1, 2 ]);
+    assert(app2[] == [ 1, 2 ]);
     assert(a == [ 1, 2 ]);
     app2 ~= 3;
     app2 ~= [ 4, 5, 6 ][];
-    assert(app2.data == [ 1, 2, 3, 4, 5, 6 ]);
+    assert(app2[] == [ 1, 2, 3, 4, 5, 6 ]);
     assert(a == [ 1, 2, 3, 4, 5, 6 ]);
 
     app2.reserve(5);
@@ -4296,12 +4313,12 @@ unittest
         app2.shrinkTo(3);
     }
     catch (Exception) assert(0);
-    assert(app2.data == [ 1, 2, 3 ]);
+    assert(app2[] == [ 1, 2, 3 ]);
     assertThrown(app2.shrinkTo(5));
 
     const app3 = app2;
     assert(app3.capacity >= 3);
-    assert(app3.data == [1, 2, 3]);
+    assert(app3[] == [1, 2, 3]);
 }
 
 @safe unittest // issue 14605
@@ -4315,7 +4332,7 @@ unittest
     Appender!(int[]) app;
     short[] range = [1, 2, 3];
     app.put(range);
-    assert(app.data == [1, 2, 3]);
+    assert(app[] == [1, 2, 3]);
 }
 
 @safe unittest
@@ -4328,8 +4345,8 @@ unittest
     put(appA, 'w');
     s ~= 'a'; //Clobbers here?
     a ~= 'a'; //Clobbers here?
-    assert(appS.data == "hellow");
-    assert(appA.data == "hellow");
+    assert(appS[] == "hellow");
+    assert(appA[] == "hellow");
 }
 
 /++


### PR DESCRIPTION
When building an array, the natural way to get the array is with opSlice(), not data().