### PR TITLE
docs: Fix small inconsistency for `slide`

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -162,7 +162,7 @@ $(BOOKTABLE ,
         $(TD Similar to `recurrence`, except that a random-access range is
         created.
     ))
-    $(TR $(TD $(D $(LREF slide)))
+    $(TR $(TD $(LREF slide))
         $(TD Creates a range that returns a fixed-size sliding window
         over the original range. Unlike chunks,
         it advances a configurable number of items at a time,


### PR DESCRIPTION
Same as https://github.com/dlang/phobos/pull/10875

slide was the only element in the overview table that was wrappen in a D markup. This made is stand out in (only) the ddox version of the docs, since it got slightly indented.