### PR TITLE
std.format: Remove arrayPtrDiff.

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1623,16 +1623,6 @@ if (isSomeString!(typeof(fmt)))
     assert(u == GC.stats().usedSize);
 }
 
-/*
- * The .ptr is unsafe because it could be dereferenced and the length of the array may be 0.
- * Returns:
- *      the difference between the starts of the arrays
- */
-package ptrdiff_t arrayPtrDiff(T)(const T[] array1, const T[] array2) @trusted pure nothrow @nogc
-{
-    return array1.ptr - array2.ptr;
-}
-
 version (StdUnittest)
 private void formatReflectTest(T)(ref T val, string fmt, string formatted, string fn = __FILE__, size_t ln = __LINE__)
 {

--- a/std/format/spec.d
+++ b/std/format/spec.d
@@ -273,7 +273,7 @@ if (is(Unqual!Char == Char))
 
     private void fillUp() scope
     {
-        import std.format : arrayPtrDiff, enforceFmt, FormatException;
+        import std.format : enforceFmt, FormatException;
 
         // Reset content
         if (__ctfe)
@@ -386,7 +386,7 @@ if (is(Unqual!Char == Char))
                 const widthOrArgIndex = parse!uint(tmp);
                 enforceFmt(tmp.length,
                     text("Incorrect format specifier %", trailing[i .. $]));
-                i = arrayPtrDiff(tmp, trailing);
+                i = trailing.length - tmp.length;
                 if (tmp.startsWith('$'))
                 {
                     // index of the form %n$
@@ -406,7 +406,7 @@ if (is(Unqual!Char == Char))
                     {
                         indexEnd = parse!(typeof(indexEnd))(tmp);
                     }
-                    i = arrayPtrDiff(tmp, trailing);
+                    i = trailing.length - tmp.length;
                     enforceFmt(trailing[i++] == '$',
                         "$ expected");
                 }
@@ -431,7 +431,7 @@ if (is(Unqual!Char == Char))
                 {
                     auto tmp = trailing[i .. $];
                     separators = parse!int(tmp);
-                    i = arrayPtrDiff(tmp, trailing);
+                    i = trailing.length - tmp.length;
                 }
                 else
                 {
@@ -472,13 +472,13 @@ if (is(Unqual!Char == Char))
                     precision = 0;
                     auto tmp = trailing[i .. $];
                     parse!int(tmp); // skip digits
-                    i = arrayPtrDiff(tmp, trailing);
+                    i = trailing.length - tmp.length;
                 }
                 else if (isDigit(trailing[i]))
                 {
                     auto tmp = trailing[i .. $];
                     precision = parse!int(tmp);
-                    i = arrayPtrDiff(tmp, trailing);
+                    i = trailing.length - tmp.length;
                 }
                 else
                 {


### PR DESCRIPTION
`arrayPtrDiff` looks a little bit C'ish... Might have had it's purpose at some time, but is not needed anymore...