### PR TITLE
Fixes UUIDv7 lack of randomness

### DIFF
--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1904,3 +1904,23 @@ public class UUIDParsingException : Exception
     auto d = DateTime(2025,8,19);
     assert((cast(DateTime) u.v7Timestamp()).year == d.year);
 }
+
+/// uuid randomness check
+@system unittest
+{
+    import std.conv : to;
+    import std.datetime : Clock;
+    import std.format : format;
+
+    UUID[10_000] uuids;
+
+    foreach (ref u; uuids)
+        u = UUID(Clock.currTime);
+
+    foreach (i; 1 .. uuids.length)
+    {
+        assert(uuids[i-1].data[6 .. $] != uuids[i].data[6 .. $],
+            format("i=%d: random parts of adjacent v7 UUIDs are equal,\n%s\n%s", i, uuids[i-1], uuids[i])
+        );
+    }
+}

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -318,6 +318,9 @@ public struct UUID
         /**
          * UUID V7 constructor
          *
+         * This implementation is not guaranteed to use a cryptographically secure PRNG.
+         * For more information please see: std.random.unpredictableSeed
+         *
          * Params:
          *   timestamp = the timestamp part of the UUID V7
          *   random = UUID V7 has 74 bits of random data, which rounds to 10 ubyte's.

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1904,23 +1904,3 @@ public class UUIDParsingException : Exception
     auto d = DateTime(2025,8,19);
     assert((cast(DateTime) u.v7Timestamp()).year == d.year);
 }
-
-/// uuid v7 randomness check
-@system unittest
-{
-    import std.conv : to;
-    import std.datetime : Clock;
-    import std.format : format;
-
-    UUID[10_000] uuids;
-
-    foreach (ref u; uuids)
-        u = UUID(Clock.currTime);
-
-    foreach (i; 1 .. uuids.length)
-    {
-        assert(uuids[i-1].data[6 .. $] != uuids[i].data[6 .. $],
-            format("i=%d: random parts of adjacent v7 UUIDs are equal,\n%s\n%s", i, uuids[i-1], uuids[i])
-        );
-    }
-}

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -1797,7 +1797,7 @@ enum uuidRegex = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}"~
 private ubyte[10] generateV7RandomData() {
     import std.random : Random, uniform, unpredictableSeed;
 
-    auto rnd = Random(unpredictableSeed!(ubyte)());
+    auto rnd = Random(unpredictableSeed);
 
     ubyte[10] bytes;
     foreach (idx; 0 .. bytes.length)
@@ -1905,7 +1905,7 @@ public class UUIDParsingException : Exception
     assert((cast(DateTime) u.v7Timestamp()).year == d.year);
 }
 
-/// uuid randomness check
+/// uuid v7 randomness check
 @system unittest
 {
     import std.conv : to;


### PR DESCRIPTION
First commit: this test fails ~~on my machine~~
Second commit fixes issue

~~I decided to use getEntropy directly instead as seed here because UUID requires a just a little more than 8 bytes of ulong needed for generate quality random sequence. So there is no point in calling Random for this.~~