### PR TITLE
Fix Issue 18780 - Inconsistent behavior with Variant holding int converting to unsigned types

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -5036,7 +5036,7 @@ template ImplicitConversionTargets(T)
                        float, double, real, char, wchar, dchar);
     else static if (is(T == byte))
         alias ImplicitConversionTargets =
-            AliasSeq!(short, ushort, int, uint, long, ulong, CentTypeList,
+            AliasSeq!(short, int, long, SignedCentTypeList,
                        float, double, real, char, wchar, dchar);
     else static if (is(T == ubyte))
         alias ImplicitConversionTargets =
@@ -5044,13 +5044,13 @@ template ImplicitConversionTargets(T)
                        float, double, real, char, wchar, dchar);
     else static if (is(T == short))
         alias ImplicitConversionTargets =
-            AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(int, long, SignedCentTypeList, float, double, real);
     else static if (is(T == ushort))
         alias ImplicitConversionTargets =
             AliasSeq!(int, uint, long, ulong, CentTypeList, float, double, real);
     else static if (is(T == int))
         alias ImplicitConversionTargets =
-            AliasSeq!(long, ulong, CentTypeList, float, double, real);
+            AliasSeq!(long, SignedCentTypeList, float, double, real);
     else static if (is(T == uint))
         alias ImplicitConversionTargets =
             AliasSeq!(long, ulong, CentTypeList, float, double, real);
@@ -5102,7 +5102,7 @@ template ImplicitConversionTargets(T)
     import std.meta : AliasSeq;
 
     static assert(is(ImplicitConversionTargets!(ulong) == AliasSeq!(float, double, real)));
-    static assert(is(ImplicitConversionTargets!(int) == AliasSeq!(long, ulong, float, double, real)));
+    static assert(is(ImplicitConversionTargets!(int) == AliasSeq!(long, float, double, real)));
     static assert(is(ImplicitConversionTargets!(float) == AliasSeq!(double, real)));
     static assert(is(ImplicitConversionTargets!(double) == AliasSeq!(real)));
 

--- a/std/variant.d
+++ b/std/variant.d
@@ -1912,7 +1912,6 @@ static class VariantException : Exception
     assert( v.convertsTo!(long) );
     assert( v.get!(int) == 42 );
     assert( v.get!(long) == 42L );
-    assert( v.get!(ulong) == 42uL );
 
     v = "Hello, World!";
     assert( v.peek!(string) );


### PR DESCRIPTION
The docs of `ImplicitConversionTargets` state: "The possible targets are computed more conservatively than the language allows, eliminating all dangerous conversions."

I can't see, why a conversion from `int` to `uint` should be more dangerous than a conversion from `int` to `ulong` and the code is too old, to find any hint, why one was originally allowed and the other not.