### PR TITLE
Improved error message when calling sum without a default value

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -6398,6 +6398,9 @@ if (isInputRange!R && !isInfinite!R && is(typeof(r.front + r.front)))
         alias Seed = typeof(E.init  + 0.0); //biggest of double/real
     else
         alias Seed = typeof(r.front + r.front);
+    static assert(is(typeof(Unqual!Seed(0))),
+        "Could not initiate an initial value for " ~ (Unqual!Seed).stringof
+        ~ ". Please supply an initial value manually.");
     return sum(r, Unqual!Seed(0));
 }
 /// ditto


### PR DESCRIPTION
If sum() is called, it tries to find a default value by constructing it with 0 (e.g. float(0)). This works for numbers, but produces obscure errors if the value cannot be constructed this way (e.g. issue #19525). The error message now states that the problem lies in the default value and suggests to supply one instead.