### PR TITLE
Fix issue 18735 all versions of find and canfind should identify usag…

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2512,6 +2512,8 @@ RandomAccessRange find(RandomAccessRange, alias pred, InputRange)(
 Convenience function. Like find, but only returns whether or not the search
 was successful.
 
+For more information about `pred` see $(LREF find).
+
 See_Also:
 $(REF among, std,algorithm,comparison) for checking a value against multiple possibilities.
  +/
@@ -2622,6 +2624,8 @@ Advances `r` until it finds the first two adjacent elements `a`,
 `b` that satisfy `pred(a, b)`. Performs $(BIGOH r.length)
 evaluations of `pred`.
 
+For more information about `pred` see $(LREF find).
+
 Params:
     pred = The predicate to satisfy.
     r = A $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) to
@@ -2698,6 +2702,8 @@ Advances `seq` by calling `seq.popFront` until either
 `find!(pred)(choices, seq.front)` is `true`, or `seq` becomes empty.
 Performs $(BIGOH seq.length * choices.length) evaluations of `pred`.
 
+For more information about `pred` see $(LREF find).
+
 Params:
     pred = The predicate to use for determining a match.
     seq = The $(REF_ALTTEXT input range, isInputRange, std,range,primitives) to
@@ -2758,6 +2764,8 @@ if (isInputRange!InputRange && isForwardRange!ForwardRange)
  * Similarly, the haystack is positioned so as `pred` evaluates to `false` for
  * `haystack.front`.
  *
+ * For more information about `pred` see $(LREF find).
+
  * Params:
  *  haystack = The
  *   $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) to search
@@ -2881,6 +2889,8 @@ the same type as `haystack`. Otherwise, `haystack` must be a
 $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives) and
 the type of `result[0]` and `result[1]` is the same as $(REF takeExactly,
 std,range).
+
+For more information about `pred` see $(LREF find).
 
 Params:
     pred = Predicate to use for comparing needle against haystack.
@@ -4594,6 +4604,8 @@ Checks whether the given
 $(REF_ALTTEXT input range, isInputRange, std,range,primitives) starts with (one
 of) the given needle(s) or, if no needles are given,
 if its front element fulfils predicate `pred`.
+
+For more information about `pred` see $(LREF find).
 
 Params:
 


### PR DESCRIPTION
…e of predicate