### PR TITLE
Add OpenBSD to the unittest.

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -332,6 +332,7 @@ public:
         version (Posix)
         {
             version (FreeBSD)            enum utcZone = "Etc/UTC";
+            else version (OpenBSD)       enum utcZone = "UTC";
             else version (NetBSD)        enum utcZone = "UTC";
             else version (DragonFlyBSD)  enum utcZone = "UTC";
             else version (linux)         enum utcZone = "UTC";


### PR DESCRIPTION
Fix Issue 22430 - OpenBSD: Add OpenBSD to the timezone unittest

Confirmed to fix the test.