### PR TITLE
Fix Issue 20552 - Deprecated Nullable.get warning with Appenders

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2942,6 +2942,22 @@ struct Nullable(T)
     }
 
     /**
+     * If value is null, sets this to null, otherwise assigns
+     * `value.get` to the internally-held state. If the assignment
+     * succeeds, `this` becomes non-null.
+     *
+     * Params:
+     *     value = A value of type `Nullable!T` to assign to this `Nullable`.
+     */
+    void opAssign()(Nullable!T value)
+    {
+        if (value._isNull)
+            nullify();
+        else
+            opAssign(value.get());
+    }
+
+    /**
      * If this `Nullable` wraps a type that already has a null value
      * (such as a pointer), then assigning the null value to this
      * `Nullable` is no different than assigning any other value of


### PR DESCRIPTION
`Nullable!T` has the following assignment operator: `opAssign()(T value)`. This `opAssign` can be called for both `Nullable!T` and `T` because of the inner `alias get this` of Nullable. However, when a Nullable is assigned to another Nullable
a bit copy is preferred rather then an alias this conversion. Despite this, `hasElaborateAssign` specifically calls opAssign thus triggering the `alias this`. To bypass this, I used the solution proposed by @FeepingCreature and added an opAssign overload that receives a `Nullable!T`. This does get rid of the deprecation, however, I don't know how to test this because when compiled with -de, the deprecation does not appear (and phobos is compiled that way). Suggestions?