### PR TITLE
std.math: Reference Issue 5305 in unittest taking pointer to function

### DIFF
--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -209,6 +209,7 @@ real sqrt(real x) @nogc @safe pure nothrow { return core.math.sqrt(x); }
 
 @safe unittest
 {
+    // https://issues.dlang.org/show_bug.cgi?id=5305
     float function(float) psqrtf = &sqrt;
     assert(psqrtf != null);
     double function(double) psqrtd = &sqrt;


### PR DESCRIPTION
Was going to move test from dmd testsuite here, but I see that it already exists.