### PR TITLE
Fix #10785 - Fix invalid access of GC memory from destructor when inside a GC finalizer with debug build

### DIFF
--- a/std/uni/package.d
+++ b/std/uni/package.d
@@ -1785,7 +1785,9 @@ alias sharSwitchLowerBound = sharMethod!switchUniformLowerBound;
     {
         debug
         {
-            arr[] = cast(typeof(T.init[0]))(0xdead_beef);
+            import core.memory : GC;
+            if (!__ctfe && !GC.inFinalizer) // only do this if we are not in the GC finalizer
+                arr[] = cast(typeof(T.init[0]))(0xdead_beef);
         }
         arr = null;
     }


### PR DESCRIPTION
This caused a segfault in testing the new GC on windows, as this new GC is more aggressive uncomitting freed memory.

redo of #10786