### PR TITLE
Ignore SECURITY file when listing timezones

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2464,7 +2464,8 @@ public:
                         if (!tzName.extension().empty ||
                             !tzName.startsWith(subName) ||
                             baseName(tzName) == "leapseconds" ||
-                            tzName == "+VERSION")
+                            tzName == "+VERSION" ||
+                            tzName == "SECURITY")
                         {
                             continue;
                         }


### PR DESCRIPTION
On Arch Linux, there's an ASCII file in /usr/share/zoneinfo with instructions on how to submit security bug reports, as can be seen in the listing here:

https://archlinux.org/packages/core/x86_64/tzdata/files/

Currently the timezone unit tests fail due to this.