### PR TITLE
Only use 'from' if a packet was actually received

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -3572,7 +3572,7 @@ class UdpSocket: Socket
     }
 }
 
-unittest
+@safe unittest
 {
     byte[] buf;
     buf.length = 1;

--- a/std/socket.d
+++ b/std/socket.d
@@ -3119,25 +3119,17 @@ public:
             from = createAddress();
         socklen_t nameLen = from.nameLen;
         version (Windows)
-        {
             auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int) flags, from.name, &nameLen);
-            if (read >= 0)
-            {
-                from.setNameLen(nameLen);
-                assert(from.addressFamily == _family);
-            }
-            return read;
-        }
+
         else
-        {
             auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int) flags, from.name, &nameLen);
-            if (read >= 0)
-            {
-                from.setNameLen(nameLen);
-                assert(from.addressFamily == _family);
-            }
-            return read;
+
+        if (read >= 0)
+        {
+            from.setNameLen(nameLen);
+            assert(from.addressFamily == _family);
         }
+        return read;
     }
 
 

--- a/std/socket.d
+++ b/std/socket.d
@@ -3121,17 +3121,21 @@ public:
         version (Windows)
         {
             auto read = .recvfrom(sock, buf.ptr, capToInt(buf.length), cast(int) flags, from.name, &nameLen);
-            from.setNameLen(nameLen);
-            assert(from.addressFamily == _family);
-            // if (!read) //connection closed
+            if (read >= 0)
+            {
+                from.setNameLen(nameLen);
+                assert(from.addressFamily == _family);
+            }
             return read;
         }
         else
         {
             auto read = .recvfrom(sock, buf.ptr, buf.length, cast(int) flags, from.name, &nameLen);
-            from.setNameLen(nameLen);
-            assert(from.addressFamily == _family);
-            // if (!read) //connection closed
+            if (read >= 0)
+            {
+                from.setNameLen(nameLen);
+                assert(from.addressFamily == _family);
+            }
             return read;
         }
     }
@@ -3574,6 +3578,17 @@ class UdpSocket: Socket
     {
         this(AddressFamily.INET);
     }
+}
+
+unittest
+{
+    byte[] buf;
+    buf.length = 1;
+    Address addr;
+    auto s = new UdpSocket;
+    s.blocking = false;
+    s.bind(new InternetAddress(InternetAddress.PORT_ANY));
+    s.receiveFrom(buf, addr);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16514


### PR DESCRIPTION
This fixes a systematic assertion error when trying to receiveFrom a
non-blocking UDP socket. In this case, 'from.addressFamily' is equal to UNSPEC,
eventually failing the comparison and crashing the program.