### PR TITLE
Narrow imports of std.math in the rest of phobos.

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -985,7 +985,7 @@ template equal(alias pred = "a == b")
 @safe @nogc unittest
 {
     import std.algorithm.comparison : equal;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     int[4] a = [ 1, 2, 4, 3 ];
     assert(!equal(a[], a[1..$]));
@@ -1023,7 +1023,7 @@ range of range (of range...) comparisons.
     import std.algorithm.iteration : map;
     import std.internal.test.dummyrange : ReferenceForwardRange,
         ReferenceInputRange, ReferenceInfiniteForwardRange;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     // various strings
     assert(equal("æøå", "æøå")); //UTF8 vs UTF8

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1343,7 +1343,7 @@ if (is(typeof(unaryFun!predicate)))
 @safe unittest
 {
     import std.algorithm.comparison : equal;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.range;
 
     int[] arr = [ 1, 2, 3, 4, 5 ];
@@ -2819,7 +2819,7 @@ nothrow pure @system unittest
 nothrow @system unittest
 {
     import std.algorithm.comparison : equal;
-    import std.math : abs;
+    import std.math.algebraic : abs;
 
     struct SomeRange
     {
@@ -2866,7 +2866,7 @@ nothrow @system unittest
 nothrow pure @system unittest
 {
     // Grouping by maximum adjacent difference:
-    import std.math : abs;
+    import std.math.algebraic : abs;
     import std.algorithm.comparison : equal;
     auto r3 = [1, 3, 2, 5, 4, 9, 10].splitWhen!((a, b) => abs(a-b) >= 3);
     assert(r3.equal!equal([
@@ -4020,7 +4020,7 @@ remarkable power and flexibility.
 @safe unittest
 {
     import std.algorithm.comparison : max, min;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.range;
 
     int[] arr = [ 1, 2, 3, 4, 5 ];
@@ -4075,7 +4075,8 @@ The number of seeds must be correspondingly increased.
 @safe unittest
 {
     import std.algorithm.comparison : max, min;
-    import std.math : isClose, sqrt;
+    import std.math.operations : isClose;
+    import std.math.algebraic : sqrt;
     import std.typecons : tuple, Tuple;
 
     double[] a = [ 3.0, 4, 7, 11, 3, 2, 5 ];
@@ -4585,7 +4586,7 @@ if (fun.length >= 1)
 {
     import std.algorithm.comparison : max, min;
     import std.array : array;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.range : chain;
 
     int[] arr = [1, 2, 3, 4, 5];
@@ -4641,7 +4642,7 @@ The number of seeds must be correspondingly increased.
 {
     import std.algorithm.comparison : max, min;
     import std.algorithm.iteration : map;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.typecons : tuple;
 
     double[] a = [3.0, 4, 7, 11, 3, 2, 5];
@@ -4696,7 +4697,7 @@ The number of seeds must be correspondingly increased.
 {
     import std.algorithm.comparison : max, min;
     import std.array : array;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.typecons : tuple;
 
     const float a = 0.0;
@@ -4718,7 +4719,7 @@ The number of seeds must be correspondingly increased.
 
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.typecons : tuple;
 
     enum foo = "a + 0.5 * b";
@@ -6717,7 +6718,7 @@ if (isInputRange!R && !isInfinite!R && is(typeof(seed = seed + r.front)))
     assert(sum([1F, 2, 3, 4]) == 10);
 
     //Force pair-wise floating point sumation on large integers
-    import std.math : isClose;
+    import std.math.operations : isClose;
     assert(iota(ulong.max / 2, ulong.max / 2 + 4096).sum(0.0)
                .isClose((ulong.max / 2) * 4096.0 + 4096^^2 / 2));
 }
@@ -6810,7 +6811,7 @@ if (isForwardRange!R && !isRandomAccessRange!R)
 private auto sumPairwiseN(size_t N, bool needEmptyChecks, F, R)(ref R r)
 if (isForwardRange!R && !isRandomAccessRange!R)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     static assert(isPowerOf2(N), "N must be a power of 2");
     static if (N == 2) return sumPair!(needEmptyChecks, F)(r);
     else return sumPairwiseN!(N/2, needEmptyChecks, F)(r)
@@ -6997,7 +6998,8 @@ if (isInputRange!R &&
 ///
 @safe @nogc pure nothrow unittest
 {
-    import std.math : isClose, isNaN;
+    import std.math.operations : isClose;
+    import std.math.traits : isNaN;
 
     static immutable arr1 = [1, 2, 3];
     static immutable arr2 = [1.5, 2.5, 12.5];
@@ -7011,7 +7013,7 @@ if (isInputRange!R &&
 @safe pure nothrow unittest
 {
     import std.internal.test.dummyrange : ReferenceInputRange;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto r1 = new ReferenceInputRange!int([1, 2, 3]);
     assert(r1.mean.isClose(2));
@@ -7025,7 +7027,7 @@ if (isInputRange!R &&
 {
     import std.bigint : BigInt;
     import std.internal.test.dummyrange : ReferenceInputRange;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto bigint_arr = [BigInt("1"), BigInt("2"), BigInt("3"), BigInt("6")];
     auto bigint_arr2 = new ReferenceInputRange!BigInt([

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1424,7 +1424,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert([[0, 4], [1, 2]].extremum!("a[1]", "a > b") == [0, 4]);
 
     // use a custom comparator
-    import std.math : cmp;
+    import std.math.operations : cmp;
     assert([-2., 0, 5].extremum!cmp == 5.0);
     assert([-2., 0, 2].extremum!`cmp(a, b) < 0` == -2.0);
 

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1990,7 +1990,8 @@ if (((ss == SwapStrategy.unstable && (hasSwappableElements!Range ||
     double[] numbers = [-0.0, 3.0, -2.0, double.nan, 0.0, -double.nan];
 
     import std.algorithm.comparison : equal;
-    import std.math : cmp, isIdentical;
+    import std.math.operations : cmp;
+    import std.math.traits : isIdentical;
 
     sort!((a, b) => cmp(a, b) < 0)(numbers);
 
@@ -4779,7 +4780,7 @@ shapes. Here's a non-trivial example:
 */
 @safe unittest
 {
-    import std.math : sqrt;
+    import std.math.algebraic : sqrt;
 
     // Print the 60 vertices of a uniform truncated icosahedron (soccer ball)
     enum real Phi = (1.0 + sqrt(5.0)) / 2.0;    // Golden ratio

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -737,7 +737,7 @@ public:
 
     @safe unittest
     {
-        import std.math : nextDown, nextUp;
+        import std.math.operations : nextDown, nextUp;
 
         const x = BigInt("0x1abc_de80_0000_0000_0000_0000_0000_0000");
         BigInt x1 = x + 1;
@@ -1077,7 +1077,8 @@ public:
     int opCmp(T)(const T y) nothrow @nogc @safe const if (isFloatingPoint!T)
     {
         import core.bitop : bsr;
-        import std.math : cmp, isFinite;
+        import std.math.operations : cmp;
+        import std.math.traits : isFinite;
 
         const asFloat = toFloat!(T, "truncate");
         if (asFloat != y)
@@ -1926,7 +1927,7 @@ unittest
 
 @safe unittest
 {
-    import std.math : abs;
+    import std.math.algebraic : abs;
     auto r = abs(BigInt(-1000)); // https://issues.dlang.org/show_bug.cgi?id=6486
     assert(r == 1000);
 

--- a/std/complex.d
+++ b/std/complex.d
@@ -159,7 +159,7 @@ if (isFloatingPoint!T)
         if (isOutputRange!(Writer, const(Char)[]))
     {
         import std.format.write : formatValue;
-        import std.math : signbit;
+        import std.math.traits : signbit;
         import std.range.primitives : put;
         formatValue(w, re, formatSpec);
         if (signbit(im) == 0)
@@ -323,7 +323,8 @@ if (isFloatingPoint!T)
         if (op == "^^" && isNumeric!R)
     {
         import core.math : cos, sin;
-        import std.math : exp, log, PI;
+        import std.math.exponential : exp, log;
+        import std.math.constants : PI;
         Unqual!(CommonType!(T, R)) ab = void, ar = void;
 
         if (lhs >= 0)
@@ -411,7 +412,7 @@ if (isFloatingPoint!T)
         if (op == "^^" && is(C R == Complex!R))
     {
         import core.math : cos, sin;
-        import std.math : exp, log;
+        import std.math.exponential : exp, log;
         immutable r = abs(this);
         immutable t = arg(this);
         immutable ab = r^^z.re * exp(-t*z.im);
@@ -739,7 +740,7 @@ if (is(T R == Complex!R))
 */
 T abs(T)(Complex!T z) @safe pure nothrow @nogc
 {
-    import std.math : hypot;
+    import std.math.algebraic : hypot;
     return hypot(z.re, z.im);
 }
 
@@ -788,7 +789,7 @@ T sqAbs(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    import std.math;
+    import std.math.operations : isClose;
     assert(sqAbs(complex(0.0)) == 0.0);
     assert(sqAbs(complex(1.0)) == 1.0);
     assert(sqAbs(complex(0.0, 1.0)) == 1.0);
@@ -806,7 +807,7 @@ if (isFloatingPoint!T)
 
 @safe pure nothrow unittest
 {
-    import std.math;
+    import std.math.operations : isClose;
     assert(sqAbs(0.0) == 0.0);
     assert(sqAbs(-1.0) == 1.0);
     assert(isClose(sqAbs(-3.0L), 9.0L));
@@ -820,14 +821,14 @@ if (isFloatingPoint!T)
  */
 T arg(T)(Complex!T z) @safe pure nothrow @nogc
 {
-    import std.math : atan2;
+    import std.math.trigonometry : atan2;
     return atan2(z.im, z.re);
 }
 
 ///
 @safe pure nothrow unittest
 {
-    import std.math;
+    import std.math.constants : PI_2, PI_4;
     assert(arg(complex(1.0)) == 0.0);
     assert(arg(complex(0.0L, 1.0L)) == PI_2);
     assert(arg(complex(1.0L, 1.0L)) == PI_4);
@@ -849,7 +850,8 @@ T norm(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, PI;
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
     assert(norm(complex(3.0, 4.0)) == 25.0);
     assert(norm(fromPolar(5.0, 0.0)) == 25.0);
     assert(isClose(norm(fromPolar(5.0L, PI / 6)), 25.0L));
@@ -930,7 +932,9 @@ Complex!(CommonType!(T, U)) fromPolar(T, U)(const T modulus, const U argument)
 @safe pure nothrow unittest
 {
     import core.math;
-    import std.math;
+    import std.math.operations : isClose;
+    import std.math.algebraic : sqrt;
+    import std.math.constants : PI_4;
     auto z = fromPolar(core.math.sqrt(2.0), PI_4);
     assert(isClose(z.re, 1.0L));
     assert(isClose(z.im, 1.0L));
@@ -941,7 +945,7 @@ version (StdUnittest)
     // Helper function for comparing two Complex numbers.
     int ceqrel(T)(const Complex!T x, const Complex!T y) @safe pure nothrow @nogc
     {
-        import std.math : feqrel;
+        import std.math.operations : feqrel;
         const r = feqrel(x.re, y.re);
         const i = feqrel(x.im, y.im);
         return r < i ? r : i;
@@ -1030,7 +1034,8 @@ Complex!T asin(T)(Complex!T z)  @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    import std.math : isClose, PI;
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
     assert(asin(complex(0.0)) == 0.0);
     assert(isClose(asin(complex(0.5L)), PI / 6));
 }
@@ -1052,7 +1057,9 @@ Complex!T acos(T)(Complex!T z)  @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    import std.math : isClose, PI, std_math_acos = acos;
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
+    import std.math.trigonometry : std_math_acos = acos;
     assert(acos(complex(0.0)) == std_math_acos(0.0));
     assert(isClose(acos(complex(0.5L)), PI / 3));
 }
@@ -1083,7 +1090,8 @@ Complex!T atan(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, PI;
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
     assert(atan(complex(0.0)) == 0.0);
     assert(isClose(atan(sqrt(complex(3.0L))), PI / 3));
     assert(isClose(atan(sqrt(complex(3.0f))), float(PI) / 3));
@@ -1137,7 +1145,8 @@ Complex!T tanh(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, std_math_tanh = tanh;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : std_math_tanh = tanh;
     assert(tanh(complex(0.0)) == 0.0);
     assert(isClose(tanh(complex(1.0L)), std_math_tanh(1.0L)));
     assert(isClose(tanh(complex(1.0f)), std_math_tanh(1.0f)));
@@ -1158,7 +1167,8 @@ Complex!T asinh(T)(Complex!T z)  @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    import std.math : isClose, std_math_asinh = asinh;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : std_math_asinh = asinh;
     assert(asinh(complex(0.0)) == 0.0);
     assert(isClose(asinh(complex(1.0L)), std_math_asinh(1.0L)));
     assert(isClose(asinh(complex(1.0f)), std_math_asinh(1.0f)));
@@ -1173,7 +1183,8 @@ Complex!T acosh(T)(Complex!T z)  @safe pure nothrow @nogc
 ///
 @safe pure nothrow unittest
 {
-    import std.math : isClose, std_math_acosh = acosh;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : std_math_acosh = acosh;
     assert(acosh(complex(1.0)) == 0.0);
     assert(isClose(acosh(complex(3.0L)), std_math_acosh(3.0L)));
     assert(isClose(acosh(complex(3.0f)), std_math_acosh(3.0f)));
@@ -1199,7 +1210,8 @@ Complex!T atanh(T)(Complex!T z) @safe pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, std_math_atanh = atanh;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : std_math_atanh = atanh;
     assert(atanh(complex(0.0)) == 0.0);
     assert(isClose(atanh(complex(0.5L)), std_math_atanh(0.5L)));
     assert(isClose(atanh(complex(0.5f)), std_math_atanh(0.5f)));
@@ -1251,7 +1263,7 @@ Complex!real coshisinh(real y) @safe pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : cosh, sinh;
+    import std.math.trigonometry : cosh, sinh;
     assert(coshisinh(3.0L) == complex(cosh(3.0L), sinh(3.0L)));
 }
 
@@ -1315,7 +1327,7 @@ Complex!T sqrt(T)(Complex!T z)  @safe pure nothrow @nogc
 
 @safe pure nothrow unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto c1 = complex(1.0, 1.0);
     auto c2 = Complex!double(0.5, 2.0);
@@ -1447,7 +1459,8 @@ Complex!T exp(T)(Complex!T x) @trusted pure nothrow @nogc // TODO: @safe
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, PI;
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
 
     assert(exp(complex(0.0, 0.0)) == complex(1.0, 0.0));
 
@@ -1460,7 +1473,7 @@ Complex!T exp(T)(Complex!T x) @trusted pure nothrow @nogc // TODO: @safe
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isNaN, isInfinity;
+    import std.math.traits : isNaN, isInfinity;
 
     auto a = exp(complex(0.0, double.infinity));
     assert(a.re.isNaN && a.im.isNaN);
@@ -1496,7 +1509,8 @@ Complex!T exp(T)(Complex!T x) @trusted pure nothrow @nogc // TODO: @safe
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : PI, isClose;
+    import std.math.constants : PI;
+    import std.math.operations : isClose;
 
     auto a = exp(complex(0.0, -PI));
     assert(isClose(a, -1.0, 0.0, 1e-15));
@@ -1589,7 +1603,8 @@ Complex!T log(T)(Complex!T x) @safe pure nothrow @nogc
 @safe pure nothrow @nogc unittest
 {
     import core.math : sqrt;
-    import std.math : PI, isClose;
+    import std.math.constants : PI;
+    import std.math.operations : isClose;
 
     auto a = complex(2.0, 1.0);
     assert(log(conj(a)) == conj(log(a)));
@@ -1604,7 +1619,8 @@ Complex!T log(T)(Complex!T x) @safe pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isNaN, isInfinity, PI, PI_2, PI_4;
+    import std.math.traits : isNaN, isInfinity;
+    import std.math.constants : PI, PI_2, PI_4;
 
     auto a = log(complex(-0.0L, 0.0L));
     assert(a == complex(-real.infinity, PI));
@@ -1636,7 +1652,8 @@ Complex!T log(T)(Complex!T x) @safe pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : PI, isClose;
+    import std.math.constants : PI;
+    import std.math.operations : isClose;
 
     auto a = log(fromPolar(1.0, PI / 6.0));
     assert(isClose(a, complex(0.0L, 0.523598775598298873077L), 0.0, 1e-15));
@@ -1675,7 +1692,8 @@ Complex!T log10(T)(Complex!T x) @safe pure nothrow @nogc
 @safe pure nothrow @nogc unittest
 {
     import core.math : sqrt;
-    import std.math : LN10, PI, isClose;
+    import std.math.constants : LN10, PI;
+    import std.math.operations : isClose;
 
     auto a = complex(2.0, 1.0);
     assert(log10(a) == log(a) / log(complex(10.0)));
@@ -1690,7 +1708,8 @@ Complex!T log10(T)(Complex!T x) @safe pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : PI, isClose;
+    import std.math.constants : PI;
+    import std.math.operations : isClose;
 
     auto a = log10(fromPolar(1.0, PI / 6.0));
     assert(isClose(a, complex(0.0L, 0.227396058973640224580L), 0.0, 1e-15));
@@ -1741,7 +1760,7 @@ if (isIntegral!Int)
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto a = complex(1.0, 2.0);
     assert(pow(a, 2) == a * a);
@@ -1771,7 +1790,7 @@ Complex!T pow(T)(Complex!T x, const T n) @trusted pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
     assert(pow(complex(0.0), 2.0) == complex(0.0));
     assert(pow(complex(5.0), 2.0) == complex(25.0));
 
@@ -1791,7 +1810,9 @@ Complex!T pow(T)(Complex!T x, Complex!T y) @trusted pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose, exp, PI;
+    import std.math.operations : isClose;
+    import std.math.exponential : exp;
+    import std.math.constants : PI;
     auto a = complex(0.0);
     auto b = complex(2.0);
     assert(pow(a, b) == complex(0.0));
@@ -1813,7 +1834,7 @@ Complex!T pow(T)(const T x, Complex!T n) @trusted pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
     assert(pow(2.0, complex(0.0)) == complex(1.0));
     assert(pow(2.0, complex(5.0)) == complex(32.0));
 
@@ -1826,7 +1847,8 @@ Complex!T pow(T)(const T x, Complex!T n) @trusted pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.math : PI, isClose;
+    import std.math.constants : PI;
+    import std.math.operations : isClose;
 
     auto a = pow(complex(3.0, 4.0), 2);
     assert(isClose(a, complex(-7.0, 24.0)));

--- a/std/conv.d
+++ b/std/conv.d
@@ -1493,7 +1493,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 {
     static if (isFloatingPoint!S && isIntegral!T)
     {
-        import std.math : isNaN;
+        import std.math.traits : isNaN;
         if (value.isNaN) throw new ConvException("Input was NaN");
     }
 
@@ -1585,7 +1585,7 @@ if (!isImplicitlyConvertible!(S, T) &&
 @safe unittest
 {
     import std.exception;
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     double d = double.nan;
     float f = to!float(d);
@@ -2137,7 +2137,8 @@ template roundTo(Target)
     Target roundTo(Source)(Source value)
     {
         import core.math : abs = fabs;
-        import std.math : log2, trunc;
+        import std.math.exponential : log2;
+        import std.math.rounding : trunc;
 
         static assert(isFloatingPoint!Source);
         static assert(isIntegral!Target);
@@ -3390,9 +3391,9 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 ///
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
+    import std.math.traits : isNaN, isInfinity;
     import std.typecons : Flag, Yes, No;
-    import std.math : isNaN, isInfinity;
     auto str = "123.456";
     assert(parse!double(str).isClose(123.456));
     auto str2 = "123.456";
@@ -3423,7 +3424,8 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 @safe unittest
 {
     import std.exception;
-    import std.math : isNaN, fabs, isInfinity;
+    import std.math.traits : isNaN, isInfinity;
+    import std.math.algebraic : fabs;
 
     // Compare reals with given precision
     bool feq(in real rx, in real ry, in real precision = 0.000001L)
@@ -5049,7 +5051,7 @@ public import core.lifetime : emplace;
 {
     import std.array : array;
     import std.datetime : SysTime, UTC;
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     static struct A
     {

--- a/std/csv.d
+++ b/std/csv.d
@@ -556,7 +556,7 @@ The header from the input can always be accessed from the `header` field.
 // Test structure conversion interface with unicode.
 @safe pure unittest
 {
-    import std.math : abs;
+    import std.math.algebraic : abs;
 
     wstring str = "\U00010143Hello,65,63.63\nWorld,123,3673.562"w;
     struct Layout
@@ -604,7 +604,7 @@ The header from the input can always be accessed from the `header` field.
 // Test struct & header interface and same unicode
 @safe unittest
 {
-    import std.math : abs;
+    import std.math.algebraic : abs;
 
     string str = "a,b,c\nHello,65,63.63\n➊➋➂❹,123,3673.562";
     struct Layout

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -398,7 +398,7 @@ public:
     @safe unittest
     {
         import std.format : format;
-        import std.math : abs;
+        import std.math.algebraic : abs;
         import std.meta : AliasSeq;
         enum limit = convert!("seconds", "hnsecs")(2);
 

--- a/std/exception.d
+++ b/std/exception.d
@@ -956,7 +956,7 @@ T assumeWontThrow(T)(lazy T expr,
 ///
 @safe unittest
 {
-    import std.math : sqrt;
+    import std.math.algebraic : sqrt;
 
     // This function may throw.
     int squareRoot(int x)

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -28,7 +28,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
     import std.experimental.allocator.common : stateSize, forwardToMember,
         roundUpToMultipleOf, alignedAt, alignDownTo, roundUpToMultipleOf,
         hasStaticallyKnownAlignment;
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     import std.traits : hasMember;
     import std.typecons : Ternary;
 

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -357,7 +357,7 @@ struct AlignedBlockList(Allocator, ParentAllocator, ulong theAlignment = (1 << 2
     }
     else
     {
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
         static assert(isPowerOf2(alignment));
         mixin AlignedBlockListImpl!false;
     }
@@ -517,7 +517,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
     }
     else
     {
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
         static assert(isPowerOf2(alignment));
         mixin AlignedBlockListImpl!true;
     }

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -392,7 +392,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
         // If shared, this is protected by a lock inside 'alignedAllocate'
         private void[] alignedAllocateImpl(size_t n, uint a)
         {
-            import std.math : isPowerOf2;
+            import std.math.traits : isPowerOf2;
             assert(a.isPowerOf2);
             if (a <= alignment) return allocate(n);
 

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -188,7 +188,7 @@ struct Region(ParentAllocator = NullAllocator,
     */
     void[] alignedAllocate(size_t n, uint a) pure nothrow @trusted @nogc
     {
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
         assert(a.isPowerOf2);
 
         const rounded = goodAllocSize(n);
@@ -1184,7 +1184,7 @@ shared struct SharedRegion(ParentAllocator = NullAllocator,
     void[] alignedAllocate(size_t n, uint a) pure nothrow @trusted @nogc
     {
         import core.atomic : cas, atomicLoad;
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
 
         assert(a.isPowerOf2);
         if (n == 0) return null;

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -117,7 +117,7 @@ Returns `n` rounded up to a multiple of alignment, which must be a power of 2.
 @safe @nogc nothrow pure
 package size_t roundUpToAlignment(size_t n, uint alignment)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);
     immutable uint slack = cast(uint) n & (alignment - 1);
     const result = slack
@@ -142,7 +142,7 @@ Returns `n` rounded down to a multiple of alignment, which must be a power of 2.
 @safe @nogc nothrow pure
 package size_t roundDownToAlignment(size_t n, uint alignment)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);
     return n & ~size_t(alignment - 1);
 }
@@ -305,7 +305,7 @@ than or equal to the given pointer.
 @nogc nothrow pure
 package void* alignDownTo(void* ptr, uint alignment)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);
     return cast(void*) (cast(size_t) ptr & ~(alignment - 1UL));
 }
@@ -317,7 +317,7 @@ than or equal to the given pointer.
 @nogc nothrow pure
 package void* alignUpTo(void* ptr, uint alignment)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);
     immutable uint slack = cast(size_t) ptr & (alignment - 1U);
     return slack ? ptr + alignment - slack : ptr;
@@ -326,14 +326,14 @@ package void* alignUpTo(void* ptr, uint alignment)
 @safe @nogc nothrow pure
 package bool isGoodStaticAlignment(uint x)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     return x.isPowerOf2;
 }
 
 @safe @nogc nothrow pure
 package bool isGoodDynamicAlignment(uint x)
 {
-    import std.math : isPowerOf2;
+    import std.math.traits : isPowerOf2;
     return x.isPowerOf2 && x >= (void*).sizeof;
 }
 
@@ -484,7 +484,7 @@ version (StdUnittest)
     package void testAllocator(alias make)()
     {
         import std.conv : text;
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
         import std.stdio : writeln, stderr;
         import std.typecons : Ternary;
         alias A = typeof(make());
@@ -626,7 +626,7 @@ version (StdUnittest)
             || is (RCAllocInterface == RCISharedAllocator));
 
         import std.conv : text;
-        import std.math : isPowerOf2;
+        import std.math.traits : isPowerOf2;
         import std.stdio : writeln, stderr;
         import std.typecons : Ternary;
         scope(failure) stderr.writeln("testAllocatorObject failed for ",

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1276,7 +1276,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
         A* b = alloc.make!A(42);
         assert(b.x == 42);
         assert(b.y is null);
-        import std.math : isNaN;
+        import std.math.traits : isNaN;
         assert(b.z.isNaN);
 
         b = alloc.make!A(43, "44", 45);

--- a/std/experimental/checkedint.d
+++ b/std/experimental/checkedint.d
@@ -1916,7 +1916,7 @@ struct ProperCompare
     assert(opCmpProper(42, 42.0) == 0);
     assert(opCmpProper(41, 42.0) < 0);
     assert(opCmpProper(42, 41.0) > 0);
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
     assert(isNaN(opCmpProper(41, double.init)));
     assert(opCmpProper(42u, 42) == 0);
     assert(opCmpProper(42, 42u) == 0);

--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -31,7 +31,10 @@ if (is(T == float) || is(T == double)
 
         if (__ctfe)
         {
-            import std.math : abs, floor, isInfinity, isNaN, log2;
+            import std.math.algebraic : abs;
+            import std.math.rounding : floor;
+            import std.math.traits : isInfinity, isNaN;
+            import std.math.exponential : log2;
 
             auto val2 = val;
 
@@ -88,7 +91,7 @@ if (is(T == float) || is(T == double)
             ulong ival = () @trusted { return *cast(ulong*) &val; }();
         }
 
-        import std.math : log2;
+        import std.math.exponential : log2;
         enum log2_max_exp = cast(int) log2(T.max_exp);
 
         ulong mnt = ival & ((1L << (T.mant_dig - 1)) - 1);
@@ -363,7 +366,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 0.0L, f) == "0x0p+0");
     assert(printFloat(buf[], -0.0L, f) == "-0x0p+0");
 
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     assert(printFloat(buf[], nextUp(0.0f), f) == "0x0.000002p-126");
     assert(printFloat(buf[], float.epsilon, f) == "0x1p-23");
@@ -383,8 +386,8 @@ if (is(T == float) || is(T == double)
         assert(printFloat(buf[], real.max, f) == "0x1.fffffffffffffffep+16383");
     }
 
-    import std.math : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
-                      LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
+    import std.math.constants : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
+                                LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
 
     assert(printFloat(buf[], cast(float) E, f) == "0x1.5bf0a8p+1");
     assert(printFloat(buf[], cast(float) PI, f) == "0x1.921fb6p+1");
@@ -1378,7 +1381,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1.000000e+30");
     assert(printFloat(buf[], -1e30f, f) == "-1.000000e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "1.401298e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-1.401298e-45");
 }
@@ -1411,7 +1414,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "    1.0000000150e+30");
     assert(printFloat(buf[], -1e30f, f) == "   -1.0000000150e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "    1.4012984643e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "   -1.4012984643e-45");
 }
@@ -1445,7 +1448,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1.0000000150e+30    ");
     assert(printFloat(buf[], -1e30f, f) == "-1.0000000150e+30   ");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "1.4012984643e-45    ");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-1.4012984643e-45   ");
 }
@@ -1479,7 +1482,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "00001.0000000150e+30");
     assert(printFloat(buf[], -1e30f, f) == "-0001.0000000150e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "00001.4012984643e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-0001.4012984643e-45");
 }
@@ -1572,7 +1575,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e300, f) == "1.000000e+300");
     assert(printFloat(buf[], -1e300, f) == "-1.000000e+300");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0), f) == "4.940656e-324");
     assert(printFloat(buf[], nextDown(-0.0), f) == "-4.940656e-324");
 }
@@ -1594,7 +1597,7 @@ printFloat_done:
     auto f = FormatSpec!dchar("");
     f.spec = 'e';
 
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     double eps = nextUp(0.0);
     f.precision = 1000;
@@ -1630,8 +1633,8 @@ printFloat_done:
     f.spec = 'e';
     f.precision = 15;
 
-    import std.math : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
-                      LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
+    import std.math.constants : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
+                                LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
 
     assert(printFloat(buf[], cast(double) E, f) == "2.718281828459045e+00");
     assert(printFloat(buf[], cast(double) PI, f) == "3.141592653589793e+00");
@@ -1706,7 +1709,7 @@ printFloat_done:
             assert(printFloat(buf[], -1e4000L, f) == "-1.000000e+4000");
         }
 
-        import std.math : nextUp, nextDown;
+        import std.math.operations : nextUp, nextDown;
         assert(printFloat(buf[], nextUp(0.0L), f) == "3.645200e-4951");
         assert(printFloat(buf[], nextDown(-0.0L), f) == "-3.645200e-4951");
     }
@@ -1715,7 +1718,8 @@ printFloat_done:
 @safe unittest
 {
     import std.exception : assertCTFEable;
-    import std.math : log2, nextDown;
+    import std.math.exponential : log2;
+    import std.math.operations : nextDown;
 
     assertCTFEable!(
     {
@@ -2263,7 +2267,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1000000015047466219876688855040.000000");
     assert(printFloat(buf[], -1e30f, f) == "-1000000015047466219876688855040.000000");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "0.000000");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-0.000000");
 }
@@ -2296,7 +2300,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1000000015047466219876688855040.0000000000");
     assert(printFloat(buf[], -1e30f, f) == "-1000000015047466219876688855040.0000000000");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "        0.0000000000");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "       -0.0000000000");
 }
@@ -2330,7 +2334,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1000000015047466219876688855040.0000000000");
     assert(printFloat(buf[], -1e30f, f) == "-1000000015047466219876688855040.0000000000");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "0.0000000000        ");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-0.0000000000       ");
 }
@@ -2364,7 +2368,7 @@ printFloat_done:
     assert(printFloat(buf[], 1e30f, f) == "1000000015047466219876688855040.0000000000");
     assert(printFloat(buf[], -1e30f, f) == "-1000000015047466219876688855040.0000000000");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "000000000.0000000000");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-00000000.0000000000");
 }
@@ -2467,7 +2471,7 @@ printFloat_done:
           ~"895323497079994508111903896764088007465274278014249457925878882005684283811566947219638686545940054"
           ~"0160.000000");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0), f) == "0.000000");
     assert(printFloat(buf[], nextDown(-0.0), f) == "-0.000000");
 }
@@ -2505,7 +2509,7 @@ printFloat_done:
             assert(result2.length == 4008 && result2[0 .. 40] == "-999999999999999999996546387309962378493");
         }
 
-        import std.math : nextUp, nextDown;
+        import std.math.operations : nextUp, nextDown;
         assert(printFloat(buf[], nextUp(0.0L), f) == "0.000000");
         assert(printFloat(buf[], nextDown(-0.0L), f) == "-0.000000");
     }
@@ -2514,7 +2518,8 @@ printFloat_done:
 @safe unittest
 {
     import std.exception : assertCTFEable;
-    import std.math : log2, nextDown;
+    import std.math.exponential : log2;
+    import std.math.operations : nextDown;
 
     assertCTFEable!(
     {
@@ -2562,7 +2567,7 @@ printFloat_done:
     auto f = FormatSpec!dchar("");
     f.spec = 'f';
 
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     double eps = nextUp(0.0);
     f.precision = 1000;
@@ -2603,8 +2608,8 @@ printFloat_done:
     f.spec = 'f';
     f.precision = 15;
 
-    import std.math : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
-                      LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
+    import std.math.constants : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
+                                LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
 
     assert(printFloat(buf[], cast(double) E, f) == "2.718281828459045");
     assert(printFloat(buf[], cast(double) PI, f) == "3.141592653589793");
@@ -2632,7 +2637,7 @@ printFloat_done:
     f.precision = 1;
     assert(printFloat(buf[], 9.99, f) == "10.0");
 
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     float eps = nextUp(0.0f);
 
@@ -2697,7 +2702,7 @@ if (is(T == float) || is(T == double)
     // to the way, D handles floating point numbers. On different
     // computers with different reals the results may vary in this gap.
 
-    import std.math : nextDown, nextUp;
+    import std.math.operations : nextDown, nextUp;
 
     char[256] buf;
     auto f = FormatSpec!dchar("");
@@ -2772,7 +2777,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e30f, f) == "1e+30");
     assert(printFloat(buf[], -1e30f, f) == "-1e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "1.4013e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-1.4013e-45");
 }
@@ -2805,7 +2810,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e30f, f) == "     1.000000015e+30");
     assert(printFloat(buf[], -1e30f, f) == "    -1.000000015e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "     1.401298464e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "    -1.401298464e-45");
 }
@@ -2840,7 +2845,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e30f, f) == "1.000000015e+30     ");
     assert(printFloat(buf[], -1e30f, f) == "-1.000000015e+30    ");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "1.401298464e-45     ");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-1.401298464e-45    ");
 }
@@ -2875,7 +2880,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e30f, f) == "000001.000000015e+30");
     assert(printFloat(buf[], -1e30f, f) == "-00001.000000015e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "000001.401298464e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-00001.401298464e-45");
 }
@@ -2909,7 +2914,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e30f, f) == "1.000000015e+30");
     assert(printFloat(buf[], -1e30f, f) == "-1.000000015e+30");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0f), f) == "1.401298464e-45");
     assert(printFloat(buf[], nextDown(-0.0f), f) == "-1.401298464e-45");
 }
@@ -3005,7 +3010,7 @@ if (is(T == float) || is(T == double)
     assert(printFloat(buf[], 1e300, f) == "1e+300");
     assert(printFloat(buf[], -1e300, f) == "-1e+300");
 
-    import std.math : nextUp, nextDown;
+    import std.math.operations : nextUp, nextDown;
     assert(printFloat(buf[], nextUp(0.0), f) == "4.94066e-324");
     assert(printFloat(buf[], nextDown(-0.0), f) == "-4.94066e-324");
 }
@@ -3028,7 +3033,7 @@ if (is(T == float) || is(T == double)
     auto f = FormatSpec!dchar("");
     f.spec = 'g';
 
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     double eps = nextUp(0.0);
     f.precision = 1000;
@@ -3065,8 +3070,8 @@ if (is(T == float) || is(T == double)
     f.spec = 'g';
     f.precision = 15;
 
-    import std.math : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
-                      LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
+    import std.math.constants : E, PI, PI_2, PI_4, M_1_PI, M_2_PI, M_2_SQRTPI,
+                                LN10, LN2, LOG2, LOG2E, LOG2T, LOG10E, SQRT2, SQRT1_2;
 
     assert(printFloat(buf[], cast(double) E, f) == "2.71828182845905");
     assert(printFloat(buf[], cast(double) PI, f) == "3.14159265358979");
@@ -3127,7 +3132,7 @@ if (is(T == float) || is(T == double)
             assert(printFloat(buf[], -1e4000L, f) == "-1e+4000");
         }
 
-        import std.math : nextUp, nextDown;
+        import std.math.operations : nextUp, nextDown;
         assert(printFloat(buf[], nextUp(0.0L), f) == "3.6452e-4951");
         assert(printFloat(buf[], nextDown(-0.0L), f) == "-3.6452e-4951");
     }
@@ -3136,7 +3141,8 @@ if (is(T == float) || is(T == double)
 @safe unittest
 {
     import std.exception : assertCTFEable;
-    import std.math : log2, nextDown;
+    import std.math.exponential : log2;
+    import std.math.operations : nextDown;
 
     assertCTFEable!(
     {
@@ -3296,7 +3302,8 @@ private auto printFloat0(bool g, Char)(return char[] buf, FormatSpec!Char f, str
     assert(printFloat(buf[], double.infinity, f) == "inf");
     assert(printFloat(buf[], -0.0, f) == "-0x0p+0");
 
-    import std.math : nextUp, E;
+    import std.math.operations : nextUp;
+    import std.math.constants : E;
 
     assert(printFloat(buf[], nextUp(0.0f), f) == "0x0.000002p-126");
     assert(printFloat(buf[], cast(float) E, f) == "0x1.5bf0a8p+1");
@@ -3370,7 +3377,7 @@ version (printFloatTest)
 
     @system unittest
     {
-        import std.math : FloatingPointControl;
+        import std.math.hardware : FloatingPointControl;
         import std.random : uniform, Random;
         import std.stdio : writefln, stderr;
         import std.datetime : MonoTime;
@@ -3495,7 +3502,7 @@ version (printFloatTest)
 
     @system unittest
     {
-        import std.math : FloatingPointControl;
+        import std.math.hardware : FloatingPointControl;
         import std.random : uniform, Random;
         import std.stdio : writefln, stderr;
         import std.datetime : MonoTime;

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -184,7 +184,7 @@ if (is(IntegralTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     enforceFmt(base > 0,
         "incompatible format character for integral argument: %" ~ f.spec);
 
-    import std.math : abs;
+    import std.math.algebraic : abs;
 
     bool negative = false;
     ulong arg = val;
@@ -398,7 +398,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     import std.algorithm.searching : find;
     import std.ascii : isUpper;
     import std.format : enforceFmt;
-    import std.math : isInfinity, isNaN, signbit;
+    import std.math.traits : isInfinity, isNaN, signbit;
     import std.range.primitives : put;
     import std.string : indexOf, indexOfAny;
 
@@ -467,7 +467,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
                || (is(T == real) && (T.mant_dig == double.mant_dig || T.mant_dig == 64)))
     {
         import std.format.internal.floats : RoundingMode, printFloat;
-        import std.math; // cannot be selective, because FloatingPointControl might not be defined
+        import std.math.hardware; // cannot be selective, because FloatingPointControl might not be defined
 
         auto mode = RoundingMode.toNearestTiesToEven;
 
@@ -747,7 +747,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 
 @safe unittest
 {
-    import std.math; // cannot be selective, because FloatingPointControl might not be defined
+    import std.math.hardware; // cannot be selective, because FloatingPointControl might not be defined
 
     // std.math's FloatingPointControl isn't available on all target platforms
     static if (is(FloatingPointControl))
@@ -819,7 +819,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 // https://issues.dlang.org/show_bug.cgi?id=20396
 @safe unittest
 {
-    import std.math : nextUp;
+    import std.math.operations : nextUp;
 
     assert(format!"%a"(nextUp(0.0f)) == "0x0.000002p-126");
     assert(format!"%a"(nextUp(0.0)) == "0x0.0000000000001p-1022");
@@ -835,7 +835,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 
 @safe unittest
 {
-    import std.math; // cannot be selective, because FloatingPointControl might not be defined
+    import std.math.hardware; // cannot be selective, because FloatingPointControl might not be defined
 
     // std.math's FloatingPointControl isn't available on all target platforms
     static if (is(FloatingPointControl))

--- a/std/format/read.d
+++ b/std/format/read.d
@@ -100,7 +100,7 @@ module std.format.read;
 @safe pure unittest
 {
     import std.format.spec : singleSpec;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     // natural notation
     auto str = "123.456";
@@ -363,7 +363,8 @@ if (isSomeString!(typeof(fmt)))
 
 @safe unittest
 {
-    import std.math : isClose, isNaN;
+    import std.math.operations : isClose;
+    import std.math.traits : isNaN;
     import std.range.primitives : empty;
 
     string s = " 1.2 3.4 ";
@@ -402,7 +403,8 @@ if (isSomeString!(typeof(fmt)))
 // for backwards compatibility
 @system pure unittest
 {
-    import std.math : isClose, isNaN;
+    import std.math.operations : isClose;
+    import std.math.traits : isNaN;
     import std.range.primitives : empty;
 
     string s = " 1.2 3.4 ";

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1185,7 +1185,7 @@ private void setConfig(ref configuration cfg, config option) @safe pure nothrow 
 @safe unittest
 {
     import std.conv;
-    import std.math;
+    import std.math.operations : isClose;
 
     uint paranoid = 2;
     string[] args = ["program.name", "--paranoid", "--paranoid", "--paranoid"];

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -340,7 +340,7 @@ if (is(T == uint))
 pure struct Cmp(T)
 if (is(T == double))
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     static auto iota(size_t low = 1, size_t high = 11)
     {

--- a/std/json.d
+++ b/std/json.d
@@ -1650,7 +1650,7 @@ if (isOutputRange!(Out,char))
                 break;
 
             case JSONType.float_:
-                import std.math : isNaN, isInfinity;
+                import std.math.traits : isNaN, isInfinity;
 
                 auto val = value.store.floating;
 
@@ -1744,7 +1744,7 @@ if (isOutputRange!(Out,char))
     // Floating points numbers are rounded to the nearest integer and thus get
     // incorrectly parsed
 
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     string s = "{\"rating\": 3.0 }";
     JSONValue j = parseJSON(s);
@@ -1775,7 +1775,7 @@ if (isOutputRange!(Out,char))
     // Result from toString is not checked here, because this
     // might differ (%e-like or %f-like output) depending
     // on OS and compiler optimization.
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     // test positive extreme values
     JSONValue j;
@@ -2113,7 +2113,7 @@ EOF";
 @safe unittest
 {
     import std.exception : assertThrown;
-    import std.math : isNaN, isInfinity;
+    import std.math.traits : isNaN, isInfinity;
 
     // expected representations of NaN and Inf
     enum {
@@ -2187,7 +2187,7 @@ pure nothrow @safe unittest
 
     static bool test(const double num0)
     {
-        import std.math : feqrel;
+        import std.math.operations : feqrel;
         const json0 = JSONValue(num0);
         const num1 = to!double(toJSON(json0));
         static if (realInDoublePrecision)

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -125,7 +125,7 @@ if (((flags & flags.signed) + precision + exponentWidth) % 8 == 0 && precision +
 ///
 @safe unittest
 {
-    import std.math : sin, cos;
+    import std.math.trigonometry : sin, cos;
 
     // Define a 16-bit floating point values
     CustomFloat!16                                x;     // Using the number of bits
@@ -863,7 +863,7 @@ public:
 
 @safe unittest
 {
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     alias cf = CustomFloat!(5, 2);
 
@@ -988,7 +988,7 @@ if (isFloatingPoint!F)
 ///
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     // Average numbers in an array
     double avg(in double[] a)
@@ -1033,7 +1033,8 @@ template secantMethod(alias fun)
 ///
 @safe unittest
 {
-    import std.math : isClose, cos;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : cos;
 
     float f(float x)
     {
@@ -1876,7 +1877,7 @@ do
 ///
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto ret = findLocalMin((double x) => (x-4)^^2, -1e7, 1e7);
     assert(ret.x.isClose(4.0));
@@ -2241,7 +2242,7 @@ if (isInputRange!Range && isFloatingPoint!(ElementType!Range))
 ///
 @safe unittest
 {
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     assert(sumOfLog2s(new double[0]) == 0);
     assert(sumOfLog2s([0.0L]) == -real.infinity);
@@ -2340,7 +2341,7 @@ if (isInputRange!(Range1) && isInputRange!(Range2))
 ///
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     double[] p = [ 0.0, 0, 0, 1 ];
     assert(kullbackLeiblerDivergence(p, p) == 0);
@@ -2424,7 +2425,7 @@ if (isInputRange!Range1 && isInputRange!Range2 &&
 ///
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     double[] p = [ 0.0, 0, 0, 1 ];
     assert(jensenShannonDivergence(p, p) == 0);
@@ -2614,7 +2615,8 @@ if (isRandomAccessRange!(R1) && hasLength!(R1) &&
 ///
 @system unittest
 {
-    import std.math : isClose, sqrt;
+    import std.math.operations : isClose;
+    import std.math.algebraic : sqrt;
 
     string[] s = ["Hello", "brave", "new", "world"];
     string[] t = ["Hello", "new", "world"];

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -53,7 +53,7 @@ else version (WatchOS)
 @system unittest
 {
     import std.algorithm.iteration : map;
-    import std.math : isClose;
+    import std.math.operations : isClose;
     import std.parallelism : taskPool;
     import std.range : iota;
 
@@ -4150,7 +4150,9 @@ version (StdUnittest)
     import std.array : split;
     import std.conv : text;
     import std.exception : assertThrown;
-    import std.math : isClose, sqrt, log, abs;
+    import std.math.operations : isClose;
+    import std.math.algebraic : sqrt, abs;
+    import std.math.exponential : log;
     import std.range : indexed, iota, join;
     import std.typecons : Tuple, tuple;
     import std.stdio;
@@ -4648,7 +4650,9 @@ version (parallelismStressTest)
         import std.stdio : stderr;
         import std.range : iota;
         import std.algorithm.iteration : filter, reduce;
-        import std.math : sqrt, isClose, isNaN;
+        import std.math.algebraic : sqrt;
+        import std.math.operations : isClose;
+        import std.math.traits : isNaN;
         import std.conv : text;
 
         foreach (attempt; 0 .. 10)

--- a/std/random.d
+++ b/std/random.d
@@ -2104,7 +2104,7 @@ if (isFloatingPoint!(CommonType!(T1, T2)) && isUniformRNG!UniformRandomNumberGen
     alias NumberType = Unqual!(CommonType!(T1, T2));
     static if (boundaries[0] == '(')
     {
-        import std.math : nextafter;
+        import std.math.operations : nextafter;
         NumberType _a = nextafter(cast(NumberType) a, NumberType.infinity);
     }
     else
@@ -2113,7 +2113,7 @@ if (isFloatingPoint!(CommonType!(T1, T2)) && isUniformRNG!UniformRandomNumberGen
     }
     static if (boundaries[1] == ')')
     {
-        import std.math : nextafter;
+        import std.math.operations : nextafter;
         NumberType _b = nextafter(cast(NumberType) b, -NumberType.infinity);
     }
     else
@@ -2639,7 +2639,7 @@ do
 ///
 @safe @nogc unittest
 {
-    import std.math : feqrel;
+    import std.math.operations : feqrel;
 
     auto rnd = MinstdRand0(42);
 
@@ -2712,7 +2712,7 @@ if (isFloatingPoint!F)
 @safe unittest
 {
     import std.algorithm.iteration : reduce;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto a = uniformDistribution(5);
     assert(a.length == 5);
@@ -3768,7 +3768,8 @@ Variable names are chosen to match those in Vitter's paper.
 */
     private size_t skipD()
     {
-        import std.math : isNaN, trunc;
+        import std.math.traits : isNaN;
+        import std.math.rounding : trunc;
         // Confirm that the check in Step D1 is valid and we
         // haven't been sent here by mistake
         assert((_alphaInverse * _toSelect) <= _available);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6068,7 +6068,9 @@ pure @safe nothrow @nogc unittest
 /// Fibonacci numbers, using function in explicit form:
 @safe nothrow @nogc unittest
 {
-    import std.math : pow, round, sqrt;
+    import std.math.exponential : pow;
+    import std.math.rounding : round;
+    import std.math.algebraic : sqrt;
     static ulong computeFib(S)(S state, size_t n)
     {
         // Binet's formula
@@ -6500,7 +6502,7 @@ do
 pure @safe unittest
 {
     import std.algorithm.comparison : equal;
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     auto r = iota(0, 10, 1);
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
@@ -6562,7 +6564,7 @@ pure @safe unittest
 {
     import std.algorithm.comparison : equal;
     import std.algorithm.searching : count;
-    import std.math : isClose, nextUp, nextDown;
+    import std.math.operations : isClose, nextUp, nextDown;
     import std.meta : AliasSeq;
 
     static assert(is(ElementType!(typeof(iota(0f))) == float));

--- a/std/regex/internal/tests2.d
+++ b/std/regex/internal/tests2.d
@@ -555,7 +555,7 @@ version (none) // TODO: revist once we have proper benchmark framework
 @safe unittest
 {
     import std.datetime.stopwatch : StopWatch, AutoStart;
-    import std.math : abs;
+    import std.math.algebraic : abs;
     import std.conv : to;
     enum re1 = ctRegex!`[0-9][0-9]`;
     immutable static re2 = ctRegex!`[0-9][0-9]`;

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -20,7 +20,7 @@ module std.sumtype;
 version (D_BetterC) {} else
 @safe unittest
 {
-    import std.math : isClose;
+    import std.math.operations : isClose;
 
     struct Fahrenheit { double degrees; }
     struct Celsius { double degrees; }
@@ -87,7 +87,10 @@ version (D_BetterC) {} else
 version (D_BetterC) {} else
 @safe unittest
 {
-    import std.math : isClose, cos, PI, sqrt;
+    import std.math.operations : isClose;
+    import std.math.trigonometry : cos;
+    import std.math.constants : PI;
+    import std.math.algebraic : sqrt;
 
     struct Rectangular { double x, y; }
     struct Polar { double r, theta; }
@@ -2096,7 +2099,7 @@ version (unittest)
     }
     else
     {
-        import std.math : isClose;
+        import std.math.operations : isClose;
     }
 }
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -818,7 +818,7 @@ if (distinctFieldNames!(Specs))
             {
                 if (field[i] != rhs.field[i])
                 {
-                    import std.math : isNaN;
+                    import std.math.traits : isNaN;
                     static if (isFloatingPoint!(Types[i]))
                     {
                         if (isNaN(field[i]))
@@ -850,7 +850,7 @@ if (distinctFieldNames!(Specs))
             {
                 if (field[i] != rhs.field[i])
                 {
-                    import std.math : isNaN;
+                    import std.math.traits : isNaN;
                     static if (isFloatingPoint!(Types[i]))
                     {
                         if (isNaN(field[i]))
@@ -4451,7 +4451,7 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
 ///
 @system unittest
 {
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     static abstract class C
     {
@@ -4474,7 +4474,7 @@ alias BlackHole(Base) = AutoImplement!(Base, generateEmptyFunction, isAbstractFu
 
 @system unittest
 {
-    import std.math : isNaN;
+    import std.math.traits : isNaN;
 
     // return default
     {
@@ -7142,7 +7142,7 @@ mixin template Proxy(alias a)
  */
 @safe unittest
 {
-    import std.math;
+    import std.math.traits : isInfinity;
 
     float f = 1.0;
     assert(!f.isInfinity);

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -1124,7 +1124,7 @@ private:
 
 size_t spaceFor(size_t _bits)(size_t new_len) @safe pure nothrow @nogc
 {
-    import std.math : nextPow2;
+    import std.math.algebraic : nextPow2;
     enum bits = _bits == 1 ? 1 : nextPow2(_bits - 1);// see PackedArrayView
     static if (bits > 8*size_t.sizeof)
     {
@@ -1149,7 +1149,7 @@ template PackedArrayView(T)
 if ((is(T dummy == BitPacked!(U, sz), U, size_t sz)
     && isBitPackableType!U) || isBitPackableType!T)
 {
-    import std.math : nextPow2;
+    import std.math.algebraic : nextPow2;
     private enum bits = bitSizeOf!T;
     alias PackedArrayView = PackedArrayViewImpl!(T, bits > 1 ? nextPow2(bits - 1) : 1);
 }
@@ -1159,7 +1159,7 @@ template PackedPtr(T)
 if ((is(T dummy == BitPacked!(U, sz), U, size_t sz)
     && isBitPackableType!U) || isBitPackableType!T)
 {
-    import std.math : nextPow2;
+    import std.math.algebraic : nextPow2;
     private enum bits = bitSizeOf!T;
     alias PackedPtr = PackedPtrImpl!(T, bits > 1 ? nextPow2(bits - 1) : 1);
 }
@@ -1652,7 +1652,7 @@ template sharMethod(alias uniLowerBound)
         if (is(T : ElementType!Range))
     {
         import std.functional : binaryFun;
-        import std.math : nextPow2, truncPow2;
+        import std.math.algebraic : nextPow2, truncPow2;
         alias pred = binaryFun!_pred;
         if (range.length == 0)
             return 0;


### PR DESCRIPTION
Like #7985 for all other modules of Phobos.

Additionally I replaced two occurrences of `approxEqual` with `isClose`.