### PR TITLE
Fix recent isPointer changes to use is(T == U*, U) instead of is(T : U*, U)

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -170,7 +170,7 @@ if (isIterable!Range && !isAutodecodableString!Range && !isInfinite!Range)
 
 /// ditto
 ForeachType!(typeof((*Range).init))[] array(Range)(Range r)
-if (is(Range : U*, U) && isIterable!U && !isAutodecodableString!Range && !isInfinite!Range)
+if (is(Range == U*, U) && isIterable!U && !isAutodecodableString!Range && !isInfinite!Range)
 {
     return array(*r);
 }

--- a/std/exception.d
+++ b/std/exception.d
@@ -1069,9 +1069,9 @@ as the language is free to assume objects don't have internal pointers
 */
 bool doesPointTo(S, T, Tdummy=void)(auto ref const S source, ref const T target) @nogc @trusted pure nothrow
 if (__traits(isRef, source) || isDynamicArray!S ||
-    is(S : U*, U) || is(S == class))
+    is(S == U*, U) || is(S == class))
 {
-    static if (is(S : U*, U) || is(S == class) || is(S == interface))
+    static if (is(S == U*, U) || is(S == class) || is(S == interface))
     {
         const m = *cast(void**) &source;
         const b = cast(void*) &target;
@@ -1115,9 +1115,9 @@ bool doesPointTo(S, T)(auto ref const shared S source, ref const shared T target
 /// ditto
 bool mayPointTo(S, T, Tdummy=void)(auto ref const S source, ref const T target) @trusted pure nothrow
 if (__traits(isRef, source) || isDynamicArray!S ||
-    is(S : U*, U) || is(S == class))
+    is(S == U*, U) || is(S == class))
 {
-    static if (is(S : U*, U) || is(S == class) || is(S == interface))
+    static if (is(S == U*, U) || is(S == class) || is(S == interface))
     {
         const m = *cast(void**) &source;
         const b = cast(void*) &target;
@@ -1532,21 +1532,6 @@ version (StdUnittest)
     assert( doesPointTo(s, j));
     assert( doesPointTo(cast(int*) s, i));
     assert(!doesPointTo(cast(int*) s, j));
-}
-@safe unittest //more alias this opCast
-{
-    void* p;
-    struct A
-    {
-        void* opCast(T)() if (is(T == void*))
-        {
-            return p;
-        }
-        alias foo = opCast!(void*);
-        alias foo this;
-    }
-    assert(!doesPointTo(A.init, p));
-    assert(!mayPointTo(A.init, p));
 }
 
 /+

--- a/std/getopt.d
+++ b/std/getopt.d
@@ -558,7 +558,7 @@ private template optionValidator(A...)
     import std.format : format;
 
     enum fmt = "getopt validator: %s (at position %d)";
-    enum isReceiver(T) = is(T : U*, U) || (is(T == function)) || (is(T == delegate));
+    enum isReceiver(T) = is(T == U*, U) || (is(T == function)) || (is(T == delegate));
     enum isOptionStr(T) = isSomeString!T || isSomeChar!T;
 
     auto validator()

--- a/std/traits.d
+++ b/std/traits.d
@@ -889,7 +889,7 @@ private template fqnType(T,
             );
         }
     }
-    else static if (is(T : U*, U))
+    else static if (is(T == U*, U))
     {
         enum fqnType = chain!(
             fqnType!(U, qualifiers) ~ "*"
@@ -3925,7 +3925,7 @@ template hasStaticMember(T, string member)
 {
     static if (__traits(hasMember, T, member))
     {
-        static if (is(T : V*, V))
+        static if (is(T == V*, V))
             alias U = V;
         else
             alias U = T;

--- a/std/utf.d
+++ b/std/utf.d
@@ -3136,7 +3136,7 @@ private T toUTFImpl(T, S)(scope S s)
     collection cycle and cause a nasty bug when the C code tries to use it.
   +/
 template toUTFz(P)
-if (is(P : C*, C) && isSomeChar!C)
+if (is(P == C*, C) && isSomeChar!C)
 {
     P toUTFz(S)(S str) @safe pure
     if (isSomeString!S)


### PR DESCRIPTION
The behaviors are different and the changes appears accidental rather than deliberate. In at least one case the change would result in wrong behavior: https://github.com/dlang/phobos/pull/8635#issuecomment-1433898162

Affected PRs: #8635, #8636, #8637, #8638, #8639