### PR TITLE
Allow GC in zlib alloc_func and free_func

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -39,7 +39,6 @@ import core.stdc.config;
 */
 
 nothrow:
-@nogc:
 extern (C):
 
 // Those are extern(D) as they should be mangled


### PR DESCRIPTION
This is quite self-explanatory.
One (such as I) would want to use `GC.malloc` and `GC.free` with zlib (and possibly not free at all).

This should be safe because Zlib's internal state (rooted at `z_stream.state`) is allocated with the supplied alloc_func and therefore will be kept in sight of the GC.
