### PR TITLE
make nested class & struct static

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -4376,8 +4376,8 @@ unittest
             return app[];
     }
 
-    class C {}
-    struct S { const(C) c; }
+    static class C {}
+    static struct S { const(C) c; }
     S[] s = [ S(new C) ];
 
     auto t = fastCopy(s); // Does not compile


### PR DESCRIPTION
Non-static classes and structs have a hidden pointer to the outer stack frame, which can cause memory safety errors.

Blocking https://github.com/dlang/dmd/pull/14367