### PR TITLE
Make std.range.enumerate @nogc. 

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10470,7 +10470,7 @@ pure @safe unittest
 }
 @nogc @safe unittest
 {
-	const val = iota(1, 100).enumerate(1);
+   const val = iota(1, 100).enumerate(1);
 }
 // https://issues.dlang.org/show_bug.cgi?id=10939
 version (none)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10203,8 +10203,6 @@ in
             {
                 return range.length;
             }
-            import std.stdio;
-            debug writeln(getLength() < signed_t.max);
             //Can length fit in the signed type
             assert(getLength() < signed_t.max, "a signed length type is required but the range's length() is too great");
             signedLength = range.length;
@@ -10483,10 +10481,8 @@ unittest {
         bool empty() { return true; }
     }
     RangePayload thePayload;
-    //Assertion won't happen when contracts are elided.
+    //Assertion won't happen when contracts are disabled for -release.
     debug assertThrown!AssertError(enumerate(thePayload, -10));
-
-    auto x = enumerate(thePayload, -10);
 }
 // https://issues.dlang.org/show_bug.cgi?id=10939
 version (none)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10195,13 +10195,18 @@ in
             auto result = adds(start, range.length, overflow);
         else static if (isSigned!Enumerator)
         {
-            Largest!(Enumerator, Signed!LengthType) signedLength;
+            alias signed_t = Largest!(Enumerator, Signed!LengthType);
+            signed_t signedLength;
+            //Can length fit in the signed type
+            overflow = range.length > signed_t.max;
+            /*
+            //This isn't nogc(but should be...)
             try signedLength = to!(typeof(signedLength))(range.length);
             catch (ConvException)
                 overflow = true;
             catch (Exception)
                 assert(false);
-
+            */
             auto result = adds(start, signedLength, overflow);
         }
         else
@@ -10463,7 +10468,10 @@ pure @safe unittest
         }
     }}
 }
-
+@nogc @safe unittest
+{
+	const val = iota(1, 100).enumerate(1);
+}
 // https://issues.dlang.org/show_bug.cgi?id=10939
 version (none)
 {

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10471,7 +10471,8 @@ pure @safe unittest
 {
    const val = iota(1, 100).enumerate(1);
 }
-unittest {
+@nogc @safe unittest
+{
     import core.exception : AssertError;
     import std.exception : assertThrown;
     struct RangePayload {

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10204,7 +10204,8 @@ in
                 return range.length;
             }
             //Can length fit in the signed type
-            assert(getLength() < signed_t.max, "a signed length type is required but the range's length() is too great");
+            assert(getLength() < signed_t.max,
+                "a signed length type is required but the range's length() is too great");
             signedLength = range.length;
             auto result = adds(start, signedLength, overflow);
         }


### PR DESCRIPTION
std.conv is not nogc but it's not really neccessary here as far as I can see (a manual > check passes all existing tests).