### PR TITLE
std.zip: Update and correct main documentation

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -1,17 +1,15 @@
 // Written in the D programming language.
 
 /**
- * Read/write data in the $(LINK2 http://www.info-zip.org, zip archive) format.
+ * Read/write data in the $(LINK2 https://en.wikipedia.org/wiki/Zip_%28file_format%29, zip archive) format.
  * Makes use of the etc.c.zlib compression library.
  *
- * Bugs:
+ * Limitations:
  *      $(UL
  *      $(LI Multi-disk zips not supported.)
  *      $(LI Only Zip version 20 formats are supported.)
  *      $(LI Only supports compression modes 0 (no compression) and 8 (deflate).)
  *      $(LI Does not support encryption.)
- *      $(LI $(BUGZILLA 592))
- *      $(LI $(BUGZILLA 2137))
  *      )
  *
  * Example:


### PR DESCRIPTION
I replaced the link below "zip archive" to the wikipedia entry, because the old link points to the zip/unzip utility webpage which contains information about this utility but not about zip archieves in general.

Further: From the 6 listed bugs, the first four are no bugs, but just limitations of the current implementation. Bug 592 is "won't fix", refering to D1; Bug 2137 is allready fixed. Therefore I removed the two real bugs and replaced the headline by "Limitations".

