### PR TITLE
Fix issue 22608 - RandomAccessInfinite is not a valid random-access range

### DIFF
--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -201,6 +201,9 @@ interface RandomAccessFinite(E) : BidirectionalRange!(E) {
 
 /**Interface for an infinite random access range of type `E`.*/
 interface RandomAccessInfinite(E) : ForwardRange!E {
+    ///
+    enum bool empty = false;
+
     /**Calls $(REF moveAt, std, range, primitives) on the wrapped range, if
      * possible. Otherwise, throws an $(LREF UnsupportedRangeMethod) exception.
      */
@@ -211,6 +214,12 @@ interface RandomAccessInfinite(E) : ForwardRange!E {
 
     ///
     E opIndex(size_t);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=22608
+@safe unittest
+{
+    static assert(isRandomAccessRange!(RandomAccessInfinite!int));
 }
 
 /**Adds assignable elements to InputRange.*/


### PR DESCRIPTION
Previously, isInfinite!(RandomAccessInfinite!T) would always evaluate to
false, because the 'empty' method inherited from InputRange could not be
evaluated at compile time. Since isRandomAccessRange!R requires
(isBidirectionalRange!R || isInfinite!R), this meant that
RandomAccessInfinite!T was not recognized as a random-access range.