### PR TITLE
Add debug symbols for tests to posix.mak

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -419,7 +419,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 %.test : %.d $(LIB)
 	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` &&                                                              \
 	  (                                                                                                     \
-	    $(DMD) -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov=ctfe -run $< ;     \
+	    $(DMD) -g -od$$T $(DFLAGS) -main $(UDFLAGS) $(LIB) $(NODEFAULTLIB) $(LINKDL) -cov=ctfe -run $< ;     \
 	    RET=$$? ; rm -rf $$T ; exit $$RET                                                                   \
 	  )
 


### PR DESCRIPTION
I realized, that I'm repeatedly adding and removing `-g` when using `.test`, because I'd like to know line numbers of runtime exceptions.

I don't know, if there is a better way to do so, because I'm not very much familiar with make files. And I also do not know, if there is a reason, why this isn't added...