### PR TITLE
Fix Issue 15230 - Inconsistent std.range.SortedRange predicate checks

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1954,7 +1954,7 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
 
     // This should get smaller with time. On occasion it may go larger, but only
     // if there's thorough justification.
-    debug enum uint watermark = 1676280;
+    debug enum uint watermark = 1676220;
     else enum uint watermark = 1676220;
 
     import std.conv;


### PR DESCRIPTION
This may reopen issue 12661. I checked this and I think it does not reopen. But IMHO someone else should confirm this.

Anyway, I think, the original fix for 12661 did not fix the real problem, but was more of a hack inducing issue 15230.