### PR TITLE
std.numeric: Hack with quadruple-precision real type

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -658,23 +658,28 @@ public:
         auto x = F(0.125);
         assert(x.get!float == 0.125F);
         assert(x.get!double == 0.125);
+        assert(x.get!real == 0.125L);
 
         x -= 0.0625;
         assert(x.get!float == 0.0625F);
         assert(x.get!double == 0.0625);
+        assert(x.get!real == 0.0625L);
 
         x *= 2;
         assert(x.get!float == 0.125F);
         assert(x.get!double == 0.125);
+        assert(x.get!real == 0.125L);
 
         x /= 4;
         assert(x.get!float == 0.03125);
         assert(x.get!double == 0.03125);
+        assert(x.get!real == 0.03125L);
 
         x = 0.5;
         x ^^= 4;
         assert(x.get!float == 1 / 16.0F);
         assert(x.get!double == 1 / 16.0);
+        assert(x.get!real == 1 / 16.0L);
     }
 }
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -373,8 +373,7 @@ public:
         {
         // Only use highest 64 significand bits from 112 explicitly stored
         align (1):
-            uint padding32;
-            ushort padding16;
+            private ubyte[6] _padding; // 48-bit of padding
             ulong significand;
             enum ulong significand_max = ulong.max;
             mixin(bitfields!(

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -79,7 +79,7 @@ public enum CustomFloatFlags
     none = 0
 }
 
-enum isIEEEQuadruple = floatTraits!real.realFormat == RealFormat.ieeeQuadruple;
+private enum isIEEEQuadruple = floatTraits!real.realFormat == RealFormat.ieeeQuadruple;
 
 private template CustomFloatParams(uint bits)
 {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -373,12 +373,23 @@ public:
         {
         // Only use highest 64 significand bits from 112 explicitly stored
         align (1):
-            private ubyte[6] _padding; // 48-bit of padding
-            ulong significand;
             enum ulong significand_max = ulong.max;
-            mixin(bitfields!(
-                T_exp , "exponent", exponentWidth,
-                bool  , "sign"    , flags & flags.signed ));
+            version (LittleEndian)
+            {
+                private ubyte[6] _padding; // 48-bit of padding
+                ulong significand;
+                mixin(bitfields!(
+                    T_exp , "exponent", exponentWidth,
+                    bool  , "sign"    , flags & flags.signed ));
+            }
+            else
+            {
+                mixin(bitfields!(
+                    T_exp , "exponent", exponentWidth,
+                    bool  , "sign"    , flags & flags.signed ));
+                ulong significand;
+                private ubyte[6] _padding; // 48-bit of padding
+            }
         }
         else
         {


### PR DESCRIPTION
The CustomFloat should be converted to real before most operations, but
there is no support for convertions of real types with
quadruple-precision (e.g. real type on RISCV64 platform). As the
significand is stored using 112 bits, which cannot fit in a ulong type
(CustomFloat do not allow significand more than a ulong), we should only
use the highest 64 bits of significand (this may cause presicion loss
	from real type, but is enough for what CustomFloat can support
	at most). So add 48 padding bits by declaring a uint and a
ushort before the significand, and set align(1) in this case.