### PR TITLE
Support of byUTF for ubyte[] argument

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -4334,13 +4334,13 @@ if (isSomeChar!C)
     import std.algorithm.comparison : equal;
 
     // hellö as a range of `char`s, which are UTF-8
-    "hell\u00F6".byUTF!char().equal(['h', 'e', 'l', 'l', 0xC3, 0xB6]);
+    assert("hell\u00F6".byUTF!char().equal(['h', 'e', 'l', 'l', 0xC3, 0xB6]));
 
     // `wchar`s are able to hold the ö in a single element (UTF-16 code unit)
-    "hell\u00F6".byUTF!wchar().equal(['h', 'e', 'l', 'l', 'ö']);
+    assert("hell\u00F6".byUTF!wchar().equal(['h', 'e', 'l', 'l', 'ö']));
 
     // 𐐷 is four code units in UTF-8, two in UTF-16, and one in UTF-32
-    "𐐷".byUTF!char().equal([0xF0, 0x90, 0x90, 0xB7]);
-    "𐐷".byUTF!wchar().equal([0xD801, 0xDC37]);
-    "𐐷".byUTF!dchar().equal([0x00010437]);
+    assert("𐐷".byUTF!char().equal([0xF0, 0x90, 0x90, 0xB7]));
+    assert("𐐷".byUTF!wchar().equal([0xD801, 0xDC37]));
+    assert("𐐷".byUTF!dchar().equal([0x00010437]));
 }

--- a/std/utf.d
+++ b/std/utf.d
@@ -4354,6 +4354,9 @@ if (isSomeChar!C)
     // hellö as a range of `ubyte`s, which are UTF-8
     assert((cast(ubyte[]) [0x68, 0x65, 0x6c, 0x6c, 0xC3, 0xB6]).byUTF!char().equal(['h', 'e', 'l', 'l', 0xC3, 0xB6]));
 
+    assertThrown((cast(ubyte[]) [0xC3, 0x28]).byUTF!char());
+    assertThrown((cast(ubyte[]) [0xC3, 0x28]).byUTF!dchar());
+
     // Conversion to ubyte is not supported.
     static assert(!__traits(compiles, (cast(ubyte[]) []).byUTF!ubyte()));
 }

--- a/std/utf.d
+++ b/std/utf.d
@@ -60,7 +60,7 @@ $(TR $(TD Miscellaneous) $(TD
    +/
 module std.utf;
 
-import std.exception;  // basicExceptionCtors, assertThrown
+import std.exception;  // basicExceptionCtors
 import std.meta;       // AliasSeq
 import std.range.primitives;
 import std.traits;     // isSomeChar, isSomeString
@@ -4338,6 +4338,7 @@ if (isSomeChar!C)
 ///
 @safe pure nothrow unittest
 {
+    import std.exception : assertThrown;
     import std.algorithm.comparison : equal;
 
     // hellö as a range of `char`s, which are UTF-8

--- a/std/utf.d
+++ b/std/utf.d
@@ -60,7 +60,7 @@ $(TR $(TD Miscellaneous) $(TD
    +/
 module std.utf;
 
-import std.exception;  // basicExceptionCtors
+import std.exception;  // basicExceptionCtors, assertThrown
 import std.meta;       // AliasSeq
 import std.range.primitives;
 import std.traits;     // isSomeChar, isSomeString


### PR DESCRIPTION
For the reasons outlined in the discussion of [that pull request](https://github.com/dlang/phobos/pull/7247), we concluded that we need to be able to call `byUTF` on the argument of type `ubyte[]`. This PR implements exactly that.

I remind that this is necessary:

1. to support converting a chunk extracted from a file;
1. to eliminate the need to validate a string of `char`s two times: when it is created and when converted by `byUTF` (this simplifies programming and improves efficiency).