### PR TITLE
 fix 22147: allow @disable this(this) T in DList!T 

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2313,12 +2313,12 @@ if (isInputRange!(Unqual!Range) &&
         /// ditto
         @property void front(ElementType!R v)
         {
+            import std.algorithm.mutation : move;
+
             assert(!empty,
                 "Attempting to assign to the front of an empty "
                 ~ Take.stringof);
-            // This has to return auto instead of void because of
-            // https://issues.dlang.org/show_bug.cgi?id=4706
-            source.front = v;
+            source.front = move(v);
         }
 
     static if (hasMobileElements!R)

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1041,7 +1041,8 @@ See_Also:
  */
 enum bool isBidirectionalRange(R) = isForwardRange!R
     && is(typeof((R r) => r.popBack))
-    && is(typeof((R r) { return r.back; } (R.init)) == ElementType!R);
+    && (is(typeof((return ref R r) => r.back)) || is(typeof(ref (return ref R r) => r.back)))
+    && is(typeof(R.init.back.init) == ElementType!R);
 
 ///
 @safe unittest


### PR DESCRIPTION
also fixes isBidirectionalRange not allowing `@disable this(this)` items (which isInputRange allows)

<details>

<summary>German Train rant</summary>

I couldn't test entire phobos locally yet, because I couldn't get the newest dmd commit to build, because the internet in German trains is about 4 kb/s, with the connection constantly dropping and me needing to pull 1 MB of changes first.

</details>
