### PR TITLE
Unify abs(Complex!T) and hypot

### DIFF
--- a/std/complex.d
+++ b/std/complex.d
@@ -767,24 +767,8 @@ if (is(T R == Complex!R))
  */
 T abs(T)(Complex!T z) @safe pure nothrow @nogc
 {
-    import std.math.algebraic : sqrt;
-    import std.math.traits : isInfinity, isNaN;
-    import std.math : fabs;
-    import std.algorithm.comparison : max;
-
-    if (isNaN(z.re) || isNaN(z.im))
-        return T.nan;
-    if (isInfinity(z.re) || isInfinity(z.im))
-        return T.infinity;
-
-    const T maxabs = max(fabs(z.re), fabs(z.im));
-    if (maxabs == 0.0)
-        return maxabs;
-
-    const T qx = z.re / maxabs;
-    const T qy = z.im / maxabs;
-
-    return maxabs * sqrt(qx * qx + qy * qy);
+    import std.math.algebraic : hypot;
+    return hypot(z.re, z.im);
 }
 
 ///

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -380,7 +380,7 @@ if (isFloatingPoint!T)
     }
 
     // both are in the normal range
-    return ratio * sqrt(u^^2 + v^^2);
+    return ratio * sqrt(u*u + v*v);
 }
 
 ///

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -420,6 +420,15 @@ if (isFloatingPoint!T)
     assert(hypot(double.infinity, double.nan) == double.infinity);
 }
 
+// https://github.com/dlang/phobos/issues/10491
+@safe pure nothrow unittest
+{
+    import std.math : isClose;
+
+    enum small = 5.016556e-20f;
+    assert(hypot(small, 0).isClose(small));
+}
+
 @safe unittest
 {
     import std.math.operations : feqrel;

--- a/std/math/algebraic.d
+++ b/std/math/algebraic.d
@@ -322,10 +322,10 @@ if (isFloatingPoint!T)
         u = fabs(y);
         if (u == T.infinity) return u; // hypot(inf, nan) == inf
         if (v == T.infinity) return v; // hypot(nan, inf) == inf
+        if (u.isNaN || v.isNaN)
+            return T.nan;
     }
-
-    if (u.isNaN || v.isNaN)
-        return T.nan;
+    assert(!(u.isNaN || v.isNaN), "Comparison to NaN always fails, thus is is always handled in the branch above");
 
     const maxabs = max(u,v);
     if (v == 0.0)


### PR DESCRIPTION
This ports the fixes from abs(T)(ComplexT) regarding NaN and skipping
potentially inaccuracy inducing mathematical no-ops when one arg is 0 to
hypot. Both functions do the same thing and should be deduplicated.
hypot also has some logic regarding under and overflows, and while I
don't fully understand it, it should probably not be removed for complex
numbers.

followup to #10679