### PR TITLE
std.traits: Fix unittest for isNumeric

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -6418,7 +6418,7 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(immutable T == immuta
         alias val this;
     }
 
-    static assert(!isIntegral!S);
+    static assert(!isNumeric!S);
 }
 
 @safe unittest


### PR DESCRIPTION
Looks like a copy-paste error from a similar unit test for std.traits.isIntegral.