### PR TITLE
Make CowArray.freeThisReference @safe

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -3373,7 +3373,7 @@ private:
         }
         else
             SP.destroy(data);
-        assert(!data.ptr);
+        assert(!&data[0]);
     }
 
     void dupThisReference(uint count)


### PR DESCRIPTION
This is needed for my build to pass when dmd flag `-checkaction=context` is used in my dub project.

Currently, the line

dflags "-checkaction=context"

in `dub.sdl` makes build error as

```
/home/per/.local/dlang/linux/bin64/src/phobos/std/uni/package.d(3376,17): Error: `this.data.ptr` cannot be used in `@safe` code, use `&this.data[0]` instead
/home/per/.local/dlang/linux/bin64/src/phobos/std/uni/package.d(2128,29): Error: template instance `std.uni.CowArray!(GcPolicy).CowArray.__ctor!(uint[])` error instantiating
/home/per/.local/dlang/linux/bin64/src/phobos/std/uni/package.d(2137,32):        instantiated from here: `__ctor!()`
/home/per/.local/dlang/linux/bin64/src/phobos/std/uni/package.d(1956,29):        instantiated from here: `InversionList!(GcPolicy)`
```

I can replace more of the `.ptr` statements if someone feels the need to.