### PR TITLE
Fixes for `-preview=rvaluerefparam`

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2560,9 +2560,6 @@ Lerr:
     string s1 = "123";
     auto a1 = parse!(int, string, Yes.doCount)(s1);
     assert(a1.data == 123 && a1.count == 3);
-
-    // parse only accepts lvalues
-    static assert(!__traits(compiles, parse!int("123")));
 }
 
 ///

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -1839,24 +1839,26 @@ template hasToString(T, Char)
     else static if (is(typeof(
         (T val) {
             const FormatSpec!Char f;
-            static struct S {void put(scope Char s){}}
+            static struct S
+            {
+                @disable this(this);
+                void put(scope Char s){}
+            }
             S s;
             val.toString(s, f);
-            static assert(!__traits(compiles, val.toString(s, FormatSpec!Char())),
-                          "force toString to take parameters by ref");
-            static assert(!__traits(compiles, val.toString(S(), f)),
-                          "force toString to take parameters by ref");
         })))
     {
         enum hasToString = HasToStringResult.customPutWriterFormatSpec;
     }
     else static if (is(typeof(
         (T val) {
-            static struct S {void put(scope Char s){}}
+            static struct S
+            {
+                @disable this(this);
+                void put(scope Char s){}
+            }
             S s;
             val.toString(s);
-            static assert(!__traits(compiles, val.toString(S())),
-                          "force toString to take parameters by ref");
         })))
     {
         enum hasToString = HasToStringResult.customPutWriter;
@@ -1996,9 +1998,10 @@ template hasToString(T, Char)
         static assert(hasToString!(G, char) == customPutWriter);
         static assert(hasToString!(H, char) == customPutWriterFormatSpec);
         static assert(hasToString!(I, char) == customPutWriterFormatSpec);
-        static assert(hasToString!(J, char) == hasSomeToString);
+        static assert(hasToString!(J, char) == hasSomeToString
+            || hasToString!(J, char) == constCharSinkFormatSpec); // depends on -preview=rvaluerefparam
         static assert(hasToString!(K, char) == constCharSinkFormatSpec);
-        static assert(hasToString!(L, char) == none);
+        static assert(hasToString!(L, char) == customPutWriterFormatSpec);
         static if (hasPreviewIn)
         {
             static assert(hasToString!(M, char) == inCharSinkFormatSpec);
@@ -2105,9 +2108,10 @@ template hasToString(T, Char)
         static assert(hasToString!(G, char) == customPutWriter);
         static assert(hasToString!(H, char) == customPutWriterFormatSpec);
         static assert(hasToString!(I, char) == customPutWriterFormatSpec);
-        static assert(hasToString!(J, char) == hasSomeToString);
+        static assert(hasToString!(J, char) == hasSomeToString
+            || hasToString!(J, char) == constCharSinkFormatSpec); // depends on -preview=rvaluerefparam
         static assert(hasToString!(K, char) == constCharSinkFormatSpec);
-        static assert(hasToString!(L, char) == none);
+        static assert(hasToString!(L, char) == HasToStringResult.customPutWriterFormatSpec);
         static if (hasPreviewIn)
         {
             static assert(hasToString!(M, char) == inCharSinkFormatSpec);
@@ -2125,9 +2129,10 @@ template hasToString(T, Char)
         static assert(hasToString!(inout(G), char) == customPutWriter);
         static assert(hasToString!(inout(H), char) == customPutWriterFormatSpec);
         static assert(hasToString!(inout(I), char) == customPutWriterFormatSpec);
-        static assert(hasToString!(inout(J), char) == hasSomeToString);
+        static assert(hasToString!(inout(J), char) == hasSomeToString
+            || hasToString!(inout(J), char) == constCharSinkFormatSpec); // depends on -preview=rvaluerefparam
         static assert(hasToString!(inout(K), char) == constCharSinkFormatSpec);
-        static assert(hasToString!(inout(L), char) == none);
+        static assert(hasToString!(inout(L), char) == customPutWriterFormatSpec);
         static if (hasPreviewIn)
         {
             static assert(hasToString!(inout(M), char) == inCharSinkFormatSpec);


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/17068#issuecomment-2502010252

`hasToString` is a bit of a tangle, it tries to force passing `FormatSpec` by `const ref` for `customPutWriter`, but not for `constCharSinkFormatSpec`. It's not necessary to require it, I guess copying it is discouraged because it is slower than needed, but it's hard to statically enforce this in the presence of overloads.