### PR TITLE
[stable] Fix std.variant unittest

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1240,7 +1240,9 @@ public:
 
 @safe unittest
 {
-    assert(VariantN!(24).sizeof == 24 + (void*).sizeof);
+    alias V = VariantN!24;
+    const alignMask = V.alignof - 1;
+    assert(V.sizeof == ((24 + (void*).sizeof + alignMask) & ~alignMask));
 }
 
 /// Can also assign class values


### PR DESCRIPTION
Accomodate for the fact that a `VariantN!24` without explicit allowed types is at least `real` aligned, and that can be 8 on some platforms (e.g., 32-bit Windows for LDC with 64-bit `real`), so that the size is aligned up to `24+4 + /*padding*/ 4 = 32`.