### PR TITLE
Fix #10581 – `std.logger` has an ostensibly broken example and wrong docs

### DIFF
--- a/std/logger/package.d
+++ b/std/logger/package.d
@@ -17,7 +17,7 @@ The easiest way to create a log message is to write:
 import std.logger;
 
 void main() {
-    log("Hello World");
+    info("Hello World");
 }
 -------------
 This will print a message to the `stderr` device. The message will contain
@@ -59,7 +59,7 @@ $(UL
     $(LI `fatal`)
 )
 The default `Logger` will by default log to `stderr` and has a default
-`LogLevel` of `LogLevel.all`. The default Logger can be accessed by
+`LogLevel` of `LogLevel.info`. The default Logger can be accessed by
 using the property called `sharedLog`. This property is a reference to the
 current default `Logger`. This reference can be used to assign a new
 default `Logger`.


### PR DESCRIPTION
Fixes #10581.
Revamp of #10573.