### PR TITLE
Rename lib to phobos.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,7 +6,7 @@ copyright "Copyright © 1999-2024, The D Language Foundation"
 
 configuration "library" {
     targetType "staticLibrary"
-    sourcePaths "lib"
+    sourcePaths "phobos"
     targetPath "generated-lib"
     #excludedSourceFiles "unittest.d" "test/**" "std/**" "tools/**" "etc/**"
 }
@@ -14,7 +14,7 @@ configuration "library" {
 configuration "unittest" {
     dflags "-main"
     targetType "executable"
-    sourcePaths "lib"
+    sourcePaths "phobos"
     targetPath "generated-lib"
     #excludedSourceFiles "unittest.d" "test/**" "std/**" "tools/**" "etc/**"
 }

--- a/lib/package.d
+++ b/lib/package.d
@@ -1,3 +1,0 @@
-module lib;
-
-public import lib.sys;

--- a/lib/sys/package.d
+++ b/lib/sys/package.d
@@ -1,4 +1,0 @@
-module lib.sys;
-
-public import lib.sys.compiler;
-public import lib.sys.system;

--- a/phobos/sys/compiler.d
+++ b/phobos/sys/compiler.d
@@ -6,14 +6,14 @@
  * Copyright: Copyright The D Language Foundation 2000 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright), Alex Rønne Petersen
- * Source:    $(PHOBOSSRC std/compiler.d)
+ * Source:    $(PHOBOSSRC phobos/sys/compiler.d)
  */
 /*          Copyright The D Language Foundation 2000 - 2011.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module lib.sys.compiler;
+module phobos.sys.compiler;
 
 immutable
 {

--- a/phobos/sys/meta.d
+++ b/phobos/sys/meta.d
@@ -69,9 +69,9 @@
     Authors: $(HTTP digitalmars.com, Walter Bright),
              $(HTTP klickverbot.at, David Nadlinger)
              $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Source:    $(PHOBOSSRC lib/sys/meta)
+    Source:    $(PHOBOSSRC phobos/sys/meta)
 +/
-module lib.sys.meta;
+module phobos.sys.meta;
 
 // Example for converting types to values from module documentation.
 @safe unittest
@@ -215,7 +215,7 @@ template Map(alias fun, args...)
 ///
 @safe unittest
 {
-    import lib.sys.traits : Unqualified;
+    import phobos.sys.traits : Unqualified;
 
     // empty
     alias Empty = Map!Unqualified;

--- a/phobos/sys/system.d
+++ b/phobos/sys/system.d
@@ -7,9 +7,9 @@
  *  License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  *  Authors:   $(HTTP digitalmars.com, Walter Bright) and
                $(HTTP jmdavisprog.com, Jonathan M Davis)
- *  Source:    $(PHOBOSSRC std/system.d)
+ *  Source:    $(PHOBOSSRC phobos/sys/system.d)
  */
-module lib.sys.system;
+module phobos.sys.system;
 
 immutable
 {

--- a/phobos/sys/traits.d
+++ b/phobos/sys/traits.d
@@ -2,7 +2,7 @@
 /++
     Templates which extract information about types and symbols at compile time.
 
-    In the context of lib.sys.traits, a "trait" is a template which provides
+    In the context of phobos.sys.traits, a "trait" is a template which provides
     information about a type or symbol. Most traits evaluate to
     $(D true) or $(D false), telling the code using it whether the given
     arguments match / have that specific trait (e.g. whether the given type is
@@ -83,9 +83,9 @@
                $(HTTP klickverbot.at, David Nadlinger),
                Kenji Hara,
                Shoichi Kato
-    Source:    $(PHOBOSSRC lib/sys/traits)
+    Source:    $(PHOBOSSRC phobos/sys/traits)
 +/
-module lib.sys.traits;
+module phobos.sys.traits;
 
 /++
     Whether the given type is a dynamic array (or what is sometimes referred to
@@ -242,7 +242,7 @@ enum isDynamicArray(T) = is(T == U[], U);
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -376,7 +376,7 @@ enum bool isStaticArray(T) = is(T == U[n], U, size_t n);
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -516,7 +516,7 @@ enum isInteger(T) = is(immutable T == immutable byte) ||
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -661,7 +661,7 @@ enum isFloatingPoint(T) = is(immutable T == immutable float) ||
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -820,7 +820,7 @@ enum isNumeric(T) = is(immutable T == immutable byte) ||
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -947,7 +947,7 @@ enum isPointer(T) = is(T == U*, U);
 
 @safe unittest
 {
-    import lib.sys.meta : Alias, AliasSeq;
+    import phobos.sys.meta : Alias, AliasSeq;
 
     static struct AliasThis(T)
     {
@@ -1240,7 +1240,7 @@ template Unshared(T)
     data and violating the type system.
 
     In particular, historically, a lot of D code has used
-    $(REF Unqual, std, traits) (which is equivalent to lib.sys.traits'
+    $(REF Unqual, std, traits) (which is equivalent to phobos.sys.traits'
     Unqualified) when the programmer's intent was to remove $(D const), and
     $(D shared) wasn't actually considered at all. And in such cases, the code
     really should use $(LREF Unconst) instead.
@@ -1342,9 +1342,9 @@ else
     Applies $(D const) to the given type.
 
     This is primarily useful in conjunction with templates that take a template
-    predicate (such as many of the templates in lib.sys.meta), since while in
+    predicate (such as many of the templates in phobos.sys.meta), since while in
     most cases, you can simply do $(D const T) or $(D const(T)) to make $(D T)
-    $(D const), with something like $(REF Map, lib, sys, meta), you need to
+    $(D const), with something like $(REF Map, phobos, sys, meta), you need to
     pass a template to be applied.
 
     See_Also:
@@ -1365,7 +1365,7 @@ alias ConstOf(T) = const T;
     // Note that const has no effect on immutable.
     static assert(is(ConstOf!(immutable int) == immutable int));
 
-    import lib.sys.meta : AliasSeq, Map;
+    import phobos.sys.meta : AliasSeq, Map;
 
     alias Types = AliasSeq!(int, long,
                             bool*, ubyte[],
@@ -1381,10 +1381,10 @@ alias ConstOf(T) = const T;
     Applies $(D immutable) to the given type.
 
     This is primarily useful in conjunction with templates that take a template
-    predicate (such as many of the templates in lib.sys.meta), since while in
+    predicate (such as many of the templates in phobos.sys.meta), since while in
     most cases, you can simply do $(D immutable T) or $(D immutable(T)) to make
-    $(D T) $(D immutable), with something like $(REF Map, lib, sys, meta), you
-    need to pass a template to be applied.
+    $(D T) $(D immutable), with something like $(REF Map, phobos, sys, meta),
+    you need to pass a template to be applied.
 
     See_Also:
         $(LREF ConstOf)
@@ -1408,7 +1408,7 @@ alias ImmutableOf(T) = immutable T;
 
     static assert(is(ImmutableOf!(immutable int) == immutable int));
 
-    import lib.sys.meta : AliasSeq, Map;
+    import phobos.sys.meta : AliasSeq, Map;
 
     alias Types = AliasSeq!(int, long,
                             bool*, ubyte[],
@@ -1424,9 +1424,9 @@ alias ImmutableOf(T) = immutable T;
     Applies $(D inout) to the given type.
 
     This is primarily useful in conjunction with templates that take a template
-    predicate (such as many of the templates in lib.sys.meta), since while in
+    predicate (such as many of the templates in phobos.sys.meta), since while in
     most cases, you can simply do $(D inout T) or $(D inout(T)) to make $(D T)
-    $(D inout), with something like $(REF Map, lib, sys, meta), you need to
+    $(D inout), with something like $(REF Map, phobos, sys, meta), you need to
     pass a template to be applied.
 
     See_Also:
@@ -1447,7 +1447,7 @@ alias InoutOf(T) = inout T;
     // Note that inout has no effect on immutable.
     static assert(is(InoutOf!(immutable int) == immutable int));
 
-    import lib.sys.meta : AliasSeq, Map;
+    import phobos.sys.meta : AliasSeq, Map;
 
     alias Types = AliasSeq!(int, long,
                             bool*, ubyte[],
@@ -1463,9 +1463,9 @@ alias InoutOf(T) = inout T;
     Applies $(D shared) to the given type.
 
     This is primarily useful in conjunction with templates that take a template
-    predicate (such as many of the templates in lib.sys.meta), since while in
+    predicate (such as many of the templates in phobos.sys.meta), since while in
     most cases, you can simply do $(D shared T) or $(D shared(T)) to make $(D T)
-    $(D shared), with something like $(REF Map, lib, sys, meta), you need to
+    $(D shared), with something like $(REF Map, phobos, sys, meta), you need to
     pass a template to be applied.
 
     See_Also:
@@ -1487,7 +1487,7 @@ alias SharedOf(T) = shared T;
     // implicitly shared.
     static assert(is(SharedOf!(immutable int) == immutable int));
 
-    import lib.sys.meta : AliasSeq, Map;
+    import phobos.sys.meta : AliasSeq, Map;
 
     alias Types = AliasSeq!(int, long,
                             bool*, ubyte[],


### PR DESCRIPTION
As discussed in a recent planning meeting, we're renaming lib to phobos, making it so that the root for Phobos v3 is phobos. So, that's what this commit does.

However, on top of that, I removed the existing package.d files (both lib/package.d and lib/sys/package.d) rather than fixing them, since I'm inclined to think that we should be very selective about when we use package.d, and I think that allowing something like import phobos; is a mistake.

It wouldn't surprise me if we get screaming about that later, and maybe we'll add it back at that point, but I'd rather not worry about maintaining it as modules get added, and if we can get away with it, I think that we should just not have it at all, since it's better practice in general to limit the symbols that you import to something close to what you're actually using, whereas import phobos; would be importing everything. And having a package.d at each level like lib/sys/package.d seems to be trying to do would complicate things even further.

We may very well end up with some package.d files in some cases, but I think that that should be handled on a case-by-case basis - and that the default should be to only have one module to import a symbol from.

So, with these changes, lib becomes phobos, and there are no longer any package.d files in it.