### PR TITLE
Make string/character auto-escaping more prominent

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -343,7 +343,8 @@ limited to a $(B '-') flag.
     string will be included following the last array element.
 
     NOTE: Inside a grouping format specifier, strings and characters are
-    escaped automatically. To avoid this behavior, add '-' flag to "%(".
+    escaped automatically. To avoid this behavior, add the $(B '-') flag
+    to `"%$(LPAREN)"`.
 
     Example using array and nested array formatting:
     -------------------------
@@ -415,7 +416,7 @@ $(CONSOLE
 
     As previously stated, strings and characters are escaped
     automatically inside compound format specifiers. To avoid
-    this behavior, add $(B '-') flag to `"%$(LPAREN)"`.
+    this behavior, add the $(B '-') flag to `"%$(LPAREN)"`.
     -------------------------
     import std.stdio;
 

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -342,6 +342,9 @@ limited to a $(B '-') flag.
     the start of the delimiter, so that the preceding portion of the
     string will be included following the last array element.
 
+    NOTE: Inside a grouping format specifier, strings and characters are
+    escaped automatically. To avoid this behavior, add '-' flag to "%(".
+
     Example using array and nested array formatting:
     -------------------------
     import std.stdio;
@@ -410,9 +413,9 @@ $(CONSOLE
  [7 8 9]]
 )
 
-    Inside a compound format specifier, strings and characters are escaped
-    automatically. To avoid this behavior, add $(B '-') flag to
-    `"%$(LPAREN)"`.
+    As previously stated, strings and characters are escaped
+    automatically inside compound format specifiers. To avoid
+    this behavior, add $(B '-') flag to `"%$(LPAREN)"`.
     -------------------------
     import std.stdio;
 

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -343,8 +343,8 @@ limited to a $(B '-') flag.
     string will be included following the last array element.
 
     NOTE: Inside a grouping format specifier, strings and characters are
-    escaped automatically. To avoid this behavior, add the $(B '-') flag
-    to `"%$(LPAREN)"`.
+    escaped automatically. To avoid this behavior, use `"%-$(LPAREN)"`
+    instead of `"%$(LPAREN)"`.
 
     Example using array and nested array formatting:
     -------------------------
@@ -416,7 +416,7 @@ $(CONSOLE
 
     As previously stated, strings and characters are escaped
     automatically inside compound format specifiers. To avoid
-    this behavior, add the $(B '-') flag to `"%$(LPAREN)"`.
+    this behavior, use `"%-$(LPAREN)"` instead of `"%$(LPAREN)"`.
     -------------------------
     import std.stdio;
 


### PR DESCRIPTION
This functionality is unexpected and buried in between examples down the page. This adds a note just below where compound specifiers are first introduced to make it more prominent for anyone reading the docs.