### PR TITLE
[stable] std.math: Remove accidental public AliasSeq import

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -133,9 +133,6 @@ static import core.stdc.fenv;
 import std.traits :  CommonType, isFloatingPoint, isIntegral, isNumeric,
     isSigned, isUnsigned, Largest, Unqual;
 
-// Note: Exposed accidentally, should be deprecated / removed
-public import std.meta : AliasSeq;
-
 version (DigitalMars)
 {
     version = INLINE_YL2X;        // x87 has opcodes for these


### PR DESCRIPTION
This wasn't in 2.092.x, so better get rid of this ASAP.