### PR TITLE
Fix 23245, 23246 - std.format regressions

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1337,7 +1337,7 @@ if (is(StringTypeOf!T) && !is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToSt
 /*
     Static-size arrays are formatted as dynamic arrays.
  */
-void formatValueImpl(Writer, T, Char)(auto ref Writer w, auto ref const(T) obj,
+void formatValueImpl(Writer, T, Char)(auto ref Writer w, auto ref T obj,
     scope const ref FormatSpec!Char f)
 if (is(StaticArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 {

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1782,13 +1782,13 @@ void formatChar(Writer)(ref Writer w, in dchar c, in char quote)
     Associative arrays are formatted by using `':'` and $(D ", ") as
     separators, and enclosed by `'['` and `']'`.
  */
-void formatValueImpl(Writer, T, Char)(auto ref Writer w, const(T) obj, scope const ref FormatSpec!Char f)
+void formatValueImpl(Writer, T, Char)(auto ref Writer w, T obj, scope const ref FormatSpec!Char f)
 if (is(AssocArrayTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 {
     import std.format : enforceFmt, formatValue;
     import std.range.primitives : put;
 
-    AssocArrayTypeOf!(const(T)) val = obj;
+    AssocArrayTypeOf!T val = obj;
     const spec = f.spec;
 
     enforceFmt(spec == 's' || spec == '(',

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1356,6 +1356,18 @@ if (isSomeChar!Char)
     assert(result == "    1");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=23245
+@safe unittest
+{
+    static struct S
+    {
+        string toString() { return "S"; }
+    }
+
+    S[1] s;
+    assert(format("%s", s) == "[S]");
+}
+
 /// ditto
 typeof(fmt) format(alias fmt, Args...)(Args args)
 if (isSomeString!(typeof(fmt)))

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1368,6 +1368,18 @@ if (isSomeChar!Char)
     assert(format("%s", s) == "[S]");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=23246
+@safe unittest
+{
+    static struct S
+    {
+        string toString() { return "S"; }
+    }
+
+    S[int] s = [0 : S()];
+    assert(format("%s", s) == "[0:S]");
+}
+
 /// ditto
 typeof(fmt) format(alias fmt, Args...)(Args args)
 if (isSomeString!(typeof(fmt)))


### PR DESCRIPTION
In general, we should be wary of forcibly converting user-defined types to `const` in generic code.