### PR TITLE
std/file: use size_t instead of ulong for ReadFile on Windows

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -425,10 +425,10 @@ version (Windows) private void[] readImpl(scope const(char)[] name, scope const(
             fileSize = makeUlong(sizeLow, sizeHigh);
         return result;
     }
-    static trustedReadFile(HANDLE hFile, void *lpBuffer, ulong nNumberOfBytesToRead)
+    static trustedReadFile(HANDLE hFile, void *lpBuffer, size_t nNumberOfBytesToRead)
     {
         // Read by chunks of size < 4GB (Windows API limit)
-        ulong totalNumRead = 0;
+        size_t totalNumRead = 0;
         while (totalNumRead != nNumberOfBytesToRead)
         {
             const uint chunkSize = min(nNumberOfBytesToRead - totalNumRead, 0xffff_0000);


### PR DESCRIPTION
Since ReadFile requires an offset buffer and the maximum size is size_t.max, we
should offset with size_t to avoid overflow on dereferencing.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Blocking https://github.com/dlang/dmd/pull/13732 .