### PR TITLE
std.stdio: move std.process import inside unittest

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1493,8 +1493,9 @@ Removes the lock over the specified file segment.
     }
 
     version (Posix)
-    static if (__traits(compiles, { import std.process : spawnProcess; }))
     @system unittest
+    {
+    static if (__traits(compiles, { import std.process : spawnProcess; }))
     {
         static import std.file;
         auto deleteme = testFilename();
@@ -1548,7 +1549,8 @@ Removes the lock over the specified file segment.
             g.unlock();
         });
         f.unlock();
-    }
+    } // static if
+    } // unittest
 
 
 /**


### PR DESCRIPTION
This moves the std.process import inside the unittest. The import is not used elsewhere, and so is unnecessary for non-unittest builds. This greatly speeds up importing std.stdio. (In a simple testcase, more than 90% of the import time of std.stdio was spent on std.process)

I've tried to keep whitespace changes to a minimum, while keeping the code readable.