### PR TITLE
Add note to Unqualified about is(immutable T == immutable U).

### DIFF
--- a/phobos/sys/traits.d
+++ b/phobos/sys/traits.d
@@ -4820,16 +4820,24 @@ template Unshared(T)
     testing for, then that's what Unqualified is for. It's just that it's best
     practice to use $(LREF Unconst) when it's not clear that $(D shared) should
     be removed as well.
+
+    Also, note that $(D is(immutable T == immutable U))) is equivalent to
+    $(D is(Unqualified!T == Unqualified!U)) (using $(D immutable) converts
+    $(D const), $(D inout), and $(D shared) to $(D immutable), whereas using
+    Unqualified strips off all type qualifiers, but the resulting comparison is
+    the same as long as $(D immutable) is used on both sides or Unqualified is
+    used on both sides)). So, in cases where code needs to compare two types to
+    see whether they're the same while ignoring all qualifiers, it's generally
+    better to use $(D immutable) on both types rather than using Unqualfied on
+    both types, since that avoids needing to instantiate a template, and those
+    instantiations can really add up when a project has a lot of templates
+    with template constraints, $(D static if)s, and other forms of conditional
+    compilation that need to compare types.
   +/
-version (StdDdoc) template Unqualified(T)
+template Unqualified(T)
 {
     import core.internal.traits : CoreUnqualified = Unqual;
     alias Unqualified = CoreUnqualified!(T);
-}
-else
-{
-    import core.internal.traits : CoreUnqualified = Unqual;
-    alias Unqualified = CoreUnqualified;
 }
 
 ///


### PR DESCRIPTION
In many cases, even when using Unqualified makes sense (as opposed to Unconst or Unshared), using is(immutable T == immutable U) works just as well and avoids instantiating any additional templates. This seems to becoming more known in the D community over time, but it seems appropriate to mention it in Unqualified's documentation so that more people will be made aware.

Also, I changed it so that Unqualified is always a wrapper template instead of directly being an alias of Unqual in core.internal.traits. This is because the names don't match, and the alias will show up in any error messages. Long term, we would ideally rename the symbol in core.internal (potentially turning the std.traits versions into a wrapper templates instead of an alias). However, since the functionality is effectively the same, and the std.traits one is the one currently being used by code in general, it seems better to let the std.traits one be the alias for now. The same applies to a few traits which are implemented in core.internal.traits and imported in std.traits or phobos.sys.traits.