### PR TITLE
mark access to `value.store.str` as @trusted

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1205,8 +1205,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                     break;
                 }
 
-                value.type_tag = JSONType.string;
-                () @trusted { value.store.str = str; } ();
+                value.assign(str);
                 break;
 
             case '0': .. case '9':

--- a/std/json.d
+++ b/std/json.d
@@ -1206,7 +1206,7 @@ if (isInputRange!T && !isInfinite!T && isSomeChar!(ElementEncodingType!T))
                 }
 
                 value.type_tag = JSONType.string;
-                value.store.str = str;
+                () @trusted { value.store.str = str; } ();
                 break;
 
             case '0': .. case '9':


### PR DESCRIPTION
When issue 20655 ("attribute inference accepts unsafe union access as
@safe") is fixed, DMD correctly complains about the operation being unsafe.

Needed for <https://github.com/dlang/dmd/pull/10884>.