### PR TITLE
Breaking change: `Rebindable` is always a struct with `get`.

### DIFF
--- a/changelog/rebindable_special_cases_removed.md
+++ b/changelog/rebindable_special_cases_removed.md
@@ -1,0 +1,12 @@
+`std.typecons.Rebindable` no longer has special handling for arrays, classes and interfaces.
+
+Previously, `Rebindable!(const T[])` used to simply alias to `const(T)[]`, creating a mutable version of
+the parameter type. This special case has been removed, and `Rebindable!(const T[])` is now a struct, just
+as every other instance of `Rebindable`.
+
+The same goes for classes: `Rebindable!C` used to just alias to `C` if `C` was not const or immutable.
+This special case has also been removed.
+
+As a consequence, when you declare `Rebindable!T foo`, you can now always write `foo.get` to get a value of
+type `T`. This is expected to reduce the amount of required specialcasing in template code that uses
+`Rebindable`.


### PR DESCRIPTION
Previously, `Rebindable!T` aliases itself away to `T` if `T` is an array. This is bad, because it means we cannot reliably get rid of `Rebindable` with `r.get` again, forcing an additional cryptic `static if` in all code where the callee should never be `Rebindable`. 

Let's just get rid of it.

See #8734 for a PR made awkward by `Rebindable!T` sometimes aliasing itself to `T`.

~~Note: This PR is largely to run Buildkite to see if this breaks anything.~~

Seems surprisingly green!

Okay, what do I need to do to get this merged?