### PR TITLE
fixes #23507 sockets are blocking by default, this needs to reflect that

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2628,7 +2628,7 @@ private:
     AddressFamily _family;
 
     version (Windows)
-        bool _blocking = false;         /// Property to get or set whether the socket is blocking or nonblocking.
+        bool _blocking = true;         /// Property to get or set whether the socket is blocking or nonblocking.
 
     // The WinSock timeouts seem to be effectively skewed by a constant
     // offset of about half a second (value in milliseconds). This has


### PR DESCRIPTION
This is remarkable to me - git blame says this was there in the initial commit to git in 2007, meaning it goes back to prehistory (though I could probably download some ancient phobos and check there, but i suspect it has been there the whole time), but I'm almost certain this is wrong.

Windows sockets are blocking by default. The Phobos docs, the constructor for Socket, states that it "creates a blocking socket". The behavior is blocking. But this property defaults to false.... and a new commit to my code happened to use it, assuming it had correct info, causing a regression for me!

But, as far as I can tell, this should have been true by default the whole time.