### PR TITLE
Fix issue 22701: Remove is(typeof()) callable check in std.typecons.apply.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4042,7 +4042,7 @@ template apply(alias fun)
     import std.functional : unaryFun;
 
     auto apply(T)(auto ref T t)
-    if (isInstanceOf!(Nullable, T) && is(typeof(unaryFun!fun(T.init.get))))
+    if (isInstanceOf!(Nullable, T))
     {
         alias FunType = typeof(unaryFun!fun(T.init.get));
 


### PR DESCRIPTION
To quote my bug report:

As I said in my DConf talk, `__traits(compiles)` is Satan, the Great Deceiver. The presence of `is(typeof())` (`__traits(compiles` by any other name) in the definition of `apply` needlessly turns a clear, readable error in the passed lambda into an incomprehensible template error that requires advanced language knowledge or blind guessing to untangle. And there's no point, because there's only one apply function! It should just be removed.

(Let's see if this passes the testsuite!)