### PR TITLE
Reference std.digest.fromHexString in doc of std.conv.hexString

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5611,6 +5611,14 @@ Params:
 
 Returns:
     a `string`, a `wstring` or a `dstring`, according to the type of hexData.
+
+See_Also:
+    Use $(REF fromHexString, std, digest) for run time conversions.
+    Note, these functions are not drop-in replacements and have different
+    input requirements.
+    This template inherits its data syntax from builtin
+    $(LINK2 $(ROOT_DIR)spec/lex.html#hex_string, hex strings).
+    See $(REF fromHexString, std, digest) for its own respective requirements.
  */
 template hexString(string hexData)
 if (hexData.isHexLiteral)


### PR DESCRIPTION
Documents that add similar function for run time use cases has been added and warns about their differences.
(I'm not a native English speaker. Please proof-read.)