### PR TITLE
Reactivate unittests for findRoot

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1480,7 +1480,7 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
         //numCalls=0;
         //++numProblems;
         assert(!x1.isNaN() && !x2.isNaN());
-        assert(signbit(x1) != signbit(x2));
+        assert(signbit(f(x1)) != signbit(f(x2)));
         auto result = findRoot(f, x1, x2, f(x1), f(x2),
           (real lo, real hi) { return false; });
 
@@ -1505,9 +1505,9 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
     }
     // Test a function with more than one root.
     real multisine(real x) { ++numCalls; return sin(x); }
-    //testFindRoot( &multisine, 6, 90);
-    //testFindRoot(&cubicfn, -100, 100);
-    //testFindRoot( &cubicfn, -double.max, real.max);
+    testFindRoot( &multisine, 6, 90);
+    testFindRoot(&cubicfn, -100, 100);
+    testFindRoot( &cubicfn, -double.max, real.max);
 
 
 /* Tests from the paper:
@@ -1540,7 +1540,7 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
     foreach (k; power_nvals)
     {
         n = k;
-        //testFindRoot(&power, -1, 10);
+        testFindRoot(&power, -1, 10);
     }
 
     int powerProblems = numProblems;
@@ -1601,17 +1601,17 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
     }
 
     numProblems=0;
-    //testFindRoot(&alefeld0, PI_2, PI);
+    testFindRoot(&alefeld0, PI_2, PI);
     for (n=1; n <= 10; ++n)
     {
-        //testFindRoot(&alefeld0, n*n+1e-9L, (n+1)*(n+1)-1e-9L);
+        testFindRoot(&alefeld0, n*n+1e-9L, (n+1)*(n+1)-1e-9L);
     }
     ale_a = -40; ale_b = -1;
-    //testFindRoot(&alefeld1, -9, 31);
+    testFindRoot(&alefeld1, -9, 31);
     ale_a = -100; ale_b = -2;
-    //testFindRoot(&alefeld1, -9, 31);
+    testFindRoot(&alefeld1, -9, 31);
     ale_a = -200; ale_b = -3;
-    //testFindRoot(&alefeld1, -9, 31);
+    testFindRoot(&alefeld1, -9, 31);
     int [] nvals_3 = [1, 2, 5, 10, 15, 20];
     int [] nvals_5 = [1, 2, 4, 5, 8, 15, 20];
     int [] nvals_6 = [1, 5, 10, 15, 20];
@@ -1619,48 +1619,48 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
 
     for (int i=4; i<12; i+=2)
     {
-       n = i;
-       ale_a = 0.2;
-       //testFindRoot(&alefeld2, 0, 5);
-       ale_a=1;
-       //testFindRoot(&alefeld2, 0.95, 4.05);
-       //testFindRoot(&alefeld2, 0, 1.5);
+        n = i;
+        ale_a = 0.2;
+        testFindRoot(&alefeld2, 0, 5);
+        ale_a=1;
+        testFindRoot(&alefeld2, 0.95, 4.05);
+        testFindRoot(&alefeld2, 0, 1.5);
     }
     foreach (i; nvals_3)
     {
         n=i;
-        //testFindRoot(&alefeld3, 0, 1);
+        testFindRoot(&alefeld3, 0, 1);
     }
     foreach (i; nvals_3)
     {
         n=i;
-        //testFindRoot(&alefeld4, 0, 1);
+        testFindRoot(&alefeld4, 0, 1);
     }
     foreach (i; nvals_5)
     {
         n=i;
-        //testFindRoot(&alefeld5, 0, 1);
+        testFindRoot(&alefeld5, 0, 1);
     }
     foreach (i; nvals_6)
     {
         n=i;
-        //testFindRoot(&alefeld6, 0, 1);
+        testFindRoot(&alefeld6, 0, 1);
     }
     foreach (i; nvals_7)
     {
         n=i;
-        //testFindRoot(&alefeld7, 0.01L, 1);
+        testFindRoot(&alefeld7, 0.01L, 1);
     }
     real worstcase(real x)
     {
         ++numCalls;
         return x<0.3*real.max? -0.999e-3 : 1.0;
     }
-    //testFindRoot(&worstcase, -real.max, real.max);
+    testFindRoot(&worstcase, -real.max, real.max);
 
     // just check that the double + float cases compile
-    //findRoot((double x){ return 0.0; }, -double.max, double.max);
-    //findRoot((float x){ return 0.0f; }, -float.max, float.max);
+    findRoot((double x){ return 0.0; }, -double.max, double.max);
+    findRoot((float x){ return 0.0f; }, -float.max, float.max);
 
 /*
    int grandtotal=0;


### PR DESCRIPTION
When trying to do more covering for findRoot I noticed, that all unittests where commented out. I tried to find out, why this happend. It was in 2009 in commit 0c1429... The reason was probably, that an erroneous assert inside of testFindRoot was added and with little time left (the next release was due), the solution was to comment out the unittests.

I fixed the assert (although I think it's not 100% correct now, because one of the numbers could be 0 and the other >=0 which means, both have the same sign and still the call is correct; maybe, the assert should be removed alltogether?). 