### PR TITLE
Refactor `std.internal.entropy` to provide reusable handles

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -1819,11 +1819,10 @@ how excellent the source of entropy is.
 {
     version (SeedUseGetEntropy)
     {
-        import std.internal.entropy : crashOnError, EntropySourceID, getEntropy;
+        import std.internal.entropy : getEntropyOrCrash;
 
         uint buffer;
-        const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySourceID.tryAll))();
-        crashOnError(status);
+        getEntropyOrCrash(&buffer, buffer.sizeof);
         return buffer;
     }
     else version (AnyARC4Random)
@@ -1877,11 +1876,10 @@ if (isUnsigned!UIntType)
         {
             version (SeedUseGetEntropy)
             {
-                import std.internal.entropy : crashOnError, EntropySourceID, getEntropy;
+                import std.internal.entropy : getEntropyOrCrash;
 
                 UIntType buffer;
-                const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySourceID.tryAll))();
-                crashOnError(status);
+                getEntropyOrCrash(&buffer, buffer.sizeof);
                 return buffer;
             }
             else version (AnyARC4Random)

--- a/std/random.d
+++ b/std/random.d
@@ -1819,10 +1819,10 @@ how excellent the source of entropy is.
 {
     version (SeedUseGetEntropy)
     {
-        import std.internal.entropy : crashOnError, EntropySource, getEntropy;
+        import std.internal.entropy : crashOnError, EntropySourceID, getEntropy;
 
         uint buffer;
-        const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySource.tryAll))();
+        const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySourceID.tryAll))();
         crashOnError(status);
         return buffer;
     }
@@ -1877,10 +1877,10 @@ if (isUnsigned!UIntType)
         {
             version (SeedUseGetEntropy)
             {
-                import std.internal.entropy : crashOnError, EntropySource, getEntropy;
+                import std.internal.entropy : crashOnError, EntropySourceID, getEntropy;
 
                 UIntType buffer;
-                const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySource.tryAll))();
+                const status = (() @trusted => getEntropy(&buffer, buffer.sizeof, EntropySourceID.tryAll))();
                 crashOnError(status);
                 return buffer;
             }


### PR DESCRIPTION
Refactor `std.internal.entropy` to provide reusable handles.

This allows a more efficient use of the module on certain platforms (for future code).
To be fair, it might also make it slightly less efficient on others (e.g. Windows), though I think the reduction of TLS variables there might also be an improvement.

Please do *not* merge this yet. It needs further testing (that I haven’t performed yet).
Also, I’d prefer v2.112.0 to have the non-handle version of module which should be easier to deal with in case of any regressions that may arise.