### PR TITLE
sumtype: reduce template overhead of match

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1869,18 +1869,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
         alias stride(size_t i) = .stride!(i, typeCounts);
         alias TagTuple = .TagTuple!typeCounts;
 
-        /*
-         * A list of arguments to be passed to a handler needed for the case
-         * labeled with `caseId`.
-         */
-        template handlerArgs(size_t caseId)
-        {
-            enum tags = TagTuple.fromCaseId(caseId);
-            enum argsFrom(size_t i : tags.length) = "";
-            enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
-                ".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
-            enum handlerArgs = argsFrom!0;
-        }
+        alias handlerArgs(size_t caseId) = .handlerArgs!(caseId, typeCounts);
 
         /* An AliasSeq of the types of the member values in the argument list
          * returned by `handlerArgs!caseId`.
@@ -2105,6 +2094,18 @@ private size_t stride(size_t dim, lengths...)()
      */
     assert(!overflow, "Integer overflow");
     return result;
+}
+
+/* A list of arguments to be passed to a handler needed for the case
+ * labeled with `caseId`.
+ */
+private template handlerArgs(size_t caseId, typeCounts...)
+{
+    enum tags = TagTuple!typeCounts.fromCaseId(caseId);
+    enum argsFrom(size_t i : tags.length) = "";
+    enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
+        ".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
+    enum handlerArgs = argsFrom!0;
 }
 
 // Matching

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -2102,10 +2102,17 @@ private size_t stride(size_t dim, lengths...)()
 private template handlerArgs(size_t caseId, typeCounts...)
 {
     enum tags = TagTuple!typeCounts.fromCaseId(caseId);
-    enum argsFrom(size_t i : tags.length) = "";
-    enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
-        ".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
-    enum handlerArgs = argsFrom!0;
+
+    alias handlerArgs = AliasSeq!();
+
+    static foreach (i; 0 .. tags.length)
+    {
+        handlerArgs = AliasSeq!(
+            handlerArgs,
+            "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
+            ".Types[" ~ toCtString!(tags[i]) ~ "])(), "
+        );
+    }
 }
 
 // Matching


### PR DESCRIPTION
**Please review this PR commit-by-commit.**

The changes in this PR can be grouped into two categories:

1. Refactoring of helper templates use by `matchImpl` to eliminate unnecessary instantiations.
2. Addition of a fast path for single dispatch to `matchImpl`.

Altogether, these changes reduce the time take to run `std.sumtype`'s test suite by about 14%.

See also pbackus/sumtype#91, which added these changes to the dub version of `sumtype`.

### Before

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `../dmd/generated/linux/release/64/dmd -conf= -I../dmd/druntime/import  -w -preview=dip1000 -preview=dtorfields -preview=fieldwise -m64 -fPIC -O -release -main -unittest -version=StdUnittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-lpthread -L-lm -L-ldl -cov=ctfe -run std/sumtype.d` | 4.790 ± 0.234 | 4.586 | 5.198 | 1.00 |

### After

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `../dmd/generated/linux/release/64/dmd -conf= -I../dmd/druntime/import  -w -preview=dip1000 -preview=dtorfields -preview=fieldwise -m64 -fPIC -O -release -main -unittest -version=StdUnittest generated/linux/release/64/libphobos2.a -defaultlib= -debuglib= -L-lpthread -L-lm -L-ldl -cov=ctfe -run std/sumtype.d` | 4.143 ± 0.079 | 4.064 | 4.290 | 1.00 |
