### PR TITLE
Faster staticMap and Filter

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -916,10 +916,10 @@ private alias Nothing = AliasSeq!(); // yes, this really does speed up compilati
  */
 template Filter(alias Pred, Args ...)
 {
-    template MaybeNothing(alias Q)
+    template MaybeNothing(Q ...)
     {
-        static if (Pred!Q)
-            alias MaybeNothing = Q;
+        static if (Pred!(Q[0]))
+            alias MaybeNothing = AliasSeq!(Q[0]);
         else
             alias MaybeNothing = Nothing;
     }
@@ -948,6 +948,12 @@ template Filter(alias Pred, Args ...)
     static assert(is(Filter!isPointer == AliasSeq!()));
 }
 
+@safe unittest
+{
+    enum Yes(T) = true;
+    static struct S {}
+    static assert(is(Filter!(Yes, const(int), const(S)) == AliasSeq!(const(int), const(S))));
+}
 
 // Used in template predicate unit tests below.
 private version (StdUnittest)


### PR DESCRIPTION
### staticMap
There are a few separate optimisations here:
1. make `staticMapImpl` , meaning that the template you're instantiating a lot of doesn't have to take the `F` every time. Improvement: only ~1-2% but very stable, I suspect this approach might be more rewarding elsewhere.
2. expand out many small cases (150). Any more than 3 was slower if done inline with `static if` chains, but combined with the following you can really crank it
3. generate the small cases as an `AliasSeq` of strings, so no static if chains, just an O(1) lookup (at least I hope so). This is the big one, enabling the expansion to work cheaply.
4. in the binary split branch immediately do what work you can. Combined with the rest this is an extra ~20% speedup and 10% memory reduction

Overall, this was ~2.5x faster and ~4x less RAM in my tests.
My tests were all biased towards very long `Args` and simple `F`s.

### Filter
Armed with this nice basic tool, Filter can be attacked, I saw ~4x speedup and ~3x memory reduction

I'm sure a combination of either implementing in terms of this faster `staticMap` or using same techniques could be done across a lot of `std.meta`

Todo:
* [ ] Proper benchmarks across different scales. I heavily tested with large synthetic `AliasSeq`s and then did some tweaks for a large codebase mostly using small ones.