### PR TITLE
[std/traits] Improve getSymbolsByUDA test

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -8877,7 +8877,9 @@ template getSymbolsByUDA(alias symbol, alias attribute)
         @Attr void c();
     }
 
-    static assert(getSymbolsByUDA!(A, Attr).stringof == "tuple(a, a, c)");
+    alias ola = __traits(getOverloads, A, "a");
+    static assert(__traits(isSame, getSymbolsByUDA!(A, Attr),
+        AliasSeq!(ola[0], ola[1], A.c)));
 }
 
 // getSymbolsByUDA no longer works on modules


### PR DESCRIPTION
Don't rely on result `.stringof`, which also failed to check each overload of `a` was present.

This is also necessary for https://github.com/dlang/dmd/pull/15363.