### PR TITLE
Use ref element in foreach in assocArray to avoid any calls to copy c…

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -586,7 +586,7 @@ if (isInputRange!Range)
     static assert(isMutable!ValueType, "assocArray: value type must be mutable");
 
     ValueType[KeyType] aa;
-    foreach (t; r)
+    foreach (ref t; r)
         aa[t[0]] = t[1];
     return aa;
 }


### PR DESCRIPTION
…onstructor of element type

Tests pass locally.