### PR TITLE
Somewhat clean up win64.mak

### DIFF
--- a/etc/c/zlib/win64.mak
+++ b/etc/c/zlib/win64.mak
@@ -1,13 +1,12 @@
 # Makefile for zlib64
 
 MODEL=64
-VCDIR=\Program Files (x86)\Microsoft Visual Studio 10.0\VC
 
-CC=$(VCDIR)\bin\amd64\cl
-LD=$(VCDIR)\bin\amd64\link
-LIB=$(VCDIR)\bin\amd64\lib
+CC=cl
+LD=link
+AR=lib
 
-CFLAGS=/O2 /nologo /I"$(VCDIR)\INCLUDE"
+CFLAGS=/O2 /nologo
 LIBFLAGS=/nologo
 LDFLAGS=/nologo
 O=.obj
@@ -21,7 +20,7 @@ OBJS = adler32$(O) compress$(O) crc32$(O) deflate$(O) gzclose$(O) gzlib$(O) gzre
 	gzwrite$(O) infback$(O) inffast$(O) inflate$(O) inftrees$(O) trees$(O) uncompr$(O) zutil$(O)
 
 
-all:  zlib64.lib example.exe infcover.exe minigzip.exe
+all:  zlib$(MODEL).lib example.exe infcover.exe minigzip.exe
 
 adler32.obj: zutil.h zlib.h zconf.h
 	"$(CC)" /c $(CFLAGS) $*.c
@@ -80,7 +79,7 @@ minigzip.obj: test\minigzip.c zlib.h zconf.h
 	"$(CC)" /c $(cvarsdll) $(CFLAGS) test\$*.c
 
 zlib$(MODEL).lib: $(OBJS)
-	"$(LIB)" $(LIBFLAGS) /OUT:zlib$(MODEL).lib $(OBJS)
+	"$(AR)" $(LIBFLAGS) /OUT:zlib$(MODEL).lib $(OBJS)
 
 example.exe: example.obj zlib$(MODEL).lib
 	"$(LD)" $(LDFLAGS) example.obj zlib$(MODEL).lib


### PR DESCRIPTION
* Remove some unused variables.
* Default to a matching MSVC `cl.exe` & `lib.exe` in PATH instead of an ancient Visual Studio 2010 installation.
* Remove explicit 32-bit recipes, requiring a separate make invocation.

Analogous to https://github.com/dlang/druntime/pull/3853.