### PR TITLE
Mark RBNode.left and RBNode.right `@trusted`

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -136,9 +136,12 @@ struct RBNode(V)
      * Set the left child.  Also updates the new child's parent node.  This
      * does not update the previous child.
      *
+     * $(RED Warning: If the node this is called on is a local variable, a stack pointer can be
+     * escaped through `newNode.parent`. It's marked `@trusted` only for backwards compatibility.)
+     *
      * Returns newNode
      */
-    @property Node left(Node newNode)
+    @property Node left(return scope Node newNode) @trusted
     {
         _left = newNode;
         if (newNode !is null)
@@ -150,9 +153,12 @@ struct RBNode(V)
      * Set the right child.  Also updates the new child's parent node.  This
      * does not update the previous child.
      *
+     * $(RED Warning: If the node this is called on is a local variable, a stack pointer can be
+     * escaped through `newNode.parent`. It's marked `@trusted` only for backwards compatibility.)
+     *
      * Returns newNode
      */
-    @property Node right(Node newNode)
+    @property Node right(return scope Node newNode) @trusted
     {
         _right = newNode;
         if (newNode !is null)


### PR DESCRIPTION
Needed for https://github.com/dlang/dmd/pull/12812

`RedBlackTree` is problematic for dip1000 because it has double links: a `RBNode` stores pointers to both left/right and parent nodes, so `scope` is defeated by a single round-trip `left.parent` or `right.parent`. It can be made to work by encapsulating the tree, but `RBNode` has a public `@safe` API that stores `&this` (a `scope` pointer) in a node supplied by a parameter. In the long term, either dip1000 needs to be improved or the current `RedBlackTree` API needs to be deprecated.

Related: https://github.com/dlang/phobos/pull/6922