### PR TITLE
std.net.curl: Fix example in HTTP documentation

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2332,7 +2332,8 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * // Track progress
   * auto http = HTTP();
   * http.method = HTTP.Method.get;
-  * http.url = "http://upload.wikimedia.org/wikipedia/commons/5/53/Wikipedia-logo-en-big.png";
+  * http.url = "http://upload.wikimedia.org/wikipedia/commons/" ~
+               "5/53/Wikipedia-logo-en-big.png";
   * http.onReceive = (ubyte[] data) { return data.length; };
   * http.onProgress = (size_t dltotal, size_t dlnow,
   *                    size_t ultotal, size_t ulnow)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2325,6 +2325,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * ---
   * import std.net.curl, std.stdio;
   *
+  * auto http = HTTP();
   * auto msg = "Hello world";
   * http.contentLength = msg.length;
   * http.onSend = (void[] data)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2330,8 +2330,9 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * http.perform();
   *
   * // Track progress
+  * auto http = HTTP();
   * http.method = HTTP.Method.get;
-  * http.url = "http://upload.wikimedia.org/wikipedia/commons/"
+  * http.url = "http://upload.wikimedia.org/wikipedia/commons/~" ~
   *            "5/53/Wikipedia-logo-en-big.png";
   * http.onReceive = (ubyte[] data) { return data.length; };
   * http.onProgress = (size_t dltotal, size_t dlnow,

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2328,7 +2328,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *     return len;
   * };
   * http.perform();
-  *
+  * ---
   * // Track progress
   * auto http = HTTP();
   * http.method = HTTP.Method.get;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2349,7 +2349,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * auto http = HTTP();
   * http.method = HTTP.Method.get;
   * http.url = "http://upload.wikimedia.org/wikipedia/commons/" ~
-               "5/53/Wikipedia-logo-en-big.png";
+  *            "5/53/Wikipedia-logo-en-big.png";
   * http.onReceive = (ubyte[] data) { return data.length; };
   * http.onProgress = (size_t dltotal, size_t dlnow,
   *                    size_t ultotal, size_t ulnow)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2314,8 +2314,17 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *     (in char[] key, in char[] value) { writeln(key ~ ": " ~ value); };
   * http.onReceive = (ubyte[] data) { /+ drop +/ return data.length; };
   * http.perform();
+  * ---
   *
-  * // Put with data senders
+  */
+
+/**
+  * HTTP Put with data senders
+  *
+  * Example:
+  * ---
+  * import std.net.curl, std.stdio;
+  *
   * auto msg = "Hello world";
   * http.contentLength = msg.length;
   * http.onSend = (void[] data)
@@ -2328,8 +2337,17 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *     return len;
   * };
   * http.perform();
+  *
   * ---
-  * // Track progress
+  */
+
+/**
+  * HTTP Track progress
+  *
+  * Example:
+  * ---
+  * import std.net.curl, std.stdio;
+  *
   * auto http = HTTP();
   * http.method = HTTP.Method.get;
   * http.url = "http://upload.wikimedia.org/wikipedia/commons/" ~

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2323,7 +2323,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * ---
   * import std.net.curl, std.stdio;
   *
-  * auto http = HTTP();
+  * auto http = HTTP("dlang.org");
   * auto msg = "Hello world";
   * http.contentLength = msg.length;
   * http.onSend = (void[] data)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2308,7 +2308,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * import std.net.curl, std.stdio;
   *
   * // Get with custom data receivers
-  * auto http = HTTP("dlang.org");
+  * auto http = HTTP("https://dlang.org");
   * http.onReceiveHeader =
   *     (in char[] key, in char[] value) { writeln(key ~ ": " ~ value); };
   * http.onReceive = (ubyte[] data) { /+ drop +/ return data.length; };
@@ -2323,7 +2323,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * ---
   * import std.net.curl, std.stdio;
   *
-  * auto http = HTTP("dlang.org");
+  * auto http = HTTP("https://dlang.org");
   * auto msg = "Hello world";
   * http.contentLength = msg.length;
   * http.onSend = (void[] data)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2303,11 +2303,11 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
 
 /**
   * HTTP client functionality.
+  * Get with custom data receivers
   *
   * ---
   * import std.net.curl, std.stdio;
   *
-  * // Get with custom data receivers
   * auto http = HTTP("https://dlang.org");
   * http.onReceiveHeader =
   *     (in char[] key, in char[] value) { writeln(key ~ ": " ~ value); };

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2337,8 +2337,8 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *     return len;
   * };
   * http.perform();
-  *
   * ---
+  *
   */
 
 /**

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2319,7 +2319,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   */
 
 /**
-  * HTTP Put with data senders
+  * Put with data senders:
   *
   * Example:
   * ---
@@ -2343,7 +2343,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   */
 
 /**
-  * HTTP Track progress
+  * Tracking progress:
   *
   * Example:
   * ---

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2332,8 +2332,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   * // Track progress
   * auto http = HTTP();
   * http.method = HTTP.Method.get;
-  * http.url = "http://upload.wikimedia.org/wikipedia/commons/~" ~
-  *            "5/53/Wikipedia-logo-en-big.png";
+  * http.url = "http://upload.wikimedia.org/wikipedia/commons/5/53/Wikipedia-logo-en-big.png";
   * http.onReceive = (ubyte[] data) { return data.length; };
   * http.onProgress = (size_t dltotal, size_t dlnow,
   *                    size_t ultotal, size_t ulnow)

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2303,6 +2303,9 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
 
 /**
   * HTTP client functionality.
+  *
+  * Example:
+  *
   * Get with custom data receivers
   *
   * ---

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2304,7 +2304,6 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
 /**
   * HTTP client functionality.
   *
-  * Example:
   * ---
   * import std.net.curl, std.stdio;
   *
@@ -2321,7 +2320,6 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
 /**
   * Put with data senders:
   *
-  * Example:
   * ---
   * import std.net.curl, std.stdio;
   *
@@ -2345,7 +2343,6 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
 /**
   * Tracking progress:
   *
-  * Example:
   * ---
   * import std.net.curl, std.stdio;
   *

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2306,7 +2306,7 @@ private bool decodeLineInto(Terminator, Char = char)(ref const(ubyte)[] basesrc,
   *
   * Example:
   *
-  * Get with custom data receivers
+  * Get with custom data receivers:
   *
   * ---
   * import std.net.curl, std.stdio;


### PR DESCRIPTION
https://dlang.org/phobos/std_net_curl.html#.HTTP
The Example seems to not work without these fixes.

* Fixed missing http variable
* Fixed deprecated concatenation 
```
Error: Implicit string concatenation is deprecated, use "http://upload.wikimedia.org/wikipedia/commons/" ~ "5/53/Wikipedia-logo-en-big.png" instead
```