### PR TITLE
std.process: Add scope to pipeProcessImpl command parameter

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2923,7 +2923,7 @@ ProcessPipes pipeShell(scope const(char)[] command,
 
 // Implementation of the pipeProcess() family of functions.
 private ProcessPipes pipeProcessImpl(alias spawnFunc, Cmd, ExtraSpawnFuncArgs...)
-                                    (Cmd command,
+                                    (scope Cmd command,
                                      Redirect redirectFlags,
                                      const string[string] env = null,
                                      Config config = Config.none,


### PR DESCRIPTION
Both public `pipeProcess` and `pipeShell` functions accept a `scope` program/command parameter.  It looks like a mistake that the internal Impl function doesn't, which triggers an error if the target ABI requires that the caller destroys all arguments ([issue 21880](https://issues.dlang.org/show_bug.cgi?id=21880)).