### PR TITLE
std.uuid.randomUUID() is insecure and has been deprecated

### DIFF
--- a/changelog/uuid_deprecation.dd
+++ b/changelog/uuid_deprecation.dd
@@ -1,0 +1,16 @@
+std.uuid.randomUUID() is insecure and has been deprecated
+
+The `randomUUID()` overload not taking any arguments has been deprecated.
+It is dangerous, as it causes predictable, non-secure UUIDs and has not been
+documented as doing that previously. Silently changing this function to use a secure
+system RNG is not possible, as these RNGs may block at early boot when they are
+not yet seeded, causing `randomUUID` to block as well.
+See $(LINK2 https://forum.dlang.org/thread/zjmyxudvscfwrkrdabmt@forum.dlang.org, this forum thread)
+for a detailed discussion of the problem.
+
+Depending on whether the desired output needs to be cryptographically secure and
+considering the potential blocking problem, users should use `rndGen` (insecure)
+from std.random or a secure alternative like this:
+----------------------------
+auto insecureUUID = rndGen.randomUUID();
+----------------------------

--- a/std/process.d
+++ b/std/process.d
@@ -1597,6 +1597,9 @@ version (Posix) @system unittest
     assert(wait(spawnProcess(envProg.path, env, Config.newEnv)) == 6);
 }
 
+version (unittest)
+    import std.uuid;
+
 @system unittest // Stream redirection in spawnProcess().
 {
     import std.path : buildPath;
@@ -1615,11 +1618,11 @@ version (Posix) @system unittest
     // Pipes
     void testPipes(Config config)
     {
-        import std.file, std.uuid, core.thread, std.exception;
+        import std.file, core.thread, std.exception;
         auto pipei = pipe();
         auto pipeo = pipe();
         auto pipee = pipe();
-        auto done = buildPath(tempDir(), randomUUID().toString());
+        auto done = buildPath(tempDir(), rndGen.randomUUID().toString());
         auto pid = spawnProcess([prog.path, "foo", "bar", done],
                                     pipei.readEnd, pipeo.writeEnd, pipee.writeEnd, null, config);
         pipei.writeEnd.writeln("input");
@@ -1636,15 +1639,15 @@ version (Posix) @system unittest
     // Files
     void testFiles(Config config)
     {
-        import std.ascii, std.file, std.uuid, core.thread, std.exception;
-        auto pathi = buildPath(tempDir(), randomUUID().toString());
-        auto patho = buildPath(tempDir(), randomUUID().toString());
-        auto pathe = buildPath(tempDir(), randomUUID().toString());
+        import std.ascii, std.file, core.thread, std.exception;
+        auto pathi = buildPath(tempDir(), rndGen.randomUUID().toString());
+        auto patho = buildPath(tempDir(), rndGen.randomUUID().toString());
+        auto pathe = buildPath(tempDir(), rndGen.randomUUID().toString());
         std.file.write(pathi, "INPUT"~std.ascii.newline);
         auto filei = File(pathi, "r");
         auto fileo = File(patho, "w");
         auto filee = File(pathe, "w");
-        auto done = buildPath(tempDir(), randomUUID().toString());
+        auto done = buildPath(tempDir(), rndGen.randomUUID().toString());
         auto pid = spawnProcess([prog.path, "bar", "baz", done], filei, fileo, filee, null, config);
         if (config & Config.detached)
             while (!done.exists) Thread.sleep(10.msecs);
@@ -3271,10 +3274,9 @@ private string uniqueTempPath() @safe
 {
     import std.file : tempDir;
     import std.path : buildPath;
-    import std.uuid : randomUUID;
     // Path should contain spaces to test escaping whitespace
     return buildPath(tempDir(), "std.process temporary file " ~
-        randomUUID().toString());
+        rndGen.randomUUID().toString());
 }
 
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -11315,6 +11315,9 @@ that break its sorted-ness, `SortedRange` will work erratically.
     assert(s.groupBy.equal!equal([[100, 101, 102], [200, 201], [300]]));
 }
 
+version (unittest)
+    import std.uuid;
+
 // Test on an input range
 @system unittest
 {
@@ -11322,9 +11325,8 @@ that break its sorted-ness, `SortedRange` will work erratically.
     import std.file : exists, remove, tempDir;
     import std.path : buildPath;
     import std.stdio : File;
-    import std.uuid : randomUUID;
     auto name = buildPath(tempDir(), "test.std.range.line-" ~ text(__LINE__) ~
-                          "." ~ randomUUID().toString());
+                          "." ~ rndGen.randomUUID().toString());
     auto f = File(name, "w");
     scope(exit) if (exists(name)) remove(name);
     // write a sorted range of lines to the file


### PR DESCRIPTION
The `randomUUID()` overload not taking any arguments has been deprecated. It is dangerous, as it causes predictable, non-secure UUIDs and has not been documented as doing that previously. Silently changing this function to use a secure system RNG is not possible, as these RNGs may block at early boot when they are not yet seeded, causing `randomUUID` to block as well: https://wiki.debian.org/BoottimeEntropyStarvation

See https://forum.dlang.org/thread/zjmyxudvscfwrkrdabmt@forum.dlang.org for a detailed discussion of the problem.

Depending on whether the desired output needs to be cryptographically secure and considering the potential blocking problem, users should use `rndGen` (insecure) from std.random or a secure alternative (currently not available in phobos) like this:
```d
auto insecureUUID = rndGen.randomUUID();
```

### Affected phobos modules
All callers in phobos are in unittests and don't necessarily need secure, unpredictable UUIDs, they just need unique IDs to generate file names. The affected unittests have been updated to explicitly use the insecure rndGen.

### Followup PRs
#7619 adds an interface to the OS RNG, which allows to generate secure UUIDs with std.uuid.