### PR TITLE
merge stable

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1508,7 +1508,7 @@ public:
 
         if (this.size == 0)
         {
-            return rangeLen;
+            return max(rangeLen, 1);
         }
 
         immutable size_t eightSize = 4 * (this.size + 1);
@@ -3642,6 +3642,15 @@ ParallelForeach!R parallel(R)(R range, size_t workUnitSize)
     auto arrIndex = new int[10];
     parallel(arrIndex).each!((i, ref e) => e += i);
     assert(arrIndex.sum == 10.iota.sum);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=22745
+@system unittest
+{
+    auto pool = new TaskPool(0);
+    int[] empty;
+    foreach (i; pool.parallel(empty)) {}
+    pool.finish();
 }
 
 // Thrown when a parallel foreach loop is broken from.


### PR DESCRIPTION
- Re-instate accidentally reverted fixes on RefCounted (#8599)
- Remove usages of 'in' on Windows C bindings
- Fix Issue 22745 - std.parallelism.parallel fails to process empty range on a single CPU
