### PR TITLE
std.conv: add writeText, writeWText, writeDText

### DIFF
--- a/changelog/write-text.dd
+++ b/changelog/write-text.dd
@@ -1,0 +1,20 @@
+Add `writeText`, `writeWText`, and `writeDText` to `std.conv`
+
+These functions are variants of the existing `text`, `wtext`, and `dtext`
+functions. Instead of returning a string, they write their output to an output
+range.
+
+Like `text`, `writeText` can accept an
+$(LINK2 $(ROOT_DIR)spec/istring.html, interpolated expression sequence) as an
+argument.
+
+Example:
+
+---
+import std.conv : writeText;
+import std.array : appender;
+
+auto output = appender!string();
+output.writeText(i"2 + 2 == $(2 + 2)");
+assert(output.data == "2 + 2 == 4");
+---

--- a/std/conv.d
+++ b/std/conv.d
@@ -5096,27 +5096,32 @@ private S textImpl(S, U...)(U args)
         // assume that on average, parameters will have less
         // than 20 elements
         app.reserve(U.length * 20);
-        // Must be static foreach because of https://issues.dlang.org/show_bug.cgi?id=21209
-        static foreach (arg; args)
-        {
-            static if (
-                isSomeChar!(typeof(arg))
-                || isSomeString!(typeof(arg))
-                || ( isInputRange!(typeof(arg)) && isSomeChar!(ElementType!(typeof(arg))) )
-            )
-                app.put(arg);
-            else static if (
-
-                is(immutable typeof(arg) == immutable uint) || is(immutable typeof(arg) == immutable ulong) ||
-                is(immutable typeof(arg) == immutable int) || is(immutable typeof(arg) == immutable long)
-            )
-                // https://issues.dlang.org/show_bug.cgi?id=17712#c15
-                app.put(textImpl!(S)(arg));
-            else
-                app.put(to!S(arg));
-        }
-
+        app.writeTextImpl!S(args);
         return app.data;
+    }
+}
+
+private void writeTextImpl(S, Sink, U...)(ref Sink sink, U args)
+if (isSomeString!S && isOutputRange!(Sink, ElementEncodingType!S))
+{
+    // Must be static foreach because of https://issues.dlang.org/show_bug.cgi?id=21209
+    static foreach (arg; args)
+    {
+        static if (
+            isSomeChar!(typeof(arg))
+            || isSomeString!(typeof(arg))
+            || ( isInputRange!(typeof(arg)) && isSomeChar!(ElementType!(typeof(arg))) )
+        )
+            put(sink, arg);
+        else static if (
+
+            is(immutable typeof(arg) == immutable uint) || is(immutable typeof(arg) == immutable ulong) ||
+            is(immutable typeof(arg) == immutable int) || is(immutable typeof(arg) == immutable long)
+        )
+            // https://issues.dlang.org/show_bug.cgi?id=17712#c15
+            put(sink, textImpl!(S)(arg));
+        else
+            put(sink, to!S(arg));
     }
 }
 


### PR DESCRIPTION
These are variants of text, wtext, and dtext that write their output to an output range instead of returning a string.

Fixes #10550