### PR TITLE
same name fix

### DIFF
--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -630,36 +630,36 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         import core.atomic : atomicLoad, MemoryOrder;
         static if (is(typeof(this.payload.atomicLoad!(MemoryOrder.acq)) P))
         {
-            auto payload = __ctfe ? cast(P) this.payload
+            auto local_payload = __ctfe ? cast(P) this.payload
                                   : this.payload.atomicLoad!(MemoryOrder.acq);
         }
         else
         {
-            alias payload = this.payload;
+            alias local_payload = this.payload;
         }
 
         static if (hasMember!(Hook, "hookToHash"))
         {
-            return hook.hookToHash(payload);
+            return hook.hookToHash(local_payload);
         }
         else static if (stateSize!Hook > 0)
         {
-            static if (hasMember!(typeof(payload), "toHash"))
+            static if (hasMember!(typeof(local_payload), "toHash"))
             {
-                return payload.toHash() ^ hashOf(hook);
+                return local_payload.toHash() ^ hashOf(hook);
             }
             else
             {
-                return hashOf(payload) ^ hashOf(hook);
+                return hashOf(local_payload) ^ hashOf(hook);
             }
         }
-        else static if (hasMember!(typeof(payload), "toHash"))
+        else static if (hasMember!(typeof(local_payload), "toHash"))
         {
-            return payload.toHash();
+            return local_payload.toHash();
         }
         else
         {
-            return .hashOf(payload);
+            return .hashOf(local_payload);
         }
     }
 

--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -630,36 +630,36 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         import core.atomic : atomicLoad, MemoryOrder;
         static if (is(typeof(this.payload.atomicLoad!(MemoryOrder.acq)) P))
         {
-            auto local_payload = __ctfe ? cast(P) this.payload
+            auto localPayload = __ctfe ? cast(P) this.payload
                                   : this.payload.atomicLoad!(MemoryOrder.acq);
         }
         else
         {
-            alias local_payload = this.payload;
+            alias localPayload = this.payload;
         }
 
         static if (hasMember!(Hook, "hookToHash"))
         {
-            return hook.hookToHash(local_payload);
+            return hook.hookToHash(localPayload);
         }
         else static if (stateSize!Hook > 0)
         {
-            static if (hasMember!(typeof(local_payload), "toHash"))
+            static if (hasMember!(typeof(localPayload), "toHash"))
             {
-                return local_payload.toHash() ^ hashOf(hook);
+                return localPayload.toHash() ^ hashOf(hook);
             }
             else
             {
-                return hashOf(local_payload) ^ hashOf(hook);
+                return hashOf(localPayload) ^ hashOf(hook);
             }
         }
-        else static if (hasMember!(typeof(local_payload), "toHash"))
+        else static if (hasMember!(typeof(localPayload), "toHash"))
         {
-            return local_payload.toHash();
+            return localPayload.toHash();
         }
         else
         {
-            return .hashOf(local_payload);
+            return .hashOf(localPayload);
         }
     }
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10095,7 +10095,7 @@ else version (Windows)
 
         static void testScope(scope ref SysTime st) @safe
         {
-            auto local_result = SysTimeToSYSTEMTIME(st);
+            auto localResult = SysTimeToSYSTEMTIME(st);
         }
     }
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -10095,7 +10095,7 @@ else version (Windows)
 
         static void testScope(scope ref SysTime st) @safe
         {
-            auto result = SysTimeToSYSTEMTIME(st);
+            auto local_result = SysTimeToSYSTEMTIME(st);
         }
     }
 
@@ -10178,7 +10178,7 @@ else version (Windows)
 
         static void testScope(scope ref SysTime st) @safe
         {
-            auto result = SysTimeToFILETIME(st);
+            auto local_result = SysTimeToFILETIME(st);
         }
     }
 }

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -202,14 +202,14 @@ if (hashBlockSize % 8 == 0)
         import std.string : representation;
         string data1 = "Hello, world", data2 = "Hola mundo";
         auto hmac = HMAC!SHA1("My s3cR3T keY".representation);
-        auto digestTest = hmac.put(data1.representation)
+        auto testDigest = hmac.put(data1.representation)
                           .put(data2.representation)
                           .finish();
         static immutable expected = [
             197, 57, 52, 3, 13, 194, 13,
             36, 117, 228, 8, 11, 111, 51,
             165, 3, 123, 31, 251, 113];
-        assert(digestTest == expected);
+        assert(testDigest == expected);
     }
 }
 

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -202,14 +202,14 @@ if (hashBlockSize % 8 == 0)
         import std.string : representation;
         string data1 = "Hello, world", data2 = "Hola mundo";
         auto hmac = HMAC!SHA1("My s3cR3T keY".representation);
-        auto digest = hmac.put(data1.representation)
+        auto digestTest = hmac.put(data1.representation)
                           .put(data2.representation)
                           .finish();
         static immutable expected = [
             197, 57, 52, 3, 13, 194, 13,
             36, 117, 228, 8, 11, 111, 51,
             165, 3, 123, 31, 251, 113];
-        assert(digest == expected);
+        assert(digestTest == expected);
     }
 }
 

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3148,7 +3148,7 @@ if (isPointer!T && !is(T == enum) && !hasToString!(T, Char))
 
     auto a = iota(0, 10);
     auto b = iota(0, 10);
-    auto p = () @trusted { auto p = &a; return p; }();
+    auto p = () @trusted { auto scoped_p = &a; return scoped_p; }();
 
     assert(format("%s",p) != format("%s",b));
 }

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3148,7 +3148,7 @@ if (isPointer!T && !is(T == enum) && !hasToString!(T, Char))
 
     auto a = iota(0, 10);
     auto b = iota(0, 10);
-    auto p = () @trusted { auto scoped_p = &a; return scoped_p; }();
+    auto p = () @trusted { auto result = &a; return result; }();
 
     assert(format("%s",p) != format("%s",b));
 }

--- a/std/socket.d
+++ b/std/socket.d
@@ -2646,17 +2646,17 @@ private:
 
             enum msecs = 1000;
             auto pair = socketPair();
-            auto sock = pair[0];
-            sock.setOption(SocketOptionLevel.SOCKET,
+            auto sockTest = pair[0];
+            sockTest.setOption(SocketOptionLevel.SOCKET,
                 SocketOption.RCVTIMEO, dur!"msecs"(msecs));
 
             auto sw = StopWatch(Yes.autoStart);
             ubyte[1] buf;
-            sock.receive(buf);
+            sockTest.receive(buf);
             sw.stop();
 
             Duration readBack = void;
-            sock.getOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, readBack);
+            sockTest.getOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, readBack);
 
             assert(readBack.total!"msecs" == msecs);
             assert(sw.peek().total!"msecs" > msecs - 100 && sw.peek().total!"msecs" < msecs + 100);

--- a/std/socket.d
+++ b/std/socket.d
@@ -2646,17 +2646,17 @@ private:
 
             enum msecs = 1000;
             auto pair = socketPair();
-            auto sockTest = pair[0];
-            sockTest.setOption(SocketOptionLevel.SOCKET,
+            auto testSock = pair[0];
+            testSock.setOption(SocketOptionLevel.SOCKET,
                 SocketOption.RCVTIMEO, dur!"msecs"(msecs));
 
             auto sw = StopWatch(Yes.autoStart);
             ubyte[1] buf;
-            sockTest.receive(buf);
+            testSock.receive(buf);
             sw.stop();
 
             Duration readBack = void;
-            sockTest.getOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, readBack);
+            testSock.getOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, readBack);
 
             assert(readBack.total!"msecs" == msecs);
             assert(sw.peek().total!"msecs" > msecs - 100 && sw.peek().total!"msecs" < msecs + 100);

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1952,10 +1952,10 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
         // An array that maps caseIds to handler indices ("hids").
         enum matches = ()
         {
-            size_t[numCases] matches;
+            size_t[numCases] scoped_matches;
 
             // Workaround for https://issues.dlang.org/show_bug.cgi?id=19561
-            foreach (ref match; matches)
+            foreach (ref match; scoped_matches)
             {
                 match = noMatch;
             }
@@ -1966,15 +1966,15 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
                 {
                     static if (canMatch!(handler, valueTypes!caseId))
                     {
-                        if (matches[caseId] == noMatch)
+                        if (scoped_matches[caseId] == noMatch)
                         {
-                            matches[caseId] = hid;
+                            scoped_matches[caseId] = hid;
                         }
                     }
                 }
             }
 
-            return matches;
+            return scoped_matches;
         }();
 
         import std.algorithm.searching : canFind;

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1952,10 +1952,10 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
         // An array that maps caseIds to handler indices ("hids").
         enum matches = ()
         {
-            size_t[numCases] scoped_matches;
+            size_t[numCases] result;
 
             // Workaround for https://issues.dlang.org/show_bug.cgi?id=19561
-            foreach (ref match; scoped_matches)
+            foreach (ref match; result)
             {
                 match = noMatch;
             }
@@ -1966,15 +1966,15 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
                 {
                     static if (canMatch!(handler, valueTypes!caseId))
                     {
-                        if (scoped_matches[caseId] == noMatch)
+                        if (result[caseId] == noMatch)
                         {
-                            scoped_matches[caseId] = hid;
+                            result[caseId] = hid;
                         }
                     }
                 }
             }
 
-            return scoped_matches;
+            return result;
         }();
 
         import std.algorithm.searching : canFind;

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -6271,8 +6271,8 @@ struct UnicodeSetParser(Range)
         {
             if (casefold_)
             {
-                auto local_range = simpleCaseFoldings(ch);
-                foreach (v; local_range)
+                auto foldings = simpleCaseFoldings(ch);
+                foreach (v; foldings)
                     set |= v;
             }
             else

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -6271,8 +6271,8 @@ struct UnicodeSetParser(Range)
         {
             if (casefold_)
             {
-                auto range = simpleCaseFoldings(ch);
-                foreach (v; range)
+                auto local_range = simpleCaseFoldings(ch);
+                foreach (v; local_range)
                     set |= v;
             }
             else


### PR DESCRIPTION
I am currently working on improving D-Scanner and currently it does not catch this "same name variable" situation for the changed files, hence my version of D-Scanner applied to phobos will fail because of this. (even if the warning is valid)

Concretely, current D-Scanner won't throws a warning for situations like this:

```
int a;
// ...
void foo() { auto a = 3; }
```

This was just an example but from what I can tell it won't throw the warning for any `auto` declarations (even when that's the case)