### PR TITLE
std.stdio: Deprecate extern(C) getdelim

### DIFF
--- a/changelog/deprecate-stdio-bindings.dd
+++ b/changelog/deprecate-stdio-bindings.dd
@@ -1,5 +1,5 @@
-Deprecate `std.stdio.getline`
+Deprecate `std.stdio.getdelim` and `std.stdio.getline`
 
-The publicly available `extern(C)` binding for `getline` in `std.stdio` has
-been deprecated. Any code that still needs it can import the symbol from
-`core.sys.posix.stdio` in druntime instead.
+The publicly available `extern(C)` bindings for `getdelim` and `getline` in
+`std.stdio` have been deprecated. Any code that still needs it can import the
+symbol from `core.sys.posix.stdio` in druntime instead.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -256,6 +256,8 @@ static if (__traits(compiles, core.sys.posix.stdio.getdelim))
 {
     extern(C) nothrow @nogc
     {
+        // @@@DEPRECATED_2.104@@@
+        deprecated("To be removed after 2.104. Use core.sys.posix.stdio.getline instead.")
         ptrdiff_t getdelim(char**, size_t*, int, FILE*);
 
         // @@@DEPRECATED_2.104@@@
@@ -5497,7 +5499,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
             }
         }
 
-        auto s = getdelim(&lineptr, &n, terminator, fps);
+        auto s = core.sys.posix.stdio.getdelim(&lineptr, &n, terminator, fps);
         if (s < 0)
         {
             if (ferror(fps))


### PR DESCRIPTION
The publicly available `extern(C)` binding for `getdelim` in `std.stdio` has been deprecated. Any code that still needs it can import the symbol from `core.sys.posix.stdio` in druntime instead.