### PR TITLE
Fix Issue 20186 - File size of "Hello, world" executable increased by 185KB

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -290,6 +290,7 @@ object_const_check="-std.algorithm.searching,-std.array,-std.bitmanip,-std.concu
 ; Checks that opEquals and toHash are both defined or neither are defined
 opequals_tohash_check="-std.complex,-std.container.array,-std.container.dlist,-std.container.rbtree,-std.container.slist,-std.datetime,-std.datetime.date,-std.experimental.checkedint,-std.internal.test.dummyrange,-std.json,-std.numeric,-std.random,-std.socket,-std.typecons,-std.uni"
 ; Check for properly documented public functions (Returns, Params)
+; Note: DScanner doesn't understand documenting parameters of IFTI/eponymous templates.
 properly_documented_public_functions="-etc.c.odbc.sql,\
 -etc.c.odbc.sqlext,\
 -etc.c.zlib,\
@@ -298,6 +299,7 @@ properly_documented_public_functions="-etc.c.odbc.sql,\
 -std.algorithm.searching,\
 -std.algorithm.setops,\
 -std.algorithm.sorting,\
+-std.array,\
 -std.base64,\
 -std.bigint,\
 -std.bitmanip,\

--- a/std/array.d
+++ b/std/array.d
@@ -3216,7 +3216,6 @@ struct Appender(A)
 if (isDynamicArray!A)
 {
     import core.memory : GC;
-    import std.format : FormatSpec;
 
     private alias T = ElementEncodingType!A;
 
@@ -3559,7 +3558,7 @@ if (isDynamicArray!A)
      * Returns:
      *     A `string` if `writer` is not set; `void` otherwise.
      */
-    string toString() const
+    string toString()() const
     {
         import std.format : singleSpec;
 
@@ -3582,15 +3581,20 @@ if (isDynamicArray!A)
     }
 
     /// ditto
-    void toString(Writer)(ref Writer w, scope const ref FormatSpec!char fmt) const
+    template toString(Writer)
     if (isOutputRange!(Writer, char))
     {
-        import std.format : formatValue;
-        import std.range.primitives : put;
-        put(w, Unqual!(typeof(this)).stringof);
-        put(w, '(');
-        formatValue(w, data, fmt);
-        put(w, ')');
+        import std.format : FormatSpec;
+
+        void toString(ref Writer w, scope const ref std.format.FormatSpec!char fmt) const
+        {
+            import std.format : formatValue;
+            import std.range.primitives : put;
+            put(w, Unqual!(typeof(this)).stringof);
+            put(w, '(');
+            formatValue(w, data, fmt);
+            put(w, ')');
+        }
     }
 
     // @@@DEPRECATED_2.089@@@


### PR DESCRIPTION
We can delay the std.format import until the relevant templates are instantiated.

This brings the filesize from 1114048 to 908544 bytes.

CC @JackStouffer