### PR TITLE
Feature: Add std.typecons.ManagedLifetime.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2711,29 +2711,23 @@ Convenience function for creating a `Rebindable` using automatic type
 inference.
 
 Params:
-    obj = A reference to an object, interface, associative array, or an array slice.
-    s = Struct instance.
+    value = Value to be stored in the `Rebindable`.
 
 Returns:
     A newly constructed `Rebindable` initialized with the given data.
 */
-Rebindable!T rebindable(T)(T obj)
-if (is(T == class) || is(T == interface) || isDynamicArray!T || isAssociativeArray!T)
+Rebindable!T rebindable(T)(T value)
 {
-    typeof(return) ret;
-    ret = obj;
-    return ret;
-}
-
-/// ditto
-Rebindable!S rebindable(S)(S s)
-if (is(S == struct) && !isInstanceOf!(Rebindable, S))
-{
-    // workaround for rebindableS = rebindable(s)
-    static if (isMutable!S)
-        return s;
+    static if (is(T == class) || is(T == interface) || isDynamicArray!T || isAssociativeArray!T)
+    {
+        Rebindable!T ret;
+        ret = value;
+        return ret;
+    }
     else
-        return Rebindable!S(s);
+    {
+        return Rebindable!T(value);
+    }
 }
 
 ///
@@ -2756,22 +2750,6 @@ if (is(S == struct) && !isInstanceOf!(Rebindable, S))
 
     const c3 = c2.get;
     assert(c3.payload == 2);
-}
-
-/**
-This function simply returns the `Rebindable` object passed in.  It's useful
-in generic programming cases when a given object may be either a regular
-`class` or a `Rebindable`.
-
-Params:
-    obj = An instance of Rebindable!T.
-
-Returns:
-    `obj` without any modification.
-*/
-Rebindable!T rebindable(T)(Rebindable!T obj)
-{
-    return obj;
 }
 
 // TODO: remove me once the rebindable overloads have been joined

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2712,21 +2712,20 @@ if (is(S == struct))
         }
 
         // must not escape when S is immutable
-        private
-        ref trustedPayload() @trusted
+        private ref trustedPayload() @trusted
         {
-            return *cast(S*)mutPayload.ptr;
+            return *cast(S*) mutPayload.ptr;
         }
 
         static if (!is(S == immutable))
-        ref S Rebindable_getRef() @property
+        private ref S Rebindable_getRef() @property
         {
             // payload exposed as const ref when S is const
             return trustedPayload;
         }
 
         static if (is(S == immutable))
-        S Rebindable_get() @property
+        private S Rebindable_get() @property
         {
             // we return a copy for immutable S
             return trustedPayload;
@@ -2737,11 +2736,10 @@ if (is(S == struct))
         else
             alias Rebindable_getRef this;
 
-        private
-        auto movePayload() @trusted
+        private auto movePayload() @trusted
         {
             import std.algorithm : move;
-            return cast(S)move(*cast(Unqual!S*)mutPayload.ptr);
+            return cast(S) move(*cast(Unqual!S*) mutPayload.ptr);
         }
 
         ~this()

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2673,9 +2673,9 @@ public:
 }
 
 /**
- * Permits explicit control of the lifetime of a contained `S`.
+ * Permits explicit control of the lifetime of a contained `T`.
  *
- * This works regardless of the constness of `S`.
+ * This works regardless of the constness of `T`.
  *
  * The container starts out in an empty state. It may only be assigned to when empty,
  * and only once; it must be cleared before the next assignment.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2799,6 +2799,7 @@ Returns:
     A newly constructed `Rebindable` initialized with the given data.
 */
 Rebindable!T rebindable(T)(T value)
+if (!is(T == Rebindable!U, U))
 {
     static if (is(T == class) || is(T == interface) || isDynamicArray!T || isAssociativeArray!T)
     {
@@ -2832,6 +2833,20 @@ Rebindable!T rebindable(T)(T value)
 
     const c3 = c2.get;
     assert(c3.payload == 2);
+}
+
+/**
+This function simply returns the `Rebindable` object passed in.  It's useful
+in generic programming cases when a given object may be either a regular
+`class` or a `Rebindable`.
+Params:
+    obj = An instance of Rebindable!T.
+Returns:
+    `obj` without any modification.
+*/
+Rebindable!T rebindable(T)(Rebindable!T obj)
+{
+    return obj;
 }
 
 // TODO: remove me once the rebindable overloads have been joined

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2718,14 +2718,14 @@ if (is(S == struct))
         }
 
         static if (!is(S == immutable))
-        private ref S Rebindable_getRef() @property
+        ref S Rebindable_getRef() @property
         {
             // payload exposed as const ref when S is const
             return trustedPayload;
         }
 
         static if (is(S == immutable))
-        private S Rebindable_get() @property
+        S Rebindable_get() @property
         {
             // we return a copy for immutable S
             return trustedPayload;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2671,7 +2671,7 @@ if (is(S == struct))
         // mutPayload's pointers must be treated as tail const
         void[S.sizeof] mutPayload;
 
-        void emplace(ref S s)
+        void emplacePayload(ref S s)
         {
             import std.conv : emplace;
             static if (__traits(compiles, () @safe {S tmp = s;}))
@@ -2683,27 +2683,27 @@ if (is(S == struct))
     public:
         this()(auto ref S s)
         {
-            emplace(s);
+            emplacePayload(s);
         }
 
         // immutable S cannot be passed to auto ref S above
         static if (!is(S == immutable))
         this()(immutable S s)
         {
-            emplace(s);
+            emplacePayload(s);
         }
 
         void opAssign()(auto ref S s)
         {
             movePayload;
-            emplace(s);
+            emplacePayload(s);
         }
 
         static if (!is(S == immutable))
         void opAssign()(immutable S s)
         {
             movePayload;
-            emplace(s);
+            emplacePayload(s);
         }
 
         void opAssign(Rebindable other)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2490,38 +2490,38 @@ public:
         @disable this();
     }
 
-    this(S s)
+    this(S s) @trusted
     {
         payload.set(s);
     }
 
-    void opAssign(this This)(S s)
+    void opAssign(this This)(S s) @trusted
     {
         payload.clear;
         payload.set(s);
     }
 
-    void opAssign(this This)(Rebindable other)
+    void opAssign(this This)(Rebindable other) @trusted
     {
         payload.clear;
         payload.set(other.payload.get);
     }
 
-    S get(this This)() @property
+    S get(this This)() @property @trusted
     {
         return payload.get;
     }
 
     alias get this;
 
-    ~this()
+    ~this() @trusted
     {
         payload.clear;
     }
 }
 
 ///
-@safe unittest
+@system unittest
 {
     static struct S
     {
@@ -2702,7 +2702,7 @@ public:
      * Set the container to a value.
      * The container must be empty.
      */
-    void set(this This)(T value) @trusted
+    void set(this This)(T value)
     {
         // as `mutPayload` won't call the destructor, we deliberately leak a copy here:
         static union DontCallDestructor
@@ -2717,7 +2717,7 @@ public:
      * Destroy the value saved in the container.
      * The container must be set to a value.
      */
-    void clear(this This)() @trusted
+    void clear(this This)()
     {
         import std.typecons : No;
 
@@ -2752,14 +2752,14 @@ public:
      * Return a copy of the stored value.
      * The container must be set to a value.
      */
-    T get(this This)() @property @trusted
+    T get(this This)() @property
     {
         return *cast(T*) &mutPayload;
     }
 }
 
 ///
-@safe unittest
+@system unittest
 {
     int del;
     int post;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2781,6 +2781,36 @@ if (is(S == struct))
     assert(rs.ptr is null);
 }
 
+/// Using Rebindable in a generic algorithm:
+@safe unittest
+{
+    import std.range.primitives : front, popFront;
+
+    // simple version of std.algorithm.searching.maxElement
+    typeof(R.init.front) maxElement(R)(R r)
+    {
+        auto max = rebindable(r.front);
+        r.popFront;
+        foreach (e; r)
+            if (e > max)
+                max = e; // Rebindable allows const-correct reassignment
+        return max;
+    }
+    struct S
+    {
+        char[] arr;
+        alias arr this; // for comparison
+    }
+    // can't convert to mutable
+    const S cs;
+    static assert(!__traits(compiles, { S s = cs; }));
+
+    alias CS = const S;
+    CS[] arr = [CS("harp"), CS("apple"), CS("pot")];
+    CS ms = maxElement(arr);
+    assert(ms.arr == "pot");
+}
+
 // Test Rebindable!immutable
 @safe unittest
 {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2332,7 +2332,7 @@ break the soundness of D's type system and does not incur any of the
 risks usually associated with `cast`.
 
 Params:
-    T = An object, interface, array slice type, or associative array type.
+    T = Any type.
  */
 template Rebindable(T)
 if (is(T == class) || is(T == interface) || isDynamicArray!T || isAssociativeArray!T)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2739,6 +2739,16 @@ public:
     }
 
     /**
+     * Set the container to a value if there is already a value in it.
+     * Convenience shortcut for `clear; set(value);`
+     */
+    void replace(this This)(T value)
+    {
+        clear;
+        set(value);
+    }
+
+    /**
      * Return a copy of the stored value.
      * The container must be set to a value.
      */

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2652,10 +2652,13 @@ Rebindable!T rebindable(T)(Rebindable!T obj)
 
 /** Models safe reassignment of otherwise constant struct instances.
  *
- * A struct with a field of reference type cannot be assigned to a constant
- * struct of the same type. `Rebindable!(const S)` allows assignment to
- * a `const S` while enforcing only constant access to its fields.
+ * A constant struct with a field of reference type cannot be assigned to a mutable
+ * struct of the same type. This protects the constant reference field from being
+ * mutably aliased, potentially allowing mutation of `immutable` data. However, the
+ * assignment could be safe if all reference fields are only exposed as `const`.
  *
+ * `Rebindable!(const S)` accepts assignment from
+ * a `const S` while enforcing only constant access to its fields.
  * `Rebindable!(immutable S)` does the same but field access may create a
  * temporary copy of `S` in order to enforce _true immutability.
  */


### PR DESCRIPTION
Add `std.typecons.ManagedLifetime(T)`.

Use it to implement `Rebindable` for structs.

# Previous description

This is a rewrite, heavily based on https://github.com/FeepingCreature/rebindable/ , of #6136 which is itself a revival of #4363.

For rationale, see my 2022 DConf talk https://www.youtube.com/watch?v=eGX_fxlig8I

I'm not sure how much hope this has, but I figured I'd put it out there.

The major new piece in this version is the addition of `MutableImitation`, being a slight rewrite/cleanup copypaste of my `DeepUnqual`. The primary motivation for this over the prior `void[sizeof]`, aside from being more GC-friendly, is that `MutableImitation` casts can (sometimes) be evaluated during CTFE, which is necessary for, for instance, passing types to `format`.

I also entirely ditched the complexities with `ref` arguments, on the basis that good god I could not care any less about struct copies if I tried. If you're running inner std.algorithm loops with data types with nontrivial copy constructor semantics, your usecases and mine do not overlap in any way.

Besides, it can always be added later.