### PR TITLE
std.range: make unittests reproducible when -boundscheck=off is present

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -12740,8 +12740,12 @@ if (isInputRange!R && isIntegral!(ElementType!R))
 
         import std.exception : assertThrown;
 
-        // Check out of bounds error
-        assertThrown!Error(bw[2 * bitsNum - 1]);
+        version (D_NoBoundsChecks) {}
+        else
+        {
+            // Check out of bounds error
+            assertThrown!Error(bw[2 * bitsNum - 1]);
+        }
 
         bw[2] = true;
         assert(bw[2] == true);


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>