### PR TITLE
Prepare to split up std.math into submodules.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -207,14 +207,14 @@ P2MODULES=$(foreach P,$1,$(addprefix $P/,$(PACKAGE_$(subst /,_,$P))))
 STD_PACKAGES = std $(addprefix std/,\
   algorithm container datetime digest experimental/allocator \
   experimental/allocator/building_blocks experimental/logger \
-  format net uni \
+  format math net uni \
   experimental range regex windows)
 
 # Modules broken down per package
 
 PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
   conv csv demangle encoding exception file \
-  functional getopt json math mathspecial meta mmfile numeric \
+  functional getopt json mathspecial meta mmfile numeric \
   outbuffer package parallelism path process random signals socket stdint \
   stdio string sumtype system traits typecons \
   uri utf uuid variant xml zip zlib
@@ -234,6 +234,7 @@ PACKAGE_std_experimental_allocator_building_blocks = \
   kernighan_ritchie null_allocator package quantizer \
   region scoped_allocator segregator stats_collector
 PACKAGE_std_format = package read spec write $(addprefix internal/, floats read write)
+PACKAGE_std_math = package
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \

--- a/std/math/package.d
+++ b/std/math/package.d
@@ -117,7 +117,7 @@ $(TR $(TDNW Hardware Control) $(TD
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
  *            Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
- * Source: $(PHOBOSSRC std/math.d)
+ * Source: $(PHOBOSSRC std/math/package.d)
  */
 module std.math;
 
@@ -765,7 +765,7 @@ private T tanImpl(T)(T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testTan!T();
 
-    assert(equalsDigit(tan(PI / 3), std.math.sqrt(3.0L), useDigits));
+    assert(equalsDigit(tan(PI / 3), sqrt(3.0L), useDigits));
 }
 
 /***************
@@ -794,13 +794,13 @@ float acos(float x) @safe pure nothrow @nogc  { return acos(cast(real) x); }
 @safe unittest
 {
     assert(acos(0.0).isClose(1.570796327));
-    assert(acos(0.5).isClose(std.math.PI / 3));
+    assert(acos(0.5).isClose(PI / 3));
     assert(acos(PI).isNaN);
 }
 
 @safe @nogc nothrow unittest
 {
-    assert(equalsDigit(acos(0.5), std.math.PI / 3, useDigits));
+    assert(equalsDigit(acos(0.5), PI / 3, useDigits));
 }
 
 /***************
@@ -1077,7 +1077,7 @@ private T atanImpl(T)(T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testAtan!T();
 
-    assert(equalsDigit(atan(std.math.sqrt(3.0L)), PI / 3, useDigits));
+    assert(equalsDigit(atan(sqrt(3.0L)), PI / 3, useDigits));
 }
 
 /***************
@@ -1278,7 +1278,7 @@ private T atan2Impl(T)(T y, T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testAtan2!T();
 
-    assert(equalsDigit(atan2(1.0L, std.math.sqrt(3.0L)), PI / 6, useDigits));
+    assert(equalsDigit(atan2(1.0L, sqrt(3.0L)), PI / 6, useDigits));
 }
 
 /***********************************
@@ -9982,7 +9982,7 @@ if (isNumeric!X)
     }}
 }
 
-package: // Not public yet
+package(std): // Not public yet
 /* Return the value that lies halfway between x and y on the IEEE number line.
  *
  * Formally, the result is the arithmetic mean of the binary significands of x

--- a/win32.mak
+++ b/win32.mak
@@ -111,7 +111,6 @@ SRC_STD_2a= \
 
 SRC_STD_3= \
 	std\csv.d \
-	std\math.d \
 	std\complex.d \
 	std\numeric.d \
 	std\bigint.d \
@@ -213,6 +212,9 @@ SRC_STD_FORMAT= \
     std\format\internal\floats.d \
     std\format\internal\read.d \
     std\format\internal\write.d
+
+SRC_STD_MATH= \
+    std\math\package.d
 
 SRC_STD_NET= \
 	std\net\isemail.d \
@@ -322,6 +324,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_DATETIME) \
 	$(SRC_STD_DIGEST) \
 	$(SRC_STD_FORMAT) \
+	$(SRC_STD_MATH) \
 	$(SRC_STD_NET) \
 	$(SRC_STD_RANGE) \
 	$(SRC_STD_REGEX) \
@@ -392,6 +395,7 @@ UNITTEST_OBJS= \
 		unittest4.obj \
 		unittest5.obj \
 		unittest5a.obj \
+		unittest5b.obj \
 		unittest6.obj \
 		unittest6a.obj \
 		unittest6b.obj \
@@ -414,6 +418,7 @@ unittest : $(LIB)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest4.obj $(SRC_STD_4) $(SRC_STD_DIGEST)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5.obj $(SRC_STD_ALGO)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5a.obj $(SRC_STD_FORMAT)
+	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest5b.obj $(SRC_STD_MATH)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6.obj $(SRC_STD_6) $(SRC_STD_CONTAINER)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6a.obj $(SRC_STD_EXP_ALLOC)
 	$(DMD) $(UDFLAGS) -L/co -c  -ofunittest6b.obj $(SRC_STD_EXP_LOGGER)
@@ -450,7 +455,6 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=ctfe -cov=41 $(UDFLAGS) -main -run std\outbuffer.d
 	$(DMD) -conf= -cov=ctfe -cov=89 $(UDFLAGS) -main -run std\utf.d
 	$(DMD) -conf= -cov=ctfe -cov=93 $(UDFLAGS) -main -run std\csv.d
-	$(DMD) -conf= -cov=ctfe -cov=91 $(UDFLAGS) -main -run std\math.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\complex.d
 	$(DMD) -conf= -cov=ctfe -cov=70 $(UDFLAGS) -main -run std\numeric.d
 	$(DMD) -conf= -cov=ctfe -cov=94 $(UDFLAGS) -main -run std\bigint.d
@@ -493,6 +497,7 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\setops.d
 	$(DMD) -conf= -cov=ctfe -cov=95 $(UDFLAGS) -main -run std\algorithm\sorting.d
 	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\format\package.d
+	$(DMD) -conf= -cov=ctfe -cov=71 $(UDFLAGS) -main -run std\math\package.d
 	$(DMD) -conf= -cov=ctfe -cov=83 $(UDFLAGS) -main -run std\variant.d
 	$(DMD) -conf= -cov=ctfe -cov=58 $(UDFLAGS) -main -run std\zlib.d
 	$(DMD) -conf= -cov=ctfe -cov=53 $(UDFLAGS) -main -run std\socket.d

--- a/win64.mak
+++ b/win64.mak
@@ -119,9 +119,6 @@ SRC_STD_3= \
 	std\numeric.d \
 	std\bigint.d
 
-SRC_STD_3a= \
-	std\math.d
-
 SRC_STD_3b= \
 	std\base64.d \
 	std\ascii.d \
@@ -211,6 +208,9 @@ SRC_STD_FORMAT= \
     std\format\internal\floats.d \
     std\format\internal\read.d \
     std\format\internal\write.d
+
+SRC_STD_MATH = \
+    std\math\package.d
 
 SRC_STD_CONTAINER= \
 	std\container\array.d \
@@ -347,6 +347,7 @@ SRC_TO_COMPILE= \
 	$(SRC_STD_DATETIME) \
 	$(SRC_STD_DIGEST) \
 	$(SRC_STD_FORMAT) \
+	$(SRC_STD_MATH) \
 	$(SRC_STD_NET) \
 	$(SRC_STD_RANGE) \
 	$(SRC_STD_REGEX) \
@@ -412,7 +413,6 @@ UNITTEST_OBJS= \
 		unittest2.obj \
 		unittest2a.obj \
 		unittest3.obj \
-		unittest3a.obj \
 		unittest3b.obj \
 		unittest3c.obj \
 		unittest3d.obj \
@@ -421,6 +421,7 @@ UNITTEST_OBJS= \
 		unittest5b.obj \
 		unittest5c.obj \
 		unittest5d.obj \
+		unittest5e.obj \
 		unittest6a.obj \
 		unittest6c.obj \
 		unittest6e.obj \
@@ -442,7 +443,6 @@ unittest : $(LIB)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest2.obj $(SRC_STD_RANGE)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest2a.obj $(SRC_STD_2a)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest3.obj $(SRC_STD_3)
-	"$(DMD)" $(UDFLAGS) -c  -ofunittest3a.obj $(SRC_STD_3a)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest3b.obj $(SRC_STD_3b)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest3c.obj $(SRC_STD_3c)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest3d.obj $(SRC_STD_3d) $(SRC_STD_DATETIME)
@@ -451,6 +451,7 @@ unittest : $(LIB)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5b.obj $(SRC_STD_ALGO_2)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5c.obj $(SRC_STD_ALGO_3)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest5d.obj $(SRC_STD_FORMAT)
+	"$(DMD)" $(UDFLAGS) -c  -ofunittest5e.obj $(SRC_STD_MATH)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6a.obj $(SRC_STD_6a)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6c.obj $(SRC_STD_6c)
 	"$(DMD)" $(UDFLAGS) -c  -ofunittest6e.obj $(SRC_STD_6e)


### PR DESCRIPTION
As this path worked quite well with `std.format`, I'll try it here too. The idea is to just move everything to package. This is simple to review and makes it much easier to split of single modules later.

@ibuclaw tried this several times in the past, last try with #7326. According to him, meanwhile all problems with compiler magic should be removed.