### PR TITLE
[std.container.rbtree] Fix rbtree correct so it works with DIP1000 an…

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -887,7 +887,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      * Returns:
      *   true if node was added
      */
-    private bool _add(return scope Elem n)
+    private bool _add(Elem n)
     {
         Node result;
         static if (!allowDuplicates)
@@ -1282,7 +1282,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      *
      * Complexity: $(BIGOH m * log(n))
      */
-    size_t stableInsert(Stuff)(scope Stuff stuff)
+    size_t stableInsert(Stuff)(Stuff stuff)
         if (isInputRange!Stuff &&
             isImplicitlyConvertible!(ElementType!Stuff, Elem))
     {
@@ -2117,7 +2117,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
     auto rbt3 = redBlackTree(chain([0, 1], [7, 5]));
     assert(equal(rbt3[], [0, 1, 5, 7]));
 
-    auto rbt4 = redBlackTree(chain(["hello"], ["world"]));
+    auto rbt4 = redBlackTree(chain(["hello"].idup, ["world"].idup));
     assert(equal(rbt4[], ["hello", "world"]));
 
     auto rbt5 = redBlackTree!true(chain([0, 1], [5, 7, 5]));


### PR DESCRIPTION
Fix rbtree correctly so it works with DIP1000 and dmd-2.101 or higher

The RebBlackTree._add parameter has a scope attribute it can't have a scope if it references to the element allocated. 
The PR corrects this by removing the scope.

Example. 
Which can't compile with -dip1000 -dip25 


file rbtree_scope.d
```
import std.container.rbtree;

@safe:
enum Type
{
    REMOVE = -1,
    NONE = 0,
    ADD = 1
}

class Archive
{
    string fingerprint;
    Type type;
    this(string f, Type t)
    {
        fingerprint = f;
        type = t;
    }
}

alias Archives = RedBlackTree!(Archive, (a,
        b) @safe => (a.fingerprint < b.fingerprint)
        || (a.fingerprint == b.fingerprint) && (a.type < a.type));

@safe
unittest
{
    auto rbt = new Archives;
    rbt.insert(new Archive("test", Type.ADD));
}

```

```
dmd rbtest_scope.d -unittest -main
rbtest_scope.d(30): Deprecation: `@safe` function `__unittest_L27_C1` calling `stableInsert`
/usr/include/dmd/phobos/std/container/rbtree.d(1273):        which calls `std.container.rbtree.RedBlackTree!(Archive, (a, b) @safe => a.fingerprint < b.fingerprint || a.fingerprint == b.fingerprint && (a.type < a.type), false).RedBlackTree._add`
/usr/include/dmd/phobos/std/container/rbtree.d(898):        which would be `@system` because of:
/usr/include/dmd/phobos/std/container/rbtree.d(898):        scope variable `n` assigned to non-scope parameter `v` calling `allocate`
```

And
```
dmd -dip1000 -dip25 rbtest_scope.d -unittest -main
rbtest_scope.d(30): Error: `@safe` function `rbtest_scope.__unittest_L27_C1` cannot call `@system` function `std.container.rbtree.RedBlackTree!(Archive, (a, b) @safe => a.fingerprint < b.fingerprint || a.fingerprint == b.fingerprint && (a.type < a.type), false).RedBlackTree.stableInsert!(Archive).stableInsert`
/usr/include/dmd/phobos/std/container/rbtree.d(890):        which calls `std.container.rbtree.RedBlackTree!(Archive, (a, b) @safe => a.fingerprint < b.fingerprint || a.fingerprint == b.fingerprint && (a.type < a.type), false).RedBlackTree._add`
/usr/include/dmd/phobos/std/container/rbtree.d(898):        which was inferred `@system` because of:
/usr/include/dmd/phobos/std/container/rbtree.d(898):        scope variable `n` assigned to non-scope parameter `v` calling `allocate`
/usr/include/dmd/phobos/std/container/rbtree.d(1264):        `std.container.rbtree.RedBlackTree!(Archive, (a, b) @safe => a.fingerprint < b.fingerprint || a.fingerprint == b.fingerprint && (a.type < a.type), false).RedBlackTree.stableInsert!(Archive).stableInsert` is declared here
```
