### PR TITLE
[stable] Cherry-pick changes from master that are needed for `dub` to compile

### DIFF
--- a/std/internal/windows/advapi32.d
+++ b/std/internal/windows/advapi32.d
@@ -36,7 +36,9 @@ pragma(lib, "advapi32.lib");
 HMODULE hAdvapi32 = null;
 extern (Windows)
 {
-    LONG function(in HKEY hkey, in LPCWSTR lpSubKey, in REGSAM samDesired, in DWORD reserved) pRegDeleteKeyExW;
+    LONG function(
+        scope const HKEY hkey, scope const LPCWSTR lpSubKey,
+        scope const REGSAM samDesired, scope const DWORD reserved) pRegDeleteKeyExW;
 }
 
 void loadAdvapi32()

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -145,8 +145,8 @@ version (Windows)
     // encoded in CP_ACP on Windows instead of UTF-8.
     /+ Waiting for druntime pull 299
     +/
-    extern (C) nothrow @nogc FILE* _wfopen(in wchar* filename, in wchar* mode);
-    extern (C) nothrow @nogc FILE* _wfreopen(in wchar* filename, in wchar* mode, FILE* fp);
+    extern (C) nothrow @nogc FILE* _wfopen(scope const wchar* filename, scope const wchar* mode);
+    extern (C) nothrow @nogc FILE* _wfreopen(scope const wchar* filename, scope const wchar* mode, FILE* fp);
 
     import core.sys.windows.basetsd : HANDLE;
 }

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -10129,15 +10129,11 @@ struct RefCounted(T, RefCountedAutoInitialize autoInit =
         private enum enableGCScan = hasIndirections!T;
     }
 
-    // TODO remove pure when https://issues.dlang.org/show_bug.cgi?id=15862 has been fixed
     extern(C) private pure nothrow @nogc static
     {
         pragma(mangle, "free") void pureFree( void *ptr );
         static if (enableGCScan)
-        {
-            pragma(mangle, "gc_addRange") void pureGcAddRange( in void* p, size_t sz, const TypeInfo ti = null );
-            pragma(mangle, "gc_removeRange") void pureGcRemoveRange( in void* p );
-        }
+            import core.memory : GC;
     }
 
     struct RefCountedStore
@@ -10176,7 +10172,7 @@ struct RefCounted(T, RefCountedAutoInitialize autoInit =
             {
                 import std.internal.memory : enforceCalloc;
                 _store = cast(Impl*) enforceCalloc(1, Impl.sizeof);
-                pureGcAddRange(&_store._payload, T.sizeof);
+                GC.addRange(&_store._payload, T.sizeof);
             }
             else
             {
@@ -10189,7 +10185,7 @@ struct RefCounted(T, RefCountedAutoInitialize autoInit =
         {
             static if (enableGCScan)
             {
-                pureGcRemoveRange(&this._store._payload);
+                GC.removeRange(&this._store._payload);
             }
             pureFree(_store);
             _store = null;


### PR DESCRIPTION
Dub uses `-preview=in` to compile in its `build.d` script, but not in the `dub.sdl` (because Vibe.d wasn't DIP1000 compatible).
DMD v2.101.0 introduced a change that means `-preview=in` now disallows `in` on non-`extern(D)` / `extern(C++)` functions.
But since the fixes were done 3 days after the start of the v2.101 release, the dub CI is currently broken with latest.