### PR TITLE
add fromHexString

### DIFF
--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1221,7 +1221,7 @@ if (isInputRange!R1 && isInputRange!R2 && !isInfinite!R1 && !isInfinite!R2 &&
  * ubyte[] dby  = "0xBA".toDigest;   // returns dynamic array, gc allocating
  * ---
  */
-auto toDigest(const string hex) pure nothrow @safe
+auto fromHexString(const string hex) pure nothrow @safe
 {
     auto digest = new ubyte[hex.length / 2 + hex.length % 2];
     return toDigestImpl(hex, digest);

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1232,7 +1232,7 @@ auto fromHexString(T)(T hex) @safe pure nothrow @nogc
 ///
 @safe unittest
 {
-    import std.array: array, staticArray;
+    import std.array : array, staticArray;
     import std;
 
     void testToDigest(T)(const ubyte[] b, const T s) @safe
@@ -1241,8 +1241,8 @@ auto fromHexString(T)(T hex) @safe pure nothrow @nogc
 
         assert(b == s.fromHexString.array,
                 text(s ~ ".fromHexString returned ",
-                    s.fromHexString.array,
-                    ", instead of ", b));
+                s.fromHexString.array,
+                ", instead of ", b));
     }
 
     testToDigest([255], "0xff");
@@ -1265,12 +1265,10 @@ auto fromHexString(T)(T hex) @safe pure nothrow @nogc
     void testToStaticDigest(size_t n, T)(const ubyte[n]b, const T s ) @safe
     {
         import std.conv : text;
-        assert(
-                b == s.fromHexString.staticArray!n,
-                text(
-                    s ~ ".fromHexString returned ",
-                    s.fromHexString.staticArray!n,
-                    ", instead of ", b));
+        assert(b == s.fromHexString.staticArray!n,
+                text(s ~ ".fromHexString returned ",
+                s.fromHexString.staticArray!n,
+                ", instead of ", b));
     }
 
     testToStaticDigest!3([0, 0, 255], "0x0000ff");
@@ -1307,11 +1305,13 @@ private struct ByteRange(T)
 
     this(T hex)
     {
-        if(hex.length > 0){
+        if (hex.length > 0)
+        {
             if (hex[0 .. 2] == "0x")
                 hex= hex[2 .. $];
             length = hex.length / 2 + hex.length % 2;
-            if(length == 0) empty = true;
+            if (length == 0) empty = true;
+
             else if (hex.length % 2 == 1)
             {
                 front = cast(ubyte)(toByte(hex[0]));
@@ -1331,7 +1331,11 @@ private struct ByteRange(T)
 
     void popFront()
     {
-       if(hex.length == 0) {empty = true; return;}
+       if (hex.length == 0)
+       {
+           empty = true;
+           return;
+       }
        front = cast(ubyte)(toByte(hex[0]) << 4 | toByte(hex[1]));
        hex= hex[2 .. $];
     }

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1215,23 +1215,27 @@ if (isInputRange!R1 && isInputRange!R2 && !isInfinite!R1 && !isInfinite!R2 &&
 
 /**
  * Used to convert hex string to byte array
+ * Params:
+ *  hex = hex string 
+ *  num = count of bytes 
+ * Returns: byte array
  * Example:
  * ---
- * ubyte[2] sba = "0xAA".toDigest!2; // returns static array, no allocating
- * ubyte[] dby  = "0xBA".toDigest;   // returns dynamic array, gc allocating
+ * ubyte[2] sba = "0xAA".fromHexString!2; // returns static array, no allocating
+ * ubyte[] dby  = "0xBA".fromHexString;   // returns dynamic array, gc allocating
  * ---
  */
 auto fromHexString(const string hex) pure nothrow @safe
 {
     auto digest = new ubyte[hex.length / 2 + hex.length % 2];
-    return toDigestImpl(hex, digest);
+    return fromHexStringImpl(hex, digest);
 }
 
 /// ditto
-auto fromHexString(const string hex) pure nothrow @safe @nogc
+auto fromHexString(size_t num)(const string hex) pure nothrow @safe @nogc
 {
     ubyte[num] digest;
-    toDigestImpl(hex, digest);
+    fromHexStringImpl(hex, digest);
     return digest;
 }
 
@@ -1242,7 +1246,7 @@ auto fromHexString(const string hex) pure nothrow @safe @nogc
     {
         import std.conv : text;
 
-        assert(b == s.toDigest, text(s ~ ".toDigest returned ", s.toDigest, ", instead of ", b));
+        assert(b == s.fromHexString, text(s ~ ".fromHexString returned ", s.fromHexString, ", instead of ", b));
     }
 
     testToDigest([255], "0xff");
@@ -1262,7 +1266,7 @@ auto fromHexString(const string hex) pure nothrow @safe @nogc
     void testToStaticDigest(size_t n)(const ubyte[n]b, const string s ) @safe
     {
         import std.conv : text;
-        assert(b == s.toDigest!n, text(s ~ ".toDigest returned ", s.toDigest, ", instead of ", b));
+        assert(b == s.fromHexString!n, text(s ~ ".fromHexString returned ", s.fromHexString, ", instead of ", b));
     }
 
     testToStaticDigest!3([0, 0, 255], "0xff");

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1276,7 +1276,7 @@ auto fromHexString(const string hex) pure nothrow @safe @nogc
 /*
  * Fill in a preallocated byte buffer by values from ASCII hex buffer
  */
-private auto toDigestImpl(BB, HB)(
+private auto fromHexStringImpl(BB, HB)(
     scope const ref HB hexBuffer, return scope ref BB byteBuffer) @safe pure nothrow @nogc
 {
     size_t bi = byteBuffer.length - 1, hi;

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1216,8 +1216,8 @@ if (isInputRange!R1 && isInputRange!R2 && !isInfinite!R1 && !isInfinite!R2 &&
 /**
  * Used to convert hex string to byte array
  * Params:
- *  hex = hex string 
- *  num = count of bytes 
+ *  hex = hex string
+ *  num = count of bytes
  * Returns: byte array
  * Example:
  * ---

--- a/std/digest/package.d
+++ b/std/digest/package.d
@@ -1228,7 +1228,7 @@ auto toDigest(const string hex) pure nothrow @safe
 }
 
 /// ditto
-auto toDigest(size_t num)(const string hex) pure nothrow @safe @nogc
+auto fromHexString(const string hex) pure nothrow @safe @nogc
 {
     ubyte[num] digest;
     toDigestImpl(hex, digest);


### PR DESCRIPTION
As I understood Phobos does not contain any functions for converting text strings to byte array

hexString - template(not usable in runtime
parse, to -  cannot convert into byte array