### PR TITLE
Reduce imports needed to print floats

### DIFF
--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -28,6 +28,15 @@ if (is(T == float) || is(T == double)
     return w.data;
 }
 
+/// Returns: whether `c` is a supported format specifier for floats
+package(std.format) bool isFloatSpec(char c) nothrow @nogc pure @safe
+{
+    return c == 'a' || c == 'A'
+           || c == 'e' || c == 'E'
+           || c == 'f' || c == 'F'
+           || c == 'g' || c == 'G';
+}
+
 package(std.format) void printFloat(Writer, T, Char)(auto ref Writer w, const(T) val, FormatSpec!Char f)
 if (is(T == float) || is(T == double)
     || (is(T == real) && (T.mant_dig == double.mant_dig || T.mant_dig == 64)))
@@ -43,10 +52,7 @@ if (is(T == float) || is(T == double)
     if (sgn == "" && f.flPlus) sgn = "+";
     if (sgn == "" && f.flSpace) sgn = " ";
 
-    assert(f.spec == 'a' || f.spec == 'A'
-           || f.spec == 'e' || f.spec == 'E'
-           || f.spec == 'f' || f.spec == 'F'
-           || f.spec == 'g' || f.spec == 'G', "unsupported format specifier");
+    assert(isFloatSpec(f.spec), "unsupported format specifier");
     bool is_upper = f.spec == 'A' || f.spec == 'E' || f.spec=='F' || f.spec=='G';
 
     // special treatment for nan and inf

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -570,9 +570,9 @@ void formatValueImpl(Writer, T, Char)(auto ref Writer w, const(T) obj,
                                       scope const ref FormatSpec!Char f)
 if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 {
-    import std.algorithm.searching : find;
     import std.format : enforceFmt;
     import std.range.primitives : put;
+    import std.format.internal.floats : printFloat, isFloatSpec;
 
     FloatingPointTypeOf!T val = obj;
     const char spec = f.spec;
@@ -597,11 +597,9 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         return;
     }
 
-    enforceFmt(find("fgFGaAeEs", spec).length,
-        "incompatible format character for floating point argument: %" ~ spec);
-
     FormatSpec!Char fs = f; // fs is copy for change its values.
     fs.spec = spec == 's' ? 'g' : spec;
+    enforceFmt(isFloatSpec(fs.spec), "incompatible format character for floating point argument: %" ~ spec);
 
     static if (is(T == float) || is(T == double)
                || (is(T == real) && (T.mant_dig == double.mant_dig || T.mant_dig == 64)))
@@ -631,7 +629,6 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
             tval = -doubleLowest;
     }
 
-    import std.format.internal.floats : printFloat;
     printFloat(w, tval, fs);
 }
 


### PR DESCRIPTION
Saves a few ms of compilation time when compiling `writeln(1.0)`. I couldn't get rid of the `std.uni` import entirely yet because `writeAligned` calls `getWidth` which calls `graphemeStride`.