### PR TITLE
CirrusCI: Use HOST_DMD instead of HOST_DC

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ environment:
   CIRRUS_CLONE_DEPTH: 1
   # for ci.sh:
   MODEL: 64
-  HOST_DC: dmd
+  HOST_DMD: dmd
   N: 4
   OS_NAME: linux
   FULL_BUILD: false


### PR DESCRIPTION
Using HOST_DC is deprecated in the makefile, and the CI triggers a message
that can be misleading while trying to debug.