### PR TITLE
Improve std.stdio.File documentation

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -708,10 +708,10 @@ The mode must be compatible with the mode of the file descriptor.
 
 Throws: `ErrnoException` in case of error.
 Params:
-    fd = File descriptor to open.
-    stdioOpenmode = Mode to open the file. `stdioOpenmode` has the same semantics
+    fd = File descriptor to associate with this `File`.
+    stdioOpenmode = Mode to associate with theis `File`. `stdioOpenmode` has the same semantics
         semantics as in the C standard library
-        $(HTTP .cplusplus.com/reference/cstdio/fopen/, fdopen) function.
+        $(HTTP .cplusplus.com/reference/cstdio/fopen/, fdopen) function, and must be compatible with `fd`.
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -825,11 +825,11 @@ Throws: `Exception` if the file is not opened.
 
 /**
  Returns the name last used to initialize this `File`, if any.
- 
+
  Some functions that create or initialize the `File` set the name field to `null`.
  Examples include $(LREF tmpfile), $(LREF wrapFile), and $(LREF fdopen). See the
  documentation of those functions for details.
- 
+
  Returns: The name last used to initialize this this file, if it has a name, or `null` otherwise.
  */
     @property string name() const @safe pure nothrow

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -712,7 +712,7 @@ Params:
     fd = File descriptor to associate with this `File`.
     stdioOpenmode = Mode to associate with this File. The mode has the same semantics
         semantics as in the C standard library
-        $(HTTP .cplusplus.com/reference/cstdio/fopen/, fdopen) function, and must be compatible with `fd`.
+        $(HTTP cplusplus.com/reference/cstdio/fopen/, fdopen) function, and must be compatible with `fd`.
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -818,7 +818,7 @@ Throws: `Exception` if the file is not opened.
         return .feof(cast(FILE*) _p.handle) != 0;
     }
 
-/** Returns the name of the last opened file, if any.
+/** Returns the name of the current file, if any.
 If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
 it has no name.*/
     @property string name() const @safe pure nothrow

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -820,7 +820,10 @@ Throws: `Exception` if the file is not opened.
 
 /** Returns the name of the current file, if any.
 If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
-it has no name.*/
+it has no name.
+
+Returns: The name of this file, if it has a name.
+*/
     @property string name() const @safe pure nothrow
     {
         return _name;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -818,7 +818,7 @@ Throws: `Exception` if the file is not opened.
         return .feof(cast(FILE*) _p.handle) != 0;
     }
 
-/** Returns the name of the last opened file from this instance, if any.
+/** Returns the name of the last file opened from this instance, if any.
 If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
 it has no name.
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -709,7 +709,9 @@ The mode must be compatible with the mode of the file descriptor.
 Throws: `ErrnoException` in case of error.
 Params:
     fd = File descriptor to open.
-    stdioOpenmode = Mode to open the file ("r", "wb" ...).
+    stdioOpenmode = Mode to open the file. `stdioOpenmode` has the same semantics
+        semantics as in the C standard library
+        $(HTTP .cplusplus.com/reference/cstdio/fopen/, fdopen) function.
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -818,7 +818,7 @@ Throws: `Exception` if the file is not opened.
         return .feof(cast(FILE*) _p.handle) != 0;
     }
 
-/** Returns the name of the current file, if any.
+/** Returns the name of the last opened file from this instance, if any.
 If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
 it has no name.
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -818,12 +818,15 @@ Throws: `Exception` if the file is not opened.
         return .feof(cast(FILE*) _p.handle) != 0;
     }
 
-/** Returns the name of the last file opened from this instance, if any.
-If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
-it has no name.
-
-Returns: The name of this file, if it has a name, or `null` otherwise.
-*/
+/**
+ Returns the name last used to initialize this `File`, if any.
+ 
+ Some functions that create or initialize the `File` set the name field to `null`.
+ Examples include $(LREF tmpfile), $(LREF wrapFile), and $(LREF fdopen). See the
+ documentation of those functions for details.
+ 
+ Returns: The name last used to initialize this this file, if it has a name, or `null` otherwise.
+ */
     @property string name() const @safe pure nothrow
     {
         return _name;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -707,6 +707,9 @@ associate the given file descriptor with the `File`, and sets the file's name to
 The mode must be compatible with the mode of the file descriptor.
 
 Throws: `ErrnoException` in case of error.
+Params:
+    fd = File descriptor to open.
+    stdioOpenmode = Mode to open the file ("r", "wb" ...).
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -822,7 +822,7 @@ Throws: `Exception` if the file is not opened.
 If a `File` was created with $(LREF tmpfile) and $(LREF wrapFile)
 it has no name.
 
-Returns: The name of this file, if it has a name.
+Returns: The name of this file, if it has a name, or `null` otherwise.
 */
     @property string name() const @safe pure nothrow
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -702,9 +702,9 @@ Throws: `ErrnoException` in case of error.
     }
 
 /**
-First calls `detach` (throwing on failure), and then attempts to
-associate the given file descriptor with the `File`. The mode must
-be compatible with the mode of the file descriptor.
+First calls `detach` (throwing on failure), then attempts to
+associate the given file descriptor with the `File`, and sets the file's name to `null`.
+The mode must be compatible with the mode of the file descriptor.
 
 Throws: `ErrnoException` in case of error.
  */

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -704,12 +704,13 @@ Throws: `ErrnoException` in case of error.
 /**
 First calls `detach` (throwing on failure), then attempts to
 associate the given file descriptor with the `File`, and sets the file's name to `null`.
+
 The mode must be compatible with the mode of the file descriptor.
 
 Throws: `ErrnoException` in case of error.
 Params:
     fd = File descriptor to associate with this `File`.
-    stdioOpenmode = Mode to associate with theis `File`. `stdioOpenmode` has the same semantics
+    stdioOpenmode = Mode to associate with this File. The mode has the same semantics
         semantics as in the C standard library
         $(HTTP .cplusplus.com/reference/cstdio/fopen/, fdopen) function, and must be compatible with `fd`.
  */

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -831,7 +831,7 @@ Throws: `Exception` if the file is not opened.
  Examples include $(LREF tmpfile), $(LREF wrapFile), and $(LREF fdopen). See the
  documentation of those functions for details.
 
- Returns: The name last used to initialize this this file, if it has a name, or `null` otherwise.
+ Returns: The name last used to initialize this this file, or `null` otherwise.
  */
     @property string name() const @safe pure nothrow
     {


### PR DESCRIPTION
The documentation for `File.name()` stated it "Returns the name of the last opened file..." This implies `name()` is a static function which returns the name of whatever file happened to be initialized and opened most recently, rather than the name of the FILE* which the struct refers to.

I propose correcting the documentation to reflect `name()`'s actual purpose.