### PR TITLE
Fix issue 21296 - std.variant.Variant cannot be initialized with immu…

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -485,7 +485,7 @@ private:
                 (*zis)[index] = args[0].get!(typeof((*zis)[0]));
                 break;
             }
-            else static if (isAssociativeArray!(A))
+            else static if (isAssociativeArray!(A) && is(typeof((*zis)[A.init.keys[0]] = A.init.values[0])))
             {
                 (*zis)[args[1].get!(typeof(A.init.keys[0]))]
                     = args[0].get!(typeof(A.init.values[0]));
@@ -3122,4 +3122,11 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     alias Outer = Algebraic!(Inner, This*);
 
     static assert(is(Outer.AllowedTypes == AliasSeq!(Inner, Outer*)));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21296
+@system unittest
+{
+    immutable aa = ["0": 0];
+    auto v = Variant(aa); // compile error
 }


### PR DESCRIPTION
…table AA

The source of this issue is that the private static method `Variant.handler.tryPutting` accidentally generate a code for `opIndexAssign` to immutable AA in compile time.
This request fixes this issue by making `tryPutting` throwing an exception in runtime for such cases.

---
I also confirmed that [Issue 13930](https://issues.dlang.org/show_bug.cgi?id=13930) (std.concurrency can't send immutable AA) is also solved by this change.
It might be possible to add a test for issue 13930 but unfortunately there still remains an issue in receiving side (not yet filed).
