### PR TITLE
Remove dscanner check for const/immutable variables in unit tests.

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -52,7 +52,7 @@ comma_expression_check="enabled"
 ; Checks for local imports that are too broad
 local_import_check="skip-unittest"
 ; Checks for variables that could be declared immutable
-could_be_immutable_check="enabled"
+could_be_immutable_check="skip-unittest"
 ; Checks for redundant expressions in if statements
 redundant_if_check="enabled"
 ; Checks for redundant parenthesis


### PR DESCRIPTION
This appears to be the check which is making
https://github.com/dlang/phobos/pull/8924 fail the style check with warnings such as

std/internal/test/range.d(43:14)[warn]: Variable b is never modified and could have been declared const or immutable.

It makes no sense to require that unit tests follow such a rule, and it is actually detrimental when tests involve stuff like copy constructors, because then the type of the target variable matters as part of the test.

Honestly, I think that it should probably not be checked at all, since it's a pretty questionable requirement in many cases given how strict D's const and immutable are, but that's more debatable, whereas this check really makes no sense with unit tests, so I'm just disabling it for unit tests for now. We can disable it more generally later if it turns out that it's causing problems for normal code.