### PR TITLE
fix issue 21148, possible failure of CI when testing nano precision of file time stamps

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1913,8 +1913,8 @@ else version (Posix)
 //
 // Note: on linux systems, although in theory a change to a file date
 // can be tracked with precision of 4 msecs, this test waits 20 msecs
-// to prevent possible problems relative to the CI services the dlang uses, 
-// as they may have the HZ setting that controls the software clock set to 100 
+// to prevent possible problems relative to the CI services the dlang uses,
+// as they may have the HZ setting that controls the software clock set to 100
 // (instead of the more common 250).
 // see https://man7.org/linux/man-pages/man7/time.7.html
 //     https://stackoverflow.com/a/14393315,

--- a/std/file.d
+++ b/std/file.d
@@ -1915,7 +1915,7 @@ else version (Posix)
 // can be tracked with precision of 4 msecs, this test waits 20 msecs
 // to prevent possible problems relative to the CI services the dlang uses, 
 // as they may have the HZ setting that controls the software clock set to 100 
-// (instead of the more more common 250).
+// (instead of the more common 250).
 // see https://man7.org/linux/man-pages/man7/time.7.html
 //     https://stackoverflow.com/a/14393315,
 //     https://issues.dlang.org/show_bug.cgi?id=21148

--- a/std/file.d
+++ b/std/file.d
@@ -1928,7 +1928,7 @@ version (OSX) {} else
         remove(deleteme);
         assert(time != lastTime);
         lastTime = time;
-        Thread.sleep(10.msecs);
+        Thread.sleep(20.msecs);
     }
 }
 

--- a/std/file.d
+++ b/std/file.d
@@ -1910,6 +1910,15 @@ else version (Posix)
 //   vfs.timestamp_precision sysctl to a value greater than zero.
 // - OS X, where the native filesystem (HFS+) stores filesystem
 //   timestamps with 1-second precision.
+//
+// Note: on linux systems, although in theory a change to a file date
+// can be tracked with precision of 4 msecs, this test waits 20 msecs
+// to prevent possible problems relative to the CI services the dlang uses, 
+// as they may have the HZ setting that controls the software clock set to 100 
+// (instead of the more more common 250).
+// see https://man7.org/linux/man-pages/man7/time.7.html
+//     https://stackoverflow.com/a/14393315,
+//     https://issues.dlang.org/show_bug.cgi?id=21148
 version (FreeBSD) {} else
 version (DragonFlyBSD) {} else
 version (OSX) {} else


### PR DESCRIPTION
from man time:

```
       The software clock, HZ, and jiffies
       The accuracy of various system calls that set timeouts, (e.g.,
       select(2), sigtimedwait(2)) and measure CPU time (e.g., getrusage(2))
       is limited by the resolution of the software clock, a clock
       maintained by the kernel which measures time in jiffies.  The size of
       a jiffy is determined by the value of the kernel constant HZ.

       The value of HZ varies across kernel versions and hardware platforms.
       On i386 the situation is as follows: on kernels up to and including
       2.4.x, HZ was 100, giving a jiffy value of 0.01 seconds; starting
       with 2.6.0, HZ was raised to 1000, giving a jiffy of 0.001 seconds.
       Since kernel 2.6.13, the HZ value is a kernel configuration parameter
       and can be **100**, 250 (the default) or 1000, yielding a jiffies value
       of, respectively, 0.01, 0.004, or 0.001 seconds.  Since kernel
       2.6.20, a further frequency is available: 300, a number that divides
       evenly for the common video frame rates (PAL, 25 HZ; NTSC, 30 HZ).

       The times(2) system call is a special case.  It reports times with a
       granularity defined by the kernel constant USER_HZ.  User-space
       applications can determine the value of this constant using
       sysconf(_SC_CLK_TCK).
```
TL;DR

If the kernel setting for the software clock frequency (HZ) is set to 100, we got 10 msec resolution. CIs being on VMs we cant control it's better to assume that the setting can be set to this worst value, so test with a value greater than 10 msecs.