### PR TITLE
[trivial] std.path: Note that absolutePath and co. do not collapse ".."

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -2732,6 +2732,9 @@ else version (Posix)
     The function allocates memory if and only if it gets to the third stage
     of this algorithm.
 
+    Note that `absolutePath` will not normalize `..` segments.
+    Use `buildNormalizedPath(absolutePath(path))` if that is desired.
+
     Params:
         path = the relative path to transform
         base = the base directory of the relative path
@@ -2814,6 +2817,9 @@ string absolutePath(return scope const string path, lazy string base = getcwd())
         $(LI Otherwise, append `path` to the current working directory,
         which allocates memory.)
     )
+
+    Note that `asAbsolutePath` will not normalize `..` segments.
+    Use `asNormalizedPath(asAbsolutePath(path))` if that is desired.
 
     Params:
         path = the relative path to transform


### PR DESCRIPTION
There's a good reason why we don't do this automatically (at least on POSIX): `foo` and `foo/bar/..` may point to different things, if `foo/bar` is a symlink. This is because `..` is a hard link which "physically" goes to the parent directory in the real hierarchy.

So just note this in the docs as a potential footgun.
