### PR TITLE
Eliminate redundant allocation in to!string for types with toString

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1013,7 +1013,17 @@ if (!(is(S : T) &&
     !isEnumStrToStr!(S, T) && !isNullToStr!(S, T)) &&
     !isInfinite!S && isExactSomeString!T)
 {
-    static if (isExactSomeString!S && value[0].sizeof == ElementEncodingType!T.sizeof)
+    static if (is(typeof(T.init.toString())) && __traits(compiles, T.init.toString()) &&
+               isSomeString!(typeof(T.init.toString())))
+    {
+
+        auto toImpl(T value)
+        {
+            return value.toString();
+        }
+    }
+
+    else static if (isExactSomeString!S && value[0].sizeof == ElementEncodingType!T.sizeof)
     {
         // string-to-string with incompatible qualifier conversion
         static if (is(ElementEncodingType!T == immutable))


### PR DESCRIPTION
This PR fixes the issue where `to!string` creates an unnecessary allocation when used on types that already have a `toString()` method. By adding a specialized implementation for these types, we directly use the string returned by `toString()` instead of creating a new allocation. This improves performance and reduces memory usage in common type conversion scenarios.