### PR TITLE
Revert "std.allocator: Comment out broken class instance size test"

### DIFF
--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -63,8 +63,7 @@ unittest
     class C2 { char c; }
     static assert(stateSize!C2 == 4 * size_t.sizeof);
     static class C3 { char c; }
-    // Uncomment test after dmd issue closed https://github.com/dlang/dmd/issues/21065
-    //static assert(stateSize!C3 == 3 * size_t.sizeof);
+    static assert(stateSize!C3 == 2 * size_t.sizeof + char.sizeof);
 }
 
 /**


### PR DESCRIPTION
Reverts dlang/phobos#10717

Behaviour has been clarified.