### PR TITLE
std.socket: replace static this with crt_constructor

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -285,7 +285,7 @@ private immutable
     typeof(&freeaddrinfo) freeaddrinfoPointer;
 }
 
-shared static this() @system
+pragma(crt_constructor) @system void socket_initialization()
 {
     version (Windows)
     {


### PR DESCRIPTION
This is the only `static this` left in Phobos. Removing it makes for reducing need for ModuleInfo.