### PR TITLE
[stable] std.format.internal.write: Replace brittle runtime check by compile-time check

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -2313,11 +2313,7 @@ if (is(T == class) && !is(T == enum))
         }
         else
         {
-            // string delegate() dg = &val.toString;
-            Object o = val;     // workaround
-            string delegate() dg = &o.toString;
-            scope Object object = new Object();
-            if (dg.funcptr != (&object.toString).funcptr) // toString is overridden
+            static if (!is(__traits(parent, T.toString) == Object)) // not inherited Object.toString
             {
                 formatObject(w, val, f);
             }


### PR DESCRIPTION
When checking whether `T.toString` for some class `T` is inherited from base class `Object`.

The runtime check fails when using a druntime DLL on Windows, where `Object.toString` in other DLLs/executables is a trampoline (in the druntime import library) to the dllimported function, with its own identity.