### PR TITLE
Mark CTFE bitmanip function for generating longs to a string as @safe and pure

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -56,13 +56,22 @@ import std.range.primitives;
 public import std.system : Endian;
 import std.traits;
 
-private string myToString(ulong n)
+private string myToString(ulong n) pure @safe
 {
     import core.internal.string : UnsignedStringBuf, unsignedToTempString;
     UnsignedStringBuf buf;
     auto s = unsignedToTempString(n, buf);
-    return cast(string) s ~ (n > uint.max ? "UL" : "U");
+    // pure allows implicit cast to string
+    return s ~ (n > uint.max ? "UL" : "U");
 }
+
+@safe pure unittest
+{
+    assert(myToString(5) == "5U");
+    assert(myToString(uint.max) == "4294967295U");
+    assert(myToString(uint.max + 1UL) == "4294967296UL");
+}
+
 
 private template createAccessors(
     string store, T, string name, size_t len, size_t offset)


### PR DESCRIPTION
Helps with proposed DIP1028 (https://github.com/dlang/dmd/pull/10709, https://github.com/dlang/DIPs/blob/1b705f8d4faa095d6d9e3a1b81d6cfa6d688554b/DIPs/DIP1028.md)

Not sure if there will be more. It's difficult to test this, but this seems to be the most common problem.

cc @WebFreak001 