### PR TITLE
Make task() example compilable.

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -847,7 +847,7 @@ void main()
 {
     // Create and execute a Task for reading
     // foo.txt.
-    auto file1Task = task(&read, "foo.txt");
+    auto file1Task = task(&read!string, "foo.txt", size_t.max);
     file1Task.executeInNewThread();
 
     // Read bar.txt in parallel.


### PR DESCRIPTION
This example seems to not have worked ever.

You cannot create a delegate to an uninstantiated template function, and for the task() template function to be able to deduce a function, all optional parameters to read() need to be given.

The delegate issue is kind of obvious. The default parameter issue I don't know whether is a compiler limitation that could be lifted or not.

These fixes make the example less pretty, especially compared to the example of the other overload of task(), but is it how it is.

Runnable variant: https://run.dlang.io/is/WAns8z (not for publication)