### PR TITLE
Annotate `SysTime.endOfMonth` as `return scope`

### DIFF
--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -7668,7 +7668,7 @@ public:
         $(LREF SysTime) for the last day in the month that this Date is in.
         The time portion of endOfMonth is always 23:59:59.9999999.
       +/
-    @property SysTime endOfMonth() @safe const nothrow scope
+    @property SysTime endOfMonth() @safe const nothrow return scope
     {
         immutable hnsecs = adjTime;
         immutable days = getUnitsFromHNSecs!"days"(hnsecs);


### PR DESCRIPTION
It returns a time zone class instance:
```
auto retval = SysTime(this._stdTime, this._timezone);
```
This is not caught because of a bug in dmd where it quits checking when it sees that the first argument `this._stdTime` has no pointers (PR with fix incoming).
