### PR TITLE
[Trivial] Remove obsolete hack in std.internal.math.biguintcore

### DIFF
--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -197,8 +197,7 @@ else alias multibyteSquare = std.internal.math.biguintnoasm.multibyteSquare;
 @nogc nothrow pure @safe size_t getCacheLimit()
 {
     import core.cpuid : dataCaches;
-    return (cast(size_t function() @nogc nothrow pure)
-        (() => dataCaches[0].size * 1024 / 2))();
+    return dataCaches[0].size * 1024 / 2;
 }
 enum size_t FASTDIVLIMIT = 100; // crossover to recursive division
 


### PR DESCRIPTION
LDC refuses to compile this, due to the `@safe` parent calling a `@system` lambda. `core.cpuid.dataCaches` is an [appropriate](https://github.com/dlang/druntime/blob/f80a07e1a0140f01878a4b13e2eea61faf6a3063/src/core/cpuid.d#L121) function anyway.