### PR TITLE
[std/array] Improve `assocArray` docs

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -604,16 +604,6 @@ if (isInputRange!Range)
     assert(b == ["foo":"bar", "baz":"quux"]);
 }
 
-/** Duplicate an AA - see $(LREF byPair).
-*/
-@safe pure nothrow unittest
-{
-    auto aa = [0:"a", 1:"b", 2:"c"];
-    auto bb = assocArray(aa.byPair());
-    assert(aa == bb);
-    assert(aa !is bb);
-}
-
 /**
 Creates an associative array from a range of keys and a range of values.
 


### PR DESCRIPTION
Update quickindex description to include 2nd overload.
Split docs for overloads, rearrange/improve wording. 
Add nothrow to unittests.
~~Add example showing how to duplicate an AA.~~
Remove redundant `zip` example now there's a separate overload.