### PR TITLE
[stable] std.format.internal.floats: Restore compilability of unittests for targets with quadruple `real` precision

### DIFF
--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -261,12 +261,19 @@ if (is(T == float) || is(T == double)
     assert(printFloat(0.0, f) == "0x0p+0");
     assert(printFloat(-0.0, f) == "-0x0p+0");
 
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
-    assert(printFloat(0.0L, f) == "0x0p+0");
-    assert(printFloat(-0.0L, f) == "-0x0p+0");
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+        assert(printFloat(0.0L, f) == "0x0p+0");
+        assert(printFloat(-0.0L, f) == "-0x0p+0");
+    }
 
     import std.math.operations : nextUp;
 
@@ -1367,12 +1374,19 @@ printFloat_done:
 
 @safe unittest
 {
-    auto f = FormatSpec!dchar("");
-    f.spec = 'e';
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        auto f = FormatSpec!dchar("");
+        f.spec = 'e';
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+    }
 }
 
 @safe unittest
@@ -1461,14 +1475,21 @@ printFloat_done:
 
 @safe unittest
 {
-    auto f = FormatSpec!dchar("");
-    f.spec = 'e';
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
-    assert(printFloat(0.0L, f) == "0.000000e+00");
-    assert(printFloat(-0.0L, f) == "-0.000000e+00");
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        auto f = FormatSpec!dchar("");
+        f.spec = 'e';
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+        assert(printFloat(0.0L, f) == "0.000000e+00");
+        assert(printFloat(-0.0L, f) == "-0.000000e+00");
+    }
 
     static if (real.mant_dig == 64)
     {
@@ -2169,14 +2190,21 @@ printFloat_done:
 
 @safe unittest
 {
-    auto f = FormatSpec!dchar("");
-    f.spec = 'f';
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
-    assert(printFloat(0.0L, f) == "0.000000");
-    assert(printFloat(-0.0L, f) == "-0.000000");
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        auto f = FormatSpec!dchar("");
+        f.spec = 'f';
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+        assert(printFloat(0.0L, f) == "0.000000");
+        assert(printFloat(-0.0L, f) == "-0.000000");
+    }
 
     static if (real.mant_dig == 64)
     {
@@ -2696,14 +2724,21 @@ if (is(T == float) || is(T == double)
 
 @safe unittest
 {
-    char[256] buf;
-    auto f = FormatSpec!dchar("");
-    f.spec = 'g';
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        char[256] buf;
+        auto f = FormatSpec!dchar("");
+        f.spec = 'g';
 
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+    }
 }
 
 @safe unittest
@@ -2779,14 +2814,21 @@ if (is(T == float) || is(T == double)
 
 @safe unittest
 {
-    auto f = FormatSpec!dchar("");
-    f.spec = 'g';
-    assert(printFloat(real.nan, f) == "nan");
-    assert(printFloat(-real.nan, f) == "-nan");
-    assert(printFloat(real.infinity, f) == "inf");
-    assert(printFloat(-real.infinity, f) == "-inf");
-    assert(printFloat(0.0L, f) == "0");
-    assert(printFloat(-0.0L, f) == "-0");
+    static if (real.mant_dig > 64)
+    {
+        pragma(msg, "printFloat tests disabled because of unsupported `real` format");
+    }
+    else
+    {
+        auto f = FormatSpec!dchar("");
+        f.spec = 'g';
+        assert(printFloat(real.nan, f) == "nan");
+        assert(printFloat(-real.nan, f) == "-nan");
+        assert(printFloat(real.infinity, f) == "inf");
+        assert(printFloat(-real.infinity, f) == "-inf");
+        assert(printFloat(0.0L, f) == "0");
+        assert(printFloat(-0.0L, f) == "-0");
+    }
 
     static if (real.mant_dig == 64)
     {


### PR DESCRIPTION
Such as non-Apple AArch64; `printFloat()` doesn't support that format.