### PR TITLE
std.format: Make formatting nan and inf 100% @nogc.

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -542,8 +542,9 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         }
 
         fs.spec = spec2;
-        buf = printFloat(buf2[], val, fs, mode);
+        buf = printFloat(buf2[], w, val, fs, mode);
         len = buf.length;
+        if (len == 0) return;
     }
     else
     {
@@ -3112,7 +3113,7 @@ private bool needToSwapEndianess(Char)(scope const ref FormatSpec!Char f)
         || endian == Endian.bigEndian && f.flDash;
 }
 
-private void writeAligned(Writer, T, Char)(auto ref Writer w, T s, scope const ref FormatSpec!Char f)
+void writeAligned(Writer, T, Char)(auto ref Writer w, T s, scope const ref FormatSpec!Char f)
 if (isSomeString!T)
 {
     writeAligned(w,"","",s,f);
@@ -3151,7 +3152,7 @@ if (isSomeString!T)
     assert(w.data == "a本Ä       ", w.data);
 }
 
-private void writeAligned(Writer, T1, T2, T3, Char)(auto ref Writer w,
+void writeAligned(Writer, T1, T2, T3, Char)(auto ref Writer w,
     T1 prefix, T2 grouped, T3 suffix, scope const ref FormatSpec!Char f,
     bool integer_precision = false)
 if (isSomeString!T1 && isSomeString!T2 && isSomeString!T3)


### PR DESCRIPTION
This is a first step towards making formatting floats 100% `@nogc`, by using `writeAligned`. To do so, `formatValueImpl` in `internal.write` has to pass the writer to `printFloat`. 

To avoid having to do so in all unittests too, I wrote a small wrapper for the unittests. This wrapper is not `@nogc`, but the unittests in `std.format.internal.floats` don't need to be, only the one which guards against allocating.

In this last test, I used `NoOpSink` from `std.format.package.d` as a writer, because for that test the formatted result is not important. Therefore the tests which take nan or inf as argument now return an empty string. I added one more test there, showing, that indeed no allocations happen, even when the width is larger than the buffer size.

Finally I had to make `writeAligned` `package(std.format)` scope (default in `internal.write`), to be able to access it from `internal.floats`.

PS: Meanwhile I prepared some followup PRs: The roadmap looks like this: Next one will make formatting zeros `@nogc` and add a necessary enhancement to `writeAligned` in `std.format.interal.write`. After that, there are three more PRs, that can be done in parallel: One about `%a`, one about `%e` and one about `%f` (with the last two covering the `%g` case too). After that, there will be a (not yet prepared) clean up PR which (probably among other things) removes no longer needed buffers.