### PR TITLE
Change Socket constructor to accept its parameter by const scope

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2723,7 +2723,7 @@ public:
      * Create a blocking socket using the parameters from the specified
      * `AddressInfo` structure.
      */
-    this(in AddressInfo info)
+    this(const scope AddressInfo info)
     {
         this(info.family, info.type, info.protocol);
     }


### PR DESCRIPTION
This is the only occurence in Phobos where 'in' would get 'ref' applied.
Changing this ensures that users can use '-preview=in' in their code.

Ref: dlang/dmd#11000