### PR TITLE
Improve speed for printing floats with %a.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -7123,11 +7123,15 @@ if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.
     size_t hex_mant_pos = 0;
     size_t pos = mant_len;
 
+    auto gap = 39 - 32 * is_upper;
     while (pos >= 4 && (mnt & ((1L << pos) - 1)) != 0)
     {
         pos -= 4;
         size_t tmp = (mnt >> pos) & 15;
-        hex_mant[hex_mant_pos++] = cast(char) (tmp < 10 ? ('0' + tmp) : ((is_upper?'A':'a') + tmp - 10));
+        // For speed reasons the better readable
+        // ... = tmp < 10 ? ('0' + tmp) : ((is_upper ? 'A' : 'a') + tmp - 10))
+        // has been replaced with an expression without branches, doing the same
+        hex_mant[hex_mant_pos++] = cast(char) (tmp + gap * ((tmp + 6) >> 4) + '0');
     }
 
     // save integer part


### PR DESCRIPTION
Inspired by an [article](https://dlang.org/blog/2020/05/14/lomutos-comeback/) from @andralex I found some speed optimizations for printing floating point numbers with %a. The idea is, to replace branches inside of a loop with arithmetics doing the same.

Some speed messurements (times in ns):

Compiler | fp type | old version with snprintf | current version | proposed version
--|--|--|--|--
dmd | float | 414 | 422 | 408
dmd -O ... | float | 421 | 344 | 306
ldc | float | 520 | 517 | 465
ldc2 -O3 ... | float | 292 | 105 | 105
ldc2 with DPO | float | 207 | 103 | 104
dmd | double | 420 | 504 | 414
dmd -O ... | double | 410 | 406 | 314
ldc | double | 509 | 593 | 513
ldc2 -O3 ... | double | 242 | 106 | 106
ldc2 with DPO | double | 216 | 106 | 105

Compilerflags for optimization with dmd where `-O -release -boundscheck=off` and with ldc2 they where `-O3 -release -boundscheck=off -flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -mcpu=native`.

Seems like ldc with aggressive optimization is able to figure this out itself, while DPO only improves the use of `snprintf`.

(I did not manage to install a working version of gdc, so I had to skip it - maybe @ibuclaw might like to help me doing so? If yes, I'll supply times later.)

Thanks to @kinke and @Geod24 for help on ldc2 compilerflags.