### PR TITLE
Revert "Memory leak on std.process"

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1038,7 +1038,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                 // signal safe functions list, but practically this should
                 // not be a problem. Java VM and CPython also use malloc()
                 // in its own implementation via opendir().
-                import core.stdc.stdlib : malloc, free;
+                import core.stdc.stdlib : malloc;
                 import core.sys.posix.poll : pollfd, poll, POLLNVAL;
                 import core.sys.posix.sys.resource : rlimit, getrlimit, RLIMIT_NOFILE;
 
@@ -1055,7 +1055,6 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
 
                 // Call poll() to see which ones are actually open:
                 auto pfds = cast(pollfd*) malloc(pollfd.sizeof * maxToClose);
-                scope(exit) free(pfds);
                 if (pfds is null)
                 {
                     abortOnError(forkPipeOut, InternalError.malloc, .errno);


### PR DESCRIPTION
Reverts dlang/phobos#8695

A forked process does not affect the original process's memory usage. And the process image is either going to be replaced with a new one via exec, or exec is going to fail and the process is going to exit.

There is no need to clean up the fds, it's just wasting cycles.