### PR TITLE
std.format: Make formatting %e (and partly %g) 100% @nogc.

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -940,6 +940,12 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(format("%a", r) == "0x1p-20");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21840
+@safe pure unittest
+{
+    assert(format!"% 0,e"(0.0) == " 0.000000e+00");
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=21836
 @safe pure unittest
 {

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -946,6 +946,12 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(format!"% 0,e"(0.0) == " 0.000000e+00");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21841
+@safe pure unittest
+{
+    assert(format!"%0.0,e"(0.0) == "0e+00");
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=21836
 @safe pure unittest
 {


### PR DESCRIPTION
Followup on #7971 and #8000. See there for more details. See also #8005.