### PR TITLE
Bump macOS to `macos-14` on GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
             container_image: alpine:3.21
             host_dmd: ldmd2
           # macOS
-          - job_name: macOS 13 x64
-            os: macos-13
+          - job_name: macOS x64
+            os: macos-14
           # Windows
           - job_name: Windows x64
             os: windows-2022


### PR DESCRIPTION
Rationale: <https://github.com/actions/runner-images/issues/13046>

This might need a maintainer to tune the configured requirement settings — similar to <https://github.com/dlang/dmd/pull/21985#issuecomment-3423261842>.

I’ve also removed the version number from `job_name` — this matches how the Windows job is named and would make the upgrade to a `macos-15` based image less painful.