### PR TITLE
prepare for fix of issue 20138 ("is expression not evaluating correct…

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2521,10 +2521,10 @@ Rebindable!T rebindable(T)(Rebindable!T obj)
 template UnqualRef(T)
 if (is(T == class) || is(T == interface))
 {
-    static if (is(T == const U, U)
-        || is(T == immutable U, U)
-        || is(T == shared U, U)
-        || is(T == const shared U, U))
+    static if (is(T == immutable U, U)
+        || is(T == const shared U, U)
+        || is(T == const U, U)
+        || is(T == shared U, U))
     {
         struct UnqualRef
         {


### PR DESCRIPTION
…ly?")

With issue 20138 fixed, `const U` and `shared U` do match `const shared T`,
and they leave the other qualifier intact. So `const shared U` must be
attempted first if we want to strip both qualifiers.

This is blocking <https://github.com/dlang/dmd/pull/10317>.