### PR TITLE
extractBitpattern: Add implied bit to mantissa and subtract bias from exponent.

### DIFF
--- a/std/math/operations.d
+++ b/std/math/operations.d
@@ -1807,6 +1807,14 @@ if (isFloatingPoint!T)
         ret.negative = (ival >> (T.mant_dig + log2_max_exp)) & 1;
     }
 
+    // add leading 1 for normalized values and correct exponent for denormalied values
+    if (ret.exponent != 0 && ret.exponent != 2 * T.max_exp - 1)
+        ret.mantissa |= 1L << (T.mant_dig - 1);
+    else if (ret.exponent == 0)
+        ret.exponent = 1;
+
+    ret.exponent -= T.max_exp - 1;
+
     return ret;
 }
 
@@ -1814,39 +1822,39 @@ if (isFloatingPoint!T)
 {
     float f = 1.0f;
     auto bp = extractBitpattern(f);
-    assert(bp.mantissa == 0);
-    assert(bp.exponent == 127);
+    assert(bp.mantissa == 0x80_0000);
+    assert(bp.exponent == 0);
     assert(bp.negative == false);
 
     f = float.max;
     bp = extractBitpattern(f);
-    assert(bp.mantissa == 0x7f_ffff);
-    assert(bp.exponent == 254);
+    assert(bp.mantissa == 0xff_ffff);
+    assert(bp.exponent == 127);
     assert(bp.negative == false);
 
     f = -1.5432e-17f;
     bp = extractBitpattern(f);
-    assert(bp.mantissa == 0x0e_55c8);
-    assert(bp.exponent == 71);
+    assert(bp.mantissa == 0x8e_55c8);
+    assert(bp.exponent == -56);
     assert(bp.negative == true);
 
     // using double literal due to https://issues.dlang.org/show_bug.cgi?id=20361
     f = 2.3822073893521890206e-44;
     bp = extractBitpattern(f);
     assert(bp.mantissa == 0x00_0011);
-    assert(bp.exponent == 0);
+    assert(bp.exponent == -126);
     assert(bp.negative == false);
 
     f = -float.infinity;
     bp = extractBitpattern(f);
     assert(bp.mantissa == 0);
-    assert(bp.exponent == 255);
+    assert(bp.exponent == 128);
     assert(bp.negative == true);
 
     f = float.nan;
     bp = extractBitpattern(f);
     assert(bp.mantissa != 0); // we don't guarantee payloads
-    assert(bp.exponent == 255);
+    assert(bp.exponent == 128);
     assert(bp.negative == false);
 }
 
@@ -1854,38 +1862,38 @@ if (isFloatingPoint!T)
 {
     double d = 1.0;
     auto bp = extractBitpattern(d);
-    assert(bp.mantissa == 0);
-    assert(bp.exponent == 1023);
+    assert(bp.mantissa == 0x10_0000_0000_0000L);
+    assert(bp.exponent == 0);
     assert(bp.negative == false);
 
     d = double.max;
     bp = extractBitpattern(d);
-    assert(bp.mantissa == 0xf_ffff_ffff_ffffL);
-    assert(bp.exponent == 2046);
+    assert(bp.mantissa == 0x1f_ffff_ffff_ffffL);
+    assert(bp.exponent == 1023);
     assert(bp.negative == false);
 
     d = -1.5432e-222;
     bp = extractBitpattern(d);
-    assert(bp.mantissa == 0x1_d9b6_a401_3b04L);
-    assert(bp.exponent == 286);
+    assert(bp.mantissa == 0x11_d9b6_a401_3b04L);
+    assert(bp.exponent == -737);
     assert(bp.negative == true);
 
     d = 0.0.nextUp;
     bp = extractBitpattern(d);
-    assert(bp.mantissa == 0x0_0000_0000_0001L);
-    assert(bp.exponent == 0);
+    assert(bp.mantissa == 0x00_0000_0000_0001L);
+    assert(bp.exponent == -1022);
     assert(bp.negative == false);
 
     d = -double.infinity;
     bp = extractBitpattern(d);
     assert(bp.mantissa == 0);
-    assert(bp.exponent == 2047);
+    assert(bp.exponent == 1024);
     assert(bp.negative == true);
 
     d = double.nan;
     bp = extractBitpattern(d);
     assert(bp.mantissa != 0); // we don't guarantee payloads
-    assert(bp.exponent == 2047);
+    assert(bp.exponent == 1024);
     assert(bp.negative == false);
 }
 
@@ -1898,44 +1906,44 @@ if (isFloatingPoint!T)
     {
         real r = 1.0L;
         auto bp = extractBitpattern(r);
-        assert(bp.mantissa == 0);
-        assert(bp.exponent == 16383);
+        assert(bp.mantissa == 0x8000_0000_0000_0000L);
+        assert(bp.exponent == 0);
         assert(bp.negative == false);
 
         r = real.max;
         bp = extractBitpattern(r);
-        assert(bp.mantissa == 0x7fff_ffff_ffff_ffffL);
-        assert(bp.exponent == 32766);
+        assert(bp.mantissa == 0xffff_ffff_ffff_ffffL);
+        assert(bp.exponent == 16383);
         assert(bp.negative == false);
 
         r = -1.5432e-3333L;
         bp = extractBitpattern(r);
-        assert(bp.mantissa == 0x4768_a2c7_a616_cc22L);
-        assert(bp.exponent == 5311);
+        assert(bp.mantissa == 0xc768_a2c7_a616_cc22L);
+        assert(bp.exponent == -11072);
         assert(bp.negative == true);
 
         r = 0.0L.nextUp;
         bp = extractBitpattern(r);
         assert(bp.mantissa == 0x0000_0000_0000_0001L);
-        assert(bp.exponent == 0);
+        assert(bp.exponent == -16382);
         assert(bp.negative == false);
 
         r = -float.infinity;
         bp = extractBitpattern(r);
         assert(bp.mantissa == 0);
-        assert(bp.exponent == 32767);
+        assert(bp.exponent == 16384);
         assert(bp.negative == true);
 
         r = float.nan;
         bp = extractBitpattern(r);
         assert(bp.mantissa != 0); // we don't guarantee payloads
-        assert(bp.exponent == 32767);
+        assert(bp.exponent == 16384);
         assert(bp.negative == false);
 
         r = nextDown(0x1p+16383L);
         bp = extractBitpattern(r);
-        assert(bp.mantissa == 0x7fff_ffff_ffff_ffffL);
-        assert(bp.exponent == 32765);
+        assert(bp.mantissa == 0xffff_ffff_ffff_ffffL);
+        assert(bp.exponent == 16382);
         assert(bp.negative == false);
     }
 }
@@ -1955,44 +1963,44 @@ if (isFloatingPoint!T)
     {
         enum r1 = 1.0L;
         enum bp1 = extractBitpattern(r1);
-        static assert(bp1.mantissa == 0);
-        static assert(bp1.exponent == 16383);
+        static assert(bp1.mantissa == 0x8000_0000_0000_0000L);
+        static assert(bp1.exponent == 0);
         static assert(bp1.negative == false);
 
         enum r2 = real.max;
         enum bp2 = extractBitpattern(r2);
-        static assert(bp2.mantissa == 0x7fff_ffff_ffff_ffffL);
-        static assert(bp2.exponent == 32766);
+        static assert(bp2.mantissa == 0xffff_ffff_ffff_ffffL);
+        static assert(bp2.exponent == 16383);
         static assert(bp2.negative == false);
 
         enum r3 = -1.5432e-3333L;
         enum bp3 = extractBitpattern(r3);
-        static assert(bp3.mantissa == 0x4768_a2c7_a616_cc22L);
-        static assert(bp3.exponent == 5311);
+        static assert(bp3.mantissa == 0xc768_a2c7_a616_cc22L);
+        static assert(bp3.exponent == -11072);
         static assert(bp3.negative == true);
 
         enum r4 = 0.0L.nextUp;
         enum bp4 = extractBitpattern(r4);
         static assert(bp4.mantissa == 0x0000_0000_0000_0001L);
-        static assert(bp4.exponent == 0);
+        static assert(bp4.exponent == -16382);
         static assert(bp4.negative == false);
 
         enum r5 = -real.infinity;
         enum bp5 = extractBitpattern(r5);
         static assert(bp5.mantissa == 0);
-        static assert(bp5.exponent == 32767);
+        static assert(bp5.exponent == 16384);
         static assert(bp5.negative == true);
 
         enum r6 = real.nan;
         enum bp6 = extractBitpattern(r6);
         static assert(bp6.mantissa != 0); // we don't guarantee payloads
-        static assert(bp6.exponent == 32767);
+        static assert(bp6.exponent == 16384);
         static assert(bp6.negative == false);
 
         enum r7 = nextDown(0x1p+16383L);
         enum bp7 = extractBitpattern(r7);
-        static assert(bp2.mantissa == 0x7fff_ffff_ffff_ffffL);
-        static assert(bp2.exponent == 32766);
+        static assert(bp2.mantissa == 0xffff_ffff_ffff_ffffL);
+        static assert(bp2.exponent == 16383);
         static assert(bp2.negative == false);
     }
 }


### PR DESCRIPTION
Followup on #8004.

`extractBitpattern` now returns the mantissa with implied bit and subtracts the bias from the exponent.

In `std.format` I removed this repeating code. For `%a` I had to move part of the code ahead of the digit extraction (and alter it slightly) to keep it working. All else is straight forward.