### PR TITLE
std.random: Fix unittests on x32 ABI targets

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -2516,7 +2516,7 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
     assert(rnd.uniform!ulong == 4838462006927449017);
 
     enum Fruit { apple, mango, pear }
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(rnd.uniform!Fruit == Fruit.mango);
 }
 
@@ -2798,7 +2798,7 @@ auto ref choice(Range)(ref Range range)
     auto rnd = MinstdRand0(42);
 
     auto elem  = [1, 2, 3, 4, 5].choice(rnd);
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(elem == 3);
 }
 
@@ -2913,7 +2913,7 @@ if (isRandomAccessRange!Range)
     auto rnd = MinstdRand0(42);
 
     auto arr = [1, 2, 3, 4, 5].randomShuffle(rnd);
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(arr == [3, 5, 2, 4, 1]);
 }
 
@@ -3003,15 +3003,15 @@ if (isRandomAccessRange!Range)
     auto arr = [1, 2, 3, 4, 5, 6];
     arr = arr.dup.partialShuffle(1, rnd);
 
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(arr == [2, 1, 3, 4, 5, 6]); // 1<->2
 
     arr = arr.dup.partialShuffle(2, rnd);
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(arr == [1, 4, 3, 2, 5, 6]); // 1<->2, 2<->4
 
     arr = arr.dup.partialShuffle(3, rnd);
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(arr == [5, 4, 6, 2, 1, 3]); // 1<->5, 2<->4, 3<->6
 }
 
@@ -3428,7 +3428,7 @@ if (isRandomAccessRange!Range)
     import std.range : iota;
     auto rnd = MinstdRand0(42);
 
-    version (X86_64) // https://issues.dlang.org/show_bug.cgi?id=15147
+    version (D_LP64) // https://issues.dlang.org/show_bug.cgi?id=15147
     assert(10.iota.randomCover(rnd).equal([7, 4, 2, 0, 1, 6, 8, 3, 9, 5]));
 }
 


### PR DESCRIPTION
According to issue 15147, uniform() will return a different values on 64-bit vs. 32-bit pointer targets when passed a size_t.

The x32 ABI is a 32-bit pointer target on x86_64, so all these tests currently fail.  Change the condition to only run the test on 64-bit _pointer_ targets.