### PR TITLE
`getrandom()` backwards compatibility shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ ifdef NO_AUTODECODE
 override DFLAGS += -version=NoAutodecodeStrings
 endif
 
+ifdef LINUX_LEGACY_EMULATE_GETRANDOM
+override DFLAGS += -version=linux_legacy_emulate_getrandom
+endif
+
 UDFLAGS=-unittest -version=StdUnittest
 
 LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)

--- a/std/random.d
+++ b/std/random.d
@@ -1798,12 +1798,12 @@ version (linux)
 
         /+
             Linux `getrandom()` emulation built upon `/dev/urandom`.
-            Parameter `flags` is happily ignored.
+            The fourth parameter (`uint flags`) is happily ignored.
          +/
         private ssize_t getrandom(
                 void* buf,
                 size_t buflen,
-                uint flags,
+                uint,
         ) @system nothrow @nogc
         {
             import core.stdc.stdio : fclose, fopen, fread;

--- a/std/random.d
+++ b/std/random.d
@@ -1774,19 +1774,65 @@ else
 
 version (linux)
 {
-    // `getrandom()` was introduced in Linux 3.17.
+    version (linux_legacy_emulate_getrandom)
+    {
+        /+
+            Emulates `getrandom()` for backwards compatibility
+            with outdated kernels and legacy libc versions.
 
-    // Shim for missing bindings in druntime
-    version (none)
-        import core.sys.linux.sys.random : getrandom;
+            `getrandom()` was added to the GNU C Library in v2.25.
+         +/
+        pragma(msg, "`getrandom()` emulation for legacy Linux targets is enabled.");
+
+        /+
+            On modern kernels (5.6+), `/dev/random` would behave more similar
+            to `getrandom()`.
+            However, this emulator was specifically written for systems older
+            than that. Hence, `/dev/urandom` is the CSPRNG of choice.
+
+            <https://web.archive.org/web/20200914181930/https://www.2uo.de/myths-about-urandom/>
+         +/
+        private static immutable _pathLinuxSystemCSPRNG = "/dev/urandom";
+
+        import core.sys.posix.sys.types : ssize_t;
+
+        /+
+            Linux `getrandom()` emulation built upon `/dev/urandom`.
+            Parameter `flags` is happily ignored.
+         +/
+        private ssize_t getrandom(
+                void* buf,
+                size_t buflen,
+                uint flags,
+        ) @system nothrow @nogc
+        {
+            import core.stdc.stdio : fclose, fopen, fread;
+
+            auto blockDev = fopen(_pathLinuxSystemCSPRNG.ptr, "r");
+            if (blockDev is null)
+                assert(false, "System CSPRNG unavailable: `fopen(\"" ~ _pathLinuxSystemCSPRNG ~ "\")` failed.");
+            scope (exit) fclose(blockDev);
+
+            const bytesRead = fread(buf, 1, buflen, blockDev);
+            return bytesRead;
+        }
+    }
     else
     {
-        import core.sys.posix.sys.types : ssize_t;
-        extern extern(C) ssize_t getrandom(
-            void* buf,
-            size_t buflen,
-            uint flags,
-        ) @system nothrow @nogc;
+        // `getrandom()` was introduced in Linux 3.17.
+
+        // Shim for missing bindings in druntime
+        version (none)
+            import core.sys.linux.sys.random : getrandom;
+        else
+        {
+            import core.sys.posix.sys.types : ssize_t;
+            private extern extern(C) ssize_t getrandom(
+                void* buf,
+                size_t buflen,
+                uint flags,
+            ) @system nothrow @nogc;
+        }
     }
 }
 


### PR DESCRIPTION
People have been unhappy about the new `getrandom()` dependency.

- <https://github.com/dlang/phobos/pull/10623#issuecomment-2778500400>
- <https://forum.dlang.org/post/dxgjgvfrlawgiajklzpm@forum.dlang.org>

Instead of [reverting](https://forum.dlang.org/post/txltgbfjxvsclwjuotry@forum.dlang.org) the whole thing, we could supply a compatibility mode to users stuck with legacy systems.