### PR TITLE
Remove duplicate assumePureFunction from std.regex

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -567,7 +567,7 @@ private auto defaultFactoryImpl(Char)(const ref Regex!Char re)
 
 // Used to generate a pure wrapper for defaultFactoryImpl. Based on the example in
 // the std.traits.SetFunctionAttributes documentation.
-private auto assumePureFunction(T)(T t)
+auto assumePureFunction(T)(T t)
 if (isFunctionPointer!T)
 {
     enum attrs = functionAttributes!T | FunctionAttribute.pure_;

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -851,17 +851,6 @@ private auto matchOnceImpl(RegEx, R)(R input, const auto ref RegEx prog) @truste
     return captures;
 }
 
-// Used to generate a pure wrapper for matchOnceImpl. Based on the example in the
-// std.traits.SetFunctionAttributes documentation.
-private auto assumePureFunction(T)(T t)
-{
-    if (isFunctionPointer!T)
-    {
-        enum attrs = functionAttributes!T | FunctionAttribute.pure_;
-        return cast(SetFunctionAttributes!(T, functionLinkage!T, attrs)) t;
-    }
-}
-
 // matchOnce is constructed as a safe, pure wrapper over matchOnceImpl. It can be
 // faked as pure because the static mutable variables are used to cache the key and
 // character matcher. The technique used avoids delegates and GC.


### PR DESCRIPTION
It's redundant and has the same invalid constraint that was
fixed for the other implementation