### PR TITLE
preallocate oom error

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -505,7 +505,7 @@ struct File
 
         assert(!_p);
         auto memory = malloc(Impl.sizeof);
-        if(!memory)
+        if (!memory)
         {
             import core.exception : onOutOfMemoryError;
             onOutOfMemoryError();

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5134,7 +5134,7 @@ if (is(typeof(copy(data, stdout.lockingBinaryWriter))))
 }
 
 /*********************
- * Thrown if I/O exceptions happen.
+ * Thrown if I/O errors happen.
  */
 class StdioException : Exception
 {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -504,13 +504,12 @@ struct File
         import std.exception : enforce;
 
         assert(!_p);
-        auto memory = malloc(Impl.sizeof);
-        if (!memory)
+        _p = cast(Impl*) malloc(Impl.sizeof);
+        if (!_p)
         {
             import core.exception : onOutOfMemoryError;
             onOutOfMemoryError();
         }
-        _p = cast(Impl*) memory;
         initImpl(handle, name, refs, isPopened);
     }
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -501,7 +501,6 @@ struct File
     package this(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted @nogc nothrow
     {
         import core.stdc.stdlib : malloc;
-        import std.exception : enforce;
 
         assert(!_p);
         _p = cast(Impl*) malloc(Impl.sizeof);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -504,7 +504,13 @@ struct File
         import std.exception : enforce;
 
         assert(!_p);
-        _p = cast(Impl*) enforce(malloc(Impl.sizeof), preAllocatedStdioOOMError);
+        auto memory = malloc(Impl.sizeof);
+        if(!memory)
+        {
+            import core.exception : onOutOfMemoryError;
+            onOutOfMemoryError();
+        }
+        _p = cast(Impl*) memory;
         initImpl(handle, name, refs, isPopened);
     }
 
@@ -5167,12 +5173,6 @@ Initialize with a message and an error code.
     {
         throw new StdioException(null, core.stdc.errno.errno);
     }
-}
-
-private Error preAllocatedStdioOOMError;
-static this()
-{
-	preAllocatedStdioOOMError = new Error("Out of memory");
 }
 
 enum StdFileHandle: string

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -498,7 +498,7 @@ struct File
     private Impl* _p;
     private string _name;
 
-    package this(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted //@nogc nothrow
+    package this(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted @nogc nothrow
     {
         import core.stdc.stdlib : malloc;
         import std.exception : enforce;


### PR DESCRIPTION
fixes [issue 23196](https://issues.dlang.org/show_bug.cgi?id=23196).

~~unfortunately, while i believe it should be possible to make this function `@nogc nothrow` [since we are throwing an error, which cannot be recovered from], i wasn't able to figure out how to get enforce to realise it. advice would be greatly appreciated on this front.~~