### PR TITLE
container: array: add type checks for passed arguments in insertAfter()

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -1008,6 +1008,8 @@ if (!is(immutable T == immutable bool))
 
     /// ditto
     size_t insertAfter(Stuff)(Range r, Stuff stuff)
+    if (isImplicitlyConvertible!(Stuff, T) ||
+            isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))
     {
         import std.algorithm.mutation : bringToFront;
         enforce(r._outer._data is _data);
@@ -2183,6 +2185,8 @@ if (is(immutable T == immutable bool))
 
     /// ditto
     size_t insertAfter(Stuff)(Range r, Stuff stuff)
+    if (isImplicitlyConvertible!(Stuff, T) ||
+            isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))
     {
         import std.algorithm.mutation : bringToFront;
         // TODO: make this faster, it moves one bit at a time


### PR DESCRIPTION
insertAfter should receive a valid element or a Range of values according to
type T of the corresponding instance Array!T.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>