### PR TITLE
math: mark tan as @safe instead of @trusted

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -455,7 +455,7 @@ float sin(float x) @safe pure nothrow @nogc { return core.math.sin(x); }
  *      $(TR $(TD $(PLUSMNINF))  $(TD $(NAN))       $(TD yes))
  *      )
  */
-real tan(real x) @trusted pure nothrow @nogc // TODO: @safe
+real tan(real x) @safe pure nothrow @nogc
 {
     version (InlineAsm_X86_Any)
     {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---
I don't really understood the `TODO` here, as `tanImpl` is @safe and `tanAsm` is @trusted, so here should be marked as @safe .