### PR TITLE
Cirrus: Bump FreeBSD from v11/12 to v12/13

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,30 +51,30 @@ macos_task:
   << : *COMMON_STEPS_TEMPLATE
 
 # FreeBSD
-freebsd12_task:
-  name: FreeBSD 12.2 x64
+freebsd13_task:
+  name: FreeBSD 13.0 x64
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-13-0
     cpu: 4
     memory: 8G
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
-    CI_DFLAGS: -version=TARGET_FREEBSD12
+    CI_DFLAGS: -version=TARGET_FREEBSD13
   install_bash_and_git_script: pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE
 
-freebsd11_task:
-  name: FreeBSD 11.4 x64
+freebsd12_task:
+  name: FreeBSD 12.3 x64
   freebsd_instance:
-    image_family: freebsd-11-4
+    image_family: freebsd-12-3
     cpu: 4
     memory: 8G
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
-    HOST_DMD: dmd-2.079.0
-    CI_DFLAGS: -version=TARGET_FREEBSD11
+    HOST_DMD: dmd-2.095.0
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_and_git_script: |
     sed -i '' -e 's|pkg.FreeBSD.org|mirrors.xtom.com/freebsd-pkg|' /etc/pkg/FreeBSD.conf
     pkg install -y bash git


### PR DESCRIPTION
This was done in DMD (https://github.com/dlang/dmd/commit/c63a8be0aa0781a59df63a98f56aa09f0fec4645) but not here, and the CI is currently broken on 11.