### PR TITLE
disable function attributes dscanner check

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -46,7 +46,7 @@ logical_precedence_check="enabled"
 ; Checks for undocumented public declarations
 undocumented_declaration_check="enabled"
 ; Checks for poor placement of function attributes
-function_attribute_check="enabled"
+function_attribute_check="disabled"
 ; Checks for use of the comma operator
 comma_expression_check="enabled"
 ; Checks for local imports that are too broad


### PR DESCRIPTION
I think this check should be disabled for now, because it does not work as expected. A very brief example:
```
bool foo() @property { return true; } // [warn]: Zero-parameter '@property' function should be marked 'const', 'inout', or 'immutable'.
@property bool foo() { return true; } // Should throw a warning but doesn't
```
I fixed that issue in my fork of `D-Scanner`, but I can't really move forward until this check is disabled, because one of `D-Scanner`'s tests is to apply it to `phobos` and have 0 warnings, but I'm getting a lot of warnings from constructions like the second expression mentioned in the example. After I will be done with my project I will probably take the time and fix the warnings `D-Scanner` throws when applied to `phobos`, but this is a significant effort, and for now it would be really helpful to disable this check in order to be able to move forward with my project(https://github.com/Dlang-UPB/D-scanner)