### PR TITLE
chore(std): add std.checkedint to std module

### DIFF
--- a/std/package.d
+++ b/std/package.d
@@ -35,6 +35,7 @@ public import
  std.base64,
  std.bigint,
  std.bitmanip,
+ std.checkedint,
  std.compiler,
  std.complex,
  std.concurrency,


### PR DESCRIPTION
Previous change that moved std.checkedint out of experimental stage
didn't added the module to the list of modules on std module
`std/package.d`. This patch does that.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>