### PR TITLE
Fix issue 23976: std.range.slide fails in dmd-2.104.0

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -9115,7 +9115,7 @@ public:
         {
             static if (needsEndTracker)
             {
-                if (poppedElems < windowSize)
+                if (nextSource.empty)
                     hasShownPartialBefore = true;
             }
             else
@@ -10093,6 +10093,15 @@ public:
     import std.algorithm.iteration : splitter;
 
     assert("ab cd".splitter(' ').slide!(No.withPartial)(2).equal!equal([["ab", "cd"]]));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23976
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.algorithm.iteration : splitter;
+
+    assert("1<2".splitter('<').slide(2).equal!equal([["1", "2"]]));
 }
 
 private struct OnlyResult(Values...)


### PR DESCRIPTION
I think possibly `hasShownPartialBefore` is just simply wrongly named in the `withPartial` branch.