### PR TITLE
Fix issue 7033: File.rawWrite is slow on Windows

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1077,6 +1077,12 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
         {
             immutable fd = ._fileno(_p.handle);
             immutable oldMode = ._setmode(fd, _O_BINARY);
+
+            version (DIGITAL_MARS_STDIO)
+            {
+                immutable info = __fhnd_info[fd];
+            }
+
             
             if (oldMode != _O_BINARY)
             {
@@ -1089,8 +1095,7 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
                 {
                     import core.atomic : atomicOp;
 
-                    // https://issues.dlang.org/show_bug.cgi?id=4243
-                    immutable info = __fhnd_info[fd];
+                    // https://issues.dlang.org/show_bug.cgi?id=4243 
                     atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT); 
                 }
             } 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -417,8 +417,8 @@ struct File
     }
 
     /**
-        Parses an open mode string where each mode is stored as a flag in
-        _p.openModeFlags.
+        Parses an open mode string where each specified mode is stored as a
+        flag in _p.openModeFlags.
 
         This function doesn't check if the string is invalid (e.g. nonsensical
         combinations); it merely returns if an unknown character is found.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -400,10 +400,10 @@ struct File
     package this(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted
     {
         import core.stdc.stdlib : malloc;
-        import std.exception : enforce; 
+        import std.exception : enforce;
         assert(!_p);
         _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
-        initImpl(handle, name, refs, isPopened); 
+        initImpl(handle, name, refs, isPopened);
     }
 
     private void initImpl(FILE* handle, string name, uint refs = 1, bool isPopened = false)
@@ -476,12 +476,12 @@ Throws: `ErrnoException` if the file could not be opened.
     this(string name, scope const(char)[] stdioOpenmode = "rb") @safe
     {
         import std.conv : text;
-        import std.exception : errnoEnforce; 
+        import std.exception : errnoEnforce;
 
         this(errnoEnforce(_fopen(name, stdioOpenmode),
                         text("Cannot open file `", name, "' in mode `",
                                 stdioOpenmode, "'")),
-                name); 
+                name);
 
         // MSVCRT workaround (issue 14422)
         version (MICROSOFT_STDIO)
@@ -520,7 +520,7 @@ Throws: `ErrnoException` if the file could not be opened.
     }
 
     ~this() @safe
-    { 
+    {
         detach();
     }
 
@@ -561,7 +561,7 @@ Throws: `ErrnoException` in case of error.
  */
     void open(string name, scope const(char)[] stdioOpenmode = "rb") @trusted
     {
-        resetFile(name, stdioOpenmode, false); 
+        resetFile(name, stdioOpenmode, false);
     }
 
     // https://issues.dlang.org/show_bug.cgi?id=20585
@@ -778,7 +778,7 @@ Params:
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe
     {
-        fdopen(fd, stdioOpenmode, null); 
+        fdopen(fd, stdioOpenmode, null);
     }
 
     package void fdopen(int fd, scope const(char)[] stdioOpenmode, string name) @trusted

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1077,7 +1077,7 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
         {
             immutable fd = ._fileno(_p.handle);
             immutable oldMode = ._setmode(fd, _O_BINARY);
-            
+
             if (oldMode != _O_BINARY)
             {
                 // need to flush the data that was written with the original mode
@@ -1090,8 +1090,8 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
             {
                 import core.atomic : atomicOp;
 
-                immutable info = __fhnd_info[fd];
                 // https://issues.dlang.org/show_bug.cgi?id=4243
+                immutable info = __fhnd_info[fd];
                 atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT);
                 scope (exit) __fhnd_info[fd] = info;
             }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1084,16 +1084,16 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
                 ._setmode(fd, oldMode);
                 flush(); // before changing translation mode ._setmode(fd, _O_BINARY);
                 .setmode(fd, _O_BINARY);
-            }
 
-            version (DIGITAL_MARS_STDIO)
-            {
-                import core.atomic : atomicOp;
+                version (DIGITAL_MARS_STDIO)
+                {
+                    import core.atomic : atomicOp;
 
-                // https://issues.dlang.org/show_bug.cgi?id=4243
-                immutable info = __fhnd_info[fd];
-                atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT);
-                scope(exit) __fhnd_info[fd] = info;
+                    // https://issues.dlang.org/show_bug.cgi?id=4243
+                    immutable info = __fhnd_info[fd];
+                    atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT);
+                    scope(exit) __fhnd_info[fd] = info;
+                }
             } 
         }
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1091,8 +1091,7 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
 
                     // https://issues.dlang.org/show_bug.cgi?id=4243
                     immutable info = __fhnd_info[fd];
-                    atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT);
-                    scope(exit) __fhnd_info[fd] = info;
+                    atomicOp!"&="(__fhnd_info[fd], ~FHND_TEXT); 
                 }
             } 
         }
@@ -1109,6 +1108,12 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
             if (oldMode != _O_BINARY)
             {
                 flush();
+
+                version (DIGITAL_MARS_STDIO)
+                {
+                    __fhnd_info[fd] = info;
+                }
+
                 ._setmode(fd, oldMode);
             }
         }


### PR DESCRIPTION
To fix this issue, the newly added `openModeFlags` (and the enum `OpenMode` from which it's derived) is used to store the current open mode of a file. Thus, `rawWrite` can check if the file was already opened in binary mode to obviate temporarily changing the mode and thus executing two flushes.
A new method, `parseOpenModeString` is used to parse an open mode string, and it stores the desired open mode in `openModeFlags`. It's called in every method that changes a file's open mode. (See the documentation of this function for more information.)

I'd like your input on this, @schveiguy, since you asked to be notified about this.
