### PR TITLE
Fix Issue 22738 - std.file.tempDir adds an addition / even when it already has one

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -5274,7 +5274,21 @@ Returns:
 */
 string tempDir() @trusted
 {
-    import std.path : dirSeparator;
+    // We must check that the end of a path is not a seperator, before adding another
+    // If we don't we end up with https://issues.dlang.org/show_bug.cgi?id=22738
+    static string addSeperator(string input)
+    {
+        import std.path : dirSeparator;
+        import std.algorithm.searching : endsWith;
+        
+        // It is very rare a directory path will reach this point with a directory seperator at the end
+        // However on OSX this can happen, so we must verify least we break user code i.e. https://github.com/dlang/dub/pull/2208
+        if (!input.endsWith(dirSeparator))
+            return input ~ dirSeparator;
+        else
+            return input;
+    }
+    
     static string cache;
     if (cache is null)
     {
@@ -5294,7 +5308,7 @@ string tempDir() @trusted
             static string findExistingDir(T...)(lazy T alternatives)
             {
                 foreach (dir; alternatives)
-                    if (!dir.empty && exists(dir)) return dir ~ dirSeparator;
+                    if (!dir.empty && exists(dir)) return addSeperator(dir);
                 return null;
             }
 
@@ -5309,7 +5323,7 @@ string tempDir() @trusted
 
         if (cache is null)
         {
-            cache = getcwd() ~ dirSeparator;
+            cache = addSeperator(getcwd());
         }
     }
     return cache;
@@ -5338,6 +5352,9 @@ string tempDir() @trusted
     import std.algorithm.searching : endsWith;
     import std.path : dirSeparator;
     assert(tempDir.endsWith(dirSeparator));
+    
+    // https://issues.dlang.org/show_bug.cgi?id=22738
+    assert(!tempDir.endsWith(dirSeparator ~ dirSeparator));
 }
 
 /**

--- a/std/file.d
+++ b/std/file.d
@@ -5282,7 +5282,7 @@ string tempDir() @trusted
         import std.algorithm.searching : endsWith;
 
         // It is very rare a directory path will reach this point with a directory separator at the end
-        // However on OSX this can happen, so we must verify least we break user code i.e. https://github.com/dlang/dub/pull/2208
+        // However on OSX this can happen, so we must verify lest we break user code i.e. https://github.com/dlang/dub/pull/2208
         if (!input.endsWith(dirSeparator))
             return input ~ dirSeparator;
         else

--- a/std/file.d
+++ b/std/file.d
@@ -5352,7 +5352,7 @@ string tempDir() @trusted
     import std.algorithm.searching : endsWith;
     import std.path : dirSeparator;
     assert(tempDir.endsWith(dirSeparator));
-    
+
     // https://issues.dlang.org/show_bug.cgi?id=22738
     assert(!tempDir.endsWith(dirSeparator ~ dirSeparator));
 }

--- a/std/file.d
+++ b/std/file.d
@@ -5280,7 +5280,7 @@ string tempDir() @trusted
     {
         import std.path : dirSeparator;
         import std.algorithm.searching : endsWith;
-        
+
         // It is very rare a directory path will reach this point with a directory seperator at the end
         // However on OSX this can happen, so we must verify least we break user code i.e. https://github.com/dlang/dub/pull/2208
         if (!input.endsWith(dirSeparator))
@@ -5288,7 +5288,7 @@ string tempDir() @trusted
         else
             return input;
     }
-    
+
     static string cache;
     if (cache is null)
     {

--- a/std/file.d
+++ b/std/file.d
@@ -5274,14 +5274,14 @@ Returns:
 */
 string tempDir() @trusted
 {
-    // We must check that the end of a path is not a seperator, before adding another
+    // We must check that the end of a path is not a separator, before adding another
     // If we don't we end up with https://issues.dlang.org/show_bug.cgi?id=22738
-    static string addSeperator(string input)
+    static string addSeparator(string input)
     {
         import std.path : dirSeparator;
         import std.algorithm.searching : endsWith;
 
-        // It is very rare a directory path will reach this point with a directory seperator at the end
+        // It is very rare a directory path will reach this point with a directory separator at the end
         // However on OSX this can happen, so we must verify least we break user code i.e. https://github.com/dlang/dub/pull/2208
         if (!input.endsWith(dirSeparator))
             return input ~ dirSeparator;
@@ -5308,7 +5308,7 @@ string tempDir() @trusted
             static string findExistingDir(T...)(lazy T alternatives)
             {
                 foreach (dir; alternatives)
-                    if (!dir.empty && exists(dir)) return addSeperator(dir);
+                    if (!dir.empty && exists(dir)) return addSeparator(dir);
                 return null;
             }
 
@@ -5323,7 +5323,7 @@ string tempDir() @trusted
 
         if (cache is null)
         {
-            cache = addSeperator(getcwd());
+            cache = addSeparator(getcwd());
         }
     }
     return cache;


### PR DESCRIPTION
Bug https://issues.dlang.org/show_bug.cgi?id=22738

Discovered due to dub CI being broken due to [17488](https://issues.dlang.org/show_bug.cgi?id=17488) adding an additional path separator when it can on some platforms already have it at the end.

Workaround to get dub passing CI https://github.com/dlang/dub/pull/2208