### PR TITLE
std.math: Fix comment for isIdentical

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6994,10 +6994,6 @@ if (isFloatingPoint!(X))
 
 /*********************************
  * Is the binary representation of x identical to y?
- *
- * Same as ==, except that positive and negative zero are not identical,
- * and two $(NAN)s are identical if they have the same 'payload', sign bit,
- * and quiet bit.
  */
 bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 {


### PR DESCRIPTION
Following up on #7516. There exist equivalent binary representations which aren't identical, not just 0 and NaNs.