### PR TITLE
Make `throw` functions compile with dip1000 pure-scope fix

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2377,7 +2377,7 @@ Throws:
     A $(LREF ConvException) If an overflow occurred during conversion or
     if no character of the input was meaningfully converted.
 */
-auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref Source s)
+auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref scope Source s)
 if (isSomeChar!(ElementType!Source) &&
     isIntegral!Target && !is(Target == enum))
 {
@@ -2482,7 +2482,7 @@ if (isSomeChar!(ElementType!Source) &&
                 v = -v;
 
             static if (isNarrowString!Source)
-                s = cast(Source) source;
+                s = s[$-source.length..$];
 
             static if (doCount)
             {

--- a/std/utf.d
+++ b/std/utf.d
@@ -1168,7 +1168,7 @@ do
 
 /// ditto
 dchar decode(UseReplacementDchar useReplacementDchar = No.useReplacementDchar, S)(
-auto ref S str, ref size_t index) @trusted pure
+auto ref scope S str, ref size_t index) @trusted pure
 if (isSomeString!S)
 in
 {
@@ -1274,7 +1274,7 @@ do
 
 /// ditto
 dchar decodeFront(UseReplacementDchar useReplacementDchar = No.useReplacementDchar, S)(
-ref S str, out size_t numCodeUnits) @trusted pure
+ref scope S str, out size_t numCodeUnits) @trusted pure
 if (isSomeString!S)
 in
 {

--- a/std/xml.d
+++ b/std/xml.d
@@ -433,7 +433,7 @@ enum DecodeMode
  * writefln(decode("a &gt; b")); // writes "a > b"
  * --------------
  */
-string decode(return scope string s, DecodeMode mode=DecodeMode.LOOSE) @safe pure
+string decode(string s, DecodeMode mode=DecodeMode.LOOSE) @safe pure
 {
     import std.algorithm.searching : startsWith;
 


### PR DESCRIPTION
Attempt to make Phobos compile with https://github.com/dlang/dmd/pull/12989
The biggest problem so far is that range functions on narrow strings can throw exceptions on invalid encoding, so their free `scope` is gone. This does not fix the unittest build yet, and is still WIP. The `@trusted` on `put` needs to go and forcing `scope` on generic range objects is bad practice.

@nordlow 