### PR TITLE
std.logger default example does not work

### DIFF
--- a/std/logger/package.d
+++ b/std/logger/package.d
@@ -17,7 +17,7 @@ The easiest way to create a log message is to write:
 import std.logger;
 
 void main() {
-    log("Hello World");
+    logf("Hello World");
 }
 -------------
 This will print a message to the `stderr` device. The message will contain


### PR DESCRIPTION
Example does not compile as provided. I believe you want 'logf' to otherwise have 'printf' style logging.

If this is accepted, I'll update the documentation below to reflect this is writing to stdout intead of stderr.