### PR TITLE
Issue 17712 - Add tests & Revert std.conv.toChars workaround for dmd link error

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -124,6 +124,21 @@ publictests()
     # run -betterC tests
     make -f posix.mak test_extractor # build in single-threaded mode
     make -f posix.mak -j$N betterc
+
+    # independent tests
+    test_other
+}
+
+# FIXME: tests should run in parallel
+test_other()
+{
+    pushd test
+    TEST_FILES=compilable/*.d
+    for F in $TEST_FILES; do
+        echo Building $F
+        $DMD $F || exit 1
+    done
+    popd
 }
 
 # test stdx dub package

--- a/test/compilable/b17712.d
+++ b/test/compilable/b17712.d
@@ -1,0 +1,40 @@
+void main(){}
+// https://issues.dlang.org/show_bug.cgi?id=17712
+
+struct Bytecode
+{
+    uint data;
+}
+
+@trusted ctSub(U)(string format, U args)
+{
+    import std.conv : to;
+    foreach (i; format)
+        return  format~ to!string(args);
+    return format;
+}
+
+struct CtContext
+{
+    import std.uni : CodepointSet;
+
+    CodepointSet[] charsets;
+
+    string ctAtomCode(Bytecode[] ir)
+    {
+        string code;
+        switch (code)
+        {
+            OrChar:
+                code ~=  ``;
+                for (uint i ; i ;)
+                    code ~= ctSub(``, ir[i].data);
+                charsets[ir[0].data].toSourceCode;
+                break;
+
+            default:
+                assert(0);
+        }
+        return code;
+    }
+}

--- a/test/compilable/b17712_c13.d
+++ b/test/compilable/b17712_c13.d
@@ -1,0 +1,54 @@
+// https://issues.dlang.org/show_bug.cgi?id=17712#c13
+
+import std.datetime;
+import std.typecons;
+import std.variant;
+
+
+Y a()
+{
+    Y n = Y(Y[].init);
+
+    n.get!(X[]);
+    return n;
+}
+
+struct X
+{
+    Y key;
+}
+struct Y
+{
+    Algebraic!(Y[]) value_;
+    this(T)(T value)
+    {
+        value_ = value;
+    }
+    bool opEquals(T)(T rhs) const
+    {
+        static if(is(Unqual!T == Y))
+        {
+            return true;
+        }
+        else
+        {
+            return get!(T, No.x) == get!T;
+        }
+    }
+    T get(T, Flag!"x" x = Yes.x)() const
+    {
+        return this[""].get!(T, x);
+    }
+
+    Y opIndex(T)(T index) const
+    {
+        const X[] pairs;
+        if(pairs[0].key == index)
+        {
+            assert(0);
+        }
+        assert(0);
+    }
+}
+
+void main(){}


### PR DESCRIPTION
Draft for now. ~~Once the test cases in https://github.com/dlang/dmd/pull/11300 are merged~~ This pull now contains the tests, which use Phobos. I had to edit `test/run.sh` to run them.

The dmd bug for the `b17712_c13.d` test case has been fixed in dlang/dmd#9636.
The original test case is still unfixed in dmd. The workaround in `std.conv.text`, added in #6659 causes unnecessary allocations when there are multiple arguments and >0 integer arguments.

Undefined reference to `std.conv.toChars!(10, char, 1, uint).toChars(uint)`:
https://issues.dlang.org/show_bug.cgi?id=17712