### PR TITLE
Fix #9584 - Using dirEntries and chdir() can have unwanted results

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4138,11 +4138,13 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
     dirEntries("", SpanMode.shallow).walkLength();
 
     // issue 6138
-    foreach (string entry; dirEntries(testdir, SpanMode.shallow) {
+    string cwd = getcwd();
+    foreach (string entry; dirEntries(testdir, SpanMode.shallow)) {
         if (entry.isDir) {
              chdir(entry);
         }
     }
+    chdir (cwd); // needed for the directories to be removed
 }
 
 /// Ditto

--- a/std/file.d
+++ b/std/file.d
@@ -4038,7 +4038,7 @@ foreach (d; dFiles)
  +/
 auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 {
-	import std.path: absolutePath;
+    import std.path: absolutePath;
     return DirIterator(absolutePath(path), mode, followSymlink);
 }
 
@@ -4058,7 +4058,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
             .array;
     }
 
-	void main(string[] args)
+    void main(string[] args)
     {
         import std.stdio;
 

--- a/std/file.d
+++ b/std/file.d
@@ -4038,7 +4038,8 @@ foreach (d; dFiles)
  +/
 auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 {
-    return DirIterator(path, mode, followSymlink);
+	import std.path: absolutePath;
+    return DirIterator(absolutePath(path), mode, followSymlink);
 }
 
 /// Duplicate functionality of D1's $(D std.file.listdir()):
@@ -4057,7 +4058,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
             .array;
     }
 
-    void main(string[] args)
+	void main(string[] args)
     {
         import std.stdio;
 
@@ -4109,7 +4110,7 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
     foreach (string name; dirEntries(testdir, SpanMode.breadth))
     {
         //writeln(name);
-        assert(name.startsWith(testdir));
+        assert(name.startsWith(absolutePath(testdir)));
     }
     foreach (DirEntry e; dirEntries(absolutePath(testdir), SpanMode.breadth))
     {

--- a/std/file.d
+++ b/std/file.d
@@ -4139,8 +4139,10 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 
     // issue 6138
     string cwd = getcwd();
-    foreach (string entry; dirEntries(testdir, SpanMode.shallow)) {
-        if (entry.isDir) {
+    foreach (string entry; dirEntries(testdir, SpanMode.shallow))
+    {
+        if (entry.isDir)
+        {
              chdir(entry);
         }
     }

--- a/std/file.d
+++ b/std/file.d
@@ -4038,7 +4038,7 @@ foreach (d; dFiles)
  +/
 auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 {
-    import std.path: absolutePath;
+    import std.path : absolutePath;
     return DirIterator(absolutePath(path), mode, followSymlink);
 }
 

--- a/std/file.d
+++ b/std/file.d
@@ -4136,6 +4136,13 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
 
     // issue 15146
     dirEntries("", SpanMode.shallow).walkLength();
+
+    // issue 6138
+    foreach (string entry; dirEntries(testdir, SpanMode.shallow) {
+        if (entry.isDir) {
+             chdir(entry);
+        }
+    }
 }
 
 /// Ditto


### PR DESCRIPTION
This is a reconstruction of #6125 which had its source branch deleted.