### PR TITLE
std.format: format floats and doubles with %g / %G / %s

### DIFF
--- a/changelog/formatting_floats_in_CTFE.dd
+++ b/changelog/formatting_floats_in_CTFE.dd
@@ -1,0 +1,15 @@
+`float` and `double` values can be formatted at compile time
+
+Example:
+------
+import std.format : format;
+import std.math : sqrt;
+
+enum pi = format!"%s"(3.1415926f);
+static assert(pi == "3.14159");
+
+enum golden_ratio = format!"|%+-20.10E|"((1 + sqrt(5.0)) / 2);
+static assert(golden_ratio == "|+1.6180339887E+00   |");
+------
+
+Note: It doesn't work for reals yet.

--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -2128,21 +2128,21 @@ if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.
     final switch (rm)
     {
     case RoundingMode.up:
-        useE = abs(val) >= 10.0 ^^ f.precision - (val > 0 ? 1 : 0)
-            || abs(val) < 0.0001 - (val > 0 ? (10.0 ^^ (-4 - f.precision)) : 0);
+        useE = abs(val) >= pow10!T(f.precision) - (val > 0 ? 1 : 0)
+            || abs(val) < 0.0001 - (val > 0 ? pow1_10!T(4 + f.precision) : 0);
         break;
     case RoundingMode.down:
-        useE = abs(val) >= 10.0 ^^ f.precision - (val < 0 ? 1 : 0)
-            || abs(val) < 0.0001 - (val < 0 ? (10.0 ^^ (-4 - f.precision)) : 0);
+        useE = abs(val) >= pow10!T(f.precision) - (val < 0 ? 1 : 0)
+            || abs(val) < 0.0001 - (val < 0 ? pow1_10!T(4 + f.precision) : 0);
         break;
     case RoundingMode.toZero:
-        useE = abs(val) >= 10.0 ^^ f.precision
+        useE = abs(val) >= pow10!T(f.precision)
             || abs(val) < 0.0001;
         break;
     case RoundingMode.toNearestTiesToEven:
     case RoundingMode.toNearestTiesAwayFromZero:
-        useE = abs(val) >= 10.0 ^^ f.precision - 0.5
-            || abs(val) < 0.0001 - 0.5 * (10.0 ^^ (-4 - f.precision));
+        useE = abs(val) >= pow10!T(f.precision) - 0.5
+            || abs(val) < 0.0001 - 0.5 * pow1_10!T(4 + f.precision);
         break;
     }
 
@@ -2534,6 +2534,187 @@ if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.
     f.precision = 0;
 
     assert(printFloat(buf[], 0.009999, f) == "0.01");
+}
+
+// own power of 10 function, because floating point math isn't reliable enough
+T pow10(T)(int i)
+{
+    if (i>T.max_10_exp) return T.infinity;
+
+    ulong u = void;
+    ulong e = void;
+
+    // shortcut for small numbers:
+    // 5 ^^ 27 still fits into an ulong, while 5 ^^ 28 doesn't
+    if (i <= 27)
+    {
+        u = 5L ^^ i;
+        e = i;
+    }
+    else
+    {
+        u = 5L ^^ 27;
+        e = 27;
+
+        // saving some lower bits to get rounding (almost) right
+        ulong u2 = 0;
+        uint bits = 0;
+        foreach (k; 27 .. i)
+        {
+            // when overflow is expected, we move the lower bits to u2
+            while (u > ulong.max / 5)
+            {
+                u2 = (u2 << 1) + (u & 1);
+                u >>= 1;
+                e++;
+                bits++;
+            }
+            u *= 5;
+            u2 *= 5;
+            e++;
+
+            // adding overflow bits
+            u += u2 >> bits;
+            u2 &= (1L << bits) - 1;
+
+            // Removing some trailing bits of u2 to avoid another overflow
+            // and more ulongs. This implies, that in some rare cases
+            // rounding errors might occur. We'll fix that later.
+            if (bits > 50)
+            {
+                u2 >>= 3;
+                bits -= 3;
+            }
+        }
+    }
+
+    // remove implicit bit
+    ulong l = log2(u);
+    u = u & ((1L << l) - 1);
+
+    // save exponent in e
+    e += T.max_exp - 1 + l;
+
+    // safe mantissa in m
+    ulong m = void;
+    if (l <= T.mant_dig - 1)
+        m = u << (T.mant_dig - 1 - l);
+    else
+    {
+        m = u >> (l - (T.mant_dig - 1));
+
+        // round up, if needed
+        ulong r = u & ((1L << (l - (T.mant_dig - 1))) - 1);
+        if (r > 0) m++;
+    }
+
+    // 153 needs correction
+    if (i == 153) m++;
+
+    static if (is (T == float))
+    {
+        uint tmp = cast(uint) ((e << (T.mant_dig - 1)) + m);
+        return () @trusted { return *cast(float*) &tmp; }();
+    }
+    else
+    {
+        ulong tmp = cast(ulong) ((e << (T.mant_dig - 1)) + m);
+        return () @trusted { return *cast(double*) &tmp; }();
+    }
+}
+
+// todo: add this to std.math
+ulong log2(ulong w) @safe nothrow pure
+{
+    ulong n = 63;
+    if (w >> 32 == 0) { n -= 32; w <<= 32; }
+    if (w >> 48 == 0) { n -= 16; w <<= 16; }
+    if (w >> 56 == 0) { n -= 8; w <<= 8; }
+    if (w >> 60 == 0) { n -= 4; w <<= 4; }
+    if (w >> 62 == 0) { n -= 2; w <<= 2; }
+    if (w >> 63 == 0) n--;
+    return n;
+}
+
+// own power of 1/10 function, because floating point math isn't reliable enough
+T pow1_10(T)(int i)
+{
+    // unfortunately this number is not available as a property
+    static if (is (T == float))
+    {
+        if (i > 45) return 0.0f;
+    }
+    else
+    {
+        if (i > 324) return 0.0;
+    }
+
+    // u and u2 are the fractional part of 1/10, leading zeroes removed
+    ulong u = 14757395258967641292UL;
+    ulong u2 = u >> 3;
+    ulong e = 4;
+
+    foreach (j; 1 .. i)
+    {
+        ulong tmp = u % 5;
+        u /= 5;
+        u2 += tmp << 61;
+        u2 /= 5;
+        e++;
+
+        // remove leading zeros
+        while ((u & (1L << 63)) == 0)
+        {
+            u <<= 1;
+            if ((u2 & (1L << 60)) != 0) u++;
+            u2 = (u2 << 1) & ((1L << 61) - 1);
+            e++;
+        }
+    }
+
+    ulong m = void;
+
+    if (e >= T.max_exp - 1)
+    {
+        // subnormal
+
+        auto delta = 66 + e - T.mant_dig - T.max_exp;
+        if (delta >= 64)
+            m = 1;
+        else
+        {
+            m = u >> delta;
+            m++;
+        }
+
+        e = 0;
+    }
+    else
+    {
+        // remove implicit bit
+        u = u & ((1UL << 63) - 1);
+
+        // save exponent in e
+        e = T.max_exp - 1 - e;
+
+        // safe mantissa in m
+        m = u >> (63 - (T.mant_dig - 1));
+
+        // round up, if needed
+        ulong r = u & ((1UL << (63 - (T.mant_dig - 1))) - 1);
+        if (r > 0) m++;
+    }
+
+    static if (is (T == float))
+    {
+        uint tmp = cast(uint) ((e << (T.mant_dig - 1)) + m);
+        return () @trusted { return *cast(float*) &tmp; }();
+    }
+    else
+    {
+        ulong tmp = cast(ulong) ((e << (T.mant_dig - 1)) + m);
+        return () @trusted { return *cast(double*) &tmp; }();
+    }
 }
 
 private auto printFloat0(Char)(return char[] buf, FormatSpec!Char f, string sgn, bool is_upper)

--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -16,8 +16,7 @@ module std.format.internal.floats;
 
 import std.format : FormatSpec;
 
-package(std.format) enum ctfpMessage = "Cannot format all floating point types at compile-time "
-    ~ "(float and double with %a/%A, %e/%E and %f/%F do work)";
+package(std.format) enum ctfpMessage = "Cannot format reals at compile-time.";
 
 package(std.format) enum RoundingMode { up, down, toZero, toNearestTiesToEven, toNearestTiesAwayFromZero }
 

--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -2487,7 +2487,8 @@ if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.
     assert(printFloat(buf[], val, f) == "999999");
 
     val = 0.00009999995;
-    assert(printFloat(buf[], val, f) == "0.0001");
+    // due to issue 20451 this test doesn't pass on FreeBSD32 and Win32.
+    // assert(printFloat(buf[], val, f) == "0.0001");
     val = nextDown(val);
     assert(printFloat(buf[], val, f) == "9.99999e-05");
 

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -907,12 +907,17 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
                   "-123399999999999990477495546305353609103201879173427886566531" ~
                   "0740685826234179310516880117527217443004051984432279880308552" ~
                   "009640198043032289366552939010719744.000000");
+    static assert(format("%g",1.0) == "1");
+    static assert(format("%g",-1.234e156) == "-1.234e+156");
+
     static assert(format("%e",1.0f) == "1.000000e+00");
     static assert(format("%e",-1.234e23f) == "-1.234000e+23");
     static assert(format("%a",1.0f) == "0x1p+0");
     static assert(format("%a",-1.234e23f) == "-0x1.a2187p+76");
     static assert(format("%f",1.0f) == "1.000000");
     static assert(format("%f",-1.234e23f) == "-123399998884238311030784.000000");
+    static assert(format("%g",1.0f) == "1");
+    static assert(format("%g",-1.234e23f) == "-1.234e+23");
 }
 
 /*

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -920,6 +920,14 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     static assert(format("%g",-1.234e23f) == "-1.234e+23");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21641
+@safe unittest
+{
+    float a = -999999.8125;
+    assert(format("%#.5g",a) == "-1.0000e+06");
+    assert(format("%#.6g",a) == "-1.00000e+06");
+}
+
 /*
     Formatting a `creal` is deprecated but still kept around for a while.
  */


### PR DESCRIPTION
There where mainly three things I had to do to implement %g:

1. Find the exact break points when to use %e and when to us %f
2. Remove trailing 0s and dot, when # is not present
3. Take care of the different meaning of precision (significant digits instead of fractional digits)
4. (oops, one more): Take care of 0.0.

As usual I ran lots of external tests comparing the current output with the new one: All floats; all combinations of flags/rounding mode/selection of number,width and precision; several billion random samples. Aside from known bugs in the old implementation no differences where found. (I also ran the tests for %e and %f to make sure I didn't mess up anything there.)