### PR TITLE
Add explicit default ctor for DList.PayNode

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -196,6 +196,12 @@ struct DList(T)
 
         T _payload = T.init;
 
+        this (BaseNode _base, T _payload)
+        {
+            this._base = _base;
+            this._payload = _payload;
+        }
+
         inout(BaseNode)* asBaseNode() inout @trusted
         {
             return &_base;


### PR DESCRIPTION
Worksaround Issue 22510 (https://issues.dlang.org/show_bug.cgi?id=22510)
which prevented us from using structs with explicit copy ctors with DList.