### PR TITLE
Fix #9585 Add check `variant` alignment

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -3262,7 +3262,9 @@ if (isAlgebraic!VariantType && Handler.length > 0)
 {
     static struct Foo { double x; }
     alias AFoo1 = Algebraic!(Foo);
-    static assert(AFoo1.alignof == 8);
-    // This should also hold for 32 bit versions
-    static assert(AFoo1.sizeof == 16);
+    static assert(AFoo1.alignof >= double.alignof);
+
+    // Algebraic using a function pointer is an implementation detail. If test fails, this is safe to change
+    enum FP_SIZE = (int function()).sizeof;
+    static assert(AFoo1.sizeof >= double.sizeof + FP_SIZE);
 }

--- a/std/variant.d
+++ b/std/variant.d
@@ -3255,3 +3255,14 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     immutable aa = ["0": 0];
     auto v = Variant(aa); // compile error
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=8195
+// Verify that alignment is respected
+@safe unittest
+{
+    static struct Foo { double x; }
+    alias AFoo1 = Algebraic!(Foo);
+    static assert(AFoo1.alignof == 8);
+    // This should also hold for 32 bit versions
+    static assert(AFoo1.sizeof == 16);
+}


### PR DESCRIPTION
There has been code that handles alignment for a long time now, and while this module is unlikely to be touched anymore, create a regression test so the issue can be closed.