### PR TITLE
Fix issue #9874 - Cannot insert const/immutable elements into DList

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1468,20 +1468,16 @@ private void moveEmplaceImpl(T)(ref scope T target, ref return scope T source)
         // object in order to avoid double freeing and undue aliasing
         static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
         {
-            // Skip zeroing out for const/immutable source
-            static if (!is(T == const) && !is(T == immutable))
-            {
-                // If T is nested struct, keep original context pointer
-                static if (__traits(isNested, T))
-                    enum sz = T.sizeof - (void*).sizeof;
-                else
-                    enum sz = T.sizeof;
+            // If T is nested struct, keep original context pointer
+            static if (__traits(isNested, T))
+                enum sz = T.sizeof - (void*).sizeof;
+            else
+                enum sz = T.sizeof;
 
-                static if (__traits(isZeroInit, T))
-                    () @trusted { memset(&source, 0, sz); }();
-                else
-                    () @trusted { memcpy(&source, __traits(initSymbol, T).ptr, sz); }();
-            }
+            static if (__traits(isZeroInit, T))
+                () @trusted { memset(&source, 0, sz); }();
+            else
+                () @trusted { memcpy(&source, __traits(initSymbol, T).ptr, sz); }();
         }
     }
     else static if (isStaticArray!T)
@@ -1496,6 +1492,7 @@ private void moveEmplaceImpl(T)(ref scope T target, ref return scope T source)
         target = source;
     }
 }
+
 /**
  * Similar to $(LREF move) but assumes `target` is uninitialized. This
  * is more efficient because `source` can be blitted over `target`

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -1172,3 +1172,23 @@ private:
     B.insert(a);
     assert(B[].equal([A(1), A(3)]));
 }
+
+@safe unittest
+{
+    import std.algorithm.comparison : equal;
+    import std.container : DList;
+
+    DList!int D;
+    D.insert(1);
+    assert(D[].equal([1]));
+
+    int i = 2;
+    D.insert(i);
+    assert(D[].equal([1, 2]));
+
+    const c = 3;
+    static assert(__traits(compiles, { D.insert(c); }));
+    static assert(__traits(compiles, { D.insert(c + 1); }));
+
+    static assert(__traits(compiles, { D.insert(c + c); }));
+}

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -1189,6 +1189,5 @@ private:
     const c = 3;
     static assert(__traits(compiles, { D.insert(c); }));
     static assert(__traits(compiles, { D.insert(c + 1); }));
-
     static assert(__traits(compiles, { D.insert(c + c); }));
 }


### PR DESCRIPTION
Fixed issue #9874 made DList.insert correctly handles const values by adjusting how moveEmplaceImpl interacts with const data 