### PR TITLE
std.math.hardware: Remove mixin around RISCV implementations

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -153,14 +153,12 @@ private:
         }
         else version (RISCV_Any)
         {
-            mixin(`
             uint result = void;
             asm pure nothrow @nogc
             {
                 "frflags %0" : "=r" (result);
             }
             return result;
-            `);
         }
         else version (LoongArch_Any)
         {
@@ -195,13 +193,11 @@ private:
         }
         else version (RISCV_Any)
         {
-            mixin(`
             uint newValues = 0x0;
             asm pure nothrow @nogc
             {
                 "fsflags %0" : : "r" (newValues);
             }
-            `);
         }
         else version (LoongArch_Any)
         {
@@ -875,14 +871,12 @@ private:
         }
         else version (RISCV_Any)
         {
-            mixin(`
             ControlState cont;
             asm pure nothrow @nogc
             {
                 "frcsr %0" : "=r" (cont);
             }
             return cont;
-            `);
         }
         else version (LoongArch_Any)
         {
@@ -930,12 +924,10 @@ private:
         }
         else version (RISCV_Any)
         {
-            mixin(`
             asm pure nothrow @nogc
             {
                 "fscsr %0" : : "r" (newState);
             }
-            `);
         }
         else version (LoongArch_Any)
         {


### PR DESCRIPTION
Given #8850 passed all CI pipelines, I gather dscanner has been fixed to not complain about gcc-style asm statements (or maybe it's no longer used).