### PR TITLE
specify return type for SortedRange.opBinaryRight!"in"

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -11147,7 +11147,7 @@ evaluations of `pred`.
 /**
 Like `contains`, but the value is specified before the range.
 */
-    auto opBinaryRight(string op, V)(V value)
+    bool opBinaryRight(string op, V)(V value)
     if (op == "in" && isRandomAccessRange!Range)
     {
         return contains(value);


### PR DESCRIPTION
I saw the docs, and thought it was going to return a pointer to the element. It returns a bool (basically returns `contains(value)`)

There's no need to hide this in the docs/API.