### PR TITLE
merge stable

### DIFF
--- a/etc/c/zlib/osx.mak
+++ b/etc/c/zlib/osx.mak
@@ -3,6 +3,10 @@
 CC=gcc
 LD=link
 CFLAGS=-I. -O -g -DHAVE_UNISTD_H -DHAVE_STDARG_H
+ifeq (64,$(MODEL))
+	CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+endif
+
 LDFLAGS=
 O=.o
 

--- a/posix.mak
+++ b/posix.mak
@@ -135,6 +135,12 @@ else
 		endif
 	endif
 endif
+ifeq (osx,$(OS))
+	ifeq (64,$(MODEL))
+		CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+	endif
+endif
+
 
 # Set DFLAGS
 DFLAGS=

--- a/std/array.d
+++ b/std/array.d
@@ -586,7 +586,7 @@ if (isInputRange!Range)
     static assert(isMutable!ValueType, "assocArray: value type must be mutable");
 
     ValueType[KeyType] aa;
-    foreach (t; r)
+    foreach (ref t; r)
         aa[t[0]] = t[1];
     return aa;
 }


### PR DESCRIPTION
- Fix issue 23400 - Can't format enum value whose base type has non-const opEquals
- Clarify the format flags documentation. (#8612)
