### PR TITLE
Make sanitize() safe

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1879,11 +1879,11 @@ immutable(E)[] sanitize(E)(immutable(E)[] s)
         offset += n;
         t = t[n..$];
     }
-    return cast(immutable(E)[])array[0 .. offset];
+    return () @trusted { return cast(immutable(E)[])array[0 .. offset]; } ();
 }
 
 ///
-@system pure unittest
+@safe pure unittest
 {
     assert(sanitize("hello \xF0\x80world") == "hello \xEF\xBF\xBDworld");
 }


### PR DESCRIPTION
Neither returning the original input string, nor returning a slice of the newly allocated array as immutable is unsafe. As such, the interface of sanitize() should come out as safe.