### PR TITLE
std.container.rbtree: Return range elements by ref

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -679,7 +679,7 @@ private struct RBRange(N)
     /**
      * Returns the first element in the range
      */
-    @property Elem front()
+    ref @property Elem front()
     {
         return _begin.value;
     }
@@ -687,7 +687,7 @@ private struct RBRange(N)
     /**
      * Returns the last element in the range
      */
-    @property Elem back()
+    ref @property Elem back()
     {
         return _end.prev.value;
     }
@@ -1036,7 +1036,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      *
      * Complexity: $(BIGOH 1)
      */
-    inout(Elem) front() inout
+    ref inout(Elem) front() inout
     {
         return _begin.value;
     }
@@ -1046,7 +1046,7 @@ if (is(typeof(binaryFun!less(T.init, T.init))))
      *
      * Complexity: $(BIGOH log(n))
      */
-    inout(Elem) back() inout
+    ref inout(Elem) back() inout
     {
         return _end.prev.value;
     }

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -737,6 +737,10 @@ private struct RBRange(N)
  * elements `a` and `b`, $(D less(a, b) == !less(b, a)). $(D less(a, a)) should
  * always equal `false`.
  *
+ * Care should also be taken to not modify elements in the tree (e.g. via `front` /
+ * `back`, which return by `ref`) in a way which would affect the order defined by
+ * the `less` predicate.
+ *
  * If `allowDuplicates` is set to `true`, then inserting the same element more than
  * once continues to add more elements.  If it is `false`, duplicate elements are
  * ignored on insertion.  If duplicates are allowed, then new elements are


### PR DESCRIPTION
I don't see any downsides, and it will allow updating value types in-place as we're iterating over the tree.

Some counter-arguments I can think of:

- What if this is used to change the key such that the tree is no longer ordered?
  - Well you can do that already anyway if `Elem` is a reference type, it's not like we're returning `const`.

- What if the tree is changed while we're holding a reference to a node?
  - We're allocating nodes with `new`, so even if they're gone from the tree, it shouldn't result in a dangling pointer.

Did I miss anything?

CC @schveiguy 