### PR TITLE
std/math/hardware.d: Partial IeeeFlags implementation on SPARC

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -60,6 +60,7 @@ else version (RISCV_Any) version = IeeeFlagsSupport;
 else version (MIPS_Any)  version = IeeeFlagsSupport;
 else version (LoongArch_Any) version = IeeeFlagsSupport;
 else version (ARM_Any)   version = IeeeFlagsSupport;
+else version (SPARC_Any) version = IeeeFlagsSupport;
 
 // Struct FloatingPointControl is only available if hardware FP units are available.
 version (D_HardFloat)
@@ -87,7 +88,7 @@ private:
     // The x87 FPU status register is 16 bits.
     // The Pentium SSE2 status register is 32 bits.
     // The ARM and PowerPC FPSCR is a 32-bit register.
-    // The SPARC FSR is a 32bit register (64 bits for SPARC 7 & 8, but high bits are uninteresting).
+    // The SPARC FSR is a 32-bit register (64 bits for SPARC V9, but high bits are uninteresting).
     // The RISC-V (32 & 64 bit) fcsr is 32-bit register.
     // THe LoongArch fcsr (fcsr0) is a 32-bit register.
     uint flags;
@@ -112,8 +113,21 @@ private:
     else version (Solaris)
     {
         // Solaris <fenv.h> uses hardware-incompatible floating-point status flags.
+        // Use the <sys/fsr.h> AEXC (Accrued EXCeption) bit field of fsr instead.
+        version (SPARC_Any)
+        {
+            enum : int
+            {
+                INEXACT_MASK    = 0x020,
+                UNDERFLOW_MASK  = 0x080,
+                OVERFLOW_MASK   = 0x100,
+                DIVBYZERO_MASK  = 0x040,
+                INVALID_MASK    = 0x200,
+                EXCEPTIONS_MASK = 0x3E0,
+            }
+        }
         // Use the <sys/fp.h> masks for 80387 control word or SSE/SSE2 MXCSR instead.
-        version (X86_Any)
+        else version (X86_Any)
         {
             enum : int
             {
@@ -524,9 +538,21 @@ nothrow @nogc:
     else version (Solaris)
     {
         // Solaris <fenv.h> uses hardware-incompatible floating-point status flags.
+        // Use the <sys/fsr.h> RD (Rounding Direction) field of fsr instead.
+        version (SPARC_Any)
+        {
+            enum : RoundingMode
+            {
+                roundToNearest = 0x00000000,
+                roundDown      = 0xC0000000,
+                roundUp        = 0x80000000,
+                roundToZero    = 0x40000000,
+                roundingMask   = roundToNearest | roundDown
+                                 | roundUp | roundToZero,
+            }
+        }
         // Use the <sys/fp.h> rounding options in control word instead.
-
-        version (X86_Any)
+        else version (X86_Any)
         {
             enum : RoundingMode
             {
@@ -767,6 +793,8 @@ nothrow @nogc:
             return true;
         else version (LoongArch_Any)
             return true;
+        else version (SPARC_Any)
+            return true;
         else version (ARM_Any)
         {
             // The hasExceptionTraps_impl function is basically pure,
@@ -850,7 +878,7 @@ private:
     }
     else version (SPARC_Any)
     {
-        alias ControlState = ulong;
+        alias ControlState = uint;
     }
     else version (IBMZ_Any)
     {


### PR DESCRIPTION
There's currently no SPARC implementation of `IeeeFlags`.

This patch provides the part that is shared between Phobos and GCC's `libphobos`.  Besides, Solaris/SPARC uses hardware-incompatible floating-point status flags, which are included, too.

The remainder of the implementation (GDC-only) can be found in

	PR d/123202
	libphobos.phobos/std_math_hardware.d FAILs on SPARC
	https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123202

Together they fix:

	libphobos.phobos/std_math_hardware.d (test for excess errors)
	libphobos.phobos/std_math_hardware.d execution test

Tested on GCC trunk on sparc-sun-solaris2.11 and sparc64-unknown-linux-gnu.