### PR TITLE
Make permutations into forward range.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -7909,7 +7909,13 @@ if (isRandomAccessRange!Range && hasLength!Range)
         _indices = iota(size_t(r.length)).array;
         _empty = r.length == 0;
     }
-
+    private this(size_t[] indices, size_t[] state, Range r, bool empty_)
+    {
+        _indices = indices;
+        _state = state;
+        _r = r;
+        _empty = empty_;
+    }
     /// Returns: `true` if the range is empty, `false` otherwise.
     @property bool empty() const pure nothrow @safe @nogc
     {
@@ -7950,6 +7956,13 @@ if (isRandomAccessRange!Range && hasLength!Range)
 
         next(2);
     }
+    static if (isForwardRange!Range) {
+        ///
+        auto save()
+        {
+            return typeof(this)(_indices.dup, _state.dup, _r.save, _empty);
+        }
+    }
 }
 
 ///
@@ -7964,4 +7977,16 @@ if (isRandomAccessRange!Range && hasLength!Range)
          [0, 2, 1],
          [1, 2, 0],
          [2, 1, 0]]));
+}
+
+@safe unittest
+{
+    import std.algorithm : equal;
+    import std.range : ElementType;
+    import std.array : array;
+    auto p = [1, 2, 3].permutations;
+    auto x = p.save.front;
+    p.popFront;
+    auto y = p.front;
+    assert(x != y);
 }


### PR DESCRIPTION
Since there was nothing preventing permutations from being a forward range, I have added a save method to make it into one. This is related to [Issue 18975](https://issues.dlang.org/show_bug.cgi?id=18975) - permutations.array creates an array of the original type without the permutations but doesn't fix it.