### PR TITLE
rbtree lambda references stack frame

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -2055,7 +2055,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 }
 
 //Combinations not in examples.
-@safe pure unittest
+@system pure unittest
 {
     auto rbt1 = redBlackTree!(true, string)("hello", "hello");
     auto rbt2 = redBlackTree!((a, b){return a < b;}, double)(5.1, 2.3);


### PR DESCRIPTION
In service of getting https://github.com/dlang/dmd/pull/14367 to compile.

The trouble boils down to:
```
final class RedBlackTree(alias less)
{
    this() { }
}

auto redBlackTree(alias less)()
{
    return new RedBlackTree!(less)();
}

@safe void test()
{
    auto rbt2 = redBlackTree!((a, b) => a < b)();
}
```
where the lambda initializing rbt2 is inferred to be a delegate, with a reference to the stack frame of test(). This causes the return statement to fail as the RedBlackTree is presumed to save a copy of the `less` delegate, referencing that frame.

I'd file an enhancement request on this, but bugzilla is down for the moment.