### PR TITLE
std.bigint: toHex pure attrib missed

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1541,7 +1541,7 @@ Returns:
     number in upper case.
 
 */
-string toHex(const(BigInt) x) @safe
+string toHex(const(BigInt) x) pure @safe
 {
     import std.array : appender;
     auto outbuff = appender!string();


### PR DESCRIPTION
toDecimalString has pure nothrow @safe
and toHex has only @safe 

