### PR TITLE
Add -cov=ctfe to enable CTFE coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Run all public unittests
       - run:
           command: ./.circleci/run.sh coverage
-          name: Run Phobos testsuite with -cov
+          name: Run Phobos testsuite with -cov=ctfe
       - run:
           command: bash <(curl -s https://codecov.io/bash)
           name: Upload coverage files to CodeCov

--- a/posix.mak
+++ b/posix.mak
@@ -147,7 +147,7 @@ override DFLAGS += -O -release
 endif
 
 ifdef ENABLE_COVERAGE
-override DFLAGS  += -cov
+override DFLAGS  += -cov=ctfe
 endif
 
 ifdef NO_AUTODECODE
@@ -414,7 +414,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov -run $< ;     \
+	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov=ctfe -run $< ;     \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 

--- a/win32.mak
+++ b/win32.mak
@@ -420,91 +420,91 @@ unittest : $(LIB)
 #	dmc unittest.obj -g
 
 cov : $(SRC_TO_COMPILE) $(LIB)
-#	$(DMD) -conf= -cov $(UDFLAGS) -ofcov.exe -main $(SRC_TO_COMPILE) $(LIB)
+#	$(DMD) -conf= -cov=ctfe -cov $(UDFLAGS) -ofcov.exe -main $(SRC_TO_COMPILE) $(LIB)
 #	cov
 	del *.lst
-	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\stdio.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\string.d
-	$(DMD) -conf= -cov=71 $(UDFLAGS) -main -run std\format.d
-	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\file.d
-	$(DMD) -conf= -cov=86 $(UDFLAGS) -main -run std\range\package.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\array.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\functional.d
-	$(DMD) -conf= -cov=96 $(UDFLAGS) -main -run std\path.d
-	$(DMD) -conf= -cov=41 $(UDFLAGS) -main -run std\outbuffer.d
-	$(DMD) -conf= -cov=89 $(UDFLAGS) -main -run std\utf.d
-	$(DMD) -conf= -cov=93 $(UDFLAGS) -main -run std\csv.d
-	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\math.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\complex.d
-	$(DMD) -conf= -cov=70 $(UDFLAGS) -main -run std\numeric.d
-	$(DMD) -conf= -cov=94 $(UDFLAGS) -main -run std\bigint.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\bitmanip.d
-	$(DMD) -conf= -cov=82 $(UDFLAGS) -main -run std\typecons.d
-	$(DMD) -conf= -cov=44 $(UDFLAGS) -main -run std\uni\package.d
-	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\base64.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\ascii.d
-	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\demangle.d
-	$(DMD) -conf= -cov=57 $(UDFLAGS) -main -run std\uri.d
-	$(DMD) -conf= -cov=51 $(UDFLAGS) -main -run std\mmfile.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\getopt.d
-	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\signals.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\meta.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\typetuple.d
-	$(DMD) -conf= -cov=85 $(UDFLAGS) -main -run std\traits.d
-	$(DMD) -conf= -cov=62 $(UDFLAGS) -main -run std\encoding.d
-	$(DMD) -conf= -cov=61 $(UDFLAGS) -main -run std\xml.d
-	$(DMD) -conf= -cov=79 $(UDFLAGS) -main -run std\random.d
-	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\exception.d
-	$(DMD) -conf= -cov=73 $(UDFLAGS) -main -run std\concurrency.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\date.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\interval.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\package.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\stopwatch.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\systime.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\datetime\timezone.d
-	$(DMD) -conf= -cov=96 $(UDFLAGS) -main -run std\uuid.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\crc.d
-	$(DMD) -conf= -cov=55 $(UDFLAGS) -main -run std\digest\sha.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\md.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\ripemd.d
-	$(DMD) -conf= -cov=75 $(UDFLAGS) -main -run std\digest\digest.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\digest\hmac.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\package.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\comparison.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\iteration.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\mutation.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\searching.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\setops.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\algorithm\sorting.d
-	$(DMD) -conf= -cov=83 $(UDFLAGS) -main -run std\variant.d
-	$(DMD) -conf= -cov=58 $(UDFLAGS) -main -run std\zlib.d
-	$(DMD) -conf= -cov=53 $(UDFLAGS) -main -run std\socket.d
-	$(DMD) -conf= -cov=95 $(UDFLAGS) -main -run std\container\array.d
-	$(DMD) -conf= -cov=68 $(UDFLAGS) -main -run std\container\binaryheap.d
-	$(DMD) -conf= -cov=91 $(UDFLAGS) -main -run std\container\dlist.d
-	$(DMD) -conf= -cov=93 $(UDFLAGS) -main -run std\container\rbtree.d
-	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\container\slist.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\container\util.d
-	$(DMD) -conf= -cov=100 $(UDFLAGS) -main -run std\container\package.d
-	$(DMD) -conf= -cov=90 $(UDFLAGS) -main -run std\conv.d
-	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\zip.d
-	$(DMD) -conf= -cov=77 $(UDFLAGS) -main -run std\regex\tests.d
-	$(DMD) -conf= -cov=77 $(UDFLAGS) -main -run std\regex\tests2.d
-	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\json.d
-	$(DMD) -conf= -cov=87 $(UDFLAGS) -main -run std\parallelism.d
-	$(DMD) -conf= -cov=50 $(UDFLAGS) -main -run std\mathspecial.d
-	$(DMD) -conf= -cov=71 $(UDFLAGS) -main -run std\process.d
-	$(DMD) -conf= -cov=70 $(UDFLAGS) -main -run std\net\isemail.d
-	$(DMD) -conf= -cov=2  $(UDFLAGS) -main -run std\net\curl.d
-	$(DMD) -conf= -cov=60 $(UDFLAGS) -main -run std\windows\registry.d
-	$(DMD) -conf= -cov=0  $(UDFLAGS) -main -run std\internal\digest\sha_SSSE3.d
-	$(DMD) -conf= -cov=50 $(UDFLAGS) -main -run std\internal\math\biguintcore.d
-	$(DMD) -conf= -cov=75 $(UDFLAGS) -main -run std\internal\math\biguintnoasm.d
-#	$(DMD) -conf= -cov $(UDFLAGS) -main -run std\internal\math\biguintx86.d
-	$(DMD) -conf= -cov=94 $(UDFLAGS) -main -run std\internal\math\gammafunction.d
-	$(DMD) -conf= -cov=92 $(UDFLAGS) -main -run std\internal\math\errorfunction.d
-	$(DMD) -conf= -cov=31 $(UDFLAGS) -main -run std\internal\windows\advapi32.d
-	$(DMD) -conf= -cov=58 $(UDFLAGS) -main -run etc\c\zlib.d
+	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\stdio.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\string.d
+	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\format.d
+	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\file.d
+	$(DMD) -conf= -cov=ctfe -cov=86 $(UDFLAGS) -main -run std\range\package.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\array.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\functional.d
+	$(DMD) -conf= -cov=ctfe -cov=96 $(UDFLAGS) -main -run std\path.d
+	$(DMD) -conf= -cov=ctfe -cov=41 $(UDFLAGS) -main -run std\outbuffer.d
+	$(DMD) -conf= -cov=ctfe -cov=89 $(UDFLAGS) -main -run std\utf.d
+	$(DMD) -conf= -cov=ctfe -cov=93 $(UDFLAGS) -main -run std\csv.d
+	$(DMD) -conf= -cov=ctfe -cov=91 $(UDFLAGS) -main -run std\math.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\complex.d
+	$(DMD) -conf= -cov=ctfe -cov=70 $(UDFLAGS) -main -run std\numeric.d
+	$(DMD) -conf= -cov=ctfe -cov=94 $(UDFLAGS) -main -run std\bigint.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\bitmanip.d
+	$(DMD) -conf= -cov=ctfe -cov=82 $(UDFLAGS) -main -run std\typecons.d
+	$(DMD) -conf= -cov=ctfe -cov=44 $(UDFLAGS) -main -run std\uni\package.d
+	$(DMD) -conf= -cov=ctfe -cov=91 $(UDFLAGS) -main -run std\base64.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\ascii.d
+	$(DMD) -conf= -cov=ctfe -cov=0  $(UDFLAGS) -main -run std\demangle.d
+	$(DMD) -conf= -cov=ctfe -cov=57 $(UDFLAGS) -main -run std\uri.d
+	$(DMD) -conf= -cov=ctfe -cov=51 $(UDFLAGS) -main -run std\mmfile.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\getopt.d
+	$(DMD) -conf= -cov=ctfe -cov=92 $(UDFLAGS) -main -run std\signals.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\meta.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\typetuple.d
+	$(DMD) -conf= -cov=ctfe -cov=85 $(UDFLAGS) -main -run std\traits.d
+	$(DMD) -conf= -cov=ctfe -cov=62 $(UDFLAGS) -main -run std\encoding.d
+	$(DMD) -conf= -cov=ctfe -cov=61 $(UDFLAGS) -main -run std\xml.d
+	$(DMD) -conf= -cov=ctfe -cov=79 $(UDFLAGS) -main -run std\random.d
+	$(DMD) -conf= -cov=ctfe -cov=92 $(UDFLAGS) -main -run std\exception.d
+	$(DMD) -conf= -cov=ctfe -cov=73 $(UDFLAGS) -main -run std\concurrency.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\date.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\interval.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\package.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\stopwatch.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\systime.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\datetime\timezone.d
+	$(DMD) -conf= -cov=ctfe -cov=96 $(UDFLAGS) -main -run std\uuid.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\digest\crc.d
+	$(DMD) -conf= -cov=ctfe -cov=55 $(UDFLAGS) -main -run std\digest\sha.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\digest\md.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\digest\ripemd.d
+	$(DMD) -conf= -cov=ctfe -cov=75 $(UDFLAGS) -main -run std\digest\digest.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\digest\hmac.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\package.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\comparison.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\iteration.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\mutation.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\searching.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\setops.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\sorting.d
+	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\variant.d
+	$(DMD) -conf= -cov=ctfe -cov=58 $(UDFLAGS) -main -run std\zlib.d
+	$(DMD) -conf= -cov=ctfe -cov=53 $(UDFLAGS) -main -run std\socket.d
+	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\container\array.d
+	$(DMD) -conf= -cov=ctfe -cov=68 $(UDFLAGS) -main -run std\container\binaryheap.d
+	$(DMD) -conf= -cov=ctfe -cov=91 $(UDFLAGS) -main -run std\container\dlist.d
+	$(DMD) -conf= -cov=ctfe -cov=93 $(UDFLAGS) -main -run std\container\rbtree.d
+	$(DMD) -conf= -cov=ctfe -cov=92 $(UDFLAGS) -main -run std\container\slist.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\container\util.d
+	$(DMD) -conf= -cov=ctfe -cov=100 $(UDFLAGS) -main -run std\container\package.d
+	$(DMD) -conf= -cov=ctfe -cov=90 $(UDFLAGS) -main -run std\conv.d
+	$(DMD) -conf= -cov=ctfe -cov=0  $(UDFLAGS) -main -run std\zip.d
+	$(DMD) -conf= -cov=ctfe -cov=77 $(UDFLAGS) -main -run std\regex\tests.d
+	$(DMD) -conf= -cov=ctfe -cov=77 $(UDFLAGS) -main -run std\regex\tests2.d
+	$(DMD) -conf= -cov=ctfe -cov=92 $(UDFLAGS) -main -run std\json.d
+	$(DMD) -conf= -cov=ctfe -cov=87 $(UDFLAGS) -main -run std\parallelism.d
+	$(DMD) -conf= -cov=ctfe -cov=50 $(UDFLAGS) -main -run std\mathspecial.d
+	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\process.d
+	$(DMD) -conf= -cov=ctfe -cov=70 $(UDFLAGS) -main -run std\net\isemail.d
+	$(DMD) -conf= -cov=ctfe -cov=2  $(UDFLAGS) -main -run std\net\curl.d
+	$(DMD) -conf= -cov=ctfe -cov=60 $(UDFLAGS) -main -run std\windows\registry.d
+	$(DMD) -conf= -cov=ctfe -cov=0  $(UDFLAGS) -main -run std\internal\digest\sha_SSSE3.d
+	$(DMD) -conf= -cov=ctfe -cov=50 $(UDFLAGS) -main -run std\internal\math\biguintcore.d
+	$(DMD) -conf= -cov=ctfe -cov=75 $(UDFLAGS) -main -run std\internal\math\biguintnoasm.d
+#	$(DMD) -conf= -cov=ctfe -cov $(UDFLAGS) -main -run std\internal\math\biguintx86.d
+	$(DMD) -conf= -cov=ctfe -cov=94 $(UDFLAGS) -main -run std\internal\math\gammafunction.d
+	$(DMD) -conf= -cov=ctfe -cov=92 $(UDFLAGS) -main -run std\internal\math\errorfunction.d
+	$(DMD) -conf= -cov=ctfe -cov=31 $(UDFLAGS) -main -run std\internal\windows\advapi32.d
+	$(DMD) -conf= -cov=ctfe -cov=58 $(UDFLAGS) -main -run etc\c\zlib.d
 
 ######################################################
 


### PR DESCRIPTION
Makes coverage reports more accurate now that it can trace CTFE.

EDIT:
CodeCov reports an _enormous_ increase of ~0.9%...