### PR TITLE
cirrus-ci: bump OS CI versions to latest and keep last LTS supported

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,14 +52,14 @@ task:
 
 # FreeBSD
 task:
-  name: FreeBSD 12.1 x64
+  name: FreeBSD 13.0 x64
   freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-13-0
     cpu: 4
     memory: 8G
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
-    CI_DFLAGS: -version=TARGET_FREEBSD12
+    CI_DFLAGS: -version=TARGET_FREEBSD13
   install_bash_and_git_script: pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,17 @@ task:
 
 # Mac
 task:
+  name: macOS 11 x64
+  osx_instance:
+    image: big-sur-xcode
+  timeout_in: 60m
+  environment:
+    OS_NAME: darwin
+    # override Cirrus default OS (`darwin`)
+    OS: osx
+  << : *COMMON_STEPS_TEMPLATE
+
+task:
   name: macOS 10.15 x64
   osx_instance:
     image: catalina-xcode
@@ -61,5 +72,18 @@ task:
   environment:
     OS_NAME: freebsd
     CI_DFLAGS: -version=TARGET_FREEBSD13
+  install_bash_and_git_script: pkg install -y bash git
+  << : *COMMON_STEPS_TEMPLATE
+
+task:
+  name: FreeBSD 12.2 x64
+  freebsd_instance:
+    image_family: freebsd-12-2
+    cpu: 4
+    memory: 8G
+  timeout_in: 60m
+  environment:
+    OS_NAME: freebsd
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_and_git_script: pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,9 +24,24 @@ environment:
 
 # Linux
 task:
-  name: Ubuntu 16.04 $TASK_NAME_SUFFIX
+  name: Ubuntu 20.04 $TASK_NAME_SUFFIX
   container:
-    image: ubuntu:16.04
+    image: ubuntu:20.04
+    cpu: 4
+    memory: 8G
+  timeout_in: 60m
+  environment:
+    matrix:
+      - TASK_NAME_SUFFIX: x86
+        MODEL: 32
+      - TASK_NAME_SUFFIX: x64
+  install_git_script: apt-get -q update && apt-get install -yq git-core
+  << : *COMMON_STEPS_TEMPLATE
+
+task:
+  name: Ubuntu 18.04 $TASK_NAME_SUFFIX
+  container:
+    image: ubuntu:18.04
     cpu: 4
     memory: 8G
   timeout_in: 60m


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---
Read the patch notes.