### PR TITLE
std/math.d: Explicitly handle zero and inf in scalbn.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4600,6 +4600,13 @@ real modf(real x, ref real i) @trusted nothrow @nogc
 real scalbn(real x, int n) @safe pure nothrow @nogc
 {
     pragma(inline, true);
+
+    if (__ctfe)
+    {
+        // Handle special cases.
+        if (x == 0.0 || isInfinity(x))
+            return x;
+    }
     return core.math.ldexp(x, n);
 }
 


### PR DESCRIPTION
Fixes the CTFE test for gdc when x is real.infinity.  It fails as an inf result from ldexp is treated as an overflow in gcc's const fold internals.