### PR TITLE
Fix linting issue in filelogger.d

### DIFF
--- a/std/logger/filelogger.d
+++ b/std/logger/filelogger.d
@@ -276,7 +276,7 @@ class FileLogger : Logger
 {
     // we don't need to actually run the code, only make sure
     // it compiles
-    static _() {
+    static void _() {
         auto l = new shared FileLogger("");
     }
 }


### PR DESCRIPTION
Fix a linting issue introduced in filelogger.d:
```
std/logger/filelogger.d(279:12)[warn]: Auto function without return statement, prefer inserting void to be explicit
```