### PR TITLE
[stable] std.container.rbtree: Refactor template constraint wrt. `less` and use it for redBlackTree() functions too

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -755,7 +755,7 @@ private struct RBRange(N)
  * inserted after all existing duplicate elements.
  */
 final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
-if (is(typeof((ref const T a) => binaryFun!less(a, a))))
+if (isSuitablePredicate!(less, T))
 {
     import std.meta : allSatisfy;
     import std.range : Take;
@@ -2003,7 +2003,9 @@ assert(equal(rbt[], [5]));
 }
 
 import std.range.primitives : isInputRange, ElementType;
-import std.traits : isArray, isSomeString;
+import std.traits : isArray, isSomeString, lvalueOf;
+
+private enum isSuitablePredicate(alias less, T) = is(typeof(binaryFun!less(lvalueOf!(const T), lvalueOf!(const T))));
 
 /++
     Convenience function for creating a `RedBlackTree!E` from a list of
@@ -2028,14 +2030,14 @@ auto redBlackTree(bool allowDuplicates, E)(E[] elems...)
 
 /++ Ditto +/
 auto redBlackTree(alias less, E)(E[] elems...)
-if (is(typeof(binaryFun!less(E.init, E.init))))
+if (isSuitablePredicate!(less, E))
 {
     return new RedBlackTree!(E, less)(elems);
 }
 
 /++ Ditto +/
 auto redBlackTree(alias less, bool allowDuplicates, E)(E[] elems...)
-if (is(typeof(binaryFun!less(E.init, E.init))))
+if (isSuitablePredicate!(less, E))
 {
     //We shouldn't need to instantiate less here, but for some reason,
     //dmd can't handle it if we don't (even though the template which
@@ -2059,7 +2061,7 @@ if (isInputRange!Stuff && !isArray!(Stuff))
 
 /++ Ditto +/
 auto redBlackTree(alias less, Stuff)(Stuff range)
-if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init)))
+if (isSuitablePredicate!(less, ElementType!Stuff)
     && isInputRange!Stuff && !isArray!(Stuff))
 {
     return new RedBlackTree!(ElementType!Stuff, less)(range);
@@ -2067,7 +2069,7 @@ if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init
 
 /++ Ditto +/
 auto redBlackTree(alias less, bool allowDuplicates, Stuff)(Stuff range)
-if ( is(typeof(binaryFun!less((ElementType!Stuff).init, (ElementType!Stuff).init)))
+if (isSuitablePredicate!(less, ElementType!Stuff)
     && isInputRange!Stuff && !isArray!(Stuff))
 {
     //We shouldn't need to instantiate less here, but for some reason,


### PR DESCRIPTION
PR #10792 changed the constraint to allow const-ref predicates too, using a lambda - which seems to have a very bad effect on attributes inference. Avoiding the lambda and using `std.traits.lvalueOf()` instead seems to work better.

Also update the template constraints of the free-standing `redBlackTree()` functions, which were forgotten in #10792.