### PR TITLE
Bump minimum MACOSX version to 10.9

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -37,7 +37,7 @@ DMD_DIR=../dmd
 include $(DMD_DIR)/src/osmodel.mak
 
 ifeq (osx,$(OS))
-	export MACOSX_DEPLOYMENT_TARGET=10.7
+	export MACOSX_DEPLOYMENT_TARGET=10.9
 endif
 
 # Default to a release build, override with BUILD=debug


### PR DESCRIPTION
This was done in DMD two years ago but never applied here.

https://github.com/dlang/dmd/pull/7578

Originally found while working on Druntime, the PR there will follow soon.