### PR TITLE
Add scope decorations to std.socket

### DIFF
--- a/changelog/scopesocket.dd
+++ b/changelog/scopesocket.dd
@@ -1,0 +1,9 @@
+`std.socket.Socket` methods now accept only `scope` arrays.
+
+To comply with dip1000, `std.socket.Socket` methods now all have `scope`
+attributes applied to any slice parameters. This includes `receive` and `send`
+flavors, and also `setOption`. While not technically a breaking change for
+users of `Socket`, if you derive from it, you must apply those attributes to your
+derivatives or it will fail to compile. However, applying the attributes is
+backwards compatible with previous versions of Phobos, so there is no need for
+a migration path.

--- a/std/socket.d
+++ b/std/socket.d
@@ -3000,7 +3000,7 @@ public:
      * Returns: The number of bytes actually sent, or `Socket.ERROR` on
      * failure.
      */
-    ptrdiff_t send(const(void)[] buf, SocketFlags flags) @trusted
+    ptrdiff_t send(scope const(void)[] buf, SocketFlags flags) @trusted
     {
         static if (is(typeof(MSG_NOSIGNAL)))
         {
@@ -3014,7 +3014,7 @@ public:
     }
 
     /// ditto
-    ptrdiff_t send(const(void)[] buf)
+    ptrdiff_t send(scope const(void)[] buf)
     {
         return send(buf, SocketFlags.NONE);
     }
@@ -3026,7 +3026,7 @@ public:
      * Returns: The number of bytes actually sent, or `Socket.ERROR` on
      * failure.
      */
-    ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags, Address to) @trusted
+    ptrdiff_t sendTo(scope const(void)[] buf, SocketFlags flags, Address to) @trusted
     {
         static if (is(typeof(MSG_NOSIGNAL)))
         {
@@ -3042,7 +3042,7 @@ public:
     }
 
     /// ditto
-    ptrdiff_t sendTo(const(void)[] buf, Address to)
+    ptrdiff_t sendTo(scope const(void)[] buf, Address to)
     {
         return sendTo(buf, SocketFlags.NONE, to);
     }
@@ -3050,7 +3050,7 @@ public:
 
     //assumes you connect()ed
     /// ditto
-    ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags) @trusted
+    ptrdiff_t sendTo(scope const(void)[] buf, SocketFlags flags) @trusted
     {
         static if (is(typeof(MSG_NOSIGNAL)))
         {
@@ -3065,7 +3065,7 @@ public:
 
     //assumes you connect()ed
     /// ditto
-    ptrdiff_t sendTo(const(void)[] buf)
+    ptrdiff_t sendTo(scope const(void)[] buf)
     {
         return sendTo(buf, SocketFlags.NONE);
     }
@@ -3077,7 +3077,7 @@ public:
      * Returns: The number of bytes actually received, `0` if the remote side
      * has closed the connection, or `Socket.ERROR` on failure.
      */
-    ptrdiff_t receive(void[] buf, SocketFlags flags) @trusted
+    ptrdiff_t receive(scope void[] buf, SocketFlags flags) @trusted
     {
         version (Windows)         // Does not use size_t
         {
@@ -3094,7 +3094,7 @@ public:
     }
 
     /// ditto
-    ptrdiff_t receive(void[] buf)
+    ptrdiff_t receive(scope void[] buf)
     {
         return receive(buf, SocketFlags.NONE);
     }
@@ -3106,7 +3106,7 @@ public:
      * Returns: The number of bytes actually received, `0` if the remote side
      * has closed the connection, or `Socket.ERROR` on failure.
      */
-    ptrdiff_t receiveFrom(void[] buf, SocketFlags flags, ref Address from) @trusted
+    ptrdiff_t receiveFrom(scope void[] buf, SocketFlags flags, ref Address from) @trusted
     {
         if (!buf.length)         //return 0 and don't think the connection closed
             return 0;
@@ -3129,7 +3129,7 @@ public:
 
 
     /// ditto
-    ptrdiff_t receiveFrom(void[] buf, ref Address from)
+    ptrdiff_t receiveFrom(scope void[] buf, ref Address from)
     {
         return receiveFrom(buf, SocketFlags.NONE, from);
     }
@@ -3137,7 +3137,7 @@ public:
 
     //assumes you connect()ed
     /// ditto
-    ptrdiff_t receiveFrom(void[] buf, SocketFlags flags) @trusted
+    ptrdiff_t receiveFrom(scope void[] buf, SocketFlags flags) @trusted
     {
         if (!buf.length)         //return 0 and don't think the connection closed
             return 0;
@@ -3158,7 +3158,7 @@ public:
 
     //assumes you connect()ed
     /// ditto
-    ptrdiff_t receiveFrom(void[] buf)
+    ptrdiff_t receiveFrom(scope void[] buf)
     {
         return receiveFrom(buf, SocketFlags.NONE);
     }
@@ -3169,7 +3169,7 @@ public:
      * Returns: The number of bytes written to `result`.
      * The length, in bytes, of the actual result - very different from getsockopt()
      */
-    int getOption(SocketOptionLevel level, SocketOption option, void[] result) @trusted
+    int getOption(SocketOptionLevel level, SocketOption option, scope void[] result) @trusted
     {
         socklen_t len = cast(socklen_t) result.length;
         if (_SOCKET_ERROR == .getsockopt(sock, cast(int) level, cast(int) option, result.ptr, &len))
@@ -3217,7 +3217,7 @@ public:
     }
 
     /// Set a socket option.
-    void setOption(SocketOptionLevel level, SocketOption option, void[] value) @trusted
+    void setOption(SocketOptionLevel level, SocketOption option, scope void[] value) @trusted
     {
         if (_SOCKET_ERROR == .setsockopt(sock, cast(int) level,
                                         cast(int) option, value.ptr, cast(uint) value.length))
@@ -3647,55 +3647,55 @@ class UdpSocket: Socket
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @trusted ptrdiff_t send(const(void)[] buf, SocketFlags flags)
+            @trusted ptrdiff_t send(scope const(void)[] buf, SocketFlags flags)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t send(const(void)[] buf)
+            @safe ptrdiff_t send(scope const(void)[] buf)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags, Address to)
+            @trusted ptrdiff_t sendTo(scope const(void)[] buf, SocketFlags flags, Address to)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t sendTo(const(void)[] buf, Address to)
+            @safe ptrdiff_t sendTo(scope const(void)[] buf, Address to)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted ptrdiff_t sendTo(const(void)[] buf, SocketFlags flags)
+            @trusted ptrdiff_t sendTo(scope const(void)[] buf, SocketFlags flags)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t sendTo(const(void)[] buf)
+            @safe ptrdiff_t sendTo(scope const(void)[] buf)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted ptrdiff_t receive(void[] buf, SocketFlags flags)
+            @trusted ptrdiff_t receive(scope void[] buf, SocketFlags flags)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t receive(void[] buf)
+            @safe ptrdiff_t receive(scope void[] buf)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted ptrdiff_t receiveFrom(void[] buf, SocketFlags flags, ref Address from)
+            @trusted ptrdiff_t receiveFrom(scope void[] buf, SocketFlags flags, ref Address from)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t receiveFrom(void[] buf, ref Address from)
+            @safe ptrdiff_t receiveFrom(scope void[] buf, ref Address from)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted ptrdiff_t receiveFrom(void[] buf, SocketFlags flags)
+            @trusted ptrdiff_t receiveFrom(scope void[] buf, SocketFlags flags)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
-            @safe ptrdiff_t receiveFrom(void[] buf)
+            @safe ptrdiff_t receiveFrom(scope void[] buf)
             {
                 checkAttributes!q{@safe}; assert(0);
             }
-            @trusted int getOption(SocketOptionLevel level, SocketOption option, void[] result)
+            @trusted int getOption(SocketOptionLevel level, SocketOption option, scope void[] result)
             {
                 checkAttributes!q{@trusted}; assert(0);
             }
@@ -3711,7 +3711,7 @@ class UdpSocket: Socket
             {
                 checkAttributes!q{@trusted};
             }
-            @trusted void setOption(SocketOptionLevel level, SocketOption option, void[] value)
+            @trusted void setOption(SocketOptionLevel level, SocketOption option, scope void[] value)
             {
                 checkAttributes!q{@trusted};
             }
@@ -3793,11 +3793,11 @@ Socket[2] socketPair() @trusted
 ///
 @safe unittest
 {
-    immutable ubyte[] data = [1, 2, 3, 4];
+    immutable ubyte[4] data = [1, 2, 3, 4];
     auto pair = socketPair();
     scope(exit) foreach (s; pair) s.close();
 
-    pair[0].send(data);
+    pair[0].send(data[]);
 
     auto buf = new ubyte[data.length];
     pair[1].receive(buf);


### PR DESCRIPTION
This is to fix issues with compiling projects with dip1000.

I'm not sure how to add appropriate tests, since dip1000 is a compiler switch.