### PR TITLE
show that chomp doesn't remove spaces in example

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -3815,6 +3815,7 @@ unittest
     assert(chomp(" hello world  \n\n" ~ [lineSep]) == " hello world  \n\n");
     assert(chomp(" hello world  \n\n" ~ [paraSep]) == " hello world  \n\n");
     assert(chomp(" hello world  \n\n" ~ [ nelSep]) == " hello world  \n\n");
+    assert(chomp(" hello world ") == " hello world ");
     assert(chomp(" hello world") == " hello world");
     assert(chomp("") == "");
 


### PR DESCRIPTION
It was written in the docs, but I think the example shows it more clearly and doesn't require the user to test it if in doubt anymore.