### PR TITLE
use cast() where we can

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2959,10 +2959,10 @@ if (__traits(isIntegral, T))
     Unqual!T result;
     version (LittleEndian)
         foreach_reverse (b; array)
-            result = cast(Unqual!T) ((result << 8) | b);
+            result = cast() cast(T) ((result << 8) | b);
     else
         foreach (b; array)
-            result = cast(Unqual!T) ((result << 8) | b);
+            result = cast() cast(T) ((result << 8) | b);
     return cast(T) result;
 }
 
@@ -2977,7 +2977,7 @@ if (__traits(isIntegral, T))
         foreach (i; 0 .. T.sizeof)
         {
             result[i] = cast(ubyte) tmp;
-            tmp = cast(Unqual!T) (tmp >>> 8);
+            tmp = cast() cast(T) (tmp >>> 8);
         }
     }
     else
@@ -2985,7 +2985,7 @@ if (__traits(isIntegral, T))
         foreach_reverse (i; 0 .. T.sizeof)
         {
             result[i] = cast(ubyte) tmp;
-            tmp = cast(Unqual!T) (tmp >>> 8);
+            tmp = cast()(T) (tmp >>> 8);
         }
     }
     return result;

--- a/std/conv.d
+++ b/std/conv.d
@@ -5250,7 +5250,7 @@ if (isIntegral!T && isOutputRange!(W, char))
 auto unsigned(T)(T x)
 if (isIntegral!T)
 {
-    return cast(Unqual!(Unsigned!T))x;
+    return cast() cast(Unsigned!T) x;
 }
 
 ///
@@ -5271,7 +5271,7 @@ if (isSomeChar!T)
 {
     // All characters are unsigned
     static assert(T.min == 0, T.stringof ~ ".min must be zero");
-    return cast(Unqual!T) x;
+    return cast() x;
 }
 
 @safe unittest
@@ -5328,7 +5328,7 @@ if (isSomeChar!T)
 auto signed(T)(T x)
 if (isIntegral!T)
 {
-    return cast(Unqual!(Signed!T))x;
+    return cast() cast(Signed!T) x;
 }
 
 ///

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -974,9 +974,9 @@ private T powIntegralImpl(PowType type, T)(T val)
     else
     {
         static if (isSigned!T)
-            return cast(Unqual!T) (val < 0 ? -(T(1) << bsr(0 - val) + type) : T(1) << bsr(val) + type);
+            return cast() cast(T) (val < 0 ? -(T(1) << bsr(0 - val) + type) : T(1) << bsr(val) + type);
         else
-            return cast(Unqual!T) (T(1) << bsr(val) + type);
+            return cast() cast(T) (T(1) << bsr(val) + type);
     }
 }
 

--- a/std/variant.d
+++ b/std/variant.d
@@ -382,7 +382,7 @@ private:
                         static if (isStaticArray!A && isDynamicArray!T)
                         {
                             auto this_ = (*src)[];
-                            emplaceRef(*cast(Unqual!T*) zat, cast(Unqual!T) this_);
+                            emplaceRef(*cast(Unqual!T*) zat, cast() cast(T) this_);
                         }
                         else
                         {


### PR DESCRIPTION
`cast()` removes the qualifiers from an expression's type.