### PR TITLE
Fix D-Scanner linting issues

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -102,7 +102,7 @@ template among(values...)
 if (isExpressionTuple!values)
 {
     uint among(Value)(Value value)
-        if (!is(CommonType!(Value, values) == void))
+    if (!is(CommonType!(Value, values) == void))
     {
         switch (value)
         {

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -443,7 +443,8 @@ if (fun.length >= 1)
         A range with each fun applied to all the elements. If there is more than one
         fun, the element type will be `Tuple` containing one element for each fun.
      */
-    auto map(Range)(Range r) if (isInputRange!(Unqual!Range))
+    auto map(Range)(Range r)
+    if (isInputRange!(Unqual!Range))
     {
         import std.meta : AliasSeq, staticMap;
 
@@ -1308,7 +1309,8 @@ if (is(typeof(unaryFun!predicate)))
         A range containing only elements `x` in `range` for
         which `predicate(x)` returns `true`.
      */
-    auto filter(Range)(Range range) if (isInputRange!(Unqual!Range))
+    auto filter(Range)(Range range)
+    if (isInputRange!(Unqual!Range))
     {
         return FilterResult!(unaryFun!predicate, Range)(range);
     }
@@ -1545,7 +1547,8 @@ template filterBidirectional(alias pred)
     Returns:
         A range containing only the elements in `r` for which `pred` returns `true`.
      */
-    auto filterBidirectional(Range)(Range r) if (isBidirectionalRange!(Unqual!Range))
+    auto filterBidirectional(Range)(Range r)
+    if (isBidirectionalRange!(Unqual!Range))
     {
         return FilterBidiResult!(unaryFun!pred, Range)(r);
     }

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1331,7 +1331,8 @@ Returns:
     The extreme value according to `map` and `selector` of the passed-in values.
 */
 private auto extremum(alias map, alias selector = "a < b", Range)(Range r)
-if (isInputRange!Range && !isInfinite!Range && is(typeof(unaryFun!map(ElementType!(Range).init))))
+if (isInputRange!Range && !isInfinite!Range &&
+    is(typeof(unaryFun!map(ElementType!(Range).init))))
 in
 {
     assert(!r.empty, "r is an empty range");
@@ -1424,7 +1425,8 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 private auto extremum(alias selector = "a < b", Range)(Range r)
-if (isInputRange!Range && !isInfinite!Range && !is(typeof(unaryFun!selector(ElementType!(Range).init))))
+if (isInputRange!Range && !isInfinite!Range &&
+    !is(typeof(unaryFun!selector(ElementType!(Range).init))))
 {
     return extremum!(a => a, selector)(r);
 }

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1331,8 +1331,7 @@ Returns:
     The extreme value according to `map` and `selector` of the passed-in values.
 */
 private auto extremum(alias map, alias selector = "a < b", Range)(Range r)
-if (isInputRange!Range && !isInfinite!Range &&
-    is(typeof(unaryFun!map(ElementType!(Range).init))))
+if (isInputRange!Range && !isInfinite!Range && is(typeof(unaryFun!map(ElementType!(Range).init))))
 in
 {
     assert(!r.empty, "r is an empty range");
@@ -1425,8 +1424,7 @@ if (isInputRange!Range && !isInfinite!Range &&
 }
 
 private auto extremum(alias selector = "a < b", Range)(Range r)
-if (isInputRange!Range && !isInfinite!Range &&
-    !is(typeof(unaryFun!selector(ElementType!(Range).init))))
+if (isInputRange!Range && !isInfinite!Range && !is(typeof(unaryFun!selector(ElementType!(Range).init))))
 {
     return extremum!(a => a, selector)(r);
 }

--- a/std/array.d
+++ b/std/array.d
@@ -2332,8 +2332,7 @@ if (isInputRange!RoR &&
 
 /// Ditto
 ElementEncodingType!(ElementType!RoR)[] join(RoR)(RoR ror)
-if (isInputRange!RoR &&
-    isInputRange!(Unqual!(ElementType!RoR)))
+if (isInputRange!RoR && isInputRange!(Unqual!(ElementType!RoR)))
 {
     alias RetType = typeof(return);
     alias ConstRetTypeElement = ElementEncodingType!RetType;
@@ -3701,7 +3700,8 @@ if (isDynamicArray!A)
      * Params:
      *     item = the single item to append
      */
-    void put(U)(U item) if (canPutItem!U)
+    void put(U)(U item)
+    if (canPutItem!U)
     {
         static if (isSomeChar!T && isSomeChar!U && T.sizeof < U.sizeof)
         {
@@ -3730,7 +3730,8 @@ if (isDynamicArray!A)
     }
 
     // Const fixing hack.
-    void put(Range)(Range items) if (canPutConstRange!Range)
+    void put(Range)(Range items)
+    if (canPutConstRange!Range)
     {
         alias p = put!(Unqual!Range);
         p(items);
@@ -3743,7 +3744,8 @@ if (isDynamicArray!A)
      * Params:
      *     items = the range of items to append
      */
-    void put(Range)(Range items) if (canPutRange!Range)
+    void put(Range)(Range items)
+    if (canPutRange!Range)
     {
         // note, we disable this branch for appending one type of char to
         // another because we can't trust the length portion.

--- a/std/array.d
+++ b/std/array.d
@@ -2332,7 +2332,8 @@ if (isInputRange!RoR &&
 
 /// Ditto
 ElementEncodingType!(ElementType!RoR)[] join(RoR)(RoR ror)
-if (isInputRange!RoR && isInputRange!(Unqual!(ElementType!RoR)))
+if (isInputRange!RoR &&
+    isInputRange!(Unqual!(ElementType!RoR)))
 {
     alias RetType = typeof(return);
     alias ConstRetTypeElement = ElementEncodingType!RetType;

--- a/std/base64.d
+++ b/std/base64.d
@@ -299,9 +299,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     /**
      * ditto
      */
-    char[] encode(R1, R2)(R1 source, R2 buffer) if (!isArray!R1 && isInputRange!R1 &&
-                                                    is(ElementType!R1 : ubyte) && hasLength!R1 &&
-                                                    is(R2 == char[]))
+    char[] encode(R1, R2)(R1 source, R2 buffer)
+    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : ubyte) && hasLength!R1 && is(R2 == char[]))
     in
     {
         assert(buffer.length >= encodeLength(source.length), "Insufficient buffer for encoding");
@@ -474,8 +473,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     size_t encode(R1, R2)(R1 source, auto ref R2 range)
-        if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : ubyte) &&
-            hasLength!R1 && !is(R2 == char[]) && isOutputRange!(R2, char))
+    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : ubyte) &&
+        hasLength!R1 && !is(R2 == char[]) && isOutputRange!(R2, char))
     {
         immutable srcLen = source.length;
         if (srcLen == 0)
@@ -559,7 +558,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  A newly-allocated `char[]` buffer containing the encoded string.
      */
     @safe
-    pure char[] encode(Range)(Range source) if (isArray!Range && is(ElementType!Range : ubyte))
+    pure char[] encode(Range)(Range source)
+    if (isArray!Range && is(ElementType!Range : ubyte))
     {
         return encode(source, new char[encodeLength(source.length)]);
     }
@@ -575,8 +575,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     /**
      * ditto
      */
-    char[] encode(Range)(Range source) if (!isArray!Range && isInputRange!Range &&
-                                           is(ElementType!Range : ubyte) && hasLength!Range)
+    char[] encode(Range)(Range source)
+    if (!isArray!Range && isInputRange!Range && is(ElementType!Range : ubyte) && hasLength!Range)
     {
         return encode(source, new char[encodeLength(source.length)]);
     }
@@ -592,8 +592,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF encoder) function instead.
      */
-    struct Encoder(Range) if (isInputRange!Range && (is(ElementType!Range : const(ubyte)[]) ||
-                                                     is(ElementType!Range : const(char)[])))
+    struct Encoder(Range)
+    if (isInputRange!Range && (is(ElementType!Range : const(ubyte)[]) || is(ElementType!Range : const(char)[])))
     {
       private:
         Range  range_;
@@ -702,7 +702,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF encoder) function instead.
      */
-    struct Encoder(Range) if (isInputRange!Range && is(ElementType!Range : ubyte))
+    struct Encoder(Range)
+    if (isInputRange!Range && is(ElementType!Range : ubyte))
     {
       private:
         Range range_;
@@ -884,7 +885,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * }
      * -----
      */
-    Encoder!(Range) encoder(Range)(Range range) if (isInputRange!Range)
+    Encoder!(Range) encoder(Range)(Range range)
+    if (isInputRange!Range)
     {
         return typeof(return)(range);
     }
@@ -981,8 +983,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  base alphabet of the current Base64 encoding scheme.
      */
     @trusted
-    pure ubyte[] decode(R1, R2)(in R1 source, return scope R2 buffer) if (isArray!R1 && is(ElementType!R1 : dchar) &&
-                                                             is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    pure ubyte[] decode(R1, R2)(in R1 source, return scope R2 buffer)
+    if (isArray!R1 && is(ElementType!R1 : dchar) && is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     in
     {
         assert(buffer.length >= realDecodeLength(source), "Insufficient buffer for decoding");
@@ -1065,9 +1067,9 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     /**
      * ditto
      */
-    ubyte[] decode(R1, R2)(R1 source, R2 buffer) if (!isArray!R1 && isInputRange!R1 &&
-                                                     is(ElementType!R1 : dchar) && hasLength!R1 &&
-                                                     is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    ubyte[] decode(R1, R2)(R1 source, R2 buffer)
+    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : dchar) && hasLength!R1
+        && is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     in
     {
         assert(buffer.length >= decodeLength(source.length), "Insufficient buffer for decoding");
@@ -1156,8 +1158,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  base alphabet of the current Base64 encoding scheme.
      */
     size_t decode(R1, R2)(in R1 source, auto ref R2 range)
-        if (isArray!R1 && is(ElementType!R1 : dchar) &&
-            !is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    if (isArray!R1 && is(ElementType!R1 : dchar) &&
+        !is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     out(result)
     {
         immutable expect = realDecodeLength(source);
@@ -1244,8 +1246,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     size_t decode(R1, R2)(R1 source, auto ref R2 range)
-        if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : dchar) &&
-            hasLength!R1 && !is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : dchar) &&
+        hasLength!R1 && !is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     out(result)
     {
         // @@@BUG@@@ Workaround for DbC problem.
@@ -1334,7 +1336,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      *  A newly-allocated `ubyte[]` buffer containing the decoded string.
      */
     @safe
-    pure ubyte[] decode(Range)(Range source) if (isArray!Range && is(ElementType!Range : dchar))
+    pure ubyte[] decode(Range)(Range source)
+    if (isArray!Range && is(ElementType!Range : dchar))
     {
         return decode(source, new ubyte[decodeLength(source.length)]);
     }
@@ -1350,8 +1353,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
     /**
      * ditto
      */
-    ubyte[] decode(Range)(Range source) if (!isArray!Range && isInputRange!Range &&
-                                            is(ElementType!Range : dchar) && hasLength!Range)
+    ubyte[] decode(Range)(Range source)
+    if (!isArray!Range && isInputRange!Range && is(ElementType!Range : dchar) && hasLength!Range)
     {
         return decode(source, new ubyte[decodeLength(source.length)]);
     }
@@ -1367,8 +1370,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF decoder) function instead.
      */
-    struct Decoder(Range) if (isInputRange!Range && (is(ElementType!Range : const(char)[]) ||
-                                                     is(ElementType!Range : const(ubyte)[])))
+    struct Decoder(Range)
+    if (isInputRange!Range && (is(ElementType!Range : const(char)[]) || is(ElementType!Range : const(ubyte)[])))
     {
       private:
         Range   range_;
@@ -1492,7 +1495,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * Note: This struct is not intended to be created in user code directly;
      * use the $(LREF decoder) function instead.
      */
-    struct Decoder(Range) if (isInputRange!Range && is(ElementType!Range : char))
+    struct Decoder(Range)
+    if (isInputRange!Range && is(ElementType!Range : char))
     {
       private:
         Range range_;
@@ -1683,7 +1687,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * }
      * -----
      */
-    Decoder!(Range) decoder(Range)(Range range) if (isInputRange!Range)
+    Decoder!(Range) decoder(Range)(Range range)
+    if (isInputRange!Range)
     {
         return typeof(return)(range);
     }

--- a/std/base64.d
+++ b/std/base64.d
@@ -300,7 +300,9 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     char[] encode(R1, R2)(R1 source, R2 buffer)
-    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : ubyte) && hasLength!R1 && is(R2 == char[]))
+    if (!isArray!R1 && isInputRange!R1 &&
+        is(ElementType!R1 : ubyte) && hasLength!R1 &&
+        is(R2 == char[]))
     in
     {
         assert(buffer.length >= encodeLength(source.length), "Insufficient buffer for encoding");
@@ -576,7 +578,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     char[] encode(Range)(Range source)
-    if (!isArray!Range && isInputRange!Range && is(ElementType!Range : ubyte) && hasLength!Range)
+    if (!isArray!Range && isInputRange!Range &&
+        is(ElementType!Range : ubyte) && hasLength!Range)
     {
         return encode(source, new char[encodeLength(source.length)]);
     }
@@ -593,7 +596,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * use the $(LREF encoder) function instead.
      */
     struct Encoder(Range)
-    if (isInputRange!Range && (is(ElementType!Range : const(ubyte)[]) || is(ElementType!Range : const(char)[])))
+    if (isInputRange!Range && (is(ElementType!Range : const(ubyte)[]) ||
+        is(ElementType!Range : const(char)[])))
     {
       private:
         Range  range_;
@@ -984,7 +988,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      */
     @trusted
     pure ubyte[] decode(R1, R2)(in R1 source, return scope R2 buffer)
-    if (isArray!R1 && is(ElementType!R1 : dchar) && is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    if (isArray!R1 && is(ElementType!R1 : dchar) &&
+        is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     in
     {
         assert(buffer.length >= realDecodeLength(source), "Insufficient buffer for decoding");
@@ -1068,8 +1073,9 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     ubyte[] decode(R1, R2)(R1 source, R2 buffer)
-    if (!isArray!R1 && isInputRange!R1 && is(ElementType!R1 : dchar) && hasLength!R1
-        && is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
+    if (!isArray!R1 && isInputRange!R1 &&
+        is(ElementType!R1 : dchar) && hasLength!R1 &&
+        is(R2 == ubyte[]) && isOutputRange!(R2, ubyte))
     in
     {
         assert(buffer.length >= decodeLength(source.length), "Insufficient buffer for decoding");
@@ -1354,7 +1360,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * ditto
      */
     ubyte[] decode(Range)(Range source)
-    if (!isArray!Range && isInputRange!Range && is(ElementType!Range : dchar) && hasLength!Range)
+    if (!isArray!Range && isInputRange!Range &&
+        is(ElementType!Range : dchar) && hasLength!Range)
     {
         return decode(source, new ubyte[decodeLength(source.length)]);
     }
@@ -1371,7 +1378,8 @@ template Base64Impl(char Map62th, char Map63th, char Padding = '=')
      * use the $(LREF decoder) function instead.
      */
     struct Decoder(Range)
-    if (isInputRange!Range && (is(ElementType!Range : const(char)[]) || is(ElementType!Range : const(ubyte)[])))
+    if (isInputRange!Range && (is(ElementType!Range : const(char)[]) ||
+        is(ElementType!Range : const(ubyte)[])))
     {
       private:
         Range   range_;

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -63,8 +63,8 @@ public:
      * Throws:
      *     $(REF ConvException, std,conv) if the string doesn't represent a valid number
      */
-    this(Range)(Range s) if (
-        isBidirectionalRange!Range &&
+    this(Range)(Range s)
+    if (isBidirectionalRange!Range &&
         isSomeChar!(ElementType!Range) &&
         !isInfinite!Range &&
         !isNarrowString!Range)
@@ -160,8 +160,8 @@ public:
      *          (ignored when magnitude is zero)
      *     magnitude = a finite range of unsigned integers
      */
-    this(Range)(bool isNegative, Range magnitude) if (
-        isInputRange!Range &&
+    this(Range)(bool isNegative, Range magnitude)
+    if (isInputRange!Range &&
         isUnsigned!(ElementType!Range) &&
         (hasLength!Range || isForwardRange!Range) &&
         !isInfinite!Range)
@@ -181,7 +181,8 @@ public:
     }
 
     /// Construct a `BigInt` from a built-in integral type.
-    this(T)(T x) pure nothrow @safe if (isIntegral!T)
+    this(T)(T x) pure nothrow @safe
+    if (isIntegral!T)
     {
         data = data.init; // @@@: Workaround for compiler bug
         opAssign(x);
@@ -196,7 +197,8 @@ public:
     }
 
     /// Construct a `BigInt` from another `BigInt`.
-    this(T)(T x) pure nothrow @safe if (is(immutable T == immutable BigInt))
+    this(T)(T x) pure nothrow @safe
+    if (is(immutable T == immutable BigInt))
     {
         opAssign(x);
     }
@@ -210,7 +212,8 @@ public:
     }
 
     /// Assignment from built-in integer types.
-    BigInt opAssign(T)(T x) pure nothrow @safe if (isIntegral!T)
+    BigInt opAssign(T)(T x) pure nothrow @safe
+    if (isIntegral!T)
     {
         data = cast(ulong) absUnsign(x);
         sign = (x < 0);
@@ -247,8 +250,8 @@ public:
      * `BigInt op= integer`.
      */
     BigInt opOpAssign(string op, T)(T y) pure nothrow @safe return scope
-        if ((op=="+" || op=="-" || op=="*" || op=="/" || op=="%"
-          || op==">>" || op=="<<" || op=="^^" || op=="|" || op=="&" || op=="^") && isIntegral!T)
+    if ((op=="+" || op=="-" || op=="*" || op=="/" || op=="%"
+        || op==">>" || op=="<<" || op=="^^" || op=="|" || op=="&" || op=="^") && isIntegral!T)
     {
         ulong u = absUnsign(y);
 
@@ -436,8 +439,7 @@ public:
      * Implements assignment operators of the form `BigInt op= BigInt`.
      */
     BigInt opOpAssign(string op, T)(T y) pure nothrow @safe return scope
-        if ((op=="+" || op== "-" || op=="*" || op=="|" || op=="&" || op=="^" || op=="/" || op=="%")
-            && is (T: BigInt))
+    if ((op=="+" || op== "-" || op=="*" || op=="|" || op=="&" || op=="^" || op=="/" || op=="%") && is (T: BigInt))
     {
         static if (op == "+")
         {
@@ -494,9 +496,8 @@ public:
      * Implements binary operators between `BigInt`s.
      */
     BigInt opBinary(string op, T)(T y) pure nothrow @safe const return scope
-        if ((op=="+" || op == "*" || op=="-" || op=="|" || op=="&" || op=="^" ||
-            op=="/" || op=="%")
-            && is (T: BigInt))
+    if ((op=="+" || op == "*" || op=="-" || op=="|" || op=="&" || op=="^" ||
+        op=="/" || op=="%") && is (T: BigInt))
     {
         BigInt r = this;
         return r.opOpAssign!(op)(y);
@@ -515,9 +516,9 @@ public:
      * Implements binary operators between `BigInt`'s and built-in integers.
      */
     BigInt opBinary(string op, T)(T y) pure nothrow @safe const return scope
-        if ((op=="+" || op == "*" || op=="-" || op=="/" || op=="|" || op=="&" ||
-            op=="^"|| op==">>" || op=="<<" || op=="^^")
-            && isIntegral!T)
+    if ((op=="+" || op == "*" || op=="-" || op=="/" || op=="|" || op=="&" ||
+        op=="^"|| op==">>" || op=="<<" || op=="^^")
+        && isIntegral!T)
     {
         BigInt r = this;
         r.opOpAssign!(op)(y);
@@ -546,7 +547,7 @@ public:
         )
      */
     auto opBinary(string op, T)(T y) pure nothrow @safe const
-        if (op == "%" && isIntegral!T)
+    if (op == "%" && isIntegral!T)
     {
         assert(y != 0, "% 0 not allowed");
 
@@ -602,7 +603,7 @@ public:
         `BigInt` on the right-hand side.
      */
     BigInt opBinaryRight(string op, T)(T y) pure nothrow @safe const
-        if ((op=="+" || op=="*" || op=="|" || op=="&" || op=="^") && isIntegral!T)
+    if ((op=="+" || op=="*" || op=="|" || op=="&" || op=="^") && isIntegral!T)
     {
         return opBinary!(op)(y);
     }
@@ -627,7 +628,7 @@ public:
     //  BigInt = integer op BigInt
     /// ditto
     BigInt opBinaryRight(string op, T)(T y) pure nothrow @safe const
-        if (op == "-" && isIntegral!T)
+    if (op == "-" && isIntegral!T)
     {
         ulong u = absUnsign(y);
         BigInt r;
@@ -643,7 +644,7 @@ public:
     //  integer = integer op BigInt
     /// ditto
     T opBinaryRight(string op, T)(T x) pure nothrow @safe const
-        if ((op=="%" || op=="/") && isIntegral!T)
+    if ((op=="%" || op=="/") && isIntegral!T)
     {
         checkDivByZero();
 
@@ -669,7 +670,8 @@ public:
     /**
         Implements `BigInt` unary operators.
      */
-    BigInt opUnary(string op)() pure nothrow @safe const if (op=="+" || op=="-" || op=="~")
+    BigInt opUnary(string op)() pure nothrow @safe const
+    if (op=="+" || op=="-" || op=="~")
     {
        static if (op=="-")
        {
@@ -687,7 +689,8 @@ public:
 
     // non-const unary operations
     /// ditto
-    BigInt opUnary(string op)() pure nothrow @safe if (op=="++" || op=="--")
+    BigInt opUnary(string op)() pure nothrow @safe
+    if (op=="++" || op=="--")
     {
         static if (op=="++")
         {
@@ -721,7 +724,8 @@ public:
     }
 
     /// ditto
-    bool opEquals(T)(const T y) const pure nothrow @nogc @safe if (isIntegral!T)
+    bool opEquals(T)(const T y) const pure nothrow @nogc @safe
+    if (isIntegral!T)
     {
         if (sign != (y<0))
             return 0;
@@ -729,7 +733,8 @@ public:
     }
 
     /// ditto
-    bool opEquals(T)(const T y) const pure nothrow @nogc if (isFloatingPoint!T)
+    bool opEquals(T)(const T y) const pure nothrow @nogc
+    if (isFloatingPoint!T)
     {
         return 0 == opCmp(y);
     }
@@ -896,7 +901,8 @@ public:
     /**
         Implements casting to floating point types.
      */
-    T opCast(T)() @safe nothrow @nogc const if (isFloatingPoint!T)
+    T opCast(T)() @safe nothrow @nogc const
+    if (isFloatingPoint!T)
     {
         return toFloat!(T, "nearest");
     }
@@ -1090,7 +1096,8 @@ public:
     }
 
     /// ditto
-    int opCmp(T)(const T y) pure nothrow @nogc @safe const if (isIntegral!T)
+    int opCmp(T)(const T y) pure nothrow @nogc @safe const
+    if (isIntegral!T)
     {
         if (sign != (y<0) )
             return sign ? -1 : 1;
@@ -1098,7 +1105,8 @@ public:
         return sign? -cmp: cmp;
     }
     /// ditto
-    int opCmp(T)(const T y) nothrow @nogc @safe const if (isFloatingPoint!T)
+    int opCmp(T)(const T y) nothrow @nogc @safe const
+    if (isFloatingPoint!T)
     {
         import core.bitop : bsr;
         import std.math.operations : cmp;

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1925,7 +1925,7 @@ public:
      * Support for unary operator ~ for `BitArray`.
      */
     BitArray opUnary(string op)() const pure nothrow
-        if (op == "~")
+    if (op == "~")
     {
         auto dim = this.dim;
 
@@ -1962,7 +1962,7 @@ public:
      * Support for binary bitwise operators for `BitArray`.
      */
     BitArray opBinary(string op)(const BitArray e2) const pure nothrow
-        if (op == "-" || op == "&" || op == "|" || op == "^")
+    if (op == "-" || op == "&" || op == "|" || op == "^")
     in
     {
         assert(e2.length == _len, "e2 must have the same length as this");
@@ -2064,7 +2064,7 @@ public:
      * Support for operator op= for `BitArray`.
      */
     BitArray opOpAssign(string op)(const BitArray e2) @nogc pure nothrow return scope
-        if (op == "-" || op == "&" || op == "|" || op == "^")
+    if (op == "-" || op == "&" || op == "|" || op == "^")
     in
     {
         assert(e2.length == _len, "e2 must have the same length as this");
@@ -2185,7 +2185,7 @@ public:
      * concatenation semantics are not followed)
      */
     BitArray opOpAssign(string op)(bool b) pure nothrow return scope
-        if (op == "~")
+    if (op == "~")
     {
         length = _len + 1;
         this[_len - 1] = b;
@@ -2215,7 +2215,7 @@ public:
      * ditto
      */
     BitArray opOpAssign(string op)(BitArray b) pure nothrow return scope
-        if (op == "~")
+    if (op == "~")
     {
         auto istart = _len;
         length = _len + b.length;
@@ -2249,7 +2249,7 @@ public:
      * Support for binary operator ~ for `BitArray`.
      */
     BitArray opBinary(string op)(bool b) const pure nothrow
-        if (op == "~")
+    if (op == "~")
     {
         BitArray r;
 
@@ -2261,7 +2261,7 @@ public:
 
     /** ditto */
     BitArray opBinaryRight(string op)(bool b) const pure nothrow
-        if (op == "~")
+    if (op == "~")
     {
         BitArray r;
 
@@ -2274,7 +2274,7 @@ public:
 
     /** ditto */
     BitArray opBinary(string op)(BitArray b) const pure nothrow
-        if (op == "~")
+    if (op == "~")
     {
         BitArray r;
 
@@ -2398,7 +2398,7 @@ public:
      * preserve bits past the end of the array.)
      */
     void opOpAssign(string op)(size_t nbits) @nogc pure nothrow
-        if (op == "<<")
+    if (op == "<<")
     {
         size_t wordsToShift = nbits / bitsPerSizeT;
         size_t bitsToShift = nbits % bitsPerSizeT;
@@ -2432,7 +2432,7 @@ public:
      * preserve bits past the end of the array.)
      */
     void opOpAssign(string op)(size_t nbits) @nogc pure nothrow
-        if (op == ">>")
+    if (op == ">>")
     {
         size_t wordsToShift = nbits / bitsPerSizeT;
         size_t bitsToShift = nbits % bitsPerSizeT;

--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -3362,12 +3362,14 @@ version (StdUnittest) private struct CountOverflows
     static struct Hook1
     {
         uint calls;
-        auto hookOpUnary(string op, T)(T value) if (op == "-")
+        auto hookOpUnary(string op, T)(T value)
+        if (op == "-")
         {
             ++calls;
             return T(42);
         }
-        auto hookOpUnary(string op, T)(T value) if (op == "~")
+        auto hookOpUnary(string op, T)(T value)
+        if (op == "~")
         {
             ++calls;
             return T(43);
@@ -3383,12 +3385,14 @@ version (StdUnittest) private struct CountOverflows
     static struct Hook2
     {
         uint calls;
-        void hookOpUnary(string op, T)(ref T value) if (op == "++")
+        void hookOpUnary(string op, T)(ref T value)
+        if (op == "++")
         {
             ++calls;
             --value;
         }
-        void hookOpUnary(string op, T)(ref T value) if (op == "--")
+        void hookOpUnary(string op, T)(ref T value)
+        if (op == "--")
         {
             ++calls;
             ++value;

--- a/std/complex.d
+++ b/std/complex.d
@@ -156,7 +156,7 @@ if (isFloatingPoint!T)
 
     /// ditto
     void toString(Writer, Char)(scope Writer w, scope const ref FormatSpec!Char formatSpec) const
-        if (isOutputRange!(Writer, const(Char)[]))
+    if (isOutputRange!(Writer, const(Char)[]))
     {
         import std.format.write : formatValue;
         import std.math.traits : signbit;
@@ -231,14 +231,14 @@ if (isFloatingPoint!T)
 
     // +complex
     Complex opUnary(string op)() const
-        if (op == "+")
+    if (op == "+")
     {
         return this;
     }
 
     // -complex
     Complex opUnary(string op)() const
-        if (op == "-")
+    if (op == "-")
     {
         return Complex(-re, -im);
     }
@@ -255,7 +255,7 @@ if (isFloatingPoint!T)
 
     // complex op numeric
     Complex!(CommonType!(T,R)) opBinary(string op, R)(const R r) const
-        if (isNumeric!R)
+    if (isNumeric!R)
     {
         alias C = typeof(return);
         auto w = C(this.re, this.im);
@@ -264,21 +264,21 @@ if (isFloatingPoint!T)
 
     // numeric + complex,  numeric * complex
     Complex!(CommonType!(T, R)) opBinaryRight(string op, R)(const R r) const
-        if ((op == "+" || op == "*") && (isNumeric!R))
+    if ((op == "+" || op == "*") && (isNumeric!R))
     {
         return opBinary!(op)(r);
     }
 
     // numeric - complex
     Complex!(CommonType!(T, R)) opBinaryRight(string op, R)(const R r) const
-        if (op == "-" && isNumeric!R)
+    if (op == "-" && isNumeric!R)
     {
         return Complex(r - re, -im);
     }
 
     // numeric / complex
     Complex!(CommonType!(T, R)) opBinaryRight(string op, R)(const R r) const
-        if (op == "/" && isNumeric!R)
+    if (op == "/" && isNumeric!R)
     {
         version (FastMath)
         {
@@ -320,7 +320,7 @@ if (isFloatingPoint!T)
 
     // numeric ^^ complex
     Complex!(CommonType!(T, R)) opBinaryRight(string op, R)(const R lhs) const
-        if (op == "^^" && isNumeric!R)
+    if (op == "^^" && isNumeric!R)
     {
         import core.math : cos, sin;
         import std.math.exponential : exp, log;
@@ -349,7 +349,7 @@ if (isFloatingPoint!T)
 
     // complex += complex,  complex -= complex
     ref Complex opOpAssign(string op, C)(const C z)
-        if ((op == "+" || op == "-") && is(C R == Complex!R))
+    if ((op == "+" || op == "-") && is(C R == Complex!R))
     {
         mixin ("re "~op~"= z.re;");
         mixin ("im "~op~"= z.im;");
@@ -358,7 +358,7 @@ if (isFloatingPoint!T)
 
     // complex *= complex
     ref Complex opOpAssign(string op, C)(const C z)
-        if (op == "*" && is(C R == Complex!R))
+    if (op == "*" && is(C R == Complex!R))
     {
         auto temp = re*z.re - im*z.im;
         im = im*z.re + re*z.im;
@@ -368,7 +368,7 @@ if (isFloatingPoint!T)
 
     // complex /= complex
     ref Complex opOpAssign(string op, C)(const C z)
-        if (op == "/" && is(C R == Complex!R))
+    if (op == "/" && is(C R == Complex!R))
     {
         version (FastMath)
         {
@@ -409,7 +409,7 @@ if (isFloatingPoint!T)
 
     // complex ^^= complex
     ref Complex opOpAssign(string op, C)(const C z)
-        if (op == "^^" && is(C R == Complex!R))
+    if (op == "^^" && is(C R == Complex!R))
     {
         import core.math : cos, sin;
         import std.math.exponential : exp, log;
@@ -425,7 +425,7 @@ if (isFloatingPoint!T)
 
     // complex += numeric,  complex -= numeric
     ref Complex opOpAssign(string op, U : T)(const U a)
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         mixin ("re "~op~"= a;");
         return this;
@@ -433,7 +433,7 @@ if (isFloatingPoint!T)
 
     // complex *= numeric,  complex /= numeric
     ref Complex opOpAssign(string op, U : T)(const U a)
-        if (op == "*" || op == "/")
+    if (op == "*" || op == "/")
     {
         mixin ("re "~op~"= a;");
         mixin ("im "~op~"= a;");
@@ -442,7 +442,7 @@ if (isFloatingPoint!T)
 
     // complex ^^= real
     ref Complex opOpAssign(string op, R)(const R r)
-        if (op == "^^" && isFloatingPoint!R)
+    if (op == "^^" && isFloatingPoint!R)
     {
         import core.math : cos, sin;
         immutable ab = abs(this)^^r;
@@ -454,7 +454,7 @@ if (isFloatingPoint!T)
 
     // complex ^^= int
     ref Complex opOpAssign(string op, U)(const U i)
-        if (op == "^^" && isIntegral!U)
+    if (op == "^^" && isIntegral!U)
     {
         switch (i)
         {

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -163,7 +163,8 @@ private
         MsgType type;
         Variant data;
 
-        this(T...)(MsgType t, T vals) if (T.length > 0)
+        this(T...)(MsgType t, T vals)
+        if (T.length > 0)
         {
             static if (T.length == 1)
             {

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -245,7 +245,8 @@ struct DList(T)
 /**
 Constructor taking a number of nodes
      */
-    this(U)(U[] values...) if (isImplicitlyConvertible!(U, T))
+    this(U)(U[] values...)
+    if (isImplicitlyConvertible!(U, T))
     {
         insertBack(values);
     }

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -801,7 +801,8 @@ Indexing operators yield or modify the value at a specified index.
 /**
 $(D k in container) returns true if the given key is in the container.
  */
-    bool opBinaryRight(string op)(KeyType k) if (op == "in")
+    bool opBinaryRight(string op)(KeyType k)
+    if (op == "in")
     {
         assert(0, "Not implemented");
     }
@@ -843,13 +844,15 @@ define `opBinary`.
 Complexity: $(BIGOH n + m), where m is the number of elements in $(D
 stuff)
  */
-    TotalContainer opBinary(string op)(Stuff rhs) if (op == "~")
+    TotalContainer opBinary(string op)(Stuff rhs)
+    if (op == "~")
     {
         assert(0, "Not implemented");
     }
 
     /// ditto
-    TotalContainer opBinaryRight(string op)(Stuff lhs) if (op == "~")
+    TotalContainer opBinaryRight(string op)(Stuff lhs)
+    if (op == "~")
     {
         assert(0, "Not implemented");
     }
@@ -857,7 +860,8 @@ stuff)
 /**
 Forwards to $(D insertAfter(this[], stuff)).
  */
-    void opOpAssign(string op)(Stuff stuff) if (op == "~")
+    void opOpAssign(string op)(Stuff stuff)
+    if (op == "~")
     {
         assert(0, "Not implemented");
     }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1285,7 +1285,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      * Complexity: $(BIGOH m * log(n))
      */
     size_t stableInsert(Stuff)(scope Stuff stuff)
-    if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem))
+    if (isInputRange!Stuff &&
+        isImplicitlyConvertible!(ElementType!Stuff, Elem))
     {
         size_t result = 0;
         static if (allowDuplicates)
@@ -1565,7 +1566,9 @@ assert(equal(rbt[], [5]));
 
     /++ Ditto +/
     size_t removeKey(Stuff)(Stuff stuff)
-    if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem) && !isDynamicArray!Stuff)
+    if (isInputRange!Stuff &&
+        isImplicitlyConvertible!(ElementType!Stuff, Elem) &&
+        !isDynamicArray!Stuff)
     {
         import std.array : array;
         //We use array in case stuff is a Range from this RedBlackTree - either

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1057,7 +1057,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
 
        Complexity: $(BIGOH log(n))
      +/
-    bool opBinaryRight(string op)(Elem e) const if (op == "in")
+    bool opBinaryRight(string op)(Elem e) const
+    if (op == "in")
     {
         return _find(e) !is null;
     }
@@ -1261,7 +1262,8 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      *
      * Complexity: $(BIGOH log(n))
      */
-    size_t stableInsert(Stuff)(Stuff stuff) if (isImplicitlyConvertible!(Stuff, Elem))
+    size_t stableInsert(Stuff)(Stuff stuff)
+    if (isImplicitlyConvertible!(Stuff, Elem))
     {
         static if (allowDuplicates)
         {
@@ -1283,8 +1285,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      * Complexity: $(BIGOH m * log(n))
      */
     size_t stableInsert(Stuff)(scope Stuff stuff)
-        if (isInputRange!Stuff &&
-            isImplicitlyConvertible!(ElementType!Stuff, Elem))
+    if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem))
     {
         size_t result = 0;
         static if (allowDuplicates)
@@ -1534,7 +1535,7 @@ assert(equal(rbt[], [5]));
 --------------------
       +/
     size_t removeKey(U...)(U elems)
-        if (allSatisfy!(isImplicitlyConvertibleToElem, U))
+    if (allSatisfy!(isImplicitlyConvertibleToElem, U))
     {
         Elem[U.length] toRemove = [elems];
         return removeKey(toRemove[]);
@@ -1542,7 +1543,7 @@ assert(equal(rbt[], [5]));
 
     /++ Ditto +/
     size_t removeKey(U)(scope U[] elems)
-        if (isImplicitlyConvertible!(U, Elem))
+    if (isImplicitlyConvertible!(U, Elem))
     {
         immutable lenBefore = length;
 
@@ -1564,9 +1565,7 @@ assert(equal(rbt[], [5]));
 
     /++ Ditto +/
     size_t removeKey(Stuff)(Stuff stuff)
-        if (isInputRange!Stuff &&
-           isImplicitlyConvertible!(ElementType!Stuff, Elem) &&
-           !isDynamicArray!Stuff)
+    if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem) && !isDynamicArray!Stuff)
     {
         import std.array : array;
         //We use array in case stuff is a Range from this RedBlackTree - either
@@ -1873,7 +1872,8 @@ assert(equal(rbt[], [5]));
     /**
      * Constructor. Pass in a range of elements to initialize the tree with.
      */
-    this(Stuff)(Stuff stuff) if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem))
+    this(Stuff)(Stuff stuff)
+    if (isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, Elem))
     {
         _setup();
         stableInsert(stuff);

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -182,7 +182,8 @@ if (!is(T == shared))
 /**
 Constructor taking a number of nodes
      */
-    this(U)(U[] values...) if (isImplicitlyConvertible!(U, T))
+    this(U)(U[] values...)
+    if (isImplicitlyConvertible!(U, T))
     {
         insertFront(values);
     }

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -109,14 +109,14 @@ if (!is(Container))
     import std.traits : isDynamicArray;
 
     auto make(Range)(Range range)
-        if (!isDynamicArray!Range && isInputRange!Range && !isInfinite!Range)
+    if (!isDynamicArray!Range && isInputRange!Range && !isInfinite!Range)
     {
         import std.range : ElementType;
         return .make!(Container!(ElementType!Range, Args))(range);
     }
 
     auto make(T)(T[] items...)
-        if (!isInfinite!T)
+    if (!isInfinite!T)
     {
         return .make!(Container!(T, Args))(items);
     }

--- a/std/conv.d
+++ b/std/conv.d
@@ -205,21 +205,21 @@ $(PRE $(I UnsignedInteger):
 template to(T)
 {
     T to(A...)(A args)
-        if (A.length > 0)
+    if (A.length > 0)
     {
         return toImpl!T(args);
     }
 
     // Fix https://issues.dlang.org/show_bug.cgi?id=6175
     T to(S)(ref S arg)
-        if (isStaticArray!S)
+    if (isStaticArray!S)
     {
         return toImpl!T(arg);
     }
 
     // Fix https://issues.dlang.org/show_bug.cgi?id=16108
     T to(S)(ref S arg)
-        if (isAggregateType!S && !isCopyable!S)
+    if (isAggregateType!S && !isCopyable!S)
     {
         return toImpl!T(arg);
     }

--- a/std/datetime/date.d
+++ b/std/datetime/date.d
@@ -1075,7 +1075,7 @@ public:
       +/
     ref DateTime add(string units)
                     (long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe pure nothrow @nogc
-        if (units == "years" || units == "months")
+    if (units == "years" || units == "months")
     {
         _date.add!units(value, allowOverflow);
         return this;
@@ -1140,7 +1140,7 @@ public:
       +/
     ref DateTime roll(string units)
                      (long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe pure nothrow @nogc
-        if (units == "years" || units == "months")
+    if (units == "years" || units == "months")
     {
         _date.roll!units(value, allowOverflow);
         return this;
@@ -1209,7 +1209,7 @@ public:
             A reference to the `DateTime` (`this`).
       +/
     ref DateTime roll(string units)(long value) @safe pure nothrow @nogc
-        if (units == "days")
+    if (units == "days")
     {
         _date.roll!"days"(value);
         return this;
@@ -1250,9 +1250,9 @@ public:
 
     /// ditto
     ref DateTime roll(string units)(long value) @safe pure nothrow @nogc
-        if (units == "hours" ||
-            units == "minutes" ||
-            units == "seconds")
+    if (units == "hours" ||
+        units == "minutes" ||
+        units == "seconds")
     {
         _tod.roll!units(value);
         return this;
@@ -2138,7 +2138,7 @@ public:
                        this $(LREF DateTime).
       +/
     DateTime opBinary(string op)(Duration duration) const @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         DateTime retval = this;
         immutable seconds = duration.total!"seconds";
@@ -2233,7 +2233,7 @@ public:
                        $(LREF DateTime).
       +/
     ref DateTime opOpAssign(string op)(Duration duration) @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         import core.time : convert;
         import std.format : format;
@@ -2339,7 +2339,7 @@ public:
         )
       +/
     Duration opBinary(string op)(DateTime rhs) const @safe pure nothrow @nogc
-        if (op == "-")
+    if (op == "-")
     {
         immutable dateResult = _date - rhs.date;
         immutable todResult = _tod - rhs._tod;
@@ -3151,7 +3151,7 @@ public:
             be valid.
       +/
     static DateTime fromISOString(S)(scope const S isoString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.algorithm.searching : countUntil;
         import std.exception : enforce;
@@ -3252,7 +3252,7 @@ public:
             would not be valid.
       +/
     static DateTime fromISOExtString(S)(scope const S isoExtString) @safe pure
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : countUntil;
         import std.exception : enforce;
@@ -3353,7 +3353,7 @@ public:
             would not be valid.
       +/
     static DateTime fromSimpleString(S)(scope const S simpleString) @safe pure
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : countUntil;
         import std.exception : enforce;
@@ -4483,7 +4483,7 @@ public:
       +/
     @safe pure nothrow @nogc
     ref Date add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-        if (units == "years")
+    if (units == "years")
     {
         _year += value;
 
@@ -4724,7 +4724,7 @@ public:
     // Shares documentation with "years" version.
     @safe pure nothrow @nogc
     ref Date add(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-        if (units == "months")
+    if (units == "months")
     {
         auto years = months / 12;
         months %= 12;
@@ -5268,7 +5268,7 @@ public:
       +/
     @safe pure nothrow @nogc
     ref Date roll(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-        if (units == "years")
+    if (units == "years")
     {
         return add!"years"(value, allowOverflow);
     }
@@ -5313,7 +5313,7 @@ public:
     // Shares documentation with "years" version.
     @safe pure nothrow @nogc
     ref Date roll(string units)(long months, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-        if (units == "months")
+    if (units == "months")
     {
         months %= 12;
         auto newMonth = _month + months;
@@ -5910,7 +5910,7 @@ public:
             A reference to the `Date` (`this`).
       +/
     ref Date roll(string units)(long days) @safe pure nothrow @nogc
-        if (units == "days")
+    if (units == "days")
     {
         immutable limit = maxDay(_year, _month);
         days %= limit;
@@ -6148,7 +6148,7 @@ public:
                        this $(LREF Date).
       +/
     Date opBinary(string op)(Duration duration) const @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         Date retval = this;
         immutable days = duration.total!"days";
@@ -6238,7 +6238,7 @@ public:
                        this $(LREF Date).
       +/
     ref Date opOpAssign(string op)(Duration duration) @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         immutable days = duration.total!"days";
         mixin("return _addDays(" ~ op ~ "days);");
@@ -6313,7 +6313,7 @@ public:
         )
       +/
     Duration opBinary(string op)(Date rhs) const @safe pure nothrow @nogc
-        if (op == "-")
+    if (op == "-")
     {
         import core.time : dur;
         return dur!"days"(this.dayOfGregorianCal - rhs.dayOfGregorianCal);
@@ -7621,7 +7621,7 @@ public:
             valid.
       +/
     static Date fromISOString(S)(scope const S isoString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.algorithm.searching : startsWith;
         import std.conv : to, text, ConvException;
@@ -7764,7 +7764,7 @@ public:
             would not be valid.
       +/
     static Date fromISOExtString(S)(scope const S isoExtString) @safe pure
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : startsWith;
         import std.conv : to, ConvException;
@@ -7902,7 +7902,7 @@ public:
             be valid.
       +/
     static Date fromSimpleString(S)(scope const S simpleString) @safe pure
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : startsWith;
         import std.conv : to, ConvException;
@@ -8606,7 +8606,7 @@ public:
             A reference to the `TimeOfDay` (`this`).
       +/
     ref TimeOfDay roll(string units)(long value) @safe pure nothrow @nogc
-        if (units == "hours")
+    if (units == "hours")
     {
         import core.time : dur;
         return this += dur!"hours"(value);
@@ -8655,7 +8655,7 @@ public:
 
     /// ditto
     ref TimeOfDay roll(string units)(long value) @safe pure nothrow @nogc
-        if (units == "minutes" || units == "seconds")
+    if (units == "minutes" || units == "seconds")
     {
         import std.format : format;
 
@@ -8851,7 +8851,7 @@ public:
                        this $(LREF TimeOfDay).
       +/
     TimeOfDay opBinary(string op)(Duration duration) const @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         TimeOfDay retval = this;
         immutable seconds = duration.total!"seconds";
@@ -8938,7 +8938,7 @@ public:
                        this $(LREF TimeOfDay).
       +/
     ref TimeOfDay opOpAssign(string op)(Duration duration) @safe pure nothrow @nogc
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         immutable seconds = duration.total!"seconds";
         mixin("return _addSeconds(" ~ op ~ "seconds);");
@@ -9004,7 +9004,7 @@ public:
             rhs = The $(LREF TimeOfDay) to subtract from this one.
       +/
     Duration opBinary(string op)(TimeOfDay rhs) const @safe pure nothrow @nogc
-        if (op == "-")
+    if (op == "-")
     {
         immutable lhsSec = _hour * 3600 + _minute * 60 + _second;
         immutable rhsSec = rhs._hour * 3600 + rhs._minute * 60 + rhs._second;
@@ -9201,7 +9201,7 @@ public:
             not be valid.
       +/
     static TimeOfDay fromISOString(S)(scope const S isoString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.conv : to, text, ConvException;
         import std.exception : enforce;
@@ -9326,7 +9326,7 @@ public:
             would not be valid.
       +/
     static TimeOfDay fromISOExtString(S)(scope const S isoExtString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.conv : ConvException, text, to;
         import std.string : strip;

--- a/std/datetime/interval.d
+++ b/std/datetime/interval.d
@@ -137,7 +137,7 @@ public:
         --------------------
       +/
     this(U)(scope const TP begin, scope const U end) pure
-        if (is(immutable TP == immutable U))
+    if (is(immutable TP == immutable U))
     {
         if (!_valid(begin, end))
             throw new DateTimeException("Arguments would result in an invalid Interval.");
@@ -162,7 +162,7 @@ public:
         --------------------
       +/
     this(D)(scope const TP begin, scope const D duration) pure
-        if (__traits(compiles, begin + duration))
+    if (__traits(compiles, begin + duration))
     {
         _begin = cast(TP) begin;
         _end = begin + duration;
@@ -1118,7 +1118,7 @@ public:
         --------------------
       +/
     void shift(D)(D duration) pure
-        if (__traits(compiles, begin + duration))
+    if (__traits(compiles, begin + duration))
     {
         _enforceNotEmpty();
 
@@ -1168,7 +1168,7 @@ public:
             --------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-            if (isIntegral!T)
+        if (isIntegral!T)
         {
             _enforceNotEmpty();
 
@@ -1215,7 +1215,7 @@ public:
         --------------------
       +/
     void expand(D)(D duration, Direction dir = Direction.both) pure
-        if (__traits(compiles, begin + duration))
+    if (__traits(compiles, begin + duration))
     {
         _enforceNotEmpty();
 
@@ -3919,7 +3919,7 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
 --------------------
       +/
     void shift(D)(D duration) pure nothrow
-        if (__traits(compiles, begin + duration))
+    if (__traits(compiles, begin + duration))
     {
         _begin += duration;
     }
@@ -3960,7 +3960,7 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
 --------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-            if (isIntegral!T)
+        if (isIntegral!T)
         {
             auto begin = _begin;
 
@@ -3992,7 +3992,7 @@ assert(interval2 == PosInfInterval!Date(Date(1996, 1, 4)));
 --------------------
       +/
     void expand(D)(D duration) pure nothrow
-        if (__traits(compiles, begin + duration))
+    if (__traits(compiles, begin + duration))
     {
         _begin -= duration;
     }
@@ -4028,7 +4028,7 @@ assert(interval2 == PosInfInterval!Date(Date(1998, 1, 2)));
 --------------------
           +/
         void expand(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-            if (isIntegral!T)
+        if (isIntegral!T)
         {
             auto begin = _begin;
 
@@ -6145,7 +6145,7 @@ assert(interval2 == NegInfInterval!Date( Date(2012, 2, 15)));
 --------------------
       +/
     void shift(D)(D duration) pure nothrow
-        if (__traits(compiles, end + duration))
+    if (__traits(compiles, end + duration))
     {
         _end += duration;
     }
@@ -6185,7 +6185,7 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
 --------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-            if (isIntegral!T)
+        if (isIntegral!T)
         {
             auto end = _end;
 
@@ -6217,7 +6217,7 @@ assert(interval2 == NegInfInterval!Date(Date(2012, 2, 28)));
 --------------------
       +/
     void expand(D)(D duration) pure nothrow
-        if (__traits(compiles, end + duration))
+    if (__traits(compiles, end + duration))
     {
         _end += duration;
     }
@@ -6253,7 +6253,7 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
 --------------------
           +/
         void expand(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
-            if (isIntegral!T)
+        if (isIntegral!T)
         {
             auto end = _end;
 

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -2444,7 +2444,7 @@ public:
             this SysTime.
       +/
     T toUnixTime(T = time_t)() @safe const pure nothrow scope
-        if (is(T == int) || is(T == long))
+    if (is(T == int) || is(T == long))
     {
         return stdTimeToUnixTime!T(_stdTime);
     }
@@ -2792,7 +2792,7 @@ public:
                             causing the month to increment.
       +/
     ref SysTime add(string units)(long value, AllowDayOverflow allowOverflow = AllowDayOverflow.yes) @safe nothrow scope
-        if (units == "years" || units == "months")
+    if (units == "years" || units == "months")
     {
         auto hnsecs = adjTime;
         auto days = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -4830,7 +4830,7 @@ public:
                     $(LREF SysTime).
       +/
     ref SysTime roll(string units)(long value) @safe nothrow scope
-        if (units == "days")
+    if (units == "days")
     {
         auto hnsecs = adjTime;
         auto gdays = splitUnitsFromHNSecs!"days"(hnsecs) + 1;
@@ -5195,7 +5195,7 @@ public:
 
     // Shares documentation with "days" version.
     ref SysTime roll(string units)(long value) @safe nothrow scope
-        if (units == "hours" || units == "minutes" || units == "seconds")
+    if (units == "hours" || units == "minutes" || units == "seconds")
     {
         try
         {
@@ -5871,7 +5871,7 @@ public:
 
     // Shares documentation with "days" version.
     ref SysTime roll(string units)(long value) @safe nothrow scope
-        if (units == "msecs" || units == "usecs" || units == "hnsecs")
+    if (units == "msecs" || units == "usecs" || units == "hnsecs")
     {
         auto hnsecs = adjTime;
         immutable days = splitUnitsFromHNSecs!"days"(hnsecs);
@@ -6308,7 +6308,7 @@ public:
                        this $(LREF SysTime).
       +/
     SysTime opBinary(string op)(Duration duration) @safe const pure nothrow return scope
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         SysTime retval = SysTime(this._stdTime, this._timezone);
         immutable hnsecs = duration.total!"hnsecs";
@@ -6528,7 +6528,7 @@ public:
                        this $(LREF SysTime).
       +/
     ref SysTime opOpAssign(string op)(Duration duration) @safe pure nothrow scope
-        if (op == "+" || op == "-")
+    if (op == "+" || op == "-")
     {
         immutable hnsecs = duration.total!"hnsecs";
         mixin("_stdTime " ~ op ~ "= hnsecs;");
@@ -6732,7 +6732,7 @@ public:
         )
       +/
     Duration opBinary(string op)(SysTime rhs) @safe const pure nothrow scope
-        if (op == "-")
+    if (op == "-")
     {
         return dur!"hnsecs"(_stdTime - rhs._stdTime);
     }
@@ -7992,7 +7992,7 @@ public:
         Returns a $(REF Date,std,datetime,date) equivalent to this $(LREF SysTime).
       +/
     Date opCast(T)() @safe const nothrow scope
-        if (is(immutable T == immutable Date))
+    if (is(immutable T == immutable Date))
     {
         return Date(dayOfGregorianCal);
     }
@@ -8033,7 +8033,7 @@ public:
         $(LREF SysTime).
       +/
     DateTime opCast(T)() @safe const nothrow scope
-        if (is(immutable T == immutable DateTime))
+    if (is(immutable T == immutable DateTime))
     {
         try
         {
@@ -8099,7 +8099,7 @@ public:
         $(LREF SysTime).
       +/
     TimeOfDay opCast(T)() @safe const nothrow scope
-        if (is(immutable T == immutable TimeOfDay))
+    if (is(immutable T == immutable TimeOfDay))
     {
         try
         {
@@ -8156,7 +8156,7 @@ public:
     // should be allowed, and it doesn't work without this opCast() since opCast()
     // has already been defined for other types.
     SysTime opCast(T)() @safe const pure nothrow scope
-        if (is(immutable T == immutable SysTime))
+    if (is(immutable T == immutable SysTime))
     {
         return SysTime(_stdTime, _timezone);
     }
@@ -8799,7 +8799,7 @@ public:
             be valid.
       +/
     static SysTime fromISOString(S)(scope const S isoString, immutable TimeZone tz = null) @safe
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.algorithm.searching : startsWith, find;
         import std.conv : to;
@@ -9100,7 +9100,7 @@ public:
             be valid.
       +/
     static SysTime fromISOExtString(S)(scope const S isoExtString, immutable TimeZone tz = null) @safe
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : countUntil, find;
         import std.conv : to;
@@ -9351,7 +9351,7 @@ public:
             be valid.
       +/
     static SysTime fromSimpleString(S)(scope const S simpleString, immutable TimeZone tz = null) @safe
-        if (isSomeString!(S))
+    if (isSomeString!(S))
     {
         import std.algorithm.searching : find;
         import std.conv : to;

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -1550,7 +1550,7 @@ package:
             isoString = A string which represents a time zone in the ISO format.
       +/
     static immutable(SimpleTimeZone) fromISOString(S)(S isoString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.algorithm.searching : startsWith;
         import std.conv : text, to, ConvException;
@@ -1704,7 +1704,7 @@ package:
             isoExtString = A string which represents a time zone in the ISO format.
       +/
     static immutable(SimpleTimeZone) fromISOExtString(S)(scope S isoExtString) @safe pure
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         import std.algorithm.searching : startsWith;
         import std.conv : ConvException, to;
@@ -2642,7 +2642,7 @@ private:
         Reads an int from a TZ file.
       +/
     static T readVal(T)(ref File tzFile) @trusted
-        if ((isIntegral!T || isSomeChar!T) || is(immutable T == immutable bool))
+    if ((isIntegral!T || isSomeChar!T) || is(immutable T == immutable bool))
     {
         import std.bitmanip : bigEndianToNative;
         T[1] buff;
@@ -2657,7 +2657,7 @@ private:
         Reads an array of values from a TZ file.
       +/
     static T readVal(T)(ref File tzFile, size_t length) @trusted
-        if (isArray!T)
+    if (isArray!T)
     {
         auto buff = new T(length);
 
@@ -2672,7 +2672,7 @@ private:
         Reads a `TempTTInfo` from a TZ file.
       +/
     static T readVal(T)(ref File tzFile) @safe
-        if (is(T == TempTTInfo))
+    if (is(T == TempTTInfo))
     {
         return TempTTInfo(readVal!int(tzFile),
                           readVal!bool(tzFile),

--- a/std/file.d
+++ b/std/file.d
@@ -4794,7 +4794,7 @@ private struct DirIteratorImpl
     }
 
     this(R)(R pathname, SpanMode mode, bool followSymlink)
-        if (isSomeFiniteCharInputRange!R)
+    if (isSomeFiniteCharInputRange!R)
     {
         _mode = mode;
         _followSymlink = followSymlink;

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1935,7 +1935,8 @@ template hasToString(T, Char)
     static struct G
     {
         string toString() {return "";}
-        void toString(Writer)(ref Writer w) if (isOutputRange!(Writer, string)) {}
+        void toString(Writer)(ref Writer w)
+        if (isOutputRange!(Writer, string)) {}
     }
     static struct H
     {
@@ -1946,7 +1947,8 @@ template hasToString(T, Char)
     }
     static struct I
     {
-        void toString(Writer)(ref Writer w) if (isOutputRange!(Writer, string)) {}
+        void toString(Writer)(ref Writer w)
+        if (isOutputRange!(Writer, string)) {}
         void toString(Writer)(ref Writer w, scope const ref FormatSpec!char fmt)
         if (isOutputRange!(Writer, string))
         {}
@@ -2042,7 +2044,8 @@ template hasToString(T, Char)
     static struct G
     {
         string toString() const {return "";}
-        void toString(Writer)(ref Writer w) const if (isOutputRange!(Writer, string)) {}
+        void toString(Writer)(ref Writer w) const
+        if (isOutputRange!(Writer, string)) {}
     }
     static struct H
     {
@@ -2053,7 +2056,8 @@ template hasToString(T, Char)
     }
     static struct I
     {
-        void toString(Writer)(ref Writer w) const if (isOutputRange!(Writer, string)) {}
+        void toString(Writer)(ref Writer w) const
+        if (isOutputRange!(Writer, string)) {}
         void toString(Writer)(ref Writer w, scope const ref FormatSpec!char fmt) const
         if (isOutputRange!(Writer, string))
         {}
@@ -2603,7 +2607,8 @@ if ((is(T == struct) || is(T == union)) && (hasToString!(T, Char) || !is(Builtin
     {
         int n = 0;
         alias n this;
-        T opCast(T) () if (is(T == Frop))
+        T opCast(T) ()
+        if (is(T == Frop))
         {
             return Frop();
         }

--- a/std/functional.d
+++ b/std/functional.d
@@ -445,7 +445,7 @@ if (S=="<"||S==">"||S=="<="||S==">="||S=="=="||S=="!=")
 {
     import std.traits : isIntegral;
     private bool unsafeOp(ElementType1, ElementType2)(ElementType1 a, ElementType2 b) pure
-        if (isIntegral!ElementType1 && isIntegral!ElementType2)
+    if (isIntegral!ElementType1 && isIntegral!ElementType2)
     {
         import std.traits : CommonType;
         alias T = CommonType!(ElementType1, ElementType2);

--- a/std/int128.d
+++ b/std/int128.d
@@ -111,7 +111,7 @@ public struct Int128
      * Returns: lvalue of result
      */
     Int128 opUnary(string op)() const
-        if (op == "+")
+    if (op == "+")
     {
         return this;
     }
@@ -121,7 +121,7 @@ public struct Int128
      * Returns: lvalue of result
      */
     Int128 opUnary(string op)() const
-        if (op == "-" || op == "~")
+    if (op == "-" || op == "~")
     {
         static if (op == "-")
             return Int128(neg(this.data));
@@ -134,7 +134,7 @@ public struct Int128
      * Returns: lvalue of result
      */
     Int128 opUnary(string op)()
-        if (op == "++" || op == "--")
+    if (op == "++" || op == "--")
     {
         static if (op == "++")
             this.data = inc(this.data);
@@ -206,9 +206,9 @@ public struct Int128
      * Returns: value after the operation is applied
      */
     Int128 opBinary(string op)(Int128 op2) const
-        if (op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^")
+    if (op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^")
     {
         static if (op == "+")
             return Int128(add(this.data, op2.data));
@@ -236,10 +236,10 @@ public struct Int128
 
     /// ditto
     Int128 opBinary(string op, Int)(const Int op2) const
-        if ((op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^") &&
-            is(Int : long) && __traits(isIntegral, Int))
+    if ((op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^") &&
+        is(Int : long) && __traits(isIntegral, Int))
     {
         static if (__traits(isUnsigned, Int))
             return mixin("this " ~ op ~ " Int128(0, op2)");
@@ -249,20 +249,20 @@ public struct Int128
 
     /// ditto
     Int128 opBinary(string op, IntLike)(auto ref IntLike op2) const
-        if ((op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^") &&
-            is(IntLike : long) && !__traits(isIntegral, IntLike))
+    if ((op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^") &&
+        is(IntLike : long) && !__traits(isIntegral, IntLike))
     {
         return opBinary!(op)(__traits(getMember, op2, __traits(getAliasThis, IntLike)[0]));
     }
 
     /// ditto
     Int128 opBinaryRight(string op, Int)(const Int op2) const
-        if ((op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^") &&
-            is(Int : long) && __traits(isIntegral, Int))
+    if ((op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^") &&
+        is(Int : long) && __traits(isIntegral, Int))
     {
         static if (__traits(isUnsigned, Int))
             mixin("return Int128(0, op2) " ~ op ~ " this;");
@@ -272,31 +272,31 @@ public struct Int128
 
     /// ditto
     Int128 opBinaryRight(string op, IntLike)(auto ref IntLike op2) const
-        if ((op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^") &&
-            is(IntLike : long) && !__traits(isIntegral, IntLike))
+    if ((op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^") &&
+        is(IntLike : long) && !__traits(isIntegral, IntLike))
     {
         return opBinaryRight!(op)(__traits(getMember, op2, __traits(getAliasThis, IntLike)[0]));
     }
 
     /// ditto
     Int128 opBinary(string op)(long op2) const
-        if (op == "<<")
+    if (op == "<<")
     {
         return Int128(shl(this.data, cast(uint) op2));
     }
 
     /// ditto
     Int128 opBinary(string op)(long op2) const
-        if (op == ">>")
+    if (op == ">>")
     {
         return Int128(sar(this.data, cast(uint) op2));
     }
 
     /// ditto
     Int128 opBinary(string op)(long op2) const
-        if (op == ">>>")
+    if (op == ">>>")
     {
         return Int128(shr(this.data, cast(uint) op2));
     }
@@ -307,10 +307,10 @@ public struct Int128
      * Returns: lvalue of updated left operand
      */
     ref Int128 opOpAssign(string op)(Int128 op2)
-        if (op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^" ||
-            op == "<<" || op == ">>" || op == ">>>")
+    if (op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^" ||
+        op == "<<" || op == ">>" || op == ">>>")
     {
         mixin("this = this " ~ op ~ " op2;");
         return this;
@@ -318,11 +318,11 @@ public struct Int128
 
     /// ditto
     ref Int128 opOpAssign(string op, Int)(auto ref Int op2)
-        if ((op == "+" || op == "-" ||
-            op == "*" || op == "/" || op == "%" ||
-            op == "&" || op == "|" || op == "^" ||
-            op == "<<" || op == ">>" || op == ">>>")
-            && is(Int : long))
+    if ((op == "+" || op == "-" ||
+        op == "*" || op == "/" || op == "%" ||
+        op == "&" || op == "|" || op == "^" ||
+        op == "<<" || op == ">>" || op == ">>>")
+        && is(Int : long))
     {
         mixin("this = this " ~ op ~ " op2;");
         return this;

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -250,7 +250,8 @@ private:
        data = x;
     }
   package(std)  // used from: std.bigint
-    this(T)(T x) pure nothrow @safe scope if (isIntegral!T)
+    this(T)(T x) pure nothrow @safe scope
+    if (isIntegral!T)
     {
         opAssign(x);
     }
@@ -312,7 +313,8 @@ public:
     }
 
     ///
-    void opAssign(Tulong)(Tulong u) pure nothrow @safe scope if (is (Tulong == ulong))
+    void opAssign(Tulong)(Tulong u) pure nothrow @safe scope
+    if (is (Tulong == ulong))
     {
         if (u == 0) data = ZERO;
         else if (u == 1) data = ONE;
@@ -356,7 +358,8 @@ public:
     }
 
     ///
-    int opCmp(Tulong)(Tulong y) pure nothrow @nogc const @safe scope if (is (Tulong == ulong))
+    int opCmp(Tulong)(Tulong y) pure nothrow @nogc const @safe scope
+    if (is (Tulong == ulong))
     {
         if (data.length > maxBigDigits!Tulong)
             return 1;
@@ -501,8 +504,8 @@ public:
     }
 
     // return false if invalid character found
-    bool fromHexString(Range)(Range s) scope if (
-        isBidirectionalRange!Range && isSomeChar!(ElementType!Range))
+    bool fromHexString(Range)(Range s) scope
+    if (isBidirectionalRange!Range && isSomeChar!(ElementType!Range))
     {
         import std.range : walkLength;
 
@@ -570,8 +573,8 @@ public:
     }
 
     // return true if OK; false if erroneous characters found
-    bool fromDecimalString(Range)(Range s) scope if (
-        isForwardRange!Range && isSomeChar!(ElementType!Range))
+    bool fromDecimalString(Range)(Range s) scope
+    if (isForwardRange!Range && isSomeChar!(ElementType!Range))
     {
         import std.range : walkLength;
 
@@ -596,9 +599,9 @@ public:
     }
 
     void fromMagnitude(Range)(Range magnitude) scope
-        if (isInputRange!Range
-            && (isForwardRange!Range || hasLength!Range)
-            && isUnsigned!(ElementType!Range))
+    if (isInputRange!Range
+        && (isForwardRange!Range || hasLength!Range)
+        && isUnsigned!(ElementType!Range))
     {
         while (!magnitude.empty && magnitude.front == 0)
             magnitude.popFront;
@@ -711,7 +714,7 @@ public:
 
     // return x >> y
     BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const return scope
-        if (op == ">>" && is (Tulong == ulong))
+    if (op == ">>" && is (Tulong == ulong))
     {
         assert(y > 0, "Can not right shift BigUint by 0");
         uint bits = cast(uint) y & BIGDIGITSHIFTMASK;
@@ -735,7 +738,7 @@ public:
 
     // return x << y
     BigUint opBinary(string op, Tulong)(Tulong y) pure nothrow @safe const scope
-        if (op == "<<" && is (Tulong == ulong))
+    if (op == "<<" && is (Tulong == ulong))
     {
         assert(y > 0, "Can not left shift BigUint by 0");
         if (isZero()) return this;
@@ -761,8 +764,8 @@ public:
 
     // If wantSub is false, return x + y, leaving sign unchanged
     // If wantSub is true, return abs(x - y), negating sign if x < y
-    static BigUint addOrSubInt(Tulong)(const scope BigUint x, Tulong y,
-            bool wantSub, ref bool sign) pure nothrow @safe if (is(Tulong == ulong))
+    static BigUint addOrSubInt(Tulong)(const scope BigUint x, Tulong y, bool wantSub, ref bool sign) pure nothrow @safe
+    if (is(Tulong == ulong))
     {
         BigUint r;
         if (wantSub)
@@ -921,7 +924,8 @@ public:
     }
 
     // return x % y
-    static uint modInt(T)(scope BigUint x, T y_) pure if ( is(immutable T == immutable uint) )
+    static uint modInt(T)(scope BigUint x, T y_) pure
+    if ( is(immutable T == immutable uint) )
     {
         import core.memory : GC;
         uint y = y_;
@@ -994,7 +998,8 @@ public:
 
     // return x op y
     static BigUint bitwiseOp(string op)(scope BigUint x, scope BigUint y, bool xSign, bool ySign, ref bool resultSign)
-    pure nothrow @safe if (op == "|" || op == "^" || op == "&")
+    pure nothrow @safe
+    if (op == "|" || op == "^" || op == "&")
     {
         auto d1 = includeSign(x.data, y.uintLength, xSign);
         auto d2 = includeSign(y.data, x.uintLength, ySign);

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -255,10 +255,11 @@ class ReferenceInputRange(T)
 {
     import std.array : array;
 
-    this(Range)(Range r) if (isInputRange!Range) {_payload = array(r);}
-    final @property ref T front(){return _payload.front;}
-    final void popFront(){_payload.popFront();}
-    final @property bool empty(){return _payload.empty;}
+    this(Range)(Range r)
+    if (isInputRange!Range) {_payload = array(r);}
+    final @property ref T front() {return _payload.front;}
+    final void popFront() {_payload.popFront();}
+    final @property bool empty() {return _payload.empty;}
     protected T[] _payload;
 }
 
@@ -268,8 +269,8 @@ Infinite input range
 class ReferenceInfiniteInputRange(T)
 {
     this(T first = T.init) {_val = first;}
-    final @property T front(){return _val;}
-    final void popFront(){++_val;}
+    final @property T front() {return _val;}
+    final void popFront() {++_val;}
     enum bool empty = false;
     protected T _val;
 }
@@ -279,7 +280,8 @@ Reference forward range
 */
 class ReferenceForwardRange(T) : ReferenceInputRange!T
 {
-    this(Range)(Range r) if (isInputRange!Range) {super(r);}
+    this(Range)(Range r)
+    if (isInputRange!Range) {super(r);}
     final @property auto save(this This)() {return new This( _payload);}
 }
 
@@ -298,9 +300,10 @@ Reference bidirectional range
 */
 class ReferenceBidirectionalRange(T) : ReferenceForwardRange!T
 {
-    this(Range)(Range r) if (isInputRange!Range) {super(r);}
-    final @property ref T back(){return _payload.back;}
-    final void popBack(){_payload.popBack();}
+    this(Range)(Range r)
+    if (isInputRange!Range) {super(r);}
+    final @property ref T back() {return _payload.back;}
+    final void popBack() {_payload.popBack();}
 }
 
 @safe unittest

--- a/std/json.d
+++ b/std/json.d
@@ -652,7 +652,8 @@ struct JSONValue
         }
     }
 
-    private void assignRef(T)(ref T arg) if (isStaticArray!T)
+    private void assignRef(T)(ref T arg)
+    if (isStaticArray!T)
     {
         type_tag = JSONType.array;
         static if (is(ElementEncodingType!T : JSONValue))
@@ -680,12 +681,14 @@ struct JSONValue
      * and `K` i.e. a JSON object, any array or `bool`. The type will
      * be set accordingly.
      */
-    this(T)(T arg) if (!isStaticArray!T)
+    this(T)(T arg)
+    if (!isStaticArray!T)
     {
         assign(arg);
     }
     /// Ditto
-    this(T)(ref T arg) if (isStaticArray!T)
+    this(T)(ref T arg)
+    if (isStaticArray!T)
     {
         assignRef(arg);
     }
@@ -774,12 +777,14 @@ struct JSONValue
         assert(arr1 != arr2);
     }
 
-    void opAssign(T)(T arg) if (!isStaticArray!T && !is(T : JSONValue))
+    void opAssign(T)(T arg)
+    if (!isStaticArray!T && !is(T : JSONValue))
     {
         assign(arg);
     }
 
-    void opAssign(T)(ref T arg) if (isStaticArray!T)
+    void opAssign(T)(ref T arg)
+    if (isStaticArray!T)
     {
         assignRef(arg);
     }

--- a/std/logger/core.d
+++ b/std/logger/core.d
@@ -1154,8 +1154,10 @@ abstract class Logger
         string funcName = __FUNCTION__,
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(lazy A args)
-    if ((args.length > 1 && !is(Unqual!(A[0]) : bool)
-        && !is(immutable A[0] == immutable LogLevel)) || args.length == 0)
+    if ((args.length > 1
+        && !is(Unqual!(A[0]) : bool)
+        && !is(immutable A[0] == immutable LogLevel))
+        || args.length == 0)
     {
         synchronized (mutex)
         {

--- a/std/logger/core.d
+++ b/std/logger/core.d
@@ -293,7 +293,7 @@ template defaultLogFunction(LogLevel ll)
         string funcName = __FUNCTION__,
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(lazy A args)
-        if ((args.length > 0 && !is(Unqual!(A[0]) : bool)) || args.length == 0)
+    if ((args.length > 0 && !is(Unqual!(A[0]) : bool)) || args.length == 0)
     {
             stdThreadLocalLog.memLogFunctions!(ll).logImpl!(line, file, funcName,
                 prettyFuncName, moduleName)(args);
@@ -446,7 +446,7 @@ private struct MsgRange
     }
 
     void put(T)(T msg) @safe
-        if (isSomeString!T)
+    if (isSomeString!T)
     {
         log.logMsgPart(msg);
     }
@@ -735,7 +735,7 @@ abstract class Logger
             string funcName = __FUNCTION__,
             string prettyFuncName = __PRETTY_FUNCTION__,
             string moduleName = __MODULE__, A...)(lazy A args)
-            if (args.length == 0 || (args.length > 0 && !is(A[0] : bool)))
+        if (args.length == 0 || (args.length > 0 && !is(A[0] : bool)))
         {
             synchronized (mutex)
             {
@@ -948,7 +948,7 @@ abstract class Logger
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(const LogLevel ll,
         lazy bool condition, lazy A args)
-        if (args.length != 1)
+    if (args.length != 1)
     {
         synchronized (mutex)
         {
@@ -1016,7 +1016,7 @@ abstract class Logger
         string funcName = __FUNCTION__,
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(const LogLevel ll, lazy A args)
-        if ((args.length > 1 && !is(Unqual!(A[0]) : bool)) || args.length == 0)
+    if ((args.length > 1 && !is(Unqual!(A[0]) : bool)) || args.length == 0)
     {
         synchronized (mutex)
         {
@@ -1085,7 +1085,7 @@ abstract class Logger
         string funcName = __FUNCTION__,
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(lazy bool condition, lazy A args)
-        if (args.length != 1)
+    if (args.length != 1)
     {
         synchronized (mutex)
         {
@@ -1154,10 +1154,8 @@ abstract class Logger
         string funcName = __FUNCTION__,
         string prettyFuncName = __PRETTY_FUNCTION__,
         string moduleName = __MODULE__, A...)(lazy A args)
-        if ((args.length > 1
-                && !is(Unqual!(A[0]) : bool)
-                && !is(immutable A[0] == immutable LogLevel))
-            || args.length == 0)
+    if ((args.length > 1 && !is(Unqual!(A[0]) : bool)
+        && !is(immutable A[0] == immutable LogLevel)) || args.length == 0)
     {
         synchronized (mutex)
         {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -496,7 +496,8 @@ public:
     static @property CustomFloat im() { return CustomFloat(0.0f); }
 
     /// Initialize from any `real` compatible type.
-    this(F)(F input) if (__traits(compiles, cast(real) input ))
+    this(F)(F input)
+    if (__traits(compiles, cast(real) input ))
     {
         this = input;
     }
@@ -512,7 +513,7 @@ public:
 
     /// Assigns from any `real` compatible type.
     void opAssign(F)(F input)
-        if (__traits(compiles, cast(real) input))
+    if (__traits(compiles, cast(real) input))
     {
         import std.conv : text;
 
@@ -546,7 +547,7 @@ public:
 
     /// Fetches the stored value either as a `float`, `double` or `real`.
     @property F get(F)()
-        if (staticIndexOf!(immutable F, immutable float, immutable double, immutable real) >= 0)
+    if (staticIndexOf!(immutable F, immutable float, immutable double, immutable real) >= 0)
     {
         import std.conv : text;
 
@@ -574,7 +575,7 @@ public:
 
     /// Convert the CustomFloat to a real and perform the relevant operator on the result
     real opUnary(string op)()
-        if (__traits(compiles, mixin(op~`(get!real)`)) || op=="++" || op=="--")
+    if (__traits(compiles, mixin(op~`(get!real)`)) || op=="++" || op=="--")
     {
         static if (op=="++" || op=="--")
         {
@@ -591,31 +592,31 @@ public:
     // do not match equally, which is disallowed by the spec:
     // https://dlang.org/spec/operatoroverloading.html#binary
     real opBinary(string op,T)(T b)
-         if (__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
-     {
-         return mixin(`get!real`~op~`b.get!real`);
-     }
+    if (__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
+    {
+        return mixin(`get!real`~op~`b.get!real`);
+    }
 
     /// ditto
     real opBinary(string op,T)(T b)
-        if ( __traits(compiles, mixin(`get!real`~op~`b`)) &&
-            !__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
+    if ( __traits(compiles, mixin(`get!real`~op~`b`)) &&
+        !__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
     {
         return mixin(`get!real`~op~`b`);
     }
 
     /// ditto
     real opBinaryRight(string op,T)(T a)
-        if ( __traits(compiles, mixin(`a`~op~`get!real`)) &&
-            !__traits(compiles, mixin(`get!real`~op~`b`)) &&
-            !__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
+    if ( __traits(compiles, mixin(`a`~op~`get!real`)) &&
+        !__traits(compiles, mixin(`get!real`~op~`b`)) &&
+        !__traits(compiles, mixin(`get!real`~op~`b.get!real`)))
     {
         return mixin(`a`~op~`get!real`);
     }
 
     /// ditto
     int opCmp(T)(auto ref T b)
-        if (__traits(compiles, cast(real) b))
+    if (__traits(compiles, cast(real) b))
     {
         auto x = get!real;
         auto y = cast(real) b;
@@ -624,7 +625,7 @@ public:
 
     /// ditto
     void opOpAssign(string op, T)(auto ref T b)
-        if (__traits(compiles, mixin(`get!real`~op~`cast(real) b`)))
+    if (__traits(compiles, mixin(`get!real`~op~`cast(real) b`)))
     {
         return mixin(`this = this `~op~` cast(real) b`);
     }
@@ -3687,7 +3688,7 @@ public:
      *              i.e., output[j] := sum[ exp(-2 PI i j k / N) input[k] ].
      */
     Complex!F[] fft(F = double, R)(R range) const
-        if (isFloatingPoint!F && isRandomAccessRange!R)
+    if (isFloatingPoint!F && isRandomAccessRange!R)
     {
         enforceSize(range);
         Complex!F[] ret;
@@ -3710,7 +3711,7 @@ public:
      * property that can be both read and written and are floating point numbers.
      */
     void fft(Ret, R)(R range, Ret buf) const
-        if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
+    if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
     {
         assert(buf.length == range.length);
         enforceSize(range);
@@ -3759,7 +3760,7 @@ public:
      *              output[j] := (1 / N) sum[ exp(+2 PI i j k / N) input[k] ].
      */
     Complex!F[] inverseFft(F = double, R)(R range) const
-        if (isRandomAccessRange!R && isComplexLike!(ElementType!R) && isFloatingPoint!F)
+    if (isRandomAccessRange!R && isComplexLike!(ElementType!R) && isFloatingPoint!F)
     {
         enforceSize(range);
         Complex!F[] ret;
@@ -3781,7 +3782,7 @@ public:
      * must be some complex-like type.
      */
     void inverseFft(Ret, R)(R range, Ret buf) const
-        if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
+    if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
     {
         enforceSize(range);
 

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2269,7 +2269,8 @@ public:
     call to `popFront` or, if thrown during construction, simply
     allowed to propagate to the caller.
     */
-    auto asyncBuf(S)(S source, size_t bufSize = 100) if (isInputRange!S)
+    auto asyncBuf(S)(S source, size_t bufSize = 100)
+    if (isInputRange!S)
     {
         static final class AsyncBuf
         {

--- a/std/path.d
+++ b/std/path.d
@@ -1446,8 +1446,7 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
         of segments to assemble the path from.
     Returns: The assembled path.
 */
-immutable(ElementEncodingType!(ElementType!Range))[]
-    buildPath(Range)(scope Range segments)
+immutable(ElementEncodingType!(ElementType!Range))[] buildPath(Range)(scope Range segments)
 if (isInputRange!Range && !isInfinite!Range && isSomeString!(ElementType!Range))
 {
     if (segments.empty) return null;

--- a/std/path.d
+++ b/std/path.d
@@ -1446,9 +1446,8 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
         of segments to assemble the path from.
     Returns: The assembled path.
 */
-immutable(ElementEncodingType!(ElementType!Range))[]
-    buildPath(Range)(scope Range segments)
-    if (isInputRange!Range && !isInfinite!Range && isSomeString!(ElementType!Range))
+immutable(ElementEncodingType!(ElementType!Range))[] buildPath(Range)(scope Range segments)
+if (isInputRange!Range && !isInfinite!Range && isSomeString!(ElementType!Range))
 {
     if (segments.empty) return null;
 

--- a/std/path.d
+++ b/std/path.d
@@ -1446,7 +1446,8 @@ private auto _withDefaultExtension(R, C)(R path, C[] ext)
         of segments to assemble the path from.
     Returns: The assembled path.
 */
-immutable(ElementEncodingType!(ElementType!Range))[] buildPath(Range)(scope Range segments)
+immutable(ElementEncodingType!(ElementType!Range))[]
+    buildPath(Range)(scope Range segments)
 if (isInputRange!Range && !isInfinite!Range && isSomeString!(ElementType!Range))
 {
     if (segments.empty) return null;

--- a/std/random.d
+++ b/std/random.d
@@ -2283,6 +2283,10 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
 @safe unittest
 {
     import std.conv : to;
+    import std.meta : AliasSeq;
+    import std.range.primitives : isForwardRange;
+    import std.traits : isIntegral, isSomeChar;
+
     auto gen = Mt19937(123_456_789);
     static assert(isForwardRange!(typeof(gen)));
 
@@ -2293,7 +2297,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
     auto c = uniform(0.0, 1.0);
     assert(0 <= c && c < 1);
 
-    static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
+    static foreach (T; AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong, float, double, real))
     {{
         T lo = 0, hi = 100;
@@ -2347,7 +2351,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
 
     auto reproRng = Xorshift(239842);
 
-    static foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short,
+    static foreach (T; AliasSeq!(char, wchar, dchar, byte, ubyte, short,
                           ushort, int, uint, long, ulong))
     {{
         T lo = T.min + 10, hi = T.max - 10;

--- a/std/random.d
+++ b/std/random.d
@@ -2154,7 +2154,7 @@ if (isFloatingPoint!(CommonType!(T1, T2)) && isUniformRNG!UniformRandomNumberGen
 }
 
 // Implementation of uniform for integral types
-/** Description of algorithm and suggestion of correctness:
+/+ Description of algorithm and suggestion of correctness:
 
 The modulus operator maps an integer to a small, finite space. For instance, `x
 % 3` will map whatever x is into the range [0 .. 3). 0 maps to 0, 1 maps to 1, 2
@@ -2215,7 +2215,8 @@ at least that number won't be represented fairly.
 
 Hence, our condition to reroll is
 `bucketFront > (UpperType.max - (upperDist - 1))`
-*/
++/
+/// ditto
 auto uniform(string boundaries = "[)", T1, T2, RandomGen)
 (T1 a, T2 b, ref RandomGen rng)
 if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&

--- a/std/random.d
+++ b/std/random.d
@@ -2153,7 +2153,7 @@ if (isFloatingPoint!(CommonType!(T1, T2)) && isUniformRNG!UniformRandomNumberGen
 }
 
 // Implementation of uniform for integral types
-/+ Description of algorithm and suggestion of correctness:
+/** Description of algorithm and suggestion of correctness:
 
 The modulus operator maps an integer to a small, finite space. For instance, `x
 % 3` will map whatever x is into the range [0 .. 3). 0 maps to 0, 1 maps to 1, 2
@@ -2214,7 +2214,7 @@ at least that number won't be represented fairly.
 
 Hence, our condition to reroll is
 `bucketFront > (UpperType.max - (upperDist - 1))`
-+/
+*/
 auto uniform(string boundaries = "[)", T1, T2, RandomGen)
 (T1 a, T2 b, ref RandomGen rng)
 if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
@@ -2277,6 +2277,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
     return cast(ResultType)(lower + offset);
 }
 
+///
 @safe unittest
 {
     import std.conv : to;

--- a/std/random.d
+++ b/std/random.d
@@ -935,7 +935,8 @@ Parameters for the generator.
    `Exception` if the InputRange didn't provide enough elements to seed the generator.
    The number of elements required is the 'n' template parameter of the MersenneTwisterEngine struct.
  */
-    void seed(T)(T range) if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
+    void seed(T)(T range)
+    if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
     {
         this.seedImpl(range, this.state);
     }
@@ -945,7 +946,7 @@ Parameters for the generator.
        which can be used with an arbitrary `State` instance
     */
     private static void seedImpl(T)(T range, ref State mtState)
-        if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
+    if (isInputRange!T && is(immutable ElementType!T == immutable UIntType))
     {
         size_t j;
         for (j = 0; j < n && !range.empty; ++j, range.popFront())

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -7492,7 +7492,8 @@ if (!isIntegral!(CommonType!(B, E)) &&
 
         bool opEquals(Cyclic c) const { return current == c.current; }
         bool opEquals(int i) const { return current == i; }
-        void opUnary(string op)() if (op == "++")
+        void opUnary(string op)()
+        if (op == "++")
         {
             current = (current + 1) % wrapAround;
         }
@@ -12607,13 +12608,13 @@ public:
     else static if (isRandomAccessRange!R)
     {
         auto ref opIndex(IndexType)(IndexType index)
-            if (is(typeof((*_range)[index])))
+        if (is(typeof((*_range)[index])))
         {
             return (*_range)[index];
         }
 
         auto ref opIndex(IndexType)(IndexType index) const
-            if (is(typeof((*cast(const R*)_range)[index])))
+        if (is(typeof((*cast(const R*)_range)[index])))
         {
             return (*_range)[index];
         }
@@ -12695,14 +12696,14 @@ public:
 
         RefRange!T opSlice(IndexType1, IndexType2)
                     (IndexType1 begin, IndexType2 end)
-            if (is(typeof((*_range)[begin .. end])))
+        if (is(typeof((*_range)[begin .. end])))
         {
             mixin(_genOpSlice());
         }
 
         RefRange!CT opSlice(IndexType1, IndexType2)
                     (IndexType1 begin, IndexType2 end) const
-            if (is(typeof((*cast(const R*)_range)[begin .. end])))
+        if (is(typeof((*cast(const R*)_range)[begin .. end])))
         {
             mixin(_genOpSlice());
         }

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -474,7 +474,8 @@ void put(R, E)(ref R r, E e)
     {
         string data;
 
-        void put(C)(C c) if (isSomeChar!C)
+        void put(C)(C c)
+        if (isSomeChar!C)
         {
             data ~= c;
         }

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -702,7 +702,7 @@ final:
     }
 
     void stackPush(T)(T val)
-        if (!isDynamicArray!T)
+    if (!isDynamicArray!T)
     {
         *cast(T*)&memory[lastState] = val;
         enum delta = (T.sizeof+size_t.sizeof/2)/size_t.sizeof;
@@ -720,7 +720,7 @@ final:
     }
 
     void stackPop(T)(ref T val)
-        if (!isDynamicArray!T)
+    if (!isDynamicArray!T)
     {
         enum delta = (T.sizeof+size_t.sizeof/2)/size_t.sizeof;
         lastState -= delta;

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -542,7 +542,7 @@ if (isForwardRange!R && is(ElementType!R : dchar))
     Generator g;
 
     @trusted this(S)(R pattern, S flags)
-        if (isSomeString!S)
+    if (isSomeString!S)
     {
         pat = origin = pattern;
         //reserve slightly more then avg as sampled from unittests

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -276,7 +276,7 @@ template ThompsonOps(E, S, bool withInput:true)
     }
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.RepeatEnd || code == IR.RepeatQEnd)
+    if (code == IR.RepeatEnd || code == IR.RepeatQEnd)
     {
         with(e) with(state)
         {
@@ -331,7 +331,7 @@ template ThompsonOps(E, S, bool withInput:true)
     }
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.InfiniteEnd || code == IR.InfiniteQEnd)
+    if (code == IR.InfiniteEnd || code == IR.InfiniteQEnd)
     {
         with(e) with(state)
         {
@@ -366,7 +366,7 @@ template ThompsonOps(E, S, bool withInput:true)
     }
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.InfiniteBloomEnd)
+    if (code == IR.InfiniteBloomEnd)
     {
         with(e) with(state)
         {
@@ -507,7 +507,7 @@ template ThompsonOps(E, S, bool withInput:true)
 
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.LookbehindStart || code == IR.NeglookbehindStart)
+    if (code == IR.LookbehindStart || code == IR.NeglookbehindStart)
     {
         with(e) with(state)
         {
@@ -534,7 +534,7 @@ template ThompsonOps(E, S, bool withInput:true)
     }
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.LookaheadStart || code == IR.NeglookaheadStart)
+    if (code == IR.LookaheadStart || code == IR.NeglookaheadStart)
     {
         with(e) with(state)
         {
@@ -563,8 +563,8 @@ template ThompsonOps(E, S, bool withInput:true)
     }
 
     static bool op(IR code)(E e, S* state)
-        if (code == IR.LookaheadEnd || code == IR.NeglookaheadEnd ||
-            code == IR.LookbehindEnd || code == IR.NeglookbehindEnd)
+    if (code == IR.LookaheadEnd || code == IR.NeglookaheadEnd ||
+        code == IR.LookbehindEnd || code == IR.NeglookbehindEnd)
     {
         with(e) with(state)
         {
@@ -675,7 +675,7 @@ template ThompsonOps(E,S, bool withInput:false)
 @trusted:
     // can't match these without input
     static bool op(IR code)(E e, S* state)
-        if (code == IR.Char || code == IR.OrChar || code == IR.CodepointSet
+    if (code == IR.Char || code == IR.OrChar || code == IR.CodepointSet
         || code == IR.Trie || code == IR.Char || code == IR.Any)
     {
         return state.popState(e);
@@ -701,7 +701,7 @@ template ThompsonOps(E,S, bool withInput:false)
 
     // forward all control flow to normal versions
     static bool op(IR code)(E e, S* state)
-        if (code != IR.Char && code != IR.OrChar && code != IR.CodepointSet
+    if (code != IR.Char && code != IR.OrChar && code != IR.CodepointSet
         && code != IR.Trie && code != IR.Char && code != IR.Any && code != IR.Backref)
     {
         return ThompsonOps!(E,S,true).op!code(e,state);

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -688,7 +688,7 @@ public:
         ----
     +/
     R opIndex(String)(String i) /*const*/ //@@@BUG@@@
-        if (isSomeString!String)
+    if (isSomeString!String)
     {
         size_t index = lookupNamedGroup(_names, i);
         return getMatch(index);

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3015,7 +3015,10 @@ is empty, throws an `Exception`. In case of an I/O error throws
 
         /// Range primitive implementations.
         void put(A)(scope A writeme)
-        if ((isSomeChar!(ElementType!A) || is(ElementType!A : const(ubyte))) && isInputRange!A && !isInfinite!A)
+        if ((isSomeChar!(ElementType!A) ||
+            is(ElementType!A : const(ubyte))) &&
+            isInputRange!A &&
+            !isInfinite!A)
         {
             import std.exception : errnoEnforce;
 

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -447,7 +447,7 @@ Throws: `ErrnoException` if the file could not be opened.
 
     /// ditto
     this(R1, R2)(R1 name)
-        if (isSomeFiniteCharInputRange!R1)
+    if (isSomeFiniteCharInputRange!R1)
     {
         import std.conv : to;
         this(name.to!string, "rb");
@@ -455,8 +455,8 @@ Throws: `ErrnoException` if the file could not be opened.
 
     /// ditto
     this(R1, R2)(R1 name, R2 mode)
-        if (isSomeFiniteCharInputRange!R1 &&
-            isSomeFiniteCharInputRange!R2)
+    if (isSomeFiniteCharInputRange!R1 &&
+        isSomeFiniteCharInputRange!R2)
     {
         import std.conv : to;
         this(name.to!string, mode.to!string);
@@ -3015,10 +3015,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
 
         /// Range primitive implementations.
         void put(A)(scope A writeme)
-            if ((isSomeChar!(ElementType!A) ||
-                  is(ElementType!A : const(ubyte))) &&
-                isInputRange!A &&
-                !isInfinite!A)
+        if ((isSomeChar!(ElementType!A) || is(ElementType!A : const(ubyte))) && isInputRange!A && !isInfinite!A)
         {
             import std.exception : errnoEnforce;
 
@@ -3044,7 +3041,8 @@ is empty, throws an `Exception`. In case of an I/O error throws
         }
 
         /// ditto
-        void put(C)(scope C c) @safe if (isSomeChar!C || is(C : const(ubyte)))
+        void put(C)(scope C c) @safe
+        if (isSomeChar!C || is(C : const(ubyte)))
         {
             import std.utf : decodeFront, encode, stride;
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -7367,10 +7367,12 @@ template isInstanceOf(alias S, alias T)
     static struct A(T = void)
     {
         // doesn't work as expected, only accepts A when T = void
-        void func(B)(B b) if (isInstanceOf!(A, B)) {}
+        void func(B)(B b)
+        if (isInstanceOf!(A, B)) {}
 
         // correct behavior
-        void method(B)(B b) if (isInstanceOf!(TemplateOf!(A), B)) {}
+        void method(B)(B b)
+        if (isInstanceOf!(TemplateOf!(A), B)) {}
     }
 
     A!(void) a1;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2235,12 +2235,14 @@ template tuple(Names...)
             // e.g. Tuple!(int, "x", string, "y")
             template Interleave(A...)
             {
-                template and(B...) if (B.length == 1)
+                template and(B...)
+                if (B.length == 1)
                 {
                     alias and = AliasSeq!(A[0], B[0]);
                 }
 
-                template and(B...) if (B.length != 1)
+                template and(B...)
+                if (B.length != 1)
                 {
                     alias and = AliasSeq!(A[0], B[0],
                         Interleave!(A[1..$]).and!(B[1..$]));
@@ -5134,7 +5136,7 @@ Params:
             non-release mode.
  */
     void opAssign()(T value)
-        if (isAssignable!T) //@@@9416@@@
+    if (isAssignable!T) //@@@9416@@@
     {
         enum message = "Called `opAssign' on null NullableRef!" ~ T.stringof ~ ".";
         assert(!isNull, message);
@@ -7498,7 +7500,8 @@ Constructor that initializes the payload.
 
 Postcondition: `refCountedStore.isInitialized`
  */
-    this(A...)(auto ref A args) if (A.length > 0)
+    this(A...)(auto ref A args)
+    if (A.length > 0)
     out
     {
         assert(refCountedStore.isInitialized);
@@ -7931,7 +7934,8 @@ template borrow(alias fun)
 {
     import std.functional : unaryFun;
 
-    auto ref borrow(RC)(RC refCount) if
+    auto ref borrow(RC)(RC refCount)
+    if
     (
         isInstanceOf!(SafeRefCounted, RC)
         && is(typeof(unaryFun!fun(refCount.refCountedPayload)))
@@ -8140,7 +8144,7 @@ mixin template Proxy(alias a)
         }
 
         bool opEquals(T)(T b)
-            if (is(ValueType : T) || is(typeof(a.opEquals(b))) || is(typeof(b.opEquals(a))))
+        if (is(ValueType : T) || is(typeof(a.opEquals(b))) || is(typeof(b.opEquals(a))))
         {
             static if (is(typeof(a.opEquals(b))))
                 return a.opEquals(b);
@@ -8164,7 +8168,7 @@ mixin template Proxy(alias a)
         }
 
         int opCmp(T)(auto ref const T b)
-            if (is(ValueType : T) || is(typeof(a.opCmp(b))) || is(typeof(b.opCmp(a))))
+        if (is(ValueType : T) || is(typeof(a.opCmp(b))) || is(typeof(b.opCmp(a))))
         {
             static if (is(typeof(a.opCmp(b))))
                 return a.opCmp(b);
@@ -8274,7 +8278,8 @@ mixin template Proxy(alias a)
         }
     }
 
-    auto ref opAssign     (this X, V      )(auto ref V v) if (!is(V == typeof(this))) { return a       = v; }
+    auto ref opAssign     (this X, V      )(auto ref V v)
+    if (!is(V == typeof(this))) { return a       = v; }
     auto ref opIndexAssign(this X, V, D...)(auto ref V v, auto ref D i)               { return a[i]    = v; }
     auto ref opSliceAssign(this X, V      )(auto ref V v)                             { return a[]     = v; }
     auto ref opSliceAssign(this X, V, B, E)(auto ref V v, auto ref B b, auto ref E e) { return a[b .. e] = v; }
@@ -9941,7 +9946,7 @@ public:
     }
 
     this(T...)(T flags)
-        if (allSatisfy!(isBaseEnumType, T))
+    if (allSatisfy!(isBaseEnumType, T))
     {
         this = flags;
     }
@@ -9952,19 +9957,19 @@ public:
     }
 
     Base opCast(B)() const
-        if (is(Base : B))
+    if (is(Base : B))
     {
         return mValue;
     }
 
     auto opUnary(string op)() const
-        if (op == "~")
+    if (op == "~")
     {
         return BitFlags(cast(E) cast(Base) ~mValue);
     }
 
     auto ref opAssign(T...)(T flags)
-        if (allSatisfy!(isBaseEnumType, T))
+    if (allSatisfy!(isBaseEnumType, T))
     {
         mValue = 0;
         foreach (E flag; flags)
@@ -10005,7 +10010,7 @@ public:
     }
 
     auto opBinary(string op)(BitFlags flags) const
-        if (op == "|" || op == "&")
+    if (op == "|" || op == "&")
     {
         BitFlags result = this;
         result.opOpAssign!op(flags);
@@ -10013,7 +10018,7 @@ public:
     }
 
     auto opBinary(string op)(E flag) const
-        if (op == "|" || op == "&")
+    if (op == "|" || op == "&")
     {
         BitFlags result = this;
         result.opOpAssign!op(flag);
@@ -10021,7 +10026,7 @@ public:
     }
 
     auto opBinaryRight(string op)(E flag) const
-        if (op == "|" || op == "&")
+    if (op == "|" || op == "&")
     {
         return opBinary!op(flag);
     }
@@ -10653,25 +10658,29 @@ struct Ternary
       $(TR $(TD `unknown`) $(TD `unknown`) $(TD) $(TD `unknown`) $(TD `unknown`) $(TD `unknown`))
     )
     */
-    Ternary opUnary(string s)() if (s == "~")
+    Ternary opUnary(string s)()
+    if (s == "~")
     {
         return make((386 >> value) & 6);
     }
 
     /// ditto
-    Ternary opBinary(string s)(Ternary rhs) if (s == "|")
+    Ternary opBinary(string s)(Ternary rhs)
+    if (s == "|")
     {
         return make((25_512 >> (value + rhs.value)) & 6);
     }
 
     /// ditto
-    Ternary opBinary(string s)(Ternary rhs) if (s == "&")
+    Ternary opBinary(string s)(Ternary rhs)
+    if (s == "&")
     {
         return make((26_144 >> (value + rhs.value)) & 6);
     }
 
     /// ditto
-    Ternary opBinary(string s)(Ternary rhs) if (s == "^")
+    Ternary opBinary(string s)(Ternary rhs)
+    if (s == "^")
     {
         return make((26_504 >> (value + rhs.value)) & 6);
     }
@@ -10937,7 +10946,8 @@ struct RefCounted(T, RefCountedAutoInitialize autoInit =
         return _refCounted;
     }
 
-    this(A...)(auto ref A args) if (A.length > 0)
+    this(A...)(auto ref A args)
+    if (A.length > 0)
     out
     {
         assert(refCountedStore.isInitialized);

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -7643,7 +7643,8 @@ public:
 
     ///ditto
     this(Input)(Input seq)
-    if (!isDynamicArray!Input && isInputRange!Input && is(ElementType!Input : dchar))
+    if (!isDynamicArray!Input
+        && isInputRange!Input && is(ElementType!Input : dchar))
     {
         this ~= seq;
     }
@@ -9945,7 +9946,8 @@ private template toCaseLength(alias indexFn, uint maxIdx, alias tableFn)
 // case-converted stuf to the new string
 private template toCaseInPlaceAlloc(alias indexFn, uint maxIdx, alias tableFn)
 {
-    void toCaseInPlaceAlloc(C)(ref C[] s, size_t curIdx, size_t destIdx) @trusted pure
+    void toCaseInPlaceAlloc(C)(ref C[] s, size_t curIdx,
+        size_t destIdx) @trusted pure
     if (is(C == char) || is(C == wchar) || is(C == dchar))
     {
         import std.utf : decode;

--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -962,7 +962,7 @@ struct MultiArray(Types...)
     }
 
     void store(OutRange)(scope OutRange sink) const
-        if (isOutputRange!(OutRange, char))
+    if (isOutputRange!(OutRange, char))
     {
         import std.format.write : formattedWrite;
         formattedWrite(sink, "[%( 0x%x, %)]", offsets[]);
@@ -1653,7 +1653,7 @@ if (is(T : ElementType!Range))
 template sharMethod(alias uniLowerBound)
 {
     size_t sharMethod(alias _pred="a<b", Range, T)(Range range, T needle)
-        if (is(T : ElementType!Range))
+    if (is(T : ElementType!Range))
     {
         import std.functional : binaryFun;
         import std.math.algebraic : nextPow2, truncPow2;
@@ -1769,19 +1769,19 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     }
 
     static void append(T, V)(ref T[] arr, V value)
-        if (!isInputRange!V)
+    if (!isInputRange!V)
     {
         arr ~= force!T(value);
     }
 
     static void append(T, V)(ref T[] arr, V value)
-        if (isInputRange!V)
+    if (isInputRange!V)
     {
         insertInPlace(arr, arr.length, value);
     }
 
     static void destroy(T)(ref T arr) pure // pure required for -dip25, inferred for -dip1000
-        if (isDynamicArray!T && is(Unqual!T == T))
+    if (isDynamicArray!T && is(Unqual!T == T))
     {
         debug
         {
@@ -1791,7 +1791,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     }
 
     static void destroy(T)(ref T arr) pure // pure required for -dip25, inferred for -dip1000
-        if (isDynamicArray!T && !is(Unqual!T == T))
+    if (isDynamicArray!T && !is(Unqual!T == T))
     {
         arr = null;
     }
@@ -1846,7 +1846,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     }
 
     static void append(T, V)(ref T[] arr, V value)
-        if (!isInputRange!V)
+    if (!isInputRange!V)
     {
         if (arr.length == size_t.max) assert(0);
         arr = realloc(arr, arr.length+1);
@@ -1863,7 +1863,7 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     }
 
     static void append(T, V)(ref T[] arr, V value)
-        if (isInputRange!V && hasLength!V)
+    if (isInputRange!V && hasLength!V)
     {
         import core.checkedint : addu;
         bool overflow;
@@ -2059,7 +2059,7 @@ public struct InversionList(SP=GcPolicy)
         Construct from another code point set of any type.
     */
     this(Set)(Set set) pure
-        if (isCodepointSet!Set)
+    if (isCodepointSet!Set)
     {
         uint[] arr;
         foreach (v; set.byInterval)
@@ -2074,7 +2074,7 @@ public struct InversionList(SP=GcPolicy)
         Construct a set from a forward range of code point intervals.
     */
     this(Range)(Range intervals) pure
-        if (isForwardRange!Range && isIntegralPair!(ElementType!Range))
+    if (isForwardRange!Range && isIntegralPair!(ElementType!Range))
     {
         uint[] arr;
         foreach (v; intervals)
@@ -2246,7 +2246,7 @@ public:
         )
     */
     This opBinary(string op, U)(U rhs)
-        if (isCodepointSet!U || is(U:dchar))
+    if (isCodepointSet!U || is(U:dchar))
     {
         static if (op == "&" || op == "|" || op == "~")
         {// symmetric ops thus can swap arguments to reuse r-value
@@ -2311,7 +2311,7 @@ public:
 
     /// The 'op=' versions of the above overloaded operators.
     ref This opOpAssign(string op, U)(U rhs)
-        if (isCodepointSet!U || is(U:dchar))
+    if (isCodepointSet!U || is(U:dchar))
     {
         static if (op == "|")    // union
         {
@@ -2343,7 +2343,7 @@ public:
         the same as $(LREF opIndex).
     */
     bool opBinaryRight(string op: "in", U)(U ch) const
-        if (is(U : dchar))
+    if (is(U : dchar))
     {
         return this[ch];
     }
@@ -2523,7 +2523,7 @@ private:
 
   package(std)  // used from: std.regex.internal.parser
     ref intersect(U)(U rhs)
-        if (isCodepointSet!U)
+    if (isCodepointSet!U)
     {
         Marker mark;
         foreach ( i; rhs.byInterval)
@@ -2557,7 +2557,7 @@ private:
     // same as the above except that skip & drop parts are swapped
   package(std)  // used from: std.regex.internal.parser
     ref sub(U)(U rhs)
-        if (isCodepointSet!U)
+    if (isCodepointSet!U)
     {
         Marker mark;
         foreach (i; rhs.byInterval)
@@ -2570,7 +2570,7 @@ private:
 
   package(std)  // used from: std.regex.internal.parse
     ref add(U)(U rhs)
-        if (isCodepointSet!U)
+    if (isCodepointSet!U)
     {
         Marker start;
         foreach (i; rhs.byInterval)
@@ -3207,7 +3207,7 @@ struct CowArray(SP=GcPolicy)
     }
 
     this(Range)(Range range)
-        if (isInputRange!Range && hasLength!Range)
+    if (isInputRange!Range && hasLength!Range)
     {
         import std.algorithm.mutation : copy;
         length = range.length;
@@ -3215,7 +3215,7 @@ struct CowArray(SP=GcPolicy)
     }
 
     this(Range)(Range range)
-        if (isForwardRange!Range && !hasLength!Range)
+    if (isForwardRange!Range && !hasLength!Range)
     {
         import std.algorithm.mutation : copy;
         import std.range.primitives : walkLength;
@@ -3337,7 +3337,7 @@ struct CowArray(SP=GcPolicy)
     }
 
     void append(Range)(Range range)
-        if (isInputRange!Range && hasLength!Range && is(ElementType!Range : uint))
+    if (isInputRange!Range && hasLength!Range && is(ElementType!Range : uint))
     {
         size_t nl = length + range.length;
         length = nl;
@@ -3794,7 +3794,7 @@ auto arrayRepr(T)(T x)
 template mapTrieIndex(Prefix...)
 {
     size_t mapTrieIndex(Key)(Key key)
-        if (isValidPrefixForTrie!(Key, Prefix))
+    if (isValidPrefixForTrie!(Key, Prefix))
     {
         alias p = Prefix;
         size_t idx;
@@ -4185,7 +4185,7 @@ if (isValidPrefixForTrie!(Key, Args)
 
     ///
     void store(OutRange)(scope OutRange sink) const
-        if (isOutputRange!(OutRange, char))
+    if (isOutputRange!(OutRange, char))
     {
         _table.store(sink);
     }
@@ -4286,7 +4286,7 @@ public template codepointSetTrie(sizes...)
 if (sumOfIntegerTuple!sizes == 21)
 {
     auto codepointSetTrie(Set)(Set set)
-        if (isCodepointSet!Set)
+    if (isCodepointSet!Set)
     {
         auto builder = TrieBuilder!(bool, dchar, lastDchar+1, GetBitSlicing!(21, sizes))(false);
         foreach (ival; set.byInterval)
@@ -4323,7 +4323,7 @@ if (sumOfIntegerTuple!sizes == 21)
     static if (is(TypeOfBitPacked!T == bool))
     {
         auto codepointTrie(Set)(const scope Set set)
-            if (isCodepointSet!Set)
+        if (isCodepointSet!Set)
         {
             return codepointSetTrie(set);
         }
@@ -4338,9 +4338,9 @@ if (sumOfIntegerTuple!sizes == 21)
     // unsorted range of pairs
     ///
     auto codepointTrie(R)(R range, T defValue=T.init)
-        if (isInputRange!R
-            && is(typeof(ElementType!R.init[0]) : T)
-            && is(typeof(ElementType!R.init[1]) : dchar))
+    if (isInputRange!R
+        && is(typeof(ElementType!R.init[0]) : T)
+        && is(typeof(ElementType!R.init[1]) : dchar))
     {
         // build from unsorted array of pairs
         // TODO: expose index sorting functions for Trie
@@ -4468,8 +4468,8 @@ if (isValidArgsForTrie!(Key, Args))
         $(REF setUnion, std,_algorithm).
     */
     auto buildTrie(Range)(Range range, Value filler=Value.init)
-        if (isInputRange!Range && is(typeof(Range.init.front[0]) : Value)
-            && is(typeof(Range.init.front[1]) : Key))
+    if (isInputRange!Range && is(typeof(Range.init.front[0]) : Value)
+        && is(typeof(Range.init.front[1]) : Key))
     {
         auto builder = TrieBuilder!(Value, Key, Prefix)(filler);
         foreach (v; range)
@@ -4488,9 +4488,9 @@ if (isValidArgsForTrie!(Key, Args))
         and `filler` is false.
     */
     auto buildTrie(Range)(Range range, Value filler=Value.init)
-        if (is(TypeOfBitPacked!Value ==  bool)
-            && isInputRange!Range && is(typeof(Range.init.front[0]) : Key)
-            && is(typeof(Range.init.front[1]) : Key))
+    if (is(TypeOfBitPacked!Value ==  bool)
+        && isInputRange!Range && is(typeof(Range.init.front[0]) : Key)
+        && is(typeof(Range.init.front[1]) : Key))
     {
         auto builder = TrieBuilder!(Value, Key, Prefix)(filler);
         foreach (ival; range)
@@ -4499,9 +4499,9 @@ if (isValidArgsForTrie!(Key, Args))
     }
 
     auto buildTrie(Range)(Range range, Value filler, bool unsorted)
-        if (isInputRange!Range
-            && is(typeof(Range.init.front[0]) : Value)
-            && is(typeof(Range.init.front[1]) : Key))
+    if (isInputRange!Range
+        && is(typeof(Range.init.front[0]) : Value)
+        && is(typeof(Range.init.front[1]) : Key))
     {
         import std.algorithm.sorting : multiSort;
         alias Comps = GetComparators!(Prefix.length);
@@ -4520,8 +4520,8 @@ if (isValidArgsForTrie!(Key, Args))
         If no filler provided keys map to true, and `filler` is false.
     */
     auto buildTrie(Range)(Range range, Value filler=Value.init)
-        if (is(TypeOfBitPacked!Value ==  bool)
-            && isInputRange!Range && is(typeof(Range.init.front) : Key))
+    if (is(TypeOfBitPacked!Value ==  bool)
+        && isInputRange!Range && is(typeof(Range.init.front) : Key))
     {
         auto builder = TrieBuilder!(Value, Key, Prefix)(filler);
         foreach (v; range)
@@ -4534,7 +4534,7 @@ if (isValidArgsForTrie!(Key, Args))
         of values where array index serves as key.
     */
     auto buildTrie()(Value[] array, Value filler=Value.init)
-        if (isUnsigned!Key)
+    if (isUnsigned!Key)
     {
         auto builder = TrieBuilder!(Value, Key, Prefix)(filler);
         foreach (idx, v; array)
@@ -4596,21 +4596,21 @@ public struct MatcherConcept
         of the result of test.)
     */
     public bool match(Range)(ref Range inp)
-        if (isRandomAccessRange!Range && is(ElementType!Range : char))
+    if (isRandomAccessRange!Range && is(ElementType!Range : char))
     {
        assert(false);
     }
 
     ///ditto
     public bool skip(Range)(ref Range inp)
-        if (isRandomAccessRange!Range && is(ElementType!Range : char))
+    if (isRandomAccessRange!Range && is(ElementType!Range : char))
     {
         assert(false);
     }
 
     ///ditto
     public bool test(Range)(ref Range inp)
-        if (isRandomAccessRange!Range && is(ElementType!Range : char))
+    if (isRandomAccessRange!Range && is(ElementType!Range : char))
     {
         assert(false);
     }
@@ -4766,7 +4766,7 @@ template Utf8Matcher()
     }
 
     static auto encode(size_t sz)(dchar ch)
-        if (sz > 1)
+    if (sz > 1)
     {
         import std.utf : encodeUTF = encode;
         char[4] buf;
@@ -4822,8 +4822,8 @@ template Utf8Matcher()
         enum dispatch = genDispatch();
 
         public bool match(Range)(ref Range inp) const
-            if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
-                !isDynamicArray!Range)
+        if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
+            !isDynamicArray!Range)
         {
             enum mode = Mode.skipOnMatch;
             assert(!inp.empty);
@@ -4847,8 +4847,8 @@ template Utf8Matcher()
         static if (Sizes.length == 4) // can skip iff can detect all encodings
         {
             public bool skip(Range)(ref Range inp) const
-                if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
-                    !isDynamicArray!Range)
+            if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
+                !isDynamicArray!Range)
             {
                 enum mode = Mode.alwaysSkip;
                 assert(!inp.empty);
@@ -4869,8 +4869,8 @@ template Utf8Matcher()
         }
 
         public bool test(Range)(ref Range inp) const
-            if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
-                !isDynamicArray!Range)
+        if (isRandomAccessRange!Range && is(ElementType!Range : char) &&
+            !isDynamicArray!Range)
         {
             enum mode = Mode.neverSkip;
             assert(!inp.empty);
@@ -4888,19 +4888,19 @@ template Utf8Matcher()
         }
 
         bool match(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"match"(str);
         }
 
         bool skip(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"skip"(str);
         }
 
         bool test(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"test"(str);
         }
@@ -5057,8 +5057,8 @@ template Utf16Matcher()
     mixin template DefMatcher()
     {
         public bool match(Range)(ref Range inp) const
-            if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
-                !isDynamicArray!Range)
+        if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
+            !isDynamicArray!Range)
         {
             enum mode = Mode.skipOnMatch;
             assert(!inp.empty);
@@ -5084,8 +5084,8 @@ template Utf16Matcher()
         static if (Sizes.length == 2)
         {
             public bool skip(Range)(ref Range inp) const
-                if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
-                    !isDynamicArray!Range)
+            if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
+                !isDynamicArray!Range)
             {
                 enum mode = Mode.alwaysSkip;
                 assert(!inp.empty);
@@ -5106,8 +5106,8 @@ template Utf16Matcher()
         }
 
         public bool test(Range)(ref Range inp) const
-            if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
-                !isDynamicArray!Range)
+        if (isRandomAccessRange!Range && is(ElementType!Range : wchar) &&
+            !isDynamicArray!Range)
         {
             enum mode = Mode.neverSkip;
             assert(!inp.empty);
@@ -5119,19 +5119,19 @@ template Utf16Matcher()
         }
 
         bool match(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"match"(str);
         }
 
         bool skip(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"skip"(str);
         }
 
         bool test(C)(ref C[] str) const
-            if (isSomeChar!C)
+        if (isSomeChar!C)
         {
             return fwdStr!"test"(str);
         }
@@ -5140,7 +5140,7 @@ template Utf16Matcher()
     }
 
     struct Impl(Sizes...)
-        if (Sizes.length >= 1 && Sizes.length <= 2)
+    if (Sizes.length >= 1 && Sizes.length <= 2)
     {
     private:
         import std.meta : allSatisfy;
@@ -5230,7 +5230,7 @@ template Utf16Matcher()
     }
 
     struct CherryPick(I, Sizes...)
-        if (Sizes.length >= 1 && Sizes.length <= 2)
+    if (Sizes.length >= 1 && Sizes.length <= 2)
     {
     private:
         import std.meta : allSatisfy;
@@ -6106,7 +6106,7 @@ template SetSearcher(alias table, string kind)
 {
     /// Run-time checked search.
     static auto opCall(C)(const scope C[] name)
-        if (is(C : dchar))
+    if (is(C : dchar))
     {
         import std.conv : to;
         CodepointSet set;
@@ -6766,7 +6766,7 @@ struct UnicodeSetParser(Range)
         sets.
     */
     static auto opCall(C)(const scope C[] name)
-        if (is(C : dchar))
+    if (is(C : dchar))
     {
         return loadAny(name);
     }
@@ -7636,15 +7636,14 @@ if (isInputRange!Range && is(immutable ElementType!Range == immutable dchar))
 public:
     /// Ctor
     this(C)(const scope C[] chars...)
-        if (is(C : dchar))
+    if (is(C : dchar))
     {
         this ~= chars;
     }
 
     ///ditto
     this(Input)(Input seq)
-        if (!isDynamicArray!Input
-            && isInputRange!Input && is(ElementType!Input : dchar))
+    if (!isDynamicArray!Input && isInputRange!Input && is(ElementType!Input : dchar))
     {
         this ~= seq;
     }
@@ -7763,7 +7762,7 @@ public:
 
     /// Append all $(CHARACTERS) from the input range `inp` to this Grapheme.
     ref opOpAssign(string op, Input)(scope Input inp)
-        if (isInputRange!Input && is(ElementType!Input : dchar))
+    if (isInputRange!Input && is(ElementType!Input : dchar))
     {
         static if (op == "~")
         {
@@ -9946,9 +9945,8 @@ private template toCaseLength(alias indexFn, uint maxIdx, alias tableFn)
 // case-converted stuf to the new string
 private template toCaseInPlaceAlloc(alias indexFn, uint maxIdx, alias tableFn)
 {
-    void toCaseInPlaceAlloc(C)(ref C[] s, size_t curIdx,
-        size_t destIdx) @trusted pure
-        if (is(C == char) || is(C == wchar) || is(C == dchar))
+    void toCaseInPlaceAlloc(C)(ref C[] s, size_t curIdx, size_t destIdx) @trusted pure
+    if (is(C == char) || is(C == wchar) || is(C == dchar))
     {
         import std.utf : decode;
         alias caseLength = toCaseLength!(indexFn, maxIdx, tableFn);

--- a/std/utf.d
+++ b/std/utf.d
@@ -4303,13 +4303,13 @@ if (isSomeChar!C)
     else:
 
     auto ref byUTF(R)(R r)
-        if (isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingType!R))
+    if (isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingType!R))
     {
         return byUTF(r.byCodeUnit());
     }
 
     auto ref byUTF(R)(R r)
-        if (!isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingType!R))
+    if (!isAutodecodableString!R && isInputRange!R && isSomeChar!(ElementEncodingType!R))
     {
         static if (is(immutable ElementEncodingType!R == immutable RC, RC) && is(RC == C))
         {

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -275,7 +275,7 @@ public struct UUID
          * You need to pass exactly 16 ubytes.
          */
         @safe pure this(T...)(T uuidData)
-            if (uuidData.length == 16 && allSatisfy!(isIntegral, T))
+        if (uuidData.length == 16 && allSatisfy!(isIntegral, T))
         {
             import std.conv : to;
 
@@ -331,7 +331,8 @@ public struct UUID
          *
          * For a less strict parser, see $(LREF parseUUID)
          */
-        this(T)(in T[] uuid) if (isSomeChar!T)
+        this(T)(in T[] uuid)
+        if (isSomeChar!T)
         {
             import std.conv : to, parse;
             if (uuid.length < 36)

--- a/std/variant.d
+++ b/std/variant.d
@@ -658,7 +658,7 @@ public:
 
     /// Allows assignment from a subset algebraic type
     this(T : VariantN!(tsize, Types), size_t tsize, Types...)(T value)
-        if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
+    if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
     {
         opAssign(value);
     }
@@ -735,7 +735,7 @@ public:
 
     // Allow assignment from another variant which is a subset of this one
     VariantN opAssign(T : VariantN!(tsize, Types), size_t tsize, Types...)(T rhs)
-        if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
+    if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
     {
         // discover which type rhs is actually storing
         foreach (V; T.AllowedTypes)
@@ -1098,7 +1098,7 @@ public:
     { return opLogic!(T, op)(lhs); }
     ///ditto
     VariantN opBinary(string op, T)(T rhs)
-        if (op == "~")
+    if (op == "~")
     {
         auto temp = this;
         temp ~= rhs;
@@ -1191,7 +1191,8 @@ public:
        If the `VariantN` contains an array, applies `dg` to each
        element of the array in turn. Otherwise, throws an exception.
      */
-    int opApply(Delegate)(scope Delegate dg) if (is(Delegate == delegate))
+    int opApply(Delegate)(scope Delegate dg)
+    if (is(Delegate == delegate))
     {
         alias A = Parameters!(Delegate)[0];
         if (type == typeid(A[]))
@@ -2410,7 +2411,7 @@ if (Handlers.length > 0)
 {
     ///
     auto visit(VariantType)(VariantType variant)
-        if (isAlgebraic!VariantType)
+    if (isAlgebraic!VariantType)
     {
         return visitImpl!(true, VariantType, Handlers)(variant);
     }
@@ -2553,7 +2554,7 @@ if (Handlers.length > 0)
 {
     ///
     auto tryVisit(VariantType)(VariantType variant)
-        if (isAlgebraic!VariantType)
+    if (isAlgebraic!VariantType)
     {
         return visitImpl!(false, VariantType, Handlers)(variant);
     }


### PR DESCRIPTION
This PR contains only code format changes.

There are a couple of linting issues that are now detected with the dmd-as-a-lib D-Scanner.

* UndocumentedDeclarationCheck => detects undocumented public declarations; the fix consists of changing the normal comment chars to DDoc comment chars and documenting the unit test;
* IfConstraintsIndentCheck => detects static ifs that are not on separate lines nor to they match the template's column indentation; the fix consists of moving the if conditions on separate lines and aligning them with the template declaration.