### PR TITLE
Fix Issue 16200 - Faster pow implementation for integral exponents

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -7449,6 +7449,9 @@ real fma(real x, real y, real z) @safe pure nothrow @nogc { return (x * y) + z; 
 Unqual!F pow(F, G)(F x, G n) @nogc @trusted pure nothrow
 if (isFloatingPoint!(F) && isIntegral!(G))
 {
+    // NaN ^^ 0 is an exception defined by IEEE (yields 1 instead of NaN)
+    if (isNaN(x)) return n ? x : 1.0;
+
     import std.traits : Unsigned;
     real p = 1.0, v = void;
     Unsigned!(Unqual!G) m = n;
@@ -7468,13 +7471,76 @@ if (isFloatingPoint!(F) && isIntegral!(G))
             return 1.0;
         case 1:
             return x;
-        case 2:
-            return x * x;
         default:
         }
 
         v = x;
     }
+
+    // Bail out early, if we can estimate that the result is infinity or 0.0:
+    //
+    // We use the following two conclusions:
+    //
+    //    m * floor(log2(abs(v))) >= F.max_exp
+    // =>             abs(v) ^^ m >  F.max == nextDown(F.infinity)
+    //
+    //    m * (bias - ex - 1) >= bias + F.mant_dig - 1
+    // =>         abs(v) ^^ m <  2 ^^ (-bias - F.mant_dig + 2) == nextUp(0.0)
+    //
+    // floor(log2(abs(v))) == ex - bias can be directly taken from the
+    // exponent of the floating point represantation, to avoid long
+    // calculations here.
+
+    enum uint bias = F.max_exp - 1;
+
+    static if (is(F == float))
+    {
+        float f = cast(float) v;
+        uint ival = () @trusted { return *cast(uint*) &f; }();
+        ulong ex = (ival >> 23) & 255;
+    }
+    else static if (is(F == double) || (is(T == real) && T.mant_dig == double.mant_dig))
+    {
+        double d = cast(double) v;
+        ulong ival = () @trusted { return *cast(ulong*) &d; }();
+        ulong ex = (ival >> 52) & 2047;
+    }
+    else static if (is (F == real) && real.mant_dig == 64)
+    {
+        ulong ex = void;
+        if (__ctfe)
+        {
+            // in CTFE we cannot access the bit patterns and have therefore to
+            // fall back to the (slower) general case
+            // skipping subnormals by setting ex = bias
+            ex = abs(v) == F.infinity ? 2 * bias + 1 :
+                (abs(v) < F.min_normal ? bias : cast(ulong) (floor(log2(abs(v))) + bias));
+        }
+        else
+        {
+            ulong[2] ival = () @trusted { return *cast(ulong[2]*) &v; }();
+            ex = ival[1] & 32767;
+        }
+    }
+    else
+    {
+        // ToDo: Add special treatment for other reals too.
+
+        // In the general case we have to fall back to log2, which is slower, but still
+        // a certain speed gain compared to not bailing out early.
+            // skipping subnormals by setting ex = bias
+        ulong ex = abs(v) == F.infinity ? 2 * bias + 1 :
+            (abs(v) < F.min_normal ? bias : cast(ulong) (floor(log2(abs(v))) + bias));
+    }
+
+    // m * (...) can exceed ulong.max, we therefore first check m >= (...).
+    // This is sufficient to know that the result will be infinity or 0.0
+    // and at the same time it guards against an overflow.
+    if (ex > bias && (m >= F.max_exp || m * (ex - bias) >= F.max_exp))
+        return (m % 2 == 0 || v > 0) ? F.infinity : -F.infinity;
+    else if (ex < bias - 1
+             && (m >= bias + F.mant_dig - 1 || m * (bias - ex - 1) >= bias + F.mant_dig - 1))
+        return 0.0;
 
     while (1)
     {


### PR DESCRIPTION
A few weeks ago I checked the alternative algorithms for `pow` given in issue 16200. Although not the way @andralex suggests there (see attachment of the issue for why I did not implement the suggested algorithm and more details), this finally lead to some other ideas on how to improve speed for this function. The main idea is to bail out early, when the result is a fixpoint (NaN, +/-inf and 0.0).

IMHO, the result speaks for itself (averaged over random bit patterns for the floating point value and iterating the exponent from -500 to 500 on x-axis, run on 2 billion tests for each FP type):

![image](https://user-images.githubusercontent.com/77570303/109549168-e55e9f00-7acd-11eb-86d9-d225500eecf7.png)

For "normal" operations, that is calls, where the result is not one of the fix points, there is no theoretical advantage in this algorithm. But luckily, there seems to be no disadvantage in practice. Seems, we get the speedup here (almost) for free due to some pipelining techniques or similar in the processor.

Averages on my computer in 1/100 ns:

Type | Result | current | proposed
-|-|-|-
float | NaN | 168,000 | 1
|| +/-inf | 16,253 | 140
|| 0.0 | 11,555 | 160
|| other | 668 | 668
|| avg | 14,302 | 158
double | NaN | 166,192 | 3
|| +/-inf | 52,007 | 18
|| 0.0 | 14,980 | 21
|| other | 194 | 195
|| avg | 33,069 | 22
real | NaN | 162,821 | 4,990
|| +/-inf | 124,132 | 8
|| 0.0 | 12.271 | 8
|| other | 21 | 24
|| avg | 67,210 | 8

A strange casual result is the long duration `isNaN` takes for reals...

Proof of the two conclusions used in the code:

```
   m * floor(log2(abs(v))) >= F.max_exp  
=>        m * log2(abs(v)) >= F.max_exp
=>         log2(abs(v)^^m) >= F.max_exp = log2(F.max+1)
=>               abs(v)^^m >= F.max+1
=>               abs(v)^^m >  F.max
```

For the second one we have to note, that `nextUp(0.0) == 2 ^^ (-bias - F.mant_dig + 2)` and `floor(log2(abs(v))) == ex - bias`.

```
              m * (bias - ex - 1) >= bias + F.mant_dig - 1
=>            m * (bias - ex - 1) >= bias + F.mant_dig - 1
=>           -m * (ex - bias + 1) >= bias + F.mant_dig - 1
=> -m * (floor(log2(abs(v))) + 1) >= bias + F.mant_dig - 1
=>        -m * ceil(log2(abs(v))) >= bias + F.mant_dig - 1          // note: log2(abs(v)) < 0
=>              -m * log2(abs(v)) >= bias + F.mant_dig - 1
=>              -m * log2(abs(v)) >  bias + F.mant_dig - 2
=>               m * log2(abs(v)) <  -(bias + F.mant_dig - 2)
=>                log2(abs(v)^^m) <  -(bias + F.mant_dig - 2)
=>                      abs(v)^^m <  2^^(-bias - F.mant_dig + 2)
```
