### PR TITLE
Clearer documentation for approxEqual

### DIFF
--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -354,7 +354,7 @@ if (is(T == double))
         arr = iota().array;
     }
 
-    alias cmp = approxEqual!(double,double);
+    alias cmp = approxEqual!(double,double,double);
 
     enum dummyValue = 1337.0;
     enum dummyValueRslt = 1337.0 * 2.0;

--- a/std/math.d
+++ b/std/math.d
@@ -8927,11 +8927,11 @@ bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff = 1e-2, V maxAbsDiff = 1e-5
     assert(approxEqual(arr1, arr2));
 
     real num = real.infinity;
-    assert(num == real.infinity);  // Passes.
-    assert(approxEqual(num, real.infinity));  // Fails.
+    assert(num == real.infinity);
+    assert(approxEqual(num, real.infinity));
     num = -real.infinity;
-    assert(num == -real.infinity);  // Passes.
-    assert(approxEqual(num, -real.infinity));  // Fails.
+    assert(num == -real.infinity);
+    assert(approxEqual(num, -real.infinity));
 
     assert(!approxEqual(3, 0));
     assert(approxEqual(3, 3));

--- a/std/math.d
+++ b/std/math.d
@@ -8944,14 +8944,6 @@ bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff = 1e-2, V maxAbsDiff = 1e-5
 
 @safe pure nothrow @nogc unittest
 {
-    real num = real.infinity;
-    assert(num == real.infinity);  // Passes.
-    assert(approxEqual(num, real.infinity));  // Fails.
-}
-
-
-@safe pure nothrow @nogc unittest
-{
     float f = sqrt(2.0f);
     assert(fabs(f * f - 2.0f) < .00001);
 

--- a/std/math.d
+++ b/std/math.d
@@ -8849,7 +8849,7 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
     See_Also:
         Use $(LREF feqrel) to get the number of equal bits in the mantissa.
  */
-bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
+bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff = 1e-2, V maxAbsDiff = 1e-5)
 {
     import std.range.primitives : empty, front, isInputRange, popFront;
     static if (isInputRange!T)
@@ -8915,12 +8915,6 @@ bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
                 || maxAbsDiff != 0 && fabs(lhs - rhs) <= maxAbsDiff;
         }
     }
-}
-
-/// ditto
-bool approxEqual(T, U)(T lhs, U rhs)
-{
-    return approxEqual(lhs, rhs, 1e-2, 1e-5);
 }
 
 ///


### PR DESCRIPTION
In issue 15881 and 15763 people complain about unintuitiv behaviour of approxEqual. I adapted the documentation of the function to address this.

a) Symmetry: I renamed the first two parameters to make clear, that they have different meaning. Also changed the wording in the documentation and added more unittest to clearify.

b) Purpose of the two checks: I made clearer, why two checks are run (basically, one for numbers close to zero and one for all other) and that passing one check is sufficient. Added unittests to document this.

Additionally I added some more unittests. E.g. for testing 3rd and 4th parameters and for some strange results and cornercases.

I did not change the behaviour of the function, let alone, I removed an (almost) superfluous overload - almost, because an alias in dummyrange.d now needs a third parameter.

I refrained from removing "maxAbsDiff != 0 &&" in the last line of the template, which in my eyes is also unnecessary. (If you think, I should remove this too, please tell me.)

I'm not sure, if this can be called a fix for issue 15881.

As already mentioned in PR #7173, I'll provide an additional function in a separate PR, which has similar functionallity, but is better suited for testing for floatingpoint rounding errors.