### PR TITLE
Silence warning: struct Rebindable has method toHash, however it cannot be called with const(Rebindable!(const(C))) this.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1790,7 +1790,7 @@ if (isInputRange!R)
     assert(equal(g3, [ tuple(1, 2u), tuple(2, 2u) ]));
 
     interface I {}
-    class C : I {}
+    class C : I { override size_t toHash() const nothrow @safe { return 0; } }
     const C[] a4 = [new const C()];
     auto g4 = a4.group!"a is b";
     assert(g4.front[1] == 1);

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1979,7 +1979,7 @@ private template ReverseTupleSpecs(T...)
 
 @safe unittest
 {
-    class C {}
+    class C { override size_t toHash() const nothrow @safe { return 0; } }
     Tuple!(Rebindable!(const C)) a;
     Tuple!(const C) b;
     a = b;


### PR DESCRIPTION
Unexpected/unhandled compiler message cause testsuite failures in gdc.

The content of the message suggests this is a deliberate deprecation, rather than a bug in druntime.