### PR TITLE
std.stdio: Deprecate extern(C) getline

### DIFF
--- a/changelog/deprecate-stdio-bindings.dd
+++ b/changelog/deprecate-stdio-bindings.dd
@@ -1,0 +1,5 @@
+Deprecate `std.stdio.getline`
+
+The publicly available `extern(C)` binding for `getline` in `std.stdio` has
+been deprecated. Any code that still needs it can import the symbol from
+`core.sys.posix.stdio` in druntime instead.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -264,7 +264,10 @@ else
 version (HAS_GETDELIM) extern(C) nothrow @nogc
 {
     ptrdiff_t getdelim(char**, size_t*, int, FILE*);
+
+    // @@@DEPRECATED_2.104@@@
     // getline() always comes together with getdelim()
+    deprecated("To be removed after 2.104. Use core.sys.posix.stdio.getline instead.")
     ptrdiff_t getline(char**, size_t*, FILE*);
 }
 


### PR DESCRIPTION
The (accidentally?) publicly available `extern(C)` binding for `getline` in `std.stdio` has been deprecated. Any code that still needs it can import the symbol from `core.sys.posix.stdio` in druntime instead.

Within phobos itself, this function is unused.