### PR TITLE
Fix CTFE error in biguintcore.d

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -264,18 +264,19 @@ public:
             data = BigUint.addOrSubInt!ulong(data, u, wantSub: sign == (y<0), sign);
         }
         else static if (op=="*")
-        {
-            if (y == 0)
-            {
-                sign = false;
-                data = 0UL;
-            }
-            else
-            {
-                sign = ( sign != (y<0) );
-                data = BigUint.mulInt(data, u);
-            }
-        }
+{
+    if (y == 0 || data.isZero())
+    {
+        data = 0UL;
+        sign = false;
+        return this;
+    }
+    else
+    {
+        sign = ( sign != (y<0) );
+        data = BigUint.mulInt(data, u);
+    }
+}
         else static if (op=="/")
         {
             assert(y != 0, "Division by zero");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -264,19 +264,19 @@ public:
             data = BigUint.addOrSubInt!ulong(data, u, wantSub: sign == (y<0), sign);
         }
         else static if (op=="*")
-{
-    if (y == 0 || data.isZero())
-    {
-        data = 0UL;
-        sign = false;
-        return this;
-    }
-    else
-    {
-        sign = ( sign != (y<0) );
-        data = BigUint.mulInt(data, u);
-    }
-}
+        {
+            if (y == 0 || data.isZero())
+            {
+                data = 0UL;
+                sign = false;
+                return this;
+            }
+            else
+            {
+                sign = ( sign != (y<0) );
+                data = BigUint.mulInt(data, u);
+            }
+        }
         else static if (op=="/")
         {
             assert(y != 0, "Division by zero");

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -362,6 +362,29 @@ public:
         return this;
     }
 
+    // https://issues.dlang.org/show_bug.cgi?id=10565
+@safe unittest
+{
+    // Test cases from the issue
+    BigInt a = BigInt("0");
+    BigInt b = BigInt("-0");
+    BigInt c = BigInt("0") * -1;
+    BigInt d = BigInt("0") * -42;
+    BigInt e = BigInt("0"); e *= -1;
+    BigInt f = BigInt(c);
+    BigInt g = BigInt("0") * cast(byte) -1;
+    BigInt h = BigInt("0"); h *= BigInt("-1");
+    BigInt i = BigInt("0"); i -= 2 * i;
+    BigInt j = BigInt("0"); j = -j;
+    // All of these should be zero and not negative
+    auto values = [a, b, c, d, e, f, g, h, i, j];
+    foreach (val; values)
+    {
+        assert(val == 0, "BigInt value should be equal to zero");
+        assert(!(val < 0), "BigInt zero should not be negative");
+    }
+}
+
     ///
     @safe unittest
     {

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -267,8 +267,8 @@ public:
         {
             if (y == 0 || data.isZero())
             {
-                data = 0UL;
                 sign = false;
+                data = 0UL;
                 return this;
             }
             else
@@ -422,31 +422,6 @@ public:
     `58105600`
         ));
     }
-// https://issues.dlang.org/show_bug.cgi?id=10565
-@safe unittest
-{
-    // Test cases from the issue
-    BigInt a = BigInt("0");
-    BigInt b = BigInt("-0");
-    BigInt c = BigInt("0") * -1;
-    BigInt d = BigInt("0") * -42;
-    BigInt e = BigInt("0"); e *= -1;
-    BigInt f = BigInt(c);
-    BigInt g = BigInt("0") * cast(byte) -1;
-    BigInt h = BigInt("0"); h *= BigInt("-1");
-    BigInt i = BigInt("0"); i -= 2 * i;
-    BigInt j = BigInt("0"); j = -j;
-    
-    // All of these should be zero and not negative
-    BigInt[] test = [a, b, c, d, e, f, g, h, i, j];
-    foreach(idx, t; test) {
-        assert(t == 0, "BigInt should be equal to zero");
-        assert(!(t < 0), "BigInt zero should not be negative");
-    }
-}
-
-
-
 
     // https://issues.dlang.org/show_bug.cgi?id=24028
     @system unittest

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -422,6 +422,31 @@ public:
     `58105600`
         ));
     }
+// https://issues.dlang.org/show_bug.cgi?id=10565
+@safe unittest
+{
+    // Test cases from the issue
+    BigInt a = BigInt("0");
+    BigInt b = BigInt("-0");
+    BigInt c = BigInt("0") * -1;
+    BigInt d = BigInt("0") * -42;
+    BigInt e = BigInt("0"); e *= -1;
+    BigInt f = BigInt(c);
+    BigInt g = BigInt("0") * cast(byte) -1;
+    BigInt h = BigInt("0"); h *= BigInt("-1");
+    BigInt i = BigInt("0"); i -= 2 * i;
+    BigInt j = BigInt("0"); j = -j;
+    
+    // All of these should be zero and not negative
+    BigInt[] test = [a, b, c, d, e, f, g, h, i, j];
+    foreach(idx, t; test) {
+        assert(t == 0, "BigInt should be equal to zero");
+        assert(!(t < 0), "BigInt zero should not be negative");
+    }
+}
+
+
+
 
     // https://issues.dlang.org/show_bug.cgi?id=24028
     @system unittest

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -2785,6 +2785,10 @@ do
         adjustRemainder(quotient[0 .. k], u[0 .. v.length], v, k,
             scratch[0 .. 2 * k]);
     }
+    () @trusted { 
+        if (!__ctfe) 
+            GC.free(scratchbuff.ptr); 
+    } ();
 }
 
 // rem -= quot * v[0 .. k].
@@ -2842,7 +2846,10 @@ pure nothrow @safe
         m -= v.length;
     }
     recursiveDivMod(quotient[0 .. m], u[0 .. m + v.length], v, scratch);
-    () @trusted { GC.free(scratch.ptr); } ();
+    () @trusted { 
+        if (!__ctfe) 
+            GC.free(scratch.ptr); 
+    } ();
 }
 
 @system unittest


### PR DESCRIPTION
This PR fixes a compile-time function evaluation (CTFE) error in biguintcore.d.

The error occurs because GC.free() cannot be interpreted at compile time.
I've added checks using __ctfe to ensure the free() operations only happen 
at runtime, while allowing the functions to still be usable in CTFE.

This allows the affected functions to be used both at compile time and 
runtime without errors.