### PR TITLE
[std.process] Make `environment` use a ReadWriteMutex

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -308,7 +308,7 @@ static:
     multi-threaded programs. See e.g.
     $(LINK2 https://www.gnu.org/software/libc/manual/html_node/Environment-Access.html#Environment-Access, glibc).
     */
-    void remove(scope const(char)[] name) @trusted //nothrow @nogc
+    void remove(scope const(char)[] name) @trusted
     {
         synchronized (mutex.writer)
         version (Windows)    SetEnvironmentVariableW(name.tempCStringW(), null);


### PR DESCRIPTION
Fixes #10580.

Make getEnvironPtr `@system`.
Use a ReadWriteMutex to protect reading and writing to `environment`. 
Add `scope` to `getImpl` callback parameter.

Warning 1: This (currently) removes `nothrow @nogc` from `remove`. 
Warning 2: I am not that experienced with locks (particularly on Windows), so bear that in mind, I may have done something wrong. Or there may be a better solution, please let me know.