### PR TITLE
std.process: Do not kill process group 2 in unittest

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2856,7 +2856,7 @@ void kill(Pid pid, int codeOrSignal)
     do { s = tryWait(pid); } while (!s.terminated);
     version (Windows)    assert(s.status == 123);
     else version (Posix) assert(s.status == -SIGKILL);
-    assertThrown!ProcessException(kill(pid));
+    assert(pid.processID == Pid.terminated);
 }
 
 @system unittest // wait() and kill() detached process


### PR DESCRIPTION
When passing a Pid object to tryWait(), its processId will be changed to Pid.terminated, which happens to be -2. Passing this value to kill() will kill the process group 2 on Posix systems. If you run the build and test suite using this process group, the test case will kill the entire build.

Bug-Debian: https://bugs.debian.org/1089007