### PR TITLE
Revert "Fix Issue 19105 - Bogus recursive template expansion via getS…

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8409,7 +8409,7 @@ private template isDesiredUDA(alias attribute)
 
 /**
 Params:
-    symbol = The aggregate type to search
+    symbol = The aggregate type or module to search
     attribute = The user-defined attribute to search for
 
 Returns:
@@ -8598,6 +8598,14 @@ template getSymbolsByUDA(alias symbol, alias attribute)
     }
 
     static assert(getSymbolsByUDA!(A, Attr).stringof == "tuple(a, a, c)");
+}
+
+// Issue 20054: getSymbolsByUDA no longer works on modules
+version (unittest)
+{
+    @("Issue20054")
+    void issue20054() {}
+    static assert(__traits(compiles, getSymbolsByUDA!(mixin(__MODULE__), "Issue20054")));
 }
 
 private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)

--- a/std/traits.d
+++ b/std/traits.d
@@ -8420,7 +8420,6 @@ Note:
     nested structs or unions.
  */
 template getSymbolsByUDA(alias symbol, alias attribute)
-if (isAggregateType!symbol)
 {
     alias membersWithUDA = getSymbolsByUDAImpl!(symbol, attribute, __traits(allMembers, symbol));
 
@@ -8545,15 +8544,6 @@ if (isAggregateType!symbol)
 
     static assert(getSymbolsByUDA!(A, attr1).length == 2);
     static assert(getSymbolsByUDA!(A, attr2).length == 1);
-}
-
-// Issue 19105
-@safe unittest
-{
-    struct A(Args...) {}
-    struct B {}
-    // modules cannot be passed as the first argument of getSymbolsByUDA
-    static assert(!__traits(compiles, A!( getSymbolsByUDA!(traits, B))));
 }
 
 // #15335: getSymbolsByUDA fails if type has private members


### PR DESCRIPTION
…ymbolsByUDA"

This reverts commit 86733d5a4a5379219f04524bead35eff33c6a1a7.

Since [PR 7100](https://github.com/dlang/phobos/pull/7100) did absolutely nothing to actually fix issue 19105 (it's a DMD issue, not a Phobos one), and instead disallows perfectly valid code, it should be reverted.