### PR TITLE
[Refactor] Move toCtString to std.conv

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5983,3 +5983,14 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
         }
     }
 }
+
+// Converts an unsigned integer to a compile-time string constant.
+package enum toCtString(ulong n) = n.stringof[0 .. $ - "LU".length];
+
+// Check that .stringof does what we expect, since it's not guaranteed by the
+// language spec.
+@safe /*@betterC*/ unittest
+{
+    assert(toCtString!0 == "0");
+    assert(toCtString!123456 == "123456");
+}

--- a/std/functional.d
+++ b/std/functional.d
@@ -65,6 +65,7 @@ module std.functional;
 
 import std.meta : AliasSeq, Reverse;
 import std.traits : isCallable, Parameters;
+import std.conv : toCtString;
 
 import std.internal.attributes : betterC;
 
@@ -1846,17 +1847,6 @@ if (isCallable!(F))
         auto dg_xtrnD = toDelegate(&S.xtrnD);
         static assert(! is(typeof(dg_xtrnC) == typeof(dg_xtrnD)));
     }
-}
-
-// Converts an unsigned integer to a compile-time string constant.
-private enum toCtString(ulong n) = n.stringof[0 .. $ - "LU".length];
-
-// Check that .stringof does what we expect, since it's not guaranteed by the
-// language spec.
-@safe unittest
-{
-    assert(toCtString!0 == "0");
-    assert(toCtString!123456 == "123456");
 }
 
 /**

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -237,20 +237,10 @@ import std.traits : ConstOf, ImmutableOf, InoutOf, TemplateArgsOf;
 import std.traits : CommonType, DeducedParameterType;
 import std.typecons : ReplaceTypeUnless;
 import std.typecons : Flag;
+import std.conv : toCtString;
 
 /// Placeholder used to refer to the enclosing [SumType].
 struct This {}
-
-// Converts an unsigned integer to a compile-time string constant.
-private enum toCtString(ulong n) = n.stringof[0 .. $ - "LU".length];
-
-// Check that .stringof does what we expect, since it's not guaranteed by the
-// language spec.
-@safe unittest
-{
-    assert(toCtString!0 == "0");
-    assert(toCtString!123456 == "123456");
-}
 
 // True if a variable of type T can appear on the lhs of an assignment
 private enum isAssignableTo(T) =


### PR DESCRIPTION
Previously, it was duplicated in std.functional and std.sumtype.