### PR TITLE
std.conv: Avoid undefined bytes in toChars() results for radix 10

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5719,7 +5719,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
             char[(UT.sizeof == 4) ? 10 + isSigned!T : 20] buf = void;
         }
 
-        Result result = void;
+        Result result;
         result.initialize(value);
         return result;
     }
@@ -5806,6 +5806,8 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
 {
     import std.array;
     import std.range;
+
+    assert(toChars(123) == toChars(123));
 
     {
         assert(toChars!2(0u).array == "0");


### PR DESCRIPTION
The buffer is initialized from right-to-left in `initialize()`, and unused bytes are left alone. Previously, the whole result wasn't preinitialized with `T.init`, so the unused buffer bytes weren't well-defined. Initialize it now (with zeros), as the whole buffer is still used for equality/identity comparisons etc.