### PR TITLE
Fix 22369 - Omit unreachable statements in std.concurrency

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2146,14 +2146,16 @@ private
 
                     if (msg.convertsTo!(Args))
                     {
-                        static if (is(ReturnType!(t) == bool))
+                        alias RT = ReturnType!(t);
+                        static if (is(RT == bool))
                         {
                             return msg.map(op);
                         }
                         else
                         {
                             msg.map(op);
-                            return true;
+                            static if (!is(immutable RT == immutable noreturn))
+                                return true;
                         }
                     }
                 }
@@ -2742,7 +2744,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, shared Mutex mutex)
             if (!atomicLoad!(MemoryOrder.raw)(flag))
             {
                 var = init;
-                atomicStore!(MemoryOrder.rel)(flag, true);
+                static if (!is(immutable typeof(var) == immutable noreturn))
+                    atomicStore!(MemoryOrder.rel)(flag, true);
             }
         }
     }
@@ -2823,4 +2826,28 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
     auto result1 = receiveOnly!(const Aggregate)();
     immutable expected = Aggregate(42, [1, 2, 3, 4, 5]);
     assert(result1 == expected);
+}
+
+// Noreturn support
+@system unittest
+{
+    static noreturn foo(int) { throw new Exception(""); }
+
+    // spawn expecpts void return
+    // if (false) spawn(&foo, 1);
+    // if (false) spawnLinked(&foo, 1);
+
+    if (false) receive(&foo);
+    if (false) receiveTimeout(Duration.init, &foo);
+
+    // Wrapped in __traits(compiles) to skip codegen which crashes dmd's backend
+    static assert(__traits(compiles, receiveOnly!noreturn()                 ));
+    static assert(__traits(compiles, send(Tid.init, noreturn.init)          ));
+    static assert(__traits(compiles, prioritySend(Tid.init, noreturn.init)  ));
+    static assert(__traits(compiles, yield(noreturn.init)                   ));
+
+    static assert(__traits(compiles, {
+        __gshared noreturn n;
+        initOnce!n(noreturn.init);
+    }));
 }


### PR DESCRIPTION
Instantiating these templates with noreturn values / callbacks causes
the versioned statements to become unreachable.

---

Includes #8265 to make the test case compilable