### PR TITLE
chore(algorithm): mark reverse as return scope

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2558,7 +2558,7 @@ Note:
 
 See_Also: $(REF retro, std,range) for a lazy reverse without changing `r`
 */
-Range reverse(Range)(Range r)
+Range reverse(Range)(return scope Range r)
 if (isBidirectionalRange!Range &&
         (hasSwappableElements!Range ||
          (hasAssignableElements!Range && hasLength!Range && isRandomAccessRange!Range) ||


### PR DESCRIPTION
Parameters with indirections make `reverse` template @system.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

I tested on the latest DMD on `run.dlang.io` and can't reproduce, so I assume the error is only on master? Otherwise, this needs a regression issue and should target `stable`.

CC @dkorpel , as I think you are the most experienced with `return scope` and you might have some context.