### PR TITLE
[std.traits] Docs: Fix render error

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -7585,7 +7585,7 @@ enum bool isSomeFunction(alias T) =
 
 /**
 Detect whether `T` is a callable object, which can be called with the
-function call operator `$(LPAREN)...$(RPAREN)`.
+function call operator $(PRE $(LPAREN)...$(RPAREN)).
  */
 template isCallable(alias callable)
 {


### PR DESCRIPTION
The official documentation renders this wrongly, escaping the macros.

Current text is: `class="pln">LPAREN...class="pln">RPAREN` 
https://dlang.org/library/std/traits/is_callable.html