### PR TITLE
Fix `@system` annotation in multisort unittest

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1642,9 +1642,9 @@ private void multiSortImpl(Range, SwapStrategy ss, funs...)(Range r)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16413 - @system comparison function
-@safe unittest
+@system unittest
 {
-    bool lt(int a, int b) { return a < b; } static @system
+    static @system bool lt(int a, int b) { return a < b; }
     auto a = [2, 1];
     a.multiSort!(lt, lt);
     assert(a == [1, 2]);


### PR DESCRIPTION
`@system` in that position applies to the variable on the next line, not the function.

Blocking / uncovered by https://github.com/dlang/dmd/pull/14478