### PR TITLE
Fix chain potentially mutating a stale object

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1042,7 +1042,7 @@ if (Ranges.length > 0 &&
                 // We do this separately to avoid invoking `empty` needlessly.
                 // While not recommended, a range may depend on side effects of
                 // `empty` call.
-                foreach (i, ref v; input) if (!v.empty)
+                foreach (i, ref v; source) if (!v.empty)
                 {
                     frontIndex = i;
                     static if (bidirectional) backIndex = i+1;
@@ -1056,7 +1056,7 @@ if (Ranges.length > 0 &&
                     static foreach_reverse (i; 1 .. R.length + 1)
                 {
                     if (i <= frontIndex + 1) return;
-                    if (!input[i-1].empty)
+                    if (!source[i-1].empty)
                     {
                         backIndex = i;
                         return;
@@ -11017,6 +11017,23 @@ auto only()()
     static assert(!__traits(compiles, r3.back = 789));
     // Workaround https://issues.dlang.org/show_bug.cgi?id=24383
     static assert(!__traits(compiles, () { r3[0] = 789; }));
+}
+
+// https://github.com/dlang/phobos/issues/10561
+@safe unittest
+{
+    static struct Range
+    {
+        private int i;
+
+        enum bool empty = false;
+        int front() => i;
+        void popFront() { ++i; }
+    }
+    import std.algorithm;
+
+    assert(Range().take(10).filter!"a>8".chain(only(100)).equal([9,100]));
+    assert((new Range()).take(10).filter!"a>8".chain(only(100)).equal([9,100]));
 }
 
 /**


### PR DESCRIPTION
The constructor of the result of std.range.chain copies it's input tuple and then has to check which of the input-ranges in the first non-empty one. The member function empty is not guaranteed to be const, filter is probably the most prominent function that has to be "primed". On the first call to empty(), filter will try to advance all it's input ranges to the first element that matches the predicate.
For ranges with full value semantics, using the old input object instead of the new internal buffer means that the work of priming is done twice. If any ranges have reference semantics, the references gets advances, but the value-semantic parts of the range-composition gets reset.

This fixes #10561 and #9877