### PR TITLE
Deprecate separatorCharPos in FormatSpec.

### DIFF
--- a/std/format/spec.d
+++ b/std/format/spec.d
@@ -65,11 +65,25 @@ if (is(Unqual!Char == Char))
     int separators = UNSPECIFIED;
 
     /**
+       The separator charactar is supplied at runtime.
+
+       _Default: false;
+     */
+    bool dynamicSeparatorChar = false;
+
+    /**
        Set to `DYNAMIC` when the separator character is supplied at runtime.
 
        _Default: `UNSPECIFIED`.
      */
-    int separatorCharPos = UNSPECIFIED;
+    // @@@DEPRECATED_[2.107.0]@@@
+    deprecated("separatorCharPos will be removed in 2.107.0. Please use dynamicSeparatorChar instead.")
+    int separatorCharPos() { return dynamicSeparatorChar ? DYNAMIC : UNSPECIFIED; }
+
+    /// ditto
+    // @@@DEPRECATED_[2.107.0]@@@
+    deprecated("separatorCharPos will be removed in 2.107.0. Please use dynamicSeparatorChar instead.")
+    void separatorCharPos(int value) { dynamicSeparatorChar = value == DYNAMIC; }
 
     /**
        Character to use as separator.
@@ -79,8 +93,7 @@ if (is(Unqual!Char == Char))
     dchar separatorChar = ',';
 
     /**
-       Special value for `width`, `precision`, `separators` and
-       `separatorCharPos`.
+       Special value for `width`, `precision` and `separators`.
 
        It flags that these values will be passed at runtime through
        variadic arguments.
@@ -88,7 +101,7 @@ if (is(Unqual!Char == Char))
     enum int DYNAMIC = int.max;
 
     /**
-       Special value for `precision`, `separators` and `separatorCharPos`.
+       Special value for `precision` and `separators`.
 
        It flags that these values have not been specified.
      */
@@ -420,7 +433,7 @@ if (is(Unqual!Char == Char))
 
                 if (trailing[i] == '?')
                 {
-                    separatorCharPos = DYNAMIC;
+                    dynamicSeparatorChar = true;
                     ++i;
                 }
 
@@ -940,7 +953,7 @@ void enforceValidFormatSpec(T, Char)(scope const ref FormatSpec!Char f)
     assert(collectExceptionMsg!FormatException(format("%*.*d", 5))
         == "Missing integer precision argument");
 
-    // separatorCharPos
+    // dynamicSeparatorChar
     assert(collectExceptionMsg!FormatException(format("%,?d", 5))
         == "separator character expected, not int for argument #1");
     assert(collectExceptionMsg!FormatException(format("%,?d", '?'))

--- a/std/format/write.d
+++ b/std/format/write.d
@@ -162,12 +162,12 @@ uint formattedWrite(Writer, Char, A...)(auto ref Writer w, const scope Char[] fm
             ++currentArg;
         }
 
-        if (spec.separatorCharPos == spec.DYNAMIC)
+        if (spec.dynamicSeparatorChar)
         {
             auto separatorChar =
                 getNth!("separator character", isSomeChar, dchar)(currentArg, args);
             spec.separatorChar = separatorChar;
-            spec.separatorCharPos = spec.UNSPECIFIED;
+            spec.dynamicSeparatorChar = false;
             ++currentArg;
         }
 
@@ -288,7 +288,7 @@ void formatValue(Writer, T, Char)(auto ref Writer w, auto ref T val, scope const
     import std.format : enforceFmt;
 
     enforceFmt(f.width != f.DYNAMIC && f.precision != f.DYNAMIC
-               && f.separators != f.DYNAMIC && f.separatorCharPos != f.DYNAMIC,
+               && f.separators != f.DYNAMIC && !f.dynamicSeparatorChar,
                "Dynamic argument not allowed for `formatValue`");
 
     formatValueImpl(w, val, f);


### PR DESCRIPTION
I suggest to replace `separatorCharPos` from `FormatSpec` by a new variable `dynamicSeparatorChar`. The reason is, that `separatorCharPos` is used like a `bool` but is an `int`. Furthermore I perceive the name as misleading because it does not denote a position, but just answers the question, if the character is dynamically provided at runtime or not.

I didn't add a release note, because I think, it is too unimportant for that. If I should guess, I'd say, that probably nobody is using this directly...