### PR TITLE
Fix Issue 20869 - `move` is overly trusting of `opPostMove`

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -284,7 +284,7 @@ local_import_check="-std.format"
 logical_precedence_check="+disabled"
 ;logical_precedence_check="-std.algorithm.mutation,-std.algorithm.searching,-std.algorithm.setops,-std.algorithm.sorting,-std.array,-std.container.array,-std.conv,-std.experimental.checkedint,-std.file,-std.format,-std.getopt,-std.math,-std.net.isemail,-std.path,-std.range,-std.range.primitives,-std.stdio,-std.string"
 ; Checks for mismatched argument and parameter names
-mismatched_args_check="-std.container.dlist,-std.encoding,-std.internal.math.biguintcore,-std.math,-std.net.curl,-std.numeric,-std.uni"
+mismatched_args_check="-std.algorithm.mutation,-std.container.dlist,-std.encoding,-std.internal.math.biguintcore,-std.math,-std.net.curl,-std.numeric,-std.uni"
 ; Check number literals for readability
 number_style_check="+disabled"
 ;number_style_check="-std.algorithm.iteration,-std.algorithm.sorting,-std.array,-std.bigint,-std.bitmanip,-std.container.array,-std.conv,-std.datetime.date,-std.datetime.systime,-std.datetime.timezone,-std.digest.crc,-std.digest,-std.digest.md,-std.digest.ripemd,-std.digest.sha,-std.experimental.allocator.building_blocks.free_tree,-std.experimental.allocator.building_blocks.kernighan_ritchie,-std.experimental.checkedint,-std.file,-std.format,-std.functional,-std.internal.math.biguintcore,-std.internal.math.gammafunction,-std.json,-std.math,-std.outbuffer,-std.parallelism,-std.random,-std.range,-std.regex.internal.generator,-std.utf,-std.zip,-std.zlib"


### PR DESCRIPTION
Remove the manual check whether move is `@safe` and instead let the compiler do the attribute interference by adding appropriate `@trusted` blocks.

Note: I could've extend the current checks `trustedMoveImpl` but that could easily miss other corner cases.

TLDR: Only use `@trusted` when necessary