### PR TITLE
Update GitHub usernames in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,8 +15,8 @@ circleci.sh @CyberShadow @MartinNowak @wilzbach
 etc/c/* @CyberShadow
 posix.mak @CyberShadow @MartinNowak @wilzbach
 std/* @andralex
-std/algorithm/* @andralex @JackStouffer @wilzbach @ZombineDev
-std/array.d @JackStouffer @wilzbach @ZombineDev
+std/algorithm/* @andralex @JackStouffer @wilzbach @PetarKirov
+std/array.d @JackStouffer @wilzbach @PetarKirov
 std/ascii.d @JackStouffer @wilzbach
 # std/base64.d
 std/bigint.d @Biotronic
@@ -25,7 +25,7 @@ std/c/windows/* @CyberShadow
 # std/compiler.d
 std/complex.d @kyllingstad
 std/concurrency.d @MartinNowak
-std/container/ @ZombineDev
+std/container/ @PetarKirov
 std/conv.d @JackStouffer
 # std/csv.d
 std/datetime/* @jmdavis
@@ -33,7 +33,7 @@ std/demangle.d @MartinNowak @rainers
 std/digest/* @jpf91
 # std/encoding.d
 # std/exception.d
-std/experimental/allocator/* @andralex @wilzbach @ZombineDev
+std/experimental/allocator/* @andralex @wilzbach @PetarKirov
 std/experimental/checkedint/* @andralex
 std/experimental/logger/* @burner
 # std/experimental/typecons.d
@@ -43,8 +43,8 @@ std/file.d @CyberShadow
 # std/getopt.d
 # std/internal/
 std/json.d @CyberShadow
-std/math* @Biotronic @ibuclaw @klickverbot
-std/meta.d @Biotronic @klickverbot @MetaLang @ZombineDev
+std/math* @Biotronic @ibuclaw @dnadlinger
+std/meta.d @Biotronic @dnadlinger @MetaLang @PetarKirov
 # std/mmfile.d
 std/net/curl.d @CyberShadow
 std/net/isemail.d @JackStouffer
@@ -54,17 +54,17 @@ std/net/isemail.d @JackStouffer
 std/path.d @CyberShadow @kyllingstad
 std/process.d @CyberShadow @kyllingstad @schveiguy
 std/random.d @WebDrake @wilzbach
-std/range/* @andralex @JackStouffer @wilzbach @ZombineDev
+std/range/* @andralex @JackStouffer @wilzbach @PetarKirov
 std/regex/* @DmitryOlshansky
 # std/signals.d
-std/socket.d @CyberShadow @klickverbot
+std/socket.d @CyberShadow @dnadlinger
 # std/stdint.d
 std/stdio.d @CyberShadow @schveiguy
 std/string.d @burner @JackStouffer
 std/sumtype.d @pbackus
 # std/system.d
-std/traits.d @Biotronic @klickverbot @ZombineDev
-std/typecons.d @Biotronic @MetaLang @ZombineDev
+std/traits.d @Biotronic @dnadlinger @PetarKirov
+std/typecons.d @Biotronic @MetaLang @PetarKirov
 # std/typetuple.d
 std/uni.d @DmitryOlshansky
 # std/uri.d


### PR DESCRIPTION
GitHub says "This CODEOWNERS file contains errors". I changed ZombineDev -> PetarKirov and klickverbot -> dnadlinger. I don't know what to do about code owners that don't have writing permissions to Phobos.