### PR TITLE
merge stable

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3619,17 +3619,18 @@ if (isDynamicArray!A)
 
         auto app = appender!string();
         auto spec = singleSpec("%s");
+        immutable len = _data ? _data.arr.length : 0;
         // different reserve lengths because each element in a
         // non-string-like array uses two extra characters for `, `.
         static if (isSomeString!A)
         {
-            app.reserve(_data.arr.length + 25);
+            app.reserve(len + 25);
         }
         else
         {
             // Multiplying by three is a very conservative estimate of
             // length, as it assumes each element is only one char
-            app.reserve((_data.arr.length * 3) + 25);
+            app.reserve((len * 3) + 25);
         }
         toString(app, spec);
         return app.data;
@@ -3771,6 +3772,16 @@ if (isDynamicArray!A)
     auto wstr = appender!wstring();
     put(wstr, str.byCodeUnit);
     assert(wstr.data == str.to!wstring);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21256
+@safe unittest
+{
+    Appender!string app1;
+    app1.toString();
+
+    Appender!(int[]) app2;
+    app2.toString();
 }
 
 //Calculates an efficient growth scheme based on the old capacity

--- a/std/random.d
+++ b/std/random.d
@@ -2427,9 +2427,9 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T) && isUniformRNG!UniformRand
     /* dchar does not use its full bit range, so we must
      * revert to the uniform with specified bounds
      */
-    static if (is(T == dchar))
+    static if (is(immutable T == immutable dchar))
     {
-        return uniform!"[]"(T.min, T.max);
+        return uniform!"[]"(T.min, T.max, urng);
     }
     else
     {
@@ -2467,6 +2467,16 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
     enum Fruit { apple, mango, pear }
     version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(rnd.uniform!Fruit == Fruit.mango);
+}
+
+@safe unittest
+{
+    // https://issues.dlang.org/show_bug.cgi?id=21383
+    auto rng1 = Xorshift32(123456789);
+    auto rng2 = rng1.save;
+    assert(rng1.uniform!dchar == rng2.uniform!dchar);
+    // https://issues.dlang.org/show_bug.cgi?id=21384
+    assert(rng1.uniform!(const shared dchar) <= dchar.max);
 }
 
 @safe unittest


### PR DESCRIPTION
- Fix Issue 21383 - std.random.uniform!T(urng) when T is dchar disregards urng and always uses a thread-local random
- Fix Issue 21384 - std.random.uniform!T() and std.random.uniform!T(urng) when T is dchar with any qualifiers can exceed dchar.max
- Fix Issue 21256 - Segfault with Appender!string.init.toString()
