### PR TITLE
Add optional element type to remaining range predicates

### DIFF
--- a/changelog/is_forward_range_element.dd
+++ b/changelog/is_forward_range_element.dd
@@ -1,7 +1,0 @@
-isForwardRange now takes an optional element type.
-
-isForwardRange now has an optional 2nd template parameter that defaults
-to void. If not void, it only evaluates to true if the range's element
-type is the same type as this extra argument, modulo const. For
-instance, `isForwardRange!(int[], const(int))` is true, but
-`isForwardRange!(int[], string)` is false.

--- a/changelog/range_predicate_element.dd
+++ b/changelog/range_predicate_element.dd
@@ -1,0 +1,24 @@
+`isForwardRange`, `isBidirectionalRange`, and `isRandomAccessRange` now take an optional element type
+
+In Phobos 2.106, an optional second template parameter was added to
+`isInputRange` to enable conveniently checking a range's element type. Now, the
+same parameter has been added to `isForwardRange`, `isBidirectionalRange`, and
+`isRandomAccessRange`.
+
+As before, if a second type argument is passed to one of these templates, the
+range's element type is checked to see if it is
+$(DDSUBLINK spec/const3, implicit_qualifier_conversions, qualifier-convertible)
+to the given type, and this additional check must pass in order for the
+template to evaluate to `true`.
+
+Examples:
+---
+// exact match
+static assert( isForwardRange!(int[], int));
+
+// match with qualifier conversion
+static assert( isBidirectionalRange!(int[], const(int));
+
+// not a match
+static assert(!isRandomAccessRange!(int[], string));
+---

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1167,6 +1167,15 @@ are bidirectional ranges only.
 
 See_Also:
     The header of $(MREF std,range) for tutorials on ranges.
+
+Params:
+    R = type to be tested
+    E = if present, the elements of the range must be
+        $(DDSUBLINK spec/const3, implicit_qualifier_conversions, qualifier-convertible)
+        to this type
+
+Returns:
+    `true` if R is a random-access range (possibly with element type `E`), `false` if not
  */
 enum bool isRandomAccessRange(R) =
     is(typeof(lvalueOf!R[1]) == ElementType!R)
@@ -1176,6 +1185,10 @@ enum bool isRandomAccessRange(R) =
     && (hasLength!R || isInfinite!R)
     && (isInfinite!R || !is(typeof(lvalueOf!R[$ - 1]))
         || is(typeof(lvalueOf!R[$ - 1]) == ElementType!R));
+
+/// ditto
+enum bool isRandomAccessRange(R, E) =
+    .isRandomAccessRange!R && isQualifierConvertible!(ElementType!R, E);
 
 ///
 @safe unittest
@@ -1205,6 +1218,18 @@ enum bool isRandomAccessRange(R) =
         static if (!isInfinite!R)
             static assert(is(typeof(f) == typeof(r[$ - 1])));
     }
+
+    // Checking the element type
+    static assert( isRandomAccessRange!(int[], const int));
+    static assert(!isRandomAccessRange!(int[], immutable int));
+
+    static assert(!isRandomAccessRange!(const(int)[], int));
+    static assert( isRandomAccessRange!(const(int)[], const int));
+    static assert(!isRandomAccessRange!(const(int)[], immutable int));
+
+    static assert(!isRandomAccessRange!(immutable(int)[], int));
+    static assert( isRandomAccessRange!(immutable(int)[], const int));
+    static assert( isRandomAccessRange!(immutable(int)[], immutable int));
 }
 
 @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1077,11 +1077,24 @@ element in the range. Calling `r.back` is allowed only if calling
 
 See_Also:
     The header of $(MREF std,range) for tutorials on ranges.
+
+Params:
+    R = type to be tested
+    E = if present, the elements of the range must be
+        $(DDSUBLINK spec/const3, implicit_qualifier_conversions, qualifier-convertible)
+        to this type
+
+Returns:
+    `true` if R is a bidirectional range (possibly with element type `E`), `false` if not
  */
 enum bool isBidirectionalRange(R) = isForwardRange!R
     && is(typeof((R r) => r.popBack))
     && (is(typeof((return ref R r) => r.back)) || is(typeof(ref (return ref R r) => r.back)))
     && is(typeof(R.init.back.init) == ElementType!R);
+
+/// ditto
+enum bool isBidirectionalRange(R, E) =
+    .isBidirectionalRange!R && isQualifierConvertible!(ElementType!R, E);
 
 ///
 @safe unittest
@@ -1093,6 +1106,18 @@ enum bool isBidirectionalRange(R) = isForwardRange!R
     auto t = r.back;                           // can get the back of the range
     auto w = r.front;
     static assert(is(typeof(t) == typeof(w))); // same type for front and back
+
+    // Checking the element type
+    static assert( isBidirectionalRange!(int[], const int));
+    static assert(!isBidirectionalRange!(int[], immutable int));
+
+    static assert(!isBidirectionalRange!(const(int)[], int));
+    static assert( isBidirectionalRange!(const(int)[], const int));
+    static assert(!isBidirectionalRange!(const(int)[], immutable int));
+
+    static assert(!isBidirectionalRange!(immutable(int)[], int));
+    static assert( isBidirectionalRange!(immutable(int)[], const int));
+    static assert( isBidirectionalRange!(immutable(int)[], immutable int));
 }
 
 @safe unittest

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1011,6 +1011,15 @@ have a `save` function.
 
 See_Also:
     The header of $(MREF std,range) for tutorials on ranges.
+
+Params:
+    R = type to be tested
+    E = if present, the elements of the range must be
+        $(DDSUBLINK spec/const3, implicit_qualifier_conversions, qualifier-convertible)
+        to this type
+
+Returns:
+    `true` if R is a forward range (possibly with element type `E`), `false` if not
  */
 enum bool isForwardRange(R) = isInputRange!R
     && is(typeof((R r) { return r.save; } (R.init)) == R);


### PR DESCRIPTION
Continuation of #8819 and #8842 for `isBidirectionalRange` and `isRandomAccessRange`. Also adds missing docs for `isForwardRange`.

cc @atilaneves 