### PR TITLE
Polish `getrandom()` backwards compatibility shim

### DIFF
--- a/changelog/emulate_getrandom.dd
+++ b/changelog/emulate_getrandom.dd
@@ -1,0 +1,19 @@
+`getrandom()` backwards compatibility shim
+
+To restore compatibility with older Linux platforms where `getrandom()` is
+unavailable either due to an outdated kernel or a legacy C library, Phobos now
+ships with a shim that emulates a limited subset of `getrandom()` by reading
+random bytes from `/dev/urandom`.
+
+To enable the shim, build DMD and Phobos with the environment variable
+`LINUX_LEGACY_EMULATE_GETRANDOM` set to `1`.
+
+```
+cd phobos
+LINUX_LEGACY_EMULATE_GETRANDOM=1 make
+```
+
+This functionality is a temporary fix and expected to be removed again soon
+by an upcoming release (approx. v2.112.0 or v2.113.0).
+The expected change is to replace the current “binding or shim” solution with
+a syscall wrapper and automatic `/dev/urandom` fallback.

--- a/changelog/emulate_getrandom.dd
+++ b/changelog/emulate_getrandom.dd
@@ -2,8 +2,8 @@
 
 To restore compatibility with older Linux platforms where `getrandom()` is
 unavailable either due to an outdated kernel or a legacy C library, Phobos now
-ships with a shim that emulates a limited subset of `getrandom()` by reading
-random bytes from `/dev/urandom`.
+ships with a shim that emulates a limited subset of `getrandom()`’s behavior
+by reading random bytes from `/dev/urandom`.
 
 To enable the shim, build DMD and Phobos with the environment variable
 `LINUX_LEGACY_EMULATE_GETRANDOM` set to `1`.

--- a/std/random.d
+++ b/std/random.d
@@ -1782,7 +1782,6 @@ version (linux)
 
             `getrandom()` was added to the GNU C Library in v2.25.
          +/
-        //pragma(msg, "`getrandom()` emulation for legacy Linux targets is enabled.");
 
         /+
             On modern kernels (5.6+), `/dev/random` would behave more similar

--- a/std/random.d
+++ b/std/random.d
@@ -1782,7 +1782,7 @@ version (linux)
 
             `getrandom()` was added to the GNU C Library in v2.25.
          +/
-        pragma(msg, "`getrandom()` emulation for legacy Linux targets is enabled.");
+        //pragma(msg, "`getrandom()` emulation for legacy Linux targets is enabled.");
 
         /+
             On modern kernels (5.6+), `/dev/random` would behave more similar


### PR DESCRIPTION
Adds a changelog entry.

Comments out the message pragma.
I wouldn’t mind it, but it’s really a bit spammy. Also see Atila’s upvote on my message suggesting this change: <https://github.com/dlang/phobos/pull/10741#discussion_r2030025301>