### PR TITLE
Fix issue 21302: std.uni's documentation contains a dead link to its …

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -688,7 +688,7 @@ $(TR $(TD Building blocks) $(TD
     Copyright: Copyright 2013 -
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Dmitry Olshansky
-    Source:    $(PHOBOSSRC std/uni.d)
+    Source:    $(PHOBOSSRC std/uni/package.d)
     Standards: $(HTTP www.unicode.org/versions/Unicode6.2.0/, Unicode v6.2)
 
 Macros:


### PR DESCRIPTION
…source file