### PR TITLE
Fix #10699 - std.format with position with omitted second number does not work

### DIFF
--- a/std/format/write.d
+++ b/std/format/write.d
@@ -622,17 +622,13 @@ uint formattedWrite(Writer, Char, Args...)(auto ref Writer w, const scope Char[]
         size_t index = currentArg;
         if (spec.indexStart != 0)
             index = spec.indexStart - 1;
-        else
-            ++currentArg;
     SWITCH: switch (index)
         {
             foreach (i, Tunused; Args)
             {
             case i:
                 formatValue(w, args[i], spec);
-                if (currentArg < spec.indexEnd)
-                    currentArg = spec.indexEnd;
-                // A little know feature of format is to format a range
+                // A little-known feature of format is to format a range
                 // of arguments, e.g. `%1:3$` will format the first 3
                 // arguments. Since they have to be consecutive we can
                 // just use explicit fallthrough to cover that case.
@@ -642,10 +638,16 @@ uint formattedWrite(Writer, Char, Args...)(auto ref Writer w, const scope Char[]
                     static if (i + 1 < Args.length)
                         goto case;
                     else
+                    {
+                        currentArg = i + 1;
                         goto default;
+                    }
                 }
                 else
+                {
+                    currentArg = i + 1;
                     break SWITCH;
+                }
             }
         default:
             if (spec.indexEnd == spec.indexEnd.max)
@@ -1212,8 +1214,9 @@ if (isSomeString!(typeof(fmt)))
     import std.array : appender;
     auto w = appender!(char[])();
 
-    formattedWrite(w, "%1:$d", 1, 2, 3);
+    uint count = formattedWrite(w, "%1:$d", 1, 2, 3);
     assert(w.data == "123");
+    assert(count == 3);
 }
 
 /**


### PR DESCRIPTION
This is part 2 of the fix of #10699.

After the previous commit, the invocation
```
  format ("%1$x %+2:$d", 11, 22, 33, 44, 55, 66, 77, 88, 99)
```
produces an exception
```
  std.format.FormatException@.../std/format/package.d(785): Orphan format arguments: args[65535..9]
```
apparently because the function formattedWrite returned 65535,
where 9 would be the correct return value. Namely,
  https://dlang.org/library/std/format/write/formatted_write.html
says that the function formattedWrite returns
  "The index of the last argument that was formatted."

The fix does this by correcting the value of `currentArg` at the end of the
`foreach (i, Tunused; Args)` loop. There is no need to update `currentArg`
right before this loop, nor at each iteration of this loop. A single update
of `currentArg`, when the loop is left (through a `goto` or `break` statement),
is sufficient.

Note also that in the assignment `currentArg = i + 1;`, `i + 1` is a constant
expression, as can be seen by compiling the test case with `gdc -S -g`.
