### PR TITLE
[std.algorithm.searching] Add extrema to compute min and max

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -34,6 +34,7 @@ $(T2 commonPrefix,
         `commonPrefix("parakeet", "parachute")` returns `"para"`.)
 $(T2 endsWith,
         `endsWith("rocks", "ks")` returns `true`.)
+$(T2 extrema, `extrema([2, 1, 3, 5, 4])` returns `[1, 5]`.)
 $(T2 find,
         `find("hello world", "or")` returns `"orld"` using linear search.
         (For binary search refer to $(REF SortedRange, std,range).))
@@ -3684,7 +3685,7 @@ Note:
 
 See_Also:
 
-    $(LREF maxElement), $(REF min, std,algorithm,comparison), $(LREF minCount),
+    $(LREF extrema), $(LREF maxElement), $(REF min, std,algorithm,comparison), $(LREF minCount),
     $(LREF minIndex), $(LREF minPos)
 */
 auto minElement(alias map = (a => a), Range)(Range r)
@@ -3865,7 +3866,7 @@ Note:
 
 See_Also:
 
-    $(LREF minElement), $(REF max, std,algorithm,comparison), $(LREF maxCount),
+    $(LREF extrema), $(LREF minElement), $(REF max, std,algorithm,comparison), $(LREF maxCount),
     $(LREF maxIndex), $(LREF maxPos)
 */
 auto maxElement(alias map = (a => a), Range)(Range r)
@@ -4033,6 +4034,70 @@ if (isInputRange!Range && !isInfinite!Range &&
 
     auto arr = [S(19), S(2), S(145), S(7)];
     assert(maxElement(arr) == S(145));
+}
+
+/** Returns an array of the minimum and maximum element in `r`.
+ * Makes `< 3n/2` comparisons.
+ */
+// TODO alias map = a => a
+ElementType!Range[2] extrema(Range)(Range r)
+if (isRandomAccessRange!Range && hasLength!Range)
+in (!r.empty)
+{
+    if (r.length == 1)
+        return [r[0], r[0]];
+
+    typeof(return) result;
+    size_t i;
+    if (r.length & 1) // odd
+    {
+        result = [r[0], r[0]];
+        i = 1;
+    }
+    else
+    {
+        result = (r[0] < r[1]) ? [r[0], r[1]] : [r[1], r[0]];
+        i = 2;
+    }
+    // iterate pairs
+    const imax = r.length;
+    for (; i != imax; i += 2)
+    {
+        // save work
+        if (r[i] < r[i+1])
+        {
+            if (r[i] < result[0])
+                result[0] = r[i];
+            if (r[i+1] > result[1])
+                result[1] = r[i+1];
+        }
+        else
+        {
+            if (r[i+1] < result[0])
+                result[0] = r[i+1];
+            if (r[i] > result[1])
+                result[1] = r[i];
+        }
+    }
+    return result;
+}
+
+unittest
+{
+    assert(extrema([5,2,9,4,1]) == [1, 9]);
+    assert(extrema([8,3,7,4,9]) == [3, 9]);
+    assert(extrema([1,5,3,2]) == [1, 5]);
+    assert(extrema([2,3,3,2]) == [2, 3]);
+
+    version (StdRandomTests)
+    foreach (i; 0..1000)
+    {
+        import std.random, std.range;
+        auto arr = generate!(() => uniform(0, 100)).takeExactly(uniform(1, 10)).array;
+        auto result = arr.extrema;
+        assert(result[0] == arr.minElement);
+        assert(result[1] == arr.maxElement);
+    }
 }
 
 // minPos

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4140,14 +4140,21 @@ in (!r.empty)
     assert(extrema([1,5,3,2]) == [1, 5]);
     assert(extrema([2,3,3,2]) == [2, 3]);
 
+    import std.range;
+    assert(iota(2, 5).extrema == [2, 4]);
+    assert(iota(3, 7).retro.extrema == [3, 6]);
+
     import std.internal.test.dummyrange;
-    DummyRange!(ReturnBy.Reference, Length.No, RangeType.Input) r;
-    assert(r.extrema == [1u, 10u]);
+    foreach (DummyType; AllDummyRanges)
+    {
+        DummyType d;
+        assert(d.extrema == [1, 10]);
+    }
 
     version (StdRandomTests)
     foreach (i; 0 .. 1000)
     {
-        import std.random, std.range;
+        import std.random;
         auto arr = generate!(() => uniform(0, 100)).takeExactly(uniform(1, 10)).array;
         auto result = arr.extrema;
         assert(result[0] == arr.minElement);

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -4037,7 +4037,9 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 /** Returns an array of the minimum and maximum element in `r`.
- * Makes `< 3n/2` comparisons.
+ * Performs `< 3n/2` comparisons, unlike the naive `< 2n`.
+ * Params:
+ *  r = The range to traverse.
  */
 // TODO alias map = a => a
 ElementType!Range[2] extrema(Range)(Range r)
@@ -4082,15 +4084,20 @@ in (!r.empty)
     return result;
 }
 
-unittest
+///
+@safe unittest
 {
     assert(extrema([5,2,9,4,1]) == [1, 9]);
+}
+
+@safe unittest
+{
     assert(extrema([8,3,7,4,9]) == [3, 9]);
     assert(extrema([1,5,3,2]) == [1, 5]);
     assert(extrema([2,3,3,2]) == [2, 3]);
 
     version (StdRandomTests)
-    foreach (i; 0..1000)
+    foreach (i; 0 .. 1000)
     {
         import std.random, std.range;
         auto arr = generate!(() => uniform(0, 100)).takeExactly(uniform(1, 10)).array;


### PR DESCRIPTION
Performs `< 3n/2` comparisons, unlike the naive `< 2n`.
Implemented for an input range.
TODO add `alias map = a => a` parameter, once design is confirmed OK.