### PR TITLE
merge stable

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -374,14 +374,22 @@ if (isInputRange!SourceRange && isOutputRange!(TargetRange, ElementType!SourceRa
         assert(tlen >= slen,
                 "Cannot copy a source range into a smaller target range.");
 
-        immutable overlaps = __ctfe || () @trusted {
+        immutable overlaps = () @trusted {
             return source.ptr < target.ptr + tlen &&
                 target.ptr < source.ptr + slen; }();
 
         if (overlaps)
         {
-            foreach (idx; 0 .. slen)
-                target[idx] = source[idx];
+            if (source.ptr < target.ptr)
+            {
+                foreach_reverse (idx; 0 .. slen)
+                    target[idx] = source[idx];
+            }
+            else
+            {
+                foreach (idx; 0 .. slen)
+                    target[idx] = source[idx];
+            }
             return target[slen .. tlen];
         }
         else
@@ -505,6 +513,13 @@ $(LINK2 http://en.cppreference.com/w/cpp/algorithm/copy_backward, STL's `copy_ba
         int[] a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         copy(a[5 .. 10], a[4 .. 9]);
         assert(a[4 .. 9] == [6, 7, 8, 9, 10]);
+    }
+
+    // https://issues.dlang.org/show_bug.cgi?id=21724
+    {
+        int[] a = [1, 2, 3, 4];
+        copy(a[0 .. 2], a[1 .. 3]);
+        assert(a == [1, 1, 2, 4]);
     }
 
     // https://issues.dlang.org/show_bug.cgi?id=7898

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -103,6 +103,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.searching;
 
 import std.functional : unaryFun, binaryFun;
+import std.meta : allSatisfy;
 import std.range.primitives;
 import std.traits;
 import std.typecons : Tuple, Flag, Yes, No, tuple;
@@ -770,9 +771,7 @@ ptrdiff_t countUntil(alias pred = "a == b", R, Rs...)(R haystack, Rs needles)
 if (isForwardRange!R
     && Rs.length > 0
     && isForwardRange!(Rs[0]) == isInputRange!(Rs[0])
-    && is(typeof(startsWith!pred(haystack, needles[0])))
-    && (Rs.length == 1
-    || is(typeof(countUntil!pred(haystack, needles[1 .. $])))))
+    && allSatisfy!(canTestStartsWith!(pred, R), Rs))
 {
     typeof(return) result;
 
@@ -1028,8 +1027,7 @@ In the case when no needle parameters are given, return `true` iff back of
 */
 uint endsWith(alias pred = "a == b", Range, Needles...)(Range doesThisEnd, Needles withOneOfThese)
 if (isBidirectionalRange!Range && Needles.length > 1 &&
-    is(typeof(.endsWith!pred(doesThisEnd, withOneOfThese[0])) : bool) &&
-    is(typeof(.endsWith!pred(doesThisEnd, withOneOfThese[1 .. $])) : uint))
+    allSatisfy!(canTestStartsWith!(pred, Range), Needles))
 {
     alias haystack = doesThisEnd;
     alias needles  = withOneOfThese;
@@ -2500,8 +2498,6 @@ $(REF among, std,algorithm,comparison) for checking a value against multiple pos
  +/
 template canFind(alias pred="a == b")
 {
-    import std.meta : allSatisfy;
-
     /++
     Returns `true` if and only if any value `v` found in the
     input range `range` satisfies the predicate `pred`.
@@ -4218,8 +4214,6 @@ Params:
 */
 template skipOver(alias pred = (a, b) => a == b)
 {
-    import std.meta : allSatisfy;
-
     enum bool isPredComparable(T) = ifTestable!(T, binaryFun!pred);
 
     /**
@@ -4608,11 +4602,8 @@ In the case when no needle parameters are given, return `true` iff front of
  */
 uint startsWith(alias pred = (a, b) => a == b, Range, Needles...)(Range doesThisStart, Needles withOneOfThese)
 if (isInputRange!Range && Needles.length > 1 &&
-    is(typeof(.startsWith!pred(doesThisStart, withOneOfThese[0])) : bool ) &&
-    is(typeof(.startsWith!pred(doesThisStart, withOneOfThese[1 .. $])) : uint))
+    allSatisfy!(canTestStartsWith!(pred, Range), Needles))
 {
-    import std.meta : allSatisfy;
-
     template checkType(T)
     {
         enum checkType = is(immutable ElementEncodingType!Range == immutable T);
@@ -4932,6 +4923,12 @@ if (isInputRange!R &&
         assert(startsWith!("a%10 == b%10")(arr, [10, 11]));
         assert(!startsWith!("a%10 == b%10")(arr, [10, 12]));
     }}
+}
+
+private template canTestStartsWith(alias pred, Haystack)
+{
+    enum bool canTestStartsWith(Needle) = is(typeof(
+        (ref Haystack h, ref Needle n) => startsWith!pred(h, n)));
 }
 
 /* (Not yet documented.)

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -980,7 +980,8 @@ public:
                 uint resultBits = (uint(isNegative) << 31) | // sign bit
                     ((0xFF & (exponent - float.min_exp)) << 23) | // exponent
                     cast(uint) ((sansExponent << 1) >>> (64 - 23)); // mantissa.
-                return *cast(float*) &resultBits;
+                // TODO: remove @trusted lambda after DIP 1000 is enabled by default.
+                return (() @trusted => *cast(float*) &resultBits)();
             }
             else static if (T.mant_dig == double.mant_dig)
             {
@@ -989,7 +990,8 @@ public:
                 ulong resultBits = (ulong(isNegative) << 63) | // sign bit
                     ((0x7FFUL & (exponent - double.min_exp)) << 52) | // exponent
                     ((sansExponent << 1) >>> (64 - 52)); // mantissa.
-                return *cast(double*) &resultBits;
+                // TODO: remove @trusted lambda after DIP 1000 is enabled by default.
+                return (() @trusted => *cast(double*) &resultBits)();
             }
             else
             {

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -297,7 +297,7 @@ string bitfields(T...)()
 
         // would be nice to check for valid variable names too
         static if (i % 3 == 1)
-            static assert(is (typeof(ARG) == string),
+            static assert(is (typeof(ARG) : string),
                           "Variable name expected, found " ~ ARG.stringof);
 
         static if (i % 3 == 2)
@@ -634,6 +634,18 @@ unittest
     {
         mixin(bitfields!(int, "", 1,
                          int, "gshared", 7));
+    }
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21725
+@safe unittest
+{
+    struct S
+    {
+        mixin(bitfields!(
+            uint, q{foo}, 4,
+            uint, null, 4,
+        ));
     }
 }
 

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -1047,7 +1047,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         {
             bool overflow;
             auto r = opChecked!op(lhs, T(payload), overflow);
-            if (overflow) r = hook.onOverflow!op(42);
+            if (overflow) r = hook.onOverflow!op(lhs, payload);
             return Checked!(typeof(r), Hook)(r);
         }
         else
@@ -1216,6 +1216,18 @@ if (is(typeof(Checked!(T, Hook)(value))))
     test!ubyte;
     test!(const ubyte);
     test!(immutable ubyte);
+}
+
+@system unittest
+{
+    // https://issues.dlang.org/show_bug.cgi?id=21758
+    assert(4 * checked(5L) == 20);
+    assert(20 / checked(5L) == 4);
+    assert(2 ^^ checked(3L) == 8);
+    assert(12 % checked(5L) == 2);
+    assert((0xff & checked(3L)) == 3);
+    assert((0xf0 | checked(3L)) == 0xf3);
+    assert((0xff ^ checked(3L)) == 0xfc);
 }
 
 // Abort


### PR DESCRIPTION
- Fix issue #21702 - avoid quadratic template expansion in constraints of multiple search term versions of std.algorithm.searching.startsWith & endsWith
- Fix Issue 21725 - Specifying null as bitfields variable name now fails
- Fix Issue 21721 - casting std.BigInts to built-in floating point types not allowed in `@safe` code without -preview=dip1000
- Fix Issue 21724 - std.algorithm.mutation.copy fails on overlapping arrays if the source array's pointer is less than the destination array's pointer
- Fix issue 21716: std.regex performance regression.
- Fix Issue 21758 - std.experimental.checkedint opBinaryRight with integer left-hand side does not compile for any operators except + and -
