### PR TITLE
Fix bugzilla issue 24389 - Make Phobos compile on FreeBSD 14 again.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,12 @@ endif
 # default to compiling the C parts (zlib) with DMD via importC; override with USE_IMPORTC=1/0
 USE_IMPORTC:=1
 
+# FreeBSD 14 can't use importC for zlib thanks to asm in stdlib.h, which dmd can't handle.
+# https://issues.dlang.org/show_bug.cgi?id=24389
+ifeq (freebsd,$(OS))
+	USE_IMPORTC=0
+endif
+
 # Configurable stuff that's rarely edited
 INSTALL_DIR = ../install
 DRUNTIME_PATH = $(DMD_DIR)/druntime


### PR DESCRIPTION
zlib can't be built with importC on FreeBSD 14, because qsort_r in stdlib.h uses some asm instructions, which dmd can't handle.

https://github.com/dlang/dmd/pull/16184 fixed it so that we got a proper error message about it (and theoretically making it so that zlib could be compiled on FreeBSD 14 with gdc or ldc, though I haven't tried that), but it didn't fix it so that it could build on dmd, since that would require that dmd be able to handle GNU assembly code, which isn't a planned feature AFAIK.

https://github.com/dlang/phobos/pull/8914 fixed it so that it's possible to build Phobos without using importC by providing a make variable, but it didn't do anything for FreeBSD specifically.

This commit changes it so that FreeBSD sets that make variable in the makefile so that you don't have to do it manually to get FreeBSD 14 to build. It's not necessary for FreeBSD 13.2 (which is what the auto testers currently use), but it will be necessary for FreeBSD 14 (14.0 currently being the latest release of FreeBSD).

I can confirm from testing that explicitly setting USE_IMPORTC=1 on the command line will overrides this change, so that variable can still be set one way or the other on FreeBSD. It's just now 0 by default so that it will build by default on FreeBSD 14.