### PR TITLE
Switch to faster version of staticMap

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -627,35 +627,9 @@ Evaluates to `AliasSeq!(fun!(args[0]), fun!(args[1]), ..., fun!(args[$ - 1]))`.
  */
 template staticMap(alias fun, args...)
 {
-    version (__staticMap_simplest_but_buggy)
-    {
-        // @@@ BUG @@@
-        // The following straightforward implementation exposes a bug.
-        // See issue https://issues.dlang.org/show_bug.cgi?id=22421 and unittest below.
-        alias staticMap = AliasSeq!();
-        static foreach (arg; args)
-             staticMap = AliasSeq!(staticMap, fun!arg);
-    }
-    else version (__staticMap_simple_but_slow)
-    {
-        // This has a performance bug. Appending to the staticMap seems to be quadratic.
-        alias staticMap = AliasSeq!();
-        static foreach (i; 0 .. args.length)
-            staticMap = AliasSeq!(staticMap, fun!(args[i]));
-    }
-    else // Current best-of-breed implementation imitates quicksort
-    {
-        static if (args.length <= 8)
-        {
-            alias staticMap = AliasSeq!();
-            static foreach (i; 0 .. args.length)
-                staticMap = AliasSeq!(staticMap, fun!(args[i]));
-        }
-        else
-        {
-            alias staticMap = AliasSeq!(staticMap!(fun, args[0 .. $ / 2]), staticMap!(fun, args[$ / 2 .. $]));
-        }
-    }
+    alias staticMap = AliasSeq!();
+    static foreach (arg; args)
+        staticMap = AliasSeq!(staticMap, fun!arg);
 }
 
 ///


### PR DESCRIPTION
Now that

- https://issues.dlang.org/show_bug.cgi?id=22421 has been fixed via https://github.com/dlang/dmd/pull/13252 and
- quadratic behavior of alias assign has been removed via https://github.com/dlang/dmd/pull/14332.

When compiling https://github.com/nordlow/phobos-next/blob/master/snippets/benchmark_staticMap.d,
the first implementation is the fastest and least memory consuming.

Implementations:

1. 0.08s 90 Mb
2. 0.12s 109 Mb
3. 0.12s 109 Mb

FYI, @andralex @atilaneves.