### PR TITLE
std.format: Make formatting 0.0 100% @nogc.

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -925,6 +925,12 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(format("%a", r) == "0x1p-20");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21836
+@safe pure unittest
+{
+    assert(format!"%-5,1g"(0.0) == "0    ");
+}
+
 /*
     Formatting a `creal` is deprecated but still kept around for a while.
  */


### PR DESCRIPTION
Followup on #7971; see there for the roadmap.

The calls to `printFloat0` are replaced by a calls to `writeAligned` which does the same more general and without allocating.

`writeAligned` needed another parameter: fractional digits are yet another stretchable element due to trailing zeros. The interpretation of `precision` for floating point values differs from the interpretation of it for integral values. Therefore I added an `enum PrecisionType` to distinguish the various meanings of `precision`. Eventually it will replace the boolean parameter `integer_precision` - for the time being I added an additional wrapper.