### PR TITLE
std.math.exponential: Disable use of fyl2x and fyl2xp1 intrinsics on dmd/macOS port

### DIFF
--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -39,7 +39,8 @@ static import core.stdc.math;
 
 version (DigitalMars)
 {
-    version = INLINE_YL2X;        // x87 has opcodes for these
+    version (OSX) { }             // macOS 13 (M1) has issues emulating instruction
+    else version = INLINE_YL2X;   // x87 has opcodes for these
 }
 
 version (D_InlineAsm_X86)    version = InlineAsm_X86_Any;


### PR DESCRIPTION
After some probing, looks like Apple M1 emulation of x86 instructions is bugged.  Nothing we can do besides opening a ticket with Apple, so disabling use fyl2xp1 intrinsics on the target. 