### PR TITLE
fix std.encoding.sanitize usable in @safe.Fix #10545

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -1879,7 +1879,7 @@ immutable(E)[] sanitize(E)(immutable(E)[] s)
         offset += n;
         t = t[n..$];
     }
-    return cast(immutable(E)[])array[0 .. offset];
+    return array[0 .. offset];
 }
 
 ///


### PR DESCRIPTION
## Fix Issue #10545: Make `std.encoding.sanitize` usable in `@safe` code
**Changes:**  
- Replaced `return cast(immutable(E)[]) array[0 .. offset];` to `return array[0 .. offset];`.

**Explain:** 
- It seems like that: It works because it's a template function and the compiler can see that the array slice array[0 .. offset] is unique (no other references exist) at the point of return, so it allows the implicit conversion to immutable. If it's not a template function, and the compiler cannot prove the uniqueness of the array slice. I tested it by following codes: 

**Tests:**
This snippet code could be compiled: 
```d
@safe immutable(E)[] templateFunc(E)(immutable(E)[] s) {
    E[] array = new E[s.length];
    array[0..s.length] = s;
    return array[0..5];
}
int main(string[] args) {
    writeln(templateFunc("SSSSSSSSSS"));//SSSSS
    return 0;
}
```
This snippet code could NOT be compiled: 
```d
immutable(char)[] notTemplateFunc(immutable(char)[] s) {
    char[] array = new char[s.length];
    array[0..s.length] = s;
    return array[0..5];
}

int main(string[] args) {
    writeln(notTemplateFunc("SSSSSSSSSS"));
    return 0;
}
```
After fixed this issue, the following test was passed:
```d
@safe unittest {  
    import std.encoding : sanitize;  
    auto result = sanitize("valid"w);
    assert(result == "valid");  
} 
```