### PR TITLE
Fix slow compilation when using std.regex

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -932,13 +932,6 @@ nothrow pure @safe @nogc unittest
     assert(result > 0);
 }
 
-nothrow pure @safe unittest
-{
-    // Parallelism (was broken by inferred return type "immutable int")
-    import std.parallelism : task;
-    auto t = task!cmp("foo", "bar");
-}
-
 // equal
 /**
 Compares two or more ranges for equality, as defined by predicate `pred`

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4914,3 +4914,10 @@ version (parallelismStressTest)
     try foreach (rnd; rndGen.parallel) break;
     catch (ParallelForeachError e) {}
 }
+
+nothrow pure @safe unittest
+{
+    // Parallelism (was broken by inferred return type "immutable int")
+    import std.algorithm.comparison;
+    auto t = task!cmp("foo", "bar");
+}

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -49,10 +49,11 @@ CharMatcher[CodepointSet] matcherCache;
     }
 }
 
-@property ref wordMatcher()()
+static immutable CharMatcher wordMatcher;
+
+shared static this()
 {
-    static immutable CharMatcher matcher = CharMatcher(wordCharacter);
-    return matcher;
+    wordMatcher = immutable CharMatcher(wordCharacter);
 }
 
 // some special Unicode white space characters
@@ -965,6 +966,13 @@ struct CharMatcher {
     Trie trie;      // slow path for Unicode
 
     this(CodepointSet set)
+    {
+        auto asciiSet = set & unicode.ASCII;
+        ascii = BitTable(asciiSet);
+        trie = makeTrie(set);
+    }
+
+    immutable this(CodepointSet set)
     {
         auto asciiSet = set & unicode.ASCII;
         ascii = BitTable(asciiSet);

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -2159,7 +2159,7 @@ public struct InversionList(SP=GcPolicy)
     /**
         Get range that spans all of the $(CODEPOINT) intervals in this $(LREF InversionList).
     */
-    @property auto byInterval() scope
+    @property auto byInterval() scope const
     {
         // TODO: change this to data[] once the -dip1000 errors have been fixed
         // see e.g. https://github.com/dlang/phobos/pull/6638
@@ -4282,7 +4282,7 @@ template isValidArgsForTrie(Key, Args...)
 public template codepointSetTrie(sizes...)
 if (sumOfIntegerTuple!sizes == 21)
 {
-    auto codepointSetTrie(Set)(Set set)
+    auto codepointSetTrie(Set)(const auto ref Set set) pure
         if (isCodepointSet!Set)
     {
         auto builder = TrieBuilder!(bool, dchar, lastDchar+1, GetBitSlicing!(21, sizes))(false);


### PR DESCRIPTION
Taking this short program as an example:
```d
import std.regex, std.stdio;

void main(string[] argv) {
	auto re = regex(argv[1]);
	auto matches = matchFirst(argv[2], re);
	writeln(matches);
}
```

Before:
```
time dmd re.d

real	0m2,404s
user	0m2,205s
sys	0m0,200s
```
After:
```
time dmd re.d

real	0m1,198s
user	0m1,103s
sys	0m0,096s
```

I still think the compile time is too big, maybe there is another CTFE-heavy construction hiding in there.