### PR TITLE
[dmd-cxx] Remove support for extern(Pascal)

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1927,7 +1927,7 @@ Determine the linkage attribute of the function.
 Params:
     func = the function symbol, or the type of a function, delegate, or pointer to function
 Returns:
-    one of the strings "D", "C", "Windows", "Pascal", or "Objective-C"
+    one of the strings "D", "C", "Windows", or "Objective-C"
 */
 template functionLinkage(func...)
     if (func.length == 1 && isCallable!func)
@@ -2148,7 +2148,7 @@ template SetFunctionAttributes(T, string linkage, uint attrs)
             !(attrs & FunctionAttribute.safe),
             "Cannot have a function/delegate that is both trusted and safe.");
 
-        static immutable linkages = ["D", "C", "Windows", "Pascal", "C++", "System"];
+        static immutable linkages = ["D", "C", "Windows", "C++", "System"];
         static assert(canFind(linkages, linkage), "Invalid linkage '" ~
             linkage ~ "', must be one of " ~ linkages.stringof ~ ".");
 
@@ -2263,7 +2263,7 @@ version (unittest)
             // Check that all linkage types work (D-style variadics require D linkage).
             static if (variadicFunctionStyle!T != Variadic.d)
             {
-                foreach (newLinkage; AliasSeq!("D", "C", "Windows", "Pascal", "C++"))
+                foreach (newLinkage; AliasSeq!("D", "C", "Windows", "C++"))
                 {
                     alias New = SetFunctionAttributes!(T, newLinkage, attrs);
                     static assert(functionLinkage!New == newLinkage,


### PR DESCRIPTION
Notable dead feature (never been supported) in gdc that should definitely be removed. :-)