### PR TITLE
chore(math/hardware): align spaces by 4 instead of by 3

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -137,12 +137,12 @@ private:
         }
         else version (SPARC)
         {
-           /*
+            /*
                int retval;
                asm pure nothrow @nogc { st %fsr, retval; }
                return retval;
             */
-           assert(0, "Not yet supported");
+            assert(0, "Not yet supported");
         }
         else version (ARM)
         {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This triggered my editor to think Phobos is aligned by 3 spaces.