### PR TITLE
remove redundant attributes in typecons.d

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5536,7 +5536,7 @@ private static:
     }
 
     // handle each overload set
-    private string generateCodeForOverloadSet(alias oset)() @property
+    string generateCodeForOverloadSet(alias oset)() @property
     {
         string code = "";
 
@@ -5666,7 +5666,7 @@ private static:
      * "ref int a0, real a1, ..."
      */
     static struct GenParams { string imports, params; }
-    private GenParams generateParameters(string myFuncInfo, func...)()
+    GenParams generateParameters(string myFuncInfo, func...)()
     {
         alias STC = ParameterStorageClass;
         alias stcs = ParameterStorageClassTuple!(func);
@@ -5716,7 +5716,7 @@ private static:
 
     // Returns D code which enumerates n parameter variables using comma as the
     // separator.  "a0, a1, a2, a3"
-    private string enumerateParameters(size_t n)() @property
+    string enumerateParameters(size_t n)() @property
     {
         string params = "";
 


### PR DESCRIPTION
I am currently working on improving D-Scanner and currently it does not catch this "redundant attributes" situation for this particular file, hence my version of D-Scanner applied to phobos will fail because of this. (even if the warning is valid)

Concretely, the `private` access modifiers that I deleted are not necessary, because all these declarations are inside a private scope (that starts on line 5467)
https://github.com/dlang/phobos/blob/master/std/typecons.d#L5467