### PR TITLE
Use `icmp` instead of `toUpper` in getopt

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1108,7 +1108,7 @@ private bool optMatch(string arg, scope string optPattern, ref string value,
 {
     import std.algorithm.iteration : splitter;
     import std.string : indexOf;
-    import std.uni : toUpper;
+    import std.uni : icmp;
     //writeln("optMatch:\n  ", arg, "\n  ", optPattern, "\n  ", value);
     //scope(success) writeln("optMatch result: ", value);
     if (arg.length < 2 || arg[0] != optionChar) return false;
@@ -1151,7 +1151,7 @@ private bool optMatch(string arg, scope string optPattern, ref string value,
     foreach (v; splitter(optPattern, "|"))
     {
         //writeln("Trying variant: ", v, " against ", arg);
-        if (arg == v || !cfg.caseSensitive && toUpper(arg) == toUpper(v))
+        if (arg == v || (!cfg.caseSensitive && icmp(arg, v) == 0))
             return true;
         if (cfg.bundling && !isLong && v.length == 1
                 && indexOf(arg, v) >= 0)


### PR DESCRIPTION
Part of https://github.com/dlang/phobos/pull/8113

The loop variable `v` is inferred `scope`, while `toUpper` simply accepts `string`. The input of `toUpper` could be annotated `return scope`, but that depends on the template `toCase` being inferred correctly.