### PR TITLE
Rename lib.sys.traits' Unqual to Unqualified.

### DIFF
--- a/lib/sys/meta.d
+++ b/lib/sys/meta.d
@@ -215,18 +215,18 @@ template Map(alias fun, args...)
 ///
 @safe unittest
 {
-    import lib.sys.traits : Unqual;
+    import lib.sys.traits : Unqualified;
 
     // empty
-    alias Empty = Map!Unqual;
+    alias Empty = Map!Unqualified;
     static assert(Empty.length == 0);
 
     // single
-    alias Single = Map!(Unqual, const int);
+    alias Single = Map!(Unqualified, const int);
     static assert(is(Single == AliasSeq!int));
 
     // several
-    alias Several = Map!(Unqual, int, const int, immutable int, uint,
+    alias Several = Map!(Unqualified, int, const int, immutable int, uint,
                          ubyte, byte, short, ushort, const long);
     static assert(is(Several == AliasSeq!(int, int, int, uint,
                                           ubyte, byte, short, ushort, long)));

--- a/lib/sys/traits.d
+++ b/lib/sys/traits.d
@@ -62,7 +62,7 @@
     $(TR $(TD Traits for removing type qualfiers) $(TD
               $(LREF Unconst)
               $(LREF Unshared)
-              $(LREF Unqual)
+              $(LREF Unqualified)
     ))
     $(TR $(TD Type Constructors) $(TD
              $(LREF ConstOf)
@@ -990,19 +990,31 @@ enum isPointer(T) = is(T == U*, U);
     If none of those qualifiers have been applied to the outer layer of
     type $(D T), then the result is $(D T).
 
-    Due to limitations with D's type system, user-defined types have the type
-    qualifier removed entirely if present. The types of the member variables
-    themselves are unaffected beyond how removing the type qualifier from the
-    type containing them affects them (e.g. an $(D int*) member that is
-    $(D const(int*)) because the type containing it is $(D const) becomes
-    $(D int*) when Unconst is used on the containing type, because $(D const)
-    is removed from the containing type. The member does not become
-    $(D const(int)*) as would occur if Unconst were used directly on a
-    $(D const(int*))).
+    For the built-in, scalar types (that is $(D bool), the character types, and
+    the numeric types), they only have one layer, so $(D const U) simply becomes
+    $(D U).
 
-    Also, Unconst has no effect on what a templated type is instantiated with,
-    so if a templated type is instantiated with a template argument which is a
-    const type, the template instantiation will not change.
+    Where the layers come in is pointers and arrays. $(D const(U*)) becomes
+    $(D const(U)*), and $(D const(U[])), becomes $(D const(U)[]). So, a pointer
+    goes from being fully $(D const) to being a mutable pointer to $(D const),
+    and a dynamic array goes from being fully $(D const) to being a mutable
+    dynamic array of $(D const) elements. And if there are multiple layers of
+    pointers or arrays, it's just that outer layer which is affected - e.g.
+    $(D const(U**)) would become $(D const(U*)*).
+
+    For user-defined types, the effect is that $(D const U) becomes $(D U), and
+    how that affects member variables depends on the type of the member
+    variable. If a member variable is explicitly marked with any mutability
+    qualifiers, then it will continue to have those qualifiers even after
+    Unconst has stripped all mutability qualifiers from the containing type.
+    However, if a mutability qualifier was on the member variable only because
+    the containing type had that qualifier, then when Unconst removes the
+    qualifier from the containing type, it is removed from the member variable
+    as well.
+
+    Also, Unconst has no effect on what a templated type is instantiated
+    with, so if a templated type is instantiated with a template argument which
+    has a mutability qualifier, the template instantiation will not change.
   +/
 version (StdDdoc) template Unconst(T)
 {
@@ -1045,16 +1057,25 @@ else
     static struct S
     {
         int* ptr;
+        const int* cPtr;
+        shared int* sPtr;
     }
 
     const S s;
     static assert(is(typeof(s) == const S));
     static assert(is(typeof(typeof(s).ptr) == const int*));
+    static assert(is(typeof(typeof(s).cPtr) == const int*));
+    static assert(is(typeof(typeof(s).sPtr) == const shared int*));
 
-    // For user-defined types, the const qualifier is removed entirely.
+    // For user-defined types, all mutability qualifiers that are applied to
+    // member variables only because the containing type has them are removed,
+    // but the ones that are directly on those member variables remain.
+
     // const S -> S
     static assert(is(Unconst!(typeof(s)) == S));
     static assert(is(typeof(Unconst!(typeof(s)).ptr) == int*));
+    static assert(is(typeof(Unconst!(typeof(s)).cPtr) == const int*));
+    static assert(is(typeof(Unconst!(typeof(s)).sPtr) == shared int*));
 
     static struct Foo(T)
     {
@@ -1075,21 +1096,32 @@ else
     the result is $(D T).
 
     Note that while $(D immutable) is implicitly $(D shared), it is unaffected
-    by Unshared. Only explict $(D shared) is removed.
+    by Unshared. Only explicit $(D shared) is removed.
 
-    Due to limitations with D's type system, user-defined types have the type
-    qualifier removed entirely if present. The types of the member variables
-    themselves are unaffected beyond how removing the type qualifier from the
-    type containing them affects them (e.g. an $(D int*) member that is
-    $(D shared(int*)) because the type containing it is $(D shared) becomes
-    $(D int*) when Unshared is used on the containing type, because $(D shared)
-    is removed from the containing type. The member does not become
-    $(D shared(int)*) as would occur if Unshared were used directly on a
-    $(D shared(int*))).
+    For the built-in, scalar types (that is $(D bool), the character types, and
+    the numeric types), they only have one layer, so $(D shared U) simply
+    becomes $(D U).
 
-    Also, Unshared has no effect on what a templated type is instantiated with,
-    so if a templated type is instantiated with a template argument which is a
-    shared type, the template instantiation will not change.
+    Where the layers come in is pointers and arrays. $(D shared(U*)) becomes
+    $(D shared(U)*), and $(D shared(U[])), becomes $(D shared(U)[]). So, a
+    pointer goes from being fully $(D shared) to being a mutable pointer to
+    $(D shared), and a dynamic array goes from being fully $(D shared) to being
+    a mutable dynamic array of $(D shared) elements. And if there are multiple
+    layers of pointers or arrays, it's just that outer layer which is affected
+    - e.g. $(D shared(U**)) would become $(D shared(U*)*).
+
+    For user-defined types, the effect is that $(D shared U) becomes $(D U),
+    and how that affects member variables depends on the type of the member
+    variable. If a member variable is explicitly marked with $(D shared), then
+    it will continue to be $(D shared) even after Unshared has stripped
+    $(D shared) from the containing type. However, if $(D shared) was on the
+    member variable only because the containing type was $(D shared), then when
+    Unshared removes the qualifier from the containing type, it is removed from
+    the member variable as well.
+
+    Also, Unshared has no effect on what a templated type is instantiated
+    with, so if a templated type is instantiated with a template argument which
+    has a type qualifier, the template instantiation will not change.
   +/
 template Unshared(T)
 {
@@ -1133,23 +1165,33 @@ template Unshared(T)
     static struct S
     {
         int* ptr;
+        const int* cPtr;
+        shared int* sPtr;
     }
 
     shared S s;
     static assert(is(typeof(s) == shared S));
     static assert(is(typeof(typeof(s).ptr) == shared int*));
+    static assert(is(typeof(typeof(s).cPtr) == const shared int*));
+    static assert(is(typeof(typeof(s).sPtr) == shared int*));
 
-    // For user-defined types, the shared qualifier is removed entirely.
+    // For user-defined types, if shared is applied to a member variable only
+    // because the containing type is shared, then shared is removed from that
+    // member variable, but if the member variable is directly marked as shared,
+    // then it continues to be shared.
+
     // shared S -> S
     static assert(is(Unshared!(typeof(s)) == S));
     static assert(is(typeof(Unshared!(typeof(s)).ptr) == int*));
+    static assert(is(typeof(Unshared!(typeof(s)).cPtr) == const int*));
+    static assert(is(typeof(Unshared!(typeof(s)).sPtr) == shared int*));
 
     static struct Foo(T)
     {
         T* ptr;
     }
 
-    // The qualifer on the type is affected, but the qualifier on the template
+    // The qualifer on the type is removed, but the qualifier on the template
     // argument is not.
     static assert(is(Unshared!(shared(Foo!(shared int))) == Foo!(shared int)));
     static assert(is(Unshared!(Foo!(shared int)) == Foo!(shared int)));
@@ -1157,117 +1199,143 @@ template Unshared(T)
 }
 
 /++
-    Removes the outer layer of all type qualifiers from type $(D T).
+    Removes the outer layer of all type qualifiers from type $(D T) - this
+    includes $(D shared).
 
     If no type qualifiers have been applied to the outer layer of type $(D T),
     then the result is $(D T).
 
-    Due to limitations with D's type system, user-defined types have the type
-    qualifier removed entirely if present. The types of the member variables
-    themselves are unaffected beyond how removing the type qualifier from the
-    type containing them affects them (e.g. a $(D int*) member that is
-    $(D const(int*)) because the type containing it is $(D const) becomes
-    $(D int*) when Unqual is used on the containing type, because $(D const)
-    is removed from the containing type. The member does not become
-    $(D const(int)*) as would occur if Unqual were used directly on a
-    $(D const(int*))).
+    For the built-in, scalar types (that is $(D bool), the character types, and
+    the numeric types), they only have one layer, so $(D const U) simply becomes
+    $(D U).
 
-    Also, Unqual has no effect on what a templated type is instantiated with,
-    so if a templated type is instantiated with a template argument which has a
-    type qualifier, the template instantiation will not change.
+    Where the layers come in is pointers and arrays. $(D const(U*)) becomes
+    $(D const(U)*), and $(D const(U[])), becomes $(D const(U)[]). So, a pointer
+    goes from being fully $(D const) to being a mutable pointer to $(D const),
+    and a dynamic array goes from being fully $(D const) to being a mutable
+    dynamic array of $(D const) elements. And if there are multiple layers of
+    pointers or arrays, it's just that outer layer which is affected - e.g.
+    $(D shared(U**)) would become $(D shared(U*)*).
+
+    For user-defined types, the effect is that $(D const U) becomes $(D U), and
+    how that affects member variables depends on the type of the member
+    variable. If a member variable is explicitly marked with any qualifiers,
+    then it will continue to have those qualifiers even after Unqualified has
+    stripped all qualifiers from the containing type. However, if a qualifier
+    was on the member variable only because the containing type had that
+    qualifier, then when Unqualified removes the qualifier from the containing
+    type, it is removed from the member variable as well.
+
+    Also, Unqualified has no effect on what a templated type is instantiated
+    with, so if a templated type is instantiated with a template argument which
+    has a type qualifier, the template instantiation will not change.
 
     Note that in most cases, $(LREF Unconst) or $(LREF Unshared) should be used
-    rather than Unqual, because in most cases, code is not designed to work with
-    $(D shared) and thus doing type checks which remove $(D shared) will allow
-    $(D shared) types to pass template constraints when they won't actually
-    work with the code. And when code is designed to work with $(D shared),
-    it's often the case that the type checks need to take $(D const) into
-    account to work properly.
+    rather than Unqualified, because in most cases, code is not designed to
+    work with $(D shared) and thus doing type checks which remove $(D shared)
+    will allow $(D shared) types to pass template constraints when they won't
+    actually work with the code. And when code is designed to work with
+    $(D shared), it's often the case that the type checks need to take
+    $(D const) into account in order to avoid accidentally mutating $(D const)
+    data and violating the type system.
 
-    In particular, historically, a lot of D code has used Unqual when the
-    programmer's intent was to remove $(D const), and $(D shared) wasn't
-    actually considered at all. And in such cases, the code really should use
-    $(LREF Unconst) instead.
+    In particular, historically, a lot of D code has used
+    $(REF Unqual, std, traits) (which is equivalent to lib.sys.traits'
+    Unqualified) when the programmer's intent was to remove $(D const), and
+    $(D shared) wasn't actually considered at all. And in such cases, the code
+    really should use $(LREF Unconst) instead.
 
     But of course, if a template constraint or $(D static if) really needs to
     strip off both the mutability qualifers and $(D shared) for what it's
-    testing for, then that's what Unqual is for.
+    testing for, then that's what Unqualified is for. It's just that it's best
+    practice to use $(LREF Unconst) when it's not clear that $(D shared) should
+    be removed as well.
   +/
-version (StdDdoc) template Unqual(T)
+version (StdDdoc) template Unqualified(T)
 {
-    import core.internal.traits : CoreUnqual = Unqual;
-    alias Unqual = CoreUnqual!(T);
+    import core.internal.traits : CoreUnqualified = Unqual;
+    alias Unqualified = CoreUnqualified!(T);
 }
 else
 {
-    import core.internal.traits : CoreUnqual = Unqual;
-    alias Unqual = CoreUnqual;
+    import core.internal.traits : CoreUnqualified = Unqual;
+    alias Unqualified = CoreUnqualified;
 }
 
+///
 @safe unittest
 {
-    static assert(is(Unqual!(                   int) == int));
-    static assert(is(Unqual!(             const int) == int));
-    static assert(is(Unqual!(       inout       int) == int));
-    static assert(is(Unqual!(       inout const int) == int));
-    static assert(is(Unqual!(shared             int) == int));
-    static assert(is(Unqual!(shared       const int) == int));
-    static assert(is(Unqual!(shared inout       int) == int));
-    static assert(is(Unqual!(shared inout const int) == int));
-    static assert(is(Unqual!(         immutable int) == int));
+    static assert(is(Unqualified!(                   int) == int));
+    static assert(is(Unqualified!(             const int) == int));
+    static assert(is(Unqualified!(       inout       int) == int));
+    static assert(is(Unqualified!(       inout const int) == int));
+    static assert(is(Unqualified!(shared             int) == int));
+    static assert(is(Unqualified!(shared       const int) == int));
+    static assert(is(Unqualified!(shared inout       int) == int));
+    static assert(is(Unqualified!(shared inout const int) == int));
+    static assert(is(Unqualified!(         immutable int) == int));
 
     // Only the outer layer of immutable is removed.
     // immutable(int[]) -> immutable(int)[]
     alias ImmIntArr = immutable(int[]);
-    static assert(is(Unqual!ImmIntArr == immutable(int)[]));
+    static assert(is(Unqualified!ImmIntArr == immutable(int)[]));
 
     // Only the outer layer of const is removed.
     // const(int*) -> const(int)*
     alias ConstIntPtr = const(int*);
-    static assert(is(Unqual!ConstIntPtr == const(int)*));
+    static assert(is(Unqualified!ConstIntPtr == const(int)*));
 
     // const(int)* -> const(int)*
     alias PtrToConstInt = const(int)*;
-    static assert(is(Unqual!PtrToConstInt == const(int)*));
+    static assert(is(Unqualified!PtrToConstInt == const(int)*));
 
     // Only the outer layer of shared is removed.
     // shared(int*) -> shared(int)*
     alias SharedIntPtr = shared(int*);
-    static assert(is(Unqual!SharedIntPtr == shared(int)*));
+    static assert(is(Unqualified!SharedIntPtr == shared(int)*));
 
     // shared(int)* -> shared(int)*
     alias PtrToSharedInt = shared(int)*;
-    static assert(is(Unqual!PtrToSharedInt == shared(int)*));
+    static assert(is(Unqualified!PtrToSharedInt == shared(int)*));
 
     // Both const and shared are removed from the outer layer.
     // shared const int[] -> shared(const(int))[]
     alias SharedConstIntArr = shared const(int[]);
-    static assert(is(Unqual!SharedConstIntArr == shared(const(int))[]));
+    static assert(is(Unqualified!SharedConstIntArr == shared(const(int))[]));
 
     static struct S
     {
         int* ptr;
+        const int* cPtr;
+        shared int* sPtr;
     }
 
     shared const S s;
     static assert(is(typeof(s) == shared const S));
     static assert(is(typeof(typeof(s).ptr) == shared const int*));
+    static assert(is(typeof(typeof(s).cPtr) == shared const int*));
+    static assert(is(typeof(typeof(s).sPtr) == shared const int*));
 
-    // For user-defined types, the qualifiers are removed entirely.
+    // For user-defined types, all qualifiers that are applied to member
+    // variables only because the containing type has them are removed, but the
+    // ones that are directly on those member variables remain.
+
     // shared const S -> S
-    static assert(is(Unqual!(typeof(s)) == S));
-    static assert(is(typeof(Unqual!(typeof(s)).ptr) == int*));
+    static assert(is(Unqualified!(typeof(s)) == S));
+    static assert(is(typeof(Unqualified!(typeof(s)).ptr) == int*));
+    static assert(is(typeof(Unqualified!(typeof(s)).cPtr) == const int*));
+    static assert(is(typeof(Unqualified!(typeof(s)).sPtr) == shared int*));
 
     static struct Foo(T)
     {
         T* ptr;
     }
 
-    // The qualifers on the type are affected, but the qualifiers on the
-    // template argument is not.
-    static assert(is(Unqual!(const(Foo!(const int))) == Foo!(const int)));
-    static assert(is(Unqual!(Foo!(const int)) == Foo!(const int)));
-    static assert(is(Unqual!(const(Foo!int)) == Foo!int));
+    // The qualifers on the type are removed, but the qualifiers on the
+    // template argument are not.
+    static assert(is(Unqualified!(const(Foo!(const int))) == Foo!(const int)));
+    static assert(is(Unqualified!(Foo!(const int)) == Foo!(const int)));
+    static assert(is(Unqualified!(const(Foo!int)) == Foo!int));
 }
 
 /++


### PR DESCRIPTION
The reason for this is because Unqual currently gets used heavily when in many (most?) cases, Unconst should be used instead, because the code in question is not supposed to be operating on shared, and thus stripping off shared will either allow shared types in when they shouldn't be (e.g. with a template constraint), or in the case of a cast, it will actually strip off shared and the protections that it provides, risking concurrency bugs. But a lot of D programmers are in the habit of using Unqual rather than Unconst (probably in part because Unqual has been around longer) when they simply want to remove const, and by renaming it, we will hopefully discourage its use - or at least make programmers think about it briefly rather than unthinkingly grabbing Unqual.

Obviously, there are cases where Unqualified should still be used, but hopefully, with the new name, it will be used less when it shouldn't be.

I've also adjusted the documentation on Unconst, Unqualified, and Unshared to try to better clarify the situation with user-defined types and member variables (since as Paul Backus has pointed out, it's often incorrectly assumed that Unqual is guaranteed to strip const off of all of the member variables when that's not actually true).

And yes, I'll create another PR to rename lib.sys to phobos.sys as requested in the recent planning meeting, but I was already partially done with this, so I completed it first.