### PR TITLE
std.format: Add formatting integers with %e, %f, %g and %a.

### DIFF
--- a/changelog/add_format_integers_as_floats.dd
+++ b/changelog/add_format_integers_as_floats.dd
@@ -1,0 +1,14 @@
+Formatting integers with `%e`, `%f`, `%g` and `%a` is now possible.
+
+The formatting posibilities of integers have been expanded to the
+specifiers that are typical for floating point numbers: Integers can
+now be formatted using `%e`, `%f`, `%g` and `%a`. The result is
+similar to the result expected for the corresponding floating point
+value.
+
+```
+assert(format!"%.3e"(ulong.max) == "1.845e+19");
+assert(format!"%.3,3f"(ulong.max) == "18,446,744,073,709,551,615.000");
+assert(format!"%.3g"(ulong.max) == "1.84e+19");
+assert(format!"%.3a"(ulong.max) == "0x1.000p+64");
+```

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -497,6 +497,63 @@ if (is(IntegralTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     assert(format!"%#.0o"(0) == "0");
 }
 
+@safe pure unittest
+{
+    assert(format!"%e"(10000) == "1.0000e+04");
+    assert(format!"%.2e"(10000) == "1.00e+04");
+    assert(format!"%.10e"(10000) == "1.0000000000e+04");
+
+    assert(format!"%e"(9999) == "9.999e+03");
+    assert(format!"%.2e"(9999) == "1.00e+04");
+    assert(format!"%.10e"(9999) == "9.9990000000e+03");
+
+    assert(format!"%f"(10000) == "10000");
+    assert(format!"%.2f"(10000) == "10000.00");
+
+    assert(format!"%g"(10000) == "10000");
+    assert(format!"%.2g"(10000) == "1e+04");
+    assert(format!"%.10g"(10000) == "10000");
+
+    assert(format!"%#g"(10000) == "10000.");
+    assert(format!"%#.2g"(10000) == "1.0e+04");
+    assert(format!"%#.10g"(10000) == "10000.00000");
+
+    assert(format!"%g"(9999) == "9999");
+    assert(format!"%.2g"(9999) == "1e+04");
+    assert(format!"%.10g"(9999) == "9999");
+
+    assert(format!"%a"(0x10000) == "0x1.0000p+16");
+    assert(format!"%.2a"(0x10000) == "0x1.00p+16");
+    assert(format!"%.10a"(0x10000) == "0x1.0000000000p+16");
+
+    assert(format!"%a"(0xffff) == "0xf.fffp+12");
+    assert(format!"%.2a"(0xffff) == "0x1.00p+16");
+    assert(format!"%.10a"(0xffff) == "0xf.fff0000000p+12");
+}
+
+@safe pure unittest
+{
+    assert(format!"%.3e"(ulong.max) == "1.845e+19");
+    assert(format!"%.3f"(ulong.max) == "18446744073709551615.000");
+    assert(format!"%.3g"(ulong.max) == "1.84e+19");
+    assert(format!"%.3a"(ulong.max) == "0x1.000p+64");
+
+    assert(format!"%.3e"(long.min) == "-9.223e+18");
+    assert(format!"%.3f"(long.min) == "-9223372036854775808.000");
+    assert(format!"%.3g"(long.min) == "-9.22e+18");
+    assert(format!"%.3a"(long.min) == "-0x8.000p+60");
+
+    assert(format!"%e"(0) == "0e+00");
+    assert(format!"%f"(0) == "0");
+    assert(format!"%g"(0) == "0");
+    assert(format!"%a"(0) == "0x0p+00");
+}
+
+@safe pure unittest
+{
+    assert(format!"%.0g"(1500) == "2e+03");
+}
+
 /*
     Floating-point values are formatted like $(REF printf, core, stdc, stdio)
  */

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3551,6 +3551,282 @@ private long getWidth(T)(T s)
     return width;
 }
 
+enum RoundingClass { ZERO, LOWER, FIVE, UPPER }
+
+bool round(T)(ref T sequence, size_t left, size_t right, RoundingClass type, bool negative, char max = '9')
+in (left > 0) // != 0 because we might need one carry
+in (left < sequence.length)
+in (right >= 0)
+in (right <= sequence.length)
+in (right >= left)
+in (max == '9' || max == 'f' || max == 'F')
+{
+    import std.format.internal.floats : RoundingMode;
+    import std.math.hardware;
+
+    auto mode = RoundingMode.toNearestTiesToEven;
+
+    if (!__ctfe)
+    {
+        // std.math's FloatingPointControl isn't available on all target platforms
+        static if (is(FloatingPointControl))
+        {
+            switch (FloatingPointControl.rounding)
+            {
+            case FloatingPointControl.roundUp:
+                mode = RoundingMode.up;
+                break;
+            case FloatingPointControl.roundDown:
+                mode = RoundingMode.down;
+                break;
+            case FloatingPointControl.roundToZero:
+                mode = RoundingMode.toZero;
+                break;
+            case FloatingPointControl.roundToNearest:
+                mode = RoundingMode.toNearestTiesToEven;
+                break;
+            default: assert(false, "Unknown floating point rounding mode");
+            }
+        }
+    }
+
+    bool roundUp = false;
+    if (mode == RoundingMode.up)
+        roundUp = type != RoundingClass.ZERO && !negative;
+    else if (mode == RoundingMode.down)
+        roundUp = type != RoundingClass.ZERO && negative;
+    else if (mode == RoundingMode.toZero)
+        roundUp = false;
+    else
+    {
+        roundUp = type == RoundingClass.UPPER;
+
+        if (type == RoundingClass.FIVE)
+        {
+            // IEEE754 allows for two different ways of implementing roundToNearest:
+
+            if (mode == RoundingMode.toNearestTiesAwayFromZero)
+                roundUp = true;
+            else
+            {
+                // Round to nearest, ties to even
+                auto last = sequence[right - 1];
+                if (last == '.') last = sequence[right - 2];
+                roundUp = last % 2 != 0;
+            }
+        }
+    }
+
+    if (!roundUp) return false;
+
+    foreach_reverse (i;left .. right)
+    {
+        if (sequence[i] == '.') continue;
+        if (sequence[i] == max)
+            sequence[i] = '0';
+        else
+        {
+            if (max != '9' && sequence[i] == '9')
+                sequence[i] = max == 'f' ? 'a' : 'A';
+            else
+                sequence[i]++;
+            return false;
+        }
+    }
+
+    sequence[left - 1] = '1';
+    return true;
+}
+
+@safe unittest
+{
+    char[10] c;
+    size_t left = 5;
+    size_t right = 8;
+
+    c[4 .. 8] = "x.99";
+    assert(round(c, left, right, RoundingClass.UPPER, false) == true);
+    assert(c[4 .. 8] == "1.00");
+
+    c[4 .. 8] = "x.99";
+    assert(round(c, left, right, RoundingClass.FIVE, false) == true);
+    assert(c[4 .. 8] == "1.00");
+
+    c[4 .. 8] = "x.99";
+    assert(round(c, left, right, RoundingClass.LOWER, false) == false);
+    assert(c[4 .. 8] == "x.99");
+
+    c[4 .. 8] = "x.99";
+    assert(round(c, left, right, RoundingClass.ZERO, false) == false);
+    assert(c[4 .. 8] == "x.99");
+
+    import std.math.hardware;
+    static if (is(FloatingPointControl))
+    {
+        FloatingPointControl fpctrl;
+
+        fpctrl.rounding = FloatingPointControl.roundUp;
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.UPPER, false) == true);
+        assert(c[4 .. 8] == "1.00");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.FIVE, false) == true);
+        assert(c[4 .. 8] == "1.00");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.LOWER, false) == true);
+        assert(c[4 .. 8] == "1.00");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.ZERO, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        fpctrl.rounding = FloatingPointControl.roundDown;
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.UPPER, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.FIVE, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.LOWER, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.ZERO, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        fpctrl.rounding = FloatingPointControl.roundToZero;
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.UPPER, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.FIVE, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.LOWER, false) == false);
+        assert(c[4 .. 8] == "x.99");
+
+        c[4 .. 8] = "x.99";
+        assert(round(c, left, right, RoundingClass.ZERO, false) == false);
+        assert(c[4 .. 8] == "x.99");
+    }
+}
+
+@safe unittest
+{
+    char[10] c;
+    size_t left = 5;
+    size_t right = 8;
+
+    c[4 .. 8] = "x8.5";
+    assert(round(c, left, right, RoundingClass.UPPER, true) == false);
+    assert(c[4 .. 8] == "x8.6");
+
+    c[4 .. 8] = "x8.5";
+    assert(round(c, left, right, RoundingClass.FIVE, true) == false);
+    assert(c[4 .. 8] == "x8.6");
+
+    c[4 .. 8] = "x8.4";
+    assert(round(c, left, right, RoundingClass.FIVE, true) == false);
+    assert(c[4 .. 8] == "x8.4");
+
+    c[4 .. 8] = "x8.5";
+    assert(round(c, left, right, RoundingClass.LOWER, true) == false);
+    assert(c[4 .. 8] == "x8.5");
+
+    c[4 .. 8] = "x8.5";
+    assert(round(c, left, right, RoundingClass.ZERO, true) == false);
+    assert(c[4 .. 8] == "x8.5");
+
+    import std.math.hardware;
+    static if (is(FloatingPointControl))
+    {
+        FloatingPointControl fpctrl;
+
+        fpctrl.rounding = FloatingPointControl.roundUp;
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.UPPER, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.FIVE, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.LOWER, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.ZERO, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        fpctrl.rounding = FloatingPointControl.roundDown;
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.UPPER, true) == false);
+        assert(c[4 .. 8] == "x8.6");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.FIVE, true) == false);
+        assert(c[4 .. 8] == "x8.6");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.LOWER, true) == false);
+        assert(c[4 .. 8] == "x8.6");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.ZERO, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        fpctrl.rounding = FloatingPointControl.roundToZero;
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.UPPER, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.FIVE, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.LOWER, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+
+        c[4 .. 8] = "x8.5";
+        assert(round(c, left, right, RoundingClass.ZERO, true) == false);
+        assert(c[4 .. 8] == "x8.5");
+    }
+}
+
+@safe unittest
+{
+    char[10] c;
+    size_t left = 5;
+    size_t right = 8;
+
+    c[4 .. 8] = "x8.9";
+    assert(round(c, left, right, RoundingClass.UPPER, true, 'f') == false);
+    assert(c[4 .. 8] == "x8.a");
+
+    c[4 .. 8] = "x8.9";
+    assert(round(c, left, right, RoundingClass.UPPER, true, 'F') == false);
+    assert(c[4 .. 8] == "x8.A");
+
+    c[4 .. 8] = "x8.f";
+    assert(round(c, left, right, RoundingClass.UPPER, true, 'f') == false);
+    assert(c[4 .. 8] == "x9.0");
+}
+
 version (StdUnittest)
 private void formatTest(T)(T val, string expected, size_t ln = __LINE__, string fn = __FILE__)
 {

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -331,7 +331,7 @@ $(BOOKTABLE ,
    $(TR $(TD $(B 'r'))
             $(TD `\0` or `\1`)
    )
-   $(TR $(MULTIROW_CELL 3, $(I Integral))
+   $(TR $(MULTIROW_CELL 4, $(I Integral))
         $(TD $(B 's'), $(B 'd'))
             $(TD A signed decimal number. The $(B '#') flag is ignored.)
    )
@@ -342,6 +342,16 @@ $(BOOKTABLE ,
                  denotes that the number must be preceded by `0` and `0x`, with
                  the exception of the value 0, where this does not apply. For
                  $(B 'b') and $(B 'u') the $(B '#') flag has no effect.)
+   )
+   $(TR $(TD $(B 'e'), $(B 'E'), $(B 'f'), $(B 'F'), $(B 'g'), $(B 'G'), $(B 'a'), $(B 'A'))
+            $(TD As a floating point value with the same specifier.
+
+                 Default precision is large enough to add all digits
+                 of the integral value.
+
+                 In case of ($B 'a') and $(B 'A'), the integral digit can be
+                 any hexadecimal digit.
+               )
    )
    $(TR $(TD $(B 'r'))
             $(TD Characters taken directly from the binary representation.)

--- a/std/format/write.d
+++ b/std/format/write.d
@@ -15,7 +15,7 @@ $(BOOKTABLE ,
 $(TR $(TH) $(TH s) $(TH c) $(TH d, u, b, o) $(TH x, X) $(TH e, E, f, F, g, G, a, A) $(TH r) $(TH compound))
 $(TR $(TD `bool`) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD $(MDASH)))
 $(TR $(TD `null`) $(TD yes) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)))
-$(TR $(TD $(I integer)) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD $(MDASH)))
+$(TR $(TD $(I integer)) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD yes) $(TD yes) $(TD yes) $(TD $(MDASH)))
 $(TR $(TD $(I floating point)) $(TD yes) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD yes) $(TD yes) $(TD $(MDASH)))
 $(TR $(TD $(I character)) $(TD yes) $(TD yes) $(TD yes) $(TD yes) $(TD $(MDASH)) $(TD yes) $(TD $(MDASH)))
 $(TR $(TD $(I string)) $(TD yes) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD $(MDASH)) $(TD yes) $(TD yes))

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -2490,7 +2490,7 @@ public:
     {
         import std.exception : assertThrown;
         import std.format : format, FormatException;
-        assertThrown!FormatException(format("%a", unicode.ASCII));
+        assertThrown!FormatException(format("%z", unicode.ASCII));
     }
 
 


### PR DESCRIPTION
Inspired by [issue 16078](https://issues.dlang.org/show_bug.cgi?id=16078) I added formatting with `%e` etc. for integers. I tried to reach an identical result to first casting and then formatting, while preserving all digits:

```
writefln!"%.10e"(1234567890);
writefln!"%.10e"(cast(float) 1234567890);
```

yields:

```
1.2345678900e+09
1.2345679360e+09
```

As can be seen: With the cast, the last four digits are lost while they are preserved without.

I decided to deviate from the floating point behavior in two places:

- Default precision isn't anymore 6, but just as large as necessary to keep all digits. The reason for this change is, that the trailing fractional digits of floating point values normally don't contain any information and thus can be cut away. This is not true for integrals and so I think it's better to preserve this information as a default.
- With `%a`, the integral digit can be larger than 1. `%a` tries to resemble the mantissa and therefore the integral digit is always 0 or 1 and the fractional digits match with the fractional digits of the mantissa. Integral values don't have a mantissa nor have they fractional digits. So it's more natural to build them from right to left instead of left to right which is natural for floating point values. But that leads to larger integral digits. (And as a side effect, the digits of `%a` and `%x` are the same which is also preferable.)

The first commit adds a rounding tool. I plan to use this to simplify the functions in `std.format.internal.floats`. Therefore I put it into a separate function.