### PR TITLE
Fix Issue 20286 - CustomFloat.min_normal fails, when not allowDenorm

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -462,9 +462,9 @@ public:
     {
         CustomFloat value;
         static if (flags & Flags.signed)
-            value.sign        = 0;
-        value.exponent    = 1;
-        static if (flags&Flags.storeNormalized)
+            value.sign = 0;
+        value.exponent = (flags & Flags.allowDenorm) != 0;
+        static if (flags & Flags.storeNormalized)
             value.significand = 0;
         else
             value.significand = cast(T_sig) 1uL << (precision - 1);
@@ -802,7 +802,7 @@ public:
     assert(CustomFloat!(1, 6).min_10_exp == -9);
     assert(CustomFloat!(5, 10).min_10_exp == -153);
     assert(CustomFloat!(2, 6, CustomFloatFlags.none).min_10_exp == -9);
-    assert(CustomFloat!(6, 10, CustomFloatFlags.none).min_10_exp == -153);
+    assert(CustomFloat!(6, 10, CustomFloatFlags.none).min_10_exp == -154);
     assert(CustomFloat!(2, 6, CustomFloatFlags.nan).min_10_exp == -9);
     assert(CustomFloat!(6, 10, CustomFloatFlags.nan).min_10_exp == -153);
     assert(CustomFloat!(2, 6, CustomFloatFlags.allowDenorm).min_10_exp == -9);
@@ -873,7 +873,7 @@ public:
     static assert(CustomFloat!(1,6).min_normal.sign == 0);
     static assert(CustomFloat!(1,6).min_normal.exponent == 1);
     static assert(CustomFloat!(1,6).min_normal.significand == 0);
-    //static assert(CustomFloat!(3,5, CustomFloatFlags.none).min_normal.exponent == 0); // doesn't work due to bug 20286
+    static assert(CustomFloat!(3,5, CustomFloatFlags.none).min_normal.exponent == 0);
     static assert(CustomFloat!(3,5, CustomFloatFlags.none).min_normal.significand == 4);
 }
 


### PR DESCRIPTION
First of all, the question is, what is a normalized value, when storeNormalized is not set. From checking several places in the code I concluded that all values, where the first bit of the mantissa is set, are considered normalized in that case. With that, the fix was easy: the exponent is only 1 when allowDenorm is set, else it's 0.

Unfortunately one unittest was broken by this fix. I recalculated the value of the unittest manually and found out, that the unittest was wrong. Here the calculation: The smallest number with an exponent of 10 digits and a mantissa of 6 digits is created by setting all bits to 0 except the first of the mantissa which is needed to stay in the realm of normalized values (see note above). The value of this number is 2^^(-2^^9). To get to min_10_exp, you need to take log10 of that value. I used the unix tool bc to calculate this value using a scale of 1000. The result is -154.12735... which means, the correct value is indeed -154 here.