### PR TITLE
Remove version(assert) from TimSort

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2332,7 +2332,7 @@ private template TimSortImpl(alias pred, R)
             }
 
             // Assert that the code above established the invariant correctly
-            version (assert)
+            version (StdUnittest)
             {
                 if (stackLen == 2)
                 {


### PR DESCRIPTION
If `-debug` is passed to the compiler, `version(assert)` is true.
TimSort has a `version(assert)` that checks some invariants, and uses
std.format.format for better error messages. Unfortunately, since it
is templated code, this results in Phobos template instantiations of
`format` in the user's code when `-debug` is used.

Given that default dub builds use `-debug`, this is a very common
problem.

Instead of removing the invariant checks, this changes it so they only
happen when testing Phobos itself.

This is blocking removing the special cases in dmd for template codegen when -debug or -unittest are used.