### PR TITLE
[std.traits] Add 'See also: __traits'

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2568,6 +2568,7 @@ if (is(T == class))
 /**
 Determines whether `T` has its own context pointer.
 `T` must be either `class`, `struct`, or `union`.
+See also: `__traits(isNested, T)`
 */
 template isNested(T)
 if (is(T == class) || is(T == struct) || is(T == union))
@@ -3853,7 +3854,8 @@ package alias Identity(alias A) = A;
 /**
    Yields `true` if and only if `T` is an aggregate that defines
    a symbol called `name`.
-   $(NOTE Use `__traits(hasMember, T, name)` instead in new code.)
+
+   See also: `__traits(hasMember, T, name)`
  */
 enum hasMember(T, string name) = __traits(hasMember, T, name);
 
@@ -4836,7 +4838,7 @@ package enum maxAlignment(U...) =
 
 /**
 Returns class instance alignment.
-$(NOTE Use `__traits(classInstanceAlignment, T)` instead in new code.)
+See also: `__traits(classInstanceAlignment, T)`
  */
 template classInstanceAlignment(T)
 if (is(T == class))
@@ -6257,7 +6259,8 @@ template isIntegral(T)
 
 /**
  * Detect whether `T` is a built-in floating point type.
- * $(NOTE Use `__traits(isFloating, T)` instead in new code.)
+ *
+ * See also: `__traits(isFloating, T)`
  */
 // is(T : real) to discount complex types
 enum bool isFloatingPoint(T) = __traits(isFloating, T) && is(T : real);
@@ -6397,7 +6400,8 @@ template isNumeric(T)
 /**
  * Detect whether `T` is a scalar type (a built-in numeric, character or
  * boolean type).
- * $(NOTE Use `__traits(isScalar, T)` instead in new code.)
+ *
+ * See also: `__traits(isScalar, T)`
  */
 // is(T : real) to discount complex types
 enum bool isScalarType(T) = __traits(isScalar, T) && is(T : real);
@@ -6928,7 +6932,8 @@ template isAutodecodableString(T)
 
 /**
  * Detect whether type `T` is a static array.
- * $(NOTE Use `__traits(isStaticArray, T)` instead in new code.)
+ *
+ * See also: `__traits(isStaticArray, T)`
  */
 enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
@@ -7058,7 +7063,8 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 
 /**
  * Detect whether `T` is an associative array type
- * $(NOTE Use `__traits(isAssociativeArray, T)` instead in new code.)
+ *
+ * See also: `__traits(isAssociativeArray, T)`
  */
 enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 
@@ -7631,7 +7637,7 @@ template isCallable(alias callable)
 /**
 Detect whether `S` is an abstract function.
 
-$(NOTE Use `__traits(isAbstractFunction, S)` instead in new code.)
+See also: `__traits(isAbstractFunction, S)`
 Params:
     S = The symbol to check
 Returns:
@@ -7653,7 +7659,8 @@ enum isAbstractFunction(alias S) = __traits(isAbstractFunction, S);
 
 /**
  * Detect whether `S` is a final function.
- * $(NOTE Use `__traits(isFinalFunction, S)` instead in new code.)
+ *
+ * See also: `__traits(isFinalFunction, S)`
  */
 enum isFinalFunction(alias S) = __traits(isFinalFunction, S);
 
@@ -7722,7 +7729,8 @@ template isNestedFunction(alias f)
 
 /**
  * Detect whether `S` is an abstract class.
- * $(NOTE Use `__traits(isAbstractClass, S)` instead in new code.)
+ *
+ * See also: `__traits(isAbstractClass, S)`
  */
 enum isAbstractClass(alias S) = __traits(isAbstractClass, S);
 
@@ -7743,7 +7751,8 @@ enum isAbstractClass(alias S) = __traits(isAbstractClass, S);
 
 /**
  * Detect whether `S` is a final class.
- * $(NOTE Use `__traits(isFinalClass, S)` instead in new code.)
+ *
+ * See also: `__traits(isFinalClass, S)`
  */
 enum isFinalClass(alias S) = __traits(isFinalClass, S);
 
@@ -9087,7 +9096,7 @@ template isFinal(alias X)
  + If a type cannot be copied, then code such as `MyStruct x; auto y = x;` will fail to compile.
  + Copying for structs can be disabled by using `@disable this(this)`.
  +
- + $(NOTE Use `__traits(isCopyable, S)` instead in new code.)
+ + See also: `__traits(isCopyable, S)`
  + Params:
  +  S = The type to check.
  +

--- a/std/traits.d
+++ b/std/traits.d
@@ -2568,6 +2568,7 @@ if (is(T == class))
 /**
 Determines whether `T` has its own context pointer.
 `T` must be either `class`, `struct`, or `union`.
+
 See also: `__traits(isNested, T)`
 */
 template isNested(T)
@@ -4838,6 +4839,7 @@ package enum maxAlignment(U...) =
 
 /**
 Returns class instance alignment.
+
 See also: `__traits(classInstanceAlignment, T)`
  */
 template classInstanceAlignment(T)

--- a/std/traits.d
+++ b/std/traits.d
@@ -3853,6 +3853,7 @@ package alias Identity(alias A) = A;
 /**
    Yields `true` if and only if `T` is an aggregate that defines
    a symbol called `name`.
+   $(NOTE Use `__traits(hasMember, T, name)` instead in new code.)
  */
 enum hasMember(T, string name) = __traits(hasMember, T, name);
 
@@ -4835,6 +4836,7 @@ package enum maxAlignment(U...) =
 
 /**
 Returns class instance alignment.
+$(NOTE Use `__traits(classInstanceAlignment, T)` instead in new code.)
  */
 template classInstanceAlignment(T)
 if (is(T == class))
@@ -6161,7 +6163,7 @@ template BuiltinTypeOf(T)
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 
 /**
- * Detect whether `T` is a built-in boolean type.
+ * Detect whether `T` is a built-in boolean type or enum of boolean base type.
  */
 enum bool isBoolean(T) = __traits(isUnsigned, T) && is(T : bool);
 
@@ -6255,7 +6257,9 @@ template isIntegral(T)
 
 /**
  * Detect whether `T` is a built-in floating point type.
+ * $(NOTE Use `__traits(isFloating, T)` instead in new code.)
  */
+// is(T : real) to discount complex types
 enum bool isFloatingPoint(T) = __traits(isFloating, T) && is(T : real);
 
 ///
@@ -6393,7 +6397,9 @@ template isNumeric(T)
 /**
  * Detect whether `T` is a scalar type (a built-in numeric, character or
  * boolean type).
+ * $(NOTE Use `__traits(isScalar, T)` instead in new code.)
  */
+// is(T : real) to discount complex types
 enum bool isScalarType(T) = __traits(isScalar, T) && is(T : real);
 
 ///
@@ -6922,6 +6928,7 @@ template isAutodecodableString(T)
 
 /**
  * Detect whether type `T` is a static array.
+ * $(NOTE Use `__traits(isStaticArray, T)` instead in new code.)
  */
 enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
@@ -7051,6 +7058,7 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 
 /**
  * Detect whether `T` is an associative array type
+ * $(NOTE Use `__traits(isAssociativeArray, T)` instead in new code.)
  */
 enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 
@@ -7552,14 +7560,12 @@ template isCallable(alias callable)
     else static if (is(typeof(&callable.opCall) V : V*) && is(V == function))
         // T is a type which has a static member function opCall().
         enum bool isCallable = true;
-    else static if (is(typeof(&callable.opCall!())))
+    else static if (is(typeof(&callable.opCall!()) TemplateInstanceType))
     {
-        alias TemplateInstanceType = typeof(&callable.opCall!());
         enum bool isCallable = isCallable!TemplateInstanceType;
     }
-    else static if (is(typeof(&callable!())))
+    else static if (is(typeof(&callable!()) TemplateInstanceType))
     {
-        alias TemplateInstanceType = typeof(&callable!());
         enum bool isCallable = isCallable!TemplateInstanceType;
     }
     else
@@ -7623,14 +7629,15 @@ template isCallable(alias callable)
 
 
 /**
-Detect whether `T` is an abstract function.
+Detect whether `S` is an abstract function.
 
+$(NOTE Use `__traits(isAbstractFunction, S)` instead in new code.)
 Params:
-    T = The type to check
+    S = The symbol to check
 Returns:
     A `bool`
  */
-enum isAbstractFunction(alias T) = __traits(isAbstractFunction, T);
+enum isAbstractFunction(alias S) = __traits(isAbstractFunction, S);
 
 ///
 @safe unittest
@@ -7645,9 +7652,10 @@ enum isAbstractFunction(alias T) = __traits(isAbstractFunction, T);
 }
 
 /**
- * Detect whether `T` is a final function.
+ * Detect whether `S` is a final function.
+ * $(NOTE Use `__traits(isFinalFunction, S)` instead in new code.)
  */
-enum isFinalFunction(alias T) = __traits(isFinalFunction, T);
+enum isFinalFunction(alias S) = __traits(isFinalFunction, S);
 
 ///
 @safe unittest
@@ -7713,9 +7721,10 @@ template isNestedFunction(alias f)
 }
 
 /**
- * Detect whether `T` is an abstract class.
+ * Detect whether `S` is an abstract class.
+ * $(NOTE Use `__traits(isAbstractClass, S)` instead in new code.)
  */
-enum isAbstractClass(alias T) = __traits(isAbstractClass, T);
+enum isAbstractClass(alias S) = __traits(isAbstractClass, S);
 
 ///
 @safe unittest
@@ -7733,9 +7742,10 @@ enum isAbstractClass(alias T) = __traits(isAbstractClass, T);
 }
 
 /**
- * Detect whether `T` is a final class.
+ * Detect whether `S` is a final class.
+ * $(NOTE Use `__traits(isFinalClass, S)` instead in new code.)
  */
-enum isFinalClass(alias T) = __traits(isFinalClass, T);
+enum isFinalClass(alias S) = __traits(isFinalClass, S);
 
 ///
 @safe unittest
@@ -9077,12 +9087,13 @@ template isFinal(alias X)
  + If a type cannot be copied, then code such as `MyStruct x; auto y = x;` will fail to compile.
  + Copying for structs can be disabled by using `@disable this(this)`.
  +
+ + $(NOTE Use `__traits(isCopyable, S)` instead in new code.)
  + Params:
  +  S = The type to check.
  +
  + Returns:
  +  `true` if `S` can be copied. `false` otherwise.
- + ++/
+ +/
 enum isCopyable(S) = __traits(isCopyable, S);
 
 ///

--- a/std/traits.d
+++ b/std/traits.d
@@ -1194,7 +1194,7 @@ if (isCallable!func)
 }
 
 /**
-Convert the result of `__traits(getParameterStorageClasses)`
+Convert the result of $(DDSUBLINK spec/traits, getParameterStorageClasses, `__traits(getParameterStorageClasses)`)
 to $(LREF ParameterStorageClass) `enum`s.
 
 Params:
@@ -2569,7 +2569,7 @@ if (is(T == class))
 Determines whether `T` has its own context pointer.
 `T` must be either `class`, `struct`, or `union`.
 
-See also: `__traits(isNested, T)`
+See also: $(DDSUBLINK spec/traits, isNested, `__traits(isNested, T)`)
 */
 template isNested(T)
 if (is(T == class) || is(T == struct) || is(T == union))
@@ -3856,7 +3856,7 @@ package alias Identity(alias A) = A;
    Yields `true` if and only if `T` is an aggregate that defines
    a symbol called `name`.
 
-   See also: `__traits(hasMember, T, name)`
+   See also: $(DDSUBLINK spec/traits, hasMember, `__traits(hasMember, T, name)`)
  */
 enum hasMember(T, string name) = __traits(hasMember, T, name);
 
@@ -4840,7 +4840,7 @@ package enum maxAlignment(U...) =
 /**
 Returns class instance alignment.
 
-See also: `__traits(classInstanceAlignment, T)`
+See also: $(DDSUBLINK spec/traits, classInstanceAlignment, `__traits(classInstanceAlignment, T)`)
  */
 template classInstanceAlignment(T)
 if (is(T == class))
@@ -5681,7 +5681,7 @@ private struct __InoutWorkaroundStruct{}
 
 /**
 Creates an lvalue or rvalue of type `T` for `typeof(...)` and
-`__traits(compiles, ...)` purposes. No actual value is returned.
+$(DDSUBLINK spec/traits, compiles, `__traits(compiles, ...)`) purposes. No actual value is returned.
 
 Params:
     T = The type to transform
@@ -6262,7 +6262,7 @@ template isIntegral(T)
 /**
  * Detect whether `T` is a built-in floating point type.
  *
- * See also: `__traits(isFloating, T)`
+ * See also: $(DDSUBLINK spec/traits, isFloating, `__traits(isFloating, T)`)
  */
 // is(T : real) to discount complex types
 enum bool isFloatingPoint(T) = __traits(isFloating, T) && is(T : real);
@@ -6403,7 +6403,7 @@ template isNumeric(T)
  * Detect whether `T` is a scalar type (a built-in numeric, character or
  * boolean type).
  *
- * See also: `__traits(isScalar, T)`
+ * See also: $(DDSUBLINK spec/traits, isScalar, `__traits(isScalar, T)`)
  */
 // is(T : real) to discount complex types
 enum bool isScalarType(T) = __traits(isScalar, T) && is(T : real);
@@ -6935,7 +6935,7 @@ template isAutodecodableString(T)
 /**
  * Detect whether type `T` is a static array.
  *
- * See also: `__traits(isStaticArray, T)`
+ * See also: $(DDSUBLINK spec/traits, isStaticArray, `__traits(isStaticArray, T)`)
  */
 enum bool isStaticArray(T) = __traits(isStaticArray, T);
 
@@ -7066,7 +7066,7 @@ enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;
 /**
  * Detect whether `T` is an associative array type
  *
- * See also: `__traits(isAssociativeArray, T)`
+ * See also: $(DDSUBLINK spec/traits, isAssociativeArray, `__traits(isAssociativeArray, T)`)
  */
 enum bool isAssociativeArray(T) = __traits(isAssociativeArray, T);
 
@@ -7639,7 +7639,7 @@ template isCallable(alias callable)
 /**
 Detect whether `S` is an abstract function.
 
-See also: `__traits(isAbstractFunction, S)`
+See also: $(DDSUBLINK spec/traits, isAbstractFunction, `__traits(isAbstractFunction, S)`)
 Params:
     S = The symbol to check
 Returns:
@@ -7662,7 +7662,7 @@ enum isAbstractFunction(alias S) = __traits(isAbstractFunction, S);
 /**
  * Detect whether `S` is a final function.
  *
- * See also: `__traits(isFinalFunction, S)`
+ * See also: $(DDSUBLINK spec/traits, isFinalFunction, `__traits(isFinalFunction, S)`)
  */
 enum isFinalFunction(alias S) = __traits(isFinalFunction, S);
 
@@ -7732,7 +7732,7 @@ template isNestedFunction(alias f)
 /**
  * Detect whether `S` is an abstract class.
  *
- * See also: `__traits(isAbstractClass, S)`
+ * See also: $(DDSUBLINK spec/traits, isAbstractClass, `__traits(isAbstractClass, S)`)
  */
 enum isAbstractClass(alias S) = __traits(isAbstractClass, S);
 
@@ -7754,7 +7754,7 @@ enum isAbstractClass(alias S) = __traits(isAbstractClass, S);
 /**
  * Detect whether `S` is a final class.
  *
- * See also: `__traits(isFinalClass, S)`
+ * See also: $(DDSUBLINK spec/traits, isFinalClass, `__traits(isFinalClass, S)`)
  */
 enum isFinalClass(alias S) = __traits(isFinalClass, S);
 
@@ -9098,7 +9098,7 @@ template isFinal(alias X)
  + If a type cannot be copied, then code such as `MyStruct x; auto y = x;` will fail to compile.
  + Copying for structs can be disabled by using `@disable this(this)`.
  +
- + See also: `__traits(isCopyable, S)`
+ + See also: $(DDSUBLINK spec/traits, isCopyable, `__traits(isCopyable, S)`)
  + Params:
  +  S = The type to check.
  +


### PR DESCRIPTION
**Note: Originally this recommended using __traits instead, now it just says see also.**

---
That will reduce template instantiation overhead.
Note that some __traits accept type instances in addition to just types.

~~I've left `isNested` as that only applies to types not functions - ideally it would be named `isNestedType` to avoid confusion with `__traits(isNested)`.~~

@schveiguy