### PR TITLE
Enable `@safe` on `cartesianProduct`'s `Result.popFront`

### DIFF
--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -391,7 +391,7 @@ if (ranges.length >= 2 &&
             return mixin(algoFormat("tuple(%(current[%d].front%|,%))",
                                     iota(0, current.length)));
         }
-        void popFront() scope @trusted // @trusted until dmd #9220 is pulled
+        void popFront() scope @safe
         {
             foreach_reverse (i, ref r; current)
             {


### PR DESCRIPTION
```
The DMD PR has long been pulled but the comment hasn't been fixed.
```

Not sure this works, let's see what the auto-tester says.