### PR TITLE
Fix #9584 - Using dirEntries and chdir() can still have unwanted results

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4804,17 +4804,17 @@ private struct DirIteratorImpl
         _mode = mode;
         _followSymlink = followSymlink;
 
-        string pathnameStr;
-        if (pathname.isAbsolute)
-            pathnameStr = pathname;
-        else
+        if (!pathname.isAbsolute)
         {
-            pathnameStr = pathname.absolutePath;
-            const offset = (pathnameStr.length - pathname.length);
-            _pathPrefix = pathnameStr[0 .. offset];
+            const pathnameRel = pathname;
+            alias pathnameAbs = pathname;
+            pathname = pathname.absolutePath;
+
+            const offset = pathnameAbs.length - pathnameRel.length;
+            _pathPrefix  = pathnameAbs[0 .. offset];
         }
 
-        if (stepIn(pathnameStr))
+        if (stepIn(pathname))
         {
             if (_mode == SpanMode.depth)
                 while (mayStepIn())

--- a/std/file.d
+++ b/std/file.d
@@ -4978,6 +4978,11 @@ alias DirIterator = _DirIterator!dip1000Enabled;
     Note: The order of returned directory entries is as it is provided by the
     operating system / filesystem, and may not follow any particular sorting.
 
+    Pitfall: In cases where a change of the working directory (`chdir`) can occur,
+    it's recommended that one either uses absolute paths
+    or avoids converting `DirEntry` structures to `string`.
+    For further details see $(LINK2 https://github.com/dlang/phobos/issues/9584, #9584 on GitHub).
+
     Params:
         Path = Type of the directory path.
                Can be either a `string` or a `DirEntry`.

--- a/std/file.d
+++ b/std/file.d
@@ -4797,34 +4797,20 @@ private struct DirIteratorImpl
         }
     }
 
-    this(R)(R pathname, SpanMode mode, bool followSymlink)
-    if (isSomeFiniteCharInputRange!R)
+    this(string pathname, SpanMode mode, bool followSymlink)
     {
+        import std.path : absolutePath, isAbsolute;
+
         _mode = mode;
         _followSymlink = followSymlink;
 
-        static if (isNarrowString!R && is(immutable ElementEncodingType!R == immutable char))
-        {
-            import std.path : absolutePath, isAbsolute;
-            string pathnameStr;
-            if (pathname.isAbsolute)
-                pathnameStr = pathname;
-            else
-            {
-                pathnameStr = pathname.absolutePath;
-                const offset = (pathnameStr.length - pathname.length);
-                _pathPrefix = pathnameStr[0 .. offset];
-            }
-        }
+        string pathnameStr;
+        if (pathname.isAbsolute)
+            pathnameStr = pathname;
         else
         {
-            import std.algorithm.searching : count;
-            import std.array : array;
-            import std.path : asAbsolutePath;
-            import std.utf : byChar;
-            string pathnameStr = pathname.asAbsolutePath.array;
-            const pathnameCount = pathname.byChar.count;
-            const offset = (pathnameStr.length - pathnameCount);
+            pathnameStr = pathname.absolutePath;
+            const offset = (pathnameStr.length - pathname.length);
             _pathPrefix = pathnameStr[0 .. offset];
         }
 

--- a/std/file.d
+++ b/std/file.d
@@ -3846,7 +3846,7 @@ else version (Windows)
 
         this(return scope string path, return scope string prefix)
         {
-            _prefix = prefix;
+            _namePrefix = prefix;
             this(path);
         }
 
@@ -3857,7 +3857,7 @@ else version (Windows)
             import std.datetime.systime : FILETIMEToSysTime;
             import std.path : buildPath;
 
-            _prefix = prefix;
+            _namePrefix = prefix;
 
             fd.cFileName[$ - 1] = 0;
 
@@ -3873,7 +3873,7 @@ else version (Windows)
         @property string name() const pure nothrow return scope
         {
             import std.string : chompPrefix;
-            return _name.chompPrefix(_prefix);
+            return _name.chompPrefix(_namePrefix);
         }
 
         @property string nameWithPrefix() const pure nothrow return scope
@@ -3931,7 +3931,7 @@ else version (Windows)
 
     private:
         string _name; /// The file or directory represented by this DirEntry.
-        string _prefix; /// A prefix to be chomped off the name (e.g. parent directories of an absolute path).
+        string _namePrefix; /// A prefix to be chomped off the name (e.g. parent directories of an absolute path).
 
         SysTime _timeCreated;      /// The time when the file was created.
         SysTime _timeLastAccessed; /// The time when the file was last accessed.
@@ -3965,7 +3965,7 @@ else version (Posix)
         {
             import std.path : buildPath;
 
-            _prefix = prefix;
+            _namePrefix = prefix;
 
             static if (is(typeof(fd.d_namlen)))
                 immutable len = fd.d_namlen;
@@ -4005,7 +4005,7 @@ else version (Posix)
         @property string name() const pure nothrow return scope
         {
             import std.string : chompPrefix;
-            return _name.chompPrefix(_prefix);
+            return _name.chompPrefix(_namePrefix);
         }
 
         @property string nameWithPrefix() const pure nothrow return scope
@@ -4143,7 +4143,7 @@ else version (Posix)
         }
 
         string _name; /// The file or directory represented by this DirEntry.
-        string _prefix; /// A prefix to be chomped off the name (e.g. parent directories of an absolute path).
+        string _namePrefix; /// A prefix to be chomped off the name (e.g. parent directories of an absolute path).
 
         stat_t _statBuf = void;   /// The result of stat().
         uint  _lstatMode;         /// The stat mode from lstat().

--- a/std/file.d
+++ b/std/file.d
@@ -5400,7 +5400,7 @@ if (is(Path == DirEntry))
 		if (entry.isDir)
 			foreach (DirEntry subEntry; entry.dirEntries(SpanMode.shallow))
 				if (subEntry.isDir)
-					chdir(subEntry.absolutePath); // ←
+					chdir(subEntry.absolutePath);
 	}
 
     chdir(root);
@@ -5410,7 +5410,7 @@ if (is(Path == DirEntry))
 		if (entry.isDir)
 			foreach (DirEntry subEntry; entry.dirEntries("*", SpanMode.shallow))
 				if (subEntry.isDir)
-					chdir(subEntry.absolutePath); // ←
+					chdir(subEntry.absolutePath);
 	}
 }
 

--- a/std/file.d
+++ b/std/file.d
@@ -3829,6 +3829,11 @@ else version (Windows)
     {
     @safe:
     public:
+        /+
+            Note for Phobos v3:
+            This has caused user confusion in cases where nested directory trees are interated.
+            See <https://github.com/dlang/phobos/issues/9584> for details.
+         +/
         alias name this;
 
         this(return scope string path)
@@ -3958,6 +3963,11 @@ else version (Posix)
     {
     @safe:
     public:
+        /+
+            Note for Phobos v3:
+            This has caused user confusion in cases where nested directory trees are interated.
+            See <https://github.com/dlang/phobos/issues/9584> for details.
+         +/
         alias name this;
 
         this(return scope string path)


### PR DESCRIPTION
Unlike #10666, this should fix #9584 properly.

TODO: Eventually, this should have an appropriate test, too.
The one that #10666 copied from #6125 didn't really cut it in the first place AFAICT.

Depends on #10666, #10667 and #10668 as-is.