### PR TITLE
Fix 22851 - Add source reference to std.sumtype

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -13,6 +13,7 @@ include:
 
 License: Boost License 1.0
 Authors: Paul Backus
+Source: $(PHOBOSSRC std/sumtype.d)
 +/
 module std.sumtype;
 


### PR DESCRIPTION
Add `Source: $(PHOBOSSRC std/sumtype.d)` to `std.sumtype`'s module documentation.