### PR TITLE
Fix sharedLog assignment.

### DIFF
--- a/std/logger/core.d
+++ b/std/logger/core.d
@@ -1433,7 +1433,7 @@ logger by the user, the default logger's log level is LogLevel.info.
 
 Example:
 -------------
-sharedLog = new FileLogger(yourFile);
+sharedLog = new shared FileLogger(yourFile);
 -------------
 The example sets a new `FileLogger` as new `sharedLog`.
 
@@ -1450,7 +1450,7 @@ writing `sharedLog`.
 The default `Logger` is thread-safe.
 -------------
 if (sharedLog !is myLogger)
-    sharedLog = new myLogger;
+    sharedLog = new shared myLogger;
 -------------
 */
 @property shared(Logger) sharedLog() @safe

--- a/std/logger/filelogger.d
+++ b/std/logger/filelogger.d
@@ -80,10 +80,7 @@ class FileLogger : Logger
                                    " created in '", d,"' could not be created."));
         }
 
-        static if (is(This == shared))
-            () @trusted { (cast() this.file_).open(this.filename, "a"); }();
-        else
-            this.file_.open(this.filename, "a");
+        () @trusted { (cast() this.file_).open(this.filename, "a"); }();
     }
 
     /** A constructor for the `FileLogger` Logger that takes a reference to

--- a/std/logger/filelogger.d
+++ b/std/logger/filelogger.d
@@ -80,6 +80,7 @@ class FileLogger : Logger
                                    " created in '", d,"' could not be created."));
         }
 
+        // Cast away `shared` when the constructor is inferred shared.
         () @trusted { (cast() this.file_).open(this.filename, "a"); }();
     }
 

--- a/std/logger/filelogger.d
+++ b/std/logger/filelogger.d
@@ -37,7 +37,7 @@ class FileLogger : Logger
     auto l3 = new FileLogger("logFile", LogLevel.fatal, CreateFolder.yes);
     -------------
     */
-    this(const string fn, const LogLevel lv = LogLevel.all) @safe
+    this(this This)(const string fn, const LogLevel lv = LogLevel.all)
     {
          this(fn, lv, CreateFolder.yes);
     }
@@ -63,7 +63,7 @@ class FileLogger : Logger
     auto l2 = new FileLogger(file, LogLevel.fatal);
     -------------
     */
-    this(const string fn, const LogLevel lv, CreateFolder createFileNameFolder) @safe
+    this(this This)(const string fn, const LogLevel lv, CreateFolder createFileNameFolder)
     {
         import std.file : exists, mkdirRecurse;
         import std.path : dirName;
@@ -80,7 +80,10 @@ class FileLogger : Logger
                                    " created in '", d,"' could not be created."));
         }
 
-        this.file_.open(this.filename, "a");
+        static if (is(This == shared))
+            () @trusted { (cast() this.file_).open(this.filename, "a"); }();
+        else
+            this.file_.open(this.filename, "a");
     }
 
     /** A constructor for the `FileLogger` Logger that takes a reference to
@@ -269,4 +272,13 @@ class FileLogger : Logger
     auto tl = cast(StdForwardLogger) stdThreadLocalLog;
     assert(tl !is null);
     stdThreadLocalLog.logLevel = LogLevel.all;
+}
+
+@safe unittest
+{
+    // we don't need to actually run the code, only make sure
+    // it compiles
+    static _() {
+        auto l = new shared FileLogger("");
+    }
 }

--- a/std/logger/package.d
+++ b/std/logger/package.d
@@ -64,7 +64,7 @@ using the property called `sharedLog`. This property is a reference to the
 current default `Logger`. This reference can be used to assign a new
 default `Logger`.
 -------------
-sharedLog = new FileLogger("New_Default_Log_File.log");
+sharedLog = new shared FileLogger("New_Default_Log_File.log");
 -------------
 
 Additional `Logger` can be created by creating a new instance of the


### PR DESCRIPTION
Without the cast recent compilers complain with
```
Error: none of the overloads of `sharedLog` are callable using argument types `(FileLogger)`
        Candidates are: `std.logger.core.sharedLog()`
                        `std.logger.core.sharedLog(shared(Logger) logger)`
```