### PR TITLE
Improve std.regex wordMatcher build times by delaying its work from CT to RT if possible

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -49,10 +49,29 @@ CharMatcher[CodepointSet] matcherCache;
     }
 }
 
-@property ref wordMatcher()()
+// Force pure because that is needed
+// Templated so that we don't pull in std.uni wordCharacter unnecessarily.
+@property ref wordMatcher()() pure
 {
-    static immutable CharMatcher matcher = CharMatcher(wordCharacter);
-    return matcher;
+    static auto actual()
+    {
+        static CharMatcher matcher;
+        static bool haveMatcher;
+
+        if (!haveMatcher)
+        {
+            matcher = CharMatcher(wordCharacter);
+            haveMatcher = true;
+        }
+
+        return &matcher;
+    }
+
+    // WORKAROUND: if the compiler won't memoize the output of the function for us,
+    //  we'll do it with pure and there will be casts and it'll be happy about it.
+    // This is unfortunately needed to make std.regex as a whole faster to import & use
+    //  in build times ~500ms.
+    return *(cast(immutable(CharMatcher)* function() @safe nothrow @nogc pure)&actual)();
 }
 
 // some special Unicode white space characters


### PR DESCRIPTION
This will improve std.regex build times by about ~500ms if used. It delays initialization of the wordMatcher tables till runtime if possible. This should mean it won't work at CTFE, but we'll see if we need to fix that later (it can be cached where it's used and computed each time).

Tracking issue (does not close): https://issues.dlang.org/show_bug.cgi?id=23737