### PR TITLE
fix: remove stray parenthesis in changelog README

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -34,7 +34,7 @@ For more infos, see the [Ddoc spec](https://dlang.org/spec/ddoc.html).
 Preview changes
 ---------------
 
-If you have cloned the [tools](https://github.com/dlang/tools) and [dlang.org](https://github.com/dlang/dlang.org) repo),
+If you have cloned the [tools](https://github.com/dlang/tools) and [dlang.org](https://github.com/dlang/dlang.org) repo,
 you can preview the changelog with:
 
 ```


### PR DESCRIPTION
This pull request fixes a small typo in `changelog/README.md` by removing an extra closing parenthesis from the sentence describing how to preview the changelog.

Before:
... repo),

After:
... repo,

This improves clarity and maintains consistency in documentation.
