### PR TITLE
Fix Bugzilla Issue 24458 - Mac M3 associative array keys on std.net.curl gets overwritten

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2449,6 +2449,8 @@ struct HTTP
 
                     auto m = header.findSplit(": ");
                     auto fieldName = m[0].toLower();
+                    ///Fixes https://issues.dlang.org/show_bug.cgi?id=24458
+                    fieldName = fieldName.idup;
                     auto fieldContent = m[2].chomp;
                     if (fieldName == "content-type")
                     {

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2422,6 +2422,7 @@ struct HTTP
             import std.algorithm.searching : findSplit, startsWith;
             import std.string : indexOf, chomp;
             import std.uni : toLower;
+            import std.exception : assumeUnique;
 
             // Wrap incoming callback in order to separate http status line from
             // http headers.  On redirected requests there may be several such
@@ -2448,9 +2449,9 @@ struct HTTP
                     }
 
                     auto m = header.findSplit(": ");
-                    auto fieldName = m[0].toLower();
+                    const(char)[] lowerFieldName = m[0].toLower();
                     ///Fixes https://issues.dlang.org/show_bug.cgi?id=24458
-                    fieldName = fieldName.idup;
+                    string fieldName = lowerFieldName is m[0] ? lowerFieldName.idup : assumeUnique(lowerFieldName);
                     auto fieldContent = m[2].chomp;
                     if (fieldName == "content-type")
                     {


### PR DESCRIPTION
@schveiguy Helped discover and fix the problem