### PR TITLE
std.file: Posix readImpl: An internal check of correctness.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -390,6 +390,7 @@ version (Posix) private void[] readImpl(scope const(char)[] name, scope const(FS
         if (actual == 0) break;
         size += actual;
         if (size >= upTo) break;
+        assert(size <= result.length);
         if (size < result.length) continue;
         immutable newAlloc = size + sizeIncrement;
         result = GC.realloc(result.ptr, newAlloc.get, GC.BlkAttr.NO_SCAN)[0 .. newAlloc.get];


### PR DESCRIPTION
The last two lines of the loop:

    immutable newAlloc = size + sizeIncrement;
    result = GC.realloc(result.ptr, newAlloc.get, GC.BlkAttr.NO_SCAN)[0 .. newAlloc.get];

should only be executed when "size == result.length", not generally when "size >= length", though the "if" condition immediately above may indicate the general case.

The "size > result.length" case can never happen. If it does, we have an internal bug (or there is a bug in the implementation of the POSIX read function).

However, this is not obvious without looking attentively at the code (this is subjective--it might simply mean that I am slow).

I wish to suggest that we clarify by a comment/assertion/always-enabled-assertion. Currently, by an assertion.