### PR TITLE
merge stable

### DIFF
--- a/changelog/digest.dd
+++ b/changelog/digest.dd
@@ -3,5 +3,5 @@ The deprecated aliases in std.digest.digest were removed
 They were deprecated since 2.076.1 and have now been removed.
 Import `std.digest` or its submodules instead.
 
-Additionally the deprecation cycle for `std.digest` was started
+Additionally the deprecation cycle for `std.digest.digest` was started
 and the module will be removed in 2.101.


### PR DESCRIPTION
- Documentation fix: std.digest is not going to be removed, std.digest.digest is
