### PR TITLE
enable a formatValue test runs on all platforms

### DIFF
--- a/std/format/internal/write.d
+++ b/std/format/internal/write.d
@@ -3111,13 +3111,10 @@ if (isDelegate!T)
     import std.format : formatValue;
 
     void func() @system { __gshared int x; ++x; throw new Exception("msg"); }
-    version (linux)
-    {
-        FormatSpec!char f;
-        auto w = appender!string();
-        formatValue(w, &func, f);
-        assert(w.data.length >= 15 && w.data[0 .. 15] == "void delegate()");
-    }
+    FormatSpec!char f;
+    auto w = appender!string();
+    formatValue(w, &func, f);
+    assert(w.data.length >= 15 && w.data[0 .. 15] == "void delegate()");
 }
 
 // string elements are formatted like UTF-8 string literals.


### PR DESCRIPTION
The Linux-specific restriction was added in #4464, but the reasoning for this limitation is unclear. These tests should work across all platforms, so remove the restriction.