### PR TITLE
Fix #10023 - Add `ctEval` to Phobos

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -51,6 +51,9 @@ $(TR $(TH Function Name) $(TH Description)
     $(TR $(TD $(LREF bind))
         $(TD Passes the fields of a struct as arguments to a function.
     ))
+    $(TR $(TD $(LREF ctEval))
+        $(TD Enforces the execution of a function during compile-time.
+    ))
 ))
 
 Copyright: Copyright Andrei Alexandrescu 2008 - 2009.
@@ -2166,4 +2169,51 @@ template bind(alias fun)
     tuple(123).bind!((auto ref x) {
         static assert(!__traits(isRef, x));
     });
+}
+
+/**
+ * Enforces the execution of a function during compile-time.
+ *
+ * Computes the return value of a function call during compilation (CTFE).
+ *
+ * This is useful for call chains in functional programming
+ * where no explicit `enum` can be placed inline and would require splitting
+ * the pipeline.
+ *
+ * Params:
+ *   fun = callable to evaluate
+ * See_also:
+ *   $(LINK https://dlang.org/spec/function.html#interpretation)
+ */
+enum ctEval(alias fun) = fun;
+
+///
+@safe unittest
+{
+    import std.math : abs;
+
+    // No explicit `enum` needed.
+    float result = ctEval!(abs(-3));
+    assert(result == 3);
+
+    // Can be statically asserted.
+    static assert(ctEval!(abs(-4)) == 4);
+    static assert(ctEval!(abs( 9)) == 9);
+}
+
+///
+@safe unittest
+{
+    import core.stdc.math : round;
+    import std.conv : to;
+    import std.math : abs, PI, sin;
+
+    // `round` from the C standard library cannot be interpreted at compile
+    // time, because it has no available source code. However the function
+    // calls preceding `round` can be evaluated during compile time.
+    int result = ctEval!(abs(sin(1.0)) * 180 / PI)
+        .round()
+        .to!int();
+
+    assert(result == 48);
 }

--- a/std/functional.d
+++ b/std/functional.d
@@ -52,7 +52,7 @@ $(TR $(TH Function Name) $(TH Description)
         $(TD Passes the fields of a struct as arguments to a function.
     ))
     $(TR $(TD $(LREF ctEval))
-        $(TD Enforces the execution of a function during compile-time.
+        $(TD Enforces the evaluation of an expression during compile-time.
     ))
 ))
 
@@ -2172,20 +2172,20 @@ template bind(alias fun)
 }
 
 /**
- * Enforces the execution of a function during compile-time.
+ * Enforces the evaluation of an expression during compile-time.
  *
- * Computes the return value of a function call during compilation (CTFE).
+ * Computes the value of an expression during compilation (CTFE).
  *
  * This is useful for call chains in functional programming
- * where no explicit `enum` can be placed inline and would require splitting
+ * where declaring an `enum` constant would require splitting
  * the pipeline.
  *
  * Params:
- *   fun = callable to evaluate
+ *   expr = expression to evaluate
  * See_also:
  *   $(LINK https://dlang.org/spec/function.html#interpretation)
  */
-enum ctEval(alias fun) = fun;
+enum ctEval(alias expr) = expr;
 
 ///
 @safe unittest


### PR DESCRIPTION
Implements a `ctEval` function as suggested in #10023.