### PR TITLE
Revert "sumtype: work around issue 21975 in isSumType"

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1569,27 +1569,7 @@ private enum bool isSumTypeInstance(T) = is(T == SumType!Args, Args...);
 }
 
 /// True if `T` is a [SumType] or implicitly converts to one, otherwise false.
-template isSumType(T)
-{
-    static if (is(T : SumType!Args, Args...))
-    {
-        enum isSumType = true;
-    }
-    else static if (is(T == struct) && __traits(getAliasThis, T).length > 0)
-    {
-        // Workaround for https://issues.dlang.org/show_bug.cgi?id=21975
-        import std.traits : ReturnType;
-
-        alias AliasThisType = ReturnType!((T t) =>
-            __traits(getMember, t, __traits(getAliasThis, T)[0])
-        );
-        enum isSumType = .isSumType!AliasThisType;
-    }
-    else
-    {
-        enum isSumType = false;
-    }
-}
+enum bool isSumType(T) = is(T : SumType!Args, Args...);
 
 ///
 @safe unittest
@@ -1608,25 +1588,6 @@ template isSumType(T)
     assert(isSumType!(SumType!int));
     assert(isSumType!ConvertsToSumType);
     assert(!isSumType!ContainsSumType);
-}
-
-@safe unittest
-{
-    static struct AliasThisVar(T)
-    {
-        SumType!T payload;
-        alias payload this;
-    }
-
-    static struct AliasThisFunc(T)
-    {
-        SumType!T payload;
-        ref get() { return payload; }
-        alias get this;
-    }
-
-    static assert(isSumType!(AliasThisVar!int));
-    static assert(isSumType!(AliasThisFunc!int));
 }
 
 /**


### PR DESCRIPTION
Reverts dlang/phobos#8394

---

Issue 21975 was fixed by https://github.com/dlang/dmd/pull/13738, so this is no longer needed.