### PR TITLE
merge stable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -54,14 +54,10 @@ ifneq ($(BUILD),release)
     endif
 endif
 
-# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# default to PIC, use PIC=1/0 to en-/disable PIC.
 # Note that shared libraries and C files are always compiled with PIC.
 ifeq ($(PIC),)
-    ifeq ($(MODEL),64) # x86_64
-        PIC:=1
-    else
-        PIC:=0
-    endif
+    PIC:=1
 endif
 ifeq ($(PIC),1)
     override PIC:=-fPIC

--- a/std/traits.d
+++ b/std/traits.d
@@ -6348,7 +6348,7 @@ template isIntegral(T)
 /**
  * Detect whether `T` is a built-in floating point type.
  */
-enum bool isFloatingPoint(T) = __traits(isFloating, T) && !is(T : ireal) && !is(T : creal);
+enum bool isFloatingPoint(T) = __traits(isFloating, T) && is(T : real);
 
 ///
 @safe unittest
@@ -6392,16 +6392,28 @@ enum bool isFloatingPoint(T) = __traits(isFloating, T) && !is(T : ireal) && !is(
             static assert(!isFloatingPoint!(Q!T));
         }
     }
+    static if (is(__vector(float[4])))
+    {
+        static assert(!isFloatingPoint!(__vector(float[4])));
+    }
 }
 
 /**
  * Detect whether `T` is a built-in numeric type (integral or floating
  * point).
  */
-enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(immutable T == immutable bool) ||
-                                                        is(immutable T == immutable char) ||
-                                                        is(immutable T == immutable wchar) ||
-                                                        is(immutable T == immutable dchar));
+template isNumeric(T)
+{
+    static if (!__traits(isArithmetic, T))
+        enum isNumeric = false;
+    else static if (__traits(isFloating, T))
+        enum isNumeric = is(T : real); // Not __vector, imaginary, or complex.
+    else static if (is(T U == enum))
+        enum isNumeric = isNumeric!U;
+    else
+        enum isNumeric = __traits(isZeroInit, T) // Not char, wchar, or dchar.
+            && !is(immutable T == immutable bool) && !is(T == __vector);
+}
 
 ///
 @safe unittest
@@ -6453,6 +6465,21 @@ enum bool isNumeric(T) = __traits(isArithmetic, T) && !(is(immutable T == immuta
         alias t this;
     }
     static assert(!isNumeric!(S!int));
+
+    enum EChar : char { a = 0, }
+    static assert(!isNumeric!EChar);
+
+    static if (is(__vector(float[4])))
+    {
+        static assert(!isNumeric!(__vector(float[4])));
+    }
+    static if (is(__vector(int[4])))
+    {
+        static assert(!isNumeric!(__vector(int[4])));
+    }
+
+    static assert(!isNumeric!ifloat);
+    static assert(!isNumeric!cfloat);
 }
 
 /**
@@ -6514,10 +6541,16 @@ enum bool isBasicType(T) = isScalarType!T || is(immutable T == immutable void);
 /**
  * Detect whether `T` is a built-in unsigned numeric type.
  */
-enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(immutable T == immutable char) ||
-                                                       is(immutable T == immutable wchar) ||
-                                                       is(immutable T == immutable dchar) ||
-                                                       is(immutable T == immutable bool));
+template isUnsigned(T)
+{
+    static if (!__traits(isUnsigned, T))
+        enum isUnsigned = false;
+    else static if (is(T U == enum))
+        enum isUnsigned = isUnsigned!U;
+    else
+        enum isUnsigned = __traits(isZeroInit, T) // Not char, wchar, or dchar.
+            && !is(immutable T == immutable bool) && !is(T == __vector);
+}
 
 ///
 @safe unittest
@@ -6554,12 +6587,21 @@ enum bool isUnsigned(T) = __traits(isUnsigned, T) && !(is(immutable T == immutab
         alias t this;
     }
     static assert(!isUnsigned!(S!uint));
+
+    enum EChar : char { a = 0, }
+    static assert(!isUnsigned!EChar);
+
+    static if (is(__vector(uint[4])))
+    {
+        static assert(!isUnsigned!(__vector(uint[4])));
+    }
 }
 
 /**
  * Detect whether `T` is a built-in signed numeric type.
  */
-enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
+enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T)
+                                                  && is(T : real);
 
 ///
 @safe unittest
@@ -6598,6 +6640,14 @@ enum bool isSigned(T) = __traits(isArithmetic, T) && !__traits(isUnsigned, T);
         alias t this;
     }
     static assert(!isSigned!(S!uint));
+
+    static if (is(__vector(int[4])))
+    {
+        static assert(!isSigned!(__vector(int[4])));
+    }
+
+    static assert(!isSigned!ifloat);
+    static assert(!isSigned!cfloat);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17196

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6659,7 +6659,16 @@ assert(refCountedStore.isInitialized)).
         string toString(this This)()
         {
             import std.conv : to;
-            return to!string(refCountedPayload);
+
+            static if (autoInit)
+                return to!string(refCountedPayload);
+            else
+            {
+                if (!_refCounted.isInitialized)
+                    return This.stringof ~ "(RefCountedStore(null))";
+                else
+                    return to!string(_refCounted._store._payload);
+            }
         }
     }
 }
@@ -6797,16 +6806,23 @@ pure @system unittest
     import std.conv : to;
     // Check that string conversion is transparent for refcounted
     // structs that do not have either toString or alias this.
-    struct A { Object a; }
+    static struct A { Object a; }
     auto a  = A(new Object());
     auto r = refCounted(a);
     assert(to!string(r) == to!string(a));
     assert(to!string(cast(const) r) == to!string(cast(const) a));
     // Check that string conversion is still transparent for refcounted
     // structs that have alias this.
-    struct B { int b; alias b this; }
-    struct C { B b; alias b this; }
+    static struct B { int b; alias b this; }
+    static struct C { B b; alias b this; }
     assert(to!string(refCounted(C(B(123)))) == to!string(C(B(123))));
+    // https://issues.dlang.org/show_bug.cgi?id=22093
+    // Check that uninitialized refcounted structs that previously could be
+    // converted to strings still can be.
+    alias R = typeof(r);
+    R r2;
+    cast(void) (((const ref R a) => to!string(a))(r2));
+    cast(void) to!string(RefCounted!(A, RefCountedAutoInitialize.no).init);
 }
 
 /**


### PR DESCRIPTION
- std.math.operations: Fix out-of-bounds read in extractBitpattern()
- std.math.operations: Make extractBitpattern() @trusted
- std.math.operations: Slightly simplify extractBitpattern()
- std.math.operations: Fix extractBitpattern() unittest
- Fix 22056, 22057, 22058 - [Reg 2.074] std.traits.isFloatingPoint, isNumeric, isUnsigned, and isSigned should never be true for SIMD vectors, imaginary/complex numbers, or enums with character base types
- Fix 22093 - [Reg 2.097] std.typecons.RefCounted!T for struct T without an explicit toString or alias this previously could be converted to string even when uninitialized but now cannot
- Issue 21488 - Always compile phobos library with -fPIC on POSIX targets (#8154)
