### PR TITLE
std.file: DirEntry: Avoid repeated stat on failure-and-retry.

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4038,10 +4038,10 @@ else version (Posix)
             if (_didStat)
                 return;
 
+            scope(exit) _didStat = true;
+
             enforce(stat(_name.tempCString(), &_statBuf) == 0,
                     "Failed to stat file `" ~ _name ~ "'");
-
-            _didStat = true;
         }
 
         /++
@@ -4080,6 +4080,8 @@ else version (Posix)
             if (_didLStat)
                 return;
 
+            scope(exit) _didLStat = true;
+
             stat_t statbuf = void;
             enforce(lstat(_name.tempCString(), &statbuf) == 0,
                 "Failed to stat file `" ~ _name ~ "'");
@@ -4087,7 +4089,6 @@ else version (Posix)
             _lstatMode = statbuf.st_mode;
 
             _dTypeSet = true;
-            _didLStat = true;
         }
 
         string _name; /// The file or directory represented by this DirEntry.


### PR DESCRIPTION
For DirEntry, if stat (or lstat) fails, but the user [eventually] catches the exception and [eventually] retries, do we want to retry performing stat (or lstat) ?

I feel that, in some cases, this might lead to repeated "Failed to stat file ..." exceptions.

And, generally, it is difficult for me to think of a scenario where stat (or lstat) fails on the first attempt(s) and later succeeds (for the same file).

Perhaps we can clarify together.

Thank you.

(And I apologize for not having worked lately on my other pull requests. Thank you for the patience.)