### PR TITLE
Replace internal `getEnvironPtr` with its equivalent from druntime

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -146,23 +146,8 @@ private
     // POSIX API declarations.
     version (Posix)
     {
-        version (Darwin)
-        {
-            extern(C) char*** _NSGetEnviron() nothrow;
-            const(char**) getEnvironPtr() @trusted
-            {
-                return *_NSGetEnviron;
-            }
-        }
-        else
-        {
-            // Made available by the C runtime:
-            extern(C) extern __gshared const char** environ;
-            const(char**) getEnvironPtr() @trusted
-            {
-                return environ;
-            }
-        }
+        static import core.sys.posix.unistd;
+        private alias getEnvironPtr = core.sys.posix.unistd.environ;
 
         @system unittest
         {

--- a/std/process.d
+++ b/std/process.d
@@ -146,8 +146,7 @@ private
     // POSIX API declarations.
     version (Posix)
     {
-        static import core.sys.posix.unistd;
-        private alias getEnvironPtr = core.sys.posix.unistd.environ;
+        import core.sys.posix.unistd : getEnvironPtr = environ;
 
         @system unittest
         {


### PR DESCRIPTION
Comment says,
<https://github.com/dlang/phobos/blob/8c6fca9ccdb30b69b627808c698526a76f7c4248/std/process.d#L131-L133>

Turns out, *druntime* already provides equivalent functionality in `core.sys.posix.unistd`:
<https://github.com/dlang/dmd/blob/9d72ed4249075ccd6edbb4732b9027ebe92d4c0f/druntime/src/core/sys/posix/unistd.d#L2726-L2771>