### PR TITLE
Add Unconst to std.traits

### DIFF
--- a/changelog/unconst.dd
+++ b/changelog/unconst.dd
@@ -1,0 +1,5 @@
+Added std.traits.Unconst
+
+$(REF Unconst, std, traits) works like $(REF Unqual, std, traits), but removes
+only `const`, `inout` and `immutable` qualifiers from a type.
+

--- a/std/traits.d
+++ b/std/traits.d
@@ -129,6 +129,7 @@
  *           $(LREF OriginalType)
  *           $(LREF PointerTarget)
  *           $(LREF Signed)
+ *           $(LREF Unconst)
  *           $(LREF Unqual)
  *           $(LREF Unsigned)
  *           $(LREF ValueType)
@@ -7490,6 +7491,41 @@ if (T.length == 1)
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 // General Types
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
+
+/**
+Removes `const`, `inout` and `immutable` qualifiers, if any, from type `T`.
+ */
+template Unconst(T)
+{
+    import core.internal.traits : CoreUnconst = Unconst;
+    alias Unconst = CoreUnconst!(T);
+}
+
+///
+@safe unittest
+{
+    static assert(is(Unconst!int == int));
+    static assert(is(Unconst!(const int) == int));
+    static assert(is(Unconst!(immutable int) == int));
+    static assert(is(Unconst!(shared int) == shared int));
+    static assert(is(Unconst!(shared(const int)) == shared int));
+}
+
+@safe unittest
+{
+    static assert(is(Unconst!(                   int) == int));
+    static assert(is(Unconst!(             const int) == int));
+    static assert(is(Unconst!(       inout       int) == int));
+    static assert(is(Unconst!(       inout const int) == int));
+    static assert(is(Unconst!(shared             int) == shared int));
+    static assert(is(Unconst!(shared       const int) == shared int));
+    static assert(is(Unconst!(shared inout       int) == shared int));
+    static assert(is(Unconst!(shared inout const int) == shared int));
+    static assert(is(Unconst!(         immutable int) == int));
+
+    alias ImmIntArr = immutable(int[]);
+    static assert(is(Unconst!ImmIntArr == immutable(int)[]));
+}
 
 /**
 Removes all qualifiers, if any, from type `T`.


### PR DESCRIPTION
Existing ˋstd.traits.Unqualˋ removes all qualifiers from a type. Quite often that is a bit too aggressive, because it would also strip off 'shared'. ˋUnconstˋ (which already exists in ˋcore.internal.traitsˋ) is helpful in such cases. This PR adds an alias for ˋUnconstˋ to ˋstd.traitsˋ, very similar to what is already there for ˋUnqualˋ.