### PR TITLE
std.net.curl: Fix fast-path check when encoding is "utf-8" (lower-case)

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -1226,9 +1226,10 @@ private auto _decodeContent(T)(ubyte[] content, string encoding)
     {
         import std.exception : enforce;
         import std.format : format;
+        import std.uni : icmp;
 
         // Optimally just return the utf8 encoded content
-        if (encoding == "UTF-8")
+        if (icmp(encoding, "UTF-8") == 0)
             return cast(char[])(content);
 
         // The content has to be re-encoded to utf8


### PR DESCRIPTION
For HTTP, the response body encoding is specified in the "Content-Type" header, e.g.: "Content-Type: application/json; charset=utf-8".

MDN [says](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type#directives):

> - `charset`: Indicates the character encoding standard used.
>   The value is **case insensitive but lowercase is preferred**.

However, `_decodeContent` was comparing the encoding with the exact string "UTF-8", which causes most HTTP requests to go through the slow path.

Fix this by using `icmp`, like elsewhere in the module for case-insensitive string comparisons.