### PR TITLE
std.json: Void initialize return value in emptyOrderedObject

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -736,7 +736,7 @@ struct JSONValue
      * Unlike `emptyObject`, the order of inserted keys is preserved.
      */
     enum emptyOrderedObject = {
-        JSONValue v;
+        JSONValue v = void;
         v.orderedObject = null;
         return v;
     }();


### PR DESCRIPTION
Works around issue seen in dlang/dmd#20675.