### PR TITLE
std/math/hardware.d: Fix compile error for LoongArch

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -165,7 +165,7 @@ private:
             uint result = void;
             asm pure nothrow @nogc
             {
-                "movfcsr2gr %0,$r2" : "=r" (result);
+                "movfcsr2gr %0, $fcsr2" : "=r" (result);
             }
             return result & EXCEPTIONS_MASK;
         }
@@ -883,7 +883,7 @@ private:
             ControlState cont;
             asm pure nothrow @nogc
             {
-                "movfcsr2gr %0,$r0" : "=r" (cont);
+                "movfcsr2gr %0, $fcsr0" : "=r" (cont);
             }
             cont &= (roundingMask | allExceptions);
             return cont;


### PR DESCRIPTION
This PR fixes the following compile error for LoongArch:

```
std/math/hardware.d(187):1:19: error: invalid operand for instruction
        movfcsr2gr $a0, $r2
```