### PR TITLE
merge stable

### DIFF
--- a/changelog/formatting_floats_nogc.dd
+++ b/changelog/formatting_floats_nogc.dd
@@ -1,4 +1,4 @@
-Floating point numbers don't allocate with the GC anymore.
+Formatting floating point numbers don't allocate with the GC anymore.
 
 The implementation of formatting floating point numbers has been
 reworked. We made sure that working examples never allocate with the

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -2285,11 +2285,7 @@ if (is(T == class) && !is(T == enum))
         }
         else
         {
-            // string delegate() dg = &val.toString;
-            Object o = val;     // workaround
-            string delegate() dg = &o.toString;
-            scope Object object = new Object();
-            if (dg.funcptr != (&object.toString).funcptr) // toString is overridden
+            static if (!is(__traits(parent, T.toString) == Object)) // not inherited Object.toString
             {
                 formatObject(w, val, f);
             }


### PR DESCRIPTION
- Fix wording in changelog regarding formatting floats is @nogc.
- std.format.internal.write: Replace brittle runtime check by compile-time check
