### PR TITLE
freebsd/ci: Explicitly target FreeBSD 12 in cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,5 +60,6 @@ task:
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_and_git_script: pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE


### PR DESCRIPTION
CI script was updated to handle environment variable in dlang/dmd#11982 