### PR TITLE
Fix Issue 21916 - Error message is obfuscated when using wrong format…

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -732,7 +732,7 @@ if (isInputRange!Range)
 }
 
 // Used to check format strings are compatible with argument types
-package(std) static const checkFormatException(alias fmt, Args...) =
+package(std) enum checkFormatException(alias fmt, Args...) =
 {
     import std.conv : text;
 
@@ -743,7 +743,7 @@ package(std) static const checkFormatException(alias fmt, Args...) =
         enforceFmt(n == Args.length, text("Orphan format arguments: args[", n, "..", Args.length, "]"));
     }
     catch (Exception e)
-        return e;
+        return e.msg;
     return null;
 }();
 
@@ -1367,7 +1367,7 @@ if (isSomeString!(typeof(fmt)))
     alias e = checkFormatException!(fmt, Args);
     alias Char = Unqual!(ElementEncodingType!(typeof(fmt)));
 
-    static assert(!e, e.msg);
+    static assert(!e, e);
     auto w = appender!(immutable(Char)[]);
 
     // no need to traverse the string twice during compile time


### PR DESCRIPTION
… specifier at compile-time

Before:

```
.../std/format/package.d(748): Error: expression `FormatException(['I', 'n', 'c', 'o', 'r', 'r', 'e', 'c', 't', ' ', 'f', 'o', 'r', 'm', 'a', 't', ' ', 's', 'p', 'e', 'c', 'i', 'f', 'i', 'e', 'r', ' ', 'f', 'o', 'r', ' ', 'r', 'a', 'n', 'g', 'e', ':', ' ', '%', 'f'], ".../std/format/internal/write.d", 1722LU, null, null, 0u)` is not constant
.../std/format/package.d(1370):        while evaluating: `static assert(!e)`
test.d(5): Error: template instance `std.format.format!("%f", int[])` error instantiating
```

After:

```
.../std/format/package.d(1370): Error: static assert:  "Incorrect format specifier for range: %f"
test.d(5):        instantiated from here: `format!("%f", int[])`
```

No test because (AFAIK) we can't test static assert error messages in Phobos.