### PR TITLE
fix Issue 20134 - autodecode should use replacementDchar rather than throwing on invalid

### DIFF
--- a/changelog/replacementDchar.dd
+++ b/changelog/replacementDchar.dd
@@ -1,0 +1,31 @@
+# Change autodecode from throwing `UTFException` on invalid encodings to returning `std.utf.replacementDchar` `('\uFFFD')` instead.
+
+When `char` and `wchar` slices are iterated, they are autodecoded meaning the UTF-8 and
+UTF-16 code unit sequences are automatically consumed and decoded into `dchar` code points.
+If an invalid sequence is encountered, a
+$(LINK2 https://dlang.org/phobos/std_utf.html#UTFExceptions,`UTFException`)
+is raised.
+
+This change instead causes
+$(LINK2 https://dlang.org/phobos/std_utf.html#replacementDchar, `std.utf.replacementDchar`)
+to be the decoded result of an invalid sequence.
+
+If the old behavior is desired, the autodecoding iteration can be replaced with
+$(LINK2 https://dlang.org/phobos/std_utf.html#byUTF, `std.utf.byUTF!(dchar, UseReplacementDchar.no)`)
+to detect the invalid sequences and throw the exception, as in the following example:
+
+---
+import std.utf;
+import std.stdio;
+
+void test(string s)
+{
+    s.byDchar!(dchar, UseReplacementDchar.no)().write();
+}
+
+void main()
+{
+    test("hello");
+    test("\xFFbetty");
+}
+---

--- a/std/exception.d
+++ b/std/exception.d
@@ -1908,17 +1908,21 @@ pure @safe unittest
 ///
 pure @safe unittest
 {
-    import std.algorithm.comparison : equal;
-    import std.range : retro;
-    import std.utf : UTFException;
+    version (none) // autodecode no longer throws on invalid UTF sequences
+                   // issues.dlang.org/show_bug.cgi?id=20134
+    {
+        import std.algorithm.comparison : equal;
+        import std.range : retro;
+        import std.utf : UTFException;
 
-    auto str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
+        auto str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
 
-    auto handled = str.handle!(UTFException, RangePrimitive.access,
-            (e, r) => ' '); // Replace invalid code points with spaces
+        auto handled = str.handle!(UTFException, RangePrimitive.access,
+                (e, r) => ' '); // Replace invalid code points with spaces
 
-    assert(handled.equal("hello world")); // `front` is handled,
-    assert(handled.retro.equal("dlrow olleh")); // as well as `back`
+        assert(handled.equal("hello world")); // `front` is handled,
+        assert(handled.retro.equal("dlrow olleh")); // as well as `back`
+    }
 }
 
 /** Handle exceptions thrown from range primitives.
@@ -2201,17 +2205,21 @@ pure @safe unittest
 ///
 pure @safe unittest
 {
-    import std.algorithm.comparison : equal;
-    import std.range : retro;
-    import std.utf : UTFException;
+    version (none) // autodecode no longer throws on invalid UTF sequences
+                   // issues.dlang.org/show_bug.cgi?id=20134
+    {
+        import std.algorithm.comparison : equal;
+        import std.range : retro;
+        import std.utf : UTFException;
 
-    auto str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
+        auto str = "hello\xFFworld"; // 0xFF is an invalid UTF-8 code unit
 
-    auto handled = str.handle!(UTFException, RangePrimitive.access,
-            (e, r) => ' '); // Replace invalid code points with spaces
+        auto handled = str.handle!(UTFException, RangePrimitive.access,
+                (e, r) => ' '); // Replace invalid code points with spaces
 
-    assert(handled.equal("hello world")); // `front` is handled,
-    assert(handled.retro.equal("dlrow olleh")); // as well as `back`
+        assert(handled.equal("hello world")); // `front` is handled,
+        assert(handled.retro.equal("dlrow olleh")); // as well as `back`
+    }
 }
 
 pure nothrow @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2498,10 +2498,10 @@ if (!isAutodecodableString!(T[]) && !is(T[] == void[]))
 @property dchar front(T)(scope const(T)[] a) @safe pure
 if (isAutodecodableString!(T[]))
 {
-    import std.utf : decode;
+    import std.utf;
     assert(a.length, "Attempting to fetch the front of an empty array of " ~ T.stringof);
     size_t i = 0;
-    return decode(a, i);
+    return decode!(UseReplacementDchar.yes)(a, i);
 }
 
 /**
@@ -2542,10 +2542,10 @@ if (!isAutodecodableString!(T[]) && !is(T[] == void[]))
 @property dchar back(T)(scope const(T)[] a) @safe pure
 if (isAutodecodableString!(T[]))
 {
-    import std.utf : decode, strideBack;
+    import std.utf;
     assert(a.length, "Attempting to fetch the back of an empty array of " ~ T.stringof);
     size_t i = a.length - strideBack(a, a.length);
-    return decode(a, i);
+    return decode!(UseReplacementDchar.yes)(a, i);
 }
 
 /*


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=20134