### PR TITLE
UUIDv7 Method 3 implementation

### DIFF
--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1417,7 +1417,7 @@ class MonotonicUUIDsFactory
     ///
     this(in SysTime startTime = SysTime.fromUnixTime(0)) shared
     {
-        this(Clock.currTime - startTime);
+        this(Clock.currTime(UTC()) - startTime);
     }
 
     ///


### PR DESCRIPTION
It seems, our UUIDv7 generation system is not suitable for high frequency generation (thousand UUIDs per millisecond) - for this purpose implementation does not fully comply with RFC 9562. Namely, in such cases they insist that instead of a completely random number, monotonic counter or monotonic clock should be used: [6.2. ](https://datatracker.ietf.org/doc/html/rfc9562#section-6.2)[Monotonicity and Counters](https://datatracker.ietf.org/doc/html/rfc9562#name-monotonicity-and-counters)

Here is my implementation of "Method 3" from RFC 9562.

"Method 3" is pretty cool idea here that time divides the data into +/- identical 1/4 microsecond buckets with random 60-bits tails. This should divide into unique all UUIDs in the world that were generated in that 1/4 microsecond moment.

For accurate time stamps I used `StopWatch`, which internally uses `MonoTime`. Is it okay to keep `MonoTime` running for a very long time? Won't it break after six months of continuous running or something like?