### PR TITLE
ieeeFlags unittest: the optimizer might remove operations that the te…

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5690,15 +5690,17 @@ public:
         static void func() {
             int a = 10 * 10;
         }
-
+        pragma(inline, false) static void blockopt(ref real x) {}
         real a = 3.5;
         // Set all the flags to zero
         resetIeeeFlags();
         assert(!ieeeFlags.divByZero);
+        blockopt(a); // avoid constant propagation by the optimizer
         // Perform a division by zero.
         a /= 0.0L;
         assert(a == real.infinity);
         assert(ieeeFlags.divByZero);
+        blockopt(a); // avoid constant propagation by the optimizer
         // Create a NaN
         a *= 0.0L;
         assert(ieeeFlags.invalid);
@@ -5790,9 +5792,12 @@ void resetIeeeFlags() @trusted nothrow @nogc
 {
     version (InlineAsm_X86_Any)
     {
+        pragma(inline, false) static void blockopt(ref real x) {}
         resetIeeeFlags();
         real a = 3.5;
+        blockopt(a); // avoid constant propagation by the optimizer
         a /= 0.0L;
+        blockopt(a); // avoid constant propagation by the optimizer
         assert(a == real.infinity);
         assert(ieeeFlags.divByZero);
 
@@ -5812,12 +5817,15 @@ void resetIeeeFlags() @trusted nothrow @nogc
 {
     version (InlineAsm_X86_Any)
     {
+        pragma(inline, false) static void blockopt(ref real x) {}
         resetIeeeFlags();
         real a = 3.5;
+        blockopt(a); // avoid constant propagation by the optimizer
 
         a /= 0.0L;
         assert(a == real.infinity);
         assert(ieeeFlags.divByZero);
+        blockopt(a); // avoid constant propagation by the optimizer
 
         a *= 0.0L;
         assert(isNaN(a));
@@ -6351,10 +6359,12 @@ version (InlineAsm_X86_Any) @safe unittest // rounding
         {
             static T addRound(T)(uint rm)
             {
+                pragma(inline, false) static void blockopt(ref T x) {}
                 pragma(inline, false);
                 FloatingPointControl fpctrl;
                 fpctrl.rounding = rm;
                 T x = 1;
+                blockopt(x); // avoid constant propagation by the optimizer
                 x += 0.1;
                 return x;
             }
@@ -6370,10 +6380,12 @@ version (InlineAsm_X86_Any) @safe unittest // rounding
         {
             static T subRound(T)(uint rm)
             {
+                pragma(inline, false) static void blockopt(ref T x) {}
                 pragma(inline, false);
                 FloatingPointControl fpctrl;
                 fpctrl.rounding = rm;
                 T x = -1;
+                blockopt(x); // avoid constant propagation by the optimizer
                 x -= 0.1;
                 return x;
             }


### PR DESCRIPTION
…st is depending upon
The optimizer removes all traces of `a` because it is const-folded to `nan`. That means no side effects appear.

This test is failing here: https://dev.azure.com/dlanguage/dmd/_build/results?buildId=3982&view=logs&jobId=995050be-48e9-58a0-3553-d9a547fe6c20&taskId=3bcde2a0-396a-5c5e-c7d5-d0568bb0ee4b&lineStart=4275&lineEnd=4276&colStart=1&colEnd=1

Not sure why it doesn't appear on other platforms, but it triggers when using dmd built against the MS C runtime.