### PR TITLE
Improve std.experimental.allocator docs

### DIFF
--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -149,6 +149,9 @@ block size of 4 KB. Sizes above that are passed direct to the `GCAllocator`.
 
 $(RUNNABLE_EXAMPLE
     ----
+    import std.experimental.allocator;
+    import std.algorithm.comparison : max;
+
     alias FList = FreeList!(GCAllocator, 0, unbounded);
     alias A = Segregator!(
         8, FreeList!(GCAllocator, 0, 8),
@@ -158,8 +161,7 @@ $(RUNNABLE_EXAMPLE
         1024, Bucketizer!(FList, 513, 1024, 128),
         2048, Bucketizer!(FList, 1025, 2048, 256),
         3584, Bucketizer!(FList, 2049, 3584, 512),
-        4072 * 1024, AllocatorList!(
-            () => BitmappedBlock!(GCAllocator, 4096)(4072 * 1024)),
+        4072 * 1024, AllocatorList!(n => Region!GCAllocator(max(n, 1024 * 4096))),
         GCAllocator
     );
     A tuMalloc;

--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -147,7 +147,8 @@ Sizes through 3584 bytes are handled via freelists of staggered sizes. Sizes
 from 3585 bytes through 4072 KB are handled by a `BitmappedBlock` with a
 block size of 4 KB. Sizes above that are passed direct to the `GCAllocator`.
 
-----
+$(RUNNABLE_EXAMPLE
+    ----
     alias FList = FreeList!(GCAllocator, 0, unbounded);
     alias A = Segregator!(
         8, FreeList!(GCAllocator, 0, 8),
@@ -169,7 +170,8 @@ block size of 4 KB. Sizes above that are passed direct to the `GCAllocator`.
     assert(tuMalloc.expand(c, 14));
     tuMalloc.deallocate(b);
     tuMalloc.deallocate(c);
-----
+    ----
+)
 
 $(H2 Allocating memory for sharing across threads)
 

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -27,13 +27,22 @@ $(TR $(TD Global) $(TD
     $(LREF theAllocator)
 ))
 $(TR $(TD Class interface) $(TD
-    $(LREF allocatorObject)
     $(LREF CAllocatorImpl)
+    $(LREF CSharedAllocatorImpl)
     $(LREF IAllocator)
+    $(LREF ISharedAllocator)
+))
+$(TR $(TD Structs) $(TD
+    $(LREF allocatorObject)
+    $(LREF RCIAllocator)
+    $(LREF RCISharedAllocator)
+    $(LREF sharedAllocatorObject)
+    $(LREF ThreadLocal)
 ))
 )
 
 Synopsis:
+$(RUNNABLE_EXAMPLE
 ---
 // Allocate an int, initialize it with 42
 int* p = theAllocator.make!int(42);
@@ -46,7 +55,10 @@ p = processAllocator.make!int(100);
 assert(*p == 100);
 // Destroy and deallocate
 processAllocator.dispose(p);
-
+---
+)
+$(RUNNABLE_EXAMPLE
+---
 // Create an array of 50 doubles initialized to -1.0
 double[] arr = theAllocator.makeArray!double(50, -1.0);
 // Append two zeros to it
@@ -56,6 +68,7 @@ theAllocator.shrinkArray(arr, 2);
 // Destroy and deallocate
 theAllocator.dispose(arr);
 ---
+)
 
 $(H2 Layered Structure)
 


### PR DESCRIPTION
Add missing LREFs in top table.
Use RUNNABLE_EXAMPLE for synopsis.