### PR TITLE
Disable `make install` for the Darwin_64_32 target on the auto-tester

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -292,9 +292,14 @@ else
 all : lib
 endif
 
+ifneq (,$(findstring Darwin_64_32, $(PWD)))
+install:
+	echo "Darwin_64_32_disabled"
+else
 install :
 	$(MAKE) -f $(MAKEFILE) OS=$(OS) MODEL=$(MODEL) BUILD=release INSTALL_DIR=$(INSTALL_DIR) \
 		DMD=$(DMD) install2
+endif
 
 .PHONY : unittest
 ifeq (1,$(BUILD_WAS_SPECIFIED))


### PR DESCRIPTION
OSX 32 bits on the auto-tester isn't supposed to be busy.

It isn't causing any trouble being run here in phobos but in dmd `make install` sometimes hangs and it has to be disabled in phobos first before it can be disabled in dmd.
See: https://github.com/dlang/dmd/pull/10705.