### PR TITLE
Add initial support for iOS, tvOS and watchOS

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -32,6 +32,15 @@ $(TR $(TD Conversion) $(TD
 +/
 module std.datetime.systime;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 /// Get the current time as a $(LREF SysTime)
 @safe unittest
 {
@@ -212,7 +221,7 @@ public:
             static import core.stdc.time;
             enum hnsecsToUnixEpoch = unixTimeToStdTime(0);
 
-            version (OSX)
+            version (Darwin)
             {
                 static if (clockType == ClockType.second)
                     return unixTimeToStdTime(core.stdc.time.time(null));

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -33,6 +33,15 @@ import std.datetime.systime : Clock, stdTimeToUnixTime, SysTime;
 import std.range.primitives : back, empty, front, isOutputRange, popFront;
 import std.traits : isIntegral, isSomeString, Unqual;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 version (Windows)
 {
     import core.stdc.time : time_t;
@@ -326,7 +335,7 @@ public:
             else version (NetBSD)        enum utcZone = "UTC";
             else version (DragonFlyBSD)  enum utcZone = "UTC";
             else version (linux)         enum utcZone = "UTC";
-            else version (OSX)           enum utcZone = "UTC";
+            else version (Darwin)        enum utcZone = "UTC";
             else version (Solaris)       enum utcZone = "UTC";
             else static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -630,7 +630,10 @@ alias errnoEnforce = enforce!ErrnoException;
 @system unittest
 {
     import core.stdc.stdio : fclose, fgets, fopen;
-    auto f = fopen(__FILE_FULL_PATH__, "r").errnoEnforce;
+    import std.file : thisExePath;
+    import std.string : toStringz;
+
+    auto f = fopen(thisExePath.toStringz, "r").errnoEnforce;
     scope(exit) fclose(f);
     char[100] buf;
     auto line = fgets(buf.ptr, buf.length, f);

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -4,6 +4,8 @@ Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/allocator_list.d)
 */
 module std.experimental.allocator.building_blocks.allocator_list;
 
+import core.memory : minimumPageSize;
+
 import std.experimental.allocator.building_blocks.null_allocator;
 import std.experimental.allocator.common;
 import std.experimental.allocator.gc_allocator;
@@ -823,7 +825,7 @@ version (Posix) @system unittest
     import std.algorithm.comparison : max;
     import std.typecons : Ternary;
 
-    enum pageSize = 4096;
+    enum pageSize = minimumPageSize;
 
     static void testrw(void[] b)
     {
@@ -883,7 +885,7 @@ version (Posix) @system unittest
     import std.algorithm.comparison : max;
     import std.typecons : Ternary;
 
-    enum pageSize = 4096;
+    enum pageSize = minimumPageSize;
 
     static void testrw(void[] b)
     {
@@ -950,7 +952,7 @@ version (Posix) @system unittest
     import std.algorithm.comparison : max;
     import std.typecons : Ternary;
 
-    enum pageSize = 4096;
+    enum pageSize = minimumPageSize;
 
     static void testrw(void[] b)
     {
@@ -966,15 +968,15 @@ version (Posix) @system unittest
     AllocatorList!((n) => AscendingPageAllocator(max(n, numPages * pageSize)), NullAllocator) a;
     auto b = a.alignedAllocate(1, pageSize * 2);
     assert(b.length == 1);
-    assert(a.expand(b, 4095));
-    assert(b.ptr.alignedAt(2 * 4096));
-    assert(b.length == 4096);
+    assert(a.expand(b, pageSize - 1));
+    assert(b.ptr.alignedAt(2 * pageSize));
+    assert(b.length == pageSize);
 
-    b = a.allocate(4096);
-    assert(b.length == 4096);
+    b = a.allocate(pageSize);
+    assert(b.length == pageSize);
     assert(a.allocators.length == 1);
 
-    assert(a.allocate(4096 * 5).length == 4096 * 5);
+    assert(a.allocate(pageSize * 5).length == pageSize * 5);
     assert(a.allocators.length == 2);
 
     assert(a.deallocateAll());

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -8,6 +8,15 @@ import std.experimental.allocator.building_blocks.null_allocator;
 import std.experimental.allocator.common;
 import std.typecons : Flag, Yes, No;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 /**
 A `Region` allocator allocates memory straight from one contiguous chunk.
 There is no deallocation, and once the region is full, allocation requests
@@ -964,7 +973,7 @@ version (Posix) @system nothrow @nogc unittest
     assert((() nothrow @safe @nogc => alloc.owns(a))() == Ternary.yes);
     assert((() nothrow @safe @nogc => alloc.owns(b))() == Ternary.yes);
     // reducing the brk does not work on OSX
-    version (OSX) {} else
+    version (Darwin) {} else
     {
         assert((() nothrow @nogc => alloc.deallocate(b))());
         // Check that expand and deallocate work well

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -3144,11 +3144,12 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 // Issue 15517
 @system unittest
 {
-    import std.file : exists, remove;
+    import std.file : exists, remove, tempDir;
+    import std.path : buildPath;
     import std.stdio : File;
     import std.string : indexOf;
 
-    string fn = "logfile.log";
+    string fn = tempDir.buildPath("logfile.log");
     if (exists(fn))
     {
         remove(fn);

--- a/std/file.d
+++ b/std/file.d
@@ -4940,7 +4940,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
                                    // called from a shared library on Android,
                                    // ie an apk
     else
-        string testdir = "deleteme.dmd.unittest.std.file" ~ to!string(thisProcessID); // needs to be relative
+        string testdir = tempDir.buildPath("deleteme.dmd.unittest.std.file" ~ to!string(thisProcessID));
     mkdirRecurse(buildPath(testdir, "somedir"));
     scope(exit) rmdirRecurse(testdir);
     write(buildPath(testdir, "somefile"), null);

--- a/std/file.d
+++ b/std/file.d
@@ -93,6 +93,15 @@ import std.range.primitives;
 import std.traits;
 import std.typecons;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 version (Windows)
 {
     import core.sys.windows.winbase, core.sys.windows.winnt, std.windows.syserror;
@@ -3448,7 +3457,7 @@ else version (Posix) string getcwd() @trusted
     assert(s.length);
 }
 
-version (OSX)
+version (Darwin)
     private extern (C) int _NSGetExecutablePath(char* buf, uint* bufsize);
 else version (FreeBSD)
     private extern (C) int sysctl (const int* name, uint namelen, void* oldp,
@@ -3468,7 +3477,7 @@ else version (NetBSD)
  */
 @trusted string thisExePath()
 {
-    version (OSX)
+    version (Darwin)
     {
         import core.sys.posix.stdlib : realpath;
         import std.conv : to;

--- a/std/file.d
+++ b/std/file.d
@@ -4459,7 +4459,7 @@ version (Windows) @system unittest
 version (Posix) @system unittest
 {
     import std.exception : enforce, collectException;
-    import std.process : executeShell;
+
     collectException(rmdirRecurse(deleteme));
     auto d = deleteme~"/a/b/c/d/e/f/g";
     enforce(collectException(mkdir(d)));
@@ -4473,9 +4473,8 @@ version (Posix) @system unittest
 
     d = deleteme~"/a/b/c/d/e/f/g";
     mkdirRecurse(d);
-    version (Android) string link_cmd = "ln -s ";
-    else string link_cmd = "ln -sf ";
-    executeShell(link_cmd~deleteme~"/a/b/c "~deleteme~"/link");
+    const linkTarget = deleteme ~ "/link";
+    symlink(deleteme ~ "/a/b/c", linkTarget);
     rmdirRecurse(deleteme);
     enforce(!exists(deleteme));
 }

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -30,6 +30,8 @@ Windows x86 note:
 A DMD compatible libcurl static library can be downloaded from the dlang.org
 $(LINK2 http://downloads.dlang.org/other/index.html, download archive page).
 
+This module is not available for iOS, tvOS or watchOS.
+
 Compared to using libcurl directly this module allows simpler client code for
 common uses, requires no unsafe operations, and integrates better with the rest
 of the language. Futhermore it provides $(MREF_ALTTEXT range, std,range)
@@ -163,6 +165,16 @@ import std.range.primitives;
 import std.encoding : EncodingScheme;
 import std.traits : isSomeChar;
 import std.typecons : Flag, Yes, No, Tuple;
+
+version (iOS)
+    version = iOSDerived;
+else version (TVOS)
+    version = iOSDerived;
+else version (WatchOS)
+    version = iOSDerived;
+
+version (iOSDerived) {}
+else:
 
 version (StdUnittest)
 {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -40,6 +40,15 @@ License:    $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
 */
 module std.parallelism;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 ///
 @system unittest
 {
@@ -86,7 +95,7 @@ import std.meta;
 import std.range.primitives;
 import std.traits;
 
-version (OSX)
+version (Darwin)
 {
     version = useSysctlbyname;
 }
@@ -986,9 +995,9 @@ uint totalCPUsImpl() @nogc nothrow @trusted
     }
     else version (useSysctlbyname)
     {
-        version (OSX)
+        version (Darwin)
         {
-            auto nameStr = "machdep.cpu.core_count\0".ptr;
+            enum nameStr = "hw.physicalcpu";
         }
         else version (FreeBSD)
         {

--- a/std/path.d
+++ b/std/path.d
@@ -4116,7 +4116,10 @@ string expandTilde(string inputPath) @safe nothrow
 {
     version (Posix)
     {
-        import std.process : executeShell, environment;
+        static if (__traits(compiles, { import std.process : executeShell; }))
+            import std.process : executeShell;
+
+        import std.process : environment;
         import std.string : strip;
 
         // Retrieve the current home variable.
@@ -4141,12 +4144,15 @@ string expandTilde(string inputPath) @safe nothrow
         if (oldHome !is null) environment["HOME"] = oldHome;
         else environment.remove("HOME");
 
-        immutable tildeUser = "~" ~ environment.get("USER");
-        immutable path = executeShell("echo " ~ tildeUser).output.strip();
-        immutable expTildeUser = expandTilde(tildeUser);
-        assert(expTildeUser == path, expTildeUser);
-        immutable expTildeUserSlash = expandTilde(tildeUser ~ "/");
-        assert(expTildeUserSlash == path ~ "/", expTildeUserSlash);
+        static if (is(typeof(executeShell)))
+        {
+            immutable tildeUser = "~" ~ environment.get("USER");
+            immutable path = executeShell("echo " ~ tildeUser).output.strip();
+            immutable expTildeUser = expandTilde(tildeUser);
+            assert(expTildeUser == path, expTildeUser);
+            immutable expTildeUserSlash = expandTilde(tildeUser ~ "/");
+            assert(expTildeUserSlash == path ~ "/", expTildeUserSlash);
+        }
 
         assert(expandTilde("~Idontexist/hey") == "~Idontexist/hey");
     }

--- a/std/socket.d
+++ b/std/socket.d
@@ -2461,12 +2461,21 @@ public:
 
 @safe unittest
 {
-    softUnittest({
+    version (iOSDerived)
+    {
+        enum PAIRS = 256;
+        enum LIMIT = 1024;
+    }
+    else
+    {
         enum PAIRS = 768;
+        enum LIMIT = 2048;
+    }
+
+    softUnittest({
         version (Posix)
         () @trusted
         {
-            enum LIMIT = 2048;
             static assert(LIMIT > PAIRS*2);
             import core.sys.posix.sys.resource;
             rlimit fileLimit;

--- a/std/socket.d
+++ b/std/socket.d
@@ -52,6 +52,12 @@ import std.exception;
 
 import std.internal.cstring;
 
+version (iOS)
+    version = iOSDerived;
+else version (TVOS)
+    version = iOSDerived;
+else version (WatchOS)
+    version = iOSDerived;
 
 @safe:
 
@@ -2041,14 +2047,33 @@ static if (is(sockaddr_un))
     @safe unittest
     {
         import core.stdc.stdio : remove;
-        import std.file : deleteme;
+
+        version (iOSDerived)
+        {
+            // Slightly different version of `std.file.deleteme` to reduce the path
+            // length on iOS derived platforms. Due to the sandbox, the length
+            // of paths can quickly become too long.
+            static string deleteme()
+            {
+                import std.conv : text;
+                import std.process : thisProcessID;
+                import std.file : tempDir;
+
+                return text(tempDir, thisProcessID);
+            }
+        }
+
+        else
+            import std.file : deleteme;
 
         immutable ubyte[] data = [1, 2, 3, 4];
         Socket[2] pair;
 
-        auto names = [ deleteme ~ "-unix-socket" ];
+        const basePath = deleteme;
+        auto names = [ basePath ~ "-unix-socket" ];
         version (linux)
-            names ~= "\0" ~ deleteme ~ "-abstract\0unix\0socket";
+            names ~= "\0" ~ basePath ~ "-abstract\0unix\0socket";
+
         foreach (name; names)
         {
             auto address = new UnixAddress(name);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1456,6 +1456,7 @@ Removes the lock over the specified file segment.
     }
 
     version (Posix)
+    static if (__traits(compiles, { import std.process : spawnProcess; }))
     @system unittest
     {
         static import std.file;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -66,6 +66,21 @@ version (OSX)
     version = GENERIC_IO;
     version = HAS_GETDELIM;
 }
+else version (iOS)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
+else version (TVOS)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
+else version (WatchOS)
+{
+    version = GENERIC_IO;
+    version = HAS_GETDELIM;
+}
 else version (FreeBSD)
 {
     version = GENERIC_IO;

--- a/std/zip.d
+++ b/std/zip.d
@@ -114,6 +114,15 @@ module std.zip;
 
 import std.exception : enforce;
 
+// Non-Android/Apple ARM POSIX-only, because we can't rely on the unzip
+// command being available on Android, Apple ARM or Windows
+version (Android) {}
+else version (iOS) {}
+else version (TVOS) {}
+else version (WatchOS) {}
+else version (Posix)
+    version = HasUnzip;
+
 //debug=print;
 
 /// Thrown on error.
@@ -1700,10 +1709,8 @@ the quick brown fox jumps over the lazy dog\r
     assert(za.directory.length == 0);
 }
 
-// Non-Android POSIX-only, because we can't rely on the unzip command being
-// available on Android or Windows
-version (Android) {} else
-version (Posix) @system unittest
+version (HasUnzip)
+@system unittest
 {
     import std.datetime, std.file, std.format, std.path, std.process, std.stdio;
 


### PR DESCRIPTION
I've only tested this on a 64 bit iPhone running iOS 12. 32 bit is obsolete and I don't have access to the other platforms.

* `std.net.curl` is disabled, libcurl is not shipped on these platforms. This should possible to fix by static linking libcurl and shipping libcurl together with the D compilers. But for that, some extra work are required due to `dlopen` not being allowed.

* Most of the functionality in `std.process` is disabled. Creating new processes are not allowed.

* Some of the unit tests in `std.experimental.allocator` fail. Perhaps the https://github.com/dlang/phobos/commit/537cef3c792f797f68bf75db12709d9ca87387d2 commit should be removed since it doesn't fix the unit test anyway
* Some math related unit tests fail
* One test in `std.socket` fail, but that is allowed to fail

The rest of the unit tests pass.

I recommend reviewing the commits one by one. The individual commit messages contain information of why something was changed. The diff for `std.process` is very big, but the only thing I did was to move `environment`, `thisThreadID` and `thisProcessID` to the top of the module. This allows to easily version out the rest.

druntime PR: https://github.com/dlang/druntime/pull/2910.
LDC PR: https://github.com/ldc-developers/ldc/pull/3288.