### PR TITLE
Make `std.concurrency.Tid.toString` @safe-able

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -387,17 +387,17 @@ public:
      * that a Tid executed in the future will have the same toString() output
      * as another Tid that has already terminated.
      */
-    void toString(scope void delegate(const(char)[]) sink) const
+    void toString(W)(ref W w) const
     {
-        import std.format.write : formattedWrite;
-        formattedWrite(sink, "Tid(%x)", cast(void*) mbox);
+        import std.format : formattedWrite;
+        auto p = () @trusted { return cast(void*) mbox; }();
+        formattedWrite(w, "Tid(%x)", p);
     }
 
 }
 
-@system unittest
+@safe unittest
 {
-    // text!Tid is @system
     import std.conv : text;
     Tid tid;
     assert(text(tid) == "Tid(0)");

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -389,7 +389,7 @@ public:
      */
     void toString(W)(ref W w) const
     {
-        import std.format : formattedWrite;
+        import std.format.write : formattedWrite;
         auto p = () @trusted { return cast(void*) mbox; }();
         formattedWrite(w, "Tid(%x)", p);
     }


### PR DESCRIPTION
Currently `std.concurrency.Tid` cannot be converted to a string safely by `std.conv` family, for example.
This request fixes this issue.

- It fixes the signature of `Tid.toString` to work with safe code (See also [std.format.formatValue](https://dlang.org/phobos/std_format.html#.formatValue)), and
- encloses an unsafe cast from `MessageBox` to `void*` with a trusted lambda function.
