### PR TITLE
[DSSv3] Fix Issue 19727 - std.algorithm.endsWith fails to compile while startsWith succeeds

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3509,6 +3509,50 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     assert(inputRangeObject([""]).joiner("lz").equal(""));
 }
 
+@safe pure unittest
+{
+    struct inputRangeStrings
+    {
+        private string[] strings;
+
+        string front()
+        {
+            return strings[0];
+        }
+
+        void popFront()
+        {
+            strings = strings[1..$];
+        }
+
+        bool empty() const
+        {
+           return strings.length == 0;
+        }
+    }
+
+    auto arr = inputRangeStrings([""]);
+
+    import std.algorithm.comparison : equal;
+
+    assert(arr.joiner("./").equal(""));
+}
+
+@safe pure unittest
+{
+    auto r = joiner(["", "", "abc", "", ""], "");
+    char[] res;
+    while (!r.empty)
+    {
+        res ~= r.back;
+        r.popBack;
+    }
+
+    import std.algorithm.comparison : equal;
+
+    assert(res.equal("cba"));
+}
+
 
 /// Ditto
 auto joiner(RoR)(RoR r)

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3412,7 +3412,48 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
         assert(resFront.equal("ȘȚabcȘȚ"));
         assert(resBack.equal("ȘȚcbaȘȚ"));
     }
+
+    {
+        import std.algorithm.comparison : equal;
+        auto r = [""];
+        r.popBack;
+        assert(r.joiner("AB").equal(""));
+    }
+
+    {
+        auto r = ["", "", "", "abc", ""].joiner("../");
+        auto rCopy = r.save;
+
+        char[] resFront;
+        char[] resBack;
+
+        while (!r.empty)
+        {
+            resFront ~= r.front;
+            r.popFront;
+        }
+
+        while (!rCopy.empty)
+        {
+            resBack ~= rCopy.back;
+            rCopy.popBack;
+        }
+
+        import std.algorithm.comparison : equal;
+
+        assert(resFront.equal("../../../abc../"));
+        assert(resBack.equal("../cba../../../"));
+    }
 }
+
+@system unittest
+{
+    import std.range;
+    import std.algorithm.comparison : equal;
+
+    assert(inputRangeObject([""]).joiner("lz").equal(""));
+}
+
 
 /// Ditto
 auto joiner(RoR)(RoR r)

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1274,6 +1274,16 @@ if (isInputRange!R &&
     }}
 }
 
+@safe pure unittest
+{
+    //example from issue 19727
+    import std.path : asRelativePath;
+    string[] ext = ["abc", "def", "ghi"];
+    string path = "/foo/file.def";
+    assert(ext.any!(e => path.asRelativePath("/foo").endsWith(e)) == true);
+    assert(ext.any!(e => path.asRelativePath("/foo").startsWith(e)) == false);
+}
+
 private enum bool hasConstEmptyMember(T) = is(typeof(((const T* a) => (*a).empty)(null)) : bool);
 
 // Rebindable doesn't work with structs

--- a/std/path.d
+++ b/std/path.d
@@ -3063,6 +3063,19 @@ if ((isNarrowString!R1 ||
         static assert(0);
 }
 
+@safe unittest
+{
+    version (Posix)
+    {
+        assert(isBidirectionalRange!(typeof(asRelativePath("foo/bar/baz", "/foo/woo/wee"))));
+    }
+
+    version (Windows)
+    {
+        assert(isBidirectionalRange!(typeof(asRelativePath(`c:\foo\bar`, `c:\foo\baz`))));
+    }
+}
+
 auto asRelativePath(CaseSensitive cs = CaseSensitive.osDefault, R1, R2)
     (auto ref R1 path, auto ref R2 base)
 if (isConvertibleToString!R1 || isConvertibleToString!R2)


### PR DESCRIPTION
This pull request is based on #8183. I merged the branch from #8183 into this one. I fixed this issue by implementing bidirectional range support for std.algorithm.iteration.joiner with separator. I included #8183 because std.path.asRelativePath, used in the issue example,(```ex.any!(e => t.asRelativePath("/folder").endsWith(e))```) cannot return a bidirectional range due to following reason : 
```
auto asRelativePath(CaseSensitive cs = CaseSensitive.osDefault, R1, R2)
    (R1 path, R2 base)
....
auto r1 = ".."
        .byChar
        .repeat(basePS.walkLength())
        .joiner(dirSeparator.byChar);

auto r2 = pathPS
        .joiner(dirSeparator.byChar) //issue fixed in this pull request
        .byChar; //byChar(alias of byUTF!char) cannot return a bidirectional range for non-auto-decodable ranges
                                                                       //issue fixed in my #8183 pull request
    // Return (r1 ~ sep ~ r2)
    return choose(choosePath, path.byCodeUnit, chain(r1, sep.byChar, r2));
    //ChooseResult!(ByCodeUnitImpl, Result) cannot be bidirectional due to r2
```
I also implemented some unittests and I will implement more if necessary.