### PR TITLE
Annotate more of phobos with `return` and `scope`

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1074,7 +1074,7 @@ Params:
 */
 void move(T)(ref T source, ref T target)
 {
-    moveImpl(source, target);
+    moveImpl(target, source);
 }
 
 /// For non-struct types, `move` just performs `target = source`:
@@ -1244,7 +1244,7 @@ pure nothrow @safe @nogc unittest
     static assert(is(typeof({ S s; move(s, s); }) == T));
 }
 
-private void moveImpl(T)(ref T source, ref T target)
+private void moveImpl(T)(ref scope T target, ref return scope T source)
 {
     import std.traits : hasElaborateDestructor;
 
@@ -1257,10 +1257,10 @@ private void moveImpl(T)(ref T source, ref T target)
         static if (hasElaborateDestructor!T) target.__xdtor();
     }
     // move and emplace source into target
-    moveEmplaceImpl(source, target);
+    moveEmplaceImpl(target, source);
 }
 
-private T moveImpl(T)(ref T source)
+private T moveImpl(T)(ref return scope T source)
 {
     // Properly infer safety from moveEmplaceImpl as the implementation below
     // might void-initialize pointers in result and hence needs to be @trusted
@@ -1269,10 +1269,10 @@ private T moveImpl(T)(ref T source)
     return trustedMoveImpl(source);
 }
 
-private T trustedMoveImpl(T)(ref T source) @trusted
+private T trustedMoveImpl(T)(ref return scope T source) @trusted
 {
     T result = void;
-    moveEmplaceImpl(source, result);
+    moveEmplaceImpl(result, source);
     return result;
 }
 
@@ -1415,7 +1415,7 @@ private T trustedMoveImpl(T)(ref T source) @trusted
     move(x, x);
 }
 
-private void moveEmplaceImpl(T)(ref T source, ref T target)
+private void moveEmplaceImpl(T)(ref scope T target, ref return scope T source)
 {
     import core.stdc.string : memcpy, memset;
     import std.traits : hasAliasing, hasElaborateAssign,
@@ -1486,7 +1486,7 @@ private void moveEmplaceImpl(T)(ref T source, ref T target)
  */
 void moveEmplace(T)(ref T source, ref T target) pure @system
 {
-    moveEmplaceImpl(source, target);
+    moveEmplaceImpl(target, source);
 }
 
 ///
@@ -2388,7 +2388,7 @@ Range remove(alias pred, SwapStrategy s = SwapStrategy.stable, Range)(Range rang
 @nogc @safe unittest
 {
     // @nogc test
-    int[10] arr = [0,1,2,3,4,5,6,7,8,9];
+    static int[] arr = [0,1,2,3,4,5,6,7,8,9];
     alias pred = e => e < 5;
 
     auto r = arr[].remove!(SwapStrategy.unstable)(0);

--- a/std/array.d
+++ b/std/array.d
@@ -1953,7 +1953,7 @@ private enum bool hasCheapIteration(R) = isArray!R;
    See_Also:
         For a lazy version, see $(REF joiner, std,algorithm,iteration)
   +/
-ElementEncodingType!(ElementType!RoR)[] join(RoR, R)(RoR ror, scope R sep)
+ElementEncodingType!(ElementType!RoR)[] join(RoR, R)(RoR ror, R sep)
 if (isInputRange!RoR &&
     isInputRange!(Unqual!(ElementType!RoR)) &&
     isInputRange!R &&

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -1702,7 +1702,7 @@ package:
         Params:
             isoExtString = A string which represents a time zone in the ISO format.
       +/
-    static immutable(SimpleTimeZone) fromISOExtString(S)(S isoExtString) @safe pure
+    static immutable(SimpleTimeZone) fromISOExtString(S)(scope S isoExtString) @safe pure
         if (isSomeString!S)
     {
         import std.algorithm.searching : startsWith;

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -761,7 +761,7 @@ public:
 
     // If wantSub is false, return x + y, leaving sign unchanged
     // If wantSub is true, return abs(x - y), negating sign if x < y
-    static BigUint addOrSubInt(Tulong)(const BigUint x, Tulong y,
+    static BigUint addOrSubInt(Tulong)(const scope BigUint x, Tulong y,
             bool wantSub, ref bool sign) pure nothrow @safe if (is(Tulong == ulong))
     {
         BigUint r;
@@ -1380,7 +1380,7 @@ pure nothrow @safe
 }
 
 // Encode BigInt as BigDigit array (sign and 2's complement)
-BigDigit[] includeSign(const(BigDigit) [] x, size_t minSize, bool sign)
+BigDigit[] includeSign(scope const(BigDigit) [] x, size_t minSize, bool sign)
 pure nothrow @safe
 {
     size_t length = (x.length > minSize) ? x.length : minSize;

--- a/std/path.d
+++ b/std/path.d
@@ -558,14 +558,14 @@ if (isRandomAccessRange!R && hasSlicing!R && isSomeChar!(ElementType!R) || isNar
     the POSIX requirements for the 'dirname' shell utility)
     (with suitable adaptations for Windows paths).
 */
-auto dirName(R)(R path)
+auto dirName(R)(return scope R path)
 if (isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) && !isSomeString!R)
 {
     return _dirName(path);
 }
 
 /// ditto
-auto dirName(C)(C[] path)
+auto dirName(C)(return scope C[] path)
 if (isSomeChar!C)
 {
     return _dirName(path);
@@ -662,7 +662,7 @@ if (isSomeChar!C)
     //static assert(dirName("dir/file".byChar).array == "dir");
 }
 
-private auto _dirName(R)(R path)
+private auto _dirName(R)(return scope R path)
 {
     static auto result(bool dot, typeof(path[0 .. 1]) p)
     {
@@ -1448,7 +1448,7 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
     Returns: The assembled path.
 */
 immutable(ElementEncodingType!(ElementType!Range))[]
-    buildPath(Range)(Range segments)
+    buildPath(Range)(scope Range segments)
     if (isInputRange!Range && !isInfinite!Range && isSomeString!(ElementType!Range))
 {
     if (segments.empty) return null;
@@ -2747,7 +2747,7 @@ else version (Posix)
     See_Also:
         $(LREF asAbsolutePath) which does not allocate
 */
-string absolutePath(return scope string path, lazy string base = getcwd())
+string absolutePath(string path, lazy string base = getcwd())
     @safe pure
 {
     import std.array : array;
@@ -2893,7 +2893,7 @@ if (isConvertibleToString!R)
     `Exception` if the specified _base directory is not absolute.
 */
 string relativePath(CaseSensitive cs = CaseSensitive.osDefault)
-    (scope return string path, lazy string base = getcwd())
+    (string path, lazy string base = getcwd())
 {
     if (!isAbsolute(path))
         return path;

--- a/std/process.d
+++ b/std/process.d
@@ -276,7 +276,7 @@ static:
     multi-threaded programs. See e.g.
     $(LINK2 https://www.gnu.org/software/libc/manual/html_node/Environment-Access.html#Environment-Access, glibc).
     */
-    inout(char)[] opIndexAssign(inout char[] value, scope const(char)[] name) @trusted
+    inout(char)[] opIndexAssign(return inout char[] value, scope const(char)[] name) @trusted
     {
         version (Posix)
         {

--- a/std/random.d
+++ b/std/random.d
@@ -3362,8 +3362,8 @@ if (isRandomAccessRange!Range)
     // Optionally @nogc std.random.randomCover
     // https://issues.dlang.org/show_bug.cgi?id=14001
     auto rng = Xorshift(123_456_789);
-    int[5] sa = [1, 2, 3, 4, 5];
-    auto r = randomCover(sa[], rng);
+    static immutable int[] sa = [1, 2, 3, 4, 5];
+    auto r = randomCover(sa, rng);
     assert(!r.empty);
     const x = r.front;
     r.popFront();

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7708,7 +7708,7 @@ if (isForwardRange!RangeOfRanges &&
 @safe unittest
 {
     import std.algorithm.comparison : equal;
-    ulong[1] t0 = [ 123 ];
+    ulong[] t0 = [ 123 ];
 
     assert(!hasAssignableElements!(typeof(t0[].chunks(1))));
     assert(!is(typeof(transposed(t0[].chunks(1)))));
@@ -10850,7 +10850,7 @@ if (isInputRange!Range && !isInstanceOf!(SortedRange, Range))
     into a `SortedRange`, it extracts the original range back out of the `SortedRange`
     using $(REF, move, std,algorithm,mutation).
 */
-    auto release()
+    auto release() return scope
     {
         import std.algorithm.mutation : move;
         return move(_input);

--- a/std/string.d
+++ b/std/string.d
@@ -154,7 +154,7 @@ private:
         string _s;
     }
 
-    bool testAliasedString(alias func, Args...)(scope string s, scope Args args)
+    bool testAliasedString(alias func, Args...)(string s, Args args)
     {
         import std.algorithm.comparison : equal;
         auto a = func(TestAliasedString(s), args);
@@ -2632,8 +2632,12 @@ if (isSomeChar!C)
 
     enum S : string { a = "hello\nworld" }
     assert(S.a.splitLines() == ["hello", "world"]);
+}
 
-    char[S.a.length] sa = S.a[];
+@system pure nothrow unittest
+{
+    // dip1000 cannot express an array of scope arrays, so this is not @safe
+    char[11] sa = "hello\nworld";
     assert(sa.splitLines() == ["hello", "world"]);
 }
 


### PR DESCRIPTION
Continuation of https://github.com/dlang/phobos/pull/8076, but for https://github.com/dlang/dmd/pull/12010 instead of https://github.com/dlang/dmd/pull/10924

I'm still figuring out what to do with range functions like `array`, `text` and `toCase`. `scope` fails to be inferred for simple `char[]` cases, but putting `scope` on them forces every InputRange it's called on to be `scope` compatible, while a generic `InputRange` can escape its innards through global variables or Exceptions. Not that I *want* to support such ranges, but it would make transitioning to `-dip1000` more diffcult for users, so it may be better to leave them be and use work-arounds for current Phobos functions that need them to be `scope`, like I did in `std.getopt` by replacing `split` (not `scope` compatible, returns array of slices)  with `splitter` (lazy, `scope` compatible).