### PR TITLE
Remove posix only unittest relying on presence of unzip untility.

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -978,6 +978,12 @@ version (Posix) @system unittest
 {
     import std.datetime, std.file, std.format, std.path, std.process, std.stdio;
 
+    if (executeShell("unzip").status != 0)
+    {
+        writeln("Can't run unzip, skipping unzip test");
+        return;
+    }
+
     auto zr = new ZipArchive();
     auto am = new ArchiveMember();
     am.compressionMethod = CompressionMethod.deflate;


### PR DESCRIPTION
Even on posix systems you cannot rely on unzip being installed. In such cases, the unittest will fail, but should not fail.