### PR TITLE
container.array: RangeT: moveBack: Improve an assertion.

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -152,7 +152,7 @@ private struct RangeT(A)
         E moveBack()
         {
             assert(!empty, "Attempting to moveBack an empty Array");
-            assert(_a <= _outer.length,
+            assert(_b - 1 < _outer.length,
                 "Attempting to moveBack using an out of bounds high index on an Array");
             return move(_outer._data._payload[_b - 1]);
         }


### PR DESCRIPTION
Perhaps instead of (_a <= _outer.length) the intention was to write (_b <= _outer.length).

But I feel that (b - 1 < _outer.length) looks even better -- and is more consistent with various other checks (which also use <, not <=).

Yupii !