### PR TITLE
std.complex: Use complex(LN10) as divisor in log10

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -1695,9 +1695,9 @@ Complex!T log(T)(Complex!T x) @safe pure nothrow @nogc
  */
 Complex!T log10(T)(Complex!T x) @safe pure nothrow @nogc
 {
-    static import std.math;
+    import std.math.constants : LN10;
 
-    return log(x) / Complex!T(std.math.log(10.0));
+    return log(x) / Complex!T(LN10);
 }
 
 ///


### PR DESCRIPTION
I suspect this'll double the speed of complex log10, and fixes a potential precision bug.