### PR TITLE
Fix issue 21022 - only should work with qualifiers

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -9814,6 +9814,9 @@ if (Values.length > 1)
             private UnqualValues values = void;
     }
     else
+        // These may alias to shared or immutable data. Do not let the user
+        // to access these directly, and do not allow mutation without checking
+        // the qualifier.
         private UnqualValues values;
 }
 
@@ -9880,6 +9883,9 @@ private struct OnlyResult(T)
         return copy;
     }
 
+    // This may alias to shared or immutable data. Do not let the user
+    // to access this directly, and do not allow mutation without checking
+    // the qualifier.
     private Unqual!T _value;
     private bool _empty = true;
     private @trusted T fetchFront()


### PR DESCRIPTION
The code example in linked issue is just about `const` and the single-element `only`, but I also made it work with `immutable` and multi-element `only`s.