### PR TITLE
Improve std.regex build times by removing a formattedWrite call

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1010,12 +1010,14 @@ if (isForwardRange!R && is(ElementType!R : dchar))
     //
     @trusted void error(string msg)
     {
-        import std.array : appender;
-        import std.format.write : formattedWrite;
-        auto app = appender!string();
-        formattedWrite(app, "%s\nPattern with error: `%s` <--HERE-- `%s`",
-                       msg, origin[0..$-pat.length], pat);
-        throw new RegexException(app.data);
+        import std.conv : text;
+        string app = msg;
+        app ~= "\nPattern with error: `";
+        app ~= origin[0..$-pat.length].text;
+        app ~= "` <--HERE-- `";
+        app ~= pat.text;
+        app ~= "`";
+        throw new RegexException(app);
     }
 
     alias Char = BasicElementOf!R;


### PR DESCRIPTION
I don't know how much we can actually do to speed it up, but this is at least still a win at about ~100ms. That shouldn't change anything other than build times.

Tracking issue (does not close): https://issues.dlang.org/show_bug.cgi?id=23737