### PR TITLE
Deprecate ImplicitConversionTarget

### DIFF
--- a/changelog/add_conversion_target.dd
+++ b/changelog/add_conversion_target.dd
@@ -1,6 +1,7 @@
-New function: `AllImplicitConversionTargets`
+`AllImplicitConversionTargets` replaces `ImplicitConversionTargets`
 
 The function `ImplicitConversionTargets` in module `std.traits` has a
 design flaw: The list of conversion targets contains some, but not all
-unsafe conversion targets. To overcome this, a new functions has been
-added.
+unsafe conversion targets. To overcome this, a new function
+`AllImplicitConversionTargets` has been added and
+`ImplicitConversionTargets` has been deprecated.

--- a/std/traits.d
+++ b/std/traits.d
@@ -5140,6 +5140,10 @@ template AllImplicitConversionTargets(T)
 Params:
     T = The type to check
 
+Warning:
+    This template is considered out-dated. It will be removed from
+    Phobos in 2.107.0. Please use $(LREF AllImplicitConversionTargets) instead.
+
 Returns:
     An $(REF AliasSeq,std,meta) with all possible target types of an implicit
     conversion `T`.
@@ -5158,6 +5162,9 @@ Note:
 See_Also:
     $(LREF isImplicitlyConvertible)
  */
+// @@@DEPRECATED_[2.107.0]@@@
+deprecated("ImplicitConversionTargets has been deprecated in favour of AllImplicitConversionTargets "
+   ~ "and will be removed in 2.107.0")
 template ImplicitConversionTargets(T)
 {
     static if (is(T == bool))
@@ -5226,8 +5233,7 @@ template ImplicitConversionTargets(T)
         alias ImplicitConversionTargets = AliasSeq!();
 }
 
-///
-@safe unittest
+deprecated @safe unittest
 {
     import std.meta : AliasSeq;
 
@@ -5260,7 +5266,7 @@ template ImplicitConversionTargets(T)
     )));
 }
 
-@safe unittest
+deprecated @safe unittest
 {
     static assert(is(ImplicitConversionTargets!(double)[0] == real));
     static assert(is(ImplicitConversionTargets!(string)[0] == const(char)[]));


### PR DESCRIPTION
This is a logical followup on #7881 and #7954. `ImplicitConversionTarget` is neither fish nor fowl.