### PR TITLE
stdio: add readfln and File.readfln

### DIFF
--- a/changelog/readfln.dd
+++ b/changelog/readfln.dd
@@ -1,0 +1,6 @@
+Added `readfln` and `File.readfln` to `std.stdio`
+
+These functions read a single line of input and parse it using a format string.
+Unlike `readf`, they will not accidentally read multiple lines if the user
+forgets to include a line terminator in the format string—a common mistake for
+beginners.


### PR DESCRIPTION
Compared to readf, these functions provide a less error-prone way to read a single line of formatted input.

Fixes #10370