### PR TITLE
Fix 22383 - Reject noreturn[] as an autodecodable string

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2562,3 +2562,20 @@ package(std) mixin template ImplementLength(alias member)
         alias opDollar = length;
     }
 }
+
+@safe unittest
+{
+    import std.meta : AliasSeq;
+
+    foreach (alias E; AliasSeq!(noreturn, const(noreturn), immutable(noreturn) ))
+    {
+        alias R = E[];
+
+        static assert(isInputRange!R);
+        static assert(isForwardRange!R);
+        static assert(isBidirectionalRange!R);
+        static assert(isRandomAccessRange!R);
+    }
+
+    static assert(isOutputRange!(noreturn[], noreturn));
+}

--- a/std/traits.d
+++ b/std/traits.d
@@ -6872,7 +6872,9 @@ template isAutodecodableString(T)
     import std.range.primitives : autodecodeStrings;
 
     enum isAutodecodableString = autodecodeStrings &&
-        (is(T : const char[]) || is(T : const wchar[])) && !is(T : U[n], U, size_t n);
+        (is(T : const char[]) || is(T : const wchar[]))
+        && !is(T : U[n], U, size_t n)
+        && !is(immutable T : immutable noreturn[]);
 }
 
 ///
@@ -6907,6 +6909,9 @@ template isAutodecodableString(T)
 
     static assert(isAutodecodableString!(H));
     static assert(isAutodecodableString!(I));
+
+    static assert(!isAutodecodableString!(noreturn[]));
+    static assert(!isAutodecodableString!(immutable(noreturn)[]));
 }
 
 /**


### PR DESCRIPTION
`noreturn[]` does not contain characters and hence is not subject to
autodecoding. The previous behaviour caused the range primitives (`put`,
...) to call into autodecoding related functions which couldn't handle
`noreturn[]`.
That error caused `isInputRange!(noreturn[])` to yield false.