### PR TITLE
swap-and-destroy called too eagerly

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -971,7 +971,7 @@ if (distinctFieldNames!(Specs))
         {
             import std.algorithm.mutation : swap;
 
-            static if (is(R : Tuple!Types) && !__traits(isRef, rhs) && isTuple!R)
+            static if (is(R == Tuple!Types) && !__traits(isRef, rhs) && isTuple!R)
             {
                 if (__ctfe)
                 {


### PR DESCRIPTION
The error exhibits as:
```
std/typecons.d(984): Error: none of the overloads of template `std.algorithm.mutation.swap` are callable using argument types `!(Tuple!(ubyte, uint))(Tuple!(ubyte, uint), Tuple!(immutable(ubyte), uint))`
std/algorithm/mutation.d(2840):        Candidates are: `swap(T)(ref T lhs, ref T rhs)`
std/algorithm/mutation.d(3102):                        `swap(T)(ref T lhs, ref T rhs)`
  with `T = Tuple!(ubyte, uint)`
  must satisfy the following constraint:
       `is(typeof(lhs.proxySwap(rhs)))`
iteration.d(69): Error: template instance `std.typecons.Tuple!(ubyte, uint).Tuple.opAssign!(Tuple!(immutable(ubyte), uint))` error instantiating
iteration.d(13):        instantiated from here: `Group!("a == b", immutable(ubyte)[])`
iteration.d(109):        instantiated from here: `group!("a == b", immutable(ubyte)[])`
```
triggered by https://github.com/dlang/dmd/pull/16314 and is blocking it.

The trouble is Tuple.opAssign() selects swap-and-destroy when one of the arguments is const/mutable/shared, and so cannot be assigned to. This fix causes the opAssign branch to be taken instead.

The test case is a bit difficult to come up with, as it comes with 16384.