### PR TITLE
Fix issue 22176: Revert #7759 "Deprecated Nullable.get warning with Appenders"

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3031,22 +3031,6 @@ struct Nullable(T)
     }
 
     /**
-     * If value is null, sets this to null, otherwise assigns
-     * `value.get` to the internally-held state. If the assignment
-     * succeeds, `this` becomes non-null.
-     *
-     * Params:
-     *     value = A value of type `Nullable!T` to assign to this `Nullable`.
-     */
-    void opAssign()(Nullable!T value)
-    {
-        if (value._isNull)
-            nullify();
-        else
-            opAssign(value.get());
-    }
-
-    /**
      * If this `Nullable` wraps a type that already has a null value
      * (such as a pointer), then assigning the null value to this
      * `Nullable` is no different than assigning any other value of
@@ -4120,6 +4104,23 @@ unittest
 {
     struct S { int i; }
     assert(S(5).nullable.apply!"a.i" == 5);
+}
+
+// regression test for https://issues.dlang.org/show_bug.cgi?id=22176
+@safe @nogc nothrow pure
+unittest
+{
+    struct S
+    {
+        int i;
+        invariant(i != 0);
+
+        // Nullable shouldn't cause S to generate an
+        // opAssign that would check the invariant.
+        Nullable!int j;
+    }
+    S s;
+    s = S(5);
 }
 
 /**


### PR DESCRIPTION
Revert https://github.com/dlang/phobos/pull/7759
`alias Nullable.get this` is removed anyways.
See https://issues.dlang.org/show_bug.cgi?id=22176
Ping @RazvanN7 