### PR TITLE
std.algorithm.sorting: Enable binary transform function for schwartzSort

### DIFF
--- a/changelog/schwartzSort.dd
+++ b/changelog/schwartzSort.dd
@@ -1,0 +1,9 @@
+`std.algorithm.sorting.schwartzSort` supports binary transform functions too
+
+The `transform` template parameter of $(REF schwartzSort, std, algorithm, sorting)
+isn't restricted to unary functions taking an element anymore, but can
+also be a binary function taking an element and its index in the
+original range.
+
+The original index can therefore be used when computing the transformed
+value to sort by.

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2941,8 +2941,10 @@ because the effect can be achieved by calling $(D
 isSorted!less(map!transform(r))).
 
 Params:
-    transform = The transformation to apply.
-    less = The predicate to sort by.
+    transform = The transformation to apply. Either a unary function
+                (`unaryFun!transform(element)`), or a binary function
+                (`binaryFun!transform(element, index)`).
+    less = The predicate to sort the transformed elements by.
     ss = The swapping strategy to use.
     r = The range to sort.
 
@@ -2960,7 +2962,21 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R &&
     import std.range : zip, SortedRange;
     import std.string : representation;
 
-    alias T = typeof(unaryFun!transform(r.front));
+    static if (is(typeof(unaryFun!transform(r.front))))
+    {
+        alias transformFun = unaryFun!transform;
+        alias T = typeof(transformFun(r.front));
+        enum isBinary = false;
+    }
+    else static if (is(typeof(binaryFun!transform(r.front, 0))))
+    {
+        alias transformFun = binaryFun!transform;
+        alias T = typeof(transformFun(r.front, 0));
+        enum isBinary = true;
+    }
+    else
+        static assert(false, "unsupported `transform` alias");
+
     static trustedMalloc(size_t len) @trusted
     {
         import core.checkedint : mulu;
@@ -2988,7 +3004,10 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R &&
     }
     for (; length != r.length; ++length)
     {
-        emplace(&xform1[length], unaryFun!transform(r[length]));
+        static if (isBinary)
+            emplace(&xform1[length], transformFun(r[length], length));
+        else
+            emplace(&xform1[length], transformFun(r[length]));
     }
     // Make sure we use ubyte[] and ushort[], not char[] and wchar[]
     // for the intermediate array, lest zip gets confused.
@@ -3052,6 +3071,14 @@ if (isRandomAccessRange!R && hasLength!R && hasSwappableElements!R)
     assert(arr[1] == midEnt);
     assert(arr[2] == highEnt);
     assert(isSorted!("a < b")(map!(entropy)(arr)));
+}
+
+@safe unittest
+{
+    // binary transform function
+    string[] strings = [ "one", "two", "three" ];
+    schwartzSort!((element, index) => size_t.max - index)(strings);
+    assert(strings == [ "three", "two", "one" ]);
 }
 
 @safe unittest


### PR DESCRIPTION
Receiving the element's index in the original range as 2nd parameter. I have a use case for this.