### PR TITLE
Fix unsafe union access in std.regex and std.uni

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -1045,7 +1045,7 @@ if (!hasElaborateDestructor!T)
         return isBig ? big.ptr[0 .. length] : small[0 .. length];
     }
 
-    this(this)
+    this(this) @trusted
     {
         if (isBig)
         {

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -7697,6 +7697,15 @@ public:
             static assert(false, "No operation "~op~" defined for Grapheme");
     }
 
+    // This is not a good `opEquals`, but formerly the automatically generated
+    // opEquals was used, which was inferred `@safe` because of bugzilla 20655:
+    // https://issues.dlang.org/show_bug.cgi?id=20655
+    // This `@trusted opEquals` is only here to prevent breakage.
+    bool opEquals(R)(const auto ref R other) const @trusted
+    {
+        return this.tupleof == other.tupleof;
+    }
+
     /++
         True if this object contains valid extended grapheme cluster.
         Decoding primitives of this module always return a valid `Grapheme`.


### PR DESCRIPTION
Similar to https://github.com/dlang/phobos/pull/8786, trying to unblock [dlang/dmd#14827](https://github.com/dlang/dmd/pull/14827) by removing Phobos' reliance on overlapped pointer access in `@safe` code.