### PR TITLE
Restore accidentally removed import from std.math

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -133,6 +133,9 @@ static import core.stdc.fenv;
 import std.traits :  CommonType, isFloatingPoint, isIntegral, isNumeric,
     isSigned, isUnsigned, Largest, Unqual;
 
+// Note: Exposed accidentally, should be deprecated / removed
+public import std.meta : AliasSeq;
+
 version (DigitalMars)
 {
     version = INLINE_YL2X;        // x87 has opcodes for these


### PR DESCRIPTION
It was removed in PR7473: https://github.com/dlang/phobos/pull/7473#issuecomment-628176305
It caused a two-days-long outage of Buildkite: https://github.com/dlang/ci/pull/418#issuecomment-629223669