### PR TITLE
azure-pipelines.yml: Reduce timeout time to 60 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
 
 jobs:
   - job: Windows
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -42,7 +42,7 @@ jobs:
         displayName: Build and test
 
   - job: Windows_VisualD
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:


### PR DESCRIPTION
Working pipelines finish within 30 minutes, this prevents choking up the PR queue when there are real issues going on that cause Azure CI to stop and stall until the timeout limit.

(Also, cirrus CI timeout is set at 60m too).
https://github.com/dlang/phobos/blob/73e51d395ebee36029f337b3b97bd5efbcb694a4/.cirrus.yml#L32