### PR TITLE
[std.typecons docs] Add links

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -21,10 +21,15 @@ $(TR $(TD Flags) $(TD
     $(LREF No)
     $(LREF Yes)
 ))
-$(TR $(TD Memory allocation) $(TD
+$(TR $(TD Reference Counting) $(TD
+    $(LREF borrow)
+    $(LREF RefCountedAutoInitialize)
+    $(LREF RefCounted)
+    $(LREF refCounted)
     $(LREF SafeRefCounted)
     $(LREF safeRefCounted)
-    $(LREF RefCountedAutoInitialize)
+))
+$(TR $(TD Memory allocation) $(TD
     $(LREF scoped)
     $(LREF Unique)
 ))
@@ -33,9 +38,11 @@ $(TR $(TD Code generation) $(TD
     $(LREF BlackHole)
     $(LREF generateAssertTrap)
     $(LREF generateEmptyFunction)
+    $(LREF NotImplementedError)
     $(LREF WhiteHole)
 ))
 $(TR $(TD Nullable) $(TD
+    $(LREF apply)
     $(LREF Nullable)
     $(LREF nullable)
     $(LREF NullableRef)
@@ -45,12 +52,13 @@ $(TR $(TD Proxies) $(TD
     $(LREF Proxy)
     $(LREF rebindable)
     $(LREF Rebindable)
-    $(LREF ReplaceType)
     $(LREF unwrap)
     $(LREF wrap)
 ))
 $(TR $(TD Types) $(TD
     $(LREF alignForSize)
+    $(LREF ReplaceType)
+    $(LREF ReplaceTypeUnless)
     $(LREF Ternary)
     $(LREF Typedef)
     $(LREF TypedefType)
@@ -5255,7 +5263,7 @@ if (is (typeof(nullValue) == T))
 
 // apply
 /**
-Unpacks the content of a `Nullable`, performs an operation and packs it again. Does nothing if isNull.
+Unpacks the content of a $(LREF Nullable), performs an operation and packs it again. Does nothing if $(LREF isNull).
 
 When called on a `Nullable`, `apply` will unpack the value contained in the `Nullable`,
 pass it to the function you provide and wrap the result in another `Nullable` (if necessary).
@@ -5275,6 +5283,7 @@ template apply(alias fun)
 {
     import std.functional : unaryFun;
 
+    ///
     auto apply(T)(auto ref T t)
     if (isInstanceOf!(Nullable, T))
     {
@@ -8326,6 +8335,7 @@ template borrow(alias fun)
 {
     import std.functional : unaryFun;
 
+    ///
     auto ref borrow(RC)(RC refCount)
     if
     (


### PR DESCRIPTION
Add Reference Counting link section, add `borrow`. 
Add `NotImplementedError` link.
Add `apply` link.
Add `ReplaceTypeUnless` link, regroup ReplaceType.
Add LREFs in `apply` docs.

Also show `apply` and `borrow` function signatures in docs.