### PR TITLE
 [std.range docs] drop and dropOne may not mutate the range 

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3883,8 +3883,7 @@ pure @safe nothrow @nogc unittest
 /++
     `drop` is a convenience function which calls
     $(REF popFrontN, std, range, primitives)`(range, n)` and returns `range`.
-    Unlike `popFrontN`, the range argument is not passed by `ref`, so
-    the source range may not get popped.
+    Unlike `popFrontN`, the range argument is passed by copy, not by `ref`.
 
     `drop` makes it easier to pop elements from a range rvalue
     and then pass it to another function within a single expression,
@@ -4038,8 +4037,7 @@ if (isBidirectionalRange!R)
 /++
     `dropOne` is a convenience function which calls
     `range.popFront()` and returns `range`.
-    Unlike `popFront`, the range argument is not passed by `ref`, so
-    the source range may not get popped.
+    Unlike `popFront`, the range argument is passed by copy, not by `ref`.
 
     `dropOne` makes it easier to pop an element from a range rvalue
     and then pass it to another function within a single expression,


### PR DESCRIPTION
Fixes #10828.