### PR TITLE
Fix Issue 21846 - std.format: provided format string for toString does not work with grouping

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1317,6 +1317,23 @@ if (isSomeChar!Char)
     assert(d == "^-NAN         $", "\ngot:'"~ d ~ "'\nexp:'^-NAN         $'");
 }
 
+@system unittest
+{
+    struct S
+    {
+        int a;
+
+        void toString(void delegate(const(char)[]) sink, string fmt)
+        {
+            auto spec = singleSpec(fmt);
+            sink.formatValue(a, spec);
+        }
+    }
+
+    S s = S(1);
+    assert(format!"%5,3d"(s) == "    1");
+}
+
 /// ditto
 typeof(fmt) format(alias fmt, Args...)(Args args)
 if (isSomeString!(typeof(fmt)))

--- a/std/format/spec.d
+++ b/std/format/spec.d
@@ -584,7 +584,6 @@ if (is(Unqual!Char == Char))
         if (flSpace) put(w, ' ');
         if (flPlus) put(w, '+');
         if (flHash) put(w, '#');
-        if (flSeparator) put(w, ',');
         if (width != 0)
             formatValue(w, width, f);
         if (precision != FormatSpec!Char.UNSPECIFIED)
@@ -592,6 +591,9 @@ if (is(Unqual!Char == Char))
             put(w, '.');
             formatValue(w, precision, f);
         }
+        if (flSeparator) put(w, ',');
+        if (separators != FormatSpec!Char.UNSPECIFIED)
+            formatValue(w, separators, f);
         put(w, spec);
         return w.data;
     }


### PR DESCRIPTION
The `separator` needs to be after `width`. I don't know though, if it should be before or after `precision`. The current implementation allows both.