### PR TITLE
std.math.hardware: Fix broken IEEE FP flags tests

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -236,6 +236,7 @@ public:
 }
 
 ///
+version (StdDdoc)
 @safe unittest
 {
     import std.math.traits : isNaN;
@@ -243,19 +244,43 @@ public:
     static void func() {
         int a = 10 * 10;
     }
-    pragma(inline, false) static void blockopt(ref real x) {}
     real a = 3.5;
     // Set all the flags to zero
     resetIeeeFlags();
     assert(!ieeeFlags.divByZero);
-    blockopt(a); // avoid constant propagation by the optimizer
     // Perform a division by zero.
     a /= 0.0L;
     assert(a == real.infinity);
     assert(ieeeFlags.divByZero);
-    blockopt(a); // avoid constant propagation by the optimizer
     // Create a NaN
     a *= 0.0L;
+    assert(ieeeFlags.invalid);
+    assert(isNaN(a));
+
+    // Check that calling func() has no effect on the
+    // status flags.
+    IeeeFlags f = ieeeFlags;
+    func();
+    assert(ieeeFlags == f);
+}
+
+@safe unittest
+{
+    import std.math.traits : isNaN;
+
+    static void func() {
+        int a = 10 * 10;
+    }
+    real a = 3.5;
+    // Set all the flags to zero
+    resetIeeeFlags();
+    assert(!ieeeFlags.divByZero);
+    // Perform a division by zero.
+    a = forceDivOp(a, 0.0L);
+    assert(a == real.infinity);
+    assert(ieeeFlags.divByZero);
+    // Create a NaN
+    a = forceMulOp(a, 0.0L);
     assert(ieeeFlags.invalid);
     assert(isNaN(a));
 
@@ -319,14 +344,24 @@ void resetIeeeFlags() @trusted nothrow @nogc
 }
 
 ///
+version (StdDdoc)
 @safe unittest
 {
-    pragma(inline, false) static void blockopt(ref real x) {}
     resetIeeeFlags();
     real a = 3.5;
-    blockopt(a); // avoid constant propagation by the optimizer
     a /= 0.0L;
-    blockopt(a); // avoid constant propagation by the optimizer
+    assert(a == real.infinity);
+    assert(ieeeFlags.divByZero);
+
+    resetIeeeFlags();
+    assert(!ieeeFlags.divByZero);
+}
+
+@safe unittest
+{
+    resetIeeeFlags();
+    real a = 3.5;
+    a = forceDivOp(a, 0.0L);
     assert(a == real.infinity);
     assert(ieeeFlags.divByZero);
 
@@ -341,21 +376,35 @@ void resetIeeeFlags() @trusted nothrow @nogc
 }
 
 ///
+version (StdDdoc)
 @safe nothrow unittest
 {
     import std.math.traits : isNaN;
 
-    pragma(inline, false) static void blockopt(ref real x) {}
     resetIeeeFlags();
     real a = 3.5;
-    blockopt(a); // avoid constant propagation by the optimizer
 
     a /= 0.0L;
     assert(a == real.infinity);
     assert(ieeeFlags.divByZero);
-    blockopt(a); // avoid constant propagation by the optimizer
 
     a *= 0.0L;
+    assert(isNaN(a));
+    assert(ieeeFlags.invalid);
+}
+
+@safe nothrow unittest
+{
+    import std.math.traits : isNaN;
+
+    resetIeeeFlags();
+    real a = 3.5;
+
+    a = forceDivOp(a, 0.0L);
+    assert(a == real.infinity);
+    assert(ieeeFlags.divByZero);
+
+    a = forceMulOp(a, 0.0L);
     assert(isNaN(a));
     assert(ieeeFlags.invalid);
 }
@@ -904,25 +953,21 @@ private:
 
     static T addRound(T)(uint rm)
     {
-        pragma(inline, false) static void blockopt(ref T x) {}
         pragma(inline, false);
         FloatingPointControl fpctrl;
         fpctrl.rounding = rm;
         T x = 1;
-        blockopt(x); // avoid constant propagation by the optimizer
-        x += 0.1L;
+        x = forceAddOp(x, 0.1L);
         return x;
     }
 
     static T subRound(T)(uint rm)
     {
-        pragma(inline, false) static void blockopt(ref T x) {}
         pragma(inline, false);
         FloatingPointControl fpctrl;
         fpctrl.rounding = rm;
         T x = -1;
-        blockopt(x); // avoid constant propagation by the optimizer
-        x -= 0.1L;
+        x = forceSubOp(x, 0.1L);
         return x;
     }
 
@@ -953,4 +998,16 @@ private:
     }}
 }
 
+} // FloatingPointControlSupport
+
+version (StdUnittest)
+{
+    // These helpers are intended to avoid constant propagation by the optimizer.
+    pragma(inline, false) private @safe
+    {
+        T forceAddOp(T)(T x, T y) { return x + y; }
+        T forceSubOp(T)(T x, T y) { return x - y; }
+        T forceMulOp(T)(T x, T y) { return x * y; }
+        T forceDivOp(T)(T x, T y) { return x / y; }
+    }
 }


### PR DESCRIPTION
1. The `pragma(inline, false)` doesn't do what the author thinks it does (Issue 23520).
2. Change that introduced `blockopt` seems to have a slight misunderstanding about what constant propagation is (`a /= 0.0L` can always be constant propagated regardless of what surrounds it).
3. Undocument tests that depend on the need for forcing operations to disarm the optimizer, and replace with simple tests behind `StdDdoc`.
