### PR TITLE
Add transition note from approxEqual to isClose.

### DIFF
--- a/std/math/operations.d
+++ b/std/math/operations.d
@@ -1006,7 +1006,11 @@ if (isFloatingPoint!(X))
 
    Warning:
         This template is considered out-dated. It will be removed from
-        Phobos in 2.106.0. Please use $(LREF isClose) instead.
+        Phobos in 2.106.0. Please use $(LREF isClose) instead. To achieve
+        a similar behaviour to `approxEqual(a, b)` use
+        `isClose(a, b, 1e-2, 1e-5)`. In case of comparing to 0.0,
+        `isClose(a, b, 0.0, eps)` should be used, where `eps`
+        represents the accepted deviation from 0.0."
 
    Params:
         value = Value to compare.


### PR DESCRIPTION
Like suggested in #7775 by @jondegenhardt I added the transition note from the release note and additional information on how to cope with 0.0 in the out of date note of `approxEqual` to make the transition easier.