### PR TITLE
Fix 23132 - Avoid ranges copy when compared for equality

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1027,7 +1027,7 @@ template equal(alias pred = "a == b")
         }
     }
 
-    private bool equalLoop(Rs...)(Rs rs)
+    private bool equalLoop(Rs...)(ref Rs rs)
     {
         for (; !rs[0].empty; rs[0].popFront)
             static foreach (r; rs[1 .. $])


### PR DESCRIPTION
With this change, at least my code compiles again successfully.