### PR TITLE
DRAFT: Json5 for std.json

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -1170,6 +1170,45 @@ if (isSomeFiniteCharInputRange!T)
         return val;
     }
 
+	string parseJson5Identifier() {
+		static const reservedKeywords = [ "break", "do", "instanceof", "typeof"
+			, "case", "else", "new", "var"
+			, "catch", "finally", "return", "void"
+			, "continue", "for", "switch", "while"
+			, "debugger", "function", "this", "with"
+			, "default", "if", "throw"
+			, "delete", "in", "try"
+			
+			, "class", "enum", "extends", "super"
+			, "const", "export", "import"
+			
+			, "implements", "let", "private", "public", "yield"
+			, "interface", "package", "protected", "static"
+		];
+
+		auto app = appender!string();
+
+		Nullable!Char c = peekCharNullable();
+		while(!c.isNull()) {
+			Char cnn = c.get();
+			if(isWhite(cnn) || cnn == ':') {
+				break;
+			}
+			app.put(cnn);
+			c.nullify();
+			getChar();
+			c = peekCharNullable();
+		}
+
+		foreach(it; reservedKeywords) {
+			if(app.data() == it) {
+                throw new JSONException("The reserved keyword '"
+						~ it ~ "' can not be used as an identifier");
+			}
+		}
+		return app.data();
+	}
+
     string parseString()
     {
         import std.uni : isSurrogateHi, isSurrogateLo;
@@ -1288,8 +1327,12 @@ if (isSomeFiniteCharInputRange!T)
                     {
                         break;
                     }
-                    checkChar('"');
-                    string name = parseString();
+					string name;
+					if(testChar('"')) {
+                    	name = parseString();
+					} else {
+						name = parseJson5Identifier();
+					}
                     checkChar(':');
                     JSONValue member;
                     parseValue(member);
@@ -2546,6 +2589,39 @@ pure nothrow @safe unittest
     JSONValue j = parseJSON(s);
 	JSONValue* a = "a" in j;
 	assert(a !is null, "No 'a' found");
+	assert(a.type == JSONType.integer, "A not an integer but " 
+			~ to!string(a.type));
+	assert(a.integer() == 10, "A is not 10 but " ~ to!string(a.integer()));
+}
+
+// JSON5 identifier
+@safe unittest {
+	string s = `{ a : 10 } `;
+    JSONValue j = parseJSON(s);
+	JSONValue* a = "a" in j;
+	assert(a !is null, "No 'a' found");
+	assert(a.type == JSONType.integer, "A not an integer but " 
+			~ to!string(a.type));
+	assert(a.integer() == 10, "A is not 10 but " ~ to!string(a.integer()));
+}
+
+// JSON5 identifier
+@safe unittest {
+	string s = `{ $a : 10 } `;
+    JSONValue j = parseJSON(s);
+	JSONValue* a = "$a" in j;
+	assert(a !is null, "No '$a' found");
+	assert(a.type == JSONType.integer, "A not an integer but " 
+			~ to!string(a.type));
+	assert(a.integer() == 10, "A is not 10 but " ~ to!string(a.integer()));
+}
+
+// JSON5 identifier
+@safe unittest {
+	string s = `{ ßßüöäÄöPl : 10 } `;
+    JSONValue j = parseJSON(s);
+	JSONValue* a = "ßßüöäÄöPl" in j;
+	assert(a !is null, "No 'ßßüöäÄöPl' found");
 	assert(a.type == JSONType.integer, "A not an integer but " 
 			~ to!string(a.type));
 	assert(a.integer() == 10, "A is not 10 but " ~ to!string(a.integer()));


### PR DESCRIPTION
This PR adds Json5 support to std.json.

done:
* single tick strings
* json5 identifier
* single line comments //
* multi line comments /*
* multi line strings

todo:
* Numbers may be hexadecimal.
* Numbers may have a leading or trailing decimal point.
* Numbers may be [IEEE 754](http://ieeexplore.ieee.org/servlet/opac?punumber=4610933) positive infinity, negative infinity, and NaN.
* Numbers may begin with an explicit plus sign.

