### PR TITLE
std.mmfile: correct the documented type of thrown exceptions

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -68,7 +68,8 @@ class MmFile
      * Open memory mapped file filename for reading.
      * File is closed when the object instance is deleted.
      * Throws:
-     *  std.file.FileException
+     *  - On POSIX, $(REF ErrnoException, std, exception).
+     *  - On Windows, $(REF WindowsException, std, windows, syserror).
      */
     this(string filename)
     {
@@ -164,7 +165,8 @@ class MmFile
      *      with 0 meaning map the entire file. The window size must be a
      *      multiple of the memory allocation page size.
      * Throws:
-     *  std.file.FileException
+     *  - On POSIX, $(REF ErrnoException, std, exception).
+     *  - On Windows, $(REF WindowsException, std, windows, syserror).
      */
     this(string filename, Mode mode, ulong size, void* address,
             size_t window = 0)


### PR DESCRIPTION
MmFile.this claims that it throws std.file.FileException.
However, that never happens in practice:
  * On POSIX, ErrnoException is thrown (due to use of errnoEnforce).
  * On Windows, WindowsException is thrown (due to use of wenforce).

This change updates the documentation to reflect real types of
exceptions thrown by the constructors.

Another alternative is to change the MmFile itself to throw
FileException as it claims to do, but this will break backward
compatibility with existing programs.