### PR TITLE
std.path.globMatch: Don't throw from nothrow contract

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -3357,8 +3357,16 @@ in
 {
     // Verify that pattern[] is valid
     import std.algorithm.searching : balancedParens;
-    assert(balancedParens(pattern, '[', ']', 0));
-    assert(balancedParens(pattern, '{', '}', 0));
+
+    try
+    {
+        assert(balancedParens(pattern, '[', ']', 0));
+        assert(balancedParens(pattern, '{', '}', 0));
+    }
+    catch (Exception e)
+    {
+        assert(0);
+    }
 }
 do
 {


### PR DESCRIPTION
dlang/dmd#14383 deprecates throwing from contracts of `nothrow` functions. This change removes such cases from Phobos.