### PR TITLE
Replace template AliasSeq with a simple alias

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -86,10 +86,7 @@ import std.range.primitives : isInfinite;
  *
  * In previous versions of Phobos, this was known as `TypeTuple`.
  */
-template AliasSeq(TList...)
-{
-    alias AliasSeq = TList;
-}
+alias AliasSeq(TList...) = TList;
 
 ///
 @safe unittest


### PR DESCRIPTION
This is a direct realization of AliasSeq that better clarifies its intent.