### PR TITLE
Fix #10981 - Wrong usage of the write() system call in std.file.write() and in std.file.copy()

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -4397,6 +4397,7 @@ private void copyImpl(scope const(char)[] f, scope const(char)[] t,
                 }
 
                 size_t wrAcc = 0;
+                assert(rr > 0);
                 while (wrAcc < rr)
                 {
                     auto wr = core.sys.posix.unistd.write(

--- a/std/file.d
+++ b/std/file.d
@@ -842,14 +842,25 @@ version (Posix) private void writeImpl(scope const(char)[] name, scope const(FSC
         scope(failure) core.sys.posix.unistd.close(fd);
 
         immutable size = buffer.length;
-        size_t sum, cnt = void;
+        size_t sum;
         while (sum != size)
         {
-            cnt = (size - sum < 2^^30) ? (size - sum) : 2^^30;
+            size_t cnt = (size - sum < 2^^30) ? (size - sum) : 2^^30;
             const numwritten = core.sys.posix.unistd.write(fd, buffer.ptr + sum, cnt);
-            if (numwritten != cnt)
-                break;
-            sum += numwritten;
+            if (numwritten > 0)
+            {
+                sum += numwritten;
+                continue;
+            }
+            if (numwritten == -1)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+                break;  // error
+            }
+            break;
         }
         cenforce(sum == size, name, namez);
     }
@@ -4369,16 +4380,40 @@ private void copyImpl(scope const(char)[] f, scope const(char)[] t,
             }
             scope(exit) core.stdc.stdlib.free(buf);
 
-            for (auto size = statbufr.st_size; size; )
+            while (true)
             {
-                immutable toxfer = (size > BUFSIZ) ? BUFSIZ : cast(size_t) size;
-                cenforce(
-                    core.sys.posix.unistd.read(fdr, buf, toxfer) == toxfer
-                    && core.sys.posix.unistd.write(fdw, buf, toxfer) == toxfer,
-                    f, fromz);
-                assert(size >= toxfer);
-                size -= toxfer;
+                auto rr = core.sys.posix.unistd.read(fdr, buf, BUFSIZ);
+                if (rr == 0)
+                {
+                    break;
+                }
+                if (rr == -1)
+                {
+                    if (errno == EINTR)
+                    {
+                        continue;
+                    }
+                    cenforce(false, f, fromz);
+                }
+
+                size_t wrAcc = 0;
+                while (wrAcc < rr)
+                {
+                    auto wr = core.sys.posix.unistd.write(
+                        fdw, buf + wrAcc, rr - wrAcc);
+                    if (wr == -1)
+                    {
+                        if (errno == EINTR)
+                        {
+                            continue;
+                        }
+                        cenforce(false, t, toz);
+                    }
+                    cenforce(wr > 0, t, toz);
+                    wrAcc += wr;
+                }
             }
+
             if (preserve)
                 cenforce(fchmod(fdw, to!mode_t(statbufr.st_mode)) == 0, f, fromz);
         }


### PR DESCRIPTION
For the `write` system call (as with `read`), it is normal behavior to return fewer bytes than requested.

A more serious issue was found in std.file.copy:
```d
cenforce(
    core.sys.posix.unistd.read(fdr, buf, toxfer) == toxfer
    && core.sys.posix.unistd.write(fdw, buf, toxfer) == toxfer,
    f, fromz);
```

The problem here is that an error may occur during the `write` call (for example, `ENOSPC`), but the programmer receives no information about it. Moreover, in my case, I encountered a phantom `ENOENT` error reported for the source file, which is clearly incorrect.

The behavior of the function has now been significantly improved.