### PR TITLE
std.stdio: Make makeGlobal @trusted

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -5239,7 +5239,7 @@ enum StdFileHandle: string
 }
 
 // Undocumented but public because the std* handles are aliasing it.
-@property ref File makeGlobal(StdFileHandle _iob)()
+@property ref File makeGlobal(StdFileHandle _iob)() @trusted
 {
     __gshared File.Impl impl;
     __gshared File result;


### PR DESCRIPTION
Fixes issue https://github.com/dlang/phobos/issues/10794

IDK if it makes sense but a function without arguments seems likely to have a memory-safe interface.
