### PR TITLE
Remove deprecated symbols from std.digest.digest

### DIFF
--- a/changelog/digest.dd
+++ b/changelog/digest.dd
@@ -1,0 +1,7 @@
+The deprecated aliases in std.digest.digest were removed
+
+They were deprecated since 2.076.1 and have now been removed.
+Import `std.digest` or its submodules instead.
+
+Additionally the deprecation cycle for `std.digest` was started
+and the module will be removed in 2.101.

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -135,13 +135,13 @@ alias CRC32 = CRC!(32, 0xEDB88320);
 
 /**
  * Template API CRC64-ECMA implementation.
- * See `std.digest.digest` for differences between template and OOP API.
+ * See `std.digest` for differences between template and OOP API.
  */
 alias CRC64ECMA = CRC!(64, 0xC96C5795D7870F42);
 
 /**
  * Template API CRC64-ISO implementation.
- * See `std.digest.digest` for differences between template and OOP API.
+ * See `std.digest` for differences between template and OOP API.
  */
 alias CRC64ISO = CRC!(64, 0xD800000000000000);
 
@@ -154,7 +154,7 @@ alias CRC64ISO = CRC!(64, 0xD800000000000000);
  * You may want to use the CRC32, CRC65ECMA and CRC64ISO aliases
  * for convenience.
  *
- * See `std.digest.digest` for differences between template and OOP API.
+ * See `std.digest` for differences between template and OOP API.
  */
 struct CRC(uint N, ulong P)
 if (N == 32 || N == 64)
@@ -609,7 +609,7 @@ alias CRC32Digest = WrapperDigest!CRC32;
 
 /**
  * OOP API CRC64-ECMA implementation.
- * See `std.digest.digest` for differences between template and OOP API.
+ * See `std.digest` for differences between template and OOP API.
  *
  * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!CRC64ECMA),
  * see there for more information.
@@ -618,7 +618,7 @@ alias CRC64ECMADigest = WrapperDigest!CRC64ECMA;
 
 /**
  * OOP API CRC64-ISO implementation.
- * See `std.digest.digest` for differences between template and OOP API.
+ * See `std.digest` for differences between template and OOP API.
  *
  * This is an alias for $(D $(REF WrapperDigest, std,digest,digest)!CRC64ISO),
  * see there for more information.

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -1,35 +1,3 @@
+// @@@DEPRECATED_2.091@@@
+deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.101")
 module std.digest.digest;
-
-import _newDigest = std.digest;
-
-// @@@DEPRECATED_2.084@@@
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias isDigest = _newDigest.isDigest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias DigestType = _newDigest.DigestType;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias hasPeek = _newDigest.hasPeek;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias hasBlockSize = _newDigest.hasBlockSize;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias digest = _newDigest.digest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias hexDigest = _newDigest.hexDigest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias makeDigest = _newDigest.makeDigest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias Digest = _newDigest.Digest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias Order = _newDigest.Order;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias toHexString = _newDigest.toHexString;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias asArray = _newDigest.asArray;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias digestLength = _newDigest.digestLength;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias WrapperDigest = _newDigest.WrapperDigest;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias secureEqual = _newDigest.secureEqual;
-deprecated("import std.digest instead of std.digest.digest. std.digest.digest will be removed in 2.084")
-alias LetterCase = _newDigest.LetterCase;

--- a/unittest.d
+++ b/unittest.d
@@ -51,7 +51,7 @@ public import std.zip;
 public import std.zlib;
 public import std.net.isemail;
 public import std.net.curl;
-public import std.digest.digest;
+public import std.digest;
 public import std.digest.crc;
 public import std.digest.sha;
 public import std.digest.md;


### PR DESCRIPTION
Blocked by:

- [x] CyberShadow/ae#42
- [x] Upgrade [dlang-bot](https://github.com/dlang/dlang-bot) to newer vibe-d