### PR TITLE
Remove all Replace definitions except for alias

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -543,24 +543,6 @@ template NoDuplicates(TList...)
  * Returns an `AliasSeq` created from TList with the first occurrence
  * of type T, if found, replaced with type U.
  */
-template Replace(T, U, TList...)
-{
-    alias Replace = GenericReplace!(T, U, TList).result;
-}
-
-/// Ditto
-template Replace(alias T, U, TList...)
-{
-    alias Replace = GenericReplace!(T, U, TList).result;
-}
-
-/// Ditto
-template Replace(T, alias U, TList...)
-{
-    alias Replace = GenericReplace!(T, U, TList).result;
-}
-
-/// Ditto
 template Replace(alias T, alias U, TList...)
 {
     alias Replace = GenericReplace!(T, U, TList).result;


### PR DESCRIPTION
Unittests pass so I'm putting this up for review. If there was a reason for all, we'll see soon enough.