### PR TITLE
Change how preview=in is detected

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1829,7 +1829,8 @@ enum HasToStringResult
     customPutWriterFormatSpec,
 }
 
-private enum hasPreviewIn = !is(typeof(mixin(q{(in ref int a) => a})));
+private alias DScannerBug895 = int[256];
+private immutable bool hasPreviewIn = ((in DScannerBug895 a) { return __traits(isRef, a); })(DScannerBug895.init);
 
 template hasToString(T, Char)
 {


### PR DESCRIPTION
This is a minor internal change, but will allow us to deprecate in ref at the parser level.