### PR TITLE
std.process.browse should use internal functions for executing subprocess #10564

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -4539,9 +4539,8 @@ else version (Posix)
 
     void browse(scope const(char)[] url) @safe
     {
-    import std.process : environment, spawnProcess, Config;
     version (OSX)
-    enum defaultBrowser = "open";
+        enum defaultBrowser = "open";
     else
         enum defaultBrowser = "xdg-open";
     string browserName = environment.get("BROWSER", defaultBrowser);


### PR DESCRIPTION
- Uses spawnProcess/spawnShell with Config.detached for proper process handling
- Maintains cross-platform compatibility (Windows and Posix)
- Preserves the original behavior of launching browsers
- Keeps the same function signature and attributes for backward compatibility