### PR TITLE
Update math.algebraic.d#abs to return correct integral type

### DIFF
--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -43,10 +43,10 @@ import std.traits : CommonType, isFloatingPoint, isIntegral, isSigned, Unqual;
  *     the return type will be the same as the input.
  *
  * Limitations:
- *     When x is a signed integral equal to `Num`.min the value of x will be returned instead.
- *     Note for 2's complement; -`Num`.min (= `Num`.max + 1) is not representable due to overflow.
+ *     When x is a signed integral equal to `Num.min` the value of x will be returned instead.
+ *     Note for 2's complement; `-Num.min` (= `Num.max + 1`) is not representable due to overflow.
  */
-auto abs(Num)(Num x) @nogc pure nothrow
+auto abs(Num)(Num x) @nogc nothrow pure
 if (isIntegral!Num || (is(typeof(Num.init >= 0)) && is(typeof(-Num.init))))
 {
     static if (isFloatingPoint!(Num))

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -43,7 +43,8 @@ import std.traits : CommonType, isFloatingPoint, isIntegral, isSigned, Unqual;
  *     the return type will be the same as the input.
  *
  * Limitations:
- *     Does not work correctly for value `Num`.min.
+ *     When x is a signed integral equal to `Num`.min the value of x will be returned instead.
+ *     Note for 2's complement; -`Num`.min (= `Num`.max + 1) is not representable due to overflow.
  */
 auto abs(Num)(Num x) @nogc pure nothrow
 if (isIntegral!Num || (is(typeof(Num.init >= 0)) && is(typeof(-Num.init))))

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -74,14 +74,22 @@ if (isIntegral!Num || (is(typeof(Num.init >= 0)) && is(typeof(-Num.init))))
 
 @safe pure nothrow @nogc unittest
 {
-    assert(abs(byte(-8)) == 8 && is(typeof(abs(byte(-8))) == byte));
-    assert(abs(ubyte(8u)) == 8 && is(typeof(abs(ubyte(8u))) == ubyte));
-    assert(abs(short(-8)) == 8 && is(typeof(abs(short(-8))) == short));
-    assert(abs(ushort(8u)) == 8 && is(typeof(abs(ushort(8u))) == ushort));
-    assert(abs(int(-8)) == 8 && is(typeof(abs(int(-8))) == int));
-    assert(abs(uint(8u)) == 8 && is(typeof(abs(uint(8u))) == uint));
-    assert(abs(long(-8)) == 8 && is(typeof(abs(long(-8))) == long));
-    assert(abs(ulong(8u)) == 8 && is(typeof(abs(ulong(8u))) == ulong));
+    assert(abs(byte(-8)) == 8);
+    assert(abs(ubyte(8u)) == 8);
+    assert(abs(short(-8)) == 8);
+    assert(abs(ushort(8u)) == 8);
+    assert(abs(int(-8)) == 8);
+    assert(abs(uint(8u)) == 8);
+    assert(abs(long(-8)) == 8);
+    assert(abs(ulong(8u)) == 8);
+    assert(is(typeof(abs(byte(-8))) == byte));
+    assert(is(typeof(abs(ubyte(8u))) == ubyte));
+    assert(is(typeof(abs(short(-8))) == short));
+    assert(is(typeof(abs(ushort(8u))) == ushort));
+    assert(is(typeof(abs(int(-8))) == int));
+    assert(is(typeof(abs(uint(8u))) == uint));
+    assert(is(typeof(abs(long(-8))) == long));
+    assert(is(typeof(abs(ulong(8u))) == ulong));
 }
 
 @safe pure nothrow @nogc unittest


### PR DESCRIPTION
The documentation states the return type for an argument of integral types (assuming under phobos: (u)byte,short,int,long) should equal its own type.

Under current implementation this is not the case. Exemptions are made for short and byte.
Using `isIntegral` instead yields the correct behavior, also for unsigned types (which simply return themselves).