### PR TITLE
Move unittests from std.format.internal.write at correct place.

### DIFF
--- a/std/format/read.d
+++ b/std/format/read.d
@@ -96,7 +96,7 @@ module std.format.read;
     assert(result == 373 /* little endian */ || result == 29953 /* big endian */ );
 }
 
-// Floating point numbers
+/// Floating point numbers
 @safe pure unittest
 {
     import std.format.spec : singleSpec;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1615,6 +1615,22 @@ if (distinctFieldNames!(Specs))
     assert(!(t == t));
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=8015
+@safe unittest
+{
+    struct MyStruct
+    {
+        string str;
+        @property string toStr()
+        {
+            return str;
+        }
+        alias toStr this;
+    }
+
+    Tuple!(MyStruct) t;
+}
+
 /**
     Creates a copy of a $(LREF Tuple) with its fields in _reverse order.
 


### PR DESCRIPTION
Several unittests in `std.format` are scattered around. I collected all of `std.format.internal.write` that belonged to a different place and put them where they should be (e.g. next to the function they test.)

There was one unittest that I moved to `std.typecons`. The original bug resided in `std.format`, but meanwhile the implementation of `std.typecons` changed and `formatElement` isn't called there anymore. IMHO it makes no sense to keep this in `std.format`.