### PR TITLE
Add empty submodules to std.math.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -234,7 +234,8 @@ PACKAGE_std_experimental_allocator_building_blocks = \
   kernighan_ritchie null_allocator package quantizer \
   region scoped_allocator segregator stats_collector
 PACKAGE_std_format = package read spec write $(addprefix internal/, floats read write)
-PACKAGE_std_math = package
+PACKAGE_std_math = algebraic constants exponential floats hardware \
+  integral package remainder rounding traits trigonometry
 PACKAGE_std_net = curl isemail
 PACKAGE_std_range = interfaces package primitives
 PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/algebraic.d)
+ */
+
+module std.math.algebraic;
+
+// Will contain functions like abs, sqrt, hypot, poly and nextPow2

--- a/std/math/constants.d
+++ b/std/math/constants.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/constants.d)
+ */
+
+module std.math.constants;
+
+// Will contain constants, like E, PI and so on.

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -1,0 +1,23 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+           D implementations of exp, expm1, exp2, log, log10, log1p, and log2
+           functions are based on the CEPHES math library, which is Copyright
+           (C) 2001 Stephen L. Moshier $(LT)steve@moshier.net$(GT) and are
+           incorporated herein by permission of the author. The author reserves
+           the right to distribute this material elsewhere under different
+           copying permissions. These modifications are distributed here under
+           the following terms:
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/exponential.d)
+ */
+
+module std.math.exponential;
+
+// Will contain functions like pow, exp, log2

--- a/std/math/floats.d
+++ b/std/math/floats.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/floats.d)
+ */
+
+module std.math.floats;
+
+// Will contain functions like feqrel, nextDown, isClose

--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/hardware.d)
+ */
+
+module std.math.hardware;
+
+// Will contain IeeeFlags and FloatingPointControl

--- a/std/math/integral.d
+++ b/std/math/integral.d
@@ -1,0 +1,14 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2021 - .
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Source: $(PHOBOSSRC std/math/integral.d)
+ */
+
+module std.math.integral;
+
+// Will contain functions like isqrt, ilog2, isPrime and maybe also gcd from std.numeric

--- a/std/math/package.d
+++ b/std/math/package.d
@@ -121,6 +121,17 @@ $(TR $(TDNW Hardware Control) $(TD
  */
 module std.math;
 
+public import std.math.algebraic;
+public import std.math.constants;
+public import std.math.exponential;
+public import std.math.floats;
+public import std.math.hardware;
+public import std.math.integral;
+public import std.math.remainder;
+public import std.math.rounding;
+public import std.math.traits;
+public import std.math.trigonometry;
+
 static import core.math;
 static import core.stdc.math;
 static import core.stdc.fenv;

--- a/std/math/remainder.d
+++ b/std/math/remainder.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/remainder.d)
+ */
+
+module std.math.remainder;
+
+// Will contain functions like fmod and remainder

--- a/std/math/rounding.d
+++ b/std/math/rounding.d
@@ -1,0 +1,22 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+           D implementations of floor, ceil, and lrint functions are based on the
+           CEPHES math library, which is Copyright (C) 2001 Stephen L. Moshier
+           $(LT)steve@moshier.net$(GT) and are incorporated herein by permission
+           of the author. The author reserves the right to distribute this
+           material elsewhere under different copying permissions.
+           These modifications are distributed here under the following terms:
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/rounding.d)
+ */
+
+module std.math.rounding;
+
+// Will contain functions like ceil, floor, round, quantize

--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -1,0 +1,16 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/traits.d)
+ */
+
+module std.math.traits;
+
+// Will contain functions like isFinite, isIdentical, ...

--- a/std/math/trigonometry.d
+++ b/std/math/trigonometry.d
@@ -1,0 +1,22 @@
+// Written in the D programming language.
+
+/**
+This package is currently in a nascent state and may be subject to
+change. Please do not use it yet, but stick to $(MREF std, math).
+
+Copyright: Copyright The D Language Foundation 2000 - 2011.
+           D implementations of tan, atan, and atan2 functions are based on the
+           CEPHES math library, which is Copyright (C) 2001 Stephen L. Moshier
+           $(LT)steve@moshier.net$(GT) and are incorporated herein by permission
+           of the author. The author reserves the right to distribute this
+           material elsewhere under different copying permissions.
+           These modifications are distributed here under the following terms:
+License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+Authors:   $(HTTP digitalmars.com, Walter Bright), Don Clugston,
+           Conversion of CEPHES math library to D by Iain Buclaw and David Nadlinger
+Source: $(PHOBOSSRC std/math/trigonometry.d)
+ */
+
+module std.math.trigonometry;
+
+// Will contain functions like sin, cos and so on

--- a/win32.mak
+++ b/win32.mak
@@ -214,7 +214,17 @@ SRC_STD_FORMAT= \
     std\format\internal\write.d
 
 SRC_STD_MATH= \
-    std\math\package.d
+    std\math\algebraic.d \
+    std\math\constants.d \
+    std\math\exponential.d \
+    std\math\floats.d \
+    std\math\hardware.d \
+    std\math\integral.d \
+    std\math\package.d \
+    std\math\remainder.d \
+    std\math\rounding.d \
+    std\math\traits.d \
+    std\math\trigonometry.d
 
 SRC_STD_NET= \
 	std\net\isemail.d \

--- a/win64.mak
+++ b/win64.mak
@@ -210,7 +210,17 @@ SRC_STD_FORMAT= \
     std\format\internal\write.d
 
 SRC_STD_MATH = \
-    std\math\package.d
+    std\math\algebraic.d \
+    std\math\constants.d \
+    std\math\exponential.d \
+    std\math\floats.d \
+    std\math\hardware.d \
+    std\math\integral.d \
+    std\math\package.d \
+    std\math\remainder.d \
+    std\math\rounding.d \
+    std\math\traits.d \
+    std\math\trigonometry.d
 
 SRC_STD_CONTAINER= \
 	std\container\array.d \


### PR DESCRIPTION
Since splitting out a whole has not worked out well here (see #7887), I'd like to try a different approach: This PR provides only a skeleton, that needs to be filled. This way it is possible to move the unproblematic functions and care about the problematic ones separately.

I tried to find good names for the subpackages, by going through math packages of other languages. The rough idea was to use the table at the top of `std.math`s docs as a guide. I add `integral` though, which is a new submodule. It should contain integer maths, like `isqrt` or `isSquare` or such things. IMHO this is something, that Phobos is missing.