### PR TITLE
added 'version (D_BetterC)' to bypass std.exception.enforce

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -391,8 +391,16 @@ if (!is(immutable T == immutable bool))
 
     import core.memory : GC;
 
-    import std.exception : enforce;
     import std.typecons : RefCounted, RefCountedAutoInitialize;
+
+    version (D_BetterC)
+    {
+        enum enforce(alias value) = assert(value);
+    }
+    else
+    {
+        import std.exception : enforce;
+    }
 
     // This structure is not copyable.
     private struct Payload
@@ -1777,8 +1785,16 @@ if (!is(immutable T == immutable bool))
 struct Array(T)
 if (is(immutable T == immutable bool))
 {
-    import std.exception : enforce;
     import std.typecons : RefCounted, RefCountedAutoInitialize;
+
+    version (D_BetterC)
+    {
+        enum enforce(alias value) = assert(value);
+    }
+    else
+    {
+        import std.exception : enforce;
+    }
 
     static immutable uint bitsPerWord = size_t.sizeof * 8;
     private static struct Data

--- a/std/container/array.d
+++ b/std/container/array.d
@@ -392,15 +392,7 @@ if (!is(immutable T == immutable bool))
     import core.memory : GC;
 
     import std.typecons : RefCounted, RefCountedAutoInitialize;
-
-    version (D_BetterC)
-    {
-        enum enforce(alias value) = assert(value);
-    }
-    else
-    {
-        import std.exception : enforce;
-    }
+    import std.exception : enforce;
 
     // This structure is not copyable.
     private struct Payload
@@ -1786,15 +1778,7 @@ struct Array(T)
 if (is(immutable T == immutable bool))
 {
     import std.typecons : RefCounted, RefCountedAutoInitialize;
-
-    version (D_BetterC)
-    {
-        enum enforce(alias value) = assert(value);
-    }
-    else
-    {
-        import std.exception : enforce;
-    }
+    import std.exception : enforce;
 
     static immutable uint bitsPerWord = size_t.sizeof * 8;
     private static struct Data

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -69,16 +69,9 @@ if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
     import std.algorithm.mutation : move, swapAt;
     import std.algorithm.sorting : HeapOps;
     import std.functional : binaryFun;
-    import std.typecons : RefCounted, RefCountedAutoInitialize;
 
-    version (D_BetterC)
-    {
-        enum enforce(alias value) = assert(value);
-    }
-    else
-    {
-        import std.exception : enforce;
-    }
+    import std.typecons : RefCounted, RefCountedAutoInitialize;
+    import std.exception : enforce;
 
     static if (isRandomAccessRange!Store)
         alias Range = Store;

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -68,9 +68,17 @@ if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
     import std.algorithm.comparison : min;
     import std.algorithm.mutation : move, swapAt;
     import std.algorithm.sorting : HeapOps;
-    import std.exception : enforce;
     import std.functional : binaryFun;
     import std.typecons : RefCounted, RefCountedAutoInitialize;
+
+    version (D_BetterC)
+    {
+        enum enforce(alias value) = assert(value);
+    }
+    else
+    {
+        import std.exception : enforce;
+    }
 
     static if (isRandomAccessRange!Store)
         alias Range = Store;

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -56,10 +56,18 @@ public import std.container.util;
 struct SList(T)
 if (!is(T == shared))
 {
-    import std.exception : enforce;
     import std.range : Take;
     import std.range.primitives : isInputRange, isForwardRange, ElementType;
     import std.traits : isImplicitlyConvertible;
+
+    version (D_BetterC)
+    {
+        enum enforce(alias value) = assert(value);
+    }
+    else
+    {
+        import std.exception : enforce;
+    }
 
     private struct Node
     {

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -60,14 +60,7 @@ if (!is(T == shared))
     import std.range.primitives : isInputRange, isForwardRange, ElementType;
     import std.traits : isImplicitlyConvertible;
 
-    version (D_BetterC)
-    {
-        enum enforce(alias value) = assert(value);
-    }
-    else
-    {
-        import std.exception : enforce;
-    }
+    import std.exception : enforce;
 
     private struct Node
     {

--- a/std/exception.d
+++ b/std/exception.d
@@ -430,37 +430,46 @@ void assertThrown(T : Throwable = Exception, E)
         If a delegate is passed, the safety and purity of this function are inferred
         from `Dg`'s safety and purity.
  +/
-template enforce(E : Throwable = Exception)
-if (is(typeof(new E("", string.init, size_t.init)) : Throwable) ||
-    is(typeof(new E(string.init, size_t.init)) : Throwable))
+version (D_BetterC)
 {
-    ///
-    T enforce(T)(T value, lazy const(char)[] msg = null,
-    string file = __FILE__, size_t line = __LINE__)
-    if (is(typeof({ if (!value) {} })))
-    {
-        if (!value) bailOut!E(file, line, msg);
+    T enforce(T)(T value) {
+        assert(value);
         return value;
     }
 }
-
-/// ditto
-T enforce(T, Dg, string file = __FILE__, size_t line = __LINE__)
-    (T value, scope Dg dg)
-if (isSomeFunction!Dg && is(typeof( dg() )) &&
-    is(typeof({ if (!value) {} })))
+else
 {
-    if (!value) dg();
-    return value;
-}
+    template enforce(E : Throwable = Exception)
+    if (is(typeof(new E("", string.init, size_t.init)) : Throwable) ||
+        is(typeof(new E(string.init, size_t.init)) : Throwable))
+    {
+        ///
+        T enforce(T)(T value, lazy const(char)[] msg = null,
+        string file = __FILE__, size_t line = __LINE__)
+        if (is(typeof({ if (!value) {} })))
+        {
+            if (!value) bailOut!E(file, line, msg);
+            return value;
+        }
+    }
 
-/// ditto
-T enforce(T)(T value, lazy Throwable ex)
-{
-    if (!value) throw ex();
-    return value;
-}
+    /// ditto
+    T enforce(T, Dg, string file = __FILE__, size_t line = __LINE__)
+        (T value, scope Dg dg)
+    if (isSomeFunction!Dg && is(typeof( dg() )) &&
+        is(typeof({ if (!value) {} })))
+    {
+        if (!value) dg();
+        return value;
+    }
 
+    /// ditto
+    T enforce(T)(T value, lazy Throwable ex)
+    {
+        if (!value) throw ex();
+        return value;
+    }
+}
 ///
 @system unittest
 {


### PR DESCRIPTION
I added a definition of `std.exception.enforce` conditional upon `version (D_BetterC)` which uses a simple assert and returns the value if OK so as to allow modules that import this function to compile with `-betterC`

mainly aimed at `std.container` modules but might be useful for others as well