### PR TITLE
Add explanatory comment to addressOf

### DIFF
--- a/std/algorithm/internal.d
+++ b/std/algorithm/internal.d
@@ -62,4 +62,6 @@ version (StdUnittest)
     }
 }
 
+// Used instead of `&object.member` when `member` may be
+// either a field or a @property function.
 package(std) T* addressOf(T)(ref T val) { return &val; }


### PR DESCRIPTION
@schveiguy pointed out this function in the community Discord and nobody could figure out what it was for until we dug into the git history. Now, future readers will not have to wonder.