### PR TITLE
Fix getSymbolsByUDA by replacing broad __traits(compiles) with a more narrow condition

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8847,6 +8847,14 @@ version (StdUnittest)
     static assert(__traits(compiles, getSymbolsByUDA!(mixin(__MODULE__), "Issue20054")));
 }
 
+private template isAliasSeq(Args...)
+{
+    static if (Args.length != 1)
+        enum isAliasSeq = true;
+    else
+        enum isAliasSeq = false;
+}
+
 private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
 {
     import std.meta : Alias, AliasSeq, Filter;
@@ -8868,12 +8876,12 @@ private template getSymbolsByUDAImpl(alias symbol, alias attribute, names...)
             alias member = __traits(getMember, symbol, names[0]);
 
             // Filtering not compiled members such as alias of basic types.
-            static if (!__traits(compiles, hasUDA!(member, attribute)))
+            static if (isAliasSeq!member || isType!member)
             {
                 alias getSymbolsByUDAImpl = tail;
             }
-            // Get overloads for functions, in case different overloads have different sets of UDAs.
-            else static if (isFunction!member)
+            // If a symbol is overloaded, get UDAs for each overload (including templated overlaods).
+            else static if (__traits(getOverloads, symbol, names[0], true).length > 0)
             {
                 enum hasSpecificUDA(alias member) = hasUDA!(member, attribute);
                 alias overloadsWithUDA = Filter!(hasSpecificUDA, __traits(getOverloads, symbol, names[0]));


### PR DESCRIPTION
This was discovered in https://github.com/dlang/dmd/pull/14554.

`hasUDA` uses `getUDAs` underneath which in turn uses `traits(getAttributes)`. Up until dmd PR 14554 `getUDAs` would happily accept an overload set and because of the bug in `__traits(getAttributes)` it would just check the first lexicographically overload encountered.

`getSymbolsByUDA` which uses `hasUDA` internally would first check if `hasUDA` is callalble on the members of the passed aggregate by using `__traits(compiles, hasUDA!member)`. This was done to prevent calling `traits(getAttributes)` on types or alias sequences, however, with the new deprecation from dmd PR 14554 and since phobos compiles with -de the `__traits(compiles)` check now fails for functions that have overloads, thus breaking `getSymbolsByUDA`.

The fix is to narrow the condition by specifically checking for types and alias sequences in the internals of `getSymbolsByUDA`, which this PR does, thus unblocking dmd PR 14554.