### PR TITLE
Fix Issue 21853 - std.format: formatting real.max in CTFE fails

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -918,6 +918,15 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21853
+@safe pure unittest
+{
+    static if (real.mant_dig == 64) // 80 bit reals
+    {
+        static assert(format!"%e"(real.max) == "1.189731e+4932");
+    }
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=20536
 @safe pure unittest
 {


### PR DESCRIPTION
I introduced this bug in #7862: The reason is, that `log2` rounds up (due to floating points not precise enough) when the result is very close to an integer and thus the appended `floor` won't work anymore.

I fixed this by checking for `max_exp - 1` explicitly and for all others by detecting, that the first (implied) bit of the mantissa is 0 and not 1 as it should be. In this case the result is corrected accordingly.

PS: I would really appreciate if we could have a `cast(ulong[2])` for reals in CTFE, similar to the available casts for `float` and `double`. This would safe us from such trouble.