### PR TITLE
Mostly fix 18559: std.math.* should stop using real overloads by default

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -991,20 +991,20 @@ public:
             if (w1 == 0)
                 return T(0); // Special: bsr(w1) is undefined.
             int bitsStillNeeded = totalNeededBits - bsr(w1) - 1;
-            T acc = scalbn(w1, scale);
+            T acc = scalbn(cast(T) w1, scale);
             for (ptrdiff_t i = ulongLength - 2; i >= 0 && bitsStillNeeded > 0; i--)
             {
                 ulong w = data.peekUlong(i);
                 // To round towards zero we must make sure not to use too many bits.
                 if (bitsStillNeeded >= 64)
                 {
-                    acc += scalbn(w, scale -= 64);
+                    acc += scalbn(cast(T) w, scale -= 64);
                     bitsStillNeeded -= 64;
                 }
                 else
                 {
                     w = (w >>> (64 - bitsStillNeeded)) << (64 - bitsStillNeeded);
-                    acc += scalbn(w, scale -= 64);
+                    acc += scalbn(cast(T) w, scale -= 64);
                     break;
                 }
             }

--- a/std/math.d
+++ b/std/math.d
@@ -376,12 +376,10 @@ if ((is(immutable Num == immutable short) || is(immutable Num == immutable byte)
  */
 
 real cos(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.cos(x); }
-//FIXME
 ///ditto
-double cos(double x) @safe pure nothrow @nogc { return cos(cast(real) x); }
-//FIXME
+double cos(double x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.cos(x); }
 ///ditto
-float cos(float x) @safe pure nothrow @nogc { return cos(cast(real) x); }
+float cos(float x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.cos(x); }
 
 ///
 @safe unittest
@@ -418,12 +416,10 @@ float cos(float x) @safe pure nothrow @nogc { return cos(cast(real) x); }
  */
 
 real sin(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.sin(x); }
-//FIXME
 ///ditto
-double sin(double x) @safe pure nothrow @nogc { return sin(cast(real) x); }
-//FIXME
+double sin(double x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.sin(x); }
 ///ditto
-float sin(float x) @safe pure nothrow @nogc { return sin(cast(real) x); }
+float sin(float x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.sin(x); }
 
 ///
 @safe unittest
@@ -1563,35 +1559,6 @@ long rndtol(float x) @safe pure nothrow @nogc { return rndtol(cast(real) x); }
 {
     long function(real) prndtol = &rndtol;
     assert(prndtol != null);
-}
-
-/**
-$(RED Deprecated. Please use $(LREF round) instead.)
-
-Returns `x` rounded to a `long` value using the `FE_TONEAREST` rounding mode.
-If the integer value of `x` is greater than `long.max`, the result is
-indeterminate.
-
-Only works with the Digital Mars C Runtime.
-
-Params:
-    x = the number to round
-Returns:
-    `x` rounded to an integer value
- */
-deprecated("rndtonl is to be removed by 2.089. Please use round instead")
-extern (C) real rndtonl(real x);
-
-///
-deprecated @system unittest
-{
-    version (CRuntime_DigitalMars)
-    {
-        assert(rndtonl(1.0) is -real.nan);
-        assert(rndtonl(1.2) is -real.nan);
-        assert(rndtonl(1.7) is -real.nan);
-        assert(rndtonl(1.0001) is -real.nan);
-    }
 }
 
 /***************************************
@@ -4646,13 +4613,20 @@ real nearbyint(real x) @safe pure nothrow @nogc
  * $(LREF nearbyint) performs the same operation, but does
  * not set the FE_INEXACT exception.
  */
-real rint(real x) @safe pure nothrow @nogc { pragma(inline, true); return core.math.rint(x); }
-//FIXME
+real rint(real x) @safe pure nothrow @nogc
+{
+    pragma(inline, true); return core.math.rint(x);
+}
 ///ditto
-double rint(double x) @safe pure nothrow @nogc { return rint(cast(real) x); }
-//FIXME
+double rint(double x) @safe pure nothrow @nogc
+{
+    pragma(inline, true); return core.math.rint(x);
+}
 ///ditto
-float rint(float x) @safe pure nothrow @nogc { return rint(cast(real) x); }
+float rint(float x) @safe pure nothrow @nogc
+{
+    pragma(inline, true); return core.math.rint(x);
+}
 
 ///
 @safe unittest


### PR DESCRIPTION
Changes from old PR:`LN2` are are now cast to the appropriate precision, `0.5* _` now have the appropriate precision suffix.

Still to go, functions with `real` only implementations:
* remainder
* remquo
* NaN (creating one with a given payload)
* getNaNPayload
* logarithmic functions

Blocked on:
* https://github.com/Netflix/vectorflow/pull/33 merged, waiting on new tag.