### PR TITLE
structure SSSE3 array of constants

### DIFF
--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -122,18 +122,18 @@ version (USE_SSSE3)
     }
 
     /* The control words for the byte shuffle instruction and the round constants. */
-    align(16) public immutable uint[20] constants =
+    align(16) public immutable uint[4][5] constants =
     [
         // The control words for the byte shuffle instruction.
-        0x0001_0203, 0x0405_0607, 0x0809_0a0b, 0x0c0d_0e0f,
+        [ 0x0001_0203, 0x0405_0607, 0x0809_0a0b, 0x0c0d_0e0f ],
         // Constants for round 0-19
-        0x5a827999, 0x5a827999, 0x5a827999, 0x5a827999,
+        [ 0x5a827999, 0x5a827999, 0x5a827999, 0x5a827999 ],
         // Constants for round 20-39
-        0x6ed9eba1, 0x6ed9eba1, 0x6ed9eba1, 0x6ed9eba1,
+        [ 0x6ed9eba1, 0x6ed9eba1, 0x6ed9eba1, 0x6ed9eba1 ],
         // Constants for round 40-59
-        0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc,
+        [ 0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc ],
         // Constants for round 60-79
-        0xca62c1d6, 0xca62c1d6, 0xca62c1d6, 0xca62c1d6
+        [ 0xca62c1d6, 0xca62c1d6, 0xca62c1d6, 0xca62c1d6 ]
     ];
 
     /** Simple version to produce numbers < 100 as string. */


### PR DESCRIPTION
It may be hopeless to bring type safety to the internal assembler and retain backwards compatibility, but I'm going to try. The trouble with this one is using an array of uints to represent a 128 bit XMM value. The original set up is an array of 20 uints, and the fix is to make it an array of 5 4-uint values. One 4-uint value for 128 bits.

This is blocking https://github.com/dlang/dmd/pull/11570

If I can't make it work, I'll have to abandon fixing https://issues.dlang.org/show_bug.cgi?id=12832