### PR TITLE
Deprecate the range API functions on Nullable.

### DIFF
--- a/changelog/nullable_range.md
+++ b/changelog/nullable_range.md
@@ -1,0 +1,22 @@
+The range API functions on `Nullable` have been deprecated.
+
+Treating `Nullable` as a range has been causing problems for generic code
+similar to when `Nullable` used `alias this` with `get`, so it was clearly
+a mistake to add that functionality. As with implicitly converting `Nullable`
+to the type it contains, implictly converting it to a range of the type that
+it contains is just too bug-prone.
+
+As with containers, `Nullable` supports slicing to get a range, so anyone who
+wishes to use a `Nullable` as a range can simply slice it.
+
+Examples:
+--
+auto n = nullable(42);
+
+// deprecated
+auto value = n.front;
+
+// This still works
+auto range = n[];
+assert(range.front == 42);
+--

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1691,7 +1691,7 @@ pure @safe nothrow unittest
 
     immutable Nullable!string foo = "b";
     string[] bar = ["a"];
-    assert(chain(bar, foo).equal(["a", "b"]));
+    assert(chain(bar, foo[]).equal(["a", "b"]));
 }
 
 pure @safe nothrow @nogc unittest

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3787,7 +3787,7 @@ auto nullable(T)(T t)
 ///
 @safe unittest
 {
-    import std.algorithm.iteration : each, joiner;
+    import std.algorithm.iteration : each, joiner, map;
     Nullable!int a = 42;
     Nullable!int b;
     // Add each value to an array
@@ -3799,7 +3799,7 @@ auto nullable(T)(T t)
     // Take first value from an array of Nullables
     Nullable!int[] c = new Nullable!int[](10);
     c[7] = Nullable!int(42);
-    assert(c.joiner.front == 42);
+    assert(c.map!(a => a[]).joiner.front == 42);
 }
 @safe unittest
 {
@@ -4271,42 +4271,6 @@ auto nullable(T)(T t)
     Nullable!int a, b, c;
     a = b = c = 5;
     a = b = c = nullable(5);
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=18374
-@safe pure nothrow unittest
-{
-    import std.algorithm.comparison : equal;
-    import std.range : only, takeNone;
-    import std.range.primitives : hasAssignableElements, hasLength,
-        hasLvalueElements, hasSlicing, hasSwappableElements,
-        isRandomAccessRange;
-    Nullable!int a = 42;
-    assert(!a.empty);
-    assert(a.front == 42);
-    assert(a.back == 42);
-    assert(a[0] == 42);
-    assert(a.equal(only(42)));
-    assert(a[0 .. $].equal(only(42)));
-    a[0] = 43;
-    assert(a.equal(only(43)));
-    --a[0];
-    assert(a.equal(only(42)));
-    Nullable!int b;
-    assert(b.empty);
-    assert(b.equal(takeNone(b)));
-    Nullable!int c = a.save();
-    assert(!c.empty);
-    c.popFront();
-    assert(!a.empty);
-    assert(c.empty);
-
-    assert(isRandomAccessRange!(Nullable!int));
-    assert(hasLength!(Nullable!int));
-    assert(hasSlicing!(Nullable!int));
-    assert(hasAssignableElements!(Nullable!int));
-    assert(hasSwappableElements!(Nullable!int));
-    assert(hasLvalueElements!(Nullable!int));
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=23640

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3595,53 +3595,69 @@ struct Nullable(T)
     }
 
     /// $(MREF_ALTTEXT Range interface, std, range, primitives) functions.
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     alias empty = isNull;
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     alias popFront = nullify;
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     alias popBack = nullify;
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     @property ref inout(T) front() inout @safe pure nothrow
     {
         return get();
     }
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     alias back = front;
 
     /// ditto
     static if (isCopyable!T)
-    @property inout(typeof(this)) save() inout
     {
-        return this;
+        deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
+        @property inout(typeof(this)) save() inout
+        {
+            return this;
+        }
     }
 
     /// ditto
     static if (isCopyable!T)
-    inout(typeof(this)) opIndex(size_t[2] dim) inout
-    in (dim[0] <= length && dim[1] <= length && dim[1] >= dim[0])
     {
-        return (dim[0] == 0 && dim[1] == 1) ? this : this.init;
+        deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
+        inout(typeof(this)) opIndex(size_t[2] dim) inout
+        in (dim[0] <= length && dim[1] <= length && dim[1] >= dim[0])
+        {
+            return (dim[0] == 0 && dim[1] == 1) ? this : this.init;
+        }
     }
+
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     size_t[2] opSlice(size_t dim : 0)(size_t from, size_t to) const
     {
         return [from, to];
     }
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     @property size_t length() const @safe pure nothrow
     {
         return !empty;
     }
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     alias opDollar(size_t dim : 0) = length;
 
     /// ditto
+    deprecated("If you want to use Nullable as a range, then use [] on it to get a range.")
     ref inout(T) opIndex(size_t index) inout @safe pure nothrow
     in (index < length)
     {


### PR DESCRIPTION
I don't know how acceptable it is to do this (the functionality was added in
2.100.0 back in May 2022, so it's not particularly old, but it's not exactly
new either). However, I'm sick of dealing with bugs related to Nullables being
treated as ranges. We got rid of the alias this on Nullable precisely to fix
problems related to implict conversions and Nullable, and making Nullable a
range just added a whole new set of them - ones which typically pop up in
generic code, forcing you to do stuff like check that a type is not an instance
of a Nullable or add an overload just for Nullables so that the range-based
overload doesn't take it.

Code that wants to get a range from Nullable can do so by slicing it, just like
you can with static arrays and other container types. So, code that wants to
continue to use Nullables as ranges can do so quite easily by simply adding [].
In the meantime, they'll get a deprecation message, so no code will break -
though unfortunately, the problems with Nullable being a range will of course
continue until we can actually remove the deprecated functions down the road.

The second commit fixes the few tests which need to use [] to get rid of the deprecation messages - and it unfortunately also removes the unittest block that's intended to test that the range API functions on Nullable work properly, since apparently, Phobos is currently compiled with -de, which makes it impossible to actually test deprecated code.