### PR TITLE
etc.c.odbc: Update removal dates for ODBC deprecations

### DIFF
--- a/etc/c/odbc/sql.d
+++ b/etc/c/odbc/sql.d
@@ -1,8 +1,9 @@
-// @@@DEPRECATED_2022-02@@@
+// @@@DEPRECATED_2.106@@@
 
 /**
-$(RED Deprecated. Use `core.sys.windows.sql` instead. This module will be
-      removed in February 2022.)
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.106.
+      Use `core.sys.windows.sql` instead.)
 
 Declarations for interfacing with the ODBC library.
 

--- a/etc/c/odbc/sqlext.d
+++ b/etc/c/odbc/sqlext.d
@@ -1,8 +1,9 @@
-// @@@DEPRECATED_2022-02@@@
+// @@@DEPRECATED_2.106@@@
 
 /**
-$(RED Deprecated. Use `core.sys.windows.sqlext` instead. This module will be
-      removed in February 2022.)
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.106.
+      Use `core.sys.windows.sqlext` instead.)
 
 Declarations for interfacing with the ODBC library.
 

--- a/etc/c/odbc/sqltypes.d
+++ b/etc/c/odbc/sqltypes.d
@@ -1,8 +1,9 @@
-// @@@DEPRECATED_2022-02@@@
+// @@@DEPRECATED_2.106@@@
 
 /**
-$(RED Deprecated. Use `core.sys.windows.sqltypes` instead. This module will be
-      removed in February 2022.)
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.106.
+      Use `core.sys.windows.sqltypes` instead.)
 
 Declarations for interfacing with the ODBC library.
 

--- a/etc/c/odbc/sqlucode.d
+++ b/etc/c/odbc/sqlucode.d
@@ -1,8 +1,9 @@
-// @@@DEPRECATED_2022-02@@@
+// @@@DEPRECATED_2.106@@@
 
 /**
-$(RED Deprecated. Use `core.sys.windows.sqlucode` instead. This module will be
-      removed in February 2022.)
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.106.
+      Use `core.sys.windows.sqlucode` instead.)
 
 Declarations for interfacing with the ODBC library.
 


### PR DESCRIPTION
I raised the original PR in 2019, but it didn't get merged until 2021, so the time-based deprecation process that was being used then is completely useless.