### PR TITLE
std.regex: put disassemble function in debug version

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -682,7 +682,7 @@ final:
                     while (prevStack()) {}
                     return re.ir[pc].data;
                 default:
-                    debug printBytecode(re.ir[0..$]);
+                    debug(std_regex_debug) printBytecode(re.ir[0..$]);
                     assert(0);
                 L_backtrack:
                     if (!popState())

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -403,7 +403,7 @@ struct Group(DataIndex)
 }
 
 //debugging tool, prints out instruction along with opcodes
-@trusted string disassemble(in Bytecode[] irb, uint pc, in NamedGroup[] dict=[])
+debug(std_regex_parser) @trusted string disassemble(in Bytecode[] irb, uint pc, in NamedGroup[] dict=[])
 {
     import std.array : appender;
     import std.format.write : formattedWrite;
@@ -467,7 +467,7 @@ struct Group(DataIndex)
 }
 
 //disassemble the whole chunk
-@trusted void printBytecode()(in Bytecode[] slice, in NamedGroup[] dict=[])
+debug(std_regex_parser) @trusted void printBytecode()(in Bytecode[] slice, in NamedGroup[] dict=[])
 {
     import std.stdio : writeln;
     for (uint pc=0; pc<slice.length; pc += slice[pc].length)


### PR DESCRIPTION
It's meant to be a debugging tool, but gets compiled anyways. Other debugging functions use `debug(std_regex_parser)`, so add them here to. This saves ~50 ms semantic analysis time when compiling Phobos, and reduces resulting libphobos.a size by 278 Kb