### PR TITLE
std.container: Fix warnings that memory may be used uninitialized

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -482,15 +482,15 @@ if (!is(immutable T == immutable bool))
                 assert(false, "Overflow");
         }
         auto p = cast(T*) enforceMalloc(nbytes);
+        // Before it is added to the gc, initialize the newly allocated memory
+        foreach (i, e; values)
+        {
+            emplace(p + i, e);
+        }
         static if (hasIndirections!T)
         {
             if (p)
                 GC.addRange(p, T.sizeof * values.length);
-        }
-
-        foreach (i, e; values)
-        {
-            emplace(p + i, e);
         }
         _data = Data(p[0 .. values.length]);
     }
@@ -614,6 +614,8 @@ if (!is(immutable T == immutable bool))
             auto p = enforceMalloc(sz);
             static if (hasIndirections!T)
             {
+                // Zero out unused capacity to prevent gc from seeing false pointers
+                memset(p, 0, sz);
                 GC.addRange(p, sz);
             }
             _data = Data(cast(T[]) p[0 .. 0]);


### PR DESCRIPTION
This is a warning that showed up when running the testsuite in GDC with the -Wextra flag.  Said warning is by design and based on the assumption that any function declared to take a const pointer or reference as an argument reads the pointed-to-object.

In the case of GC.addRange(), the possibility is that a scan could occur before the memory is initialized, and the GC sees false pointers as a result of that.