### PR TITLE
Fix Issue 23288 - zlib: Fix potential buffer overflow

### DIFF
--- a/etc/c/zlib/inflate.c
+++ b/etc/c/zlib/inflate.c
@@ -764,8 +764,9 @@ int flush;
                 if (copy > have) copy = have;
                 if (copy) {
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        (len = state->head->extra_len - state->length) <
+                            state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
Hello --

As mentioned in the bug report, this fixes a potential buffer overflow in zlib. It is a combined diff from
https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1
and
https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d

I wasn't sure whether this should go in master or stable, so I chose master. In any event, we probably want this.