### PR TITLE
Fix unittest, which assumed real exponents having at least 15 bit.

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -620,7 +620,7 @@ public:
         AliasSeq!(
             CustomFloat!(5, 10),
             CustomFloat!(5, 11, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
-            CustomFloat!(1, 15, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
+            CustomFloat!(1, 7, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
             CustomFloat!(4, 3, CustomFloatFlags.ieee | CustomFloatFlags.probability ^ CustomFloatFlags.signed)
         );
 


### PR DESCRIPTION
See https://github.com/dlang/phobos/pull/7219#discussion_r360726810 for the motivation.

One of the unittests for CustomFloat assumed, that the exponent of a real has at least 15 bit, which isn't true. It can only be assumed, that it has at least 11 bits (real==double). This unittest (although broken) worked until PR #7219 because the size of the exponent was never checked until then and the asserts in the unittests had to work with smaller exponents too (see AliasSeq), so the broken part was never checked.

I first tried to fix this, keeping the 15 bit exponent, whenever real supports it, but that proved to be more difficult than I first thought, because the sum of exponent bits and mantiassa bits has to be 8, 16, 32 or 64 and guaranteeing this for all possible exponent sizes would need some extra calculations which IMHO isn't worth it, especially as CustomFloat(1,7) essentially checks the same as CustomFloat(1,15) did.