### PR TITLE
Simplify and improve staticIndexOf

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -249,19 +249,21 @@ if (!isAggregateType!T || is(Unqual!T == T))
 }
 
 /**
- * Returns the index of the first occurrence of T in the
- * sequence TList.
- * If not found, -1 is returned.
+ * Returns the index of the first occurrence of `args[0]` in the
+ * sequence `args[1 .. $]`. `args` may be types or compile-time values.
+ * If not found, `-1` is returned.
  */
-template staticIndexOf(T, TList...)
+template staticIndexOf(args...)
+if (args.length >= 1)
 {
-    enum staticIndexOf = genericIndexOf!(T, TList);
-}
-
-/// Ditto
-template staticIndexOf(alias T, TList...)
-{
-    enum staticIndexOf = genericIndexOf!(T, TList);
+    enum staticIndexOf =
+    {
+        static foreach (idx, arg; args[1 .. $])
+            static if (isSame!(args[0], arg))
+                // `if (__ctfe)` is redundant here but avoids the "Unreachable code" warning.
+                if (__ctfe) return idx;
+        return -1;
+    }();
 }
 
 ///
@@ -274,24 +276,6 @@ template staticIndexOf(alias T, TList...)
         writefln("The index of long is %s",
                  staticIndexOf!(long, AliasSeq!(int, long, double)));
         // prints: The index of long is 1
-    }
-}
-
-// [internal]
-private template genericIndexOf(args...)
-if (args.length >= 1)
-{
-    static foreach (idx, arg; args[1 .. $])
-    {
-        static if (is(typeof(genericIndexOf) == void) && // not yet defined
-                   isSame!(args[0], arg))
-        {
-            enum genericIndexOf = idx;
-        }
-    }
-    static if (is(typeof(genericIndexOf) == void)) // no hit
-    {
-        enum genericIndexOf = -1;
     }
 }
 


### PR DESCRIPTION
This PR:

* simplifies definition of `staticIndexOf` by unifying the type- and alias-based variants
* improves the implementation
