### PR TITLE
std.random: Fix test for version(X32) targets

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -166,12 +166,16 @@ version (D_InlineAsm_X86_64) version = InlineAsm_X86_Any;
     assert(10.iota.randomSample(3, rnd2).equal([7, 8, 9]));
 
     // Cover all elements in an array in random order
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
-    assert(10.iota.randomCover(rnd2).equal([7, 4, 2, 0, 1, 6, 8, 3, 9, 5]));
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
+        assert(10.iota.randomCover(rnd2).equal([7, 4, 2, 0, 1, 6, 8, 3, 9, 5]));
+    else
+        assert(10.iota.randomCover(rnd2).equal([4, 8, 7, 3, 5, 9, 2, 6, 0, 1]));
 
     // Shuffle an array
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
-    assert([0, 1, 2, 4, 5].randomShuffle(rnd2).equal([2, 0, 4, 5, 1]));
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
+        assert([0, 1, 2, 4, 5].randomShuffle(rnd2).equal([2, 0, 4, 5, 1]));
+    else
+        assert([0, 1, 2, 4, 5].randomShuffle(rnd2).equal([4, 2, 5, 0, 1]));
 }
 
 version (StdUnittest)


### PR DESCRIPTION
(Of the machines I have immediately in-front of me).
X86_64 generates:
```
[7, 4, 2, 0, 1, 6, 8, 3, 9, 5]
[2, 0, 4, 5, 1]
```
X86 generates:
```
[4, 8, 7, 3, 5, 9, 2, 6, 0, 1]
[4, 2, 5, 0, 1]
```
X32 generates:
```
[4, 8, 7, 3, 5, 9, 2, 6, 0, 1]
[4, 2, 5, 0, 1]
```
SPARC64 generates:
```
[7, 4, 2, 0, 1, 6, 8, 3, 9, 5]
[2, 0, 4, 5, 1]
```
MIPS32 generates:
```
[4, 8, 7, 3, 5, 9, 2, 6, 0, 1]
[4, 2, 5, 0, 1]
```
MIPS64 generates:
```
[7, 4, 2, 0, 1, 6, 8, 3, 9, 5]
[2, 0, 4, 5, 1]
```
MIPSN32 generates:
```
[4, 8, 7, 3, 5, 9, 2, 6, 0, 1]
[4, 2, 5, 0, 1]
```
Obviously there's nothing target specific about this test, it's simply a 32-bit vs. 64-bit pointer discrepancy.