### PR TITLE
Fix old alias syntax

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -2246,8 +2246,8 @@ if (isCallable!func)
     static assert(is( typeof(test) == FunctionTypeOf!test ));
     static assert(is( typeof(test) == FunctionTypeOf!test_fp ));
     static assert(is( typeof(test) == FunctionTypeOf!test_dg ));
-    alias int GetterType() @property;
-    alias int SetterType(int) @property;
+    alias GetterType = int() @property;
+    alias SetterType = int(int) @property;
     static assert(is( FunctionTypeOf!propGet == GetterType ));
     static assert(is( FunctionTypeOf!propSet == SetterType ));
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7586,12 +7586,12 @@ private template TypeMod(T)
     }
     alias methods = GetOverloadedMethods!A;
 
-    alias int F1();
-    alias @property int F2();
-    alias string F3();
-    alias nothrow @trusted uint F4();
-    alias int F5(Object);
-    alias bool F6(Object);
+    alias F1 = int();
+    alias F2 = @property int();
+    alias F3 = string();
+    alias F4 = nothrow @trusted uint();
+    alias F5 = int(Object);
+    alias F6 = bool(Object);
     static assert(methods.length == 3 + 4);
     static assert(__traits(identifier, methods[0]) == "draw"     && is(typeof(&methods[0]) == F1*));
     static assert(__traits(identifier, methods[1]) == "value"    && is(typeof(&methods[1]) == F2*));
@@ -7675,49 +7675,49 @@ package template DerivedFunctionType(T...)
 @safe unittest
 {
     // attribute covariance
-    alias int F1();
+    alias F1 = int();
     static assert(is(DerivedFunctionType!(F1, F1) == F1));
-    alias int F2() pure nothrow;
+    alias F2 = int() pure nothrow;
     static assert(is(DerivedFunctionType!(F1, F2) == F2));
-    alias int F3() @safe;
-    alias int F23() @safe pure nothrow;
+    alias F3 = int() @safe;
+    alias F23 = int() @safe pure nothrow;
     static assert(is(DerivedFunctionType!(F2, F3) == F23));
 
     // return type covariance
-    alias long F4();
+    alias F4 = long();
     static assert(is(DerivedFunctionType!(F1, F4) == void));
     class C {}
     class D : C {}
-    alias C F5();
-    alias D F6();
+    alias F5 = C();
+    alias F6 = D();
     static assert(is(DerivedFunctionType!(F5, F6) == F6));
-    alias typeof(null) F7();
-    alias int[] F8();
-    alias int* F9();
+    alias F7 = typeof(null)();
+    alias F8 = int[]();
+    alias F9 = int*();
     static assert(is(DerivedFunctionType!(F5, F7) == F7));
     static assert(is(DerivedFunctionType!(F7, F8) == void));
     static assert(is(DerivedFunctionType!(F7, F9) == F7));
 
     // variadic type equality
-    alias int F10(int);
-    alias int F11(int...);
-    alias int F12(int, ...);
+    alias F10 = int(int);
+    alias F11 = int(int...);
+    alias F12 = int(int, ...);
     static assert(is(DerivedFunctionType!(F10, F11) == void));
     static assert(is(DerivedFunctionType!(F10, F12) == void));
     static assert(is(DerivedFunctionType!(F11, F12) == void));
 
     // linkage equality
-    alias extern(C) int F13(int);
-    alias extern(D) int F14(int);
-    alias extern(Windows) int F15(int);
+    alias F13 = extern(C) int(int);
+    alias F14 = extern(D) int(int);
+    alias F15 = extern(Windows) int(int);
     static assert(is(DerivedFunctionType!(F13, F14) == void));
     static assert(is(DerivedFunctionType!(F13, F15) == void));
     static assert(is(DerivedFunctionType!(F14, F15) == void));
 
     // ref & @property equality
-    alias int F16(int);
-    alias ref int F17(int);
-    alias @property int F18(int);
+    alias F16 = int(int);
+    alias F17 = ref int(int);
+    alias F18 = @property int(int);
     static assert(is(DerivedFunctionType!(F16, F17) == void));
     static assert(is(DerivedFunctionType!(F16, F18) == void));
     static assert(is(DerivedFunctionType!(F17, F18) == void));


### PR DESCRIPTION
I used [dscanner](https://github.com/dlang-community/D-Scanner/pull/975).

Needed as https://github.com/dlang/dmd/pull/22244 was merged.