### PR TITLE
Undeprecate JSONType member to avoid deprecation warnings

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -95,15 +95,19 @@ enum JSONType : byte
     object,   /// ditto
     true_,    /// ditto
     false_,   /// ditto
-    deprecated("Use .null_")    NULL = null_,
-    deprecated("Use .string")   STRING = string,
-    deprecated("Use .integer")  INTEGER = integer,
-    deprecated("Use .uinteger") UINTEGER = uinteger,
-    deprecated("Use .float_")   FLOAT = float_,
-    deprecated("Use .array")    ARRAY = array,
-    deprecated("Use .object")   OBJECT = object,
-    deprecated("Use .true_")    TRUE = true_,
-    deprecated("Use .false_")   FALSE = false_,
+    // FIXME: Find some way to deprecate the enum members below, which does NOT
+    // create lots of spam-like deprecation warnings, which can't be fixed
+    // by the user. See discussion on this issue at
+    // https://forum.dlang.org/post/feudrhtxkaxxscwhhhff@forum.dlang.org
+    /* deprecated("Use .null_")    */ NULL = null_,
+    /* deprecated("Use .string")   */ STRING = string,
+    /* deprecated("Use .integer")  */ INTEGER = integer,
+    /* deprecated("Use .uinteger") */ UINTEGER = uinteger,
+    /* deprecated("Use .float_")   */ FLOAT = float_,
+    /* deprecated("Use .array")    */ ARRAY = array,
+    /* deprecated("Use .object")   */ OBJECT = object,
+    /* deprecated("Use .true_")    */ TRUE = true_,
+    /* deprecated("Use .false_")   */ FALSE = false_,
 }
 
 deprecated("Use JSONType") alias JSON_TYPE = JSONType;

--- a/std/json.d
+++ b/std/json.d
@@ -110,7 +110,7 @@ enum JSONType : byte
     /* deprecated("Use .false_")   */ FALSE = false_,
 }
 
-deprecated("Use JSONType") alias JSON_TYPE = JSONType;
+deprecated("Use JSONType and the new enum member names") alias JSON_TYPE = JSONType;
 
 /**
 JSON value node


### PR DESCRIPTION
Undeprecate JSONType members, which create lots of spam-like
deprecation warnings, which can't be fixed by the user.

See discussion on this issue at
  https://forum.dlang.org/post/feudrhtxkaxxscwhhhff@forum.dlang.org