### PR TITLE
Deprecate std.typetuple.

### DIFF
--- a/changelog/deprecate_typetuple.dd
+++ b/changelog/deprecate_typetuple.dd
@@ -1,0 +1,7 @@
+Deprecate std.typetuple
+
+std.typetuple has been replaced by std.meta in 2015. For legacy
+reasons it has been kept since then. Now it is deprecated and will be
+removed in 2.107.0.
+
+Please use `std.meta : AliasSeq` instead of `std.typetuple : TypeTuple`.

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -2,6 +2,8 @@
  * This module was renamed to disambiguate the term tuple, use
  * $(MREF std, meta) instead.
  *
+ * $(RED Warning: This module will be removed from Phobos in 2.107.0.)
+ *
  * Copyright: Copyright The D Language Foundation 2005 - 2015.
  * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
@@ -9,17 +11,22 @@
  *
  * $(SCRIPT inhibitQuickIndex = 1;)
  */
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("Will be removed from Phobos in 2.107.0. Use std.meta : AliasSeq instead.")
 module std.typetuple;
 
 public import std.meta;
 
 /**
  * Alternate name for $(REF AliasSeq, std,meta) for legacy compatibility.
+ *
+ * Will be removed in 2.107.0.
  */
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("TypeTuple will be removed in 2.107.0. Use std.meta : AliasSeq instead.")
 alias TypeTuple = AliasSeq;
 
-///
-@safe unittest
+deprecated @safe unittest
 {
     import std.typetuple;
     alias TL = TypeTuple!(int, double);
@@ -31,8 +38,7 @@ alias TypeTuple = AliasSeq;
     assert(foo(1, 2.5) == 3);
 }
 
-///
-@safe unittest
+deprecated @safe unittest
 {
     alias TL = TypeTuple!(int, double);
 


### PR DESCRIPTION
I suggest to deprecate this. It was removed in 2015 and is now been long around...