### PR TITLE
add std.compiler.Version

### DIFF
--- a/changelog/std_compiler_version.dd
+++ b/changelog/std_compiler_version.dd
@@ -1,0 +1,26 @@
+Added `std.compiler.Version`
+
+A new struct allowing for version conditions to be used as boolean values
+has been added to std.compiler.
+-------
+import std.compiler;
+
+static if (Version.D_InlineAsm_X86 || Version.D_InlineAsm_X86_64)
+{
+    version = UseX86Assembly;
+}
+
+int expensiveFunction()
+{
+    version(UseX86Assembly)
+    {
+        asm {
+            // x86 assembly implementation goes here
+        }
+    }
+    else
+    {
+        // a fallback implementation for non-x86 systems
+    }
+}
+-------

--- a/std/compiler.d
+++ b/std/compiler.d
@@ -56,3 +56,48 @@ immutable
     uint D_major = 2;
     uint D_minor = 0;
 }
+
+/**
+ * Allows version conditions to be available as boolean values at compile
+ * time, allowing for more complex combinations of versions to be expressed
+ * more simply. Any valid version(x) will have an equivalent Version.x
+ * evaluating to either true or false depending on whether version(x) was
+ * defined.
+ */
+struct Version
+{
+    static bool opDispatch(string identifier)()
+    {
+        mixin("
+            version(", identifier, ")
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        ");
+    }
+}
+
+///
+@system unittest
+{
+    static if (Version.D_InlineAsm_X86 || Version.D_InlineAsm_X86_64)
+    {
+        asm {
+            // x86 assembly goes here
+        }
+    }
+    else
+    {
+        // a fallback implementation
+    }
+}
+
+@safe pure unittest
+{
+    static assert(Version.all);
+    static assert(!Version.none);
+}


### PR DESCRIPTION
I am hesitant to call this a fix for [issue 7417](https://issues.dlang.org/show_bug.cgi?id=7417), because I think there is still some merit to the idea as proposed, but this is a common-enough workaround that I feel it is an appropriate for inclusion in Phobos. The rationale both for and against this has been discussed to death already, and can be found in the issue as well as the many forum threads that have come up over the years.

I am unsure if std.compiler is the ideal module for this, but it doesn't seem like any other module is a better fit, and I don't think adding a new module just for this is justifiable.

Note that the example in the changelog entry and the example in the unittest differ - this is due to a limitation of version specifications. They are only permitted at module scope.