### PR TITLE
[std/array] Fix wrong Appender docs 'global locking for each append'

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3416,7 +3416,8 @@ do
 Implements an output range that appends data to an array. This is
 recommended over $(D array ~= data) when appending many elements because it is more
 efficient. `Appender` maintains its own array metadata locally, so it can avoid
-global locking for each append where $(LREF capacity) is non-zero.
+the $(DDSUBLINK spec/arrays, capacity-reserve, performance hit of looking up slice `capacity`)
+for each append.
 
 Params:
     A = the array type to simulate.


### PR DESCRIPTION
@schveiguy explained there is a thread-local cache that avoids a global lock once the cache is filled.
See https://github.com/dlang/dlang.org/pull/3445#discussion_r1002773401. 
Add link to spec (instead of capacity LREF which already exists just above Appender).