### PR TITLE
Fix Issue 21601 - std.math : pow(float/double, -2) produces sometimes wrong result

### DIFF
--- a/changelog/bugfix_for_pow.dd
+++ b/changelog/bugfix_for_pow.dd
@@ -1,0 +1,13 @@
+Implementation of `pow(f, -2)` and `f ^^ -2` changed
+
+We noticed that the implementation of `pow(f, -2)` and `f ^^ -2` with
+`f` being a floating point value, was buggy for some values of `f`.
+Unfortunately the fix implies small changes for other values for `f`
+(with exponent `-2`) too: The least significant bits of the result might
+differ from the current implementation. (This is due to the
+peculiarities of floating point numbers and cannot be avoided with
+reasonable means.)
+
+To avoid problems, make sure, that your algorithms do not rely on the
+least significant bits of floating point calculations, for example by
+using `isClose` instead of `==`.


### PR DESCRIPTION
Recently I compared several algorithms for calculating `pow(b, e)` with `b` being a floating point and `e` an integer. I checked the current implementation, the implementation suggested in PR #7297, the implementation suggested in issue 16200 and the original algorithm from stepanov quoted in issue 16200 with the intend to replace the current algorithm with the one mentioned in issue 16200.

First, I tested the algorithms for correctness, by comparing several random generated calls with the exact result calculated with the linux tool 'bc' and rounded appropriately. The results showed, that the current algorithm has a design flaw for exponent -2 and PR #7297 has further design flaws for exponent -3 and 3.

|float|current|PR #7297|issue 16200|stepanov
|-|-|-|-|-
wrong|4098 (1.64%)|9411 (3.76%)|0|0
difference (avg.) | 466.22 | 858.19 | 0.00 | 0.00
difference (max.) | 2,011,150 | 2,011,150 | 0 | 0

|double|current|PR #7297|issue 16200|stepanov
|-|-|-|-|-
wrong|1386 (1.37%)|3145 (3.15%)|194 (0.19%)|194 (0.19%)
difference (avg.) | 28,323,033,265.48 | 51,480,639,103.68 | 0.00 | 0.00
difference (max.) | 631,739,613,622,540 | 782,593,570,062,451 | 1 | 1

|x87 real|current|PR #7297|issue 16200|stepanov
|-|-|-|-|-
wrong|5155 (68.73%)|5133 (68.44%)|5169 (68.92%)|5169 (68.92%)
difference (avg.) | 7.24 | 7.24 | 7.25 | 7.25
difference (max.) | 238 | 238 | 238 | 238

250000 tests for float, 100000 tests for double and 7500 tests for real. Tests did not include results, that reached a fixpoint (NaN, +/-inf, 0.0); difference has been messured in the number of 'nextUp' calls that where needed to get from the smaller number to the larger.

IMHO, the result clearly rules PR #7297 out. 

The issue with the current implementation can easily be fixed by removing the special treatment for -2 (this is, what this PR does - the suggested speed optimization is more difficult and left for an other PR). 

I also replaced the `switch` statement by an `if` statement. With that, the hack around a bug in the `switch` statement (see PR #7294) is not needed anymore and I removed this too.

Furthermore I had to fix some unittests for `quantize`: They used `==` for comparing floating point numbers which luckily worked with the old version, but does not with the new one.