### PR TITLE
Revert "Annotate std/path.d to please dlang/dmd#12520"

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -115,13 +115,13 @@ version (StdUnittest)
 private:
     struct TestAliasedString
     {
-        string get() @safe @nogc pure nothrow return scope { return _s; }
+        string get() @safe @nogc pure nothrow { return _s; }
         alias get this;
         @disable this(this);
         string _s;
     }
 
-    bool testAliasedString(alias func, Args...)(scope string s, scope Args args)
+    bool testAliasedString(alias func, Args...)(string s, Args args)
     {
         return func(TestAliasedString(s), args) == func(s, args);
     }
@@ -406,14 +406,14 @@ else static assert(0);
     the POSIX requirements for the 'basename' shell utility)
     (with suitable adaptations for Windows paths).
 */
-auto baseName(R)(return scope R path)
+auto baseName(R)(R path)
 if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) && !isSomeString!R)
 {
     return _baseName(path);
 }
 
 /// ditto
-auto baseName(C)(return scope C[] path)
+auto baseName(C)(C[] path)
 if (isSomeChar!C)
 {
     return _baseName(path);
@@ -421,7 +421,7 @@ if (isSomeChar!C)
 
 /// ditto
 inout(C)[] baseName(CaseSensitive cs = CaseSensitive.osDefault, C, C1)
-    (return scope inout(C)[] path, in C1[] suffix)
+    (inout(C)[] path, in C1[] suffix)
     @safe pure //TODO: nothrow (because of filenameCmp())
 if (isSomeChar!C && isSomeChar!C1)
 {
@@ -522,7 +522,7 @@ if (isSomeChar!C && isSomeChar!C1)
     assert(sa.baseName == "test");
 }
 
-private R _baseName(R)(return scope R path)
+private R _baseName(R)(R path)
 if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) || isNarrowString!R)
 {
     auto p1 = stripDrive(path);
@@ -1910,7 +1910,7 @@ if (isSomeChar!C)
         normalized path as a forward range
 */
 
-auto asNormalizedPath(R)(return scope R path)
+auto asNormalizedPath(R)(R path)
 if (isSomeChar!(ElementEncodingType!R) &&
     (isRandomAccessRange!R && hasSlicing!R && hasLength!R || isNarrowString!R) &&
     !isConvertibleToString!R)
@@ -2077,7 +2077,7 @@ if (isSomeChar!(ElementEncodingType!R) &&
     }
 }
 
-auto asNormalizedPath(R)(return scope auto ref R path)
+auto asNormalizedPath(R)(auto ref R path)
 if (isConvertibleToString!R)
 {
     return asNormalizedPath!(StringTypeOf!R)(path);
@@ -2747,7 +2747,7 @@ else version (Posix)
     See_Also:
         $(LREF asAbsolutePath) which does not allocate
 */
-string absolutePath(return scope string path, lazy string base = getcwd())
+string absolutePath(string path, lazy string base = getcwd())
     @safe pure
 {
     import std.array : array;


### PR DESCRIPTION
Reverts dlang/phobos#8090

Something broke master, and this is the only change that touches absolutePath. 