### PR TITLE
Make tests for issue 19797 Windows-only

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1098,6 +1098,14 @@ Throws: `Exception` if the file is not opened.
         import std.conv : to, text;
         import std.exception : enforce, errnoEnforce;
 
+        // Some libc sanitize the whence input (e.g. glibc), but some don't,
+        // e.g. Microsoft runtime crashes on an invalid origin,
+        // and Musl additionally accept SEEK_DATA & SEEK_HOLE (Linux extension).
+        // To provide a consistent behavior cross platform, we use the glibc check
+        // See also https://issues.dlang.org/show_bug.cgi?id=19797
+        enforce(origin == SEEK_SET || origin == SEEK_CUR ||  origin == SEEK_END,
+                "Invalid `origin` argument passed to `seek`, must be one of: SEEK_SET, SEEK_CUR, SEEK_END");
+
         enforce(isOpen, "Attempting to seek() in an unopened file");
         version (Windows)
         {
@@ -1105,9 +1113,6 @@ Throws: `Exception` if the file is not opened.
             {
                 alias fseekFun = _fseeki64;
                 alias off_t = long;
-                // Issue 19797
-                enforce(origin >= SEEK_SET && origin <= SEEK_END,
-                        "Could not seek in file `"~_name~"' (Invalid argument)");
             }
             else
             {
@@ -1151,7 +1156,8 @@ Throws: `Exception` if the file is not opened.
         // f.rawWrite("abcdefghijklmnopqrstuvwxyz");
         // f.seek(-3, SEEK_END);
         // assert(f.readln() == "xyz");
-        assertThrown(f.seek(0, 3));
+
+        assertThrown(f.seek(0, ushort.max));
     }
 
 /**


### PR DESCRIPTION
```
Value '3' is a valid value on Linux (SEEK_DATA, since 3.18).
Hence, in some cases (depending on FS support / Kernel version),
this test can fails.
```

If you're curious, more info [here](https://github.com/alpinelinux/aports/pull/11931#issuecomment-544831142).