### PR TITLE
Annotate with `return` or `return scope` to please dlang/dmd#12520

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1601,7 +1601,7 @@ if (isInputRange!InputRange &&
             {
                 if (!__ctfe && canSearchInCodeUnits!char(needle))
                 {
-                    static R trustedMemchr(ref R haystack, ref E needle) @trusted nothrow pure
+                    static inout(R) trustedMemchr(ref return scope inout(R) haystack, ref const scope E needle) @trusted nothrow pure
                     {
                         import core.stdc.string : memchr;
                         auto ptr = memchr(haystack.ptr, needle, haystack.length);
@@ -1665,7 +1665,7 @@ if (isInputRange!InputRange &&
         {
             import std.algorithm.comparison : max, min;
 
-            R findHelper(ref R haystack, ref E needle) @trusted nothrow pure
+            R findHelper(return scope ref R haystack, ref E needle) @trusted nothrow pure
             {
                 import core.stdc.string : memchr;
 

--- a/std/base64.d
+++ b/std/base64.d
@@ -218,7 +218,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  The slice of $(D_PARAM buffer) that contains the encoded string.
      */
     @trusted
-    pure char[] encode(R1, R2)(in R1 source, R2 buffer) if (isArray!R1 && is(ElementType!R1 : ubyte) &&
+    pure char[] encode(R1, R2)(in R1 source, return scope R2 buffer) if (isArray!R1 && is(ElementType!R1 : ubyte) &&
                                                             is(R2 == char[]))
     in
     {
@@ -981,7 +981,7 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  base alphabet of the current Base64 encoding scheme.
      */
     @trusted
-    pure ubyte[] decode(R1, R2)(in R1 source, R2 buffer) if (isArray!R1 && is(ElementType!R1 : dchar) &&
+    pure ubyte[] decode(R1, R2)(in R1 source, return scope R2 buffer) if (isArray!R1 && is(ElementType!R1 : dchar) &&
                                                              is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     in
     {

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -246,7 +246,7 @@ public:
      * Implements assignment operators from built-in integers of the form
      * `BigInt op= integer`.
      */
-    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe
+    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe return
         if ((op=="+" || op=="-" || op=="*" || op=="/" || op=="%"
           || op==">>" || op=="<<" || op=="^^" || op=="|" || op=="&" || op=="^") && isIntegral!T)
     {
@@ -414,7 +414,7 @@ public:
     /**
      * Implements assignment operators of the form `BigInt op= BigInt`.
      */
-    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe
+    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe scope return
         if ((op=="+" || op== "-" || op=="*" || op=="|" || op=="&" || op=="^" || op=="/" || op=="%")
             && is (T: BigInt))
     {
@@ -472,13 +472,14 @@ public:
     /**
      * Implements binary operators between `BigInt`s.
      */
-    BigInt opBinary(string op, T)(T y) pure nothrow @safe const
+    BigInt opBinary(string op, T)(T y) pure nothrow @safe const return scope
         if ((op=="+" || op == "*" || op=="-" || op=="|" || op=="&" || op=="^" ||
             op=="/" || op=="%")
             && is (T: BigInt))
     {
         BigInt r = this;
-        return r.opOpAssign!(op)(y);
+        r.opOpAssign!(op)(y);
+        return r;
     }
 
     ///
@@ -1454,19 +1455,19 @@ public:
     }
 
 private:
-    void negate() @safe pure nothrow @nogc
+    void negate() @safe pure nothrow @nogc scope
     {
         if (!data.isZero())
             sign = !sign;
     }
-    bool isZero() pure const nothrow @nogc @safe
+    bool isZero() pure const nothrow @nogc @safe scope
     {
         return data.isZero();
     }
     alias isNegative = sign;
 
     // Generate a runtime error if division by zero occurs
-    void checkDivByZero() pure const nothrow @safe
+    void checkDivByZero() pure const nothrow @safe scope
     {
         assert(!isZero(), "BigInt division by zero");
     }

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1598,7 +1598,7 @@ public:
     /**********************************************
      * Reverses the bits of the `BitArray`.
      */
-    @property BitArray reverse() @nogc pure nothrow
+    @property BitArray reverse() @nogc pure nothrow return
     out (result)
     {
         assert(result == this, "the result must be equal to this");
@@ -1638,7 +1638,7 @@ public:
     /**********************************************
      * Sorts the `BitArray`'s elements.
      */
-    @property BitArray sort() @nogc pure nothrow
+    @property BitArray sort() @nogc pure nothrow return
     out (result)
     {
         assert(result == this, "the result must be equal to this");
@@ -2063,7 +2063,7 @@ public:
     /***************************************
      * Support for operator op= for `BitArray`.
      */
-    BitArray opOpAssign(string op)(const BitArray e2) @nogc pure nothrow
+    BitArray opOpAssign(string op)(const BitArray e2) @nogc pure nothrow return scope
         if (op == "-" || op == "&" || op == "|" || op == "^")
     in
     {
@@ -2184,7 +2184,7 @@ public:
      * shared between BitArray objects. i.e. D dynamic array
      * concatenation semantics are not followed)
      */
-    BitArray opOpAssign(string op)(bool b) pure nothrow
+    BitArray opOpAssign(string op)(bool b) pure nothrow return scope
         if (op == "~")
     {
         length = _len + 1;
@@ -2214,7 +2214,7 @@ public:
     /***************************************
      * ditto
      */
-    BitArray opOpAssign(string op)(BitArray b) pure nothrow
+    BitArray opOpAssign(string op)(BitArray b) pure nothrow return scope
         if (op == "~")
     {
         auto istart = _len;

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -127,19 +127,19 @@ nothrow @safe pure:
     }
 
     @property
-    bool empty() const
+    bool empty() const scope
     {
         assert((_first is null) == (_last is null), "DList.Range: Invalidated state");
         return !_first;
     }
 
-    @property BaseNode* front()
+    @property BaseNode* front() return scope
     {
         assert(!empty, "DList.Range.front: Range is empty");
         return _first;
     }
 
-    void popFront()
+    void popFront() scope
     {
         assert(!empty, "DList.Range.popFront: Range is empty");
         if (_first is _last)
@@ -153,13 +153,13 @@ nothrow @safe pure:
         }
     }
 
-    @property BaseNode* back()
+    @property BaseNode* back() return scope
     {
         assert(!empty, "DList.Range.front: Range is empty");
         return _last;
     }
 
-    void popBack()
+    void popBack() scope
     {
         assert(!empty, "DList.Range.popBack: Range is empty");
         if (_first is _last)
@@ -174,7 +174,7 @@ nothrow @safe pure:
     }
 
     /// Forward range primitive.
-    @property DRange save() { return this; }
+    @property DRange save() return scope { return this; }
 }
 
 /**

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -540,7 +540,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
         }
 
         pure nothrow @safe @nogc
-        private void[] smallAlloc(uint blocks)
+        private void[] smallAlloc(uint blocks) return scope
         {
             assert(blocks >= 2 && blocks <= 64);
             void[] result;
@@ -596,7 +596,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
         }
 
         pure nothrow @trusted @nogc
-        private void[] hugeAlloc(size_t blocks)
+        private void[] hugeAlloc(size_t blocks) return scope
         {
             assert(blocks > 64);
             if (_startIdx == _control._rep.length)
@@ -978,7 +978,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
             }
         }
 
-        void[] allocateAll()
+        void[] allocateAll() return scope
         {
             static if (isShared)
             {

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -303,7 +303,7 @@ Aligns a pointer down to a specified alignment. The resulting pointer is less
 than or equal to the given pointer.
 */
 @nogc nothrow pure
-package void* alignDownTo(void* ptr, uint alignment)
+package void* alignDownTo(return scope void* ptr, uint alignment)
 {
     import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);
@@ -315,7 +315,7 @@ Aligns a pointer up to a specified alignment. The resulting pointer is greater
 than or equal to the given pointer.
 */
 @nogc nothrow pure
-package void* alignUpTo(void* ptr, uint alignment)
+package void* alignUpTo(return scope void* ptr, uint alignment)
 {
     import std.math.traits : isPowerOf2;
     assert(alignment.isPowerOf2);

--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -194,13 +194,16 @@ version (USE_SSSE3)
     /**
      * Chooses the instruction sequence based on the 32bit or 64bit model.
      */
-    private nothrow pure string[] swt3264(string[] insn32, string[] insn64)
+    version (_32Bit)
     {
-        version (_32Bit)
+        private nothrow pure string[] swt3264(return scope string[] insn32, scope string[] insn64)
         {
             return insn32;
         }
-        version (_64Bit)
+    }
+    version (_64Bit)
+    {
+        private nothrow pure string[] swt3264(scope string[] insn32, return scope string[] insn64)
         {
             return insn64;
         }

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -245,12 +245,12 @@ private:
 
     immutable(BigDigit) [] data = ZERO;
 
-    this(immutable(BigDigit) [] x) pure nothrow @nogc @safe
+    this(immutable(BigDigit) [] x) pure nothrow @nogc @trusted scope // TODO @safe when -dip1000 understand scope of immutable arrays
     {
        data = x;
     }
   package(std)  // used from: std.bigint
-    this(T)(T x) pure nothrow @safe if (isIntegral!T)
+    this(T)(T x) pure nothrow @safe scope if (isIntegral!T)
     {
         opAssign(x);
     }
@@ -260,7 +260,7 @@ private:
     };
 public:
     // Length in uints
-    @property size_t uintLength() pure nothrow const @safe @nogc
+    @property size_t uintLength() pure nothrow const @safe @nogc scope
     {
         static if (BigDigit.sizeof == uint.sizeof)
         {
@@ -272,7 +272,7 @@ public:
             ((data[$-1] & 0xFFFF_FFFF_0000_0000L) ? 1 : 0);
         }
     }
-    @property size_t ulongLength() pure nothrow const @safe @nogc
+    @property size_t ulongLength() pure nothrow const @safe @nogc scope
     {
         static if (BigDigit.sizeof == uint.sizeof)
         {
@@ -285,7 +285,7 @@ public:
     }
 
     // The value at (cast(ulong[]) data)[n]
-    ulong peekUlong(size_t n) pure nothrow const @safe @nogc
+    ulong peekUlong(size_t n) pure nothrow const @safe @nogc scope
     {
         static if (BigDigit.sizeof == int.sizeof)
         {
@@ -298,7 +298,7 @@ public:
         }
     }
 
-    uint peekUint(size_t n) pure nothrow const @safe @nogc
+    uint peekUint(size_t n) pure nothrow const @safe @nogc scope
     {
         static if (BigDigit.sizeof == int.sizeof)
         {
@@ -312,7 +312,7 @@ public:
     }
 
     ///
-    void opAssign(Tulong)(Tulong u) pure nothrow @safe if (is (Tulong == ulong))
+    void opAssign(Tulong)(Tulong u) pure nothrow @safe scope if (is (Tulong == ulong))
     {
         if (u == 0) data = ZERO;
         else if (u == 1) data = ONE;
@@ -339,13 +339,13 @@ public:
             }
         }
     }
-    void opAssign(Tdummy = void)(BigUint y) pure nothrow @nogc @safe
+    void opAssign(Tdummy = void)(BigUint y) pure nothrow @nogc @safe scope
     {
         this.data = y.data;
     }
 
     ///
-    int opCmp(Tdummy = void)(const BigUint y) pure nothrow @nogc const @safe
+    int opCmp(Tdummy = void)(const BigUint y) pure nothrow @nogc const @safe scope
     {
         if (data.length != y.data.length)
             return (data.length > y.data.length) ?  1 : -1;
@@ -356,7 +356,7 @@ public:
     }
 
     ///
-    int opCmp(Tulong)(Tulong y) pure nothrow @nogc const @safe if (is (Tulong == ulong))
+    int opCmp(Tulong)(Tulong y) pure nothrow @nogc const @safe scope if (is (Tulong == ulong))
     {
         if (data.length > maxBigDigits!Tulong)
             return 1;
@@ -382,12 +382,12 @@ public:
         return 0;
     }
 
-    bool opEquals(Tdummy = void)(ref const BigUint y) pure nothrow @nogc const @safe
+    bool opEquals(Tdummy = void)(ref const BigUint y) pure nothrow @nogc const @safe scope
     {
            return y.data[] == data[];
     }
 
-    bool opEquals(Tdummy = void)(ulong y) pure nothrow @nogc const @safe
+    bool opEquals(Tdummy = void)(ulong y) pure nothrow @nogc const @safe scope
     {
         if (data.length > 2)
             return false;
@@ -400,18 +400,18 @@ public:
         return (data[0] == ylo);
     }
 
-    bool isZero() pure const nothrow @safe @nogc
+    bool isZero() pure const nothrow @safe @nogc scope
     {
         return data.length == 1 && data[0] == 0;
     }
 
-    size_t numBytes() pure nothrow const @safe @nogc
+    size_t numBytes() pure nothrow const @safe @nogc scope
     {
         return data.length * BigDigit.sizeof;
     }
 
     // the extra bytes are added to the start of the string
-    char [] toDecimalString(int frontExtraBytes) const pure nothrow @safe
+    char [] toDecimalString(int frontExtraBytes) const pure nothrow @safe scope
     {
         immutable predictlength = 20+20*(data.length/2); // just over 19
         char [] buff = new char[frontExtraBytes + predictlength];
@@ -428,7 +428,7 @@ public:
      */
     char [] toHexString(int frontExtraBytes, char separator = 0,
             int minPadding=0, char padChar = '0',
-            LetterCase letterCase = LetterCase.upper) const pure nothrow @safe
+            LetterCase letterCase = LetterCase.upper) const pure nothrow @safe scope
     {
         // Calculate number of extra padding bytes
         size_t extraPad = (minPadding > data.length * 2 * BigDigit.sizeof)
@@ -492,7 +492,7 @@ public:
     /**
      * Convert to an octal string.
      */
-    char[] toOctalString() pure nothrow @safe const
+    char[] toOctalString() pure nothrow @safe const scope
     {
         auto predictLength = 1 + data.length*BigDigitBits / 3;
         char[] buff = new char[predictLength];
@@ -501,7 +501,7 @@ public:
     }
 
     // return false if invalid character found
-    bool fromHexString(Range)(Range s) if (
+    bool fromHexString(Range)(Range s) scope if (
         isBidirectionalRange!Range && isSomeChar!(ElementType!Range))
     {
         import std.range : walkLength;
@@ -570,7 +570,7 @@ public:
     }
 
     // return true if OK; false if erroneous characters found
-    bool fromDecimalString(Range)(Range s) if (
+    bool fromDecimalString(Range)(Range s) scope if (
         isForwardRange!Range && isSomeChar!(ElementType!Range))
     {
         import std.range : walkLength;
@@ -595,7 +595,7 @@ public:
         return true;
     }
 
-    void fromMagnitude(Range)(Range magnitude)
+    void fromMagnitude(Range)(Range magnitude) scope
         if (isInputRange!Range
             && (isForwardRange!Range || hasLength!Range)
             && isUnsigned!(ElementType!Range))
@@ -734,7 +734,7 @@ public:
     }
 
     // return x << y
-    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const
+    BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const scope
         if (op == "<<" && is (Tulong == ulong))
     {
         assert(y > 0, "Can not left shift BigUint by 0");
@@ -813,7 +813,7 @@ public:
 
     // If wantSub is false, return x + y, leaving sign unchanged.
     // If wantSub is true, return abs(x - y), negating sign if x<y
-    static BigUint addOrSub(BigUint x, BigUint y, bool wantSub, bool *sign)
+    static BigUint addOrSub(scope BigUint x, scope BigUint y, bool wantSub, bool *sign)
         pure nothrow @safe
     {
         BigUint r;
@@ -858,7 +858,7 @@ public:
 
     /*  return x * y.
      */
-    static BigUint mul(BigUint x, BigUint y) pure nothrow @safe
+    static BigUint mul(scope BigUint x, scope BigUint y) pure nothrow @safe
     {
         if (y == 0 || x == 0)
             return BigUint(ZERO);
@@ -879,7 +879,7 @@ public:
     }
 
     // return x / y
-    static BigUint divInt(T)(BigUint x, T y_) pure nothrow @safe
+    static BigUint divInt(T)(scope return BigUint x, T y_) pure nothrow @safe
     if ( is(immutable T == immutable uint) )
     {
         uint y = y_;
@@ -905,7 +905,7 @@ public:
         return BigUint(removeLeadingZeros(trustedAssumeUnique(result)));
     }
 
-    static BigUint divInt(T)(BigUint x, T y) pure nothrow @safe
+    static BigUint divInt(T)(scope BigUint x, T y) pure nothrow @safe
     if ( is(immutable T == immutable ulong) )
     {
         if (y <= uint.max)
@@ -921,7 +921,7 @@ public:
     }
 
     // return x % y
-    static uint modInt(T)(BigUint x, T y_) pure if ( is(immutable T == immutable uint) )
+    static uint modInt(T)(scope BigUint x, T y_) pure if ( is(immutable T == immutable uint) )
     {
         import core.memory : GC;
         uint y = y_;
@@ -942,7 +942,7 @@ public:
     }
 
     // return x / y
-    static BigUint div(BigUint x, BigUint y) pure nothrow @safe
+    static BigUint div(scope return BigUint x, scope BigUint y) pure nothrow @safe
     {
         if (y.data.length > x.data.length)
             return BigUint(ZERO);
@@ -954,7 +954,7 @@ public:
     }
 
     // return x % y
-    static BigUint mod(BigUint x, BigUint y) pure nothrow @safe
+    static BigUint mod(scope return BigUint x, scope BigUint y) pure nothrow @safe
     {
         if (y.data.length > x.data.length) return x;
         if (y.data.length == 1)
@@ -968,16 +968,20 @@ public:
     }
 
     // Return x / y in quotient, x % y in remainder
-    static void divMod(BigUint x, BigUint y, out BigUint quotient, out BigUint remainder) pure nothrow @safe
+    static void divMod(scope return BigUint x, scope return BigUint y, scope out BigUint quotient, scope out BigUint remainder) pure nothrow @safe
     {
         if (y.data.length > x.data.length)
         {
             quotient = 0uL;
-            remainder = x;
+            () @trusted { // TODO remove when `scope return` understands out parameters
+                remainder = x;
+            } ();
         }
         else if (y.data.length == 1)
         {
-            quotient = divInt(x, y.data[0]);
+            () @trusted { // TODO remove when `scope return` understands out parameters
+                quotient = divInt(x, y.data[0]);
+            } ();
             remainder = BigUint([modInt(x, y.data[0])]);
         }
         else
@@ -991,7 +995,7 @@ public:
     }
 
     // return x op y
-    static BigUint bitwiseOp(string op)(BigUint x, BigUint y, bool xSign, bool ySign, ref bool resultSign)
+    static BigUint bitwiseOp(string op)(scope BigUint x, scope BigUint y, bool xSign, bool ySign, ref bool resultSign)
     pure nothrow @safe if (op == "|" || op == "^" || op == "&")
     {
         auto d1 = includeSign(x.data, y.uintLength, xSign);
@@ -1018,7 +1022,7 @@ public:
      * exponentiation is used.
      * Memory allocation is minimized: at most one temporary BigUint is used.
      */
-    static BigUint pow(BigUint x, ulong y) pure nothrow @safe
+    static BigUint pow(scope return BigUint x, ulong y) pure nothrow @safe
     {
         // Deal with the degenerate cases first.
         if (y == 0) return BigUint(ONE);
@@ -1226,7 +1230,7 @@ public:
     }
 
     // Implement toHash so that BigUint works properly as an AA key.
-    size_t toHash() const @nogc nothrow pure @safe
+    size_t toHash() const @nogc nothrow pure @safe scope
     {
         return .hashOf(data);
     }
@@ -1257,7 +1261,7 @@ public:
 }
 
 // Remove leading zeros from x, to restore the BigUint invariant
-inout(BigDigit) [] removeLeadingZeros(inout(BigDigit) [] x) pure nothrow @safe
+inout(BigDigit) [] removeLeadingZeros(scope return inout(BigDigit) [] x) pure nothrow @safe
 {
     size_t k = x.length;
     while (k>1 && x[k - 1]==0) --k;
@@ -1915,7 +1919,7 @@ private:
 // every 8 digits.
 // buff.length must be data.length*8 if separator is zero,
 // or data.length*9 if separator is non-zero. It will be completely filled.
-char [] biguintToHex(char [] buff, const BigDigit [] data, char separator=0,
+char [] biguintToHex(scope return char [] buff, const scope BigDigit [] data, char separator=0,
         LetterCase letterCase = LetterCase.upper) pure nothrow @safe
 {
     int x=0;

--- a/std/json.d
+++ b/std/json.d
@@ -159,7 +159,7 @@ struct JSONValue
         return store.str;
     }
     /// ditto
-    @property string str(return scope string v) pure nothrow @nogc @safe
+    @property string str(return scope string v) pure nothrow @nogc @safe scope
     {
         assign(v);
         return v;
@@ -189,7 +189,7 @@ struct JSONValue
         return store.integer;
     }
     /// ditto
-    @property long integer(long v) pure nothrow @safe @nogc
+    @property long integer(long v) pure nothrow @safe @nogc scope
     {
         assign(v);
         return store.integer;
@@ -207,7 +207,7 @@ struct JSONValue
         return store.uinteger;
     }
     /// ditto
-    @property ulong uinteger(ulong v) pure nothrow @safe @nogc
+    @property ulong uinteger(ulong v) pure nothrow @safe @nogc scope
     {
         assign(v);
         return store.uinteger;
@@ -226,7 +226,7 @@ struct JSONValue
         return store.floating;
     }
     /// ditto
-    @property double floating(double v) pure nothrow @safe @nogc
+    @property double floating(double v) pure nothrow @safe @nogc scope
     {
         assign(v);
         return store.floating;
@@ -245,7 +245,7 @@ struct JSONValue
         throw new JSONException("JSONValue is not a boolean type");
     }
     /// ditto
-    @property bool boolean(bool v) pure nothrow @safe @nogc
+    @property bool boolean(bool v) pure nothrow @safe @nogc scope
     {
         assign(v);
         return v;
@@ -282,7 +282,7 @@ struct JSONValue
         return store.object;
     }
     /// ditto
-    @property JSONValue[string] object(return scope JSONValue[string] v) pure nothrow @nogc @safe
+    @property JSONValue[string] object(return scope JSONValue[string] v) pure nothrow @nogc @safe scope
     {
         assign(v);
         return v;
@@ -328,7 +328,7 @@ struct JSONValue
         return store.array;
     }
     /// ditto
-    @property JSONValue[] array(return scope JSONValue[] v) pure nothrow @nogc @safe
+    @property JSONValue[] array(return scope JSONValue[] v) pure nothrow @nogc @safe scope
     {
         assign(v);
         return v;
@@ -461,7 +461,7 @@ struct JSONValue
         assertNotThrown(json["h"].get!float);
     }
 
-    private void assign(T)(scope T arg)
+    private void assign(T)(scope T arg) scope
     {
         static if (is(T : typeof(null)))
         {
@@ -602,7 +602,7 @@ struct JSONValue
         assert(j.type == JSONType.object);
     }
 
-    void opAssign(T)(T arg) if (!isStaticArray!T && !is(T : JSONValue))
+    void opAssign(T)(T arg) scope if (!isStaticArray!T && !is(T : JSONValue))
     {
         assign(arg);
     }

--- a/std/json.d
+++ b/std/json.d
@@ -152,14 +152,14 @@ struct JSONValue
      * Throws: `JSONException` for read access if `type` is not
      * `JSONType.string`.
      */
-    @property string str() const pure @trusted
+    @property string str() const pure @trusted return scope
     {
         enforce!JSONException(type == JSONType.string,
                                 "JSONValue is not a string");
         return store.str;
     }
     /// ditto
-    @property string str(string v) pure nothrow @nogc @safe
+    @property string str(return scope string v) pure nothrow @nogc @safe
     {
         assign(v);
         return v;
@@ -282,7 +282,7 @@ struct JSONValue
         return store.object;
     }
     /// ditto
-    @property JSONValue[string] object(JSONValue[string] v) pure nothrow @nogc @safe
+    @property JSONValue[string] object(return scope JSONValue[string] v) pure nothrow @nogc @safe
     {
         assign(v);
         return v;
@@ -328,7 +328,7 @@ struct JSONValue
         return store.array;
     }
     /// ditto
-    @property JSONValue[] array(JSONValue[] v) pure nothrow @nogc @safe
+    @property JSONValue[] array(return scope JSONValue[] v) pure nothrow @nogc @safe
     {
         assign(v);
         return v;
@@ -461,7 +461,7 @@ struct JSONValue
         assertNotThrown(json["h"].get!float);
     }
 
-    private void assign(T)(T arg)
+    private void assign(T)(scope T arg)
     {
         static if (is(T : typeof(null)))
         {
@@ -635,7 +635,7 @@ struct JSONValue
      * Hash syntax for json objects.
      * Throws: `JSONException` if `type` is not `JSONType.object`.
      */
-    ref inout(JSONValue) opIndex(string k) inout pure @safe
+    ref inout(JSONValue) opIndex(return scope string k) inout pure @safe return
     {
         auto o = this.objectNoRef;
         return *enforce!JSONException(k in o,

--- a/std/net/isemail.d
+++ b/std/net/isemail.d
@@ -1303,37 +1303,37 @@ struct EmailStatus
     }
 
     /// Returns: If the email address is valid or not.
-    @property bool valid() const @safe @nogc pure nothrow
+    @property bool valid() const @safe @nogc pure nothrow scope
     {
         return valid_;
     }
 
     /// Returns: The local part of the email address, that is, the part before the @ sign.
-    @property string localPart() const @safe @nogc pure nothrow
+    @property string localPart() const @safe @nogc pure nothrow return scope
     {
         return localPart_;
     }
 
     /// Returns: The domain part of the email address, that is, the part after the @ sign.
-    @property string domainPart() const @safe @nogc pure nothrow
+    @property string domainPart() const @safe @nogc pure nothrow return scope
     {
         return domainPart_;
     }
 
     /// Returns: The email status code
-    @property EmailStatusCode statusCode() const @safe @nogc pure nothrow
+    @property EmailStatusCode statusCode() const @safe @nogc pure nothrow scope
     {
         return statusCode_;
     }
 
     /// Returns: A describing string of the status code
-    @property string status() const @safe @nogc pure nothrow
+    @property string status() const @safe @nogc pure nothrow scope
     {
         return statusCodeDescription(statusCode_);
     }
 
     /// Returns: A textual representation of the email status
-    string toString() const @safe pure
+    string toString() const @safe pure scope
     {
         import std.format : format;
         return format("EmailStatus\n{\n\tvalid: %s\n\tlocalPart: %s\n\tdomainPart: %s\n\tstatusCode: %s\n}", valid,

--- a/std/path.d
+++ b/std/path.d
@@ -115,13 +115,13 @@ version (StdUnittest)
 private:
     struct TestAliasedString
     {
-        string get() @safe @nogc pure nothrow { return _s; }
+        string get() @safe @nogc pure nothrow return scope { return _s; }
         alias get this;
         @disable this(this);
         string _s;
     }
 
-    bool testAliasedString(alias func, Args...)(string s, Args args)
+    bool testAliasedString(alias func, Args...)(scope string s, scope Args args)
     {
         return func(TestAliasedString(s), args) == func(s, args);
     }
@@ -406,14 +406,14 @@ else static assert(0);
     the POSIX requirements for the 'basename' shell utility)
     (with suitable adaptations for Windows paths).
 */
-auto baseName(R)(R path)
+auto baseName(R)(return scope R path)
 if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) && !isSomeString!R)
 {
     return _baseName(path);
 }
 
 /// ditto
-auto baseName(C)(C[] path)
+auto baseName(C)(return scope C[] path)
 if (isSomeChar!C)
 {
     return _baseName(path);
@@ -421,7 +421,7 @@ if (isSomeChar!C)
 
 /// ditto
 inout(C)[] baseName(CaseSensitive cs = CaseSensitive.osDefault, C, C1)
-    (inout(C)[] path, in C1[] suffix)
+    (return scope inout(C)[] path, in C1[] suffix)
     @safe pure //TODO: nothrow (because of filenameCmp())
 if (isSomeChar!C && isSomeChar!C1)
 {
@@ -522,7 +522,7 @@ if (isSomeChar!C && isSomeChar!C1)
     assert(sa.baseName == "test");
 }
 
-private R _baseName(R)(R path)
+private R _baseName(R)(return scope R path)
 if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) || isNarrowString!R)
 {
     auto p1 = stripDrive(path);
@@ -1910,7 +1910,7 @@ if (isSomeChar!C)
         normalized path as a forward range
 */
 
-auto asNormalizedPath(R)(R path)
+auto asNormalizedPath(R)(return scope R path)
 if (isSomeChar!(ElementEncodingType!R) &&
     (isRandomAccessRange!R && hasSlicing!R && hasLength!R || isNarrowString!R) &&
     !isConvertibleToString!R)
@@ -2077,7 +2077,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
     }
 }
 
-auto asNormalizedPath(R)(auto ref R path)
+auto asNormalizedPath(R)(return scope auto ref R path)
 if (isConvertibleToString!R)
 {
     return asNormalizedPath!(StringTypeOf!R)(path);
@@ -2747,7 +2747,7 @@ else version (Posix)
     See_Also:
         $(LREF asAbsolutePath) which does not allocate
 */
-string absolutePath(string path, lazy string base = getcwd())
+string absolutePath(return scope string path, lazy string base = getcwd())
     @safe pure
 {
     import std.array : array;

--- a/std/process.d
+++ b/std/process.d
@@ -3628,7 +3628,7 @@ string escapeShellCommand(scope const(char[])[] args...) @safe pure
             assert(escapeShellCommand(test.args) == test.posix  );
 }
 
-private string escapeShellCommandString(string command) @safe pure
+private string escapeShellCommandString(return scope string command) @safe pure
 {
     version (Windows)
         return escapeWindowsShellCommand(command);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -12159,7 +12159,7 @@ private:
         @property int front() @safe const pure nothrow { return 0; }
         enum bool empty = false;
         void popFront() @safe pure nothrow { }
-        @property auto save() @safe pure nothrow { return this; }
+        @property auto save() @safe pure nothrow return scope { return this; }
     }
 
     S s;
@@ -12174,7 +12174,7 @@ private:
         @property int front() @safe const pure nothrow { return 0; }
         @property bool empty() @safe const pure nothrow { return false; }
         void popFront() @safe pure nothrow { }
-        @property auto save() @safe pure nothrow { return this; }
+        @property auto save() @safe pure nothrow return scope { return this; }
     }
     static assert(isForwardRange!C);
 

--- a/std/socket.d
+++ b/std/socket.d
@@ -1394,12 +1394,12 @@ protected:
 
 
 public:
-    override @property sockaddr* name()
+    override @property sockaddr* name() return
     {
         return &sa;
     }
 
-    override @property const(sockaddr)* name() const
+    override @property const(sockaddr)* name() const return
     {
         return &sa;
     }
@@ -1475,12 +1475,12 @@ protected:
 
 
 public:
-    override @property sockaddr* name()
+    override @property sockaddr* name() return
     {
         return cast(sockaddr*)&sin;
     }
 
-    override @property const(sockaddr)* name() const
+    override @property const(sockaddr)* name() const return
     {
         return cast(const(sockaddr)*)&sin;
     }
@@ -1729,12 +1729,12 @@ protected:
 
 
 public:
-    override @property sockaddr* name()
+    override @property sockaddr* name() return
     {
         return cast(sockaddr*)&sin6;
     }
 
-    override @property const(sockaddr)* name() const
+    override @property const(sockaddr)* name() const return
     {
         return cast(const(sockaddr)*)&sin6;
     }
@@ -1969,12 +1969,12 @@ static if (is(sockaddr_un))
         }
 
     public:
-        override @property sockaddr* name()
+        override @property sockaddr* name() return
         {
             return cast(sockaddr*)&sun;
         }
 
-        override @property const(sockaddr)* name() const
+        override @property const(sockaddr)* name() const return
         {
             return cast(const(sockaddr)*)&sun;
         }

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -952,7 +952,7 @@ Throws: `Exception` if the file is not opened.
 
  Returns: The name last used to initialize this this file, or `null` otherwise.
  */
-    @property string name() const @safe pure nothrow
+    @property string name() const @safe pure nothrow return
     {
         return _name;
     }

--- a/std/string.d
+++ b/std/string.d
@@ -148,13 +148,13 @@ version (StdUnittest)
 private:
     struct TestAliasedString
     {
-        string get() @safe @nogc pure nothrow { return _s; }
+        string get() @safe @nogc pure nothrow return scope { return _s; }
         alias get this;
         @disable this(this);
         string _s;
     }
 
-    bool testAliasedString(alias func, Args...)(string s, Args args)
+    bool testAliasedString(alias func, Args...)(scope string s, scope Args args)
     {
         import std.algorithm.comparison : equal;
         auto a = func(TestAliasedString(s), args);
@@ -6432,7 +6432,7 @@ if (isConvertibleToString!Range)
  * See_Also:
  *  $(LREF soundexer)
  */
-char[] soundex(scope const(char)[] str, char[] buffer = null)
+char[] soundex(scope const(char)[] str, return scope char[] buffer = null)
     @safe pure nothrow
 in
 {
@@ -6937,7 +6937,7 @@ void main() {
  *     StringException if indentation is done with different sequences
  *     of whitespace characters.
  */
-S[] outdent(S)(S[] lines) @safe pure
+S[] outdent(S)(return scope S[] lines) @safe pure
 if (isSomeString!S)
 {
     import std.algorithm.searching : startsWith;

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -5922,7 +5922,7 @@ pure:
         return _idx == size_t.max;
     }
 
-    @property DecompressedIntervals save() { return this; }
+    @property DecompressedIntervals save() return scope { return this; }
 }
 
 @safe pure nothrow @nogc unittest
@@ -8563,7 +8563,7 @@ enum {
     In cases where the string in question is already normalized,
     it is returned unmodified and no memory allocation happens.
 +/
-inout(C)[] normalize(NormalizationForm norm=NFC, C)(inout(C)[] input)
+inout(C)[] normalize(NormalizationForm norm=NFC, C)(return scope inout(C)[] input)
 {
     import std.algorithm.mutation : SwapStrategy;
     import std.algorithm.sorting : sort;
@@ -8750,7 +8750,7 @@ private size_t recompose(size_t start, dchar[] input, ubyte[] ccc) pure nothrow 
 // returns tuple of 2 indexes that delimit:
 // normalized text, piece that needs normalization and
 // the rest of input starting with stable code point
-private auto splitNormalized(NormalizationForm norm, C)(const(C)[] input)
+private auto splitNormalized(NormalizationForm norm, C)(scope const(C)[] input)
 {
     import std.typecons : tuple;
     ubyte lastCC = 0;

--- a/std/utf.d
+++ b/std/utf.d
@@ -81,7 +81,7 @@ class UTFException : UnicodeException
     size_t  len;
 
     @safe pure nothrow @nogc
-    UTFException setSequence(scope uint[] data...)
+    UTFException setSequence(scope uint[] data...) return
     {
         assert(data.length <= 4);
 
@@ -3104,7 +3104,7 @@ if (isPointer!P && isSomeChar!(typeof(*P.init)))
     auto p6 = toUTFz!(immutable(dchar)*)("hello world"w);
 }
 
-private P toUTFzImpl(P, S)(S str) @safe pure
+private P toUTFzImpl(P, S)(return scope S str) @safe pure
 if (is(immutable typeof(*P.init) == typeof(str[0])))
 //immutable(C)[] -> C*, const(C)*, or immutable(C)*
 {
@@ -3147,7 +3147,7 @@ if (is(immutable typeof(*P.init) == typeof(str[0])))
     }
 }
 
-private P toUTFzImpl(P, S)(S str) @safe pure
+private P toUTFzImpl(P, S)(return scope S str) @safe pure
 if (is(typeof(str[0]) C) && is(immutable typeof(*P.init) == immutable C) && !is(C == immutable))
 //C[] or const(C)[] -> C*, const(C)*, or immutable(C)*
 {

--- a/std/xml.d
+++ b/std/xml.d
@@ -433,7 +433,7 @@ enum DecodeMode
  * writefln(decode("a &gt; b")); // writes "a > b"
  * --------------
  */
-string decode(string s, DecodeMode mode=DecodeMode.LOOSE) @safe pure
+string decode(return scope string s, DecodeMode mode=DecodeMode.LOOSE) @safe pure
 {
     import std.algorithm.searching : startsWith;
 


### PR DESCRIPTION
Unblocks dlang/dmd#12520.

`make -f posix.mak unittest` passes locally for me now when using dlang/dmd#12520.

There are a couple of places where I had to qualify as `@trusted` to silence. I've commented those places with a TODO.

Furthermore, there are several places where I have no idea how to explain to the compiler that the code should compile when lambdas inside `map` and `file`. For instance,

```d
@safe unittest
{
    string[] listdir(string pathname)
    {
        import std.algorithm;
        import std.array;
        import std.file;
        import std.path;

        return std.file.dirEntries(pathname, SpanMode.shallow)
            .filter!(a => a.isFile)
            .map!(a => std.path.baseName(a.name))
            .array;
    }

    void main(string[] args)
    {
        import std.stdio;

        string[] files = listdir(args[1]);
        writefln("%s", files);
     }
}
```

erroring as

```
std/file.d(4987): Error: returning `baseName(a.name())` escapes a reference to parameter `a`
std/file.d(4987):        perhaps annotate the parameter with `return`
std/algorithm/iteration.d(524):        instantiated from here: `MapResult!(__lambda3, FilterResult!(__lambda2, DirIterator))`
std/file.d(4987):        instantiated from here: `map!(FilterResult!(__lambda2, DirIterator))`
```

Not even qualifying `listdir` as `@trusted` silences the diagnostics. Shouldn't it?