### PR TITLE
Remove deallocate and reallocate from GCAllocator

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -507,10 +507,10 @@ version (StdUnittest)
 
 @system unittest
 {
-    import std.experimental.allocator.gc_allocator;
-    alias a = AffixAllocator!(GCAllocator, uint).instance;
+    import std.experimental.allocator.mallocator;
+    alias a = AffixAllocator!(Mallocator, uint).instance;
 
-    // Check that goodAllocSize inherits from parent, i.e. GCAllocator
+    // Check that goodAllocSize inherits from parent, i.e. Mallocator
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(1))()));
 
     // Ensure deallocate inherits from parent

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -314,7 +314,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         }
         else
         {
-            bkalloc.deallocate(toFree);
+            static if (hasMember!(typeof(bkalloc), "deallocate"))
+                bkalloc.deallocate(toFree);
         }
     }
 
@@ -577,7 +578,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
             n.a.deallocateAll;
             n.a.destroy;
         }
-        bkalloc.deallocate(allocators);
+        static if (hasMember!(typeof(bkalloc), "deallocate"))
+            bkalloc.deallocate(allocators);
         allocators = null;
         root = null;
         return true;

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -243,8 +243,8 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
 version (StdUnittest)
 @system unittest
 {
-    import std.experimental.allocator.gc_allocator : GCAllocator;
-    alias MyAlloc = Quantizer!(GCAllocator,
+    import std.experimental.allocator.mallocator : Mallocator;
+    alias MyAlloc = Quantizer!(Mallocator,
         (size_t n) => n.roundUpToMultipleOf(64));
     testAllocator!(() => MyAlloc());
 

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -194,8 +194,13 @@ struct ScopedAllocator(ParentAllocator)
             void* p = n + 1;
             auto length = n.length;
             n = n.next;
-            if (!parent.deallocate(p[0 .. length]))
+            static if (!hasMember!(Allocator, "deallocate"))
                 result = false;
+            else
+            {
+                if (!parent.deallocate(p[0 .. length]))
+                    result = false;
+            }
         }
         root = null;
         return result;
@@ -245,8 +250,8 @@ version (StdUnittest)
 
 @system unittest
 {
-    import std.experimental.allocator.gc_allocator : GCAllocator;
-    ScopedAllocator!GCAllocator a;
+    import std.experimental.allocator.mallocator : Mallocator;
+    ScopedAllocator!Mallocator a;
 
     assert(__traits(compiles, (() nothrow @safe @nogc => a.goodAllocSize(0))()));
 

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -23,9 +23,7 @@ struct GCAllocator
     enum uint alignment = platformAlignment;
 
     /**
-    Standard allocator methods per the semantics defined above. The
-    `reallocate` method is `@system` because it may leave dangling
-    pointers in user code.
+    Standard allocator methods per the semantics defined above.
     */
     pure nothrow @trusted void[] allocate(size_t bytes) shared const
     {
@@ -54,23 +52,6 @@ struct GCAllocator
             assert(newSize >= desired);
         }
         b = b.ptr[0 .. desired];
-        return true;
-    }
-
-    /// Ditto
-    pure nothrow @system bool reallocate(ref void[] b, size_t newSize) shared const
-    {
-        import core.exception : OutOfMemoryError;
-        try
-        {
-            auto p = cast(ubyte*) GC.realloc(b.ptr, newSize);
-            b = p[0 .. newSize];
-        }
-        catch (OutOfMemoryError)
-        {
-            // leave the block in place, tell caller
-            return false;
-        }
         return true;
     }
 

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -8,7 +8,14 @@ module std.experimental.allocator.gc_allocator;
 import std.experimental.allocator.common;
 
 /**
-D's built-in garbage-collected allocator.
+Allocator interface to D's built-in garbage collector.
+
+Provides `@safe` memory management with no manual deallocation.
+
+See_Also:
+    - $(LINK2 https://dlang.org/spec/garbage.html, Garbage Collection) in the
+      D language specification.
+    - $(MREF core,memory)
 */
 struct GCAllocator
 {


### PR DESCRIPTION
This is necessary to make clients of GCAllocator (e.g., generic
containers) usable in @safe code.

Memory allocated by GC allocator will still be freed by the GC when it
is no longer reachable.

Rejected alternatives:

- Making GCAllocator.deallocate a no-op method that always returns
  false. The documentation in std.experimental.allocator.building_blocks
  specifically says not to do that.

- Special-casing client code for GCAllocator to avoid calling its
  'deallocate' method, while still calling 'deallocate' for other
  allocators.

'deallocate' has been documented as an optional method since
std.experimental.allocator was introduced in 2015 (commit 8b249a6240),
so this change will not break code that correctly adheres to the
documented allocator interface (i.e., checks for the presence of
'deallocate' before calling it).

Fixes issue 23318.

---

Submitted as a draft to see what breaks on Buildkite.

This is going to be pretty disruptive, but better to rip the band-aid off now while allocators are still in `std.experimental` than to be stuck with a design mistake forever.

### TODO

- [ ] Fix [CyberShadow/ae](https://github.com/CyberShadow/ae) (red)
- ~~Fix [atilaneves/automem](https://github.com/atilaneves/automem) (green but will break)~~ Depends on fixes to `make`/`dispose` in this PR
- [ ] Fix [dlang-community/containers](https://github.com/dlang-community/containers) (green but will break)