### PR TITLE
Eliminate the need for shared static this() on Posix

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -79,6 +79,13 @@ version (Windows)
     {
         return WSAGetLastError();
     }
+
+    immutable
+    {
+        typeof(&getnameinfo) getnameinfoPointer;
+        typeof(&getaddrinfo) getaddrinfoPointer;
+        typeof(&freeaddrinfo) freeaddrinfoPointer;
+    }
 }
 else version (Posix)
 {
@@ -120,6 +127,10 @@ else version (Posix)
     {
         return errno;
     }
+
+    enum getnameinfoPointer = &getnameinfo;
+    enum getaddrinfoPointer = &getaddrinfo;
+    enum freeaddrinfoPointer = &freeaddrinfo;
 }
 else
 {
@@ -289,20 +300,6 @@ bool wouldHaveBlocked() nothrow @nogc
     assert(rec == -1 && wouldHaveBlocked());
 }
 
-
-version (Windows)
-{
-    private: immutable:
-    typeof(&getnameinfo) getnameinfoPointer;
-    typeof(&getaddrinfo) getaddrinfoPointer;
-    typeof(&freeaddrinfo) freeaddrinfoPointer;
-}
-else version (Posix)
-{
-    enum getnameinfoPointer = &getnameinfo;
-    enum getaddrinfoPointer = &getaddrinfo;
-    enum freeaddrinfoPointer = &freeaddrinfo;
-}
 
 version (Windows)
 {


### PR DESCRIPTION
It would be great if we could eliminate all static ctors/dtors from Phobos and use lazy initialization instead. This PR is a simple step in that direction - there's really no need to initialize those pointers to function (or test them) in Posix.