### PR TITLE
Cleanup temp files in libphobos unittest at src/std/process.d

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2581,6 +2581,7 @@ private auto executeImpl(alias pipeFunc, Cmd, ExtraPipeFuncArgs...)(
 
     ReturnType!executeShell r;
     auto tmpname = uniqueTempPath;
+    scope(exit) if (exists(tmpname)) remove(tmpname);
     auto t = stderr;
     // Open a new scope to minimize code ran with stderr redirected.
     {


### PR DESCRIPTION
Hi,

I've noticed that a couple temp files are leaked after each full
gcc test-suite run.

I'd like to fix that by the following patch.


Bootstrapped and reg-tested on x86_64-pc-linux-gnu.
Is it OK for trunk?


Thanks
Bernd.