### PR TITLE
std.file docs: Tweak dirEntries examples

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4958,7 +4958,7 @@ version (StdDdoc)
 {
     string[] listdir(string pathname)
     {
-        import std.algorithm : filter, map;
+        import std.algorithm.iteration : filter, map;
         import std.array : array;
         import std.path : baseName;
 

--- a/std/file.d
+++ b/std/file.d
@@ -4940,19 +4940,6 @@ foreach (DirEntry e; dirEntries("dmd-testing", SpanMode.breadth))
     writeln(e.name, "\t", e.size);
 }
 
-// Iterate over all *.d files in current directory and all its subdirectories
-auto dFiles = dirEntries("", SpanMode.depth).filter!(f => f.name.endsWith(".d"));
-foreach (d; dFiles)
-    writeln(d.name);
-
-// Hook it up with std.parallelism to compile them all in parallel:
-foreach (d; parallel(dFiles, 1)) //passes by 1 file to each thread
-{
-    string cmd = "dmd -c "  ~ d.name;
-    writeln(cmd);
-    std.process.executeShell(cmd);
-}
-
 // Iterate over all D source files in current directory and all its
 // subdirectories
 auto dFiles = dirEntries("","*.{d,di}",SpanMode.depth);
@@ -4966,28 +4953,49 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 }
 
 /// Duplicate functionality of D1's `std.file.listdir()`:
+version (StdDdoc)
 @safe unittest
 {
     string[] listdir(string pathname)
     {
-        import std.algorithm;
-        import std.array;
-        import std.file;
-        import std.path;
+        import std.algorithm : filter, map;
+        import std.array : array;
+        import std.path : baseName;
 
-        return std.file.dirEntries(pathname, SpanMode.shallow)
+        return dirEntries(pathname, SpanMode.shallow)
             .filter!(a => a.isFile)
-            .map!(a => std.path.baseName(a.name))
+            .map!(a => baseName(a.name))
             .array;
     }
 
-    void main(string[] args)
-    {
+    void main() {
         import std.stdio;
 
-        string[] files = listdir(args[1]);
-        writefln("%s", files);
-     }
+        string[] files = listdir("");
+        writeln(files);
+    }
+}
+
+/// Compile D files in parallel:
+version (StdDdoc)
+@system unittest
+{
+    import std.stdio;
+    import std.parallelism;
+    import std.process;
+
+    // Iterate over all *.d files in current directory and all its subdirectories
+    auto dFiles = dirEntries("", "*.d", SpanMode.depth);
+    foreach (d; dFiles)
+        writeln(d.name);
+
+    foreach (d; parallel(dFiles, 1)) // process each entry in a new thread
+    {
+        // compile source file
+        string cmd = "dmd -c "  ~ d.name;
+        writeln(cmd);
+        std.process.executeShell(cmd);
+    }
 }
 
 @system unittest

--- a/std/file.d
+++ b/std/file.d
@@ -4953,7 +4953,6 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 }
 
 /// Duplicate functionality of D1's `std.file.listdir()`:
-version (StdDdoc)
 @safe unittest
 {
     string[] listdir(string pathname)

--- a/std/file.d
+++ b/std/file.d
@@ -4968,10 +4968,11 @@ version (StdDdoc)
             .array;
     }
 
-    void main() {
+    void main()
+    {
         import std.stdio;
 
-        string[] files = listdir("");
+        string[] files = listdir(".");
         writeln(files);
     }
 }
@@ -4985,14 +4986,14 @@ version (StdDdoc)
     import std.process;
 
     // Iterate over all *.d files in current directory and all its subdirectories
-    auto dFiles = dirEntries("", "*.d", SpanMode.depth);
+    auto dFiles = dirEntries(".", "*.d", SpanMode.depth);
     foreach (d; dFiles)
         writeln(d.name);
 
-    foreach (d; parallel(dFiles, 1)) // process each entry in a new thread
+    foreach (d; parallel(dFiles, 1)) // process each entry in a separate thread
     {
         // compile source file
-        string cmd = "dmd -c "  ~ d.name;
+        string cmd = "dmd -c " ~ d.name;
         writeln(cmd);
         std.process.executeShell(cmd);
     }


### PR DESCRIPTION
Use selective imports for `listdir` example, not fully qualified calls.
Don't use `args`, use current directory for working runnable example.

Move parallel dmd example into a documented unittest. Use `pattern` argument instead of filter & endsWith for simplicity. Note the `listdir` example already uses `map`.

Only run these 'tests' for `version(StdDdoc)`.