### PR TITLE
std.format: Add overview of format indicator

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -144,6 +144,60 @@ recommended to assign (lower- and uppercase) letters.
 Note: The $(I Parameters) of a $(I CompoundIndicator) are currently
 limited to a $(B '-') flag.
 
+$(SECTION4 Format Indicator)
+
+The $(I format indicator) can either be a single character or an
+expression surrounded by $(B %\() and $(B %\)). It specifies the
+basic manner in which a value will be formatted and is the minimum
+requirement to format a value.
+
+The following characters can be used as $(I format characters):
+
+$(BOOKTABLE ,
+   $(TR $(TH FormatCharacter) $(TH Semantics))
+   $(TR $(TD $(B 's'))
+        $(TD To be formatted in a human readable format.
+             Can be used with all types.))
+   $(TR $(TD $(B 'c'))
+        $(TD To be formatted as a character.))
+   $(TR $(TD $(B 'd'))
+        $(TD To be formatted as a signed decimal integer.))
+   $(TR $(TD $(B 'u'))
+        $(TD To be formatted as a decimal image of the underlying bit representation.))
+   $(TR $(TD $(B 'b'))
+        $(TD To be formatted as a binary image of the underlying bit representation.))
+   $(TR $(TD $(B 'o'))
+        $(TD To be formatted as an octal image of the underlying bit representation.))
+   $(TR $(TD $(B 'x') / $(B 'X'))
+        $(TD To be formatted as a hexadecimal image of the underlying bit representation.))
+   $(TR $(TD $(B 'e') / $(B 'E'))
+        $(TD To be formatted as a real number in decimal scientific notation.))
+   $(TR $(TD $(B 'f') / $(B 'F'))
+        $(TD To be formatted as a real number in decimal natural notation.))
+   $(TR $(TD $(B 'g') / $(B 'G'))
+        $(TD To be formatted as a real number in decimal short notation.
+             Depending on the number, a scientific notation or
+             a natural notation is used.))
+   $(TR $(TD $(B 'a') / $(B 'A'))
+        $(TD To be formatted as a real number in hexadezimal scientific notation.))
+   $(TR $(TD $(B 'r'))
+        $(TD To be formatted as raw bytes.
+             The output may not be printable and depends on endianess.))
+)
+
+The $(I compound indicator) can be used to describe compound types
+like arrays or structs in more detail. A compound type is enclosed
+within $(B '%\(') and $(B '%\)'). It either contains a $(I format
+string) or a $(I format string) and a $(I delimiter). In the second
+case $(I format string) and $(I delimiter) are separated by $(B '%|').
+If the delimiter is not present a comma, followed by a space, is used
+as delimiter.
+
+The $(I format string) inside of the $(I compound indicator) should
+contain exactly one $(I format specifier), which specifies the way,
+the elements of the compound type will be formatted. This $(I format
+specifier) can be a $(I compound indicator) itself.
+
 
 
 


### PR DESCRIPTION
Formatting decimals with `%b`, `%o` and `%x` is often referred to as writing this number in binary, octal and hexadecimal. But that is not, what (C-)users expect and what the current implementation produces: It is just an image of the underlying bits. That means `format!"%x"(-10);` results in `fffffff6` instead of `-a`. I tried to follow this with the descriptions.

A similar problem occurs with `%u`, which is often called as formatting as unsigned integer. This was needed with C, because C has no traits and cannot know if the argument was meant to be a signed or an unsigned integer, as far as I know. In D this does not make any sense and in the current implementation `%u` just produces the same results as `%d`. IMHO `%u` could be discarded completely. Yet, people think of it as a feature (e.g. #7913). To make the best out of it, I choose to describe it similar to `%b`, `%o` and `%x` as a (yet buggy implemented) representation of the bit pattern. This seems to me closest to the intention behind `%u`. An alternative would be to kick it into the long grass. Would be fine for me, but might be perceived as a breaking change.