### PR TITLE
Fix default argument attributes

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2041,7 +2041,7 @@ public:
         enum defaultTZDatabaseDir = "";
     }
 
-    private static string getDefaultTZDatabaseDir()
+    private static string getDefaultTZDatabaseDir() @trusted
     {
         import core.stdc.stdlib : getenv;
         import std.string : fromStringz;


### PR DESCRIPTION
Blocking https://github.com/dlang/dmd/pull/22903

The value of `getDefaultTZDatabaseDir()` is used as a default argument in `@safe` functions, which was previously allowed, but with the bug fix applied gives the correct error:
```
  std/datetime/timezone.d(2083): Error: `@safe` function `std.datetime.systime.SysTime.__unittest_L6751_C11` cannot call `@system` function `std.datetime.timezone.PosixTimeZone.getDefaultTZDatabaseDir`
      static immutable(PosixTimeZone) getTimeZone(string name, string tzDatabaseDir = getDefaultTZDatabaseDir()) @trusted
                                                                                                             ^
  std/datetime/timezone.d(2044):        `std.datetime.timezone.PosixTimeZone.getDefaultTZDatabaseDir` is declared here
      private static string getDefaultTZDatabaseDir()
                            ^
```