### PR TITLE
[allocator/region] Issue 23090 - Don't use NullAllocator as a sentinel type

### DIFF
--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -521,9 +521,9 @@ version (StdUnittest)
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    auto a = AffixAllocator!(Region!(), uint)(Region!()(new ubyte[1024 * 64]));
+    auto a = AffixAllocator!(BorrowedRegion!(), uint)(BorrowedRegion!()(new ubyte[1024 * 64]));
     auto b = a.allocate(42);
     assert(b.length == 42);
     // Test that expand infers from parent

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -526,7 +526,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
 ///
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : SharedRegion;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.experimental.allocator.building_blocks.ascending_page_allocator : SharedAscendingPageAllocator;
     import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
     import core.thread : ThreadGroup;
@@ -536,11 +536,11 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
     enum maxIter = 10;
 
     /*
-    In this example we use 'SharedAlignedBlockList' together with 'SharedRegion',
-    in order to create a fast, thread-safe allocator.
+    In this example we use 'SharedAlignedBlockList' together with
+    'shared(BorrowedRegion)', in order to create a fast, thread-safe allocator.
     */
     alias SuperAllocator = SharedAlignedBlockList!(
-            SharedRegion!(NullAllocator, 1),
+            shared(BorrowedRegion!(1)),
             SharedAscendingPageAllocator,
             4096);
 
@@ -597,7 +597,7 @@ version (StdUnittest)
     SpinLock lock = SpinLock(SpinLock.Contention.brief);
 
     alias SuperAllocator = SharedAlignedBlockList!(
-            SharedRegion!(NullAllocator, 1),
+            shared(BorrowedRegion!(1)),
             SharedAscendingPageAllocator,
             1 << 16);
     void[][totalAllocs] buf;

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -526,7 +526,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
 ///
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
+    import std.experimental.allocator.building_blocks.region : SharedBorrowedRegion;
     import std.experimental.allocator.building_blocks.ascending_page_allocator : SharedAscendingPageAllocator;
     import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
     import core.thread : ThreadGroup;
@@ -537,10 +537,10 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
 
     /*
     In this example we use 'SharedAlignedBlockList' together with
-    'shared(BorrowedRegion)', in order to create a fast, thread-safe allocator.
+    'SharedBorrowedRegion', in order to create a fast, thread-safe allocator.
     */
     alias SuperAllocator = SharedAlignedBlockList!(
-            shared(BorrowedRegion!(1)),
+            SharedBorrowedRegion!(1),
             SharedAscendingPageAllocator,
             4096);
 
@@ -597,7 +597,7 @@ version (StdUnittest)
     SpinLock lock = SpinLock(SpinLock.Contention.brief);
 
     alias SuperAllocator = SharedAlignedBlockList!(
-            shared(BorrowedRegion!(1)),
+            SharedBorrowedRegion!(1),
             SharedAscendingPageAllocator,
             1 << 16);
     void[][totalAllocs] buf;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -679,8 +679,8 @@ version (Posix) @system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
-    import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
+    AllocatorList!((n) => BorrowedRegion!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.alignedAllocate(1024 * 8192, 1024);
     assert(b1 !is null); // still works due to overdimensioning
     assert(b1.length == 1024 * 8192);
@@ -707,8 +707,8 @@ version (Posix) @system unittest
 
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
-    import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
+    AllocatorList!((n) => BorrowedRegion!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.alignedAllocate(0, 1);
     assert(b1 is null);
 
@@ -728,8 +728,8 @@ version (Posix) @system unittest
 
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
-    import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
+    AllocatorList!((n) => BorrowedRegion!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b0 = a.alignedAllocate(1, 1024);
     assert(b0.length == 1);
     assert(b0.ptr.alignedAt(1024));
@@ -765,8 +765,8 @@ version (Posix) @system unittest
 {
     // Create an allocator based upon 4MB regions, fetched from the GC heap.
     import std.algorithm.comparison : max;
-    import std.experimental.allocator.building_blocks.region : Region;
-    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)])) a;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
+    AllocatorList!((n) => BorrowedRegion!()(new ubyte[max(n, 1024 * 4096)])) a;
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null); // still works due to overdimensioning
     b1 = a.allocate(1024 * 10);
@@ -779,10 +779,10 @@ version (Posix) @system unittest
 @system unittest
 {
     import std.algorithm.comparison : max;
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.experimental.allocator.mallocator : Mallocator;
     import std.typecons : Ternary;
-    AllocatorList!((n) => Region!()(new ubyte[max(n, 1024 * 4096)]), Mallocator) a;
+    AllocatorList!((n) => BorrowedRegion!()(new ubyte[max(n, 1024 * 4096)]), Mallocator) a;
     auto b1 = a.allocate(1024 * 8192);
     assert(b1 !is null);
     b1 = a.allocate(1024 * 10);

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -342,12 +342,12 @@ struct FallbackAllocator(Primary, Fallback)
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.typecons : Ternary;
 
-    auto a = FallbackAllocator!(Region!(), Region!())(
-                Region!()(new ubyte[4096 * 1024]),
-                Region!()(new ubyte[4096 * 1024]));
+    auto a = FallbackAllocator!(BorrowedRegion!(), BorrowedRegion!())(
+                BorrowedRegion!()(new ubyte[4096 * 1024]),
+                BorrowedRegion!()(new ubyte[4096 * 1024]));
 
     auto b = a.alignedAllocate(42, 8);
     assert(b.length == 42);
@@ -506,11 +506,11 @@ version (StdUnittest)
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.typecons : Ternary;
 
-    alias A = FallbackAllocator!(Region!(), Region!());
-    auto a = A(Region!()(new ubyte[16_384]), Region!()(new ubyte[16_384]));
+    alias A = FallbackAllocator!(BorrowedRegion!(), BorrowedRegion!());
+    auto a = A(BorrowedRegion!()(new ubyte[16_384]), BorrowedRegion!()(new ubyte[16_384]));
 
     auto b = a.allocate(42);
     assert(b.length == 42);

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -486,9 +486,9 @@ struct FreeList(ParentAllocator,
 // Test that deallocateAll infers from parent
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    auto fl = FreeList!(Region!(), 0, 16)(Region!()(new ubyte[1024 * 64]));
+    auto fl = FreeList!(BorrowedRegion!(), 0, 16)(BorrowedRegion!()(new ubyte[1024 * 64]));
     auto b = fl.allocate(42);
     assert(b.length == 42);
     assert((() pure nothrow @safe @nogc => fl.expand(b, 48))());

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -502,9 +502,9 @@ version (StdUnittest)
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    auto a = FreeTree!(Region!())(Region!()(new ubyte[1024 * 64]));
+    auto a = FreeTree!(BorrowedRegion!())(BorrowedRegion!()(new ubyte[1024 * 64]));
     auto b = a.allocate(42);
     assert(b.length == 42);
     assert((() pure nothrow @safe @nogc => a.expand(b, 22))());

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -315,14 +315,14 @@ version (StdUnittest)
 version (StdUnittest)
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.typecons : Ternary;
 
-    alias MyAlloc = Quantizer!(Region!(),
+    alias MyAlloc = Quantizer!(BorrowedRegion!(),
         (size_t n) => n.roundUpToMultipleOf(64));
-    testAllocator!(() => MyAlloc(Region!()(new ubyte[1024 * 64])));
+    testAllocator!(() => MyAlloc(BorrowedRegion!()(new ubyte[1024 * 64])));
 
-    auto a = MyAlloc(Region!()(new ubyte[1024 * 64]));
+    auto a = MyAlloc(BorrowedRegion!()(new ubyte[1024 * 64]));
     // Check that empty inherits from parent
     assert((() pure nothrow @safe @nogc => a.empty)() == Ternary.yes);
     auto b = a.allocate(42);

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -259,10 +259,10 @@ version (StdUnittest)
 // Test that deallocateAll infers from parent
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    ScopedAllocator!(Region!()) a;
-    a.parent.parent = Region!()(new ubyte[1024 * 64]);
+    ScopedAllocator!(BorrowedRegion!()) a;
+    a.parent.parent = BorrowedRegion!()(new ubyte[1024 * 64]);
     auto b = a.allocate(42);
     assert(b.length == 42);
     assert((() pure nothrow @safe @nogc => a.expand(b, 22))());

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -503,12 +503,12 @@ if (Args.length > 3)
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.typecons : Ternary;
 
-    auto a = Segregator!(10_240, Region!(), Region!())(
-                Region!()(new ubyte[4096 * 1024]),
-                Region!()(new ubyte[4096 * 1024]));
+    auto a = Segregator!(10_240, BorrowedRegion!(), BorrowedRegion!())(
+                BorrowedRegion!()(new ubyte[4096 * 1024]),
+                BorrowedRegion!()(new ubyte[4096 * 1024]));
 
     assert((() nothrow @safe @nogc => a.empty)() == Ternary.yes);
     auto b = a.alignedAllocate(42, 8);

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -845,9 +845,9 @@ public:
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    auto a = StatsCollector!(Region!(), Options.all, Options.all)(Region!()(new ubyte[1024 * 64]));
+    auto a = StatsCollector!(BorrowedRegion!(), Options.all, Options.all)(BorrowedRegion!()(new ubyte[1024 * 64]));
     auto b = a.allocate(42);
     assert(b.length == 42);
     // Test that reallocate infers from parent
@@ -859,9 +859,9 @@ public:
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
 
-    auto a = StatsCollector!(Region!(), Options.all)(Region!()(new ubyte[1024 * 64]));
+    auto a = StatsCollector!(BorrowedRegion!(), Options.all)(BorrowedRegion!()(new ubyte[1024 * 64]));
     auto b = a.alignedAllocate(42, 128);
     assert(b.length == 42);
     assert(b.ptr.alignedAt(128));

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -547,24 +547,24 @@ nothrow:
 
 @system unittest
 {
-    import std.experimental.allocator.building_blocks.region : Region;
+    import std.experimental.allocator.building_blocks.region : BorrowedRegion;
     import std.conv : emplace;
 
-    auto reg = Region!()(new ubyte[1024]);
-    auto state = reg.allocate(stateSize!(CAllocatorImpl!(Region!(), Yes.indirect)));
-    auto regObj = emplace!(CAllocatorImpl!(Region!(), Yes.indirect))(state, &reg);
+    auto reg = BorrowedRegion!()(new ubyte[1024]);
+    auto state = reg.allocate(stateSize!(CAllocatorImpl!(BorrowedRegion!(), Yes.indirect)));
+    auto regObj = emplace!(CAllocatorImpl!(BorrowedRegion!(), Yes.indirect))(state, &reg);
 
     auto rcalloc = RCIAllocator(regObj);
     auto b = rcalloc.allocate(10);
     assert(b.length == 10);
 
     // The reference counting is zero based
-    assert((cast(CAllocatorImpl!(Region!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
+    assert((cast(CAllocatorImpl!(BorrowedRegion!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
     {
         auto rca2 = rcalloc;
-        assert((cast(CAllocatorImpl!(Region!(), Yes.indirect))(rcalloc._alloc)).rc == 2);
+        assert((cast(CAllocatorImpl!(BorrowedRegion!(), Yes.indirect))(rcalloc._alloc)).rc == 2);
     }
-    assert((cast(CAllocatorImpl!(Region!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
+    assert((cast(CAllocatorImpl!(BorrowedRegion!(), Yes.indirect))(rcalloc._alloc)).rc == 1);
 }
 
 @system unittest


### PR DESCRIPTION
This PR addresses [issue 23090][1] for `std.experimental.allocator.building_blocks.region` by splitting the functionality previously accessed using `NullAllocator` out into two new allocators, `BorrowedRegion` and `SharedBorrowedRegion`. The original `Region` and `SharedRegion` are now assumed to always own the memory they allocate from, and will always (attempt to) deallocate it in their destructor.

To avoid code duplication, `Region` and `SharedRegion` have been refactored to use `BorrowedRegion` and `SharedBorrowedRegion` internally.

cc @atilaneves 

[1]: https://issues.dlang.org/show_bug.cgi?id=23090

---

Buildkite is green so hopefully this won't be too disruptive.