### PR TITLE
[std.datetime] Tweak docs

### DIFF
--- a/std/datetime/package.d
+++ b/std/datetime/package.d
@@ -12,6 +12,7 @@
     $(TR
         $(TD Points in Time)
         $(TD
+            $(REF_ALTTEXT Clock, Clock, std, datetime, systime)$(NBSP)
             $(REF_ALTTEXT Date, Date, std, datetime, date)$(NBSP)
             $(REF_ALTTEXT TimeOfDay, TimeOfDay, std, datetime, date)$(NBSP)
             $(REF_ALTTEXT DateTime, DateTime, std, datetime, date)$(NBSP)
@@ -19,7 +20,7 @@
         )
     )
     $(TR
-        $(TD Timezones)
+        $(TD $(MREF_ALTTEXT Timezones, std, datetime, timezone))
         $(TD
             $(REF_ALTTEXT TimeZone, TimeZone, std, datetime, timezone)$(NBSP)
             $(REF_ALTTEXT UTC, UTC, std, datetime, timezone)$(NBSP)
@@ -38,7 +39,7 @@
         )
     )
     $(TR
-        $(TD Durations of Time)
+        $(TD $(MREF_ALTTEXT Durations of Time, core, time))
         $(TD
             $(REF_ALTTEXT Duration, Duration, core, time)$(NBSP)
             $(REF_ALTTEXT weeks, weeks, core, time)$(NBSP)
@@ -62,7 +63,7 @@
     )
     ))
 
-    This functionality is separated into the following modules
+    This functionality is separated into the following modules:
 
     $(UL
         $(LI $(MREF std, datetime, date) for points in time without timezones.)
@@ -73,6 +74,7 @@
     )
 
     See_Also:
+        $(MREF core, time)$(BR)
         $(DDLINK intro-to-datetime, Introduction to std.datetime,
                  Introduction to std&#46;datetime)<br>
         $(HTTP en.wikipedia.org/wiki/ISO_8601, ISO 8601)<br>
@@ -87,7 +89,7 @@
 +/
 module std.datetime;
 
-/// Get the current time from the system clock
+/// Get the current time from the system clock.
 @safe unittest
 {
     import std.datetime.systime : SysTime, Clock;

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -9685,7 +9685,7 @@ private:
 @safe unittest
 {
     import core.time : days, hours, seconds;
-    import std.datetime.date : DateTime;
+    import std.datetime.date : Date, DateTime;
     import std.datetime.timezone : SimpleTimeZone, UTC;
 
     const dt = DateTime(2018, 1, 1, 10, 30, 0);

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -2,7 +2,6 @@
 
 /++
 
-$(SCRIPT inhibitQuickIndex = 1;)
 $(DIVC quickindex,
 $(BOOKTABLE,
 $(TR $(TH Category) $(TH Functions))
@@ -468,30 +467,38 @@ private:
     `SysTime` (though for local time applications, time zones can be ignored
     and it will work, since it defaults to using the local time zone). It holds
     its internal time in std time (hnsecs since midnight, January 1st, 1 A.D.
-    UTC), so it interfaces well with the system time. However, that means that,
-    unlike $(REF DateTime,std,datetime,date), it is not optimized for
-    calendar-based operations, and getting individual units from it such as
-    years or days is going to involve conversions and be less efficient.
+    UTC), so it interfaces well with the system time.
 
     An $(I hnsec) (hecto-nanosecond) is 100 nanoseconds. There are 10,000,000 hnsecs in a second.
 
-    For calendar-based operations that don't
-    care about time zones, then $(REF DateTime,std,datetime,date) would be
-    the type to use. For system time, use `SysTime`.
+$(PANEL
+    Unlike $(REF_SHORT DateTime,std,datetime,date), `SysTime` is not optimized for
+    calendar-based operations, and getting individual units from it such as
+    years or days is going to involve conversions and be less efficient.
 
-    $(LREF Clock.currTime) will return the current time as a `SysTime`.
-    To convert a `SysTime` to a $(REF Date,std,datetime,date) or
-    $(REF DateTime,std,datetime,date), simply cast it. To convert a
-    $(REF Date,std,datetime,date) or $(REF DateTime,std,datetime,date) to a
+    For calendar-based operations that don't
+    care about time zones, then $(REF_SHORT DateTime,std,datetime,date) would be
+    the type to use. For system time, use `SysTime`.
+)
+$(P
+    Casting a `SysTime` to one of the following types will perform a conversion:
+)
+    * $(REF Date,std,datetime,date)
+    * $(REF_SHORT DateTime,std,datetime,date)
+    * $(REF_SHORT TimeOfDay,std,datetime,date)
+$(P
+    To convert a
+    $(REF_SHORT Date,std,datetime,date) or $(REF_SHORT DateTime,std,datetime,date) to a
     `SysTime`, use `SysTime`'s constructor, and pass in the intended time
     zone with it (or don't pass in a $(REF TimeZone,std,datetime,timezone), and
     the local time zone will be used). Be aware, however, that converting from a
-    $(REF DateTime,std,datetime,date) to a `SysTime` will not necessarily
+    $(REF_SHORT DateTime,std,datetime,date) to a `SysTime` will not necessarily
     be 100% accurate due to DST (one hour of the year doesn't exist and another
     occurs twice). To not risk any conversion errors, keep times as
     `SysTime`s. Aside from DST though, there shouldn't be any conversion
     problems.
-
+)
+$(PANEL
     For using time zones other than local time or UTC, use
     $(REF PosixTimeZone,std,datetime,timezone) on Posix systems (or on Windows,
     if providing the TZ Database files), and use
@@ -499,16 +506,20 @@ private:
     `SysTime` is kept internally in hnsecs from midnight, January 1st, 1 A.D.
     UTC. Conversion error cannot happen when changing the time zone of a
     `SysTime`. $(REF LocalTime,std,datetime,timezone) is the
-    $(REF TimeZone,std,datetime,timezone) class which represents the local time,
-    and `UTC` is the $(REF TimeZone,std,datetime,timezone) class which
-    represents UTC. `SysTime` uses $(REF LocalTime,std,datetime,timezone) if
-    no $(REF TimeZone,std,datetime,timezone) is provided. For more details on
-    time zones, see the documentation for $(REF TimeZone,std,datetime,timezone),
-    $(REF PosixTimeZone,std,datetime,timezone), and
-    $(REF WindowsTimeZone,std,datetime,timezone).
-
+    $(REF_SHORT TimeZone,std,datetime,timezone) class which represents the local time,
+    and `UTC` is the $(REF_SHORT TimeZone,std,datetime,timezone) class which
+    represents UTC. `SysTime` uses $(REF_SHORT LocalTime,std,datetime,timezone) if
+    no $(REF_SHORT TimeZone,std,datetime,timezone) is provided. For more details on
+    time zones, see the documentation for $(REF_SHORT TimeZone,std,datetime,timezone),
+    $(REF_SHORT PosixTimeZone,std,datetime,timezone), and
+    $(REF_SHORT WindowsTimeZone,std,datetime,timezone).
+)
+$(P
     `SysTime`'s range is from approximately 29,000 B.C. to approximately
     29,000 A.D.
+)
+See_Also:
+    $(RELATIVE_LINK2 .Clock.currTime, `Clock.currTime`) will return the current time as a `SysTime`.
   +/
 struct SysTime
 {
@@ -9677,13 +9688,22 @@ private:
     import std.datetime.date : DateTime;
     import std.datetime.timezone : SimpleTimeZone, UTC;
 
+    const dt = DateTime(2018, 1, 1, 10, 30, 0);
     // make a specific point in time in the UTC timezone
-    auto st = SysTime(DateTime(2018, 1, 1, 10, 30, 0), UTC());
+    auto st = SysTime(dt, UTC());
+    assert(st.year == 2018);
+    assert(st.hour == 10);
+
+    // cast to convert
+    assert(cast(DateTime) st == dt);
+    assert(cast(Date) st == Date(2018, 1, 1));
+
     // make a specific point in time in the New York timezone
-    auto ny = SysTime(
-        DateTime(2018, 1, 1, 10, 30, 0),
+    const ny = SysTime(dt,
         new immutable SimpleTimeZone(-5.hours, "America/New_York")
     );
+    assert(ny != st);
+    assert(ny.hour == 10);
 
     // ISO standard time strings
     assert(st.toISOString() == "20180101T103000Z");
@@ -9775,7 +9795,7 @@ long unixTimeToStdTime(long unixTime) @safe pure nothrow @nogc
 
     "std time"'s epoch is based on the Proleptic Gregorian Calendar per ISO
     8601 and is what $(LREF SysTime) uses internally. However, holding the time
-    as an integer in hnescs since that epoch technically isn't actually part of
+    as an integer in hnsecs since that epoch technically isn't actually part of
     the standard, much as it's based on it, so the name "std time" isn't
     particularly good, but there isn't an official name for it. C# uses "ticks"
     for the same thing, but they aren't actually clock ticks, and the term


### PR DESCRIPTION
Add links to package.d.
Tweak formatting for SysTime, use PANEL.
Use REF_SHORT after first reference.
List TimeOfDay cast target.
Move currTime link to See Also.
Fix anchor for currTime - need `.` prefix before fully-qualified names.
Extend example.
Fix typo.

Part of Issue 24288.