### PR TITLE
Revert "Fix 22386 - Omit unreachable throw in assertThrown with noreturn value"

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -191,7 +191,7 @@ auto assertNotThrown(T : Throwable = Exception, E)
 {
     import core.exception : AssertError;
 
-    static noreturn throwEx(Throwable t) { throw t; }
+    void throwEx(Throwable t) { throw t; }
     bool nothrowEx() { return true; }
 
     try
@@ -294,9 +294,7 @@ void assertThrown(T : Throwable = Exception, E)
         expression();
     catch (T)
         return;
-
-    static if (!is(immutable E == immutable noreturn))
-        throw new AssertError("assertThrown failed: No " ~ T.stringof ~ " was thrown"
+    throw new AssertError("assertThrown failed: No " ~ T.stringof ~ " was thrown"
                                  ~ (msg.length == 0 ? "." : ": ") ~ msg,
                           file, line);
 }
@@ -320,7 +318,7 @@ void assertThrown(T : Throwable = Exception, E)
 {
     import core.exception : AssertError;
 
-    static noreturn throwEx(Throwable t) { throw t; }
+    void throwEx(Throwable t) { throw t; }
     void nothrowEx() { }
 
     try


### PR DESCRIPTION
Reverts dlang/phobos#8273

There is a thinko somewhere in this change that leaves a hole open for `noreturn` - or the front-end implementation of `noreturn` is still incomplete meaning this is not suitable for inclusion just yet.

```
std/exception.d: In function ‘assertNotThrown’:
std/exception.d:157: warning: ‘noreturn’ function does return
std/exception.d: In function ‘assertNotThrown’:
std/exception.d:157: warning: ‘noreturn’ function does return
```

Would be good to reduce this to a tangible case.