### PR TITLE
fix issue 23881: add std.system.instructionSetArchitecture and std.system.ISA

### DIFF
--- a/changelog/std_system_instruction_set_architecture.dd
+++ b/changelog/std_system_instruction_set_architecture.dd
@@ -1,0 +1,15 @@
+Added `std.system.instructionSetArchitecture` and `std.system.ISA`
+
+A new enum representing the instruction set architecture for the targeted
+system was added. It is intended for cases where a targeted CPU's ISA is only
+needed at runtime, such as providing human-readable messages as demonstrated
+below.
+-------
+import std.stdio;
+import std.system;
+
+void main()
+{
+    writeln("Hello ", instructionSetArchitecture, " world!");
+}
+-------

--- a/std/system.d
+++ b/std/system.d
@@ -82,5 +82,77 @@ immutable
     /// The endianness that the program was compiled for.
     version (LittleEndian) Endian endian = Endian.littleEndian;
     else                  Endian endian = Endian.bigEndian;
+    /++
+        Instruction Set Architecture.
+
+        Note:
+            This is intended for cases where you need a value representing the
+            instruction set architecture at runtime. If you're doing something
+            which should compile differently depending on instruction set
+            architecture, then please use `version (X86_64)`, `version (ARM)`,
+            etc.
+
+        See_Also:
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
+      +/
+    enum ISA
+    {
+        x86,   /// Intel and AMD 32-bit processors
+        x86_64, /// Intel and AMD 64-bit processors
+        arm, /// The ARM architecture (32-bit) (AArch32 et al)
+        aarch64, /// The Advanced RISC Machine architecture (64-bit)
+        asmJS, /// The asm.js intermediate programming language
+        avr, /// 8-bit Atmel AVR Microcontrollers
+        epiphany, /// The Epiphany architecture
+        ppc, /// The PowerPC architecture, 32-bit
+        ppc64, /// The PowerPC architecture, 64-bit
+        ia64, /// The Itanium architecture (64-bit)
+        mips32, /// The MIPS architecture, 32-bit
+        mips64, /// The MIPS architecture, 64-bit
+        msp430, /// The MSP430 architecture
+        nvptx, /// The Nvidia Parallel Thread Execution (PTX) architecture, 32-bit
+        nvptx64, /// The Nvidia Parallel Thread Execution (PTX) architecture, 64-bit
+        riscv32, /// The RISC-V architecture, 32-bit
+        riscv64, /// The RISC-V architecture, 64-bit
+        sparc, /// The SPARC architecture, 32-bit
+        sparc64, /// The SPARC architecture, 64-bit
+        s390, /// The System/390 architecture, 32-bit
+        systemZ, /// The System Z architecture, 64-bit
+        hppa, /// The HP PA-RISC architecture, 32-bit
+        hppa64, /// The HP PA-RISC architecture, 64-bit
+        sh, /// The SuperH architecture, 32-bit
+        webAssembly, /// The WebAssembly virtual ISA (instruction set architecture), 32-bit
+        alpha, /// The Alpha architecture
+        unknown, /// Unknown
+    }
+
+    /// The instruction set architecture that the program was compiled for.
+    version (X86) ISA instructionSetArchitecture = ISA.x86;
+    else version (X86_64)   ISA instructionSetArchitecture = ISA.x86_64;
+    else version (ARM)      ISA instructionSetArchitecture = ISA.arm;
+    else version (AArch64)  ISA instructionSetArchitecture = ISA.aarch64;
+    else version (AsmJS)    ISA instructionSetArchitecture = ISA.asmJS;
+    else version (AVR)      ISA instructionSetArchitecture = ISA.avr;
+    else version (Epiphany) ISA instructionSetArchitecture = ISA.epiphany;
+    else version (PPC)      ISA instructionSetArchitecture = ISA.ppc;
+    else version (PPC64)    ISA instructionSetArchitecture = ISA.ppc64;
+    else version (IA64)     ISA instructionSetArchitecture = ISA.ia64;
+    else version (MIPS32)   ISA instructionSetArchitecture = ISA.mips32;
+    else version (MIPS64)   ISA instructionSetArchitecture = ISA.mips64;
+    else version (MSP430)   ISA instructionSetArchitecture = ISA.msp430;
+    else version (NVPTX)    ISA instructionSetArchitecture = ISA.nvptx;
+    else version (NVPTX64)  ISA instructionSetArchitecture = ISA.nvptx64;
+    else version (RISCV32)  ISA instructionSetArchitecture = ISA.riscv32;
+    else version (RISCV64)  ISA instructionSetArchitecture = ISA.riscv64;
+    else version (SPARC)    ISA instructionSetArchitecture = ISA.sparc;
+    else version (SPARC64)  ISA instructionSetArchitecture = ISA.sparc64;
+    else version (S390)     ISA instructionSetArchitecture = ISA.s390;
+    else version (SystemZ)  ISA instructionSetArchitecture = ISA.systemZ;
+    else version (HPPA)     ISA instructionSetArchitecture = ISA.hppa;
+    else version (HPPA64)   ISA instructionSetArchitecture = ISA.hppa64;
+    else version (SH)       ISA instructionSetArchitecture = ISA.sh;
+    else version (WebAssembly) ISA instructionSetArchitecture = ISA.webAssembly;
+    else version (Alpha)    ISA instructionSetArchitecture = ISA.alpha;
+    else ISA instructionSetArchitecture = ISA.unknown;
 }
 


### PR DESCRIPTION
I tried to keep things aligned with the [Predefined Versions](https://dlang.org/spec/version.html#predefined-versions), so hopefully there's nothing surprising here. This does not cover ABIs, which would be somewhat more complicated to support.