### PR TITLE
Add forgotten modules to std.package.

### DIFF
--- a/std/package.d
+++ b/std/package.d
@@ -69,6 +69,7 @@ public import
  std.stdint,
  std.stdio,
  std.string,
+ std.sumtype,
  std.system,
  std.traits,
  std.typecons,


### PR DESCRIPTION
Maybe `typetuple` was intentionally left out?