### PR TITLE
Rename the initial value of some enums from init to _init

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -848,7 +848,7 @@ private template GenericEncoder()
 //=============================================================================
 
 /** Defines various character sets. */
-enum AsciiChar : ubyte { init }
+enum AsciiChar : ubyte { _init }
 /// Ditto
 alias AsciiString = immutable(AsciiChar)[];
 
@@ -928,7 +928,7 @@ template EncoderInstance(CharType : AsciiChar)
 //=============================================================================
 
 /** Defines an Latin1-encoded character. */
-enum Latin1Char : ubyte { init }
+enum Latin1Char : ubyte { _init }
 /**
 Defines an Latin1-encoded string (as an array of $(D
 immutable(Latin1Char))).
@@ -1004,7 +1004,7 @@ template EncoderInstance(CharType : Latin1Char)
 //=============================================================================
 
 /// Defines a Latin2-encoded character.
-enum Latin2Char : ubyte { init }
+enum Latin2Char : ubyte { _init }
 
 /**
  * Defines an Latin2-encoded string (as an array of $(D
@@ -1084,7 +1084,7 @@ private template EncoderInstance(CharType : Latin2Char)
 //=============================================================================
 
 /// Defines a Windows1250-encoded character.
-enum Windows1250Char : ubyte { init }
+enum Windows1250Char : ubyte { _init }
 
 /**
  * Defines an Windows1250-encoded string (as an array of $(D
@@ -1177,7 +1177,7 @@ private template EncoderInstance(CharType : Windows1250Char)
 //=============================================================================
 
 /// Defines a Windows1251-encoded character.
-enum Windows1251Char : ubyte { init }
+enum Windows1251Char : ubyte { _init }
 
 /**
  * Defines an Windows1251-encoded string (as an array of $(D
@@ -1272,7 +1272,7 @@ private template EncoderInstance(CharType : Windows1251Char)
 //=============================================================================
 
 /// Defines a Windows1252-encoded character.
-enum Windows1252Char : ubyte { init }
+enum Windows1252Char : ubyte { _init }
 
 /**
  * Defines an Windows1252-encoded string (as an array of $(D

--- a/std/experimental/allocator/typed.d
+++ b/std/experimental/allocator/typed.d
@@ -28,7 +28,7 @@ allocator accordingly.
 */
 enum AllocFlag : uint
 {
-    init = 0,
+    _init = 0,
     /**
     Fixed-size allocation (unlikely to get reallocated later). Examples: `int`,
     `double`, any `struct` or `class` type. By default it is assumed that the

--- a/std/socket.d
+++ b/std/socket.d
@@ -86,7 +86,7 @@ else version (Posix)
 
     import core.stdc.errno;
 
-    enum socket_t : int32_t { init = -1 }
+    enum socket_t : int32_t { _init = -1 }
     private const int _SOCKET_ERROR = -1;
 
     private enum : int


### PR DESCRIPTION
Avoid conflicts with builtin `.init`.

Related [DMD pull](https://github.com/dlang/dmd/pull/12512).