### PR TITLE
[std.socket] Cast assign to getaddrinfoPointer is not @safe

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -1116,7 +1116,7 @@ Address[] getAddress(scope const(char)[] hostname, ushort port)
             // test via gethostbyname
             auto getaddrinfoPointerBackup = getaddrinfoPointer;
             cast() getaddrinfoPointer = null;
-            scope(exit) cast() getaddrinfoPointer = getaddrinfoPointerBackup;
+            scope(exit) () @trusted { cast() getaddrinfoPointer = getaddrinfoPointerBackup; }();
 
             addresses = getAddress("63.105.9.61");
             assert(addresses.length && addresses[0].toAddrString() == "63.105.9.61");
@@ -1196,7 +1196,7 @@ Address parseAddress(scope const(char)[] hostaddr, ushort port)
             // test via inet_addr
             auto getaddrinfoPointerBackup = getaddrinfoPointer;
             cast() getaddrinfoPointer = null;
-            scope(exit) cast() getaddrinfoPointer = getaddrinfoPointerBackup;
+            scope(exit) () @trusted { cast() getaddrinfoPointer = getaddrinfoPointerBackup; }();
 
             address = parseAddress("63.105.9.61");
             assert(address.toAddrString() == "63.105.9.61");
@@ -1698,7 +1698,7 @@ public:
                 // test reverse lookup, via gethostbyaddr
                 auto getnameinfoPointerBackup = getnameinfoPointer;
                 cast() getnameinfoPointer = null;
-                scope(exit) cast() getnameinfoPointer = getnameinfoPointerBackup;
+                scope(exit) () @trusted { cast() getnameinfoPointer = getnameinfoPointerBackup; }();
 
                 assert(ia.toHostNameString() == "digitalmars.com");
             }
@@ -1716,7 +1716,7 @@ public:
             // test failing reverse lookup, via gethostbyaddr
             auto getnameinfoPointerBackup = getnameinfoPointer;
             cast() getnameinfoPointer = null;
-            scope(exit) cast() getnameinfoPointer = getnameinfoPointerBackup;
+            scope(exit) () @trusted { cast() getnameinfoPointer = getnameinfoPointerBackup; }();
 
             assert(ia.toHostNameString() is null);
         }


### PR DESCRIPTION
Fixes needed for https://github.com/dlang/dmd/pull/16315

With that pull, using a type qualifier cast is not `@safe` to use as an lvalue.
Workaround this with `@trusted` lambdas. This is not ideal, but the alternative of making the whole softUnittest argument `@trusted` then might fail to check the other calls are `@safe`.