### PR TITLE
Add `thisExeDir()` function

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -16,6 +16,7 @@ $(TR $(TD General) $(TD
           $(LREF isFile)
           $(LREF isSymlink)
           $(LREF rename)
+          $(LREF thisExeDir)
           $(LREF thisExePath)
 ))
 $(TR $(TD Directories) $(TD
@@ -3632,6 +3633,32 @@ else version (Posix) string getcwd() @trusted
     assert(path.exists);
     assert(path.isAbsolute);
     assert(path.isFile);
+}
+
+/**
+ * Returns the full path to the directory containing the current executable.
+ *
+ * Returns:
+ *     The path of the directory as a `string`.
+ *
+ * Throws:
+ * $(REF1 Exception, object)
+ */
+@safe string thisExeDir()
+{
+    import std.path : dirName;
+    return dirName(thisExePath());
+}
+
+///
+@safe unittest
+{
+    import std.path : isAbsolute;
+    auto dir = thisExeDir();
+
+    assert(dir.exists);
+    assert(dir.isAbsolute);
+    assert(dir.isDir);
 }
 
 version (StdDdoc)


### PR DESCRIPTION
`thisExeDir()` returns the path of the directory of the current executable.

To me such a function has been quite useful and I’ve copy and pasted it this helper function into many of my codebases since I originally wrote it [in 2018](https://github.com/analogjupiter/DaReal2/blob/0bef4ed00e9109a8800591f828a893891bc3f03a/source/dareal/util/path.d#L14). My usual use-case is building paths relative to the executable.

Having a ready-to-use function providing only the directory path is significantly more convenient than having to extract the dir name from `thisExePath` at the time of use in my own code. Imho the advantage is that the user doesn’t have to think about *how* to get the directory from the file path.

```d
string myPath = thisExePath.dirName().buildPath(/* … */);
// vs.
string myPath = thisExeDir.buildPath(/* … */);
```