### PR TITLE
std.typecons.Nullable: Remove deprecated 'alias get this'.

### DIFF
--- a/changelog/nullable-remove-alias-get-this.dd
+++ b/changelog/nullable-remove-alias-get-this.dd
@@ -1,0 +1,7 @@
+`std.typecons.Nullable`: Remove deprecated `alias get this`.
+
+`Nullable` no longer implicitly converts to its member.
+This feature was problematic because a simple use of a value could
+invisibly cause an assertion due to type conversion.
+To restore the previous behavior, replace uses of a `Nullable` value
+`n` with `n.get`.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3071,54 +3071,6 @@ struct Nullable(T)
     {
         return isNull ? fallback : _value.payload;
     }
-
-    //@@@DEPRECATED_2.096@@@
-    deprecated(
-        "Implicit conversion with `alias Nullable.get this` will be removed after 2.096. Please use `.get` explicitly.")
-    @system unittest
-    {
-        import core.exception : AssertError;
-        import std.exception : assertThrown, assertNotThrown;
-
-        Nullable!int ni;
-        int i = 42;
-        //`get` is implicitly called. Will throw
-        //an AssertError in non-release mode
-        assertThrown!AssertError(i = ni);
-        assert(i == 42);
-
-        ni = 5;
-        assertNotThrown!AssertError(i = ni);
-        assert(i == 5);
-    }
-
-    //@@@DEPRECATED_2.096@@@
-    deprecated(
-        "Implicit conversion with `alias Nullable.get this` will be removed after 2.096. Please use `.get` explicitly.")
-    @property ref inout(T) get_() inout @safe pure nothrow
-    {
-        return get;
-    }
-
-    ///
-    @safe pure nothrow unittest
-    {
-        int i = 42;
-        Nullable!int ni;
-        int x = ni.get(i);
-        assert(x == i);
-
-        ni = 7;
-        x = ni.get(i);
-        assert(x == 7);
-    }
-
-    /**
-     * Implicitly converts to `T`.
-     * `this` must not be in the null state.
-     * This feature is deprecated and will be removed after 2.096.
-     */
-    alias get_ this;
 }
 
 /// ditto
@@ -3171,33 +3123,6 @@ auto nullable(T)(T t)
     a.nullify();
     assert(a.isNull);
     assertThrown!Throwable(a.get);
-}
-
-//@@@DEPRECATED_2.096@@@
-deprecated(
-    "Implicit conversion with `alias Nullable.get this` will be removed after 2.096. Please use `.get` explicitly.")
-@system unittest
-{
-    import std.exception : assertThrown;
-
-    Nullable!int a;
-    assert(a.isNull);
-    assertThrown!Throwable(a.get);
-    a = 5;
-    assert(!a.isNull);
-    assert(a == 5);
-    assert(a != 3);
-    assert(a.get != 3);
-    a.nullify();
-    assert(a.isNull);
-    a = 3;
-    assert(a == 3);
-    a *= 6;
-    assert(a == 18);
-    a = a;
-    assert(a == 18);
-    a.nullify();
-    assertThrown!Throwable(a += 2);
 }
 @safe unittest
 {


### PR DESCRIPTION
As per https://github.com/dlang/phobos/pull/7759

This is a bit early. There's three possible interpretations of the deprecation plan: the comments say "after 2.096", the deprecation notice says "in 2.096", and strictly speaking it should be removed in 2.098 because it was deprecated two major versions later than I'd originally intended.

But given all the issues we've had with the damn deprecation warning, at this stage I think people will mostly be glad just to be rid of it - especially considering this does not remove functionality, just convenience.

edit: added changelog entry