### PR TITLE
partial fix for Issue 23344 - std.stdio: error: undefined identifier fputc_unlocked

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -85,8 +85,7 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    // uClibc supports GCC IO
-    version = GCC_IO;
+    version = GENERIC_IO;
 }
 else version (OSX)
 {


### PR DESCRIPTION
While the proper fix would be to define the missing getc/putc macros, for now to keep the build happy, just treat uClibc as a GENERIC_IO platform.

From comment here https://github.com/compiler-explorer/compiler-explorer/issues/3973#issuecomment-1250074395, and tested using the given crosstools-ng scripts.