### PR TITLE
Make isAutoDecodableString independent of issue 21570

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6770,7 +6770,7 @@ template isAutodecodableString(T)
     import std.range.primitives : autodecodeStrings;
 
     enum isAutodecodableString = autodecodeStrings &&
-        (is(T : const char[]) || is(T : const wchar[])) && !isStaticArray!T;
+        (is(T : const char[]) || is(T : const wchar[])) && !is(T : U[n], U, size_t n);
 }
 
 ///


### PR DESCRIPTION
The current implementation relies on issue 21570 to reject enums with
static arrays as their base type.

Use another is-expression instead of `isStaticArray` to detect types
that are (convertible to) static arrays.

See https://issues.dlang.org/show_bug.cgi?id=21570

---

Blocking dlang/dmd#12142