### PR TITLE
Make sure that uses of testAllocator are inside of StdUnittest version blocks.

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -440,6 +440,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
         && B.suffix(b) == 0xDEAD_BEEF);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1366,6 +1366,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     }
     else
     {
+        version (StdUnittest)
         @system unittest
         {
             import std.algorithm.comparison : max;
@@ -1759,12 +1760,14 @@ pure @safe unittest
     assert(b.length == 100);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     testAllocator!(() => BitmappedBlock!(64, 8, GCAllocator)(1024 * 64));
 }
 
+version (StdUnittest)
 @system unittest
 {
     // Test chooseAtRuntime
@@ -1774,6 +1777,7 @@ pure @safe unittest
     testAllocator!(() => BitmappedBlock!(chooseAtRuntime, 8, GCAllocator, No.multiblock)(1024 * 64, blockSize));
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1781,6 +1785,7 @@ pure @safe unittest
     testAllocator!(() => SharedBitmappedBlock!(64, 8, Mallocator, No.multiblock)(1024 * 64));
 }
 
+version (StdUnittest)
 @system unittest
 {
     // Test chooseAtRuntime
@@ -2167,6 +2172,7 @@ struct BitmappedBlockWithInternalPointers(
     import std.typecons : Ternary;
 
     static if (!stateSize!ParentAllocator)
+    version (StdUnittest)
     @system unittest
     {
         import std.experimental.allocator.mallocator : AlignedMallocator;

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -30,6 +30,7 @@ struct FallbackAllocator(Primary, Fallback)
     // Need both allocators to be stateless
     // This is to avoid using default initialized stateful allocators
     static if (!stateSize!Primary && !stateSize!Fallback)
+    version (StdUnittest)
     @system unittest
     {
         testAllocator!(() => FallbackAllocator());
@@ -354,6 +355,7 @@ struct FallbackAllocator(Primary, Fallback)
     assert(b.length == 100);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.bitmapped_block : BitmappedBlockWithInternalPointers;
@@ -469,6 +471,7 @@ fallbackAllocator(Primary, Fallback)(auto ref Primary p, auto ref Fallback f)
     assert(a.primary.owns(b2) == Ternary.no);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -411,6 +411,7 @@ struct FreeTree(ParentAllocator)
     }
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -744,6 +744,7 @@ it actually returns memory to the operating system when possible.
     }
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.algorithm.comparison : max;

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -240,6 +240,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(buf.ptr);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
@@ -294,6 +295,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(c.length == 100);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;
@@ -310,6 +312,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     assert(alignedAt(&b[0], 16));
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.building_blocks.region : Region;

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -465,6 +465,7 @@ struct Region(ParentAllocator = NullAllocator,
     Mallocator.instance.deallocate(tmp);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -23,6 +23,7 @@ struct ScopedAllocator(ParentAllocator)
     static if (!stateSize!ParentAllocator)
     {
         // This test is available only for stateless allocators
+        version (StdUnittest)
         @system unittest
         {
             testAllocator!(() => ScopedAllocator());
@@ -223,6 +224,7 @@ struct ScopedAllocator(ParentAllocator)
     assert(alloc.empty == Ternary.no);
 }
 
+version (StdUnittest)
 @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -14,7 +14,7 @@ struct GCAllocator
 {
     import core.memory : GC;
     import std.typecons : Ternary;
-    @system unittest { testAllocator!(() => GCAllocator.instance); }
+    version (StdUnittest) @system unittest { testAllocator!(() => GCAllocator.instance); }
 
     /**
     The alignment is a static constant equal to `platformAlignment`, which

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -12,7 +12,7 @@ import std.experimental.allocator.common;
  */
 struct Mallocator
 {
-    @system unittest { testAllocator!(() => Mallocator.instance); }
+    version (StdUnittest) @system unittest { testAllocator!(() => Mallocator.instance); }
 
     /**
     The alignment is a static constant equal to `platformAlignment`, which
@@ -210,7 +210,7 @@ version (Windows)
  */
 struct AlignedMallocator
 {
-    @system unittest { testAllocator!(() => typeof(this).instance); }
+    version (StdUnittest) @system unittest { testAllocator!(() => typeof(this).instance); }
 
     /**
     The default alignment is `platformAlignment`.


### PR DESCRIPTION
https://github.com/dlang/phobos/pull/7353 moved the declaration of `testAllocator` inside of a version block, but not all of the unit tests that use this template were put in similar version blocks. This causes CI tests for dsymbol to fail when built with 2.091.0.