### PR TITLE
Makefiles: Enable -checkaction-context for unittest builds

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -158,7 +158,7 @@ ifdef NO_AUTODECODE
 override DFLAGS += -version=NoAutodecodeStrings
 endif
 
-UDFLAGS=-unittest -version=StdUnittest
+UDFLAGS=-unittest -version=StdUnittest -checkaction=context
 
 # Set DOTOBJ and DOTEXE
 ifeq (,$(findstring win,$(OS)))
@@ -421,7 +421,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov=ctfe -run $< ;     \
+	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov=ctfe -checkaction=D -run $< ;     \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 
@@ -650,7 +650,7 @@ publictests: $(addsuffix .publictests,$(D_MODULES))
 
 %.publictests: %.d $(LIB) $(TESTS_EXTRACTOR) | $(PUBLICTESTS_DIR)/.directory
 	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
-	@$(DMD) $(DFLAGS) $(NODEFAULTLIB) $(LIB) -main $(UDFLAGS) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
+	@$(DMD) $(DFLAGS) $(NODEFAULTLIB) $(LIB) -main $(UDFLAGS) -checkaction=D -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 
 ################################################################################
 # Check and run @betterC tests

--- a/win32.mak
+++ b/win32.mak
@@ -47,7 +47,7 @@ DFLAGS=-conf= -O -release -w -de -preview=dip1000 -preview=dtorfields -I$(DRUNTI
 
 ## Flags for compiling unittests
 
-UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest -conf= -O -w -preview=dip1000 -I$(DRUNTIME)\import
+UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest -conf= -O -w -preview=dip1000 -I$(DRUNTIME)\import -checkaction=context
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -50,7 +50,7 @@ DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -preview=dtorfields
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -I$(DRUNTIME)\import -unittest -version=StdUnittest -version=CoreUnittest
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -I$(DRUNTIME)\import -unittest -version=StdUnittest -version=CoreUnittest -checkaction=context
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
See dlang/druntime#2836.

Blocked by
- [x] dlang/dmd#10535
- [x] dlang/dmd#10550
- [ ] dlang/dmd#10677
- [x] dlang/dmd#12258