### PR TITLE
Don't define version CoreUnittest as it's not necessary any more

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -150,7 +150,7 @@ ifdef ENABLE_COVERAGE
 override DFLAGS  += -cov
 endif
 
-UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest
+UDFLAGS=-unittest -version=StdUnittest
 
 # Set DOTOBJ and DOTEXE
 ifeq (,$(findstring win,$(OS)))


### PR DESCRIPTION
The following druntime commit:
https://github.com/dlang/druntime/commit/ddf4bcc6e315a364e2e9aa57566459c9f793a1e4
removed the need for that, by preventing phobos from instantiating
template nested unittest blocks (from core.time).