### PR TITLE
Fix bugzilla 24596: std.typecons.Rebindable2: Don't destroy classes! Only destroy structs!

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3873,6 +3873,21 @@ if (isInputRange!Range && !isInfinite!Range &&
     assert([BigInt(2), BigInt(3)].maxElement == BigInt(3));
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=24596
+@safe unittest
+{
+    static class A {
+        int i;
+        int getI() @safe => i;
+        this(int i) @safe { this.i = i; }
+    }
+    auto arr = [new A(2), new A(3)];
+
+    arr.maxElement!(a => a.getI);
+
+    assert(arr[0].getI == 2);
+}
+
 // minPos
 /**
 Computes a subrange of `range` starting at the first occurrence of `range`'s

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3125,7 +3125,10 @@ private:
         }
 
         // call possible struct destructors
-        .destroy!(No.initialize)(*cast(T*) &this.data);
+        static if (is(T == struct))
+        {
+            .destroy!(No.initialize)(*cast(T*) &this.data);
+        }
     }
 }
 


### PR DESCRIPTION
PR fixes https://github.com/dlang/phobos/pull/8768 for classes.

`object.destroy` is, perhaps appropriately, the most destructive function ever written.

It does something useful (resetting the value and calling the destructor) for structs and struct derivatives, but something horrible (destroying the *class data*) for objects. So you're always tempted to use it, but you have to remember, every time, to disable the cases where it silently causes future crashes.

I forgot this time.

edit: `core.internal.container.common.destroy` looks like it does it right... Maybe I just switch to that? Is that safe to call from `std.typecons`?