### PR TITLE
Variant segfault

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -850,7 +850,14 @@ public:
      */
     @property inout(T) get(T)() inout
     {
-        inout(T) result = void;
+        static union SupressDestructor {
+            T val;
+        }
+
+        /* If this function fails and it throws, copy elision will not run and the destructor might be called.
+         * But since this value is void initialized, this is undesireable.
+         */
+        inout(SupressDestructor) result = void;
         static if (is(T == shared))
             alias R = shared Unqual!T;
         else
@@ -861,7 +868,7 @@ public:
         {
             throw new VariantException(type, typeid(T));
         }
-        return result;
+        return result.val;
     }
 
     /// Ditto
@@ -3267,4 +3274,32 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     // Algebraic using a function pointer is an implementation detail. If test fails, this is safe to change
     enum FP_SIZE = (int function()).sizeof;
     static assert(AFoo1.sizeof >= double.sizeof + FP_SIZE);
+}
+
+// https://github.com/dlang/phobos/issues/10518
+@system unittest
+{
+    import std.exception : assertThrown;
+
+    struct Huge {
+        real a, b, c, d, e, f, g;
+    }
+    Huge h = {1,1,1,1,1,1,1};
+    Variant variant = Variant([
+            "one": Variant(1),
+    ]);
+    // Testing that this doesn't segfault. Future work might make enable this
+    assertThrown!VariantException(variant["three"] = 3);
+    assertThrown!VariantException(variant["four"] = Variant(4));
+    /* Storing huge works too, value will moved to the heap
+    * Testing this as a regression test here as the AA handling code is still somewhat brittle and might add changes
+    * that depend payload size in the future
+    */
+    assertThrown!VariantException(variant["huge"] = Variant(h));
+    /+
+    assert(variant["one"] == Variant(1));
+    assert(variant["three"] == Variant(3));
+    assert(variant["three"] == 3);
+    assert(variant["huge"] == Variant(h));
+    +/
 }

--- a/std/variant.d
+++ b/std/variant.d
@@ -3256,7 +3256,7 @@ if (isAlgebraic!VariantType && Handler.length > 0)
     auto v = Variant(aa); // compile error
 }
 
-// https://issues.dlang.org/show_bug.cgi?id=8195
+// https://github.com/dlang/phobos/issues/9585
 // Verify that alignment is respected
 @safe unittest
 {


### PR DESCRIPTION
Adresses part of #10518, now adding to Variant(Variant[string]) doesn't segfault anymore, but at least throws.

The issue was calling the destructor of unitinialized memory.

How to fix the exception is harder. I think there are 3 places where this could handled, either in `get(T)`, `tryPutting` inside the handler, or `case OpID.indexAssign:` . Of these, `tryPutting` probably is the most "correct", but also seems the hardest to understand to me and will have the biggest fallout in unrelated places if you get it wrong.

Whatever place is eventually chosen, you can't just memcopy the storage, as big types are often implicitly allocated on the heap and stored as a pointer.