### PR TITLE
Deprecate std.signals

### DIFF
--- a/changelog/deprecate_std_signals.dd
+++ b/changelog/deprecate_std_signals.dd
@@ -1,0 +1,10 @@
+Deprecate std.signals
+
+`std.signals` is considered out-dated and not up to Phobos' current
+standards. It will be removed from Phobos in 2.107.0.
+
+If you still need it, go to $(LINK https://github.com/DigitalMars/undeaD)
+
+Other alternatives are:
+$(LINK https://code.dlang.org/packages/descore) and
+$(LINK https://code.dlang.org/packages/phobosx)

--- a/std/package.d
+++ b/std/package.d
@@ -64,7 +64,6 @@ public import
  std.random,
  std.range,
  std.regex,
- std.signals,
  std.socket,
  std.stdint,
  std.stdio,

--- a/std/signals.d
+++ b/std/signals.d
@@ -1,6 +1,10 @@
 // Written in the D programming language.
 
 /**
+ * $(RED Warning: This module is considered out-dated and not up to Phobos'
+ * current standards. It will be removed from Phobos in 2.107.0.
+ * If you still need it, go to $(LINK https://github.com/DigitalMars/undeaD))
+ *
  * Signals and Slots are an implementation of the Observer Pattern.
  * Essentially, when a Signal is emitted, a list of connected Observers
  * (called slots) are called.
@@ -60,6 +64,8 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("Will be removed from Phobos in 2.107.0. If you still need it, go to https://github.com/DigitalMars/undeaD")
 module std.signals;
 
 import core.exception : onOutOfMemoryError;
@@ -286,7 +292,6 @@ mixin template Signal(T1...)
     ST status;
 }
 
-///
 @system unittest
 {
     import std.signals;


### PR DESCRIPTION
I've got the feeling, that std.signals is rarely used and not up to D's standards...

The [discussion in the forum](https://forum.dlang.org/post/oyizvsedzuoqpekmjwkm@forum.dlang.org) only revealed, that we might have failed to prove a point.

See also https://github.com/dlang/undeaD/pull/45.