### PR TITLE
docs: Fix small inconsistenc for dropBackOne

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -86,7 +86,7 @@ $(BOOKTABLE ,
         $(TD Creates the range that results from discarding
         the first element from the given range.
     ))
-    $(TR $(TD $(D $(LREF dropBackOne)))
+    $(TR $(TD $(LREF dropBackOne))
         $(TD Creates the range that results from discarding
         the last element from the given range.
     ))


### PR DESCRIPTION
dropBackOne was the only element in the overview table that was wrappen in a `D` markup. This made is stand out in (only) the ddox version of the docs, since it got slightly indented.