### PR TITLE
Use consistent quickindex wrapper around hand-written list-of-links t…

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -5,6 +5,7 @@ Functions and types that manipulate built-in arrays and associative arrays.
 This module provides all kinds of functions to create, manipulate or convert arrays:
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
@@ -67,7 +68,7 @@ $(TR $(TH Function Name) $(TH Description)
     $(TR $(TD $(LREF uninitializedArray))
         $(TD Returns a new array of type `T` without initializing its elements.
     ))
-)
+))
 
 Copyright: Copyright Andrei Alexandrescu 2008- and Jonathan M Davis 2011-.
 

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4,6 +4,7 @@
 Bit-level manipulation facilities.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Bit constructs) $(TD
@@ -32,7 +33,7 @@ $(TR $(TD Tagging) $(TD
     $(LREF taggedClassRef)
     $(LREF taggedPointer)
 ))
-)
+))
 
 Copyright: Copyright The D Language Foundation 2007 - 2011.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/conv.d
+++ b/std/conv.d
@@ -4,6 +4,7 @@
 A one-stop shop for converting values from one type to another.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Generic) $(TD
@@ -30,7 +31,7 @@ $(TR $(TD Exceptions) $(TD
         $(LREF ConvException)
         $(LREF ConvOverflowException)
 ))
-)
+))
 
 Copyright: Copyright The D Language Foundation 2007-.
 

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -2,6 +2,7 @@
 /++
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Main date types) $(TD
@@ -32,7 +33,7 @@ $(TR $(TD Other) $(TD
     $(LREF AllowDayOverflow)
     $(LREF DateTimeException)
 ))
-)
+))
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -2,6 +2,7 @@
 
 /++
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Main types) $(TD
@@ -25,7 +26,7 @@ $(TR $(TD Underlying ranges) $(TD
 $(TR $(TD Flags) $(TD
     $(LREF PopFirst)
 ))
-)
+))
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)

--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -6,6 +6,7 @@
     For convenience, this module publicly imports $(MREF core,time).
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Main functionality) $(TD
@@ -15,7 +16,7 @@ $(TR $(TD Main functionality) $(TD
 $(TR $(TD Flags) $(TD
     $(LREF AutoStart)
 ))
-)
+))
 
     $(RED Unlike the other modules in std.datetime, this module is not currently
           publicly imported in std.datetime.package, because the old

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -3,6 +3,7 @@
 /++
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Types) $(TD
@@ -23,7 +24,7 @@ $(TR $(TD Conversion) $(TD
     $(LREF SysTimeToSYSTEMTIME)
     $(LREF unixTimeToStdTime)
 ))
-)
+))
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -3,6 +3,7 @@
 /++
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Time zones) $(TD
@@ -19,7 +20,7 @@ $(TR $(TD Utilities) $(TD
     $(LREF setTZEnvVar)
     $(LREF TZConversions)
 ))
-)
+))
 
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -12,6 +12,7 @@ Encodings currently supported are UTF-8, UTF-16, UTF-32, ASCII, ISO-8859-1
 and WINDOWS-1252.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Decode) $(TD
@@ -75,7 +76,7 @@ $(TR $(TD Exceptions) $(TD
     $(LREF INVALID_SEQUENCE)
     $(LREF EncodingException)
 ))
-)
+))
 
 For cases where the encoding is not known at compile-time, but is
 known at run-time, the abstract class $(LREF EncodingScheme)

--- a/std/exception.d
+++ b/std/exception.d
@@ -5,6 +5,7 @@
     handling. It also defines functions intended to aid in unit testing.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Assumptions) $(TD
@@ -31,7 +32,7 @@ $(TR $(TD Other) $(TD
         $(LREF ErrnoException)
         $(LREF RangePrimitive)
 ))
-)
+))
 
     Copyright: Copyright Andrei Alexandrescu 2008-, Jonathan M Davis 2011-.
     License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/std/file.d
+++ b/std/file.d
@@ -7,6 +7,7 @@ at a time. For opening files and manipulating them via handles refer
 to module $(MREF std, stdio).
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD General) $(TD
@@ -64,7 +65,7 @@ $(TR $(TD Other) $(TD
           $(LREF SpanMode)
           $(LREF getAvailableDiskSpace)
 ))
-)
+))
 
 
 Copyright: Copyright The D Language Foundation 2007 - 2011.

--- a/std/functional.d
+++ b/std/functional.d
@@ -8,6 +8,7 @@ functions are helpful when constructing predicates for the algorithms in
 $(MREF std, algorithm) or $(MREF std, range).
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Function Name) $(TH Description)
 )
@@ -50,7 +51,7 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Create a unary or binary function from a string. Most often
         used when defining algorithms on ranges.
     ))
-)
+))
 
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/random.d
+++ b/std/random.d
@@ -4,6 +4,7 @@
 Facilities for random number generation.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Uniform sampling) $(TD
@@ -52,7 +53,7 @@ $(TR $(TD Traits) $(TD
     $(LREF isSeedable)
     $(LREF isUniformRNG)
 ))
-)
+))
 
 $(RED Disclaimer:) The random number generators and API provided in this
 module are not designed to be cryptographically secure, and are therefore

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -8,6 +8,7 @@ provides a number of object and `interface` definitions that can be used to
 wrap around range objects created by the $(MREF std, range) templates.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE ,
     $(TR $(TD $(LREF InputRange))
         $(TD Wrapper for input ranges.
@@ -58,7 +59,7 @@ $(BOOKTABLE ,
     $(TR $(TD $(LREF MostDerivedInputRange))
         $(TD Returns the interface type that best matches the range.
     ))
-)
+))
 
 
 Source: $(PHOBOSSRC std/range/interfaces.d)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -47,6 +47,7 @@ composition templates that let you construct new ranges out of existing ranges:
 
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE ,
     $(TR $(TD $(LREF chain))
         $(TD Concatenates several ranges into a single range.
@@ -206,7 +207,7 @@ $(BOOKTABLE ,
         tuple of all the first elements, a tuple of all the second elements,
         etc.
     ))
-)
+))
 
 Sortedness:
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -8,6 +8,7 @@ It provides basic range functionality by defining several templates for testing
 whether a given object is a range, and what kind of range it is:
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE ,
     $(TR $(TD $(LREF isInputRange))
         $(TD Tests if something is an $(I input range), defined to be
@@ -35,7 +36,7 @@ $(BOOKTABLE ,
         bidirectional range that also supports the array subscripting
         operation via the primitive `opIndex`.
     ))
-)
+))
 
 It also provides number of templates that test for various range capabilities:
 

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -7,6 +7,7 @@
   in text processing utilities.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Matching) $(TD
@@ -39,7 +40,7 @@ $(TR $(TD Objects) $(TD
         $(LREF Splitter)
         $(LREF StaticRegex)
 ))
-)
+))
 
   $(SECTION Synopsis)
   ---

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5,6 +5,7 @@ This module implements a variety of type constructors, i.e., templates
 that allow construction of new, useful general-purpose types.
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Tuple) $(TD
@@ -55,7 +56,7 @@ $(TR $(TD Types) $(TD
     $(LREF TypedefType)
     $(LREF UnqualRef)
 ))
-)
+))
 
 Copyright: Copyright the respective authors, 2008-
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/std/uni.d
+++ b/std/uni.d
@@ -8,6 +8,7 @@
     for this functionality. )
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Decode) $(TD
@@ -96,7 +97,7 @@ $(TR $(TD Building blocks) $(TD
     $(LREF combiningClass)
     $(LREF Grapheme)
 ))
-)
+))
 
     $(P All primitives listed operate on Unicode characters and
         sets of characters. For functions which operate on ASCII characters

--- a/std/utf.d
+++ b/std/utf.d
@@ -7,6 +7,7 @@
     $(D '\u0000' &lt;= character &lt;= '\U0010FFFF').
 
 $(SCRIPT inhibitQuickIndex = 1;)
+$(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
 $(TR $(TD Decode) $(TD
@@ -47,7 +48,7 @@ $(TR $(TD Miscellaneous) $(TD
     $(LREF UseReplacementDchar)
     $(LREF UTFException)
 ))
-)
+))
     See_Also:
         $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
         $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>


### PR DESCRIPTION
…ables

About half the files did it one way and half did it another way. See:

https://dlang.org/phobos/std_algorithm.html
vs
https://dlang.org/phobos/std_encoding.html

for example. Whereas the handwritten list of links is semantically a quickindex the same as the auto-generated version, I decided to consistently apply that quickindex class throughout, so going with what std.algorithm (and std.math, std.ascii, and std.net.curl, among other random modules) has now extended consistently to all of them.

Note that I did NOT apply this to all the std.algorithm submodule "cheat sheets" because those tables are not just a list of links, those are more prose-y than list-y.

Then we can also change style on them consistently, if desired in the future, with one css rule without affecting other tables.