### PR TITLE
replace delegate with simple nested function

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1537,19 +1537,15 @@ if (isOutputRange!(Out,char))
             toStringImpl!char(str);
     }
 
-    // recursive @safe inference is broken here
-    // workaround: if json.put is @safe, we should be too,
-    // so annotate the recursion as @safe manually
-    static if (isSafe!({ json.put(""); }))
-    {
-        void delegate(ref const JSONValue, ulong) @safe toValue;
-    }
-    else
-    {
-        void delegate(ref const JSONValue, ulong) @system toValue;
-    }
+    /* make the function infoer @system when json.put() is @system
+     */
+    if (0)
+        json.put(' ');
 
-    void toValueImpl(ref const JSONValue value, ulong indentLevel)
+    /* Mark as @trusted because json.put() may be @system. This has difficulty
+     * inferring @safe because it is recursive.
+     */
+    void toValueImpl(ref const JSONValue value, ulong indentLevel) @trusted
     {
         void putTabs(ulong additionalIndent = 0)
         {
@@ -1594,7 +1590,7 @@ if (isOutputRange!(Out,char))
                             json.put(':');
                             if (pretty)
                                 json.put(' ');
-                            toValue(member, indentLevel + 1);
+                            toValueImpl(member, indentLevel + 1);
                         }
                     }
 
@@ -1631,7 +1627,7 @@ if (isOutputRange!(Out,char))
                         if (i)
                             putCharAndEOL(',');
                         putTabs(1);
-                        toValue(el, indentLevel + 1);
+                        toValueImpl(el, indentLevel + 1);
                     }
                     putEOL();
                     putTabs();
@@ -1710,9 +1706,7 @@ if (isOutputRange!(Out,char))
         }
     }
 
-    toValue = &toValueImpl;
-
-    toValue(root, 0);
+    toValueImpl(root, 0);
 }
 
  // https://issues.dlang.org/show_bug.cgi?id=12897

--- a/std/json.d
+++ b/std/json.d
@@ -1537,7 +1537,7 @@ if (isOutputRange!(Out,char))
             toStringImpl!char(str);
     }
 
-    /* make the function infoer @system when json.put() is @system
+    /* make the function infer @system when json.put() is @system
      */
     if (0)
         json.put(' ');


### PR DESCRIPTION
The code has a kludge in it where it is recursively attempting to infer @safe, but that doesn't work, as the compiler assumes it is not @safe if recursive. The workaround in the code is to use a delegate. The trouble with the delegate a dynamic closure is allocated for it. Dynamic closures can escape, so dip1000 complains about `ref json` escaping the scope.

The solution is to get rid of the delegates, and use a nested function directly. Mark it as @trusted, which is also a workaround, but a better workaround than the old method, and at least this will work with https://github.com/dlang/dmd/pull/14364

For the future, it would be better to simply require the `json` parameter to be @safe.