### PR TITLE
Replace equalsDigit with isClose

### DIFF
--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -218,9 +218,9 @@ if (isFloatingPoint!(F) && isIntegral!(G))
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
-    assert(equalsDigit(pow(2.0L, 10L), 1024, 19));
+    assert(isClose(pow(2.0L, 10L), 1024, 1e-18));
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=21601
@@ -775,9 +775,9 @@ if (isFloatingPoint!(F) && isFloatingPoint!(G))
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
-    assert(equalsDigit(pow(2.0L, 10.0L), 1024, 19));
+    assert(isClose(pow(2.0L, 10.0L), 1024, 1e-18));
 }
 
 @safe pure nothrow @nogc unittest
@@ -1045,8 +1045,7 @@ private T expImpl(T)(T x) @safe pure nothrow @nogc
 
 @safe @nogc nothrow unittest
 {
-    import std.math : floatTraits, RealFormat, NaN, E, feqrel, isIdentical, abs,
-        equalsDigit, useDigits;
+    import std.math : floatTraits, RealFormat, NaN, E, feqrel, isIdentical, abs, isClose;
 
     version (IeeeFlagsSupport) import std.math : IeeeFlags, resetIeeeFlags, ieeeFlags;
     version (FloatingPointControlSupport)
@@ -1191,7 +1190,7 @@ private T expImpl(T)(T x) @safe pure nothrow @nogc
     // High resolution test (verified against GNU MPFR/Mathematica).
     assert(exp(0.5L) == 0x1.A612_98E1_E069_BC97_2DFE_FAB6_DF34p+0L);
 
-    assert(equalsDigit(exp(3.0L), E * E * E, useDigits));
+    assert(isClose(exp(3.0L), E * E * E, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /**
@@ -2229,13 +2228,13 @@ if (isFloatingPoint!T)
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
     int exp;
     real mantissa = frexp(123.456L, exp);
 
     // check if values are equal to 19 decimal digits of precision
-    assert(equalsDigit(mantissa * pow(2.0L, cast(real) exp), 123.456L, 19));
+    assert(isClose(mantissa * pow(2.0L, cast(real) exp), 123.456L, 1e-18));
 }
 
 @safe unittest
@@ -2721,7 +2720,7 @@ float ldexp(float n, int exp)   @safe pure nothrow @nogc { return core.math.ldex
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
     static real[3][] vals =    // value,exp,ldexp
     [
@@ -2743,7 +2742,7 @@ float ldexp(float n, int exp)   @safe pure nothrow @nogc { return core.math.ldex
         real z = vals[i][2];
         real l = ldexp(x, exp);
 
-        assert(equalsDigit(z, l, 7));
+        assert(isClose(z, l, 1e-6));
     }
 
     real function(real, int) pldexp = &ldexp;
@@ -3198,10 +3197,10 @@ real log2(real x) @safe pure nothrow @nogc
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
     // check if values are equal to 19 decimal digits of precision
-    assert(equalsDigit(log2(1024.0L), 10, 19));
+    assert(isClose(log2(1024.0L), 10, 1e-18));
 }
 
 /*****************************************

--- a/std/math/package.d
+++ b/std/math/package.d
@@ -262,60 +262,6 @@ version (D_HardFloat)
     version (IeeeFlagsSupport) version = FloatingPointControlSupport;
 }
 
-package(std.math)
-{
-    static if (real.sizeof > double.sizeof)
-        enum uint useDigits = 16;
-    else
-        enum uint useDigits = 15;
-
-    /******************************************
-     * Compare floating point numbers to n decimal digits of precision.
-     * Returns:
-     *  1       match
-     *  0       nomatch
-     */
-
-    package(std.math) bool equalsDigit(real x, real y, uint ndigits) @safe nothrow @nogc
-    {
-        import core.stdc.stdio : sprintf;
-
-        if (signbit(x) != signbit(y))
-            return 0;
-
-        if (isInfinity(x) && isInfinity(y))
-            return 1;
-        if (isInfinity(x) || isInfinity(y))
-            return 0;
-
-        if (isNaN(x) && isNaN(y))
-            return 1;
-        if (isNaN(x) || isNaN(y))
-            return 0;
-
-        char[30] bufx;
-        char[30] bufy;
-        assert(ndigits < bufx.length);
-
-        int ix;
-        int iy;
-        version (CRuntime_Microsoft)
-            alias real_t = double;
-        else
-            alias real_t = real;
-
-        () @trusted {
-            ix = sprintf(bufx.ptr, is(real_t == real) ? "%.*Lg" : "%.*g", ndigits, cast(real_t) x);
-            iy = sprintf(bufy.ptr, is(real_t == real) ? "%.*Lg" : "%.*g", ndigits, cast(real_t) y);
-        } ();
-
-        assert(ix < bufx.length && ix > 0);
-        assert(ix < bufy.length && ix > 0);
-
-        return bufx[0 .. ix] == bufy[0 .. iy];
-    }
-}
-
 version (IeeeFlagsSupport)
 {
 

--- a/std/math/trigonometry.d
+++ b/std/math/trigonometry.d
@@ -473,8 +473,8 @@ private T tanImpl(T)(T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testTan!T();
 
-    import std.math : equalsDigit, PI, sqrt, useDigits;
-    assert(equalsDigit(tan(PI / 3), sqrt(3.0L), useDigits));
+    import std.math : isClose, PI, sqrt;
+    assert(isClose(tan(PI / 3), sqrt(3.0L), real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***************
@@ -513,9 +513,9 @@ float acos(float x) @safe pure nothrow @nogc  { return acos(cast(real) x); }
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit, PI, useDigits;
+    import std.math : isClose, PI;
 
-    assert(equalsDigit(acos(0.5), PI / 3, useDigits));
+    assert(isClose(acos(0.5), PI / 3, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***************
@@ -554,9 +554,9 @@ float asin(float x) @safe pure nothrow @nogc  { return asin(cast(real) x); }
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit, PI, useDigits;
+    import std.math : isClose, PI;
 
-    assert(equalsDigit(asin(0.5), PI / 6, useDigits));
+    assert(isClose(asin(0.5), PI / 6, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***************
@@ -804,8 +804,8 @@ private T atanImpl(T)(T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testAtan!T();
 
-    import std.math : equalsDigit, sqrt, PI, useDigits;
-    assert(equalsDigit(atan(sqrt(3.0L)), PI / 3, useDigits));
+    import std.math : isClose, sqrt, PI;
+    assert(isClose(atan(sqrt(3.0L)), PI / 3, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***************
@@ -1012,8 +1012,8 @@ private T atan2Impl(T)(T y, T x) @safe pure nothrow @nogc
     foreach (T; AliasSeq!(real, double, float))
         testAtan2!T();
 
-    import std.math : equalsDigit, sqrt, PI, useDigits;
-    assert(equalsDigit(atan2(1.0L, sqrt(3.0L)), PI / 6, useDigits));
+    import std.math : isClose, sqrt, PI;
+    assert(isClose(atan2(1.0L, sqrt(3.0L)), PI / 6, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***********************************
@@ -1051,9 +1051,9 @@ float cosh(float x) @safe pure nothrow @nogc  { return cosh(cast(real) x); }
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit, E, useDigits;
+    import std.math : isClose, E;
 
-    assert(equalsDigit(cosh(1.0), (E + 1.0 / E) / 2, useDigits));
+    assert(isClose(cosh(1.0), (E + 1.0 / E) / 2, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***********************************
@@ -1106,9 +1106,9 @@ private F _sinh(F)(F x)
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit, E, useDigits;
+    import std.math : isClose, E;
 
-    assert(equalsDigit(sinh(1.0L), real((E - 1.0 / E) / 2), useDigits));
+    assert(isClose(sinh(1.0L), real((E - 1.0 / E) / 2), real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 /***********************************
  * Calculates the hyperbolic tangent of x.
@@ -1152,9 +1152,9 @@ private F _tanh(F)(F x)
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit;
+    import std.math : isClose;
 
-    assert(equalsDigit(tanh(1.0L), sinh(1.0L) / cosh(1.0L), 15));
+    assert(isClose(tanh(1.0L), sinh(1.0L) / cosh(1.0L), real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***********************************
@@ -1207,9 +1207,9 @@ private F _acosh(F)(F x) @safe pure nothrow @nogc
 
 @safe @nogc nothrow unittest
 {
-    import std.math : equalsDigit, useDigits;
+    import std.math : isClose;
 
-    assert(equalsDigit(acosh(cosh(3.0L)), 3.0L, useDigits));
+    assert(isClose(acosh(cosh(3.0L)), 3.0L, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***********************************
@@ -1261,9 +1261,9 @@ private F _asinh(F)(F x)
 
 @safe unittest
 {
-    import std.math : equalsDigit, useDigits;
+    import std.math : isClose;
 
-    assert(equalsDigit(asinh(sinh(3.0L)), 3.0L, useDigits));
+    assert(isClose(asinh(sinh(3.0L)), 3.0L, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }
 
 /***********************************
@@ -1312,7 +1312,7 @@ float atanh(float x) @safe pure nothrow @nogc { return atanh(cast(real) x); }
 
 @safe unittest
 {
-    import std.math : equalsDigit, useDigits;
+    import std.math : isClose;
 
-    assert(equalsDigit(atanh(tanh(0.5L)), 0.5, useDigits));
+    assert(isClose(atanh(tanh(0.5L)), 0.5, real.sizeof > double.sizeof ? 1e-15 : 1e-14));
 }


### PR DESCRIPTION
`isClose` does essentially the same as `equalsDigit`, is faster and doesn't use `libc`. This change was suggested by @ibuclaw in #7942 (second to last "show resolved" parts).