### PR TITLE
Fix issue 24704: Improve error messages for from*String in std.datetime.

### DIFF
--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -3161,10 +3161,10 @@ public:
 
         auto str = strip(isoString);
 
-        enforce(str.length >= 15, new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce!DateTimeException(str.length >= 15, format("Invalid format for DateTime.fromISOString %s", isoString));
         auto t = str.byCodeUnit.countUntil('T');
 
-        enforce(t != -1, new DateTimeException(format("Invalid ISO String: %s", isoString)));
+        enforce!DateTimeException(t != -1, format("Invalid format for DateTime.fromISOString: %s", isoString));
 
         immutable date = Date.fromISOString(str[0 .. t]);
         immutable tod = TimeOfDay.fromISOString(str[t+1 .. $]);
@@ -3262,10 +3262,11 @@ public:
 
         auto str = strip(isoExtString);
 
-        enforce(str.length >= 15, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
+        enforce!DateTimeException(str.length >= 15,
+                                  format("Invalid format for DateTime.fromISOExtString: %s", isoExtString));
         auto t = str.byCodeUnit.countUntil('T');
 
-        enforce(t != -1, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
+        enforce!DateTimeException(t != -1, format("Invalid format for DateTime.fromISOExtString: %s", isoExtString));
 
         immutable date = Date.fromISOExtString(str[0 .. t]);
         immutable tod = TimeOfDay.fromISOExtString(str[t+1 .. $]);
@@ -3362,10 +3363,11 @@ public:
 
         auto str = strip(simpleString);
 
-        enforce(str.length >= 15, new DateTimeException(format("Invalid string format: %s", simpleString)));
+        enforce!DateTimeException(str.length >= 15,
+                                  format("Invalid format for DateTime.fromSimpleString: %s", simpleString));
         auto t = str.byCodeUnit.countUntil(' ');
 
-        enforce(t != -1, new DateTimeException(format("Invalid string format: %s", simpleString)));
+        enforce!DateTimeException(t != -1, format("Invalid format for DateTime.fromSimpleString: %s", simpleString));
 
         immutable date = Date.fromSimpleString(str[0 .. t]);
         immutable tod = TimeOfDay.fromISOExtString(str[t+1 .. $]);
@@ -7628,7 +7630,7 @@ public:
 
         auto str = isoString.strip;
 
-        enforce!DateTimeException(str.length >= 8, text("Invalid ISO String: ", isoString));
+        enforce!DateTimeException(str.length >= 8, text("Invalid format for Date.fromISOString: ", isoString));
 
         int day, month, year;
         auto yearStr = str[0 .. $ - 4];
@@ -7643,7 +7645,7 @@ public:
             if (yearStr.length > 4)
             {
                 enforce!DateTimeException(yearStr.startsWith('-', '+'),
-                        text("Invalid ISO String: ", isoString));
+                        text("Invalid format for Date.fromISOString: ", isoString));
                 year = to!int(yearStr);
             }
             else
@@ -7653,7 +7655,7 @@ public:
         }
         catch (ConvException)
         {
-            throw new DateTimeException(text("Invalid ISO String: ", isoString));
+            throw new DateTimeException(text("Invalid format for Date.fromISOString: ", isoString));
         }
 
         return Date(year, month, day);
@@ -7774,13 +7776,13 @@ public:
         ubyte month, day;
 
         if (str.length < 10 || str[$-3] != '-' || str[$-6] != '-')
-            throw new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString));
+            throw new DateTimeException(format("Invalid format for Date.fromISOExtString: %s", isoExtString));
 
         auto yearStr = str[0 .. $-6];
         auto signAtBegining = cast(bool) yearStr.startsWith('-', '+');
         if ((yearStr.length > 4) != signAtBegining)
         {
-            throw new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString));
+            throw new DateTimeException(format("Invalid format for Date.fromISOExtString: %s", isoExtString));
         }
 
         try
@@ -7791,7 +7793,7 @@ public:
         }
         catch (ConvException)
         {
-            throw new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString));
+            throw new DateTimeException(format("Invalid format for Date.fromISOExtString: %s", isoExtString));
         }
 
         return Date(year, month, day);
@@ -7910,7 +7912,7 @@ public:
         auto str = strip(simpleString);
 
         if (str.length < 11 || str[$-3] != '-' || str[$-7] != '-')
-            throw new DateTimeException(format!"Invalid string format: %s"(simpleString));
+            throw new DateTimeException(format!"Invalid format for Date.fromSimpleString: %s"(simpleString));
 
         int year;
         uint day;
@@ -7919,7 +7921,7 @@ public:
         auto signAtBegining = cast(bool) yearStr.startsWith('-', '+');
         if ((yearStr.length > 4) != signAtBegining)
         {
-            throw new DateTimeException(format!"Invalid string format: %s"(simpleString));
+            throw new DateTimeException(format!"Invalid format for Date.fromSimpleString: %s"(simpleString));
         }
 
         try
@@ -7929,7 +7931,7 @@ public:
         }
         catch (ConvException)
         {
-            throw new DateTimeException(format!"Invalid string format: %s"(simpleString));
+            throw new DateTimeException(format!"Invalid format for Date.fromSimpleString: %s"(simpleString));
         }
 
         return Date(year, month, day);
@@ -9208,7 +9210,7 @@ public:
         int hours, minutes, seconds;
         auto str = strip(isoString);
 
-        enforce!DateTimeException(str.length == 6, text("Invalid ISO String: ", isoString));
+        enforce!DateTimeException(str.length == 6, text("Invalid format for TimeOfDay.fromISOString: ", isoString));
 
         try
         {
@@ -9220,7 +9222,7 @@ public:
         }
         catch (ConvException)
         {
-            throw new DateTimeException(text("Invalid ISO String: ", isoString));
+            throw new DateTimeException(text("Invalid format for TimeOfDay.fromISOString: ", isoString));
         }
 
         return TimeOfDay(hours, minutes, seconds);
@@ -9333,7 +9335,7 @@ public:
         int hours, minutes, seconds;
 
         if (str.length != 8 || str[2] != ':' || str[5] != ':')
-            throw new DateTimeException(text("Invalid ISO Extended String: ", isoExtString));
+            throw new DateTimeException(text("Invalid format for TimeOfDay.fromISOExtString: ", isoExtString));
 
         try
         {
@@ -9345,7 +9347,7 @@ public:
         }
         catch (ConvException)
         {
-            throw new DateTimeException(text("Invalid ISO Extended String: ", isoExtString));
+            throw new DateTimeException(text("Invalid format for TimeOfDay.fromISOExtString: ", isoExtString));
         }
 
         return TimeOfDay(hours, minutes, seconds);

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -8879,7 +8879,7 @@ public:
             return retval;
         }
         catch (DateTimeException dte)
-            throw new DateTimeException(format("Invalid ISO String: %s", isoString));
+            throw new DateTimeException(format("Invalid format for SysTime.fromISOString: %s", isoString));
     }
 
     ///
@@ -9109,7 +9109,8 @@ public:
         auto str = strip(isoExtString);
 
         auto tIndex = str.indexOf('T');
-        enforce(tIndex != -1, new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString)));
+        enforce!DateTimeException(tIndex != -1,
+                                  format("Invalid format for SysTime.fromISOExtString: %s", isoExtString));
 
         auto found = str[tIndex + 1 .. $].find('.', 'Z', '+', '-');
         auto dateTimeStr = str[0 .. $ - found[0].length];
@@ -9157,7 +9158,7 @@ public:
             return retval;
         }
         catch (DateTimeException dte)
-            throw new DateTimeException(format("Invalid ISO Extended String: %s", isoExtString));
+            throw new DateTimeException(format("Invalid format for SysTime.fromISOExtString: %s", isoExtString));
     }
 
     ///
@@ -9359,7 +9360,8 @@ public:
         auto str = strip(simpleString);
 
         auto spaceIndex = str.indexOf(' ');
-        enforce(spaceIndex != -1, new DateTimeException(format("Invalid Simple String: %s", simpleString)));
+        enforce!DateTimeException(spaceIndex != -1,
+                                  format("Invalid format for SysTime.fromSimpleString: %s", simpleString));
 
         auto found = str[spaceIndex + 1 .. $].find('.', 'Z', '+', '-');
         auto dateTimeStr = str[0 .. $ - found[0].length];
@@ -9407,7 +9409,7 @@ public:
             return retval;
         }
         catch (DateTimeException dte)
-            throw new DateTimeException(format("Invalid Simple String: %s", simpleString));
+            throw new DateTimeException(format("Invalid format for SysTime.fromSimpleString: %s", simpleString));
     }
 
     ///
@@ -11170,6 +11172,7 @@ if (isSomeString!S)
     import std.algorithm.searching : all;
     import std.ascii : isDigit;
     import std.conv : to;
+    import std.format : format;
     import std.string : representation;
 
     if (isoString.empty)
@@ -11177,10 +11180,11 @@ if (isSomeString!S)
 
     auto str = isoString.representation;
 
-    enforce(str[0] == '.', new DateTimeException("Invalid ISO String"));
+    enforce!DateTimeException(str[0] == '.', format("Invalid format for fracSecsFromISOString: %s", isoString));
     str.popFront();
 
-    enforce(!str.empty && all!isDigit(str), new DateTimeException("Invalid ISO String"));
+    enforce!DateTimeException(!str.empty && all!isDigit(str),
+                              format("Invalid format for fracSecsFromISOString: %s", isoString));
 
     dchar[7] fullISOString = void;
     foreach (i, ref dchar c; fullISOString)


### PR DESCRIPTION
The documentation for the from*String functions specifies what they accept, and the fromISO*String functions accept ISO or ISO extended strings, but it is technically the case that there are ISO and ISO extended strings which they do not accept (since the standard specifies what the fields should look like for each string but doesn't specify that all fields must be present or that any code parsing them must accept all variants).

So, technically, the error messages which have said that the given strings are not valid ISO or ISO extended strings are not necessarily correct. So, this changes the error messages to remove that ambiguity.