### PR TITLE
Added spawnRef and spawnLinkedRef for passing by reference through spawn

### DIFF
--- a/changelog/spawn-by-ref.dd
+++ b/changelog/spawn-by-ref.dd
@@ -1,0 +1,20 @@
+Added spawnRef and spawnLinkedRef for passing by reference through spawn
+
+Now it will be possible to pass variables to the thread created with spawnRef/spawnLinkedRef by reference,
+to do this you need the shared type and add ref to the attributes of the arguments of the function to be executed.
+
+---
+import std.concurrency : spawnRef;
+import core.atomic : atomicOp;
+import core.thread : thread_joinAll;
+
+static void f1(ref shared(int) number)
+{
+  atomicOp!"+="(number, 1);
+}
+
+shared(int) number = 10;
+spawnRef(&f1, number);
+thread_joinAll();
+assert(number == 11);
+---


### PR DESCRIPTION
It is often useful to pass a mutable by reference type to the spawned
thread, the need to have to use a raw pointer before this patch made
the syntax boring and not in line with the rest of the DLang style
(use pointer as little as possible).

With this patch it will be possible to write code like this:
```
import std.concurrency : spawnRef;
import core.atomic : atomicOp;
import core.thread : thread_joinAll;

static void f1(ref shared(int) number)
{
  atomicOp!"+="(number, 1);
}

shared(int) number = 10;
spawnRef(&f1, number);
thread_joinAll();
assert(number == 11);
```

Instead of the boring:
```
import std.concurrency : spawn;
import core.atomic : atomicOp;
import core.thread : thread_joinAll;

static void f1(ref shared(int)* number)
{
  atomicOp!"+="(*number, 1);
}

shared(int) number = 10;
spawn(&f1, &number);
thread_joinAll();
assert(number == 11);
```

This PR is an alternative of https://github.com/dlang/phobos/pull/7124