### PR TITLE
iteration: use static class

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1798,7 +1798,7 @@ if (isInputRange!R)
     assert(equal(g3, [ tuple(1, 2u), tuple(2, 2u) ]));
 
     interface I {}
-    class C : I { override size_t toHash() const nothrow @safe { return 0; } }
+    static class C : I { override size_t toHash() const nothrow @safe { return 0; } }
     const C[] a4 = [new const C()];
     auto g4 = a4.group!"a is b";
     assert(g4.front[1] == 1);
@@ -2255,25 +2255,26 @@ if (isForwardRange!Range)
     import std.algorithm.comparison : equal;
 
     size_t popCount = 0;
-    class RefFwdRange
+    static class RefFwdRange
     {
         int[]  impl;
+        size_t* pcount;
 
         @safe nothrow:
 
-        this(int[] data) { impl = data; }
+        this(int[] data, size_t* pcount) { impl = data; this.pcount = pcount; }
         @property bool empty() { return impl.empty; }
         @property auto ref front() { return impl.front; }
         void popFront()
         {
             impl.popFront();
-            popCount++;
+            (*pcount)++;
         }
-        @property auto save() { return new RefFwdRange(impl); }
+        @property auto save() { return new RefFwdRange(impl, pcount); }
     }
     static assert(isForwardRange!RefFwdRange);
 
-    auto testdata = new RefFwdRange([1, 3, 5, 2, 4, 7, 6, 8, 9]);
+    auto testdata = new RefFwdRange([1, 3, 5, 2, 4, 7, 6, 8, 9], &popCount);
     auto groups = testdata.chunkBy!((a,b) => (a % 2) == (b % 2));
     auto outerSave1 = groups.save;
 
@@ -6058,7 +6059,7 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
     import std.algorithm.comparison : equal;
 
     // Test by-reference separator
-    class RefSep {
+    static class RefSep {
     @safe:
         string _impl;
         this(string s) { _impl = s; }


### PR DESCRIPTION
Needed for https://github.com/dlang/dmd/pull/14367 to eliminate escaping uplevel references.