### PR TITLE
Fix %*s handling by formattedRead()

### DIFF
--- a/std/format/internal/read.d
+++ b/std/format/internal/read.d
@@ -24,7 +24,7 @@ package(std.format):
 
 void skipData(Range, Char)(ref Range input, scope const ref FormatSpec!Char spec)
 {
-    import std.ascii : isDigit;
+    import std.ascii : isDigit, isWhite;
     import std.range.primitives : empty, front, popFront;
 
     switch (spec.spec)
@@ -33,6 +33,9 @@ void skipData(Range, Char)(ref Range input, scope const ref FormatSpec!Char spec
         case 'd':
             if (input.front == '+' || input.front == '-') input.popFront();
             goto case 'u';
+        case 's':
+            while (!input.empty && !isWhite(input.front)) input.popFront();
+            break;
         case 'u':
             while (!input.empty && isDigit(input.front)) input.popFront();
             break;

--- a/std/format/read.d
+++ b/std/format/read.d
@@ -377,6 +377,16 @@ if (!isType!fmt && isSomeString!(typeof(fmt)))
     assert(t[0] == 1 && t[1] == 2.125);
 }
 
+@safe pure unittest
+{
+    string hello;
+    string world;
+
+    assert("hello ignore world".formattedRead("%s %*s %s", hello, world) == 2);
+    assert(hello == "hello");
+    assert(world == "world");
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=23600
 @safe pure unittest
 {


### PR DESCRIPTION
This PR addresses issue #10598. The problem lies in the lack of handling for certain specifiers in the `skipData` function of `std/format/internal/read.d`. The `switch` statement only handles `%c`, `%d` and `%u`. Handling of `%s` was added but the problem is analogous in the case of other specifiers. For example, the program:

```
import std.format;
import std.stdio;
void main()
{
    string str = "3.14159 0.0 6.28318";
    double pi, tau;
    str.formattedRead("%f %*f %f", pi, tau);
    writeln("Pi is: ", pi , ", Tau is: ", tau);
}
```

outputs this:

```
core.exception.AssertError@/home/nick/dlang/dmd/generated/linux/release/64/../../../../../phobos/std/format/internal/read.d(43): Format specifier not understood: %f
----------------
??:? _d_assert_msg [0x55af8fd75528]
??:? pure @safe void std.format.internal.read.skipData!(immutable(char)[], char).skipData(ref immutable(char)[], scope ref const(std.format.spec.FormatSpec!(char).FormatSpec)) [0x55af8fd4f58d]
??:? pure @safe void std.format.read.formattedRead!(immutable(char)[], char, double).formattedRead(ref immutable(char)[], const(char)[], ref double).skipUnstoredFields() [0x55af8fd51091]
??:? pure @safe uint std.format.read.formattedRead!(immutable(char)[], char, double).formattedRead(ref immutable(char)[], const(char)[], ref double) [0x55af8fd50ffa]
??:? pure @safe uint std.format.read.formattedRead!(immutable(char)[], char, double, double).formattedRead(ref immutable(char)[], const(char)[], ref double, ref double) [0x55af8fd49d4f]
??:? _Dmain [0x55af8fd49918]
```

Therefore, the remaining specifiers also need to be handled. Should I include them in this PR, or should I open a separate, more general issue and PR for this problem?
