### PR TITLE
co-locate overloads of std.algorithm.mutation.swap()

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2843,6 +2843,7 @@ void swap(T)(ref T lhs, ref T rhs)
     lhs.proxySwap(rhs);
 }
 
+/// ditto
 void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow @nogc
 if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 {

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2838,7 +2838,7 @@ Params:
     rhs = Data to be swapped with `lhs`.
 */
 void swap(T)(ref T lhs, ref T rhs)
-    if (is(typeof(lhs.proxySwap(rhs))))
+if (is(typeof(lhs.proxySwap(rhs))))
 {
     lhs.proxySwap(rhs);
 }

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -2837,6 +2837,12 @@ Params:
     lhs = Data to be swapped with `rhs`.
     rhs = Data to be swapped with `lhs`.
 */
+void swap(T)(ref T lhs, ref T rhs)
+    if (is(typeof(lhs.proxySwap(rhs))))
+{
+    lhs.proxySwap(rhs);
+}
+
 void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow @nogc
 if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 {
@@ -3096,13 +3102,6 @@ if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 
     A[1] a3, a4;
     swap(a3, a4);
-}
-
-/// ditto
-void swap(T)(ref T lhs, ref T rhs)
-if (is(typeof(lhs.proxySwap(rhs))))
-{
-    lhs.proxySwap(rhs);
 }
 
 /**


### PR DESCRIPTION
The two overloads are widely separated. This puts them together for easier study. The changes are mostly indenting.

Also has its own error message rather than the compiler generated one.