### PR TITLE
Merge pull request #7328 from berni44/reg_numeric_customfloat

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -629,7 +629,7 @@ public:
         AliasSeq!(
             CustomFloat!(5, 10),
             CustomFloat!(5, 11, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
-            CustomFloat!(1, 15, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
+            CustomFloat!(1, 7, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
             CustomFloat!(4, 3, CustomFloatFlags.ieee | CustomFloatFlags.probability ^ CustomFloatFlags.signed)
         );
 


### PR DESCRIPTION
Fix unittest, which assumed real exponents having at least 15 bit.
merged-on-behalf-of: Nicholas Wilson <thewilsonator@users.noreply.github.com>

It's the first time I'm using cherry-pick, so I hope I got everything right. The original PR #7328 was merged on master, but should have been on stable. This PR is intended to fix this...