### PR TITLE
Replace quadratic Reverse with quasilinear

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -559,9 +559,18 @@ template ReplaceAll(args...)
  */
 template Reverse(args...)
 {
-    alias Reverse = AliasSeq!();
-    static foreach_reverse (arg; args)
-        Reverse = AliasSeq!(Reverse, arg);
+    static if (args.length <= 8)
+    {
+        // This part is O(n * n) because it grows an array by front insertions
+        alias Reverse = AliasSeq!();
+        static foreach_reverse (arg; args)
+            Reverse = AliasSeq!(Reverse, arg);
+    }
+    else
+    {
+        // This part is O(n * log n) because it does O(n) work for n, n/2, n/4...
+        alias Reverse = AliasSeq!(Reverse!(args[$ / 2 .. $]), Reverse!(args[0 .. $ / 2]));
+    }
 }
 
 ///


### PR DESCRIPTION
Since alias sequences are stored internally as arrays, `Reverse` is quadratic because it builds an array by prepending an element. Each step creates a new array and copies the existing one into it.

The proposed implementation uses the quadratic algorithm for short arrays (where it is still efficient) and switches to a divide & conquer approach for larger arrays. Unless I'm wrong it does `O(n)` work for each level of the tree formed by halving, for a total of `O(n long n)` work. The short arrays case improves this by a constant. factor.

I think we ought to examine other compile-time algorithms with an eye for compile-time complexity. Also, per the https://github.com/dlang/phobos/pull/8039, this pattern should be detected and implemented so it has constant amortized complexity:

`x = AliasSeq!(x, one_more_element);`