### PR TITLE
Remove useless warnings

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2703,7 +2703,7 @@ Params:
 
     /// Ditto
     bool opEquals(U)(auto ref const(U) rhs) const
-    if (is(typeof(this.get == rhs)))
+    if (!is(U : typeof(this)) && is(typeof(this.get == rhs)))
     {
         return _isNull ? false : rhs == _value.payload;
     }


### PR DESCRIPTION
to get rid of annoying deprecation warnings because in case the rhs is an other Nullable instance the constraint `is(typeof(this.get == rhs))` triggers the deprecation warning because the rhs implicitly calls deprecated `get_` member. This guard constraint prevents the rhs from being an other Nullable instance. No resolution logic change. Just getting rid of useless warning.