### PR TITLE
Reuse new builtin trait isCopyable in std.traits.isCopyable

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -512,7 +512,11 @@ template to(T)
         void fun() inout
         {
             static foreach (const idx; 0 .. this.tupleof.length)
-                this.tupleof[idx].to!string();
+            {
+                {
+                    const _ = this.tupleof[idx].to!string();
+                }
+            }
         }
     }
 }

--- a/std/traits.d
+++ b/std/traits.d
@@ -8904,9 +8904,7 @@ if (X.length == 1)
  + Returns:
  +  `true` if `S` can be copied. `false` otherwise.
  + ++/
-enum isCopyable(S) = is(typeof(
-    { S foo = S.init; S copy = foo; }
-));
+enum isCopyable(S) = __traits(isCopyable, S);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -8904,15 +8904,7 @@ if (X.length == 1)
  + Returns:
  +  `true` if `S` can be copied. `false` otherwise.
  + ++/
-template isCopyable(S)
-{
-    enum isCopyable_old = is(typeof({ S foo = S.init; S copy = foo; }));
-    enum isCopyable = __traits(isCopyable, S);
-    static if (isCopyable_old !is isCopyable)
-    {
-        pragma(msg, "New builtin trait isCopyable differs from old for type " ~ S.stringof);
-    }
-}
+enum isCopyable(S) = __traits(isCopyable, S);
 
 ///
 @safe unittest

--- a/std/traits.d
+++ b/std/traits.d
@@ -8908,7 +8908,10 @@ template isCopyable(S)
 {
     enum isCopyable_old = is(typeof({ S foo = S.init; S copy = foo; }));
     enum isCopyable = __traits(isCopyable, S);
-    static assert(isCopyable_old is isCopyable, "New builtin trait isCopyable differs from old for type " ~ S.stringof);
+    static if (isCopyable_old !is isCopyable)
+    {
+        pragma(msg, "New builtin trait isCopyable differs from old for type " ~ S.stringof);
+    }
 }
 
 ///

--- a/std/traits.d
+++ b/std/traits.d
@@ -8904,7 +8904,12 @@ if (X.length == 1)
  + Returns:
  +  `true` if `S` can be copied. `false` otherwise.
  + ++/
-enum isCopyable(S) = __traits(isCopyable, S);
+template isCopyable(S)
+{
+    enum isCopyable_old = is(typeof({ S foo = S.init; S copy = foo; }));
+    enum isCopyable = __traits(isCopyable, S);
+    static assert(isCopyable_old is isCopyable, "New builtin trait isCopyable differs from old for type " ~ S.stringof);
+}
 
 ///
 @safe unittest


### PR DESCRIPTION
By looking at the build errors in the calls to `std.conv.to` I reckon I didn't manage to exactly mimic the current definition of `std.traits.isCopyable` in dmd's definition of `__traits(isCopyable)`. Any clues on how to detect these discrepancies?

Add `static assert` inside the current definition `std.traits.isCopyable` that checks that `__traits(isCopyable)` equals `std.traits.isCopyable` is a way forward. I'll try that.