### PR TITLE
std.format: handle "exotic" reals by casting to double

### DIFF
--- a/changelog/formatting_floats_in_CTFE.dd
+++ b/changelog/formatting_floats_in_CTFE.dd
@@ -11,6 +11,3 @@ static assert(pi == "3.14159");
 enum golden_ratio = format!"|%+-20.10E|"((1 + sqrt(5.0)) / 2);
 static assert(golden_ratio == "|+1.6180339887E+00   |");
 ------
-
-Note: compile time formatting `real`s is only supported for 64-bit
-reals and 80-bit reals.

--- a/changelog/formatting_some_reals_as_doubles.dd
+++ b/changelog/formatting_some_reals_as_doubles.dd
@@ -1,0 +1,13 @@
+Some reals will be downcast to double when used with `std.format`.
+
+In the internals of `std.format` we replaced a call to `snprintf` of
+`libc` with routines written in D for formatting floating point
+values. These functions only work for floats, doubles, 64-bit-reals
+and 80-bit-reals (x87-reals) yet.
+
+All other reals are handled by downcasting them to doubles before
+being formatted. This might result in a loss of precision in the
+output. Further, numbers larger than `double.max` will be formatted like
+`double.max` and numbers large than zero but smaller than the smallest
+positive double will be formatted like the smallest positive double.
+Likewise for negative values.

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -300,6 +300,9 @@ $(UL
        of the floating point unit, if available.)
   $(LI The floating point values `NaN` and `Infinity` are formatted as
        `nan` and `inf`, possibly preceded by $(B '+') or $(B '-') sign.)
+  $(LI Formatting reals is only supported for 64 bit reals and 80 bit reals.
+       All other reals are cast to double before they are formatted. This will
+       cause the result to be `inf` for very large numbers.)
   $(LI Characters and strings formatted with the $(B 's') format character
        inside of compound types are surrounded by single and double quotes
        and unprintable characters are escaped. To avoid this, a $(B '-')


### PR DESCRIPTION
I'd like to get rid of using `libc` in `std.format`. Meanwhile it is only used to format "exotic" reals, that is reals which are not 64-bit-reals nor x87-reals. I suggest to handle them (until someone volunteers to implement `printFloat` for them), by downcasting them to double and formatting that double.

Advantages:
- No dependency of `libc` anymore, that is, `snprintf` is finally removed.
- And that means: no dependency of the bugs in `snprintf`.
- CTFE for all reals
- Identical results on all platforms (the results from different `libc` implementations vary)
- No more known-to-be-buggy code in the floating point specialization of `formatValueImpl`.
- Support for more than 500 characters in the output.
- Use of the new =-flag also for "exotic" reals.
- No interference with `snprintf` and `@nogc` inference.
- It might even be the case, that some "exotic" reals where not supported yet, because a `libc` implementation was missing. In that case, these reals are now supported.

Disadvantages:
- Lower precision for "exotic" reals.
- Large values of "exotic" reals are formatted as "inf".
- Might be perceived as a breaking change (by users of "exotic" reals). (I thought about starting a deprecation cycle, but have not found a good idea, how to do so: Using these reals is not deprecated nor do I want to ask the users to downcast them themselves, because if they are eventually implemented, these downcast will become bugs.)

In my opinion the advantages outweigh the disadvantages. What do you think?