### PR TITLE
std/math/hardware.d: use an alternative register naming to fix LDC compilation

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -203,7 +203,7 @@ private:
         {
             asm nothrow @nogc
             {
-                "movgr2fcsr $r2,$r0";
+                "movgr2fcsr $fcsr2,$r0";
             }
         }
         else
@@ -933,7 +933,7 @@ private:
         {
             asm nothrow @nogc
             {
-                "movgr2fcsr $r0,%0" :
+                "movgr2fcsr $fcsr0,%0" :
                 : "r" (newState & (roundingMask | allExceptions));
             }
         }


### PR DESCRIPTION
This pull request switches `std/math/hardware.d` to use an alternative register naming for LoongArch64 so that LDC/LLVM can recognize certain fp instructions.