### PR TITLE
Fix issue #22222 - Custom unittest runner on phobos fails due to segfault on fork() exiting

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1649,14 +1649,13 @@ Removes the lock over the specified file segment.
         // the same process. fork() is used to create a second process.
         static void runForked(void delegate() code)
         {
-            import core.stdc.stdlib : exit;
             import core.sys.posix.sys.wait : waitpid;
-            import core.sys.posix.unistd : fork;
+            import core.sys.posix.unistd : fork, _exit;
             int child, status;
             if ((child = fork()) == 0)
             {
                 code();
-                exit(0);
+                _exit(0);
             }
             else
             {


### PR DESCRIPTION
Fixes #22222.

`exit(0)` call from libc does an exit sequence before exit and therefore
doesn't exit immediately. This causes problems on custom unittest runners. To
circunvent this problem we should call `_exit()` syscall to exit immediately.
In this context this is just fine to do and can prevent any future frustration
when debugging.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>