### PR TITLE
Rework documentation of std.zip.

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -386,7 +386,6 @@ properly_documented_public_functions="-etc.c.odbc.sql,\
 -std.uuid,\
 -std.variant,\
 -std.xml,\
--std.zip,\
 -std.zlib"
 ; Check for redundant attributes
 redundant_attributes_check="-std.concurrency,-std.digest.md,-std.digest.ripemd,-std.digest.sha,-std.internal.math.biguintcore,-std.math,-std.meta,-std.range,-std.regex.internal.ir,-std.uni,-std.windows.registry"


### PR DESCRIPTION
The format of the table in the main documentation is not yet perfect, but I could not find anything better. Especially I found no local link version, where the displayed value is different to the anchor value. I used REF1_ALTTEXT for this.

I left out the flags and internalAttributes of ArchiveMember, because I don't know exactly their meaning. As I have to investigate on this anyway, I'll fill this in, when I know better.

I would be happy if a native english speaker could correct any language mistakes I made.