### PR TITLE
Fix 22487 - Don't access payload for unititialized array data

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -565,7 +565,7 @@ if (!is(immutable T == immutable bool))
 
     T[] data() @system
     {
-        return _data._payload;
+        return _data.refCountedStore.isInitialized ? _data._payload : [];
     }
 
     /**
@@ -2633,4 +2633,10 @@ if (is(immutable T == immutable bool))
 
     data[0] = 0;
     assert(arr[0] == 0);
+
+    arr.length = 0;
+    assert(arr.data == []);
+
+    Array!int empty;
+    assert(empty.data == []);
 }


### PR DESCRIPTION
Explicitly return `[]` when `store` wasn't intialized yet.

---

Targeting `stable` because this is minor fix.