### PR TITLE
[trivial] std.array: Don't assume that .idup of immutable array will reallocate

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1158,7 +1158,7 @@ if (is(typeof(a.ptr < b.ptr) == bool))
     test(a, b);
     assert(overlap(a, b.dup).empty);
     test(c, d);
-    assert(overlap(c, d.idup).empty);
+    assert(overlap(c, d.dup.idup).empty);
 }
 
  // https://issues.dlang.org/show_bug.cgi?id=9836


### PR DESCRIPTION
Fixes a unit test to pass with https://github.com/dlang/druntime/pull/3281.