### PR TITLE
declaring templates inside static foreach is not reliable

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -902,6 +902,30 @@ private:
 {
     import std.meta : AliasSeq;
 
+    static T addRound(T)(uint rm)
+    {
+        pragma(inline, false) static void blockopt(ref T x) {}
+        pragma(inline, false);
+        FloatingPointControl fpctrl;
+        fpctrl.rounding = rm;
+        T x = 1;
+        blockopt(x); // avoid constant propagation by the optimizer
+        x += 0.1L;
+        return x;
+    }
+
+    static T subRound(T)(uint rm)
+    {
+        pragma(inline, false) static void blockopt(ref T x) {}
+        pragma(inline, false);
+        FloatingPointControl fpctrl;
+        fpctrl.rounding = rm;
+        T x = -1;
+        blockopt(x); // avoid constant propagation by the optimizer
+        x -= 0.1L;
+        return x;
+    }
+
     static foreach (T; AliasSeq!(float, double, real))
     {{
         /* Be careful with changing the rounding mode, it interferes
@@ -910,18 +934,6 @@ private:
          */
 
         {
-            static T addRound(T)(uint rm)
-            {
-                pragma(inline, false) static void blockopt(ref T x) {}
-                pragma(inline, false);
-                FloatingPointControl fpctrl;
-                fpctrl.rounding = rm;
-                T x = 1;
-                blockopt(x); // avoid constant propagation by the optimizer
-                x += 0.1L;
-                return x;
-            }
-
             T u = addRound!(T)(FloatingPointControl.roundUp);
             T d = addRound!(T)(FloatingPointControl.roundDown);
             T z = addRound!(T)(FloatingPointControl.roundToZero);
@@ -931,18 +943,6 @@ private:
         }
 
         {
-            static T subRound(T)(uint rm)
-            {
-                pragma(inline, false) static void blockopt(ref T x) {}
-                pragma(inline, false);
-                FloatingPointControl fpctrl;
-                fpctrl.rounding = rm;
-                T x = -1;
-                blockopt(x); // avoid constant propagation by the optimizer
-                x -= 0.1L;
-                return x;
-            }
-
             T u = subRound!(T)(FloatingPointControl.roundUp);
             T d = subRound!(T)(FloatingPointControl.roundDown);
             T z = subRound!(T)(FloatingPointControl.roundToZero);


### PR DESCRIPTION
Because of bugs https://issues.dlang.org/show_bug.cgi?id=20565 and https://issues.dlang.org/show_bug.cgi?id=14831 the code generation for template functions declared inside static foreach loops is not reliable. Until this gets fixed, it's best to move these outside the static foreach.