### PR TITLE
stdio: optimize readln algorithm for non-char type

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1846,14 +1846,19 @@ is recommended if you want to process a complete file.
         }
         else
         {
-            // TODO: optimize this
             string s = readln(terminator);
-            buf.length = 0;
-            if (!s.length) return 0;
-            foreach (C c; s)
+            if (!s.length)
             {
-                buf ~= c;
+                buf = buf[0 .. 0];
+                return 0;
             }
+
+            import std.utf : codeLength;
+            buf.length = codeLength!C(s);
+            size_t idx;
+            foreach (C c; s)
+                buf[idx++] = c;
+
             return buf.length;
         }
     }


### PR DESCRIPTION
Instead of using buf.length = 0, use buf = buf[0..0] slice technique to clean
the array and reuse, if possible, the buffer to reduce GC allocations.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---
Benchmark: https://gist.github.com/run-dlang/7d0a5264d186ac8db487447ec5352366