### PR TITLE
fix Issue 23340 - std.path: expandTilde erroneously raises onOutOfMemory on failed getpwam_r()

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -3967,7 +3967,7 @@ string expandTilde(string inputPath) @safe nothrow
     version (Posix)
     {
         import core.exception : onOutOfMemoryError;
-        import core.stdc.errno : errno, ERANGE;
+        import core.stdc.errno : errno, EBADF, ENOENT, EPERM, ERANGE, ESRCH;
         import core.stdc.stdlib : malloc, free, realloc;
 
         /*  Joins a path from a C string to the remainder of path.
@@ -4073,7 +4073,7 @@ string expandTilde(string inputPath) @safe nothrow
                 char[] extra_memory;
 
                 passwd result;
-                while (1)
+                loop: while (1)
                 {
                     extra_memory.length += extra_memory_size;
 
@@ -4096,10 +4096,23 @@ string expandTilde(string inputPath) @safe nothrow
                         break;
                     }
 
-                    if (errno != ERANGE &&
+                    switch (errno)
+                    {
+                        case ERANGE:
                         // On BSD and OSX, errno can be left at 0 instead of set to ERANGE
-                        errno != 0)
-                        onOutOfMemoryError();
+                        case 0:
+                            break;
+
+                        case ENOENT:
+                        case ESRCH:
+                        case EBADF:
+                        case EPERM:
+                            // The given name or uid was not found.
+                            break loop;
+
+                        default:
+                            onOutOfMemoryError();
+                    }
 
                     // extra_memory isn't large enough
                     import core.checkedint : mulu;


### PR DESCRIPTION
Respect other valid errno codes that mean the name or uid given was not found on the system, instead of incorrectly raising an OOM error.