### PR TITLE
Fix bigint `return scope` order

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -414,7 +414,7 @@ public:
     /**
      * Implements assignment operators of the form `BigInt op= BigInt`.
      */
-    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe scope return
+    BigInt opOpAssign(string op, T)(T y) pure nothrow @safe return scope
         if ((op=="+" || op== "-" || op=="*" || op=="|" || op=="&" || op=="^" || op=="/" || op=="%")
             && is (T: BigInt))
     {


### PR DESCRIPTION
It's returning itself by value. See https://issues.dlang.org/show_bug.cgi?id=22790