### PR TITLE
Fix Issue 21707 - std.base64: Faulty input creates range error…

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -1462,14 +1462,6 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                     data ~= cast(const(char)[])range_.front;
                 }
             }
-            else
-            {
-                while (data.length % 4 != 0)
-                {
-                    range_.popFront();
-                    data ~= cast(const(char)[])range_.front;
-                }
-            }
 
             auto size = decodeLength(data.length);
             if (size > buffer_.length)
@@ -2236,4 +2228,12 @@ class Base64Exception : Exception
 
     assert(Base64.decode(ir, or) == 2);
     assert(or.result == [ 123, 45 ]);
+}
+
+@safe unittest
+{
+    import std.exception : assertThrown;
+
+    char[][] t = [[ 'Z', 'g', '=' ]];
+    assertThrown!Base64Exception(Base64.decoder(t));
 }


### PR DESCRIPTION
…instead of Base64Exception

While trying to write a covering unittest for the removed part, I realised, that the body of the while loop can only be reached with input, that is too short (that is, data.length is not dividable by 4). And all that it does in that case is to access that missing input, which leads to an `assertError` inside `std.range.primitives` and thus prevents the correct `Base64Exception` to be thrown (in line 1001 which was added later).