### PR TITLE
merge stable

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1342,7 +1342,6 @@ if (isInputRange!Range && !isInfinite!Range &&
     // if we only have one statement in the loop, it can be optimized a lot better
     static if (__traits(isSame, map, a => a))
     {
-
         // direct access via a random access range is faster
         static if (isRandomAccessRange!Range)
         {
@@ -3863,6 +3862,14 @@ if (isInputRange!Range && !isInfinite!Range &&
     const(B)[] arr = [new B(0), new B(1)];
     // can't compare directly - https://issues.dlang.org/show_bug.cgi?id=1824
     assert(arr.maxElement!"a.val".val == 1);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23993
+@safe unittest
+{
+    import std.bigint : BigInt;
+
+    assert([BigInt(2), BigInt(3)].maxElement == BigInt(3));
 }
 
 // minPos

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -9142,7 +9142,7 @@ public:
         {
             static if (needsEndTracker)
             {
-                if (poppedElems < windowSize)
+                if (nextSource.empty)
                     hasShownPartialBefore = true;
             }
             else
@@ -10120,6 +10120,15 @@ public:
     import std.algorithm.iteration : splitter;
 
     assert("ab cd".splitter(' ').slide!(No.withPartial)(2).equal!equal([["ab", "cd"]]));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23976
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.algorithm.iteration : splitter;
+
+    assert("1<2".splitter('<').slide(2).equal!equal([["1", "2"]]));
 }
 
 private struct OnlyResult(Values...)


### PR DESCRIPTION
- Fix issue 23993: Discard Rebindable before passing extremum to comparator.
- Fix issue 23976: std.range.slide fails in dmd-2.104.0 I think possibly `hasShownPartialBefore` is just simply wrongly named in the `withPartial` branch.
