### PR TITLE
merge stable

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -1027,7 +1027,7 @@ template equal(alias pred = "a == b")
         }
     }
 
-    private bool equalLoop(Rs...)(Rs rs)
+    private bool equalLoop(Rs...)(ref Rs rs)
     {
         for (; !rs[0].empty; rs[0].popFront)
             static foreach (r; rs[1 .. $])

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4905,8 +4905,14 @@ if (is(Interface == interface) && is(BaseClass == class))
         // - try default first
         // - only on a failure run & return fallback
         enum fallback = q{
-            scope (failure) return fallback.%1$s(args);
-            return default_.%1$s(args);
+            try
+            {
+                return default_.%1$s(args);
+            }
+            catch (Exception)
+            {
+                return fallback.%1$s(args);
+            }
         }.format(__traits(identifier, func));
     }
 


### PR DESCRIPTION
- Fix 23132 - Avoid ranges copy when compared for equality
- Use try-catch instead of scope(failure) for block that returns
