### PR TITLE
Fix Issue 23706 - Do not escape POSIX shell parameters unless necessary

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -3675,6 +3675,16 @@ string escapeShellCommand(scope const(char[])[] args...) @safe pure
             windows : `"foo bar" ^"'\^"^^\\^"`,
             posix   : `'foo bar' ''\''"^\'`
         },
+        {
+            args    : ["foo bar", ""],
+            windows : `"foo bar" ^"^"`,
+            posix   : `'foo bar' ''`
+        },
+        {
+            args    : ["foo bar", "2"],
+            windows : `"foo bar" ^"2^"`,
+            posix   : `'foo bar' '2'`
+        },
     ];
 
     foreach (test; tests)

--- a/std/process.d
+++ b/std/process.d
@@ -3678,10 +3678,14 @@ string escapeShellCommand(scope const(char[])[] args...) @safe pure
     ];
 
     foreach (test; tests)
+    {
+        auto actual = escapeShellCommand(test.args);
         version (Windows)
-            assert(escapeShellCommand(test.args) == test.windows);
+            string expected = test.windows;
         else
-            assert(escapeShellCommand(test.args) == test.posix  );
+            string expected = test.posix;
+        assert(actual == expected, "\nExpected: " ~ expected ~ "\nGot: " ~ actual);
+    }
 }
 
 private string escapeShellCommandString(return scope string command) @safe pure

--- a/std/process.d
+++ b/std/process.d
@@ -3999,6 +3999,11 @@ version (unittest_burnin)
     // Then, test this module with:
     // rdmd --main -unittest -version=unittest_burnin process.d
 
+    import std.file : readText, remove;
+    import std.format : format;
+    import std.path : absolutePath;
+    import std.random : uniform;
+
     auto helper = absolutePath("std_process_unittest_helper");
     assert(executeShell(helper ~ " hello").output.split("\0")[1..$] == ["hello"], "Helper malfunction");
 

--- a/std/process.d
+++ b/std/process.d
@@ -2505,7 +2505,7 @@ version (Windows)
     import std.exception : collectException;
     import std.typecons : tuple;
 
-    TestScript prog = ":Loop\ngoto Loop;";
+    TestScript prog = ":Loop\r\n" ~ "goto Loop";
     auto pid = spawnProcess(prog.path);
 
     // Doesn't block longer than one second


### PR DESCRIPTION
POSIX follow-up to Issue 13447 / 09a0b876c87cec6bb7af62b55179aff745b203dc.