### PR TITLE
Added 'Haiku' and 'Solaris' to 'system'.

### DIFF
--- a/phobos/sys/system.d
+++ b/phobos/sys/system.d
@@ -39,6 +39,7 @@ immutable
         openBSD,   /// OpenBSD
         dragonFlyBSD, /// DragonFlyBSD
         solaris,   /// Solaris
+        haiku, /// HaikuOS
         android,   /// Android
         otherPosix, /// Other Posix Systems
         unknown,   /// Unknown
@@ -57,6 +58,8 @@ immutable
     else version (NetBSD)  OS os = OS.netBSD;
     else version (OpenBSD) OS os = OS.openBSD;
     else version (DragonFlyBSD) OS os = OS.dragonFlyBSD;
+    else version (Solaris) OS os = OS.solaris;
+    else version (Haiku) OS os = OS.haiku;
     else version (Posix)   OS os = OS.otherPosix;
     else OS os = OS.unknown;
 

--- a/phobos/sys/system.d
+++ b/phobos/sys/system.d
@@ -158,4 +158,3 @@ immutable
     else version (Alpha)    ISA instructionSetArchitecture = ISA.alpha;
     else ISA instructionSetArchitecture = ISA.unknown;
 }
-


### PR DESCRIPTION
A very small change. Solaris was not being used in version checking, so decided to add it. Same with HaikuOS, only there I had to add it to the `OS` enum manually.

To start with something small contributing to Phobos.

