### PR TITLE
Fix issue 13930, 19345 - Fix `receiveOnly` for non-assignable types

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -700,7 +700,15 @@ public:
                 {
                     alias UT = Unqual!T;
                     auto p = new UT;
-                    *p = rhs;
+                    static if (isAssignable!UT)
+                    {
+                        *p = rhs;
+                    }
+                    else
+                    {
+                        import core.lifetime : emplace;
+                        emplace(p, rhs);
+                    }
                 }
                 memcpy(&store, &p, p.sizeof);
             }


### PR DESCRIPTION
This is a re-submit version of #7655.

