### PR TITLE
Fix Issue 14478 - isInputRange should allow ranges of non-copyable elements

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -171,7 +171,8 @@ Returns:
 enum bool isInputRange(R) =
     is(typeof(R.init) == R)
     && is(ReturnType!((R r) => r.empty) == bool)
-    && is(typeof((return ref R r) => r.front))
+    && (is(typeof(ref (return ref R r) => r.front))
+    || is(typeof((return ref R r) => r.front)))
     && !is(ReturnType!((R r) => r.front) == void)
     && is(typeof((R r) => r.popFront));
 
@@ -250,6 +251,26 @@ enum bool isInputRange(R) =
 
     static assert(isInputRange!R);
     assert(r.equal([ 0, 1, 2 ]));
+}
+
+
+@safe unittest
+{
+    // https://issues.dlang.org/show_bug.cgi?id=14478
+    static struct S
+    {
+        @disable this (this);
+    }
+
+    struct Range(T)
+    {
+        T a;
+        bool empty() { return false; }
+        void popFront() {}
+        ref T front() { return a; }
+    }
+
+    static assert(isInputRange!(Range!S));
 }
 
 /+


### PR DESCRIPTION
The condition

```d
is(typeof((return ref R r) => r.front))
```

Creates a lambda that returns a by value element of type R. Because of that, ranges with uncopyable elements will not pass the `isInputRange` test even though `front` might return by ref. To fix this, I simply changed the return type of the lambda by adding `.sizeof`; if the type R has `.front` then the test will pass (it doesn't matter the return type of `front`), otherwise you would have `__error__.front` which obviously is not going to produce a valid type.

The problem is that the original bug report is still not going to compile, because `chain` has code that does copies even though it does not explicitly check for this ability (because `isInputRange` assumed it). I suspect this pattern is prevalent throughout phobos and the fix would be to use `isCopyable!(ElementType!Range)` wherever isInputRange is used.