### PR TITLE
Add Unshared to std.traits.

### DIFF
--- a/changelog/unshared.dd
+++ b/changelog/unshared.dd
@@ -1,0 +1,13 @@
+Add Unshared to std.traits.
+
+`Unshared` is the `shared` equivalent of `Unconst`. It strips off the outer
+layer of `shared` from a type. e.g.
+
+```
+    static assert(Unshared!(shared int) == int);
+    static assert(Unshared!(shared(int[])) == shared(int)[]);
+```
+
+So, `Unconst` strips off the outer layer of `const`, `immutable`, and `inout`;
+`Unshared` strips off the outer layer of `shared`; and `Unqual` strips off all
+qualifiers from the outer layer of a type.

--- a/std/traits.d
+++ b/std/traits.d
@@ -132,6 +132,7 @@
  *           $(LREF PointerTarget)
  *           $(LREF Signed)
  *           $(LREF Unconst)
+ *           $(LREF Unshared)
  *           $(LREF Unqual)
  *           $(LREF Unsigned)
  *           $(LREF ValueType)
@@ -7846,6 +7847,46 @@ else
 
     alias ImmIntArr = immutable(int[]);
     static assert(is(Unconst!ImmIntArr == immutable(int)[]));
+}
+
+/++
+    Removes `shared` qualifier, if any, from type `T`.
+
+    Note that while `immutable` is implicitly `shared`, it is unaffected by
+    Unshared. Only explict `shared` is removed.
+  +/
+template Unshared(T)
+{
+    static if (is(T == shared U, U))
+        alias Unshared = U;
+    else
+        alias Unshared = T;
+}
+
+///
+@safe unittest
+{
+    static assert(is(Unshared!int == int));
+    static assert(is(Unshared!(const int) == const int));
+    static assert(is(Unshared!(immutable int) == immutable int));
+
+    static assert(is(Unshared!(shared int) == int));
+    static assert(is(Unshared!(shared(const int)) == const int));
+
+    static assert(is(Unshared!(shared(int[])) == shared(int)[]));
+}
+
+@safe unittest
+{
+    static assert(is(Unshared!(                   int) == int));
+    static assert(is(Unshared!(             const int) == const int));
+    static assert(is(Unshared!(       inout       int) == inout int));
+    static assert(is(Unshared!(       inout const int) == inout const int));
+    static assert(is(Unshared!(shared             int) == int));
+    static assert(is(Unshared!(shared       const int) == const int));
+    static assert(is(Unshared!(shared inout       int) == inout int));
+    static assert(is(Unshared!(shared inout const int) == inout const int));
+    static assert(is(Unshared!(         immutable int) == immutable int));
 }
 
 version (StdDdoc)


### PR DESCRIPTION
This is the shared equivalent of Unconst. It allows code to strip off shared without stripping off const.