### PR TITLE
[dmd-cxx] Fix Issue 17844 - std.process.execute should allow not capturing stderr 

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1358,7 +1358,8 @@ version (Windows)
 
 
 /**
-Flags that control the behaviour of $(LREF spawnProcess) and
+Flags that control the behaviour of process creation functions in this
+module. Most flags only apply to $(LREF spawnProcess) and
 $(LREF spawnShell).
 
 Use bitwise OR to combine flags.
@@ -1444,6 +1445,8 @@ enum Config
     Specify this flag when calling `execute` or `executeShell` to
     cause invoked processes' stderr stream to be sent to $(REF stderr,
     std,stdio), and only capture and return standard output.
+
+    This flag has no effect on $(LREF spawnProcess) or $(LREF spawnShell).
     */
     stderrPassThrough = 128,
 }

--- a/std/process.d
+++ b/std/process.d
@@ -2569,7 +2569,20 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     auto r3 = executeShell("exit 123");
     assert(r3.status == 123);
     assert(r3.output.empty);
-    auto r4 = executeShell("echo -n '\r' 1>&2",
+}
+
+unittest
+{
+    // Temporarily disable output to stderr so as to not spam the build log.
+    import std.stdio : stderr;
+    auto t = stderr;
+    version (Posix)
+        stderr.open("/dev/null", "w");
+    else
+        stderr.open("nul", "w");
+    scope(exit) stderr = t;
+
+    auto r4 = executeShell("echo This line should not be visible. 1>&2",
         null, Config.stderrPassThrough);
     assert(r4.status == 0);
     assert(r4.output.empty);

--- a/std/process.d
+++ b/std/process.d
@@ -2589,10 +2589,8 @@ unittest
     assert(r.status == 0);
     assert(r.output.empty);
     auto witness = readText(tmpname);
-    version (Posix)
-        assert(witness == "D rox.\n", "'" ~ witness ~ "'");
-    else
-        assert(witness == "D rox.\r\n", "'" ~ witness ~ "'");
+    import std.ascii : newline;
+    assert(witness == "D rox." ~ newline, "'" ~ witness ~ "'");
 }
 
 @safe unittest

--- a/std/process.d
+++ b/std/process.d
@@ -2584,13 +2584,13 @@ unittest
     {
         stderr.open(tmpname, "w");
         scope(exit) stderr = t;
-        r = executeShell("echo D rox. 1>&2", null, Config.stderrPassThrough);
+        r = executeShell("echo D rox>&2", null, Config.stderrPassThrough);
     }
     assert(r.status == 0);
     assert(r.output.empty);
     auto witness = readText(tmpname);
     import std.ascii : newline;
-    assert(witness == "D rox." ~ newline, "'" ~ witness ~ "'");
+    assert(witness == "D rox" ~ newline, "'" ~ witness ~ "'");
 }
 
 @safe unittest

--- a/std/process.d
+++ b/std/process.d
@@ -1433,6 +1433,19 @@ enum Config
     Calling $(LREF wait) or $(LREF kill) with the resulting $(D Pid) is invalid.
     */
     detached = 64,
+
+    /**
+    By default, the $(LREF execute) and $(LREF executeShell) functions
+    will capture child processes' both stdout and stderr. This can be
+    undesirable if the standard output is to be processed or otherwise
+    used by the invoking program, as `execute`'s result would then
+    contain a mix of output and warning/error messages.
+
+    Specify this flag when calling `execute` or `executeShell` to
+    cause invoked processes' stderr stream to be sent to $(REF stderr,
+    std,stdio), and only capture and return standard output.
+    */
+    stderrPassThrough = 128,
 }
 
 
@@ -2487,7 +2500,11 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     import std.array : appender;
     import std.typecons : Tuple;
 
-    auto p = pipeFunc(commandLine, Redirect.stdout | Redirect.stderrToStdout,
+    auto redirect = (config & Config.stderrPassThrough)
+        ? Redirect.stdout
+        : Redirect.stdout | Redirect.stderrToStdout;
+
+    auto p = pipeFunc(commandLine, redirect,
                       env, config, workDir, extraArgs);
 
     auto a = appender!(ubyte[])();
@@ -2549,6 +2566,10 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     auto r3 = executeShell("exit 123");
     assert(r3.status == 123);
     assert(r3.output.empty);
+    auto r4 = executeShell("echo stderr test, please ignore 1>&2",
+        null, Config.stderrPassThrough);
+    assert(r4.status == 0);
+    assert(r4.output.empty);
 }
 
 @safe unittest

--- a/std/process.d
+++ b/std/process.d
@@ -2571,13 +2571,15 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     assert(r3.output.empty);
 }
 
-unittest
+@system unittest
 {
     // Temporarily disable output to stderr so as to not spam the build log.
     import std.stdio : stderr;
     import std.typecons : Tuple;
     import std.file : readText;
-    Tuple!(int, "status", string, "output") r;
+    import std.traits : ReturnType;
+
+    ReturnType!executeShell r;
     auto tmpname = uniqueTempPath;
     auto t = stderr;
     // Open a new scope to minimize code ran with stderr redirected.

--- a/std/process.d
+++ b/std/process.d
@@ -2569,7 +2569,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
     auto r3 = executeShell("exit 123");
     assert(r3.status == 123);
     assert(r3.output.empty);
-    auto r4 = executeShell("echo stderr test, please ignore 1>&2",
+    auto r4 = executeShell("echo -n '\r' 1>&2",
         null, Config.stderrPassThrough);
     assert(r4.status == 0);
     assert(r4.output.empty);


### PR DESCRIPTION
From #5742