### PR TITLE
[std.container DList docs] Fix time complexity of `insertFront` etc

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -451,7 +451,7 @@ iterating over the container are never invalidated.
 
 Returns: The number of elements inserted
 
-Complexity: $(BIGOH log(n))
+Complexity: $(BIGOH m), where `m` is the length of `stuff`
      */
     size_t insertFront(Stuff)(Stuff stuff)
     {


### PR DESCRIPTION
See https://forum.dlang.org/post/vkubcdpniiseeuxvdvim@forum.dlang.org

This matches SList's `insertFront`:
https://dlang.org/phobos/std_container_slist.html#.SList.insert