### PR TITLE
Fix macros inside backticks

### DIFF
--- a/std/format/package.d
+++ b/std/format/package.d
@@ -202,8 +202,8 @@ compound type. This $(I format specifier) can be a $(I compound
 indicator) itself.
 
 Note: Inside a $(I compound indicator), strings and characters are
-escaped automatically. To avoid this behavior, use `"%-$(LPAREN)"`
-instead of `"%$(LPAREN)"`.
+escaped automatically. To avoid this behavior, use `"%-("`
+instead of `"%("`.
 
 $(SECTION4 Flags)
 
@@ -307,7 +307,7 @@ $(UL
        inside of compound types are surrounded by single and double quotes
        and unprintable characters are escaped. To avoid this, a $(B '-')
        flag can be specified for the compound specifier
-       $(LPAREN)e.g. `"%-$(LPAREN)%s%$(RPAREN)"` instead of `"%$(LPAREN)%s%$(RPAREN)"` $(RPAREN).)
+       (e.g. `"%-(%s%)"` instead of `"%(%s%)"`).)
   $(LI Structs, unions, classes and interfaces are formatted by calling a
        `toString` method if available.
        See $(MREF_ALTTEXT $(D module std.format.write), std, format, write) for more
@@ -417,7 +417,7 @@ $(BOOKTABLE ,
                  character is surrounded by single quotes and non printable
                  characters are escaped. This can be avoided by preceding
                  the compound indicator with a $(B '-') flag
-                 $(LPAREN)e.g. `"%-$(LPAREN)%s%$(RPAREN)"`$(RPAREN).)
+                 (e.g. `"%-(%s%)"`).)
    )
    $(TR $(TD $(B 'b'), $(B 'd'), $(B 'o'), $(B 'u'), $(B 'x'), $(B 'X'))
             $(TD As the integral that represents the character.)
@@ -432,7 +432,7 @@ $(BOOKTABLE ,
                  Inside of a compound indicator the string is surrounded by double quotes
                  and non printable characters are escaped. This can be avoided
                  by preceding the compound indicator with a $(B '-') flag
-                 $(LPAREN)e.g. `"%-$(LPAREN)%s%$(RPAREN)"`$(RPAREN).)
+                 (e.g. `"%-(%s%)"`).)
    )
    $(TR $(TD $(B 'r'))
             $(TD The sequence of characters, each formatted with $(B 'r').)

--- a/std/random.d
+++ b/std/random.d
@@ -2029,8 +2029,8 @@ if (is(MTEngine : MersenneTwisterEngine!Params, Params...))
 /**
 Generates a number between `a` and `b`. The `boundaries`
 parameter controls the shape of the interval (open vs. closed on
-either side). Valid values for `boundaries` are `"[]"`, $(D
-"$(LPAREN)]"), `"[$(RPAREN)"`, and `"()"`. The default interval
+either side). Valid values for `boundaries` are `"[]"`,
+`"(]"`, `"[)"`, and `"()"`. The default interval
 is closed to the left and open to the right. The version that does not
 take `urng` uses the default generator `rndGen`.
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -7548,7 +7548,7 @@ enum bool isSomeFunction(alias T) =
 
 /**
 Detect whether `T` is a callable object, which can be called with the
-function call operator `$(LPAREN)...$(RPAREN)`.
+function call operator `(...)`.
  */
 template isCallable(alias callable)
 {


### PR DESCRIPTION
Fixes Issue 23849 - Ddoc `$(LPAREN)` and `$(RPAREN)` not formatted properly

Introduced by #6391 in 2018.