### PR TITLE
std.process: use local imports

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -98,9 +98,6 @@ version (Windows)
     import std.windows.syserror;
 }
 
-import core.exception : OutOfMemoryError;
-
-import std.exception : enforce;
 import std.internal.cstring;
 import std.range.primitives;
 import std.stdio;
@@ -1527,6 +1524,7 @@ private:
     version (Posix)
     int performWait(bool block) @trusted
     {
+        import std.exception : enforce;
         enforce!ProcessException(owned, "Can't wait on a detached process");
         if (_processID == terminated) return _exitCode;
         int exitCode;
@@ -1576,6 +1574,7 @@ private:
     {
         int performWait(bool block) @trusted
         {
+            import std.exception : enforce;
             enforce!ProcessException(owned, "Can't wait on a detached process");
             if (_processID == terminated) return _exitCode;
             assert(_handle != INVALID_HANDLE_VALUE);
@@ -1821,6 +1820,7 @@ void kill(Pid pid)
 /// ditto
 void kill(Pid pid, int codeOrSignal)
 {
+    import std.exception : enforce;
     enforce!ProcessException(pid.owned, "Can't kill detached process");
     version (Windows)
     {
@@ -3350,6 +3350,7 @@ static:
     */
     string opIndex(scope const(char)[] name) @safe
     {
+        import std.exception : enforce;
         string value;
         enforce(getImpl(name, value), "Environment variable not found: "~name);
         return value;
@@ -3418,7 +3419,7 @@ static:
     {
         version (Posix)
         {
-            import std.exception : errnoEnforce;
+            import std.exception : enforce, errnoEnforce;
             if (value is null)
             {
                 remove(name);
@@ -3438,6 +3439,7 @@ static:
         }
         else version (Windows)
         {
+            import std.exception : enforce;
             enforce(
                 SetEnvironmentVariableW(name.tempCStringW(), value.tempCStringW()),
                 sysErrorString(GetLastError())
@@ -3547,6 +3549,7 @@ static:
         }
         else version (Windows)
         {
+            import std.exception : enforce;
             import std.uni : toUpper;
             auto envBlock = GetEnvironmentStringsW();
             enforce(envBlock, "Failed to retrieve environment variables.");
@@ -3918,6 +3921,8 @@ extern(C)
 
 private int execv_(in string pathname, in string[] argv)
 {
+    import core.exception : OutOfMemoryError;
+    import std.exception : enforce;
     auto argv_ = cast(const(char)**)core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
     enforce!OutOfMemoryError(argv_ !is null, "Out of memory in std.process.");
     scope(exit) core.stdc.stdlib.free(argv_);
@@ -3929,6 +3934,8 @@ private int execv_(in string pathname, in string[] argv)
 
 private int execve_(in string pathname, in string[] argv, in string[] envp)
 {
+    import core.exception : OutOfMemoryError;
+    import std.exception : enforce;
     auto argv_ = cast(const(char)**)core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
     enforce!OutOfMemoryError(argv_ !is null, "Out of memory in std.process.");
     scope(exit) core.stdc.stdlib.free(argv_);
@@ -3944,6 +3951,8 @@ private int execve_(in string pathname, in string[] argv, in string[] envp)
 
 private int execvp_(in string pathname, in string[] argv)
 {
+    import core.exception : OutOfMemoryError;
+    import std.exception : enforce;
     auto argv_ = cast(const(char)**)core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
     enforce!OutOfMemoryError(argv_ !is null, "Out of memory in std.process.");
     scope(exit) core.stdc.stdlib.free(argv_);
@@ -3992,6 +4001,8 @@ version (Posix)
 }
 else version (Windows)
 {
+    import core.exception : OutOfMemoryError;
+    import std.exception : enforce;
     auto argv_ = cast(const(char)**)core.stdc.stdlib.malloc((char*).sizeof * (1 + argv.length));
     enforce!OutOfMemoryError(argv_ !is null, "Out of memory in std.process.");
     scope(exit) core.stdc.stdlib.free(argv_);


### PR DESCRIPTION
In current phobos policy, local imports should be preferred over global
imports.