### PR TITLE
Force makefile to x86 on Apple ARM cpu (dmd does not support ARM)

### DIFF
--- a/etc/c/zlib/osx.mak
+++ b/etc/c/zlib/osx.mak
@@ -3,6 +3,10 @@
 CC=gcc
 LD=link
 CFLAGS=-I. -O -g -DHAVE_UNISTD_H -DHAVE_STDARG_H
+ifeq (64,$(MODEL))
+	CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+endif
+
 LDFLAGS=
 O=.o
 

--- a/posix.mak
+++ b/posix.mak
@@ -135,6 +135,12 @@ else
 		endif
 	endif
 endif
+ifeq (osx,$(OS))
+	ifeq (64,$(MODEL))
+		CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+	endif
+endif
+
 
 # Set DFLAGS
 DFLAGS=


### PR DESCRIPTION
This fixes `make -j4 -C ../phobos -f posix.mak` on Apple OSX with an ARM cpu.

Related DMD PR: https://github.com/dlang/dmd/pull/14586