### PR TITLE
Remove deprecated std.range.Transposed.save

### DIFF
--- a/changelog/transposed-remove-save.dd
+++ b/changelog/transposed-remove-save.dd
@@ -1,0 +1,3 @@
+`std.range.Transposed`: Remove deprecated member `save`
+
+`Transposed` never worked as forward range.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7564,12 +7564,6 @@ if (isForwardRange!RangeOfRanges &&
         return true;
     }
 
-    deprecated("This function is incorrect and will be removed November 2018. See the docs for more details.")
-    @property Transposed save()
-    {
-        return Transposed(_input.save);
-    }
-
     auto opSlice() { return this; }
 
 private:

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7632,10 +7632,6 @@ private:
 Given a range of ranges, returns a range of ranges where the $(I i)'th subrange
 contains the $(I i)'th elements of the original subranges.
 
-$(RED `Transposed` currently defines `save`, but does not work as a forward range.
-Consuming a copy made with `save` will consume all copies, even the original sub-ranges
-fed into `Transposed`.)
-
 Params:
     opt = Controls the assumptions the function makes about the lengths of the ranges (i.e. jagged or not)
     rr = Range of ranges


### PR DESCRIPTION
Using CI to see if there are any tests that need to be updated.

If changelog entry is too short maybe someone could fill in some more details. I don't know the full story behind the `Transposed.save`.