### PR TITLE
[dmd-cxx] std.algorithm.iteration: Fix typo.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3151,7 +3151,7 @@ The number of seeds must be correspondingly increased.
     static assert(!is(typeof(reduce!(min, max)(tuple(c), "hello"))));
     //"Seed (dchar, dchar, dchar) does not have the correct amount of fields (should be 2)"
     static assert(!is(typeof(reduce!(min, max)(tuple(c, c, c), "hello"))));
-    //"Incompatable function/seed/element: all(alias pred = "a")/int/dchar"
+    //"Incompatible function/seed/element: all(alias pred = "a")/int/dchar"
     static assert(!is(typeof(reduce!all(1, "hello"))));
     static assert(!is(typeof(reduce!(all, all)(tuple(1, 1), "hello"))));
 }
@@ -3620,7 +3620,7 @@ The number of seeds must be correspondingly increased.
     static assert(!__traits(compiles, cumulativeFold!(min, max)("hello", tuple(c))));
     //"Seed (dchar, dchar, dchar) does not have the correct amount of fields (should be 2)"
     static assert(!__traits(compiles, cumulativeFold!(min, max)("hello", tuple(c, c, c))));
-    //"Incompatable function/seed/element: all(alias pred = "a")/int/dchar"
+    //"Incompatible function/seed/element: all(alias pred = "a")/int/dchar"
     static assert(!__traits(compiles, cumulativeFold!all("hello", 1)));
     static assert(!__traits(compiles, cumulativeFold!(all, all)("hello", tuple(1, 1))));
 }


### PR DESCRIPTION
Taken from patch for gdc bugzilla PR other/93756