### PR TITLE
Fix issue 20589 - typeof may give wrong result in case of classes defining `opCall` operator

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1585,6 +1585,26 @@ if (!is(Unqual!T == bool))
     ai.insertBack(arr);
 }
 
+/**
+ * issue 20589 - typeof may give wrong result in case of classes defining `opCall` operator
+ * https://issues.dlang.org/show_bug.cgi?id=20589
+ *
+ * destructor std.container.array.Array!(MyClass).Array.~this is @system
+ * so the unittest is @system too
+ */
+@system unittest
+{
+    class MyClass
+    {
+        T opCall(T)(T p)
+        {
+            return p;
+        }
+    }
+
+    Array!MyClass arr;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Array!bool

--- a/std/conv.d
+++ b/std/conv.d
@@ -4462,7 +4462,7 @@ package void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
         }
         if (__ctfe)
         {
-            static if (is(typeof(chunk = T(args))))
+            static if (__traits(compiles, chunk = T(args)))
                 chunk = T(args);
             else static if (args.length == 1 && is(typeof(chunk = args[0])))
                 chunk = args[0];


### PR DESCRIPTION
See bugzilla [here](https://issues.dlang.org/show_bug.cgi?id=20589)