### PR TITLE
Fix Bugzilla Issue 24818 Sumtype with single-type wastes space

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1570,6 +1570,13 @@ version (D_BetterC) {} else
     enum result = test();
 }
 
+// https://github.com/dlang/phobos/issues/10563
+// Do not waste space for tag if sumtype has only single type
+unittest
+{
+    static assert(SumType!int.sizeof == 4);
+}
+
 /// True if `T` is an instance of the `SumType` template, otherwise false.
 private enum bool isSumTypeInstance(T) = is(T == SumType!Args, Args...);
 
@@ -2626,11 +2633,4 @@ private void destroyIfOwner(T)(ref T value)
     {
         destroy(value);
     }
-}
-
-// https://github.com/dlang/phobos/issues/10563
-// Do not waste space for tag if sumtype has only single type
-unittest
-{
-    static assert(SumType!int.sizeof == 4);
 }

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1572,9 +1572,9 @@ version (D_BetterC) {} else
 
 // https://github.com/dlang/phobos/issues/10563
 // Do not waste space for tag if sumtype has only single type
-unittest
+@safe unittest
 {
-    static assert(SumType!int.sizeof == 4);
+    static assert(SumType!int.sizeof == int.sizeof);
 }
 
 /// True if `T` is an instance of the `SumType` template, otherwise false.

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -304,7 +304,10 @@ private:
     }
 
     Storage storage;
-    Tag tag;
+    static if (Types.length > 1)
+        Tag tag;
+    else
+        enum Tag tag = 0;
 
     /* Accesses the value stored in a SumType by its index.
      *
@@ -369,7 +372,8 @@ public:
                 storage.tupleof[tid] = forward!value;
             }
 
-            tag = tid;
+            static if (Types.length > 1)
+                tag = tid;
         }
 
         static if (isCopyable!(const(T)))
@@ -380,7 +384,8 @@ public:
                 this(const(T) value) const
                 {
                     storage.tupleof[tid] = value;
-                    tag = tid;
+                    static if (Types.length > 1)
+                        tag = tid;
                 }
             }
         }
@@ -397,7 +402,8 @@ public:
                 this(immutable(T) value) immutable
                 {
                     storage.tupleof[tid] = value;
-                    tag = tid;
+                    static if (Types.length > 1)
+                        tag = tid;
                 }
             }
         }
@@ -415,7 +421,8 @@ public:
                 if (is(Value == DeducedParameterType!(inout(T))))
                 {
                     storage.tupleof[tid] = value;
-                    tag = tid;
+                    static if (Types.length > 1)
+                        tag = tid;
                 }
             }
         }
@@ -449,7 +456,8 @@ public:
                     return newStorage;
                 });
 
-                tag = other.tag;
+                static if (Types.length > 1)
+                    tag = other.tag;
             }
         }
         else
@@ -469,7 +477,8 @@ public:
                         return newStorage;
                     });
 
-                    tag = other.tag;
+                    static if (Types.length > 1)
+                        tag = other.tag;
                 }
             }
             else
@@ -493,7 +502,8 @@ public:
                         return newStorage;
                     });
 
-                    tag = other.tag;
+                    static if (Types.length > 1)
+                        tag = other.tag;
                 }
             }
             else
@@ -517,7 +527,8 @@ public:
                         return newStorage;
                     });
 
-                    tag = other.tag;
+                    static if (Types.length > 1)
+                        tag = other.tag;
                 }
             }
             else
@@ -644,7 +655,8 @@ public:
                 }
 
                 storage = newStorage;
-                tag = tid;
+                static if (Types.length > 1)
+                    tag = tid;
 
                 return this;
             }
@@ -2614,4 +2626,11 @@ private void destroyIfOwner(T)(ref T value)
     {
         destroy(value);
     }
+}
+
+// https://github.com/dlang/phobos/issues/10563
+// Do not waste space for tag if sumtype has only single type
+unittest
+{
+    static assert(SumType!int.sizeof == 4);
 }


### PR DESCRIPTION
Github issue #10563

I tried doing this with a template mixin that takes the new tag as an alias parameter to avoid having to deplicate the static check all over the place, but that gave me deprecation warnings about assigning a variable to itself and also failed the unittest in line 936 where one postblit destructor didn't execute correctly ...