### PR TITLE
Reduce template instantiations when importing std.bitmanip

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -786,7 +786,7 @@ if (is(T == class))
 
 /**
    Allows manipulating the fraction, exponent, and sign parts of a
-   $(D_PARAM float) separately. The definition is:
+   `float` separately. The definition is:
 
 ----
 struct FloatRep
@@ -803,17 +803,52 @@ struct FloatRep
 }
 ----
 */
-struct FloatRep
+alias FloatRep = FloatingPointRepresentation!float;
+
+/**
+   Allows manipulating the fraction, exponent, and sign parts of a
+   `double` separately. The definition is:
+
+----
+struct DoubleRep
 {
     union
     {
-        float value;
+        double value;
         mixin(bitfields!(
-                  uint,  "fraction", 23,
-                  ubyte, "exponent",  8,
-                  bool,  "sign",      1));
+                  ulong,   "fraction", 52,
+                  ushort,  "exponent", 11,
+                  bool,    "sign",      1));
     }
-    enum uint bias = 127, fractionBits = 23, exponentBits = 8, signBits = 1;
+    enum uint bias = 1023, signBits = 1, fractionBits = 52, exponentBits = 11;
+}
+----
+*/
+alias DoubleRep = FloatingPointRepresentation!double;
+
+private struct FloatingPointRepresentation(T)
+{
+    static if (is(T == float))
+    {
+        enum uint bias = 127, fractionBits = 23, exponentBits = 8, signBits = 1;
+        alias FractionType = uint;
+        alias ExponentType = ubyte;
+    }
+    else
+    {
+        enum uint bias = 1023, fractionBits = 52, exponentBits = 11, signBits = 1;
+        alias FractionType = ulong;
+        alias ExponentType = ushort;
+    }
+
+    union
+    {
+        T value;
+        mixin(bitfields!(
+                  FractionType, "fraction", fractionBits,
+                  ExponentType, "exponent", exponentBits,
+                  bool,  "sign",     signBits));
+    }
 }
 
 ///
@@ -862,39 +897,6 @@ struct FloatRep
     assert(rep.fraction == 2796203);
     assert(rep.exponent == 125);
     assert(rep.sign);
-}
-
-/**
-   Allows manipulating the fraction, exponent, and sign parts of a
-   $(D_PARAM double) separately. The definition is:
-
-----
-struct DoubleRep
-{
-    union
-    {
-        double value;
-        mixin(bitfields!(
-                  ulong,   "fraction", 52,
-                  ushort,  "exponent", 11,
-                  bool,    "sign",      1));
-    }
-    enum uint bias = 1023, signBits = 1, fractionBits = 52, exponentBits = 11;
-}
-----
-*/
-
-struct DoubleRep
-{
-    union
-    {
-        double value;
-        mixin(bitfields!(
-                  ulong,  "fraction", 52,
-                  ushort, "exponent", 11,
-                  bool,   "sign",      1));
-    }
-    enum uint bias = 1023, signBits = 1, fractionBits = 52, exponentBits = 11;
 }
 
 ///


### PR DESCRIPTION
Compiling a file that only imports `std.bitmanip` with `-vtemplates` printed before this PR:

```
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(182): vtemplate: 8 (8 unique) instantiation(s) of template `createFields(string store, ulong offset, Ts...)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(229): vtemplate: 7 (6 unique) instantiation(s) of template `sizeOfBitField(T...)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(150): vtemplate: 7 (6 unique) instantiation(s) of template `createStoreName(Ts...)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(77): vtemplate: 6 (6 unique) instantiation(s) of template `createAccessors(string store, T, string name, ulong len, ulong offset)` found
/dlang/dmd/linux/bin64/../../src/druntime/import/core/stdc/config.d(232): vtemplate: 3 (3 unique) instantiation(s) of template `_Complex(T)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/typecons.d(8459): vtemplate: 17 (2 unique) instantiation(s) of template `Flag(string name)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(285): vtemplate: 2 (2 unique) instantiation(s) of template `bitfields(T...)()` found
/dlang/dmd/linux/bin64/../../src/phobos/std/bitmanip.d(158): vtemplate: 2 (2 unique) instantiation(s) of template `createStorageAndFields(Ts...)` found
/dlang/dmd/linux/bin64/../../src/druntime/import/core/internal/array/equality.d(20): vtemplate: 6 (1 unique) instantiation(s) of template `__equals(T1, T2)(scope const T1[] lhs, scope const T2[] rhs)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/traits.d(188): vtemplate: 2 (1 unique) instantiation(s) of template `Demangle(T)` found
/dlang/dmd/linux/bin64/../../src/druntime/import/core/internal/string.d(31): vtemplate: 1 (1 unique) instantiation(s) of template `unsignedToTempString(uint radix = 10)(ulong value, return scope char[] buf)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/meta.d(89): vtemplate: 1 (0 unique) instantiation(s) of template `AliasSeq(TList...)` found
```

After:

```
/dlang/dmd/linux/bin64/../../src/phobos/std/traits.d(188): vtemplate: 2 (1 unique) instantiation(s) of template `Demangle(T)` found
/dlang/dmd/linux/bin64/../../src/phobos/std/meta.d(89): vtemplate: 1 (0 unique) instantiation(s) of template `AliasSeq(TList...)` found
```