### PR TITLE
Fix Issue 21708 - SumType.opEquals gives confusing error message

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -647,7 +647,7 @@ public:
      * contain values of the same type, and those values are equal.
      */
     bool opEquals(this This, Rhs)(auto ref Rhs rhs)
-    if (is(CommonType!(This, Rhs)))
+    if (!is(CommonType!(This, Rhs) == void))
     {
         static if (is(This == Rhs))
         {


### PR DESCRIPTION
See pbackus/sumtype#54.