### PR TITLE
Revert "Makefile: Compile zlib .c files with DMD via importC"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,27 +101,58 @@ else
 	DRUNTIME = $(DRUNTIME_PATH)/../generated/$(OS)/$(BUILD)/$(MODEL)/druntime.lib
 endif
 
-# Set DMD
+# Set CC and DMD
 ifeq ($(OS),win32wine)
+	CC = wine dmc.exe
 	DMD = wine dmd.exe
 	RUN = wine
 else
 	DMD = $(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE)
+	ifeq ($(MODEL),32omf)
+		CC = dmc
+	else ifeq ($(OS),windows)
+		CC = cl.exe
+	else
+		CC = cc
+	endif
 	RUN =
 endif
 
-# Set extra CFLAGS (for DMD - the zlib .c files are compiled via importC)
+# Set CFLAGS
+OUTFILEFLAG = -o
 NODEFAULTLIB=-defaultlib= -debuglib=
-CFLAGS=-P=-Ietc/c/zlib
 ifeq (,$(findstring win,$(OS)))
-	CFLAGS += -P=-DHAVE_UNISTD_H
+	CFLAGS=$(MODEL_FLAG) -fPIC -std=c11 -DHAVE_UNISTD_H
 # Bundled with the system library on OSX, and doesn't work with >= MacOS 11
 	ifneq (osx,$(OS))
 		NODEFAULTLIB += -L-lpthread -L-lm
 	endif
+	ifeq ($(BUILD),debug)
+		CFLAGS += -g
+	else
+		CFLAGS += -O3
+	endif
 else
 	ifeq ($(MODEL),32omf)
-		CFLAGS += -P=-DNO_snprintf
+		CFLAGS=-DNO_snprintf
+		ifeq ($(BUILD),debug)
+			CFLAGS += -g
+		else
+			CFLAGS += -O
+		endif
+	else # win64/win32coff
+		OUTFILEFLAG = /Fo
+		CFLAGS += /nologo /Zl /GS-
+		ifeq ($(BUILD),debug)
+			CFLAGS += /Z7
+		else
+			CFLAGS += /O2
+		endif
+	endif
+endif
+ifeq (osx,$(OS))
+	ifeq (64,$(MODEL))
+		CFLAGS+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
 	endif
 endif
 
@@ -317,9 +348,9 @@ endif
 lib: $(LIB)
 dll: $(ROOT)/libphobos2.so
 
-# compile zlib .c files via importC; the druntime dependency makes sure DMD has been built
-$(ROOT)/%$(DOTOBJ): %.c $(DRUNTIME)
-	$(DMD) -c $(DFLAGS) $(CFLAGS) -of$@ $<
+$(ROOT)/%$(DOTOBJ): %.c
+	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
+	$(CC) -c $(CFLAGS) $< $(OUTFILEFLAG)$@
 
 $(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
 	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)

--- a/etc/c/zlib/gzwrite.c
+++ b/etc/c/zlib/gzwrite.c
@@ -465,12 +465,7 @@ int ZEXPORTVA gzprintf(gzFile file, const char *format, ...)
     va_list va;
     int ret;
 
-// needed on Win64 - MS __va_start intrinsic not supported by importC yet
-#if __IMPORTC__
-    __builtin_va_start(va, format);
-#else
     va_start(va, format);
-#endif
     ret = gzvprintf(file, format, va);
     va_end(va);
     return ret;


### PR DESCRIPTION
Reverts dlang/phobos#8865

Broke dmd mainline, and release builds.
```
Error: C preprocess command C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX64\x86\cl.exe failed for file etc\c\zlib\compress.c, exit status 2

Error: C preprocess command C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX64\x86\cl.exe failed for file etc\c\zlib\deflate.c, exit status 2

cl : Command line warning D9002 : ignoring unknown option '/Zc:preprocessor'
cl : Command line warning D9002 : ignoring unknown option '/PD'
etc\c\zlib\deflate.c: fatal error C1083: Cannot open include file: '../dmd/druntime/import\importc.h': No such file or directory
Error: C preprocess command C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX64\x86\cl.exe failed for file etc\c\zlib\adler32.c, exit status 2

cl : Command line warning D9002 : ignoring unknown option '/Zc:preprocessor'
cl : Command line warning D9002 : ignoring unknown option '/PD'
etc\c\zlib\compress.c: fatal error C1083: Cannot open include file: '../dmd/druntime/import\importc.h': No such file or directory
cl : Command line warning D9002 : ignoring unknown option '/Zc:preprocessor'
cl : Command line warning D9002 : ignoring unknown option '/PD'
etc\c\zlib\adler32.c: fatal error C1083: Cannot open include file: '../dmd/druntime/import\importc.h': No such file or directory
Error: C preprocess command C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\HostX64\x86\cl.exe failed for file etc\c\zlib\crc32.c, exit status 2

cl : Command line warning D9002 : ignoring unknown option '/Zc:preprocessor'
cl : Command line warning D9002 : ignoring unknown option '/PD'
etc\c\zlib\crc32.c: fatal error C1083: Cannot open include file: '../dmd/druntime/import\importc.h': No such file or directory
mingw32-make: *** [Makefile:322: generated/windows/release/32/etc/c/zlib/deflate.obj] Error 1
mingw32-make: *** Waiting for unfinished jobs....
mingw32-make: *** [Makefile:322: generated/windows/release/32/etc/c/zlib/compress.obj] Error 1
mingw32-make: *** [Makefile:322: generated/windows/release/32/etc/c/zlib/adler32.obj] Error 1
mingw32-make: *** [Makefile:322: generated/windows/release/32/etc/c/zlib/crc32.obj] Error 1
create_dmd_release: Error: Command failed (ran from dir 'clones\phobos'): "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64_x86 && mingw32-make -j4 MODEL=32 "DMD=C:\Users\vagrant\clones/dmd/generated/windows/release/32/dmd.exe" ENABLE_RELEASE=1 LATEST=master
```

Sorry @kinke - please try again after release freeze.