### PR TITLE
Bring back "std.range.dropBack" code examples

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3313,16 +3313,6 @@ if (isBidirectionalRange!R)
 {
     import std.algorithm.comparison : equal;
 
-    assert([0, 2, 1, 5, 0, 3].drop(3) == [5, 0, 3]);
-    assert("hello world".drop(6) == "world");
-    assert("hello world".drop(50).empty);
-    assert("hello world".take(6).drop(3).equal("lo "));
-}
-
-@safe unittest
-{
-    import std.algorithm.comparison : equal;
-
     assert([0, 2, 1, 5, 0, 3].dropBack(3) == [0, 2, 1]);
     assert("hello world".dropBack(6) == "hello");
     assert("hello world".dropBack(50).empty);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3308,6 +3308,16 @@ if (isBidirectionalRange!R)
     return range;
 }
 
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+
+    assert([0, 2, 1, 5, 0, 3].drop(3) == [5, 0, 3]);
+    assert("hello world".drop(6) == "world");
+    assert("hello world".drop(50).empty);
+    assert("hello world".take(6).drop(3).equal("lo "));
+}
+
 ///
 @safe unittest
 {

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3300,14 +3300,8 @@ if (isInputRange!R)
     range.popFrontN(n);
     return range;
 }
-/// ditto
-R dropBack(R)(R range, size_t n)
-if (isBidirectionalRange!R)
-{
-    range.popBackN(n);
-    return range;
-}
 
+///
 @safe unittest
 {
     import std.algorithm.comparison : equal;
@@ -3316,6 +3310,14 @@ if (isBidirectionalRange!R)
     assert("hello world".drop(6) == "world");
     assert("hello world".drop(50).empty);
     assert("hello world".take(6).drop(3).equal("lo "));
+}
+
+/// ditto
+R dropBack(R)(R range, size_t n)
+if (isBidirectionalRange!R)
+{
+    range.popBackN(n);
+    return range;
 }
 
 ///


### PR DESCRIPTION
For some reason `std.range.dropBack` **Example** field contains examples from `std.range.drop` in the [docs](https://dlang.org/library/std/range/drop_back.html). I think removing them from here should bring back the actual ones.