### PR TITLE
Fix issue 11000

### DIFF
--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -2449,16 +2449,17 @@ public:
         }
         else
         {
-            import std.path : baseName;
-            // dirEntries is @system because it uses a DirIterator with a
-            // RefCounted variable, but here, no references to the payload is
-            // escaped to the outside, so this should be @trusted
+            import std.path : baseName, relativePath;
+            // dirEntries might be @system because it uses a DirIterator with a
+            // SafeRefCounted variable that's only safe under DIP1000, but
+            // here no references to the payload are escaped to the outside,
+            // so this should be @trusted.
             () @trusted {
                 foreach (DirEntry de; dirEntries(tzDatabaseDir, SpanMode.depth))
                 {
                     if (de.isFile)
                     {
-                        auto tzName = de.name[tzDatabaseDir.length .. $];
+                        auto tzName = relativePath(de.name, tzDatabaseDir);
 
                         if (!tzName.extension().empty ||
                             !tzName.startsWith(subName) ||


### PR DESCRIPTION
With the default TZDatabaseDir values, time zones work as designed. However, if one has TZDIR environment variable set without a trailing slash, PosixTimeZone.getInstalledTZNames will turn the time zone names into nonexistent absolute paths, such as /Europe/Rome, failing the test suite.

This should fix it. Also updated an on-site comment a bit while there.

This is #10999 but with a different commit message. I didn't want to edit the commit message in original branch because I have already used the hash of that commit elsewhere.