### PR TITLE
Fix issue  std.conv.parse!(int, string) counts when doCount is false #9829

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2553,6 +2553,7 @@ Lerr:
             throw convError!(Source, Target)(source);
     }
 }
+
 ///
 @safe pure unittest
 {
@@ -2937,6 +2938,7 @@ do
         return v;
     }
 }
+
 @safe pure unittest
 {
     string s; // parse doesn't accept rvalues
@@ -3147,6 +3149,7 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
     {
         alias p = source;
     }
+
     void advanceSource()
     {
         static if (isNarrowString!Source)
@@ -3159,13 +3162,16 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
     static immutable real[13] postab =
         [ 1e+4096L,1e+2048L,1e+1024L,1e+512L,1e+256L,1e+128L,1e+64L,1e+32L,
                 1e+16L,1e+8L,1e+4L,1e+2L,1e+1L ];
+
     ConvException bailOut()(string msg = null, string fn = __FILE__, size_t ln = __LINE__)
     {
         if (msg == null)
             msg = "Floating point conversion error";
         return new ConvException(text(msg, " for input \"", source, "\"."), fn, ln);
     }
+
     enforce(!p.empty, bailOut());
+
     size_t count = 0;
     bool sign = false;
     switch (p.front)
@@ -4736,6 +4742,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         return cast (dchar) result;
     }
 }
+
 @safe pure unittest
 {
     string[] s1 = [

--- a/std/conv.d
+++ b/std/conv.d
@@ -2883,7 +2883,6 @@ do
 
     static if (doCount)
         size_t count = 0;
-
     auto found = false;
     do
     {
@@ -2910,10 +2909,8 @@ do
         auto nextv = v.mulu(radix, overflow).addu(c - '0', overflow);
         enforce!ConvOverflowException(!overflow && nextv <= Target.max, "Overflow in integral conversion");
         v = cast(Target) nextv;
-
         static if (doCount)
             ++count;
-
         s.popFront();
         found = true;
     } while (!s.empty);
@@ -4102,22 +4099,18 @@ if (isDynamicArray!Target && !is(Target == enum) &&
     isSomeString!Source && !is(Source == enum))
 {
     import std.array : appender;
-
+    
     auto result = appender!Target();
 
     parseCheck!s(lbracket);
-
     static if (doCount)
         size_t count = 1;
-
     static if (doCount)
         count += skipWS!(Source, Yes.doCount)(s);
     else
         skipWS!(Source, No.doCount)(s);
-
     if (s.empty)
         throw convError!(Source, Target)(s);
-
     if (s.front == rbracket)
     {
         s.popFront();
@@ -4131,12 +4124,10 @@ if (isDynamicArray!Target && !is(Target == enum) &&
             return result.data;
         }
     }
-
     for (;;)
     {
         if (!s.empty && s.front == rbracket)
             break;
-
         static if (doCount)
         {
             auto r = parseElement!(WideElementType!Target, Source, Yes.doCount)(s);
@@ -4150,26 +4141,19 @@ if (isDynamicArray!Target && !is(Target == enum) &&
             result ~= r;
             skipWS!(Source, No.doCount)(s);
         }
-
         if (s.empty)
             throw convError!(Source, Target)(s);
-
         if (s.front != comma)
             break;
-
         s.popFront();
-
         static if (doCount)
             ++count;
-
         static if (doCount)
             count += skipWS!(Source, Yes.doCount)(s);
         else
             skipWS!(Source, No.doCount)(s);
     }
-
     parseCheck!s(rbracket);
-
     static if (doCount)
     {
         ++count;
@@ -4330,18 +4314,14 @@ if (isStaticArray!Target && !is(Target == enum) &&
         Target result = void;
 
     parseCheck!s(lbracket);
-
     static if (doCount)
         size_t count = 1;
-
     static if (doCount)
         count += skipWS!(Source, Yes.doCount)(s);
     else
         skipWS!(Source, No.doCount)(s);
-
     if (s.empty)
         throw convError!(Source, Target)(s);
-
     if (s.front == rbracket)
     {
         static if (result.length != 0)
@@ -4360,12 +4340,10 @@ if (isStaticArray!Target && !is(Target == enum) &&
             }
         }
     }
-
     for (size_t i = 0; ; )
     {
         if (i == result.length)
             goto Lmanyerr;
-
         static if (doCount)
         {
             auto r = parseElement!(ElementType!Target, Source, Yes.doCount)(s);
@@ -4379,30 +4357,23 @@ if (isStaticArray!Target && !is(Target == enum) &&
             result[i++] = r;
             skipWS!(Source, No.doCount)(s);
         }
-
         if (s.empty)
             throw convError!(Source, Target)(s);
-
         if (s.front != comma)
         {
             if (i != result.length)
                 goto Lfewerr;
             break;
         }
-
         s.popFront();
-
         static if (doCount)
             ++count;
-
         static if (doCount)
             count += skipWS!(Source, Yes.doCount)(s);
         else
             skipWS!(Source, No.doCount)(s);
     }
-
     parseCheck!s(rbracket);
-
     static if (doCount)
     {
         ++count;
@@ -4475,15 +4446,12 @@ if (isAssociativeArray!Target && !is(Target == enum) &&
     static if (doCount) size_t count;
 
     parseCheck!s(lbracket);
-
     static if (doCount)
         count = 1 + skipWS!(Source, Yes.doCount)(s);
     else
         skipWS!(Source, No.doCount)(s);
-
     if (s.empty)
         throw convError!(Source, Target)(s);
-
     if (s.front == rbracket)
     {
         s.popFront();
@@ -4492,56 +4460,44 @@ if (isAssociativeArray!Target && !is(Target == enum) &&
         else
             return result;
     }
-
     for (;;)
     {
         static if (doCount)
         {
             auto key = parseElement!(KeyType, Source, Yes.doCount)(s);
             count += key.count + skipWS!(Source, Yes.doCount)(s);
-
             parseCheck!s(keyval);
             count += 1 + skipWS!(Source, Yes.doCount)(s);
             auto val = parseElement!(ValType, Source, Yes.doCount)(s);
             count += val.count + skipWS!(Source, Yes.doCount)(s);
-
             result[key.data] = val.data;
         }
         else
         {
             auto key = parseElement!(KeyType, Source, No.doCount)(s);
             skipWS!(Source, No.doCount)(s);
-
             parseCheck!s(keyval);
             skipWS!(Source, No.doCount)(s);
             auto val = parseElement!(ValType, Source, No.doCount)(s);
             skipWS!(Source, No.doCount)(s);
-
             result[key] = val;
         }
-
         if (s.empty)
             throw convError!(Source, Target)(s);
-
         if (s.front != comma)
             break;
-
         s.popFront();
-
         static if (doCount)
             count += 1 + skipWS!(Source, Yes.doCount)(s);
         else
             skipWS!(Source, No.doCount)(s);
     }
-
     parseCheck!s(rbracket);
-
     static if (doCount)
         return tuple!("data", "count")(result, count + 1);
     else
         return result;
 }
-
 
 ///
 @safe pure unittest
@@ -4600,7 +4556,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
     size_t count;
     static if (doCount)
         count = 1;
-
     if (s.empty)
         throw parseError("Unterminated escape sequence");
 
@@ -4618,7 +4573,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
             throw parseError("Hex digit is missing");
         return isAlpha(c) ? ((c & ~0x20) - ('A' - 10)) : c - '0';
     }
-
     // We need to do octals separate, because they need a lookahead to find out,
     // where the escape sequence ends.
     auto first = s.front;
@@ -4628,7 +4582,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-
         if (s.empty)
         {
             static if (doCount)
@@ -4655,7 +4608,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-
         dchar c3 = s.front;
         if (c3 < '0' || c3 > '7')
         {
@@ -4671,7 +4623,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-
         if (c1 > '3')
             throw parseError("Octal sequence is larger than \\377");
         static if (doCount)
@@ -4763,7 +4714,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         // https://issues.dlang.org/show_bug.cgi?id=9621 (Named Character Entities)
         //'\&amp;', '\&quot;',
     ];
-
     foreach (i ; 0 .. s1.length)
     {
         assert(s2[i] == parseEscape(s1[i]));
@@ -4819,7 +4769,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     size_t count;
     static if (doCount)
         count = 1;
-
     if (s.empty)
         throw convError!(Source, Target)(s);
     if (s.front == '\"')
@@ -4835,7 +4784,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
             return result.data;
         }
     }
-
     while (true)
     {
         if (s.empty)
@@ -4885,7 +4833,6 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     Unqual!Target c;
 
     parseCheck!s('\'');
-
     size_t count;
     static if (doCount)
         count = 1;
@@ -4905,9 +4852,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         else
             c = parseEscape!(typeof(s), No.doCount)(s);
     }
-
     parseCheck!s('\'');
-
     static if (doCount)
     {
         count++;

--- a/std/conv.d
+++ b/std/conv.d
@@ -2849,7 +2849,7 @@ Lerr:
 
 /// ditto
 auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref Source source, uint radix)
-if (isIntegral!Target && !is(Target == enum) && 
+if (isIntegral!Target && !is(Target == enum) &&
     isSomeChar!(ElementType!Source))
 in
 {
@@ -2859,17 +2859,17 @@ do
 {
     import core.checkedint : mulu, addu;
     import std.exception : enforce;
-    
+
     if (radix == 10)
     {
         return parse!(Target, Source, doCount)(source);
     }
-    
+
     enforce!ConvException(!source.empty, "s must not be empty in integral parse");
-    
+
     immutable uint beyond = (radix < 10 ? '0' : 'a'-10) + radix;
     Target v = 0;
-    
+
     static if (isNarrowString!Source)
     {
         import std.string : representation;
@@ -2879,10 +2879,10 @@ do
     {
         alias s = source;
     }
-    
+
     static if (doCount)
         size_t count = 0;
-    
+
     auto found = false;
     do
     {
@@ -2904,19 +2904,19 @@ do
                 c -= 'a'-10-'0';
             }
         }
-        
+
         bool overflow = false;
         auto nextv = v.mulu(radix, overflow).addu(c - '0', overflow);
         enforce!ConvOverflowException(!overflow && nextv <= Target.max, "Overflow in integral conversion");
         v = cast(Target) nextv;
-        
+
         static if (doCount)
             ++count;
-            
+
         s.popFront();
         found = true;
     } while (!s.empty);
-    
+
     if (!found)
     {
         static if (isNarrowString!Source)
@@ -2924,10 +2924,10 @@ do
         else
             throw convError!(Source, Target)(source);
     }
-    
+
     static if (isNarrowString!Source)
         source = source[$ - s.length .. $];
-    
+
     static if (doCount)
     {
         return tuple!("data", "count")(v, count);
@@ -4104,22 +4104,22 @@ if (isDynamicArray!Target && !is(Target == enum) &&
     isSomeString!Source && !is(Source == enum))
 {
     import std.array : appender;
-    
+
     auto result = appender!Target();
-    
+
     parseCheck!s(lbracket);
-    
+
     static if (doCount)
         size_t count = 1;
-    
+
     static if (doCount)
         count += skipWS!(Source, Yes.doCount)(s);
     else
         skipWS!(Source, No.doCount)(s);
-        
+
     if (s.empty)
         throw convError!(Source, Target)(s);
-        
+
     if (s.front == rbracket)
     {
         s.popFront();
@@ -4133,12 +4133,12 @@ if (isDynamicArray!Target && !is(Target == enum) &&
             return result.data;
         }
     }
-    
+
     for (;;)
     {
         if (!s.empty && s.front == rbracket)
             break;
-            
+
         static if (doCount)
         {
             auto r = parseElement!(WideElementType!Target, Source, Yes.doCount)(s);
@@ -4152,26 +4152,26 @@ if (isDynamicArray!Target && !is(Target == enum) &&
             result ~= r;
             skipWS!(Source, No.doCount)(s);
         }
-        
+
         if (s.empty)
             throw convError!(Source, Target)(s);
-            
+
         if (s.front != comma)
             break;
-            
+
         s.popFront();
-        
+
         static if (doCount)
             ++count;
-            
+
         static if (doCount)
             count += skipWS!(Source, Yes.doCount)(s);
         else
             skipWS!(Source, No.doCount)(s);
     }
-    
+
     parseCheck!s(rbracket);
-    
+
     static if (doCount)
     {
         ++count;
@@ -4330,20 +4330,20 @@ if (isStaticArray!Target && !is(Target == enum) &&
         Target result = Target.init[0].init;
     else
         Target result = void;
-    
+
     parseCheck!s(lbracket);
-    
+
     static if (doCount)
         size_t count = 1;
-    
+
     static if (doCount)
         count += skipWS!(Source, Yes.doCount)(s);
     else
         skipWS!(Source, No.doCount)(s);
-        
+
     if (s.empty)
         throw convError!(Source, Target)(s);
-        
+
     if (s.front == rbracket)
     {
         static if (result.length != 0)
@@ -4362,12 +4362,12 @@ if (isStaticArray!Target && !is(Target == enum) &&
             }
         }
     }
-    
+
     for (size_t i = 0; ; )
     {
         if (i == result.length)
             goto Lmanyerr;
-            
+
         static if (doCount)
         {
             auto r = parseElement!(ElementType!Target, Source, Yes.doCount)(s);
@@ -4381,30 +4381,30 @@ if (isStaticArray!Target && !is(Target == enum) &&
             result[i++] = r;
             skipWS!(Source, No.doCount)(s);
         }
-        
+
         if (s.empty)
             throw convError!(Source, Target)(s);
-            
+
         if (s.front != comma)
         {
             if (i != result.length)
                 goto Lfewerr;
             break;
         }
-        
+
         s.popFront();
-        
+
         static if (doCount)
             ++count;
-            
+
         static if (doCount)
             count += skipWS!(Source, Yes.doCount)(s);
         else
             skipWS!(Source, No.doCount)(s);
     }
-    
+
     parseCheck!s(rbracket);
-    
+
     static if (doCount)
     {
         ++count;
@@ -4414,7 +4414,7 @@ if (isStaticArray!Target && !is(Target == enum) &&
     {
         return result;
     }
-    
+
 Lmanyerr:
     throw new ConvException("Too many elements in input for static array");
 Lfewerr:
@@ -4466,9 +4466,9 @@ Lfewerr:
  *     if `doCount` is set to `Yes.doCount`))
  */
 auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(
-    ref Source s, dchar lbracket = '[', dchar rbracket = ']', 
+    ref Source s, dchar lbracket = '[', dchar rbracket = ']',
     dchar keyval = ':', dchar comma = ',')
-if (isAssociativeArray!Target && !is(Target == enum) && 
+if (isAssociativeArray!Target && !is(Target == enum) &&
     isSomeString!Source && !is(Source == enum))
 {
     alias KeyType = typeof(Target.init.keys[0]);
@@ -4478,7 +4478,7 @@ if (isAssociativeArray!Target && !is(Target == enum) &&
     static if (doCount) size_t count;
 
     parseCheck!s(lbracket);
-    
+
     static if (doCount)
         count = 1 + skipWS!(Source, Yes.doCount)(s);
     else
@@ -4603,7 +4603,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
     size_t count;
     static if (doCount)
         count = 1;
-        
+
     if (s.empty)
         throw parseError("Unterminated escape sequence");
 
@@ -4631,7 +4631,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-            
+
         if (s.empty)
         {
             static if (doCount)
@@ -4658,7 +4658,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-            
+
         dchar c3 = s.front;
         if (c3 < '0' || c3 > '7')
         {
@@ -4674,7 +4674,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
         s.popFront();
         static if (doCount)
             ++count;
-            
+
         if (c1 > '3')
             throw parseError("Octal sequence is larger than \\377");
         static if (doCount)
@@ -4803,12 +4803,12 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source))
 
 // Undocumented
 auto parseElement(Target, Source, Flag!"doCount" doCount = No.doCount)(ref Source s)
-if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) && 
+if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum) &&
     isExactSomeString!Target)
 {
     import std.array : appender;
     auto result = appender!Target();
-    
+
     // parse array of chars
     if (s.empty)
         throw convError!(Source, Target)(s);
@@ -4816,12 +4816,12 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     {
         return parse!(Target, Source, doCount)(s);
     }
-    
+
     parseCheck!s('\"');
     size_t count;
     static if (doCount)
         count = 1;
-        
+
     if (s.empty)
         throw convError!(Source, Target)(s);
     if (s.front == '\"')
@@ -4837,7 +4837,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
             return result.data;
         }
     }
-    
+
     while (true)
     {
         if (s.empty)
@@ -4885,19 +4885,19 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
     is(CharTypeOf!Target == dchar) && !is(Target == enum))
 {
     Unqual!Target c;
-    
+
     parseCheck!s('\'');
-    
+
     size_t count;
     static if (doCount)
         count = 1; // Only initialize count when needed
-    
+
     if (s.empty)
         throw convError!(Source, Target)(s);
-    
+
     static if (doCount)
         count++; // Only increment when doCount is true
-    
+
     if (s.front != '\\')
     {
         c = s.front;
@@ -4910,9 +4910,9 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         else
             c = parseEscape!(typeof(s), No.doCount)(s);
     }
-    
+
     parseCheck!s('\'');
-    
+
     static if (doCount)
     {
         count++; // Only increment when doCount is true

--- a/std/conv.d
+++ b/std/conv.d
@@ -4099,7 +4099,7 @@ if (isDynamicArray!Target && !is(Target == enum) &&
     isSomeString!Source && !is(Source == enum))
 {
     import std.array : appender;
-    
+
     auto result = appender!Target();
 
     parseCheck!s(lbracket);

--- a/std/conv.d
+++ b/std/conv.d
@@ -3147,7 +3147,6 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
     {
         alias p = source;
     }
-
     void advanceSource()
     {
         static if (isNarrowString!Source)
@@ -3167,7 +3166,7 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
         return new ConvException(text(msg, " for input \"", source, "\"."), fn, ln);
     }
     enforce(!p.empty, bailOut());
-    size_t count = 0; 
+    size_t count = 0;
     bool sign = false;
     switch (p.front)
     {
@@ -4885,9 +4884,8 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
         count = 1;
     if (s.empty)
         throw convError!(Source, Target)(s);
-
     static if (doCount)
-        count++; 
+        count++;
     if (s.front != '\\')
     {
         c = s.front;

--- a/std/conv.d
+++ b/std/conv.d
@@ -3167,14 +3167,8 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
             msg = "Floating point conversion error";
         return new ConvException(text(msg, " for input \"", source, "\"."), fn, ln);
     }
-
     enforce(!p.empty, bailOut());
-
-    static if (doCount)
-        size_t count = 0;
-    else
-        size_t count = 0; // Still needed for algorithm logic but will be optimized out
-
+    size_t count = 0; 
     bool sign = false;
     switch (p.front)
     {
@@ -4416,9 +4410,9 @@ if (isStaticArray!Target && !is(Target == enum) &&
     }
 
 Lmanyerr:
-    throw new ConvException("Too many elements in input for static array");
+    throw parseError(text("Too many elements in input, ", result.length, " elements expected."));
 Lfewerr:
-    throw new ConvException("Too few elements in input for static array");
+    throw parseError(text("Too few elements in input, ", result.length, " elements expected."));
 }
 
 @safe pure unittest
@@ -4465,9 +4459,8 @@ Lfewerr:
  *     $(LI A `tuple` containing an associative array of type `Target` and a `size_t`
  *     if `doCount` is set to `Yes.doCount`))
  */
-auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(
-    ref Source s, dchar lbracket = '[', dchar rbracket = ']',
-    dchar keyval = ':', dchar comma = ',')
+auto parse(Target, Source, Flag!"doCount" doCount = No.doCount)(ref Source s, dchar lbracket = '[',
+                             dchar rbracket = ']', dchar keyval = ':', dchar comma = ',')
 if (isAssociativeArray!Target && !is(Target == enum) &&
     isSomeString!Source && !is(Source == enum))
 {
@@ -4890,13 +4883,13 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 
     size_t count;
     static if (doCount)
-        count = 1; // Only initialize count when needed
+        count = 1; 
 
     if (s.empty)
         throw convError!(Source, Target)(s);
 
     static if (doCount)
-        count++; // Only increment when doCount is true
+        count++; 
 
     if (s.front != '\\')
     {
@@ -4915,7 +4908,7 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 
     static if (doCount)
     {
-        count++; // Only increment when doCount is true
+        count++;
         return tuple!("data", "count")(c, count);
     }
     else

--- a/std/conv.d
+++ b/std/conv.d
@@ -3160,7 +3160,6 @@ if (isFloatingPoint!Target && !is(Target == enum) &&
     static immutable real[13] postab =
         [ 1e+4096L,1e+2048L,1e+1024L,1e+512L,1e+256L,1e+128L,1e+64L,1e+32L,
                 1e+16L,1e+8L,1e+4L,1e+2L,1e+1L ];
-
     ConvException bailOut()(string msg = null, string fn = __FILE__, size_t ln = __LINE__)
     {
         if (msg == null)
@@ -4883,14 +4882,12 @@ if (isInputRange!Source && isSomeChar!(ElementType!Source) && !is(Source == enum
 
     size_t count;
     static if (doCount)
-        count = 1; 
-
+        count = 1;
     if (s.empty)
         throw convError!(Source, Target)(s);
 
     static if (doCount)
         count++; 
-
     if (s.front != '\\')
     {
         c = s.front;


### PR DESCRIPTION
Optimize std.conv.parse by eliminating unnecessary count increments