### PR TITLE
[std.traits] Improve docs and unittest for `isFunction`

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -9143,7 +9143,7 @@ enum isType(alias X) = is(X);
 }
 
 /**
- * Detect whether symbol or type `X` is a function or function type.
+ * Detect whether symbol or type `X` is a function.
  * This is different from finding if a symbol is callable or satisfying `is(X == return)`.
  * It finds specifically if the symbol represents a normal function (or method) declaration, i.e.
  * not a delegate or a function pointer.


### PR DESCRIPTION
Note that [`is(X == function)`](https://dlang.org/spec/expression.html#is-type-equal) is only true when X is a function type, so the docs here were misleading (e.g. implying that passes function pointers).
Remove unnecessary `T` identifier in implementation. 
Add tests.