### PR TITLE
Initialize Tid for ThreadInfo in thisInfo() instead of in thisTid().

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -370,9 +370,6 @@ public:
     // TODO: remove when concurrency is safe
     static auto trus() @trusted
     {
-        if (thisInfo.ident != Tid.init)
-            return thisInfo.ident;
-        thisInfo.ident = Tid(new MessageBox);
         return thisInfo.ident;
     }
 
@@ -1110,6 +1107,11 @@ struct ThreadInfo
     static @property ref thisInfo() nothrow
     {
         static ThreadInfo val;
+
+        if (val.ident == Tid.init) {
+            val.ident = Tid(new MessageBox);
+        }
+
         return val;
     }
 

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1108,7 +1108,8 @@ struct ThreadInfo
     {
         static ThreadInfo val;
 
-        if (val.ident == Tid.init) {
+        // initialize ident on first use
+        if (val.ident.mbox is null) {
             val.ident = Tid(new MessageBox);
         }
 


### PR DESCRIPTION
ThreadInfo.ident wouldn't be initialized unless `thisTid()` was called. But the variable is accessible from ThreadInfo.thisInfo().ident, circumventing the initialization.