### PR TITLE
Clarify the format flags documentation.

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -213,7 +213,7 @@ $(BOOKTABLE ,
    $(TR $(TH Flag) $(TH Semantics))
    $(TR $(TD $(B '-'))
         $(TD When the formatted result is shorter than the value
-             given by the width parameter, then the output is left
+             given by the width parameter, the output is left
              justified. Without the $(B '-') flag, the output remains
              right justified.
 
@@ -223,7 +223,7 @@ $(BOOKTABLE ,
              no special handling of the members is applied.))
    $(TR $(TD $(B '='))
         $(TD When the formatted result is shorter than the value
-             given by the width parameter, then the output is centered.
+             given by the width parameter, the output is centered.
              If the central position is not possible it is moved slightly
              to the right. In this case, if $(B '-') flag is present in
              addition to the $(B '=') flag, it is moved slightly to the left.))

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -212,18 +212,18 @@ There are several flags that affect the outcome of the formatting.
 $(BOOKTABLE ,
    $(TR $(TH Flag) $(TH Semantics))
    $(TR $(TD $(B '-'))
-        $(TD When the formatted result is shorter then the value
-             given by the width parameter, the output is right
-             justified. With the $(B '-') flag this is changed
-             to left justification.
+        $(TD When the formatted result is shorter than the value
+             given by the width parameter, then the output is left
+             justified. Without the $(B '-') flag the output remains
+             right justified.
 
              There are two exceptions where the $(B '-') flag has a
              different meaning: (1) with $(B 'r') it denotes to use little
              endian and (2) in case of a compound indicator it means that
              no special handling of the members is applied.))
    $(TR $(TD $(B '='))
-        $(TD When the formatted result is shorter then the value
-             given by the width parameter, the output is centered.
+        $(TD When the formatted result is shorter than the value
+             given by the width parameter, then the output is centered.
              If the central position is not possible it is moved slightly
              to the right. In this case, if $(B '-') flag is present in
              addition to the $(B '=') flag, it is moved slightly to the left.))

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -214,7 +214,7 @@ $(BOOKTABLE ,
    $(TR $(TD $(B '-'))
         $(TD When the formatted result is shorter than the value
              given by the width parameter, then the output is left
-             justified. Without the $(B '-') flag the output remains
+             justified. Without the $(B '-') flag, the output remains
              right justified.
 
              There are two exceptions where the $(B '-') flag has a


### PR DESCRIPTION
Resolve a `then`/`than` error and focus on what the flag does instead of on the default behaviour when the flag is absent. This way the descriptions for the `-` and `=` flags are more in line.