### PR TITLE
Handle `DirEntry` as a first-class citizen parameter with file- and path-related functions

### DIFF
--- a/changelog/direntries-ng_windows.dd
+++ b/changelog/direntries-ng_windows.dd
@@ -45,3 +45,8 @@ trick.
 Evidence for the confusing nature of the previous behavior can be found on
 the issue tracker:
 $(LINK2 https://github.com/dlang/phobos/issues/9584, #9584)
+
+On POSIX the newly introduced overloads currently still emulate the old
+behavior. This might be subject to change and should not be relied on.
+In general, it is preferable to explicitly use the `name` property of
+`DirEntry` in cases where the old behavior is desired.

--- a/changelog/direntries-ng_windows.dd
+++ b/changelog/direntries-ng_windows.dd
@@ -1,0 +1,47 @@
+Increase  more functions accept `DirEntry` on Windows.
+
+The `DirEntry` structure from `std.file` will now capture its absolute path
+upon construction on Windows targets.
+
+Unlike POSIX systems, absolute paths are unproblematic on Windows,
+as filesystem permissions are evaluated only on the node itself, not by
+traversing the whole directory tree along the path.
+This means, even if a user has no permission to access to `C:\some-dir\`,
+they can still access `C:\some-dir\file` if sufficient permissions are granted
+to them for the file entry itself. The same applies to directories.
+
+A good chunk of file-related Phobos functions are “made compatible” with
+`DirEntry` through the implicit conversion mechanism provided by `alias this`
+found in `DirEntry`. This allows `DirEntry` to become a `string` as needed.
+
+Unfortunately, this comes at the downside that functions can receive a relative
+path that is not relative to the current working directory if it has changed
+since the construction of the `DirEntry` handle. This does not always align
+with the expectations of unsuspecting users — especially in the case where they
+have passed a “fat” `DirEntry` handle instead of a raw path string.
+
+Not much can be done in the case where users convert the `DirEntry` into a
+`string` on their own. When Phobos functions are called with an actual
+`DirEntry`, however, the library can make use of an absolute path that has been
+captured in advance and stored in the `DirEntry`.
+
+This describes exactly what has been changed. `std.file` and a number of
+functions in `std.path` have been overloaded or modified to also accept a
+`DirEntry` parameter in addition to the existing `string` path overloads.
+
+The old behavior can be easily restored either by manually converting a
+`DirEntry` to `string` by casting or using the `name` property of said struct.
+
+While this was implemented to be as backwards compatible as reasonably
+possible, in certain edge cases a simple adaption to user code might be
+necessary. This is the case when users relied on the fact that a relative path
+held by a `DirEntry` structure would always be relative to the current working
+directory at the time of use. Additionally, rare meta programming code which
+assumed that the `string` path overload of applicable functions would get
+matched by `DirEntry` structures will have to be updated.
+As outlined before, manually converting the `DirEntry` to `string` will do the
+trick.
+
+Evidence for the confusing nature of the previous behavior can be found on
+the issue tracker:
+$(LINK2 https://github.com/dlang/phobos/issues/9584, #9584)

--- a/std/file.d
+++ b/std/file.d
@@ -817,6 +817,38 @@ version (Windows) @safe unittest
             assert(slurp!(int)(entry, "%d") == [10, 20]);
         });
     });
+
+    // Mild chaos directory tree traversal test
+    runIn(root, {
+        auto iterator = ".".dirEntries(SpanMode.shallow);
+
+        int found1 = 0;
+        int found3 = 0;
+        int foundOthers = 0;
+
+        runIn(nirvana, {
+            foreach (DirEntry entry; iterator)
+            {
+                switch (entry.name[$-1])
+                {
+                    case '1':
+                        ++found1;
+                        break;
+                    case '3':
+                        ++found3;
+                        break;
+                    default:
+                        ++foundOthers;
+                        break;
+                }
+                chdir(parent);
+            }
+        });
+
+        assert(found1 == 1);
+        assert(found3 == 1);
+        assert(foundOthers == 0);
+    });
 }
 
 // Purposefully not documented. Use at your own risk

--- a/std/file.d
+++ b/std/file.d
@@ -439,6 +439,25 @@ version (Windows) @safe unittest
 
         remove(file);
     });
+
+    // Type identification test
+    runIn(root, {
+        const string filePath = "1/2/test_" ~ lineNumberString!();
+        const string dirPath = "3/4";
+        write(filePath, "…");
+
+        const fileEntry = DirEntry(filePath);
+        const dirEntry = DirEntry(dirPath);
+
+        runIn(nirvana, {
+            assert( isFile(fileEntry));
+            assert(!isDir (fileEntry));
+            assert(!isFile( dirEntry));
+            assert( isDir ( dirEntry));
+        });
+
+        remove(filePath);
+    });
 }
 
 // Purposefully not documented. Use at your own risk
@@ -2801,9 +2820,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 @property bool isDir(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return name.isDir!(StringTypeOf!R);
+}
+
+/// ditto
+@property bool isDir(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return isDir(name.absoluteName);
+    else
+        return isDir(name.name);
 }
 
 ///
@@ -2975,9 +3004,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 @property bool isFile(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return isFile!(StringTypeOf!R)(name);
+}
+
+/// ditto
+@property bool isFile(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return isFile(name.absoluteName);
+    else
+        return isFile(name.name);
 }
 
 ///

--- a/std/file.d
+++ b/std/file.d
@@ -4166,11 +4166,18 @@ version (Posix) @safe unittest
         $(LREF FileException) on error.
   +/
 version (StdDdoc) string readLink(R)(R link)
-if (isSomeFiniteCharInputRange!R || isConvertibleToString!R);
+if (isSomeFiniteCharInputRange!R || isConvertibleToString!R || isDirEntry!R);
 else version (Posix) string readLink(R)(R link)
-if (isSomeFiniteCharInputRange!R || isConvertibleToString!R)
+if (isSomeFiniteCharInputRange!R || isConvertibleToString!R || isDirEntry!R)
 {
-    static if (isConvertibleToString!R)
+    static if (isDirEntry!R)
+    {
+        version (Windows) // hypothetically, currently ruled out by `version (Posix)`
+            return readLink(link.absoluteName);
+        else
+            return readLink(link.name);
+    }
+    else static if (isConvertibleToString!R)
     {
         return readLink!(convertToString!R)(link);
     }

--- a/std/file.d
+++ b/std/file.d
@@ -312,7 +312,10 @@ version (Windows) @safe unittest
                 import std.stdio : stderr;
                 () @trusted
                 {
-                    stderr.writeln("Unexpected access time; probably caused by time-sync or filesystem.");
+                    stderr.writeln(
+                        __FILE__, ":", __LINE__,
+                        "Unexpected access time; probably caused by time-sync or filesystem. ",
+                    );
                 }();
             }
             if (modificationTime < now)
@@ -320,7 +323,10 @@ version (Windows) @safe unittest
                 import std.stdio : stderr;
                 () @trusted
                 {
-                    stderr.writeln("Unexpected modification time; probably caused by time-sync or filesystem.");
+                    stderr.writeln(
+                        __FILE__, ":", __LINE__,
+                        "Unexpected modification time; probably caused by time-sync or filesystem.",
+                    );
                 }();
             }
         });

--- a/std/file.d
+++ b/std/file.d
@@ -302,6 +302,20 @@ version (Windows) @safe unittest
             assert( "1".exists);
             assert(!"x".exists);
         }
+        // string-based path to `DirEntry` renaming with `chdir()`
+        {
+            auto de1 = DirEntry("1");
+            rename("1", "x");
+
+            assert(!"1".exists);
+            assert( "x".exists);
+
+            runIn(nirvana, {
+                rename(root.buildPath("x"), de1);
+            });
+            assert( "1".exists);
+            assert(!"x".exists);
+        }
         // Dual-DirEntry renaming with `chdir()`
         {
             auto de1 = DirEntry("1");

--- a/std/file.d
+++ b/std/file.d
@@ -131,15 +131,15 @@ private enum isDirEntry(T) = is(T == DirEntry);
 
 @safe unittest
 {
-	import std.path : absolutePath, buildPath;
+    import std.path : absolutePath, buildPath;
 
-	string root = deleteme();
-	mkdirRecurse(root);
-	scope (exit) rmdirRecurse(root);
+    string root = deleteme();
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(parent);
 
-	mkdirRecurse(root.buildPath("1", "2"));
-	mkdirRecurse(root.buildPath("3", "4"));
-	mkdirRecurse(root.buildPath("3", "5", "6"));
+    mkdirRecurse(root.buildPath("1", "2"));
+    mkdirRecurse(root.buildPath("3", "4"));
+    mkdirRecurse(root.buildPath("3", "5", "6"));
 
     const origWD = getcwd();
 

--- a/std/file.d
+++ b/std/file.d
@@ -474,6 +474,22 @@ version (Windows) @safe unittest
             assert(sentinel.isFile);
         });
     });
+
+    // Directory creation test
+    runIn(root, {
+        const string dirPath = "3/5/" ~ lineNumberString!();
+        mkdir(dirPath);
+
+        const dirEntry = DirEntry(dirPath);
+        rmdir(dirPath);
+        assert(!dirPath.exists);
+
+        runIn(nirvana, {
+            mkdir(dirEntry);
+        });
+        assert(dirPath.exists);
+        rmdir(dirPath);
+    });
 }
 
 // Purposefully not documented. Use at your own risk
@@ -3500,9 +3516,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 void mkdir(R)(auto ref R pathname)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return mkdir!(StringTypeOf!R)(pathname);
+}
+
+/// ditto
+void mkdir(R)(auto ref R pathname)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return mkdir(pathname.absoluteName);
+    else
+        return mkdir(pathname.name);
 }
 
 @safe unittest

--- a/std/file.d
+++ b/std/file.d
@@ -157,9 +157,9 @@ version (Windows) @safe unittest
     // DirEntry existance test
     runIn(root, {
         auto entry = ".".dirEntries(SpanMode.shallow).front;
-        assert(entry.exists);
+        assert(exists(entry));
         runIn(nirvana, () {
-            assert(entry.exists);
+            assert(exists(entry));
         });
     });
 
@@ -264,7 +264,9 @@ version (Windows) @safe unittest
         assert(file.exists);
 
         runIn(nirvana, {
+            assert(entry.exists);
             remove(entry);
+            assert(!entry.exists);
         });
         assert(!file.exists);
     });

--- a/std/file.d
+++ b/std/file.d
@@ -302,6 +302,22 @@ version (Windows) @safe unittest
             assert( "1".exists);
             assert(!"x".exists);
         }
+        // Dual-DirEntry renaming with `chdir()`
+        {
+            auto de1 = DirEntry("1");
+            runIn(nirvana, {
+                rename(de1, root.buildPath("x"));
+            });
+            assert(!"1".exists);
+            assert( "x".exists);
+
+            auto deX = DirEntry("x");
+            runIn(nirvana, {
+                rename(deX, de1);
+            });
+            assert( "1".exists);
+            assert(!"x".exists);
+        }
     });
 
     // Removal test

--- a/std/file.d
+++ b/std/file.d
@@ -129,7 +129,7 @@ else
 private enum isConvertibleToStringButNoDirEntry(T) = !is(T == DirEntry) && isConvertibleToString!T;
 private enum isDirEntry(T) = is(T == DirEntry);
 
-@safe unittest
+version (Windows) @safe unittest
 {
     import std.path : absolutePath, buildPath;
 

--- a/std/file.d
+++ b/std/file.d
@@ -870,6 +870,16 @@ version (Windows) @safe unittest
         assert(found3 == 1);
         assert(foundOthers == 0);
     });
+
+    // Chaotic directory tree traversal test
+    runIn(root, {
+        // <https://github.com/dlang/phobos/issues/9584>
+        foreach (DirEntry entry; ".".dirEntries("*", SpanMode.shallow))
+            if (entry.isDir)
+                foreach (DirEntry subEntry; entry.dirEntries("*", SpanMode.shallow))
+                    if (subEntry.isDir)
+                        chdir(subEntry);
+    });
 }
 
 // Purposefully not documented. Use at your own risk

--- a/std/file.d
+++ b/std/file.d
@@ -295,16 +295,15 @@ version (Windows) @safe unittest
 
     // File-time querying test
     runIn(root, {
-        import std.datetime : Clock;
+        import std.datetime : Clock, SysTime;
         import std.stdio : stderr;
 
-        auto now = Clock.currTime();
+        const now = Clock.currTime();
         const string file = "1/2/test.txt";
         write(file, "…");
 
         auto entry = DirEntry(file);
         runIn(nirvana, {
-            assert(!file.exists);
             SysTime accessTime, modificationTime;
             getTimes(entry, accessTime, modificationTime);
 
@@ -336,7 +335,7 @@ version (Windows) @safe unittest
 
     // Windows File-time querying test
     version (Windows) runIn(root, {
-        import std.datetime : Clock;
+        import std.datetime : Clock, SysTime;
         import std.stdio : stderr;
 
         auto now = Clock.currTime();
@@ -345,7 +344,6 @@ version (Windows) @safe unittest
 
         auto entry = DirEntry(file);
         runIn(nirvana, {
-            assert(!file.exists);
             SysTime creationTime, accessTime, modificationTime;
             getTimesWin(entry, creationTime, accessTime, modificationTime);
 

--- a/std/file.d
+++ b/std/file.d
@@ -761,7 +761,6 @@ version (Windows) @safe unittest
     });
 
     // Directory tree removal test
-    version (none) // TODO: port `dirEntries()`
     runIn(root, {
         import std.exception : assertThrown;
 

--- a/std/file.d
+++ b/std/file.d
@@ -133,6 +133,18 @@ version (Windows) @safe unittest
 {
     import std.path : absolutePath, buildPath;
 
+    template lineNumberString(size_t line = __LINE__)
+    {
+        import std.conv : to;
+        enum lineNumberString = to!string(line);
+    }
+
+    {
+        import std.conv : to;
+        assert(lineNumberString!().to!size_t() == __LINE__);
+        assert(lineNumberString!().to!size_t() == __LINE__);
+    }
+
     static void runIn(string dir, void delegate() @safe callback)
     {
         const origWD = getcwd();
@@ -265,7 +277,7 @@ version (Windows) @safe unittest
 
     // Removal test
     runIn(root, {
-        const string file = "1/2/test.txt";
+        const string file = "1/2/test_" ~ lineNumberString!();
         write(file, "…");
         auto entry = DirEntry(file);
         assert(file.exists);
@@ -280,7 +292,7 @@ version (Windows) @safe unittest
 
     // File-size querying test
     runIn(root, {
-        const string file = "1/2/test.txt";
+        const string file = "1/2/test_" ~ lineNumberString!();
         static immutable data = cast(immutable(ubyte)[]) "foobar";
         write(file, data);
 
@@ -299,7 +311,7 @@ version (Windows) @safe unittest
         import std.stdio : stderr;
 
         const now = Clock.currTime();
-        const string file = "1/2/test.txt";
+        const string file = "1/2/test_" ~ lineNumberString!();
         write(file, "…");
 
         auto entry = DirEntry(file);
@@ -348,7 +360,7 @@ version (Windows) @safe unittest
         import std.stdio : stderr;
 
         auto now = Clock.currTime();
-        const string file = "1/2/test.txt";
+        const string file = "1/2/test_" ~ lineNumberString!();
         write(file, "…");
 
         auto entry = DirEntry(file);
@@ -402,7 +414,7 @@ version (Windows) @safe unittest
         const thePast = now - oneYear;
         const theFuture = now + oneYear;
 
-        const string file = "1/2/test.txt";
+        const string file = "1/2/test_" ~ lineNumberString!();
         write(file, "…");
 
         auto entry = DirEntry(file);

--- a/std/file.d
+++ b/std/file.d
@@ -296,6 +296,7 @@ version (Windows) @safe unittest
     // File-time querying test
     runIn(root, {
         import std.datetime : Clock;
+        import std.stdio : stderr;
 
         auto now = Clock.currTime();
         const string file = "1/2/test.txt";
@@ -309,22 +310,20 @@ version (Windows) @safe unittest
 
             if (accessTime < now)
             {
-                import std.stdio : stderr;
                 () @trusted
                 {
                     stderr.writeln(
-                        __FILE__, ":", __LINE__,
+                        __FILE__, "(", __LINE__, "): ",
                         "Unexpected access time; probably caused by time-sync or filesystem. ",
                     );
                 }();
             }
             if (modificationTime < now)
             {
-                import std.stdio : stderr;
                 () @trusted
                 {
                     stderr.writeln(
-                        __FILE__, ":", __LINE__,
+                        __FILE__, "(", __LINE__, "): ",
                         "Unexpected modification time; probably caused by time-sync or filesystem.",
                     );
                 }();
@@ -338,6 +337,7 @@ version (Windows) @safe unittest
     // Windows File-time querying test
     version (Windows) runIn(root, {
         import std.datetime : Clock;
+        import std.stdio : stderr;
 
         auto now = Clock.currTime();
         const string file = "1/2/test.txt";
@@ -351,33 +351,30 @@ version (Windows) @safe unittest
 
             if (creationTime < now)
             {
-                import std.stdio : stderr;
                 () @trusted
                 {
                     stderr.writeln(
-                        __FILE__, ":", __LINE__,
+                        __FILE__, "(", __LINE__, "): ",
                         "Unexpected creation time; probably caused by time-sync or filesystem.",
                     );
                 }();
             }
             if (accessTime < now)
             {
-                import std.stdio : stderr;
                 () @trusted
                 {
                     stderr.writeln(
-                        __FILE__, ":", __LINE__,
+                        __FILE__, "(", __LINE__, "): ",
                         "Unexpected access time; probably caused by time-sync or filesystem.",
                     );
                 }();
             }
             if (modificationTime < now)
             {
-                import std.stdio : stderr;
                 () @trusted
                 {
                     stderr.writeln(
-                        __FILE__, ":", __LINE__,
+                        __FILE__, "(", __LINE__, "): ",
                         "Unexpected modification time; probably caused by time-sync or filesystem.",
                     );
                 }();

--- a/std/file.d
+++ b/std/file.d
@@ -262,6 +262,24 @@ version (Windows) @safe unittest
         });
     });
 
+    // Path determination test
+    runIn(root, {
+        import std.path : asRelativePath, relativePath, asNormalizedPath;
+
+        const string relative = "1";
+        const string absolute = absolutePath(relative);
+        const string expected = relativePath(absolute, nirvana);
+
+        const entry = DirEntry(relative);
+
+        runIn(nirvana, {
+            import std.algorithm.comparison : equal;
+            assert(equal(  relativePath(entry          ), expected));
+            assert(equal(  relativePath(entry, getcwd()), expected));
+            assert(equal(asRelativePath(entry, getcwd()), expected));
+        });
+    });
+
     // Renaming tests
     runIn(root, {
         // string-based renaming

--- a/std/file.d
+++ b/std/file.d
@@ -154,6 +154,12 @@ version (Windows) @safe unittest
         callback();
     }
 
+    static void warnAbout(string msg, string file = __FILE__, size_t line = __LINE__) @trusted
+    {
+        import std.stdio : stderr;
+        stderr.writefln!"%s(%s): %s"(file, line, msg);
+    }
+
     string parent = deleteme().absolutePath;
     string root = parent.buildPath("r");
     mkdirRecurse(root);
@@ -320,25 +326,9 @@ version (Windows) @safe unittest
             getTimes(entry, accessTime, modificationTime);
 
             if (accessTime < now)
-            {
-                () @trusted
-                {
-                    stderr.writeln(
-                        __FILE__, "(", __LINE__, "): ",
-                        "Unexpected access time; probably caused by time-sync or filesystem. ",
-                    );
-                }();
-            }
+                warnAbout("Unexpected access time; probably caused by time-sync or filesystem.");
             if (modificationTime < now)
-            {
-                () @trusted
-                {
-                    stderr.writeln(
-                        __FILE__, "(", __LINE__, "): ",
-                        "Unexpected modification time; probably caused by time-sync or filesystem.",
-                    );
-                }();
-            }
+                warnAbout("Unexpected modification time; probably caused by time-sync or filesystem.");
         });
 
         runIn(nirvana, {
@@ -369,35 +359,11 @@ version (Windows) @safe unittest
             getTimesWin(entry, creationTime, accessTime, modificationTime);
 
             if (creationTime < now)
-            {
-                () @trusted
-                {
-                    stderr.writeln(
-                        __FILE__, "(", __LINE__, "): ",
-                        "Unexpected creation time; probably caused by time-sync or filesystem.",
-                    );
-                }();
-            }
+                warnAbout("Unexpected creation time; probably caused by time-sync or filesystem.");
             if (accessTime < now)
-            {
-                () @trusted
-                {
-                    stderr.writeln(
-                        __FILE__, "(", __LINE__, "): ",
-                        "Unexpected access time; probably caused by time-sync or filesystem.",
-                    );
-                }();
-            }
+                warnAbout("Unexpected access time; probably caused by time-sync or filesystem.");
             if (modificationTime < now)
-            {
-                () @trusted
-                {
-                    stderr.writeln(
-                        __FILE__, "(", __LINE__, "): ",
-                        "Unexpected modification time; probably caused by time-sync or filesystem.",
-                    );
-                }();
-            }
+                warnAbout("Unexpected modification time; probably caused by time-sync or filesystem.");
         });
 
         remove(file);
@@ -426,25 +392,9 @@ version (Windows) @safe unittest
         getTimes(entry, accessTime, modificationTime);
 
         if (accessTime != thePast)
-        {
-            () @trusted
-            {
-                stderr.writeln(
-                    __FILE__, "(", __LINE__, "): ",
-                    "Unexpected access time; probably caused by time-sync or filesystem.",
-                );
-            }();
-        }
+            warnAbout("Unexpected access time; probably caused by time-sync or filesystem.");
         if (modificationTime != theFuture)
-        {
-            () @trusted
-            {
-                stderr.writeln(
-                    __FILE__, "(", __LINE__, "): ",
-                    "Unexpected modification time; probably caused by time-sync or filesystem.",
-                );
-            }();
-        }
+            warnAbout("Unexpected modification time; probably caused by time-sync or filesystem.");
 
         remove(file);
         assert(!file.exists);

--- a/std/file.d
+++ b/std/file.d
@@ -182,6 +182,19 @@ version (Windows) @safe unittest
     mkdirRecurse(root.buildPath("3", "4"));
     mkdirRecurse(root.buildPath("3", "5", "6"));
 
+    // DirEntry backwards compatibility test
+    runIn(root, {
+        runIn(nirvana, () {
+            foreach(entry; ".".dirEntries(SpanMode.shallow))
+            {
+                // This does not make sense on its own but asserts that
+                // existing (quirky) code works like it did in the past.
+                assert(absolutePath(entry.name        ) == nirvana.buildPath(entry.name));
+                assert(absolutePath(cast(string) entry) == nirvana.buildPath(entry.name));
+            }
+        });
+    });
+
     // DirEntry existance test
     runIn(root, {
         auto entry = ".".dirEntries(SpanMode.shallow).front;

--- a/std/file.d
+++ b/std/file.d
@@ -161,6 +161,13 @@ version (Windows) @safe unittest
         runIn(nirvana, () {
             assert(exists(entry));
         });
+
+        const file2 = "3/5/6";
+        auto entry2 = DirEntry(file2);
+        runIn(nirvana, () {
+            assert(!exists(file2));
+            assert( exists(entry2));
+        });
     });
 
     // Directory tree traversal test

--- a/std/file.d
+++ b/std/file.d
@@ -126,6 +126,9 @@ else version (Posix)
 else
     static assert(0);
 
+private enum isConvertibleToStringButNoDirEntry(T) = !is(T == DirEntry) && isConvertibleToString!T;
+private enum isDirEntry(T) = is(T == DirEntry);
+
 @safe unittest
 {
 	import std.path : absolutePath, buildPath;

--- a/std/file.d
+++ b/std/file.d
@@ -620,6 +620,18 @@ version (Windows) @safe unittest
             assertThrown(getAvailableDiskSpace(entry2));
         });
     });
+
+    // Slurping test
+    runIn(root, {
+        const string filePath = "1/test_" ~ lineNumberString!();
+        write(filePath, "10\r\n20");
+        scope (exit) remove(filePath);
+
+        auto entry = DirEntry(filePath);
+        runIn(nirvana, () @trusted {
+            assert(slurp!(int)(entry, "%d") == [10, 20]);
+        });
+    });
 }
 
 // Purposefully not documented. Use at your own risk
@@ -5990,6 +6002,15 @@ slurp(Types...)(string filename, scope const(char)[] format)
         app.put(toAdd);
     }
     return app.data;
+}
+
+/// ditto
+auto slurp(Types...)(const DirEntry filename, scope const(char)[] format)
+{
+    version (Windows)
+        return slurp!(Types)(filename.absoluteName, format);
+    else
+        return slurp!(Types)(filename.name, format);
 }
 
 ///

--- a/std/file.d
+++ b/std/file.d
@@ -241,6 +241,27 @@ version (Windows) @safe unittest
         assert(found[5] == 0);
     });
 
+    // Path determination test
+    runIn(root, {
+        import std.path : asAbsolutePath, asNormalizedPath;
+
+        const string relative = "1";
+        const string absolute = absolutePath(relative);
+
+        const entry = DirEntry(relative);
+        runIn(nirvana, {
+            import std.algorithm.comparison : equal;
+            assert(equal(
+                absolutePath(entry).asNormalizedPath,
+                absolute.asNormalizedPath
+            ));
+            assert(equal(
+                asAbsolutePath(entry).asNormalizedPath,
+                absolute.asNormalizedPath
+            ));
+        });
+    });
+
     // Renaming tests
     runIn(root, {
         // string-based renaming

--- a/std/file.d
+++ b/std/file.d
@@ -462,7 +462,7 @@ version (Windows) @safe unittest
     runIn(root, {
         const string dirPath = "3/5";
 
-        const string sentinel = lineNumberString!();
+        const string sentinel = "sentinel_" ~ lineNumberString!();
         const string sentinelPath = dirPath.buildPath(sentinel);
         write(sentinelPath, "…");
         scope (exit) remove(sentinelPath);
@@ -477,7 +477,7 @@ version (Windows) @safe unittest
 
     // Directory creation test
     runIn(root, {
-        const string dirPath = "3/5/" ~ lineNumberString!();
+        const string dirPath = "3/5/test_" ~ lineNumberString!();
         mkdir(dirPath);
 
         const dirEntry = DirEntry(dirPath);
@@ -493,7 +493,7 @@ version (Windows) @safe unittest
 
     // Directory removal test
     runIn(root, {
-        const string dirPath = "3/5/" ~ lineNumberString!();
+        const string dirPath = "3/5/test_" ~ lineNumberString!();
         mkdir(dirPath);
 
         assert(dirPath.exists);
@@ -504,7 +504,7 @@ version (Windows) @safe unittest
         assert(!dirPath.exists);
     });
 
-    // Directory non-removal test
+    // Directory tree non-removal test
     runIn(root, {
         import std.exception : assertThrown;
 

--- a/std/file.d
+++ b/std/file.d
@@ -399,6 +399,22 @@ version (Windows) @safe unittest
         remove(file);
         assert(!file.exists);
     });
+
+    // Attribute querying test
+    runIn(root, {
+        const string path = "1/2";
+        auto entry = DirEntry(path);
+
+        runIn(nirvana, {
+            const   attributes = getAttributes(entry);
+            assert( attributes.attrIsDir);
+            assert(!attributes.attrIsFile);
+
+            const   linkAttributes = getLinkAttributes(entry);
+            assert( linkAttributes.attrIsDir);
+            assert(!linkAttributes.attrIsFile);
+        });
+    });
 }
 
 // Purposefully not documented. Use at your own risk
@@ -2437,9 +2453,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 uint getAttributes(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return getAttributes!(StringTypeOf!R)(name);
+}
+
+/// ditto
+uint getAttributes(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return getAttributes(name.absoluteName);
+    else
+        return getAttributes(name.name);
 }
 
 /// getAttributes with a file
@@ -2526,9 +2552,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 uint getLinkAttributes(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return getLinkAttributes!(StringTypeOf!R)(name);
+}
+
+/// ditto
+uint getLinkAttributes(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return getLinkAttributes(name.absoluteName);
+    else
+        return getLinkAttributes(name.name);
 }
 
 ///

--- a/std/file.d
+++ b/std/file.d
@@ -145,13 +145,21 @@ version (Windows) @safe unittest
         assert(lineNumberString!().to!size_t() == __LINE__);
     }
 
+    /++
+        Saves the current working directory,
+        changes it to `dir` before executing `callback`
+        and eventually restores the original working directory.
+
+        The provided callback is free to call `chdir()` as it needs.
+        This function will always restore the original working directory.
+     +/
     static void runIn(string dir, void delegate() @safe callback)
     {
         const origWD = getcwd();
         assert(origWD.isAbsolute);
 
         chdir(dir);
-        scope (exit) chdir(origWD);
+        scope (exit) chdir(origWD); // always(!) restore the original working directory
 
         callback();
     }

--- a/std/file.d
+++ b/std/file.d
@@ -255,6 +255,23 @@ version (Windows) @safe unittest
             assert(!"x".exists);
         }
     }
+
+    // Removal test
+    {
+        chdir(root);
+        scope(exit) chdir(origWD);
+
+        const string file = "1/2/test.txt";
+        write(file, "…");
+        auto entry = DirEntry(file);
+        assert(file.exists);
+
+        chdir(nirvana);
+        remove(entry);
+
+        chdir(root);
+        assert(!file.exists);
+    }
 }
 
 // Purposefully not documented. Use at your own risk
@@ -1177,9 +1194,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 void remove(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     remove!(StringTypeOf!R)(name);
+}
+
+/// ditto
+void remove(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return remove(name.absoluteName);
+    else
+        return remove(name.name);
 }
 
 ///

--- a/std/file.d
+++ b/std/file.d
@@ -126,8 +126,8 @@ else version (Posix)
 else
     static assert(0);
 
-private enum isConvertibleToStringButNoDirEntry(T) = !is(T == DirEntry) && isConvertibleToString!T;
-private enum isDirEntry(T) = is(T == DirEntry);
+private enum isDirEntry(T) = is(T == DirEntry) || is(T == const(DirEntry)) || is(T == immutable(DirEntry));
+private enum isConvertibleToStringButNoDirEntry(T) = !isDirEntry!T && isConvertibleToString!T;
 
 version (Windows) @safe unittest
 {

--- a/std/file.d
+++ b/std/file.d
@@ -316,6 +316,31 @@ version (Windows) @safe unittest
             assert( "1".exists);
             assert(!"x".exists);
         }
+        // `const` variation
+        {
+            const string rp1 = "1";
+            const string rpX = "x";
+            const string ap1 = absolutePath(rp1);
+            const string apX = absolutePath(rpX);
+            const de1 = DirEntry("1");
+            rename("1", "x");
+            const deX = DirEntry("x");
+
+            runIn(nirvana, {
+                rename(apX, de1);
+            });
+            assert( "1".exists);
+            assert(!"x".exists);
+
+            runIn(nirvana, {
+                rename(de1, apX);
+            });
+            runIn(nirvana, {
+                rename(deX, ap1);
+            });
+            assert( "1".exists);
+            assert(!"x".exists);
+        }
         // Dual-DirEntry renaming with `chdir()`
         {
             auto de1 = DirEntry("1");

--- a/std/file.d
+++ b/std/file.d
@@ -3944,6 +3944,8 @@ else version (Windows)
             _timeLastAccessed = FILETIMEToSysTime(&fd.ftLastAccessTime);
             _timeLastModified = FILETIMEToSysTime(&fd.ftLastWriteTime);
             _attributes = fd.dwFileAttributes;
+
+            this.absolutizeName();
         }
 
         private void absolutizeName() pure return scope

--- a/std/file.d
+++ b/std/file.d
@@ -3809,7 +3809,7 @@ else version (Windows)
     {
     @safe:
     public:
-        alias name this;
+        deprecated("0xEAB") alias name this; // TODO: undo temporary deprecation
 
         this(return scope string path)
         {
@@ -3918,7 +3918,7 @@ else version (Posix)
     {
     @safe:
     public:
-        alias name this;
+        deprecated("0xEAB") alias name this; // TODO: undo temporary deprecation
 
         this(return scope string path)
         {

--- a/std/file.d
+++ b/std/file.d
@@ -5698,7 +5698,8 @@ private struct DirIteratorImpl
             HANDLE h;
         }
 
-        bool stepIn(string directory) @safe
+        bool stepIn(Path)(Path directory) @safe
+        if (isString!Path)
         {
             import std.path : chainPath;
             auto searchPattern = chainPath(directory, "*.*");
@@ -5714,7 +5715,8 @@ private struct DirIteratorImpl
             return toNext(false, &_findinfo);
         }
 
-        bool stepIn(const DirEntry directory)
+        bool stepIn(Path)(Path directory)
+        if (isDirEntry!Path)
         {
             return this.stepIn(directory.absoluteName);
         }

--- a/std/file.d
+++ b/std/file.d
@@ -280,6 +280,32 @@ version (Windows) @safe unittest
         });
     });
 
+    // Path normalization test
+    runIn(root, {
+        import std.path : asNormalizedPath, buildNormalizedPath;
+        import std.range : array;
+
+        const string relative = "./3/4/../5/../5/6";
+        assert(!isAbsolute(relative));
+
+        assert(!isAbsolute(buildNormalizedPath(relative)));
+        assert(!isAbsolute(asNormalizedPath(relative).array));
+
+        const entry = DirEntry(relative);
+        runIn(nirvana, {
+            import std.algorithm.comparison : equal;
+
+            static immutable expected = buildNormalizedPath("../r/3/5/6");
+            assert(buildNormalizedPath(entry)              == expected);
+            assert(buildNormalizedPath(entry, "../6")      == expected);
+            assert(buildNormalizedPath(entry, "../6", ".") == expected);
+            assert(equal(asNormalizedPath(entry), expected));
+
+            assert(!isAbsolute(buildNormalizedPath(entry)));
+            assert(!isAbsolute(asNormalizedPath(entry).array));
+        });
+    });
+
     // Renaming tests
     runIn(root, {
         // string-based renaming

--- a/std/file.d
+++ b/std/file.d
@@ -133,9 +133,13 @@ private enum isDirEntry(T) = is(T == DirEntry);
 {
     import std.path : absolutePath, buildPath;
 
-    string root = deleteme();
+    string parent = deleteme().absolutePath;
+    string root = parent.buildPath("r");
     mkdirRecurse(root);
     scope (exit) rmdirRecurse(parent);
+
+    string nirvana = parent.buildPath("nirvana");
+    mkdir(nirvana);
 
     mkdirRecurse(root.buildPath("1", "2"));
     mkdirRecurse(root.buildPath("3", "4"));

--- a/std/file.d
+++ b/std/file.d
@@ -3946,15 +3946,13 @@ else version (Windows)
             _attributes = fd.dwFileAttributes;
         }
 
-        private void absolutizeName()
+        private void absolutizeName() pure return scope
         {
-            import std.path : absolutePath, isAbsolute;
-
-            if (_name.isAbsolute)
-                return;
+            import std.path : absolutePath;
 
             const rel = _name;
-            const abs = rel.absolutePath;
+            alias abs = _name;
+            _name = _name.absolutePath;
             const idx = abs.length - rel.length;
 
             if (idx == 0)

--- a/std/file.d
+++ b/std/file.d
@@ -449,10 +449,12 @@ version (Windows) @safe unittest
         const dirEntry = DirEntry(dirPath);
 
         runIn(nirvana, {
-            assert( isFile(fileEntry));
-            assert(!isDir (fileEntry));
-            assert(!isFile( dirEntry));
-            assert( isDir ( dirEntry));
+            assert( isFile   (fileEntry));
+            assert(!isDir    (fileEntry));
+            assert(!isSymlink(fileEntry));
+            assert(!isFile   ( dirEntry));
+            assert( isDir    ( dirEntry));
+            assert(!isSymlink( dirEntry));
         });
     });
 
@@ -3203,9 +3205,19 @@ if (isSomeFiniteCharInputRange!R && !isConvertibleToString!R)
 
 /// ditto
 @property bool isSymlink(R)(auto ref R name)
-if (isConvertibleToString!R)
+if (isConvertibleToStringButNoDirEntry!R)
 {
     return name.isSymlink!(StringTypeOf!R);
+}
+
+/// ditto
+@property bool isSymlink(R)(auto ref R name)
+if (isDirEntry!R)
+{
+    version (Windows)
+        return isSymlink(name.absoluteName);
+    else
+        return isSymlink(name.name);
 }
 
 @safe unittest

--- a/std/file.d
+++ b/std/file.d
@@ -131,7 +131,7 @@ private enum isConvertibleToStringButNoDirEntry(T) = !isDirEntry!T && isConverti
 
 version (Windows) @safe unittest
 {
-    import std.path : absolutePath, buildPath;
+    import std.path : absolutePath, buildPath, isAbsolute;
 
     template lineNumberString(size_t line = __LINE__)
     {
@@ -148,6 +148,8 @@ version (Windows) @safe unittest
     static void runIn(string dir, void delegate() @safe callback)
     {
         const origWD = getcwd();
+        assert(origWD.isAbsolute);
+
         chdir(dir);
         scope (exit) chdir(origWD);
 

--- a/std/file.d
+++ b/std/file.d
@@ -126,7 +126,7 @@ else version (Posix)
 else
     static assert(0);
 
-private enum isDirEntry(T) = is(T == DirEntry) || is(T == const(DirEntry)) || is(T == immutable(DirEntry));
+private enum isDirEntry(T) = is(Unconst!T == DirEntry);
 private enum isConvertibleToStringButNoDirEntry(T) = !isDirEntry!T && isConvertibleToString!T;
 
 version (Windows) @safe unittest

--- a/std/file.d
+++ b/std/file.d
@@ -344,7 +344,7 @@ version (Windows) @safe unittest
         });
     });
 
-    // Windows File-time querying test
+    // Windows-only file-time querying test
     version (Windows) runIn(root, {
         import std.datetime : Clock, SysTime;
         import std.stdio : stderr;

--- a/std/path.d
+++ b/std/path.d
@@ -1783,7 +1783,7 @@ immutable(char)[] buildNormalizedPath(const DirEntry path0, const(char[])[] path
         return buildNormalizedPath!char(arg0 ~ paths);
     }
     else
-        return buildNormalizedPath!char(arg0 ~ paths);
+        return buildNormalizedPath!char(path0 ~ paths);
 }
 
 ///


### PR DESCRIPTION
*I’m opening this as a proof-of-concept PR for my own peace of mind.*

Currently, a good chunk of file- and path-related functions accepts `DirEntry` structures as parameter through implicit conversion to `string` provided by the `alias name this` property of `DirEntry`. This unfortunately comes with the downside that it pins relative paths to the current working directory at the time of the function call. While this is fine in theory, in practice the current working directory might no longer be the one that the string stored in a `DirEntry` structure is relative to. Though obviously a bug in user code, it also poses an unnecessary footgun — as outlined in #9584.

This *could* be one of the better ways to solve the underlying issue. I’ve attempted to keep things as backwards-compatible as possible.

The current implementation focuses on Windows where absolute paths are not applicable to restrictions imposed by filesystem permissions of parent directories. A POSIX implementation would likely be more complex and have to involve the usage of more specific system APIs that work on handles instead of path strings and such.

Speaking of #9584, we obviously cannot fix the risks imposed by code that explicitly converts `DirEntry` to `string` without greater breakage.

As @jmdavis has already hinted, though, there’s a change we might prefer to call it a day for Phobos v2 and provide an overall better API in Phobos v3.