### PR TITLE
Add closures to warning and mark warning in red.

### DIFF
--- a/std/signals.d
+++ b/std/signals.d
@@ -37,11 +37,11 @@
  *      $(LINK2 http://www.digitalmars.com/d/archives/16368.html, signals and slots)$(BR)
  *
  * Bugs:
- *      Slots can only be delegates formed from class objects or
+ *      $(RED Slots can only be delegates formed from class objects or
  *      interfaces to class objects. If a delegate to something else
  *      is passed to connect(), such as a struct member function,
- *      a nested function or a COM interface, undefined behavior
- *      will result.
+ *      a nested function, a COM interface or a closure, undefined behavior
+ *      will result.)
  *
  *      Not safe for multiple threads operating on the same signals
  *      or slots.


### PR DESCRIPTION
This addresses [issue 9603](https://issues.dlang.org/show_bug.cgi?id=9603). I think, inside of Phobos this cannot be repaired (maybe with a complete rewrite), nor is it possible to add an exception to prevent the crash.

I remember, that I've seen an even more impressive warning somewhere, but could not find it again. I think it would be the right thing to add here.