### PR TITLE
merge stable

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -52,7 +52,7 @@ comma_expression_check="enabled"
 ; Checks for local imports that are too broad
 local_import_check="skip-unittest"
 ; Checks for variables that could be declared immutable
-could_be_immutable_check="enabled"
+could_be_immutable_check="skip-unittest"
 ; Checks for redundant expressions in if statements
 redundant_if_check="enabled"
 ; Checks for redundant parenthesis

--- a/std/internal/test/range.d
+++ b/std/internal/test/range.d
@@ -23,3 +23,94 @@ module std.internal.test.range;
     auto r = R().chunks(3);
     assert(r.equal!equal([[ 0, 1, 2 ], [ 3, 4 ]]));
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=24415
+@safe unittest
+{
+    import std.range : only;
+
+    static struct S(T)
+    {
+        T i;
+
+        this(ref return scope inout(S) rhs) scope @safe inout pure nothrow
+        {
+            i = rhs.i;
+        }
+    }
+    {
+        auto a = only(S!int(42));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!int(42));
+
+        a.popFront();
+        auto c = a;
+        assert(c.empty);
+    }
+    {
+        auto a = only(S!(const int)(42));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!(const int)(42));
+
+        a.popFront();
+        auto c = a;
+        assert(c.empty);
+    }
+    {
+        auto a = only(S!(immutable int)(42));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!(immutable int)(42));
+
+        a.popFront();
+        auto c = a;
+        assert(c.empty);
+    }
+    {
+        auto a = only(S!int(42), S!int(192));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!int(42));
+
+        a.popFront();
+        auto c = a;
+        assert(!c.empty);
+        assert(c.front == S!int(192));
+
+        a.popFront();
+        auto d = a;
+        assert(d.empty);
+    }
+    {
+        auto a = only(S!(const int)(42), S!(const int)(192));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!(const int)(42));
+
+        a.popFront();
+        auto c = a;
+        assert(!c.empty);
+        assert(c.front == S!(const int)(192));
+
+        a.popFront();
+        auto d = a;
+        assert(d.empty);
+    }
+    {
+        auto a = only(S!(immutable int)(42), S!(immutable int)(192));
+        auto b = a;
+        assert(!b.empty);
+        assert(b.front == S!(immutable int)(42));
+
+        a.popFront();
+        auto c = a;
+        assert(!c.empty);
+        assert(c.front == S!(immutable int)(192));
+
+        a.popFront();
+        auto d = a;
+        assert(d.empty);
+    }
+}

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -10398,6 +10398,14 @@ private struct OnlyResult(T)
     }
     alias opDollar = length;
 
+    // FIXME Workaround for https://issues.dlang.org/show_bug.cgi?id=24415
+    import std.traits : hasElaborateCopyConstructor;
+    static if (hasElaborateCopyConstructor!T)
+    {
+        private static struct WorkaroundBugzilla24415 {}
+        public this()(WorkaroundBugzilla24415) {}
+    }
+
     private this()(return scope auto ref T value)
     {
         ref @trusted unqual(ref T x){return cast() x;}


### PR DESCRIPTION
- Remove dscanner check for const/immutable variables in unit tests.
- Work around bugzilla issue 24415 - only doesn't work with elements with a copy constructor.
