### PR TITLE
Memory leak on std.process

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1038,7 +1038,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                 // signal safe functions list, but practically this should
                 // not be a problem. Java VM and CPython also use malloc()
                 // in its own implementation via opendir().
-                import core.stdc.stdlib : malloc;
+                import core.stdc.stdlib : malloc, free;
                 import core.sys.posix.poll : pollfd, poll, POLLNVAL;
                 import core.sys.posix.sys.resource : rlimit, getrlimit, RLIMIT_NOFILE;
 
@@ -1055,6 +1055,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
 
                 // Call poll() to see which ones are actually open:
                 auto pfds = cast(pollfd*) malloc(pollfd.sizeof * maxToClose);
+                scope(exit) free(pfds);
                 if (pfds is null)
                 {
                     abortOnError(forkPipeOut, InternalError.malloc, .errno);


### PR DESCRIPTION
In the forked process, the array "pfds" is allocated and never free'd. That's a problem if you're going to spawn and keep running a lot of processes, since it's a quite big array.