### PR TITLE
Fix Issue 20283 - CustomFloat.max_exp not working in some cases

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -438,7 +438,7 @@ public:
     static @property int max_10_exp(){ return cast(int) log10( +max ); }
 
     /// maximum int value such that 2<sup>max_exp-1</sup> is representable
-    enum max_exp = exponent_max-bias+((~flags&(Flags.infinity|flags.nan))!=0);
+    enum max_exp = exponent_max - bias - ((flags & (Flags.infinity | Flags.nan)) != 0) + 1;
 
     /// Returns: minimum int value such that 10<sup>min_10_exp</sup> is representable
     static @property int min_10_exp(){ return cast(int) log10( +min_normal ); }
@@ -766,9 +766,8 @@ public:
     static assert(CustomFloat!(2, 6, CustomFloatFlags.none).max_exp == 2^^5);
     static assert(CustomFloat!(5, 10).max_exp == 2^^9);
     static assert(CustomFloat!(6, 10, CustomFloatFlags.none).max_exp == 2^^9);
-    // doesn't work yet due to bug 20283
-//    static assert(CustomFloat!(2, 6, CustomFloatFlags.nan).max_exp == 2^^5);
-//    static assert(CustomFloat!(6, 10, CustomFloatFlags.nan).max_exp == 2^^9);
+    static assert(CustomFloat!(2, 6, CustomFloatFlags.nan).max_exp == 2^^5);
+    static assert(CustomFloat!(6, 10, CustomFloatFlags.nan).max_exp == 2^^9);
 }
 
 // testing .min_exp


### PR DESCRIPTION
There were actually two bugs in here, that cancelled out in most cases.

First, flags.nan was used instead of Flags.nan.

Second, it was tried to mix the substraction of 1 in case of infinity or nan with the addition of 1 that's needed by definition, by using ~flags instead of flags, which does not always work. Although it's probably possible to find a term that mixes that, I separated these two terms. The speedgain would be little and done at compile time anyway.