### PR TITLE
Remove empty line between doc comment and unittest

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2369,7 +2369,6 @@ if (isConvertibleToString!R)
 }
 
 ///
-
 @safe unittest
 {
     import std.exception : assertThrown;


### PR DESCRIPTION
AFAICT there’s no indication that the new line would have been there on purpose.

- <https://github.com/dlang/phobos/commit/0b153a28844187f815375eae54880cb2dbc39704#diff-4710c350a9e857256a051a404aa4aade17b784a0ae5460bddc10bd248d5b1debR2257-R2259>
- <https://github.com/dlang/phobos/pull/6320>