### PR TITLE
std.zip: Remove some unnecessary private variables

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -602,6 +602,24 @@ public:
         _directory.remove(de.name);
     }
 
+    // issue 20398
+    @safe unittest
+    {
+        import std.string : representation;
+
+        ArchiveMember file1 = new ArchiveMember();
+        file1.name = "test1.txt";
+        file1.expandedData("Test data.\n".dup.representation);
+
+        ZipArchive zip = new ZipArchive();
+
+        zip.addMember(file1);
+        assert(zip.totalEntries == 1);
+
+        zip.deleteMember(file1);
+        assert(zip.totalEntries == 0);
+    }
+
     /**
      * Construct the entire contents of the current members of the archive.
      *


### PR DESCRIPTION
Without multidisk support, numEntries and totalEntries are the same numbers and furthermore they should always be the same as the length of the directory. This is enforced, when reading a directory, but when adding a member to the directory or deleting one this is currently not the case. See [issue 20398](https://issues.dlang.org/show_bug.cgi?id=20398).

This creates a change-feature-and-deprecate case. But I see no merit in first fixing the bug with a PR and then deprecating the feature in the next PR.

I also replaced the private variable endrecOffset by a local variable inside findEndOfCentralDirRecord(). Beside being a return value, this was only used in lines 844 to 851. The checks and the copy there are allready done in the constructor and therefore there is no need to do it once again.