### PR TITLE
upgrade zlib C files to C11

### DIFF
--- a/etc/c/zlib/gzguts.h
+++ b/etc/c/zlib/gzguts.h
@@ -147,8 +147,6 @@ ssize_t write(int, const void*, size_t);
 int close(int);
 #endif
 
-
-
 /* provide prototypes for these when building zlib without LFS */
 #if !defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0
     ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));

--- a/etc/c/zlib/gzguts.h
+++ b/etc/c/zlib/gzguts.h
@@ -136,6 +136,19 @@
 #  endif
 #endif
 
+/* C11 no longer allows implicit declaration of functions */
+#if defined(__DMC__)
+#include <io.h>
+#elif defined(_MSC_VER)
+#include <io.h>
+#else
+ssize_t read(int, void*, size_t);
+ssize_t write(int, const void*, size_t);
+int close(int);
+#endif
+
+
+
 /* provide prototypes for these when building zlib without LFS */
 #if !defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0
     ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));

--- a/posix.mak
+++ b/posix.mak
@@ -107,7 +107,7 @@ endif
 OUTFILEFLAG = -o
 NODEFAULTLIB=-defaultlib= -debuglib=
 ifeq (,$(findstring win,$(OS)))
-	CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+	CFLAGS=$(MODEL_FLAG) -fPIC -std=c11 -DHAVE_UNISTD_H
 	NODEFAULTLIB += -L-lpthread -L-lm
 	ifeq ($(BUILD),debug)
 		CFLAGS += -g


### PR DESCRIPTION
ImportC is a C11 compiler, so this upgrades the zlib C sources to C11.

It paves the way to using ImportC to compile zlib.