### PR TITLE
Fix Issue 15940 - ImplicitConversionTargets and class alias in struct

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -4999,7 +4999,7 @@ template ImplicitConversionTargets(T)
             AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T : typeof(null)))
         alias ImplicitConversionTargets = AliasSeq!(typeof(null));
-    else static if (is(T : Object))
+    else static if (is(T == class))
         alias ImplicitConversionTargets = TransitiveBaseTypeTuple!(T);
     else static if (isDynamicArray!T && !is(typeof(T.init[0]) == const))
     {

--- a/std/variant.d
+++ b/std/variant.d
@@ -3064,6 +3064,19 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 
 @system unittest
 {
+    // Bugzilla 15940
+    class C { }
+    struct S
+    {
+        C a;
+        alias a this;
+    }
+    S s = S(new C());
+    auto v = Variant(s); // compile error
+}
+
+@system unittest
+{
     // Test if we don't have scoping issues.
     Variant createVariant(int[] input)
     {


### PR DESCRIPTION
Based on PR #4342. I don't really completely understand the implications of this change, but all tests pass and as the original PR has been more or less approved by JackStouffer and I think, that PR was only closed, because the author of the PR left, I resubmit it. 