### PR TITLE
std.numeric: Always use Stein's algorithm for integral gcd()

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -2931,6 +2931,7 @@ Params:
     T = Any numerical type that supports the modulo operator `%`. If
         bit-shifting `<<` and `>>` are also supported, Stein's algorithm will
         be used; otherwise, Euclid's algorithm is used as _a fallback.
+
 Returns:
     The greatest common divisor of the given arguments.
  */
@@ -2940,20 +2941,6 @@ if (isIntegral!T)
     static if (is(T == const) || is(T == immutable))
     {
         return gcd!(Unqual!T)(a, b);
-    }
-    else version (DigitalMars)
-    {
-        static if (T.min < 0)
-        {
-            assert(a >= 0 && b >= 0);
-        }
-        while (b)
-        {
-            immutable t = b;
-            b = a % b;
-            a = t;
-        }
-        return a;
     }
     else
     {


### PR DESCRIPTION
Whatever tests/observations were done in #4940 no longer apply when I run benchmarks locally:
```
ubyte_euclid: 10 secs, 741 ms, 853 μs, and 9 hnsecs
ubyte_stein: 6 secs, 98 ms, 939 μs, and 7 hnsecs
ushort_euclid: 13 secs, 442 ms, 495 μs, and 6 hnsecs
ushort_stein: 9 secs, 266 ms, 581 μs, and 2 hnsecs
uint_euclid: 13 secs, 285 ms, 480 μs, and 4 hnsecs
uint_stein: 9 secs, 173 ms, 414 μs, and 8 hnsecs
ulong_euclid: 20 secs, 227 ms, 886 μs, and 2 hnsecs
ulong_stein: 9 secs, 181 ms, 300 μs, and 8 hnsecs
```