### PR TITLE
Sync Azure CI script with druntime's

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@
 
 variables:
   DMD_BRANCH: $[ coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranchName'], 'master') ]
+  VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
 
 jobs:
   - job: Windows
@@ -9,84 +10,71 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     variables:
-      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: 2.093.1
+      D_COMPILER: dmd
+      HOST_DMD_VERSION: LATEST
     strategy:
       matrix:
         x64:
           OS: Win_64
           MODEL: 64
           ARCH: x64
-          D_COMPILER: dmd
-    steps:
-      - script: set
-        displayName: environment
-      - script: systeminfo
-        displayName: systeminfo
-      - task: CopyFiles@2
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)'
-          contents: '**/*'
-          TargetFolder: '$(Build.SourcesDirectory)/../phobos'
-      - script: git clone --branch $(DMD_BRANCH) https://github.com/dlang/dmd.git ../dmd
-      - script: |
-          call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
-          cd ../dmd && sh --login .azure-pipelines/windows.sh
-        displayName: Build DMD
-
-  - job: Windows_OMF
-    timeoutInMinutes: 120
-    pool:
-      vmImage: 'vs2017-win2016'
-    variables:
-      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: LATEST
-    strategy:
-      matrix:
-        x86:
+        x86-OMF:
           OS: Win_32
           MODEL: 32
           ARCH: x86
-          D_COMPILER: dmd
     steps:
+      - checkout: self
+        fetchDepth: 1
       - script: set
-        displayName: environment
+        displayName: Print environment variables
       - script: systeminfo
-        displayName: systeminfo
+        displayName: Print system info
       - task: CopyFiles@2
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)'
           contents: '**/*'
           TargetFolder: '$(Build.SourcesDirectory)/../phobos'
-      - script: git clone --branch $(DMD_BRANCH) https://github.com/dlang/dmd.git ../dmd
-      - script: cd ../dmd && sh --login .azure-pipelines/windows.sh
+      - script: git clone --branch $(DMD_BRANCH) --depth 1 https://github.com/dlang/dmd.git ../dmd
+        displayName: Clone DMD repo
+      - script: |
+          call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
+          cd ../dmd && sh --login .azure-pipelines/windows.sh
+        displayName: Build and test
 
   - job: Windows_VisualD
     timeoutInMinutes: 120
     pool:
       vmImage: 'vs2017-win2016'
     variables:
-      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: 2.093.1
+      D_COMPILER: ldc
+      VISUALD_VER: v0.49.0
+      LDC_VERSION: 1.23.0
     strategy:
       matrix:
-        win32-ldc:
+        x86-mscoff:
           OS: Win_32
-          MODEL: 32
+          MODEL: 32mscoff
           ARCH: x86
-          D_COMPILER: ldc
-          VISUALD_VER: v0.49.0
-          LDC_VERSION: 1.14.0
+        x86-mscoff_MinGW:
+          OS: Win_32
+          MODEL: 32mscoff
+          ARCH: x86
+          C_RUNTIME: mingw
     steps:
+      - checkout: self
+        fetchDepth: 1
       - script: set
-        displayName: environment
+        displayName: Print environment variables
       - script: systeminfo
-        displayName: systeminfo
+        displayName: Print system info
       - task: CopyFiles@2
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)'
           contents: '**/*'
           TargetFolder: '$(Build.SourcesDirectory)/../phobos'
-      - script: git clone --branch $(DMD_BRANCH) https://github.com/dlang/dmd.git ../dmd
+      - script: git clone --branch $(DMD_BRANCH) --depth 1 https://github.com/dlang/dmd.git ../dmd
+        displayName: Clone DMD repo
       - script: cd ../dmd && sh --login .azure-pipelines/windows-visual-studio.sh
-      - script: cd ../dmd && call .azure-pipelines\windows-msbuild.bat
+        displayName: Download required binaries
+      - script: cd ../dmd && call .azure-pipelines/windows-msbuild.bat
+        displayName: Build and test


### PR DESCRIPTION
Including the addition of a `x86-mscoff_MinGW` job. The Phobos unittests are currently skipped for that job though, apparently due to an issue with the used LLD linker.