### PR TITLE
std.experimental.allocator: use core.bitop for trailingZeroes and leadingOnes

### DIFF
--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -2456,13 +2456,9 @@ If `x` contains no zeros (i.e. is equal to `ulong.max`), returns 64.
 pure nothrow @safe @nogc
 private uint leadingOnes(ulong x)
 {
-    uint result = 0;
-    while (cast(long) x < 0)
-    {
-        ++result;
-        x <<= 1;
-    }
-    return result;
+    import core.bitop : bsr;
+    const x_ = ~x;
+    return x_ == 0 ? 64 : (63 - bsr(x_));
 }
 
 @safe unittest

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -255,12 +255,8 @@ Returns the number of trailing zeros of `x`.
 @safe @nogc nothrow pure
 package uint trailingZeros(ulong x)
 {
-    uint result;
-    while (result < 64 && !(x & (1UL << result)))
-    {
-        ++result;
-    }
-    return result;
+    import core.bitop : bsf;
+    return x == 0 ? 64 : bsf(x);
 }
 
 @safe @nogc nothrow pure


### PR DESCRIPTION
`trailingZeroes` and `leadingOnes` have unit tests and they are still passing.