### PR TITLE
ci: circleci: bump host compiler used for bootstrapping

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.079.1
+HOST_DMD_VER=2.082.1
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 DUB=${DUB:-dub}
 N=${N:-2}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>