### PR TITLE
Fix withExtension for types incompatible with const

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -992,7 +992,7 @@ private auto _stripDrive(R)(R path)
     Returns:
         index of extension separator (the dot), or -1 if not found
 */
-private ptrdiff_t extSeparatorPos(R)(const R path)
+private ptrdiff_t extSeparatorPos(R)(R path)
 if (isRandomAccessRange!R && hasLength!R && isSomeChar!(ElementType!R) ||
     isNarrowString!R)
 {
@@ -1278,6 +1278,11 @@ if (isSomeChar!C1 && isSomeChar!C2)
     assert(withExtension("file".byChar, "ext").array == "file.ext");
     assert(withExtension("file"w.byWchar, ".ext"w).array == "file.ext"w);
     assert(withExtension("file.ext"w.byWchar, ".").array == "file."w);
+}
+
+@safe unittest
+{
+    assert(chainPath("directory", "file").withExtension(".ext").array == buildPath("directory", "file.ext"));
 }
 
 @safe unittest


### PR DESCRIPTION
The `extSeparatorPos` has a useless `const` in its signature. This prevents using it with ranges that do not support `const`, so even an obvious combination like `chainPath(...).setExtension(...)` fails to compile.

```d
private ptrdiff_t extSeparatorPos(R)(const R path)
```