### PR TITLE
Fix std.path unittest returning dangling pointer

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -1519,7 +1519,7 @@ if (isSomeChar!C)
     import std.range;
     // ir() wraps an array in a plain (i.e. non-forward) input range, so that
     // we can test both code paths
-    InputRange!(C[]) ir(C)(C[][] p...) { return inputRangeObject(p); }
+    InputRange!(C[]) ir(C)(C[][] p...) { return inputRangeObject(p.dup); }
     version (Posix)
     {
         assert(buildPath("foo") == "foo");


### PR DESCRIPTION
Uncovered by https://github.com/dlang/dmd/pull/13993

typesafe variadic parameters are allocated on the stack, so they shouldn't be returned. This doesn't give an error here because the unittest is `@system`, since `buildPath` is not `@safe` yet.

