### PR TITLE
Simplify endian conversion functions in std.bitmanip.

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3131,7 +3131,7 @@ auto nativeToLittleEndian(T)(const T val) @trusted pure nothrow @nogc
 if (canSwapEndianness!T)
 {
     static if (isFloatOrDouble!T)
-        return nativeToLittleEndian(*cast(const UnsignedOfSize!(T.sizeof)*)&val);
+        return nativeToLittleEndian(*cast(const UnsignedOfSize!(T.sizeof)*) &val);
     else
     {
         enum len = T.sizeof;
@@ -3151,9 +3151,21 @@ if (canSwapEndianness!T)
     ubyte[4] swappedI = nativeToLittleEndian(i);
     assert(i == littleEndianToNative!int(swappedI));
 
+    float f = 123.45f;
+    ubyte[4] swappedF = nativeToLittleEndian(f);
+    assert(f == littleEndianToNative!float(swappedF));
+
+    const float cf = 123.45f;
+    ubyte[4] swappedCF = nativeToLittleEndian(cf);
+    assert(cf == littleEndianToNative!float(swappedCF));
+
     double d = 123.45;
     ubyte[8] swappedD = nativeToLittleEndian(d);
     assert(d == littleEndianToNative!double(swappedD));
+
+    const double cd = 123.45;
+    ubyte[8] swappedCD = nativeToLittleEndian(cd);
+    assert(cd == littleEndianToNative!double(swappedCD));
 }
 
 @safe unittest


### PR DESCRIPTION
They're overly complex (e.g. testing for the native endianness of the machine when that's actually completely unnecessary), and they use unions in a manner that is undefined behavior in C/C++ (since they write to one field and then read from another). I don't see any mention of whether that behavior is defined in D in D's spec, but it's probably undefined in D given that it's undefined in C/C++. Either way, it's an overly complex solution.

This solution gets rid of all of the endian version checks in std.bitmanip, and it allows the implementations of the endian conversion functions to be the same between CTFE and runtime.

@atilaneves Assuming that I didn't screw up the implementation somehow, this should be much more to your liking than what's been here. Either way, it results in a lot less code to be screwed up. :)