### PR TITLE
Fix Issue 15425 - std.traits.hasIndirections fails to recognize nested structs

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3379,13 +3379,14 @@ private template hasAliasingImpl(T)
 /**
 Returns `true` if and only if `T`'s representation includes at
 least one of the following: $(OL $(LI a raw pointer `U*`;) $(LI an
-array `U[]`;) $(LI a reference to a class type `C`.)
-$(LI an associative array.) $(LI a delegate.))
+array `U[]`;) $(LI a reference to a class type `C`;)
+$(LI an associative array;) $(LI a delegate;)
+$(LI a [context pointer][isNested].))
  */
 template hasIndirections(T)
 {
     static if (is(T == struct) || is(T == union))
-        enum hasIndirections = anySatisfy!(.hasIndirections, FieldTypeTuple!T);
+        enum hasIndirections = anySatisfy!(.hasIndirections, typeof(T.tupleof));
     else static if (isStaticArray!T && is(T : E[N], E, size_t N))
         enum hasIndirections = is(E == void) ? true : hasIndirections!E;
     else static if (isFunctionPointer!T)
@@ -3466,6 +3467,9 @@ template hasIndirections(T)
     static assert( hasIndirections!S24);
     static assert( hasIndirections!S25);
     static assert( hasIndirections!S26);
+    int local;
+    struct HasContextPointer { int opCall() { return ++local; } }
+    static assert(hasIndirections!HasContextPointer);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=12000


### PR DESCRIPTION
>`hasIndirections` is used (among other things) to check whether a memory allocation needs to be registered with the GC (e.g. in `RefCounted`), or whether an object can be safely sent to another thread (e.g. `hasUnsharedAliasing`). For these purposes, it is crucial that it checks _all_ indirections, not just the explicitly declared ones.

This also affects a great deal of code in the wild ([for instance esmi_containers](https://github.com/dlang-community/containers/blob/fc1625a5a0c253272b80addfb4107928495fd647/src/containers/internal/node.d#L60-L64)). However this behavior change has the potential to cause disruption so I thought it would make sense to target master rather than stable. Does that make sense?