### PR TITLE
regex: partially make regex pure

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -29,7 +29,7 @@ if (is(Char : dchar))
     enum initialStack = 1 << 11; // items in a block of segmented stack
     alias String = const(Char)[];
     alias RegEx = Regex!Char;
-    alias MatchFn = bool function (BacktrackingMatcher);
+    alias MatchFn = bool function(BacktrackingMatcher) pure;
     const RegEx re;         // regex program
     MatchFn nativeFn; // native code for that program
     // Stream state
@@ -318,7 +318,7 @@ final:
         match subexpression against input,
         results are stored in matches
     +/
-    int matchImpl()
+    int matchImpl() pure
     {
         if (nativeFn)
         {

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -9,6 +9,8 @@ package(std.regex):
 import core.stdc.stdlib, std.range.primitives, std.traits, std.typecons;
 import std.regex.internal.ir;
 
+import core.memory : pureMalloc, pureFree;
+
 /+
     BacktrackingMatcher implements backtracking scheme of matching
     regular expressions.
@@ -134,10 +136,10 @@ final:
         }
         else
         {
-            import core.stdc.stdlib : free;
+            import core.memory : pureFree;
             // memory used in previous block
             size_t size = memory.ptr[-1];
-            free(memory.ptr-2);
+            pureFree(memory.ptr-2);
             memory = prev[0 .. size];
             lastState = size;
             return true;
@@ -604,8 +606,8 @@ final:
                     immutable len = re.ir[pc].data;
                     auto save = index;
                     immutable ms = re.ir[pc+1].raw, me = re.ir[pc+2].raw;
-                    auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
-                    scope(exit) free(mem.ptr);
+                    auto mem = pureMalloc(initialMemory(re))[0 .. initialMemory(re)];
+                    scope(exit) pureFree(mem.ptr);
                     auto slicedRe = re.withCode(re.ir[
                         pc+IRL!(IR.LookaheadStart) .. pc+IRL!(IR.LookaheadStart)+len+IRL!(IR.LookaheadEnd)
                     ]);
@@ -633,8 +635,8 @@ final:
                 case IR.NeglookbehindStart:
                     immutable len = re.ir[pc].data;
                     immutable ms = re.ir[pc+1].raw, me = re.ir[pc+2].raw;
-                    auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
-                    scope(exit) free(mem.ptr);
+                    auto mem = pureMalloc(initialMemory(re))[0 .. initialMemory(re)];
+                    scope(exit) pureFree(mem.ptr);
                     auto slicedRe = re.withCode(re.ir[
                         pc + IRL!(IR.LookbehindStart) .. pc + IRL!(IR.LookbehindStart) + len + IRL!(IR.LookbehindEnd)
                     ]);
@@ -975,8 +977,8 @@ struct CtContext
                         //(neg)lookaround piece ends
                     }
                     auto save = index;
-                    auto mem = malloc(initialMemory(re))[0 .. initialMemory(re)];
-                    scope(exit) free(mem.ptr);
+                    auto mem = pureMalloc(initialMemory(re))[0 .. initialMemory(re)];
+                    scope(exit) pureFree(mem.ptr);
                     static if (typeof(matcher.s).isLoopback)
                         auto lookaround = $$;
                     else
@@ -1465,7 +1467,7 @@ struct CtContext
     {
         auto bdy = ctGenBlock(ir, 0);
         auto r = `
-            import core.stdc.stdlib;
+            import core.memory : pureMalloc, pureFree;
             with(matcher)
             {
             pc = 0;

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -717,9 +717,9 @@ if (is(Char : dchar))
 {
     alias DataIndex = Stream.DataIndex;
     alias Stream = StreamType;
-    alias OpFunc = bool function(ThompsonMatcher, State*);
+    alias OpFunc = bool function(ThompsonMatcher, State*) pure;
     alias BackMatcher = ThompsonMatcher!(Char, BackLooper!(Stream));
-    alias OpBackFunc = bool function(BackMatcher, BackMatcher.State*);
+    alias OpBackFunc = bool function(BackMatcher, BackMatcher.State*) pure;
     Thread!DataIndex* freelist;
     ThreadList!DataIndex clist, nlist;
     DataIndex[] merge;
@@ -740,6 +740,7 @@ if (is(Char : dchar))
     bool exhausted;
 
 final:
+    pure
     static struct State
     {
         Thread!DataIndex* t;


### PR DESCRIPTION
Use pure/enforced version of `malloc` and `free` functions and fake pure the custom memoized `defaultFactory` and `matchOnce`.