### PR TITLE
Fix dlang#10798 — Reimplement FFT solver to support `@nogc nothrow pure @safe`

### DIFF
--- a/changelog/add_nogc_fft.dd
+++ b/changelog/add_nogc_fft.dd
@@ -1,0 +1,45 @@
+Add `FFT` that doesn’t use GC.
+
+`FFT` is an FFT solver compatible with `@nogc`, `nothrow`, `@safe`, and `pure`.
+```D
+@nogc nothrow pure @safe void fun()
+{
+    import std.complex;
+
+    enum size = 8;
+    float[size] arr = [1,2,3,4,5,6,7,8];
+    Complex!float[size] fft;
+
+    immutable fftSolver = FFT(size);
+
+    fftSolver.compute(arr[], fft[]);
+}
+```
+
+Convenience functions now use `FFT`. In effect, `fft(R, Ret)` and
+`inverseFft(R, Ret)` also can be used in `@nogc`, `nothrow`, `pure`,
+and `@safe` code.
+
+`FFT` can also avoid dynamic memory allocation by using a preallocated buffer.
+However, this is not `@safe`. The buffer must not be modified or freed within
+the lifetime of the `FFT` instance.
+
+```D
+@nogc nothrow pure @system void unsafeFun()
+{
+    import std.complex;
+
+    enum size = 8;
+    float[size] arr = [1,2,3,4,5,6,7,8];
+    Complex!float[size] fft;
+
+    enum bufferSize = FFT.requiredBufferSize(size);
+    ubyte[bufferSize] buff;
+    immutable fftSolver = FFT(size, buff);
+
+    fftSolver.compute(arr[], fft[]);
+}
+```
+
+`Fft` class is still available for backwards compatibility. It is not recommended
+for new code.

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3706,6 +3706,7 @@ public:
     this(size_t size)
     {
         import core.stdc.stdlib;
+        import core.exception : onOutOfMemoryError;
         if (size == 0)
         {
             this([]);
@@ -3713,6 +3714,9 @@ public:
         else {
             immutable bufferSize = 2*size;
             this.pStorage = cast(lookup_t*)malloc(lookup_t.sizeof*bufferSize);
+            if (!this.pStorage) {
+                onOutOfMemoryError();
+            }
             this(pStorage[0..bufferSize]);
         }
     }

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3483,6 +3483,21 @@ private:
 
 public:
 
+    /// Returns the size of a lookup table required for the given FFT size.
+    static size_t lookupTableSize(size_t fftSize) @nogc nothrow => fftSize*2;
+
+    ///
+    unittest {
+        enum size = 8;
+        float[size] arr = [1,2,3,4,5,6,7,8];
+        Complex!float[size] fft1;
+
+        lookup_t[FFT.lookupTableSize(size)] buff;
+        auto fft = FFT(buff);
+
+        fft.compute(arr[], fft1[]);
+    }
+
     /**Create an `FFT` object for computing fast Fourier transforms of
      * power of two sizes of `size` or smaller.  `size` must be a
      * power of two.
@@ -3493,7 +3508,7 @@ public:
     }
 
     /**This constructor takes a preallocated buffer for a lookup table.
-     * The table must be twice as big as the desired FFT size.
+     * Use `lookupTableSize` to calculate the required buffer size.
      *
      * Unsafe because the `memSpace` buffer will be cast to `immutable`.
      */
@@ -4210,14 +4225,15 @@ void inverseFft(Ret, R)(R range, Ret buf)
 {
     static struct C { float re, im; }
 
-    float[8] arr = [1,2,3,4,5,6,7,8];
-    C[8] fft1;
-    C[8] inv;
+    enum size = 8;
+    float[size] arr = [1,2,3,4,5,6,7,8];
+    C[size] fft1;
+    C[size] inv;
 
     fft(arr[], fft1[]);
     inverseFft(fft1[], inv[]);
 
-    lookup_t[16] buff;
+    lookup_t[FFT.lookupTableSize(size)] buff;
     auto fft = FFT(buff);
 
     fft.compute(arr[], fft1[]);

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3994,7 +3994,7 @@ void inverseFft(Ret, R)(R range, Ret buf)
     return fftObj.computeInverse!(Ret, R)(range, buf);
 }
 
-@system unittest
+pure @system unittest
 {
     import std.algorithm;
     import std.conv;
@@ -4065,7 +4065,7 @@ void inverseFft(Ret, R)(R range, Ret buf)
 }
 
 // https://github.com/dlang/phobos/issues/10796
-@system unittest
+pure @system unittest
 {
     import std.algorithm;
     import std.range;
@@ -4085,7 +4085,7 @@ void inverseFft(Ret, R)(R range, Ret buf)
 }
 
 // https://github.com/dlang/phobos/issues/10798
-@nogc nothrow @system unittest
+@nogc nothrow pure @system unittest
 {
     static struct C { float re, im; }
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3767,8 +3767,14 @@ private:
 public:
 
     /// Returns the size of a buffer required for the given FFT size.
-    static size_t requiredBufferSize(size_t fftSize) @nogc nothrow pure @safe {
-        return lookup_t.sizeof*fftSize*2;
+    static size_t requiredBufferSize(size_t fftSize) @nogc nothrow pure @safe
+    {
+        import core.checkedint : mulu;
+        immutable nitems = fftSize*2;
+        bool overflow;
+        immutable nbytes = mulu(nitems, lookup_t.sizeof, overflow);
+        if (overflow) assert(false, "multiplication overflowed");
+        return nbytes;
     }
 
     ///
@@ -3790,7 +3796,7 @@ public:
      * power of two.
      */
     this(size_t size) @nogc nothrow pure @safe
-	in (size == 0 || isPowerOf2(size),
+    in (size == 0 || isPowerOf2(size),
             "Can only do FFTs on ranges with a size that is a power of two.")
     {
         import core.memory : pureMalloc;

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3869,7 +3869,7 @@ public:
         else
         {
             immutable bufferSize = 2*size;
-            this.pStorage = cast(lookup_t*)malloc(lookup_t.sizeof*bufferSize);
+            this.pStorage = cast(lookup_t*) malloc(lookup_t.sizeof*bufferSize);
             if (!this.pStorage)
             {
                 onOutOfMemoryError();
@@ -3946,7 +3946,7 @@ public:
             }
         }
 
-        this.table = cast(immutable)memSpace;
+        this.table = cast(immutable) memSpace;
     }
 
     ///

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3733,11 +3733,13 @@ public:
         }
         else if (range.length == 1)
         {
-            static if (isComplexLike!(ElementType!R)) {
+            static if (isComplexLike!(ElementType!R))
+			{
                 buf[0].re = range[0].re;
                 buf[0].im = range[0].im;
             }
-            else {
+            else
+			{
                 buf[0].re = range[0];
                 buf[0].im = 0;
             }
@@ -4143,13 +4145,15 @@ if (isComplexLike!(ElementType!Ret))
 in (range.length == 2)
 in (buf.length == 2)
 {
-    static if (isComplexLike!(ElementType!R)) {
+    static if (isComplexLike!(ElementType!R)) 
+	{
         buf[0].re = range[0].re + range[1].re;
         buf[0].im = range[0].im + range[1].im;
         buf[1].re = range[0].re - range[1].re;
         buf[1].im = range[0].im - range[1].im;
     }
-    else {
+    else 
+	{
         buf[0].re = range[0] + range[1];
         buf[0].im = 0;
         buf[1].re = range[0] - range[1];

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3357,8 +3357,7 @@ if (!isIntegral!T &&
 // though floats seem accurate enough for all practical purposes, since
 // they pass the "isClose(inverseFft(fft(arr)), arr)" test even for
 // size 2 ^^ 22.
-/// Value type for `FFT` lookup table
-alias lookup_t = float;
+private alias lookup_t = float;
 
 /**A class for performing fast Fourier transforms of power of two sizes.
  * This class encapsulates a large amount of state that is reusable when

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -4333,7 +4333,7 @@ in (buf.length == 2)
         buf[0].im = range[0].im + range[1].im;
         buf[1].re = range[0].re - range[1].re;
         buf[1].im = range[0].im - range[1].im;
-}
+    }
 }
 
 // Hard-coded base case for FFT of size 4.  Doesn't work as well as the size

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3413,7 +3413,7 @@ public:
     if (isFloatingPoint!F && isRandomAccessRange!R)
     {
         enforceSize(range);
-        return impl.fft(range);
+        return impl.compute(range);
     }
 
     /**Same as the overload, but allows for the results to be stored in a user-
@@ -3427,7 +3427,7 @@ public:
     in (buf.length == range.length)
     {
         enforceSize(range);
-        impl.fft(range, buf);
+        impl.compute(range, buf);
     }
 
     /**
@@ -3446,7 +3446,7 @@ public:
     if (isRandomAccessRange!R && isComplexLike!(ElementType!R) && isFloatingPoint!F)
     {
         enforceSize(range);
-        return impl.inverseFft(range);
+        return impl.computeInverse(range);
     }
 
     /**
@@ -3458,7 +3458,7 @@ public:
     if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
     {
         enforceSize(range);
-        impl.inverseFft(range, buf);
+        impl.computeInverse(range, buf);
     }
 }
 
@@ -3587,7 +3587,7 @@ private:
             auto oddsImag = OddToImaginary(range);
         }
 
-        fft(oddsImag, buf[0..$ / 2]);
+        compute(oddsImag, buf[0..$ / 2]);
         auto evenFft = buf[0..$ / 2];
         auto oddFft = buf[$ / 2..$];
         immutable halfN = evenFft.length;
@@ -3807,7 +3807,7 @@ public:
      * Conventions: The exponent is negative and the factor is one,
      *              i.e., output[j] := sum[ exp(-2 PI i j k / N) input[k] ].
      */
-    Complex!F[] fft(F = double, R)(R range) const
+    Complex!F[] compute(F = double, R)(R range) const
     if (isFloatingPoint!F && isRandomAccessRange!R)
     in (range.length <= size, "FFT size mismatch.")
     {
@@ -3821,7 +3821,7 @@ public:
         // Don't waste time initializing the memory for ret.
         ret = uninitializedArray!(Complex!F[])(range.length);
 
-        fft(range,  ret);
+        compute(range,  ret);
         return ret;
     }
 
@@ -3831,7 +3831,7 @@ public:
      * complex-like.  This means that they must have a .re and a .im member or
      * property that can be both read and written and are floating point numbers.
      */
-    void fft(Ret, R)(R range, Ret buf) const
+    void compute(Ret, R)(R range, Ret buf) const
     if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
     in (range.length <= size, "FFT size mismatch.")
     in (buf.length == range.length)
@@ -3888,7 +3888,7 @@ public:
      * Conventions: The exponent is positive and the factor is 1/N, i.e.,
      *              output[j] := (1 / N) sum[ exp(+2 PI i j k / N) input[k] ].
      */
-    Complex!F[] inverseFft(F = double, R)(R range) const
+    Complex!F[] computeInverse(F = double, R)(R range) const
     if (isRandomAccessRange!R && isComplexLike!(ElementType!R) && isFloatingPoint!F)
     in (range.length <= size, "FFT size mismatch.")
     {
@@ -3902,7 +3902,7 @@ public:
         // Don't waste time initializing the memory for ret.
         ret = uninitializedArray!(Complex!F[])(range.length);
 
-        inverseFft(range, ret);
+        computeInverse(range, ret);
         return ret;
     }
 
@@ -3911,12 +3911,12 @@ public:
      * must be a random access range with slicing, and its elements
      * must be some complex-like type.
      */
-    void inverseFft(Ret, R)(R range, Ret buf) const
+    void computeInverse(Ret, R)(R range, Ret buf) const
     if (isRandomAccessRange!Ret && isComplexLike!(ElementType!Ret) && hasSlicing!Ret)
     in (range.length <= size, "FFT size mismatch.")
     {
         auto swapped = map!swapRealImag(range);
-        fft(swapped,  buf);
+        compute(swapped,  buf);
 
         immutable lenNeg1 = 1.0 / buf.length;
         foreach (ref elem; buf)
@@ -3939,28 +3939,28 @@ public:
 Complex!F[] fft(F = double, R)(R range)
 {
     auto fftObj = FFTImpl(range.length);
-    return fftObj.fft!(F, R)(range);
+    return fftObj.compute!(F, R)(range);
 }
 
 /// ditto
 void fft(Ret, R)(R range, Ret buf)
 {
     auto fftObj = FFTImpl(range.length);
-    return fftObj.fft!(Ret, R)(range, buf);
+    return fftObj.compute!(Ret, R)(range, buf);
 }
 
 /// ditto
 Complex!F[] inverseFft(F = double, R)(R range)
 {
     auto fftObj = FFTImpl(range.length);
-    return fftObj.inverseFft!(F, R)(range);
+    return fftObj.computeInverse!(F, R)(range);
 }
 
 /// ditto
 void inverseFft(Ret, R)(R range, Ret buf)
 {
     auto fftObj = FFTImpl(range.length);
-    return fftObj.inverseFft!(Ret, R)(range, buf);
+    return fftObj.computeInverse!(Ret, R)(range, buf);
 }
 
 @system unittest

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3733,15 +3733,15 @@ public:
         }
         else if (range.length == 1)
         {
-            static if (isComplexLike!(ElementType!R))
-			{
-                buf[0].re = range[0].re;
-                buf[0].im = range[0].im;
-            }
-            else
-			{
+            static if (isNumeric!(ElementType!R))
+            {
                 buf[0].re = range[0];
                 buf[0].im = 0;
+            }
+            else
+            {
+                buf[0].re = range[0].re;
+                buf[0].im = range[0].im;
             }
             return;
         }
@@ -4145,19 +4145,19 @@ if (isComplexLike!(ElementType!Ret))
 in (range.length == 2)
 in (buf.length == 2)
 {
-    static if (isComplexLike!(ElementType!R)) 
-	{
-        buf[0].re = range[0].re + range[1].re;
-        buf[0].im = range[0].im + range[1].im;
-        buf[1].re = range[0].re - range[1].re;
-        buf[1].im = range[0].im - range[1].im;
-    }
-    else 
-	{
+    static if (isNumeric!(ElementType!R))
+    {
         buf[0].re = range[0] + range[1];
         buf[0].im = 0;
         buf[1].re = range[0] - range[1];
         buf[1].im = 0;
+    }
+    else
+    {
+        buf[0].re = range[0].re + range[1].re;
+        buf[0].im = range[0].im + range[1].im;
+        buf[1].re = range[0].re - range[1].re;
+        buf[1].im = range[0].im - range[1].im;
     }
 }
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3489,6 +3489,7 @@ public:
     ///
     unittest
     {
+        import std.complex : Complex;
         enum size = 8;
         float[size] arr = [1,2,3,4,5,6,7,8];
         Complex!float[size] fft1;

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3487,7 +3487,8 @@ public:
     static size_t lookupTableSize(size_t fftSize) @nogc nothrow => fftSize*2;
 
     ///
-    unittest {
+    unittest
+    {
         enum size = 8;
         float[size] arr = [1,2,3,4,5,6,7,8];
         Complex!float[size] fft1;
@@ -3865,10 +3866,12 @@ public:
         {
             this([]);
         }
-        else {
+        else
+        {
             immutable bufferSize = 2*size;
             this.pStorage = cast(lookup_t*)malloc(lookup_t.sizeof*bufferSize);
-            if (!this.pStorage) {
+            if (!this.pStorage)
+            {
                 onOutOfMemoryError();
             }
             this(pStorage[0..bufferSize]);

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3487,7 +3487,7 @@ public:
     static size_t lookupTableSize(size_t fftSize) @nogc nothrow => fftSize*2;
 
     ///
-    unittest
+    @system unittest
     {
         import std.complex : Complex;
         enum size = 8;
@@ -3861,7 +3861,7 @@ public:
      */
     this(size_t size) @nogc nothrow
     {
-        import core.stdc.stdlib;
+        import core.stdc.stdlib : malloc;
         import core.exception : onOutOfMemoryError;
         if (size == 0)
         {
@@ -3875,7 +3875,7 @@ public:
             {
                 onOutOfMemoryError();
             }
-            this(pStorage[0..bufferSize]);
+            this(pStorage[0 .. bufferSize]);
         }
     }
 
@@ -3912,7 +3912,7 @@ public:
          * The index of the `i`th lookup is `2^^i` and the length is also `2^^i`.
          */
 
-        memSpace[0..2] = float.nan;
+        memSpace[0 .. 2] = float.nan;
 
         auto lastRow = memSpace[$ - size .. $];
         lastRow[0] = 0;  // -sin(0) == 0.
@@ -3956,7 +3956,7 @@ public:
     ///
     ~this() @nogc nothrow
     {
-        import core.stdc.stdlib;
+        import core.stdc.stdlib : free;
         free(pStorage);
     }
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3357,7 +3357,8 @@ if (!isIntegral!T &&
 // though floats seem accurate enough for all practical purposes, since
 // they pass the "isClose(inverseFft(fft(arr)), arr)" test even for
 // size 2 ^^ 22.
-private alias lookup_t = float;
+/// Value type for `FFT` lookup table
+alias lookup_t = float;
 
 /**A class for performing fast Fourier transforms of power of two sizes.
  * This class encapsulates a large amount of state that is reusable when

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3463,7 +3463,7 @@ public:
 }
 
 /**A struct for performing fast Fourier transforms of power of two sizes.
- * This class encapsulates a large amount of state that is reusable when
+ * This struct encapsulates a large amount of state that is reusable when
  * performing multiple FFTs of sizes smaller than or equal to that specified
  * in the constructor. This results in substantial speedups when performing
  * multiple FFTs with a known maximum size.  However,
@@ -3818,8 +3818,6 @@ public:
 
     /**This constructor takes a preallocated buffer for a lookup table.
      * Use `lookupTableSize` to calculate the required buffer size.
-     *
-     * Unsafe because the `memSpace` buffer will be cast to `immutable`.
      */
     this(size_t size, return scope void[] buffer) @nogc nothrow pure @system
     in (size == 0 || isPowerOf2(size),
@@ -3981,11 +3979,6 @@ public:
 
 /**Convenience functions that create an `Fft` object, run the FFT or inverse
  * FFT and return the result.  Useful for one-off FFTs.
- *
- * Note:  In addition to convenience, these functions are slightly more
- *        efficient than manually creating an Fft object for a single use,
- *        as the Fft object is deterministically destroyed before these
- *        functions return.
  */
 Complex!F[] fft(F = double, R)(R range)
 {

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3374,7 +3374,7 @@ alias lookup_t = float;
 final class Fft
 {
 private:
-    FFTImpl impl;
+    FFT impl;
     void enforceSize(R)(R range) const
     {
         import std.conv : text;
@@ -3389,7 +3389,7 @@ public:
      */
     this(size_t size)
     {
-        this.impl = FFTImpl(size);
+        this.impl = FFT(size);
     }
 
     @property size_t size() const => impl.size;
@@ -3463,8 +3463,6 @@ public:
     }
 }
 
-alias FFT = FFTImpl;
-
 /**A struct for performing fast Fourier transforms of power of two sizes.
  * This class encapsulates a large amount of state that is reusable when
  * performing multiple FFTs of sizes smaller than or equal to that specified
@@ -3476,7 +3474,7 @@ alias FFT = FFTImpl;
  * References:
  * $(HTTP en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm)
  */
-struct FFTImpl
+struct FFT
 {
     import core.bitop : bsf;
     import std.algorithm.iteration : map;
@@ -3813,7 +3811,7 @@ public:
     }
 
     ///
-    @disable this(ref FFTImpl);
+    @disable this(ref FFT);
 
     ///
     ~this() @nogc nothrow
@@ -3971,28 +3969,28 @@ public:
  */
 Complex!F[] fft(F = double, R)(R range)
 {
-    auto fftObj = FFTImpl(range.length);
+    auto fftObj = FFT(range.length);
     return fftObj.compute!(F, R)(range);
 }
 
 /// ditto
 void fft(Ret, R)(R range, Ret buf)
 {
-    auto fftObj = FFTImpl(range.length);
+    auto fftObj = FFT(range.length);
     return fftObj.compute!(Ret, R)(range, buf);
 }
 
 /// ditto
 Complex!F[] inverseFft(F = double, R)(R range)
 {
-    auto fftObj = FFTImpl(range.length);
+    auto fftObj = FFT(range.length);
     return fftObj.computeInverse!(F, R)(range);
 }
 
 /// ditto
 void inverseFft(Ret, R)(R range, Ret buf)
 {
-    auto fftObj = FFTImpl(range.length);
+    auto fftObj = FFT(range.length);
     return fftObj.computeInverse!(Ret, R)(range, buf);
 }
 

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3959,7 +3959,7 @@ void inverseFft(Ret, R)(R range, Ret buf)
     return fftObj.computeInverse!(Ret, R)(range, buf);
 }
 
-pure @system unittest
+pure @safe unittest
 {
     import std.algorithm;
     import std.conv;
@@ -4030,7 +4030,7 @@ pure @system unittest
 }
 
 // https://github.com/dlang/phobos/issues/10796
-pure @system unittest
+pure @safe unittest
 {
     import std.algorithm;
     import std.range;

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -3733,7 +3733,14 @@ public:
         }
         else if (range.length == 1)
         {
-            buf[0] = range[0];
+            static if (isComplexLike!(ElementType!R)) {
+                buf[0].re = range[0].re;
+                buf[0].im = range[0].im;
+            }
+            else {
+                buf[0].re = range[0];
+                buf[0].im = 0;
+            }
             return;
         }
         else if (range.length == 2)
@@ -3931,6 +3938,26 @@ void inverseFft(Ret, R)(R range, Ret buf)
     assert(isClose(twoInv[1].im, 0, 0.0, 1e-10));
 }
 
+// https://github.com/dlang/phobos/issues/10796
+@system unittest
+{
+    import std.algorithm;
+    import std.range;
+    static struct C { float re, im; } // User-defined complex
+
+    float[8] arr = [1,2,3,4,5,6,7,8];
+    C[8] fft1;
+    fft(arr[], fft1[]);
+    assert(isClose(fft1[].map!"a.re",
+        [36.0, -4, -4, -4, -4, -4, -4, -4], 1e-4));
+    assert(isClose(fft1[].map!"a.im",
+        [0, 9.6568, 4, 1.6568, 0, -1.6568, -4, -9.6568], 1e-4));
+
+    auto inv = inverseFft(fft1[]);
+    assert(isClose(inv[].map!"a.re", arr[], 1e-6));
+    assert(inv[].map!"a.im".maxElement < 1e-10);
+}
+
 // Swaps the real and imaginary parts of a complex number.  This is useful
 // for inverse FFTs.
 C swapRealImag(C)(C input)
@@ -4112,11 +4139,22 @@ struct Stride(R)
 // using a generic slow DFT.  This seems to be the best base case.  (Size 1
 // can be coded inline as buf[0] = range[0]).
 void slowFourier2(Ret, R)(R range, Ret buf)
+if (isComplexLike!(ElementType!Ret))
+in (range.length == 2)
+in (buf.length == 2)
 {
-    assert(range.length == 2);
-    assert(buf.length == 2);
-    buf[0] = range[0] + range[1];
-    buf[1] = range[0] - range[1];
+    static if (isComplexLike!(ElementType!R)) {
+        buf[0].re = range[0].re + range[1].re;
+        buf[0].im = range[0].im + range[1].im;
+        buf[1].re = range[0].re - range[1].re;
+        buf[1].im = range[0].im - range[1].im;
+    }
+    else {
+        buf[0].re = range[0] + range[1];
+        buf[0].im = 0;
+        buf[1].re = range[0] - range[1];
+        buf[1].im = 0;
+    }
 }
 
 // Hard-coded base case for FFT of size 4.  Doesn't work as well as the size


### PR DESCRIPTION
Fix dlang#10798

* FFT solver is reimplemented as a struct called `FFT`. It either allocates a buffer for a lookup table using `malloc`, or uses a preallocated buffer. In the former case, the buffer is freed upon destruction. `FFT` is non-copyable. 
* `Fft` class now is just a wrapper around `FFT`. 
* Convenience functions use `FFT` instead of `Fft`. In effect, `fft(R, Ret)` and `inverseFft(R, Ret)` can be used in `@nogc`, `nothrow`, `pure` and `@safe` code.

Though the optimization of the algorithm itself was not the goal of this change, the new version performs slightly better on the larger FFT sizes. Using LDC2 with `-O -release` flags, on size=64 `FFT.compute` works about as fast as the old `Fft.fft`, and on size=32768 it works 6-7 % faster.  DMD shows similar results.