### PR TITLE
Fix a printf prototype in std.traits test

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2184,7 +2184,7 @@ if (isCallable!func)
     void func() {}
     static assert(variadicFunctionStyle!func == Variadic.no);
 
-    extern(C) int printf(in char*, ...);
+    extern(C) int printf(const char*, ...);
     static assert(variadicFunctionStyle!printf == Variadic.c);
 }
 


### PR DESCRIPTION
I thought I was done with Phobos, but it strikes yet again.