### PR TITLE
Add some conversions to JSONValue.get!T

### DIFF
--- a/changelog/jsonvalue-get-integer-conv.dd
+++ b/changelog/jsonvalue-get-integer-conv.dd
@@ -1,0 +1,10 @@
+Add integer conversions in `JSONValue.get`
+
+`JSONValue.get` now allows to convert a stored `uinteger` or `integer` into any
+signed or unsigned integer. The conversion is performed with `std.conv.to`, and
+throws a `ConvException` in case of an integer overflow;
+
+-------
+auto json = parseJSON(`{"a": 123}`);
+writeln(json["a"].get!ubyte);
+-------

--- a/std/json.d
+++ b/std/json.d
@@ -368,11 +368,10 @@ struct JSONValue
      * A convenience getter that returns this `JSONValue` as the specified D type.
      * Note: only numeric, `bool`, `string`, `JSONValue[string]` and `JSONValue[]` types are accepted
      * Throws: `JSONException` if `T` cannot hold the contents of this `JSONValue`
-     *         `ConvException` if there is a type overflow issue
+     *         `ConvException` in case of integer overflow when converting to `T`
      */
     @property inout(T) get(T)() inout const pure @safe
     {
-        import std.conv : to;
         static if (is(immutable T == immutable string))
         {
             return str;
@@ -404,7 +403,7 @@ struct JSONValue
             case JSONType.integer:
                 return integer.to!T;
             default:
-                throw new JSONException("JSONValue is not a number type");
+                throw new JSONException("JSONValue is not a an integral type");
             }
         }
         else


### PR DESCRIPTION
Currently `JSONValue.get` allows to convert the stored `integer`, `uinteger` or `float_` to a floating point type, but throws a JSONException("JSONValue is not a xxx") when trying to convert a stored `uinteger` to any signed int, or a stored `integer` to any unsigned int.

This can be quite annoying as the parser sets the type to either ulong or long depending on how high is the parsed value.

This patch adds the following conversions:
- `integer` -> any signed or unsigned int
- `uinteger` -> any signed or unsigned int

Note:
- The value will be truncated if the target type is narrower than the stored type, but this seems to be expected as it is the current behaviour when converting for example a `ulong` to `ubyte`
- `JSONException`s are raised if there is a conversion overflow
- Should I also add conversions from `float_` to integer types?