### PR TITLE
unittest: Don't run x87 log2 test on 64-bit real targets

### DIFF
--- a/std/format/internal/floats.d
+++ b/std/format/internal/floats.d
@@ -1476,37 +1476,40 @@ if (is(T == float) || is(T == double)
 
     assertCTFEable!(
     {
-        // log2 is broken for x87-reals on some computers in CTFE
-        // the following tests excludes these computers from the tests
-        // (https://issues.dlang.org/show_bug.cgi?id=21757)
-        enum test = cast(int) log2(3.05e2312L);
-        static if (real.mant_dig == 64 && test == 7681)
+        static if (real.mant_dig == 64) // 80 bit reals
         {
-            auto f = FormatSpec!dchar("");
-            f.spec = 'e';
-            assert(printFloat(real.infinity, f) == "inf");
-            assert(printFloat(10.0L, f) == "1.000000e+01");
-            assert(printFloat(2.6080L, f) == "2.608000e+00");
-            assert(printFloat(3.05e2312L, f) == "3.050000e+2312");
+            // log2 is broken for x87-reals on some computers in CTFE
+            // the following tests excludes these computers from the tests
+            // (https://issues.dlang.org/show_bug.cgi?id=21757)
+            enum test = cast(int) log2(3.05e2312L);
+            static if (test == 7681)
+            {
+                auto f = FormatSpec!dchar("");
+                f.spec = 'e';
+                assert(printFloat(real.infinity, f) == "inf");
+                assert(printFloat(10.0L, f) == "1.000000e+01");
+                assert(printFloat(2.6080L, f) == "2.608000e+00");
+                assert(printFloat(3.05e2312L, f) == "3.050000e+2312");
 
-            f.precision = 60;
-            assert(printFloat(2.65e-54L, f) ==
-                   "2.650000000000000000059009987400547013941028940935296547599415e-54");
+                f.precision = 60;
+                assert(printFloat(2.65e-54L, f) ==
+                       "2.650000000000000000059009987400547013941028940935296547599415e-54");
 
-            /*
-             commented out, because CTFE is currently too slow for 5000 digits with extreme values
+                /*
+                 commented out, because CTFE is currently too slow for 5000 digits with extreme values
 
-            f.precision = 5000;
-            auto result2 = printFloat(1.2119e-4822L, f);
-            assert(result2.length == 5008);
-            assert(result2[$ - 20 .. $] == "60729486595339e-4822");
-            auto result3 = printFloat(real.min_normal, f);
-            assert(result3.length == 5008);
-            assert(result3[$ - 20 .. $] == "20781410082267e-4932");
-            auto result4 = printFloat(real.min_normal.nextDown, f);
-            assert(result4.length == 5008);
-            assert(result4[$ - 20 .. $] == "81413263331006e-4932");
-             */
+                f.precision = 5000;
+                auto result2 = printFloat(1.2119e-4822L, f);
+                assert(result2.length == 5008);
+                assert(result2[$ - 20 .. $] == "60729486595339e-4822");
+                auto result3 = printFloat(real.min_normal, f);
+                assert(result3.length == 5008);
+                assert(result3[$ - 20 .. $] == "20781410082267e-4932");
+                auto result4 = printFloat(real.min_normal.nextDown, f);
+                assert(result4.length == 5008);
+                assert(result4[$ - 20 .. $] == "81413263331006e-4932");
+                 */
+            }
         }
     });
 }
@@ -2149,39 +2152,42 @@ if (is(T == float) || is(T == double)
 
     assertCTFEable!(
     {
-        // log2 is broken for x87-reals on some computers in CTFE
-        // the following tests excludes these computers from the tests
-        // (https://issues.dlang.org/show_bug.cgi?id=21757)
-        enum test = cast(int) log2(3.05e2312L);
-        static if (real.mant_dig == 64 && test == 7681)
+        static if (real.mant_dig == 64) // 80 bit reals
         {
-            auto f = FormatSpec!dchar("");
-            f.spec = 'f';
-            assert(printFloat(real.infinity, f) == "inf");
-            assert(printFloat(10.0L, f) == "10.000000");
-            assert(printFloat(2.6080L, f) == "2.608000");
-            auto result1 = printFloat(3.05e2312L, f);
-            assert(result1.length == 2320);
-            assert(result1[0 .. 20] == "30499999999999999999");
+            // log2 is broken for x87-reals on some computers in CTFE
+            // the following tests excludes these computers from the tests
+            // (https://issues.dlang.org/show_bug.cgi?id=21757)
+            enum test = cast(int) log2(3.05e2312L);
+            static if (test == 7681)
+            {
+                auto f = FormatSpec!dchar("");
+                f.spec = 'f';
+                assert(printFloat(real.infinity, f) == "inf");
+                assert(printFloat(10.0L, f) == "10.000000");
+                assert(printFloat(2.6080L, f) == "2.608000");
+                auto result1 = printFloat(3.05e2312L, f);
+                assert(result1.length == 2320);
+                assert(result1[0 .. 20] == "30499999999999999999");
 
-            f.precision = 60;
-            assert(printFloat(2.65e-54L, f) ==
-                   "0.000000000000000000000000000000000000000000000000000002650000");
+                f.precision = 60;
+                assert(printFloat(2.65e-54L, f) ==
+                       "0.000000000000000000000000000000000000000000000000000002650000");
 
-            /*
-             commented out, because CTFE is currently too slow for 5000 digits with extreme values
+                /*
+                 commented out, because CTFE is currently too slow for 5000 digits with extreme values
 
-            f.precision = 5000;
-            auto result2 = printFloat(1.2119e-4822L, f);
-            assert(result2.length == 5002);
-            assert(result2[$ - 20 .. $] == "60076763752233836613");
-            auto result3 = printFloat(real.min_normal, f);
-            assert(result3.length == 5002);
-            assert(result3[$ - 20 .. $] == "47124010882722980874");
-            auto result4 = printFloat(real.min_normal.nextDown, f);
-            assert(result4.length == 5002);
-            assert(result4[$ - 20 .. $] == "52925846892214823939");
-             */
+                f.precision = 5000;
+                auto result2 = printFloat(1.2119e-4822L, f);
+                assert(result2.length == 5002);
+                assert(result2[$ - 20 .. $] == "60076763752233836613");
+                auto result3 = printFloat(real.min_normal, f);
+                assert(result3.length == 5002);
+                assert(result3[$ - 20 .. $] == "47124010882722980874");
+                auto result4 = printFloat(real.min_normal.nextDown, f);
+                assert(result4.length == 5002);
+                assert(result4[$ - 20 .. $] == "52925846892214823939");
+                 */
+            }
         }
     });
 }
@@ -2830,37 +2836,40 @@ if (is(T == float) || is(T == double)
 
     assertCTFEable!(
     {
-        // log2 is broken for x87-reals on some computers in CTFE
-        // the following tests excludes these computers from the tests
-        // (https://issues.dlang.org/show_bug.cgi?id=21757)
-        enum test = cast(int) log2(3.05e2312L);
-        static if (real.mant_dig == 64 && test == 7681)
+        static if (real.mant_dig == 64) // 80 bit reals
         {
-            auto f = FormatSpec!dchar("");
-            f.spec = 'g';
-            assert(printFloat(real.infinity, f) == "inf");
-            assert(printFloat(10.0L, f) == "10");
-            assert(printFloat(2.6080L, f) == "2.608");
-            assert(printFloat(3.05e2312L, f) == "3.05e+2312");
+            // log2 is broken for x87-reals on some computers in CTFE
+            // the following tests excludes these computers from the tests
+            // (https://issues.dlang.org/show_bug.cgi?id=21757)
+            enum test = cast(int) log2(3.05e2312L);
+            static if (test == 7681)
+            {
+                auto f = FormatSpec!dchar("");
+                f.spec = 'g';
+                assert(printFloat(real.infinity, f) == "inf");
+                assert(printFloat(10.0L, f) == "10");
+                assert(printFloat(2.6080L, f) == "2.608");
+                assert(printFloat(3.05e2312L, f) == "3.05e+2312");
 
-            f.precision = 60;
-            assert(printFloat(2.65e-54L, f) ==
-                   "2.65000000000000000005900998740054701394102894093529654759941e-54");
+                f.precision = 60;
+                assert(printFloat(2.65e-54L, f) ==
+                       "2.65000000000000000005900998740054701394102894093529654759941e-54");
 
-            /*
-             commented out, because CTFE is currently too slow for 5000 digits with extreme values
+                /*
+                 commented out, because CTFE is currently too slow for 5000 digits with extreme values
 
-            f.precision = 5000;
-            auto result2 = printFloat(1.2119e-4822L, f);
-            assert(result2.length == 5007);
-            assert(result2[$ - 20 .. $] == "26072948659534e-4822");
-            auto result3 = printFloat(real.min_normal, f);
-            assert(result3.length == 5007);
-            assert(result3[$ - 20 .. $] == "72078141008227e-4932");
-            auto result4 = printFloat(real.min_normal.nextDown, f);
-            assert(result4.length == 5007);
-            assert(result4[$ - 20 .. $] == "48141326333101e-4932");
-             */
+                f.precision = 5000;
+                auto result2 = printFloat(1.2119e-4822L, f);
+                assert(result2.length == 5007);
+                assert(result2[$ - 20 .. $] == "26072948659534e-4822");
+                auto result3 = printFloat(real.min_normal, f);
+                assert(result3.length == 5007);
+                assert(result3[$ - 20 .. $] == "72078141008227e-4932");
+                auto result4 = printFloat(real.min_normal.nextDown, f);
+                assert(result4.length == 5007);
+                assert(result4[$ - 20 .. $] == "48141326333101e-4932");
+                 */
+            }
         }
     });
 }

--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -902,13 +902,14 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
 {
     import std.math.exponential : log2;
 
-    // log2 is broken for x87-reals on some computers in CTFE
-    // the following test excludes these computers from the test
-    // (https://issues.dlang.org/show_bug.cgi?id=21757)
-    enum test = cast(int) log2(3.05e2312L);
-    static if (real.mant_dig == 64 && test == 7681) // 80 bit reals
+    static if (real.mant_dig == 64) // 80 bit reals
     {
-        static assert(format!"%e"(real.max) == "1.189731e+4932");
+        // log2 is broken for x87-reals on some computers in CTFE
+        // the following test excludes these computers from the test
+        // (https://issues.dlang.org/show_bug.cgi?id=21757)
+        enum test = cast(int) log2(3.05e2312L);
+        static if (test == 7681)
+            static assert(format!"%e"(real.max) == "1.189731e+4932");
     }
 }
 

--- a/std/math/operations.d
+++ b/std/math/operations.d
@@ -1950,52 +1950,55 @@ if (isFloatingPoint!T)
 
     alias F = floatTraits!real;
 
-    // log2 is broken for x87-reals on some computers in CTFE
-    // the following test excludes these computers from the test
-    // (https://issues.dlang.org/show_bug.cgi?id=21757)
-    enum test = cast(int) log2(3.05e2312L);
-    static if (F.realFormat == RealFormat.ieeeExtended && test == 7681)
+    static if (F.realFormat == RealFormat.ieeeExtended)
     {
-        enum r1 = 1.0L;
-        enum bp1 = extractBitpattern(r1);
-        static assert(bp1.mantissa == 0x8000_0000_0000_0000L);
-        static assert(bp1.exponent == 0);
-        static assert(bp1.negative == false);
+        // log2 is broken for x87-reals on some computers in CTFE
+        // the following test excludes these computers from the test
+        // (https://issues.dlang.org/show_bug.cgi?id=21757)
+        enum test = cast(int) log2(3.05e2312L);
+        static if (test == 7681)
+        {
+            enum r1 = 1.0L;
+            enum bp1 = extractBitpattern(r1);
+            static assert(bp1.mantissa == 0x8000_0000_0000_0000L);
+            static assert(bp1.exponent == 0);
+            static assert(bp1.negative == false);
 
-        enum r2 = real.max;
-        enum bp2 = extractBitpattern(r2);
-        static assert(bp2.mantissa == 0xffff_ffff_ffff_ffffL);
-        static assert(bp2.exponent == 16383);
-        static assert(bp2.negative == false);
+            enum r2 = real.max;
+            enum bp2 = extractBitpattern(r2);
+            static assert(bp2.mantissa == 0xffff_ffff_ffff_ffffL);
+            static assert(bp2.exponent == 16383);
+            static assert(bp2.negative == false);
 
-        enum r3 = -1.5432e-3333L;
-        enum bp3 = extractBitpattern(r3);
-        static assert(bp3.mantissa == 0xc768_a2c7_a616_cc22L);
-        static assert(bp3.exponent == -11072);
-        static assert(bp3.negative == true);
+            enum r3 = -1.5432e-3333L;
+            enum bp3 = extractBitpattern(r3);
+            static assert(bp3.mantissa == 0xc768_a2c7_a616_cc22L);
+            static assert(bp3.exponent == -11072);
+            static assert(bp3.negative == true);
 
-        enum r4 = 0.0L.nextUp;
-        enum bp4 = extractBitpattern(r4);
-        static assert(bp4.mantissa == 0x0000_0000_0000_0001L);
-        static assert(bp4.exponent == -16382);
-        static assert(bp4.negative == false);
+            enum r4 = 0.0L.nextUp;
+            enum bp4 = extractBitpattern(r4);
+            static assert(bp4.mantissa == 0x0000_0000_0000_0001L);
+            static assert(bp4.exponent == -16382);
+            static assert(bp4.negative == false);
 
-        enum r5 = -real.infinity;
-        enum bp5 = extractBitpattern(r5);
-        static assert(bp5.mantissa == 0);
-        static assert(bp5.exponent == 16384);
-        static assert(bp5.negative == true);
+            enum r5 = -real.infinity;
+            enum bp5 = extractBitpattern(r5);
+            static assert(bp5.mantissa == 0);
+            static assert(bp5.exponent == 16384);
+            static assert(bp5.negative == true);
 
-        enum r6 = real.nan;
-        enum bp6 = extractBitpattern(r6);
-        static assert(bp6.mantissa != 0); // we don't guarantee payloads
-        static assert(bp6.exponent == 16384);
-        static assert(bp6.negative == false);
+            enum r6 = real.nan;
+            enum bp6 = extractBitpattern(r6);
+            static assert(bp6.mantissa != 0); // we don't guarantee payloads
+            static assert(bp6.exponent == 16384);
+            static assert(bp6.negative == false);
 
-        enum r7 = nextDown(0x1p+16383L);
-        enum bp7 = extractBitpattern(r7);
-        static assert(bp7.mantissa == 0xffff_ffff_ffff_ffffL);
-        static assert(bp7.exponent == 16382);
-        static assert(bp7.negative == false);
+            enum r7 = nextDown(0x1p+16383L);
+            enum bp7 = extractBitpattern(r7);
+            static assert(bp7.mantissa == 0xffff_ffff_ffff_ffffL);
+            static assert(bp7.exponent == 16382);
+            static assert(bp7.negative == false);
+        }
     }
 }


### PR DESCRIPTION
`3.05e2312L` is an unrepresentable number on targets where `real.mant_dig == double.mant_dig`, so the test ends up requesting the result of `log2(real.infinity)`.

Best viewed with [hide whitespace](https://github.com/dlang/phobos/pull/10627/files?diff=unified&w=1).