### PR TITLE
Remove outdated @safe bug entry from toDelegate documentation in `std.functional.toDelegate` (Fixes #10637)

### DIFF
--- a/std/functional.d
+++ b/std/functional.d
@@ -1808,7 +1808,6 @@ private struct DelegateFaker(F)
  *
  * BUGS:
  * $(UL
- *   $(LI Does not work with `@safe` functions.)
  *   $(LI Ignores C-style / D-style variadic arguments.)
  * )
  */


### PR DESCRIPTION
Fixes #10637

## Changes
- Removed the outdated BUGS entry about `@safe` functions in the documentation of `std.functional.toDelegate`.
- Verified that PR #10599 resolved this issue, with test cases added.

## Validation Steps
1. **Test support for `@safe` functions**:
   ```d
   @safe int add(int a, int b) {
       return a + b;
   }
   assert(toDelegate(&add)(2, 3) == 5); // Test passes