### PR TITLE
Fix issue 19544 - Can't call inputRangeObject on ranges not supported by …

### DIFF
--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -100,7 +100,9 @@ interface InputRange(E) {
     ///
     @property E front();
 
-    ///
+    /**Calls $(REF moveFront, std, range, primitives) on the wrapped range, if
+     * possible. Otherwise, throws an exception.
+     */
     E moveFront();
 
     ///
@@ -162,7 +164,9 @@ interface BidirectionalRange(E) : ForwardRange!(E) {
     ///
     @property E back();
 
-    ///
+    /**Calls $(REF moveBack, std, range, primitives) on the wrapped range, if
+     * possible. Otherwise, throws an exception
+     */
     E moveBack();
 
     ///
@@ -197,7 +201,9 @@ interface RandomAccessFinite(E) : BidirectionalRange!(E) {
 
 /**Interface for an infinite random access range of type `E`.*/
 interface RandomAccessInfinite(E) : ForwardRange!E {
-    ///
+    /**Calls $(REF moveAt, std, range, primitives) on the wrapped range, if
+     * possible. Otherwise, throws an exception.
+     */
     E moveAt(size_t);
 
     ///
@@ -377,7 +383,10 @@ if (isInputRange!(Unqual!R))
             @property E front() { return _range.front; }
 
             E moveFront() {
-                return _range.moveFront();
+                static if (__traits(compiles, _range.moveFront()))
+                    return _range.moveFront();
+                else
+                    throw new Exception("Cannot move the front of a(n) `" ~ R.stringof ~ "`");
             }
 
             void popFront() { _range.popFront(); }
@@ -402,7 +411,10 @@ if (isInputRange!(Unqual!R))
                 @property E back() { return _range.back; }
 
                 E moveBack() {
-                    return _range.moveBack();
+                    static if (__traits(compiles, _range.moveFront()))
+                        return _range.moveBack();
+                    else
+                        throw new Exception("Cannot move the back of a(n) `" ~ R.stringof ~ "`");
                 }
 
                 void popBack() { return _range.popBack(); }
@@ -422,7 +434,10 @@ if (isInputRange!(Unqual!R))
                 }
 
                 E moveAt(size_t index) {
-                    return _range.moveAt(index);
+                    static if (__traits(compiles, _range.moveAt(index)))
+                        return _range.moveAt(index);
+                    else
+                        throw new Exception("Cannot move an element of a(n) `" ~ R.stringof ~ "`");
                 }
 
                 static if (hasAssignableElements!R)
@@ -567,4 +582,17 @@ template outputRangeObject(E...) {
     appWrapped.put([2, 3]);
     assert(app.data.length == 3);
     assert(equal(app.data, [1,2,3]));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=19544
+@safe unittest
+{
+    import std.range : repeat;
+
+    static struct HasCC
+    {
+        inout this(ref inout typeof(this)) {}
+    }
+
+    auto r = repeat(HasCC.init).inputRangeObject;
 }

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -101,7 +101,7 @@ interface InputRange(E) {
     @property E front();
 
     /**Calls $(REF moveFront, std, range, primitives) on the wrapped range, if
-     * possible. Otherwise, throws an exception.
+     * possible. Otherwise, throws an $(LREF UnsupportedRangeMethod) exception.
      */
     E moveFront();
 
@@ -165,7 +165,7 @@ interface BidirectionalRange(E) : ForwardRange!(E) {
     @property E back();
 
     /**Calls $(REF moveBack, std, range, primitives) on the wrapped range, if
-     * possible. Otherwise, throws an exception
+     * possible. Otherwise, throws an $(LREF UnsupportedRangeMethod) exception
      */
     E moveBack();
 
@@ -202,7 +202,7 @@ interface RandomAccessFinite(E) : BidirectionalRange!(E) {
 /**Interface for an infinite random access range of type `E`.*/
 interface RandomAccessInfinite(E) : ForwardRange!E {
     /**Calls $(REF moveAt, std, range, primitives) on the wrapped range, if
-     * possible. Otherwise, throws an exception.
+     * possible. Otherwise, throws an $(LREF UnsupportedRangeMethod) exception.
      */
     E moveAt(size_t);
 
@@ -386,7 +386,8 @@ if (isInputRange!(Unqual!R))
                 static if (__traits(compiles, _range.moveFront()))
                     return _range.moveFront();
                 else
-                    throw new Exception("Cannot move the front of a(n) `" ~ R.stringof ~ "`");
+                    throw new UnsupportedRangeMethod(
+                        "Cannot move the front of a(n) `" ~ R.stringof ~ "`");
             }
 
             void popFront() { _range.popFront(); }
@@ -414,7 +415,8 @@ if (isInputRange!(Unqual!R))
                     static if (__traits(compiles, _range.moveFront()))
                         return _range.moveBack();
                     else
-                        throw new Exception("Cannot move the back of a(n) `" ~ R.stringof ~ "`");
+                        throw new UnsupportedRangeMethod(
+                            "Cannot move the back of a(n) `" ~ R.stringof ~ "`");
                 }
 
                 void popBack() { return _range.popBack(); }
@@ -437,7 +439,8 @@ if (isInputRange!(Unqual!R))
                     static if (__traits(compiles, _range.moveAt(index)))
                         return _range.moveAt(index);
                     else
-                        throw new Exception("Cannot move an element of a(n) `" ~ R.stringof ~ "`");
+                        throw new UnsupportedRangeMethod(
+                            "Cannot move an element of a(n) `" ~ R.stringof ~ "`");
                 }
 
                 static if (hasAssignableElements!R)
@@ -533,6 +536,14 @@ template outputRangeObject(E...) {
      auto appWrapped = outputRangeObject!(uint, uint[])(app);
      static assert(is(typeof(appWrapped) : OutputRange!(uint[])));
      static assert(is(typeof(appWrapped) : OutputRange!(uint)));
+}
+
+/// Thrown when an interface method is not supported by the wrapped range
+class UnsupportedRangeMethod : Exception
+{
+    import std.exception : basicExceptionCtors;
+
+    mixin basicExceptionCtors;
 }
 
 @system unittest


### PR DESCRIPTION
…moveFront

The range algorithms moveFront, moveBack, and moveAt do not accept all
valid input ranges, bidirectional ranges, and random-access ranges,
respectively. Their inclusion as methods of the InputRange,
BidirectionalRange, and RandomAccessFinite interfaces previously caused
InputRangeObject, which implements those interfaces, to fail to compile
when instantiated with certain valid input, bidirectional, and
random-access ranges.

These methods should not have been included in their respective
interfaces to begin with, but removing them now would break existing
code. Instead, as a workaround, InputRangeObject now implements these
methods by throwing an exception if the wrapped range does not support
them.