### PR TITLE
Make Nullable(T, T value) conform to Nullable(T)

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4530,12 +4530,6 @@ Returns:
     ni = 0;
     assertNotThrown!Throwable(ni == 0);
 }
-
-/**
-Implicitly converts to `T`.
-`this` must not be in the null state.
- */
-    alias get this;
 }
 
 /// ditto


### PR DESCRIPTION
A while back `alias get this` was removed from the other nullable implementations. It seems this one was missed. Part of the point of a nullable struct is to disarm a segfault footgun by hiding the possibility of null behind the type system. The alias this statement subverts this entirely. Worse, its only for the one overload.