### PR TITLE
Fix Issue 21456 - std.format does not accept enum member with string base type as template parameter

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1344,8 +1344,8 @@ if (isSomeChar!Char)
 }
 
 /// ditto
-typeof(fmt) format(alias fmt, Args...)(Args args)
-if (isSomeString!(typeof(fmt)))
+auto format(alias fmt, Args...)(Args args)
+if (is(StringTypeOf!(typeof(fmt))))
 {
     import std.array : appender;
     import std.range.primitives : ElementEncodingType;
@@ -1397,6 +1397,25 @@ if (isSomeString!(typeof(fmt)))
     static assert(!__traits(compiles, format!"%f"(1.5, 2)));
     static assert(!__traits(compiles, format!"%s"(1.5L, 2)));
     static assert(!__traits(compiles, format!"%f"(1.5L, 2)));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21456
+@safe pure unittest
+{
+    enum FMTS1 = "%s is %s";
+    assert(format!FMTS1("Pi", 3.14) == "Pi is 3.14");
+
+    enum
+    {
+        FMTS2 = "%s is %s"
+    }
+    assert(format!FMTS2("Pi", 3.14) == "Pi is 3.14");
+
+    enum FMTS3 : string
+    {
+        ONE = "%s is %s"
+    }
+    assert(format!(FMTS3.ONE)("Pi", 3.14) == "Pi is 3.14");
 }
 
 // called during compilation to guess the length of the


### PR DESCRIPTION
Don't know if it wouldn't be better to have to return type just being `auto`...