### PR TITLE
Fix Issue 12461 - Typedef and opOpAssign

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6771,7 +6771,7 @@ mixin template Proxy(alias a)
 
     auto ref opOpAssign     (string op, this X, V      )(auto ref V v)
     {
-        return mixin("a "      ~op~"= v");
+        return mixin("a = a "~op~" v");
     }
     auto ref opIndexOpAssign(string op, this X, V, D...)(auto ref V v, auto ref D i)
     {
@@ -7478,6 +7478,16 @@ struct Typedef(T, T init = T.init, string cookie=null)
 
     // The two Typedefs are _not_ the same type.
     static assert(!is(MoneyEuros == MoneyDollars));
+}
+
+// issue 12461
+@safe unittest
+{
+    alias Int = Typedef!int;
+
+    Int a, b;
+    a += b;
+    assert(a == 0);
 }
 
 /**


### PR DESCRIPTION
In the bugreport another potetial fix is reported:

```
private enum getField(T) = is(T == typeof(this)) ? ("." ~ __traits(identifier, a)) : "";

auto ref opOpAssign(string op, this X, V)(auto ref V v)
{
    return mixin("a " ~ op ~ "= v" ~ getField!V);
}
```

I don't know for sure, what the impact of either is exactly and therefore I'm lost in deciding, which one is better...