### PR TITLE
Throughout Phobos use core.math intrinsics instead of std.math wrappers

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2133,7 +2133,8 @@ template roundTo(Target)
 {
     Target roundTo(Source)(Source value)
     {
-        import std.math : abs, log2, trunc;
+        import core.math : abs = fabs;
+        import std.math : log2, trunc;
 
         static assert(isFloatingPoint!Source);
         static assert(isIntegral!Target);
@@ -3335,7 +3336,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         ldval = ldval * msscale + lsdec;
     if (isHex)
     {
-        import std.math : ldexp;
+        import core.math : ldexp;
 
         // Exponent is power of 2, not power of 10
         ldval = ldexp(ldval,exp);

--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -2057,7 +2057,7 @@ private auto printFloatG(T, Char)(return char[] buf, T val, FormatSpec!Char f, R
                                   string sgn, int exp, ulong mnt, bool is_upper)
 if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.mant_dig))
 {
-    import std.math : abs;
+    import core.math : abs = fabs;
 
     if (f.precision == f.UNSPECIFIED)
         f.precision = 6;

--- a/std/internal/math/errorfunction.d
+++ b/std/internal/math/errorfunction.d
@@ -24,6 +24,7 @@
  */
 module std.internal.math.errorfunction;
 import std.math;
+import core.math : sqrt;
 
 pure:
 nothrow:

--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -21,6 +21,7 @@ Macros:
 module std.internal.math.gammafunction;
 import std.internal.math.errorfunction;
 import std.math;
+import core.math : fabs, sin, sqrt;
 
 pure:
 nothrow:

--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -119,6 +119,7 @@ real logGamma(real x)
  */
 real sgnGamma(real x)
 {
+    import core.math : rndtol;
     /* Author: Don Clugston. */
     if (isNaN(x)) return x;
     if (x > 0) return 1.0;

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -22,6 +22,7 @@ module std.numeric;
 
 import std.complex;
 import std.math;
+import core.math : fabs, ldexp, sin, sqrt;
 import std.range.primitives;
 import std.traits;
 import std.typecons;


### PR DESCRIPTION
Followup to PR #7821.