### PR TITLE
Revert "Fix #9584 - Using dirEntries and chdir() can have unwanted results (#10666)"

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4695,7 +4695,6 @@ private struct DirIteratorImpl
         bool toNext(bool fetch, scope WIN32_FIND_DATAW* findinfo) @trusted
         {
             import core.stdc.wchar_ : wcscmp;
-            import std.string : chompPrefix;
 
             if (fetch)
             {
@@ -4712,7 +4711,7 @@ private struct DirIteratorImpl
                     popDirStack();
                     return false;
                 }
-            _cur = DirEntry(_stack[$-1].dirpath.chompPrefix(_pathPrefix), findinfo);
+            _cur = DirEntry(_stack[$-1].dirpath, findinfo);
             return true;
         }
 
@@ -4757,8 +4756,6 @@ private struct DirIteratorImpl
 
         bool next() @trusted
         {
-            import std.string : chompPrefix;
-
             if (_stack.length == 0)
                 return false;
 
@@ -4768,7 +4765,7 @@ private struct DirIteratorImpl
                 if (core.stdc.string.strcmp(&fdata.d_name[0], ".") &&
                     core.stdc.string.strcmp(&fdata.d_name[0], ".."))
                 {
-                    _cur = DirEntry(_stack[$-1].dirpath.chompPrefix(_pathPrefix), fdata);
+                    _cur = DirEntry(_stack[$-1].dirpath, fdata);
                     return true;
                 }
             }
@@ -4798,20 +4795,8 @@ private struct DirIteratorImpl
 
     this(string pathname, SpanMode mode, bool followSymlink)
     {
-        import std.path : absolutePath, isAbsolute;
-
         _mode = mode;
         _followSymlink = followSymlink;
-
-        if (!pathname.isAbsolute)
-        {
-            const pathnameRel = pathname;
-            alias pathnameAbs = pathname;
-            pathname = pathname.absolutePath;
-
-            const offset = pathnameAbs.length - pathnameRel.length;
-            _pathPrefix  = pathnameAbs[0 .. offset];
-        }
 
         if (stepIn(pathname))
         {


### PR DESCRIPTION
This essentially reverts commit 274109b3de5f5d61d5a1f99a53a83e5e10056230.
It doesn’t remove the added unittest yet because it wonderfully underlines the point I’m going to make:

It adds no value.
The patch was a nerfed version of #6125. Well, it was nerfed to provide backwards compatibility. But this came at a cost: It no longer helped with the footgun imposed by relative paths that the original version did actually help with.

Let’s verify that Phobos still passes its testsuite and remove it for better (or worse).

#### Further thoughts

In addition it still failed to address the underlying problem that `DirEntry`-s that hold relative paths aren’t really aware of which directory they are relative to. That’s what needs to be fixed to resolve the UX issue at hand. I’ve spent quite a while hacking on the module and debugging my and existing code with my attempts at #10669 and #10706. The insight I’ve gained from this made it clear that any improvement implemented in this regard needs to be a thoroughly engineered one that doesn’t try to cut corners. I’ve also come to the conclusion that we still lack a proper unittest that doesn’t make premature assumptions; in particular one thing that prominent examples in the original issue report (and my later patches) got wrong is the expectation that we could just request the absolute path of a `DirEntry` and get a accurate result independent of the current working directory. (I’m actually a bit surprised now that I could get ae555fb879ecadc3ffb09c45b7c6f9e536be8590 to pass CI tests.) The way `std.file` currently works, doesn’t provide any guarantees that could come close to fulfilling such a requirement yet. If we want to make `DirEntry` work with no dependency on the current working directory, we’ll need to overhaul the whole module accordingly. Otherwise users are still in for surprises like the one in #9584. Fixing `dirEntries` alone won’t provide a satisfactory result.