### PR TITLE
Add std.internal.memory to the makefiles

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -256,7 +256,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 	algorithm/internal \
 	digest/digest \
 	$(addprefix internal/, \
-		cstring digest/sha_SSSE3 \
+		cstring memory digest/sha_SSSE3 \
 		$(addprefix math/, biguintcore biguintnoasm biguintx86	\
 						   errorfunction gammafunction ) \
 		scopebuffer test/dummyrange test/range \

--- a/win32.mak
+++ b/win32.mak
@@ -256,6 +256,7 @@ SRC_STD_WIN= \
 
 SRC_STD_INTERNAL= \
 	std\internal\cstring.d \
+	std\internal\memory.d \
 	std\internal\unicode_tables.d \
 	std\internal\unicode_comp.d \
 	std\internal\unicode_decomp.d \

--- a/win64.mak
+++ b/win64.mak
@@ -264,6 +264,7 @@ SRC_STD_WIN= \
 
 SRC_STD_INTERNAL= \
 	std\internal\cstring.d \
+	std\internal\memory.d \
 	std\internal\unicode_tables.d \
 	std\internal\unicode_comp.d \
 	std\internal\unicode_decomp.d \


### PR DESCRIPTION
I had a linker error due to a missing symbol for the ModuleInfo for std.internal.memory. This commit fixes that.