### PR TITLE
Add missing log function

### DIFF
--- a/std/logger/package.d
+++ b/std/logger/package.d
@@ -54,6 +54,7 @@ $(UL
     $(LI `trace`)
     $(LI `info`)
     $(LI `warning`)
+    #(LI `error`)
     $(LI `critical`)
     $(LI `fatal`)
 )


### PR DESCRIPTION
Error was missing from the documentation here.