### PR TITLE
Remove SumType's invariant

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -753,23 +753,6 @@ public:
         }
     }
 
-    invariant
-    {
-        this.match!((ref value) {
-            static if (is(typeof(value) == class))
-            {
-                if (value !is null)
-                {
-                    assert(value);
-                }
-            }
-            else static if (is(typeof(value) == struct))
-            {
-                assert(&value);
-            }
-        });
-    }
-
     // Workaround for https://issues.dlang.org/show_bug.cgi?id=21400
     version (StdDdoc)
     {
@@ -1328,36 +1311,6 @@ version (D_BetterC) {} else
             {
         x = MySum(123);
     }));
-}
-
-// Types with invariants
-// Disabled in BetterC due to use of exceptions
-version (D_BetterC) {} else
-version (D_Invariants)
-@system unittest
-{
-    import std.exception : assertThrown;
-    import core.exception : AssertError;
-
-    struct S
-    {
-        int i;
-        invariant { assert(i >= 0); }
-    }
-
-    class C
-    {
-        int i;
-        invariant { assert(i >= 0); }
-    }
-
-    SumType!S x;
-    x.match!((ref v) { v.i = -1; });
-    assertThrown!AssertError(assert(&x));
-
-    SumType!C y = new C();
-    y.match!((ref v) { v.i = -1; });
-    assertThrown!AssertError(assert(&y));
 }
 
 // Calls value postblit on self-assignment


### PR DESCRIPTION
According to earlier versions of the language spec, checking the
invariant of a struct would also cause its fields' invariants to be
checked, recursively. SumType's invariant was added to make SumType
behave consistently with other structs in this regard.

The spec, however, was wrong: invariants of struct fields are not
checked unless the field is accessed directly, and never have been.
Thus, to make SumType behave consistently with other structs, its
invariant must be removed.

This change should not break any valid programs, since code that relies
on the failure of an invariant has undefined behavior per the spec.

Spec correction PR: https://github.com/dlang/dlang.org/pull/3405