### PR TITLE
docs(std.logger.package): Fix ddoc macro typo in "Basic Logging" section

### DIFF
--- a/std/logger/package.d
+++ b/std/logger/package.d
@@ -54,7 +54,7 @@ $(UL
     $(LI `trace`)
     $(LI `info`)
     $(LI `warning`)
-    #(LI `error`)
+    $(LI `error`)
     $(LI `critical`)
     $(LI `fatal`)
 )


### PR DESCRIPTION
Fixes the typo made in #8846.