### PR TITLE
Clarify documentation for betaIncomplete.

### DIFF
--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -202,13 +202,14 @@ real logmdigammaInverse(real x)
 
 /** Incomplete beta integral
  *
- * Returns incomplete beta integral of the arguments, evaluated
+ * Returns regularized incomplete beta integral of the arguments, evaluated
  * from zero to x. The regularized incomplete beta function is defined as
  *
  * betaIncomplete(a, b, x) = $(GAMMA)(a + b) / ( $(GAMMA)(a) $(GAMMA)(b) ) *
  * $(INTEGRATE 0, x) $(POWER t, a-1)$(POWER (1-t), b-1) dt
  *
- * and is the same as the the cumulative distribution function.
+ * and is the same as the the cumulative distribution function of the Beta
+ * distribution.
  *
  * The domain of definition is 0 <= x <= 1.  In this
  * implementation a and b are restricted to positive values.

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -208,7 +208,7 @@ real logmdigammaInverse(real x)
  * betaIncomplete(a, b, x) = $(GAMMA)(a + b) / ( $(GAMMA)(a) $(GAMMA)(b) ) *
  * $(INTEGRATE 0, x) $(POWER t, a-1)$(POWER (1-t), b-1) dt
  *
- * and is the same as the the cumulative distribution function of the Beta
+ * and is the same as the cumulative distribution function of the Beta
  * distribution.
  *
  * The domain of definition is 0 <= x <= 1.  In this


### PR DESCRIPTION
The documentation alternately describes betaIncomplete as computing the incomplete beta function and the *regularized* incomplete beta function. The definition given is that of the regularized version, and the values returned are consistent with this interpretation as well.