### PR TITLE
std.file.rename: avoid segfault on null string (#10727)

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -969,6 +969,18 @@ if (isConvertibleToString!RF || isConvertibleToString!RT)
     assert(t2.readText == "2");
 }
 
+unittest
+{
+    import std.file;
+    import std.exception : assertThrown;
+
+    string f = null;
+
+    // Check if FileException is thrown for invalid rename
+    assertThrown!FileException(rename("", f));
+    assertThrown!FileException(rename(f, ""));
+}
+
 private void renameImpl(scope const(char)[] f, scope const(char)[] t,
                         scope const(FSChar)* fromz, scope const(FSChar)* toz) @trusted
 {
@@ -983,10 +995,10 @@ private void renameImpl(scope const(char)[] f, scope const(char)[] t,
             import std.conv : to, text;
 
             if (!f)
-                f = to!(typeof(f))(fromz[0 .. wcslen(fromz)]);
+                f = fromz is null ? null : to!(typeof(f))(fromz[0 .. wcslen(fromz)]);
 
             if (!t)
-                t = to!(typeof(t))(toz[0 .. wcslen(toz)]);
+                t = toz is null ? null : to!(typeof(t))(toz[0 .. wcslen(toz)]);
 
             enforce(false,
                 new FileException(


### PR DESCRIPTION
Fixes #10727: std.file.rename segfaults when source or destination is null on Windows.

- Check for null `fromz` and `toz` before calling wcslen.
- If null, leave f/t null instead of slicing.
- Added runtime unittests to assert FileException is thrown for null inputs
  (rename("", null) and rename(null, "")).
