### PR TITLE
std.typecons: Make Nullable.toString always a template

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3836,22 +3836,22 @@ struct Nullable(T)
      * Returns:
      *     A `string` if `writer` and `fmt` are not set; `void` otherwise.
      */
-    string toString()
+    string toString()()
     {
         import std.array : appender;
         auto app = appender!string();
         auto spec = singleSpec("%s");
-        toString(app, spec);
+        this.toString(app, spec);
         return app.data;
     }
 
     /// ditto
-    string toString() const
+    string toString()() const
     {
         import std.array : appender;
         auto app = appender!string();
         auto spec = singleSpec("%s");
-        toString(app, spec);
+        this.toString(app, spec);
         return app.data;
     }
 


### PR DESCRIPTION
Because some overloads of `Nullable!T.toString` are not templates, instantiating a `Nullable!T` also always instantiates `formatValue!T`, and all of its dependencies.

For large type hierarchies, this can add a significant amount of compilation overhead.

We can avoid this by making remaining overloads of `Nullable!T.toString` templates as well, similar to `Tuple`.

Timings from internal motivating use case:

Before:

```
9.00user 1.38system 0:10.57elapsed 98%CPU (0avgtext+0avgdata 5851516maxresident)k
21968inputs+48144outputs (0major+1468687minor)pagefaults 0swaps
```

After:

```
5.11user 0.61system 0:05.75elapsed 99%CPU (0avgtext+0avgdata 2762392maxresident)k
0inputs+34528outputs (0major+685900minor)pagefaults 0swaps
```
