### PR TITLE
[dmd-cxx] std.range.primitives: Fix static condition for X32 targets

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1416,12 +1416,12 @@ unittest
     struct A { ulong length; }
     struct B { @property uint length() { return 0; } }
 
-    version (X86)
+    static if (is(size_t == uint))
     {
         static assert(!hasLength!(A));
         static assert(hasLength!(B));
     }
-    else version(X86_64)
+    else static if (is(size_t == ulong))
     {
         static assert(hasLength!(A));
         static assert(!hasLength!(B));


### PR DESCRIPTION
Cherry-picked from #7447