### PR TITLE
Use `static foreach` for correct `scope` inference

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -932,7 +932,8 @@ if (Ranges.length > 0 &&
         public:
             this(R input)
             {
-                foreach (i, v; input)
+                // Must be static foreach because of https://issues.dlang.org/show_bug.cgi?id=21209
+                static foreach (i, v; input)
                 {
                     source[i] = v;
                 }


### PR DESCRIPTION
Part of https://github.com/dlang/phobos/pull/8113

Turns `foreach` over an AliasSeq into `static foreach` because of [issue 21209 - scope attribute inference with does not work well with foreach](https://issues.dlang.org/show_bug.cgi?id=21209). Without this, `text` and `chain` are not `scope` compatible.