### PR TITLE
Add AllImplicitConversionTargets

### DIFF
--- a/changelog/add_conversion_target.dd
+++ b/changelog/add_conversion_target.dd
@@ -1,0 +1,6 @@
+New function: `AllImplicitConversionTargets`
+
+The function `ImplicitConversionTargets` in module `std.traits` has a
+design flaw: The list of conversion targets contains some, but not all
+unsafe conversion targets. To overcome this, a new functions has been
+added.


### PR DESCRIPTION
This is meant as an alternative to #7842: The idea is to add two new functions to make clear, if the list contains unsafe conversions, or not.

If accepted, I will use these in a separate PR (because it needs also some changes in `std.variant`) to deprecate `ImplicitConversionTargets`.

I left everything, that is not about builtin types untouched. (I don't understand this part in every detail yet.)

Some points, that might be debatable in `SafeImplicitConversionTargets`:
- I removed `byte` from the list of `char` and likewise `short` from `wchar` and `int` from `dchar`. For me, these casts feel unsafe. What do you think?
- I treated `real` like `double`. For x87-reals this makes no difference, but longer reals should be able to represent all values of `long` and `ulong`. As there is no clear list of which reals D does support, I can't check this.