### PR TITLE
Fix potential null check error in Socket.select

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -3510,7 +3510,7 @@ public:
             if (checkError) checkError.setMinCapacity(n);
         }
 
-        int result = .select(n, fr, fw, fe, &timeout.ctimeval);
+        int result = .select(n, fr, fw, fe, timeout !is null ? &timeout.ctimeval : null);
 
         version (Windows)
         {


### PR DESCRIPTION
Found by @adamdruppe.

It is the classic ``null + 0 = 0`` error. It is fine today, but not forevermore.