### PR TITLE
Fix issue 16034: map should be possible with a reference only

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -172,7 +172,7 @@ Returns:
 enum bool isInputRange(R) =
     is(typeof(R.init) == R)
     && is(ReturnType!((R r) => r.empty) == bool)
-    && is(typeof((return ref R r) => r.front))
+    && (is(typeof((return ref R r) => r.front)) || is(typeof(ref (return ref R r) => r.front)))
     && !is(ReturnType!((R r) => r.front) == void)
     && is(typeof((R r) => r.popFront));
 
@@ -226,6 +226,22 @@ enum bool isInputRange(R) =
         void front();
     }
     static assert(!isInputRange!VoidFront);
+}
+// Verify fix for: https://issues.dlang.org/show_bug.cgi?id=16034
+@safe unittest
+{
+    struct One
+    {
+        int entry = 1;
+        @disable this(this);
+    }
+
+    One[] ones = [One(), One()];
+
+    import std.algorithm.iteration : map;
+    import std.algorithm.comparison : equal;
+
+    assert(ones.map!`a.entry + 1`.equal([2, 2]));
 }
 
 @safe unittest


### PR DESCRIPTION
The fix is really about a template constraint isInputRange used by map.