### PR TITLE
Remove tests for complex and imaginary types

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -3001,44 +3001,6 @@ if (is(immutable T : immutable creal) && !is(T == enum) && !hasToString!(T, Char
     put(w, 'i');
 }
 
-version (TestComplex)
-deprecated
-@safe /*pure*/ unittest     // formatting floating point values is now impure
-{
-    import std.conv : to;
-    static foreach (T; AliasSeq!(cfloat, cdouble, creal))
-    {
-        formatTest( to!(          T)(1 + 1i), "1+1i" );
-        formatTest( to!(    const T)(1 + 1i), "1+1i" );
-        formatTest( to!(immutable T)(1 + 1i), "1+1i" );
-    }
-    static foreach (T; AliasSeq!(cfloat, cdouble, creal))
-    {
-        formatTest( to!(          T)(0 - 3i), "0-3i" );
-        formatTest( to!(    const T)(0 - 3i), "0-3i" );
-        formatTest( to!(immutable T)(0 - 3i), "0-3i" );
-    }
-}
-
-version (TestComplex)
-deprecated
-@system unittest
-{
-    formatTest( 3+2.25i, "3+2.25i" );
-
-    class C1 { cdouble val; alias val this; this(cdouble v){ val = v; } }
-    class C2 { cdouble val; alias val this; this(cdouble v){ val = v; }
-               override string toString() const { return "C"; } }
-    formatTest( new C1(3+2.25i), "3+2.25i" );
-    formatTest( new C2(3+2.25i), "C" );
-
-    struct S1 { cdouble val; alias val this; }
-    struct S2 { cdouble val; alias val this;
-                string toString() const { return "S"; } }
-    formatTest( S1(3+2.25i), "3+2.25i" );
-    formatTest( S2(3+2.25i), "S" );
-}
-
 /*
     Formatting an `ireal` is deprecated but still kept around for a while.
  */
@@ -3050,38 +3012,6 @@ if (is(immutable T : immutable ireal) && !is(T == enum) && !hasToString!(T, Char
 
     formatValueImpl(w, val.im, f);
     put(w, 'i');
-}
-
-version (TestComplex)
-deprecated
-@safe /*pure*/ unittest     // formatting floating point values is now impure
-{
-    import std.conv : to;
-    static foreach (T; AliasSeq!(ifloat, idouble, ireal))
-    {
-        formatTest( to!(          T)(1i), "1i" );
-        formatTest( to!(    const T)(1i), "1i" );
-        formatTest( to!(immutable T)(1i), "1i" );
-    }
-}
-
-version (TestComplex)
-deprecated
-@system unittest
-{
-    formatTest( 2.25i, "2.25i" );
-
-    class C1 { idouble val; alias val this; this(idouble v){ val = v; } }
-    class C2 { idouble val; alias val this; this(idouble v){ val = v; }
-               override string toString() const { return "C"; } }
-    formatTest( new C1(2.25i), "2.25i" );
-    formatTest( new C2(2.25i), "C" );
-
-    struct S1 { idouble val; alias val this; }
-    struct S2 { idouble val; alias val this;
-                string toString() const { return "S"; } }
-    formatTest( S1(2.25i), "2.25i" );
-    formatTest( S2(2.25i), "S" );
 }
 
 /*
@@ -6136,14 +6066,6 @@ private bool needToSwapEndianess(Char)(scope const ref FormatSpec!Char f)
 
     s = format("%d %s", 0x1234AF, 0xAFAFAFAF);
     assert(s == "1193135 2947526575");
-}
-
-version (TestComplex)
-deprecated
-@system unittest
-{
-        string s = format("%s", 1.2 + 3.4i);
-        assert(s == "1.2+3.4i", s);
 }
 
 @system unittest

--- a/std/string.d
+++ b/std/string.d
@@ -6314,14 +6314,6 @@ if (isSomeString!S ||
     assert(!isNumeric("+"));
 }
 
-version (TestComplex)
-deprecated
-@safe unittest
-{
-    import std.conv : to;
-    assert(isNumeric(to!string(123e+2+1234.78Li)) == true);
-}
-
 /*****************************
  * Soundex algorithm.
  *

--- a/std/traits.d
+++ b/std/traits.d
@@ -6196,12 +6196,6 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !is(T : ireal) && !is(
 
     static assert(!isFloatingPoint!int);
 
-    // complex and imaginary numbers do not pass
-    static assert(
-        !isFloatingPoint!cfloat &&
-        !isFloatingPoint!ifloat
-    );
-
     // types which act as floating point values do not pass
     struct S
     {
@@ -6231,18 +6225,6 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !is(T : ireal) && !is(
             static assert(!isFloatingPoint!(Q!T));
         }
     }
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=17195
-@safe unittest
-{
-    static assert(!isFloatingPoint!cfloat);
-    static assert(!isFloatingPoint!cdouble);
-    static assert(!isFloatingPoint!creal);
-
-    static assert(!isFloatingPoint!ifloat);
-    static assert(!isFloatingPoint!idouble);
-    static assert(!isFloatingPoint!ireal);
 }
 
 /**
@@ -6625,7 +6607,6 @@ enum bool isOrderingComparable(T) = is(typeof((ref T a) => a < a ? 1 : 0));
 {
     static assert(isOrderingComparable!int);
     static assert(isOrderingComparable!string);
-    static assert(!isOrderingComparable!creal);
 
     static struct Foo {}
     static assert(!isOrderingComparable!Foo);
@@ -6665,13 +6646,6 @@ enum bool isEqualityComparable(T) = is(typeof((ref T a) => a == a ? 1 : 0));
     static assert(isEqualityComparable!Bar);
     assert(b1 == b2);
     assert(b1 != b3);
-}
-
-version (TestComplex)
-deprecated
-@safe unittest
-{
-    static assert(isEqualityComparable!creal);
 }
 
 /**

--- a/std/variant.d
+++ b/std/variant.d
@@ -2015,15 +2015,6 @@ static class VariantException : Exception
     }
 }
 
-version (TestComplex)
-deprecated
-@system unittest
-{
-    auto v3 = Variant(1+2.0i);
-    hash[v3] = 2;
-    assert( hash[v3] == 2 );
-}
-
 @system unittest
 {
     // check comparisons incompatible with AllowedTypes


### PR DESCRIPTION
Because taking these types out of the language would be [no small feat](https://github.com/dlang/dmd/pull/12069), the simplest place to begin is to stop testing for it.  Listed as the first point to tackle in [issue 14488](https://issues.dlang.org/show_bug.cgi?id=14488).