### PR TITLE
Fix #10565: Prevent negative zero when multiplying BigInt zero by neg…

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -264,18 +264,19 @@ public:
             data = BigUint.addOrSubInt!ulong(data, u, wantSub: sign == (y<0), sign);
         }
         else static if (op=="*")
-        {
-            if (y == 0)
-            {
-                sign = false;
-                data = 0UL;
-            }
-            else
-            {
-                sign = ( sign != (y<0) );
-                data = BigUint.mulInt(data, u);
-            }
-        }
+{
+    if (y == 0 || data.isZero())
+    {
+        data = 0UL;
+        sign = false;
+        return this;
+    }
+    else
+    {
+        sign = ( sign != (y<0) );
+        data = BigUint.mulInt(data, u);
+    }
+}
         else static if (op=="/")
         {
             assert(y != 0, "Division by zero");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -264,19 +264,19 @@ public:
             data = BigUint.addOrSubInt!ulong(data, u, wantSub: sign == (y<0), sign);
         }
         else static if (op=="*")
-{
-    if (y == 0 || data.isZero())
-    {
-        data = 0UL;
-        sign = false;
-        return this;
-    }
-    else
-    {
-        sign = ( sign != (y<0) );
-        data = BigUint.mulInt(data, u);
-    }
-}
+        {
+            if (y == 0 || data.isZero())
+            {
+                data = 0UL;
+                sign = false;
+                return this;
+            }
+            else
+            {
+                sign = ( sign != (y<0) );
+                data = BigUint.mulInt(data, u);
+            }
+        }
         else static if (op=="/")
         {
             assert(y != 0, "Division by zero");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -362,6 +362,29 @@ public:
         return this;
     }
 
+    // https://issues.dlang.org/show_bug.cgi?id=10565
+@safe unittest
+{
+    // Test cases from the issue
+    BigInt a = BigInt("0");
+    BigInt b = BigInt("-0");
+    BigInt c = BigInt("0") * -1;
+    BigInt d = BigInt("0") * -42;
+    BigInt e = BigInt("0"); e *= -1;
+    BigInt f = BigInt(c);
+    BigInt g = BigInt("0") * cast(byte) -1;
+    BigInt h = BigInt("0"); h *= BigInt("-1");
+    BigInt i = BigInt("0"); i -= 2 * i;
+    BigInt j = BigInt("0"); j = -j;
+    // All of these should be zero and not negative
+    auto values = [a, b, c, d, e, f, g, h, i, j];
+    foreach (val; values)
+    {
+        assert(val == 0, "BigInt value should be equal to zero");
+        assert(!(val < 0), "BigInt zero should not be negative");
+    }
+}
+
     ///
     @safe unittest
     {

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -267,8 +267,8 @@ public:
         {
             if (y == 0 || data.isZero())
             {
-                data = 0UL;
                 sign = false;
+                data = 0UL;
                 return this;
             }
             else
@@ -422,31 +422,6 @@ public:
     `58105600`
         ));
     }
-// https://issues.dlang.org/show_bug.cgi?id=10565
-@safe unittest
-{
-    // Test cases from the issue
-    BigInt a = BigInt("0");
-    BigInt b = BigInt("-0");
-    BigInt c = BigInt("0") * -1;
-    BigInt d = BigInt("0") * -42;
-    BigInt e = BigInt("0"); e *= -1;
-    BigInt f = BigInt(c);
-    BigInt g = BigInt("0") * cast(byte) -1;
-    BigInt h = BigInt("0"); h *= BigInt("-1");
-    BigInt i = BigInt("0"); i -= 2 * i;
-    BigInt j = BigInt("0"); j = -j;
-    
-    // All of these should be zero and not negative
-    BigInt[] test = [a, b, c, d, e, f, g, h, i, j];
-    foreach(idx, t; test) {
-        assert(t == 0, "BigInt should be equal to zero");
-        assert(!(t < 0), "BigInt zero should not be negative");
-    }
-}
-
-
-
 
     // https://issues.dlang.org/show_bug.cgi?id=24028
     @system unittest

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -422,6 +422,31 @@ public:
     `58105600`
         ));
     }
+// https://issues.dlang.org/show_bug.cgi?id=10565
+@safe unittest
+{
+    // Test cases from the issue
+    BigInt a = BigInt("0");
+    BigInt b = BigInt("-0");
+    BigInt c = BigInt("0") * -1;
+    BigInt d = BigInt("0") * -42;
+    BigInt e = BigInt("0"); e *= -1;
+    BigInt f = BigInt(c);
+    BigInt g = BigInt("0") * cast(byte) -1;
+    BigInt h = BigInt("0"); h *= BigInt("-1");
+    BigInt i = BigInt("0"); i -= 2 * i;
+    BigInt j = BigInt("0"); j = -j;
+    
+    // All of these should be zero and not negative
+    BigInt[] test = [a, b, c, d, e, f, g, h, i, j];
+    foreach(idx, t; test) {
+        assert(t == 0, "BigInt should be equal to zero");
+        assert(!(t < 0), "BigInt zero should not be negative");
+    }
+}
+
+
+
 
     // https://issues.dlang.org/show_bug.cgi?id=24028
     @system unittest


### PR DESCRIPTION
**### Fix for BigInt multiplication of 0 by integral (non-BigInt) type creating "-0" (negative zero)**

**Issue Description**
When multiplying a BigInt with value 0 by a negative integral type (e.g. -1 or cast(byte)(-1)), the resulting BigInt incorrectly becomes "-0" (negative zero), which leads to unexpected behavior. A BigInt with value zero should always have a positive sign regardless of operations performed on it.

**Root Cause**
The issue is in the opOpAssign method for the multiplication operator when handling integral types. Currently, when multiplying by zero, the code sets the data to 0 but still updates the sign based on the operand's sign. This is incorrect mathematical behavior since zero multiplied by any number should be positive zero.

**Fix**
The solution is to modify the opOpAssign method to check both if the operand is zero OR if the BigInt's data is already zero. In either case, we set the sign to false (positive) and the data to zero.