### PR TITLE
Expand `goo.gl` links that may break

### DIFF
--- a/std/experimental/allocator/building_blocks/package.d
+++ b/std/experimental/allocator/building_blocks/package.d
@@ -43,7 +43,7 @@ alignedReallocate) APIs.))
 $(TR $(TDC size_t goodAllocSize(size_t n);, $(POST $(RES) >= n)) $(TD Allocators
 customarily allocate memory in discretely-sized chunks. Therefore, a request for
 `n` bytes may result in a larger allocation. The extra memory allocated goes
-unused and adds to the so-called $(HTTP goo.gl/YoKffF,internal fragmentation).
+unused and adds to the so-called $(HTTPS en.wikipedia.org/wiki/Fragmentation_(computing)#Internal_fragmentation,internal fragmentation).
 The function `goodAllocSize(n)` returns the actual number of bytes that would
 be allocated upon a request for `n` bytes. This module defines a default
 implementation that returns `n` rounded up to a multiple of the allocator's
@@ -137,7 +137,7 @@ thread-safe or not, this instance may be `shared`.))
 
 $(H2 Sample Assembly)
 
-The example below features an _allocator modeled after $(HTTP goo.gl/m7329l,
+The example below features an _allocator modeled after $(HTTP jemalloc.net/,
 jemalloc), which uses a battery of free-list allocators spaced so as to keep
 internal fragmentation to a minimum. The `FList` definitions specify no
 bounds for the freelist because the `Segregator` does all size selection in

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -134,7 +134,7 @@ enum Options : ulong
     bytesNotMoved = 1u << 17,
     /**
     Measures the sum of extra bytes allocated beyond the bytes requested, i.e.
-    the $(HTTP goo.gl/YoKffF, internal fragmentation). This is the current
+    the $(HTTPS en.wikipedia.org/wiki/Fragmentation_(computing)#Internal_fragmentation, internal fragmentation). This is the current
     effective number of slack bytes, and it goes up and down with time.
     */
     bytesSlack = 1u << 18,

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -52,7 +52,7 @@ struct Mallocator
         import core.memory : pureRealloc;
         if (!s)
         {
-            // fuzzy area in the C standard, see http://goo.gl/ZpWeSE
+            // fuzzy area in the C standard, see https://stackoverflow.com/questions/6502077/malloc-and-realloc-functions
             // so just deallocate and nullify the pointer
             deallocate(b);
             b = null;


### PR DESCRIPTION
Fixes Bugzilla Issue 24667 - goo.gl is going away.

Note: [www.canonware.com/download/jemalloc/jemalloc-latest/doc/jemalloc.html](http://www.canonware.com/download/jemalloc/jemalloc-latest/doc/jemalloc.html) jemalloc link isn't responding, replaced with jemalloc.net (link at end of https://github.com/jemalloc/jemalloc?tab=readme-ov-file#readme).