### PR TITLE
Speed up walkLength for narrow strings

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1750,6 +1750,20 @@ if (isInputRange!Range && !isInfinite!Range)
     else
     {
         size_t result;
+        static if (autodecodeStrings && isNarrowString!Range)
+        {
+            import std.utf : codeUnitLimit;
+            result = range.length;
+            foreach (const i, const c; range)
+            {
+                if (c >= codeUnitLimit!Range)
+                {
+                    result = i;
+                    break;
+                }
+            }
+            range = range[result .. $];
+        }
         for ( ; !range.empty ; range.popFront() )
             ++result;
         return result;
@@ -1766,6 +1780,20 @@ if (isInputRange!Range)
     else
     {
         size_t result;
+        static if (autodecodeStrings && isNarrowString!Range)
+        {
+            import std.utf : codeUnitLimit;
+            result = upTo > range.length ? range.length : upTo;
+            foreach (const i, const c; range[0 .. result])
+            {
+                if (c >= codeUnitLimit!Range)
+                {
+                    result = i;
+                    break;
+                }
+            }
+            range = range[result .. $];
+        }
         for ( ; result < upTo && !range.empty ; range.popFront() )
             ++result;
         return result;

--- a/std/utf.d
+++ b/std/utf.d
@@ -1410,7 +1410,8 @@ do
     assert(str.decodeBack(i) == 'å' && i == 2 && str.empty);
 }
 
-// Gives the maximum value that a code unit for the given range type can hold.
+// For the given range, code unit values less than this
+// are guaranteed to be valid single-codepoint encodings.
 package template codeUnitLimit(S)
 if (isSomeChar!(ElementEncodingType!S))
 {


### PR DESCRIPTION
walkLength can be significantly sped up for narrow strings in the common case where they begin with a run of characters that do not require decoding.

Benchmark on my laptop for 12 character all-ASCII string:

| compile command | string size | old MB/s  | new MB/s | ratio |
|-----------------|-------------|-----------|----------|-------|
| dmd             |   12        |  86.30    |  409.17  |  4.7x |
| dmd -O          |   12        |  92.85    |  840.56  |  9.1x |
| dmd -O -inline  |   12        | 298.88    |  842.44  |  2.8x |
| ldc2            |   12        |  75.58    |  474.29  |  6.3x |
| ldc2 -O3        |   12        | 727.53    | 2248.80  |  3.1x |

Benchmark on my laptop for 2000 character all-ASCII string:

 | compile command | string size | old MB/s  | new MB/s | ratio |
|-----------------|-------------|-----------|----------|-------|
| dmd             | 2000        |  94.06    |  425.60  |  4.5x |
| dmd -O          | 2000        | 102.77    | 1047.31  | 10.2x |
| dmd -O -inline  | 2000        | 239.56    | 1055.37  |  4.4x |
| ldc2            | 2000        |  86.29    |  465.99  |  5.4x |
| ldc2 -O3        | 2000        | 626.03    | 2604.25  |  4.2x |
