### PR TITLE
Fix Issue 20397

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -103,6 +103,7 @@ $(TR
         $(SUBREF sorting, multiSort)
         $(SUBREF sorting, nextEvenPermutation)
         $(SUBREF sorting, nextPermutation)
+        $(SUBREF sorting, nthPermutation)
         $(SUBREF sorting, partialSort)
         $(SUBREF sorting, partition)
         $(SUBREF sorting, partition3)


### PR DESCRIPTION
Fixed Issue 20397 - missing nthPermutation link in std.algorithm documentation page