### PR TITLE
Slim down the range constraints a bit

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -171,9 +171,9 @@ Returns:
  */
 enum bool isInputRange(R) =
     is(typeof(R.init) == R)
-    && is(ReturnType!((R r) => r.empty) == bool)
+    && is(typeof((R r) { return r.empty; } (R.init)) == bool)
     && (is(typeof((return ref R r) => r.front)) || is(typeof(ref (return ref R r) => r.front)))
-    && !is(ReturnType!((R r) => r.front) == void)
+    && !is(typeof((R r) { return r.front; } (R.init)) == void)
     && is(typeof((R r) => r.popFront));
 
 ///
@@ -998,7 +998,7 @@ See_Also:
     The header of $(MREF std,range) for tutorials on ranges.
  */
 enum bool isForwardRange(R) = isInputRange!R
-    && is(ReturnType!((R r) => r.save) == R);
+    && is(typeof((R r) { return r.save; } (R.init)) == R);
 
 ///
 @safe unittest
@@ -1041,7 +1041,7 @@ See_Also:
  */
 enum bool isBidirectionalRange(R) = isForwardRange!R
     && is(typeof((R r) => r.popBack))
-    && is(ReturnType!((R r) => r.back) == ElementType!R);
+    && is(typeof((R r) { return r.back; } (R.init)) == ElementType!R);
 
 ///
 @safe unittest
@@ -1688,7 +1688,7 @@ The following expression must be true for `hasSlicing` to be `true`:
  */
 enum bool hasSlicing(R) = isForwardRange!R
     && !(isAutodecodableString!R && !isAggregateType!R)
-    && is(ReturnType!((R r) => r[1 .. 1].length) == size_t)
+    && is(typeof((R r) { return r[1 .. 1].length; } (R.init)) == size_t)
     && (is(typeof(lvalueOf!R[1 .. 1]) == R) || isInfinite!R)
     && (!is(typeof(lvalueOf!R[0 .. $])) || is(typeof(lvalueOf!R[0 .. $]) == R))
     && (!is(typeof(lvalueOf!R[0 .. $])) || isInfinite!R


### PR DESCRIPTION
ReturnType is quite a big template for what it is accomplishing here. In my tests (see my post here: https://www.schveiguy.com/blog/2023/01/the-cost-of-compile-time-in-d/), I measured about 56k RAM savings, and if enough ranges are used, about 64microseconds per instantiation.

Note that there is no worry about losing the benefit of caching here -- isInputRange!T is calculated once per T, so the instantiation of ReturnType for the internal lambda will never be used again.

Not sure if there is a way to measure this using CI. But the code itself isn't really that much more complex.