### PR TITLE
Enable preview=fieldwise & fix blocking bug in VariantN

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -139,7 +139,7 @@ endif
 
 # Set DFLAGS
 DFLAGS=
-override DFLAGS+=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -preview=dip1000 -preview=dtorfields $(MODEL_FLAG) $(PIC) -transition=complex
+override DFLAGS+=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -preview=dip1000 -preview=dtorfields  -preview=fieldwise $(MODEL_FLAG) $(PIC) -transition=complex
 ifeq ($(BUILD),debug)
 override DFLAGS += -g -debug
 else

--- a/std/variant.d
+++ b/std/variant.d
@@ -253,7 +253,13 @@ private:
                 {
                     return 0;
                 }
-                static if (is(typeof(*zis < *rhsPA)))
+                static if (is(A == struct) && A.init.tupleof.length == 0)
+                {
+                    // The check above will always succeed if A is an empty struct.
+                    // Don't generate unreachable code as seen in
+                    // https://issues.dlang.org/show_bug.cgi?id=21231
+                }
+                else static if (is(typeof(*zis < *rhsPA)))
                 {
                     // Many types (such as any using the default Object opCmp)
                     // will throw on an invalid opCmp, so do it only
@@ -1561,6 +1567,25 @@ pure nothrow @nogc
     auto other = a.get!S;
     assert(msg.array[0] == 3);
     assert(other.array[0] == 3);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21231
+// Compatibility with -preview=fieldwise
+@system unittest
+{
+    static struct Empty
+    {
+        bool opCmp(const scope ref Empty) const
+        { return false; }
+    }
+
+    Empty a, b;
+    assert(a == b);
+    assert(!(a < b));
+
+    VariantN!(4, Empty) v = a;
+    assert(v == b);
+    assert(!(v < b));
 }
 
 /**

--- a/win32.mak
+++ b/win32.mak
@@ -41,13 +41,13 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime.lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -O -release -w -de -preview=dip1000 -preview=dtorfields -transition=complex -I$(DRUNTIME)\import
+DFLAGS=-conf= -O -release -w -de -preview=dip1000 -preview=dtorfields -preview=fieldwise -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-unittest -g
 #DFLAGS=-unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest -conf= -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
+UDFLAGS=-unittest -version=StdUnittest -version=CoreUnittest -preview=dtorfields -preview=fieldwise -conf= -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
 
 ## C compiler
 

--- a/win64.mak
+++ b/win64.mak
@@ -44,13 +44,13 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime$(MODEL).lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -preview=dtorfields -transition=complex -I$(DRUNTIME)\import
+DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -preview=dtorfields -preview=fieldwise -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-m$(MODEL) -unittest -g
 #DFLAGS=-m$(MODEL) -unittest -cov -g
 
 ## Flags for compiling unittests
 
-UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -transition=complex -I$(DRUNTIME)\import -unittest -version=StdUnittest -version=CoreUnittest
+UDFLAGS=-conf= -g -m$(MODEL) -O -w -preview=dip1000 -preview=dtorfields -preview=fieldwise -transition=complex -I$(DRUNTIME)\import -unittest -version=StdUnittest -version=CoreUnittest
 
 ## C compiler, linker, librarian
 


### PR DESCRIPTION
The first commit removes unreachable code in VaraintN for struct without members. This bug was exposed by `-preview=fieldwise` wich enables early const-folding for `EmptyStruct == EmptyStruct` (always `true`).

The second commit enables the flag for phobos s.t. it stays compatible in the future.