### PR TITLE
Fix std.format FP printing for soft-float targets

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -276,6 +276,8 @@ label_var_same_name_check="-std.algorithm.iteration,-std.algorithm.sorting,-std.
 ; Checks for subtraction from .length properties
 length_subtraction_check="+disabled"
 ;length_subtraction_check="-std.algorithm.internal,-std.algorithm.iteration,-std.algorithm.mutation,-std.algorithm.searching,-std.algorithm.sorting,-std.array,-std.concurrency,-std.container.array,-std.container.binaryheap,-std.conv,-std.datetime.timezone,-std.experimental.allocator.building_blocks.segregator,-std.experimental.logger.core,-std.file,-std.format,-std.getopt,-std.internal.math.biguintcore,-std.internal.math.biguintnoasm,-std.internal.math.biguintx86,-std.internal.scopebuffer,-std.math,-std.net.curl,-std.net.isemail,-std.numeric,-std.parallelism,-std.path,-std.process,-std.range,-std.regex,-std.regex.internal.parser,-std.regex.internal.tests,-std.string,-std.uni,-std.windows.charset,-std.windows.registry,-std.zip"
+; Checks for local imports that are too broad
+local_import_check="-std.format"
 ; Checks for confusing logical operator precedence
 logical_precedence_check="+disabled"
 ;logical_precedence_check="-std.algorithm.mutation,-std.algorithm.searching,-std.algorithm.setops,-std.algorithm.sorting,-std.array,-std.container.array,-std.conv,-std.experimental.checkedint,-std.file,-std.format,-std.getopt,-std.math,-std.net.isemail,-std.path,-std.range,-std.range.primitives,-std.stdio,-std.string"

--- a/std/format.d
+++ b/std/format.d
@@ -2658,26 +2658,30 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     {
         static if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.mant_dig))
         {
-            import std.math : FloatingPointControl;
+            import std.math;
 
             auto mode = RoundingMode.toNearestTiesToEven;
-            switch (FloatingPointControl.rounding)
-            {
-            case FloatingPointControl.roundUp:
-                mode = RoundingMode.up;
-                break;
-            case FloatingPointControl.roundDown:
-                mode = RoundingMode.down;
-                break;
-            case FloatingPointControl.roundToZero:
-                mode = RoundingMode.toZero;
-                break;
-            case FloatingPointControl.roundToNearest:
-                mode = RoundingMode.toNearestTiesToEven;
-                break;
-            default: assert(false);
-            }
 
+            // std.math's FloatingPointControl isn't available on all target platforms
+            static if (is(FloatingPointControl))
+            {
+                switch (FloatingPointControl.rounding)
+                {
+                case FloatingPointControl.roundUp:
+                    mode = RoundingMode.up;
+                    break;
+                case FloatingPointControl.roundDown:
+                    mode = RoundingMode.down;
+                    break;
+                case FloatingPointControl.roundToZero:
+                    mode = RoundingMode.toZero;
+                    break;
+                case FloatingPointControl.roundToNearest:
+                    mode = RoundingMode.toNearestTiesToEven;
+                    break;
+                default: assert(false);
+                }
+            }
 
             buf = printFloat(val, fs, mode).dup;
             len = buf.length;


### PR DESCRIPTION
After #7362.