### PR TITLE
Add `return scope` to xml.toType

### DIFF
--- a/std/xml.d
+++ b/std/xml.d
@@ -2959,7 +2959,7 @@ private alias Err = CheckException;
 
 private
 {
-    inout(T) toType(T)(inout Object o)
+    inout(T) toType(T)(inout return scope Object o)
     {
         T t = cast(T)(o);
         if (t is null)


### PR DESCRIPTION
Split off from https://github.com/dlang/phobos/pull/8113

