### PR TITLE
Procedural API for SumType

### DIFF
--- a/changelog/sumtype_procedural_api.dd
+++ b/changelog/sumtype_procedural_api.dd
@@ -1,0 +1,39 @@
+New procedural API for `std.sumtype`
+
+`std.sumtype` has three new convenience functions for querying and retrieving
+the value of a `SumType` object.
+
+* `has!T` returns `true` if the `SumType` object has a value of type `T`.
+* `get!T` returns the value if its type is `T`, or asserts if it is not.
+* `tryGet!T` returns the value if its type is `T`, or throws an exception if it
+   is not.
+
+These functions make it easier to write code using `SumType` in a procedural
+style, as opposed to the functional style encouraged by `match`.
+
+Example:
+
+---
+import std.sumtype;
+import std.stdio;
+
+SumType!(string, double) example = "hello";
+
+if (example.has!string)
+{
+    writeln("string: ", example.get!string);
+}
+else if (example.has!double)
+{
+    writeln("double: ", example.get!double);
+}
+
+try
+{
+    writeln("double: ", example.tryGet!double);
+}
+catch (MatchException e)
+{
+    writeln("Couldn't get a double.");
+}
+---

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -2667,7 +2667,7 @@ template has(T)
     }
 
     // Helper to avoid redundant template instantiations
-    bool checkType(Value)(ref Value value)
+    private bool checkType(Value)(ref Value value)
     {
         return is(Value == T);
     }

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -323,7 +323,7 @@ private:
     @trusted
     // Explicit return type omitted
     // Workaround for https://github.com/dlang/dmd/issues/20549
-    ref get(size_t tid)() inout
+    ref getByIndex(size_t tid)() inout
     if (tid < Types.length)
     {
         assert(tag == tid,
@@ -1154,7 +1154,7 @@ version (D_BetterC) {} else
     alias MySum = SumType!(ubyte, void*[2]);
 
     MySum x = [null, cast(void*) 0x12345678];
-    void** p = &x.get!1[1];
+    void** p = &x.getByIndex!1[1];
     x = ubyte(123);
 
     assert(*p != cast(void*) 0x12345678);
@@ -1186,8 +1186,8 @@ version (D_BetterC) {} else
     catch (Exception e) {}
 
     assert(
-        (x.tag == 0 && x.get!0.value == 123) ||
-        (x.tag == 1 && x.get!1.value == 456)
+        (x.tag == 0 && x.getByIndex!0.value == 123) ||
+        (x.tag == 1 && x.getByIndex!1.value == 456)
     );
 }
 
@@ -1246,8 +1246,8 @@ version (D_BetterC) {} else
     SumType!(S[1]) x = [S(0)];
     SumType!(S[1]) y = x;
 
-    auto xval = x.get!0[0].n;
-    auto yval = y.get!0[0].n;
+    auto xval = x.getByIndex!0[0].n;
+    auto yval = y.getByIndex!0[0].n;
 
     assert(xval != yval);
 }
@@ -1332,8 +1332,8 @@ version (D_BetterC) {} else
     SumType!S y;
     y = x;
 
-    auto xval = x.get!0.n;
-    auto yval = y.get!0.n;
+    auto xval = x.getByIndex!0.n;
+    auto yval = y.getByIndex!0.n;
 
     assert(xval != yval);
 }
@@ -1407,8 +1407,8 @@ version (D_BetterC) {} else
     SumType!S x = S();
     SumType!S y = x;
 
-    auto xval = x.get!0.n;
-    auto yval = y.get!0.n;
+    auto xval = x.getByIndex!0.n;
+    auto yval = y.getByIndex!0.n;
 
     assert(xval != yval);
 }
@@ -1902,10 +1902,10 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
              * argument's tag, so there's no need for TagTuple.
              */
             enum handlerArgs(size_t caseId) =
-                "args[0].get!(" ~ toCtString!caseId ~ ")()";
+                "args[0].getByIndex!(" ~ toCtString!caseId ~ ")()";
 
             alias valueTypes(size_t caseId) =
-                typeof(args[0].get!(caseId)());
+                typeof(args[0].getByIndex!(caseId)());
 
             enum numCases = SumTypes[0].Types.length;
         }
@@ -1931,7 +1931,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 
                 template getType(size_t i)
                 {
-                    alias getType = typeof(args[i].get!(tags[i])());
+                    alias getType = typeof(args[i].getByIndex!(tags[i])());
                 }
 
                 alias valueTypes = Map!(getType, Iota!(tags.length));
@@ -2156,7 +2156,7 @@ private template handlerArgs(size_t caseId, typeCounts...)
     {
         handlerArgs = AliasSeq!(
             handlerArgs,
-            "args[" ~ toCtString!i ~ "].get!(" ~ toCtString!(tags[i]) ~ ")(), "
+            "args[" ~ toCtString!i ~ "].getByIndex!(" ~ toCtString!(tags[i]) ~ ")(), "
         );
     }
 }
@@ -2420,7 +2420,7 @@ version (D_Exceptions)
         (ref double d) { d *= 2; }
     );
 
-    assert(value.get!1.isClose(6.28));
+    assert(value.getByIndex!1.isClose(6.28));
 }
 
 // Unreachable handlers

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -2987,9 +2987,23 @@ version (D_Exceptions)
     assert(ctResult == ElaborateCopy());
 }
 
-private enum failedGetMessage(Expected, Actual) =
-    "Tried to get `" ~ Expected.stringof ~ "`" ~
-    " but found `" ~ Actual.stringof ~ "`";
+private template failedGetMessage(Expected, Actual)
+{
+    static if (Expected.stringof == Actual.stringof)
+    {
+        enum expectedStr = __traits(fullyQualifiedName, Expected);
+        enum actualStr = __traits(fullyQualifiedName, Actual);
+    }
+    else
+    {
+        enum expectedStr = Expected.stringof;
+        enum actualStr = Actual.stringof;
+    }
+
+    enum failedGetMessage =
+        "Tried to get `" ~ expectedStr ~ "`" ~
+        " but found `" ~ actualStr ~ "`";
+}
 
 private template getLvalue(Flag!"try_" try_, T)
 {


### PR DESCRIPTION
This PR introduces three new convenience functions that allow code using `SumType` to be written in a more procedural style (as opposed to the functional style of `match`).

* `has!T` checks whether a `SumType` contains a value of type `T`.
* `get!T` accesses a `SumType`'s value if it has type `T`, or asserts if it does not.
* `tryGet!T` is like `get!T`, but throws an exception instead of asserting on failure.

To make room for `get!T`, the existing `SumType.get` method is renamed to `getByIndex`.

CC @atilaneves since this introduces new public symbols
CC @jmdavis who requested this in the community Discord