### PR TITLE
std.stdio: remove redundant version declarations

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -122,17 +122,12 @@ alias KeepTerminator = Flag!"keepTerminator";
 
 version (CRuntime_Microsoft)
 {
-    version = MICROSOFT_STDIO;
 }
 else version (CRuntime_DigitalMars)
 {
-    // Specific to the way Digital Mars C does stdio
-    version = DIGITAL_MARS_STDIO;
 }
 else version (CRuntime_Glibc)
 {
-    // Specific to the way Gnu C does stdio
-    version = GCC_IO;
 }
 else version (CRuntime_Bionic)
 {
@@ -220,7 +215,7 @@ version (Posix)
     static import core.sys.posix.stdio; // getdelim, flockfile
 }
 
-version (DIGITAL_MARS_STDIO)
+version (CRuntime_DigitalMars)
 {
     private alias _FPUTC = _fputc_nlock;
     private alias _FPUTWC = _fputwc_nlock;
@@ -229,7 +224,7 @@ version (DIGITAL_MARS_STDIO)
     private alias _FLOCK = __fp_lock;
     private alias _FUNLOCK = __fp_unlock;
 
-    // Alias for MICROSOFT_STDIO compatibility.
+    // Alias for CRuntime_Microsoft compatibility.
     // @@@DEPRECATED_2.107@@@
     // Rename this back to _setmode once the deprecation phase has ended.
     private alias __setmode = setmode;
@@ -267,7 +262,7 @@ version (DIGITAL_MARS_STDIO)
                ~ "std.stdio and will be removed afer 2.107")
     fileno_t _fileno(FILE* f) { return f._file; }
 }
-else version (MICROSOFT_STDIO)
+else version (CRuntime_Microsoft)
 {
     private alias _FPUTC = _fputc_nolock;
     private alias _FPUTWC = _fputwc_nolock;
@@ -277,7 +272,7 @@ else version (MICROSOFT_STDIO)
     private alias _FUNLOCK = _unlock_file;
 
     // @@@DEPRECATED_2.107@@@
-    // Remove this once the deprecation phase for DIGITAL_MARS_STDIO has ended.
+    // Remove this once the deprecation phase for CRuntime_DigitalMars has ended.
     private alias __setmode = _setmode;
 
     // @@@DEPRECATED_2.107@@@
@@ -305,7 +300,7 @@ else version (MICROSOFT_STDIO)
                ~ "std.stdio and will be removed afer 2.107")
     alias FUNLOCK = _unlock_file;
 }
-else version (GCC_IO)
+else version (CRuntime_Glibc)
 {
     private alias _FPUTC = fputc_unlocked;
     private alias _FPUTWC = fputwc_unlocked;
@@ -419,7 +414,7 @@ private extern (C) @nogc nothrow
 {
     pragma(mangle, _FPUTC.mangleof) int trustedFPUTC(int ch, _iobuf* h) @trusted;
 
-    version (DIGITAL_MARS_STDIO)
+    version (CRuntime_DigitalMars)
         pragma(mangle, _FPUTWC.mangleof) int trustedFPUTWC(int ch, _iobuf* h) @trusted;
     else
         pragma(mangle, _FPUTWC.mangleof) int trustedFPUTWC(wchar_t ch, _iobuf* h) @trusted;
@@ -598,7 +593,7 @@ Throws: `ErrnoException` if the file could not be opened.
                 name);
 
         // MSVCRT workaround (https://issues.dlang.org/show_bug.cgi?id=14422)
-        version (MICROSOFT_STDIO)
+        version (CRuntime_Microsoft)
         {
             setAppendWin(stdioOpenmode);
         }
@@ -726,7 +721,7 @@ Throws: `ErrnoException` in case of error.
         }
         _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
         initImpl(handle, name, 1, isPopened);
-        version (MICROSOFT_STDIO)
+        version (CRuntime_Microsoft)
         {
             setAppendWin(stdioOpenmode);
         }
@@ -761,7 +756,7 @@ Throws: `ErrnoException` in case of error.
         }
     }
 
-    version (MICROSOFT_STDIO)
+    version (CRuntime_Microsoft)
     {
         private void setAppendWin(scope const(char)[] stdioOpenmode) @safe
         {
@@ -894,7 +889,7 @@ Params:
         auto modez = stdioOpenmode.tempCString();
         detach();
 
-        version (DIGITAL_MARS_STDIO)
+        version (CRuntime_DigitalMars)
         {
             // This is a re-implementation of DMC's fdopen, but without the
             // mucking with the file descriptor.  POSIX standard requires the
@@ -945,7 +940,7 @@ Throws: `ErrnoException` in case of error.
         import std.format : format;
 
         // Create file descriptors from the handles
-        version (DIGITAL_MARS_STDIO)
+        version (CRuntime_DigitalMars)
             auto fd = _handleToFD(handle, FHND_DEVICE);
         else // MSVCRT
         {
@@ -1190,7 +1185,7 @@ Throws: `ErrnoException` if the file is not opened or the call to `fread` fails.
             immutable fileno_t fd = .fileno(_p.handle);
             immutable mode = .__setmode(fd, _O_BINARY);
             scope(exit) .__setmode(fd, mode);
-            version (DIGITAL_MARS_STDIO)
+            version (CRuntime_DigitalMars)
             {
                 import core.atomic : atomicOp;
 
@@ -1288,7 +1283,7 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
                 .__setmode(fd, _O_BINARY);
             }
 
-            version (DIGITAL_MARS_STDIO)
+            version (CRuntime_DigitalMars)
             {
                 import core.atomic : atomicOp;
 
@@ -2351,7 +2346,7 @@ Returns the underlying operating system `HANDLE` (Windows only).
     version (Windows)
     @property HANDLE windowsHandle()
     {
-        version (DIGITAL_MARS_STDIO)
+        version (CRuntime_DigitalMars)
             return _fdToHandle(fileno);
         else
             return cast(HANDLE)_get_osfhandle(fileno);
@@ -3147,7 +3142,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
             file_ = f;
             FILE* fps = f._p.handle;
 
-            version (MICROSOFT_STDIO)
+            version (CRuntime_Microsoft)
             {
                 // Microsoft doesn't implement fwide. Instead, there's the
                 // concept of ANSI/UNICODE mode. fputc doesn't work in UNICODE
@@ -3388,7 +3383,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
         {
             fileno_t fd;
             int oldMode;
-            version (DIGITAL_MARS_STDIO)
+            version (CRuntime_DigitalMars)
                 ubyte oldInfo;
         }
 
@@ -3410,7 +3405,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
                 .fflush(fps); // before changing translation mode
                 fd = .fileno(fps);
                 oldMode = .__setmode(fd, _O_BINARY);
-                version (DIGITAL_MARS_STDIO)
+                version (CRuntime_DigitalMars)
                 {
                     import core.atomic : atomicOp;
 
@@ -3431,7 +3426,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
             version (Windows)
             {
                 .fflush(fps); // before restoring translation mode
-                version (DIGITAL_MARS_STDIO)
+                version (CRuntime_DigitalMars)
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=4243
                     __fhnd_info[fd] = oldInfo;
@@ -3889,7 +3884,7 @@ void main()
         return setlocale(LC_CTYPE, loc.ptr).fromStringz.endsWith(loc);
     });
     scope(exit) () @trusted { setlocale(LC_CTYPE, oldCt); } ();
-    version (DIGITAL_MARS_STDIO) // DM can't handle Unicode above U+07FF.
+    version (CRuntime_DigitalMars) // DM can't handle Unicode above U+07FF.
     {
         alias strs = AliasSeq!("xä\u07FE", "yö\u07FF"w);
     }
@@ -3899,7 +3894,7 @@ void main()
     }
     {
         auto f = File(deleteme, "w");
-        version (MICROSOFT_STDIO)
+        version (CRuntime_Microsoft)
         {
             () @trusted { __setmode(fileno(f.getFP()), _O_U8TEXT); } ();
         }
@@ -5539,7 +5534,7 @@ private struct LockedFile
 // Private implementation of readln
 private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orientation orientation) @safe
 {
-    version (DIGITAL_MARS_STDIO)
+    version (CRuntime_DigitalMars)
     return () @trusted {
         auto lf = LockedFile(fps);
         ReadlnAppender app;
@@ -5652,7 +5647,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
         buf = app.data;
         return buf.length;
     }();
-    else version (MICROSOFT_STDIO)
+    else version (CRuntime_Microsoft)
     {
         auto lf = LockedFile(fps);
 


### PR DESCRIPTION
These just confuse things.