### PR TITLE
merge stable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -504,7 +504,7 @@ $(JSON) : $(ALL_D_FILES)
 ###########################################################
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(EXTRA_DOCUMENTABLES))
 # Set DDOC, the documentation generator
-DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -preview=markdown -version=StdDdoc \
+DDOC=$(DMD) -conf= $(MODEL_FLAG) -w -c -o- -version=StdDdoc \
 	-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS)
 
 # D file to html, e.g. std/conv.d -> std_conv.html

--- a/posix.mak
+++ b/posix.mak
@@ -139,7 +139,7 @@ endif
 
 # Set DFLAGS
 DFLAGS=
-override DFLAGS+=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -preview=dip1000 $(MODEL_FLAG) $(PIC) -transition=complex
+override DFLAGS+=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -preview=dip1000 -preview=dtorfields $(MODEL_FLAG) $(PIC) -transition=complex
 ifeq ($(BUILD),debug)
 override DFLAGS += -g -debug
 else

--- a/std/math.d
+++ b/std/math.d
@@ -7228,43 +7228,63 @@ real fdim(real x, real y) @safe pure nothrow @nogc
 }
 
 /**
- * Returns the larger of x and y.
+ * Returns the larger of `x` and `y`.
  *
- * If one of the arguments is a NaN, the other is returned.
+ * If one of the arguments is a `NaN`, the other is returned.
+ *
+ * See_Also: $(REF max, std,algorithm,comparison) is faster because it does not perform the `isNaN` test.
  */
-real fmax(real x, real y) @safe pure nothrow @nogc
+F fmax(F)(const F x, const F y) @safe pure nothrow @nogc
+if (__traits(isFloating, F))
 {
-    return (y > x || isNaN(x)) ? y : x;
+    // Do the more predictable test first. Generates 0 branches with ldc and 1 branch with gdc.
+    // See https://godbolt.org/z/erxrW9
+    if (isNaN(x)) return y;
+    return y > x ? y : x;
 }
 
 ///
 @safe pure nothrow @nogc unittest
 {
-    assert(fmax(0.0, 2.0) == 2.0);
-    assert(fmax(-2.0, 0.0) == 0.0);
-    assert(fmax(real.infinity, 2.0) == real.infinity);
-    assert(fmax(real.nan, 2.0) == 2.0);
-    assert(fmax(2.0, real.nan) == 2.0);
+    import std.meta : AliasSeq;
+    static foreach (F; AliasSeq!(float, double, real))
+    {
+        assert(fmax(F(0.0), F(2.0)) == 2.0);
+        assert(fmax(F(-2.0), 0.0) == F(0.0));
+        assert(fmax(F.infinity, F(2.0)) == F.infinity);
+        assert(fmax(F.nan, F(2.0)) == F(2.0));
+        assert(fmax(F(2.0), F.nan) == F(2.0));
+    }
 }
 
 /**
- * Returns the smaller of x and y.
+ * Returns the smaller of `x` and `y`.
  *
- * If one of the arguments is a NaN, the other is returned.
+ * If one of the arguments is a `NaN`, the other is returned.
+ *
+ * See_Also: $(REF min, std,algorithm,comparison) is faster because it does not perform the `isNaN` test.
  */
-real fmin(real x, real y) @safe pure nothrow @nogc
+F fmin(F)(const F x, const F y) @safe pure nothrow @nogc
+if (__traits(isFloating, F))
 {
-    return (y < x || isNaN(x)) ? y : x;
+    // Do the more predictable test first. Generates 0 branches with ldc and 1 branch with gdc.
+    // See https://godbolt.org/z/erxrW9
+    if (isNaN(x)) return y;
+    return y < x ? y : x;
 }
 
 ///
 @safe pure nothrow @nogc unittest
 {
-    assert(fmin(0.0, 2.0) == 0.0);
-    assert(fmin(-2.0, 0.0) == -2.0);
-    assert(fmin(real.infinity, 2.0) == 2.0);
-    assert(fmin(real.nan, 2.0) == 2.0);
-    assert(fmin(2.0, real.nan) == 2.0);
+    import std.meta : AliasSeq;
+    static foreach (F; AliasSeq!(float, double, real))
+    {
+        assert(fmin(F(0.0), F(2.0)) == 0.0);
+        assert(fmin(F(-2.0), F(0.0)) == -2.0);
+        assert(fmin(F.infinity, F(2.0)) == 2.0);
+        assert(fmin(F.nan, F(2.0)) == 2.0);
+        assert(fmin(F(2.0), F.nan) == 2.0);
+    }
 }
 
 /**************************************

--- a/win32.mak
+++ b/win32.mak
@@ -41,7 +41,7 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime.lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -O -release -w -de -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
+DFLAGS=-conf= -O -release -w -de -preview=dip1000 -preview=dtorfields -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-unittest -g
 #DFLAGS=-unittest -cov -g
 

--- a/win64.mak
+++ b/win64.mak
@@ -44,7 +44,7 @@ DRUNTIMELIB=$(DRUNTIME)/lib/druntime$(MODEL).lib
 
 ## Flags for dmd D compiler
 
-DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -transition=complex -I$(DRUNTIME)\import
+DFLAGS=-conf= -m$(MODEL) -O -release -w -de -preview=dip1000 -preview=dtorfields -transition=complex -I$(DRUNTIME)\import
 #DFLAGS=-m$(MODEL) -unittest -g
 #DFLAGS=-m$(MODEL) -unittest -cov -g
 


### PR DESCRIPTION
- Fix issue 21129: Make `OnlyResult` store the actual types passed to it as a tuple, instead of a static array of CommonType. (#7584)
- Fix Issue 21183 - schwartzSort does not strip const
- Add makefile target for testing with no autodecode. This is so CI can run a valid target without failing.
