### PR TITLE
Makefile: Compile zlib .c files with DMD via importC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,58 +101,27 @@ else
 	DRUNTIME = $(DRUNTIME_PATH)/../generated/$(OS)/$(BUILD)/$(MODEL)/druntime.lib
 endif
 
-# Set CC and DMD
+# Set DMD
 ifeq ($(OS),win32wine)
-	CC = wine dmc.exe
 	DMD = wine dmd.exe
 	RUN = wine
 else
 	DMD = $(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE)
-	ifeq ($(MODEL),32omf)
-		CC = dmc
-	else ifeq ($(OS),windows)
-		CC = cl.exe
-	else
-		CC = cc
-	endif
 	RUN =
 endif
 
-# Set CFLAGS
-OUTFILEFLAG = -o
+# Set extra CFLAGS (for DMD - the zlib .c files are compiled via importC)
 NODEFAULTLIB=-defaultlib= -debuglib=
+CFLAGS=-P=-Ietc/c/zlib
 ifeq (,$(findstring win,$(OS)))
-	CFLAGS=$(MODEL_FLAG) -fPIC -std=c11 -DHAVE_UNISTD_H
+	CFLAGS += -P=-DHAVE_UNISTD_H
 # Bundled with the system library on OSX, and doesn't work with >= MacOS 11
 	ifneq (osx,$(OS))
 		NODEFAULTLIB += -L-lpthread -L-lm
 	endif
-	ifeq ($(BUILD),debug)
-		CFLAGS += -g
-	else
-		CFLAGS += -O3
-	endif
 else
 	ifeq ($(MODEL),32omf)
-		CFLAGS=-DNO_snprintf
-		ifeq ($(BUILD),debug)
-			CFLAGS += -g
-		else
-			CFLAGS += -O
-		endif
-	else # win64/win32coff
-		OUTFILEFLAG = /Fo
-		CFLAGS += /nologo /Zl /GS-
-		ifeq ($(BUILD),debug)
-			CFLAGS += /Z7
-		else
-			CFLAGS += /O2
-		endif
-	endif
-endif
-ifeq (osx,$(OS))
-	ifeq (64,$(MODEL))
-		CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+		CFLAGS += -P=-DNO_snprintf
 	endif
 endif
 
@@ -351,8 +320,7 @@ lib: $(LIB)
 dll: $(ROOT)/libphobos2.so
 
 $(ROOT)/%$(DOTOBJ): %.c
-	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
-	$(CC) -c $(CFLAGS) $< $(OUTFILEFLAG)$@
+	$(DMD) -c $(DFLAGS) $(CFLAGS) -of$@ $<
 
 $(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)


### PR DESCRIPTION
Depends on https://github.com/dlang/phobos/pull/8862.

According to earlier CI results, this works - except for a problem on Win64 only:
```
phobos64.lib(gzwrite.obj) : error LNK2019: unresolved external symbol __va_start referenced in function gzprintf
```

So looks like this `__va_start` could be a candidate for inclusion in druntime's `__builtins.di` (which already defines a `__builtin_va_start` alias).