### PR TITLE
getopt: make unittest @system because of delegate

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1835,7 +1835,7 @@ void defaultGetoptFormatter(Output)(Output output, string text, Option[] opt, st
     assert(flag);
 }
 
-@safe unittest  // Delegates as callbacks
+@system unittest  // Delegates as callbacks
 {
     alias TwoArgOptionHandler = void delegate(string option, string value) @safe;
 


### PR DESCRIPTION
The error message:
```
std/getopt.d(1863): Error: `@safe` function `std.getopt.__unittest_L1838_C7` cannot call `@system` function `std.getopt.__unittest_L1838_C7.makeAddNHandler`
std/getopt.d(1842):        `std.getopt.__unittest_L1838_C7.makeAddNHandler` is declared here
std/getopt.d(1866): Error: `@safe` function `std.getopt.__unittest_L1838_C7` cannot call `@system` function `std.getopt.__unittest_L1838_C7.makeAddNHandler`
std/getopt.d(1842):        `std.getopt.__unittest_L1838_C7.makeAddNHandler` is declared here
``` 
when compiled with https://github.com/dlang/dmd/pull/14364 because the delegate is enclosing a ref. This blocks that PR.