### PR TITLE
Fix std.range.retro not behaving the same as foreach_reverse

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -236,6 +236,7 @@ public import std.typecons : Flag, Yes, No;
 
 import std.internal.attributes : betterC;
 import std.meta : allSatisfy, staticMap;
+import std.traits : ReturnType;
 import std.traits : CommonType;
 import std.traits : isFloatingPoint, isIntegral, isPointer, isStaticArray;
 import std.traits : isCallable, isSomeFunction, isInstanceOf;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -259,7 +259,9 @@ See_Also:
     $(REF reverse, std,algorithm,mutation) for mutating the source range directly.
  */
 auto retro(Range)(Range r)
-if (isBidirectionalRange!(Unqual!Range))
+if (isInputRange!Range
+    && is(typeof((Range r) => r.popBack))
+    && is(ReturnType!((Range r) => r.back) == ElementType!Range))
 {
     // Check for retro(retro(r)) and just return r in that case
     static if (is(typeof(retro(r.source)) == Range))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -481,6 +481,23 @@ pure @safe nothrow @nogc unittest
     foreach (x; data.retro) {}
 }
 
+pure @safe nothrow unittest
+{
+    struct MyRange
+    {
+        int[] data;
+
+        auto front() { return .front(data); }
+        auto back() { return .back(data); }
+        bool empty() { return .empty(data); }
+        void popFront() { .popFront(data); }
+        void popBack() { .popBack(data); }
+    }
+
+    import std.algorithm.comparison : equal;
+    assert(MyRange([1, 2, 3]).retro.equal([3, 2, 1]));
+}
+
 
 /**
 Iterates range `r` with stride `n`. If the range is a

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -289,6 +289,8 @@ if (isInputRange!Range
             alias Source = R;
 
             @property bool empty() { return source.empty; }
+
+            static if (is(ReturnType!((Range r) => r.save) == Range))
             @property auto save()
             {
                 return Result(source.save);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -236,8 +236,10 @@ public import std.typecons : Flag, Yes, No;
 
 import std.internal.attributes : betterC;
 import std.meta : allSatisfy, staticMap;
-import std.traits : CommonType, isCallable, isFloatingPoint, isIntegral,
-    isPointer, isSomeFunction, isStaticArray, Unqual, isInstanceOf;
+import std.traits : CommonType;
+import std.traits : isFloatingPoint, isIntegral, isPointer, isStaticArray;
+import std.traits : isCallable, isSomeFunction, isInstanceOf;
+import std.traits : Unqual;
 
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -151,7 +151,7 @@ $(BOOKTABLE ,
         times, or an infinite range repeating that element indefinitely.
     ))
     $(TR $(TD $(LREF retro))
-        $(TD Iterates a bidirectional range backwards.
+        $(TD Iterates a range backwards.
     ))
     $(TR $(TD $(LREF roundRobin))
         $(TD Given $(I n) ranges, creates a new range that return the $(I n)
@@ -244,17 +244,18 @@ import std.traits : Unqual;
 
 
 /**
-Iterates a bidirectional range backwards. The original range can be
-accessed by using the `source` property. Applying retro twice to
-the same range yields the original range.
+Iterates a range backwards. The original range can be accessed by using the
+`source` property. Applying retro twice to the same range yields the original
+range.
 
 Params:
-    r = the bidirectional range to iterate backwards
+    r = the range to iterate backwards.
 
 Returns:
-    A bidirectional range with length if `r` also provides a length. Or,
-    if `r` is a random access range, then the return value will be random
-    access as well.
+    An InputRange range with 'popBack' and 'back', with length if `r` also
+    provides a length. Or, if `r` is a random access range, then the return
+    value will be random access as well. If the 'r' is a ForwardRange the
+    returned range will also be a ForwardRange.
 See_Also:
     $(REF reverse, std,algorithm,mutation) for mutating the source range directly.
  */


### PR DESCRIPTION
This was first discussed on the Discord server, and it was only about the 'save' method being enforced. This PR touches only on that, but since then I've been thinking and the whole behavior should be the same as the 'foreach_reverse'.

@maxhaton said at the time he was going to analyze the code, so I would like to know his opinion as well.