### PR TITLE
compile .c files with ImportC

### DIFF
--- a/etc/c/zlib/gzguts.h
+++ b/etc/c/zlib/gzguts.h
@@ -142,9 +142,11 @@
 #elif defined(_MSC_VER)
 #include <io.h>
 #else
-ssize_t read(int, void*, size_t);
-ssize_t write(int, const void*, size_t);
-int close(int);
+#include <unistd.h>
+//off_t lseek(int, off_t, int);
+//ssize_t read(int, void*, size_t);
+//ssize_t write(int, const void*, size_t);
+//int close(int);
 #endif
 
 /* provide prototypes for these when building zlib without LFS */

--- a/posix.mak
+++ b/posix.mak
@@ -332,7 +332,8 @@ dll: $(ROOT)/libphobos2.so
 
 $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
-	$(CC) -c $(CFLAGS) $< $(OUTFILEFLAG)$@
+#	$(CC) -c $(CFLAGS) $< $(OUTFILEFLAG)$@
+	$(DMD) -c $(DFLAGS) -I. -v $< -of$@
 
 $(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)


### PR DESCRIPTION
This is a work in progress to use ImportC to compile all the .c files in Phobos.