### PR TITLE
Remove failing FreeBSD 12 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,6 @@ jobs:
         include:
           - job_name: FreeBSD 13.2 x64
             freebsd_version: '13.2'
-          - job_name: FreeBSD 12.4 x64
-            freebsd_version: '12.4'
     name: ${{ matrix.job_name }}
     runs-on: macos-latest
     timeout-minutes: 60


### PR DESCRIPTION
Analogous to https://github.com/dlang/dmd/pull/15979

It keeps failing, because there's no git package anymore?

```
  + echo '::group::Install git'
  + sudo pkg install -y git
  Updating FreeBSD repository catalogue...
  repository FreeBSD has no meta file, using default settings
  pkg: http://pkgmir.geo.freebsd.org/FreeBSD:12:amd64/quarterly/meta.txz: Not Found
  pkg: http://pkgmir.geo.freebsd.org/FreeBSD:12:amd64/quarterly/packagesite.pkg: Not Found
  pkg: http://pkgmir.geo.freebsd.org/FreeBSD:12:amd64/quarterly/packagesite.txz: Not Found
  Unable to update repository FreeBSD
  Error updating repositories!
```