### PR TITLE
std.utf: Add isValidCodepoint.

### DIFF
--- a/changelog/add_isValidCharacter.dd
+++ b/changelog/add_isValidCharacter.dd
@@ -1,0 +1,12 @@
+New function `isValidCharacter` in `std.utf`
+
+A new function `isValidCharacter` has been added to `std.utf`. It can
+be used to check if a single character forms a valid code point. For
+example the `char` `0x80` is not a valid code point, because it can
+only be used in trailing characters of UTF8 sequences, whereas the
+wchar `ä` is a valid character:
+
+```
+assert(!isValidCharacter(cast(char) 0x80));
+assert(isValidCharacter('ä'));
+```


### PR DESCRIPTION
For improving formatting characters with `std.format` I need this function (e.g. fixing [issue 21815](https://issues.dlang.org/show_bug.cgi?id=21815), but can also be used for [issue 6125](https://issues.dlang.org/show_bug.cgi?id=6125)). I could add it as a private function to `std.format`, but I think, it fits better in here and might be useful for users too. Especially, because the `dchar` version already exists here as `isValidDchar`, while `isValidWchar` and `isValidChar` are missing (and it's not D like to use these functions instead of a single template).

I did not manage to find out, why `isValidDchar` was designed like this. It was added in 2007 to git, but probably existed prior to that somewhere else. Eventually, `isValidCharacter` might replace `isValidDchar`. (Should I do so immediately?)

cc @atilaneves