### PR TITLE
Remove public comment from array_ptr_diff.

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1953,7 +1953,7 @@ char[] sformat(Char, Args...)(return scope char[] buf, scope const(Char)[] fmt, 
     assert(u == GC.stats().usedSize);
 }
 
-/*****************************
+/*
  * The .ptr is unsafe because it could be dereferenced and the length of the array may be 0.
  * Returns:
  *      the difference between the starts of the arrays


### PR DESCRIPTION
`array_ptr_diff` has got a public comment and therefore shows up in the docs, where it doesn't belong...