### PR TITLE
Add xxhash digests to phobos library

### DIFF
--- a/changelog/std_digest_xxh.dd
+++ b/changelog/std_digest_xxh.dd
@@ -52,7 +52,7 @@ as well as with the OOP versions:
     auto xxh1 = new XXH3_64Digest();
     ubyte[] hash2 = xxh2.digest("abc");
 
-    auto xxh2 = new XXH128Digest();
+    auto xxh2 = new XXH3_128Digest();
     ubyte[] hash3 = xxh3.digest("abc");
 -------
 

--- a/changelog/std_digest_xxh.dd
+++ b/changelog/std_digest_xxh.dd
@@ -1,0 +1,60 @@
+Add XXHash digests to phobos library
+
+This patch is motivated by the need to have a much faster alternative to the slow MD5 or SHAx cryptographic digests.
+XXHash by itself is no cryptographic hash, but good enough to create suitable checksums and is used e.g. with ZSTD compression.
+
+The patch adds the four digest variants of the XXHash project (see github.com:Cyan4973/xxHash.git) ranging
+from 32 to 128 bits bits digests. Both variants for the 64 bit digest (XXH and XXH3) are implemented.
+
+The C sources are ported to D and currently only implement the 'scalar' mode of operation. The further optimisations (SIMD)
+are added later. So this ported XXHash digests are probably slower than the original C sources. There is also an experimental
+version using the embedded C sources with optimisations, but initial reviewers rejected the idea of embedded more C sources
+into Phobos, and argued for porting the C code to D.
+
+The digests results were compared against the outputs of the xxhsum commandline utility manually and match the outputs
+of the command line utility.
+
+There are unittests for all variants of XXHash (taken from MD5 sources and digest values were updated accordingly).
+
+The digests can be used with the template API:
+
+-------
+    XXH_32 hash0;
+    hash0.start();
+    hash0.put(cast(ubyte) 0);
+    auto result = hash0.finish();
+
+    XXH_64 hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+
+    XXH3_64 hash2;
+    hash2.start();
+    hash2.put(cast(ubyte) 0);
+    auto result = hash2.finish();
+
+    XXH3_128 hash3;
+    hash3.start();
+    hash3.put(cast(ubyte) 0);
+    auto result = hash3.finish();
+-------
+
+as well as with the OOP versions:
+
+-------
+    auto xxh0 = new XXH32Digest();
+    ubyte[] hash0 = xxh0.digest("abc");
+
+    auto xxh1 = new XXH64Digest();
+    ubyte[] hash1 = xxh1.digest("abc");
+
+    auto xxh1 = new XXH3_64Digest();
+    ubyte[] hash2 = xxh2.digest("abc");
+
+    auto xxh2 = new XXH128Digest();
+    ubyte[] hash3 = xxh3.digest("abc");
+-------
+
+There are some extra functions in the ported code (secrets, seeds), which are not yet
+implemented publically. These functions will be added later.

--- a/posix.mak
+++ b/posix.mak
@@ -222,7 +222,7 @@ PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
   sorting
 PACKAGE_std_container = array binaryheap dlist package rbtree slist util
 PACKAGE_std_datetime = date interval package stopwatch systime timezone
-PACKAGE_std_digest = crc hmac md murmurhash package ripemd sha
+PACKAGE_std_digest = crc hmac md murmurhash package ripemd sha xxh
 PACKAGE_std_experimental_logger = core filelogger \
   nulllogger multilogger package
 PACKAGE_std_experimental_allocator = \

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -179,7 +179,7 @@ import std.traits;
         auto xxh32 = new XXH32Digest();
         auto xxh64 = new XXH64Digest();
         auto xxh3_64 = new XXH3_64Digest();
-        auto xxh3_128 = new XXH128Digest();
+        auto xxh3_128 = new XXH3_128Digest();
 
         foreach (arg; args[1 .. $])
         {
@@ -706,7 +706,7 @@ interface Digest
     ubyte[] xxh32 = (new XXH32Digest()).digest("The quick brown fox jumps over the lazy dog");
     ubyte[] xxh64 = (new XXH64Digest()).digest("The quick brown fox jumps over the lazy dog");
     ubyte[] xxh3_64 = (new XXH3_64Digest()).digest("The quick brown fox jumps over the lazy dog");
-    ubyte[] xxh3_128 = (new XXH128Digest()).digest("The quick brown fox jumps over the lazy dog");
+    ubyte[] xxh3_128 = (new XXH3_128Digest()).digest("The quick brown fox jumps over the lazy dog");
     ubyte[] crc32 = (new CRC32Digest()).digest("The quick brown fox jumps over the lazy dog");
     assert(crcHexString(crc32) == "414FA339");
 }

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -154,7 +154,7 @@ import std.traits;
 ///
 @system unittest
 {
-    import std.digest.crc, std.digest.md, std.digest.sha;
+    import std.digest.crc, std.digest.md, std.digest.sha, std.digest.xxh;
     import std.stdio;
 
     // Digests a file and prints the result.
@@ -176,12 +176,20 @@ import std.traits;
         auto md5 = new MD5Digest();
         auto sha1 = new SHA1Digest();
         auto crc32 = new CRC32Digest();
+        auto xxh32 = new XXH32Digest();
+        auto xxh64 = new XXH64Digest();
+        auto xxh3_64 = new XXH3_64Digest();
+        auto xxh3_128 = new XXH128Digest();
 
         foreach (arg; args[1 .. $])
         {
           digestFile(md5, arg);
           digestFile(sha1, arg);
           digestFile(crc32, arg);
+          digestFile(xxh32, arg);
+          digestFile(xxh64, arg);
+          digestFile(xxh3_64, arg);
+          digestFile(xxh3_128, arg);
         }
     }
 }
@@ -692,9 +700,13 @@ interface Digest
 ///
 @system unittest
 {
-    import std.digest.crc, std.digest.md, std.digest.sha;
+    import std.digest.crc, std.digest.md, std.digest.sha, std.digest.xxh;
     ubyte[] md5   = (new MD5Digest()).digest("The quick brown fox jumps over the lazy dog");
     ubyte[] sha1  = (new SHA1Digest()).digest("The quick brown fox jumps over the lazy dog");
+    ubyte[] xxh32 = (new XXH32Digest()).digest("The quick brown fox jumps over the lazy dog");
+    ubyte[] xxh64 = (new XXH64Digest()).digest("The quick brown fox jumps over the lazy dog");
+    ubyte[] xxh3_64 = (new XXH3_64Digest()).digest("The quick brown fox jumps over the lazy dog");
+    ubyte[] xxh3_128 = (new XXH128Digest()).digest("The quick brown fox jumps over the lazy dog");
     ubyte[] crc32 = (new CRC32Digest()).digest("The quick brown fox jumps over the lazy dog");
     assert(crcHexString(crc32) == "414FA339");
 }
@@ -898,6 +910,11 @@ unittest
 {
     import std.digest.md : MD5;
     import std.digest.sha : SHA1, SHA256, SHA512;
+    import std.digest.xxh : XXH_32, XXH_64, XXH3_64, XXH3_128;
+    assert(digestLength!XXH_32 == 4);
+    assert(digestLength!XXH_64 == 8);
+    assert(digestLength!XXH3_64 == 8);
+    assert(digestLength!XXH3_128 == 16);
     assert(digestLength!MD5 == 16);
     assert(digestLength!SHA1 == 20);
     assert(digestLength!SHA256 == 32);

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -1950,7 +1950,7 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
  */
-private XXH_errorcode XXH3_update(XXH3_state_t* state, const(ubyte)* input,
+private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
@@ -2083,7 +2083,7 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(ubyte)* input,
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len) @safe pure nothrow @nogc
+XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len) @safe pure nothrow @nogc
 {
     return XXH3_update(state, cast(const(ubyte)*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
@@ -2575,7 +2575,7 @@ XXH_errorcode XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
     return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
 }
 
-XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len) @safe pure nothrow @nogc
+XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, scope const void* input, size_t len) @safe pure nothrow @nogc
 {
     return XXH3_update(state, cast(const ubyte*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -135,10 +135,7 @@ align(16) struct XXH128_hash_t
     XXH64_hash_t high64; /** `value >> 64` */
 }
 
-struct XXH32_canonical_t
-{
-    ubyte[4] digest; /** Hash bytes, big endian */
-}
+alias XXH32_canonical_t = ubyte[XXH32_hash_t.sizeof];
 static assert(XXH32_canonical_t.sizeof == 4, "32bit integers should be 4 bytes?");
 alias XXH64_canonical_t = ubyte[XXH64_hash_t.sizeof];
 static assert(XXH64_hash_t.sizeof == 8, "64bit integers should be 8 bytes?");

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -323,7 +323,7 @@ private uint xxh_get32bits(const void* p, XXH_alignment align_) @safe pure nothr
 private uint xxh32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
 {
-    void XXH_PROCESS1(ref uint hash, ref const(ubyte)* ptr)
+    static void XXH_PROCESS1(ref uint hash, ref const(ubyte)* ptr)
     {
         hash += (*ptr++) * XXH_PRIME32_5;
         hash = rol(hash, 11) * XXH_PRIME32_1;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -96,31 +96,46 @@ alias xxh_u8 = ubyte;
 alias xxh_u32 = uint;
 alias xxh_u64 = ulong;
 
-private uint32_t XXH_rotl32(uint32_t x, uint r) @trusted pure nothrow @nogc { return (((x) << (r)) | ((x) >> (32 - (r)))); }
-private uint64_t XXH_rotl64(uint64_t x, uint r) @trusted pure nothrow @nogc { return (((x) << (r)) | ((x) >> (64 - (r)))); }
+private uint32_t XXH_rotl32(uint32_t x, uint r) @trusted pure nothrow @nogc
+{
+    return (((x) << (r)) | ((x) >> (32 - (r))));
+}
+
+private uint64_t XXH_rotl64(uint64_t x, uint r) @trusted pure nothrow @nogc
+{
+    return (((x) << (r)) | ((x) >> (64 - (r))));
+}
 /* *************************************
 *  Misc
 ***************************************/
 
-enum XXH_VERSION_MAJOR   = 0;
-enum XXH_VERSION_MINOR   = 8;
+enum XXH_VERSION_MAJOR = 0;
+enum XXH_VERSION_MINOR = 8;
 enum XXH_VERSION_RELEASE = 1;
 /** Version number, encoded as two digits each */
-enum XXH_VERSION_NUMBER = (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE);
+enum XXH_VERSION_NUMBER = (XXH_VERSION_MAJOR * 100 * 100 + XXH_VERSION_MINOR
+            * 100 + XXH_VERSION_RELEASE);
 
 /** Get version number */
-uint XXH_versionNumber ()  @trusted pure nothrow @nogc
+uint XXH_versionNumber() @trusted pure nothrow @nogc
 {
     return XXH_VERSION_NUMBER;
+}
+///
+@safe unittest
+{
+    import std.stdio : writeln;
+    writeln("XXH Version is", XXH_versionNumber());
 }
 
 private import std.stdint;
 
 alias XXH32_hash_t = uint32_t;
 alias XXH64_hash_t = uint64_t;
-struct XXH128_hash_t {
-    XXH64_hash_t low64;   /*!< `value & 0xFFFFFFFFFFFFFFFF` */
-    XXH64_hash_t high64;  /*!< `value >> 64` */
+struct XXH128_hash_t
+{
+    XXH64_hash_t low64; /*!< `value & 0xFFFFFFFFFFFFFFFF` */
+    XXH64_hash_t high64; /*!< `value >> 64` */
 }
 
 alias XXH64_canonical_t = uint64_t;
@@ -148,42 +163,41 @@ alias XXH128_canonical_t = XXH128_hash_t;
  * @see XXH3_createState(), XXH3_freeState().
  * @see XXH32_state_s, XXH64_state_s
  */
-struct XXH3_state_t {
-   align(64)  XXH64_hash_t[8] acc;
-       /*!< The 8 accumulators. See @ref XXH32_state_s::v and @ref XXH64_state_s::v */
-   align(64)  ubyte[XXH3_SECRET_DEFAULT_SIZE] customSecret;
-       /*!< Used to store a custom secret generated from a seed. */
-   align(64)  ubyte[XXH3_INTERNALBUFFER_SIZE] buffer;
-       /*!< The internal buffer. @see XXH32_state_s::mem32 */
-   XXH32_hash_t bufferedSize;
-       /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
-   XXH32_hash_t useSeed;
-       /*!< Reserved field. Needed for padding on 64-bit. */
-   size_t nbStripesSoFar;
-       /*!< Number or stripes processed. */
-   XXH64_hash_t totalLen;
-       /*!< Total length hashed. 64-bit even on 32-bit targets. */
-   size_t nbStripesPerBlock;
-       /*!< Number of stripes per block. */
-   size_t secretLimit;
-       /*!< Size of @ref customSecret or @ref extSecret */
-   XXH64_hash_t seed;
-       /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
-   XXH64_hash_t reserved64;
-       /*!< Reserved field. */
-   const(ubyte)* extSecret;
-       /*!< Reference to an external secret for the _withSecret variants, null
+struct XXH3_state_t
+{
+    align(64) XXH64_hash_t[8] acc;
+    /*!< The 8 accumulators. See @ref XXH32_state_s::v and @ref XXH64_state_s::v */
+    align(64) ubyte[XXH3_SECRET_DEFAULT_SIZE] customSecret;
+    /*!< Used to store a custom secret generated from a seed. */
+    align(64) ubyte[XXH3_INTERNALBUFFER_SIZE] buffer;
+    /*!< The internal buffer. @see XXH32_state_s::mem32 */
+    XXH32_hash_t bufferedSize;
+    /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
+    XXH32_hash_t useSeed;
+    /*!< Reserved field. Needed for padding on 64-bit. */
+    size_t nbStripesSoFar;
+    /*!< Number or stripes processed. */
+    XXH64_hash_t totalLen;
+    /*!< Total length hashed. 64-bit even on 32-bit targets. */
+    size_t nbStripesPerBlock;
+    /*!< Number of stripes per block. */
+    size_t secretLimit;
+    /*!< Size of @ref customSecret or @ref extSecret */
+    XXH64_hash_t seed;
+    /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
+    XXH64_hash_t reserved64;
+    /*!< Reserved field. */
+    const(ubyte)* extSecret;
+    /*!< Reference to an external secret for the _withSecret variants, null
         *   for other variants. */
-   /* note: there may be some padding at the end due to alignment on 64 bytes */
+    /* note: there may be some padding at the end due to alignment on 64 bytes */
 } /* typedef'd to XXH3_state_t */
 
-
-enum XXH_errorcode {
+enum XXH_errorcode
+{
     XXH_OK = 0, /*!< OK */
-    XXH_ERROR   /*!< Error */
+    XXH_ERROR /*!< Error */
 }
-
-
 
 /*!
  * @internal
@@ -197,14 +211,15 @@ enum XXH_errorcode {
  * Do not access the members of this struct directly.
  * @see XXH64_state_s, XXH3_state_s
  */
-struct XXH32_state_t {
-   XXH32_hash_t total_len_32; /*!< Total length hashed, modulo 2^32 */
-   XXH32_hash_t large_len;    /*!< Whether the hash is >= 16 (handles @ref total_len_32 overflow) */
-   XXH32_hash_t[4] v;         /*!< Accumulator lanes */
-   XXH32_hash_t[4] mem32;     /*!< Internal buffer for partial reads. Treated as unsigned char[16]. */
-   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem32 */
-   XXH32_hash_t reserved;     /*!< Reserved field. Do not read nor write to it. */
-}   /* typedef'd to XXH32_state_t */
+struct XXH32_state_t
+{
+    XXH32_hash_t total_len_32; /*!< Total length hashed, modulo 2^32 */
+    XXH32_hash_t large_len; /*!< Whether the hash is >= 16 (handles @ref total_len_32 overflow) */
+    XXH32_hash_t[4] v; /*!< Accumulator lanes */
+    XXH32_hash_t[4] mem32; /*!< Internal buffer for partial reads. Treated as unsigned char[16]. */
+    XXH32_hash_t memsize; /*!< Amount of data in @ref mem32 */
+    XXH32_hash_t reserved; /*!< Reserved field. Do not read nor write to it. */
+} /* typedef'd to XXH32_state_t */
 
 /*!
  * @internal
@@ -218,16 +233,18 @@ struct XXH32_state_t {
  * Do not access the members of this struct directly.
  * @see XXH32_state_s, XXH3_state_s
  */
-struct XXH64_state_t {
-   XXH64_hash_t total_len;    /*!< Total length hashed. This is always 64-bit. */
-   XXH64_hash_t[4] v;         /*!< Accumulator lanes */
-   XXH64_hash_t[4] mem64;     /*!< Internal buffer for partial reads. Treated as unsigned char[32]. */
-   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem64 */
-   XXH32_hash_t reserved32;   /*!< Reserved field, needed for padding anyways*/
-   XXH64_hash_t reserved64;   /*!< Reserved field. Do not read or write to it. */
-}   /* typedef'd to XXH64_state_t */
+struct XXH64_state_t
+{
+    XXH64_hash_t total_len; /*!< Total length hashed. This is always 64-bit. */
+    XXH64_hash_t[4] v; /*!< Accumulator lanes */
+    XXH64_hash_t[4] mem64; /*!< Internal buffer for partial reads. Treated as unsigned char[32]. */
+    XXH32_hash_t memsize; /*!< Amount of data in @ref mem64 */
+    XXH32_hash_t reserved32; /*!< Reserved field, needed for padding anyways*/
+    XXH64_hash_t reserved64; /*!< Reserved field. Do not read or write to it. */
+} /* typedef'd to XXH64_state_t */
 
-struct XXH32_canonical_t {
+struct XXH32_canonical_t
+{
     ubyte[4] digest; /*!< Hash bytes, big endian */
 }
 
@@ -236,28 +253,28 @@ struct XXH32_canonical_t {
  * Param: x = The 32-bit integer to byteswap.
  * Return: x, byteswapped.
  */
-private xxh_u32 XXH_swap32 (xxh_u32 x) @trusted pure nothrow @nogc
+private xxh_u32 XXH_swap32(xxh_u32 x) @trusted pure nothrow @nogc
 {
-    return  ((x << 24) & 0xff000000 ) |
-            ((x <<  8) & 0x00ff0000 ) |
-            ((x >>  8) & 0x0000ff00 ) |
-            ((x >> 24) & 0x000000ff );
+    return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) | (
+            (x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
 }
 
 /* ***************************
 *  Memory reads
 *****************************/
 
-/** Enum to indicate whether a pointer is aligned. */
-enum XXH_alignment {
-    XXH_aligned,  /** Aligned */
+/** Enum to indicate whether a pointer is aligned.
+ */
+private enum XXH_alignment
+{
+    XXH_aligned, /** Aligned */
     XXH_unaligned /** Possibly unaligned */
 }
 
 private xxh_u32 XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     xxh_u32 val;
-    (cast(ubyte*) &val)[0 .. xxh_u32.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u32.sizeof];
+    (cast(ubyte*)&val)[0 .. xxh_u32.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u32.sizeof];
     return val;
 }
 
@@ -273,21 +290,25 @@ private xxh_u32 XXH_readBE32(const void* ptr) @trusted pure nothrow @nogc
 
 private xxh_u32 XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
-    if (align_==XXH_alignment.XXH_unaligned) {
+    if (align_ == XXH_alignment.XXH_unaligned)
+    {
         return XXH_readLE32(ptr);
-    } else {
-        return XXH_CPU_LITTLE_ENDIAN ? * cast(const xxh_u32*) ptr : XXH_swap32(* cast(const xxh_u32*) ptr);
+    }
+    else
+    {
+        return XXH_CPU_LITTLE_ENDIAN ? *cast(const xxh_u32*) ptr : XXH_swap32(
+                *cast(const xxh_u32*) ptr);
     }
 }
 
 /* *******************************************************************
 *  32-bit hash functions
 *********************************************************************/
-enum XXH_PRIME32_1 = 0x9E3779B1U;  /** 0b10011110001101110111100110110001 */
-enum XXH_PRIME32_2 = 0x85EBCA77U;  /** 0b10000101111010111100101001110111 */
-enum XXH_PRIME32_3 = 0xC2B2AE3DU;  /** 0b11000010101100101010111000111101 */
-enum XXH_PRIME32_4 = 0x27D4EB2FU;  /** 0b00100111110101001110101100101111 */
-enum XXH_PRIME32_5 = 0x165667B1U;  /** 0b00010110010101100110011110110001 */
+enum XXH_PRIME32_1 = 0x9E3779B1U; /** 0b10011110001101110111100110110001 */
+enum XXH_PRIME32_2 = 0x85EBCA77U; /** 0b10000101111010111100101001110111 */
+enum XXH_PRIME32_3 = 0xC2B2AE3DU; /** 0b11000010101100101010111000111101 */
+enum XXH_PRIME32_4 = 0x27D4EB2FU; /** 0b00100111110101001110101100101111 */
+enum XXH_PRIME32_5 = 0x165667B1U; /** 0b00010110010101100110011110110001 */
 
 /**  Normal stripe processing routine.
  *
@@ -301,7 +322,7 @@ enum XXH_PRIME32_5 = 0x165667B1U;  /** 0b00010110010101100110011110110001 */
 private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @trusted pure nothrow @nogc
 {
     acc += input * XXH_PRIME32_2;
-    acc  = XXH_rotl32(acc, 13);
+    acc = XXH_rotl32(acc, 13);
     acc *= XXH_PRIME32_1;
     return acc;
 }
@@ -344,75 +365,99 @@ private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @trusted pure
  * @return The finalized hash.
  * @see XXH64_finalize().
  */
-private xxh_u32
-XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)  @trusted pure nothrow @nogc
+private xxh_u32 XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)
+    @trusted pure nothrow @nogc
 {
     void XXH_PROCESS1(ref uint32_t hash, ref const(xxh_u8)* ptr)
     {
         hash += (*ptr++) * XXH_PRIME32_5;
         hash = XXH_rotl32(hash, 11) * XXH_PRIME32_1;
     }
+
     void XXH_PROCESS4(ref uint32_t hash, ref const(xxh_u8)* ptr)
     {
         hash += XXH_get32bits(ptr, align_) * XXH_PRIME32_3;
         ptr += 4;
-        hash  = XXH_rotl32(hash, 17) * XXH_PRIME32_4;
+        hash = XXH_rotl32(hash, 17) * XXH_PRIME32_4;
     }
 
     /* Compact rerolled version; generally faster */
-    if (!XXH32_ENDJMP) {
+    if (!XXH32_ENDJMP)
+    {
         len &= 15;
-        while (len >= 4) {
+        while (len >= 4)
+        {
             XXH_PROCESS4(hash, ptr);
             len -= 4;
         }
-        while (len > 0) {
+        while (len > 0)
+        {
             XXH_PROCESS1(hash, ptr);
             --len;
         }
         return XXH32_avalanche(hash);
-    } else {
-         switch(len&15) /* or switch(bEnd - p) */ {
-           case 12:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 8:       XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 4:       XXH_PROCESS4(hash, ptr);
-                         return XXH32_avalanche(hash);
+    }
+    else
+    {
+        switch (len & 15) /* or switch (bEnd - p) */
+        {
+        case 12:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 8:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 4:
+            XXH_PROCESS4(hash, ptr);
+            return XXH32_avalanche(hash);
 
-           case 13:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 9:       XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 5:       XXH_PROCESS4(hash, ptr);
-                         XXH_PROCESS1(hash, ptr);
-                         return XXH32_avalanche(hash);
+        case 13:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 9:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 5:
+            XXH_PROCESS4(hash, ptr);
+            XXH_PROCESS1(hash, ptr);
+            return XXH32_avalanche(hash);
 
-           case 14:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 10:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 6:       XXH_PROCESS4(hash, ptr);
-                         XXH_PROCESS1(hash, ptr);
-                         XXH_PROCESS1(hash, ptr);
-                         return XXH32_avalanche(hash);
+        case 14:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 10:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 6:
+            XXH_PROCESS4(hash, ptr);
+            XXH_PROCESS1(hash, ptr);
+            XXH_PROCESS1(hash, ptr);
+            return XXH32_avalanche(hash);
 
-           case 15:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 11:      XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 7:       XXH_PROCESS4(hash, ptr);
-                         goto case;
-           case 3:       XXH_PROCESS1(hash, ptr);
-                         goto case;
-           case 2:       XXH_PROCESS1(hash, ptr);
-                         goto case;
-           case 1:       XXH_PROCESS1(hash, ptr);
-                         goto case;
-           case 0:       return XXH32_avalanche(hash);
-           default: assert(0);
+        case 15:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 11:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 7:
+            XXH_PROCESS4(hash, ptr);
+            goto case;
+        case 3:
+            XXH_PROCESS1(hash, ptr);
+            goto case;
+        case 2:
+            XXH_PROCESS1(hash, ptr);
+            goto case;
+        case 1:
+            XXH_PROCESS1(hash, ptr);
+            goto case;
+        case 0:
+            return XXH32_avalanche(hash);
+        default:
+            assert(0, "Internal error");
         }
-        return hash;   /* reaching this point is deemed impossible */
+        return hash; /* reaching this point is deemed impossible */
     }
 }
 
@@ -425,12 +470,13 @@ XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
-private xxh_u32
-XXH32_endian_align(const(xxh_u8)* input, size_t len, xxh_u32 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+private xxh_u32 XXH32_endian_align(const(xxh_u8)* input, size_t len,
+        xxh_u32 seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     xxh_u32 h32;
 
-    if (len>=16) {
+    if (len >= 16)
+    {
         const xxh_u8* bEnd = input + len;
         const xxh_u8* limit = bEnd - 15;
         xxh_u32 v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
@@ -438,48 +484,65 @@ XXH32_endian_align(const(xxh_u8)* input, size_t len, xxh_u32 seed, XXH_alignment
         xxh_u32 v3 = seed + 0;
         xxh_u32 v4 = seed - XXH_PRIME32_1;
 
-        do {
-            v1 = XXH32_round(v1, XXH_get32bits(input, align_)); input += 4;
-            v2 = XXH32_round(v2, XXH_get32bits(input, align_)); input += 4;
-            v3 = XXH32_round(v3, XXH_get32bits(input, align_)); input += 4;
-            v4 = XXH32_round(v4, XXH_get32bits(input, align_)); input += 4;
-        } while (input < limit);
+        do
+        {
+            v1 = XXH32_round(v1, XXH_get32bits(input, align_));
+            input += 4;
+            v2 = XXH32_round(v2, XXH_get32bits(input, align_));
+            input += 4;
+            v3 = XXH32_round(v3, XXH_get32bits(input, align_));
+            input += 4;
+            v4 = XXH32_round(v4, XXH_get32bits(input, align_));
+            input += 4;
+        }
+        while (input < limit);
 
-        h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
-            + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
-    } else {
-        h32  = seed + XXH_PRIME32_5;
+        h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    }
+    else
+    {
+        h32 = seed + XXH_PRIME32_5;
     }
 
     h32 += cast(xxh_u32) len;
 
-    return XXH32_finalize(h32, input, len&15, align_);
+    return XXH32_finalize(h32, input, len & 15, align_);
 }
 
-XXH32_hash_t XXH32 (const void* input, size_t len, XXH32_hash_t seed) @trusted pure nothrow @nogc
+XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @trusted pure nothrow @nogc
 {
-    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2) {
+    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
+    {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH32_state_t state;
         XXH32_reset(&state, seed);
         XXH32_update(&state, cast(const(xxh_u8)*) input, len);
         return XXH32_digest(&state);
-    } else {
-        if (XXH_FORCE_ALIGN_CHECK) {
-            if (((cast(size_t) input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
-                return XXH32_endian_align(cast(const(xxh_u8)*)input, len, seed, XXH_alignment.XXH_aligned);
-        }   }
+    }
+    else
+    {
+        if (XXH_FORCE_ALIGN_CHECK)
+        {
+            if (((cast(size_t) input) & 3) == 0)
+            { /* Input is 4-bytes aligned, leverage the speed benefit */
+                return XXH32_endian_align(cast(const(xxh_u8)*) input, len,
+                        seed, XXH_alignment.XXH_aligned);
+            }
+        }
 
-        return XXH32_endian_align(cast(const(xxh_u8)*) input, len, seed, XXH_alignment.XXH_unaligned);
+        return XXH32_endian_align(cast(const(xxh_u8)*) input, len, seed,
+                XXH_alignment.XXH_unaligned);
     }
 }
 
 XXH32_state_t* XXH32_createState() @trusted pure nothrow @nogc
 {
     import core.memory : pureMalloc;
+
     return cast(XXH32_state_t*) pureMalloc(XXH32_state_t.sizeof);
 
 }
+
 XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr) @trusted pure nothrow @nogc
 {
     import core.memory : pureFree;
@@ -499,7 +562,7 @@ XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted p
 {
     import core.stdc.string : memset;
 
-    assert(statePtr != null);
+    assert(statePtr != null, "statePtr is null");
     memset(statePtr, 0, (*statePtr).sizeof);
     statePtr.v[0] = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
     statePtr.v[1] = seed + XXH_PRIME32_2;
@@ -512,51 +575,66 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 {
     import core.stdc.string : memcpy;
 
-    if (input==null) {
-        assert(len == 0);
+    if (input == null)
+    {
+        assert(len == 0, "input null ptr only allowed with len == 0");
         return XXH_errorcode.XXH_OK;
     }
 
-    {   const(xxh_u8)* p = cast(const(xxh_u8) *) input;
+    {
+        const(xxh_u8)* p = cast(const(xxh_u8)*) input;
         const xxh_u8* bEnd = p + len;
 
         state.total_len_32 += cast(XXH32_hash_t) len;
-        state.large_len |= cast(XXH32_hash_t) ((len>=16) | (state.total_len_32>=16));
+        state.large_len |= cast(XXH32_hash_t)((len >= 16) | (state.total_len_32 >= 16));
 
-        if (state.memsize + len < 16)  {   /* fill in tmp buffer */
-            memcpy(cast(xxh_u8*) (state.mem32) + state.memsize, input, len);
+        if (state.memsize + len < 16)
+        { /* fill in tmp buffer */
+            memcpy(cast(xxh_u8*)(state.mem32) + state.memsize, input, len);
             state.memsize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
 
-        if (state.memsize) {   /* some data left from previous update */
-            memcpy(cast(xxh_u8*) (state.mem32) + state.memsize, input, 16-state.memsize);
+        if (state.memsize)
+        { /* some data left from previous update */
+            memcpy(cast(xxh_u8*)(state.mem32) + state.memsize, input, 16 - state.memsize);
             {
-                const(xxh_u32)* p32 = cast(const(xxh_u32)*) &state.mem32[0];
-                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32)); p32++;
-                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p32)); p32++;
-                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p32)); p32++;
+                const(xxh_u32)* p32 = cast(const(xxh_u32)*)&state.mem32[0];
+                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32));
+                p32++;
+                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p32));
+                p32++;
+                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p32));
+                p32++;
                 state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p32));
             }
-            p += 16-state.memsize;
+            p += 16 - state.memsize;
             state.memsize = 0;
         }
 
-        if (p <= bEnd-16) {
+        if (p <= bEnd - 16)
+        {
             const xxh_u8* limit = bEnd - 16;
 
-            do {
-                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p)); p+=4;
-                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p)); p+=4;
-                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p)); p+=4;
-                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p)); p+=4;
-            } while (p<=limit);
+            do
+            {
+                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p));
+                p += 4;
+                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p));
+                p += 4;
+                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p));
+                p += 4;
+                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p));
+                p += 4;
+            }
+            while (p <= limit);
 
         }
 
-        if (p < bEnd) {
-            memcpy(cast(void*) &state.mem32[0], p, cast(size_t) (bEnd-p));
-            state.memsize = cast(XXH32_hash_t) (bEnd-p);
+        if (p < bEnd)
+        {
+            memcpy(cast(void*)&state.mem32[0], p, cast(size_t)(bEnd - p));
+            state.memsize = cast(XXH32_hash_t)(bEnd - p);
         }
     }
 
@@ -567,26 +645,30 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 {
     xxh_u32 h32;
 
-    if (state.large_len) {
-        h32 = XXH_rotl32(state.v[0], 1)
-            + XXH_rotl32(state.v[1], 7)
-            + XXH_rotl32(state.v[2], 12)
-            + XXH_rotl32(state.v[3], 18);
-    } else {
-        h32 = state.v[2] /* == seed */ + XXH_PRIME32_5;
+    if (state.large_len)
+    {
+        h32 = XXH_rotl32(state.v[0], 1) + XXH_rotl32(state.v[1],
+                7) + XXH_rotl32(state.v[2], 12) + XXH_rotl32(state.v[3], 18);
+    }
+    else
+    {
+        h32 = state.v[2] /* == seed */  + XXH_PRIME32_5;
     }
 
     h32 += state.total_len_32;
 
-    return XXH32_finalize(h32, cast(const xxh_u8*) state.mem32, state.memsize, XXH_alignment.XXH_aligned);
+    return XXH32_finalize(h32, cast(const xxh_u8*) state.mem32, state.memsize,
+            XXH_alignment.XXH_aligned);
 }
 
 void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
-    static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof);
-    static if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
+                    "(XXH32_canonical_t).sizeof != (XXH32_hash_t).sizeof");
+    static if (XXH_CPU_LITTLE_ENDIAN)
+        hash = XXH_swap32(hash);
     memcpy(dst, &hash, (*dst).sizeof);
 }
 
@@ -602,20 +684,16 @@ XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @trusted pure
 private xxh_u64 XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 {
     xxh_u64 val;
-    (cast(ubyte*) &val)[0 .. xxh_u64.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u64.sizeof];
+    (cast(ubyte*)&val)[0 .. xxh_u64.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u64.sizeof];
     return val;
 }
 
 private xxh_u64 XXH_swap64(xxh_u64 x) @trusted pure nothrow @nogc
 {
-    return  ((x << 56) & 0xff00000000000000) |
-            ((x << 40) & 0x00ff000000000000) |
-            ((x << 24) & 0x0000ff0000000000) |
-            ((x << 8)  & 0x000000ff00000000) |
-            ((x >> 8)  & 0x00000000ff000000) |
-            ((x >> 24) & 0x0000000000ff0000) |
-            ((x >> 40) & 0x000000000000ff00) |
-            ((x >> 56) & 0x00000000000000ff);
+    return ((x << 56) & 0xff00000000000000) | ((x << 40) & 0x00ff000000000000) | (
+            (x << 24) & 0x0000ff0000000000) | ((x << 8) & 0x000000ff00000000) | (
+            (x >> 8) & 0x00000000ff000000) | ((x >> 24) & 0x0000000000ff0000) | (
+            (x >> 40) & 0x000000000000ff00) | ((x >> 56) & 0x00000000000000ff);
 }
 
 private xxh_u64 XXH_readLE64(const void* ptr) @trusted pure nothrow @nogc
@@ -630,32 +708,36 @@ private xxh_u64 XXH_readBE64(const void* ptr) @trusted pure nothrow @nogc
 
 private xxh_u64 XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
-    if (align_==XXH_alignment.XXH_unaligned) {
+    if (align_ == XXH_alignment.XXH_unaligned)
+    {
         return XXH_readLE64(ptr);
-    } else {
-        return XXH_CPU_LITTLE_ENDIAN ? * cast(const xxh_u64*) ptr : XXH_swap64(* cast(const xxh_u64*) ptr);
+    }
+    else
+    {
+        return XXH_CPU_LITTLE_ENDIAN ? *cast(const xxh_u64*) ptr : XXH_swap64(
+                *cast(const xxh_u64*) ptr);
     }
 }
 
-enum XXH_PRIME64_1 = 0x9E3779B185EBCA87;  /*!< 0b1001111000110111011110011011000110000101111010111100101010000111 */
-enum XXH_PRIME64_2 = 0xC2B2AE3D27D4EB4F;  /*!< 0b1100001010110010101011100011110100100111110101001110101101001111 */
-enum XXH_PRIME64_3 = 0x165667B19E3779F9;  /*!< 0b0001011001010110011001111011000110011110001101110111100111111001 */
-enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63;  /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
-enum XXH_PRIME64_5 = 0x27D4EB2F165667C5;  /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
+enum XXH_PRIME64_1 = 0x9E3779B185EBCA87; /*!< 0b1001111000110111011110011011000110000101111010111100101010000111 */
+enum XXH_PRIME64_2 = 0xC2B2AE3D27D4EB4F; /*!< 0b1100001010110010101011100011110100100111110101001110101101001111 */
+enum XXH_PRIME64_3 = 0x165667B19E3779F9; /*!< 0b0001011001010110011001111011000110011110001101110111100111111001 */
+enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63; /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
+enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
 private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @trusted pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
-    acc  = XXH_rotl64(acc, 31);
+    acc = XXH_rotl64(acc, 31);
     acc *= XXH_PRIME64_1;
     return acc;
 }
 
 private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @trusted pure nothrow @nogc
 {
-    val  = XXH64_round(0, val);
+    val = XXH64_round(0, val);
     acc ^= val;
-    acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
+    acc = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
     return acc;
 }
 
@@ -689,31 +771,35 @@ xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @trusted pure nothrow
  * @return The finalized hash
  * @see XXH32_finalize().
  */
-private xxh_u64
-XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_) @trusted pure nothrow @nogc
+private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)
+    @trusted pure nothrow @nogc
 {
-    if (ptr==null) assert (len == 0);
+    if (ptr == null)
+        assert(len == 0, "len != 0");
 
     len &= 31;
-    while (len >= 8) {
+    while (len >= 8)
+    {
         xxh_u64 k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
         ptr += 8;
         hash ^= k1;
-        hash  = XXH_rotl64(hash,27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+        hash = XXH_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
         len -= 8;
     }
-    if (len >= 4) {
-        hash ^= cast(xxh_u64) (XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
+    if (len >= 4)
+    {
+        hash ^= cast(xxh_u64)(XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
         ptr += 4;
         hash = XXH_rotl64(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
         len -= 4;
     }
-    while (len > 0) {
+    while (len > 0)
+    {
         hash ^= (*ptr++) * XXH_PRIME64_5;
         hash = XXH_rotl64(hash, 11) * XXH_PRIME64_1;
         --len;
     }
-    return  XXH64_avalanche(hash);
+    return XXH64_avalanche(hash);
 }
 
 /*!
@@ -724,13 +810,15 @@ XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align
  * @param align Whether @p input is aligned.
  * @return The calculated hash.
  */
-private xxh_u64
-XXH64_endian_align(const(xxh_u8)* input, size_t len, xxh_u64 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+private xxh_u64 XXH64_endian_align(const(xxh_u8)* input, size_t len,
+        xxh_u64 seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     xxh_u64 h64;
-    if (input==null) assert(len == 0);
+    if (input == null)
+        assert(len == 0, "len != 0");
 
-    if (len>=32) {
+    if (len >= 32)
+    {
         const xxh_u8* bEnd = input + len;
         const xxh_u8* limit = bEnd - 31;
         xxh_u64 v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
@@ -738,12 +826,18 @@ XXH64_endian_align(const(xxh_u8)* input, size_t len, xxh_u64 seed, XXH_alignment
         xxh_u64 v3 = seed + 0;
         xxh_u64 v4 = seed - XXH_PRIME64_1;
 
-        do {
-            v1 = XXH64_round(v1, XXH_get64bits(input, align_)); input+=8;
-            v2 = XXH64_round(v2, XXH_get64bits(input, align_)); input+=8;
-            v3 = XXH64_round(v3, XXH_get64bits(input, align_)); input+=8;
-            v4 = XXH64_round(v4, XXH_get64bits(input, align_)); input+=8;
-        } while (input<limit);
+        do
+        {
+            v1 = XXH64_round(v1, XXH_get64bits(input, align_));
+            input += 8;
+            v2 = XXH64_round(v2, XXH_get64bits(input, align_));
+            input += 8;
+            v3 = XXH64_round(v3, XXH_get64bits(input, align_));
+            input += 8;
+            v4 = XXH64_round(v4, XXH_get64bits(input, align_));
+            input += 8;
+        }
+        while (input < limit);
 
         h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
         h64 = XXH64_mergeRound(h64, v1);
@@ -751,8 +845,10 @@ XXH64_endian_align(const(xxh_u8)* input, size_t len, xxh_u64 seed, XXH_alignment
         h64 = XXH64_mergeRound(h64, v3);
         h64 = XXH64_mergeRound(h64, v4);
 
-    } else {
-        h64  = seed + XXH_PRIME64_5;
+    }
+    else
+    {
+        h64 = seed + XXH_PRIME64_5;
     }
 
     h64 += cast(xxh_u64) len;
@@ -760,30 +856,40 @@ XXH64_endian_align(const(xxh_u8)* input, size_t len, xxh_u64 seed, XXH_alignment
     return XXH64_finalize(h64, input, len, align_);
 }
 
-XXH64_hash_t XXH64 (const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2) {
+    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
+    {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH64_state_t state;
         XXH64_reset(&state, seed);
         XXH64_update(&state, cast(const(xxh_u8)*) input, len);
         return XXH64_digest(&state);
-    } else {
-        if (XXH_FORCE_ALIGN_CHECK) {
-            if (((cast(size_t) input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
-                return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,  XXH_alignment.XXH_aligned);
-        }   }
+    }
+    else
+    {
+        if (XXH_FORCE_ALIGN_CHECK)
+        {
+            if (((cast(size_t) input) & 7) == 0)
+            { /* Input is aligned, let's leverage the speed advantage */
+                return XXH64_endian_align(cast(const(xxh_u8)*) input, len,
+                        seed, XXH_alignment.XXH_aligned);
+            }
+        }
 
-        return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,  XXH_alignment.XXH_unaligned);
+        return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,
+                XXH_alignment.XXH_unaligned);
     }
 }
 
 XXH64_state_t* XXH64_createState() @trusted pure nothrow @nogc
 {
     import core.memory : pureMalloc;
+
     return cast(XXH64_state_t*) pureMalloc(XXH64_state_t.sizeof);
 
 }
+
 XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr) @trusted pure nothrow @nogc
 {
     import core.memory : pureFree;
@@ -803,7 +909,7 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
 {
     import core.stdc.string : memset;
 
-    assert(statePtr != null);
+    assert(statePtr != null, "statePtr == null");
     memset(statePtr, 0, (*statePtr).sizeof);
     statePtr.v[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
     statePtr.v[1] = seed + XXH_PRIME64_2;
@@ -812,28 +918,32 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH64_update (XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
-    if (input==null) {
-        assert(len == 0);
+    if (input == null)
+    {
+        assert(len == 0, "len != 0");
         return XXH_errorcode.XXH_OK;
     }
 
-    {   const(xxh_u8)* p = cast(const(xxh_u8) *)input;
+    {
+        const(xxh_u8)* p = cast(const(xxh_u8)*) input;
         const xxh_u8* bEnd = p + len;
 
         state.total_len += len;
 
-        if (state.memsize + len < 32) {  /* fill in tmp buffer */
+        if (state.memsize + len < 32)
+        { /* fill in tmp buffer */
             memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, len);
             state.memsize += cast(xxh_u32) len;
             return XXH_errorcode.XXH_OK;
         }
 
-        if (state.memsize) {   /* tmp buffer is full */
-            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, 32-state.memsize);
+        if (state.memsize)
+        { /* tmp buffer is full */
+            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, 32 - state.memsize);
             state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
             state.v[1] = XXH64_round(state.v[1], XXH_readLE64(&state.mem64[1]));
             state.v[2] = XXH64_round(state.v[2], XXH_readLE64(&state.mem64[2]));
@@ -842,21 +952,29 @@ XXH_errorcode XXH64_update (XXH64_state_t* state, const void* input, size_t len)
             state.memsize = 0;
         }
 
-        if (p+32 <= bEnd) {
+        if (p + 32 <= bEnd)
+        {
             const xxh_u8* limit = bEnd - 32;
 
-            do {
-                state.v[0] = XXH64_round(state.v[0], XXH_readLE64(p)); p+=8;
-                state.v[1] = XXH64_round(state.v[1], XXH_readLE64(p)); p+=8;
-                state.v[2] = XXH64_round(state.v[2], XXH_readLE64(p)); p+=8;
-                state.v[3] = XXH64_round(state.v[3], XXH_readLE64(p)); p+=8;
-            } while (p<=limit);
+            do
+            {
+                state.v[0] = XXH64_round(state.v[0], XXH_readLE64(p));
+                p += 8;
+                state.v[1] = XXH64_round(state.v[1], XXH_readLE64(p));
+                p += 8;
+                state.v[2] = XXH64_round(state.v[2], XXH_readLE64(p));
+                p += 8;
+                state.v[3] = XXH64_round(state.v[3], XXH_readLE64(p));
+                p += 8;
+            }
+            while (p <= limit);
 
         }
 
-        if (p < bEnd) {
-            memcpy(cast(void*) &state.mem64[0], p, cast(size_t) (bEnd-p));
-            state.memsize = cast(XXH32_hash_t)(bEnd-p);
+        if (p < bEnd)
+        {
+            memcpy(cast(void*)&state.mem64[0], p, cast(size_t)(bEnd - p));
+            state.memsize = cast(XXH32_hash_t)(bEnd - p);
         }
     }
 
@@ -867,27 +985,34 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 {
     xxh_u64 h64;
 
-    if (state.total_len >= 32) {
-        h64 = XXH_rotl64(state.v[0], 1) + XXH_rotl64(state.v[1], 7) + XXH_rotl64(state.v[2], 12) + XXH_rotl64(state.v[3], 18);
+    if (state.total_len >= 32)
+    {
+        h64 = XXH_rotl64(state.v[0], 1) + XXH_rotl64(state.v[1],
+                7) + XXH_rotl64(state.v[2], 12) + XXH_rotl64(state.v[3], 18);
         h64 = XXH64_mergeRound(h64, state.v[0]);
         h64 = XXH64_mergeRound(h64, state.v[1]);
         h64 = XXH64_mergeRound(h64, state.v[2]);
         h64 = XXH64_mergeRound(h64, state.v[3]);
-    } else {
-        h64  = state.v[2] /*seed*/ + XXH_PRIME64_5;
+    }
+    else
+    {
+        h64 = state.v[2] /*seed*/  + XXH_PRIME64_5;
     }
 
     h64 += cast(xxh_u64) state.total_len;
 
-    return XXH64_finalize(h64, cast(const xxh_u8*) state.mem64, cast(size_t) state.total_len, XXH_alignment.XXH_aligned);
+    return XXH64_finalize(h64, cast(const xxh_u8*) state.mem64,
+            cast(size_t) state.total_len, XXH_alignment.XXH_aligned);
 }
 
 void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
-    static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof);
-    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
+                    "(XXH64_canonical_t).sizeof != (XXH64_hash_t).sizeof");
+    if (XXH_CPU_LITTLE_ENDIAN)
+        hash = XXH_swap64(hash);
     memcpy(dst, &hash, (*dst).sizeof);
 }
 
@@ -903,26 +1028,30 @@ XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @trusted pure
 ************************************************************************ */
 
 enum XXH3_SECRET_SIZE_MIN = 136; /// The bare minimum size for a custom secret.
-enum XXH3_SECRET_DEFAULT_SIZE = 192;   /* minimum XXH3_SECRET_SIZE_MIN */
-enum XXH_SECRET_DEFAULT_SIZE = 192;   /* minimum XXH3_SECRET_SIZE_MIN */
+enum XXH3_SECRET_DEFAULT_SIZE = 192; /* minimum XXH3_SECRET_SIZE_MIN */
+enum XXH_SECRET_DEFAULT_SIZE = 192; /* minimum XXH3_SECRET_SIZE_MIN */
 enum XXH3_INTERNALBUFFER_SIZE = 256; ///The size of the internal XXH3 buffer.
 
-static assert (XXH_SECRET_DEFAULT_SIZE >= XXH3_SECRET_SIZE_MIN, "default keyset is not large enough");
+static assert(XXH_SECRET_DEFAULT_SIZE >= XXH3_SECRET_SIZE_MIN, "default keyset is not large enough");
 
 /*! Pseudorandom secret taken directly from FARSH. */
 align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
-    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
-    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
-    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
-    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
-    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
-    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
-    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
-    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
-    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
-    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
-    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
-    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c,
+    0xf7, 0x21, 0xad, 0x1c, 0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb,
+    0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f, 0xcb, 0x79, 0xe6, 0x4e,
+    0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6,
+    0x81, 0x3a, 0x26, 0x4c, 0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb,
+    0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3, 0x71, 0x64, 0x48, 0x97,
+    0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7,
+    0xc7, 0x0b, 0x4f, 0x1d, 0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31,
+    0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64, 0xea, 0xc5, 0xac, 0x83,
+    0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26,
+    0x29, 0xd4, 0x68, 0x9e, 0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc,
+    0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce, 0x45, 0xcb, 0x3a, 0x8f,
+    0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
 ];
 
 /*
@@ -934,8 +1063,8 @@ align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
  */
 private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @trusted pure nothrow @nogc
 {
-    return (cast(xxh_u64) (x) * cast(xxh_u64) (y));
-} 
+    return (cast(xxh_u64)(x) * cast(xxh_u64)(y));
+}
 
 /*!
  * @brief Calculates a 64.128-bit long multiply.
@@ -946,34 +1075,35 @@ private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @trusted pure nothrow @nogc
  * @param lhs , rhs The 64-bit integers to be multiplied
  * @return The 128-bit result represented in an @ref XXH128_hash_t.
  */
-private XXH128_hash_t
-XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
 {
     static if (is(ucent))
     {
-        import std.int128;
+        //import std.int128;
         //alias uint128_t = Int128;
 
-        const uint128_t product = cast(uint128_t_)lhs * cast(uint128_t_)rhs;
+        const uint128_t product = cast(uint128_t_) lhs * cast(uint128_t_) rhs;
         XXH128_hash_t r128;
         // r128.low64  = cast(xxh_u64) (product);
         // r128.high64 = cast(xxh_u64) (product >> 64);
-        r128.low64  = product.data.lo;
+        r128.low64 = product.data.lo;
         r128.high64 = product.data.hi;
-    } else {
+    }
+    else
+    {
         /* First calculate all of the cross products. */
         const xxh_u64 lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
-        const xxh_u64 hi_lo = XXH_mult32to64(lhs >> 32,        rhs & 0xFFFFFFFF);
+        const xxh_u64 hi_lo = XXH_mult32to64(lhs >> 32, rhs & 0xFFFFFFFF);
         const xxh_u64 lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
-        const xxh_u64 hi_hi = XXH_mult32to64(lhs >> 32,        rhs >> 32);
+        const xxh_u64 hi_hi = XXH_mult32to64(lhs >> 32, rhs >> 32);
 
         /* Now add the products together. These will never overflow. */
         const xxh_u64 cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
-        const xxh_u64 upper = (hi_lo >> 32) + (cross >> 32)        + hi_hi;
+        const xxh_u64 upper = (hi_lo >> 32) + (cross >> 32) + hi_hi;
         const xxh_u64 lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
 
         XXH128_hash_t r128;
-        r128.low64  = lower;
+        r128.low64 = lower;
         r128.high64 = upper;
 
     }
@@ -990,8 +1120,7 @@ XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
  * @return The low 64 bits of the product XOR'd by the high 64 bits.
  * @see XXH_mult64to128()
  */
-private xxh_u64
-XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+private xxh_u64 XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
 {
     XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
     return product.low64 ^ product.high64;
@@ -1000,7 +1129,7 @@ XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
 /*! Seems to produce slightly better code on GCC for some reason. */
 private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @trusted pure nothrow @nogc
 {
-    assert(0 <= shift && shift < 64);
+    assert(0 <= shift && shift < 64, "shift out of range");
     return v64 ^ (v64 >> shift);
 }
 
@@ -1026,7 +1155,7 @@ static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @trusted pure nothrow 
     /* this mix is inspired by Pelle Evensen's rrmxmx */
     h64 ^= XXH_rotl64(h64, 49) ^ XXH_rotl64(h64, 24);
     h64 *= 0x9FB21C651E98DF25;
-    h64 ^= (h64 >> 35) + len ;
+    h64 ^= (h64 >> 35) + len;
     h64 *= 0x9FB21C651E98DF25;
     return XXH_xorshift64(h64, 28);
 }
@@ -1064,75 +1193,85 @@ static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @trusted pure nothrow 
  *
  * This adds an extra layer of strength for custom secrets.
  */
-private XXH64_hash_t
-XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_1to3_64b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(input != null);
-    assert(1 <= len && len <= 3);
-    assert(secret != null);
+    assert(input != null, "input == null");
+    assert(1 <= len && len <= 3, "len out of range");
+    assert(secret != null, "secret == null");
     /*
      * len = 1: combined = { input[0], 0x01, input[0], input[0] }
      * len = 2: combined = { input[1], 0x02, input[0], input[1] }
      * len = 3: combined = { input[2], 0x03, input[0], input[1] }
      */
-    {   const xxh_u8  c1 = input[0];
-        const xxh_u8  c2 = input[len >> 1];
-        const xxh_u8  c3 = input[len - 1];
-        const xxh_u32 combined = (cast(xxh_u32)c1 << 16) | (cast(xxh_u32)c2  << 24)
-                               | (cast(xxh_u32)c3 <<  0) | (cast(xxh_u32)len << 8);
-        const xxh_u64 bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
-        const xxh_u64 keyed = cast(xxh_u64)combined ^ bitflip;
+    {
+        const xxh_u8 c1 = input[0];
+        const xxh_u8 c2 = input[len >> 1];
+        const xxh_u8 c3 = input[len - 1];
+        const xxh_u32 combined = (cast(xxh_u32) c1 << 16) | (
+                cast(xxh_u32) c2 << 24) | (cast(xxh_u32) c3 << 0) | (cast(xxh_u32) len << 8);
+        const xxh_u64 bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+        const xxh_u64 keyed = cast(xxh_u64) combined ^ bitflip;
         return XXH64_avalanche(keyed);
     }
 }
 
-private XXH64_hash_t  
-XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_4to8_64b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(input != null);
-    assert(secret != null);
-    assert(4 <= len && len <= 8);
-    seed ^= cast(xxh_u64)XXH_swap32(cast(xxh_u32)seed) << 32;
-    {   const xxh_u32 input1 = XXH_readLE32(input);
+    assert(input != null, "input == null");
+    assert(secret != null, "secret == null");
+    assert(4 <= len && len <= 8, "len out of range");
+    seed ^= cast(xxh_u64) XXH_swap32(cast(xxh_u32) seed) << 32;
+    {
+        const xxh_u32 input1 = XXH_readLE32(input);
         const xxh_u32 input2 = XXH_readLE32(input + len - 4);
-        const xxh_u64 bitflip = (XXH_readLE64(secret+8) ^ XXH_readLE64(secret+16)) - seed;
-        const xxh_u64 input64 = input2 + ((cast(xxh_u64)input1) << 32);
+        const xxh_u64 bitflip = (XXH_readLE64(secret + 8) ^ XXH_readLE64(secret + 16)) - seed;
+        const xxh_u64 input64 = input2 + ((cast(xxh_u64) input1) << 32);
         const xxh_u64 keyed = input64 ^ bitflip;
         return XXH3_rrmxmx(keyed, len);
     }
 }
 
-private XXH64_hash_t
-XXH3_len_9to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_9to16_64b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(input != null);
-    assert(secret != null);
-    assert(9 <= len && len <= 16);
-    {   const xxh_u64 bitflip1 = (XXH_readLE64(secret+24) ^ XXH_readLE64(secret+32)) + seed;
-        const xxh_u64 bitflip2 = (XXH_readLE64(secret+40) ^ XXH_readLE64(secret+48)) - seed;
-        const xxh_u64 input_lo = XXH_readLE64(input)           ^ bitflip1;
+    assert(input != null, "input == null");
+    assert(secret != null, "secret == null");
+    assert(9 <= len && len <= 16, "len out of range");
+    {
+        const xxh_u64 bitflip1 = (XXH_readLE64(secret + 24) ^ XXH_readLE64(secret + 32)) + seed;
+        const xxh_u64 bitflip2 = (XXH_readLE64(secret + 40) ^ XXH_readLE64(secret + 48)) - seed;
+        const xxh_u64 input_lo = XXH_readLE64(input) ^ bitflip1;
         const xxh_u64 input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
-        const xxh_u64 acc = len
-                          + XXH_swap64(input_lo) + input_hi
-                          + XXH3_mul128_fold64(input_lo, input_hi);
+        const xxh_u64 acc = len + XXH_swap64(input_lo) + input_hi + XXH3_mul128_fold64(input_lo,
+                input_hi);
         return XXH3_avalanche(acc);
     }
 }
 
-private bool XXH_likely(bool exp) @trusted pure nothrow @nogc { return exp; }
-private bool XXH_unlikely(bool exp) @trusted pure nothrow @nogc { return exp; }
-
-private XXH64_hash_t 
-XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private bool XXH_likely(bool exp) @trusted pure nothrow @nogc
 {
-    assert(len <= 16);
-    {   if (XXH_likely(len >  8)) return XXH3_len_9to16_64b(input, len, secret, seed);
-        if (XXH_likely(len >= 4)) return XXH3_len_4to8_64b(input, len, secret, seed);
-        if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
-        return XXH64_avalanche(seed ^ (XXH_readLE64(secret+56) ^ XXH_readLE64(secret+64)));
+    return exp;
+}
+
+private bool XXH_unlikely(bool exp) @trusted pure nothrow @nogc
+{
+    return exp;
+}
+
+private XXH64_hash_t XXH3_len_0to16_64b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+{
+    assert(len <= 16, "len > 16");
+    {
+        if (XXH_likely(len > 8))
+            return XXH3_len_9to16_64b(input, len, secret, seed);
+        if (XXH_likely(len >= 4))
+            return XXH3_len_4to8_64b(input, len, secret, seed);
+        if (len)
+            return XXH3_len_1to3_64b(input, len, secret, seed);
+        return XXH64_avalanche(seed ^ (XXH_readLE64(secret + 56) ^ XXH_readLE64(secret + 64)));
     }
 }
 
@@ -1162,44 +1301,43 @@ XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
-private xxh_u64 XXH3_mix16B(const(xxh_u8)* input,
-                                     const(xxh_u8)* secret, xxh_u64 seed64)
-@trusted pure nothrow @nogc
+private xxh_u64 XXH3_mix16B(const(xxh_u8)* input, const(xxh_u8)* secret, xxh_u64 seed64) @trusted pure nothrow @nogc
 {
-    {   const xxh_u64 input_lo = XXH_readLE64(input);
-        const xxh_u64 input_hi = XXH_readLE64(input+8);
-        return XXH3_mul128_fold64(
-            input_lo ^ (XXH_readLE64(secret)   + seed64),
-            input_hi ^ (XXH_readLE64(secret+8) - seed64)
-        );
+    {
+        const xxh_u64 input_lo = XXH_readLE64(input);
+        const xxh_u64 input_hi = XXH_readLE64(input + 8);
+        return XXH3_mul128_fold64(input_lo ^ (XXH_readLE64(secret) + seed64),
+                input_hi ^ (XXH_readLE64(secret + 8) - seed64));
     }
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
-private XXH64_hash_t
-XXH3_len_17to128_64b(const(xxh_u8)* input, size_t len,
-                     const(xxh_u8)* secret, size_t secretSize,
-                     XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_17to128_64b(const(xxh_u8)* input, size_t len,
+        const(xxh_u8)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
-    assert(16 < len && len <= 128);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
+    cast(void) secretSize;
+    assert(16 < len && len <= 128, "len out of range");
 
-    {   xxh_u64 acc = len * XXH_PRIME64_1;
-        if (len > 32) {
-            if (len > 64) {
-                if (len > 96) {
-                    acc += XXH3_mix16B(input+48, secret+96, seed);
-                    acc += XXH3_mix16B(input+len-64, secret+112, seed);
+    {
+        xxh_u64 acc = len * XXH_PRIME64_1;
+        if (len > 32)
+        {
+            if (len > 64)
+            {
+                if (len > 96)
+                {
+                    acc += XXH3_mix16B(input + 48, secret + 96, seed);
+                    acc += XXH3_mix16B(input + len - 64, secret + 112, seed);
                 }
-                acc += XXH3_mix16B(input+32, secret+64, seed);
-                acc += XXH3_mix16B(input+len-48, secret+80, seed);
+                acc += XXH3_mix16B(input + 32, secret + 64, seed);
+                acc += XXH3_mix16B(input + len - 48, secret + 80, seed);
             }
-            acc += XXH3_mix16B(input+16, secret+32, seed);
-            acc += XXH3_mix16B(input+len-32, secret+48, seed);
+            acc += XXH3_mix16B(input + 16, secret + 32, seed);
+            acc += XXH3_mix16B(input + len - 32, secret + 48, seed);
         }
-        acc += XXH3_mix16B(input+0, secret+0, seed);
-        acc += XXH3_mix16B(input+len-16, secret+16, seed);
+        acc += XXH3_mix16B(input + 0, secret + 0, seed);
+        acc += XXH3_mix16B(input + len - 16, secret + 16, seed);
 
         return XXH3_avalanche(acc);
     }
@@ -1207,31 +1345,33 @@ XXH3_len_17to128_64b(const(xxh_u8)* input, size_t len,
 
 enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
-enum XXH3_MIDSIZE_LASTOFFSET  = 17;
+enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
-private XXH64_hash_t
-XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
-                      const(xxh_u8)* secret, size_t secretSize,
-                      XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
+        const(xxh_u8)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
-    assert(128 < len && len <= XXH3_MIDSIZE_MAX);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
+    cast(void) secretSize;
+    assert(128 < len && len <= XXH3_MIDSIZE_MAX, "128 >= len || len > XXH3_MIDSIZE_MAX");
 
-
-    {   xxh_u64 acc = len * XXH_PRIME64_1;
+    {
+        xxh_u64 acc = len * XXH_PRIME64_1;
         const int nbRounds = cast(int) len / 16;
         int i;
-        for (i=0; i<8; i++) {
-            acc += XXH3_mix16B(input+(16*i), secret+(16*i), seed);
+        for (i = 0; i < 8; i++)
+        {
+            acc += XXH3_mix16B(input + (16 * i), secret + (16 * i), seed);
         }
         acc = XXH3_avalanche(acc);
-        assert(nbRounds >= 8);
-        for (i=8 ; i < nbRounds; i++) {
-            acc += XXH3_mix16B(input+(16*i), secret+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
+        assert(nbRounds >= 8, "nbRounds < 8");
+        for (i = 8; i < nbRounds; i++)
+        {
+            acc += XXH3_mix16B(input + (16 * i),
+                    secret + (16 * (i - 8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
         }
         /* last bytes */
-        acc += XXH3_mix16B(input + len - 16, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+        acc += XXH3_mix16B(input + len - 16,
+                secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
         return XXH3_avalanche(acc);
     }
 }
@@ -1239,15 +1379,15 @@ XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
 /* =======     Long Keys     ======= */
 
 enum XXH_STRIPE_LEN = 64;
-enum XXH_SECRET_CONSUME_RATE = 8;   /* nb of secret bytes consumed at each accumulation */
+enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumulation */
 enum XXH_ACC_NB = (XXH_STRIPE_LEN / (xxh_u64).sizeof);
 
-
-private void XXH_writeLE64(void* dst, xxh_u64 v64)
-@trusted pure nothrow @nogc
+private void XXH_writeLE64(void* dst, xxh_u64 v64) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
-    if (!XXH_CPU_LITTLE_ENDIAN) v64 = XXH_swap64(v64);
+
+    if (!XXH_CPU_LITTLE_ENDIAN)
+        v64 = XXH_swap64(v64);
     memcpy(dst, &v64, (v64).sizeof);
 }
 
@@ -1264,18 +1404,14 @@ enum XXH_ACC_ALIGN = 8;
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-private void
-XXH3_scalarRound(void* acc,
-                 const(void) * input,
-                 const(void) * secret,
-                 size_t lane)
-@trusted pure nothrow @nogc
+private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
+    @trusted pure nothrow @nogc
 {
     xxh_u64* xacc = cast(xxh_u64*) acc;
-    xxh_u8 * xinput  = cast(xxh_u8 *) input;
-    xxh_u8 * xsecret = cast(xxh_u8 *) secret;
-    assert(lane < XXH_ACC_NB);
-    assert((cast(size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
+    xxh_u8* xinput = cast(xxh_u8*) input;
+    xxh_u8* xsecret = cast(xxh_u8*) secret;
+    assert(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB");
+    assert((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_ALIGN - 1)) != 0");
     {
         const xxh_u64 data_val = XXH_readLE64(xinput + lane * 8);
         const xxh_u64 data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
@@ -1288,14 +1424,11 @@ XXH3_scalarRound(void* acc,
  * @internal
  * @brief Processes a 64 byte block of data using the scalar path.
  */
-private void
-XXH3_accumulate_512_scalar(void* acc,
-                     const(void)* input,
-                     const(void)* secret)
-@trusted pure nothrow @nogc
+private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @trusted pure nothrow @nogc
 {
     size_t i;
-    for (i=0; i < XXH_ACC_NB; i++) {
+    for (i = 0; i < XXH_ACC_NB; i++)
+    {
         XXH3_scalarRound(acc, input, secret, i);
     }
 }
@@ -1307,16 +1440,12 @@ XXH3_accumulate_512_scalar(void* acc,
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-private void
-XXH3_scalarScrambleRound(void*  acc,
-                         const(void)*  secret,
-                         size_t lane)
-@trusted pure nothrow @nogc
+private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 {
-    xxh_u64* xacc = cast(xxh_u64*) acc;   /* presumed aligned */
-    const xxh_u8* xsecret = cast(const xxh_u8*) secret;   /* no alignment restriction */
-    assert(((cast(size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
-    assert(lane < XXH_ACC_NB);
+    xxh_u64* xacc = cast(xxh_u64*) acc; /* presumed aligned */
+    const xxh_u8* xsecret = cast(const xxh_u8*) secret; /* no alignment restriction */
+    assert(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0");
+    assert(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB");
     {
         const xxh_u64 key64 = XXH_readLE64(xsecret + lane * 8);
         xxh_u64 acc64 = xacc[lane];
@@ -1331,27 +1460,24 @@ XXH3_scalarScrambleRound(void*  acc,
  * @internal
  * @brief Scrambles the accumulators after a large chunk has been read
  */
-private void
-XXH3_scrambleAcc_scalar(void* acc, const(void)* secret)
-@trusted pure nothrow @nogc
+private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @trusted pure nothrow @nogc
 {
     size_t i;
-    for (i=0; i < XXH_ACC_NB; i++) {
+    for (i = 0; i < XXH_ACC_NB; i++)
+    {
         XXH3_scalarScrambleRound(acc, secret, i);
     }
 }
 
-private void
-XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64)
-@trusted pure nothrow @nogc
+private void XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64) @trusted pure nothrow @nogc
 {
     /*
      * We need a separate pointer for the hack below,
      * which requires a non-const pointer.
      * Any decent compiler will optimize this out otherwise.
      */
-    const xxh_u8* kSecretPtr = cast(xxh_u8*)XXH3_kSecret;
-    static assert((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
+    const xxh_u8* kSecretPtr = cast(xxh_u8*) XXH3_kSecret;
+    static assert((XXH_SECRET_DEFAULT_SIZE & 15) == 0, "(XXH_SECRET_DEFAULT_SIZE & 15) != 0");
 
     /*
      * Note: in debug mode, this overrides the asm optimization
@@ -1359,65 +1485,58 @@ XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64)
      */
     //assert(kSecretPtr == XXH3_kSecret);
 
-    {   const int nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
+    {
+        const int nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
         int i;
-        for (i=0; i < nbRounds; i++) {
+        for (i = 0; i < nbRounds; i++)
+        {
             /*
              * The asm hack causes Clang to assume that kSecretPtr aliases with
              * customSecret, and on aarch64, this prevented LDP from merging two
              * loads together for free. Putting the loads together before the stores
              * properly generates LDP.
              */
-            xxh_u64 lo = XXH_readLE64(kSecretPtr + 16*i)     + seed64;
-            xxh_u64 hi = XXH_readLE64(kSecretPtr + 16*i + 8) - seed64;
-            XXH_writeLE64(cast(xxh_u8*)customSecret + 16*i,     lo);
-            XXH_writeLE64(cast(xxh_u8*)customSecret + 16*i + 8, hi);
-    }   }
+            xxh_u64 lo = XXH_readLE64(kSecretPtr + 16 * i) + seed64;
+            xxh_u64 hi = XXH_readLE64(kSecretPtr + 16 * i + 8) - seed64;
+            XXH_writeLE64(cast(xxh_u8*) customSecret + 16 * i, lo);
+            XXH_writeLE64(cast(xxh_u8*) customSecret + 16 * i + 8, hi);
+        }
+    }
 }
 
-alias XXH3_f_accumulate_512 = void function(void* , const(void)*,  const(void)*) @trusted pure nothrow @nogc;
-alias XXH3_f_scrambleAcc = void function(void* , const void*)@trusted pure nothrow @nogc;
-alias XXH3_f_initCustomSecret = void function(void* , xxh_u64)@trusted pure nothrow @nogc;
+alias XXH3_f_accumulate_512 = void function(void*, const(void)*, const(void)*) @trusted pure nothrow @nogc;
+alias XXH3_f_scrambleAcc = void function(void*, const void*) @trusted pure nothrow @nogc;
+alias XXH3_f_initCustomSecret = void function(void*, xxh_u64) @trusted pure nothrow @nogc;
 
 immutable XXH3_f_accumulate_512 XXH3_accumulate_512 = &XXH3_accumulate_512_scalar;
-immutable XXH3_f_scrambleAcc XXH3_scrambleAcc    = &XXH3_scrambleAcc_scalar;
+immutable XXH3_f_scrambleAcc XXH3_scrambleAcc = &XXH3_scrambleAcc_scalar;
 immutable XXH3_f_initCustomSecret XXH3_initCustomSecret = &XXH3_initCustomSecret_scalar;
 
 enum XXH_PREFETCH_DIST = 384;
-private void XXH_PREFETCH(const xxh_u8* ptr) 
-@trusted pure nothrow @nogc
-{ cast(void)(ptr); }
+private void XXH_PREFETCH(const xxh_u8* ptr) @trusted pure nothrow @nogc
+{
+    cast(void)(ptr);
+}
 
 /*
  * XXH3_accumulate()
  * Loops over XXH3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
-private void
-XXH3_accumulate(     xxh_u64* acc,
-                const xxh_u8* input,
-                const xxh_u8* secret,
-                      size_t nbStripes,
-                      XXH3_f_accumulate_512 f_acc512)
-@trusted pure nothrow @nogc
+private void XXH3_accumulate(xxh_u64* acc, const xxh_u8* input,
+        const xxh_u8* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
     size_t n;
-    for (n = 0; n < nbStripes; n++ ) {
-        const xxh_u8* in_ = input + n*XXH_STRIPE_LEN;
+    for (n = 0; n < nbStripes; n++)
+    {
+        const xxh_u8* in_ = input + n * XXH_STRIPE_LEN;
         XXH_PREFETCH(in_ + XXH_PREFETCH_DIST);
-        f_acc512(acc,
-                 in_,
-                 secret + n*XXH_SECRET_CONSUME_RATE);
+        f_acc512(acc, in_, secret + n * XXH_SECRET_CONSUME_RATE);
     }
 }
 
-private void
-XXH3_hashLong_internal_loop(xxh_u64*  acc,
-                      const xxh_u8*  input, size_t len,
-                      const xxh_u8*  secret, size_t secretSize,
-                            XXH3_f_accumulate_512 f_acc512,
-                            XXH3_f_scrambleAcc f_scramble)
-@trusted pure nothrow @nogc
+private void XXH3_hashLong_internal_loop(xxh_u64* acc, const xxh_u8* input, size_t len, const xxh_u8* secret,
+        size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     const size_t nbStripesPerBlock = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
     const size_t block_len = XXH_STRIPE_LEN * nbStripesPerBlock;
@@ -1425,69 +1544,71 @@ XXH3_hashLong_internal_loop(xxh_u64*  acc,
 
     size_t n;
 
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
 
-    for (n = 0; n < nb_blocks; n++) {
-        XXH3_accumulate(acc, input + n*block_len, secret, nbStripesPerBlock, f_acc512);
+    for (n = 0; n < nb_blocks; n++)
+    {
+        XXH3_accumulate(acc, input + n * block_len, secret, nbStripesPerBlock, f_acc512);
         f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
     }
 
     /* last partial block */
-    assert(len > XXH_STRIPE_LEN);
-    {   const size_t nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
-        assert(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
-        XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, f_acc512);
+    assert(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN");
+    {
+        const size_t nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
+        assert(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE),
+                "nbStripes > (secretSize / XXH_SECRET_CONSUME_RATE)");
+        XXH3_accumulate(acc, input + nb_blocks * block_len, secret, nbStripes, f_acc512);
 
         /* last stripe */
-        {   const xxh_u8* p = input + len - XXH_STRIPE_LEN;
+        {
+            const xxh_u8* p = input + len - XXH_STRIPE_LEN;
             f_acc512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
-    }   }
+        }
+    }
 }
 
-enum XXH_SECRET_LASTACC_START = 7;  /* not aligned on 8, last secret is different from acc & scrambler */
+enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
-private xxh_u64
-XXH3_mix2Accs(const(xxh_u64)* acc, const(xxh_u8)* secret)
-@trusted pure nothrow @nogc
+private xxh_u64 XXH3_mix2Accs(const(xxh_u64)* acc, const(xxh_u8)* secret) @trusted pure nothrow @nogc
 {
-    return XXH3_mul128_fold64(
-               acc[0] ^ XXH_readLE64(secret),
-               acc[1] ^ XXH_readLE64(secret+8) );
+    return XXH3_mul128_fold64(acc[0] ^ XXH_readLE64(secret), acc[1] ^ XXH_readLE64(secret + 8));
 }
 
-private XXH64_hash_t
-XXH3_mergeAccs(const(xxh_u64)* acc, const(xxh_u8)* secret, xxh_u64 start)
+private XXH64_hash_t XXH3_mergeAccs(const(xxh_u64)* acc, const(xxh_u8)* secret, xxh_u64 start)
 @trusted pure nothrow @nogc
 {
     xxh_u64 result64 = start;
     size_t i = 0;
 
-    for (i = 0; i < 4; i++) {
-        result64 += XXH3_mix2Accs(acc+2*i, secret + 16*i);
+    for (i = 0; i < 4; i++)
+    {
+        result64 += XXH3_mix2Accs(acc + 2 * i, secret + 16 * i);
     }
 
     return XXH3_avalanche(result64);
 }
 
-enum XXH3_INIT_ACC = [ XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, 
-                        XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 ];
+static immutable XXH3_INIT_ACC = [
+        XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3,
+        XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1
+    ];
 
-private XXH64_hash_t
-XXH3_hashLong_64b_internal(const(void)*  input, size_t len,
-                           const(void)*  secret, size_t secretSize,
-                           XXH3_f_accumulate_512 f_acc512,
-                           XXH3_f_scrambleAcc f_scramble)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
+        size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const(xxh_u8)*) input, len, cast(const(xxh_u8)*) secret, secretSize, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(&acc[0], cast(const(xxh_u8)*) input, len,
+            cast(const(xxh_u8)*) secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
-    static assert((acc).sizeof == 64);
+    static assert((acc).sizeof == 64, "(acc).sizeof != 64");
     /* do not align on 8, so that the secret is different from the accumulator */
-    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
-    return XXH3_mergeAccs(&acc[0], cast(const(xxh_u8)*) secret + XXH_SECRET_MERGEACCS_START, cast(xxh_u64) len * XXH_PRIME64_1);
+    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START,
+            "secretSize < (acc).sizeof + XXH_SECRET_MERGEACCS_START");
+    return XXH3_mergeAccs(&acc[0], cast(const(xxh_u8)*) secret + XXH_SECRET_MERGEACCS_START,
+            cast(xxh_u64) len * XXH_PRIME64_1);
 }
 
 enum XXH_SECRET_MERGEACCS_START = 11;
@@ -1497,13 +1618,12 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * so that the compiler can properly optimize the vectorized loop.
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
-private XXH64_hash_t
-XXH3_hashLong_64b_withSecret(const(void)* input, size_t len,
-                             XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
+        size_t len, XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)seed64;
-    return XXH3_hashLong_64b_internal(input, len, secret, secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
+    cast(void) seed64;
+    return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
+            XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 /*
@@ -1512,13 +1632,14 @@ XXH3_hashLong_64b_withSecret(const(void)* input, size_t len,
  * Note that inside this no_inline function, we do inline the internal loop,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
-private XXH64_hash_t
-XXH3_hashLong_64b_default(const(void)* input, size_t len,
-                          XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_hashLong_64b_default(const(void)* input, size_t len,
+        XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)seed64; cast(void)secret; cast(void)secretLen;
-    return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
+    cast(void) seed64;
+    cast(void) secret;
+    cast(void) secretLen;
+    return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 enum XXH_SEC_ALIGN = 8;
@@ -1529,55 +1650,48 @@ enum XXH_SEC_ALIGN = 8;
  * and then use this key for long mode hashing.
  *
  * This operation is decently fast but nonetheless costs a little bit of time.
- * Try to avoid it whenever possible (typically when seed==0).
+ * Try to avoid it whenever possible (typically when seed == 0).
  *
  * It's important for performance that XXH3_hashLong is not inlined. Not sure
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
-private XXH64_hash_t
-XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len,
-                                    XXH64_hash_t seed,
-                                    XXH3_f_accumulate_512 f_acc512,
-                                    XXH3_f_scrambleAcc f_scramble,
-                                    XXH3_f_initCustomSecret f_initSec)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
+        XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
+        XXH3_f_initCustomSecret f_initSec) @trusted pure nothrow @nogc
 {
-//#if XXH_SIZE_OPT <= 0
+    //#if XXH_SIZE_OPT <= 0
     if (seed == 0)
-        return XXH3_hashLong_64b_internal(input, len,
-                                          &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
-                                          f_acc512, f_scramble);
-//#endif
-    {   align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0],
+                (XXH3_kSecret).sizeof, f_acc512, f_scramble);
+    //#endif
+    {
+        align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed);
-        return XXH3_hashLong_64b_internal(input, len, &secret[0], (secret).sizeof,
-                                          f_acc512, f_scramble);
+        return XXH3_hashLong_64b_internal(input, len, &secret[0], (secret)
+                .sizeof, f_acc512, f_scramble);
     }
 }
 
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-private XXH64_hash_t
-XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
-                           XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
+        XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)secret; cast(void)secretLen;
+    cast(void) secret;
+    cast(void) secretLen;
     return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
-                XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+            XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
 }
 
-alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)* , size_t,
-                                          XXH64_hash_t, const(xxh_u8)* , size_t) @trusted pure nothrow @nogc;
+alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
+        XXH64_hash_t, const(xxh_u8)*, size_t) @trusted pure nothrow @nogc;
 
-private XXH64_hash_t
-XXH3_64bits_internal(const(void)*  input, size_t len,
-                     XXH64_hash_t seed64, const(void)* secret, size_t secretLen,
-                     XXH3_hashLong64_f f_hashLong)
-@trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
+        XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
+        @trusted pure nothrow @nogc
 {
-    assert(secretLen >= XXH3_SECRET_SIZE_MIN);
+    assert(secretLen >= XXH3_SECRET_SIZE_MIN, "secretLen < XXH3_SECRET_SIZE_MIN");
     /*
      * If an action is to be taken if `secretLen` condition is not respected,
      * it should be done here.
@@ -1586,46 +1700,49 @@ XXH3_64bits_internal(const(void)*  input, size_t len,
      * Also, note that function signature doesn't offer room to return an error.
      */
     if (len <= 16)
-        return XXH3_len_0to16_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, seed64);
+        return XXH3_len_0to16_64b(cast(const(xxh_u8)*) input, len,
+                cast(const(xxh_u8)*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, secretLen, seed64);
+        return XXH3_len_17to128_64b(cast(const(xxh_u8)*) input, len,
+                cast(const(xxh_u8)*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, secretLen, seed64);
-    return f_hashLong(input, len, seed64, cast(const(xxh_u8)*)secret, secretLen);
+        return XXH3_len_129to240_64b(cast(const(xxh_u8)*) input, len,
+                cast(const(xxh_u8)*) secret, secretLen, seed64);
+    return f_hashLong(input, len, seed64, cast(const(xxh_u8)*) secret, secretLen);
 }
 
 /* ===   Public entry point   === */
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t XXH3_64bits(const(void)* input, size_t length)
-@trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits(const(void)* input, size_t length) @trusted pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, 0, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_default);
+    return XXH3_64bits_internal(input, length, 0, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_default);
 }
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t
-XXH3_64bits_withSecret(const(void)* input, size_t length, const(void)* secret, size_t secretSize)
-@trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits_withSecret(const(void)* input, size_t length,
+        const(void)* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, 0, secret, secretSize, &XXH3_hashLong_64b_withSecret);
+    return XXH3_64bits_internal(input, length, 0, secret, secretSize,
+            &XXH3_hashLong_64b_withSecret);
 }
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t
-XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_withSeed);
+    return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_withSeed);
 }
 
-XXH64_hash_t
-XXH3_64bits_withSecretandSeed(const(void)* input, size_t length, const(void)* secret, size_t secretSize, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits_withSecretandSeed(const(void)* input, size_t length,
+        const(void)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     if (length <= XXH3_MIDSIZE_MAX)
-        return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, null);
-    return XXH3_hashLong_64b_withSecret(input, length, seed, cast(const(xxh_u8)*)secret, secretSize);
+        return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
+                (XXH3_kSecret).sizeof, null);
+    return XXH3_hashLong_64b_withSecret(input, length, seed,
+            cast(const(xxh_u8)*) secret, secretSize);
 }
 
 /* ===   XXH3 streaming   === */
@@ -1652,31 +1769,31 @@ XXH3_64bits_withSecretandSeed(const(void)* input, size_t length, const(void)* se
  *
  * Align must be a power of 2 and 8 <= align <= 128.
  */
-private void* XXH_alignedMalloc(size_t s, size_t align_)
-@trusted nothrow @nogc
+private void* XXH_alignedMalloc(size_t s, size_t align_) @trusted nothrow @nogc
 {
     import core.stdc.stdlib : malloc;
 
-    assert(align_ <= 128 && align_ >= 8); /* range check */
-    assert((align_ & (align_-1)) == 0);   /* power of 2 */
-    assert(s != 0 && s < (s + align_));  /* empty/overflow */
-    {   /* Overallocate to make room for manual realignment and an offset byte */
-        xxh_u8* base = cast(xxh_u8*)malloc(s + align_);
-        if (base != null) {
+    assert(align_ <= 128 && align_ >= 8, "align out of range"); /* range check */
+    assert((align_ & (align_ - 1)) == 0, "(align_ & (align_ - 1)) != 0"); /* power of 2 */
+    assert(s != 0 && s < (s + align_), "s == 0 || s >= (s + align_)"); /* empty/overflow */
+    { /* Overallocate to make room for manual realignment and an offset byte */
+        xxh_u8* base = cast(xxh_u8*) malloc(s + align_);
+        if (base != null)
+        {
             /*
              * Get the offset needed to align this pointer.
              *
              * Even if the returned pointer is aligned, there will always be
              * at least one byte to store the offset to the original pointer.
              */
-            size_t offset = align_ - (cast(size_t)base & (align_ - 1)); /* base % align */
+            size_t offset = align_ - (cast(size_t) base & (align_ - 1)); /* base % align */
             /* Add the offset for the now-aligned pointer */
             xxh_u8* ptr = base + offset;
 
-            assert(cast(size_t)ptr % align_ == 0);
+            assert(cast(size_t) ptr % align_ == 0, "ptr % align_ != 0");
 
             /* Store the offset immediately before the returned pointer. */
-            ptr[-1] = cast(xxh_u8)offset;
+            ptr[-1] = cast(xxh_u8) offset;
             return ptr;
         }
         return null;
@@ -1686,13 +1803,13 @@ private void* XXH_alignedMalloc(size_t s, size_t align_)
  * Frees an aligned pointer allocated by XXH_alignedMalloc(). Don't pass
  * normal malloc'd pointers, XXH_alignedMalloc has a specific data layout.
  */
-private void XXH_alignedFree(void* p)
-@trusted nothrow @nogc
+private void XXH_alignedFree(void* p) @trusted nothrow @nogc
 {
     import core.stdc.stdlib : free;
 
-    if (p != null) {
-        xxh_u8* ptr = cast(xxh_u8*)p;
+    if (p != null)
+    {
+        xxh_u8* ptr = cast(xxh_u8*) p;
         /* Get the offset byte we added in XXH_malloc. */
         xxh_u8 offset = ptr[-1];
         /* Free the original malloc'd pointer */
@@ -1702,46 +1819,44 @@ private void XXH_alignedFree(void* p)
 }
 
 private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @trusted nothrow @nogc
-{ (XXH3_state_ptr).seed = 0; }
+{
+    (XXH3_state_ptr).seed = 0;
+}
 
 /*! @ingroup XXH3_family */
-XXH3_state_t* XXH3_createState()
-@trusted nothrow @nogc
+XXH3_state_t* XXH3_createState() @trusted nothrow @nogc
 {
-    XXH3_state_t* state = cast(XXH3_state_t*)XXH_alignedMalloc((XXH3_state_t).sizeof, 64);
-    if (state==null) return null;
+    XXH3_state_t* state = cast(XXH3_state_t*) XXH_alignedMalloc((XXH3_state_t).sizeof, 64);
+    if (state == null)
+        return null;
     XXH3_INITSTATE(state);
     return state;
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr)
-@trusted nothrow @nogc
+XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr) @trusted nothrow @nogc
 {
     XXH_alignedFree(statePtr);
     return XXH_errorcode.XXH_OK;
 }
 
-void
-XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state)
-@trusted pure nothrow @nogc
+void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
+
     memcpy(dst_state, src_state, (*dst_state).sizeof);
 }
 
-private void
-XXH3_reset_internal(XXH3_state_t* statePtr,
-                    XXH64_hash_t seed,
-                    const void* secret, size_t secretSize)
-@trusted pure nothrow @nogc
+private void XXH3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,
+        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memset;
 
     const size_t initStart = XXH3_state_t.bufferedSize.offsetof;
     const size_t initLength = XXH3_state_t.nbStripesPerBlock.offsetof - initStart;
-    assert(XXH3_state_t.nbStripesPerBlock.offsetof > initStart);
-    assert(statePtr != null);
+    assert(XXH3_state_t.nbStripesPerBlock.offsetof > initStart,
+            "(XXH3_state_t.nbStripesPerBlock.offsetof <= initStart");
+    assert(statePtr != null, "statePtr == null");
     /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
     memset(cast(char*) statePtr + initStart, 0, initLength);
     statePtr.acc[0] = XXH_PRIME32_3;
@@ -1755,76 +1870,84 @@ XXH3_reset_internal(XXH3_state_t* statePtr,
     statePtr.seed = seed;
     statePtr.useSeed = (seed != 0);
     statePtr.extSecret = cast(const(ubyte)*) secret;
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
     statePtr.secretLimit = secretSize - XXH_STRIPE_LEN;
     statePtr.nbStripesPerBlock = statePtr.secretLimit / XXH_SECRET_CONSUME_RATE;
 }
 
-XXH_errorcode
-XXH3_64bits_reset(XXH3_state_t* statePtr)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc
 {
-    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    if (statePtr == null)
+        return XXH_errorcode.XXH_ERROR;
     XXH3_reset_internal(statePtr, 0, &XXH3_kSecret[0], XXH_SECRET_DEFAULT_SIZE);
     return XXH_errorcode.XXH_OK;
 }
-XXH_errorcode
-XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
-@trusted pure nothrow @nogc
+
+XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr,
+        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
-    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    if (statePtr == null)
+        return XXH_errorcode.XXH_ERROR;
     XXH3_reset_internal(statePtr, 0, secret, secretSize);
-    if (secret == null) return  XXH_errorcode.XXH_ERROR;
-    if (secretSize < XXH3_SECRET_SIZE_MIN) return  XXH_errorcode.XXH_ERROR;
+    if (secret == null)
+        return XXH_errorcode.XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN)
+        return XXH_errorcode.XXH_ERROR;
     return XXH_errorcode.XXH_OK;
 }
-XXH_errorcode
-XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+
+XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
-    if (seed==0) return XXH3_64bits_reset(statePtr);
+    if (statePtr == null)
+        return XXH_errorcode.XXH_ERROR;
+    if (seed == 0)
+        return XXH3_64bits_reset(statePtr);
     if ((seed != statePtr.seed) || (statePtr.extSecret != null))
         XXH3_initCustomSecret(&statePtr.customSecret[0], seed);
     XXH3_reset_internal(statePtr, seed, null, XXH_SECRET_DEFAULT_SIZE);
     return XXH_errorcode.XXH_OK;
 }
-XXH_errorcode
-XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr, const(void)* secret, size_t secretSize, XXH64_hash_t seed64)
-@trusted pure nothrow @nogc
+
+XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
+        const(void)* secret, size_t secretSize, XXH64_hash_t seed64) @trusted pure nothrow @nogc
 {
-    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
-    if (secret == null) return XXH_errorcode.XXH_ERROR;
-    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_errorcode.XXH_ERROR;
+    if (statePtr == null)
+        return XXH_errorcode.XXH_ERROR;
+    if (secret == null)
+        return XXH_errorcode.XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN)
+        return XXH_errorcode.XXH_ERROR;
     XXH3_reset_internal(statePtr, seed64, secret, secretSize);
-    statePtr.useSeed = 1; /* always, even if seed64==0 */
+    statePtr.useSeed = 1; /* always, even if seed64 == 0 */
     return XXH_errorcode.XXH_OK;
 }
 
 /* Note : when XXH3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
-private void
-XXH3_consumeStripes(xxh_u64*  acc,
-                    size_t*  nbStripesSoFarPtr, size_t nbStripesPerBlock,
-                    const xxh_u8*  input, size_t nbStripes,
-                    const xxh_u8*  secret, size_t secretLimit,
-                    XXH3_f_accumulate_512 f_acc512,
-                    XXH3_f_scrambleAcc f_scramble)
-@trusted pure nothrow @nogc
+private void XXH3_consumeStripes(xxh_u64* acc, size_t* nbStripesSoFarPtr,
+        size_t nbStripesPerBlock, const xxh_u8* input, size_t nbStripes,
+        const xxh_u8* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
+        XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
-    assert(nbStripes <= nbStripesPerBlock);  /* can handle max 1 scramble per invocation */
-    assert(*nbStripesSoFarPtr < nbStripesPerBlock);
-    if (nbStripesPerBlock - *nbStripesSoFarPtr <= nbStripes) {
+    assert(nbStripes <= nbStripesPerBlock, "nbStripes > nbStripesPerBlock"); /* can handle max 1 scramble per invocation */
+    assert(*nbStripesSoFarPtr < nbStripesPerBlock, "*nbStripesSoFarPtr >= nbStripesPerBlock");
+    if (nbStripesPerBlock - *nbStripesSoFarPtr <= nbStripes)
+    {
         /* need a scrambling operation */
         const size_t nbStripesToEndofBlock = nbStripesPerBlock - *nbStripesSoFarPtr;
         const size_t nbStripesAfterBlock = nbStripes - nbStripesToEndofBlock;
-        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripesToEndofBlock, f_acc512);
+        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE,
+                nbStripesToEndofBlock, f_acc512);
         f_scramble(acc, secret + secretLimit);
-        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN, secret, nbStripesAfterBlock, f_acc512);
+        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN,
+                secret, nbStripesAfterBlock, f_acc512);
         *nbStripesSoFarPtr = nbStripesAfterBlock;
-    } else {
-        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, f_acc512);
+    }
+    else
+    {
+        XXH3_accumulate(acc, input,
+                secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, f_acc512);
         *nbStripesSoFarPtr += nbStripes;
     }
 }
@@ -1833,78 +1956,86 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
  */
-private XXH_errorcode
-XXH3_update(XXH3_state_t* state,
-            const(xxh_u8)*  input, size_t len,
-            XXH3_f_accumulate_512 f_acc512,
-            XXH3_f_scrambleAcc f_scramble)
-@trusted pure nothrow @nogc
+private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
+        size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
-    if (input==null) {
-        assert(len == 0);
+    if (input == null)
+    {
+        assert(len == 0, "len != 0");
         return XXH_errorcode.XXH_OK;
     }
 
-    assert(state != null);
-    {   const xxh_u8* bEnd = input + len;
-        const(ubyte)* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
-        static if (XXH3_STREAM_USE_STACK >= 1) {
+    assert(state != null, "state == null");
+    {
+        const xxh_u8* bEnd = input + len;
+        const(ubyte)* secret = (state.extSecret == null) ? &state
+            .customSecret[0] : &state.extSecret[0];
+        static if (XXH3_STREAM_USE_STACK >= 1)
+        {
             /* For some reason, gcc and MSVC seem to suffer greatly
             * when operating accumulators directly into state.
             * Operating into stack space seems to enable proper optimization.
             * clang, on the other hand, doesn't seem to need this trick */
-            align(XXH_ACC_ALIGN) xxh_u64[8] acc; memcpy(&acc[0], &state.acc[0], (acc).sizeof);
-        } else {
+            align(XXH_ACC_ALIGN) xxh_u64[8] acc;
+            memcpy(&acc[0], &state.acc[0], (acc).sizeof);
+        }
+        else
+        {
             xxh_u64* acc = state.acc;
         }
         state.totalLen += len;
-        assert(state.bufferedSize <= XXH3_INTERNALBUFFER_SIZE);
+        assert(state.bufferedSize <= XXH3_INTERNALBUFFER_SIZE, "state.bufferedSize > XXH3_INTERNALBUFFER_SIZE");
 
         /* small input : just fill in tmp buffer */
-        if (state.bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE) {
+        if (state.bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE)
+        {
             memcpy(&state.buffer[0] + state.bufferedSize, input, len);
-            state.bufferedSize += cast(XXH32_hash_t)len;
+            state.bufferedSize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
 
         /* total input is now > XXH3_INTERNALBUFFER_SIZE */
         enum XXH3_INTERNALBUFFER_STRIPES = (XXH3_INTERNALBUFFER_SIZE / XXH_STRIPE_LEN);
-        static assert(XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN == 0);   /* clean multiple */
+        static assert(XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN == 0, "XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN != 0"); /* clean multiple */
 
         /*
          * Internal buffer is partially filled (always, except at beginning)
          * Complete it, then consume it.
          */
-        if (state.bufferedSize) {
+        if (state.bufferedSize)
+        {
             const size_t loadSize = XXH3_INTERNALBUFFER_SIZE - state.bufferedSize;
             memcpy(&state.buffer[0] + state.bufferedSize, input, loadSize);
             input += loadSize;
-            XXH3_consumeStripes(&acc[0],
-                               &state.nbStripesSoFar, state.nbStripesPerBlock,
-                                &state.buffer[0], XXH3_INTERNALBUFFER_STRIPES,
-                                secret, state.secretLimit,
-                                f_acc512, f_scramble);
+            XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock,
+                    &state.buffer[0], XXH3_INTERNALBUFFER_STRIPES, secret,
+                    state.secretLimit, f_acc512, f_scramble);
             state.bufferedSize = 0;
         }
-        assert(input < bEnd);
+        assert(input < bEnd, "input >= bEnd");
 
         /* large input to consume : ingest per full block */
-        if (cast(size_t) (bEnd - input) > state.nbStripesPerBlock * XXH_STRIPE_LEN) {
-            size_t nbStripes = cast(size_t) (bEnd - 1 - input) / XXH_STRIPE_LEN;
-            assert(state.nbStripesPerBlock >= state.nbStripesSoFar);
+        if (cast(size_t)(bEnd - input) > state.nbStripesPerBlock * XXH_STRIPE_LEN)
+        {
+            size_t nbStripes = cast(size_t)(bEnd - 1 - input) / XXH_STRIPE_LEN;
+            assert(state.nbStripesPerBlock >= state.nbStripesSoFar, "state.nbStripesPerBlock < state.nbStripesSoFar");
             /* join to current block's end */
-            {   const size_t nbStripesToEnd = state.nbStripesPerBlock - state.nbStripesSoFar;
-                assert(nbStripesToEnd <= nbStripes);
-                XXH3_accumulate(&acc[0], input, secret + state.nbStripesSoFar * XXH_SECRET_CONSUME_RATE, nbStripesToEnd, f_acc512);
+            {
+                const size_t nbStripesToEnd = state.nbStripesPerBlock - state.nbStripesSoFar;
+                assert(nbStripesToEnd <= nbStripes, "nbStripesToEnd > nbStripes");
+                XXH3_accumulate(&acc[0], input,
+                        secret + state.nbStripesSoFar * XXH_SECRET_CONSUME_RATE,
+                        nbStripesToEnd, f_acc512);
                 f_scramble(&acc[0], secret + state.secretLimit);
                 state.nbStripesSoFar = 0;
                 input += nbStripesToEnd * XXH_STRIPE_LEN;
                 nbStripes -= nbStripesToEnd;
             }
             /* consume per entire blocks */
-            while(nbStripes >= state.nbStripesPerBlock) {
+            while (nbStripes >= state.nbStripesPerBlock)
+            {
                 XXH3_accumulate(&acc[0], input, secret, state.nbStripesPerBlock, f_acc512);
                 f_scramble(&acc[0], secret + state.secretLimit);
                 input += state.nbStripesPerBlock * XXH_STRIPE_LEN;
@@ -1913,36 +2044,42 @@ XXH3_update(XXH3_state_t* state,
             /* consume last partial block */
             XXH3_accumulate(&acc[0], input, secret, nbStripes, f_acc512);
             input += nbStripes * XXH_STRIPE_LEN;
-            assert(input < bEnd);  /* at least some bytes left */
+            assert(input < bEnd, "input exceeds buffer, no bytes left"); /* at least some bytes left */
             state.nbStripesSoFar = nbStripes;
             /* buffer predecessor of last partial stripe */
-            memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
-            assert(bEnd - input <= XXH_STRIPE_LEN);
-        } else {
+            memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN,
+                    input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+            assert(bEnd - input <= XXH_STRIPE_LEN, "input exceed strip length");
+        }
+        else
+        {
             /* content to consume <= block size */
             /* Consume input by a multiple of internal buffer size */
-            if (bEnd - input > XXH3_INTERNALBUFFER_SIZE) {
+            if (bEnd - input > XXH3_INTERNALBUFFER_SIZE)
+            {
                 const xxh_u8* limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
-                do {
-                    XXH3_consumeStripes(&acc[0],
-                                       &state.nbStripesSoFar, state.nbStripesPerBlock,
-                                        input, XXH3_INTERNALBUFFER_STRIPES,
-                                        secret, state.secretLimit,
-                                        f_acc512, f_scramble);
+                do
+                {
+                    XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock, input,
+                            XXH3_INTERNALBUFFER_STRIPES, secret,
+                            state.secretLimit, f_acc512, f_scramble);
                     input += XXH3_INTERNALBUFFER_SIZE;
-                } while (input<limit);
+                }
+                while (input < limit);
                 /* buffer predecessor of last partial stripe */
-                memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+                memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN,
+                        input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
             }
         }
 
         /* Some remaining input (always) : buffer it */
-        assert(input < bEnd);
-        assert(bEnd - input <= XXH3_INTERNALBUFFER_SIZE);
-        assert(state.bufferedSize == 0);
-        memcpy(&state.buffer[0], input, cast(size_t)(bEnd-input));
-        state.bufferedSize = cast(XXH32_hash_t)(bEnd-input);
-        static if (XXH3_STREAM_USE_STACK >= 1) {
+        assert(input < bEnd, "input exceeds buffer");
+        assert(bEnd - input <= XXH3_INTERNALBUFFER_SIZE, "input outside buffer");
+        assert(state.bufferedSize == 0, "bufferedSize != 0");
+        memcpy(&state.buffer[0], input, cast(size_t)(bEnd - input));
+        state.bufferedSize = cast(XXH32_hash_t)(bEnd - input);
+        static if (XXH3_STREAM_USE_STACK >= 1)
+        {
             /* save stack accumulators into state */
             memcpy(&state.acc[0], &acc[0], (acc).sizeof);
         }
@@ -1952,19 +2089,13 @@ XXH3_update(XXH3_state_t* state,
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode
-XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len) @trusted pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const(xxh_u8)*)input, len,
-                       XXH3_accumulate_512, XXH3_scrambleAcc);
+    return XXH3_update(state, cast(const(xxh_u8)*) input, len,
+            XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
-void
-XXH3_digest_long (XXH64_hash_t* acc,
-                  const XXH3_state_t* state,
-                  const ubyte* secret)
-@trusted pure nothrow @nogc
+void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
@@ -1973,47 +2104,44 @@ XXH3_digest_long (XXH64_hash_t* acc,
      * continue ingesting more input afterwards.
      */
     memcpy(&acc[0], &state.acc[0], (state.acc).sizeof);
-    if (state.bufferedSize >= XXH_STRIPE_LEN) {
+    if (state.bufferedSize >= XXH_STRIPE_LEN)
+    {
         const size_t nbStripes = (state.bufferedSize - 1) / XXH_STRIPE_LEN;
         size_t nbStripesSoFar = state.nbStripesSoFar;
-        XXH3_consumeStripes(acc,
-                           &nbStripesSoFar, state.nbStripesPerBlock,
-                            &state.buffer[0], nbStripes,
-                            secret, state.secretLimit,
-                            XXH3_accumulate_512, XXH3_scrambleAcc);
+        XXH3_consumeStripes(acc, &nbStripesSoFar, state.nbStripesPerBlock, &state.buffer[0],
+                nbStripes, secret, state.secretLimit, XXH3_accumulate_512, XXH3_scrambleAcc);
         /* last stripe */
-        XXH3_accumulate_512(acc,
-                            &state.buffer[0] + state.bufferedSize - XXH_STRIPE_LEN,
-                            secret + state.secretLimit - XXH_SECRET_LASTACC_START);
-    } else {  /* bufferedSize < XXH_STRIPE_LEN */
+        XXH3_accumulate_512(acc, &state.buffer[0] + state.bufferedSize - XXH_STRIPE_LEN,
+                secret + state.secretLimit - XXH_SECRET_LASTACC_START);
+    }
+    else
+    { /* bufferedSize < XXH_STRIPE_LEN */
         xxh_u8[XXH_STRIPE_LEN] lastStripe;
         const size_t catchupSize = XXH_STRIPE_LEN - state.bufferedSize;
-        assert(state.bufferedSize > 0);  /* there is always some input buffered */
+        assert(state.bufferedSize > 0, "bufferedSize <= 0"); /* there is always some input buffered */
         memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
         memcpy(&lastStripe[0] + catchupSize, &state.buffer[0], state.bufferedSize);
-        XXH3_accumulate_512(&acc[0],
-                            &lastStripe[0],
-                            &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
+        XXH3_accumulate_512(&acc[0], &lastStripe[0],
+                &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
     }
 }
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
-@trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
-    if (state.totalLen > XXH3_MIDSIZE_MAX) {
+    if (state.totalLen > XXH3_MIDSIZE_MAX)
+    {
         align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
         XXH3_digest_long(&acc[0], state, secret);
-        return XXH3_mergeAccs(&acc[0],
-                              secret + XXH_SECRET_MERGEACCS_START,
-                              cast(xxh_u64)state.totalLen * XXH_PRIME64_1);
+        return XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
+                cast(xxh_u64) state.totalLen * XXH_PRIME64_1);
     }
     /* totalLen <= XXH3_MIDSIZE_MAX: digesting a short input */
     if (state.useSeed)
-        return XXH3_64bits_withSeed(&state.buffer[0], cast(size_t)state.totalLen, state.seed);
-    return XXH3_64bits_withSecret(&state.buffer[0], cast(size_t)(state.totalLen),
-                                  secret, state.secretLimit + XXH_STRIPE_LEN);
+        return XXH3_64bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
+    return XXH3_64bits_withSecret(&state.buffer[0],
+            cast(size_t)(state.totalLen), secret, state.secretLimit + XXH_STRIPE_LEN);
 }
 
 /* ==========================================
@@ -2032,80 +2160,82 @@ XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
  * XXH128 is also more oriented towards 64-bit machines. It is still extremely
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
-private XXH128_hash_t
-XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_1to3_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     /* A doubled version of 1to3_64b with different constants. */
-    assert(input != null);
-    assert(1 <= len && len <= 3);
-    assert(secret != null);
+    assert(input != null, "input is null");
+    assert(1 <= len && len <= 3, "len is out of range");
+    assert(secret != null, "secret is null");
     /*
      * len = 1: combinedl = { input[0], 0x01, input[0], input[0] }
      * len = 2: combinedl = { input[1], 0x02, input[0], input[1] }
      * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
      */
-    {   const xxh_u8 c1 = input[0];
+    {
+        const xxh_u8 c1 = input[0];
         const xxh_u8 c2 = input[len >> 1];
         const xxh_u8 c3 = input[len - 1];
-        const xxh_u32 combinedl = (cast(xxh_u32)c1 <<16) | (cast(xxh_u32)c2 << 24)
-                                | (cast(xxh_u32)c3 << 0) | (cast(xxh_u32)len << 8);
+        const xxh_u32 combinedl = (cast(xxh_u32) c1 << 16) | (
+                cast(xxh_u32) c2 << 24) | (cast(xxh_u32) c3 << 0) | (cast(xxh_u32) len << 8);
         const xxh_u32 combinedh = XXH_rotl32(XXH_swap32(combinedl), 13);
-        const xxh_u64 bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
-        const xxh_u64 bitfliph = (XXH_readLE32(secret+8) ^ XXH_readLE32(secret+12)) - seed;
-        const xxh_u64 keyed_lo = cast(xxh_u64)combinedl ^ bitflipl;
-        const xxh_u64 keyed_hi = cast(xxh_u64)combinedh ^ bitfliph;
+        const xxh_u64 bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+        const xxh_u64 bitfliph = (XXH_readLE32(secret + 8) ^ XXH_readLE32(secret + 12)) - seed;
+        const xxh_u64 keyed_lo = cast(xxh_u64) combinedl ^ bitflipl;
+        const xxh_u64 keyed_hi = cast(xxh_u64) combinedh ^ bitfliph;
         XXH128_hash_t h128;
-        h128.low64  = XXH64_avalanche(keyed_lo);
+        h128.low64 = XXH64_avalanche(keyed_lo);
         h128.high64 = XXH64_avalanche(keyed_hi);
         return h128;
     }
 }
-private XXH128_hash_t
-XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+
+private XXH128_hash_t XXH3_len_4to8_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(input != null);
-    assert(secret != null);
-    assert(4 <= len && len <= 8);
-    seed ^= cast(xxh_u64)XXH_swap32(cast(xxh_u32)seed) << 32;
-    {   const xxh_u32 input_lo = XXH_readLE32(input);
+    assert(input != null, "input is null");
+    assert(secret != null, "secret is null");
+    assert(4 <= len && len <= 8, "len is out of range");
+    seed ^= cast(xxh_u64) XXH_swap32(cast(xxh_u32) seed) << 32;
+    {
+        const xxh_u32 input_lo = XXH_readLE32(input);
         const xxh_u32 input_hi = XXH_readLE32(input + len - 4);
-        const xxh_u64 input_64 = input_lo + (cast(xxh_u64)input_hi << 32);
-        const xxh_u64 bitflip = (XXH_readLE64(secret+16) ^ XXH_readLE64(secret+24)) + seed;
+        const xxh_u64 input_64 = input_lo + (cast(xxh_u64) input_hi << 32);
+        const xxh_u64 bitflip = (XXH_readLE64(secret + 16) ^ XXH_readLE64(secret + 24)) + seed;
         const xxh_u64 keyed = input_64 ^ bitflip;
 
         /* Shift len to the left to ensure it is even, this avoids even multiplies. */
         XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
 
         m128.high64 += (m128.low64 << 1);
-        m128.low64  ^= (m128.high64 >> 3);
+        m128.low64 ^= (m128.high64 >> 3);
 
-        m128.low64   = XXH_xorshift64(m128.low64, 35);
-        m128.low64  *= 0x9FB21C651E98DF25;
-        m128.low64   = XXH_xorshift64(m128.low64, 28);
-        m128.high64  = XXH3_avalanche(m128.high64);
+        m128.low64 = XXH_xorshift64(m128.low64, 35);
+        m128.low64 *= 0x9FB21C651E98DF25;
+        m128.low64 = XXH_xorshift64(m128.low64, 28);
+        m128.high64 = XXH3_avalanche(m128.high64);
         return m128;
     }
 }
-private XXH128_hash_t
-XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+
+private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(input != null);
-    assert(secret != null);
-    assert(9 <= len && len <= 16);
-    {   const xxh_u64 bitflipl = (XXH_readLE64(secret+32) ^ XXH_readLE64(secret+40)) - seed;
-        const xxh_u64 bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) + seed;
+    assert(input != null, "input is null");
+    assert(secret != null, "secret is null");
+    assert(9 <= len && len <= 16, "len out of range");
+    {
+        const xxh_u64 bitflipl = (XXH_readLE64(secret + 32) ^ XXH_readLE64(secret + 40)) - seed;
+        const xxh_u64 bitfliph = (XXH_readLE64(secret + 48) ^ XXH_readLE64(secret + 56)) + seed;
         const xxh_u64 input_lo = XXH_readLE64(input);
-        xxh_u64       input_hi = XXH_readLE64(input + len - 8);
+        xxh_u64 input_hi = XXH_readLE64(input + len - 8);
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
         /*
          * Put len in the middle of m128 to ensure that the length gets mixed to
          * both the low and high bits in the 128x64 multiply below.
          */
         m128.low64 += cast(xxh_u64)(len - 1) << 54;
-        input_hi   ^= bitfliph;
+        input_hi ^= bitfliph;
         /*
          * Add the high 32 bits of input_hi to the high 32 bits of m128, then
          * add the long product of the low 32 bits of input_hi and XXH_PRIME32_2 to
@@ -2113,15 +2243,19 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
          *
          * The best approach to this operation is different on 32-bit and 64-bit.
          */
-        if ((void *).sizeof < (xxh_u64).sizeof) { /* 32-bit */
+        if ((void*).sizeof < (xxh_u64).sizeof)
+        { /* 32-bit */
             /*
              * 32-bit optimized version, which is more readable.
              *
              * On 32-bit, it removes an ADC and delays a dependency between the two
              * halves of m128.high64, but it generates an extra mask on 64-bit.
              */
-            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(xxh_u32)input_hi, XXH_PRIME32_2);
-        } else {
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(xxh_u32) input_hi,
+                    XXH_PRIME32_2);
+        }
+        else
+        {
             /*
              * 64-bit optimized (albeit more confusing) version.
              *
@@ -2146,58 +2280,63 @@ XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64
              * Since input_hi.hi + input_hi.lo == input_hi, we get this:
              *    input_hi + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
              */
-            m128.high64 += input_hi + XXH_mult32to64(cast(xxh_u32)input_hi, XXH_PRIME32_2 - 1);
+            m128.high64 += input_hi + XXH_mult32to64(cast(xxh_u32) input_hi, XXH_PRIME32_2 - 1);
         }
         /* m128 ^= XXH_swap64(m128 >> 64); */
-        m128.low64  ^= XXH_swap64(m128.high64);
+        m128.low64 ^= XXH_swap64(m128.high64);
 
-        {   /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
+        { /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
             XXH128_hash_t h128 = XXH_mult64to128(m128.low64, XXH_PRIME64_2);
             h128.high64 += m128.high64 * XXH_PRIME64_2;
 
-            h128.low64   = XXH3_avalanche(h128.low64);
-            h128.high64  = XXH3_avalanche(h128.high64);
+            h128.low64 = XXH3_avalanche(h128.low64);
+            h128.high64 = XXH3_avalanche(h128.high64);
             return h128;
-    }   }
+        }
+    }
 }
-private XXH128_hash_t
-XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+
+private XXH128_hash_t XXH3_len_0to16_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(len <= 16);
-    {   if (len > 8) return XXH3_len_9to16_128b(input, len, secret, seed);
-        if (len >= 4) return XXH3_len_4to8_128b(input, len, secret, seed);
-        if (len) return XXH3_len_1to3_128b(input, len, secret, seed);
-        {   XXH128_hash_t h128;
-            const xxh_u64 bitflipl = XXH_readLE64(secret+64) ^ XXH_readLE64(secret+72);
-            const xxh_u64 bitfliph = XXH_readLE64(secret+80) ^ XXH_readLE64(secret+88);
+    assert(len <= 16, "len > 16");
+    {
+        if (len > 8)
+            return XXH3_len_9to16_128b(input, len, secret, seed);
+        if (len >= 4)
+            return XXH3_len_4to8_128b(input, len, secret, seed);
+        if (len)
+            return XXH3_len_1to3_128b(input, len, secret, seed);
+        {
+            XXH128_hash_t h128;
+            const xxh_u64 bitflipl = XXH_readLE64(secret + 64) ^ XXH_readLE64(secret + 72);
+            const xxh_u64 bitfliph = XXH_readLE64(secret + 80) ^ XXH_readLE64(secret + 88);
             h128.low64 = XXH64_avalanche(seed ^ bitflipl);
-            h128.high64 = XXH64_avalanche( seed ^ bitfliph);
+            h128.high64 = XXH64_avalanche(seed ^ bitfliph);
             return h128;
-    }   }
+        }
+    }
 }
-private XXH128_hash_t
-XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1, const xxh_u8* input_2,
-              const xxh_u8* secret, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+
+private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1,
+        const xxh_u8* input_2, const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    acc.low64  += XXH3_mix16B (input_1, secret+0, seed);
-    acc.low64  ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
-    acc.high64 += XXH3_mix16B (input_2, secret+16, seed);
+    acc.low64 += XXH3_mix16B(input_1, secret + 0, seed);
+    acc.low64 ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
+    acc.high64 += XXH3_mix16B(input_2, secret + 16, seed);
     acc.high64 ^= XXH_readLE64(input_1) + XXH_readLE64(input_1 + 8);
     return acc;
 }
 
-private XXH128_hash_t
-XXH3_len_17to128_128b(const xxh_u8*  input, size_t len,
-                      const xxh_u8*  secret, size_t secretSize,
-                      XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_17to128_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
-    assert(16 < len && len <= 128);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSie < XXH3_SECRET_SIZE_MIN");
+    cast(void) secretSize;
+    assert(16 < len && len <= 128, "len out of range");
 
-    {   XXH128_hash_t acc;
+    {
+        XXH128_hash_t acc;
         acc.low64 = len * XXH_PRIME64_1;
         acc.high64 = 0;
 
@@ -2205,178 +2344,160 @@ XXH3_len_17to128_128b(const xxh_u8*  input, size_t len,
         {
             /* Smaller, but slightly slower. */
             size_t i = (len - 1) / 32;
-            do {
-                acc = XXH128_mix32B(acc, input+16*i, input+len-16*(i+1), secret+32*i, seed);
-            } while (i-- != 0);
-        }
-        else 
-        {
-            if (len > 32) {
-                if (len > 64) {
-                    if (len > 96) {
-                        acc = XXH128_mix32B(acc, input+48, input+len-64, secret+96, seed);
-                    }
-                    acc = XXH128_mix32B(acc, input+32, input+len-48, secret+64, seed);
-                }
-                acc = XXH128_mix32B(acc, input+16, input+len-32, secret+32, seed);
+            do
+            {
+                acc = XXH128_mix32B(acc, input + 16 * i,
+                        input + len - 16 * (i + 1), secret + 32 * i, seed);
             }
-            acc = XXH128_mix32B(acc, input, input+len-16, secret, seed);
+            while (i-- != 0);
         }
-        {   XXH128_hash_t h128;
-            h128.low64  = acc.low64 + acc.high64;
-            h128.high64 = (acc.low64    * XXH_PRIME64_1)
-                        + (acc.high64   * XXH_PRIME64_4)
-                        + ((len - seed) * XXH_PRIME64_2);
-            h128.low64  = XXH3_avalanche(h128.low64);
-            h128.high64 = cast(XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+        else
+        {
+            if (len > 32)
+            {
+                if (len > 64)
+                {
+                    if (len > 96)
+                    {
+                        acc = XXH128_mix32B(acc, input + 48, input + len - 64, secret + 96, seed);
+                    }
+                    acc = XXH128_mix32B(acc, input + 32, input + len - 48, secret + 64, seed);
+                }
+                acc = XXH128_mix32B(acc, input + 16, input + len - 32, secret + 32, seed);
+            }
+            acc = XXH128_mix32B(acc, input, input + len - 16, secret, seed);
+        }
+        {
+            XXH128_hash_t h128;
+            h128.low64 = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64 * XXH_PRIME64_1) + (
+                    acc.high64 * XXH_PRIME64_4) + ((len - seed) * XXH_PRIME64_2);
+            h128.low64 = XXH3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t) 0 - XXH3_avalanche(h128.high64);
             return h128;
         }
     }
 }
 
-private XXH128_hash_t
-XXH3_len_129to240_128b(const xxh_u8*  input, size_t len,
-                       const xxh_u8*  secret, size_t secretSize,
-                       XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_129to240_128b(const xxh_u8* input, size_t len,
+        const xxh_u8* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
-    assert(128 < len && len <= XXH3_MIDSIZE_MAX);
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
+    cast(void) secretSize;
+    assert(128 < len && len <= XXH3_MIDSIZE_MAX, "len > 128 or len > XXH3_MIDSIZE_MAX");
 
-    {   XXH128_hash_t acc;
-        const int nbRounds = cast(int)len / 32;
+    {
+        XXH128_hash_t acc;
+        const int nbRounds = cast(int) len / 32;
         int i;
         acc.low64 = len * XXH_PRIME64_1;
         acc.high64 = 0;
-        for (i=0; i<4; i++) {
-            acc = XXH128_mix32B(acc,
-                                input  + (32 * i),
-                                input  + (32 * i) + 16,
-                                secret + (32 * i),
-                                seed);
+        for (i = 0; i < 4; i++)
+        {
+            acc = XXH128_mix32B(acc, input + (32 * i), input + (32 * i) + 16, secret + (32 * i),
+                    seed);
         }
         acc.low64 = XXH3_avalanche(acc.low64);
         acc.high64 = XXH3_avalanche(acc.high64);
-        assert(nbRounds >= 4);
-        for (i=4 ; i < nbRounds; i++) {
-            acc = XXH128_mix32B(acc,
-                                input + (32 * i),
-                                input + (32 * i) + 16,
-                                secret + XXH3_MIDSIZE_STARTOFFSET + (32 * (i - 4)),
-                                seed);
+        assert(nbRounds >= 4, "nbRounds < 4");
+        for (i = 4; i < nbRounds; i++)
+        {
+            acc = XXH128_mix32B(acc, input + (32 * i), input + (32 * i) + 16,
+                    secret + XXH3_MIDSIZE_STARTOFFSET + (32 * (i - 4)), seed);
         }
         /* last bytes */
-        acc = XXH128_mix32B(acc,
-                            input + len - 16,
-                            input + len - 32,
-                            secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16,
-                            0 - seed);
+        acc = XXH128_mix32B(acc, input + len - 16, input + len - 32,
+                secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0 - seed);
 
-        {   XXH128_hash_t h128;
-            h128.low64  = acc.low64 + acc.high64;
-            h128.high64 = (acc.low64    * XXH_PRIME64_1)
-                        + (acc.high64   * XXH_PRIME64_4)
-                        + ((len - seed) * XXH_PRIME64_2);
-            h128.low64  = XXH3_avalanche(h128.low64);
-            h128.high64 = cast(XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+        {
+            XXH128_hash_t h128;
+            h128.low64 = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64 * XXH_PRIME64_1) + (
+                    acc.high64 * XXH_PRIME64_4) + ((len - seed) * XXH_PRIME64_2);
+            h128.low64 = XXH3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t) 0 - XXH3_avalanche(h128.high64);
             return h128;
         }
     }
 }
 
-private XXH128_hash_t
-XXH3_hashLong_128b_internal(const void*  input, size_t len,
-                            const xxh_u8*  secret, size_t secretSize,
-                            XXH3_f_accumulate_512 f_acc512,
-                            XXH3_f_scrambleAcc f_scramble)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len, const xxh_u8* secret,
+        size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const xxh_u8*)input, len, secret, secretSize, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(&acc[0], cast(const xxh_u8*) input, len,
+            secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
-    static assert((acc).sizeof == 64);
-    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
-    {   XXH128_hash_t h128;
-        h128.low64  = XXH3_mergeAccs(&acc[0],
-                                     secret + XXH_SECRET_MERGEACCS_START,
-                                     cast(xxh_u64)len * XXH_PRIME64_1);
-        h128.high64 = XXH3_mergeAccs(&acc[0],
-                                     secret + secretSize
-                                            - (acc).sizeof - XXH_SECRET_MERGEACCS_START,
-                                     ~(cast(xxh_u64)len * XXH_PRIME64_2));
+    static assert((acc).sizeof == 64, "acc isn't 64 bytes long");
+    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START, "secretSze < allowed limit.");
+    {
+        XXH128_hash_t h128;
+        h128.low64 = XXH3_mergeAccs(&acc[0],
+                secret + XXH_SECRET_MERGEACCS_START, cast(xxh_u64) len * XXH_PRIME64_1);
+        h128.high64 = XXH3_mergeAccs(&acc[0], secret + secretSize - (acc)
+                .sizeof - XXH_SECRET_MERGEACCS_START, ~(cast(xxh_u64) len * XXH_PRIME64_2));
         return h128;
     }
 }
 
-private XXH128_hash_t
-XXH3_hashLong_128b_default(const void*  input, size_t len,
-                           XXH64_hash_t seed64,
-                           const void*  secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
+        XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)seed64; cast(void)secret; cast(void)secretLen;
-    return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
-                                       XXH3_accumulate_512, XXH3_scrambleAcc);
+    cast(void) seed64;
+    cast(void) secret;
+    cast(void) secretLen;
+    return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 /*
  * It's important for performance to pass @p secretLen (when it's static)
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
-private XXH128_hash_t
-XXH3_hashLong_128b_withSecret(const void* input, size_t len,
-                              XXH64_hash_t seed64,
-                              const void* secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
+        size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)seed64;
-    return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*)secret, secretLen,
-                                       XXH3_accumulate_512, XXH3_scrambleAcc);
+    cast(void) seed64;
+    return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*) secret,
+            secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
-private XXH128_hash_t
-XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len,
-                                XXH64_hash_t seed64,
-                                XXH3_f_accumulate_512 f_acc512,
-                                XXH3_f_scrambleAcc f_scramble,
-                                XXH3_f_initCustomSecret f_initSec)
-@trusted pure nothrow @nogc
+
+private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
+        XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
+        XXH3_f_initCustomSecret f_initSec) @trusted pure nothrow @nogc
 {
     if (seed64 == 0)
-        return XXH3_hashLong_128b_internal(input, len,
-                                           &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
-                                           f_acc512, f_scramble);
-    {   align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
+                (XXH3_kSecret).sizeof, f_acc512, f_scramble);
+    {
+        align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed64);
-        return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*)&secret[0], (secret).sizeof,
-                                           f_acc512, f_scramble);
+        return XXH3_hashLong_128b_internal(input, len,
+                cast(const xxh_u8*)&secret[0], (secret).sizeof, f_acc512, f_scramble);
     }
 }
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-private XXH128_hash_t
-XXH3_hashLong_128b_withSeed(const void* input, size_t len,
-                            XXH64_hash_t seed64, const void* secret, size_t secretLen)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
+        XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
 {
-    cast(void)secret; cast(void)secretLen;
+    cast(void) secret;
+    cast(void) secretLen;
     return XXH3_hashLong_128b_withSeed_internal(input, len, seed64,
-                XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+            XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
 }
 
-alias XXH3_hashLong128_f = XXH128_hash_t function(const void* , size_t,
-                                            XXH64_hash_t, const void* , size_t)
-                                            @trusted pure nothrow @nogc;
+alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
+        XXH64_hash_t, const void*, size_t) @trusted pure nothrow @nogc;
 
-private XXH128_hash_t
-XXH3_128bits_internal(const void* input, size_t len,
-                      XXH64_hash_t seed64, const void* secret, size_t secretLen,
-                      XXH3_hashLong128_f f_hl128)
-@trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
+        XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
+        @trusted pure nothrow @nogc
 {
-    assert(secretLen >= XXH3_SECRET_SIZE_MIN);
+    assert(secretLen >= XXH3_SECRET_SIZE_MIN, "Secret length is < XXH3_SECRET_SIZE_MIN");
     /*
      * If an action is to be taken if `secret` conditions are not respected,
      * it should be done here.
@@ -2384,204 +2505,115 @@ XXH3_128bits_internal(const void* input, size_t len,
      * Adding a check and a branch here would cost performance at every hash.
      */
     if (len <= 16)
-        return XXH3_len_0to16_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, seed64);
+        return XXH3_len_0to16_128b(cast(const xxh_u8*) input, len,
+                cast(const xxh_u8*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, secretLen, seed64);
+        return XXH3_len_17to128_128b(cast(const xxh_u8*) input, len,
+                cast(const xxh_u8*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, secretLen, seed64);
+        return XXH3_len_129to240_128b(cast(const xxh_u8*) input, len,
+                cast(const xxh_u8*) secret, secretLen, seed64);
     return f_hl128(input, len, seed64, secret, secretLen);
 }
 
 /* ===   Public XXH128 API   === */
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t XXH3_128bits(const void* input, size_t len)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits(const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, 0,
-                                 &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
-                                 &XXH3_hashLong_128b_default);
+    return XXH3_128bits_internal(input, len, 0, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_default);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t
-XXH3_128bits_withSecret(const void* input, size_t len, const void* secret, size_t secretSize)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits_withSecret(const void* input, size_t len,
+        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, 0,
-                                 cast(const xxh_u8*)secret, secretSize,
-                                 &XXH3_hashLong_128b_withSecret);
+    return XXH3_128bits_internal(input, len, 0, cast(const xxh_u8*) secret,
+            secretSize, &XXH3_hashLong_128b_withSecret);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t
-XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, seed,
-                                 &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
-                                 &XXH3_hashLong_128b_withSeed);
+    return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
+            (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_withSeed);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t
-XXH3_128bits_withSecretandSeed(const void* input, size_t len, const void* secret, size_t secretSize, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits_withSecretandSeed(const void* input, size_t len,
+        const void* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, null);
+        return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
+                (XXH3_kSecret).sizeof, null);
     return XXH3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t
-XXH128(const void* input, size_t len, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH128(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     return XXH3_128bits_withSeed(input, len, seed);
 }
 
-XXH_errorcode
-XXH3_128bits_reset(XXH3_state_t* statePtr)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc
 {
     return XXH3_64bits_reset(statePtr);
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode
-XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr,
+        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSecret(statePtr, secret, secretSize);
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode
-XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSeed(statePtr, seed);
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode
-XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr, const void* secret, size_t secretSize, XXH64_hash_t seed)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
+        const void* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
 }
 
-XXH_errorcode
-XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
-@trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const xxh_u8*)input, len,
-                       XXH3_accumulate_512, XXH3_scrambleAcc);
+    return XXH3_update(state, cast(const xxh_u8*) input, len,
+            XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
-@trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
-    if (state.totalLen > XXH3_MIDSIZE_MAX) {
+    if (state.totalLen > XXH3_MIDSIZE_MAX)
+    {
         align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
         XXH3_digest_long(&acc[0], state, secret);
-        assert(state.secretLimit + XXH_STRIPE_LEN >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
-        {   XXH128_hash_t h128;
-            h128.low64  = XXH3_mergeAccs(&acc[0],
-                                         secret + XXH_SECRET_MERGEACCS_START,
-                                         cast(xxh_u64)state.totalLen * XXH_PRIME64_1);
-            h128.high64 = XXH3_mergeAccs(&acc[0],
-                                         secret + state.secretLimit + XXH_STRIPE_LEN
-                                                - (acc).sizeof - XXH_SECRET_MERGEACCS_START,
-                                         ~(cast(xxh_u64)state.totalLen * XXH_PRIME64_2));
+        assert(state.secretLimit + XXH_STRIPE_LEN >= (acc).sizeof + XXH_SECRET_MERGEACCS_START, "Internal error");
+        {
+            XXH128_hash_t h128;
+            h128.low64 = XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
+                    cast(xxh_u64) state.totalLen * XXH_PRIME64_1);
+            h128.high64 = XXH3_mergeAccs(&acc[0], secret + state.secretLimit + XXH_STRIPE_LEN - (acc)
+                    .sizeof - XXH_SECRET_MERGEACCS_START,
+                    ~(cast(xxh_u64) state.totalLen * XXH_PRIME64_2));
             return h128;
         }
     }
     /* len <= XXH3_MIDSIZE_MAX : short code */
     if (state.seed)
-        return XXH3_128bits_withSeed(&state.buffer[0], cast(size_t)state.totalLen, state.seed);
-    return XXH3_128bits_withSecret(&state.buffer[0], cast(size_t)(state.totalLen),
-                                   secret, state.secretLimit + XXH_STRIPE_LEN);
+        return XXH3_128bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
+    return XXH3_128bits_withSecret(&state.buffer[0],
+            cast(size_t)(state.totalLen), secret, state.secretLimit + XXH_STRIPE_LEN);
 }
 
 /* ----------------------------------------------------------------------------------------*/
-/* ----------------------------------------------------------------------------------------*/
-extern (C) {
-//    uint XXH_versionNumber () @trusted pure nothrow @nogc;
-//    XXH32_hash_t XXH32 (const void* input, size_t length, XXH32_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH32_state_t* XXH32_createState() @trusted pure nothrow @nogc;
-//    XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr) @trusted pure nothrow @nogc;
-//    void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length) @trusted pure nothrow @nogc;
-//    XXH32_hash_t XXH32_digest (const XXH32_state_t* statePtr) @trusted pure nothrow @nogc;
-//    void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc;
-//    XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @trusted pure nothrow @nogc;
-
-//    XXH64_hash_t XXH64(const void* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH64_state_t* XXH64_createState() @trusted pure nothrow @nogc;
-//    XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr) @trusted pure nothrow @nogc;
-//    void XXH64_copyState(XXH64_state_t* dst_state, const XXH64_state_t* src_state) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH64_reset  (XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length) @trusted pure nothrow @nogc;
-//    XXH64_hash_t XXH64_digest (const XXH64_state_t* statePtr) @trusted pure nothrow @nogc;
-//    void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc;
-//    XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @trusted pure nothrow @nogc;
-
-//    XXH64_hash_t XXH3_64bits(const void* input, size_t length) @trusted pure nothrow @nogc;
-//    XXH64_hash_t XXH3_64bits_withSeed(const void* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
-//        @trusted pure nothrow @nogc;
-//    XXH3_state_t* XXH3_createState() @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
-//    void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
-//        @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_64bits_update (XXH3_state_t* statePtr, const void* input, size_t length)
-//        @trusted pure nothrow @nogc;
-//    XXH64_hash_t  XXH3_64bits_digest (const XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
-
-//    XXH128_hash_t XXH3_128bits(const void* data, size_t len) @trusted pure nothrow @nogc;
-//    XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH128_hash_t XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
-//        @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
-//        @trusted pure nothrow @nogc;
-//    XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const void* input, size_t length)
-//        @trusted pure nothrow @nogc;
-//    XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
-
-    int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2) @trusted pure nothrow @nogc;
-    int XXH128_cmp(const void* h128_1, const void* h128_2) @trusted pure nothrow @nogc;
-    void XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash) @trusted pure nothrow @nogc;
-    XXH128_hash_t XXH128_hashFromCanonical(const XXH128_canonical_t* src) @trusted pure nothrow @nogc;
-    XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-
-    XXH_errorcode XXH3_generateSecret(void* secretBuffer, size_t secretSize, const void* customSeed,
-        size_t customSeedSize) @trusted pure nothrow @nogc;
-    void XXH3_generateSecret_fromSeed(void* secretBuffer, XXH64_hash_t seed) @trusted pure nothrow @nogc;
-    XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len) @trusted pure nothrow @nogc;
-    XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
-        @trusted pure nothrow @nogc;
-    XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret,
-        size_t secretLen) @trusted pure nothrow @nogc;
-    XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
-        @trusted pure nothrow @nogc;
-    XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len) @trusted pure nothrow @nogc;
-    XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
-        @trusted pure nothrow @nogc;
-    XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret,
-        size_t secretLen) @trusted pure nothrow @nogc;
-    XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
-        @trusted pure nothrow @nogc;
-}
 
 import core.bitop;
 
@@ -2596,10 +2628,19 @@ version (LittleEndian)
     private alias nativeToBigEndian = bswap;
     private alias bigEndianToNative = bswap;
 }
-else pragma(inline, true) private pure @nogc nothrow @safe
+else
+    pragma(inline, true) private pure @nogc nothrow @safe
 {
-    uint nativeToBigEndian(uint val) { return val; }
-    ulong nativeToBigEndian(ulong val) { return val; }
+    uint nativeToBigEndian(uint val)
+    {
+        return val;
+    }
+
+    ulong nativeToBigEndian(ulong val)
+    {
+        return val;
+    }
+
     alias bigEndianToNative = nativeToBigEndian;
 }
 
@@ -2609,15 +2650,15 @@ else pragma(inline, true) private pure @nogc nothrow @safe
  */
 struct XXHTemplate(HASH, STATE, bool useXXH3)
 {
-    private:
-        HASH hash;
-        STATE* state = null;
-        HASH seed = HASH.init;
+private:
+    HASH hash;
+    STATE* state = null;
+    HASH seed = HASH.init;
 
-    public:
-        enum digestSize = HASH.sizeof * 8;
+public:
+    enum digestSize = HASH.sizeof * 8;
 
-        /**
+    /**
          * Use this to feed the digest with data.
          * Also implements the $(REF isOutputRange, std,range,primitives)
          * interface for `ubyte` and `const(ubyte)[]`.
@@ -2631,24 +2672,25 @@ struct XXHTemplate(HASH, STATE, bool useXXH3)
          * dig.put(buf); //buffer
          * ----
          */
-        void put(scope const(ubyte)[] data...) @trusted nothrow @nogc
-        {
-            XXH_errorcode ec;
-            if (state == null) this.start;
-            static if (digestSize == 32)
-                ec = XXH32_update(state, data.ptr, data.length);
-            else static if (digestSize == 64 && !useXXH3)
-                ec = XXH64_update(state, data.ptr, data.length);
-            else static if (digestSize == 64 && useXXH3)
-                ec = XXH3_64bits_update(state, data.ptr, data.length);
-            else static if (digestSize == 128)
-                ec = XXH3_128bits_update(state, data.ptr, data.length);
-            else
-                assert(false, "Unknown XXH bitdeep or variant");
-            assert(ec == XXH_errorcode.XXH_OK, "Update failed");
-        }
+    void put(scope const(ubyte)[] data...) @trusted nothrow @nogc
+    {
+        XXH_errorcode ec;
+        if (state == null)
+            this.start;
+        static if (digestSize == 32)
+            ec = XXH32_update(state, data.ptr, data.length);
+        else static if (digestSize == 64 && !useXXH3)
+            ec = XXH64_update(state, data.ptr, data.length);
+        else static if (digestSize == 64 && useXXH3)
+            ec = XXH3_64bits_update(state, data.ptr, data.length);
+        else static if (digestSize == 128)
+            ec = XXH3_128bits_update(state, data.ptr, data.length);
+        else
+            assert(false, "Unknown XXH bitdeep or variant");
+        assert(ec == XXH_errorcode.XXH_OK, "Update failed");
+    }
 
-        /**
+    /**
          * Used to (re)initialize the XXHTemplate digest.
          *
          * Example:
@@ -2658,74 +2700,82 @@ struct XXHTemplate(HASH, STATE, bool useXXH3)
          * digest.put(0);
          * --------
          */
-        void start() @safe nothrow @nogc
+    void start() @safe nothrow @nogc
+    {
+        this = typeof(this).init;
+        XXH_errorcode ec;
+        static if (digestSize == 32)
         {
-            this = typeof(this).init;
-            XXH_errorcode ec;
-            static if (digestSize == 32)
-            {
-                if (state == null) state = XXH32_createState();
-                ec = XXH32_reset(state, seed);
-            }
-            else static if (digestSize == 64 && !useXXH3)
-            {
-                if (state == null) state = XXH64_createState();
-                ec = XXH64_reset(state, seed);
-            }
-            else static if (digestSize == 64 && useXXH3)
-            {
-                if (state == null) state = XXH3_createState();
-                ec = XXH3_64bits_reset(state);
-            }
-            else static if (digestSize == 128)
-            {
-                if (state == null) state = XXH3_createState();
-                ec = XXH3_128bits_reset(state);
-            }
-            else
-                assert(false, "Unknown XXH bitdeep or variant");
-            //assert(ec == XXH_errorcode.XXH_OK, "reset failed");
+            if (state == null)
+                state = XXH32_createState();
+            ec = XXH32_reset(state, seed);
         }
+        else static if (digestSize == 64 && !useXXH3)
+        {
+            if (state == null)
+                state = XXH64_createState();
+            ec = XXH64_reset(state, seed);
+        }
+        else static if (digestSize == 64 && useXXH3)
+        {
+            if (state == null)
+                state = XXH3_createState();
+            ec = XXH3_64bits_reset(state);
+        }
+        else static if (digestSize == 128)
+        {
+            if (state == null)
+                state = XXH3_createState();
+            ec = XXH3_128bits_reset(state);
+        }
+        else
+            assert(false, "Unknown XXH bitdeep or variant");
+        //assert(ec == XXH_errorcode.XXH_OK, "reset failed");
+    }
 
-        /**
+    /**
          * Returns the finished XXH hash. This also calls $(LREF start) to
          * reset the internal state.
           */
-        ubyte[digestSize/8] finish() @trusted nothrow @nogc
+    ubyte[digestSize / 8] finish() @trusted nothrow @nogc
+    {
+        XXH_errorcode ec;
+        static if (digestSize == 32)
         {
-            XXH_errorcode ec;
-            static if (digestSize == 32)
-            {
-                hash = XXH32_digest(state);
-                if (state != null) ec = XXH32_freeState(state);
-                auto rc = nativeToBigEndian(hash);
-            }
-            else static if (digestSize == 64 && !useXXH3)
-            {
-                hash = XXH64_digest(state);
-                if (state != null) ec = XXH64_freeState(state);
-                auto rc = nativeToBigEndian(hash);
-            }
-            else static if (digestSize == 64 && useXXH3)
-            {
-                hash = XXH3_64bits_digest(state);
-                if (state != null) ec = XXH3_freeState(state);
-                auto rc = nativeToBigEndian(hash);
-            }
-            else static if (digestSize == 128)
-            {
-                hash = XXH3_128bits_digest(state);
-                if (state != null) ec = XXH3_freeState(state);
-                HASH rc;
-                // Note: low64 and high64 are intentionally exchanged!
-                rc.low64 = nativeToBigEndian(hash.high64);
-                rc.high64 = nativeToBigEndian(hash.low64);
-            }
-            assert(ec == XXH_errorcode.XXH_OK, "freestate failed");
-            state = null;
-
-            return (cast(ubyte*) &rc)[0 .. rc.sizeof];
+            hash = XXH32_digest(state);
+            if (state != null)
+                ec = XXH32_freeState(state);
+            auto rc = nativeToBigEndian(hash);
         }
+        else static if (digestSize == 64 && !useXXH3)
+        {
+            hash = XXH64_digest(state);
+            if (state != null)
+                ec = XXH64_freeState(state);
+            auto rc = nativeToBigEndian(hash);
+        }
+        else static if (digestSize == 64 && useXXH3)
+        {
+            hash = XXH3_64bits_digest(state);
+            if (state != null)
+                ec = XXH3_freeState(state);
+            auto rc = nativeToBigEndian(hash);
+        }
+        else static if (digestSize == 128)
+        {
+            hash = XXH3_128bits_digest(state);
+            if (state != null)
+                ec = XXH3_freeState(state);
+            HASH rc;
+            // Note: low64 and high64 are intentionally exchanged!
+            rc.low64 = nativeToBigEndian(hash.high64);
+            rc.high64 = nativeToBigEndian(hash.low64);
+        }
+        assert(ec == XXH_errorcode.XXH_OK, "freestate failed");
+        state = null;
+
+        return (cast(ubyte*)&rc)[0 .. rc.sizeof];
+    }
 }
 ///
 @safe unittest
@@ -2793,7 +2843,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     //Simple example, hashing a string using xxh32Of helper function
     auto hash = xxh64Of("abc");
     //Let's get a hash string
-    assert(toHexString(hash) == "44BC2CF5AD770999" ); // XXH64
+    assert(toHexString(hash) == "44BC2CF5AD770999"); // XXH64
 }
 ///
 @safe unittest
@@ -2801,7 +2851,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     //Simple example, hashing a string using xxh32Of helper function
     auto hash = xxh3_64Of("abc");
     //Let's get a hash string
-    assert(toHexString(hash) == "78AF5F94892F3950" ); // XXH3/64
+    assert(toHexString(hash) == "78AF5F94892F3950"); // XXH3/64
 }
 ///
 @safe unittest
@@ -2867,6 +2917,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     {
         hash.put(cast(ubyte) 0);
     }
+
     XXH_32 xxh;
     xxh.start();
     doSomething(xxh);
@@ -2882,6 +2933,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     {
         hash.put(cast(ubyte) 0);
     }
+
     XXH_64 xxh;
     xxh.start();
     doSomething(xxh);
@@ -2897,6 +2949,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     {
         hash.put(cast(ubyte) 0);
     }
+
     XXH3_64 xxh;
     xxh.start();
     doSomething(xxh);
@@ -2912,6 +2965,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     {
         hash.put(cast(ubyte) 0);
     }
+
     XXH3_128 xxh;
     xxh.start();
     doSomething(xxh);
@@ -2938,9 +2992,9 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     ubyte[16] digest128;
 
     XXH_32 xxh;
-    xxh.put(cast(ubyte[])"abcdef");
+    xxh.put(cast(ubyte[]) "abcdef");
     xxh.start();
-    xxh.put(cast(ubyte[])"");
+    xxh.put(cast(ubyte[]) "");
     assert(xxh.finish() == cast(ubyte[]) hexString!"02cc5d05");
 
     digest32 = xxh32Of("");
@@ -2950,7 +3004,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("");
     assert(digest64 == cast(ubyte[]) hexString!"2D06800538D394C2", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("");
-    assert(digest128 == cast(ubyte[]) hexString!"99AA06D3014798D86001C324468D497F", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"99AA06D3014798D86001C324468D497F",
+            "Got " ~ toHexString(digest128));
 
     digest32 = xxh32Of("a");
     assert(digest32 == cast(ubyte[]) hexString!"550d7456");
@@ -2959,7 +3014,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("a");
     assert(digest64 == cast(ubyte[]) hexString!"E6C632B61E964E1F", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("a");
-    assert(digest128 == cast(ubyte[]) hexString!"A96FAF705AF16834E6C632B61E964E1F", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"A96FAF705AF16834E6C632B61E964E1F",
+            "Got " ~ toHexString(digest128));
 
     digest32 = xxh32Of("abc");
     assert(digest32 == cast(ubyte[]) hexString!"32D153FF");
@@ -2977,7 +3033,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
     assert(digest64 == cast(ubyte[]) hexString!"5BBCBBABCDCC3D3F", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
-    assert(digest128 == cast(ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7",
+            "Got " ~ toHexString(digest128));
 
     digest32 = xxh32Of("message digest");
     assert(digest32 == cast(ubyte[]) hexString!"7c948494");
@@ -2986,7 +3043,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("message digest");
     assert(digest64 == cast(ubyte[]) hexString!"160D8E9329BE94F9", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("message digest");
-    assert(digest128 == cast(ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424",
+            "Got " ~ toHexString(digest128));
 
     digest32 = xxh32Of("abcdefghijklmnopqrstuvwxyz");
     assert(digest32 == cast(ubyte[]) hexString!"63a14d5f");
@@ -2995,7 +3053,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("abcdefghijklmnopqrstuvwxyz");
     assert(digest64 == cast(ubyte[]) hexString!"810F9CA067FBB90C", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("abcdefghijklmnopqrstuvwxyz");
-    assert(digest128 == cast(ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6",
+            "Got " ~ toHexString(digest128));
 
     digest32 = xxh32Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     assert(digest32 == cast(ubyte[]) hexString!"9c285e64");
@@ -3004,24 +3063,25 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
     assert(digest64 == cast(ubyte[]) hexString!"643542BB51639CB2", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-    assert(digest128 == cast(ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB",
+            "Got " ~ toHexString(digest128));
 
-    digest32 = xxh32Of("1234567890123456789012345678901234567890"~
-                    "1234567890123456789012345678901234567890");
+    digest32 = xxh32Of(
+            "1234567890123456789012345678901234567890" ~ "1234567890123456789012345678901234567890");
     assert(digest32 == cast(ubyte[]) hexString!"9c05f475");
-    digest64 = xxh64Of("1234567890123456789012345678901234567890"~
-                    "1234567890123456789012345678901234567890");
+    digest64 = xxh64Of(
+            "1234567890123456789012345678901234567890" ~ "1234567890123456789012345678901234567890");
     assert(digest64 == cast(ubyte[]) hexString!"E04A477F19EE145D", "Got " ~ toHexString(digest64));
-    digest64 = xxh3_64Of("1234567890123456789012345678901234567890"~
-                    "1234567890123456789012345678901234567890");
+    digest64 = xxh3_64Of(
+            "1234567890123456789012345678901234567890" ~ "1234567890123456789012345678901234567890");
     assert(digest64 == cast(ubyte[]) hexString!"7F58AA2520C681F9", "Got " ~ toHexString(digest64));
-    digest128 = xxh128Of("1234567890123456789012345678901234567890"~
-                    "1234567890123456789012345678901234567890");
-    assert(digest128 == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8", "Got " ~ toHexString(digest128));
+    digest128 = xxh128Of(
+            "1234567890123456789012345678901234567890" ~ "1234567890123456789012345678901234567890");
+    assert(digest128 == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8",
+            "Got " ~ toHexString(digest128));
 
     enum ubyte[16] input = cast(ubyte[16]) hexString!"c3fcd3d76192e4007dfb496cca67e13b";
-    assert(toHexString(input)
-        == "C3FCD3D76192E4007DFB496CCA67E13B");
+    assert(toHexString(input) == "C3FCD3D76192E4007DFB496CCA67E13B");
 
     ubyte[] onemilliona = new ubyte[1000000];
     onemilliona[] = 'a';
@@ -3032,9 +3092,10 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of(onemilliona);
     assert(digest64 == cast(ubyte[]) hexString!"B1FD6FAE5285C4EB", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of(onemilliona);
-    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB",
+            "Got " ~ toHexString(digest128));
 
-    auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
+    auto oneMillionRange = repeat!ubyte(cast(ubyte) 'a', 1000000);
     digest32 = xxh32Of(oneMillionRange);
     assert(digest32 == cast(ubyte[]) hexString!"E1155920", "Got " ~ toHexString(digest32));
     digest64 = xxh64Of(oneMillionRange);
@@ -3042,7 +3103,8 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     digest64 = xxh3_64Of(oneMillionRange);
     assert(digest64 == cast(ubyte[]) hexString!"B1FD6FAE5285C4EB", "Got " ~ toHexString(digest64));
     digest128 = xxh128Of(oneMillionRange);
-    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB", "Got " ~ toHexString(digest128));
+    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB",
+            "Got " ~ toHexString(digest128));
 }
 
 /**
@@ -3135,11 +3197,12 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 ///
 @system unittest
 {
-     //Let's use the OOP features:
+    //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte) 0);
+        dig.put(cast(ubyte) 0);
     }
+
     auto xxh = new XXH32Digest();
     test(xxh);
 
@@ -3151,11 +3214,12 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 ///
 @system unittest
 {
-     //Let's use the OOP features:
+    //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte) 0);
+        dig.put(cast(ubyte) 0);
     }
+
     auto xxh = new XXH64Digest();
     test(xxh);
 
@@ -3167,11 +3231,12 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 ///
 @system unittest
 {
-     //Let's use the OOP features:
+    //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte) 0);
+        dig.put(cast(ubyte) 0);
     }
+
     auto xxh = new XXH3_64Digest();
     test(xxh);
 
@@ -3183,11 +3248,12 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 ///
 @system unittest
 {
-     //Let's use the OOP features:
+    //Let's use the OOP features:
     void test(Digest dig)
     {
-      dig.put(cast(ubyte) 0);
+        dig.put(cast(ubyte) 0);
     }
+
     auto xxh = new XXH128Digest();
     test(xxh);
 
@@ -3200,24 +3266,27 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 @system unittest
 {
     import std.conv : hexString;
+
     auto xxh = new XXH32Digest();
     auto xxh64 = new XXH64Digest();
     auto xxh3_64 = new XXH3_64Digest();
     auto xxh128 = new XXH128Digest();
 
-    xxh.put(cast(ubyte[])"abcdef");
+    xxh.put(cast(ubyte[]) "abcdef");
     xxh.reset();
-    xxh.put(cast(ubyte[])"");
+    xxh.put(cast(ubyte[]) "");
     assert(xxh.finish() == cast(ubyte[]) hexString!"02cc5d05");
 
-    xxh.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
+    xxh.put(cast(ubyte[]) "abcdefghijklmnopqrstuvwxyz");
     ubyte[20] result;
     auto result2 = xxh.finish(result[]);
-    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[]) hexString!"63a14d5f", "Got " ~ toHexString(result));
+    assert(result[0 .. 4] == result2
+            && result2 == cast(ubyte[]) hexString!"63a14d5f", "Got " ~ toHexString(result));
 
     debug
     {
         import std.exception;
+
         assertThrown!Error(xxh.finish(result[0 .. 3]));
     }
 
@@ -3241,44 +3310,43 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
     assert(xxh3_64.digest("abc") == cast(ubyte[]) hexString!"78AF5F94892F3950");
     assert(xxh128.digest("abc") == cast(ubyte[]) hexString!"06B05AB6733A618578AF5F94892F3950");
 
-    assert(xxh.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) hexString!"89ea60c3");
-    assert(xxh64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) hexString!"F06103773E8585DF");
-    assert(xxh3_64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) hexString!"5BBCBBABCDCC3D3F");
-    assert(xxh128.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
-           == cast(ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7");
+    assert(xxh.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") == cast(
+            ubyte[]) hexString!"89ea60c3");
+    assert(xxh64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") == cast(
+            ubyte[]) hexString!"F06103773E8585DF");
+    assert(xxh3_64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") == cast(
+            ubyte[]) hexString!"5BBCBBABCDCC3D3F");
+    assert(xxh128.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") == cast(
+            ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7");
 
     assert(xxh.digest("message digest") == cast(ubyte[]) hexString!"7c948494");
     assert(xxh64.digest("message digest") == cast(ubyte[]) hexString!"066ED728FCEEB3BE");
     assert(xxh3_64.digest("message digest") == cast(ubyte[]) hexString!"160D8E9329BE94F9");
-    assert(xxh128.digest("message digest") == cast(ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424");
+    assert(xxh128.digest("message digest") == cast(
+            ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424");
 
     assert(xxh.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"63a14d5f");
     assert(xxh64.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"CFE1F278FA89835C");
-    assert(xxh3_64.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"810F9CA067FBB90C");
-    assert(xxh128.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6");
+    assert(xxh3_64.digest("abcdefghijklmnopqrstuvwxyz") == cast(
+            ubyte[]) hexString!"810F9CA067FBB90C");
+    assert(xxh128.digest("abcdefghijklmnopqrstuvwxyz") == cast(
+            ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6");
 
-    assert(xxh.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) hexString!"9c285e64");
-    assert(xxh64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) hexString!"AAA46907D3047814");
-    assert(xxh3_64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) hexString!"643542BB51639CB2");
-    assert(xxh128.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-           == cast(ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB");
+    assert(xxh.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") == cast(
+            ubyte[]) hexString!"9c285e64");
+    assert(xxh64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") == cast(
+            ubyte[]) hexString!"AAA46907D3047814");
+    assert(xxh3_64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") == cast(
+            ubyte[]) hexString!"643542BB51639CB2");
+    assert(xxh128.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") == cast(
+            ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB");
 
     assert(xxh.digest("1234567890123456789012345678901234567890",
-                                   "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) hexString!"9c05f475");
+            "1234567890123456789012345678901234567890") == cast(ubyte[]) hexString!"9c05f475");
     assert(xxh64.digest("1234567890123456789012345678901234567890",
-                                   "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) hexString!"E04A477F19EE145D");
+            "1234567890123456789012345678901234567890") == cast(ubyte[]) hexString!"E04A477F19EE145D");
     assert(xxh3_64.digest("1234567890123456789012345678901234567890",
-                                   "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) hexString!"7F58AA2520C681F9");
+            "1234567890123456789012345678901234567890") == cast(ubyte[]) hexString!"7F58AA2520C681F9");
     assert(xxh128.digest("1234567890123456789012345678901234567890",
-                                   "1234567890123456789012345678901234567890")
-           == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8");
+            "1234567890123456789012345678901234567890") == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8");
 }

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -459,9 +459,16 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
     {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH32_state_t state;
-        xxh32_reset(&state, seed);
-        xxh32_update(&state, cast(const(ubyte)*) input, len);
-        return xxh32_digest(&state);
+        auto rc = xxh32_reset(&state, seed);
+        if (rc == XXH_errorcode.XXH_OK)
+        {
+            rc = xxh32_update(&state, cast(const(ubyte)*) input, len);
+            if (rc == XXH_errorcode.XXH_OK)
+            {
+                return xxh32_digest(&state);
+            }
+        }
+        return XXH_errorcode.XXH_ERROR;
     }
     else
     {
@@ -792,9 +799,16 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
     {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH64_state_t state;
-        xxh64_reset(&state, seed);
-        xxh64_update(&state, cast(const(ubyte)*) input, len);
-        return xxh64_digest(&state);
+        auto rc = xxh64_reset(&state, seed);
+        if (rc == XXH_errorcode.XXH_OK)
+        {
+            rc = xxh64_update(&state, cast(const(ubyte)*) input, len);
+            if (rc == XXH_errorcode.XXH_OK)
+            {
+                return xxh64_digest(&state);
+            }
+        }
+        return XXH_errorcode.XXH_ERROR;
     }
     else
     {

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -2957,7 +2957,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     enum ubyte[16] input = cast(ubyte[16]) hexString!"c3fcd3d76192e4007dfb496cca67e13b";
     assert(toHexString(input) == "C3FCD3D76192E4007DFB496CCA67E13B");
 
-    ubyte[] onemilliona = new ubyte[1000000];
+    ubyte[] onemilliona = new ubyte[1_000_000];
     onemilliona[] = 'a';
     digest32 = xxh32Of(onemilliona);
     assert(digest32 == cast(ubyte[]) hexString!"E1155920", "Got " ~ toHexString(digest32));
@@ -2969,7 +2969,7 @@ alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 f
     assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB",
             "Got " ~ toHexString(digest128));
 
-    auto oneMillionRange = repeat!ubyte(cast(ubyte) 'a', 1000000);
+    auto oneMillionRange = repeat!ubyte(cast(ubyte) 'a', 1_000_000);
     digest32 = xxh32Of(oneMillionRange);
     assert(digest32 == cast(ubyte[]) hexString!"E1155920", "Got " ~ toHexString(digest32));
     digest64 = xxh64Of(oneMillionRange);

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -185,6 +185,7 @@ private enum XXH_alignment
     XXH_unaligned /** Possibly unaligned */
 }
 
+pragma(inline, true)
 private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
@@ -195,6 +196,7 @@ private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
+pragma(inline, true)
 private uint XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -211,6 +213,7 @@ private uint XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
         return XXH_read32(ptr);
 }
 
+pragma(inline, true)
 private uint XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -393,6 +396,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
+pragma(inline, true)
 private uint XXH32_endian_align(const(ubyte)* input, size_t len,
         uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
@@ -589,6 +593,7 @@ private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
+pragma(inline, true)
 private ulong XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -605,6 +610,7 @@ private ulong XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
         return XXH_read64(ptr);
 }
 
+pragma(inline, true)
 private ulong XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -707,6 +713,7 @@ private ulong XXH64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alig
  * Param: align Whether @p input is aligned.
  * Return: The calculated hash.
  */
+pragma(inline, true)
 private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
@@ -1038,6 +1045,7 @@ private ulong XXH3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 }
 
 /* Seems to produce slightly better code on GCC for some reason. */
+pragma(inline, true)
 private ulong XXH_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
 {
     assert(0 <= shift && shift < 64, "shift out of range");
@@ -1104,6 +1112,7 @@ static XXH64_hash_t XXH3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
  *
  * This adds an extra layer of strength for custom secrets.
  */
+pragma(inline, true)
 private XXH64_hash_t XXH3_len_1to3_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1127,6 +1136,7 @@ private XXH64_hash_t XXH3_len_1to3_64b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH64_hash_t XXH3_len_4to8_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1144,6 +1154,7 @@ private XXH64_hash_t XXH3_len_4to8_64b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH64_hash_t XXH3_len_9to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1161,16 +1172,19 @@ private XXH64_hash_t XXH3_len_9to16_64b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private bool XXH_likely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
+pragma(inline, true)
 private bool XXH_unlikely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
+pragma(inline, true)
 private XXH64_hash_t XXH3_len_0to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1212,6 +1226,7 @@ private XXH64_hash_t XXH3_len_0to16_64b(const ubyte* input, size_t len,
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
+pragma(inline, true)
 private ulong XXH3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
 {
     {
@@ -1223,6 +1238,7 @@ private ulong XXH3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed6
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
+pragma(inline, true)
 private XXH64_hash_t XXH3_len_17to128_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1258,6 +1274,7 @@ enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
+pragma(inline, false)
 private XXH64_hash_t XXH3_len_129to240_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1293,6 +1310,7 @@ enum XXH_STRIPE_LEN = 64;
 enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumulation */
 enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
+pragma(inline, true)
 private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     version (LittleEndian) {}
@@ -1310,6 +1328,7 @@ enum XXH_ACC_ALIGN = 8;
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
+pragma(inline, true)
 private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 {
@@ -1327,6 +1346,7 @@ private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret
 }
 
 /* Processes a 64 byte block of data using the scalar path. */
+pragma(inline, true)
 private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1341,6 +1361,7 @@ private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
+pragma(inline, true)
 private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 {
     ulong* xacc = cast(ulong*) acc; /* presumed aligned */
@@ -1358,6 +1379,7 @@ private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lan
 }
 
 /* Scrambles the accumulators after a large chunk has been read */
+pragma(inline, true)
 private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1367,6 +1389,7 @@ private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure 
     }
 }
 
+pragma(inline, true)
 private void XXH3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
 {
     /*
@@ -1421,6 +1444,7 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
  * Loops over XXH3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
+pragma(inline, true)
 private void XXH3_accumulate(ulong* acc, const ubyte* input,
         const ubyte* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
@@ -1433,6 +1457,7 @@ private void XXH3_accumulate(ulong* acc, const ubyte* input,
     }
 }
 
+pragma(inline, true)
 private void XXH3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -1468,6 +1493,7 @@ private void XXH3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t 
 
 enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
+pragma(inline, true)
 private ulong XXH3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
 {
     return XXH3_mul128_fold64(acc[0] ^ XXH_readLE64(secret), acc[1] ^ XXH_readLE64(secret + 8));
@@ -1492,6 +1518,7 @@ static immutable XXH3_INIT_ACC = [
         XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1
     ];
 
+pragma(inline, true)
 private XXH64_hash_t XXH3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -1516,6 +1543,7 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * so that the compiler can properly optimize the vectorized loop.
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
+pragma(inline, true)
 private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
         size_t len, XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1530,6 +1558,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
  * Note that inside this no_inline function, we do inline the internal loop,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
+pragma(inline, false)
 private XXH64_hash_t XXH3_hashLong_64b_default(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1553,6 +1582,7 @@ enum XXH_SEC_ALIGN = 8;
  * It's important for performance that XXH3_hashLong is not inlined. Not sure
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
+pragma(inline, true)
 private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -1573,6 +1603,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, siz
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
+pragma(inline, false)
 private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
         XXH64_hash_t seed, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1585,6 +1616,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
         XXH64_hash_t, const(ubyte)*, size_t) @safe pure nothrow @nogc;
 
+pragma(inline, true)
 private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
         @safe pure nothrow @nogc
@@ -1722,6 +1754,7 @@ XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 /* Note : when XXH3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
+pragma(inline, true)
 private void XXH3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
         size_t nbStripesPerBlock, const ubyte* input, size_t nbStripes,
         const ubyte* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
@@ -1753,6 +1786,7 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
  */
+pragma(inline, true)
 private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -1894,6 +1928,7 @@ XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, 
             XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
+pragma(inline, true)
 private void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
     @trusted pure nothrow @nogc
 {
@@ -1958,6 +1993,7 @@ XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * XXH128 is also more oriented towards 64-bit machines. It is still extremely
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
+pragma(inline, true)
 private XXH128_hash_t XXH3_len_1to3_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -1988,6 +2024,7 @@ private XXH128_hash_t XXH3_len_1to3_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_len_4to8_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2016,6 +2053,7 @@ private XXH128_hash_t XXH3_len_4to8_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2094,6 +2132,7 @@ private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_len_0to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2116,6 +2155,7 @@ private XXH128_hash_t XXH3_len_0to16_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
         const ubyte* input_2, const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2126,6 +2166,7 @@ private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
     return acc;
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2177,6 +2218,7 @@ private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, false)
 private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2219,6 +2261,7 @@ private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
     }
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -2240,6 +2283,7 @@ private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len,
     }
 }
 
+pragma(inline, false)
 private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2254,6 +2298,7 @@ private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
  * It's important for performance to pass @p secretLen (when it's static)
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
+pragma(inline, true)
 private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
         size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2262,6 +2307,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
             secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -2279,6 +2325,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, si
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
+pragma(inline, false)
 private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2291,6 +2338,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
 alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
         XXH64_hash_t, const void*, size_t) @safe pure nothrow @nogc;
 
+pragma(inline, true)
 private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
         @safe pure nothrow @nogc

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -1702,7 +1702,7 @@ private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(
     XXH3_f_accumulate_512 f_acc512,
     XXH3_f_scrambleAcc f_scramble,
     XXH3_f_initCustomSecret f_initSec)
-    @safe pure nothrow @nogc
+    @trusted pure nothrow @nogc
 {
     //#if XXH_SIZE_OPT <= 0
     if (seed == 0)
@@ -2444,7 +2444,7 @@ private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(
     const void* input, size_t len, XXH64_hash_t seed64,
     XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
     XXH3_f_initCustomSecret f_initSec)
-    @safe pure nothrow @nogc
+    @trusted pure nothrow @nogc
 {
     if (seed64 == 0)
         return xxh3_hashLong_128b_internal(input, len, &xxh3_kSecret[0],

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -1498,9 +1498,24 @@ immutable XXH3_f_scrambleAcc xxh3_scrambleAcc = &xxh3_scrambleAcc_scalar;
 immutable XXH3_f_initCustomSecret xxh3_initCustomSecret = &xxh3_initCustomSecret_scalar;
 
 enum XXH_PREFETCH_DIST = 384;
+/* TODO: Determine how to implement prefetching in D! Disabled for now
+ *
+ */
 private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
 {
-    cast(void)(ptr);
+    cast(void)(ptr); /* DISABLED prefetch and do nothing here */
+
+//TODO In C it is done with the following code lines:
+//TODO  if XXH_SIZE_OPT >= 1
+//TODO    define XXH_PREFETCH(ptr) (void)(ptr)
+//TODO  elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))  /* _mm_prefetch() not defined outside of x86/x64 */
+//TODO    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
+//TODO    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
+//TODO  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
+//TODO    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
+//TODO  else
+//TODO    define XXH_PREFETCH(ptr) (void)(ptr)  /* disabled */
+//TODO  endif
 }
 
 /*

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -741,7 +741,7 @@ private ulong XXH64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alig
     @trusted pure nothrow @nogc
 {
     if (ptr == null)
-        assert(len == 0, "len != 0");
+        assert(len == 0, "input null ptr only allowed with len == 0");
 
     len &= 31;
     while (len >= 8)
@@ -781,7 +781,7 @@ private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
 {
     ulong h64;
     if (input == null)
-        assert(len == 0, "len != 0");
+        assert(len == 0, "input null ptr only allowed with len == 0");
 
     if (len >= 32)
     {
@@ -863,7 +863,7 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 {
     if (input == null)
     {
-        assert(len == 0, "len != 0");
+        assert(len == 0, "input null ptr only allowed with len == 0");
         return XXH_errorcode.XXH_OK;
     }
 

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -523,13 +523,6 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
     }
 }
 
-void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState) @trusted pure nothrow @nogc
-{
-    import core.stdc.string : memcpy;
-
-    memcpy(dstState, srcState, (*dstState).sizeof);
-}
-
 XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memset;
@@ -855,13 +848,6 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
         return XXH64_endian_align(cast(const(ubyte)*) input, len, seed,
                 XXH_alignment.XXH_unaligned);
     }
-}
-
-void XXH64_copyState(XXH64_state_t* dstState, const XXH64_state_t* srcState) @trusted pure nothrow @nogc
-{
-    import core.stdc.string : memcpy;
-
-    memcpy(dstState, srcState, (*dstState).sizeof);
 }
 
 XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
@@ -1710,13 +1696,6 @@ XXH64_hash_t XXH3_64bits_withSecretandSeed(const(void)* input, size_t length,
 private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @safe nothrow @nogc
 {
     (XXH3_state_ptr).seed = 0;
-}
-
-void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state) @trusted pure nothrow @nogc
-{
-    import core.stdc.string : memcpy;
-
-    memcpy(dst_state, src_state, (*dst_state).sizeof);
 }
 
 private void XXH3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -118,6 +118,7 @@ class XXHException : Exception
 ///
 @safe unittest
 {
+    import std.exception : enforce;
     enforce!XXHException(true, "This never throws...");
 }
 
@@ -157,8 +158,7 @@ uint xxh_versionNumber() @safe pure nothrow @nogc
 ///
 @safe unittest
 {
-    import std.stdio : writeln;
-    writeln("Ported XXH version is ", xxh_versionNumber());
+    assert(XXH_VERSION_NUMBER == xxh_versionNumber(), "Version mismatch");
 }
 
 enum XXH_errorcode

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -1934,13 +1934,15 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len) @safe pure nothrow @nogc
+XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len)
+    @safe pure nothrow @nogc
 {
     return XXH3_update(state, cast(const(ubyte)*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
-void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret) @trusted pure nothrow @nogc
+private void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
+    @trusted pure nothrow @nogc
 {
     /*
      * Digest on a local copy. This way, the state remains unaltered, and it can

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -94,10 +94,6 @@ version (LittleEndian)
 else
     private immutable bool XXH_CPU_LITTLE_ENDIAN = false;
 
-alias xxh_u8 = ubyte;
-alias xxh_u32 = uint;
-alias xxh_u64 = ulong;
-
 private import core.bitop : rol;
 
 /* *************************************
@@ -248,7 +244,7 @@ struct XXH32_canonical_t
  * Param: x = The 32-bit integer to byteswap.
  * Return: x, byteswapped.
  */
-private xxh_u32 XXH_swap32(xxh_u32 x) @safe pure nothrow @nogc
+private uint XXH_swap32(uint x) @safe pure nothrow @nogc
 {
     return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) | (
             (x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
@@ -266,24 +262,24 @@ private enum XXH_alignment
     XXH_unaligned /** Possibly unaligned */
 }
 
-private xxh_u32 XXH_read32(const void* ptr) @trusted pure nothrow @nogc
+private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
-    xxh_u32 val;
-    (cast(ubyte*)&val)[0 .. xxh_u32.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u32.sizeof];
+    uint val;
+    (cast(ubyte*)&val)[0 .. uint.sizeof] = (cast(ubyte*) ptr)[0 .. uint.sizeof];
     return val;
 }
 
-private xxh_u32 XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
+private uint XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
 }
 
-private xxh_u32 XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
+private uint XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
 }
 
-private xxh_u32 XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+private uint XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
     {
@@ -291,8 +287,8 @@ private xxh_u32 XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trust
     }
     else
     {
-        return XXH_CPU_LITTLE_ENDIAN ? *cast(const xxh_u32*) ptr : XXH_swap32(
-                *cast(const xxh_u32*) ptr);
+        return XXH_CPU_LITTLE_ENDIAN ? *cast(const uint*) ptr : XXH_swap32(
+                *cast(const uint*) ptr);
     }
 }
 
@@ -314,7 +310,7 @@ enum XXH_PRIME32_5 = 0x165667B1U; /** 0b00010110010101100110011110110001 */
  * Param: input The stripe of input to mix.
  * Return: The mixed accumulator lane.
  */
-private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @safe pure nothrow @nogc
+private uint XXH32_round(uint acc, uint input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME32_2;
     acc = rol(acc, 13);
@@ -330,7 +326,7 @@ private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @safe pure nothrow @nogc
  * Param: hash = The hash to avalanche.
  * Return The avalanched hash.
  */
-private xxh_u32 XXH32_avalanche(xxh_u32 hash) @safe pure nothrow @nogc
+private uint XXH32_avalanche(uint hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 15;
     hash *= XXH_PRIME32_2;
@@ -340,7 +336,7 @@ private xxh_u32 XXH32_avalanche(xxh_u32 hash) @safe pure nothrow @nogc
     return hash;
 }
 
-private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
+private uint XXH_get32bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
     return XXH_readLE32_align(p, align_);
 }
@@ -360,16 +356,16 @@ private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @safe pure no
  * @return The finalized hash.
  * @see XXH64_finalize().
  */
-private xxh_u32 XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)
+private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
 {
-    void XXH_PROCESS1(ref uint32_t hash, ref const(xxh_u8)* ptr)
+    void XXH_PROCESS1(ref uint32_t hash, ref const(ubyte)* ptr)
     {
         hash += (*ptr++) * XXH_PRIME32_5;
         hash = rol(hash, 11) * XXH_PRIME32_1;
     }
 
-    void XXH_PROCESS4(ref uint32_t hash, ref const(xxh_u8)* ptr)
+    void XXH_PROCESS4(ref uint32_t hash, ref const(ubyte)* ptr)
     {
         hash += XXH_get32bits(ptr, align_) * XXH_PRIME32_3;
         ptr += 4;
@@ -465,19 +461,19 @@ private xxh_u32 XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
-private xxh_u32 XXH32_endian_align(const(xxh_u8)* input, size_t len,
-        xxh_u32 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+private uint XXH32_endian_align(const(ubyte)* input, size_t len,
+        uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
-    xxh_u32 h32;
+    uint h32;
 
     if (len >= 16)
     {
-        const xxh_u8* bEnd = input + len;
-        const xxh_u8* limit = bEnd - 15;
-        xxh_u32 v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
-        xxh_u32 v2 = seed + XXH_PRIME32_2;
-        xxh_u32 v3 = seed + 0;
-        xxh_u32 v4 = seed - XXH_PRIME32_1;
+        const ubyte* bEnd = input + len;
+        const ubyte* limit = bEnd - 15;
+        uint v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+        uint v2 = seed + XXH_PRIME32_2;
+        uint v3 = seed + 0;
+        uint v4 = seed - XXH_PRIME32_1;
 
         do
         {
@@ -499,7 +495,7 @@ private xxh_u32 XXH32_endian_align(const(xxh_u8)* input, size_t len,
         h32 = seed + XXH_PRIME32_5;
     }
 
-    h32 += cast(xxh_u32) len;
+    h32 += cast(uint) len;
 
     return XXH32_finalize(h32, input, len & 15, align_);
 }
@@ -511,7 +507,7 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH32_state_t state;
         XXH32_reset(&state, seed);
-        XXH32_update(&state, cast(const(xxh_u8)*) input, len);
+        XXH32_update(&state, cast(const(ubyte)*) input, len);
         return XXH32_digest(&state);
     }
     else
@@ -520,12 +516,12 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
         {
             if (((cast(size_t) input) & 3) == 0)
             { /* Input is 4-bytes aligned, leverage the speed benefit */
-                return XXH32_endian_align(cast(const(xxh_u8)*) input, len,
+                return XXH32_endian_align(cast(const(ubyte)*) input, len,
                         seed, XXH_alignment.XXH_aligned);
             }
         }
 
-        return XXH32_endian_align(cast(const(xxh_u8)*) input, len, seed,
+        return XXH32_endian_align(cast(const(ubyte)*) input, len, seed,
                 XXH_alignment.XXH_unaligned);
     }
 }
@@ -577,24 +573,24 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
     }
 
     {
-        const(xxh_u8)* p = cast(const(xxh_u8)*) input;
-        const xxh_u8* bEnd = p + len;
+        const(ubyte)* p = cast(const(ubyte)*) input;
+        const ubyte* bEnd = p + len;
 
         state.total_len_32 += cast(XXH32_hash_t) len;
         state.large_len |= cast(XXH32_hash_t)((len >= 16) | (state.total_len_32 >= 16));
 
         if (state.memsize + len < 16)
         { /* fill in tmp buffer */
-            memcpy(cast(xxh_u8*)(state.mem32) + state.memsize, input, len);
+            memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, len);
             state.memsize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
 
         if (state.memsize)
         { /* some data left from previous update */
-            memcpy(cast(xxh_u8*)(state.mem32) + state.memsize, input, 16 - state.memsize);
+            memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, 16 - state.memsize);
             {
-                const(xxh_u32)* p32 = cast(const(xxh_u32)*)&state.mem32[0];
+                const(uint)* p32 = cast(const(uint)*)&state.mem32[0];
                 state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32));
                 p32++;
                 state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p32));
@@ -609,7 +605,7 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 
         if (p <= bEnd - 16)
         {
-            const xxh_u8* limit = bEnd - 16;
+            const ubyte* limit = bEnd - 16;
 
             do
             {
@@ -638,7 +634,7 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 
 XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nogc
 {
-    xxh_u32 h32;
+    uint h32;
 
     if (state.large_len)
     {
@@ -652,7 +648,7 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 
     h32 += state.total_len_32;
 
-    return XXH32_finalize(h32, cast(const xxh_u8*) state.mem32, state.memsize,
+    return XXH32_finalize(h32, cast(const ubyte*) state.mem32, state.memsize,
             XXH_alignment.XXH_aligned);
 }
 
@@ -676,14 +672,14 @@ XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure no
 /* ----------------------------------------------------------------------------------------*/
 /* ----------------------------------------------------------------------------------------*/
 
-private xxh_u64 XXH_read64(const void* ptr) @trusted pure nothrow @nogc
+private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 {
-    xxh_u64 val;
-    (cast(ubyte*)&val)[0 .. xxh_u64.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u64.sizeof];
+    ulong val;
+    (cast(ubyte*)&val)[0 .. ulong.sizeof] = (cast(ubyte*) ptr)[0 .. ulong.sizeof];
     return val;
 }
 
-private xxh_u64 XXH_swap64(xxh_u64 x) @safe pure nothrow @nogc
+private ulong XXH_swap64(ulong x) @safe pure nothrow @nogc
 {
     return ((x << 56) & 0xff00000000000000) | ((x << 40) & 0x00ff000000000000) | (
             (x << 24) & 0x0000ff0000000000) | ((x << 8) & 0x000000ff00000000) | (
@@ -691,17 +687,17 @@ private xxh_u64 XXH_swap64(xxh_u64 x) @safe pure nothrow @nogc
             (x >> 40) & 0x000000000000ff00) | ((x >> 56) & 0x00000000000000ff);
 }
 
-private xxh_u64 XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
+private ulong XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
 }
 
-private xxh_u64 XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
+private ulong XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
 }
 
-private xxh_u64 XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+private ulong XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
     {
@@ -709,8 +705,8 @@ private xxh_u64 XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trust
     }
     else
     {
-        return XXH_CPU_LITTLE_ENDIAN ? *cast(const xxh_u64*) ptr : XXH_swap64(
-                *cast(const xxh_u64*) ptr);
+        return XXH_CPU_LITTLE_ENDIAN ? *cast(const ulong*) ptr : XXH_swap64(
+                *cast(const ulong*) ptr);
     }
 }
 
@@ -720,7 +716,7 @@ enum XXH_PRIME64_3 = 0x165667B19E3779F9; /*!< 0b00010110010101100110011110110001
 enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63; /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
 enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
-private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @safe pure nothrow @nogc
+private ulong XXH64_round(ulong acc, ulong input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
     acc = rol(acc, 31);
@@ -728,7 +724,7 @@ private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @safe pure nothrow @nogc
     return acc;
 }
 
-private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @safe pure nothrow @nogc
+private ulong XXH64_mergeRound(ulong acc, ulong val) @safe pure nothrow @nogc
 {
     val = XXH64_round(0, val);
     acc ^= val;
@@ -736,7 +732,7 @@ private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @safe pure nothrow @n
     return acc;
 }
 
-private xxh_u64 XXH64_avalanche(xxh_u64 hash) @safe pure nothrow @nogc
+private ulong XXH64_avalanche(ulong hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 33;
     hash *= XXH_PRIME64_2;
@@ -746,7 +742,7 @@ private xxh_u64 XXH64_avalanche(xxh_u64 hash) @safe pure nothrow @nogc
     return hash;
 }
 
-xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
+ulong XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
     return XXH_readLE64_align(p, align_);
 }
@@ -766,7 +762,7 @@ xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @n
  * @return The finalized hash
  * @see XXH32_finalize().
  */
-private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)
+private ulong XXH64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
 {
     if (ptr == null)
@@ -775,7 +771,7 @@ private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH
     len &= 31;
     while (len >= 8)
     {
-        xxh_u64 k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
+        ulong k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
         ptr += 8;
         hash ^= k1;
         hash = rol(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
@@ -783,7 +779,7 @@ private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH
     }
     if (len >= 4)
     {
-        hash ^= cast(xxh_u64)(XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
+        hash ^= cast(ulong)(XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
         ptr += 4;
         hash = rol(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
         len -= 4;
@@ -805,21 +801,21 @@ private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH
  * @param align Whether @p input is aligned.
  * @return The calculated hash.
  */
-private xxh_u64 XXH64_endian_align(const(xxh_u8)* input, size_t len,
-        xxh_u64 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
+        ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
-    xxh_u64 h64;
+    ulong h64;
     if (input == null)
         assert(len == 0, "len != 0");
 
     if (len >= 32)
     {
-        const xxh_u8* bEnd = input + len;
-        const xxh_u8* limit = bEnd - 31;
-        xxh_u64 v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
-        xxh_u64 v2 = seed + XXH_PRIME64_2;
-        xxh_u64 v3 = seed + 0;
-        xxh_u64 v4 = seed - XXH_PRIME64_1;
+        const ubyte* bEnd = input + len;
+        const ubyte* limit = bEnd - 31;
+        ulong v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+        ulong v2 = seed + XXH_PRIME64_2;
+        ulong v3 = seed + 0;
+        ulong v4 = seed - XXH_PRIME64_1;
 
         do
         {
@@ -846,7 +842,7 @@ private xxh_u64 XXH64_endian_align(const(xxh_u8)* input, size_t len,
         h64 = seed + XXH_PRIME64_5;
     }
 
-    h64 += cast(xxh_u64) len;
+    h64 += cast(ulong) len;
 
     return XXH64_finalize(h64, input, len, align_);
 }
@@ -858,7 +854,7 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH64_state_t state;
         XXH64_reset(&state, seed);
-        XXH64_update(&state, cast(const(xxh_u8)*) input, len);
+        XXH64_update(&state, cast(const(ubyte)*) input, len);
         return XXH64_digest(&state);
     }
     else
@@ -867,12 +863,12 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
         {
             if (((cast(size_t) input) & 7) == 0)
             { /* Input is aligned, let's leverage the speed advantage */
-                return XXH64_endian_align(cast(const(xxh_u8)*) input, len,
+                return XXH64_endian_align(cast(const(ubyte)*) input, len,
                         seed, XXH_alignment.XXH_aligned);
             }
         }
 
-        return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,
+        return XXH64_endian_align(cast(const(ubyte)*) input, len, seed,
                 XXH_alignment.XXH_unaligned);
     }
 }
@@ -924,21 +920,21 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
     }
 
     {
-        const(xxh_u8)* p = cast(const(xxh_u8)*) input;
-        const xxh_u8* bEnd = p + len;
+        const(ubyte)* p = cast(const(ubyte)*) input;
+        const ubyte* bEnd = p + len;
 
         state.total_len += len;
 
         if (state.memsize + len < 32)
         { /* fill in tmp buffer */
-            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, len);
-            state.memsize += cast(xxh_u32) len;
+            memcpy((cast(ubyte*) state.mem64) + state.memsize, input, len);
+            state.memsize += cast(uint) len;
             return XXH_errorcode.XXH_OK;
         }
 
         if (state.memsize)
         { /* tmp buffer is full */
-            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, 32 - state.memsize);
+            memcpy((cast(ubyte*) state.mem64) + state.memsize, input, 32 - state.memsize);
             state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
             state.v[1] = XXH64_round(state.v[1], XXH_readLE64(&state.mem64[1]));
             state.v[2] = XXH64_round(state.v[2], XXH_readLE64(&state.mem64[2]));
@@ -949,7 +945,7 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 
         if (p + 32 <= bEnd)
         {
-            const xxh_u8* limit = bEnd - 32;
+            const ubyte* limit = bEnd - 32;
 
             do
             {
@@ -978,7 +974,7 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 
 XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nogc
 {
-    xxh_u64 h64;
+    ulong h64;
 
     if (state.total_len >= 32)
     {
@@ -994,9 +990,9 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
         h64 = state.v[2] /*seed*/  + XXH_PRIME64_5;
     }
 
-    h64 += cast(xxh_u64) state.total_len;
+    h64 += cast(ulong) state.total_len;
 
-    return XXH64_finalize(h64, cast(const xxh_u8*) state.mem64,
+    return XXH64_finalize(h64, cast(const ubyte*) state.mem64,
             cast(size_t) state.total_len, XXH_alignment.XXH_aligned);
 }
 
@@ -1030,7 +1026,7 @@ enum XXH3_INTERNALBUFFER_SIZE = 256; ///The size of the internal XXH3 buffer.
 static assert(XXH_SECRET_DEFAULT_SIZE >= XXH3_SECRET_SIZE_MIN, "default keyset is not large enough");
 
 /*! Pseudorandom secret taken directly from FARSH. */
-align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
+align(64) private immutable ubyte[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
     0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c,
     0xf7, 0x21, 0xad, 0x1c, 0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb,
     0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f, 0xcb, 0x79, 0xe6, 0x4e,
@@ -1056,9 +1052,9 @@ align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
  * The other method, (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF), will AND both operands
  * and perform a full 64x64 multiply -- entirely redundant on 32-bit.
  */
-private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @safe pure nothrow @nogc
+private ulong XXH_mult32to64(uint x, uint y) @safe pure nothrow @nogc
 {
-    return (cast(xxh_u64)(x) * cast(xxh_u64)(y));
+    return (cast(ulong)(x) * cast(ulong)(y));
 }
 
 /*!
@@ -1070,7 +1066,7 @@ private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @safe pure nothrow @nogc
  * @param lhs , rhs The 64-bit integers to be multiplied
  * @return The 128-bit result represented in an @ref XXH128_hash_t.
  */
-private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothrow @nogc
+private XXH128_hash_t XXH_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
     static if (is(ucent))
     {
@@ -1079,23 +1075,23 @@ private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothr
 
         const uint128_t product = cast(uint128_t_) lhs * cast(uint128_t_) rhs;
         XXH128_hash_t r128;
-        // r128.low64  = cast(xxh_u64) (product);
-        // r128.high64 = cast(xxh_u64) (product >> 64);
+        // r128.low64  = cast(ulong) (product);
+        // r128.high64 = cast(ulong) (product >> 64);
         r128.low64 = product.data.lo;
         r128.high64 = product.data.hi;
     }
     else
     {
         /* First calculate all of the cross products. */
-        const xxh_u64 lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
-        const xxh_u64 hi_lo = XXH_mult32to64(lhs >> 32, rhs & 0xFFFFFFFF);
-        const xxh_u64 lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
-        const xxh_u64 hi_hi = XXH_mult32to64(lhs >> 32, rhs >> 32);
+        const ulong lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
+        const ulong hi_lo = XXH_mult32to64(lhs >> 32, rhs & 0xFFFFFFFF);
+        const ulong lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
+        const ulong hi_hi = XXH_mult32to64(lhs >> 32, rhs >> 32);
 
         /* Now add the products together. These will never overflow. */
-        const xxh_u64 cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
-        const xxh_u64 upper = (hi_lo >> 32) + (cross >> 32) + hi_hi;
-        const xxh_u64 lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
+        const ulong cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
+        const ulong upper = (hi_lo >> 32) + (cross >> 32) + hi_hi;
+        const ulong lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
 
         XXH128_hash_t r128;
         r128.low64 = lower;
@@ -1115,14 +1111,14 @@ private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothr
  * @return The low 64 bits of the product XOR'd by the high 64 bits.
  * @see XXH_mult64to128()
  */
-private xxh_u64 XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothrow @nogc
+private ulong XXH3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
     XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
     return product.low64 ^ product.high64;
 }
 
 /*! Seems to produce slightly better code on GCC for some reason. */
-private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @safe pure nothrow @nogc
+private ulong XXH_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
 {
     assert(0 <= shift && shift < 64, "shift out of range");
     return v64 ^ (v64 >> shift);
@@ -1132,7 +1128,7 @@ private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @safe pure nothrow @nogc
  * This is a fast avalanche stage,
  * suitable when input bits are already partially mixed
  */
-private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @safe pure nothrow @nogc
+private XXH64_hash_t XXH3_avalanche(ulong h64) @safe pure nothrow @nogc
 {
     h64 = XXH_xorshift64(h64, 37);
     h64 *= 0x165667919E3779F9;
@@ -1145,7 +1141,7 @@ private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @safe pure nothrow @nogc
  * inspired by Pelle Evensen's rrmxmx
  * preferable when input has not been previously mixed
  */
-static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @safe pure nothrow @nogc
+static XXH64_hash_t XXH3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
 {
     /* this mix is inspired by Pelle Evensen's rrmxmx */
     h64 ^= rol(h64, 49) ^ rol(h64, 24);
@@ -1188,8 +1184,8 @@ static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @safe pure nothrow @no
  *
  * This adds an extra layer of strength for custom secrets.
  */
-private XXH64_hash_t XXH3_len_1to3_64b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_1to3_64b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input == null");
     assert(1 <= len && len <= 3, "len out of range");
@@ -1200,46 +1196,46 @@ private XXH64_hash_t XXH3_len_1to3_64b(const xxh_u8* input, size_t len,
      * len = 3: combined = { input[2], 0x03, input[0], input[1] }
      */
     {
-        const xxh_u8 c1 = input[0];
-        const xxh_u8 c2 = input[len >> 1];
-        const xxh_u8 c3 = input[len - 1];
-        const xxh_u32 combined = (cast(xxh_u32) c1 << 16) | (
-                cast(xxh_u32) c2 << 24) | (cast(xxh_u32) c3 << 0) | (cast(xxh_u32) len << 8);
-        const xxh_u64 bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
-        const xxh_u64 keyed = cast(xxh_u64) combined ^ bitflip;
+        const ubyte c1 = input[0];
+        const ubyte c2 = input[len >> 1];
+        const ubyte c3 = input[len - 1];
+        const uint combined = (cast(uint) c1 << 16) | (
+                cast(uint) c2 << 24) | (cast(uint) c3 << 0) | (cast(uint) len << 8);
+        const ulong bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+        const ulong keyed = cast(ulong) combined ^ bitflip;
         return XXH64_avalanche(keyed);
     }
 }
 
-private XXH64_hash_t XXH3_len_4to8_64b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_4to8_64b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input == null");
     assert(secret != null, "secret == null");
     assert(4 <= len && len <= 8, "len out of range");
-    seed ^= cast(xxh_u64) XXH_swap32(cast(xxh_u32) seed) << 32;
+    seed ^= cast(ulong) XXH_swap32(cast(uint) seed) << 32;
     {
-        const xxh_u32 input1 = XXH_readLE32(input);
-        const xxh_u32 input2 = XXH_readLE32(input + len - 4);
-        const xxh_u64 bitflip = (XXH_readLE64(secret + 8) ^ XXH_readLE64(secret + 16)) - seed;
-        const xxh_u64 input64 = input2 + ((cast(xxh_u64) input1) << 32);
-        const xxh_u64 keyed = input64 ^ bitflip;
+        const uint input1 = XXH_readLE32(input);
+        const uint input2 = XXH_readLE32(input + len - 4);
+        const ulong bitflip = (XXH_readLE64(secret + 8) ^ XXH_readLE64(secret + 16)) - seed;
+        const ulong input64 = input2 + ((cast(ulong) input1) << 32);
+        const ulong keyed = input64 ^ bitflip;
         return XXH3_rrmxmx(keyed, len);
     }
 }
 
-private XXH64_hash_t XXH3_len_9to16_64b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_9to16_64b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input == null");
     assert(secret != null, "secret == null");
     assert(9 <= len && len <= 16, "len out of range");
     {
-        const xxh_u64 bitflip1 = (XXH_readLE64(secret + 24) ^ XXH_readLE64(secret + 32)) + seed;
-        const xxh_u64 bitflip2 = (XXH_readLE64(secret + 40) ^ XXH_readLE64(secret + 48)) - seed;
-        const xxh_u64 input_lo = XXH_readLE64(input) ^ bitflip1;
-        const xxh_u64 input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
-        const xxh_u64 acc = len + XXH_swap64(input_lo) + input_hi + XXH3_mul128_fold64(input_lo,
+        const ulong bitflip1 = (XXH_readLE64(secret + 24) ^ XXH_readLE64(secret + 32)) + seed;
+        const ulong bitflip2 = (XXH_readLE64(secret + 40) ^ XXH_readLE64(secret + 48)) - seed;
+        const ulong input_lo = XXH_readLE64(input) ^ bitflip1;
+        const ulong input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
+        const ulong acc = len + XXH_swap64(input_lo) + input_hi + XXH3_mul128_fold64(input_lo,
                 input_hi);
         return XXH3_avalanche(acc);
     }
@@ -1255,8 +1251,8 @@ private bool XXH_unlikely(bool exp) @safe pure nothrow @nogc
     return exp;
 }
 
-private XXH64_hash_t XXH3_len_0to16_64b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_0to16_64b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(len <= 16, "len > 16");
     {
@@ -1296,26 +1292,26 @@ private XXH64_hash_t XXH3_len_0to16_64b(const xxh_u8* input, size_t len,
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
-private xxh_u64 XXH3_mix16B(const(xxh_u8)* input, const(xxh_u8)* secret, xxh_u64 seed64) @trusted pure nothrow @nogc
+private ulong XXH3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
 {
     {
-        const xxh_u64 input_lo = XXH_readLE64(input);
-        const xxh_u64 input_hi = XXH_readLE64(input + 8);
+        const ulong input_lo = XXH_readLE64(input);
+        const ulong input_hi = XXH_readLE64(input + 8);
         return XXH3_mul128_fold64(input_lo ^ (XXH_readLE64(secret) + seed64),
                 input_hi ^ (XXH_readLE64(secret + 8) - seed64));
     }
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
-private XXH64_hash_t XXH3_len_17to128_64b(const(xxh_u8)* input, size_t len,
-        const(xxh_u8)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_17to128_64b(const(ubyte)* input, size_t len,
+        const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
     cast(void) secretSize;
     assert(16 < len && len <= 128, "len out of range");
 
     {
-        xxh_u64 acc = len * XXH_PRIME64_1;
+        ulong acc = len * XXH_PRIME64_1;
         if (len > 32)
         {
             if (len > 64)
@@ -1342,15 +1338,15 @@ enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
-private XXH64_hash_t XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
-        const(xxh_u8)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_len_129to240_64b(const(ubyte)* input, size_t len,
+        const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
     cast(void) secretSize;
     assert(128 < len && len <= XXH3_MIDSIZE_MAX, "128 >= len || len > XXH3_MIDSIZE_MAX");
 
     {
-        xxh_u64 acc = len * XXH_PRIME64_1;
+        ulong acc = len * XXH_PRIME64_1;
         const int nbRounds = cast(int) len / 16;
         int i;
         for (i = 0; i < 8; i++)
@@ -1375,9 +1371,9 @@ private XXH64_hash_t XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
 
 enum XXH_STRIPE_LEN = 64;
 enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumulation */
-enum XXH_ACC_NB = (XXH_STRIPE_LEN / (xxh_u64).sizeof);
+enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
-private void XXH_writeLE64(void* dst, xxh_u64 v64) @trusted pure nothrow @nogc
+private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
@@ -1402,14 +1398,14 @@ enum XXH_ACC_ALIGN = 8;
 private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 {
-    xxh_u64* xacc = cast(xxh_u64*) acc;
-    xxh_u8* xinput = cast(xxh_u8*) input;
-    xxh_u8* xsecret = cast(xxh_u8*) secret;
+    ulong* xacc = cast(ulong*) acc;
+    ubyte* xinput = cast(ubyte*) input;
+    ubyte* xsecret = cast(ubyte*) secret;
     assert(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB");
     assert((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_ALIGN - 1)) != 0");
     {
-        const xxh_u64 data_val = XXH_readLE64(xinput + lane * 8);
-        const xxh_u64 data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
+        const ulong data_val = XXH_readLE64(xinput + lane * 8);
+        const ulong data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
         xacc[lane ^ 1] += data_val; /* swap adjacent lanes */
         xacc[lane] += XXH_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
     }
@@ -1437,13 +1433,13 @@ private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  */
 private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 {
-    xxh_u64* xacc = cast(xxh_u64*) acc; /* presumed aligned */
-    const xxh_u8* xsecret = cast(const xxh_u8*) secret; /* no alignment restriction */
+    ulong* xacc = cast(ulong*) acc; /* presumed aligned */
+    const ubyte* xsecret = cast(const ubyte*) secret; /* no alignment restriction */
     assert(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0");
     assert(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB");
     {
-        const xxh_u64 key64 = XXH_readLE64(xsecret + lane * 8);
-        xxh_u64 acc64 = xacc[lane];
+        const ulong key64 = XXH_readLE64(xsecret + lane * 8);
+        ulong acc64 = xacc[lane];
         acc64 = XXH_xorshift64(acc64, 47);
         acc64 ^= key64;
         acc64 *= XXH_PRIME32_1;
@@ -1464,14 +1460,14 @@ private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure 
     }
 }
 
-private void XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64) @trusted pure nothrow @nogc
+private void XXH3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
 {
     /*
      * We need a separate pointer for the hack below,
      * which requires a non-const pointer.
      * Any decent compiler will optimize this out otherwise.
      */
-    const xxh_u8* kSecretPtr = cast(xxh_u8*) XXH3_kSecret;
+    const ubyte* kSecretPtr = cast(ubyte*) XXH3_kSecret;
     static assert((XXH_SECRET_DEFAULT_SIZE & 15) == 0, "(XXH_SECRET_DEFAULT_SIZE & 15) != 0");
 
     /*
@@ -1491,24 +1487,24 @@ private void XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64) @t
              * loads together for free. Putting the loads together before the stores
              * properly generates LDP.
              */
-            xxh_u64 lo = XXH_readLE64(kSecretPtr + 16 * i) + seed64;
-            xxh_u64 hi = XXH_readLE64(kSecretPtr + 16 * i + 8) - seed64;
-            XXH_writeLE64(cast(xxh_u8*) customSecret + 16 * i, lo);
-            XXH_writeLE64(cast(xxh_u8*) customSecret + 16 * i + 8, hi);
+            ulong lo = XXH_readLE64(kSecretPtr + 16 * i) + seed64;
+            ulong hi = XXH_readLE64(kSecretPtr + 16 * i + 8) - seed64;
+            XXH_writeLE64(cast(ubyte*) customSecret + 16 * i, lo);
+            XXH_writeLE64(cast(ubyte*) customSecret + 16 * i + 8, hi);
         }
     }
 }
 
 alias XXH3_f_accumulate_512 = void function(void*, const(void)*, const(void)*) @safe pure nothrow @nogc;
 alias XXH3_f_scrambleAcc = void function(void*, const void*) @safe pure nothrow @nogc;
-alias XXH3_f_initCustomSecret = void function(void*, xxh_u64) @safe pure nothrow @nogc;
+alias XXH3_f_initCustomSecret = void function(void*, ulong) @safe pure nothrow @nogc;
 
 immutable XXH3_f_accumulate_512 XXH3_accumulate_512 = &XXH3_accumulate_512_scalar;
 immutable XXH3_f_scrambleAcc XXH3_scrambleAcc = &XXH3_scrambleAcc_scalar;
 immutable XXH3_f_initCustomSecret XXH3_initCustomSecret = &XXH3_initCustomSecret_scalar;
 
 enum XXH_PREFETCH_DIST = 384;
-private void XXH_PREFETCH(const xxh_u8* ptr) @safe pure nothrow @nogc
+private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
 {
     cast(void)(ptr);
 }
@@ -1518,19 +1514,19 @@ private void XXH_PREFETCH(const xxh_u8* ptr) @safe pure nothrow @nogc
  * Loops over XXH3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
-private void XXH3_accumulate(xxh_u64* acc, const xxh_u8* input,
-        const xxh_u8* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
+private void XXH3_accumulate(ulong* acc, const ubyte* input,
+        const ubyte* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
     size_t n;
     for (n = 0; n < nbStripes; n++)
     {
-        const xxh_u8* in_ = input + n * XXH_STRIPE_LEN;
+        const ubyte* in_ = input + n * XXH_STRIPE_LEN;
         XXH_PREFETCH(in_ + XXH_PREFETCH_DIST);
         f_acc512(acc, in_, secret + n * XXH_SECRET_CONSUME_RATE);
     }
 }
 
-private void XXH3_hashLong_internal_loop(xxh_u64* acc, const xxh_u8* input, size_t len, const xxh_u8* secret,
+private void XXH3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     const size_t nbStripesPerBlock = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
@@ -1557,7 +1553,7 @@ private void XXH3_hashLong_internal_loop(xxh_u64* acc, const xxh_u8* input, size
 
         /* last stripe */
         {
-            const xxh_u8* p = input + len - XXH_STRIPE_LEN;
+            const ubyte* p = input + len - XXH_STRIPE_LEN;
             f_acc512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
         }
     }
@@ -1565,15 +1561,15 @@ private void XXH3_hashLong_internal_loop(xxh_u64* acc, const xxh_u8* input, size
 
 enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
-private xxh_u64 XXH3_mix2Accs(const(xxh_u64)* acc, const(xxh_u8)* secret) @trusted pure nothrow @nogc
+private ulong XXH3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
 {
     return XXH3_mul128_fold64(acc[0] ^ XXH_readLE64(secret), acc[1] ^ XXH_readLE64(secret + 8));
 }
 
-private XXH64_hash_t XXH3_mergeAccs(const(xxh_u64)* acc, const(xxh_u8)* secret, xxh_u64 start)
+private XXH64_hash_t XXH3_mergeAccs(const(ulong)* acc, const(ubyte)* secret, ulong start)
 @trusted pure nothrow @nogc
 {
-    xxh_u64 result64 = start;
+    ulong result64 = start;
     size_t i = 0;
 
     for (i = 0; i < 4; i++)
@@ -1592,18 +1588,18 @@ static immutable XXH3_INIT_ACC = [
 private XXH64_hash_t XXH3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
-    align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
+    align(XXH_ACC_ALIGN) ulong[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const(xxh_u8)*) input, len,
-            cast(const(xxh_u8)*) secret, secretSize, f_acc512, f_scramble);
+    XXH3_hashLong_internal_loop(&acc[0], cast(const(ubyte)*) input, len,
+            cast(const(ubyte)*) secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
     static assert((acc).sizeof == 64, "(acc).sizeof != 64");
     /* do not align on 8, so that the secret is different from the accumulator */
     assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START,
             "secretSize < (acc).sizeof + XXH_SECRET_MERGEACCS_START");
-    return XXH3_mergeAccs(&acc[0], cast(const(xxh_u8)*) secret + XXH_SECRET_MERGEACCS_START,
-            cast(xxh_u64) len * XXH_PRIME64_1);
+    return XXH3_mergeAccs(&acc[0], cast(const(ubyte)*) secret + XXH_SECRET_MERGEACCS_START,
+            cast(ulong) len * XXH_PRIME64_1);
 }
 
 enum XXH_SECRET_MERGEACCS_START = 11;
@@ -1614,7 +1610,7 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
 private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
-        size_t len, XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
+        size_t len, XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
@@ -1628,7 +1624,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
 private XXH64_hash_t XXH3_hashLong_64b_default(const(void)* input, size_t len,
-        XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
+        XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     cast(void) secret;
@@ -1660,7 +1656,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, siz
                 (XXH3_kSecret).sizeof, f_acc512, f_scramble);
     //#endif
     {
-        align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        align(XXH_SEC_ALIGN) ubyte[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed);
         return XXH3_hashLong_64b_internal(input, len, &secret[0], (secret)
                 .sizeof, f_acc512, f_scramble);
@@ -1671,7 +1667,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, siz
  * It's important for performance that XXH3_hashLong is not inlined.
  */
 private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
-        XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
+        XXH64_hash_t seed, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) secret;
     cast(void) secretLen;
@@ -1680,7 +1676,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
 }
 
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
-        XXH64_hash_t, const(xxh_u8)*, size_t) @safe pure nothrow @nogc;
+        XXH64_hash_t, const(ubyte)*, size_t) @safe pure nothrow @nogc;
 
 private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
@@ -1695,15 +1691,15 @@ private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
      * Also, note that function signature doesn't offer room to return an error.
      */
     if (len <= 16)
-        return XXH3_len_0to16_64b(cast(const(xxh_u8)*) input, len,
-                cast(const(xxh_u8)*) secret, seed64);
+        return XXH3_len_0to16_64b(cast(const(ubyte)*) input, len,
+                cast(const(ubyte)*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_64b(cast(const(xxh_u8)*) input, len,
-                cast(const(xxh_u8)*) secret, secretLen, seed64);
+        return XXH3_len_17to128_64b(cast(const(ubyte)*) input, len,
+                cast(const(ubyte)*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b(cast(const(xxh_u8)*) input, len,
-                cast(const(xxh_u8)*) secret, secretLen, seed64);
-    return f_hashLong(input, len, seed64, cast(const(xxh_u8)*) secret, secretLen);
+        return XXH3_len_129to240_64b(cast(const(ubyte)*) input, len,
+                cast(const(ubyte)*) secret, secretLen, seed64);
+    return f_hashLong(input, len, seed64, cast(const(ubyte)*) secret, secretLen);
 }
 
 /* ===   Public entry point   === */
@@ -1737,7 +1733,7 @@ XXH64_hash_t XXH3_64bits_withSecretandSeed(const(void)* input, size_t length,
         return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
                 (XXH3_kSecret).sizeof, null);
     return XXH3_hashLong_64b_withSecret(input, length, seed,
-            cast(const(xxh_u8)*) secret, secretSize);
+            cast(const(ubyte)*) secret, secretSize);
 }
 
 /* ===   XXH3 streaming   === */
@@ -1772,7 +1768,7 @@ private void* XXH_alignedMalloc(size_t s, size_t align_) @trusted nothrow @nogc
     assert((align_ & (align_ - 1)) == 0, "(align_ & (align_ - 1)) != 0"); /* power of 2 */
     assert(s != 0 && s < (s + align_), "s == 0 || s >= (s + align_)"); /* empty/overflow */
     { /* Overallocate to make room for manual realignment and an offset byte */
-        xxh_u8* base = cast(xxh_u8*) malloc(s + align_);
+        ubyte* base = cast(ubyte*) malloc(s + align_);
         if (base != null)
         {
             /*
@@ -1783,12 +1779,12 @@ private void* XXH_alignedMalloc(size_t s, size_t align_) @trusted nothrow @nogc
              */
             size_t offset = align_ - (cast(size_t) base & (align_ - 1)); /* base % align */
             /* Add the offset for the now-aligned pointer */
-            xxh_u8* ptr = base + offset;
+            ubyte* ptr = base + offset;
 
             assert(cast(size_t) ptr % align_ == 0, "ptr % align_ != 0");
 
             /* Store the offset immediately before the returned pointer. */
-            ptr[-1] = cast(xxh_u8) offset;
+            ptr[-1] = cast(ubyte) offset;
             return ptr;
         }
         return null;
@@ -1804,11 +1800,11 @@ private void XXH_alignedFree(void* p) @trusted nothrow @nogc
 
     if (p != null)
     {
-        xxh_u8* ptr = cast(xxh_u8*) p;
+        ubyte* ptr = cast(ubyte*) p;
         /* Get the offset byte we added in XXH_malloc. */
-        xxh_u8 offset = ptr[-1];
+        ubyte offset = ptr[-1];
         /* Free the original malloc'd pointer */
-        xxh_u8* base = ptr - offset;
+        ubyte* base = ptr - offset;
         free(base);
     }
 }
@@ -1920,9 +1916,9 @@ XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 /* Note : when XXH3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
-private void XXH3_consumeStripes(xxh_u64* acc, size_t* nbStripesSoFarPtr,
-        size_t nbStripesPerBlock, const xxh_u8* input, size_t nbStripes,
-        const xxh_u8* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
+private void XXH3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
+        size_t nbStripesPerBlock, const ubyte* input, size_t nbStripes,
+        const ubyte* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
         XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     assert(nbStripes <= nbStripesPerBlock, "nbStripes > nbStripesPerBlock"); /* can handle max 1 scramble per invocation */
@@ -1951,7 +1947,7 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
  */
-private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
+private XXH_errorcode XXH3_update(XXH3_state_t* state, const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
@@ -1964,7 +1960,7 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
 
     assert(state != null, "state == null");
     {
-        const xxh_u8* bEnd = input + len;
+        const ubyte* bEnd = input + len;
         const(ubyte)* secret = (state.extSecret == null) ? &state
             .customSecret[0] : &state.extSecret[0];
         static if (XXH3_STREAM_USE_STACK >= 1)
@@ -1973,12 +1969,12 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
             * when operating accumulators directly into state.
             * Operating into stack space seems to enable proper optimization.
             * clang, on the other hand, doesn't seem to need this trick */
-            align(XXH_ACC_ALIGN) xxh_u64[8] acc;
+            align(XXH_ACC_ALIGN) ulong[8] acc;
             memcpy(&acc[0], &state.acc[0], (acc).sizeof);
         }
         else
         {
-            xxh_u64* acc = state.acc;
+            ulong* acc = state.acc;
         }
         state.totalLen += len;
         assert(state.bufferedSize <= XXH3_INTERNALBUFFER_SIZE, "state.bufferedSize > XXH3_INTERNALBUFFER_SIZE");
@@ -2052,7 +2048,7 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
             /* Consume input by a multiple of internal buffer size */
             if (bEnd - input > XXH3_INTERNALBUFFER_SIZE)
             {
-                const xxh_u8* limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
+                const ubyte* limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
                 do
                 {
                     XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock, input,
@@ -2086,7 +2082,7 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
 /*! @ingroup XXH3_family */
 XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len) @safe pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const(xxh_u8)*) input, len,
+    return XXH3_update(state, cast(const(ubyte)*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
@@ -2111,7 +2107,7 @@ void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte*
     }
     else
     { /* bufferedSize < XXH_STRIPE_LEN */
-        xxh_u8[XXH_STRIPE_LEN] lastStripe;
+        ubyte[XXH_STRIPE_LEN] lastStripe;
         const size_t catchupSize = XXH_STRIPE_LEN - state.bufferedSize;
         assert(state.bufferedSize > 0, "bufferedSize <= 0"); /* there is always some input buffered */
         memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
@@ -2130,7 +2126,7 @@ XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
         align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
         XXH3_digest_long(&acc[0], state, secret);
         return XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
-                cast(xxh_u64) state.totalLen * XXH_PRIME64_1);
+                cast(ulong) state.totalLen * XXH_PRIME64_1);
     }
     /* totalLen <= XXH3_MIDSIZE_MAX: digesting a short input */
     if (state.useSeed)
@@ -2155,8 +2151,8 @@ XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * XXH128 is also more oriented towards 64-bit machines. It is still extremely
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
-private XXH128_hash_t XXH3_len_1to3_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_1to3_128b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     /* A doubled version of 1to3_64b with different constants. */
     assert(input != null, "input is null");
@@ -2168,16 +2164,16 @@ private XXH128_hash_t XXH3_len_1to3_128b(const xxh_u8* input, size_t len,
      * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
      */
     {
-        const xxh_u8 c1 = input[0];
-        const xxh_u8 c2 = input[len >> 1];
-        const xxh_u8 c3 = input[len - 1];
-        const xxh_u32 combinedl = (cast(xxh_u32) c1 << 16) | (
-                cast(xxh_u32) c2 << 24) | (cast(xxh_u32) c3 << 0) | (cast(xxh_u32) len << 8);
-        const xxh_u32 combinedh = rol(XXH_swap32(combinedl), 13);
-        const xxh_u64 bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
-        const xxh_u64 bitfliph = (XXH_readLE32(secret + 8) ^ XXH_readLE32(secret + 12)) - seed;
-        const xxh_u64 keyed_lo = cast(xxh_u64) combinedl ^ bitflipl;
-        const xxh_u64 keyed_hi = cast(xxh_u64) combinedh ^ bitfliph;
+        const ubyte c1 = input[0];
+        const ubyte c2 = input[len >> 1];
+        const ubyte c3 = input[len - 1];
+        const uint combinedl = (cast(uint) c1 << 16) | (
+                cast(uint) c2 << 24) | (cast(uint) c3 << 0) | (cast(uint) len << 8);
+        const uint combinedh = rol(XXH_swap32(combinedl), 13);
+        const ulong bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+        const ulong bitfliph = (XXH_readLE32(secret + 8) ^ XXH_readLE32(secret + 12)) - seed;
+        const ulong keyed_lo = cast(ulong) combinedl ^ bitflipl;
+        const ulong keyed_hi = cast(ulong) combinedh ^ bitfliph;
         XXH128_hash_t h128;
         h128.low64 = XXH64_avalanche(keyed_lo);
         h128.high64 = XXH64_avalanche(keyed_hi);
@@ -2185,19 +2181,19 @@ private XXH128_hash_t XXH3_len_1to3_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH3_len_4to8_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_4to8_128b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input is null");
     assert(secret != null, "secret is null");
     assert(4 <= len && len <= 8, "len is out of range");
-    seed ^= cast(xxh_u64) XXH_swap32(cast(xxh_u32) seed) << 32;
+    seed ^= cast(ulong) XXH_swap32(cast(uint) seed) << 32;
     {
-        const xxh_u32 input_lo = XXH_readLE32(input);
-        const xxh_u32 input_hi = XXH_readLE32(input + len - 4);
-        const xxh_u64 input_64 = input_lo + (cast(xxh_u64) input_hi << 32);
-        const xxh_u64 bitflip = (XXH_readLE64(secret + 16) ^ XXH_readLE64(secret + 24)) + seed;
-        const xxh_u64 keyed = input_64 ^ bitflip;
+        const uint input_lo = XXH_readLE32(input);
+        const uint input_hi = XXH_readLE32(input + len - 4);
+        const ulong input_64 = input_lo + (cast(ulong) input_hi << 32);
+        const ulong bitflip = (XXH_readLE64(secret + 16) ^ XXH_readLE64(secret + 24)) + seed;
+        const ulong keyed = input_64 ^ bitflip;
 
         /* Shift len to the left to ensure it is even, this avoids even multiplies. */
         XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
@@ -2213,23 +2209,23 @@ private XXH128_hash_t XXH3_len_4to8_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input is null");
     assert(secret != null, "secret is null");
     assert(9 <= len && len <= 16, "len out of range");
     {
-        const xxh_u64 bitflipl = (XXH_readLE64(secret + 32) ^ XXH_readLE64(secret + 40)) - seed;
-        const xxh_u64 bitfliph = (XXH_readLE64(secret + 48) ^ XXH_readLE64(secret + 56)) + seed;
-        const xxh_u64 input_lo = XXH_readLE64(input);
-        xxh_u64 input_hi = XXH_readLE64(input + len - 8);
+        const ulong bitflipl = (XXH_readLE64(secret + 32) ^ XXH_readLE64(secret + 40)) - seed;
+        const ulong bitfliph = (XXH_readLE64(secret + 48) ^ XXH_readLE64(secret + 56)) + seed;
+        const ulong input_lo = XXH_readLE64(input);
+        ulong input_hi = XXH_readLE64(input + len - 8);
         XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
         /*
          * Put len in the middle of m128 to ensure that the length gets mixed to
          * both the low and high bits in the 128x64 multiply below.
          */
-        m128.low64 += cast(xxh_u64)(len - 1) << 54;
+        m128.low64 += cast(ulong)(len - 1) << 54;
         input_hi ^= bitfliph;
         /*
          * Add the high 32 bits of input_hi to the high 32 bits of m128, then
@@ -2238,7 +2234,7 @@ private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
          *
          * The best approach to this operation is different on 32-bit and 64-bit.
          */
-        if ((void*).sizeof < (xxh_u64).sizeof)
+        if ((void*).sizeof < (ulong).sizeof)
         { /* 32-bit */
             /*
              * 32-bit optimized version, which is more readable.
@@ -2246,7 +2242,7 @@ private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
              * On 32-bit, it removes an ADC and delays a dependency between the two
              * halves of m128.high64, but it generates an extra mask on 64-bit.
              */
-            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(xxh_u32) input_hi,
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(uint) input_hi,
                     XXH_PRIME32_2);
         }
         else
@@ -2270,12 +2266,12 @@ private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
              *    a + b + (b * (c - 1))
              *
              * Substitute a, b, and c:
-             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             *    input_hi.hi + input_hi.lo + ((ulong)input_hi.lo * (XXH_PRIME32_2 - 1))
              *
              * Since input_hi.hi + input_hi.lo == input_hi, we get this:
-             *    input_hi + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             *    input_hi + ((ulong)input_hi.lo * (XXH_PRIME32_2 - 1))
              */
-            m128.high64 += input_hi + XXH_mult32to64(cast(xxh_u32) input_hi, XXH_PRIME32_2 - 1);
+            m128.high64 += input_hi + XXH_mult32to64(cast(uint) input_hi, XXH_PRIME32_2 - 1);
         }
         /* m128 ^= XXH_swap64(m128 >> 64); */
         m128.low64 ^= XXH_swap64(m128.high64);
@@ -2291,8 +2287,8 @@ private XXH128_hash_t XXH3_len_9to16_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH3_len_0to16_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_0to16_128b(const ubyte* input, size_t len,
+        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(len <= 16, "len > 16");
     {
@@ -2304,8 +2300,8 @@ private XXH128_hash_t XXH3_len_0to16_128b(const xxh_u8* input, size_t len,
             return XXH3_len_1to3_128b(input, len, secret, seed);
         {
             XXH128_hash_t h128;
-            const xxh_u64 bitflipl = XXH_readLE64(secret + 64) ^ XXH_readLE64(secret + 72);
-            const xxh_u64 bitfliph = XXH_readLE64(secret + 80) ^ XXH_readLE64(secret + 88);
+            const ulong bitflipl = XXH_readLE64(secret + 64) ^ XXH_readLE64(secret + 72);
+            const ulong bitfliph = XXH_readLE64(secret + 80) ^ XXH_readLE64(secret + 88);
             h128.low64 = XXH64_avalanche(seed ^ bitflipl);
             h128.high64 = XXH64_avalanche(seed ^ bitfliph);
             return h128;
@@ -2313,8 +2309,8 @@ private XXH128_hash_t XXH3_len_0to16_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1,
-        const xxh_u8* input_2, const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
+        const ubyte* input_2, const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     acc.low64 += XXH3_mix16B(input_1, secret + 0, seed);
     acc.low64 ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
@@ -2323,8 +2319,8 @@ private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1,
     return acc;
 }
 
-private XXH128_hash_t XXH3_len_17to128_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
+        const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSie < XXH3_SECRET_SIZE_MIN");
     cast(void) secretSize;
@@ -2374,8 +2370,8 @@ private XXH128_hash_t XXH3_len_17to128_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH3_len_129to240_128b(const xxh_u8* input, size_t len,
-        const xxh_u8* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
+        const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
     cast(void) secretSize;
@@ -2416,12 +2412,12 @@ private XXH128_hash_t XXH3_len_129to240_128b(const xxh_u8* input, size_t len,
     }
 }
 
-private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len, const xxh_u8* secret,
+private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
-    align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
+    align(XXH_ACC_ALIGN) ulong[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const xxh_u8*) input, len,
+    XXH3_hashLong_internal_loop(&acc[0], cast(const ubyte*) input, len,
             secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
@@ -2430,9 +2426,9 @@ private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len,
     {
         XXH128_hash_t h128;
         h128.low64 = XXH3_mergeAccs(&acc[0],
-                secret + XXH_SECRET_MERGEACCS_START, cast(xxh_u64) len * XXH_PRIME64_1);
+                secret + XXH_SECRET_MERGEACCS_START, cast(ulong) len * XXH_PRIME64_1);
         h128.high64 = XXH3_mergeAccs(&acc[0], secret + secretSize - (acc)
-                .sizeof - XXH_SECRET_MERGEACCS_START, ~(cast(xxh_u64) len * XXH_PRIME64_2));
+                .sizeof - XXH_SECRET_MERGEACCS_START, ~(cast(ulong) len * XXH_PRIME64_2));
         return h128;
     }
 }
@@ -2455,7 +2451,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
         size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
-    return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*) secret,
+    return XXH3_hashLong_128b_internal(input, len, cast(const ubyte*) secret,
             secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
@@ -2467,10 +2463,10 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, si
         return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
                 (XXH3_kSecret).sizeof, f_acc512, f_scramble);
     {
-        align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        align(XXH_SEC_ALIGN) ubyte[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed64);
         return XXH3_hashLong_128b_internal(input, len,
-                cast(const xxh_u8*)&secret[0], (secret).sizeof, f_acc512, f_scramble);
+                cast(const ubyte*)&secret[0], (secret).sizeof, f_acc512, f_scramble);
     }
 }
 /*
@@ -2500,14 +2496,14 @@ private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
      * Adding a check and a branch here would cost performance at every hash.
      */
     if (len <= 16)
-        return XXH3_len_0to16_128b(cast(const xxh_u8*) input, len,
-                cast(const xxh_u8*) secret, seed64);
+        return XXH3_len_0to16_128b(cast(const ubyte*) input, len,
+                cast(const ubyte*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_128b(cast(const xxh_u8*) input, len,
-                cast(const xxh_u8*) secret, secretLen, seed64);
+        return XXH3_len_17to128_128b(cast(const ubyte*) input, len,
+                cast(const ubyte*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_128b(cast(const xxh_u8*) input, len,
-                cast(const xxh_u8*) secret, secretLen, seed64);
+        return XXH3_len_129to240_128b(cast(const ubyte*) input, len,
+                cast(const ubyte*) secret, secretLen, seed64);
     return f_hl128(input, len, seed64, secret, secretLen);
 }
 
@@ -2524,7 +2520,7 @@ XXH128_hash_t XXH3_128bits(const void* input, size_t len) @safe pure nothrow @no
 XXH128_hash_t XXH3_128bits_withSecret(const void* input, size_t len,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, 0, cast(const xxh_u8*) secret,
+    return XXH3_128bits_internal(input, len, 0, cast(const ubyte*) secret,
             secretSize, &XXH3_hashLong_128b_withSecret);
 }
 
@@ -2578,7 +2574,7 @@ XXH_errorcode XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 
 XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len) @safe pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const xxh_u8*) input, len,
+    return XXH3_update(state, cast(const ubyte*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
 }
 
@@ -2594,10 +2590,10 @@ XXH128_hash_t XXH3_128bits_digest(const XXH3_state_t* state) @trusted pure nothr
         {
             XXH128_hash_t h128;
             h128.low64 = XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
-                    cast(xxh_u64) state.totalLen * XXH_PRIME64_1);
+                    cast(ulong) state.totalLen * XXH_PRIME64_1);
             h128.high64 = XXH3_mergeAccs(&acc[0], secret + state.secretLimit + XXH_STRIPE_LEN - (acc)
                     .sizeof - XXH_SECRET_MERGEACCS_START,
-                    ~(cast(xxh_u64) state.totalLen * XXH_PRIME64_2));
+                    ~(cast(ulong) state.totalLen * XXH_PRIME64_2));
             return h128;
         }
     }

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -499,6 +499,8 @@ do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;
+    else if (input == null && len != 0)
+        return XXH_errorcode.XXH_ERROR;
     else
     {
         const(ubyte)* p = cast(const(ubyte)*) input;
@@ -703,7 +705,6 @@ in
 }
 do
 {
-
     len &= 31;
     while (len >= 8)
     {
@@ -831,6 +832,8 @@ do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;
+    else if (input == null && len != 0)
+        return XXH_errorcode.XXH_ERROR;
     else
     {
         const(ubyte)* p = cast(const(ubyte)*) input;
@@ -1826,6 +1829,8 @@ do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;
+    else if (input == null && len != 0)
+        return XXH_errorcode.XXH_ERROR;
     else
     {
         const ubyte* bEnd = input + len;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -54,7 +54,7 @@ else version (X86_64)
 //      The code from core.int128 doesn't inline.
 //version = Have128BitInteger;
 
-version(Have128BitInteger)
+version (Have128BitInteger)
 {
     import core.int128;
 }
@@ -1064,7 +1064,7 @@ private ulong xxh_mult32to64(uint x, uint y) @safe pure nothrow @nogc
  */
 private XXH128_hash_t xxh_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
-    version(Have128BitInteger)
+    version (Have128BitInteger)
     {
         Cent cent_lhs; cent_lhs.lo = lhs;
         Cent cent_rhs; cent_rhs.lo = rhs;
@@ -1512,7 +1512,7 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
 //TODO    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
 //TODO    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
 //TODO  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-//TODO    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
+//TODO    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw == read */, 3 /* locality */)
 //TODO  else
 //TODO    define XXH_PREFETCH(ptr) (void)(ptr)  /* disabled */
 //TODO  endif

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -98,15 +98,8 @@ alias xxh_u8 = ubyte;
 alias xxh_u32 = uint;
 alias xxh_u64 = ulong;
 
-private uint32_t XXH_rotl32(uint32_t x, uint r) @safe pure nothrow @nogc
-{
-    return (((x) << (r)) | ((x) >> (32 - (r))));
-}
+private import core.bitop : rol;
 
-private uint64_t XXH_rotl64(uint64_t x, uint r) @safe pure nothrow @nogc
-{
-    return (((x) << (r)) | ((x) >> (64 - (r))));
-}
 /* *************************************
 *  Misc
 ***************************************/
@@ -324,7 +317,7 @@ enum XXH_PRIME32_5 = 0x165667B1U; /** 0b00010110010101100110011110110001 */
 private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME32_2;
-    acc = XXH_rotl32(acc, 13);
+    acc = rol(acc, 13);
     acc *= XXH_PRIME32_1;
     return acc;
 }
@@ -373,14 +366,14 @@ private xxh_u32 XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH
     void XXH_PROCESS1(ref uint32_t hash, ref const(xxh_u8)* ptr)
     {
         hash += (*ptr++) * XXH_PRIME32_5;
-        hash = XXH_rotl32(hash, 11) * XXH_PRIME32_1;
+        hash = rol(hash, 11) * XXH_PRIME32_1;
     }
 
     void XXH_PROCESS4(ref uint32_t hash, ref const(xxh_u8)* ptr)
     {
         hash += XXH_get32bits(ptr, align_) * XXH_PRIME32_3;
         ptr += 4;
-        hash = XXH_rotl32(hash, 17) * XXH_PRIME32_4;
+        hash = rol(hash, 17) * XXH_PRIME32_4;
     }
 
     /* Compact rerolled version; generally faster */
@@ -499,7 +492,7 @@ private xxh_u32 XXH32_endian_align(const(xxh_u8)* input, size_t len,
         }
         while (input < limit);
 
-        h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+        h32 = rol(v1, 1) + rol(v2, 7) + rol(v3, 12) + rol(v4, 18);
     }
     else
     {
@@ -649,8 +642,8 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 
     if (state.large_len)
     {
-        h32 = XXH_rotl32(state.v[0], 1) + XXH_rotl32(state.v[1],
-                7) + XXH_rotl32(state.v[2], 12) + XXH_rotl32(state.v[3], 18);
+        h32 = rol(state.v[0], 1) + rol(state.v[1],
+                7) + rol(state.v[2], 12) + rol(state.v[3], 18);
     }
     else
     {
@@ -730,7 +723,7 @@ enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /*!< 0b00100111110101001110101100101111
 private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
-    acc = XXH_rotl64(acc, 31);
+    acc = rol(acc, 31);
     acc *= XXH_PRIME64_1;
     return acc;
 }
@@ -785,20 +778,20 @@ private xxh_u64 XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH
         xxh_u64 k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
         ptr += 8;
         hash ^= k1;
-        hash = XXH_rotl64(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+        hash = rol(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
         len -= 8;
     }
     if (len >= 4)
     {
         hash ^= cast(xxh_u64)(XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
         ptr += 4;
-        hash = XXH_rotl64(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
+        hash = rol(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
         len -= 4;
     }
     while (len > 0)
     {
         hash ^= (*ptr++) * XXH_PRIME64_5;
-        hash = XXH_rotl64(hash, 11) * XXH_PRIME64_1;
+        hash = rol(hash, 11) * XXH_PRIME64_1;
         --len;
     }
     return XXH64_avalanche(hash);
@@ -841,7 +834,7 @@ private xxh_u64 XXH64_endian_align(const(xxh_u8)* input, size_t len,
         }
         while (input < limit);
 
-        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = rol(v1, 1) + rol(v2, 7) + rol(v3, 12) + rol(v4, 18);
         h64 = XXH64_mergeRound(h64, v1);
         h64 = XXH64_mergeRound(h64, v2);
         h64 = XXH64_mergeRound(h64, v3);
@@ -989,8 +982,8 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 
     if (state.total_len >= 32)
     {
-        h64 = XXH_rotl64(state.v[0], 1) + XXH_rotl64(state.v[1],
-                7) + XXH_rotl64(state.v[2], 12) + XXH_rotl64(state.v[3], 18);
+        h64 = rol(state.v[0], 1) + rol(state.v[1],
+                7) + rol(state.v[2], 12) + rol(state.v[3], 18);
         h64 = XXH64_mergeRound(h64, state.v[0]);
         h64 = XXH64_mergeRound(h64, state.v[1]);
         h64 = XXH64_mergeRound(h64, state.v[2]);
@@ -1155,7 +1148,7 @@ private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @safe pure nothrow @nogc
 static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @safe pure nothrow @nogc
 {
     /* this mix is inspired by Pelle Evensen's rrmxmx */
-    h64 ^= XXH_rotl64(h64, 49) ^ XXH_rotl64(h64, 24);
+    h64 ^= rol(h64, 49) ^ rol(h64, 24);
     h64 *= 0x9FB21C651E98DF25;
     h64 ^= (h64 >> 35) + len;
     h64 *= 0x9FB21C651E98DF25;
@@ -2180,7 +2173,7 @@ private XXH128_hash_t XXH3_len_1to3_128b(const xxh_u8* input, size_t len,
         const xxh_u8 c3 = input[len - 1];
         const xxh_u32 combinedl = (cast(xxh_u32) c1 << 16) | (
                 cast(xxh_u32) c2 << 24) | (cast(xxh_u32) c3 << 0) | (cast(xxh_u32) len << 8);
-        const xxh_u32 combinedh = XXH_rotl32(XXH_swap32(combinedl), 13);
+        const xxh_u32 combinedh = rol(XXH_swap32(combinedl), 13);
         const xxh_u64 bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
         const xxh_u64 bitfliph = (XXH_readLE32(secret + 8) ^ XXH_readLE32(secret + 12)) - seed;
         const xxh_u64 keyed_lo = cast(xxh_u64) combinedl ^ bitflipl;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -80,7 +80,9 @@ public import std.digest;
     hash = xxh.finish();
 }
 
-/* Port of C sources (release 0.8.1) to D language below */
+public import std.digest;
+
+/* --- Port of C sources (release 0.8.1) to D language below ---------------- */
 
 enum XXH_NO_STREAM = false;
 enum XXH_SIZE_OPT = 0;
@@ -96,12 +98,12 @@ alias xxh_u8 = ubyte;
 alias xxh_u32 = uint;
 alias xxh_u64 = ulong;
 
-private uint32_t XXH_rotl32(uint32_t x, uint r) @trusted pure nothrow @nogc
+private uint32_t XXH_rotl32(uint32_t x, uint r) @safe pure nothrow @nogc
 {
     return (((x) << (r)) | ((x) >> (32 - (r))));
 }
 
-private uint64_t XXH_rotl64(uint64_t x, uint r) @trusted pure nothrow @nogc
+private uint64_t XXH_rotl64(uint64_t x, uint r) @safe pure nothrow @nogc
 {
     return (((x) << (r)) | ((x) >> (64 - (r))));
 }
@@ -117,7 +119,7 @@ enum XXH_VERSION_NUMBER = (XXH_VERSION_MAJOR * 100 * 100 + XXH_VERSION_MINOR
             * 100 + XXH_VERSION_RELEASE);
 
 /** Get version number */
-uint XXH_versionNumber() @trusted pure nothrow @nogc
+uint XXH_versionNumber() @safe pure nothrow @nogc
 {
     return XXH_VERSION_NUMBER;
 }
@@ -253,7 +255,7 @@ struct XXH32_canonical_t
  * Param: x = The 32-bit integer to byteswap.
  * Return: x, byteswapped.
  */
-private xxh_u32 XXH_swap32(xxh_u32 x) @trusted pure nothrow @nogc
+private xxh_u32 XXH_swap32(xxh_u32 x) @safe pure nothrow @nogc
 {
     return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) | (
             (x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
@@ -278,12 +280,12 @@ private xxh_u32 XXH_read32(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-private xxh_u32 XXH_readLE32(const void* ptr) @trusted pure nothrow @nogc
+private xxh_u32 XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
 }
 
-private xxh_u32 XXH_readBE32(const void* ptr) @trusted pure nothrow @nogc
+private xxh_u32 XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
 }
@@ -319,7 +321,7 @@ enum XXH_PRIME32_5 = 0x165667B1U; /** 0b00010110010101100110011110110001 */
  * Param: input The stripe of input to mix.
  * Return: The mixed accumulator lane.
  */
-private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @trusted pure nothrow @nogc
+private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME32_2;
     acc = XXH_rotl32(acc, 13);
@@ -335,7 +337,7 @@ private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @trusted pure nothrow @n
  * Param: hash = The hash to avalanche.
  * Return The avalanched hash.
  */
-private xxh_u32 XXH32_avalanche(xxh_u32 hash) @trusted pure nothrow @nogc
+private xxh_u32 XXH32_avalanche(xxh_u32 hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 15;
     hash *= XXH_PRIME32_2;
@@ -345,7 +347,7 @@ private xxh_u32 XXH32_avalanche(xxh_u32 hash) @trusted pure nothrow @nogc
     return hash;
 }
 
-private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @trusted pure nothrow @nogc
+private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
     return XXH_readLE32_align(p, align_);
 }
@@ -509,7 +511,7 @@ private xxh_u32 XXH32_endian_align(const(xxh_u8)* input, size_t len,
     return XXH32_finalize(h32, input, len & 15, align_);
 }
 
-XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @trusted pure nothrow @nogc
+XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure nothrow @nogc
 {
     static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
     {
@@ -672,7 +674,7 @@ void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted
     memcpy(dst, &hash, (*dst).sizeof);
 }
 
-XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @trusted pure nothrow @nogc
+XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure nothrow @nogc
 {
     return XXH_readBE32(src);
 }
@@ -688,7 +690,7 @@ private xxh_u64 XXH_read64(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-private xxh_u64 XXH_swap64(xxh_u64 x) @trusted pure nothrow @nogc
+private xxh_u64 XXH_swap64(xxh_u64 x) @safe pure nothrow @nogc
 {
     return ((x << 56) & 0xff00000000000000) | ((x << 40) & 0x00ff000000000000) | (
             (x << 24) & 0x0000ff0000000000) | ((x << 8) & 0x000000ff00000000) | (
@@ -696,12 +698,12 @@ private xxh_u64 XXH_swap64(xxh_u64 x) @trusted pure nothrow @nogc
             (x >> 40) & 0x000000000000ff00) | ((x >> 56) & 0x00000000000000ff);
 }
 
-private xxh_u64 XXH_readLE64(const void* ptr) @trusted pure nothrow @nogc
+private xxh_u64 XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
 }
 
-private xxh_u64 XXH_readBE64(const void* ptr) @trusted pure nothrow @nogc
+private xxh_u64 XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
 {
     return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
 }
@@ -725,7 +727,7 @@ enum XXH_PRIME64_3 = 0x165667B19E3779F9; /*!< 0b00010110010101100110011110110001
 enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63; /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
 enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
-private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @trusted pure nothrow @nogc
+private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
     acc = XXH_rotl64(acc, 31);
@@ -733,7 +735,7 @@ private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @trusted pure nothrow @n
     return acc;
 }
 
-private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @trusted pure nothrow @nogc
+private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @safe pure nothrow @nogc
 {
     val = XXH64_round(0, val);
     acc ^= val;
@@ -741,7 +743,7 @@ private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @trusted pure nothrow
     return acc;
 }
 
-private xxh_u64 XXH64_avalanche(xxh_u64 hash) @trusted pure nothrow @nogc
+private xxh_u64 XXH64_avalanche(xxh_u64 hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 33;
     hash *= XXH_PRIME64_2;
@@ -751,7 +753,7 @@ private xxh_u64 XXH64_avalanche(xxh_u64 hash) @trusted pure nothrow @nogc
     return hash;
 }
 
-xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @trusted pure nothrow @nogc
+xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
     return XXH_readLE64_align(p, align_);
 }
@@ -856,7 +858,7 @@ private xxh_u64 XXH64_endian_align(const(xxh_u8)* input, size_t len,
     return XXH64_finalize(h64, input, len, align_);
 }
 
-XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
     {
@@ -1017,7 +1019,7 @@ void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted
 }
 
 /*! @ingroup XXH64_family */
-XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @trusted pure nothrow @nogc
+XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @safe pure nothrow @nogc
 {
     return XXH_readBE64(src);
 }
@@ -1061,7 +1063,7 @@ align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
  * The other method, (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF), will AND both operands
  * and perform a full 64x64 multiply -- entirely redundant on 32-bit.
  */
-private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @trusted pure nothrow @nogc
+private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @safe pure nothrow @nogc
 {
     return (cast(xxh_u64)(x) * cast(xxh_u64)(y));
 }
@@ -1075,7 +1077,7 @@ private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @trusted pure nothrow @nogc
  * @param lhs , rhs The 64-bit integers to be multiplied
  * @return The 128-bit result represented in an @ref XXH128_hash_t.
  */
-private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothrow @nogc
 {
     static if (is(ucent))
     {
@@ -1120,14 +1122,14 @@ private XXH128_hash_t XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure no
  * @return The low 64 bits of the product XOR'd by the high 64 bits.
  * @see XXH_mult64to128()
  */
-private xxh_u64 XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+private xxh_u64 XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @safe pure nothrow @nogc
 {
     XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
     return product.low64 ^ product.high64;
 }
 
 /*! Seems to produce slightly better code on GCC for some reason. */
-private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @trusted pure nothrow @nogc
+private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @safe pure nothrow @nogc
 {
     assert(0 <= shift && shift < 64, "shift out of range");
     return v64 ^ (v64 >> shift);
@@ -1137,7 +1139,7 @@ private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @trusted pure nothrow @no
  * This is a fast avalanche stage,
  * suitable when input bits are already partially mixed
  */
-private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @trusted pure nothrow @nogc
+private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @safe pure nothrow @nogc
 {
     h64 = XXH_xorshift64(h64, 37);
     h64 *= 0x165667919E3779F9;
@@ -1150,7 +1152,7 @@ private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @trusted pure nothrow @nogc
  * inspired by Pelle Evensen's rrmxmx
  * preferable when input has not been previously mixed
  */
-static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @trusted pure nothrow @nogc
+static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @safe pure nothrow @nogc
 {
     /* this mix is inspired by Pelle Evensen's rrmxmx */
     h64 ^= XXH_rotl64(h64, 49) ^ XXH_rotl64(h64, 24);
@@ -1250,12 +1252,12 @@ private XXH64_hash_t XXH3_len_9to16_64b(const xxh_u8* input, size_t len,
     }
 }
 
-private bool XXH_likely(bool exp) @trusted pure nothrow @nogc
+private bool XXH_likely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
-private bool XXH_unlikely(bool exp) @trusted pure nothrow @nogc
+private bool XXH_unlikely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
@@ -1424,7 +1426,7 @@ private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret
  * @internal
  * @brief Processes a 64 byte block of data using the scalar path.
  */
-private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @trusted pure nothrow @nogc
+private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
     for (i = 0; i < XXH_ACC_NB; i++)
@@ -1460,7 +1462,7 @@ private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lan
  * @internal
  * @brief Scrambles the accumulators after a large chunk has been read
  */
-private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @trusted pure nothrow @nogc
+private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
     for (i = 0; i < XXH_ACC_NB; i++)
@@ -1504,16 +1506,16 @@ private void XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64) @t
     }
 }
 
-alias XXH3_f_accumulate_512 = void function(void*, const(void)*, const(void)*) @trusted pure nothrow @nogc;
-alias XXH3_f_scrambleAcc = void function(void*, const void*) @trusted pure nothrow @nogc;
-alias XXH3_f_initCustomSecret = void function(void*, xxh_u64) @trusted pure nothrow @nogc;
+alias XXH3_f_accumulate_512 = void function(void*, const(void)*, const(void)*) @safe pure nothrow @nogc;
+alias XXH3_f_scrambleAcc = void function(void*, const void*) @safe pure nothrow @nogc;
+alias XXH3_f_initCustomSecret = void function(void*, xxh_u64) @safe pure nothrow @nogc;
 
 immutable XXH3_f_accumulate_512 XXH3_accumulate_512 = &XXH3_accumulate_512_scalar;
 immutable XXH3_f_scrambleAcc XXH3_scrambleAcc = &XXH3_scrambleAcc_scalar;
 immutable XXH3_f_initCustomSecret XXH3_initCustomSecret = &XXH3_initCustomSecret_scalar;
 
 enum XXH_PREFETCH_DIST = 384;
-private void XXH_PREFETCH(const xxh_u8* ptr) @trusted pure nothrow @nogc
+private void XXH_PREFETCH(const xxh_u8* ptr) @safe pure nothrow @nogc
 {
     cast(void)(ptr);
 }
@@ -1619,7 +1621,7 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
 private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
-        size_t len, XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
+        size_t len, XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
@@ -1633,7 +1635,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
 private XXH64_hash_t XXH3_hashLong_64b_default(const(void)* input, size_t len,
-        XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
+        XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     cast(void) secret;
@@ -1657,7 +1659,7 @@ enum XXH_SEC_ALIGN = 8;
  */
 private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
-        XXH3_f_initCustomSecret f_initSec) @trusted pure nothrow @nogc
+        XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
 {
     //#if XXH_SIZE_OPT <= 0
     if (seed == 0)
@@ -1676,7 +1678,7 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, siz
  * It's important for performance that XXH3_hashLong is not inlined.
  */
 private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
-        XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen) @trusted pure nothrow @nogc
+        XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) secret;
     cast(void) secretLen;
@@ -1685,11 +1687,11 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
 }
 
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
-        XXH64_hash_t, const(xxh_u8)*, size_t) @trusted pure nothrow @nogc;
+        XXH64_hash_t, const(xxh_u8)*, size_t) @safe pure nothrow @nogc;
 
 private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
-        @trusted pure nothrow @nogc
+        @safe pure nothrow @nogc
 {
     assert(secretLen >= XXH3_SECRET_SIZE_MIN, "secretLen < XXH3_SECRET_SIZE_MIN");
     /*
@@ -1714,7 +1716,7 @@ private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
 /* ===   Public entry point   === */
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t XXH3_64bits(const(void)* input, size_t length) @trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits(const(void)* input, size_t length) @safe pure nothrow @nogc
 {
     return XXH3_64bits_internal(input, length, 0, &XXH3_kSecret[0],
             (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_default);
@@ -1722,21 +1724,21 @@ XXH64_hash_t XXH3_64bits(const(void)* input, size_t length) @trusted pure nothro
 
 /*! @ingroup XXH3_family */
 XXH64_hash_t XXH3_64bits_withSecret(const(void)* input, size_t length,
-        const(void)* secret, size_t secretSize) @trusted pure nothrow @nogc
+        const(void)* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     return XXH3_64bits_internal(input, length, 0, secret, secretSize,
             &XXH3_hashLong_64b_withSecret);
 }
 
 /*! @ingroup XXH3_family */
-XXH64_hash_t XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH64_hash_t XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
             (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_withSeed);
 }
 
 XXH64_hash_t XXH3_64bits_withSecretandSeed(const(void)* input, size_t length,
-        const(void)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+        const(void)* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (length <= XXH3_MIDSIZE_MAX)
         return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
@@ -1818,7 +1820,7 @@ private void XXH_alignedFree(void* p) @trusted nothrow @nogc
     }
 }
 
-private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @trusted nothrow @nogc
+private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @safe nothrow @nogc
 {
     (XXH3_state_ptr).seed = 0;
 }
@@ -1834,7 +1836,7 @@ XXH3_state_t* XXH3_createState() @trusted nothrow @nogc
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr) @trusted nothrow @nogc
+XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr) @safe nothrow @nogc
 {
     XXH_alignedFree(statePtr);
     return XXH_errorcode.XXH_OK;
@@ -1875,7 +1877,7 @@ private void XXH3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,
     statePtr.nbStripesPerBlock = statePtr.secretLimit / XXH_SECRET_CONSUME_RATE;
 }
 
-XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
@@ -1884,7 +1886,7 @@ XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @n
 }
 
 XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr,
-        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
+        const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
@@ -1896,7 +1898,7 @@ XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr,
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
@@ -1909,7 +1911,7 @@ XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t se
 }
 
 XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
-        const(void)* secret, size_t secretSize, XXH64_hash_t seed64) @trusted pure nothrow @nogc
+        const(void)* secret, size_t secretSize, XXH64_hash_t seed64) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
@@ -2089,7 +2091,7 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, const(xxh_u8)* input,
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len) @safe pure nothrow @nogc
 {
     return XXH3_update(state, cast(const(xxh_u8)*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
@@ -2443,7 +2445,7 @@ private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len,
 }
 
 private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
-        XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
+        XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     cast(void) secret;
@@ -2457,7 +2459,7 @@ private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
 private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
-        size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
+        size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*) secret,
@@ -2466,7 +2468,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
 
 private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
-        XXH3_f_initCustomSecret f_initSec) @trusted pure nothrow @nogc
+        XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
 {
     if (seed64 == 0)
         return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
@@ -2482,7 +2484,7 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, si
  * It's important for performance that XXH3_hashLong is not inlined.
  */
 private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
-        XXH64_hash_t seed64, const void* secret, size_t secretLen) @trusted pure nothrow @nogc
+        XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) secret;
     cast(void) secretLen;
@@ -2491,11 +2493,11 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
 }
 
 alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
-        XXH64_hash_t, const void*, size_t) @trusted pure nothrow @nogc;
+        XXH64_hash_t, const void*, size_t) @safe pure nothrow @nogc;
 
 private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
-        @trusted pure nothrow @nogc
+        @safe pure nothrow @nogc
 {
     assert(secretLen >= XXH3_SECRET_SIZE_MIN, "Secret length is < XXH3_SECRET_SIZE_MIN");
     /*
@@ -2519,7 +2521,7 @@ private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
 /* ===   Public XXH128 API   === */
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t XXH3_128bits(const void* input, size_t len) @trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits(const void* input, size_t len) @safe pure nothrow @nogc
 {
     return XXH3_128bits_internal(input, len, 0, &XXH3_kSecret[0],
             (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_default);
@@ -2527,14 +2529,14 @@ XXH128_hash_t XXH3_128bits(const void* input, size_t len) @trusted pure nothrow 
 
 /*! @ingroup XXH3_family */
 XXH128_hash_t XXH3_128bits_withSecret(const void* input, size_t len,
-        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
+        const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     return XXH3_128bits_internal(input, len, 0, cast(const xxh_u8*) secret,
             secretSize, &XXH3_hashLong_128b_withSecret);
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH128_hash_t XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
             (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_withSeed);
@@ -2542,7 +2544,7 @@ XXH128_hash_t XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t 
 
 /*! @ingroup XXH3_family */
 XXH128_hash_t XXH3_128bits_withSecretandSeed(const void* input, size_t len,
-        const void* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+        const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (len <= XXH3_MIDSIZE_MAX)
         return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
@@ -2551,37 +2553,37 @@ XXH128_hash_t XXH3_128bits_withSecretandSeed(const void* input, size_t len,
 }
 
 /*! @ingroup XXH3_family */
-XXH128_hash_t XXH128(const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH128_hash_t XXH128(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return XXH3_128bits_withSeed(input, len, seed);
 }
 
-XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
     return XXH3_64bits_reset(statePtr);
 }
 
 /*! @ingroup XXH3_family */
 XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr,
-        const void* secret, size_t secretSize) @trusted pure nothrow @nogc
+        const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSecret(statePtr, secret, secretSize);
 }
 
 /*! @ingroup XXH3_family */
-XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSeed(statePtr, seed);
 }
 
 /*! @ingroup XXH3_family */
 XXH_errorcode XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
-        const void* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+        const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
 }
 
-XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len) @safe pure nothrow @nogc
 {
     return XXH3_update(state, cast(const xxh_u8*) input, len,
             XXH3_accumulate_512, XXH3_scrambleAcc);
@@ -2672,19 +2674,19 @@ public:
          * dig.put(buf); //buffer
          * ----
          */
-    void put(scope const(ubyte)[] data...) @trusted nothrow @nogc
+    void put(scope const(ubyte)[] data...) @safe nothrow @nogc
     {
         XXH_errorcode ec;
         if (state == null)
             this.start;
         static if (digestSize == 32)
-            ec = XXH32_update(state, data.ptr, data.length);
+            ec = XXH32_update(state, &data[0], data.length);
         else static if (digestSize == 64 && !useXXH3)
-            ec = XXH64_update(state, data.ptr, data.length);
+            ec = XXH64_update(state, &data[0], data.length);
         else static if (digestSize == 64 && useXXH3)
-            ec = XXH3_64bits_update(state, data.ptr, data.length);
+            ec = XXH3_64bits_update(state, &data[0], data.length);
         else static if (digestSize == 128)
-            ec = XXH3_128bits_update(state, data.ptr, data.length);
+            ec = XXH3_128bits_update(state, &data[0], data.length);
         else
             assert(false, "Unknown XXH bitdeep or variant");
         assert(ec == XXH_errorcode.XXH_OK, "Update failed");

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -127,14 +127,17 @@ class XXHException : Exception
 
 alias XXH32_hash_t = uint;
 alias XXH64_hash_t = ulong;
-struct XXH128_hash_t
+align(16) struct XXH128_hash_t
 {
     XXH64_hash_t low64; /** `value & 0xFFFFFFFFFFFFFFFF` */
     XXH64_hash_t high64; /** `value >> 64` */
 }
 
 alias XXH64_canonical_t = ubyte[XXH64_hash_t.sizeof];
+static assert(XXH64_hash_t.sizeof == 8, "64bit integers should be 8 bytes?");
 alias XXH128_canonical_t = ubyte[XXH128_hash_t.sizeof];
+static assert(XXH128_hash_t.sizeof == 16, "128bit integers should be 16 bytes?");
+
 
 enum XXH_VERSION_MAJOR = 0;
 enum XXH_VERSION_MINOR = 8;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -424,8 +424,9 @@ private uint xxh32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
-private uint xxh32_endian_align(const(ubyte)* input, size_t len,
-        uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
+private uint xxh32_endian_align(
+    const(ubyte)* input, size_t len, uint seed, XXH_alignment align_)
+    @trusted pure nothrow @nogc
 {
     uint h32;
 
@@ -674,7 +675,8 @@ private void xxh32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash)
 
 /* Helper functions to read 64bit data quantities from memory follow */
 
-private ulong xxh_read64(const void* ptr) @trusted pure nothrow @nogc
+private ulong xxh_read64(const void* ptr)
+    @trusted pure nothrow @nogc
 {
     ulong val;
     version (HaveUnalignedLoads)
@@ -684,7 +686,8 @@ private ulong xxh_read64(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-private ulong xxh_readLE64(const void* ptr) @safe pure nothrow @nogc
+private ulong xxh_readLE64(const void* ptr)
+    @safe pure nothrow @nogc
 {
     version (LittleEndian)
         return xxh_read64(ptr);
@@ -692,7 +695,8 @@ private ulong xxh_readLE64(const void* ptr) @safe pure nothrow @nogc
         return bswap(xxh_read64(ptr));
 }
 
-private ulong xxh_readBE64(const void* ptr) @safe pure nothrow @nogc
+private ulong xxh_readBE64(const void* ptr)
+    @safe pure nothrow @nogc
 {
     version (LittleEndian)
         return bswap(xxh_read64(ptr));
@@ -700,7 +704,8 @@ private ulong xxh_readBE64(const void* ptr) @safe pure nothrow @nogc
         return xxh_read64(ptr);
 }
 
-private ulong xxh_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+private ulong xxh_readLE64_align(const void* ptr, XXH_alignment align_)
+    @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
     {
@@ -721,7 +726,8 @@ enum XXH_PRIME64_3 = 0x165667B19E3779F9; /** 0b000101100101011001100111101100011
 enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63; /** 0b1000010111101011110010100111011111000010101100101010111001100011 */
 enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /** 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
-private ulong xxh64_round(ulong acc, ulong input) @safe pure nothrow @nogc
+private ulong xxh64_round(ulong acc, ulong input)
+    @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
     acc = rol(acc, 31);
@@ -729,7 +735,8 @@ private ulong xxh64_round(ulong acc, ulong input) @safe pure nothrow @nogc
     return acc;
 }
 
-private ulong xxh64_mergeRound(ulong acc, ulong val) @safe pure nothrow @nogc
+private ulong xxh64_mergeRound(ulong acc, ulong val)
+    @safe pure nothrow @nogc
 {
     val = xxh64_round(0, val);
     acc ^= val;
@@ -737,7 +744,8 @@ private ulong xxh64_mergeRound(ulong acc, ulong val) @safe pure nothrow @nogc
     return acc;
 }
 
-private ulong xxh64_avalanche(ulong hash) @safe pure nothrow @nogc
+private ulong xxh64_avalanche(ulong hash)
+    @safe pure nothrow @nogc
 {
     hash ^= hash >> 33;
     hash *= XXH_PRIME64_2;
@@ -747,7 +755,8 @@ private ulong xxh64_avalanche(ulong hash) @safe pure nothrow @nogc
     return hash;
 }
 
-ulong xxh_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
+ulong xxh_get64bits(const void* p, XXH_alignment align_)
+    @safe pure nothrow @nogc
 {
     return xxh_readLE64_align(p, align_);
 }
@@ -896,7 +905,7 @@ private XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed)
 
 /* XXH PUBLIC API - hidden in D module */
 private XXH_errorcode xxh64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed)
-    @trusted pure nothrow @nogc
+    @safe pure nothrow @nogc
 {
     assert(statePtr != null, "statePtr == null");
     *statePtr = XXH64_state_t.init;
@@ -909,7 +918,7 @@ private XXH_errorcode xxh64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed)
 
 /* XXH PUBLIC API - hidden in D module */
 private XXH_errorcode xxh64_update(XXH64_state_t* state, const void* input, size_t len)
-@trusted pure nothrow @nogc
+    @trusted pure nothrow @nogc
 in
 {
     if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
@@ -1220,9 +1229,9 @@ static private XXH64_hash_t xxh3_rrmxmx(ulong h64, ulong len) @safe pure nothrow
  *
  * This adds an extra layer of strength for custom secrets.
  */
-private XXH64_hash_t xxh3_len_1to3_64b(const ubyte* input, size_t len,
-        const ubyte* secret, XXH64_hash_t seed)
-        @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_1to3_64b(
+    const ubyte* input, size_t len, const ubyte* secret, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(input != null, "input == null")
 in(1 <= len && len <= 3, "len out of range")
 in(secret != null, "secret == null")
@@ -1244,8 +1253,9 @@ in(secret != null, "secret == null")
     }
 }
 
-private XXH64_hash_t xxh3_len_4to8_64b(const ubyte* input, size_t len,
-        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_4to8_64b(
+    const ubyte* input, size_t len, const ubyte* secret, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(input != null, "input == null")
 in(secret != null, "secret == null")
 in(4 <= len && len <= 8, "len out of range")
@@ -1261,8 +1271,9 @@ in(4 <= len && len <= 8, "len out of range")
     }
 }
 
-private XXH64_hash_t xxh3_len_9to16_64b(const ubyte* input, size_t len,
-        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_9to16_64b(
+    const ubyte* input, size_t len, const ubyte* secret, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(input != null, "input == null")
 in(secret != null, "secret == null")
 in(9 <= len && len <= 16, "len out of range")
@@ -1278,18 +1289,21 @@ in(9 <= len && len <= 16, "len out of range")
     }
 }
 
-private bool xxh_likely(bool exp) @safe pure nothrow @nogc
+private bool xxh_likely(bool exp)
+    @safe pure nothrow @nogc
 {
     return exp;
 }
 
-private bool xxh_unlikely(bool exp) @safe pure nothrow @nogc
+private bool xxh_unlikely(bool exp)
+    @safe pure nothrow @nogc
 {
     return exp;
 }
 
-private XXH64_hash_t xxh3_len_0to16_64b(const ubyte* input, size_t len,
-        const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_0to16_64b(
+    const ubyte* input, size_t len, const ubyte* secret, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(len <= 16, "len > 16")
 {
     {
@@ -1329,7 +1343,8 @@ in(len <= 16, "len > 16")
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
-private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
+private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64)
+    @trusted pure nothrow @nogc
 {
     {
         const ulong input_lo = xxh_readLE64(input);
@@ -1341,8 +1356,9 @@ private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed6
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
-private XXH64_hash_t xxh3_len_17to128_64b(const(ubyte)* input, size_t len,
-        const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_17to128_64b(
+    const(ubyte)* input, size_t len, const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
 in(16 < len && len <= 128, "len out of range")
 {
@@ -1372,8 +1388,9 @@ enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
-private XXH64_hash_t xxh3_len_129to240_64b(const(ubyte)* input, size_t len,
-        const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_len_129to240_64b(
+    const(ubyte)* input, size_t len, const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed)
+    @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
 in { const int nbRounds = cast(int) len / 16; assert(nbRounds >= 8, "nbRounds < 8"); }
 in(128 < len && len <= XXH3_MIDSIZE_MAX, "128 >= len || len > XXH3_MIDSIZE_MAX")
@@ -1450,7 +1467,8 @@ private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
+private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane)
+    @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 {
     version (CheckACCAlignment)
@@ -1468,7 +1486,8 @@ in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 }
 
 /* Scrambles the accumulators after a large chunk has been read */
-private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
+private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret)
+    @safe pure nothrow @nogc
 {
     size_t i;
     for (i = 0; i < XXH_ACC_NB; i++)
@@ -1477,7 +1496,8 @@ private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure 
     }
 }
 
-private void xxh3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
+private void xxh3_initCustomSecret_scalar(void* customSecret, ulong seed64)
+    @trusted pure nothrow @nogc
 {
     /*
      * We need a separate pointer for the hack below,
@@ -1619,8 +1639,10 @@ static immutable XXH3_INIT_ACC = [
         XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1
     ];
 
-private XXH64_hash_t xxh3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
-        size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
+private XXH64_hash_t xxh3_hashLong_64b_internal(
+    const(void)* input, size_t len, const(void)* secret, size_t secretSize,
+    XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble)
+    @trusted pure nothrow @nogc
 {
     align(XXH_ACC_ALIGN) ulong[XXH_ACC_NB] acc = XXH3_INIT_ACC; /* NOTE: This doesn't work in D, fails on 32bit NetBSD */
 

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -525,10 +525,8 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
 
 XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memset;
-
     assert(statePtr != null, "statePtr is null");
-    memset(statePtr, 0, (*statePtr).sizeof);
+    *statePtr = XXH32_state_t.init;
     statePtr.v[0] = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
     statePtr.v[1] = seed + XXH_PRIME32_2;
     statePtr.v[2] = seed + 0;
@@ -852,10 +850,8 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
 
 XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memset;
-
     assert(statePtr != null, "statePtr == null");
-    memset(statePtr, 0, (*statePtr).sizeof);
+    *statePtr = XXH64_state_t.init;
     statePtr.v[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
     statePtr.v[1] = seed + XXH_PRIME64_2;
     statePtr.v[2] = seed + 0;
@@ -1701,15 +1697,12 @@ private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @safe nothrow @nogc
 private void XXH3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,
         const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memset;
-
     const size_t initStart = XXH3_state_t.bufferedSize.offsetof;
-    const size_t initLength = XXH3_state_t.nbStripesPerBlock.offsetof - initStart;
     assert(XXH3_state_t.nbStripesPerBlock.offsetof > initStart,
             "(XXH3_state_t.nbStripesPerBlock.offsetof <= initStart");
     assert(statePtr != null, "statePtr == null");
     /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
-    memset(cast(char*) statePtr + initStart, 0, initLength);
+    *statePtr = XXH3_state_t.init;
     statePtr.acc[0] = XXH_PRIME32_3;
     statePtr.acc[1] = XXH_PRIME64_1;
     statePtr.acc[2] = XXH_PRIME64_2;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -253,7 +253,10 @@ private enum XXH_alignment
 private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
-    (cast(ubyte*)&val)[0 .. uint.sizeof] = (cast(ubyte*) ptr)[0 .. uint.sizeof];
+    version(HaveUnalignedLoads)
+        val = *(cast(uint*)ptr);
+    else
+        (cast(ubyte*)&val)[0 .. uint.sizeof] = (cast(ubyte*) ptr)[0 .. uint.sizeof];
     return val;
 }
 
@@ -671,7 +674,10 @@ XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure no
 private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 {
     ulong val;
-    (cast(ubyte*)&val)[0 .. ulong.sizeof] = (cast(ubyte*) ptr)[0 .. ulong.sizeof];
+    version(HaveUnalignedLoads)
+        val = *(cast(ulong*)ptr);
+    else    
+        (cast(ubyte*)&val)[0 .. ulong.sizeof] = (cast(ubyte*) ptr)[0 .. ulong.sizeof];
     return val;
 }
 

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -252,7 +252,7 @@ private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
     version (HaveUnalignedLoads)
-        val = *(cast(uint*)ptr);
+        val = *(cast(uint*) ptr);
     else
         (cast(ubyte*)&val)[0 .. uint.sizeof] = (cast(ubyte*) ptr)[0 .. uint.sizeof];
     return val;
@@ -536,7 +536,7 @@ XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted p
 
 XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     if (input == null)
     {
@@ -553,14 +553,18 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 
         if (state.memsize + len < 16)
         { /* fill in tmp buffer */
-            memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, len);
+            //OBS memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, len);
+            (cast(ubyte*) state.mem32)[state.memsize .. state.memsize + len] =
+                (cast(ubyte*) input)[0 .. len];
             state.memsize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
 
         if (state.memsize)
         { /* some data left from previous update */
-            memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, 16 - state.memsize);
+            //OBS memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, 16 - state.memsize);
+            (cast(ubyte*) state.mem32)[state.memsize .. state.memsize + (16 - state.memsize)] =
+                (cast(ubyte*) input)[0 .. (16 - state.memsize)];
             {
                 const(uint)* p32 = cast(const(uint)*)&state.mem32[0];
                 state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32));
@@ -596,7 +600,9 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 
         if (p < bEnd)
         {
-            memcpy(cast(void*)&state.mem32[0], p, cast(size_t)(bEnd - p));
+            //OBS memcpy(cast(void*)&state.mem32[0], p, cast(size_t)(bEnd - p));
+            (cast(ubyte*) state.mem32)[0 .. cast(size_t)(bEnd - p) ] =
+                (cast(ubyte*) p)[0 .. cast(size_t)(bEnd - p) ];
             state.memsize = cast(XXH32_hash_t)(bEnd - p);
         }
     }
@@ -626,13 +632,14 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 
 void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
                     "(XXH32_canonical_t).sizeof != (XXH32_hash_t).sizeof");
     version (LittleEndian)
         hash = bswap(hash);
-    memcpy(dst, &hash, (*dst).sizeof);
+    //OBS memcpy(dst, &hash, (*dst).sizeof);
+    (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
 XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure nothrow @nogc
@@ -648,7 +655,7 @@ private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 {
     ulong val;
     version (HaveUnalignedLoads)
-        val = *(cast(ulong*)ptr);
+        val = *(cast(ulong*) ptr);
     else
         (cast(ubyte*)&val)[0 .. ulong.sizeof] = (cast(ubyte*) ptr)[0 .. ulong.sizeof];
     return val;
@@ -861,7 +868,7 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
 
 XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS: import core.stdc.string : memcpy;
 
     if (input == null)
     {
@@ -877,14 +884,18 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 
         if (state.memsize + len < 32)
         { /* fill in tmp buffer */
-            memcpy((cast(ubyte*) state.mem64) + state.memsize, input, len);
+            //OBS memcpy((cast(ubyte*) state.mem64) + state.memsize, input, len);
+            (cast(ubyte*) state.mem64) [state.memsize .. state.memsize + len] =
+                 (cast(ubyte*) input) [0 .. len];
             state.memsize += cast(uint) len;
             return XXH_errorcode.XXH_OK;
         }
 
         if (state.memsize)
         { /* tmp buffer is full */
-            memcpy((cast(ubyte*) state.mem64) + state.memsize, input, 32 - state.memsize);
+            //OBS memcpy((cast(ubyte*) state.mem64) + state.memsize, input, 32 - state.memsize);
+            (cast(ubyte*) state.mem64) [state.memsize .. state.memsize + (32 - state.memsize)] =
+                 (cast(ubyte*) input) [0 .. (32 - state.memsize)];
             state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
             state.v[1] = XXH64_round(state.v[1], XXH_readLE64(&state.mem64[1]));
             state.v[2] = XXH64_round(state.v[2], XXH_readLE64(&state.mem64[2]));
@@ -914,7 +925,9 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 
         if (p < bEnd)
         {
-            memcpy(cast(void*)&state.mem64[0], p, cast(size_t)(bEnd - p));
+            //OBS memcpy(cast(void*)&state.mem64[0], p, cast(size_t)(bEnd - p));
+            (cast(void*) &state.mem64[0]) [0 .. cast(size_t) (bEnd - p)] =
+                (cast(void*) p) [0 .. cast(size_t) (bEnd - p)];
             state.memsize = cast(XXH32_hash_t)(bEnd - p);
         }
     }
@@ -948,13 +961,14 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 
 void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
                     "(XXH64_canonical_t).sizeof != (XXH64_hash_t).sizeof");
     version (LittleEndian)
         hash = bswap(hash);
-    memcpy(dst, &hash, (*dst).sizeof);
+    //OBS memcpy(dst, &hash, (*dst).sizeof);
+    (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
 /*! @ingroup XXH64_family */
@@ -1325,12 +1339,13 @@ enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
 private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     version (LittleEndian) {}
     else
         v64 = bswap(v64);
-    memcpy(dst, &v64, (v64).sizeof);
+    //OBS memcpy(dst, &v64, (v64).sizeof);
+    (cast(ubyte*) dst) [0 .. v64.sizeof] = (cast(ubyte*) &v64) [0 .. v64.sizeof];
 }
 
 alias xxh_i64 = int64_t;
@@ -1803,7 +1818,7 @@ enum XXH3_STREAM_USE_STACK = 1;
 private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     if (input == null)
     {
@@ -1822,7 +1837,8 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
             * Operating into stack space seems to enable proper optimization.
             * clang, on the other hand, doesn't seem to need this trick */
             align(XXH_ACC_ALIGN) ulong[8] acc;
-            memcpy(&acc[0], &state.acc[0], (acc).sizeof);
+            //OBS memcpy(&acc[0], &state.acc[0], (acc).sizeof);
+            (cast(ubyte*) &acc[0]) [0 .. acc.sizeof] = (cast(ubyte*) &state.acc[0]) [0 .. acc.sizeof];
         }
         else
         {
@@ -1834,7 +1850,9 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         /* small input : just fill in tmp buffer */
         if (state.bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE)
         {
-            memcpy(&state.buffer[0] + state.bufferedSize, input, len);
+            //OBS memcpy(&state.buffer[0] + state.bufferedSize, input, len);
+            (cast(ubyte*) &state.buffer[0]) [state.bufferedSize .. state.bufferedSize + len] =
+                (cast(ubyte*) input) [0 .. len];
             state.bufferedSize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
@@ -1850,7 +1868,9 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         if (state.bufferedSize)
         {
             const size_t loadSize = XXH3_INTERNALBUFFER_SIZE - state.bufferedSize;
-            memcpy(&state.buffer[0] + state.bufferedSize, input, loadSize);
+            //OBS memcpy(&state.buffer[0] + state.bufferedSize, input, loadSize);
+            (cast(ubyte*)&state.buffer[0]) [state.bufferedSize .. state.bufferedSize + loadSize] =
+                (cast(ubyte*) input) [0 .. loadSize];
             input += loadSize;
             XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock,
                     &state.buffer[0], XXH3_INTERNALBUFFER_STRIPES, secret,
@@ -1890,8 +1910,10 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
             assert(input < bEnd, "input exceeds buffer, no bytes left"); /* at least some bytes left */
             state.nbStripesSoFar = nbStripes;
             /* buffer predecessor of last partial stripe */
-            memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN,
-                    input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+            //OBS memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+            (cast(ubyte*) &state.buffer[0])
+                [state.buffer.sizeof - XXH_STRIPE_LEN .. state.buffer.sizeof - XXH_STRIPE_LEN + XXH_STRIPE_LEN] =
+                (cast(ubyte*) input - XXH_STRIPE_LEN) [0 .. XXH_STRIPE_LEN];
             assert(bEnd - input <= XXH_STRIPE_LEN, "input exceed strip length");
         }
         else
@@ -1910,8 +1932,10 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
                 }
                 while (input < limit);
                 /* buffer predecessor of last partial stripe */
-                memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN,
-                        input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+                //OBS memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+                (cast(ubyte*) &state.buffer[0])
+                    [state.buffer.sizeof - XXH_STRIPE_LEN .. state.buffer.sizeof - XXH_STRIPE_LEN + XXH_STRIPE_LEN] =
+                    (cast(ubyte*) input - XXH_STRIPE_LEN) [0 .. XXH_STRIPE_LEN];
             }
         }
 
@@ -1919,12 +1943,15 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         assert(input < bEnd, "input exceeds buffer");
         assert(bEnd - input <= XXH3_INTERNALBUFFER_SIZE, "input outside buffer");
         assert(state.bufferedSize == 0, "bufferedSize != 0");
-        memcpy(&state.buffer[0], input, cast(size_t)(bEnd - input));
+        //OBS memcpy(&state.buffer[0], input, cast(size_t)(bEnd - input));
+        (cast(ubyte*) &state.buffer[0]) [0 .. cast(size_t)(bEnd - input)] =
+            (cast(ubyte*) input) [0 .. cast(size_t)(bEnd - input)];
         state.bufferedSize = cast(XXH32_hash_t)(bEnd - input);
         static if (XXH3_STREAM_USE_STACK >= 1)
         {
             /* save stack accumulators into state */
-            memcpy(&state.acc[0], &acc[0], (acc).sizeof);
+            //OBS memcpy(&state.acc[0], &acc[0], (acc).sizeof);
+            (cast(ubyte*) &state.acc[0]) [0 .. acc.sizeof] = (cast(ubyte*) &acc[0]) [0 .. acc.sizeof];
         }
     }
 
@@ -1940,13 +1967,14 @@ XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, 
 
 void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret) @trusted pure nothrow @nogc
 {
-    import core.stdc.string : memcpy;
+    //OBS import core.stdc.string : memcpy;
 
     /*
      * Digest on a local copy. This way, the state remains unaltered, and it can
      * continue ingesting more input afterwards.
      */
-    memcpy(&acc[0], &state.acc[0], (state.acc).sizeof);
+    //OBS memcpy(&acc[0], &state.acc[0], (state.acc).sizeof);
+    (cast(ubyte*) &acc[0]) [0 .. state.acc.sizeof] = (cast(ubyte*) &state.acc[0]) [0 .. state.acc.sizeof];
     if (state.bufferedSize >= XXH_STRIPE_LEN)
     {
         const size_t nbStripes = (state.bufferedSize - 1) / XXH_STRIPE_LEN;
@@ -1962,10 +1990,13 @@ void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte*
         ubyte[XXH_STRIPE_LEN] lastStripe;
         const size_t catchupSize = XXH_STRIPE_LEN - state.bufferedSize;
         assert(state.bufferedSize > 0, "bufferedSize <= 0"); /* there is always some input buffered */
-        memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
-        memcpy(&lastStripe[0] + catchupSize, &state.buffer[0], state.bufferedSize);
-        XXH3_accumulate_512(&acc[0], &lastStripe[0],
-                &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
+        //OBS memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
+        (cast(ubyte*) &lastStripe[0]) [0 .. catchupSize] =
+            (cast(ubyte*) &state.buffer[0]) [state.buffer.sizeof - catchupSize .. state.buffer.sizeof];
+        //OBS memcpy(&lastStripe[0] + catchupSize, &state.buffer[0], state.bufferedSize);
+        (cast(ubyte*) &lastStripe[0]) [catchupSize .. catchupSize + state.bufferedSize] =
+            (cast(ubyte*) &state.buffer[0]) [0 .. state.buffer.sizeof];
+        XXH3_accumulate_512(&acc[0], &lastStripe[0], &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
     }
 }
 

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -251,7 +251,7 @@ private enum XXH_alignment
 private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
-    version(HaveUnalignedLoads)
+    version (HaveUnalignedLoads)
         val = *(cast(uint*)ptr);
     else
         (cast(ubyte*)&val)[0 .. uint.sizeof] = (cast(ubyte*) ptr)[0 .. uint.sizeof];
@@ -647,7 +647,7 @@ XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure no
 private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 {
     ulong val;
-    version(HaveUnalignedLoads)
+    version (HaveUnalignedLoads)
         val = *(cast(ulong*)ptr);
     else
         (cast(ubyte*)&val)[0 .. ulong.sizeof] = (cast(ubyte*) ptr)[0 .. ulong.sizeof];

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -92,11 +92,6 @@ enum XXH_SIZE_OPT = 0;
 enum XXH_FORCE_ALIGN_CHECK = true;
 enum XXH32_ENDJMP = false;
 
-version (LittleEndian)
-    private immutable bool XXH_CPU_LITTLE_ENDIAN = true;
-else
-    private immutable bool XXH_CPU_LITTLE_ENDIAN = false;
-
 private import core.bitop : rol;
 
 /* *************************************
@@ -274,12 +269,18 @@ private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 
 private uint XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
-    return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+    version (LittleEndian)
+        return XXH_read32(ptr);
+    else
+        return XXH_swap32(XXH_read32(ptr));
 }
 
 private uint XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
 {
-    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+    version (LittleEndian)
+        return XXH_swap32(XXH_read32(ptr));
+    else
+        return XXH_read32(ptr);
 }
 
 private uint XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
@@ -290,8 +291,10 @@ private uint XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted 
     }
     else
     {
-        return XXH_CPU_LITTLE_ENDIAN ? *cast(const uint*) ptr : XXH_swap32(
-                *cast(const uint*) ptr);
+        version (LittleEndian)
+            return *cast(const uint*) ptr;
+        else
+            return XXH_swap32(*cast(const uint*) ptr);
     }
 }
 
@@ -661,7 +664,7 @@ void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted
 
     static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
                     "(XXH32_canonical_t).sizeof != (XXH32_hash_t).sizeof");
-    static if (XXH_CPU_LITTLE_ENDIAN)
+    version (LittleEndian)
         hash = XXH_swap32(hash);
     memcpy(dst, &hash, (*dst).sizeof);
 }
@@ -692,12 +695,18 @@ private ulong XXH_swap64(ulong x) @safe pure nothrow @nogc
 
 private ulong XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
-    return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+    version (LittleEndian)
+        return XXH_read64(ptr);
+    else
+        return XXH_swap64(XXH_read64(ptr));
 }
 
 private ulong XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
 {
-    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+    version (LittleEndian)
+        return XXH_swap64(XXH_read64(ptr));
+    else
+        return XXH_read64(ptr);
 }
 
 private ulong XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
@@ -708,8 +717,10 @@ private ulong XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted
     }
     else
     {
-        return XXH_CPU_LITTLE_ENDIAN ? *cast(const ulong*) ptr : XXH_swap64(
-                *cast(const ulong*) ptr);
+        version (LittleEndian)
+            return *cast(const ulong*) ptr;
+        else
+            return XXH_swap64(*cast(const ulong*) ptr);
     }
 }
 
@@ -1005,7 +1016,7 @@ void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted
 
     static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
                     "(XXH64_canonical_t).sizeof != (XXH64_hash_t).sizeof");
-    if (XXH_CPU_LITTLE_ENDIAN)
+    version (LittleEndian)
         hash = XXH_swap64(hash);
     memcpy(dst, &hash, (*dst).sizeof);
 }
@@ -1380,7 +1391,8 @@ private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     import core.stdc.string : memcpy;
 
-    if (!XXH_CPU_LITTLE_ENDIAN)
+    version (LittleEndian) {}
+    else
         v64 = XXH_swap64(v64);
     memcpy(dst, &v64, (v64).sizeof);
 }

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -138,7 +138,7 @@ enum XXH_VERSION_NUMBER =
      XXH_VERSION_RELEASE);
 
 /** Get version number */
-uint XXH_versionNumber() @safe pure nothrow @nogc
+uint xxh_versionNumber() @safe pure nothrow @nogc
 {
     return XXH_VERSION_NUMBER;
 }
@@ -146,7 +146,7 @@ uint XXH_versionNumber() @safe pure nothrow @nogc
 @safe unittest
 {
     import std.stdio : writeln;
-    writeln("Ported XXH version is ", XXH_versionNumber());
+    writeln("Ported XXH version is ", xxh_versionNumber());
 }
 
 enum XXH_errorcode
@@ -203,7 +203,7 @@ private enum XXH_alignment
 }
 
 pragma(inline, true)
-private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
+private uint xxh_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
     version (HaveUnalignedLoads)
@@ -214,28 +214,28 @@ private uint XXH_read32(const void* ptr) @trusted pure nothrow @nogc
 }
 
 pragma(inline, true)
-private uint XXH_readLE32(const void* ptr) @safe pure nothrow @nogc
+private uint xxh_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
-        return XXH_read32(ptr);
+        return xxh_read32(ptr);
     else
-        return bswap(XXH_read32(ptr));
+        return bswap(xxh_read32(ptr));
 }
 
-private uint XXH_readBE32(const void* ptr) @safe pure nothrow @nogc
+private uint xxh_readBE32(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
-        return bswap(XXH_read32(ptr));
+        return bswap(xxh_read32(ptr));
     else
-        return XXH_read32(ptr);
+        return xxh_read32(ptr);
 }
 
 pragma(inline, true)
-private uint XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+private uint xxh_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
     {
-        return XXH_readLE32(ptr);
+        return xxh_readLE32(ptr);
     }
     else
     {
@@ -264,7 +264,7 @@ enum XXH_PRIME32_5 = 0x165667B1U; /** 0b00010110010101100110011110110001 */
  * Param: input = The stripe of input to mix.
  * Return: The mixed accumulator lane.
  */
-private uint XXH32_round(uint acc, uint input) @safe pure nothrow @nogc
+private uint xxh32_round(uint acc, uint input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME32_2;
     acc = rol(acc, 13);
@@ -280,7 +280,7 @@ private uint XXH32_round(uint acc, uint input) @safe pure nothrow @nogc
  * Param: hash = The hash to avalanche.
  * Return The avalanched hash.
  */
-private uint XXH32_avalanche(uint hash) @safe pure nothrow @nogc
+private uint xxh32_avalanche(uint hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 15;
     hash *= XXH_PRIME32_2;
@@ -290,9 +290,9 @@ private uint XXH32_avalanche(uint hash) @safe pure nothrow @nogc
     return hash;
 }
 
-private uint XXH_get32bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
+private uint xxh_get32bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
-    return XXH_readLE32_align(p, align_);
+    return xxh_readLE32_align(p, align_);
 }
 
 /** Processes the last 0-15 bytes of @p ptr.
@@ -306,9 +306,9 @@ private uint XXH_get32bits(const void* p, XXH_alignment align_) @safe pure nothr
  * Param: len = The remaining length, modulo 16.
  * Param: align = Whether @p ptr is aligned.
  * Return: The finalized hash.
- * See: XXH64_finalize().
+ * See: xxh64_finalize().
  */
-private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
+private uint xxh32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
 {
     void XXH_PROCESS1(ref uint hash, ref const(ubyte)* ptr)
@@ -319,7 +319,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
 
     void XXH_PROCESS4(ref uint hash, ref const(ubyte)* ptr)
     {
-        hash += XXH_get32bits(ptr, align_) * XXH_PRIME32_3;
+        hash += xxh_get32bits(ptr, align_) * XXH_PRIME32_3;
         ptr += 4;
         hash = rol(hash, 17) * XXH_PRIME32_4;
     }
@@ -338,7 +338,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
             XXH_PROCESS1(hash, ptr);
             --len;
         }
-        return XXH32_avalanche(hash);
+        return xxh32_avalanche(hash);
     }
     else
     {
@@ -352,7 +352,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
             goto case;
         case 4:
             XXH_PROCESS4(hash, ptr);
-            return XXH32_avalanche(hash);
+            return xxh32_avalanche(hash);
 
         case 13:
             XXH_PROCESS4(hash, ptr);
@@ -363,7 +363,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
         case 5:
             XXH_PROCESS4(hash, ptr);
             XXH_PROCESS1(hash, ptr);
-            return XXH32_avalanche(hash);
+            return xxh32_avalanche(hash);
 
         case 14:
             XXH_PROCESS4(hash, ptr);
@@ -375,7 +375,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
             XXH_PROCESS4(hash, ptr);
             XXH_PROCESS1(hash, ptr);
             XXH_PROCESS1(hash, ptr);
-            return XXH32_avalanche(hash);
+            return xxh32_avalanche(hash);
 
         case 15:
             XXH_PROCESS4(hash, ptr);
@@ -396,7 +396,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
             XXH_PROCESS1(hash, ptr);
             goto case;
         case 0:
-            return XXH32_avalanche(hash);
+            return xxh32_avalanche(hash);
         default:
             assert(0, "Internal error");
         }
@@ -414,7 +414,7 @@ private uint XXH32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
  * Return: The calculated hash.
  */
 pragma(inline, true)
-private uint XXH32_endian_align(const(ubyte)* input, size_t len,
+private uint xxh32_endian_align(const(ubyte)* input, size_t len,
         uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     uint h32;
@@ -430,13 +430,13 @@ private uint XXH32_endian_align(const(ubyte)* input, size_t len,
 
         do
         {
-            v1 = XXH32_round(v1, XXH_get32bits(input, align_));
+            v1 = xxh32_round(v1, xxh_get32bits(input, align_));
             input += 4;
-            v2 = XXH32_round(v2, XXH_get32bits(input, align_));
+            v2 = xxh32_round(v2, xxh_get32bits(input, align_));
             input += 4;
-            v3 = XXH32_round(v3, XXH_get32bits(input, align_));
+            v3 = xxh32_round(v3, xxh_get32bits(input, align_));
             input += 4;
-            v4 = XXH32_round(v4, XXH_get32bits(input, align_));
+            v4 = xxh32_round(v4, xxh_get32bits(input, align_));
             input += 4;
         }
         while (input < limit);
@@ -450,7 +450,7 @@ private uint XXH32_endian_align(const(ubyte)* input, size_t len,
 
     h32 += cast(uint) len;
 
-    return XXH32_finalize(h32, input, len & 15, align_);
+    return xxh32_finalize(h32, input, len & 15, align_);
 }
 
 XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure nothrow @nogc
@@ -459,9 +459,9 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
     {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH32_state_t state;
-        XXH32_reset(&state, seed);
-        XXH32_update(&state, cast(const(ubyte)*) input, len);
-        return XXH32_digest(&state);
+        xxh32_reset(&state, seed);
+        xxh32_update(&state, cast(const(ubyte)*) input, len);
+        return xxh32_digest(&state);
     }
     else
     {
@@ -469,17 +469,17 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
         {
             if (((cast(size_t) input) & 3) == 0)
             { /* Input is 4-bytes aligned, leverage the speed benefit */
-                return XXH32_endian_align(cast(const(ubyte)*) input, len,
+                return xxh32_endian_align(cast(const(ubyte)*) input, len,
                         seed, XXH_alignment.XXH_aligned);
             }
         }
 
-        return XXH32_endian_align(cast(const(ubyte)*) input, len, seed,
+        return xxh32_endian_align(cast(const(ubyte)*) input, len, seed,
                 XXH_alignment.XXH_unaligned);
     }
 }
 
-XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
+XXH_errorcode xxh32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
 in (statePtr != null, "statePtr is null")
 {
     *statePtr = XXH32_state_t.init;
@@ -490,7 +490,7 @@ in (statePtr != null, "statePtr is null")
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+XXH_errorcode xxh32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 in
 {
     if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
@@ -524,13 +524,13 @@ do
                 (cast(ubyte*) input)[0 .. (16 - state.memsize)];
             {
                 const(uint)* p32 = cast(const(uint)*)&state.mem32[0];
-                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32));
+                state.v[0] = xxh32_round(state.v[0], xxh_readLE32(p32));
                 p32++;
-                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p32));
+                state.v[1] = xxh32_round(state.v[1], xxh_readLE32(p32));
                 p32++;
-                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p32));
+                state.v[2] = xxh32_round(state.v[2], xxh_readLE32(p32));
                 p32++;
-                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p32));
+                state.v[3] = xxh32_round(state.v[3], xxh_readLE32(p32));
             }
             p += 16 - state.memsize;
             state.memsize = 0;
@@ -542,13 +542,13 @@ do
 
             do
             {
-                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p));
+                state.v[0] = xxh32_round(state.v[0], xxh_readLE32(p));
                 p += 4;
-                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p));
+                state.v[1] = xxh32_round(state.v[1], xxh_readLE32(p));
                 p += 4;
-                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p));
+                state.v[2] = xxh32_round(state.v[2], xxh_readLE32(p));
                 p += 4;
-                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p));
+                state.v[3] = xxh32_round(state.v[3], xxh_readLE32(p));
                 p += 4;
             }
             while (p <= limit);
@@ -566,7 +566,7 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
-XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nogc
+XXH32_hash_t xxh32_digest(const XXH32_state_t* state) @trusted pure nothrow @nogc
 {
     uint h32;
 
@@ -582,11 +582,11 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 
     h32 += state.total_len_32;
 
-    return XXH32_finalize(h32, cast(const ubyte*) state.mem32, state.memsize,
+    return xxh32_finalize(h32, cast(const ubyte*) state.mem32, state.memsize,
             XXH_alignment.XXH_aligned);
 }
 
-void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
+void xxh32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
 {
     static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
                     "(XXH32_canonical_t).sizeof != (XXH32_hash_t).sizeof");
@@ -595,16 +595,16 @@ void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
-XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure nothrow @nogc
+XXH32_hash_t xxh32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure nothrow @nogc
 {
-    return XXH_readBE32(src);
+    return xxh_readBE32(src);
 }
 
 /* ----------------------------------------------------------------------------------------*/
 /* ----------------------------------------------------------------------------------------*/
 /* ----------------------------------------------------------------------------------------*/
 
-private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
+private ulong xxh_read64(const void* ptr) @trusted pure nothrow @nogc
 {
     ulong val;
     version (HaveUnalignedLoads)
@@ -615,28 +615,28 @@ private ulong XXH_read64(const void* ptr) @trusted pure nothrow @nogc
 }
 
 pragma(inline, true)
-private ulong XXH_readLE64(const void* ptr) @safe pure nothrow @nogc
+private ulong xxh_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
-        return XXH_read64(ptr);
+        return xxh_read64(ptr);
     else
-        return bswap(XXH_read64(ptr));
+        return bswap(xxh_read64(ptr));
 }
 
-private ulong XXH_readBE64(const void* ptr) @safe pure nothrow @nogc
+private ulong xxh_readBE64(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
-        return bswap(XXH_read64(ptr));
+        return bswap(xxh_read64(ptr));
     else
-        return XXH_read64(ptr);
+        return xxh_read64(ptr);
 }
 
 pragma(inline, true)
-private ulong XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+private ulong xxh_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
     {
-        return XXH_readLE64(ptr);
+        return xxh_readLE64(ptr);
     }
     else
     {
@@ -653,7 +653,7 @@ enum XXH_PRIME64_3 = 0x165667B19E3779F9; /** 0b000101100101011001100111101100011
 enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63; /** 0b1000010111101011110010100111011111000010101100101010111001100011 */
 enum XXH_PRIME64_5 = 0x27D4EB2F165667C5; /** 0b0010011111010100111010110010111100010110010101100110011111000101 */
 
-private ulong XXH64_round(ulong acc, ulong input) @safe pure nothrow @nogc
+private ulong xxh64_round(ulong acc, ulong input) @safe pure nothrow @nogc
 {
     acc += input * XXH_PRIME64_2;
     acc = rol(acc, 31);
@@ -661,15 +661,15 @@ private ulong XXH64_round(ulong acc, ulong input) @safe pure nothrow @nogc
     return acc;
 }
 
-private ulong XXH64_mergeRound(ulong acc, ulong val) @safe pure nothrow @nogc
+private ulong xxh64_mergeRound(ulong acc, ulong val) @safe pure nothrow @nogc
 {
-    val = XXH64_round(0, val);
+    val = xxh64_round(0, val);
     acc ^= val;
     acc = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
     return acc;
 }
 
-private ulong XXH64_avalanche(ulong hash) @safe pure nothrow @nogc
+private ulong xxh64_avalanche(ulong hash) @safe pure nothrow @nogc
 {
     hash ^= hash >> 33;
     hash *= XXH_PRIME64_2;
@@ -679,9 +679,9 @@ private ulong XXH64_avalanche(ulong hash) @safe pure nothrow @nogc
     return hash;
 }
 
-ulong XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
+ulong xxh_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nogc
 {
-    return XXH_readLE64_align(p, align_);
+    return xxh_readLE64_align(p, align_);
 }
 
 /** Processes the last 0-31 bytes of @p ptr.
@@ -695,9 +695,9 @@ ulong XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nog
  * Param: len The remaining length, modulo 32.
  * Param: align Whether @p ptr is aligned.
  * Return: The finalized hash
- * See: XXH32_finalize().
+ * See: xxh32_finalize().
  */
-private ulong XXH64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
+private ulong xxh64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
 in
 {
@@ -708,7 +708,7 @@ do
     len &= 31;
     while (len >= 8)
     {
-        ulong k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
+        ulong k1 = xxh64_round(0, xxh_get64bits(ptr, align_));
         ptr += 8;
         hash ^= k1;
         hash = rol(hash, 27) * XXH_PRIME64_1 + XXH_PRIME64_4;
@@ -716,7 +716,7 @@ do
     }
     if (len >= 4)
     {
-        hash ^= cast(ulong)(XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
+        hash ^= cast(ulong)(xxh_get32bits(ptr, align_)) * XXH_PRIME64_1;
         ptr += 4;
         hash = rol(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
         len -= 4;
@@ -727,7 +727,7 @@ do
         hash = rol(hash, 11) * XXH_PRIME64_1;
         --len;
     }
-    return XXH64_avalanche(hash);
+    return xxh64_avalanche(hash);
 }
 
 /** The implementation for XXH64().
@@ -737,7 +737,7 @@ do
  * Return: The calculated hash.
  */
 pragma(inline, true)
-private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
+private ulong xxh64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 in
 {
@@ -758,22 +758,22 @@ do
 
         do
         {
-            v1 = XXH64_round(v1, XXH_get64bits(input, align_));
+            v1 = xxh64_round(v1, xxh_get64bits(input, align_));
             input += 8;
-            v2 = XXH64_round(v2, XXH_get64bits(input, align_));
+            v2 = xxh64_round(v2, xxh_get64bits(input, align_));
             input += 8;
-            v3 = XXH64_round(v3, XXH_get64bits(input, align_));
+            v3 = xxh64_round(v3, xxh_get64bits(input, align_));
             input += 8;
-            v4 = XXH64_round(v4, XXH_get64bits(input, align_));
+            v4 = xxh64_round(v4, xxh_get64bits(input, align_));
             input += 8;
         }
         while (input < limit);
 
         h64 = rol(v1, 1) + rol(v2, 7) + rol(v3, 12) + rol(v4, 18);
-        h64 = XXH64_mergeRound(h64, v1);
-        h64 = XXH64_mergeRound(h64, v2);
-        h64 = XXH64_mergeRound(h64, v3);
-        h64 = XXH64_mergeRound(h64, v4);
+        h64 = xxh64_mergeRound(h64, v1);
+        h64 = xxh64_mergeRound(h64, v2);
+        h64 = xxh64_mergeRound(h64, v3);
+        h64 = xxh64_mergeRound(h64, v4);
 
     }
     else
@@ -783,7 +783,7 @@ do
 
     h64 += cast(ulong) len;
 
-    return XXH64_finalize(h64, input, len, align_);
+    return xxh64_finalize(h64, input, len, align_);
 }
 
 XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
@@ -792,9 +792,9 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
     {
         /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
         XXH64_state_t state;
-        XXH64_reset(&state, seed);
-        XXH64_update(&state, cast(const(ubyte)*) input, len);
-        return XXH64_digest(&state);
+        xxh64_reset(&state, seed);
+        xxh64_update(&state, cast(const(ubyte)*) input, len);
+        return xxh64_digest(&state);
     }
     else
     {
@@ -802,17 +802,17 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
         {
             if (((cast(size_t) input) & 7) == 0)
             { /* Input is aligned, let's leverage the speed advantage */
-                return XXH64_endian_align(cast(const(ubyte)*) input, len,
+                return xxh64_endian_align(cast(const(ubyte)*) input, len,
                         seed, XXH_alignment.XXH_aligned);
             }
         }
 
-        return XXH64_endian_align(cast(const(ubyte)*) input, len, seed,
+        return xxh64_endian_align(cast(const(ubyte)*) input, len, seed,
                 XXH_alignment.XXH_unaligned);
     }
 }
 
-XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
+XXH_errorcode xxh64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(statePtr != null, "statePtr == null");
     *statePtr = XXH64_state_t.init;
@@ -823,7 +823,7 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+XXH_errorcode xxh64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 in
 {
     if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
@@ -855,10 +855,10 @@ do
             /* tmp buffer is full */
             (cast(ubyte*) state.mem64) [state.memsize .. state.memsize + (32 - state.memsize)] =
                  (cast(ubyte*) input) [0 .. (32 - state.memsize)];
-            state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
-            state.v[1] = XXH64_round(state.v[1], XXH_readLE64(&state.mem64[1]));
-            state.v[2] = XXH64_round(state.v[2], XXH_readLE64(&state.mem64[2]));
-            state.v[3] = XXH64_round(state.v[3], XXH_readLE64(&state.mem64[3]));
+            state.v[0] = xxh64_round(state.v[0], xxh_readLE64(&state.mem64[0]));
+            state.v[1] = xxh64_round(state.v[1], xxh_readLE64(&state.mem64[1]));
+            state.v[2] = xxh64_round(state.v[2], xxh_readLE64(&state.mem64[2]));
+            state.v[3] = xxh64_round(state.v[3], xxh_readLE64(&state.mem64[3]));
             p += 32 - state.memsize;
             state.memsize = 0;
         }
@@ -869,13 +869,13 @@ do
 
             do
             {
-                state.v[0] = XXH64_round(state.v[0], XXH_readLE64(p));
+                state.v[0] = xxh64_round(state.v[0], xxh_readLE64(p));
                 p += 8;
-                state.v[1] = XXH64_round(state.v[1], XXH_readLE64(p));
+                state.v[1] = xxh64_round(state.v[1], xxh_readLE64(p));
                 p += 8;
-                state.v[2] = XXH64_round(state.v[2], XXH_readLE64(p));
+                state.v[2] = xxh64_round(state.v[2], xxh_readLE64(p));
                 p += 8;
-                state.v[3] = XXH64_round(state.v[3], XXH_readLE64(p));
+                state.v[3] = xxh64_round(state.v[3], xxh_readLE64(p));
                 p += 8;
             }
             while (p <= limit);
@@ -893,7 +893,7 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
-XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nogc
+XXH64_hash_t xxh64_digest(const XXH64_state_t* state) @trusted pure nothrow @nogc
 {
     ulong h64;
 
@@ -901,10 +901,10 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
     {
         h64 = rol(state.v[0], 1) + rol(state.v[1],
                 7) + rol(state.v[2], 12) + rol(state.v[3], 18);
-        h64 = XXH64_mergeRound(h64, state.v[0]);
-        h64 = XXH64_mergeRound(h64, state.v[1]);
-        h64 = XXH64_mergeRound(h64, state.v[2]);
-        h64 = XXH64_mergeRound(h64, state.v[3]);
+        h64 = xxh64_mergeRound(h64, state.v[0]);
+        h64 = xxh64_mergeRound(h64, state.v[1]);
+        h64 = xxh64_mergeRound(h64, state.v[2]);
+        h64 = xxh64_mergeRound(h64, state.v[3]);
     }
     else
     {
@@ -913,12 +913,12 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 
     h64 += cast(ulong) state.total_len;
 
-    return XXH64_finalize(h64, cast(const ubyte*) state.mem64,
+    return xxh64_finalize(h64, cast(const ubyte*) state.mem64,
             cast(size_t) state.total_len, XXH_alignment.XXH_aligned);
 }
 
 
-void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
+void xxh64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
 {
     static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
                     "(XXH64_canonical_t).sizeof != (XXH64_hash_t).sizeof");
@@ -927,9 +927,9 @@ void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
-XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @safe pure nothrow @nogc
+XXH64_hash_t xxh64_hashFromCanonical(const XXH64_canonical_t* src) @safe pure nothrow @nogc
 {
-    return XXH_readBE64(src);
+    return xxh_readBE64(src);
 }
 
 /* *********************************************************************
@@ -985,7 +985,7 @@ align(64) struct XXH3_state_t
 static assert(XXH_SECRET_DEFAULT_SIZE >= XXH3_SECRET_SIZE_MIN, "default keyset is not large enough");
 
 /** Pseudorandom secret taken directly from FARSH. */
-align(64) private immutable ubyte[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
+align(64) private immutable ubyte[XXH3_SECRET_DEFAULT_SIZE] xxh3_kSecret = [
     0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c,
     0xf7, 0x21, 0xad, 0x1c, 0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb,
     0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f, 0xcb, 0x79, 0xe6, 0x4e,
@@ -1011,7 +1011,7 @@ align(64) private immutable ubyte[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
  * The other method, (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF), will AND both operands
  * and perform a full 64x64 multiply -- entirely redundant on 32-bit.
  */
-private ulong XXH_mult32to64(uint x, uint y) @safe pure nothrow @nogc
+private ulong xxh_mult32to64(uint x, uint y) @safe pure nothrow @nogc
 {
     return (cast(ulong)(x) * cast(ulong)(y));
 }
@@ -1024,7 +1024,7 @@ private ulong XXH_mult32to64(uint x, uint y) @safe pure nothrow @nogc
  * Param: lhs , rhs The 64-bit integers to be multiplied
  * Return: The 128-bit result represented in an XXH128_hash_t.
  */
-private XXH128_hash_t XXH_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @nogc
+private XXH128_hash_t xxh_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
     static if (is(ucent))
     {
@@ -1041,10 +1041,10 @@ private XXH128_hash_t XXH_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @
     else
     {
         /* First calculate all of the cross products. */
-        const ulong lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
-        const ulong hi_lo = XXH_mult32to64(lhs >> 32, rhs & 0xFFFFFFFF);
-        const ulong lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
-        const ulong hi_hi = XXH_mult32to64(lhs >> 32, rhs >> 32);
+        const ulong lo_lo = xxh_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
+        const ulong hi_lo = xxh_mult32to64(lhs >> 32, rhs & 0xFFFFFFFF);
+        const ulong lo_hi = xxh_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
+        const ulong hi_hi = xxh_mult32to64(lhs >> 32, rhs >> 32);
 
         /* Now add the products together. These will never overflow. */
         const ulong cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
@@ -1066,17 +1066,17 @@ private XXH128_hash_t XXH_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @
  *
  * Param: lhs , rhs The 64-bit integers to multiply
  * Return: The low 64 bits of the product XOR'd by the high 64 bits.
- * See: XXH_mult64to128()
+ * See: xxh_mult64to128()
  */
-private ulong XXH3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
+private ulong xxh3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
-    XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
+    XXH128_hash_t product = xxh_mult64to128(lhs, rhs);
     return product.low64 ^ product.high64;
 }
 
 /* Seems to produce slightly better code on GCC for some reason. */
 pragma(inline, true)
-private ulong XXH_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
+private ulong xxh_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
 in(0 <= shift && shift < 64, "shift out of range")
 {
     return v64 ^ (v64 >> shift);
@@ -1086,11 +1086,11 @@ in(0 <= shift && shift < 64, "shift out of range")
  * This is a fast avalanche stage,
  * suitable when input bits are already partially mixed
  */
-private XXH64_hash_t XXH3_avalanche(ulong h64) @safe pure nothrow @nogc
+private XXH64_hash_t xxh3_avalanche(ulong h64) @safe pure nothrow @nogc
 {
-    h64 = XXH_xorshift64(h64, 37);
+    h64 = xxh_xorshift64(h64, 37);
     h64 *= 0x165667919E3779F9;
-    h64 = XXH_xorshift64(h64, 32);
+    h64 = xxh_xorshift64(h64, 32);
     return h64;
 }
 
@@ -1099,14 +1099,14 @@ private XXH64_hash_t XXH3_avalanche(ulong h64) @safe pure nothrow @nogc
  * inspired by Pelle Evensen's rrmxmx
  * preferable when input has not been previously mixed
  */
-static XXH64_hash_t XXH3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
+static XXH64_hash_t xxh3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
 {
     /* this mix is inspired by Pelle Evensen's rrmxmx */
     h64 ^= rol(h64, 49) ^ rol(h64, 24);
     h64 *= 0x9FB21C651E98DF25;
     h64 ^= (h64 >> 35) + len;
     h64 *= 0x9FB21C651E98DF25;
-    return XXH_xorshift64(h64, 28);
+    return xxh_xorshift64(h64, 28);
 }
 
 /* ==========================================
@@ -1143,7 +1143,7 @@ static XXH64_hash_t XXH3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
  * This adds an extra layer of strength for custom secrets.
  */
 pragma(inline, true)
-private XXH64_hash_t XXH3_len_1to3_64b(const ubyte* input, size_t len,
+private XXH64_hash_t xxh3_len_1to3_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed)
         @trusted pure nothrow @nogc
 in(input != null, "input == null")
@@ -1161,14 +1161,14 @@ in(secret != null, "secret == null")
         const ubyte c3 = input[len - 1];
         const uint combined = (cast(uint) c1 << 16) | (
                 cast(uint) c2 << 24) | (cast(uint) c3 << 0) | (cast(uint) len << 8);
-        const ulong bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+        const ulong bitflip = (xxh_readLE32(secret) ^ xxh_readLE32(secret + 4)) + seed;
         const ulong keyed = cast(ulong) combined ^ bitflip;
-        return XXH64_avalanche(keyed);
+        return xxh64_avalanche(keyed);
     }
 }
 
 pragma(inline, true)
-private XXH64_hash_t XXH3_len_4to8_64b(const ubyte* input, size_t len,
+private XXH64_hash_t xxh3_len_4to8_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
 in(secret != null, "secret == null")
@@ -1176,58 +1176,58 @@ in(4 <= len && len <= 8, "len out of range")
 {
     seed ^= cast(ulong) bswap(cast(uint) seed) << 32;
     {
-        const uint input1 = XXH_readLE32(input);
-        const uint input2 = XXH_readLE32(input + len - 4);
-        const ulong bitflip = (XXH_readLE64(secret + 8) ^ XXH_readLE64(secret + 16)) - seed;
+        const uint input1 = xxh_readLE32(input);
+        const uint input2 = xxh_readLE32(input + len - 4);
+        const ulong bitflip = (xxh_readLE64(secret + 8) ^ xxh_readLE64(secret + 16)) - seed;
         const ulong input64 = input2 + ((cast(ulong) input1) << 32);
         const ulong keyed = input64 ^ bitflip;
-        return XXH3_rrmxmx(keyed, len);
+        return xxh3_rrmxmx(keyed, len);
     }
 }
 
 pragma(inline, true)
-private XXH64_hash_t XXH3_len_9to16_64b(const ubyte* input, size_t len,
+private XXH64_hash_t xxh3_len_9to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
 in(secret != null, "secret == null")
 in(9 <= len && len <= 16, "len out of range")
 {
     {
-        const ulong bitflip1 = (XXH_readLE64(secret + 24) ^ XXH_readLE64(secret + 32)) + seed;
-        const ulong bitflip2 = (XXH_readLE64(secret + 40) ^ XXH_readLE64(secret + 48)) - seed;
-        const ulong input_lo = XXH_readLE64(input) ^ bitflip1;
-        const ulong input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
-        const ulong acc = len + bswap(input_lo) + input_hi + XXH3_mul128_fold64(input_lo,
+        const ulong bitflip1 = (xxh_readLE64(secret + 24) ^ xxh_readLE64(secret + 32)) + seed;
+        const ulong bitflip2 = (xxh_readLE64(secret + 40) ^ xxh_readLE64(secret + 48)) - seed;
+        const ulong input_lo = xxh_readLE64(input) ^ bitflip1;
+        const ulong input_hi = xxh_readLE64(input + len - 8) ^ bitflip2;
+        const ulong acc = len + bswap(input_lo) + input_hi + xxh3_mul128_fold64(input_lo,
                 input_hi);
-        return XXH3_avalanche(acc);
+        return xxh3_avalanche(acc);
     }
 }
 
 pragma(inline, true)
-private bool XXH_likely(bool exp) @safe pure nothrow @nogc
+private bool xxh_likely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
 pragma(inline, true)
-private bool XXH_unlikely(bool exp) @safe pure nothrow @nogc
+private bool xxh_unlikely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
 pragma(inline, true)
-private XXH64_hash_t XXH3_len_0to16_64b(const ubyte* input, size_t len,
+private XXH64_hash_t xxh3_len_0to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(len <= 16, "len > 16")
 {
     {
-        if (XXH_likely(len > 8))
-            return XXH3_len_9to16_64b(input, len, secret, seed);
-        if (XXH_likely(len >= 4))
-            return XXH3_len_4to8_64b(input, len, secret, seed);
+        if (xxh_likely(len > 8))
+            return xxh3_len_9to16_64b(input, len, secret, seed);
+        if (xxh_likely(len >= 4))
+            return xxh3_len_4to8_64b(input, len, secret, seed);
         if (len)
-            return XXH3_len_1to3_64b(input, len, secret, seed);
-        return XXH64_avalanche(seed ^ (XXH_readLE64(secret + 56) ^ XXH_readLE64(secret + 64)));
+            return xxh3_len_1to3_64b(input, len, secret, seed);
+        return xxh64_avalanche(seed ^ (xxh_readLE64(secret + 56) ^ xxh_readLE64(secret + 64)));
     }
 }
 
@@ -1237,13 +1237,13 @@ in(len <= 16, "len > 16")
  *
  * However, they are very unlikely.
  *
- * Keep this in mind when using the unseeded XXH3_64bits() variant: As with all
+ * Keep this in mind when using the unseeded xxh3_64bits() variant: As with all
  * unseeded non-cryptographic hashes, it does not attempt to defend itself
  * against specially crafted inputs, only random inputs.
  *
  * Compared to classic UMAC where a 1 in 2^31 chance of 4 consecutive bytes
  * cancelling out the secret is taken an arbitrary number of times (addressed
- * in XXH3_accumulate_512), this collision is very unlikely with random inputs
+ * in xxh3_accumulate_512), this collision is very unlikely with random inputs
  * and/or proper seeding:
  *
  * This only has a 1 in 2^63 chance of 8 consecutive bytes cancelling out, in a
@@ -1258,19 +1258,19 @@ in(len <= 16, "len > 16")
  * about strength.
  */
 pragma(inline, true)
-private ulong XXH3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
+private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
 {
     {
-        const ulong input_lo = XXH_readLE64(input);
-        const ulong input_hi = XXH_readLE64(input + 8);
-        return XXH3_mul128_fold64(input_lo ^ (XXH_readLE64(secret) + seed64),
-                input_hi ^ (XXH_readLE64(secret + 8) - seed64));
+        const ulong input_lo = xxh_readLE64(input);
+        const ulong input_hi = xxh_readLE64(input + 8);
+        return xxh3_mul128_fold64(input_lo ^ (xxh_readLE64(secret) + seed64),
+                input_hi ^ (xxh_readLE64(secret + 8) - seed64));
     }
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
 pragma(inline, true)
-private XXH64_hash_t XXH3_len_17to128_64b(const(ubyte)* input, size_t len,
+private XXH64_hash_t xxh3_len_17to128_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
 in(16 < len && len <= 128, "len out of range")
@@ -1284,19 +1284,19 @@ in(16 < len && len <= 128, "len out of range")
             {
                 if (len > 96)
                 {
-                    acc += XXH3_mix16B(input + 48, secret + 96, seed);
-                    acc += XXH3_mix16B(input + len - 64, secret + 112, seed);
+                    acc += xxh3_mix16B(input + 48, secret + 96, seed);
+                    acc += xxh3_mix16B(input + len - 64, secret + 112, seed);
                 }
-                acc += XXH3_mix16B(input + 32, secret + 64, seed);
-                acc += XXH3_mix16B(input + len - 48, secret + 80, seed);
+                acc += xxh3_mix16B(input + 32, secret + 64, seed);
+                acc += xxh3_mix16B(input + len - 48, secret + 80, seed);
             }
-            acc += XXH3_mix16B(input + 16, secret + 32, seed);
-            acc += XXH3_mix16B(input + len - 32, secret + 48, seed);
+            acc += xxh3_mix16B(input + 16, secret + 32, seed);
+            acc += xxh3_mix16B(input + len - 32, secret + 48, seed);
         }
-        acc += XXH3_mix16B(input + 0, secret + 0, seed);
-        acc += XXH3_mix16B(input + len - 16, secret + 16, seed);
+        acc += xxh3_mix16B(input + 0, secret + 0, seed);
+        acc += xxh3_mix16B(input + len - 16, secret + 16, seed);
 
-        return XXH3_avalanche(acc);
+        return xxh3_avalanche(acc);
     }
 }
 
@@ -1305,7 +1305,7 @@ enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
 pragma(inline, false)
-private XXH64_hash_t XXH3_len_129to240_64b(const(ubyte)* input, size_t len,
+private XXH64_hash_t xxh3_len_129to240_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
 in { const int nbRounds = cast(int) len / 16; assert(nbRounds >= 8, "nbRounds < 8"); }
@@ -1318,18 +1318,18 @@ in(128 < len && len <= XXH3_MIDSIZE_MAX, "128 >= len || len > XXH3_MIDSIZE_MAX")
         int i;
         for (i = 0; i < 8; i++)
         {
-            acc += XXH3_mix16B(input + (16 * i), secret + (16 * i), seed);
+            acc += xxh3_mix16B(input + (16 * i), secret + (16 * i), seed);
         }
-        acc = XXH3_avalanche(acc);
+        acc = xxh3_avalanche(acc);
         for (i = 8; i < nbRounds; i++)
         {
-            acc += XXH3_mix16B(input + (16 * i),
+            acc += xxh3_mix16B(input + (16 * i),
                     secret + (16 * (i - 8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
         }
         /* last bytes */
-        acc += XXH3_mix16B(input + len - 16,
+        acc += xxh3_mix16B(input + len - 16,
                 secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
-        return XXH3_avalanche(acc);
+        return xxh3_avalanche(acc);
     }
 }
 
@@ -1340,7 +1340,7 @@ enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumul
 enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
 pragma(inline, true)
-private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
+private void xxh_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     version (LittleEndian) {}
     else
@@ -1352,13 +1352,13 @@ private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 
 enum XXH_ACC_ALIGN = 8;
 
-/** Scalar round for XXH3_accumulate_512_scalar().
+/** Scalar round for xxh3_accumulate_512_scalar().
  *
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
 pragma(inline, true)
-private void XXH3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
+private void xxh3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 in((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_ALIGN - 1)) != 0")
@@ -1367,40 +1367,40 @@ in((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_
     ubyte* xinput = cast(ubyte*) input;
     ubyte* xsecret = cast(ubyte*) secret;
     {
-        const ulong data_val = XXH_readLE64(xinput + lane * 8);
-        const ulong data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
+        const ulong data_val = xxh_readLE64(xinput + lane * 8);
+        const ulong data_key = data_val ^ xxh_readLE64(xsecret + lane * 8);
         xacc[lane ^ 1] += data_val; /* swap adjacent lanes */
-        xacc[lane] += XXH_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
+        xacc[lane] += xxh_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
     }
 }
 
 /* Processes a 64 byte block of data using the scalar path. */
 pragma(inline, true)
-private void XXH3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
+private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
     for (i = 0; i < XXH_ACC_NB; i++)
     {
-        XXH3_scalarRound(acc, input, secret, i);
+        xxh3_scalarRound(acc, input, secret, i);
     }
 }
 
-/* Scalar scramble step for XXH3_scrambleAcc_scalar().
+/* Scalar scramble step for xxh3_scrambleAcc_scalar().
  *
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
 pragma(inline, true)
-private void XXH3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
+private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 in(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0")
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 {
     ulong* xacc = cast(ulong*) acc; /* presumed aligned */
     const ubyte* xsecret = cast(const ubyte*) secret; /* no alignment restriction */
     {
-        const ulong key64 = XXH_readLE64(xsecret + lane * 8);
+        const ulong key64 = xxh_readLE64(xsecret + lane * 8);
         ulong acc64 = xacc[lane];
-        acc64 = XXH_xorshift64(acc64, 47);
+        acc64 = xxh_xorshift64(acc64, 47);
         acc64 ^= key64;
         acc64 *= XXH_PRIME32_1;
         xacc[lane] = acc64;
@@ -1409,31 +1409,31 @@ in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 
 /* Scrambles the accumulators after a large chunk has been read */
 pragma(inline, true)
-private void XXH3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
+private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
     for (i = 0; i < XXH_ACC_NB; i++)
     {
-        XXH3_scalarScrambleRound(acc, secret, i);
+        xxh3_scalarScrambleRound(acc, secret, i);
     }
 }
 
 pragma(inline, true)
-private void XXH3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
+private void xxh3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
 {
     /*
      * We need a separate pointer for the hack below,
      * which requires a non-const pointer.
      * Any decent compiler will optimize this out otherwise.
      */
-    const ubyte* kSecretPtr = cast(ubyte*) XXH3_kSecret;
+    const ubyte* kSecretPtr = cast(ubyte*) xxh3_kSecret;
     static assert((XXH_SECRET_DEFAULT_SIZE & 15) == 0, "(XXH_SECRET_DEFAULT_SIZE & 15) != 0");
 
     /*
      * Note: in debug mode, this overrides the asm optimization
      * and Clang will emit MOVK chains again.
      */
-    //assert(kSecretPtr == XXH3_kSecret);
+    //assert(kSecretPtr == xxh3_kSecret);
 
     {
         const int nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
@@ -1446,10 +1446,10 @@ private void XXH3_initCustomSecret_scalar(void* customSecret, ulong seed64) @tru
              * loads together for free. Putting the loads together before the stores
              * properly generates LDP.
              */
-            ulong lo = XXH_readLE64(kSecretPtr + 16 * i) + seed64;
-            ulong hi = XXH_readLE64(kSecretPtr + 16 * i + 8) - seed64;
-            XXH_writeLE64(cast(ubyte*) customSecret + 16 * i, lo);
-            XXH_writeLE64(cast(ubyte*) customSecret + 16 * i + 8, hi);
+            ulong lo = xxh_readLE64(kSecretPtr + 16 * i) + seed64;
+            ulong hi = xxh_readLE64(kSecretPtr + 16 * i + 8) - seed64;
+            xxh_writeLE64(cast(ubyte*) customSecret + 16 * i, lo);
+            xxh_writeLE64(cast(ubyte*) customSecret + 16 * i + 8, hi);
         }
     }
 }
@@ -1458,9 +1458,9 @@ alias XXH3_f_accumulate_512 = void function(void*, const(void)*, const(void)*) @
 alias XXH3_f_scrambleAcc = void function(void*, const void*) @safe pure nothrow @nogc;
 alias XXH3_f_initCustomSecret = void function(void*, ulong) @safe pure nothrow @nogc;
 
-immutable XXH3_f_accumulate_512 XXH3_accumulate_512 = &XXH3_accumulate_512_scalar;
-immutable XXH3_f_scrambleAcc XXH3_scrambleAcc = &XXH3_scrambleAcc_scalar;
-immutable XXH3_f_initCustomSecret XXH3_initCustomSecret = &XXH3_initCustomSecret_scalar;
+immutable XXH3_f_accumulate_512 xxh3_accumulate_512 = &xxh3_accumulate_512_scalar;
+immutable XXH3_f_scrambleAcc xxh3_scrambleAcc = &xxh3_scrambleAcc_scalar;
+immutable XXH3_f_initCustomSecret xxh3_initCustomSecret = &xxh3_initCustomSecret_scalar;
 
 enum XXH_PREFETCH_DIST = 384;
 private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
@@ -1469,12 +1469,12 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
 }
 
 /*
- * XXH3_accumulate()
- * Loops over XXH3_accumulate_512().
+ * xxh3_accumulate()
+ * Loops over xxh3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
 pragma(inline, true)
-private void XXH3_accumulate(ulong* acc, const ubyte* input,
+private void xxh3_accumulate(ulong* acc, const ubyte* input,
         const ubyte* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
     size_t n;
@@ -1487,7 +1487,7 @@ private void XXH3_accumulate(ulong* acc, const ubyte* input,
 }
 
 pragma(inline, true)
-private void XXH3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
+private void xxh3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
 in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
@@ -1500,7 +1500,7 @@ in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
 
     for (n = 0; n < nb_blocks; n++)
     {
-        XXH3_accumulate(acc, input + n * block_len, secret, nbStripesPerBlock, f_acc512);
+        xxh3_accumulate(acc, input + n * block_len, secret, nbStripesPerBlock, f_acc512);
         f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
     }
 
@@ -1509,7 +1509,7 @@ in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
         const size_t nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
         assert(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE),
                 "nbStripes > (secretSize / XXH_SECRET_CONSUME_RATE)");
-        XXH3_accumulate(acc, input + nb_blocks * block_len, secret, nbStripes, f_acc512);
+        xxh3_accumulate(acc, input + nb_blocks * block_len, secret, nbStripes, f_acc512);
 
         /* last stripe */
         {
@@ -1522,12 +1522,12 @@ in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
 enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
 pragma(inline, true)
-private ulong XXH3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
+private ulong xxh3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
 {
-    return XXH3_mul128_fold64(acc[0] ^ XXH_readLE64(secret), acc[1] ^ XXH_readLE64(secret + 8));
+    return xxh3_mul128_fold64(acc[0] ^ xxh_readLE64(secret), acc[1] ^ xxh_readLE64(secret + 8));
 }
 
-private XXH64_hash_t XXH3_mergeAccs(const(ulong)* acc, const(ubyte)* secret, ulong start)
+private XXH64_hash_t xxh3_mergeAccs(const(ulong)* acc, const(ubyte)* secret, ulong start)
 @trusted pure nothrow @nogc
 {
     ulong result64 = start;
@@ -1535,10 +1535,10 @@ private XXH64_hash_t XXH3_mergeAccs(const(ulong)* acc, const(ubyte)* secret, ulo
 
     for (i = 0; i < 4; i++)
     {
-        result64 += XXH3_mix2Accs(acc + 2 * i, secret + 16 * i);
+        result64 += xxh3_mix2Accs(acc + 2 * i, secret + 16 * i);
     }
 
-    return XXH3_avalanche(result64);
+    return xxh3_avalanche(result64);
 }
 
 static immutable XXH3_INIT_ACC = [
@@ -1547,12 +1547,12 @@ static immutable XXH3_INIT_ACC = [
     ];
 
 pragma(inline, true)
-private XXH64_hash_t XXH3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
+private XXH64_hash_t xxh3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     align(XXH_ACC_ALIGN) ulong[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const(ubyte)*) input, len,
+    xxh3_hashLong_internal_loop(&acc[0], cast(const(ubyte)*) input, len,
             cast(const(ubyte)*) secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
@@ -1560,7 +1560,7 @@ private XXH64_hash_t XXH3_hashLong_64b_internal(const(void)* input, size_t len, 
     /* do not align on 8, so that the secret is different from the accumulator */
     assert(secretSize >= acc.sizeof + XXH_SECRET_MERGEACCS_START,
             "secretSize < acc.sizeof + XXH_SECRET_MERGEACCS_START");
-    return XXH3_mergeAccs(&acc[0], cast(const(ubyte)*) secret + XXH_SECRET_MERGEACCS_START,
+    return xxh3_mergeAccs(&acc[0], cast(const(ubyte)*) secret + XXH_SECRET_MERGEACCS_START,
             cast(ulong) len * XXH_PRIME64_1);
 }
 
@@ -1572,12 +1572,12 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
 pragma(inline, true)
-private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
+private XXH64_hash_t xxh3_hashLong_64b_withSecret(const(void)* input,
         size_t len, XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
-    return XXH3_hashLong_64b_internal(input, len, secret, secretLen,
-            XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_hashLong_64b_internal(input, len, secret, secretLen,
+            xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
 /*
@@ -1587,21 +1587,21 @@ private XXH64_hash_t XXH3_hashLong_64b_withSecret(const(void)* input,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
 pragma(inline, false)
-private XXH64_hash_t XXH3_hashLong_64b_default(const(void)* input, size_t len,
+private XXH64_hash_t xxh3_hashLong_64b_default(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     cast(void) secret;
     cast(void) secretLen;
-    return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_hashLong_64b_internal(input, len, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
 enum XXH_SEC_ALIGN = 8;
 
 /*
- * XXH3_hashLong_64b_withSeed():
- * Generate a custom key based on alteration of default XXH3_kSecret with the seed,
+ * xxh3_hashLong_64b_withSeed():
+ * Generate a custom key based on alteration of default xxh3_kSecret with the seed,
  * and then use this key for long mode hashing.
  *
  * This operation is decently fast but nonetheless costs a little bit of time.
@@ -1611,19 +1611,19 @@ enum XXH_SEC_ALIGN = 8;
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
 pragma(inline, true)
-private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
+private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
 {
     //#if XXH_SIZE_OPT <= 0
     if (seed == 0)
-        return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0],
-                (XXH3_kSecret).sizeof, f_acc512, f_scramble);
+        return xxh3_hashLong_64b_internal(input, len, &xxh3_kSecret[0],
+                (xxh3_kSecret).sizeof, f_acc512, f_scramble);
     //#endif
     {
         align(XXH_SEC_ALIGN) ubyte[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed);
-        return XXH3_hashLong_64b_internal(input, len, &secret[0], (secret)
+        return xxh3_hashLong_64b_internal(input, len, &secret[0], (secret)
                 .sizeof, f_acc512, f_scramble);
     }
 }
@@ -1632,20 +1632,20 @@ private XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const(void)* input, siz
  * It's important for performance that XXH3_hashLong is not inlined.
  */
 pragma(inline, false)
-private XXH64_hash_t XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
+private XXH64_hash_t xxh3_hashLong_64b_withSeed(const(void)* input, size_t len,
         XXH64_hash_t seed, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) secret;
     cast(void) secretLen;
-    return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
-            XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+    return xxh3_hashLong_64b_withSeed_internal(input, len, seed,
+            xxh3_accumulate_512, xxh3_scrambleAcc, xxh3_initCustomSecret);
 }
 
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
         XXH64_hash_t, const(ubyte)*, size_t) @safe pure nothrow @nogc;
 
 pragma(inline, true)
-private XXH64_hash_t XXH3_64bits_internal(const(void)* input, size_t len,
+private XXH64_hash_t xxh3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
         @safe pure nothrow @nogc
 in(secretLen >= XXH3_SECRET_SIZE_MIN, "secretLen < XXH3_SECRET_SIZE_MIN")
@@ -1658,45 +1658,45 @@ in(secretLen >= XXH3_SECRET_SIZE_MIN, "secretLen < XXH3_SECRET_SIZE_MIN")
      * Also, note that function signature doesn't offer room to return an error.
      */
     if (len <= 16)
-        return XXH3_len_0to16_64b(cast(const(ubyte)*) input, len,
+        return xxh3_len_0to16_64b(cast(const(ubyte)*) input, len,
                 cast(const(ubyte)*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_64b(cast(const(ubyte)*) input, len,
+        return xxh3_len_17to128_64b(cast(const(ubyte)*) input, len,
                 cast(const(ubyte)*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_64b(cast(const(ubyte)*) input, len,
+        return xxh3_len_129to240_64b(cast(const(ubyte)*) input, len,
                 cast(const(ubyte)*) secret, secretLen, seed64);
     return f_hashLong(input, len, seed64, cast(const(ubyte)*) secret, secretLen);
 }
 
 /* ===   Public entry point   === */
 
-XXH64_hash_t XXH3_64bits(const(void)* input, size_t length) @safe pure nothrow @nogc
+XXH64_hash_t xxh3_64bits(const(void)* input, size_t length) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, 0, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_default);
+    return xxh3_64bits_internal(input, length, 0, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, &xxh3_hashLong_64b_default);
 }
 
-XXH64_hash_t XXH3_64bits_withSecret(const(void)* input, size_t length,
+XXH64_hash_t xxh3_64bits_withSecret(const(void)* input, size_t length,
         const(void)* secret, size_t secretSize) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, 0, secret, secretSize,
-            &XXH3_hashLong_64b_withSecret);
+    return xxh3_64bits_internal(input, length, 0, secret, secretSize,
+            &xxh3_hashLong_64b_withSecret);
 }
 
-XXH64_hash_t XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @safe pure nothrow @nogc
+XXH64_hash_t xxh3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_withSeed);
+    return xxh3_64bits_internal(input, length, seed, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, &xxh3_hashLong_64b_withSeed);
 }
 
-XXH64_hash_t XXH3_64bits_withSecretandSeed(const(void)* input, size_t length,
+XXH64_hash_t xxh3_64bits_withSecretandSeed(const(void)* input, size_t length,
         const(void)* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (length <= XXH3_MIDSIZE_MAX)
-        return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0],
-                (XXH3_kSecret).sizeof, null);
-    return XXH3_hashLong_64b_withSecret(input, length, seed,
+        return xxh3_64bits_internal(input, length, seed, &xxh3_kSecret[0],
+                (xxh3_kSecret).sizeof, null);
+    return xxh3_hashLong_64b_withSecret(input, length, seed,
             cast(const(ubyte)*) secret, secretSize);
 }
 
@@ -1707,7 +1707,7 @@ private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @safe nothrow @nogc
     (XXH3_state_ptr).seed = 0;
 }
 
-private void XXH3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,
+private void xxh3_reset_internal(XXH3_state_t* statePtr, XXH64_hash_t seed,
         const void* secret, size_t secretSize) @trusted pure nothrow @nogc
 in
 {
@@ -1735,20 +1735,20 @@ in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
     statePtr.nbStripesPerBlock = statePtr.secretLimit / XXH_SECRET_CONSUME_RATE;
 }
 
-XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
+XXH_errorcode xxh3_64bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
-    XXH3_reset_internal(statePtr, 0, &XXH3_kSecret[0], XXH_SECRET_DEFAULT_SIZE);
+    xxh3_reset_internal(statePtr, 0, &xxh3_kSecret[0], XXH_SECRET_DEFAULT_SIZE);
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr,
+XXH_errorcode xxh3_64bits_reset_withSecret(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
-    XXH3_reset_internal(statePtr, 0, secret, secretSize);
+    xxh3_reset_internal(statePtr, 0, secret, secretSize);
     if (secret == null)
         return XXH_errorcode.XXH_ERROR;
     if (secretSize < XXH3_SECRET_SIZE_MIN)
@@ -1756,19 +1756,19 @@ XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr,
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
+XXH_errorcode xxh3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (statePtr == null)
         return XXH_errorcode.XXH_ERROR;
     if (seed == 0)
-        return XXH3_64bits_reset(statePtr);
+        return xxh3_64bits_reset(statePtr);
     if ((seed != statePtr.seed) || (statePtr.extSecret != null))
-        XXH3_initCustomSecret(&statePtr.customSecret[0], seed);
-    XXH3_reset_internal(statePtr, seed, null, XXH_SECRET_DEFAULT_SIZE);
+        xxh3_initCustomSecret(&statePtr.customSecret[0], seed);
+    xxh3_reset_internal(statePtr, seed, null, XXH_SECRET_DEFAULT_SIZE);
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
+XXH_errorcode xxh3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
         const(void)* secret, size_t secretSize, XXH64_hash_t seed64) @safe pure nothrow @nogc
 {
     if (statePtr == null)
@@ -1777,16 +1777,16 @@ XXH_errorcode XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
         return XXH_errorcode.XXH_ERROR;
     if (secretSize < XXH3_SECRET_SIZE_MIN)
         return XXH_errorcode.XXH_ERROR;
-    XXH3_reset_internal(statePtr, seed64, secret, secretSize);
+    xxh3_reset_internal(statePtr, seed64, secret, secretSize);
     statePtr.useSeed = 1; /* always, even if seed64 == 0 */
     return XXH_errorcode.XXH_OK;
 }
 
-/* Note : when XXH3_consumeStripes() is invoked,
+/* Note : when xxh3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
 pragma(inline, true)
-private void XXH3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
+private void xxh3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
         size_t nbStripesPerBlock, const ubyte* input, size_t nbStripes,
         const ubyte* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
         XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
@@ -1798,16 +1798,16 @@ in(*nbStripesSoFarPtr < nbStripesPerBlock, "*nbStripesSoFarPtr >= nbStripesPerBl
         /* need a scrambling operation */
         const size_t nbStripesToEndofBlock = nbStripesPerBlock - *nbStripesSoFarPtr;
         const size_t nbStripesAfterBlock = nbStripes - nbStripesToEndofBlock;
-        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE,
+        xxh3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE,
                 nbStripesToEndofBlock, f_acc512);
         f_scramble(acc, secret + secretLimit);
-        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN,
+        xxh3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN,
                 secret, nbStripesAfterBlock, f_acc512);
         *nbStripesSoFarPtr = nbStripesAfterBlock;
     }
     else
     {
-        XXH3_accumulate(acc, input,
+        xxh3_accumulate(acc, input,
                 secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, f_acc512);
         *nbStripesSoFarPtr += nbStripes;
     }
@@ -1815,10 +1815,10 @@ in(*nbStripesSoFarPtr < nbStripesPerBlock, "*nbStripesSoFarPtr >= nbStripesPerBl
 
 enum XXH3_STREAM_USE_STACK = 1;
 /*
- * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
+ * Both xxh3_64bits_update and xxh3_128bits_update use this routine.
  */
 pragma(inline, true)
-private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
+private XXH_errorcode xxh3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(state != null, "state == null")
 in
@@ -1874,7 +1874,7 @@ do
             (cast(ubyte*)&state.buffer[0]) [state.bufferedSize .. state.bufferedSize + loadSize] =
                 (cast(ubyte*) input) [0 .. loadSize];
             input += loadSize;
-            XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock,
+            xxh3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock,
                     &state.buffer[0], XXH3_INTERNALBUFFER_STRIPES, secret,
                     state.secretLimit, f_acc512, f_scramble);
             state.bufferedSize = 0;
@@ -1890,7 +1890,7 @@ do
             {
                 const size_t nbStripesToEnd = state.nbStripesPerBlock - state.nbStripesSoFar;
                 assert(nbStripesToEnd <= nbStripes, "nbStripesToEnd > nbStripes");
-                XXH3_accumulate(&acc[0], input,
+                xxh3_accumulate(&acc[0], input,
                         secret + state.nbStripesSoFar * XXH_SECRET_CONSUME_RATE,
                         nbStripesToEnd, f_acc512);
                 f_scramble(&acc[0], secret + state.secretLimit);
@@ -1901,13 +1901,13 @@ do
             /* consume per entire blocks */
             while (nbStripes >= state.nbStripesPerBlock)
             {
-                XXH3_accumulate(&acc[0], input, secret, state.nbStripesPerBlock, f_acc512);
+                xxh3_accumulate(&acc[0], input, secret, state.nbStripesPerBlock, f_acc512);
                 f_scramble(&acc[0], secret + state.secretLimit);
                 input += state.nbStripesPerBlock * XXH_STRIPE_LEN;
                 nbStripes -= state.nbStripesPerBlock;
             }
             /* consume last partial block */
-            XXH3_accumulate(&acc[0], input, secret, nbStripes, f_acc512);
+            xxh3_accumulate(&acc[0], input, secret, nbStripes, f_acc512);
             input += nbStripes * XXH_STRIPE_LEN;
             assert(input < bEnd, "input exceeds buffer, no bytes left"); /* at least some bytes left */
             state.nbStripesSoFar = nbStripes;
@@ -1926,7 +1926,7 @@ do
                 const ubyte* limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
                 do
                 {
-                    XXH3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock, input,
+                    xxh3_consumeStripes(&acc[0], &state.nbStripesSoFar, state.nbStripesPerBlock, input,
                             XXH3_INTERNALBUFFER_STRIPES, secret,
                             state.secretLimit, f_acc512, f_scramble);
                     input += XXH3_INTERNALBUFFER_SIZE;
@@ -1956,15 +1956,15 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
-XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len)
+XXH_errorcode xxh3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len)
     @safe pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const(ubyte)*) input, len,
-            XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_update(state, cast(const(ubyte)*) input, len,
+            xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
 pragma(inline, true)
-private void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
+private void xxh3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
     @trusted pure nothrow @nogc
 {
     /*
@@ -1976,10 +1976,10 @@ private void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, cons
     {
         const size_t nbStripes = (state.bufferedSize - 1) / XXH_STRIPE_LEN;
         size_t nbStripesSoFar = state.nbStripesSoFar;
-        XXH3_consumeStripes(acc, &nbStripesSoFar, state.nbStripesPerBlock, &state.buffer[0],
-                nbStripes, secret, state.secretLimit, XXH3_accumulate_512, XXH3_scrambleAcc);
+        xxh3_consumeStripes(acc, &nbStripesSoFar, state.nbStripesPerBlock, &state.buffer[0],
+                nbStripes, secret, state.secretLimit, xxh3_accumulate_512, xxh3_scrambleAcc);
         /* last stripe */
-        XXH3_accumulate_512(acc, &state.buffer[0] + state.bufferedSize - XXH_STRIPE_LEN,
+        xxh3_accumulate_512(acc, &state.buffer[0] + state.bufferedSize - XXH_STRIPE_LEN,
                 secret + state.secretLimit - XXH_SECRET_LASTACC_START);
     }
     else
@@ -1991,24 +1991,24 @@ private void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, cons
             (cast(ubyte*) &state.buffer[0]) [state.buffer.sizeof - catchupSize .. state.buffer.sizeof];
         (cast(ubyte*) &lastStripe[0]) [catchupSize .. catchupSize + state.bufferedSize] =
             (cast(ubyte*) &state.buffer[0]) [0 .. state.buffer.sizeof];
-        XXH3_accumulate_512(&acc[0], &lastStripe[0], &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
+        xxh3_accumulate_512(&acc[0], &lastStripe[0], &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
     }
 }
 
-XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
+XXH64_hash_t xxh3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
     if (state.totalLen > XXH3_MIDSIZE_MAX)
     {
         align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
-        XXH3_digest_long(&acc[0], state, secret);
-        return XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
+        xxh3_digest_long(&acc[0], state, secret);
+        return xxh3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
                 cast(ulong) state.totalLen * XXH_PRIME64_1);
     }
     /* totalLen <= XXH3_MIDSIZE_MAX: digesting a short input */
     if (state.useSeed)
-        return XXH3_64bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
-    return XXH3_64bits_withSecret(&state.buffer[0],
+        return xxh3_64bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
+    return xxh3_64bits_withSecret(&state.buffer[0],
             cast(size_t)(state.totalLen), secret, state.secretLimit + XXH_STRIPE_LEN);
 }
 
@@ -2019,7 +2019,7 @@ XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * even without counting the significantly larger output size.
  *
  * For example, extra steps are taken to avoid the seed-dependent collisions
- * in 17-240 byte inputs (See XXH3_mix16B and XXH128_mix32B).
+ * in 17-240 byte inputs (See xxh3_mix16B and xxh128_mix32B).
  *
  * This strength naturally comes at the cost of some speed, especially on short
  * lengths. Note that longer hashes are about as fast as the 64-bit version
@@ -2029,7 +2029,7 @@ XXH64_hash_t XXH3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
 pragma(inline, true)
-private XXH128_hash_t XXH3_len_1to3_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_1to3_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     /* A doubled version of 1to3_64b with different constants. */
@@ -2048,19 +2048,19 @@ private XXH128_hash_t XXH3_len_1to3_128b(const ubyte* input, size_t len,
         const uint combinedl = (cast(uint) c1 << 16) | (
                 cast(uint) c2 << 24) | (cast(uint) c3 << 0) | (cast(uint) len << 8);
         const uint combinedh = rol(bswap(combinedl), 13);
-        const ulong bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
-        const ulong bitfliph = (XXH_readLE32(secret + 8) ^ XXH_readLE32(secret + 12)) - seed;
+        const ulong bitflipl = (xxh_readLE32(secret) ^ xxh_readLE32(secret + 4)) + seed;
+        const ulong bitfliph = (xxh_readLE32(secret + 8) ^ xxh_readLE32(secret + 12)) - seed;
         const ulong keyed_lo = cast(ulong) combinedl ^ bitflipl;
         const ulong keyed_hi = cast(ulong) combinedh ^ bitfliph;
         XXH128_hash_t h128;
-        h128.low64 = XXH64_avalanche(keyed_lo);
-        h128.high64 = XXH64_avalanche(keyed_hi);
+        h128.low64 = xxh64_avalanche(keyed_lo);
+        h128.high64 = xxh64_avalanche(keyed_hi);
         return h128;
     }
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_len_4to8_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_4to8_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input is null");
@@ -2068,39 +2068,39 @@ private XXH128_hash_t XXH3_len_4to8_128b(const ubyte* input, size_t len,
     assert(4 <= len && len <= 8, "len is out of range");
     seed ^= cast(ulong) bswap(cast(uint) seed) << 32;
     {
-        const uint input_lo = XXH_readLE32(input);
-        const uint input_hi = XXH_readLE32(input + len - 4);
+        const uint input_lo = xxh_readLE32(input);
+        const uint input_hi = xxh_readLE32(input + len - 4);
         const ulong input_64 = input_lo + (cast(ulong) input_hi << 32);
-        const ulong bitflip = (XXH_readLE64(secret + 16) ^ XXH_readLE64(secret + 24)) + seed;
+        const ulong bitflip = (xxh_readLE64(secret + 16) ^ xxh_readLE64(secret + 24)) + seed;
         const ulong keyed = input_64 ^ bitflip;
 
         /* Shift len to the left to ensure it is even, this avoids even multiplies. */
-        XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
+        XXH128_hash_t m128 = xxh_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
 
         m128.high64 += (m128.low64 << 1);
         m128.low64 ^= (m128.high64 >> 3);
 
-        m128.low64 = XXH_xorshift64(m128.low64, 35);
+        m128.low64 = xxh_xorshift64(m128.low64, 35);
         m128.low64 *= 0x9FB21C651E98DF25;
-        m128.low64 = XXH_xorshift64(m128.low64, 28);
-        m128.high64 = XXH3_avalanche(m128.high64);
+        m128.low64 = xxh_xorshift64(m128.low64, 28);
+        m128.high64 = xxh3_avalanche(m128.high64);
         return m128;
     }
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_9to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(input != null, "input is null");
     assert(secret != null, "secret is null");
     assert(9 <= len && len <= 16, "len out of range");
     {
-        const ulong bitflipl = (XXH_readLE64(secret + 32) ^ XXH_readLE64(secret + 40)) - seed;
-        const ulong bitfliph = (XXH_readLE64(secret + 48) ^ XXH_readLE64(secret + 56)) + seed;
-        const ulong input_lo = XXH_readLE64(input);
-        ulong input_hi = XXH_readLE64(input + len - 8);
-        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
+        const ulong bitflipl = (xxh_readLE64(secret + 32) ^ xxh_readLE64(secret + 40)) - seed;
+        const ulong bitfliph = (xxh_readLE64(secret + 48) ^ xxh_readLE64(secret + 56)) + seed;
+        const ulong input_lo = xxh_readLE64(input);
+        ulong input_hi = xxh_readLE64(input + len - 8);
+        XXH128_hash_t m128 = xxh_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
         /*
          * Put len in the middle of m128 to ensure that the length gets mixed to
          * both the low and high bits in the 128x64 multiply below.
@@ -2122,7 +2122,7 @@ private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
              * On 32-bit, it removes an ADC and delays a dependency between the two
              * halves of m128.high64, but it generates an extra mask on 64-bit.
              */
-            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(uint) input_hi,
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + xxh_mult32to64(cast(uint) input_hi,
                     XXH_PRIME32_2);
         }
         else
@@ -2151,58 +2151,58 @@ private XXH128_hash_t XXH3_len_9to16_128b(const ubyte* input, size_t len,
              * Since input_hi.hi + input_hi.lo == input_hi, we get this:
              *    input_hi + ((ulong)input_hi.lo * (XXH_PRIME32_2 - 1))
              */
-            m128.high64 += input_hi + XXH_mult32to64(cast(uint) input_hi, XXH_PRIME32_2 - 1);
+            m128.high64 += input_hi + xxh_mult32to64(cast(uint) input_hi, XXH_PRIME32_2 - 1);
         }
         /* m128 ^= bswap(m128 >> 64); */
         m128.low64 ^= bswap(m128.high64);
 
         { /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
-            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, XXH_PRIME64_2);
+            XXH128_hash_t h128 = xxh_mult64to128(m128.low64, XXH_PRIME64_2);
             h128.high64 += m128.high64 * XXH_PRIME64_2;
 
-            h128.low64 = XXH3_avalanche(h128.low64);
-            h128.high64 = XXH3_avalanche(h128.high64);
+            h128.low64 = xxh3_avalanche(h128.low64);
+            h128.high64 = xxh3_avalanche(h128.high64);
             return h128;
         }
     }
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_len_0to16_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_0to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(len <= 16, "len > 16");
     {
         if (len > 8)
-            return XXH3_len_9to16_128b(input, len, secret, seed);
+            return xxh3_len_9to16_128b(input, len, secret, seed);
         if (len >= 4)
-            return XXH3_len_4to8_128b(input, len, secret, seed);
+            return xxh3_len_4to8_128b(input, len, secret, seed);
         if (len)
-            return XXH3_len_1to3_128b(input, len, secret, seed);
+            return xxh3_len_1to3_128b(input, len, secret, seed);
         {
             XXH128_hash_t h128;
-            const ulong bitflipl = XXH_readLE64(secret + 64) ^ XXH_readLE64(secret + 72);
-            const ulong bitfliph = XXH_readLE64(secret + 80) ^ XXH_readLE64(secret + 88);
-            h128.low64 = XXH64_avalanche(seed ^ bitflipl);
-            h128.high64 = XXH64_avalanche(seed ^ bitfliph);
+            const ulong bitflipl = xxh_readLE64(secret + 64) ^ xxh_readLE64(secret + 72);
+            const ulong bitfliph = xxh_readLE64(secret + 80) ^ xxh_readLE64(secret + 88);
+            h128.low64 = xxh64_avalanche(seed ^ bitflipl);
+            h128.high64 = xxh64_avalanche(seed ^ bitfliph);
             return h128;
         }
     }
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
+private XXH128_hash_t xxh128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
         const ubyte* input_2, const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
-    acc.low64 += XXH3_mix16B(input_1, secret + 0, seed);
-    acc.low64 ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
-    acc.high64 += XXH3_mix16B(input_2, secret + 16, seed);
-    acc.high64 ^= XXH_readLE64(input_1) + XXH_readLE64(input_1 + 8);
+    acc.low64 += xxh3_mix16B(input_1, secret + 0, seed);
+    acc.low64 ^= xxh_readLE64(input_2) + xxh_readLE64(input_2 + 8);
+    acc.high64 += xxh3_mix16B(input_2, secret + 16, seed);
+    acc.high64 ^= xxh_readLE64(input_1) + xxh_readLE64(input_1 + 8);
     return acc;
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_17to128_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSie < XXH3_SECRET_SIZE_MIN");
@@ -2220,7 +2220,7 @@ private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
             size_t i = (len - 1) / 32;
             do
             {
-                acc = XXH128_mix32B(acc, input + 16 * i,
+                acc = xxh128_mix32B(acc, input + 16 * i,
                         input + len - 16 * (i + 1), secret + 32 * i, seed);
             }
             while (i-- != 0);
@@ -2233,28 +2233,28 @@ private XXH128_hash_t XXH3_len_17to128_128b(const ubyte* input, size_t len,
                 {
                     if (len > 96)
                     {
-                        acc = XXH128_mix32B(acc, input + 48, input + len - 64, secret + 96, seed);
+                        acc = xxh128_mix32B(acc, input + 48, input + len - 64, secret + 96, seed);
                     }
-                    acc = XXH128_mix32B(acc, input + 32, input + len - 48, secret + 64, seed);
+                    acc = xxh128_mix32B(acc, input + 32, input + len - 48, secret + 64, seed);
                 }
-                acc = XXH128_mix32B(acc, input + 16, input + len - 32, secret + 32, seed);
+                acc = xxh128_mix32B(acc, input + 16, input + len - 32, secret + 32, seed);
             }
-            acc = XXH128_mix32B(acc, input, input + len - 16, secret, seed);
+            acc = xxh128_mix32B(acc, input, input + len - 16, secret, seed);
         }
         {
             XXH128_hash_t h128;
             h128.low64 = acc.low64 + acc.high64;
             h128.high64 = (acc.low64 * XXH_PRIME64_1) + (
                     acc.high64 * XXH_PRIME64_4) + ((len - seed) * XXH_PRIME64_2);
-            h128.low64 = XXH3_avalanche(h128.low64);
-            h128.high64 = cast(XXH64_hash_t) 0 - XXH3_avalanche(h128.high64);
+            h128.low64 = xxh3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t) 0 - xxh3_avalanche(h128.high64);
             return h128;
         }
     }
 }
 
 pragma(inline, false)
-private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
+private XXH128_hash_t xxh3_len_129to240_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN");
@@ -2269,19 +2269,19 @@ private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
         acc.high64 = 0;
         for (i = 0; i < 4; i++)
         {
-            acc = XXH128_mix32B(acc, input + (32 * i), input + (32 * i) + 16, secret + (32 * i),
+            acc = xxh128_mix32B(acc, input + (32 * i), input + (32 * i) + 16, secret + (32 * i),
                     seed);
         }
-        acc.low64 = XXH3_avalanche(acc.low64);
-        acc.high64 = XXH3_avalanche(acc.high64);
+        acc.low64 = xxh3_avalanche(acc.low64);
+        acc.high64 = xxh3_avalanche(acc.high64);
         assert(nbRounds >= 4, "nbRounds < 4");
         for (i = 4; i < nbRounds; i++)
         {
-            acc = XXH128_mix32B(acc, input + (32 * i), input + (32 * i) + 16,
+            acc = xxh128_mix32B(acc, input + (32 * i), input + (32 * i) + 16,
                     secret + XXH3_MIDSIZE_STARTOFFSET + (32 * (i - 4)), seed);
         }
         /* last bytes */
-        acc = XXH128_mix32B(acc, input + len - 16, input + len - 32,
+        acc = xxh128_mix32B(acc, input + len - 16, input + len - 32,
                 secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16, 0 - seed);
 
         {
@@ -2289,20 +2289,20 @@ private XXH128_hash_t XXH3_len_129to240_128b(const ubyte* input, size_t len,
             h128.low64 = acc.low64 + acc.high64;
             h128.high64 = (acc.low64 * XXH_PRIME64_1) + (
                     acc.high64 * XXH_PRIME64_4) + ((len - seed) * XXH_PRIME64_2);
-            h128.low64 = XXH3_avalanche(h128.low64);
-            h128.high64 = cast(XXH64_hash_t) 0 - XXH3_avalanche(h128.high64);
+            h128.low64 = xxh3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t) 0 - xxh3_avalanche(h128.high64);
             return h128;
         }
     }
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
+private XXH128_hash_t xxh3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
     align(XXH_ACC_ALIGN) ulong[XXH_ACC_NB] acc = XXH3_INIT_ACC;
 
-    XXH3_hashLong_internal_loop(&acc[0], cast(const ubyte*) input, len,
+    xxh3_hashLong_internal_loop(&acc[0], cast(const ubyte*) input, len,
             secret, secretSize, f_acc512, f_scramble);
 
     /* converge into final hash */
@@ -2310,23 +2310,23 @@ private XXH128_hash_t XXH3_hashLong_128b_internal(const void* input, size_t len,
     assert(secretSize >= acc.sizeof + XXH_SECRET_MERGEACCS_START, "secretSze < allowed limit.");
     {
         XXH128_hash_t h128;
-        h128.low64 = XXH3_mergeAccs(&acc[0],
+        h128.low64 = xxh3_mergeAccs(&acc[0],
                 secret + XXH_SECRET_MERGEACCS_START, cast(ulong) len * XXH_PRIME64_1);
-        h128.high64 = XXH3_mergeAccs(&acc[0], secret + secretSize - (acc)
+        h128.high64 = xxh3_mergeAccs(&acc[0], secret + secretSize - (acc)
                 .sizeof - XXH_SECRET_MERGEACCS_START, ~(cast(ulong) len * XXH_PRIME64_2));
         return h128;
     }
 }
 
 pragma(inline, false)
-private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
+private XXH128_hash_t xxh3_hashLong_128b_default(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
     cast(void) secret;
     cast(void) secretLen;
-    return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_hashLong_128b_internal(input, len, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
 /*
@@ -2334,26 +2334,26 @@ private XXH128_hash_t XXH3_hashLong_128b_default(const void* input, size_t len,
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
 pragma(inline, true)
-private XXH128_hash_t XXH3_hashLong_128b_withSecret(const void* input,
+private XXH128_hash_t xxh3_hashLong_128b_withSecret(const void* input,
         size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) seed64;
-    return XXH3_hashLong_128b_internal(input, len, cast(const ubyte*) secret,
-            secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_hashLong_128b_internal(input, len, cast(const ubyte*) secret,
+            secretLen, xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
+private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
 {
     if (seed64 == 0)
-        return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0],
-                (XXH3_kSecret).sizeof, f_acc512, f_scramble);
+        return xxh3_hashLong_128b_internal(input, len, &xxh3_kSecret[0],
+                (xxh3_kSecret).sizeof, f_acc512, f_scramble);
     {
         align(XXH_SEC_ALIGN) ubyte[XXH_SECRET_DEFAULT_SIZE] secret;
         f_initSec(&secret[0], seed64);
-        return XXH3_hashLong_128b_internal(input, len,
+        return xxh3_hashLong_128b_internal(input, len,
                 cast(const ubyte*)&secret[0], (secret).sizeof, f_acc512, f_scramble);
     }
 }
@@ -2361,20 +2361,20 @@ private XXH128_hash_t XXH3_hashLong_128b_withSeed_internal(const void* input, si
  * It's important for performance that XXH3_hashLong is not inlined.
  */
 pragma(inline, false)
-private XXH128_hash_t XXH3_hashLong_128b_withSeed(const void* input, size_t len,
+private XXH128_hash_t xxh3_hashLong_128b_withSeed(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
     cast(void) secret;
     cast(void) secretLen;
-    return XXH3_hashLong_128b_withSeed_internal(input, len, seed64,
-            XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+    return xxh3_hashLong_128b_withSeed_internal(input, len, seed64,
+            xxh3_accumulate_512, xxh3_scrambleAcc, xxh3_initCustomSecret);
 }
 
 alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
         XXH64_hash_t, const void*, size_t) @safe pure nothrow @nogc;
 
 pragma(inline, true)
-private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
+private XXH128_hash_t xxh3_128bits_internal(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
         @safe pure nothrow @nogc
 {
@@ -2386,93 +2386,93 @@ private XXH128_hash_t XXH3_128bits_internal(const void* input, size_t len,
      * Adding a check and a branch here would cost performance at every hash.
      */
     if (len <= 16)
-        return XXH3_len_0to16_128b(cast(const ubyte*) input, len,
+        return xxh3_len_0to16_128b(cast(const ubyte*) input, len,
                 cast(const ubyte*) secret, seed64);
     if (len <= 128)
-        return XXH3_len_17to128_128b(cast(const ubyte*) input, len,
+        return xxh3_len_17to128_128b(cast(const ubyte*) input, len,
                 cast(const ubyte*) secret, secretLen, seed64);
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_len_129to240_128b(cast(const ubyte*) input, len,
+        return xxh3_len_129to240_128b(cast(const ubyte*) input, len,
                 cast(const ubyte*) secret, secretLen, seed64);
     return f_hl128(input, len, seed64, secret, secretLen);
 }
 
 /* ===   Public XXH128 API   === */
 
-XXH128_hash_t XXH3_128bits(const void* input, size_t len) @safe pure nothrow @nogc
+XXH128_hash_t xxh3_128bits(const void* input, size_t len) @safe pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, 0, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_default);
+    return xxh3_128bits_internal(input, len, 0, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, &xxh3_hashLong_128b_default);
 }
 
-XXH128_hash_t XXH3_128bits_withSecret(const void* input, size_t len,
+XXH128_hash_t xxh3_128bits_withSecret(const void* input, size_t len,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, 0, cast(const ubyte*) secret,
-            secretSize, &XXH3_hashLong_128b_withSecret);
+    return xxh3_128bits_internal(input, len, 0, cast(const ubyte*) secret,
+            secretSize, &xxh3_hashLong_128b_withSecret);
 }
 
-XXH128_hash_t XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
+XXH128_hash_t xxh3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
-    return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
-            (XXH3_kSecret).sizeof, &XXH3_hashLong_128b_withSeed);
+    return xxh3_128bits_internal(input, len, seed, &xxh3_kSecret[0],
+            (xxh3_kSecret).sizeof, &xxh3_hashLong_128b_withSeed);
 }
 
-XXH128_hash_t XXH3_128bits_withSecretandSeed(const void* input, size_t len,
+XXH128_hash_t xxh3_128bits_withSecretandSeed(const void* input, size_t len,
         const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (len <= XXH3_MIDSIZE_MAX)
-        return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0],
-                (XXH3_kSecret).sizeof, null);
-    return XXH3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
+        return xxh3_128bits_internal(input, len, seed, &xxh3_kSecret[0],
+                (xxh3_kSecret).sizeof, null);
+    return xxh3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
 }
 
 XXH128_hash_t XXH128(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
-    return XXH3_128bits_withSeed(input, len, seed);
+    return xxh3_128bits_withSeed(input, len, seed);
 }
 
-XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
+XXH_errorcode xxh3_128bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_reset(statePtr);
+    return xxh3_64bits_reset(statePtr);
 }
 
-XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr,
+XXH_errorcode xxh3_128bits_reset_withSecret(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_reset_withSecret(statePtr, secret, secretSize);
+    return xxh3_64bits_reset_withSecret(statePtr, secret, secretSize);
 }
 
-XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
+XXH_errorcode xxh3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_reset_withSeed(statePtr, seed);
+    return xxh3_64bits_reset_withSeed(statePtr, seed);
 }
 
-XXH_errorcode XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
+XXH_errorcode xxh3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
-    return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
+    return xxh3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
 }
 
-XXH_errorcode XXH3_128bits_update(XXH3_state_t* state, scope const void* input, size_t len) @safe pure nothrow @nogc
+XXH_errorcode xxh3_128bits_update(XXH3_state_t* state, scope const void* input, size_t len) @safe pure nothrow @nogc
 {
-    return XXH3_update(state, cast(const ubyte*) input, len,
-            XXH3_accumulate_512, XXH3_scrambleAcc);
+    return xxh3_update(state, cast(const ubyte*) input, len,
+            xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
-XXH128_hash_t XXH3_128bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
+XXH128_hash_t xxh3_128bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
     if (state.totalLen > XXH3_MIDSIZE_MAX)
     {
         align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
-        XXH3_digest_long(&acc[0], state, secret);
+        xxh3_digest_long(&acc[0], state, secret);
         assert(state.secretLimit + XXH_STRIPE_LEN >= acc.sizeof + XXH_SECRET_MERGEACCS_START, "Internal error");
         {
             XXH128_hash_t h128;
-            h128.low64 = XXH3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
+            h128.low64 = xxh3_mergeAccs(&acc[0], secret + XXH_SECRET_MERGEACCS_START,
                     cast(ulong) state.totalLen * XXH_PRIME64_1);
-            h128.high64 = XXH3_mergeAccs(&acc[0], secret + state.secretLimit + XXH_STRIPE_LEN - (acc)
+            h128.high64 = xxh3_mergeAccs(&acc[0], secret + state.secretLimit + XXH_STRIPE_LEN - (acc)
                     .sizeof - XXH_SECRET_MERGEACCS_START,
                     ~(cast(ulong) state.totalLen * XXH_PRIME64_2));
             return h128;
@@ -2480,8 +2480,8 @@ XXH128_hash_t XXH3_128bits_digest(const XXH3_state_t* state) @trusted pure nothr
     }
     /* len <= XXH3_MIDSIZE_MAX : short code */
     if (state.seed)
-        return XXH3_128bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
-    return XXH3_128bits_withSecret(&state.buffer[0],
+        return xxh3_128bits_withSeed(&state.buffer[0], cast(size_t) state.totalLen, state.seed);
+    return xxh3_128bits_withSecret(&state.buffer[0],
             cast(size_t)(state.totalLen), secret, state.secretLimit + XXH_STRIPE_LEN);
 }
 
@@ -2550,13 +2550,13 @@ public:
         if (data.length > 0) // digest will only change, when there is data!
         {
             static if (digestSize == 32)
-                ec = XXH32_update(&state, &data[0], data.length);
+                ec = xxh32_update(&state, &data[0], data.length);
             else static if (digestSize == 64 && !useXXH3)
-                ec = XXH64_update(&state, &data[0], data.length);
+                ec = xxh64_update(&state, &data[0], data.length);
             else static if (digestSize == 64 && useXXH3)
-                ec = XXH3_64bits_update(&state, &data[0], data.length);
+                ec = xxh3_64bits_update(&state, &data[0], data.length);
             else static if (digestSize == 128)
-                ec = XXH3_128bits_update(&state, &data[0], data.length);
+                ec = xxh3_128bits_update(&state, &data[0], data.length);
             else
                 assert(false, "Unknown XXH bitdeep or variant");
         }
@@ -2580,22 +2580,22 @@ public:
         static if (digestSize == 32)
         {
             assert(state.alignof == uint.alignof, "Wrong alignment for state structure");
-            ec = XXH32_reset(&state, seed);
+            ec = xxh32_reset(&state, seed);
         }
         else static if (digestSize == 64 && !useXXH3)
         {
             assert(state.alignof == ulong.alignof, "Wrong alignment for state structure");
-            ec = XXH64_reset(&state, seed);
+            ec = xxh64_reset(&state, seed);
         }
         else static if (digestSize == 64 && useXXH3)
         {
             assert(state.alignof == 64, "Wrong alignment for state structure");
-            ec = XXH3_64bits_reset(&state);
+            ec = xxh3_64bits_reset(&state);
         }
         else static if (digestSize == 128)
         {
             assert(state.alignof == 64, "Wrong alignment for state structure");
-            ec = XXH3_128bits_reset(&state);
+            ec = xxh3_128bits_reset(&state);
         }
         else
             assert(false, "Unknown XXH bitdeep or variant");
@@ -2611,22 +2611,22 @@ public:
         XXH_errorcode ec;
         static if (digestSize == 32)
         {
-            hash = XXH32_digest(&state);
+            hash = xxh32_digest(&state);
             auto rc = nativeToBigEndian(hash);
         }
         else static if (digestSize == 64 && !useXXH3)
         {
-            hash = XXH64_digest(&state);
+            hash = xxh64_digest(&state);
             auto rc = nativeToBigEndian(hash);
         }
         else static if (digestSize == 64 && useXXH3)
         {
-            hash = XXH3_64bits_digest(&state);
+            hash = xxh3_64bits_digest(&state);
             auto rc = nativeToBigEndian(hash);
         }
         else static if (digestSize == 128)
         {
-            hash = XXH3_128bits_digest(&state);
+            hash = xxh3_128bits_digest(&state);
             HASH rc;
             // Note: low64 and high64 are intentionally exchanged!
             rc.low64 = nativeToBigEndian(hash.high64);

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -3086,7 +3086,7 @@ auto xxh128Of(T...)(T data)
 alias XXH32Digest = WrapperDigest!XXH_32;
 alias XXH64Digest = WrapperDigest!XXH_64; ///ditto
 alias XXH3_64Digest = WrapperDigest!XXH3_64; ///ditto
-alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
+alias XXH3_128Digest = WrapperDigest!XXH3_128; ///ditto
 
 ///
 @safe unittest
@@ -3119,7 +3119,7 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
 @safe unittest
 {
     //Simple example, hashing a string using Digest.digest helper function
-    auto xxh = new XXH128Digest();
+    auto xxh = new XXH3_128Digest();
     ubyte[] hash = xxh.digest("abc");
     //Let's get a hash string
     assert(toHexString(hash) == "06B05AB6733A618578AF5F94892F3950");
@@ -3185,7 +3185,7 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
         dig.put(cast(ubyte) 0);
     }
 
-    auto xxh = new XXH128Digest();
+    auto xxh = new XXH3_128Digest();
     test(xxh);
 
     //Let's use a custom buffer:
@@ -3201,7 +3201,7 @@ alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
     auto xxh = new XXH32Digest();
     auto xxh64 = new XXH64Digest();
     auto xxh3_64 = new XXH3_64Digest();
-    auto xxh128 = new XXH128Digest();
+    auto xxh128 = new XXH3_128Digest();
 
     xxh.put(cast(ubyte[]) "abcdef");
     xxh.reset();

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -718,8 +718,7 @@ private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     ulong h64;
-    if (input == null)
-        assert(len == 0, "input null ptr only allowed with len == 0");
+    assert(input !is null && !len, "input null ptr only allowed with len == 0");
 
     if (len >= 32)
     {

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -453,6 +453,7 @@ private uint xxh32_endian_align(const(ubyte)* input, size_t len,
     return xxh32_finalize(h32, input, len & 15, align_);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure nothrow @nogc
 {
     static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
@@ -486,6 +487,7 @@ XXH32_hash_t XXH32(const void* input, size_t len, XXH32_hash_t seed) @safe pure 
     }
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
 in (statePtr != null, "statePtr is null")
 {
@@ -497,6 +499,7 @@ in (statePtr != null, "statePtr is null")
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 in
 {
@@ -573,6 +576,7 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH32_hash_t xxh32_digest(const XXH32_state_t* state) @trusted pure nothrow @nogc
 {
     uint h32;
@@ -593,6 +597,7 @@ XXH32_hash_t xxh32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
             XXH_alignment.XXH_aligned);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 void xxh32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
 {
     static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
@@ -602,6 +607,7 @@ void xxh32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH32_hash_t xxh32_hashFromCanonical(const XXH32_canonical_t* src) @safe pure nothrow @nogc
 {
     return xxh_readBE32(src);
@@ -793,6 +799,7 @@ do
     return xxh64_finalize(h64, input, len, align_);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2)
@@ -826,6 +833,7 @@ XXH64_hash_t XXH64(const void* input, size_t len, XXH64_hash_t seed) @safe pure 
     }
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
     assert(statePtr != null, "statePtr == null");
@@ -837,6 +845,7 @@ XXH_errorcode xxh64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 in
 {
@@ -907,6 +916,7 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh64_digest(const XXH64_state_t* state) @trusted pure nothrow @nogc
 {
     ulong h64;
@@ -932,6 +942,7 @@ XXH64_hash_t xxh64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 }
 
 
+/* XXH PUBLIC API - hidden in D module */ private
 void xxh64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
 {
     static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
@@ -941,6 +952,7 @@ void xxh64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh64_hashFromCanonical(const XXH64_canonical_t* src) @safe pure nothrow @nogc
 {
     return xxh_readBE64(src);
@@ -1685,12 +1697,14 @@ in(secretLen >= XXH3_SECRET_SIZE_MIN, "secretLen < XXH3_SECRET_SIZE_MIN")
 
 /* ===   Public entry point   === */
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh3_64bits(const(void)* input, size_t length) @safe pure nothrow @nogc
 {
     return xxh3_64bits_internal(input, length, 0, &xxh3_kSecret[0],
             (xxh3_kSecret).sizeof, &xxh3_hashLong_64b_default);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh3_64bits_withSecret(const(void)* input, size_t length,
         const(void)* secret, size_t secretSize) @safe pure nothrow @nogc
 {
@@ -1698,12 +1712,14 @@ XXH64_hash_t xxh3_64bits_withSecret(const(void)* input, size_t length,
             &xxh3_hashLong_64b_withSecret);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return xxh3_64bits_internal(input, length, seed, &xxh3_kSecret[0],
             (xxh3_kSecret).sizeof, &xxh3_hashLong_64b_withSeed);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh3_64bits_withSecretandSeed(const(void)* input, size_t length,
         const(void)* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
@@ -1749,6 +1765,7 @@ in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
     statePtr.nbStripesPerBlock = statePtr.secretLimit / XXH_SECRET_CONSUME_RATE;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_64bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
     if (statePtr == null)
@@ -1757,6 +1774,7 @@ XXH_errorcode xxh3_64bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_64bits_reset_withSecret(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
@@ -1770,6 +1788,7 @@ XXH_errorcode xxh3_64bits_reset_withSecret(XXH3_state_t* statePtr,
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     if (statePtr == null)
@@ -1782,6 +1801,7 @@ XXH_errorcode xxh3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t se
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
         const(void)* secret, size_t secretSize, XXH64_hash_t seed64) @safe pure nothrow @nogc
 {
@@ -1970,6 +1990,7 @@ do
     return XXH_errorcode.XXH_OK;
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_64bits_update(XXH3_state_t* state, scope const(void)* input, size_t len)
     @safe pure nothrow @nogc
 {
@@ -2009,6 +2030,7 @@ private void xxh3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, cons
     }
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH64_hash_t xxh3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
@@ -2413,12 +2435,14 @@ private XXH128_hash_t xxh3_128bits_internal(const void* input, size_t len,
 
 /* ===   Public XXH128 API   === */
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t xxh3_128bits(const void* input, size_t len) @safe pure nothrow @nogc
 {
     return xxh3_128bits_internal(input, len, 0, &xxh3_kSecret[0],
             (xxh3_kSecret).sizeof, &xxh3_hashLong_128b_default);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t xxh3_128bits_withSecret(const void* input, size_t len,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
@@ -2426,12 +2450,14 @@ XXH128_hash_t xxh3_128bits_withSecret(const void* input, size_t len,
             secretSize, &xxh3_hashLong_128b_withSecret);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t xxh3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return xxh3_128bits_internal(input, len, seed, &xxh3_kSecret[0],
             (xxh3_kSecret).sizeof, &xxh3_hashLong_128b_withSeed);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t xxh3_128bits_withSecretandSeed(const void* input, size_t len,
         const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
@@ -2441,39 +2467,46 @@ XXH128_hash_t xxh3_128bits_withSecretandSeed(const void* input, size_t len,
     return xxh3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t XXH128(const void* input, size_t len, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return xxh3_128bits_withSeed(input, len, seed);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_128bits_reset(XXH3_state_t* statePtr) @safe pure nothrow @nogc
 {
     return xxh3_64bits_reset(statePtr);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_128bits_reset_withSecret(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize) @safe pure nothrow @nogc
 {
     return xxh3_64bits_reset_withSecret(statePtr, secret, secretSize);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return xxh3_64bits_reset_withSeed(statePtr, seed);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
         const void* secret, size_t secretSize, XXH64_hash_t seed) @safe pure nothrow @nogc
 {
     return xxh3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH_errorcode xxh3_128bits_update(XXH3_state_t* state, scope const void* input, size_t len) @safe pure nothrow @nogc
 {
     return xxh3_update(state, cast(const ubyte*) input, len,
             xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
+/* XXH PUBLIC API - hidden in D module */ private
 XXH128_hash_t xxh3_128bits_digest(const XXH3_state_t* state) @trusted pure nothrow @nogc
 {
     const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -1,0 +1,3284 @@
+/**
+ * Computes xxHash hashes of arbitrary data. xxHash hashes are either uint32_t, uint64_t or uint128_t quantities that are like a
+ * checksum or CRC, but are more robust and very performant.
+ *
+$(SCRIPT inhibitQuickIndex = 1;)
+
+$(DIVC quickindex,
+$(BOOKTABLE ,
+$(TR $(TH Category) $(TH Functions)
+)
+$(TR $(TDNW Template API) $(TD $(MYREF XXHTemplate)
+)
+)
+$(TR $(TDNW OOP API) $(TD $(MYREF XXH32Digest))
+)
+$(TR $(TDNW Helpers) $(TD $(MYREF xxh32Of))
+)
+)
+)
+
+ * This module conforms to the APIs defined in `std.digest`. To understand the
+ * differences between the template and the OOP API, see $(MREF std, digest).
+ *
+ * This module publicly imports $(MREF std, digest) and can be used as a stand-alone
+ * module.
+ *
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ *
+ * CTFE:
+ * Digests do not work in CTFE
+ *
+ * Authors:
+ * Carsten Schlote, Piotr Szturmaj, Kai Nacke, Johannes Pfau $(BR)
+ * The routines and algorithms are provided by the xxhash.[ch] source
+ * provided at $(I git@github.com:Cyan4973/xxHash.git).
+ *
+ * References:
+ *      $(LINK2 https://github.com/Cyan4973/xxHash, GitHub website of project)
+ *
+ * Source: $(PHOBOSSRC std/digest/xxh.d)
+ *
+ */
+
+/* xxh.d - A wrapper for the original C implementation */
+module std.digest.xxh;
+
+public import std.digest;
+
+///
+@safe unittest
+{
+    //Template API
+    import std.digest.md;
+
+    //Feeding data
+    ubyte[1024] data;
+    XXH_32 xxh;
+    xxh.start();
+    xxh.put(data[]);
+    xxh.start(); //Start again
+    xxh.put(data[]);
+    auto hash = xxh.finish();
+}
+
+///
+@safe unittest
+{
+    //OOP API
+    import std.digest.md;
+
+    auto xxh = new XXH32Digest();
+    ubyte[] hash = xxh.digest("abc");
+    assert(toHexString(hash) == "32D153FF", "Got " ~ toHexString(hash));
+
+    //Feeding data
+    ubyte[1024] data;
+    xxh.put(data[]);
+    xxh.reset(); //Start again
+    xxh.put(data[]);
+    hash = xxh.finish();
+}
+
+/* Port of C sources (release 0.8.1) to D language below */
+
+enum XXH_NO_STREAM = false;
+enum XXH_SIZE_OPT = 0;
+enum XXH_FORCE_ALIGN_CHECK = true;
+enum XXH32_ENDJMP = false;
+
+version (LittleEndian)
+    private immutable bool XXH_CPU_LITTLE_ENDIAN = true;
+else
+    private immutable bool XXH_CPU_LITTLE_ENDIAN = false;
+
+alias xxh_u8 = ubyte;
+alias xxh_u32 = uint;
+alias xxh_u64 = ulong;
+
+private uint32_t XXH_rotl32(uint32_t x, uint r) @trusted pure nothrow @nogc { return (((x) << (r)) | ((x) >> (32 - (r)))); }
+private uint64_t XXH_rotl64(uint64_t x, uint r) @trusted pure nothrow @nogc { return (((x) << (r)) | ((x) >> (64 - (r)))); }
+/* *************************************
+*  Misc
+***************************************/
+
+enum XXH_VERSION_MAJOR   = 0;
+enum XXH_VERSION_MINOR   = 8;
+enum XXH_VERSION_RELEASE = 1;
+/** Version number, encoded as two digits each */
+enum XXH_VERSION_NUMBER = (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE);
+
+/** Get version number */
+uint XXH_versionNumber ()  @trusted pure nothrow @nogc
+{
+    return XXH_VERSION_NUMBER;
+}
+
+private import std.stdint;
+
+alias XXH32_hash_t = uint32_t;
+alias XXH64_hash_t = uint64_t;
+struct XXH128_hash_t {
+    XXH64_hash_t low64;   /*!< `value & 0xFFFFFFFFFFFFFFFF` */
+    XXH64_hash_t high64;  /*!< `value >> 64` */
+}
+
+alias XXH64_canonical_t = uint64_t;
+alias XXH128_canonical_t = XXH128_hash_t;
+
+/*!
+ * @internal
+ * @brief Structure for XXH3 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined.
+ * Otherwise it is an opaque type.
+ * Never use this definition in combination with dynamic library.
+ * This allows fields to safely be changed in the future.
+ *
+ * @note ** This structure has a strict alignment requirement of 64 bytes!! **
+ * Do not allocate this with `malloc()` or `new`,
+ * it will not be sufficiently aligned.
+ * Use @ref XXH3_createState() and @ref XXH3_freeState(), or stack allocation.
+ *
+ * Typedef'd to @ref XXH3_state_t.
+ * Do never access the members of this struct directly.
+ *
+ * @see XXH3_INITSTATE() for stack initialization.
+ * @see XXH3_createState(), XXH3_freeState().
+ * @see XXH32_state_s, XXH64_state_s
+ */
+struct XXH3_state_t {
+   align(64)  XXH64_hash_t[8] acc;
+       /*!< The 8 accumulators. See @ref XXH32_state_s::v and @ref XXH64_state_s::v */
+   align(64)  ubyte[XXH3_SECRET_DEFAULT_SIZE] customSecret;
+       /*!< Used to store a custom secret generated from a seed. */
+   align(64)  ubyte[XXH3_INTERNALBUFFER_SIZE] buffer;
+       /*!< The internal buffer. @see XXH32_state_s::mem32 */
+   XXH32_hash_t bufferedSize;
+       /*!< The amount of memory in @ref buffer, @see XXH32_state_s::memsize */
+   XXH32_hash_t useSeed;
+       /*!< Reserved field. Needed for padding on 64-bit. */
+   size_t nbStripesSoFar;
+       /*!< Number or stripes processed. */
+   XXH64_hash_t totalLen;
+       /*!< Total length hashed. 64-bit even on 32-bit targets. */
+   size_t nbStripesPerBlock;
+       /*!< Number of stripes per block. */
+   size_t secretLimit;
+       /*!< Size of @ref customSecret or @ref extSecret */
+   XXH64_hash_t seed;
+       /*!< Seed for _withSeed variants. Must be zero otherwise, @see XXH3_INITSTATE() */
+   XXH64_hash_t reserved64;
+       /*!< Reserved field. */
+   const(ubyte)* extSecret;
+       /*!< Reference to an external secret for the _withSecret variants, null
+        *   for other variants. */
+   /* note: there may be some padding at the end due to alignment on 64 bytes */
+} /* typedef'd to XXH3_state_t */
+
+
+enum XXH_errorcode {
+    XXH_OK = 0, /*!< OK */
+    XXH_ERROR   /*!< Error */
+}
+
+
+
+/*!
+ * @internal
+ * @brief Structure for XXH32 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined. Otherwise it is
+ * an opaque type. This allows fields to safely be changed.
+ *
+ * Typedef'd to @ref XXH32_state_t.
+ * Do not access the members of this struct directly.
+ * @see XXH64_state_s, XXH3_state_s
+ */
+struct XXH32_state_t {
+   XXH32_hash_t total_len_32; /*!< Total length hashed, modulo 2^32 */
+   XXH32_hash_t large_len;    /*!< Whether the hash is >= 16 (handles @ref total_len_32 overflow) */
+   XXH32_hash_t[4] v;         /*!< Accumulator lanes */
+   XXH32_hash_t[4] mem32;     /*!< Internal buffer for partial reads. Treated as unsigned char[16]. */
+   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem32 */
+   XXH32_hash_t reserved;     /*!< Reserved field. Do not read nor write to it. */
+}   /* typedef'd to XXH32_state_t */
+
+/*!
+ * @internal
+ * @brief Structure for XXH64 streaming API.
+ *
+ * @note This is only defined when @ref XXH_STATIC_LINKING_ONLY,
+ * @ref XXH_INLINE_ALL, or @ref XXH_IMPLEMENTATION is defined. Otherwise it is
+ * an opaque type. This allows fields to safely be changed.
+ *
+ * Typedef'd to @ref XXH64_state_t.
+ * Do not access the members of this struct directly.
+ * @see XXH32_state_s, XXH3_state_s
+ */
+struct XXH64_state_t {
+   XXH64_hash_t total_len;    /*!< Total length hashed. This is always 64-bit. */
+   XXH64_hash_t[4] v;         /*!< Accumulator lanes */
+   XXH64_hash_t[4] mem64;     /*!< Internal buffer for partial reads. Treated as unsigned char[32]. */
+   XXH32_hash_t memsize;      /*!< Amount of data in @ref mem64 */
+   XXH32_hash_t reserved32;   /*!< Reserved field, needed for padding anyways*/
+   XXH64_hash_t reserved64;   /*!< Reserved field. Do not read or write to it. */
+}   /* typedef'd to XXH64_state_t */
+
+struct XXH32_canonical_t {
+    ubyte[4] digest; /*!< Hash bytes, big endian */
+}
+
+/** A 32-bit byteswap.
+ *
+ * Param: x = The 32-bit integer to byteswap.
+ * Return: x, byteswapped.
+ */
+private xxh_u32 XXH_swap32 (xxh_u32 x) @trusted pure nothrow @nogc
+{
+    return  ((x << 24) & 0xff000000 ) |
+            ((x <<  8) & 0x00ff0000 ) |
+            ((x >>  8) & 0x0000ff00 ) |
+            ((x >> 24) & 0x000000ff );
+}
+
+/* ***************************
+*  Memory reads
+*****************************/
+
+/** Enum to indicate whether a pointer is aligned. */
+enum XXH_alignment {
+    XXH_aligned,  /** Aligned */
+    XXH_unaligned /** Possibly unaligned */
+}
+
+private xxh_u32 XXH_read32(const void* ptr) @trusted pure nothrow @nogc
+{
+    xxh_u32 val;
+    (cast(ubyte*) &val)[0 .. xxh_u32.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u32.sizeof];
+    return val;
+}
+
+private xxh_u32 XXH_readLE32(const void* ptr) @trusted pure nothrow @nogc
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+}
+
+private xxh_u32 XXH_readBE32(const void* ptr) @trusted pure nothrow @nogc
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap32(XXH_read32(ptr)) : XXH_read32(ptr);
+}
+
+private xxh_u32 XXH_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    if (align_==XXH_alignment.XXH_unaligned) {
+        return XXH_readLE32(ptr);
+    } else {
+        return XXH_CPU_LITTLE_ENDIAN ? * cast(const xxh_u32*) ptr : XXH_swap32(* cast(const xxh_u32*) ptr);
+    }
+}
+
+/* *******************************************************************
+*  32-bit hash functions
+*********************************************************************/
+enum XXH_PRIME32_1 = 0x9E3779B1U;  /** 0b10011110001101110111100110110001 */
+enum XXH_PRIME32_2 = 0x85EBCA77U;  /** 0b10000101111010111100101001110111 */
+enum XXH_PRIME32_3 = 0xC2B2AE3DU;  /** 0b11000010101100101010111000111101 */
+enum XXH_PRIME32_4 = 0x27D4EB2FU;  /** 0b00100111110101001110101100101111 */
+enum XXH_PRIME32_5 = 0x165667B1U;  /** 0b00010110010101100110011110110001 */
+
+/**  Normal stripe processing routine.
+ *
+ * This shuffles the bits so that any bit from @p input impacts several bits in
+ * acc.
+ *
+ * Param: acc The accumulator lane.
+ * Param: input The stripe of input to mix.
+ * Return: The mixed accumulator lane.
+ */
+private xxh_u32 XXH32_round(xxh_u32 acc, xxh_u32 input) @trusted pure nothrow @nogc
+{
+    acc += input * XXH_PRIME32_2;
+    acc  = XXH_rotl32(acc, 13);
+    acc *= XXH_PRIME32_1;
+    return acc;
+}
+
+/** Mixes all bits to finalize the hash.
+ *
+ * The final mix ensures that all input bits have a chance to impact any bit in
+ * the output digest, resulting in an unbiased distribution.
+ *
+ * Param: hash = The hash to avalanche.
+ * Return The avalanched hash.
+ */
+private xxh_u32 XXH32_avalanche(xxh_u32 hash) @trusted pure nothrow @nogc
+{
+    hash ^= hash >> 15;
+    hash *= XXH_PRIME32_2;
+    hash ^= hash >> 13;
+    hash *= XXH_PRIME32_3;
+    hash ^= hash >> 16;
+    return hash;
+}
+
+private xxh_u32 XXH_get32bits(const void* p, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    return XXH_readLE32_align(p, align_);
+}
+
+/*!
+ * @internal
+ * @brief Processes the last 0-15 bytes of @p ptr.
+ *
+ * There may be up to 15 bytes remaining to consume from the input.
+ * This final stage will digest them to ensure that all input bytes are present
+ * in the final mix.
+ *
+ * @param hash The hash to finalize.
+ * @param ptr The pointer to the remaining input.
+ * @param len The remaining length, modulo 16.
+ * @param align Whether @p ptr is aligned.
+ * @return The finalized hash.
+ * @see XXH64_finalize().
+ */
+private xxh_u32
+XXH32_finalize(xxh_u32 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_)  @trusted pure nothrow @nogc
+{
+    void XXH_PROCESS1(ref uint32_t hash, ref const(xxh_u8)* ptr)
+    {
+        hash += (*ptr++) * XXH_PRIME32_5;
+        hash = XXH_rotl32(hash, 11) * XXH_PRIME32_1;
+    }
+    void XXH_PROCESS4(ref uint32_t hash, ref const(xxh_u8)* ptr)
+    {
+        hash += XXH_get32bits(ptr, align_) * XXH_PRIME32_3;
+        ptr += 4;
+        hash  = XXH_rotl32(hash, 17) * XXH_PRIME32_4;
+    }
+
+    /* Compact rerolled version; generally faster */
+    if (!XXH32_ENDJMP) {
+        len &= 15;
+        while (len >= 4) {
+            XXH_PROCESS4(hash, ptr);
+            len -= 4;
+        }
+        while (len > 0) {
+            XXH_PROCESS1(hash, ptr);
+            --len;
+        }
+        return XXH32_avalanche(hash);
+    } else {
+         switch(len&15) /* or switch(bEnd - p) */ {
+           case 12:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 8:       XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 4:       XXH_PROCESS4(hash, ptr);
+                         return XXH32_avalanche(hash);
+
+           case 13:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 9:       XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 5:       XXH_PROCESS4(hash, ptr);
+                         XXH_PROCESS1(hash, ptr);
+                         return XXH32_avalanche(hash);
+
+           case 14:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 10:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 6:       XXH_PROCESS4(hash, ptr);
+                         XXH_PROCESS1(hash, ptr);
+                         XXH_PROCESS1(hash, ptr);
+                         return XXH32_avalanche(hash);
+
+           case 15:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 11:      XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 7:       XXH_PROCESS4(hash, ptr);
+                         goto case;
+           case 3:       XXH_PROCESS1(hash, ptr);
+                         goto case;
+           case 2:       XXH_PROCESS1(hash, ptr);
+                         goto case;
+           case 1:       XXH_PROCESS1(hash, ptr);
+                         goto case;
+           case 0:       return XXH32_avalanche(hash);
+           default: assert(0);
+        }
+        return hash;   /* reaching this point is deemed impossible */
+    }
+}
+
+/** The implementation for @ref XXH32().
+ *
+ * Params:
+ *  input = Directly passed from @ref XXH32().
+ *  len = Ditto
+ *  seed = Ditto
+ *  align_ = Whether input is aligned.
+ * Return: The calculated hash.
+ */
+private xxh_u32
+XXH32_endian_align(const(xxh_u8)* input, size_t len, xxh_u32 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    xxh_u32 h32;
+
+    if (len>=16) {
+        const xxh_u8* bEnd = input + len;
+        const xxh_u8* limit = bEnd - 15;
+        xxh_u32 v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+        xxh_u32 v2 = seed + XXH_PRIME32_2;
+        xxh_u32 v3 = seed + 0;
+        xxh_u32 v4 = seed - XXH_PRIME32_1;
+
+        do {
+            v1 = XXH32_round(v1, XXH_get32bits(input, align_)); input += 4;
+            v2 = XXH32_round(v2, XXH_get32bits(input, align_)); input += 4;
+            v3 = XXH32_round(v3, XXH_get32bits(input, align_)); input += 4;
+            v4 = XXH32_round(v4, XXH_get32bits(input, align_)); input += 4;
+        } while (input < limit);
+
+        h32 = XXH_rotl32(v1, 1)  + XXH_rotl32(v2, 7)
+            + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    } else {
+        h32  = seed + XXH_PRIME32_5;
+    }
+
+    h32 += cast(xxh_u32) len;
+
+    return XXH32_finalize(h32, input, len&15, align_);
+}
+
+XXH32_hash_t XXH32 (const void* input, size_t len, XXH32_hash_t seed) @trusted pure nothrow @nogc
+{
+    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2) {
+        /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+        XXH32_state_t state;
+        XXH32_reset(&state, seed);
+        XXH32_update(&state, cast(const(xxh_u8)*) input, len);
+        return XXH32_digest(&state);
+    } else {
+        if (XXH_FORCE_ALIGN_CHECK) {
+            if (((cast(size_t) input) & 3) == 0) {   /* Input is 4-bytes aligned, leverage the speed benefit */
+                return XXH32_endian_align(cast(const(xxh_u8)*)input, len, seed, XXH_alignment.XXH_aligned);
+        }   }
+
+        return XXH32_endian_align(cast(const(xxh_u8)*) input, len, seed, XXH_alignment.XXH_unaligned);
+    }
+}
+
+XXH32_state_t* XXH32_createState() @trusted pure nothrow @nogc
+{
+    import core.memory : pureMalloc;
+    return cast(XXH32_state_t*) pureMalloc(XXH32_state_t.sizeof);
+
+}
+XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr) @trusted pure nothrow @nogc
+{
+    import core.memory : pureFree;
+
+    pureFree(statePtr);
+    return XXH_errorcode.XXH_OK;
+}
+
+void XXH32_copyState(XXH32_state_t* dstState, const XXH32_state_t* srcState) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    memcpy(dstState, srcState, (*dstState).sizeof);
+}
+
+XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memset;
+
+    assert(statePtr != null);
+    memset(statePtr, 0, (*statePtr).sizeof);
+    statePtr.v[0] = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+    statePtr.v[1] = seed + XXH_PRIME32_2;
+    statePtr.v[2] = seed + 0;
+    statePtr.v[3] = seed - XXH_PRIME32_1;
+    return XXH_errorcode.XXH_OK;
+}
+
+XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    if (input==null) {
+        assert(len == 0);
+        return XXH_errorcode.XXH_OK;
+    }
+
+    {   const(xxh_u8)* p = cast(const(xxh_u8) *) input;
+        const xxh_u8* bEnd = p + len;
+
+        state.total_len_32 += cast(XXH32_hash_t) len;
+        state.large_len |= cast(XXH32_hash_t) ((len>=16) | (state.total_len_32>=16));
+
+        if (state.memsize + len < 16)  {   /* fill in tmp buffer */
+            memcpy(cast(xxh_u8*) (state.mem32) + state.memsize, input, len);
+            state.memsize += cast(XXH32_hash_t) len;
+            return XXH_errorcode.XXH_OK;
+        }
+
+        if (state.memsize) {   /* some data left from previous update */
+            memcpy(cast(xxh_u8*) (state.mem32) + state.memsize, input, 16-state.memsize);
+            {
+                const(xxh_u32)* p32 = cast(const(xxh_u32)*) &state.mem32[0];
+                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p32)); p32++;
+                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p32)); p32++;
+                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p32)); p32++;
+                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p32));
+            }
+            p += 16-state.memsize;
+            state.memsize = 0;
+        }
+
+        if (p <= bEnd-16) {
+            const xxh_u8* limit = bEnd - 16;
+
+            do {
+                state.v[0] = XXH32_round(state.v[0], XXH_readLE32(p)); p+=4;
+                state.v[1] = XXH32_round(state.v[1], XXH_readLE32(p)); p+=4;
+                state.v[2] = XXH32_round(state.v[2], XXH_readLE32(p)); p+=4;
+                state.v[3] = XXH32_round(state.v[3], XXH_readLE32(p)); p+=4;
+            } while (p<=limit);
+
+        }
+
+        if (p < bEnd) {
+            memcpy(cast(void*) &state.mem32[0], p, cast(size_t) (bEnd-p));
+            state.memsize = cast(XXH32_hash_t) (bEnd-p);
+        }
+    }
+
+    return XXH_errorcode.XXH_OK;
+}
+
+XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nogc
+{
+    xxh_u32 h32;
+
+    if (state.large_len) {
+        h32 = XXH_rotl32(state.v[0], 1)
+            + XXH_rotl32(state.v[1], 7)
+            + XXH_rotl32(state.v[2], 12)
+            + XXH_rotl32(state.v[3], 18);
+    } else {
+        h32 = state.v[2] /* == seed */ + XXH_PRIME32_5;
+    }
+
+    h32 += state.total_len_32;
+
+    return XXH32_finalize(h32, cast(const xxh_u8*) state.mem32, state.memsize, XXH_alignment.XXH_aligned);
+}
+
+void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof);
+    static if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap32(hash);
+    memcpy(dst, &hash, (*dst).sizeof);
+}
+
+XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @trusted pure nothrow @nogc
+{
+    return XXH_readBE32(src);
+}
+
+/* ----------------------------------------------------------------------------------------*/
+/* ----------------------------------------------------------------------------------------*/
+/* ----------------------------------------------------------------------------------------*/
+
+private xxh_u64 XXH_read64(const void* ptr) @trusted pure nothrow @nogc
+{
+    xxh_u64 val;
+    (cast(ubyte*) &val)[0 .. xxh_u64.sizeof] = (cast(ubyte*) ptr)[0 .. xxh_u64.sizeof];
+    return val;
+}
+
+private xxh_u64 XXH_swap64(xxh_u64 x) @trusted pure nothrow @nogc
+{
+    return  ((x << 56) & 0xff00000000000000) |
+            ((x << 40) & 0x00ff000000000000) |
+            ((x << 24) & 0x0000ff0000000000) |
+            ((x << 8)  & 0x000000ff00000000) |
+            ((x >> 8)  & 0x00000000ff000000) |
+            ((x >> 24) & 0x0000000000ff0000) |
+            ((x >> 40) & 0x000000000000ff00) |
+            ((x >> 56) & 0x00000000000000ff);
+}
+
+private xxh_u64 XXH_readLE64(const void* ptr) @trusted pure nothrow @nogc
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+}
+
+private xxh_u64 XXH_readBE64(const void* ptr) @trusted pure nothrow @nogc
+{
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_swap64(XXH_read64(ptr)) : XXH_read64(ptr);
+}
+
+private xxh_u64 XXH_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    if (align_==XXH_alignment.XXH_unaligned) {
+        return XXH_readLE64(ptr);
+    } else {
+        return XXH_CPU_LITTLE_ENDIAN ? * cast(const xxh_u64*) ptr : XXH_swap64(* cast(const xxh_u64*) ptr);
+    }
+}
+
+enum XXH_PRIME64_1 = 0x9E3779B185EBCA87;  /*!< 0b1001111000110111011110011011000110000101111010111100101010000111 */
+enum XXH_PRIME64_2 = 0xC2B2AE3D27D4EB4F;  /*!< 0b1100001010110010101011100011110100100111110101001110101101001111 */
+enum XXH_PRIME64_3 = 0x165667B19E3779F9;  /*!< 0b0001011001010110011001111011000110011110001101110111100111111001 */
+enum XXH_PRIME64_4 = 0x85EBCA77C2B2AE63;  /*!< 0b1000010111101011110010100111011111000010101100101010111001100011 */
+enum XXH_PRIME64_5 = 0x27D4EB2F165667C5;  /*!< 0b0010011111010100111010110010111100010110010101100110011111000101 */
+
+private xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input) @trusted pure nothrow @nogc
+{
+    acc += input * XXH_PRIME64_2;
+    acc  = XXH_rotl64(acc, 31);
+    acc *= XXH_PRIME64_1;
+    return acc;
+}
+
+private xxh_u64 XXH64_mergeRound(xxh_u64 acc, xxh_u64 val) @trusted pure nothrow @nogc
+{
+    val  = XXH64_round(0, val);
+    acc ^= val;
+    acc  = acc * XXH_PRIME64_1 + XXH_PRIME64_4;
+    return acc;
+}
+
+private xxh_u64 XXH64_avalanche(xxh_u64 hash) @trusted pure nothrow @nogc
+{
+    hash ^= hash >> 33;
+    hash *= XXH_PRIME64_2;
+    hash ^= hash >> 29;
+    hash *= XXH_PRIME64_3;
+    hash ^= hash >> 32;
+    return hash;
+}
+
+xxh_u64 XXH_get64bits(const void* p, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    return XXH_readLE64_align(p, align_);
+}
+
+/*!
+ * @internal
+ * @brief Processes the last 0-31 bytes of @p ptr.
+ *
+ * There may be up to 31 bytes remaining to consume from the input.
+ * This final stage will digest them to ensure that all input bytes are present
+ * in the final mix.
+ *
+ * @param hash The hash to finalize.
+ * @param ptr The pointer to the remaining input.
+ * @param len The remaining length, modulo 32.
+ * @param align Whether @p ptr is aligned.
+ * @return The finalized hash
+ * @see XXH32_finalize().
+ */
+private xxh_u64
+XXH64_finalize(xxh_u64 hash, const(xxh_u8)* ptr, size_t len, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    if (ptr==null) assert (len == 0);
+
+    len &= 31;
+    while (len >= 8) {
+        xxh_u64 k1 = XXH64_round(0, XXH_get64bits(ptr, align_));
+        ptr += 8;
+        hash ^= k1;
+        hash  = XXH_rotl64(hash,27) * XXH_PRIME64_1 + XXH_PRIME64_4;
+        len -= 8;
+    }
+    if (len >= 4) {
+        hash ^= cast(xxh_u64) (XXH_get32bits(ptr, align_)) * XXH_PRIME64_1;
+        ptr += 4;
+        hash = XXH_rotl64(hash, 23) * XXH_PRIME64_2 + XXH_PRIME64_3;
+        len -= 4;
+    }
+    while (len > 0) {
+        hash ^= (*ptr++) * XXH_PRIME64_5;
+        hash = XXH_rotl64(hash, 11) * XXH_PRIME64_1;
+        --len;
+    }
+    return  XXH64_avalanche(hash);
+}
+
+/*!
+ * @internal
+ * @brief The implementation for @ref XXH64().
+ *
+ * @param input , len , seed Directly passed from @ref XXH64().
+ * @param align Whether @p input is aligned.
+ * @return The calculated hash.
+ */
+private xxh_u64
+XXH64_endian_align(const(xxh_u8)* input, size_t len, xxh_u64 seed, XXH_alignment align_) @trusted pure nothrow @nogc
+{
+    xxh_u64 h64;
+    if (input==null) assert(len == 0);
+
+    if (len>=32) {
+        const xxh_u8* bEnd = input + len;
+        const xxh_u8* limit = bEnd - 31;
+        xxh_u64 v1 = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+        xxh_u64 v2 = seed + XXH_PRIME64_2;
+        xxh_u64 v3 = seed + 0;
+        xxh_u64 v4 = seed - XXH_PRIME64_1;
+
+        do {
+            v1 = XXH64_round(v1, XXH_get64bits(input, align_)); input+=8;
+            v2 = XXH64_round(v2, XXH_get64bits(input, align_)); input+=8;
+            v3 = XXH64_round(v3, XXH_get64bits(input, align_)); input+=8;
+            v4 = XXH64_round(v4, XXH_get64bits(input, align_)); input+=8;
+        } while (input<limit);
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+        h64 = XXH64_mergeRound(h64, v1);
+        h64 = XXH64_mergeRound(h64, v2);
+        h64 = XXH64_mergeRound(h64, v3);
+        h64 = XXH64_mergeRound(h64, v4);
+
+    } else {
+        h64  = seed + XXH_PRIME64_5;
+    }
+
+    h64 += cast(xxh_u64) len;
+
+    return XXH64_finalize(h64, input, len, align_);
+}
+
+XXH64_hash_t XXH64 (const void* input, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc
+{
+    static if (!XXH_NO_STREAM && XXH_SIZE_OPT >= 2) {
+        /* Simple version, good for code maintenance, but unfortunately slow for small inputs */
+        XXH64_state_t state;
+        XXH64_reset(&state, seed);
+        XXH64_update(&state, cast(const(xxh_u8)*) input, len);
+        return XXH64_digest(&state);
+    } else {
+        if (XXH_FORCE_ALIGN_CHECK) {
+            if (((cast(size_t) input) & 7)==0) {  /* Input is aligned, let's leverage the speed advantage */
+                return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,  XXH_alignment.XXH_aligned);
+        }   }
+
+        return XXH64_endian_align(cast(const(xxh_u8)*) input, len, seed,  XXH_alignment.XXH_unaligned);
+    }
+}
+
+XXH64_state_t* XXH64_createState() @trusted pure nothrow @nogc
+{
+    import core.memory : pureMalloc;
+    return cast(XXH64_state_t*) pureMalloc(XXH64_state_t.sizeof);
+
+}
+XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr) @trusted pure nothrow @nogc
+{
+    import core.memory : pureFree;
+
+    pureFree(statePtr);
+    return XXH_errorcode.XXH_OK;
+}
+
+void XXH64_copyState(XXH64_state_t* dstState, const XXH64_state_t* srcState) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    memcpy(dstState, srcState, (*dstState).sizeof);
+}
+
+XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memset;
+
+    assert(statePtr != null);
+    memset(statePtr, 0, (*statePtr).sizeof);
+    statePtr.v[0] = seed + XXH_PRIME64_1 + XXH_PRIME64_2;
+    statePtr.v[1] = seed + XXH_PRIME64_2;
+    statePtr.v[2] = seed + 0;
+    statePtr.v[3] = seed - XXH_PRIME64_1;
+    return XXH_errorcode.XXH_OK;
+}
+
+XXH_errorcode XXH64_update (XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    if (input==null) {
+        assert(len == 0);
+        return XXH_errorcode.XXH_OK;
+    }
+
+    {   const(xxh_u8)* p = cast(const(xxh_u8) *)input;
+        const xxh_u8* bEnd = p + len;
+
+        state.total_len += len;
+
+        if (state.memsize + len < 32) {  /* fill in tmp buffer */
+            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, len);
+            state.memsize += cast(xxh_u32) len;
+            return XXH_errorcode.XXH_OK;
+        }
+
+        if (state.memsize) {   /* tmp buffer is full */
+            memcpy((cast(xxh_u8*) state.mem64) + state.memsize, input, 32-state.memsize);
+            state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
+            state.v[1] = XXH64_round(state.v[1], XXH_readLE64(&state.mem64[1]));
+            state.v[2] = XXH64_round(state.v[2], XXH_readLE64(&state.mem64[2]));
+            state.v[3] = XXH64_round(state.v[3], XXH_readLE64(&state.mem64[3]));
+            p += 32 - state.memsize;
+            state.memsize = 0;
+        }
+
+        if (p+32 <= bEnd) {
+            const xxh_u8* limit = bEnd - 32;
+
+            do {
+                state.v[0] = XXH64_round(state.v[0], XXH_readLE64(p)); p+=8;
+                state.v[1] = XXH64_round(state.v[1], XXH_readLE64(p)); p+=8;
+                state.v[2] = XXH64_round(state.v[2], XXH_readLE64(p)); p+=8;
+                state.v[3] = XXH64_round(state.v[3], XXH_readLE64(p)); p+=8;
+            } while (p<=limit);
+
+        }
+
+        if (p < bEnd) {
+            memcpy(cast(void*) &state.mem64[0], p, cast(size_t) (bEnd-p));
+            state.memsize = cast(XXH32_hash_t)(bEnd-p);
+        }
+    }
+
+    return XXH_errorcode.XXH_OK;
+}
+
+XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nogc
+{
+    xxh_u64 h64;
+
+    if (state.total_len >= 32) {
+        h64 = XXH_rotl64(state.v[0], 1) + XXH_rotl64(state.v[1], 7) + XXH_rotl64(state.v[2], 12) + XXH_rotl64(state.v[3], 18);
+        h64 = XXH64_mergeRound(h64, state.v[0]);
+        h64 = XXH64_mergeRound(h64, state.v[1]);
+        h64 = XXH64_mergeRound(h64, state.v[2]);
+        h64 = XXH64_mergeRound(h64, state.v[3]);
+    } else {
+        h64  = state.v[2] /*seed*/ + XXH_PRIME64_5;
+    }
+
+    h64 += cast(xxh_u64) state.total_len;
+
+    return XXH64_finalize(h64, cast(const xxh_u8*) state.mem64, cast(size_t) state.total_len, XXH_alignment.XXH_aligned);
+}
+
+void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof);
+    if (XXH_CPU_LITTLE_ENDIAN) hash = XXH_swap64(hash);
+    memcpy(dst, &hash, (*dst).sizeof);
+}
+
+/*! @ingroup XXH64_family */
+XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @trusted pure nothrow @nogc
+{
+    return XXH_readBE64(src);
+}
+
+/* *********************************************************************
+*  XXH3
+*  New generation hash designed for speed on small keys and vectorization
+************************************************************************ */
+
+enum XXH3_SECRET_SIZE_MIN = 136; /// The bare minimum size for a custom secret.
+enum XXH3_SECRET_DEFAULT_SIZE = 192;   /* minimum XXH3_SECRET_SIZE_MIN */
+enum XXH_SECRET_DEFAULT_SIZE = 192;   /* minimum XXH3_SECRET_SIZE_MIN */
+enum XXH3_INTERNALBUFFER_SIZE = 256; ///The size of the internal XXH3 buffer.
+
+static assert (XXH_SECRET_DEFAULT_SIZE >= XXH3_SECRET_SIZE_MIN, "default keyset is not large enough");
+
+/*! Pseudorandom secret taken directly from FARSH. */
+align(64) private immutable xxh_u8[XXH3_SECRET_DEFAULT_SIZE] XXH3_kSecret = [
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
+    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
+    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
+    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
+    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
+    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
+    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
+    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
+    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+];
+
+/*
+ * Downcast + upcast is usually better than masking on older compilers like
+ * GCC 4.2 (especially 32-bit ones), all without affecting newer compilers.
+ *
+ * The other method, (x & 0xFFFFFFFF) * (y & 0xFFFFFFFF), will AND both operands
+ * and perform a full 64x64 multiply -- entirely redundant on 32-bit.
+ */
+private xxh_u64 XXH_mult32to64(xxh_u32 x, xxh_u32 y) @trusted pure nothrow @nogc
+{
+    return (cast(xxh_u64) (x) * cast(xxh_u64) (y));
+} 
+
+/*!
+ * @brief Calculates a 64.128-bit long multiply.
+ *
+ * Uses `__uint128_t` and `_umul128` if available, otherwise uses a scalar
+ * version.
+ *
+ * @param lhs , rhs The 64-bit integers to be multiplied
+ * @return The 128-bit result represented in an @ref XXH128_hash_t.
+ */
+private XXH128_hash_t
+XXH_mult64to128(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+{
+    static if (is(ucent))
+    {
+        import std.int128;
+        //alias uint128_t = Int128;
+
+        const uint128_t product = cast(uint128_t_)lhs * cast(uint128_t_)rhs;
+        XXH128_hash_t r128;
+        // r128.low64  = cast(xxh_u64) (product);
+        // r128.high64 = cast(xxh_u64) (product >> 64);
+        r128.low64  = product.data.lo;
+        r128.high64 = product.data.hi;
+    } else {
+        /* First calculate all of the cross products. */
+        const xxh_u64 lo_lo = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs & 0xFFFFFFFF);
+        const xxh_u64 hi_lo = XXH_mult32to64(lhs >> 32,        rhs & 0xFFFFFFFF);
+        const xxh_u64 lo_hi = XXH_mult32to64(lhs & 0xFFFFFFFF, rhs >> 32);
+        const xxh_u64 hi_hi = XXH_mult32to64(lhs >> 32,        rhs >> 32);
+
+        /* Now add the products together. These will never overflow. */
+        const xxh_u64 cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
+        const xxh_u64 upper = (hi_lo >> 32) + (cross >> 32)        + hi_hi;
+        const xxh_u64 lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
+
+        XXH128_hash_t r128;
+        r128.low64  = lower;
+        r128.high64 = upper;
+
+    }
+    return r128;
+}
+
+/*!
+ * @brief Calculates a 64-bit to 128-bit multiply, then XOR folds it.
+ *
+ * The reason for the separate function is to prevent passing too many structs
+ * around by value. This will hopefully inline the multiply, but we don't force it.
+ *
+ * @param lhs , rhs The 64-bit integers to multiply
+ * @return The low 64 bits of the product XOR'd by the high 64 bits.
+ * @see XXH_mult64to128()
+ */
+private xxh_u64
+XXH3_mul128_fold64(xxh_u64 lhs, xxh_u64 rhs) @trusted pure nothrow @nogc
+{
+    XXH128_hash_t product = XXH_mult64to128(lhs, rhs);
+    return product.low64 ^ product.high64;
+}
+
+/*! Seems to produce slightly better code on GCC for some reason. */
+private xxh_u64 XXH_xorshift64(xxh_u64 v64, int shift) @trusted pure nothrow @nogc
+{
+    assert(0 <= shift && shift < 64);
+    return v64 ^ (v64 >> shift);
+}
+
+/*
+ * This is a fast avalanche stage,
+ * suitable when input bits are already partially mixed
+ */
+private XXH64_hash_t XXH3_avalanche(xxh_u64 h64) @trusted pure nothrow @nogc
+{
+    h64 = XXH_xorshift64(h64, 37);
+    h64 *= 0x165667919E3779F9;
+    h64 = XXH_xorshift64(h64, 32);
+    return h64;
+}
+
+/*
+ * This is a stronger avalanche,
+ * inspired by Pelle Evensen's rrmxmx
+ * preferable when input has not been previously mixed
+ */
+static XXH64_hash_t XXH3_rrmxmx(xxh_u64 h64, xxh_u64 len) @trusted pure nothrow @nogc
+{
+    /* this mix is inspired by Pelle Evensen's rrmxmx */
+    h64 ^= XXH_rotl64(h64, 49) ^ XXH_rotl64(h64, 24);
+    h64 *= 0x9FB21C651E98DF25;
+    h64 ^= (h64 >> 35) + len ;
+    h64 *= 0x9FB21C651E98DF25;
+    return XXH_xorshift64(h64, 28);
+}
+
+/* ==========================================
+ * Short keys
+ * ==========================================
+ * One of the shortcomings of XXH32 and XXH64 was that their performance was
+ * sub-optimal on short lengths. It used an iterative algorithm which strongly
+ * favored lengths that were a multiple of 4 or 8.
+ *
+ * Instead of iterating over individual inputs, we use a set of single shot
+ * functions which piece together a range of lengths and operate in constant time.
+ *
+ * Additionally, the number of multiplies has been significantly reduced. This
+ * reduces latency, especially when emulating 64-bit multiplies on 32-bit.
+ *
+ * Depending on the platform, this may or may not be faster than XXH32, but it
+ * is almost guaranteed to be faster than XXH64.
+ */
+
+/*
+ * At very short lengths, there isn't enough input to fully hide secrets, or use
+ * the entire secret.
+ *
+ * There is also only a limited amount of mixing we can do before significantly
+ * impacting performance.
+ *
+ * Therefore, we use different sections of the secret and always mix two secret
+ * samples with an XOR. This should have no effect on performance on the
+ * seedless or withSeed variants because everything _should_ be constant folded
+ * by modern compilers.
+ *
+ * The XOR mixing hides individual parts of the secret and increases entropy.
+ *
+ * This adds an extra layer of strength for custom secrets.
+ */
+private XXH64_hash_t
+XXH3_len_1to3_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
+{
+    assert(input != null);
+    assert(1 <= len && len <= 3);
+    assert(secret != null);
+    /*
+     * len = 1: combined = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combined = { input[1], 0x02, input[0], input[1] }
+     * len = 3: combined = { input[2], 0x03, input[0], input[1] }
+     */
+    {   const xxh_u8  c1 = input[0];
+        const xxh_u8  c2 = input[len >> 1];
+        const xxh_u8  c3 = input[len - 1];
+        const xxh_u32 combined = (cast(xxh_u32)c1 << 16) | (cast(xxh_u32)c2  << 24)
+                               | (cast(xxh_u32)c3 <<  0) | (cast(xxh_u32)len << 8);
+        const xxh_u64 bitflip = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
+        const xxh_u64 keyed = cast(xxh_u64)combined ^ bitflip;
+        return XXH64_avalanche(keyed);
+    }
+}
+
+private XXH64_hash_t  
+XXH3_len_4to8_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(input != null);
+    assert(secret != null);
+    assert(4 <= len && len <= 8);
+    seed ^= cast(xxh_u64)XXH_swap32(cast(xxh_u32)seed) << 32;
+    {   const xxh_u32 input1 = XXH_readLE32(input);
+        const xxh_u32 input2 = XXH_readLE32(input + len - 4);
+        const xxh_u64 bitflip = (XXH_readLE64(secret+8) ^ XXH_readLE64(secret+16)) - seed;
+        const xxh_u64 input64 = input2 + ((cast(xxh_u64)input1) << 32);
+        const xxh_u64 keyed = input64 ^ bitflip;
+        return XXH3_rrmxmx(keyed, len);
+    }
+}
+
+private XXH64_hash_t
+XXH3_len_9to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(input != null);
+    assert(secret != null);
+    assert(9 <= len && len <= 16);
+    {   const xxh_u64 bitflip1 = (XXH_readLE64(secret+24) ^ XXH_readLE64(secret+32)) + seed;
+        const xxh_u64 bitflip2 = (XXH_readLE64(secret+40) ^ XXH_readLE64(secret+48)) - seed;
+        const xxh_u64 input_lo = XXH_readLE64(input)           ^ bitflip1;
+        const xxh_u64 input_hi = XXH_readLE64(input + len - 8) ^ bitflip2;
+        const xxh_u64 acc = len
+                          + XXH_swap64(input_lo) + input_hi
+                          + XXH3_mul128_fold64(input_lo, input_hi);
+        return XXH3_avalanche(acc);
+    }
+}
+
+private bool XXH_likely(bool exp) @trusted pure nothrow @nogc { return exp; }
+private bool XXH_unlikely(bool exp) @trusted pure nothrow @nogc { return exp; }
+
+private XXH64_hash_t 
+XXH3_len_0to16_64b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(len <= 16);
+    {   if (XXH_likely(len >  8)) return XXH3_len_9to16_64b(input, len, secret, seed);
+        if (XXH_likely(len >= 4)) return XXH3_len_4to8_64b(input, len, secret, seed);
+        if (len) return XXH3_len_1to3_64b(input, len, secret, seed);
+        return XXH64_avalanche(seed ^ (XXH_readLE64(secret+56) ^ XXH_readLE64(secret+64)));
+    }
+}
+
+/*
+ * DISCLAIMER: There are known *seed-dependent* multicollisions here due to
+ * multiplication by zero, affecting hashes of lengths 17 to 240.
+ *
+ * However, they are very unlikely.
+ *
+ * Keep this in mind when using the unseeded XXH3_64bits() variant: As with all
+ * unseeded non-cryptographic hashes, it does not attempt to defend itself
+ * against specially crafted inputs, only random inputs.
+ *
+ * Compared to classic UMAC where a 1 in 2^31 chance of 4 consecutive bytes
+ * cancelling out the secret is taken an arbitrary number of times (addressed
+ * in XXH3_accumulate_512), this collision is very unlikely with random inputs
+ * and/or proper seeding:
+ *
+ * This only has a 1 in 2^63 chance of 8 consecutive bytes cancelling out, in a
+ * function that is only called up to 16 times per hash with up to 240 bytes of
+ * input.
+ *
+ * This is not too bad for a non-cryptographic hash function, especially with
+ * only 64 bit outputs.
+ *
+ * The 128-bit variant (which trades some speed for strength) is NOT affected
+ * by this, although it is always a good idea to use a proper seed if you care
+ * about strength.
+ */
+private xxh_u64 XXH3_mix16B(const(xxh_u8)* input,
+                                     const(xxh_u8)* secret, xxh_u64 seed64)
+@trusted pure nothrow @nogc
+{
+    {   const xxh_u64 input_lo = XXH_readLE64(input);
+        const xxh_u64 input_hi = XXH_readLE64(input+8);
+        return XXH3_mul128_fold64(
+            input_lo ^ (XXH_readLE64(secret)   + seed64),
+            input_hi ^ (XXH_readLE64(secret+8) - seed64)
+        );
+    }
+}
+
+/* For mid range keys, XXH3 uses a Mum-hash variant. */
+private XXH64_hash_t
+XXH3_len_17to128_64b(const(xxh_u8)* input, size_t len,
+                     const(xxh_u8)* secret, size_t secretSize,
+                     XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
+    assert(16 < len && len <= 128);
+
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
+        if (len > 32) {
+            if (len > 64) {
+                if (len > 96) {
+                    acc += XXH3_mix16B(input+48, secret+96, seed);
+                    acc += XXH3_mix16B(input+len-64, secret+112, seed);
+                }
+                acc += XXH3_mix16B(input+32, secret+64, seed);
+                acc += XXH3_mix16B(input+len-48, secret+80, seed);
+            }
+            acc += XXH3_mix16B(input+16, secret+32, seed);
+            acc += XXH3_mix16B(input+len-32, secret+48, seed);
+        }
+        acc += XXH3_mix16B(input+0, secret+0, seed);
+        acc += XXH3_mix16B(input+len-16, secret+16, seed);
+
+        return XXH3_avalanche(acc);
+    }
+}
+
+enum XXH3_MIDSIZE_MAX = 240;
+enum XXH3_MIDSIZE_STARTOFFSET = 3;
+enum XXH3_MIDSIZE_LASTOFFSET  = 17;
+
+private XXH64_hash_t
+XXH3_len_129to240_64b(const(xxh_u8)* input, size_t len,
+                      const(xxh_u8)* secret, size_t secretSize,
+                      XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
+    assert(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+
+    {   xxh_u64 acc = len * XXH_PRIME64_1;
+        const int nbRounds = cast(int) len / 16;
+        int i;
+        for (i=0; i<8; i++) {
+            acc += XXH3_mix16B(input+(16*i), secret+(16*i), seed);
+        }
+        acc = XXH3_avalanche(acc);
+        assert(nbRounds >= 8);
+        for (i=8 ; i < nbRounds; i++) {
+            acc += XXH3_mix16B(input+(16*i), secret+(16*(i-8)) + XXH3_MIDSIZE_STARTOFFSET, seed);
+        }
+        /* last bytes */
+        acc += XXH3_mix16B(input + len - 16, secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+        return XXH3_avalanche(acc);
+    }
+}
+
+/* =======     Long Keys     ======= */
+
+enum XXH_STRIPE_LEN = 64;
+enum XXH_SECRET_CONSUME_RATE = 8;   /* nb of secret bytes consumed at each accumulation */
+enum XXH_ACC_NB = (XXH_STRIPE_LEN / (xxh_u64).sizeof);
+
+
+private void XXH_writeLE64(void* dst, xxh_u64 v64)
+@trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+    if (!XXH_CPU_LITTLE_ENDIAN) v64 = XXH_swap64(v64);
+    memcpy(dst, &v64, (v64).sizeof);
+}
+
+alias xxh_i64 = int64_t;
+
+/* scalar variants - universal */
+
+enum XXH_ACC_ALIGN = 8;
+
+/*!
+ * @internal
+ * @brief Scalar round for @ref XXH3_accumulate_512_scalar().
+ *
+ * This is extracted to its own function because the NEON path uses a combination
+ * of NEON and scalar.
+ */
+private void
+XXH3_scalarRound(void* acc,
+                 const(void) * input,
+                 const(void) * secret,
+                 size_t lane)
+@trusted pure nothrow @nogc
+{
+    xxh_u64* xacc = cast(xxh_u64*) acc;
+    xxh_u8 * xinput  = cast(xxh_u8 *) input;
+    xxh_u8 * xsecret = cast(xxh_u8 *) secret;
+    assert(lane < XXH_ACC_NB);
+    assert((cast(size_t)acc & (XXH_ACC_ALIGN-1)) == 0);
+    {
+        const xxh_u64 data_val = XXH_readLE64(xinput + lane * 8);
+        const xxh_u64 data_key = data_val ^ XXH_readLE64(xsecret + lane * 8);
+        xacc[lane ^ 1] += data_val; /* swap adjacent lanes */
+        xacc[lane] += XXH_mult32to64(data_key & 0xFFFFFFFF, data_key >> 32);
+    }
+}
+
+/*!
+ * @internal
+ * @brief Processes a 64 byte block of data using the scalar path.
+ */
+private void
+XXH3_accumulate_512_scalar(void* acc,
+                     const(void)* input,
+                     const(void)* secret)
+@trusted pure nothrow @nogc
+{
+    size_t i;
+    for (i=0; i < XXH_ACC_NB; i++) {
+        XXH3_scalarRound(acc, input, secret, i);
+    }
+}
+
+/*!
+ * @internal
+ * @brief Scalar scramble step for @ref XXH3_scrambleAcc_scalar().
+ *
+ * This is extracted to its own function because the NEON path uses a combination
+ * of NEON and scalar.
+ */
+private void
+XXH3_scalarScrambleRound(void*  acc,
+                         const(void)*  secret,
+                         size_t lane)
+@trusted pure nothrow @nogc
+{
+    xxh_u64* xacc = cast(xxh_u64*) acc;   /* presumed aligned */
+    const xxh_u8* xsecret = cast(const xxh_u8*) secret;   /* no alignment restriction */
+    assert(((cast(size_t)acc) & (XXH_ACC_ALIGN-1)) == 0);
+    assert(lane < XXH_ACC_NB);
+    {
+        const xxh_u64 key64 = XXH_readLE64(xsecret + lane * 8);
+        xxh_u64 acc64 = xacc[lane];
+        acc64 = XXH_xorshift64(acc64, 47);
+        acc64 ^= key64;
+        acc64 *= XXH_PRIME32_1;
+        xacc[lane] = acc64;
+    }
+}
+
+/*!
+ * @internal
+ * @brief Scrambles the accumulators after a large chunk has been read
+ */
+private void
+XXH3_scrambleAcc_scalar(void* acc, const(void)* secret)
+@trusted pure nothrow @nogc
+{
+    size_t i;
+    for (i=0; i < XXH_ACC_NB; i++) {
+        XXH3_scalarScrambleRound(acc, secret, i);
+    }
+}
+
+private void
+XXH3_initCustomSecret_scalar(void* customSecret, xxh_u64 seed64)
+@trusted pure nothrow @nogc
+{
+    /*
+     * We need a separate pointer for the hack below,
+     * which requires a non-const pointer.
+     * Any decent compiler will optimize this out otherwise.
+     */
+    const xxh_u8* kSecretPtr = cast(xxh_u8*)XXH3_kSecret;
+    static assert((XXH_SECRET_DEFAULT_SIZE & 15) == 0);
+
+    /*
+     * Note: in debug mode, this overrides the asm optimization
+     * and Clang will emit MOVK chains again.
+     */
+    //assert(kSecretPtr == XXH3_kSecret);
+
+    {   const int nbRounds = XXH_SECRET_DEFAULT_SIZE / 16;
+        int i;
+        for (i=0; i < nbRounds; i++) {
+            /*
+             * The asm hack causes Clang to assume that kSecretPtr aliases with
+             * customSecret, and on aarch64, this prevented LDP from merging two
+             * loads together for free. Putting the loads together before the stores
+             * properly generates LDP.
+             */
+            xxh_u64 lo = XXH_readLE64(kSecretPtr + 16*i)     + seed64;
+            xxh_u64 hi = XXH_readLE64(kSecretPtr + 16*i + 8) - seed64;
+            XXH_writeLE64(cast(xxh_u8*)customSecret + 16*i,     lo);
+            XXH_writeLE64(cast(xxh_u8*)customSecret + 16*i + 8, hi);
+    }   }
+}
+
+alias XXH3_f_accumulate_512 = void function(void* , const(void)*,  const(void)*) @trusted pure nothrow @nogc;
+alias XXH3_f_scrambleAcc = void function(void* , const void*)@trusted pure nothrow @nogc;
+alias XXH3_f_initCustomSecret = void function(void* , xxh_u64)@trusted pure nothrow @nogc;
+
+immutable XXH3_f_accumulate_512 XXH3_accumulate_512 = &XXH3_accumulate_512_scalar;
+immutable XXH3_f_scrambleAcc XXH3_scrambleAcc    = &XXH3_scrambleAcc_scalar;
+immutable XXH3_f_initCustomSecret XXH3_initCustomSecret = &XXH3_initCustomSecret_scalar;
+
+enum XXH_PREFETCH_DIST = 384;
+private void XXH_PREFETCH(const xxh_u8* ptr) 
+@trusted pure nothrow @nogc
+{ cast(void)(ptr); }
+
+/*
+ * XXH3_accumulate()
+ * Loops over XXH3_accumulate_512().
+ * Assumption: nbStripes will not overflow the secret size
+ */
+private void
+XXH3_accumulate(     xxh_u64* acc,
+                const xxh_u8* input,
+                const xxh_u8* secret,
+                      size_t nbStripes,
+                      XXH3_f_accumulate_512 f_acc512)
+@trusted pure nothrow @nogc
+{
+    size_t n;
+    for (n = 0; n < nbStripes; n++ ) {
+        const xxh_u8* in_ = input + n*XXH_STRIPE_LEN;
+        XXH_PREFETCH(in_ + XXH_PREFETCH_DIST);
+        f_acc512(acc,
+                 in_,
+                 secret + n*XXH_SECRET_CONSUME_RATE);
+    }
+}
+
+private void
+XXH3_hashLong_internal_loop(xxh_u64*  acc,
+                      const xxh_u8*  input, size_t len,
+                      const xxh_u8*  secret, size_t secretSize,
+                            XXH3_f_accumulate_512 f_acc512,
+                            XXH3_f_scrambleAcc f_scramble)
+@trusted pure nothrow @nogc
+{
+    const size_t nbStripesPerBlock = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
+    const size_t block_len = XXH_STRIPE_LEN * nbStripesPerBlock;
+    const size_t nb_blocks = (len - 1) / block_len;
+
+    size_t n;
+
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN);
+
+    for (n = 0; n < nb_blocks; n++) {
+        XXH3_accumulate(acc, input + n*block_len, secret, nbStripesPerBlock, f_acc512);
+        f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
+    }
+
+    /* last partial block */
+    assert(len > XXH_STRIPE_LEN);
+    {   const size_t nbStripes = ((len - 1) - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
+        assert(nbStripes <= (secretSize / XXH_SECRET_CONSUME_RATE));
+        XXH3_accumulate(acc, input + nb_blocks*block_len, secret, nbStripes, f_acc512);
+
+        /* last stripe */
+        {   const xxh_u8* p = input + len - XXH_STRIPE_LEN;
+            f_acc512(acc, p, secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
+    }   }
+}
+
+enum XXH_SECRET_LASTACC_START = 7;  /* not aligned on 8, last secret is different from acc & scrambler */
+
+private xxh_u64
+XXH3_mix2Accs(const(xxh_u64)* acc, const(xxh_u8)* secret)
+@trusted pure nothrow @nogc
+{
+    return XXH3_mul128_fold64(
+               acc[0] ^ XXH_readLE64(secret),
+               acc[1] ^ XXH_readLE64(secret+8) );
+}
+
+private XXH64_hash_t
+XXH3_mergeAccs(const(xxh_u64)* acc, const(xxh_u8)* secret, xxh_u64 start)
+@trusted pure nothrow @nogc
+{
+    xxh_u64 result64 = start;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++) {
+        result64 += XXH3_mix2Accs(acc+2*i, secret + 16*i);
+    }
+
+    return XXH3_avalanche(result64);
+}
+
+enum XXH3_INIT_ACC = [ XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, 
+                        XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 ];
+
+private XXH64_hash_t
+XXH3_hashLong_64b_internal(const(void)*  input, size_t len,
+                           const(void)*  secret, size_t secretSize,
+                           XXH3_f_accumulate_512 f_acc512,
+                           XXH3_f_scrambleAcc f_scramble)
+@trusted pure nothrow @nogc
+{
+    align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(&acc[0], cast(const(xxh_u8)*) input, len, cast(const(xxh_u8)*) secret, secretSize, f_acc512, f_scramble);
+
+    /* converge into final hash */
+    static assert((acc).sizeof == 64);
+    /* do not align on 8, so that the secret is different from the accumulator */
+    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
+    return XXH3_mergeAccs(&acc[0], cast(const(xxh_u8)*) secret + XXH_SECRET_MERGEACCS_START, cast(xxh_u64) len * XXH_PRIME64_1);
+}
+
+enum XXH_SECRET_MERGEACCS_START = 11;
+
+/*
+ * It's important for performance to transmit secret's size (when it's static)
+ * so that the compiler can properly optimize the vectorized loop.
+ * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
+ */
+private XXH64_hash_t
+XXH3_hashLong_64b_withSecret(const(void)* input, size_t len,
+                             XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)seed64;
+    return XXH3_hashLong_64b_internal(input, len, secret, secretLen, XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+/*
+ * It's preferable for performance that XXH3_hashLong is not inlined,
+ * as it results in a smaller function for small data, easier to the instruction cache.
+ * Note that inside this no_inline function, we do inline the internal loop,
+ * and provide a statically defined secret size to allow optimization of vector loop.
+ */
+private XXH64_hash_t
+XXH3_hashLong_64b_default(const(void)* input, size_t len,
+                          XXH64_hash_t seed64, const(xxh_u8)* secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)seed64; cast(void)secret; cast(void)secretLen;
+    return XXH3_hashLong_64b_internal(input, len, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+enum XXH_SEC_ALIGN = 8;
+
+/*
+ * XXH3_hashLong_64b_withSeed():
+ * Generate a custom key based on alteration of default XXH3_kSecret with the seed,
+ * and then use this key for long mode hashing.
+ *
+ * This operation is decently fast but nonetheless costs a little bit of time.
+ * Try to avoid it whenever possible (typically when seed==0).
+ *
+ * It's important for performance that XXH3_hashLong is not inlined. Not sure
+ * why (uop cache maybe?), but the difference is large and easily measurable.
+ */
+private XXH64_hash_t
+XXH3_hashLong_64b_withSeed_internal(const(void)* input, size_t len,
+                                    XXH64_hash_t seed,
+                                    XXH3_f_accumulate_512 f_acc512,
+                                    XXH3_f_scrambleAcc f_scramble,
+                                    XXH3_f_initCustomSecret f_initSec)
+@trusted pure nothrow @nogc
+{
+//#if XXH_SIZE_OPT <= 0
+    if (seed == 0)
+        return XXH3_hashLong_64b_internal(input, len,
+                                          &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
+                                          f_acc512, f_scramble);
+//#endif
+    {   align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        f_initSec(&secret[0], seed);
+        return XXH3_hashLong_64b_internal(input, len, &secret[0], (secret).sizeof,
+                                          f_acc512, f_scramble);
+    }
+}
+
+/*
+ * It's important for performance that XXH3_hashLong is not inlined.
+ */
+private XXH64_hash_t
+XXH3_hashLong_64b_withSeed(const(void)* input, size_t len,
+                           XXH64_hash_t seed, const(xxh_u8)* secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)secret; cast(void)secretLen;
+    return XXH3_hashLong_64b_withSeed_internal(input, len, seed,
+                XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+}
+
+alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)* , size_t,
+                                          XXH64_hash_t, const(xxh_u8)* , size_t) @trusted pure nothrow @nogc;
+
+private XXH64_hash_t
+XXH3_64bits_internal(const(void)*  input, size_t len,
+                     XXH64_hash_t seed64, const(void)* secret, size_t secretLen,
+                     XXH3_hashLong64_f f_hashLong)
+@trusted pure nothrow @nogc
+{
+    assert(secretLen >= XXH3_SECRET_SIZE_MIN);
+    /*
+     * If an action is to be taken if `secretLen` condition is not respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash.
+     * Also, note that function signature doesn't offer room to return an error.
+     */
+    if (len <= 16)
+        return XXH3_len_0to16_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, seed64);
+    if (len <= 128)
+        return XXH3_len_17to128_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, secretLen, seed64);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_64b(cast(const(xxh_u8)*)input, len, cast(const(xxh_u8)*)secret, secretLen, seed64);
+    return f_hashLong(input, len, seed64, cast(const(xxh_u8)*)secret, secretLen);
+}
+
+/* ===   Public entry point   === */
+
+/*! @ingroup XXH3_family */
+XXH64_hash_t XXH3_64bits(const(void)* input, size_t length)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_internal(input, length, 0, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_default);
+}
+
+/*! @ingroup XXH3_family */
+XXH64_hash_t
+XXH3_64bits_withSecret(const(void)* input, size_t length, const(void)* secret, size_t secretSize)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_internal(input, length, 0, secret, secretSize, &XXH3_hashLong_64b_withSecret);
+}
+
+/*! @ingroup XXH3_family */
+XXH64_hash_t
+XXH3_64bits_withSeed(const(void)* input, size_t length, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, &XXH3_hashLong_64b_withSeed);
+}
+
+XXH64_hash_t
+XXH3_64bits_withSecretandSeed(const(void)* input, size_t length, const(void)* secret, size_t secretSize, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    if (length <= XXH3_MIDSIZE_MAX)
+        return XXH3_64bits_internal(input, length, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, null);
+    return XXH3_hashLong_64b_withSecret(input, length, seed, cast(const(xxh_u8)*)secret, secretSize);
+}
+
+/* ===   XXH3 streaming   === */
+/*
+ * Malloc's a pointer that is always aligned to align.
+ *
+ * This must be freed with `XXH_alignedFree()`.
+ *
+ * malloc typically guarantees 16 byte alignment on 64-bit systems and 8 byte
+ * alignment on 32-bit. This isn't enough for the 32 byte aligned loads in AVX2
+ * or on 32-bit, the 16 byte aligned loads in SSE2 and NEON.
+ *
+ * This underalignment previously caused a rather obvious crash which went
+ * completely unnoticed due to XXH3_createState() not actually being tested.
+ * Credit to RedSpah for noticing this bug.
+ *
+ * The alignment is done manually: Functions like posix_memalign or _mm_malloc
+ * are avoided: To maintain portability, we would have to write a fallback
+ * like this anyways, and besides, testing for the existence of library
+ * functions without relying on external build tools is impossible.
+ *
+ * The method is simple: Overallocate, manually align, and store the offset
+ * to the original behind the returned pointer.
+ *
+ * Align must be a power of 2 and 8 <= align <= 128.
+ */
+private void* XXH_alignedMalloc(size_t s, size_t align_)
+@trusted nothrow @nogc
+{
+    import core.stdc.stdlib : malloc;
+
+    assert(align_ <= 128 && align_ >= 8); /* range check */
+    assert((align_ & (align_-1)) == 0);   /* power of 2 */
+    assert(s != 0 && s < (s + align_));  /* empty/overflow */
+    {   /* Overallocate to make room for manual realignment and an offset byte */
+        xxh_u8* base = cast(xxh_u8*)malloc(s + align_);
+        if (base != null) {
+            /*
+             * Get the offset needed to align this pointer.
+             *
+             * Even if the returned pointer is aligned, there will always be
+             * at least one byte to store the offset to the original pointer.
+             */
+            size_t offset = align_ - (cast(size_t)base & (align_ - 1)); /* base % align */
+            /* Add the offset for the now-aligned pointer */
+            xxh_u8* ptr = base + offset;
+
+            assert(cast(size_t)ptr % align_ == 0);
+
+            /* Store the offset immediately before the returned pointer. */
+            ptr[-1] = cast(xxh_u8)offset;
+            return ptr;
+        }
+        return null;
+    }
+}
+/*
+ * Frees an aligned pointer allocated by XXH_alignedMalloc(). Don't pass
+ * normal malloc'd pointers, XXH_alignedMalloc has a specific data layout.
+ */
+private void XXH_alignedFree(void* p)
+@trusted nothrow @nogc
+{
+    import core.stdc.stdlib : free;
+
+    if (p != null) {
+        xxh_u8* ptr = cast(xxh_u8*)p;
+        /* Get the offset byte we added in XXH_malloc. */
+        xxh_u8 offset = ptr[-1];
+        /* Free the original malloc'd pointer */
+        xxh_u8* base = ptr - offset;
+        free(base);
+    }
+}
+
+private void XXH3_INITSTATE(XXH3_state_t* XXH3_state_ptr) @trusted nothrow @nogc
+{ (XXH3_state_ptr).seed = 0; }
+
+/*! @ingroup XXH3_family */
+XXH3_state_t* XXH3_createState()
+@trusted nothrow @nogc
+{
+    XXH3_state_t* state = cast(XXH3_state_t*)XXH_alignedMalloc((XXH3_state_t).sizeof, 64);
+    if (state==null) return null;
+    XXH3_INITSTATE(state);
+    return state;
+}
+
+/*! @ingroup XXH3_family */
+XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr)
+@trusted nothrow @nogc
+{
+    XXH_alignedFree(statePtr);
+    return XXH_errorcode.XXH_OK;
+}
+
+void
+XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state)
+@trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+    memcpy(dst_state, src_state, (*dst_state).sizeof);
+}
+
+private void
+XXH3_reset_internal(XXH3_state_t* statePtr,
+                    XXH64_hash_t seed,
+                    const void* secret, size_t secretSize)
+@trusted pure nothrow @nogc
+{
+    import core.stdc.string : memset;
+
+    const size_t initStart = XXH3_state_t.bufferedSize.offsetof;
+    const size_t initLength = XXH3_state_t.nbStripesPerBlock.offsetof - initStart;
+    assert(XXH3_state_t.nbStripesPerBlock.offsetof > initStart);
+    assert(statePtr != null);
+    /* set members from bufferedSize to nbStripesPerBlock (excluded) to 0 */
+    memset(cast(char*) statePtr + initStart, 0, initLength);
+    statePtr.acc[0] = XXH_PRIME32_3;
+    statePtr.acc[1] = XXH_PRIME64_1;
+    statePtr.acc[2] = XXH_PRIME64_2;
+    statePtr.acc[3] = XXH_PRIME64_3;
+    statePtr.acc[4] = XXH_PRIME64_4;
+    statePtr.acc[5] = XXH_PRIME32_2;
+    statePtr.acc[6] = XXH_PRIME64_5;
+    statePtr.acc[7] = XXH_PRIME32_1;
+    statePtr.seed = seed;
+    statePtr.useSeed = (seed != 0);
+    statePtr.extSecret = cast(const(ubyte)*) secret;
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN);
+    statePtr.secretLimit = secretSize - XXH_STRIPE_LEN;
+    statePtr.nbStripesPerBlock = statePtr.secretLimit / XXH_SECRET_CONSUME_RATE;
+}
+
+XXH_errorcode
+XXH3_64bits_reset(XXH3_state_t* statePtr)
+@trusted pure nothrow @nogc
+{
+    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    XXH3_reset_internal(statePtr, 0, &XXH3_kSecret[0], XXH_SECRET_DEFAULT_SIZE);
+    return XXH_errorcode.XXH_OK;
+}
+XXH_errorcode
+XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+@trusted pure nothrow @nogc
+{
+    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    XXH3_reset_internal(statePtr, 0, secret, secretSize);
+    if (secret == null) return  XXH_errorcode.XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return  XXH_errorcode.XXH_ERROR;
+    return XXH_errorcode.XXH_OK;
+}
+XXH_errorcode
+XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    if (seed==0) return XXH3_64bits_reset(statePtr);
+    if ((seed != statePtr.seed) || (statePtr.extSecret != null))
+        XXH3_initCustomSecret(&statePtr.customSecret[0], seed);
+    XXH3_reset_internal(statePtr, seed, null, XXH_SECRET_DEFAULT_SIZE);
+    return XXH_errorcode.XXH_OK;
+}
+XXH_errorcode
+XXH3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr, const(void)* secret, size_t secretSize, XXH64_hash_t seed64)
+@trusted pure nothrow @nogc
+{
+    if (statePtr == null) return XXH_errorcode.XXH_ERROR;
+    if (secret == null) return XXH_errorcode.XXH_ERROR;
+    if (secretSize < XXH3_SECRET_SIZE_MIN) return XXH_errorcode.XXH_ERROR;
+    XXH3_reset_internal(statePtr, seed64, secret, secretSize);
+    statePtr.useSeed = 1; /* always, even if seed64==0 */
+    return XXH_errorcode.XXH_OK;
+}
+
+/* Note : when XXH3_consumeStripes() is invoked,
+ * there must be a guarantee that at least one more byte must be consumed from input
+ * so that the function can blindly consume all stripes using the "normal" secret segment */
+private void
+XXH3_consumeStripes(xxh_u64*  acc,
+                    size_t*  nbStripesSoFarPtr, size_t nbStripesPerBlock,
+                    const xxh_u8*  input, size_t nbStripes,
+                    const xxh_u8*  secret, size_t secretLimit,
+                    XXH3_f_accumulate_512 f_acc512,
+                    XXH3_f_scrambleAcc f_scramble)
+@trusted pure nothrow @nogc
+{
+    assert(nbStripes <= nbStripesPerBlock);  /* can handle max 1 scramble per invocation */
+    assert(*nbStripesSoFarPtr < nbStripesPerBlock);
+    if (nbStripesPerBlock - *nbStripesSoFarPtr <= nbStripes) {
+        /* need a scrambling operation */
+        const size_t nbStripesToEndofBlock = nbStripesPerBlock - *nbStripesSoFarPtr;
+        const size_t nbStripesAfterBlock = nbStripes - nbStripesToEndofBlock;
+        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripesToEndofBlock, f_acc512);
+        f_scramble(acc, secret + secretLimit);
+        XXH3_accumulate(acc, input + nbStripesToEndofBlock * XXH_STRIPE_LEN, secret, nbStripesAfterBlock, f_acc512);
+        *nbStripesSoFarPtr = nbStripesAfterBlock;
+    } else {
+        XXH3_accumulate(acc, input, secret + nbStripesSoFarPtr[0] * XXH_SECRET_CONSUME_RATE, nbStripes, f_acc512);
+        *nbStripesSoFarPtr += nbStripes;
+    }
+}
+
+enum XXH3_STREAM_USE_STACK = 1;
+/*
+ * Both XXH3_64bits_update and XXH3_128bits_update use this routine.
+ */
+private XXH_errorcode
+XXH3_update(XXH3_state_t* state,
+            const(xxh_u8)*  input, size_t len,
+            XXH3_f_accumulate_512 f_acc512,
+            XXH3_f_scrambleAcc f_scramble)
+@trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    if (input==null) {
+        assert(len == 0);
+        return XXH_errorcode.XXH_OK;
+    }
+
+    assert(state != null);
+    {   const xxh_u8* bEnd = input + len;
+        const(ubyte)* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
+        static if (XXH3_STREAM_USE_STACK >= 1) {
+            /* For some reason, gcc and MSVC seem to suffer greatly
+            * when operating accumulators directly into state.
+            * Operating into stack space seems to enable proper optimization.
+            * clang, on the other hand, doesn't seem to need this trick */
+            align(XXH_ACC_ALIGN) xxh_u64[8] acc; memcpy(&acc[0], &state.acc[0], (acc).sizeof);
+        } else {
+            xxh_u64* acc = state.acc;
+        }
+        state.totalLen += len;
+        assert(state.bufferedSize <= XXH3_INTERNALBUFFER_SIZE);
+
+        /* small input : just fill in tmp buffer */
+        if (state.bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE) {
+            memcpy(&state.buffer[0] + state.bufferedSize, input, len);
+            state.bufferedSize += cast(XXH32_hash_t)len;
+            return XXH_errorcode.XXH_OK;
+        }
+
+        /* total input is now > XXH3_INTERNALBUFFER_SIZE */
+        enum XXH3_INTERNALBUFFER_STRIPES = (XXH3_INTERNALBUFFER_SIZE / XXH_STRIPE_LEN);
+        static assert(XXH3_INTERNALBUFFER_SIZE % XXH_STRIPE_LEN == 0);   /* clean multiple */
+
+        /*
+         * Internal buffer is partially filled (always, except at beginning)
+         * Complete it, then consume it.
+         */
+        if (state.bufferedSize) {
+            const size_t loadSize = XXH3_INTERNALBUFFER_SIZE - state.bufferedSize;
+            memcpy(&state.buffer[0] + state.bufferedSize, input, loadSize);
+            input += loadSize;
+            XXH3_consumeStripes(&acc[0],
+                               &state.nbStripesSoFar, state.nbStripesPerBlock,
+                                &state.buffer[0], XXH3_INTERNALBUFFER_STRIPES,
+                                secret, state.secretLimit,
+                                f_acc512, f_scramble);
+            state.bufferedSize = 0;
+        }
+        assert(input < bEnd);
+
+        /* large input to consume : ingest per full block */
+        if (cast(size_t) (bEnd - input) > state.nbStripesPerBlock * XXH_STRIPE_LEN) {
+            size_t nbStripes = cast(size_t) (bEnd - 1 - input) / XXH_STRIPE_LEN;
+            assert(state.nbStripesPerBlock >= state.nbStripesSoFar);
+            /* join to current block's end */
+            {   const size_t nbStripesToEnd = state.nbStripesPerBlock - state.nbStripesSoFar;
+                assert(nbStripesToEnd <= nbStripes);
+                XXH3_accumulate(&acc[0], input, secret + state.nbStripesSoFar * XXH_SECRET_CONSUME_RATE, nbStripesToEnd, f_acc512);
+                f_scramble(&acc[0], secret + state.secretLimit);
+                state.nbStripesSoFar = 0;
+                input += nbStripesToEnd * XXH_STRIPE_LEN;
+                nbStripes -= nbStripesToEnd;
+            }
+            /* consume per entire blocks */
+            while(nbStripes >= state.nbStripesPerBlock) {
+                XXH3_accumulate(&acc[0], input, secret, state.nbStripesPerBlock, f_acc512);
+                f_scramble(&acc[0], secret + state.secretLimit);
+                input += state.nbStripesPerBlock * XXH_STRIPE_LEN;
+                nbStripes -= state.nbStripesPerBlock;
+            }
+            /* consume last partial block */
+            XXH3_accumulate(&acc[0], input, secret, nbStripes, f_acc512);
+            input += nbStripes * XXH_STRIPE_LEN;
+            assert(input < bEnd);  /* at least some bytes left */
+            state.nbStripesSoFar = nbStripes;
+            /* buffer predecessor of last partial stripe */
+            memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+            assert(bEnd - input <= XXH_STRIPE_LEN);
+        } else {
+            /* content to consume <= block size */
+            /* Consume input by a multiple of internal buffer size */
+            if (bEnd - input > XXH3_INTERNALBUFFER_SIZE) {
+                const xxh_u8* limit = bEnd - XXH3_INTERNALBUFFER_SIZE;
+                do {
+                    XXH3_consumeStripes(&acc[0],
+                                       &state.nbStripesSoFar, state.nbStripesPerBlock,
+                                        input, XXH3_INTERNALBUFFER_STRIPES,
+                                        secret, state.secretLimit,
+                                        f_acc512, f_scramble);
+                    input += XXH3_INTERNALBUFFER_SIZE;
+                } while (input<limit);
+                /* buffer predecessor of last partial stripe */
+                memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
+            }
+        }
+
+        /* Some remaining input (always) : buffer it */
+        assert(input < bEnd);
+        assert(bEnd - input <= XXH3_INTERNALBUFFER_SIZE);
+        assert(state.bufferedSize == 0);
+        memcpy(&state.buffer[0], input, cast(size_t)(bEnd-input));
+        state.bufferedSize = cast(XXH32_hash_t)(bEnd-input);
+        static if (XXH3_STREAM_USE_STACK >= 1) {
+            /* save stack accumulators into state */
+            memcpy(&state.acc[0], &acc[0], (acc).sizeof);
+        }
+    }
+
+    return XXH_errorcode.XXH_OK;
+}
+
+/*! @ingroup XXH3_family */
+XXH_errorcode
+XXH3_64bits_update(XXH3_state_t* state, const(void)* input, size_t len)
+@trusted pure nothrow @nogc
+{
+    return XXH3_update(state, cast(const(xxh_u8)*)input, len,
+                       XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+void
+XXH3_digest_long (XXH64_hash_t* acc,
+                  const XXH3_state_t* state,
+                  const ubyte* secret)
+@trusted pure nothrow @nogc
+{
+    import core.stdc.string : memcpy;
+
+    /*
+     * Digest on a local copy. This way, the state remains unaltered, and it can
+     * continue ingesting more input afterwards.
+     */
+    memcpy(&acc[0], &state.acc[0], (state.acc).sizeof);
+    if (state.bufferedSize >= XXH_STRIPE_LEN) {
+        const size_t nbStripes = (state.bufferedSize - 1) / XXH_STRIPE_LEN;
+        size_t nbStripesSoFar = state.nbStripesSoFar;
+        XXH3_consumeStripes(acc,
+                           &nbStripesSoFar, state.nbStripesPerBlock,
+                            &state.buffer[0], nbStripes,
+                            secret, state.secretLimit,
+                            XXH3_accumulate_512, XXH3_scrambleAcc);
+        /* last stripe */
+        XXH3_accumulate_512(acc,
+                            &state.buffer[0] + state.bufferedSize - XXH_STRIPE_LEN,
+                            secret + state.secretLimit - XXH_SECRET_LASTACC_START);
+    } else {  /* bufferedSize < XXH_STRIPE_LEN */
+        xxh_u8[XXH_STRIPE_LEN] lastStripe;
+        const size_t catchupSize = XXH_STRIPE_LEN - state.bufferedSize;
+        assert(state.bufferedSize > 0);  /* there is always some input buffered */
+        memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
+        memcpy(&lastStripe[0] + catchupSize, &state.buffer[0], state.bufferedSize);
+        XXH3_accumulate_512(&acc[0],
+                            &lastStripe[0],
+                            &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);
+    }
+}
+
+/*! @ingroup XXH3_family */
+XXH64_hash_t XXH3_64bits_digest (const XXH3_state_t* state)
+@trusted pure nothrow @nogc
+{
+    const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
+    if (state.totalLen > XXH3_MIDSIZE_MAX) {
+        align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
+        XXH3_digest_long(&acc[0], state, secret);
+        return XXH3_mergeAccs(&acc[0],
+                              secret + XXH_SECRET_MERGEACCS_START,
+                              cast(xxh_u64)state.totalLen * XXH_PRIME64_1);
+    }
+    /* totalLen <= XXH3_MIDSIZE_MAX: digesting a short input */
+    if (state.useSeed)
+        return XXH3_64bits_withSeed(&state.buffer[0], cast(size_t)state.totalLen, state.seed);
+    return XXH3_64bits_withSecret(&state.buffer[0], cast(size_t)(state.totalLen),
+                                  secret, state.secretLimit + XXH_STRIPE_LEN);
+}
+
+/* ==========================================
+ * XXH3 128 bits (a.k.a XXH128)
+ * ==========================================
+ * XXH3's 128-bit variant has better mixing and strength than the 64-bit variant,
+ * even without counting the significantly larger output size.
+ *
+ * For example, extra steps are taken to avoid the seed-dependent collisions
+ * in 17-240 byte inputs (See XXH3_mix16B and XXH128_mix32B).
+ *
+ * This strength naturally comes at the cost of some speed, especially on short
+ * lengths. Note that longer hashes are about as fast as the 64-bit version
+ * due to it using only a slight modification of the 64-bit loop.
+ *
+ * XXH128 is also more oriented towards 64-bit machines. It is still extremely
+ * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
+ */
+private XXH128_hash_t
+XXH3_len_1to3_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    /* A doubled version of 1to3_64b with different constants. */
+    assert(input != null);
+    assert(1 <= len && len <= 3);
+    assert(secret != null);
+    /*
+     * len = 1: combinedl = { input[0], 0x01, input[0], input[0] }
+     * len = 2: combinedl = { input[1], 0x02, input[0], input[1] }
+     * len = 3: combinedl = { input[2], 0x03, input[0], input[1] }
+     */
+    {   const xxh_u8 c1 = input[0];
+        const xxh_u8 c2 = input[len >> 1];
+        const xxh_u8 c3 = input[len - 1];
+        const xxh_u32 combinedl = (cast(xxh_u32)c1 <<16) | (cast(xxh_u32)c2 << 24)
+                                | (cast(xxh_u32)c3 << 0) | (cast(xxh_u32)len << 8);
+        const xxh_u32 combinedh = XXH_rotl32(XXH_swap32(combinedl), 13);
+        const xxh_u64 bitflipl = (XXH_readLE32(secret) ^ XXH_readLE32(secret+4)) + seed;
+        const xxh_u64 bitfliph = (XXH_readLE32(secret+8) ^ XXH_readLE32(secret+12)) - seed;
+        const xxh_u64 keyed_lo = cast(xxh_u64)combinedl ^ bitflipl;
+        const xxh_u64 keyed_hi = cast(xxh_u64)combinedh ^ bitfliph;
+        XXH128_hash_t h128;
+        h128.low64  = XXH64_avalanche(keyed_lo);
+        h128.high64 = XXH64_avalanche(keyed_hi);
+        return h128;
+    }
+}
+private XXH128_hash_t
+XXH3_len_4to8_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(input != null);
+    assert(secret != null);
+    assert(4 <= len && len <= 8);
+    seed ^= cast(xxh_u64)XXH_swap32(cast(xxh_u32)seed) << 32;
+    {   const xxh_u32 input_lo = XXH_readLE32(input);
+        const xxh_u32 input_hi = XXH_readLE32(input + len - 4);
+        const xxh_u64 input_64 = input_lo + (cast(xxh_u64)input_hi << 32);
+        const xxh_u64 bitflip = (XXH_readLE64(secret+16) ^ XXH_readLE64(secret+24)) + seed;
+        const xxh_u64 keyed = input_64 ^ bitflip;
+
+        /* Shift len to the left to ensure it is even, this avoids even multiplies. */
+        XXH128_hash_t m128 = XXH_mult64to128(keyed, XXH_PRIME64_1 + (len << 2));
+
+        m128.high64 += (m128.low64 << 1);
+        m128.low64  ^= (m128.high64 >> 3);
+
+        m128.low64   = XXH_xorshift64(m128.low64, 35);
+        m128.low64  *= 0x9FB21C651E98DF25;
+        m128.low64   = XXH_xorshift64(m128.low64, 28);
+        m128.high64  = XXH3_avalanche(m128.high64);
+        return m128;
+    }
+}
+private XXH128_hash_t
+XXH3_len_9to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(input != null);
+    assert(secret != null);
+    assert(9 <= len && len <= 16);
+    {   const xxh_u64 bitflipl = (XXH_readLE64(secret+32) ^ XXH_readLE64(secret+40)) - seed;
+        const xxh_u64 bitfliph = (XXH_readLE64(secret+48) ^ XXH_readLE64(secret+56)) + seed;
+        const xxh_u64 input_lo = XXH_readLE64(input);
+        xxh_u64       input_hi = XXH_readLE64(input + len - 8);
+        XXH128_hash_t m128 = XXH_mult64to128(input_lo ^ input_hi ^ bitflipl, XXH_PRIME64_1);
+        /*
+         * Put len in the middle of m128 to ensure that the length gets mixed to
+         * both the low and high bits in the 128x64 multiply below.
+         */
+        m128.low64 += cast(xxh_u64)(len - 1) << 54;
+        input_hi   ^= bitfliph;
+        /*
+         * Add the high 32 bits of input_hi to the high 32 bits of m128, then
+         * add the long product of the low 32 bits of input_hi and XXH_PRIME32_2 to
+         * the high 64 bits of m128.
+         *
+         * The best approach to this operation is different on 32-bit and 64-bit.
+         */
+        if ((void *).sizeof < (xxh_u64).sizeof) { /* 32-bit */
+            /*
+             * 32-bit optimized version, which is more readable.
+             *
+             * On 32-bit, it removes an ADC and delays a dependency between the two
+             * halves of m128.high64, but it generates an extra mask on 64-bit.
+             */
+            m128.high64 += (input_hi & 0xFFFFFFFF00000000) + XXH_mult32to64(cast(xxh_u32)input_hi, XXH_PRIME32_2);
+        } else {
+            /*
+             * 64-bit optimized (albeit more confusing) version.
+             *
+             * Uses some properties of addition and multiplication to remove the mask:
+             *
+             * Let:
+             *    a = input_hi.lo = (input_hi & 0x00000000FFFFFFFF)
+             *    b = input_hi.hi = (input_hi & 0xFFFFFFFF00000000)
+             *    c = XXH_PRIME32_2
+             *
+             *    a + (b * c)
+             * Inverse Property: x + y - x == y
+             *    a + (b * (1 + c - 1))
+             * Distributive Property: x * (y + z) == (x * y) + (x * z)
+             *    a + (b * 1) + (b * (c - 1))
+             * Identity Property: x * 1 == x
+             *    a + b + (b * (c - 1))
+             *
+             * Substitute a, b, and c:
+             *    input_hi.hi + input_hi.lo + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             *
+             * Since input_hi.hi + input_hi.lo == input_hi, we get this:
+             *    input_hi + ((xxh_u64)input_hi.lo * (XXH_PRIME32_2 - 1))
+             */
+            m128.high64 += input_hi + XXH_mult32to64(cast(xxh_u32)input_hi, XXH_PRIME32_2 - 1);
+        }
+        /* m128 ^= XXH_swap64(m128 >> 64); */
+        m128.low64  ^= XXH_swap64(m128.high64);
+
+        {   /* 128x64 multiply: h128 = m128 * XXH_PRIME64_2; */
+            XXH128_hash_t h128 = XXH_mult64to128(m128.low64, XXH_PRIME64_2);
+            h128.high64 += m128.high64 * XXH_PRIME64_2;
+
+            h128.low64   = XXH3_avalanche(h128.low64);
+            h128.high64  = XXH3_avalanche(h128.high64);
+            return h128;
+    }   }
+}
+private XXH128_hash_t
+XXH3_len_0to16_128b(const xxh_u8* input, size_t len, const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(len <= 16);
+    {   if (len > 8) return XXH3_len_9to16_128b(input, len, secret, seed);
+        if (len >= 4) return XXH3_len_4to8_128b(input, len, secret, seed);
+        if (len) return XXH3_len_1to3_128b(input, len, secret, seed);
+        {   XXH128_hash_t h128;
+            const xxh_u64 bitflipl = XXH_readLE64(secret+64) ^ XXH_readLE64(secret+72);
+            const xxh_u64 bitfliph = XXH_readLE64(secret+80) ^ XXH_readLE64(secret+88);
+            h128.low64 = XXH64_avalanche(seed ^ bitflipl);
+            h128.high64 = XXH64_avalanche( seed ^ bitfliph);
+            return h128;
+    }   }
+}
+private XXH128_hash_t
+XXH128_mix32B(XXH128_hash_t acc, const xxh_u8* input_1, const xxh_u8* input_2,
+              const xxh_u8* secret, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    acc.low64  += XXH3_mix16B (input_1, secret+0, seed);
+    acc.low64  ^= XXH_readLE64(input_2) + XXH_readLE64(input_2 + 8);
+    acc.high64 += XXH3_mix16B (input_2, secret+16, seed);
+    acc.high64 ^= XXH_readLE64(input_1) + XXH_readLE64(input_1 + 8);
+    return acc;
+}
+
+private XXH128_hash_t
+XXH3_len_17to128_128b(const xxh_u8*  input, size_t len,
+                      const xxh_u8*  secret, size_t secretSize,
+                      XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
+    assert(16 < len && len <= 128);
+
+    {   XXH128_hash_t acc;
+        acc.low64 = len * XXH_PRIME64_1;
+        acc.high64 = 0;
+
+        static if (XXH_SIZE_OPT >= 1)
+        {
+            /* Smaller, but slightly slower. */
+            size_t i = (len - 1) / 32;
+            do {
+                acc = XXH128_mix32B(acc, input+16*i, input+len-16*(i+1), secret+32*i, seed);
+            } while (i-- != 0);
+        }
+        else 
+        {
+            if (len > 32) {
+                if (len > 64) {
+                    if (len > 96) {
+                        acc = XXH128_mix32B(acc, input+48, input+len-64, secret+96, seed);
+                    }
+                    acc = XXH128_mix32B(acc, input+32, input+len-48, secret+64, seed);
+                }
+                acc = XXH128_mix32B(acc, input+16, input+len-32, secret+32, seed);
+            }
+            acc = XXH128_mix32B(acc, input, input+len-16, secret, seed);
+        }
+        {   XXH128_hash_t h128;
+            h128.low64  = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
+            h128.low64  = XXH3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+            return h128;
+        }
+    }
+}
+
+private XXH128_hash_t
+XXH3_len_129to240_128b(const xxh_u8*  input, size_t len,
+                       const xxh_u8*  secret, size_t secretSize,
+                       XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    assert(secretSize >= XXH3_SECRET_SIZE_MIN); cast(void)secretSize;
+    assert(128 < len && len <= XXH3_MIDSIZE_MAX);
+
+    {   XXH128_hash_t acc;
+        const int nbRounds = cast(int)len / 32;
+        int i;
+        acc.low64 = len * XXH_PRIME64_1;
+        acc.high64 = 0;
+        for (i=0; i<4; i++) {
+            acc = XXH128_mix32B(acc,
+                                input  + (32 * i),
+                                input  + (32 * i) + 16,
+                                secret + (32 * i),
+                                seed);
+        }
+        acc.low64 = XXH3_avalanche(acc.low64);
+        acc.high64 = XXH3_avalanche(acc.high64);
+        assert(nbRounds >= 4);
+        for (i=4 ; i < nbRounds; i++) {
+            acc = XXH128_mix32B(acc,
+                                input + (32 * i),
+                                input + (32 * i) + 16,
+                                secret + XXH3_MIDSIZE_STARTOFFSET + (32 * (i - 4)),
+                                seed);
+        }
+        /* last bytes */
+        acc = XXH128_mix32B(acc,
+                            input + len - 16,
+                            input + len - 32,
+                            secret + XXH3_SECRET_SIZE_MIN - XXH3_MIDSIZE_LASTOFFSET - 16,
+                            0 - seed);
+
+        {   XXH128_hash_t h128;
+            h128.low64  = acc.low64 + acc.high64;
+            h128.high64 = (acc.low64    * XXH_PRIME64_1)
+                        + (acc.high64   * XXH_PRIME64_4)
+                        + ((len - seed) * XXH_PRIME64_2);
+            h128.low64  = XXH3_avalanche(h128.low64);
+            h128.high64 = cast(XXH64_hash_t)0 - XXH3_avalanche(h128.high64);
+            return h128;
+        }
+    }
+}
+
+private XXH128_hash_t
+XXH3_hashLong_128b_internal(const void*  input, size_t len,
+                            const xxh_u8*  secret, size_t secretSize,
+                            XXH3_f_accumulate_512 f_acc512,
+                            XXH3_f_scrambleAcc f_scramble)
+@trusted pure nothrow @nogc
+{
+    align(XXH_ACC_ALIGN) xxh_u64[XXH_ACC_NB] acc = XXH3_INIT_ACC;
+
+    XXH3_hashLong_internal_loop(&acc[0], cast(const xxh_u8*)input, len, secret, secretSize, f_acc512, f_scramble);
+
+    /* converge into final hash */
+    static assert((acc).sizeof == 64);
+    assert(secretSize >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
+    {   XXH128_hash_t h128;
+        h128.low64  = XXH3_mergeAccs(&acc[0],
+                                     secret + XXH_SECRET_MERGEACCS_START,
+                                     cast(xxh_u64)len * XXH_PRIME64_1);
+        h128.high64 = XXH3_mergeAccs(&acc[0],
+                                     secret + secretSize
+                                            - (acc).sizeof - XXH_SECRET_MERGEACCS_START,
+                                     ~(cast(xxh_u64)len * XXH_PRIME64_2));
+        return h128;
+    }
+}
+
+private XXH128_hash_t
+XXH3_hashLong_128b_default(const void*  input, size_t len,
+                           XXH64_hash_t seed64,
+                           const void*  secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)seed64; cast(void)secret; cast(void)secretLen;
+    return XXH3_hashLong_128b_internal(input, len, &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
+                                       XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+/*
+ * It's important for performance to pass @p secretLen (when it's static)
+ * to the compiler, so that it can properly optimize the vectorized loop.
+ */
+private XXH128_hash_t
+XXH3_hashLong_128b_withSecret(const void* input, size_t len,
+                              XXH64_hash_t seed64,
+                              const void* secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)seed64;
+    return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*)secret, secretLen,
+                                       XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+private XXH128_hash_t
+XXH3_hashLong_128b_withSeed_internal(const void* input, size_t len,
+                                XXH64_hash_t seed64,
+                                XXH3_f_accumulate_512 f_acc512,
+                                XXH3_f_scrambleAcc f_scramble,
+                                XXH3_f_initCustomSecret f_initSec)
+@trusted pure nothrow @nogc
+{
+    if (seed64 == 0)
+        return XXH3_hashLong_128b_internal(input, len,
+                                           &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
+                                           f_acc512, f_scramble);
+    {   align(XXH_SEC_ALIGN) xxh_u8[XXH_SECRET_DEFAULT_SIZE] secret;
+        f_initSec(&secret[0], seed64);
+        return XXH3_hashLong_128b_internal(input, len, cast(const xxh_u8*)&secret[0], (secret).sizeof,
+                                           f_acc512, f_scramble);
+    }
+}
+/*
+ * It's important for performance that XXH3_hashLong is not inlined.
+ */
+private XXH128_hash_t
+XXH3_hashLong_128b_withSeed(const void* input, size_t len,
+                            XXH64_hash_t seed64, const void* secret, size_t secretLen)
+@trusted pure nothrow @nogc
+{
+    cast(void)secret; cast(void)secretLen;
+    return XXH3_hashLong_128b_withSeed_internal(input, len, seed64,
+                XXH3_accumulate_512, XXH3_scrambleAcc, XXH3_initCustomSecret);
+}
+
+alias XXH3_hashLong128_f = XXH128_hash_t function(const void* , size_t,
+                                            XXH64_hash_t, const void* , size_t)
+                                            @trusted pure nothrow @nogc;
+
+private XXH128_hash_t
+XXH3_128bits_internal(const void* input, size_t len,
+                      XXH64_hash_t seed64, const void* secret, size_t secretLen,
+                      XXH3_hashLong128_f f_hl128)
+@trusted pure nothrow @nogc
+{
+    assert(secretLen >= XXH3_SECRET_SIZE_MIN);
+    /*
+     * If an action is to be taken if `secret` conditions are not respected,
+     * it should be done here.
+     * For now, it's a contract pre-condition.
+     * Adding a check and a branch here would cost performance at every hash.
+     */
+    if (len <= 16)
+        return XXH3_len_0to16_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, seed64);
+    if (len <= 128)
+        return XXH3_len_17to128_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, secretLen, seed64);
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_len_129to240_128b(cast(const xxh_u8*)input, len, cast(const xxh_u8*)secret, secretLen, seed64);
+    return f_hl128(input, len, seed64, secret, secretLen);
+}
+
+/* ===   Public XXH128 API   === */
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t XXH3_128bits(const void* input, size_t len)
+@trusted pure nothrow @nogc
+{
+    return XXH3_128bits_internal(input, len, 0,
+                                 &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
+                                 &XXH3_hashLong_128b_default);
+}
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t
+XXH3_128bits_withSecret(const void* input, size_t len, const void* secret, size_t secretSize)
+@trusted pure nothrow @nogc
+{
+    return XXH3_128bits_internal(input, len, 0,
+                                 cast(const xxh_u8*)secret, secretSize,
+                                 &XXH3_hashLong_128b_withSecret);
+}
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t
+XXH3_128bits_withSeed(const void* input, size_t len, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    return XXH3_128bits_internal(input, len, seed,
+                                 &XXH3_kSecret[0], (XXH3_kSecret).sizeof,
+                                 &XXH3_hashLong_128b_withSeed);
+}
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t
+XXH3_128bits_withSecretandSeed(const void* input, size_t len, const void* secret, size_t secretSize, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    if (len <= XXH3_MIDSIZE_MAX)
+        return XXH3_128bits_internal(input, len, seed, &XXH3_kSecret[0], (XXH3_kSecret).sizeof, null);
+    return XXH3_hashLong_128b_withSecret(input, len, seed, secret, secretSize);
+}
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t
+XXH128(const void* input, size_t len, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    return XXH3_128bits_withSeed(input, len, seed);
+}
+
+XXH_errorcode
+XXH3_128bits_reset(XXH3_state_t* statePtr)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_reset(statePtr);
+}
+
+/*! @ingroup XXH3_family */
+XXH_errorcode
+XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_reset_withSecret(statePtr, secret, secretSize);
+}
+
+/*! @ingroup XXH3_family */
+XXH_errorcode
+XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_reset_withSeed(statePtr, seed);
+}
+
+/*! @ingroup XXH3_family */
+XXH_errorcode
+XXH3_128bits_reset_withSecretandSeed(XXH3_state_t* statePtr, const void* secret, size_t secretSize, XXH64_hash_t seed)
+@trusted pure nothrow @nogc
+{
+    return XXH3_64bits_reset_withSecretandSeed(statePtr, secret, secretSize, seed);
+}
+
+XXH_errorcode
+XXH3_128bits_update(XXH3_state_t* state, const void* input, size_t len)
+@trusted pure nothrow @nogc
+{
+    return XXH3_update(state, cast(const xxh_u8*)input, len,
+                       XXH3_accumulate_512, XXH3_scrambleAcc);
+}
+
+/*! @ingroup XXH3_family */
+XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
+@trusted pure nothrow @nogc
+{
+    const ubyte* secret = (state.extSecret == null) ? &state.customSecret[0] : &state.extSecret[0];
+    if (state.totalLen > XXH3_MIDSIZE_MAX) {
+        align(XXH_ACC_ALIGN) XXH64_hash_t[XXH_ACC_NB] acc;
+        XXH3_digest_long(&acc[0], state, secret);
+        assert(state.secretLimit + XXH_STRIPE_LEN >= (acc).sizeof + XXH_SECRET_MERGEACCS_START);
+        {   XXH128_hash_t h128;
+            h128.low64  = XXH3_mergeAccs(&acc[0],
+                                         secret + XXH_SECRET_MERGEACCS_START,
+                                         cast(xxh_u64)state.totalLen * XXH_PRIME64_1);
+            h128.high64 = XXH3_mergeAccs(&acc[0],
+                                         secret + state.secretLimit + XXH_STRIPE_LEN
+                                                - (acc).sizeof - XXH_SECRET_MERGEACCS_START,
+                                         ~(cast(xxh_u64)state.totalLen * XXH_PRIME64_2));
+            return h128;
+        }
+    }
+    /* len <= XXH3_MIDSIZE_MAX : short code */
+    if (state.seed)
+        return XXH3_128bits_withSeed(&state.buffer[0], cast(size_t)state.totalLen, state.seed);
+    return XXH3_128bits_withSecret(&state.buffer[0], cast(size_t)(state.totalLen),
+                                   secret, state.secretLimit + XXH_STRIPE_LEN);
+}
+
+/* ----------------------------------------------------------------------------------------*/
+/* ----------------------------------------------------------------------------------------*/
+extern (C) {
+//    uint XXH_versionNumber () @trusted pure nothrow @nogc;
+//    XXH32_hash_t XXH32 (const void* input, size_t length, XXH32_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH32_state_t* XXH32_createState() @trusted pure nothrow @nogc;
+//    XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr) @trusted pure nothrow @nogc;
+//    void XXH32_copyState(XXH32_state_t* dst_state, const XXH32_state_t* src_state) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length) @trusted pure nothrow @nogc;
+//    XXH32_hash_t XXH32_digest (const XXH32_state_t* statePtr) @trusted pure nothrow @nogc;
+//    void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc;
+//    XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src) @trusted pure nothrow @nogc;
+
+//    XXH64_hash_t XXH64(const void* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH64_state_t* XXH64_createState() @trusted pure nothrow @nogc;
+//    XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr) @trusted pure nothrow @nogc;
+//    void XXH64_copyState(XXH64_state_t* dst_state, const XXH64_state_t* src_state) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH64_reset  (XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length) @trusted pure nothrow @nogc;
+//    XXH64_hash_t XXH64_digest (const XXH64_state_t* statePtr) @trusted pure nothrow @nogc;
+//    void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc;
+//    XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src) @trusted pure nothrow @nogc;
+
+//    XXH64_hash_t XXH3_64bits(const void* input, size_t length) @trusted pure nothrow @nogc;
+//    XXH64_hash_t XXH3_64bits_withSeed(const void* input, size_t length, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH64_hash_t XXH3_64bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
+//        @trusted pure nothrow @nogc;
+//    XXH3_state_t* XXH3_createState() @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_freeState(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
+//    void XXH3_copyState(XXH3_state_t* dst_state, const XXH3_state_t* src_state) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_64bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_64bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_64bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+//        @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_64bits_update (XXH3_state_t* statePtr, const void* input, size_t length)
+//        @trusted pure nothrow @nogc;
+//    XXH64_hash_t  XXH3_64bits_digest (const XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
+
+//    XXH128_hash_t XXH3_128bits(const void* data, size_t len) @trusted pure nothrow @nogc;
+//    XXH128_hash_t XXH3_128bits_withSeed(const void* data, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH128_hash_t XXH3_128bits_withSecret(const void* data, size_t len, const void* secret, size_t secretSize)
+//        @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_128bits_reset(XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_128bits_reset_withSeed(XXH3_state_t* statePtr, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_128bits_reset_withSecret(XXH3_state_t* statePtr, const void* secret, size_t secretSize)
+//        @trusted pure nothrow @nogc;
+//    XXH_errorcode XXH3_128bits_update (XXH3_state_t* statePtr, const void* input, size_t length)
+//        @trusted pure nothrow @nogc;
+//    XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* statePtr) @trusted pure nothrow @nogc;
+
+    int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2) @trusted pure nothrow @nogc;
+    int XXH128_cmp(const void* h128_1, const void* h128_2) @trusted pure nothrow @nogc;
+    void XXH128_canonicalFromHash(XXH128_canonical_t* dst, XXH128_hash_t hash) @trusted pure nothrow @nogc;
+    XXH128_hash_t XXH128_hashFromCanonical(const XXH128_canonical_t* src) @trusted pure nothrow @nogc;
+    XXH128_hash_t XXH128(const void* data, size_t len, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+
+    XXH_errorcode XXH3_generateSecret(void* secretBuffer, size_t secretSize, const void* customSeed,
+        size_t customSeedSize) @trusted pure nothrow @nogc;
+    void XXH3_generateSecret_fromSeed(void* secretBuffer, XXH64_hash_t seed) @trusted pure nothrow @nogc;
+    XXH64_hash_t  XXH3_64bits_dispatch(const void* input, size_t len) @trusted pure nothrow @nogc;
+    XXH64_hash_t  XXH3_64bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
+        @trusted pure nothrow @nogc;
+    XXH64_hash_t  XXH3_64bits_withSecret_dispatch(const void* input, size_t len, const void* secret,
+        size_t secretLen) @trusted pure nothrow @nogc;
+    XXH_errorcode XXH3_64bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
+        @trusted pure nothrow @nogc;
+    XXH128_hash_t XXH3_128bits_dispatch(const void* input, size_t len) @trusted pure nothrow @nogc;
+    XXH128_hash_t XXH3_128bits_withSeed_dispatch(const void* input, size_t len, XXH64_hash_t seed)
+        @trusted pure nothrow @nogc;
+    XXH128_hash_t XXH3_128bits_withSecret_dispatch(const void* input, size_t len, const void* secret,
+        size_t secretLen) @trusted pure nothrow @nogc;
+    XXH_errorcode XXH3_128bits_update_dispatch(XXH3_state_t* state, const void* input, size_t len)
+        @trusted pure nothrow @nogc;
+}
+
+import core.bitop;
+
+public import std.digest;
+
+/*
+ * Helper methods for encoding the buffer.
+ * Can be removed if the optimizer can inline the methods from std.bitmanip.
+ */
+version (LittleEndian)
+{
+    private alias nativeToBigEndian = bswap;
+    private alias bigEndianToNative = bswap;
+}
+else pragma(inline, true) private pure @nogc nothrow @safe
+{
+    uint nativeToBigEndian(uint val) { return val; }
+    ulong nativeToBigEndian(ulong val) { return val; }
+    alias bigEndianToNative = nativeToBigEndian;
+}
+
+/**
+ * Template API XXHTemplate implementation. Uses parameters to configure for number of bits and XXH variant (classic or XXH3)
+ * See `std.digest` for differences between template and OOP API.
+ */
+struct XXHTemplate(HASH, STATE, bool useXXH3)
+{
+    private:
+        HASH hash;
+        STATE* state = null;
+        HASH seed = HASH.init;
+
+    public:
+        enum digestSize = HASH.sizeof * 8;
+
+        /**
+         * Use this to feed the digest with data.
+         * Also implements the $(REF isOutputRange, std,range,primitives)
+         * interface for `ubyte` and `const(ubyte)[]`.
+         *
+         * Example:
+         * ----
+         * XXHTemplate!(hashtype,statetype,useXXH3) dig;
+         * dig.put(cast(ubyte) 0); //single ubyte
+         * dig.put(cast(ubyte) 0, cast(ubyte) 0); //variadic
+         * ubyte[10] buf;
+         * dig.put(buf); //buffer
+         * ----
+         */
+        void put(scope const(ubyte)[] data...) @trusted nothrow @nogc
+        {
+            XXH_errorcode ec;
+            if (state == null) this.start;
+            static if (digestSize == 32)
+                ec = XXH32_update(state, data.ptr, data.length);
+            else static if (digestSize == 64 && !useXXH3)
+                ec = XXH64_update(state, data.ptr, data.length);
+            else static if (digestSize == 64 && useXXH3)
+                ec = XXH3_64bits_update(state, data.ptr, data.length);
+            else static if (digestSize == 128)
+                ec = XXH3_128bits_update(state, data.ptr, data.length);
+            else
+                assert(false, "Unknown XXH bitdeep or variant");
+            assert(ec == XXH_errorcode.XXH_OK, "Update failed");
+        }
+
+        /**
+         * Used to (re)initialize the XXHTemplate digest.
+         *
+         * Example:
+         * --------
+         * XXHTemplate!(hashtype,statetype,useXXH3) digest;
+         * digest.start();
+         * digest.put(0);
+         * --------
+         */
+        void start() @safe nothrow @nogc
+        {
+            this = typeof(this).init;
+            XXH_errorcode ec;
+            static if (digestSize == 32)
+            {
+                if (state == null) state = XXH32_createState();
+                ec = XXH32_reset(state, seed);
+            }
+            else static if (digestSize == 64 && !useXXH3)
+            {
+                if (state == null) state = XXH64_createState();
+                ec = XXH64_reset(state, seed);
+            }
+            else static if (digestSize == 64 && useXXH3)
+            {
+                if (state == null) state = XXH3_createState();
+                ec = XXH3_64bits_reset(state);
+            }
+            else static if (digestSize == 128)
+            {
+                if (state == null) state = XXH3_createState();
+                ec = XXH3_128bits_reset(state);
+            }
+            else
+                assert(false, "Unknown XXH bitdeep or variant");
+            //assert(ec == XXH_errorcode.XXH_OK, "reset failed");
+        }
+
+        /**
+         * Returns the finished XXH hash. This also calls $(LREF start) to
+         * reset the internal state.
+          */
+        ubyte[digestSize/8] finish() @trusted nothrow @nogc
+        {
+            XXH_errorcode ec;
+            static if (digestSize == 32)
+            {
+                hash = XXH32_digest(state);
+                if (state != null) ec = XXH32_freeState(state);
+                auto rc = nativeToBigEndian(hash);
+            }
+            else static if (digestSize == 64 && !useXXH3)
+            {
+                hash = XXH64_digest(state);
+                if (state != null) ec = XXH64_freeState(state);
+                auto rc = nativeToBigEndian(hash);
+            }
+            else static if (digestSize == 64 && useXXH3)
+            {
+                hash = XXH3_64bits_digest(state);
+                if (state != null) ec = XXH3_freeState(state);
+                auto rc = nativeToBigEndian(hash);
+            }
+            else static if (digestSize == 128)
+            {
+                hash = XXH3_128bits_digest(state);
+                if (state != null) ec = XXH3_freeState(state);
+                HASH rc;
+                // Note: low64 and high64 are intentionally exchanged!
+                rc.low64 = nativeToBigEndian(hash.high64);
+                rc.high64 = nativeToBigEndian(hash.low64);
+            }
+            assert(ec == XXH_errorcode.XXH_OK, "freestate failed");
+            state = null;
+
+            return (cast(ubyte*) &rc)[0 .. rc.sizeof];
+        }
+}
+///
+@safe unittest
+{
+    // Simple example using the XXH_64 digest
+    XXHTemplate!(XXH64_hash_t, XXH64_state_t, false) hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+}
+
+alias XXH_32 = XXHTemplate!(XXH32_hash_t, XXH32_state_t, false); /// XXH_32 for XXH, 32bit, hash is ubyte[4]
+alias XXH_64 = XXHTemplate!(XXH64_hash_t, XXH64_state_t, false); /// XXH_64 for XXH, 64bit, hash is ubyte[8]
+alias XXH3_64 = XXHTemplate!(XXH64_hash_t, XXH3_state_t, true); /// XXH3_64 for XXH3, 64bits, hash is ubyte[8]
+alias XXH3_128 = XXHTemplate!(XXH128_hash_t, XXH3_state_t, true); /// XXH3_128 for XXH3, 128bits, hash is ubyte[16]
+
+///
+@safe unittest
+{
+    //Simple example
+    XXH_32 hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+}
+///
+@safe unittest
+{
+    //Simple example
+    XXH_64 hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+}
+///
+@safe unittest
+{
+    //Simple example
+    XXH3_64 hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+}
+///
+@safe unittest
+{
+    //Simple example
+    XXH3_128 hash1;
+    hash1.start();
+    hash1.put(cast(ubyte) 0);
+    auto result = hash1.finish();
+}
+
+///
+@safe unittest
+{
+    //Simple example, hashing a string using xxh32Of helper function
+    auto hash = xxh32Of("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "32D153FF");
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using xxh32Of helper function
+    auto hash = xxh64Of("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "44BC2CF5AD770999" ); // XXH64
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using xxh32Of helper function
+    auto hash = xxh3_64Of("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "78AF5F94892F3950" ); // XXH3/64
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using xxh32Of helper function
+    auto hash = xxh128Of("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "06B05AB6733A618578AF5F94892F3950");
+
+}
+
+///
+@safe unittest
+{
+    //Using the basic API
+    XXH_32 hash;
+    hash.start();
+    ubyte[1024] data;
+    //Initialize data here...
+    hash.put(data);
+    ubyte[4] result = hash.finish();
+}
+///
+@safe unittest
+{
+    //Using the basic API
+    XXH_64 hash;
+    hash.start();
+    ubyte[1024] data;
+    //Initialize data here...
+    hash.put(data);
+    ubyte[8] result = hash.finish();
+}
+///
+@safe unittest
+{
+    //Using the basic API
+    XXH3_64 hash;
+    hash.start();
+    ubyte[1024] data;
+    //Initialize data here...
+    hash.put(data);
+    ubyte[8] result = hash.finish();
+}
+///
+@safe unittest
+{
+    //Using the basic API
+    XXH3_128 hash;
+    hash.start();
+    ubyte[1024] data;
+    //Initialize data here...
+    hash.put(data);
+    ubyte[16] result = hash.finish();
+}
+
+///
+@safe unittest
+{
+    //Let's use the template features:
+    void doSomething(T)(ref T hash)
+    if (isDigest!T)
+    {
+        hash.put(cast(ubyte) 0);
+    }
+    XXH_32 xxh;
+    xxh.start();
+    doSomething(xxh);
+    auto hash = xxh.finish;
+    assert(toHexString(hash) == "CF65B03E", "Got " ~ toHexString(hash));
+}
+///
+@safe unittest
+{
+    //Let's use the template features:
+    void doSomething(T)(ref T hash)
+    if (isDigest!T)
+    {
+        hash.put(cast(ubyte) 0);
+    }
+    XXH_64 xxh;
+    xxh.start();
+    doSomething(xxh);
+    auto hash = xxh.finish;
+    assert(toHexString(hash) == "E934A84ADB052768", "Got " ~ toHexString(hash));
+}
+///
+@safe unittest
+{
+    //Let's use the template features:
+    void doSomething(T)(ref T hash)
+    if (isDigest!T)
+    {
+        hash.put(cast(ubyte) 0);
+    }
+    XXH3_64 xxh;
+    xxh.start();
+    doSomething(xxh);
+    auto hash = xxh.finish;
+    assert(toHexString(hash) == "C44BDFF4074EECDB", "Got " ~ toHexString(hash));
+}
+///
+@safe unittest
+{
+    //Let's use the template features:
+    void doSomething(T)(ref T hash)
+    if (isDigest!T)
+    {
+        hash.put(cast(ubyte) 0);
+    }
+    XXH3_128 xxh;
+    xxh.start();
+    doSomething(xxh);
+    auto hash = xxh.finish;
+    assert(toHexString(hash) == "A6CD5E9392000F6AC44BDFF4074EECDB", "Got " ~ toHexString(hash));
+}
+
+///
+@safe unittest
+{
+    assert(isDigest!XXH_32);
+    assert(isDigest!XXH_64);
+    assert(isDigest!XXH3_64);
+    assert(isDigest!XXH3_128);
+}
+
+@system unittest
+{
+    import std.range;
+    import std.conv : hexString;
+
+    ubyte[4] digest32;
+    ubyte[8] digest64;
+    ubyte[16] digest128;
+
+    XXH_32 xxh;
+    xxh.put(cast(ubyte[])"abcdef");
+    xxh.start();
+    xxh.put(cast(ubyte[])"");
+    assert(xxh.finish() == cast(ubyte[]) hexString!"02cc5d05");
+
+    digest32 = xxh32Of("");
+    assert(digest32 == cast(ubyte[]) hexString!"02cc5d05");
+    digest64 = xxh64Of("");
+    assert(digest64 == cast(ubyte[]) hexString!"EF46DB3751D8E999", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("");
+    assert(digest64 == cast(ubyte[]) hexString!"2D06800538D394C2", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("");
+    assert(digest128 == cast(ubyte[]) hexString!"99AA06D3014798D86001C324468D497F", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("a");
+    assert(digest32 == cast(ubyte[]) hexString!"550d7456");
+    digest64 = xxh64Of("a");
+    assert(digest64 == cast(ubyte[]) hexString!"D24EC4F1A98C6E5B", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("a");
+    assert(digest64 == cast(ubyte[]) hexString!"E6C632B61E964E1F", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("a");
+    assert(digest128 == cast(ubyte[]) hexString!"A96FAF705AF16834E6C632B61E964E1F", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("abc");
+    assert(digest32 == cast(ubyte[]) hexString!"32D153FF");
+    digest64 = xxh64Of("abc");
+    assert(digest64 == cast(ubyte[]) hexString!"44BC2CF5AD770999");
+    digest64 = xxh3_64Of("abc");
+    assert(digest64 == cast(ubyte[]) hexString!"78AF5F94892F3950");
+    digest128 = xxh128Of("abc");
+    assert(digest128 == cast(ubyte[]) hexString!"06B05AB6733A618578AF5F94892F3950");
+
+    digest32 = xxh32Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    assert(digest32 == cast(ubyte[]) hexString!"89ea60c3");
+    digest64 = xxh64Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    assert(digest64 == cast(ubyte[]) hexString!"F06103773E8585DF", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    assert(digest64 == cast(ubyte[]) hexString!"5BBCBBABCDCC3D3F", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+    assert(digest128 == cast(ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("message digest");
+    assert(digest32 == cast(ubyte[]) hexString!"7c948494");
+    digest64 = xxh64Of("message digest");
+    assert(digest64 == cast(ubyte[]) hexString!"066ED728FCEEB3BE", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("message digest");
+    assert(digest64 == cast(ubyte[]) hexString!"160D8E9329BE94F9", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("message digest");
+    assert(digest128 == cast(ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("abcdefghijklmnopqrstuvwxyz");
+    assert(digest32 == cast(ubyte[]) hexString!"63a14d5f");
+    digest64 = xxh64Of("abcdefghijklmnopqrstuvwxyz");
+    assert(digest64 == cast(ubyte[]) hexString!"CFE1F278FA89835C", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("abcdefghijklmnopqrstuvwxyz");
+    assert(digest64 == cast(ubyte[]) hexString!"810F9CA067FBB90C", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("abcdefghijklmnopqrstuvwxyz");
+    assert(digest128 == cast(ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    assert(digest32 == cast(ubyte[]) hexString!"9c285e64");
+    digest64 = xxh64Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    assert(digest64 == cast(ubyte[]) hexString!"AAA46907D3047814", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    assert(digest64 == cast(ubyte[]) hexString!"643542BB51639CB2", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    assert(digest128 == cast(ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB", "Got " ~ toHexString(digest128));
+
+    digest32 = xxh32Of("1234567890123456789012345678901234567890"~
+                    "1234567890123456789012345678901234567890");
+    assert(digest32 == cast(ubyte[]) hexString!"9c05f475");
+    digest64 = xxh64Of("1234567890123456789012345678901234567890"~
+                    "1234567890123456789012345678901234567890");
+    assert(digest64 == cast(ubyte[]) hexString!"E04A477F19EE145D", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of("1234567890123456789012345678901234567890"~
+                    "1234567890123456789012345678901234567890");
+    assert(digest64 == cast(ubyte[]) hexString!"7F58AA2520C681F9", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of("1234567890123456789012345678901234567890"~
+                    "1234567890123456789012345678901234567890");
+    assert(digest128 == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8", "Got " ~ toHexString(digest128));
+
+    enum ubyte[16] input = cast(ubyte[16]) hexString!"c3fcd3d76192e4007dfb496cca67e13b";
+    assert(toHexString(input)
+        == "C3FCD3D76192E4007DFB496CCA67E13B");
+
+    ubyte[] onemilliona = new ubyte[1000000];
+    onemilliona[] = 'a';
+    digest32 = xxh32Of(onemilliona);
+    assert(digest32 == cast(ubyte[]) hexString!"E1155920", "Got " ~ toHexString(digest32));
+    digest64 = xxh64Of(onemilliona);
+    assert(digest64 == cast(ubyte[]) hexString!"DC483AAA9B4FDC40", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of(onemilliona);
+    assert(digest64 == cast(ubyte[]) hexString!"B1FD6FAE5285C4EB", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of(onemilliona);
+    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB", "Got " ~ toHexString(digest128));
+
+    auto oneMillionRange = repeat!ubyte(cast(ubyte)'a', 1000000);
+    digest32 = xxh32Of(oneMillionRange);
+    assert(digest32 == cast(ubyte[]) hexString!"E1155920", "Got " ~ toHexString(digest32));
+    digest64 = xxh64Of(oneMillionRange);
+    assert(digest64 == cast(ubyte[]) hexString!"DC483AAA9B4FDC40", "Got " ~ toHexString(digest64));
+    digest64 = xxh3_64Of(oneMillionRange);
+    assert(digest64 == cast(ubyte[]) hexString!"B1FD6FAE5285C4EB", "Got " ~ toHexString(digest64));
+    digest128 = xxh128Of(oneMillionRange);
+    assert(digest128 == cast(ubyte[]) hexString!"A545DF8E384A9579B1FD6FAE5285C4EB", "Got " ~ toHexString(digest128));
+}
+
+/**
+ * This is a convenience alias for $(REF digest, std,digest) using the
+ * XXH implementation.
+ */
+//simple alias doesn't work here, hope this gets inlined...
+auto xxh32Of(T...)(T data)
+{
+    return digest!(XXH_32, T)(data);
+}
+/// Ditto
+auto xxh64Of(T...)(T data)
+{
+    return digest!(XXH_64, T)(data);
+}
+/// Ditto
+auto xxh3_64Of(T...)(T data)
+{
+    return digest!(XXH3_64, T)(data);
+}
+/// Ditto
+auto xxh128Of(T...)(T data)
+{
+    return digest!(XXH3_128, T)(data);
+}
+
+///
+@safe unittest
+{
+    auto hash = xxh32Of("abc");
+    assert(hash == digest!XXH_32("abc"));
+    auto hash1 = xxh64Of("abc");
+    assert(hash1 == digest!XXH_64("abc"));
+    auto hash2 = xxh3_64Of("abc");
+    assert(hash2 == digest!XXH3_64("abc"));
+    auto hash3 = xxh128Of("abc");
+    assert(hash3 == digest!XXH3_128("abc"));
+}
+
+/**
+ * OOP API XXH implementation.
+ * See `std.digest` for differences between template and OOP API.
+ *
+ * This is an alias for $(D $(REF WrapperDigest, std,digest)!XXH_32), see
+ * there for more information.
+ */
+alias XXH32Digest = WrapperDigest!XXH_32;
+alias XXH64Digest = WrapperDigest!XXH_64; ///ditto
+alias XXH3_64Digest = WrapperDigest!XXH3_64; ///ditto
+alias XXH128Digest = WrapperDigest!XXH3_128; ///ditto
+
+///
+@safe unittest
+{
+    //Simple example, hashing a string using Digest.digest helper function
+    auto xxh = new XXH32Digest();
+    ubyte[] hash = xxh.digest("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "32D153FF");
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using Digest.digest helper function
+    auto xxh = new XXH64Digest();
+    ubyte[] hash = xxh.digest("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "44BC2CF5AD770999");
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using Digest.digest helper function
+    auto xxh = new XXH3_64Digest();
+    ubyte[] hash = xxh.digest("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "78AF5F94892F3950");
+}
+///
+@safe unittest
+{
+    //Simple example, hashing a string using Digest.digest helper function
+    auto xxh = new XXH128Digest();
+    ubyte[] hash = xxh.digest("abc");
+    //Let's get a hash string
+    assert(toHexString(hash) == "06B05AB6733A618578AF5F94892F3950");
+}
+
+///
+@system unittest
+{
+     //Let's use the OOP features:
+    void test(Digest dig)
+    {
+      dig.put(cast(ubyte) 0);
+    }
+    auto xxh = new XXH32Digest();
+    test(xxh);
+
+    //Let's use a custom buffer:
+    ubyte[16] buf;
+    ubyte[] result = xxh.finish(buf[]);
+    assert(toHexString(result) == "CF65B03E", "Got " ~ toHexString(result));
+}
+///
+@system unittest
+{
+     //Let's use the OOP features:
+    void test(Digest dig)
+    {
+      dig.put(cast(ubyte) 0);
+    }
+    auto xxh = new XXH64Digest();
+    test(xxh);
+
+    //Let's use a custom buffer:
+    ubyte[16] buf;
+    ubyte[] result = xxh.finish(buf[]);
+    assert(toHexString(result) == "E934A84ADB052768", "Got " ~ toHexString(result));
+}
+///
+@system unittest
+{
+     //Let's use the OOP features:
+    void test(Digest dig)
+    {
+      dig.put(cast(ubyte) 0);
+    }
+    auto xxh = new XXH3_64Digest();
+    test(xxh);
+
+    //Let's use a custom buffer:
+    ubyte[16] buf;
+    ubyte[] result = xxh.finish(buf[]);
+    assert(toHexString(result) == "C44BDFF4074EECDB", "Got " ~ toHexString(result));
+}
+///
+@system unittest
+{
+     //Let's use the OOP features:
+    void test(Digest dig)
+    {
+      dig.put(cast(ubyte) 0);
+    }
+    auto xxh = new XXH128Digest();
+    test(xxh);
+
+    //Let's use a custom buffer:
+    ubyte[16] buf;
+    ubyte[] result = xxh.finish(buf[]);
+    assert(toHexString(result) == "A6CD5E9392000F6AC44BDFF4074EECDB", "Got " ~ toHexString(result));
+}
+
+@system unittest
+{
+    import std.conv : hexString;
+    auto xxh = new XXH32Digest();
+    auto xxh64 = new XXH64Digest();
+    auto xxh3_64 = new XXH3_64Digest();
+    auto xxh128 = new XXH128Digest();
+
+    xxh.put(cast(ubyte[])"abcdef");
+    xxh.reset();
+    xxh.put(cast(ubyte[])"");
+    assert(xxh.finish() == cast(ubyte[]) hexString!"02cc5d05");
+
+    xxh.put(cast(ubyte[])"abcdefghijklmnopqrstuvwxyz");
+    ubyte[20] result;
+    auto result2 = xxh.finish(result[]);
+    assert(result[0 .. 4] == result2 && result2 == cast(ubyte[]) hexString!"63a14d5f", "Got " ~ toHexString(result));
+
+    debug
+    {
+        import std.exception;
+        assertThrown!Error(xxh.finish(result[0 .. 3]));
+    }
+
+    assert(xxh.length == 4);
+    assert(xxh64.length == 8);
+    assert(xxh3_64.length == 8);
+    assert(xxh128.length == 16);
+
+    assert(xxh.digest("") == cast(ubyte[]) hexString!"02cc5d05");
+    assert(xxh64.digest("") == cast(ubyte[]) hexString!"EF46DB3751D8E999");
+    assert(xxh3_64.digest("") == cast(ubyte[]) hexString!"2D06800538D394C2");
+    assert(xxh128.digest("") == cast(ubyte[]) hexString!"99AA06D3014798D86001C324468D497F");
+
+    assert(xxh.digest("a") == cast(ubyte[]) hexString!"550d7456");
+    assert(xxh64.digest("a") == cast(ubyte[]) hexString!"D24EC4F1A98C6E5B");
+    assert(xxh3_64.digest("a") == cast(ubyte[]) hexString!"E6C632B61E964E1F");
+    assert(xxh128.digest("a") == cast(ubyte[]) hexString!"A96FAF705AF16834E6C632B61E964E1F");
+
+    assert(xxh.digest("abc") == cast(ubyte[]) hexString!"32D153FF");
+    assert(xxh64.digest("abc") == cast(ubyte[]) hexString!"44BC2CF5AD770999");
+    assert(xxh3_64.digest("abc") == cast(ubyte[]) hexString!"78AF5F94892F3950");
+    assert(xxh128.digest("abc") == cast(ubyte[]) hexString!"06B05AB6733A618578AF5F94892F3950");
+
+    assert(xxh.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+           == cast(ubyte[]) hexString!"89ea60c3");
+    assert(xxh64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+           == cast(ubyte[]) hexString!"F06103773E8585DF");
+    assert(xxh3_64.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+           == cast(ubyte[]) hexString!"5BBCBBABCDCC3D3F");
+    assert(xxh128.digest("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+           == cast(ubyte[]) hexString!"3D62D22A5169B016C0D894FD4828A1A7");
+
+    assert(xxh.digest("message digest") == cast(ubyte[]) hexString!"7c948494");
+    assert(xxh64.digest("message digest") == cast(ubyte[]) hexString!"066ED728FCEEB3BE");
+    assert(xxh3_64.digest("message digest") == cast(ubyte[]) hexString!"160D8E9329BE94F9");
+    assert(xxh128.digest("message digest") == cast(ubyte[]) hexString!"34AB715D95E3B6490ABFABECB8E3A424");
+
+    assert(xxh.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"63a14d5f");
+    assert(xxh64.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"CFE1F278FA89835C");
+    assert(xxh3_64.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"810F9CA067FBB90C");
+    assert(xxh128.digest("abcdefghijklmnopqrstuvwxyz") == cast(ubyte[]) hexString!"DB7CA44E84843D67EBE162220154E1E6");
+
+    assert(xxh.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+           == cast(ubyte[]) hexString!"9c285e64");
+    assert(xxh64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+           == cast(ubyte[]) hexString!"AAA46907D3047814");
+    assert(xxh3_64.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+           == cast(ubyte[]) hexString!"643542BB51639CB2");
+    assert(xxh128.digest("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+           == cast(ubyte[]) hexString!"5BCB80B619500686A3C0560BD47A4FFB");
+
+    assert(xxh.digest("1234567890123456789012345678901234567890",
+                                   "1234567890123456789012345678901234567890")
+           == cast(ubyte[]) hexString!"9c05f475");
+    assert(xxh64.digest("1234567890123456789012345678901234567890",
+                                   "1234567890123456789012345678901234567890")
+           == cast(ubyte[]) hexString!"E04A477F19EE145D");
+    assert(xxh3_64.digest("1234567890123456789012345678901234567890",
+                                   "1234567890123456789012345678901234567890")
+           == cast(ubyte[]) hexString!"7F58AA2520C681F9");
+    assert(xxh128.digest("1234567890123456789012345678901234567890",
+                                   "1234567890123456789012345678901234567890")
+           == cast(ubyte[]) hexString!"08DD22C3DDC34CE640CB8D6AC672DCB8");
+}

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -45,10 +45,14 @@ $(TR $(TDNW Helpers) $(TD $(MYREF xxh32Of))
 /* xxh.d - A wrapper for the original C implementation */
 module std.digest.xxh;
 
+
 version (X86)
     version = HaveUnalignedLoads;
 else version (X86_64)
     version = HaveUnalignedLoads;
+
+//TODO: Properly detect this requirement.
+//version = CheckACCAlignment;
 
 //TODO: Check, if this code is an advantage over XXH provided code
 //      The code from core.int128 doesn't inline.
@@ -1396,8 +1400,9 @@ enum XXH_ACC_ALIGN = 8;
 private void xxh3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
-in((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_ALIGN - 1)) != 0")
 {
+    version (CheckACCAlignment)
+        assert((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_ALIGN - 1)) != 0");
     ulong* xacc = cast(ulong*) acc;
     ubyte* xinput = cast(ubyte*) input;
     ubyte* xsecret = cast(ubyte*) secret;
@@ -1427,9 +1432,10 @@ private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  */
 // TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
-in(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0")
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 {
+    version (CheckACCAlignment)
+        assert(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0");
     ulong* xacc = cast(ulong*) acc; /* presumed aligned */
     const ubyte* xsecret = cast(const ubyte*) secret; /* no alignment restriction */
     {

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -50,6 +50,15 @@ version (X86)
 else version (X86_64)
     version = HaveUnalignedLoads;
 
+//TODO: Check, if this code is an advantage over XXH provided code
+//      The code from core.int128 doesn't inline.
+//version = Have128BitInteger;
+
+version(Have128BitInteger)
+{
+    import core.int128;
+}
+
 ///
 @safe unittest
 {
@@ -1052,17 +1061,14 @@ private ulong xxh_mult32to64(uint x, uint y) @safe pure nothrow @nogc
  */
 private XXH128_hash_t xxh_mult64to128(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 {
-    static if (is(ucent))
+    version(Have128BitInteger)
     {
-        //import std.int128;
-        //alias uint128_t = Int128;
-
-        const uint128_t product = cast(uint128_t_) lhs * cast(uint128_t_) rhs;
+        Cent cent_lhs; cent_lhs.lo = lhs;
+        Cent cent_rhs; cent_rhs.lo = rhs;
+        const Cent product = mul(cent_lhs, cent_rhs);
         XXH128_hash_t r128;
-        // r128.low64  = cast(ulong) (product);
-        // r128.high64 = cast(ulong) (product >> 64);
-        r128.low64 = product.data.lo;
-        r128.high64 = product.data.hi;
+        r128.low64 = product.lo;
+        r128.high64 = product.hi;
     }
     else
     {

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -2517,17 +2517,20 @@ public:
          */
     void put(scope const(ubyte)[] data...) @safe nothrow @nogc
     {
-        XXH_errorcode ec;
-        static if (digestSize == 32)
-            ec = XXH32_update(&state, &data[0], data.length);
-        else static if (digestSize == 64 && !useXXH3)
-            ec = XXH64_update(&state, &data[0], data.length);
-        else static if (digestSize == 64 && useXXH3)
-            ec = XXH3_64bits_update(&state, &data[0], data.length);
-        else static if (digestSize == 128)
-            ec = XXH3_128bits_update(&state, &data[0], data.length);
-        else
-            assert(false, "Unknown XXH bitdeep or variant");
+        XXH_errorcode ec = XXH_errorcode.XXH_OK;
+        if (data.length > 0) // digest will only change, when there is data!
+        {
+            static if (digestSize == 32)
+                ec = XXH32_update(&state, &data[0], data.length);
+            else static if (digestSize == 64 && !useXXH3)
+                ec = XXH64_update(&state, &data[0], data.length);
+            else static if (digestSize == 64 && useXXH3)
+                ec = XXH3_64bits_update(&state, &data[0], data.length);
+            else static if (digestSize == 128)
+                ec = XXH3_128bits_update(&state, &data[0], data.length);
+            else
+                assert(false, "Unknown XXH bitdeep or variant");
+        }
         assert(ec == XXH_errorcode.XXH_OK, "Update failed");
     }
 

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -536,8 +536,6 @@ XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, XXH32_hash_t seed) @trusted p
 
 XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     if (input == null)
     {
         assert(len == 0, "input null ptr only allowed with len == 0");
@@ -552,17 +550,16 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
         state.large_len |= cast(XXH32_hash_t)((len >= 16) | (state.total_len_32 >= 16));
 
         if (state.memsize + len < 16)
-        { /* fill in tmp buffer */
-            //OBS memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, len);
-            (cast(ubyte*) state.mem32)[state.memsize .. state.memsize + len] =
-                (cast(ubyte*) input)[0 .. len];
+        {
+            /* fill in tmp buffer */
+            (cast(ubyte*) state.mem32)[state.memsize .. state.memsize + len] = (cast(ubyte*) input)[0 .. len];
             state.memsize += cast(XXH32_hash_t) len;
             return XXH_errorcode.XXH_OK;
         }
 
         if (state.memsize)
-        { /* some data left from previous update */
-            //OBS memcpy(cast(ubyte*)(state.mem32) + state.memsize, input, 16 - state.memsize);
+        {
+            /* some data left from previous update */
             (cast(ubyte*) state.mem32)[state.memsize .. state.memsize + (16 - state.memsize)] =
                 (cast(ubyte*) input)[0 .. (16 - state.memsize)];
             {
@@ -600,7 +597,6 @@ XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) 
 
         if (p < bEnd)
         {
-            //OBS memcpy(cast(void*)&state.mem32[0], p, cast(size_t)(bEnd - p));
             (cast(ubyte*) state.mem32)[0 .. cast(size_t)(bEnd - p) ] =
                 (cast(ubyte*) p)[0 .. cast(size_t)(bEnd - p) ];
             state.memsize = cast(XXH32_hash_t)(bEnd - p);
@@ -632,13 +628,10 @@ XXH32_hash_t XXH32_digest(const XXH32_state_t* state) @trusted pure nothrow @nog
 
 void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t hash) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     static assert((XXH32_canonical_t).sizeof == (XXH32_hash_t).sizeof,
                     "(XXH32_canonical_t).sizeof != (XXH32_hash_t).sizeof");
     version (LittleEndian)
         hash = bswap(hash);
-    //OBS memcpy(dst, &hash, (*dst).sizeof);
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
@@ -868,8 +861,6 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
 
 XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
 {
-    //OBS: import core.stdc.string : memcpy;
-
     if (input == null)
     {
         assert(len == 0, "len != 0");
@@ -883,8 +874,8 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
         state.total_len += len;
 
         if (state.memsize + len < 32)
-        { /* fill in tmp buffer */
-            //OBS memcpy((cast(ubyte*) state.mem64) + state.memsize, input, len);
+        {
+            /* fill in tmp buffer */
             (cast(ubyte*) state.mem64) [state.memsize .. state.memsize + len] =
                  (cast(ubyte*) input) [0 .. len];
             state.memsize += cast(uint) len;
@@ -892,8 +883,8 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
         }
 
         if (state.memsize)
-        { /* tmp buffer is full */
-            //OBS memcpy((cast(ubyte*) state.mem64) + state.memsize, input, 32 - state.memsize);
+        {
+            /* tmp buffer is full */
             (cast(ubyte*) state.mem64) [state.memsize .. state.memsize + (32 - state.memsize)] =
                  (cast(ubyte*) input) [0 .. (32 - state.memsize)];
             state.v[0] = XXH64_round(state.v[0], XXH_readLE64(&state.mem64[0]));
@@ -925,7 +916,6 @@ XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) 
 
         if (p < bEnd)
         {
-            //OBS memcpy(cast(void*)&state.mem64[0], p, cast(size_t)(bEnd - p));
             (cast(void*) &state.mem64[0]) [0 .. cast(size_t) (bEnd - p)] =
                 (cast(void*) p) [0 .. cast(size_t) (bEnd - p)];
             state.memsize = cast(XXH32_hash_t)(bEnd - p);
@@ -961,13 +951,10 @@ XXH64_hash_t XXH64_digest(const XXH64_state_t* state) @trusted pure nothrow @nog
 
 void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     static assert((XXH64_canonical_t).sizeof == (XXH64_hash_t).sizeof,
                     "(XXH64_canonical_t).sizeof != (XXH64_hash_t).sizeof");
     version (LittleEndian)
         hash = bswap(hash);
-    //OBS memcpy(dst, &hash, (*dst).sizeof);
     (cast(ubyte*) dst) [0 .. dst.sizeof] = (cast(ubyte*) &hash) [0 .. dst.sizeof];
 }
 
@@ -1339,12 +1326,9 @@ enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
 private void XXH_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     version (LittleEndian) {}
     else
         v64 = bswap(v64);
-    //OBS memcpy(dst, &v64, (v64).sizeof);
     (cast(ubyte*) dst) [0 .. v64.sizeof] = (cast(ubyte*) &v64) [0 .. v64.sizeof];
 }
 
@@ -1818,8 +1802,6 @@ enum XXH3_STREAM_USE_STACK = 1;
 private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     if (input == null)
     {
         assert(len == 0, "len != 0");
@@ -1837,7 +1819,6 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
             * Operating into stack space seems to enable proper optimization.
             * clang, on the other hand, doesn't seem to need this trick */
             align(XXH_ACC_ALIGN) ulong[8] acc;
-            //OBS memcpy(&acc[0], &state.acc[0], (acc).sizeof);
             (cast(ubyte*) &acc[0]) [0 .. acc.sizeof] = (cast(ubyte*) &state.acc[0]) [0 .. acc.sizeof];
         }
         else
@@ -1850,7 +1831,6 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         /* small input : just fill in tmp buffer */
         if (state.bufferedSize + len <= XXH3_INTERNALBUFFER_SIZE)
         {
-            //OBS memcpy(&state.buffer[0] + state.bufferedSize, input, len);
             (cast(ubyte*) &state.buffer[0]) [state.bufferedSize .. state.bufferedSize + len] =
                 (cast(ubyte*) input) [0 .. len];
             state.bufferedSize += cast(XXH32_hash_t) len;
@@ -1868,7 +1848,6 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         if (state.bufferedSize)
         {
             const size_t loadSize = XXH3_INTERNALBUFFER_SIZE - state.bufferedSize;
-            //OBS memcpy(&state.buffer[0] + state.bufferedSize, input, loadSize);
             (cast(ubyte*)&state.buffer[0]) [state.bufferedSize .. state.bufferedSize + loadSize] =
                 (cast(ubyte*) input) [0 .. loadSize];
             input += loadSize;
@@ -1910,7 +1889,6 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
             assert(input < bEnd, "input exceeds buffer, no bytes left"); /* at least some bytes left */
             state.nbStripesSoFar = nbStripes;
             /* buffer predecessor of last partial stripe */
-            //OBS memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
             (cast(ubyte*) &state.buffer[0])
                 [state.buffer.sizeof - XXH_STRIPE_LEN .. state.buffer.sizeof - XXH_STRIPE_LEN + XXH_STRIPE_LEN] =
                 (cast(ubyte*) input - XXH_STRIPE_LEN) [0 .. XXH_STRIPE_LEN];
@@ -1932,7 +1910,6 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
                 }
                 while (input < limit);
                 /* buffer predecessor of last partial stripe */
-                //OBS memcpy(&state.buffer[0] + (state.buffer).sizeof - XXH_STRIPE_LEN, input - XXH_STRIPE_LEN, XXH_STRIPE_LEN);
                 (cast(ubyte*) &state.buffer[0])
                     [state.buffer.sizeof - XXH_STRIPE_LEN .. state.buffer.sizeof - XXH_STRIPE_LEN + XXH_STRIPE_LEN] =
                     (cast(ubyte*) input - XXH_STRIPE_LEN) [0 .. XXH_STRIPE_LEN];
@@ -1943,14 +1920,12 @@ private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input
         assert(input < bEnd, "input exceeds buffer");
         assert(bEnd - input <= XXH3_INTERNALBUFFER_SIZE, "input outside buffer");
         assert(state.bufferedSize == 0, "bufferedSize != 0");
-        //OBS memcpy(&state.buffer[0], input, cast(size_t)(bEnd - input));
         (cast(ubyte*) &state.buffer[0]) [0 .. cast(size_t)(bEnd - input)] =
             (cast(ubyte*) input) [0 .. cast(size_t)(bEnd - input)];
         state.bufferedSize = cast(XXH32_hash_t)(bEnd - input);
         static if (XXH3_STREAM_USE_STACK >= 1)
         {
             /* save stack accumulators into state */
-            //OBS memcpy(&state.acc[0], &acc[0], (acc).sizeof);
             (cast(ubyte*) &state.acc[0]) [0 .. acc.sizeof] = (cast(ubyte*) &acc[0]) [0 .. acc.sizeof];
         }
     }
@@ -1967,13 +1942,10 @@ XXH_errorcode XXH3_64bits_update(XXH3_state_t* state, scope const(void)* input, 
 
 void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret) @trusted pure nothrow @nogc
 {
-    //OBS import core.stdc.string : memcpy;
-
     /*
      * Digest on a local copy. This way, the state remains unaltered, and it can
      * continue ingesting more input afterwards.
      */
-    //OBS memcpy(&acc[0], &state.acc[0], (state.acc).sizeof);
     (cast(ubyte*) &acc[0]) [0 .. state.acc.sizeof] = (cast(ubyte*) &state.acc[0]) [0 .. state.acc.sizeof];
     if (state.bufferedSize >= XXH_STRIPE_LEN)
     {
@@ -1990,10 +1962,8 @@ void XXH3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte*
         ubyte[XXH_STRIPE_LEN] lastStripe;
         const size_t catchupSize = XXH_STRIPE_LEN - state.bufferedSize;
         assert(state.bufferedSize > 0, "bufferedSize <= 0"); /* there is always some input buffered */
-        //OBS memcpy(&lastStripe[0], &state.buffer[0] + (state.buffer).sizeof - catchupSize, catchupSize);
         (cast(ubyte*) &lastStripe[0]) [0 .. catchupSize] =
             (cast(ubyte*) &state.buffer[0]) [state.buffer.sizeof - catchupSize .. state.buffer.sizeof];
-        //OBS memcpy(&lastStripe[0] + catchupSize, &state.buffer[0], state.bufferedSize);
         (cast(ubyte*) &lastStripe[0]) [catchupSize .. catchupSize + state.bufferedSize] =
             (cast(ubyte*) &state.buffer[0]) [0 .. state.buffer.sizeof];
         XXH3_accumulate_512(&acc[0], &lastStripe[0], &secret[0] + state.secretLimit - XXH_SECRET_LASTACC_START);

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -218,7 +218,6 @@ private enum XXH_alignment
     XXH_unaligned /** Possibly unaligned */
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
@@ -229,7 +228,6 @@ private uint xxh_read32(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -246,7 +244,6 @@ private uint xxh_readBE32(const void* ptr) @safe pure nothrow @nogc
         return xxh_read32(ptr);
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -429,7 +426,6 @@ private uint xxh32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private uint xxh32_endian_align(const(ubyte)* input, size_t len,
         uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
@@ -643,7 +639,6 @@ private ulong xxh_read64(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -660,7 +655,6 @@ private ulong xxh_readBE64(const void* ptr) @safe pure nothrow @nogc
         return xxh_read64(ptr);
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -765,7 +759,6 @@ do
  * Param: align Whether @p input is aligned.
  * Return: The calculated hash.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 in
@@ -1114,7 +1107,6 @@ private ulong xxh3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 }
 
 /* Seems to produce slightly better code on GCC for some reason. */
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
 in(0 <= shift && shift < 64, "shift out of range")
 {
@@ -1181,7 +1173,6 @@ static XXH64_hash_t xxh3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
  *
  * This adds an extra layer of strength for custom secrets.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_1to3_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed)
         @trusted pure nothrow @nogc
@@ -1206,7 +1197,6 @@ in(secret != null, "secret == null")
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_4to8_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
@@ -1224,7 +1214,6 @@ in(4 <= len && len <= 8, "len out of range")
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_9to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
@@ -1242,19 +1231,16 @@ in(9 <= len && len <= 16, "len out of range")
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private bool xxh_likely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private bool xxh_unlikely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_0to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(len <= 16, "len > 16")
@@ -1296,7 +1282,6 @@ in(len <= 16, "len > 16")
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
 {
     {
@@ -1308,7 +1293,6 @@ private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed6
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_17to128_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1343,7 +1327,6 @@ enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
-// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_len_129to240_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1378,7 +1361,6 @@ enum XXH_STRIPE_LEN = 64;
 enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumulation */
 enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     version (LittleEndian) {}
@@ -1396,7 +1378,6 @@ enum XXH_ACC_ALIGN = 8;
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
@@ -1415,7 +1396,6 @@ in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 }
 
 /* Processes a 64 byte block of data using the scalar path. */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1430,7 +1410,6 @@ private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 {
@@ -1449,7 +1428,6 @@ in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 }
 
 /* Scrambles the accumulators after a large chunk has been read */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1459,7 +1437,6 @@ private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure 
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
 {
     /*
@@ -1511,17 +1488,17 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
 {
     cast(void)(ptr); /* DISABLED prefetch and do nothing here */
 
-//TODO In C it is done with the following code lines:
-//TODO  if XXH_SIZE_OPT >= 1
-//TODO    define XXH_PREFETCH(ptr) (void)(ptr)
-//TODO  elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))  /* _mm_prefetch() not defined outside of x86/x64 */
-//TODO    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
-//TODO    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
-//TODO  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-//TODO    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw == read */, 3 /* locality */)
-//TODO  else
-//TODO    define XXH_PREFETCH(ptr) (void)(ptr)  /* disabled */
-//TODO  endif
+// In C it is done with the following code lines:
+//  if XXH_SIZE_OPT >= 1
+//    define XXH_PREFETCH(ptr) (void)(ptr)
+//  elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))  /* _mm_prefetch() not defined outside of x86/x64 */
+//    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
+//    define XXH_PREFETCH(ptr)  _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
+//  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
+//    define XXH_PREFETCH(ptr)  __builtin_prefetch((ptr), 0 /* rw == read */, 3 /* locality */)
+//  else
+//    define XXH_PREFETCH(ptr) (void)(ptr)  /* disabled */
+//  endif
 }
 
 /*
@@ -1529,7 +1506,6 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
  * Loops over xxh3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_accumulate(ulong* acc, const ubyte* input,
         const ubyte* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
@@ -1542,7 +1518,6 @@ private void xxh3_accumulate(ulong* acc, const ubyte* input,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1577,7 +1552,6 @@ in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
 
 enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
-// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
 {
     return xxh3_mul128_fold64(acc[0] ^ xxh_readLE64(secret), acc[1] ^ xxh_readLE64(secret + 8));
@@ -1602,7 +1576,6 @@ static immutable XXH3_INIT_ACC = [
         XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1
     ];
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -1627,7 +1600,6 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * so that the compiler can properly optimize the vectorized loop.
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_withSecret(const(void)* input,
         size_t len, XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1642,7 +1614,6 @@ private XXH64_hash_t xxh3_hashLong_64b_withSecret(const(void)* input,
  * Note that inside this no_inline function, we do inline the internal loop,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
-// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_hashLong_64b_default(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1666,7 +1637,6 @@ enum XXH_SEC_ALIGN = 8;
  * It's important for performance that XXH3_hashLong is not inlined. Not sure
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -1687,7 +1657,6 @@ private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(const(void)* input, siz
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_hashLong_64b_withSeed(const(void)* input, size_t len,
         XXH64_hash_t seed, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1700,7 +1669,6 @@ private XXH64_hash_t xxh3_hashLong_64b_withSeed(const(void)* input, size_t len,
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
         XXH64_hash_t, const(ubyte)*, size_t) @safe pure nothrow @nogc;
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
         @safe pure nothrow @nogc
@@ -1849,7 +1817,6 @@ XXH_errorcode xxh3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 /* Note : when xxh3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
         size_t nbStripesPerBlock, const ubyte* input, size_t nbStripes,
         const ubyte* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
@@ -1881,7 +1848,6 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both xxh3_64bits_update and xxh3_128bits_update use this routine.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH_errorcode xxh3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(state != null, "state == null")
@@ -2028,7 +1994,6 @@ XXH_errorcode xxh3_64bits_update(XXH3_state_t* state, scope const(void)* input, 
             xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
     @trusted pure nothrow @nogc
 {
@@ -2094,7 +2059,6 @@ XXH64_hash_t xxh3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * XXH128 is also more oriented towards 64-bit machines. It is still extremely
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_1to3_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2125,7 +2089,6 @@ private XXH128_hash_t xxh3_len_1to3_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_4to8_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2154,7 +2117,6 @@ private XXH128_hash_t xxh3_len_4to8_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_9to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2233,7 +2195,6 @@ private XXH128_hash_t xxh3_len_9to16_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_0to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2256,7 +2217,6 @@ private XXH128_hash_t xxh3_len_0to16_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
         const ubyte* input_2, const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2267,7 +2227,6 @@ private XXH128_hash_t xxh128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
     return acc;
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_17to128_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2319,7 +2278,6 @@ private XXH128_hash_t xxh3_len_17to128_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_len_129to240_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2362,7 +2320,6 @@ private XXH128_hash_t xxh3_len_129to240_128b(const ubyte* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -2384,7 +2341,6 @@ private XXH128_hash_t xxh3_hashLong_128b_internal(const void* input, size_t len,
     }
 }
 
-// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_hashLong_128b_default(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2399,7 +2355,6 @@ private XXH128_hash_t xxh3_hashLong_128b_default(const void* input, size_t len,
  * It's important for performance to pass @p secretLen (when it's static)
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_withSecret(const void* input,
         size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2408,7 +2363,6 @@ private XXH128_hash_t xxh3_hashLong_128b_withSecret(const void* input,
             secretLen, xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -2426,7 +2380,6 @@ private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(const void* input, si
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_hashLong_128b_withSeed(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2439,7 +2392,6 @@ private XXH128_hash_t xxh3_hashLong_128b_withSeed(const void* input, size_t len,
 alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
         XXH64_hash_t, const void*, size_t) @safe pure nothrow @nogc;
 
-// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_128bits_internal(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
         @safe pure nothrow @nogc
@@ -2578,7 +2530,7 @@ version (LittleEndian)
     private alias bigEndianToNative = bswap;
 }
 else
-    // TODO: Do we need that? // pragma(inline, true) private pure @nogc nothrow @safe
+pragma(inline, true) private pure @nogc nothrow @safe
 {
     uint nativeToBigEndian(uint val)
     {

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -44,7 +44,10 @@ $(TR $(TDNW Helpers) $(TD $(MYREF xxh32Of))
 /* xxh.d - A wrapper for the original C implementation */
 module std.digest.xxh;
 
-public import std.digest;
+version (X86)
+    version = HaveUnalignedLoads;
+else version (X86_64)
+    version = HaveUnalignedLoads;
 
 ///
 @safe unittest

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -491,7 +491,11 @@ in (statePtr != null, "statePtr is null")
 }
 
 XXH_errorcode XXH32_update(XXH32_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
-in(input !is null && !len, "input null ptr only allowed with len == 0")
+in
+{
+    if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
+}
+do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;
@@ -693,8 +697,13 @@ ulong XXH_get64bits(const void* p, XXH_alignment align_) @safe pure nothrow @nog
  */
 private ulong XXH64_finalize(ulong hash, const(ubyte)* ptr, size_t len, XXH_alignment align_)
     @trusted pure nothrow @nogc
-in(ptr !is null && !len, "input null ptr only allowed with len == 0")
+in
 {
+    if (ptr == null) assert(len == 0, "input null ptr only allowed with len == 0");
+}
+do
+{
+
     len &= 31;
     while (len >= 8)
     {
@@ -729,7 +738,11 @@ in(ptr !is null && !len, "input null ptr only allowed with len == 0")
 pragma(inline, true)
 private ulong XXH64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
-in(input !is null && !len, "input null ptr only allowed with len == 0")
+in
+{
+    if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
+}
+do
 {
     ulong h64;
 
@@ -810,7 +823,11 @@ XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, XXH64_hash_t seed) @trusted p
 }
 
 XXH_errorcode XXH64_update(XXH64_state_t* state, const void* input, size_t len) @trusted pure nothrow @nogc
-in(input !is null && !len, "input null ptr only allowed with len == 0")
+in
+{
+    if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
+}
+do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;
@@ -1801,7 +1818,11 @@ pragma(inline, true)
 private XXH_errorcode XXH3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(state != null, "state == null")
-in(input !is null && !len, "input null ptr only allowed with len == 0")
+in
+{
+    if (input == null) assert(len == 0, "input null ptr only allowed with len == 0");
+}
+do
 {
     if (input == null && len == 0)
         return XXH_errorcode.XXH_OK;

--- a/std/digest/xxh.d
+++ b/std/digest/xxh.d
@@ -202,7 +202,7 @@ private enum XXH_alignment
     XXH_unaligned /** Possibly unaligned */
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_read32(const void* ptr) @trusted pure nothrow @nogc
 {
     uint val;
@@ -213,7 +213,7 @@ private uint xxh_read32(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_readLE32(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -230,7 +230,7 @@ private uint xxh_readBE32(const void* ptr) @safe pure nothrow @nogc
         return xxh_read32(ptr);
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private uint xxh_readLE32_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -413,7 +413,7 @@ private uint xxh32_finalize(uint hash, const(ubyte)* ptr, size_t len, XXH_alignm
  *  align_ = Whether input is aligned.
  * Return: The calculated hash.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private uint xxh32_endian_align(const(ubyte)* input, size_t len,
         uint seed, XXH_alignment align_) @trusted pure nothrow @nogc
 {
@@ -627,7 +627,7 @@ private ulong xxh_read64(const void* ptr) @trusted pure nothrow @nogc
     return val;
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_readLE64(const void* ptr) @safe pure nothrow @nogc
 {
     version (LittleEndian)
@@ -644,7 +644,7 @@ private ulong xxh_readBE64(const void* ptr) @safe pure nothrow @nogc
         return xxh_read64(ptr);
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_readLE64_align(const void* ptr, XXH_alignment align_) @trusted pure nothrow @nogc
 {
     if (align_ == XXH_alignment.XXH_unaligned)
@@ -749,7 +749,7 @@ do
  * Param: align Whether @p input is aligned.
  * Return: The calculated hash.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh64_endian_align(const(ubyte)* input, size_t len,
         ulong seed, XXH_alignment align_) @trusted pure nothrow @nogc
 in
@@ -1101,7 +1101,7 @@ private ulong xxh3_mul128_fold64(ulong lhs, ulong rhs) @safe pure nothrow @nogc
 }
 
 /* Seems to produce slightly better code on GCC for some reason. */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh_xorshift64(ulong v64, int shift) @safe pure nothrow @nogc
 in(0 <= shift && shift < 64, "shift out of range")
 {
@@ -1168,7 +1168,7 @@ static XXH64_hash_t xxh3_rrmxmx(ulong h64, ulong len) @safe pure nothrow @nogc
  *
  * This adds an extra layer of strength for custom secrets.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_1to3_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed)
         @trusted pure nothrow @nogc
@@ -1193,7 +1193,7 @@ in(secret != null, "secret == null")
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_4to8_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
@@ -1211,7 +1211,7 @@ in(4 <= len && len <= 8, "len out of range")
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_9to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(input != null, "input == null")
@@ -1229,19 +1229,19 @@ in(9 <= len && len <= 16, "len out of range")
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private bool xxh_likely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private bool xxh_unlikely(bool exp) @safe pure nothrow @nogc
 {
     return exp;
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_0to16_64b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(len <= 16, "len > 16")
@@ -1283,7 +1283,7 @@ in(len <= 16, "len > 16")
  * by this, although it is always a good idea to use a proper seed if you care
  * about strength.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed64) @trusted pure nothrow @nogc
 {
     {
@@ -1295,7 +1295,7 @@ private ulong xxh3_mix16B(const(ubyte)* input, const(ubyte)* secret, ulong seed6
 }
 
 /* For mid range keys, XXH3 uses a Mum-hash variant. */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_len_17to128_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1330,7 +1330,7 @@ enum XXH3_MIDSIZE_MAX = 240;
 enum XXH3_MIDSIZE_STARTOFFSET = 3;
 enum XXH3_MIDSIZE_LASTOFFSET = 17;
 
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_len_129to240_64b(const(ubyte)* input, size_t len,
         const(ubyte)* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1365,7 +1365,7 @@ enum XXH_STRIPE_LEN = 64;
 enum XXH_SECRET_CONSUME_RATE = 8; /* nb of secret bytes consumed at each accumulation */
 enum XXH_ACC_NB = (XXH_STRIPE_LEN / (ulong).sizeof);
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh_writeLE64(void* dst, ulong v64) @trusted pure nothrow @nogc
 {
     version (LittleEndian) {}
@@ -1383,7 +1383,7 @@ enum XXH_ACC_ALIGN = 8;
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scalarRound(void* acc, const(void)* input, const(void)* secret, size_t lane)
     @trusted pure nothrow @nogc
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
@@ -1401,7 +1401,7 @@ in((cast(size_t) acc & (XXH_ACC_ALIGN - 1)) == 0, "(cast(size_t) acc & (XXH_ACC_
 }
 
 /* Processes a 64 byte block of data using the scalar path. */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1416,7 +1416,7 @@ private void xxh3_accumulate_512_scalar(void* acc, const(void)* input, const(voi
  * This is extracted to its own function because the NEON path uses a combination
  * of NEON and scalar.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scalarScrambleRound(void* acc, const(void)* secret, size_t lane) @trusted pure nothrow @nogc
 in(((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) == 0, "((cast(size_t) acc) & (XXH_ACC_ALIGN - 1)) != 0")
 in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
@@ -1434,7 +1434,7 @@ in(lane < XXH_ACC_NB, "lane >= XXH_ACC_NB")
 }
 
 /* Scrambles the accumulators after a large chunk has been read */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure nothrow @nogc
 {
     size_t i;
@@ -1444,7 +1444,7 @@ private void xxh3_scrambleAcc_scalar(void* acc, const(void)* secret) @safe pure 
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_initCustomSecret_scalar(void* customSecret, ulong seed64) @trusted pure nothrow @nogc
 {
     /*
@@ -1499,7 +1499,7 @@ private void XXH_PREFETCH(const ubyte* ptr) @safe pure nothrow @nogc
  * Loops over xxh3_accumulate_512().
  * Assumption: nbStripes will not overflow the secret size
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_accumulate(ulong* acc, const ubyte* input,
         const ubyte* secret, size_t nbStripes, XXH3_f_accumulate_512 f_acc512) @trusted pure nothrow @nogc
 {
@@ -1512,7 +1512,7 @@ private void xxh3_accumulate(ulong* acc, const ubyte* input,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_hashLong_internal_loop(ulong* acc, const ubyte* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(secretSize >= XXH3_SECRET_SIZE_MIN, "secretSize < XXH3_SECRET_SIZE_MIN")
@@ -1547,7 +1547,7 @@ in(len > XXH_STRIPE_LEN, "len <= XXH_STRIPE_LEN")
 
 enum XXH_SECRET_LASTACC_START = 7; /* not aligned on 8, last secret is different from acc & scrambler */
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private ulong xxh3_mix2Accs(const(ulong)* acc, const(ubyte)* secret) @trusted pure nothrow @nogc
 {
     return xxh3_mul128_fold64(acc[0] ^ xxh_readLE64(secret), acc[1] ^ xxh_readLE64(secret + 8));
@@ -1572,7 +1572,7 @@ static immutable XXH3_INIT_ACC = [
         XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1
     ];
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_internal(const(void)* input, size_t len, const(void)* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -1597,7 +1597,7 @@ enum XXH_SECRET_MERGEACCS_START = 11;
  * so that the compiler can properly optimize the vectorized loop.
  * This makes a big performance difference for "medium" keys (<1 KB) when using AVX instruction set.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_withSecret(const(void)* input,
         size_t len, XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1612,7 +1612,7 @@ private XXH64_hash_t xxh3_hashLong_64b_withSecret(const(void)* input,
  * Note that inside this no_inline function, we do inline the internal loop,
  * and provide a statically defined secret size to allow optimization of vector loop.
  */
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_hashLong_64b_default(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1636,7 +1636,7 @@ enum XXH_SEC_ALIGN = 8;
  * It's important for performance that XXH3_hashLong is not inlined. Not sure
  * why (uop cache maybe?), but the difference is large and easily measurable.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(const(void)* input, size_t len, XXH64_hash_t seed,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -1657,7 +1657,7 @@ private XXH64_hash_t xxh3_hashLong_64b_withSeed_internal(const(void)* input, siz
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH64_hash_t xxh3_hashLong_64b_withSeed(const(void)* input, size_t len,
         XXH64_hash_t seed, const(ubyte)* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -1670,7 +1670,7 @@ private XXH64_hash_t xxh3_hashLong_64b_withSeed(const(void)* input, size_t len,
 alias XXH3_hashLong64_f = XXH64_hash_t function(const(void)*, size_t,
         XXH64_hash_t, const(ubyte)*, size_t) @safe pure nothrow @nogc;
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH64_hash_t xxh3_64bits_internal(const(void)* input, size_t len,
         XXH64_hash_t seed64, const(void)* secret, size_t secretLen, XXH3_hashLong64_f f_hashLong)
         @safe pure nothrow @nogc
@@ -1819,7 +1819,7 @@ XXH_errorcode xxh3_64bits_reset_withSecretandSeed(XXH3_state_t* statePtr,
 /* Note : when xxh3_consumeStripes() is invoked,
  * there must be a guarantee that at least one more byte must be consumed from input
  * so that the function can blindly consume all stripes using the "normal" secret segment */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_consumeStripes(ulong* acc, size_t* nbStripesSoFarPtr,
         size_t nbStripesPerBlock, const ubyte* input, size_t nbStripes,
         const ubyte* secret, size_t secretLimit, XXH3_f_accumulate_512 f_acc512,
@@ -1851,7 +1851,7 @@ enum XXH3_STREAM_USE_STACK = 1;
 /*
  * Both xxh3_64bits_update and xxh3_128bits_update use this routine.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH_errorcode xxh3_update(XXH3_state_t* state, scope const(ubyte)* input,
         size_t len, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 in(state != null, "state == null")
@@ -1998,7 +1998,7 @@ XXH_errorcode xxh3_64bits_update(XXH3_state_t* state, scope const(void)* input, 
             xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private void xxh3_digest_long(XXH64_hash_t* acc, const XXH3_state_t* state, const ubyte* secret)
     @trusted pure nothrow @nogc
 {
@@ -2064,7 +2064,7 @@ XXH64_hash_t xxh3_64bits_digest(const XXH3_state_t* state) @trusted pure nothrow
  * XXH128 is also more oriented towards 64-bit machines. It is still extremely
  * fast for a _128-bit_ hash on 32-bit (it usually clears XXH64).
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_1to3_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2095,7 +2095,7 @@ private XXH128_hash_t xxh3_len_1to3_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_4to8_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2124,7 +2124,7 @@ private XXH128_hash_t xxh3_len_4to8_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_9to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2203,7 +2203,7 @@ private XXH128_hash_t xxh3_len_9to16_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_0to16_128b(const ubyte* input, size_t len,
         const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2226,7 +2226,7 @@ private XXH128_hash_t xxh3_len_0to16_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
         const ubyte* input_2, const ubyte* secret, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2237,7 +2237,7 @@ private XXH128_hash_t xxh128_mix32B(XXH128_hash_t acc, const ubyte* input_1,
     return acc;
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_len_17to128_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2289,7 +2289,7 @@ private XXH128_hash_t xxh3_len_17to128_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_len_129to240_128b(const ubyte* input, size_t len,
         const ubyte* secret, size_t secretSize, XXH64_hash_t seed) @trusted pure nothrow @nogc
 {
@@ -2332,7 +2332,7 @@ private XXH128_hash_t xxh3_len_129to240_128b(const ubyte* input, size_t len,
     }
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_internal(const void* input, size_t len, const ubyte* secret,
         size_t secretSize, XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble) @trusted pure nothrow @nogc
 {
@@ -2354,7 +2354,7 @@ private XXH128_hash_t xxh3_hashLong_128b_internal(const void* input, size_t len,
     }
 }
 
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_hashLong_128b_default(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2369,7 +2369,7 @@ private XXH128_hash_t xxh3_hashLong_128b_default(const void* input, size_t len,
  * It's important for performance to pass @p secretLen (when it's static)
  * to the compiler, so that it can properly optimize the vectorized loop.
  */
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_withSecret(const void* input,
         size_t len, XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2378,7 +2378,7 @@ private XXH128_hash_t xxh3_hashLong_128b_withSecret(const void* input,
             secretLen, xxh3_accumulate_512, xxh3_scrambleAcc);
 }
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(const void* input, size_t len, XXH64_hash_t seed64,
         XXH3_f_accumulate_512 f_acc512, XXH3_f_scrambleAcc f_scramble,
         XXH3_f_initCustomSecret f_initSec) @safe pure nothrow @nogc
@@ -2396,7 +2396,7 @@ private XXH128_hash_t xxh3_hashLong_128b_withSeed_internal(const void* input, si
 /*
  * It's important for performance that XXH3_hashLong is not inlined.
  */
-pragma(inline, false)
+// TODO: Do we need that? // pragma(inline, false)
 private XXH128_hash_t xxh3_hashLong_128b_withSeed(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen) @safe pure nothrow @nogc
 {
@@ -2409,7 +2409,7 @@ private XXH128_hash_t xxh3_hashLong_128b_withSeed(const void* input, size_t len,
 alias XXH3_hashLong128_f = XXH128_hash_t function(const void*, size_t,
         XXH64_hash_t, const void*, size_t) @safe pure nothrow @nogc;
 
-pragma(inline, true)
+// TODO: Do we need that? // pragma(inline, true)
 private XXH128_hash_t xxh3_128bits_internal(const void* input, size_t len,
         XXH64_hash_t seed64, const void* secret, size_t secretLen, XXH3_hashLong128_f f_hl128)
         @safe pure nothrow @nogc
@@ -2548,7 +2548,7 @@ version (LittleEndian)
     private alias bigEndianToNative = bswap;
 }
 else
-    pragma(inline, true) private pure @nogc nothrow @safe
+    // TODO: Do we need that? // pragma(inline, true) private pure @nogc nothrow @safe
 {
     uint nativeToBigEndian(uint val)
     {

--- a/win32.mak
+++ b/win32.mak
@@ -204,6 +204,7 @@ SRC_STD_DIGEST= \
 	std\digest\ripemd.d \
 	std\digest\hmac.d \
 	std\digest\murmurhash.d \
+	std\digest\xxh.d \
 	std\digest\package.d
 
 SRC_STD_FORMAT= \

--- a/win64.mak
+++ b/win64.mak
@@ -233,6 +233,7 @@ SRC_STD_DIGEST= \
 	std\digest\ripemd.d \
 	std\digest\hmac.d \
 	std\digest\murmurhash.d \
+	std\digest\xxh.d \
 	std\digest\package.d
 
 SRC_STD_NET= \


### PR DESCRIPTION
Add XXHash digests to phobos library

This patch is motivated by the need to have a much faster alternative to the slow MD5 or SHAx cryptographic digests.
XXHash by itself is no cryptographic hash, but good enough to create suitable checksums and is used e.g. with ZSTD compression.

The patch adds the four digest variants of the XXHash project (see github.com:Cyan4973/xxHash.git) ranging
from 32 to 128 bits bits digests. Both variants for the 64 bit digest (XXH and XXH3) are implemented.

The C sources are ported to D and currently only implements the 'scalar' mode of operation. The further optimisations (SIMD)
are added later. So this ported XXHash digests are probably slower than the original C sources. There is also an experimental
version using the embedded C sources with optimisations, but initial reviewers rejected the idea of embedded more C sources
into Phobos, and argued for porting the C code to D.

The digests results were compared against the outputs of the xxhsum commandline utility manually and match the outputs
of the command line utility.

There are unittests for all variants of XXHash (taken from MD5 sources and digest values were updated accordingly).

The digests can be used with the template API:

-------
    XXH_32 hash0;
    hash0.start();
    hash0.put(cast(ubyte) 0);
    auto result = hash0.finish();

    XXH_64 hash1;
    hash1.start();
    hash1.put(cast(ubyte) 0);
    auto result = hash1.finish();

    XXH3_64 hash2;
    hash2.start();
    hash2.put(cast(ubyte) 0);
    auto result = hash2.finish();

    XXH3_128 hash3;
    hash3.start();
    hash3.put(cast(ubyte) 0);
    auto result = hash3.finish();
-------

as well as with the OOP versions:

-------
    auto xxh0 = new XXH32Digest();
    ubyte[] hash0 = xxh0.digest("abc");

    auto xxh1 = new XXH64Digest();
    ubyte[] hash1 = xxh1.digest("abc");

    auto xxh1 = new XXH3_64Digest();
    ubyte[] hash2 = xxh2.digest("abc");

    auto xxh2 = new XXH128Digest();
    ubyte[] hash3 = xxh3.digest("abc");
-------

There are some extra functions in the ported code (secrets, seeds), which are not yet
implemented publically. These functions will be added later.

------------------------------------------------------------------------------------------------------

Benchmarks:
https://gitlab.vahanus.net/dlang/hashbench.git

```
$ dub run --compiler=dmd-beta --
Performing "debug" build using dmd-beta for x86_64.
hashbench ~master: building configuration "application"...
Running pre-build commands...
Linking...
Running hashbench 
A benchmark utility for the phobos digests.

Build is a0026c2

Time Limit per test is 180
Phobos Digest Test 'test_md5.test_md5' (compiled on May 24 2022)
Average 147.586716 MB/s
Phobos Digest Test 'test_xxh32.test_xxh32' (compiled on May 24 2022)
Average 961.077881 MB/s
Phobos Digest Test 'test_xxh64.test_xxh64' (compiled on May 24 2022)
Average 1938.343140 MB/s
Phobos Digest Test 'test_xxh3_64.test_xxh3_64' (compiled on May 24 2022)
Average 1084.588257 MB/s
Phobos Digest Test 'test_xxh3_128.test_xxh3_128' (compiled on May 24 2022)
Average 1052.687256 MB/s
Phobos Digest Test 'test_murmur32.test_mm32' (compiled on May 24 2022)
Average 334.169739 MB/s
Phobos Digest Test 'test_murmur128.test_mm128' (compiled on May 24 2022)
Average 774.752014 MB/s
Total test duration: 28 secs, 388 ms, 258 μs, and 9 hnsecs
```
Optimized
```
$ dub run --compiler=dmd-beta -b=release --
Performing "release" build using dmd-beta for x86_64.
hashbench 0.0.0: building configuration "application"...
Running pre-build commands...
Linking...
Running hashbench 
A benchmark utility for the phobos digests.

Build is v0.0.0-0-gd5526bf

Time Limit per test is 180
Phobos Digest Test 'test_md5.test_md5' (compiled on May 24 2022)
Average 162.910431 MB/s
Phobos Digest Test 'test_xxh32.test_xxh32' (compiled on May 24 2022)
Average 945.801086 MB/s
Phobos Digest Test 'test_xxh64.test_xxh64' (compiled on May 24 2022)
Average 1801.930542 MB/s
Phobos Digest Test 'test_xxh3_64.test_xxh3_64' (compiled on May 24 2022)
Average 1074.387695 MB/s
Phobos Digest Test 'test_xxh3_128.test_xxh3_128' (compiled on May 24 2022)
Average 1072.683472 MB/s
Phobos Digest Test 'test_murmur32.test_mm32' (compiled on May 24 2022)
Average 4091.976562 MB/s
Phobos Digest Test 'test_murmur128.test_mm128' (compiled on May 24 2022)
Average 5495.587402 MB/s
Total test duration: 20 secs, 239 ms, 25 μs, and 1 hnsec
```

**Reference benchmark from XXH C Implementation:**
**Note: XXH3 uses vector code**
```
$ xxhsum -b
xxhsum 0.8.1 by Yann Collet 
compiled as 64-bit x86_64 autoVec little endian with GCC 11.2.0 
Sample of 100 KB...        
 1#XXH32                         :     102400 ->    93288 it/s ( 9110.2 MB/s)   
 3#XXH64                         :     102400 ->   135630 it/s (13245.2 MB/s)   
 5#XXH3_64b                      :     102400 ->   594488 it/s (58055.5 MB/s)   
11#XXH128                        :     102400 ->   591542 it/s (57767.8 MB/s)   
```

**Obviously the D variant of XXH does NOT optimize well at the moment.  Especially the XXH3 variants could be much faster using vector commands**

**For comparition the same benchmarks with embeeded XXH  C sources into Phobos:**
**Note: Vector Code disabled because of problems on Darwin! XXH3 is scalar code.**
```
$ dub run --compiler=dmd-beta -b release -- 
Performing "release" build using dmd-beta for x86_64.
hashbench 0.0.0: target for configuration "application" is up to date.
To force a rebuild of up-to-date targets, run again with --force.
Running hashbench 
A benchmark utility for the phobos digests.

Build is v0.0.0-0-gd5526bf

Time Limit per test is 180
Phobos Digest Test 'test_md5.test_md5' (compiled on May 25 2022)
Average 159.477325 MB/s
Phobos Digest Test 'test_xxh32.test_xxh32' (compiled on May 25 2022)
Average 8726.523438 MB/s
Phobos Digest Test 'test_xxh64.test_xxh64' (compiled on May 25 2022)
Average 17062.607422 MB/s
Phobos Digest Test 'test_xxh3_64.test_xxh3_64' (compiled on May 25 2022)
Average 18957.285156 MB/s
Phobos Digest Test 'test_xxh3_128.test_xxh3_128' (compiled on May 25 2022)
Average 18937.341797 MB/s
Phobos Digest Test 'test_murmur32.test_mm32' (compiled on May 25 2022)
Average 4002.023682 MB/s
Phobos Digest Test 'test_murmur128.test_mm128' (compiled on May 25 2022)
Average 5361.663574 MB/s
Total test duration: 14 secs, 740 ms, and 589 μs
```