### PR TITLE
Fix #10577 - [std.math] std.math.algebraic.cbrt is not pure

### DIFF
--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -256,7 +256,7 @@ real sqrt(real x) @nogc @safe pure nothrow { return core.math.sqrt(x); }
  *      $(TR $(TD $(PLUSMN)$(INFIN)) $(TD $(PLUSMN)$(INFIN)) $(TD no) )
  *      )
  */
-real cbrt(real x) @trusted nothrow @nogc
+real cbrt(real x) @trusted pure nothrow @nogc
 {
     version (CRuntime_Microsoft)
     {

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -273,7 +273,7 @@ real cbrt(real x) @trusted pure nothrow @nogc
 }
 
 ///
-@safe unittest
+@safe pure unittest
 {
     import std.math.operations : feqrel;
 


### PR DESCRIPTION
fixed  issue [std.math] std.math.algebraic.cbrt is not pure #10577
https://github.com/dlang/phobos/issues/10577

