### PR TITLE
Fix Issue 20393 - formattedRead accepts input, that should be rejected

### DIFF
--- a/std/format/read.d
+++ b/std/format/read.d
@@ -710,3 +710,11 @@ T unformatValue(T, Range, Char)(ref Range input, scope const ref FormatSpec!Char
     assert(result[0] == 'a');
 }
 
+@safe pure unittest
+{
+    import std.exception : assertThrown;
+    string str = "foo 12a-buzz";
+    string a, c;
+    int b;
+    assertThrown(formattedRead(str, "%s %d-%s", &a, &b, &c));
+}

--- a/std/format/read.d
+++ b/std/format/read.d
@@ -710,6 +710,7 @@ T unformatValue(T, Range, Char)(ref Range input, scope const ref FormatSpec!Char
     assert(result[0] == 'a');
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=20393
 @safe pure unittest
 {
     import std.exception : assertThrown;

--- a/std/format/spec.d
+++ b/std/format/spec.d
@@ -538,7 +538,9 @@ if (is(Unqual!Char == Char))
                 {
                     assert(!r.empty, "Required at least one more input");
                     // Require a '%'
-                    if (r.front != '%') break;
+                    enforceFmt (r.front == '%',
+                        text("parseToFormatSpec: Cannot find character '",
+                             c2, "' in the input string."));
                     trailing = trailing[2 .. $];
                     r.popFront();
                 }
@@ -560,10 +562,9 @@ if (is(Unqual!Char == Char))
                 }
                 else
                 {
-                    enforceFmt(!r.empty,
+                    enforceFmt(!r.empty && r.front == trailing.front,
                         text("parseToFormatSpec: Cannot find character '",
                              c, "' in the input string."));
-                    if (r.front != trailing.front) break;
                     r.popFront();
                 }
                 trailing = trailing[stride(trailing, 0) .. $];


### PR DESCRIPTION
Function readUpToNextSpec in std/format/spec.d returned false when it encountered some specific types of errors and threw an exception on other types, however this wasn't taken into account in formattedRead in which it was assumed that readUpToNextSpec always threw exception. The change makes it so that readUpToNextSpec throws an exception instead of returning false. 