### PR TITLE
Add the Phobos v3 unit tests to the regular unittest build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ else
 unittest : unittest-debug unittest-release
 unittest-%:
 	$(MAKE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
+	DMD=$(DMD) $(DMD) -run build_v3.d unittest-$*
 endif
 
 ################################################################################

--- a/phobos/sys/meta.d
+++ b/phobos/sys/meta.d
@@ -435,14 +435,13 @@ private template AppendIfUnique(alias Cmp, Args...)
 ///
 @safe unittest
 {
-    alias Types = AliasSeq!(int, uint, long, string, short, int*, ushort);
+    alias Types = AliasSeq!(int, uint, long, short, int*, ushort);
 
     template sameSize(T)
     {
         enum sameSize(U) = T.sizeof == U.sizeof;
     }
-    static assert(is(Unique!(sameSize, Types) ==
-                     AliasSeq!(int, long, string, short)));
+    static assert(is(Unique!(sameSize, Types) == AliasSeq!(int, long, short)));
 
     // The predicate must be partially instantiable.
     enum sameSize_fails(T, U) = T.sizeof == U.sizeof;


### PR DESCRIPTION
This probably isn't the best way to do this, and presumably, it'll need to be reworked at some point (just like the Phobos v3 build in general likely will need to be reworked), but this should at least make it so that the Phobos v3 tests get run as part of the CI.