### PR TITLE
Fix #10701 - Broken link in documentation of randomUUID

### DIFF
--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1205,10 +1205,7 @@ public struct UUID
  * This function is not supported at compile time.
  *
  * Bugs:
- * $(LINK2
- *     https://github.com/dlang/phobos/issues/9881
- *     Issue #9881 - Randomness in UUID generation is insufficient
- * )
+ * $(LINK2 https://github.com/dlang/phobos/issues/9881, Issue #9881 - Randomness in UUID generation is insufficient)
  *
  * Warning:
  * $(B This function must not be used for cryptographic purposes.)


### PR DESCRIPTION
Arguments to DDoc macros must be separated by a comma and at most one space, not spread over multiple lines.

CC @0xEAB 