### PR TITLE
Add `scope` preparing for `in` to become `const scope`

### DIFF
--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -801,7 +801,7 @@ ref T[N] asArray(size_t N, T)(ref T[] source, string errorMsg = "")
  * Fill in a preallocated buffer with the ASCII hex representation from a byte buffer
  */
 private void toHexStringImpl(Order order, LetterCase letterCase, BB, HB)
-(const ref BB byteBuffer, ref HB hexBuffer){
+(scope const ref BB byteBuffer, ref HB hexBuffer){
     static if (letterCase == LetterCase.upper)
     {
         import std.ascii : hexDigits = hexDigits;

--- a/std/string.d
+++ b/std/string.d
@@ -5425,7 +5425,7 @@ if (isSomeChar!C1 && isSomeString!S && isSomeChar!C2 && isOutputRange!(Buffer, S
 }
 
 private void translateImpl(C1, T, C2, Buffer)(const(C1)[] str,
-                                      T transTable,
+                                      scope T transTable,
                                       const(C2)[] toRemove,
                                       Buffer buffer)
 {


### PR DESCRIPTION
This would unblock [the dmd PR changing `in` to mean `const scope`](https://github.com/dlang/dmd/pull/10506).