### PR TITLE
Remove flakey stopwatch test

### DIFF
--- a/std/datetime/stopwatch.d
+++ b/std/datetime/stopwatch.d
@@ -166,7 +166,6 @@ public:
         Thread.sleep(usecs(1));
 
         sw.reset();
-        assert(sw.peek() < msecs(1));
         assert(sw._timeStarted > before);
         assert(sw._timeStarted <= MonoTime.currTime);
     }


### PR DESCRIPTION
Thread.sleep sleeps for a minimum amount of time, it doesn't guarantee a maximum wait time. Consequently, it can randomly fail: https://github.com/dlang/dmd/pull/20751#issuecomment-2605539022