### PR TITLE
Optimised std.range.chain

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -949,13 +949,29 @@ if (Ranges.length > 0 &&
                 frontIndex = source.length;
                 static if (bidirectional) backIndex = 0;
 
-                foreach (i, v; input)
+                foreach (i, ref v; input) source[i] = v;
+
+                // We do this separately to avoid invoking `empty` needlessly.
+                // While not recommended, a range may depend on side effects of
+                // `empty` call.
+                foreach (i, ref v; input) if (!v.empty)
                 {
-                    source[i] = v;
-                    if (!v.empty)
+                    frontIndex = i;
+                    static if (bidirectional) backIndex = i+1;
+                    break;
+                }
+
+                // backIndex is already set in the first loop to
+                // as frontIndex+1, so we'll use that if we don't find a
+                // non-empty range here.
+                static if (bidirectional)
+                    static foreach_reverse (i; 1 .. R.length + 1)
+                {
+                    if (i <= frontIndex + 1) return;
+                    if (!input[i-1].empty)
                     {
-                        if (i < frontIndex) frontIndex = i;
-                        static if (bidirectional) backIndex = i+1;
+                        backIndex = i;
+                        return;
                     }
                 }
             }
@@ -999,7 +1015,7 @@ if (Ranges.length > 0 &&
                     assert(0, "Attempt to `popFront` of empty `chain` range");
 
                 default:
-                    assert(0, "Shouldn't be possible to end up here");
+                    assert(0, "Internal library error. Please report it.");
                 }
 
                 sw2: switch (frontIndex)
@@ -1020,7 +1036,7 @@ if (Ranges.length > 0 &&
                     break;
 
                 default:
-                    assert(0, "Shouldn't be possible to end up here");
+                    assert(0, "Internal library error. Please report it.");
                 }
             }
 
@@ -1038,7 +1054,7 @@ if (Ranges.length > 0 &&
                     assert(0, "Attempt to get `front` of empty `chain` range");
 
                 default:
-                    assert(0, "Shouldn't be possible to end up here");
+                    assert(0, "Internal library error. Please report it.");
                 }
             }
 
@@ -1062,7 +1078,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Attempt to set `front` of empty `chain` range");
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
                 }
             }
@@ -1083,7 +1099,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Attempt to `moveFront` of empty `chain` range");
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
                 }
             }
@@ -1104,7 +1120,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Attempt to get `back` of empty `chain` range");
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
                 }
 
@@ -1123,7 +1139,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Attempt to `popFront` of empty `chain` range");
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
 
                     sw2: switch (backIndex)
@@ -1144,7 +1160,7 @@ if (Ranges.length > 0 &&
                         break;
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
                 }
 
@@ -1164,7 +1180,7 @@ if (Ranges.length > 0 &&
                             assert(0, "Attempt to `moveBack` of empty `chain` range");
 
                         default:
-                            assert(0, "Shouldn't be possible to end up here");
+                            assert(0, "Internal library error. Please report it.");
                         }
                     }
                 }
@@ -1186,7 +1202,7 @@ if (Ranges.length > 0 &&
                             assert(0, "Attempt to set `back` of empty `chain` range");
 
                         default:
-                            assert(0, "Shouldn't be possible to end up here");
+                            assert(0, "Internal library error. Please report it.");
                         }
                     }
                 }
@@ -1211,7 +1227,7 @@ if (Ranges.length > 0 &&
                         break;
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
 
                     return result;
@@ -1246,7 +1262,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Attempt to access out-of-bounds index of `chain` range");
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
                 }
 
@@ -1276,7 +1292,7 @@ if (Ranges.length > 0 &&
                             assert(0, "Attempt to move out-of-bounds index of `chain` range");
 
                         default:
-                            assert(0, "Shouldn't be possible to end up here");
+                            assert(0, "Internal library error. Please report it.");
                         }
                     }
                 }
@@ -1307,7 +1323,7 @@ if (Ranges.length > 0 &&
                             assert(0, "Attempt to write out-of-bounds index of `chain` range");
 
                         default:
-                            assert(0, "Shouldn't be possible to end up here");
+                            assert(0, "Internal library error. Please report it.");
                         }
                     }
             }
@@ -1345,7 +1361,7 @@ if (Ranges.length > 0 &&
                         break;
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
 
                     // Overflow intentional if end index too big.
@@ -1381,7 +1397,7 @@ if (Ranges.length > 0 &&
                         break sw2;
 
                     default:
-                        assert(0, "Shouldn't be possible to end up here");
+                        assert(0, "Internal library error. Please report it.");
                     }
 
                     return result;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -986,7 +986,7 @@ if (Ranges.length > 0 &&
 
             void popFront()
             {
-                sw1: switch(frontIndex)
+                sw1: switch (frontIndex)
                 {
                     static foreach (i; 0 .. R.length)
                     {
@@ -1002,7 +1002,7 @@ if (Ranges.length > 0 &&
                     assert(0, "Shouldn't be possible to end up here");
                 }
 
-                sw2: switch(frontIndex)
+                sw2: switch (frontIndex)
                 {
                     static foreach (i; 0 .. R.length)
                     {
@@ -1026,7 +1026,7 @@ if (Ranges.length > 0 &&
 
             @property auto ref front()
             {
-                switch(frontIndex)
+                switch (frontIndex)
                 {
                     static foreach (i; 0 .. R.length)
                     {
@@ -1049,7 +1049,7 @@ if (Ranges.length > 0 &&
 
                 @property void front(RvalueElementType v)
                 {
-                    sw: switch(frontIndex)
+                    sw: switch (frontIndex)
                     {
                         static foreach (i; 0 .. R.length)
                         {
@@ -1071,7 +1071,7 @@ if (Ranges.length > 0 &&
             {
                 RvalueElementType moveFront()
                 {
-                    switch(frontIndex)
+                    switch (frontIndex)
                     {
                         static foreach (i; 0 .. R.length)
                         {
@@ -1110,7 +1110,7 @@ if (Ranges.length > 0 &&
 
                 void popBack()
                 {
-                    sw1: switch(backIndex)
+                    sw1: switch (backIndex)
                     {
                         static foreach_reverse (i; 1 .. R.length + 1)
                         {
@@ -1126,7 +1126,7 @@ if (Ranges.length > 0 &&
                         assert(0, "Shouldn't be possible to end up here");
                     }
 
-                    sw2: switch(backIndex)
+                    sw2: switch (backIndex)
                     {
                         static foreach_reverse (i; 1 .. R.length + 1)
                         {
@@ -1152,7 +1152,7 @@ if (Ranges.length > 0 &&
                 {
                     RvalueElementType moveBack()
                     {
-                        switch(backIndex)
+                        switch (backIndex)
                         {
                             static foreach_reverse (i; 1 .. R.length + 1)
                             {

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -985,20 +985,24 @@ if (Ranges.length > 0 &&
             }
             else
             {
-                @property bool empty() {return frontIndex >= backIndex;}
+                @property bool empty() => frontIndex >= backIndex;
             }
 
             static if (allSatisfy!(isForwardRange, R))
+            {
                 @property auto save()
                 {
-                    auto saveI(size_t i)(){return source[i].save;}
+                    auto saveI(size_t i)() => source[i].save;
 
-                    auto saveResult
-                        = Result(staticMap!(saveI, aliasSeqOf!(R.length.iota)));
-                    saveResult.frontIndex = frontIndex;
-                    static if (bidirectional) saveResult.backIndex = backIndex;
+                    // TODO: this has the constructor needlessly refind
+                    // frontIndex and backIndex. It'd be better to just copy
+                    // those from `.this`.
+                    auto saveResult =
+                        Result(staticMap!(saveI, aliasSeqOf!(R.length.iota)));
+
                     return saveResult;
                 }
+            }
 
             void popFront()
             {


### PR DESCRIPTION
On each `empty`, `popFront`, or similar call, `chain` iterates over the same empty ranges again and again, which seems wasteful for me. This PR changes that. The index of first and last non-empty ranges are now cached in the range instead.

I benchmarked the resulting chain against that coming with version 2.100.1:
```D
@safe void main()
{   import std;
    import std.datetime.stopwatch;
    auto testData = uninitializedArray!(long[])(600_000);
    foreach(ref el; testData) el = uniform(0, 10);

    long total = 0;
    StopWatch sw;
    sw.start();

    foreach(i; 0 .. testData.length / 120) total |= chain
    (   testData.drop(i*120).take(60),
        testData.drop(i*120 + 60).take(60)
    ).fold!"a+b"(1L);

    sw.stop();
    writeln("time: ", sw.peek);
    writeln("result: ", total);
}
```

On my computer, the new version wins at factor 5 : 6. This chain has only two parts so checking the first range for emptiness should be as fast as switch statements. I'm guessing the advantage comes from empty checks, as the new version only has to do one comparison, as opposed to two empty checks the old chain does.

What if I use a four-part chain instead? The loop is now:
```D
foreach(i; 0 .. testData.length / 120) total |= chain
(   testData.drop(i*120).take(30),
    testData.drop(i*120 + 30).take(30),
    testData.drop(i*120 + 60).take(30),
    testData.drop(i*120 + 90).take(30),
).fold!"a+b"(1L);
```

The difference now increases to 3 : 4. We can go even further and compare with a six-part chain.

```D
foreach(i; 0 .. testData.length / 120) total |= chain
(   testData.drop(i*120).take(20),
    testData.drop(i*120 + 20).take(20),
    testData.drop(i*120 + 40).take(20),
    testData.drop(i*120 + 60).take(20),
    testData.drop(i*120 + 80).take(20),
    testData.drop(i*120 + 100).take(20),
).fold!"a+b"(1L);
```

This shows an even greater performance gap of 5 : 8, again in favour of the new version. Two caveats though: First off, I'm not compiling these two with the same compiler. The new chain is compiled with a recent master version, while the old one is compiled with 2.100.1. Second, I'm using dmd (with the `-O` flag). I'm not sure what the difference would be with GDC or LDC.

However, I find it unlikely this performance difference would be due to a difference in the compilers, especially since the difference is greater for a longer chain, as excepted from the nature of the changes.