### PR TITLE
Add automatic number conversion to std.json

### DIFF
--- a/changelog/json_number_conversion.dd
+++ b/changelog/json_number_conversion.dd
@@ -1,0 +1,12 @@
+Added get!(T) getter to std.json
+
+This getter will try to return underlying json type as T if possible.
+It is convenient for automatic integer conversion like this:
+-------
+import std.json;
+string s = `{ "a": 123 }`;
+auto json = parseJSON(s);
+
+// This will throw with json["a"].floating
+assert(json["a"].get!double == 123.0);
+-------

--- a/std/json.d
+++ b/std/json.d
@@ -359,6 +359,90 @@ struct JSONValue
         return type == JSONType.null_;
     }
 
+    /***
+     * Generic type value getter
+     * A convenience getter that returns this `JSONValue` as the specified D type.
+     * Note: only numeric, `bool`, `string`, `JSONValue[string]` and `JSONValue[]` types are accepted
+     * Throws: `JSONException` if `T` cannot hold the contents of this `JSONValue`
+     */
+    @property inout(T) get(T)() inout const pure @safe
+    {
+        static if (is(Unqual!T == string))
+        {
+            return str;
+        }
+        else static if (is(Unqual!T == bool))
+        {
+            return boolean;
+        }
+        else static if (isFloatingPoint!T)
+        {
+            switch (type)
+            {
+            case JSONType.float_:
+                return cast(T) floating;
+            case JSONType.uinteger:
+                return cast(T) uinteger;
+            case JSONType.integer:
+                return cast(T) integer;
+            default:
+                throw new JSONException("JSONValue is not a number type");
+            }
+        }
+        else static if (__traits(isUnsigned, T))
+        {
+            return cast(T) uinteger;
+        }
+        else static if (isSigned!T)
+        {
+            return cast(T) integer;
+        }
+        else
+        {
+            static assert(false, "Unsupported type");
+        }
+    }
+    // This specialization is needed because arrayNoRef requires inout
+    @property inout(T) get(T : JSONValue[])() inout pure @trusted /// ditto
+    {
+        return arrayNoRef;
+    }
+    /// ditto
+    @property inout(T) get(T : JSONValue[string])() inout pure @trusted
+    {
+        return object;
+    }
+    ///
+    @safe unittest
+    {
+        import std.exception;
+        string s =
+        `{
+            "a": 123,
+            "b": 3.1415,
+            "c": "text",
+            "d": true,
+            "e": [1, 2, 3],
+            "f": { "a": 1 }
+         }`;
+
+        struct a { }
+
+        immutable json = parseJSON(s);
+        assert(json["a"].get!double == 123.0);
+        assert(json["a"].get!int == 123);
+        assert(json["b"].get!double == 3.1415);
+        assertThrown(json["b"].get!int);
+        assert(json["c"].get!string == "text");
+        assert(json["d"].get!bool == true);
+        assertNotThrown(json["e"].get!(JSONValue[]));
+        assertNotThrown(json["f"].get!(JSONValue[string]));
+        static assert(!__traits(compiles, json["a"].get!a));
+        assertThrown(json["e"].get!float);
+        assertThrown(json["d"].get!(JSONValue[string]));
+        assertThrown(json["f"].get!(JSONValue[]));
+    }
+
     private void assign(T)(T arg) @safe
     {
         static if (is(T : typeof(null)))


### PR DESCRIPTION
The JSON standard only defines the "number" type. Therefore it is expected that any whole number would be castable as floating and it doesn't. This little PR changes the behaviour of `floating()` so it will cast any numeric type to double and return it.