### PR TITLE
[std/traits] Improve `isCallable` docs

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -7602,7 +7602,7 @@ enum bool isSomeFunction(alias T) =
 }
 
 /**
-Detect whether `T` is a callable object, which can be called with the
+Detect whether `callable` is a callable object, which can be called with the
 function call operator `$(LPAREN)...$(RPAREN)`.
 
 $(NOTE Implicit Function Template Instantiation is *not* attempted - see below.)
@@ -7610,10 +7610,10 @@ $(NOTE Implicit Function Template Instantiation is *not* attempted - see below.)
 template isCallable(alias callable)
 {
     static if (is(typeof(&callable.opCall) == delegate))
-        // T is a object which has a member function opCall().
+        // callable is a object which has a member function opCall().
         enum bool isCallable = true;
     else static if (is(typeof(&callable.opCall) V : V*) && is(V == function))
-        // T is a type which has a static member function opCall().
+        // callable is a type which has a static member function opCall().
         enum bool isCallable = true;
     else static if (is(typeof(&callable.opCall!()) TemplateInstanceType))
     {
@@ -7629,7 +7629,7 @@ template isCallable(alias callable)
     }
 }
 
-/// Functions, function pointers, delegates, lambdas.
+/// Functions, function pointers, delegates, non-template function literals.
 @safe unittest
 {
     void f() { }
@@ -7644,6 +7644,8 @@ template isCallable(alias callable)
 
     int x;
     static assert(!isCallable!x);
+    auto d = () => x;
+    static assert( isCallable!d);
 }
 
 /// Aggregate types with (static) opCall.
@@ -7658,7 +7660,6 @@ template isCallable(alias callable)
     static assert( isCallable!(c.opCall));
     static assert( isCallable!S);
     static assert( isCallable!(I.value));
-    static assert( isCallable!((int a) { return a; }));
 
     static assert(!isCallable!I);
 }
@@ -7668,11 +7669,13 @@ template isCallable(alias callable)
 {
     void f()() { }
     T g(T = int)(T x) { return x; }
+    int h(T)();
     struct S1 { static void opCall()() { } }
     struct S2 { static T opCall(T = int)(T x) {return x; } }
 
     static assert( isCallable!f);
     static assert( isCallable!g);
+    static assert(!isCallable!h);
     static assert( isCallable!S1);
     static assert( isCallable!S2);
 


### PR DESCRIPTION
Fix renamed T parameter.
Replace *lambdas* with 'non-template function literals'.
Show delegate is true.
Show function template with non-default parameter is false.