### PR TITLE
Issue 21250 - dirEntries on non-existent directory causes assert error

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -5156,6 +5156,12 @@ auto dirEntries(string path, string pattern, SpanMode mode,
     assert(equal(files, result));
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21250
+@system unittest
+{
+    import std.exception : assertThrown;
+    assertThrown!Exception(dirEntries("237f5babd6de21f40915826699582e36", "*.bin", SpanMode.depth));
+}
 
 /**
  * Reads a file line by line and parses the line into a single value or a

--- a/std/file.d
+++ b/std/file.d
@@ -4855,7 +4855,7 @@ struct DirIterator
 {
 @safe:
 private:
-    RefCounted!(DirIteratorImpl, RefCountedAutoInitialize.no) impl = void;
+    RefCounted!(DirIteratorImpl, RefCountedAutoInitialize.no) impl;
     this(string pathname, SpanMode mode, bool followSymlink) @trusted
     {
         impl = typeof(impl)(pathname, mode, followSymlink);

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6344,7 +6344,7 @@ if (!is(T == class) && !(is(T == interface)))
             import std.conv : emplace;
 
             allocateStore();
-            scope(failure) deallocateStore();
+            version (D_Exceptions) scope(failure) deallocateStore();
             emplace(&_store._payload, args);
             _store._count = 1;
         }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6344,6 +6344,7 @@ if (!is(T == class) && !(is(T == interface)))
             import std.conv : emplace;
 
             allocateStore();
+            scope(failure) deallocateStore();
             emplace(&_store._payload, args);
             _store._count = 1;
         }
@@ -6371,6 +6372,16 @@ if (!is(T == class) && !(is(T == interface)))
                 import std.internal.memory : enforceMalloc;
                 _store = cast(Impl*) enforceMalloc(Impl.sizeof);
             }
+        }
+
+        private void deallocateStore() nothrow pure
+        {
+            static if (enableGCScan)
+            {
+                pureGcRemoveRange(&this._store._payload);
+            }
+            pureFree(_store);
+            _store = null;
         }
 
         /**
@@ -6418,6 +6429,11 @@ Constructor that initializes the payload.
 Postcondition: `refCountedStore.isInitialized`
  */
     this(A...)(auto ref A args) if (A.length > 0)
+    out
+    {
+        assert(refCountedStore.isInitialized);
+    }
+    do
     {
         _refCounted.initialize(args);
     }
@@ -6450,15 +6466,9 @@ to deallocate the corresponding resource.
         assert(_refCounted._store._count > 0);
         if (--_refCounted._store._count)
             return;
-        // Done, deallocate
+        // Done, destroy and deallocate
         .destroy(_refCounted._store._payload);
-        static if (enableGCScan)
-        {
-            pureGcRemoveRange(&_refCounted._store._payload);
-        }
-
-        pureFree(_refCounted._store);
-        _refCounted._store = null;
+        _refCounted.deallocateStore();
     }
 
 /**


### PR DESCRIPTION
Reproduced the issue on a Linux box, problem was with throwing constructors during `RefCounted` initialization.