### PR TITLE
Revert "Fix Issue 21707 - std.base64: Faulty input creates range erro…

### DIFF
--- a/std/base64.d
+++ b/std/base64.d
@@ -1463,6 +1463,14 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
                     data ~= cast(const(char)[])range_.front;
                 }
             }
+            else
+            {
+                while (data.length % 4 != 0)
+                {
+                    range_.popFront();
+                    data ~= cast(const(char)[])range_.front;
+                }
+            }
 
             auto size = decodeLength(data.length);
             if (size > buffer_.length)
@@ -2141,12 +2149,4 @@ class Base64Exception : Exception
 
     import std.exception : assertThrown;
     assertThrown!Base64Exception(Base64.decode(c));
-}
-
-@safe unittest
-{
-    import std.exception : assertThrown;
-
-    char[][] t = [[ 'Z', 'g', '=' ]];
-    assertThrown!Base64Exception(Base64.decoder(t));
 }

--- a/std/base64.d
+++ b/std/base64.d
@@ -2150,3 +2150,11 @@ class Base64Exception : Exception
     import std.exception : assertThrown;
     assertThrown!Base64Exception(Base64.decode(c));
 }
+
+@safe unittest
+{
+    import std.array : array;
+
+    char[][] input = [['e', 'y'], ['0', '=']];
+    assert(Base64.decoder(input).array == [[123, 45]]);
+}


### PR DESCRIPTION
…r instead of Base64Exception"

This reverts commit cf41baba2123e1c4680baf06016b8a93bbaf57ce.

Meanwhile I found out, why the removed piece of code was added. Removing it introduced a regression (see below), so I decided to revert this. I'll have to find an other way to fix that bug, but that seems more difficult...

The following code now fails, but has worked before:

```
ubyte[][] input = [['e', 'y'], ['0', '=']];
Base64.decoder(input);
```