### PR TITLE
Update Phobos 3 Package Map to account for DConf 2025 announcements.

### DIFF
--- a/phobos/PackageMap.md
+++ b/phobos/PackageMap.md
@@ -23,7 +23,7 @@ Packages/Modules with an asterisk are new.
 
 ### Proposed Package Structure
 
-This map is not final.
+***This map is not final!***
 
 ```
 core.*
@@ -38,17 +38,11 @@ platform
 based
   | bigint
   | bitmanip
-  | checkedint
+  | checkedint (core.checkedint)
   | complex
   | compiler
-  | console (stdio)
-  | datetime
-    | date
-    | interval
-    | stopwatch
-    | systime
-    | timezone
-  | demangle
+  | console (std.stdio)
+  | demangle (core.demangle)
   | file
   | int128
   | math
@@ -64,12 +58,12 @@ based
     | special
     | numeric
   | meta
-  | optional* (typecons)
+  | optional* (std.typecons)
   | stdint
   | sumtype
   | system
+  | time (core.time)
   | traits
-  | variant
 phobos.sys
   | algorithm
     | comparison
@@ -79,7 +73,15 @@ phobos.sys
     | setops
     | sorting
   | array
+  | checkedint
   | conv
+  | datetime
+    | date
+    | interval
+    | stopwatch
+    | systime
+    | timezone
+  | demangle
   | exception
   | functional
   | meta
@@ -90,6 +92,7 @@ phobos.sys
   | signals
   | traits
   | uuid
+  | variant
 phobos.data
   | base64
   | csv
@@ -110,7 +113,7 @@ phobos.crypto*
   | rsa
   | symmetric
 phobos.io
-  | console (stdio)
+  | console (std.stdio)
   | stream* (iopipe)
   | mmfile
   | path

--- a/phobos/PackageMap.md
+++ b/phobos/PackageMap.md
@@ -1,34 +1,47 @@
 ## Phobos 3 Package Map
 
+`based` modules duplicated in `phobos` will contain a mix of wrapped `based` functions, new fuctions, and public imports of `based` symbols, depending on what ends up being the most effective solution.
+
+Packages/Modules with an asterisk are new.
+
 ### Open Questions
 
 1. `std.container`: Does it belong in `sys` or it's own root? This likely hinges on the status of [DIP1000](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md) and whether or not it needs a ground up rewrite.
 2. `std.concurrency`: It is possible that not all platforms support Concurrency mechanics. Should `std.concurrency` be required in the core roots or moved to a non-core root?
 3. `std.parallelism`: It is possible that not all platforms support Task Parallelism mechanics. Should `std.parallelism` be required in the core roots or moved to a non-core root?
-4. `std.digest`: Cryptography routines have unique requirements that would be best served by providing them in their own root. But in all cases providing bespoke implementations of cryptography routines is never recommended. Third-party trusted implementations should be used instead. This could be from OpenSSL/LibreSSL (POSIX), SChannel/BCrypt (Windows), or CryptoKit (MacOS/IOS). It is acceptable to provide implementations of Non-Cryptographic routines such as CRC and Murmur. This would entail removing all the digests except CRC and Murmur from this package and building a separate cryptography package.
-5. Which, if any, modules should be removed? This could be either a permanent removal or pending replacement with ground-up rewrites.
+4.  Which, if any, modules should be removed? This could be either a permanent removal or pending replacement with ground-up rewrites.
 
-### Proposed Package Structure (Existing Modules Only)
+### Closed Questions
+1. `std.digest`: Only non-cryptographic digests will be kept. SHA2/3 will be available in `phobos.sys.hash` using the system provided API.
+2. Removed modules:
+    1. `std.json` (Replaced with [JSONIOPipe](https://github.com/schveiguy/jsoniopipe))
+    2. `std.getopt`
+    3. `std.logger`
+    4. `std.experimental`
+    5. `std.digest` (only: `hmac`/`md`/`ripemd`/`sha`)
+3. `std.typecons` will be split into distinct modules.
+
+### Proposed Package Structure
+
+This map is not final.
 
 ```
 core.*
 etc.*
 std.*
-phobos.sys
-  | algorithm
-    | comparison
-    | iteration
-    | mutation
-    | searching
-    | setops
-    | sorting
-  | array
+platform
+  | freebsd
+  | linux
+  | macos
+  | stdc
+  | win
+based
   | bigint
   | bitmanip
   | checkedint
-  | compiler
   | complex
-  | conv
+  | compiler
+  | console (stdio)
   | datetime
     | date
     | interval
@@ -36,15 +49,8 @@ phobos.sys
     | systime
     | timezone
   | demangle
-  | exception
-  | functional
-  | getopt
+  | file
   | int128
-  | io
-    | console (stdio)
-    | file
-    | mmfile
-    | path
   | math
     | algebraic
     | constants
@@ -58,30 +64,65 @@ phobos.sys
     | special
     | numeric
   | meta
+  | optional* (typecons)
+  | stdint
+  | sumtype
+  | system
+  | traits
+  | variant
+phobos.sys
+  | algorithm
+    | comparison
+    | iteration
+    | mutation
+    | searching
+    | setops
+    | sorting
+  | array
+  | conv
+  | exception
+  | functional
+  | meta
   | outbuffer
   | process
   | random
   | range
   | signals
-  | stdint
-  | string
-  | sumtype
-  | system
   | traits
-  | typecons
   | uuid
-  | variant
 phobos.data
   | base64
   | csv
-  | json
+  | json*
+  | toml*
+  | sdl*
   | zip
+phobos.crypto*
+  | digest
+    | crc
+    | murmurhash
+  | ecc
+  | hash
+    | sha
+    | hmac
+  | kdf
+  | random
+  | rsa
+  | symmetric
+phobos.io
+  | console (stdio)
+  | stream* (iopipe)
+  | mmfile
+  | path
 phobos.text
   | ascii
   | encoding
+  | string
   | uni
   | utf
 phobos.net
+  | http*
   | socket
+  | tls*
   | uri
 ```

--- a/phobos/PackageMap.md
+++ b/phobos/PackageMap.md
@@ -100,18 +100,18 @@ phobos.data
   | toml*
   | sdl*
   | zip
-phobos.crypto*
+phobos.crypto
   | digest
     | crc
     | murmurhash
-  | ecc
-  | hash
-    | sha
-    | hmac
-  | kdf
-  | random
-  | rsa
-  | symmetric
+  | ecc*
+  | hash*
+    | sha*
+    | hmac*
+  | kdf*
+  | random*
+  | rsa*
+  | symmetric*
 phobos.io
   | console (std.stdio)
   | stream* (iopipe)

--- a/phobos/PackageMap.md
+++ b/phobos/PackageMap.md
@@ -120,6 +120,7 @@ phobos.io
 phobos.text
   | ascii
   | encoding
+  | format
   | string
   | uni
   | utf


### PR DESCRIPTION
This PR does the following: 
1. Adds the `platform` system binding root package.
2. Adds the `based` root package.
3. Moves Phobos 2 modules into `based`.
4. Adds the `phobos.crypto` package.
5. Adds the `phobos.io` package, and moves relevant modules into it.

@jmdavis @pbackus @rikkimax @schveiguy 