### PR TITLE
std.format: Replace snprintf for x87-reals

### DIFF
--- a/changelog/formatting_floats_in_CTFE.dd
+++ b/changelog/formatting_floats_in_CTFE.dd
@@ -1,4 +1,4 @@
-`float` and `double` values can be formatted at compile time
+Floating point numbers can be formatted at compile time
 
 Example:
 ------
@@ -12,4 +12,5 @@ enum golden_ratio = format!"|%+-20.10E|"((1 + sqrt(5.0)) / 2);
 static assert(golden_ratio == "|+1.6180339887E+00   |");
 ------
 
-Note: compile time formatting `real`s remains unsupported.
+Note: compile time formatting `real`s is only supported for 64-bit
+reals and 80-bit reals.

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1041,6 +1041,15 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     static assert(format("%s", 0.6L) == "0.6");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=9297
+@safe pure unittest
+{
+    static if (real.mant_dig == 64) // 80 bit reals
+    {
+        assert(format("%.25f", 1.6180339887_4989484820_4586834365L) == "1.6180339887498948482072100");
+    }
+}
+
 /*
     Formatting a `creal` is deprecated but still kept around for a while.
  */

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -893,7 +893,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     real a = 0.16;
     real b = 0.016;
     assert(format("%.1f", a) == "0.2");
-//    assert(format("%.2f", b) == "0.02"); // Windows still fails here...
+    assert(format("%.2f", b) == "0.02");
 
     double a1 = 0.16;
     double b1 = 0.016;

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -597,7 +597,8 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     char[512] buf2 = void;
     size_t len;
     char[] buf;
-    static if (is(T == float) || is(T == double) || (is(T == real) && T.mant_dig == double.mant_dig))
+    static if (is(T == float) || is(T == double)
+               || (is(T == real) && (T.mant_dig == double.mant_dig || T.mant_dig == 64)))
     {
         import std.format.internal.floats : RoundingMode, printFloat;
         import std.math; // cannot be selective, because FloatingPointControl might not be defined
@@ -648,7 +649,8 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
             return;
         }
 
-        enforceFmt(!__ctfe, "Cannot format reals at compile-time.");
+        enforceFmt(!__ctfe, mixin("\"Unsupported `real` type: real.sizeof = ", real.sizeof,
+                                  " | real.mant_dig = ", real.mant_dig, "\""));
 
         char[1 /*%*/ + 5 /*flags*/ + 3 /*width.prec*/ + 2 /*format*/
              + 1 /*\0*/] sprintfSpec = void;

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1033,6 +1033,14 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(format("%#.6g",a) == "-1.00000e+06");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=8424
+@safe pure unittest
+{
+    static assert(format("%s", 0.6f) == "0.6");
+    static assert(format("%s", 0.6) == "0.6");
+    static assert(format("%s", 0.6L) == "0.6");
+}
+
 /*
     Formatting a `creal` is deprecated but still kept around for a while.
  */

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -964,6 +964,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 {
     assert(format!"%.1000a"(1.0).length == 1007);
     assert(format!"%.600f"(0.1).length == 602);
+    assert(format!"%.600e"(0.1L).length == 606);
 }
 
 @safe unittest

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1051,6 +1051,13 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=20536
+@safe pure unittest
+{
+    real r = .00000095367431640625L;
+    assert(format("%a", r) == "0x1p-20");
+}
+
 /*
     Formatting a `creal` is deprecated but still kept around for a while.
  */


### PR DESCRIPTION
Finally going life with formatting x87-reals.

I consider this a fix for several issues, although the issues might still remain for some exotic reals: There is no official list, which reals D does support and also no way for me to test if the issues still exist. That means, the issues can never be closed if we do not decide at some time, that it's enough and anyway any fix of these issues will high likely be to support printing floats for that exotic reals, so there is no benefit in leaving the issues open.