### PR TITLE
Deprecate public access of enforceValidFormatSpec

### DIFF
--- a/changelog/deprecate_enforceValidFormatSpec.dd
+++ b/changelog/deprecate_enforceValidFormatSpec.dd
@@ -1,0 +1,4 @@
+Deprecate std.format : enforceValidFormatSpec
+
+`enforceValidFormatSpec` from `std.format` has been accidentally made
+public and will be removed from public view in 2.107.0.

--- a/std/format/spec.d
+++ b/std/format/spec.d
@@ -902,22 +902,13 @@ FormatSpec!Char singleSpec(Char)(Char[] fmt)
     assertThrown!FormatException(singleSpec("%%"));
 }
 
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("enforceValidFormatSpec was accidentally made public and will be removed in 2.107.0")
 void enforceValidFormatSpec(T, Char)(scope const ref FormatSpec!Char f)
 {
-    import std.format : enforceFmt;
-    import std.range : isInputRange;
-    import std.format.internal.write : hasToString, HasToStringResult;
+    import std.format.internal.write : evfs = enforceValidFormatSpec;
 
-    enum overload = hasToString!(T, Char);
-    static if (
-            overload != HasToStringResult.constCharSinkFormatSpec &&
-            overload != HasToStringResult.constCharSinkFormatString &&
-            overload != HasToStringResult.customPutWriterFormatSpec &&
-            !isInputRange!T)
-    {
-        enforceFmt(f.spec == 's',
-            "Expected '%s' format specifier for type '" ~ T.stringof ~ "'");
-    }
+    evfs!T(f);
 }
 
 @safe unittest


### PR DESCRIPTION
That is the third (and last) item in `std.format` that has been made public without any good reason. It's probably only used in `formatValueImpl`.

I did not manage to find a useful workaround here, but IMHO there is no real use case either.