### PR TITLE
Fix Issue 18446 - Wrong curl onProgress examples

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2187,10 +2187,11 @@ private mixin template Protocol()
       * ----
       * import std.net.curl, std.stdio;
       * auto client = HTTP("dlang.org");
-      * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t ult)
+      * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t uln)
       * {
       *     writeln("Progress: downloaded ", dln, " of ", dl);
       *     writeln("Progress: uploaded ", uln, " of ", ul);
+      *     return 0;
       * };
       * client.perform();
       * ----
@@ -2826,10 +2827,11 @@ struct HTTP
          * ----
          * import std.net.curl, std.stdio;
          * auto client = HTTP("dlang.org");
-         * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t ult)
+         * client.onProgress = delegate int(size_t dl, size_t dln, size_t ul, size_t uln)
          * {
          *     writeln("Progress: downloaded ", dln, " of ", dl);
          *     writeln("Progress: uploaded ", uln, " of ", ul);
+         *     return 0;
          * };
          * client.perform();
          * ----
@@ -4717,16 +4719,17 @@ struct Curl
       *
       * Example:
       * ----
-      * import std.net.curl;
+      * import std.net.curl, std.stdio;
       * Curl curl;
       * curl.initialize();
       * curl.set(CurlOption.url, "http://dlang.org");
-      * curl.onProgress = delegate int(size_t dltotal, size_t dlnow, size_t ultotal, size_t uln)
+      * curl.onProgress = delegate int(size_t dltotal, size_t dlnow, size_t ultotal, size_t ulnow)
       * {
       *     writeln("Progress: downloaded bytes ", dlnow, " of ", dltotal);
       *     writeln("Progress: uploaded bytes ", ulnow, " of ", ultotal);
-      *     curl.perform();
+      *     return 0;
       * };
+      * curl.perform();
       * ----
       */
     @property void onProgress(int delegate(size_t dlTotal,


### PR DESCRIPTION
The other examples in std.net.curl should IMHO also be checked...

Is it possible to move them to unittests instead? Or does the internet access needed lead to a problem? And if yes, what is best practice here?