### PR TITLE
std.algorithm.sorting: fix typo and related texts

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2209,7 +2209,7 @@ package(std) template HeapOps(alias less, Range)
         ~ " RandomAccessRange");
     static assert(hasLength!Range, Range.stringof ~ " must have length");
     static assert(hasSwappableElements!Range || hasAssignableElements!Range,
-        Range.stringof ~ " must have swappable of assignable Elements");
+        Range.stringof ~ " must have swappable or assignable Elements");
 
     alias lessFun = binaryFun!less;
 
@@ -2329,8 +2329,8 @@ private template TimSortImpl(alias pred, R)
         ~ " RandomAccessRange");
     static assert(hasLength!R, R.stringof ~ " must have a length");
     static assert(hasSlicing!R, R.stringof ~ " must support slicing");
-    static assert(hasAssignableElements!R, R.stringof ~ " must support"
-        ~ " assigning elements");
+    static assert(hasAssignableElements!R, R.stringof ~ " must have"
+        ~ " assignable elements");
 
     alias T = ElementType!R;
 
@@ -3571,7 +3571,7 @@ void topNImpl(alias less, R)(R r, size_t n, ref bool useSampling)
 private size_t topNPartition(alias lp, R)(R r, size_t n, bool useSampling)
 {
     import std.format : format;
-    assert(r.length >= 9 && n < r.length, "length must be longer than 9"
+    assert(r.length >= 9 && n < r.length, "length must be longer than 8"
         ~ " and n must be less than r.length");
     immutable ninth = r.length / 9;
     auto pivot = ninth / 2;
@@ -4220,8 +4220,8 @@ if (isRandomAccessRange!Range && hasLength!Range &&
     Indexes.length >= 2 && Indexes.length <= 5 &&
     allSatisfy!(isUnsigned, Indexes))
 {
-    assert(r.length >= Indexes.length, "r.length must be greater equal to"
-        ~ " Indexes.length");
+    assert(r.length >= Indexes.length, "r.length must be greater than or"
+        ~ " equal to Indexes.length");
     import std.functional : binaryFun;
     alias lt = binaryFun!less;
     enum k = Indexes.length;

--- a/std/string.d
+++ b/std/string.d
@@ -2265,8 +2265,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
         haystack = String to search for needles in.
         needles = Strings to search for in haystack.
         stopIdx = slices haystack like this $(D haystack[0 .. stopIdx]) If
-        the stopIdx is greater than or equal to the length of haystack the
-        functions returns `-1`.
+            the stopIdx is greater than or equal to the length of haystack the
+            functions returns `-1`.
         cs = Indicates whether the comparisons are case sensitive.
 */
 ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,

--- a/std/string.d
+++ b/std/string.d
@@ -1759,8 +1759,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
         haystack = String to search for needles in.
         needles = Strings to search for in haystack.
         startIdx = slices haystack like this $(D haystack[startIdx .. $]). If
-            the startIdx is greater equal the length of haystack the functions
-            returns `-1`.
+            the startIdx is greater than or equal to the length of haystack the
+            functions returns `-1`.
         cs = Indicates whether the comparisons are case sensitive.
 */
 ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
@@ -1926,8 +1926,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
         haystack = String to search for needles in.
         needles = Strings to search for in haystack.
         stopIdx = slices haystack like this $(D haystack[0 .. stopIdx]). If
-            the stopIdx is greater equal the length of haystack the functions
-            returns `-1`.
+            the stopIdx is greater than or equal to the length of haystack the
+            functions returns `-1`.
         cs = Indicates whether the comparisons are case sensitive.
 */
 ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
@@ -2105,8 +2105,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
         haystack = String to search for needles in.
         needles = Strings to search for in haystack.
         startIdx = slices haystack like this $(D haystack[startIdx .. $]). If
-            the startIdx is greater equal the length of haystack the functions
-            returns `-1`.
+            the startIdx is greater than or equal to the length of haystack the
+            functions returns `-1`.
         cs = Indicates whether the comparisons are case sensitive.
 */
 ptrdiff_t indexOfNeither(Char,Char2)(const(Char)[] haystack,
@@ -2265,8 +2265,8 @@ if (isSomeChar!Char && isSomeChar!Char2)
         haystack = String to search for needles in.
         needles = Strings to search for in haystack.
         stopIdx = slices haystack like this $(D haystack[0 .. stopIdx]) If
-        the stopIdx is greater equal the length of haystack the functions
-        returns `-1`.
+        the stopIdx is greater than or equal to the length of haystack the
+        functions returns `-1`.
         cs = Indicates whether the comparisons are case sensitive.
 */
 ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,


### PR DESCRIPTION
std.sorting.algorithm's `HeapOps` has a static assert that requests "swappable of assignable" elements, where it clearly means "or". This PR fixes that typo and since it was such a small thing I scanned through the rest of the assert texts in that module, making some other minor changes, and then looked for more of the "greater equal" language elsewhere in Phobos, and changed those to "greater than or equal to".

Note that `>= n` comparisons with "greater than [n-1]" messages are very common in std.algorithm.sorting, e.g. in `topNPartitionOffMedian`:

```d
    assert(r.length >= 12, "The length of r must be greater than 11");
```

So I adjusted the one off-by-one number down rather than use "greater than or equal" language, following this existing pattern.