### PR TITLE
container.array: RangeT: (front|back|opIndex): pure nothrow.

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -114,12 +114,12 @@ private struct RangeT(A)
     }
     alias opDollar = length;
 
-    @property ref inout(E) front() inout
+    @property ref inout(E) front() inout pure nothrow
     {
         assert(!empty, "Attempting to access the front of an empty Array");
         return _outer[_a];
     }
-    @property ref inout(E) back() inout
+    @property ref inout(E) back() inout pure nothrow
     {
         assert(!empty, "Attempting to access the back of an empty Array");
         return _outer[_b - 1];
@@ -167,7 +167,7 @@ private struct RangeT(A)
         }
     }
 
-    ref inout(E) opIndex(size_t i) inout
+    ref inout(E) opIndex(size_t i) inout pure nothrow
     {
         assert(_a + i < _b,
             "Attempting to fetch using an out of bounds index on an Array");


### PR DESCRIPTION
Currently, this Pull-Request is more of a Request-for-Comments (or Request-for-Guidance).

`std.container.array`: `RangeT`:

Since `front`, `back` and `opIndex` return a reference, I feel they can be `nothrow` (and, therefore, should be `nothrow`).

BTW, for `nothrow`, is the "can=>should" inference always true, please ?

Also, could they not also be `@pure` (just like `empty` and `length`) ?

BTW, for `@pure`, is the "can=>should" inference always true, please ?

Testing information:

    $ cd std/container/
    $ rdmd -unittest --main array.d
    1 modules passed unittests

Thank you for considering this.