### PR TITLE
Make std.bigint `@safe`

### DIFF
--- a/changelog/bigint-safe.dd
+++ b/changelog/bigint-safe.dd
@@ -1,0 +1,4 @@
+`std.bigint` is now `@safe`
+
+Many `BigInt` operations used to be `@system` because of assembly routines and casts from mutable to immutable data.
+These parts are now marked `@trusted`, so that `BigInt` can now be used in `@safe` code.

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -907,7 +907,7 @@ public:
         Warning: Casting to/from `const` or `immutable` may break type
         system guarantees. Use with care.
      */
-    T opCast(T)() pure nothrow @nogc @safe const
+    T opCast(T)() pure nothrow @nogc const
     if (is(Unqual!T == BigInt))
     {
         return this;

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1131,6 +1131,7 @@ public:
     /// ditto
     void toString(Writer)(scope Writer sink, scope const ref FormatSpec!char f) const
     {
+        import std.range.primitives : put;
         const spec = f.spec;
         immutable hex = (spec == 'x' || spec == 'X');
         if (!(spec == 's' || spec == 'd' || spec =='o' || hex))
@@ -1177,23 +1178,23 @@ public:
 
         if (!f.flDash && !f.flZero)
             foreach (i; 0 .. difw)
-                sink(" ");
+                put(sink, " ");
 
         if (signChar)
         {
             scope char[1] buf = signChar;
-            sink(buf[]);
+            put(sink, buf[]);
         }
 
         if (!f.flDash && f.flZero)
             foreach (i; 0 .. difw)
-                sink("0");
+                put(sink, "0");
 
-        sink(buff);
+        put(sink, buff);
 
         if (f.flDash)
             foreach (i; 0 .. difw)
-                sink(" ");
+                put(sink, " ");
     }
 
     /**

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -123,7 +123,7 @@ public:
         this(s.byCodeUnit);
     }
 
-    @system unittest
+    @safe unittest
     {
         // system because of the dummy ranges eventually call std.array!string
         import std.exception : assertThrown;
@@ -146,29 +146,28 @@ public:
     }
 
     /// Construct a `BigInt` from a built-in integral type.
-    this(T)(T x) pure nothrow if (isIntegral!T)
+    this(T)(T x) pure nothrow @safe if (isIntegral!T)
     {
         data = data.init; // @@@: Workaround for compiler bug
         opAssign(x);
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
-        // @system due to failure in FreeBSD32
         ulong data = 1_000_000_000_000;
         auto bigData = BigInt(data);
         assert(bigData == BigInt("1_000_000_000_000"));
     }
 
     /// Construct a `BigInt` from another `BigInt`.
-    this(T)(T x) pure nothrow if (is(Unqual!T == BigInt))
+    this(T)(T x) pure nothrow @safe if (is(Unqual!T == BigInt))
     {
         opAssign(x);
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         const(BigInt) b1 = BigInt("1_234_567_890");
         BigInt b2 = BigInt(b1);
@@ -176,7 +175,7 @@ public:
     }
 
     /// Assignment from built-in integer types.
-    BigInt opAssign(T)(T x) pure nothrow if (isIntegral!T)
+    BigInt opAssign(T)(T x) pure nothrow @safe if (isIntegral!T)
     {
         data = cast(ulong) absUnsign(x);
         sign = (x < 0);
@@ -184,7 +183,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto b = BigInt("123");
         b = 456;
@@ -192,7 +191,7 @@ public:
     }
 
     /// Assignment from another BigInt.
-    BigInt opAssign(T:BigInt)(T x) pure @nogc
+    BigInt opAssign(T:BigInt)(T x) pure @nogc @safe
     {
         data = x.data;
         sign = x.sign;
@@ -200,7 +199,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto b1 = BigInt("123");
         auto b2 = BigInt("456");
@@ -212,7 +211,7 @@ public:
      * Implements assignment operators from built-in integers of the form
      * `BigInt op= integer`.
      */
-    BigInt opOpAssign(string op, T)(T y) pure nothrow
+    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe
         if ((op=="+" || op=="-" || op=="*" || op=="/" || op=="%"
           || op==">>" || op=="<<" || op=="^^" || op=="|" || op=="&" || op=="^") && isIntegral!T)
     {
@@ -301,9 +300,8 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
-        //@system because opOpAssign is @system
         auto b = BigInt("1_000_000_000");
 
         b += 12345;
@@ -314,7 +312,7 @@ public:
     }
 
     // Issue 16264
-    @system unittest
+    @safe unittest
     {
         auto a = BigInt(
     `335690982744637013564796917901053301979460129353374296317539383938630086938` ~
@@ -365,7 +363,7 @@ public:
     /**
      * Implements assignment operators of the form `BigInt op= BigInt`.
      */
-    BigInt opOpAssign(string op, T)(T y) pure nothrow
+    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe
         if ((op=="+" || op== "-" || op=="*" || op=="|" || op=="&" || op=="^" || op=="/" || op=="%")
             && is (T: BigInt))
     {
@@ -412,9 +410,8 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
-        // @system because opOpAssign is @system
         auto x = BigInt("123");
         auto y = BigInt("321");
         x += y;
@@ -424,7 +421,7 @@ public:
     /**
      * Implements binary operators between `BigInt`s.
      */
-    BigInt opBinary(string op, T)(T y) pure nothrow const
+    BigInt opBinary(string op, T)(T y) pure nothrow @safe const
         if ((op=="+" || op == "*" || op=="-" || op=="|" || op=="&" || op=="^" ||
             op=="/" || op=="%")
             && is (T: BigInt))
@@ -434,7 +431,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("123");
         auto y = BigInt("456");
@@ -445,7 +442,7 @@ public:
     /**
      * Implements binary operators between `BigInt`'s and built-in integers.
      */
-    BigInt opBinary(string op, T)(T y) pure nothrow const
+    BigInt opBinary(string op, T)(T y) pure nothrow @safe const
         if ((op=="+" || op == "*" || op=="-" || op=="/" || op=="|" || op=="&" ||
             op=="^"|| op==">>" || op=="<<" || op=="^^")
             && isIntegral!T)
@@ -455,7 +452,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("123");
         x *= 300;
@@ -475,7 +472,7 @@ public:
         $(TR $(TD `BigInt`) $(TD $(CODE_PERCENT)) $(TD other type) $(TD $(RARR)) $(TD `int`))
         )
      */
-    auto opBinary(string op, T)(T y) pure nothrow const
+    auto opBinary(string op, T)(T y) pure nothrow @safe const
         if (op == "%" && isIntegral!T)
     {
         assert(y != 0, "% 0 not allowed");
@@ -513,7 +510,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto  x  = BigInt("1_000_000_500");
         long  l  = 1_000_000L;
@@ -531,14 +528,14 @@ public:
         Implements operators with built-in integers on the left-hand side and
         `BigInt` on the right-hand side.
      */
-    BigInt opBinaryRight(string op, T)(T y) pure nothrow const
+    BigInt opBinaryRight(string op, T)(T y) pure nothrow @safe const
         if ((op=="+" || op=="*" || op=="|" || op=="&" || op=="^") && isIntegral!T)
     {
         return opBinary!(op)(y);
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("100");
         BigInt y = 123 + x;
@@ -556,7 +553,7 @@ public:
 
     //  BigInt = integer op BigInt
     /// ditto
-    BigInt opBinaryRight(string op, T)(T y) pure nothrow const
+    BigInt opBinaryRight(string op, T)(T y) pure nothrow @safe const
         if (op == "-" && isIntegral!T)
     {
         ulong u = absUnsign(y);
@@ -572,7 +569,7 @@ public:
 
     //  integer = integer op BigInt
     /// ditto
-    T opBinaryRight(string op, T)(T x) pure nothrow const
+    T opBinaryRight(string op, T)(T x) pure nothrow @safe const
         if ((op=="%" || op=="/") && isIntegral!T)
     {
         checkDivByZero();
@@ -599,7 +596,7 @@ public:
     /**
         Implements `BigInt` unary operators.
      */
-    BigInt opUnary(string op)() pure nothrow const if (op=="+" || op=="-" || op=="~")
+    BigInt opUnary(string op)() pure nothrow @safe const if (op=="+" || op=="-" || op=="~")
     {
        static if (op=="-")
        {
@@ -617,7 +614,7 @@ public:
 
     // non-const unary operations
     /// ditto
-    BigInt opUnary(string op)() pure nothrow if (op=="++" || op=="--")
+    BigInt opUnary(string op)() pure nothrow @safe if (op=="++" || op=="--")
     {
         static if (op=="++")
         {
@@ -632,7 +629,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("1234");
         assert(-x == BigInt("-1234"));
@@ -645,13 +642,13 @@ public:
         Implements `BigInt` equality test with other `BigInt`'s and built-in
         numeric types.
      */
-    bool opEquals()(auto ref const BigInt y) const pure @nogc
+    bool opEquals()(auto ref const BigInt y) const pure @nogc @safe
     {
        return sign == y.sign && y.data == data;
     }
 
     /// ditto
-    bool opEquals(T)(const T y) const pure nothrow @nogc if (isIntegral!T)
+    bool opEquals(T)(const T y) const pure nothrow @nogc @safe if (isIntegral!T)
     {
         if (sign != (y<0))
             return 0;
@@ -676,7 +673,7 @@ public:
         assert(BigInt(123456789) != cast(float) 123456789);
     }
 
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("12345");
         auto y = BigInt("12340");
@@ -690,7 +687,7 @@ public:
         assert(x != w);
     }
 
-    @system unittest
+    @safe unittest
     {
         import std.math : nextDown, nextUp;
 
@@ -726,13 +723,13 @@ public:
     /**
         Implements casting to `bool`.
      */
-    T opCast(T:bool)() pure nothrow @nogc const
+    T opCast(T:bool)() pure nothrow @nogc @safe const
     {
         return !isZero();
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         // Non-zero values are regarded as true
         auto x = BigInt("1");
@@ -751,7 +748,7 @@ public:
         Throws: $(REF ConvOverflowException, std,conv) if the number exceeds
         the target type's range.
      */
-    T opCast(T:ulong)() pure const
+    T opCast(T:ulong)() pure @safe const
     {
         if (isUnsigned!T && sign)
             { /* throw */ }
@@ -779,7 +776,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         import std.conv : to, ConvOverflowException;
         import std.exception : assertThrown;
@@ -792,7 +789,7 @@ public:
         assertThrown!ConvOverflowException(BigInt("-1").to!ubyte);
     }
 
-    @system unittest
+    @safe unittest
     {
         import std.conv : to, ConvOverflowException;
         import std.exception : assertThrown;
@@ -910,14 +907,14 @@ public:
         Warning: Casting to/from `const` or `immutable` may break type
         system guarantees. Use with care.
      */
-    T opCast(T)() pure nothrow @nogc const
+    T opCast(T)() pure nothrow @nogc @safe const
     if (is(Unqual!T == BigInt))
     {
         return this;
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         const(BigInt) x = BigInt("123");
         BigInt y = cast() x;    // cast away const
@@ -931,14 +928,14 @@ public:
         Implements 3-way comparisons of `BigInt` with `BigInt` or `BigInt` with
         built-in numeric types.
      */
-    int opCmp(ref const BigInt y) pure nothrow @nogc const
+    int opCmp(ref const BigInt y) pure nothrow @nogc @safe const
     {
         // Simply redirect to the "real" opCmp implementation.
         return this.opCmp!BigInt(y);
     }
 
     /// ditto
-    int opCmp(T)(const T y) pure nothrow @nogc const if (isIntegral!T)
+    int opCmp(T)(const T y) pure nothrow @nogc @safe const if (isIntegral!T)
     {
         if (sign != (y<0) )
             return sign ? -1 : 1;
@@ -946,7 +943,7 @@ public:
         return sign? -cmp: cmp;
     }
     /// ditto
-    int opCmp(T)(const T y) nothrow @nogc const if (isFloatingPoint!T)
+    int opCmp(T)(const T y) nothrow @nogc @safe const if (isFloatingPoint!T)
     {
         import core.bitop : bsr;
         import std.math : cmp, isFinite;
@@ -976,7 +973,7 @@ public:
         return 0;
     }
     /// ditto
-    int opCmp(T:BigInt)(const T y) pure nothrow @nogc const
+    int opCmp(T:BigInt)(const T y) pure nothrow @nogc @safe const
     {
         if (sign != y.sign)
             return sign ? -1 : 1;
@@ -985,7 +982,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("100");
         auto y = BigInt("10");
@@ -999,7 +996,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto x = BigInt("0x1abc_de80_0000_0000_0000_0000_0000_0000");
         BigInt y = x - 1;
@@ -1016,7 +1013,7 @@ public:
         assert(BigInt(123456789) < cast(float) 123456789);
     }
 
-    @system unittest
+    @safe unittest
     {
         assert(BigInt("999_999_999_999_999_999_999_999_999_999_999_999_999") < float.infinity);
 
@@ -1062,7 +1059,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto b = BigInt("12345");
         long l = b.toLong();
@@ -1082,7 +1079,7 @@ public:
     }
 
     ///
-    @system unittest
+    @safe unittest
     {
         auto big = BigInt("5_000_000");
         auto i = big.toInt();
@@ -1111,7 +1108,7 @@ public:
     /** Convert the `BigInt` to `string`, passing it to the given sink.
      *
      * Params:
-     *  sink = A delegate for accepting possibly piecewise segments of the
+     *  sink = An OutputRange for accepting possibly piecewise segments of the
      *      formatted string.
      *  formatString = A format string specifying the output format.
      *
@@ -1124,7 +1121,7 @@ public:
      * $(TR $(TD null) $(TD Default formatting (same as "d") ))
      * )
      */
-    void toString(scope void delegate(const (char)[]) sink, string formatString) const
+    void toString(Writer)(scope Writer sink, string formatString) const
     {
         auto f = FormatSpec!char(formatString);
         f.writeUpToNextSpec(sink);
@@ -1132,7 +1129,7 @@ public:
     }
 
     /// ditto
-    void toString(scope void delegate(const(char)[]) sink, scope const ref FormatSpec!char f) const
+    void toString(Writer)(scope Writer sink, scope const ref FormatSpec!char f) const
     {
         const spec = f.spec;
         immutable hex = (spec == 'x' || spec == 'X');
@@ -1183,7 +1180,10 @@ public:
                 sink(" ");
 
         if (signChar)
-            sink((&signChar)[0 .. 1]);
+        {
+            scope char[1] buf = signChar;
+            sink(buf[]);
+        }
 
         if (!f.flDash && f.flZero)
             foreach (i; 0 .. difw)
@@ -1200,7 +1200,7 @@ public:
         `toString` is rarely directly invoked; the usual way of using it is via
         $(REF format, std, format):
      */
-    @system unittest
+    @safe unittest
     {
         import std.format : format;
 
@@ -1264,7 +1264,7 @@ public:
     }
 
     ///
-    @system pure unittest
+    @safe pure unittest
     {
         auto a = BigInt("1000");
         assert(a.ulongLength() == 1);
@@ -1307,7 +1307,7 @@ private:
 }
 
 ///
-@system unittest
+@safe unittest
 {
     BigInt a = "9588669891916142";
     BigInt b = "7452469135154800";
@@ -1346,7 +1346,7 @@ Returns:
     A `string` that represents the `BigInt` as a decimal number.
 
 */
-string toDecimalString(const(BigInt) x) pure nothrow
+string toDecimalString(const(BigInt) x) pure nothrow @safe
 {
     auto buff = x.data.toDecimalString(x.isNegative ? 1 : 0);
     if (x.isNegative)
@@ -1355,7 +1355,7 @@ string toDecimalString(const(BigInt) x) pure nothrow
 }
 
 ///
-@system pure unittest
+@safe pure unittest
 {
     auto x = BigInt("123");
     x *= 1000;
@@ -1374,7 +1374,7 @@ Returns:
     number in upper case.
 
 */
-string toHex(const(BigInt) x)
+string toHex(const(BigInt) x) @safe
 {
     string outbuff="";
     void sink(const(char)[] s) { outbuff ~= s; }
@@ -1383,7 +1383,7 @@ string toHex(const(BigInt) x)
 }
 
 ///
-@system unittest
+@safe unittest
 {
     auto x = BigInt("123");
     x *= 1000;
@@ -1422,14 +1422,14 @@ if (isIntegral!T)
 }
 
 ///
-nothrow pure @system
+nothrow pure @safe
 unittest
 {
     assert((-1).absUnsign == 1);
     assert(1.absUnsign == 1);
 }
 
-nothrow pure @system
+nothrow pure @safe
 unittest
 {
     BigInt a, b;
@@ -1439,7 +1439,7 @@ unittest
     assert(c == 3);
 }
 
-nothrow pure @system
+nothrow pure @safe
 unittest
 {
     long a;
@@ -1450,7 +1450,7 @@ unittest
     assert(d == 0);
 }
 
-nothrow pure @system
+nothrow pure @safe
 unittest
 {
     BigInt x = 1, y = 2;
@@ -1475,7 +1475,7 @@ unittest
     assert(incr == BigInt(1));
 }
 
-@system unittest
+@safe unittest
 {
     // Radix conversion
     assert( toDecimalString(BigInt("-1_234_567_890_123_456_789"))
@@ -1513,7 +1513,7 @@ unittest
         == "1234567");
 }
 
-@system unittest // Minimum signed value bug tests.
+@safe unittest // Minimum signed value bug tests.
 {
     assert(BigInt("-0x8000000000000000") == BigInt(long.min));
     assert(BigInt("-0x8000000000000000")+1 > BigInt(long.min));
@@ -1534,7 +1534,7 @@ unittest
     assert((BigInt(int.min)-1)%int.min == -1);
 }
 
-@system unittest // Recursive division, bug 5568
+@safe unittest // Recursive division, bug 5568
 {
     enum Z = 4843;
     BigInt m = (BigInt(1) << (Z*8) ) - 1;
@@ -1580,7 +1580,7 @@ unittest
     a8165[0] = a8165[1] = 1;
 }
 
-@system unittest
+@safe unittest
 {
     import std.array;
     import std.format;
@@ -1631,7 +1631,7 @@ unittest
     }
 }
 
-@system unittest
+@safe unittest
 {
     import std.array;
     import std.format;
@@ -1682,7 +1682,7 @@ unittest
     }
 }
 
-@system unittest
+@safe unittest
 {
     import std.array;
     import std.format;
@@ -1734,7 +1734,7 @@ unittest
 }
 
 // 6448
-@system unittest
+@safe unittest
 {
     import std.array;
     import std.format;
@@ -1776,7 +1776,7 @@ unittest
     assert(one && !zero);
 }
 
-@system unittest // 6850
+@safe unittest // 6850
 {
     pure long pureTest() {
         BigInt a = 1;
@@ -1788,7 +1788,7 @@ unittest
     assert(pureTest() == 1337);
 }
 
-@system unittest // 8435 & 10118
+@safe unittest // 8435 & 10118
 {
     auto i = BigInt(100);
     auto j = BigInt(100);
@@ -1812,7 +1812,7 @@ unittest
     assert(keys.empty);
 }
 
-@system unittest // 11148
+@safe unittest // 11148
 {
     void foo(BigInt) {}
     const BigInt cbi = 3;
@@ -1876,7 +1876,7 @@ unittest
     assert(l5 == b5);
 }
 
-@system unittest // 11600
+@safe unittest // 11600
 {
     import std.conv;
     import std.exception : assertThrown;
@@ -1897,7 +1897,7 @@ unittest
     assert((x > 0) == false);
 }
 
-@system unittest // 13391
+@safe unittest // 13391
 {
     BigInt x1 = "123456789";
     BigInt x2 = "123456789123456789";
@@ -1928,7 +1928,7 @@ unittest
     assert(x2 == 1);
 }
 
-@system unittest // 13963
+@safe unittest // 13963
 {
     BigInt x = 1;
     import std.meta : AliasSeq;
@@ -1979,7 +1979,7 @@ unittest
     assert(-x2 % ulong.max == -x2);
 }
 
-@system unittest // 14124
+@safe unittest // 14124
 {
     auto x = BigInt(-3);
     x %= 3;
@@ -2003,7 +2003,7 @@ unittest
 }
 
 // issue 15678
-@system unittest
+@safe unittest
 {
     import std.exception : assertThrown;
     assertThrown!ConvException(BigInt(""));
@@ -2012,7 +2012,7 @@ unittest
 }
 
 // Issue 6447
-@system unittest
+@safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.range : iota;
@@ -2028,13 +2028,13 @@ unittest
 }
 
 // Issue 17330
-@system unittest
+@safe unittest
 {
     auto b = immutable BigInt("123");
     assert(b == 123);
 }
 
-@system pure unittest // issue 14767
+@safe pure unittest // issue 14767
 {
     static immutable a = BigInt("340282366920938463463374607431768211455");
     assert(a == BigInt("340282366920938463463374607431768211455"));
@@ -2058,7 +2058,7 @@ unittest
  *     quotient = is set to the result of the division
  *     remainder = is set to the remainder of the division
  */
-void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, out BigInt remainder) pure nothrow
+void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, out BigInt remainder) pure nothrow @safe
 {
     BigUint q, r;
     BigUint.divMod(dividend.data, divisor.data, q, r);
@@ -2069,7 +2069,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
 }
 
 ///
-@system pure nothrow unittest
+@safe pure nothrow unittest
 {
     auto a = BigInt(123);
     auto b = BigInt(25);
@@ -2083,7 +2083,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
 }
 
 // Issue 18086
-@system pure nothrow unittest
+@safe pure nothrow unittest
 {
     BigInt q = 1;
     BigInt r = 1;
@@ -2112,7 +2112,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
 }
 
 // Issue 19740
-@system unittest
+@safe unittest
 {
     BigInt a = BigInt(
         "241127122100380210001001124020210001001100000200003101000062221012075223052000021042250111300200000000000" ~
@@ -2131,7 +2131,7 @@ void divMod(const BigInt dividend, const BigInt divisor, out BigInt quotient, ou
         "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
 }
 
-@system unittest
+@safe unittest
 {
     auto n = BigInt("1234"d);
 }
@@ -2145,7 +2145,7 @@ Params:
 Returns:
      The power modulus value of (base ^ exponent) % modulus.
 */
-BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow
+BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow @safe
 {
     BigInt result = 1;
 
@@ -2164,7 +2164,7 @@ BigInt powmod(BigInt base, BigInt exponent, BigInt modulus) pure nothrow
 }
 
 /// for powmod
-@system unittest
+@safe unittest
 {
     BigInt base = BigInt("123456789012345678901234567890");
     BigInt exponent = BigInt("1234567890123456789012345678901234567");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1236,11 +1236,16 @@ public:
     // the function failed to instantiate.
     @system unittest
     {
+        import std.format : FormatSpec;
+        import std.array : appender;
         BigInt num = 503;
-        import std.array: appender;
         auto dst = appender!string();
         num.toString(str => dst.put(str), null);
         assert(dst[] == "503");
+        num = 504;
+        auto f = FormatSpec!char("");
+        num.toString(str => dst.put(str), f);
+        assert(dst[] == "503504");
     }
 
     // Implement toHash so that BigInt works properly as an AA key.

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -724,7 +724,7 @@ public:
 
 
     //  return x*y.
-    static BigUint mulInt(T = ulong)(BigUint x, T y) pure nothrow
+    static BigUint mulInt(T = ulong)(BigUint x, T y) pure nothrow @safe
     {
         if (y == 0 || x == 0) return BigUint(ZERO);
         static if (T.sizeof * 8 <= 32)
@@ -765,7 +765,7 @@ public:
     }
 
     // return x / y
-    static BigUint divInt(T)(BigUint x, T y_) pure nothrow
+    static BigUint divInt(T)(BigUint x, T y_) pure nothrow @safe
     if ( is(Unqual!T == uint) )
     {
         uint y = y_;
@@ -791,7 +791,7 @@ public:
         return BigUint(removeLeadingZeros(trustedAssumeUnique(result)));
     }
 
-    static BigUint divInt(T)(BigUint x, T y) pure nothrow
+    static BigUint divInt(T)(BigUint x, T y) pure nothrow @safe
     if ( is(Unqual!T == ulong) )
     {
         if (y <= uint.max)
@@ -2431,7 +2431,7 @@ void schoolbookDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
             {
                 // Note: On DMD, this is only ~10% faster than the non-asm code.
                 uint *p = &u[j + v.length - 1];
-                asm pure nothrow
+                asm pure nothrow @trusted
                 {
                     mov EAX, p;
                     mov EDX, [EAX+4];

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -194,7 +194,7 @@ else alias multibyteSquare = std.internal.math.biguintnoasm.multibyteSquare;
 
 // Limits for when to switch between algorithms.
 // Half the size of the data cache.
-@nogc nothrow pure size_t getCacheLimit()
+@nogc nothrow pure @safe size_t getCacheLimit()
 {
     import core.cpuid : dataCaches;
     return (cast(size_t function() @nogc nothrow pure)
@@ -411,7 +411,7 @@ public:
     }
 
     // the extra bytes are added to the start of the string
-    char [] toDecimalString(int frontExtraBytes) const pure nothrow
+    char [] toDecimalString(int frontExtraBytes) const pure nothrow @safe
     {
         immutable predictlength = 20+20*(data.length/2); // just over 19
         char [] buff = new char[frontExtraBytes + predictlength];
@@ -492,7 +492,7 @@ public:
     /**
      * Convert to an octal string.
      */
-    char[] toOctalString() const
+    char[] toOctalString() pure nothrow @safe const
     {
         auto predictLength = 1 + data.length*BigDigitBits / 3;
         char[] buff = new char[predictLength];
@@ -600,7 +600,7 @@ public:
     // All of these member functions create a new BigUint.
 
     // return x >> y
-    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow const
+    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const
         if (op == ">>" && is (Tulong == ulong))
     {
         assert(y > 0, "Can not right shift BigUint by 0");
@@ -624,7 +624,7 @@ public:
     }
 
     // return x << y
-    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow const
+    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const
         if (op == "<<" && is (Tulong == ulong))
     {
         assert(y > 0, "Can not left shift BigUint by 0");
@@ -652,14 +652,14 @@ public:
     // If wantSub is false, return x + y, leaving sign unchanged
     // If wantSub is true, return abs(x - y), negating sign if x < y
     static BigUint addOrSubInt(Tulong)(const BigUint x, Tulong y,
-            bool wantSub, ref bool sign) pure nothrow if (is(Tulong == ulong))
+            bool wantSub, ref bool sign) pure nothrow @safe if (is(Tulong == ulong))
     {
         BigUint r;
         if (wantSub)
         {   // perform a subtraction
             if (x.data.length > 2)
             {
-                r.data = cast(immutable) subInt(x.data, y);
+                r.data = (() @trusted => cast(immutable) subInt(x.data, y))();
             }
             else
             {   // could change sign!
@@ -694,7 +694,7 @@ public:
         }
         else
         {
-            r.data = cast(immutable) addInt(x.data, y);
+            r.data = (() @trusted => cast(immutable) addInt(x.data, y))();
         }
         return r;
     }
@@ -702,13 +702,13 @@ public:
     // If wantSub is false, return x + y, leaving sign unchanged.
     // If wantSub is true, return abs(x - y), negating sign if x<y
     static BigUint addOrSub(BigUint x, BigUint y, bool wantSub, bool *sign)
-        pure nothrow
+        pure nothrow @safe
     {
         BigUint r;
         if (wantSub)
         {   // perform a subtraction
             bool negative;
-            r.data = cast(immutable) sub(x.data, y.data, &negative);
+            r.data = (() @trusted => cast(immutable) sub(x.data, y.data, &negative))();
             *sign ^= negative;
             if (r.isZero())
             {
@@ -717,7 +717,7 @@ public:
         }
         else
         {
-            r.data = cast(immutable) add(x.data, y.data);
+            r.data = (() @trusted => cast(immutable) add(x.data, y.data))();
         }
         return r;
     }
@@ -744,7 +744,7 @@ public:
 
     /*  return x * y.
      */
-    static BigUint mul(BigUint x, BigUint y) pure nothrow
+    static BigUint mul(BigUint x, BigUint y) pure nothrow @safe
     {
         if (y == 0 || x == 0)
             return BigUint(ZERO);
@@ -828,7 +828,7 @@ public:
     }
 
     // return x / y
-    static BigUint div(BigUint x, BigUint y) pure nothrow
+    static BigUint div(BigUint x, BigUint y) pure nothrow @safe
     {
         if (y.data.length > x.data.length)
             return BigUint(ZERO);
@@ -840,7 +840,7 @@ public:
     }
 
     // return x % y
-    static BigUint mod(BigUint x, BigUint y) pure nothrow
+    static BigUint mod(BigUint x, BigUint y) pure nothrow @safe
     {
         if (y.data.length > x.data.length) return x;
         if (y.data.length == 1)
@@ -854,7 +854,7 @@ public:
     }
 
     // Return x / y in quotient, x % y in remainder
-    static void divMod(BigUint x, BigUint y, out BigUint quotient, out BigUint remainder) pure nothrow
+    static void divMod(BigUint x, BigUint y, out BigUint quotient, out BigUint remainder) pure nothrow @safe
     {
         if (y.data.length > x.data.length)
         {
@@ -904,7 +904,7 @@ public:
      * exponentiation is used.
      * Memory allocation is minimized: at most one temporary BigUint is used.
      */
-    static BigUint pow(BigUint x, ulong y) pure nothrow
+    static BigUint pow(BigUint x, ulong y) pure nothrow @safe
     {
         // Deal with the degenerate cases first.
         if (y == 0) return BigUint(ONE);
@@ -1149,7 +1149,7 @@ inout(BigDigit) [] removeLeadingZeros(inout(BigDigit) [] x) pure nothrow @safe
     return x[0 .. k];
 }
 
-pure @system unittest
+pure @safe unittest
 {
    BigUint r = BigUint([5]);
    BigUint t = BigUint([7]);
@@ -1171,7 +1171,7 @@ pure @system unittest
 
 
 // Pow tests
-pure @system unittest
+pure @safe unittest
 {
     BigUint r, s;
     r.fromHexString("80000000_00000001");
@@ -1382,7 +1382,7 @@ private int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe
  *    unique memory
  */
 BigDigit [] sub(const BigDigit [] x, const BigDigit [] y, bool *negative)
-pure nothrow
+pure nothrow @safe
 {
     if (x.length == y.length)
     {
@@ -1441,7 +1441,7 @@ pure nothrow
  * Returns:
  *    unique memory
  */
-BigDigit [] add(const BigDigit [] a, const BigDigit [] b) pure nothrow
+BigDigit [] add(const BigDigit [] a, const BigDigit [] b) pure nothrow @safe
 {
     const(BigDigit) [] x, y;
     if (a.length < b.length)
@@ -1473,7 +1473,7 @@ BigDigit [] add(const BigDigit [] a, const BigDigit [] b) pure nothrow
 
 /**  return x + y
  */
-BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow
+BigDigit [] addInt(const BigDigit[] x, ulong y) @safe pure nothrow
 {
     uint hi = cast(uint)(y >>> 32);
     uint lo = cast(uint)(y& 0xFFFF_FFFF);
@@ -1500,7 +1500,7 @@ BigDigit [] addInt(const BigDigit[] x, ulong y) pure nothrow
 /** Return x - y.
  *  x must be greater than y.
  */
-BigDigit [] subInt(const BigDigit[] x, ulong y) pure nothrow
+BigDigit [] subInt(const BigDigit[] x, ulong y) pure nothrow @safe
 {
     uint hi = cast(uint)(y >>> 32);
     uint lo = cast(uint)(y & 0xFFFF_FFFF);
@@ -1525,7 +1525,7 @@ BigDigit [] subInt(const BigDigit[] x, ulong y) pure nothrow
  *
  */
 void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
-    pure nothrow
+    pure nothrow @safe
 {
     import core.memory : GC;
     assert( result.length == x.length + y.length,
@@ -1677,7 +1677,7 @@ void mulInternal(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
  *   NOTE: If the highest half-digit of x is zero, the highest digit of result will
  *   also be zero.
  */
-void squareInternal(BigDigit[] result, const BigDigit[] x) pure nothrow
+void squareInternal(BigDigit[] result, const BigDigit[] x) pure nothrow @safe
 {
   import core.memory : GC;
   // Squaring is potentially half a multiply, plus add the squares of
@@ -1704,7 +1704,7 @@ import core.bitop : bsr;
 
 /// if remainder is null, only calculate quotient.
 void divModInternal(BigDigit [] quotient, BigDigit[] remainder, const BigDigit [] u,
-        const BigDigit [] v) pure nothrow
+        const BigDigit [] v) pure nothrow @safe
 {
     import core.memory : GC;
     assert(quotient.length == u.length - v.length + 1,
@@ -1751,7 +1751,7 @@ void divModInternal(BigDigit [] quotient, BigDigit[] remainder, const BigDigit [
     () @trusted { GC.free(un.ptr); GC.free(vn.ptr); } ();
 }
 
-pure @system unittest
+pure @safe unittest
 {
     immutable(uint) [] u = [0, 0xFFFF_FFFE, 0x8000_0000];
     immutable(uint) [] v = [0xFFFF_FFFF, 0x8000_0000];
@@ -1866,7 +1866,7 @@ size_t biguintToOctal(char[] buff, const(BigDigit)[] data)
  * Returns:
  *    the lowest index of buff which was used.
  */
-size_t biguintToDecimal(char [] buff, BigDigit [] data) pure nothrow
+size_t biguintToDecimal(char [] buff, BigDigit [] data) pure nothrow @safe
 {
     ptrdiff_t sofar = buff.length;
     // Might be better to divide by (10^38/2^32) since that gives 38 digits for
@@ -2048,7 +2048,7 @@ private:
 
 // Classic 'schoolbook' multiplication.
 void mulSimple(BigDigit[] result, const(BigDigit) [] left,
-        const(BigDigit)[] right) pure nothrow
+        const(BigDigit)[] right) pure nothrow @safe
 in
 {
     assert(result.length == left.length + right.length,
@@ -2062,7 +2062,7 @@ do
 }
 
 // Classic 'schoolbook' squaring
-void squareSimple(BigDigit[] result, const(BigDigit) [] x) pure nothrow
+void squareSimple(BigDigit[] result, const(BigDigit) [] x) pure nothrow @safe
 in
 {
     assert(result.length == 2*x.length, "result must be twice as long as x");
@@ -2078,7 +2078,7 @@ do
 // as the larger length.
 // Returns carry (0 or 1).
 uint addSimple(BigDigit[] result, const BigDigit [] left, const BigDigit [] right)
-pure nothrow
+pure nothrow @safe
 in
 {
     assert(result.length == left.length,
@@ -2128,7 +2128,7 @@ do
  * Returns carry = 1 if result was less than right.
 */
 BigDigit subAssignSimple(BigDigit [] result, const(BigDigit) [] right)
-pure nothrow
+pure nothrow @safe
 {
     assert(result.length >= right.length,
        "result must be longer or of equal length to right");
@@ -2141,7 +2141,7 @@ pure nothrow
 /* result = result + right
 */
 BigDigit addAssignSimple(BigDigit [] result, const(BigDigit) [] right)
-pure nothrow
+pure nothrow @safe
 {
     assert(result.length >= right.length,
        "result must be longer or of equal length to right");
@@ -2154,7 +2154,7 @@ pure nothrow
 /* performs result += wantSub? - right : right;
 */
 BigDigit addOrSubAssignSimple(BigDigit [] result, const(BigDigit) [] right,
-        bool wantSub) pure nothrow
+        bool wantSub) pure nothrow @safe
 {
     if (wantSub)
         return subAssignSimple(result, right);
@@ -2164,7 +2164,7 @@ BigDigit addOrSubAssignSimple(BigDigit [] result, const(BigDigit) [] right,
 
 
 // return true if x<y, considering leading zeros
-bool less(const(BigDigit)[] x, const(BigDigit)[] y) pure nothrow
+bool less(const(BigDigit)[] x, const(BigDigit)[] y) pure nothrow @safe
 {
     assert(x.length >= y.length,
        "x must be longer or of equal length to y");
@@ -2180,7 +2180,7 @@ bool less(const(BigDigit)[] x, const(BigDigit)[] y) pure nothrow
 
 // Set result = abs(x-y), return true if result is negative(x<y), false if x <= y.
 bool inplaceSub(BigDigit[] result, const(BigDigit)[] x, const(BigDigit)[] y)
-    pure nothrow
+    pure nothrow @safe
 {
     assert(result.length == ((x.length >= y.length) ? x.length : y.length),
         "result must capable to store the maximum of x and y");
@@ -2238,7 +2238,7 @@ size_t karatsubaRequiredBuffSize(size_t xlen) pure nothrow @safe
 * scratchbuff      An array long enough to store all the temporaries. Will be destroyed.
 */
 void mulKaratsuba(BigDigit [] result, const(BigDigit) [] x,
-        const(BigDigit)[] y, BigDigit [] scratchbuff) pure nothrow
+        const(BigDigit)[] y, BigDigit [] scratchbuff) pure nothrow @safe
 {
     assert(x.length >= y.length, "x must be greater or equal to y");
     assert(result.length < uint.max, "Operands too large");
@@ -2344,7 +2344,7 @@ void mulKaratsuba(BigDigit [] result, const(BigDigit) [] x,
 }
 
 void squareKaratsuba(BigDigit [] result, const BigDigit [] x,
-        BigDigit [] scratchbuff) pure nothrow
+        BigDigit [] scratchbuff) pure nothrow @safe
 {
     // See mulKaratsuba for implementation comments.
     // Squaring is simpler, since it never gets asymmetric.
@@ -2402,7 +2402,7 @@ void squareKaratsuba(BigDigit [] result, const BigDigit [] x,
  * u[0 .. v.length] holds the remainder.
  */
 void schoolbookDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
-    pure nothrow
+    pure nothrow @safe
 {
     assert(quotient.length == u.length - v.length,
         "quotient has wrong length");
@@ -2578,7 +2578,7 @@ Returns:
 */
 void recursiveDivMod(BigDigit[] quotient, BigDigit[] u, const(BigDigit)[] v,
                      BigDigit[] scratch, bool mayOverflow = false)
-                     pure nothrow
+                     pure nothrow @safe
 in
 {
     // v must be normalized
@@ -2672,7 +2672,7 @@ do
 // Needs (quot.length * k) scratch space to store the result of the multiply.
 void adjustRemainder(BigDigit[] quot, BigDigit[] rem, const(BigDigit)[] v,
         ptrdiff_t k,
-        BigDigit[] scratch, bool mayOverflow = false) pure nothrow
+        BigDigit[] scratch, bool mayOverflow = false) pure nothrow @safe
 {
     assert(rem.length == v.length, "rem must be as long as v");
     mulInternal(scratch, quot, v[0 .. k]);
@@ -2690,7 +2690,7 @@ void adjustRemainder(BigDigit[] quot, BigDigit[] rem, const(BigDigit)[] v,
 
 // Cope with unbalanced division by performing block schoolbook division.
 void blockDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
-pure nothrow
+pure nothrow @safe
 {
     import core.memory : GC;
     assert(quotient.length == u.length - v.length,

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -659,6 +659,7 @@ public:
         {   // perform a subtraction
             if (x.data.length > 2)
             {
+                // subInt returns GC allocated array, can be safely cast to immutable
                 r.data = (() @trusted => cast(immutable) subInt(x.data, y))();
             }
             else
@@ -694,6 +695,7 @@ public:
         }
         else
         {
+            // addInt returns GC allocated array, can be safely cast to immutable
             r.data = (() @trusted => cast(immutable) addInt(x.data, y))();
         }
         return r;
@@ -708,6 +710,7 @@ public:
         if (wantSub)
         {   // perform a subtraction
             bool negative;
+            // sub returns GC allocated array, can be safely cast to immutable
             r.data = (() @trusted => cast(immutable) sub(x.data, y.data, &negative))();
             *sign ^= negative;
             if (r.isZero())
@@ -717,6 +720,7 @@ public:
         }
         else
         {
+            // add returns GC allocated array, can be safely cast to immutable
             r.data = (() @trusted => cast(immutable) add(x.data, y.data))();
         }
         return r;

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -111,7 +111,7 @@ enum : int { KARATSUBASQUARELIMIT=26 } // Minimum value for which square Karatsu
  * Set op == '+' for addition, '-' for subtraction.
  */
 uint multibyteAddSub(char op)(uint[] dest, const uint [] src1, const uint []
-        src2, uint carry) pure
+        src2, uint carry) pure @safe
 {
     // Timing:
     // Pentium M: 2.25/int
@@ -121,7 +121,7 @@ uint multibyteAddSub(char op)(uint[] dest, const uint [] src1, const uint []
     // a resister (AL), and restoring it after the branch.
 
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push EDI;
         push EBX;
@@ -142,13 +142,13 @@ uint multibyteAddSub(char op)(uint[] dest, const uint [] src1, const uint []
 L_unrolled:
         shr AL, 1; // get carry from EAX
     }
-    mixin(" asm pure nothrow {"
+    mixin(" asm pure nothrow @trusted {"
         ~ indexedLoopUnroll( 8,
         "mov EAX, [@*4-8*4+EDX+ECX*4];"
         ~ ( op == '+' ? "adc" : "sbb" ) ~ " EAX, [@*4-8*4+ESI+ECX*4];"
         ~ "mov [@*4-8*4+EDI+ECX*4], EAX;")
         ~ "}");
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         setc AL; // save carry
         add ECX, 8;
         ja L_unrolled;
@@ -159,12 +159,12 @@ L2:     // Do the residual 1 .. 7 ints.
 L_residual:
         shr AL, 1; // get carry from EAX
     }
-    mixin(" asm pure nothrow {"
+    mixin(" asm pure nothrow @trusted {"
         ~ indexedLoopUnroll( 1,
         "mov EAX, [@*4+EDX+ECX*4];"
         ~ ( op == '+' ? "adc" : "sbb" ) ~ " EAX, [@*4+ESI+ECX*4];"
         ~ "mov [@*4+EDI+ECX*4], EAX;") ~ "}");
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         setc AL; // save carry
         add ECX, 1;
         jnz L_residual;
@@ -177,7 +177,7 @@ done:
     }
 }
 
-@system unittest
+@safe unittest
 {
     uint [] a = new uint[40];
     uint [] b = new uint[40];
@@ -224,10 +224,10 @@ done:
  *  op must be '+' or '-'
  *  Returns final carry or borrow (0 or 1)
  */
-uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
+uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure @safe
 {
     enum { LASTPARAM = 1*4 } // 0* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         mov ECX, [ESP + LASTPARAM + 0*4]; // dest.length;
         mov EDX, [ESP + LASTPARAM + 1*4]; // dest.ptr
@@ -235,10 +235,10 @@ uint multibyteIncrementAssign(char op)(uint[] dest, uint carry) pure
 L1: ;
     }
     static if (op=='+')
-        asm pure nothrow { add [EDX], EAX; }
+        asm pure nothrow @trusted { add [EDX], EAX; }
     else
-        asm pure nothrow { sub [EDX], EAX; }
-    asm pure nothrow {
+        asm pure nothrow @trusted { sub [EDX], EAX; }
+    asm pure nothrow @trusted {
         mov EAX, 1;
         jnc L2;
         add EDX, 4;
@@ -254,13 +254,13 @@ L2:     dec EAX;
  *  numbits must be in the range 1 .. 31
  *  Returns the overflow
  */
-uint multibyteShlNoMMX(uint [] dest, const uint [] src, uint numbits) pure
+uint multibyteShlNoMMX(uint [] dest, const uint [] src, uint numbits) pure @safe
 {
     // Timing: Optimal for P6 family.
     // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // 5.0 cycles/int on Athlon, which has 7 cycles for SHLD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -305,12 +305,12 @@ L_last:
  *  numbits must be in the range 1 .. 31
  * This version uses MMX.
  */
-uint multibyteShl(uint [] dest, const uint [] src, uint numbits) pure
+uint multibyteShl(uint [] dest, const uint [] src, uint numbits) pure @safe
 {
     // Timing:
     // K7 1.2/int. PM 1.7/int P4 5.3/int
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -388,10 +388,10 @@ L_length1:
     }
 }
 
-void multibyteShr(uint [] dest, const uint [] src, uint numbits) pure
+void multibyteShr(uint [] dest, const uint [] src, uint numbits) pure @safe
 {
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -475,13 +475,13 @@ L_length1:
 /** dest[#] = src[#] >> numbits
  *  numbits must be in the range 1 .. 31
  */
-void multibyteShrNoMMX(uint [] dest, const uint [] src, uint numbits) pure
+void multibyteShrNoMMX(uint [] dest, const uint [] src, uint numbits) pure @safe
 {
     // Timing: Optimal for P6 family.
     // 2.0 cycles/int on PPro .. PM (limited by execution port p0)
     // Terrible performance on AMD64, which has 7 cycles for SHRD!!
     enum { LASTPARAM = 4*4 } // 3* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -564,7 +564,7 @@ L_last:
  * Returns carry.
  */
 uint multibyteMul(uint[] dest, const uint[] src, uint multiplier, uint carry)
-    pure
+    pure @safe
 {
     // Timing: definitely not optimal.
     // Pentium M: 5.0 cycles/operation, has 3 resource stalls/iteration
@@ -579,9 +579,9 @@ uint multibyteMul(uint[] dest, const uint[] src, uint multiplier, uint carry)
     }
     else
     {
-        __gshared int zero = 0;
+        static immutable int zero = 0;
     }
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -636,7 +636,7 @@ L_odd:
 // Multiples by M_ADDRESS which should be "ESP+LASTPARAM" or "ESP". OP must be "add" or "sub"
 // This is the most time-critical code in the BigInt library.
 // It is used by both MulAdd, multiplyAccumulate, and triangleAccumulate
-string asmMulAdd_innerloop(string OP, string M_ADDRESS) pure {
+string asmMulAdd_innerloop(string OP, string M_ADDRESS) pure @safe {
     // The bottlenecks in this code are extremely complicated. The MUL, ADD, and ADC
     // need 4 cycles on each of the ALUs units p0 and p1. So we use memory load
     // (unit p2) for initializing registers to zero.
@@ -707,7 +707,7 @@ L_done: " ~ OP ~ " [-8+EDI+4*EBX], ECX;
                 // final carry is now in EBP
 }
 
-string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure
+string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure @safe
 {
     return "
         mul int ptr [" ~M_ADDRESS ~"];
@@ -730,7 +730,7 @@ string asmMulAdd_enter_odd(string OP, string M_ADDRESS) pure
  * Returns carry out of MSB (0 .. FFFF_FFFF).
  */
 uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
-        multiplier, uint carry) pure {
+        multiplier, uint carry) pure @safe {
     // Timing: This is the most time-critical bignum function.
     // Pentium M: 5.4 cycles/operation, still has 2 resource stalls + 1load block/iteration
 
@@ -754,13 +754,13 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
     {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
-        __gshared int zero = 0;
+        static immutable int zero = 0;
         // use p3/p4 units
-        __gshared int storagenop; // write-only
+        shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 5*4 } // 4* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
 
         push ESI;
@@ -782,8 +782,8 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
         jnz L_enter_odd;
     }
     // Main loop, with entry point for even length
-    mixin("asm pure nothrow {" ~ asmMulAdd_innerloop(OP, "ESP+LASTPARAM") ~ "}");
-    asm pure nothrow {
+    mixin("asm pure nothrow @trusted {" ~ asmMulAdd_innerloop(OP, "ESP+LASTPARAM") ~ "}");
+    asm pure nothrow @trusted {
         mov EAX, EBP; // get final carry
         pop EBP;
         pop EBX;
@@ -792,7 +792,7 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
         ret 5*4;
     }
 L_enter_odd:
-    mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd(OP, "ESP+LASTPARAM") ~ "}");
+    mixin("asm pure nothrow @trusted {" ~ asmMulAdd_enter_odd(OP, "ESP+LASTPARAM") ~ "}");
 }
 
 @system unittest
@@ -820,7 +820,7 @@ L_enter_odd:
     ----
  */
 void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
-        const uint [] right) pure {
+        const uint [] right) pure @safe {
     // Register usage
     // EDX:EAX = used in multiply
     // EBX = index
@@ -838,13 +838,13 @@ void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
     {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
-        __gshared int zero = 0;
+        static immutable int zero = 0;
         // use p3/p4 units
-        __gshared int storagenop; // write-only
+        shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
 
         push ESI;
@@ -875,8 +875,8 @@ outer_loop:
         jnz L_enter_odd;
     }
     // -- Inner loop, with even entry point
-    mixin("asm pure nothrow { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
-    asm pure nothrow {
+    mixin("asm pure nothrow @trusted { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
+    asm pure nothrow @trusted {
         mov [-4+EDI+4*EBX], EBP;
         add EDI, 4;
         cmp EDI, [ESP + LASTPARAM + 4*0]; // is EDI = &dest[$]?
@@ -896,7 +896,7 @@ outer_done:
         ret 6*4;
     }
 L_enter_odd:
-    mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
+    mixin("asm pure nothrow @trusted {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
 }
 
 /**  dest[#] /= divisor.
@@ -908,7 +908,7 @@ L_enter_odd:
  * Based on public domain code by Eric Bainville.
  * (http://www.bealto.com/) Used with permission.
  */
-uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow) pure
+uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow) pure @safe
 {
     // Timing: limited by a horrible dependency chain.
     // Pentium M: 18 cycles/op, 8 resource stalls/op.
@@ -922,7 +922,7 @@ uint multibyteDivAssign(uint [] dest, uint divisor, uint overflow) pure
     // [ESP] = kinv (2^64 /divisor)
     enum { LASTPARAM = 5*4 } // 4* pushes + return address.
     enum { LOCALS = 2*4} // MASK, KINV
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
 
         push ESI;
@@ -1015,7 +1015,7 @@ Lc:
     }
 }
 
-@system unittest
+@safe unittest
 {
     uint [] aa = new uint[101];
     for (int i=0; i<aa.length; ++i) aa[i] = 0x8765_4321 * (i+3);
@@ -1026,7 +1026,7 @@ Lc:
 }
 
 // Set dest[2*i .. 2*i+1]+=src[i]*src[i]
-void multibyteAddDiagonalSquares(uint [] dest, const uint [] src) pure
+void multibyteAddDiagonalSquares(uint [] dest, const uint [] src) pure @safe
 {
     /* Unlike mulAdd, the carry is only 1 bit,
            since FFFF*FFFF+FFFF_FFFF = 1_0000_0000.
@@ -1037,7 +1037,7 @@ void multibyteAddDiagonalSquares(uint [] dest, const uint [] src) pure
            improve it by moving the mov EAX after the adc [EDI], EAX. Probably not worthwhile.
     */
     enum { LASTPARAM = 4*5 } // 4* pushes + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
         push ESI;
         push EDI;
@@ -1068,7 +1068,7 @@ L1:
     }
 }
 
-@system unittest
+@safe unittest
 {
     uint [] aa = new uint[13];
         uint [] bb = new uint[6];
@@ -1080,7 +1080,7 @@ L1:
         for (int i=0; i<bb.length; ++i) { assert(aa[2*i]==0x8000_0000+i*i); assert(aa[2*i+1]==0x8000_0000); }
 }
 
-void multibyteTriangleAccumulateD(uint[] dest, uint[] x) pure
+void multibyteTriangleAccumulateD(uint[] dest, uint[] x) pure @safe
 {
     for (int i = 0; i < x.length-3; ++i)
     {
@@ -1103,7 +1103,7 @@ length2:
 //dest += src[0]*src[1...$] + src[1]*src[2..$] + ... + src[$-3]*src[$-2..$]+ src[$-2]*src[$-1]
 // assert(dest.length = src.length*2);
 // assert(src.length >= 3);
-void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure
+void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure @safe
 {
     // Register usage
     // EDX:EAX = used in multiply
@@ -1122,13 +1122,13 @@ void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure
     {
         // use p2 (load unit) instead of the overworked p0 or p1 (ALU units)
         // when initializing registers to zero.
-        __gshared int zero = 0;
+        static immutable int zero = 0;
         // use p3/p4 units
-        __gshared int storagenop; // write-only
+        shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.
-    asm pure nothrow {
+    asm pure nothrow @trusted {
         naked;
 
         push ESI;
@@ -1172,8 +1172,8 @@ outer_loop:
         jnz L_enter_odd;
     }
     // -- Inner loop, with even entry point
-    mixin("asm pure nothrow { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
-    asm pure nothrow {
+    mixin("asm pure nothrow @trusted { " ~ asmMulAdd_innerloop("add", "ESP") ~ "}");
+    asm pure nothrow @trusted {
         mov [-4+EDI+4*EBX], EBP;
         add EDI, 4;
         cmp EDI, [ESP + LASTPARAM + 4*2]; // is EDI = &dest[$-3]?
@@ -1209,10 +1209,10 @@ length_is_3:
         ret 4*4;
     }
 L_enter_odd:
-    mixin("asm pure nothrow {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
+    mixin("asm pure nothrow @trusted {" ~ asmMulAdd_enter_odd("add", "ESP") ~ "}");
 }
 
-@system unittest
+@safe unittest
 {
    uint [] aa = new uint[200];
    uint [] a  = aa[0 .. 100];
@@ -1256,7 +1256,7 @@ L_enter_odd:
 }
 
 
-void multibyteSquare(BigDigit[] result, const BigDigit [] x) pure
+void multibyteSquare(BigDigit[] result, const BigDigit [] x) pure @safe
 {
     if (x.length < 4)
     {

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -522,7 +522,7 @@ L_last:
     }
 }
 
-@system unittest
+@safe unittest
 {
 
     uint [] aa = [0x1222_2223, 0x4555_5556, 0x8999_999A, 0xBCCC_CCCD, 0xEEEE_EEEE];

--- a/std/internal/math/biguintx86.d
+++ b/std/internal/math/biguintx86.d
@@ -756,7 +756,7 @@ uint multibyteMulAdd(char op)(uint [] dest, const uint [] src, uint
         // when initializing registers to zero.
         static immutable int zero = 0;
         // use p3/p4 units
-        shared int storagenop; // write-only
+        //shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 5*4 } // 4* pushes + return address.
@@ -840,7 +840,7 @@ void multibyteMultiplyAccumulate(uint [] dest, const uint[] left,
         // when initializing registers to zero.
         static immutable int zero = 0;
         // use p3/p4 units
-        shared int storagenop; // write-only
+        //shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.
@@ -1100,6 +1100,14 @@ length2:
         dest[$-2] = cast(uint) c;
 }
 
+version (D_PIC) {} else
+{
+    // this cannot be declared inside the relevant functions because that is
+    // not allowed in @safe functions. It cannot be regular shared either since
+    // that gives an access violation on Win32 for some reason.
+    private __gshared int storagenop;
+}
+
 //dest += src[0]*src[1...$] + src[1]*src[2..$] + ... + src[$-3]*src[$-2..$]+ src[$-2]*src[$-1]
 // assert(dest.length = src.length*2);
 // assert(src.length >= 3);
@@ -1124,7 +1132,7 @@ void multibyteTriangleAccumulateAsm(uint[] dest, const uint[] src) pure @safe
         // when initializing registers to zero.
         static immutable int zero = 0;
         // use p3/p4 units
-        shared int storagenop; // write-only
+        //shared int storagenop; // write-only
     }
 
     enum { LASTPARAM = 6*4 } // 4* pushes + local + return address.


### PR DESCRIPTION
A start of making std.bigint `@safe`.
It's WIP because it will certainly fail on targets with `version (D_InlineAsm_X86)` active since I haven't touched that.
If anyone knows how to test that on a 64-bit machine, please tell.