### PR TITLE
Simplify std.uni.isAlpha

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -10193,16 +10193,7 @@ bool isAlpha(dchar c)
     // optimization
     if (c < 0xAA)
     {
-        size_t x = c - 'A';
-        if (x <= 'Z' - 'A')
-            return true;
-        else
-        {
-            x = c - 'a';
-            if (x <= 'z'-'a')
-                return true;
-        }
-        return false;
+        return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z');
     }
 
     return alphaTrie[c];


### PR DESCRIPTION
The codegen is literally the same.

I could have delegated to std/ascii, and in fact, I do think this would be the right thing to do int he absence of DMD's inliner being what it is.