### PR TITLE
Reduce default template instantiations

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -1508,7 +1508,7 @@ private:
     T* arr;
 }
 
-@safe pure unittest
+@safe pure nothrow @nogc unittest
 {
     static assert(isRandomAccessRange!(SliceOverIndexed!(int[])));
 }
@@ -5606,7 +5606,7 @@ struct sliceBits(size_t from, size_t to)
 alias lo8 = assumeSize!(low_8, 8);
 alias mlo8 = assumeSize!(midlow_8, 8);
 
-@safe pure unittest
+@safe pure nothrow @nogc unittest
 {
     static assert(bitSizeOf!lo8 == 8);
     static assert(bitSizeOf!(sliceBits!(4, 7)) == 3);
@@ -5925,7 +5925,7 @@ pure:
     @property DecompressedIntervals save() { return this; }
 }
 
-@safe pure unittest
+@safe pure nothrow @nogc unittest
 {
     static assert(isInputRange!DecompressedIntervals);
     static assert(isForwardRange!DecompressedIntervals);

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -1508,7 +1508,10 @@ private:
     T* arr;
 }
 
-static assert(isRandomAccessRange!(SliceOverIndexed!(int[])));
+@safe pure unittest
+{
+    static assert(isRandomAccessRange!(SliceOverIndexed!(int[])));
+}
 
 SliceOverIndexed!(const(T)) sliceOverIndexed(T)(size_t a, size_t b, const(T)* x)
 if (is(Unqual!T == T))
@@ -5603,9 +5606,12 @@ struct sliceBits(size_t from, size_t to)
 alias lo8 = assumeSize!(low_8, 8);
 alias mlo8 = assumeSize!(midlow_8, 8);
 
-static assert(bitSizeOf!lo8 == 8);
-static assert(bitSizeOf!(sliceBits!(4, 7)) == 3);
-static assert(bitSizeOf!(BitPacked!(uint, 2)) == 2);
+@safe pure unittest
+{
+    static assert(bitSizeOf!lo8 == 8);
+    static assert(bitSizeOf!(sliceBits!(4, 7)) == 3);
+    static assert(bitSizeOf!(BitPacked!(uint, 2)) == 2);
+}
 
 template Sequence(size_t start, size_t end)
 {
@@ -5919,8 +5925,12 @@ pure:
     @property DecompressedIntervals save() { return this; }
 }
 
-static assert(isInputRange!DecompressedIntervals);
-static assert(isForwardRange!DecompressedIntervals);
+@safe pure unittest
+{
+    static assert(isInputRange!DecompressedIntervals);
+    static assert(isForwardRange!DecompressedIntervals);
+}
+
 //============================================================================
 
 version (std_uni_bootstrap){}


### PR DESCRIPTION
Wrap static assert assert in unittests. std.uni seems to be only one that has any of these.

More to come.

Discovered by compiling `import std;` with https://github.com/dlang/dmd/pull/11463.