### PR TITLE
Prepare to split up std.format into submodules.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -207,13 +207,13 @@ P2MODULES=$(foreach P,$1,$(addprefix $P/,$(PACKAGE_$(subst /,_,$P))))
 STD_PACKAGES = std $(addprefix std/,\
   algorithm container datetime digest experimental/allocator \
   experimental/allocator/building_blocks experimental/logger \
-  net uni \
+  format net uni \
   experimental range regex windows)
 
 # Modules broken down per package
 
 PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
-  conv csv demangle encoding exception file format \
+  conv csv demangle encoding exception file \
   functional getopt json math mathspecial meta mmfile numeric \
   outbuffer package parallelism path process random signals socket stdint \
   stdio string system traits typecons \
@@ -233,6 +233,7 @@ PACKAGE_std_experimental_allocator_building_blocks = \
   bucketizer fallback_allocator free_list free_tree bitmapped_block \
   kernighan_ritchie null_allocator package quantizer \
   region scoped_allocator segregator stats_collector
+PACKAGE_std_format = package
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -6418,7 +6418,7 @@ private bool needToSwapEndianess(Char)(scope const ref FormatSpec!Char f)
 }
 
 // Used to check format strings are compatible with argument types
-package static const checkFormatException(alias fmt, Args...) =
+package(std) static const checkFormatException(alias fmt, Args...) =
 {
     import std.conv : text;
 

--- a/win32.mak
+++ b/win32.mak
@@ -100,7 +100,6 @@ SRC= \
 SRC_STD_1= \
 	std\stdio.d \
 	std\string.d \
-	std\format.d \
 	std\file.d
 
 SRC_STD_2a= \
@@ -201,6 +200,9 @@ SRC_STD_DIGEST= \
 	std\digest\hmac.d \
 	std\digest\murmurhash.d \
 	std\digest\package.d
+
+SRC_STD_FORMAT= \
+    std\format\package.d
 
 SRC_STD_NET= \
 	std\net\isemail.d \
@@ -309,6 +311,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_CONTAINER) \
 	$(SRC_STD_DATETIME) \
 	$(SRC_STD_DIGEST) \
+	$(SRC_STD_FORMAT) \
 	$(SRC_STD_NET) \
 	$(SRC_STD_RANGE) \
 	$(SRC_STD_REGEX) \
@@ -378,6 +381,7 @@ UNITTEST_OBJS= \
 		unittest3b.obj \
 		unittest4.obj \
 		unittest5.obj \
+		unittest5a.obj \
 		unittest6.obj \
 		unittest6a.obj \
 		unittest6b.obj \
@@ -398,6 +402,7 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest3b.obj $(SRC_STD_DATETIME)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5.obj $(SRC_STD_ALGO)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5a.obj $(SRC_STD_FORMAT)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6a.obj $(SRC_STD_EXP_ALLOC)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
@@ -425,7 +430,6 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	del *.lst
 	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\stdio.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\string.d
-	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\format.d
 	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\file.d
 	$(DMD) -conf= -cov=ctfe -cov=86 $(UDFLAGS) -main -run std\range\package.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\array.d
@@ -476,6 +480,7 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\searching.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\setops.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\sorting.d
+	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\format\package.d
 	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\variant.d
 	$(DMD) -conf= -cov=ctfe -cov=58 $(UDFLAGS) -main -run std\zlib.d
 	$(DMD) -conf= -cov=ctfe -cov=53 $(UDFLAGS) -main -run std\socket.d

--- a/win64.mak
+++ b/win64.mak
@@ -104,7 +104,6 @@ SRC= \
 SRC_STD_1= \
 	std\stdio.d \
 	std\string.d \
-	std\format.d \
 	std\file.d
 
 SRC_STD_2a= \
@@ -199,6 +198,9 @@ SRC_STD_ALGO= \
 	$(SRC_STD_ALGO_1) \
 	$(SRC_STD_ALGO_2) \
 	$(SRC_STD_ALGO_3)
+
+SRC_STD_FORMAT= \
+    std\format\package.d
 
 SRC_STD_CONTAINER= \
 	std\container\array.d \
@@ -334,6 +336,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_CONTAINER) \
 	$(SRC_STD_DATETIME) \
 	$(SRC_STD_DIGEST) \
+	$(SRC_STD_FORMAT) \
 	$(SRC_STD_NET) \
 	$(SRC_STD_RANGE) \
 	$(SRC_STD_REGEX) \
@@ -407,6 +410,7 @@ UNITTEST_OBJS= \
 		unittest5a.obj \
 		unittest5b.obj \
 		unittest5c.obj \
+		unittest5d.obj \
 		unittest6a.obj \
 		unittest6c.obj \
 		unittest6e.obj \
@@ -435,6 +439,7 @@ unittest : $(LIB)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5a.obj $(SRC_STD_ALGO_1)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5b.obj $(SRC_STD_ALGO_2)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5c.obj $(SRC_STD_ALGO_3)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest5d.obj $(SRC_STD_FORMAT)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6a.obj $(SRC_STD_6a)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6c.obj $(SRC_STD_6c)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6e.obj $(SRC_STD_6e)


### PR DESCRIPTION
The idea is, to make very small steps here. One of the main problem of splitting modules is, that ideally no other PR should be merged during the process, because it's easy to overlook some of these changes while rebasing a splitting PR. So I just moved here everything to std/format/package.d (with only a single slight change, that was needed). This can be repeated, whenever another PR is merged, without fear of any loss.

Ideally PRs #7617 and #5797 are merged before this one, so no rebasing is needed there anymore (both are already labeled with the merge label, but the tests are for unknown reasons stalled since days).

See also PR #7765 for the main idea behind this.