### PR TITLE
std.format: Use rounding tool to round %a on floats.

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3677,7 +3677,7 @@ private long getWidth(T)(T s)
 enum RoundingClass { ZERO, LOWER, FIVE, UPPER }
 
 bool round(T)(ref T sequence, size_t left, size_t right, RoundingClass type, bool negative, char max = '9')
-in (left > 0) // != 0 because we might need one carry
+in (left >= 0) // should be left > 0, but if you know ahead, that there's no carry, left == 0 is fine
 in (left < sequence.length)
 in (right >= 0)
 in (right <= sequence.length)


### PR DESCRIPTION
See #8050 for the general idea.

I had to do two more things here

1. The rounding tool needs to have access to the integral part, therefore I included it into `hex_mant` and thus had to move there everything one character to the right.
2. When calling the rounding tool, I know ahead, that the integral part is always 0 or 1. Therefore a carry can never happen. To avoid adding a never used character to the left of `hex_mant`, I had to relax the in-constraint.