### PR TITLE
Increase timeout of `macOS x64` to 60 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           # macOS
           - job_name: macOS x64
             os: macos-14
+            timeout-minutes: 60
           # Windows
           - job_name: Windows x64
             os: windows-2022


### PR DESCRIPTION
Increase timeout of `macOS x64` on GHA to 60 minutes.
This job currently times out on a regular basis.