### PR TITLE
win*.mak: Sync compiler flags with Posix ones

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -41,13 +41,13 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime.lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -O -release -w -de -dip25 -I$(DRUNTIME)\import
+DFLAGS=-conf= -O -release -w -de -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-unittest -g
 #DFLAGS=-unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-unittest -conf= -O -w -dip25 -I$(DRUNTIME)\import
+UDFLAGS=-unittest -conf= -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -44,13 +44,13 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime$(MODEL).lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -m$(MODEL) -O -release -w -de -dip25 -I$(DRUNTIME)\import
+DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-m$(MODEL) -unittest -g
 #DFLAGS=-m$(MODEL) -unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -dip25 -I$(DRUNTIME)\import -unittest
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import -unittest
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
Unfortunately, these files seem untested by CI here, but they are used by Azure pipelines for DMD, so one can easily [break](https://dev.azure.com/dlanguage/dmd/_build/results?buildId=4086) DMD CI by a seemingly fine Phobos change (#7142 in this case, which requires DIP1000). From: https://github.com/dlang/phobos/blob/a2b9977f9b26476264b76034a32c15615dd7af54/posix.mak#L142