### PR TITLE
Move Sink out of sformat()

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -1559,40 +1559,6 @@ char[] sformat(Char, Args...)(return scope char[] buf, scope const(Char)[] fmt, 
     import std.range.primitives;
     import std.utf : encode;
 
-    static struct Sink
-    {
-        char[] buf;
-        size_t i;
-        void put(dchar c)
-        {
-            char[4] enc;
-            auto n = encode(enc, c);
-
-            if (buf.length < i + n)
-                throw new RangeError(__FILE__, __LINE__);
-
-            buf[i .. i + n] = enc[0 .. n];
-            i += n;
-        }
-        void put(scope const(char)[] s)
-        {
-            if (buf.length < i + s.length)
-                throw new RangeError(__FILE__, __LINE__);
-
-            buf[i .. i + s.length] = s[];
-            i += s.length;
-        }
-        void put(scope const(wchar)[] s)
-        {
-            for (; !s.empty; s.popFront())
-                put(s.front);
-        }
-        void put(scope const(dchar)[] s)
-        {
-            for (; !s.empty; s.popFront())
-                put(s.front);
-        }
-    }
     auto sink = Sink(buf);
     auto n = formattedWrite(sink, fmt, args);
     version (all)
@@ -1685,6 +1651,45 @@ if (isSomeString!(typeof(fmt)))
     sformat(buf, "%s", 'c');
     const v = () @trusted { return GC.stats().usedSize; } ();
     assert(u == v);
+}
+
+private struct Sink
+{
+    import core.exception : RangeError;
+    import std.range.primitives;
+    import std.utf : encode;
+
+    char[] buf;
+    size_t i;
+    void put(dchar c)
+    {
+        char[4] enc;
+        auto n = encode(enc, c);
+
+        if (buf.length < i + n)
+            throw new RangeError(__FILE__, __LINE__);
+
+        buf[i .. i + n] = enc[0 .. n];
+        i += n;
+    }
+    void put(scope const(char)[] s)
+    {
+        if (buf.length < i + s.length)
+            throw new RangeError(__FILE__, __LINE__);
+
+        buf[i .. i + s.length] = s[];
+        i += s.length;
+    }
+    void put(scope const(wchar)[] s)
+    {
+        for (; !s.empty; s.popFront())
+            put(s.front);
+    }
+    void put(scope const(dchar)[] s)
+    {
+        for (; !s.empty; s.popFront())
+            put(s.front);
+    }
 }
 
 version (StdUnittest)


### PR DESCRIPTION
`Sink` does not have any specialization on `Args` and therefore we only ever need one definition of it.

On my machine this patch has a pretty significant impact on compile-time speeds (1.2sec => 0.8sec). But this is on a low KLOC codebase and a very beefy machine.

Unfortunately the compiler doesn't know how to optimize this to improve compile-time speeds. Perhaps it could try to "move" symbols into module scope if they're static and also have no dependency on the function's type parameters (essentially this patch, but done automatically under the hood). But that could create problems during linking. It would be an interesting problem to solve. @WalterBright maybe this one is interesting to you?