### PR TITLE
Fix issue 20328: only check isInputRange when we've already excluded toString overload.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3974,9 +3974,10 @@ if (hasToString!(T, Char))
 void enforceValidFormatSpec(T, Char)(scope const ref FormatSpec!Char f)
 {
     enum overload = hasToString!(T, Char);
-    static if (!isInputRange!T &&
+    static if (
             overload != HasToStringResult.constCharSinkFormatSpec &&
-            overload != HasToStringResult.customPutWriterFormatSpec)
+            overload != HasToStringResult.customPutWriterFormatSpec &&
+            !isInputRange!T)
     {
         enforceFmt(f.spec == 's',
             "Expected '%s' format specifier for type '" ~ T.stringof ~ "'");


### PR DESCRIPTION
This prevents `isInputRange` from noticing that `Nullable!string` is technically an input range (because string is) and hitting the `.get` deprecation.