### PR TITLE
Revert "Fix issue 13930, 19345 - Fix `receiveOnly` for non-assignable types "

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -802,17 +802,7 @@ do
 
     thisInfo.ident.mbox.get((T val) {
         static if (T.length)
-        {
-            static if (isAssignable!T)
-            {
-                ret.field = val;
-            }
-            else
-            {
-                import core.lifetime : emplace;
-                emplace(&ret, val);
-            }
-        }
+            ret.field = val;
     },
     (LinkTerminated e) { throw e; },
     (OwnerTerminated e) { throw e; },
@@ -2736,28 +2726,4 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
     tid.send(x);
     receiveOnly!(bool);
     assert(x[0] == 5);
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=13930
-@system unittest
-{
-    immutable aa = ["0":0];
-    thisTid.send(aa);
-    receiveOnly!(immutable int[string]); // compile error
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=19345
-@system unittest
-{
-    static struct Aggregate { const int a; const int[5] b; }
-    static void t1(Tid mainTid)
-    {
-        const sendMe = Aggregate(42, [1, 2, 3, 4, 5]);
-        mainTid.send(sendMe);
-    }
-
-    spawn(&t1, thisTid);
-    auto result1 = receiveOnly!(const Aggregate)();
-    immutable expected = Aggregate(42, [1, 2, 3, 4, 5]);
-    assert(result1 == expected);
 }


### PR DESCRIPTION
Reverts dlang/phobos#7655

As mentioned [here](https://github.com/dlang/phobos/pull/7655#issuecomment-706595379), this broke the CI.