### PR TITLE
RISCV: Fix wrong ExceptionMask values

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -540,9 +540,9 @@ nothrow @nogc:
         enum : ExceptionMask
         {
             inexactException      = 0x01,
-            divByZeroException    = 0x02,
-            underflowException    = 0x04,
-            overflowException     = 0x08,
+            divByZeroException    = 0x08,
+            underflowException    = 0x02,
+            overflowException     = 0x04,
             invalidException      = 0x10,
             severeExceptions   = overflowException | divByZeroException
                                  | invalidException,


### PR DESCRIPTION
According to RISCV specifications
https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf,
figure 11.2, the mask flags should be NX, UF, OF, DZ, NV in order.