### PR TITLE
alias FSChar = char for a wider range of platforms

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -107,16 +107,11 @@ version (Windows)
 {
     private alias FSChar = wchar;
 }
-else version (Posix)
-{
-    private alias FSChar = char;
-}
-else version (GENERIC_IO)
-{
-    private alias FSChar = char;
-}
 else
-    static assert(0);
+{
+    private alias FSChar = char;
+}
+
 
 version (Windows)
 {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -111,6 +111,10 @@ else version (Posix)
 {
     private alias FSChar = char;
 }
+else version (GENERIC_IO)
+{
+    private alias FSChar = char;
+}
 else
     static assert(0);
 


### PR DESCRIPTION
Especially for non-windows && non-posix