### PR TITLE
Fix Issue 22572 - Cannot define SumType over immutable struct with Nu…

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -262,6 +262,8 @@ private enum isHashable(T) = __traits(compiles,
 
 private enum hasPostblit(T) = __traits(hasPostblit, T);
 
+private enum isInout(T) = is(T == inout);
+
 /**
  * A [tagged union](https://en.wikipedia.org/wiki/Tagged_union) that can hold a
  * single value from any of a specified set of types.
@@ -419,6 +421,7 @@ public:
         (
             allSatisfy!(isCopyable, Map!(InoutOf, Types))
             && !anySatisfy!(hasPostblit, Map!(InoutOf, Types))
+            && allSatisfy!(isInout, Map!(InoutOf, Types))
         )
         {
             /// Constructs a `SumType` that's a copy of another `SumType`.
@@ -1490,6 +1493,23 @@ version (D_BetterC) {} else
     SumType!(int*) s = &n;
     const SumType!(int*) sc = &n;
     immutable SumType!(int*) si = &ni;
+}
+
+// Immutable member type with copy constructor
+// https://issues.dlang.org/show_bug.cgi?id=22572
+@safe unittest
+{
+    static struct CopyConstruct
+    {
+        this(ref inout CopyConstruct other) inout {}
+    }
+
+    static immutable struct Value
+    {
+        CopyConstruct c;
+    }
+
+    SumType!Value s;
 }
 
 /// True if `T` is an instance of the `SumType` template, otherwise false.


### PR DESCRIPTION
…llable

Previously, SumType incorrectly assumed that all members of an
inout(SumType) must themselves be inout-qualified. However, this is not
the case when one of those member types is declared as immutable, since
the qualifier combination `immutable inout` collapses to just
`immutable`.

Attempting to copy an immutable member type as though it were inout
caused matching to fail in SumType's copy constructor, due to the
following (gagged) error:

>  Error: `inout` on `return` means `inout` must be on a parameter as
>  well for `pure nothrow @nogc @safe inout(Storage)(ref immutable(Value)
>  value)`

---

Dub version: pbackus/sumtype#78