### PR TITLE
typecons: fix use-after-scope bug in RefCounted unittest

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7420,8 +7420,8 @@ pure @system unittest
         rc1 = rc2;
         assert(rc1._refCounted._store._count == 2);
         // Artificially end scope of rc1 and rc2 by calling ~this() explicitly
-        rc2.__dtor();
-        rc1.__dtor();
+        rc2.__xdtor();
+        rc1.__xdtor();
         assert(p._refCounted._store == null);
 
         // [Safe]RefCounted as a member

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7406,21 +7406,22 @@ pure @system unittest
     foreach (MyRefCounted; AliasSeq!(SafeRefCounted, RefCounted))
     {
         MyRefCounted!int* p;
-        {
-            auto rc1 = MyRefCounted!int(5);
-            p = &rc1;
-            assert(rc1 == 5);
-            assert(rc1._refCounted._store._count == 1);
-            auto rc2 = rc1;
-            assert(rc1._refCounted._store._count == 2);
-            // Reference semantics
-            rc2 = 42;
-            assert(rc1 == 42);
-            rc2 = rc2;
-            assert(rc2._refCounted._store._count == 2);
-            rc1 = rc2;
-            assert(rc1._refCounted._store._count == 2);
-        }
+        auto rc1 = MyRefCounted!int(5);
+        p = &rc1;
+        assert(rc1 == 5);
+        assert(rc1._refCounted._store._count == 1);
+        auto rc2 = rc1;
+        assert(rc1._refCounted._store._count == 2);
+        // Reference semantics
+        rc2 = 42;
+        assert(rc1 == 42);
+        rc2 = rc2;
+        assert(rc2._refCounted._store._count == 2);
+        rc1 = rc2;
+        assert(rc1._refCounted._store._count == 2);
+        // Artificially end scope of rc1 and rc2 by calling ~this() explicitly
+        rc2.__dtor();
+        rc1.__dtor();
         assert(p._refCounted._store == null);
 
         // [Safe]RefCounted as a member

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7410,17 +7410,18 @@ pure @system unittest
         p = &rc1;
         assert(rc1 == 5);
         assert(rc1._refCounted._store._count == 1);
-        auto rc2 = rc1;
-        assert(rc1._refCounted._store._count == 2);
-        // Reference semantics
-        rc2 = 42;
-        assert(rc1 == 42);
-        rc2 = rc2;
-        assert(rc2._refCounted._store._count == 2);
-        rc1 = rc2;
-        assert(rc1._refCounted._store._count == 2);
-        // Artificially end scope of rc1 and rc2 by calling ~this() explicitly
-        rc2.__xdtor();
+        {
+            auto rc2 = rc1;
+            assert(rc1._refCounted._store._count == 2);
+            // Reference semantics
+            rc2 = 42;
+            assert(rc1 == 42);
+            rc2 = rc2;
+            assert(rc2._refCounted._store._count == 2);
+            rc1 = rc2;
+            assert(rc1._refCounted._store._count == 2);
+        }
+        // Artificially end scope of rc1 by calling ~this() explicitly
         rc1.__xdtor();
         assert(p._refCounted._store == null);
 


### PR DESCRIPTION
The access through `p` to `rc1` outside the scope of `rc1` is undefined behavior. We have to artificially end the scope of `rc1` ~~and `rc2`~~, such that within the same scope we can check that the destructor calls do the correct thing of nulling the `_store`.

@dkorpel 

Related work on LDC: https://github.com/ldc-developers/ldc/pull/4395#issuecomment-1548389374