### PR TITLE
Fix second part of Issue 21722 - toString(sink, string format) does not work with non-"%s" strings

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -2732,6 +2732,31 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
 
     Bar b;
     assert(format("%b", b) == "Hello");
+
+    static if (hasPreviewIn)
+    {
+        struct Foo
+        {
+            void toString(scope void delegate(in char[]) sink, in FormatSpec!char fmt)
+            {
+                sink("Hello");
+            }
+        }
+
+        Foo f;
+        assert(format("%b", f) == "Hello");
+
+        struct Foo2
+        {
+            void toString(scope void delegate(in char[]) sink, string fmt)
+            {
+                sink("Hello");
+            }
+        }
+
+        Foo2 f2;
+        assert(format("%b", f2) == "Hello");
+    }
 }
 
 void enforceValidFormatSpec(T, Char)(scope const ref FormatSpec!Char f)
@@ -2744,6 +2769,8 @@ void enforceValidFormatSpec(T, Char)(scope const ref FormatSpec!Char f)
     static if (
             overload != HasToStringResult.constCharSinkFormatSpec &&
             overload != HasToStringResult.constCharSinkFormatString &&
+            overload != HasToStringResult.inCharSinkFormatSpec &&
+            overload != HasToStringResult.inCharSinkFormatString &&
             overload != HasToStringResult.customPutWriterFormatSpec &&
             !isInputRange!T)
     {


### PR DESCRIPTION
It took me a whole month to understand a comment from @Geod24 in #7870. Sorry for being so ignorant. This is essentially the same fix, but with `-preview=in`, so I did not create a new issue; hope this is correct - the testers currently don't check with `-preview=in` as far as I know. I did that locally though. (And I still based on master, due to the heavy changes to `std.format` in the last weeks; again I hope that's ok.)

Finally, I wonder, why there is no `customPutWriterFormatString`. Does anybody know a reason? Or was it just forgotten?