### PR TITLE
ci: Update cirrus macOS image to macos-monterey-xcode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,9 +40,9 @@ linux_task:
 
 # Mac
 macos_task:
-  name: macOS 11.x x64
-  osx_instance:
-    image: big-sur-xcode
+  name: macOS 12.x x64 (M1)
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
   timeout_in: 60m
   environment:
     OS_NAME: darwin


### PR DESCRIPTION
We seem to have missed the memo saying that the Intel-based runners will be removed from 1st Jan 2023, no idea if we are even ready to run on M1 hosts?

https://cirrus-ci.org/blog/2022/11/08/sunsetting-intel-macos-instances/