### PR TITLE
Use version (StdUnittest) in std/meta.d

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -803,6 +803,7 @@ template templateNot(alias pred)
     static assert(allSatisfy!(isNoPointer, string, char, float));
 }
 
+version (StdUnittest)
 @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))
@@ -854,6 +855,7 @@ template templateAnd(Preds...)
     static assert(alwaysTrue!int);
 }
 
+version (StdUnittest)
 @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))
@@ -912,6 +914,7 @@ template templateOr(Preds...)
     static assert(!alwaysFalse!int);
 }
 
+version (StdUnittest)
 @safe unittest
 {
     static foreach (T; AliasSeq!(int, staticMap, 42))


### PR DESCRIPTION
because the symbols referenced in these unittests are defined as

```d
// Used in template predicate unit tests below.
private version (StdUnittest)
{
    template testAlways(T...)
    {
        enum testAlways = true;
    }

    template testNever(T...)
    {
        enum testNever = false;
    }

    template testError(T...)
    {
        static assert(false, "Should never be instantiated.");
    }
}
```

Trivial, @RazvanN7.
