### PR TITLE
Revert "std.traits: Adapt unittest to pass with `-preview=in`"

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5180,10 +5180,10 @@ enum isAssignable(Lhs, Rhs = Lhs) = isRvalueAssignable!(Lhs, Rhs) && isLvalueAss
 }
 
 // ditto
-private enum isRvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, { lvalueOf!Lhs = rvalueOf!Rhs; });
+private enum isRvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, lvalueOf!Lhs = rvalueOf!Rhs);
 
 // ditto
-private enum isLvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, { lvalueOf!Lhs = lvalueOf!Rhs; });
+private enum isLvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, lvalueOf!Lhs = lvalueOf!Rhs);
 
 @safe unittest
 {
@@ -5219,26 +5219,11 @@ private enum isLvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, { lvalueOf!
     static assert( isAssignable!(S4, immutable int));
 
     struct S5 { @disable this(); @disable this(this); }
-
-    // `-preview=in` is enabled
-    static if (!is(typeof(mixin(q{(in ref int a) => a}))))
-    {
-        struct S6 { void opAssign(in S5); }
-
-        static assert(isRvalueAssignable!(S6, S5));
-        static assert(isLvalueAssignable!(S6, S5));
-        static assert(isAssignable!(S6, S5));
-        static assert(isAssignable!(S6, immutable S5));
-    }
-    else
-    {
-        mixin(q{ struct S6 { void opAssign(in ref S5); } });
-
-        static assert(!isRvalueAssignable!(S6, S5));
-        static assert( isLvalueAssignable!(S6, S5));
-        static assert(!isAssignable!(S6, S5));
-        static assert( isLvalueAssignable!(S6, immutable S5));
-    }
+    struct S6 { void opAssign(in ref S5); }
+    static assert(!isAssignable!(S6, S5));
+    static assert(!isRvalueAssignable!(S6, S5));
+    static assert( isLvalueAssignable!(S6, S5));
+    static assert( isLvalueAssignable!(S6, immutable S5));
 }
 
 


### PR DESCRIPTION
Reverts dlang/phobos#7609

Checking whether this PR broke the Buildkite sumtype build.