### PR TITLE
container: array: move memory reserve assert to the correct scope

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -427,9 +427,9 @@ if (!is(immutable T == immutable bool))
             if (_capacity == length)
             {
                 reserve(1 + capacity * 3 / 2);
+                assert(capacity > length && _payload.ptr,
+                    "Failed to reserve memory");
             }
-            assert(capacity > length && _payload.ptr,
-                "Failed to reserve memory");
             emplace(_payload.ptr + _payload.length, elem);
             _payload = _payload.ptr[0 .. _payload.length + 1];
             return 1;


### PR DESCRIPTION
Verification for faulty reserve() should only occur if a reserve() actually
occur.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>