### PR TITLE
sumtype: add hint to "never matches" message

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1988,7 +1988,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
                     ? "template"
                     : typeof(handler).stringof
                 ) ~ "` " ~
-                "never matches"
+                "never matches. Perhaps the handler failed to compile"
             );
         }
 


### PR DESCRIPTION
A common cause of the "handler never matches" error is a template handler that contains a typo or other compile-time error. Since the location of the actual error is suppressed by __traits(compiles), users often do not think to look for a mistake inside the handler itself. Now, the message itself includes a hint to do so.