### PR TITLE
Avoid use of EnumMembers in enum specialization of formatValueImpl

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3019,15 +3019,10 @@ if (is(T == enum))
 
     if (f.spec == 's')
     {
-        foreach (i, e; EnumMembers!T)
-        {
-            if (val == e)
-            {
-                formatValueImpl(w, __traits(allMembers, T)[i], f);
-                return;
-            }
-        }
-
+        static immutable members = __traits(allMembers, T);
+        foreach (immutable member; members)
+            if (val == __traits(getMember, T, member))
+                return formatValueImpl(w, member, f);
         auto w2 = appender!string();
 
         // val is not a member of T, output cast(T) rawValue instead.

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3019,8 +3019,7 @@ if (is(T == enum))
 
     if (f.spec == 's')
     {
-        static immutable members = __traits(allMembers, T);
-        foreach (immutable member; members)
+        foreach (immutable member; __traits(allMembers, T))
             if (val == __traits(getMember, T, member))
                 return formatValueImpl(w, member, f);
         auto w2 = appender!string();


### PR DESCRIPTION
Also see https://github.com/dlang/phobos/pull/8591.