### PR TITLE
std.allocator: Comment out broken class instance size test

### DIFF
--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -63,7 +63,8 @@ unittest
     class C2 { char c; }
     static assert(stateSize!C2 == 4 * size_t.sizeof);
     static class C3 { char c; }
-    static assert(stateSize!C3 == 2 * size_t.sizeof + char.sizeof);
+    // Uncomment test after dmd issue closed https://github.com/dlang/dmd/issues/21065
+    //static assert(stateSize!C3 == 3 * size_t.sizeof);
 }
 
 /**


### PR DESCRIPTION
This can be reverted after the fix for dlang issue 21065 is merged

Refs: dlang/dmd#21065