### PR TITLE
std.path.expandTilde: make compatible with scope and preview='in'

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -3955,7 +3955,7 @@ if (isConvertibleToString!Range)
     }
     -----
 */
-string expandTilde(string inputPath) @safe nothrow
+string expandTilde(return scope const string inputPath) @safe nothrow
 {
     version (Posix)
     {
@@ -4138,7 +4138,7 @@ string expandTilde(string inputPath) @safe nothrow
 }
 
 ///
-@system unittest
+@safe unittest
 {
     version (Posix)
     {
@@ -4153,7 +4153,7 @@ string expandTilde(string inputPath) @safe nothrow
     }
 }
 
-@system unittest
+@safe unittest
 {
     version (Posix)
     {
@@ -4204,6 +4204,26 @@ string expandTilde(string inputPath) @safe nothrow
         assert(expandTilde("~Idontexist/hey") == "~Idontexist/hey");
     }
 }
+
+@safe unittest
+{
+    version (Posix)
+    {
+        import std.process : environment;
+
+        string testPath(scope const string source_path) {
+            return source_path.expandTilde;
+        }
+
+        auto oldHome = environment["HOME"];
+        scope(exit) environment["HOME"] = oldHome;
+
+        environment["HOME"] = "dmd/test";
+        assert(testPath("~/") == "dmd/test/");
+        assert(testPath("~") == "dmd/test");
+    }
+}
+
 
 version (StdUnittest)
 {


### PR DESCRIPTION
When using `expandTilde` with 'priview=in' enabled, it requires to duplicate value to be able to call this function. Within this commit the signature of expandTilde function is changed from `string expandTilde(string inputPath) @safe nothrow` to `string expandTilde(return scope const string inputPath) @safe nothrow` thus, after this commit it is possible to use this func in scope context.

Also, in this PR tests for `expandTilde` become safe.

Example case:

```d
/+ dub.sdl:
    name "dub-example"
    dflags "-preview=in" "-preview=dip1000"
+/

import std.stdio;
import std.path;

@safe:

    string fun(in string path) {
        return path.expandTilde;
    }

    void main() {
        string p = fun("~/tests/1");
        writefln("P: %s", p);
    }
```

---

PS: Not sure if it is good enough to target this on stable branch, but it seems that this change will not have side effects.