### PR TITLE
EASY: factor implementations of range length into a mixin template

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -371,10 +371,7 @@ private struct _Cache(R, bool bidir)
             return source.empty;
         }
 
-    static if (hasLength!R) auto length() @property
-    {
-        return source.length;
-    }
+    mixin ImplementLength!source;
 
     E front() @property
     {
@@ -641,15 +638,7 @@ private struct MapResult(alias fun, Range)
         }
     }
 
-    static if (hasLength!R)
-    {
-        @property auto length()
-        {
-            return _input.length;
-        }
-
-        alias opDollar = length;
-    }
+    mixin ImplementLength!_input;
 
     static if (hasSlicing!R)
     {
@@ -4373,13 +4362,7 @@ if (fun.length >= 1)
                 }
             }
 
-            static if (hasLength!R)
-            {
-                @property size_t length()
-                {
-                    return source.length;
-                }
-            }
+            mixin ImplementLength!source;
         }
 
         return Result(range, args);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -349,15 +349,7 @@ if (isBidirectionalRange!(Unqual!Range))
                     }
             }
 
-            static if (hasLength!R)
-            {
-                @property auto length()
-                {
-                    return source.length;
-                }
-
-                alias opDollar = length;
-            }
+            mixin ImplementLength!source;
         }
 
         return Result!()(r);
@@ -7075,16 +7067,7 @@ struct FrontTransversal(Ror,
                 _input[n].front = val;
             }
         }
-        /// Ditto
-        static if (hasLength!RangeOfRanges)
-        {
-            @property size_t length()
-            {
-                return _input.length;
-            }
-
-            alias opDollar = length;
-        }
+        mixin ImplementLength!_input;
 
 /**
    Slicing if offered if `RangeOfRanges` supports slicing and all the
@@ -7414,16 +7397,7 @@ struct Transversal(Ror,
             }
         }
 
-        /// Ditto
-        static if (hasLength!RangeOfRanges)
-        {
-            @property size_t length()
-            {
-                return _input.length;
-            }
-
-            alias opDollar = length;
-        }
+        mixin ImplementLength!_input;
 
 /**
    Slicing if offered if `RangeOfRanges` supports slicing and all the
@@ -7853,16 +7827,7 @@ if (isRandomAccessRange!Source && isInputRange!Indices &&
         }
     }
 
-    static if (hasLength!Indices)
-    {
-        /// Ditto
-         @property size_t length()
-        {
-            return _indices.length;
-        }
-
-        alias opDollar = length;
-    }
+    mixin ImplementLength!_indices;
 
     static if (isRandomAccessRange!Indices)
     {
@@ -10304,12 +10269,7 @@ do
 
         static if (hasLength!Range)
         {
-            size_t length() @property
-            {
-                return range.length;
-            }
-
-            alias opDollar = length;
+            mixin ImplementLength!range;
 
             static if (isBidirectionalRange!Range)
             {
@@ -10852,15 +10812,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
             return result;
         }
 
-    /// Ditto
-    static if (hasLength!Range)
-    {
-        @property size_t length()          //const
-        {
-            return _input.length;
-        }
-        alias opDollar = length;
-    }
+    mixin ImplementLength!_input;
 
 /**
    Releases the controlled range and returns it.
@@ -11769,15 +11721,11 @@ public:
 
     version (StdDdoc)
     {
-        /++
-            Only defined if `hasLength!R` is `true`.
-          +/
-        @property auto length() {assert(0);}
-
-        /++ Ditto +/
-        @property auto length() const {assert(0);}
-
-        /++ Ditto +/
+        /// Only defined if `hasLength!R` is `true`.
+        @property size_t length();
+        /// ditto
+        @property size_t length() const;
+        /// Ditto
         alias opDollar = length;
     }
     else static if (hasLength!R)
@@ -11786,12 +11734,10 @@ public:
         {
             return (*_range).length;
         }
-
         static if (is(typeof((*cast(const R*)_range).length))) @property auto length() const
         {
             return (*_range).length;
         }
-
         alias opDollar = length;
     }
 
@@ -12843,13 +12789,7 @@ if (isInputRange!R1 && isOutputRange!(R2, ElementType!R1))
             private bool _frontAccessed;
         }
 
-        static if (hasLength!R1)
-        {
-            @property auto length()
-            {
-                return _input.length;
-            }
-        }
+        mixin ImplementLength!_input;
 
         static if (isInfinite!R1)
         {

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2509,3 +2509,18 @@ if (isAutodecodableString!(T[]))
     size_t i = a.length - strideBack(a, a.length);
     return decode(a, i);
 }
+
+/*
+Implements `length` for a range by forwarding it to `member`.
+*/
+package(std) mixin template ImplementLength(alias member)
+{
+    static if (hasLength!(typeof(member)))
+    {
+        @property auto length()
+        {
+            return member.length;
+        }
+        alias opDollar = length;
+    }
+}


### PR DESCRIPTION
Arguably this is closer to correctness because some of these ranges don't define `opDollar`.