### PR TITLE
Fix unittest, which assumes real > double.

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1498,8 +1498,8 @@ T findRoot(T, R)(scope R delegate(T) f, in T a, in T b,
         //++numCalls;
         if (x>float.max)
             x = float.max;
-        if (x<-double.max)
-            x = -double.max;
+        if (x<-float.max)
+            x = -float.max;
         // This has a single real root at -59.286543284815
         return 0.386*x*x*x + 23*x*x + 15.7*x + 525.2;
     }


### PR DESCRIPTION
See https://github.com/dlang/phobos/pull/7219#discussion_r360729014 for the motivation.

When `real==double`, the function calculates for `x==-double.max` the value `-inf + inf + ...` which produces a `nan` and therefore the overall result is a `nan` which breaks the test in `testFindRoot`.