### PR TITLE
merge stable

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2138,9 +2138,20 @@ struct Config
     enum Config inheritFDs = Config(Flags.inheritFDs); /// ditto
     enum Config detached = Config(Flags.detached); /// ditto
     enum Config stderrPassThrough = Config(Flags.stderrPassThrough); /// ditto
-    Config opBinary(string op : "|")(Config other)
+    Config opUnary(string op)()
+    if (is(typeof(mixin(op ~ q{flags}))))
     {
-        return Config(flags | other.flags);
+        return Config(mixin(op ~ q{flags}));
+    } /// ditto
+    Config opBinary(string op)(Config other)
+    if (is(typeof(mixin(q{flags} ~ op ~ q{other.flags}))))
+    {
+        return Config(mixin(q{flags} ~ op ~ q{other.flags}));
+    } /// ditto
+    Config opOpAssign(string op)(Config other)
+    if (is(typeof(mixin(q{flags} ~ op ~ q{=other.flags}))))
+    {
+        return Config(mixin(q{flags} ~ op ~ q{=other.flags}));
     } /// ditto
 
     version (StdDdoc)
@@ -2156,6 +2167,16 @@ struct Config
     {
         bool function() nothrow @nogc @safe preExecFunction;
     }
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=22125
+@safe unittest
+{
+    Config c = Config.retainStdin;
+    c |= Config.retainStdout;
+    c |= Config.retainStderr;
+    c &= ~Config.retainStderr;
+    assert(c == (Config.retainStdin | Config.retainStdout));
 }
 
 /// A handle that corresponds to a spawned process.

--- a/std/signals.d
+++ b/std/signals.d
@@ -37,10 +37,10 @@
  *      $(LINK2 http://www.digitalmars.com/d/archives/16368.html, signals and slots)$(BR)
  *
  * Bugs:
- *      $(RED Slots can only be delegates formed from class objects or
- *      interfaces to class objects. If a delegate to something else
+ *      $(RED Slots can only be delegates referring directly to
+ *      class or interface member functions. If a delegate to something else
  *      is passed to connect(), such as a struct member function,
- *      a nested function, a COM interface or a closure, undefined behavior
+ *      a nested function, a COM interface, a closure, undefined behavior
  *      will result.)
  *
  *      Not safe for multiple threads operating on the same signals
@@ -93,7 +93,8 @@ mixin template Signal(T1...)
      * The delegate must be to an instance of a class or an interface
      * to a class instance.
      * Delegates to struct instances or nested functions must not be
-     * used as slots.
+     * used as slots. This applies even if the nested function does not access
+     * it's parent function variables.
      */
     alias slot_t = void delegate(T1);
 


### PR DESCRIPTION
- Issue 19842 - only class member functions must be used be used as slots
- Fix Issue 22125 - std.process.Config was changed to a struct but miss operator overloads
