### PR TITLE
fix Issue 23312 - Crash when calling writeln in WinMain

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3108,10 +3108,13 @@ is empty, throws an `Exception`. In case of an I/O error throws
                 // "wide-oriented" for us.
                 immutable int mode = __setmode(f.fileno, _O_TEXT);
                     // Set some arbitrary mode to obtain the previous one.
-                __setmode(f.fileno, mode); // Restore previous mode.
-                if (mode & (_O_WTEXT | _O_U16TEXT | _O_U8TEXT))
+                if (mode != -1) // __setmode() succeeded
                 {
-                    orientation_ = 1; // wide
+                    __setmode(f.fileno, mode); // Restore previous mode.
+                    if (mode & (_O_WTEXT | _O_U16TEXT | _O_U8TEXT))
+                    {
+                        orientation_ = 1; // wide
+                    }
                 }
             }
             else


### PR DESCRIPTION
I am not very happy with this, because stdio.d is such a confusing mess. However, the error return from __setmode() is not checked for, which is clearly wrong.

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170