### PR TITLE
remove isScalar check from std.traits.isPointer

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -7138,7 +7138,7 @@ enum bool isSIMDVector(T) = is(T : __vector(V[N]), V, size_t N);
 /**
  * Detect whether type `T` is a pointer.
  */
-enum bool isPointer(T) = is(T == U*, U) && __traits(isScalar, T);
+enum bool isPointer(T) = is(T == U*, U);
 
 ///
 @safe unittest


### PR DESCRIPTION
I have no idea why the isScalar check is there. Let's see if removing it breaks anything. The is checked should be sufficient.