### PR TITLE
chore(sumtype): avoid quadratic memory complexity on opEquals

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -714,16 +714,24 @@ public:
     {
         static if (is(This == Rhs))
         {
-            return AliasSeq!(this, rhs).match!((ref value, ref rhsValue) {
-                static if (is(typeof(value) == typeof(rhsValue)))
+            final switch(tag)
+            {
+                static foreach(idx, T; Types)
                 {
-                    return value == rhsValue;
+                    case idx:
+                        final switch (rhs.tag)
+                        {
+                            static foreach(ridx, U; typeof(rhs).Types)
+                            {
+                                case ridx:
+                                    static if (is(immutable T == immutable U))
+                                        return get!T == rhs.get!U;
+                                    else
+                                        return false;
+                            }
+                        }
                 }
-                else
-                {
-                    return false;
-                }
-            });
+            }
         }
         else
         {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Due to `match` template being quadratic/exponential in terms of memory complexity, (`-vtemplate` reports a rediculous amount of templates) using `opEquals` will generate a lot of unnecessary template instances. Removing `match` here to prevent that.