### PR TITLE
Fix issue 21575 - Child processes spawned by std.process.spawnProcess accidentally inherit signal masks in parent process

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2114,7 +2114,7 @@ enum Config
 }
 
 /**
-A sturct that controls the behavior of process creation functions in this module.
+A struct that controls the behavior of process creation functions in this module.
 */
 struct AdvancedConfig
 {

--- a/std/process.d
+++ b/std/process.d
@@ -1101,7 +1101,10 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                 if (stderrFD > STDERR_FILENO)  close(stderrFD);
             }
 
-            config.preExecFunction(&abortOnErrorInPreExec);
+            if (config.preExecFunction !is null)
+            {
+                config.preExecFunction(&abortOnErrorInPreExec);
+            }
 
             // Execute program.
             core.sys.posix.unistd.execve(argz[0], argz.ptr, envz);

--- a/std/process.d
+++ b/std/process.d
@@ -2121,7 +2121,6 @@ struct AdvancedConfig
     /**
     A function type that notifies error in forked process.
     */
-    version (Posix)
     alias AbortOnError = void delegate() nothrow @nogc @safe;
 
     /**

--- a/std/process.d
+++ b/std/process.d
@@ -2134,13 +2134,21 @@ struct Config
         return Config(flags | other.flags);
     } /// ditto
 
-    /**
-    A function that is called before `exec` in $(LREF spawnProcess).
-    $(LREF AbortOnError) can be called to notify errors in `preExecFunction` and
-    to abort forked process.  On Windows, this member has no effect.
-    */
-    alias AbortOnError = void delegate() nothrow @nogc @safe;
-    void function(AbortOnError) nothrow @nogc @safe preExecFunction; /// ditto
+    version (StdDdoc)
+    {
+        /**
+        A function that is called before `exec` in $(LREF spawnProcess).
+        $(LREF AbortOnError) can be called to notify errors in `preExecFunction` and
+        to abort forked process.  On Windows, this member has no effect.
+        */
+        alias AbortOnError = void delegate() nothrow @nogc @safe;
+        void function(AbortOnError) nothrow @nogc @safe preExecFunction; /// ditto
+    }
+    else version (Posix)
+    {
+        alias AbortOnError = void delegate() nothrow @nogc @safe;
+        void function(AbortOnError) nothrow @nogc @safe preExecFunction;
+    }
 }
 
 /// A handle that corresponds to a spawned process.

--- a/std/process.d
+++ b/std/process.d
@@ -1360,7 +1360,7 @@ private Pid spawnProcessWin(scope const(char)[] commandLine,
         throw ProcessException.newFromLastError("Failed to spawn process \"" ~ cast(string) program ~ '"');
 
     // figure out if we should close any of the streams
-    if (!(config & Config.retainStdin ) && stdinFD  > STDERR_FILENO
+    if (!(config.flags & Config.Flags.retainStdin ) && stdinFD  > STDERR_FILENO
                                         && stdinFD  != getFD(std.stdio.stdin ))
         stdin.close();
     if (!(config.flags & Config.Flags.retainStdout) && stdoutFD > STDERR_FILENO


### PR DESCRIPTION
It simply unblocks all the signals in a forked process spawned by `spawnProcessPosix`.

Note that the unittest for it uses `std.concurrency.receiveTimeout` and waits 3 seconds in the worst case. It may slows down the speed of unittests.
I will be happy if you have ideas to improve the test for it.
