### PR TITLE
chore(utf): documentation of byUTF is wrong about thrown exceptions

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -4278,7 +4278,7 @@ private int impureVariable;
  *      `UTFException` if invalid UTF sequence and `useReplacementDchar` is set to `UseReplacementDchar.no`
  *
  * GC:
- *      Does not use GC if `useReplacementDchar` is set to `UseReplacementDchar.no`
+ *      Does not use GC if `useReplacementDchar` is set to `UseReplacementDchar.yes`
  *
  * Returns:
  *      A bidirectional range if `R` is a bidirectional range and not auto-decodable,

--- a/std/utf.d
+++ b/std/utf.d
@@ -4275,7 +4275,7 @@ private int impureVariable;
  *                            UseReplacementDchar.no means throw `UTFException` for invalid UTF
  *
  * Throws:
- *      `UTFException` if invalid UTF sequence and `useReplacementDchar` is set to `UseReplacementDchar.yes`
+ *      `UTFException` if invalid UTF sequence and `useReplacementDchar` is set to `UseReplacementDchar.no`
  *
  * GC:
  *      Does not use GC if `useReplacementDchar` is set to `UseReplacementDchar.no`


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>