### PR TITLE
Use __traits(identifier) to format enum member

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3019,11 +3019,11 @@ if (is(T == enum))
 
     if (f.spec == 's')
     {
-        foreach (i, e; EnumMembers!T)
+        static foreach (e; EnumMembers!T)
         {
             if (val == e)
             {
-                formatValueImpl(w, __traits(allMembers, T)[i], f);
+                formatValueImpl(w, __traits(identifier, e), f);
                 return;
             }
         }


### PR DESCRIPTION
No behavioral change, but simplifies the code.

---

See discussion in #8593 for additional context.