### PR TITLE
Inline trivial functions in std.ascii

### DIFF
--- a/std/ascii.d
+++ b/std/ascii.d
@@ -185,6 +185,7 @@ else
     Params: c = The character to test.
     Returns: Whether `c` is a letter or a number (0 .. 9, a .. z, A .. Z).
   +/
+pragma(inline, true)
 bool isAlphaNum(dchar c) @safe pure nothrow @nogc
 {
     const hc = c | 0x20;
@@ -217,6 +218,7 @@ bool isAlphaNum(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is an ASCII letter (A .. Z, a .. z).
   +/
+pragma(inline, true)
 bool isAlpha(dchar c) @safe pure nothrow @nogc
 {
     // Optimizer can turn this into a bitmask operation on 64 bit code
@@ -249,6 +251,7 @@ bool isAlpha(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is a lowercase ASCII letter (a .. z).
   +/
+pragma(inline, true)
 bool isLower(dchar c) @safe pure nothrow @nogc
 {
     return c >= 'a' && c <= 'z';
@@ -281,6 +284,7 @@ bool isLower(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is an uppercase ASCII letter (A .. Z).
   +/
+pragma(inline, true)
 bool isUpper(dchar c) @safe pure nothrow @nogc
 {
     return c <= 'Z' && 'A' <= c;
@@ -313,6 +317,7 @@ bool isUpper(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is a digit (0 .. 9).
   +/
+pragma(inline, true)
 bool isDigit(dchar c) @safe pure nothrow @nogc
 {
     return '0' <= c && c <= '9';
@@ -346,6 +351,7 @@ bool isDigit(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is a digit in base 8 (0 .. 7).
   +/
+pragma(inline, true)
 bool isOctalDigit(dchar c) @safe pure nothrow @nogc
 {
     return c >= '0' && c <= '7';
@@ -376,6 +382,7 @@ bool isOctalDigit(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is a digit in base 16 (0 .. 9, A .. F, a .. f).
   +/
+pragma(inline, true)
 bool isHexDigit(dchar c) @safe pure nothrow @nogc
 {
     const hc = c | 0x20;
@@ -410,6 +417,7 @@ bool isHexDigit(dchar c) @safe pure nothrow @nogc
     space, tab, vertical tab, form feed, carriage return, and linefeed
     characters.
   +/
+pragma(inline, true)
 bool isWhite(dchar c) @safe pure nothrow @nogc
 {
     return c == ' ' || (c >= 0x09 && c <= 0x0D);
@@ -446,6 +454,7 @@ bool isWhite(dchar c) @safe pure nothrow @nogc
     Params: c = The character to test.
     Returns: Whether `c` is a control character.
   +/
+pragma(inline, true)
 bool isControl(dchar c) @safe pure nothrow @nogc
 {
     return c < 0x20 || c == 0x7F;
@@ -486,6 +495,7 @@ bool isControl(dchar c) @safe pure nothrow @nogc
     all ASCII characters which are not control characters, letters, digits, or
     whitespace.
   +/
+pragma(inline, true)
 bool isPunctuation(dchar c) @safe pure nothrow @nogc
 {
     return c <= '~' && c >= '!' && !isAlphaNum(c);
@@ -530,6 +540,7 @@ bool isPunctuation(dchar c) @safe pure nothrow @nogc
     Returns: Whether or not `c` is a printable character other than the
     space character.
   +/
+pragma(inline, true)
 bool isGraphical(dchar c) @safe pure nothrow @nogc
 {
     return '!' <= c && c <= '~';
@@ -566,6 +577,7 @@ bool isGraphical(dchar c) @safe pure nothrow @nogc
     Returns: Whether or not `c` is a printable character - including the
     space character.
   +/
+pragma(inline, true)
 bool isPrintable(dchar c) @safe pure nothrow @nogc
 {
     return c >= ' ' && c <= '~';


### PR DESCRIPTION
```d
bool isASCII(dchar c) @safe pure nothrow @nogc
{
    return c <= 0x7F;
}
```

is already inlined so I see no reason why these shouldn't also be.