### PR TITLE
replace dead links

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -3339,7 +3339,7 @@ else version (Posix)
     Windows uses a different set of time zone names than the IANA time zone
     database does, and how they correspond to one another changes over time
     (particularly when Microsoft updates Windows).
-    $(HTTP unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+    $(HTTP github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml, windowsZones.xml)
     provides the current conversions (which may or may not match up with what's
     on a particular Windows box depending on how up-to-date it is), and
     parseTZConversions reads in those conversions from windowsZones.xml so that
@@ -3358,7 +3358,7 @@ else version (Posix)
 
     Params:
         windowsZonesXMLText = The text from
-        $(HTTP unicode.org/cldr/data/common/supplemental/windowsZones.xml, windowsZones.xml)
+        $(HTTP github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml, windowsZones.xml)
 
     Throws:
         Exception if there is an error while parsing the given XML.
@@ -3372,7 +3372,7 @@ else version (Posix)
     // and parse it so that it's guaranteed to be up-to-date, though
     // that has the downside that the code needs to worry about the
     // site being down or unicode.org changing the URL.
-    auto url = "http://unicode.org/cldr/data/common/supplemental/windowsZones.xml";
+    auto url = "https://raw.githubusercontent.com/unicode-org/cldr/main/common/supplemental/windowsZones.xml";
     auto conversions2 = parseTZConversions(std.net.curl.get(url));
 --------------------
   +/
@@ -3458,7 +3458,7 @@ TZConversions parseTZConversions(string windowsZonesXMLText) @safe pure
     import std.algorithm.iteration : uniq;
     import std.algorithm.sorting : isSorted;
 
-    // Reduced text from http://unicode.org/cldr/data/common/supplemental/windowsZones.xml
+    // Reduced text from https://github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml
     auto sampleFileText =
 `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE supplementalData SYSTEM "../../common/dtd/ldmlSupplemental.dtd">

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -904,7 +904,7 @@ version (DragonFlyBSD)
 {
     // sbrk is deprecated in favor of mmap   (we could implement a mmap + MAP_NORESERVE + PROT_NONE version)
     // brk has been removed
-    // https://www.dragonflydigest.com/2019/02/22/22586.html
+    // https://web.archive.org/web/20221006070113/https://www.dragonflydigest.com/2019/02/22/22586.html
     // http://gitweb.dragonflybsd.org/dragonfly.git/commitdiff/dc676eaefa61b0f47bbea1c53eab86fd5ccd78c6
     // http://gitweb.dragonflybsd.org/dragonfly.git/commitdiff/4b5665564ef37dc939a3a9ffbafaab9894c18885
     // http://gitweb.dragonflybsd.org/dragonfly.git/commitdiff/8618d94a0e2ff8303ad93c123a3fa598c26a116e
@@ -968,7 +968,7 @@ version (Posix) struct SbrkRegion(uint minAlign = platformAlignment)
         scope(exit) pthread_mutex_unlock(cast(pthread_mutex_t*) &sbrkMutex) == 0
             || assert(0);
         // Assume sbrk returns the old break. Most online documentation confirms
-        // that, except for http://www.inf.udec.cl/~leo/Malloc_tutorial.pdf,
+        // that, except for https://web.archive.org/web/20171014020821/http://www.inf.udec.cl/~leo/Malloc_tutorial.pdf,
         // which claims the returned value is not portable.
         auto p = sbrk(rounded);
         if (p == cast(void*) -1)

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -60,7 +60,7 @@ struct MmapAllocator
             // http://man7.org/linux/man-pages/man2/mmap.2.html
             package alias allocateZeroed = allocate;
         else version (NetBSD)
-            // http://netbsd.gw.com/cgi-bin/man-cgi?mmap+2+NetBSD-current
+            // https://man.netbsd.org/mmap.2
             package alias allocateZeroed = allocate;
         else version (Solaris)
             // https://docs.oracle.com/cd/E88353_01/html/E37841/mmap-2.html

--- a/std/json.d
+++ b/std/json.d
@@ -13,7 +13,7 @@ also $(LINK https://forum.dlang.org/post/dzfyaxypmkdrpakmycjv@forum.dlang.org).)
 Copyright: Copyright Jeremie Pelletier 2008 - 2009.
 License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   Jeremie Pelletier, David Herberth
-References: $(LINK http://json.org/), $(LINK http://seriot.ch/parsing_json.html)
+References: $(LINK http://json.org/), $(LINK https://seriot.ch/projects/parsing_json.html)
 Source:    $(PHOBOSSRC std/json.d)
 */
 /*

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3405,7 +3405,7 @@ private:
 
     // This algorithm works by performing the even and odd parts of our FFT
     // using the "two for the price of one" method mentioned at
-    // http://www.engineeringproductivitytools.com/stuff/T0001/PT10.HTM#Head521
+    // https://web.archive.org/web/20180312110051/http://www.engineeringproductivitytools.com/stuff/T0001/PT10.HTM#Head521
     // by making the odd terms into the imaginary components of our new FFT,
     // and then using symmetry to recombine them.
     void fftImplPureReal(Ret, R)(R range, Ret buf) const

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -813,8 +813,9 @@ The mode must be compatible with the mode of the file descriptor.
 Throws: `ErrnoException` in case of error.
 Params:
     fd = File descriptor to associate with this `File`.
-    stdioOpenmode = Mode to associate with this File. The mode has the same semantics
-        semantics as in the C standard library $(CSTDIO fdopen) function,
+    stdioOpenmode = Mode to associate with this File. The mode has the same
+        semantics as in the POSIX library function $(HTTP
+        pubs.opengroup.org/onlinepubs/7908799/xsh/fdopen.html, fdopen)
         and must be compatible with `fd`.
  */
     void fdopen(int fd, scope const(char)[] stdioOpenmode = "rb") @safe

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -795,7 +795,7 @@ Throws: `ErrnoException` in case of error.
 /**
 Detaches from the current file (throwing on failure), and then runs a command
 by calling the C standard library function $(HTTP
-opengroup.org/onlinepubs/007908799/xsh/_popen.html, _popen).
+pubs.opengroup.org/onlinepubs/7908799/xsh/popen.html, popen).
 
 Throws: `ErrnoException` in case of error.
  */
@@ -4576,11 +4576,11 @@ if ((isSomeFiniteCharInputRange!R1 || isSomeString!R1) &&
         {
             /*
              * The new opengroup large file support API is transparently
-             * included in the normal C bindings. http://opengroup.org/platform/lfs.html#1.0
+             * included in the normal C bindings. https://www.opengroup.org/platform/lfs.html#1.0
              * if _FILE_OFFSET_BITS in druntime is 64, off_t is 64 bit and
              * the normal functions work fine. If not, then large file support
              * probably isn't available. Do not use the old transitional API
-             * (the native extern(C) fopen64, http://www.unix.org/version2/whatsnew/lfs20mar.html#3.0)
+             * (the native extern(C) fopen64, https://unix.org/version2/whatsnew/lfs20mar.html#3.0)
              */
             import core.sys.posix.stdio : fopen;
             return fopen(namez, modez);

--- a/std/utf.d
+++ b/std/utf.d
@@ -53,7 +53,7 @@ $(TR $(TD Miscellaneous) $(TD
     See_Also:
         $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
         $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>
-        $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
+        $(LINK https://web.archive.org/web/20100113043530/https://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
     Copyright: Copyright The D Language Foundation 2000 - 2012.
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP digitalmars.com, Walter Bright) and


### PR DESCRIPTION
Found with the following script

```
for link in $(grep -Eor 'https?://[^\\)", ]+' | grep -v dlang.org \
| grep -Eo 'https?://.+'); do (printf "%s: " "$link"; curl -Is "$link" \
| head -n1) | grep -E '4..$'; done

for link in $(grep -Eor '\\$\\(HTTP .+, ' | grep -v dlang.org \
| cut -d' ' -f2- | sed 's/, .*$//'); do out="$(curl -Is "$link")"; \
(! [ $? = 0 ] || printf '%s' "$out" | head -n1 | grep -Eq '4..') \
&& printf '%s\\n' "$link"; done
```