### PR TITLE
Improve `std.conv.parse` support for `scope` strings

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2850,7 +2850,7 @@ do
     static if (isNarrowString!Source)
     {
         import std.string : representation;
-        auto s = source.representation;
+        scope s = source.representation;
     }
     else
     {
@@ -2898,7 +2898,7 @@ do
     }
 
     static if (isNarrowString!Source)
-        source = cast(Source) s;
+        source = source[$ - s.length .. $];
 
     static if (doCount)
     {
@@ -3105,7 +3105,7 @@ if (isSomeString!Source && !is(Source == enum) &&
  *     A $(LREF ConvException) if `source` is empty, if no number could be
  *     parsed, or if an overflow occurred.
  */
-auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref scope Source source)
+auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref Source source)
 if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
     isFloatingPoint!Target && !is(Target == enum))
 {
@@ -3115,18 +3115,17 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     static if (isNarrowString!Source)
     {
         import std.string : representation;
-        auto p = source.representation;
+        scope p = source.representation;
     }
     else
     {
         alias p = source;
     }
 
-    void advanceSource() @trusted
+    void advanceSource()
     {
-        // p is assigned from source.representation above so the cast is valid
         static if (isNarrowString!Source)
-            source = cast(Source) p;
+            source = source[$ - p.length .. $];
     }
 
     static immutable real[14] negtab =


### PR DESCRIPTION
Needed for unblocking the unittest build of Phobos with https://github.com/dlang/dmd/pull/12989

For the `isIntegral!Target` overload, make `scope` inference work.
For the `isFloatingPoint!Target`, avoid `@trusted`, and make `scope` inference work instead of forcing `scope` on the `source` range parameter (follow up of https://github.com/dlang/phobos/pull/8410).