### PR TITLE
Fix #10513 - powmod is slow for ulong

### DIFF
--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -881,7 +881,8 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             }
             else version (X86_64)
             {
-                uint low, high;
+                T low = void;
+                T high = void;
 
                 asm pure @trusted nothrow @nogc
                 {

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -839,9 +839,9 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             {
             import core.int128 : Cent, mul, udivmod;
             const product128 = mul(a, b);
-            Cent remainder = void;
-            udivmod(product128, Cent(c), remainder);
-            return cast(T)(remainder.lo);
+            Cent remainder;
+            udivmod(product128, Cent(lo: c), remainder);
+            return cast(T) remainder.lo;
             }
         }
         else static if (T.sizeof == 4)

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -881,7 +881,6 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             }
             else version (X86_64)
             {
-                T low = a;  // Input a goes in low (RAX)
                 T high = void;
 
                 asm pure @trusted nothrow @nogc

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -831,7 +831,7 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
         alias DoubleT = AliasSeq!(void, ushort, uint, void, ulong)[T.sizeof];
     }
 
-    static T mulmod(T)(T a,T b,T c)
+    static T mulmod(T a, T b, T c)
     {
         static if (T.sizeof == 8)
         {

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -837,13 +837,13 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
         {
             if (c <= 0x100000000)
             {
-                T result=a*b;
-                return result%c;
+                T result = a*b;
+                return result % c;
             }
             version (D_InlineAsm_X86_64)
             {
-                ulong low=void;
-                ulong high=void;
+                ulong low = void;
+                ulong high = void;
 
                 // Perform 128-bit multiplication: a * b = [high:low]
                 asm pure @trusted nothrow @nogc
@@ -856,12 +856,12 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
 
                 if (high >= c)
                 {
-                    high%=c;
+                    high %= c;
                 }
 
                 if (high == 0)
                 {
-                    return low%c;
+                    return low % c;
                 }
 
                 asm pure @trusted nothrow @nogc

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -881,7 +881,7 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             }
             else version (X86_64)
             {
-                T low = void;
+                T low = a;  // Input a goes in low (RAX)
                 T high = void;
 
                 asm pure @trusted nothrow @nogc
@@ -890,16 +890,6 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
                     : "=a"(low), "=d"(high)                 // Store result: low part in RAX, high part in RDX
                     : [fac] "r"(b), [mulip] "0"(a)      // Input: 'a' in RAX, 'b' as multiplier mulip == multiplicand
                     : "cc";                                 // Flags are clobbered
-                }
-
-                if (high >= c)
-                {
-                    high %= c;
-                }
-
-                if (high == 0)
-                {
-                    return low % c;
                 }
 
                 asm pure @trusted nothrow @nogc

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -58,11 +58,6 @@ version (D_HardFloat)
     // FloatingPointControl.clearExceptions() depends on version IeeeFlagsSupport
     version (IeeeFlagsSupport) version = FloatingPointControlSupport;
 }
-version (X86_64)
-{
-    version (GNU) version = GNU_OR_LDC_X86_64;
-    version (LDC) version = GNU_OR_LDC_X86_64;
-}
 
 /**
  * Compute the value of x $(SUPERSCRIPT n), where n is an integer

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -854,16 +854,6 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
                     mov high,RDX;   // Store high 64 bits
                 }
 
-                if (high >= c)
-                {
-                    high %= c;
-                }
-
-                if (high == 0)
-                {
-                    return low % c;
-                }
-
                 asm pure @trusted nothrow @nogc
                 {
                     mov RAX,high;   // Load high part

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -832,7 +832,7 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
         {
             if (c <= 0x100000000)
             {
-                T result = a*b;
+                T result = a * b;
                 return result % c;
             }
             else

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -838,10 +838,12 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             else
             {
             import core.int128 : Cent, mul, udivmod;
-            const product128 = mul(a, b);
-            Cent remainder;
-            udivmod(product128, Cent(lo: c), remainder);
-            return cast(T) remainder.lo;
+            auto product = mul(a, b);
+            if (product.hi >= c)
+            product.hi %= c;
+            T remainder = void;
+            udivmod(product, c, remainder);
+            return remainder;
             }
         }
         else static if (T.sizeof == 4)

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -885,9 +885,9 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
 
                 asm pure @trusted nothrow @nogc
                 {
-                    "mulq %[factor]"                        // Multiply RAX by 'factor'
+                    "mulq %[fac]"                        // Multiply RAX by 'fac==factor'
                     : "=a"(low), "=d"(high)                 // Store result: low part in RAX, high part in RDX
-                    : [factor] "r"(b), [multiplicand] "0"(a)// Input: 'a' in RAX, 'b' as multiplier
+                    : [fac] "r"(b), [mulip] "0"(a)      // Input: 'a' in RAX, 'b' as multiplier mulip==multiplicand
                     : "cc";                                 // Flags are clobbered
                 }
 

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -860,7 +860,7 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
         else
         {
             DoubleT result = cast(DoubleT) (cast(DoubleT) a * cast(DoubleT) b);
-            return result%c;
+            return result % c;
         }
     }
 

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -837,13 +837,16 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             }
             else
             {
-            import core.int128 : Cent, mul, udivmod;
-            auto product = mul(a, b);
-            if (product.hi >= c)
-            product.hi %= c;
-            T remainder = void;
-            udivmod(product, c, remainder);
-            return remainder;
+                import core.int128 : Cent, mul, udivmod;
+
+                auto product = mul(a, b);
+
+                if (product.hi >= c)
+                product.hi %= c;
+
+                T remainder = void;
+                udivmod(product, c, remainder);
+                return remainder;
             }
         }
         else static if (T.sizeof == 4)

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -885,9 +885,9 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
 
                 asm pure @trusted nothrow @nogc
                 {
-                    "mulq %[fac]"                        // Multiply RAX by 'fac==factor'
+                    "mulq %[fac]"                        // Multiply RAX by 'fac == factor'
                     : "=a"(low), "=d"(high)                 // Store result: low part in RAX, high part in RDX
-                    : [fac] "r"(b), [mulip] "0"(a)      // Input: 'a' in RAX, 'b' as multiplier mulip==multiplicand
+                    : [fac] "r"(b), [mulip] "0"(a)      // Input: 'a' in RAX, 'b' as multiplier mulip == multiplicand
                     : "cc";                                 // Flags are clobbered
                 }
 

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -838,10 +838,10 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             else
             {
             import core.int128 : Cent, mul, udivmod;
-            const product128 = mul(Cent(a), Cent(b));
-            Cent centRemainder;
-            udivmod(product128, Cent(c), centRemainder);
-            return cast(T)(centRemainder.lo);
+            const product128 = mul(a, b);
+            T remainder = void;
+            udivmod(product128, c, remainder);
+            return remainder;
             }
         }
         else static if (T.sizeof == 4)

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -839,9 +839,9 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
             {
             import core.int128 : Cent, mul, udivmod;
             const product128 = mul(a, b);
-            T remainder = void;
-            udivmod(product128, c, remainder);
-            return remainder;
+            Cent remainder = void;
+            udivmod(product128, Cent(c), remainder);
+            return cast(T)(remainder.lo);
             }
         }
         else static if (T.sizeof == 4)

--- a/std/math/exponential.d
+++ b/std/math/exponential.d
@@ -842,7 +842,9 @@ if (isUnsigned!F && isUnsigned!G && isUnsigned!H)
                 auto product = mul(a, b);
 
                 if (product.hi >= c)
-                product.hi %= c;
+                {
+                    product.hi %= c;
+                }
 
                 T remainder = void;
                 udivmod(product, c, remainder);


### PR DESCRIPTION
The key optimizations I've made are:

128-bit multiplication via inline assembly:

For 64-bit types on x86_64 platforms, I've added direct use of hardware multiplication that produces a 128-bit result (stored in high:low registers)
This avoids the repeated addition loop in the original algorithm


Efficient modular reduction:

Implemented a reduction algorithm that handles the 128-bit result efficiently
Uses a simplified approach for when the high bits are zero


Early reduction:

The base value is reduced modulo m at the beginning, which improves performance when the base is large and modulus is small


Special case handling:

Added explicit handling for modulus=1 and exponent=0 cases up front


Version checks:

The code falls back to the original algorithm if inline assembly is not available
This ensures portability while providing optimizations where possible