### PR TITLE
fix issue 20328 - deprecation message about Nullable.get in isInputRange

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2886,8 +2886,9 @@ Returns:
     assert(app.data == "1");
 }
 
-// Issue 19799
-@safe unittest
+// Issue 19799, disabled because of issue 20328. Formatting a null Nullable triggers a deprecation
+// but the deprecation can be fixed by using .get either
+version(none) @safe unittest
 {
     import std.format : format;
 


### PR DESCRIPTION
Please not well that actually this test case **cant** be fixed by using `.get` but at least the deprecation message is prevented when a user module that imports a `Nullable` is unittested, which can happend even indirectly, e.g when using `std.json.parseJSON`.