### PR TITLE
std.logger.core unittest forgotton thread.join

### DIFF
--- a/std/logger/core.d
+++ b/std/logger/core.d
@@ -1566,8 +1566,14 @@ class StdForwardLogger : Logger
     {
         sharedLog = oldSharedLog;
     }
-    () @trusted { new Thread(() { log("foo"); }).start(); }();
+    Thread toWaitFor;
+    () @trusted { toWaitFor = new Thread(() { log("foo"); }).start(); }();
     log("bar");
+
+    () @trusted
+    {
+        toWaitFor.join();
+    }();
 }
 
 /** This `LogLevel` is unqiue to every thread.


### PR DESCRIPTION
At this point I'm quite sure that the sporadic unittest errors happen because the created Thread is still active after the unittest is finish. The log message is written after the test is done.

This PR makes the test join the thread.