### PR TITLE
Fix Issue 20540 - (White|Black)Hole does not work with return|scope functions

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4375,6 +4375,17 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
     BlackHole!Foo o;
 }
 
+nothrow pure @safe unittest
+{
+    static interface I
+    {
+        void foo() nothrow pure @nogc @safe;
+    }
+
+    auto cb = new BlackHole!I();
+    cb.foo();
+}
+
 
 /**
 `WhiteHole!Base` is a subclass of `Base` which automatically implements
@@ -4408,10 +4419,25 @@ alias WhiteHole(Base) = AutoImplement!(Base, generateAssertTrap, isAbstractFunct
     assertThrown!NotImplementedError(c.notYetImplemented()); // throws an Error
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=20232
+nothrow pure @safe unittest
+{
+    static interface I
+    {
+        void foo() nothrow pure @safe;
+    }
+
+    if (0) // Just checking attribute interference
+    {
+        auto cw = new WhiteHole!I();
+        cw.foo();
+    }
+}
+
 // / ditto
 class NotImplementedError : Error
 {
-    this(string method)
+    this(string method) nothrow pure @safe
     {
         super(method ~ " is not implemented");
     }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4375,14 +4375,14 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
     BlackHole!Foo o;
 }
 
-nothrow pure @safe unittest
+nothrow pure @nogc @safe unittest
 {
     static interface I
     {
-        void foo() nothrow pure @nogc @safe;
+        I foo() nothrow pure @nogc @safe return scope;
     }
 
-    auto cb = new BlackHole!I();
+    scope cb = new BlackHole!I();
     cb.foo();
 }
 
@@ -4424,12 +4424,12 @@ nothrow pure @safe unittest
 {
     static interface I
     {
-        void foo() nothrow pure @safe;
+        I foo() nothrow pure @safe return scope;
     }
 
     if (0) // Just checking attribute interference
     {
-        auto cw = new WhiteHole!I();
+        scope cw = new WhiteHole!I();
         cw.foo();
     }
 }
@@ -5211,6 +5211,8 @@ private static:
                 if (atts & FA.property) poatts ~= " @property";
                 if (atts & FA.safe    ) poatts ~= " @safe";
                 if (atts & FA.trusted ) poatts ~= " @trusted";
+                if (atts & FA.scope_ )  poatts ~= " scope";
+                if (atts & FA.return_ ) poatts ~= " return";
                 return poatts;
             }
             enum postAtts = make_postAtts();


### PR DESCRIPTION
Includes #7375 because it extends the test case with the appropriate attributes