### PR TITLE
std.path.absolutePath: make compatible with scope and preview='in'

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -2745,7 +2745,7 @@ else version (Posix)
     See_Also:
         $(LREF asAbsolutePath) which does not allocate
 */
-string absolutePath(string path, lazy string base = getcwd())
+string absolutePath(return scope const string path, lazy string base = getcwd())
     @safe pure
 {
     import std.array : array;
@@ -2790,6 +2790,19 @@ string absolutePath(string path, lazy string base = getcwd())
 
     import std.exception;
     assertThrown(absolutePath("bar", "foo"));
+}
+
+// Ensure that we can call absolute path with scope paramaters
+@safe unittest
+{
+    string testAbsPath(scope const string path, scope const string base) {
+        return absolutePath(path, base);
+    }
+
+    version (Posix)
+        assert(testAbsPath("some/file", "/foo/bar")  == "/foo/bar/some/file");
+    version (Windows)
+        assert(testAbsPath(`some\file`, `c:\foo\bar`)    == `c:\foo\bar\some\file`);
 }
 
 /** Transforms `path` into an absolute path.


### PR DESCRIPTION
When using `absolutePath` with 'priview=in' enabled, it requires to duplicate value to be able to call this function. Within this commit the signature of `absolutePath` function is changed from `string absolutePath(string path, lazy string base = getcwd())` to `string absolutePath(return scope const string path, lazy string base = getcwd())` thus, after this commit it is possible to use this func in scope context.

Example case:

```d
/+ dub.sdl:
    name "dub-example"
    dflags "-preview=in" "-preview=dip1000"
+/

import std.stdio;
import std.path;

@safe:

    string fun(in string path) {
        return path.absolutePath;
    }

    void main() {
        string p = fun("~/tests/1");
        writefln("P: %s", p);
    }

```