### PR TITLE
Fix issue 20554 - std.algorithm.searching.all 's static assert produc…

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -122,7 +122,9 @@ template all(alias pred = "a")
     if (isInputRange!Range)
     {
         static assert(is(typeof(unaryFun!pred(range.front))),
-                "`" ~ pred.stringof[1..$-1] ~ "` isn't a unary predicate function for range.front");
+                "`" ~ (isSomeString!(typeof(pred))
+                    ? pred.stringof[1..$-1] : pred.stringof)
+                ~ "` isn't a unary predicate function for range.front");
         import std.functional : not;
 
         return find!(not!(unaryFun!pred))(range).empty;


### PR DESCRIPTION
…es a garbled error message

Currently the static assert strips the first and last character from `pred.stringof`. Illustrative drepl session:

```
D> import std;
std
D> "hi".all!isWhite
static assert:  "`sWhit` isn't a unary predicate function for range.front"
/tmp/drepl.bcFRnD/_mod1.d(10):        instantiated from here: `all!string`

D> "hi".all!(c => c.isWhite)
static assert:  "`_lambda` isn't a unary predicate function for range.front"
/tmp/drepl.bcFRnD/_mod1.d(10):        instantiated from here: `all!string`

D> "hi".all!"a.isWhite"
static assert:  "`a.isWhite` isn't a unary predicate function for range.front"
/tmp/drepl.bcFRnD/_mod1.d(10):        instantiated from here: `all!string`
```

This PR fixes this in the direction of not stripping ever, which results in embedded doublequotes while not rendering `all!X` and `all!"X"` identically.

Drepl session with the patch:

```
D> import std;
std
D> "hi".all!isWhite
static assert:  "`isWhite` isn't a unary predicate function for range.front"
/tmp/drepl.rnH8WL/_mod1.d(10):        instantiated from here: `all!string`

D> "hi".all!(c => c.isWhite)
static assert:  "`__lambda2` isn't a unary predicate function for range.front"
/tmp/drepl.rnH8WL/_mod1.d(10):        instantiated from here: `all!string`

D> "hi".all!"a.isWhite"
static assert:  "`"a.isWhite"` isn't a unary predicate function for range.front"
/tmp/drepl.rnH8WL/_mod1.d(10):        instantiated from here: `all!string`
```