### PR TITLE
Add `toJSONValue` function for converting arbitrary data structures to JSONValue

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1761,7 +1761,7 @@ if (isOutputRange!(Out,char))
 /**
 Determines if the given type may be serialized into JSON. This includes both
 primitive values like numbers, strings, and booleans, as well as arrays and
-composite types like associative arrays, structs, and classes.
+composite types like associative arrays and POD-style structs.
 */
 bool isJSONSerializable(T)() {
     static if (is(T : void) || isPointer!T) {


### PR DESCRIPTION
One thing that pretty much most JSON libs out there have, is some way to generate JSON from the language's own data and structures. I think such functionality should be provided by Phobos' implementation, so that developers don't need to pull in a third-party lib just for that.

I haven't put too much time into fleshing out the scope of what sort of values are acceptable to serialize to JSON (nullables, any range? I don't know yet), but what I've put up initially can be considered a proof-of-concept.

Also, the reverse action may be desired: converting a JSONValue to a particular data structure. However, that can be added in a separate PR if this one is deemed as satisfactory.