### PR TITLE
[std.math.traits] Add error message for DMD on Arm targeting X86

### DIFF
--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -981,6 +981,17 @@ template floatTraits(T)
                 enum SIGNPOS_BYTE = 0;
             }
         }
+        else static if (T.sizeof == 16)
+        {
+            version (DigialMars)
+            {
+                version (X86_64)
+                    static assert(false,"No traits support for " ~ T.stringof ~
+                                  ". If you are on ARM, DMD is trying to target X86_64.");
+            }
+            else
+                static assert(false, "No traits support for " ~ T.stringof);
+        }
         else
             static assert(false, "No traits support for " ~ T.stringof);
     }

--- a/std/math/traits.d
+++ b/std/math/traits.d
@@ -988,6 +988,8 @@ template floatTraits(T)
                 version (X86_64)
                     static assert(false,"No traits support for " ~ T.stringof ~
                                   ". If you are on ARM, DMD is trying to target X86_64.");
+                else
+                    static assert(false, "No traits support for " ~ T.stringof);
             }
             else
                 static assert(false, "No traits support for " ~ T.stringof);


### PR DESCRIPTION
On my Mac M1, by default DMD tries to target X86_64 (separate issue), `real.sizeof == 16LU` and `real.mant_dig == 53`.
Special case the error message I got so that other people have context.