### PR TITLE
Fix 13541 - Replace plain usages of sysErrorString for errors

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -3471,7 +3471,7 @@ else version (Posix) string getcwd() @trusted
         while (true)
         {
             auto len = GetModuleFileNameW(null, buffer.ptr, cast(DWORD) buffer.length);
-            enforce(len, sysErrorString(GetLastError()));
+            wenforce(len);
             if (len != buffer.length)
                 return to!(string)(buffer[0 .. len]);
             buffer.length *= 2;

--- a/std/file.d
+++ b/std/file.d
@@ -214,7 +214,7 @@ class FileException : Exception
                           string file = __FILE__,
                           size_t line = __LINE__) @safe
     {
-        this(name, sysErrorString(errno), file, line, errno);
+        this(name, generateSysErrorMsg(errno), file, line, errno);
     }
     else version (Posix) this(scope const(char)[] name,
                              uint errno = .errno,

--- a/std/process.d
+++ b/std/process.d
@@ -299,10 +299,9 @@ static:
         }
         else version (Windows)
         {
-            import std.exception : enforce;
-            enforce(
+            import std.windows.syserror : wenforce;
+            wenforce(
                 SetEnvironmentVariableW(name.tempCStringW(), value.tempCStringW()),
-                sysErrorString(GetLastError())
             );
             return value;
         }

--- a/std/process.d
+++ b/std/process.d
@@ -1329,7 +1329,7 @@ private Pid spawnProcessWin(scope const(char)[] commandLine,
                 {
                     throw new StdioException(
                         "Failed to make "~which~" stream inheritable by child process ("
-                        ~sysErrorString(GetLastError()) ~ ')',
+                        ~generateSysErrorMsg() ~ ')',
                         0);
                 }
             }
@@ -2774,7 +2774,7 @@ Pipe pipe() @trusted //TODO: @safe
     if (!CreatePipe(&readHandle, &writeHandle, null, 0))
     {
         throw new StdioException(
-            "Error creating pipe (" ~ sysErrorString(GetLastError()) ~ ')',
+            "Error creating pipe (" ~ generateSysErrorMsg() ~ ')',
             0);
     }
 
@@ -3474,7 +3474,7 @@ class ProcessException : Exception
                                              string file = __FILE__,
                                              size_t line = __LINE__)
     {
-        auto lastMsg = sysErrorString(GetLastError());
+        auto lastMsg = generateSysErrorMsg();
         auto msg = customMsg.empty ? lastMsg
                                    : customMsg ~ " (" ~ lastMsg ~ ')';
         return new ProcessException(msg, file, line);

--- a/std/socket.d
+++ b/std/socket.d
@@ -169,7 +169,7 @@ string formatSocketError(int err) @trusted
     else
     version (Windows)
     {
-        return sysErrorString(err);
+        return generateSysErrorMsg(err);
     }
     else
         return "Socket error " ~ to!string(err);
@@ -842,7 +842,7 @@ private string formatGaiError(int err) @trusted
 {
     version (Windows)
     {
-        return sysErrorString(err);
+        return generateSysErrorMsg(err);
     }
     else
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1458,6 +1458,7 @@ Throws: `Exception` if the file is not opened.
     {
         import core.sys.windows.winbase : OVERLAPPED;
         import core.sys.windows.winnt : BOOL, ULARGE_INTEGER;
+        import std.windows.syserror : wenforce;
 
         private BOOL lockImpl(alias F, Flags...)(ulong start, ulong length,
             Flags flags)
@@ -1473,15 +1474,6 @@ Throws: `Exception` if the file is not opened.
             overlapped.hEvent = null;
             return F(windowsHandle, flags, 0, liLength.LowPart,
                 liLength.HighPart, &overlapped);
-        }
-
-        private static T wenforce(T)(T cond, lazy string str)
-        {
-            import core.sys.windows.winbase : GetLastError;
-            import std.windows.syserror : sysErrorString;
-
-            if (cond) return cond;
-            throw new Exception(str ~ ": " ~ sysErrorString(GetLastError()));
         }
     }
     version (Posix)

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -76,12 +76,7 @@ const(char)* toMBSz(scope const(char)[] s, uint codePage = 0)
                         to!int(result.length), null, null);
             }
 
-            if (!readLen || readLen != result.length)
-            {
-                throw new Exception("Couldn't convert string: " ~
-                        sysErrorString(GetLastError()));
-            }
-
+            wenforce(readLen && readLen == result.length, "Couldn't convert string");
             return result.ptr;
         }
     }
@@ -107,16 +102,10 @@ string fromMBSz(return scope immutable(char)* s, int codePage = 0)
                         to!int(result.length));
             }
 
-            if (!readLen || readLen != result.length)
-            {
-                throw new Exception("Couldn't convert string: " ~
-                    sysErrorString(GetLastError()));
-            }
+            wenforce(readLen && readLen == result.length, "Couldn't convert string");
 
             return result[0 .. result.length-1].to!string; // omit trailing null
         }
     }
     return s[0 .. c-s];         // string is ASCII, no conversion necessary
 }
-
-

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -232,3 +232,18 @@ T wenforce(T)(T condition, const(char)[] name, const(wchar)* namez, string file 
     e = new WindowsException(DWORD.max);
     assert(e.msg == "Error 4294967295");
 }
+
+/// Tries to translate an error code from the Windows API to the corresponding
+/// error message. Returns `Error <code>` on failure
+package (std) string generateSysErrorMsg(DWORD errCode = GetLastError()) nothrow @trusted
+{
+    auto buf = appender!(char[]);
+    cast(void) writeErrorMessage(errCode, buf);
+    return cast(immutable) buf[];
+}
+
+nothrow @safe unittest
+{
+    assert(generateSysErrorMsg(ERROR_PATH_NOT_FOUND) !is null);
+    assert(generateSysErrorMsg(DWORD.max) == "Error 4294967295");
+}

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -169,7 +169,7 @@ private bool writeErrorMessage(DWORD code, ref Appender!(char[]) buf) nothrow
     return success;
 }
 
-T wenforce(T, S)(T value, lazy S msg = null,
+T wenforce(T, S = string)(T value, lazy S msg = null,
 string file = __FILE__, size_t line = __LINE__)
 if (isSomeString!S)
 {


### PR DESCRIPTION
`sysErrorString` is used internally when creating an exception message for another error. But `sysErrorString` might throw an exception when the error message could not be retrieved - suppressing the actual error.

This patch replaces the internal usages of `sysErrorString` with `wenforce` / a helper function which report `Error X` if the lookup fails.
