### PR TITLE
Deprecate public access of formatElement

### DIFF
--- a/changelog/deprecate_formatElement.dd
+++ b/changelog/deprecate_formatElement.dd
@@ -1,0 +1,12 @@
+Deprecate std.format : formatElement
+
+`formatElement` from `std.format` has been accidentally made public and
+will be removed from public view in 2.107.0.
+
+Please use instead of `formatElement(sink, value, fmt)`:
+
+```
+import std.range : only;
+
+sink.put(format!("%("~fmt~"%)")(only(value)));
+```

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -411,132 +411,34 @@ class FormatException : Exception
 
 package alias enforceFmt = enforce!FormatException;
 
-// undocumented because of deprecation
-// string elements are formatted like UTF-8 string literals.
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("formatElement was accidentally made public and will be removed in 2.107.0")
 void formatElement(Writer, T, Char)(auto ref Writer w, T val, scope const ref FormatSpec!Char f)
 if (is(StringTypeOf!T) && !hasToString!(T, Char) && !is(T == enum))
 {
-    import std.array : appender;
-    import std.format.internal.write : formatChar;
-    import std.range.primitives : put;
-    import std.utf : decode, UTFException;
+    import std.format.internal.write : fe = formatElement;
 
-    StringTypeOf!T str = val;   // https://issues.dlang.org/show_bug.cgi?id=8015
-
-    if (f.spec == 's')
-    {
-        try
-        {
-            // ignore other specifications and quote
-            for (size_t i = 0; i < str.length; )
-            {
-                auto c = decode(str, i);
-                // \uFFFE and \uFFFF are considered valid by isValidDchar,
-                // so need checking for interchange.
-                if (c == 0xFFFE || c == 0xFFFF)
-                    goto LinvalidSeq;
-            }
-            put(w, '\"');
-            for (size_t i = 0; i < str.length; )
-            {
-                auto c = decode(str, i);
-                formatChar(w, c, '"');
-            }
-            put(w, '\"');
-            return;
-        }
-        catch (UTFException)
-        {
-        }
-
-        // If val contains invalid UTF sequence, formatted like HexString literal
-    LinvalidSeq:
-        static if (is(typeof(str[0]) : const(char)))
-        {
-            enum postfix = 'c';
-            alias IntArr = const(ubyte)[];
-        }
-        else static if (is(typeof(str[0]) : const(wchar)))
-        {
-            enum postfix = 'w';
-            alias IntArr = const(ushort)[];
-        }
-        else static if (is(typeof(str[0]) : const(dchar)))
-        {
-            enum postfix = 'd';
-            alias IntArr = const(uint)[];
-        }
-        formattedWrite(w, "x\"%(%02X %)\"%s", cast(IntArr) str, postfix);
-    }
-    else
-        formatValue(w, str, f);
+    fe(w, val, f);
 }
 
-@safe pure unittest
-{
-    import std.array : appender;
-
-    auto w = appender!string();
-    auto spec = singleSpec("%s");
-    formatElement(w, "Hello World", spec);
-
-    assert(w.data == "\"Hello World\"");
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=8015
-@safe unittest
-{
-    import std.typecons : Tuple;
-
-    struct MyStruct
-    {
-        string str;
-        @property string toStr()
-        {
-            return str;
-        }
-        alias toStr this;
-    }
-
-    Tuple!(MyStruct) t;
-}
-
-// undocumented because of deprecation
-// Character elements are formatted like UTF-8 character literals.
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("formatElement was accidentally made public and will be removed in 2.107.0")
 void formatElement(Writer, T, Char)(auto ref Writer w, T val, scope const ref FormatSpec!Char f)
 if (is(CharTypeOf!T) && !is(T == enum))
 {
-    import std.range.primitives : put;
-    import std.format.internal.write : formatChar;
+    import std.format.internal.write : fe = formatElement;
 
-    if (f.spec == 's')
-    {
-        put(w, '\'');
-        formatChar(w, val, '\'');
-        put(w, '\'');
-    }
-    else
-        formatValue(w, val, f);
+    fe(w, val, f);
 }
 
-///
-@safe unittest
-{
-    import std.array : appender;
-
-    auto w = appender!string();
-    auto spec = singleSpec("%s");
-    formatElement(w, "H", spec);
-
-    assert(w.data == "\"H\"", w.data);
-}
-
-// undocumented
-// Maybe T is noncopyable struct, so receive it by 'auto ref'.
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("formatElement was accidentally made public and will be removed in 2.107.0")
 void formatElement(Writer, T, Char)(auto ref Writer w, auto ref T val, scope const ref FormatSpec!Char f)
 if ((!is(StringTypeOf!T) || hasToString!(T, Char)) && !is(CharTypeOf!T) || is(T == enum))
 {
-    formatValue(w, val, f);
+    import std.format.internal.write : fe = formatElement;
+
+    fe(w, val, f);
 }
 
 // Like NullSink, but toString() isn't even called at all. Used to test the format string.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1296,7 +1296,9 @@ if (distinctFieldNames!(Specs))
         /// ditto
         void toString(DG, Char)(scope DG sink, scope const ref FormatSpec!Char fmt) const
         {
-            import std.format : formatElement, formattedWrite, FormatException;
+            import std.format : format, FormatException;
+            import std.format.write : formattedWrite;
+            import std.range : only;
             if (fmt.nested)
             {
                 if (fmt.sep)
@@ -1335,15 +1337,14 @@ if (distinctFieldNames!(Specs))
                     {
                         sink(separator);
                     }
-                    // TODO: Change this once formatElement() works for shared objects.
+                    // TODO: Change this once format() works for shared objects.
                     static if (is(Type == class) && is(Type == shared))
                     {
                         sink(Type.stringof);
                     }
                     else
                     {
-                        FormatSpec!Char f;
-                        formatElement(sink, field[i], f);
+                        sink(format!("%(%s%)")(only(field[i])));
                     }
                 }
                 sink(footer);


### PR DESCRIPTION
`formatElement` is currently `public`, but undocumented. A comment next to it says "undocumented because of deprecation", but I think this is wrong. Looking into the history of this, I found out, that it was made public, because it was useful in `std.typecons`. I presume, that at that time `package(std)` was not available.

I see two ways out of this:
1. Make it really public, that is add documentation and useful public unittests.
2. Deprecate it's public view.

I've chosen the second way, because in my opinion formatting elements and should not be done differently to formatting these elements as single items (i.e. "%(%s%)" should not format an element different than "%s" does). While this PR doesn't really change this behavior, it makes it easier to do so later with an other deprecation cycle.

To deprecate the public use, but not the private use, I moved them to `std.format.internal.write` and replaced the original calls by wrappers with the `deprecated` attribute.

Due to the use in `std.typecons` I had to make the moved functions `package(std)`. Unfortunately this doesn't work well with the package statement `package(std.format):` at the top of the file, so I had to remove this and add it to all symbols that where not private separately.