### PR TITLE
Replace Unqual-based idiom with immutable-based idiom

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1955,7 +1955,7 @@ if (isInputRange!RoR &&
     // This converts sep to an array (forward range) if it isn't one,
     // and makes sure it has the same string encoding for string types.
     static if (isSomeString!RetType &&
-               !is(RetTypeElement == Unqual!(ElementEncodingType!R)))
+               !is(immutable ElementEncodingType!RetType == immutable ElementEncodingType!R))
     {
         import std.conv : to;
         auto sepArr = to!RetType(sep);

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3251,7 +3251,7 @@ if (isFloatOrDouble!T && n == T.sizeof)
 private template isFloatOrDouble(T)
 {
     enum isFloatOrDouble = isFloatingPoint!T &&
-                           !is(Unqual!(FloatingPointTypeOf!T) == real);
+                           !is(immutable FloatingPointTypeOf!T == immutable real);
 }
 
 @safe unittest

--- a/std/format.d
+++ b/std/format.d
@@ -2719,7 +2719,7 @@ useSnprintf:
         if (fs.flHash) sprintfSpec[i++] = '#';
         sprintfSpec[i .. i + 3] = "*.*";
         i += 3;
-        if (is(Unqual!(typeof(val)) == real)) sprintfSpec[i++] = 'L';
+        if (is(immutable typeof(val) == immutable real)) sprintfSpec[i++] = 'L';
         sprintfSpec[i++] = spec2;
         sprintfSpec[i] = 0;
         //printf("format: '%s'; geeba: %g\n", sprintfSpec.ptr, val);
@@ -2953,7 +2953,7 @@ useSnprintf:
  */
 deprecated("Use of complex types is deprecated. Use std.complex")
 private void formatValueImpl(Writer, T, Char)(auto ref Writer w, T obj, scope const ref FormatSpec!Char f)
-if (is(Unqual!T : creal) && !is(T == enum) && !hasToString!(T, Char))
+if (is(immutable T : immutable creal) && !is(T == enum) && !hasToString!(T, Char))
 {
     immutable creal val = obj;
 
@@ -3009,7 +3009,7 @@ deprecated
  */
 deprecated("Use of imaginary types is deprecated. Use std.complex")
 private void formatValueImpl(Writer, T, Char)(auto ref Writer w, T obj, scope const ref FormatSpec!Char f)
-if (is(Unqual!T : ireal) && !is(T == enum) && !hasToString!(T, Char))
+if (is(immutable T : immutable ireal) && !is(T == enum) && !hasToString!(T, Char))
 {
     immutable ireal val = obj;
 

--- a/std/random.d
+++ b/std/random.d
@@ -902,7 +902,7 @@ Parameters for the generator.
    `Exception` if the InputRange didn't provide enough elements to seed the generator.
    The number of elements required is the 'n' template parameter of the MersenneTwisterEngine struct.
  */
-    void seed(T)(T range) if (isInputRange!T && is(Unqual!(ElementType!T) == UIntType))
+    void seed(T)(T range) if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
     {
         this.seedImpl(range, this.state);
     }
@@ -912,7 +912,7 @@ Parameters for the generator.
        which can be used with an arbitrary `State` instance
     */
     private static void seedImpl(T)(T range, ref State mtState)
-        if (isInputRange!T && is(Unqual!(ElementType!T) == UIntType))
+        if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
     {
         size_t j;
         for (j = 0; j < n && !range.empty; ++j, range.popFront())

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2241,7 +2241,7 @@ Allows to directly use range operations on lines of a file.
                     else static if (isArray!Terminator)
                     {
                         static assert(
-                            is(Unqual!(ElementEncodingType!Terminator) == Char));
+                            is(immutable ElementEncodingType!Terminator == immutable Char));
                         const tlen = terminator.length;
                     }
                     else
@@ -2324,7 +2324,7 @@ the contents may well have changed).
 /// ditto
     auto byLine(Terminator, Char = char)
             (KeepTerminator keepTerminator, Terminator terminator)
-    if (is(Unqual!(ElementEncodingType!Terminator) == Char))
+    if (is(immutable ElementEncodingType!Terminator == immutable Char))
     {
         return ByLineImpl!(Char, Terminator)(this, keepTerminator, terminator);
     }

--- a/std/variant.d
+++ b/std/variant.d
@@ -457,7 +457,7 @@ private:
 
         case OpID.index:
             auto result = cast(Variant*) parm;
-            static if (isArray!(A) && !is(Unqual!(typeof(A.init[0])) == void))
+            static if (isArray!(A) && !is(immutable typeof(A.init[0]) == immutable void))
             {
                 // array type; input and output are the same VariantN
                 size_t index = result.convertsTo!(int)
@@ -497,7 +497,7 @@ private:
             }
 
         case OpID.catAssign:
-            static if (!is(Unqual!(typeof((*zis)[0])) == void) && is(typeof((*zis)[0])) && is(typeof((*zis) ~= *zis)))
+            static if (!is(immutable typeof((*zis)[0]) == immutable void) && is(typeof((*zis)[0])) && is(typeof((*zis) ~= *zis)))
             {
                 // array type; parm is the element to append
                 auto arg = cast(Variant*) parm;
@@ -923,9 +923,9 @@ public:
 
     // returns 1 if the two are equal
     bool opEquals(T)(auto ref T rhs) const
-    if (allowed!T || is(Unqual!T == VariantN))
+    if (allowed!T || is(immutable T == immutable VariantN))
     {
-        static if (is(Unqual!T == VariantN))
+        static if (is(immutable T == immutable VariantN))
             alias temp = rhs;
         else
             auto temp = VariantN(rhs);

--- a/std/variant.d
+++ b/std/variant.d
@@ -497,7 +497,8 @@ private:
             }
 
         case OpID.catAssign:
-            static if (!is(immutable typeof((*zis)[0]) == immutable void) && is(typeof((*zis)[0])) && is(typeof((*zis) ~= *zis)))
+            static if (!is(immutable typeof((*zis)[0]) == immutable void) &&
+                    is(typeof((*zis)[0])) && is(typeof(*zis ~= *zis)))
             {
                 // array type; parm is the element to append
                 auto arg = cast(Variant*) parm;


### PR DESCRIPTION
Aplying `immutable` to `T` makes it `immutable T` regardless of whatever qualifiers `T` has. This allows for a simple idiom for type comparison, per this PR.