### PR TITLE
Use size_t instead of uint for data indexing, because it hangs with f…

### DIFF
--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -295,7 +295,8 @@ struct MD5
          */
         void put(scope const(ubyte)[] data...) @trusted pure nothrow @nogc
         {
-            uint i, index, partLen;
+            size_t i;
+            uint index, partLen;
             auto inputLen = data.length;
 
             //Compute number of bytes mod 64


### PR DESCRIPTION
…iles > 4g on x64