### PR TITLE
std.complex: Add missing imports in unittests for non-DigitalMars targets

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -1042,6 +1042,8 @@ Complex!T asin(T)(Complex!T z)  @safe pure nothrow @nogc
 
 @safe pure nothrow unittest
 {
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
     version (DigitalMars) {} else // Disabled because of issue 21376
     assert(isClose(asin(complex(0.5f)), float(PI) / 6));
 }
@@ -1066,6 +1068,8 @@ Complex!T acos(T)(Complex!T z)  @safe pure nothrow @nogc
 
 @safe pure nothrow unittest
 {
+    import std.math.operations : isClose;
+    import std.math.constants : PI;
     version (DigitalMars) {} else // Disabled because of issue 21376
     assert(isClose(acos(complex(0.5f)), float(PI) / 3));
 }


### PR DESCRIPTION
Hopefully with #8065 in, `sqrt` won't be done at the wrong precision.