### PR TITLE
Tuple toString

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1355,15 +1355,7 @@ if (distinctFieldNames!(Specs))
                         {
                             sink(fmt.sep);
                         }
-                        // TODO: Change this once formattedWrite() works for shared objects.
-                        static if (is(Type == class) && is(Type == shared))
-                        {
-                            sink(Type.stringof);
-                        }
-                        else
-                        {
-                            formattedWrite(sink, fmt.nested, this.field[i]);
-                        }
+                        formattedWrite(sink, fmt.nested, this.field[i]);
                     }
                 }
                 else
@@ -1383,15 +1375,7 @@ if (distinctFieldNames!(Specs))
                     {
                         sink(separator);
                     }
-                    // TODO: Change this once format() works for shared objects.
-                    static if (is(Type == class) && is(Type == shared))
-                    {
-                        sink(Type.stringof);
-                    }
-                    else
-                    {
-                        sink.formattedWrite!("%(%s%)")(only(field[i]));
-                    }
+                    sink.formattedWrite!("%(%s%)")(only(field[i]));
                 }
                 sink(footer);
             }
@@ -1812,7 +1796,15 @@ private template ReverseTupleSpecs(T...)
         Tuple!(int, shared A) nosh;
         nosh[0] = 5;
         assert(nosh[0] == 5 && nosh[1] is null);
-        assert(nosh.to!string == "Tuple!(int, shared(A))(5, shared(A))");
+
+        assert(nosh.to!string == "Tuple!(int, shared(A))(5, null)");
+    }
+    {
+        static struct A {}
+        Tuple!(int, shared A*) nosh;
+        nosh[0] = 5;
+        assert(nosh[0] == 5 && nosh[1] is null);
+        assert(nosh.to!string == "Tuple!(int, shared(A*))(5, null)");
     }
     {
         Tuple!(int, string) t;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1803,6 +1803,7 @@ private template ReverseTupleSpecs(T...)
         // Currently contains the mangled type name
         // 5, const(std.typecons.__unittest_L1750_C7.A)
         // This assert is not necessarily to prescribe this behaviour, only to signal if there is a breaking change.
+        // See https://github.com/dlang/phobos/issues/9811
         auto s = f();
         assert(s.canFind("__unittest_L"));
         assert(s.endsWith(".A)"));

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1362,6 +1362,7 @@ if (distinctFieldNames!(Specs))
                     {
                         sink(separator);
                     }
+                    // Among other things, using "only" causes string-fields to be inside quotes in the result
                     sink.formattedWrite!("%(%s%)")(only(field[i]));
                 }
                 sink(footer);

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -447,19 +447,6 @@ private:
     assert(ptr.bar.val == 7);
 }
 
-// Used in Tuple.toString
-private template sharedToString(alias field)
-if (is(typeof(field) == shared))
-{
-    static immutable sharedToString = typeof(field).stringof;
-}
-
-private template sharedToString(alias field)
-if (!is(typeof(field) == shared))
-{
-    alias sharedToString = field;
-}
-
 private enum bool distinctFieldNames(names...) = __traits(compiles,
 {
     static foreach (__name; names)
@@ -1360,7 +1347,7 @@ if (distinctFieldNames!(Specs))
                 }
                 else
                 {
-                    formattedWrite(sink, fmt.nested, staticMap!(sharedToString, this.expand));
+                    formattedWrite(sink, fmt.nested, this.expand);
                 }
             }
             else if (fmt.spec == 's')
@@ -1798,6 +1785,26 @@ private template ReverseTupleSpecs(T...)
         assert(nosh[0] == 5 && nosh[1] is null);
 
         assert(nosh.to!string == "Tuple!(int, shared(A))(5, null)");
+    }
+    {
+        // Shared, without fmt.sep
+        import std.format;
+        import std.algorithm.searching;
+        static class A {int i = 1;}
+        Tuple!(int, shared A) nosh;
+        nosh[0] = 5;
+        assert(nosh[0] == 5 && nosh[1] is null);
+
+        // needs trusted, because Object.toString() isn't @safe
+        auto f = ()@trusted => format!("%(%s, %s%)")(nosh);
+        assert(f() == "5, null");
+        nosh[1] = new shared A();
+        // Currently contains the mangled type name
+        // 5, const(std.typecons.__unittest_L1750_C7.A)
+        // This assert is not necessarily to prescribe this behaviour, only to signal if there is a breaking change.
+        auto s = f();
+        assert(s.canFind("__unittest_L"));
+        assert(s.endsWith(".A)"));
     }
     {
         static struct A {}

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1390,7 +1390,7 @@ if (distinctFieldNames!(Specs))
                     }
                     else
                     {
-                        sink(format!("%(%s%)")(only(field[i])));
+                        sink.formattedWrite!("%(%s%)")(only(field[i]));
                     }
                 }
                 sink(footer);


### PR DESCRIPTION
* Use formattedWrite instead of format
* Remove some workarounds for shared types that have been put in there a few years ago

I'm not entirely sure why these workaround have been added, but I suspect that #6207 fixed this in `std.format`.  The unittests still work.

This is a breaking change. See line 1787 (in the new version), If a class is null, the Tuple.toString will now print null instead of the mangled typename (because this is what std.format does)