### PR TITLE
std.stdio: Fix typo in getdelim deprecation message

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -257,7 +257,7 @@ static if (__traits(compiles, core.sys.posix.stdio.getdelim))
     extern(C) nothrow @nogc
     {
         // @@@DEPRECATED_2.104@@@
-        deprecated("To be removed after 2.104. Use core.sys.posix.stdio.getline instead.")
+        deprecated("To be removed after 2.104. Use core.sys.posix.stdio.getdelim instead.")
         ptrdiff_t getdelim(char**, size_t*, int, FILE*);
 
         // @@@DEPRECATED_2.104@@@


### PR DESCRIPTION
@thewilsonator failed my little turing test. :stuck_out_tongue: 