### PR TITLE
Fix bugzilla 24524: Very slow process fork if RLIMIT_NOFILE is too high

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1034,6 +1034,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
 
             if (!(config.flags & Config.Flags.inheritFDs))
             {
+                import core.sys.posix.sys.resource : rlimit, getrlimit, RLIMIT_NOFILE;
                 import core.sys.posix.dirent : dirent, opendir, readdir, closedir, DIR;
                 import core.sys.posix.unistd : close;
                 import core.sys.posix.stdlib : atoi, malloc, free;
@@ -1042,9 +1043,23 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                 pragma(mangle, "dirfd")
                 extern(C) nothrow @nogc int dirfd(DIR* dir);
 
-                // Try to open the directory /dev/fd or /proc/self/fd
-                DIR* dir = opendir("/dev/fd");
-                if (dir is null) dir = opendir("/proc/self/fd");
+                // Get the maximum number of file descriptors that could be open.
+                rlimit r;
+                if (getrlimit(RLIMIT_NOFILE, &r) != 0)
+                    abortOnError(forkPipeOut, InternalError.getrlimit, .errno);
+
+                DIR* dir = null;
+
+                // Reading /dev/fd or /proc/self/fd works better than using poll() if ...
+                if (
+                    r.rlim_cur/(forkPipeOut+1) > 120 ||     // ... the number of file descriptors is small ...
+                    r.rlim_cur > 1024*1024                  // ... or the soft limit is high. In this case poll would allocate a huge array)
+                )
+                {
+                    // Try to open the directory /dev/fd or /proc/self/fd
+                    dir = opendir("/dev/fd");
+                    if (dir is null) dir = opendir("/proc/self/fd");
+                }
 
                 // If we have a directory, close all file descriptors except stdin, stdout, stderr and forkPipeOut
                 if (dir)
@@ -1077,14 +1092,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                     // in its own implementation via opendir().
                     import core.stdc.stdlib : malloc;
                     import core.sys.posix.poll : pollfd, poll, POLLNVAL;
-                    import core.sys.posix.sys.resource : rlimit, getrlimit, RLIMIT_NOFILE;
 
-                    // Get the maximum number of file descriptors that could be open.
-                    rlimit r;
-                    if (getrlimit(RLIMIT_NOFILE, &r) != 0)
-                    {
-                        abortOnError(forkPipeOut, InternalError.getrlimit, .errno);
-                    }
                     immutable maxDescriptors = cast(int) r.rlim_cur;
 
                     // The above, less stdin, stdout, and stderr

--- a/std/process.d
+++ b/std/process.d
@@ -1069,14 +1069,14 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                     int opendirfd = dirfd(dir);
 
                     // Iterate over all file descriptors
-                    while(true)
+                    while (true)
                     {
                         dirent* entry = readdir(dir);
 
                         if (entry is null) break;
                         if (entry.d_name[0] == '.') continue;
 
-                        int fd = atoi(cast(char*)entry.d_name);
+                        int fd = atoi(cast(char*) entry.d_name);
 
                         // Don't close stdin, stdout, stderr, forkPipeOut or the directory file descriptor
                         if (fd < 3 || fd == forkPipeOut || fd == opendirfd) continue;

--- a/std/process.d
+++ b/std/process.d
@@ -1050,11 +1050,8 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
 
                 DIR* dir = null;
 
-                // Reading /dev/fd or /proc/self/fd works better than using poll() if ...
-                if (
-                    r.rlim_cur/(forkPipeOut+1) > 120 ||     // ... the number of file descriptors is small ...
-                    r.rlim_cur > 1024*1024                  // ... or the soft limit is high. In this case poll would allocate a huge array)
-                )
+                // We read from /dev/fd or /proc/self/fd only if the limit is high enough
+                if (r.rlim_cur > 128*1024)
                 {
                     // Try to open the directory /dev/fd or /proc/self/fd
                     dir = opendir("/dev/fd");
@@ -1084,43 +1081,54 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
                         close(fd);
                     }
                 }
-                else // Fallback
+                else
                 {
-                    // NOTE: malloc() and getrlimit() are not on the POSIX async
-                    // signal safe functions list, but practically this should
-                    // not be a problem. Java VM and CPython also use malloc()
-                    // in its own implementation via opendir().
-                    import core.stdc.stdlib : malloc;
-                    import core.sys.posix.poll : pollfd, poll, POLLNVAL;
+                    bool fallback = true;
 
-                    immutable maxDescriptors = cast(int) r.rlim_cur;
+                    // This is going to allocate 8 bytes for each possible file descriptor from 3 to r.rlim_cur
+                    if (r.rlim_cur <= 128*1024)
+                    {
+                        // NOTE: malloc() and getrlimit() are not on the POSIX async
+                        // signal safe functions list, but practically this should
+                        // not be a problem. Java VM and CPython also use malloc()
+                        // in its own implementation via opendir().
+                        import core.stdc.stdlib : malloc;
+                        import core.sys.posix.poll : pollfd, poll, POLLNVAL;
 
-                    // The above, less stdin, stdout, and stderr
-                    immutable maxToClose = maxDescriptors - 3;
+                        immutable maxDescriptors = cast(int) r.rlim_cur;
 
-                    // Call poll() to see which ones are actually open:
-                    auto pfds = cast(pollfd*) malloc(pollfd.sizeof * maxToClose);
-                    if (pfds is null)
-                    {
-                        abortOnError(forkPipeOut, InternalError.malloc, .errno);
-                    }
-                    foreach (i; 0 .. maxToClose)
-                    {
-                        pfds[i].fd = i + 3;
-                        pfds[i].events = 0;
-                        pfds[i].revents = 0;
-                    }
-                    if (poll(pfds, maxToClose, 0) >= 0)
-                    {
+                        // The above, less stdin, stdout, and stderr
+                        immutable maxToClose = maxDescriptors - 3;
+
+                        // Call poll() to see which ones are actually open:
+                        auto pfds = cast(pollfd*) malloc(pollfd.sizeof * maxToClose);
+                        if (pfds is null)
+                        {
+                            abortOnError(forkPipeOut, InternalError.malloc, .errno);
+                        }
+
                         foreach (i; 0 .. maxToClose)
                         {
-                            // don't close pipe write end
-                            if (pfds[i].fd == forkPipeOut) continue;
-                            // POLLNVAL will be set if the file descriptor is invalid.
-                            if (!(pfds[i].revents & POLLNVAL)) close(pfds[i].fd);
+                            pfds[i].fd = i + 3;
+                            pfds[i].events = 0;
+                            pfds[i].revents = 0;
+                        }
+
+                        if (poll(pfds, maxToClose, 0) >= 0)
+                        {
+                            foreach (i; 0 .. maxToClose)
+                            {
+                                // don't close pipe write end
+                                if (pfds[i].fd == forkPipeOut) continue;
+                                // POLLNVAL will be set if the file descriptor is invalid.
+                                if (!(pfds[i].revents & POLLNVAL)) close(pfds[i].fd);
+                            }
+
+                            fallback = false;
                         }
                     }
-                    else
+
+                    if (fallback)
                     {
                         // Fall back to closing everything.
                         foreach (i; 3 .. maxDescriptors)


### PR DESCRIPTION
When the soft limit for NOFILE is set to a high number, the current code for `spawnProcess`, `pipeProcess`, etc. becomes very slow and memory intensive.

This is particularly evident when running a D application inside a Docker container. Docker sets the soft limit to the maximum allowed, which on some systems can be as high as 2^30.

This code reads the list of file descriptors in use from `/dev/fd` or `/proc/this/fd`, avoiding the need to scroll through the entire list of possible file descriptors.