### PR TITLE
Document behavior of "any" and "all" with an empty range

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -108,7 +108,7 @@ import std.traits;
 import std.typecons : Tuple, Flag, Yes, No, tuple;
 
 /++
-Checks if $(I _all) of the elements verify `pred`.
+Checks if $(I _all) of the elements satisfy `pred`.
  +/
 template all(alias pred = "a")
 {
@@ -155,8 +155,8 @@ are true.
 }
 
 /++
-Checks if $(I _any) of the elements verifies `pred`.
-`!any` can be used to verify that $(I none) of the elements verify
+Checks if $(I _any) of the elements satisfies `pred`.
+`!any` can be used to verify that $(I none) of the elements satisfy
 `pred`.
 This is sometimes called `exists` in other languages.
  +/

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -113,8 +113,8 @@ Checks if $(I _all) of the elements verify `pred`.
 template all(alias pred = "a")
 {
     /++
-    Returns `true` if and only if $(I _all) values `v` found in the
-    input range `range` satisfy the predicate `pred`.
+    Returns `true` if and only if the input range `range` is empty
+    or $(I _all) values found in `range` satisfy the predicate `pred`.
     Performs (at most) $(BIGOH range.length) evaluations of `pred`.
      +/
     bool all(Range)(Range range)
@@ -163,8 +163,9 @@ This is sometimes called `exists` in other languages.
 template any(alias pred = "a")
 {
     /++
-    Returns `true` if and only if $(I _any) value `v` found in the
-    input range `range` satisfies the predicate `pred`.
+    Returns `true` if and only if the input range `range` is non-empty
+    and $(I _any) value found in `range` satisfies the predicate
+    `pred`.
     Performs (at most) $(BIGOH range.length) evaluations of `pred`.
      +/
     bool any(Range)(Range range)


### PR DESCRIPTION
This was implied by the previous version, but it's not super intuitive, so it's worth spelling out explicitly.

I also fixed a simple usage error in the docs for `any` and `all`.