### PR TITLE
Fix Issue 10448 - min and max are not NaN aware

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1513,17 +1513,21 @@ if (isConvertibleToString!Range1 || isConvertibleToString!Range2)
     assert(levenshteinDistanceAndPath(S("cat"), "rat")[0] == 1);
 }
 
+
 // max
 /**
-Iterates the passed arguments and return the maximum value.
+Iterates the passed arguments and returns the maximum value.
 
 Params:
     args = The values to select the maximum from. At least two arguments must
-    be passed.
+    be passed, and they must be comparable with `>`.
 
 Returns:
-    The maximum of the passed-in args. The type of the returned value is
+    The maximum of the passed-in values. The type of the returned value is
     the type among the passed arguments that is able to store the largest value.
+    If at least one of the arguments is NaN, the result is an unspecified value.
+    See $(REF maxElement, std,algorithm,searching) for examples on how to cope
+    with NaNs.
 
 See_Also:
     $(REF maxElement, std,algorithm,searching)
@@ -1634,9 +1638,17 @@ if (T.length >= 1)
 /**
 Iterates the passed arguments and returns the minimum value.
 
-Params: args = The values to select the minimum from. At least two arguments
-    must be passed, and they must be comparable with `<`.
-Returns: The minimum of the passed-in values.
+Params:
+    args = The values to select the minimum from. At least two arguments must
+    be passed, and they must be comparable with `<`.
+
+Returns:
+    The minimum of the passed-in values. The type of the returned value is
+    the type among the passed arguments that is able to store the smallest value.
+    If at least one of the arguments is NaN, the result is an unspecified value.
+    See $(REF minElement, std,algorithm,searching) for examples on how to cope
+    with NaNs.
+
 See_Also:
     $(REF minElement, std,algorithm,searching)
 */

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3539,6 +3539,24 @@ Params:
 
 Returns: The minimal element of the passed-in range.
 
+Note:
+    If at least one of the arguments is NaN, the result is an unspecified value.
+
+    If you want to ignore NaNs, you can use $(REF filter, std,algorithm,iteration)
+    and $(REF isNaN, std,math) to remove them, before applying minElement.
+    Add a suitable seed, to avoid error messages if all elements are NaNs:
+
+    ---
+    <range>.filter!(a=>!a.isNaN).minElement(<seed>);
+    ---
+
+    If you want to get NaN as a result if a NaN is present in the range,
+    you can use $(REF fold, std.algorithm,iteration) and $(REF isNaN, std,math):
+
+    ---
+    <range>.fold!((a,b)=>a.isNaN || b.isNaN ? real.nan : a < b ? a : b);
+    ---
+
 See_Also:
 
     $(LREF maxElement), $(REF min, std,algorithm,comparison), $(LREF minCount),
@@ -3662,16 +3680,20 @@ Iterates the passed range and returns the maximal element.
 A custom mapping function can be passed to `map`.
 In other languages this is sometimes called `argmax`.
 
-Complexity:
+Complexity: O(n)
     Exactly `n - 1` comparisons are needed.
 
 Params:
     map = custom accessor for the comparison key
-    r = range from which the maximum will be selected
+    r = range from which the maximum element will be selected
     seed = custom seed to use as initial element
 
 Returns: The maximal element of the passed-in range.
 
+Note:
+    If at least one of the arguments is NaN, the result is an unspecified value.
+    See $(REF minElement, std,algorithm,searching) for examples on how to cope
+    with NaNs.
 
 See_Also:
 


### PR DESCRIPTION
This is a replacement for PR #7181, because I had to delete my old account on github. Here my original comment:

The discussion of issue 10448 and of the related pull requests show, that there is no consensus on the best result of min and max, when some parameters are NaNs, even experts, namely people who where involved in writing IEEE754, cannot agree on that. But most people agree, that the functions should be fast and extra treatment for NaNs would slow them down. Therefore, I think, the best solution is to document, that the functions will result in undefined behaviour if NaNs are used and give examples on how to cope with NaNs beyond using this functions.

In the documentation for minElement I added two such examples, namely for ignoring NaNs and for returning NaN in case at least one element is NaN. In the documentation for maxElement, min and max I just added a pointer to minElement, to avoid duplication.

I'm aware, that there are more functions, which have this problem. But before doing all the work to identify them and to add a note to everyones documentation, I'd make like to make sure, that this will be accepted. Therefore I'll wait for this PR to be merged, before continuing.

