### PR TITLE
Fix issue 10962 - improved handling of gammaIncompleteCompleInverse edge cases

### DIFF
--- a/std/mathspecial.d
+++ b/std/mathspecial.d
@@ -505,23 +505,59 @@ do
     assert(isClose(gammaIncompleteCompl(1, 2), 1-gammaIncomplete(1, 2)));
 }
 
-/** Inverse of complemented incomplete gamma integral
+/** Inverse regularized upper incomplete gamma function Q$(SUP -1)(a,p) with respect to p
  *
- * Given a and p, the function finds x such that
+ * Given a and p, the function finds x such that p = Q(a,x).
  *
- *  gammaIncompleteCompl( a, x ) = p.
+ * Params:
+ *   a = the shape parameter, must be positive
+ *   p = Q(a,x), must be in the interval [0,1]
+ *
+ * Returns:
+ *   It returns x, a value $(GE) 0
+ *
+ * $(TABLE_SV
+ *   $(TR $(TH a)               $(TH p)        $(TH gammaIncompleteComplInverse(a, p)) )
+ *   $(TR $(TD negative)        $(TD)          $(TD $(NAN))                            )
+ *   $(TR $(TD)                 $(TD $(LT) 0)  $(TD $(NAN))                            )
+ *   $(TR $(TD)                 $(TD $(GT) 1)  $(TD $(NAN))                            )
+ *   $(TR $(TD +0)              $(TD $(LT) 1)  $(TD $(NAN))                            )
+ *   $(TR $(TD $(INFIN))        $(TD $(GT) 0)  $(TD $(NAN))                            )
+ *   $(TR $(TD $(GT) 0)         $(TD 0)        $(TD $(INFIN))                          )
+ *   $(TR $(TD $(LT) $(INFIN))  $(TD 1)        $(TD 0)                                 )
+ * )
+ *
+ * See_Also: $(LREF gammaIncompleteCompl)
  */
 real gammaIncompleteComplInverse(real a, real p)
 in
 {
-  assert(p >= 0 && p <= 1);
-  assert(a > 0);
+    // allow NaN input to pass through so that it can be addressed by the
+    // internal NaN payload propagation logic
+    if (!isNaN(a) && !isNaN(p))
+    {
+        assert(signbit(a) == 0, "a must be positive");
+        assert(p >= 0.0L && p <= 1.0L, "p must be in the interval [0,1]");
+    }
 }
+out(x; isNaN(x) || x >= 0.0L)
 do
 {
     return std.internal.math.gammafunction.gammaIncompleteComplInv(a, p);
 }
 
+///
+@safe unittest
+{
+    const a = 2, p = 0.5L;
+    assert(isClose(gammaIncompleteComplInverse(a, gammaIncompleteCompl(a, p)), p));
+
+    assert(gammaIncompleteComplInverse(1, 1/E) == 1);
+    assert(isNaN(gammaIncompleteComplInverse(+0.0L, 0.1)));
+    assert(isNaN(gammaIncompleteComplInverse(real.infinity, 0.2)));
+    assert(gammaIncompleteComplInverse(3, 0) is real.infinity);
+    assert(gammaIncompleteComplInverse(4, 1) == 0);
+}
 
 /* ***********************************************
  *     ERROR FUNCTIONS & NORMAL DISTRIBUTION     *


### PR DESCRIPTION
This resolves issue #10962.

* Made NaN handling conform to that of builtin binary operators, i.e., when both input values are NaN, the one with the larger payload is returned.
* Extended domain coverage to handle a = +0
* Short circuit cases where Q isn't invertible and return NaN
* Explicitly handle p = 1 edge case.