### PR TITLE
fix ddoc blunders

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1306,7 +1306,7 @@ public:
 
     /**
       Sets the bits of a slice of `BitArray` starting
-      at index `start` and ends at index ($D end - 1)
+      at index `start` and ends at index $(D end - 1)
       with the values specified by `val`.
      */
     void opSliceAssign(bool val, size_t start, size_t end) @nogc pure nothrow

--- a/std/exception.d
+++ b/std/exception.d
@@ -1542,7 +1542,7 @@ version (StdUnittest)
 /+
 Returns true if the field at index `i` in $(D T) shares its address with another field.
 
-Note: This does not merelly check if the field is a member of an union, but also that
+Note: This does not merely check if the field is a member of an union, but also that
 it is not a single child.
 +/
 package enum isUnionAliased(T, size_t i) = isUnionAliasedImpl!T(T.tupleof[i].offsetof);

--- a/std/exception.d
+++ b/std/exception.d
@@ -1540,7 +1540,7 @@ version (StdUnittest)
 }
 
 /+
-Returns true if the field at index `i` in ($D T) shares its address with another field.
+Returns true if the field at index `i` in $(D T) shares its address with another field.
 
 Note: This does not merelly check if the field is a member of an union, but also that
 it is not a single child.

--- a/std/format/package.d
+++ b/std/format/package.d
@@ -358,7 +358,7 @@ $(BOOKTABLE ,
                  Default precision is large enough to add all digits
                  of the integral value.
 
-                 In case of ($B 'a') and $(B 'A'), the integral digit can be
+                 In case of $(B 'a') and $(B 'A'), the integral digit can be
                  any hexadecimal digit.
                )
    )


### PR DESCRIPTION
Caught with `grep -Er '\(\$[A-Za-z]'`