### PR TITLE
Fix Issue 17381 - Checked format string is permissive after floating point argument

### DIFF
--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -16,8 +16,6 @@ module std.format.internal.floats;
 
 import std.format.spec : FormatSpec;
 
-package(std.format) enum ctfpMessage = "Cannot format reals at compile-time.";
-
 package(std.format) enum RoundingMode { up, down, toZero, toNearestTiesToEven, toNearestTiesAwayFromZero }
 
 package(std.format) auto printFloat(T, Char)(return char[] buf, T val, FormatSpec!Char f,

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -628,9 +628,6 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
     else
     {
-        import std.format.internal.floats : ctfpMessage;
-        enforceFmt(!__ctfe, ctfpMessage);
-
         if (nan || inf)
         {
             const sb = signbit(tval);
@@ -644,6 +641,8 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
             formatValue(w, ns, co);
             return;
         }
+
+        enforceFmt(!__ctfe, "Cannot format reals at compile-time.");
 
         char[1 /*%*/ + 5 /*flags*/ + 3 /*width.prec*/ + 2 /*format*/
              + 1 /*\0*/] sprintfSpec = void;

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1872,7 +1872,6 @@ if (isInputRange!Range)
 package(std) static const checkFormatException(alias fmt, Args...) =
 {
     import std.conv : text;
-    import std.format.internal.floats : ctfpMessage;
 
     try
     {
@@ -1881,7 +1880,7 @@ package(std) static const checkFormatException(alias fmt, Args...) =
         enforceFmt(n == Args.length, text("Orphan format arguments: args[", n, "..", Args.length, "]"));
     }
     catch (Exception e)
-        return (e.msg == ctfpMessage) ? null : e;
+        return e;
     return null;
 }();
 
@@ -2010,6 +2009,15 @@ if (isSomeString!(typeof(fmt)))
     static assert(!__traits(compiles, {s = format!"%l"();}));     // missing arg
     static assert(!__traits(compiles, {s = format!""(404);}));    // surplus arg
     static assert(!__traits(compiles, {s = format!"%d"(4.03);})); // incompatible arg
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=17381
+@safe pure unittest
+{
+    static assert(!__traits(compiles, format!"%s"(1.5, 2)));
+    static assert(!__traits(compiles, format!"%f"(1.5, 2)));
+    static assert(!__traits(compiles, format!"%s"(1.5L, 2)));
+    static assert(!__traits(compiles, format!"%f"(1.5L, 2)));
 }
 
 // called during compilation to guess the length of the


### PR DESCRIPTION
On my computer there is no failure, but in the [Online D Editor](https://run.dlang.io/is/YrEFFp) it reports failures since 2.074.1, but worked before.

I just added a unittest to find out on which computers this fails.