### PR TITLE
Fix Issue 22557 - std.traits.fqnType is missing support for typeof(null)

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -834,6 +834,10 @@ private template fqnType(T,
     {
         enum fqnType = "dstring";
     }
+    else static if (is(T == typeof(null)))
+    {
+        enum fqnType = "typeof(null)";
+    }
     else static if (isBasicType!T && !is(T == enum))
     {
         enum fqnType = chain!((Unqual!T).stringof);
@@ -924,6 +928,7 @@ private template fqnType(T,
         static assert(fqn!(string) == "string");
         static assert(fqn!(wstring) == "wstring");
         static assert(fqn!(dstring) == "dstring");
+        static assert(fqn!(typeof(null)) == "typeof(null)");
         static assert(fqn!(void) == "void");
         static assert(fqn!(const(void)) == "const(void)");
         static assert(fqn!(shared(void)) == "shared(void)");


### PR DESCRIPTION
Can we please have this target stable? We depend on this at work and would like to avoid an intermediate fix of copying `fullyQualifiedName` into our code base.

Resolves https://issues.dlang.org/show_bug.cgi?id=22557.