### PR TITLE
specialize max/min for common case

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1681,7 +1681,7 @@ if (is(T == U) && is(typeof(a < b)))
    /* Handle the common case without all the template expansions
     * of the general case
     */
-    return a < b ? a : b;
+    return b < a ? b : a;
 }
 
 

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1516,7 +1516,7 @@ Iterates the passed arguments and returns the maximum value.
 
 Params:
     args = The values to select the maximum from. At least two arguments must
-    be passed, and they must be comparable with `>`.
+    be passed, and they must be comparable with `<`.
 
 Returns:
     The maximum of the passed-in values. The type of the returned value is
@@ -1562,6 +1562,16 @@ if (T.length >= 2 && !is(CommonType!T == void))
     import std.functional : lessThan;
     immutable chooseB = lessThan!(T0, T1)(a, b);
     return cast(Result) (chooseB ? b : a);
+}
+
+///
+T max(T, U)(T a, U b)
+if (is(T == U) && is(typeof(a < b)))
+{
+   /* Handle the common case without all the template expansions
+    * of the general case
+    */
+    return a < b ? b : a;
 }
 
 ///
@@ -1663,6 +1673,17 @@ if (T.length >= 2 && !is(CommonType!T == void))
     immutable chooseB = lessThan!(T1, T0)(b, a);
     return cast(Result) (chooseB ? b : a);
 }
+
+///
+T min(T, U)(T a, U b)
+if (is(T == U) && is(typeof(a < b)))
+{
+   /* Handle the common case without all the template expansions
+    * of the general case
+    */
+    return a < b ? a : b;
+}
+
 
 ///
 @safe @nogc @betterC unittest

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1564,7 +1564,7 @@ if (T.length >= 2 && !is(CommonType!T == void))
     return cast(Result) (chooseB ? b : a);
 }
 
-///
+/// ditto
 T max(T, U)(T a, U b)
 if (is(T == U) && is(typeof(a < b)))
 {
@@ -1674,7 +1674,7 @@ if (T.length >= 2 && !is(CommonType!T == void))
     return cast(Result) (chooseB ? b : a);
 }
 
-///
+/// ditto
 T min(T, U)(T a, U b)
 if (is(T == U) && is(typeof(a < b)))
 {


### PR DESCRIPTION
because the general case instantiates a large number of templates.