### PR TITLE
Document dirEntries throws without read permission

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4931,8 +4931,8 @@ alias DirIterator = _DirIterator!dip1000Enabled;
 
     Throws:
         $(UL
-        $(LI $(LREF FileException) if the *path* directory does not exist or read permission is denied.)
-        $(LI $(LREF FileException) if *mode* is not `shallow` and a subdirectory cannot be read.)
+        $(LI $(LREF FileException) if the $(B path) directory does not exist or read permission is denied.)
+        $(LI $(LREF FileException) if $(B mode) is not `shallow` and a subdirectory cannot be read.)
         )
 
 Example:

--- a/std/file.d
+++ b/std/file.d
@@ -4930,8 +4930,10 @@ alias DirIterator = _DirIterator!dip1000Enabled;
         $(LREF DirEntry).
 
     Throws:
-        * $(LREF FileException) if the *path* directory does not exist or read permission is denied.
-        * $(LREF FileException) if *mode* is not `shallow` and a subdirectory cannot be read.
+        $(UL
+        $(LI $(LREF FileException) if the *path* directory does not exist or read permission is denied.)
+        $(LI $(LREF FileException) if *mode* is not `shallow` and a subdirectory cannot be read.)
+        )
 
 Example:
 --------------------

--- a/std/file.d
+++ b/std/file.d
@@ -4930,7 +4930,8 @@ alias DirIterator = _DirIterator!dip1000Enabled;
         $(LREF DirEntry).
 
     Throws:
-        $(LREF FileException) if the directory does not exist.
+        * $(LREF FileException) if the *path* directory does not exist or read permission is denied.
+        * $(LREF FileException) if *mode* is not `shallow` and a subdirectory cannot be read.
 
 Example:
 --------------------
@@ -4971,6 +4972,26 @@ auto dFiles = dirEntries("","*.{d,di}",SpanMode.depth);
 foreach (d; dFiles)
     writeln(d.name);
 --------------------
+To handle subdirectories with denied read permission, use `SpanMode.shallow`:
+$(RUNNABLE_EXAMPLE
+---
+void scan(string path)
+{
+    foreach (DirEntry entry; dirEntries(path, SpanMode.shallow))
+    {
+        try
+        {
+            writeln(entry.name);
+            if (entry.isDir)
+                scan(entry.name);
+        }
+        catch (FileException fe) { continue; } // ignore
+    }
+}
+
+scan("");
+---
+)
  +/
 
 // For some reason, doing the same alias-to-a-template trick as with DirIterator

--- a/std/file.d
+++ b/std/file.d
@@ -4975,7 +4975,6 @@ foreach (d; dFiles)
     writeln(d.name);
 --------------------
 To handle subdirectories with denied read permission, use `SpanMode.shallow`:
-$(RUNNABLE_EXAMPLE
 ---
 void scan(string path)
 {
@@ -4993,8 +4992,7 @@ void scan(string path)
 
 scan("");
 ---
-)
- +/
++/
 
 // For some reason, doing the same alias-to-a-template trick as with DirIterator
 // does not work here.


### PR DESCRIPTION
Part of Issue 12391.

Add example showing how to handle subdirectory read permission failures.