### PR TITLE
add Alpine timeout override

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
             os: ubuntu-latest
             container_image: alpine:3.21
             host_dmd: ldmd2
+            timeout-minutes: 60  # Alpine/musl pushes test_phobos beyond the 40 min default
           # macOS
           - job_name: macOS x64
             os: macos-14


### PR DESCRIPTION
Alpine/musl pushes `test_phobos` beyond the 40-minute default budget.
Adds `timeout-minutes: 60` to the Alpine matrix entry.
