### PR TITLE
Fix Issue 19283 - [std.mathspecial] documentation for normal distribution doesn't list parameters

### DIFF
--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -327,7 +327,7 @@ real erfc(real x)
 }
 
 
-/** Normal distribution function.
+/** Standard normal distribution function.
  *
  * The normal (or Gaussian, or bell-shaped) distribution is
  * defined as:
@@ -349,7 +349,7 @@ real normalDistribution(real x)
     return std.internal.math.errorfunction.normalDistributionImpl(x);
 }
 
-/** Inverse of Normal distribution function
+/** Inverse of Standard normal distribution function
  *
  * Returns the argument, x, for which the area under the
  * Normal probability density function (integrated from


### PR DESCRIPTION
The two functions use *standard* normal distribution, which implies that mean=0.0, stdev=1.0.

In the bugreport is stated, that reportee was not able to follow the implementation for the case z>=1. Me neither. But as the case z<1 is obviously the standard normal distribution it would be an error, if the case z>=1 would be some other distribution. I compared some computed values to the [table given in the German Wikipedia](https://de.wikipedia.org/wiki/Standardnormalverteilungstabelle) and found no difference.