### PR TITLE
Fix issue 22077 - `std.sumtype` support for copy constructors is inco…

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -387,7 +387,7 @@ public:
             tag = tid;
         }
 
-        static if (isCopyable!T)
+        static if (isCopyable!(const(T)))
         {
             static if (IndexOf!(const(T), Map!(ConstOf, Types)) == tid)
             {
@@ -406,7 +406,14 @@ public:
                     tag = tid;
                 }
             }
+        }
+        else
+        {
+            @disable this(const(T) value) const;
+        }
 
+        static if (isCopyable!(immutable(T)))
+        {
             static if (IndexOf!(immutable(T), Map!(ImmutableOf, Types)) == tid)
             {
                 /// ditto
@@ -427,7 +434,6 @@ public:
         }
         else
         {
-            @disable this(const(T) value) const;
             @disable this(immutable(T) value) immutable;
         }
     }
@@ -1417,6 +1423,27 @@ version (D_BetterC) {} else
 
     Outer x;
     Outer y = x;
+}
+
+// Types with qualified copy constructors
+@safe unittest
+{
+    static struct ConstCopy
+    {
+        int n;
+        this(inout int n) inout { this.n = n; }
+        this(ref const typeof(this) other) const { this.n = other.n; }
+    }
+
+    static struct ImmutableCopy
+    {
+        int n;
+        this(inout int n) inout { this.n = n; }
+        this(ref immutable typeof(this) other) immutable { this.n = other.n; }
+    }
+
+    const SumType!ConstCopy x = const(ConstCopy)(1);
+    immutable SumType!ImmutableCopy y = immutable(ImmutableCopy)(1);
 }
 
 // Types with disabled opEquals


### PR DESCRIPTION
…mplete

Previously, SumType would define the wrong set of constructors for types
whose copyability varies depending on their mutability--a situation that
was impossible with postblits, but is now possible with copy
constructors.

---

Based on pbackus/sumtype@a4cfa0d3b14abaca24b3b03556c428a75c135fd4 and pbackus/sumtype@708630fda3e420dcde9ddb8dd62f9cfcbadaf5b6.