### PR TITLE
Make std.uni unittest compile with inout-return fix

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -5363,7 +5363,7 @@ pure @safe unittest
 pure @safe unittest
 {
     import std.range : stride;
-    static bool testAll(Matcher, Range)(scope ref Matcher m, ref Range r)
+    static bool testAll(Matcher, Range)(ref Matcher m, ref Range r) @safe
     {
         bool t = m.test(r);
         auto save = r.idx;


### PR DESCRIPTION
For https://github.com/dlang/dmd/pull/12689. The first parameter of `test` is not inferred `scope` anymore when `inout` doesn't imply a free `return`. I simply remove the needless `scope` from `testAll`,  I don't want to delve through multiple layers of templates to find the missing `return` / `scope` annotation when I don't need to.