### PR TITLE
Fix 21131 -- proper handling of non-dchar appending to Appender!wstring and Appender!dstring

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3501,6 +3501,17 @@ if (isDynamicArray!A)
             //We do this at the end, in case of exceptions
             _data.arr = bigData;
         }
+        else static if (isSomeChar!T && isSomeChar!(ElementType!Range) &&
+                        !is(immutable T == immutable ElementType!Range))
+        {
+            // need to decode and encode
+            import std.utf : decodeFront;
+            while (!items.empty)
+            {
+                auto c = items.decodeFront;
+                put(c);
+            }
+        }
         else
         {
             //pragma(msg, Range.stringof);
@@ -3715,6 +3726,16 @@ if (isDynamicArray!A)
     auto result = appender[][0];
 
     assert(result.value != 23);
+}
+
+@safe unittest
+{
+    import std.conv : to;
+    import std.utf : byCodeUnit;
+    auto str = "ウェブサイト";
+    auto wstr = appender!wstring();
+    put(wstr, str.byCodeUnit);
+    assert(wstr.data == str.to!wstring);
 }
 
 //Calculates an efficient growth scheme based on the old capacity

--- a/std/utf.d
+++ b/std/utf.d
@@ -1221,7 +1221,7 @@ do
         // overloads of decodeImpl need it. So, it should be moved back into
         // decodeImpl once https://issues.dlang.org/show_bug.cgi?id=8521
         // has been fixed.
-        enum canIndex = isRandomAccessRange!S && hasSlicing!S && hasLength!S;
+        enum canIndex = is(S : const char[]) || isRandomAccessRange!S && hasSlicing!S && hasLength!S;
         immutable retval = decodeImpl!(canIndex, useReplacementDchar)(cast(TypeForDecode!S) str, numCodeUnits);
 
         // The other range types were already popped by decodeImpl.


### PR DESCRIPTION
~~This fails on my local machine, but I wanted to see if the auto tester has the same issue. I can't reproduce it outside of this environment, and it makes no sense why it's failing.~~

Turns out my local failure is in master as well, if you do `make -f posix.mak std/array.test`, so this should still pass.