### PR TITLE
std.datetime.date: make opCmp compilable on Windows with release mode

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -8374,16 +8374,19 @@ public:
      +/
     int opCmp(TimeOfDay rhs) const @safe pure nothrow @nogc
     {
+        auto _hour = this._hour;
         if (_hour < rhs._hour)
             return -1;
         if (_hour > rhs._hour)
             return 1;
 
+        auto _minute = this._minute;
         if (_minute < rhs._minute)
             return -1;
         if (_minute > rhs._minute)
             return 1;
 
+        auto _second = this._second;
         if (_second < rhs._second)
             return -1;
         if (_second > rhs._second)


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This is more of a PR to trigger a discussion on investigating this problem on DMD. Part of my journey on extensively testing Phobos, found out that this specific function, on the following specific `assert` fails by giving a wrong comparison value.

```d
assert(DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33)).opCmp(
   DateTime(Date(1999, 7, 6), TimeOfDay(12, 31, 33))) < 0);
```

This happens when compiling Phobos with `-O -release -boundscheck=off`. Phobos doesn't compile with only these arguments as the test suite blow up further with a SIGILL and adding `-g` ends successfully. It seems a stack problem and I think this should be seriously investigated.

Oddly enough, this goes away with this patch. Why? I don't really know. Moreover, this fix doesn't work particularly when variables are declared altogether like:

```d
auto _hour = this._hour;
auto _minute = this._minute;
auto _second = this._second;
```

As far as I know, @iK4tsu already experienced something similar to this sorcery and putting a copy of the variable in the function scope, solves the issue, but this time it happened on Linux.

I can't help much on this as I don't use Windows and debugging there is kinda hard to me because it requires me to host a virtual machine and my current setup struggles on doing big work inside of a VM.