### PR TITLE
circleci: Migrate to circleci convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/phobos
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:current-20.04
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
The circle/ images were [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) in 2021, and no longer receive updates.  As seen by a couple repositories [beginning to fail](https://circleci.com/gh/dlang/dlang.org/4716) due to outdated curl/ca certificates.