### PR TITLE
Fix issue 22939 - bad error message: Error: no property `msg` for typ…

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1589,7 +1589,7 @@ char[] sformat(alias fmt, Args...)(char[] buf, Args args)
 if (isSomeString!(typeof(fmt)))
 {
     alias e = checkFormatException!(fmt, Args);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .sformat(buf, fmt, args);
 }
 

--- a/std/format/read.d
+++ b/std/format/read.d
@@ -305,7 +305,7 @@ if (isSomeString!(typeof(fmt)))
     import std.format : checkFormatException;
 
     alias e = checkFormatException!(fmt, Args);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .formattedRead(r, fmt, args);
 }
 

--- a/std/format/write.d
+++ b/std/format/write.d
@@ -677,7 +677,7 @@ if (isSomeString!(typeof(fmt)))
     import std.format : checkFormatException;
 
     alias e = checkFormatException!(fmt, Args);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .formattedWrite(w, fmt, args);
 }
 

--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -331,7 +331,7 @@ class OutBuffer
         import std.format : checkFormatException;
 
         alias e = checkFormatException!(fmt, A);
-        static assert(!e, e.msg);
+        static assert(!e, e);
         return this.writef(fmt, args);
     }
 
@@ -377,7 +377,7 @@ class OutBuffer
         import std.format : checkFormatException;
 
         alias e = checkFormatException!(fmt, A);
-        static assert(!e, e.msg);
+        static assert(!e, e);
         return this.writefln(fmt, args);
     }
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1783,7 +1783,7 @@ Throws: `Exception` if the file is not opened.
         import std.format : checkFormatException;
 
         alias e = checkFormatException!(fmt, A);
-        static assert(!e, e.msg);
+        static assert(!e, e);
         return this.writef(fmt, args);
     }
 
@@ -1802,7 +1802,7 @@ Throws: `Exception` if the file is not opened.
         import std.format : checkFormatException;
 
         alias e = checkFormatException!(fmt, A);
-        static assert(!e, e.msg);
+        static assert(!e, e);
         return this.writefln(fmt, args);
     }
 
@@ -2151,7 +2151,7 @@ $(CONSOLE
         import std.format : checkFormatException;
 
         alias e = checkFormatException!(format, Data);
-        static assert(!e, e.msg);
+        static assert(!e, e);
         return this.readf(format, data);
     }
 
@@ -4388,7 +4388,7 @@ if (isSomeString!(typeof(fmt)))
     import std.format : checkFormatException;
 
     alias e = checkFormatException!(fmt, A);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .writef(fmt, args);
 }
 
@@ -4429,7 +4429,7 @@ if (isSomeString!(typeof(fmt)))
     import std.format : checkFormatException;
 
     alias e = checkFormatException!(fmt, A);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .writefln(fmt, args);
 }
 
@@ -4510,7 +4510,7 @@ if (isSomeString!(typeof(format)))
     import std.format : checkFormatException;
 
     alias e = checkFormatException!(format, A);
-    static assert(!e, e.msg);
+    static assert(!e, e);
     return .readf(format, args);
 }
 


### PR DESCRIPTION
…e `string`

`checkFormatException` was changed to return a `string` instead of an `Exception` in https://github.com/dlang/phobos/pull/8070, but only 1/12 usage sites was updated.