### PR TITLE
Fix #10731 - Windows link error with std.random.uniform() in v2.111

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 		scopebuffer test/dummyrange test/range \
 		test/sumtype_example_overloads \
 		$(addprefix unicode_, comp decomp grapheme norm tables) \
-		windows/advapi32 \
+		windows/advapi32 windows/bcrypt \
 	) \
 	typetuple \
 )

--- a/std/internal/windows/bcrypt.d
+++ b/std/internal/windows/bcrypt.d
@@ -1,0 +1,65 @@
+module std.internal.windows.bcrypt;
+
+version (Windows):
+
+import core.sys.windows.bcrypt : BCryptGenRandom, BCRYPT_USE_SYSTEM_PREFERRED_RNG;
+import core.sys.windows.windef : HMODULE, PUCHAR, ULONG;
+import core.sys.windows.ntdef : NT_SUCCESS;
+
+pragma(lib, "Bcrypt.lib");
+
+package(std) bool bcryptGenRandom(T)(out T result) @trusted
+{
+    loadBcrypt();
+
+    const gotRandom = ptrBCryptGenRandom(
+        null,
+        cast(PUCHAR) &result,
+        ULONG(T.sizeof),
+        BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+    );
+
+    return NT_SUCCESS(gotRandom);
+}
+
+private
+{
+    HMODULE hBcrypt = null;
+    typeof(BCryptGenRandom)* ptrBCryptGenRandom;
+}
+
+private void loadBcrypt() @nogc nothrow
+{
+    import core.sys.windows.winbase : GetProcAddress, LoadLibraryA;
+
+    if (!hBcrypt)
+    {
+        hBcrypt = LoadLibraryA("Bcrypt.dll");
+        if (!hBcrypt)
+            assert(false, `LoadLibraryA("Bcrypt.dll") failed.`); // `@nogc`
+
+        ptrBCryptGenRandom = cast(typeof(ptrBCryptGenRandom)) GetProcAddress(hBcrypt , "BCryptGenRandom");
+        if (!ptrBCryptGenRandom)
+            assert(false, `GetProcAddress(hBcrypt , "BCryptGenRandom") failed.`); // `@nogc`
+    }
+}
+
+// Will free `Bcrypt.dll`.
+private void freeBcrypt() @nogc nothrow
+{
+    import core.sys.windows.winbase : FreeLibrary;
+
+    if (hBcrypt)
+    {
+        if (!FreeLibrary(hBcrypt))
+            assert(false, `FreeLibrary("Bcrypt.dll") failed.`); // `@nogc`
+
+        hBcrypt = null;
+        ptrBCryptGenRandom = null;
+    }
+}
+
+static ~this()
+{
+    freeBcrypt();
+}

--- a/std/random.d
+++ b/std/random.d
@@ -1792,23 +1792,7 @@ version (linux)
 
 version (Windows)
 {
-    pragma(lib, "Bcrypt.lib");
-
-    private bool bcryptGenRandom(T)(out T result) @trusted
-    {
-        import core.sys.windows.windef : PUCHAR, ULONG;
-        import core.sys.windows.ntdef : NT_SUCCESS;
-        import core.sys.windows.bcrypt : BCryptGenRandom, BCRYPT_USE_SYSTEM_PREFERRED_RNG;
-
-        const gotRandom = BCryptGenRandom(
-            null,
-            cast(PUCHAR) &result,
-            ULONG(T.sizeof),
-            BCRYPT_USE_SYSTEM_PREFERRED_RNG,
-        );
-
-        return NT_SUCCESS(gotRandom);
-    }
+    import std.internal.windows.bcrypt : bcryptGenRandom;
 }
 
 /**


### PR DESCRIPTION
Load `Bcrypt.dll` ourselves as needed.