### PR TITLE
std.format: Fix compilation with no autodecode

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3971,7 +3971,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 // ditto
 Target parseElement(Target, Source)(ref Source s)
 if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
-    isSomeChar!Target && !is(Target == enum))
+    is(CharTypeOf!Target == dchar) && !is(Target == enum))
 {
     Unqual!Target c;
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -3973,7 +3973,7 @@ Target parseElement(Target, Source)(ref Source s)
 if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
     isSomeChar!Target && !is(Target == enum))
 {
-    Target c;
+    Unqual!Target c;
 
     parseCheck!s('\'');
     if (s.empty)

--- a/std/conv.d
+++ b/std/conv.d
@@ -3547,7 +3547,7 @@ if (isSomeString!Source && !is(Source == enum) &&
     {
         if (!s.empty && s.front == rbracket)
             break;
-        result ~= parseElement!(ElementType!Target)(s);
+        result ~= parseElement!(WideElementType!Target)(s);
         skipWS(s);
         if (s.empty)
             throw convError!(Source, Target)(s);
@@ -3996,6 +3996,17 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) &&
     !isSomeString!Target && !isSomeChar!Target)
 {
     return parse!Target(s);
+}
+
+// Use this when parsing a type that will ultimately be appended to a
+// string.
+package template WideElementType(T)
+{
+    alias E = ElementType!T;
+    static if (isSomeChar!E)
+        alias WideElementType = dchar;
+    else
+        alias WideElementType = E;
 }
 
 

--- a/std/format.d
+++ b/std/format.d
@@ -5878,7 +5878,8 @@ do
             }
             else static if (isDynamicArray!T)
             {
-                result ~= unformatElement!(ElementType!T)(input, fmt);
+                import std.conv : WideElementType;
+                result ~= unformatElement!(WideElementType!T)(input, fmt);
             }
             else static if (isAssociativeArray!T)
             {


### PR DESCRIPTION
The entire instantiated template hierarchy there actually can't compile or work with a narrow char type, because at some point it wants to decode an escape, which will fit only in a `dchar` anyway.

For https://github.com/dlang/phobos/pull/7130