### PR TITLE
Fix public examples failing due to missing imports

### DIFF
--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -480,6 +480,8 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     ///
     static if (is(T == int) && is(Hook == void)) @safe unittest
     {
+        import std.traits : isUnsigned;
+
         static struct MyHook
         {
             static bool thereWereErrors;
@@ -616,6 +618,8 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     ///
     static if (is(T == int) && is(Hook == void)) @safe unittest
     {
+        import std.traits : isUnsigned;
+
         static struct MyHook
         {
             static bool thereWereErrors;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -591,6 +591,7 @@ if (distinctFieldNames!(Specs))
         ///
         static if (Specs.length == 0) @safe unittest
         {
+            import std.meta : AliasSeq;
             alias Fields = Tuple!(int, "id", string, float);
             static assert(is(Fields.Types == AliasSeq!(int, string, float)));
         }
@@ -603,6 +604,7 @@ if (distinctFieldNames!(Specs))
         ///
         static if (Specs.length == 0) @safe unittest
         {
+            import std.meta : AliasSeq;
             alias Fields = Tuple!(int, "id", string, float);
             static assert(Fields.fieldNames == AliasSeq!("id", "", ""));
         }
@@ -992,7 +994,7 @@ if (distinctFieldNames!(Specs))
             t2 = tuple(3,4,5);
             auto t2Named = t2.rename!("", "b");
             // "a" no longer has a name
-            static assert(!hasMember!(typeof(t2Named), "a"));
+            static assert(!__traits(hasMember, typeof(t2Named), "a"));
             assert(t2Named[0] == 3);
             assert(t2Named.b == 4);
             assert(t2Named.c == 5);


### PR DESCRIPTION
Seems like those test weren't checked before the recent improvements to `test_extractor.d`. Not sure why the CI didn't fail for those PR's though ...