### PR TITLE
Sync Fields with FieldNameTuple for interfaces

### DIFF
--- a/changelog/fields_interface.dd
+++ b/changelog/fields_interface.dd
@@ -1,0 +1,8 @@
+`Fields` (formerly `FieldTypeTuple`) now returns an empty tuple for interfaces
+
+Previously `Fields` returned `AliasSeq!(Interface)` for interfaces as done for
+non-aggregate types like `int`, `char*`, ... . This behaviour was surprising
+because an instance of an interface *may* have members that just are not
+known at compile time.
+
+`Fields` will now return an empty `AliasSeq!()` for interfaces.

--- a/std/traits.d
+++ b/std/traits.d
@@ -2740,14 +2740,14 @@ template hasNested(T)
  * This consists of the fields that take up memory space,
  * excluding the hidden fields like the virtual function
  * table pointer or a context pointer for nested types.
- * If `T` isn't a struct, class, or union returns a tuple
+ * If `T` isn't a struct, class, interface or union returns a tuple
  * with one element `T`.
  */
 template Fields(T)
 {
     static if (is(T == struct) || is(T == union))
         alias Fields = typeof(T.tupleof[0 .. $ - isNested!T]);
-    else static if (is(T == class))
+    else static if (is(T == class) || is(T == interface))
         alias Fields = typeof(T.tupleof);
     else
         alias Fields = AliasSeq!T;
@@ -2786,8 +2786,10 @@ alias FieldTypeTuple = Fields;
 
     class NestedClass { int a; void f() { ++i; } }
     static assert(is(FieldTypeTuple!NestedClass == AliasSeq!int));
-}
 
+    static interface I {}
+    static assert(is(Fields!I == AliasSeq!()));
+}
 
 //Required for FieldNameTuple
 private enum NameOf(alias T) = T.stringof;

--- a/std/traits.d
+++ b/std/traits.d
@@ -2742,6 +2742,9 @@ template hasNested(T)
  * table pointer or a context pointer for nested types.
  * If `T` isn't a struct, class, interface or union returns a tuple
  * with one element `T`.
+ *
+ * History:
+ *   - Returned `AliasSeq!(Interface)` for interfaces prior to 2.097
  */
 template Fields(T)
 {
@@ -2802,6 +2805,9 @@ private enum NameOf(alias T) = T.stringof;
  * Inherited fields (for classes) are not included.
  * If `T` isn't a struct, class, interface or union, an
  * expression tuple with an empty string is returned.
+ *
+ * History:
+ *   - Returned `AliasSeq!""` for interfaces prior to 2.097
  */
 template FieldNameTuple(T)
 {


### PR DESCRIPTION
`FieldNameTuple` now yields an empty tuple for interfaces, so `Fields` should match that behaviour.

Followup to #8011 / #8014 

---

Also added `History` sections to the documentation of `Fields` and `FieldNameTuple` to make the change more obvious for people who don't read the changelog (as proposed by @adamdruppe)