### PR TITLE
Fix Issue 10386: Make std.math.isIdentical work in CTFE with coverage tests

### DIFF
--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -21,6 +21,7 @@ module std.math.traits;
 
 import std.traits : isFloatingPoint, isIntegral, isNumeric, isSigned;
 
+
 /*********************************
  * Determines if $(D_PARAM x) is NaN.
  * Params:
@@ -513,26 +514,42 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 ///
 @safe @nogc pure nothrow unittest
 {
+
+    // We're forcing the CTFE to run by assigning the result of the function to an enum
+    enum test1 = isIdentical(1.0,1.0);
+    enum test2 = isIdentical(real.nan,real.nan);
+    enum test3 = isIdentical(real.infinity, real.infinity);
+    enum test4 = isIdentical(real.infinity, real.infinity);
+    enum test5 = isIdentical(0.0, 0.0);
+
+    assert(test1);
+    assert(test2);
+    assert(test3);
+    assert(test4);
+    assert(test5);
+
+    enum test6 = !isIdentical(0.0, -0.0);
+    enum test7 = !isIdentical(real.nan, -real.nan);
+    enum test8 = !isIdentical(real.infinity, -real.infinity);
+
+    assert(test6);
+    assert(test7);
+    assert(test8);
+    
+}
+
+@safe @nogc pure nothrow unittest
+{
+    assert( !isIdentical(1.2,1.3));
     assert( isIdentical(0.0, 0.0));
     assert( isIdentical(1.0, 1.0));
     assert( isIdentical(real.infinity, real.infinity));
     assert( isIdentical(-real.infinity, -real.infinity));
+    assert( isIdentical(real.nan, real.nan));
 
     assert(!isIdentical(0.0, -0.0));
     assert(!isIdentical(real.nan, -real.nan));
     assert(!isIdentical(real.infinity, -real.infinity));
-}
-@safe @nogc pure nothrow unittest
-{
-    static assert( isIdentical(0.0, 0.0));
-    static assert( isIdentical(1.0, 1.0));
-    static assert( isIdentical(real.infinity, real.infinity));
-    static assert( isIdentical(-real.infinity, -real.infinity));
-    static assert( isIdentical(real.nan, real.nan));
-
-    static assert(!isIdentical(0.0, -0.0));
-    static assert(!isIdentical(real.nan, -real.nan));
-    static assert(!isIdentical(real.infinity, -real.infinity));
 }
 /*********************************
  * Return 1 if sign bit of e is set, 0 if not.

--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -534,8 +534,7 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 
     assert(test6);
     assert(test7);
-    assert(test8);
-    
+    assert(test8); 
 }
 
 @safe @nogc pure nothrow unittest

--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -514,7 +514,6 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 ///
 @safe @nogc pure nothrow unittest
 {
-
     // We're forcing the CTFE to run by assigning the result of the function to an enum
     enum test1 = isIdentical(1.0,1.0);
     enum test2 = isIdentical(real.nan,real.nan);
@@ -534,7 +533,7 @@ bool isIdentical(real x, real y) @trusted pure nothrow @nogc
 
     assert(test6);
     assert(test7);
-    assert(test8); 
+    assert(test8);
 }
 
 @safe @nogc pure nothrow unittest


### PR DESCRIPTION
I took the modifications @n8sh made in _math.d_ and moved in _traits.d_ since _math.d_ doesn't exist anymore and the math library is now composed of multiple files, and then added more tests because the piece of code that is interpreted in CTFE wasn't covered.
Credit to @n8sh for the code in isIdentical.