### PR TITLE
Fix issue 23540 - std.uni loadProperty aliases for C are incorrect

### DIFF
--- a/changelog/unicode_properties_c.dd
+++ b/changelog/unicode_properties_c.dd
@@ -1,0 +1,24 @@
+The Unicode property "C" aka "Other" has had the wrong properties associated with it.
+
+If you use `unicode.c` or `unicode.Other` (case insensitive) from `std.uni`, you should mitigate or fix your codebase.
+
+This change makes it match the [Unicode Techical Report #44](https://www.unicode.org/reports/tr44/). Unfortunately if you are already using it with its previous wrong values, this will break your code, below is a function which reflects the original values that you can use to mitigate against any breakage.
+
+---
+@property auto loadPropertyOriginal(string name)() pure
+{
+    import std.uni : unicode;
+
+    static if (name == "C" || name == "c" || name == "other" || name == "Other")
+    {
+        auto target = unicode.Co;
+        target |= unicode.Lo;
+        target |= unicode.No;
+        target |= unicode.So;
+        target |= unicode.Po;
+        return target;
+    }
+    else
+        return unicode.opDispatch!name;
+}
+---

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -6031,11 +6031,11 @@ bool loadProperty(Set=CodepointSet, C)
     }
     else if (ucmp(name, "C") == 0 || ucmp(name, "Other") == 0)
     {
-        target = asSet(uniProps.Co);
-        target |= asSet(uniProps.Lo);
-        target |= asSet(uniProps.No);
-        target |= asSet(uniProps.So);
-        target |= asSet(uniProps.Po);
+        target = asSet(uniProps.Cc);
+        target |= asSet(uniProps.Cf);
+        target |= asSet(uniProps.Cs);
+        target |= asSet(uniProps.Co);
+        target |= asSet(uniProps.Cn);
     }
     else if (ucmp(name, "graphical") == 0)
     {


### PR DESCRIPTION
This is a bit of unfortunate breakage, but it is what it is.

It shouldn't come up again and doesn't need a test as it should never have diverged from the standard like this.

There is a mitigation code in the changelog & I'll do an announcement to give people time to mitigate this and the tables being updated.