### PR TITLE
Add EINTR handling for std.stdio and std.process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ EXTRA_MODULES_INTERNAL := $(addprefix std/, \
 	algorithm/internal \
 	$(addprefix internal/, \
 		cstring memory digest/sha_SSSE3 \
-		entropy \
+		entropy retry \
 		$(addprefix math/, biguintcore biguintnoasm biguintx86	\
 						   errorfunction gammafunction ) \
 		scopebuffer test/dummyrange test/range \

--- a/std/internal/retry.d
+++ b/std/internal/retry.d
@@ -1,0 +1,168 @@
+/**
+Internal helpers for retrying interrupted system calls.
+
+These helpers are $(D package(std)) — visible to every Phobos module but
+not part of the documented public API.
+
+See $(LINK https://man7.org/linux/man-pages/man7/signal.7.html).
+
+Copyright: The D Language Foundation
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+*/
+module std.internal.retry;
+
+import core.stdc.errno : errno, EINTR;
+
+/**
+Repeatedly invokes $(D syscall) while it returns $(D errorSentinel) and
+$(D errno == EINTR). Returns the final result — the caller remains
+responsible for diagnosing any non-$(D EINTR) error.
+
+Use for one-shot calls whose failure indicator is a sentinel value
+($(D -1), $(D EOF), $(D WEOF), $(D null), …). For partial-progress I/O
+loops, prefer $(D retryShortIO).
+*/
+package(std) auto retryOnEINTR(T)(scope T delegate() syscall, T errorSentinel) @system
+{
+    auto r = syscall();
+    while (r == errorSentinel && .errno == EINTR)
+        r = syscall();
+    return r;
+}
+
+/// Convenience overload for the common $(D errorSentinel = -1) case.
+package(std) auto retryOnEINTR(T)(scope T delegate() syscall) @system
+if (is(T : long))
+{
+    return retryOnEINTR!T(syscall, cast(T) -1);
+}
+
+/**
+Drives $(D attempt(offset)) until it has consumed all $(D total) items or
+hit a non-$(D EINTR) error/EOF. $(D attempt) receives the current write
+offset and must return the number of items transferred on that call
+(matching $(D fwrite)'s and $(D posix.write)'s semantics).
+
+Returns the cumulative number of items transferred. The caller compares
+the return with $(D total) to decide whether to throw or accept a short
+result.
+
+$(D onEINTR) runs after every $(D EINTR)-induced retry decision. Pass
+$(D () { clearerr(handle); }) for stdio call sites to prevent the
+stream's sticky error flag from lying to subsequent code; pass $(D null)
+for raw-syscall sites that have no error flag to clear.
+*/
+package(std) size_t retryShortIO(
+    scope size_t delegate(size_t startOffset) attempt,
+    size_t total,
+    scope void delegate() onEINTR = null) @system
+{
+    size_t done = 0;
+    while (done < total)
+    {
+        immutable n = attempt(done);
+        if (n > 0)
+        {
+            done += n;
+            continue;
+        }
+        if (.errno == EINTR)
+        {
+            if (onEINTR !is null) onEINTR();
+            continue;
+        }
+        break; // permanent error or EOF — caller decides
+    }
+    return done;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — all use stubs; no real I/O needed.
+// ---------------------------------------------------------------------------
+
+@system unittest
+{
+    import core.stdc.errno : EIO;
+
+    // retryOnEINTR returns immediately on success.
+    {
+        int calls = 0;
+        int r = retryOnEINTR(() { ++calls; return 0; }, -1);
+        assert(r == 0 && calls == 1);
+    }
+
+    // retryOnEINTR retries while sentinel + EINTR, stops when errno != EINTR,
+    // and propagates the final return value.
+    {
+        int attempts = 0;
+        int r = retryOnEINTR(() @system {
+            ++attempts;
+            if (attempts < 3)
+            {
+                .errno = EINTR;
+                return -1;
+            }
+            return 42;
+        }, -1);
+        assert(r == 42 && attempts == 3);
+    }
+
+    // retryOnEINTR does NOT retry on a non-EINTR errno.
+    {
+        int calls = 0;
+        int r = retryOnEINTR(() @system {
+            ++calls;
+            .errno = EIO;
+            return -1;
+        }, -1);
+        assert(r == -1 && calls == 1);
+    }
+
+    // retryShortIO advances `done` by each chunk's report and passes the
+    // correct offset to each successive call.
+    {
+        size_t[] offsets;
+        size_t r = retryShortIO(
+            (size_t off) { offsets ~= off; return cast(size_t) 2; },
+            6);
+        assert(r == 6);
+        assert(offsets == [0, 2, 4]);
+    }
+
+    // retryShortIO retries on (0, EINTR) and breaks on (0, non-EINTR).
+    {
+        int calls = 0;
+        size_t r = retryShortIO(
+            (size_t off) @system {
+                ++calls;
+                if (calls == 1) { .errno = EINTR; return cast(size_t) 0; }
+                return cast(size_t) 1;
+            },
+            1);
+        assert(r == 1 && calls == 2);
+
+        calls = 0;
+        r = retryShortIO(
+            (size_t off) @system {
+                ++calls;
+                .errno = EIO;
+                return cast(size_t) 0;
+            },
+            4);
+        assert(r == 0 && calls == 1);
+    }
+
+    // retryShortIO invokes onEINTR exactly once per EINTR retry decision.
+    {
+        int eintrCallbacks = 0, calls = 0;
+        size_t r = retryShortIO(
+            (size_t off) @system {
+                ++calls;
+                if (calls <= 2) { .errno = EINTR; return cast(size_t) 0; }
+                return cast(size_t) 3;
+            },
+            3,
+            () { ++eintrCallbacks; });
+        assert(r == 3 && eintrCallbacks == 2);
+    }
+}

--- a/std/process.d
+++ b/std/process.d
@@ -1244,18 +1244,11 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
     {
         closePipeWriteEnds();
 
-        T retryInterrupted(T)(scope T delegate() syscall)
-        {
-            import core.stdc.errno : errno, EINTR;
-            T result;
-            do
-                result = syscall();
-            while (result == -1 && .errno == EINTR);
-            return result;
-        }
+        import std.internal.retry : retryOnEINTR;
 
         auto status = InternalError.noerror;
-        auto readExecResult = retryInterrupted(() => core.sys.posix.unistd.read(forkPipe[0], &status, status.sizeof));
+        auto readExecResult = retryOnEINTR(
+            () => core.sys.posix.unistd.read(forkPipe[0], &status, status.sizeof));
         // Save error number just in case if subsequent "waitpid" fails and overrides errno
         immutable lastError = .errno;
 
@@ -1264,7 +1257,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
             // Forked child exits right after creating second fork. So it should be safe to wait here.
             import core.sys.posix.sys.wait : waitpid;
             int waitResult;
-            retryInterrupted(() => waitpid(id, &waitResult, 0));
+            retryOnEINTR(() => waitpid(id, &waitResult, 0));
         }
 
         if (readExecResult == -1)
@@ -1274,7 +1267,7 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
         if (status != InternalError.noerror)
         {
             int error;
-            readExecResult = retryInterrupted(() => read(forkPipe[0], &error, error.sizeof));
+            readExecResult = retryOnEINTR(() => read(forkPipe[0], &error, error.sizeof));
             string errorMsg;
             final switch (status)
             {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1093,6 +1093,7 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
     {
         import std.conv : text;
         import std.exception : errnoEnforce;
+        import std.internal.retry : retryShortIO;
 
         version (Windows)
         {
@@ -1117,10 +1118,13 @@ Throws: `ErrnoException` if the file is not opened or if the call to `fwrite` fa
             }
         }
 
-        auto result = trustedFwrite(_p.handle, buffer);
-        if (result == result.max) result = 0;
-        errnoEnforce(result == buffer.length,
-                text("Wrote ", result, " instead of ", buffer.length,
+        FILE* h = _p.handle;
+        immutable n = (() @trusted => retryShortIO(
+            (size_t off) => trustedFwrite(h, buffer[off .. $]),
+            buffer.length,
+            () { .clearerr(h); }))();
+        errnoEnforce(n == buffer.length,
+                text("Wrote ", n, " instead of ", buffer.length,
                         " objects of type ", T.stringof, " to file `",
                         _name, "'"));
     }
@@ -3106,14 +3110,18 @@ is empty, throws an `Exception`. In case of an I/O error throws
         private void putcChecked(_iobuf* h, int c) @trusted
         {
             import std.exception : errnoEnforce;
-            if (trustedFPUTC(c, h) == EOF) errnoEnforce(0);
+            import std.internal.retry : retryOnEINTR;
+            if (retryOnEINTR(() => trustedFPUTC(c, h), EOF) == EOF)
+                errnoEnforce(0);
         }
 
         private void putwcChecked(_iobuf* h, wchar_t c) @trusted
         {
             import std.exception : errnoEnforce;
+            import std.internal.retry : retryOnEINTR;
             // fputwc returns WEOF (= -1) on error
-            if (trustedFPUTWC(c, h) == -1) errnoEnforce(0);
+            if (retryOnEINTR(() => trustedFPUTWC(c, h)) == -1)
+                errnoEnforce(0);
         }
 
         /// Range primitive implementations.
@@ -3133,8 +3141,13 @@ is empty, throws an `Exception`. In case of an I/O error throws
                 {
                     //file.write(writeme); causes infinite recursion!!!
                     //file.rawWrite(writeme);
-                    auto result = trustedFwrite(file_._p.handle, writeme);
-                    if (result != writeme.length) errnoEnforce(0);
+                    import std.internal.retry : retryShortIO;
+                    FILE* h = file_._p.handle;
+                    immutable n = (() @trusted => retryShortIO(
+                        (size_t off) => trustedFwrite(h, writeme[off .. $]),
+                        writeme.length,
+                        () { .clearerr(h); }))();
+                    if (n != writeme.length) errnoEnforce(0);
                     return;
                 }
             }
@@ -3354,11 +3367,15 @@ is empty, throws an `Exception`. In case of an I/O error throws
         {
             import std.conv : text;
             import std.exception : errnoEnforce;
+            import std.internal.retry : retryShortIO;
 
-            auto result = trustedFwrite(file_._p.handle, buffer);
-            if (result == result.max) result = 0;
-            errnoEnforce(result == buffer.length,
-                    text("Wrote ", result, " instead of ", buffer.length,
+            FILE* h = file_._p.handle;
+            immutable n = (() @trusted => retryShortIO(
+                (size_t off) => trustedFwrite(h, buffer[off .. $]),
+                buffer.length,
+                () { .clearerr(h); }))();
+            errnoEnforce(n == buffer.length,
+                    text("Wrote ", n, " instead of ", buffer.length,
                             " objects of type ", T.stringof, " to file `",
                             name, "'"));
         }
@@ -3856,6 +3873,59 @@ version (linux)
     f.setvbuf(0, _IONBF);
     auto w = f.lockingTextWriter();
     assertThrown!ErrnoException(w.put('x'));
+}
+
+// https://github.com/dlang/phobos/issues/11006
+// LockingTextWriter.put survives an EINTR from a signal without SA_RESTART.
+version (linux)
+@system unittest
+{
+    import core.atomic : atomicLoad, atomicStore;
+    import core.sys.posix.pthread : pthread_kill;
+    import core.sys.posix.signal : SA_RESTART, SIGUSR1, sigaction, sigaction_t,
+        sigemptyset;
+    import core.sys.posix.unistd : read;
+    import core.thread : Thread;
+    import core.time : msecs;
+    import std.process : pipe;
+
+    // Install a SIGUSR1 handler without SA_RESTART so that fwrite may return
+    // short with errno == EINTR when the signal arrives mid-write.
+    extern (C) static nothrow void noop(int) {}
+    sigaction_t sa;
+    sa.sa_handler = &noop;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0; // no SA_RESTART
+    sigaction(SIGUSR1, &sa, null);
+
+    auto p = pipe();
+    // Write 512 KiB — much larger than the default 64 KiB pipe buffer —
+    // so the writer thread reliably blocks inside write(2).
+    immutable msg = new ubyte[512 * 1024];
+
+    shared bool done = false;
+    shared bool threw = false;
+    auto t = new Thread(() {
+        try
+            p.writeEnd.lockingTextWriter.put(cast(const(ubyte)[]) msg);
+        catch (Exception)
+            atomicStore(threw, true);
+        atomicStore(done, true);
+    });
+    t.start();
+
+    // Give the writer time to block inside write(2) before signalling.
+    Thread.sleep(50.msecs);
+    pthread_kill(t.id, SIGUSR1);
+
+    // Drain the pipe so the blocked write can make progress and complete.
+    ubyte[4096] buf;
+    while (!atomicLoad(done))
+        read(p.readEnd.fileno, buf.ptr, buf.length);
+    t.join();
+
+    assert(!atomicLoad(threw),
+        "LockingTextWriter.put threw on EINTR — retryShortIO not working");
 }
 
 @safe unittest // https://issues.dlang.org/show_bug.cgi?id=21592

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3103,6 +3103,19 @@ is empty, throws an `Exception`. In case of an I/O error throws
             }
         }
 
+        private void putcChecked(_iobuf* h, int c) @trusted
+        {
+            import std.exception : errnoEnforce;
+            if (trustedFPUTC(c, h) == EOF) errnoEnforce(0);
+        }
+
+        private void putwcChecked(_iobuf* h, wchar_t c) @trusted
+        {
+            import std.exception : errnoEnforce;
+            // fputwc returns WEOF (= -1) on error
+            if (trustedFPUTWC(c, h) == -1) errnoEnforce(0);
+        }
+
         /// Range primitive implementations.
         void put(A)(scope A writeme)
         if ((isSomeChar!(ElementType!A) ||
@@ -3142,8 +3155,8 @@ is empty, throws an `Exception`. In case of an I/O error throws
             static if (c.sizeof == 1)
             {
                 highSurrogateShouldBeEmpty();
-                if (orientation_ <= 0) trustedFPUTC(c, handle_);
-                else if (c <= 0x7F) trustedFPUTWC(c, handle_);
+                if (orientation_ <= 0) putcChecked(handle_, c);
+                else if (c <= 0x7F) putwcChecked(handle_, c);
                 else if (c >= 0b1100_0000) // start byte of multibyte sequence
                 {
                     rbuf8[0] = c;
@@ -3160,7 +3173,7 @@ is empty, throws an `Exception`. In case of an I/O error throws
                         wchar_t[4 / wchar_t.sizeof] wbuf;
                         immutable size = encode(wbuf, d);
                         foreach (i; 0 .. size)
-                            trustedFPUTWC(wbuf[i], handle_);
+                            putwcChecked(handle_, wbuf[i]);
                         rbuf8Filled = 0;
                     }
                 }
@@ -3172,8 +3185,8 @@ is empty, throws an `Exception`. In case of an I/O error throws
                 if (c <= 0x7F)
                 {
                     highSurrogateShouldBeEmpty();
-                    if (orientation_ <= 0) trustedFPUTC(c, handle_);
-                    else trustedFPUTWC(c, handle_);
+                    if (orientation_ <= 0) putcChecked(handle_, c);
+                    else putwcChecked(handle_, c);
                 }
                 else if (0xD800 <= c && c <= 0xDBFF) // high surrogate
                 {
@@ -3195,14 +3208,14 @@ is empty, throws an `Exception`. In case of an I/O error throws
                         char[4] wbuf;
                         immutable size = encode(wbuf, d);
                         foreach (i; 0 .. size)
-                            trustedFPUTC(wbuf[i], handle_);
+                            putcChecked(handle_, wbuf[i]);
                     }
                     else
                     {
                         wchar_t[4 / wchar_t.sizeof] wbuf;
                         immutable size = encode(wbuf, d);
                         foreach (i; 0 .. size)
-                            trustedFPUTWC(wbuf[i], handle_);
+                            putwcChecked(handle_, wbuf[i]);
                     }
                     rbuf8Filled = 0;
                 }
@@ -3216,14 +3229,14 @@ is empty, throws an `Exception`. In case of an I/O error throws
                 {
                     if (c <= 0x7F)
                     {
-                        trustedFPUTC(c, handle_);
+                        putcChecked(handle_, c);
                     }
                     else
                     {
                         char[4] buf = void;
                         immutable len = encode(buf, c);
                         foreach (i ; 0 .. len)
-                            trustedFPUTC(buf[i], handle_);
+                            putcChecked(handle_, buf[i]);
                     }
                 }
                 else
@@ -3235,21 +3248,20 @@ is empty, throws an `Exception`. In case of an I/O error throws
                         assert(isValidDchar(c));
                         if (c <= 0xFFFF)
                         {
-                            trustedFPUTWC(cast(wchar_t) c, handle_);
+                            putwcChecked(handle_, cast(wchar_t) c);
                         }
                         else
                         {
-                            trustedFPUTWC(cast(wchar_t)
+                            putwcChecked(handle_, cast(wchar_t)
                                     ((((c - 0x10000) >> 10) & 0x3FF)
-                                            + 0xD800), handle_);
-                            trustedFPUTWC(cast(wchar_t)
-                                    (((c - 0x10000) & 0x3FF) + 0xDC00),
-                                    handle_);
+                                            + 0xD800));
+                            putwcChecked(handle_, cast(wchar_t)
+                                    (((c - 0x10000) & 0x3FF) + 0xDC00));
                         }
                     }
                     else version (Posix)
                     {
-                        trustedFPUTWC(cast(wchar_t) c, handle_);
+                        putwcChecked(handle_, cast(wchar_t) c);
                     }
                     else
                     {
@@ -3829,6 +3841,21 @@ void main()
     import std.exception : collectException;
     auto e = collectException({ File f; f.writeln("Hello!"); }());
     assert(e && e.msg == "Attempting to write to closed File");
+}
+
+// https://github.com/dlang/phobos/issues/11005
+// LockingTextWriter's per-character path used to discard fputc's return value.
+version (linux)
+@system unittest
+{
+    import std.exception : assertThrown, ErrnoException;
+
+    // /dev/full always returns ENOSPC on write, making the error deterministic.
+    // _IONBF disables buffering so fputc hits the kernel on every call.
+    auto f = File("/dev/full", "w");
+    f.setvbuf(0, _IONBF);
+    auto w = f.lockingTextWriter();
+    assertThrown!ErrnoException(w.put('x'));
 }
 
 @safe unittest // https://issues.dlang.org/show_bug.cgi?id=21592


### PR DESCRIPTION
Fixes #11006. As a bonus, also fixes #11005 (bug was noticed during implementation).