### PR TITLE
Made SortedRange verifications conditionally compiled.

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -233,6 +233,7 @@ public import std.range.interfaces;
 public import std.range.primitives;
 public import std.typecons : Flag, Yes, No;
 
+import std.internal.attributes : betterC;
 import std.meta : allSatisfy, staticMap;
 import std.traits : CommonType, isCallable, isFloatingPoint, isIntegral,
     isPointer, isSomeFunction, isStaticArray, Unqual, isInstanceOf;
@@ -10645,6 +10646,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
     }
 
     // Assertion only.
+    static if (opt == SortedRangeOptions.checkRoughly)
     private void roughlyVerifySorted(Range r)
     {
         if (!__ctfe)
@@ -10669,6 +10671,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
     }
 
     // Assertion only.
+    static if (opt == SortedRangeOptions.checkStrictly)
     private void strictlyVerifySorted(Range r)
     {
         if (!__ctfe)
@@ -11223,9 +11226,9 @@ that break its sorted-ness, `SortedRange` will work erratically.
     assert(!r.contains(42));            // passes although it shouldn't
 }
 
-@safe unittest
+@betterC @nogc nothrow @safe unittest
 {
-    immutable(int)[] arr = [ 1, 2, 3 ];
+    static immutable(int)[] arr = [ 1, 2, 3 ];
     auto s = assumeSorted(arr);
 }
 


### PR DESCRIPTION
Those verifications broke SortedRange with -betterC even when they were off.