### PR TITLE
Fix issue 23640: Use `Nullable[]` to allow iterating `Nullable` of immutable type.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3160,12 +3160,6 @@ struct Nullable(T)
     }
 
     /// ditto
-    inout(typeof(this)) opIndex() inout
-    {
-        return this;
-    }
-
-    /// ditto
     inout(typeof(this)) opIndex(size_t[2] dim) inout
     in (dim[0] <= length && dim[1] <= length && dim[1] >= dim[0])
     {
@@ -3191,6 +3185,74 @@ struct Nullable(T)
     in (index < length)
     {
         return get();
+    }
+
+    /**
+     * Converts `Nullable` to a range. Works even when the contained type is `immutable`.
+     */
+    auto opSlice(this This)()
+    {
+        static struct NullableRange
+        {
+            private This value;
+
+            // starts out true if value is null
+            private bool empty_;
+
+            @property bool empty() const @safe pure nothrow
+            {
+                return empty_;
+            }
+
+            void popFront() @safe pure nothrow
+            {
+                empty_ = true;
+            }
+
+            alias popBack = popFront;
+
+            @property ref inout(typeof(value.get())) front() inout @safe pure nothrow
+            {
+                return value.get();
+            }
+
+            alias back = front;
+
+            @property inout(typeof(this)) save() inout
+            {
+                return this;
+            }
+
+            size_t[2] opSlice(size_t dim : 0)(size_t from, size_t to) const
+            {
+                return [from, to];
+            }
+
+            @property size_t length() const @safe pure nothrow
+            {
+                return !empty;
+            }
+
+            alias opDollar(size_t dim : 0) = length;
+
+            ref inout(typeof(value.get())) opIndex(size_t index) inout @safe pure nothrow
+            in (index < length)
+            {
+                return value.get();
+            }
+
+            inout(typeof(this)) opIndex(size_t[2] dim) inout
+            in (dim[0] <= length && dim[1] <= length && dim[1] >= dim[0])
+            {
+                return (dim[0] == 0 && dim[1] == 1) ? this : this.init;
+            }
+
+            auto opIndex() inout
+            {
+                return this;
+            }
+        }
+        return NullableRange(this, isNull);
     }
 }
 
@@ -3772,6 +3834,34 @@ auto nullable(T)(T t)
     assert(hasAssignableElements!(Nullable!int));
     assert(hasSwappableElements!(Nullable!int));
     assert(hasLvalueElements!(Nullable!int));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23640
+@safe pure nothrow unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.range : only;
+    import std.range.primitives : hasLength, hasSlicing,
+        isRandomAccessRange;
+    static immutable struct S { int[] array; }
+    auto value = S([42]);
+    alias ImmutableNullable = immutable Nullable!S;
+    auto a = ImmutableNullable(value)[];
+    alias Range = typeof(a);
+    assert(isRandomAccessRange!Range);
+    assert(hasLength!Range);
+    assert(hasSlicing!Range);
+    assert(!a.empty);
+    assert(a.front == value);
+    assert(a.back == value);
+    assert(a[0] == value);
+    assert(a.equal(only(value)));
+    assert(a[0 .. $].equal(only(value)));
+    Range b = a.save();
+    assert(!b.empty);
+    b.popFront();
+    assert(!a.empty);
+    assert(b.empty);
 }
 
 /**


### PR DESCRIPTION
~~Technically a breaking change: `nullable[]` no longer allows ref access. But that functionality was always weird.~~

~~Code sample broken by this PR: `Nullable!int n = Nullable!int(3); n[][0] = 5;` Who does that?~~

edit: Hang on, that never worked. All good!

The `opIndexImpl` hack is because `inout` doesn't work for a field of a struct (`NullableRange.value`), and `empty_` must remain mutable (that's the whole point) so we can't return `inout(NullableRange)`, but `opIndex` can't be a template (`(this This)`) because then DMD doesn't notice it as the right overload for `nullable[]`.

edit: Changing the overload from `opIndex` to `opSlice` removes the need for the const overload hack.