### PR TITLE
unsignedToTempString: use the template version

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5790,12 +5790,12 @@ if (isIntegral!T && isOutputRange!(W, char))
     if (value < 0)
     {
         SignedStringBuf buf = void;
-        put(writer, signedToTempString(value, buf, 10));
+        put(writer, signedToTempString(value, buf));
     }
     else
     {
         UnsignedStringBuf buf = void;
-        put(writer, unsignedToTempString(value, buf, 10));
+        put(writer, unsignedToTempString(value, buf));
     }
 }
 

--- a/std/random.d
+++ b/std/random.d
@@ -929,7 +929,7 @@ Parameters for the generator.
 
             UnsignedStringBuf buf = void;
             string s = "MersenneTwisterEngine.seed: Input range didn't provide enough elements: Need ";
-            s ~= unsignedToTempString(n, buf, 10) ~ " elements.";
+            s ~= unsignedToTempString(n, buf) ~ " elements.";
             throw new Exception(s);
         }
 

--- a/std/utf.d
+++ b/std/utf.d
@@ -107,7 +107,7 @@ class UTFException : UnicodeException
          size_t line = __LINE__, Throwable next = null) @safe pure nothrow
     {
         UnsignedStringBuf buf = void;
-        msg ~= " (at index " ~ unsignedToTempString(index, buf, 10) ~ ")";
+        msg ~= " (at index " ~ unsignedToTempString(index, buf) ~ ")";
         super(msg, index, file, line, next);
     }
 
@@ -133,7 +133,7 @@ class UTFException : UnicodeException
         {
             UnsignedStringBuf buf = void;
             result ~= ' ';
-            auto h = unsignedToTempString(i, buf, 16);
+            auto h = unsignedToTempString!16(i, buf);
             if (h.length == 1)
                 result ~= '0';
             result ~= h;


### PR DESCRIPTION
Companion to https://github.com/dlang/druntime/pull/3169. After this, the old functions in there can be removed.