### PR TITLE
find Phobos dependencies on autodecode

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2412,7 +2412,7 @@ if (isAutodecodableString!(T[]) && !isAggregateType!(T[]))
 Autodecoding is enabled if this is set to true.
 */
 
-enum autodecodeStrings = true;
+enum autodecodeStrings = false;
 
 /**
 Implements the range interface primitive `front` for built-in


### PR DESCRIPTION
To get rid of autodecode, first we must make Phobos independent of whether autodecoding is on or off. So turn it off and see what breaks.

Fixes should be in separate PRs labelled with [no autodecode]. They should be one of:

1. use https://dlang.org/phobos/std_utf.html#byChar
2. use https://dlang.org/phobos/std_utf.html#byDchar
3. hardcode decoding