### PR TITLE
isSomeChar!(Unqual!T) -> isSomeChar!T

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3153,7 +3153,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
 
         /// Range primitive implementations.
         void put(A)(scope A writeme)
-            if ((isSomeChar!(Unqual!(ElementType!A)) ||
+            if ((isSomeChar!(ElementType!A) ||
                   is(ElementType!A : const(ubyte))) &&
                 isInputRange!A &&
                 !isInfinite!A)

--- a/std/string.d
+++ b/std/string.d
@@ -6707,7 +6707,7 @@ string[string] abbrev(string[] values) @safe pure
  */
 
 size_t column(Range)(Range str, in size_t tabsize = 8)
-if ((isInputRange!Range && isSomeChar!(Unqual!(ElementEncodingType!Range)) ||
+if ((isInputRange!Range && isSomeChar!(ElementEncodingType!Range) ||
     isNarrowString!Range) &&
     !isConvertibleToString!Range)
 {

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -331,7 +331,7 @@ public struct UUID
          *
          * For a less strict parser, see $(LREF parseUUID)
          */
-        this(T)(in T[] uuid) if (isSomeChar!(Unqual!T))
+        this(T)(in T[] uuid) if (isSomeChar!T)
         {
             import std.conv : to, parse;
             if (uuid.length < 36)


### PR DESCRIPTION
Removing the redundant `Unqual` does not change the result.