### PR TITLE
variant regression: Make sure untyped pointers are scanned by the GC

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -37,6 +37,7 @@ Source:    $(PHOBOSSRC std/variant.d)
 module std.variant;
 
 import std.meta, std.traits, std.typecons;
+import core.memory : GC;
 
 ///
 @system unittest
@@ -428,8 +429,8 @@ private:
                     }
                     else
                     {
-                        // object will be intialized later. Using ubyte buffer in case `this()` is disabled
-                        A* p = cast(A*) (new ubyte[A.sizeof]).ptr;
+                        // object will be intialized later. Using malloc in case `this()` is disabled
+                        A* p = cast(A*) GC.malloc(A.sizeof, 0, typeid(A));
                     }
                     *cast(A**)&target.store = p;
                 }
@@ -679,8 +680,8 @@ switchStmtTupAssign:
                         static if (is(A == U[n], U, size_t n))
                             auto p = cast(A*) (new U[n]).ptr;
                         else
-                            // object will be intialized later. Using ubyte buffer in case `this()` is disabled
-                            A* p = cast(A*) (new ubyte[A.sizeof]).ptr;
+                            // object will be intialized later. Using malloc in case `this()` is disabled
+                            A* p = cast(A*) GC.malloc(A.sizeof, 0, typeid(A));
                         // Emplace will run the postblit of `A` us, no need to do it manually, then
                         copyEmplace(*zis, *p);
                         *(cast(A**) pStore) = p;
@@ -789,8 +790,8 @@ public:
                 static if (is(T == U[n], U, size_t n))
                     T* p = cast(T*) (new U[n]).ptr;
                 else
-                    // object will be intialized later. Using ubyte buffer in case `this()` is disabled
-                    T* p = cast(T*) (new ubyte[T.sizeof]).ptr;
+                    // object will be intialized later. Using malloc in case `this()` is disabled
+                    T* p = cast(T*) GC.malloc(T.sizeof, 0, typeid(T));
                 copyEmplace(rhs, *p);
                 *(cast(T**) &store) = p;
             }


### PR DESCRIPTION
To make sure that Variant works with big structs that it has to allocate on the heap which can't be allocated with a simple `new T` due to default constructor being disabled, the allocation strategy used was to just allocate an array of ubytes and cast the region appropriately.

But if the GC only knows about this memory region as ubyte[], it won't scan it for pointers. I think there might even be issues with alignment, depending on how the GC works.

Using GC.malloc with typeinfo should provide the GC with all the relevant info to recursively scan this region and is preferable to just conservatively marking the whole buffer as a new GC root.