### PR TITLE
Fix Issue 23350 - Nondeterministic test failure in std.concurrency

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -257,9 +257,12 @@ private
 
     @property ref ThreadInfo thisInfo() nothrow
     {
-        if (scheduler is null)
+        import core.atomic : atomicLoad;
+
+        auto localScheduler = atomicLoad(scheduler);
+        if (localScheduler is null)
             return ThreadInfo.thisInfo;
-        return scheduler.thisInfo;
+        return localScheduler.thisInfo;
     }
 }
 


### PR DESCRIPTION
Previously, a TOCTOU bug in threadInfo could result in a null dereference if 'scheduler' was changed to null between the evaluation of the 'if' condition and the call to scheduler.threadInfo.