### PR TITLE
remove unnecessary extra semicolon

### DIFF
--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -733,7 +733,7 @@ version (USE_SSSE3)
      */
     public void transformSSSE3(uint[5]* state, const(ubyte[64])* buffer, ExtraArgs) pure nothrow @nogc
     {
-        mixin(wrap(["naked;"] ~ prologue()));
+        mixin(wrap(["naked"] ~ prologue()));
         // Precalc first 4*16=64 bytes
         mixin(wrap(xsetup(0)));
         mixin(wrap(weave(precalc(0)~precalc(1)~precalc(2)~precalc(3),


### PR DESCRIPTION
wrap already adds a semicolon, so this makes an extra empty statement