### PR TITLE
[posix.mak]: Build @betterC extracted tests without -unittest

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -646,9 +646,9 @@ betterc: betterc-phobos-tests
 	@# Due to the FORCE rule on druntime, make will always try to rebuild Phobos (even as an order-only dependency)
 	@# However, we still need to ensure that the test_extractor is built once
 	@[ -f "$(TESTS_EXTRACTOR)" ] || ${MAKE} -f posix.mak "$(TESTS_EXTRACTOR)"
-	@$(TESTS_EXTRACTOR) --betterC --attributes betterC \
+	$(TESTS_EXTRACTOR) --betterC --attributes betterC \
 		--inputdir  $< --outputdir $(BETTERCTESTS_DIR)
-	@$(DMD) $(DFLAGS) $(NODEFAULTLIB) -betterC $(UDFLAGS) -run $(BETTERCTESTS_DIR)/$(subst /,_,$<)
+	$(DMD) $(DFLAGS) $(NODEFAULTLIB) -betterC -run $(BETTERCTESTS_DIR)/$(subst /,_,$<)
 
 ################################################################################
 


### PR DESCRIPTION
We don't want to compile -betterC test files with -unittest because this
will also compile the unit tests of imported files, and those unit tests
were not written in -betterC in mind.

PR https://github.com/dlang/tools/pull/386 allows us to not compile with
-unittest such files and this commit makes this change.

Also enable command output for the last 2 lines of the %.betterc rule is
it's quite helpful in order to see what's going on.

Blocked on:
* [x] https://github.com/dlang/tools/pull/386