### PR TITLE
Revert change to FieldNameTuple for non-interface types

### DIFF
--- a/changelog/fieldnametuple_interface.dd
+++ b/changelog/fieldnametuple_interface.dd
@@ -1,0 +1,8 @@
+`FieldnameTuple` now returns an empty tuple for interfaces
+
+Previously `FieldNameTuple` returned `AliasSeq!""` for interfaces as done for
+non-aggregate types like `int`, `char*`, ... . This behaviour was surprising
+because an instance of that interface *may* have members that just are not
+known at compile time.
+
+`FieldNameTuple` will now return an empty `AliasSeq!()` for interfaces.

--- a/std/traits.d
+++ b/std/traits.d
@@ -2798,7 +2798,7 @@ private enum NameOf(alias T) = T.stringof;
  * hidden fields like the virtual function table pointer or a context pointer
  * for nested types.
  * Inherited fields (for classes) are not included.
- * If `T` isn't a struct, class, or union, an
+ * If `T` isn't a struct, class, interface or union, an
  * expression tuple with an empty string is returned.
  */
 template FieldNameTuple(T)
@@ -2806,10 +2806,10 @@ template FieldNameTuple(T)
     import std.meta : staticMap;
     static if (is(T == struct) || is(T == union))
         alias FieldNameTuple = staticMap!(NameOf, T.tupleof[0 .. $ - isNested!T]);
-    else static if (is(T == class))
+    else static if (is(T == class) || is(T == interface))
         alias FieldNameTuple = staticMap!(NameOf, T.tupleof);
     else
-        alias FieldNameTuple = AliasSeq!();
+        alias FieldNameTuple = AliasSeq!"";
 }
 
 ///
@@ -2818,12 +2818,12 @@ template FieldNameTuple(T)
     import std.meta : AliasSeq;
     struct S { int x; float y; }
     static assert(FieldNameTuple!S == AliasSeq!("x", "y"));
-    static assert(FieldNameTuple!int == AliasSeq!());
+    static assert(FieldNameTuple!int == AliasSeq!"");
 }
 
 @safe unittest
 {
-    static assert(FieldNameTuple!int == AliasSeq!());
+    static assert(FieldNameTuple!int == AliasSeq!"");
 
     static struct StaticStruct1 { }
     static assert(is(FieldNameTuple!StaticStruct1 == AliasSeq!()));


### PR DESCRIPTION
Partially reverts the changes made in #8011 for non-interface types to keep `AliasSeq!""` as a special error code. 

CC @RazvanN7 @Geod24 