### PR TITLE
fix real precision use for inverse and hyperbolic trig, scalbn, fdim, fma, pow

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4035,6 +4035,8 @@ float scalbn(float x, int n) @safe pure nothrow @nogc { return _scalbn(x,n); }
 {
     assert(scalbn(0x1.2345678abcdefp0L, 999) == 0x1.2345678abcdefp999L);
     assert(scalbn(-real.infinity, 5) == -real.infinity);
+    assert(scalbn(2.0,10) == 2048.0);
+    assert(scalbn(2048.0f,-10) == 2.0f);
 }
 
 private F _scalbn(F)(F x, int n)

--- a/std/math.d
+++ b/std/math.d
@@ -1348,8 +1348,14 @@ private F _sinh(F)(F x)
 ///
 @safe unittest
 {
-    assert(isIdentical(sinh(0.0), 0.0));
-    assert(sinh(1.0).approxEqual((E - 1.0 / E) / 2));
+    enum sinh1 = (E - 1.0 / E) / 2;
+    import std.meta : AliasSeq;
+    static foreach(F; AliasSeq!(float, double, real))
+    {
+        assert(isIdentical(sinh(F(0.0)), F(0.0)));
+        assert(sinh(F(1.0)).approxEqual(F(sinh1)));
+    }
+    
 }
 
 @safe @nogc nothrow unittest

--- a/std/math.d
+++ b/std/math.d
@@ -1330,6 +1330,18 @@ double sinh(double x) @safe pure nothrow @nogc { return _sinh(x); }
 /// ditto
 float sinh(float x) @safe pure nothrow @nogc { return _sinh(x); }
 
+///
+@safe unittest
+{
+    enum sinh1 = (E - 1.0 / E) / 2;
+    import std.meta : AliasSeq;
+    static foreach (F; AliasSeq!(float, double, real))
+    {
+        assert(isIdentical(sinh(F(0.0)), F(0.0)));
+        assert(sinh(F(1.0)).approxEqual(F(sinh1)));
+    }
+}
+
 private F _sinh(F)(F x)
 {
     //  sinh(x) =  (exp(x)-exp(-x))/2;
@@ -1343,18 +1355,6 @@ private F _sinh(F)(F x)
 
     const y = expm1(x);
     return F(0.5) * y / (y+1) * (y+2);
-}
-
-///
-@safe unittest
-{
-    enum sinh1 = (E - 1.0 / E) / 2;
-    import std.meta : AliasSeq;
-    static foreach (F; AliasSeq!(float, double, real))
-    {
-        assert(isIdentical(sinh(F(0.0)), F(0.0)));
-        assert(sinh(F(1.0)).approxEqual(F(sinh1)));
-    }
 }
 
 @safe @nogc nothrow unittest

--- a/std/math.d
+++ b/std/math.d
@@ -4032,6 +4032,8 @@ float scalbn(float x, int n) @safe pure nothrow @nogc { return _scalbn(x,n); }
 
 ///
 @safe pure nothrow @nogc unittest
+{
+    assert(scalbn(0x1.2345678abcdefp0L, 999) == 0x1.2345678abcdefp999L);
     assert(scalbn(-real.infinity, 5) == -real.infinity);
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -1322,26 +1322,28 @@ float cosh(float x) @safe pure nothrow @nogc  { return cosh(cast(real) x); }
  *      $(TR $(TD $(PLUSMN)$(INFIN)) $(TD $(PLUSMN)$(INFIN)) $(TD no))
  *      )
  */
-real sinh(real x) @safe pure nothrow @nogc
+real sinh(real x) @safe pure nothrow @nogc { return _sinh(x); }
+
+/// ditto
+double sinh(double x) @safe pure nothrow @nogc { return _sinh(x); }
+
+/// ditto
+float sinh(float x) @safe pure nothrow @nogc { return _sinh(x); }
+
+private F _sinh(F)(F x)
 {
     //  sinh(x) =  (exp(x)-exp(-x))/2;
     // Very large arguments could cause an overflow, but
     // the maximum value of x for which exp(x) + exp(-x)) != exp(x)
     // is x = 0.5 * (real.mant_dig) * LN2. // = 22.1807 for real80.
-    if (fabs(x) > real.mant_dig * LN2)
+    if (fabs(x) > F.mant_dig * F(LN2))
     {
-        return copysign(0.5 * exp(fabs(x)), x);
+        return copysign(F(0.5) * exp(fabs(x)), x);
     }
 
-    const real y = expm1(x);
-    return 0.5 * y / (y+1) * (y+2);
+    const y = expm1(x);
+    return F(0.5) * y / (y+1) * (y+2);
 }
-
-/// ditto
-double sinh(double x) @safe pure nothrow @nogc { return sinh(cast(real) x); }
-
-/// ditto
-float sinh(float x) @safe pure nothrow @nogc  { return sinh(cast(real) x); }
 
 ///
 @safe unittest

--- a/std/math.d
+++ b/std/math.d
@@ -1350,7 +1350,7 @@ private F _sinh(F)(F x)
 {
     enum sinh1 = (E - 1.0 / E) / 2;
     import std.meta : AliasSeq;
-    static foreach(F; AliasSeq!(float, double, real))
+    static foreach (F; AliasSeq!(float, double, real))
     {
         assert(isIdentical(sinh(F(0.0)), F(0.0)));
         assert(sinh(F(1.0)).approxEqual(F(sinh1)));

--- a/std/math.d
+++ b/std/math.d
@@ -1370,23 +1370,13 @@ private F _sinh(F)(F x)
  *      $(TR $(TD $(PLUSMN)$(INFIN)) $(TD $(PLUSMN)1.0) $(TD no))
  *      )
  */
-real tanh(real x) @safe pure nothrow @nogc
-{
-    //  tanh(x) = (exp(x) - exp(-x))/(exp(x)+exp(-x))
-    if (fabs(x) > real.mant_dig * LN2)
-    {
-        return copysign(1, x);
-    }
-
-    const real y = expm1(2*x);
-    return y / (y + 2);
-}
+real tanh(real x) @safe pure nothrow @nogc { return _tanh(x); }
 
 /// ditto
-double tanh(double x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
+double tanh(double x) @safe pure nothrow @nogc { return _tanh(x); }
 
 /// ditto
-float tanh(float x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
+float tanh(float x) @safe pure nothrow @nogc { return _tanh(x); }
 
 ///
 @safe unittest
@@ -1395,9 +1385,21 @@ float tanh(float x) @safe pure nothrow @nogc { return tanh(cast(real) x); }
     assert(tanh(1.0).approxEqual(sinh(1.0) / cosh(1.0)));
 }
 
+private F _tanh(F)(F x)
+{
+    //  tanh(x) = (exp(x) - exp(-x))/(exp(x)+exp(-x))
+    if (fabs(x) > F.mant_dig * F(LN2))
+    {
+        return copysign(1, x);
+    }
+
+    const y = expm1(2*x);
+    return y / (y + 2);
+}
+
 @safe @nogc nothrow unittest
 {
-    assert(equalsDigit(tanh(1.0), sinh(1.0) / cosh(1.0), 15));
+    assert(equalsDigit(tanh(1.0L), sinh(1.0L) / cosh(1.0L), 15));
 }
 
 /***********************************

--- a/std/math.d
+++ b/std/math.d
@@ -4024,10 +4024,10 @@ real modf(real x, ref real i) @trusted nothrow @nogc
  */
 real scalbn(real x, int n) @safe pure nothrow @nogc { return _scalbn(x,n); }
 
-///
+/// ditto
 double scalbn(double x, int n) @safe pure nothrow @nogc { return _scalbn(x,n); }
 
-///
+/// ditto
 float scalbn(float x, int n) @safe pure nothrow @nogc { return _scalbn(x,n); }
 
 ///

--- a/std/math.d
+++ b/std/math.d
@@ -1355,14 +1355,12 @@ private F _sinh(F)(F x)
         assert(isIdentical(sinh(F(0.0)), F(0.0)));
         assert(sinh(F(1.0)).approxEqual(F(sinh1)));
     }
-    
 }
 
 @safe @nogc nothrow unittest
 {
-    assert(equalsDigit(sinh(1.0), (E - 1.0 / E) / 2, useDigits));
+    assert(equalsDigit(sinh(1.0L), real((E - 1.0 / E) / 2), useDigits));
 }
-
 /***********************************
  * Calculates the hyperbolic tangent of x.
  *


### PR DESCRIPTION
part of the fix for https://issues.dlang.org/show_bug.cgi?id=18559
Previous PR: https://github.com/dlang/phobos/pull/7463