### PR TITLE
WIP: OS Random number generator interface

### DIFF
--- a/changelog/random_os.dd
+++ b/changelog/random_os.dd
@@ -1,0 +1,10 @@
+OS secure random number generator interface added
+
+An interface to use the operating system's secure random number generator
+has been added to `std.random`. The OS RNG is accessed using the
+`osRNDGen` global instance and adheres to the `std.random` RNG interface.
+
+----------------------------
+import std.random;
+auto secureValue = osRNDGen.dice(70, 20, 10);
+----------------------------


### PR DESCRIPTION
Note: This PR is based on https://github.com/dlang/phobos/pull/7618 and should be merged only after that PR.

An interface to use the operating system's secure random number generator has been added to `std.random`. The OS RNG is accessed using the `osRNDGen` global instance and adheres to the `std.random` RNG interface.

```d
import std.random;
auto secureValue = osRNDGen.dice(70, 20, 10);
```

This is required to allow generating secure UUIDs in `std.uuid`. The `std.uuid` documentation has been updated in this PR to show how to use the secure RNG interface.


## Open Issues:
* How to handle the static initialization required for e.g. the windows RNG? I think we generally want to avoid `shared static this` and it also does not work for this module anyway (`Cyclic dependency between module constructors/destructors of std.random and std.parallelism`). In C/C++/GCC druntime, I'd just do lazy initialization guarded by `pthread_once` or using a **statically initialized** mutex. But afaik, both options are not available in phobos? How do you guys usually handle initialization of shared resources in phobos?
* How to do the `/dev/urandom` implementation? I guess we don't want to reinvent std.stdio.file in Phobos, but this means that the interface can't be nogc, as `File` is not nogc.... We really need `std.io/iopipe` in phobos...
* I've not included the linux getrandom version. Properly versioning this for old kernel versions may be some work and the file based version is required for FreeBSD anyway.