### PR TITLE
std.format: make reflection test work for floating point values

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1638,7 +1638,8 @@ private void formatReflectTest(T)(ref T val, string fmt, string formatted, strin
 {
     import core.exception : AssertError;
     import std.array : appender;
-    import std.traits : isAssociativeArray;
+    import std.math.operations : isClose;
+    import std.traits : isAssociativeArray, FloatingPointTypeOf;
 
     auto w = appender!string();
     formattedWrite(w, fmt, val);
@@ -1672,7 +1673,10 @@ private void formatReflectTest(T)(ref T val, string fmt, string formatted, strin
             return;
         }
 
-    enforce!AssertError(val == val2, input, fn, ln);
+    static if (is(FloatingPointTypeOf!T))
+        enforce!AssertError(isClose(val, val2), input, fn, ln);
+    else
+        enforce!AssertError(val == val2, input, fn, ln);
 }
 
 version (StdUnittest)
@@ -1680,7 +1684,8 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
 {
     import core.exception : AssertError;
     import std.array : appender;
-    import std.traits : isAssociativeArray;
+    import std.math.operations : isClose;
+    import std.traits : isAssociativeArray, FloatingPointTypeOf;
 
     auto w = appender!string();
     formattedWrite(w, fmt, val);
@@ -1719,7 +1724,10 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
             return;
         }
 
-    enforce!AssertError(val == val2, input, fn, ln);
+    static if (is(FloatingPointTypeOf!T))
+        enforce!AssertError(isClose(val, val2), input, fn, ln);
+    else
+        enforce!AssertError(val == val2, input, fn, ln);
 }
 
 @system unittest
@@ -1806,7 +1814,7 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
     {
         booleanTest();
         integerTest();
-        if (!__ctfe) floatingTest();    // snprintf
+        floatingTest();
         charTest();
         strTest();
         daTest();
@@ -1815,4 +1823,3 @@ private void formatReflectTest(T)(ref T val, string fmt, string[] formatted, str
         return true;
     });
 }
-


### PR DESCRIPTION
`snprintf` wasn't the only reason, why this test didn't work...