### PR TITLE
10920: Extend gammaIncomplete to cover large a≈x

### DIFF
--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -257,7 +257,7 @@ real igammaTemmeLarge(real a, real x, bool compl)
     }
 }
 
-unittest
+@safe unittest
 {
     // Values were generated using scipy, which restricts values to double precision.
     assert(feqrel(igammaTemmeLarge(25.0, 25.0, true), 0.47339_84685_56349_37L) >= double.mant_dig);


### PR DESCRIPTION
This addresses #10920.

Adapted the existing function igammaTemmeLarge os that it supports gammaIncomplete as well as its complement gammaIncompleteCompl. As part of this adaptation, log(sigma+1) was replaced with log1p(sigma), since Temme's alorithm requires a to be close to x, which means that sigma is close to 0, making log(sigma+1) imprecise. gammaIncomplete was then modified to use igammaTemmeLarge when x is much larger than 1 and a is near x.