### PR TITLE
make std.parallelism.AbstractTask inaccessible

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -418,8 +418,8 @@ Bugs:  Changes to `ref` and `out` arguments are not propagated to the
 */
 struct Task(alias fun, Args...)
 {
-    AbstractTask base = {runTask : &impl};
-    alias base this;
+    private AbstractTask base = {runTask : &impl};
+    private alias base this;
 
     private @property AbstractTask* basePtr()
     {


### PR DESCRIPTION
No valid code should be using these members, they are thread-unsafe.

Note, this appears to have been changed to public to workaround some compiler issue, but the PR doesn't seem to be real: https://github.com/dlang/phobos/commit/9d151ac1f9e45d4d57a0b74508b41b303a6a293d