### PR TITLE
Rewrite dubious refRange() shortcuts in unittests

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1831,7 +1831,8 @@ pure @safe unittest // issue 18657
 {
     import std.algorithm.comparison : equal;
     import std.range : refRange;
-    auto r = refRange(&["foo"][0]).group;
+    string s = "foo";
+    auto r = refRange(&s).group;
     assert(equal(r.save, "foo".group));
     assert(equal(r, "foo".group));
 }
@@ -5376,7 +5377,8 @@ pure @safe unittest // issue 18657
 {
     import std.algorithm.comparison : equal;
     import std.range : refRange;
-    auto r = refRange(&["foobar"][0]).splitter!(c => c == 'b');
+    string s = "foobar";
+    auto r = refRange(&s).splitter!(c => c == 'b');
     assert(equal!equal(r.save, ["foo", "ar"]));
     assert(equal!equal(r.save, ["foo", "ar"]));
 }

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -5099,12 +5099,14 @@ pure @safe unittest // issue 18657
     import std.algorithm.comparison : equal;
     import std.range : refRange;
     {
-        auto r = refRange(&["foobar"][0]).until("bar");
+        string s = "foobar";
+        auto r = refRange(&s).until("bar");
         assert(equal(r.save, "foo"));
         assert(equal(r.save, "foo"));
     }
     {
-        auto r = refRange(&["foobar"][0]).until!(e => e == 'b');
+        string s = "foobar";
+        auto r = refRange(&s).until!(e => e == 'b');
         assert(equal(r.save, "foo"));
         assert(equal(r.save, "foo"));
     }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1392,7 +1392,8 @@ pure @safe nothrow @nogc unittest
 pure @safe unittest // issue 18657
 {
     import std.algorithm.comparison : equal;
-    auto r = refRange(&["foo"][0]).chain("bar");
+    string s = "foo";
+    auto r = refRange(&s).chain("bar");
     assert(equal(r.save, "foobar"));
     assert(equal(r, "foobar"));
 }
@@ -1665,7 +1666,8 @@ private struct ChooseResult(R1, R2)
 pure @safe unittest // issue 18657
 {
     import std.algorithm.comparison : equal;
-    auto r = choose(true, refRange(&["foo"][0]), "bar");
+    string s = "foo";
+    auto r = choose(true, refRange(&s), "bar");
     assert(equal(r.save, "foo"));
     assert(equal(r, "foo"));
 }
@@ -2037,7 +2039,8 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
 pure @safe unittest
 {
     import std.algorithm.comparison : equal;
-    auto r = roundRobin(refRange(&["foo"][0]), refRange(&["bar"][0]));
+    string f = "foo", b = "bar";
+    auto r = roundRobin(refRange(&f), refRange(&b));
     assert(equal(r.save, "fboaor"));
     assert(equal(r.save, "fboaor"));
 }
@@ -4268,7 +4271,8 @@ if (isStaticArray!R)
 pure @safe unittest // issue 18657
 {
     import std.algorithm.comparison : equal;
-    auto r = refRange(&["foo"][0]).cycle.take(4);
+    string s = "foo";
+    auto r = refRange(&s).cycle.take(4);
     assert(equal(r.save, "foof"));
     assert(equal(r.save, "foof"));
 }


### PR DESCRIPTION
As preparation for dlang/dmd#10124, which makes elements of array literals rvalues, so this trick for converting a string literal to an lvalue doesn't work anymore.