### PR TITLE
Fix partially Issue 11809 - unit tests leave behind temporary files

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2318,6 +2318,7 @@ the contents may well have changed).
         static import std.file;
         auto deleteme = testFilename();
         std.file.write(deleteme, "Line 1\nLine 2\nLine 3\n");
+        scope(success) std.file.remove(deleteme);
 
         auto f = File(deleteme);
         f.byLine();


### PR DESCRIPTION
On linux there is nothing left now, but I have no means to check that for other OS.