### PR TITLE
Add further example for std.normalize

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2203,6 +2203,7 @@ if (isForwardRange!(R))
     a = [ 1.0, 3.0 ];
     assert(normalize(a));
     assert(a == [ 0.25, 0.75 ]);
+    assert(normalize!(typeof(a))(a, 50)); // a = [12.5, 37.5]
     a = [ 0.0, 0.0 ];
     assert(!normalize(a));
     assert(a == [ 0.5, 0.5 ]);


### PR DESCRIPTION
No examples provided which specify use of "sum" parameter.  The current examples imply that template parameters are not required, but this is not true when "sum" value is specified, which may confuse users wondering why normalize(a,50) does not compile.

The added example makes it clearer.