### PR TITLE
disable unittest on FreeBSD that is spuriously stalling the CI pipelines

### DIFF
--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -1328,6 +1328,10 @@ template SharedAllocatorList(alias factoryFunction,
     assert(a.deallocateAll());
 }
 
+//BUG: this test freezes spuriously on FreeBSD, see also https://github.com/dlang/phobos/issues/10730.
+// The lock in a.allocate() below blocks in all remaining threads causing the join to never complete.
+// This might also hint at problems in the spinlock implementation.
+version (FreeBSD) {} else
 @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;


### PR DESCRIPTION
I happen to have reproduced the stall in phobos testing on FreeBSD that is plaguing the CI here and in the dmd repo. The process `generated/freebsd/debug/64/unittest/test_runner std.experimental.allocator.building_blocks.allocator_list` did not terminate running 87 threads. Unfortuantely gdb could not show reasonable callstacks.

I could reproduce it again, by running some processes in parallel to slow down the execution of the test, in this case building dmd tests. The test is waiting for threads to join, and all remaining threads show this callstack:
```
Thread 118 (LWP 153620 of process 29596):
#0  0x0000000805fb0a0a in sched_yield () from /lib/libc.so.7
#1  0x00000008055a4da1 in core.thread.osthread.Thread.yield() () at src/core/thread/osthread.d:1039
#2  0x0000000805578ccf in core.internal.spinlock.SpinLock.yield(ulong) shared (this=@0x8002fa050: <unknown type>, k=1853142) at src/core/internal/spinlock.d:57
#3  0x0000000805578c6a in core.internal.spinlock.SpinLock.lock() shared (this=@0x8002fa050: <unknown type>) at src/core/internal/spinlock.d:39
#4  0x0000000804ce0b8c in std.experimental.allocator.building_blocks.allocator_list.SharedAllocatorList!(std.experimental.allocator.building_blocks.allocator_list.SharedAllocatorList!(std.experimental.allocator.building_blocks.allocator_list.__unittest_L1331_C9().__lambda_L1340_C26, std.experimental.allocator.mallocator.Mallocator).Factory, std.experimental.allocator.mallocator.Mallocator).SharedAllocatorList.allocate(ulong) shared (this=@0x8002fa038: <unknown type>, s=512) at std/experimental/allocator/building_blocks/allocator_list.d:721
#5  0x0000000804cb8b93 in std.experimental.allocator.building_blocks.allocator_list.__unittest_L1331_C9().fun() (__capture=0x8002fa030) at std/experimental/allocator/building_blocks/allocator_list.d:1344
#6  0x00000008055a5f11 in core.thread.context.Callable.opCall() (this=...) at src/core/thread/context.d:46
#7  0x00000008055a2e11 in core.thread.threadbase.ThreadBase.run() (this=0x800309a00) at src/core/thread/threadbase.d:440
#8  0x00000008055a4555 in core.thread.osthread.Thread.run() (this=0x800309a00) at src/core/thread/osthread.d:331
#9  0x00000008055a5677 in thread_entryPoint (arg=0x806a1bb30) at src/core/thread/osthread.d:2545
#10 0x00000008002589e2 in ?? () from /lib/libthr.so.3
#11 0x0000000000000000 in ?? ()
```

So they are failing to get the spinlock, Let's see whether disabling this test makes the CI more reliable...

Just noticed that this has been reported before: https://github.com/dlang/phobos/issues/10730 and that LDC disables the test of this module.