### PR TITLE
ascii: rewrite function to naturally generate more optimized code

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -187,7 +187,7 @@ else
   +/
 bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 {
-    return c <= 'z' && c >= '0' && (c <= '9' || c >= 'a' || (c >= 'A' && c <= 'Z'));
+    return isAlpha(c) || isDigit(c);
 }
 
 ///
@@ -219,7 +219,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 bool isAlpha(dchar c) @safe pure nothrow @nogc
 {
     // Optimizer can turn this into a bitmask operation on 64 bit code
-    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    return (c | 32) - 'a' < 26;
 }
 
 ///
@@ -250,7 +250,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
   +/
 bool isLower(dchar c) @safe pure nothrow @nogc
 {
-    return c >= 'a' && c <= 'z';
+    return c - 'a' < 26;
 }
 
 ///
@@ -282,7 +282,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
   +/
 bool isUpper(dchar c) @safe pure nothrow @nogc
 {
-    return c <= 'Z' && 'A' <= c;
+    return c - 'A' < 26;
 }
 
 ///
@@ -314,7 +314,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
   +/
 bool isDigit(dchar c) @safe pure nothrow @nogc
 {
-    return '0' <= c && c <= '9';
+    return c - '0' < 10;
 }
 
 ///
@@ -347,7 +347,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
   +/
 bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 {
-    return c >= '0' && c <= '7';
+    return c - '0' < 8;
 }
 
 ///
@@ -377,7 +377,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
   +/
 bool isHexDigit(dchar c) @safe pure nothrow @nogc
 {
-    return c <= 'f' && c >= '0' && (c <= '9' || c >= 'a' || (c >= 'A' && c <= 'F'));
+    return isDigit(c) || (c | 32) - 'a' < 6;
 }
 
 ///
@@ -410,7 +410,7 @@ bool isHexDigit(dchar c) @safe pure nothrow @nogc
   +/
 bool isWhite(dchar c) @safe pure nothrow @nogc
 {
-    return c == ' ' || (c >= 0x09 && c <= 0x0D);
+    return c == ' ' || c - '\t' < 5;
 }
 
 ///
@@ -486,7 +486,7 @@ bool isControl(dchar c) @safe pure nothrow @nogc
   +/
 bool isPunctuation(dchar c) @safe pure nothrow @nogc
 {
-    return c <= '~' && c >= '!' && !isAlphaNum(c);
+    return isGraphical(c) && !isAlphaNum(c);
 }
 
 ///
@@ -530,7 +530,7 @@ bool isPunctuation(dchar c) @safe pure nothrow @nogc
   +/
 bool isGraphical(dchar c) @safe pure nothrow @nogc
 {
-    return '!' <= c && c <= '~';
+    return c - 0x21 < 0x5e;
 }
 
 ///
@@ -566,7 +566,7 @@ bool isGraphical(dchar c) @safe pure nothrow @nogc
   +/
 bool isPrintable(dchar c) @safe pure nothrow @nogc
 {
-    return c >= ' ' && c <= '~';
+    return c - 0x20 < 0x5f;
 }
 
 ///
@@ -642,7 +642,7 @@ if (is(C : dchar))
     else static if (is(immutable OriginalType!C == immutable OC, OC))
         alias R = OC;
 
-    return isUpper(c) ? cast(R)(cast(R) c + 'a' - 'A') : cast(R) c;
+    return isUpper(c) ? cast(R)(cast(R) c | 32) : cast(R) c;
 }
 
 ///
@@ -704,7 +704,7 @@ if (is(C : dchar))
     else static if (is(immutable OriginalType!C == immutable OC, OC))
         alias R = OC;
 
-    return isLower(c) ? cast(R)(cast(R) c - ('a' - 'A')) : cast(R) c;
+    return isLower(c) ? cast(R)(cast(R) c & 0x5f) : cast(R) c;
 }
 
 ///


### PR DESCRIPTION
A lot of functions inside std.ascii and std.uni are fast only optimized by the
compiler optimizer. Some functions can be written to naturally generate more
optimized code.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Take the example of isDigit implementation:

Here are some performance tests comparing std and new std implementations. Running with 100 000 000 randomized iterations without running the optimizer

```
DMD64 v2.095.0
2 ms, 253 μs, and 9 hnsecs
2 ms, 242 μs, and 6 hnsecs

LDC 1.24.0
2 ms, 148 μs, and 2 hnsecs
2 ms, 105 μs, and 6 hnsecs

GDC 10.2.0
2 ms, 266 μs, and 5 hnsecs
2 ms, 251 μs, and 5 hnsecs
```

NOTE: These times are for 100 000 runs because the benchmark was made with 1000 different random seeds.

Generated Assembly for both implementations without the optimizer: https://godbolt.org/z/sav5qe
Benchmark source code: https://gist.github.com/run-dlang/8198a98f4fb4e99120f6351bd764408a
