### PR TITLE
Phobos 3 Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /phobos.json
 
 generated
+generated-lib
 GNUmakefile
 .DS_Store
 .*.sw*
@@ -18,7 +19,7 @@ obj/
 
 # Rule for VS Code config folder
 .vscode
-
+dub.selections.json
 *.html
 
 .dub/

--- a/dub.sdl
+++ b/dub.sdl
@@ -2,8 +2,19 @@ name "phobos"
 license "BSL-1.0"
 description "D Standard Library"
 authors "DLang Community"
-copyright "Copyright © 1999-2018, The D Language Foundation"
+copyright "Copyright © 1999-2024, The D Language Foundation"
 
-targetType "library"
-sourcePaths "std" "etc"
-targetPath "generated"
+configuration "library" {
+    targetType "staticLibrary"
+    sourcePaths "lib"
+    targetPath "generated-lib"
+    #excludedSourceFiles "unittest.d" "test/**" "std/**" "tools/**" "etc/**"
+}
+
+configuration "unittest" {
+    dflags "-main"
+    targetType "executable"
+    sourcePaths "lib"
+    targetPath "generated-lib"
+    #excludedSourceFiles "unittest.d" "test/**" "std/**" "tools/**" "etc/**"
+}

--- a/lib/package.d
+++ b/lib/package.d
@@ -1,0 +1,3 @@
+module lib;
+
+public import lib.sys;

--- a/lib/sys/compiler.d
+++ b/lib/sys/compiler.d
@@ -1,0 +1,58 @@
+// Written in the D programming language.
+
+/**
+ * Identify the compiler used and its various features.
+ *
+ * Copyright: Copyright The D Language Foundation 2000 - 2011.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright), Alex Rønne Petersen
+ * Source:    $(PHOBOSSRC std/compiler.d)
+ */
+/*          Copyright The D Language Foundation 2000 - 2011.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module lib.sys.compiler;
+
+immutable
+{
+    /// Vendor specific string naming the compiler, for example: "Digital Mars D".
+    string name = __VENDOR__;
+
+    /// Master list of D compiler vendors.
+    enum Vendor
+    {
+        unknown = 0,     /// Compiler vendor could not be detected
+        digitalMars = 1, /// Digital Mars D (DMD)
+        gnu = 2,         /// GNU D Compiler (GDC)
+        llvm = 3,        /// LLVM D Compiler (LDC)
+        dotNET = 4,      /// D.NET
+        sdc = 5,         /// Snazzy D Compiler (SDC)
+    }
+
+    /// Which vendor produced this compiler.
+    version (StdDdoc)          Vendor vendor;
+    else version (DigitalMars) Vendor vendor = Vendor.digitalMars;
+    else version (GNU)         Vendor vendor = Vendor.gnu;
+    else version (LDC)         Vendor vendor = Vendor.llvm;
+    else version (D_NET)       Vendor vendor = Vendor.dotNET;
+    else version (SDC)         Vendor vendor = Vendor.sdc;
+    else                       Vendor vendor = Vendor.unknown;
+
+
+    /**
+     * The vendor specific version number, as in
+     * version_major.version_minor
+     */
+    uint version_major = __VERSION__ / 1000;
+    uint version_minor = __VERSION__ % 1000;    /// ditto
+
+
+    /**
+     * The version of the D Programming Language Specification
+     * supported by the compiler.
+     */
+    uint D_major = 2;
+    uint D_minor = 0;
+}

--- a/lib/sys/package.d
+++ b/lib/sys/package.d
@@ -1,0 +1,5 @@
+module lib.sys;
+
+public import lib.sys.compiler;
+public import lib.sys.stdint;
+public import lib.sys.system;

--- a/lib/sys/stdint.d
+++ b/lib/sys/stdint.d
@@ -1,0 +1,131 @@
+// Written in the D programming language.
+
+/**
+ *
+    D constrains integral types to specific sizes. But efficiency
+    of different sizes varies from machine to machine,
+    pointer sizes vary, and the maximum integer size varies.
+    <b>stdint</b> offers a portable way of trading off size
+    vs efficiency, in a manner compatible with the <tt>stdint.h</tt>
+    definitions in C.
+
+    In the table below, the $(B exact alias)es are types of exactly the
+    specified number of bits.
+    The $(B at least alias)es are at least the specified number of bits
+    large, and can be larger.
+    The $(B fast alias)es are the fastest integral type supported by the
+    processor that is at least as wide as the specified number of bits.
+
+    The aliases are:
+
+    $(ATABLE $(TR
+    $(TH Exact Alias)
+    $(TH Description)
+    $(TH At Least Alias)
+    $(TH Description)
+    $(TH Fast Alias)
+    $(TH Description)
+    )$(TR
+    $(TD int8_t)
+    $(TD exactly 8 bits signed)
+    $(TD int_least8_t)
+    $(TD at least 8 bits signed)
+    $(TD int_fast8_t)
+    $(TD fast 8 bits signed)
+    )$(TR
+    $(TD uint8_t)
+    $(TD exactly 8 bits unsigned)
+    $(TD uint_least8_t)
+    $(TD at least 8 bits unsigned)
+    $(TD uint_fast8_t)
+    $(TD fast 8 bits unsigned)
+
+    )$(TR
+    $(TD int16_t)
+    $(TD exactly 16 bits signed)
+    $(TD int_least16_t)
+    $(TD at least 16 bits signed)
+    $(TD int_fast16_t)
+    $(TD fast 16 bits signed)
+    )$(TR
+    $(TD uint16_t)
+    $(TD exactly 16 bits unsigned)
+    $(TD uint_least16_t)
+    $(TD at least 16 bits unsigned)
+    $(TD uint_fast16_t)
+    $(TD fast 16 bits unsigned)
+
+    )$(TR
+    $(TD int32_t)
+    $(TD exactly 32 bits signed)
+    $(TD int_least32_t)
+    $(TD at least 32 bits signed)
+    $(TD int_fast32_t)
+    $(TD fast 32 bits signed)
+    )$(TR
+    $(TD uint32_t)
+    $(TD exactly 32 bits unsigned)
+    $(TD uint_least32_t)
+    $(TD at least 32 bits unsigned)
+    $(TD uint_fast32_t)
+    $(TD fast 32 bits unsigned)
+
+    )$(TR
+    $(TD int64_t)
+    $(TD exactly 64 bits signed)
+    $(TD int_least64_t)
+    $(TD at least 64 bits signed)
+    $(TD int_fast64_t)
+    $(TD fast 64 bits signed)
+    )$(TR
+    $(TD uint64_t)
+    $(TD exactly 64 bits unsigned)
+    $(TD uint_least64_t)
+    $(TD at least 64 bits unsigned)
+    $(TD uint_fast64_t)
+    $(TD fast 64 bits unsigned)
+    ))
+
+    The ptr aliases are integral types guaranteed to be large enough
+    to hold a pointer without losing bits:
+
+    $(ATABLE $(TR
+    $(TH Alias)
+    $(TH Description)
+    )$(TR
+    $(TD intptr_t)
+    $(TD signed integral type large enough to hold a pointer)
+    )$(TR
+    $(TD uintptr_t)
+    $(TD unsigned integral type large enough to hold a pointer)
+    ))
+
+    The max aliases are the largest integral types:
+
+    $(ATABLE $(TR
+    $(TH Alias)
+    $(TH Description)
+    )$(TR
+    $(TD intmax_t)
+    $(TD the largest signed integral type)
+    )$(TR
+    $(TD uintmax_t)
+    $(TD the largest unsigned integral type)
+    ))
+
+ * Macros:
+ *  ATABLE=<table border="1" cellspacing="0" cellpadding="5">$0</table>
+ *
+ * Copyright: Copyright The D Language Foundation 2000 - 2009.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
+ * Source:    $(PHOBOSSRC std/stdint.d)
+ */
+/*          Copyright The D Language Foundation 2000 - 2009.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module lib.sys.stdint;
+
+public import core.stdc.stdint;

--- a/lib/sys/system.d
+++ b/lib/sys/system.d
@@ -1,0 +1,158 @@
+// Written in the D programming language.
+
+/**
+ * Information about the target operating system, environment, and CPU.
+ *
+ *  Copyright: Copyright The D Language Foundation 2000 - 2011
+ *  License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ *  Authors:   $(HTTP digitalmars.com, Walter Bright) and
+               $(HTTP jmdavisprog.com, Jonathan M Davis)
+ *  Source:    $(PHOBOSSRC std/system.d)
+ */
+module lib.sys.system;
+
+immutable
+{
+    /++
+        Operating system.
+
+        Note:
+            This is for cases where you need a value representing the OS at
+            runtime. If you're doing something which should compile differently
+            on different OSes, then please use `version (Windows)`,
+            `version (linux)`, etc.
+
+        See_Also:
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
+      +/
+    enum OS
+    {
+        win32 = 1, /// Microsoft 32 bit Windows systems
+        win64,     /// Microsoft 64 bit Windows systems
+        linux,     /// All Linux Systems, except for Android
+        osx,       /// Mac OS X
+        iOS,       /// iOS
+        tvOS,      /// tvOS
+        watchOS,   /// watchOS
+        freeBSD,   /// FreeBSD
+        netBSD,    /// NetBSD
+        openBSD,   /// OpenBSD
+        dragonFlyBSD, /// DragonFlyBSD
+        solaris,   /// Solaris
+        android,   /// Android
+        otherPosix, /// Other Posix Systems
+        unknown,   /// Unknown
+    }
+
+    /// The OS that the program was compiled for.
+    version (Win32)        OS os = OS.win32;
+    else version (Win64)   OS os = OS.win64;
+    else version (Android) OS os = OS.android;
+    else version (linux)   OS os = OS.linux;
+    else version (OSX)     OS os = OS.osx;
+    else version (iOS)     OS os = OS.iOS;
+    else version (tvOS)    OS os = OS.tvOS;
+    else version (watchOS) OS os = OS.watchOS;
+    else version (FreeBSD) OS os = OS.freeBSD;
+    else version (NetBSD)  OS os = OS.netBSD;
+    else version (OpenBSD) OS os = OS.openBSD;
+    else version (DragonFlyBSD) OS os = OS.dragonFlyBSD;
+    else version (Posix)   OS os = OS.otherPosix;
+    else OS os = OS.unknown;
+
+    /++
+        Byte order endianness.
+
+        Note:
+            This is intended for cases where you need to deal with endianness at
+            runtime. If you're doing something which should compile differently
+            depending on whether you're compiling on a big endian or little
+            endian machine, then please use `version (BigEndian)` and
+            `version (LittleEndian)`.
+
+        See_Also:
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
+      +/
+    enum Endian
+    {
+        bigEndian,   /// Big endian byte order
+        littleEndian /// Little endian byte order
+    }
+
+    /// The endianness that the program was compiled for.
+    version (LittleEndian) Endian endian = Endian.littleEndian;
+    else                  Endian endian = Endian.bigEndian;
+    /++
+        Instruction Set Architecture.
+
+        Note:
+            This is intended for cases where you need a value representing the
+            instruction set architecture at runtime. If you're doing something
+            which should compile differently depending on instruction set
+            architecture, then please use `version (X86_64)`, `version (ARM)`,
+            etc.
+
+        See_Also:
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
+      +/
+    enum ISA
+    {
+        x86,   /// Intel and AMD 32-bit processors
+        x86_64, /// Intel and AMD 64-bit processors
+        arm, /// The ARM architecture (32-bit) (AArch32 et al)
+        aarch64, /// The Advanced RISC Machine architecture (64-bit)
+        asmJS, /// The asm.js intermediate programming language
+        avr, /// 8-bit Atmel AVR Microcontrollers
+        epiphany, /// The Epiphany architecture
+        ppc, /// The PowerPC architecture, 32-bit
+        ppc64, /// The PowerPC architecture, 64-bit
+        ia64, /// The Itanium architecture (64-bit)
+        mips32, /// The MIPS architecture, 32-bit
+        mips64, /// The MIPS architecture, 64-bit
+        msp430, /// The MSP430 architecture
+        nvptx, /// The Nvidia Parallel Thread Execution (PTX) architecture, 32-bit
+        nvptx64, /// The Nvidia Parallel Thread Execution (PTX) architecture, 64-bit
+        riscv32, /// The RISC-V architecture, 32-bit
+        riscv64, /// The RISC-V architecture, 64-bit
+        sparc, /// The SPARC architecture, 32-bit
+        sparc64, /// The SPARC architecture, 64-bit
+        s390, /// The System/390 architecture, 32-bit
+        systemZ, /// The System Z architecture, 64-bit
+        hppa, /// The HP PA-RISC architecture, 32-bit
+        hppa64, /// The HP PA-RISC architecture, 64-bit
+        sh, /// The SuperH architecture, 32-bit
+        webAssembly, /// The WebAssembly virtual ISA (instruction set architecture), 32-bit
+        alpha, /// The Alpha architecture
+        unknown, /// Unknown
+    }
+
+    /// The instruction set architecture that the program was compiled for.
+    version (X86) ISA instructionSetArchitecture = ISA.x86;
+    else version (X86_64)   ISA instructionSetArchitecture = ISA.x86_64;
+    else version (ARM)      ISA instructionSetArchitecture = ISA.arm;
+    else version (AArch64)  ISA instructionSetArchitecture = ISA.aarch64;
+    else version (AsmJS)    ISA instructionSetArchitecture = ISA.asmJS;
+    else version (AVR)      ISA instructionSetArchitecture = ISA.avr;
+    else version (Epiphany) ISA instructionSetArchitecture = ISA.epiphany;
+    else version (PPC)      ISA instructionSetArchitecture = ISA.ppc;
+    else version (PPC64)    ISA instructionSetArchitecture = ISA.ppc64;
+    else version (IA64)     ISA instructionSetArchitecture = ISA.ia64;
+    else version (MIPS32)   ISA instructionSetArchitecture = ISA.mips32;
+    else version (MIPS64)   ISA instructionSetArchitecture = ISA.mips64;
+    else version (MSP430)   ISA instructionSetArchitecture = ISA.msp430;
+    else version (NVPTX)    ISA instructionSetArchitecture = ISA.nvptx;
+    else version (NVPTX64)  ISA instructionSetArchitecture = ISA.nvptx64;
+    else version (RISCV32)  ISA instructionSetArchitecture = ISA.riscv32;
+    else version (RISCV64)  ISA instructionSetArchitecture = ISA.riscv64;
+    else version (SPARC)    ISA instructionSetArchitecture = ISA.sparc;
+    else version (SPARC64)  ISA instructionSetArchitecture = ISA.sparc64;
+    else version (S390)     ISA instructionSetArchitecture = ISA.s390;
+    else version (SystemZ)  ISA instructionSetArchitecture = ISA.systemZ;
+    else version (HPPA)     ISA instructionSetArchitecture = ISA.hppa;
+    else version (HPPA64)   ISA instructionSetArchitecture = ISA.hppa64;
+    else version (SH)       ISA instructionSetArchitecture = ISA.sh;
+    else version (WebAssembly) ISA instructionSetArchitecture = ISA.webAssembly;
+    else version (Alpha)    ISA instructionSetArchitecture = ISA.alpha;
+    else ISA instructionSetArchitecture = ISA.unknown;
+}
+


### PR DESCRIPTION
Copy over base packages that have no imports. Rewrite dub.sdl so that it can be used for Phobos3. Update .gitignore.

This PR lays down some of the basics of the Phobos 3 project. Moving forward, Phobos 3 will be developed and maintained side-by-side with the existing Phobos 2 code. This will simplify the process of maintaining both code-bases as we progress. Future PR's for Phobos will be required to submit fixes to both versions to ensure that both maintain parity.

@WalterBright @atilaneves Thought you two would want to know this was happening.
@thewilsonator Would you mind doing the review honors?