### PR TITLE
variant: Support get!Variant

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -3347,3 +3347,18 @@ if (isAlgebraic!VariantType && Handler.length > 0)
             msg: "Variant: attempting to use incompatible types int and immutable(int)[]"
     );
 }
+
+// https://github.com/dlang/phobos/issues/9980
+@system unittest
+{
+    import std.stdio;
+    Variant[] top, bottom;
+	top = new Variant[](1);
+	bottom = new Variant[](1);
+
+	bottom[0] = "bar";
+	top[0] = bottom;
+	assert(top[0][0] == "bar");
+	top[0][0] = "foo";
+	assert(top[0][0] == "foo");
+}


### PR DESCRIPTION
variant.get!Variant used to segfault, but after PR #10697 it only threw an exception.

The reason for that was that get!Variant called the `handler` with OpID.get. Handler is a function pointer to a templated function parametrized on the type currently wrapped by Variant. Because Variant generally get flattened, so `Variant(Variant(4))` just wraps the value `4`, instead of `Variant(4)`, the wrapped type (should generally) not be "Variant", and thus the OpID.get operation will fail.

This couldn't be fixed in the handler, because OpID.get uses typeinfo for the target type, but VariantN is a template, so afaik we can't really test it against the infinite set of valid VariantN instantiations. `get` still gets the target type as a template parameter, so we can handle the problem there.

Supporting get!Variant incidentally also fixed #10518. Adding variant inside an associative array of variants failed:
```
Variant variant = Variant([
    "one": Variant(1),
  ]);

  variant["four"] = Variant(4);
```
This was because `opIndexAssign` wrapps the index as well as the value you want to assign in a Variant again.
```
Variant opIndexAssign(T, N)(T value, N i)
{
    Variant[2] args = [ Variant(value), Variant(i) ];
    fptr(OpID.indexAssign, &store, &args) == 0 || assert(false);
    return args[0];
}
```
The handler of `variant` containing the AA is parametrized with `Variant[string]`, but opIndexAssign passes a variant of type int instead of Variant(Variant(int)) due to the aformentioned flattening.

Eventually in the handler, it ends up calling `Variant(i).get!Variant`, which crashed.

For the github automation:

Fixes #10431
Fixes #10518
Fixes #9980