### PR TITLE
Tune FreeBSD timeouts on GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,13 +126,14 @@ jobs:
             freebsd_version: '13.2'
     name: ${{ matrix.job_name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20  # Should complete in 11 minutes
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Run in VM
         uses: cross-platform-actions/action@v0.23.0
+        timeout-minutes: 19
         with:
           operating_system: freebsd
           hypervisor: qemu


### PR DESCRIPTION
Currently, our FreeBSD CI tests…
- either complete within about 11 minutes
- or timeout after 60 mins – ~49 of them spent idling erroneously.

I think it wouldn’t hurt to tune this a bit.

---

The old timeouts seemingly date back to the Cirrus CI to GHA migration and haven’t been adapted since:
<https://github.com/dlang/phobos/blame/91af96cddbc6ff23e0453ec31165d7fa85b9100e/.github/workflows/main.yml#L129>

---

The new values are calculated as follows:
$Value\ from\ DMD + 5\ extra\ minutes$

- <https://github.com/dlang/dmd/blob/2036516c1758815739c069a19b0832ef6a0d26e7/.github/workflows/main.yml#L194>
- <https://github.com/dlang/dmd/blob/2036516c1758815739c069a19b0832ef6a0d26e7/.github/workflows/main.yml#L201>

The extra headroom could be remove later on, if practice shows we can tighten thresholds further.