### PR TITLE
Simplify allSameType

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8899,28 +8899,22 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 }
 
 /**
-   Returns: `true` iff all types `T` are the same.
+   Returns: `true` iff all types `Ts` are the same.
 */
-template allSameType(T...)
+enum bool allSameType(Ts...) =
 {
-    static foreach (idx, Ti; T)
-    {
-        static if (idx + 1 < T.length &&
-                   !is(typeof(allSameType) == bool) &&
-                   !is(T[idx] == T[idx + 1]))
-        {
-            enum bool allSameType = false;
-        }
-    }
-    static if (!is(typeof(allSameType) == bool))
-    {
-        enum bool allSameType = true;
-    }
-}
+    static foreach (T; Ts[Ts.length > 1 .. $])
+        static if (!is(Ts[0] == T))
+            if (__ctfe)  // Dodge the "statement is unreachable" warning
+                return false;
+    return true;
+}();
 
 ///
 @safe unittest
 {
+    static assert(allSameType!());
+    static assert(allSameType!(int));
     static assert(allSameType!(int, int));
     static assert(allSameType!(int, int, int));
     static assert(allSameType!(float, float, float));


### PR DESCRIPTION
1. Simplify implementation by using a lambda to initialize an enum, instead of the current trickery
2. Add unittest for clarifying that `allSameType` is vacuously true for 0 or 1 parameters.