### PR TITLE
Remove void initialization for member with destructor

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4855,7 +4855,7 @@ struct DirIterator
 {
 @safe:
 private:
-    RefCounted!(DirIteratorImpl, RefCountedAutoInitialize.no) impl = void;
+    RefCounted!(DirIteratorImpl, RefCountedAutoInitialize.no) impl;
     this(string pathname, SpanMode mode, bool followSymlink) @trusted
     {
         impl = typeof(impl)(pathname, mode, followSymlink);


### PR DESCRIPTION
Having a member with a destructor initialized to `void` is clearly problematic. I think it's so certifiably problematic, the compiler could actually issue an error about it.