### PR TITLE
Fix 17416 - Add REUSEPORT to std.socket

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -54,6 +54,12 @@ version (Windows)
     enum socket_t : SOCKET { INVALID_SOCKET }
     private const int _SOCKET_ERROR = SOCKET_ERROR;
 
+    /**
+     * On Windows, there is no `SO_REUSEPORT`.
+     * However, `SO_REUSEADDR` is equivalent to `SO_REUSEPORT` there.
+     * $(LINK https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse)
+     */
+    private enum SO_REUSEPORT = SO_REUSEADDR;
 
     private int _lasterr() nothrow @nogc
     {
@@ -2589,6 +2595,22 @@ enum SocketOption: int
     DEBUG =                SO_DEBUG,            /// Record debugging information
     BROADCAST =            SO_BROADCAST,        /// Allow transmission of broadcast messages
     REUSEADDR =            SO_REUSEADDR,        /// Allow local reuse of address
+    /**
+     * Allow local reuse of port
+     *
+     * On Windows, this is equivalent to `SocketOption.REUSEADDR`.
+     * There is in fact no option named `REUSEPORT`.
+     * However, `SocketOption.REUSEADDR` matches the behavior of
+     * `SocketOption.REUSEPORT` on other platforms. Further details on this
+     * topic can be found here:
+     * $(LINK https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse)
+     *
+     * On Linux, this ensures fair distribution of incoming connections accross threads.
+     *
+     * See_Also:
+     *   https://lwn.net/Articles/542629/
+     */
+    REUSEPORT =            SO_REUSEPORT,
     LINGER =               SO_LINGER,           /// Linger on close if unsent data is present
     OOBINLINE =            SO_OOBINLINE,        /// Receive out-of-band data in band
     SNDBUF =               SO_SNDBUF,           /// Send buffer size


### PR DESCRIPTION
#8389 plus a reference link as requested by @CyberShadow.
Text has been adjusted to provide further explanations.

Further reading: <https://stackoverflow.com/a/14388707>