### PR TITLE
Add std.typecons.Rebindable2 for internal use.

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1315,19 +1315,12 @@ in
 }
 do
 {
-    import std.typecons : Rebindable;
+    import std.typecons : Rebindable2;
 
     alias Element = ElementType!Range;
-    Rebindable!Element seed = r.front;
+    auto seed = Rebindable2!Element(r.front);
     r.popFront();
-    static if (is(Rebindable!Element == T[], T))
-    {
-        return extremum!(map, selector)(r, seed);
-    }
-    else
-    {
-        return extremum!(map, selector)(r, seed.get);
-    }
+    return extremum!(map, selector)(r, seed.get);
 }
 
 private auto extremum(alias map, alias selector = "a < b", Range,
@@ -1337,14 +1330,14 @@ if (isInputRange!Range && !isInfinite!Range &&
     !is(CommonType!(ElementType!Range, RangeElementType) == void) &&
      is(typeof(unaryFun!map(ElementType!(Range).init))))
 {
-    import std.typecons : Rebindable;
+    import std.typecons : Rebindable2;
 
     alias mapFun = unaryFun!map;
     alias selectorFun = binaryFun!selector;
 
     alias Element = ElementType!Range;
     alias CommonElement = CommonType!(Element, RangeElementType);
-    Rebindable!CommonElement extremeElement = seedElement;
+    auto extremeElement = Rebindable2!CommonElement(seedElement);
 
     // if we only have one statement in the loop, it can be optimized a lot better
     static if (__traits(isSame, map, a => a))
@@ -1355,7 +1348,7 @@ if (isInputRange!Range && !isInfinite!Range &&
         {
             foreach (const i; 0 .. r.length)
             {
-                if (selectorFun(r[i], extremeElement))
+                if (selectorFun(r[i], extremeElement.get))
                 {
                     extremeElement = r[i];
                 }
@@ -1365,7 +1358,7 @@ if (isInputRange!Range && !isInfinite!Range &&
         {
             while (!r.empty)
             {
-                if (selectorFun(r.front, extremeElement))
+                if (selectorFun(r.front, extremeElement.get))
                 {
                     extremeElement = r.front;
                 }
@@ -1376,7 +1369,7 @@ if (isInputRange!Range && !isInfinite!Range &&
     else
     {
         alias MapType = Unqual!(typeof(mapFun(CommonElement.init)));
-        MapType extremeElementMapped = mapFun(extremeElement);
+        MapType extremeElementMapped = mapFun(extremeElement.get);
 
         // direct access via a random access range is faster
         static if (isRandomAccessRange!Range)
@@ -1405,15 +1398,7 @@ if (isInputRange!Range && !isInfinite!Range &&
             }
         }
     }
-    // Rebindable is an alias to T for arrays
-    static if (is(typeof(extremeElement) == T[], T))
-    {
-        return extremeElement;
-    }
-    else
-    {
-        return extremeElement.get;
-    }
+    return extremeElement.get;
 }
 
 private auto extremum(alias selector = "a < b", Range)(Range r)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3902,24 +3902,17 @@ Returns:
 struct Repeat(T)
 {
 private:
-    //Store a non-qualified T when possible: This is to make Repeat assignable
-    static if ((is(T == class) || is(T == interface)) && (is(T == const) || is(T == immutable)))
-    {
-        import std.typecons : Rebindable;
-        alias UT = Rebindable!T;
-    }
-    else static if (is(T : Unqual!T) && is(Unqual!T : T))
-        alias UT = Unqual!T;
-    else
-        alias UT = T;
-    UT _value;
+    import std.typecons : Rebindable2;
+
+    // Store a rebindable T to make Repeat assignable.
+    Rebindable2!T _value;
 
 public:
     /// Range primitives
-    @property inout(T) front() inout { return _value; }
+    @property inout(T) front() inout { return _value.get; }
 
     /// ditto
-    @property inout(T) back() inout { return _value; }
+    @property inout(T) back() inout { return _value.get; }
 
     /// ditto
     enum bool empty = false;
@@ -3934,7 +3927,7 @@ public:
     @property auto save() inout { return this; }
 
     /// ditto
-    inout(T) opIndex(size_t) inout { return _value; }
+    inout(T) opIndex(size_t) inout { return _value.get; }
 
     /// ditto
     auto opSlice(size_t i, size_t j)
@@ -3959,7 +3952,12 @@ public:
 }
 
 /// Ditto
-Repeat!T repeat(T)(T value) { return Repeat!T(value); }
+Repeat!T repeat(T)(T value)
+{
+    import std.typecons : Rebindable2;
+
+    return Repeat!T(Rebindable2!T(value));
+}
 
 ///
 pure @safe nothrow unittest


### PR DESCRIPTION
`Rebindable2` is a simplified version of `std.typecons.Rebindable` that cleans up every special case: classes, arrays and structs now have the same `struct Rebindable2`.

Whichever type you instantiate `Rebindable2` with, you always get the same type out by calling `value.get` on the resulting container.

Also use this type to simplify the parts of Phobos I previously used `Rebindable` for.

This PR is the announced follow-up to https://github.com/dlang/phobos/pull/8735