### PR TITLE
Remove Allman checks from grep lints as DScanner covers these.

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -118,7 +118,13 @@ trust_too_much="enabled"
 ; Check for uses of the old-style alias syntax
 alias_syntax_check="-std.traits,-std.typecons"
 ; Check allman brace style
-allman_braces_check="+disabled"
+allman_braces_check="-etc.c.curl,\
+-etc.c.sqlite3,\
+-etc.c.zlib,\
+-etc.c.odbc.sql,\
+-etc.c.odbc.sqlext,\
+-etc.c.odbc.sqltypes,\
+-etc.c.odbc.sqlucode"
 ; Checks for confusing code in inline asm statements
 asm_style_check="-std.math"
 ; Check for asserts without an explanatory message

--- a/posix.mak
+++ b/posix.mak
@@ -602,12 +602,6 @@ style_lint_shellcmds:
 	@echo "Check for package wide std.algorithm imports"
 	grep -nr 'import std.algorithm : ' $$(find etc std -name '*.d') ; test $$? -eq 1
 
-	@echo "Enforce Allman style"
-	grep -nrE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$$' $$(find etc std -name '*.d'); test $$? -eq 1
-
-	@echo "Enforce do { to be in Allman style"
-	grep -nr 'do *{$$' $$(find etc std -name '*.d') ; test $$? -eq 1
-
 	@echo "Enforce no space between assert and the opening brace, i.e. assert("
 	grep -nrE 'assert +\(' $$(find etc std -name '*.d') ; test $$? -eq 1
 


### PR DESCRIPTION
@thewilsonator As requested.