### PR TITLE
Update CODEOWNERS to reflect that `logger` has been moved out of `std…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,13 +36,13 @@ std/digest/*
 # std/exception.d
 std/experimental/allocator/* @PetarKirov
 std/experimental/checkedint/*
-std/experimental/logger/* @burner
 std/file.d @CyberShadow
 # std/format.d
 # std/functional.d
 # std/getopt.d
 # std/internal/
 std/json.d @CyberShadow
+std/logger/* @burner
 std/math* @ibuclaw
 std/meta.d @PetarKirov
 # std/mmfile.d


### PR DESCRIPTION
This update the `CODEOWNERS` file to reflect that `logger` has been moved out of `std.experimental`.