### PR TITLE
Deprecate public access of unformatElement

### DIFF
--- a/changelog/deprecate_unformatElement.dd
+++ b/changelog/deprecate_unformatElement.dd
@@ -1,0 +1,7 @@
+Deprecate std.format : unformatElement
+
+`unformatElement` from `std.format` has been accidentally made public and
+will be removed from public view in 2.107.0.
+
+Please use instead for strings and characters `parseElement` from
+`std.conv` and for all else `unformatValue` from `std.format.read`.

--- a/std/format/internal/read.d
+++ b/std/format/internal/read.d
@@ -302,7 +302,7 @@ private T unformatRange(T, Range, Char)(ref Range input, scope const ref FormatS
 in (spec.spec == '(', "spec.spec must be '(' not " ~ spec.spec)
 {
     import std.range.primitives : empty, front, popFront;
-    import std.format : enforceFmt, format, unformatElement;
+    import std.format : enforceFmt, format;
 
     T result;
     static if (isStaticArray!T)
@@ -383,4 +383,28 @@ in (spec.spec == '(', "spec.spec must be '(' not " ~ spec.spec)
                    "Too few (%d) format specifiers for static array of length %d".format(i, T.length));
     }
     return result;
+}
+
+T unformatElement(T, Range, Char)(ref Range input, scope const ref FormatSpec!Char spec)
+if (isInputRange!Range)
+{
+    import std.conv : parseElement;
+    import std.format.read : unformatValue;
+
+    static if (isSomeString!T)
+    {
+        if (spec.spec == 's')
+        {
+            return parseElement!T(input);
+        }
+    }
+    else static if (isSomeChar!T)
+    {
+        if (spec.spec == 's')
+        {
+            return parseElement!T(input);
+        }
+    }
+
+    return unformatValue!T(input, spec);
 }

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1512,28 +1512,14 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
     });
 }
 
-// Undocumented
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("unformatElement was accidentally made public and will be removed in 2.107.0")
 T unformatElement(T, Range, Char)(ref Range input, scope const ref FormatSpec!Char spec)
 if (isInputRange!Range)
 {
-    import std.conv : parseElement;
+    import std.format.internal.read : ue = unformatElement;
 
-    static if (isSomeString!T)
-    {
-        if (spec.spec == 's')
-        {
-            return parseElement!T(input);
-        }
-    }
-    else static if (isSomeChar!T)
-    {
-        if (spec.spec == 's')
-        {
-            return parseElement!T(input);
-        }
-    }
-
-    return unformatValue!T(input, spec);
+    return ue(input, spec);
 }
 
 /* ======================== Unit Tests ====================================== */


### PR DESCRIPTION
This is a logical followup of #7875. IMHO `unformatElement` is even less useful for public use, than `formatElement`.