### PR TITLE
Add support for FreeBSD x86 reals

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -936,7 +936,8 @@ Complex!T sin(T)(Complex!T z)  @safe pure nothrow @nogc
 
 @safe pure nothrow unittest
 {
-    assert(ceqrel(sin(complex(2.0L, 0)), std.math.sin(2.0L)) >= real.mant_dig - 1);
+    static import std.math;
+    assert(ceqrel(sin(complex(2.0L, 0)), complex(std.math.sin(2.0L))) >= real.mant_dig - 1);
 }
 
 /// ditto

--- a/std/complex.d
+++ b/std/complex.d
@@ -901,6 +901,17 @@ Complex!(CommonType!(T, U)) fromPolar(T, U)(const T modulus, const U argument)
     assert(approxEqual(z.im, 1.0L, real.epsilon));
 }
 
+version (StdUnittest)
+{
+    // Helper function for comparing two Complex numbers.
+    int ceqrel(T)(const Complex!T x, const Complex!T y) @safe pure nothrow @nogc
+    {
+        import std.math : feqrel;
+        const r = feqrel(x.re, y.re);
+        const i = feqrel(x.im, y.im);
+        return r < i ? r : i;
+    }
+}
 
 /**
     Trigonometric functions on complex numbers.
@@ -920,9 +931,13 @@ Complex!T sin(T)(Complex!T z)  @safe pure nothrow @nogc
 {
     static import std.math;
     assert(sin(complex(0.0)) == 0.0);
-    assert(sin(complex(2.0L, 0)) == std.math.sin(2.0L));
+    assert(sin(complex(2.0, 0)) == std.math.sin(2.0));
 }
 
+@safe pure nothrow unittest
+{
+    assert(ceqrel(sin(complex(2.0L, 0)), std.math.sin(2.0L)) >= real.mant_dig - 1);
+}
 
 /// ditto
 Complex!T cos(T)(Complex!T z)  @safe pure nothrow @nogc
@@ -937,26 +952,15 @@ Complex!T cos(T)(Complex!T z)  @safe pure nothrow @nogc
 {
     static import std.math;
     assert(cos(complex(0.0)) == 1.0);
-    assert(cos(complex(1.3L, 0.0)) == std.math.cos(1.3L));
-    assert(cos(complex(0.0L, 5.2L)) == std.math.cosh(5.2L));
-}
-
-version (StdUnittest)
-{
-    int ceqrel(T)(const Complex!T x, const Complex!T y) @safe pure nothrow @nogc
-    {
-        import std.math : feqrel;
-        const r = feqrel(x.re, y.re);
-        const i = feqrel(x.im, y.im);
-        return r < i ? r : i;
-    }
+    assert(cos(complex(1.3, 0.0)) == std.math.cos(1.3));
+    assert(cos(complex(0.0, 5.2)) == std.math.cosh(5.2));
 }
 
 @safe pure nothrow unittest
 {
     static import std.math;
     assert(ceqrel(cos(complex(0, 5.2L)), complex(std.math.cosh(5.2L), 0.0L)) >= real.mant_dig - 1);
-    assert(cos(complex(1.3L)) == std.math.cos(1.3L));
+    assert(ceqrel(cos(complex(1.3L)), complex(std.math.cos(1.3L))) >= real.mant_dig - 1);
 }
 
 /// ditto

--- a/std/conv.d
+++ b/std/conv.d
@@ -1750,6 +1750,8 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
     }
     static void testFloatingToIntegral(Floating, Integral)()
     {
+        import std.math : floatTraits, RealFormat;
+
         bool convFails(Source, Target, E)(Source src)
         {
             try
@@ -1781,18 +1783,23 @@ if (!isImplicitlyConvertible!(S, T) && isAssociativeArray!S &&
         {
             a = -a; // -Integral.min not representable as an Integral
             assert(convFails!(Floating, Integral, ConvOverflowException)(a)
-                    || Floating.sizeof <= Integral.sizeof);
+                    || Floating.sizeof <= Integral.sizeof
+                    || floatTraits!Floating.realFormat == RealFormat.ieeeExtended53);
         }
         a = 0.0 + Integral.min;
         assert(to!Integral(a) == Integral.min);
         --a; // no more representable as an Integral
         assert(convFails!(Floating, Integral, ConvOverflowException)(a)
-                || Floating.sizeof <= Integral.sizeof);
+                || Floating.sizeof <= Integral.sizeof
+                || floatTraits!Floating.realFormat == RealFormat.ieeeExtended53);
         a = 0.0 + Integral.max;
-        assert(to!Integral(a) == Integral.max || Floating.sizeof <= Integral.sizeof);
+        assert(to!Integral(a) == Integral.max
+                || Floating.sizeof <= Integral.sizeof
+                || floatTraits!Floating.realFormat == RealFormat.ieeeExtended53);
         ++a; // no more representable as an Integral
         assert(convFails!(Floating, Integral, ConvOverflowException)(a)
-                || Floating.sizeof <= Integral.sizeof);
+                || Floating.sizeof <= Integral.sizeof
+                || floatTraits!Floating.realFormat == RealFormat.ieeeExtended53);
         // convert a value with a fractional part
         a = 3.14;
         assert(to!Integral(a) == 3);
@@ -3278,7 +3285,9 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 @system unittest
 {
     // @system because strtod is not @safe.
-    static if (real.mant_dig == 53)
+    import std.math : floatTraits, RealFormat;
+
+    static if (floatTraits!real.realFormat == RealFormat.ieeeDouble)
     {
         import core.stdc.stdlib, std.exception, std.math;
 
@@ -3361,7 +3370,8 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         {
             ushort[8] value;
         }
-        else static if (floatTraits!real.realFormat == RealFormat.ieeeExtended)
+        else static if (floatTraits!real.realFormat == RealFormat.ieeeExtended ||
+                        floatTraits!real.realFormat == RealFormat.ieeeExtended53)
         {
             ushort[5] value;
         }
@@ -3383,6 +3393,8 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         enum s = "0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382";
     else static if (floatTraits!real.realFormat == RealFormat.ieeeExtended)
         enum s = "0x1.FFFFFFFFFFFFFFFEp-16382";
+    else static if (floatTraits!real.realFormat == RealFormat.ieeeExtended53)
+        enum s = "0x1.FFFFFFFFFFFFFFFEp-16382";
     else static if (floatTraits!real.realFormat == RealFormat.ieeeDouble)
         enum s = "0x1.FFFFFFFFFFFFFFFEp-1000";
     else
@@ -3400,6 +3412,8 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         else
             ld1 = strtold(s.ptr, null);
     }
+    else static if (floatTraits!real.realFormat == RealFormat.ieeeExtended53)
+        ld1 = 0x1.FFFFFFFFFFFFFFFEp-16382L; // strtold rounds to 53 bits.
     else
         ld1 = strtold(s.ptr, null);
 

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -253,6 +253,8 @@ static if (floatTraits!(real).realFormat == RealFormat.ieeeQuadruple)
     enum real MAXGAMMA = 1755.5483429L;
 else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
     enum real MAXGAMMA = 1755.5483429L;
+else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended53)
+    enum real MAXGAMMA = 1755.5483429L;
 else static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     enum real MAXGAMMA = 171.6243769L;
 else
@@ -599,6 +601,11 @@ static if (floatTraits!(real).realFormat == RealFormat.ieeeQuadruple)
     enum real MINLOG = -0x1.6546282207802c89d24d65e96274p+13L; // log(real.min_normal*real.epsilon) = log(smallest denormal)
 }
 else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended)
+{
+    enum real MAXLOG = 0x1.62e42fefa39ef358p+13L;  // log(real.max)
+    enum real MINLOG = -0x1.6436716d5406e6d8p+13L; // log(real.min_normal*real.epsilon) = log(smallest denormal)
+}
+else static if (floatTraits!(real).realFormat == RealFormat.ieeeExtended53)
 {
     enum real MAXLOG = 0x1.62e42fefa39ef358p+13L;  // log(real.max)
     enum real MINLOG = -0x1.6436716d5406e6d8p+13L; // log(real.min_normal*real.epsilon) = log(smallest denormal)


### PR DESCRIPTION
These are changes based off the dmd-cxx branch, so there may be a few more cases that need to be dealt with in master, however this is enough for 32-bit FreeBSD to compile and initially pass all phobos unittests.