### PR TITLE
Replaced version (unittest) with version (StdUnittest) to avoid unnecessary overhead when compiling with -unittest

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -150,7 +150,7 @@ ifdef ENABLE_COVERAGE
 override DFLAGS  += -cov
 endif
 
-UDFLAGS=-unittest
+UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest
 
 # Set DOTOBJ and DOTEXE
 ifeq (,$(findstring win,$(OS)))

--- a/std/algorithm/internal.d
+++ b/std/algorithm/internal.d
@@ -14,7 +14,7 @@ package template algoFormat()
 }
 
 // Internal random array generators
-version (unittest)
+version (StdUnittest)
 {
     package enum size_t maxArraySize = 50;
     package enum size_t minArraySize = maxArraySize - 1;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -642,7 +642,7 @@ if (isRandomAccessRange!Range && hasLength!Range && hasSlicing!Range && hasAssig
         for (;;)
         {
             // Loop invariant
-            version (unittest)
+            version (StdUnittest)
             {
                 // this used to import std.algorithm.all, but we want to save
                 // imports when unittests are enabled if possible.
@@ -4082,7 +4082,7 @@ if (isRandomAccessRange!Range && hasLength!Range &&
     else static if (k == 5)
     {
         // Credit: Teppo Niinimäki
-        version (unittest) scope(success)
+        version (StdUnittest) scope(success)
         {
             assert(!lt(r[c], r[a]), "less than check failed");
             assert(!lt(r[c], r[b]), "less than check failed");

--- a/std/array.d
+++ b/std/array.d
@@ -222,7 +222,7 @@ if (isPointer!Range && isIterable!(PointerTarget!Range) && !isNarrowString!Range
     assert(a.length == 5);
 }
 
-version (unittest)
+version (StdUnittest)
     private extern(C) void _d_delarray_t(void[] *p, TypeInfo_Struct ti);
 
 @system unittest
@@ -553,7 +553,7 @@ if (isInputRange!Values && isInputRange!Keys)
     assert(c == expected);
 }
 
-// @@@11053@@@ - Cannot be version (unittest) - recursive instantiation error
+// @@@11053@@@ - Cannot be version (StdUnittest) - recursive instantiation error
 @safe unittest
 {
     import std.typecons;
@@ -4624,7 +4624,7 @@ nothrow pure @safe unittest
     staticArray!(long, 2.iota).checkStaticArray!long([0, 1]);
 }
 
-version (unittest) private void checkStaticArray(T, T1, T2)(T1 a, T2 b) nothrow @safe pure @nogc
+version (StdUnittest) private void checkStaticArray(T, T1, T2)(T1 a, T2 b) nothrow @safe pure @nogc
 {
     static assert(is(T1 == T[T1.length]));
     assert(a == b, "a must be equal to b");

--- a/std/base64.d
+++ b/std/base64.d
@@ -363,7 +363,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         }
 
         // @@@BUG@@@ Workaround for DbC problem. See comment on 'out'.
-        version (unittest)
+        version (StdUnittest)
             assert(
                 bufptr - buffer.ptr == encodeLength(srcLen),
                 "The length of result is different from Base64"
@@ -541,7 +541,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         }
 
         // @@@BUG@@@ Workaround for DbC problem.
-        version (unittest)
+        version (StdUnittest)
             assert(
                 pcount == encodeLength(srcLen),
                 "The number of put is different from the length of Base64"
@@ -1136,7 +1136,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         }
 
         // @@@BUG@@@ Workaround for DbC problem.
-        version (unittest)
+        version (StdUnittest)
             assert(
                 (bufptr - buffer.ptr) >= (decodeLength(srcLen) - 2),
                 "The length of result is smaller than expected length"
@@ -1321,7 +1321,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
         }
 
         // @@@BUG@@@ Workaround for DbC problem.
-        version (unittest)
+        version (StdUnittest)
             assert(
                 pcount >= (decodeLength(srcLen) - 2),
                 "The length of result is smaller than expected length"

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -747,7 +747,7 @@ do
 }
 
 // Make sure receive() works with free functions as well.
-version (unittest)
+version (StdUnittest)
 {
     private void receiveFunction(int x) {}
 }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -61,7 +61,7 @@ import std.functional : binaryFun;
 
 public import std.container.util;
 
-version (unittest) debug = RBDoChecks;
+version (StdUnittest) debug = RBDoChecks;
 
 //debug = RBDoChecks;
 
@@ -745,7 +745,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
     alias _less = binaryFun!less;
 
-    version (unittest)
+    version (StdUnittest)
     {
         static if (is(typeof(less) == string))
         {

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -45,7 +45,7 @@ import std.traits : isSomeString, Unqual;
 import std.typecons : Flag;
 import std.range.primitives : isOutputRange;
 
-version (unittest) import std.exception : assertThrown;
+version (StdUnittest) import std.exception : assertThrown;
 
 @safe unittest
 {
@@ -10438,7 +10438,7 @@ if (isSomeString!T)
 // NOTE: all the non-simple array literals are wrapped in functions, because
 // otherwise importing causes re-evaluation of the static initializers using
 // CTFE with unittests enabled
-version (unittest)
+version (StdUnittest)
 {
 private @safe:
     // All of these helper arrays are sorted in ascending order.

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -41,7 +41,7 @@ import std.range.primitives : isOutputRange;
 import std.traits : isIntegral, Unqual;
 import std.typecons : Flag;
 
-version (unittest) import std.exception : assertThrown;
+version (StdUnittest) import std.exception : assertThrown;
 
 
 /++

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -91,7 +91,7 @@ else version (Posix)
     import core.sys.posix.sys.types : time_t;
 }
 
-version (unittest)
+version (StdUnittest)
 {
     import core.exception : AssertError;
     import std.exception : assertThrown;
@@ -10454,7 +10454,7 @@ afterMon: stripAndCheckLen(value[3 .. value.length], "1200:00A".length);
     assertThrown!DateTimeException(parseRFC822DateTime(badStr));
 }
 
-version (unittest) private void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
+version (StdUnittest) private void testParse822(alias cr)(string str, SysTime expected, size_t line = __LINE__)
 {
     import std.format : format;
     auto value = cr(str);
@@ -10463,7 +10463,7 @@ version (unittest) private void testParse822(alias cr)(string str, SysTime expec
         throw new AssertError(format("wrong result. expected [%s], actual[%s]", expected, result), __FILE__, line);
 }
 
-version (unittest) private void testBadParse822(alias cr)(string str, size_t line = __LINE__)
+version (StdUnittest) private void testBadParse822(alias cr)(string str, size_t line = __LINE__)
 {
     try
         parseRFC822DateTime(cr(str));
@@ -11403,7 +11403,7 @@ if (isIntegral!T && isSigned!T) // The constraints on R were already covered by 
 // NOTE: all the non-simple array literals are wrapped in functions, because
 // otherwise importing causes re-evaluation of the static initializers using
 // CTFE with unittests enabled
-version (unittest)
+version (StdUnittest)
 {
 private @safe:
     // Variables to help in testing.

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -51,7 +51,7 @@ else version (Posix)
     import core.sys.posix.sys.types : time_t;
 }
 
-version (unittest) import std.exception : assertThrown;
+version (StdUnittest) import std.exception : assertThrown;
 
 
 /++

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -321,7 +321,7 @@ unittest
     import std.digest.sha : SHA1, SHA256;
 
     // Note, can't be UFCS because we don't want to import inside
-    // version (unittest).
+    // version (StdUnittest).
     import std.digest : toHexString, LetterCase;
     alias hex = toHexString!(LetterCase.lower);
 

--- a/std/digest/murmurhash.d
+++ b/std/digest/murmurhash.d
@@ -685,7 +685,7 @@ the 'put' method.
     assert(hashed == [181, 151, 88, 252]);
 }
 
-version (unittest)
+version (StdUnittest)
 {
     private auto hash(H, Element = H.Element)(string data)
     {

--- a/std/exception.d
+++ b/std/exception.d
@@ -1309,7 +1309,7 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
 }
 
 
-version (unittest)
+version (StdUnittest)
 {
     // 17084 : the bug doesn't happen if these declarations are
     // in the unittest block (static or not).
@@ -1851,7 +1851,7 @@ expression.
     static assert(!__traits(compiles, (new Object()).ifThrown(e=>1)));
 }
 
-version (unittest) package
+version (StdUnittest) package
 void assertCTFEable(alias dg)()
 {
     static assert({ cast(void) dg(); return true; }());

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -566,7 +566,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
     tg.joinAll();
 }
 
-version (unittest)
+version (StdUnittest)
 {
     static void testrw(void[] b)
     {

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -663,7 +663,7 @@ public:
     tg.joinAll();
 }
 
-version (unittest)
+version (StdUnittest)
 {
     private static void testrw(void[] b) @nogc nothrow
     {

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1640,7 +1640,7 @@ shared struct SharedBitmappedBlock(size_t theBlockSize, uint theAlignment = plat
     }
     else
     {
-        version (unittest)
+        version (StdUnittest)
         @system unittest
         {
             import std.algorithm.comparison : max;

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -482,7 +482,7 @@ Forwards each of the methods in `funs` (if defined) to `member`.
     return result;
 }
 
-version (unittest)
+version (StdUnittest)
 {
 
     package void testAllocator(alias make)()

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -2076,7 +2076,7 @@ if (isInputRange!R && !isInfinite!R)
     assert(arr2.map!`a.val`.equal(iota(32, 204, 2)));
 }
 
-version (unittest)
+version (StdUnittest)
 {
     private struct ForcedInputRange
     {

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -2709,7 +2709,7 @@ if (isIntegral!T && T.sizeof >= 4)
     testPow!ulong(3, 41);
 }
 
-version (unittest) private struct CountOverflows
+version (StdUnittest) private struct CountOverflows
 {
     uint calls;
     auto onOverflow(string op, Lhs)(Lhs lhs)
@@ -2734,19 +2734,18 @@ version (unittest) private struct CountOverflows
     }
 }
 
-version (unittest) private struct CountOpBinary
-{
-    uint calls;
-    auto hookOpBinary(string op, Lhs, Rhs)(Lhs lhs, Rhs rhs)
-    {
-        ++calls;
-        return mixin("lhs" ~ op ~ "rhs");
-    }
-}
-
 // opBinary
 @nogc nothrow pure @safe unittest
 {
+    static struct CountOpBinary
+    {
+        uint calls;
+        auto hookOpBinary(string op, Lhs, Rhs)(Lhs lhs, Rhs rhs)
+        {
+            ++calls;
+            return mixin("lhs" ~ op ~ "rhs");
+        }
+    }
     auto x = Checked!(const int, void)(42), y = Checked!(immutable int, void)(142);
     assert(x + y == 184);
     assert(x + 100 == 142);

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1846,7 +1846,7 @@ package class TestLogger : Logger
     }
 }
 
-version (unittest) private void testFuncNames(Logger logger) @safe
+version (StdUnittest) private void testFuncNames(Logger logger) @safe
 {
     string s = "I'm here";
     logger.log(s);

--- a/std/file.d
+++ b/std/file.d
@@ -131,7 +131,7 @@ else
     return fileName;
 }
 
-version (unittest) private struct TestAliasedString
+version (StdUnittest) private struct TestAliasedString
 {
     string get() @safe @nogc pure nothrow { return _s; }
     alias get this;
@@ -3396,7 +3396,7 @@ version (Windows) string getcwd() @trusted
         3. the buffer (lpBuffer) is not large enough: the required size of
     the buffer, in characters, including the null-terminating character.
     */
-    version (unittest)
+    version (StdUnittest)
         enum BUF_SIZE = 10;     // trigger reallocation code
     else
         enum BUF_SIZE = 4096;   // enough for most common case

--- a/std/format.d
+++ b/std/format.d
@@ -4241,7 +4241,7 @@ if (is(T == class) && !is(T == enum))
 
 // outside the unittest block, otherwise the FQN of the
 // class contains the line number of the unittest
-version (unittest)
+version (StdUnittest)
 {
     private class C {}
 }
@@ -4866,7 +4866,7 @@ private T getNth(string kind, alias Condition, T, A...)(uint index, A args)
 
 /* ======================== Unit Tests ====================================== */
 
-version (unittest)
+version (StdUnittest)
 private void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
@@ -4880,7 +4880,7 @@ private void formatTest(T)(T val, string expected, size_t ln = __LINE__, string 
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version (unittest)
+version (StdUnittest)
 private void formatTest(T)(string fmt, T val, string expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
@@ -4893,7 +4893,7 @@ private void formatTest(T)(string fmt, T val, string expected, size_t ln = __LIN
             text("expected = `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version (unittest)
+version (StdUnittest)
 private void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__)
 {
     import core.exception : AssertError;
@@ -4911,7 +4911,7 @@ private void formatTest(T)(T val, string[] expected, size_t ln = __LINE__, strin
             text("expected one of `", expected, "`, result = `", w.data, "`"), fn, ln);
 }
 
-version (unittest)
+version (StdUnittest)
 private void formatTest(T)(string fmt, T val, string[] expected, size_t ln = __LINE__, string fn = __FILE__) @safe
 {
     import core.exception : AssertError;
@@ -5359,7 +5359,7 @@ here:
     assert(a == "hello" && b == 124 && c == 34.5);
 }
 
-version (unittest)
+version (StdUnittest)
 private void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;
@@ -5401,7 +5401,7 @@ private void formatReflectTest(T)(ref T val, string fmt, string formatted, strin
             input, fn, ln);
 }
 
-version (unittest)
+version (StdUnittest)
 private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, string fn = __FILE__, size_t ln = __LINE__)
 {
     import core.exception : AssertError;

--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -252,7 +252,7 @@ private:
 
     To* _ptr;
     size_t _length;        // length of the string
-    version (unittest)
+    version (StdUnittest)
     // the 'small string optimization'
     {
         // smaller size to trigger reallocations. Padding is to account for

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -1355,7 +1355,7 @@ int highestPowerBelowUlongMax(uint x) pure nothrow @safe
      return 2;
 }
 
-version (unittest)
+version (StdUnittest)
 {
 
 private int slowHighestPowerBelowUintMax(uint x) pure nothrow @safe

--- a/std/math.d
+++ b/std/math.d
@@ -186,7 +186,7 @@ else version (X86)
     private alias haveSSE = core.cpuid.sse;
 }
 
-version (unittest) private
+version (StdUnittest) private
 {
     static if (real.sizeof > double.sizeof)
         enum uint useDigits = 16;

--- a/std/meta.d
+++ b/std/meta.d
@@ -921,7 +921,7 @@ template Filter(alias pred, TList...)
 
 
 // Used in template predicate unit tests below.
-private version (unittest)
+private version (StdUnittest)
 {
     template testAlways(T...)
     {

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -164,7 +164,7 @@ import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
 
-version (unittest)
+version (StdUnittest)
 {
     import std.socket : Socket, SocketShutdown;
 
@@ -222,7 +222,9 @@ version (unittest)
         return TestServer(addr, tid, sock);
     }
 
+    /** Test server */
     __gshared TestServer server;
+    /** Thread-local storage init */
     bool tlsInit;
 
     private ref TestServer testServer()

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -251,7 +251,7 @@ class OutBuffer
         import core.stdc.stdlib : alloca;
         import std.string : toStringz;
 
-        version (unittest)
+        version (StdUnittest)
             char[3] buffer = void;      // trigger reallocation
         else
             char[128] buffer = void;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4132,7 +4132,7 @@ private struct RoundRobinBuffer(C1, C2)
     }
 }
 
-version (unittest)
+version (StdUnittest)
 {
     // This was the only way I could get nested maps to work.
     private __gshared TaskPool poolInstance;

--- a/std/path.d
+++ b/std/path.d
@@ -101,7 +101,7 @@ static import std.meta;
 import std.range.primitives;
 import std.traits;
 
-version (unittest)
+version (StdUnittest)
 {
 private:
     struct TestAliasedString
@@ -4031,7 +4031,7 @@ string expandTilde(string inputPath) @safe nothrow
                 assert(last_char > 1);
 
                 // Reserve C memory for the getpwnam_r() function.
-                version (unittest)
+                version (StdUnittest)
                     uint extra_memory_size = 2;
                 else
                     uint extra_memory_size = 5 * 1024;
@@ -4152,7 +4152,7 @@ string expandTilde(string inputPath) @safe nothrow
     }
 }
 
-version (unittest)
+version (StdUnittest)
 {
 private:
     /* Define a mock RandomAccessRange to use for unittesting.

--- a/std/process.d
+++ b/std/process.d
@@ -2753,7 +2753,7 @@ version (Windows) private immutable string shellSwitch = "/C";
 // file. On Windows the file name gets a .cmd extension, while on
 // POSIX its executable permission bit is set.  The file is
 // automatically deleted when the object goes out of scope.
-version (unittest)
+version (StdUnittest)
 private struct TestScript
 {
     this(string code) @system
@@ -2797,7 +2797,7 @@ private struct TestScript
     string path;
 }
 
-version (unittest)
+version (StdUnittest)
 private string uniqueTempPath() @safe
 {
     import std.file : tempDir;
@@ -3096,7 +3096,7 @@ if (is(typeof(allocator(size_t.init)[0] = char.init)))
     return buf;
 }
 
-version (Windows) version (unittest)
+version (Windows) version (StdUnittest)
 {
 private:
     import core.stdc.stddef;

--- a/std/random.d
+++ b/std/random.d
@@ -161,7 +161,7 @@ import std.traits;
     assert([0, 1, 2, 4, 5].randomShuffle(rnd2).equal([2, 0, 4, 5, 1]));
 }
 
-version (unittest)
+version (StdUnittest)
 {
     static import std.meta;
     package alias Xorshift64_64 = XorshiftEngine!(ulong, 64, -12, 25, -27);

--- a/std/socket.d
+++ b/std/socket.d
@@ -120,7 +120,7 @@ else
     static assert(0, "No socket support for this platform yet.");
 }
 
-version (unittest)
+version (StdUnittest)
 {
     // Print a message on exception instead of failing the unittest.
     private void softUnittest(void delegate() @safe test, int line = __LINE__) @trusted

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5501,7 +5501,7 @@ version (linux)
     }
 }
 
-version (unittest) private string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
+version (StdUnittest) private string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
 {
     import std.conv : text;
     import std.file : deleteme;

--- a/std/string.d
+++ b/std/string.d
@@ -143,7 +143,7 @@ Source:    $(PHOBOSSRC std/string.d)
 */
 module std.string;
 
-version (unittest)
+version (StdUnittest)
 {
 private:
     struct TestAliasedString

--- a/std/traits.d
+++ b/std/traits.d
@@ -470,7 +470,7 @@ template QualifierOf(T)
     alias Qual7 = QualifierOf!(   immutable int);   static assert(is(Qual7!long ==    immutable long));
 }
 
-version (unittest)
+version (StdUnittest)
 {
     alias TypeQualifierList = AliasSeq!(MutableOf, ConstOf, SharedOf, SharedConstOf, ImmutableOf);
 
@@ -653,7 +653,7 @@ if (T.length == 1)
     static assert(fullyQualifiedName!fullyQualifiedName == "std.traits.fullyQualifiedName");
 }
 
-version (unittest)
+version (StdUnittest)
 {
     // Used for both fqnType and fqnSym unittests
     private struct QualifiedNameTests
@@ -2463,7 +2463,7 @@ if (is(T == function))
     assert(g() > 0);
 }
 
-version (unittest)
+version (StdUnittest)
 {
 private:
     // Some function types to test.
@@ -8064,7 +8064,7 @@ if (sth.length == 1)
     static assert(TL == AliasSeq!("i", "xi", "yi"));
 }
 
-version (unittest) private void freeFunc(string);
+version (StdUnittest) private void freeFunc(string);
 
 @safe unittest
 {
@@ -8601,7 +8601,7 @@ template getSymbolsByUDA(alias symbol, alias attribute)
 }
 
 // Issue 20054: getSymbolsByUDA no longer works on modules
-version (unittest)
+version (StdUnittest)
 {
     @("Issue20054")
     void issue20054() {}

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4957,7 +4957,7 @@ private static:
     alias Implementation = AutoImplement!(Issue17177, how, templateNot!isFinalFunction);
 }
 
-version (unittest)
+version (StdUnittest)
 {
     // Issue 10647
     // Add prefix "issue10647_" as a workaround for issue 1238

--- a/std/uni.d
+++ b/std/uni.d
@@ -7219,7 +7219,7 @@ if (isInputRange!Range && is(Unqual!(ElementType!Range) == dchar))
 }
 
 // For testing non-forward-range input ranges
-version (unittest)
+version (StdUnittest)
 private static struct InputRangeString
 {
     private string s;

--- a/std/utf.d
+++ b/std/utf.d
@@ -1858,7 +1858,7 @@ unittest
 }
 
 
-version (unittest) private void testDecode(R)(R range,
+version (StdUnittest) private void testDecode(R)(R range,
                                              size_t index,
                                              dchar expectedChar,
                                              size_t expectedIndex,
@@ -1888,7 +1888,7 @@ version (unittest) private void testDecode(R)(R range,
     }
 }
 
-version (unittest) private void testDecodeFront(R)(ref R range,
+version (StdUnittest) private void testDecodeFront(R)(ref R range,
                                                   dchar expectedChar,
                                                   size_t expectedNumCodeUnits,
                                                   size_t line = __LINE__)
@@ -1914,7 +1914,7 @@ version (unittest) private void testDecodeFront(R)(ref R range,
     }
 }
 
-version (unittest) private void testDecodeBack(R)(ref R range,
+version (StdUnittest) private void testDecodeBack(R)(ref R range,
                                                  dchar expectedChar,
                                                  size_t expectedNumCodeUnits,
                                                  size_t line = __LINE__)
@@ -1946,7 +1946,7 @@ version (unittest) private void testDecodeBack(R)(ref R range,
     }
 }
 
-version (unittest) private void testAllDecode(R)(R range,
+version (StdUnittest) private void testAllDecode(R)(R range,
                                                 dchar expectedChar,
                                                 size_t expectedIndex,
                                                 size_t line = __LINE__)
@@ -1960,7 +1960,7 @@ version (unittest) private void testAllDecode(R)(R range,
     testDecodeFront(range, expectedChar, expectedIndex, line);
 }
 
-version (unittest) private void testBadDecode(R)(R range, size_t index, size_t line = __LINE__)
+version (StdUnittest) private void testBadDecode(R)(R range, size_t index, size_t line = __LINE__)
 {
     import core.exception : AssertError;
     import std.exception : assertThrown, enforce;
@@ -1987,7 +1987,7 @@ version (unittest) private void testBadDecode(R)(R range, size_t index, size_t l
         assertThrown!UTFException(decodeFront(range, index), null, __FILE__, line);
 }
 
-version (unittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
+version (StdUnittest) private void testBadDecodeBack(R)(R range, size_t line = __LINE__)
 {
     // This condition is to allow unit testing all `decode` functions together
     static if (!isBidirectionalRange!R)
@@ -3391,7 +3391,7 @@ if (isSomeChar!C)
 
 
 // Ranges of code units for testing.
-version (unittest)
+version (StdUnittest)
 {
 private:
     struct InputCU(C)
@@ -4148,7 +4148,7 @@ pure @safe nothrow @nogc unittest
     foreach (c; s[].byDchar()) { }
 }
 
-version (unittest)
+version (StdUnittest)
 private int impureVariable;
 
 @system unittest

--- a/std/windows/registry.d
+++ b/std/windows/registry.d
@@ -81,7 +81,7 @@ class Win32Exception : WindowsException
     @property int error() { return super.code; }
 }
 
-version (unittest) import std.string : startsWith, endsWith;
+version (StdUnittest) import std.string : startsWith, endsWith;
 
 @safe unittest
 {

--- a/win32.mak
+++ b/win32.mak
@@ -47,7 +47,7 @@ DFLAGS=-conf= -O -release -w -de -preview=dip1000 -transition=complex -I$(DRUNTI
 
 ## Flags for compiling unittests
 
-UDFLAGS=-unittest -conf= -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
+UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest -conf= -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -50,7 +50,7 @@ DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -transition=complex
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import -unittest
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import -unittest -version=StdUnittest -version=CoreUnittest
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
Related to https://github.com/dlang/druntime/pull/2888