### PR TITLE
improve precondition of std.path.globMatch

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -3357,16 +3357,10 @@ in
 {
     // Verify that pattern[] is valid
     import std.algorithm.searching : balancedParens;
+    import std.utf : byUTF;
 
-    try
-    {
-        assert(balancedParens(pattern, '[', ']', 0));
-        assert(balancedParens(pattern, '{', '}', 0));
-    }
-    catch (Exception e)
-    {
-        assert(0);
-    }
+    assert(balancedParens(pattern.byUTF!C, '[', ']', 0));
+    assert(balancedParens(pattern.byUTF!C, '{', '}', 0));
 }
 do
 {


### PR DESCRIPTION
This improves the somewhat hacky implementation of #8547 ~~and, more generally, makes `std.algorithm.searching.balancedParens` `nothrow` when both the range's element type and `E` are either `char`, `wchar`, or `dchar`~~.