### PR TITLE
Improve error message for to!string when used on infinite ranges

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -547,6 +547,7 @@ private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
     auto _ = value;
+    //Using an extra variable to PASS the dscanner in style check in CI
     static assert(0, "Cannot convert infinite range to string. " ~
                   "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -546,8 +546,18 @@ template to(T)
 private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
-    auto _ = value;
-    static assert(0, "Cannot convert infinite range to string. Use `.take(n)` or `.array` to make it finite.");
+    auto _ = value;  
+    static assert(0, "Cannot convert infinite range to string. Use `std.range.take` or `std.range.takeExactly` to make it finite.");
+}
+
+// Test for issue : https://github.com/dlang/phobos/issues/10559
+@safe pure nothrow unittest
+{
+    import std.range : repeat;
+    import std.conv : to;
+
+    // Test that converting an infinite range doesn't compile
+    static assert(!__traits(compiles, repeat(1).to!string));
 }
 
 /**

--- a/std/conv.d
+++ b/std/conv.d
@@ -547,7 +547,7 @@ private T toImpl(T, S)(S)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
     static assert(0, "Cannot convert infinite range to string. " ~
-                  "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
+                "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }
 
 // Test for issue : https://github.com/dlang/phobos/issues/10559

--- a/std/conv.d
+++ b/std/conv.d
@@ -543,11 +543,9 @@ template to(T)
     }
 }
 
-private T toImpl(T, S)(S value)
+private T toImpl(T, S)(S)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
-    //Using an extra variable to PASS the dscanner in style check in CI
-    auto _ = value;
     static assert(0, "Cannot convert infinite range to string. " ~
                   "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -547,7 +547,8 @@ private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
     auto _ = value;
-    static assert(0, "Cannot convert infinite range to string. Use `std.range.take` or `std.range.takeExactly` to make it finite.");
+    static assert(0, "Cannot convert infinite range to string. 
+                  Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }
 
 // Test for issue : https://github.com/dlang/phobos/issues/10559

--- a/std/conv.d
+++ b/std/conv.d
@@ -546,8 +546,8 @@ template to(T)
 private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
-    auto _ = value;
     //Using an extra variable to PASS the dscanner in style check in CI
+    auto _ = value;
     static assert(0, "Cannot convert infinite range to string. " ~
                   "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }

--- a/std/conv.d
+++ b/std/conv.d
@@ -546,7 +546,7 @@ template to(T)
 private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
-    auto _ = value;  
+    auto _ = value;
     static assert(0, "Cannot convert infinite range to string. Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -546,6 +546,7 @@ template to(T)
 private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
+    auto _ = value;
     static assert(0, "Cannot convert infinite range to string. Use `.take(n)` or `.array` to make it finite.");
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -547,8 +547,8 @@ private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
     auto _ = value;
-    static assert(0, "Cannot convert infinite range to string.
-                  Use `std.range.take` or `std.range.takeExactly` to make it finite.");
+    static assert(0, "Cannot convert infinite range to string. " ~
+                  "Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }
 
 // Test for issue : https://github.com/dlang/phobos/issues/10559

--- a/std/conv.d
+++ b/std/conv.d
@@ -543,6 +543,12 @@ template to(T)
     }
 }
 
+private T toImpl(T, S)(S value)
+if (isInputRange!S && isInfinite!S && isExactSomeString!T)
+{
+    static assert(0, "Cannot convert infinite range to string. Use `.take(n)` or `.array` to make it finite.");
+}
+
 /**
 If the source type is implicitly convertible to the target type, $(D
 to) simply performs the implicit conversion.

--- a/std/conv.d
+++ b/std/conv.d
@@ -547,7 +547,7 @@ private T toImpl(T, S)(S value)
 if (isInputRange!S && isInfinite!S && isExactSomeString!T)
 {
     auto _ = value;
-    static assert(0, "Cannot convert infinite range to string. 
+    static assert(0, "Cannot convert infinite range to string.
                   Use `std.range.take` or `std.range.takeExactly` to make it finite.");
 }
 


### PR DESCRIPTION
Partial Fix: #10559

### Summary
This PR improves compile-time diagnostics when attempting to convert an infinite input range to a string using to!string.

### Root Cause
Currently, the following code fails with a long and unhelpful template constraint error:

```d
import std.range, std.conv;
void main() {
    auto s = 42.repeat.to!string;
}
```

Error :
```d
none of the overloads of template std.conv.toImpl are callable using argument types !(string)(Repeat!int)
```

The reason is that Repeat!int is an infinite range and does not meet any of the constraints for string conversion — but the compiler doesn’t provide a meaningful message.

### Fix
This patch adds a specialized overload of toImpl in std.conv to detect the pattern of:

```d
to!string(range) // where range is an infinite input range
```

And explicitly raises a meaningful compile-time error:

```d
static assert(0, "Cannot convert infinite range to string. Use `.take(n)` or `.array` to make it finite.");
```
### Example Reproducer

```d
import std.range, std.conv;
void main() {
    auto s = 42.repeat.to!string;
}
```

Now output : 

```d
Error: static assert:  "Cannot convert infinite range to string. Use `.take(n)` or `.array` to make it finite."
```

###Notes

Fix added in std.conv via an early overload of toImpl.

Helps developers identify misuse with a clear and actionable message.

Verified manually via unittests on custom Phobos build