### PR TITLE
Clarify that buf can be shortened in readln

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1688,7 +1688,8 @@ $(REF newline, std,ascii) for portability (unless the file was opened in
 text mode).
 
 Returns:
-0 for end of file, otherwise number of characters read (i.e., buf.length)
+0 for end of file, otherwise number of characters read.
+The return value will always be equal to `buf.length`.
 
 Throws: `StdioException` on I/O error, or `UnicodeException` on Unicode
 conversion error.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1682,13 +1682,13 @@ must copy the previous contents if you wish to retain them.
 
 Params:
 buf = Buffer used to store the resulting line data. buf is
-resized as necessary.
+resized to exactly contain the line.
 terminator = Line terminator (by default, `'\n'`). Use
 $(REF newline, std,ascii) for portability (unless the file was opened in
 text mode).
 
 Returns:
-0 for end of file, otherwise number of characters read
+0 for end of file, otherwise number of characters read (i.e., buf.length)
 
 Throws: `StdioException` on I/O error, or `UnicodeException` on Unicode
 conversion error.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1682,7 +1682,7 @@ must copy the previous contents if you wish to retain them.
 
 Params:
 buf = Buffer used to store the resulting line data. buf is
-resized to exactly contain the line.
+enlarged if necessary, then set to the slice exactly containing the line.
 terminator = Line terminator (by default, `'\n'`). Use
 $(REF newline, std,ascii) for portability (unless the file was opened in
 text mode).


### PR DESCRIPTION
It wasn't clear on inspection if buf could be shortened, or if it was just lengthened. "As necessary" suggested that buf would only be resized if absolutely necessary, which would only be when it needs to be lengthened. 