### PR TITLE
std.format: Repair docs of compound indicator and add examples.

### DIFF
--- a/changelog/rework_format_docs.dd
+++ b/changelog/rework_format_docs.dd
@@ -1,0 +1,15 @@
+Documentation of `std.format` has been completely reworked.
+
+In the last years, the documentation of `std.format` was outdated
+little by little and therefore needed a complete rework. The whole
+package was reviewed and all documentations, including examples,
+improved and extended.
+
+Some highlights:
+
+$(UL
+$(LI The grammar of the format string was updated.)
+$(LI A detailed description of format specifiers was provided.)
+$(LI Several examples on how to use the functions and the format
+     strings were added.)
+)


### PR DESCRIPTION
Last one in a long row of rework document `std.format` PRs!

While trying to unify the descriptions of compound specifiers I realized, that I erred on the use of them. So I mainly took the former description (which was updated in PR #7944) and merged it somehow with my former description.

I moved all examples to real unittests and added several more to cover most of the stuff explained before.

Finally I added a release note.