### PR TITLE
Improve isAlphaNum

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -187,7 +187,8 @@ else
   +/
 bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 {
-    return c <= 'z' && c >= '0' && (c <= '9' || c >= 'a' || (c >= 'A' && c <= 'Z'));
+    const hc = c | 0x20;
+    return ('0' <= c && c <= '9') || ('a' <= hc && hc <= 'z');
 }
 
 ///


### PR DESCRIPTION
Using recent version of LDC, here are the codegen I get:
```
        lea     eax, [rdi - 48]
        cmp     eax, 74
        ja      .LBB2_1
        lea     ecx, [rdi - 97]
        mov     al, 1
        cmp     ecx, -39
        jb      .LBB2_4
        add     edi, -65
        cmp     edi, 26
        setb    al
.LBB2_4:
        ret
.LBB2_1:
        xor     eax, eax
        ret
```

And now:
```
        lea     eax, [rdi - 48]
        cmp     eax, 9
        setb    cl
        or      edi, 32
        add     edi, -97
        cmp     edi, 26
        setb    al
        or      al, cl
        ret
```

Which is much better all around: less instructions, no branches, etc...

I will note that doing `isDigit(c) || isAlpha(c)` also gives me good codegen using LDC, but I chose against it as DMD fails to inline properly and the end result is pretty bad.